### PR TITLE
ci: ignore codecov-action leftovers so tag releases don't fail dirty check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,13 @@
 coverage.out
 coverage.html
 
+# codecov-action@v5 downloads these into the checkout on Linux runners.
+# Without this ignore, GoReleaser on tag pushes aborts with "git is in a
+# dirty state" because the codecov uploader runs earlier in the same job.
+/codecov
+/codecov.SHA256SUM
+/codecov.SHA256SUM.sig
+
 # Frontend
 web/node_modules/
 web/dist/


### PR DESCRIPTION
## Summary

v0.6.2's GoReleaser step failed with \`git is in a dirty state\` — the codecov-action@v5 that runs earlier in the same CI job leaves three files (\`codecov\`, \`codecov.SHA256SUM\`, \`codecov.SHA256SUM.sig\`) in the checkout root, and GoReleaser refuses to operate on a dirty worktree.

Fix: add those filenames to \`.gitignore\`. Coverage uploads still work (gitignored files are still present on disk); GoReleaser sees a clean worktree.

No runtime change. CI-only hotfix.

## Test plan
- [x] Local: coverage workflow step produces files, \`git status\` reports clean with the new ignore
- [ ] PR CI passes
- [ ] After merge: delete phantom v0.6.2 tag/release, re-tag v0.6.2 on the merge commit so GoReleaser publishes binaries cleanly