### PR TITLE
chore: add PR template with doc-update checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed
+- [ ] `CHANGELOG.md` `[Unreleased]` section updated
+- [ ] Wiki pages updated if user-facing behaviour changed
+
+## Test plan
+
+- [ ] `go test ./cmd/... ./internal/...`
+- [ ] `cd web && npm run build`


### PR DESCRIPTION
## Summary

- Adds `.github/pull_request_template.md` so every PR renders a checklist reminding the author to update DEPLOYMENT.md, CHANGELOG.md, and wiki pages when user-facing behaviour changes.
- Prevents the multi-release doc drift we just fixed in #113 — argon2id, env vars, and upgrade notes were stale across four releases because nothing prompted the update at PR time.

## Checklist

- [x] Tests added or updated — N/A (no code change)
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed — N/A
- [x] `CHANGELOG.md` `[Unreleased]` section updated — N/A (process change, not feature)
- [x] Wiki pages updated if user-facing behaviour changed — N/A