### PR TITLE
fix(ui): show error in Add Author modal when metadata provider is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
 
+## [v0.9.1] — 2026-04-15
+
+Patch release fixing a silent failure in the Add Author modal when OpenLibrary is temporarily unavailable.
+
+### Fixed
+
+- **Author search shows error when metadata provider is down** — when OpenLibrary returns an HTTP error (e.g. 503 during an outage), the Add Author modal now displays a visible error message instead of silently showing an empty results list. The error is cleared automatically when the next search succeeds.
+
 ## [v0.9.0] — 2026-04-15
 
 Major feature release completing the Calibre integration story and fixing critical onboarding issues that caused new installs to immediately fire download storms and fail to detect existing libraries.

--- a/web/src/components/AddAuthorModal.test.tsx
+++ b/web/src/components/AddAuthorModal.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import AddAuthorModal from './AddAuthorModal'
+
+// Mock the entire api/client module so no real HTTP calls are made.
+vi.mock('../api/client', () => ({
+  api: {
+    listMetadataProfiles: vi.fn().mockResolvedValue([]),
+    searchAuthors: vi.fn(),
+    addAuthor: vi.fn(),
+  },
+}))
+
+// Import after the mock is set up so we get the mocked version.
+import { api } from '../api/client'
+
+describe('AddAuthorModal — search error handling', () => {
+  const onClose = vi.fn()
+  const onAdded = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.listMetadataProfiles).mockResolvedValue([])
+  })
+
+  it('shows an error banner when the metadata provider is unreachable', async () => {
+    vi.mocked(api.searchAuthors).mockRejectedValue(
+      new Error('search authors: HTTP 503: Service Unavailable')
+    )
+
+    render(<AddAuthorModal onClose={onClose} onAdded={onAdded} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Search by author name...'), {
+      target: { value: 'tolkien' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/HTTP 503/i)).toBeInTheDocument()
+    )
+    // "No results found" should NOT appear alongside the error
+    expect(screen.queryByText(/no results found/i)).not.toBeInTheDocument()
+  })
+
+  it('displays results when the search succeeds', async () => {
+    vi.mocked(api.searchAuthors).mockResolvedValue([
+      {
+        id: 1,
+        foreignAuthorId: 'OL26320A',
+        authorName: 'J.R.R. Tolkien',
+        sortName: 'Tolkien, J.R.R.',
+        description: '',
+        imageUrl: '',
+        disambiguation: 'The Hobbit',
+        ratingsCount: 5000,
+        averageRating: 4.8,
+        monitored: true,
+        statistics: { bookCount: 12, availableBookCount: 0, wantedBookCount: 0 },
+      },
+    ])
+
+    render(<AddAuthorModal onClose={onClose} onAdded={onAdded} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Search by author name...'), {
+      target: { value: 'tolkien' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText('J.R.R. Tolkien')).toBeInTheDocument()
+    )
+    expect(screen.queryByText(/no results found/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/could not reach/i)).not.toBeInTheDocument()
+  })
+
+  it('clears the error banner when a subsequent search succeeds', async () => {
+    vi.mocked(api.searchAuthors)
+      .mockRejectedValueOnce(new Error('search authors: HTTP 503: Service Unavailable'))
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          foreignAuthorId: 'OL26320A',
+          authorName: 'J.R.R. Tolkien',
+          sortName: 'Tolkien, J.R.R.',
+          description: '',
+          imageUrl: '',
+          disambiguation: '',
+          ratingsCount: 0,
+          averageRating: 0,
+          monitored: true,
+        },
+      ])
+
+    render(<AddAuthorModal onClose={onClose} onAdded={onAdded} />)
+
+    const input = screen.getByPlaceholderText('Search by author name...')
+    const btn = screen.getByRole('button', { name: /^search$/i })
+
+    fireEvent.change(input, { target: { value: 'tolkien' } })
+    fireEvent.click(btn)
+    await waitFor(() => expect(screen.getByText(/HTTP 503/i)).toBeInTheDocument())
+
+    fireEvent.click(btn)
+    await waitFor(() =>
+      expect(screen.queryByText(/HTTP 503/i)).not.toBeInTheDocument()
+    )
+    expect(screen.getByText('J.R.R. Tolkien')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -10,6 +10,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<Author[]>([])
   const [searching, setSearching] = useState(false)
+  const [searchError, setSearchError] = useState<string | null>(null)
   const [adding, setAdding] = useState<string | null>(null)
   const [profiles, setProfiles] = useState<MetadataProfile[]>([])
   const [profileId, setProfileId] = useState<number | null>(null)
@@ -28,11 +29,13 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const search = async () => {
     if (!query.trim()) return
     setSearching(true)
+    setSearchError(null)
     try {
       const authors = await api.searchAuthors(query)
       setResults(authors)
     } catch (err) {
-      console.error(err)
+      setSearchError(err instanceof Error ? err.message : 'Search failed — try again')
+      setResults([])
     } finally {
       setSearching(false)
     }
@@ -112,6 +115,11 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
           </div>
 
           <div className="mt-4 max-h-80 overflow-y-auto space-y-2">
+            {searchError && (
+              <p className="text-sm text-red-400 text-center py-4">
+                Could not reach the metadata provider — {searchError}
+              </p>
+            )}
             {results.map(author => (
               <div
                 key={author.foreignAuthorId}
@@ -134,7 +142,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
                 </button>
               </div>
             ))}
-            {results.length === 0 && !searching && query && (
+            {results.length === 0 && !searching && !searchError && query && (
               <p className="text-sm text-slate-600 dark:text-zinc-500 text-center py-4">No results found</p>
             )}
           </div>

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -14,4 +14,9 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test-setup.ts',
+  },
 })


### PR DESCRIPTION
## Problem

When OpenLibrary returns an HTTP error (e.g. 503 during an outage), the Add Author search silently showed an empty results list with "No results found". The `catch` block only called `console.error` — `setResults` was never reached, so the UI looked exactly like a legitimate empty search rather than a failure.

## Fix

- Add `searchError` state to `AddAuthorModal`
- On failure, set the error and show a visible banner: _"Could not reach the metadata provider — \<message\>"_
- Clear the error at the start of each new search so it disappears once the provider recovers
- Hide "No results found" when an error is already shown (they're mutually exclusive)

## Tests

First frontend tests in the repo — adds Vitest + jsdom + `@testing-library/react` config:

- **Error banner shown** when `api.searchAuthors` rejects with a 503 message
- **Results displayed** when the search succeeds (no error banner, no "no results")
- **Error clears** on a subsequent successful search

## Release

Intended as v0.9.1 patch on `main`. Root cause: OpenLibrary 503 outage on 2026-04-15.