### PR TITLE
fix(theme): apply dark class in Shell on every mount (closes #109)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import SeriesPage from './pages/SeriesPage'
 import CalendarPage from './pages/CalendarPage'
 import BlocklistPage from './pages/BlocklistPage'
 import Logo from './components/Logo'
+import { useTheme } from './theme'
 
 const NAV_KEYS = [
   { to: '/', key: 'authors', end: true },
@@ -32,6 +33,7 @@ const NAV_KEYS = [
 ]
 
 function Shell() {
+  useTheme() // ensures dark class is applied on every mount, not only when Settings is visited
   const { t } = useTranslation()
   const [version, setVersion] = useState('')
   const [menuOpen, setMenuOpen] = useState(false)


### PR DESCRIPTION
## Problem
Dark mode preference was only applied when navigating to **Settings**, because `useTheme()` was called exclusively inside `ThemeToggle`, which only renders in `SettingsPage`. The `index.html` inline script handles the pre-paint case, but if it misses (first visit, localStorage cleared, OS light mode with a saved dark preference from a previous session), the app rendered in light mode until Settings was visited.

## Fix
Add a single `useTheme()` call at the top of `Shell` in `App.tsx`. This ensures React applies the stored preference on every mount regardless of which page the user lands on. The inline script in `index.html` and `ThemeToggle` in Settings are unchanged.

## Files changed
- `web/src/App.tsx` — `useTheme()` in `Shell` (+2 lines)

Closes #109.