### PR TITLE
fix(scanner): check library for existing files before auto-searching on author add

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -198,7 +198,7 @@ func main() {
 	// API handlers
 	authHandler := api.NewAuthHandler(userRepo, settingsRepo, loginLimiter)
 	searchHandler := api.NewSearchHandler(metaAgg)
-	authorHandler := api.NewAuthorHandler(authorRepo, authorAliasRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched)
+	authorHandler := api.NewAuthorHandler(authorRepo, authorAliasRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched).WithFinder(importScanner)
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
 	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).WithSettings(settingsRepo)
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, idxSearcher, settingsRepo, blocklistRepo)

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -24,10 +24,19 @@ type AuthorHandler struct {
 	settings *db.SettingsRepo
 	profiles *db.MetadataProfileRepo
 	searcher BookSearcher
+	finder   LibraryFinder
 }
 
 func NewAuthorHandler(authors *db.AuthorRepo, aliases *db.AuthorAliasRepo, books *db.BookRepo, series *db.SeriesRepo, meta *metadata.Aggregator, settings *db.SettingsRepo, profiles *db.MetadataProfileRepo, searcher BookSearcher) *AuthorHandler {
 	return &AuthorHandler{authors: authors, aliases: aliases, books: books, series: series, meta: meta, settings: settings, profiles: profiles, searcher: searcher}
+}
+
+// WithFinder attaches a LibraryFinder to the handler. When set, FetchAuthorBooks
+// will check whether each newly-created book already exists on disk before
+// queuing an auto-search, preventing re-downloads of books the user owns.
+func (h *AuthorHandler) WithFinder(f LibraryFinder) *AuthorHandler {
+	h.finder = f
+	return h
 }
 
 func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -347,6 +356,15 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool)
 			}
 			if err := h.series.LinkBook(ctx, s.ID, b.ID, ref.Position, ref.Primary); err != nil {
 				slog.Warn("failed to link book to series", "book", b.Title, "series", ref.Title, "error", err)
+			}
+		}
+
+		// Check if the user already owns this book before queuing a download.
+		if h.finder != nil {
+			if existingPath := h.finder.FindExisting(ctx, b.Title, author.Name); existingPath != "" {
+				slog.Info("library: found existing file, skipping auto-search", "title", b.Title, "path", existingPath)
+				_ = h.books.SetFilePath(ctx, b.ID, existingPath)
+				continue // don't auto-search for a book we already have
 			}
 		}
 

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -254,6 +254,89 @@ func TestFetchAuthorBooks_FiresSearchForMonitoredAuthor(t *testing.T) {
 	}
 }
 
+// stubLibraryFinder is a mock LibraryFinder that returns a fixed path for
+// a specific title and "" for everything else.
+type stubLibraryFinder struct {
+	ownedTitle string
+	ownedPath  string
+}
+
+func (f *stubLibraryFinder) FindExisting(_ context.Context, title, _ string) string {
+	if title == f.ownedTitle {
+		return f.ownedPath
+	}
+	return ""
+}
+
+// TestFetchAuthorBooks_SkipsSearchForOwnedBooks verifies that when the
+// LibraryFinder reports a book is already on disk, FetchAuthorBooks sets the
+// file path on the book row and does NOT call SearchAndGrabBook for it. Books
+// NOT found on disk should still be searched normally.
+func TestFetchAuthorBooks_SkipsSearchForOwnedBooks(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL700A", Name: "Owned Author", SortName: "Author, Owned",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	stub := &stubMetaProvider{
+		works: []models.Book{
+			{ForeignID: "OL701W", Title: "Already Owned", SortTitle: "already owned", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+			{ForeignID: "OL702W", Title: "Not Yet Owned", SortTitle: "not yet owned", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+		},
+	}
+	agg := metadata.NewAggregator(stub)
+	spy := &searcherSpy{}
+	finder := &stubLibraryFinder{
+		ownedTitle: "Already Owned",
+		ownedPath:  "/library/Owned Author/Already Owned.epub",
+	}
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, spy).WithFinder(finder)
+	h.FetchAuthorBooks(author, true)
+
+	titles := spy.titles()
+	// Only "Not Yet Owned" should have triggered a search.
+	if len(titles) != 1 {
+		t.Fatalf("expected 1 searcher call, got %d: %v", len(titles), titles)
+	}
+	if titles[0] != "Not Yet Owned" {
+		t.Errorf("expected search for 'Not Yet Owned', got %q", titles[0])
+	}
+
+	// The owned book's file path should have been persisted in the DB.
+	books, err := bookRepo.ListByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ownedBook *models.Book
+	for i := range books {
+		if books[i].Title == "Already Owned" {
+			ownedBook = &books[i]
+			break
+		}
+	}
+	if ownedBook == nil {
+		t.Fatal("expected 'Already Owned' book to be created in DB")
+	}
+	if ownedBook.FilePath != finder.ownedPath {
+		t.Errorf("expected file path %q, got %q", finder.ownedPath, ownedBook.FilePath)
+	}
+}
+
 // TestFetchAuthorBooks_SkipsSearchWhenNotMonitored confirms that books added
 // for an unmonitored author do NOT trigger an indexer search — the user has
 // opted out of automatic activity for this author.

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -17,6 +17,12 @@ type BookSearcher interface {
 	SearchAndGrabBook(ctx context.Context, book models.Book)
 }
 
+// LibraryFinder checks whether a book already exists in the local library.
+// Implemented by *importer.Scanner; a nil implementation is a no-op.
+type LibraryFinder interface {
+	FindExisting(ctx context.Context, title, authorName string) string
+}
+
 func contextBackground() context.Context {
 	return context.Background()
 }

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -362,6 +362,31 @@ func (s *Scanner) clearSABHistory(ctx context.Context, sab *sabnzbd.Client, nzoI
 	}
 }
 
+// FindExisting searches the library directory for a book file that matches
+// the given title and author. Returns the first matching file path, or ""
+// if none is found. Intended to be called before auto-searching so books
+// the user already owns are not re-downloaded.
+func (s *Scanner) FindExisting(ctx context.Context, title, authorName string) string {
+	if s.libraryDir == "" || title == "" {
+		return ""
+	}
+	var found string
+	filepath.Walk(s.libraryDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || found != "" {
+			return nil
+		}
+		if !IsBookFile(path) {
+			return nil
+		}
+		parsed := ParseFilename(path)
+		if titleMatch(parsed.Title, title) && authorMatch(authorName, parsed.Author) {
+			found = path
+		}
+		return nil
+	})
+	return found
+}
+
 // titleMatch returns true when bookTitle and parsedTitle refer to the same work.
 // It handles numeric titles (1984, 2001), article normalization ("Title, The"),
 // and uses dynamic overlap thresholds so short titles still match correctly.


### PR DESCRIPTION
Closes #79. Depends on #77 and #78 — merge those first, then rebase this branch on development before merging.

## Summary
- Adds `Scanner.FindExisting` to `internal/importer/scanner.go` — walks the library directory looking for a book file whose parsed title/author match the given arguments
- Adds `authorMatch` helper in the same file (will be superseded by #78's version when that merges)
- Defines `LibraryFinder` interface in `internal/api/helpers.go` alongside `BookSearcher`
- Adds `finder LibraryFinder` field and `WithFinder` fluent method to `AuthorHandler`
- Guards the `SearchAndGrabBook` call in `FetchAuthorBooks`: if the finder reports an existing file, the path is persisted on the book row and the search is skipped
- Wires `WithFinder(importScanner)` in `cmd/bindery/main.go`
- Adds `TestFetchAuthorBooks_SkipsSearchForOwnedBooks` to verify owned books are not re-searched while unowned books still are

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (all 20 packages green)
- [ ] Manual: add an author whose books are already in the library directory — verify no grab is queued and the file path appears on the book row immediately