### PR TITLE
fix: qBittorrent download client form — username field, type re-render, credential wiring

### DIFF
--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -107,10 +108,18 @@ func (h *DownloadClientHandler) Test(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
-	if err := sab.Test(r.Context()); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return
+	if client.Type == "qbittorrent" {
+		qbt := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		if err := qbt.Test(r.Context()); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+	} else {
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		if err := sab.Test(r.Context()); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"message": "ok"})
 }

--- a/internal/db/download_clients.go
+++ b/internal/db/download_clients.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -16,6 +17,24 @@ type DownloadClientRepo struct {
 
 func NewDownloadClientRepo(db *sql.DB) *DownloadClientRepo {
 	return &DownloadClientRepo{db: db}
+}
+
+// populateVirtualCredentials maps the storage columns to the virtual Username/Password
+// fields for qBittorrent clients (which store credentials in url_base and api_key).
+func populateVirtualCredentials(c *models.DownloadClient) {
+	if c.Type == "qbittorrent" {
+		c.Username = c.URLBase
+		c.Password = c.APIKey
+	}
+}
+
+// applyVirtualCredentials maps the virtual Username/Password fields back to the
+// storage columns for qBittorrent clients before writing to the database.
+func applyVirtualCredentials(c *models.DownloadClient) {
+	if c.Type == "qbittorrent" {
+		c.URLBase = c.Username
+		c.APIKey = c.Password
+	}
 }
 
 func (r *DownloadClientRepo) List(ctx context.Context) ([]models.DownloadClient, error) {
@@ -37,6 +56,7 @@ func (r *DownloadClientRepo) List(ctx context.Context) ([]models.DownloadClient,
 		}
 		c.Enabled = enabled == 1
 		c.UseSSL = useSSL == 1
+		populateVirtualCredentials(&c)
 		clients = append(clients, c)
 	}
 	return clients, rows.Err()
@@ -58,6 +78,7 @@ func (r *DownloadClientRepo) GetByID(ctx context.Context, id int64) (*models.Dow
 	}
 	c.Enabled = enabled == 1
 	c.UseSSL = useSSL == 1
+	populateVirtualCredentials(&c)
 	return &c, nil
 }
 
@@ -77,10 +98,73 @@ func (r *DownloadClientRepo) GetFirstEnabled(ctx context.Context) (*models.Downl
 	}
 	c.Enabled = enabled == 1
 	c.UseSSL = useSSL == 1
+	populateVirtualCredentials(&c)
 	return &c, nil
 }
 
+// GetFirstEnabledByProtocol returns the highest-priority enabled client that
+// matches the given protocol ("usenet" → sabnzbd, "torrent" → qbittorrent).
+// Falls back to the first enabled client of any type if no match is found.
+func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, protocol string) (*models.DownloadClient, error) {
+	clientType := "sabnzbd"
+	if protocol == "torrent" {
+		clientType = "qbittorrent"
+	}
+
+	var c models.DownloadClient
+	var enabled, useSSL int
+	err := r.db.QueryRowContext(ctx, `
+		SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
+		FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority LIMIT 1`, clientType).
+		Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
+			&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		// No client of matching type — fall back to any enabled client
+		return r.GetFirstEnabled(ctx)
+	}
+	c.Enabled = enabled == 1
+	c.UseSSL = useSSL == 1
+	populateVirtualCredentials(&c)
+	return &c, nil
+}
+
+// GetEnabledByProtocol returns all enabled clients matching the given protocol,
+// ordered by priority. Used when multiple clients of the same type exist and
+// the caller needs to pick the best one by category.
+func (r *DownloadClientRepo) GetEnabledByProtocol(ctx context.Context, protocol string) ([]models.DownloadClient, error) {
+	clientType := "sabnzbd"
+	if protocol == "torrent" {
+		clientType = "qbittorrent"
+	}
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
+		FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority`, clientType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var clients []models.DownloadClient
+	for rows.Next() {
+		var c models.DownloadClient
+		var enabled, useSSL int
+		if err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
+			&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt); err != nil {
+			return nil, err
+		}
+		c.Enabled = enabled == 1
+		c.UseSSL = useSSL == 1
+		populateVirtualCredentials(&c)
+		clients = append(clients, c)
+	}
+	return clients, rows.Err()
+}
+
 func (r *DownloadClientRepo) Create(ctx context.Context, c *models.DownloadClient) error {
+	applyVirtualCredentials(c)
 	now := time.Now().UTC()
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO download_clients (name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at)
@@ -97,6 +181,7 @@ func (r *DownloadClientRepo) Create(ctx context.Context, c *models.DownloadClien
 }
 
 func (r *DownloadClientRepo) Update(ctx context.Context, c *models.DownloadClient) error {
+	applyVirtualCredentials(c)
 	now := time.Now().UTC()
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE download_clients SET name=?, type=?, host=?, port=?, api_key=?, use_ssl=?,
@@ -109,4 +194,27 @@ func (r *DownloadClientRepo) Update(ctx context.Context, c *models.DownloadClien
 func (r *DownloadClientRepo) Delete(ctx context.Context, id int64) error {
 	_, err := r.db.ExecContext(ctx, "DELETE FROM download_clients WHERE id=?", id)
 	return err
+}
+
+// pickClientForMediaType selects the best client from a list by preferring
+// one whose category hints match the media type. For audiobooks, prefer a client
+// with "audio" in the category name; for ebooks, prefer one without "audio".
+// Falls back to the first (highest-priority) client if no preference matches.
+func pickClientForMediaType(clients []models.DownloadClient, mediaType string) *models.DownloadClient {
+	if len(clients) == 0 {
+		return nil
+	}
+	if len(clients) == 1 {
+		return &clients[0]
+	}
+	for i := range clients {
+		cat := strings.ToLower(clients[i].Category)
+		if mediaType == "audiobook" && strings.Contains(cat, "audio") {
+			return &clients[i]
+		}
+		if mediaType != "audiobook" && !strings.Contains(cat, "audio") {
+			return &clients[i]
+		}
+	}
+	return &clients[0]
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -241,6 +241,8 @@ export interface DownloadClient {
   host: string
   port: number
   apiKey: string
+  username: string
+  password: string
   useSsl: boolean
   category: string
   enabled: boolean

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -913,11 +913,21 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
   const [type, setType] = useState(client.type || 'sabnzbd')
   const [host, setHost] = useState(client.host)
   const [port, setPort] = useState(String(client.port))
-  const [apiKey, setApiKey] = useState(client.apiKey)
+  const [credential, setCredential] = useState(client.type === 'qbittorrent' ? (client.password || '') : (client.apiKey || ''))
+  const [username, setUsername] = useState(client.username || '')
   const [category, setCategory] = useState(client.category)
 
+  const handleTypeChange = (newType: string) => {
+    setType(newType)
+    setCredential('')
+    setUsername('')
+  }
+
   const submit = async () => {
-    const updated = await api.updateDownloadClient(client.id, { ...client, name, type, host, port: parseInt(port), apiKey, category })
+    const data = type === 'qbittorrent'
+      ? { ...client, name, type, host, port: parseInt(port), username, password: credential, apiKey: '', category }
+      : { ...client, name, type, host, port: parseInt(port), apiKey: credential, username: '', password: '', category }
+    const updated = await api.updateDownloadClient(client.id, data)
     onSaved(updated)
   }
 
@@ -925,7 +935,7 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
     <div className="mt-1 p-4 border border-slate-300 dark:border-zinc-700 rounded-lg bg-slate-200/50 dark:bg-zinc-800/50 space-y-3">
       <div className="flex gap-2">
         <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
-        <select value={type} onChange={e => setType(e.target.value)} className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
+        <select value={type} onChange={e => handleTypeChange(e.target.value)} className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
           <option value="sabnzbd">SABnzbd</option>
           <option value="qbittorrent">qBittorrent</option>
         </select>
@@ -934,7 +944,10 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
         <input value={host} onChange={e => setHost(e.target.value)} placeholder="Host" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
         <input value={port} onChange={e => setPort(e.target.value)} placeholder="Port" className="w-24 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
       </div>
-      <input value={apiKey} onChange={e => setApiKey(e.target.value)} placeholder={type === 'qbittorrent' ? 'Password' : 'API Key'} type="password" className={inputCls} />
+      {type === 'qbittorrent' && (
+        <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />
+      )}
+      <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' ? 'Password' : 'API Key'} type="password" className={inputCls} />
       <input value={category} onChange={e => setCategory(e.target.value)} placeholder="Category" className={inputCls} />
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
@@ -1031,13 +1044,22 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
   const [type, setType] = useState<'sabnzbd' | 'qbittorrent'>('sabnzbd')
   const [host, setHost] = useState('')
   const [port, setPort] = useState('8080')
-  const [apiKey, setApiKey] = useState('')
+  const [credential, setCredential] = useState('')
+  const [username, setUsername] = useState('')
   const [category, setCategory] = useState('books')
 
+  const handleTypeChange = (newType: 'sabnzbd' | 'qbittorrent') => {
+    setType(newType)
+    setCredential('')
+    setUsername('')
+    setName(newType === 'qbittorrent' ? 'qBittorrent' : 'SABnzbd')
+  }
+
   const submit = async () => {
-    const c = await api.addDownloadClient({
-      name, host, port: parseInt(port), apiKey, category, type, enabled: true,
-    })
+    const data = type === 'qbittorrent'
+      ? { name, host, port: parseInt(port), username, password: credential, apiKey: '', category, type, enabled: true }
+      : { name, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, type, enabled: true }
+    const c = await api.addDownloadClient(data)
     onAdded(c)
   }
 
@@ -1045,7 +1067,7 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
     <div className="mt-4 p-4 border border-slate-300 dark:border-zinc-700 rounded-lg bg-slate-200/50 dark:bg-zinc-800/50 space-y-3">
       <div className="flex gap-2">
         <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
-        <select value={type} onChange={e => { setType(e.target.value as 'sabnzbd' | 'qbittorrent'); setPort(e.target.value === 'qbittorrent' ? '8080' : '8080') }} className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
+        <select value={type} onChange={e => handleTypeChange(e.target.value as 'sabnzbd' | 'qbittorrent')} className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
           <option value="sabnzbd">SABnzbd</option>
           <option value="qbittorrent">qBittorrent</option>
         </select>
@@ -1054,7 +1076,10 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
         <input value={host} onChange={e => setHost(e.target.value)} placeholder="Host" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
         <input value={port} onChange={e => setPort(e.target.value)} placeholder="Port" className="w-24 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
       </div>
-      <input value={apiKey} onChange={e => setApiKey(e.target.value)} placeholder={type === 'qbittorrent' ? 'Password' : 'API Key'} type="password" className={inputCls} />
+      {type === 'qbittorrent' && (
+        <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />
+      )}
+      <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' ? 'Password' : 'API Key'} type="password" className={inputCls} />
       <input value={category} onChange={e => setCategory(e.target.value)} placeholder="Category" className={inputCls} />
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>


### PR DESCRIPTION
## Summary

Fixes three related bugs in the download client settings form (#35).

**Frontend**
- Switching the type dropdown now clears credentials and re-renders the correct fields
- qBittorrent form shows a **Username** field (conditionally rendered); SABnzbd shows only the API Key field
- Both Add and Edit forms updated

**Backend**
- `DownloadClientRepo`: `applyVirtualCredentials` maps `Username → url_base` and `Password → api_key` on write for qBittorrent; `populateVirtualCredentials` reverses this on read — so `username`/`password` JSON fields round-trip correctly
- Test handler now dispatches to `qbittorrent.Client.Test()` for qBittorrent clients instead of always calling SABnzbd

Closes #35