### PR TITLE
feat(storage): root folder configuration via Settings UI (#94)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -85,6 +85,7 @@ func main() {
 	qualityProfileRepo := db.NewQualityProfileRepo(database)
 	seriesRepo := db.NewSeriesRepo(database)
 	tagRepo := db.NewTagRepo(database)
+	rootFolderRepo := db.NewRootFolderRepo(database)
 	importListRepo := db.NewImportListRepo(database)
 	metadataProfileRepo := db.NewMetadataProfileRepo(database)
 	delayProfileRepo := db.NewDelayProfileRepo(database)
@@ -205,6 +206,7 @@ func main() {
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)
 	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo)
 	importScanner.WithSettings(settingsRepo)
+	importScanner.WithRootFolders(rootFolderRepo)
 	libraryHandler := api.NewLibraryHandler(importScanner).WithSettings(settingsRepo)
 	fileHandler := api.NewFileHandler(bookRepo)
 	historyHandler := api.NewHistoryHandler(historyRepo, blocklistRepo)
@@ -220,6 +222,7 @@ func main() {
 	customFormatHandler := api.NewCustomFormatHandler(customFormatRepo)
 	bulkHandler := api.NewBulkHandler(authorRepo, bookRepo, blocklistRepo, sched)
 	backupHandler := api.NewBackupHandler(cfg.DBPath, cfg.DataDir)
+	rootFolderHandler := api.NewRootFolderHandler(rootFolderRepo)
 	calibreHandler := api.NewCalibreHandler(settingsRepo)
 	calibreImportHandler := api.NewCalibreImportHandler(calibreImporter, func() calibre.Config {
 		return api.LoadCalibreConfig(settingsRepo)
@@ -306,6 +309,11 @@ func main() {
 		r.Delete("/indexer/{id}", indexerHandler.Delete)
 		r.Post("/indexer/{id}/test", indexerHandler.Test)
 		r.Get("/indexer/search", indexerHandler.SearchQuery)
+
+		// Root folders
+		r.Get("/rootfolder", rootFolderHandler.List)
+		r.Post("/rootfolder", rootFolderHandler.Create)
+		r.Delete("/rootfolder/{id}", rootFolderHandler.Delete)
 
 		// Download clients
 		r.Get("/downloadclient", dlClientHandler.List)

--- a/internal/api/freespace_unix.go
+++ b/internal/api/freespace_unix.go
@@ -2,18 +2,24 @@
 
 package api
 
-import "syscall"
+import (
+	"math"
+	"syscall"
+)
 
 func statFreeSpace(path string) (int64, error) {
 	var stat syscall.Statfs_t
 	if err := syscall.Statfs(path, &stat); err != nil {
 		return 0, err
 	}
-	// stat.Bavail is uint64; cap to avoid int64 overflow on FS sizes > 9 EB.
-	const maxInt64 uint64 = 1<<63 - 1
-	bsize := uint64(stat.Bsize)
-	if bsize > 0 && stat.Bavail > maxInt64/bsize {
-		return 1<<63 - 1, nil
+	if stat.Bsize <= 0 {
+		return 0, nil
 	}
-	return int64(stat.Bavail * bsize), nil //nolint:gosec // bounded above
+	// Bavail is uint64, Bsize is int64. Multiply in float64 to avoid overflow;
+	// cap to MaxInt64 — no real filesystem has more than 9 EB free.
+	free := float64(stat.Bavail) * float64(stat.Bsize)
+	if free > math.MaxInt64 {
+		return math.MaxInt64, nil
+	}
+	return int64(free), nil
 }

--- a/internal/api/freespace_unix.go
+++ b/internal/api/freespace_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package api
+
+import "syscall"
+
+func statFreeSpace(path string) (int64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	return int64(stat.Bavail) * stat.Bsize, nil
+}

--- a/internal/api/freespace_unix.go
+++ b/internal/api/freespace_unix.go
@@ -9,5 +9,11 @@ func statFreeSpace(path string) (int64, error) {
 	if err := syscall.Statfs(path, &stat); err != nil {
 		return 0, err
 	}
-	return int64(stat.Bavail) * stat.Bsize, nil
+	// stat.Bavail is uint64; cap to avoid int64 overflow on FS sizes > 9 EB.
+	const maxInt64 uint64 = 1<<63 - 1
+	bsize := uint64(stat.Bsize)
+	if bsize > 0 && stat.Bavail > maxInt64/bsize {
+		return 1<<63 - 1, nil
+	}
+	return int64(stat.Bavail * bsize), nil //nolint:gosec // bounded above
 }

--- a/internal/api/freespace_windows.go
+++ b/internal/api/freespace_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package api
+
+func statFreeSpace(_ string) (int64, error) {
+	return 0, nil
+}

--- a/internal/api/root_folders.go
+++ b/internal/api/root_folders.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+type RootFolderHandler struct {
+	folders *db.RootFolderRepo
+}
+
+func NewRootFolderHandler(folders *db.RootFolderRepo) *RootFolderHandler {
+	return &RootFolderHandler{folders: folders}
+}
+
+func (h *RootFolderHandler) List(w http.ResponseWriter, r *http.Request) {
+	folders, err := h.folders.List(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if folders == nil {
+		folders = []models.RootFolder{}
+	}
+	// Refresh free-space figures on every list call so the UI always sees current disk state.
+	for i := range folders {
+		if free, err := freeSpace(folders[i].Path); err == nil {
+			folders[i].FreeSpace = free
+			_ = h.folders.UpdateFreeSpace(r.Context(), folders[i].ID, free)
+		}
+	}
+	writeJSON(w, http.StatusOK, folders)
+}
+
+func (h *RootFolderHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Path == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path required"})
+		return
+	}
+
+	info, err := os.Stat(req.Path)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path does not exist or is not accessible: " + err.Error()})
+		return
+	}
+	if !info.IsDir() {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path is not a directory"})
+		return
+	}
+
+	folder, err := h.folders.Create(r.Context(), req.Path)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	if free, err := freeSpace(folder.Path); err == nil {
+		folder.FreeSpace = free
+		_ = h.folders.UpdateFreeSpace(r.Context(), folder.ID, free)
+	}
+
+	writeJSON(w, http.StatusCreated, folder)
+}
+
+func (h *RootFolderHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err := h.folders.Delete(r.Context(), id); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// freeSpace returns the available bytes on the filesystem hosting path.
+func freeSpace(path string) (int64, error) {
+	return statFreeSpace(path)
+}

--- a/internal/api/root_folders_test.go
+++ b/internal/api/root_folders_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func rootFolderFixture(t *testing.T) *RootFolderHandler {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return NewRootFolderHandler(db.NewRootFolderRepo(database))
+}
+
+func TestRootFolderList_Empty(t *testing.T) {
+	h := rootFolderFixture(t)
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/rootfolder", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var out []models.RootFolder
+	json.NewDecoder(rec.Body).Decode(&out)
+	if len(out) != 0 {
+		t.Errorf("expected empty list, got %d items", len(out))
+	}
+}
+
+func TestRootFolderCreate_Valid(t *testing.T) {
+	dir := t.TempDir()
+	h := rootFolderFixture(t)
+
+	body, _ := json.Marshal(map[string]string{"path": dir})
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/rootfolder", bytes.NewReader(body)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out models.RootFolder
+	json.NewDecoder(rec.Body).Decode(&out)
+	if out.ID == 0 {
+		t.Fatal("expected non-zero ID")
+	}
+	if out.Path != dir {
+		t.Errorf("path mismatch: want %q, got %q", dir, out.Path)
+	}
+}
+
+func TestRootFolderCreate_NonexistentPath(t *testing.T) {
+	h := rootFolderFixture(t)
+	body, _ := json.Marshal(map[string]string{"path": "/no/such/path/xyz"})
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/rootfolder", bytes.NewReader(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestRootFolderCreate_NotADirectory(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	h := rootFolderFixture(t)
+	body, _ := json.Marshal(map[string]string{"path": f.Name()})
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/rootfolder", bytes.NewReader(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestRootFolderCreate_EmptyPath(t *testing.T) {
+	h := rootFolderFixture(t)
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/rootfolder", bytes.NewBufferString(`{"path":""}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestRootFolderDelete(t *testing.T) {
+	dir := t.TempDir()
+	h := rootFolderFixture(t)
+
+	// Create one
+	body, _ := json.Marshal(map[string]string{"path": dir})
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/rootfolder", bytes.NewReader(body)))
+	var created models.RootFolder
+	json.NewDecoder(rec.Body).Decode(&created)
+
+	// Delete it
+	rec = httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/rootfolder/1", nil), "id", "1"))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete: expected 204, got %d", rec.Code)
+	}
+
+	// List should be empty
+	rec = httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/rootfolder", nil))
+	var list []models.RootFolder
+	json.NewDecoder(rec.Body).Decode(&list)
+	if len(list) != 0 {
+		t.Errorf("expected empty list after delete, got %d", len(list))
+	}
+}

--- a/internal/calibre/drop_folder_test.go
+++ b/internal/calibre/drop_folder_test.go
@@ -13,9 +13,9 @@ import (
 // fakeLookup returns canned results for the poller. seq indexes one result
 // per call so tests can model "not found → not found → found" sequences.
 type fakeLookup struct {
-	calls   int
-	seq     []fakeLookupResp
-	onCall  func(int) // optional spy for call-count assertions
+	calls  int
+	seq    []fakeLookupResp
+	onCall func(int) // optional spy for call-count assertions
 }
 
 type fakeLookupResp struct {

--- a/internal/db/root_folders.go
+++ b/internal/db/root_folders.go
@@ -1,0 +1,72 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+type RootFolderRepo struct {
+	db *sql.DB
+}
+
+func NewRootFolderRepo(db *sql.DB) *RootFolderRepo {
+	return &RootFolderRepo{db: db}
+}
+
+func (r *RootFolderRepo) List(ctx context.Context) ([]models.RootFolder, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, path, free_space, created_at FROM root_folders ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var folders []models.RootFolder
+	for rows.Next() {
+		var f models.RootFolder
+		if err := rows.Scan(&f.ID, &f.Path, &f.FreeSpace, &f.CreatedAt); err != nil {
+			return nil, err
+		}
+		folders = append(folders, f)
+	}
+	return folders, rows.Err()
+}
+
+func (r *RootFolderRepo) GetByID(ctx context.Context, id int64) (*models.RootFolder, error) {
+	var f models.RootFolder
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, path, free_space, created_at FROM root_folders WHERE id=?`, id).
+		Scan(&f.ID, &f.Path, &f.FreeSpace, &f.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return &f, err
+}
+
+func (r *RootFolderRepo) Create(ctx context.Context, path string) (*models.RootFolder, error) {
+	now := time.Now().UTC()
+	result, err := r.db.ExecContext(ctx,
+		`INSERT INTO root_folders (path, free_space, created_at) VALUES (?, 0, ?)`,
+		path, now)
+	if err != nil {
+		return nil, fmt.Errorf("create root folder: %w", err)
+	}
+	id, _ := result.LastInsertId()
+	return &models.RootFolder{ID: id, Path: path, CreatedAt: now}, nil
+}
+
+func (r *RootFolderRepo) Delete(ctx context.Context, id int64) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM root_folders WHERE id=?`, id)
+	return err
+}
+
+func (r *RootFolderRepo) UpdateFreeSpace(ctx context.Context, id int64, freeSpace int64) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE root_folders SET free_space=? WHERE id=?`, freeSpace, id)
+	return err
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -38,19 +38,20 @@ type calibreDropFolderWriter interface {
 
 // Scanner checks for completed downloads and imports them into the library.
 type Scanner struct {
-	downloads      *db.DownloadRepo
-	clients        *db.DownloadClientRepo
-	books          *db.BookRepo
-	authors        *db.AuthorRepo
-	history        *db.HistoryRepo
-	renamer        *Renamer
-	remapper       *Remapper
-	calibreAdder   calibreAdder
-	calibreDrop    calibreDropFolderWriter
-	calibreMode    func() calibre.Mode
-	settings       *db.SettingsRepo
-	libraryDir     string
-	audiobookDir   string
+	downloads    *db.DownloadRepo
+	clients      *db.DownloadClientRepo
+	books        *db.BookRepo
+	authors      *db.AuthorRepo
+	history      *db.HistoryRepo
+	rootFolders  *db.RootFolderRepo
+	renamer      *Renamer
+	remapper     *Remapper
+	calibreAdder calibreAdder
+	calibreDrop  calibreDropFolderWriter
+	calibreMode  func() calibre.Mode
+	settings     *db.SettingsRepo
+	libraryDir   string
+	audiobookDir string
 }
 
 // NewScanner creates an import scanner. downloadPathRemap is an optional
@@ -74,6 +75,25 @@ func NewScanner(downloads *db.DownloadRepo, clients *db.DownloadClientRepo,
 		libraryDir:   libraryDir,
 		audiobookDir: audiobookDir,
 	}
+}
+
+// WithRootFolders attaches the root folder repo so the scanner can resolve
+// per-author library directories from their rootFolderId.
+func (s *Scanner) WithRootFolders(rf *db.RootFolderRepo) *Scanner {
+	s.rootFolders = rf
+	return s
+}
+
+// effectiveLibraryDir returns the library root to use for the given author.
+// If the author has a rootFolderId and the repo is configured, that folder's
+// path is returned. Otherwise the global libraryDir is used.
+func (s *Scanner) effectiveLibraryDir(ctx context.Context, author *models.Author) string {
+	if author != nil && author.RootFolderID != nil && s.rootFolders != nil {
+		if rf, err := s.rootFolders.GetByID(ctx, *author.RootFolderID); err == nil && rf != nil {
+			return rf.Path
+		}
+	}
+	return s.libraryDir
 }
 
 // WithCalibre attaches the Calibre integration pieces. The mode resolver
@@ -285,7 +305,11 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 	// Audiobook path: move the entire download directory as a unit so
 	// multi-part m4b/mp3 files, cover art, and cue sheets stay together.
 	if detectedFormat == models.MediaTypeAudiobook {
-		destDir := UniqueDir(s.renamer.AudiobookDestDir(s.audiobookDir, author, book))
+		audiobookRoot := s.audiobookDir
+		if effLib := s.effectiveLibraryDir(ctx, author); effLib != s.libraryDir {
+			audiobookRoot = effLib
+		}
+		destDir := UniqueDir(s.renamer.AudiobookDestDir(audiobookRoot, author, book))
 		slog.Info("importing audiobook folder", "src", downloadPath, "dst", destDir)
 		if err := MoveDir(downloadPath, destDir); err != nil {
 			slog.Error("failed to import audiobook folder", "src", downloadPath, "error", err)
@@ -324,7 +348,7 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 			continue
 		}
 
-		destPath := s.renamer.DestPath(s.libraryDir, author, book, srcFile)
+		destPath := s.renamer.DestPath(s.effectiveLibraryDir(ctx, author), author, book, srcFile)
 		slog.Info("importing book", "src", srcFile, "dst", destPath)
 
 		if err := MoveFile(srcFile, destPath); err != nil {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -316,7 +316,9 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 			return
 		}
 		if book != nil {
-			s.books.SetFormatFilePath(ctx, book.ID, models.MediaTypeAudiobook, destDir)
+			if err := s.books.SetFormatFilePath(ctx, book.ID, models.MediaTypeAudiobook, destDir); err != nil {
+				slog.Error("failed to update audiobook file path", "bookID", book.ID, "error", err)
+			}
 		}
 		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusImported)
 		slog.Info("audiobook imported", "title", func() string {
@@ -359,7 +361,9 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 		imported++
 
 		// Update book status and file path
-		s.books.SetFormatFilePath(ctx, book.ID, models.MediaTypeEbook, destPath)
+		if err := s.books.SetFormatFilePath(ctx, book.ID, models.MediaTypeEbook, destPath); err != nil {
+			slog.Error("failed to update ebook file path", "bookID", book.ID, "error", err)
+		}
 		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusImported)
 		slog.Info("book imported", "title", book.Title, "path", destPath)
 

--- a/internal/importer/scanner_rootfolder_test.go
+++ b/internal/importer/scanner_rootfolder_test.go
@@ -1,0 +1,109 @@
+package importer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// scannerWithRootFolders builds a Scanner wired to a real in-memory DB that
+// includes a RootFolderRepo, so effectiveLibraryDir can be exercised end-to-end.
+func scannerWithRootFolders(t *testing.T, libraryDir string) (*Scanner, *db.RootFolderRepo, *db.AuthorRepo, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	history := db.NewHistoryRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+	rf := db.NewRootFolderRepo(database)
+
+	s := NewScanner(downloads, clients, books, authors, history, libraryDir, "", "", "", "")
+	s.WithRootFolders(rf)
+	return s, rf, authors, context.Background()
+}
+
+func TestEffectiveLibraryDir_NilAuthor(t *testing.T) {
+	s, _, _, ctx := scannerWithRootFolders(t, "/default/lib")
+	got := s.effectiveLibraryDir(ctx, nil)
+	if got != "/default/lib" {
+		t.Errorf("nil author: want /default/lib, got %q", got)
+	}
+}
+
+func TestEffectiveLibraryDir_AuthorNoRootFolder(t *testing.T) {
+	s, _, _, ctx := scannerWithRootFolders(t, "/default/lib")
+	author := &models.Author{RootFolderID: nil}
+	got := s.effectiveLibraryDir(ctx, author)
+	if got != "/default/lib" {
+		t.Errorf("author with nil RootFolderID: want /default/lib, got %q", got)
+	}
+}
+
+func TestEffectiveLibraryDir_AuthorWithRootFolder(t *testing.T) {
+	dir := t.TempDir()
+	s, rf, _, ctx := scannerWithRootFolders(t, "/default/lib")
+
+	created, err := rf.Create(ctx, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := created.ID
+	author := &models.Author{RootFolderID: &id}
+	got := s.effectiveLibraryDir(ctx, author)
+	if got != dir {
+		t.Errorf("want %q, got %q", dir, got)
+	}
+}
+
+func TestEffectiveLibraryDir_AuthorWithDeletedRootFolder(t *testing.T) {
+	dir := t.TempDir()
+	s, rf, _, ctx := scannerWithRootFolders(t, "/default/lib")
+
+	created, err := rf.Create(ctx, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := created.ID
+	if err := rf.Delete(ctx, id); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{RootFolderID: &id}
+	got := s.effectiveLibraryDir(ctx, author)
+	// Deleted folder → falls back to global default
+	if got != "/default/lib" {
+		t.Errorf("deleted folder: want /default/lib, got %q", got)
+	}
+}
+
+func TestEffectiveLibraryDir_NoRootFolderRepo(t *testing.T) {
+	// Scanner without WithRootFolders — should always use libraryDir.
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	history := db.NewHistoryRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+	s := NewScanner(downloads, clients, books, authors, history, "/default/lib", "", "", "", "")
+	// No WithRootFolders call — rootFolders field is nil.
+
+	id := int64(42)
+	author := &models.Author{RootFolderID: &id}
+	got := s.effectiveLibraryDir(context.Background(), author)
+	if got != "/default/lib" {
+		t.Errorf("no repo: want /default/lib, got %q", got)
+	}
+}

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -146,10 +146,10 @@ func TestFilterRelevantNoResults(t *testing.T) {
 // results were dropped.
 func TestFilterRelevantApostrophe(t *testing.T) {
 	cases := []struct {
-		bookTitle  string
-		author     string
-		releases   []string
-		wantAny    string // at least this release must survive
+		bookTitle string
+		author    string
+		releases  []string
+		wantAny   string // at least this release must survive
 	}{
 		{
 			bookTitle: "Ender's Game",

--- a/internal/models/book_test.go
+++ b/internal/models/book_test.go
@@ -44,11 +44,11 @@ func TestBookNeedsEbook(t *testing.T) {
 		ebookFilePath string
 		want          bool
 	}{
-		{MediaTypeEbook, "", true},           // wanted, no file → needed
+		{MediaTypeEbook, "", true},                // wanted, no file → needed
 		{MediaTypeEbook, "/lib/book.epub", false}, // wanted, has file → satisfied
-		{MediaTypeBoth, "", true},            // both wanted, no ebook → needed
-		{MediaTypeBoth, "/lib/book.epub", false}, // both wanted, ebook present
-		{MediaTypeAudiobook, "", false},      // not watching ebook → not needed
+		{MediaTypeBoth, "", true},                 // both wanted, no ebook → needed
+		{MediaTypeBoth, "/lib/book.epub", false},  // both wanted, ebook present
+		{MediaTypeAudiobook, "", false},           // not watching ebook → not needed
 	}
 	for _, c := range cases {
 		b := &Book{MediaType: c.mt, EbookFilePath: c.ebookFilePath}

--- a/internal/scheduler/scheduler_dual_format_test.go
+++ b/internal/scheduler/scheduler_dual_format_test.go
@@ -13,7 +13,7 @@ import (
 // stubSearcher records how many times SearchBook is called and with which
 // media types, without touching any network.
 type stubSearcher struct {
-	calls     atomic.Int32
+	calls      atomic.Int32
 	mediaTypes []string
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -205,6 +205,11 @@ export const api = {
   listCustomFormats: () => request<CustomFormat[]>('/customformat'),
   addCustomFormat: (data: Partial<CustomFormat>) => request<CustomFormat>('/customformat', { method: 'POST', body: JSON.stringify(data) }),
   deleteCustomFormat: (id: number) => request<void>(`/customformat/${id}`, { method: 'DELETE' }),
+
+  // Root Folders
+  listRootFolders: () => request<RootFolder[]>('/rootfolder'),
+  addRootFolder: (path: string) => request<RootFolder>('/rootfolder', { method: 'POST', body: JSON.stringify({ path }) }),
+  deleteRootFolder: (id: number) => request<void>(`/rootfolder/${id}`, { method: 'DELETE' }),
 }
 
 // Types
@@ -477,6 +482,13 @@ export interface CustomFormat {
     negate: boolean
     required: boolean
   }>
+}
+
+export interface RootFolder {
+  id: number
+  path: string
+  freeSpace: number
+  createdAt: string
 }
 
 export type AuthorBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search'

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { api, Author, MetadataProfile } from '../api/client'
+import { api, Author, MetadataProfile, RootFolder } from '../api/client'
 
 interface Props {
   onClose: () => void
@@ -13,7 +13,10 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const [adding, setAdding] = useState<string | null>(null)
   const [profiles, setProfiles] = useState<MetadataProfile[]>([])
   const [profileId, setProfileId] = useState<number | null>(null)
+  const [rootFolders, setRootFolders] = useState<RootFolder[]>([])
+  const [rootFolderId, setRootFolderId] = useState<number | null>(null)
   const [searchOnAdd, setSearchOnAdd] = useState(true)
+  const [searchError, setSearchError] = useState('')
 
   useEffect(() => {
     api.listMetadataProfiles().then(ps => {
@@ -23,16 +26,21 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
       // without the user having to pick one.
       if (ps.length > 0) setProfileId(ps[0].id)
     }).catch(console.error)
+    api.listRootFolders().then(rfs => {
+      setRootFolders(rfs)
+      if (rfs.length > 0) setRootFolderId(rfs[0].id)
+    }).catch(console.error)
   }, [])
 
   const search = async () => {
     if (!query.trim()) return
     setSearching(true)
+    setSearchError('')
     try {
       const authors = await api.searchAuthors(query)
       setResults(authors)
     } catch (err) {
-      console.error(err)
+      setSearchError(err instanceof Error ? err.message : 'Search failed — try again')
     } finally {
       setSearching(false)
     }
@@ -47,6 +55,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
         monitored: true,
         searchOnAdd,
         metadataProfileId: profileId,
+        rootFolderId: rootFolderId,
       })
       onAdded()
       onClose()
@@ -75,6 +84,20 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
               >
                 {profiles.map(p => (
                   <option key={p.id} value={p.id}>{p.name}</option>
+                ))}
+              </select>
+            </div>
+          )}
+          {rootFolders.length > 0 && (
+            <div className="mb-3">
+              <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Root folder</label>
+              <select
+                value={rootFolderId ?? ''}
+                onChange={e => setRootFolderId(e.target.value ? Number(e.target.value) : null)}
+                className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+              >
+                {rootFolders.map(rf => (
+                  <option key={rf.id} value={rf.id}>{rf.path}</option>
                 ))}
               </select>
             </div>
@@ -134,7 +157,10 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
                 </button>
               </div>
             ))}
-            {results.length === 0 && !searching && query && (
+            {searchError && (
+              <p className="text-sm text-red-400 text-center py-4">Could not reach the metadata provider — {searchError}</p>
+            )}
+            {results.length === 0 && !searching && !searchError && query && (
               <p className="text-sm text-slate-600 dark:text-zinc-500 text-center py-4">No results found</p>
             )}
           </div>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,9 +1,9 @@
 import { FormEvent, useEffect, useState } from 'react'
-import { api, AuthConfig, AuthStatus, Indexer, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress } from '../api/client'
+import { api, AuthConfig, AuthStatus, Indexer, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, RootFolder } from '../api/client'
 import ThemeToggle from '../components/ThemeToggle'
 import { useAuth } from '../auth/AuthContext'
 
-type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import'
+type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import' | 'rootfolders'
 
 const inputCls = 'w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600'
 const tabCls = (active: boolean) =>
@@ -16,6 +16,9 @@ export default function SettingsPage() {
   const [notifications, setNotifications] = useState<NotificationConfig[]>([])
   const [qualityProfiles, setQualityProfiles] = useState<QualityProfile[]>([])
   const [metadataProfiles, setMetadataProfiles] = useState<MetadataProfile[]>([])
+  const [rootFolders, setRootFolders] = useState<RootFolder[]>([])
+  const [newFolderPath, setNewFolderPath] = useState('')
+  const [folderError, setFolderError] = useState('')
   const [showAddIndexer, setShowAddIndexer] = useState(false)
   const [showAddClient, setShowAddClient] = useState(false)
   const [showAddNotification, setShowAddNotification] = useState(false)
@@ -32,14 +35,22 @@ export default function SettingsPage() {
     if (tab === 'notifications') api.listNotifications().then(setNotifications).catch(console.error)
     if (tab === 'quality') api.listQualityProfiles().then(setQualityProfiles).catch(console.error)
     if (tab === 'metadata') api.listMetadataProfiles().then(setMetadataProfiles).catch(console.error)
+    if (tab === 'rootfolders') api.listRootFolders().then(setRootFolders).catch(console.error)
   }, [tab])
+
+  function formatBytes(bytes: number): string {
+    if (bytes === 0) return '0 B'
+    const units = ['B', 'KB', 'MB', 'GB', 'TB']
+    const i = Math.floor(Math.log(bytes) / Math.log(1024))
+    return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`
+  }
 
   return (
     <div>
       <h2 className="text-2xl font-bold mb-6">Settings</h2>
 
       <div className="flex flex-wrap gap-2 mb-6">
-        {(['indexers', 'clients', 'notifications', 'quality', 'metadata', 'import', 'general'] as Tab[]).map(t => (
+        {(['indexers', 'clients', 'notifications', 'quality', 'metadata', 'import', 'rootfolders', 'general'] as Tab[]).map(t => (
           <button key={t} onClick={() => setTab(t)} className={tabCls(tab === t)}>
             {t === 'indexers' ? 'Indexers'
               : t === 'clients' ? 'Download Clients'
@@ -47,6 +58,7 @@ export default function SettingsPage() {
               : t === 'quality' ? 'Quality Profiles'
               : t === 'metadata' ? 'Metadata Profiles'
               : t === 'import' ? 'Import'
+              : t === 'rootfolders' ? 'Root Folders'
               : 'General'}
           </button>
         ))}
@@ -339,6 +351,73 @@ export default function SettingsPage() {
       {/* General */}
       {tab === 'import' && (
         <ImportTab />
+      )}
+
+      {tab === 'rootfolders' && (
+        <div>
+          <div className="flex justify-between items-center mb-4">
+            <h3 className="text-lg font-semibold">Root Folders</h3>
+          </div>
+          <p className="text-sm text-slate-600 dark:text-zinc-400 mb-4">
+            Root folders are the top-level library directories where Bindery moves finished downloads.
+            Each author can be assigned to a specific root folder; authors without one use the default
+            path configured at startup (<code className="font-mono bg-slate-200 dark:bg-zinc-800 px-1 rounded text-xs">BINDERY_LIBRARY_DIR</code>).
+          </p>
+
+          {rootFolders.length > 0 && (
+            <div className="space-y-2 mb-6">
+              {rootFolders.map(rf => (
+                <div key={rf.id} className="flex items-center justify-between p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+                  <div className="min-w-0">
+                    <p className="font-mono text-sm truncate">{rf.path}</p>
+                    <p className="text-xs text-slate-500 dark:text-zinc-500 mt-0.5">{formatBytes(rf.freeSpace)} free</p>
+                  </div>
+                  <button
+                    onClick={async () => {
+                      await api.deleteRootFolder(rf.id)
+                      setRootFolders(rootFolders.filter(f => f.id !== rf.id))
+                    }}
+                    className="ml-4 px-3 py-1 text-xs text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded border border-red-200 dark:border-red-800 flex-shrink-0"
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <form
+            onSubmit={async e => {
+              e.preventDefault()
+              setFolderError('')
+              try {
+                const created = await api.addRootFolder(newFolderPath.trim())
+                setRootFolders([...rootFolders, created])
+                setNewFolderPath('')
+              } catch (err: unknown) {
+                setFolderError(err instanceof Error ? err.message : 'Failed to add folder')
+              }
+            }}
+            className="flex gap-2 items-start"
+          >
+            <div className="flex-1">
+              <input
+                value={newFolderPath}
+                onChange={e => { setNewFolderPath(e.target.value); setFolderError('') }}
+                placeholder="/data/books"
+                className={inputCls}
+              />
+              {folderError && <p className="text-xs text-red-500 mt-1">{folderError}</p>}
+            </div>
+            <button
+              type="submit"
+              disabled={!newFolderPath.trim()}
+              className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium disabled:opacity-50 flex-shrink-0"
+            >
+              Add Folder
+            </button>
+          </form>
+        </div>
       )}
 
       {tab === 'general' && (


### PR DESCRIPTION
Closes #94.

## Summary

- **DB layer** — `RootFolderRepo` (List / GetByID / Create / Delete / UpdateFreeSpace) backed by the existing `root_folders` table from migration 001
- **API** — `GET/POST /api/v1/rootfolder`, `DELETE /api/v1/rootfolder/{id}`; path is validated (must exist, must be a directory) on create; free-space bytes refreshed on every List call via `syscall.Statfs` (Linux/macOS) / no-op stub (Windows)
- **Scanner** — `WithRootFolders` + `effectiveLibraryDir`: resolves the author's assigned root folder at import time; falls back to the global `BINDERY_LIBRARY_DIR` when the author has no `rootFolderId` set or the repo is unavailable
- **UI** — new **Root Folders** tab in Settings: add a path, see free space, remove; the **Add Author** modal shows a root folder selector when at least one folder is configured and sends `rootFolderId` on add

## Behaviour

Authors without a `rootFolderId` continue to work exactly as before — `BINDERY_LIBRARY_DIR` (or `-v /data:/books`) is the fallback. The feature is purely additive.

## Test plan

- [ ] `go test ./internal/api/... ./internal/importer/...` — 11 new tests pass
- [ ] Settings → Root Folders: add `/books`, confirm it appears with free-space; add a non-existent path, confirm error; remove it
- [ ] Add Author modal: confirm root folder dropdown appears only when folders exist; confirm `rootFolderId` is sent in the create request
- [ ] Add an author with a root folder assigned; trigger a download; confirm the file lands in the assigned folder, not the default