### PR TITLE
fix(api): handle discarded errors in queue, migrate, library (G104)

### DIFF
--- a/internal/api/migrate.go
+++ b/internal/api/migrate.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -114,11 +115,13 @@ func (h *MigrateHandler) ImportReadarr(w http.ResponseWriter, r *http.Request) {
 	tmpPath := tmp.Name()
 	defer os.Remove(tmpPath)
 	if _, err := io.Copy(tmp, file); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "write temp: " + err.Error()})
 		return
 	}
-	tmp.Close()
+	if err := tmp.Close(); err != nil {
+		slog.Error("failed to close temp file", "path", tmpPath, "error", err)
+	}
 
 	result, err := migrate.ImportReadarr(
 		r.Context(), tmpPath,


### PR DESCRIPTION
## Summary

gosec flagged eight sites where method return values were silently discarded:

- **queue.go** (4 sites): `SetError`, `UpdateStatus`, `SetNzoID` on the download repo — fire-and-forget DB writes in the grab handler. Now logged at error level so a failing database surfaces in logs.
- **migrate.go** (2 sites): `tmp.Close()` on the Readarr import temp file. Error path uses `_ =` (file is about to be removed); success path checks and logs.
- **library.go** (1 site): `w.Write` on a pre-serialised JSON string. Explicitly discarded with `_, _ =` — the only possible error is a disconnected client, which net/http already handles.

Closes gosec G104 alerts #71–74, #76–78.

## Test plan

- [x] `go test ./internal/api/...` passes
- [ ] CI green