### PR TITLE
fix: build frontend before GoReleaser compiles release binaries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,8 @@ project_name: bindery
 before:
   hooks:
     - go mod download
+    - npm ci --prefix web
+    - npm run build --prefix web
 
 builds:
   - id: bindery


### PR DESCRIPTION
## Problem
All released standalone binaries (Windows, macOS, Linux) shipped with no UI — visiting port 8787 showed only `.gitkeep`. The Docker image was unaffected.

**Root cause**: `.goreleaser.yaml` only had `go mod download` in `before.hooks`. The `npm run build` step existed in CI but ran in the Docker build job, not before GoReleaser. So `internal/webui/dist/` contained only `.gitkeep` when GoReleaser compiled the binaries.

## Fix
Add `npm ci --prefix web` and `npm run build --prefix web` to `before.hooks` in `.goreleaser.yaml`. GoReleaser runs these once before compiling any target, so `dist/` is populated for all platforms.

## Reported by
User on v0.6.2 — Windows binary, UI not loading.