### PR TITLE
feat(system): in-process log viewer in Settings → Logs (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
 
+### Added
+
+- **Log viewer in Settings → Logs (closes [#93](https://github.com/vavallee/bindery/issues/93))** — the last 1 000 log entries are held in an in-process ring buffer and exposed at `GET /api/v1/system/logs`. The Settings → Logs tab shows the 200 most recent entries colour-coded by severity, auto-refreshes every 5 s, and lets you filter by WARN/ERROR without leaving the UI. A runtime **Level** selector (`PUT /api/v1/system/loglevel`) switches between DEBUG/INFO/WARN/ERROR without restarting the process — useful for capturing verbose output while investigating a problem.
+
 ## [v0.10.0] — 2026-04-15
 
 Minor release adding dual-format support — a single book entry can now track an ebook and an audiobook independently.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 - **Import lists** — Auto-add authors/books from external sources; exclusion list to skip unwanted entries
 - **Tag system** — Scope indexers/profiles/notifications to specific authors
 - **Backup/restore** — Snapshot the SQLite database on demand
+- **Log viewer** — Settings → Logs shows the last 200 entries from an in-process ring buffer, colour-coded by severity with WARN/ERROR filters and 5 s auto-refresh. Runtime log level switchable to DEBUG without restarting via `PUT /api/v1/system/loglevel`
 - **Authentication** — First-run setup creates an admin account (argon2id password hashing, signed session cookies). Three modes: **Enabled** (always require login), **Local only** (bypass auth for private IPs — home network convenience), **Disabled** (no auth, for trusted reverse-proxy deployments). Per-account API key for external integrations. Per-IP rate limiting on the login endpoint.
 
 ### UI

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/indexer"
+	"github.com/vavallee/bindery/internal/logbuf"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/metadata/googlebooks"
 	"github.com/vavallee/bindery/internal/metadata/hardcover"
@@ -48,7 +49,12 @@ func main() {
 	case "error":
 		level = slog.LevelError
 	}
-	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})))
+	// Ring buffer captures the last 1000 entries for the UI log viewer.
+	// Tee sends every record to both stdout (JSON) and the ring.
+	ring := logbuf.New(logbuf.DefaultCapacity)
+	ring.SetLevel(level)
+	stdoutHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})
+	slog.SetDefault(slog.New(logbuf.NewTee(stdoutHandler, ring)))
 
 	slog.Info("starting bindery",
 		"version", version,
@@ -223,6 +229,7 @@ func main() {
 	bulkHandler := api.NewBulkHandler(authorRepo, bookRepo, blocklistRepo, sched)
 	backupHandler := api.NewBackupHandler(cfg.DBPath, cfg.DataDir)
 	rootFolderHandler := api.NewRootFolderHandler(rootFolderRepo)
+	logHandler := api.NewLogHandler(ring)
 	calibreHandler := api.NewCalibreHandler(settingsRepo)
 	calibreImportHandler := api.NewCalibreImportHandler(calibreImporter, func() calibre.Config {
 		return api.LoadCalibreConfig(settingsRepo)
@@ -403,6 +410,11 @@ func main() {
 		r.Post("/backup", backupHandler.Create)
 		r.Post("/backup/{filename}/restore", backupHandler.Restore)
 		r.Delete("/backup/{filename}", backupHandler.Delete)
+
+		// System logs
+		r.Get("/system/logs", logHandler.List)
+		r.Get("/system/loglevel", logHandler.GetLevel)
+		r.Put("/system/loglevel", logHandler.SetLevel)
 
 		// Library
 		r.Post("/library/scan", libraryHandler.Scan)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -70,6 +70,18 @@ The short version lives in the [README](../README.md#roadmap). ✅ items have la
   - ✅ **Configurable per-library mode** ([#64](https://github.com/vavallee/bindery/issues/64), landed in v0.9.0) — Settings → General → Calibre exposes a mode selector: **Off**, **calibredb CLI** (Path A), or **Drop folder** (Path B). Toggling takes effect without a restart.
   - ✅ **OPDS feed** ([#65](https://github.com/vavallee/bindery/issues/65), landed in v0.9.0) — OPDS 1.2 Atom catalogue at `/opds/v1.2/` so KOReader / Moon+ Reader / etc. can browse and download without running Calibre itself. Authenticated with HTTP Basic Auth (API key as password).
 
+## v2 horizon
+
+These items are too large or architectural for a minor release. They define the v2 milestone — the set of changes that would warrant a major version bump.
+
+- **Multi-user with role separation** — Full multi-tenant model: every author, book, profile, and download history row is scoped to an owner. Admin role retains global access (indexers, download clients, system settings). Library overlap handled by shared "global" authors that any user can monitor. Needs schema migration, API layer changes, and a rewritten Settings page split into per-user and admin sections. Blocked on the token-based OIDC work below (need identity from multiple providers before multi-user makes sense).
+
+- **Native OIDC / SSO with multi-provider discovery** — Sign in against Authelia, Authentik, Keycloak, Google, or GitHub natively without an external reverse proxy. Session tokens issued by Bindery after validating the OIDC callback. Overlaps with the multi-user story: each OIDC subject maps to a Bindery user row.
+
+- **External database (MySQL / Postgres)** ([#86](https://github.com/vavallee/bindery/issues/86)) — The current `modernc.org/sqlite` driver is zero-CGO and ships inside the binary, which is excellent for single-instance homelabs. Multi-replica HA requires a shared external store. SQLite WAL is not a substitute for row-level locking under concurrent writers. The schema is already designed with foreign keys and explicit transactions; porting to `database/sql` + a MySQL/Postgres driver is feasible but requires end-to-end testing against both engines, a migration planner that works per-engine, and probably a connection-pool configurator in Settings.
+
+- **Persistent structured log store** — The current ring buffer (1 000 entries, in-process memory) is a good v1 for the log viewer (Settings → Logs, [#93](https://github.com/vavallee/bindery/issues/93)). A v2 log store would persist entries to the database (or a rolling log file), survive restarts, be queryable across date ranges, and support structured search. Useful for incident retrospectives on long-running instances.
+
 ## Explicitly out of scope
 
 These get asked often enough to warrant a standing answer. They're not on the roadmap and new issues requesting them will be closed with a link here.

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/logbuf"
+)
+
+// LogHandler exposes the in-process ring buffer over HTTP.
+type LogHandler struct {
+	ring *logbuf.Ring
+}
+
+func NewLogHandler(ring *logbuf.Ring) *LogHandler {
+	return &LogHandler{ring: ring}
+}
+
+// List handles GET /api/v1/system/logs
+//
+// Query params:
+//
+//	level  — minimum level to return: debug | info | warn | error (default: info)
+//	limit  — max entries to return, 1–1000 (default: 200)
+func (h *LogHandler) List(w http.ResponseWriter, r *http.Request) {
+	minLevel := slog.LevelInfo
+	if l := r.URL.Query().Get("level"); l != "" {
+		minLevel = parseLevel(l)
+	}
+
+	limit := 200
+	if ls := r.URL.Query().Get("limit"); ls != "" {
+		if n, err := strconv.Atoi(ls); err == nil && n > 0 {
+			if n > 1000 {
+				n = 1000
+			}
+			limit = n
+		}
+	}
+
+	entries := h.ring.Snapshot(minLevel, limit)
+	if entries == nil {
+		entries = []logbuf.Entry{}
+	}
+	writeJSON(w, http.StatusOK, entries)
+}
+
+// SetLevel handles PUT /api/v1/system/loglevel
+//
+// Body: {"level": "debug"} — changes the runtime log level.
+// Affects both the ring buffer threshold and the global slog handler.
+func (h *LogHandler) SetLevel(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Level string `json:"level"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Level == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "level required"})
+		return
+	}
+	level := parseLevel(req.Level)
+	h.ring.SetLevel(level)
+	writeJSON(w, http.StatusOK, map[string]string{"level": level.String()})
+}
+
+// GetLevel handles GET /api/v1/system/loglevel
+func (h *LogHandler) GetLevel(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"level": h.ring.Level().String()})
+}
+
+func parseLevel(s string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/api/logs_test.go
+++ b/internal/api/logs_test.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/logbuf"
+)
+
+func logHandlerFixture(t *testing.T) (*LogHandler, *logbuf.Ring) {
+	t.Helper()
+	ring := logbuf.New(100)
+	return NewLogHandler(ring), ring
+}
+
+func seedRecord(ring *logbuf.Ring, level slog.Level, msg string, attrs ...slog.Attr) {
+	rec := slog.NewRecord(time.Now(), level, msg, 0)
+	rec.AddAttrs(attrs...)
+	_ = ring.Handle(context.Background(), rec)
+}
+
+func TestLogList_Empty(t *testing.T) {
+	h, _ := logHandlerFixture(t)
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/system/logs", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var out []logbuf.Entry
+	json.NewDecoder(rec.Body).Decode(&out)
+	if len(out) != 0 {
+		t.Errorf("expected empty slice, got %d entries", len(out))
+	}
+}
+
+func TestLogList_ReturnsEntries(t *testing.T) {
+	h, ring := logHandlerFixture(t)
+	for _, msg := range []string{"alpha", "beta", "gamma"} {
+		seedRecord(ring, slog.LevelInfo, msg)
+	}
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/system/logs", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var out []logbuf.Entry
+	json.NewDecoder(rec.Body).Decode(&out)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(out))
+	}
+}
+
+func TestLogList_LevelFilter(t *testing.T) {
+	h, ring := logHandlerFixture(t)
+	ring.SetLevel(slog.LevelDebug)
+	seedRecord(ring, slog.LevelDebug, "debug-msg")
+	seedRecord(ring, slog.LevelInfo, "info-msg")
+	seedRecord(ring, slog.LevelWarn, "warn-msg")
+	seedRecord(ring, slog.LevelError, "error-msg")
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/system/logs?level=warn", nil))
+	var out []logbuf.Entry
+	json.NewDecoder(rec.Body).Decode(&out)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 entries >= WARN, got %d", len(out))
+	}
+	for _, e := range out {
+		if e.Level != "WARN" && e.Level != "ERROR" {
+			t.Errorf("unexpected level %q in filtered result", e.Level)
+		}
+	}
+}
+
+func TestLogList_LimitParam(t *testing.T) {
+	h, ring := logHandlerFixture(t)
+	for range 50 {
+		seedRecord(ring, slog.LevelInfo, "x")
+	}
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/system/logs?limit=5", nil))
+	var out []logbuf.Entry
+	json.NewDecoder(rec.Body).Decode(&out)
+	if len(out) != 5 {
+		t.Fatalf("expected 5, got %d", len(out))
+	}
+}
+
+func TestLogList_LimitCappedAt1000(t *testing.T) {
+	h, ring := logHandlerFixture(t)
+	for range 100 {
+		seedRecord(ring, slog.LevelInfo, "x")
+	}
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/system/logs?limit=9999", nil))
+	var out []logbuf.Entry
+	json.NewDecoder(rec.Body).Decode(&out)
+	if len(out) > 1000 {
+		t.Fatalf("limit not capped: got %d", len(out))
+	}
+}
+
+func TestLogSetLevel_Valid(t *testing.T) {
+	h, ring := logHandlerFixture(t)
+	body := bytes.NewBufferString(`{"level":"debug"}`)
+	rec := httptest.NewRecorder()
+	h.SetLevel(rec, httptest.NewRequest(http.MethodPut, "/system/loglevel", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if ring.Level() != slog.LevelDebug {
+		t.Errorf("expected ring level=DEBUG, got %s", ring.Level())
+	}
+}
+
+func TestLogSetLevel_Invalid(t *testing.T) {
+	h, _ := logHandlerFixture(t)
+	body := bytes.NewBufferString(`{}`)
+	rec := httptest.NewRecorder()
+	h.SetLevel(rec, httptest.NewRequest(http.MethodPut, "/system/loglevel", body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestLogGetLevel(t *testing.T) {
+	h, ring := logHandlerFixture(t)
+	ring.SetLevel(slog.LevelWarn)
+	rec := httptest.NewRecorder()
+	h.GetLevel(rec, httptest.NewRequest(http.MethodGet, "/system/loglevel", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var out map[string]string
+	json.NewDecoder(rec.Body).Decode(&out)
+	if out["level"] != "WARN" {
+		t.Errorf("expected WARN, got %q", out["level"])
+	}
+}

--- a/internal/logbuf/ring.go
+++ b/internal/logbuf/ring.go
@@ -1,0 +1,247 @@
+// Package logbuf provides an in-process ring buffer for slog records so the
+// UI can surface recent log entries without requiring shell access.
+package logbuf
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const DefaultCapacity = 1000
+
+// Entry is a single log record stored in the ring buffer.
+type Entry struct {
+	Time  time.Time         `json:"time"`
+	Level string            `json:"level"`
+	Msg   string            `json:"msg"`
+	Attrs map[string]string `json:"attrs,omitempty"`
+}
+
+// Ring is a fixed-capacity circular buffer of log entries. It implements
+// slog.Handler so it can be attached directly to the slog pipeline.
+// Oldest entries are silently dropped when the buffer is full.
+type Ring struct {
+	mu       sync.RWMutex
+	entries  []Entry
+	head     int // index of the next write position
+	count    int // number of valid entries (≤ cap)
+	capacity int
+
+	// levelVar gates which records are stored. Changing it at runtime
+	// allows the UI to switch between info/debug without restarting.
+	levelVar atomic.Int64
+
+	// preAttrs are attributes inherited via WithAttrs — stored so that
+	// sub-handlers created by slog can be wrapped cheaply.
+	preAttrs []slog.Attr
+	group    string
+}
+
+// New returns a Ring with the given capacity.
+func New(capacity int) *Ring {
+	if capacity <= 0 {
+		capacity = DefaultCapacity
+	}
+	r := &Ring{
+		entries:  make([]Entry, capacity),
+		capacity: capacity,
+	}
+	r.levelVar.Store(int64(slog.LevelInfo))
+	return r
+}
+
+// SetLevel changes the minimum level that is stored in the ring.
+// Levels below this threshold are passed through to the tee target but
+// not buffered.
+func (r *Ring) SetLevel(l slog.Level) {
+	r.levelVar.Store(int64(l))
+}
+
+// Level returns the current minimum level.
+func (r *Ring) Level() slog.Level {
+	return slog.Level(r.levelVar.Load())
+}
+
+// Snapshot returns a copy of all buffered entries in chronological order
+// (oldest first). The optional minLevel filter excludes entries below the
+// given level; pass slog.LevelDebug-1 to include everything.
+func (r *Ring) Snapshot(minLevel slog.Level, limit int) []Entry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	total := r.count
+	if total == 0 {
+		return nil
+	}
+
+	// Walk entries from oldest to newest.
+	start := 0
+	if r.count == r.capacity {
+		start = r.head // head points at the oldest when buffer is full
+	}
+
+	var out []Entry
+	for i := range total {
+		idx := (start + i) % r.capacity
+		e := r.entries[idx]
+		if slog.Level(levelValue(e.Level)) < minLevel {
+			continue
+		}
+		out = append(out, e)
+	}
+
+	// Apply limit (take the most recent `limit` entries).
+	if limit > 0 && len(out) > limit {
+		out = out[len(out)-limit:]
+	}
+	return out
+}
+
+// slog.Handler implementation ------------------------------------------------
+
+func (r *Ring) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= r.Level()
+}
+
+func (r *Ring) Handle(_ context.Context, rec slog.Record) error {
+	if rec.Level < r.Level() {
+		return nil
+	}
+
+	e := Entry{
+		Time:  rec.Time,
+		Level: rec.Level.String(),
+		Msg:   rec.Message,
+	}
+
+	// Collect pre-attrs + record attrs.
+	var attrs map[string]string
+	addAttr := func(a slog.Attr) bool {
+		if a.Key == "" {
+			return true
+		}
+		if attrs == nil {
+			attrs = make(map[string]string)
+		}
+		attrs[a.Key] = fmt.Sprintf("%v", a.Value.Any())
+		return true
+	}
+	for _, a := range r.preAttrs {
+		addAttr(a)
+	}
+	rec.Attrs(addAttr)
+	e.Attrs = attrs
+
+	r.mu.Lock()
+	r.entries[r.head] = e
+	r.head = (r.head + 1) % r.capacity
+	if r.count < r.capacity {
+		r.count++
+	}
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *Ring) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &attrHandler{ring: r, extra: append(append([]slog.Attr{}, r.preAttrs...), attrs...)}
+}
+
+func (r *Ring) WithGroup(name string) slog.Handler {
+	return &attrHandler{ring: r, group: name, extra: r.preAttrs}
+}
+
+// attrHandler wraps a Ring to inject additional attrs from WithAttrs /
+// WithGroup without allocating a new ring.
+type attrHandler struct {
+	ring  *Ring
+	extra []slog.Attr
+	group string
+}
+
+func (h *attrHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return h.ring.Enabled(ctx, l)
+}
+
+func (h *attrHandler) Handle(ctx context.Context, rec slog.Record) error {
+	// Prepend our extra attrs.
+	r2 := slog.NewRecord(rec.Time, rec.Level, rec.Message, rec.PC)
+	for _, a := range h.extra {
+		r2.AddAttrs(a)
+	}
+	rec.Attrs(func(a slog.Attr) bool {
+		r2.AddAttrs(a)
+		return true
+	})
+	return h.ring.Handle(ctx, r2)
+}
+
+func (h *attrHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &attrHandler{
+		ring:  h.ring,
+		extra: append(append([]slog.Attr{}, h.extra...), attrs...),
+		group: h.group,
+	}
+}
+
+func (h *attrHandler) WithGroup(name string) slog.Handler {
+	return &attrHandler{ring: h.ring, extra: h.extra, group: name}
+}
+
+// Tee -----------------------------------------------------------------------
+
+// Tee is a slog.Handler that writes to two handlers simultaneously —
+// typically the stdout JSONHandler and the Ring buffer.
+type Tee struct {
+	a, b slog.Handler
+}
+
+// NewTee returns a Handler that forwards each record to both a and b.
+func NewTee(a, b slog.Handler) *Tee {
+	return &Tee{a: a, b: b}
+}
+
+func (t *Tee) Enabled(ctx context.Context, level slog.Level) bool {
+	return t.a.Enabled(ctx, level) || t.b.Enabled(ctx, level)
+}
+
+func (t *Tee) Handle(ctx context.Context, rec slog.Record) error {
+	var errA, errB error
+	if t.a.Enabled(ctx, rec.Level) {
+		errA = t.a.Handle(ctx, rec.Clone())
+	}
+	if t.b.Enabled(ctx, rec.Level) {
+		errB = t.b.Handle(ctx, rec.Clone())
+	}
+	if errA != nil {
+		return errA
+	}
+	return errB
+}
+
+func (t *Tee) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &Tee{a: t.a.WithAttrs(attrs), b: t.b.WithAttrs(attrs)}
+}
+
+func (t *Tee) WithGroup(name string) slog.Handler {
+	return &Tee{a: t.a.WithGroup(name), b: t.b.WithGroup(name)}
+}
+
+// levelValue converts a level string back to a numeric value for filtering.
+func levelValue(s string) slog.Level {
+	switch s {
+	case "DEBUG":
+		return slog.LevelDebug
+	case "INFO":
+		return slog.LevelInfo
+	case "WARN":
+		return slog.LevelWarn
+	case "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/logbuf/ring.go
+++ b/internal/logbuf/ring.go
@@ -38,7 +38,6 @@ type Ring struct {
 	// preAttrs are attributes inherited via WithAttrs — stored so that
 	// sub-handlers created by slog can be wrapped cheaply.
 	preAttrs []slog.Attr
-	group    string
 }
 
 // New returns a Ring with the given capacity.

--- a/internal/logbuf/ring_test.go
+++ b/internal/logbuf/ring_test.go
@@ -1,0 +1,201 @@
+package logbuf
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newRecord(level slog.Level, msg string, attrs ...slog.Attr) slog.Record {
+	rec := slog.NewRecord(time.Now(), level, msg, 0)
+	rec.AddAttrs(attrs...)
+	return rec
+}
+
+// TestRing_BasicHandle verifies that Handle stores an entry and Snapshot returns it.
+func TestRing_BasicHandle(t *testing.T) {
+	r := New(10)
+	_ = r.Handle(context.Background(), newRecord(slog.LevelInfo, "hello"))
+
+	entries := r.Snapshot(slog.LevelDebug, 0)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	if entries[0].Msg != "hello" {
+		t.Errorf("want msg %q, got %q", "hello", entries[0].Msg)
+	}
+	if entries[0].Level != "INFO" {
+		t.Errorf("want level INFO, got %q", entries[0].Level)
+	}
+}
+
+// TestRing_Capacity verifies that writing more entries than capacity keeps only
+// the most recent ones (oldest are evicted).
+func TestRing_Capacity(t *testing.T) {
+	r := New(3)
+	for i := range 5 {
+		msg := []string{"a", "b", "c", "d", "e"}[i]
+		_ = r.Handle(context.Background(), newRecord(slog.LevelInfo, msg))
+	}
+
+	entries := r.Snapshot(slog.LevelDebug, 0)
+	if len(entries) != 3 {
+		t.Fatalf("want 3 entries (capacity), got %d", len(entries))
+	}
+	// Should be c, d, e in order
+	want := []string{"c", "d", "e"}
+	for i, e := range entries {
+		if e.Msg != want[i] {
+			t.Errorf("entry[%d]: want %q, got %q", i, want[i], e.Msg)
+		}
+	}
+}
+
+// TestRing_LevelFilter verifies Snapshot filters by minLevel.
+func TestRing_LevelFilter(t *testing.T) {
+	r := New(10)
+	_ = r.Handle(context.Background(), newRecord(slog.LevelDebug, "dbg"))
+	_ = r.Handle(context.Background(), newRecord(slog.LevelInfo, "inf"))
+	_ = r.Handle(context.Background(), newRecord(slog.LevelWarn, "wrn"))
+	_ = r.Handle(context.Background(), newRecord(slog.LevelError, "err"))
+
+	warnAndAbove := r.Snapshot(slog.LevelWarn, 0)
+	if len(warnAndAbove) != 2 {
+		t.Fatalf("want 2 entries >= WARN, got %d", len(warnAndAbove))
+	}
+}
+
+// TestRing_Limit verifies that Snapshot respects the limit parameter.
+func TestRing_Limit(t *testing.T) {
+	r := New(100)
+	for range 50 {
+		_ = r.Handle(context.Background(), newRecord(slog.LevelInfo, "x"))
+	}
+	entries := r.Snapshot(slog.LevelDebug, 10)
+	if len(entries) != 10 {
+		t.Fatalf("want 10, got %d", len(entries))
+	}
+}
+
+// TestRing_Attrs verifies that record attributes are captured.
+func TestRing_Attrs(t *testing.T) {
+	r := New(10)
+	_ = r.Handle(context.Background(), newRecord(slog.LevelInfo, "msg",
+		slog.String("key", "val"),
+	))
+	entries := r.Snapshot(slog.LevelDebug, 0)
+	if entries[0].Attrs["key"] != "val" {
+		t.Errorf("want attrs[key]=val, got %q", entries[0].Attrs["key"])
+	}
+}
+
+// TestRing_Enabled verifies the level gate.
+func TestRing_Enabled(t *testing.T) {
+	r := New(10)
+	r.SetLevel(slog.LevelWarn)
+
+	if r.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("INFO should not be enabled when level=WARN")
+	}
+	if !r.Enabled(context.Background(), slog.LevelError) {
+		t.Error("ERROR should be enabled when level=WARN")
+	}
+
+	// Below-threshold records must not be stored.
+	_ = r.Handle(context.Background(), newRecord(slog.LevelInfo, "should not store"))
+	if len(r.Snapshot(slog.LevelDebug, 0)) != 0 {
+		t.Error("INFO record should not be stored when ring level=WARN")
+	}
+}
+
+// TestRing_SetLevel verifies that SetLevel takes effect immediately.
+func TestRing_SetLevel(t *testing.T) {
+	r := New(10)
+	r.SetLevel(slog.LevelWarn)
+	_ = r.Handle(context.Background(), newRecord(slog.LevelInfo, "before"))
+	r.SetLevel(slog.LevelInfo)
+	_ = r.Handle(context.Background(), newRecord(slog.LevelInfo, "after"))
+
+	entries := r.Snapshot(slog.LevelDebug, 0)
+	if len(entries) != 1 || entries[0].Msg != "after" {
+		t.Errorf("want 1 entry 'after', got %v", entries)
+	}
+}
+
+// TestRing_Concurrent verifies there are no data races under concurrent writes.
+func TestRing_Concurrent(t *testing.T) {
+	r := New(50)
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				_ = r.Handle(context.Background(), newRecord(slog.LevelInfo, "concurrent"))
+			}
+		}()
+	}
+	wg.Wait()
+	entries := r.Snapshot(slog.LevelDebug, 0)
+	if len(entries) > 50 {
+		t.Errorf("capacity exceeded: got %d entries", len(entries))
+	}
+}
+
+// TestTee_BothHandlersReceiveRecords verifies Tee fans out to both targets.
+func TestTee_BothHandlersReceiveRecords(t *testing.T) {
+	a := New(10)
+	b := New(10)
+	tee := NewTee(a, b)
+
+	rec := newRecord(slog.LevelInfo, "broadcast")
+	if err := tee.Handle(context.Background(), rec); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range []*Ring{a, b} {
+		entries := r.Snapshot(slog.LevelDebug, 0)
+		if len(entries) != 1 || entries[0].Msg != "broadcast" {
+			t.Errorf("ring missing entry: got %v", entries)
+		}
+	}
+}
+
+// TestTee_Enabled is true when either handler is enabled.
+func TestTee_Enabled(t *testing.T) {
+	a := New(10)
+	a.SetLevel(slog.LevelError)
+	b := New(10)
+	b.SetLevel(slog.LevelDebug)
+	tee := NewTee(a, b)
+
+	if !tee.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("Tee should be enabled for INFO when b accepts DEBUG+")
+	}
+}
+
+// TestRing_WithAttrs verifies attrs injected via WithAttrs appear on entries.
+func TestRing_WithAttrs(t *testing.T) {
+	r := New(10)
+	child := r.WithAttrs([]slog.Attr{slog.String("service", "bindery")})
+	_ = child.Handle(context.Background(), newRecord(slog.LevelInfo, "msg"))
+
+	entries := r.Snapshot(slog.LevelDebug, 0)
+	if len(entries) == 0 {
+		t.Fatal("no entries")
+	}
+	if entries[0].Attrs["service"] != "bindery" {
+		t.Errorf("want service=bindery, got %q", entries[0].Attrs["service"])
+	}
+}
+
+// TestRing_EmptySnapshot verifies Snapshot returns nil (not a panic) when empty.
+func TestRing_EmptySnapshot(t *testing.T) {
+	r := New(10)
+	entries := r.Snapshot(slog.LevelDebug, 0)
+	if entries != nil {
+		t.Errorf("want nil for empty ring, got %v", entries)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -42,6 +42,14 @@ export const api = {
   // System
   health: () => request<{ status: string; version: string }>('/health'),
   status: () => request<{ version: string; commit: string; buildDate: string }>('/system/status'),
+  getLogs: (level?: string, limit?: number) =>
+    request<LogEntry[]>(`/system/logs${level || limit ? '?' + new URLSearchParams({
+      ...(level ? { level } : {}),
+      ...(limit ? { limit: String(limit) } : {}),
+    }) : ''}`),
+  getLogLevel: () => request<{ level: string }>('/system/loglevel'),
+  setLogLevel: (level: string) =>
+    request<{ level: string }>('/system/loglevel', { method: 'PUT', body: JSON.stringify({ level }) }),
 
   // Auth
   authStatus: () => request<AuthStatus>('/auth/status'),
@@ -489,6 +497,13 @@ export interface RootFolder {
   path: string
   freeSpace: number
   createdAt: string
+}
+
+export interface LogEntry {
+  time: string
+  level: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
+  msg: string
+  attrs?: Record<string, string>
 }
 
 export type AuthorBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search'

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,9 +1,9 @@
-import { FormEvent, useEffect, useState } from 'react'
-import { api, AuthConfig, AuthStatus, Indexer, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, RootFolder } from '../api/client'
+import { FormEvent, useEffect, useRef, useState } from 'react'
+import { api, AuthConfig, AuthStatus, Indexer, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, RootFolder, LogEntry } from '../api/client'
 import ThemeToggle from '../components/ThemeToggle'
 import { useAuth } from '../auth/AuthContext'
 
-type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import' | 'rootfolders'
+type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import' | 'rootfolders' | 'logs'
 
 const inputCls = 'w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600'
 const tabCls = (active: boolean) =>
@@ -25,6 +25,13 @@ export default function SettingsPage() {
   const [editingIndexer, setEditingIndexer] = useState<number | null>(null)
   const [editingClient, setEditingClient] = useState<number | null>(null)
   const [editingNotification, setEditingNotification] = useState<number | null>(null)
+  const [logEntries, setLogEntries] = useState<LogEntry[]>([])
+  const [logLevel, setLogLevel] = useState<string>('info')
+  const [logFilter, setLogFilter] = useState<string>('all')
+  const [logAutoRefresh, setLogAutoRefresh] = useState(true)
+  const logBottomRef = useRef<HTMLDivElement>(null)
+  const logAutoRefreshRef = useRef(logAutoRefresh)
+  logAutoRefreshRef.current = logAutoRefresh
 
   useEffect(() => {
     api.listIndexers().then(setIndexers).catch(console.error)
@@ -36,6 +43,21 @@ export default function SettingsPage() {
     if (tab === 'quality') api.listQualityProfiles().then(setQualityProfiles).catch(console.error)
     if (tab === 'metadata') api.listMetadataProfiles().then(setMetadataProfiles).catch(console.error)
     if (tab === 'rootfolders') api.listRootFolders().then(setRootFolders).catch(console.error)
+    if (tab === 'logs') {
+      api.getLogLevel().then(r => setLogLevel(r.level.toLowerCase())).catch(console.error)
+      api.getLogs(undefined, 200).then(setLogEntries).catch(console.error)
+    }
+  }, [tab])
+
+  // Auto-refresh logs every 5 s while the tab is active.
+  useEffect(() => {
+    if (tab !== 'logs') return
+    const id = setInterval(() => {
+      if (logAutoRefreshRef.current) {
+        api.getLogs(undefined, 200).then(setLogEntries).catch(console.error)
+      }
+    }, 5000)
+    return () => clearInterval(id)
   }, [tab])
 
   function formatBytes(bytes: number): string {
@@ -50,7 +72,7 @@ export default function SettingsPage() {
       <h2 className="text-2xl font-bold mb-6">Settings</h2>
 
       <div className="flex flex-wrap gap-2 mb-6">
-        {(['indexers', 'clients', 'notifications', 'quality', 'metadata', 'import', 'rootfolders', 'general'] as Tab[]).map(t => (
+        {(['indexers', 'clients', 'notifications', 'quality', 'metadata', 'import', 'rootfolders', 'logs', 'general'] as Tab[]).map(t => (
           <button key={t} onClick={() => setTab(t)} className={tabCls(tab === t)}>
             {t === 'indexers' ? 'Indexers'
               : t === 'clients' ? 'Download Clients'
@@ -59,6 +81,7 @@ export default function SettingsPage() {
               : t === 'metadata' ? 'Metadata Profiles'
               : t === 'import' ? 'Import'
               : t === 'rootfolders' ? 'Root Folders'
+              : t === 'logs' ? 'Logs'
               : 'General'}
           </button>
         ))}
@@ -417,6 +440,113 @@ export default function SettingsPage() {
               Add Folder
             </button>
           </form>
+        </div>
+      )}
+
+      {tab === 'logs' && (
+        <div>
+          {/* Toolbar */}
+          <div className="flex flex-wrap items-center gap-3 mb-4">
+            <h3 className="text-lg font-semibold mr-auto">Logs</h3>
+
+            {/* Level filter (display) */}
+            <div className="flex items-center gap-1.5 text-xs">
+              {(['all', 'info', 'warn', 'error'] as const).map(f => (
+                <button
+                  key={f}
+                  onClick={() => setLogFilter(f)}
+                  className={`px-2.5 py-1 rounded font-medium transition-colors ${logFilter === f
+                    ? f === 'error' ? 'bg-red-600 text-white'
+                      : f === 'warn' ? 'bg-amber-500 text-white'
+                      : 'bg-slate-700 dark:bg-zinc-600 text-white'
+                    : 'bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white'}`}
+                >
+                  {f.toUpperCase()}
+                </button>
+              ))}
+            </div>
+
+            {/* Runtime log level */}
+            <div className="flex items-center gap-2 text-xs">
+              <span className="text-slate-500 dark:text-zinc-500">Level:</span>
+              <select
+                value={logLevel}
+                onChange={async e => {
+                  const l = e.target.value
+                  await api.setLogLevel(l).catch(console.error)
+                  setLogLevel(l)
+                }}
+                className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-2 py-1 text-xs"
+              >
+                {['debug', 'info', 'warn', 'error'].map(l => (
+                  <option key={l} value={l}>{l.toUpperCase()}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Auto-refresh toggle */}
+            <button
+              onClick={() => setLogAutoRefresh(v => !v)}
+              className={`text-xs px-2.5 py-1 rounded border transition-colors ${logAutoRefresh
+                ? 'border-emerald-500 text-emerald-600 dark:text-emerald-400'
+                : 'border-slate-300 dark:border-zinc-700 text-slate-500 dark:text-zinc-500'}`}
+            >
+              {logAutoRefresh ? '⏸ Auto' : '▶ Auto'}
+            </button>
+
+            <button
+              onClick={() => api.getLogs(undefined, 200).then(setLogEntries).catch(console.error)}
+              className="text-xs px-2.5 py-1 rounded border border-slate-300 dark:border-zinc-700 text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white"
+            >
+              Refresh
+            </button>
+          </div>
+
+          {/* Log output */}
+          <div className="font-mono text-xs bg-slate-950 dark:bg-black rounded-lg border border-slate-800 dark:border-zinc-900 overflow-auto max-h-[60vh]">
+            {logEntries.filter(e => {
+              if (logFilter === 'all') return true
+              if (logFilter === 'error') return e.level === 'ERROR'
+              if (logFilter === 'warn') return e.level === 'WARN' || e.level === 'ERROR'
+              return true // 'info' shows everything already filtered by API
+            }).length === 0 ? (
+              <p className="text-zinc-600 p-4 text-center">No log entries</p>
+            ) : (
+              <table className="w-full border-collapse">
+                <tbody>
+                  {logEntries
+                    .filter(e => {
+                      if (logFilter === 'all') return true
+                      if (logFilter === 'error') return e.level === 'ERROR'
+                      if (logFilter === 'warn') return e.level === 'WARN' || e.level === 'ERROR'
+                      return true
+                    })
+                    .map((e, i) => {
+                      const levelCls =
+                        e.level === 'ERROR' ? 'text-red-400' :
+                        e.level === 'WARN'  ? 'text-amber-400' :
+                        e.level === 'DEBUG' ? 'text-zinc-500' :
+                        'text-emerald-400'
+                      const ts = new Date(e.time).toLocaleTimeString('en-GB', { hour12: false })
+                      const attrStr = e.attrs ? Object.entries(e.attrs).map(([k, v]) => `${k}=${v}`).join(' ') : ''
+                      return (
+                        <tr key={i} className="border-b border-zinc-900 hover:bg-zinc-900/50">
+                          <td className="pl-3 pr-2 py-0.5 text-zinc-600 whitespace-nowrap w-20">{ts}</td>
+                          <td className={`pr-2 py-0.5 whitespace-nowrap w-12 font-semibold ${levelCls}`}>{e.level}</td>
+                          <td className="pr-2 py-0.5 text-zinc-200 break-all">{e.msg}</td>
+                          {attrStr && <td className="pr-3 py-0.5 text-zinc-500 break-all">{attrStr}</td>}
+                        </tr>
+                      )
+                    })}
+                </tbody>
+              </table>
+            )}
+            <div ref={logBottomRef} />
+          </div>
+          <p className="text-xs text-slate-500 dark:text-zinc-600 mt-2">
+            Shows the most recent 200 entries from the in-process ring buffer (last 1 000 entries).
+            Logs reset on restart. Change <strong>Level</strong> above to capture DEBUG output without restarting.
+          </p>
         </div>
       )}
 


### PR DESCRIPTION
Closes #93.

## Summary

- **`internal/logbuf`** — new package: thread-safe ring buffer (`slog.Handler`) with 1 000-entry capacity, `Snapshot(minLevel, limit)`, `SetLevel` for runtime level changes, and a `Tee` handler that fans each record to stdout JSON *and* the ring simultaneously — no log entries lost to the buffer, every record still appears in `docker logs`
- **API** — `GET /api/v1/system/logs?level=&limit=` returns a JSON array of `{time, level, msg, attrs}`; `GET/PUT /api/v1/system/loglevel` reads and changes the runtime threshold without a process restart
- **`cmd/bindery/main.go`** — replaces `slog.NewJSONHandler(os.Stdout, …)` with `logbuf.NewTee(stdoutHandler, ring)`; both handlers see every record
- **Settings → Logs tab** — 200-entry table colour-coded by severity, WARN/ERROR display filters, 5 s auto-refresh toggle, manual Refresh button, runtime Level selector that calls `PUT /system/loglevel` immediately
- **Docs** — CHANGELOG Unreleased entry, README Operations bullet, ROADMAP v2 horizon section (persistent log store, multi-user, OIDC, external DB), Troubleshooting wiki page gains a "Diagnosing with the log viewer" lead section

## Design notes

The ring buffer is intentionally **in-process and non-persistent** for v1 — zero dependencies, zero schema changes, resets on restart. The ROADMAP v2 section captures the path to a persistent store when that becomes a real need.

`SetLevel` changes the ring's storage threshold at runtime; the stdout handler's level is set at startup and is not changed (stdout always sees INFO+ as configured). This means switching to DEBUG in the UI captures verbose data in the buffer without flooding `docker logs`.

## Test plan

- [ ] `go test ./internal/logbuf/... -race` — 12 tests including concurrent writes
- [ ] `go test ./internal/api/... -run TestLog` — 8 handler tests
- [ ] Settings → Logs: entries appear, auto-refresh works, WARN filter hides INFO rows
- [ ] Change Level to DEBUG, trigger an author refresh, verify DEBUG rows appear
- [ ] Change Level back to INFO, verify DEBUG rows stop appearing