### PR TITLE
feat(api): image proxy cache to prevent cover-URL tracking

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -242,6 +242,7 @@ func main() {
 	calibreImportHandler := api.NewCalibreImportHandler(calibreImporter, func() calibre.Config {
 		return api.LoadCalibreConfig(settingsRepo)
 	})
+	imageProxyHandler := api.NewImageProxyHandler(cfg.DataDir)
 	migrateHandler := api.NewMigrateHandler(
 		authorRepo, indexerRepo, dlClientRepo, blocklistRepo, bookRepo, metaAgg,
 		// Bulk imports always populate the catalogue but never auto-grab.
@@ -441,6 +442,10 @@ func main() {
 		// Migration imports (CSV of author names, or Readarr SQLite DB).
 		r.Post("/migrate/csv", migrateHandler.ImportCSV)
 		r.Post("/migrate/readarr", migrateHandler.ImportReadarr)
+
+		// Image proxy — caches external cover images locally so the browser
+		// never leaks the user's IP to Goodreads / OpenLibrary / etc.
+		r.Get("/images", imageProxyHandler.Serve)
 	})
 
 	// OPDS 1.2 catalogue — KOReader / Moon+ Reader / Aldiko speak this

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -48,6 +48,9 @@ func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
 	if authors == nil {
 		authors = []models.Author{}
 	}
+	for i := range authors {
+		proxyAuthorImages(&authors[i])
+	}
 	writeJSON(w, http.StatusOK, authors)
 }
 
@@ -82,6 +85,7 @@ func (h *AuthorHandler) Get(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	proxyAuthorImages(author)
 	writeJSON(w, http.StatusOK, author)
 }
 

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -91,6 +91,9 @@ func (h *BookHandler) List(w http.ResponseWriter, r *http.Request) {
 	if books == nil {
 		books = []models.Book{}
 	}
+	for i := range books {
+		proxyBookImages(&books[i])
+	}
 	writeJSON(w, http.StatusOK, books)
 }
 
@@ -110,6 +113,7 @@ func (h *BookHandler) Get(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}
+	proxyBookImages(book)
 	writeJSON(w, http.StatusOK, book)
 }
 

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/vavallee/bindery/internal/httpsec"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+const (
+	imageCacheTTL  = 30 * 24 * time.Hour
+	imageMaxBytes  = 10 * 1024 * 1024 // 10 MB
+	imageCacheMode = 0o640
+	imageDirMode   = 0o750
+)
+
+// ImageProxyHandler serves GET /api/v1/images?url=<encoded>.
+// On first request it fetches the external image, validates it, writes it to a
+// local disk cache under <dataDir>/image-cache/, and returns it. Subsequent
+// requests within the 30-day TTL are served entirely from the cache — no
+// outbound traffic, no third-party tracking.
+type ImageProxyHandler struct {
+	cacheDir    string
+	client      *http.Client
+	validateURL func(string) error // defaults to httpsec.ValidateOutboundURL; overridable in tests
+}
+
+// NewImageProxyHandler creates a handler that caches images under
+// <dataDir>/image-cache/.
+func NewImageProxyHandler(dataDir string) *ImageProxyHandler {
+	return &ImageProxyHandler{
+		cacheDir:    filepath.Join(dataDir, "image-cache"),
+		client:      &http.Client{Timeout: 15 * time.Second},
+		validateURL: func(u string) error { return httpsec.ValidateOutboundURL(u, httpsec.PolicyStrict) },
+	}
+}
+
+// Serve handles GET /api/v1/images?url=<encoded-external-url>.
+func (h *ImageProxyHandler) Serve(w http.ResponseWriter, r *http.Request) {
+	raw := r.URL.Query().Get("url")
+	if raw == "" {
+		http.Error(w, "url parameter required", http.StatusBadRequest)
+		return
+	}
+
+	// Block SSRF — image URLs come from metadata providers we trust, but the
+	// stored value could be tampered with; always re-validate before fetching.
+	if err := h.validateURL(raw); err != nil {
+		http.Error(w, "invalid url", http.StatusBadRequest)
+		return
+	}
+
+	sum := sha256.Sum256([]byte(raw))
+	key := fmt.Sprintf("%x", sum)
+	imgFile := filepath.Join(h.cacheDir, key)
+	ctFile := imgFile + ".ct"
+
+	// Serve from cache if fresh.
+	if info, err := os.Stat(imgFile); err == nil && time.Since(info.ModTime()) < imageCacheTTL {
+		ct, _ := os.ReadFile(ctFile) //nolint:gosec // path is constructed from sha256, not user input
+		if len(ct) == 0 {
+			ct = []byte("image/jpeg")
+		}
+		w.Header().Set("Content-Type", string(ct))
+		w.Header().Set("Cache-Control", "public, max-age=2592000")
+		http.ServeFile(w, r, imgFile)
+		return
+	}
+
+	// Fetch from upstream.
+	resp, err := h.client.Get(raw) //nolint:noctx // timeout set on client
+	if err != nil {
+		http.Error(w, "upstream fetch failed", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		http.Error(w, "upstream returned non-200", http.StatusBadGateway)
+		return
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "image/") {
+		http.Error(w, "upstream response is not an image", http.StatusBadGateway)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, imageMaxBytes+1))
+	if err != nil {
+		http.Error(w, "read error", http.StatusBadGateway)
+		return
+	}
+	if len(body) > imageMaxBytes {
+		http.Error(w, "image exceeds 10 MB limit", http.StatusBadGateway)
+		return
+	}
+
+	// Write to cache (best-effort — a write failure is not fatal).
+	if mkErr := os.MkdirAll(h.cacheDir, imageDirMode); mkErr == nil {
+		_ = os.WriteFile(imgFile, body, imageCacheMode)
+		_ = os.WriteFile(ctFile, []byte(ct), imageCacheMode)
+	}
+
+	w.Header().Set("Content-Type", ct)
+	w.Header().Set("Cache-Control", "public, max-age=2592000")
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+	_, _ = w.Write(body)
+}
+
+// ProxyImageURL rewrites a raw external image URL into the local proxy path
+// /api/v1/images?url=<encoded>. Returns raw unchanged when it is empty or
+// already a relative URL (already proxied or intentionally local).
+func ProxyImageURL(raw string) string {
+	if raw == "" || strings.HasPrefix(raw, "/") {
+		return raw
+	}
+	return "/api/v1/images?url=" + url.QueryEscape(raw)
+}
+
+// proxyAuthorImages rewrites ImageURL on an author and all its embedded books.
+// Mutates in place — callers own the struct and it is not shared with the DB layer.
+func proxyAuthorImages(a *models.Author) {
+	a.ImageURL = ProxyImageURL(a.ImageURL)
+	for i := range a.Books {
+		proxyBookImages(&a.Books[i])
+	}
+}
+
+// proxyBookImages rewrites ImageURL on a book.
+func proxyBookImages(b *models.Book) {
+	b.ImageURL = ProxyImageURL(b.ImageURL)
+}

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -75,8 +75,16 @@ func (h *ImageProxyHandler) Serve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fetch from upstream.
-	resp, err := h.client.Get(raw) //nolint:noctx // timeout set on client
+	// Fetch from upstream. Use NewRequestWithContext so the request respects
+	// the caller's context (cancellation, deadline). The URL has already been
+	// validated by h.validateURL; the nolint suppresses the gosec taint warning
+	// that can't trace through the validateURL indirection.
+	upReq, err := http.NewRequestWithContext(r.Context(), http.MethodGet, raw, nil) //nolint:gosec // URL validated above
+	if err != nil {
+		http.Error(w, "upstream fetch failed", http.StatusBadGateway)
+		return
+	}
+	resp, err := h.client.Do(upReq)
 	if err != nil {
 		http.Error(w, "upstream fetch failed", http.StatusBadGateway)
 		return

--- a/internal/api/imageproxy_test.go
+++ b/internal/api/imageproxy_test.go
@@ -1,0 +1,195 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newFakeUpstream starts a test HTTP server that responds with the given
+// content-type and body. Caller must call Close().
+func newFakeUpstream(ct string, body []byte, status int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", ct)
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	}))
+}
+
+// newTestHandler creates an ImageProxyHandler wired to the given test server.
+// It bypasses the SSRF validator (which would block 127.0.0.1) while keeping
+// all other production logic intact.
+func newTestHandler(dir string, upstream *httptest.Server) *ImageProxyHandler {
+	h := NewImageProxyHandler(dir)
+	h.client = upstream.Client()
+	h.validateURL = func(_ string) error { return nil } // allow loopback in tests
+	return h
+}
+
+// TestImageProxy_CacheMiss fetches an image for the first time (cache miss):
+// the handler must contact upstream, write the cache files, and respond 200
+// with the correct Content-Type.
+func TestImageProxy_CacheMiss(t *testing.T) {
+	upstream := newFakeUpstream("image/jpeg", []byte("FAKEJPEG"), http.StatusOK)
+	defer upstream.Close()
+
+	dir := t.TempDir()
+	h := newTestHandler(dir, upstream)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images?url="+upstream.URL+"/cover.jpg", nil)
+	rr := httptest.NewRecorder()
+	h.Serve(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "image/jpeg" {
+		t.Errorf("Content-Type = %q, want image/jpeg", ct)
+	}
+	if body := rr.Body.String(); body != "FAKEJPEG" {
+		t.Errorf("body = %q, want FAKEJPEG", body)
+	}
+
+	// Cache directory should now contain the key file and .ct sidecar.
+	entries, _ := os.ReadDir(filepath.Join(dir, "image-cache"))
+	if len(entries) < 2 {
+		t.Errorf("expected at least 2 cache files (body + .ct), got %d", len(entries))
+	}
+}
+
+// TestImageProxy_CacheHit serves the same URL twice; the second request must
+// be served from cache (upstream server is shut down before the second call).
+func TestImageProxy_CacheHit(t *testing.T) {
+	upstream := newFakeUpstream("image/png", []byte("FAKEPNG"), http.StatusOK)
+
+	dir := t.TempDir()
+	h := newTestHandler(dir, upstream)
+
+	imgURL := upstream.URL + "/img.png"
+	req1 := httptest.NewRequest(http.MethodGet, "/api/v1/images?url="+imgURL, nil)
+	rr1 := httptest.NewRecorder()
+	h.Serve(rr1, req1)
+	if rr1.Code != http.StatusOK {
+		t.Fatalf("first request: status = %d, want 200", rr1.Code)
+	}
+
+	// Shut the upstream down — second request must be served from disk.
+	upstream.Close()
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/images?url="+imgURL, nil)
+	rr2 := httptest.NewRecorder()
+	h.Serve(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("second request (cache hit): status = %d, want 200", rr2.Code)
+	}
+	if ct := rr2.Header().Get("Content-Type"); ct != "image/png" {
+		t.Errorf("Content-Type = %q, want image/png", ct)
+	}
+}
+
+// TestImageProxy_MissingURL ensures a missing url parameter returns 400.
+func TestImageProxy_MissingURL(t *testing.T) {
+	h := NewImageProxyHandler(t.TempDir())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images", nil)
+	rr := httptest.NewRecorder()
+	h.Serve(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}
+
+// TestImageProxy_SSRFRejected verifies that private/loopback URLs are blocked.
+func TestImageProxy_SSRFRejected(t *testing.T) {
+	h := NewImageProxyHandler(t.TempDir())
+
+	ssrfURLs := []string{
+		"http://169.254.169.254/latest/meta-data/",
+		"http://10.0.0.1/cover.jpg",
+		"http://192.168.1.1/cover.jpg",
+		"http://127.0.0.1/cover.jpg",
+		"file:///etc/passwd",
+	}
+	for _, u := range ssrfURLs {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/images?url="+u, nil)
+		rr := httptest.NewRecorder()
+		h.Serve(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("url %q: status = %d, want 400 (SSRF rejected)", u, rr.Code)
+		}
+	}
+}
+
+// TestImageProxy_NonImageRejected ensures non-image content-types from
+// upstream are rejected with 502.
+func TestImageProxy_NonImageRejected(t *testing.T) {
+	upstream := newFakeUpstream("text/html", []byte("<html/>"), http.StatusOK)
+	defer upstream.Close()
+
+	h := newTestHandler(t.TempDir(), upstream)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images?url="+upstream.URL+"/not-an-image", nil)
+	rr := httptest.NewRecorder()
+	h.Serve(rr, req)
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 for non-image content-type", rr.Code)
+	}
+}
+
+// TestImageProxy_UpstreamNon200 ensures a non-200 from upstream returns 502.
+func TestImageProxy_UpstreamNon200(t *testing.T) {
+	upstream := newFakeUpstream("image/jpeg", nil, http.StatusNotFound)
+	defer upstream.Close()
+
+	h := newTestHandler(t.TempDir(), upstream)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images?url="+upstream.URL+"/missing.jpg", nil)
+	rr := httptest.NewRecorder()
+	h.Serve(rr, req)
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 for upstream 404", rr.Code)
+	}
+}
+
+// TestImageProxy_SizeLimit enforces the 10 MB cap.
+func TestImageProxy_SizeLimit(t *testing.T) {
+	big := make([]byte, imageMaxBytes+1)
+	upstream := newFakeUpstream("image/jpeg", big, http.StatusOK)
+	defer upstream.Close()
+
+	h := newTestHandler(t.TempDir(), upstream)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images?url="+upstream.URL+"/huge.jpg", nil)
+	rr := httptest.NewRecorder()
+	h.Serve(rr, req)
+	if rr.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 for oversized image", rr.Code)
+	}
+}
+
+// TestProxyImageURL covers the ProxyImageURL helper for various inputs.
+func TestProxyImageURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"/already/relative", "/already/relative"},
+		{"https://covers.openlibrary.org/b/id/123-L.jpg", "/api/v1/images?url=https%3A%2F%2Fcovers.openlibrary.org%2Fb%2Fid%2F123-L.jpg"},
+		{"http://example.com/img.png", "/api/v1/images?url=http%3A%2F%2Fexample.com%2Fimg.png"},
+	}
+	for _, tc := range cases {
+		got := ProxyImageURL(tc.in)
+		if got != tc.want {
+			t.Errorf("ProxyImageURL(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+		// Proxied result must start with /api/v1/images when non-trivial.
+		if tc.in != "" && !strings.HasPrefix(tc.in, "/") {
+			if !strings.HasPrefix(got, "/api/v1/images?url=") {
+				t.Errorf("ProxyImageURL(%q): result %q should start with /api/v1/images?url=", tc.in, got)
+			}
+		}
+	}
+}

--- a/internal/api/imageproxy_test.go
+++ b/internal/api/imageproxy_test.go
@@ -1,12 +1,16 @@
 package api
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
 )
 
 // newFakeUpstream starts a test HTTP server that responds with the given
@@ -166,6 +170,95 @@ func TestImageProxy_SizeLimit(t *testing.T) {
 	h.Serve(rr, req)
 	if rr.Code != http.StatusBadGateway {
 		t.Errorf("status = %d, want 502 for oversized image", rr.Code)
+	}
+}
+
+// TestImageProxy_CacheHitMissingCT verifies that a cache hit with a missing
+// or empty .ct sidecar falls back to "image/jpeg" as the content-type.
+func TestImageProxy_CacheHitMissingCT(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "image-cache")
+	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-seed the cache with only the body file — no .ct sidecar.
+	const rawURL = "https://example.com/noct.jpg"
+	sum := sha256.Sum256([]byte(rawURL))
+	key := fmt.Sprintf("%x", sum)
+	if err := os.WriteFile(filepath.Join(cacheDir, key), []byte("CACHEDIMG"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewImageProxyHandler(dir)
+	h.validateURL = func(_ string) error { return nil }
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/images?url="+rawURL, nil)
+	rr := httptest.NewRecorder()
+	h.Serve(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "image/jpeg" {
+		t.Errorf("Content-Type = %q, want image/jpeg (default fallback)", ct)
+	}
+}
+
+// TestProxyAuthorImages verifies that proxyAuthorImages rewrites the author's
+// ImageURL and all embedded books' ImageURLs in place.
+func TestProxyAuthorImages(t *testing.T) {
+	a := &models.Author{
+		ImageURL: "https://example.com/author.jpg",
+		Books: []models.Book{
+			{ImageURL: "https://example.com/book1.jpg"},
+			{ImageURL: "/already/relative"},
+			{ImageURL: ""},
+		},
+	}
+	proxyAuthorImages(a)
+
+	if !strings.HasPrefix(a.ImageURL, "/api/v1/images?url=") {
+		t.Errorf("Author.ImageURL not rewritten: %q", a.ImageURL)
+	}
+	if !strings.HasPrefix(a.Books[0].ImageURL, "/api/v1/images?url=") {
+		t.Errorf("Books[0].ImageURL not rewritten: %q", a.Books[0].ImageURL)
+	}
+	if a.Books[1].ImageURL != "/already/relative" {
+		t.Errorf("Books[1].ImageURL should be unchanged: %q", a.Books[1].ImageURL)
+	}
+	if a.Books[2].ImageURL != "" {
+		t.Errorf("Books[2].ImageURL should be empty: %q", a.Books[2].ImageURL)
+	}
+}
+
+// TestProxyBookImages verifies that proxyBookImages rewrites the book's
+// ImageURL and leaves relative/empty URLs untouched.
+func TestProxyBookImages(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string // prefix check: "/" means unchanged, "/api" means rewritten
+	}{
+		{"https://example.com/cover.jpg", "/api/v1/images?url="},
+		{"/local/cover.jpg", "/local/cover.jpg"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		b := &models.Book{ImageURL: tc.in}
+		proxyBookImages(b)
+		if tc.want == "" {
+			if b.ImageURL != "" {
+				t.Errorf("in=%q: want empty, got %q", tc.in, b.ImageURL)
+			}
+		} else if strings.HasPrefix(tc.want, "/api") {
+			if !strings.HasPrefix(b.ImageURL, tc.want) {
+				t.Errorf("in=%q: want prefix %q, got %q", tc.in, tc.want, b.ImageURL)
+			}
+		} else {
+			if b.ImageURL != tc.want {
+				t.Errorf("in=%q: want %q, got %q", tc.in, tc.want, b.ImageURL)
+			}
+		}
 	}
 }
 

--- a/internal/importer/import_mode_test.go
+++ b/internal/importer/import_mode_test.go
@@ -185,8 +185,8 @@ func TestImportMode_Settings(t *testing.T) {
 	}{
 		{setValue: "copy", want: "copy"},
 		{setValue: "hardlink", want: "hardlink"},
-		{setValue: "invalid", want: "move"},  // unknown value falls back to move
-		{setValue: "", want: "move"},          // absent key falls back to move
+		{setValue: "invalid", want: "move"}, // unknown value falls back to move
+		{setValue: "", want: "move"},        // absent key falls back to move
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/images?url=<encoded>` — a local caching image proxy that prevents the browser from leaking the user's IP to external cover-image hosts (Goodreads, OpenLibrary, etc.)
- Cache key is SHA256 of the original URL; bytes + a `.ct` sidecar for the content-type live under `<dataDir>/image-cache/`. 30-day TTL enforced via `os.Stat().ModTime()`.
- SSRF protection via `httpsec.ValidateOutboundURL(raw, httpsec.PolicyStrict)` before any outbound fetch; 10 MB response cap.
- `ProxyImageURL` helper rewrites external URLs → `/api/v1/images?url=<encoded>`. Applied to author and book list/get responses so the browser always hits the local proxy.

Closes #112

## Test plan

- [ ] `go test ./internal/api/ -run 'TestImageProxy|TestProxyImageURL'` — 8 tests: cache miss, cache hit (upstream shut down), missing url param, SSRF rejection, non-image content-type, upstream non-200, size limit, ProxyImageURL helper
- [ ] Open the UI, navigate to Authors — cover images should load from `/api/v1/images?url=...` (check Network tab)
- [ ] Confirm no requests go directly to `covers.openlibrary.org` or `goodreads.com` after first page load (all served from cache on reload)
- [ ] Confirm private/loopback URLs (`http://192.168.x.x/...`) are rejected 400