### PR TITLE
feat(books): add exclude/hide flag (#103)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -313,6 +313,7 @@ func main() {
 		r.Put("/book/{id}", bookHandler.Update)
 		r.Delete("/book/{id}", bookHandler.Delete)
 		r.Delete("/book/{id}/file", bookHandler.DeleteFile)
+		r.Put("/book/{id}/exclude", bookHandler.ToggleExcluded)
 		r.Post("/book/{id}/enrich-audiobook", bookHandler.EnrichAudiobook)
 		r.Post("/book/{id}/search", indexerHandler.SearchBook)
 		r.Get("/book/{id}/file", fileHandler.Download)

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -73,15 +73,28 @@ func (h *BookHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	authorID := r.URL.Query().Get("authorId")
 	status := r.URL.Query().Get("status")
+	includeExcluded := r.URL.Query().Get("includeExcluded") == "true"
 
 	switch {
 	case authorID != "":
 		id, _ := strconv.ParseInt(authorID, 10, 64)
-		books, err = h.books.ListByAuthor(r.Context(), id)
+		if includeExcluded {
+			books, err = h.books.ListByAuthorIncludingExcluded(r.Context(), id)
+		} else {
+			books, err = h.books.ListByAuthor(r.Context(), id)
+		}
 	case status != "":
-		books, err = h.books.ListByStatus(r.Context(), status)
+		if includeExcluded {
+			books, err = h.books.ListByStatusIncludingExcluded(r.Context(), status)
+		} else {
+			books, err = h.books.ListByStatus(r.Context(), status)
+		}
 	default:
-		books, err = h.books.List(r.Context())
+		if includeExcluded {
+			books, err = h.books.ListIncludingExcluded(r.Context())
+		} else {
+			books, err = h.books.List(r.Context())
+		}
 	}
 
 	if err != nil {
@@ -334,7 +347,13 @@ func removeBookPath(p string) error {
 }
 
 func (h *BookHandler) ListWanted(w http.ResponseWriter, r *http.Request) {
-	books, err := h.books.ListByStatus(r.Context(), models.BookStatusWanted)
+	var books []models.Book
+	var err error
+	if r.URL.Query().Get("includeExcluded") == "true" {
+		books, err = h.books.ListByStatusIncludingExcluded(r.Context(), models.BookStatusWanted)
+	} else {
+		books, err = h.books.ListByStatus(r.Context(), models.BookStatusWanted)
+	}
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -343,4 +362,26 @@ func (h *BookHandler) ListWanted(w http.ResponseWriter, r *http.Request) {
 		books = []models.Book{}
 	}
 	writeJSON(w, http.StatusOK, books)
+}
+
+// ToggleExcluded flips the excluded flag on a book. The response body is the
+// updated book so the UI can refresh in place without a second round-trip.
+func (h *BookHandler) ToggleExcluded(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	book, err := h.books.GetByID(r.Context(), id)
+	if err != nil || book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
+
+	newVal := !book.Excluded
+	if err := h.books.SetExcluded(r.Context(), id, newVal); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	book.Excluded = newVal
+	writeJSON(w, http.StatusOK, book)
 }

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -22,17 +22,32 @@ const bookColumns = `id, foreign_id, author_id, title, sort_title, original_titl
 	image_url, release_date, genres, average_rating, ratings_count, monitored, status,
 	any_edition_ok, selected_edition_id, file_path, language, media_type, narrator, duration_seconds, asin,
 	calibre_id, metadata_provider, last_metadata_refresh_at, created_at, updated_at,
-	ebook_file_path, audiobook_file_path`
+	ebook_file_path, audiobook_file_path, excluded`
 
 func (r *BookRepo) List(ctx context.Context) ([]models.Book, error) {
+	return r.query(ctx, "SELECT "+bookColumns+" FROM books WHERE excluded = 0 ORDER BY sort_title", nil)
+}
+
+// ListIncludingExcluded returns all books regardless of their excluded flag.
+func (r *BookRepo) ListIncludingExcluded(ctx context.Context) ([]models.Book, error) {
 	return r.query(ctx, "SELECT "+bookColumns+" FROM books ORDER BY sort_title", nil)
 }
 
 func (r *BookRepo) ListByAuthor(ctx context.Context, authorID int64) ([]models.Book, error) {
+	return r.query(ctx, "SELECT "+bookColumns+" FROM books WHERE author_id = ? AND excluded = 0 ORDER BY release_date", []any{authorID})
+}
+
+// ListByAuthorIncludingExcluded returns all books for an author regardless of excluded flag.
+func (r *BookRepo) ListByAuthorIncludingExcluded(ctx context.Context, authorID int64) ([]models.Book, error) {
 	return r.query(ctx, "SELECT "+bookColumns+" FROM books WHERE author_id = ? ORDER BY release_date", []any{authorID})
 }
 
 func (r *BookRepo) ListByStatus(ctx context.Context, status string) ([]models.Book, error) {
+	return r.query(ctx, "SELECT "+bookColumns+" FROM books WHERE status = ? AND monitored = 1 AND excluded = 0 ORDER BY sort_title", []any{status})
+}
+
+// ListByStatusIncludingExcluded returns books with the given status regardless of excluded flag.
+func (r *BookRepo) ListByStatusIncludingExcluded(ctx context.Context, status string) ([]models.Book, error) {
 	return r.query(ctx, "SELECT "+bookColumns+" FROM books WHERE status = ? AND monitored = 1 ORDER BY sort_title", []any{status})
 }
 
@@ -214,6 +229,16 @@ func (r *BookRepo) FindByAuthorAndTitle(ctx context.Context, authorID int64, tit
 	return &books[0], nil
 }
 
+// SetExcluded toggles the excluded flag on a book.
+func (r *BookRepo) SetExcluded(ctx context.Context, id int64, excluded bool) error {
+	v := 0
+	if excluded {
+		v = 1
+	}
+	_, err := r.db.ExecContext(ctx, "UPDATE books SET excluded=?, updated_at=? WHERE id=?", v, time.Now().UTC(), id)
+	return err
+}
+
 func (r *BookRepo) Delete(ctx context.Context, id int64) error {
 	_, err := r.db.ExecContext(ctx, "DELETE FROM books WHERE id=?", id)
 	return err
@@ -235,7 +260,7 @@ func (r *BookRepo) query(ctx context.Context, q string, args []any) ([]models.Bo
 	var books []models.Book
 	for rows.Next() {
 		var b models.Book
-		var monitored, anyEditionOK int
+		var monitored, anyEditionOK, excluded int
 		var genresStr string
 		err := rows.Scan(
 			&b.ID, &b.ForeignID, &b.AuthorID, &b.Title, &b.SortTitle,
@@ -247,12 +272,14 @@ func (r *BookRepo) query(ctx context.Context, q string, args []any) ([]models.Bo
 			&b.CalibreID, &b.MetadataProvider, &b.LastMetadataRefreshAt,
 			&b.CreatedAt, &b.UpdatedAt,
 			&b.EbookFilePath, &b.AudiobookFilePath,
+			&excluded,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan book: %w", err)
 		}
 		b.Monitored = monitored == 1
 		b.AnyEditionOK = anyEditionOK == 1
+		b.Excluded = excluded == 1
 		_ = json.Unmarshal([]byte(genresStr), &b.Genres)
 		if b.Genres == nil {
 			b.Genres = []string{}

--- a/internal/db/migrations/014_book_excluded.sql
+++ b/internal/db/migrations/014_book_excluded.sql
@@ -1,0 +1,2 @@
+-- +migrate Up
+ALTER TABLE books ADD COLUMN excluded INTEGER NOT NULL DEFAULT 0;

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -41,6 +41,8 @@ type Book struct {
 	CreatedAt             time.Time  `json:"createdAt"`
 	UpdatedAt             time.Time  `json:"updatedAt"`
 
+	Excluded bool `json:"excluded"`
+
 	// Per-format file paths for dual-format support (media_type = 'both').
 	// Single-format books populate only the relevant column; the other stays "".
 	EbookFilePath     string `json:"ebookFilePath"`

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -280,6 +280,9 @@ func (s *Scheduler) searchWanted() {
 	}
 
 	for _, book := range wanted {
+		if book.Excluded {
+			continue
+		}
 		s.SearchAndGrabBook(ctx, book)
 	}
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -99,10 +99,11 @@ export const api = {
     }),
 
   // Books
-  listBooks: (params?: { authorId?: number; status?: string }) => {
+  listBooks: (params?: { authorId?: number; status?: string; includeExcluded?: boolean }) => {
     const q = new URLSearchParams()
     if (params?.authorId) q.set('authorId', String(params.authorId))
     if (params?.status) q.set('status', params.status)
+    if (params?.includeExcluded) q.set('includeExcluded', 'true')
     const qs = q.toString()
     return request<Book[]>(`/book${qs ? '?' + qs : ''}`)
   },
@@ -113,9 +114,13 @@ export const api = {
   deleteBookFile: (id: number, queryParams = '') => request<Book>(`/book/${id}/file${queryParams}`, { method: 'DELETE' }),
   searchBook: (id: number) => request<SearchResult[]>(`/book/${id}/search`, { method: 'POST' }),
   enrichAudiobook: (id: number) => request<Book>(`/book/${id}/enrich-audiobook`, { method: 'POST' }),
+  toggleExcluded: (id: number) => request<Book>(`/book/${id}/exclude`, { method: 'PUT' }),
 
   // Wanted
-  listWanted: () => request<Book[]>('/wanted/missing'),
+  listWanted: (opts?: { includeExcluded?: boolean }) => {
+    const qs = opts?.includeExcluded ? '?includeExcluded=true' : ''
+    return request<Book[]>(`/wanted/missing${qs}`)
+  },
 
   // Bulk actions
   bulkActionAuthors: (ids: number[], action: AuthorBulkAction) =>
@@ -273,6 +278,7 @@ export interface Book {
   // Per-format file paths for dual-format books (mediaType='both').
   ebookFilePath: string
   audiobookFilePath: string
+  excluded: boolean
   narrator?: string
   durationSeconds?: number
   asin?: string

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -123,7 +123,11 @@
     "statusDownloaded": "Downloaded",
     "statusImported": "In Library",
     "statusSkipped": "Skipped",
-    "audioLabel": "🎧 Audio"
+    "audioLabel": "🎧 Audio",
+    "exclude": "Exclude",
+    "unexclude": "Un-exclude",
+    "excluded": "Excluded",
+    "showExcluded": "Show excluded"
   },
   "wanted": {
     "title": "Wanted",
@@ -145,7 +149,9 @@
     "ebookDone": "📖 ✓",
     "audiobookDone": "🎧 ✓",
     "selectBook": "Select {{title}}",
-    "unmonitorHint": "Stop monitoring this book"
+    "unmonitorHint": "Stop monitoring this book",
+    "showExcluded": "Show excluded",
+    "excluded": "Excluded"
   },
   "history": {
     "title": "History",

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -44,6 +44,7 @@ export default function AuthorDetailPage() {
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
   const [showMerge, setShowMerge] = useState(false)
+  const [showExcluded, setShowExcluded] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const [view, setView] = useView('author-detail', 'grid')
@@ -102,20 +103,20 @@ export default function AuthorDetailPage() {
     setLoading(true)
     Promise.all([
       api.getAuthor(authorId),
-      api.listBooks({ authorId }),
+      api.listBooks({ authorId, includeExcluded: showExcluded }),
     ])
       .then(([a, bs]) => { if (!cancelled) { setAuthor(a); setBooks(bs) } })
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load'))
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
-  }, [authorId])
+  }, [authorId, showExcluded])
 
   const handleRefresh = async () => {
     if (!author) return
     setRefreshing(true)
     try {
       await api.refreshAuthor(author.id)
-      const [a, bs] = await Promise.all([api.getAuthor(authorId), api.listBooks({ authorId })])
+      const [a, bs] = await Promise.all([api.getAuthor(authorId), api.listBooks({ authorId, includeExcluded: showExcluded })])
       setAuthor(a)
       setBooks(bs)
     } catch (e) {
@@ -298,7 +299,18 @@ export default function AuthorDetailPage() {
               </span>
             )}
           </h3>
-          <ViewToggle view={view} onChange={setView} />
+          <div className="flex items-center gap-3">
+            <label className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-zinc-400 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={showExcluded}
+                onChange={e => setShowExcluded(e.target.checked)}
+                className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+              />
+              Show excluded
+            </label>
+            <ViewToggle view={view} onChange={setView} />
+          </div>
         </div>
 
         {/* Filter chips */}
@@ -369,6 +381,11 @@ export default function AuthorDetailPage() {
                         <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
                           {statusLabel[book.status] ?? book.status}
                         </span>
+                        {book.excluded && (
+                          <span className="inline-block ml-1 px-2 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">
+                            Excluded
+                          </span>
+                        )}
                       </td>
                     </tr>
                   ))}
@@ -401,6 +418,9 @@ export default function AuthorDetailPage() {
                     </span>
                     {book.mediaType === 'audiobook' && (
                       <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300">🎧 Audio</span>
+                    )}
+                    {book.excluded && (
+                      <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">Excluded</span>
                     )}
                   </div>
                   {book.releaseDate && (

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -42,6 +42,7 @@ export default function BookDetailPage() {
   const [enriching, setEnriching] = useState(false)
   const [deletingFile, setDeletingFile] = useState(false)
   const [deletingBook, setDeletingBook] = useState(false)
+  const [togglingExclude, setTogglingExclude] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -179,6 +180,19 @@ export default function BookDetailPage() {
     }
   }
 
+  const toggleExclude = async () => {
+    if (!book) return
+    setTogglingExclude(true)
+    try {
+      const updated = await api.toggleExcluded(book.id)
+      setBook(updated)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to toggle exclude')
+    } finally {
+      setTogglingExclude(false)
+    }
+  }
+
   if (loading) return <div className="text-slate-600 dark:text-zinc-500">Loading…</div>
   if (!book) return <div className="text-slate-600 dark:text-zinc-500">Book not found</div>
 
@@ -217,6 +231,11 @@ export default function BookDetailPage() {
             <span className={`inline-block px-2 py-0.5 rounded font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
               {book.status}
             </span>
+            {book.excluded && (
+              <span className="inline-block px-2 py-0.5 rounded font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">
+                Excluded
+              </span>
+            )}
             {book.releaseDate && (
               <span className="text-slate-600 dark:text-zinc-500">
                 {new Date(book.releaseDate).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
@@ -268,7 +287,22 @@ export default function BookDetailPage() {
               <span className="text-xs text-slate-500 dark:text-zinc-500 break-all">{book.filePath}</span>
             </div>
           ) : null}
-          <div className="mt-3">
+          <div className="mt-3 flex items-center gap-3">
+            <button
+              onClick={toggleExclude}
+              disabled={togglingExclude}
+              className={`text-xs font-medium px-3 py-1.5 rounded transition-colors disabled:opacity-40 ${
+                book.excluded
+                  ? 'bg-amber-500/20 text-amber-700 dark:text-amber-400 hover:bg-amber-500/30'
+                  : 'bg-slate-200 dark:bg-zinc-800 text-slate-700 dark:text-zinc-300 hover:bg-slate-300 dark:hover:bg-zinc-700'
+              }`}
+              title={book.excluded ? 'Un-exclude this book from searches and the Wanted page' : 'Exclude this book from searches and the Wanted page'}
+            >
+              {togglingExclude ? '…' : book.excluded ? 'Un-exclude' : 'Exclude'}
+            </button>
+            {book.excluded && (
+              <span className="text-xs text-amber-600 dark:text-amber-400 font-medium">Excluded from searches</span>
+            )}
             <button
               onClick={deleteBook}
               disabled={deletingBook || deletingFile}

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -20,15 +20,16 @@ export default function WantedPage() {
   const [unmonitoringId, setUnmonitoringId] = useState<number | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
   const [bulkBusy, setBulkBusy] = useState(false)
+  const [showExcluded, setShowExcluded] = useState(false)
   const selectAllRef = useRef<HTMLInputElement>(null)
 
   const load = () => {
-    api.listWanted().then(setBooks).catch(console.error).finally(() => setLoading(false))
+    api.listWanted({ includeExcluded: showExcluded }).then(setBooks).catch(console.error).finally(() => setLoading(false))
   }
 
   useEffect(() => {
     load()
-  }, [])
+  }, [showExcluded])
 
   const filtered = useMemo(() => {
     if (!search.trim()) return books
@@ -145,7 +146,18 @@ export default function WantedPage() {
     <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-bold">{t('wanted.title')}</h2>
-        <span className="text-sm text-slate-600 dark:text-zinc-500">{t('wanted.countLabel', { filtered: filtered.length, total: books.length })}</span>
+        <div className="flex items-center gap-4">
+          <label className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-zinc-400 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={showExcluded}
+              onChange={e => setShowExcluded(e.target.checked)}
+              className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+            />
+            {t('wanted.showExcluded')}
+          </label>
+          <span className="text-sm text-slate-600 dark:text-zinc-500">{t('wanted.countLabel', { filtered: filtered.length, total: books.length })}</span>
+        </div>
       </div>
 
       <input
@@ -233,6 +245,11 @@ export default function WantedPage() {
                     </div>
                   </div>
                   <div className="flex items-center gap-2 flex-shrink-0">
+                    {book.excluded && (
+                      <span className="px-2 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">
+                        {t('wanted.excluded')}
+                      </span>
+                    )}
                     <button
                       onClick={() => unmonitor(book)}
                       disabled={unmonitoringId === book.id}


### PR DESCRIPTION
## Summary
- Adds an `excluded` boolean column to books (migration 014) so users can hide specific books from the Wanted page and automated search/grab without deleting or unmonitoring them
- Backend: `PUT /book/{id}/exclude` toggles the flag; all list endpoints filter excluded books by default with `?includeExcluded=true` opt-in; scheduler skips excluded books in the wanted-search loop
- Frontend: Exclude/Un-exclude button on book detail page, "Show excluded" toggle on Wanted and Author detail pages, amber "Excluded" badges throughout

## Test plan
- [ ] Verify migration 014 applies cleanly on a fresh DB and on upgrade
- [ ] Toggle exclude on a book via the detail page — confirm badge appears and book disappears from Wanted
- [ ] Enable "Show excluded" on Wanted — confirm excluded books reappear with badge
- [ ] Verify excluded books are skipped by the 12-hour auto-search job
- [ ] Check Author detail page hides excluded books by default, shows them with toggle
- [ ] Un-exclude a book and confirm it returns to normal Wanted flow

Closes #103