### PR TITLE
fix(search): return 502 on metadata provider failures, not 500 (#91)

### DIFF
--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -15,6 +15,16 @@ func NewSearchHandler(meta *metadata.Aggregator) *SearchHandler {
 	return &SearchHandler{meta: meta}
 }
 
+// writeUpstreamError responds with 502 Bad Gateway and a message that makes
+// it obvious the failure is on the metadata provider side (OpenLibrary,
+// Google Books, Hardcover), not inside Bindery. Using 500 for this conflates
+// provider outages with real server bugs and trains users to ignore 500s.
+func writeUpstreamError(w http.ResponseWriter, err error) {
+	writeJSON(w, http.StatusBadGateway, map[string]string{
+		"error": "metadata provider unavailable: " + err.Error(),
+	})
+}
+
 func (h *SearchHandler) SearchAuthors(w http.ResponseWriter, r *http.Request) {
 	term := r.URL.Query().Get("term")
 	if term == "" {
@@ -24,7 +34,7 @@ func (h *SearchHandler) SearchAuthors(w http.ResponseWriter, r *http.Request) {
 
 	authors, err := h.meta.SearchAuthors(r.Context(), term)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeUpstreamError(w, err)
 		return
 	}
 
@@ -40,7 +50,7 @@ func (h *SearchHandler) SearchBooks(w http.ResponseWriter, r *http.Request) {
 
 	books, err := h.meta.SearchBooks(r.Context(), term)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeUpstreamError(w, err)
 		return
 	}
 
@@ -56,7 +66,7 @@ func (h *SearchHandler) LookupByISBN(w http.ResponseWriter, r *http.Request) {
 
 	book, err := h.meta.GetBookByISBN(r.Context(), isbn)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeUpstreamError(w, err)
 		return
 	}
 	if book == nil {

--- a/internal/api/search_test.go
+++ b/internal/api/search_test.go
@@ -69,8 +69,8 @@ func TestSearchAuthors(t *testing.T) {
 	p.authorsErr = errors.New("upstream down")
 	rec = httptest.NewRecorder()
 	h.SearchAuthors(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/author?term=x", nil))
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("error: expected 500, got %d", rec.Code)
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("error: expected 502, got %d", rec.Code)
 	}
 }
 
@@ -96,8 +96,8 @@ func TestSearchBooks(t *testing.T) {
 	p.booksErr = errors.New("upstream down")
 	rec = httptest.NewRecorder()
 	h.SearchBooks(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/book?term=x", nil))
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("error: expected 500, got %d", rec.Code)
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("error: expected 502, got %d", rec.Code)
 	}
 }
 
@@ -133,7 +133,7 @@ func TestLookupByISBN(t *testing.T) {
 	h3 := NewSearchHandler(metadata.NewAggregator(p3))
 	rec = httptest.NewRecorder()
 	h3.LookupByISBN(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/isbn?isbn=fail", nil))
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("error: expected 500, got %d", rec.Code)
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("error: expected 502, got %d", rec.Code)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #91. When OpenLibrary / Google Books / Hardcover were unreachable, the author-search, book-search, and ISBN-lookup endpoints surfaced the upstream error as HTTP **500 Internal Server Error** with the raw message. Users reasonably interpreted that as a Bindery bug and filed tickets / restarted containers instead of just waiting out the upstream outage.

Now those three handlers return **502 Bad Gateway** with a prefix that names the subsystem:
\`\`\`json
{\"error\":\"metadata provider unavailable: <original message>\"}
\`\`\`
so the UI (and future retries) can distinguish \"our fault\" (500) from \"their fault\" (502).

## Test plan

- [x] \`go test ./internal/api/...\` — updated \`search_test.go\` now asserts 502 on the error branches
- [ ] Manual: kill network, hit \`/api/v1/search/author?term=x\`, confirm 502 with the new message prefix