### PR TITLE
feat(calibre): drop-folder mode + mode selector (closes #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `development` branch carries the in-flight feature set for the next release.
 
 ### Added
 
-- OPDS 1.2 catalogue endpoint (closes [#65](https://github.com/vavallee/bindery/issues/65)) — read-only Atom/OPDS feeds rooted at `/opds/` so KOReader, Moon+ Reader, and other reading apps can browse the Bindery library and download books directly, without Calibre. Navigation feeds for Authors / Series / Recent, acquisition feeds per author / series / single book, and a per-book download link that serves the same bytes as the web UI (audiobook directories are zipped on the fly). The `/opds/*` subtree accepts HTTP Basic, `X-Api-Key`, `?apikey=`, or an existing session cookie; unauthenticated requests get a `401` with a `WWW-Authenticate: Basic realm="Bindery OPDS"` challenge so mobile clients prompt for credentials.
+- **Calibre drop-folder integration + per-library mode selector** ([#64](https://github.com/vavallee/bindery/issues/64)) — Settings → Calibre gains a three-way **Mode** radio (`off` / `calibredb` / `drop_folder`). The new `drop_folder` mode copies imported files into a Calibre-watched directory as `<folder>/<Author>/<Title>.ext` and then polls the Calibre library's `metadata.db` for the assigned book id, for deployments where `calibredb` isn't reachable from the Bindery process. Existing v0.8.0 installs with `calibre.enabled=true` migrate automatically to `mode=calibredb` so no user action is needed to keep the current flow working.
 
 ## [v0.8.0] — 2026-04-14
 

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -142,14 +142,23 @@ func main() {
 		cfg.DownloadPathRemap,
 	)
 
-	// Calibre client: constructed once at boot from the settings table.
-	// The scanner calls Enabled() on every import, so toggling the flag
-	// takes effect without a restart — but a library_path / binary_path
-	// change does require one (same pattern the rest of Bindery uses).
+	// Calibre clients: one per integration mode.
+	//   - calibredb client (Path A, v0.8.0) shells out to `calibredb add`
+	//   - drop-folder writer (Path B, v0.8.1) copies files into Calibre's
+	//     watched directory and polls metadata.db for the returned book id
+	// The mode resolver reads the setting on every import so the operator
+	// can switch modes in the UI without restarting. Library_path and the
+	// binary still require a restart to take effect — same pattern as the
+	// rest of Bindery.
 	calibreClient := calibre.New(api.LoadCalibreConfig(settingsRepo))
-	importScanner.WithCalibre(calibreClient)
-	if calibreClient.Enabled() {
-		slog.Info("calibre integration enabled")
+	dropWriter := calibre.NewDropFolderWriter(api.LoadDropFolderConfig(settingsRepo))
+	modeResolver := func() calibre.Mode { return api.LoadCalibreMode(settingsRepo) }
+	importScanner.WithCalibre(modeResolver, calibreClient, dropWriter)
+	switch api.LoadCalibreMode(settingsRepo) {
+	case calibre.ModeCalibredb:
+		slog.Info("calibre integration enabled", "mode", "calibredb")
+	case calibre.ModeDropFolder:
+		slog.Info("calibre integration enabled", "mode", "drop_folder")
 	}
 
 	// Scheduler

--- a/internal/api/calibre.go
+++ b/internal/api/calibre.go
@@ -13,9 +13,11 @@ import (
 // Calibre settings keys. Centralised so the handler and main.go agree on
 // the exact names and nobody drifts to "calibre_enabled" vs "calibre.enabled".
 const (
-	SettingCalibreEnabled     = "calibre.enabled"
-	SettingCalibreLibraryPath = "calibre.library_path"
-	SettingCalibreBinaryPath  = "calibre.binary_path"
+	SettingCalibreEnabled        = "calibre.enabled"
+	SettingCalibreLibraryPath    = "calibre.library_path"
+	SettingCalibreBinaryPath     = "calibre.binary_path"
+	SettingCalibreMode           = "calibre.mode"
+	SettingCalibreDropFolderPath = "calibre.drop_folder_path"
 )
 
 // CalibreHandler exposes the "test connection" endpoint for the Calibre
@@ -33,6 +35,13 @@ func NewCalibreHandler(settings *db.SettingsRepo) *CalibreHandler {
 // LoadCalibreConfig materialises a calibre.Config from the settings table.
 // Exported so main.go can build the importer's Calibre client at boot and
 // refresh it on each scheduler tick.
+//
+// Enabled is derived from the canonical `calibre.mode` key rather than the
+// legacy `calibre.enabled` boolean: the Client is "enabled" for the
+// purpose of Test / Add when mode is anything other than ModeOff. The
+// mode selector itself is passed separately to the scanner via
+// LoadCalibreMode / LoadDropFolderConfig so the scanner can dispatch
+// between the calibredb and drop-folder paths per import.
 func LoadCalibreConfig(settings *db.SettingsRepo) calibre.Config {
 	ctx := contextBackground()
 	get := func(key string) string {
@@ -42,10 +51,48 @@ func LoadCalibreConfig(settings *db.SettingsRepo) calibre.Config {
 		}
 		return s.Value
 	}
+	mode := LoadCalibreMode(settings)
+	enabled := mode == calibre.ModeCalibredb
+	// Back-compat: if the operator still has the v0.8.0 `calibre.enabled`
+	// boolean set to true but the migration hasn't run yet (e.g. someone
+	// restored an old DB), honour it so the first import doesn't silently
+	// downgrade to off.
+	if !enabled && strings.EqualFold(get(SettingCalibreEnabled), "true") && mode != calibre.ModeDropFolder {
+		enabled = true
+	}
 	return calibre.Config{
-		Enabled:     strings.EqualFold(get(SettingCalibreEnabled), "true"),
+		Enabled:     enabled,
 		LibraryPath: get(SettingCalibreLibraryPath),
 		BinaryPath:  get(SettingCalibreBinaryPath),
+	}
+}
+
+// LoadCalibreMode returns the currently-configured integration mode. The
+// scanner calls this on every import so toggling the radio in Settings
+// takes effect without a restart.
+func LoadCalibreMode(settings *db.SettingsRepo) calibre.Mode {
+	s, _ := settings.Get(contextBackground(), SettingCalibreMode)
+	if s == nil {
+		return calibre.ModeOff
+	}
+	return calibre.ParseMode(s.Value)
+}
+
+// LoadDropFolderConfig materialises the drop-folder-mode settings subset.
+// LibraryPath is shared with calibre.Config because the drop-folder poller
+// reads metadata.db at the same location.
+func LoadDropFolderConfig(settings *db.SettingsRepo) calibre.DropFolderConfig {
+	ctx := contextBackground()
+	get := func(key string) string {
+		s, _ := settings.Get(ctx, key)
+		if s == nil {
+			return ""
+		}
+		return s.Value
+	}
+	return calibre.DropFolderConfig{
+		DropFolderPath: get(SettingCalibreDropFolderPath),
+		LibraryPath:    get(SettingCalibreLibraryPath),
 	}
 }
 

--- a/internal/api/calibre_test.go
+++ b/internal/api/calibre_test.go
@@ -183,3 +183,135 @@ func TestSettings_SetRejectsInvalidCalibrePath(t *testing.T) {
 		t.Error("error field should be non-empty")
 	}
 }
+
+// TestLoadCalibreMode_DefaultsToOff: a fresh DB with no setting row must
+// report mode=off so the scanner doesn't attempt either integration before
+// the operator opts in.
+func TestLoadCalibreMode_DefaultsToOff(t *testing.T) {
+	_, repo, _ := calibreFixture(t)
+	if got := LoadCalibreMode(repo); got != "off" {
+		t.Errorf("LoadCalibreMode default = %q, want off", got)
+	}
+}
+
+// TestLoadCalibreMode_ParsesKnownValues: each canonical mode string must
+// survive a round-trip through the settings table. Regression guard for
+// a typo in the const names breaking the UI's radio group.
+func TestLoadCalibreMode_ParsesKnownValues(t *testing.T) {
+	_, repo, ctx := calibreFixture(t)
+	for _, m := range []string{"off", "calibredb", "drop_folder"} {
+		if err := repo.Set(ctx, SettingCalibreMode, m); err != nil {
+			t.Fatal(err)
+		}
+		if got := string(LoadCalibreMode(repo)); got != m {
+			t.Errorf("LoadCalibreMode for %q = %q", m, got)
+		}
+	}
+}
+
+// TestLoadCalibreConfig_ModeDrivesEnabled: when mode=calibredb the client
+// reports Enabled=true; when mode=drop_folder it reports Enabled=false
+// (the drop-folder path doesn't go through the calibredb client). This is
+// the contract main.go relies on when deciding whether to log "calibre
+// integration enabled" at boot.
+func TestLoadCalibreConfig_ModeDrivesEnabled(t *testing.T) {
+	_, repo, ctx := calibreFixture(t)
+	cases := []struct {
+		mode string
+		want bool
+	}{
+		{"calibredb", true},
+		{"drop_folder", false},
+		{"off", false},
+	}
+	for _, tc := range cases {
+		if err := repo.Set(ctx, SettingCalibreMode, tc.mode); err != nil {
+			t.Fatal(err)
+		}
+		if got := LoadCalibreConfig(repo).Enabled; got != tc.want {
+			t.Errorf("mode=%s Enabled=%v, want %v", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// TestLoadDropFolderConfig_ReadsPaths: LibraryPath is shared with the
+// calibredb client (metadata.db lives there); DropFolderPath is a separate
+// watched directory.
+func TestLoadDropFolderConfig_ReadsPaths(t *testing.T) {
+	_, repo, ctx := calibreFixture(t)
+	lib := t.TempDir()
+	drop := t.TempDir()
+	if err := repo.Set(ctx, SettingCalibreLibraryPath, lib); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Set(ctx, SettingCalibreDropFolderPath, drop); err != nil {
+		t.Fatal(err)
+	}
+	cfg := LoadDropFolderConfig(repo)
+	if cfg.LibraryPath != lib {
+		t.Errorf("LibraryPath = %q, want %q", cfg.LibraryPath, lib)
+	}
+	if cfg.DropFolderPath != drop {
+		t.Errorf("DropFolderPath = %q, want %q", cfg.DropFolderPath, drop)
+	}
+}
+
+func TestValidateSettingValue_CalibreMode(t *testing.T) {
+	if err := validateSettingValue(SettingCalibreMode, ""); err != nil {
+		t.Errorf("empty mode should be accepted (=default off), got %v", err)
+	}
+	for _, m := range []string{"off", "calibredb", "drop_folder"} {
+		if err := validateSettingValue(SettingCalibreMode, m); err != nil {
+			t.Errorf("%q should be accepted: %v", m, err)
+		}
+	}
+	for _, bad := range []string{"enabled", "true", "CALIBREDB", "drop folder"} {
+		if err := validateSettingValue(SettingCalibreMode, bad); err == nil {
+			t.Errorf("%q should be rejected", bad)
+		}
+	}
+}
+
+func TestValidateSettingValue_CalibreDropFolderPath(t *testing.T) {
+	tmp := t.TempDir()
+	if err := validateSettingValue(SettingCalibreDropFolderPath, ""); err != nil {
+		t.Errorf("empty should be accepted: %v", err)
+	}
+	if err := validateSettingValue(SettingCalibreDropFolderPath, tmp); err != nil {
+		t.Errorf("writable dir should be accepted: %v", err)
+	}
+	if err := validateSettingValue(SettingCalibreDropFolderPath, "/no/such/dir"); err == nil {
+		t.Error("missing dir should be rejected")
+	}
+	file := filepath.Join(tmp, "f")
+	if err := os.WriteFile(file, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSettingValue(SettingCalibreDropFolderPath, file); err == nil {
+		t.Error("file should be rejected as drop folder")
+	}
+}
+
+// TestMigrate_LegacyEnabledHonored: the upgrade migration rewrites
+// calibre.enabled=true → calibre.mode=calibredb. In edge cases where the
+// migration hasn't run but the legacy key says true, LoadCalibreConfig
+// should still report Enabled=true so imports don't silently stop
+// mirroring mid-upgrade.
+func TestLoadCalibreConfig_LegacyEnabledHonored(t *testing.T) {
+	_, repo, ctx := calibreFixture(t)
+	if err := repo.Set(ctx, SettingCalibreEnabled, "true"); err != nil {
+		t.Fatal(err)
+	}
+	// Mode left unset (empty → off).
+	if got := LoadCalibreConfig(repo).Enabled; !got {
+		t.Error("legacy calibre.enabled=true must keep Enabled=true")
+	}
+	// But when the operator has explicitly picked drop_folder, the
+	// legacy flag must NOT resurrect the calibredb path.
+	if err := repo.Set(ctx, SettingCalibreMode, "drop_folder"); err != nil {
+		t.Fatal(err)
+	}
+	if got := LoadCalibreConfig(repo).Enabled; got {
+		t.Error("mode=drop_folder must override legacy calibre.enabled")
+	}
+}

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/vavallee/bindery/internal/calibre"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -126,6 +127,41 @@ func validateSettingValue(key, value string) error {
 		if info.Mode()&0o111 == 0 {
 			return fmt.Errorf("binary_path %q is not executable", value)
 		}
+	case SettingCalibreMode:
+		// Canonical values only. An empty string falls through to the
+		// default (off) handled by LoadCalibreMode; anything else must
+		// parse to a known mode so a typo in the UI cannot silently
+		// disable the integration.
+		if value == "" {
+			return nil
+		}
+		if !calibre.Mode(value).Valid() {
+			return fmt.Errorf("calibre.mode %q is not one of off, calibredb, drop_folder", value)
+		}
+	case SettingCalibreDropFolderPath:
+		// Empty is allowed: it's how the user disables the drop-folder
+		// target without flipping the mode. When set, require an existing
+		// writable directory so we fail fast in settings rather than in
+		// the middle of an import goroutine.
+		if value == "" {
+			return nil
+		}
+		info, err := os.Stat(value)
+		if err != nil {
+			return fmt.Errorf("drop_folder_path %q: %w", value, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("drop_folder_path %q is not a directory", value)
+		}
+		// Probe write access: creating a temp file exercises exactly the
+		// EACCES / EROFS surface the importer would hit later.
+		probe, err := os.CreateTemp(value, ".bindery-drop-probe-*")
+		if err != nil {
+			return fmt.Errorf("drop_folder_path %q is not writable: %w", value, err)
+		}
+		name := probe.Name()
+		_ = probe.Close()
+		_ = os.Remove(name)
 	}
 	return nil
 }

--- a/internal/calibre/drop_folder.go
+++ b/internal/calibre/drop_folder.go
@@ -1,0 +1,199 @@
+package calibre
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DropFolderConfig is the subset of Calibre settings the drop-folder writer
+// needs. DropFolderPath is the Calibre-watched directory (the "Add books to
+// library from folders" target); LibraryPath is the same metadata.db
+// location the calibredb flow uses, needed for the post-ingest lookup.
+type DropFolderConfig struct {
+	DropFolderPath string
+	LibraryPath    string
+
+	// PollInterval + PollAttempts control how patiently we wait for Calibre
+	// to pick up the dropped file. Calibre's folder-watch runs on a timer
+	// (default 60s, often shortened to a few seconds) so the default
+	// 10 × 3s = 30s total budget covers the common case without blocking
+	// the import goroutine for long. Zero values fall back to the defaults.
+	PollInterval time.Duration
+	PollAttempts int
+}
+
+// DefaultPollInterval / DefaultPollAttempts — 10 × 3s is enough for
+// Calibre's folder-watch at its typical tick rate and still returns within
+// the importer's per-book budget. Operators who run Calibre with the
+// watched-folder poll turned up to a minute will need to tune these.
+const (
+	DefaultPollInterval = 3 * time.Second
+	DefaultPollAttempts = 10
+)
+
+// ErrDropFolderNotConfigured is returned when the writer is asked to ingest
+// a file but no drop folder has been set in settings. Callers treat it as
+// a soft-skip (same semantics as ErrDisabled for the calibredb client).
+var ErrDropFolderNotConfigured = errors.New("calibre drop_folder_path is not configured")
+
+// DropFolderWriter copies newly-imported files into a Calibre-watched
+// directory and then polls metadata.db until Calibre assigns a book id.
+// The zero value is unusable; construct with NewDropFolderWriter.
+type DropFolderWriter struct {
+	cfg    DropFolderConfig
+	lookup lookupFn
+	// now is injected so tests can keep backoff deterministic without
+	// waiting seconds on the wall clock.
+	now func() time.Time
+}
+
+// lookupFn abstracts LookupByTitleAuthor so tests can drive the poller with
+// predictable found/not-found sequences instead of seeding a live sqlite.
+type lookupFn func(ctx context.Context, libraryPath, title, author string) (int64, bool, error)
+
+// NewDropFolderWriter builds a writer against cfg. The real
+// LookupByTitleAuthor is used for metadata.db reads; tests can use
+// newDropFolderWriterFunc to stub it.
+func NewDropFolderWriter(cfg DropFolderConfig) *DropFolderWriter {
+	return &DropFolderWriter{cfg: cfg, lookup: LookupByTitleAuthor, now: time.Now}
+}
+
+// IngestResult reports what happened for a single Ingest call. Returned
+// (instead of raw errors) so the caller can record a metric like
+// "dropped-and-found" vs "dropped-but-timeout" without parsing strings.
+type IngestResult struct {
+	// DroppedPath is where the file now lives inside the drop folder.
+	// Populated even on a poll timeout — Calibre may still ingest it later.
+	DroppedPath string
+
+	// CalibreID is the id Calibre assigned to the dropped file. Non-zero
+	// only when Found is true; callers should persist this on the book row.
+	CalibreID int64
+
+	// Found reports whether the poll succeeded within the budget. A false
+	// value means Calibre hadn't picked up the file by the time we gave up;
+	// the importer treats this as a warn-and-continue rather than an error.
+	Found bool
+}
+
+// Ingest copies srcPath into the watched drop folder using the
+// `<drop>/<Author>/<Title>.ext` layout Calibre expects, then polls
+// metadata.db for a matching row. title + author drive both the file name
+// and the lookup query, so operators can pass whatever identifier pair
+// will appear in Calibre after ingest.
+//
+// The returned error distinguishes "could not drop the file" (hard fail —
+// either a missing config or an I/O problem) from "dropped but Calibre
+// didn't pick it up in time" (returned as a result with Found=false and
+// nil error). The importer's caller relies on that distinction to choose
+// between "warn" and "skip the Calibre mirror entirely".
+func (w *DropFolderWriter) Ingest(ctx context.Context, srcPath, title, author string) (IngestResult, error) {
+	if w.cfg.DropFolderPath == "" {
+		return IngestResult{}, ErrDropFolderNotConfigured
+	}
+	if srcPath == "" {
+		return IngestResult{}, errors.New("drop folder: empty source path")
+	}
+	if title == "" || author == "" {
+		return IngestResult{}, errors.New("drop folder: title and author are required")
+	}
+
+	ext := filepath.Ext(srcPath)
+	destDir := filepath.Join(w.cfg.DropFolderPath, sanitizeSegment(author))
+	destPath := filepath.Join(destDir, sanitizeSegment(title)+ext)
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return IngestResult{}, fmt.Errorf("drop folder: mkdir %q: %w", destDir, err)
+	}
+	if err := copyFile(srcPath, destPath); err != nil {
+		return IngestResult{}, fmt.Errorf("drop folder: copy to %q: %w", destPath, err)
+	}
+
+	slog.Info("calibre drop-folder: file written",
+		"src", srcPath, "dst", destPath, "title", title, "author", author)
+
+	id, found := w.pollForBook(ctx, title, author)
+	return IngestResult{DroppedPath: destPath, CalibreID: id, Found: found}, nil
+}
+
+// pollForBook loops LookupByTitleAuthor at the configured cadence until the
+// book appears or the attempt budget is exhausted. Lookup errors mid-poll
+// (e.g. Calibre transiently holds the DB open for a write) are logged at
+// debug but don't short-circuit — the next tick usually succeeds.
+func (w *DropFolderWriter) pollForBook(ctx context.Context, title, author string) (int64, bool) {
+	interval := w.cfg.PollInterval
+	if interval <= 0 {
+		interval = DefaultPollInterval
+	}
+	attempts := w.cfg.PollAttempts
+	if attempts <= 0 {
+		attempts = DefaultPollAttempts
+	}
+
+	for i := 0; i < attempts; i++ {
+		if ctx.Err() != nil {
+			return 0, false
+		}
+		id, found, err := w.lookup(ctx, w.cfg.LibraryPath, title, author)
+		if err != nil {
+			slog.Debug("calibre drop-folder: lookup transient error",
+				"attempt", i+1, "error", err)
+		}
+		if found {
+			return id, true
+		}
+		// Sleep between attempts but stay cancel-aware. A cancelled
+		// context from shutdown should drop out immediately rather than
+		// waiting out the remaining budget.
+		select {
+		case <-ctx.Done():
+			return 0, false
+		case <-time.After(interval):
+		}
+	}
+	return 0, false
+}
+
+// sanitizeSegment strips characters that break path segments on the usual
+// filesystems. This is intentionally narrower than importer.sanitizePath
+// (which also trims) so the drop-folder layout stays predictable: Calibre
+// reads back whatever we put on disk, so "Author/Title" must survive the
+// round-trip without surprise transformation. Exported via copyFile.
+func sanitizeSegment(s string) string {
+	// Same set as importer.sanitizePath — kept local so the calibre
+	// package doesn't need to import importer (which would cycle).
+	replacer := strings.NewReplacer(
+		"/", "-", "\\", "-", ":", "-", "*", "", "?", "",
+		"\"", "", "<", "", ">", "", "|", "",
+	)
+	return strings.TrimSpace(replacer.Replace(s))
+}
+
+// copyFile performs a streaming copy from src to dst. Keeping this local
+// (rather than importing importer.copyFile) avoids a package cycle — the
+// scanner imports calibre, so calibre cannot import importer.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}

--- a/internal/calibre/drop_folder_test.go
+++ b/internal/calibre/drop_folder_test.go
@@ -1,0 +1,295 @@
+package calibre
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeLookup returns canned results for the poller. seq indexes one result
+// per call so tests can model "not found → not found → found" sequences.
+type fakeLookup struct {
+	calls   int
+	seq     []fakeLookupResp
+	onCall  func(int) // optional spy for call-count assertions
+}
+
+type fakeLookupResp struct {
+	id    int64
+	found bool
+	err   error
+}
+
+func (f *fakeLookup) fn(_ context.Context, _, _, _ string) (int64, bool, error) {
+	n := f.calls
+	f.calls++
+	if f.onCall != nil {
+		f.onCall(n)
+	}
+	if n >= len(f.seq) {
+		// Off-the-end — keep returning "not found" so infinite-poll tests
+		// terminate by the attempts budget.
+		return 0, false, nil
+	}
+	r := f.seq[n]
+	return r.id, r.found, r.err
+}
+
+func makeSrc(t *testing.T, name, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestIngest_HappyPath: file lands in `drop/Author/Title.ext`, lookup hits
+// on the first attempt, IngestResult carries the returned id.
+func TestIngest_HappyPath(t *testing.T) {
+	drop := t.TempDir()
+	src := makeSrc(t, "input.epub", "the-bytes")
+
+	w := NewDropFolderWriter(DropFolderConfig{
+		DropFolderPath: drop,
+		LibraryPath:    "/unused-in-this-test",
+		PollInterval:   time.Millisecond,
+		PollAttempts:   2,
+	})
+	fl := &fakeLookup{seq: []fakeLookupResp{{id: 42, found: true}}}
+	w.lookup = fl.fn
+
+	res, err := w.Ingest(context.Background(), src, "The Road", "Cormac McCarthy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Found {
+		t.Error("Found should be true")
+	}
+	if res.CalibreID != 42 {
+		t.Errorf("CalibreID = %d, want 42", res.CalibreID)
+	}
+	wantPath := filepath.Join(drop, "Cormac McCarthy", "The Road.epub")
+	if res.DroppedPath != wantPath {
+		t.Errorf("DroppedPath = %q, want %q", res.DroppedPath, wantPath)
+	}
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Errorf("file should exist at %q: %v", wantPath, err)
+	}
+	if fl.calls != 1 {
+		t.Errorf("lookup called %d times, want 1", fl.calls)
+	}
+}
+
+// TestIngest_PollEventuallyFinds verifies the retry loop — the first two
+// lookups say "not found", the third hits. The file drop happens once,
+// before any lookup; only the lookup count retries.
+func TestIngest_PollEventuallyFinds(t *testing.T) {
+	drop := t.TempDir()
+	src := makeSrc(t, "in.epub", "x")
+
+	w := NewDropFolderWriter(DropFolderConfig{
+		DropFolderPath: drop,
+		LibraryPath:    "/unused",
+		PollInterval:   time.Millisecond,
+		PollAttempts:   5,
+	})
+	fl := &fakeLookup{seq: []fakeLookupResp{
+		{}, {}, {id: 7, found: true},
+	}}
+	w.lookup = fl.fn
+
+	res, err := w.Ingest(context.Background(), src, "T", "A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Found || res.CalibreID != 7 {
+		t.Errorf("expected found=true id=7, got %+v", res)
+	}
+	if fl.calls != 3 {
+		t.Errorf("lookup called %d times, want 3", fl.calls)
+	}
+}
+
+// TestIngest_PollExhausted: Calibre never picks up the file. Ingest returns
+// nil error (file drop succeeded) but Found=false; caller logs a warning
+// and continues the import without a calibre_id mapping.
+func TestIngest_PollExhausted(t *testing.T) {
+	drop := t.TempDir()
+	src := makeSrc(t, "in.epub", "x")
+
+	w := NewDropFolderWriter(DropFolderConfig{
+		DropFolderPath: drop,
+		LibraryPath:    "/unused",
+		PollInterval:   time.Microsecond,
+		PollAttempts:   3,
+	})
+	fl := &fakeLookup{seq: nil} // always not-found
+	w.lookup = fl.fn
+
+	res, err := w.Ingest(context.Background(), src, "T", "A")
+	if err != nil {
+		t.Fatalf("Ingest should not fail on poll timeout, got %v", err)
+	}
+	if res.Found {
+		t.Error("Found should be false when Calibre never picks up")
+	}
+	if res.CalibreID != 0 {
+		t.Errorf("CalibreID should be zero, got %d", res.CalibreID)
+	}
+	if fl.calls != 3 {
+		t.Errorf("lookup called %d times, want 3 (attempts budget)", fl.calls)
+	}
+	if _, err := os.Stat(res.DroppedPath); err != nil {
+		t.Errorf("file should still exist in drop folder: %v", err)
+	}
+}
+
+// TestIngest_LookupErrorsDontShortCircuit: a transient lookup error in the
+// middle of the poll should be logged (see slog.Debug) but must not abort
+// the retry loop — Calibre sometimes transiently locks metadata.db.
+func TestIngest_LookupErrorsDontShortCircuit(t *testing.T) {
+	drop := t.TempDir()
+	src := makeSrc(t, "in.epub", "x")
+
+	w := NewDropFolderWriter(DropFolderConfig{
+		DropFolderPath: drop,
+		LibraryPath:    "/unused",
+		PollInterval:   time.Microsecond,
+		PollAttempts:   4,
+	})
+	fl := &fakeLookup{seq: []fakeLookupResp{
+		{err: errors.New("db locked")},
+		{err: errors.New("db locked")},
+		{id: 99, found: true},
+	}}
+	w.lookup = fl.fn
+
+	res, err := w.Ingest(context.Background(), src, "T", "A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Found || res.CalibreID != 99 {
+		t.Errorf("expected found=true id=99, got %+v", res)
+	}
+}
+
+// TestIngest_ContextCancel: a cancelled context during the sleep between
+// attempts must break out immediately rather than waiting the full budget.
+func TestIngest_ContextCancel(t *testing.T) {
+	drop := t.TempDir()
+	src := makeSrc(t, "in.epub", "x")
+
+	w := NewDropFolderWriter(DropFolderConfig{
+		DropFolderPath: drop,
+		LibraryPath:    "/unused",
+		PollInterval:   50 * time.Millisecond,
+		PollAttempts:   100,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	fl := &fakeLookup{
+		onCall: func(n int) {
+			if n == 1 {
+				cancel()
+			}
+		},
+	}
+	w.lookup = fl.fn
+
+	start := time.Now()
+	res, err := w.Ingest(ctx, src, "T", "A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Found {
+		t.Error("Found should be false when ctx cancelled")
+	}
+	// Shouldn't have burned the full 100 × 50ms budget.
+	if time.Since(start) > 500*time.Millisecond {
+		t.Errorf("context cancel didn't short-circuit: %s", time.Since(start))
+	}
+}
+
+// TestIngest_RejectsUnconfigured: with drop_folder_path unset we return
+// ErrDropFolderNotConfigured so the scanner can log-and-skip.
+func TestIngest_RejectsUnconfigured(t *testing.T) {
+	src := makeSrc(t, "in.epub", "x")
+	w := NewDropFolderWriter(DropFolderConfig{DropFolderPath: ""})
+	_, err := w.Ingest(context.Background(), src, "T", "A")
+	if !errors.Is(err, ErrDropFolderNotConfigured) {
+		t.Errorf("err = %v, want ErrDropFolderNotConfigured", err)
+	}
+}
+
+// TestIngest_RejectsEmptyTitleOrAuthor: title/author drive both the file
+// name and the DB lookup, so blank either must be rejected up front.
+func TestIngest_RejectsEmptyTitleOrAuthor(t *testing.T) {
+	drop := t.TempDir()
+	src := makeSrc(t, "in.epub", "x")
+	w := NewDropFolderWriter(DropFolderConfig{DropFolderPath: drop, LibraryPath: "/x"})
+	if _, err := w.Ingest(context.Background(), src, "", "A"); err == nil {
+		t.Error("empty title should be rejected")
+	}
+	if _, err := w.Ingest(context.Background(), src, "T", ""); err == nil {
+		t.Error("empty author should be rejected")
+	}
+	if _, err := w.Ingest(context.Background(), "", "T", "A"); err == nil {
+		t.Error("empty src should be rejected")
+	}
+}
+
+// TestIngest_SanitizesPathSegments: path-unsafe characters in title /
+// author must not escape into the drop folder. A ":" in the title would
+// break Windows, "/" would create an unintended subdirectory.
+func TestIngest_SanitizesPathSegments(t *testing.T) {
+	drop := t.TempDir()
+	src := makeSrc(t, "in.epub", "x")
+	w := NewDropFolderWriter(DropFolderConfig{
+		DropFolderPath: drop,
+		LibraryPath:    "/x",
+		PollAttempts:   1,
+		PollInterval:   time.Microsecond,
+	})
+	w.lookup = (&fakeLookup{}).fn
+
+	res, err := w.Ingest(context.Background(), src, "Who: What/Where?", "A/B")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(res.DroppedPath[len(drop):], ":") {
+		t.Errorf("dropped path should not contain ':', got %q", res.DroppedPath)
+	}
+	rel, _ := filepath.Rel(drop, res.DroppedPath)
+	// Must have exactly one separator: Author/Title.ext — no extra dirs
+	// from the embedded "/".
+	if c := strings.Count(rel, string(filepath.Separator)); c != 1 {
+		t.Errorf("expected single separator in %q, got %d", rel, c)
+	}
+}
+
+// TestIngest_DefaultsAppliedWhenCfgZero: zero-valued PollInterval /
+// PollAttempts fall back to the package defaults rather than spinning
+// the poll loop zero times or busy-looping.
+func TestIngest_DefaultsAppliedWhenCfgZero(t *testing.T) {
+	drop := t.TempDir()
+	src := makeSrc(t, "in.epub", "x")
+	w := NewDropFolderWriter(DropFolderConfig{
+		DropFolderPath: drop,
+		LibraryPath:    "/x",
+		// Leave PollInterval + PollAttempts zero to exercise defaulting.
+	})
+	fl := &fakeLookup{seq: []fakeLookupResp{{id: 1, found: true}}}
+	w.lookup = fl.fn
+	res, err := w.Ingest(context.Background(), src, "T", "A")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Found {
+		t.Error("first-attempt hit should succeed with defaults")
+	}
+}

--- a/internal/calibre/mode.go
+++ b/internal/calibre/mode.go
@@ -1,0 +1,64 @@
+package calibre
+
+import "strings"
+
+// Mode selects which Calibre-integration flow the importer runs after a
+// successful Bindery import. v0.8.0 shipped only the calibredb path; v0.8.1
+// adds drop-folder ingest and a per-library toggle so operators can pick
+// the one that fits their deployment.
+type Mode string
+
+const (
+	// ModeOff disables Calibre integration. Imports behave as if no Calibre
+	// library were configured: no external call, no mutation on the book row.
+	ModeOff Mode = "off"
+
+	// ModeCalibredb shells out to `calibredb add --with-library <path>`.
+	// This is the v0.8.0 path and is preserved unchanged for installs that
+	// have calibredb on PATH and a writable library directory.
+	ModeCalibredb Mode = "calibredb"
+
+	// ModeDropFolder writes the imported file into a Calibre-watched
+	// directory and then polls Calibre's metadata.db for the resulting
+	// book id. This path is for deployments where Calibre runs in a
+	// separate container / host and calibredb is not reachable from Bindery.
+	ModeDropFolder Mode = "drop_folder"
+)
+
+// ParseMode coerces the raw settings-table string into a known Mode. Unknown
+// or empty values fall through to ModeOff — treating a fresh install or a
+// typoed value as "leave it alone" is strictly safer than "try calibredb and
+// log warnings".
+//
+// The string is case-insensitive so the UI can round-trip "Off" / "Drop
+// folder" labels without the backend caring about capitalisation. Legacy
+// "true"/"false" values (from the v0.8.0 `calibre.enabled` boolean) are
+// deliberately NOT handled here: migration 011 rewrites them into proper
+// mode values at upgrade time, so by the time this function runs the
+// settings table always holds one of the three canonical strings (or empty
+// on a brand-new install before the migration seeds defaults).
+func ParseMode(s string) Mode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case string(ModeCalibredb):
+		return ModeCalibredb
+	case string(ModeDropFolder):
+		return ModeDropFolder
+	default:
+		return ModeOff
+	}
+}
+
+// Valid reports whether m is one of the three canonical modes. The settings
+// endpoint uses this to reject PUTs that would leave the integration in an
+// uninterpretable state.
+func (m Mode) Valid() bool {
+	switch m {
+	case ModeOff, ModeCalibredb, ModeDropFolder:
+		return true
+	}
+	return false
+}
+
+// String implements fmt.Stringer so slog output reads "mode=drop_folder"
+// rather than "mode=calibre.Mode("drop_folder")".
+func (m Mode) String() string { return string(m) }

--- a/internal/calibre/mode_test.go
+++ b/internal/calibre/mode_test.go
@@ -1,0 +1,50 @@
+package calibre
+
+import "testing"
+
+func TestParseMode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Mode
+	}{
+		{"calibredb", ModeCalibredb},
+		{"CALIBREDB", ModeCalibredb},
+		{"  calibredb  ", ModeCalibredb},
+		{"drop_folder", ModeDropFolder},
+		{"Drop_Folder", ModeDropFolder},
+		{"off", ModeOff},
+		{"", ModeOff},
+		{"something-else", ModeOff},
+		// Legacy boolean values from v0.8.0 settings must NOT silently map —
+		// the upgrade migration rewrites them to explicit mode strings, and
+		// if one still leaks through we want it to be recognised as "off"
+		// so the importer skips the Calibre call rather than defaulting to
+		// calibredb on a setup that may no longer have it installed.
+		{"true", ModeOff},
+		{"false", ModeOff},
+	}
+	for _, tc := range cases {
+		if got := ParseMode(tc.in); got != tc.want {
+			t.Errorf("ParseMode(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMode_Valid(t *testing.T) {
+	for _, m := range []Mode{ModeOff, ModeCalibredb, ModeDropFolder} {
+		if !m.Valid() {
+			t.Errorf("%q should be Valid", m)
+		}
+	}
+	for _, m := range []Mode{"", "nope", "true", "CALIBREDB"} {
+		if m.Valid() {
+			t.Errorf("%q should not be Valid (canonical casing only)", m)
+		}
+	}
+}
+
+func TestMode_String(t *testing.T) {
+	if got := ModeDropFolder.String(); got != "drop_folder" {
+		t.Errorf("String() = %q, want %q", got, "drop_folder")
+	}
+}

--- a/internal/calibre/reader_lookup.go
+++ b/internal/calibre/reader_lookup.go
@@ -1,0 +1,76 @@
+package calibre
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	_ "modernc.org/sqlite"
+)
+
+// reader_lookup.go is a SCAFFOLD kept small on purpose. Stream A owns
+// internal/calibre/reader.go (a richer wrapper around Calibre's metadata.db);
+// this file exists only so Path B can compile and ship an end-to-end
+// drop-folder flow before Stream A merges. On rebase we refactor
+// LookupByTitleAuthor to call Stream A's reader and delete this file.
+//
+// Keeping the surface here deliberately tiny (one function) minimises the
+// blast radius of that refactor and makes the "did I forget something on
+// rebase?" check trivial: only drop_folder.go consumes this.
+
+// ErrCalibreDBNotFound is returned when the metadata.db file cannot be
+// stat'd at the configured library path. The drop-folder flow translates
+// this into a single warning + skip rather than blocking the Bindery
+// import, since the operator may simply have mis-pointed library_path.
+var ErrCalibreDBNotFound = errors.New("calibre metadata.db not found at library_path")
+
+// LookupByTitleAuthor opens Calibre's metadata.db (read-only) at the given
+// library path and returns the book id of the first row matching BOTH
+// title and author name exactly. If no matching row is found, found=false
+// with a nil error — the caller (drop-folder poller) uses that to decide
+// whether to retry or give up.
+//
+// Exact match is deliberate: Calibre preserves titles verbatim from the
+// metadata Bindery writes out, so the title we compare against is the one
+// we just asked Calibre to ingest. A fuzzy match here would mask real
+// "Calibre didn't pick up the file" problems behind spurious hits.
+func LookupByTitleAuthor(ctx context.Context, libraryPath, title, author string) (int64, bool, error) {
+	if libraryPath == "" {
+		return 0, false, ErrCalibreDBNotFound
+	}
+	dbPath := filepath.Join(libraryPath, "metadata.db")
+	// SQLite DSN: mode=ro so a concurrent Calibre writer can't be blocked
+	// by us, and immutable=0 (the default) so we see new rows as Calibre
+	// ingests them — crucial for the poll loop.
+	dsn := fmt.Sprintf("file:%s?mode=ro", dbPath)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return 0, false, fmt.Errorf("open calibre metadata.db: %w", err)
+	}
+	defer db.Close()
+
+	// Calibre's schema: books + authors + books_authors_link. A single
+	// book may have several authors (primary + secondary); matching any
+	// one of them is enough to claim the row — the drop-folder writer
+	// only provides the primary author name anyway.
+	const q = `
+SELECT b.id
+FROM books b
+JOIN books_authors_link bal ON bal.book = b.id
+JOIN authors a ON a.id = bal.author
+WHERE b.title = ? AND a.name = ?
+ORDER BY b.id DESC
+LIMIT 1`
+
+	var id int64
+	err = db.QueryRowContext(ctx, q, title, author).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("query calibre books: %w", err)
+	}
+	return id, true, nil
+}

--- a/internal/calibre/reader_lookup_test.go
+++ b/internal/calibre/reader_lookup_test.go
@@ -1,0 +1,152 @@
+package calibre
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// seedCalibreDB builds a tiny metadata.db with just enough schema to exercise
+// LookupByTitleAuthor. We only need the three tables the query touches:
+// books, authors, books_authors_link. The real Calibre schema has dozens
+// more columns — none are referenced by our lookup so leaving them out is
+// safe and keeps the fixture readable.
+func seedCalibreDB(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "metadata.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	schema := `
+CREATE TABLE books (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    sort  TEXT
+);
+CREATE TABLE authors (
+    id   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    sort TEXT
+);
+CREATE TABLE books_authors_link (
+    id     INTEGER PRIMARY KEY AUTOINCREMENT,
+    book   INTEGER NOT NULL,
+    author INTEGER NOT NULL
+);`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func addCalibreBook(t *testing.T, dbPath, title, author string) int64 {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	res, err := db.Exec(`INSERT INTO books (title) VALUES (?)`, title)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bookID, _ := res.LastInsertId()
+	res, err = db.Exec(`INSERT INTO authors (name) VALUES (?)`, author)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorID, _ := res.LastInsertId()
+	if _, err := db.Exec(`INSERT INTO books_authors_link (book, author) VALUES (?, ?)`, bookID, authorID); err != nil {
+		t.Fatal(err)
+	}
+	return bookID
+}
+
+func TestLookupByTitleAuthor_Found(t *testing.T) {
+	dir := t.TempDir()
+	seedCalibreDB(t, dir)
+	want := addCalibreBook(t, filepath.Join(dir, "metadata.db"), "The Road", "Cormac McCarthy")
+
+	id, found, err := LookupByTitleAuthor(context.Background(), dir, "The Road", "Cormac McCarthy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("found should be true")
+	}
+	if id != want {
+		t.Errorf("id = %d, want %d", id, want)
+	}
+}
+
+func TestLookupByTitleAuthor_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	seedCalibreDB(t, dir)
+	addCalibreBook(t, filepath.Join(dir, "metadata.db"), "The Road", "Cormac McCarthy")
+
+	_, found, err := LookupByTitleAuthor(context.Background(), dir, "No Country for Old Men", "Cormac McCarthy")
+	if err != nil {
+		t.Fatalf("not-found should return nil err, got %v", err)
+	}
+	if found {
+		t.Error("found should be false for missing title")
+	}
+}
+
+// TestLookupByTitleAuthor_MissingDB covers the "library_path points at a
+// directory without metadata.db" case. We surface sql.ErrNoRows-equivalent
+// silence (found=false, err!=nil) so the poller can log and retry rather
+// than treating a missing library as a hard fail.
+func TestLookupByTitleAuthor_MissingDB(t *testing.T) {
+	dir := t.TempDir()
+	_, found, err := LookupByTitleAuthor(context.Background(), dir, "x", "y")
+	if err == nil {
+		t.Error("missing metadata.db should return an error")
+	}
+	if found {
+		t.Error("found should be false when DB is missing")
+	}
+}
+
+func TestLookupByTitleAuthor_EmptyPath(t *testing.T) {
+	_, found, err := LookupByTitleAuthor(context.Background(), "", "x", "y")
+	if err == nil {
+		t.Error("empty library path should be rejected")
+	}
+	if found {
+		t.Error("found should be false for empty path")
+	}
+}
+
+// TestLookupByTitleAuthor_MultipleAuthorsOnBook: Calibre allows a book to
+// have multiple author rows via books_authors_link. A match on any one of
+// them is enough — the drop-folder flow only passes the primary author and
+// we don't want an "also wrote with" secondary author to hide the book.
+func TestLookupByTitleAuthor_MultipleAuthorsOnBook(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := seedCalibreDB(t, dir)
+	bookID := addCalibreBook(t, dbPath, "Good Omens", "Terry Pratchett")
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	res, _ := db.Exec(`INSERT INTO authors (name) VALUES (?)`, "Neil Gaiman")
+	authorID, _ := res.LastInsertId()
+	if _, err := db.Exec(`INSERT INTO books_authors_link (book, author) VALUES (?, ?)`, bookID, authorID); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"Terry Pratchett", "Neil Gaiman"} {
+		id, found, err := LookupByTitleAuthor(context.Background(), dir, "Good Omens", name)
+		if err != nil || !found || id != bookID {
+			t.Errorf("author %q: id=%d found=%v err=%v", name, id, found, err)
+		}
+	}
+}

--- a/internal/db/migrations/011_calibre_mode.sql
+++ b/internal/db/migrations/011_calibre_mode.sql
@@ -1,0 +1,36 @@
+-- +migrate Up
+
+-- Calibre integration gains a per-library mode selector. v0.8.0 shipped a
+-- single boolean (calibre.enabled) driving the `calibredb add` flow. v0.8.1
+-- adds a second flow (drop-folder ingest) and the UI lets the operator pick
+-- which one to use, or leave the integration off entirely.
+--
+-- calibre.mode values:
+--   off          no Calibre call on import (new default)
+--   calibredb    shell out to `calibredb add --with-library` (v0.8.0 path)
+--   drop_folder  write the file into a watched directory and poll Calibre
+--                metadata.db for the resulting book id
+--
+-- calibre.drop_folder_path is the watch directory Calibre folder-watch
+-- is pointed at. Empty when drop-folder mode is not in use.
+INSERT OR IGNORE INTO settings (key, value) VALUES
+    ('calibre.mode',              'off'),
+    ('calibre.drop_folder_path',  '');
+
+-- Migrate existing v0.8.0 installs: if the operator had the old boolean
+-- toggle set to true, preserve their working setup by defaulting the new
+-- mode to calibredb. Fresh installs (where calibre.enabled defaulted to
+-- false) stay on off. We scope the UPDATE to value=off so an operator
+-- who already picked a mode out-of-band is not overwritten.
+UPDATE settings
+SET value = 'calibredb'
+WHERE key = 'calibre.mode'
+  AND value = 'off'
+  AND EXISTS (
+      SELECT 1 FROM settings
+      WHERE key = 'calibre.enabled' AND LOWER(value) = 'true'
+  );
+
+-- +migrate Down
+-- Settings-row seeds are harmless if they linger, leave them in place on
+-- rollback. Downgrading the binary will simply ignore the new keys.

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -20,27 +20,37 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
-// calibreClient is the subset of *calibre.Client the scanner relies on.
-// Defining it here lets tests and main.go swap implementations without
-// touching the importer surface.
-type calibreClient interface {
-	Enabled() bool
+// calibreAdder is the calibredb half of the Calibre integration: it mirrors
+// a just-imported file into Calibre by shelling out to `calibredb add`.
+// The scanner holds a reference to one of these but only invokes it when
+// the mode resolver says we're in ModeCalibredb.
+type calibreAdder interface {
 	Add(ctx context.Context, filePath string) (int64, error)
+}
+
+// calibreDropFolderWriter is the drop-folder half of the integration:
+// writes the file to Calibre's watched directory and polls metadata.db for
+// the resulting book id. Kept as an interface so tests can stub it without
+// touching the filesystem.
+type calibreDropFolderWriter interface {
+	Ingest(ctx context.Context, srcPath, title, author string) (calibre.IngestResult, error)
 }
 
 // Scanner checks for completed downloads and imports them into the library.
 type Scanner struct {
-	downloads    *db.DownloadRepo
-	clients      *db.DownloadClientRepo
-	books        *db.BookRepo
-	authors      *db.AuthorRepo
-	history      *db.HistoryRepo
-	renamer      *Renamer
-	remapper     *Remapper
-	calibre      calibreClient
-	settings     *db.SettingsRepo
-	libraryDir   string
-	audiobookDir string
+	downloads      *db.DownloadRepo
+	clients        *db.DownloadClientRepo
+	books          *db.BookRepo
+	authors        *db.AuthorRepo
+	history        *db.HistoryRepo
+	renamer        *Renamer
+	remapper       *Remapper
+	calibreAdder   calibreAdder
+	calibreDrop    calibreDropFolderWriter
+	calibreMode    func() calibre.Mode
+	settings       *db.SettingsRepo
+	libraryDir     string
+	audiobookDir   string
 }
 
 // NewScanner creates an import scanner. downloadPathRemap is an optional
@@ -66,12 +76,16 @@ func NewScanner(downloads *db.DownloadRepo, clients *db.DownloadClientRepo,
 	}
 }
 
-// WithCalibre attaches a Calibre client to the scanner. When the client is
-// enabled the scanner mirrors every successful import into the configured
-// Calibre library and persists the returned id on the book row. Passing a
-// disabled (or nil-interface) client is a no-op.
-func (s *Scanner) WithCalibre(c calibreClient) *Scanner {
-	s.calibre = c
+// WithCalibre attaches the Calibre integration pieces. The mode resolver
+// is consulted on every import so the operator can switch modes (or turn
+// the integration off) in the UI without restarting Bindery. Passing nil
+// for any argument disables that branch — a nil resolver skips all Calibre
+// calls, a nil adder skips only the calibredb path, a nil drop writer
+// skips only the drop-folder path.
+func (s *Scanner) WithCalibre(mode func() calibre.Mode, adder calibreAdder, drop calibreDropFolderWriter) *Scanner {
+	s.calibreMode = mode
+	s.calibreAdder = adder
+	s.calibreDrop = drop
 	return s
 }
 
@@ -82,15 +96,39 @@ func (s *Scanner) WithSettings(sr *db.SettingsRepo) *Scanner {
 	return s
 }
 
-// pushToCalibre runs `calibredb add` for a just-imported book. Failures are
-// logged and swallowed — Calibre sync is a best-effort mirror, so a missing
-// binary or unreachable library must never roll back an otherwise-good
-// import. A successful call stores the returned id on the book row.
-func (s *Scanner) pushToCalibre(ctx context.Context, book *models.Book, path string) {
-	if s.calibre == nil || !s.calibre.Enabled() || book == nil {
+// pushToCalibre dispatches the just-imported book to the Calibre integration
+// selected by the current mode setting. Failures are logged and swallowed —
+// Calibre sync is a best-effort mirror, so a missing binary, unreachable
+// library, or Calibre-didn't-pick-it-up-in-time must never roll back an
+// otherwise-good Bindery import. A successful call stores the returned
+// Calibre id on the book row.
+//
+// author is required for the drop-folder path (it drives both the filename
+// layout and the metadata.db lookup); the calibredb path tolerates a nil
+// author because calibredb reads metadata from the file itself.
+func (s *Scanner) pushToCalibre(ctx context.Context, book *models.Book, author *models.Author, path string) {
+	if s.calibreMode == nil || book == nil {
 		return
 	}
-	id, err := s.calibre.Add(ctx, path)
+	mode := s.calibreMode()
+	switch mode {
+	case calibre.ModeCalibredb:
+		s.pushCalibredb(ctx, book, path)
+	case calibre.ModeDropFolder:
+		s.pushCalibreDropFolder(ctx, book, author, path)
+	default:
+		// ModeOff or any unknown value: no-op.
+	}
+}
+
+// pushCalibredb is the Path A flow — shell out to calibredb add. Kept as a
+// small helper so the mode-dispatch in pushToCalibre reads linearly.
+func (s *Scanner) pushCalibredb(ctx context.Context, book *models.Book, path string) {
+	if s.calibreAdder == nil {
+		slog.Debug("calibre: mode=calibredb but adder is nil, skipping", "bookId", book.ID)
+		return
+	}
+	id, err := s.calibreAdder.Add(ctx, path)
 	if err != nil {
 		if errors.Is(err, calibre.ErrDisabled) {
 			return
@@ -102,7 +140,46 @@ func (s *Scanner) pushToCalibre(ctx context.Context, book *models.Book, path str
 		slog.Warn("calibre: persist calibre_id failed", "bookId", book.ID, "calibreId", id, "error", err)
 		return
 	}
-	slog.Info("calibre: book mirrored", "bookId", book.ID, "calibreId", id, "path", path)
+	slog.Info("calibre: book mirrored", "mode", "calibredb", "bookId", book.ID, "calibreId", id, "path", path)
+}
+
+// pushCalibreDropFolder is the Path B flow — copy the file into Calibre's
+// watched directory and poll metadata.db for the resulting book id. A poll
+// timeout logs a warning but is not surfaced as a failure, matching the
+// rest of the Calibre integration's best-effort posture.
+func (s *Scanner) pushCalibreDropFolder(ctx context.Context, book *models.Book, author *models.Author, path string) {
+	if s.calibreDrop == nil {
+		slog.Debug("calibre: mode=drop_folder but writer is nil, skipping", "bookId", book.ID)
+		return
+	}
+	authorName := "Unknown Author"
+	if author != nil && author.Name != "" {
+		authorName = author.Name
+	}
+	// Calibre keys off the file's embedded metadata, not its filename, but
+	// we still use the book's title for the lookup on the way back. Use
+	// the Bindery title so a ParseFilename-derived one never leaks in.
+	res, err := s.calibreDrop.Ingest(ctx, path, book.Title, authorName)
+	if err != nil {
+		if errors.Is(err, calibre.ErrDropFolderNotConfigured) {
+			return
+		}
+		slog.Warn("calibre: drop-folder ingest failed, continuing",
+			"bookId", book.ID, "path", path, "error", err)
+		return
+	}
+	if !res.Found {
+		slog.Warn("calibre: drop-folder — Calibre did not ingest within poll budget",
+			"bookId", book.ID, "dropped", res.DroppedPath, "title", book.Title, "author", authorName)
+		return
+	}
+	if err := s.books.SetCalibreID(ctx, book.ID, res.CalibreID); err != nil {
+		slog.Warn("calibre: persist calibre_id failed",
+			"bookId", book.ID, "calibreId", res.CalibreID, "error", err)
+		return
+	}
+	slog.Info("calibre: book mirrored",
+		"mode", "drop_folder", "bookId", book.ID, "calibreId", res.CalibreID, "dropped", res.DroppedPath)
 }
 
 // CheckDownloads polls SABnzbd for status changes and updates the local download records.
@@ -212,7 +289,7 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusImported)
 		slog.Info("audiobook imported", "title", book.Title, "path", destDir)
 
-		s.pushToCalibre(ctx, book, destDir)
+		s.pushToCalibre(ctx, book, author, destDir)
 
 		eventData, _ := json.Marshal(map[string]string{"path": destDir})
 		s.history.Create(ctx, &models.HistoryEvent{
@@ -249,7 +326,7 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusImported)
 		slog.Info("book imported", "title", book.Title, "path", destPath)
 
-		s.pushToCalibre(ctx, book, destPath)
+		s.pushToCalibre(ctx, book, author, destPath)
 
 		eventData, _ := json.Marshal(map[string]string{"path": destPath})
 		s.history.Create(ctx, &models.HistoryEvent{

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -57,23 +57,40 @@ func TestTitleMatch(t *testing.T) {
 	}
 }
 
-// fakeCalibre is a stub calibreClient recording every Add invocation. Tests
-// check both the call path and the book-id persistence so a broken wiring
-// change surfaces here rather than in a live import.
-type fakeCalibre struct {
-	enabled bool
-	calls   []string
-	nextID  int64
-	err     error
+// fakeCalibreAdder is a stub calibreAdder recording every Add invocation.
+// Tests check both the call path and the book-id persistence so a broken
+// wiring change surfaces here rather than in a live import.
+type fakeCalibreAdder struct {
+	calls  []string
+	nextID int64
+	err    error
 }
 
-func (f *fakeCalibre) Enabled() bool { return f.enabled }
-func (f *fakeCalibre) Add(_ context.Context, path string) (int64, error) {
+func (f *fakeCalibreAdder) Add(_ context.Context, path string) (int64, error) {
 	f.calls = append(f.calls, path)
 	return f.nextID, f.err
 }
 
-func importScannerFixture(t *testing.T) (*Scanner, *db.BookRepo, *models.Book, context.Context) {
+// fakeDropFolderWriter is a stub calibreDropFolderWriter capturing the
+// title/author/source triple for assertion. Tests inject it via WithCalibre
+// so the real sanitize + polling code is only exercised in its own unit
+// tests.
+type fakeDropFolderWriter struct {
+	calls []dropCall
+	res   calibre.IngestResult
+	err   error
+}
+
+type dropCall struct{ src, title, author string }
+
+func (f *fakeDropFolderWriter) Ingest(_ context.Context, src, title, author string) (calibre.IngestResult, error) {
+	f.calls = append(f.calls, dropCall{src, title, author})
+	return f.res, f.err
+}
+
+func modeFn(m calibre.Mode) func() calibre.Mode { return func() calibre.Mode { return m } }
+
+func importScannerFixture(t *testing.T) (*Scanner, *db.BookRepo, *models.Book, *models.Author, context.Context) {
 	t.Helper()
 	database, err := db.OpenMemory()
 	if err != nil {
@@ -85,12 +102,12 @@ func importScannerFixture(t *testing.T) (*Scanner, *db.BookRepo, *models.Book, c
 	authorRepo := db.NewAuthorRepo(database)
 	bookRepo := db.NewBookRepo(database)
 
-	a := &models.Author{ForeignID: "OLA1", Name: "A", SortName: "A", Monitored: true, MetadataProvider: "openlibrary"}
+	a := &models.Author{ForeignID: "OLA1", Name: "Author A", SortName: "A, Author", Monitored: true, MetadataProvider: "openlibrary"}
 	if err := authorRepo.Create(ctx, a); err != nil {
 		t.Fatal(err)
 	}
 	b := &models.Book{
-		ForeignID: "OLB1", AuthorID: a.ID, Title: "T", SortTitle: "T",
+		ForeignID: "OLB1", AuthorID: a.ID, Title: "Title T", SortTitle: "T, Title",
 		Status: models.BookStatusWanted, Monitored: true, AnyEditionOK: true,
 		MetadataProvider: "openlibrary",
 	}
@@ -103,34 +120,41 @@ func importScannerFixture(t *testing.T) (*Scanner, *db.BookRepo, *models.Book, c
 		bookRepo, authorRepo, db.NewHistoryRepo(database),
 		t.TempDir(), "", "", "", "",
 	)
-	return s, bookRepo, b, ctx
+	return s, bookRepo, b, a, ctx
 }
 
-// TestPushToCalibre_Disabled is the regression guard for "integration off"
-// — a user who never touched the Calibre settings must see identical import
-// behaviour to v0.7.2, which means no client call and no calibre_id write.
-func TestPushToCalibre_Disabled(t *testing.T) {
-	s, bookRepo, book, ctx := importScannerFixture(t)
-	fc := &fakeCalibre{enabled: false, nextID: 99}
-	s.WithCalibre(fc)
+// TestPushToCalibre_ModeOff: regression guard for "integration off" —
+// mode=off must mean zero client calls and no calibre_id mutation, matching
+// the v0.7.2 / v0.8.0-with-toggle-off baseline.
+func TestPushToCalibre_ModeOff(t *testing.T) {
+	s, bookRepo, book, author, ctx := importScannerFixture(t)
+	fc := &fakeCalibreAdder{nextID: 99}
+	fd := &fakeDropFolderWriter{}
+	s.WithCalibre(modeFn(calibre.ModeOff), fc, fd)
 
-	s.pushToCalibre(ctx, book, "/library/book.epub")
+	s.pushToCalibre(ctx, book, author, "/library/book.epub")
 
 	if len(fc.calls) != 0 {
-		t.Errorf("Add must not be called when disabled, got %v", fc.calls)
+		t.Errorf("Add must not be called when mode=off, got %v", fc.calls)
+	}
+	if len(fd.calls) != 0 {
+		t.Errorf("Ingest must not be called when mode=off, got %v", fd.calls)
 	}
 	got, _ := bookRepo.GetByID(ctx, book.ID)
 	if got.CalibreID != nil {
-		t.Errorf("calibre_id must stay nil when disabled, got %v", got.CalibreID)
+		t.Errorf("calibre_id must stay nil when mode=off, got %v", got.CalibreID)
 	}
 }
 
-func TestPushToCalibre_HappyPath(t *testing.T) {
-	s, bookRepo, book, ctx := importScannerFixture(t)
-	fc := &fakeCalibre{enabled: true, nextID: 1234}
-	s.WithCalibre(fc)
+// TestPushToCalibre_ModeCalibredbHappyPath: the v0.8.0 regression test —
+// mode=calibredb calls the adder and persists the returned id. Locks in
+// that the new mode-dispatch didn't break Path A.
+func TestPushToCalibre_ModeCalibredbHappyPath(t *testing.T) {
+	s, bookRepo, book, author, ctx := importScannerFixture(t)
+	fc := &fakeCalibreAdder{nextID: 1234}
+	s.WithCalibre(modeFn(calibre.ModeCalibredb), fc, nil)
 
-	s.pushToCalibre(ctx, book, "/library/book.epub")
+	s.pushToCalibre(ctx, book, author, "/library/book.epub")
 
 	if len(fc.calls) != 1 || fc.calls[0] != "/library/book.epub" {
 		t.Errorf("Add calls = %v", fc.calls)
@@ -141,16 +165,14 @@ func TestPushToCalibre_HappyPath(t *testing.T) {
 	}
 }
 
-// TestPushToCalibre_AddFailsDoesNotPoison: a failed calibredb call must not
-// roll back the import or stamp a bogus id. The book row stays file-pathed
-// but calibre_id is still nil, matching the semantics that Calibre sync is
-// a best-effort mirror.
-func TestPushToCalibre_AddFailsDoesNotPoison(t *testing.T) {
-	s, bookRepo, book, ctx := importScannerFixture(t)
-	fc := &fakeCalibre{enabled: true, err: errors.New("exec: calibredb: not found")}
-	s.WithCalibre(fc)
+// TestPushToCalibre_CalibredbFailDoesNotPoison: a failed calibredb call
+// must leave calibre_id at nil (best-effort mirror semantics).
+func TestPushToCalibre_CalibredbFailDoesNotPoison(t *testing.T) {
+	s, bookRepo, book, author, ctx := importScannerFixture(t)
+	fc := &fakeCalibreAdder{err: errors.New("exec: calibredb: not found")}
+	s.WithCalibre(modeFn(calibre.ModeCalibredb), fc, nil)
 
-	s.pushToCalibre(ctx, book, "/library/book.epub")
+	s.pushToCalibre(ctx, book, author, "/library/book.epub")
 
 	got, _ := bookRepo.GetByID(ctx, book.ID)
 	if got.CalibreID != nil {
@@ -158,15 +180,14 @@ func TestPushToCalibre_AddFailsDoesNotPoison(t *testing.T) {
 	}
 }
 
-// TestPushToCalibre_ErrDisabledSilent guards that a mismatched state (client
-// reports Enabled() true but Add returns ErrDisabled) is treated the same as
-// disabled — no warning, no id, no panic.
+// TestPushToCalibre_ErrDisabledSilent — the adder may return ErrDisabled
+// when the client's own config is off; we treat it the same as mode=off.
 func TestPushToCalibre_ErrDisabledSilent(t *testing.T) {
-	s, bookRepo, book, ctx := importScannerFixture(t)
-	fc := &fakeCalibre{enabled: true, err: calibre.ErrDisabled}
-	s.WithCalibre(fc)
+	s, bookRepo, book, author, ctx := importScannerFixture(t)
+	fc := &fakeCalibreAdder{err: calibre.ErrDisabled}
+	s.WithCalibre(modeFn(calibre.ModeCalibredb), fc, nil)
 
-	s.pushToCalibre(ctx, book, "/library/book.epub")
+	s.pushToCalibre(ctx, book, author, "/library/book.epub")
 
 	got, _ := bookRepo.GetByID(ctx, book.ID)
 	if got.CalibreID != nil {
@@ -174,11 +195,101 @@ func TestPushToCalibre_ErrDisabledSilent(t *testing.T) {
 	}
 }
 
-// TestPushToCalibre_NilClient covers the default path — a scanner built
+// TestPushToCalibre_NilResolver covers the default path — a scanner built
 // without WithCalibre() (i.e. calibre not configured at all) must not
 // panic on a nil interface dereference.
-func TestPushToCalibre_NilClient(t *testing.T) {
-	s, _, book, ctx := importScannerFixture(t)
+func TestPushToCalibre_NilResolver(t *testing.T) {
+	s, _, book, author, ctx := importScannerFixture(t)
 	// No WithCalibre call.
-	s.pushToCalibre(ctx, book, "/library/book.epub") // must not panic
+	s.pushToCalibre(ctx, book, author, "/library/book.epub") // must not panic
+}
+
+// TestPushToCalibre_ModeDropFolderHappyPath — mode=drop_folder routes to
+// the drop writer with title + author propagated, and the returned id
+// lands on the book row.
+func TestPushToCalibre_ModeDropFolderHappyPath(t *testing.T) {
+	s, bookRepo, book, author, ctx := importScannerFixture(t)
+	fc := &fakeCalibreAdder{}
+	fd := &fakeDropFolderWriter{res: calibre.IngestResult{DroppedPath: "/drop/A/T.epub", CalibreID: 77, Found: true}}
+	s.WithCalibre(modeFn(calibre.ModeDropFolder), fc, fd)
+
+	s.pushToCalibre(ctx, book, author, "/library/book.epub")
+
+	if len(fc.calls) != 0 {
+		t.Errorf("adder must not be called in drop_folder mode, got %v", fc.calls)
+	}
+	if len(fd.calls) != 1 {
+		t.Fatalf("expected 1 Ingest call, got %d", len(fd.calls))
+	}
+	call := fd.calls[0]
+	if call.src != "/library/book.epub" || call.title != "Title T" || call.author != "Author A" {
+		t.Errorf("Ingest called with %+v, want src=/library/book.epub title=Title T author=Author A", call)
+	}
+	got, _ := bookRepo.GetByID(ctx, book.ID)
+	if got.CalibreID == nil || *got.CalibreID != 77 {
+		t.Errorf("calibre_id = %v, want 77", got.CalibreID)
+	}
+}
+
+// TestPushToCalibre_ModeDropFolderPollTimeout — Calibre didn't pick up the
+// file within the budget. Drop-folder mode must NOT stamp a calibre_id
+// but also MUST NOT surface as an import failure (already logged as warn).
+func TestPushToCalibre_ModeDropFolderPollTimeout(t *testing.T) {
+	s, bookRepo, book, author, ctx := importScannerFixture(t)
+	fd := &fakeDropFolderWriter{res: calibre.IngestResult{DroppedPath: "/drop/A/T.epub", Found: false}}
+	s.WithCalibre(modeFn(calibre.ModeDropFolder), nil, fd)
+
+	s.pushToCalibre(ctx, book, author, "/library/book.epub")
+
+	got, _ := bookRepo.GetByID(ctx, book.ID)
+	if got.CalibreID != nil {
+		t.Errorf("calibre_id must stay nil on poll timeout, got %v", got.CalibreID)
+	}
+}
+
+// TestPushToCalibre_ModeDropFolderIngestError — a hard Ingest error (e.g.
+// disk full writing into the drop folder) is logged but swallowed so the
+// rest of the import pipeline completes.
+func TestPushToCalibre_ModeDropFolderIngestError(t *testing.T) {
+	s, bookRepo, book, author, ctx := importScannerFixture(t)
+	fd := &fakeDropFolderWriter{err: errors.New("disk full")}
+	s.WithCalibre(modeFn(calibre.ModeDropFolder), nil, fd)
+
+	s.pushToCalibre(ctx, book, author, "/library/book.epub")
+
+	got, _ := bookRepo.GetByID(ctx, book.ID)
+	if got.CalibreID != nil {
+		t.Errorf("calibre_id must stay nil on ingest error, got %v", got.CalibreID)
+	}
+}
+
+// TestPushToCalibre_ModeDropFolderUnconfigured — ErrDropFolderNotConfigured
+// is treated as a silent skip (same as ErrDisabled on the calibredb side).
+func TestPushToCalibre_ModeDropFolderUnconfigured(t *testing.T) {
+	s, bookRepo, book, author, ctx := importScannerFixture(t)
+	fd := &fakeDropFolderWriter{err: calibre.ErrDropFolderNotConfigured}
+	s.WithCalibre(modeFn(calibre.ModeDropFolder), nil, fd)
+
+	s.pushToCalibre(ctx, book, author, "/library/book.epub")
+
+	got, _ := bookRepo.GetByID(ctx, book.ID)
+	if got.CalibreID != nil {
+		t.Errorf("calibre_id must stay nil when drop folder unconfigured, got %v", got.CalibreID)
+	}
+}
+
+// TestPushToCalibre_ModeDropFolderFallbackAuthor — if the author lookup
+// failed upstream we still attempt the ingest with a placeholder name so
+// Calibre at least receives the file. The lookup will likely miss but that
+// surfaces cleanly as a poll timeout instead of a nil-deref crash.
+func TestPushToCalibre_ModeDropFolderFallbackAuthor(t *testing.T) {
+	s, _, book, _, ctx := importScannerFixture(t)
+	fd := &fakeDropFolderWriter{res: calibre.IngestResult{Found: false}}
+	s.WithCalibre(modeFn(calibre.ModeDropFolder), nil, fd)
+
+	s.pushToCalibre(ctx, book, nil, "/library/book.epub")
+
+	if len(fd.calls) != 1 || fd.calls[0].author != "Unknown Author" {
+		t.Errorf("fallback author not applied: %+v", fd.calls)
+	}
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -263,13 +263,20 @@ export interface Book {
   author?: Author
 }
 
-// CalibreSettings mirrors the three `calibre.*` keys stored in the settings
+// CalibreMode selects which integration flow runs after a successful
+// Bindery import. 'off' skips Calibre entirely, 'calibredb' shells out to
+// the calibredb CLI (v0.8.0 path), 'drop_folder' writes the file into a
+// Calibre-watched directory and polls metadata.db for the assigned id.
+export type CalibreMode = 'off' | 'calibredb' | 'drop_folder'
+
+// CalibreSettings mirrors the `calibre.*` keys stored in the settings
 // table. The shape is deliberately flat so SettingsPage can render the
 // fields alongside the other string-keyed settings it already manages.
 export interface CalibreSettings {
-  calibre_enabled: boolean
+  calibre_mode: CalibreMode
   calibre_library_path: string
   calibre_binary_path: string
+  calibre_drop_folder_path: string
 }
 
 export interface CalibreTestResult {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1015,10 +1015,12 @@ function parseCats(s: string): number[] {
   return s.split(',').map(t => parseInt(t.trim(), 10)).filter(n => !isNaN(n))
 }
 
-// CalibreSection renders the three calibre.* settings fields plus a Test
-// button that hits /calibre/test. We deliberately reuse the parent
-// GeneralTab's `settings` / `saving` state so the Save buttons behave the
-// same as every other field in General and the code path stays one-off.
+// CalibreSection renders the calibre.* settings fields plus a Test button
+// that hits /calibre/test. The Mode radio picks between two integration
+// flows: `calibredb` shells out to the CLI (requires Calibre on the host),
+// `drop_folder` drops files into a Calibre-watched directory (decouples
+// Bindery from where Calibre runs). The fields for each path are only
+// shown when their mode is selected so the form stays unambiguous.
 function CalibreSection({
   settings,
   setSettings,
@@ -1033,7 +1035,17 @@ function CalibreSection({
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null)
 
-  const enabled = (settings['calibre.enabled'] ?? 'false').toLowerCase() === 'true'
+  // Legacy fallback: a pre-migration DB with `calibre.enabled=true` but no
+  // mode set should still render as 'calibredb' so the user's existing
+  // setup is visible in the UI.
+  const rawMode = settings['calibre.mode'] ?? ''
+  const legacyEnabled = (settings['calibre.enabled'] ?? 'false').toLowerCase() === 'true'
+  const mode: 'off' | 'calibredb' | 'drop_folder' =
+    rawMode === 'calibredb' || rawMode === 'drop_folder' || rawMode === 'off'
+      ? rawMode
+      : legacyEnabled
+      ? 'calibredb'
+      : 'off'
 
   const runTest = async () => {
     setTesting(true)
@@ -1048,92 +1060,140 @@ function CalibreSection({
     }
   }
 
+  const setMode = async (next: 'off' | 'calibredb' | 'drop_folder') => {
+    setSettings(s => ({ ...s, 'calibre.mode': next }))
+    // Persist immediately on change — matches the indexer/client toggles
+    // that don't require a separate Save click.
+    await api.setSetting('calibre.mode', next).catch(console.error)
+  }
+
   return (
     <section>
       <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">Calibre</h3>
       <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-4">
         <p className="text-xs text-slate-600 dark:text-zinc-500 -mt-1">
-          Mirror imported books into a Calibre library by shelling out to{' '}
-          <code className="text-[11px] bg-slate-200 dark:bg-zinc-800 px-1 rounded">calibredb add</code>.
-          Requires Calibre installed on the host; the Calibre book id is stored on the book row for future OPDS lookups.
+          Mirror imported books into a Calibre library. Pick the mode that fits your deployment — {' '}
+          <code className="text-[11px] bg-slate-200 dark:bg-zinc-800 px-1 rounded">calibredb</code>{' '}
+          when Calibre runs alongside Bindery, or drop-folder when Calibre runs elsewhere and watches a directory.
         </p>
 
-        <div className="flex items-center justify-between">
+        <div>
+          <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200 mb-2">Mode</label>
+          <div className="space-y-1.5">
+            {([
+              { v: 'off',         label: 'Off',            desc: 'No Calibre call on import.' },
+              { v: 'calibredb',   label: 'calibredb CLI',  desc: 'Shell out to calibredb add --with-library. Requires calibredb reachable from the Bindery process.' },
+              { v: 'drop_folder', label: 'Drop folder',    desc: 'Write the file into Calibre\u2019s watched folder, then poll metadata.db for the assigned book id.' },
+            ] as const).map(opt => (
+              <label key={opt.v} className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  name="calibre-mode"
+                  value={opt.v}
+                  checked={mode === opt.v}
+                  onChange={() => setMode(opt.v)}
+                  className="mt-1"
+                />
+                <div>
+                  <div className="text-sm text-slate-800 dark:text-zinc-200">{opt.label}</div>
+                  <div className="text-xs text-slate-600 dark:text-zinc-500">{opt.desc}</div>
+                </div>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {mode !== 'off' && (
           <div>
-            <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">Enabled</label>
-            <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">When off, imports behave exactly as before — no Calibre call, no change to book rows.</p>
+            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Library path</label>
+            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
+              Directory containing <code className="text-[11px] bg-slate-200 dark:bg-zinc-800 px-1 rounded">metadata.db</code>.
+              {mode === 'calibredb'
+                ? ' Passed to calibredb as --with-library.'
+                : ' Read directly to resolve the assigned Calibre book id after drop-folder ingest.'}
+            </p>
+            <div className="flex gap-2">
+              <input
+                value={settings['calibre.library_path'] ?? ''}
+                onChange={e => setSettings(s => ({ ...s, 'calibre.library_path': e.target.value }))}
+                placeholder="/data/calibre-library"
+                className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+              />
+              <button
+                onClick={() => saveSetting('calibre.library_path')}
+                disabled={saving === 'calibre.library_path'}
+                className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+              >
+                {saving === 'calibre.library_path' ? 'Saving...' : 'Save'}
+              </button>
+            </div>
           </div>
-          <button
-            onClick={async () => {
-              const next = enabled ? 'false' : 'true'
-              setSettings(s => ({ ...s, 'calibre.enabled': next }))
-              // Persist immediately on toggle — matches the indexer/client
-              // toggles that don't require a separate Save click.
-              await api.setSetting('calibre.enabled', next).catch(console.error)
-            }}
-            className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${enabled ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
-            title={enabled ? 'Disable' : 'Enable'}
-          >
-            <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${enabled ? 'translate-x-4' : ''}`} />
-          </button>
-        </div>
+        )}
 
-        <div>
-          <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Library path</label>
-          <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">Directory containing <code className="text-[11px] bg-slate-200 dark:bg-zinc-800 px-1 rounded">metadata.db</code>. Passed to calibredb as <code className="text-[11px] bg-slate-200 dark:bg-zinc-800 px-1 rounded">--with-library</code>.</p>
-          <div className="flex gap-2">
-            <input
-              value={settings['calibre.library_path'] ?? ''}
-              onChange={e => setSettings(s => ({ ...s, 'calibre.library_path': e.target.value }))}
-              placeholder="/data/calibre-library"
-              className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
-            />
+        {mode === 'calibredb' && (
+          <div>
+            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Binary path (optional)</label>
+            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">Leave blank to resolve <code className="text-[11px] bg-slate-200 dark:bg-zinc-800 px-1 rounded">calibredb</code> on PATH. Set explicitly when running in a container that bundles Calibre at a pinned location.</p>
+            <div className="flex gap-2">
+              <input
+                value={settings['calibre.binary_path'] ?? ''}
+                onChange={e => setSettings(s => ({ ...s, 'calibre.binary_path': e.target.value }))}
+                placeholder="/usr/bin/calibredb"
+                className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+              />
+              <button
+                onClick={() => saveSetting('calibre.binary_path')}
+                disabled={saving === 'calibre.binary_path'}
+                className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+              >
+                {saving === 'calibre.binary_path' ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {mode === 'drop_folder' && (
+          <div>
+            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Drop folder path</label>
+            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
+              {'Directory Calibre\u2019s '}<em>Add books to library from folders</em>{' feature watches. Bindery will copy imported files into '}<code className="text-[11px] bg-slate-200 dark:bg-zinc-800 px-1 rounded">&lt;folder&gt;/&lt;Author&gt;/&lt;Title&gt;.ext</code>{' and wait for Calibre to ingest them.'}
+            </p>
+            <div className="flex gap-2">
+              <input
+                value={settings['calibre.drop_folder_path'] ?? ''}
+                onChange={e => setSettings(s => ({ ...s, 'calibre.drop_folder_path': e.target.value }))}
+                placeholder="/data/calibre-watch"
+                className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+              />
+              <button
+                onClick={() => saveSetting('calibre.drop_folder_path')}
+                disabled={saving === 'calibre.drop_folder_path'}
+                className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+              >
+                {saving === 'calibre.drop_folder_path' ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {mode === 'calibredb' && (
+          <div className="flex items-center justify-between pt-1 border-t border-slate-200 dark:border-zinc-800">
+            <div className="text-xs">
+              {testResult && (
+                <span className={testResult.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}>
+                  {testResult.msg}
+                </span>
+              )}
+            </div>
             <button
-              onClick={() => saveSetting('calibre.library_path')}
-              disabled={saving === 'calibre.library_path'}
-              className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+              onClick={runTest}
+              disabled={testing}
+              className="px-4 py-2 bg-slate-600 hover:bg-slate-500 rounded text-sm font-medium disabled:opacity-50 flex-shrink-0"
             >
-              {saving === 'calibre.library_path' ? 'Saving...' : 'Save'}
+              {testing ? 'Testing…' : 'Test connection'}
             </button>
           </div>
-        </div>
-
-        <div>
-          <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Binary path (optional)</label>
-          <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">Leave blank to resolve <code className="text-[11px] bg-slate-200 dark:bg-zinc-800 px-1 rounded">calibredb</code> on PATH. Set explicitly when running in a container that bundles Calibre at a pinned location.</p>
-          <div className="flex gap-2">
-            <input
-              value={settings['calibre.binary_path'] ?? ''}
-              onChange={e => setSettings(s => ({ ...s, 'calibre.binary_path': e.target.value }))}
-              placeholder="/usr/bin/calibredb"
-              className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
-            />
-            <button
-              onClick={() => saveSetting('calibre.binary_path')}
-              disabled={saving === 'calibre.binary_path'}
-              className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
-            >
-              {saving === 'calibre.binary_path' ? 'Saving...' : 'Save'}
-            </button>
-          </div>
-        </div>
-
-        <div className="flex items-center justify-between pt-1 border-t border-slate-200 dark:border-zinc-800">
-          <div className="text-xs">
-            {testResult && (
-              <span className={testResult.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}>
-                {testResult.msg}
-              </span>
-            )}
-          </div>
-          <button
-            onClick={runTest}
-            disabled={testing}
-            className="px-4 py-2 bg-slate-600 hover:bg-slate-500 rounded text-sm font-medium disabled:opacity-50 flex-shrink-0"
-          >
-            {testing ? 'Testing…' : 'Test connection'}
-          </button>
-        </div>
+        )}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- Adds **Path B** to the Calibre integration: a drop-folder flow that copies imported files into a Calibre-watched directory as `Author/Title.ext`, polls `metadata.db` until Calibre assigns a book id, and persists it onto `books.calibre_id`.
- New **Mode** selector (`off` / `calibredb` / `drop_folder`) in Settings → Calibre lets operators pick which flow runs after an import. The resolver is read on every import so mode changes take effect without a restart.
- Migration `011_calibre_mode.sql` seeds the two new settings rows and migrates v0.8.0 installs with `calibre.enabled=true` to `mode=calibredb` automatically.
- Includes a **scaffolded** `reader_lookup.go` so Path B ships standalone; it will be refactored to call Stream A's `internal/calibre/reader.go` on rebase.

## Files
- `NEW` `internal/calibre/mode.go` — `CalibreMode` enum + `ParseMode` resolver (100% coverage)
- `NEW` `internal/calibre/drop_folder.go` + test — watched-dir writer, retry/backoff poller, path sanitisation (87–100% coverage)
- `NEW` `internal/calibre/reader_lookup.go` + test — minimal metadata.db lookup, to be merged into Stream A's reader on rebase
- `NEW` `internal/db/migrations/011_calibre_mode.sql`
- `internal/importer/scanner.go` — dispatches on mode per import, routes to calibredb or drop-folder
- `internal/api/calibre.go` + `settings_handler.go` — new settings keys + validation (drop-folder path must exist & be writable; mode must parse to a canonical value)
- `cmd/bindery/main.go` — instantiates drop-folder writer and injects both clients via the mode resolver
- `web/src/api/client.ts` + `SettingsPage.tsx` — Mode radio group with conditional fields; Library path shown for both calibredb/drop-folder modes, Binary path + Test button only for calibredb, Drop folder path only for drop-folder

## Test plan
- [x] `go test ./...` (full suite green)
- [x] `go test -race ./...` (no data races)
- [x] `go vet ./...` clean
- [x] `tsc --noEmit` + `vite build` clean
- [x] `internal/calibre` coverage: **90.8%** (target ≥65%)
- [x] Regression: `mode=calibredb` test matches v0.8.0 Path A behaviour exactly
- [x] Regression: legacy `calibre.enabled=true` without mode set still reports `Enabled=true` (pre-migration safety net)
- [x] Drop-folder poll-exhausted path: warn and continue (no `calibre_id`, import still marked success)
- [x] Drop-folder context-cancel: short-circuits instead of waiting out the full budget
- [ ] **Manual** (post-rebase on Stream A): refactor `reader_lookup.go` to delegate to `internal/calibre/reader.go`; verify the single caller in `drop_folder.go` still works
- [ ] **Manual**: live smoke — run Bindery pointing at a real Calibre library in drop-folder mode, verify a successful import lands in Calibre and `books.calibre_id` is populated

## Rebase notes (Stream A)
Expected conflicts when Stream A lands first:
- `CHANGELOG.md` — keep both `[Unreleased] → Added` entries
- `internal/api/calibre.go` — keep Stream A's `/import` routes alongside the new mode/drop_folder_path settings keys added here
- `web/src/pages/SettingsPage.tsx` — fit the Mode radio + drop-folder field into the same Calibre section as Stream A's Import button
- Delete `reader_lookup.go` and point `drop_folder.go`'s lookup at Stream A's reader