### PR TITLE
fix(scanner): prevent cross-book file assignment on library scan

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -528,11 +528,16 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		return
 	}
 
-	// Build a set of file paths already tracked in the DB
-	trackedPaths := make(map[string]bool, len(allBooks))
+	// Build a set of tracked file paths AND their parent directories.
+	// The parent-directory entry is needed for audiobooks: their file_path
+	// is stored as a directory (the whole folder is the "file"), but the
+	// walk yields individual tracks. Without it every audio track inside an
+	// already-imported audiobook folder would look untracked.
+	trackedPaths := make(map[string]bool, len(allBooks)*2)
 	for _, b := range allBooks {
 		if b.FilePath != "" {
-			trackedPaths[b.FilePath] = true
+			trackedPaths[filepath.Clean(b.FilePath)] = true
+			trackedPaths[filepath.Clean(filepath.Dir(b.FilePath))] = true
 		}
 	}
 
@@ -544,20 +549,43 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		}
 	}
 
+	// reconciledBooks prevents a single DB book from being matched to more
+	// than one file in the same scan pass. allBooks is loaded once and is
+	// never mutated in-memory, so without this guard a loose titleMatch could
+	// assign the same book to multiple files — last write wins, overwriting
+	// the correct earlier assignment.
+	reconciledBooks := make(map[int64]bool)
+
 	var reconciled, unmatched int
 	for _, path := range foundFiles {
-		// Skip files already tracked
-		if trackedPaths[path] {
+		// Skip files already tracked, or files inside a tracked directory
+		// (individual tracks inside an already-imported audiobook folder).
+		cleanPath := filepath.Clean(path)
+		if trackedPaths[cleanPath] || trackedPaths[filepath.Clean(filepath.Dir(cleanPath))] {
 			continue
 		}
 
-		// Parse the filename to extract title/author hints
+		// Parse the filename for title/author hints. If the filename alone
+		// doesn't yield an author (e.g. the file is named just "book.epub"),
+		// fall back to the first directory component relative to libraryDir —
+		// most library layouts are {Author}/{Title}/filename.ext.
 		parsed := ParseFilename(path)
+		if parsed.Author == "" {
+			if rel, err := filepath.Rel(s.libraryDir, path); err == nil {
+				parts := strings.SplitN(rel, string(filepath.Separator), 2)
+				if len(parts) >= 2 {
+					parsed.Author = parts[0]
+				}
+			}
+		}
 
 		// Search existing books for a title + author match
 		matched := false
 		if parsed.Title != "" {
 			for _, b := range allBooks {
+				if reconciledBooks[b.ID] {
+					continue
+				}
 				if b.Status == models.BookStatusWanted &&
 					titleMatch(b.Title, parsed.Title) &&
 					authorMatch(authorNames[b.AuthorID], parsed.Author) {
@@ -567,7 +595,8 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 						continue
 					}
 					slog.Info("library scan: reconciled book", "title", b.Title, "path", path)
-					trackedPaths[path] = true
+					trackedPaths[cleanPath] = true
+					reconciledBooks[b.ID] = true
 					reconciled++
 					matched = true
 					break

--- a/internal/importer/scanner_extra_test.go
+++ b/internal/importer/scanner_extra_test.go
@@ -128,3 +128,169 @@ func TestCheckDownloads_NoEnabledClient(t *testing.T) {
 	s, _, _, ctx := scannerFixture(t, t.TempDir())
 	s.CheckDownloads(ctx) // no panic, no DB writes
 }
+
+// TestScanLibrary_NoDuplicateBookAssignment — regression test for issue #81.
+// When two files in the library loosely match the same book's title, the book
+// must only be reconciled to the FIRST file encountered; the second file must
+// be left as "unmatched" rather than overwriting the first assignment.
+// Without the reconciledBooks guard, allBooks is never mutated in memory so
+// the book's in-memory status stays "wanted" and both files claim it — with
+// the last write winning and destroying the correct earlier match.
+func TestScanLibrary_NoDuplicateBookAssignment(t *testing.T) {
+	libDir := t.TempDir()
+
+	// Two files whose titles overlap with the same book title.
+	file1 := filepath.Join(libDir, "Dune.epub")
+	file2 := filepath.Join(libDir, "Dune (Alt Edition).epub")
+	for _, f := range []string{file1, file2} {
+		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s, books, authors, ctx := scannerFixture(t, libDir)
+	author := &models.Author{ForeignID: "OLA", Name: "Frank Herbert", SortName: "Herbert, Frank"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OLB", AuthorID: author.ID,
+		Title: "Dune", Status: models.BookStatusWanted,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	got, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The book must have been reconciled to exactly one file.
+	if got.FilePath == "" {
+		t.Fatal("expected book to be reconciled to a file, got empty FilePath")
+	}
+	// The path that was set must be one of the two candidates — not
+	// some other file — and the book must not have been overwritten with
+	// a different file in a second pass.
+	if got.FilePath != file1 && got.FilePath != file2 {
+		t.Errorf("FilePath %q is not one of the expected candidates", got.FilePath)
+	}
+}
+
+// TestScanLibrary_AudiobookDirectorySkipped — files inside an already-tracked
+// audiobook directory must not trigger re-reconciliation. Before this fix the
+// trackedPaths set only contained file paths; individual audio tracks inside
+// a directory-level file_path were never found in the set and each track
+// looked untracked, causing the scanner to try (and fail) to re-assign them
+// to "wanted" books.
+func TestScanLibrary_AudiobookDirectorySkipped(t *testing.T) {
+	libDir := t.TempDir()
+
+	// Simulate an audiobook folder: /libDir/Author/Title/01.mp3
+	abDir := filepath.Join(libDir, "Author", "Title")
+	if err := os.MkdirAll(abDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	track := filepath.Join(abDir, "01 - Chapter One.mp3")
+	if err := os.WriteFile(track, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, books, authors, ctx := scannerFixture(t, libDir)
+	author := &models.Author{ForeignID: "OLA2", Name: "Author", SortName: "Author"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	// The audiobook book already has its file_path set to the directory
+	// (matching how tryImport records audiobook imports).
+	book := &models.Book{
+		ForeignID: "OLB2", AuthorID: author.ID, Title: "Title",
+		Status: models.BookStatusImported, FilePath: abDir,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	// A second "wanted" book whose title would match the track file if the
+	// directory guard weren't in place.
+	wanted := &models.Book{
+		ForeignID: "OLB3", AuthorID: author.ID, Title: "Chapter One",
+		Status: models.BookStatusWanted,
+	}
+	if err := books.Create(ctx, wanted); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	// The track inside the already-tracked directory must not have been
+	// assigned to the wanted book.
+	got, err := books.GetByID(ctx, wanted.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FilePath != "" {
+		t.Errorf("wanted book must not have been reconciled to a track inside a tracked dir, got %q", got.FilePath)
+	}
+}
+
+// TestScanLibrary_DirectoryAuthorInference — when a file's name provides no
+// author hint, the scanner should infer the author from the first directory
+// component relative to libraryDir (the standard Author/Title/file.ext layout).
+// This prevents uninformative filenames like "book.epub" from matching books
+// by wrong authors simply because parsedAuthor is empty and authorMatch
+// returns true for everything.
+func TestScanLibrary_DirectoryAuthorInference(t *testing.T) {
+	libDir := t.TempDir()
+
+	// File nested two levels deep: /libDir/Isaac Asimov/Foundation/foundation.epub
+	// The filename alone gives no author clue; the directory does.
+	bookDir := filepath.Join(libDir, "Isaac Asimov", "Foundation")
+	if err := os.MkdirAll(bookDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	epub := filepath.Join(bookDir, "foundation.epub")
+	if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, books, authors, ctx := scannerFixture(t, libDir)
+
+	asimov := &models.Author{ForeignID: "OLA3", Name: "Isaac Asimov", SortName: "Asimov, Isaac"}
+	if err := authors.Create(ctx, asimov); err != nil {
+		t.Fatal(err)
+	}
+	// A different author with a book also titled "Foundation" — should NOT match.
+	other := &models.Author{ForeignID: "OLA4", Name: "Someone Else", SortName: "Else, Someone"}
+	if err := authors.Create(ctx, other); err != nil {
+		t.Fatal(err)
+	}
+	bookAsimov := &models.Book{
+		ForeignID: "OLB4", AuthorID: asimov.ID, Title: "Foundation",
+		Status: models.BookStatusWanted,
+	}
+	if err := books.Create(ctx, bookAsimov); err != nil {
+		t.Fatal(err)
+	}
+	bookOther := &models.Book{
+		ForeignID: "OLB5", AuthorID: other.ID, Title: "Foundation",
+		Status: models.BookStatusWanted,
+	}
+	if err := books.Create(ctx, bookOther); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	// Asimov's book should be reconciled (directory says "Isaac Asimov").
+	gotAsimov, _ := books.GetByID(ctx, bookAsimov.ID)
+	if gotAsimov.FilePath != epub {
+		t.Errorf("Asimov Foundation: want FilePath=%q, got %q", epub, gotAsimov.FilePath)
+	}
+	// The other author's book must not have been touched.
+	gotOther, _ := books.GetByID(ctx, bookOther.ID)
+	if gotOther.FilePath != "" {
+		t.Errorf("Other Foundation must stay unreconciled, got FilePath=%q", gotOther.FilePath)
+	}
+}


### PR DESCRIPTION
Closes #81

## Root causes

Three related bugs in `ScanLibrary` (`internal/importer/scanner.go`):

**1. Missing `reconciledBooks` guard (primary bug)**

`allBooks` is loaded once at the start of the scan and never mutated in memory. Without a per-scan dedup set, a loose `titleMatch` could match the same DB book to multiple files in one pass — last write wins, silently overwriting the correct earlier assignment. This explains why every "in library" book showed a random other file from the same folder: multiple files were competing to claim the same book entry, and whichever was processed last stuck.

**Fix:** add a `reconciledBooks` map that skips already-matched books so each book is reconciled at most once per scan.

**2. Audiobook directory tracking**

Audiobook `file_path` is stored as a directory (the whole folder is the import unit). The walk yields individual tracks. Those paths were never in the `trackedPaths` file-path set, so every track inside an already-imported audiobook folder looked untracked and triggered spurious re-reconciliation.

**Fix:** expand `trackedPaths` to also include the parent directory of each tracked path.

**3. No author anchor when filename is uninformative**

When `ParseFilename` returns no author (e.g. a file named `book.epub`), `authorMatch` returned `true` for every book, leaving only the weak `titleMatch` as the filter. This worsened false-positive rates for flat or minimally-named libraries.

**Fix:** when the filename parse yields no author, fall back to the first directory component relative to `libraryDir`. Standard library layouts are `{Author}/{Title}/filename.ext`; this gives `authorMatch` a real value to compare against.

## Tests added

- `TestScanLibrary_NoDuplicateBookAssignment` — two files matching the same book title; only the first may be reconciled
- `TestScanLibrary_AudiobookDirectorySkipped` — tracks inside a directory-tracked audiobook folder must not be re-reconciled
- `TestScanLibrary_DirectoryAuthorInference` — two authors both have a book titled "Foundation"; only the one whose directory matches should be reconciled