### PR TITLE
fix(search): custom indexer categories + filterRelevant phrase-match trap

### DIFF
--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -224,14 +224,21 @@ func titleMatchesResult(normResult string, titleKws []string, surname string, al
 
 // filterRelevant removes results that don't plausibly match the requested book.
 // Strategy:
-//   - Multi-significant-word titles: require a contiguous phrase match. If no
-//     result in the batch matches as a phrase, relax to "every keyword at a
-//     word boundary" so we still surface something for oddly-structured names.
+//   - Multi-significant-word titles: try a contiguous phrase match first; if
+//     the phrase fails, accept the result if every significant keyword appears
+//     at a word boundary (handles titles like "The Name of the Wind" where stop
+//     words between sigWords prevent a direct phrase hit on the release title).
 //   - Single-significant-word titles: require the word AND the author surname
 //     at word boundaries (prevents "sparrow" alone from matching noise).
 //   - Titles with no significant words: fall back to the author surname alone.
 //   - Subtitle handling: if the title has "primary: subtitle", results matching
 //     either the primary-only or the full title form are accepted.
+//
+// Each result is evaluated independently. The previous batch-level
+// anyPhraseMatch gate (which disabled keyword fallback for the whole batch if
+// any result happened to phrase-match) caused correctly-titled releases to be
+// dropped when an abbreviated result set the gate — e.g. "Name.Wind.epub"
+// enabling strict mode that then rejected "Name.of.the.Wind.epub".
 func filterRelevant(results []newznab.SearchResult, title, author string) []newznab.SearchResult {
 	fullKws := sigWords(title)
 	primaryKws := sigWords(primaryTitle(title))
@@ -248,28 +255,16 @@ func filterRelevant(results []newznab.SearchResult, title, author string) []newz
 		normTitles[i] = NormalizeRelease(r.Title)
 	}
 
-	// First pass: strict (no keyword-only fallback). This determines whether
-	// any phrase match exists.
-	anyPhraseMatch := false
-	if len(fullKws) >= 2 {
-		for _, n := range normTitles {
-			if ContainsPhrase(n, fullKws) || (len(primaryKws) >= 2 && ContainsPhrase(n, primaryKws)) {
-				anyPhraseMatch = true
-				break
-			}
-		}
-	}
-
-	allowFallback := !anyPhraseMatch
-
 	filtered := make([]newznab.SearchResult, 0, len(results))
 	for i, r := range results {
 		n := normTitles[i]
 
-		fullOK := titleMatchesResult(n, fullKws, surname, allowFallback)
+		// allowFallback=true: each result gets phrase match first, then keyword
+		// fallback if the phrase fails. No batch-level gate.
+		fullOK := titleMatchesResult(n, fullKws, surname, true)
 		primaryOK := false
 		if !fullOK && len(primaryKws) > 0 && !sameKws(primaryKws, fullKws) {
-			primaryOK = titleMatchesResult(n, primaryKws, surname, allowFallback)
+			primaryOK = titleMatchesResult(n, primaryKws, surname, true)
 		}
 		if fullOK || primaryOK {
 			filtered = append(filtered, r)

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -415,6 +415,92 @@ func TestTitleMatchesSingleKeyword(t *testing.T) {
 	}
 }
 
+// Regression: the old anyPhraseMatch batch gate caused correctly-titled results
+// to be dropped when an abbreviated result in the same batch happened to have
+// the significant keywords adjacent, setting anyPhraseMatch=true and disabling
+// keyword fallback for the whole batch.
+func TestFilterRelevantAnyPhraseMatchTrap(t *testing.T) {
+	// "The Name of the Wind" — sigWords = ["name", "wind"].
+	// Phrase \bname\W+wind\b fails for "name of the wind" (stop words between).
+	// An abbreviated result "name.wind.epub" would previously trigger
+	// anyPhraseMatch=true, causing the correct release to be dropped.
+	results := toResults(
+		"Patrick.Rothfuss.-.The.Name.of.the.Wind.EPUB",
+		"Name.Wind.Rothfuss.epub", // abbreviated — phrase-matches ["name","wind"]
+		"Completely.Unrelated.Book.epub",
+	)
+	got := filterRelevant(results, "The Name of the Wind", "Patrick Rothfuss")
+
+	if !contains(got, "Patrick.Rothfuss.-.The.Name.of.the.Wind.EPUB") {
+		t.Errorf("correct release dropped by anyPhraseMatch trap; got %v", resultTitles(got))
+	}
+	if !contains(got, "Name.Wind.Rothfuss.epub") {
+		t.Errorf("abbreviated release should also pass; got %v", resultTitles(got))
+	}
+	if contains(got, "Completely.Unrelated.Book.epub") {
+		t.Error("unrelated result should be filtered out")
+	}
+}
+
+// Titles with stop words between significant keywords should pass keyword
+// fallback even when no result has a strict adjacency phrase match.
+func TestFilterRelevantStopWordsBetweenKeywords(t *testing.T) {
+	// "Lord of the Rings" — sigWords = ["lord", "rings"].
+	// Phrase \blord\W+rings\b never matches because "of the" sits between them.
+	// All correct results should pass via keyword fallback.
+	results := toResults(
+		"J.R.R.Tolkien.-.The.Lord.of.the.Rings.EPUB",
+		"Lord.Of.The.Rings.Tolkien.epub",
+		"The.Lord.of.the.Rings.Fellowship.epub",
+		"Lord.of.the.Rings.Unabridged.m4b",
+		"Unrelated.Fantasy.Novel.epub",
+	)
+	got := filterRelevant(results, "The Lord of the Rings", "J.R.R. Tolkien")
+
+	for _, title := range []string{
+		"J.R.R.Tolkien.-.The.Lord.of.the.Rings.EPUB",
+		"Lord.Of.The.Rings.Tolkien.epub",
+		"The.Lord.of.the.Rings.Fellowship.epub",
+		"Lord.of.the.Rings.Unabridged.m4b",
+	} {
+		if !contains(got, title) {
+			t.Errorf("expected %q to pass stop-word keyword fallback; got %v", title, resultTitles(got))
+		}
+	}
+	if contains(got, "Unrelated.Fantasy.Novel.epub") {
+		t.Error("unrelated result should be filtered out")
+	}
+}
+
+// Custom indexer categories (e.g. 7120 for German books) must pass through
+// filterCategoriesForMedia unchanged.
+func TestFilterCategoriesCustomIDs(t *testing.T) {
+	// SceneNZBs-style: 7120 = German books, 3130 = German audio.
+	cats := []int{7020, 7120, 3030, 3130}
+
+	ebook := filterCategoriesForMedia(cats, "ebook")
+	wantEbook := []int{7020, 7120}
+	if len(ebook) != len(wantEbook) {
+		t.Fatalf("ebook cats = %v, want %v", ebook, wantEbook)
+	}
+	for i, v := range wantEbook {
+		if ebook[i] != v {
+			t.Errorf("ebook[%d] = %d, want %d", i, ebook[i], v)
+		}
+	}
+
+	audio := filterCategoriesForMedia(cats, "audiobook")
+	wantAudio := []int{3030, 3130}
+	if len(audio) != len(wantAudio) {
+		t.Fatalf("audio cats = %v, want %v", audio, wantAudio)
+	}
+	for i, v := range wantAudio {
+		if audio[i] != v {
+			t.Errorf("audio[%d] = %d, want %d", i, audio[i], v)
+		}
+	}
+}
+
 func TestIsAudiobookFormat(t *testing.T) {
 	for _, f := range []string{"m4b", "m4a", "mp3", "flac", "ogg"} {
 		if !isAudiobookFormat(f) {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -917,14 +917,19 @@ function GeneralTab() {
   )
 }
 
+function parseCats(s: string): number[] {
+  return s.split(',').map(t => parseInt(t.trim(), 10)).filter(n => !isNaN(n))
+}
+
 function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onClose: () => void; onSaved: (idx: Indexer) => void }) {
   const [name, setName] = useState(indexer.name)
   const [type, setType] = useState(indexer.type || 'newznab')
   const [url, setUrl] = useState(indexer.url)
   const [apiKey, setApiKey] = useState(indexer.apiKey)
+  const [categories, setCategories] = useState((indexer.categories ?? [7020]).join(', '))
 
   const submit = async () => {
-    const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey })
+    const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey, categories: parseCats(categories) })
     onSaved(updated)
   }
 
@@ -939,6 +944,10 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
       </div>
       <input value={url} onChange={e => setUrl(e.target.value)} placeholder="URL" className={inputCls} />
       <input value={apiKey} onChange={e => setApiKey(e.target.value)} placeholder="API Key" type="password" className={inputCls} />
+      <div>
+        <input value={categories} onChange={e => setCategories(e.target.value)} placeholder="Categories (e.g. 7020, 7120, 3030)" className={inputCls} />
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Comma-separated Newznab category IDs. 7020 = eBooks, 3030 = Audiobooks. Add custom IDs for indexers with non-standard categories (e.g. 7120 for German books).</p>
+      </div>
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
         <button onClick={submit} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium">Save</button>
@@ -1052,10 +1061,10 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
   const [type, setType] = useState<'newznab' | 'torznab'>('newznab')
   const [url, setUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
+  const [categories, setCategories] = useState('7020')
 
   const submit = async () => {
-    const cats = type === 'torznab' ? [7000, 7020] : [7000, 7020]
-    const idx = await api.addIndexer({ name, url, apiKey, type, categories: cats, enabled: true })
+    const idx = await api.addIndexer({ name, url, apiKey, type, categories: parseCats(categories), enabled: true })
     onAdded(idx)
   }
 
@@ -1070,6 +1079,10 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
       </div>
       <input value={url} onChange={e => setUrl(e.target.value)} placeholder="URL (e.g. https://api.nzbgeek.info)" className={inputCls} />
       <input value={apiKey} onChange={e => setApiKey(e.target.value)} placeholder="API Key" type="password" className={inputCls} />
+      <div>
+        <input value={categories} onChange={e => setCategories(e.target.value)} placeholder="Categories (e.g. 7020, 7120, 3030)" className={inputCls} />
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Comma-separated Newznab category IDs. 7020 = eBooks, 3030 = Audiobooks. Add custom IDs for indexers with non-standard categories (e.g. 7120 for German books).</p>
+      </div>
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
         <button onClick={submit} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium">Save</button>


### PR DESCRIPTION
Closes #47.

## Summary

Two related bugs causing zero search results on indexers that are known to have the requested books.

### Cause A — Hardcoded indexer categories, no UI to change them

`AddIndexerForm` always wrote `[7000, 7020]`; `EditIndexerForm` had no categories field at all. Users on indexers with non-standard category IDs (SceneNZBs uses **7120 for German books** and **3130 for German audio**) got zero results because the `cat=7000,7020` query returned nothing from those indexers.

**Fix:** both Add and Edit indexer forms now expose a comma-separated categories input. `filterCategoriesForMedia` already handles custom IDs correctly — any 7xxx entry routes to ebook searches, any 3xxx entry routes to audiobook searches. Default for new indexers is `7020`.

### Cause B — `filterRelevant` anyPhraseMatch batch gate

`filterRelevant` pre-scanned the whole result batch to check if *any* result had the significant title keywords adjacent (phrase match `\bkw1\W+kw2\b`). If yes, keyword fallback was **disabled for all results**. For titles like *"The Name of the Wind"* (`sigWords: ["name","wind"]`), the phrase pattern fails because `"of the"` (word characters) sit between the keywords in the correct release title. An abbreviated result like `"Name.Wind.epub"` could trigger `anyPhraseMatch=true`, causing the legitimately-titled releases to be dropped.

**Fix:** remove the batch gate. Each result is now evaluated independently — phrase match is tried first, keyword fallback always allowed if phrase fails.

## Changes

| File | What changed |
|------|-------------|
| `internal/indexer/searcher.go` | Remove `anyPhraseMatch` pre-pass; always pass `allowFallback=true` per result |
| `internal/indexer/searcher_test.go` | Regression tests: anyPhraseMatch trap, stop-word keyword fallback, custom category IDs |
| `web/src/pages/SettingsPage.tsx` | Add categories input to `AddIndexerForm` and `EditIndexerForm`; extract `parseCats` helper |

## Test plan

- [ ] Add a new indexer — categories input pre-filled with `7020`, editable
- [ ] Edit an existing indexer — categories field shows current values, saves correctly
- [ ] For SceneNZBs: set categories to `7020, 7120, 3030, 3130` — German books and audio now searchable
- [ ] Search for a book with stop words in the title (e.g. *The Name of the Wind*, *Lord of the Rings*) — results no longer dropped when an abbreviated release is in the same batch
- [ ] All existing `TestFilterRelevant*` tests continue to pass