### PR TITLE
release: v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
 
+## [v0.6.1] — 2026-04-14
+
+### Fixed
+- GoReleaser was cross-compiling `internal/db/db.go` for `GOOS=windows` and hitting `undefined: syscall.Stat_t`, which aborted the Windows targets and failed the entire v0.6.0 tag release before any binaries or the `ghcr.io/vavallee/bindery:0.6.0` tag were published. `describeDir` (the Linux ownership hint in the SQLite "can't open" error path) is now split into `describe_unix.go` (POSIX uid/gid) and `describe_windows.go` (path + mode only). v0.6.1 ships the same feature set as v0.6.0; no runtime behaviour changes on Linux. The v0.6.0 GitHub release has been marked as draft since no assets were published under that tag.
+
 ## [v0.6.0] — 2026-04-14
 
 ### Authentication overhaul

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "sha-8ee10bd"
+  tag: "sha-62b7c2a"
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "sha-e7be7af"
+  tag: "sha-1ce1733"
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "sha-62b7c2a"
+  tag: "sha-e7be7af"
   pullPolicy: IfNotPresent
 
 service:

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -131,20 +131,6 @@ func annotateCantOpen(dbPath string, err error) error {
 	return fmt.Errorf("open database %q: %w — %s", abs, err, hint)
 }
 
-// describeDir renders the parent directory's permissions + ownership in a
-// form most Linux operators read fluently (matches `ls -ld`'s mode column
-// plus a "uid:gid" tail). We skip username lookup to keep this cheap and
-// dependency-free; numeric IDs are unambiguous anyway.
-func describeDir(path string, info os.FileInfo) string {
-	uid, gid := "?", "?"
-	if st, ok := info.Sys().(*syscall.Stat_t); ok {
-		uid = fmt.Sprintf("%d", st.Uid)
-		gid = fmt.Sprintf("%d", st.Gid)
-	}
-	return fmt.Sprintf("%s mode=%s owner=%s:%s — ensure this directory is writable by the UID running bindery (distroless nonroot is 65532)",
-		path, info.Mode().Perm().String(), uid, gid)
-}
-
 func setPragmas(db *sql.DB) error {
 	pragmas := []string{
 		"PRAGMA journal_mode=WAL",

--- a/internal/db/describe_unix.go
+++ b/internal/db/describe_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package db
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// describeDir renders the parent directory's permissions + ownership in a
+// form most Linux operators read fluently (matches `ls -ld`'s mode column
+// plus a "uid:gid" tail). We skip username lookup to keep this cheap and
+// dependency-free; numeric IDs are unambiguous anyway.
+func describeDir(path string, info os.FileInfo) string {
+	uid, gid := "?", "?"
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		uid = fmt.Sprintf("%d", st.Uid)
+		gid = fmt.Sprintf("%d", st.Gid)
+	}
+	return fmt.Sprintf("%s mode=%s owner=%s:%s — ensure this directory is writable by the UID running bindery (distroless nonroot is 65532)",
+		path, info.Mode().Perm().String(), uid, gid)
+}

--- a/internal/db/describe_windows.go
+++ b/internal/db/describe_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package db
+
+import (
+	"fmt"
+	"os"
+)
+
+// describeDir is the Windows fallback: we skip uid/gid (no POSIX Stat_t) and
+// return just the path and mode so the SQLite error still gets a useful hint.
+func describeDir(path string, info os.FileInfo) string {
+	return fmt.Sprintf("%s mode=%s — ensure this directory is writable by the user running bindery",
+		path, info.Mode().Perm().String())
+}


### PR DESCRIPTION
## Summary
- Fix `syscall.Stat_t` cross-compile failure on Windows that broke GoReleaser during the v0.6.0 tag CI.
- Split `describeDir` into `describe_unix.go` + `describe_windows.go`.
- v0.6.0 GitHub release marked as draft (no assets ever published under that tag); shipping the full v0.6.0 feature set as v0.6.1.

## Test plan
- [x] `go build ./...` on linux/amd64
- [x] `GOOS=windows GOARCH=amd64 go build ./...`
- [x] `GOOS=darwin GOARCH=arm64 go build ./...`
- [x] `go test ./internal/db/...`
- [ ] GoReleaser tag CI succeeds on v0.6.1