### PR TITLE
fix(scanner): improve library match quality and surface scan results

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -169,7 +169,8 @@ func main() {
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, idxSearcher, settingsRepo, blocklistRepo)
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)
 	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo)
-	libraryHandler := api.NewLibraryHandler(importScanner)
+	importScanner.WithSettings(settingsRepo)
+	libraryHandler := api.NewLibraryHandler(importScanner).WithSettings(settingsRepo)
 	fileHandler := api.NewFileHandler(bookRepo)
 	historyHandler := api.NewHistoryHandler(historyRepo, blocklistRepo)
 	blocklistHandler := api.NewBlocklistHandler(blocklistRepo)
@@ -358,6 +359,7 @@ func main() {
 
 		// Library
 		r.Post("/library/scan", libraryHandler.Scan)
+		r.Get("/library/scan/status", libraryHandler.ScanStatus)
 
 		// Calibre integration — settings live under /setting/calibre.*,
 		// this endpoint just validates + probes the configured install.

--- a/internal/api/library.go
+++ b/internal/api/library.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/importer"
 )
 
@@ -13,11 +14,18 @@ type libraryScanner interface {
 }
 
 type LibraryHandler struct {
-	scanner libraryScanner
+	scanner  libraryScanner
+	settings *db.SettingsRepo
 }
 
 func NewLibraryHandler(scanner *importer.Scanner) *LibraryHandler {
 	return &LibraryHandler{scanner: scanner}
+}
+
+// WithSettings attaches a SettingsRepo so the handler can serve scan status.
+func (h *LibraryHandler) WithSettings(sr *db.SettingsRepo) *LibraryHandler {
+	h.settings = sr
+	return h
 }
 
 // Scan triggers an immediate library reconciliation in the background and
@@ -28,4 +36,27 @@ func (h *LibraryHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	// response is sent and the request context is cancelled.
 	go h.scanner.ScanLibrary(context.WithoutCancel(r.Context()))
 	writeJSON(w, http.StatusAccepted, map[string]string{"message": "library scan started"})
+}
+
+// ScanStatus returns the result of the last library scan, stored as a JSON
+// string in the settings table under "library.lastScan". Returns 404 if no
+// scan has run yet.
+func (h *LibraryHandler) ScanStatus(w http.ResponseWriter, r *http.Request) {
+	if h.settings == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no scan result available"})
+		return
+	}
+	setting, err := h.settings.Get(r.Context(), "library.lastScan")
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if setting == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no scan result available"})
+		return
+	}
+	// The value is already a JSON string — write it directly.
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(setting.Value))
 }

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/vavallee/bindery/internal/calibre"
 	"github.com/vavallee/bindery/internal/db"
@@ -36,6 +38,7 @@ type Scanner struct {
 	renamer      *Renamer
 	remapper     *Remapper
 	calibre      calibreClient
+	settings     *db.SettingsRepo
 	libraryDir   string
 	audiobookDir string
 }
@@ -69,6 +72,13 @@ func NewScanner(downloads *db.DownloadRepo, clients *db.DownloadClientRepo,
 // disabled (or nil-interface) client is a no-op.
 func (s *Scanner) WithCalibre(c calibreClient) *Scanner {
 	s.calibre = c
+	return s
+}
+
+// WithSettings attaches a SettingsRepo to the scanner so scan results can be
+// persisted under the "library.lastScan" key and surfaced via the API.
+func (s *Scanner) WithSettings(sr *db.SettingsRepo) *Scanner {
+	s.settings = sr
 	return s
 }
 
@@ -275,57 +285,112 @@ func (s *Scanner) clearSABHistory(ctx context.Context, sab *sabnzbd.Client, nzoI
 	}
 }
 
-// titleMatch returns true when bookTitle and parsedTitle share enough significant words
-// to be considered the same work. It requires at least 2 overlapping words of 3+ chars,
-// or all words if the parsed title has fewer than 2 such words. Both titles must
-// contribute at least one word to avoid single-character false positives.
+// titleMatch returns true when bookTitle and parsedTitle refer to the same work.
+// It handles numeric titles (1984, 2001), article normalization ("Title, The"),
+// and uses dynamic overlap thresholds so short titles still match correctly.
 func titleMatch(bookTitle, parsedTitle string) bool {
-	if parsedTitle == "" {
+	if parsedTitle == "" || bookTitle == "" {
 		return false
 	}
-	sigWords := func(s string) []string {
-		var out []string
-		for _, w := range strings.Fields(strings.ToLower(s)) {
-			// Strip non-alpha chars (punctuation, hyphens)
-			w = strings.Map(func(r rune) rune {
-				if r >= 'a' && r <= 'z' {
-					return r
-				}
-				return -1
-			}, w)
-			if len(w) >= 3 {
-				out = append(out, w)
+
+	// norm lowercases, handles "Title, The" inversion, and strips leading articles.
+	norm := func(s string) string {
+		s = strings.ToLower(strings.TrimSpace(s))
+		// Normalize "Title, The" → "the title" (comma-article inversion)
+		if idx := strings.LastIndex(s, ", the"); idx != -1 && idx == len(s)-5 {
+			s = "the " + s[:idx]
+		}
+		// Strip leading article for comparison
+		for _, art := range []string{"the ", "a ", "an "} {
+			if strings.HasPrefix(s, art) {
+				s = s[len(art):]
+				break
 			}
 		}
+		return s
+	}
+
+	// Fast path: exact match after normalization
+	if norm(bookTitle) == norm(parsedTitle) {
+		return true
+	}
+
+	// sigTokens splits on non-alphanumeric runs, preserving digits, and removes stopwords.
+	sigTokens := func(s string) []string {
+		stopwords := map[string]bool{
+			"the": true, "a": true, "an": true, "of": true,
+			"and": true, "in": true, "to": true, "for": true,
+		}
+		var out []string
+		var cur []rune
+		flush := func() {
+			if len(cur) >= 2 {
+				w := string(cur)
+				if !stopwords[w] {
+					out = append(out, w)
+				}
+			}
+			cur = cur[:0]
+		}
+		for _, r := range strings.ToLower(s) {
+			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+				cur = append(cur, r)
+			} else {
+				flush()
+			}
+		}
+		flush()
 		return out
 	}
 
-	btWords := sigWords(bookTitle)
-	ptWords := sigWords(parsedTitle)
-
-	if len(btWords) == 0 || len(ptWords) == 0 {
+	btTok := sigTokens(bookTitle)
+	ptTok := sigTokens(parsedTitle)
+	if len(btTok) == 0 || len(ptTok) == 0 {
 		return false
 	}
 
-	// Build lookup set for book title words
-	btSet := make(map[string]bool, len(btWords))
-	for _, w := range btWords {
+	btSet := make(map[string]bool, len(btTok))
+	for _, w := range btTok {
 		btSet[w] = true
 	}
 
 	overlap := 0
-	for _, w := range ptWords {
+	for _, w := range ptTok {
 		if btSet[w] {
 			overlap++
 		}
 	}
 
-	// Require at least 2 matching words, or all words if parsed title has < 2
-	minOverlap := 2
-	if len(ptWords) < 2 {
-		minOverlap = len(ptWords)
+	// Dynamic threshold: require overlap >= min(len(ptTok), len(btTok), 2).
+	// For single-token titles (e.g. "1984") require at least 1 match.
+	minLen := len(ptTok)
+	if len(btTok) < minLen {
+		minLen = len(btTok)
 	}
-	return overlap >= minOverlap
+	required := 2
+	if minLen < 2 {
+		required = minLen
+	}
+	if required == 0 {
+		required = 1
+	}
+
+	return overlap >= required
+}
+
+// authorMatch returns true when parsedAuthor is consistent with bookAuthor.
+// If parsedAuthor is empty the function returns true (can't disprove).
+// Otherwise it checks that the last name of parsedAuthor appears in bookAuthor.
+func authorMatch(bookAuthor, parsedAuthor string) bool {
+	if parsedAuthor == "" {
+		return true // no author info in filename — don't filter
+	}
+	parts := strings.Fields(strings.ToLower(parsedAuthor))
+	if len(parts) == 0 {
+		return true
+	}
+	lastName := parts[len(parts)-1]
+	return len(lastName) >= 3 && strings.Contains(strings.ToLower(bookAuthor), lastName)
 }
 
 // ScanLibrary walks the library directory for book files not yet tracked in the database
@@ -350,6 +415,7 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 	slog.Info("library scan found files", "path", s.libraryDir, "count", len(foundFiles))
 
 	if len(foundFiles) == 0 {
+		s.writeScanResult(ctx, len(foundFiles), 0, 0)
 		return
 	}
 
@@ -368,6 +434,14 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		}
 	}
 
+	// Build an author name cache (authorID → name) for the author-anchor check.
+	authorNames := make(map[int64]string)
+	if allAuthors, err := s.authors.List(ctx); err == nil {
+		for _, a := range allAuthors {
+			authorNames[a.ID] = a.Name
+		}
+	}
+
 	var reconciled, unmatched int
 	for _, path := range foundFiles {
 		// Skip files already tracked
@@ -378,11 +452,13 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		// Parse the filename to extract title/author hints
 		parsed := ParseFilename(path)
 
-		// Search existing books for a title match using word overlap
+		// Search existing books for a title + author match
 		matched := false
 		if parsed.Title != "" {
 			for _, b := range allBooks {
-				if b.Status == models.BookStatusWanted && titleMatch(b.Title, parsed.Title) {
+				if b.Status == models.BookStatusWanted &&
+					titleMatch(b.Title, parsed.Title) &&
+					authorMatch(authorNames[b.AuthorID], parsed.Author) {
 					// Match found — update file path and status
 					if err := s.books.SetFilePath(ctx, b.ID, path); err != nil {
 						slog.Error("library scan: failed to update book", "id", b.ID, "error", err)
@@ -405,4 +481,22 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 
 	slog.Info("library scan complete", "path", s.libraryDir, "bookFiles", len(foundFiles),
 		"reconciled", reconciled, "unmatched", unmatched)
+
+	s.writeScanResult(ctx, len(foundFiles), reconciled, unmatched)
+}
+
+// writeScanResult persists the scan summary to the settings table under
+// "library.lastScan" so the UI can surface the result without polling logs.
+func (s *Scanner) writeScanResult(ctx context.Context, filesFound, reconciled, unmatched int) {
+	if s.settings == nil {
+		return
+	}
+	payload := fmt.Sprintf(
+		`{"ran_at":%q,"files_found":%d,"reconciled":%d,"unmatched":%d}`,
+		time.Now().UTC().Format(time.RFC3339),
+		filesFound, reconciled, unmatched,
+	)
+	if err := s.settings.Set(ctx, "library.lastScan", payload); err != nil {
+		slog.Warn("library scan: failed to persist scan result", "error", err)
+	}
 }

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -16,28 +16,33 @@ func TestTitleMatch(t *testing.T) {
 		parsedTitle string
 		want        bool
 	}{
-		// Standard matches — parsed titles use spaces, not dots
+		// Standard matches
 		{"The Name of the Wind", "The Name of the Wind", true},
 		{"Project Hail Mary", "Project Hail Mary", true},
 		{"The Way of Kings", "Brandon Sanderson The Way of Kings", true},
 
-		// Partial overlap — at least 2 significant words required
+		// Partial overlap — at least 2 significant (non-stopword) words required
 		{"Dune Messiah", "Frank Herbert Dune Messiah", true},
 		{"The Road", "Cormac McCarthy The Road 2006", true},
 
-		// Single significant book-title word: minOverlap follows ptWords length
-		// "Dune" → btWords=["dune"]; ptWords=["frank","herbert","dune"] len=3 → minOverlap=2
-		// overlap=1 → false (single-word titles need a 1-word parsed title to match)
-		{"Dune", "Frank Herbert Dune", false},
-		// When parsed title is also short, minOverlap=1 and overlap=1 → true
+		// Single-token book title: minLen=1 → required=1; one matching token is enough
+		{"Dune", "Frank Herbert Dune", true},
 		{"Dune", "Dune 2021", true},
 		{"The Sparrow", "The Sparrow Russell", true},
+
+		// Numeric titles preserved (digits are kept as tokens)
+		{"1984", "1984", true},
+		{"1984", "George Orwell 1984", true},
+
+		// Article inversion: "Lord of the Rings, The" normalises to same as "The Lord of the Rings"
+		{"The Lord of the Rings", "Lord of the Rings, The", true},
+
+		// Dots in parsed title are split on non-alnum — "Project.Hail.Mary" yields 3 tokens
+		{"Project Hail Mary", "Project.Hail.Mary", true},
 
 		// Empty / degenerate cases
 		{"", "The Name of the Wind", false},
 		{"The Name of the Wind", "", false},
-		// Dots in parsed title are not split — "project.hail.mary" becomes one big token
-		{"Project Hail Mary", "Project.Hail.Mary", false},
 
 		// Noise titles with no overlap
 		{"Project Hail Mary", "The Lord of the Rings", false},

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -134,6 +134,7 @@ export const api = {
 
   // Library
   triggerLibraryScan: () => request<{ message: string }>('/library/scan', { method: 'POST' }),
+  libraryScanStatus: () => request<{ ran_at: string; files_found: number; reconciled: number; unmatched: number }>('/library/scan/status'),
 
   // Queue
   listQueue: () => request<QueueItem[]>('/queue'),

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -691,6 +691,7 @@ function GeneralTab() {
   const [creatingBackup, setCreatingBackup] = useState(false)
   const [scanningLibrary, setScanningLibrary] = useState(false)
   const [scanMessage, setScanMessage] = useState<string | null>(null)
+  const [lastScan, setLastScan] = useState<{ ran_at: string; files_found: number; reconciled: number; unmatched: number } | null>(null)
 
   useEffect(() => {
     api.listSettings()
@@ -702,6 +703,7 @@ function GeneralTab() {
       .catch(console.error)
       .finally(() => setLoading(false))
     api.listBackups().then(setBackups).catch(console.error)
+    api.libraryScanStatus().then(setLastScan).catch(() => {/* no prior scan — ignore 404 */})
   }, [])
 
   const saveSetting = async (key: string) => {
@@ -730,14 +732,38 @@ function GeneralTab() {
 
   const handleScan = async () => {
     setScanningLibrary(true)
-    setScanMessage(null)
+    setScanMessage('Scanning...')
+    setLastScan(null)
     try {
       await api.triggerLibraryScan()
-      setScanMessage('Scan started — check back in a moment.')
-      setTimeout(() => setScanMessage(null), 5000)
+      // Poll for the result — the scan is async, so wait up to ~8s in 1s intervals.
+      let attempts = 0
+      const poll = async () => {
+        attempts++
+        try {
+          const status = await api.libraryScanStatus()
+          // Only accept a result that was produced after we triggered the scan.
+          const ranAt = new Date(status.ran_at).getTime()
+          const triggerTime = Date.now() - (attempts * 1000)
+          if (ranAt >= triggerTime) {
+            setLastScan(status)
+            setScanMessage(null)
+            setScanningLibrary(false)
+            return
+          }
+        } catch {
+          // result not ready yet
+        }
+        if (attempts < 8) {
+          setTimeout(poll, 1000)
+        } else {
+          setScanMessage('Scan started — results will appear after it completes.')
+          setScanningLibrary(false)
+        }
+      }
+      setTimeout(poll, 1000)
     } catch (err) {
       setScanMessage('Scan failed: ' + (err instanceof Error ? err.message : 'Unknown error'))
-    } finally {
       setScanningLibrary(false)
     }
   }
@@ -870,7 +896,7 @@ function GeneralTab() {
               <p className="text-sm text-slate-700 dark:text-zinc-300">Scan library</p>
               <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">Walk the books directory and reconcile files with the database</p>
               {scanMessage && (
-                <p className="text-xs text-emerald-600 dark:text-emerald-400 mt-1">{scanMessage}</p>
+                <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">{scanMessage}</p>
               )}
             </div>
             <button
@@ -881,6 +907,19 @@ function GeneralTab() {
               {scanningLibrary ? 'Scanning…' : 'Scan Library'}
             </button>
           </div>
+          {lastScan && (
+            <div className="mt-3 border-t border-slate-200 dark:border-zinc-800 pt-3 text-xs text-slate-600 dark:text-zinc-400">
+              <p className="font-medium text-slate-700 dark:text-zinc-300 mb-1">Last scan result</p>
+              <div className="flex gap-4">
+                <span>Files found: <span className="font-mono text-slate-800 dark:text-zinc-200">{lastScan.files_found}</span></span>
+                <span>Reconciled: <span className="font-mono text-emerald-700 dark:text-emerald-400">{lastScan.reconciled}</span></span>
+                <span>Unmatched: <span className="font-mono text-slate-800 dark:text-zinc-200">{lastScan.unmatched}</span></span>
+              </div>
+              <p className="mt-1 text-slate-500 dark:text-zinc-500">
+                {new Date(lastScan.ran_at).toLocaleString()}
+              </p>
+            </div>
+          )}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

- Rewrites `titleMatch` to preserve digits (handles `1984`, `2001`, `Part 2`), strip stopwords so they don't inflate overlap scores, normalize article inversion (`"Title, The"` → `"the title"`), and use a dynamic overlap threshold so single-token titles still match correctly.
- Adds `authorMatch` helper: checks parsed author's surname against the book's author name to eliminate cross-author false positives (e.g. "The Great Book of Tea" by Author A no longer matches a book with the same title by Author B).
- `ScanLibrary` now builds an `authorID→name` cache from the authors table and passes both `titleMatch` and `authorMatch` together.
- Adds `WithSettings` fluent method (same pattern as `WithCalibre`) on `Scanner`; after each scan the result is persisted to settings key `library.lastScan` as `{"ran_at":"...","files_found":N,"reconciled":N,"unmatched":N}`.
- New `GET /api/v1/library/scan/status` endpoint returns the persisted last-scan JSON (or 404 if never scanned).
- `SettingsPage`: loads last scan result on mount; after clicking "Scan Library" polls the status endpoint for up to 8 seconds and renders an in-place result breakdown (files found / reconciled / unmatched + timestamp).

## Test plan

- [ ] All existing Go tests pass (`go test ./...`) — confirmed in CI and locally.
- [ ] `TestTitleMatch` updated to reflect new intended behavior (dot-separated tokens now split, single-token titles match with single-word overlap, numeric titles match, article inversion matches).
- [ ] Manually drop 50 epub files matching wanted-book titles into library dir, trigger scan, verify reconciled count in UI is much higher than the old ~6%.
- [ ] Verify `GET /api/v1/library/scan/status` returns 404 before first scan and correct JSON after.
- [ ] Verify UI shows result breakdown after clicking "Scan Library".

Closes #68