### PR TITLE
fix(imageproxy): sharded cache dirs, eviction, and atomic writes (#138)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -265,6 +266,7 @@ func main() {
 	})
 	recHandler := api.NewRecommendationHandler(recRepo, recEngine, authorRepo, bookRepo, sched)
 	imageProxyHandler := api.NewImageProxyHandler(cfg.DataDir)
+	imageProxyHandler.StartEviction(24 * time.Hour)
 	migrateHandler := api.NewMigrateHandler(
 		authorRepo, indexerRepo, dlClientRepo, blocklistRepo, bookRepo, metaAgg,
 		// Bulk imports always populate the catalogue but never auto-grab.
@@ -294,7 +296,11 @@ func main() {
 		})
 		r.Get("/system/status", func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"version":"` + version + `","commit":"` + commit + `","buildDate":"` + date + `"}`))
+			cacheBytes, _ := imageProxyHandler.CacheSize()
+			_, _ = fmt.Fprintf(w,
+				`{"version":"%s","commit":"%s","buildDate":"%s","imageCacheBytes":%d}`,
+				version, commit, date, cacheBytes,
+			)
 		})
 
 		// Auth — status/login/logout/setup are always allowed through the

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -119,7 +119,7 @@ func (h *ImageProxyHandler) Serve(w http.ResponseWriter, r *http.Request) {
 
 	// Write to cache (best-effort — a write failure is not fatal).
 	// Atomic: write to .tmp, then rename so readers never see partial files.
-	if mkErr := os.MkdirAll(filepath.Dir(imgFile), imageDirMode); mkErr == nil {
+	if mkErr := os.MkdirAll(filepath.Dir(imgFile), imageDirMode); mkErr == nil { // #nosec G301 G304 -- path derived from sha256(url), not user input
 		tmp := imgFile + ".tmp"
 		if err := os.WriteFile(tmp, body, imageCacheMode); err == nil { // #nosec
 			_ = os.Rename(tmp, imgFile) // #nosec

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -119,7 +119,7 @@ func (h *ImageProxyHandler) Serve(w http.ResponseWriter, r *http.Request) {
 
 	// Write to cache (best-effort — a write failure is not fatal).
 	// Atomic: write to .tmp, then rename so readers never see partial files.
-	if mkErr := os.MkdirAll(filepath.Dir(imgFile), imageDirMode); mkErr == nil { // #nosec G301 G304 -- path derived from sha256(url), not user input
+	if mkErr := os.MkdirAll(filepath.Dir(imgFile), imageDirMode); mkErr == nil { // #nosec G301 G304 G703 -- path derived from sha256(url), not user input
 		tmp := imgFile + ".tmp"
 		if err := os.WriteFile(tmp, body, imageCacheMode); err == nil { // #nosec
 			_ = os.Rename(tmp, imgFile) // #nosec

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -4,10 +4,12 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -36,11 +38,13 @@ type ImageProxyHandler struct {
 // NewImageProxyHandler creates a handler that caches images under
 // <dataDir>/image-cache/.
 func NewImageProxyHandler(dataDir string) *ImageProxyHandler {
-	return &ImageProxyHandler{
+	h := &ImageProxyHandler{
 		cacheDir:    filepath.Join(dataDir, "image-cache"),
 		client:      &http.Client{Timeout: 15 * time.Second},
 		validateURL: func(u string) error { return httpsec.ValidateOutboundURL(u, httpsec.PolicyStrict) },
 	}
+	go h.migrateFlatCache()
+	return h
 }
 
 // Serve handles GET /api/v1/images?url=<encoded-external-url>.
@@ -60,7 +64,8 @@ func (h *ImageProxyHandler) Serve(w http.ResponseWriter, r *http.Request) {
 
 	sum := sha256.Sum256([]byte(raw))
 	key := fmt.Sprintf("%x", sum)
-	imgFile := filepath.Join(h.cacheDir, key)
+	shard := key[:2]
+	imgFile := filepath.Join(h.cacheDir, shard, key)
 	ctFile := imgFile + ".ct"
 
 	// Serve from cache if fresh.
@@ -113,15 +118,114 @@ func (h *ImageProxyHandler) Serve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Write to cache (best-effort — a write failure is not fatal).
-	if mkErr := os.MkdirAll(h.cacheDir, imageDirMode); mkErr == nil {
-		_ = os.WriteFile(imgFile, body, imageCacheMode)      // #nosec -- path derived from sha256(url), not user input
-		_ = os.WriteFile(ctFile, []byte(ct), imageCacheMode) // #nosec -- path derived from sha256(url), not user input
+	// Atomic: write to .tmp, then rename so readers never see partial files.
+	if mkErr := os.MkdirAll(filepath.Dir(imgFile), imageDirMode); mkErr == nil {
+		tmp := imgFile + ".tmp"
+		if err := os.WriteFile(tmp, body, imageCacheMode); err == nil { // #nosec
+			_ = os.Rename(tmp, imgFile) // #nosec
+		}
+		ctTmp := ctFile + ".tmp"
+		if err := os.WriteFile(ctTmp, []byte(ct), imageCacheMode); err == nil { // #nosec
+			_ = os.Rename(ctTmp, ctFile) // #nosec
+		}
 	}
 
 	w.Header().Set("Content-Type", ct)
 	w.Header().Set("Cache-Control", "public, max-age=2592000")
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
 	_, _ = w.Write(body)
+}
+
+// hexKeyRe matches a 64-character lowercase hex string (sha256 output).
+var hexKeyRe = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// migrateFlatCache moves legacy flat-layout cache files into the sharded
+// directory structure (image-cache/<first2chars>/<key>). Runs once at startup.
+func (h *ImageProxyHandler) migrateFlatCache() {
+	entries, err := os.ReadDir(h.cacheDir) // #nosec
+	if err != nil {
+		return // cache dir may not exist yet
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		// Skip .ct sidecars — they'll be moved alongside their parent.
+		if strings.HasSuffix(name, ".ct") {
+			continue
+		}
+		if !hexKeyRe.MatchString(name) {
+			continue
+		}
+		shard := name[:2]
+		dst := filepath.Join(h.cacheDir, shard, name)
+		if err := os.MkdirAll(filepath.Join(h.cacheDir, shard), imageDirMode); err != nil {
+			slog.Warn("image cache migration: mkdir failed", "shard", shard, "error", err)
+			continue
+		}
+		src := filepath.Join(h.cacheDir, name) // #nosec
+		if err := os.Rename(src, dst); err != nil {
+			slog.Warn("image cache migration: rename failed", "src", src, "error", err)
+			continue
+		}
+		// Move the .ct sidecar if it exists.
+		ctSrc := src + ".ct"
+		if _, err := os.Stat(ctSrc); err == nil { // #nosec
+			_ = os.Rename(ctSrc, dst+".ct") // #nosec
+		}
+	}
+}
+
+// StartEviction launches a background goroutine that periodically removes
+// cached images older than imageCacheTTL.
+func (h *ImageProxyHandler) StartEviction(interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			h.evictExpired()
+		}
+	}()
+}
+
+func (h *ImageProxyHandler) evictExpired() {
+	now := time.Now()
+	_ = filepath.WalkDir(h.cacheDir, func(path string, d os.DirEntry, err error) error { // #nosec
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		// Skip .ct sidecars — they're deleted alongside their parent.
+		if strings.HasSuffix(d.Name(), ".ct") {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if now.Sub(info.ModTime()) > imageCacheTTL {
+			_ = os.Remove(path)         // #nosec
+			_ = os.Remove(path + ".ct") // #nosec
+		}
+		return nil
+	})
+}
+
+// CacheSize returns the total bytes used by the image cache directory.
+func (h *ImageProxyHandler) CacheSize() (int64, error) {
+	var total int64
+	err := filepath.WalkDir(h.cacheDir, func(_ string, d os.DirEntry, err error) error { // #nosec
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
+	return total, err
 }
 
 // ProxyImageURL rewrites a raw external image URL into the local proxy path

--- a/internal/api/imageproxy_test.go
+++ b/internal/api/imageproxy_test.go
@@ -57,10 +57,13 @@ func TestImageProxy_CacheMiss(t *testing.T) {
 		t.Errorf("body = %q, want FAKEJPEG", body)
 	}
 
-	// Cache directory should now contain the key file and .ct sidecar.
-	entries, _ := os.ReadDir(filepath.Join(dir, "image-cache"))
+	// Cache directory should now contain the key file and .ct sidecar under a shard.
+	sum := sha256.Sum256([]byte(upstream.URL + "/cover.jpg"))
+	key := fmt.Sprintf("%x", sum)
+	shardDir := filepath.Join(dir, "image-cache", key[:2])
+	entries, _ := os.ReadDir(shardDir)
 	if len(entries) < 2 {
-		t.Errorf("expected at least 2 cache files (body + .ct), got %d", len(entries))
+		t.Errorf("expected at least 2 cache files (body + .ct) in %s, got %d", shardDir, len(entries))
 	}
 }
 
@@ -186,7 +189,11 @@ func TestImageProxy_CacheHitMissingCT(t *testing.T) {
 	const rawURL = "https://example.com/noct.jpg"
 	sum := sha256.Sum256([]byte(rawURL))
 	key := fmt.Sprintf("%x", sum)
-	if err := os.WriteFile(filepath.Join(cacheDir, key), []byte("CACHEDIMG"), 0o640); err != nil {
+	shardDir := filepath.Join(cacheDir, key[:2])
+	if err := os.MkdirAll(shardDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shardDir, key), []byte("CACHEDIMG"), 0o640); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary
- Shard image cache into 256 subdirectories (`image-cache/a3/a3f7b2…`) to prevent flat-directory bloat on large libraries.
- Add one-time background migration that moves existing flat-layout files into the new sharded structure on startup.
- Replace `os.WriteFile` with atomic tmp+rename pattern so concurrent readers never see partially-written cache entries.
- Add `StartEviction(24h)` background goroutine that walks the cache tree and purges files older than the 30-day TTL.
- Expose `CacheSize()` and surface `imageCacheBytes` in `GET /api/v1/system/status`.

Closes #138

## Test plan
- [ ] Start Bindery with an existing flat image cache — verify files are migrated into `image-cache/<xx>/` subdirectories
- [ ] Browse author/book pages — confirm cover images still load from the sharded cache
- [ ] Check `GET /api/v1/system/status` returns `imageCacheBytes` field
- [ ] Manually backdate a cached file's mtime past 30 days — verify the eviction goroutine removes it on next tick