### PR TITLE
fix(clients): clearer test error + Docker host hint in download client forms

### DIFF
--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -86,8 +86,10 @@ func (c *Client) Login(ctx context.Context) error {
 
 // Test verifies connectivity by fetching the application version.
 func (c *Client) Test(ctx context.Context) error {
-	_, err := c.get(ctx, "/api/v2/app/version")
-	return err
+	if _, err := c.get(ctx, "/api/v2/app/version"); err != nil {
+		return fmt.Errorf("could not reach qBittorrent at %s — %w (in Docker use the service/container name, not localhost)", c.baseURL, err)
+	}
+	return nil
 }
 
 // AddTorrent submits a magnet link or torrent URL to qBittorrent for download.

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -34,8 +34,10 @@ func New(host string, port int, apiKey string, useSSL bool) *Client {
 
 // Test verifies connectivity by fetching categories.
 func (c *Client) Test(ctx context.Context) error {
-	_, err := c.GetCategories(ctx)
-	return err
+	if _, err := c.GetCategories(ctx); err != nil {
+		return fmt.Errorf("could not reach SABnzbd at %s — %w (in Docker use the service/container name, not localhost)", c.baseURL, err)
+	}
+	return nil
 }
 
 // AddURL sends an NZB URL to SABnzbd for download.

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -988,9 +988,12 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
           <option value="qbittorrent">qBittorrent</option>
         </select>
       </div>
-      <div className="flex gap-2">
-        <input value={host} onChange={e => setHost(e.target.value)} placeholder="Host" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
-        <input value={port} onChange={e => setPort(e.target.value)} placeholder="Port" className="w-24 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
+      <div>
+        <div className="flex gap-2">
+          <input value={host} onChange={e => setHost(e.target.value)} placeholder="Host" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
+          <input value={port} onChange={e => setPort(e.target.value)} placeholder="Port" className="w-24 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
+        </div>
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">In Docker, use the service/container name (e.g. <code className="font-mono">sabnzbd</code>) — not <code className="font-mono">localhost</code>.</p>
       </div>
       {type === 'qbittorrent' && (
         <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />
@@ -1124,9 +1127,12 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
           <option value="qbittorrent">qBittorrent</option>
         </select>
       </div>
-      <div className="flex gap-2">
-        <input value={host} onChange={e => setHost(e.target.value)} placeholder="Host" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
-        <input value={port} onChange={e => setPort(e.target.value)} placeholder="Port" className="w-24 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
+      <div>
+        <div className="flex gap-2">
+          <input value={host} onChange={e => setHost(e.target.value)} placeholder="Host" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
+          <input value={port} onChange={e => setPort(e.target.value)} placeholder="Port" className="w-24 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
+        </div>
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">In Docker, use the service/container name (e.g. <code className="font-mono">sabnzbd</code>) — not <code className="font-mono">localhost</code>.</p>
       </div>
       {type === 'qbittorrent' && (
         <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />


### PR DESCRIPTION
Closes #36.

## Problem

Users in Docker/Portainer setups who put `localhost` as the download client host get a cryptic Go network error with no indication of what went wrong or why. The most common mistake: `localhost` inside Bindery's container resolves to Bindery itself, not SABnzbd/qBittorrent.

## Changes

**Backend — `sabnzbd/client.go`, `qbittorrent/client.go`**

`Test()` now wraps the raw connection error with the URL Bindery actually tried:

> `could not reach SABnzbd at http://localhost:8080 — dial tcp [::1]:8080: connect: connection refused (in Docker use the service/container name, not localhost)`

**Frontend — `SettingsPage.tsx`**

Both the Add and Edit client forms now show a hint under the Host/Port row:

> In Docker, use the service/container name (e.g. `sabnzbd`) — not `localhost`.

## Test plan

- [ ] Add a SABnzbd client with `localhost` as host — error popup shows the full URL and the Docker hint
- [ ] Add a qBittorrent client with `localhost` as host — same
- [ ] Hint text visible under Host field in both Add and Edit forms
- [ ] Correct host/port still passes Test as before