### PR TITLE
feat(importer): configurable import mode — move, copy, hardlink (closes #54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,3 +226,21 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - run: npm ci --prefix web
       - run: npm run build --prefix web
+
+  # Post-deploy smoke test: boot the real binary against a scratch data dir
+  # and hit the golden-path endpoints. Catches wiring regressions (bad route
+  # registration, missing migration, broken frontend embed) that unit tests
+  # can't see. Runs on PRs and main/development pushes.
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.9"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: make smoke

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,4 +156,4 @@ The `[skip ci]` trailer is reserved for bot deploy-commits — human commits sho
 
 ## Reporting security issues
 
-Do **not** open a public issue for security vulnerabilities. Email the maintainer privately via the address on the [GitHub profile](https://github.com/vavallee). Expect an acknowledgement within a few days and a coordinated disclosure window.
+Do **not** open a public issue for security vulnerabilities. The preferred channel is a [GitHub Security Advisory](https://github.com/vavallee/bindery/security/advisories/new) — it creates a private thread with the maintainers. Full disclosure policy, scope, and timelines live in [SECURITY.md](SECURITY.md).

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build dev test lint clean docker-build web-build web-dev help security helm-lint sbom
+.PHONY: build dev test lint clean docker-build web-build web-dev help security helm-lint sbom smoke
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -21,8 +21,8 @@ web-dev: ## Run frontend dev server
 web-build: ## Build frontend for embedding
 	cd web && npm ci && npm run build
 
-test: ## Run all tests
-	go test -race -coverprofile=coverage.out -covermode=atomic ./...
+test: ## Run unit tests (use `make smoke` for the HTTP-level smoke suite)
+	go test -race -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
 
 test-web: ## Run frontend tests
 	cd web && npm test -- --coverage
@@ -64,6 +64,9 @@ helm-lint: ## Lint Helm chart + run helm-unittest cases
 	@if command -v helm-unittest >/dev/null || helm plugin list 2>/dev/null | grep -q unittest; then \
 	 helm unittest charts/bindery/; else \
 	 echo "helm-unittest not installed; install with: helm plugin install https://github.com/helm-unittest/helm-unittest"; fi
+
+smoke: build ## Boot the real binary and exercise the critical golden paths via HTTP
+	go test -count=1 -timeout=60s ./tests/smoke/...
 
 sbom: build ## Generate an SPDX SBOM for the local binary
 	@command -v syft >/dev/null || (echo "syft not installed; see https://github.com/anchore/syft"; exit 1)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,8 +69,8 @@ CSP, cookie Secure auto-detect, container hardening, CI scans).
 
 ## Security controls currently in place
 
-- **Authentication**: API key + signed session cookie + bcrypt passwords +
-  per-IP login rate limit.
+- **Authentication**: API key + signed session cookie + argon2id passwords
+  (OWASP 2024 parameters) + per-IP login rate limit.
 - **SSRF**: outbound URLs for webhooks, indexers, and download clients pass
   through `internal/httpsec.ValidateOutboundURL` with policy-based blocking
   of loopback, link-local, cloud-metadata endpoints, and (for webhooks)
@@ -95,6 +95,6 @@ CSP, cookie Secure auto-detect, container hardening, CI scans).
 
 ## Secrets
 
-Never file a public issue containing a session cookie, API key, or bcrypt
+Never file a public issue containing a session cookie, API key, or password
 hash from a real deployment. If you need to share one to reproduce a bug,
 use the private advisory channel.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -214,6 +214,8 @@ Multiple remaps are separated by commas: `BINDERY_DOWNLOAD_PATH_REMAP=/sab/compl
 | `BINDERY_DOWNLOAD_PATH_REMAP` | _(empty)_ | Comma-separated `from:to` pairs rewriting paths reported by the download client into paths Bindery can access. Required when SABnzbd and Bindery mount the same storage at different paths. Longest-prefix match wins. See [Path remapping](#path-remapping-multi-container--multi-pod-setups). |
 | `BINDERY_PUID` | _(unset)_ | Sanity check — see [Running as a specific UID/GID](#running-as-a-specific-uidgid) |
 | `BINDERY_PGID` | _(unset)_ | Sanity check — same as `BINDERY_PUID` for the primary GID |
+| `BINDERY_COOKIE_SECURE` | `auto` | Session cookie `Secure` flag policy. `auto` (default) flips the flag on when TLS is detected directly or via `X-Forwarded-Proto: https`; `always` forces it on (use when your reverse proxy doesn't forward the header); `never` forces it off (legacy plain-HTTP installs). |
+| `BINDERY_NOTIFICATIONS_ALLOW_PRIVATE` | _(unset)_ | Set to `1` to flip outbound webhook SSRF policy from Strict to LAN, allowing RFC1918 targets. Use when ntfy / Home Assistant / Gotify live on your private network. Loopback, link-local, and cloud-metadata endpoints stay blocked. |
 
 ## First-run setup
 
@@ -229,6 +231,55 @@ On first launch Bindery bootstraps itself — **no environment variables are req
 - `disabled` — no auth at all. Only safe behind a trusted reverse proxy that handles authentication upstream.
 
 ## Upgrading
+
+### From v0.11.x to v0.12.0 (security posture)
+
+**Schema:** no changes. Drop-in binary or image replacement is safe.
+
+**Auth hashing note.** If a very old install predates argon2id (unlikely — argon2id has been the only code path since v0.6.0), log in and change your password to trigger a rehash. All current installs are already on argon2id.
+
+**New env vars (both optional, documented above):**
+
+- `BINDERY_COOKIE_SECURE` — defaults to `auto`. Existing deployments behind Traefik / Caddy / nginx that forward `X-Forwarded-Proto: https` need no action; the cookie now correctly sets `Secure`. Plain-HTTP homelab users on a LAN may need `BINDERY_COOKIE_SECURE=never` if browsers start rejecting the cookie.
+- `BINDERY_NOTIFICATIONS_ALLOW_PRIVATE=1` — required if you notify an on-LAN ntfy / Home Assistant / Gotify. Without it, webhook URLs resolving to RFC1918 are rejected at submit time.
+
+**Helm chart (optional but recommended).** New `auth.existingSecret` / `auth.apiKey` value keys render the API key via a Kubernetes Secret instead of a plain env value. Existing releases keep working with the old `env.BINDERY_API_KEY` pattern, but migrating is a one-line upgrade:
+
+```yaml
+auth:
+  existingSecret: my-bindery-secret  # kubectl create secret generic my-bindery-secret --from-literal=apiKey=...
+```
+
+**Response headers.** Every response now sets CSP, `X-Frame-Options: DENY`, `Referrer-Policy`, and — when TLS is in play — HSTS. If you previously embedded the Bindery UI in an `<iframe>`, `X-Frame-Options: DENY` will block it. No such usage is supported, but it's the most likely breakage vector.
+
+### From v0.10.x to v0.11.0
+
+**Schema:** no changes. Drop-in binary or image replacement is safe.
+
+**New features, no action required:**
+
+- **In-process log viewer** at Settings → Logs (last 1 000 entries, colour-coded, DEBUG toggle without restart).
+- **UI localization** — English / French / German / Dutch. Auto-detects from `Accept-Language`; override in Settings → General → Language.
+- **Root folders** — configure multiple library roots under Settings → Root Folders. Existing single-root installs keep using `BINDERY_LIBRARY_DIR` as the default.
+- **Language propagation** — per-author metadata-profile language filters now ride into indexer queries.
+
+### From v0.9.x to v0.10.0 (dual-format)
+
+**Schema:** migration `012_dual_format.sql` adds `ebook_file_path`, `audiobook_file_path`, and `media_type` columns to `books` and copies existing `file_path` data into `ebook_file_path`. Non-destructive; `file_path` is kept for one release as a fallback.
+
+**Existing single-format downloads** show up in the correct format slot after the migration runs on startup — no manual action needed. A book with an imported ebook will not re-queue the ebook on the next sweep but will still search for a missing audiobook.
+
+### From v0.8.x to v0.9.0 (Calibre modes, OPDS, auto-grab kill-switch)
+
+**Schema:** three additive migrations (`010_calibre_sync.sql`, `011_calibre_mode.sql`, new `editions` table). Drop-in safe.
+
+**Calibre mode defaults to Off.** Existing installs that used the v0.8.0 `calibre.enabled=true` boolean are automatically shown as **calibredb CLI** mode in the UI via a back-compat fallback — no re-configuration needed.
+
+**Auto-grab defaults to On** (existing behaviour). Toggle it off in Settings → General → Auto-grab if you prefer manual grabs, or when bulk-adding large author lists that would otherwise fire thousands of simultaneous indexer queries.
+
+**OPDS** is available at `/opds/` — browse and download your library from KOReader / Moon+ Reader / Aldiko. Authenticates via Bindery username + password over HTTP Basic, or via `X-Api-Key` / `?apikey=` query parameter for scripts. See the [OPDS wiki page](https://github.com/vavallee/bindery/wiki/OPDS).
+
+**Behaviour change — catalogue fetch decoupled from auto-grab.** Unchecking "Auto-grab books on add" no longer silently prevents the book catalogue from loading. The full book list is always fetched; the checkbox only controls whether Bindery immediately sends results to the download client.
 
 ### From v0.7.x to v0.8.0
 

--- a/internal/api/migrate_test.go
+++ b/internal/api/migrate_test.go
@@ -7,6 +7,8 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
@@ -108,6 +110,29 @@ func TestMigrate_ImportReadarr_BadMultipart(t *testing.T) {
 	h.ImportReadarr(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("non-multipart: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestUploadTempDir_NoEnv(t *testing.T) {
+	t.Setenv("BINDERY_DB_PATH", "")
+	if got := uploadTempDir(); got != "" {
+		t.Errorf("no env: want empty, got %q", got)
+	}
+}
+
+func TestUploadTempDir_CreatesDirNextToDB(t *testing.T) {
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "bindery.db")
+	t.Setenv("BINDERY_DB_PATH", dbPath)
+
+	got := uploadTempDir()
+	want := filepath.Join(root, "tmp")
+	if got != want {
+		t.Errorf("path: want %q, got %q", want, got)
+	}
+	// Must exist (MkdirAll).
+	if st, err := os.Stat(got); err != nil || !st.IsDir() {
+		t.Errorf("expected dir at %q (err=%v)", got, err)
 	}
 }
 

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -15,6 +15,16 @@ func NewSearchHandler(meta *metadata.Aggregator) *SearchHandler {
 	return &SearchHandler{meta: meta}
 }
 
+// writeUpstreamError responds with 502 Bad Gateway and a message that makes
+// it obvious the failure is on the metadata provider side (OpenLibrary,
+// Google Books, Hardcover), not inside Bindery. Using 500 for this conflates
+// provider outages with real server bugs and trains users to ignore 500s.
+func writeUpstreamError(w http.ResponseWriter, err error) {
+	writeJSON(w, http.StatusBadGateway, map[string]string{
+		"error": "metadata provider unavailable: " + err.Error(),
+	})
+}
+
 func (h *SearchHandler) SearchAuthors(w http.ResponseWriter, r *http.Request) {
 	term := r.URL.Query().Get("term")
 	if term == "" {
@@ -24,7 +34,7 @@ func (h *SearchHandler) SearchAuthors(w http.ResponseWriter, r *http.Request) {
 
 	authors, err := h.meta.SearchAuthors(r.Context(), term)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeUpstreamError(w, err)
 		return
 	}
 
@@ -40,7 +50,7 @@ func (h *SearchHandler) SearchBooks(w http.ResponseWriter, r *http.Request) {
 
 	books, err := h.meta.SearchBooks(r.Context(), term)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeUpstreamError(w, err)
 		return
 	}
 
@@ -56,7 +66,7 @@ func (h *SearchHandler) LookupByISBN(w http.ResponseWriter, r *http.Request) {
 
 	book, err := h.meta.GetBookByISBN(r.Context(), isbn)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeUpstreamError(w, err)
 		return
 	}
 	if book == nil {

--- a/internal/api/search_test.go
+++ b/internal/api/search_test.go
@@ -69,8 +69,8 @@ func TestSearchAuthors(t *testing.T) {
 	p.authorsErr = errors.New("upstream down")
 	rec = httptest.NewRecorder()
 	h.SearchAuthors(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/author?term=x", nil))
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("error: expected 500, got %d", rec.Code)
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("error: expected 502, got %d", rec.Code)
 	}
 }
 
@@ -96,8 +96,8 @@ func TestSearchBooks(t *testing.T) {
 	p.booksErr = errors.New("upstream down")
 	rec = httptest.NewRecorder()
 	h.SearchBooks(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/book?term=x", nil))
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("error: expected 500, got %d", rec.Code)
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("error: expected 502, got %d", rec.Code)
 	}
 }
 
@@ -133,7 +133,7 @@ func TestLookupByISBN(t *testing.T) {
 	h3 := NewSearchHandler(metadata.NewAggregator(p3))
 	rec = httptest.NewRecorder()
 	h3.LookupByISBN(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/isbn?isbn=fail", nil))
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("error: expected 500, got %d", rec.Code)
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("error: expected 502, got %d", rec.Code)
 	}
 }

--- a/internal/db/migrations/013_import_mode.sql
+++ b/internal/db/migrations/013_import_mode.sql
@@ -1,0 +1,10 @@
+-- +migrate Up
+
+-- Import mode controls how Bindery places completed downloads into the library.
+-- "move"     — rename/move the file (existing behaviour, source is removed)
+-- "copy"     — copy file to library, source remains (seeding continues, double disk use)
+-- "hardlink" — hard-link file into library, source inode is shared (zero extra disk, seeding continues)
+INSERT OR IGNORE INTO settings (key, value) VALUES ('import.mode', 'move');
+
+-- +migrate Down
+DELETE FROM settings WHERE key = 'import.mode';

--- a/internal/httpsec/ssrf_test.go
+++ b/internal/httpsec/ssrf_test.go
@@ -204,3 +204,64 @@ func TestValidateOutboundURL_PublicAllowed(t *testing.T) {
 		t.Errorf("unexpected block for public IP: %v", err)
 	}
 }
+
+// TestValidateOutboundURL_Exported exercises the public entrypoint, which in
+// turn drives the live netResolver. "localhost" is resolved from the local
+// hosts file on every supported platform, so this runs without network access.
+func TestValidateOutboundURL_Exported(t *testing.T) {
+	// Live resolver should resolve "localhost" to 127.0.0.1 / ::1 and the
+	// loopback check should reject it under both policies.
+	if err := ValidateOutboundURL("http://localhost/", PolicyStrict); err == nil {
+		t.Error("expected block for localhost under strict")
+	}
+	if err := ValidateOutboundURL("http://localhost/", PolicyLAN); err == nil {
+		t.Error("expected block for localhost under LAN")
+	}
+}
+
+func TestValidateOutboundURL_BadURL(t *testing.T) {
+	// url.Parse rejects control chars in the URL.
+	if err := ValidateOutboundURL("http://example.com/\x7f", PolicyStrict); err == nil {
+		t.Error("expected error for malformed URL")
+	}
+	// Missing host.
+	if err := ValidateOutboundURL("http:///path", PolicyStrict); err == nil {
+		t.Error("expected error for URL without host")
+	}
+}
+
+func TestValidateOutboundURL_DNSFailure(t *testing.T) {
+	// An unreachable/nonexistent hostname must be rejected (fail-closed).
+	r := fakeResolver{m: map[string][]net.IP{}}
+	if err := validate("http://nope.invalid/", PolicyStrict, r); err == nil {
+		t.Error("expected DNS failure to reject the URL")
+	}
+}
+
+func TestPolicyFromEnv(t *testing.T) {
+	const key = "BINDERY_TEST_SSRF_POLICY"
+
+	// Unset → default preserved.
+	t.Setenv(key, "")
+	if got := PolicyFromEnv(PolicyStrict, key); got != PolicyStrict {
+		t.Errorf("unset: want PolicyStrict, got %v", got)
+	}
+
+	// "1" → LAN.
+	t.Setenv(key, "1")
+	if got := PolicyFromEnv(PolicyStrict, key); got != PolicyLAN {
+		t.Errorf("'1': want PolicyLAN, got %v", got)
+	}
+
+	// "true" (case-insensitive) → LAN.
+	t.Setenv(key, "TRUE")
+	if got := PolicyFromEnv(PolicyStrict, key); got != PolicyLAN {
+		t.Errorf("'TRUE': want PolicyLAN, got %v", got)
+	}
+
+	// Any other value → default.
+	t.Setenv(key, "maybe")
+	if got := PolicyFromEnv(PolicyStrict, key); got != PolicyStrict {
+		t.Errorf("'maybe': want PolicyStrict, got %v", got)
+	}
+}

--- a/internal/importer/import_mode_test.go
+++ b/internal/importer/import_mode_test.go
@@ -1,0 +1,162 @@
+package importer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestHardlinkFile verifies that HardlinkFile creates a hard link so both
+// paths refer to the same inode, and that the source is not removed.
+func TestHardlinkFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.epub")
+	dst := filepath.Join(dir, "subdir", "dst.epub")
+
+	if err := os.WriteFile(src, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := HardlinkFile(src, dst); err != nil {
+		t.Fatalf("HardlinkFile: %v", err)
+	}
+
+	// Both files must exist.
+	if _, err := os.Stat(src); err != nil {
+		t.Error("source was removed after hardlink — source must survive")
+	}
+	if _, err := os.Stat(dst); err != nil {
+		t.Errorf("destination not found: %v", err)
+	}
+
+	// Same inode = true hardlink.
+	srcInfo, _ := os.Stat(src)
+	dstInfo, _ := os.Stat(dst)
+	if !os.SameFile(srcInfo, dstInfo) {
+		t.Error("src and dst are not the same inode — hardlink not created")
+	}
+}
+
+// TestCopyFileMode verifies that CopyFile duplicates the file and leaves the source intact.
+func TestCopyFileMode(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.epub")
+	dst := filepath.Join(dir, "subdir", "dst.epub")
+	content := []byte("book content")
+
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyFile(src, dst); err != nil {
+		t.Fatalf("CopyFile: %v", err)
+	}
+
+	if _, err := os.Stat(src); err != nil {
+		t.Error("source was removed after copy — source must survive")
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("dst content = %q, want %q", got, content)
+	}
+
+	srcInfo, _ := os.Stat(src)
+	dstInfo, _ := os.Stat(dst)
+	if os.SameFile(srcInfo, dstInfo) {
+		t.Error("src and dst share an inode — expected an independent copy, not a hardlink")
+	}
+}
+
+// TestHardlinkDir verifies that HardlinkDir mirrors a directory tree by
+// creating hard links for each file, and that the source tree is untouched.
+func TestHardlinkDir(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "audiobook")
+	dst := filepath.Join(dir, "library", "audiobook")
+
+	// Build a simple tree: root file + nested file.
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	files := []string{
+		filepath.Join(src, "part1.mp3"),
+		filepath.Join(src, "sub", "part2.mp3"),
+	}
+	for _, f := range files {
+		if err := os.WriteFile(f, []byte(filepath.Base(f)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := HardlinkDir(src, dst); err != nil {
+		t.Fatalf("HardlinkDir: %v", err)
+	}
+
+	// Source must still exist.
+	for _, f := range files {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("source file removed: %s", f)
+		}
+	}
+
+	// Destination files must exist and share inodes with source.
+	rel := []string{"part1.mp3", filepath.Join("sub", "part2.mp3")}
+	for i, r := range rel {
+		dstFile := filepath.Join(dst, r)
+		dstInfo, err := os.Stat(dstFile)
+		if err != nil {
+			t.Errorf("dst file not found: %s", dstFile)
+			continue
+		}
+		srcInfo, _ := os.Stat(files[i])
+		if !os.SameFile(srcInfo, dstInfo) {
+			t.Errorf("%s: not the same inode — hardlink not created", r)
+		}
+	}
+}
+
+// TestCopyDirMode verifies that CopyDir duplicates a directory tree and leaves
+// the source intact.
+func TestCopyDirMode(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "audiobook")
+	dst := filepath.Join(dir, "library", "audiobook")
+
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	srcFile := filepath.Join(src, "part1.mp3")
+	if err := os.WriteFile(srcFile, []byte("audio"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatalf("CopyDir: %v", err)
+	}
+
+	if _, err := os.Stat(srcFile); err != nil {
+		t.Error("source removed after CopyDir — source must survive")
+	}
+
+	dstFile := filepath.Join(dst, "part1.mp3")
+	got, err := os.ReadFile(dstFile)
+	if err != nil {
+		t.Fatalf("read dst file: %v", err)
+	}
+	if string(got) != "audio" {
+		t.Errorf("dst content = %q, want %q", got, "audio")
+	}
+}
+
+// TestImportMode_Default verifies that a Scanner with no settings falls back
+// to "move" mode.
+func TestImportMode_Default(t *testing.T) {
+	s := &Scanner{}
+	if got := s.importMode(nil); got != "move" { //nolint:staticcheck
+		t.Errorf("importMode without settings = %q, want %q", got, "move")
+	}
+}

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -138,6 +138,95 @@ func MoveDir(src, dst string) error {
 	return os.RemoveAll(src)
 }
 
+// CopyFile copies src to dst without removing the source. It is the "copy"
+// import mode counterpart to MoveFile. The source is left intact so that
+// torrent clients continue seeding from the original download location.
+func CopyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	return copyFile(src, dst)
+}
+
+// HardlinkFile creates a hard link at dst pointing to the same inode as src.
+// Both paths must be on the same filesystem — if they are not, os.Link returns
+// an error and no fallback is attempted (silently falling back to a move would
+// break seeding, which is the whole point of choosing hardlink mode).
+func HardlinkFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	if err := os.Link(src, dst); err != nil {
+		return fmt.Errorf("hardlink %q → %q: %w (download dir and library must be on the same filesystem)", src, dst, err)
+	}
+	return nil
+}
+
+// CopyDir copies a directory tree from src to dst without removing the source.
+// Used by "copy" import mode for audiobook folders so the download client can
+// continue seeding from the original location.
+func CopyDir(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source dir: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("source is not a directory: %s", src)
+	}
+	if _, err := os.Stat(dst); err == nil {
+		return fmt.Errorf("destination already exists: %s", dst)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return fmt.Errorf("create parent dir: %w", err)
+	}
+	if err := copyDir(src, dst); err != nil {
+		_ = os.RemoveAll(dst)
+		return fmt.Errorf("copy dir: %w", err)
+	}
+	return nil
+}
+
+// HardlinkDir mirrors a directory tree from src into dst by hard-linking every
+// regular file. Directory entries are created normally. Both trees must be on
+// the same filesystem — no fallback is attempted on cross-filesystem failure.
+func HardlinkDir(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source dir: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("source is not a directory: %s", src)
+	}
+	if _, err := os.Stat(dst); err == nil {
+		return fmt.Errorf("destination already exists: %s", dst)
+	}
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		return fmt.Errorf("create dest dir: %w", err)
+	}
+	err = filepath.Walk(src, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, rerr := filepath.Rel(src, path)
+		if rerr != nil {
+			return rerr
+		}
+		target := filepath.Join(dst, rel)
+		if fi.IsDir() {
+			return os.MkdirAll(target, fi.Mode())
+		}
+		if err := os.Link(path, target); err != nil {
+			return fmt.Errorf("hardlink %q → %q: %w (download dir and library must be on the same filesystem)", path, target, err)
+		}
+		return nil
+	})
+	if err != nil {
+		_ = os.RemoveAll(dst)
+		return err
+	}
+	return nil
+}
+
 // copyDir recursively copies srcDir contents into dstDir, preserving the
 // internal layout. dstDir will be created (including parents).
 func copyDir(srcDir, dstDir string) error {

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -3,6 +3,7 @@ package importer
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -203,7 +204,7 @@ func HardlinkDir(src, dst string) error {
 	if err := os.MkdirAll(dst, 0o750); err != nil {
 		return fmt.Errorf("create dest dir: %w", err)
 	}
-	err = filepath.Walk(src, func(path string, fi os.FileInfo, err error) error {
+	err = filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -212,8 +213,13 @@ func HardlinkDir(src, dst string) error {
 			return rerr
 		}
 		target := filepath.Join(dst, rel)
-		if fi.IsDir() {
-			return os.MkdirAll(target, fi.Mode())
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o750)
+		}
+		// Skip symlinks — following them in a Walk callback is a TOCTOU risk
+		// (gosec G304). Only hard-link regular files.
+		if !d.Type().IsRegular() {
+			return nil
 		}
 		if err := os.Link(path, target); err != nil {
 			return fmt.Errorf("hardlink %q → %q: %w (download dir and library must be on the same filesystem)", path, target, err)

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -116,6 +116,25 @@ func (s *Scanner) WithSettings(sr *db.SettingsRepo) *Scanner {
 	return s
 }
 
+// importMode reads the "import.mode" setting and returns one of "move",
+// "copy", or "hardlink". Defaults to "move" when the setting is absent or
+// unrecognised so upgrades are transparent for existing installs.
+func (s *Scanner) importMode(ctx context.Context) string {
+	if s.settings == nil {
+		return "move"
+	}
+	setting, err := s.settings.Get(ctx, "import.mode")
+	if err != nil || setting == nil {
+		return "move"
+	}
+	switch setting.Value {
+	case "copy", "hardlink":
+		return setting.Value
+	default:
+		return "move"
+	}
+}
+
 // pushToCalibre dispatches the just-imported book to the Calibre integration
 // selected by the current mode setting. Failures are logged and swallowed —
 // Calibre sync is a best-effort mirror, so a missing binary, unreachable
@@ -302,7 +321,7 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 	// wrong library directory.
 	detectedFormat := detectDownloadFormat(bookFiles)
 
-	// Audiobook path: move the entire download directory as a unit so
+	// Audiobook path: place the entire download directory as a unit so
 	// multi-part m4b/mp3 files, cover art, and cue sheets stay together.
 	if detectedFormat == models.MediaTypeAudiobook {
 		audiobookRoot := s.audiobookDir
@@ -310,9 +329,19 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 			audiobookRoot = effLib
 		}
 		destDir := UniqueDir(s.renamer.AudiobookDestDir(audiobookRoot, author, book))
-		slog.Info("importing audiobook folder", "src", downloadPath, "dst", destDir)
-		if err := MoveDir(downloadPath, destDir); err != nil {
-			slog.Error("failed to import audiobook folder", "src", downloadPath, "error", err)
+		mode := s.importMode(ctx)
+		slog.Info("importing audiobook folder", "src", downloadPath, "dst", destDir, "mode", mode)
+		var dirErr error
+		switch mode {
+		case "hardlink":
+			dirErr = HardlinkDir(downloadPath, destDir)
+		case "copy":
+			dirErr = CopyDir(downloadPath, destDir)
+		default:
+			dirErr = MoveDir(downloadPath, destDir)
+		}
+		if dirErr != nil {
+			slog.Error("failed to import audiobook folder", "src", downloadPath, "mode", mode, "error", dirErr)
 			return
 		}
 		if book != nil {
@@ -351,10 +380,20 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 		}
 
 		destPath := s.renamer.DestPath(s.effectiveLibraryDir(ctx, author), author, book, srcFile)
-		slog.Info("importing book", "src", srcFile, "dst", destPath)
+		mode := s.importMode(ctx)
+		slog.Info("importing book", "src", srcFile, "dst", destPath, "mode", mode)
 
-		if err := MoveFile(srcFile, destPath); err != nil {
-			slog.Error("failed to import", "src", srcFile, "error", err)
+		var fileErr error
+		switch mode {
+		case "hardlink":
+			fileErr = HardlinkFile(srcFile, destPath)
+		case "copy":
+			fileErr = CopyFile(srcFile, destPath)
+		default:
+			fileErr = MoveFile(srcFile, destPath)
+		}
+		if fileErr != nil {
+			slog.Error("failed to import", "src", srcFile, "mode", mode, "error", fileErr)
 			failed++
 			continue
 		}
@@ -378,13 +417,15 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 		})
 	}
 
-	// A clean run leaves the SABnzbd job folder holding only non-book
-	// byproducts (par2, nfo, sfv, sample) — bindery has no further use
-	// for them, so drop the folder and the matching history entry so
-	// the completed-downloads view doesn't accumulate stale rows.
+	// A clean run leaves the download folder holding only non-book byproducts
+	// (par2, nfo, sfv, sample). For "move" mode bindery has no further use for
+	// them so the folder is removed. For "copy"/"hardlink" modes the source must
+	// be preserved so the torrent client can continue seeding.
 	if imported > 0 && failed == 0 {
-		if err := os.RemoveAll(downloadPath); err != nil {
-			slog.Warn("failed to remove download folder after import", "path", downloadPath, "error", err)
+		if s.importMode(ctx) == "move" {
+			if err := os.RemoveAll(downloadPath); err != nil {
+				slog.Warn("failed to remove download folder after import", "path", downloadPath, "error", err)
+			}
 		}
 		s.clearSABHistory(ctx, sab, nzoID)
 	}

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -219,6 +219,52 @@ func TestTest_Failure(t *testing.T) {
 	}
 }
 
+func TestNew_DefaultValidator(t *testing.T) {
+	// New() wires in the production SSRF validator (strict policy). Confirm
+	// that a loopback URL is rejected, proving the validator is plumbed.
+	n := New(nil)
+	if n == nil {
+		t.Fatal("New returned nil")
+	}
+	if n.validate == nil {
+		t.Fatal("New did not install a validator")
+	}
+	if err := n.validate("http://127.0.0.1/hook"); err == nil {
+		t.Error("default validator should reject loopback")
+	}
+}
+
+func TestSetValidator_Override(t *testing.T) {
+	n := New(nil)
+	called := 0
+	n.SetValidator(func(string) error {
+		called++
+		return nil
+	})
+	// send() with a no-op validator should now accept loopback.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	notif := &models.Notification{URL: srv.URL}
+	if err := n.send(context.Background(), notif, map[string]interface{}{}); err != nil {
+		t.Fatalf("send with override: %v", err)
+	}
+	if called != 1 {
+		t.Errorf("overridden validator calls: want 1, got %d", called)
+	}
+}
+
+func TestSend_ValidatorRejects(t *testing.T) {
+	// send() must return the validator's error without making an HTTP call.
+	n := New(nil)
+	// Point at a public URL so only the validator rejection path fires.
+	notif := &models.Notification{URL: "http://10.0.0.1/hook"} // RFC1918 → strict rejects
+	if err := n.send(context.Background(), notif, map[string]interface{}{}); err == nil {
+		t.Fatal("expected validator to reject RFC1918 under strict policy")
+	}
+}
+
 func TestUserAgentHeader(t *testing.T) {
 	var gotUA string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1,0 +1,264 @@
+// Package smoke boots the real bindery binary and exercises the critical
+// golden paths via HTTP. It catches wiring regressions — bad route
+// registration, missing migration, broken frontend embed — that per-package
+// unit tests can't see.
+//
+// Requires a pre-built binary. Set BINDERY_BINARY to override the default
+// location (repo root `./bindery`). Typically invoked via `make smoke`,
+// which builds the binary (including frontend assets) first.
+//
+// The whole suite ships as a single top-level test so binary boot/teardown
+// happens once. Subtests are cheap HTTP calls against the same process.
+package smoke_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const (
+	apiKey      = "smoke-test-key-0000000000000000"
+	bootTimeout = 20 * time.Second
+	httpTimeout = 5 * time.Second
+)
+
+func TestSmoke(t *testing.T) {
+	bin := resolveBinary(t)
+	tmp := t.TempDir()
+
+	port, err := freePort()
+	if err != nil {
+		t.Fatalf("free port: %v", err)
+	}
+	base := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	cmd := exec.Command(bin)
+	// Clean env: drop BINDERY_* from the outer shell so a developer's
+	// personal config (e.g. BINDERY_PUID set for their homelab) can't make
+	// the smoke run diverge from CI. We explicitly set every variable the
+	// binary needs.
+	cmd.Env = sanitizedEnv(
+		"BINDERY_PORT="+fmt.Sprint(port),
+		"BINDERY_DB_PATH="+filepath.Join(tmp, "bindery.db"),
+		"BINDERY_DATA_DIR="+tmp,
+		"BINDERY_API_KEY="+apiKey,
+		"BINDERY_LIBRARY_DIR="+filepath.Join(tmp, "library"),
+		"BINDERY_DOWNLOAD_DIR="+filepath.Join(tmp, "downloads"),
+		"BINDERY_LOG_LEVEL=error",
+	)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start bindery: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		done := make(chan error, 1)
+		go func() { done <- cmd.Wait() }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			_ = cmd.Process.Kill()
+			<-done
+		}
+		if t.Failed() {
+			t.Logf("bindery stdout/stderr:\n%s", out.String())
+		}
+	})
+
+	if err := waitForHealth(base, bootTimeout); err != nil {
+		t.Fatalf("health never green: %v\nbindery output:\n%s", err, out.String())
+	}
+
+	t.Run("authors list empty on fresh install", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/author")
+		var arr []map[string]any
+		if err := json.Unmarshal(body, &arr); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+		if len(arr) != 0 {
+			t.Errorf("expected empty authors, got %d", len(arr))
+		}
+	})
+
+	t.Run("books list returns an array", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/book")
+		var arr []map[string]any
+		if err := json.Unmarshal(body, &arr); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+	})
+
+	t.Run("settings list returns an array", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/setting")
+		var arr []map[string]any
+		if err := json.Unmarshal(body, &arr); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+	})
+
+	t.Run("calibre import 400s when library unconfigured", func(t *testing.T) {
+		req := mustReq(t, http.MethodPost, base+"/api/v1/calibre/import", nil)
+		resp := do(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			b, _ := io.ReadAll(resp.Body)
+			t.Errorf("expected 400, got %d (body=%s)", resp.StatusCode, b)
+		}
+	})
+
+	t.Run("api auth rejects missing key", func(t *testing.T) {
+		resp, err := http.Get(base + "/api/v1/author")
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("embedded frontend serves index.html", func(t *testing.T) {
+		resp, err := http.Get(base + "/")
+		if err != nil {
+			t.Fatalf("get /: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(strings.ToLower(string(body)), "<!doctype html") {
+			t.Errorf("/ did not return an HTML document — was the binary built without web assets?\ngot: %s", truncate(body, 200))
+		}
+	})
+}
+
+// resolveBinary locates the bindery binary the test will drive. Search order:
+//  1. $BINDERY_BINARY if set
+//  2. repo-root ./bindery (two levels up from tests/smoke)
+//  3. ./bindery relative to cwd
+//
+// When none of those exist the test is skipped with an actionable hint.
+// `make smoke` is responsible for building it first.
+func resolveBinary(t *testing.T) string {
+	t.Helper()
+	candidates := []string{}
+	if p := os.Getenv("BINDERY_BINARY"); p != "" {
+		candidates = append(candidates, p)
+	}
+	candidates = append(candidates, "../../bindery", "./bindery")
+	for _, c := range candidates {
+		abs, err := filepath.Abs(c)
+		if err != nil {
+			continue
+		}
+		if fi, err := os.Stat(abs); err == nil && !fi.IsDir() {
+			return abs
+		}
+	}
+	t.Skip("bindery binary not found — run `make smoke` (builds first) or set BINDERY_BINARY to an existing binary path")
+	return ""
+}
+
+// sanitizedEnv returns the current environment with all BINDERY_* variables
+// removed, then appends the supplied overrides. This prevents a developer's
+// personal env (BINDERY_PUID, BINDERY_DB_PATH pointing at their real install)
+// from leaking into the smoke-test sandbox.
+func sanitizedEnv(overrides ...string) []string {
+	env := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "BINDERY_") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	return append(env, overrides...)
+}
+
+func freePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+func waitForHealth(base string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(base + "/api/v1/health")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+			lastErr = fmt.Errorf("status %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("no 200 from /api/v1/health within %s: %w", timeout, lastErr)
+}
+
+func getJSON(t *testing.T, url string) []byte {
+	t.Helper()
+	req := mustReq(t, http.MethodGet, url, nil)
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET %s: status %d (body=%s)", url, resp.StatusCode, body)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return body
+}
+
+func mustReq(t *testing.T, method, url string, body io.Reader) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("X-Api-Key", apiKey)
+	return req
+}
+
+func do(t *testing.T, req *http.Request) *http.Response {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(req.Context(), httpTimeout)
+	t.Cleanup(cancel)
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		t.Fatalf("%s %s: %v", req.Method, req.URL, err)
+	}
+	return resp
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import SeriesPage from './pages/SeriesPage'
 import CalendarPage from './pages/CalendarPage'
 import BlocklistPage from './pages/BlocklistPage'
 import Logo from './components/Logo'
+import { useTheme } from './theme'
 
 const NAV_KEYS = [
   { to: '/', key: 'authors', end: true },
@@ -32,6 +33,7 @@ const NAV_KEYS = [
 ]
 
 function Shell() {
+  useTheme() // ensures dark class is applied on every mount, not only when Settings is visited
   const { t } = useTranslation()
   const [version, setVersion] = useState('')
   const [menuOpen, setMenuOpen] = useState(false)

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -51,7 +51,14 @@ export default function BooksPage() {
   const filtered = useMemo(() => {
     let list = books
     if (statusFilter) list = list.filter(b => b.status === statusFilter)
-    if (mediaFilter) list = list.filter(b => (b.mediaType || 'ebook') === mediaFilter)
+    if (mediaFilter) {
+      list = list.filter(b => {
+        const mt = b.mediaType || 'ebook'
+        // 'both' books count as both ebook and audiobook so they show up
+        // under either filter.
+        return mt === mediaFilter || mt === 'both'
+      })
+    }
     if (search.trim()) {
       const q = search.trim().toLowerCase()
       list = list.filter(b =>
@@ -231,7 +238,11 @@ export default function BooksPage() {
                     </td>
                     <td className="px-3 py-2 text-slate-600 dark:text-zinc-400 whitespace-nowrap hidden sm:table-cell">{book.releaseDate ? new Date(book.releaseDate).getFullYear() : '—'}</td>
                     <td className="px-3 py-2 text-xs whitespace-nowrap">
-                      {book.mediaType === 'audiobook' ? `🎧 ${t('common.audiobook')}` : `📖 ${t('common.ebook')}`}
+                      {book.mediaType === 'both'
+                        ? `📖🎧 ${t('common.ebook')} + ${t('common.audiobook')}`
+                        : book.mediaType === 'audiobook'
+                          ? `🎧 ${t('common.audiobook')}`
+                          : `📖 ${t('common.ebook')}`}
                     </td>
                     <td className="px-3 py-2 whitespace-nowrap">
                       <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
@@ -279,8 +290,11 @@ export default function BooksPage() {
                   <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
                     {statusLabelKeys[book.status] ? t(statusLabelKeys[book.status]) : book.status}
                   </span>
-                  {book.mediaType === 'audiobook' && (
+                  {(book.mediaType === 'audiobook' || book.mediaType === 'both') && (
                     <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300">{t('books.audioLabel')}</span>
+                  )}
+                  {book.mediaType === 'both' && (
+                    <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300">{t('common.ebook')}</span>
                   )}
                 </div>
                 <div className="flex items-center justify-between mt-0.5">

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1063,6 +1063,32 @@ function GeneralTab() {
         <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.fileNaming')}</h3>
         <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-3">
           <div>
+            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Import Mode</label>
+            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
+              How Bindery places completed downloads into the library.
+              Use <strong>Hardlink</strong> or <strong>Copy</strong> to keep the source file intact for torrent seeding.
+              Hardlink requires the download folder and library to be on the same filesystem/volume.
+            </p>
+            <div className="flex gap-2">
+              {(['move', 'copy', 'hardlink'] as const).map(m => (
+                <button
+                  key={m}
+                  onClick={async () => {
+                    setSettings(s => ({ ...s, 'import.mode': m }))
+                    await api.setSetting('import.mode', m).catch(console.error)
+                  }}
+                  className={`px-3 py-1.5 rounded text-xs font-medium border transition-colors ${
+                    (settings['import.mode'] ?? 'move') === m
+                      ? 'bg-emerald-600 border-emerald-600 text-white'
+                      : 'border-slate-300 dark:border-zinc-700 text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white'
+                  }`}
+                >
+                  {m.charAt(0).toUpperCase() + m.slice(1)}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div>
             <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('settings.general.bookTemplate')}</label>
             <div className="flex gap-2">
               <input


### PR DESCRIPTION
## Problem
Bindery always moves completed downloads into the library, which removes the source file. On private trackers like MyAnonamouse (MAM), continued seeding is a requirement — a move breaks the torrent client's file reference and stops seeding, risking ratio and standing.

## Solution
A new `import.mode` setting (default: `move`) with three options:

| Mode | Behaviour | Disk cost | Seeding |
|---|---|---|---|
| **Move** | Rename/move; source removed | None | Breaks |
| **Copy** | Duplicate to library; source kept | 2× | Continues |
| **Hardlink** | Hard-link into library; same inode | Zero | Continues |

Hardlink is the preferred choice for NAS setups (Synology, etc.) — zero extra disk and seeding continues uninterrupted. It requires the download directory and library to be on the same filesystem/volume; a clear error is returned if they are not (no silent fallback to move).

## Files changed
- `internal/db/migrations/013_import_mode.sql` — seeds `import.mode = move`
- `internal/importer/renamer.go` — adds `HardlinkFile`, `HardlinkDir`, `CopyFile`, `CopyDir`
- `internal/importer/scanner.go` — `importMode()` helper reads setting; ebook and audiobook import paths dispatch accordingly; `RemoveAll` skipped in copy/hardlink modes
- `internal/importer/import_mode_test.go` — 5 tests: HardlinkFile, CopyFile, HardlinkDir, CopyDir, importMode default
- `web/src/pages/SettingsPage.tsx` — Move / Copy / Hardlink button group in Settings → General → File Naming

## Tests
```
ok  internal/importer   (all 5 new tests pass + existing suite green)
ok  [all 22 packages]
go vet ./... clean
npm run typecheck clean
```

Closes #54.