### PR TITLE
feat(ui): Authors page filters and publication-date sort (#46)

### DIFF
--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { api, Author, Book } from '../api/client'
+import ViewToggle from '../components/ViewToggle'
+import { useView } from '../components/useView'
 
 const statusColors: Record<string, string> = {
   wanted: 'bg-amber-500/20 text-amber-700 dark:text-amber-400',
@@ -8,6 +10,26 @@ const statusColors: Record<string, string> = {
   downloaded: 'bg-purple-500/20 text-purple-700 dark:text-purple-400',
   imported: 'bg-emerald-500/20 text-emerald-700 dark:text-emerald-400',
   skipped: 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400',
+}
+
+const statusLabel: Record<string, string> = {
+  wanted: 'Wanted',
+  downloading: 'Downloading',
+  downloaded: 'Downloaded',
+  imported: 'In Library',
+  skipped: 'Skipped',
+}
+
+type MediaFilter = '' | 'ebook' | 'audiobook'
+type StatusFilter = '' | 'wanted' | 'downloading' | 'downloaded' | 'imported' | 'skipped'
+type PublishedFilter = '' | 'released' | 'upcoming'
+type DateSort = 'none' | 'asc' | 'desc'
+
+const TODAY = new Date().toISOString().slice(0, 10)
+
+function fmtDate(d?: string): string {
+  if (!d) return '—'
+  return d.slice(0, 10)
 }
 
 export default function AuthorDetailPage() {
@@ -20,6 +42,57 @@ export default function AuthorDetailPage() {
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  const [view, setView] = useView('author-detail', 'grid')
+
+  // Filter / sort state — persisted to localStorage under page-scoped keys
+  const [typeFilter, setTypeFilter] = useState<MediaFilter>(() => {
+    try {
+      const v = localStorage.getItem('bindery.filter.author-detail.type')
+      if (v === 'ebook' || v === 'audiobook') return v
+    } catch { /* ignore */ }
+    return ''
+  })
+
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>(() => {
+    try {
+      const v = localStorage.getItem('bindery.filter.author-detail.status')
+      if (['wanted', 'downloading', 'downloaded', 'imported', 'skipped'].includes(v ?? '')) return v as StatusFilter
+    } catch { /* ignore */ }
+    return ''
+  })
+
+  const [publishedFilter, setPublishedFilter] = useState<PublishedFilter>(() => {
+    try {
+      const v = localStorage.getItem('bindery.filter.author-detail.published')
+      if (v === 'released' || v === 'upcoming') return v
+    } catch { /* ignore */ }
+    return ''
+  })
+
+  const [dateSort, setDateSort] = useState<DateSort>(() => {
+    try {
+      const v = localStorage.getItem('bindery.sort.author-detail.date')
+      if (v === 'asc' || v === 'desc') return v
+    } catch { /* ignore */ }
+    return 'none'
+  })
+
+  useEffect(() => {
+    try { localStorage.setItem('bindery.filter.author-detail.type', typeFilter) } catch { /* ignore */ }
+  }, [typeFilter])
+
+  useEffect(() => {
+    try { localStorage.setItem('bindery.filter.author-detail.status', statusFilter) } catch { /* ignore */ }
+  }, [statusFilter])
+
+  useEffect(() => {
+    try { localStorage.setItem('bindery.filter.author-detail.published', publishedFilter) } catch { /* ignore */ }
+  }, [publishedFilter])
+
+  useEffect(() => {
+    try { localStorage.setItem('bindery.sort.author-detail.date', dateSort) } catch { /* ignore */ }
+  }, [dateSort])
 
   useEffect(() => {
     let cancelled = false
@@ -74,6 +147,25 @@ export default function AuthorDetailPage() {
     }
   }
 
+  const filteredBooks = useMemo(() => {
+    let list = books
+    if (typeFilter) list = list.filter(b => (b.mediaType || 'ebook') === typeFilter)
+    if (statusFilter) list = list.filter(b => b.status === statusFilter)
+    if (publishedFilter === 'released') {
+      list = list.filter(b => !b.releaseDate || b.releaseDate.slice(0, 10) <= TODAY)
+    } else if (publishedFilter === 'upcoming') {
+      list = list.filter(b => !!b.releaseDate && b.releaseDate.slice(0, 10) > TODAY)
+    }
+    if (dateSort !== 'none') {
+      list = [...list].sort((a, b) => {
+        const da = a.releaseDate ? new Date(a.releaseDate).getTime() : 0
+        const db = b.releaseDate ? new Date(b.releaseDate).getTime() : 0
+        return dateSort === 'asc' ? da - db : db - da
+      })
+    }
+    return list
+  }, [books, typeFilter, statusFilter, publishedFilter, dateSort])
+
   if (loading) return <div className="text-slate-600 dark:text-zinc-500">Loading…</div>
   if (!author) return <div className="text-slate-600 dark:text-zinc-500">Author not found</div>
 
@@ -83,6 +175,14 @@ export default function AuthorDetailPage() {
     wanted: books.filter(b => b.status === 'wanted').length,
     audiobook: books.filter(b => b.mediaType === 'audiobook').length,
   }
+
+  const chipCls = (active: boolean) =>
+    `px-3 py-1 rounded-md text-xs font-medium transition-colors ${active ? 'bg-slate-300 dark:bg-zinc-700 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'}`
+
+  const toggleDateSort = () =>
+    setDateSort(prev => prev === 'none' ? 'asc' : prev === 'asc' ? 'desc' : 'none')
+
+  const dateSortIcon = dateSort === 'asc' ? ' ↑' : dateSort === 'desc' ? ' ↓' : ''
 
   return (
     <div className="max-w-5xl">
@@ -145,12 +245,97 @@ export default function AuthorDetailPage() {
       )}
 
       <section>
-        <h3 className="text-lg font-semibold mb-3">Books</h3>
+        {/* Section header */}
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-lg font-semibold">
+            Books
+            {filteredBooks.length !== books.length && (
+              <span className="ml-2 text-sm font-normal text-slate-600 dark:text-zinc-500">
+                {filteredBooks.length} of {books.length}
+              </span>
+            )}
+          </h3>
+          <ViewToggle view={view} onChange={setView} />
+        </div>
+
+        {/* Filter chips */}
+        {books.length > 0 && (
+          <div className="flex gap-1 mb-4 flex-wrap">
+            <span className="text-xs text-slate-600 dark:text-zinc-500 mr-1 self-center">Type:</span>
+            <button onClick={() => setTypeFilter('')} className={chipCls(typeFilter === '')}>All</button>
+            <button onClick={() => setTypeFilter('ebook')} className={chipCls(typeFilter === 'ebook')}>📖 Ebook</button>
+            <button onClick={() => setTypeFilter('audiobook')} className={chipCls(typeFilter === 'audiobook')}>🎧 Audiobook</button>
+
+            <span className="text-xs text-slate-600 dark:text-zinc-500 mx-2 self-center">Status:</span>
+            <button onClick={() => setStatusFilter('')} className={chipCls(statusFilter === '')}>All</button>
+            <button onClick={() => setStatusFilter('wanted')} className={chipCls(statusFilter === 'wanted')}>Wanted</button>
+            <button onClick={() => setStatusFilter('downloaded')} className={chipCls(statusFilter === 'downloaded')}>Downloaded</button>
+            <button onClick={() => setStatusFilter('imported')} className={chipCls(statusFilter === 'imported')}>Imported</button>
+
+            <span className="text-xs text-slate-600 dark:text-zinc-500 mx-2 self-center">Published:</span>
+            <button onClick={() => setPublishedFilter('')} className={chipCls(publishedFilter === '')}>All</button>
+            <button onClick={() => setPublishedFilter('released')} className={chipCls(publishedFilter === 'released')}>Released</button>
+            <button onClick={() => setPublishedFilter('upcoming')} className={chipCls(publishedFilter === 'upcoming')}>Upcoming</button>
+          </div>
+        )}
+
         {books.length === 0 ? (
           <p className="text-sm text-slate-600 dark:text-zinc-500">No books tracked for this author yet.</p>
+        ) : filteredBooks.length === 0 ? (
+          <p className="text-sm text-slate-600 dark:text-zinc-500">No books match the current filters.</p>
+        ) : view === 'table' ? (
+          <div className="border border-slate-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-slate-100 dark:bg-zinc-900 border-b border-slate-200 dark:border-zinc-800">
+                    <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Title</th>
+                    <th
+                      className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase cursor-pointer select-none hover:text-slate-900 dark:hover:text-white whitespace-nowrap"
+                      onClick={toggleDateSort}
+                      title="Sort by publication date"
+                    >
+                      Published{dateSortIcon}
+                    </th>
+                    <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase hidden sm:table-cell">Type</th>
+                    <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Status</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-200 dark:divide-zinc-800">
+                  {filteredBooks.map(book => (
+                    <tr
+                      key={book.id}
+                      className="bg-slate-100/50 dark:bg-zinc-900/50 hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 cursor-pointer"
+                      onClick={() => (window.location.href = `/book/${book.id}`)}
+                    >
+                      <td className="px-3 py-2">
+                        <Link to={`/book/${book.id}`} className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
+                          {book.imageUrl ? (
+                            <img src={book.imageUrl} alt="" className="w-6 h-9 object-cover rounded flex-shrink-0" />
+                          ) : (
+                            <div className="w-6 h-9 bg-slate-200 dark:bg-zinc-800 rounded flex-shrink-0" />
+                          )}
+                          <span className="text-slate-800 dark:text-zinc-200 truncate">{book.title}</span>
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 text-slate-600 dark:text-zinc-400 whitespace-nowrap">{fmtDate(book.releaseDate)}</td>
+                      <td className="px-3 py-2 text-xs whitespace-nowrap hidden sm:table-cell">
+                        {book.mediaType === 'audiobook' ? '🎧 Audiobook' : '📖 Ebook'}
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap">
+                        <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
+                          {statusLabel[book.status] ?? book.status}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
         ) : (
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-            {books.map(book => (
+            {filteredBooks.map(book => (
               <Link
                 key={book.id}
                 to={`/book/${book.id}`}
@@ -165,7 +350,7 @@ export default function AuthorDetailPage() {
                     </div>
                   )}
                   <div className={`absolute top-2 right-2 px-2 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
-                    {book.status}
+                    {statusLabel[book.status] ?? book.status}
                   </div>
                   {book.mediaType === 'audiobook' && (
                     <div className="absolute top-2 left-2 px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-600/90 text-white">🎧</div>
@@ -174,7 +359,7 @@ export default function AuthorDetailPage() {
                 <div className="p-2">
                   <h4 className="text-xs font-medium truncate" title={book.title}>{book.title}</h4>
                   {book.releaseDate && (
-                    <p className="text-[10px] text-slate-600 dark:text-zinc-500">{new Date(book.releaseDate).getFullYear()}</p>
+                    <p className="text-[10px] text-slate-600 dark:text-zinc-500">{fmtDate(book.releaseDate)}</p>
                   )}
                 </div>
               </Link>

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -8,6 +8,7 @@ import ViewToggle from '../components/ViewToggle'
 import { useView } from '../components/useView'
 
 type SortMode = 'az' | 'za' | 'recent'
+type MonitoredFilter = '' | 'monitored' | 'unmonitored'
 
 export default function AuthorsPage() {
   const [authors, setAuthors] = useState<Author[]>([])
@@ -15,6 +16,13 @@ export default function AuthorsPage() {
   const [showAdd, setShowAdd] = useState(false)
   const [search, setSearch] = useState('')
   const [sort, setSort] = useState<SortMode>('az')
+  const [monitoredFilter, setMonitoredFilter] = useState<MonitoredFilter>(() => {
+    try {
+      const v = localStorage.getItem('bindery.filter.authors.monitored')
+      if (v === 'monitored' || v === 'unmonitored') return v
+    } catch { /* ignore */ }
+    return ''
+  })
   const [view, setView] = useView('authors', 'grid')
 
   const load = () => {
@@ -23,6 +31,10 @@ export default function AuthorsPage() {
   }
 
   useEffect(() => { load() }, [])
+
+  useEffect(() => {
+    try { localStorage.setItem('bindery.filter.authors.monitored', monitoredFilter) } catch { /* ignore */ }
+  }, [monitoredFilter])
 
   const handleDelete = async (id: number) => {
     // Peek at the author's books so the confirm can offer to sweep files.
@@ -50,6 +62,8 @@ export default function AuthorsPage() {
 
   const filtered = useMemo(() => {
     let list = authors
+    if (monitoredFilter === 'monitored') list = list.filter(a => a.monitored)
+    else if (monitoredFilter === 'unmonitored') list = list.filter(a => !a.monitored)
     if (search.trim()) {
       const q = search.trim().toLowerCase()
       list = list.filter(a =>
@@ -61,11 +75,11 @@ export default function AuthorsPage() {
     else if (sort === 'za') list = [...list].sort((a, b) => b.authorName.localeCompare(a.authorName))
     // 'recent' keeps server order (typically by id desc)
     return list
-  }, [authors, search, sort])
+  }, [authors, monitoredFilter, search, sort])
 
   const { pageItems, paginationProps, reset } = usePagination(filtered, 50, 'authors')
 
-  useEffect(() => { reset() }, [search, sort, reset])
+  useEffect(() => { reset() }, [search, sort, monitoredFilter, reset])
 
   const sortBtnCls = (active: boolean) =>
     `px-3 py-1 rounded-md text-xs font-medium transition-colors ${active ? 'bg-slate-300 dark:bg-zinc-700 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'}`
@@ -86,7 +100,7 @@ export default function AuthorsPage() {
       </div>
 
       {/* Search & Sort controls */}
-      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+      <div className="flex flex-col sm:flex-row gap-3 mb-4">
         <input
           type="search"
           value={search}
@@ -99,6 +113,14 @@ export default function AuthorsPage() {
           <button onClick={() => setSort('za')} className={sortBtnCls(sort === 'za')}>Z–A</button>
           <button onClick={() => setSort('recent')} className={sortBtnCls(sort === 'recent')}>Recent</button>
         </div>
+      </div>
+
+      {/* Monitored filter chips */}
+      <div className="flex gap-1 mb-6 flex-wrap">
+        <span className="text-xs text-slate-600 dark:text-zinc-500 mr-1 self-center">Monitored:</span>
+        <button onClick={() => setMonitoredFilter('')} className={sortBtnCls(monitoredFilter === '')}>All</button>
+        <button onClick={() => setMonitoredFilter('monitored')} className={sortBtnCls(monitoredFilter === 'monitored')}>Monitored</button>
+        <button onClick={() => setMonitoredFilter('unmonitored')} className={sortBtnCls(monitoredFilter === 'unmonitored')}>Unmonitored</button>
       </div>
 
       {loading ? (


### PR DESCRIPTION
## Summary

- **AuthorsPage**: adds `Monitored / Unmonitored / All` filter chips (matching the Type-chip pattern from BooksPage); selection persists to `localStorage` under `bindery.filter.authors.monitored`
- **AuthorDetailPage**: adds a Grid/Table `ViewToggle`, three rows of filter chips (Type · Status · Published state), and a sortable **Published** column header (click cycles `none → asc → desc → none`); dates shown in ISO short format (`YYYY-MM-DD`)
- All filter + sort preferences are persisted per-page in `localStorage` (`bindery.filter.author-detail.*`, `bindery.sort.author-detail.date`)
- `releaseDate` confirmed present in `internal/models/book.go` (`json:"releaseDate"`) — no backend changes needed
- No changes to `client.ts`, `AddAuthorModal`, or any bulk-select/schema work (deferred per issue)

## Test plan

- [ ] AuthorsPage: toggle Monitored/Unmonitored chips and verify list narrows; navigate away and back to confirm chip state survives
- [ ] AuthorDetailPage grid view: filter by Type, Status, Published; confirm counts in heading update
- [ ] AuthorDetailPage table view: switch to table, verify Published column shows `YYYY-MM-DD`; click header to cycle ↑/↓/unsorted
- [ ] Dark mode: all new chips and table cells use `dark:` variants
- [ ] `npm run typecheck && npm run lint && npm run build` — all pass (verified locally)