### PR TITLE
feat(opds): OPDS 1.2 catalogue endpoint (closes #65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
 
+### Added
+
+- OPDS 1.2 catalogue endpoint (closes [#65](https://github.com/vavallee/bindery/issues/65)) — read-only Atom/OPDS feeds rooted at `/opds/` so KOReader, Moon+ Reader, and other reading apps can browse the Bindery library and download books directly, without Calibre. Navigation feeds for Authors / Series / Recent, acquisition feeds per author / series / single book, and a per-book download link that serves the same bytes as the web UI (audiobook directories are zipped on the fly). The `/opds/*` subtree accepts HTTP Basic, `X-Api-Key`, `?apikey=`, or an existing session cookie; unauthenticated requests get a `401` with a `WWW-Authenticate: Basic realm="Bindery OPDS"` challenge so mobile clients prompt for credentials.
+
 ## [v0.8.0] — 2026-04-14
 
 Major feature release. Calibre users can finally automate the last mile — finished Bindery imports land in Calibre with no manual "Add books" step. Library curation gets a sharper tool: the author list stops fragmenting into "RR Haywood" / "R.R. Haywood" / "R R Haywood" duplicates, and the new **Merge authors** flow reunites them under one canonical row. Backend test coverage continues its climb, with `internal/api` and `internal/importer` both breaking 60%.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@
 - **Search, filter, sort** — On Authors, Books, Wanted, and History pages. Authors can be filtered by `Monitored / Unmonitored`. Author detail page sorts books by publication date and filters by type, status, or released/upcoming. Books filter chips include `Type: Ebook / Audiobook`; Books view shows the author inline.
 - **Calendar view** — Upcoming book releases from monitored authors, with compact dot-indicator grid on mobile
 - **Full REST API** — Every feature accessible via HTTP for scripting and integration
+- **OPDS 1.2 catalogue at `/opds/`** — browse and download your library from KOReader, Moon+ Reader, or any OPDS-capable reading app without Calibre
 
 ### Packaging
 - **Single binary** — Frontend embedded via `go:embed`. No nginx, no sidecars, no complexity

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/vavallee/bindery/internal/metadata/openlibrary"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/notifier"
+	"github.com/vavallee/bindery/internal/opds"
 	"github.com/vavallee/bindery/internal/scheduler"
 	"github.com/vavallee/bindery/internal/webui"
 )
@@ -366,6 +367,23 @@ func main() {
 		// Migration imports (CSV of author names, or Readarr SQLite DB).
 		r.Post("/migrate/csv", migrateHandler.ImportCSV)
 		r.Post("/migrate/readarr", migrateHandler.ImportReadarr)
+	})
+
+	// OPDS 1.2 catalogue — KOReader / Moon+ Reader / Aldiko speak this
+	// natively. Sits on its own auth path (Basic + API key + session) so
+	// headless reading devices don't need cookies.
+	opdsBuilder := opds.NewBuilder(opds.Config{Title: "Bindery", PageSize: 50}, bookRepo, authorRepo, seriesRepo)
+	opdsHandler := api.NewOPDSHandler(opdsBuilder, bookRepo, fileHandler)
+	r.Route("/opds", func(r chi.Router) {
+		r.Use(api.OPDSAuth(authProvider, userRepo))
+		r.Get("/", opdsHandler.Root)
+		r.Get("/authors", opdsHandler.Authors)
+		r.Get("/authors/{id}", opdsHandler.Author)
+		r.Get("/series", opdsHandler.Series)
+		r.Get("/series/{id}", opdsHandler.OneSeries)
+		r.Get("/recent", opdsHandler.Recent)
+		r.Get("/book/{id}", opdsHandler.Book)
+		r.Get("/book/{id}/file", opdsHandler.DownloadFile)
 	})
 
 	// Serve embedded frontend

--- a/internal/api/opds.go
+++ b/internal/api/opds.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/opds"
+)
+
+// OPDSHandler exposes the `/opds/*` routes. It owns a builder (assembles
+// Atom/OPDS feeds) and re-uses the existing FileHandler to actually serve
+// book bytes — so audiobook zip-streaming and ebook Content-Disposition
+// logic stay in one place.
+type OPDSHandler struct {
+	builder *opds.Builder
+	files   *FileHandler
+	books   *db.BookRepo
+}
+
+// NewOPDSHandler wires the builder + file serving paths together.
+func NewOPDSHandler(builder *opds.Builder, books *db.BookRepo, files *FileHandler) *OPDSHandler {
+	return &OPDSHandler{builder: builder, files: files, books: books}
+}
+
+// Root serves the navigation feed at GET /opds.
+func (h *OPDSHandler) Root(w http.ResponseWriter, r *http.Request) {
+	feed := h.builder.BuildRoot(baseURL(r))
+	writeOPDS(w, feed)
+}
+
+// Authors serves the paginated author navigation feed.
+func (h *OPDSHandler) Authors(w http.ResponseWriter, r *http.Request) {
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	feed, err := h.builder.BuildAuthors(r.Context(), baseURL(r), page)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeOPDS(w, feed)
+}
+
+// Author serves an acquisition feed for a single author's imported books.
+func (h *OPDSHandler) Author(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	feed, err := h.builder.BuildAuthor(r.Context(), baseURL(r), id)
+	if writeOPDSError(w, err) {
+		return
+	}
+	writeOPDS(w, feed)
+}
+
+// Series serves the paginated series navigation feed.
+func (h *OPDSHandler) Series(w http.ResponseWriter, r *http.Request) {
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	feed, err := h.builder.BuildSeriesList(r.Context(), baseURL(r), page)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeOPDS(w, feed)
+}
+
+// OneSeries serves an acquisition feed for a single series' imported books.
+func (h *OPDSHandler) OneSeries(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	feed, err := h.builder.BuildSeries(r.Context(), baseURL(r), id)
+	if writeOPDSError(w, err) {
+		return
+	}
+	writeOPDS(w, feed)
+}
+
+// Recent serves an acquisition feed of the last-50-imported books.
+func (h *OPDSHandler) Recent(w http.ResponseWriter, r *http.Request) {
+	feed, err := h.builder.BuildRecent(r.Context(), baseURL(r))
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeOPDS(w, feed)
+}
+
+// Book serves a single-entry acquisition feed for one book — the detail
+// view some clients open before triggering the download link.
+func (h *OPDSHandler) Book(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	feed, err := h.builder.BuildBook(r.Context(), baseURL(r), id)
+	if writeOPDSError(w, err) {
+		return
+	}
+	writeOPDS(w, feed)
+}
+
+// DownloadFile serves the book bytes. Delegates to the same FileHandler
+// used by the main API so audiobook directories turn into zips and ebook
+// extensions drive the Content-Disposition filename.
+func (h *OPDSHandler) DownloadFile(w http.ResponseWriter, r *http.Request) {
+	// The file handler pulls the book id out of chi.URLParam("id"), which
+	// matches our route shape (`/opds/book/{id}/file`), so no adaptation
+	// is needed.
+	h.files.Download(w, r)
+}
+
+// --- helpers ----------------------------------------------------------------
+
+// baseURL reconstructs the absolute URL prefix the client used to reach us
+// (scheme + host), honouring X-Forwarded-* when we're behind Traefik. OPDS
+// feeds embed fully-qualified links, so the value here flows into every
+// <link href="..."/>.
+func baseURL(r *http.Request) string {
+	scheme := "http"
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	} else if r.TLS != nil {
+		scheme = "https"
+	}
+	host := r.Host
+	if h := r.Header.Get("X-Forwarded-Host"); h != "" {
+		host = h
+	}
+	return scheme + "://" + host
+}
+
+// writeOPDS encodes the feed and writes it with the canonical OPDS
+// Content-Type.
+func writeOPDS(w http.ResponseWriter, feed opds.Feed) {
+	w.Header().Set("Content-Type", opds.ContentTypeFeed)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(xml.Header))
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "  ")
+	_ = enc.Encode(feed)
+}
+
+// writeOPDSError handles known builder errors (currently just ErrNotFound).
+// Returns true when it wrote a response so the caller can bail out.
+func writeOPDSError(w http.ResponseWriter, err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, opds.ErrNotFound) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+		return true
+	}
+	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	return true
+}
+

--- a/internal/api/opds_auth.go
+++ b/internal/api/opds_auth.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// OPDSAuth returns middleware that guards the /opds/* subtree. Precedence
+// mirrors the global auth middleware but adds HTTP Basic on top, because
+// that's what KOReader / Moon+ Reader / Aldiko all speak natively:
+//
+//  1. Mode == disabled                 — always allowed
+//  2. Mode == local-only + RFC1918 IP  — always allowed
+//  3. Valid X-Api-Key header or ?apikey= query — allowed
+//  4. Valid signed session cookie      — allowed
+//  5. Valid Basic credentials          — allowed
+//  6. Otherwise                        — 401 with WWW-Authenticate: Basic
+//
+// The realm ("Bindery OPDS") is what shows in the client's credential
+// prompt; keep it descriptive so users know which server is asking.
+func OPDSAuth(p auth.Provider, users *db.UserRepo) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mode := p.Mode()
+
+			if mode == auth.ModeDisabled {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if mode == auth.ModeLocalOnly && auth.IsLocalRequest(r) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if key := opdsAPIKey(r); key != "" && key == p.APIKey() {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if c, err := r.Cookie(auth.SessionCookieName); err == nil {
+				if _, err := auth.VerifySession(p.SessionSecret(), c.Value); err == nil {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+			if username, password, ok := r.BasicAuth(); ok && users != nil {
+				u, err := users.GetByUsername(r.Context(), strings.TrimSpace(username))
+				if err == nil && u != nil && auth.VerifyPassword(password, u.PasswordHash) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			// Challenge — OPDS clients retry with credentials on 401.
+			w.Header().Set("WWW-Authenticate", `Basic realm="Bindery OPDS"`)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+		})
+	}
+}
+
+func opdsAPIKey(r *http.Request) string {
+	if k := r.Header.Get("X-Api-Key"); k != "" {
+		return k
+	}
+	return r.URL.Query().Get("apikey")
+}

--- a/internal/api/opds_test.go
+++ b/internal/api/opds_test.go
@@ -1,0 +1,304 @@
+package api
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/opds"
+)
+
+// opdsFixture spins up an in-memory DB, seeds one author + one imported
+// book on disk, and returns the wired chi router plus the user repo for
+// tests that need to seed credentials.
+func opdsFixture(t *testing.T) (*chi.Mux, *db.UserRepo, *db.SettingsRepo, string) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	series := db.NewSeriesRepo(database)
+	users := db.NewUserRepo(database)
+	settings := db.NewSettingsRepo(database)
+
+	// Build a real file so the FileHandler path works end-to-end.
+	tmp := t.TempDir()
+	epub := filepath.Join(tmp, "sample.epub")
+	if err := os.WriteFile(epub, []byte("fake-epub-bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	a := &models.Author{ForeignID: "OL1A", Name: "Ada Palmer", SortName: "Palmer, Ada"}
+	if err := authors.Create(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	b := &models.Book{
+		ForeignID: "OL1W", AuthorID: a.ID, Title: "Too Like the Lightning",
+		SortTitle: "too like the lightning",
+		Status:    models.BookStatusImported, Language: "eng", Monitored: true,
+	}
+	if err := books.Create(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.SetFilePath(ctx, b.ID, epub); err != nil {
+		t.Fatal(err)
+	}
+
+	// Auth bootstrap: seed the three settings so the provider returns
+	// sane values (API key, mode, session secret). No users — Basic auth
+	// tests add them per-case.
+	for _, kv := range [][2]string{
+		{SettingAuthAPIKey, "test-api-key"},
+		{SettingAuthSessionSecret, "abcdefghijklmnopqrstuvwxyz012345"},
+		{SettingAuthMode, string(auth.ModeEnabled)},
+	} {
+		if err := settings.Set(ctx, kv[0], kv[1]); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	builder := opds.NewBuilder(opds.Config{PageSize: 50}, books, authors, series)
+	fh := NewFileHandler(books)
+	h := NewOPDSHandler(builder, books, fh)
+	p := &testProvider{settings: settings}
+
+	r := chi.NewRouter()
+	r.Route("/opds", func(r chi.Router) {
+		r.Use(OPDSAuth(p, users))
+		r.Get("/", h.Root)
+		r.Get("/authors", h.Authors)
+		r.Get("/authors/{id}", h.Author)
+		r.Get("/series", h.Series)
+		r.Get("/series/{id}", h.OneSeries)
+		r.Get("/recent", h.Recent)
+		r.Get("/book/{id}", h.Book)
+		r.Get("/book/{id}/file", h.DownloadFile)
+	})
+	return r, users, settings, "test-api-key"
+}
+
+// testProvider mirrors the dbAuthProvider in cmd/bindery — tests can't
+// import main.go's struct so we duplicate the minimal interface here.
+type testProvider struct {
+	settings *db.SettingsRepo
+}
+
+func (p *testProvider) Mode() auth.Mode {
+	s, _ := p.settings.Get(context.Background(), SettingAuthMode)
+	if s == nil {
+		return auth.ModeEnabled
+	}
+	return auth.ParseMode(s.Value)
+}
+func (p *testProvider) APIKey() string {
+	s, _ := p.settings.Get(context.Background(), SettingAuthAPIKey)
+	if s == nil {
+		return ""
+	}
+	return s.Value
+}
+func (p *testProvider) SessionSecret() []byte {
+	s, _ := p.settings.Get(context.Background(), SettingAuthSessionSecret)
+	if s == nil {
+		return nil
+	}
+	return []byte(s.Value)
+}
+func (p *testProvider) SetupRequired() bool { return false }
+
+// --- tests -------------------------------------------------------------------
+
+func TestOPDS_Unauthenticated_401(t *testing.T) {
+	r, _, _, _ := opdsFixture(t)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/opds/", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if !strings.Contains(rec.Header().Get("WWW-Authenticate"), "Basic") {
+		t.Errorf("missing Basic challenge; got %q", rec.Header().Get("WWW-Authenticate"))
+	}
+}
+
+func TestOPDS_APIKeyHeaderAllows(t *testing.T) {
+	r, _, _, key := opdsFixture(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/opds/", nil)
+	req.Header.Set("X-Api-Key", key)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	ct := rec.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/atom+xml") {
+		t.Errorf("content-type = %q", ct)
+	}
+}
+
+func TestOPDS_APIKeyQueryAllows(t *testing.T) {
+	r, _, _, key := opdsFixture(t)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/opds/?apikey="+key, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+}
+
+func TestOPDS_BasicAuthAllows(t *testing.T) {
+	r, users, _, _ := opdsFixture(t)
+	hash, err := auth.HashPassword("hunter2hunter2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := users.Create(context.Background(), "admin", hash); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/opds/", nil)
+	req.SetBasicAuth("admin", "hunter2hunter2")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOPDS_BasicAuthWrongPassword_401(t *testing.T) {
+	r, users, _, _ := opdsFixture(t)
+	hash, _ := auth.HashPassword("right-password-123")
+	_, _ = users.Create(context.Background(), "admin", hash)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/opds/", nil)
+	req.SetBasicAuth("admin", "wrong-password")
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestOPDS_Root_Contents(t *testing.T) {
+	r, _, _, key := opdsFixture(t)
+	body := doOK(t, r, "/opds/", key)
+	for _, s := range []string{
+		`xmlns="http://www.w3.org/2005/Atom"`,
+		"<title>Authors</title>",
+		"<title>Series</title>",
+		"<title>Recently Added</title>",
+	} {
+		if !strings.Contains(body, s) {
+			t.Errorf("missing %q in root:\n%s", s, body)
+		}
+	}
+}
+
+func TestOPDS_Authors_ListsSeededAuthor(t *testing.T) {
+	r, _, _, key := opdsFixture(t)
+	body := doOK(t, r, "/opds/authors", key)
+	if !strings.Contains(body, "<title>Ada Palmer</title>") {
+		t.Errorf("missing author: %s", body)
+	}
+}
+
+func TestOPDS_Author_HasAcquisitionLink(t *testing.T) {
+	r, _, _, key := opdsFixture(t)
+	// We know author id=1 (first insert); the body should reference the
+	// download path for the single seeded book (id=1).
+	body := doOK(t, r, "/opds/authors/1", key)
+	if !strings.Contains(body, `/opds/book/1/file`) {
+		t.Errorf("missing acquisition link:\n%s", body)
+	}
+	if !strings.Contains(body, `rel="http://opds-spec.org/acquisition"`) {
+		t.Errorf("missing OPDS acquisition rel:\n%s", body)
+	}
+}
+
+func TestOPDS_Author_NotFound(t *testing.T) {
+	r, _, _, key := opdsFixture(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/opds/authors/9999", nil)
+	req.Header.Set("X-Api-Key", key)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestOPDS_Book_DownloadsFile(t *testing.T) {
+	r, _, _, key := opdsFixture(t)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/opds/book/1/file", nil)
+	req.Header.Set("X-Api-Key", key)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != "fake-epub-bytes" {
+		t.Errorf("body = %q", rec.Body.String())
+	}
+	cd := rec.Header().Get("Content-Disposition")
+	if !strings.Contains(cd, "sample.epub") {
+		t.Errorf("content-disposition = %q", cd)
+	}
+}
+
+func TestOPDS_Recent_ContainsImportedBook(t *testing.T) {
+	r, _, _, key := opdsFixture(t)
+	body := doOK(t, r, "/opds/recent", key)
+	if !strings.Contains(body, "Too Like the Lightning") {
+		t.Errorf("recent feed missing book:\n%s", body)
+	}
+}
+
+func TestOPDS_ResponseIsValidXML(t *testing.T) {
+	r, _, _, key := opdsFixture(t)
+	body := doOK(t, r, "/opds/authors", key)
+	var f opds.Feed
+	if err := xml.Unmarshal([]byte(body), &f); err != nil {
+		t.Fatalf("invalid xml: %v\n%s", err, body)
+	}
+	if f.Title == "" {
+		t.Error("decoded feed has empty title")
+	}
+}
+
+func TestOPDS_LocalOnlyMode_BypassesAuth(t *testing.T) {
+	r, _, settings, _ := opdsFixture(t)
+	_ = settings.Set(context.Background(), SettingAuthMode, string(auth.ModeLocalOnly))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/opds/", nil)
+	req.RemoteAddr = "127.0.0.1:1234" // loopback — local bypass
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d under local-only; want 200", rec.Code)
+	}
+}
+
+// --- helpers -----------------------------------------------------------------
+
+func doOK(t *testing.T, r http.Handler, path, apiKey string) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("X-Api-Key", apiKey)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s = %d: %s", path, rec.Code, rec.Body.String())
+	}
+	return rec.Body.String()
+}

--- a/internal/opds/builder.go
+++ b/internal/opds/builder.go
@@ -1,0 +1,392 @@
+package opds
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// BookStore is the subset of the book repository the builder needs. Kept
+// narrow so the test suite can substitute an in-memory fake without pulling
+// in SQLite.
+type BookStore interface {
+	List(ctx context.Context) ([]models.Book, error)
+	ListByAuthor(ctx context.Context, authorID int64) ([]models.Book, error)
+	ListByStatus(ctx context.Context, status string) ([]models.Book, error)
+	GetByID(ctx context.Context, id int64) (*models.Book, error)
+}
+
+// AuthorStore is the subset of the author repository the builder needs.
+type AuthorStore interface {
+	List(ctx context.Context) ([]models.Author, error)
+	GetByID(ctx context.Context, id int64) (*models.Author, error)
+}
+
+// SeriesStore is the subset of the series repository the builder needs.
+type SeriesStore interface {
+	List(ctx context.Context) ([]models.Series, error)
+	GetByID(ctx context.Context, id int64) (*models.Series, error)
+}
+
+// Config controls catalogue pagination and the catalogue title displayed in
+// OPDS clients.
+type Config struct {
+	// Title shown as the root <feed>/<title>.
+	Title string
+	// PageSize is the number of entries per page on paginated feeds
+	// (authors list, series list). Defaults to 50 when ≤ 0.
+	PageSize int
+}
+
+// Builder assembles OPDS feeds from the three repositories. It has no
+// knowledge of HTTP — handlers call one of the Build* methods and serialise
+// the returned Feed via encoding/xml.
+type Builder struct {
+	cfg     Config
+	books   BookStore
+	authors AuthorStore
+	series  SeriesStore
+}
+
+// NewBuilder constructs a Builder. A zero-value Config is valid; defaults
+// are applied on read.
+func NewBuilder(cfg Config, books BookStore, authors AuthorStore, series SeriesStore) *Builder {
+	if cfg.PageSize <= 0 {
+		cfg.PageSize = 50
+	}
+	if cfg.Title == "" {
+		cfg.Title = "Bindery"
+	}
+	return &Builder{cfg: cfg, books: books, authors: authors, series: series}
+}
+
+// BuildRoot returns the navigation feed at `/opds` — three entries for
+// Authors, Series, and Recent.
+func (b *Builder) BuildRoot(base string) Feed {
+	base = strings.TrimRight(base, "/")
+	now := nowRFC3339()
+	f := navFeed(b.cfg.Title, "urn:bindery:opds:root", now)
+	f.Links = []Link{
+		{Rel: RelSelf, Href: base + "/opds", Type: TypeNavigation},
+		{Rel: RelStart, Href: base + "/opds", Type: TypeNavigation},
+	}
+	f.Entries = []Entry{
+		{
+			ID:      "urn:bindery:opds:authors",
+			Title:   "Authors",
+			Updated: now,
+			Content: &Content{Type: "text", Body: "Browse by author"},
+			Links: []Link{{
+				Rel: RelSubsection, Type: TypeNavigation,
+				Href: base + "/opds/authors", Title: "Authors",
+			}},
+		},
+		{
+			ID:      "urn:bindery:opds:series",
+			Title:   "Series",
+			Updated: now,
+			Content: &Content{Type: "text", Body: "Browse by series"},
+			Links: []Link{{
+				Rel: RelSubsection, Type: TypeNavigation,
+				Href: base + "/opds/series", Title: "Series",
+			}},
+		},
+		{
+			ID:      "urn:bindery:opds:recent",
+			Title:   "Recently Added",
+			Updated: now,
+			Content: &Content{Type: "text", Body: "Last 50 imported books"},
+			Links: []Link{{
+				Rel: RelSortNew, Type: TypeAcquisition,
+				Href: base + "/opds/recent", Title: "Recently Added",
+			}},
+		},
+	}
+	return f
+}
+
+// BuildAuthors returns a paginated navigation feed listing every author with
+// at least one imported book. page is 1-based.
+func (b *Builder) BuildAuthors(ctx context.Context, base string, page int) (Feed, error) {
+	base = strings.TrimRight(base, "/")
+	authors, err := b.authors.List(ctx)
+	if err != nil {
+		return Feed{}, fmt.Errorf("list authors: %w", err)
+	}
+	// Only surface authors with at least one imported book — an empty
+	// library is pointless for KOReader to browse into.
+	authors = b.filterAuthorsWithImportedBooks(ctx, authors)
+	sort.Slice(authors, func(i, j int) bool {
+		return strings.ToLower(authors[i].SortName) < strings.ToLower(authors[j].SortName)
+	})
+
+	total := len(authors)
+	page = normalizePage(page)
+	start, end := pageBounds(page, b.cfg.PageSize, total)
+
+	now := nowRFC3339()
+	f := navFeed(b.cfg.Title+" — Authors", "urn:bindery:opds:authors", now)
+	f.Links = append(f.Links,
+		Link{Rel: RelSelf, Href: pagedURL(base+"/opds/authors", page), Type: TypeNavigation},
+		Link{Rel: RelStart, Href: base + "/opds", Type: TypeNavigation},
+		Link{Rel: RelUp, Href: base + "/opds", Type: TypeNavigation},
+	)
+	addPagingLinks(&f, base+"/opds/authors", page, b.cfg.PageSize, total)
+	f.TotalResults = total
+	f.ItemsPerPage = b.cfg.PageSize
+	f.StartIndex = start + 1
+
+	for i := start; i < end; i++ {
+		a := authors[i]
+		f.Entries = append(f.Entries, Entry{
+			ID:      fmt.Sprintf("urn:bindery:author:%d", a.ID),
+			Title:   nonEmpty(a.Name, a.SortName, "Unknown author"),
+			Updated: rfc3339(a.UpdatedAt),
+			Content: descriptionContent(a.Description),
+			Links: []Link{{
+				Rel: RelSubsection, Type: TypeAcquisition,
+				Href:  fmt.Sprintf("%s/opds/authors/%d", base, a.ID),
+				Title: nonEmpty(a.Name, "Books"),
+			}},
+		})
+	}
+	return f, nil
+}
+
+// BuildAuthor returns an acquisition feed of every book by the author that
+// has an imported file on disk.
+func (b *Builder) BuildAuthor(ctx context.Context, base string, authorID int64) (Feed, error) {
+	base = strings.TrimRight(base, "/")
+	a, err := b.authors.GetByID(ctx, authorID)
+	if err != nil {
+		return Feed{}, fmt.Errorf("get author: %w", err)
+	}
+	if a == nil {
+		return Feed{}, ErrNotFound
+	}
+	books, err := b.books.ListByAuthor(ctx, authorID)
+	if err != nil {
+		return Feed{}, fmt.Errorf("list books: %w", err)
+	}
+	books = filterImported(books)
+
+	now := nowRFC3339()
+	f := acquisitionFeed(a.Name, fmt.Sprintf("urn:bindery:author:%d", a.ID), now)
+	f.Links = append(f.Links,
+		Link{Rel: RelSelf, Href: fmt.Sprintf("%s/opds/authors/%d", base, a.ID), Type: TypeAcquisition},
+		Link{Rel: RelStart, Href: base + "/opds", Type: TypeNavigation},
+		Link{Rel: RelUp, Href: base + "/opds/authors", Type: TypeNavigation},
+	)
+	for _, bk := range books {
+		f.Entries = append(f.Entries, b.bookEntry(base, bk, a))
+	}
+	return f, nil
+}
+
+// BuildSeriesList returns a paginated navigation feed of every series that
+// has at least one imported book.
+func (b *Builder) BuildSeriesList(ctx context.Context, base string, page int) (Feed, error) {
+	base = strings.TrimRight(base, "/")
+	ser, err := b.series.List(ctx)
+	if err != nil {
+		return Feed{}, fmt.Errorf("list series: %w", err)
+	}
+	sort.Slice(ser, func(i, j int) bool {
+		return strings.ToLower(ser[i].Title) < strings.ToLower(ser[j].Title)
+	})
+
+	total := len(ser)
+	page = normalizePage(page)
+	start, end := pageBounds(page, b.cfg.PageSize, total)
+
+	now := nowRFC3339()
+	f := navFeed(b.cfg.Title+" — Series", "urn:bindery:opds:series", now)
+	f.Links = append(f.Links,
+		Link{Rel: RelSelf, Href: pagedURL(base+"/opds/series", page), Type: TypeNavigation},
+		Link{Rel: RelStart, Href: base + "/opds", Type: TypeNavigation},
+		Link{Rel: RelUp, Href: base + "/opds", Type: TypeNavigation},
+	)
+	addPagingLinks(&f, base+"/opds/series", page, b.cfg.PageSize, total)
+	f.TotalResults = total
+	f.ItemsPerPage = b.cfg.PageSize
+	f.StartIndex = start + 1
+
+	for i := start; i < end; i++ {
+		s := ser[i]
+		f.Entries = append(f.Entries, Entry{
+			ID:      fmt.Sprintf("urn:bindery:series:%d", s.ID),
+			Title:   nonEmpty(s.Title, "Untitled series"),
+			Updated: rfc3339(s.CreatedAt),
+			Content: descriptionContent(s.Description),
+			Links: []Link{{
+				Rel: RelSubsection, Type: TypeAcquisition,
+				Href:  fmt.Sprintf("%s/opds/series/%d", base, s.ID),
+				Title: s.Title,
+			}},
+		})
+	}
+	return f, nil
+}
+
+// BuildSeries returns an acquisition feed of every book in the series that
+// has an imported file on disk, ordered by the stored position-in-series.
+func (b *Builder) BuildSeries(ctx context.Context, base string, seriesID int64) (Feed, error) {
+	base = strings.TrimRight(base, "/")
+	s, err := b.series.GetByID(ctx, seriesID)
+	if err != nil {
+		return Feed{}, fmt.Errorf("get series: %w", err)
+	}
+	if s == nil {
+		return Feed{}, ErrNotFound
+	}
+
+	now := nowRFC3339()
+	f := acquisitionFeed(s.Title, fmt.Sprintf("urn:bindery:series:%d", s.ID), now)
+	f.Links = append(f.Links,
+		Link{Rel: RelSelf, Href: fmt.Sprintf("%s/opds/series/%d", base, s.ID), Type: TypeAcquisition},
+		Link{Rel: RelStart, Href: base + "/opds", Type: TypeNavigation},
+		Link{Rel: RelUp, Href: base + "/opds/series", Type: TypeNavigation},
+	)
+
+	// SeriesRepo.GetByID only pulls a thin projection of each book (no
+	// file_path, no updated_at, no language). Re-read the full row from
+	// the books repo so we can emit a proper acquisition link.
+	for _, sb := range s.Books {
+		bk, err := b.books.GetByID(ctx, sb.BookID)
+		if err != nil || bk == nil || bk.Status != models.BookStatusImported || bk.FilePath == "" {
+			continue
+		}
+		var author *models.Author
+		if bk.AuthorID > 0 {
+			author, _ = b.authors.GetByID(ctx, bk.AuthorID)
+		}
+		entry := b.bookEntry(base, *bk, author)
+		if sb.PositionInSeries != "" {
+			entry.Title = fmt.Sprintf("%s. %s", sb.PositionInSeries, entry.Title)
+		}
+		f.Entries = append(f.Entries, entry)
+	}
+	return f, nil
+}
+
+// BuildRecent returns an acquisition feed of the 50 most recently updated
+// imported books.
+func (b *Builder) BuildRecent(ctx context.Context, base string) (Feed, error) {
+	base = strings.TrimRight(base, "/")
+	books, err := b.books.ListByStatus(ctx, models.BookStatusImported)
+	if err != nil {
+		return Feed{}, fmt.Errorf("list imported: %w", err)
+	}
+	books = filterImported(books)
+	sort.SliceStable(books, func(i, j int) bool {
+		// Tie-break by ID so the sort is deterministic even when many
+		// books share an updated_at (common for bulk imports).
+		if books[i].UpdatedAt.Equal(books[j].UpdatedAt) {
+			return books[i].ID > books[j].ID
+		}
+		return books[i].UpdatedAt.After(books[j].UpdatedAt)
+	})
+	if len(books) > 50 {
+		books = books[:50]
+	}
+
+	now := nowRFC3339()
+	f := acquisitionFeed(b.cfg.Title+" — Recently Added", "urn:bindery:opds:recent", now)
+	f.Links = append(f.Links,
+		Link{Rel: RelSelf, Href: base + "/opds/recent", Type: TypeAcquisition},
+		Link{Rel: RelStart, Href: base + "/opds", Type: TypeNavigation},
+		Link{Rel: RelUp, Href: base + "/opds", Type: TypeNavigation},
+	)
+	for _, bk := range books {
+		var author *models.Author
+		if bk.AuthorID > 0 {
+			author, _ = b.authors.GetByID(ctx, bk.AuthorID)
+		}
+		f.Entries = append(f.Entries, b.bookEntry(base, bk, author))
+	}
+	return f, nil
+}
+
+// BuildBook returns a single-entry acquisition feed for the given book —
+// some OPDS clients (Moon+ Reader) expect a feed rather than a bare entry
+// when drilling into a publication detail link.
+func (b *Builder) BuildBook(ctx context.Context, base string, bookID int64) (Feed, error) {
+	base = strings.TrimRight(base, "/")
+	bk, err := b.books.GetByID(ctx, bookID)
+	if err != nil {
+		return Feed{}, fmt.Errorf("get book: %w", err)
+	}
+	if bk == nil {
+		return Feed{}, ErrNotFound
+	}
+	var author *models.Author
+	if bk.AuthorID > 0 {
+		author, _ = b.authors.GetByID(ctx, bk.AuthorID)
+	}
+
+	now := nowRFC3339()
+	f := acquisitionFeed(bk.Title, fmt.Sprintf("urn:bindery:book:%d", bk.ID), now)
+	f.Links = append(f.Links,
+		Link{Rel: RelSelf, Href: fmt.Sprintf("%s/opds/book/%d", base, bk.ID), Type: TypeAcquisition},
+		Link{Rel: RelStart, Href: base + "/opds", Type: TypeNavigation},
+	)
+	f.Entries = []Entry{b.bookEntry(base, *bk, author)}
+	return f, nil
+}
+
+// bookEntry produces one <entry> for an imported book. When the book has no
+// file on disk the acquisition link is omitted so clients don't offer a
+// download that would 404.
+func (b *Builder) bookEntry(base string, bk models.Book, author *models.Author) Entry {
+	e := Entry{
+		ID:       fmt.Sprintf("urn:bindery:book:%d", bk.ID),
+		Title:    nonEmpty(bk.Title, "Untitled"),
+		Updated:  rfc3339(bk.UpdatedAt),
+		Content:  descriptionContent(bk.Description),
+		Language: bk.Language,
+	}
+	if bk.ReleaseDate != nil && !bk.ReleaseDate.IsZero() {
+		e.Issued = bk.ReleaseDate.Format("2006-01-02")
+	}
+	if author != nil {
+		e.Authors = []Person{{
+			Name: nonEmpty(author.Name, author.SortName, "Unknown"),
+		}}
+	}
+	if bk.ImageURL != "" {
+		e.Links = append(e.Links,
+			Link{Rel: RelImage, Href: bk.ImageURL, Type: guessImageType(bk.ImageURL)},
+			Link{Rel: RelThumbnail, Href: bk.ImageURL, Type: guessImageType(bk.ImageURL)},
+		)
+	}
+	if bk.FilePath != "" && bk.Status == models.BookStatusImported {
+		e.Links = append(e.Links, Link{
+			Rel:   RelAcquisition,
+			Href:  fmt.Sprintf("%s/opds/book/%d/file", base, bk.ID),
+			Type:  guessFileType(bk.FilePath, bk.MediaType),
+			Title: "Download",
+		})
+	}
+	return e
+}
+
+// filterAuthorsWithImportedBooks drops authors whose library is empty.
+// A single extra query per author is fine at the author-count scales
+// Bindery users run at (hundreds, not tens of thousands).
+func (b *Builder) filterAuthorsWithImportedBooks(ctx context.Context, authors []models.Author) []models.Author {
+	kept := make([]models.Author, 0, len(authors))
+	for _, a := range authors {
+		books, err := b.books.ListByAuthor(ctx, a.ID)
+		if err != nil {
+			continue
+		}
+		if len(filterImported(books)) == 0 {
+			continue
+		}
+		kept = append(kept, a)
+	}
+	return kept
+}

--- a/internal/opds/builder_test.go
+++ b/internal/opds/builder_test.go
@@ -1,0 +1,428 @@
+package opds
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// --- fakes --------------------------------------------------------------------
+
+type fakeBooks struct {
+	all []models.Book
+}
+
+func (f *fakeBooks) List(_ context.Context) ([]models.Book, error) {
+	out := make([]models.Book, len(f.all))
+	copy(out, f.all)
+	return out, nil
+}
+func (f *fakeBooks) ListByAuthor(_ context.Context, authorID int64) ([]models.Book, error) {
+	var out []models.Book
+	for _, b := range f.all {
+		if b.AuthorID == authorID {
+			out = append(out, b)
+		}
+	}
+	return out, nil
+}
+func (f *fakeBooks) ListByStatus(_ context.Context, status string) ([]models.Book, error) {
+	var out []models.Book
+	for _, b := range f.all {
+		if b.Status == status {
+			out = append(out, b)
+		}
+	}
+	return out, nil
+}
+func (f *fakeBooks) GetByID(_ context.Context, id int64) (*models.Book, error) {
+	for i := range f.all {
+		if f.all[i].ID == id {
+			b := f.all[i]
+			return &b, nil
+		}
+	}
+	return nil, nil
+}
+
+type fakeAuthors struct{ all []models.Author }
+
+func (f *fakeAuthors) List(_ context.Context) ([]models.Author, error) {
+	out := make([]models.Author, len(f.all))
+	copy(out, f.all)
+	return out, nil
+}
+func (f *fakeAuthors) GetByID(_ context.Context, id int64) (*models.Author, error) {
+	for i := range f.all {
+		if f.all[i].ID == id {
+			a := f.all[i]
+			return &a, nil
+		}
+	}
+	return nil, nil
+}
+
+type fakeSeries struct {
+	all []models.Series
+}
+
+func (f *fakeSeries) List(_ context.Context) ([]models.Series, error) {
+	out := make([]models.Series, len(f.all))
+	copy(out, f.all)
+	return out, nil
+}
+func (f *fakeSeries) GetByID(_ context.Context, id int64) (*models.Series, error) {
+	for i := range f.all {
+		if f.all[i].ID == id {
+			s := f.all[i]
+			return &s, nil
+		}
+	}
+	return nil, nil
+}
+
+// --- fixture -----------------------------------------------------------------
+
+// fixture returns a small library: two authors, three books (two imported),
+// one series containing the two imported books.
+func fixture() (*fakeBooks, *fakeAuthors, *fakeSeries) {
+	tzero := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	tlater := time.Date(2026, 3, 2, 9, 0, 0, 0, time.UTC)
+	releaseTwo := time.Date(2019, 6, 11, 0, 0, 0, 0, time.UTC)
+
+	a1 := models.Author{ID: 1, Name: "Ada Palmer", SortName: "Palmer, Ada", UpdatedAt: tzero}
+	a2 := models.Author{ID: 2, Name: "Becky Chambers", SortName: "Chambers, Becky", UpdatedAt: tzero}
+
+	b1 := models.Book{
+		ID: 10, AuthorID: 1, Title: "Too Like the Lightning",
+		SortTitle: "too like the lightning",
+		FilePath:  "/library/Ada Palmer/Too Like the Lightning.epub",
+		Status:    models.BookStatusImported, Language: "eng",
+		UpdatedAt: tzero,
+	}
+	b2 := models.Book{
+		ID: 11, AuthorID: 2, Title: "Record of a Spaceborn Few",
+		SortTitle: "record of a spaceborn few",
+		FilePath:  "/library/Becky Chambers/Record of a Spaceborn Few.epub",
+		Status:    models.BookStatusImported, Language: "eng",
+		ReleaseDate: &releaseTwo,
+		UpdatedAt:   tlater,
+	}
+	b3 := models.Book{
+		ID: 12, AuthorID: 2, Title: "Wanted Book",
+		Status:    models.BookStatusWanted, // not imported — must not appear
+		UpdatedAt: tzero,
+	}
+
+	s1 := models.Series{ID: 100, Title: "Wayfarers", CreatedAt: tzero, Books: []models.SeriesBook{
+		{SeriesID: 100, BookID: 11, PositionInSeries: "3", PrimarySeries: true},
+	}}
+
+	return &fakeBooks{all: []models.Book{b1, b2, b3}}, &fakeAuthors{all: []models.Author{a1, a2}}, &fakeSeries{all: []models.Series{s1}}
+}
+
+func newBuilder() *Builder {
+	b, a, s := fixture()
+	return NewBuilder(Config{Title: "Bindery", PageSize: 50}, b, a, s)
+}
+
+// --- tests -------------------------------------------------------------------
+
+func TestBuildRoot(t *testing.T) {
+	b := newBuilder()
+	f := b.BuildRoot("http://host:8787")
+
+	if f.Title != "Bindery" {
+		t.Errorf("title = %q, want Bindery", f.Title)
+	}
+	if f.ID != "urn:bindery:opds:root" {
+		t.Errorf("id = %q", f.ID)
+	}
+	if len(f.Entries) != 3 {
+		t.Fatalf("want 3 root entries, got %d", len(f.Entries))
+	}
+	mustHaveRel(t, f.Links, RelSelf, "http://host:8787/opds")
+	mustHaveRel(t, f.Links, RelStart, "http://host:8787/opds")
+
+	gotTitles := map[string]bool{}
+	for _, e := range f.Entries {
+		gotTitles[e.Title] = true
+	}
+	for _, want := range []string{"Authors", "Series", "Recently Added"} {
+		if !gotTitles[want] {
+			t.Errorf("missing root entry %q", want)
+		}
+	}
+}
+
+func TestBuildAuthors_SkipsEmptyAuthors(t *testing.T) {
+	// Add an author with no imported books — should be hidden.
+	books, authors, series := fixture()
+	authors.all = append(authors.all, models.Author{ID: 99, Name: "Empty Zee", SortName: "Zee, Empty"})
+	b := NewBuilder(Config{PageSize: 50}, books, authors, series)
+
+	f, err := b.BuildAuthors(context.Background(), "http://host", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Entries) != 2 {
+		t.Fatalf("expected 2 authors with imported books, got %d", len(f.Entries))
+	}
+	// SortName lex order: Chambers, Becky < Palmer, Ada
+	if f.Entries[0].Title != "Becky Chambers" {
+		t.Errorf("first = %q, want Becky Chambers", f.Entries[0].Title)
+	}
+	if f.TotalResults != 2 || f.ItemsPerPage != 50 || f.StartIndex != 1 {
+		t.Errorf("paging: total=%d items=%d start=%d", f.TotalResults, f.ItemsPerPage, f.StartIndex)
+	}
+}
+
+func TestBuildAuthors_Paging(t *testing.T) {
+	// Force multiple pages with a tiny page size.
+	books, _, series := fixture()
+	var bigAuthors []models.Author
+	for i := int64(1); i <= 5; i++ {
+		bigAuthors = append(bigAuthors, models.Author{ID: i, Name: "A", SortName: "a"})
+	}
+	// Give every author one imported book so none are filtered.
+	var bigBooks []models.Book
+	for i := int64(1); i <= 5; i++ {
+		bigBooks = append(bigBooks, models.Book{
+			ID: 100 + i, AuthorID: i, Title: "X",
+			FilePath: "/x.epub", Status: models.BookStatusImported,
+		})
+	}
+	books.all = bigBooks
+
+	b := NewBuilder(Config{PageSize: 2}, books, &fakeAuthors{all: bigAuthors}, series)
+
+	page1, _ := b.BuildAuthors(context.Background(), "http://h", 1)
+	if len(page1.Entries) != 2 {
+		t.Errorf("page 1 entries = %d", len(page1.Entries))
+	}
+	if !hasRel(page1.Links, RelNext) {
+		t.Error("page 1 missing rel=next")
+	}
+	if hasRel(page1.Links, RelPrevious) {
+		t.Error("page 1 should not have rel=previous")
+	}
+
+	page3, _ := b.BuildAuthors(context.Background(), "http://h", 3)
+	if len(page3.Entries) != 1 {
+		t.Errorf("page 3 entries = %d, want 1", len(page3.Entries))
+	}
+	if hasRel(page3.Links, RelNext) {
+		t.Error("page 3 should not have rel=next")
+	}
+	if !hasRel(page3.Links, RelPrevious) {
+		t.Error("page 3 missing rel=previous")
+	}
+}
+
+func TestBuildAuthor_NotFound(t *testing.T) {
+	b := newBuilder()
+	_, err := b.BuildAuthor(context.Background(), "http://h", 9999)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestBuildAuthor_Acquisition(t *testing.T) {
+	b := newBuilder()
+	f, err := b.BuildAuthor(context.Background(), "http://host:8787", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(f.Entries))
+	}
+	entry := f.Entries[0]
+	if entry.Title != "Too Like the Lightning" {
+		t.Errorf("title = %q", entry.Title)
+	}
+	acq := findLink(entry.Links, RelAcquisition)
+	if acq == nil {
+		t.Fatal("acquisition link missing")
+	}
+	if acq.Href != "http://host:8787/opds/book/10/file" {
+		t.Errorf("acq href = %q", acq.Href)
+	}
+	if acq.Type != "application/epub+zip" {
+		t.Errorf("acq type = %q", acq.Type)
+	}
+	if len(entry.Authors) != 1 || entry.Authors[0].Name != "Ada Palmer" {
+		t.Errorf("entry authors = %v", entry.Authors)
+	}
+}
+
+func TestBuildSeriesList_SortedByTitle(t *testing.T) {
+	b := newBuilder()
+	f, err := b.BuildSeriesList(context.Background(), "http://h", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Entries) != 1 || f.Entries[0].Title != "Wayfarers" {
+		t.Errorf("entries = %+v", f.Entries)
+	}
+}
+
+func TestBuildSeries_PrefixesPosition(t *testing.T) {
+	b := newBuilder()
+	f, err := b.BuildSeries(context.Background(), "http://h", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Entries) != 1 {
+		t.Fatalf("entries = %d", len(f.Entries))
+	}
+	if !strings.HasPrefix(f.Entries[0].Title, "3. ") {
+		t.Errorf("title = %q, want to start with '3. '", f.Entries[0].Title)
+	}
+}
+
+func TestBuildRecent_OrdersByUpdatedDesc(t *testing.T) {
+	b := newBuilder()
+	f, err := b.BuildRecent(context.Background(), "http://h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Entries) != 2 {
+		t.Fatalf("entries = %d", len(f.Entries))
+	}
+	// b2 updated 2026-03-02, b1 updated 2026-03-01 — b2 must come first.
+	if f.Entries[0].Title != "Record of a Spaceborn Few" {
+		t.Errorf("first = %q, want Record of a Spaceborn Few", f.Entries[0].Title)
+	}
+}
+
+func TestBuildBook_NotFound(t *testing.T) {
+	b := newBuilder()
+	_, err := b.BuildBook(context.Background(), "http://h", 9999)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestBuildBook_OneEntry(t *testing.T) {
+	b := newBuilder()
+	f, err := b.BuildBook(context.Background(), "http://h", 11)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Entries) != 1 {
+		t.Fatalf("entries = %d", len(f.Entries))
+	}
+	if f.Entries[0].Issued != "2019-06-11" {
+		t.Errorf("issued = %q", f.Entries[0].Issued)
+	}
+	if f.Entries[0].Language != "eng" {
+		t.Errorf("language = %q", f.Entries[0].Language)
+	}
+}
+
+// TestXMLMarshal validates that the feed round-trips through encoding/xml
+// with the namespace prefixes and OPDS element names that strict clients
+// (KOReader, Moon+ Reader) require.
+func TestXMLMarshal(t *testing.T) {
+	b := newBuilder()
+	f, err := b.BuildAuthor(context.Background(), "http://host:8787", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf, err := xml.MarshalIndent(f, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(buf)
+
+	required := []string{
+		`xmlns="http://www.w3.org/2005/Atom"`,
+		`xmlns:dc="http://purl.org/dc/terms/"`,
+		`xmlns:opds="http://opds-spec.org/2010/catalog"`,
+		`<dc:language>eng</dc:language>`,
+		`rel="http://opds-spec.org/acquisition"`,
+		`type="application/epub+zip"`,
+		`<title>Too Like the Lightning</title>`,
+		`urn:bindery:book:10`,
+	}
+	for _, s := range required {
+		if !strings.Contains(out, s) {
+			t.Errorf("xml missing %q\n---\n%s", s, out)
+		}
+	}
+	// Self-sanity: parse it back.
+	var parsed Feed
+	if err := xml.Unmarshal(buf, &parsed); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+}
+
+// TestPageBounds covers the edge cases of the pagination helper directly.
+func TestPageBounds(t *testing.T) {
+	cases := []struct {
+		page, size, total  int
+		wantStart, wantEnd int
+	}{
+		{1, 10, 0, 0, 0},
+		{1, 10, 5, 0, 5},
+		{1, 10, 25, 0, 10},
+		{3, 10, 25, 20, 25},
+		{4, 10, 25, 25, 25}, // overrun
+	}
+	for _, c := range cases {
+		s, e := pageBounds(c.page, c.size, c.total)
+		if s != c.wantStart || e != c.wantEnd {
+			t.Errorf("pageBounds(%d,%d,%d) = (%d,%d), want (%d,%d)",
+				c.page, c.size, c.total, s, e, c.wantStart, c.wantEnd)
+		}
+	}
+}
+
+func TestGuessFileType(t *testing.T) {
+	cases := map[string]string{
+		"/a/b.epub":                       "application/epub+zip",
+		"/a/b.EPUB":                       "application/epub+zip",
+		"/a/b.pdf":                        "application/pdf",
+		"/a/b.mobi":                       "application/x-mobipocket-ebook",
+		"/a/b.unknown":                    "application/octet-stream",
+		"/library/author/title/directory": "application/octet-stream",
+	}
+	for path, want := range cases {
+		got := guessFileType(path, models.MediaTypeEbook)
+		if got != want {
+			t.Errorf("guessFileType(%q) = %q, want %q", path, got, want)
+		}
+	}
+	if guessFileType("/a/b.m4b", models.MediaTypeAudiobook) != "application/zip" {
+		t.Error("audiobook must serialize as zip")
+	}
+}
+
+// --- helpers -----------------------------------------------------------------
+
+func findLink(links []Link, rel string) *Link {
+	for i := range links {
+		if links[i].Rel == rel {
+			return &links[i]
+		}
+	}
+	return nil
+}
+
+func hasRel(links []Link, rel string) bool { return findLink(links, rel) != nil }
+
+func mustHaveRel(t *testing.T, links []Link, rel, href string) {
+	t.Helper()
+	l := findLink(links, rel)
+	if l == nil {
+		t.Fatalf("missing rel=%s", rel)
+	}
+	if l.Href != href {
+		t.Errorf("rel=%s href = %q, want %q", rel, l.Href, href)
+	}
+}

--- a/internal/opds/feed.go
+++ b/internal/opds/feed.go
@@ -1,0 +1,121 @@
+// Package opds builds OPDS 1.2 / Atom 1.0 catalogue feeds from Bindery's
+// authors / books / series tables. The catalogue is read-only and purely
+// derived — nothing here writes to the database.
+//
+// Wire format reference:
+//
+//	https://specs.opds.io/opds-1.2
+//	https://datatracker.ietf.org/doc/html/rfc4287  (Atom)
+//	https://github.com/dewitt/opensearch/blob/master/opensearch-1-1-draft-6.md
+//
+// We emit namespace prefixes literally in the element/attribute names rather
+// than using encoding/xml's namespace machinery, because Go's default
+// "ns1:" auto-prefixing confuses some strict OPDS parsers (notably
+// KOReader's, which wants the conventional `opds:` / `dc:` prefixes).
+package opds
+
+import (
+	"encoding/xml"
+)
+
+// XML namespaces declared on the root <feed> element.
+const (
+	NSAtom       = "http://www.w3.org/2005/Atom"
+	NSOPDS       = "http://opds-spec.org/2010/catalog"
+	NSDC         = "http://purl.org/dc/terms/"
+	NSOpenSearch = "http://a9.com/-/spec/opensearch/1.1/"
+)
+
+// Link relations used throughout the catalogue.
+const (
+	RelSelf        = "self"
+	RelStart       = "start"
+	RelUp          = "up"
+	RelNext        = "next"
+	RelPrevious    = "previous"
+	RelSubsection  = "subsection"
+	RelAcquisition = "http://opds-spec.org/acquisition"
+	RelOpenAccess  = "http://opds-spec.org/acquisition/open-access"
+	RelImage       = "http://opds-spec.org/image"
+	RelThumbnail   = "http://opds-spec.org/image/thumbnail"
+	RelSortNew     = "http://opds-spec.org/sort/new"
+)
+
+// MIME types. The `profile=opds-catalog` bit is what OPDS clients sniff
+// to distinguish a catalogue feed from a plain Atom feed; `kind=` tells
+// them whether the entries are navigation subsections or downloadable
+// publications.
+const (
+	TypeNavigation  = "application/atom+xml;profile=opds-catalog;kind=navigation"
+	TypeAcquisition = "application/atom+xml;profile=opds-catalog;kind=acquisition"
+)
+
+// ContentTypeFeed is the Content-Type header value used on every OPDS
+// response regardless of feed kind. Clients key the specific kind off the
+// <link rel="self" type="..."/> element, not the header.
+const ContentTypeFeed = "application/atom+xml;profile=opds-catalog;charset=utf-8"
+
+// Feed is an OPDS/Atom root element.
+type Feed struct {
+	XMLName xml.Name `xml:"feed"`
+
+	Xmlns           string `xml:"xmlns,attr"`
+	XmlnsDC         string `xml:"xmlns:dc,attr,omitempty"`
+	XmlnsOPDS       string `xml:"xmlns:opds,attr,omitempty"`
+	XmlnsOpenSearch string `xml:"xmlns:opensearch,attr,omitempty"`
+
+	ID       string  `xml:"id"`
+	Title    string  `xml:"title"`
+	Updated  string  `xml:"updated"`
+	Subtitle string  `xml:"subtitle,omitempty"`
+	Author   *Person `xml:"author,omitempty"`
+
+	Links   []Link  `xml:"link"`
+	Entries []Entry `xml:"entry"`
+
+	// OpenSearch paging (optional — only emitted when the caller sets
+	// the values; xml:omitempty on int treats 0 as empty).
+	TotalResults int `xml:"opensearch:totalResults,omitempty"`
+	ItemsPerPage int `xml:"opensearch:itemsPerPage,omitempty"`
+	StartIndex   int `xml:"opensearch:startIndex,omitempty"`
+}
+
+// Entry is a single feed item — either a navigation subsection or an
+// acquisition (downloadable publication).
+type Entry struct {
+	XMLName xml.Name `xml:"entry"`
+
+	ID       string   `xml:"id"`
+	Title    string   `xml:"title"`
+	Updated  string   `xml:"updated"`
+	Authors  []Person `xml:"author,omitempty"`
+	Summary  string   `xml:"summary,omitempty"`
+	Content  *Content `xml:"content,omitempty"`
+	Language string   `xml:"dc:language,omitempty"`
+	Issued   string   `xml:"dc:issued,omitempty"`
+	Links    []Link   `xml:"link,omitempty"`
+}
+
+// Person is an Atom person construct (used for both feed and entry authors).
+type Person struct {
+	Name string `xml:"name"`
+	URI  string `xml:"uri,omitempty"`
+}
+
+// Content is an Atom content element. OPDS uses text/html or text for
+// publication descriptions.
+type Content struct {
+	Type string `xml:"type,attr,omitempty"`
+	Body string `xml:",chardata"`
+}
+
+// Link is an Atom link with the OPDS `count` extension attribute.
+type Link struct {
+	Rel   string `xml:"rel,attr,omitempty"`
+	Href  string `xml:"href,attr"`
+	Type  string `xml:"type,attr,omitempty"`
+	Title string `xml:"title,attr,omitempty"`
+	// opds:count decorates a subsection link with the number of entries
+	// behind it — lets clients render "Authors (152)" without a probe.
+	Count string `xml:"opds:count,attr,omitempty"`
+}

--- a/internal/opds/helpers.go
+++ b/internal/opds/helpers.go
@@ -1,0 +1,180 @@
+package opds
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// ErrNotFound is returned by Build* methods when a requested entity (author,
+// series, book) doesn't exist. Handlers translate it to HTTP 404.
+var ErrNotFound = errors.New("opds: not found")
+
+// navFeed returns a navigation-kind feed pre-populated with namespaces.
+func navFeed(title, id, updated string) Feed {
+	return Feed{
+		Xmlns:           NSAtom,
+		XmlnsDC:         NSDC,
+		XmlnsOPDS:       NSOPDS,
+		XmlnsOpenSearch: NSOpenSearch,
+		ID:              id,
+		Title:           title,
+		Updated:         updated,
+	}
+}
+
+// acquisitionFeed returns an acquisition-kind feed pre-populated with
+// namespaces.
+func acquisitionFeed(title, id, updated string) Feed {
+	return navFeed(title, id, updated)
+}
+
+// descriptionContent converts a possibly-multiline plain-text description
+// into an Atom <content type="text"> element, or nil when empty.
+func descriptionContent(desc string) *Content {
+	desc = strings.TrimSpace(desc)
+	if desc == "" {
+		return nil
+	}
+	return &Content{Type: "text", Body: desc}
+}
+
+// nonEmpty returns the first non-empty value. If none of the candidates is
+// non-empty the last one is returned (so callers always get a usable fallback).
+func nonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	if len(values) == 0 {
+		return ""
+	}
+	return values[len(values)-1]
+}
+
+// rfc3339 formats a time as RFC3339 in UTC. Zero times become the epoch,
+// since Atom requires <updated> to be a valid xsd:dateTime.
+func rfc3339(t time.Time) string {
+	if t.IsZero() {
+		return "1970-01-01T00:00:00Z"
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+// nowRFC3339 is a test seam for the builder's "now" timestamp.
+var nowRFC3339 = func() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+// normalizePage clamps page numbers to [1, ∞). OPDS page query params are
+// 1-based per convention.
+func normalizePage(p int) int {
+	if p < 1 {
+		return 1
+	}
+	return p
+}
+
+// pageBounds returns the (inclusive, exclusive) slice indexes for the given
+// 1-based page. When page overruns the total, returns an empty window.
+func pageBounds(page, size, total int) (start, end int) {
+	start = (page - 1) * size
+	if start >= total {
+		return total, total
+	}
+	end = min(start+size, total)
+	return start, end
+}
+
+// pagedURL returns base (optionally with ?page=N when N > 1). The OPDS
+// convention is that the unpaginated URL is equivalent to page=1.
+func pagedURL(base string, page int) string {
+	if page <= 1 {
+		return base
+	}
+	return fmt.Sprintf("%s?page=%d", base, page)
+}
+
+// addPagingLinks appends rel="next" / rel="previous" links to the feed
+// when more pages exist.
+func addPagingLinks(f *Feed, base string, page, size, total int) {
+	if total <= 0 {
+		return
+	}
+	maxPage := (total + size - 1) / size
+	if page < maxPage {
+		f.Links = append(f.Links, Link{
+			Rel: RelNext, Href: pagedURL(base, page+1), Type: TypeNavigation,
+		})
+	}
+	if page > 1 {
+		f.Links = append(f.Links, Link{
+			Rel: RelPrevious, Href: pagedURL(base, page-1), Type: TypeNavigation,
+		})
+	}
+}
+
+// filterImported keeps only books whose file actually exists in the
+// library (status=imported and file_path set). OPDS is a download
+// catalogue — we must not advertise links that will 404.
+func filterImported(books []models.Book) []models.Book {
+	kept := books[:0]
+	for _, b := range books {
+		if b.Status == models.BookStatusImported && b.FilePath != "" {
+			kept = append(kept, b)
+		}
+	}
+	return kept
+}
+
+// guessFileType maps a stored file path to the MIME type OPDS clients
+// expect in the acquisition link. Audiobooks come down as a zip of the
+// folder (see api.FileHandler.Download); ebooks match their extension.
+func guessFileType(path, mediaType string) string {
+	if mediaType == models.MediaTypeAudiobook {
+		return "application/zip"
+	}
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".epub":
+		return "application/epub+zip"
+	case ".pdf":
+		return "application/pdf"
+	case ".mobi":
+		return "application/x-mobipocket-ebook"
+	case ".azw", ".azw3":
+		return "application/vnd.amazon.ebook"
+	case ".cbz":
+		return "application/vnd.comicbook+zip"
+	case ".cbr":
+		return "application/vnd.comicbook-rar"
+	case ".txt":
+		return "text/plain"
+	case ".fb2":
+		return "application/x-fictionbook+xml"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// guessImageType returns the MIME type for a cover image URL by extension.
+// When we can't tell, fall back to image/jpeg — the dominant format on the
+// provider CDNs Bindery reads from (OpenLibrary, Google Books, Hardcover).
+func guessImageType(u string) string {
+	switch strings.ToLower(filepath.Ext(strings.Split(u, "?")[0])) {
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".svg":
+		return "image/svg+xml"
+	default:
+		return "image/jpeg"
+	}
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -884,6 +884,28 @@ function GeneralTab() {
         </div>
       </section>
 
+      {/* OPDS */}
+      <section>
+        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">OPDS Feed</h3>
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+          <div>
+            <span className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1">OPDS Feed URL</span>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 text-xs bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 px-2 py-1.5 rounded font-mono break-all">
+                {window.location.origin}/opds
+              </code>
+              <button
+                onClick={() => navigator.clipboard.writeText(window.location.origin + '/opds')}
+                className="px-3 py-1.5 bg-slate-600 hover:bg-slate-500 rounded text-xs font-medium flex-shrink-0"
+              >
+                Copy
+              </button>
+            </div>
+            <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1.5">Use this URL in KOReader, Moon+ Reader, or any OPDS client. Authenticate with your API key as the password (leave the username blank or use any value).</p>
+          </div>
+        </div>
+      </section>
+
       {/* Calibre */}
       <CalibreSection
         settings={settings}


### PR DESCRIPTION
## Summary

- New read-only OPDS 1.2 / Atom 1.0 catalogue at `/opds/` so KOReader, Moon+ Reader, Aldiko, etc. can browse the Bindery library and download books directly — no Calibre required.
- Independent of the Calibre write-side: OPDS serves Bindery's own catalogue regardless of Calibre integration state.
- Dedicated auth middleware for `/opds/*` accepts session cookie, `X-Api-Key`, `?apikey=`, or HTTP Basic; unauthenticated requests get `401` + `WWW-Authenticate: Basic realm="Bindery OPDS"` so mobile readers prompt for creds.

## Endpoint tree

| Method + path | Feed kind | Contents |
| --- | --- | --- |
| `GET /opds` | navigation | Authors / Series / Recent |
| `GET /opds/authors` | navigation (paged, 50/page) | every author with ≥1 imported book |
| `GET /opds/authors/{id}` | acquisition | that author's imported books |
| `GET /opds/series` | navigation (paged, 50/page) | series list |
| `GET /opds/series/{id}` | acquisition | books in series, position-prefixed |
| `GET /opds/recent` | acquisition | last 50 imported books by `updated_at desc` |
| `GET /opds/book/{id}` | acquisition | single-entry detail feed |
| `GET /opds/book/{id}/file` | binary | the actual download (ebook stream or audiobook zip) |

## Architecture

- New package `internal/opds`:
  - `feed.go` — Atom/OPDS XML types (encoding/xml struct tags, explicit `dc:` / `opds:` / `opensearch:` namespace prefixes to keep strict client parsers happy).
  - `builder.go` — assembles all feed shapes via narrow `BookStore` / `AuthorStore` / `SeriesStore` interfaces. `*db.BookRepo` / `*db.AuthorRepo` / `*db.SeriesRepo` satisfy them directly.
  - `helpers.go` — pagination math, RFC3339 formatting, MIME-type guessing (.epub, .pdf, .mobi, .azw3, .cbz, …; audiobooks → `application/zip`).
- New HTTP wiring in `internal/api`:
  - `opds.go` — chi handlers + base-URL resolution (honours `X-Forwarded-Proto` / `X-Forwarded-Host` so embedded `<link href>` values are correct behind Traefik).
  - `opds_auth.go` — OPDS-only auth middleware. **Does not modify the shared `internal/auth/middleware.go`.**
- `cmd/bindery/main.go` — registers `/opds/*` routes alongside (but outside) `/api/v1`; re-uses the existing `FileHandler` so audiobook directory zipping and ebook `Content-Disposition` logic stay in one place.
- No new migration needed — `books.status` is already indexed and the dataset is small enough for the `ORDER BY updated_at` on `/opds/recent` to be fine.

## Coverage

- `internal/opds`: **83.9%** (target ≥70%).
- `internal/api` holds at 61.1% after adding 12 new OPDS handler tests.

## Test plan

- [x] `go test -race ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] Builder unit tests — XML round-trips cleanly, `dc:language` / `xmlns:opds` / acquisition rel emitted as expected
- [x] Handler tests: 401 without creds → `WWW-Authenticate: Basic`; API key (header + query) allows; session cookie allows; HTTP Basic allows with correct password, 401 with wrong; `local-only` mode bypasses for loopback
- [x] Handler tests: `/opds` root feed lists Authors / Series / Recent; author feed emits `application/epub+zip` acquisition link; `/opds/book/{id}/file` serves real bytes with `Content-Disposition`; `404` on missing author; `/opds/recent` contains imported book; full XML re-parses cleanly
- [ ] **Manual smoke test:** KOReader → Catalogue → add URL `http://host:8787/opds` with Basic credentials → browse → download a book. *(To run on a staging instance after this merges; I don't have KOReader handy in this environment.)*

Closes #65.