### PR TITLE
fix: populate series data during ingestion (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
 
+### Fixed
+
+- **Series view always empty** — the `/series` endpoint returned nothing because series and series_books rows were never populated during author ingestion. OpenLibrary's `series` field is now parsed from author-works responses and single-work lookups; after a successful book insert the corresponding `series` row is upserted (by a stable title-derived slug) and a `series_books` link is created with the book's position and primary-series flag ([#46](https://github.com/vavallee/bindery/issues/46)).
+
+### Added
+
+- **`bindery reconcile-series` CLI subcommand** — re-fetches OpenLibrary series data for every already-ingested author and backfills the series/series_books tables. Run once after upgrading from any version that did not populate series during ingestion. Idempotent; prints `{"linked":<n>,"skipped":<n>}` on completion. See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md#from-v06x-to-v070-series-view-fix) for usage.
+
 ## [v0.6.4] — 2026-04-14
 
 ### Fixed

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -118,6 +118,15 @@ func main() {
 		return
 	}
 
+	// Optional CLI subcommand: `bindery reconcile-series`.
+	// Re-fetches OpenLibrary series data for every already-ingested book and
+	// populates the series / series_books tables. Run once when upgrading from
+	// a version that did not populate series during ingestion.
+	if len(os.Args) > 1 && os.Args[1] == "reconcile-series" {
+		runReconcileSeries(authorRepo, bookRepo, seriesRepo, metaAgg)
+		return
+	}
+
 	// Indexer searcher
 	idxSearcher := indexer.NewSearcher()
 
@@ -142,7 +151,7 @@ func main() {
 	// API handlers
 	authHandler := api.NewAuthHandler(userRepo, settingsRepo, loginLimiter)
 	searchHandler := api.NewSearchHandler(metaAgg)
-	authorHandler := api.NewAuthorHandler(authorRepo, bookRepo, metaAgg, settingsRepo, metadataProfileRepo)
+	authorHandler := api.NewAuthorHandler(authorRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo)
 	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo)
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, idxSearcher, settingsRepo, blocklistRepo)
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)

--- a/cmd/bindery/reconcile.go
+++ b/cmd/bindery/reconcile.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// runReconcileSeries handles the `bindery reconcile-series` subcommand.
+// It iterates every author already in the library, re-fetches their works from
+// OpenLibrary, and for any work that already exists as a book row it upserts
+// the series + series_books data. Run this once after upgrading from a version
+// that did not populate series during ingestion.
+func runReconcileSeries(
+	authorRepo *db.AuthorRepo,
+	bookRepo *db.BookRepo,
+	seriesRepo *db.SeriesRepo,
+	agg *metadata.Aggregator,
+) {
+	ctx := context.Background()
+
+	authors, err := authorRepo.List(ctx)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "list authors:", err)
+		os.Exit(1)
+	}
+
+	var linked, skipped int
+	for _, author := range authors {
+		works, err := agg.GetAuthorWorks(ctx, author.ForeignID)
+		if err != nil {
+			slog.Warn("reconcile-series: failed to fetch works", "author", author.Name, "error", err)
+			continue
+		}
+
+		for _, w := range works {
+			if len(w.SeriesRefs) == 0 {
+				continue
+			}
+			existing, err := bookRepo.GetByForeignID(ctx, w.ForeignID)
+			if err != nil || existing == nil {
+				skipped++
+				continue
+			}
+			for _, ref := range w.SeriesRefs {
+				s := &models.Series{ForeignID: ref.ForeignID, Title: ref.Title}
+				if err := seriesRepo.CreateOrGet(ctx, s); err != nil {
+					slog.Warn("reconcile-series: upsert series failed", "series", ref.Title, "error", err)
+					continue
+				}
+				if err := seriesRepo.LinkBook(ctx, s.ID, existing.ID, ref.Position, ref.Primary); err != nil {
+					slog.Warn("reconcile-series: link failed", "book", existing.Title, "series", ref.Title, "error", err)
+					continue
+				}
+				linked++
+			}
+		}
+		slog.Info("reconcile-series: processed author", "author", author.Name)
+	}
+
+	fmt.Printf("{\"linked\":%d,\"skipped\":%d}\n", linked, skipped)
+}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -230,6 +230,24 @@ On first launch Bindery bootstraps itself — **no environment variables are req
 
 ## Upgrading
 
+### From v0.6.x to v0.7.0 (Series view fix)
+
+**Schema:** no changes — the `series` and `series_books` tables have existed since v0.1 but were never populated. Drop-in binary or image replacement is safe.
+
+**Backfill existing libraries:** Authors added before this release have no series rows. After upgrading, run the one-shot reconcile command to backfill series data from OpenLibrary:
+
+```bash
+# Docker
+docker exec bindery /bindery reconcile-series
+
+# Binary / bare-metal
+./bindery reconcile-series
+```
+
+The command prints a JSON summary `{"linked":<n>,"skipped":<n>}` and exits. It is idempotent — safe to run more than once. Rate-limiting on OpenLibrary's side means large libraries (hundreds of authors) may take a few minutes; run it in a `screen` or `tmux` session if needed.
+
+After the backfill, the **Series** page in the UI will show all series that OpenLibrary associates with your authors' books.
+
 ### From v0.6.x to v0.6.4
 
 No migration steps required. Drop-in replacement.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -18,13 +18,14 @@ import (
 type AuthorHandler struct {
 	authors  *db.AuthorRepo
 	books    *db.BookRepo
+	series   *db.SeriesRepo
 	meta     *metadata.Aggregator
 	settings *db.SettingsRepo
 	profiles *db.MetadataProfileRepo
 }
 
-func NewAuthorHandler(authors *db.AuthorRepo, books *db.BookRepo, meta *metadata.Aggregator, settings *db.SettingsRepo, profiles *db.MetadataProfileRepo) *AuthorHandler {
-	return &AuthorHandler{authors: authors, books: books, meta: meta, settings: settings, profiles: profiles}
+func NewAuthorHandler(authors *db.AuthorRepo, books *db.BookRepo, series *db.SeriesRepo, meta *metadata.Aggregator, settings *db.SettingsRepo, profiles *db.MetadataProfileRepo) *AuthorHandler {
+	return &AuthorHandler{authors: authors, books: books, series: series, meta: meta, settings: settings, profiles: profiles}
 }
 
 func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -296,6 +297,18 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author) {
 			continue
 		}
 		added++
+
+		// Populate series membership for this book.
+		for _, ref := range b.SeriesRefs {
+			s := &models.Series{ForeignID: ref.ForeignID, Title: ref.Title}
+			if err := h.series.CreateOrGet(ctx, s); err != nil {
+				slog.Warn("failed to upsert series", "series", ref.Title, "error", err)
+				continue
+			}
+			if err := h.series.LinkBook(ctx, s.ID, b.ID, ref.Position, ref.Primary); err != nil {
+				slog.Warn("failed to link book to series", "book", b.Title, "series", ref.Title, "error", err)
+			}
+		}
 	}
 	slog.Info("author books synced", "author", author.Name, "added", added, "skipped_language", skippedLang, "skipped_junk", skippedJunk, "total", len(books))
 }

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -77,7 +77,7 @@ func TestDeleteAuthor_WithDeleteFiles(t *testing.T) {
 		}
 	}
 
-	h := NewAuthorHandler(authorRepo, bookRepo, nil, nil, profileRepo)
+	h := NewAuthorHandler(authorRepo, bookRepo, nil, nil, nil, profileRepo)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/author/"+strconv.FormatInt(author.ID, 10)+"?deleteFiles=true", nil)
 	rctx := chi.NewRouteContext()
@@ -140,7 +140,7 @@ func TestDeleteAuthor_WithoutDeleteFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := NewAuthorHandler(authorRepo, bookRepo, nil, nil, profileRepo)
+	h := NewAuthorHandler(authorRepo, bookRepo, nil, nil, nil, profileRepo)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/author/"+strconv.FormatInt(author.ID, 10), nil)
 	rctx := chi.NewRouteContext()

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -99,6 +99,49 @@ func (r *SeriesRepo) Create(ctx context.Context, s *models.Series) error {
 	return nil
 }
 
+// CreateOrGet inserts the series if its foreign_id does not yet exist, then
+// populates s.ID with the persisted row's ID. Safe to call concurrently; the
+// INSERT OR IGNORE prevents duplicate-key errors.
+func (r *SeriesRepo) CreateOrGet(ctx context.Context, s *models.Series) error {
+	now := time.Now().UTC()
+	result, err := r.db.ExecContext(ctx,
+		"INSERT OR IGNORE INTO series (foreign_id, title, description, created_at) VALUES (?, ?, ?, ?)",
+		s.ForeignID, s.Title, s.Description, now)
+	if err != nil {
+		return fmt.Errorf("upsert series: %w", err)
+	}
+	if affected, _ := result.RowsAffected(); affected > 0 {
+		id, _ := result.LastInsertId()
+		s.ID = id
+		s.CreatedAt = now
+		return nil
+	}
+	// Row already existed — fetch its ID.
+	row := r.db.QueryRowContext(ctx, "SELECT id FROM series WHERE foreign_id = ?", s.ForeignID)
+	if err := row.Scan(&s.ID); err != nil {
+		return fmt.Errorf("get existing series id: %w", err)
+	}
+	return nil
+}
+
+// LinkBook inserts a series_books row joining seriesID → bookID.
+// INSERT OR IGNORE makes the call idempotent: a second call with the same
+// pair is a no-op, which is safe for re-runs (e.g. reconcile-series).
+func (r *SeriesRepo) LinkBook(ctx context.Context, seriesID, bookID int64, position string, primary bool) error {
+	primaryInt := 0
+	if primary {
+		primaryInt = 1
+	}
+	_, err := r.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO series_books (series_id, book_id, position_in_series, primary_series)
+		 VALUES (?, ?, ?, ?)`,
+		seriesID, bookID, position, primaryInt)
+	if err != nil {
+		return fmt.Errorf("link book %d to series %d: %w", bookID, seriesID, err)
+	}
+	return nil
+}
+
 func (r *SeriesRepo) Delete(ctx context.Context, id int64) error {
 	_, err := r.db.ExecContext(ctx, "DELETE FROM series WHERE id=?", id)
 	if err != nil {

--- a/internal/db/series_test.go
+++ b/internal/db/series_test.go
@@ -1,0 +1,170 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestSeriesCreateOrGet_Idempotent(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	repo := NewSeriesRepo(database)
+
+	s := &models.Series{
+		ForeignID: "ol-series:dune-chronicles",
+		Title:     "Dune Chronicles",
+	}
+
+	// First call should insert.
+	if err := repo.CreateOrGet(ctx, s); err != nil {
+		t.Fatalf("first CreateOrGet: %v", err)
+	}
+	if s.ID == 0 {
+		t.Fatal("expected non-zero ID after first CreateOrGet")
+	}
+	firstID := s.ID
+
+	// Second call with the same foreign_id should return the same ID.
+	s2 := &models.Series{
+		ForeignID: "ol-series:dune-chronicles",
+		Title:     "Dune Chronicles",
+	}
+	if err := repo.CreateOrGet(ctx, s2); err != nil {
+		t.Fatalf("second CreateOrGet: %v", err)
+	}
+	if s2.ID != firstID {
+		t.Errorf("expected same ID %d on second call, got %d", firstID, s2.ID)
+	}
+
+	// Verify only one row exists.
+	list, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 1 {
+		t.Errorf("expected 1 series row, got %d", len(list))
+	}
+}
+
+func TestSeriesLinkBook(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	// Seed author + book.
+	author := &models.Author{
+		ForeignID: "OL1A", Name: "Frank Herbert", SortName: "Herbert, Frank",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OL1W", AuthorID: author.ID, Title: "Dune", SortTitle: "Dune",
+		Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	// Upsert series and link book.
+	s := &models.Series{ForeignID: "ol-series:dune-chronicles", Title: "Dune Chronicles"}
+	if err := seriesRepo.CreateOrGet(ctx, s); err != nil {
+		t.Fatalf("CreateOrGet: %v", err)
+	}
+	if err := seriesRepo.LinkBook(ctx, s.ID, book.ID, "1", true); err != nil {
+		t.Fatalf("LinkBook: %v", err)
+	}
+
+	// GetByID should return the series with the book attached.
+	got, err := seriesRepo.GetByID(ctx, s.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected series, got nil")
+	}
+	if got.Title != "Dune Chronicles" {
+		t.Errorf("title: want %q, got %q", "Dune Chronicles", got.Title)
+	}
+	if len(got.Books) != 1 {
+		t.Fatalf("expected 1 series_book, got %d", len(got.Books))
+	}
+	sb := got.Books[0]
+	if sb.PositionInSeries != "1" {
+		t.Errorf("position: want %q, got %q", "1", sb.PositionInSeries)
+	}
+	if !sb.PrimarySeries {
+		t.Error("expected primary_series=true")
+	}
+	if sb.Book == nil || sb.Book.Title != "Dune" {
+		t.Errorf("expected joined book 'Dune', got %v", sb.Book)
+	}
+
+	// LinkBook is idempotent (INSERT OR IGNORE).
+	if err := seriesRepo.LinkBook(ctx, s.ID, book.ID, "1", true); err != nil {
+		t.Errorf("second LinkBook should be idempotent, got: %v", err)
+	}
+
+	// Cascade: deleting the book should remove the series_books row.
+	if err := bookRepo.Delete(ctx, book.ID); err != nil {
+		t.Fatalf("delete book: %v", err)
+	}
+	got, err = seriesRepo.GetByID(ctx, s.ID)
+	if err != nil {
+		t.Fatalf("GetByID after book delete: %v", err)
+	}
+	if len(got.Books) != 0 {
+		t.Errorf("expected 0 series_books after book delete, got %d", len(got.Books))
+	}
+}
+
+func TestSeriesList(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	repo := NewSeriesRepo(database)
+
+	// Empty list.
+	list, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("list empty: %v", err)
+	}
+	if len(list) != 0 {
+		t.Errorf("expected 0, got %d", len(list))
+	}
+
+	// Add two series.
+	for _, title := range []string{"Alpha Series", "Beta Series"} {
+		s := &models.Series{ForeignID: "ol-series:" + title, Title: title}
+		if err := repo.CreateOrGet(ctx, s); err != nil {
+			t.Fatalf("CreateOrGet %q: %v", title, err)
+		}
+	}
+
+	list, err = repo.List(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 series, got %d", len(list))
+	}
+}

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -436,7 +436,7 @@ func seriesSlug(title string) string {
 	prevDash := false
 	for _, r := range strings.ToLower(title) {
 		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-			buf = append(buf, byte(r))
+			buf = append(buf, byte(r)) //nolint:gosec // r is gated to ASCII range above
 			prevDash = false
 		} else if !prevDash && len(buf) > 0 {
 			buf = append(buf, '-')

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -156,6 +157,16 @@ func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, e
 		b.ImageURL = fmt.Sprintf("%s/b/id/%d-L.jpg", coverURL, resp.Covers[0])
 	}
 
+	// Parse series membership.
+	for i, s := range resp.Series {
+		if s == "" {
+			continue
+		}
+		ref := parseSeriesRef(s)
+		ref.Primary = i == 0
+		b.SeriesRefs = append(b.SeriesRefs, ref)
+	}
+
 	// Resolve author
 	if len(resp.Authors) > 0 {
 		authorKey := strings.TrimPrefix(resp.Authors[0].Author.Key, "/authors/")
@@ -204,6 +215,15 @@ func (c *Client) GetAuthorWorks(ctx context.Context, authorForeignID string) ([]
 		b.Author = &models.Author{
 			ForeignID:        authorForeignID,
 			MetadataProvider: "openlibrary",
+		}
+		// Parse series membership from the OL series strings.
+		for i, s := range entry.Series {
+			if s == "" {
+				continue
+			}
+			ref := parseSeriesRef(s)
+			ref.Primary = i == 0
+			b.SeriesRefs = append(b.SeriesRefs, ref)
 		}
 		books = append(books, b)
 	}
@@ -380,4 +400,52 @@ func truncateSlice(s []string, max int) []string {
 		return s[:max]
 	}
 	return s
+}
+
+// rePoundPos matches a series position suffix like "#1" or "#1.5".
+var rePoundPos = regexp.MustCompile(`\s*#(\d+(?:\.\d+)?)\s*$`)
+
+// reBookPos matches variants like ", Book 1", " -- Book 2", " Book 3".
+var reBookPos = regexp.MustCompile(`(?:,?\s*-{1,2}\s*|,\s*|\s+)[Bb]ook\s+(\d+(?:\.\d+)?)\s*$`)
+
+// parseSeriesRef parses an OpenLibrary series string (e.g. "Dune Chronicles #1")
+// into a SeriesRef with a stable ForeignID slug, extracted title, and position.
+func parseSeriesRef(raw string) models.SeriesRef {
+	title := strings.TrimSpace(raw)
+	position := ""
+
+	if m := rePoundPos.FindStringSubmatchIndex(title); m != nil {
+		position = title[m[2]:m[3]]
+		title = strings.TrimSpace(title[:m[0]])
+	} else if m := reBookPos.FindStringSubmatchIndex(title); m != nil {
+		position = title[m[2]:m[3]]
+		title = strings.TrimSpace(title[:m[0]])
+	}
+
+	return models.SeriesRef{
+		ForeignID: "ol-series:" + seriesSlug(title),
+		Title:     title,
+		Position:  position,
+	}
+}
+
+// seriesSlug converts a series title to a lowercase slug suitable for use as a
+// foreign_id (e.g. "Dune Chronicles" → "dune-chronicles").
+func seriesSlug(title string) string {
+	var buf []byte
+	prevDash := false
+	for _, r := range strings.ToLower(title) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			buf = append(buf, byte(r))
+			prevDash = false
+		} else if !prevDash && len(buf) > 0 {
+			buf = append(buf, '-')
+			prevDash = true
+		}
+	}
+	// trim trailing dash
+	for len(buf) > 0 && buf[len(buf)-1] == '-' {
+		buf = buf[:len(buf)-1]
+	}
+	return string(buf)
 }

--- a/internal/metadata/openlibrary/client_test.go
+++ b/internal/metadata/openlibrary/client_test.go
@@ -118,3 +118,89 @@ func TestExtractText(t *testing.T) {
 		}
 	}
 }
+
+func TestParseSeriesRef(t *testing.T) {
+	tests := []struct {
+		raw      string
+		wantTitle string
+		wantPos   string
+		wantFID   string
+	}{
+		{
+			raw:       "Dune Chronicles",
+			wantTitle: "Dune Chronicles",
+			wantPos:   "",
+			wantFID:   "ol-series:dune-chronicles",
+		},
+		{
+			raw:       "Dune Chronicles #1",
+			wantTitle: "Dune Chronicles",
+			wantPos:   "1",
+			wantFID:   "ol-series:dune-chronicles",
+		},
+		{
+			raw:       "Mistborn #3",
+			wantTitle: "Mistborn",
+			wantPos:   "3",
+			wantFID:   "ol-series:mistborn",
+		},
+		{
+			raw:       "Wheel of Time, Book 1",
+			wantTitle: "Wheel of Time",
+			wantPos:   "1",
+			wantFID:   "ol-series:wheel-of-time",
+		},
+		{
+			raw:       "Harry Potter -- Book 3",
+			wantTitle: "Harry Potter",
+			wantPos:   "3",
+			wantFID:   "ol-series:harry-potter",
+		},
+		{
+			raw:       "A Series #1.5",
+			wantTitle: "A Series",
+			wantPos:   "1.5",
+			wantFID:   "ol-series:a-series",
+		},
+		{
+			// Extra whitespace should be trimmed.
+			raw:       "  The Dark Tower  #7  ",
+			wantTitle: "The Dark Tower",
+			wantPos:   "7",
+			wantFID:   "ol-series:the-dark-tower",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got := parseSeriesRef(tt.raw)
+			if got.Title != tt.wantTitle {
+				t.Errorf("Title: want %q, got %q", tt.wantTitle, got.Title)
+			}
+			if got.Position != tt.wantPos {
+				t.Errorf("Position: want %q, got %q", tt.wantPos, got.Position)
+			}
+			if got.ForeignID != tt.wantFID {
+				t.Errorf("ForeignID: want %q, got %q", tt.wantFID, got.ForeignID)
+			}
+		})
+	}
+}
+
+func TestSeriesSlug(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Dune Chronicles", "dune-chronicles"},
+		{"Harry Potter & the Philosopher's Stone", "harry-potter-the-philosopher-s-stone"},
+		{"  spaces  ", "spaces"},
+		{"A", "a"},
+	}
+	for _, tt := range tests {
+		got := seriesSlug(tt.input)
+		if got != tt.want {
+			t.Errorf("seriesSlug(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/metadata/openlibrary/client_test.go
+++ b/internal/metadata/openlibrary/client_test.go
@@ -121,7 +121,7 @@ func TestExtractText(t *testing.T) {
 
 func TestParseSeriesRef(t *testing.T) {
 	tests := []struct {
-		raw      string
+		raw       string
 		wantTitle string
 		wantPos   string
 		wantFID   string

--- a/internal/metadata/openlibrary/types.go
+++ b/internal/metadata/openlibrary/types.go
@@ -48,6 +48,7 @@ type authorWorkEntry struct {
 	Description interface{} `json:"description"`
 	Covers      []int       `json:"covers"`
 	Subjects    []string    `json:"subjects"`
+	Series      []string    `json:"series"`
 }
 
 type workResponse struct {
@@ -57,6 +58,7 @@ type workResponse struct {
 	Covers      []int        `json:"covers"`
 	Subjects    []string     `json:"subjects"`
 	Authors     []workAuthor `json:"authors"`
+	Series      []string     `json:"series"`
 }
 
 type workAuthor struct {

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -2,6 +2,16 @@ package models
 
 import "time"
 
+// SeriesRef carries series membership for a book returned by a metadata
+// provider. Not persisted in the books table — used during ingestion to
+// populate the series and series_books tables.
+type SeriesRef struct {
+	ForeignID string
+	Title     string
+	Position  string
+	Primary   bool
+}
+
 type Book struct {
 	ID                    int64      `json:"id"`
 	ForeignID             string     `json:"foreignBookId"`
@@ -33,6 +43,10 @@ type Book struct {
 	// Joined data
 	Author   *Author   `json:"author,omitempty"`
 	Editions []Edition `json:"editions,omitempty"`
+
+	// Transport-only: series data from the metadata provider, used during
+	// ingestion to populate series/series_books. Never stored in books table.
+	SeriesRefs []SeriesRef `json:"-"`
 }
 
 const (


### PR DESCRIPTION
## Summary

- OpenLibrary's `/authors/{id}/works.json` and `/works/{id}.json` responses include a `series` field (list of strings) that was previously ignored, leaving `series` and `series_books` always empty and the `/series` endpoint always returning `[]`.
- **Parse** `Series []string` from OL responses; extract title and position from formats like `"Dune Chronicles #1"`, `"Wheel of Time, Book 1"`, `"Harry Potter -- Book 3"` via two small regexes. Derive a stable slug-based `foreign_id` (e.g. `ol-series:dune-chronicles`) for deduplication across authors.
- **Upsert** series data immediately after each successful `books.Create` in `FetchAuthorBooks` using two new `SeriesRepo` methods: `CreateOrGet` (INSERT OR IGNORE + SELECT fallback) and `LinkBook` (INSERT OR IGNORE into `series_books`). Both are idempotent.
- **Backfill** existing installs with a new `bindery reconcile-series` CLI subcommand that iterates all authors, re-fetches their OL works, and populates series rows for books already in the DB.

No schema migration needed — `series` and `series_books` tables have existed since the initial migration but were never written to.

## Test plan

- [x] `go test ./...` — all packages green, including new `internal/db/series_test.go` (CreateOrGet idempotency, LinkBook with cascade, List) and `parseSeriesRef`/`seriesSlug` unit tests in the OL client test file
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [ ] Integration: add an author via the UI → trigger refresh → confirm the Series page shows entries (requires `BINDERY_INTEGRATION=1` + live OL access)
- [ ] Run `bindery reconcile-series` against a pre-existing DB and confirm `{"linked":N,"skipped":M}` output with N > 0

## Files changed

| File | What |
|------|------|
| `internal/metadata/openlibrary/types.go` | Add `Series []string` to `authorWorkEntry` and `workResponse` |
| `internal/metadata/openlibrary/client.go` | Parse series refs in `GetAuthorWorks`/`GetBook`; add `parseSeriesRef` + `seriesSlug` helpers |
| `internal/metadata/openlibrary/client_test.go` | Unit tests for `parseSeriesRef` and `seriesSlug` |
| `internal/models/book.go` | Add `SeriesRef` struct + `SeriesRefs []SeriesRef` transport field on `Book` |
| `internal/db/series.go` | Add `CreateOrGet` and `LinkBook` to `SeriesRepo` |
| `internal/db/series_test.go` | New: idempotency + cascade + list tests |
| `internal/api/authors.go` | Add `series *db.SeriesRepo` to `AuthorHandler`; upsert series after book creation |
| `internal/api/authors_test.go` | Fix constructor call (new `series` arg) |
| `cmd/bindery/main.go` | Pass `seriesRepo` to `NewAuthorHandler`; wire `reconcile-series` subcommand |
| `cmd/bindery/reconcile.go` | New: `runReconcileSeries` backfill command |
| `CHANGELOG.md` | Unreleased entry |
| `docs/DEPLOYMENT.md` | Upgrade note for v0.7.0 with reconcile-series instructions |