### PR TITLE
fix: protocol-aware download client routing (torznab → qBittorrent, format → matching SAB)

### DIFF
--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
 	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/models"
@@ -47,8 +48,8 @@ func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
 		items[i] = QueueItem{Download: d}
 	}
 
-	client, err := h.clients.GetFirstEnabled(r.Context())
-	if err == nil && client != nil {
+	client, err := h.clients.GetFirstEnabledByProtocol(r.Context(), "usenet")
+	if err == nil && client != nil && client.Type == "sabnzbd" {
 		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
 		queue, err := sab.GetQueue(r.Context())
 		if err == nil {
@@ -78,6 +79,8 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		Size      int64  `json:"size"`
 		BookID    *int64 `json:"bookId"`
 		IndexerID *int64 `json:"indexerId"`
+		Protocol  string `json:"protocol"`
+		MediaType string `json:"mediaType"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -87,6 +90,9 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "guid and nzbUrl required"})
 		return
 	}
+	if req.Protocol == "" {
+		req.Protocol = "usenet"
+	}
 
 	// Check for duplicate
 	existing, _ := h.downloads.GetByGUID(r.Context(), req.GUID)
@@ -95,8 +101,8 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get first enabled download client
-	client, err := h.clients.GetFirstEnabled(r.Context())
+	// Select download client by protocol, preferring one that matches the media type
+	client, err := h.selectClient(r.Context(), req.Protocol, req.MediaType)
 	if err != nil || client == nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "no enabled download client configured"})
 		return
@@ -112,7 +118,7 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		NZBURL:           req.NZBURL,
 		Size:             req.Size,
 		Status:           models.DownloadStatusQueued,
-		Protocol:         "usenet",
+		Protocol:         req.Protocol,
 		Quality:          indexer.ParseRelease(req.Title).Format,
 	}
 	if err := h.downloads.Create(r.Context(), dl); err != nil {
@@ -120,25 +126,38 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Send to SABnzbd
-	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
-	resp, err := sab.AddURL(r.Context(), req.NZBURL, req.Title, client.Category, 0)
-	if err != nil {
-		slog.Error("failed to send to sabnzbd", "error", err, "title", req.Title)
-		h.downloads.SetError(r.Context(), dl.ID, err.Error())
-		h.recordHistory(r.Context(), models.HistoryEventDownloadFailed, req.Title, req.BookID, map[string]interface{}{"guid": req.GUID, "message": err.Error()})
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send to SABnzbd: " + err.Error()})
-		return
+	// Dispatch to the appropriate download client
+	if req.Protocol == "torrent" {
+		qbt := qbittorrent.New(client.Host, client.Port, client.URLBase, client.APIKey, client.UseSSL)
+		if err := qbt.AddTorrent(r.Context(), req.NZBURL, client.Category, ""); err != nil {
+			slog.Error("failed to send to qBittorrent", "error", err, "title", req.Title)
+			h.downloads.SetError(r.Context(), dl.ID, err.Error())
+			h.recordHistory(r.Context(), models.HistoryEventDownloadFailed, req.Title, req.BookID, map[string]interface{}{"guid": req.GUID, "message": err.Error()})
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send to qBittorrent: " + err.Error()})
+			return
+		}
+		h.downloads.UpdateStatus(r.Context(), dl.ID, models.DownloadStatusDownloading)
+		dl.Status = models.DownloadStatusDownloading
+		slog.Info("download sent to qBittorrent", "title", req.Title)
+	} else {
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		resp, err := sab.AddURL(r.Context(), req.NZBURL, req.Title, client.Category, 0)
+		if err != nil {
+			slog.Error("failed to send to sabnzbd", "error", err, "title", req.Title)
+			h.downloads.SetError(r.Context(), dl.ID, err.Error())
+			h.recordHistory(r.Context(), models.HistoryEventDownloadFailed, req.Title, req.BookID, map[string]interface{}{"guid": req.GUID, "message": err.Error()})
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send to SABnzbd: " + err.Error()})
+			return
+		}
+		if len(resp.NzoIDs) > 0 {
+			nzoID := resp.NzoIDs[0]
+			h.downloads.SetNzoID(r.Context(), dl.ID, nzoID)
+			dl.SABnzbdNzoID = &nzoID
+		}
+		h.downloads.UpdateStatus(r.Context(), dl.ID, models.DownloadStatusDownloading)
+		dl.Status = models.DownloadStatusDownloading
+		slog.Info("download grabbed", "title", req.Title, "nzoId", dl.SABnzbdNzoID)
 	}
-
-	// Update with NZO ID
-	if len(resp.NzoIDs) > 0 {
-		nzoID := resp.NzoIDs[0]
-		h.downloads.SetNzoID(r.Context(), dl.ID, nzoID)
-		dl.SABnzbdNzoID = &nzoID
-	}
-	h.downloads.UpdateStatus(r.Context(), dl.ID, models.DownloadStatusDownloading)
-	dl.Status = models.DownloadStatusDownloading
 
 	h.recordHistory(r.Context(), models.HistoryEventGrabbed, req.Title, req.BookID, map[string]interface{}{
 		"guid":      req.GUID,
@@ -146,8 +165,21 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		"indexerId": req.IndexerID,
 	})
 
-	slog.Info("download grabbed", "title", req.Title, "nzoId", dl.SABnzbdNzoID)
 	writeJSON(w, http.StatusAccepted, dl)
+}
+
+// selectClient picks the best enabled client for the given protocol and media type.
+// It prefers a client whose category hints match the media type when multiple
+// clients of the same protocol type are configured.
+func (h *QueueHandler) selectClient(ctx context.Context, protocol, mediaType string) (*models.DownloadClient, error) {
+	candidates, err := h.clients.GetEnabledByProtocol(ctx, protocol)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return h.clients.GetFirstEnabled(ctx)
+	}
+	return db.PickClientForMediaType(candidates, mediaType), nil
 }
 
 // recordHistory is a helper to write a history event, swallowing errors.
@@ -183,9 +215,12 @@ func (h *QueueHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Remove from SABnzbd if it has an NZO ID
-	if target.SABnzbdNzoID != nil {
-		client, err := h.clients.GetFirstEnabled(r.Context())
+	// Remove from the appropriate download client
+	if target.Protocol == "torrent" {
+		// qBittorrent: we don't store a per-download torrent hash yet, so just
+		// remove the local record. Future work: store hash in Download and call qbt.DeleteTorrent.
+	} else if target.SABnzbdNzoID != nil {
+		client, err := h.clients.GetFirstEnabledByProtocol(r.Context(), "usenet")
 		if err == nil && client != nil {
 			sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
 			_ = sab.Delete(r.Context(), *target.SABnzbdNzoID, true)

--- a/internal/db/download_clients.go
+++ b/internal/db/download_clients.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -109,4 +110,85 @@ func (r *DownloadClientRepo) Update(ctx context.Context, c *models.DownloadClien
 func (r *DownloadClientRepo) Delete(ctx context.Context, id int64) error {
 	_, err := r.db.ExecContext(ctx, "DELETE FROM download_clients WHERE id=?", id)
 	return err
+}
+
+// GetFirstEnabledByProtocol returns the highest-priority enabled client that
+// matches the given protocol ("usenet" → sabnzbd, "torrent" → qbittorrent).
+// Falls back to the first enabled client of any type if no match is found.
+func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, protocol string) (*models.DownloadClient, error) {
+	clientType := "sabnzbd"
+	if protocol == "torrent" {
+		clientType = "qbittorrent"
+	}
+
+	var c models.DownloadClient
+	var enabled, useSSL int
+	err := r.db.QueryRowContext(ctx, `
+		SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
+		FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority LIMIT 1`, clientType).
+		Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
+			&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return r.GetFirstEnabled(ctx)
+	}
+	c.Enabled = enabled == 1
+	c.UseSSL = useSSL == 1
+	return &c, nil
+}
+
+// GetEnabledByProtocol returns all enabled clients matching the given protocol,
+// ordered by priority. Used when multiple clients of the same type exist and
+// the caller needs to pick the best one by category.
+func (r *DownloadClientRepo) GetEnabledByProtocol(ctx context.Context, protocol string) ([]models.DownloadClient, error) {
+	clientType := "sabnzbd"
+	if protocol == "torrent" {
+		clientType = "qbittorrent"
+	}
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
+		FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority`, clientType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var clients []models.DownloadClient
+	for rows.Next() {
+		var c models.DownloadClient
+		var enabled, useSSL int
+		if err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
+			&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt); err != nil {
+			return nil, err
+		}
+		c.Enabled = enabled == 1
+		c.UseSSL = useSSL == 1
+		clients = append(clients, c)
+	}
+	return clients, rows.Err()
+}
+
+// PickClientForMediaType selects the best client from a list by preferring one
+// whose category hints match the media type. For audiobooks, prefer a client
+// with "audio" in the category name; for ebooks, prefer one without "audio".
+// Falls back to the first (highest-priority) client if no preference matches.
+func PickClientForMediaType(clients []models.DownloadClient, mediaType string) *models.DownloadClient {
+	if len(clients) == 0 {
+		return nil
+	}
+	if len(clients) == 1 {
+		return &clients[0]
+	}
+	for i := range clients {
+		cat := strings.ToLower(clients[i].Category)
+		if mediaType == "audiobook" && strings.Contains(cat, "audio") {
+			return &clients[i]
+		}
+		if mediaType != "audiobook" && !strings.Contains(cat, "audio") {
+			return &clients[i]
+		}
+	}
+	return &clients[0]
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/robfig/cron/v3"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
 	"github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/indexer"
@@ -120,12 +121,6 @@ func (s *Scheduler) searchWanted() {
 		return
 	}
 
-	client, err := s.clients.GetFirstEnabled(ctx)
-	if err != nil || client == nil {
-		slog.Debug("no download client available, skipping wanted search")
-		return
-	}
-
 	// Read preferred language once for all books in this run
 	lang := "en"
 	if langSetting, _ := s.settings.Get(ctx, "search.preferredLanguage"); langSetting != nil {
@@ -158,13 +153,35 @@ func (s *Scheduler) searchWanted() {
 
 		// Auto-grab the top result
 		best := results[0]
+
+		// Select the download client that matches the result's protocol, preferring
+		// one whose category hints match the book's media type.
+		candidates, _ := s.clients.GetEnabledByProtocol(ctx, best.Protocol)
+		client := db.PickClientForMediaType(candidates, book.MediaType)
+		if client == nil {
+			// Fall back to any enabled client
+			client, _ = s.clients.GetFirstEnabled(ctx)
+		}
+		if client == nil {
+			slog.Debug("no download client available, skipping", "book", book.Title)
+			continue
+		}
+
 		slog.Info("auto-grabbing wanted book",
 			"book", book.Title,
 			"author", authorName,
 			"result", best.Title,
 			"indexer", best.IndexerName,
+			"protocol", best.Protocol,
+			"client", client.Name,
 			"size", best.Size,
 		)
+
+		// Check for duplicate
+		existing, _ := s.downloads.GetByGUID(ctx, best.GUID)
+		if existing != nil {
+			continue
+		}
 
 		dl := &models.Download{
 			GUID:             best.GUID,
@@ -175,14 +192,8 @@ func (s *Scheduler) searchWanted() {
 			NZBURL:           best.NZBURL,
 			Size:             best.Size,
 			Status:           models.DownloadStatusQueued,
-			Protocol:         "usenet",
+			Protocol:         best.Protocol,
 			Quality:          indexer.ParseRelease(best.Title).Format,
-		}
-
-		// Check for duplicate
-		existing, _ := s.downloads.GetByGUID(ctx, best.GUID)
-		if existing != nil {
-			continue
 		}
 
 		if err := s.downloads.Create(ctx, dl); err != nil {
@@ -190,20 +201,30 @@ func (s *Scheduler) searchWanted() {
 			continue
 		}
 
-		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
-		resp, err := sab.AddURL(ctx, best.NZBURL, best.Title, client.Category, 0)
-		if err != nil {
-			slog.Error("failed to send to SABnzbd", "title", best.Title, "error", err)
-			s.downloads.SetError(ctx, dl.ID, err.Error())
-			continue
+		if best.Protocol == "torrent" {
+			qbt := qbittorrent.New(client.Host, client.Port, client.URLBase, client.APIKey, client.UseSSL)
+			if err := qbt.AddTorrent(ctx, best.NZBURL, client.Category, ""); err != nil {
+				slog.Error("failed to send to qBittorrent", "title", best.Title, "error", err)
+				s.downloads.SetError(ctx, dl.ID, err.Error())
+				continue
+			}
+			s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading)
+			slog.Info("sent to qBittorrent", "title", best.Title)
+		} else {
+			sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+			resp, err := sab.AddURL(ctx, best.NZBURL, best.Title, client.Category, 0)
+			if err != nil {
+				slog.Error("failed to send to SABnzbd", "title", best.Title, "error", err)
+				s.downloads.SetError(ctx, dl.ID, err.Error())
+				continue
+			}
+			if len(resp.NzoIDs) > 0 {
+				nzoID := resp.NzoIDs[0]
+				s.downloads.SetNzoID(ctx, dl.ID, nzoID)
+			}
+			s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading)
+			slog.Info("sent to SABnzbd", "title", best.Title)
 		}
-
-		if len(resp.NzoIDs) > 0 {
-			nzoID := resp.NzoIDs[0]
-			s.downloads.SetNzoID(ctx, dl.ID, nzoID)
-		}
-		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading)
-		slog.Info("sent to SABnzbd", "title", best.Title)
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -269,6 +269,7 @@ export interface SearchResult {
   nzbUrl: string
   grabs: number
   pubDate: string
+  protocol: string  // "usenet" or "torrent"
 }
 
 export interface AddAuthorRequest {
@@ -288,6 +289,8 @@ export interface GrabRequest {
   size: number
   bookId?: number
   indexerId?: number
+  protocol?: string
+  mediaType?: string
 }
 
 export interface HistoryEvent {

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -46,14 +46,16 @@ export default function WantedPage() {
     }
   }
 
-  const grab = async (result: SearchResult, bookId: number) => {
+  const grab = async (result: SearchResult, book: Book) => {
     try {
       await api.grab({
         guid: result.guid,
         title: result.title,
         nzbUrl: result.nzbUrl,
         size: result.size,
-        bookId,
+        bookId: book.id,
+        protocol: result.protocol,
+        mediaType: book.mediaType,
       })
       setShowResults(null)
       // Refresh wanted list
@@ -150,7 +152,7 @@ export default function WantedPage() {
                         <span className="text-slate-600 dark:text-zinc-500 truncate block">{r.indexerName} &middot; {formatSize(r.size)} &middot; {r.grabs} grabs</span>
                       </div>
                       <button
-                        onClick={() => grab(r, book.id)}
+                        onClick={() => grab(r, book)}
                         className="px-2 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-[10px] font-medium flex-shrink-0 touch-manipulation"
                       >
                         Grab


### PR DESCRIPTION
## Summary

Fixes two related routing bugs: torznab grabs routed to SABnzbd (#31), and multi-client ebook/audiobook format routing (#21).

**Root cause (both bugs)**
The scheduler and manual-grab handler hardcoded `Protocol: "usenet"` and always picked the first enabled client regardless of type.

**Changes**

_Backend_
- `DownloadClientRepo.GetFirstEnabledByProtocol(ctx, protocol)` — returns the highest-priority enabled client matching the protocol (`usenet` → `sabnzbd`, `torrent` → `qbittorrent`); falls back to any enabled client
- `DownloadClientRepo.GetEnabledByProtocol(ctx, protocol)` — returns all enabled clients of that type, ordered by priority
- `db.PickClientForMediaType(clients, mediaType)` — prefers a client whose `category` contains "audio" for audiobooks, and one without "audio" for ebooks; falls back to highest priority
- `queue.go` Grab handler: reads `protocol` and `mediaType` from the request body, uses `selectClient` to pick the right client, dispatches to qBittorrent (`AddTorrent`) or SABnzbd (`AddURL`) accordingly
- `scheduler.go` `searchWanted`: derives `Protocol` from `best.Protocol` (already set by the indexer searcher from the indexer's type), selects the appropriate client per book, dispatches to qBittorrent or SABnzbd

_Frontend_
- `SearchResult` interface gains `protocol: string`
- `GrabRequest` gains `protocol?: string` and `mediaType?: string`
- `WantedPage` passes both fields when calling `api.grab()`

Closes #31
Closes #21