### PR TITLE
test(security): cover SSRF public API, notifier wiring, upload temp dir

### DIFF
--- a/internal/api/migrate_test.go
+++ b/internal/api/migrate_test.go
@@ -7,6 +7,8 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
@@ -108,6 +110,29 @@ func TestMigrate_ImportReadarr_BadMultipart(t *testing.T) {
 	h.ImportReadarr(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("non-multipart: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestUploadTempDir_NoEnv(t *testing.T) {
+	t.Setenv("BINDERY_DB_PATH", "")
+	if got := uploadTempDir(); got != "" {
+		t.Errorf("no env: want empty, got %q", got)
+	}
+}
+
+func TestUploadTempDir_CreatesDirNextToDB(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "bindery.db")
+	t.Setenv("BINDERY_DB_PATH", dbPath)
+
+	got := uploadTempDir()
+	want := filepath.Join(root, "tmp")
+	if got != want {
+		t.Errorf("path: want %q, got %q", want, got)
+	}
+	// Must exist (MkdirAll).
+	if st, err := os.Stat(got); err != nil || !st.IsDir() {
+		t.Errorf("expected dir at %q (err=%v)", got, err)
 	}
 }
 

--- a/internal/httpsec/ssrf_test.go
+++ b/internal/httpsec/ssrf_test.go
@@ -204,3 +204,64 @@ func TestValidateOutboundURL_PublicAllowed(t *testing.T) {
 		t.Errorf("unexpected block for public IP: %v", err)
 	}
 }
+
+// TestValidateOutboundURL_Exported exercises the public entrypoint, which in
+// turn drives the live netResolver. "localhost" is resolved from the local
+// hosts file on every supported platform, so this runs without network access.
+func TestValidateOutboundURL_Exported(t *testing.T) {
+	// Live resolver should resolve "localhost" to 127.0.0.1 / ::1 and the
+	// loopback check should reject it under both policies.
+	if err := ValidateOutboundURL("http://localhost/", PolicyStrict); err == nil {
+		t.Error("expected block for localhost under strict")
+	}
+	if err := ValidateOutboundURL("http://localhost/", PolicyLAN); err == nil {
+		t.Error("expected block for localhost under LAN")
+	}
+}
+
+func TestValidateOutboundURL_BadURL(t *testing.T) {
+	// url.Parse rejects control chars in the URL.
+	if err := ValidateOutboundURL("http://example.com/\x7f", PolicyStrict); err == nil {
+		t.Error("expected error for malformed URL")
+	}
+	// Missing host.
+	if err := ValidateOutboundURL("http:///path", PolicyStrict); err == nil {
+		t.Error("expected error for URL without host")
+	}
+}
+
+func TestValidateOutboundURL_DNSFailure(t *testing.T) {
+	// An unreachable/nonexistent hostname must be rejected (fail-closed).
+	r := fakeResolver{m: map[string][]net.IP{}}
+	if err := validate("http://nope.invalid/", PolicyStrict, r); err == nil {
+		t.Error("expected DNS failure to reject the URL")
+	}
+}
+
+func TestPolicyFromEnv(t *testing.T) {
+	const key = "BINDERY_TEST_SSRF_POLICY"
+
+	// Unset → default preserved.
+	t.Setenv(key, "")
+	if got := PolicyFromEnv(PolicyStrict, key); got != PolicyStrict {
+		t.Errorf("unset: want PolicyStrict, got %v", got)
+	}
+
+	// "1" → LAN.
+	t.Setenv(key, "1")
+	if got := PolicyFromEnv(PolicyStrict, key); got != PolicyLAN {
+		t.Errorf("'1': want PolicyLAN, got %v", got)
+	}
+
+	// "true" (case-insensitive) → LAN.
+	t.Setenv(key, "TRUE")
+	if got := PolicyFromEnv(PolicyStrict, key); got != PolicyLAN {
+		t.Errorf("'TRUE': want PolicyLAN, got %v", got)
+	}
+
+	// Any other value → default.
+	t.Setenv(key, "maybe")
+	if got := PolicyFromEnv(PolicyStrict, key); got != PolicyStrict {
+		t.Errorf("'maybe': want PolicyStrict, got %v", got)
+	}
+}

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -219,6 +219,52 @@ func TestTest_Failure(t *testing.T) {
 	}
 }
 
+func TestNew_DefaultValidator(t *testing.T) {
+	// New() wires in the production SSRF validator (strict policy). Confirm
+	// that a loopback URL is rejected, proving the validator is plumbed.
+	n := New(nil)
+	if n == nil {
+		t.Fatal("New returned nil")
+	}
+	if n.validate == nil {
+		t.Fatal("New did not install a validator")
+	}
+	if err := n.validate("http://127.0.0.1/hook"); err == nil {
+		t.Error("default validator should reject loopback")
+	}
+}
+
+func TestSetValidator_Override(t *testing.T) {
+	n := New(nil)
+	called := 0
+	n.SetValidator(func(string) error {
+		called++
+		return nil
+	})
+	// send() with a no-op validator should now accept loopback.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	notif := &models.Notification{URL: srv.URL}
+	if err := n.send(context.Background(), notif, map[string]interface{}{}); err != nil {
+		t.Fatalf("send with override: %v", err)
+	}
+	if called != 1 {
+		t.Errorf("overridden validator calls: want 1, got %d", called)
+	}
+}
+
+func TestSend_ValidatorRejects(t *testing.T) {
+	// send() must return the validator's error without making an HTTP call.
+	n := New(nil)
+	// Point at a public URL so only the validator rejection path fires.
+	notif := &models.Notification{URL: "http://10.0.0.1/hook"} // RFC1918 → strict rejects
+	if err := n.send(context.Background(), notif, map[string]interface{}{}); err == nil {
+		t.Fatal("expected validator to reject RFC1918 under strict policy")
+	}
+}
+
 func TestUserAgentHeader(t *testing.T) {
 	var gotUA string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Raises test coverage on v0.12.0 security code to keep codecov happy post-merge.

- **httpsec** 74.2% → 97.0% — tests the public `ValidateOutboundURL` entrypoint (including the live `netResolver` via `localhost`), `PolicyFromEnv` env parsing, URL-parse failures, and the fail-closed DNS-failure path.
- **notifier** 62.3% → 73.6% — tests `New()` installs a working strict-policy validator, `SetValidator` overrides it, and `send()` short-circuits on validator rejection before any HTTP call.
- **api/migrate** — tests `uploadTempDir` in both branches (no env, env set → dir created next to DB).

No production code changes.

## Test plan

- [x] `go test ./internal/httpsec/... ./internal/notifier/... ./internal/api/...` — all pass
- [x] Coverage deltas verified locally
- [ ] CI green