### PR TITLE
fix(api): library scan uses WithoutCancel so request cancellation doesn't abort it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased] — development branch
 
+### Fixed
+
+- **Manual library scan silently aborted** — `POST /api/v1/library/scan` spawned the scan goroutine with the HTTP request context, which Go cancels the moment the 202 response is sent; the scan now uses `context.WithoutCancel` so it always runs to completion (#55).
+
 The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
 
 ## [v0.7.1] — 2026-04-14

--- a/internal/api/library.go
+++ b/internal/api/library.go
@@ -1,13 +1,19 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/vavallee/bindery/internal/importer"
 )
 
+// libraryScanner is the subset of importer.Scanner used by LibraryHandler.
+type libraryScanner interface {
+	ScanLibrary(ctx context.Context)
+}
+
 type LibraryHandler struct {
-	scanner *importer.Scanner
+	scanner libraryScanner
 }
 
 func NewLibraryHandler(scanner *importer.Scanner) *LibraryHandler {
@@ -18,6 +24,8 @@ func NewLibraryHandler(scanner *importer.Scanner) *LibraryHandler {
 // returns 202 Accepted. The scan runs asynchronously; clients can monitor
 // progress via the book list.
 func (h *LibraryHandler) Scan(w http.ResponseWriter, r *http.Request) {
-	go h.scanner.ScanLibrary(r.Context())
+	// context.WithoutCancel so the goroutine isn't killed when the HTTP
+	// response is sent and the request context is cancelled.
+	go h.scanner.ScanLibrary(context.WithoutCancel(r.Context()))
 	writeJSON(w, http.StatusAccepted, map[string]string{"message": "library scan started"})
 }

--- a/internal/api/library_test.go
+++ b/internal/api/library_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,13 @@ import (
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/importer"
 )
+
+// fakeScanner records the context it received so the test can inspect it.
+type fakeScanner struct {
+	called chan context.Context
+}
+
+func (f *fakeScanner) ScanLibrary(ctx context.Context) { f.called <- ctx }
 
 func newLibraryHandler(t *testing.T) *LibraryHandler {
 	t.Helper()
@@ -26,6 +34,34 @@ func newLibraryHandler(t *testing.T) *LibraryHandler {
 		t.TempDir(), "", "", "", "",
 	)
 	return NewLibraryHandler(scanner)
+}
+
+// TestLibraryScan_ContextOutlivesRequest is a regression test for issue #55.
+// It verifies that cancelling the HTTP request context (which happens the
+// instant the 202 response is written) does not cancel the scan goroutine.
+func TestLibraryScan_ContextOutlivesRequest(t *testing.T) {
+	fake := &fakeScanner{called: make(chan context.Context, 1)}
+	h := &LibraryHandler{scanner: fake}
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/library/scan", nil).WithContext(reqCtx)
+	h.Scan(httptest.NewRecorder(), req)
+
+	// Simulate the net/http server cancelling the request context after the
+	// handler returns (the 202 has been flushed to the client).
+	cancel()
+
+	// Wait for the goroutine to call ScanLibrary and deliver its context.
+	scanCtx := <-fake.called
+
+	// The scan context must still be live even though the request context was
+	// cancelled.
+	select {
+	case <-scanCtx.Done():
+		t.Fatal("scan context was cancelled when the request context was cancelled (issue #55 regression)")
+	default:
+		// pass — context.WithoutCancel keeps the scan alive
+	}
 }
 
 func TestLibraryScan_Returns202(t *testing.T) {


### PR DESCRIPTION
Closes #55.

## Problem

`POST /api/v1/library/scan` was spawning the scan goroutine with `r.Context()`. Go cancels the HTTP request context the moment the handler returns (i.e. immediately after writing the 202 response), so `books.List(ctx)` inside `ScanLibrary` would receive a cancelled context and return early — meaning every manual scan silently did nothing.

## Fix

Replace `r.Context()` with `context.WithoutCancel(r.Context())` in the goroutine spawn. This detaches the scan's lifetime from the HTTP request while preserving any values (logger, trace IDs, etc.) carried on the original context.

The scheduled scan path in `internal/scheduler/scheduler.go` already uses `context.Background()` and is unaffected.

## Changes

- `internal/api/library.go` — introduce a minimal `libraryScanner` interface (enables test injection), apply `context.WithoutCancel`.
- `internal/api/library_test.go` — add `TestLibraryScan_ContextOutlivesRequest` regression test: cancels the request context after `Scan` returns and asserts the context delivered to the scanner goroutine is still live.
- `CHANGELOG.md` — one-line entry under `[Unreleased]`.

## Test plan

- `make build && go test ./...` passes locally (all packages green).
- `TestLibraryScan_ContextOutlivesRequest` fails on the old code (passes cancelled context) and passes on the new code.