### PR TITLE
fix: apostrophe search, cover badges, circular checkboxes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,21 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=development,enable=${{ github.ref == 'refs/heads/development' }}
             type=semver,pattern={{version}}
-      # Derive the in-binary VERSION string shown in the UI:
-      #   tag push      → "v0.4.2"
-      #   development   → "dev-abcdef1"
-      #   main / other  → "sha-abcdef1"
+      # Derive the in-binary VERSION string shown in the UI.
+      # Uses git describe so any commit on main that descends from a vX.Y.Z
+      # tag shows that tag (or "vX.Y.Z-N-gSHA" when N commits ahead).
+      # This means Argo CD deployments of post-release main commits still
+      # display a recognisable version rather than a raw SHA.
+      #   exactly on tag  → "v0.9.0"
+      #   N commits ahead → "v0.9.0-N-gabcdef1"
+      #   development     → "dev-abcdef1"
+      #   no v* tags yet  → "sha-abcdef1"
       - name: Derive version
         id: ver
         run: |
           short="${GITHUB_SHA::7}"
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          if described=$(git describe --tags --match 'v*' --always 2>/dev/null) && [[ "$described" == v* ]]; then
+            echo "version=${described}" >> "$GITHUB_OUTPUT"
           elif [[ "$GITHUB_REF" == refs/heads/development ]]; then
             echo "version=dev-${short}" >> "$GITHUB_OUTPUT"
           else

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Otherwise the server responds with `401`. The API key lives in **Settings → Ge
 
 | Topic | Where |
 |-------|-------|
+| **Quickstart** — first author to first grab in 10 minutes | [Wiki](https://github.com/vavallee/bindery/wiki/Quickstart) |
 | **Deployment** — Docker, Compose, k8s/Helm, binary, UID/GID, upgrades | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) |
 | **Roadmap** — planned work, scope notes, and explicitly-out-of-scope items (Z-Library, OpenBooks, etc.) | [docs/ROADMAP.md](docs/ROADMAP.md) |
 | **Contributing & CI checks** — dev setup, full quality/security matrix, local check suite | [CONTRIBUTING.md](CONTRIBUTING.md) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,11 +2,11 @@
 
 Tracked feature requests for future releases. Not a commitment — priorities shift based on user feedback and available time. Open an [issue](https://github.com/vavallee/bindery/issues) to propose additions.
 
-The short version lives in the [README](../README.md#roadmap). Checked boxes have landed; unchecked boxes are planned. Items with sub-lists track partially-shipped work.
+The short version lives in the [README](../README.md#roadmap). ✅ items have landed; ⬜ items are planned. Items with sub-lists track partially-shipped work.
 
 ## Planned
 
-- [ ] **Multi-user support** — per-user libraries, per-user monitored authors, per-user quality profiles.
+- ⬜ **Multi-user support** — per-user libraries, per-user monitored authors, per-user quality profiles.
 
   Today Bindery assumes a single administrator — the auth schema has a `users` table but is seeded with exactly one row. Multi-user support needs role/permission scoping across the rest of the schema and UI:
 
@@ -17,41 +17,41 @@ The short version lives in the [README](../README.md#roadmap). Checked boxes hav
 
 - **OIDC / SSO** — support both deployment shapes so Bindery fits any environment.
 
-  - [ ] **Native OIDC client** — sign in directly against Authelia / Authentik / Keycloak / Google / GitHub without a reverse proxy in the path. Session cookies from the OIDC flow live alongside the existing username/password and API-key auth; users can mix.
-  - [ ] **Reverse-proxy SSO** — accept upstream-proxy identity headers (`X-Forwarded-User` / `Remote-User`) when auth mode is **Disabled** or the trusted-proxy allowlist is configured. Already the documented workaround today (see the [Reverse-proxy & SSO wiki page](https://github.com/vavallee/bindery/wiki/Reverse-proxy-and-SSO)); formalize it as a first-class path with a trust list so operators don't have to turn auth off wholesale. Overlaps with the [Reverse-proxy header trust](#) item below.
+  - ⬜ **Native OIDC client** — sign in directly against Authelia / Authentik / Keycloak / Google / GitHub without a reverse proxy in the path. Session cookies from the OIDC flow live alongside the existing username/password and API-key auth; users can mix.
+  - ⬜ **Reverse-proxy SSO** — accept upstream-proxy identity headers (`X-Forwarded-User` / `Remote-User`) when auth mode is **Disabled** or the trusted-proxy allowlist is configured. Already the documented workaround today (see the [Reverse-proxy & SSO wiki page](https://github.com/vavallee/bindery/wiki/Reverse-proxy-and-SSO)); formalize it as a first-class path with a trust list so operators don't have to turn auth off wholesale. Overlaps with the [Reverse-proxy header trust](#) item below.
 
   Goal: the same release supports both homelab users who already run Authelia at the edge **and** users who want to plug OIDC straight into Bindery without standing up a proxy.
 
-- [ ] **Reverse-proxy header trust** — accept `X-Forwarded-User` / `Remote-User` from a configurable list of trusted upstream proxies so SSO-at-the-edge setups don't require the auth-mode-disabled escape hatch.
+- ⬜ **Reverse-proxy header trust** — accept `X-Forwarded-User` / `Remote-User` from a configurable list of trusted upstream proxies so SSO-at-the-edge setups don't require the auth-mode-disabled escape hatch.
 
   Needs a trust list, header allowlist, and clear docs on the footgun (a misconfigured proxy becomes an auth bypass).
 
-- [ ] **CSRF tokens** — explicit CSRF token middleware to harden browser flows.
+- ⬜ **CSRF tokens** — explicit CSRF token middleware to harden browser flows.
 
   Session cookies today use `SameSite=Lax`, which blocks cross-site form posts. On the list for a subsequent hardening pass.
 
-- [ ] **External database support (MySQL / Postgres)** — optional settings for DB host, credentials, and connection path so Bindery can run against a shared MySQL/Postgres instance instead of the bundled SQLite file.
+- ⬜ **External database support (MySQL / Postgres)** ([#86](https://github.com/vavallee/bindery/issues/86)) — optional settings for DB host, credentials, and connection path so Bindery can run against a shared MySQL/Postgres instance instead of the bundled SQLite file.
 
   Useful for multi-replica HA deployments.
 
 - **UI localization (i18n)** — translate the web UI into French, Dutch, and German (starting point; more languages welcome as contributors show up). Today all labels, button text, error messages, and toasts are hardcoded English strings.
 
-  - [ ] Translation-catalogue extraction pass.
-  - [ ] Runtime switcher (language selector in Settings, persisted in `localStorage` so it applies before first paint alongside the theme).
-  - [ ] Locale-aware date/number formatting.
-  - [ ] `Accept-Language` auto-detect on first load with manual override.
+  - ⬜ Translation-catalogue extraction pass.
+  - ⬜ Runtime switcher (language selector in Settings, persisted in `localStorage` so it applies before first paint alongside the theme).
+  - ⬜ Locale-aware date/number formatting.
+  - ⬜ `Accept-Language` auto-detect on first load with manual override.
 
 - **Non-English indexer / metadata support** — let monitored authors and searches pull from language-tagged catalogues and filter results by language.
 
-  - [x] Per-author metadata profiles carry an `allowed_languages` list; OpenLibrary works whose language falls outside it are dropped during author ingestion ([#14](https://github.com/vavallee/bindery/issues/14), landed in v0.6.0).
-  - [ ] Propagate the profile's languages into indexer queries (Prowlarr's `Categories` + language filters, Jackett `/api?cat=7000&...`) so Newznab-side filtering applies.
-  - [ ] Surface the language tag in search-result and wanted-books views.
-  - [ ] Persist Hardcover/Google Books' `language` field for editions.
-  - [ ] **DNB (Deutsche Nationalbibliothek) metadata provider** ([#67](https://github.com/vavallee/bindery/issues/67)) — German national library catalogue via SRU/Z39.50 or the public JSON API. Primary use case: German-language ebooks and audiobooks where OpenLibrary coverage is thin. Calibre's DNB plugin ([calibre-dnb](https://github.com/dvdwolfsburg/calibre-dnb)) serves as a reference implementation for field mapping (title, author, ISBN, publisher, language, description).
+  - ✅ Per-author metadata profiles carry an `allowed_languages` list; OpenLibrary works whose language falls outside it are dropped during author ingestion ([#14](https://github.com/vavallee/bindery/issues/14), landed in v0.6.0).
+  - ⬜ Propagate the profile's languages into indexer queries (Prowlarr's `Categories` + language filters, Jackett `/api?cat=7000&...`) so Newznab-side filtering applies.
+  - ⬜ Surface the language tag in search-result and wanted-books views.
+  - ⬜ Persist Hardcover/Google Books' `language` field for editions.
+  - ⬜ **DNB (Deutsche Nationalbibliothek) metadata provider** ([#67](https://github.com/vavallee/bindery/issues/67)) — German national library catalogue via SRU/Z39.50 or the public JSON API. Primary use case: German-language ebooks and audiobooks where OpenLibrary coverage is thin. Calibre's DNB plugin ([calibre-dnb](https://github.com/dvdwolfsburg/calibre-dnb)) serves as a reference implementation for field mapping (title, author, ISBN, publisher, language, description).
 
   Relevant to French/Dutch/German users whose libraries are mixed-language and where indexer results in the "wrong" language are currently indistinguishable.
 
-- [ ] **LinuxServer.io-style runtime user switching** — parallel image with a gosu/su-exec entrypoint that switches UID/GID at runtime based on `PUID` / `PGID`.
+- ⬜ **LinuxServer.io-style runtime user switching** ([#56](https://github.com/vavallee/bindery/issues/56)) — parallel image with a gosu/su-exec entrypoint that switches UID/GID at runtime based on `PUID` / `PGID`.
 
   The current distroless image is deliberately minimal (no shell, no `gosu`) — the v0.6.0 startup sanity check ([#13](https://github.com/vavallee/bindery/issues/13)) catches PUID/PGID misconfiguration but does not fix it. Trade-offs:
 
@@ -64,11 +64,11 @@ The short version lives in the [README](../README.md#roadmap). Checked boxes hav
 
   The user-facing goal: a monitored author releases a new book, Bindery finds and grabs it, and the result lands in Calibre under the existing author automatically — no manual "Add books" step.
 
-  - [x] **Path A — `calibredb` post-import hook** ([#32](https://github.com/vavallee/bindery/issues/32), landed in v0.8.0) — every successful Bindery import is mirrored into the configured Calibre library by shelling out to `calibredb add --with-library <path>`. The returned Calibre book id is persisted on the Bindery book row so future OPDS / sync work has a stable handle. Opt-in via Settings → General → Calibre (enabled / library path / binary path) with a Test connection button.
-  - [x] **Library import & sync** ([#63](https://github.com/vavallee/bindery/issues/63), landed in v0.9.0) — reads an existing Calibre library's `metadata.db` directly (pure Go, no CGO, read-only) and ingests it as Bindery's catalogue. Three-tier dedup (by Calibre id → title+author → insert new) makes re-imports idempotent. Co-authors become alias rows. Trigger via **Settings → General → Calibre → Import library** or `calibre.sync_on_startup`.
-  - [x] **Path B — Calibre-watched drop folder** ([#64](https://github.com/vavallee/bindery/issues/64), landed in v0.9.0) — alternative for users who'd rather let Calibre do its own ingestion (the [Calibre-Web-Automated](https://github.com/crocodilestick/Calibre-Web-Automated) pattern): Bindery drops finished files into a configured watch directory, Calibre auto-adds them, and Bindery polls `metadata.db` to discover the new book row and link it to the originating grab / history entry.
-  - [x] **Configurable per-library mode** ([#64](https://github.com/vavallee/bindery/issues/64), landed in v0.9.0) — Settings → General → Calibre exposes a mode selector: **Off**, **calibredb CLI** (Path A), or **Drop folder** (Path B). Toggling takes effect without a restart.
-  - [x] **OPDS feed** ([#65](https://github.com/vavallee/bindery/issues/65), landed in v0.9.0) — OPDS 1.2 Atom catalogue at `/opds/v1.2/` so KOReader / Moon+ Reader / etc. can browse and download without running Calibre itself. Authenticated with HTTP Basic Auth (API key as password).
+  - ✅ **Path A — `calibredb` post-import hook** ([#32](https://github.com/vavallee/bindery/issues/32), landed in v0.8.0) — every successful Bindery import is mirrored into the configured Calibre library by shelling out to `calibredb add --with-library <path>`. The returned Calibre book id is persisted on the Bindery book row so future OPDS / sync work has a stable handle. Opt-in via Settings → General → Calibre (enabled / library path / binary path) with a Test connection button.
+  - ✅ **Library import & sync** ([#63](https://github.com/vavallee/bindery/issues/63), landed in v0.9.0) — reads an existing Calibre library's `metadata.db` directly (pure Go, no CGO, read-only) and ingests it as Bindery's catalogue. Three-tier dedup (by Calibre id → title+author → insert new) makes re-imports idempotent. Co-authors become alias rows. Trigger via **Settings → General → Calibre → Import library** or `calibre.sync_on_startup`.
+  - ✅ **Path B — Calibre-watched drop folder** ([#64](https://github.com/vavallee/bindery/issues/64), landed in v0.9.0) — alternative for users who'd rather let Calibre do its own ingestion (the [Calibre-Web-Automated](https://github.com/crocodilestick/Calibre-Web-Automated) pattern): Bindery drops finished files into a configured watch directory, Calibre auto-adds them, and Bindery polls `metadata.db` to discover the new book row and link it to the originating grab / history entry.
+  - ✅ **Configurable per-library mode** ([#64](https://github.com/vavallee/bindery/issues/64), landed in v0.9.0) — Settings → General → Calibre exposes a mode selector: **Off**, **calibredb CLI** (Path A), or **Drop folder** (Path B). Toggling takes effect without a restart.
+  - ✅ **OPDS feed** ([#65](https://github.com/vavallee/bindery/issues/65), landed in v0.9.0) — OPDS 1.2 Atom catalogue at `/opds/v1.2/` so KOReader / Moon+ Reader / etc. can browse and download without running Calibre itself. Authenticated with HTTP Basic Auth (API key as password).
 
 ## Explicitly out of scope
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,6 +47,7 @@ The short version lives in the [README](../README.md#roadmap). Checked boxes hav
   - [ ] Propagate the profile's languages into indexer queries (Prowlarr's `Categories` + language filters, Jackett `/api?cat=7000&...`) so Newznab-side filtering applies.
   - [ ] Surface the language tag in search-result and wanted-books views.
   - [ ] Persist Hardcover/Google Books' `language` field for editions.
+  - [ ] **DNB (Deutsche Nationalbibliothek) metadata provider** ([#67](https://github.com/vavallee/bindery/issues/67)) — German national library catalogue via SRU/Z39.50 or the public JSON API. Primary use case: German-language ebooks and audiobooks where OpenLibrary coverage is thin. Calibre's DNB plugin ([calibre-dnb](https://github.com/dvdwolfsburg/calibre-dnb)) serves as a reference implementation for field mapping (title, author, ISBN, publisher, language, description).
 
   Relevant to French/Dutch/German users whose libraries are mixed-language and where indexer results in the "wrong" language are currently indistinguishable.
 

--- a/internal/indexer/release.go
+++ b/internal/indexer/release.go
@@ -38,8 +38,11 @@ var (
 
 // NormalizeRelease lowercases s and replaces NZB separators with single spaces.
 // Parentheses, brackets, pipes and repeated separators are all collapsed.
+// Apostrophes are stripped so possessive forms in book titles ("Ender's") match
+// the corresponding release names which typically omit them ("Enders").
 func NormalizeRelease(s string) string {
 	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, "'", "") // "ender's" → "enders", "hitchhiker's" → "hitchhikers"
 	s = separatorRe.ReplaceAllString(s, " ")
 	s = multiSpaceRe.ReplaceAllString(s, " ")
 	return strings.TrimSpace(s)

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -168,9 +168,12 @@ var stopWords = map[string]bool{
 }
 
 // sigWords returns the meaningful (non-stop, 3+ char) words from s.
+// Apostrophes are stripped so "Ender's" produces the token "enders",
+// matching the apostrophe-free form used in most release names.
 func sigWords(s string) []string {
 	var out []string
 	for _, w := range strings.Fields(strings.ToLower(s)) {
+		w = strings.ReplaceAll(w, "'", "") // "ender's" → "enders"
 		if len(w) >= 3 && !stopWords[w] {
 			out = append(out, w)
 		}

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -138,6 +138,58 @@ func TestFilterRelevantNoResults(t *testing.T) {
 	}
 }
 
+// TestFilterRelevantApostrophe — regression test for the apostrophe bug (fixes #82).
+// Book titles with possessive apostrophes ("Ender's Game", "The Handmaid's Tale")
+// produce keyword tokens like "ender's". Release filenames never carry apostrophes
+// ("Enders.Game.epub"), so after NormalizeRelease the apostrophe is absent.
+// Before the fix, WordBoundaryRegex("ender's") never matched "enders" and all
+// results were dropped.
+func TestFilterRelevantApostrophe(t *testing.T) {
+	cases := []struct {
+		bookTitle  string
+		author     string
+		releases   []string
+		wantAny    string // at least this release must survive
+	}{
+		{
+			bookTitle: "Ender's Game",
+			author:    "Orson Scott Card",
+			releases: []string{
+				"Orson.Scott.Card.Enders.Game.RETAIL.EPUB",
+				"Enders.Game.epub",
+				"Some.Other.Book.epub",
+			},
+			wantAny: "Orson.Scott.Card.Enders.Game.RETAIL.EPUB",
+		},
+		{
+			bookTitle: "The Handmaid's Tale",
+			author:    "Margaret Atwood",
+			releases: []string{
+				"Margaret.Atwood.The.Handmaids.Tale.EPUB",
+				"Handmaids.Tale.Atwood.mobi",
+			},
+			wantAny: "Margaret.Atwood.The.Handmaids.Tale.EPUB",
+		},
+		{
+			bookTitle: "The Hitchhiker's Guide to the Galaxy",
+			author:    "Douglas Adams",
+			releases: []string{
+				"Douglas.Adams.Hitchhikers.Guide.to.the.Galaxy.epub",
+				"Hitchhikers.Guide.Galaxy.Adams.RETAIL.epub",
+			},
+			wantAny: "Douglas.Adams.Hitchhikers.Guide.to.the.Galaxy.epub",
+		},
+	}
+
+	for _, tc := range cases {
+		got := filterRelevant(toResults(tc.releases...), tc.bookTitle, tc.author)
+		if !contains(got, tc.wantAny) {
+			t.Errorf("filterRelevant(%q, %q): expected %q in results, got %v",
+				tc.bookTitle, tc.author, tc.wantAny, resultTitles(got))
+		}
+	}
+}
+
 func TestRankResultsRetailBeatsScene(t *testing.T) {
 	results := toResults(
 		"The.Sparrow.Russell.SCENE.epub",

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -392,17 +392,19 @@ export default function AuthorDetailPage() {
                       <span className="text-sm text-slate-500 dark:text-zinc-600">{book.title}</span>
                     </div>
                   )}
-                  <div className={`absolute top-2 right-2 px-2 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
-                    {statusLabel[book.status] ?? book.status}
-                  </div>
-                  {book.mediaType === 'audiobook' && (
-                    <div className="absolute top-2 left-2 px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-600/90 text-white">🎧</div>
-                  )}
                 </div>
                 <div className="p-2">
                   <h4 className="text-xs font-medium truncate" title={book.title}>{book.title}</h4>
+                  <div className="flex items-center gap-1 mt-1 flex-wrap">
+                    <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
+                      {statusLabel[book.status] ?? book.status}
+                    </span>
+                    {book.mediaType === 'audiobook' && (
+                      <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300">🎧 Audio</span>
+                    )}
+                  </div>
                   {book.releaseDate && (
-                    <p className="text-[10px] text-slate-600 dark:text-zinc-500">{fmtDate(book.releaseDate)}</p>
+                    <p className="text-[10px] text-slate-600 dark:text-zinc-500 mt-0.5">{fmtDate(book.releaseDate)}</p>
                   )}
                 </div>
               </Link>

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -190,7 +190,7 @@ export default function AuthorsPage() {
                       type="checkbox"
                       checked={allPageSelected}
                       onChange={e => e.target.checked ? selectAllOnPage() : clearSelection()}
-                      className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+                      className="rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
                       title="Select all on this page"
                     />
                   </th>
@@ -212,7 +212,7 @@ export default function AuthorsPage() {
                         type="checkbox"
                         checked={selectedIds.has(author.id)}
                         onChange={() => toggleSelect(author.id)}
-                        className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+                        className="rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
                         onClick={e => e.stopPropagation()}
                       />
                     </td>
@@ -272,7 +272,7 @@ export default function AuthorsPage() {
                   type="checkbox"
                   checked={selectedIds.has(author.id)}
                   onChange={() => toggleSelect(author.id)}
-                  className="absolute top-2 left-2 z-10 rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 bg-white/80 dark:bg-zinc-900/80"
+                  className="absolute top-2 left-2 z-10 rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 bg-white/80 dark:bg-zinc-900/80"
                   title={`Select ${author.authorName}`}
                 />
                 <Link to={`/author/${author.id}`} className="flex gap-3 p-4 hover:bg-slate-200/40 dark:hover:bg-zinc-800/40 transition-colors">

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -179,7 +179,7 @@ export default function BooksPage() {
                       type="checkbox"
                       checked={allPageSelected}
                       onChange={e => e.target.checked ? selectAllOnPage() : clearSelection()}
-                      className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+                      className="rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
                       title="Select all on this page"
                     />
                   </th>
@@ -202,7 +202,7 @@ export default function BooksPage() {
                         type="checkbox"
                         checked={selectedIds.has(book.id)}
                         onChange={() => toggleSelect(book.id)}
-                        className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+                        className="rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
                       />
                     </td>
                     <td className="px-3 py-2">
@@ -253,7 +253,7 @@ export default function BooksPage() {
                   type="checkbox"
                   checked={selectedIds.has(book.id)}
                   onChange={() => toggleSelect(book.id)}
-                  className="absolute top-2 left-2 z-10 rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 bg-white/80 dark:bg-zinc-900/80"
+                  className="absolute top-2 left-2 z-10 rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 bg-white/80 dark:bg-zinc-900/80"
                   title={`Select ${book.title}`}
                   onClick={e => e.stopPropagation()}
                 />
@@ -266,18 +266,20 @@ export default function BooksPage() {
                     </div>
                   )}
                 </Link>
-                <div className={`absolute top-2 right-2 px-2 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
-                  {statusLabel[book.status] ?? book.status}
-                </div>
-                {book.mediaType === 'audiobook' && (
-                  <div className="absolute top-2 left-8 px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-600/90 text-white">🎧</div>
-                )}
               </div>
               <div className="p-2">
                 <h3 className="text-xs font-medium truncate" title={book.title}>{book.title}</h3>
                 {book.author && (
                   <p className="text-[10px] text-slate-500 dark:text-zinc-500 truncate mt-0.5">{book.author.authorName}</p>
                 )}
+                <div className="flex items-center gap-1 mt-1 flex-wrap">
+                  <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
+                    {statusLabel[book.status] ?? book.status}
+                  </span>
+                  {book.mediaType === 'audiobook' && (
+                    <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300">🎧 Audio</span>
+                  )}
+                </div>
                 <div className="flex items-center justify-between mt-0.5">
                   {book.releaseDate && (
                     <p className="text-[10px] text-slate-600 dark:text-zinc-500">{new Date(book.releaseDate).getFullYear()}</p>

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -172,7 +172,7 @@ export default function WantedPage() {
               type="checkbox"
               checked={allPageSelected}
               onChange={e => e.target.checked ? selectAllOnPage() : clearSelection()}
-              className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+              className="rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
               title="Select all on this page"
             />
             <span className="text-xs text-slate-500 dark:text-zinc-500">Select all on this page</span>
@@ -187,7 +187,7 @@ export default function WantedPage() {
                       type="checkbox"
                       checked={selectedIds.has(book.id)}
                       onChange={() => toggleSelect(book.id)}
-                      className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 flex-shrink-0"
+                      className="rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 flex-shrink-0"
                       title={`Select ${book.title}`}
                     />
                     {book.imageUrl && (


### PR DESCRIPTION
Closes #82, #73, #75, #76

Four independent fixes batched together.

---

## fix(indexer): apostrophes in book titles return zero results (closes #82)

**Root cause:** Book titles with possessives produce keyword tokens like `"ender's"`. Release filenames never carry apostrophes (`Enders.Game.epub`), so after `NormalizeRelease` the apostrophe is absent. `WordBoundaryRegex("ender's")` — pattern `\bender's\b` — never matches `"enders"`, and `filterRelevant` drops every result from the indexer.

Affected titles include: *Ender's Game*, *The Handmaid's Tale*, *The Hitchhiker's Guide to the Galaxy*, *Harry Potter and the Philosopher's Stone*, and any other book with a possessive in the title.

**Fix:** Strip apostrophes in both `NormalizeRelease` (result titles) and `sigWords` (book title keywords) so both sides are apostrophe-free before comparison. Regression test added.

---

## ci: semver version displayed in UI for all main branch deployments

**Root cause:** The `Derive version` step only set a semver string on tag-push triggers. Commits to `main` after a release fell through to `sha-${short}`, so Argo CD would deploy an image with that SHA baked in as the displayed version.

**Fix:** Use `git describe --tags --match 'v*' --always` so any commit descending from a release tag shows that tag (or `vX.Y.Z-N-gabcdef1` when N commits ahead). `fetch-depth: 0` is already present so full history is available.

---

## fix(ui): book grid status/media badges unreadable on some covers (closes #73)

Status and audiobook badges were absolutely positioned over the cover image using semi-transparent backgrounds (`bg-amber-500/20` etc.) — effectively invisible when the badge colour matched the cover art. Moved to the card text area below the title. Applied to both **BooksPage** and **AuthorDetailPage** grid views.

---

## style(ui): round selection checkboxes to circles (closes #75, #76)

`rounded` → `rounded-full` on the `@tailwindcss/forms`-styled checkboxes (table select-all, table per-row, grid card overlay) on **Authors**, **Books**, and **Wanted** pages.