### PR TITLE
feat(ui): persist page-size selection across tabs

### DIFF
--- a/web/src/components/usePagination.ts
+++ b/web/src/components/usePagination.ts
@@ -3,16 +3,36 @@ import { useMemo, useState } from 'react'
 /**
  * usePagination: client-side slicing helper.
  * Pass the full filtered list; get back the visible page + props for Pagination.
+ *
+ * storageKey: when provided, page size is persisted to localStorage under that
+ * key so the user's preference survives navigation and page reloads.
  */
-export function usePagination<T>(items: T[], defaultPageSize = 50) {
+export function usePagination<T>(items: T[], defaultPageSize = 50, storageKey?: string) {
   const [page, setPage] = useState(1)
-  const [pageSize, setPageSize] = useState(defaultPageSize)
+  const [pageSize, setPageSize] = useState(() => {
+    if (storageKey) {
+      const stored = localStorage.getItem(`pageSize:${storageKey}`)
+      if (stored) {
+        const n = parseInt(stored, 10)
+        if (!isNaN(n) && n > 0) return n
+      }
+    }
+    return defaultPageSize
+  })
 
   const totalPages = Math.max(1, Math.ceil(items.length / pageSize))
   const safePage = Math.min(page, totalPages)
   const paged = useMemo(() => items.slice((safePage - 1) * pageSize, safePage * pageSize), [items, safePage, pageSize])
 
   const reset = () => setPage(1)
+
+  const handlePageSizeChange = (size: number) => {
+    setPageSize(size)
+    setPage(1)
+    if (storageKey) {
+      localStorage.setItem(`pageSize:${storageKey}`, String(size))
+    }
+  }
 
   return {
     pageItems: paged,
@@ -22,7 +42,7 @@ export function usePagination<T>(items: T[], defaultPageSize = 50) {
       pageSize,
       totalItems: items.length,
       onPageChange: setPage,
-      onPageSizeChange: (size: number) => { setPageSize(size); setPage(1) },
+      onPageSizeChange: handlePageSizeChange,
     },
     reset,
   }

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -63,7 +63,7 @@ export default function AuthorsPage() {
     return list
   }, [authors, search, sort])
 
-  const { pageItems, paginationProps, reset } = usePagination(filtered, 50)
+  const { pageItems, paginationProps, reset } = usePagination(filtered, 50, 'authors')
 
   useEffect(() => { reset() }, [search, sort, reset])
 

--- a/web/src/pages/BlocklistPage.tsx
+++ b/web/src/pages/BlocklistPage.tsx
@@ -63,7 +63,7 @@ export default function BlocklistPage() {
 
   const allSelected = entries.length > 0 && selected.size === entries.length
 
-  const { pageItems, paginationProps } = usePagination(entries, 50)
+  const { pageItems, paginationProps } = usePagination(entries, 50, 'blocklist')
 
   return (
     <div>

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -63,7 +63,7 @@ export default function BooksPage() {
     return list
   }, [books, statusFilter, mediaFilter, search, sort])
 
-  const { pageItems, paginationProps, reset } = usePagination(filtered, 50)
+  const { pageItems, paginationProps, reset } = usePagination(filtered, 50, 'books')
 
   useEffect(() => { reset() }, [statusFilter, mediaFilter, search, sort, reset])
 

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -79,7 +79,7 @@ export default function HistoryPage() {
 
   const eventTypes = Array.from(new Set(events.map(e => e.eventType))).sort()
 
-  const { pageItems, paginationProps, reset } = usePagination(events, 100)
+  const { pageItems, paginationProps, reset } = usePagination(events, 100, 'history')
 
   useEffect(() => { reset() }, [typeFilter, reset])
 

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -64,7 +64,7 @@ export default function WantedPage() {
     }
   }
 
-  const { pageItems, paginationProps, reset } = usePagination(filtered, 50)
+  const { pageItems, paginationProps, reset } = usePagination(filtered, 50, 'wanted')
 
   useEffect(() => { reset() }, [search, reset])
 


### PR DESCRIPTION
## Summary

Page size selection now persists per page via `localStorage`. Setting 50/page on Authors and then switching to Books no longer resets it.

- `usePagination` accepts an optional `storageKey`; when provided, reads the initial value from `localStorage` and writes on every change
- All list pages pass a unique key: `authors`, `books`, `wanted`, `history`, `blocklist`

Closes #34