### PR TITLE
fix(grab): route torrent grabs to torrent clients only, fixes protocol routing regression

### DIFF
--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"fmt"
+
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
@@ -177,7 +179,7 @@ func (h *QueueHandler) selectClient(ctx context.Context, protocol, mediaType str
 		return nil, err
 	}
 	if len(candidates) == 0 {
-		return h.clients.GetFirstEnabled(ctx)
+		return nil, fmt.Errorf("no enabled %s download client configured", protocol)
 	}
 	return db.PickClientForMediaType(candidates, mediaType), nil
 }

--- a/internal/db/download_clients.go
+++ b/internal/db/download_clients.go
@@ -104,7 +104,7 @@ func (r *DownloadClientRepo) GetFirstEnabled(ctx context.Context) (*models.Downl
 
 // GetFirstEnabledByProtocol returns the highest-priority enabled client that
 // matches the given protocol ("usenet" → sabnzbd, "torrent" → qbittorrent).
-// Falls back to the first enabled client of any type if no match is found.
+// Returns (nil, nil) if no matching client is configured.
 func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, protocol string) (*models.DownloadClient, error) {
 	clientType := "sabnzbd"
 	if protocol == "torrent" {
@@ -122,8 +122,7 @@ func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, prot
 		return nil, err
 	}
 	if errors.Is(err, sql.ErrNoRows) {
-		// No client of matching type — fall back to any enabled client
-		return r.GetFirstEnabled(ctx)
+		return nil, nil
 	}
 	c.Enabled = enabled == 1
 	c.UseSSL = useSSL == 1

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -194,10 +194,7 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	candidates, _ := s.clients.GetEnabledByProtocol(ctx, best.Protocol)
 	client := db.PickClientForMediaType(candidates, mediaType)
 	if client == nil {
-		client, _ = s.clients.GetFirstEnabled(ctx)
-	}
-	if client == nil {
-		slog.Debug("SearchAndGrabBook: no download client available", "book", book.Title)
+		slog.Warn("SearchAndGrabBook: no enabled download client for protocol", "book", book.Title, "protocol", best.Protocol)
 		return
 	}
 

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -95,6 +95,8 @@ export default function BookDetailPage() {
         nzbUrl: r.nzbUrl,
         size: r.size,
         bookId: book.id,
+        protocol: r.protocol,
+        mediaType: book.mediaType,
       })
       // Refresh book + history
       const [b, h] = await Promise.all([


### PR DESCRIPTION
## Summary

- **BookDetailPage** was not passing `protocol` or `mediaType` in grab requests, causing all grabs from the book detail view to default to `"usenet"` and route to SABnzbd — even for torrent results from Torznab indexers
- Backend fallback logic in `selectClient`, `GetFirstEnabledByProtocol`, and the scheduler auto-grab silently fell back to any enabled client when no protocol-matching client existed, enabling cross-protocol routing
- Now returns a clear error (API) or warning log (scheduler) instead of falling back to a wrong-protocol client

## Changes

| File | Fix |
|------|-----|
| `web/src/pages/BookDetailPage.tsx` | Pass `protocol` and `mediaType` in grab request |
| `internal/api/queue.go` | `selectClient` returns error instead of cross-protocol fallback |
| `internal/db/download_clients.go` | `GetFirstEnabledByProtocol` returns `nil` instead of falling back |
| `internal/scheduler/scheduler.go` | Auto-grab logs warning and skips instead of using wrong client |

## Test plan

- [ ] Configure only qBittorrent — grab a torrent result from BookDetailPage → should route to qBittorrent
- [ ] Configure only SABnzbd — grab a usenet result → should route to SABnzbd
- [ ] Configure only qBittorrent — grab a usenet result → should show "no enabled usenet download client configured" error
- [ ] Verify WantedPage grabs still work (already passed protocol)
- [ ] Run `go test ./internal/...` — all pass

Closes #144