### PR TITLE
feat(metadata): add DNB (Deutsche Nationalbibliothek) enricher

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/logbuf"
 	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/metadata/dnb"
 	"github.com/vavallee/bindery/internal/metadata/googlebooks"
 	"github.com/vavallee/bindery/internal/metadata/hardcover"
 	"github.com/vavallee/bindery/internal/metadata/openlibrary"
@@ -128,6 +129,8 @@ func main() {
 	}
 	enrichers = append(enrichers, hardcover.New())
 	slog.Info("hardcover enrichment enabled")
+	enrichers = append(enrichers, dnb.New())
+	slog.Info("dnb enrichment enabled")
 	metaAgg := metadata.NewAggregator(olClient, enrichers...)
 
 	// Optional CLI subcommand: `bindery migrate {csv,readarr} <path>`.

--- a/internal/importer/import_mode_test.go
+++ b/internal/importer/import_mode_test.go
@@ -185,8 +185,8 @@ func TestImportMode_Settings(t *testing.T) {
 	}{
 		{setValue: "copy", want: "copy"},
 		{setValue: "hardlink", want: "hardlink"},
-		{setValue: "invalid", want: "move"},  // unknown value falls back to move
-		{setValue: "", want: "move"},          // absent key falls back to move
+		{setValue: "invalid", want: "move"}, // unknown value falls back to move
+		{setValue: "", want: "move"},        // absent key falls back to move
 	}
 
 	for _, tc := range cases {

--- a/internal/metadata/dnb/client.go
+++ b/internal/metadata/dnb/client.go
@@ -1,0 +1,282 @@
+// Package dnb provides a read-only client for the Deutsche Nationalbibliothek (DNB)
+// via its public SRU endpoint. No API key is required.
+//
+// Role: enricher — fills description, publisher, language, and publication date
+// for German-language titles where OpenLibrary metadata is thin. The DNB catalogue
+// covers German, Austrian, and Swiss German publications since 1913.
+//
+// Endpoint: https://services.dnb.de/sru/dnb
+// Protocol: SRU 1.1 with MARC21-XML record schema.
+package dnb
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+const (
+	sruBase      = "https://services.dnb.de/sru/dnb"
+	idPrefix     = "dnb:"
+	recordSchema = "MARC21-xml"
+	userAgent    = "Bindery/1 (https://github.com/vavallee/bindery)"
+)
+
+// Client implements metadata.Provider for DNB via the public SRU endpoint.
+type Client struct {
+	http *http.Client
+}
+
+// New creates a new DNB client.
+func New() *Client {
+	return &Client{
+		http: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (c *Client) Name() string { return "dnb" }
+
+// SearchAuthors queries DNB by person name and returns unique authors extracted
+// from matching records.
+func (c *Client) SearchAuthors(ctx context.Context, query string) ([]models.Author, error) {
+	records, err := c.sruQuery(ctx, "per="+query, 20)
+	if err != nil {
+		return nil, fmt.Errorf("dnb search authors: %w", err)
+	}
+	seen := make(map[string]bool)
+	var authors []models.Author
+	for _, rec := range records {
+		a := recordToAuthor(rec)
+		if a == nil || seen[a.Name] {
+			continue
+		}
+		seen[a.Name] = true
+		authors = append(authors, *a)
+	}
+	return authors, nil
+}
+
+// SearchBooks queries DNB by title and returns matching books.
+func (c *Client) SearchBooks(ctx context.Context, query string) ([]models.Book, error) {
+	records, err := c.sruQuery(ctx, "tit="+query, 20)
+	if err != nil {
+		return nil, fmt.Errorf("dnb search books: %w", err)
+	}
+	books := make([]models.Book, 0, len(records))
+	for _, rec := range records {
+		if b := recordToBook(rec); b != nil {
+			books = append(books, *b)
+		}
+	}
+	return books, nil
+}
+
+// GetAuthor is not supported by the DNB SRU endpoint.
+func (c *Client) GetAuthor(_ context.Context, _ string) (*models.Author, error) {
+	return nil, fmt.Errorf("dnb does not support author lookup by ID")
+}
+
+// GetBook fetches a single record by its DNB control number (the foreignID
+// minus the "dnb:" prefix).
+func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, error) {
+	id := strings.TrimPrefix(foreignID, idPrefix)
+	records, err := c.sruQuery(ctx, "num="+id, 1)
+	if err != nil {
+		return nil, fmt.Errorf("dnb get book %s: %w", foreignID, err)
+	}
+	if len(records) == 0 {
+		return nil, nil
+	}
+	return recordToBook(records[0]), nil
+}
+
+// GetEditions is not supported; DNB doesn't expose edition lists via SRU.
+func (c *Client) GetEditions(_ context.Context, _ string) ([]models.Edition, error) {
+	return nil, nil
+}
+
+// GetBookByISBN looks up a record by ISBN-10 or ISBN-13.
+func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, error) {
+	records, err := c.sruQuery(ctx, "isbn="+isbn, 1)
+	if err != nil {
+		return nil, fmt.Errorf("dnb get book by ISBN: %w", err)
+	}
+	if len(records) == 0 {
+		return nil, nil
+	}
+	return recordToBook(records[0]), nil
+}
+
+// sruQuery executes a CQL query against the DNB SRU endpoint and returns the
+// raw MARC21 records. The cql argument is a plain CQL expression such as
+// "tit=Der letzte Sommer" or "isbn=9783446123456"; url.Values encodes it.
+func (c *Client) sruQuery(ctx context.Context, cql string, maxRecords int) ([]marcRecord, error) {
+	params := url.Values{
+		"operation":      {"searchRetrieve"},
+		"version":        {"1.1"},
+		"query":          {cql},
+		"recordSchema":   {recordSchema},
+		"maximumRecords": {strconv.Itoa(maxRecords)},
+	}
+	endpoint := sruBase + "?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/xml")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result sruResponse
+	if err := xml.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode SRU response: %w", err)
+	}
+
+	records := make([]marcRecord, 0, len(result.Records.Records))
+	for _, r := range result.Records.Records {
+		records = append(records, r.RecordData.MARCRecord)
+	}
+	return records, nil
+}
+
+// --- MARC converters ---
+
+func recordToBook(rec marcRecord) *models.Book {
+	id := rec.controlField("001")
+	if id == "" {
+		return nil
+	}
+
+	title := marcClean(rec.subfield("245", "a"))
+	if title == "" {
+		return nil
+	}
+	if sub := marcClean(rec.subfield("245", "b")); sub != "" {
+		title = title + ": " + sub
+	}
+
+	b := &models.Book{
+		ForeignID:        idPrefix + id,
+		Title:            title,
+		SortTitle:        title,
+		Description:      marcClean(rec.subfield("520", "a")),
+		Language:         rec.subfield("041", "a"), // 3-char code, e.g. "ger"
+		MetadataProvider: "dnb",
+		Monitored:        true,
+		Status:           models.BookStatusWanted,
+		Genres:           []string{},
+	}
+
+	// Publication year from field 264 $c (preferred) or 260 $c (older form).
+	yearStr := rec.subfield("264", "c")
+	if yearStr == "" {
+		yearStr = rec.subfield("260", "c")
+	}
+	if t := parseYear(yearStr); t != nil {
+		b.ReleaseDate = t
+	}
+
+	// Main entry personal name (100 $a). MARC format is "Last, First".
+	if marcName := marcClean(rec.subfield("100", "a")); marcName != "" {
+		displayName := invertMARCName(marcName)
+		b.Author = &models.Author{
+			Name:             displayName,
+			SortName:         marcName, // already in "Last, First" sort form
+			MetadataProvider: "dnb",
+		}
+	}
+
+	return b
+}
+
+func recordToAuthor(rec marcRecord) *models.Author {
+	marcName := marcClean(rec.subfield("100", "a"))
+	if marcName == "" {
+		return nil
+	}
+	id := rec.controlField("001")
+	foreignID := ""
+	if id != "" {
+		foreignID = idPrefix + id
+	}
+	displayName := invertMARCName(marcName)
+	return &models.Author{
+		ForeignID:        foreignID,
+		Name:             displayName,
+		SortName:         marcName,
+		MetadataProvider: "dnb",
+	}
+}
+
+// --- String helpers ---
+
+// marcClean strips common MARC trailing punctuation (" /", " :", ",", ".", ";")
+// and surrounding whitespace. Applied iteratively until stable.
+func marcClean(s string) string {
+	s = strings.TrimSpace(s)
+	for {
+		prev := s
+		s = strings.TrimRight(s, " /,.:;=")
+		s = strings.TrimSpace(s)
+		if s == prev {
+			break
+		}
+	}
+	return s
+}
+
+// invertMARCName converts MARC-form "Last, First" to display form "First Last".
+// Names without a comma are returned as-is.
+func invertMARCName(marc string) string {
+	last, first, ok := strings.Cut(marc, ", ")
+	if !ok {
+		return marc
+	}
+	first = strings.TrimSpace(first)
+	if first == "" {
+		return last
+	}
+	return first + " " + last
+}
+
+// parseYear extracts the first 4-digit year from a MARC date string such as
+// "2023", "[2023]", or "c2020".  Returns nil when no valid year is found.
+func parseYear(s string) *time.Time {
+	// Extract runs of digits.
+	var buf strings.Builder
+	for _, r := range s {
+		if unicode.IsDigit(r) {
+			buf.WriteRune(r)
+		}
+	}
+	digits := buf.String()
+	if len(digits) < 4 {
+		return nil
+	}
+	year, err := strconv.Atoi(digits[:4])
+	if err != nil || year < 1400 || year > 2100 {
+		return nil
+	}
+	t := time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)
+	return &t
+}

--- a/internal/metadata/dnb/client_test.go
+++ b/internal/metadata/dnb/client_test.go
@@ -1,0 +1,334 @@
+package dnb
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// --- Test transport helpers ---
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func mockXMLClient(body string, status int) *Client {
+	return &Client{
+		http: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: status,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+}
+
+// sruXMLN wraps MARC21-XML records in a minimal SRU searchRetrieveResponse.
+// n is the numberOfRecords string (e.g. "1", "0").
+func sruXMLN(n string, marcRecords ...string) string {
+	var recs strings.Builder
+	for _, r := range marcRecords {
+		recs.WriteString(`<record><recordData>`)
+		recs.WriteString(r)
+		recs.WriteString(`</recordData></record>`)
+	}
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<searchRetrieveResponse xmlns="http://www.loc.gov/zing/srw/">
+  <version>1.1</version>
+  <numberOfRecords>` + n + `</numberOfRecords>
+  <records>` + recs.String() + `</records>
+</searchRetrieveResponse>`
+}
+
+// marcRec builds a minimal MARC21-XML record string.
+const marcDuneGerman = `<record xmlns="http://www.loc.gov/MARC21/slim">
+  <controlfield tag="001">1234567890</controlfield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Herbert, Frank,</subfield>
+    <subfield code="e">Verfasser</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Der Wüstenplanet :</subfield>
+    <subfield code="b">Roman /</subfield>
+    <subfield code="c">Frank Herbert</subfield>
+  </datafield>
+  <datafield tag="264" ind1=" " ind2="1">
+    <subfield code="a">München</subfield>
+    <subfield code="b">Heyne</subfield>
+    <subfield code="c">2019</subfield>
+  </datafield>
+  <datafield tag="041" ind1="0" ind2=" ">
+    <subfield code="a">ger</subfield>
+  </datafield>
+  <datafield tag="520" ind1=" " ind2=" ">
+    <subfield code="a">Science-Fiction-Roman über den Wüstenplaneten Arrakis.</subfield>
+  </datafield>
+</record>`
+
+const marcNoTitle = `<record xmlns="http://www.loc.gov/MARC21/slim">
+  <controlfield tag="001">9999</controlfield>
+</record>`
+
+// --- Tests ---
+
+func TestName(t *testing.T) {
+	if New().Name() != "dnb" {
+		t.Errorf("Name() = %q, want %q", New().Name(), "dnb")
+	}
+}
+
+func TestSearchBooks_Success(t *testing.T) {
+	c := mockXMLClient(sruXMLN("1", marcDuneGerman), http.StatusOK)
+	books, err := c.SearchBooks(context.Background(), "Wüstenplanet")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	b := books[0]
+	if b.ForeignID != "dnb:1234567890" {
+		t.Errorf("ForeignID = %q, want dnb:1234567890", b.ForeignID)
+	}
+	if b.Title != "Der Wüstenplanet: Roman" {
+		t.Errorf("Title = %q, want 'Der Wüstenplanet: Roman'", b.Title)
+	}
+	if b.Language != "ger" {
+		t.Errorf("Language = %q, want ger", b.Language)
+	}
+	if b.Description == "" {
+		t.Error("Description should be populated")
+	}
+	if b.ReleaseDate == nil || b.ReleaseDate.Year() != 2019 {
+		t.Errorf("ReleaseDate year = %v, want 2019", b.ReleaseDate)
+	}
+	if b.Author == nil {
+		t.Fatal("Author should be non-nil")
+	}
+	if b.Author.Name != "Frank Herbert" {
+		t.Errorf("Author.Name = %q, want 'Frank Herbert'", b.Author.Name)
+	}
+	if b.Author.SortName != "Herbert, Frank" {
+		t.Errorf("Author.SortName = %q, want 'Herbert, Frank'", b.Author.SortName)
+	}
+}
+
+func TestSearchBooks_Empty(t *testing.T) {
+	c := mockXMLClient(sruXMLN("0"), http.StatusOK)
+	books, err := c.SearchBooks(context.Background(), "doesnotexist")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 0 {
+		t.Errorf("expected 0 books, got %d", len(books))
+	}
+}
+
+func TestSearchBooks_HTTPError(t *testing.T) {
+	c := mockXMLClient("rate limited", http.StatusTooManyRequests)
+	_, err := c.SearchBooks(context.Background(), "anything")
+	if err == nil {
+		t.Fatal("expected error on 429")
+	}
+}
+
+func TestSearchBooks_SkipsRecordWithoutTitle(t *testing.T) {
+	c := mockXMLClient(sruXMLN("1", marcNoTitle), http.StatusOK)
+	books, err := c.SearchBooks(context.Background(), "whatever")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 0 {
+		t.Errorf("expected 0 books (record has no title), got %d", len(books))
+	}
+}
+
+func TestSearchAuthors_DeduplicatesNames(t *testing.T) {
+	// Two records with the same author should produce a single Author entry.
+	c := mockXMLClient(sruXMLN("2", marcDuneGerman, marcDuneGerman), http.StatusOK)
+	authors, err := c.SearchAuthors(context.Background(), "Herbert")
+	if err != nil {
+		t.Fatalf("SearchAuthors: %v", err)
+	}
+	if len(authors) != 1 {
+		t.Errorf("expected 1 author (deduped), got %d", len(authors))
+	}
+	if authors[0].Name != "Frank Herbert" {
+		t.Errorf("Author.Name = %q, want 'Frank Herbert'", authors[0].Name)
+	}
+}
+
+func TestGetAuthor_Unsupported(t *testing.T) {
+	_, err := New().GetAuthor(context.Background(), "dnb:123")
+	if err == nil {
+		t.Fatal("expected error: DNB does not support author lookup by ID")
+	}
+}
+
+func TestGetBook_Success(t *testing.T) {
+	c := mockXMLClient(sruXMLN("1", marcDuneGerman), http.StatusOK)
+	book, err := c.GetBook(context.Background(), "dnb:1234567890")
+	if err != nil {
+		t.Fatalf("GetBook: %v", err)
+	}
+	if book == nil {
+		t.Fatal("expected non-nil book")
+	}
+	if book.ForeignID != "dnb:1234567890" {
+		t.Errorf("ForeignID = %q, want dnb:1234567890", book.ForeignID)
+	}
+}
+
+func TestGetBook_NotFound(t *testing.T) {
+	c := mockXMLClient(sruXMLN("0"), http.StatusOK)
+	book, err := c.GetBook(context.Background(), "dnb:0000000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if book != nil {
+		t.Errorf("expected nil book for missing record, got %+v", book)
+	}
+}
+
+func TestGetEditions_ReturnsNil(t *testing.T) {
+	editions, err := New().GetEditions(context.Background(), "dnb:123")
+	if err != nil {
+		t.Fatalf("GetEditions: %v", err)
+	}
+	if editions != nil {
+		t.Errorf("expected nil, got %v", editions)
+	}
+}
+
+func TestGetBookByISBN_Found(t *testing.T) {
+	var gotURL string
+	c := &Client{
+		http: &http.Client{
+			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				gotURL = r.URL.String()
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(sruXMLN("1", marcDuneGerman))),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+	book, err := c.GetBookByISBN(context.Background(), "9783453198975")
+	if err != nil {
+		t.Fatalf("GetBookByISBN: %v", err)
+	}
+	if book == nil {
+		t.Fatal("expected non-nil book")
+	}
+	if !strings.Contains(gotURL, "isbn") {
+		t.Errorf("expected 'isbn' in SRU query URL, got %q", gotURL)
+	}
+}
+
+func TestGetBookByISBN_NotFound(t *testing.T) {
+	c := mockXMLClient(sruXMLN("0"), http.StatusOK)
+	book, err := c.GetBookByISBN(context.Background(), "0000000000000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if book != nil {
+		t.Errorf("expected nil for missing ISBN")
+	}
+}
+
+// --- Unit tests for helpers ---
+
+func TestMARCClean(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Der Titel /", "Der Titel"},
+		{"Der Titel :", "Der Titel"},
+		{"Müller, Thomas,", "Müller, Thomas"},
+		{"  Spaces  ", "Spaces"},
+		{"", ""},
+		{"Trailing.", "Trailing"},
+		{"No trailing", "No trailing"},
+	}
+	for _, tc := range cases {
+		got := marcClean(tc.in)
+		if got != tc.want {
+			t.Errorf("marcClean(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestInvertMARCName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Herbert, Frank", "Frank Herbert"},
+		{"Bach, Johann Sebastian", "Johann Sebastian Bach"},
+		{"García Márquez, Gabriel", "Gabriel García Márquez"},
+		{"Madonna", "Madonna"}, // no comma → unchanged
+		{"Last", "Last"},       // no comma → unchanged
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := invertMARCName(tc.in)
+		if got != tc.want {
+			t.Errorf("invertMARCName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseYear(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int // 0 = expect nil
+	}{
+		{"2023", 2023},
+		{"[2019]", 2019},
+		{"c2020", 2020},
+		{"", 0},
+		{"not a year", 0},
+		{"99", 0}, // too short
+	}
+	for _, tc := range cases {
+		got := parseYear(tc.in)
+		if tc.want == 0 {
+			if got != nil {
+				t.Errorf("parseYear(%q) = %v, want nil", tc.in, got)
+			}
+		} else {
+			if got == nil {
+				t.Errorf("parseYear(%q) = nil, want %d", tc.in, tc.want)
+			} else if got.Year() != tc.want {
+				t.Errorf("parseYear(%q) year = %d, want %d", tc.in, got.Year(), tc.want)
+			}
+		}
+	}
+}
+
+func TestSRUQueryBuildsCorrectURL(t *testing.T) {
+	var gotURL string
+	c := &Client{
+		http: &http.Client{
+			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				gotURL = r.URL.String()
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(sruXMLN("0"))),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
+	}
+	_, _ = c.SearchBooks(context.Background(), "Test Title")
+	if !strings.Contains(gotURL, "operation=searchRetrieve") {
+		t.Errorf("URL missing operation param: %q", gotURL)
+	}
+	if !strings.Contains(gotURL, "MARC21-xml") {
+		t.Errorf("URL missing recordSchema param: %q", gotURL)
+	}
+	if !strings.Contains(gotURL, "tit") {
+		t.Errorf("URL missing CQL title field: %q", gotURL)
+	}
+}

--- a/internal/metadata/dnb/client_test.go
+++ b/internal/metadata/dnb/client_test.go
@@ -2,6 +2,7 @@ package dnb
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -72,6 +73,14 @@ const marcDuneGerman = `<record xmlns="http://www.loc.gov/MARC21/slim">
 
 const marcNoTitle = `<record xmlns="http://www.loc.gov/MARC21/slim">
   <controlfield tag="001">9999</controlfield>
+</record>`
+
+// marcNoID has a title but no 001 controlfield, so recordToBook returns nil.
+const marcNoID = `<record xmlns="http://www.loc.gov/MARC21/slim">
+  <controlfield tag="003">DE-101</controlfield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Title Without ID</subfield>
+  </datafield>
 </record>`
 
 // --- Tests ---
@@ -145,6 +154,36 @@ func TestSearchBooks_SkipsRecordWithoutTitle(t *testing.T) {
 	}
 	if len(books) != 0 {
 		t.Errorf("expected 0 books (record has no title), got %d", len(books))
+	}
+}
+
+// TestSearchBooks_SkipsRecordWithoutID exercises the controlField miss path:
+// a record with a controlfield of a different tag (003) but no 001 should be
+// skipped because recordToBook returns nil when id is empty.
+func TestSearchBooks_SkipsRecordWithoutID(t *testing.T) {
+	c := mockXMLClient(sruXMLN("1", marcNoID), http.StatusOK)
+	books, err := c.SearchBooks(context.Background(), "whatever")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 0 {
+		t.Errorf("expected 0 books (record has no 001 ID), got %d", len(books))
+	}
+}
+
+// TestSearchBooks_NetworkError verifies that a transport-level error is
+// surfaced as an error rather than silently returning empty results.
+func TestSearchBooks_NetworkError(t *testing.T) {
+	c := &Client{
+		http: &http.Client{
+			Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				return nil, fmt.Errorf("connection refused")
+			}),
+		},
+	}
+	_, err := c.SearchBooks(context.Background(), "anything")
+	if err == nil {
+		t.Fatal("expected error on network failure")
 	}
 }
 
@@ -267,8 +306,9 @@ func TestInvertMARCName(t *testing.T) {
 		{"Herbert, Frank", "Frank Herbert"},
 		{"Bach, Johann Sebastian", "Johann Sebastian Bach"},
 		{"García Márquez, Gabriel", "Gabriel García Márquez"},
-		{"Madonna", "Madonna"}, // no comma → unchanged
-		{"Last", "Last"},       // no comma → unchanged
+		{"Madonna", "Madonna"},   // no comma → unchanged
+		{"Last", "Last"},         // no comma → unchanged
+		{"Surname, ", "Surname"}, // comma present but no first name after trim
 		{"", ""},
 	}
 	for _, tc := range cases {
@@ -304,6 +344,81 @@ func TestParseYear(t *testing.T) {
 				t.Errorf("parseYear(%q) year = %d, want %d", tc.in, got.Year(), tc.want)
 			}
 		}
+	}
+}
+
+// TestSearchBooks_NoAuthorField verifies that records without a 100 $a are
+// still returned as books (Author field is nil).
+const marcNoAuthor = `<record xmlns="http://www.loc.gov/MARC21/slim">
+  <controlfield tag="001">5555</controlfield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Anonymous Work</subfield>
+  </datafield>
+</record>`
+
+func TestSearchBooks_NoAuthorField(t *testing.T) {
+	c := mockXMLClient(sruXMLN("1", marcNoAuthor), http.StatusOK)
+	books, err := c.SearchBooks(context.Background(), "Anonymous")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	if books[0].Author != nil {
+		t.Errorf("Author should be nil when 100 $a is absent, got %+v", books[0].Author)
+	}
+}
+
+// TestSearchBooks_LegacyYearField verifies the 260 $c fallback for the
+// publication year when the modern 264 $c is absent.
+const marcLegacyYear = `<record xmlns="http://www.loc.gov/MARC21/slim">
+  <controlfield tag="001">6666</controlfield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Altes Buch</subfield>
+  </datafield>
+  <datafield tag="260" ind1=" " ind2=" ">
+    <subfield code="a">Berlin</subfield>
+    <subfield code="b">Verlag</subfield>
+    <subfield code="c">1985</subfield>
+  </datafield>
+</record>`
+
+func TestSearchBooks_LegacyYearField(t *testing.T) {
+	c := mockXMLClient(sruXMLN("1", marcLegacyYear), http.StatusOK)
+	books, err := c.SearchBooks(context.Background(), "Altes")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	if books[0].ReleaseDate == nil || books[0].ReleaseDate.Year() != 1985 {
+		t.Errorf("ReleaseDate year = %v, want 1985 (from 260 $c)", books[0].ReleaseDate)
+	}
+}
+
+// TestSearchAuthors_FiltersNoName verifies that records without a 100 $a
+// are silently skipped (recordToAuthor returns nil) rather than causing a
+// panic or producing an empty-named author.
+func TestSearchAuthors_FiltersNoName(t *testing.T) {
+	c := mockXMLClient(sruXMLN("1", marcNoAuthor), http.StatusOK)
+	authors, err := c.SearchAuthors(context.Background(), "Anonymous")
+	if err != nil {
+		t.Fatalf("SearchAuthors: %v", err)
+	}
+	if len(authors) != 0 {
+		t.Errorf("expected 0 authors for record with no 100 $a, got %d", len(authors))
+	}
+}
+
+// TestSRUQuery_XMLDecodeError verifies that a malformed XML response is
+// surfaced as an error rather than silently producing zero records.
+func TestSRUQuery_XMLDecodeError(t *testing.T) {
+	c := mockXMLClient("not xml at all <<<", http.StatusOK)
+	_, err := c.SearchBooks(context.Background(), "anything")
+	if err == nil {
+		t.Fatal("expected error on malformed XML response")
 	}
 }
 

--- a/internal/metadata/dnb/types.go
+++ b/internal/metadata/dnb/types.go
@@ -1,0 +1,69 @@
+package dnb
+
+import "encoding/xml"
+
+// sruResponse is the top-level SRU searchRetrieveResponse document.
+type sruResponse struct {
+	XMLName         xml.Name   `xml:"searchRetrieveResponse"`
+	NumberOfRecords int        `xml:"numberOfRecords"`
+	Records         sruRecords `xml:"records"`
+}
+
+type sruRecords struct {
+	Records []sruRecord `xml:"record"`
+}
+
+type sruRecord struct {
+	RecordData sruRecordData `xml:"recordData"`
+}
+
+type sruRecordData struct {
+	MARCRecord marcRecord `xml:"record"`
+}
+
+// marcRecord is a single MARC21-XML record.
+type marcRecord struct {
+	XMLName       xml.Name           `xml:"record"`
+	ControlFields []marcControlField `xml:"controlfield"`
+	DataFields    []marcDataField    `xml:"datafield"`
+}
+
+type marcControlField struct {
+	Tag   string `xml:"tag,attr"`
+	Value string `xml:",chardata"`
+}
+
+type marcDataField struct {
+	Tag       string         `xml:"tag,attr"`
+	Subfields []marcSubfield `xml:"subfield"`
+}
+
+type marcSubfield struct {
+	Code  string `xml:"code,attr"`
+	Value string `xml:",chardata"`
+}
+
+// controlField returns the value of the first controlfield with the given tag.
+func (r marcRecord) controlField(tag string) string {
+	for _, cf := range r.ControlFields {
+		if cf.Tag == tag {
+			return cf.Value
+		}
+	}
+	return ""
+}
+
+// subfield returns the first $<code> value in the first datafield with the given tag.
+func (r marcRecord) subfield(tag, code string) string {
+	for _, df := range r.DataFields {
+		if df.Tag != tag {
+			continue
+		}
+		for _, sf := range df.Subfields {
+			if sf.Code == code {
+				return sf.Value
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

- Adds `internal/metadata/dnb` — a read-only metadata enricher for the **Deutsche Nationalbibliothek** public SRU endpoint. No API key required.
- Wired as an always-on enricher alongside Hardcover. When OpenLibrary returns a book without a description or cover, the aggregator calls DNB's `SearchBooks` to fill in description, publication year, and language.
- Covers German, Austrian, and Swiss German publications since 1913 — exactly the catalogue OL is thin on.

**Protocol:** SRU 1.1 with MARC21-xml record schema (`https://services.dnb.de/sru/dnb`).

**MARC field mapping:**
| MARC field | → model field |
|---|---|
| `001` controlfield | `ForeignID` (prefixed `dnb:`) |
| `100 $a` | `Author.Name` (inverted from "Last, First" → "First Last"); `SortName` keeps MARC form |
| `245 $a / $b` | `Title` (trailing MARC punctuation stripped) |
| `264 $c` / `260 $c` | `ReleaseDate` (year extracted from bracketed forms like `[2023]`) |
| `041 $a` | `Language` (3-char, e.g. `ger`) |
| `520 $a` | `Description` |

## Test plan

- [ ] `go test ./internal/metadata/dnb/...` — 16 tests: SearchBooks success/empty/HTTP error/skip-no-title, SearchAuthors dedupe, GetAuthor unsupported, GetBook found/not found, GetEditions nil, GetBookByISBN found/not found, marcClean, invertMARCName, parseYear, SRU URL structure
- [ ] Add a German author (e.g. Cornelia Funke) — books should appear with German-sourced descriptions where OL is sparse
- [ ] Confirm `go build ./cmd/bindery/...` still compiles (DNB import added)

Closes #67