### PR TITLE
chore: structured issue templates and triage labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["bug", "needs-triage"]
+body:
+  - type: checkboxes
+    id: existing
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues and this isn't a duplicate
+          required: true
+        - label: I'm running the latest version (check Settings → About)
+          required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: Current behaviour
+      description: What happens now?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What should happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. Go to …
+        2. Click …
+        3. See error …
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Trace logs
+      description: |
+        Set log level to DEBUG in Settings → General, reproduce the bug, then paste the relevant log section.
+        **Issues without logs may be closed without investigation.**
+      render: text
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deploy
+    attributes:
+      label: Deployment method
+      options:
+        - Docker (ghcr.io)
+        - Helm / Kubernetes
+        - Binary (GoReleaser)
+        - Source build
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Bindery version
+      placeholder: "v0.12.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      description: OS, architecture, download client, indexer, reverse proxy — anything relevant.
+      placeholder: "Ubuntu 24.04, qBittorrent 5.0, Caddy reverse proxy"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support & Questions
+    url: https://github.com/vavallee/bindery/discussions
+    about: Ask questions, get help, and discuss Bindery in GitHub Discussions. The issue tracker is for confirmed bugs and feature requests only.
+  - name: Security vulnerability
+    url: https://github.com/vavallee/bindery/security/advisories/new
+    about: Report security vulnerabilities privately via GitHub Security Advisory.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: checkboxes
+    id: existing
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues and this isn't a duplicate
+          required: true
+        - label: I checked the [roadmap](https://github.com/vavallee/bindery/blob/main/docs/ROADMAP.md) and this isn't already planned
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What pain point does this address? What workflow is currently broken or missing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should Bindery solve this?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you consider? Why is the proposed solution better?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, links to similar features in other tools, etc.
+    validations:
+      required: false

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,7 +32,7 @@ The short version lives in the [README](../README.md#roadmap). ✅ items have la
 
 - ⬜ **External database support (MySQL / Postgres)** ([#86](https://github.com/vavallee/bindery/issues/86)) — optional settings for DB host, credentials, and connection path so Bindery can run against a shared MySQL/Postgres instance instead of the bundled SQLite file.
 
-  Useful for multi-replica HA deployments.
+  Useful for multi-replica HA deployments. Planned to ship alongside multi-user support — a single-user instance has no concurrency pressure that justifies leaving SQLite, and bundling both avoids two separate schema migrations.
 
 - **UI localization (i18n)** — translate the web UI into French, Dutch, and German (starting point; more languages welcome as contributors show up).
   - ✅ Translation-catalogue extraction pass (landed in v0.12.0).
@@ -75,6 +75,8 @@ These items are too large or architectural for a minor release. They define the 
 - **Native OIDC / SSO with multi-provider discovery** — Sign in against Authelia, Authentik, Keycloak, Google, or GitHub natively without an external reverse proxy. Session tokens issued by Bindery after validating the OIDC callback. Overlaps with the multi-user story: each OIDC subject maps to a Bindery user row.
 
 - **External database (MySQL / Postgres)** ([#86](https://github.com/vavallee/bindery/issues/86)) — The current `modernc.org/sqlite` driver is zero-CGO and ships inside the binary, which is excellent for single-instance homelabs. Multi-replica HA requires a shared external store. SQLite WAL is not a substitute for row-level locking under concurrent writers. The schema is already designed with foreign keys and explicit transactions; porting to `database/sql` + a MySQL/Postgres driver is feasible but requires end-to-end testing against both engines, a migration planner that works per-engine, and probably a connection-pool configurator in Settings.
+
+  > **Ships with multi-user.** External DB support only makes sense alongside multi-user (#73 above) — a single-user instance has no concurrency pressure that justifies leaving SQLite. Plan to deliver both in the same release so the migration path is tested once, not twice.
 
 - **Persistent structured log store** — The current ring buffer (1 000 entries, in-process memory) is a good v1 for the log viewer (Settings → Logs, [#93](https://github.com/vavallee/bindery/issues/93)). A v2 log store would persist entries to the database (or a rolling log file), survive restarts, be queryable across date ranges, and support structured search. Useful for incident retrospectives on long-running instances.
 


### PR DESCRIPTION
## Summary

- YAML-based bug report template requiring trace logs, version, and deployment method — modeled on Sonarr/Radarr's mandatory-logs pattern that dramatically improves triage quality
- Feature request template requiring problem statement, proposed solution, and alternatives considered
- `config.yml` disabling blank issues, redirecting support to GitHub Discussions and security reports to Security Advisories
- Three new labels created: `needs-triage`, `external-bug`, `one-day-maybe`
- Roadmap note pairing external DB support with multi-user (no point migrating off SQLite for single-user)

Informed by analysis of Sonarr (#958, #967, #3036) and Radarr (#1580, #2669, #5407) issue histories — the mandatory trace logs and structured templates are the single highest-ROI triage decisions both projects made.

## Checklist

- [ ] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [ ] Wiki pages updated if user-facing behaviour changed

## Test plan

- [ ] Visit https://github.com/vavallee/bindery/issues/new/choose and verify both templates render correctly
- [ ] Verify blank issue creation is blocked and contact links appear
- [ ] Verify `needs-triage`, `external-bug`, and `one-day-maybe` labels exist