### PR TITLE
fix(lint): resolve 5 golangci-lint failures blocking CI

### DIFF
--- a/internal/api/opds.go
+++ b/internal/api/opds.go
@@ -157,4 +157,3 @@ func writeOPDSError(w http.ResponseWriter, err error) bool {
 	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	return true
 }
-

--- a/internal/calibre/importer.go
+++ b/internal/calibre/importer.go
@@ -32,13 +32,13 @@ type ImportStats struct {
 // + Processed to fill it, and Stats (populated on completion) for the
 // summary panel.
 type ImportProgress struct {
-	Running   bool      `json:"running"`
-	StartedAt time.Time `json:"startedAt"`
-	Total     int       `json:"total"`
-	Processed int       `json:"processed"`
-	Message   string    `json:"message,omitempty"`
-	Error     string    `json:"error,omitempty"`
-	FinishedAt *time.Time `json:"finishedAt,omitempty"`
+	Running    bool         `json:"running"`
+	StartedAt  time.Time    `json:"startedAt"`
+	Total      int          `json:"total"`
+	Processed  int          `json:"processed"`
+	Message    string       `json:"message,omitempty"`
+	Error      string       `json:"error,omitempty"`
+	FinishedAt *time.Time   `json:"finishedAt,omitempty"`
 	Stats      *ImportStats `json:"stats,omitempty"`
 }
 
@@ -180,7 +180,11 @@ func (i *Importer) run(ctx context.Context, libraryPath string) *ImportStats {
 		i.fail(err)
 		return stats
 	}
-	defer reader.Close()
+	defer func() {
+		if cerr := reader.Close(); cerr != nil {
+			slog.Warn("calibre: close reader", "error", cerr)
+		}
+	}()
 
 	total, err := reader.Count(ctx)
 	if err != nil {
@@ -372,7 +376,7 @@ type bookUpsertResult struct {
 // book. Dedupe order:
 //  1. books.calibre_id == cb.CalibreID   (pure re-import; update in place)
 //  2. author_id + title match            (existing Bindery book adopted
-//                                          into Calibre; link + update)
+//     into Calibre; link + update)
 //  3. Create a fresh row with the Calibre id set.
 //
 // Returns (result, created). result.mergedByTitle is true only for path 2.

--- a/internal/calibre/reader.go
+++ b/internal/calibre/reader.go
@@ -62,10 +62,10 @@ type CalibreSeries struct {
 // single book row carry multiple formats (epub + mobi + pdf); each becomes
 // a separate Bindery edition.
 type CalibreFormat struct {
-	Format        string // uppercase file extension: EPUB, MOBI, PDF, ...
-	FileName      string // Calibre's on-disk filename (no extension)
-	AbsolutePath  string // resolved against library root + book path
-	SizeBytes     int64
+	Format       string // uppercase file extension: EPUB, MOBI, PDF, ...
+	FileName     string // Calibre's on-disk filename (no extension)
+	AbsolutePath string // resolved against library root + book path
+	SizeBytes    int64
 }
 
 // Reader opens a Calibre library's metadata.db read-only and returns

--- a/internal/calibre/reader_test.go
+++ b/internal/calibre/reader_test.go
@@ -3,6 +3,7 @@ package calibre
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -138,11 +139,16 @@ var fixtureSchema = []string{
 
 // fixtureSeed inserts a deterministic tiny library the tests can assert on.
 // Book 1 (Book One): single author (Alice), single format (epub), one series
-//                    position, ISBN.
+//
+//	position, ISBN.
+//
 // Book 2 (Book Two): two authors (Alice primary, Carol secondary), two
-//                    formats (epub + mobi), same series position 2, no ISBN.
+//
+//	formats (epub + mobi), same series position 2, no ISBN.
+//
 // Book 3 (No Cover): different author (Bob), single PDF, no series, no
-//                    cover file on disk.
+//
+//	cover file on disk.
 var fixtureSeed = []string{
 	`INSERT INTO authors (id, name, sort) VALUES
 		(1, 'Alice Author', 'Author, Alice'),
@@ -286,7 +292,7 @@ func TestReader_Books_StopsOnError(t *testing.T) {
 		seen++
 		return abort
 	})
-	if err != abort {
+	if !errors.Is(err, abort) {
 		t.Fatalf("expected abort sentinel, got %v", err)
 	}
 	if seen != 1 {


### PR DESCRIPTION
CI has been red on every PR since the Calibre feature landed. Five issues, all in Calibre-related files:

| File | Rule | Fix |
|---|---|---|
| `internal/calibre/importer.go:183` | `errcheck` | Wrapped `defer reader.Close()` to log the error |
| `internal/calibre/reader_test.go:289` | `errorlint` | `err != abort` → `errors.Is(err, abort)` |
| `internal/calibre/importer.go` | `gofmt` | `gofmt -w` |
| `internal/calibre/reader.go` | `gofmt` | `gofmt -w` |
| `internal/api/opds.go` | `gofmt` | `gofmt -w` |

No logic changes.