### PR TITLE
feat: manual library scan trigger (API + Settings UI)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -147,6 +147,7 @@ func main() {
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, idxSearcher, settingsRepo, blocklistRepo)
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)
 	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo)
+	libraryHandler := api.NewLibraryHandler(importScanner)
 	fileHandler := api.NewFileHandler(bookRepo)
 	historyHandler := api.NewHistoryHandler(historyRepo, blocklistRepo)
 	blocklistHandler := api.NewBlocklistHandler(blocklistRepo)
@@ -325,6 +326,9 @@ func main() {
 		r.Post("/backup", backupHandler.Create)
 		r.Post("/backup/{filename}/restore", backupHandler.Restore)
 		r.Delete("/backup/{filename}", backupHandler.Delete)
+
+		// Library
+		r.Post("/library/scan", libraryHandler.Scan)
 
 		// Migration imports (CSV of author names, or Readarr SQLite DB).
 		r.Post("/migrate/csv", migrateHandler.ImportCSV)

--- a/internal/api/library.go
+++ b/internal/api/library.go
@@ -1,0 +1,23 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/vavallee/bindery/internal/importer"
+)
+
+type LibraryHandler struct {
+	scanner *importer.Scanner
+}
+
+func NewLibraryHandler(scanner *importer.Scanner) *LibraryHandler {
+	return &LibraryHandler{scanner: scanner}
+}
+
+// Scan triggers an immediate library reconciliation in the background and
+// returns 202 Accepted. The scan runs asynchronously; clients can monitor
+// progress via the book list.
+func (h *LibraryHandler) Scan(w http.ResponseWriter, r *http.Request) {
+	go h.scanner.ScanLibrary(r.Context())
+	writeJSON(w, http.StatusAccepted, map[string]string{"message": "library scan started"})
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -118,6 +118,9 @@ export const api = {
   deleteDownloadClient: (id: number) => request<void>(`/downloadclient/${id}`, { method: 'DELETE' }),
   testDownloadClient: (id: number) => request<{ message: string }>(`/downloadclient/${id}/test`, { method: 'POST' }),
 
+  // Library
+  triggerLibraryScan: () => request<{ message: string }>('/library/scan', { method: 'POST' }),
+
   // Queue
   listQueue: () => request<QueueItem[]>('/queue'),
   grab: (data: GrabRequest) => request<Download>('/queue/grab', { method: 'POST', body: JSON.stringify(data) }),

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -689,6 +689,7 @@ function GeneralTab() {
   const [saving, setSaving] = useState<string | null>(null)
   const [backups, setBackups] = useState<string[]>([])
   const [creatingBackup, setCreatingBackup] = useState(false)
+  const [scanningLibrary, setScanningLibrary] = useState(false)
 
   useEffect(() => {
     api.listSettings()
@@ -723,6 +724,17 @@ function GeneralTab() {
       alert('Backup failed: ' + (err instanceof Error ? err.message : 'Unknown error'))
     } finally {
       setCreatingBackup(false)
+    }
+  }
+
+  const handleScan = async () => {
+    setScanningLibrary(true)
+    try {
+      await api.triggerLibraryScan()
+    } catch (err) {
+      alert('Scan failed: ' + (err instanceof Error ? err.message : 'Unknown error'))
+    } finally {
+      setScanningLibrary(false)
     }
   }
 
@@ -841,6 +853,26 @@ function GeneralTab() {
                 {saving === 'googlebooks.apiKey' ? 'Saving...' : 'Save'}
               </button>
             </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Library */}
+      <section>
+        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">Library</h3>
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-slate-700 dark:text-zinc-300">Scan library</p>
+              <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">Walk the books directory and reconcile files with the database</p>
+            </div>
+            <button
+              onClick={handleScan}
+              disabled={scanningLibrary}
+              className="px-4 py-2 bg-slate-600 hover:bg-slate-500 rounded text-sm font-medium disabled:opacity-50 flex-shrink-0"
+            >
+              {scanningLibrary ? 'Scanning…' : 'Scan Library'}
+            </button>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary

Adds an on-demand library scan so users don't have to wait up to 6 hours for the scheduled run.

**Backend**
- New `POST /api/v1/library/scan` — fires `scanner.ScanLibrary` in a goroutine and returns `202 Accepted` immediately
- New `internal/api/LibraryHandler` wired up in `main.go`

**Frontend**
- **Settings → General → Library** section with a **Scan Library** button (shows "Scanning…" while in-flight)
- `api.triggerLibraryScan()` method added to the API client

Closes #10