### PR TITLE
feat(books): delete files from UI + skip OL junk-title works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ The `development` branch carries the in-flight v0.5.0 feature set. Images are pu
 - `/book/{id}/enrich-audiobook` endpoint (audnex).
 - Foreign-language tag filter now word-boundary-anchored (the tag `RUSSE` no longer substring-matches inside `RUSSELL`).
 - Book PUT handler accepts `mediaType` / `asin` / `narrator` fields (was silently dropping them).
+- **Delete downloaded files from the UI.** Book detail page gains a red "Delete file" action that wipes the on-disk file (ebook) or folder (audiobook) and flips the book back to `wanted`, plus a "Delete book + files" action that removes the record and its files in one go. New endpoints: `DELETE /api/v1/book/{id}/file` and `DELETE /api/v1/book/{id}?deleteFiles=true`. A `bookFileDeleted` history event is recorded so the deletion is auditable.
+- **Skip OpenLibrary "works" whose title equals the author's name.** An upstream OL data-quality bug occasionally emits works (e.g. `OL29342228W` for Jared Diamond) where the Work record was never given a title and the API falls back to the author's name. These polluted the Wanted page and produced nonsense destination folders like `Jared M. Diamond/Jared M. Diamond ()`. `FetchAuthorBooks` now filters them out at ingest time and counts the skips in its summary log.
 
 ## [v0.4.2] — 2026-04-12
 

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -121,7 +121,7 @@ func main() {
 	// API handlers
 	searchHandler := api.NewSearchHandler(metaAgg)
 	authorHandler := api.NewAuthorHandler(authorRepo, bookRepo, metaAgg, settingsRepo)
-	bookHandler := api.NewBookHandler(bookRepo, metaAgg)
+	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo)
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, idxSearcher, settingsRepo, blocklistRepo)
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)
 	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo)
@@ -185,6 +185,7 @@ func main() {
 		r.Get("/book/{id}", bookHandler.Get)
 		r.Put("/book/{id}", bookHandler.Update)
 		r.Delete("/book/{id}", bookHandler.Delete)
+		r.Delete("/book/{id}/file", bookHandler.DeleteFile)
 		r.Post("/book/{id}/enrich-audiobook", bookHandler.EnrichAudiobook)
 		r.Post("/book/{id}/search", indexerHandler.SearchBook)
 		r.Get("/book/{id}/file", fileHandler.Download)

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -216,10 +216,24 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author) {
 		seenTitles[strings.ToLower(eb.Title)] = true
 	}
 
-	var added, skippedLang int
+	normalizedAuthor := strings.ToLower(strings.TrimSpace(author.Name))
+
+	var added, skippedLang, skippedJunk int
 	for _, b := range books {
 		b.AuthorID = author.ID
 		b.Monitored = author.Monitored
+
+		// Filter out OpenLibrary "works" whose title is empty or is just the
+		// author name — a recurring OL data-quality problem where the Work
+		// record was never titled and falls back to the author's name.
+		// Letting these through pollutes the Wanted page and produces
+		// nonsense destination folders like "Jared M. Diamond/Jared M. Diamond ()".
+		normalizedTitle := strings.ToLower(strings.TrimSpace(b.Title))
+		if normalizedTitle == "" || normalizedTitle == normalizedAuthor {
+			skippedJunk++
+			slog.Debug("skipping junk-title OL work", "title", b.Title, "foreignId", b.ForeignID)
+			continue
+		}
 
 		// Filter by language: skip books whose language is known and doesn't match.
 		// Books with an empty language (data unavailable) are always kept.
@@ -236,7 +250,6 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author) {
 		}
 
 		// Skip duplicate titles (OpenLibrary often has multiple works for the same book)
-		normalizedTitle := strings.ToLower(b.Title)
 		if seenTitles[normalizedTitle] {
 			continue
 		}
@@ -248,5 +261,5 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author) {
 		}
 		added++
 	}
-	slog.Info("author books synced", "author", author.Name, "added", added, "skipped_language", skippedLang, "total", len(books))
+	slog.Info("author books synced", "author", author.Name, "added", added, "skipped_language", skippedLang, "skipped_junk", skippedJunk, "total", len(books))
 }

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
@@ -14,12 +15,13 @@ import (
 )
 
 type BookHandler struct {
-	books *db.BookRepo
-	meta  *metadata.Aggregator
+	books   *db.BookRepo
+	meta    *metadata.Aggregator
+	history *db.HistoryRepo
 }
 
-func NewBookHandler(books *db.BookRepo, meta *metadata.Aggregator) *BookHandler {
-	return &BookHandler{books: books, meta: meta}
+func NewBookHandler(books *db.BookRepo, meta *metadata.Aggregator, history *db.HistoryRepo) *BookHandler {
+	return &BookHandler{books: books, meta: meta, history: history}
 }
 
 // EnrichAudiobook fetches audnex data for the book's ASIN and updates
@@ -162,11 +164,85 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
 		return
 	}
+	// Opt-in `?deleteFiles=true` also removes the on-disk file or folder
+	// before dropping the record, so the user doesn't have to delete the
+	// file separately after removing the book.
+	if r.URL.Query().Get("deleteFiles") == "true" {
+		if book, _ := h.books.GetByID(r.Context(), id); book != nil && book.FilePath != "" {
+			if err := removeBookPath(book.FilePath); err != nil {
+				slog.Warn("book delete: failed to remove files", "id", id, "path", book.FilePath, "error", err)
+			}
+		}
+	}
 	if err := h.books.Delete(r.Context(), id); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// DeleteFile removes the on-disk file or folder backing an imported book,
+// clears the stored file_path, and flips the status back to `wanted` so the
+// book re-appears on the Wanted page. The book record itself is kept. Used
+// to clean up bad grabs (wrong edition, corrupt files, mis-tagged metadata)
+// without losing the author/book association or its history.
+func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	book, err := h.books.GetByID(r.Context(), id)
+	if err != nil || book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
+	if book.FilePath == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "book has no file to delete"})
+		return
+	}
+
+	oldPath := book.FilePath
+	if err := removeBookPath(oldPath); err != nil {
+		slog.Error("failed to remove book path", "id", id, "path", oldPath, "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	book.FilePath = ""
+	book.Status = models.BookStatusWanted
+	if err := h.books.Update(r.Context(), book); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if h.history != nil {
+		data, _ := json.Marshal(map[string]string{"path": oldPath})
+		_ = h.history.Create(r.Context(), &models.HistoryEvent{
+			BookID:      &book.ID,
+			EventType:   models.HistoryEventBookFileDeleted,
+			SourceTitle: book.Title,
+			Data:        string(data),
+		})
+	}
+
+	writeJSON(w, http.StatusOK, book)
+}
+
+// removeBookPath deletes a file or directory at p. Audiobooks are stored as
+// folders (multi-part mp3/m4b + cover + cue); ebooks are single files.
+// Returns nil if the path no longer exists — the net state is the same.
+func removeBookPath(p string) error {
+	info, err := os.Stat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.IsDir() {
+		return os.RemoveAll(p)
+	}
+	return os.Remove(p)
 }
 
 func (h *BookHandler) ListWanted(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/books_test.go
+++ b/internal/api/books_test.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveBookPath_File(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "book.epub")
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeBookPath(p); err != nil {
+		t.Fatalf("removeBookPath: %v", err)
+	}
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Fatalf("expected file removed, stat err=%v", err)
+	}
+}
+
+func TestRemoveBookPath_Dir(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "Author", "Title (2020)")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "part1.mp3"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "part2.mp3"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeBookPath(sub); err != nil {
+		t.Fatalf("removeBookPath: %v", err)
+	}
+	if _, err := os.Stat(sub); !os.IsNotExist(err) {
+		t.Fatalf("expected dir removed, stat err=%v", err)
+	}
+}
+
+func TestRemoveBookPath_Missing(t *testing.T) {
+	// Missing paths should be treated as already-deleted, not an error.
+	// The net state the caller wants (path absent) is already true.
+	if err := removeBookPath(filepath.Join(t.TempDir(), "nope.epub")); err != nil {
+		t.Fatalf("missing path should return nil, got %v", err)
+	}
+}

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -74,4 +74,5 @@ const (
 	HistoryEventDownloadFailed       = "downloadFailed"
 	HistoryEventBookRenamed          = "bookRenamed"
 	HistoryEventDownloadFolderImport = "downloadFolderImported"
+	HistoryEventBookFileDeleted      = "bookFileDeleted"
 )

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -40,7 +40,9 @@ export const api = {
   },
   getBook: (id: number) => request<Book>(`/book/${id}`),
   updateBook: (id: number, data: Partial<Book>) => request<Book>(`/book/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
-  deleteBook: (id: number) => request<void>(`/book/${id}`, { method: 'DELETE' }),
+  deleteBook: (id: number, deleteFiles = false) =>
+    request<void>(`/book/${id}${deleteFiles ? '?deleteFiles=true' : ''}`, { method: 'DELETE' }),
+  deleteBookFile: (id: number) => request<Book>(`/book/${id}/file`, { method: 'DELETE' }),
   searchBook: (id: number) => request<SearchResult[]>(`/book/${id}/search`, { method: 'POST' }),
   enrichAudiobook: (id: number) => request<Book>(`/book/${id}/enrich-audiobook`, { method: 'POST' }),
 

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -40,6 +40,8 @@ export default function BookDetailPage() {
   const [error, setError] = useState<string | null>(null)
   const [asinDraft, setAsinDraft] = useState('')
   const [enriching, setEnriching] = useState(false)
+  const [deletingFile, setDeletingFile] = useState(false)
+  const [deletingBook, setDeletingBook] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -109,6 +111,42 @@ export default function BookDetailPage() {
     }
   }
 
+  const deleteFile = async () => {
+    if (!book || !book.filePath) return
+    const label = book.mediaType === 'audiobook' ? 'the audiobook folder' : 'this file'
+    if (!window.confirm(`Permanently delete ${label} from disk?\n\n${book.filePath}\n\nThe book record stays; it will flip back to "wanted".`)) return
+    setDeletingFile(true)
+    setError(null)
+    try {
+      const updated = await api.deleteBookFile(book.id)
+      setBook(updated)
+      const h = await api.listHistory({ bookId: book.id }).catch(() => events)
+      setEvents(h)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Delete failed')
+    } finally {
+      setDeletingFile(false)
+    }
+  }
+
+  const deleteBook = async () => {
+    if (!book) return
+    const hasFiles = !!book.filePath
+    const msg = hasFiles
+      ? `Delete "${book.title}" AND its files on disk?\n\n${book.filePath}\n\nThis cannot be undone.`
+      : `Delete "${book.title}"?\n\nThis cannot be undone.`
+    if (!window.confirm(msg)) return
+    setDeletingBook(true)
+    setError(null)
+    try {
+      await api.deleteBook(book.id, hasFiles)
+      navigate(`/author/${book.authorId}`)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Delete failed')
+      setDeletingBook(false)
+    }
+  }
+
   const enrich = async () => {
     if (!book || !book.asin) return
     setEnriching(true)
@@ -175,13 +213,35 @@ export default function BookDetailPage() {
             <p className="mt-4 text-sm text-slate-700 dark:text-zinc-300 leading-relaxed">{book.description}</p>
           )}
           {book.filePath && (
-            <a
-              href={`/api/v1/book/${book.id}/file`}
-              className="mt-3 inline-block text-sm text-emerald-500 hover:text-emerald-400"
-            >
-              Download file
-            </a>
+            <div className="mt-3 flex items-center gap-4 text-sm">
+              <a
+                href={`/api/v1/book/${book.id}/file`}
+                className="text-emerald-500 hover:text-emerald-400"
+              >
+                Download file
+              </a>
+              <button
+                onClick={deleteFile}
+                disabled={deletingFile || deletingBook}
+                className="text-red-500 hover:text-red-400 disabled:opacity-40"
+                title={`Remove ${book.mediaType === 'audiobook' ? 'folder' : 'file'} from disk; keep the book record`}
+              >
+                {deletingFile ? 'Deleting…' : 'Delete file'}
+              </button>
+            </div>
           )}
+          <div className="mt-3 text-xs text-slate-500 dark:text-zinc-500 break-all">
+            {book.filePath}
+          </div>
+          <div className="mt-3">
+            <button
+              onClick={deleteBook}
+              disabled={deletingBook || deletingFile}
+              className="text-xs text-red-600 dark:text-red-500 hover:text-red-500 dark:hover:text-red-400 disabled:opacity-40"
+            >
+              {deletingBook ? 'Deleting book…' : book.filePath ? 'Delete book + files' : 'Delete book'}
+            </button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- **Delete downloaded books from the UI.** Book detail page gains a red "Delete file" action (wipes the ebook file or audiobook folder and flips the book back to `wanted`) and a "Delete book + files" action. New endpoints: `DELETE /api/v1/book/{id}/file` and `DELETE /api/v1/book/{id}?deleteFiles=true`. A `bookFileDeleted` history event is written so deletions are auditable.
- **Filter OpenLibrary junk-title works.** `FetchAuthorBooks` now skips works whose normalized title is empty or equal to the normalized author name — these are upstream OL data-quality artifacts (e.g. work `OL29342228W` under Jared Diamond) that polluted the Wanted page and produced nonsense library paths like `Jared M. Diamond/Jared M. Diamond ()`.

## Test plan

- [x] `go test ./internal/api/...` — `removeBookPath` covers file, directory, and missing-path cases.
- [x] `go build ./...` / `go vet ./...` clean.
- [x] `vite build` clean.
- [ ] Manual: on the deployed cluster, exercise the new buttons on an imported audiobook and ebook; confirm the files disappear from NFS and the book flips to Wanted.
- [ ] Manual: re-add Jared Diamond as an author and confirm the "Jared M. Diamond" bogus work no longer appears.