### PR TITLE
feat(ui): Books / Book detail / Wanted polish (#46)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -224,6 +224,7 @@ export interface Book {
   narrator?: string
   durationSeconds?: number
   asin?: string
+  language?: string
   author?: Author
 }
 

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -200,7 +200,12 @@ export default function BookDetailPage() {
               {book.status}
             </span>
             {book.releaseDate && (
-              <span className="text-slate-600 dark:text-zinc-500">{new Date(book.releaseDate).getFullYear()}</span>
+              <span className="text-slate-600 dark:text-zinc-500">
+                {new Date(book.releaseDate).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
+              </span>
+            )}
+            {book.language && (
+              <span className="text-slate-600 dark:text-zinc-500">{book.language}</span>
             )}
             {book.narrator && (
               <span className="text-slate-600 dark:text-zinc-500">Narrated by {book.narrator}</span>

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -155,7 +155,17 @@ export default function BooksPage() {
                         <span className="text-slate-800 dark:text-zinc-200 truncate">{book.title}</span>
                       </Link>
                     </td>
-                    <td className="px-3 py-2 text-slate-600 dark:text-zinc-400 whitespace-nowrap hidden md:table-cell">{book.author?.authorName || '—'}</td>
+                    <td className="px-3 py-2 whitespace-nowrap hidden md:table-cell">
+                      {book.author ? (
+                        <Link
+                          to={`/author/${book.authorId}`}
+                          className="text-slate-600 dark:text-zinc-400 hover:text-emerald-500 dark:hover:text-emerald-400"
+                          onClick={e => e.stopPropagation()}
+                        >
+                          {book.author.authorName}
+                        </Link>
+                      ) : '—'}
+                    </td>
                     <td className="px-3 py-2 text-slate-600 dark:text-zinc-400 whitespace-nowrap hidden sm:table-cell">{book.releaseDate ? new Date(book.releaseDate).getFullYear() : '—'}</td>
                     <td className="px-3 py-2 text-xs whitespace-nowrap">
                       {book.mediaType === 'audiobook' ? '🎧 Audiobook' : '📖 Ebook'}
@@ -196,6 +206,9 @@ export default function BooksPage() {
               </div>
               <div className="p-2">
                 <h3 className="text-xs font-medium truncate" title={book.title}>{book.title}</h3>
+                {book.author && (
+                  <p className="text-[10px] text-slate-500 dark:text-zinc-500 truncate mt-0.5">{book.author.authorName}</p>
+                )}
                 <div className="flex items-center justify-between mt-0.5">
                   {book.releaseDate && (
                     <p className="text-[10px] text-slate-600 dark:text-zinc-500">{new Date(book.releaseDate).getFullYear()}</p>

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import { api, Book, SearchResult } from '../api/client'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
@@ -12,6 +13,7 @@ export default function WantedPage() {
   const [search, setSearch] = useState('')
   const [grabbingGuid, setGrabbingGuid] = useState<string | null>(null)
   const [grabbedGuid, setGrabbedGuid] = useState<string | null>(null)
+  const [unmonitoringId, setUnmonitoringId] = useState<number | null>(null)
 
   useEffect(() => {
     api.listWanted().then(setBooks).catch(console.error).finally(() => setLoading(false))
@@ -45,6 +47,18 @@ export default function WantedPage() {
       setBooks(books.map(b => b.id === book.id ? updated : b))
     } catch (err) {
       alert(err instanceof Error ? err.message : 'Failed to update')
+    }
+  }
+
+  const unmonitor = async (book: Book) => {
+    setUnmonitoringId(book.id)
+    try {
+      await api.updateBook(book.id, { monitored: false })
+      setBooks(books.filter(b => b.id !== book.id))
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to unmonitor')
+    } finally {
+      setUnmonitoringId(null)
     }
   }
 
@@ -118,7 +132,17 @@ export default function WantedPage() {
                     <img src={book.imageUrl} alt="" className="w-10 h-14 object-cover rounded flex-shrink-0" />
                   )}
                   <div className="min-w-0">
-                    <h3 className="font-medium text-sm truncate">{book.title}</h3>
+                    <Link to={`/book/${book.id}`} className="font-medium text-sm truncate block hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">
+                      {book.title}
+                    </Link>
+                    {book.author && (
+                      <Link
+                        to={`/author/${book.authorId}`}
+                        className="text-[11px] text-slate-500 dark:text-zinc-500 hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors truncate block"
+                      >
+                        {book.author.authorName}
+                      </Link>
+                    )}
                     <div className="flex items-center gap-2 mt-0.5 flex-wrap">
                       <select
                         value={book.mediaType || 'ebook'}
@@ -135,13 +159,23 @@ export default function WantedPage() {
                     )}
                   </div>
                 </div>
-                <button
-                  onClick={() => searchBook(book)}
-                  disabled={searchingId === book.id}
-                  className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium flex-shrink-0 disabled:opacity-50"
-                >
-                  {searchingId === book.id ? 'Searching...' : 'Search'}
-                </button>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <button
+                    onClick={() => unmonitor(book)}
+                    disabled={unmonitoringId === book.id}
+                    className="px-2 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-amber-100 dark:hover:bg-amber-900/30 hover:text-amber-700 dark:hover:text-amber-400 rounded text-xs font-medium disabled:opacity-50 transition-colors"
+                    title="Stop monitoring this book"
+                  >
+                    {unmonitoringId === book.id ? '…' : 'Unmonitor'}
+                  </button>
+                  <button
+                    onClick={() => searchBook(book)}
+                    disabled={searchingId === book.id}
+                    className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium disabled:opacity-50"
+                  >
+                    {searchingId === book.id ? 'Searching...' : 'Search'}
+                  </button>
+                </div>
               </div>
 
               {showResults === book.id && results.length === 0 && (


### PR DESCRIPTION
## Summary

- **BooksPage – table view**: Author cell is now a `<Link>` to `/author/:id`; was plain text before.
- **BooksPage – grid view**: Author name displayed under the book title in each card.
- **BooksPage – sort**: Date sort already used `releaseDate` (not `created_at`) — no change needed. Audiobook filter logic is also correct; if audiobooks aren't appearing it's a data issue (books may not have `mediaType: 'audiobook'` set) rather than a code bug.
- **BookDetailPage**: Publication date now shows full `Month DD, YYYY` instead of just the year. `language` field added (present in `models.Book`, was missing from the TS interface and not rendered).
- **BookDetailPage – Series**: The Go `Book` struct has no `series` join; the API response does not include series data. Skipped — needs a backend change (conflicts with Streams A/D). Can be followed up as a separate issue.
- **WantedPage**: Book title is now a `<Link to="/book/:id">`. Author name displayed below as a `<Link to="/author/:id">`. Inline **Unmonitor** button calls `PUT /api/v1/book/:id` with `{ monitored: false }` and removes the row immediately.
- **client.ts** (`language` field): additive-only change.

## Test plan

- [ ] BooksPage table: click author name → navigates to `/author/:id`
- [ ] BooksPage grid: author name visible under title; no layout breakage
- [ ] BooksPage sort Newest/Oldest: books with a release date sort correctly
- [ ] BooksPage Type filter: "Audiobook" shows only audiobook-typed books; "All" shows everything
- [ ] BookDetailPage: publication date shows month+day+year (or just year if only year is stored); language tag appears when set
- [ ] WantedPage: click book title → `/book/:id`; click author name → `/author/:id`
- [ ] WantedPage Unmonitor: clicking removes the row; disabled spinner while in-flight