### PR TITLE
chore(release): v0.12.0 prep — pin Actions, docs, coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # goreleaser needs full history + tags
 
       # Go setup + test
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.9"
       - run: go test -race -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: coverage.out
           flags: backend
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       # Node setup + build (validates lint + typecheck + build in one step)
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
@@ -49,13 +49,13 @@ jobs:
       - run: npm run build --prefix web
 
       # Docker build + push (amd64 only for speed)
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}
@@ -86,7 +86,7 @@ jobs:
             echo "version=sha-${short}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         id: push
         with:
           context: .
@@ -107,7 +107,7 @@ jobs:
       #     --repo vavallee/bindery
       # See docs/security for the full verification recipe.
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push.outputs.digest }}
@@ -164,14 +164,14 @@ jobs:
       # latest release into /usr/local/bin.
       - name: Install Syft
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
 
       # Cross-compile release binaries and attach them to the GitHub Release
       # created above. Runs only on tag push; `release.mode: append` in
       # .goreleaser.yaml keeps the CHANGELOG-derived notes intact.
       - name: GoReleaser (release binaries)
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "~> v2"
           args: release --clean
@@ -182,11 +182,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.9"
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.11.4
           args: --timeout=5m
@@ -194,7 +194,7 @@ jobs:
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
@@ -208,18 +208,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.9"
       - run: go test -race -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: coverage.out
           flags: backend
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
@@ -234,11 +234,11 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.9"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.9"
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cache/go-build
@@ -40,12 +40,12 @@ jobs:
           restore-keys: go-mod-
 
       - name: gosec (SARIF)
-        uses: securego/gosec@master
+        uses: securego/gosec@64b97151cd7b978abdf8d2f1159a4e9096a12c2b # master
         with:
           args: '-no-fail -fmt sarif -out gosec.sarif ./...'
 
       - name: Upload gosec SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         if: always()
         with:
           sarif_file: gosec.sarif
@@ -57,7 +57,7 @@ jobs:
           govulncheck ./...
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.11.4
           args: --timeout=5m
@@ -69,9 +69,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
@@ -107,7 +107,7 @@ jobs:
             src/ || true
 
       - name: Upload ESLint SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         if: always() && hashFiles('web/eslint-security.sarif') != ''
         with:
           sarif_file: web/eslint-security.sarif
@@ -121,7 +121,7 @@ jobs:
             --sarif --output semgrep.sarif . || true
 
       - name: Upload Semgrep SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         if: always() && hashFiles('semgrep.sarif') != ''
         with:
           sarif_file: semgrep.sarif
@@ -133,19 +133,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
           GITLEAKS_ENABLE_SARIF: true
 
       - name: Upload Gitleaks SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         if: always()
         with:
           sarif_file: results.sarif
@@ -157,10 +157,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Hadolint (Dockerfile)
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           dockerfile: Dockerfile
           format: sarif
@@ -168,14 +168,14 @@ jobs:
           no-fail: true
 
       - name: Upload Hadolint SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         if: always()
         with:
           sarif_file: hadolint.sarif
           category: hadolint
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: latest
 
@@ -193,7 +193,7 @@ jobs:
           cat /tmp/kubesec-results.json
 
       - name: Checkov
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@de2bfaecd21d58ef232e0d2a3391c33c32c460d7 # master
         with:
           directory: .
           file: Dockerfile
@@ -203,7 +203,7 @@ jobs:
           soft_fail: true
 
       - name: Upload Checkov SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         if: always()
         with:
           sarif_file: checkov.sarif
@@ -218,10 +218,10 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cache/go-build
@@ -233,7 +233,7 @@ jobs:
         run: docker build -t bindery:scan .
 
       - name: Trivy vulnerability scan (SARIF)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@1994662b5555670344cd84d29ed3cad4bd26f31c # master
         with:
           image-ref: bindery:scan
           format: sarif
@@ -242,14 +242,14 @@ jobs:
           exit-code: '0'
 
       - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         if: always()
         with:
           sarif_file: trivy.sarif
           category: trivy
 
       - name: Grype vulnerability scan (SARIF)
-        uses: anchore/scan-action@v6
+        uses: anchore/scan-action@1638637db639e0ade3258b51db49a9a137574c3e # v6
         id: grype
         with:
           image: bindery:scan
@@ -258,7 +258,7 @@ jobs:
           fail-build: false
 
       - name: Upload Grype SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         if: always() && hashFiles('grype.sarif') != ''
         with:
           sarif_file: grype.sarif
@@ -273,7 +273,7 @@ jobs:
             bindery:scan
 
       - name: Syft SBOM – SPDX
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: bindery:scan
           format: spdx-json
@@ -283,7 +283,7 @@ jobs:
           upload-artifact-retention: 90
 
       - name: Syft SBOM – CycloneDX
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           image: bindery:scan
           format: cyclonedx-json
@@ -298,10 +298,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Cache Go modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cache/go-build
@@ -309,11 +309,11 @@ jobs:
           key: go-mod-${{ hashFiles('go.sum') }}
           restore-keys: go-mod-
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.9"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
           cache: npm
@@ -352,7 +352,7 @@ jobs:
               -I || true
 
       - name: Upload ZAP report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: zap-baseline-report
@@ -374,19 +374,19 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Scorecard
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: scorecard.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload Scorecard SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         if: always()
         with:
           sarif_file: scorecard.sarif
@@ -399,7 +399,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: helm-unittest (docker)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,30 +6,43 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased] — development branch
 
-The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
+Nothing yet — all in-flight work landed in v0.12.0.
+
+## [v0.12.0] — 2026-04-14
+
+Feature release adding configurable import modes, an end-to-end smoke-test suite, and a full security hardening pass (SSRF guards, security headers, SLSA provenance, OpenSSF Scorecard). First release with all GitHub Actions pinned to SHA digests.
 
 ### Added
 
+- **Import mode — move / copy / hardlink (closes [#54](https://github.com/vavallee/bindery/issues/54))** — **Settings → General → Import Mode** controls how completed downloads are placed in the library. **Move** (default) removes the source after import. **Copy** duplicates to the library and leaves the source intact so torrent clients continue seeding. **Hardlink** links both paths to the same inode (zero extra disk, seeding preserved) — requires download dir and library on the same filesystem. The setting is respected for both ebook files and audiobook folders. Migration `013_import_mode.sql` seeds the default.
 - **Log viewer in Settings → Logs (closes [#93](https://github.com/vavallee/bindery/issues/93))** — the last 1 000 log entries are held in an in-process ring buffer and exposed at `GET /api/v1/system/logs`. The Settings → Logs tab shows the 200 most recent entries colour-coded by severity, auto-refreshes every 5 s, and lets you filter by WARN/ERROR without leaving the UI. A runtime **Level** selector (`PUT /api/v1/system/loglevel`) switches between DEBUG/INFO/WARN/ERROR without restarting the process — useful for capturing verbose output while investigating a problem.
 - **UI localization — English, French, German, Dutch** — the entire web UI is now internationalised with `react-i18next`. All labels, button text, error messages, and toasts are translation-keyed. Language is auto-detected from the browser's `Accept-Language` setting and can be overridden in **Settings → General → Language** (persists to `localStorage` so the first paint is always in the right language). The language switcher includes a **System (auto)** option that delegates back to the browser.
 - **Root folders** — multiple root library paths can now be configured under **Settings → Root Folders**. Each author can be assigned to a specific root folder; unassigned authors continue to use the startup default path. Free disk space is shown next to each path.
 - **Language propagation into indexer queries** — search queries now include the author's metadata-profile language filter. For Prowlarr/Jackett, the allowed-language codes are appended to the query so foreign-language releases can be excluded on the indexer side as well as during metadata ingestion. The outgoing query string is visible at DEBUG level in the new log viewer.
 - **Language field from metadata providers** — Google Books and Hardcover now populate the `language` field on book records. Hardcover exposes language via the `editions` GraphQL node; Google Books via the `volumeInfo.language` JSON field. Language pills are surfaced in the Wanted page result rows when the indexer returns `<newznab:attr name="language">`.
+- **End-to-end smoke test suite (closes [#97](https://github.com/vavallee/bindery/issues/97))** — `tests/smoke/smoke_test.go` boots the real binary against a scratch data directory and exercises the golden-path HTTP endpoints (health, auth, authors, books, settings, history, OPDS). Runs on every PR and main/development push via the `make smoke` target in CI. Catches wiring regressions (broken route registration, missing migration, bad frontend embed) that unit tests miss.
 
 ### Fixed
 
+- **Dark mode not applied on first load** — dark mode preference was only activated after visiting Settings, leaving the app in light mode on a cold start for users whose preference was already saved. `useTheme()` is now called at the `Shell` level in `App.tsx` so the correct theme is applied before any route renders.
+- **Circular checkboxes on Books page (closes [#75](https://github.com/vavallee/bindery/issues/75), [#76](https://github.com/vavallee/bindery/issues/76))** — monitor/auto-grab checkboxes on the Books and Authors pages were rendered as squares; they are now circular and visually consistent with the rest of the UI.
 - **500 on add author (closes [#91](https://github.com/vavallee/bindery/issues/91))** — when a concurrent add-author request caused a UNIQUE-constraint violation at the database layer, the handler returned a raw 500 and leaked the SQLite error message. It now returns 409 with `"author already exists"` and logs the underlying error at ERROR level with full context. A regression test covers this path.
 - **Log viewer defects (closes [#98](https://github.com/vavallee/bindery/issues/98))** — repaired column alignment, light-mode palette, timestamp formatting, attribute rendering, word-boundary wrapping, the DEBUG filter option, and the stale-ref refresh toggle. The log table is now readable in both themes and honours the selected severity filter.
 
 ### Security
 
+- **GitHub Actions pinned to SHA digests** — all actions in `ci.yml` and `security.yml` are pinned to their commit SHA (with the version tag as a comment). Satisfies the OpenSSF Scorecard Pinned-Dependencies check; eliminates the tag-mutable supply-chain risk on every workflow step.
 - **SSRF validation for outbound URLs** — webhooks, indexers, and download-client endpoints now pass through `internal/httpsec.ValidateOutboundURL` before any request is issued. The validator blocks loopback, link-local, cloud-metadata (`169.254.169.254`, `metadata.google.internal`, AWS IPv6), and (for webhooks) RFC1918 ranges; DNS results are re-checked to defeat rebinding attacks. Escape hatch: `BINDERY_NOTIFICATIONS_ALLOW_PRIVATE=1` flips webhooks to the LAN policy for on-network ntfy / Home Assistant installs.
 - **Security headers middleware** — every response emits `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, and a locked-down `Content-Security-Policy` (no `unsafe-eval`, no foreign origins, `frame-ancestors 'none'`). HSTS is emitted only when TLS is detected (direct or via `X-Forwarded-Proto: https`) so plain-HTTP homelab setups don't get locked out.
 - **Session cookie `Secure` auto-detect** — the cookie's `Secure` attribute now flips on automatically behind TLS or a TLS-terminating proxy. Override with `BINDERY_COOKIE_SECURE=auto|always|never`.
 - **Upload hardening** — `/api/v1/migrate/*` now validates the multipart Content-Type against an allowlist and spools uploads to `$BINDERY_DB_PATH/../tmp` (mode `0700`) instead of the world-writable `/tmp`. The database file is chmod'd to `0600` on boot.
 - **Container / supply chain** — Docker base images are digest-pinned (node 22, Go 1.25.9, distroless static); Dependabot keeps them fresh. A `bindery healthcheck` subcommand drives the `HEALTHCHECK` directive. GoReleaser now emits Syft SBOMs (SPDX) alongside release archives. `actions/attest-build-provenance` mints SLSA provenance on every image push, verifiable with `gh attestation verify`.
 - **Helm chart** — dedicated ServiceAccount with `automountServiceAccountToken: false`, managed or externally-referenced Secret for `BINDERY_API_KEY` (no more plain env rendering), opt-in NetworkPolicy, and an opt-in ArgoCD PostSync smoke-test hook against `/api/v1/health`. `helm-unittest` cases guard the posture against regressions.
-- **CI security pipeline** — new `.github/workflows/security.yml` runs gosec, govulncheck, golangci-lint, Semgrep, gitleaks, Trivy, Grype, Dockle, Syft, ZAP baseline, hadolint, Helm lint, and kubesec on every push / PR / weekly cron. `.github/workflows/scorecard.yml` tracks OpenSSF Scorecard. All findings upload to the Security tab as SARIF. `SECURITY.md` documents the disclosure policy.
+- **CI security pipeline** — `.github/workflows/security.yml` runs gosec, govulncheck, golangci-lint, Semgrep, gitleaks, Trivy, Grype, Dockle, Syft, ZAP baseline, hadolint, Helm lint, and kubesec on every push / PR / weekly cron. `.github/workflows/scorecard.yml` tracks OpenSSF Scorecard. All findings upload to the Security tab as SARIF. `SECURITY.md` documents the disclosure policy.
+
+### Upgrade notes
+
+- **Schema:** migration `013_import_mode.sql` inserts `import.mode = move` as a new setting row. The default is backward-compatible — existing installs behave identically (files are moved as before). Change the setting in **Settings → General → Import Mode** if you want copy or hardlink behaviour.
 
 ## [v0.10.0] — 2026-04-15
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@
 - **Failure visibility** — Download errors surfaced in Queue (active) and History (permanent)
 
 ### Import & organize
-- **Automatic import** — Completed downloads matched by NZO ID, moved to library with configurable naming template
+- **Automatic import** — Completed downloads matched by NZO ID, placed in library with configurable naming template
+- **Import modes** — **Move** (default): source deleted after import. **Copy**: source kept so torrent clients continue seeding. **Hardlink**: zero extra disk, both paths share an inode (download dir and library must be on the same filesystem). Configurable under **Settings → General → Import Mode**.
 - **Naming tokens** — `{Author}`, `{SortAuthor}`, `{Title}`, `{Year}`, `{ext}` with sanitized path components
 - **Cross-filesystem moves** — Atomic rename when possible, copy+verify+delete for NFS/separate volumes
 - **History** — Every grab, import, and failure recorded with full detail (shown inline on History page)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,9 +34,8 @@ The short version lives in the [README](../README.md#roadmap). ✅ items have la
 
   Useful for multi-replica HA deployments.
 
-- **UI localization (i18n)** — translate the web UI into French, Dutch, and German (starting point; more languages welcome as contributors show up). Today all labels, button text, error messages, and toasts are hardcoded English strings.
-
-  - ✅ Translation-catalogue extraction pass (landed in development, targeting v0.11.0).
+- **UI localization (i18n)** — translate the web UI into French, Dutch, and German (starting point; more languages welcome as contributors show up).
+  - ✅ Translation-catalogue extraction pass (landed in v0.12.0).
   - ✅ Runtime switcher (language selector in Settings, persisted in `localStorage` so it applies before first paint alongside the theme).
   - ✅ Locale-aware date/number formatting.
   - ✅ `Accept-Language` auto-detect on first load with manual override.
@@ -44,21 +43,17 @@ The short version lives in the [README](../README.md#roadmap). ✅ items have la
 - **Non-English indexer / metadata support** — let monitored authors and searches pull from language-tagged catalogues and filter results by language.
 
   - ✅ Per-author metadata profiles carry an `allowed_languages` list; OpenLibrary works whose language falls outside it are dropped during author ingestion ([#14](https://github.com/vavallee/bindery/issues/14), landed in v0.6.0).
-  - ✅ Propagate the profile's languages into indexer queries (Prowlarr's `Categories` + language filters, Jackett `/api?cat=7000&...`) so Newznab-side filtering applies (landed in development, targeting v0.11.0).
+  - ✅ Propagate the profile's languages into indexer queries (Prowlarr's `Categories` + language filters, Jackett `/api?cat=7000&...`) so Newznab-side filtering applies (landed in v0.12.0).
   - ✅ Surface the language tag in search-result and wanted-books views.
   - ✅ Persist Hardcover/Google Books' `language` field for editions.
   - ⬜ **DNB (Deutsche Nationalbibliothek) metadata provider** ([#67](https://github.com/vavallee/bindery/issues/67)) — German national library catalogue via SRU/Z39.50 or the public JSON API. Primary use case: German-language ebooks and audiobooks where OpenLibrary coverage is thin. Calibre's DNB plugin ([calibre-dnb](https://github.com/dvdwolfsburg/calibre-dnb)) serves as a reference implementation for field mapping (title, author, ISBN, publisher, language, description).
 
   Relevant to French/Dutch/German users whose libraries are mixed-language and where indexer results in the "wrong" language are currently indistinguishable.
 
-- ⬜ **LinuxServer.io-style runtime user switching** ([#56](https://github.com/vavallee/bindery/issues/56)) — parallel image with a gosu/su-exec entrypoint that switches UID/GID at runtime based on `PUID` / `PGID`.
+- ~~**LinuxServer.io-style runtime user switching** ([#56](https://github.com/vavallee/bindery/issues/56))~~ — **Won't do.** The distroless image is deliberately minimal (no shell, no `gosu`). Runtime UID/GID switching requires a shell entrypoint, which contradicts the minimal-attack-surface posture. Pass `--user <uid>:<gid>` to `docker run` or set `securityContext.runAsUser` in Helm. Closed as won't-fix.
 
-  The current distroless image is deliberately minimal (no shell, no `gosu`) — the v0.6.0 startup sanity check ([#13](https://github.com/vavallee/bindery/issues/13)) catches PUID/PGID misconfiguration but does not fix it. Trade-offs:
-
-  - Distroless image: smaller, smaller attack surface, no runtime user-switching → the user has to pass `--user`.
-  - LSIO-style image: larger, needs shell + gosu, but "just works" for users coming from the *arr ecosystem.
-
-  The likely path is to publish **both** and let operators pick.
+- **Import mode — move / copy / hardlink** ([#54](https://github.com/vavallee/bindery/issues/54))
+  - ✅ **Move / Copy / Hardlink** (landed in v0.12.0) — configurable under **Settings → General → Import Mode**. Hardlink requires the download dir and library on the same filesystem. Copy preserves the source so torrent clients continue seeding.
 
 - **Calibre library integration** — treat a Calibre library as a first-class storage target, for users who already live in Calibre or want e-reader sync.
 

--- a/internal/importer/import_mode_test.go
+++ b/internal/importer/import_mode_test.go
@@ -1,9 +1,12 @@
 package importer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
 )
 
 // TestHardlinkFile verifies that HardlinkFile creates a hard link so both
@@ -158,5 +161,45 @@ func TestImportMode_Default(t *testing.T) {
 	s := &Scanner{}
 	if got := s.importMode(nil); got != "move" { //nolint:staticcheck
 		t.Errorf("importMode without settings = %q, want %q", got, "move")
+	}
+}
+
+// TestImportMode_Settings exercises all branches of importMode when a real
+// SettingsRepo is attached: "copy", "hardlink", unknown value, and absent key.
+func TestImportMode_Settings(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	sr := db.NewSettingsRepo(database)
+
+	s := &Scanner{}
+	s.WithSettings(sr)
+
+	cases := []struct {
+		setValue string // "" means don't set the key
+		want     string
+	}{
+		{setValue: "copy", want: "copy"},
+		{setValue: "hardlink", want: "hardlink"},
+		{setValue: "invalid", want: "move"},  // unknown value falls back to move
+		{setValue: "", want: "move"},          // absent key falls back to move
+	}
+
+	for _, tc := range cases {
+		// Reset the setting before each case.
+		_ = sr.Delete(ctx, "import.mode")
+		if tc.setValue != "" {
+			if err := sr.Set(ctx, "import.mode", tc.setValue); err != nil {
+				t.Fatalf("Set: %v", err)
+			}
+		}
+		got := s.importMode(ctx)
+		if got != tc.want {
+			t.Errorf("setValue=%q: importMode = %q, want %q", tc.setValue, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Pin all GitHub Actions to SHA digests** in `ci.yml` and `security.yml` — satisfies OpenSSF Scorecard Pinned-Dependencies check and eliminates tag-mutable supply-chain risk on every workflow step. Three `@master` pins (gosec, checkov, trivy) converted to their current commit SHAs.
- **CHANGELOG**: `[Unreleased]` → `[v0.12.0] — 2026-04-14` with full entry covering import mode, dark mode fix, circular checkboxes, smoke tests, and all security work.
- **README**: import mode (move/copy/hardlink) added to the Import & organize features section.
- **ROADMAP**: import mode ✅, i18n/language items updated to v0.12.0, PUID/PGID closed as won't-do.
- **Coverage**: `TestImportMode_Settings` exercises the copy/hardlink/unknown/absent branches of `importMode` using a real in-memory `SettingsRepo` (was at 25%).

## Test plan

- [ ] CI passes (`validate` + `lint` + `smoke` jobs)
- [ ] `go test ./internal/importer/` — all tests green including new `TestImportMode_Settings`
- [ ] Verify no unpinned `@v4` / `@master` remains in both workflow files