### PR TITLE
feat: auto-search on author add and book transitions (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The `development` branch carries the in-flight feature set for the next release.
 ### Added
 
 - **`bindery reconcile-series` CLI subcommand** — re-fetches OpenLibrary series data for every already-ingested author and backfills the series/series_books tables. Run once after upgrading from any version that did not populate series during ingestion. Idempotent; prints `{"linked":<n>,"skipped":<n>}` on completion. See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md#from-v06x-to-v070-series-view-fix) for usage.
+- **Auto-search on author add** ([#11](https://github.com/vavallee/bindery/issues/11)) — when an author is added with "Start search for books on add" enabled (default on), Bindery immediately fires an indexer search for each wanted book after fetching the author's catalogue from OpenLibrary. Previously users had to wait up to 12 hours for the first automatic grab. The search is gated on the author being monitored; unmonitored authors are unaffected.
+- **Auto-search on book status transition to wanted** — updating a book's status to `wanted` (e.g. via "Delete file" → flips imported → wanted, or a manual status edit via the API) now triggers an immediate indexer search. Same logic as the 12-hour scheduler job. Always-on for v0.7.0; a `search_on_status_change` setting can be added later if opt-out is requested.
+- **"Start search for books on add" checkbox** in the Add Author modal (default checked), matching Sonarr's phrasing. Uncheck to add an author without an immediate search.
 
 ## [v0.6.4] — 2026-04-14
 

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -151,8 +151,8 @@ func main() {
 	// API handlers
 	authHandler := api.NewAuthHandler(userRepo, settingsRepo, loginLimiter)
 	searchHandler := api.NewSearchHandler(metaAgg)
-	authorHandler := api.NewAuthorHandler(authorRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo)
-	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo)
+	authorHandler := api.NewAuthorHandler(authorRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched)
+	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched)
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, idxSearcher, settingsRepo, blocklistRepo)
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)
 	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo)

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -22,10 +22,11 @@ type AuthorHandler struct {
 	meta     *metadata.Aggregator
 	settings *db.SettingsRepo
 	profiles *db.MetadataProfileRepo
+	searcher BookSearcher
 }
 
-func NewAuthorHandler(authors *db.AuthorRepo, books *db.BookRepo, series *db.SeriesRepo, meta *metadata.Aggregator, settings *db.SettingsRepo, profiles *db.MetadataProfileRepo) *AuthorHandler {
-	return &AuthorHandler{authors: authors, books: books, series: series, meta: meta, settings: settings, profiles: profiles}
+func NewAuthorHandler(authors *db.AuthorRepo, books *db.BookRepo, series *db.SeriesRepo, meta *metadata.Aggregator, settings *db.SettingsRepo, profiles *db.MetadataProfileRepo, searcher BookSearcher) *AuthorHandler {
+	return &AuthorHandler{authors: authors, books: books, series: series, meta: meta, settings: settings, profiles: profiles, searcher: searcher}
 }
 
 func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -308,6 +309,11 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author) {
 			if err := h.series.LinkBook(ctx, s.ID, b.ID, ref.Position, ref.Primary); err != nil {
 				slog.Warn("failed to link book to series", "book", b.Title, "series", ref.Title, "error", err)
 			}
+		}
+
+		// Auto-search the freshly-added wanted book if configured.
+		if h.searcher != nil && author.Monitored {
+			h.searcher.SearchAndGrabBook(ctx, b)
 		}
 	}
 	slog.Info("author books synced", "author", author.Name, "added", added, "skipped_language", skippedLang, "skipped_junk", skippedJunk, "total", len(books))

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -7,13 +7,67 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 )
+
+// searcherSpy records every SearchAndGrabBook call so tests can assert on it.
+type searcherSpy struct {
+	mu    sync.Mutex
+	calls []string // book titles in call order
+}
+
+func (s *searcherSpy) SearchAndGrabBook(_ context.Context, book models.Book) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, book.Title)
+}
+
+func (s *searcherSpy) titles() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+// stubMetaProvider is a fake metadata.Provider whose GetAuthorWorks returns
+// a caller-supplied book list, allowing FetchAuthorBooks to run without
+// hitting the real OpenLibrary API.
+type stubMetaProvider struct {
+	works []models.Book
+}
+
+func (p *stubMetaProvider) Name() string { return "stub" }
+func (p *stubMetaProvider) SearchAuthors(_ context.Context, _ string) ([]models.Author, error) {
+	return nil, nil
+}
+func (p *stubMetaProvider) SearchBooks(_ context.Context, _ string) ([]models.Book, error) {
+	return nil, nil
+}
+func (p *stubMetaProvider) GetAuthor(_ context.Context, _ string) (*models.Author, error) {
+	return nil, nil
+}
+func (p *stubMetaProvider) GetBook(_ context.Context, _ string) (*models.Book, error) {
+	return nil, nil
+}
+func (p *stubMetaProvider) GetEditions(_ context.Context, _ string) ([]models.Edition, error) {
+	return nil, nil
+}
+func (p *stubMetaProvider) GetBookByISBN(_ context.Context, _ string) (*models.Book, error) {
+	return nil, nil
+}
+
+// GetAuthorWorks satisfies the worksProvider sub-interface used by Aggregator.
+func (p *stubMetaProvider) GetAuthorWorks(_ context.Context, _ string) ([]models.Book, error) {
+	return p.works, nil
+}
 
 // TestDeleteAuthor_WithDeleteFiles verifies the ?deleteFiles=true branch
 // sweeps every book's on-disk path. The invariant under test is ordering:
@@ -77,7 +131,7 @@ func TestDeleteAuthor_WithDeleteFiles(t *testing.T) {
 		}
 	}
 
-	h := NewAuthorHandler(authorRepo, bookRepo, nil, nil, nil, profileRepo)
+	h := NewAuthorHandler(authorRepo, bookRepo, nil, nil, nil, profileRepo, nil)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/author/"+strconv.FormatInt(author.ID, 10)+"?deleteFiles=true", nil)
 	rctx := chi.NewRouteContext()
@@ -140,7 +194,7 @@ func TestDeleteAuthor_WithoutDeleteFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := NewAuthorHandler(authorRepo, bookRepo, nil, nil, nil, profileRepo)
+	h := NewAuthorHandler(authorRepo, bookRepo, nil, nil, nil, profileRepo, nil)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/author/"+strconv.FormatInt(author.ID, 10), nil)
 	rctx := chi.NewRouteContext()
@@ -155,5 +209,86 @@ func TestDeleteAuthor_WithoutDeleteFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(path); err != nil {
 		t.Errorf("file should survive default delete, stat err=%v", err)
+	}
+}
+
+// TestFetchAuthorBooks_FiresSearchForMonitoredAuthor verifies that
+// FetchAuthorBooks calls SearchAndGrabBook once per newly created book when
+// the author is monitored. The stub metadata provider returns two works so we
+// expect exactly two search calls.
+func TestFetchAuthorBooks_FiresSearchForMonitoredAuthor(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL500A", Name: "Test Author", SortName: "Author, Test",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	stub := &stubMetaProvider{
+		works: []models.Book{
+			{ForeignID: "OL501W", Title: "First Book", SortTitle: "first book", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+			{ForeignID: "OL502W", Title: "Second Book", SortTitle: "second book", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+		},
+	}
+	agg := metadata.NewAggregator(stub)
+	spy := &searcherSpy{}
+
+	h := NewAuthorHandler(authorRepo, bookRepo, nil, agg, nil, profileRepo, spy)
+	h.FetchAuthorBooks(author)
+
+	titles := spy.titles()
+	if len(titles) != 2 {
+		t.Fatalf("expected 2 searcher calls, got %d: %v", len(titles), titles)
+	}
+}
+
+// TestFetchAuthorBooks_SkipsSearchWhenNotMonitored confirms that books added
+// for an unmonitored author do NOT trigger an indexer search — the user has
+// opted out of automatic activity for this author.
+func TestFetchAuthorBooks_SkipsSearchWhenNotMonitored(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL600A", Name: "Unmonitored", SortName: "Unmonitored",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	stub := &stubMetaProvider{
+		works: []models.Book{
+			{ForeignID: "OL601W", Title: "Some Book", SortTitle: "some book", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+		},
+	}
+	agg := metadata.NewAggregator(stub)
+	spy := &searcherSpy{}
+
+	h := NewAuthorHandler(authorRepo, bookRepo, nil, agg, nil, profileRepo, spy)
+	h.FetchAuthorBooks(author)
+
+	if titles := spy.titles(); len(titles) != 0 {
+		t.Errorf("expected no searcher calls for unmonitored author, got %v", titles)
 	}
 }

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -162,10 +162,13 @@ func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
 	// Fire an immediate indexer search when a book transitions into wanted
 	// status (e.g. "Delete file" flips imported → wanted, or a manual status
 	// edit). Gate on searcher to keep tests that don't wire it nil-safe.
+	// Detach the request context so the search outlives the HTTP response
+	// but keeps any request-scoped values.
 	if h.searcher != nil && req.Status != nil &&
 		*req.Status == models.BookStatusWanted && oldStatus != models.BookStatusWanted {
 		b := *book
-		go h.searcher.SearchAndGrabBook(context.Background(), b)
+		bgCtx := context.WithoutCancel(r.Context())
+		go h.searcher.SearchAndGrabBook(bgCtx, b)
 	}
 
 	writeJSON(w, http.StatusOK, book)

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -15,13 +16,14 @@ import (
 )
 
 type BookHandler struct {
-	books   *db.BookRepo
-	meta    *metadata.Aggregator
-	history *db.HistoryRepo
+	books    *db.BookRepo
+	meta     *metadata.Aggregator
+	history  *db.HistoryRepo
+	searcher BookSearcher
 }
 
-func NewBookHandler(books *db.BookRepo, meta *metadata.Aggregator, history *db.HistoryRepo) *BookHandler {
-	return &BookHandler{books: books, meta: meta, history: history}
+func NewBookHandler(books *db.BookRepo, meta *metadata.Aggregator, history *db.HistoryRepo, searcher BookSearcher) *BookHandler {
+	return &BookHandler{books: books, meta: meta, history: history, searcher: searcher}
 }
 
 // EnrichAudiobook fetches audnex data for the book's ASIN and updates
@@ -115,6 +117,7 @@ func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}
+	oldStatus := book.Status
 
 	// Note: file_path is deliberately NOT accepted here. It's set by the
 	// importer once a grab lands, and letting clients write it arbitrarily
@@ -155,6 +158,16 @@ func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+
+	// Fire an immediate indexer search when a book transitions into wanted
+	// status (e.g. "Delete file" flips imported → wanted, or a manual status
+	// edit). Gate on searcher to keep tests that don't wire it nil-safe.
+	if h.searcher != nil && req.Status != nil &&
+		*req.Status == models.BookStatusWanted && oldStatus != models.BookStatusWanted {
+		b := *book
+		go h.searcher.SearchAndGrabBook(context.Background(), b)
+	}
+
 	writeJSON(w, http.StatusOK, book)
 }
 

--- a/internal/api/books_test.go
+++ b/internal/api/books_test.go
@@ -10,12 +10,53 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
 )
+
+// mockBookSearcher collects SearchAndGrabBook calls via a buffered channel so
+// goroutine-launched searches can be awaited in tests.
+type mockBookSearcher struct {
+	ch chan models.Book
+}
+
+func newMockBookSearcher() *mockBookSearcher {
+	return &mockBookSearcher{ch: make(chan models.Book, 8)}
+}
+
+func (m *mockBookSearcher) SearchAndGrabBook(_ context.Context, book models.Book) {
+	select {
+	case m.ch <- book:
+	default:
+	}
+}
+
+// waitForCall blocks until a search call arrives or the timeout elapses.
+func (m *mockBookSearcher) waitForCall(t *testing.T, timeout time.Duration) models.Book {
+	t.Helper()
+	select {
+	case b := <-m.ch:
+		return b
+	case <-time.After(timeout):
+		t.Fatal("timeout: SearchAndGrabBook was not called within deadline")
+		return models.Book{}
+	}
+}
+
+// assertNoCall fails the test if a search call arrives within the window.
+func (m *mockBookSearcher) assertNoCall(t *testing.T, window time.Duration) {
+	t.Helper()
+	select {
+	case b := <-m.ch:
+		t.Errorf("unexpected SearchAndGrabBook call for book %q", b.Title)
+	case <-time.After(window):
+		// good — nothing fired
+	}
+}
 
 // bookFixture spins up in-memory storage with an author + N books and
 // returns a wired BookHandler. The meta aggregator is nil — EnrichAudiobook
@@ -40,7 +81,7 @@ func bookFixture(t *testing.T) (*BookHandler, *db.BookRepo, *db.AuthorRepo, *mod
 	if err := authors.Create(ctx, author); err != nil {
 		t.Fatal(err)
 	}
-	return NewBookHandler(books, nil, history), books, authors, author, ctx
+	return NewBookHandler(books, nil, history, nil), books, authors, author, ctx
 }
 
 func withURLParam(req *http.Request, key, val string) *http.Request {
@@ -390,4 +431,87 @@ func TestEnrichAudiobook_RejectsMissingASIN(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for missing ASIN, got %d", rec.Code)
 	}
+}
+
+// bookFixtureWithSearcher is like bookFixture but wires a mock searcher.
+func bookFixtureWithSearcher(t *testing.T, searcher BookSearcher) (*BookHandler, *db.BookRepo, *models.Author, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	history := db.NewHistoryRepo(database)
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL1A", Name: "Test Author", SortName: "Author, Test",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	return NewBookHandler(books, nil, history, searcher), books, author, ctx
+}
+
+// TestBookUpdate_FiresSearchOnTransitionToWanted verifies that updating a book
+// from any non-wanted status to "wanted" immediately triggers an indexer
+// search. The call happens in a goroutine so we use the channel-based mock.
+func TestBookUpdate_FiresSearchOnTransitionToWanted(t *testing.T) {
+	searcher := newMockBookSearcher()
+	h, books, author, ctx := bookFixtureWithSearcher(t, searcher)
+
+	book := &models.Book{
+		ForeignID: "B99", AuthorID: author.ID, Title: "Transition Book", SortTitle: "transition book",
+		Status: "imported", MediaType: models.MediaTypeEbook,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	body := bytes.NewBufferString(`{"status":"wanted"}`)
+	req := withURLParam(httptest.NewRequest(http.MethodPut, "/api/v1/book/"+strconv.FormatInt(book.ID, 10), body), "id", strconv.FormatInt(book.ID, 10))
+	rec := httptest.NewRecorder()
+	h.Update(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got := searcher.waitForCall(t, time.Second)
+	if got.ID != book.ID {
+		t.Errorf("searcher called with wrong book id: got %d, want %d", got.ID, book.ID)
+	}
+}
+
+// TestBookUpdate_NoSearchWhenAlreadyWanted confirms that updating a field on a
+// book that is already "wanted" does NOT fire a duplicate search.
+func TestBookUpdate_NoSearchWhenAlreadyWanted(t *testing.T) {
+	searcher := newMockBookSearcher()
+	h, books, author, ctx := bookFixtureWithSearcher(t, searcher)
+
+	book := &models.Book{
+		ForeignID: "B88", AuthorID: author.ID, Title: "Already Wanted", SortTitle: "already wanted",
+		Status: models.BookStatusWanted, MediaType: models.MediaTypeEbook,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	// Patch the media type — status stays "wanted" throughout, so no new search.
+	body := bytes.NewBufferString(`{"status":"wanted","mediaType":"audiobook"}`)
+	req := withURLParam(httptest.NewRequest(http.MethodPut, "/api/v1/book/"+strconv.FormatInt(book.ID, 10), body), "id", strconv.FormatInt(book.ID, 10))
+	rec := httptest.NewRecorder()
+	h.Update(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	searcher.assertNoCall(t, 50*time.Millisecond)
 }

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -7,7 +7,15 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/models"
 )
+
+// BookSearcher triggers an immediate indexer search and auto-grab for a
+// single wanted book. Implemented by *scheduler.Scheduler.
+type BookSearcher interface {
+	SearchAndGrabBook(ctx context.Context, book models.Book)
+}
 
 func contextBackground() context.Context {
 	return context.Background()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -103,6 +103,113 @@ func (s *Scheduler) Stop() {
 	slog.Info("scheduler stopped")
 }
 
+// SearchAndGrabBook performs an immediate indexer search for a single wanted
+// book and auto-grabs the top result. It is the same logic the 12-hour
+// wanted-scan uses, promoted so on-add and status-transition hooks can trigger
+// a search without waiting for the next scheduled run.
+func (s *Scheduler) SearchAndGrabBook(ctx context.Context, book models.Book) {
+	idxs, err := s.indexers.List(ctx)
+	if err != nil {
+		slog.Error("SearchAndGrabBook: failed to list indexers", "error", err)
+		return
+	}
+
+	lang := "en"
+	if langSetting, _ := s.settings.Get(ctx, "search.preferredLanguage"); langSetting != nil {
+		lang = langSetting.Value
+	}
+
+	authorName := ""
+	if a, _ := s.authors.GetByID(ctx, book.AuthorID); a != nil {
+		authorName = a.Name
+	}
+	crit := indexer.MatchCriteria{
+		Title:     book.Title,
+		Author:    authorName,
+		MediaType: book.MediaType,
+		ASIN:      book.ASIN,
+	}
+	if book.ReleaseDate != nil {
+		crit.Year = book.ReleaseDate.Year()
+	}
+
+	results := s.searcher.SearchBook(ctx, idxs, crit)
+	results = indexer.FilterByLanguage(results, lang)
+	results = filterBlocklisted(ctx, s.blocklist, results)
+	if len(results) == 0 {
+		return
+	}
+
+	best := results[0]
+
+	candidates, _ := s.clients.GetEnabledByProtocol(ctx, best.Protocol)
+	client := db.PickClientForMediaType(candidates, book.MediaType)
+	if client == nil {
+		client, _ = s.clients.GetFirstEnabled(ctx)
+	}
+	if client == nil {
+		slog.Debug("SearchAndGrabBook: no download client available", "book", book.Title)
+		return
+	}
+
+	slog.Info("auto-grabbing book",
+		"book", book.Title,
+		"author", authorName,
+		"result", best.Title,
+		"indexer", best.IndexerName,
+		"protocol", best.Protocol,
+		"client", client.Name,
+		"size", best.Size,
+	)
+
+	existing, _ := s.downloads.GetByGUID(ctx, best.GUID)
+	if existing != nil {
+		return
+	}
+
+	dl := &models.Download{
+		GUID:             best.GUID,
+		BookID:           &book.ID,
+		IndexerID:        &best.IndexerID,
+		DownloadClientID: &client.ID,
+		Title:            best.Title,
+		NZBURL:           best.NZBURL,
+		Size:             best.Size,
+		Status:           models.DownloadStatusQueued,
+		Protocol:         best.Protocol,
+		Quality:          indexer.ParseRelease(best.Title).Format,
+	}
+
+	if err := s.downloads.Create(ctx, dl); err != nil {
+		slog.Error("SearchAndGrabBook: failed to create download record", "error", err)
+		return
+	}
+
+	if best.Protocol == "torrent" {
+		qbt := qbittorrent.New(client.Host, client.Port, client.URLBase, client.APIKey, client.UseSSL)
+		if err := qbt.AddTorrent(ctx, best.NZBURL, client.Category, ""); err != nil {
+			slog.Error("SearchAndGrabBook: failed to send to qBittorrent", "title", best.Title, "error", err)
+			s.downloads.SetError(ctx, dl.ID, err.Error())
+			return
+		}
+		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading)
+		slog.Info("sent to qBittorrent", "title", best.Title)
+	} else {
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		resp, err := sab.AddURL(ctx, best.NZBURL, best.Title, client.Category, 0)
+		if err != nil {
+			slog.Error("SearchAndGrabBook: failed to send to SABnzbd", "title", best.Title, "error", err)
+			s.downloads.SetError(ctx, dl.ID, err.Error())
+			return
+		}
+		if len(resp.NzoIDs) > 0 {
+			s.downloads.SetNzoID(ctx, dl.ID, resp.NzoIDs[0])
+		}
+		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading)
+		slog.Info("sent to SABnzbd", "title", best.Title)
+	}
+}
+
 func (s *Scheduler) searchWanted() {
 	ctx := context.Background()
 
@@ -115,116 +222,8 @@ func (s *Scheduler) searchWanted() {
 		return
 	}
 
-	idxs, err := s.indexers.List(ctx)
-	if err != nil {
-		slog.Error("failed to list indexers", "error", err)
-		return
-	}
-
-	// Read preferred language once for all books in this run
-	lang := "en"
-	if langSetting, _ := s.settings.Get(ctx, "search.preferredLanguage"); langSetting != nil {
-		lang = langSetting.Value
-	}
-
 	for _, book := range wanted {
-		authorName := ""
-		if a, _ := s.authors.GetByID(ctx, book.AuthorID); a != nil {
-			authorName = a.Name
-		}
-		crit := indexer.MatchCriteria{
-			Title:     book.Title,
-			Author:    authorName,
-			MediaType: book.MediaType,
-			ASIN:      book.ASIN,
-		}
-		if book.ReleaseDate != nil {
-			crit.Year = book.ReleaseDate.Year()
-		}
-
-		results := s.searcher.SearchBook(ctx, idxs, crit)
-		results = indexer.FilterByLanguage(results, lang)
-
-		// Drop blocklisted results before picking a winner.
-		results = filterBlocklisted(ctx, s.blocklist, results)
-		if len(results) == 0 {
-			continue
-		}
-
-		// Auto-grab the top result
-		best := results[0]
-
-		// Select the download client that matches the result's protocol, preferring
-		// one whose category hints match the book's media type.
-		candidates, _ := s.clients.GetEnabledByProtocol(ctx, best.Protocol)
-		client := db.PickClientForMediaType(candidates, book.MediaType)
-		if client == nil {
-			// Fall back to any enabled client
-			client, _ = s.clients.GetFirstEnabled(ctx)
-		}
-		if client == nil {
-			slog.Debug("no download client available, skipping", "book", book.Title)
-			continue
-		}
-
-		slog.Info("auto-grabbing wanted book",
-			"book", book.Title,
-			"author", authorName,
-			"result", best.Title,
-			"indexer", best.IndexerName,
-			"protocol", best.Protocol,
-			"client", client.Name,
-			"size", best.Size,
-		)
-
-		// Check for duplicate
-		existing, _ := s.downloads.GetByGUID(ctx, best.GUID)
-		if existing != nil {
-			continue
-		}
-
-		dl := &models.Download{
-			GUID:             best.GUID,
-			BookID:           &book.ID,
-			IndexerID:        &best.IndexerID,
-			DownloadClientID: &client.ID,
-			Title:            best.Title,
-			NZBURL:           best.NZBURL,
-			Size:             best.Size,
-			Status:           models.DownloadStatusQueued,
-			Protocol:         best.Protocol,
-			Quality:          indexer.ParseRelease(best.Title).Format,
-		}
-
-		if err := s.downloads.Create(ctx, dl); err != nil {
-			slog.Error("failed to create download record", "error", err)
-			continue
-		}
-
-		if best.Protocol == "torrent" {
-			qbt := qbittorrent.New(client.Host, client.Port, client.URLBase, client.APIKey, client.UseSSL)
-			if err := qbt.AddTorrent(ctx, best.NZBURL, client.Category, ""); err != nil {
-				slog.Error("failed to send to qBittorrent", "title", best.Title, "error", err)
-				s.downloads.SetError(ctx, dl.ID, err.Error())
-				continue
-			}
-			s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading)
-			slog.Info("sent to qBittorrent", "title", best.Title)
-		} else {
-			sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
-			resp, err := sab.AddURL(ctx, best.NZBURL, best.Title, client.Category, 0)
-			if err != nil {
-				slog.Error("failed to send to SABnzbd", "title", best.Title, "error", err)
-				s.downloads.SetError(ctx, dl.ID, err.Error())
-				continue
-			}
-			if len(resp.NzoIDs) > 0 {
-				nzoID := resp.NzoIDs[0]
-				s.downloads.SetNzoID(ctx, dl.ID, nzoID)
-			}
-			s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading)
-			slog.Info("sent to SABnzbd", "title", best.Title)
-		}
+		s.SearchAndGrabBook(ctx, book)
 	}
 }
 

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -13,6 +13,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const [adding, setAdding] = useState<string | null>(null)
   const [profiles, setProfiles] = useState<MetadataProfile[]>([])
   const [profileId, setProfileId] = useState<number | null>(null)
+  const [searchOnAdd, setSearchOnAdd] = useState(true)
 
   useEffect(() => {
     api.listMetadataProfiles().then(ps => {
@@ -44,7 +45,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
         foreignAuthorId: author.foreignAuthorId,
         authorName: author.authorName,
         monitored: true,
-        searchOnAdd: true,
+        searchOnAdd,
         metadataProfileId: profileId,
       })
       onAdded()
@@ -78,6 +79,16 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
               </select>
             </div>
           )}
+          <label className="flex items-center gap-2 text-sm mb-3 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={searchOnAdd}
+              onChange={e => setSearchOnAdd(e.target.checked)}
+              className="accent-emerald-500"
+            />
+            <span>Start search for books on add</span>
+          </label>
+
           <div className="flex gap-2">
             <input
               type="text"


### PR DESCRIPTION
## Summary

- **Backend — author add**: `FetchAuthorBooks` now calls `Scheduler.SearchAndGrabBook` for each newly created wanted book when the author is monitored. Zero wait for the first grab after adding an author.
- **Backend — book status transition**: `BookHandler.Update` detects a transition to `status=wanted` and fires `SearchAndGrabBook` asynchronously. Covers the "Delete file" → flips imported→wanted flow and any manual status edit. Always-on for v0.7.0.
- **Refactor**: The inner loop of the 12-hour `searchWanted` job was promoted into the public `Scheduler.SearchAndGrabBook` method. Both trigger paths reuse identical search+grab logic; the scheduled job now just calls it per book.
- **Interface injection**: `BookSearcher` interface in `internal/api` keeps both handlers testable without a real scheduler. `main.go` passes `sched` at wire-up time.
- **Frontend**: `AddAuthorModal` exposes a "Start search for books on add" checkbox (default checked, Sonarr-parity label). Previously hardcoded to `true`.

## Test plan

- [ ] `go test ./...` — all packages pass (verified locally)
- [ ] `TestFetchAuthorBooks_FiresSearchForMonitoredAuthor` — stub meta + spy searcher confirms 2 calls for 2 works
- [ ] `TestFetchAuthorBooks_SkipsSearchWhenNotMonitored` — spy confirms 0 calls for unmonitored author
- [ ] `TestBookUpdate_FiresSearchOnTransitionToWanted` — channel mock confirms call within 1 s
- [ ] `TestBookUpdate_NoSearchWhenAlreadyWanted` — mock confirms no call within 50 ms window
- [ ] Manual: add an author with checkbox ON → books appear in Wanted and a grab starts within seconds
- [ ] Manual: add an author with checkbox OFF → books appear, no grab fires
- [ ] Manual: flip an imported book to wanted via "Delete file" → grab fires immediately