### PR TITLE
fix(db): allow author delete when downloads reference the books

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -420,3 +420,63 @@ func TestCascadeDeleteAuthorBooks(t *testing.T) {
 		t.Errorf("expected 0 books after cascade delete, got %d", len(books))
 	}
 }
+
+// Regression for https://github.com/vavallee/bindery/issues/8 — deleting an
+// author failed with SQLITE_CONSTRAINT_FOREIGNKEY (787) because the
+// `downloads` table had bare `REFERENCES books(id)` (NO ACTION) and blocked
+// the author→book cascade whenever any download pointed at the book. After
+// migration 007 the reference is `ON DELETE SET NULL`, so the audit row
+// survives but loses its link.
+func TestDeleteAuthorWithDownload(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OL13A", Name: "Delete Me", SortName: "Me, Delete",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OL13W", AuthorID: author.ID, Title: "Stuck Book", SortTitle: "Stuck Book",
+		Status: "wanted", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert a download pointing at the book, bypassing the repo to keep the
+	// test schema-level (the repo layer may add defaults we don't need here).
+	_, err = database.ExecContext(ctx, `
+		INSERT INTO downloads (guid, book_id, title, nzb_url)
+		VALUES ('test-guid-1', ?, 'release.nzb', 'https://example/1')`, book.ID)
+	if err != nil {
+		t.Fatalf("seed download: %v", err)
+	}
+
+	if err := authorRepo.Delete(ctx, author.ID); err != nil {
+		t.Fatalf("delete author must succeed even with dependent download: %v", err)
+	}
+
+	var downloadCount int
+	var linkedBookID *int64
+	if err := database.QueryRowContext(ctx,
+		`SELECT COUNT(*), book_id FROM downloads WHERE guid = 'test-guid-1'`,
+	).Scan(&downloadCount, &linkedBookID); err != nil {
+		t.Fatalf("inspect download: %v", err)
+	}
+	if downloadCount != 1 {
+		t.Errorf("download row should survive parent delete, got count=%d", downloadCount)
+	}
+	if linkedBookID != nil {
+		t.Errorf("download.book_id should be NULL after cascade, got %d", *linkedBookID)
+	}
+}

--- a/internal/db/migrations/007_downloads_fk_set_null.sql
+++ b/internal/db/migrations/007_downloads_fk_set_null.sql
@@ -1,0 +1,53 @@
+-- +migrate Up
+
+-- Rebuild `downloads` to add `ON DELETE SET NULL` on every foreign key.
+-- The original schema used bare `REFERENCES` clauses (default = NO ACTION),
+-- so deleting a referenced parent row — most visibly, an Author, which
+-- cascades to Books — was blocked by a FK violation on the dangling
+-- downloads row. Matching `history.book_id` (which already uses SET NULL),
+-- we keep the download row around but detach it when its parent goes away.
+-- Audit / history value outlives the book/indexer/client.
+--
+-- SQLite can't alter a FK constraint in place, so: disable FKs for the
+-- swap, copy rows into a correctly-shaped new table, drop the old one,
+-- rename, re-create indexes, re-enable FKs.
+
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE downloads_new (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    guid               TEXT    NOT NULL UNIQUE,
+    book_id            INTEGER REFERENCES books(id)             ON DELETE SET NULL,
+    edition_id         INTEGER REFERENCES editions(id)          ON DELETE SET NULL,
+    indexer_id         INTEGER REFERENCES indexers(id)          ON DELETE SET NULL,
+    download_client_id INTEGER REFERENCES download_clients(id)  ON DELETE SET NULL,
+    title              TEXT    NOT NULL,
+    nzb_url            TEXT    NOT NULL,
+    size               INTEGER NOT NULL DEFAULT 0,
+    sabnzbd_nzo_id     TEXT,
+    status             TEXT    NOT NULL DEFAULT 'queued',
+    protocol           TEXT    NOT NULL DEFAULT 'usenet',
+    quality            TEXT    NOT NULL DEFAULT '',
+    indexer_flags      TEXT    NOT NULL DEFAULT '{}',
+    error_message      TEXT    NOT NULL DEFAULT '',
+    added_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    grabbed_at         DATETIME,
+    completed_at       DATETIME,
+    imported_at        DATETIME
+);
+
+INSERT INTO downloads_new
+SELECT id, guid, book_id, edition_id, indexer_id, download_client_id,
+       title, nzb_url, size, sabnzbd_nzo_id, status, protocol, quality,
+       indexer_flags, error_message, added_at, grabbed_at, completed_at,
+       imported_at
+FROM downloads;
+
+DROP TABLE downloads;
+ALTER TABLE downloads_new RENAME TO downloads;
+
+CREATE INDEX idx_downloads_status         ON downloads(status);
+CREATE INDEX idx_downloads_book_id        ON downloads(book_id);
+CREATE INDEX idx_downloads_sabnzbd_nzo_id ON downloads(sabnzbd_nzo_id);
+
+PRAGMA foreign_keys=ON;


### PR DESCRIPTION
Closes #8.

## Root cause
Deleting an author was failing with:

\`\`\`
delete author 13: constraint failed: FOREIGN KEY constraint failed (787)
\`\`\`

The \`downloads\` table was declared in \`001_initial.sql\` with bare \`REFERENCES\` clauses — no \`ON DELETE\` action, which SQLite treats as \`NO ACTION\`. When \`authors → books\` cascaded, any \`downloads\` row pointing at one of those books pinned the book and SQLite aborted the whole delete.

Nothing downstream of \`downloads\` is affected; nothing references \`downloads.id\`.

## Fix
Migration 007 rebuilds \`downloads\` with \`ON DELETE SET NULL\` on all four parent FKs (\`book_id\`, \`edition_id\`, \`indexer_id\`, \`download_client_id\`). This matches how \`history.book_id\` already behaves: keep the audit row, drop the link.

Uses the standard SQLite \"create new, copy, drop old, rename\" dance because \`ALTER TABLE\` can't modify FK constraints. Wrapped in \`PRAGMA foreign_keys=OFF/ON\` around the swap.

## Test plan
- [x] New \`TestDeleteAuthorWithDownload\` covers the full chain: author → book → download, delete author, assert download row survives with \`book_id = NULL\`
- [x] Existing \`TestCascadeDeleteAuthorBooks\` still passes (books still cascade-delete with the author)
- [x] \`go test ./...\` clean