### PR TITLE
ci: pass CODECOV_TOKEN to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           files: coverage.out
           flags: backend
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       # Node setup + build (validates lint + typecheck + build in one step)
       - uses: actions/setup-node@v4
@@ -187,6 +188,7 @@ jobs:
           files: coverage.out
           flags: backend
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "sha-62ce9e2"
+  tag: "sha-8e4ec6c"
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "sha-8e4ec6c"
+  tag: "sha-14fc25f"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
## Summary
- Tokenless upload was rejected by codecov (`"Token required - not valid tokenless upload"`).
- `CODECOV_TOKEN` now set as a GitHub Actions secret; wired into both the `build` and `validate` job's codecov steps.

## Test plan
- [ ] Codecov upload succeeds on this PR's CI run
- [ ] Badge resolves to a coverage number once main-push CI lands