### PR TITLE
feat(books): dual-format support — ebook + audiobook for the same book

### DIFF
--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -149,11 +149,13 @@ func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
 		book.Status = *req.Status
 	}
 	if req.MediaType != nil {
-		if *req.MediaType != models.MediaTypeEbook && *req.MediaType != models.MediaTypeAudiobook {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "mediaType must be 'ebook' or 'audiobook'"})
+		switch *req.MediaType {
+		case models.MediaTypeEbook, models.MediaTypeAudiobook, models.MediaTypeBoth:
+			book.MediaType = *req.MediaType
+		default:
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "mediaType must be 'ebook', 'audiobook', or 'both'"})
 			return
 		}
-		book.MediaType = *req.MediaType
 	}
 	if req.ASIN != nil {
 		book.ASIN = *req.ASIN
@@ -201,9 +203,19 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// before dropping the record, so the user doesn't have to delete the
 	// file separately after removing the book.
 	if r.URL.Query().Get("deleteFiles") == "true" {
-		if book, _ := h.books.GetByID(r.Context(), id); book != nil && book.FilePath != "" {
-			if err := removeBookPath(book.FilePath); err != nil {
-				slog.Warn("book delete: failed to remove files", "id", id, "path", book.FilePath, "error", err)
+		if book, _ := h.books.GetByID(r.Context(), id); book != nil {
+			for _, p := range []string{book.EbookFilePath, book.AudiobookFilePath} {
+				if p != "" {
+					if err := removeBookPath(p); err != nil {
+						slog.Warn("book delete: failed to remove files", "id", id, "path", p, "error", err)
+					}
+				}
+			}
+			// Fallback for books with only the legacy file_path set.
+			if book.EbookFilePath == "" && book.AudiobookFilePath == "" && book.FilePath != "" {
+				if err := removeBookPath(book.FilePath); err != nil {
+					slog.Warn("book delete: failed to remove files", "id", id, "path", book.FilePath, "error", err)
+				}
 			}
 		}
 	}
@@ -214,11 +226,13 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// DeleteFile removes the on-disk file or folder backing an imported book,
-// clears the stored file_path, and flips the status back to `wanted` so the
-// book re-appears on the Wanted page. The book record itself is kept. Used
-// to clean up bad grabs (wrong edition, corrupt files, mis-tagged metadata)
-// without losing the author/book association or its history.
+// DeleteFile removes the on-disk file or folder backing an imported book and
+// flips the book's status back to `wanted` so it re-appears on the Wanted page.
+//
+// For single-format books the file is always the one stored in file_path.
+// For dual-format books (media_type='both') an optional `?format=ebook` or
+// `?format=audiobook` query param scopes the deletion to one format; omitting
+// it (or passing any other value) deletes both.
 func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseID(w, r)
 	if !ok {
@@ -229,27 +243,64 @@ func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}
-	if book.FilePath == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "book has no file to delete"})
-		return
+
+	format := r.URL.Query().Get("format") // optional: "ebook" | "audiobook"
+	deleteEbook := (format == "" || format == models.MediaTypeEbook) && book.EbookFilePath != ""
+	deleteAudiobook := (format == "" || format == models.MediaTypeAudiobook) && book.AudiobookFilePath != ""
+
+	if !deleteEbook && !deleteAudiobook {
+		// Legacy fallback: check the old file_path for books migrated before
+		// the dual-format columns were added.
+		if book.FilePath == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "book has no file to delete"})
+			return
+		}
+		deleteEbook = true // treat legacy file_path as ebook
 	}
 
-	oldPath := book.FilePath
-	if err := removeBookPath(oldPath); err != nil {
-		slog.Error("failed to remove book path", "id", id, "path", oldPath, "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
+	var deletedPaths []string
+
+	if deleteEbook && book.EbookFilePath != "" {
+		if err := removeBookPath(book.EbookFilePath); err != nil {
+			slog.Error("failed to remove ebook path", "id", id, "path", book.EbookFilePath, "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		deletedPaths = append(deletedPaths, book.EbookFilePath)
+		book.EbookFilePath = ""
 	}
 
-	book.FilePath = ""
-	book.Status = models.BookStatusWanted
+	if deleteAudiobook && book.AudiobookFilePath != "" {
+		if err := removeBookPath(book.AudiobookFilePath); err != nil {
+			slog.Error("failed to remove audiobook path", "id", id, "path", book.AudiobookFilePath, "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		deletedPaths = append(deletedPaths, book.AudiobookFilePath)
+		book.AudiobookFilePath = ""
+	}
+
+	// Legacy file_path: clear when the corresponding per-format column is gone.
+	if book.EbookFilePath == "" && book.AudiobookFilePath == "" {
+		book.FilePath = ""
+	} else if book.EbookFilePath != "" {
+		book.FilePath = book.EbookFilePath
+	} else {
+		book.FilePath = book.AudiobookFilePath
+	}
+
+	// Status: back to wanted if any wanted format is now missing.
+	if book.NeedsEbook() || book.NeedsAudiobook() {
+		book.Status = models.BookStatusWanted
+	}
+
 	if err := h.books.Update(r.Context(), book); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
 
 	if h.history != nil {
-		data, _ := json.Marshal(map[string]string{"path": oldPath})
+		data, _ := json.Marshal(map[string]any{"paths": deletedPaths})
 		_ = h.history.Create(r.Context(), &models.HistoryEvent{
 			BookID:      &book.ID,
 			EventType:   models.HistoryEventBookFileDeleted,

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -21,7 +21,8 @@ func NewBookRepo(db *sql.DB) *BookRepo {
 const bookColumns = `id, foreign_id, author_id, title, sort_title, original_title, description,
 	image_url, release_date, genres, average_rating, ratings_count, monitored, status,
 	any_edition_ok, selected_edition_id, file_path, language, media_type, narrator, duration_seconds, asin,
-	calibre_id, metadata_provider, last_metadata_refresh_at, created_at, updated_at`
+	calibre_id, metadata_provider, last_metadata_refresh_at, created_at, updated_at,
+	ebook_file_path, audiobook_file_path`
 
 func (r *BookRepo) List(ctx context.Context) ([]models.Book, error) {
 	return r.query(ctx, "SELECT "+bookColumns+" FROM books ORDER BY sort_title", nil)
@@ -106,13 +107,15 @@ func (r *BookRepo) Update(ctx context.Context, b *models.Book) error {
 		                 release_date=?, genres=?, average_rating=?, ratings_count=?,
 		                 monitored=?, status=?, any_edition_ok=?, selected_edition_id=?,
 		                 file_path=?, language=?, media_type=?, narrator=?, duration_seconds=?, asin=?,
-		                 metadata_provider=?, last_metadata_refresh_at=?, updated_at=?
+		                 metadata_provider=?, last_metadata_refresh_at=?, updated_at=?,
+		                 ebook_file_path=?, audiobook_file_path=?
 		WHERE id=?`,
 		b.Title, b.SortTitle, b.OriginalTitle, b.Description, b.ImageURL,
 		b.ReleaseDate, string(genresJSON), b.AverageRating, b.RatingsCount,
 		b.Monitored, b.Status, b.AnyEditionOK, b.SelectedEditionID,
 		b.FilePath, b.Language, mediaType, b.Narrator, b.DurationSeconds, b.ASIN,
-		b.MetadataProvider, b.LastMetadataRefreshAt, now, b.ID)
+		b.MetadataProvider, b.LastMetadataRefreshAt, now,
+		b.EbookFilePath, b.AudiobookFilePath, b.ID)
 	if err != nil {
 		return fmt.Errorf("update book %d: %w", b.ID, err)
 	}
@@ -120,10 +123,54 @@ func (r *BookRepo) Update(ctx context.Context, b *models.Book) error {
 	return nil
 }
 
+// SetFormatFilePath records the on-disk path for a specific format ('ebook'
+// or 'audiobook') and recomputes the book's aggregate status:
+//   - status = 'imported' when all formats the book wants are now on disk.
+//   - status unchanged otherwise (typically 'wanted' or 'downloading').
+//
+// The legacy file_path column is kept in sync with the most-recently-set
+// format path for Calibre integration compatibility.
+func (r *BookRepo) SetFormatFilePath(ctx context.Context, id int64, mediaType, filePath string) error {
+	b, err := r.GetByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("SetFormatFilePath: load book %d: %w", id, err)
+	}
+	if b == nil {
+		return fmt.Errorf("SetFormatFilePath: book %d not found", id)
+	}
+
+	switch mediaType {
+	case models.MediaTypeAudiobook:
+		b.AudiobookFilePath = filePath
+	default: // 'ebook' or any legacy value
+		b.EbookFilePath = filePath
+	}
+	b.FilePath = filePath // keep legacy column in sync
+
+	if !b.NeedsEbook() && !b.NeedsAudiobook() {
+		b.Status = models.BookStatusImported
+	}
+
+	return r.Update(ctx, b)
+}
+
+// SetFilePath is a backward-compatible wrapper around SetFormatFilePath that
+// infers the format from the book's current media_type. Callers that know the
+// explicit format should use SetFormatFilePath directly.
 func (r *BookRepo) SetFilePath(ctx context.Context, id int64, filePath string) error {
-	_, err := r.db.ExecContext(ctx, "UPDATE books SET file_path=?, status=? WHERE id=?",
-		filePath, models.BookStatusImported, id)
-	return err
+	b, err := r.GetByID(ctx, id)
+	if err != nil || b == nil {
+		// Fall back to the legacy single-column update so existing code paths
+		// never break even if the book can't be loaded.
+		_, err2 := r.db.ExecContext(ctx, "UPDATE books SET file_path=?, status=? WHERE id=?",
+			filePath, models.BookStatusImported, id)
+		return err2
+	}
+	mediaType := b.MediaType
+	if mediaType == models.MediaTypeBoth {
+		mediaType = models.MediaTypeEbook // shouldn't happen; default to ebook
+	}
+	return r.SetFormatFilePath(ctx, id, mediaType, filePath)
 }
 
 // SetCalibreID stores the Calibre-assigned book id for the given Bindery
@@ -199,6 +246,7 @@ func (r *BookRepo) query(ctx context.Context, q string, args []any) ([]models.Bo
 			&b.Narrator, &b.DurationSeconds, &b.ASIN,
 			&b.CalibreID, &b.MetadataProvider, &b.LastMetadataRefreshAt,
 			&b.CreatedAt, &b.UpdatedAt,
+			&b.EbookFilePath, &b.AudiobookFilePath,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan book: %w", err)

--- a/internal/db/books_dual_format_test.go
+++ b/internal/db/books_dual_format_test.go
@@ -1,0 +1,198 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// openTestDB opens an in-memory database and seeds one author + one book
+// for use in dual-format tests. Returns the db, author, and book.
+func openTestDB(t *testing.T) (*sql.DB, *models.Author, *models.Book) {
+	t.Helper()
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	author := &models.Author{
+		ForeignID: "OL12345A",
+		Name:      "Test Author",
+		SortName:  "Author, Test",
+		Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatalf("create author: %v", err)
+	}
+
+	bookRepo := NewBookRepo(database)
+	book := &models.Book{
+		ForeignID: "OL99999W",
+		AuthorID:  author.ID,
+		Title:     "Test Book",
+		SortTitle: "Test Book",
+		Monitored: true,
+		Status:    models.BookStatusWanted,
+		MediaType: models.MediaTypeEbook,
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatalf("create book: %v", err)
+	}
+
+	t.Cleanup(func() { database.Close() })
+	return database, author, book
+}
+
+func TestSetFormatFilePath_Ebook(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	if err := repo.SetFormatFilePath(ctx, book.ID, models.MediaTypeEbook, "/lib/test.epub"); err != nil {
+		t.Fatalf("SetFormatFilePath: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, book.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.EbookFilePath != "/lib/test.epub" {
+		t.Errorf("EbookFilePath = %q, want /lib/test.epub", got.EbookFilePath)
+	}
+	if got.Status != models.BookStatusImported {
+		t.Errorf("Status = %q, want imported", got.Status)
+	}
+	// Legacy file_path should be in sync.
+	if got.FilePath != "/lib/test.epub" {
+		t.Errorf("FilePath = %q, want /lib/test.epub", got.FilePath)
+	}
+}
+
+func TestSetFormatFilePath_Audiobook(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	// Change the book to audiobook first.
+	book.MediaType = models.MediaTypeAudiobook
+	if err := repo.Update(ctx, book); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if err := repo.SetFormatFilePath(ctx, book.ID, models.MediaTypeAudiobook, "/ab/test"); err != nil {
+		t.Fatalf("SetFormatFilePath: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, book.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.AudiobookFilePath != "/ab/test" {
+		t.Errorf("AudiobookFilePath = %q, want /ab/test", got.AudiobookFilePath)
+	}
+	if got.Status != models.BookStatusImported {
+		t.Errorf("Status = %q, want imported", got.Status)
+	}
+}
+
+// TestSetFormatFilePath_BothPartial verifies that a 'both' book stays in
+// 'wanted' status when only one format has been imported.
+func TestSetFormatFilePath_BothPartial(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	book.MediaType = models.MediaTypeBoth
+	if err := repo.Update(ctx, book); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Import the ebook only.
+	if err := repo.SetFormatFilePath(ctx, book.ID, models.MediaTypeEbook, "/lib/test.epub"); err != nil {
+		t.Fatalf("SetFormatFilePath ebook: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, book.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.EbookFilePath != "/lib/test.epub" {
+		t.Errorf("EbookFilePath = %q, want /lib/test.epub", got.EbookFilePath)
+	}
+	if got.AudiobookFilePath != "" {
+		t.Errorf("AudiobookFilePath should be empty, got %q", got.AudiobookFilePath)
+	}
+	// Still waiting for the audiobook — must stay wanted.
+	if got.Status == models.BookStatusImported {
+		t.Errorf("Status must not be 'imported' until both formats are on disk, got %q", got.Status)
+	}
+}
+
+// TestSetFormatFilePath_BothComplete verifies that a 'both' book flips to
+// 'imported' only after both formats are on disk.
+func TestSetFormatFilePath_BothComplete(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	book.MediaType = models.MediaTypeBoth
+	if err := repo.Update(ctx, book); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if err := repo.SetFormatFilePath(ctx, book.ID, models.MediaTypeEbook, "/lib/test.epub"); err != nil {
+		t.Fatalf("SetFormatFilePath ebook: %v", err)
+	}
+	if err := repo.SetFormatFilePath(ctx, book.ID, models.MediaTypeAudiobook, "/ab/test"); err != nil {
+		t.Fatalf("SetFormatFilePath audiobook: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, book.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Status != models.BookStatusImported {
+		t.Errorf("Status = %q, want imported after both formats set", got.Status)
+	}
+	if got.EbookFilePath != "/lib/test.epub" {
+		t.Errorf("EbookFilePath = %q", got.EbookFilePath)
+	}
+	if got.AudiobookFilePath != "/ab/test" {
+		t.Errorf("AudiobookFilePath = %q", got.AudiobookFilePath)
+	}
+}
+
+// TestListByStatus_BothPartial verifies that a 'both' book in the partially-
+// satisfied state is still returned by ListByStatus("wanted").
+func TestListByStatus_BothPartial(t *testing.T) {
+	database, _, book := openTestDB(t)
+	ctx := context.Background()
+	repo := NewBookRepo(database)
+
+	book.MediaType = models.MediaTypeBoth
+	if err := repo.Update(ctx, book); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	// Import only ebook — audiobook still needed.
+	if err := repo.SetFormatFilePath(ctx, book.ID, models.MediaTypeEbook, "/lib/test.epub"); err != nil {
+		t.Fatalf("SetFormatFilePath: %v", err)
+	}
+
+	wanted, err := repo.ListByStatus(ctx, models.BookStatusWanted)
+	if err != nil {
+		t.Fatalf("ListByStatus: %v", err)
+	}
+	found := false
+	for _, b := range wanted {
+		if b.ID == book.ID {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("partially-satisfied 'both' book should still appear on the wanted list")
+	}
+}

--- a/internal/db/migrations/012_dual_format.sql
+++ b/internal/db/migrations/012_dual_format.sql
@@ -1,0 +1,16 @@
+-- +migrate Up
+
+-- Per-format file paths for dual-format support (issue #23).
+-- A book with media_type='both' tracks an ebook and an audiobook independently.
+-- The existing file_path column is kept in sync for backward compatibility.
+ALTER TABLE books ADD COLUMN ebook_file_path TEXT NOT NULL DEFAULT '';
+ALTER TABLE books ADD COLUMN audiobook_file_path TEXT NOT NULL DEFAULT '';
+
+-- Seed per-format columns from existing data so upgrades are seamless.
+UPDATE books
+SET ebook_file_path     = CASE WHEN media_type = 'ebook'     THEN file_path ELSE '' END,
+    audiobook_file_path = CASE WHEN media_type = 'audiobook' THEN file_path ELSE '' END;
+
+-- +migrate Down
+-- SQLite cannot drop columns without a full table rebuild; leave them in
+-- place on rollback to avoid data loss.

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -276,18 +276,31 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 		}
 	}
 
+	// Detect the format of the downloaded files from their extensions.
+	// This is authoritative for dual-format books (media_type='both') and
+	// also fixes edge-cases where a mislabelled book would be routed to the
+	// wrong library directory.
+	detectedFormat := detectDownloadFormat(bookFiles)
+
 	// Audiobook path: move the entire download directory as a unit so
 	// multi-part m4b/mp3 files, cover art, and cue sheets stay together.
-	if book != nil && book.MediaType == models.MediaTypeAudiobook {
+	if detectedFormat == models.MediaTypeAudiobook {
 		destDir := UniqueDir(s.renamer.AudiobookDestDir(s.audiobookDir, author, book))
 		slog.Info("importing audiobook folder", "src", downloadPath, "dst", destDir)
 		if err := MoveDir(downloadPath, destDir); err != nil {
 			slog.Error("failed to import audiobook folder", "src", downloadPath, "error", err)
 			return
 		}
-		s.books.SetFilePath(ctx, book.ID, destDir)
+		if book != nil {
+			s.books.SetFormatFilePath(ctx, book.ID, models.MediaTypeAudiobook, destDir)
+		}
 		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusImported)
-		slog.Info("audiobook imported", "title", book.Title, "path", destDir)
+		slog.Info("audiobook imported", "title", func() string {
+			if book != nil {
+				return book.Title
+			}
+			return dl.Title
+		}(), "path", destDir)
 
 		s.pushToCalibre(ctx, book, author, destDir)
 
@@ -322,7 +335,7 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 		imported++
 
 		// Update book status and file path
-		s.books.SetFilePath(ctx, book.ID, destPath)
+		s.books.SetFormatFilePath(ctx, book.ID, models.MediaTypeEbook, destPath)
 		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusImported)
 		slog.Info("book imported", "title", book.Title, "path", destPath)
 
@@ -360,6 +373,20 @@ func (s *Scanner) clearSABHistory(ctx context.Context, sab *sabnzbd.Client, nzoI
 	if err := sab.DeleteHistory(ctx, nzoID, false); err != nil {
 		slog.Warn("failed to delete SABnzbd history entry", "nzoID", nzoID, "error", err)
 	}
+}
+
+// detectDownloadFormat inspects a list of file paths and returns the media
+// type inferred from their extensions. Any audio extension tips the result to
+// audiobook; a list of only ebook files returns ebook. An empty list returns
+// ebook as a safe default.
+func detectDownloadFormat(files []string) string {
+	for _, f := range files {
+		switch strings.ToLower(filepath.Ext(f)) {
+		case ".mp3", ".m4b", ".m4a", ".aac", ".flac", ".ogg", ".opus":
+			return models.MediaTypeAudiobook
+		}
+	}
+	return models.MediaTypeEbook
 }
 
 // FindExisting searches the library directory for a book file that matches
@@ -557,12 +584,13 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		// Search existing books for a title + author match
 		matched := false
 		if parsed.Title != "" {
+			detectedFmt := detectDownloadFormat([]string{path})
 			for _, b := range allBooks {
 				if b.Status == models.BookStatusWanted &&
 					titleMatch(b.Title, parsed.Title) &&
 					authorMatch(authorNames[b.AuthorID], parsed.Author) {
-					// Match found — update file path and status
-					if err := s.books.SetFilePath(ctx, b.ID, path); err != nil {
+					// Match found — update the per-format file path and aggregate status.
+					if err := s.books.SetFormatFilePath(ctx, b.ID, detectedFmt, path); err != nil {
 						slog.Error("library scan: failed to update book", "id", b.ID, "error", err)
 						continue
 					}

--- a/internal/importer/scanner_dual_format_test.go
+++ b/internal/importer/scanner_dual_format_test.go
@@ -1,0 +1,63 @@
+package importer
+
+import (
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestDetectDownloadFormat_Ebook(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []string
+	}{
+		{"epub only", []string{"/dl/book.epub"}},
+		{"mobi only", []string{"/dl/book.mobi"}},
+		{"azw3 only", []string{"/dl/book.azw3"}},
+		{"pdf only", []string{"/dl/book.pdf"}},
+		{"multiple ebooks", []string{"/dl/a.epub", "/dl/b.mobi"}},
+		{"empty list", []string{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := detectDownloadFormat(c.files)
+			if got != models.MediaTypeEbook {
+				t.Errorf("detectDownloadFormat(%v) = %q, want %q", c.files, got, models.MediaTypeEbook)
+			}
+		})
+	}
+}
+
+func TestDetectDownloadFormat_Audiobook(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []string
+	}{
+		{"m4b only", []string{"/dl/book.m4b"}},
+		{"mp3 only", []string{"/dl/chapter01.mp3"}},
+		{"m4a only", []string{"/dl/book.m4a"}},
+		{"flac only", []string{"/dl/book.flac"}},
+		{"opus only", []string{"/dl/book.opus"}},
+		{"mixed: audio wins", []string{"/dl/book.epub", "/dl/book.m4b"}},
+		{"mp3 chapters + cover", []string{"/dl/ch1.mp3", "/dl/ch2.mp3", "/dl/cover.jpg"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := detectDownloadFormat(c.files)
+			if got != models.MediaTypeAudiobook {
+				t.Errorf("detectDownloadFormat(%v) = %q, want %q", c.files, got, models.MediaTypeAudiobook)
+			}
+		})
+	}
+}
+
+// TestDetectDownloadFormat_CaseInsensitive checks that uppercase extensions are
+// treated the same as lowercase.
+func TestDetectDownloadFormat_CaseInsensitive(t *testing.T) {
+	if got := detectDownloadFormat([]string{"/dl/BOOK.M4B"}); got != models.MediaTypeAudiobook {
+		t.Errorf("expected audiobook for .M4B, got %q", got)
+	}
+	if got := detectDownloadFormat([]string{"/dl/BOOK.EPUB"}); got != models.MediaTypeEbook {
+		t.Errorf("expected ebook for .EPUB, got %q", got)
+	}
+}

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -41,6 +41,11 @@ type Book struct {
 	CreatedAt             time.Time  `json:"createdAt"`
 	UpdatedAt             time.Time  `json:"updatedAt"`
 
+	// Per-format file paths for dual-format support (media_type = 'both').
+	// Single-format books populate only the relevant column; the other stays "".
+	EbookFilePath     string `json:"ebookFilePath"`
+	AudiobookFilePath string `json:"audiobookFilePath"`
+
 	// Joined data
 	Author   *Author   `json:"author,omitempty"`
 	Editions []Edition `json:"editions,omitempty"`
@@ -48,6 +53,26 @@ type Book struct {
 	// Transport-only: series data from the metadata provider, used during
 	// ingestion to populate series/series_books. Never stored in books table.
 	SeriesRefs []SeriesRef `json:"-"`
+}
+
+// WantsEbook reports whether the ebook format is monitored for this book.
+func (b *Book) WantsEbook() bool {
+	return b.MediaType == MediaTypeEbook || b.MediaType == MediaTypeBoth
+}
+
+// WantsAudiobook reports whether the audiobook format is monitored for this book.
+func (b *Book) WantsAudiobook() bool {
+	return b.MediaType == MediaTypeAudiobook || b.MediaType == MediaTypeBoth
+}
+
+// NeedsEbook reports whether the ebook format is monitored but not yet on disk.
+func (b *Book) NeedsEbook() bool {
+	return b.WantsEbook() && b.EbookFilePath == ""
+}
+
+// NeedsAudiobook reports whether the audiobook format is monitored but not yet on disk.
+func (b *Book) NeedsAudiobook() bool {
+	return b.WantsAudiobook() && b.AudiobookFilePath == ""
 }
 
 const (
@@ -64,4 +89,8 @@ const (
 const (
 	MediaTypeEbook     = "ebook"
 	MediaTypeAudiobook = "audiobook"
+	// MediaTypeBoth requests both an ebook and an audiobook for the same
+	// work. The search and import pipelines handle each format independently;
+	// the book's aggregate status flips to "imported" only when both are on disk.
+	MediaTypeBoth = "both"
 )

--- a/internal/models/book_test.go
+++ b/internal/models/book_test.go
@@ -1,0 +1,97 @@
+package models
+
+import "testing"
+
+func TestBookWantsEbook(t *testing.T) {
+	cases := []struct {
+		mt   string
+		want bool
+	}{
+		{MediaTypeEbook, true},
+		{MediaTypeBoth, true},
+		{MediaTypeAudiobook, false},
+		{"", false},
+	}
+	for _, c := range cases {
+		b := &Book{MediaType: c.mt}
+		if got := b.WantsEbook(); got != c.want {
+			t.Errorf("WantsEbook(%q) = %v, want %v", c.mt, got, c.want)
+		}
+	}
+}
+
+func TestBookWantsAudiobook(t *testing.T) {
+	cases := []struct {
+		mt   string
+		want bool
+	}{
+		{MediaTypeAudiobook, true},
+		{MediaTypeBoth, true},
+		{MediaTypeEbook, false},
+		{"", false},
+	}
+	for _, c := range cases {
+		b := &Book{MediaType: c.mt}
+		if got := b.WantsAudiobook(); got != c.want {
+			t.Errorf("WantsAudiobook(%q) = %v, want %v", c.mt, got, c.want)
+		}
+	}
+}
+
+func TestBookNeedsEbook(t *testing.T) {
+	cases := []struct {
+		mt            string
+		ebookFilePath string
+		want          bool
+	}{
+		{MediaTypeEbook, "", true},           // wanted, no file → needed
+		{MediaTypeEbook, "/lib/book.epub", false}, // wanted, has file → satisfied
+		{MediaTypeBoth, "", true},            // both wanted, no ebook → needed
+		{MediaTypeBoth, "/lib/book.epub", false}, // both wanted, ebook present
+		{MediaTypeAudiobook, "", false},      // not watching ebook → not needed
+	}
+	for _, c := range cases {
+		b := &Book{MediaType: c.mt, EbookFilePath: c.ebookFilePath}
+		if got := b.NeedsEbook(); got != c.want {
+			t.Errorf("NeedsEbook(mt=%q, ebookPath=%q) = %v, want %v",
+				c.mt, c.ebookFilePath, got, c.want)
+		}
+	}
+}
+
+func TestBookNeedsAudiobook(t *testing.T) {
+	cases := []struct {
+		mt                string
+		audiobookFilePath string
+		want              bool
+	}{
+		{MediaTypeAudiobook, "", true},
+		{MediaTypeAudiobook, "/ab/book", false},
+		{MediaTypeBoth, "", true},
+		{MediaTypeBoth, "/ab/book", false},
+		{MediaTypeEbook, "", false},
+	}
+	for _, c := range cases {
+		b := &Book{MediaType: c.mt, AudiobookFilePath: c.audiobookFilePath}
+		if got := b.NeedsAudiobook(); got != c.want {
+			t.Errorf("NeedsAudiobook(mt=%q, abPath=%q) = %v, want %v",
+				c.mt, c.audiobookFilePath, got, c.want)
+		}
+	}
+}
+
+// TestBothFullySatisfied checks that a 'both' book with both file paths
+// reports no further needs.
+func TestBothFullySatisfied(t *testing.T) {
+	b := &Book{
+		MediaType:         MediaTypeBoth,
+		EbookFilePath:     "/lib/book.epub",
+		AudiobookFilePath: "/ab/book",
+	}
+	if b.NeedsEbook() {
+		t.Error("NeedsEbook should be false when EbookFilePath is set")
+	}
+	if b.NeedsAudiobook() {
+		t.Error("NeedsAudiobook should be false when AudiobookFilePath is set")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -26,11 +26,18 @@ type CalibreSyncer interface {
 	RunSync(ctx context.Context)
 }
 
+// bookSearcher is the narrow interface the scheduler uses for indexer
+// searches. *indexer.Searcher satisfies it; the interface keeps the scheduler
+// testable without real network calls.
+type bookSearcher interface {
+	SearchBook(ctx context.Context, indexers []models.Indexer, c indexer.MatchCriteria) []newznab.SearchResult
+}
+
 // Scheduler runs background jobs on configurable intervals.
 type Scheduler struct {
 	cron     *cron.Cron
 	scanner  *importer.Scanner
-	searcher *indexer.Searcher
+	searcher bookSearcher
 	meta     *metadata.Aggregator
 
 	authors       *db.AuthorRepo
@@ -125,30 +132,50 @@ func (s *Scheduler) Stop() {
 	slog.Info("scheduler stopped")
 }
 
-// SearchAndGrabBook performs an immediate indexer search for a single wanted
-// book and auto-grabs the top result. It is the same logic the 12-hour
-// wanted-scan uses, promoted so on-add and status-transition hooks can trigger
-// a search without waiting for the next scheduled run.
+// SearchAndGrabBook performs an immediate indexer search for a wanted book and
+// auto-grabs the top result. For dual-format books (media_type='both') it fires
+// independent searches for whichever formats still lack a file on disk.
+// It is the same logic the 12-hour wanted-scan uses, promoted so on-add and
+// status-transition hooks can trigger a search without waiting for the next run.
 func (s *Scheduler) SearchAndGrabBook(ctx context.Context, book models.Book) {
-	idxs, err := s.indexers.List(ctx)
-	if err != nil {
-		slog.Error("SearchAndGrabBook: failed to list indexers", "error", err)
-		return
+	if book.NeedsEbook() {
+		s.searchAndGrabFormat(ctx, book, models.MediaTypeEbook)
+	}
+	if book.NeedsAudiobook() {
+		s.searchAndGrabFormat(ctx, book, models.MediaTypeAudiobook)
+	}
+}
+
+// searchAndGrabFormat searches for and grabs a specific format of a book.
+// mediaType must be MediaTypeEbook or MediaTypeAudiobook.
+func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, mediaType string) {
+	var idxs []models.Indexer
+	if s.indexers != nil {
+		var err error
+		idxs, err = s.indexers.List(ctx)
+		if err != nil {
+			slog.Error("SearchAndGrabBook: failed to list indexers", "error", err)
+			return
+		}
 	}
 
 	lang := "en"
-	if langSetting, _ := s.settings.Get(ctx, "search.preferredLanguage"); langSetting != nil {
-		lang = langSetting.Value
+	if s.settings != nil {
+		if langSetting, _ := s.settings.Get(ctx, "search.preferredLanguage"); langSetting != nil {
+			lang = langSetting.Value
+		}
 	}
 
 	authorName := ""
-	if a, _ := s.authors.GetByID(ctx, book.AuthorID); a != nil {
-		authorName = a.Name
+	if s.authors != nil {
+		if a, _ := s.authors.GetByID(ctx, book.AuthorID); a != nil {
+			authorName = a.Name
+		}
 	}
 	crit := indexer.MatchCriteria{
 		Title:     book.Title,
 		Author:    authorName,
-		MediaType: book.MediaType,
+		MediaType: mediaType,
 		ASIN:      book.ASIN,
 	}
 	if book.ReleaseDate != nil {
@@ -165,7 +192,7 @@ func (s *Scheduler) SearchAndGrabBook(ctx context.Context, book models.Book) {
 	best := results[0]
 
 	candidates, _ := s.clients.GetEnabledByProtocol(ctx, best.Protocol)
-	client := db.PickClientForMediaType(candidates, book.MediaType)
+	client := db.PickClientForMediaType(candidates, mediaType)
 	if client == nil {
 		client, _ = s.clients.GetFirstEnabled(ctx)
 	}
@@ -177,6 +204,7 @@ func (s *Scheduler) SearchAndGrabBook(ctx context.Context, book models.Book) {
 	slog.Info("auto-grabbing book",
 		"book", book.Title,
 		"author", authorName,
+		"format", mediaType,
 		"result", best.Title,
 		"indexer", best.IndexerName,
 		"protocol", best.Protocol,

--- a/internal/scheduler/scheduler_dual_format_test.go
+++ b/internal/scheduler/scheduler_dual_format_test.go
@@ -1,0 +1,155 @@
+package scheduler
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/indexer"
+	"github.com/vavallee/bindery/internal/indexer/newznab"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// stubSearcher records how many times SearchBook is called and with which
+// media types, without touching any network.
+type stubSearcher struct {
+	calls     atomic.Int32
+	mediaTypes []string
+}
+
+func (s *stubSearcher) SearchBook(_ context.Context, _ []models.Indexer, c indexer.MatchCriteria) []newznab.SearchResult {
+	s.calls.Add(1)
+	s.mediaTypes = append(s.mediaTypes, c.MediaType)
+	return nil // no results → grab nothing, but the search was counted
+}
+
+func (s *stubSearcher) SearchAndGrabBook(_ context.Context, _ models.Book) {}
+
+// TestSearchAndGrabBook_EbookOnly verifies that a single-format ebook book
+// fires exactly one search with mediaType='ebook'.
+func TestSearchAndGrabBook_EbookOnly(t *testing.T) {
+	ss := &stubSearcher{}
+	sched := &Scheduler{
+		searcher:  ss,
+		indexers:  nil, // stubSearcher ignores this
+		downloads: nil,
+		clients:   nil,
+		settings:  nil,
+		blocklist: nil,
+		authors:   nil,
+	}
+
+	book := models.Book{
+		Title:     "Ender's Game",
+		MediaType: models.MediaTypeEbook,
+		// EbookFilePath is empty → NeedsEbook() = true
+	}
+
+	sched.SearchAndGrabBook(context.Background(), book)
+
+	if n := int(ss.calls.Load()); n != 1 {
+		t.Errorf("expected 1 search call for ebook-only book, got %d", n)
+	}
+	if len(ss.mediaTypes) > 0 && ss.mediaTypes[0] != models.MediaTypeEbook {
+		t.Errorf("expected mediaType=%q, got %q", models.MediaTypeEbook, ss.mediaTypes[0])
+	}
+}
+
+// TestSearchAndGrabBook_AudiobookOnly verifies a single-format audiobook.
+func TestSearchAndGrabBook_AudiobookOnly(t *testing.T) {
+	ss := &stubSearcher{}
+	sched := &Scheduler{searcher: ss}
+
+	book := models.Book{
+		Title:     "Project Hail Mary",
+		MediaType: models.MediaTypeAudiobook,
+		// AudiobookFilePath empty → NeedsAudiobook() = true
+	}
+
+	sched.SearchAndGrabBook(context.Background(), book)
+
+	if n := int(ss.calls.Load()); n != 1 {
+		t.Errorf("expected 1 search call for audiobook-only book, got %d", n)
+	}
+	if len(ss.mediaTypes) > 0 && ss.mediaTypes[0] != models.MediaTypeAudiobook {
+		t.Errorf("expected mediaType=%q, got %q", models.MediaTypeAudiobook, ss.mediaTypes[0])
+	}
+}
+
+// TestSearchAndGrabBook_Both_BothMissing verifies that a 'both' book with
+// neither format on disk fires two independent searches.
+func TestSearchAndGrabBook_Both_BothMissing(t *testing.T) {
+	ss := &stubSearcher{}
+	sched := &Scheduler{searcher: ss}
+
+	book := models.Book{
+		Title:     "The Martian",
+		MediaType: models.MediaTypeBoth,
+		// Both EbookFilePath and AudiobookFilePath are empty.
+	}
+
+	sched.SearchAndGrabBook(context.Background(), book)
+
+	if n := int(ss.calls.Load()); n != 2 {
+		t.Errorf("expected 2 search calls for 'both' book, got %d", n)
+	}
+	sawEbook, sawAudiobook := false, false
+	for _, mt := range ss.mediaTypes {
+		switch mt {
+		case models.MediaTypeEbook:
+			sawEbook = true
+		case models.MediaTypeAudiobook:
+			sawAudiobook = true
+		}
+	}
+	if !sawEbook {
+		t.Error("expected a search with mediaType='ebook'")
+	}
+	if !sawAudiobook {
+		t.Error("expected a search with mediaType='audiobook'")
+	}
+}
+
+// TestSearchAndGrabBook_Both_EbookAlreadyImported verifies that when one
+// format is already on disk, only the missing format is searched.
+func TestSearchAndGrabBook_Both_EbookAlreadyImported(t *testing.T) {
+	ss := &stubSearcher{}
+	sched := &Scheduler{searcher: ss}
+
+	book := models.Book{
+		Title:             "Dune",
+		MediaType:         models.MediaTypeBoth,
+		EbookFilePath:     "/lib/dune.epub", // already on disk
+		AudiobookFilePath: "",               // still needed
+	}
+
+	sched.SearchAndGrabBook(context.Background(), book)
+
+	if n := int(ss.calls.Load()); n != 1 {
+		t.Errorf("expected 1 search call (audiobook only), got %d", n)
+	}
+	if len(ss.mediaTypes) > 0 && ss.mediaTypes[0] != models.MediaTypeAudiobook {
+		t.Errorf("expected mediaType=%q for remaining search, got %q",
+			models.MediaTypeAudiobook, ss.mediaTypes[0])
+	}
+}
+
+// TestSearchAndGrabBook_Both_FullySatisfied verifies that no searches are
+// fired when both formats are already on disk.
+func TestSearchAndGrabBook_Both_FullySatisfied(t *testing.T) {
+	ss := &stubSearcher{}
+	sched := &Scheduler{searcher: ss}
+
+	book := models.Book{
+		Title:             "Foundation",
+		MediaType:         models.MediaTypeBoth,
+		EbookFilePath:     "/lib/foundation.epub",
+		AudiobookFilePath: "/ab/foundation",
+	}
+
+	sched.SearchAndGrabBook(context.Background(), book)
+
+	if n := int(ss.calls.Load()); n != 0 {
+		t.Errorf("expected 0 search calls when fully satisfied, got %d", n)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -102,7 +102,7 @@ export const api = {
   updateBook: (id: number, data: Partial<Book>) => request<Book>(`/book/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   deleteBook: (id: number, deleteFiles = false) =>
     request<void>(`/book/${id}${deleteFiles ? '?deleteFiles=true' : ''}`, { method: 'DELETE' }),
-  deleteBookFile: (id: number) => request<Book>(`/book/${id}/file`, { method: 'DELETE' }),
+  deleteBookFile: (id: number, queryParams = '') => request<Book>(`/book/${id}/file${queryParams}`, { method: 'DELETE' }),
   searchBook: (id: number) => request<SearchResult[]>(`/book/${id}/search`, { method: 'POST' }),
   enrichAudiobook: (id: number) => request<Book>(`/book/${id}/enrich-audiobook`, { method: 'POST' }),
 
@@ -112,7 +112,7 @@ export const api = {
   // Bulk actions
   bulkActionAuthors: (ids: number[], action: AuthorBulkAction) =>
     request<BulkResult>('/author/bulk', { method: 'POST', body: JSON.stringify({ ids, action }) }),
-  bulkActionBooks: (ids: number[], action: BookBulkAction, mediaType?: 'ebook' | 'audiobook') =>
+  bulkActionBooks: (ids: number[], action: BookBulkAction, mediaType?: MediaType) =>
     request<BulkResult>('/book/bulk', { method: 'POST', body: JSON.stringify({ ids, action, ...(mediaType ? { mediaType } : {}) }) }),
   bulkActionWanted: (ids: number[], action: WantedBulkAction) =>
     request<BulkResult>('/wanted/bulk', { method: 'POST', body: JSON.stringify({ ids, action }) }),
@@ -242,7 +242,7 @@ export interface MergeAuthorsResult {
   TargetUpdated: boolean
 }
 
-export type MediaType = 'ebook' | 'audiobook'
+export type MediaType = 'ebook' | 'audiobook' | 'both'
 
 export interface Book {
   id: number
@@ -257,6 +257,9 @@ export interface Book {
   status: string
   filePath: string
   mediaType: MediaType
+  // Per-format file paths for dual-format books (mediaType='both').
+  ebookFilePath: string
+  audiobookFilePath: string
   narrator?: string
   durationSeconds?: number
   asin?: string

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -111,14 +111,29 @@ export default function BookDetailPage() {
     }
   }
 
-  const deleteFile = async () => {
-    if (!book || !book.filePath) return
-    const label = book.mediaType === 'audiobook' ? 'the audiobook folder' : 'this file'
-    if (!window.confirm(`Permanently delete ${label} from disk?\n\n${book.filePath}\n\nThe book record stays; it will flip back to "wanted".`)) return
+  const deleteFile = async (format?: 'ebook' | 'audiobook') => {
+    if (!book) return
+    const hasEbook = !!book.ebookFilePath
+    const hasAudiobook = !!book.audiobookFilePath
+    const hasLegacy = !!book.filePath && !hasEbook && !hasAudiobook
+    if (!hasEbook && !hasAudiobook && !hasLegacy) return
+
+    let label: string
+    let path: string
+    if (format === 'ebook' && hasEbook) {
+      label = 'the ebook file'; path = book.ebookFilePath
+    } else if (format === 'audiobook' && hasAudiobook) {
+      label = 'the audiobook folder'; path = book.audiobookFilePath
+    } else {
+      label = book.mediaType === 'audiobook' ? 'the audiobook folder' : 'this file'
+      path = book.filePath
+    }
+    if (!window.confirm(`Permanently delete ${label} from disk?\n\n${path}\n\nThe book record stays; it will flip back to "wanted".`)) return
     setDeletingFile(true)
     setError(null)
     try {
-      const updated = await api.deleteBookFile(book.id)
+      const params = format ? `?format=${format}` : ''
+      const updated = await api.deleteBookFile(book.id, params)
       setBook(updated)
       const h = await api.listHistory({ bookId: book.id }).catch(() => events)
       setEvents(h)
@@ -131,9 +146,10 @@ export default function BookDetailPage() {
 
   const deleteBook = async () => {
     if (!book) return
-    const hasFiles = !!book.filePath
+    const hasFiles = !!(book.filePath || book.ebookFilePath || book.audiobookFilePath)
+    const fileSummary = [book.ebookFilePath, book.audiobookFilePath].filter(Boolean).join('\n') || book.filePath
     const msg = hasFiles
-      ? `Delete "${book.title}" AND its files on disk?\n\n${book.filePath}\n\nThis cannot be undone.`
+      ? `Delete "${book.title}" AND its files on disk?\n\n${fileSummary}\n\nThis cannot be undone.`
       : `Delete "${book.title}"?\n\nThis cannot be undone.`
     if (!window.confirm(msg)) return
     setDeletingBook(true)
@@ -165,7 +181,7 @@ export default function BookDetailPage() {
   if (!book) return <div className="text-slate-600 dark:text-zinc-500">Book not found</div>
 
   const mt = book.mediaType || 'ebook'
-  const typeBtn = (type: 'ebook' | 'audiobook') =>
+  const typeBtn = (type: 'ebook' | 'audiobook' | 'both') =>
     `px-3 py-1.5 rounded text-sm font-medium transition-colors ${
       mt === type
         ? 'bg-emerald-600 text-white'
@@ -217,34 +233,46 @@ export default function BookDetailPage() {
           {book.description && (
             <p className="mt-4 text-sm text-slate-700 dark:text-zinc-300 leading-relaxed">{book.description}</p>
           )}
-          {book.filePath && (
+          {mt === 'both' ? (
+            <div className="mt-3 space-y-1.5 text-sm">
+              {book.ebookFilePath && (
+                <div className="flex items-center gap-3">
+                  <span className="text-xs text-slate-500 dark:text-zinc-500 break-all flex-1">📖 {book.ebookFilePath}</span>
+                  <button onClick={() => deleteFile('ebook')} disabled={deletingFile || deletingBook}
+                    className="text-red-500 hover:text-red-400 disabled:opacity-40 text-xs flex-shrink-0">Delete ebook</button>
+                </div>
+              )}
+              {book.audiobookFilePath && (
+                <div className="flex items-center gap-3">
+                  <span className="text-xs text-slate-500 dark:text-zinc-500 break-all flex-1">🎧 {book.audiobookFilePath}</span>
+                  <button onClick={() => deleteFile('audiobook')} disabled={deletingFile || deletingBook}
+                    className="text-red-500 hover:text-red-400 disabled:opacity-40 text-xs flex-shrink-0">Delete audiobook</button>
+                </div>
+              )}
+            </div>
+          ) : book.filePath ? (
             <div className="mt-3 flex items-center gap-4 text-sm">
-              <a
-                href={`/api/v1/book/${book.id}/file`}
-                className="text-emerald-500 hover:text-emerald-400"
-              >
+              <a href={`/api/v1/book/${book.id}/file`} className="text-emerald-500 hover:text-emerald-400">
                 Download file
               </a>
               <button
-                onClick={deleteFile}
+                onClick={() => deleteFile()}
                 disabled={deletingFile || deletingBook}
                 className="text-red-500 hover:text-red-400 disabled:opacity-40"
                 title={`Remove ${book.mediaType === 'audiobook' ? 'folder' : 'file'} from disk; keep the book record`}
               >
                 {deletingFile ? 'Deleting…' : 'Delete file'}
               </button>
+              <span className="text-xs text-slate-500 dark:text-zinc-500 break-all">{book.filePath}</span>
             </div>
-          )}
-          <div className="mt-3 text-xs text-slate-500 dark:text-zinc-500 break-all">
-            {book.filePath}
-          </div>
+          ) : null}
           <div className="mt-3">
             <button
               onClick={deleteBook}
               disabled={deletingBook || deletingFile}
               className="text-xs text-red-600 dark:text-red-500 hover:text-red-500 dark:hover:text-red-400 disabled:opacity-40"
             >
-              {deletingBook ? 'Deleting book…' : book.filePath ? 'Delete book + files' : 'Delete book'}
+              {deletingBook ? 'Deleting book…' : (book.filePath || book.ebookFilePath || book.audiobookFilePath) ? 'Delete book + files' : 'Delete book'}
             </button>
           </div>
         </div>
@@ -261,9 +289,23 @@ export default function BookDetailPage() {
         <div className="flex gap-2 mb-4">
           <button onClick={() => saveField({ mediaType: 'ebook' })} disabled={saving} className={typeBtn('ebook')}>📖 Ebook</button>
           <button onClick={() => saveField({ mediaType: 'audiobook' })} disabled={saving} className={typeBtn('audiobook')}>🎧 Audiobook</button>
+          <button onClick={() => saveField({ mediaType: 'both' })} disabled={saving} className={typeBtn('both')}>📖🎧 Both</button>
         </div>
 
-        {mt === 'audiobook' && (
+        {mt === 'both' && (
+          <div className="mb-4 grid grid-cols-2 gap-2 text-xs">
+            <div className={`px-3 py-2 rounded border ${book.ebookFilePath ? 'border-emerald-500/50 bg-emerald-500/5 text-emerald-700 dark:text-emerald-400' : 'border-slate-200 dark:border-zinc-700 text-slate-500 dark:text-zinc-500'}`}>
+              <span className="font-medium">📖 Ebook</span>
+              <span className="ml-2">{book.ebookFilePath ? '✓ on disk' : 'needed'}</span>
+            </div>
+            <div className={`px-3 py-2 rounded border ${book.audiobookFilePath ? 'border-emerald-500/50 bg-emerald-500/5 text-emerald-700 dark:text-emerald-400' : 'border-slate-200 dark:border-zinc-700 text-slate-500 dark:text-zinc-500'}`}>
+              <span className="font-medium">🎧 Audiobook</span>
+              <span className="ml-2">{book.audiobookFilePath ? '✓ on disk' : 'needed'}</span>
+            </div>
+          </div>
+        )}
+
+        {(mt === 'audiobook' || mt === 'both') && (
           <div className="flex items-end gap-2 mb-4">
             <div className="flex-1">
               <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">ASIN (Audible identifier)</label>
@@ -297,7 +339,13 @@ export default function BookDetailPage() {
           disabled={searching}
           className="w-full sm:w-auto px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded text-sm font-medium"
         >
-          {searching ? 'Searching all indexers…' : `Search ${mt === 'audiobook' ? 'audiobook' : 'ebook'} indexers`}
+          {searching
+            ? 'Searching all indexers…'
+            : mt === 'audiobook'
+              ? 'Search audiobook indexers'
+              : mt === 'both'
+                ? 'Search ebook + audiobook indexers'
+                : 'Search ebook indexers'}
         </button>
       </section>
 

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -49,7 +49,7 @@ export default function WantedPage() {
     }
   }
 
-  const changeMediaType = async (book: Book, mediaType: 'ebook' | 'audiobook') => {
+  const changeMediaType = async (book: Book, mediaType: 'ebook' | 'audiobook' | 'both') => {
     try {
       const updated = await api.updateBook(book.id, { mediaType })
       setBooks(books.map(b => b.id === book.id ? updated : b))
@@ -208,13 +208,21 @@ export default function WantedPage() {
                       <div className="flex items-center gap-2 mt-0.5 flex-wrap">
                         <select
                           value={book.mediaType || 'ebook'}
-                          onChange={e => changeMediaType(book, e.target.value as 'ebook' | 'audiobook')}
+                          onChange={e => changeMediaType(book, e.target.value as 'ebook' | 'audiobook' | 'both')}
                           className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded text-[11px] px-1.5 py-0.5 focus:outline-none"
                           title="Change media type"
                         >
                           <option value="ebook">📖 Ebook</option>
                           <option value="audiobook">🎧 Audiobook</option>
+                          <option value="both">📖🎧 Both</option>
                         </select>
+                        {book.mediaType === 'both' && (
+                          <span className="text-[10px] text-slate-500 dark:text-zinc-500">
+                            {book.ebookFilePath ? '📖 ✓' : '📖 needed'}
+                            {' · '}
+                            {book.audiobookFilePath ? '🎧 ✓' : '🎧 needed'}
+                          </span>
+                        )}
                       </div>
                       {book.releaseDate && (
                         <p className="text-xs text-slate-600 dark:text-zinc-500">{new Date(book.releaseDate).getFullYear()}</p>


### PR DESCRIPTION
Closes #23

## Summary

- Adds `media_type = 'both'` so a single book entry can track and grab both an ebook **and** an audiobook independently
- `status` stays `wanted` until both requested formats are on disk; flips to `imported` only when all needed formats are satisfied
- Import and search are format-aware: the importer detects format from file extensions, the scheduler fires independent searches per missing format
- Per-format deletion: `DELETE /api/v1/book/{id}/file?format=ebook|audiobook` clears one format without touching the other

## What changed

| Layer | Change |
|---|---|
| DB | Migration 012 — adds `ebook_file_path`, `audiobook_file_path`; seeds from existing `file_path` on upgrade |
| Models | `WantsEbook/Audiobook`, `NeedsEbook/Audiobook` helpers; `MediaTypeBoth` constant |
| BookRepo | `SetFormatFilePath` replaces `SetFilePath` — format-aware, recomputes aggregate status |
| Scanner | Detects format from file extensions; calls `SetFormatFilePath` |
| Scheduler | `SearchAndGrabBook` dispatches independent searches per needed format; `bookSearcher` interface extracted for testability |
| API | Accepts `'both'` media type; per-format file deletion endpoint |
| Web | Book detail page shows per-format status + individual delete buttons; Wanted page shows ebook/audiobook progress indicators for dual-format books |

## Tests

- `models/book_test.go` — `WantsEbook`, `WantsAudiobook`, `NeedsEbook`, `NeedsAudiobook`, full-satisfaction check
- `db/books_dual_format_test.go` — `SetFormatFilePath` for ebook-only, audiobook-only, partial both, complete both; `ListByStatus` for partially-satisfied books
- `importer/scanner_dual_format_test.go` — `detectDownloadFormat` across all supported extensions + case-insensitivity
- `scheduler/scheduler_dual_format_test.go` — `SearchAndGrabBook` dispatch for ebook-only, audiobook-only, both-missing, one-already-imported, fully-satisfied