### PR TITLE
chore(coverage): uplift api + importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The `development` branch carries the in-flight feature set for the next release.
 - **Calibre library integration via `calibredb` ([#32](https://github.com/vavallee/bindery/issues/32))** — after a successful import, Bindery mirrors the book into a configured Calibre library by shelling out to `calibredb add --with-library <path>` and stores the returned Calibre book id on the Bindery book row for future OPDS and cross-library lookups. Opt-in under Settings → General → Calibre with three fields (enabled / library path / binary path) and a Test connection button that probes `calibredb --version`. Failures during the Calibre call are logged and swallowed so a missing binary or unreachable library never rolls back an otherwise-good Bindery import.
 - **Author aliases — merge duplicate authors (e.g. "RR Haywood" / "R.R. Haywood")** ([#45](https://github.com/vavallee/bindery/issues/45)) — new `author_aliases` table plus a **Merge authors** modal on the Authors page (and a Merge button on each author's detail page). Picking a source and target reparents the source's books onto the target, deletes the source row, and preserves the source's name + OpenLibrary id as aliases pointing at the target. The add-author flow now consults the alias table: if the requested name already resolves to an existing author, the POST returns `409 Conflict` with `canonicalAuthorId` so the UI can prompt for merge instead of silently ingesting a duplicate. Two new endpoints: `GET /api/v1/author/{id}/aliases` and `POST /api/v1/author/{id}/merge`. The merge is transactional — if any child update fails, nothing changes.
 
+### Changed
+
+- Raised `internal/api` coverage to 62.7%, `internal/importer` to 62.2%.
+
 ## [v0.7.2] — 2026-04-14
 
 Quality release. Bulk actions land for users curating large libraries (the painful-after-CSV-import flow), the silent library-scan bug is fixed, and backend coverage jumps from 34% to 53% to quiet codecov and harden the regression safety net.

--- a/internal/api/custom_formats_test.go
+++ b/internal/api/custom_formats_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func customFormatFixture(t *testing.T) *CustomFormatHandler {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return NewCustomFormatHandler(db.NewCustomFormatRepo(database))
+}
+
+func TestCustomFormatList_Empty(t *testing.T) {
+	h := customFormatFixture(t)
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/custom-format", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if bytes.TrimSpace(rec.Body.Bytes())[0] != '[' {
+		t.Errorf("expected JSON array, got %s", rec.Body.String())
+	}
+}
+
+func TestCustomFormatCRUD(t *testing.T) {
+	h := customFormatFixture(t)
+
+	// Create
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/custom-format",
+		bytes.NewBufferString(`{"name":"prefer-epub","conditions":[{"type":"releaseTitle","pattern":"epub"}]}`)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created models.CustomFormat
+	json.NewDecoder(rec.Body).Decode(&created)
+	if created.ID == 0 {
+		t.Fatal("expected non-zero ID")
+	}
+
+	// Get
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/custom-format/1", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Errorf("get: expected 200, got %d", rec.Code)
+	}
+
+	// Get — bad id
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/custom-format/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("get bad id: expected 400, got %d", rec.Code)
+	}
+
+	// Get — missing
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/custom-format/999", nil), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("get missing: expected 404, got %d", rec.Code)
+	}
+
+	// Update (omit conditions — handler should default to [])
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/custom-format/1",
+			bytes.NewBufferString(`{"name":"renamed"}`)),
+		"id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Errorf("update: expected 200, got %d", rec.Code)
+	}
+
+	// Update — bad id
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/custom-format/abc", bytes.NewBufferString(`{}`)),
+		"id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("update bad id: expected 400, got %d", rec.Code)
+	}
+
+	// Update — missing
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/custom-format/999", bytes.NewBufferString(`{"name":"x"}`)),
+		"id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("update missing: expected 404, got %d", rec.Code)
+	}
+
+	// Update — bad body
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/custom-format/1", bytes.NewBufferString(`not-json`)),
+		"id", "1"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("update bad body: expected 400, got %d", rec.Code)
+	}
+
+	// Delete
+	rec = httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/custom-format/1", nil), "id", "1"))
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("delete: expected 204, got %d", rec.Code)
+	}
+
+	// Delete — bad id
+	rec = httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/custom-format/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("delete bad id: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestCustomFormatCreate_Validation(t *testing.T) {
+	h := customFormatFixture(t)
+	for _, tc := range []struct {
+		body, desc string
+	}{
+		{`not-json`, "invalid json"},
+		{`{}`, "missing name"},
+	} {
+		rec := httptest.NewRecorder()
+		h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/custom-format", bytes.NewBufferString(tc.body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d", tc.desc, rec.Code)
+		}
+	}
+}

--- a/internal/api/delay_profiles_test.go
+++ b/internal/api/delay_profiles_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func delayProfileFixture(t *testing.T) *DelayProfileHandler {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return NewDelayProfileHandler(db.NewDelayProfileRepo(database))
+}
+
+func TestDelayProfileList_Empty(t *testing.T) {
+	h := delayProfileFixture(t)
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/delay-profile", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if bytes.TrimSpace(rec.Body.Bytes())[0] != '[' {
+		t.Errorf("expected JSON array, got %s", rec.Body.String())
+	}
+}
+
+func TestDelayProfileCRUD(t *testing.T) {
+	h := delayProfileFixture(t)
+
+	// Create (omit preferredProtocol — handler defaults to "usenet")
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/delay-profile",
+		bytes.NewBufferString(`{"usenetDelay":30,"enableUsenet":true}`)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created models.DelayProfile
+	json.NewDecoder(rec.Body).Decode(&created)
+	if created.ID == 0 || created.PreferredProtocol != "usenet" {
+		t.Fatalf("unexpected created: %+v", created)
+	}
+
+	// Get
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/delay-profile/1", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Errorf("get: expected 200, got %d", rec.Code)
+	}
+
+	// Get — bad id
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/delay-profile/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("get bad id: expected 400, got %d", rec.Code)
+	}
+
+	// Get — missing
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/delay-profile/999", nil), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("get missing: expected 404, got %d", rec.Code)
+	}
+
+	// Update
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/delay-profile/1",
+			bytes.NewBufferString(`{"preferredProtocol":"torrent","torrentDelay":15}`)),
+		"id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Errorf("update: expected 200, got %d", rec.Code)
+	}
+
+	// Update — bad id
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/delay-profile/abc", bytes.NewBufferString(`{}`)),
+		"id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("update bad id: expected 400, got %d", rec.Code)
+	}
+
+	// Update — missing
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/delay-profile/999", bytes.NewBufferString(`{}`)),
+		"id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("update missing: expected 404, got %d", rec.Code)
+	}
+
+	// Update — bad body
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/delay-profile/1", bytes.NewBufferString(`not-json`)),
+		"id", "1"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("update bad body: expected 400, got %d", rec.Code)
+	}
+
+	// Delete
+	rec = httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/delay-profile/1", nil), "id", "1"))
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("delete: expected 204, got %d", rec.Code)
+	}
+
+	// Delete — bad id
+	rec = httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/delay-profile/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("delete bad id: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestDelayProfileCreate_BadBody(t *testing.T) {
+	h := delayProfileFixture(t)
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/delay-profile", bytes.NewBufferString(`not-json`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad body: expected 400, got %d", rec.Code)
+	}
+}

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func fileFixture(t *testing.T) (*FileHandler, *db.BookRepo, *models.Author, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	ctx := context.Background()
+	author := &models.Author{ForeignID: "OL1A", Name: "A", SortName: "A"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	return NewFileHandler(books), books, author, ctx
+}
+
+func TestFileDownload_BadID(t *testing.T) {
+	h, _, _, _ := fileFixture(t)
+	rec := httptest.NewRecorder()
+	h.Download(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/file/abc/download", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad id: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestFileDownload_NotFound(t *testing.T) {
+	h, _, _, _ := fileFixture(t)
+	rec := httptest.NewRecorder()
+	h.Download(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/file/999/download", nil), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("missing book: expected 404, got %d", rec.Code)
+	}
+}
+
+func TestFileDownload_NoFilePath(t *testing.T) {
+	h, books, author, ctx := fileFixture(t)
+	book := &models.Book{ForeignID: "OL1B", AuthorID: author.ID, Title: "T"}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	h.Download(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/file/1/download", nil), "id", "1"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("no file path: expected 404, got %d", rec.Code)
+	}
+}
+
+func TestFileDownload_FileMissingOnDisk(t *testing.T) {
+	h, books, author, ctx := fileFixture(t)
+	book := &models.Book{ForeignID: "OL1B", AuthorID: author.ID, Title: "T"}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	// FilePath set to a non-existent path.
+	if err := books.SetFilePath(ctx, book.ID, "/nope/not-a-real-path.epub"); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	h.Download(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/file/1/download", nil), "id", "1"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("file missing on disk: expected 404, got %d", rec.Code)
+	}
+}
+
+func TestFileDownload_EbookFile(t *testing.T) {
+	h, books, author, ctx := fileFixture(t)
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "book.epub")
+	if err := os.WriteFile(path, []byte("epub bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{ForeignID: "OL1B", AuthorID: author.ID, Title: "T"}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.SetFilePath(ctx, book.ID, path); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/file/1/download", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), []byte("epub bytes")) {
+		t.Errorf("body mismatch: got %q", rec.Body.String())
+	}
+	if cd := rec.Header().Get("Content-Disposition"); cd == "" {
+		t.Errorf("expected Content-Disposition header")
+	}
+}
+
+func TestFileDownload_AudiobookDirStreamsZip(t *testing.T) {
+	h, books, author, ctx := fileFixture(t)
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "Title (2020)")
+	if err := os.MkdirAll(filepath.Join(dir, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "part1.m4b"), []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "nested", "cover.jpg"), []byte("b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	book := &models.Book{ForeignID: "OL2B", AuthorID: author.ID, Title: "A", MediaType: models.MediaTypeAudiobook}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.SetFilePath(ctx, book.ID, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/file/1/download", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/zip" {
+		t.Errorf("Content-Type: got %q, want application/zip", ct)
+	}
+
+	// Unzip and check entries are present with forward slashes.
+	zr, err := zip.NewReader(bytes.NewReader(rec.Body.Bytes()), int64(rec.Body.Len()))
+	if err != nil {
+		t.Fatalf("zip reader: %v", err)
+	}
+	names := map[string]bool{}
+	for _, f := range zr.File {
+		names[f.Name] = true
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open %s: %v", f.Name, err)
+		}
+		io.Copy(io.Discard, rc)
+		rc.Close()
+	}
+	if !names["part1.m4b"] || !names["nested/cover.jpg"] {
+		t.Errorf("missing entries in zip: %v", names)
+	}
+}

--- a/internal/api/import_lists_test.go
+++ b/internal/api/import_lists_test.go
@@ -1,0 +1,193 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func importListFixture(t *testing.T) *ImportListHandler {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return NewImportListHandler(db.NewImportListRepo(database))
+}
+
+func TestImportListList_Empty(t *testing.T) {
+	h := importListFixture(t)
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/import-list", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	// Expect [] not null so the UI can render.
+	if bytes.TrimSpace(rec.Body.Bytes())[0] != '[' {
+		t.Errorf("expected JSON array, got %s", rec.Body.String())
+	}
+}
+
+func TestImportListCRUD(t *testing.T) {
+	h := importListFixture(t)
+
+	// Create (name-only; Type should default to "csv")
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/import-list",
+		bytes.NewBufferString(`{"name":"My CSV","url":""}`)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created models.ImportList
+	json.NewDecoder(rec.Body).Decode(&created)
+	if created.ID == 0 || created.Type != "csv" {
+		t.Fatalf("unexpected created list: %+v", created)
+	}
+
+	// Get
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/import-list/1", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Errorf("get: expected 200, got %d", rec.Code)
+	}
+
+	// Get — bad id
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/import-list/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("get bad id: expected 400, got %d", rec.Code)
+	}
+
+	// Get — missing
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/import-list/999", nil), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("get missing: expected 404, got %d", rec.Code)
+	}
+
+	// Update
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/import-list/1",
+			bytes.NewBufferString(`{"name":"Renamed","type":"csv"}`)),
+		"id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Errorf("update: expected 200, got %d", rec.Code)
+	}
+
+	// Update — bad id
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/import-list/abc", bytes.NewBufferString(`{}`)),
+		"id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("update bad id: expected 400, got %d", rec.Code)
+	}
+
+	// Update — missing
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/import-list/999", bytes.NewBufferString(`{"name":"x"}`)),
+		"id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("update missing: expected 404, got %d", rec.Code)
+	}
+
+	// Update — invalid body on existing row
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/import-list/1", bytes.NewBufferString(`not-json`)),
+		"id", "1"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("update bad body: expected 400, got %d", rec.Code)
+	}
+
+	// Delete
+	rec = httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/import-list/1", nil), "id", "1"))
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("delete: expected 204, got %d", rec.Code)
+	}
+
+	// Delete — bad id
+	rec = httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/import-list/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("delete bad id: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestImportListCreate_Validation(t *testing.T) {
+	h := importListFixture(t)
+	for _, tc := range []struct {
+		body string
+		desc string
+	}{
+		{`not-json`, "invalid json"},
+		{`{}`, "missing name"},
+	} {
+		rec := httptest.NewRecorder()
+		h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/import-list", bytes.NewBufferString(tc.body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d", tc.desc, rec.Code)
+		}
+	}
+}
+
+func TestImportListExclusions(t *testing.T) {
+	h := importListFixture(t)
+
+	// List empty
+	rec := httptest.NewRecorder()
+	h.ListExclusions(rec, httptest.NewRequest(http.MethodGet, "/api/v1/import-list/exclusion", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", rec.Code)
+	}
+	if bytes.TrimSpace(rec.Body.Bytes())[0] != '[' {
+		t.Errorf("expected JSON array, got %s", rec.Body.String())
+	}
+
+	// Create — validation
+	rec = httptest.NewRecorder()
+	h.CreateExclusion(rec, httptest.NewRequest(http.MethodPost, "/api/v1/import-list/exclusion",
+		bytes.NewBufferString(`not-json`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("invalid json: expected 400, got %d", rec.Code)
+	}
+	rec = httptest.NewRecorder()
+	h.CreateExclusion(rec, httptest.NewRequest(http.MethodPost, "/api/v1/import-list/exclusion",
+		bytes.NewBufferString(`{}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("missing foreignId: expected 400, got %d", rec.Code)
+	}
+
+	// Create — success
+	rec = httptest.NewRecorder()
+	h.CreateExclusion(rec, httptest.NewRequest(http.MethodPost, "/api/v1/import-list/exclusion",
+		bytes.NewBufferString(`{"foreignId":"OL1A","title":"T","authorName":"A"}`)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Delete
+	rec = httptest.NewRecorder()
+	h.DeleteExclusion(rec, withURLParam(
+		httptest.NewRequest(http.MethodDelete, "/api/v1/import-list/exclusion/1", nil), "id", "1"))
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("delete: expected 204, got %d", rec.Code)
+	}
+
+	// Delete — bad id
+	rec = httptest.NewRecorder()
+	h.DeleteExclusion(rec, withURLParam(
+		httptest.NewRequest(http.MethodDelete, "/api/v1/import-list/exclusion/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad id: expected 400, got %d", rec.Code)
+	}
+}

--- a/internal/api/migrate_test.go
+++ b/internal/api/migrate_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func migrateFixture(t *testing.T, primary metadata.Provider) *MigrateHandler {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return NewMigrateHandler(
+		db.NewAuthorRepo(database),
+		db.NewIndexerRepo(database),
+		db.NewDownloadClientRepo(database),
+		db.NewBlocklistRepo(database),
+		db.NewBookRepo(database),
+		metadata.NewAggregator(primary),
+		nil,
+	)
+}
+
+// multipartBody builds a multipart/form-data body with a single "file" field.
+func multipartBody(t *testing.T, field, filename, content string) (*bytes.Buffer, string) {
+	t.Helper()
+	body := &bytes.Buffer{}
+	w := multipart.NewWriter(body)
+	fw, err := w.CreateFormFile(field, filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(fw, content); err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+	return body, w.FormDataContentType()
+}
+
+func TestMigrate_ImportCSV_BadMultipart(t *testing.T) {
+	h := migrateFixture(t, &stubProvider{})
+
+	// Not multipart at all
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/migrate/csv", bytes.NewBufferString("junk"))
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	h.ImportCSV(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("non-multipart: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestMigrate_ImportCSV_MissingFileField(t *testing.T) {
+	h := migrateFixture(t, &stubProvider{})
+
+	// Multipart with wrong field name
+	body, ct := multipartBody(t, "notfile", "x.csv", "Andy Weir\n")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/migrate/csv", body)
+	req.Header.Set("Content-Type", ct)
+	rec := httptest.NewRecorder()
+	h.ImportCSV(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("no file field: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestMigrate_ImportCSV_Success(t *testing.T) {
+	p := &stubProvider{
+		authors: []models.Author{{Name: "Andy Weir", ForeignID: "OL1A"}},
+	}
+	h := migrateFixture(t, p)
+
+	body, ct := multipartBody(t, "file", "authors.csv", "Andy Weir\n")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/migrate/csv", body)
+	req.Header.Set("Content-Type", ct)
+	rec := httptest.NewRecorder()
+	h.ImportCSV(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Payload should be JSON with "requested" field.
+	var got map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got["requested"]; !ok {
+		t.Errorf("expected requested field in result, got %+v", got)
+	}
+}
+
+func TestMigrate_ImportReadarr_BadMultipart(t *testing.T) {
+	h := migrateFixture(t, &stubProvider{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/migrate/readarr", bytes.NewBufferString("junk"))
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	h.ImportReadarr(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("non-multipart: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestMigrate_ImportReadarr_InvalidDB(t *testing.T) {
+	h := migrateFixture(t, &stubProvider{})
+
+	// Valid multipart with garbage bytes — the SQLite driver should reject it.
+	body, ct := multipartBody(t, "file", "readarr.db", "not a real sqlite file")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/migrate/readarr", body)
+	req.Header.Set("Content-Type", ct)
+	rec := httptest.NewRecorder()
+	h.ImportReadarr(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad sqlite: expected 400, got %d", rec.Code)
+	}
+}

--- a/internal/api/notifications_test.go
+++ b/internal/api/notifications_test.go
@@ -1,0 +1,195 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/notifier"
+)
+
+func notificationFixture(t *testing.T) (*NotificationHandler, *db.NotificationRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	repo := db.NewNotificationRepo(database)
+	return NewNotificationHandler(repo, notifier.New(repo)), repo
+}
+
+func TestNotificationList_Empty(t *testing.T) {
+	h, _ := notificationFixture(t)
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/notification", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if bytes.TrimSpace(rec.Body.Bytes())[0] != '[' {
+		t.Errorf("expected JSON array, got %s", rec.Body.String())
+	}
+}
+
+func TestNotificationCRUD(t *testing.T) {
+	h, _ := notificationFixture(t)
+
+	body := `{"name":"webhook","url":"http://example.invalid/hook","enabled":true,"onGrab":true}`
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/notification", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created models.Notification
+	json.NewDecoder(rec.Body).Decode(&created)
+	if created.ID == 0 {
+		t.Fatal("expected non-zero ID")
+	}
+
+	// Get
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/notification/1", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Errorf("get: expected 200, got %d", rec.Code)
+	}
+
+	// Get — bad id
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/notification/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("get bad id: expected 400, got %d", rec.Code)
+	}
+
+	// Get — missing
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/notification/999", nil), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("get missing: expected 404, got %d", rec.Code)
+	}
+
+	// Update
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/notification/1",
+			bytes.NewBufferString(`{"name":"renamed","url":"http://new.invalid/"}`)),
+		"id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Errorf("update: expected 200, got %d", rec.Code)
+	}
+
+	// Update — bad id
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/notification/abc", bytes.NewBufferString(`{}`)),
+		"id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("update bad id: expected 400, got %d", rec.Code)
+	}
+
+	// Update — missing
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/notification/999", bytes.NewBufferString(`{"name":"x"}`)),
+		"id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("update missing: expected 404, got %d", rec.Code)
+	}
+
+	// Update — invalid body on existing row
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(
+		httptest.NewRequest(http.MethodPut, "/api/v1/notification/1", bytes.NewBufferString(`not-json`)),
+		"id", "1"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("update bad body: expected 400, got %d", rec.Code)
+	}
+
+	// Delete
+	rec = httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/notification/1", nil), "id", "1"))
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("delete: expected 204, got %d", rec.Code)
+	}
+
+	// Delete — bad id
+	rec = httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/notification/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("delete bad id: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestNotificationCreate_Validation(t *testing.T) {
+	h, _ := notificationFixture(t)
+	for _, tc := range []struct {
+		body, desc string
+	}{
+		{`not-json`, "invalid json"},
+		{`{}`, "missing name and url"},
+		{`{"name":"x"}`, "missing url"},
+		{`{"url":"http://x"}`, "missing name"},
+	} {
+		rec := httptest.NewRecorder()
+		h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/notification", bytes.NewBufferString(tc.body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d", tc.desc, rec.Code)
+		}
+	}
+}
+
+func TestNotificationTest_NotFound(t *testing.T) {
+	h, _ := notificationFixture(t)
+
+	// Bad id
+	rec := httptest.NewRecorder()
+	h.Test(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/notification/abc/test", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad id: expected 400, got %d", rec.Code)
+	}
+
+	// Missing
+	rec = httptest.NewRecorder()
+	h.Test(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/notification/999/test", nil), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("missing: expected 404, got %d", rec.Code)
+	}
+}
+
+// TestNotificationTest_Webhook runs a real HTTP test against a local server so
+// Notifier.send is exercised and the 200 path is covered.
+func TestNotificationTest_Webhook(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	h, repo := notificationFixture(t)
+	n := &models.Notification{
+		Name:    "webhook",
+		URL:     srv.URL,
+		Enabled: true,
+	}
+	if err := repo.Create(contextBackground(), n); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Test(rec, withURLParam(
+		httptest.NewRequest(http.MethodPost, "/api/v1/notification/1/test", nil),
+		"id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(gotBody, "Bindery notification test") {
+		t.Errorf("expected test payload to be delivered, got %q", gotBody)
+	}
+}

--- a/internal/api/quality_profiles_test.go
+++ b/internal/api/quality_profiles_test.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+)
+
+func qualityProfileFixture(t *testing.T) *QualityProfileHandler {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return NewQualityProfileHandler(db.NewQualityProfileRepo(database))
+}
+
+func TestQualityProfileList_Empty(t *testing.T) {
+	h := qualityProfileFixture(t)
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/quality-profile", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if bytes.TrimSpace(rec.Body.Bytes())[0] != '[' {
+		t.Errorf("expected JSON array, got %s", rec.Body.String())
+	}
+}
+
+func TestQualityProfileGet(t *testing.T) {
+	h := qualityProfileFixture(t)
+
+	// Bad id
+	rec := httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/quality-profile/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad id: expected 400, got %d", rec.Code)
+	}
+
+	// Missing
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/quality-profile/999", nil), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("missing: expected 404, got %d", rec.Code)
+	}
+}

--- a/internal/api/search_test.go
+++ b/internal/api/search_test.go
@@ -1,0 +1,139 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// stubProvider implements metadata.Provider for search handler tests.
+type stubProvider struct {
+	authors      []models.Author
+	authorsErr   error
+	books        []models.Book
+	booksErr     error
+	byISBN       *models.Book
+	byISBNErr    error
+}
+
+func (s *stubProvider) Name() string { return "stub" }
+func (s *stubProvider) SearchAuthors(context.Context, string) ([]models.Author, error) {
+	return s.authors, s.authorsErr
+}
+func (s *stubProvider) SearchBooks(context.Context, string) ([]models.Book, error) {
+	return s.books, s.booksErr
+}
+func (s *stubProvider) GetAuthor(context.Context, string) (*models.Author, error) {
+	return nil, nil
+}
+func (s *stubProvider) GetBook(context.Context, string) (*models.Book, error) {
+	return nil, nil
+}
+func (s *stubProvider) GetEditions(context.Context, string) ([]models.Edition, error) {
+	return nil, nil
+}
+func (s *stubProvider) GetBookByISBN(context.Context, string) (*models.Book, error) {
+	return s.byISBN, s.byISBNErr
+}
+
+func TestSearchAuthors(t *testing.T) {
+	p := &stubProvider{authors: []models.Author{{Name: "Frank Herbert"}}}
+	h := NewSearchHandler(metadata.NewAggregator(p))
+
+	// Missing term
+	rec := httptest.NewRecorder()
+	h.SearchAuthors(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/author", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("missing term: expected 400, got %d", rec.Code)
+	}
+
+	// Success
+	rec = httptest.NewRecorder()
+	h.SearchAuthors(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/author?term=herbert", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var got []models.Author
+	json.NewDecoder(rec.Body).Decode(&got)
+	if len(got) != 1 || got[0].Name != "Frank Herbert" {
+		t.Errorf("unexpected authors: %+v", got)
+	}
+
+	// Error propagation
+	p.authorsErr = errors.New("upstream down")
+	rec = httptest.NewRecorder()
+	h.SearchAuthors(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/author?term=x", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("error: expected 500, got %d", rec.Code)
+	}
+}
+
+func TestSearchBooks(t *testing.T) {
+	p := &stubProvider{books: []models.Book{{Title: "Dune"}}}
+	h := NewSearchHandler(metadata.NewAggregator(p))
+
+	// Missing term
+	rec := httptest.NewRecorder()
+	h.SearchBooks(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/book", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("missing term: expected 400, got %d", rec.Code)
+	}
+
+	// Success
+	rec = httptest.NewRecorder()
+	h.SearchBooks(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/book?term=dune", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	// Error
+	p.booksErr = errors.New("upstream down")
+	rec = httptest.NewRecorder()
+	h.SearchBooks(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/book?term=x", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("error: expected 500, got %d", rec.Code)
+	}
+}
+
+func TestLookupByISBN(t *testing.T) {
+	p := &stubProvider{byISBN: &models.Book{Title: "Hyperion", Description: "A long-enough description to skip the enrichment branch in the aggregator."}}
+	h := NewSearchHandler(metadata.NewAggregator(p))
+
+	// Missing isbn
+	rec := httptest.NewRecorder()
+	h.LookupByISBN(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/isbn", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("missing isbn: expected 400, got %d", rec.Code)
+	}
+
+	// Success
+	rec = httptest.NewRecorder()
+	h.LookupByISBN(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/isbn?isbn=9780553283686", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	// Not found — fresh aggregator so nothing is cached
+	p2 := &stubProvider{byISBN: nil}
+	h2 := NewSearchHandler(metadata.NewAggregator(p2))
+	rec = httptest.NewRecorder()
+	h2.LookupByISBN(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/isbn?isbn=0000000000", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("not found: expected 404, got %d", rec.Code)
+	}
+
+	// Error
+	p3 := &stubProvider{byISBNErr: errors.New("net down")}
+	h3 := NewSearchHandler(metadata.NewAggregator(p3))
+	rec = httptest.NewRecorder()
+	h3.LookupByISBN(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/isbn?isbn=fail", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("error: expected 500, got %d", rec.Code)
+	}
+}

--- a/internal/api/search_test.go
+++ b/internal/api/search_test.go
@@ -14,12 +14,12 @@ import (
 
 // stubProvider implements metadata.Provider for search handler tests.
 type stubProvider struct {
-	authors      []models.Author
-	authorsErr   error
-	books        []models.Book
-	booksErr     error
-	byISBN       *models.Book
-	byISBNErr    error
+	authors    []models.Author
+	authorsErr error
+	books      []models.Book
+	booksErr   error
+	byISBN     *models.Book
+	byISBNErr  error
 }
 
 func (s *stubProvider) Name() string { return "stub" }

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func seriesFixture(t *testing.T) (*SeriesHandler, *db.SeriesRepo, *db.AuthorRepo, *db.BookRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	repo := db.NewSeriesRepo(database)
+	return NewSeriesHandler(repo), repo, db.NewAuthorRepo(database), db.NewBookRepo(database)
+}
+
+func TestSeriesList_Empty(t *testing.T) {
+	h, _, _, _ := seriesFixture(t)
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/series", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if bytes.TrimSpace(rec.Body.Bytes())[0] != '[' {
+		t.Errorf("expected JSON array, got %s", rec.Body.String())
+	}
+}
+
+func TestSeriesGet_BadID(t *testing.T) {
+	h, _, _, _ := seriesFixture(t)
+	rec := httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/series/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad id: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestSeriesGet_NotFound(t *testing.T) {
+	h, _, _, _ := seriesFixture(t)
+	rec := httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/series/999", nil), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("missing: expected 404, got %d", rec.Code)
+	}
+}
+
+// TestSeriesListAndGet_WithData creates a series with linked books so the
+// happy path (List returns rows; Get returns the Books array non-null) is
+// covered.
+func TestSeriesListAndGet_WithData(t *testing.T) {
+	h, seriesRepo, authorRepo, bookRepo := seriesFixture(t)
+	ctx := contextBackground()
+
+	author := &models.Author{ForeignID: "OL1A", Name: "A", SortName: "A"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{ForeignID: "OL1B", AuthorID: author.ID, Title: "Book One", Status: models.BookStatusWanted}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &models.Series{ForeignID: "OLSER1", Title: "Series One"}
+	if err := seriesRepo.Create(ctx, s); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, s.ID, book.ID, "1", true); err != nil {
+		t.Fatal(err)
+	}
+
+	// List
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/series", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", rec.Code)
+	}
+	var list []models.Series
+	json.NewDecoder(rec.Body).Decode(&list)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 series, got %d", len(list))
+	}
+
+	// Get with books
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/series/1", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d", rec.Code)
+	}
+	var got models.Series
+	json.NewDecoder(rec.Body).Decode(&got)
+	if len(got.Books) != 1 || got.Books[0].BookID != book.ID {
+		t.Errorf("expected linked book in series, got %+v", got.Books)
+	}
+}

--- a/internal/importer/helpers_test.go
+++ b/internal/importer/helpers_test.go
@@ -1,0 +1,196 @@
+package importer
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestAudiobookDestDir verifies the audiobook template drops the per-file
+// parts (no {ext}) so the caller can move a whole download folder into it.
+func TestAudiobookDestDir(t *testing.T) {
+	r := NewRenamer("") // both templates default
+	releaseDate := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	author := &models.Author{Name: "Ursula K. Le Guin"}
+	book := &models.Book{Title: "The Dispossessed", ReleaseDate: &releaseDate}
+
+	got := r.AudiobookDestDir("/audio", author, book)
+	want := filepath.Join("/audio", "Ursula K. Le Guin", "The Dispossessed (2020)")
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestAudiobookDestDir_NilAuthor(t *testing.T) {
+	// When author is unknown we fall back to "Unknown Author" so imports
+	// still land under a predictable folder rather than panicking.
+	r := NewRenamer("")
+	book := &models.Book{Title: "Mystery"}
+	got := r.AudiobookDestDir("/audio", nil, book)
+	want := filepath.Join("/audio", "Unknown Author", "Mystery ()")
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestAudiobookDestDir_CustomTemplate(t *testing.T) {
+	r := NewRenamerWithAudiobook("", "Audiobooks/{SortAuthor}/{Title}")
+	author := &models.Author{Name: "Andy Weir"}
+	book := &models.Book{Title: "Project Hail Mary"}
+	got := r.AudiobookDestDir("/root", author, book)
+	want := filepath.Join("/root", "Audiobooks", "Weir, Andy", "Project Hail Mary")
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestDefaultNamingTemplate(t *testing.T) {
+	tmpl := DefaultNamingTemplate()
+	if tmpl == "" {
+		t.Fatal("expected a non-empty default template")
+	}
+	// All four substitutions must be present — callers (config UI, defaults
+	// loader) rely on the template exposing these placeholders.
+	for _, sub := range []string{"{Author}", "{Title}", "{Year}", "{ext}"} {
+		found := false
+		for i := 0; i+len(sub) <= len(tmpl); i++ {
+			if tmpl[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("default template missing %s: %q", sub, tmpl)
+		}
+	}
+}
+
+func TestNowYear(t *testing.T) {
+	got := NowYear()
+	n, err := strconv.Atoi(got)
+	if err != nil {
+		t.Fatalf("NowYear should return a numeric string, got %q: %v", got, err)
+	}
+	curr := time.Now().Year()
+	if n < curr-1 || n > curr+1 {
+		t.Errorf("NowYear returned %d; expected near %d", n, curr)
+	}
+}
+
+// TestCopyFile exercises the cross-filesystem fallback that MoveFile
+// uses when os.Rename fails. Called directly here because rename always
+// succeeds within a single temp dir — the slow path would otherwise be
+// unreachable in unit tests.
+func TestCopyFile(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src.epub")
+	dst := filepath.Join(tmp, "out", "dst.epub")
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "payload" {
+		t.Errorf("content mismatch: %q", string(got))
+	}
+	// Source still exists because copyFile alone doesn't delete it.
+	if _, err := os.Stat(src); err != nil {
+		t.Errorf("source should still exist after copyFile: %v", err)
+	}
+}
+
+func TestCopyFile_BadSource(t *testing.T) {
+	if err := copyFile("/nope/does-not-exist", "/tmp/out"); err == nil {
+		t.Error("expected error copying missing source")
+	}
+}
+
+func TestCopyFile_BadDest(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	if err := os.WriteFile(src, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Dest dir doesn't exist — os.Create fails.
+	if err := copyFile(src, filepath.Join(tmp, "missing", "out")); err == nil {
+		t.Error("expected error creating dest under missing dir")
+	}
+}
+
+// TestCopyDir verifies recursive copy preserves the directory layout.
+func TestCopyDir(t *testing.T) {
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "a.m4b"), []byte("a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sub", "b.jpg"), []byte("b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "dest")
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copyDir: %v", err)
+	}
+	for _, name := range []string{"a.m4b", "sub/b.jpg"} {
+		if _, err := os.Stat(filepath.Join(dst, name)); err != nil {
+			t.Errorf("missing %s: %v", name, err)
+		}
+	}
+}
+
+func TestCopyDir_MissingSource(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "dest")
+	if err := copyDir("/nope/does-not-exist", dst); err == nil {
+		t.Error("expected error copying missing source")
+	}
+}
+
+func TestMoveFile_RenameOverwriteDir(t *testing.T) {
+	// Dst already exists as a directory → os.Rename fails; copyFile also
+	// fails because os.Create can't create a file over a directory. This
+	// drives MoveFile down its error-handling branch.
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src.epub")
+	if err := os.WriteFile(src, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(tmp, "dest")
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := MoveFile(src, dst); err == nil {
+		t.Error("expected error moving file over existing directory")
+	}
+}
+
+func TestMoveDir_SourceNotDir(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "f.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := MoveDir(file, filepath.Join(tmp, "dst")); err == nil {
+		t.Error("expected error when source is a file, not a dir")
+	}
+}
+
+func TestMoveDir_MissingSource(t *testing.T) {
+	if err := MoveDir("/nope/does-not-exist", filepath.Join(t.TempDir(), "dst")); err == nil {
+		t.Error("expected error for missing source")
+	}
+}

--- a/internal/importer/scanner_extra_test.go
+++ b/internal/importer/scanner_extra_test.go
@@ -1,0 +1,130 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// scannerFixture spins up an in-memory DB and wires a Scanner against it.
+// All external clients (SABnzbd) stay nil — tests here exercise only the
+// Scanner paths that don't hit the download client.
+func scannerFixture(t *testing.T, libraryDir string) (*Scanner, *db.BookRepo, *db.AuthorRepo, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	history := db.NewHistoryRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+
+	s := NewScanner(downloads, clients, books, authors, history, libraryDir, "", "", "", "")
+	return s, books, authors, context.Background()
+}
+
+func TestNewScanner_AudiobookDirFallback(t *testing.T) {
+	// When audiobookDir is empty the scanner falls back to libraryDir so
+	// audiobook imports have a destination without extra configuration.
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	s := NewScanner(
+		db.NewDownloadRepo(database),
+		db.NewDownloadClientRepo(database),
+		db.NewBookRepo(database),
+		db.NewAuthorRepo(database),
+		db.NewHistoryRepo(database),
+		"/lib", "", "", "", "",
+	)
+	if s.audiobookDir != "/lib" {
+		t.Errorf("expected audiobookDir to default to libraryDir, got %q", s.audiobookDir)
+	}
+	if s.renamer == nil || s.remapper == nil {
+		t.Error("expected renamer and remapper to be wired")
+	}
+}
+
+// TestScanLibrary_EmptyLibraryDir short-circuits before touching the DB.
+func TestScanLibrary_EmptyLibraryDir(t *testing.T) {
+	s, _, _, ctx := scannerFixture(t, "")
+	s.ScanLibrary(ctx) // must not panic, must not read the DB
+}
+
+// TestScanLibrary_NoFiles walks an empty library dir and returns early.
+func TestScanLibrary_NoFiles(t *testing.T) {
+	libDir := t.TempDir()
+	s, _, _, ctx := scannerFixture(t, libDir)
+	s.ScanLibrary(ctx) // no panic, no error
+}
+
+// TestScanLibrary_ReconcilesMatchingBook puts an orphan .epub into the
+// library that matches a "wanted" book by title; the scan should attach
+// the file path to the book record.
+func TestScanLibrary_ReconcilesMatchingBook(t *testing.T) {
+	libDir := t.TempDir()
+	// "Author Name - Dark Matter.epub" → parsed title "Author Name",
+	// but the titleMatch heuristic takes significant words from both
+	// sides, so we name the file just "Dark Matter.epub" to keep the
+	// match unambiguous.
+	epub := filepath.Join(libDir, "Dark Matter.epub")
+	if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, books, authors, ctx := scannerFixture(t, libDir)
+	author := &models.Author{ForeignID: "OL1A", Name: "A", SortName: "A"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	// "Dark Matter" vs parsed "Dark Matter" → overlap=2, minOverlap=2 → match.
+	book := &models.Book{
+		ForeignID: "OL1B", AuthorID: author.ID,
+		Title: "Dark Matter", Status: models.BookStatusWanted,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	got, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FilePath != epub {
+		t.Errorf("expected book.FilePath to be set to %q, got %q", epub, got.FilePath)
+	}
+}
+
+// TestScanLibrary_NonBookFilesIgnored — extensions not in bookExtensions
+// (jpg, nfo, etc.) should not appear in the walked list.
+func TestScanLibrary_NonBookFilesIgnored(t *testing.T) {
+	libDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(libDir, "cover.jpg"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(libDir, "info.nfo"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, _, _, ctx := scannerFixture(t, libDir)
+	s.ScanLibrary(ctx) // no panic, nothing to reconcile
+}
+
+// TestCheckDownloads_NoEnabledClient returns silently when there's no
+// download client to poll. Before v0.7 this hit a nil deref on the client.
+func TestCheckDownloads_NoEnabledClient(t *testing.T) {
+	s, _, _, ctx := scannerFixture(t, t.TempDir())
+	s.CheckDownloads(ctx) // no panic, no DB writes
+}


### PR DESCRIPTION
## Summary

Raises backend coverage on the two laggards from the v0.7.2 pass. No production code was touched — only new `_test.go` files and a `CHANGELOG.md` entry.

### Coverage

| package | before | after | target |
| --- | --- | --- | --- |
| `internal/api` | 40.5% | **62.7%** | ≥60% |
| `internal/importer` | 40.7% | **62.2%** | ≥55% |
| total | 53.5% | **62.4%** | — |

### What got covered

**internal/api** — new tests for the 0%-covered handlers:

- `import_lists` (CRUD + exclusions + validation)
- `notifications` (CRUD + `Test` webhook via `httptest.NewServer`)
- `quality_profiles` (List/Get paths)
- `series` (List/Get, plus Get-with-linked-books happy path)
- `search` (authors/books/ISBN — missing param, success, error, not-found)
- `files` (ebook file download, audiobook-dir → zip stream, not-found paths)
- `migrate` (ImportCSV + ImportReadarr multipart error paths, CSV success via stub metadata provider)
- `custom_formats`, `delay_profiles` (full CRUD + validation)

**internal/importer** — new tests for previously-uncovered helpers:

- `AudiobookDestDir` (default + custom template + nil-author fallback)
- `DefaultNamingTemplate`, `NowYear`
- Cross-filesystem primitives: `copyFile`, `copyDir` (and their error branches)
- `MoveFile` / `MoveDir` error paths (dst-is-dir, src-is-file, missing-source)
- `NewScanner` (audiobookDir fallback to libraryDir)
- `ScanLibrary` (empty libraryDir short-circuit, empty-dir, non-book-files filter, reconciliation against a "wanted" book)
- `CheckDownloads` no-enabled-client short-circuit

## Test plan

- [x] `go test ./internal/api/... ./internal/importer/...` passes
- [x] `go test -race ./internal/api/... ./internal/importer/...` passes
- [x] Coverage numbers above confirmed via `go tool cover -func`
- [ ] CI green on PR