### PR TITLE
fix(authors): delete author ?deleteFiles=true sweeps on-disk files (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ Replaces the single-env-var API key gate with a full Sonarr-parity auth model. U
 - Middleware was treating `/auth/status` as an unauth-allowed path *before* verifying the session cookie, so the endpoint always reported `authenticated: false`. Valid logins still set the cookie correctly but the UI bounced right back to `/login`. Cookie verification now runs for every request; the unauth-allow list only controls the 401 rejection.
 - Login and setup forms now read values via `FormData` on submit instead of relying on React-controlled state. Browser password-manager autofill populates `input.value` without firing `onChange`, which left React state empty and silently disabled the submit button.
 
+### Author delete can sweep files ([#15](https://github.com/vavallee/bindery/issues/15))
+
+`DELETE /api/v1/author/{id}?deleteFiles=true` now walks every book's `file_path` and removes it from disk before the DB cascade takes the rows out. Paths are collected *before* the delete (the cascade wipes the book rows that hold them, so a post-delete walk would find nothing). Per-path errors are logged but don't abort the response — the author is already gone and a partial sweep is better than rolling the whole thing back.
+
+The UI confirm dialogs on the Author list and detail pages peek at each author's books, name the file/folder count in the confirmation message, and pass `deleteFiles=true` when the user OKs. Authors with no files on disk get the old plain confirm.
+
+Closes the orphan-files gap reported against the Jared Diamond delete after #9 landed.
+
 ### Metadata language filter ([#14](https://github.com/vavallee/bindery/issues/14))
 
 Foreign-language works from OpenLibrary/Hardcover/Google Books were landing in the library regardless of the user's preferred language. The `metadata_profiles` table (seeded in migration 003) already carried `allowed_languages='eng'` by default, but nothing consulted it — author-book ingestion filtered against a separate global `search.preferredLanguage` setting, and authors were never linked to a profile.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -178,10 +178,37 @@ func (h *AuthorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
 		return
 	}
+
+	// Opt-in `?deleteFiles=true` sweeps every book's on-disk path after the
+	// DB delete. We must collect the paths *before* deleting the author —
+	// the FK cascade removes the book rows along with it, which would leave
+	// us nothing to walk. Per-path errors are logged but don't abort the
+	// response: the author is already gone, and a partial sweep is better
+	// than rolling the whole thing back.
+	var pathsToRemove []string
+	if r.URL.Query().Get("deleteFiles") == "true" {
+		books, err := h.books.ListByAuthor(r.Context(), id)
+		if err != nil {
+			slog.Warn("delete author: failed to list books for file cleanup", "author_id", id, "error", err)
+		}
+		for _, b := range books {
+			if b.FilePath != "" {
+				pathsToRemove = append(pathsToRemove, b.FilePath)
+			}
+		}
+	}
+
 	if err := h.authors.Delete(r.Context(), id); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+
+	for _, p := range pathsToRemove {
+		if err := removeBookPath(p); err != nil {
+			slog.Warn("delete author: failed to remove file", "author_id", id, "path", p, "error", err)
+		}
+	}
+
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestDeleteAuthor_WithDeleteFiles verifies the ?deleteFiles=true branch
+// sweeps every book's on-disk path. The invariant under test is ordering:
+// paths must be collected from `books ListByAuthor` *before* the cascade
+// wipes the book rows, otherwise we'd have nothing to sweep. A regression
+// here re-orphans files (issue #15).
+func TestDeleteAuthor_WithDeleteFiles(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL900A", Name: "Jared Diamond", SortName: "Diamond, Jared",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two audiobook folders + one ebook file, all populated.
+	root := t.TempDir()
+	mkFolder := func(name string) string {
+		p := filepath.Join(root, name)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(p, "part1.m4b"), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	path1 := mkFolder("Guns Germs and Steel (1997)")
+	path2 := mkFolder("Collapse (2005)")
+	path3 := filepath.Join(root, "The World Until Yesterday.epub")
+	if err := os.WriteFile(path3, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Plus a file-less wanted book — must not trip anything even though
+	// FilePath is empty. Note: BookRepo.Create ignores FilePath, so we
+	// back-fill via SetFilePath (same path the real importer takes).
+	for _, b := range []*models.Book{
+		{ForeignID: "OL901W", AuthorID: author.ID, Title: "Guns Germs", SortTitle: "Guns", FilePath: path1, Status: "imported", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true},
+		{ForeignID: "OL902W", AuthorID: author.ID, Title: "Collapse", SortTitle: "Collapse", FilePath: path2, Status: "imported", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true},
+		{ForeignID: "OL903W", AuthorID: author.ID, Title: "World", SortTitle: "World", FilePath: path3, Status: "imported", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true},
+		{ForeignID: "OL904W", AuthorID: author.ID, Title: "Wanted No File", SortTitle: "Wanted", Status: "wanted", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true},
+	} {
+		if err := bookRepo.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+		if b.FilePath != "" {
+			if err := bookRepo.SetFilePath(ctx, b.ID, b.FilePath); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	h := NewAuthorHandler(authorRepo, bookRepo, nil, nil, profileRepo)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/author/"+strconv.FormatInt(author.ID, 10)+"?deleteFiles=true", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(author.ID, 10))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	h.Delete(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	for _, p := range []string{path1, path2, path3} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("expected %s removed, stat err=%v", p, err)
+		}
+	}
+	// And the author row is gone.
+	got, _ := authorRepo.GetByID(ctx, author.ID)
+	if got != nil {
+		t.Error("expected author deleted")
+	}
+}
+
+// TestDeleteAuthor_WithoutDeleteFiles confirms the default path leaves
+// files on disk. Preserves the pre-#15 behaviour for anyone who hits the
+// delete button reflexively without opting into a disk sweep.
+func TestDeleteAuthor_WithoutDeleteFiles(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL910A", Name: "Keep Files", SortName: "Files, Keep",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "book.epub")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OL911W", AuthorID: author.ID, Title: "Book", SortTitle: "Book",
+		FilePath: path, Status: "imported", Genres: []string{},
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.SetFilePath(ctx, book.ID, path); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewAuthorHandler(authorRepo, bookRepo, nil, nil, profileRepo)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/author/"+strconv.FormatInt(author.ID, 10), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(author.ID, 10))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	h.Delete(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rec.Code)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file should survive default delete, stat err=%v", err)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -80,7 +80,8 @@ export const api = {
   getAuthor: (id: number) => request<Author>(`/author/${id}`),
   addAuthor: (data: AddAuthorRequest) => request<Author>('/author', { method: 'POST', body: JSON.stringify(data) }),
   updateAuthor: (id: number, data: Partial<Author>) => request<Author>(`/author/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
-  deleteAuthor: (id: number) => request<void>(`/author/${id}`, { method: 'DELETE' }),
+  deleteAuthor: (id: number, deleteFiles = false) =>
+    request<void>(`/author/${id}${deleteFiles ? '?deleteFiles=true' : ''}`, { method: 'DELETE' }),
   refreshAuthor: (id: number) => request<void>(`/author/${id}/refresh`, { method: 'POST' }),
 
   // Books

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -61,9 +61,13 @@ export default function AuthorDetailPage() {
 
   const handleDelete = async () => {
     if (!author) return
-    if (!confirm(`Delete ${author.authorName} and all their books?`)) return
+    const withFiles = books.filter(b => b.filePath)
+    const msg = withFiles.length > 0
+      ? `Delete ${author.authorName}, all ${books.length} book(s), AND ${withFiles.length} file(s)/folder(s) on disk?\n\nThis cannot be undone.`
+      : `Delete ${author.authorName} and all ${books.length} book(s)?`
+    if (!confirm(msg)) return
     try {
-      await api.deleteAuthor(author.id)
+      await api.deleteAuthor(author.id, withFiles.length > 0)
       navigate('/')
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Delete failed')

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -25,8 +25,21 @@ export default function AuthorsPage() {
   useEffect(() => { load() }, [])
 
   const handleDelete = async (id: number) => {
-    if (!confirm('Delete this author and all their books?')) return
-    await api.deleteAuthor(id)
+    // Peek at the author's books so the confirm can offer to sweep files.
+    // Small extra roundtrip, but the list view doesn't otherwise carry
+    // per-book filePaths and we don't want to silently orphan them.
+    let withFiles = 0
+    let total = 0
+    try {
+      const books = await api.listBooks({ authorId: id })
+      total = books.length
+      withFiles = books.filter(b => b.filePath).length
+    } catch { /* fall through to no-file-sweep default */ }
+    const msg = withFiles > 0
+      ? `Delete this author, ${total} book(s), AND ${withFiles} file(s)/folder(s) on disk?\n\nThis cannot be undone.`
+      : `Delete this author and all their books?`
+    if (!confirm(msg)) return
+    await api.deleteAuthor(id, withFiles > 0)
     load()
   }
 


### PR DESCRIPTION
Closes #15.

## Summary

- `DELETE /api/v1/author/{id}?deleteFiles=true` now walks each book's `file_path` and removes it. Paths must be collected *before* the DB delete — the FK cascade would clear the book rows first and leave us nothing to sweep. Per-path errors are logged, not fatal.
- UI: the Author list and detail delete confirms peek at each author's books, report the file count in the confirmation message, and pass `deleteFiles=true` when the user accepts. No-file authors keep the old plain confirm.

Mirrors the book handler's long-standing `?deleteFiles=true` pathway, so the UX and failure semantics are consistent.

## Test plan

- [x] `go test ./internal/api/ -run TestDeleteAuthor -v` — new ordering regression test passes (collects paths → delete → sweeps) and the default path leaves files alone
- [x] `go test ./...` — all green
- [x] `web/ npm run build` — no TS errors
- [ ] Manual: create author with a mix of imported audiobook folders + ebook files → delete from detail page → confirm dialog names the file count, all files gone, DB row gone
- [ ] Manual: delete from the author list → same behavior
- [ ] Manual: delete an author with no on-disk files → old confirm text, no errors