### PR TITLE
fix(importer): clean up SAB complete/ after import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 The `development` branch carries the in-flight v0.5.0 feature set. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
 
+### Import cleanup
+- Ebook import no longer leaves the SABnzbd job folder behind. After every book file matches bindery's extension set and moves cleanly, the importer removes the source directory — PAR2, NFO, SFV, NZB, and sample leftovers go with it. Partial-failure runs are untouched so the files remain for investigation.
+- Audiobook import handles destination collisions. `UniqueDir` resolves `{Author}/{Title} ({Year})` against the filesystem and appends ` (2)`, ` (3)`, … when a prior import or manual copy already occupies the slot. Previously `MoveDir` hard-failed on any collision and the download stuck at `Completed` forever.
+- SABnzbd history is pruned once bindery owns the files. New `DeleteHistory(nzoID, deleteFiles=false)` on the SAB client is called after each successful import so completed rows stop accumulating in SAB's UI with stale storage paths.
+
 ### Audiobook support
 - Books now carry a `media_type` (`ebook` | `audiobook`) that drives indexer categories, ranking, library destination, and UI badges. Flip per-book inline on the Wanted page or via the Book detail page.
 - Search pipeline: `filterCategoriesForMedia` narrows indexer queries to the Newznab audio tree (3030) for audiobook books and the books tree (7000 range) for ebooks, with a fallback to the standard category when the indexer's configured set has nothing matching.

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -139,6 +139,22 @@ func (c *Client) Delete(ctx context.Context, nzoID string, deleteFiles bool) err
 	return c.apiCall(ctx, params, &resp)
 }
 
+// DeleteHistory removes a finished job from SABnzbd's history. When deleteFiles
+// is true, SAB also wipes the on-disk completed folder — bindery's importer has
+// typically already moved the contents, so callers usually pass false.
+func (c *Client) DeleteHistory(ctx context.Context, nzoID string, deleteFiles bool) error {
+	params := url.Values{
+		"mode":  {"history"},
+		"name":  {"delete"},
+		"value": {nzoID},
+	}
+	if deleteFiles {
+		params.Set("del_files", "1")
+	}
+	var resp SimpleResponse
+	return c.apiCall(ctx, params, &resp)
+}
+
 func (c *Client) apiCall(ctx context.Context, params url.Values, target interface{}) error {
 	params.Set("apikey", c.apiKey)
 	params.Set("output", "json")

--- a/internal/downloader/sabnzbd/client_test.go
+++ b/internal/downloader/sabnzbd/client_test.go
@@ -134,6 +134,39 @@ func TestGetCategories(t *testing.T) {
 	}
 }
 
+func TestDeleteHistory(t *testing.T) {
+	var gotMode, gotName, gotValue, gotDelFiles string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		gotMode = q.Get("mode")
+		gotName = q.Get("name")
+		gotValue = q.Get("value")
+		gotDelFiles = q.Get("del_files")
+		json.NewEncoder(w).Encode(SimpleResponse{Status: true})
+	}))
+	defer srv.Close()
+
+	c := New("127.0.0.1", 0, "testkey", false)
+	c.baseURL = srv.URL
+
+	if err := c.DeleteHistory(context.Background(), "SABnzbd_nzo_def456", false); err != nil {
+		t.Fatalf("delete history: %v", err)
+	}
+	if gotMode != "history" || gotName != "delete" || gotValue != "SABnzbd_nzo_def456" {
+		t.Errorf("unexpected params: mode=%s name=%s value=%s", gotMode, gotName, gotValue)
+	}
+	if gotDelFiles != "" {
+		t.Errorf("del_files should be unset when deleteFiles=false, got %q", gotDelFiles)
+	}
+
+	if err := c.DeleteHistory(context.Background(), "nzo_xyz", true); err != nil {
+		t.Fatalf("delete history with files: %v", err)
+	}
+	if gotDelFiles != "1" {
+		t.Errorf("del_files should be 1 when deleteFiles=true, got %q", gotDelFiles)
+	}
+}
+
 func TestTest(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(CategoriesResponse{

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -203,6 +203,24 @@ func DefaultNamingTemplate() string {
 	return defaultNamingTemplate
 }
 
+// UniqueDir returns dst if nothing exists there; otherwise appends
+// " (2)", " (3)", ... until a free path is found. MoveDir refuses an
+// existing destination, so callers that import the same title twice
+// (duplicate grab, reprocessed history, second edition) resolve the
+// collision here before the move rather than failing silently.
+func UniqueDir(dst string) string {
+	if _, err := os.Stat(dst); os.IsNotExist(err) {
+		return dst
+	}
+	for i := 2; i < 1000; i++ {
+		candidate := fmt.Sprintf("%s (%d)", dst, i)
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			return candidate
+		}
+	}
+	return dst
+}
+
 // NowYear returns the current year as a string, used as fallback.
 func NowYear() string {
 	return fmt.Sprintf("%d", time.Now().Year())

--- a/internal/importer/renamer_test.go
+++ b/internal/importer/renamer_test.go
@@ -95,3 +95,31 @@ func TestMoveFile(t *testing.T) {
 		t.Errorf("content mismatch: got %q", string(content))
 	}
 }
+
+func TestUniqueDir(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "Author", "Title (2020)")
+
+	// Nothing there yet — returned unchanged.
+	if got := UniqueDir(target); got != target {
+		t.Errorf("free path should return unchanged, got %q want %q", got, target)
+	}
+
+	// Occupy the target; next call should append " (2)".
+	if err := os.MkdirAll(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+	want := target + " (2)"
+	if got := UniqueDir(target); got != want {
+		t.Errorf("first collision: got %q want %q", got, want)
+	}
+
+	// Occupy "(2)" too — next call should pick " (3)".
+	if err := os.MkdirAll(want, 0755); err != nil {
+		t.Fatal(err)
+	}
+	want = target + " (3)"
+	if got := UniqueDir(target); got != want {
+		t.Errorf("second collision: got %q want %q", got, want)
+	}
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -74,7 +74,7 @@ func (s *Scanner) CheckDownloads(ctx context.Context) {
 			if dl.Status == models.DownloadStatusDownloading || dl.Status == models.DownloadStatusQueued {
 				slog.Info("download completed", "title", dl.Title, "path", slot.Path)
 				s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusCompleted)
-				s.tryImport(ctx, dl, slot.Path)
+				s.tryImport(ctx, sab, dl, slot.NzoID, slot.Path)
 			}
 		case "Failed":
 			if dl.Status != models.DownloadStatusFailed {
@@ -93,7 +93,9 @@ func (s *Scanner) CheckDownloads(ctx context.Context) {
 }
 
 // tryImport attempts to import a completed download into the library.
-func (s *Scanner) tryImport(ctx context.Context, dl *models.Download, downloadPath string) {
+// sab is used to clear the SABnzbd history entry once bindery has taken
+// ownership of the files; nzoID is the history slot's NZO identifier.
+func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models.Download, nzoID, downloadPath string) {
 	if s.libraryDir == "" {
 		slog.Warn("no library directory configured, skipping import")
 		return
@@ -138,7 +140,7 @@ func (s *Scanner) tryImport(ctx context.Context, dl *models.Download, downloadPa
 	// Audiobook path: move the entire download directory as a unit so
 	// multi-part m4b/mp3 files, cover art, and cue sheets stay together.
 	if book != nil && book.MediaType == models.MediaTypeAudiobook {
-		destDir := s.renamer.AudiobookDestDir(s.audiobookDir, author, book)
+		destDir := UniqueDir(s.renamer.AudiobookDestDir(s.audiobookDir, author, book))
 		slog.Info("importing audiobook folder", "src", downloadPath, "dst", destDir)
 		if err := MoveDir(downloadPath, destDir); err != nil {
 			slog.Error("failed to import audiobook folder", "src", downloadPath, "error", err)
@@ -155,9 +157,11 @@ func (s *Scanner) tryImport(ctx context.Context, dl *models.Download, downloadPa
 			SourceTitle: dl.Title,
 			Data:        string(eventData),
 		})
+		s.clearSABHistory(ctx, sab, nzoID)
 		return
 	}
 
+	var imported, failed int
 	for _, srcFile := range bookFiles {
 		if book == nil {
 			// Try to match from filename
@@ -171,8 +175,10 @@ func (s *Scanner) tryImport(ctx context.Context, dl *models.Download, downloadPa
 
 		if err := MoveFile(srcFile, destPath); err != nil {
 			slog.Error("failed to import", "src", srcFile, "error", err)
+			failed++
 			continue
 		}
+		imported++
 
 		// Update book status and file path
 		s.books.SetFilePath(ctx, book.ID, destPath)
@@ -186,6 +192,30 @@ func (s *Scanner) tryImport(ctx context.Context, dl *models.Download, downloadPa
 			SourceTitle: dl.Title,
 			Data:        string(eventData),
 		})
+	}
+
+	// A clean run leaves the SABnzbd job folder holding only non-book
+	// byproducts (par2, nfo, sfv, sample) — bindery has no further use
+	// for them, so drop the folder and the matching history entry so
+	// the completed-downloads view doesn't accumulate stale rows.
+	if imported > 0 && failed == 0 {
+		if err := os.RemoveAll(downloadPath); err != nil {
+			slog.Warn("failed to remove download folder after import", "path", downloadPath, "error", err)
+		}
+		s.clearSABHistory(ctx, sab, nzoID)
+	}
+}
+
+// clearSABHistory tells SABnzbd to drop the history entry for a job bindery
+// has finished importing. deleteFiles=false because the importer has already
+// moved the contents; asking SAB to delete would either no-op or wipe files
+// that were moved cross-filesystem and are still resolving.
+func (s *Scanner) clearSABHistory(ctx context.Context, sab *sabnzbd.Client, nzoID string) {
+	if sab == nil || nzoID == "" {
+		return
+	}
+	if err := sab.DeleteHistory(ctx, nzoID, false); err != nil {
+		slog.Warn("failed to delete SABnzbd history entry", "nzoID", nzoID, "error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Ebook import now removes the SAB job folder on clean completion.** Walked the download dir, moved recognised book files, left PAR2/NFO/SFV/NZB siblings behind — so `/complete/` accumulated stale folders forever. After a successful run (`imported > 0 && failed == 0`), `os.RemoveAll(downloadPath)` drops the leftovers.
- **Audiobook import handles destination collisions.** `MoveDir` refuses an existing `dst`, which hard-failed duplicate grabs, reprocessed history, and second editions; the download wedged at `Completed` with no retry path. New `UniqueDir` helper resolves the target to a free `{Author}/{Title} (Year) (2)` / ` (3)` / … before `MoveDir`.
- **SABnzbd history is pruned once bindery owns the files.** Added `DeleteHistory(nzoID, deleteFiles bool)` on the SAB client (the pre-existing `Delete` targeted `mode=queue`, wrong endpoint) and called it after each successful import with `del_files=false`, so SAB's completed view stops showing stale storage paths for imported jobs.

## Test plan

- [x] `go test ./cmd/... ./internal/...` — all green (new: `TestUniqueDir`, `TestDeleteHistory`)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [ ] Observe next real ebook grab: `/downloads/complete/<title>/` is gone, file lands under `{BINDERY_LIBRARY_DIR}/{Author}/{Title} ({Year})/…`, SAB History row disappears
- [ ] Observe next real audiobook grab: folder moves intact to `{BINDERY_AUDIOBOOK_DIR ?? BINDERY_LIBRARY_DIR}/{Author}/{Title} ({Year})/`, SAB History row disappears
- [ ] Trigger a duplicate grab (same book twice) and confirm the second lands in `… (2)/` instead of erroring

## Notes

- `Delete` on the queue is left intact; this adds a separate `DeleteHistory` rather than overloading.
- `UniqueDir` caps at 1000 iterations — far past any realistic duplicate count.
- No migration; no config change.
- Does **not** close the "manual-grab in SAB" gap (bindery still ignores completions whose NZO ID it doesn't own). That's a separate change — a download-dir scanner that mirrors Sonarr/Radarr import-from-complete behaviour.