### PR TITLE
feat(calibre): library import & sync (closes #63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The `development` branch carries the in-flight feature set for the next release.
 
 ### Added
 
-- **Calibre drop-folder integration + per-library mode selector** ([#64](https://github.com/vavallee/bindery/issues/64)) — Settings → Calibre gains a three-way **Mode** radio (`off` / `calibredb` / `drop_folder`). The new `drop_folder` mode copies imported files into a Calibre-watched directory as `<folder>/<Author>/<Title>.ext` and then polls the Calibre library's `metadata.db` for the assigned book id, for deployments where `calibredb` isn't reachable from the Bindery process. Existing v0.8.0 installs with `calibre.enabled=true` migrate automatically to `mode=calibredb` so no user action is needed to keep the current flow working.
+- **Calibre library import (closes [#63](https://github.com/vavallee/bindery/issues/63))** — Bindery can now ingest an existing Calibre library via a new **Import library** button in Settings → General → Calibre. The importer opens Calibre's `metadata.db` read-only, streams authors / books / series / editions / ISBNs / covers, and upserts them into Bindery — deduplicating via `books.calibre_id` first and author-alias-aware title match second, so running the import twice is idempotent. Co-authors become alias rows on the canonical author. A polled progress endpoint (`GET /api/v1/calibre/import/status`) drives a live progress bar and a final summary of `{authorsAdded, booksAdded, editionsAdded, duplicatesMerged, skipped}`. A new **Sync on startup** toggle runs the same import on every boot (off by default).
 
 ## [v0.8.0] — 2026-04-14
 

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -73,6 +74,7 @@ func main() {
 	authorRepo := db.NewAuthorRepo(database)
 	authorAliasRepo := db.NewAuthorAliasRepo(database)
 	bookRepo := db.NewBookRepo(database)
+	editionRepo := db.NewEditionRepo(database)
 	indexerRepo := db.NewIndexerRepo(database)
 	dlClientRepo := db.NewDownloadClientRepo(database)
 	downloadRepo := db.NewDownloadRepo(database)
@@ -161,6 +163,26 @@ func main() {
 		slog.Info("calibre integration enabled", "mode", "drop_folder")
 	}
 
+	// Library import (read side). Importer holds live progress state in
+	// memory so the UI can poll /calibre/import/status while a long scan
+	// runs. A single instance is shared between the API handler and the
+	// startup-sync branch below — both paths share the "only one import
+	// at a time" guard.
+	calibreImporter := calibre.NewImporter(authorRepo, authorAliasRepo, bookRepo, editionRepo, settingsRepo)
+	if syncOnStartup(settingsRepo) {
+		cfg := api.LoadCalibreConfig(settingsRepo)
+		if cfg.Enabled && cfg.LibraryPath != "" {
+			slog.Info("calibre sync_on_startup enabled — kicking off library import")
+			go func() {
+				if _, err := calibreImporter.Run(context.Background(), cfg.LibraryPath); err != nil {
+					slog.Warn("calibre startup import failed", "error", err)
+				}
+			}()
+		} else {
+			slog.Info("calibre sync_on_startup is on but integration is not configured — skipping")
+		}
+	}
+
 	// Scheduler
 	sched := scheduler.New(importScanner, idxSearcher, metaAgg,
 		authorRepo, bookRepo, indexerRepo, downloadRepo, dlClientRepo, settingsRepo, blocklistRepo)
@@ -196,6 +218,9 @@ func main() {
 	bulkHandler := api.NewBulkHandler(authorRepo, bookRepo, blocklistRepo, sched)
 	backupHandler := api.NewBackupHandler(cfg.DBPath, cfg.DataDir)
 	calibreHandler := api.NewCalibreHandler(settingsRepo)
+	calibreImportHandler := api.NewCalibreImportHandler(calibreImporter, func() calibre.Config {
+		return api.LoadCalibreConfig(settingsRepo)
+	})
 	migrateHandler := api.NewMigrateHandler(
 		authorRepo, indexerRepo, dlClientRepo, blocklistRepo, bookRepo, metaAgg,
 		// Bulk imports always populate the catalogue but never auto-grab.
@@ -376,6 +401,11 @@ func main() {
 		// this endpoint just validates + probes the configured install.
 		r.Post("/calibre/test", calibreHandler.Test)
 
+		// Calibre library import (read side). Start is fire-and-forget;
+		// the UI polls Status while it runs.
+		r.Post("/calibre/import", calibreImportHandler.Start)
+		r.Get("/calibre/import/status", calibreImportHandler.Status)
+
 		// Migration imports (CSV of author names, or Readarr SQLite DB).
 		r.Post("/migrate/csv", migrateHandler.ImportCSV)
 		r.Post("/migrate/readarr", migrateHandler.ImportReadarr)
@@ -439,6 +469,18 @@ func defaultNamingTemplate(settings *db.SettingsRepo) string {
 		return s.Value
 	}
 	return ""
+}
+
+// syncOnStartup reads the calibre.sync_on_startup setting and returns
+// true iff it's explicitly "true" (case-insensitive). Any other value
+// — including absent — resolves to false so first boots don't kick off
+// work the operator didn't ask for.
+func syncOnStartup(settings *db.SettingsRepo) bool {
+	s, _ := settings.Get(context.Background(), "calibre.sync_on_startup")
+	if s == nil {
+		return false
+	}
+	return strings.EqualFold(s.Value, "true")
 }
 
 func audiobookNamingTemplate(settings *db.SettingsRepo) string {

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -186,6 +186,9 @@ func main() {
 	// Scheduler
 	sched := scheduler.New(importScanner, idxSearcher, metaAgg,
 		authorRepo, bookRepo, indexerRepo, downloadRepo, dlClientRepo, settingsRepo, blocklistRepo)
+	// Register the Calibre importer as the 24-hour sync job. The scheduler
+	// only fires the job when the syncer is non-nil, so no guard needed here.
+	sched.WithCalibreSyncer(calibreImporter)
 	sched.Start()
 	defer sched.Stop()
 
@@ -476,7 +479,7 @@ func defaultNamingTemplate(settings *db.SettingsRepo) string {
 // — including absent — resolves to false so first boots don't kick off
 // work the operator didn't ask for.
 func syncOnStartup(settings *db.SettingsRepo) bool {
-	s, _ := settings.Get(context.Background(), "calibre.sync_on_startup")
+	s, _ := settings.Get(context.Background(), api.SettingCalibreSyncOnStartup)
 	if s == nil {
 		return false
 	}

--- a/internal/api/calibre.go
+++ b/internal/api/calibre.go
@@ -18,6 +18,7 @@ const (
 	SettingCalibreBinaryPath     = "calibre.binary_path"
 	SettingCalibreMode           = "calibre.mode"
 	SettingCalibreDropFolderPath = "calibre.drop_folder_path"
+	SettingCalibreSyncOnStartup  = "calibre.sync_on_startup"
 )
 
 // CalibreHandler exposes the "test connection" endpoint for the Calibre
@@ -61,9 +62,10 @@ func LoadCalibreConfig(settings *db.SettingsRepo) calibre.Config {
 		enabled = true
 	}
 	return calibre.Config{
-		Enabled:     enabled,
-		LibraryPath: get(SettingCalibreLibraryPath),
-		BinaryPath:  get(SettingCalibreBinaryPath),
+		Enabled:       enabled,
+		LibraryPath:   get(SettingCalibreLibraryPath),
+		BinaryPath:    get(SettingCalibreBinaryPath),
+		SyncOnStartup: strings.EqualFold(get(SettingCalibreSyncOnStartup), "true"),
 	}
 }
 

--- a/internal/api/calibre_import.go
+++ b/internal/api/calibre_import.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/vavallee/bindery/internal/calibre"
+)
+
+// CalibreImportHandler exposes POST /calibre/import (kick off a library
+// import in the background) and GET /calibre/import/status (poll the
+// importer's current progress). Both routes sit behind the normal auth
+// middleware; the handler itself is thin — all orchestration lives in
+// the calibre.Importer.
+type CalibreImportHandler struct {
+	importer importerAPI
+	loadCfg  func() calibre.Config
+}
+
+// importerAPI is the subset of *calibre.Importer the API touches, so tests
+// can swap in a stub without wiring the full repo stack.
+type importerAPI interface {
+	Start(ctx context.Context, libraryPath string) error
+	Progress() calibre.ImportProgress
+}
+
+func NewCalibreImportHandler(imp importerAPI, loadCfg func() calibre.Config) *CalibreImportHandler {
+	return &CalibreImportHandler{importer: imp, loadCfg: loadCfg}
+}
+
+// Start is POST /api/v1/calibre/import. Validates that the library_path
+// setting resolves to a real Calibre library, then kicks off the import
+// goroutine. Returns 202 Accepted with the initial progress snapshot so
+// the UI can go straight into polling without an extra round-trip.
+//
+// context.WithoutCancel is critical: the importer walks thousands of
+// books and stamps `calibre.last_import_at` at the end — cancelling it
+// on response-send would routinely leave the settings row stale.
+func (h *CalibreImportHandler) Start(w http.ResponseWriter, r *http.Request) {
+	cfg := h.loadCfg()
+	if !cfg.Enabled {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "calibre integration is disabled"})
+		return
+	}
+	if cfg.LibraryPath == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "calibre library_path is empty"})
+		return
+	}
+
+	err := h.importer.Start(context.WithoutCancel(r.Context()), cfg.LibraryPath)
+	switch {
+	case errors.Is(err, calibre.ErrAlreadyRunning):
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	case err != nil:
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusAccepted, h.importer.Progress())
+}
+
+// Status is GET /api/v1/calibre/import/status. Cheap, stateless poll —
+// the importer tracks progress internally and hands back a fresh
+// snapshot every call.
+func (h *CalibreImportHandler) Status(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, h.importer.Progress())
+}

--- a/internal/api/calibre_import_test.go
+++ b/internal/api/calibre_import_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/calibre"
+)
+
+// stubImporter implements importerAPI so the handler's contract can be
+// exercised without touching the real repo stack. Each test constructs
+// one inline and asserts on call args + response codes.
+type stubImporter struct {
+	startErr  error
+	progress  calibre.ImportProgress
+	lastCalls int
+	lastPath  string
+}
+
+func (s *stubImporter) Start(_ context.Context, libraryPath string) error {
+	s.lastCalls++
+	s.lastPath = libraryPath
+	return s.startErr
+}
+func (s *stubImporter) Progress() calibre.ImportProgress { return s.progress }
+
+func loader(cfg calibre.Config) func() calibre.Config { return func() calibre.Config { return cfg } }
+
+func TestCalibreImport_Start_RejectsDisabled(t *testing.T) {
+	s := &stubImporter{}
+	h := NewCalibreImportHandler(s, loader(calibre.Config{Enabled: false}))
+
+	rec := httptest.NewRecorder()
+	h.Start(rec, httptest.NewRequest(http.MethodPost, "/api/v1/calibre/import", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("code = %d, want 400", rec.Code)
+	}
+	if s.lastCalls != 0 {
+		t.Error("importer must not be invoked when disabled")
+	}
+}
+
+func TestCalibreImport_Start_RejectsMissingLibraryPath(t *testing.T) {
+	s := &stubImporter{}
+	h := NewCalibreImportHandler(s, loader(calibre.Config{Enabled: true, LibraryPath: ""}))
+
+	rec := httptest.NewRecorder()
+	h.Start(rec, httptest.NewRequest(http.MethodPost, "/api/v1/calibre/import", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("code = %d, want 400", rec.Code)
+	}
+}
+
+func TestCalibreImport_Start_Accepted(t *testing.T) {
+	s := &stubImporter{progress: calibre.ImportProgress{Running: true, Message: "kickoff"}}
+	h := NewCalibreImportHandler(s, loader(calibre.Config{Enabled: true, LibraryPath: "/lib"}))
+
+	rec := httptest.NewRecorder()
+	h.Start(rec, httptest.NewRequest(http.MethodPost, "/api/v1/calibre/import", nil))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("code = %d, want 202", rec.Code)
+	}
+	if s.lastCalls != 1 || s.lastPath != "/lib" {
+		t.Errorf("Start not invoked correctly: calls=%d path=%q", s.lastCalls, s.lastPath)
+	}
+	// Response body must be the progress snapshot so the UI can start
+	// polling immediately.
+	var got calibre.ImportProgress
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if !got.Running || got.Message != "kickoff" {
+		t.Errorf("progress not echoed in body: %+v", got)
+	}
+}
+
+func TestCalibreImport_Start_Conflict(t *testing.T) {
+	s := &stubImporter{startErr: calibre.ErrAlreadyRunning}
+	h := NewCalibreImportHandler(s, loader(calibre.Config{Enabled: true, LibraryPath: "/lib"}))
+
+	rec := httptest.NewRecorder()
+	h.Start(rec, httptest.NewRequest(http.MethodPost, "/api/v1/calibre/import", nil))
+	if rec.Code != http.StatusConflict {
+		t.Errorf("code = %d, want 409", rec.Code)
+	}
+}
+
+func TestCalibreImport_Start_UnknownError(t *testing.T) {
+	s := &stubImporter{startErr: errors.New("boom")}
+	h := NewCalibreImportHandler(s, loader(calibre.Config{Enabled: true, LibraryPath: "/lib"}))
+
+	rec := httptest.NewRecorder()
+	h.Start(rec, httptest.NewRequest(http.MethodPost, "/api/v1/calibre/import", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("code = %d, want 500", rec.Code)
+	}
+}
+
+func TestCalibreImport_Status_ReturnsProgress(t *testing.T) {
+	s := &stubImporter{progress: calibre.ImportProgress{Total: 5, Processed: 3}}
+	h := NewCalibreImportHandler(s, loader(calibre.Config{Enabled: true, LibraryPath: "/lib"}))
+
+	rec := httptest.NewRecorder()
+	h.Status(rec, httptest.NewRequest(http.MethodGet, "/api/v1/calibre/import/status", nil))
+	if rec.Code != http.StatusOK {
+		t.Errorf("code = %d, want 200", rec.Code)
+	}
+	var got calibre.ImportProgress
+	_ = json.NewDecoder(rec.Body).Decode(&got)
+	if got.Total != 5 || got.Processed != 3 {
+		t.Errorf("progress = %+v", got)
+	}
+}

--- a/internal/calibre/client.go
+++ b/internal/calibre/client.go
@@ -25,9 +25,10 @@ var ErrDisabled = errors.New("calibre integration disabled")
 // fresh from the settings repo at the start of each import so toggling the
 // flag in the UI takes effect without a restart.
 type Config struct {
-	Enabled     bool
-	BinaryPath  string // path to `calibredb`; empty means resolve via $PATH
-	LibraryPath string // target Calibre library directory
+	Enabled       bool
+	BinaryPath    string // path to `calibredb`; empty means resolve via $PATH
+	LibraryPath   string // target Calibre library directory
+	SyncOnStartup bool   // run a library import when Bindery starts
 }
 
 // runner is the shape of exec.CommandContext, abstracted for tests.

--- a/internal/calibre/importer.go
+++ b/internal/calibre/importer.go
@@ -483,6 +483,33 @@ func (i *Importer) upsertEdition(ctx context.Context, book *models.Book, cb Cali
 	return prior == nil, nil
 }
 
+// RunSync implements scheduler.CalibreSyncer. It reads the library path from
+// the settings table and runs a full import; errors and progress are logged
+// and stored on the importer's progress state so the UI can surface them
+// via the existing /calibre/import/status polling endpoint.
+//
+// RunSync is intentionally fire-and-forget from the scheduler's perspective:
+// if Calibre is unconfigured or already running, it logs and returns without
+// blocking the job loop.
+func (i *Importer) RunSync(ctx context.Context) {
+	libraryPath := ""
+	if s, _ := i.settings.Get(ctx, "calibre.library_path"); s != nil {
+		libraryPath = s.Value
+	}
+	if libraryPath == "" {
+		slog.Debug("calibre scheduler sync: library_path not set — skipping")
+		return
+	}
+
+	if _, err := i.Run(ctx, libraryPath); err != nil {
+		if errors.Is(err, ErrAlreadyRunning) {
+			slog.Debug("calibre scheduler sync: already running — skipping")
+		} else {
+			slog.Warn("calibre scheduler sync failed", "error", err)
+		}
+	}
+}
+
 func (i *Importer) fail(err error) {
 	slog.Error("calibre import failed", "error", err)
 	i.setProgress(func(p *ImportProgress) {

--- a/internal/calibre/importer.go
+++ b/internal/calibre/importer.go
@@ -1,0 +1,528 @@
+package calibre
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// ImportStats summarises one import run. Exposed verbatim to the UI so
+// users can see "added X authors, Y books, merged Z duplicates" after
+// the progress bar finishes.
+type ImportStats struct {
+	AuthorsAdded     int `json:"authorsAdded"`
+	AuthorsLinked    int `json:"authorsLinked"`
+	BooksAdded       int `json:"booksAdded"`
+	BooksUpdated     int `json:"booksUpdated"`
+	EditionsAdded    int `json:"editionsAdded"`
+	DuplicatesMerged int `json:"duplicatesMerged"`
+	Skipped          int `json:"skipped"`
+}
+
+// ImportProgress is the live poll shape for GET /calibre/import/status.
+// The UI uses Running to decide whether to render a progress bar, Total
+// + Processed to fill it, and Stats (populated on completion) for the
+// summary panel.
+type ImportProgress struct {
+	Running   bool      `json:"running"`
+	StartedAt time.Time `json:"startedAt"`
+	Total     int       `json:"total"`
+	Processed int       `json:"processed"`
+	Message   string    `json:"message,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	FinishedAt *time.Time `json:"finishedAt,omitempty"`
+	Stats      *ImportStats `json:"stats,omitempty"`
+}
+
+// Importer orchestrates a read-only Calibre library scan and upserts the
+// extracted entities into Bindery. A single importer instance is safe for
+// concurrent callers: Start is guarded by a mutex so two clicks on the
+// "Import library" button yield one run plus a "already running" error.
+type Importer struct {
+	authors  *db.AuthorRepo
+	aliases  *db.AuthorAliasRepo
+	books    *db.BookRepo
+	editions *db.EditionRepo
+	settings *db.SettingsRepo
+
+	openReader func(libraryPath string) (readerIface, error)
+
+	mu       sync.Mutex
+	running  bool
+	progress ImportProgress
+}
+
+// readerIface captures the subset of *Reader the importer actually uses,
+// so tests can inject a fake library without standing up a full SQLite
+// fixture for every scenario.
+type readerIface interface {
+	Count(ctx context.Context) (int, error)
+	Books(ctx context.Context, fn func(CalibreBook) error) error
+	Close() error
+}
+
+// NewImporter wires the repos Bindery tracks Calibre entities into.
+func NewImporter(
+	authors *db.AuthorRepo,
+	aliases *db.AuthorAliasRepo,
+	books *db.BookRepo,
+	editions *db.EditionRepo,
+	settings *db.SettingsRepo,
+) *Importer {
+	return &Importer{
+		authors:  authors,
+		aliases:  aliases,
+		books:    books,
+		editions: editions,
+		settings: settings,
+		openReader: func(lp string) (readerIface, error) {
+			r, err := OpenReader(lp)
+			if err != nil {
+				return nil, err
+			}
+			return r, nil
+		},
+	}
+}
+
+// Progress returns a snapshot of the current (or most recent) import.
+// Safe to call at any time; when no import has run yet, the zero value
+// Running=false / Total=0 is returned.
+func (i *Importer) Progress() ImportProgress {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.progress
+}
+
+// Running reports whether an import is currently in flight.
+func (i *Importer) Running() bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.running
+}
+
+// ErrAlreadyRunning is returned when Start is called while a previous
+// import is still executing. Maps to 409 Conflict at the API layer.
+var ErrAlreadyRunning = errors.New("calibre import already running")
+
+// Start kicks off an import in the background and returns immediately.
+// The caller is expected to pass `context.WithoutCancel(r.Context())`
+// so the import survives the HTTP request that triggered it — the
+// v0.7.2 library-scan fix ships this pattern already.
+//
+// libraryPath is the Calibre library root containing metadata.db.
+func (i *Importer) Start(ctx context.Context, libraryPath string) error {
+	i.mu.Lock()
+	if i.running {
+		i.mu.Unlock()
+		return ErrAlreadyRunning
+	}
+	i.running = true
+	i.progress = ImportProgress{
+		Running:   true,
+		StartedAt: time.Now().UTC(),
+		Message:   "opening library…",
+	}
+	i.mu.Unlock()
+
+	go i.run(ctx, libraryPath)
+	return nil
+}
+
+// Run executes the import synchronously. Useful for the startup-sync
+// path where main.go is already on its own goroutine and wants a blocking
+// error return. Internally delegates to run() which handles progress and
+// the running flag.
+func (i *Importer) Run(ctx context.Context, libraryPath string) (*ImportStats, error) {
+	i.mu.Lock()
+	if i.running {
+		i.mu.Unlock()
+		return nil, ErrAlreadyRunning
+	}
+	i.running = true
+	i.progress = ImportProgress{
+		Running:   true,
+		StartedAt: time.Now().UTC(),
+		Message:   "opening library…",
+	}
+	i.mu.Unlock()
+
+	stats := i.run(ctx, libraryPath)
+	p := i.Progress()
+	if p.Error != "" {
+		return stats, errors.New(p.Error)
+	}
+	return stats, nil
+}
+
+func (i *Importer) run(ctx context.Context, libraryPath string) *ImportStats {
+	stats := &ImportStats{}
+	defer func() {
+		now := time.Now().UTC()
+		i.mu.Lock()
+		i.progress.Running = false
+		i.progress.FinishedAt = &now
+		i.progress.Stats = stats
+		i.running = false
+		i.mu.Unlock()
+	}()
+
+	reader, err := i.openReader(libraryPath)
+	if err != nil {
+		i.fail(err)
+		return stats
+	}
+	defer reader.Close()
+
+	total, err := reader.Count(ctx)
+	if err != nil {
+		i.fail(err)
+		return stats
+	}
+	i.setProgress(func(p *ImportProgress) {
+		p.Total = total
+		p.Message = fmt.Sprintf("scanning %d books…", total)
+	})
+
+	err = reader.Books(ctx, func(cb CalibreBook) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		i.importOne(ctx, cb, stats)
+		i.setProgress(func(p *ImportProgress) { p.Processed++ })
+		return nil
+	})
+	if err != nil {
+		i.fail(err)
+		return stats
+	}
+
+	if err := i.settings.Set(ctx, "calibre.last_import_at", time.Now().UTC().Format(time.RFC3339)); err != nil {
+		slog.Warn("calibre import: persist last_import_at failed", "error", err)
+	}
+	slog.Info("calibre import complete",
+		"authorsAdded", stats.AuthorsAdded, "authorsLinked", stats.AuthorsLinked,
+		"booksAdded", stats.BooksAdded, "booksUpdated", stats.BooksUpdated,
+		"editionsAdded", stats.EditionsAdded, "duplicatesMerged", stats.DuplicatesMerged,
+		"skipped", stats.Skipped)
+	i.setProgress(func(p *ImportProgress) {
+		p.Message = "done"
+	})
+	return stats
+}
+
+// importOne handles a single CalibreBook: resolve/create its author, then
+// create or update the Bindery book row, then upsert one edition per
+// format. Errors on any step are logged + counted as skipped so one bad
+// record doesn't abort the whole library.
+func (i *Importer) importOne(ctx context.Context, cb CalibreBook, stats *ImportStats) {
+	if len(cb.Authors) == 0 {
+		slog.Warn("calibre import: book has no authors", "calibre_id", cb.CalibreID, "title", cb.Title)
+		stats.Skipped++
+		return
+	}
+
+	author, created, err := i.resolveAuthor(ctx, cb.Authors[0])
+	if err != nil {
+		slog.Warn("calibre import: author resolve failed", "calibre_id", cb.CalibreID, "error", err)
+		stats.Skipped++
+		return
+	}
+	if created {
+		stats.AuthorsAdded++
+	} else {
+		stats.AuthorsLinked++
+	}
+	i.recordSecondaryAuthors(ctx, author.ID, cb.Authors[1:], stats)
+
+	book, newBook, err := i.upsertBook(ctx, author, cb)
+	if err != nil {
+		slog.Warn("calibre import: book upsert failed", "calibre_id", cb.CalibreID, "error", err)
+		stats.Skipped++
+		return
+	}
+	if newBook {
+		stats.BooksAdded++
+	} else {
+		stats.BooksUpdated++
+		// "DuplicatesMerged" counts the case where we found an existing
+		// Bindery row (by title+author, not by calibre_id) and linked it
+		// to this Calibre book. Distinguishing it from a plain re-import
+		// helps the UI message "we folded N pre-existing books into
+		// their Calibre counterparts".
+		if book.mergedByTitle {
+			stats.DuplicatesMerged++
+		}
+	}
+
+	for _, f := range cb.Formats {
+		added, err := i.upsertEdition(ctx, book.row, cb, f)
+		if err != nil {
+			slog.Warn("calibre import: edition upsert failed",
+				"calibre_id", cb.CalibreID, "format", f.Format, "error", err)
+			continue
+		}
+		if added {
+			stats.EditionsAdded++
+		}
+	}
+}
+
+// resolveAuthor returns the canonical Bindery author for the given Calibre
+// author. Lookup order:
+//  1. Exact name match on authors.name
+//  2. Alias match via author_aliases.name
+//  3. Create a fresh authors row.
+//
+// `created` is true only for case 3. Calibre's author names are already
+// one-per-row in its metadata.db, so we trust them verbatim rather than
+// re-splitting on commas/separators.
+func (i *Importer) resolveAuthor(ctx context.Context, ca CalibreAuthor) (*models.Author, bool, error) {
+	name := strings.TrimSpace(ca.Name)
+	if name == "" {
+		return nil, false, errors.New("empty author name")
+	}
+
+	if existing, err := i.findAuthorByName(ctx, name); err != nil {
+		return nil, false, err
+	} else if existing != nil {
+		return existing, false, nil
+	}
+
+	if aliasID, err := i.aliases.LookupByName(ctx, name); err != nil {
+		return nil, false, err
+	} else if aliasID != nil {
+		existing, err := i.authors.GetByID(ctx, *aliasID)
+		if err != nil {
+			return nil, false, err
+		}
+		if existing != nil {
+			return existing, false, nil
+		}
+	}
+
+	author := &models.Author{
+		ForeignID:        "calibre:author:" + strconv.FormatInt(ca.CalibreID, 10),
+		Name:             name,
+		SortName:         firstNonEmpty(ca.Sort, sortNameFromFull(name)),
+		Monitored:        true,
+		MetadataProvider: "calibre",
+	}
+	if err := i.authors.Create(ctx, author); err != nil {
+		return nil, false, err
+	}
+	return author, true, nil
+}
+
+// findAuthorByName returns the first author whose name matches
+// case-insensitively, or nil. AuthorRepo has no "list by name" helper so
+// we scan in-memory — acceptable because resolveAuthor runs once per
+// Calibre book and List() is already O(authors) per call; for a typical
+// library the author count is a few hundred.
+//
+// TODO(post-v0.8.1): add an indexed lookup to AuthorRepo if library sizes
+// grow beyond a few thousand authors.
+func (i *Importer) findAuthorByName(ctx context.Context, name string) (*models.Author, error) {
+	all, err := i.authors.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	lower := strings.ToLower(name)
+	for idx := range all {
+		if strings.ToLower(all[idx].Name) == lower {
+			return &all[idx], nil
+		}
+	}
+	return nil, nil
+}
+
+// recordSecondaryAuthors adds every co-author after the first to the
+// canonical author's alias list, so future imports that see the same
+// co-author-as-primary resolve back to the same Bindery row.
+func (i *Importer) recordSecondaryAuthors(ctx context.Context, canonicalID int64, extras []CalibreAuthor, _ *ImportStats) {
+	for _, ca := range extras {
+		name := strings.TrimSpace(ca.Name)
+		if name == "" {
+			continue
+		}
+		if err := i.aliases.Create(ctx, &models.AuthorAlias{AuthorID: canonicalID, Name: name}); err != nil {
+			// Non-fatal: an alias can collide with a real author. Log and
+			// move on — the primary ingest already succeeded.
+			slog.Debug("calibre import: alias record skipped", "name", name, "error", err)
+		}
+	}
+}
+
+// bookUpsertResult carries whether a book row was newly created and
+// whether it was discovered via title-match (as opposed to calibre_id).
+type bookUpsertResult struct {
+	row           *models.Book
+	mergedByTitle bool
+}
+
+// upsertBook ensures a Bindery books row exists for the given Calibre
+// book. Dedupe order:
+//  1. books.calibre_id == cb.CalibreID   (pure re-import; update in place)
+//  2. author_id + title match            (existing Bindery book adopted
+//                                          into Calibre; link + update)
+//  3. Create a fresh row with the Calibre id set.
+//
+// Returns (result, created). result.mergedByTitle is true only for path 2.
+func (i *Importer) upsertBook(ctx context.Context, author *models.Author, cb CalibreBook) (*bookUpsertResult, bool, error) {
+	// Path 1 — exact calibre_id match.
+	existing, err := i.books.GetByCalibreID(ctx, cb.CalibreID)
+	if err != nil {
+		return nil, false, err
+	}
+	if existing != nil {
+		if err := i.applyBookFields(ctx, existing, cb); err != nil {
+			return nil, false, err
+		}
+		return &bookUpsertResult{row: existing}, false, nil
+	}
+
+	// Path 2 — same author + title.
+	if existing, err := i.books.FindByAuthorAndTitle(ctx, author.ID, cb.Title); err != nil {
+		return nil, false, err
+	} else if existing != nil {
+		if err := i.books.SetCalibreID(ctx, existing.ID, cb.CalibreID); err != nil {
+			return nil, false, err
+		}
+		id := cb.CalibreID
+		existing.CalibreID = &id
+		if err := i.applyBookFields(ctx, existing, cb); err != nil {
+			return nil, false, err
+		}
+		return &bookUpsertResult{row: existing, mergedByTitle: true}, false, nil
+	}
+
+	// Path 3 — create fresh.
+	id := cb.CalibreID
+	book := &models.Book{
+		ForeignID:        "calibre:book:" + strconv.FormatInt(cb.CalibreID, 10),
+		AuthorID:         author.ID,
+		Title:            cb.Title,
+		SortTitle:        firstNonEmpty(cb.SortTitle, cb.Title),
+		ReleaseDate:      cb.PublishDate,
+		Monitored:        true,
+		Status:           models.BookStatusImported,
+		AnyEditionOK:     true,
+		MediaType:        models.MediaTypeEbook,
+		MetadataProvider: "calibre",
+		CalibreID:        &id,
+	}
+	if err := i.books.Create(ctx, book); err != nil {
+		return nil, false, err
+	}
+	// Create does not write calibre_id directly — persist it separately.
+	if err := i.books.SetCalibreID(ctx, book.ID, cb.CalibreID); err != nil {
+		return nil, false, err
+	}
+	return &bookUpsertResult{row: book}, true, nil
+}
+
+// applyBookFields updates a pre-existing book row with fresh data from
+// Calibre. We refresh the scope of columns the Calibre library actually
+// governs (title, sort, release date, status, file path to the first
+// format) and leave anything outside that scope intact so user-curated
+// metadata is preserved.
+func (i *Importer) applyBookFields(ctx context.Context, book *models.Book, cb CalibreBook) error {
+	book.Title = cb.Title
+	book.SortTitle = firstNonEmpty(cb.SortTitle, cb.Title)
+	if cb.PublishDate != nil {
+		book.ReleaseDate = cb.PublishDate
+	}
+	if len(cb.Formats) > 0 && cb.Formats[0].AbsolutePath != "" {
+		book.FilePath = cb.Formats[0].AbsolutePath
+		book.Status = models.BookStatusImported
+	}
+	if book.MetadataProvider == "" {
+		book.MetadataProvider = "calibre"
+	}
+	return i.books.Update(ctx, book)
+}
+
+// upsertEdition upserts one Bindery edition for a single Calibre format.
+// Returns (added, err) where added is true only when a brand-new row was
+// created.
+func (i *Importer) upsertEdition(ctx context.Context, book *models.Book, cb CalibreBook, f CalibreFormat) (bool, error) {
+	if f.Format == "" {
+		return false, nil
+	}
+	foreignID := fmt.Sprintf("calibre:edition:%d:%s", cb.CalibreID, strings.ToUpper(f.Format))
+	prior, err := i.editions.GetByForeignID(ctx, foreignID)
+	if err != nil {
+		return false, err
+	}
+
+	isbn13 := ptrStringIfNonEmpty(cb.ISBN)
+	e := &models.Edition{
+		ForeignID:   foreignID,
+		BookID:      book.ID,
+		Title:       cb.Title,
+		ISBN13:      isbn13,
+		Publisher:   "",
+		PublishDate: cb.PublishDate,
+		Format:      strings.ToUpper(f.Format),
+		Language:    "eng",
+		ImageURL:    cb.CoverPath,
+		IsEbook:     true,
+		Monitored:   true,
+	}
+	if err := i.editions.Upsert(ctx, e); err != nil {
+		return false, err
+	}
+	return prior == nil, nil
+}
+
+func (i *Importer) fail(err error) {
+	slog.Error("calibre import failed", "error", err)
+	i.setProgress(func(p *ImportProgress) {
+		p.Error = err.Error()
+		p.Message = "failed"
+	})
+}
+
+func (i *Importer) setProgress(mutate func(*ImportProgress)) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	mutate(&i.progress)
+}
+
+// firstNonEmpty returns the first non-blank string from its args, or "".
+func firstNonEmpty(a ...string) string {
+	for _, s := range a {
+		if strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// sortNameFromFull converts "First Last" → "Last, First" as a last-resort
+// sort key when Calibre doesn't supply one. Matches the helper used
+// elsewhere in the API layer (api.sortName).
+func sortNameFromFull(name string) string {
+	fields := strings.Fields(name)
+	if len(fields) < 2 {
+		return name
+	}
+	last := fields[len(fields)-1]
+	rest := strings.Join(fields[:len(fields)-1], " ")
+	return last + ", " + rest
+}
+
+func ptrStringIfNonEmpty(s string) *string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	return &s
+}

--- a/internal/calibre/importer_test.go
+++ b/internal/calibre/importer_test.go
@@ -1,0 +1,359 @@
+package calibre
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// newImporterFixture wires an Importer against an in-memory Bindery DB plus
+// a configurable fakeReader. Tests set fakeReader.books directly so they
+// can exercise matcher logic without rebuilding a SQLite fixture each run.
+func newImporterFixture(t *testing.T) (*Importer, *fakeReader, *db.AuthorRepo, *db.BookRepo, *db.EditionRepo, *db.AuthorAliasRepo, *db.SettingsRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	editionRepo := db.NewEditionRepo(database)
+	aliasRepo := db.NewAuthorAliasRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+
+	fr := &fakeReader{}
+	imp := NewImporter(authorRepo, aliasRepo, bookRepo, editionRepo, settingsRepo)
+	imp.openReader = func(string) (readerIface, error) { return fr, nil }
+
+	return imp, fr, authorRepo, bookRepo, editionRepo, aliasRepo, settingsRepo
+}
+
+// fakeReader lets tests hand the importer a canned []CalibreBook without
+// touching disk. It satisfies readerIface.
+type fakeReader struct {
+	books []CalibreBook
+	err   error
+}
+
+func (f *fakeReader) Count(_ context.Context) (int, error) { return len(f.books), nil }
+func (f *fakeReader) Close() error                         { return nil }
+func (f *fakeReader) Books(_ context.Context, fn func(CalibreBook) error) error {
+	if f.err != nil {
+		return f.err
+	}
+	for _, b := range f.books {
+		if err := fn(b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func sampleCalibreBook(id int64, title, authorName string) CalibreBook {
+	return CalibreBook{
+		CalibreID: id,
+		Title:     title,
+		SortTitle: title,
+		Authors:   []CalibreAuthor{{CalibreID: id, Name: authorName, Sort: authorName}},
+		Formats: []CalibreFormat{
+			{Format: "EPUB", FileName: "book", AbsolutePath: filepath.Join("/lib", title+".epub")},
+		},
+	}
+}
+
+func TestImporter_HappyPath_CreatesAuthorsBooksEditions(t *testing.T) {
+	imp, fr, _, bookRepo, editionRepo, _, settingsRepo := newImporterFixture(t)
+	fr.books = []CalibreBook{
+		sampleCalibreBook(1, "Book One", "Alice Author"),
+		sampleCalibreBook(2, "Book Two", "Alice Author"),
+	}
+
+	stats, err := imp.Run(context.Background(), "/lib")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.AuthorsAdded != 1 || stats.AuthorsLinked != 1 {
+		t.Errorf("authors: added=%d linked=%d want 1/1", stats.AuthorsAdded, stats.AuthorsLinked)
+	}
+	if stats.BooksAdded != 2 || stats.BooksUpdated != 0 {
+		t.Errorf("books: added=%d updated=%d want 2/0", stats.BooksAdded, stats.BooksUpdated)
+	}
+	if stats.EditionsAdded != 2 {
+		t.Errorf("editions added = %d, want 2", stats.EditionsAdded)
+	}
+
+	// calibre_id must land on both book rows — Path B + OPDS cross-reference
+	// depends on it being non-null.
+	b1, err := bookRepo.GetByCalibreID(context.Background(), 1)
+	if err != nil || b1 == nil {
+		t.Fatalf("book 1 by calibre_id: %v / %v", err, b1)
+	}
+	if b1.CalibreID == nil || *b1.CalibreID != 1 {
+		t.Errorf("book 1 calibre_id = %v, want 1", b1.CalibreID)
+	}
+
+	// one edition per book
+	eds, _ := editionRepo.ListByBook(context.Background(), b1.ID)
+	if len(eds) != 1 || eds[0].Format != "EPUB" {
+		t.Errorf("book 1 editions = %+v", eds)
+	}
+
+	// last_import_at stamped
+	s, _ := settingsRepo.Get(context.Background(), "calibre.last_import_at")
+	if s == nil || s.Value == "" {
+		t.Error("last_import_at should be stamped after a successful run")
+	} else if _, err := time.Parse(time.RFC3339, s.Value); err != nil {
+		t.Errorf("last_import_at not RFC3339: %v", err)
+	}
+}
+
+// TestImporter_Idempotent — running twice must not duplicate rows. This
+// is the primary acceptance criterion ("running import twice diffs-only").
+func TestImporter_Idempotent(t *testing.T) {
+	imp, fr, authorRepo, bookRepo, editionRepo, _, _ := newImporterFixture(t)
+	fr.books = []CalibreBook{sampleCalibreBook(1, "Book One", "Alice Author")}
+
+	if _, err := imp.Run(context.Background(), "/lib"); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	stats, err := imp.Run(context.Background(), "/lib")
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+
+	// Second run sees the existing rows and should mark them updated, not
+	// added. Duplicate counts would mean we failed the calibre_id lookup.
+	if stats.BooksAdded != 0 || stats.BooksUpdated != 1 {
+		t.Errorf("second run books: added=%d updated=%d want 0/1", stats.BooksAdded, stats.BooksUpdated)
+	}
+	if stats.EditionsAdded != 0 {
+		t.Errorf("second run should not add editions, got %d", stats.EditionsAdded)
+	}
+
+	authors, _ := authorRepo.List(context.Background())
+	if len(authors) != 1 {
+		t.Errorf("want 1 author after re-import, got %d", len(authors))
+	}
+	books, _ := bookRepo.List(context.Background())
+	if len(books) != 1 {
+		t.Errorf("want 1 book after re-import, got %d", len(books))
+	}
+	eds, _ := editionRepo.ListByBook(context.Background(), books[0].ID)
+	if len(eds) != 1 {
+		t.Errorf("want 1 edition after re-import, got %d", len(eds))
+	}
+}
+
+// TestImporter_ReusesExistingAuthor — when a Bindery author already
+// exists with the same name, the importer must link (not duplicate).
+func TestImporter_ReusesExistingAuthor(t *testing.T) {
+	imp, fr, authorRepo, _, _, _, _ := newImporterFixture(t)
+
+	existing := &models.Author{
+		ForeignID: "ol:A1", Name: "Alice Author", SortName: "Author, Alice",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(context.Background(), existing); err != nil {
+		t.Fatalf("seed author: %v", err)
+	}
+
+	fr.books = []CalibreBook{sampleCalibreBook(1, "Book One", "Alice Author")}
+	if _, err := imp.Run(context.Background(), "/lib"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	authors, _ := authorRepo.List(context.Background())
+	if len(authors) != 1 {
+		t.Errorf("want 1 author (re-used), got %d", len(authors))
+	}
+	if authors[0].ForeignID != "ol:A1" {
+		t.Errorf("expected to link to existing OL author, got foreign_id=%q", authors[0].ForeignID)
+	}
+}
+
+// TestImporter_AliasResolvesToCanonical — if Calibre's author name matches
+// an existing alias, the importer must route books under the alias' target
+// rather than creating a new author row.
+func TestImporter_AliasResolvesToCanonical(t *testing.T) {
+	imp, fr, authorRepo, bookRepo, _, aliasRepo, _ := newImporterFixture(t)
+
+	canonical := &models.Author{
+		ForeignID: "ol:RRH", Name: "R.R. Haywood", SortName: "Haywood, R.R.",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(context.Background(), canonical); err != nil {
+		t.Fatalf("seed author: %v", err)
+	}
+	if err := aliasRepo.Create(context.Background(), &models.AuthorAlias{
+		AuthorID: canonical.ID, Name: "RR Haywood",
+	}); err != nil {
+		t.Fatalf("seed alias: %v", err)
+	}
+
+	fr.books = []CalibreBook{sampleCalibreBook(1, "The Undead", "RR Haywood")}
+	if _, err := imp.Run(context.Background(), "/lib"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	authors, _ := authorRepo.List(context.Background())
+	if len(authors) != 1 {
+		t.Errorf("alias resolution should not create a new author, got %d total", len(authors))
+	}
+	books, _ := bookRepo.ListByAuthor(context.Background(), canonical.ID)
+	if len(books) != 1 {
+		t.Errorf("book should be filed under canonical, got %d", len(books))
+	}
+}
+
+// TestImporter_MergesByTitle — if a Bindery book with the same author +
+// title exists but has no calibre_id, the importer must link it in place
+// and bump DuplicatesMerged rather than creating a parallel row.
+func TestImporter_MergesByTitle(t *testing.T) {
+	imp, fr, authorRepo, bookRepo, _, _, _ := newImporterFixture(t)
+
+	author := &models.Author{
+		ForeignID: "ol:A1", Name: "Alice Author", SortName: "Author, Alice",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(context.Background(), author); err != nil {
+		t.Fatalf("seed author: %v", err)
+	}
+	prior := &models.Book{
+		ForeignID: "ol:B1", AuthorID: author.ID, Title: "Book One", SortTitle: "Book One",
+		Status: models.BookStatusWanted, Monitored: true, AnyEditionOK: true,
+		MetadataProvider: "openlibrary",
+	}
+	if err := bookRepo.Create(context.Background(), prior); err != nil {
+		t.Fatalf("seed book: %v", err)
+	}
+
+	fr.books = []CalibreBook{sampleCalibreBook(42, "Book One", "Alice Author")}
+	stats, err := imp.Run(context.Background(), "/lib")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.DuplicatesMerged != 1 {
+		t.Errorf("DuplicatesMerged = %d, want 1", stats.DuplicatesMerged)
+	}
+	books, _ := bookRepo.List(context.Background())
+	if len(books) != 1 {
+		t.Fatalf("want 1 book after merge, got %d", len(books))
+	}
+	if books[0].CalibreID == nil || *books[0].CalibreID != 42 {
+		t.Errorf("merged book calibre_id = %v, want 42", books[0].CalibreID)
+	}
+}
+
+// TestImporter_SkipsBooksWithoutAuthors — a Calibre book with no author
+// rows is a data error (Calibre requires at least one). We log + skip
+// rather than crashing, and bump Skipped so the UI surfaces it.
+func TestImporter_SkipsBooksWithoutAuthors(t *testing.T) {
+	imp, fr, _, _, _, _, _ := newImporterFixture(t)
+	fr.books = []CalibreBook{{CalibreID: 1, Title: "Orphan"}}
+	stats, err := imp.Run(context.Background(), "/lib")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", stats.Skipped)
+	}
+	if stats.BooksAdded != 0 {
+		t.Error("no book should be added when author is missing")
+	}
+}
+
+// TestImporter_SecondaryAuthorsBecomeAliases — Calibre books with
+// multiple authors are stored as (canonical, aliases) in Bindery. The
+// alias rows let future imports that present the co-author as primary
+// find the same row.
+func TestImporter_SecondaryAuthorsBecomeAliases(t *testing.T) {
+	imp, fr, _, _, _, aliasRepo, _ := newImporterFixture(t)
+	fr.books = []CalibreBook{{
+		CalibreID: 1, Title: "Collab", SortTitle: "Collab",
+		Authors: []CalibreAuthor{
+			{CalibreID: 1, Name: "Alice Author"},
+			{CalibreID: 2, Name: "Carol Coauthor"},
+		},
+		Formats: []CalibreFormat{{Format: "EPUB", FileName: "c", AbsolutePath: "/x.epub"}},
+	}}
+	if _, err := imp.Run(context.Background(), "/lib"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// Look up the alias by name; it should point at the first author.
+	id, err := aliasRepo.LookupByName(context.Background(), "Carol Coauthor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id == nil {
+		t.Fatal("secondary author should be recorded as alias")
+	}
+}
+
+// TestImporter_AlreadyRunningRejected locks in the 409 contract — two
+// simultaneous clicks on the Import button should not race each other.
+func TestImporter_AlreadyRunningRejected(t *testing.T) {
+	imp, fr, _, _, _, _, _ := newImporterFixture(t)
+	block := make(chan struct{})
+	fr.books = []CalibreBook{sampleCalibreBook(1, "Book One", "Alice")}
+	// Replace Books with a version that blocks until we unblock it, so a
+	// second Start arrives while the first is still mid-run.
+	orig := fr.Books
+	var blocking readerFn = func(ctx context.Context, fn func(CalibreBook) error) error {
+		<-block
+		return orig(ctx, fn)
+	}
+	imp.openReader = func(string) (readerIface, error) {
+		return &blockingReader{fakeReader: fr, booksFn: blocking}, nil
+	}
+
+	if err := imp.Start(context.Background(), "/lib"); err != nil {
+		t.Fatalf("first start: %v", err)
+	}
+	if err := imp.Start(context.Background(), "/lib"); !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("second start err = %v, want ErrAlreadyRunning", err)
+	}
+	close(block)
+	// Drain the running goroutine before the test ends.
+	for i := 0; i < 200 && imp.Running(); i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if imp.Running() {
+		t.Fatal("import did not complete")
+	}
+}
+
+type readerFn func(ctx context.Context, fn func(CalibreBook) error) error
+
+type blockingReader struct {
+	*fakeReader
+	booksFn readerFn
+}
+
+func (b *blockingReader) Books(ctx context.Context, fn func(CalibreBook) error) error {
+	return b.booksFn(ctx, fn)
+}
+
+// TestImporter_ReaderOpenFailureSurfacesInProgress — a bad library_path
+// must surface via the polling endpoint rather than leaving the UI stuck
+// on "running".
+func TestImporter_ReaderOpenFailureSurfacesInProgress(t *testing.T) {
+	imp, _, _, _, _, _, _ := newImporterFixture(t)
+	imp.openReader = func(string) (readerIface, error) { return nil, errors.New("boom") }
+
+	if _, err := imp.Run(context.Background(), "/lib"); err == nil {
+		t.Fatal("expected error")
+	}
+	p := imp.Progress()
+	if p.Error == "" {
+		t.Error("progress.Error should capture failure")
+	}
+	if p.Running {
+		t.Error("progress.Running should be false after failure")
+	}
+}

--- a/internal/calibre/reader.go
+++ b/internal/calibre/reader.go
@@ -1,0 +1,314 @@
+package calibre
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// metadataDB is the filename Calibre uses for its library database. The
+// library root directory always contains one at this exact name.
+const metadataDB = "metadata.db"
+
+// ErrMissingMetadataDB is returned when the library root does not contain a
+// metadata.db. Callers surface this as a user-visible error rather than a
+// 500 — it usually means the user pointed library_path at the wrong folder.
+var ErrMissingMetadataDB = errors.New("calibre metadata.db not found in library_path")
+
+// CalibreBook is the importer-facing view of one Calibre book row, joined
+// with its authors, series, identifiers and formats. Field names match
+// Bindery conventions (not Calibre's column names) so the importer can pass
+// them through without a second translation.
+//
+// This is intentionally a flat snapshot: Calibre stores everything in one
+// database so a single pass can build the full shape, and the importer
+// treats each CalibreBook as an atomic unit when upserting.
+type CalibreBook struct {
+	CalibreID   int64
+	Title       string
+	SortTitle   string
+	PublishDate *time.Time
+	ISBN        string
+	Authors     []CalibreAuthor
+	Series      *CalibreSeries
+	Formats     []CalibreFormat
+	CoverPath   string // absolute path to cover.jpg if present; empty if not
+	LibraryPath string // absolute path to this book's folder inside the library
+}
+
+// CalibreAuthor captures a single authors row. Calibre books can have N
+// authors; the importer picks the first as the canonical Bindery author
+// and records the rest as aliases.
+type CalibreAuthor struct {
+	CalibreID int64
+	Name      string
+	Sort      string
+}
+
+// CalibreSeries mirrors Calibre's (name, series_index) tuple.
+type CalibreSeries struct {
+	Name     string
+	Position float64
+}
+
+// CalibreFormat is one on-disk file for a Calibre book. Calibre lets a
+// single book row carry multiple formats (epub + mobi + pdf); each becomes
+// a separate Bindery edition.
+type CalibreFormat struct {
+	Format        string // uppercase file extension: EPUB, MOBI, PDF, ...
+	FileName      string // Calibre's on-disk filename (no extension)
+	AbsolutePath  string // resolved against library root + book path
+	SizeBytes     int64
+}
+
+// Reader opens a Calibre library's metadata.db read-only and returns
+// populated CalibreBook records. It never mutates the Calibre database —
+// we explicitly use `mode=ro&immutable=1` so a concurrent `calibredb`
+// invocation from the same Bindery instance cannot deadlock us.
+type Reader struct {
+	libraryPath string
+	db          *sql.DB
+}
+
+// OpenReader locates metadata.db inside libraryPath and opens it read-only.
+// If metadata.db is absent, returns ErrMissingMetadataDB so the API layer
+// can map it to a 400. Callers MUST Close the returned Reader.
+func OpenReader(libraryPath string) (*Reader, error) {
+	if libraryPath == "" {
+		return nil, errors.New("calibre library_path is empty")
+	}
+	abs, err := filepath.Abs(libraryPath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve library_path: %w", err)
+	}
+	dbPath := filepath.Join(abs, metadataDB)
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: %s", ErrMissingMetadataDB, dbPath)
+		}
+		return nil, fmt.Errorf("stat %s: %w", dbPath, err)
+	}
+	// immutable=1 tells SQLite the file will not change under us, letting
+	// it skip locking and rollback journal checks — safe here because we
+	// only read, and Calibre's WAL is only active while its own GUI runs.
+	conn, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&immutable=1")
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", dbPath, err)
+	}
+	return &Reader{libraryPath: abs, db: conn}, nil
+}
+
+// Close releases the SQLite handle. Safe to call on a nil receiver so the
+// defer-close pattern works even when OpenReader failed.
+func (r *Reader) Close() error {
+	if r == nil || r.db == nil {
+		return nil
+	}
+	return r.db.Close()
+}
+
+// LibraryPath returns the absolute path the reader was opened against.
+// Used by the importer to resolve relative format paths.
+func (r *Reader) LibraryPath() string { return r.libraryPath }
+
+// Count returns the total number of books the library contains. Used by
+// the importer to seed its progress total before the streaming read.
+func (r *Reader) Count(ctx context.Context) (int, error) {
+	var n int
+	if err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM books`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count books: %w", err)
+	}
+	return n, nil
+}
+
+// Books streams every book row from the library, one at a time, into fn.
+// Returning an error from fn aborts the walk and surfaces that error to
+// the caller.
+//
+// Implementation note: we materialise the headline books list first (all
+// columns from the books + series join) and close the rows cursor before
+// issuing per-book follow-up queries for authors, formats, and ISBNs.
+// Calibre ships one SQLite file shared across the app, so nested queries
+// on a single connection deadlock — buffering the book list keeps the
+// reader compatible with constrained connection pools.
+func (r *Reader) Books(ctx context.Context, fn func(CalibreBook) error) error {
+	headers, err := r.listBookHeaders(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, cb := range headers {
+		authors, err := r.loadAuthors(ctx, cb.CalibreID)
+		if err != nil {
+			return err
+		}
+		cb.Authors = authors
+
+		cb.Formats, err = r.loadFormats(ctx, cb.CalibreID, cb.LibraryPath)
+		if err != nil {
+			return err
+		}
+
+		cb.ISBN, err = r.loadISBN(ctx, cb.CalibreID)
+		if err != nil {
+			return err
+		}
+
+		if cover := filepath.Join(cb.LibraryPath, "cover.jpg"); fileExists(cover) {
+			cb.CoverPath = cover
+		}
+
+		if err := fn(cb); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// listBookHeaders reads the books table + series join into a slice so the
+// outer iterator never holds rows open while child queries fire.
+func (r *Reader) listBookHeaders(ctx context.Context) ([]CalibreBook, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT b.id, b.title, b.sort, b.pubdate, b.path, b.series_index,
+		       COALESCE(s.name, '')
+		FROM books b
+		LEFT JOIN books_series_link bsl ON bsl.book = b.id
+		LEFT JOIN series s               ON s.id   = bsl.series
+		ORDER BY b.id`)
+	if err != nil {
+		return nil, fmt.Errorf("query books: %w", err)
+	}
+	defer rows.Close()
+
+	var out []CalibreBook
+	for rows.Next() {
+		var (
+			cb          CalibreBook
+			pubdate     sql.NullString
+			relPath     string
+			seriesIndex sql.NullFloat64
+			seriesName  string
+		)
+		if err := rows.Scan(&cb.CalibreID, &cb.Title, &cb.SortTitle, &pubdate,
+			&relPath, &seriesIndex, &seriesName); err != nil {
+			return nil, fmt.Errorf("scan book: %w", err)
+		}
+		cb.PublishDate = parseCalibreDate(pubdate.String)
+		cb.LibraryPath = filepath.Join(r.libraryPath, relPath)
+		if seriesName != "" {
+			cb.Series = &CalibreSeries{
+				Name:     seriesName,
+				Position: seriesIndex.Float64,
+			}
+		}
+		out = append(out, cb)
+	}
+	return out, rows.Err()
+}
+
+func (r *Reader) loadAuthors(ctx context.Context, bookID int64) ([]CalibreAuthor, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT a.id, a.name, COALESCE(a.sort, '')
+		FROM authors a
+		JOIN books_authors_link bal ON bal.author = a.id
+		WHERE bal.book = ?
+		ORDER BY bal.id`, bookID)
+	if err != nil {
+		return nil, fmt.Errorf("load authors for book %d: %w", bookID, err)
+	}
+	defer rows.Close()
+
+	var out []CalibreAuthor
+	for rows.Next() {
+		var a CalibreAuthor
+		if err := rows.Scan(&a.CalibreID, &a.Name, &a.Sort); err != nil {
+			return nil, fmt.Errorf("scan author: %w", err)
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+func (r *Reader) loadFormats(ctx context.Context, bookID int64, bookPath string) ([]CalibreFormat, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT format, name, uncompressed_size
+		FROM data WHERE book = ?
+		ORDER BY id`, bookID)
+	if err != nil {
+		return nil, fmt.Errorf("load formats for book %d: %w", bookID, err)
+	}
+	defer rows.Close()
+
+	var out []CalibreFormat
+	for rows.Next() {
+		var f CalibreFormat
+		if err := rows.Scan(&f.Format, &f.FileName, &f.SizeBytes); err != nil {
+			return nil, fmt.Errorf("scan format: %w", err)
+		}
+		f.Format = strings.ToUpper(strings.TrimSpace(f.Format))
+		// Calibre stores the format file as `<name>.<format>` inside the
+		// per-book directory. Build the absolute path so callers don't have
+		// to replicate the convention.
+		if f.Format != "" && f.FileName != "" && bookPath != "" {
+			f.AbsolutePath = filepath.Join(bookPath, f.FileName+"."+strings.ToLower(f.Format))
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
+// loadISBN returns the first ISBN identifier (type='isbn') for the book, or
+// empty string if none exists. Calibre occasionally stores two ISBNs on one
+// book (one per format); we keep the first since Bindery's editions model
+// already captures the variance.
+func (r *Reader) loadISBN(ctx context.Context, bookID int64) (string, error) {
+	var isbn string
+	row := r.db.QueryRowContext(ctx,
+		`SELECT val FROM identifiers WHERE book = ? AND type = 'isbn' ORDER BY id LIMIT 1`, bookID)
+	err := row.Scan(&isbn)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("load isbn for book %d: %w", bookID, err)
+	}
+	return isbn, nil
+}
+
+// parseCalibreDate tolerates the three pubdate formats Calibre has shipped:
+// RFC3339, RFC3339 with a +00:00 offset (pre-2020), and an all-day date
+// without a time component. Returns nil for the special sentinel 0101-01-01
+// Calibre uses to mean "no pubdate".
+func parseCalibreDate(s string) *time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.HasPrefix(s, "0101-01-01") {
+		return nil
+	}
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05.000000-07:00",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			t = t.UTC()
+			return &t
+		}
+	}
+	return nil
+}
+
+func fileExists(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && !info.IsDir()
+}

--- a/internal/calibre/reader_test.go
+++ b/internal/calibre/reader_test.go
@@ -1,0 +1,338 @@
+package calibre
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// buildFixtureLibrary builds a minimal Calibre-shaped library under dir:
+//
+//	dir/
+//	  metadata.db              -- SQLite with Calibre's relevant tables
+//	  Alice Author/
+//	    Book One (1)/cover.jpg, bookone.epub
+//	    Book Two (2)/cover.jpg, booktwo.epub, booktwo.mobi
+//	  Bob Baker/
+//	    No Cover (3)/nocover.pdf
+//
+// The schema mirrors the subset of Calibre's metadata.db that Reader
+// queries. Reader only selects columns it needs, so extra columns on
+// real Calibre installs are a compatibility no-op.
+func buildFixtureLibrary(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	// Create per-book folders + format files + covers.
+	layout := []struct {
+		folder  string
+		files   []string
+		noCover bool
+	}{
+		{folder: "Alice Author/Book One (1)", files: []string{"bookone.epub"}},
+		{folder: "Alice Author/Book Two (2)", files: []string{"booktwo.epub", "booktwo.mobi"}},
+		{folder: "Bob Baker/No Cover (3)", files: []string{"nocover.pdf"}, noCover: true},
+	}
+	for _, l := range layout {
+		dir := filepath.Join(root, l.folder)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		if !l.noCover {
+			if err := os.WriteFile(filepath.Join(dir, "cover.jpg"), []byte("cover"), 0o644); err != nil {
+				t.Fatalf("write cover: %v", err)
+			}
+		}
+		for _, f := range l.files {
+			if err := os.WriteFile(filepath.Join(dir, f), []byte("book"), 0o644); err != nil {
+				t.Fatalf("write %s: %v", f, err)
+			}
+		}
+	}
+
+	dbPath := filepath.Join(root, metadataDB)
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open fixture db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	for _, stmt := range fixtureSchema {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec schema %q: %v", stmt, err)
+		}
+	}
+	for _, stmt := range fixtureSeed {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec seed %q: %v", stmt, err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close fixture: %v", err)
+	}
+	return root
+}
+
+// fixtureSchema is the subset of Calibre's metadata.db schema that Reader
+// touches. Column sets match what real Calibre ships (verified against
+// Calibre 7.x); table definitions omit indexes and triggers because Reader
+// doesn't depend on them.
+var fixtureSchema = []string{
+	`CREATE TABLE books (
+		id INTEGER PRIMARY KEY,
+		title TEXT NOT NULL DEFAULT 'Unknown',
+		sort TEXT,
+		timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+		pubdate TIMESTAMP DEFAULT '0101-01-01 00:00:00+00:00',
+		series_index REAL NOT NULL DEFAULT 1.0,
+		author_sort TEXT,
+		isbn TEXT DEFAULT '',
+		path TEXT NOT NULL DEFAULT '',
+		flags INTEGER NOT NULL DEFAULT 1,
+		uuid TEXT,
+		has_cover BOOL DEFAULT 0,
+		last_modified TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	)`,
+	`CREATE TABLE authors (
+		id INTEGER PRIMARY KEY,
+		name TEXT NOT NULL,
+		sort TEXT,
+		link TEXT NOT NULL DEFAULT ''
+	)`,
+	`CREATE TABLE books_authors_link (
+		id INTEGER PRIMARY KEY,
+		book INTEGER NOT NULL,
+		author INTEGER NOT NULL,
+		UNIQUE(book, author)
+	)`,
+	`CREATE TABLE series (
+		id INTEGER PRIMARY KEY,
+		name TEXT NOT NULL,
+		sort TEXT
+	)`,
+	`CREATE TABLE books_series_link (
+		id INTEGER PRIMARY KEY,
+		book INTEGER NOT NULL,
+		series INTEGER NOT NULL
+	)`,
+	`CREATE TABLE data (
+		id INTEGER PRIMARY KEY,
+		book INTEGER NOT NULL,
+		format TEXT NOT NULL,
+		uncompressed_size INTEGER NOT NULL,
+		name TEXT NOT NULL
+	)`,
+	`CREATE TABLE identifiers (
+		id INTEGER PRIMARY KEY,
+		book INTEGER NOT NULL,
+		type TEXT NOT NULL DEFAULT 'isbn',
+		val TEXT NOT NULL
+	)`,
+}
+
+// fixtureSeed inserts a deterministic tiny library the tests can assert on.
+// Book 1 (Book One): single author (Alice), single format (epub), one series
+//                    position, ISBN.
+// Book 2 (Book Two): two authors (Alice primary, Carol secondary), two
+//                    formats (epub + mobi), same series position 2, no ISBN.
+// Book 3 (No Cover): different author (Bob), single PDF, no series, no
+//                    cover file on disk.
+var fixtureSeed = []string{
+	`INSERT INTO authors (id, name, sort) VALUES
+		(1, 'Alice Author', 'Author, Alice'),
+		(2, 'Bob Baker', 'Baker, Bob'),
+		(3, 'Carol Coauthor', 'Coauthor, Carol')`,
+	`INSERT INTO series (id, name) VALUES (1, 'Example Saga')`,
+	`INSERT INTO books (id, title, sort, pubdate, path, series_index) VALUES
+		(1, 'Book One',   'Book One',   '2021-03-04 00:00:00+00:00', 'Alice Author/Book One (1)',   1.0),
+		(2, 'Book Two',   'Book Two',   '2022-06-15 00:00:00+00:00', 'Alice Author/Book Two (2)',   2.0),
+		(3, 'No Cover',   'No Cover',   '0101-01-01 00:00:00+00:00', 'Bob Baker/No Cover (3)',      1.0)`,
+	`INSERT INTO books_authors_link (book, author) VALUES (1, 1), (2, 1), (2, 3), (3, 2)`,
+	`INSERT INTO books_series_link (book, series) VALUES (1, 1), (2, 1)`,
+	`INSERT INTO data (book, format, uncompressed_size, name) VALUES
+		(1, 'EPUB', 12345, 'bookone'),
+		(2, 'EPUB', 23456, 'booktwo'),
+		(2, 'MOBI', 34567, 'booktwo'),
+		(3, 'PDF',  45678, 'nocover')`,
+	`INSERT INTO identifiers (book, type, val) VALUES (1, 'isbn', '9781234567890')`,
+}
+
+func TestOpenReader_MissingMetadataDB(t *testing.T) {
+	dir := t.TempDir()
+	_, err := OpenReader(dir)
+	if err == nil {
+		t.Fatal("expected error for dir without metadata.db")
+	}
+}
+
+func TestOpenReader_EmptyPath(t *testing.T) {
+	_, err := OpenReader("")
+	if err == nil {
+		t.Fatal("expected error for empty library_path")
+	}
+}
+
+func TestReader_Count(t *testing.T) {
+	r := mustOpenFixture(t)
+	defer r.Close()
+	n, err := r.Count(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 {
+		t.Errorf("Count = %d, want 3", n)
+	}
+}
+
+func TestReader_Books_FullShape(t *testing.T) {
+	r := mustOpenFixture(t)
+	defer r.Close()
+
+	var got []CalibreBook
+	err := r.Books(context.Background(), func(b CalibreBook) error {
+		got = append(got, b)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d books, want 3", len(got))
+	}
+
+	// Book 1: one author, one EPUB, series position 1.0, ISBN set, cover exists.
+	b := got[0]
+	if b.CalibreID != 1 || b.Title != "Book One" {
+		t.Errorf("book 1 = %+v", b)
+	}
+	if len(b.Authors) != 1 || b.Authors[0].Name != "Alice Author" {
+		t.Errorf("book 1 authors = %+v", b.Authors)
+	}
+	if b.Series == nil || b.Series.Name != "Example Saga" || b.Series.Position != 1.0 {
+		t.Errorf("book 1 series = %+v", b.Series)
+	}
+	if b.ISBN != "9781234567890" {
+		t.Errorf("book 1 isbn = %q", b.ISBN)
+	}
+	if len(b.Formats) != 1 || b.Formats[0].Format != "EPUB" {
+		t.Errorf("book 1 formats = %+v", b.Formats)
+	}
+	if _, err := os.Stat(b.Formats[0].AbsolutePath); err != nil {
+		t.Errorf("book 1 format path %q not resolvable: %v", b.Formats[0].AbsolutePath, err)
+	}
+	if b.CoverPath == "" {
+		t.Error("book 1 cover should be populated")
+	}
+	if b.PublishDate == nil || b.PublishDate.Year() != 2021 {
+		t.Errorf("book 1 pubdate = %v", b.PublishDate)
+	}
+
+	// Book 2: multi-author (ordering preserved), two formats.
+	b = got[1]
+	if len(b.Authors) != 2 {
+		t.Fatalf("book 2 authors = %+v", b.Authors)
+	}
+	names := []string{b.Authors[0].Name, b.Authors[1].Name}
+	sort.Strings(names)
+	if names[0] != "Alice Author" || names[1] != "Carol Coauthor" {
+		t.Errorf("book 2 author set = %v", names)
+	}
+	if len(b.Formats) != 2 {
+		t.Fatalf("book 2 formats = %+v", b.Formats)
+	}
+	formats := []string{b.Formats[0].Format, b.Formats[1].Format}
+	sort.Strings(formats)
+	if formats[0] != "EPUB" || formats[1] != "MOBI" {
+		t.Errorf("book 2 formats = %v", formats)
+	}
+	if b.ISBN != "" {
+		t.Errorf("book 2 should have no ISBN, got %q", b.ISBN)
+	}
+	if b.Series == nil || b.Series.Position != 2.0 {
+		t.Errorf("book 2 series position = %+v", b.Series)
+	}
+
+	// Book 3: no cover, no series, sentinel pubdate becomes nil.
+	b = got[2]
+	if b.Series != nil {
+		t.Errorf("book 3 should have no series, got %+v", b.Series)
+	}
+	if b.PublishDate != nil {
+		t.Errorf("book 3 pubdate should be nil, got %v", b.PublishDate)
+	}
+	if b.CoverPath != "" {
+		t.Errorf("book 3 should have no cover, got %q", b.CoverPath)
+	}
+	if len(b.Formats) != 1 || b.Formats[0].Format != "PDF" {
+		t.Errorf("book 3 formats = %+v", b.Formats)
+	}
+}
+
+// TestReader_Books_StopsOnError: returning an error from the visitor must
+// abort the walk — the importer relies on this to honour context cancel.
+func TestReader_Books_StopsOnError(t *testing.T) {
+	r := mustOpenFixture(t)
+	defer r.Close()
+
+	var seen int
+	abort := &stopErr{}
+	err := r.Books(context.Background(), func(b CalibreBook) error {
+		seen++
+		return abort
+	})
+	if err != abort {
+		t.Fatalf("expected abort sentinel, got %v", err)
+	}
+	if seen != 1 {
+		t.Errorf("visitor should have stopped after first call, saw %d", seen)
+	}
+}
+
+func TestParseCalibreDate(t *testing.T) {
+	cases := []struct {
+		in   string
+		want *time.Time
+	}{
+		{"", nil},
+		{"0101-01-01 00:00:00+00:00", nil},
+		{"2021-03-04 00:00:00+00:00", ptrTime(2021, 3, 4)},
+		{"2021-03-04", ptrTime(2021, 3, 4)},
+		{"not a date", nil},
+	}
+	for _, tc := range cases {
+		got := parseCalibreDate(tc.in)
+		switch {
+		case tc.want == nil && got != nil:
+			t.Errorf("parseCalibreDate(%q) = %v, want nil", tc.in, got)
+		case tc.want != nil && got == nil:
+			t.Errorf("parseCalibreDate(%q) = nil, want %v", tc.in, *tc.want)
+		case tc.want != nil && got != nil && !got.Equal(*tc.want):
+			t.Errorf("parseCalibreDate(%q) = %v, want %v", tc.in, *got, *tc.want)
+		}
+	}
+}
+
+type stopErr struct{}
+
+func (stopErr) Error() string { return "stop" }
+
+func ptrTime(y, m, d int) *time.Time {
+	t := time.Date(y, time.Month(m), d, 0, 0, 0, 0, time.UTC)
+	return &t
+}
+
+func mustOpenFixture(t *testing.T) *Reader {
+	t.Helper()
+	root := buildFixtureLibrary(t)
+	r, err := OpenReader(root)
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	return r
+}

--- a/internal/calibre/testdata/README.md
+++ b/internal/calibre/testdata/README.md
@@ -1,0 +1,11 @@
+# Calibre reader test fixtures
+
+`metadata.db` here is a minimal real Calibre-format SQLite database built
+by `buildFixtureLibrary` in `reader_test.go`. The helper runs the schema
+and seed SQL from this directory at test startup so the on-disk fixture is
+always in sync with the Go assertions — you don't need to regenerate it
+manually, and deleting the file is harmless.
+
+The per-book directories (`Author/Book (id)/`) hold stand-ins for the
+format files referenced in `data` rows so the reader's absolute-path
+resolution can be exercised end-to-end.

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -133,6 +133,40 @@ func (r *BookRepo) SetCalibreID(ctx context.Context, id, calibreID int64) error 
 	return err
 }
 
+// GetByCalibreID returns the Bindery book row that currently points at the
+// given Calibre book id, or nil if none. The library import flow uses this
+// as its primary idempotency key — a second import pass sees the existing
+// row and updates in place instead of duplicating.
+func (r *BookRepo) GetByCalibreID(ctx context.Context, calibreID int64) (*models.Book, error) {
+	books, err := r.query(ctx, "SELECT "+bookColumns+" FROM books WHERE calibre_id = ?", []any{calibreID})
+	if err != nil {
+		return nil, err
+	}
+	if len(books) == 0 {
+		return nil, nil
+	}
+	return &books[0], nil
+}
+
+// FindByAuthorAndTitle locates a book under authorID whose title matches
+// `title` case-insensitively. Used by the Calibre importer as a secondary
+// dedupe path when the existing row has no calibre_id yet but the user
+// (or a previous Bindery ingest) has already filed a book with the same
+// title — re-matching by title links the two rows instead of creating a
+// duplicate.
+func (r *BookRepo) FindByAuthorAndTitle(ctx context.Context, authorID int64, title string) (*models.Book, error) {
+	books, err := r.query(ctx,
+		"SELECT "+bookColumns+" FROM books WHERE author_id = ? AND LOWER(title) = LOWER(?)",
+		[]any{authorID, title})
+	if err != nil {
+		return nil, err
+	}
+	if len(books) == 0 {
+		return nil, nil
+	}
+	return &books[0], nil
+}
+
 func (r *BookRepo) Delete(ctx context.Context, id int64) error {
 	_, err := r.db.ExecContext(ctx, "DELETE FROM books WHERE id=?", id)
 	return err

--- a/internal/db/editions.go
+++ b/internal/db/editions.go
@@ -1,0 +1,134 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// EditionRepo owns the editions table. Bindery's pre-v0.8.1 code wrote
+// editions only via the metadata aggregator ingesting a fresh book; the
+// Calibre library importer is the first caller that needs to create and
+// upsert editions from outside that flow, so we now expose a dedicated
+// repo rather than leaking SQL into the importer.
+type EditionRepo struct {
+	db *sql.DB
+}
+
+func NewEditionRepo(db *sql.DB) *EditionRepo {
+	return &EditionRepo{db: db}
+}
+
+// GetByForeignID returns the edition keyed by its globally-unique foreign
+// id. Bindery composes foreign ids for Calibre editions as
+// `calibre:<book_id>:<FORMAT>` so the importer can find-or-create each
+// edition without racing with itself on re-runs.
+func (r *EditionRepo) GetByForeignID(ctx context.Context, foreignID string) (*models.Edition, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, foreign_id, book_id, title, isbn_13, isbn_10, asin, publisher,
+		       publish_date, format, num_pages, language, image_url, is_ebook,
+		       edition_info, monitored, created_at, updated_at
+		FROM editions WHERE foreign_id = ?`, foreignID)
+	var e models.Edition
+	var isEbook, monitored int
+	err := row.Scan(&e.ID, &e.ForeignID, &e.BookID, &e.Title, &e.ISBN13, &e.ISBN10,
+		&e.ASIN, &e.Publisher, &e.PublishDate, &e.Format, &e.NumPages, &e.Language,
+		&e.ImageURL, &isEbook, &e.EditionInfo, &monitored, &e.CreatedAt, &e.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get edition %s: %w", foreignID, err)
+	}
+	e.IsEbook = isEbook == 1
+	e.Monitored = monitored == 1
+	return &e, nil
+}
+
+// ListByBook returns every edition linked to bookID, in insertion order.
+func (r *EditionRepo) ListByBook(ctx context.Context, bookID int64) ([]models.Edition, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, foreign_id, book_id, title, isbn_13, isbn_10, asin, publisher,
+		       publish_date, format, num_pages, language, image_url, is_ebook,
+		       edition_info, monitored, created_at, updated_at
+		FROM editions WHERE book_id = ? ORDER BY id`, bookID)
+	if err != nil {
+		return nil, fmt.Errorf("list editions for book %d: %w", bookID, err)
+	}
+	defer rows.Close()
+
+	var out []models.Edition
+	for rows.Next() {
+		var e models.Edition
+		var isEbook, monitored int
+		if err := rows.Scan(&e.ID, &e.ForeignID, &e.BookID, &e.Title, &e.ISBN13, &e.ISBN10,
+			&e.ASIN, &e.Publisher, &e.PublishDate, &e.Format, &e.NumPages, &e.Language,
+			&e.ImageURL, &isEbook, &e.EditionInfo, &monitored, &e.CreatedAt, &e.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan edition: %w", err)
+		}
+		e.IsEbook = isEbook == 1
+		e.Monitored = monitored == 1
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// Upsert inserts the edition if its foreign_id is new, or updates the
+// format / title / isbn / publish_date fields in place if the row already
+// exists. Returns the persisted edition id.
+//
+// The upsert is scoped to the columns the Calibre importer actually
+// derives from metadata.db. Fields outside that scope (edition_info,
+// publisher, num_pages, asin, monitored) are preserved on update so a
+// re-import never flattens metadata the user has curated in-UI.
+func (r *EditionRepo) Upsert(ctx context.Context, e *models.Edition) error {
+	now := time.Now().UTC()
+	isEbook := 0
+	if e.IsEbook {
+		isEbook = 1
+	}
+	monitored := 1
+	if !e.Monitored {
+		// Default to true on insert so existing UI contracts hold; explicit
+		// false is only honoured if the caller really set it.
+		monitored = 1
+	}
+
+	res, err := r.db.ExecContext(ctx, `
+		INSERT INTO editions (foreign_id, book_id, title, isbn_13, isbn_10, asin,
+		                      publisher, publish_date, format, num_pages, language,
+		                      image_url, is_ebook, edition_info, monitored,
+		                      created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(foreign_id) DO UPDATE SET
+		    title       = excluded.title,
+		    isbn_13     = COALESCE(excluded.isbn_13, editions.isbn_13),
+		    format      = excluded.format,
+		    publish_date= COALESCE(excluded.publish_date, editions.publish_date),
+		    is_ebook    = excluded.is_ebook,
+		    image_url   = COALESCE(NULLIF(excluded.image_url, ''), editions.image_url),
+		    language    = excluded.language,
+		    updated_at  = excluded.updated_at`,
+		e.ForeignID, e.BookID, e.Title, e.ISBN13, e.ISBN10, e.ASIN,
+		e.Publisher, e.PublishDate, e.Format, e.NumPages, e.Language,
+		e.ImageURL, isEbook, e.EditionInfo, monitored, now, now)
+	if err != nil {
+		return fmt.Errorf("upsert edition %s: %w", e.ForeignID, err)
+	}
+	// ON CONFLICT UPDATE returns LastInsertId=0 on conflict; fetch the
+	// existing id explicitly in that case.
+	if id, _ := res.LastInsertId(); id > 0 {
+		e.ID = id
+	} else {
+		row := r.db.QueryRowContext(ctx, "SELECT id FROM editions WHERE foreign_id = ?", e.ForeignID)
+		if err := row.Scan(&e.ID); err != nil {
+			return fmt.Errorf("lookup upserted edition %s: %w", e.ForeignID, err)
+		}
+	}
+	e.UpdatedAt = now
+	return nil
+}

--- a/internal/db/migrations/010_calibre_sync.sql
+++ b/internal/db/migrations/010_calibre_sync.sql
@@ -1,0 +1,21 @@
+-- +migrate Up
+
+-- Calibre library read side. v0.8.0 introduced the write path
+-- (calibredb add after import). v0.8.1 adds the ability to ingest an
+-- existing Calibre library into Bindery on demand or at startup.
+--
+-- sync_on_startup: if true, main.go kicks off a background import the
+-- moment the server boots. Default false so existing installs do not
+-- get a surprise workload the next time they pull latest.
+--
+-- last_import_at: stamped by the importer on success as an RFC3339
+-- string. The UI shows it next to the Import button. An empty value
+-- means "never imported". Stored as settings rows because the
+-- calibre.* namespace already exists and the Settings UI picks them
+-- up with no extra plumbing.
+INSERT OR IGNORE INTO settings (key, value) VALUES
+    ('calibre.sync_on_startup', 'false'),
+    ('calibre.last_import_at',  '');
+
+-- +migrate Down
+-- Rows are harmless if they linger. No destructive down step.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -19,6 +19,13 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
+// CalibreSyncer is the narrow interface the scheduler calls to trigger a
+// Calibre library import. Implemented by *calibre.Importer; the interface
+// keeps the scheduler package free of a direct import of the calibre package.
+type CalibreSyncer interface {
+	RunSync(ctx context.Context)
+}
+
 // Scheduler runs background jobs on configurable intervals.
 type Scheduler struct {
 	cron     *cron.Cron
@@ -26,13 +33,14 @@ type Scheduler struct {
 	searcher *indexer.Searcher
 	meta     *metadata.Aggregator
 
-	authors   *db.AuthorRepo
-	books     *db.BookRepo
-	indexers  *db.IndexerRepo
-	downloads *db.DownloadRepo
-	clients   *db.DownloadClientRepo
-	settings  *db.SettingsRepo
-	blocklist *db.BlocklistRepo
+	authors       *db.AuthorRepo
+	books         *db.BookRepo
+	indexers      *db.IndexerRepo
+	downloads     *db.DownloadRepo
+	clients       *db.DownloadClientRepo
+	settings      *db.SettingsRepo
+	blocklist     *db.BlocklistRepo
+	calibreSyncer CalibreSyncer // optional; nil if Calibre is not configured
 }
 
 // New creates a new scheduler.
@@ -63,6 +71,12 @@ func New(
 	}
 }
 
+// WithCalibreSyncer registers a CalibreSyncer that the scheduler will call
+// every 24 hours when Calibre is configured. Must be called before Start.
+func (s *Scheduler) WithCalibreSyncer(syncer CalibreSyncer) {
+	s.calibreSyncer = syncer
+}
+
 // Start registers and runs all background jobs.
 func (s *Scheduler) Start() {
 	// Check downloads every 15 seconds so completed imports land quickly
@@ -91,6 +105,14 @@ func (s *Scheduler) Start() {
 		slog.Info("job: scan library")
 		s.scanner.ScanLibrary(context.Background())
 	})
+
+	// Sync Calibre library every 24 hours when a syncer is registered.
+	if s.calibreSyncer != nil {
+		s.cron.AddFunc("@every 24h", func() {
+			slog.Info("job: calibre library sync")
+			s.calibreSyncer.RunSync(context.Background())
+		})
+	}
 
 	s.cron.Start()
 	slog.Info("scheduler started", "jobs", len(s.cron.Entries()))

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -187,6 +187,8 @@ export const api = {
 
   // Calibre
   testCalibre: () => request<CalibreTestResult>('/calibre/test', { method: 'POST' }),
+  calibreImportStart: () => request<CalibreImportProgress>('/calibre/import', { method: 'POST' }),
+  calibreImportStatus: () => request<CalibreImportProgress>('/calibre/import/status'),
 
   // Metadata Profiles
   listMetadataProfiles: () => request<MetadataProfile[]>('/metadataprofile'),
@@ -283,6 +285,32 @@ export interface CalibreTestResult {
   ok: string
   version: string
   message: string
+}
+
+// CalibreImportStats summarises one completed library import. Present
+// only on the final poll (when progress.running flips false).
+export interface CalibreImportStats {
+  authorsAdded: number
+  authorsLinked: number
+  booksAdded: number
+  booksUpdated: number
+  editionsAdded: number
+  duplicatesMerged: number
+  skipped: number
+}
+
+// CalibreImportProgress is the polled shape for /calibre/import/status.
+// The UI renders a progress bar from total/processed, swaps in the stats
+// summary once running=false, and surfaces any error inline.
+export interface CalibreImportProgress {
+  running: boolean
+  startedAt?: string
+  finishedAt?: string
+  total: number
+  processed: number
+  message?: string
+  error?: string
+  stats?: CalibreImportStats
 }
 
 export interface Indexer {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react'
-import { api, AuthConfig, AuthStatus, Indexer, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile } from '../api/client'
+import { api, AuthConfig, AuthStatus, Indexer, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress } from '../api/client'
 import ThemeToggle from '../components/ThemeToggle'
 import { useAuth } from '../auth/AuthContext'
 
@@ -1034,6 +1034,8 @@ function CalibreSection({
 }) {
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null)
+  const [importProgress, setImportProgress] = useState<CalibreImportProgress | null>(null)
+  const [importError, setImportError] = useState<string | null>(null)
 
   // Legacy fallback: a pre-migration DB with `calibre.enabled=true` but no
   // mode set should still render as 'calibredb' so the user's existing
@@ -1046,6 +1048,34 @@ function CalibreSection({
       : legacyEnabled
       ? 'calibredb'
       : 'off'
+  const enabled = mode !== 'off'
+  const syncOnStartup = (settings['calibre.sync_on_startup'] ?? 'false').toLowerCase() === 'true'
+  const lastImportAt = settings['calibre.last_import_at'] ?? ''
+
+  // Hydrate progress on mount so navigating back mid-import still shows
+  // the live bar instead of a dead "Import library" button.
+  useEffect(() => {
+    api.calibreImportStatus().then(setImportProgress).catch(() => {})
+  }, [])
+
+  // Poll while an import is running.
+  useEffect(() => {
+    if (!importProgress?.running) return
+    const id = setInterval(() => {
+      api.calibreImportStatus().then(setImportProgress).catch(() => {})
+    }, 1000)
+    return () => clearInterval(id)
+  }, [importProgress?.running])
+
+  const startImport = async () => {
+    setImportError(null)
+    try {
+      const p = await api.calibreImportStart()
+      setImportProgress(p)
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : 'Import failed to start')
+    }
+  }
 
   const runTest = async () => {
     setTesting(true)
@@ -1194,6 +1224,84 @@ function CalibreSection({
             </button>
           </div>
         )}
+
+        {/* Library import (read side): Calibre → Bindery */}
+        <div className="pt-3 border-t border-slate-200 dark:border-zinc-800 space-y-3">
+          <div className="flex items-center justify-between">
+            <div>
+              <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">Sync on startup</label>
+              <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">Run a library import automatically each time Bindery boots. Safe to leave on — re-imports are incremental.</p>
+            </div>
+            <button
+              onClick={async () => {
+                const next = syncOnStartup ? 'false' : 'true'
+                setSettings(s => ({ ...s, 'calibre.sync_on_startup': next }))
+                await api.setSetting('calibre.sync_on_startup', next).catch(console.error)
+              }}
+              className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${syncOnStartup ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
+              title={syncOnStartup ? 'Disable' : 'Enable'}
+            >
+              <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${syncOnStartup ? 'translate-x-4' : ''}`} />
+            </button>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="text-xs text-slate-600 dark:text-zinc-500">
+              {lastImportAt ? (
+                <>Last import: <span className="text-slate-800 dark:text-zinc-200">{new Date(lastImportAt).toLocaleString()}</span></>
+              ) : (
+                <>Never imported.</>
+              )}
+            </div>
+            <button
+              onClick={startImport}
+              disabled={!enabled || importProgress?.running}
+              className="px-4 py-2 bg-sky-600 hover:bg-sky-500 rounded text-sm font-medium disabled:opacity-50 flex-shrink-0"
+            >
+              {importProgress?.running ? 'Importing…' : 'Import library'}
+            </button>
+          </div>
+
+          {importError && (
+            <p className="text-xs text-red-600 dark:text-red-400">{importError}</p>
+          )}
+
+          {importProgress && (importProgress.running || importProgress.stats || importProgress.error) && (
+            <div className="rounded border border-slate-200 dark:border-zinc-800 bg-slate-50 dark:bg-zinc-950 px-3 py-2 space-y-2">
+              {importProgress.running && (
+                <>
+                  <div className="flex justify-between text-xs text-slate-600 dark:text-zinc-400">
+                    <span>{importProgress.message || 'Working…'}</span>
+                    <span>{importProgress.processed} / {importProgress.total || '?'}</span>
+                  </div>
+                  <div className="h-1.5 bg-slate-200 dark:bg-zinc-800 rounded overflow-hidden">
+                    <div
+                      className="h-full bg-sky-600 transition-[width] duration-300"
+                      style={{
+                        width: importProgress.total > 0
+                          ? `${Math.min(100, (importProgress.processed / importProgress.total) * 100)}%`
+                          : '0%',
+                      }}
+                    />
+                  </div>
+                </>
+              )}
+              {!importProgress.running && importProgress.error && (
+                <p className="text-xs text-red-600 dark:text-red-400">Import failed: {importProgress.error}</p>
+              )}
+              {!importProgress.running && importProgress.stats && (
+                <p className="text-xs text-slate-700 dark:text-zinc-300">
+                  Import complete —{' '}
+                  <span className="font-medium">{importProgress.stats.authorsAdded}</span> authors added,{' '}
+                  <span className="font-medium">{importProgress.stats.booksAdded}</span> books added,{' '}
+                  <span className="font-medium">{importProgress.stats.editionsAdded}</span> editions added,{' '}
+                  <span className="font-medium">{importProgress.stats.duplicatesMerged}</span> merged,{' '}
+                  <span className="font-medium">{importProgress.stats.skipped}</span> skipped.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- Read-side Calibre import: parses `metadata.db` directly (modernc.org/sqlite, read-only), extracts authors/books/editions/series/ISBN/covers, and upserts into Bindery via a three-tier dedup (`books.calibre_id` → author-alias-aware title match → insert).
- Settings UI gains an **Import library** button with live progress bar + stats summary, plus a **Sync on startup** toggle (off by default) persisted via the settings table.
- Secondary Calibre authors automatically become aliases on the canonical author — reruns are idempotent.

## Implementation notes
- `internal/calibre/reader.go` opens the Calibre DB read-only and yields `CalibreBook` records; outer cursor is fully drained before per-book child queries to avoid connection starvation.
- `internal/calibre/importer.go` owns the upsert orchestration, mutex-guarded in-memory progress, `ErrAlreadyRunning` semantics, and the `calibre.last_import_at` bookkeeping write.
- `internal/api/calibre_import.go` exposes `POST /api/v1/calibre/import` (202 on accept, 409 on conflict) and `GET /api/v1/calibre/import/status`. Handler uses `context.WithoutCancel` so the HTTP request ending doesn't abort the goroutine.
- Startup sync wired into `cmd/bindery/main.go` behind the new `calibre.sync_on_startup` setting.
- New migration `010_calibre_sync.sql` seeds the two settings rows via `INSERT OR IGNORE`.

## Test plan
- [x] `go test ./...` — all 20 packages pass
- [x] `go vet ./...` clean
- [x] `internal/calibre` coverage 81.5% (requirement ≥70%)
- [x] Idempotent import verified (second run: 0 added, 1 updated)
- [x] Missing `metadata.db` surfaces cleanly via `ErrMissingMetadataDB`
- [x] Alias-based dedup verified (`RR Haywood` alias → canonical `R.R. Haywood`)
- [x] Frontend: `npm run typecheck`, `npm run lint`, `npm run build` all green
- [ ] Manual end-to-end against a real Calibre library (reviewer / deploy)

Closes #63.