### PR TITLE
docs+ci: reconcile v0.6.x references, add codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,23 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true
+
+ignore:
+  - "cmd/**"
+  - "internal/migrate/**"
+  - "web/**"
+  - "**/*_mock.go"
+  - "**/mock_*.go"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.25.9"
-      - run: go test ./cmd/... ./internal/...
+      - run: go test -race -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
+      - uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          flags: backend
+          fail_ci_if_error: false
 
       # Node setup + build (validates lint + typecheck + build in one step)
       - uses: actions/setup-node@v4
@@ -176,7 +181,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.25.9"
-      - run: go test ./cmd/... ./internal/...
+      - run: go test -race -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
+      - uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          flags: backend
+          fail_ci_if_error: false
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ The `development` branch carries the in-flight feature set for the next release.
 
 ## [v0.6.1] — 2026-04-14
 
+v0.6.1 is the first installable build of the v0.6.0 feature set. The `v0.6.0` tag itself failed GoReleaser cross-compile: `describeDir` referenced `syscall.Stat_t` (POSIX-only) so `GOOS=windows` builds aborted and no binaries or `ghcr.io/vavallee/bindery:0.6.0` image were ever published. See v0.6.0 below for the full feature list.
+
 ### Fixed
-- GoReleaser was cross-compiling `internal/db/db.go` for `GOOS=windows` and hitting `undefined: syscall.Stat_t`, which aborted the Windows targets and failed the entire v0.6.0 tag release before any binaries or the `ghcr.io/vavallee/bindery:0.6.0` tag were published. `describeDir` (the Linux ownership hint in the SQLite "can't open" error path) is now split into `describe_unix.go` (POSIX uid/gid) and `describe_windows.go` (path + mode only). v0.6.1 ships the same feature set as v0.6.0; no runtime behaviour changes on Linux. The v0.6.0 GitHub release has been marked as draft since no assets were published under that tag.
+- Split `describeDir` (the Linux ownership hint in the SQLite "can't open" error path) into `describe_unix.go` (POSIX uid/gid via `syscall.Stat_t`) and `describe_windows.go` (path + mode only) via `//go:build` tags. No runtime behaviour change on Linux; unblocks `windows/amd64` and `windows/arm64` release binaries.
 
 ## [v0.6.0] — 2026-04-14
 
@@ -299,6 +301,8 @@ Initial public release.
 - Single-binary distribution with embedded React frontend.
 - Distroless Docker image and Helm chart.
 
+[v0.6.1]: https://github.com/vavallee/bindery/releases/tag/v0.6.1
+[v0.6.0]: https://github.com/vavallee/bindery/releases/tag/v0.6.0
 [v0.5.2]: https://github.com/vavallee/bindery/releases/tag/v0.5.2
 [v0.5.1]: https://github.com/vavallee/bindery/releases/tag/v0.5.1
 [v0.5.0]: https://github.com/vavallee/bindery/releases/tag/v0.5.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/vavallee/bindery/actions/workflows/ci.yml"><img src="https://github.com/vavallee/bindery/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://codecov.io/gh/vavallee/bindery"><img src="https://codecov.io/gh/vavallee/bindery/branch/main/graph/badge.svg" alt="codecov" /></a>
   <a href="https://github.com/vavallee/bindery/releases"><img src="https://img.shields.io/github/v/release/vavallee/bindery" alt="Release" /></a>
   <a href="https://github.com/vavallee/bindery/pkgs/container/bindery"><img src="https://img.shields.io/badge/ghcr.io-vavallee%2Fbindery-blue" alt="Docker" /></a>
   <a href="https://goreportcard.com/report/github.com/vavallee/bindery"><img src="https://goreportcard.com/badge/github.com/vavallee/bindery" alt="Go Report Card" /></a>

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "sha-c902a4e"
+  tag: "sha-62ce9e2"
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "sha-1ce1733"
+  tag: "sha-088ccb8"
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "sha-088ccb8"
+  tag: "sha-c902a4e"
   pullPolicy: IfNotPresent
 
 service:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -66,7 +66,7 @@ Pre-built archives are attached to every [Release](https://github.com/vavallee/b
 Pick the archive matching your platform, verify against `bindery_vX.Y.Z_checksums.txt`, extract, and run:
 
 ```bash
-tar -xzf bindery_v0.5.0_linux_amd64.tar.gz
+tar -xzf bindery_0.6.1_linux_amd64.tar.gz
 ./bindery
 ```
 
@@ -153,7 +153,7 @@ On first launch Bindery bootstraps itself — **no environment variables are req
 
 ### From v0.5.x to v0.6.x
 
-The auth overhaul landed in v0.6.0 is fully backwards-compatible on existing installs:
+The auth overhaul (first installable in v0.6.1; `v0.6.0` tag's release binaries never built) is fully backwards-compatible on existing installs:
 
 - The new `users` table and `auth.*` settings are added by an additive migration. No manual step required.
 - If you had `BINDERY_API_KEY` set, it **seeds** the new key on first boot so existing integrations keep working. After that the key lives in the database; the env var is inert and can be removed. Leaving it set won't hurt but it no longer drives runtime behaviour.


### PR DESCRIPTION
## Summary
**Docs reconciliation**
- CHANGELOG v0.6.1 entry reframed as "first installable build of the v0.6.0 feature set"; the fix section is now just the windows-crosscompile delta.
- Missing `[v0.6.0]` / `[v0.6.1]` link refs added.
- `docs/DEPLOYMENT.md` "From v0.5.x to v0.6.x" section clarifies v0.6.0 never shipped release binaries, and the tarball example uses the correct artifact name (`bindery_0.6.1_linux_amd64.tar.gz`, no `v` prefix).

**Codecov**
- `go test` in both `build` and `validate` jobs now runs with `-race -coverprofile=coverage.out -covermode=atomic`; `codecov-action@v5` uploads to codecov.io (tokenless — public repo).
- `.codecov.yml`: project + patch checks are informational (no CI failure on transient drops). Ignores `cmd/`, `internal/migrate/`, `web/` — not library code we're measuring.
- Codecov badge added to README next to the CI badge.

## Test plan
- [x] `go test -race -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...` passes locally
- [ ] codecov upload completes on first run