### PR TITLE
feat(ui): bulk actions on Authors / Books / Wanted (closes #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,19 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased] — development branch
 
-### Fixed
-
-- **Manual library scan silently aborted** — `POST /api/v1/library/scan` spawned the scan goroutine with the HTTP request context, which Go cancels the moment the 202 response is sent; the scan now uses `context.WithoutCancel` so it always runs to completion (#55).
-
 The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
+
+### Added
+
+- **Multi-select / bulk actions on Authors, Books, and Wanted** ([#12](https://github.com/vavallee/bindery/issues/12)) — row checkboxes with "Select all on this page" in table headers (and overlay checkboxes on grid cards), plus a sticky `BulkActionBar` footer that appears whenever any items are selected. Authors support Monitor / Unmonitor / Search / Delete; Books additionally support Set Ebook / Set Audiobook; Wanted supports Search / Unmonitor / Blocklist (marks book as skipped and unmonitored). Three new endpoints: `POST /api/v1/author/bulk`, `POST /api/v1/book/bulk`, `POST /api/v1/wanted/bulk`. All return a per-ID result map at HTTP 200 so partial failures (e.g. a stale ID) report inline without aborting the rest of the batch.
 
 ### Changed
 
 - **Backend test coverage raised to ≥50% (52.8% total)** — new `_test.go` files added for `internal/db`, `internal/downloader/qbittorrent`, `internal/metadata` (aggregator), `internal/metadata/googlebooks`, `internal/metadata/hardcover`, `internal/metadata/openlibrary`, `internal/notifier`, and `internal/scheduler`. No production code was modified.
+
+### Fixed
+
+- **Manual library scan silently aborted** — `POST /api/v1/library/scan` spawned the scan goroutine with the HTTP request context, which Go cancels the moment the 202 response is sent; the scan now uses `context.WithoutCancel` so it always runs to completion ([#55](https://github.com/vavallee/bindery/issues/55)).
 
 ## [v0.7.1] — 2026-04-14
 

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -169,6 +169,7 @@ func main() {
 	metadataProfileHandler := api.NewMetadataProfileHandler(metadataProfileRepo)
 	delayProfileHandler := api.NewDelayProfileHandler(delayProfileRepo)
 	customFormatHandler := api.NewCustomFormatHandler(customFormatRepo)
+	bulkHandler := api.NewBulkHandler(authorRepo, bookRepo, blocklistRepo, sched)
 	backupHandler := api.NewBackupHandler(cfg.DBPath, cfg.DataDir)
 	migrateHandler := api.NewMigrateHandler(
 		authorRepo, indexerRepo, dlClientRepo, blocklistRepo, bookRepo, metaAgg,
@@ -220,6 +221,7 @@ func main() {
 		// Authors
 		r.Get("/author", authorHandler.List)
 		r.Post("/author", authorHandler.Create)
+		r.Post("/author/bulk", bulkHandler.AuthorsBulk)
 		r.Get("/author/{id}", authorHandler.Get)
 		r.Put("/author/{id}", authorHandler.Update)
 		r.Delete("/author/{id}", authorHandler.Delete)
@@ -227,6 +229,7 @@ func main() {
 
 		// Books
 		r.Get("/book", bookHandler.List)
+		r.Post("/book/bulk", bulkHandler.BooksBulk)
 		r.Get("/book/{id}", bookHandler.Get)
 		r.Put("/book/{id}", bookHandler.Update)
 		r.Delete("/book/{id}", bookHandler.Delete)
@@ -237,6 +240,7 @@ func main() {
 
 		// Wanted
 		r.Get("/wanted/missing", bookHandler.ListWanted)
+		r.Post("/wanted/bulk", bulkHandler.WantedBulk)
 
 		// Indexers
 		r.Get("/indexer", indexerHandler.List)

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -1,0 +1,288 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// BulkHandler handles multi-ID mutation endpoints for authors, books, and
+// wanted books. All three endpoints use a per-ID result map with 200 status
+// so callers can distinguish partial failures without a second request.
+// Rationale for per-ID rather than all-or-nothing: bulk operations routinely
+// include stale IDs (page loaded, item deleted, user re-selects); aborting
+// the whole batch on one bad ID is more disruptive than reporting it inline.
+type BulkHandler struct {
+	authors   *db.AuthorRepo
+	books     *db.BookRepo
+	blocklist *db.BlocklistRepo
+	searcher  BookSearcher
+}
+
+func NewBulkHandler(authors *db.AuthorRepo, books *db.BookRepo, blocklist *db.BlocklistRepo, searcher BookSearcher) *BulkHandler {
+	return &BulkHandler{authors: authors, books: books, blocklist: blocklist, searcher: searcher}
+}
+
+// bulkItemResult is the per-ID result entry in a bulk response.
+type bulkItemResult struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+// bulkResponse is the envelope returned by all three bulk endpoints.
+// Keys are stringified IDs; every requested ID has an entry.
+type bulkResponse struct {
+	Results map[string]bulkItemResult `json:"results"`
+}
+
+// AuthorsBulk handles POST /api/v1/author/bulk.
+//
+// Supported actions: "monitor", "unmonitor", "delete", "search".
+// "search" fires an async indexer search for every wanted book belonging
+// to each requested author and always returns ok:true immediately (the search
+// outcome is visible in History).
+func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		IDs    []int64 `json:"ids"`
+		Action string  `json:"action"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if len(req.IDs) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "ids required"})
+		return
+	}
+
+	switch req.Action {
+	case "monitor", "unmonitor", "delete", "search":
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown action: " + req.Action})
+		return
+	}
+
+	resp := bulkResponse{Results: make(map[string]bulkItemResult, len(req.IDs))}
+
+	for _, id := range req.IDs {
+		key := fmt.Sprintf("%d", id)
+		switch req.Action {
+		case "monitor":
+			if err := h.setAuthorMonitored(r.Context(), id, true); err != nil {
+				resp.Results[key] = bulkItemResult{Error: err.Error()}
+				continue
+			}
+		case "unmonitor":
+			if err := h.setAuthorMonitored(r.Context(), id, false); err != nil {
+				resp.Results[key] = bulkItemResult{Error: err.Error()}
+				continue
+			}
+		case "delete":
+			if err := h.authors.Delete(r.Context(), id); err != nil {
+				resp.Results[key] = bulkItemResult{Error: err.Error()}
+				continue
+			}
+		case "search":
+			// Fetch wanted books while the request context is still alive,
+			// then detach before launching per-book goroutines.
+			books, err := h.books.ListByAuthor(r.Context(), id)
+			if err != nil {
+				resp.Results[key] = bulkItemResult{Error: err.Error()}
+				continue
+			}
+			if h.searcher != nil {
+				bgCtx := contextBackground()
+				for _, b := range books {
+					if b.Status == models.BookStatusWanted {
+						b := b
+						go h.searcher.SearchAndGrabBook(bgCtx, b)
+					}
+				}
+			}
+		}
+		resp.Results[key] = bulkItemResult{OK: true}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// BooksBulk handles POST /api/v1/book/bulk.
+//
+// Supported actions: "monitor", "unmonitor", "delete", "search", "set_media_type".
+// For "set_media_type" the body must also include "mediaType": "ebook"|"audiobook".
+func (h *BulkHandler) BooksBulk(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		IDs       []int64 `json:"ids"`
+		Action    string  `json:"action"`
+		MediaType string  `json:"mediaType"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if len(req.IDs) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "ids required"})
+		return
+	}
+
+	switch req.Action {
+	case "monitor", "unmonitor", "delete", "search", "set_media_type":
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown action: " + req.Action})
+		return
+	}
+	if req.Action == "set_media_type" && req.MediaType != models.MediaTypeEbook && req.MediaType != models.MediaTypeAudiobook {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "mediaType must be 'ebook' or 'audiobook'"})
+		return
+	}
+
+	resp := bulkResponse{Results: make(map[string]bulkItemResult, len(req.IDs))}
+
+	for _, id := range req.IDs {
+		key := fmt.Sprintf("%d", id)
+		var opErr error
+		switch req.Action {
+		case "monitor":
+			opErr = h.setBookMonitored(r.Context(), id, true)
+		case "unmonitor":
+			opErr = h.setBookMonitored(r.Context(), id, false)
+		case "delete":
+			opErr = h.books.Delete(r.Context(), id)
+		case "search":
+			book, err := h.books.GetByID(r.Context(), id)
+			if err != nil || book == nil {
+				resp.Results[key] = bulkItemResult{Error: "book not found"}
+				continue
+			}
+			if h.searcher != nil {
+				b := *book
+				go h.searcher.SearchAndGrabBook(contextBackground(), b)
+			}
+		case "set_media_type":
+			opErr = h.setBookMediaType(r.Context(), id, req.MediaType)
+		}
+		if opErr != nil {
+			resp.Results[key] = bulkItemResult{Error: opErr.Error()}
+			continue
+		}
+		resp.Results[key] = bulkItemResult{OK: true}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// WantedBulk handles POST /api/v1/wanted/bulk.
+//
+// Supported actions: "search", "unmonitor", "blocklist".
+// "blocklist" marks the book as unmonitored with status "skipped" so it
+// disappears from the Wanted page and is not auto-searched again.
+func (h *BulkHandler) WantedBulk(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		IDs    []int64 `json:"ids"`
+		Action string  `json:"action"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if len(req.IDs) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "ids required"})
+		return
+	}
+
+	switch req.Action {
+	case "search", "unmonitor", "blocklist":
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown action: " + req.Action})
+		return
+	}
+
+	resp := bulkResponse{Results: make(map[string]bulkItemResult, len(req.IDs))}
+
+	for _, id := range req.IDs {
+		key := fmt.Sprintf("%d", id)
+		var opErr error
+		switch req.Action {
+		case "search":
+			book, err := h.books.GetByID(r.Context(), id)
+			if err != nil || book == nil {
+				resp.Results[key] = bulkItemResult{Error: "book not found"}
+				continue
+			}
+			if h.searcher != nil {
+				b := *book
+				go h.searcher.SearchAndGrabBook(contextBackground(), b)
+			}
+		case "unmonitor":
+			opErr = h.setBookMonitored(r.Context(), id, false)
+		case "blocklist":
+			opErr = h.skipBook(r.Context(), id)
+		}
+		if opErr != nil {
+			resp.Results[key] = bulkItemResult{Error: opErr.Error()}
+			continue
+		}
+		resp.Results[key] = bulkItemResult{OK: true}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// --- helpers -----------------------------------------------------------------
+
+func (h *BulkHandler) setAuthorMonitored(ctx context.Context, id int64, monitored bool) error {
+	author, err := h.authors.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if author == nil {
+		return fmt.Errorf("author not found")
+	}
+	author.Monitored = monitored
+	return h.authors.Update(ctx, author)
+}
+
+func (h *BulkHandler) setBookMonitored(ctx context.Context, id int64, monitored bool) error {
+	book, err := h.books.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if book == nil {
+		return fmt.Errorf("book not found")
+	}
+	book.Monitored = monitored
+	return h.books.Update(ctx, book)
+}
+
+func (h *BulkHandler) setBookMediaType(ctx context.Context, id int64, mediaType string) error {
+	book, err := h.books.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if book == nil {
+		return fmt.Errorf("book not found")
+	}
+	book.MediaType = mediaType
+	return h.books.Update(ctx, book)
+}
+
+// skipBook marks a wanted book as unmonitored and skipped so it is removed
+// from the Wanted list and not auto-searched again. Equivalent to the
+// per-book Sonarr "mark as unmonitored" workflow when the user has no
+// interest in acquiring the title.
+func (h *BulkHandler) skipBook(ctx context.Context, id int64) error {
+	book, err := h.books.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if book == nil {
+		return fmt.Errorf("book not found")
+	}
+	book.Monitored = false
+	book.Status = models.BookStatusSkipped
+	return h.books.Update(ctx, book)
+}

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -1,0 +1,563 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// bulkFixture spins up in-memory storage with one author and a configurable
+// set of books, returns a wired BulkHandler plus the underlying repos.
+func bulkFixture(t *testing.T) (*BulkHandler, *db.AuthorRepo, *db.BookRepo, *models.Author, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	blocklist := db.NewBlocklistRepo(database)
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL_BULK_A", Name: "Bulk Author", SortName: "Author, Bulk",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewBulkHandler(authors, books, blocklist, nil)
+	return h, authors, books, author, ctx
+}
+
+// bulkFixtureWithSearcher is like bulkFixture but wires a mock searcher.
+func bulkFixtureWithSearcher(t *testing.T, searcher BookSearcher) (*BulkHandler, *db.AuthorRepo, *db.BookRepo, *models.Author, context.Context) {
+	t.Helper()
+	h, authors, books, author, ctx := bulkFixture(t)
+	// Replace nil searcher with the provided one.
+	h.searcher = searcher
+	return h, authors, books, author, ctx
+}
+
+func mustCreateBook(t *testing.T, books *db.BookRepo, ctx context.Context, b *models.Book) *models.Book {
+	t.Helper()
+	if err := books.Create(ctx, b); err != nil {
+		t.Fatalf("create book %q: %v", b.Title, err)
+	}
+	return b
+}
+
+func postBulk(t *testing.T, h http.HandlerFunc, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	h(rec, req)
+	return rec
+}
+
+// ---------------------------------------------------------------------------
+// AuthorsBulk
+// ---------------------------------------------------------------------------
+
+func TestAuthorsBulk_Monitor(t *testing.T) {
+	h, authors, _, author, ctx := bulkFixture(t)
+
+	// Start unmonitored.
+	author.Monitored = false
+	if err := authors.Update(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"monitor"}`, author.ID)
+	rec := postBulk(t, h.AuthorsBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp bulkResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	key := fmt.Sprintf("%d", author.ID)
+	if r := resp.Results[key]; !r.OK {
+		t.Errorf("expected ok for author %d, got %+v", author.ID, r)
+	}
+
+	got, _ := authors.GetByID(ctx, author.ID)
+	if !got.Monitored {
+		t.Error("author should be monitored after bulk monitor")
+	}
+}
+
+func TestAuthorsBulk_Unmonitor(t *testing.T) {
+	h, authors, _, author, ctx := bulkFixture(t)
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"unmonitor"}`, author.ID)
+	rec := postBulk(t, h.AuthorsBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	got, _ := authors.GetByID(ctx, author.ID)
+	if got.Monitored {
+		t.Error("author should be unmonitored after bulk unmonitor")
+	}
+}
+
+func TestAuthorsBulk_Delete(t *testing.T) {
+	h, authors, _, author, ctx := bulkFixture(t)
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"delete"}`, author.ID)
+	rec := postBulk(t, h.AuthorsBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	got, _ := authors.GetByID(ctx, author.ID)
+	if got != nil {
+		t.Error("author should be deleted")
+	}
+}
+
+func TestAuthorsBulk_Search_FiresSearcherForWantedBooks(t *testing.T) {
+	searcher := newMockBookSearcher()
+	h, _, books, author, ctx := bulkFixtureWithSearcher(t, searcher)
+
+	// One wanted book + one imported book; only wanted should be searched.
+	mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "OL_BK1", AuthorID: author.ID, Title: "Wanted Book",
+		SortTitle: "wanted book", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+	mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "OL_BK2", AuthorID: author.ID, Title: "Imported Book",
+		SortTitle: "imported book", Status: models.BookStatusImported,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"search"}`, author.ID)
+	rec := postBulk(t, h.AuthorsBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	// Search runs in a goroutine; wait for the single expected call.
+	got := searcher.waitForCall(t, time.Second)
+	if got.Title != "Wanted Book" {
+		t.Errorf("expected search for 'Wanted Book', got %q", got.Title)
+	}
+	// Imported book must not trigger a search.
+	searcher.assertNoCall(t, 50*time.Millisecond)
+}
+
+func TestAuthorsBulk_UnknownAction(t *testing.T) {
+	h, _, _, author, _ := bulkFixture(t)
+	body := fmt.Sprintf(`{"ids":[%d],"action":"nuke"}`, author.ID)
+	rec := postBulk(t, h.AuthorsBulk, body)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for unknown action, got %d", rec.Code)
+	}
+}
+
+func TestAuthorsBulk_EmptyIDs(t *testing.T) {
+	h, _, _, _, _ := bulkFixture(t)
+	rec := postBulk(t, h.AuthorsBulk, `{"ids":[],"action":"monitor"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for empty ids, got %d", rec.Code)
+	}
+}
+
+// TestAuthorsBulk_PartialFailure is the 5-IDs-1-bad scenario called out in the
+// issue. Four valid authors + one non-existent ID: we expect 200 with four
+// ok:true entries and one ok:false entry, not a hard 4xx abort.
+func TestAuthorsBulk_PartialFailure(t *testing.T) {
+	h, authors, _, _, ctx := bulkFixture(t)
+
+	// Create four more authors.
+	var ids []int64
+	for i := 0; i < 4; i++ {
+		a := &models.Author{
+			ForeignID:        fmt.Sprintf("OL_PF%d", i),
+			Name:             fmt.Sprintf("Author %d", i),
+			SortName:         fmt.Sprintf("Author, %d", i),
+			MetadataProvider: "openlibrary",
+			Monitored:        true,
+		}
+		if err := authors.Create(ctx, a); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, a.ID)
+	}
+	// Fifth ID is intentionally bogus.
+	const badID = int64(999999)
+	ids = append(ids, badID)
+
+	idsJSON, _ := json.Marshal(ids)
+	body := fmt.Sprintf(`{"ids":%s,"action":"unmonitor"}`, idsJSON)
+	rec := postBulk(t, h.AuthorsBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 even with partial failure, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp bulkResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Results) != 5 {
+		t.Fatalf("expected 5 result entries, got %d", len(resp.Results))
+	}
+
+	okCount, errCount := 0, 0
+	for _, r := range resp.Results {
+		if r.OK {
+			okCount++
+		} else {
+			errCount++
+		}
+	}
+	if okCount != 4 {
+		t.Errorf("expected 4 ok results, got %d", okCount)
+	}
+	if errCount != 1 {
+		t.Errorf("expected 1 error result, got %d", errCount)
+	}
+
+	badKey := fmt.Sprintf("%d", badID)
+	if r := resp.Results[badKey]; r.OK || r.Error == "" {
+		t.Errorf("expected error entry for bad id %d, got %+v", badID, r)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BooksBulk
+// ---------------------------------------------------------------------------
+
+func TestBooksBulk_Monitor(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "B_MON", AuthorID: author.ID, Title: "Monitor Me",
+		SortTitle: "monitor me", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: false,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"monitor"}`, book.ID)
+	rec := postBulk(t, h.BooksBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, _ := books.GetByID(ctx, book.ID)
+	if !got.Monitored {
+		t.Error("book should be monitored")
+	}
+}
+
+func TestBooksBulk_Unmonitor(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "B_UNM", AuthorID: author.ID, Title: "Unmonitor Me",
+		SortTitle: "unmonitor me", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"unmonitor"}`, book.ID)
+	rec := postBulk(t, h.BooksBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	got, _ := books.GetByID(ctx, book.ID)
+	if got.Monitored {
+		t.Error("book should be unmonitored")
+	}
+}
+
+func TestBooksBulk_Delete(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "B_DEL", AuthorID: author.ID, Title: "Delete Me",
+		SortTitle: "delete me", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"delete"}`, book.ID)
+	rec := postBulk(t, h.BooksBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	got, _ := books.GetByID(ctx, book.ID)
+	if got != nil {
+		t.Error("book should be deleted")
+	}
+}
+
+func TestBooksBulk_SetMediaType_Ebook(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "B_MT", AuthorID: author.ID, Title: "Media Type Book",
+		SortTitle: "media type book", Status: models.BookStatusWanted,
+		MediaType: models.MediaTypeAudiobook,
+		Genres:    []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"set_media_type","mediaType":"ebook"}`, book.ID)
+	rec := postBulk(t, h.BooksBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, _ := books.GetByID(ctx, book.ID)
+	if got.MediaType != models.MediaTypeEbook {
+		t.Errorf("expected ebook, got %q", got.MediaType)
+	}
+}
+
+func TestBooksBulk_SetMediaType_Invalid(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "B_MT2", AuthorID: author.ID, Title: "Bad Type",
+		SortTitle: "bad type", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"set_media_type","mediaType":"videogame"}`, book.ID)
+	rec := postBulk(t, h.BooksBulk, body)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid media type, got %d", rec.Code)
+	}
+}
+
+func TestBooksBulk_Search_FiresSearcher(t *testing.T) {
+	searcher := newMockBookSearcher()
+	h, _, books, author, ctx := bulkFixtureWithSearcher(t, searcher)
+
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "B_SRCH", AuthorID: author.ID, Title: "Search Me",
+		SortTitle: "search me", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"search"}`, book.ID)
+	rec := postBulk(t, h.BooksBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	got := searcher.waitForCall(t, time.Second)
+	if got.ID != book.ID {
+		t.Errorf("searcher called with wrong book id: got %d, want %d", got.ID, book.ID)
+	}
+}
+
+func TestBooksBulk_UnknownAction(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "B_UNK", AuthorID: author.ID, Title: "Unknown Action",
+		SortTitle: "unknown action", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+	body := fmt.Sprintf(`{"ids":[%d],"action":"explode"}`, book.ID)
+	rec := postBulk(t, h.BooksBulk, body)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestBooksBulk_PartialFailure(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	// Four valid books.
+	var ids []int64
+	for i := 0; i < 4; i++ {
+		b := mustCreateBook(t, books, ctx, &models.Book{
+			ForeignID:        fmt.Sprintf("B_PF%d", i),
+			AuthorID:         author.ID,
+			Title:            fmt.Sprintf("Book %d", i),
+			SortTitle:        fmt.Sprintf("book %d", i),
+			Status:           models.BookStatusWanted,
+			Genres:           []string{},
+			MetadataProvider: "openlibrary",
+			Monitored:        true,
+		})
+		ids = append(ids, b.ID)
+	}
+	// Fifth ID does not exist.
+	const badID = int64(888888)
+	ids = append(ids, badID)
+
+	idsJSON, _ := json.Marshal(ids)
+	body := fmt.Sprintf(`{"ids":%s,"action":"unmonitor"}`, idsJSON)
+	rec := postBulk(t, h.BooksBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for partial failure, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp bulkResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Results) != 5 {
+		t.Fatalf("expected 5 result entries, got %d", len(resp.Results))
+	}
+	okCount, errCount := 0, 0
+	for _, r := range resp.Results {
+		if r.OK {
+			okCount++
+		} else {
+			errCount++
+		}
+	}
+	if okCount != 4 || errCount != 1 {
+		t.Errorf("expected 4 ok + 1 error, got %d ok + %d error", okCount, errCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WantedBulk
+// ---------------------------------------------------------------------------
+
+func TestWantedBulk_Unmonitor(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "W_UNM", AuthorID: author.ID, Title: "Unmonitor Wanted",
+		SortTitle: "unmonitor wanted", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"unmonitor"}`, book.ID)
+	rec := postBulk(t, h.WantedBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	got, _ := books.GetByID(ctx, book.ID)
+	if got.Monitored {
+		t.Error("book should be unmonitored")
+	}
+}
+
+func TestWantedBulk_Blocklist(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "W_BL", AuthorID: author.ID, Title: "Blocklist Wanted",
+		SortTitle: "blocklist wanted", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"blocklist"}`, book.ID)
+	rec := postBulk(t, h.WantedBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	got, _ := books.GetByID(ctx, book.ID)
+	if got.Monitored {
+		t.Error("blocklisted book should be unmonitored")
+	}
+	if got.Status != models.BookStatusSkipped {
+		t.Errorf("blocklisted book should have status skipped, got %q", got.Status)
+	}
+}
+
+func TestWantedBulk_Search_FiresSearcher(t *testing.T) {
+	searcher := newMockBookSearcher()
+	h, _, books, author, ctx := bulkFixtureWithSearcher(t, searcher)
+
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "W_SRCH", AuthorID: author.ID, Title: "Search Wanted",
+		SortTitle: "search wanted", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"search"}`, book.ID)
+	rec := postBulk(t, h.WantedBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	got := searcher.waitForCall(t, time.Second)
+	if got.ID != book.ID {
+		t.Errorf("searcher called with wrong book id: got %d, want %d", got.ID, book.ID)
+	}
+}
+
+func TestWantedBulk_UnknownAction(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "W_UNK", AuthorID: author.ID, Title: "Unknown",
+		SortTitle: "unknown", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+	body := fmt.Sprintf(`{"ids":[%d],"action":"orbit"}`, book.ID)
+	rec := postBulk(t, h.WantedBulk, body)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestWantedBulk_PartialFailure(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	var ids []int64
+	for i := 0; i < 4; i++ {
+		b := mustCreateBook(t, books, ctx, &models.Book{
+			ForeignID:        fmt.Sprintf("W_PF%d", i),
+			AuthorID:         author.ID,
+			Title:            fmt.Sprintf("Wanted %d", i),
+			SortTitle:        fmt.Sprintf("wanted %d", i),
+			Status:           models.BookStatusWanted,
+			Genres:           []string{},
+			MetadataProvider: "openlibrary",
+			Monitored:        true,
+		})
+		ids = append(ids, b.ID)
+	}
+	const badID = int64(777777)
+	ids = append(ids, badID)
+
+	idsJSON, _ := json.Marshal(ids)
+	body := fmt.Sprintf(`{"ids":%s,"action":"blocklist"}`, idsJSON)
+	rec := postBulk(t, h.WantedBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp bulkResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Results) != 5 {
+		t.Fatalf("expected 5 results, got %d", len(resp.Results))
+	}
+	okCount, errCount := 0, 0
+	for _, r := range resp.Results {
+		if r.OK {
+			okCount++
+		} else {
+			errCount++
+		}
+	}
+	if okCount != 4 || errCount != 1 {
+		t.Errorf("expected 4 ok + 1 error, got %d ok + %d error", okCount, errCount)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -103,6 +103,14 @@ export const api = {
   // Wanted
   listWanted: () => request<Book[]>('/wanted/missing'),
 
+  // Bulk actions
+  bulkActionAuthors: (ids: number[], action: AuthorBulkAction) =>
+    request<BulkResult>('/author/bulk', { method: 'POST', body: JSON.stringify({ ids, action }) }),
+  bulkActionBooks: (ids: number[], action: BookBulkAction, mediaType?: 'ebook' | 'audiobook') =>
+    request<BulkResult>('/book/bulk', { method: 'POST', body: JSON.stringify({ ids, action, ...(mediaType ? { mediaType } : {}) }) }),
+  bulkActionWanted: (ids: number[], action: WantedBulkAction) =>
+    request<BulkResult>('/wanted/bulk', { method: 'POST', body: JSON.stringify({ ids, action }) }),
+
   // Indexers
   listIndexers: () => request<Indexer[]>('/indexer'),
   addIndexer: (data: Partial<Indexer>) => request<Indexer>('/indexer', { method: 'POST', body: JSON.stringify(data) }),
@@ -389,4 +397,12 @@ export interface CustomFormat {
     negate: boolean
     required: boolean
   }>
+}
+
+export type AuthorBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search'
+export type BookBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search' | 'set_media_type'
+export type WantedBulkAction = 'search' | 'blocklist' | 'unmonitor'
+
+export interface BulkResult {
+  results: Record<string, { ok: boolean; error?: string }>
 }

--- a/web/src/components/BulkActionBar.tsx
+++ b/web/src/components/BulkActionBar.tsx
@@ -1,0 +1,51 @@
+export interface BulkAction {
+  label: string
+  onClick: () => void
+  variant?: 'default' | 'danger'
+}
+
+interface BulkActionBarProps {
+  count: number
+  actions: BulkAction[]
+  onClear: () => void
+  busy?: boolean
+}
+
+/**
+ * Sticky footer shown whenever one or more items are selected on a list page.
+ * Renders nothing when count === 0 so callers don't need conditional wrapping.
+ */
+export default function BulkActionBar({ count, actions, onClear, busy = false }: BulkActionBarProps) {
+  if (count === 0) return null
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-between gap-4 px-6 py-3 bg-slate-800 dark:bg-zinc-950 border-t border-slate-600 dark:border-zinc-700 shadow-xl">
+      <span className="text-sm font-medium text-white shrink-0">
+        {count} selected
+      </span>
+      <div className="flex items-center gap-2 flex-wrap justify-end">
+        {actions.map((action) => (
+          <button
+            key={action.label}
+            onClick={action.onClick}
+            disabled={busy}
+            className={`px-3 py-1.5 rounded text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+              action.variant === 'danger'
+                ? 'bg-red-600 hover:bg-red-500 text-white'
+                : 'bg-slate-600 hover:bg-slate-500 dark:bg-zinc-700 dark:hover:bg-zinc-600 text-white'
+            }`}
+          >
+            {action.label}
+          </button>
+        ))}
+        <button
+          onClick={onClear}
+          disabled={busy}
+          className="px-3 py-1.5 rounded text-xs font-medium text-slate-400 hover:text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useRef, useState, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { api, Author } from '../api/client'
 import AddAuthorModal from '../components/AddAuthorModal'
+import BulkActionBar from '../components/BulkActionBar'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
 import ViewToggle from '../components/ViewToggle'
@@ -24,6 +25,9 @@ export default function AuthorsPage() {
     return ''
   })
   const [view, setView] = useView('authors', 'grid')
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [bulkBusy, setBulkBusy] = useState(false)
+  const selectAllRef = useRef<HTMLInputElement>(null)
 
   const load = () => {
     setLoading(true)
@@ -37,9 +41,6 @@ export default function AuthorsPage() {
   }, [monitoredFilter])
 
   const handleDelete = async (id: number) => {
-    // Peek at the author's books so the confirm can offer to sweep files.
-    // Small extra roundtrip, but the list view doesn't otherwise carry
-    // per-book filePaths and we don't want to silently orphan them.
     let withFiles = 0
     let total = 0
     try {
@@ -73,7 +74,6 @@ export default function AuthorsPage() {
     }
     if (sort === 'az') list = [...list].sort((a, b) => a.authorName.localeCompare(b.authorName))
     else if (sort === 'za') list = [...list].sort((a, b) => b.authorName.localeCompare(a.authorName))
-    // 'recent' keeps server order (typically by id desc)
     return list
   }, [authors, monitoredFilter, search, sort])
 
@@ -81,11 +81,45 @@ export default function AuthorsPage() {
 
   useEffect(() => { reset() }, [search, sort, monitoredFilter, reset])
 
+  // Keep the select-all checkbox indeterminate state in sync.
+  const allPageSelected = pageItems.length > 0 && pageItems.every(a => selectedIds.has(a.id))
+  const somePageSelected = pageItems.some(a => selectedIds.has(a.id)) && !allPageSelected
+  useEffect(() => {
+    if (selectAllRef.current) selectAllRef.current.indeterminate = somePageSelected
+  }, [somePageSelected])
+
+  const toggleSelect = (id: number) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const selectAllOnPage = () => setSelectedIds(new Set(pageItems.map(a => a.id)))
+  const clearSelection = () => setSelectedIds(new Set())
+
+  const runBulk = async (action: Parameters<typeof api.bulkActionAuthors>[1]) => {
+    if (selectedIds.size === 0) return
+    if (action === 'delete' && !confirm(`Delete ${selectedIds.size} author(s) and all their books?`)) return
+    setBulkBusy(true)
+    try {
+      await api.bulkActionAuthors([...selectedIds], action)
+      clearSelection()
+      load()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Bulk action failed')
+    } finally {
+      setBulkBusy(false)
+    }
+  }
+
   const sortBtnCls = (active: boolean) =>
     `px-3 py-1 rounded-md text-xs font-medium transition-colors ${active ? 'bg-slate-300 dark:bg-zinc-700 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'}`
 
   return (
-    <div>
+    <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-bold">Authors</h2>
         <div className="flex items-center gap-3">
@@ -140,6 +174,16 @@ export default function AuthorsPage() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="bg-slate-100 dark:bg-zinc-900 border-b border-slate-200 dark:border-zinc-800">
+                  <th className="px-3 py-2 w-8">
+                    <input
+                      ref={selectAllRef}
+                      type="checkbox"
+                      checked={allPageSelected}
+                      onChange={e => e.target.checked ? selectAllOnPage() : clearSelection()}
+                      className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+                      title="Select all on this page"
+                    />
+                  </th>
                   <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Name</th>
                   <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Books</th>
                   <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Rating</th>
@@ -149,7 +193,19 @@ export default function AuthorsPage() {
               </thead>
               <tbody className="divide-y divide-slate-200 dark:divide-zinc-800">
                 {pageItems.map(author => (
-                  <tr key={author.id} className="bg-slate-100/50 dark:bg-zinc-900/50 hover:bg-slate-200/50 dark:hover:bg-zinc-800/50">
+                  <tr
+                    key={author.id}
+                    className={`hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 ${selectedIds.has(author.id) ? 'bg-emerald-500/10 dark:bg-emerald-500/10' : 'bg-slate-100/50 dark:bg-zinc-900/50'}`}
+                  >
+                    <td className="px-3 py-2 w-8">
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.has(author.id)}
+                        onChange={() => toggleSelect(author.id)}
+                        className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+                        onClick={e => e.stopPropagation()}
+                      />
+                    </td>
                     <td className="px-3 py-2">
                       <Link to={`/author/${author.id}`} className="flex items-center gap-2">
                         {author.imageUrl ? (
@@ -197,22 +253,34 @@ export default function AuthorsPage() {
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
           {pageItems.map(author => (
-            <div key={author.id} className="border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden hover:border-emerald-500 transition-colors">
-              <Link to={`/author/${author.id}`} className="flex gap-3 p-4 hover:bg-slate-200/40 dark:hover:bg-zinc-800/40 transition-colors">
-                {author.imageUrl ? (
-                  <img src={author.imageUrl} alt={author.authorName} className="w-16 h-16 rounded-full object-cover flex-shrink-0" />
-                ) : (
-                  <div className="w-16 h-16 rounded-full bg-slate-200 dark:bg-zinc-800 flex items-center justify-center flex-shrink-0 text-xl font-bold text-slate-500 dark:text-zinc-600">
-                    {author.authorName.charAt(0)}
+            <div
+              key={author.id}
+              className={`border rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden hover:border-emerald-500 transition-colors ${selectedIds.has(author.id) ? 'border-emerald-500' : 'border-slate-200 dark:border-zinc-800'}`}
+            >
+              <div className="relative">
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(author.id)}
+                  onChange={() => toggleSelect(author.id)}
+                  className="absolute top-2 left-2 z-10 rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 bg-white/80 dark:bg-zinc-900/80"
+                  title={`Select ${author.authorName}`}
+                />
+                <Link to={`/author/${author.id}`} className="flex gap-3 p-4 hover:bg-slate-200/40 dark:hover:bg-zinc-800/40 transition-colors">
+                  {author.imageUrl ? (
+                    <img src={author.imageUrl} alt={author.authorName} className="w-16 h-16 rounded-full object-cover flex-shrink-0" />
+                  ) : (
+                    <div className="w-16 h-16 rounded-full bg-slate-200 dark:bg-zinc-800 flex items-center justify-center flex-shrink-0 text-xl font-bold text-slate-500 dark:text-zinc-600">
+                      {author.authorName.charAt(0)}
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <h3 className="font-semibold truncate">{author.authorName}</h3>
+                    <p className="text-xs text-slate-600 dark:text-zinc-500 mt-1 line-clamp-2">
+                      {author.description || 'No description available'}
+                    </p>
                   </div>
-                )}
-                <div className="min-w-0">
-                  <h3 className="font-semibold truncate">{author.authorName}</h3>
-                  <p className="text-xs text-slate-600 dark:text-zinc-500 mt-1 line-clamp-2">
-                    {author.description || 'No description available'}
-                  </p>
-                </div>
-              </Link>
+                </Link>
+              </div>
               <div className="flex items-center justify-between px-4 py-2 bg-slate-200/50 dark:bg-zinc-800/50 border-t border-slate-200 dark:border-zinc-800">
                 <button
                   onClick={() => handleToggleMonitored(author)}
@@ -241,6 +309,18 @@ export default function AuthorsPage() {
         </div>
       )}
       <Pagination {...paginationProps} />
+
+      <BulkActionBar
+        count={selectedIds.size}
+        onClear={clearSelection}
+        busy={bulkBusy}
+        actions={[
+          { label: 'Monitor', onClick: () => runBulk('monitor') },
+          { label: 'Unmonitor', onClick: () => runBulk('unmonitor') },
+          { label: 'Search', onClick: () => runBulk('search') },
+          { label: 'Delete', onClick: () => runBulk('delete'), variant: 'danger' },
+        ]}
+      />
 
       {showAdd && <AddAuthorModal onClose={() => setShowAdd(false)} onAdded={load} />}
     </div>

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import ViewToggle from '../components/ViewToggle'
 import { useView } from '../components/useView'
 import { api, Book } from '../api/client'
+import BulkActionBar from '../components/BulkActionBar'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
 
@@ -32,9 +33,16 @@ export default function BooksPage() {
   const [search, setSearch] = useState('')
   const [sort, setSort] = useState<SortMode>('title-az')
   const [view, setView] = useView('books', 'grid')
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [bulkBusy, setBulkBusy] = useState(false)
+  const selectAllRef = useRef<HTMLInputElement>(null)
+
+  const load = () => {
+    api.listBooks().then(setBooks).catch(console.error).finally(() => setLoading(false))
+  }
 
   useEffect(() => {
-    api.listBooks().then(setBooks).catch(console.error).finally(() => setLoading(false))
+    load()
   }, [])
 
   const filtered = useMemo(() => {
@@ -67,6 +75,40 @@ export default function BooksPage() {
 
   useEffect(() => { reset() }, [statusFilter, mediaFilter, search, sort, reset])
 
+  // Keep the select-all checkbox indeterminate state in sync.
+  const allPageSelected = pageItems.length > 0 && pageItems.every(b => selectedIds.has(b.id))
+  const somePageSelected = pageItems.some(b => selectedIds.has(b.id)) && !allPageSelected
+  useEffect(() => {
+    if (selectAllRef.current) selectAllRef.current.indeterminate = somePageSelected
+  }, [somePageSelected])
+
+  const toggleSelect = (id: number) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const selectAllOnPage = () => setSelectedIds(new Set(pageItems.map(b => b.id)))
+  const clearSelection = () => setSelectedIds(new Set())
+
+  const runBulk = async (action: Parameters<typeof api.bulkActionBooks>[1], mediaType?: 'ebook' | 'audiobook') => {
+    if (selectedIds.size === 0) return
+    if (action === 'delete' && !confirm(`Delete ${selectedIds.size} book(s)?`)) return
+    setBulkBusy(true)
+    try {
+      await api.bulkActionBooks([...selectedIds], action, mediaType)
+      clearSelection()
+      load()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Bulk action failed')
+    } finally {
+      setBulkBusy(false)
+    }
+  }
+
   const statusBtnCls = (active: boolean) =>
     `px-3 py-1 rounded-md text-xs font-medium transition-colors ${active ? 'bg-slate-300 dark:bg-zinc-700 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white'}`
 
@@ -74,7 +116,7 @@ export default function BooksPage() {
     `px-3 py-1 rounded-md text-xs font-medium transition-colors ${active ? 'bg-slate-300 dark:bg-zinc-700 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'}`
 
   return (
-    <div>
+    <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-bold">Books</h2>
         <div className="flex items-center gap-3">
@@ -131,6 +173,16 @@ export default function BooksPage() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="bg-slate-100 dark:bg-zinc-900 border-b border-slate-200 dark:border-zinc-800">
+                  <th className="px-3 py-2 w-8">
+                    <input
+                      ref={selectAllRef}
+                      type="checkbox"
+                      checked={allPageSelected}
+                      onChange={e => e.target.checked ? selectAllOnPage() : clearSelection()}
+                      className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+                      title="Select all on this page"
+                    />
+                  </th>
                   <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Title</th>
                   <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase hidden md:table-cell">Author</th>
                   <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase hidden sm:table-cell">Year</th>
@@ -142,9 +194,17 @@ export default function BooksPage() {
                 {pageItems.map(book => (
                   <tr
                     key={book.id}
-                    className="bg-slate-100/50 dark:bg-zinc-900/50 hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 cursor-pointer"
+                    className={`hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 cursor-pointer ${selectedIds.has(book.id) ? 'bg-emerald-500/10 dark:bg-emerald-500/10' : 'bg-slate-100/50 dark:bg-zinc-900/50'}`}
                     onClick={() => (window.location.href = `/book/${book.id}`)}
                   >
+                    <td className="px-3 py-2 w-8" onClick={e => e.stopPropagation()}>
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.has(book.id)}
+                        onChange={() => toggleSelect(book.id)}
+                        className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+                      />
+                    </td>
                     <td className="px-3 py-2">
                       <Link to={`/book/${book.id}`} className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
                         {book.imageUrl ? (
@@ -184,24 +244,33 @@ export default function BooksPage() {
         ) : (
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
           {pageItems.map(book => (
-            <Link
+            <div
               key={book.id}
-              to={`/book/${book.id}`}
-              className="border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden group text-left hover:border-emerald-500 transition-colors block"
+              className={`border rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden group text-left transition-colors ${selectedIds.has(book.id) ? 'border-emerald-500' : 'border-slate-200 dark:border-zinc-800 hover:border-emerald-500'}`}
             >
               <div className="aspect-[2/3] bg-slate-200 dark:bg-zinc-800 relative">
-                {book.imageUrl ? (
-                  <img src={book.imageUrl} alt={book.title} className="w-full h-full object-cover" />
-                ) : (
-                  <div className="w-full h-full flex items-center justify-center p-3 text-center">
-                    <span className="text-sm text-slate-500 dark:text-zinc-600">{book.title}</span>
-                  </div>
-                )}
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(book.id)}
+                  onChange={() => toggleSelect(book.id)}
+                  className="absolute top-2 left-2 z-10 rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 bg-white/80 dark:bg-zinc-900/80"
+                  title={`Select ${book.title}`}
+                  onClick={e => e.stopPropagation()}
+                />
+                <Link to={`/book/${book.id}`} className="block w-full h-full">
+                  {book.imageUrl ? (
+                    <img src={book.imageUrl} alt={book.title} className="w-full h-full object-cover" />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center p-3 text-center">
+                      <span className="text-sm text-slate-500 dark:text-zinc-600">{book.title}</span>
+                    </div>
+                  )}
+                </Link>
                 <div className={`absolute top-2 right-2 px-2 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
                   {statusLabel[book.status] ?? book.status}
                 </div>
                 {book.mediaType === 'audiobook' && (
-                  <div className="absolute top-2 left-2 px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-600/90 text-white">🎧</div>
+                  <div className="absolute top-2 left-8 px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-600/90 text-white">🎧</div>
                 )}
               </div>
               <div className="p-2">
@@ -225,12 +294,26 @@ export default function BooksPage() {
                   )}
                 </div>
               </div>
-            </Link>
+            </div>
           ))}
         </div>
         )
       )}
       <Pagination {...paginationProps} />
+
+      <BulkActionBar
+        count={selectedIds.size}
+        onClear={clearSelection}
+        busy={bulkBusy}
+        actions={[
+          { label: 'Monitor', onClick: () => runBulk('monitor') },
+          { label: 'Unmonitor', onClick: () => runBulk('unmonitor') },
+          { label: 'Search', onClick: () => runBulk('search') },
+          { label: '📖 Set Ebook', onClick: () => runBulk('set_media_type', 'ebook') },
+          { label: '🎧 Set Audiobook', onClick: () => runBulk('set_media_type', 'audiobook') },
+          { label: 'Delete', onClick: () => runBulk('delete'), variant: 'danger' },
+        ]}
+      />
     </div>
   )
 }

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useRef, useState, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { api, Book, SearchResult } from '../api/client'
+import BulkActionBar from '../components/BulkActionBar'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
 
@@ -14,9 +15,16 @@ export default function WantedPage() {
   const [grabbingGuid, setGrabbingGuid] = useState<string | null>(null)
   const [grabbedGuid, setGrabbedGuid] = useState<string | null>(null)
   const [unmonitoringId, setUnmonitoringId] = useState<number | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [bulkBusy, setBulkBusy] = useState(false)
+  const selectAllRef = useRef<HTMLInputElement>(null)
+
+  const load = () => {
+    api.listWanted().then(setBooks).catch(console.error).finally(() => setLoading(false))
+  }
 
   useEffect(() => {
-    api.listWanted().then(setBooks).catch(console.error).finally(() => setLoading(false))
+    load()
   }, [])
 
   const filtered = useMemo(() => {
@@ -91,6 +99,39 @@ export default function WantedPage() {
 
   useEffect(() => { reset() }, [search, reset])
 
+  // Keep the select-all checkbox indeterminate state in sync.
+  const allPageSelected = pageItems.length > 0 && pageItems.every(b => selectedIds.has(b.id))
+  const somePageSelected = pageItems.some(b => selectedIds.has(b.id)) && !allPageSelected
+  useEffect(() => {
+    if (selectAllRef.current) selectAllRef.current.indeterminate = somePageSelected
+  }, [somePageSelected])
+
+  const toggleSelect = (id: number) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const selectAllOnPage = () => setSelectedIds(new Set(pageItems.map(b => b.id)))
+  const clearSelection = () => setSelectedIds(new Set())
+
+  const runBulk = async (action: Parameters<typeof api.bulkActionWanted>[1]) => {
+    if (selectedIds.size === 0) return
+    setBulkBusy(true)
+    try {
+      await api.bulkActionWanted([...selectedIds], action)
+      clearSelection()
+      load()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Bulk action failed')
+    } finally {
+      setBulkBusy(false)
+    }
+  }
+
   const formatSize = (bytes: number) => {
     if (bytes > 1073741824) return (bytes / 1073741824).toFixed(1) + ' GB'
     if (bytes > 1048576) return (bytes / 1048576).toFixed(1) + ' MB'
@@ -98,7 +139,7 @@ export default function WantedPage() {
   }
 
   return (
-    <div>
+    <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-bold">Wanted</h2>
         <span className="text-sm text-slate-600 dark:text-zinc-500">{filtered.length} of {books.length}</span>
@@ -123,97 +164,130 @@ export default function WantedPage() {
           <p>No books match your search.</p>
         </div>
       ) : (
-        <div className="space-y-2">
-          {pageItems.map(book => (
-            <div key={book.id}>
-              <div className="flex items-center justify-between p-3 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
-                <div className="flex items-center gap-3 min-w-0">
-                  {book.imageUrl && (
-                    <img src={book.imageUrl} alt="" className="w-10 h-14 object-cover rounded flex-shrink-0" />
-                  )}
-                  <div className="min-w-0">
-                    <Link to={`/book/${book.id}`} className="font-medium text-sm truncate block hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">
-                      {book.title}
-                    </Link>
-                    {book.author && (
-                      <Link
-                        to={`/author/${book.authorId}`}
-                        className="text-[11px] text-slate-500 dark:text-zinc-500 hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors truncate block"
-                      >
-                        {book.author.authorName}
+        <>
+          {/* Select-all row */}
+          <div className="flex items-center gap-2 mb-2 px-1">
+            <input
+              ref={selectAllRef}
+              type="checkbox"
+              checked={allPageSelected}
+              onChange={e => e.target.checked ? selectAllOnPage() : clearSelection()}
+              className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+              title="Select all on this page"
+            />
+            <span className="text-xs text-slate-500 dark:text-zinc-500">Select all on this page</span>
+          </div>
+
+          <div className="space-y-2">
+            {pageItems.map(book => (
+              <div key={book.id}>
+                <div className={`flex items-center justify-between p-3 border rounded-lg transition-colors ${selectedIds.has(book.id) ? 'border-emerald-500 bg-emerald-500/5 dark:bg-emerald-500/5' : 'border-slate-200 dark:border-zinc-800 bg-slate-100 dark:bg-zinc-900'}`}>
+                  <div className="flex items-center gap-3 min-w-0">
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(book.id)}
+                      onChange={() => toggleSelect(book.id)}
+                      className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 flex-shrink-0"
+                      title={`Select ${book.title}`}
+                    />
+                    {book.imageUrl && (
+                      <img src={book.imageUrl} alt="" className="w-10 h-14 object-cover rounded flex-shrink-0" />
+                    )}
+                    <div className="min-w-0">
+                      <Link to={`/book/${book.id}`} className="font-medium text-sm truncate block hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">
+                        {book.title}
                       </Link>
-                    )}
-                    <div className="flex items-center gap-2 mt-0.5 flex-wrap">
-                      <select
-                        value={book.mediaType || 'ebook'}
-                        onChange={e => changeMediaType(book, e.target.value as 'ebook' | 'audiobook')}
-                        className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded text-[11px] px-1.5 py-0.5 focus:outline-none"
-                        title="Change media type"
-                      >
-                        <option value="ebook">📖 Ebook</option>
-                        <option value="audiobook">🎧 Audiobook</option>
-                      </select>
+                      {book.author && (
+                        <Link
+                          to={`/author/${book.authorId}`}
+                          className="text-[11px] text-slate-500 dark:text-zinc-500 hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors truncate block"
+                        >
+                          {book.author.authorName}
+                        </Link>
+                      )}
+                      <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+                        <select
+                          value={book.mediaType || 'ebook'}
+                          onChange={e => changeMediaType(book, e.target.value as 'ebook' | 'audiobook')}
+                          className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded text-[11px] px-1.5 py-0.5 focus:outline-none"
+                          title="Change media type"
+                        >
+                          <option value="ebook">📖 Ebook</option>
+                          <option value="audiobook">🎧 Audiobook</option>
+                        </select>
+                      </div>
+                      {book.releaseDate && (
+                        <p className="text-xs text-slate-600 dark:text-zinc-500">{new Date(book.releaseDate).getFullYear()}</p>
+                      )}
                     </div>
-                    {book.releaseDate && (
-                      <p className="text-xs text-slate-600 dark:text-zinc-500">{new Date(book.releaseDate).getFullYear()}</p>
-                    )}
+                  </div>
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <button
+                      onClick={() => unmonitor(book)}
+                      disabled={unmonitoringId === book.id}
+                      className="px-2 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-amber-100 dark:hover:bg-amber-900/30 hover:text-amber-700 dark:hover:text-amber-400 rounded text-xs font-medium disabled:opacity-50 transition-colors"
+                      title="Stop monitoring this book"
+                    >
+                      {unmonitoringId === book.id ? '…' : 'Unmonitor'}
+                    </button>
+                    <button
+                      onClick={() => searchBook(book)}
+                      disabled={searchingId === book.id}
+                      className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium disabled:opacity-50"
+                    >
+                      {searchingId === book.id ? 'Searching...' : 'Search'}
+                    </button>
                   </div>
                 </div>
-                <div className="flex items-center gap-2 flex-shrink-0">
-                  <button
-                    onClick={() => unmonitor(book)}
-                    disabled={unmonitoringId === book.id}
-                    className="px-2 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-amber-100 dark:hover:bg-amber-900/30 hover:text-amber-700 dark:hover:text-amber-400 rounded text-xs font-medium disabled:opacity-50 transition-colors"
-                    title="Stop monitoring this book"
-                  >
-                    {unmonitoringId === book.id ? '…' : 'Unmonitor'}
-                  </button>
-                  <button
-                    onClick={() => searchBook(book)}
-                    disabled={searchingId === book.id}
-                    className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium disabled:opacity-50"
-                  >
-                    {searchingId === book.id ? 'Searching...' : 'Search'}
-                  </button>
-                </div>
-              </div>
 
-              {showResults === book.id && results.length === 0 && (
-                <div className="mt-1 mb-3 px-3 py-2 bg-slate-200/50 dark:bg-zinc-800/50 rounded text-xs text-slate-600 dark:text-zinc-500">
-                  No results found on any indexer.
-                </div>
-              )}
+                {showResults === book.id && results.length === 0 && (
+                  <div className="mt-1 mb-3 px-3 py-2 bg-slate-200/50 dark:bg-zinc-800/50 rounded text-xs text-slate-600 dark:text-zinc-500">
+                    No results found on any indexer.
+                  </div>
+                )}
 
-              {showResults === book.id && results.length > 0 && (
-                <div className="mt-1 mb-3 space-y-1">
-                  {results.slice(0, 10).map(r => (
-                    <div key={r.guid} className="flex items-center justify-between p-2 bg-slate-200/50 dark:bg-zinc-800/50 rounded text-xs">
-                      <div className="min-w-0 mr-3">
-                        <span className="truncate block">{r.title}</span>
-                        <span className="text-slate-600 dark:text-zinc-500 truncate block">{r.indexerName} &middot; {formatSize(r.size)} &middot; {r.grabs} grabs</span>
+                {showResults === book.id && results.length > 0 && (
+                  <div className="mt-1 mb-3 space-y-1">
+                    {results.slice(0, 10).map(r => (
+                      <div key={r.guid} className="flex items-center justify-between p-2 bg-slate-200/50 dark:bg-zinc-800/50 rounded text-xs">
+                        <div className="min-w-0 mr-3">
+                          <span className="truncate block">{r.title}</span>
+                          <span className="text-slate-600 dark:text-zinc-500 truncate block">{r.indexerName} &middot; {formatSize(r.size)} &middot; {r.grabs} grabs</span>
+                        </div>
+                        <button
+                          onClick={() => grab(r, book)}
+                          disabled={grabbingGuid === r.guid || grabbedGuid === r.guid}
+                          className={`px-2 py-2 rounded text-[10px] font-medium flex-shrink-0 touch-manipulation transition-colors disabled:cursor-default ${
+                            grabbedGuid === r.guid
+                              ? 'bg-emerald-700 text-emerald-200'
+                              : grabbingGuid === r.guid
+                              ? 'bg-emerald-600/60 text-white/70'
+                              : 'bg-emerald-600 hover:bg-emerald-500 text-white'
+                          }`}
+                        >
+                          {grabbedGuid === r.guid ? '✓ Grabbed' : grabbingGuid === r.guid ? 'Grabbing…' : 'Grab'}
+                        </button>
                       </div>
-                      <button
-                        onClick={() => grab(r, book)}
-                        disabled={grabbingGuid === r.guid || grabbedGuid === r.guid}
-                        className={`px-2 py-2 rounded text-[10px] font-medium flex-shrink-0 touch-manipulation transition-colors disabled:cursor-default ${
-                          grabbedGuid === r.guid
-                            ? 'bg-emerald-700 text-emerald-200'
-                            : grabbingGuid === r.guid
-                            ? 'bg-emerald-600/60 text-white/70'
-                            : 'bg-emerald-600 hover:bg-emerald-500 text-white'
-                        }`}
-                      >
-                        {grabbedGuid === r.guid ? '✓ Grabbed' : grabbingGuid === r.guid ? 'Grabbing…' : 'Grab'}
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </>
       )}
       <Pagination {...paginationProps} />
+
+      <BulkActionBar
+        count={selectedIds.size}
+        onClear={clearSelection}
+        busy={bulkBusy}
+        actions={[
+          { label: 'Search', onClick: () => runBulk('search') },
+          { label: 'Unmonitor', onClick: () => runBulk('unmonitor') },
+          { label: 'Blocklist', onClick: () => runBulk('blocklist'), variant: 'danger' },
+        ]}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **Backend** (`internal/api/bulk.go`): three new POST endpoints — `/author/bulk`, `/book/bulk`, `/wanted/bulk` — wired in `cmd/bindery/main.go`. Each accepts `{"ids":[...], "action":"..."}` and returns a per-ID result map at HTTP 200.
- **Frontend**: `BulkActionBar` sticky footer + row checkboxes (table column + grid card overlay) on Authors/Books; checkbox + "Select all on this page" row on Wanted. Three new `api.bulkAction*` methods in `client.ts`.
- **Tests** (`internal/api/bulk_test.go`): 21 tests covering every action + partial-failure scenario (5 IDs, 1 bad → 200 with 4 ok + 1 error entry).

## Partial-failure design

The endpoints return **HTTP 200 with a per-ID result map** rather than all-or-nothing 400. Rationale: bulk operations routinely include stale IDs (page loaded while another session deletes an item); aborting the whole batch on one missing ID is more disruptive than reporting it inline and completing the rest. Response shape:

```json
{"results": {"1": {"ok": true}, "999": {"ok": false, "error": "author not found"}}}
```

## Supported actions

| Endpoint | Actions |
|---|---|
| `POST /author/bulk` | `monitor`, `unmonitor`, `delete`, `search` |
| `POST /book/bulk` | `monitor`, `unmonitor`, `delete`, `search`, `set_media_type` (+ `mediaType` field) |
| `POST /wanted/bulk` | `search`, `unmonitor`, `blocklist` |

`blocklist` on the Wanted page marks the book `monitored=false, status=skipped` so it disappears from the Wanted list and is not auto-searched again.

`search` fires `SearchAndGrabBook` goroutines with a detached background context (same pattern as the existing per-book search) and always returns `ok:true` immediately — outcome visible in History.

Routes follow the existing singular-path convention (`/author/bulk`, `/book/bulk`) to stay consistent with `/blocklist/bulk`; the issue spec used plural for readability.

## Test plan

- [ ] Select individual rows in table view on Authors → Monitor / Unmonitor / Delete / Search
- [ ] Select cards in grid view on Authors using overlay checkboxes
- [ ] "Select all on this page" checkbox (including indeterminate state when partially selected)
- [ ] BulkActionBar appears on selection, disappears on Clear, page has bottom padding
- [ ] Books page: Set Ebook / Set Audiobook changes media type badge
- [ ] Wanted page: Blocklist removes books from list; Unmonitor removes; Search triggers
- [ ] Stale ID in selection (delete one book externally while it's still selected) — other IDs succeed