### PR TITLE
fix(ux): decouple catalogue fetch from auto-grab, add global kill-switch

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -165,7 +165,7 @@ func main() {
 	searchHandler := api.NewSearchHandler(metaAgg)
 	authorHandler := api.NewAuthorHandler(authorRepo, authorAliasRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched)
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
-	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched)
+	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).WithSettings(settingsRepo)
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, idxSearcher, settingsRepo, blocklistRepo)
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)
 	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo)
@@ -187,7 +187,8 @@ func main() {
 	calibreHandler := api.NewCalibreHandler(settingsRepo)
 	migrateHandler := api.NewMigrateHandler(
 		authorRepo, indexerRepo, dlClientRepo, blocklistRepo, bookRepo, metaAgg,
-		func(a *models.Author) { authorHandler.FetchAuthorBooks(a) },
+		// Bulk imports always populate the catalogue but never auto-grab.
+		func(a *models.Author) { authorHandler.FetchAuthorBooks(a, false) },
 	)
 
 	// Router

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -148,10 +148,9 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fetch and store books for this author
-	if req.SearchOnAdd {
-		go h.FetchAuthorBooks(author)
-	}
+	// Fetch and store books for this author. Always populate the catalogue;
+	// pass searchOnAdd so FetchAuthorBooks knows whether to also queue grabs.
+	go h.FetchAuthorBooks(author, req.SearchOnAdd)
 
 	writeJSON(w, http.StatusCreated, author)
 }
@@ -252,11 +251,26 @@ func (h *AuthorHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go h.FetchAuthorBooks(author)
+	// Manual refresh always repopulates the catalogue but never auto-grabs —
+	// the user triggered it to refresh metadata, not to queue downloads.
+	go h.FetchAuthorBooks(author, false)
 	writeJSON(w, http.StatusAccepted, map[string]string{"message": "refresh started"})
 }
 
-func (h *AuthorHandler) FetchAuthorBooks(author *models.Author) {
+// isAutoGrabEnabled reads the autoGrab.enabled setting. Defaults to true when
+// the key is absent so existing installs keep working without any migration.
+func (h *AuthorHandler) isAutoGrabEnabled(ctx context.Context) bool {
+	if h.settings == nil {
+		return true
+	}
+	s, _ := h.settings.Get(ctx, "autoGrab.enabled")
+	if s == nil {
+		return true
+	}
+	return s.Value != "false"
+}
+
+func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool) {
 	ctx := contextBackground()
 	slog.Info("fetching books for author", "author", author.Name, "foreignId", author.ForeignID)
 
@@ -336,8 +350,9 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author) {
 			}
 		}
 
-		// Auto-search the freshly-added wanted book if configured.
-		if h.searcher != nil && author.Monitored {
+		// Auto-search the freshly-added wanted book only when the per-add
+		// flag AND the global auto-grab kill-switch both say yes.
+		if autoSearch && h.searcher != nil && author.Monitored && h.isAutoGrabEnabled(ctx) {
 			h.searcher.SearchAndGrabBook(ctx, b)
 		}
 	}

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -246,7 +246,7 @@ func TestFetchAuthorBooks_FiresSearchForMonitoredAuthor(t *testing.T) {
 	spy := &searcherSpy{}
 
 	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, spy)
-	h.FetchAuthorBooks(author)
+	h.FetchAuthorBooks(author, true)
 
 	titles := spy.titles()
 	if len(titles) != 2 {
@@ -286,7 +286,7 @@ func TestFetchAuthorBooks_SkipsSearchWhenNotMonitored(t *testing.T) {
 	spy := &searcherSpy{}
 
 	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, spy)
-	h.FetchAuthorBooks(author)
+	h.FetchAuthorBooks(author, true)
 
 	if titles := spy.titles(); len(titles) != 0 {
 		t.Errorf("expected no searcher calls for unmonitored author, got %v", titles)

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -20,10 +20,18 @@ type BookHandler struct {
 	meta     *metadata.Aggregator
 	history  *db.HistoryRepo
 	searcher BookSearcher
+	settings *db.SettingsRepo
 }
 
 func NewBookHandler(books *db.BookRepo, meta *metadata.Aggregator, history *db.HistoryRepo, searcher BookSearcher) *BookHandler {
 	return &BookHandler{books: books, meta: meta, history: history, searcher: searcher}
+}
+
+// WithSettings wires in the settings repo so the book handler can consult the
+// global autoGrab.enabled kill-switch.
+func (h *BookHandler) WithSettings(settings *db.SettingsRepo) *BookHandler {
+	h.settings = settings
+	return h
 }
 
 // EnrichAudiobook fetches audnex data for the book's ASIN and updates
@@ -168,7 +176,16 @@ func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
 		*req.Status == models.BookStatusWanted && oldStatus != models.BookStatusWanted {
 		b := *book
 		bgCtx := context.WithoutCancel(r.Context())
-		go h.searcher.SearchAndGrabBook(bgCtx, b)
+		// Respect the global auto-grab kill-switch.
+		autoGrabEnabled := true
+		if h.settings != nil {
+			if s, _ := h.settings.Get(bgCtx, "autoGrab.enabled"); s != nil && s.Value == "false" {
+				autoGrabEnabled = false
+			}
+		}
+		if autoGrabEnabled {
+			go h.searcher.SearchAndGrabBook(bgCtx, b)
+		}
 	}
 
 	writeJSON(w, http.StatusOK, book)

--- a/internal/migrate/csv.go
+++ b/internal/migrate/csv.go
@@ -159,13 +159,15 @@ func parseCSVRows(reader io.Reader) ([]csvRow, error) {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		out = append(out, csvRow{name: line, monitored: true, searchOnAdd: true})
+		out = append(out, csvRow{name: line, monitored: true, searchOnAdd: false})
 	}
 	return out, nil
 }
 
 func rowFromFields(fields []string) csvRow {
-	row := csvRow{monitored: true, searchOnAdd: true}
+	// Default searchOnAdd to false — bulk imports should be safe by default.
+	// Users can opt in per-row by passing a third column "true".
+	row := csvRow{monitored: true, searchOnAdd: false}
 	if len(fields) >= 1 {
 		row.name = strings.TrimSpace(fields[0])
 	}

--- a/internal/migrate/readarr.go
+++ b/internal/migrate/readarr.go
@@ -128,7 +128,10 @@ func importReadarrAuthors(ctx context.Context, src *sql.DB, repo *db.AuthorRepo,
 		res.Added++
 		res.AddedNames = append(res.AddedNames, full.Name)
 
-		if monitored && onSearchOnAdd != nil {
+		// Bulk imports are safe by default: always populate the catalogue
+		// but never auto-grab. The user can trigger grabs manually from the
+		// Wanted page after the import completes.
+		if onSearchOnAdd != nil {
 			go onSearchOnAdd(full)
 		}
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -213,6 +213,16 @@ func (s *Scheduler) SearchAndGrabBook(ctx context.Context, book models.Book) {
 func (s *Scheduler) searchWanted() {
 	ctx := context.Background()
 
+	// Respect the global auto-grab kill-switch. When disabled, the
+	// scheduled wanted-scan is skipped entirely — users manage grabs
+	// manually from the Wanted page.
+	if s.settings != nil {
+		if setting, _ := s.settings.Get(ctx, "autoGrab.enabled"); setting != nil && setting.Value == "false" {
+			slog.Info("job: auto-grab disabled globally, skipping wanted search")
+			return
+		}
+	}
+
 	wanted, err := s.books.ListByStatus(ctx, models.BookStatusWanted)
 	if err != nil {
 		slog.Error("failed to list wanted books", "error", err)

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -79,14 +79,17 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
               </select>
             </div>
           )}
-          <label className="flex items-center gap-2 text-sm mb-3 cursor-pointer select-none">
+          <label className="flex items-start gap-2 text-sm mb-3 cursor-pointer select-none">
             <input
               type="checkbox"
               checked={searchOnAdd}
               onChange={e => setSearchOnAdd(e.target.checked)}
-              className="accent-emerald-500"
+              className="accent-emerald-500 mt-0.5 flex-shrink-0"
             />
-            <span>Start search for books on add</span>
+            <span>
+              <span className="font-medium">Auto-grab books on add</span>
+              <span className="block text-xs text-slate-600 dark:text-zinc-400 mt-0.5">Bindery will always fetch the book catalogue. Enable this to also queue downloads immediately.</span>
+            </span>
           </label>
 
           <div className="flex gap-2">

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -788,6 +788,31 @@ function GeneralTab() {
         </div>
       </section>
 
+      {/* Auto-grab */}
+      <section>
+        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">Auto-grab</h3>
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+          <div className="flex items-center justify-between">
+            <div>
+              <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">Enable automatic grabbing</label>
+              <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">When enabled, Bindery automatically sends found books to the download client. When disabled, all searches run but you manually initiate grabs from the Wanted page.</p>
+            </div>
+            <button
+              onClick={async () => {
+                const current = (settings['autoGrab.enabled'] ?? 'true').toLowerCase()
+                const next = current === 'false' ? 'true' : 'false'
+                setSettings(s => ({ ...s, 'autoGrab.enabled': next }))
+                await api.setSetting('autoGrab.enabled', next).catch(console.error)
+              }}
+              className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${(settings['autoGrab.enabled'] ?? 'true') !== 'false' ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
+              title={(settings['autoGrab.enabled'] ?? 'true') !== 'false' ? 'Disable' : 'Enable'}
+            >
+              <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${(settings['autoGrab.enabled'] ?? 'true') !== 'false' ? 'translate-x-4' : ''}`} />
+            </button>
+          </div>
+        </div>
+      </section>
+
       {/* Naming */}
       <section>
         <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">File Naming</h3>


### PR DESCRIPTION
## Summary

- Fixes the "auto-grab firehose" bug (#69): `FetchAuthorBooks` is now always called on Add Author so the catalogue is always populated. The `searchOnAdd` flag is threaded through as a parameter to gate only the grab step, not the catalogue step.
- Adds a global auto-grab kill-switch (#74): new `autoGrab.enabled` setting (string `"true"`/`"false"`, default `true`) controls whether any automatic grabbing happens. Respected by `FetchAuthorBooks`, `BookHandler.Update` (status transitions), and the scheduler's 12h wanted scan.
- Bulk imports (CSV and Readarr) now default `searchOnAdd=false` — safe by default.
- Manual Refresh passes `autoSearch=false` — repopulates catalogue metadata without queuing grabs.
- Settings → General gains an "Enable automatic grabbing" toggle (immediate-save, same pattern as Calibre toggle).
- AddAuthorModal checkbox relabeled to "Auto-grab books on add" with clarifying subtext.

## Test plan

- [ ] `go build ./...` and `go test ./...` pass (verified)
- [ ] Add Author with checkbox unchecked → books appear in catalogue, no grabs queued
- [ ] Add Author with checkbox checked → books appear and grabs are queued
- [ ] Disable auto-grab in Settings → subsequent adds with checkbox checked still populate catalogue but don't grab
- [ ] Disable auto-grab → 12h scheduler run logs "auto-grab disabled globally, skipping"
- [ ] Status transition (wanted) with auto-grab disabled → no grab fired
- [ ] CSV import → no grabs, catalogue populated
- [ ] Readarr import → no grabs, catalogue populated

Closes #69, closes #74