### PR TITLE
fix(ci): scope write permissions per-job, unblock Scorecard publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,20 +7,18 @@ on:
   pull_request:
 
 permissions:
-  contents: write
-  packages: write
-  security-events: write
-  # Required for actions/attest-build-provenance to mint SLSA attestations
-  # against the OIDC token of the GitHub-hosted runner. Without this the
-  # provenance step silently produces an unsigned artifact.
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
   # Single job: test + build + push + deploy
   # Eliminates inter-job wait times and redundant checkouts
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # git push Helm chart image tag
+      packages: write      # docker push to ghcr.io
+      id-token: write      # SLSA attestation OIDC token
+      attestations: write  # actions/attest-build-provenance
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,23 +12,20 @@ on:
   push:
     branches: [main]
 
-# These permissions are the *minimum* required by scorecard-action.
-# Do NOT add extra permissions here — keep this workflow minimal.
+# Top-level permissions must be read-only — the Scorecard publish API
+# rejects results from workflows that declare any global write permission.
 permissions:
-  # Required to read Actions workflow definitions (branch-protection analysis)
   actions: read
-  # Required to read the repo tree
   contents: read
-  # Required to upload SARIF to the GitHub Security tab
-  security-events: write
-  # Required for Scorecard to sign results with Sigstore (OIDC token)
-  id-token: write
 
 jobs:
   scorecard:
     name: Scorecard Analysis
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      security-events: write  # upload SARIF to the Security tab
+      id-token: write         # Sigstore OIDC signing for publish_results
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -359,39 +359,6 @@ jobs:
           path: zap-out/
           retention-days: 30
 
-  # ── OpenSSF Scorecard ──────────────────────────────────────────────────────
-  # Only runs on push-to-main and schedule — not on PRs (no write token for forks)
-  scorecard:
-    name: OpenSSF Scorecard
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    if: >
-      github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    permissions:
-      security-events: write
-      id-token: write
-      contents: read
-      actions: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Scorecard
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
-        with:
-          results_file: scorecard.sarif
-          results_format: sarif
-          publish_results: true
-
-      - name: Upload Scorecard SARIF
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
-        if: always()
-        with:
-          sarif_file: scorecard.sarif
-          category: scorecard
-
   # ── Helm unit tests ────────────────────────────────────────────────────────
   # Stream C will add the test fixtures. continue-on-error until they land.
   policy-test:


### PR DESCRIPTION
## Summary

Three workflow permission fixes:

1. **scorecard.yml** — the Scorecard publish API rejects results from workflows that declare any global write permission. `security-events: write` and `id-token: write` were at the top level; moved them to a per-job `permissions` block. This was the root cause of every Scorecard run failing with *"workflow verification failed: global perm is set to write"*.

2. **security.yml** — removed the duplicate `scorecard` job. It can never publish results because `security.yml` needs `security-events: write` at the top level (every other job uploads SARIF). The dedicated `scorecard.yml` already handles Scorecard correctly.

3. **ci.yml** — narrowed top-level permissions to `contents: read`; moved write permissions into the `build` job only. Removed `security-events: write` entirely (ci.yml has no `upload-sarif` steps).

Addresses Scorecard TokenPermissionsID alerts #106–110 and unblocks the Scorecard badge + `publish_results` integration.

## Test plan

- [ ] CI green — `lint` and `validate` jobs succeed with narrowed `contents: read`
- [ ] `build` job still pushes image + Helm tag + SLSA attestation on main/development push
- [ ] After merge to main: Scorecard workflow passes and badge populates at `https://api.scorecard.dev/projects/github.com/vavallee/bindery/badge`