### PR TITLE
release: v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
 
+### Fixed
+- **Windows binary exits immediately** ([#7](https://github.com/vavallee/bindery/issues/7)): the default `BINDERY_DB_PATH` was hardcoded to the Linux-container path `/config/bindery.db`. On Windows, `os.MkdirAll("/config", …)` failed, the preflight write probe returned an error, and because the process was spawned from an Explorer double-click the cmd window closed before the user could read the log line. Defaults are now platform-aware via `os.UserConfigDir`: `%APPDATA%\Bindery\bindery.db` on Windows, `~/Library/Application Support/Bindery/bindery.db` on macOS, unchanged `/config/bindery.db` on Linux (existing Docker / Helm / bare-metal deployments are untouched). The resolved paths are emitted in the `"starting bindery"` startup log line so `bindery.exe` runs from `cmd` will surface them even if db.Open later fails.
+
 ## [v0.6.1] — 2026-04-14
 
 v0.6.1 is the first installable build of the v0.6.0 feature set. The `v0.6.0` tag itself failed GoReleaser cross-compile: `describeDir` referenced `syscall.Stat_t` (POSIX-only) so `GOOS=windows` builds aborted and no binaries or `ghcr.io/vavallee/bindery:0.6.0` image were ever published. See v0.6.0 below for the full feature list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,16 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
 
+## [v0.6.2] — 2026-04-14
+
+Bug-fix release on top of v0.6.1.
+
 ### Fixed
 - **Windows binary exits immediately** ([#7](https://github.com/vavallee/bindery/issues/7)): the default `BINDERY_DB_PATH` was hardcoded to the Linux-container path `/config/bindery.db`. On Windows, `os.MkdirAll("/config", …)` failed, the preflight write probe returned an error, and because the process was spawned from an Explorer double-click the cmd window closed before the user could read the log line. Defaults are now platform-aware via `os.UserConfigDir`: `%APPDATA%\Bindery\bindery.db` on Windows, `~/Library/Application Support/Bindery/bindery.db` on macOS, unchanged `/config/bindery.db` on Linux (existing Docker / Helm / bare-metal deployments are untouched). The resolved paths are emitted in the `"starting bindery"` startup log line so `bindery.exe` runs from `cmd` will surface them even if db.Open later fails.
+- **Header nav overflowed into a horizontal scrollbar** at mid viewport widths (≈768–1024px). Desktop nav + version label + sign-out now collapse into the hamburger menu at `lg` (1024px) instead of `md` (768px), and the right-hand cluster is `flex-shrink-0` so it stops being squeezed by the nav tabs.
+
+### Changed
+- CI now uploads Go coverage to Codecov (`codecov/codecov-action@v5`) on both the build and validate jobs, with a `.codecov.yml` that marks project/patch checks as informational so coverage dips don't block PRs.
 
 ## [v0.6.1] — 2026-04-14
 
@@ -304,6 +312,7 @@ Initial public release.
 - Single-binary distribution with embedded React frontend.
 - Distroless Docker image and Helm chart.
 
+[v0.6.2]: https://github.com/vavallee/bindery/releases/tag/v0.6.2
 [v0.6.1]: https://github.com/vavallee/bindery/releases/tag/v0.6.1
 [v0.6.0]: https://github.com/vavallee/bindery/releases/tag/v0.6.0
 [v0.5.2]: https://github.com/vavallee/bindery/releases/tag/v0.5.2

--- a/README.md
+++ b/README.md
@@ -116,7 +116,33 @@ docker run -d \
 
 Open <http://localhost:8787>, follow the first-run setup to create the admin account, and you're in.
 
-For Docker Compose, Kubernetes (Helm), binary downloads, running as a specific UID/GID, and upgrade notes, see **[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)**.
+### Binary (Linux / macOS / Windows)
+
+Download the archive for your platform from the [latest release](https://github.com/vavallee/bindery/releases/latest), extract, and run:
+
+```bash
+# Linux / macOS
+tar -xzf bindery_<version>_<os>_<arch>.tar.gz
+./bindery
+```
+
+```cmd
+:: Windows
+:: Unzip bindery_<version>_windows_amd64.zip, then:
+bindery.exe
+```
+
+On first run the database lands in the platform's standard location:
+
+| Platform | Default `BINDERY_DB_PATH` | Default `BINDERY_DATA_DIR` |
+|----------|---------------------------|----------------------------|
+| Linux / Docker / Helm | `/config/bindery.db` | `/config` |
+| Windows | `%APPDATA%\Bindery\bindery.db` | `%APPDATA%\Bindery` |
+| macOS | `~/Library/Application Support/Bindery/bindery.db` | `~/Library/Application Support/Bindery` |
+
+Set `BINDERY_DB_PATH` / `BINDERY_DATA_DIR` if you want them elsewhere. The resolved paths are logged at startup (`"starting bindery"` log line).
+
+For Docker Compose, Kubernetes (Helm), running as a specific UID/GID, and upgrade notes, see **[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)**.
 
 ## Configuration
 
@@ -125,8 +151,8 @@ Bindery is configured through the web UI under **Settings**. Core env vars:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `BINDERY_PORT` | `8787` | HTTP server port |
-| `BINDERY_DB_PATH` | `/config/bindery.db` | SQLite database path |
-| `BINDERY_DATA_DIR` | `/config` | Config directory (backups live here) |
+| `BINDERY_DB_PATH` | platform-dependent (see [Binary install](#binary-linux--macos--windows)) | SQLite database path |
+| `BINDERY_DATA_DIR` | platform-dependent (see [Binary install](#binary-linux--macos--windows)) | Config directory (backups live here) |
 | `BINDERY_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
 | `BINDERY_DOWNLOAD_DIR` | `/downloads` | Where the download client places completed downloads |
 | `BINDERY_LIBRARY_DIR` | `/books` | Destination for imported ebook files |

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "sha-7985cc6"
+  tag: "sha-21fe5ce"
   pullPolicy: IfNotPresent
 
 service:

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -51,6 +51,8 @@ func main() {
 		"version", version,
 		"commit", commit,
 		"port", cfg.Port,
+		"dbPath", cfg.DBPath,
+		"dataDir", cfg.DataDir,
 	)
 
 	// Fail fast if BINDERY_PUID/PGID is set but the container isn't running

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -63,12 +63,44 @@ Pre-built archives are attached to every [Release](https://github.com/vavallee/b
 | macOS | amd64, arm64 | Intel Macs, Apple Silicon |
 | Windows | amd64, arm64 | x86_64 desktops, Windows on ARM |
 
-Pick the archive matching your platform, verify against `bindery_vX.Y.Z_checksums.txt`, extract, and run:
+Pick the archive matching your platform, verify against `bindery_<version>_checksums.txt`, extract, and run.
+
+### Linux
 
 ```bash
-tar -xzf bindery_0.6.1_linux_amd64.tar.gz
+tar -xzf bindery_<version>_linux_amd64.tar.gz
 ./bindery
 ```
+
+Database and backups land in `/config/` by default so the same binary slots into existing Docker / Helm deployments. Override with `BINDERY_DB_PATH` / `BINDERY_DATA_DIR` if you don't want `/config` (bare-metal users running as non-root will need to).
+
+### macOS
+
+```bash
+tar -xzf bindery_<version>_darwin_arm64.tar.gz   # or _amd64 for Intel Macs
+./bindery
+```
+
+On first run the database resolves to `~/Library/Application Support/Bindery/bindery.db`. The app respects `BINDERY_DB_PATH` / `BINDERY_DATA_DIR` if you want them elsewhere.
+
+Gatekeeper may flag the unsigned binary; allow it in **System Settings → Privacy & Security** (the "bindery" entry shows up under "Security" after the first blocked launch).
+
+### Windows
+
+Unzip `bindery_<version>_windows_amd64.zip` (or `_arm64.zip` for Windows on ARM) and double-click `bindery.exe`. On first run the database resolves to `%APPDATA%\Bindery\bindery.db`.
+
+If the console window closes instantly, open `cmd` and run the binary from there so the error message stays readable:
+
+```cmd
+cd %USERPROFILE%\Downloads\bindery_<version>_windows_amd64
+bindery.exe
+```
+
+SmartScreen will warn about the unsigned binary on first launch — choose **More info → Run anyway**. Signed Windows builds are on the roadmap.
+
+### Resolved paths logged at startup
+
+Every launch emits a `"starting bindery"` JSON log line containing the resolved `dbPath` and `dataDir`. If the binary can't write to them, `db.Open`'s preflight will name the directory and the required UID so you can fix the permission without guesswork.
 
 The frontend is embedded in the binary via `go:embed` — no separate static-file hosting needed.
 
@@ -125,8 +157,8 @@ spec:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `BINDERY_PORT` | `8787` | HTTP server port |
-| `BINDERY_DB_PATH` | `/config/bindery.db` | SQLite database path |
-| `BINDERY_DATA_DIR` | `/config` | Config directory (backups live here) |
+| `BINDERY_DB_PATH` | `/config/bindery.db` on Linux; `%APPDATA%\Bindery\bindery.db` on Windows; `~/Library/Application Support/Bindery/bindery.db` on macOS | SQLite database path |
+| `BINDERY_DATA_DIR` | `/config` on Linux; `%APPDATA%\Bindery` on Windows; `~/Library/Application Support/Bindery` on macOS | Config directory (backups live here) |
 | `BINDERY_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
 | `BINDERY_API_KEY` | _(empty)_ | **Seed only.** Bootstraps the initial API key on first launch if set; after that the key lives in the database and can be regenerated from the UI. |
 | `BINDERY_DOWNLOAD_DIR` | `/downloads` | Where SABnzbd places completed downloads |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,11 @@
 // variables with sensible defaults.
 package config
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
 
 // Config holds the application configuration loaded from environment variables.
 type Config struct {
@@ -30,8 +34,8 @@ type Config struct {
 func Load() *Config {
 	return &Config{
 		Port:              envOr("BINDERY_PORT", "8787"),
-		DBPath:            envOr("BINDERY_DB_PATH", "/config/bindery.db"),
-		DataDir:           envOr("BINDERY_DATA_DIR", "/config"),
+		DBPath:            envOr("BINDERY_DB_PATH", defaultDBPath(runtime.GOOS, os.UserConfigDir)),
+		DataDir:           envOr("BINDERY_DATA_DIR", defaultDataDir(runtime.GOOS, os.UserConfigDir)),
 		LogLevel:          envOr("BINDERY_LOG_LEVEL", "info"),
 		APIKey:            envOr("BINDERY_API_KEY", ""),
 		DownloadDir:       envOr("BINDERY_DOWNLOAD_DIR", "/downloads"),
@@ -39,6 +43,34 @@ func Load() *Config {
 		AudiobookDir:      envOr("BINDERY_AUDIOBOOK_DIR", ""),
 		DownloadPathRemap: envOr("BINDERY_DOWNLOAD_PATH_REMAP", ""),
 	}
+}
+
+// defaultDBPath resolves the platform-appropriate SQLite path. Linux keeps the
+// historical `/config/bindery.db` so existing Docker / Helm / bare-metal
+// deployments that bind-mount `/config` are unchanged. Windows and macOS
+// resolve under os.UserConfigDir so double-clicking the published binary
+// works without setting env vars. Falls back to `/config/bindery.db` if
+// UserConfigDir errors (vanishingly rare; cmd/bindery's db.Open preflight
+// catches the resulting write failure with a clear message).
+func defaultDBPath(goos string, userConfigDir func() (string, error)) string {
+	if goos != "linux" {
+		if d, err := userConfigDir(); err == nil {
+			return filepath.Join(d, "Bindery", "bindery.db")
+		}
+	}
+	return "/config/bindery.db"
+}
+
+// defaultDataDir mirrors defaultDBPath for BINDERY_DATA_DIR (where backups
+// land). Same linux-preserving logic so the two stay in the same directory
+// on every platform.
+func defaultDataDir(goos string, userConfigDir func() (string, error)) string {
+	if goos != "linux" {
+		if d, err := userConfigDir(); err == nil {
+			return filepath.Join(d, "Bindery")
+		}
+	}
+	return "/config"
 }
 
 func envOr(key, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,11 @@
 package config
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -14,16 +18,23 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.LogLevel != "info" {
 		t.Errorf("expected default log level info, got %s", cfg.LogLevel)
 	}
-	if cfg.DBPath != "/config/bindery.db" {
-		t.Errorf("expected default db path /config/bindery.db, got %s", cfg.DBPath)
+
+	// DBPath/DataDir are platform-dependent as of #7. CI runs on linux so
+	// here we only assert the linux invariant; per-platform coverage lives
+	// in TestDefaultDBPath / TestDefaultDataDir below.
+	if runtime.GOOS == "linux" {
+		if cfg.DBPath != "/config/bindery.db" {
+			t.Errorf("expected default db path /config/bindery.db, got %s", cfg.DBPath)
+		}
+		if cfg.DataDir != "/config" {
+			t.Errorf("expected default data dir /config, got %s", cfg.DataDir)
+		}
 	}
 }
 
 func TestLoadFromEnv(t *testing.T) {
-	os.Setenv("BINDERY_PORT", "9999")
-	os.Setenv("BINDERY_LOG_LEVEL", "debug")
-	defer os.Unsetenv("BINDERY_PORT")
-	defer os.Unsetenv("BINDERY_LOG_LEVEL")
+	t.Setenv("BINDERY_PORT", "9999")
+	t.Setenv("BINDERY_LOG_LEVEL", "debug")
 
 	cfg := Load()
 
@@ -32,5 +43,71 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.LogLevel != "debug" {
 		t.Errorf("expected log level debug, got %s", cfg.LogLevel)
+	}
+}
+
+// TestDefaultDBPath_Linux pins the linux default at `/config/bindery.db`.
+// Existing Docker / Helm / bare-metal installs mount `/config`, so a drift
+// here breaks every deployed user; guard it explicitly.
+func TestDefaultDBPath_Linux(t *testing.T) {
+	got := defaultDBPath("linux", func() (string, error) { return "/home/user/.config", nil })
+	if got != "/config/bindery.db" {
+		t.Errorf("linux default must be /config/bindery.db (unchanged), got %s", got)
+	}
+}
+
+// TestDefaultDBPath_Windows is the #7 regression guard — double-clicking
+// bindery.exe was hitting os.MkdirAll("/config", …) and exiting before the
+// user could read the error. Default now routes through UserConfigDir
+// (%APPDATA% on Windows).
+func TestDefaultDBPath_Windows(t *testing.T) {
+	got := defaultDBPath("windows", func() (string, error) { return `C:\Users\u\AppData\Roaming`, nil })
+	want := filepath.Join(`C:\Users\u\AppData\Roaming`, "Bindery", "bindery.db")
+	if got != want {
+		t.Errorf("windows default: want %s, got %s", want, got)
+	}
+}
+
+func TestDefaultDBPath_Darwin(t *testing.T) {
+	got := defaultDBPath("darwin", func() (string, error) { return "/Users/u/Library/Application Support", nil })
+	want := filepath.Join("/Users/u/Library/Application Support", "Bindery", "bindery.db")
+	if got != want {
+		t.Errorf("darwin default: want %s, got %s", want, got)
+	}
+}
+
+// TestDefaultDBPath_FallsBackOnDirError — if UserConfigDir errors on a
+// non-linux platform, fall back to the linux default. db.Open's preflight
+// will still surface a clear "not writable" message rather than a silent
+// SQLite error.
+func TestDefaultDBPath_FallsBackOnDirError(t *testing.T) {
+	got := defaultDBPath("windows", func() (string, error) { return "", errors.New("no APPDATA") })
+	if got != "/config/bindery.db" {
+		t.Errorf("expected fallback /config/bindery.db on UserConfigDir error, got %s", got)
+	}
+}
+
+func TestDefaultDataDir_Linux(t *testing.T) {
+	got := defaultDataDir("linux", func() (string, error) { return "/home/user/.config", nil })
+	if got != "/config" {
+		t.Errorf("linux default must be /config, got %s", got)
+	}
+}
+
+func TestDefaultDataDir_Windows(t *testing.T) {
+	got := defaultDataDir("windows", func() (string, error) { return `C:\Users\u\AppData\Roaming`, nil })
+	want := filepath.Join(`C:\Users\u\AppData\Roaming`, "Bindery")
+	if got != want {
+		t.Errorf("windows default: want %s, got %s", want, got)
+	}
+	if !strings.HasSuffix(got, "Bindery") {
+		t.Errorf("windows data dir should end in Bindery/: %s", got)
+	}
+}
+
+func TestDefaultDataDir_FallsBackOnDirError(t *testing.T) {
+	got := defaultDataDir("darwin", func() (string, error) { return "", os.ErrNotExist })
+	if got != "/config" {
+		t.Errorf("expected fallback /config on UserConfigDir error, got %s", got)
 	}
 }


### PR DESCRIPTION
## Summary

Bug-fix release rolling up the two fixes that landed after v0.6.1:

- **#7 — Windows binary exits immediately on double-click.** `BINDERY_DB_PATH` / `BINDERY_DATA_DIR` defaults are now platform-aware via `os.UserConfigDir` (`%APPDATA%\Bindery` on Windows, `~/Library/Application Support/Bindery` on macOS, unchanged `/config` on Linux). Resolved paths are now emitted in the `"starting bindery"` log line. Covered by new tests in `internal/config/config_test.go` (100% package coverage).
- **Nav header horizontal-scroll glitch** at ≈768–1024px viewports. Raised the desktop-nav breakpoint from `md` to `lg` and marked the right-hand cluster `flex-shrink-0`.

Also includes the Codecov CI wiring (`codecov-action@v5` on both build/validate jobs, informational `.codecov.yml`) that went in after v0.6.1.

v0.6.1 was the first release whose GoReleaser cross-compile succeeded for Windows. v0.6.2 is the first tag that exercises that pipeline *with* a Windows fix on top — so tagging also validates the v0.6.1 Windows build chain end-to-end.

## Test plan
- [x] `go test ./...` green on development (via PR #26 CI)
- [x] `internal/config` package at 100% coverage
- [ ] Release PR CI passes
- [ ] Tag `v0.6.2` → GoReleaser publishes 9 artifacts + `ghcr.io/vavallee/bindery:0.6.2`
- [ ] Smoke test Windows `.exe` from the release assets (user)