### PR TITLE
feat(downloader): add Transmission RPC client (#29)

### DIFF
--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
+	"github.com/vavallee/bindery/internal/downloader/transmission"
 	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -134,18 +135,21 @@ func (h *DownloadClientHandler) Test(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if client.Type == "qbittorrent" {
+	var testErr error
+	switch client.Type {
+	case "qbittorrent":
 		qbt := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
-		if err := qbt.Test(r.Context()); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-			return
-		}
-	} else {
+		testErr = qbt.Test(r.Context())
+	case "transmission":
+		tr := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		testErr = tr.Test(r.Context())
+	default:
 		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
-		if err := sab.Test(r.Context()); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-			return
-		}
+		testErr = sab.Test(r.Context())
+	}
+	if testErr != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": testErr.Error()})
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"message": "ok"})
 }

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -3,17 +3,17 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
 
-	"fmt"
-
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
+	"github.com/vavallee/bindery/internal/downloader/transmission"
 	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -130,17 +130,24 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 
 	// Dispatch to the appropriate download client
 	if req.Protocol == "torrent" {
-		qbt := qbittorrent.New(client.Host, client.Port, client.URLBase, client.APIKey, client.UseSSL)
-		if err := qbt.AddTorrent(r.Context(), req.NZBURL, client.Category, ""); err != nil {
-			slog.Error("failed to send to qBittorrent", "error", err, "title", req.Title)
-			h.downloads.SetError(r.Context(), dl.ID, err.Error())
-			h.recordHistory(r.Context(), models.HistoryEventDownloadFailed, req.Title, req.BookID, map[string]interface{}{"guid": req.GUID, "message": err.Error()})
-			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send to qBittorrent: " + err.Error()})
+		var addErr error
+		if client.Type == "transmission" {
+			tr := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+			addErr = tr.AddTorrent(r.Context(), req.NZBURL, client.Category, "")
+		} else {
+			qbt := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+			addErr = qbt.AddTorrent(r.Context(), req.NZBURL, client.Category, "")
+		}
+		if addErr != nil {
+			slog.Error("failed to send to torrent client", "error", addErr, "title", req.Title, "client", client.Type)
+			h.downloads.SetError(r.Context(), dl.ID, addErr.Error())
+			h.recordHistory(r.Context(), models.HistoryEventDownloadFailed, req.Title, req.BookID, map[string]interface{}{"guid": req.GUID, "message": addErr.Error()})
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send to " + client.Type + ": " + addErr.Error()})
 			return
 		}
 		h.downloads.UpdateStatus(r.Context(), dl.ID, models.DownloadStatusDownloading)
 		dl.Status = models.DownloadStatusDownloading
-		slog.Info("download sent to qBittorrent", "title", req.Title)
+		slog.Info("download sent to torrent client", "title", req.Title, "client", client.Type)
 	} else {
 		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
 		resp, err := sab.AddURL(r.Context(), req.NZBURL, req.Title, client.Category, 0)
@@ -219,8 +226,8 @@ func (h *QueueHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 	// Remove from the appropriate download client
 	if target.Protocol == "torrent" {
-		// qBittorrent: we don't store a per-download torrent hash yet, so just
-		// remove the local record. Future work: store hash in Download and call qbt.DeleteTorrent.
+		// Torrent clients: we don't store a per-download torrent hash yet, so just
+		// remove the local record. Future work: store hash in Download and call DeleteTorrent.
 	} else if target.SABnzbdNzoID != nil {
 		client, err := h.clients.GetFirstEnabledByProtocol(r.Context(), "usenet")
 		if err == nil && client != nil {

--- a/internal/db/download_clients.go
+++ b/internal/db/download_clients.go
@@ -20,18 +20,19 @@ func NewDownloadClientRepo(db *sql.DB) *DownloadClientRepo {
 }
 
 // populateVirtualCredentials maps the storage columns to the virtual Username/Password
-// fields for qBittorrent clients (which store credentials in url_base and api_key).
+// fields for clients that store credentials in url_base and api_key (qBittorrent,
+// Transmission).
 func populateVirtualCredentials(c *models.DownloadClient) {
-	if c.Type == "qbittorrent" {
+	if c.Type == "qbittorrent" || c.Type == "transmission" {
 		c.Username = c.URLBase
 		c.Password = c.APIKey
 	}
 }
 
 // applyVirtualCredentials maps the virtual Username/Password fields back to the
-// storage columns for qBittorrent clients before writing to the database.
+// storage columns for credential-based clients before writing to the database.
 func applyVirtualCredentials(c *models.DownloadClient) {
-	if c.Type == "qbittorrent" {
+	if c.Type == "qbittorrent" || c.Type == "transmission" {
 		c.URLBase = c.Username
 		c.APIKey = c.Password
 	}
@@ -103,21 +104,26 @@ func (r *DownloadClientRepo) GetFirstEnabled(ctx context.Context) (*models.Downl
 }
 
 // GetFirstEnabledByProtocol returns the highest-priority enabled client that
-// matches the given protocol ("usenet" → sabnzbd, "torrent" → qbittorrent).
-// Returns (nil, nil) if no matching client is configured.
+// matches the given protocol ("usenet" -> sabnzbd, "torrent" -> qbittorrent or
+// transmission). Returns (nil, nil) if no matching client is configured.
 func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, protocol string) (*models.DownloadClient, error) {
-	clientType := "sabnzbd"
-	if protocol == "torrent" {
-		clientType = "qbittorrent"
-	}
-
 	var c models.DownloadClient
 	var enabled, useSSL int
-	err := r.db.QueryRowContext(ctx, `
-		SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
-		FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority LIMIT 1`, clientType).
-		Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt)
+	var err error
+
+	if protocol == "torrent" {
+		err = r.db.QueryRowContext(ctx, `
+			SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
+			FROM download_clients WHERE enabled=1 AND type IN ('qbittorrent','transmission') ORDER BY priority LIMIT 1`).
+			Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
+				&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt)
+	} else {
+		err = r.db.QueryRowContext(ctx, `
+			SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
+			FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority LIMIT 1`, "sabnzbd").
+			Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
+				&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt)
+	}
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
@@ -134,13 +140,17 @@ func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, prot
 // ordered by priority. Used when multiple clients of the same type exist and
 // the caller needs to pick the best one by category.
 func (r *DownloadClientRepo) GetEnabledByProtocol(ctx context.Context, protocol string) ([]models.DownloadClient, error) {
-	clientType := "sabnzbd"
+	var rows *sql.Rows
+	var err error
 	if protocol == "torrent" {
-		clientType = "qbittorrent"
+		rows, err = r.db.QueryContext(ctx, `
+			SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
+			FROM download_clients WHERE enabled=1 AND type IN ('qbittorrent','transmission') ORDER BY priority`)
+	} else {
+		rows, err = r.db.QueryContext(ctx, `
+			SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
+			FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority`, "sabnzbd")
 	}
-	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
-		FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority`, clientType)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -1,0 +1,230 @@
+// Package transmission provides a client for the Transmission RPC API,
+// used to submit magnet/torrent URLs and poll status for torrent downloads.
+package transmission
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Client interacts with the Transmission RPC API.
+// Authentication uses HTTP Basic (optional) plus a session token obtained
+// via a 409 challenge on the first request.
+//
+// Field mapping for DownloadClient storage:
+//   - APIKey  -> password  (Transmission uses username/password, not an API key)
+//   - URLBase -> username  (reused since Transmission ignores URL base)
+type Client struct {
+	baseURL   string
+	username  string
+	password  string
+	http      *http.Client
+	mu        sync.Mutex
+	sessionID string
+}
+
+// rpcRequest is the JSON envelope sent to the Transmission RPC endpoint.
+type rpcRequest struct {
+	Method    string      `json:"method"`
+	Arguments interface{} `json:"arguments,omitempty"`
+}
+
+// rpcResponse is the JSON envelope returned by the Transmission RPC endpoint.
+type rpcResponse struct {
+	Result    string          `json:"result"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// New creates a Transmission client.
+// username and password map to the DownloadClient's URLBase and APIKey fields
+// respectively (see comment on the Client struct).
+func New(host string, port int, username, password string, useSSL bool) *Client {
+	scheme := "http"
+	if useSSL {
+		scheme = "https"
+	}
+	return &Client{
+		baseURL:  fmt.Sprintf("%s://%s:%d", scheme, host, port),
+		username: username,
+		password: password,
+		http:     &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// Test verifies connectivity by calling session-get.
+func (c *Client) Test(ctx context.Context) error {
+	_, err := c.rpc(ctx, "session-get", nil)
+	if err != nil {
+		return fmt.Errorf("could not reach Transmission at %s — %w (in Docker use the service/container name, not localhost)", c.baseURL, err)
+	}
+	return nil
+}
+
+// AddTorrent submits a magnet link or torrent URL to Transmission for download.
+// The category parameter is used as the download directory (Transmission has no
+// built-in category concept).
+func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath string) error {
+	args := map[string]interface{}{
+		"filename": magnetOrURL,
+	}
+	dir := savePath
+	if dir == "" {
+		dir = category
+	}
+	if dir != "" {
+		args["download-dir"] = dir
+	}
+
+	resp, err := c.rpc(ctx, "torrent-add", args)
+	if err != nil {
+		return fmt.Errorf("add torrent: %w", err)
+	}
+	if resp.Result != "success" {
+		return fmt.Errorf("add torrent failed: %s", resp.Result)
+	}
+	return nil
+}
+
+// AddTorrentFile submits a .torrent file (as raw bytes) to Transmission.
+func (c *Client) AddTorrentFile(ctx context.Context, data []byte, category, savePath string) error {
+	args := map[string]interface{}{
+		"metainfo": base64.StdEncoding.EncodeToString(data),
+	}
+	dir := savePath
+	if dir == "" {
+		dir = category
+	}
+	if dir != "" {
+		args["download-dir"] = dir
+	}
+
+	resp, err := c.rpc(ctx, "torrent-add", args)
+	if err != nil {
+		return fmt.Errorf("add torrent file: %w", err)
+	}
+	if resp.Result != "success" {
+		return fmt.Errorf("add torrent file failed: %s", resp.Result)
+	}
+	return nil
+}
+
+// GetTorrents returns all torrents. The category parameter is accepted for
+// interface compatibility but is unused (Transmission has no built-in
+// category concept).
+func (c *Client) GetTorrents(ctx context.Context, _ string) ([]Torrent, error) {
+	args := map[string]interface{}{
+		"fields": []string{
+			"id", "name", "hashString", "status", "percentDone",
+			"rateDownload", "peersConnected", "error", "errorString", "downloadDir",
+		},
+	}
+
+	resp, err := c.rpc(ctx, "torrent-get", args)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Result != "success" {
+		return nil, fmt.Errorf("torrent-get failed: %s", resp.Result)
+	}
+
+	var result struct {
+		Torrents []Torrent `json:"torrents"`
+	}
+	if err := json.Unmarshal(resp.Arguments, &result); err != nil {
+		return nil, fmt.Errorf("decode torrents: %w", err)
+	}
+	return result.Torrents, nil
+}
+
+// DeleteTorrent removes a torrent by hash, optionally deleting its files.
+// Transmission accepts hash strings as torrent identifiers.
+func (c *Client) DeleteTorrent(ctx context.Context, hash string, deleteFiles bool) error {
+	args := map[string]interface{}{
+		"ids":               []string{hash},
+		"delete-local-data": deleteFiles,
+	}
+
+	resp, err := c.rpc(ctx, "torrent-remove", args)
+	if err != nil {
+		return fmt.Errorf("delete torrent: %w", err)
+	}
+	if resp.Result != "success" {
+		return fmt.Errorf("delete torrent failed: %s", resp.Result)
+	}
+	return nil
+}
+
+// rpc sends an RPC request to Transmission and returns the parsed response.
+// It handles the 409 session-token challenge transparently.
+func (c *Client) rpc(ctx context.Context, method string, arguments interface{}) (*rpcResponse, error) {
+	resp, err := c.doRPC(ctx, method, arguments)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle 409 Conflict — Transmission returns the session ID in the header.
+	if resp.StatusCode == http.StatusConflict {
+		sid := resp.Header.Get("X-Transmission-Session-Id")
+		resp.Body.Close()
+		if sid == "" {
+			return nil, fmt.Errorf("409 conflict but no X-Transmission-Session-Id header")
+		}
+		c.mu.Lock()
+		c.sessionID = sid
+		c.mu.Unlock()
+
+		resp, err = c.doRPC(ctx, method, arguments)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("authentication failed (HTTP 401)")
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var rpcResp rpcResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &rpcResp, nil
+}
+
+// doRPC performs a single HTTP POST to the Transmission RPC endpoint.
+func (c *Client) doRPC(ctx context.Context, method string, arguments interface{}) (*http.Response, error) {
+	body, err := json.Marshal(rpcRequest{Method: method, Arguments: arguments})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/transmission/rpc", bytes.NewReader(body)) // #nosec
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	c.mu.Lock()
+	sid := c.sessionID
+	c.mu.Unlock()
+	if sid != "" {
+		req.Header.Set("X-Transmission-Session-Id", sid)
+	}
+	if c.username != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+
+	return c.http.Do(req) // #nosec
+}

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -1,0 +1,398 @@
+package transmission
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newTestClient creates a Client pointing at the given test server URL.
+func newTestClient(serverURL, username, password string) *Client {
+	c := New("localhost", 9091, username, password, false)
+	c.baseURL = serverURL
+	return c
+}
+
+// rpcHandler returns an http.HandlerFunc that simulates the Transmission RPC endpoint.
+// It handles the 409 session-token challenge and dispatches by method name.
+func rpcHandler(t *testing.T, handlers map[string]func(json.RawMessage) (int, interface{})) http.HandlerFunc {
+	t.Helper()
+	const sessionID = "test-session-id"
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/transmission/rpc" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Session token challenge
+		if r.Header.Get("X-Transmission-Session-Id") != sessionID {
+			w.Header().Set("X-Transmission-Session-Id", sessionID)
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+
+		var req rpcRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		args, _ := json.Marshal(req.Arguments)
+		if h, ok := handlers[req.Method]; ok {
+			code, resp := h(args)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(code)
+			_ = json.NewEncoder(w).Encode(resp)
+		} else {
+			t.Errorf("unhandled method: %s", req.Method)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}
+}
+
+func TestNew(t *testing.T) {
+	c := New("myhost", 9091, "admin", "secret", false)
+	if c.baseURL != "http://myhost:9091" {
+		t.Errorf("baseURL: want %q, got %q", "http://myhost:9091", c.baseURL)
+	}
+	if c.username != "admin" || c.password != "secret" {
+		t.Error("credentials not stored correctly")
+	}
+	if c.sessionID != "" {
+		t.Error("sessionID should be empty on construction")
+	}
+
+	cs := New("securehost", 443, "u", "p", true)
+	if cs.baseURL != "https://securehost:443" {
+		t.Errorf("SSL baseURL: got %q", cs.baseURL)
+	}
+}
+
+func TestTest_Success(t *testing.T) {
+	srv := httptest.NewServer(rpcHandler(t, map[string]func(json.RawMessage) (int, interface{}){
+		"session-get": func(_ json.RawMessage) (int, interface{}) {
+			return http.StatusOK, rpcResponse{Result: "success"}
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	if err := c.Test(context.Background()); err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+}
+
+func TestTest_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("server error"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	if err := c.Test(context.Background()); err == nil {
+		t.Fatal("expected Test to fail on 500")
+	}
+}
+
+func TestTest_AuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "bad", "creds")
+	if err := c.Test(context.Background()); err == nil {
+		t.Fatal("expected Test to fail on 401")
+	}
+}
+
+func TestAddTorrent_Success(t *testing.T) {
+	var gotFilename string
+	srv := httptest.NewServer(rpcHandler(t, map[string]func(json.RawMessage) (int, interface{}){
+		"torrent-add": func(args json.RawMessage) (int, interface{}) {
+			var a map[string]interface{}
+			_ = json.Unmarshal(args, &a)
+			gotFilename, _ = a["filename"].(string)
+			return http.StatusOK, rpcResponse{Result: "success"}
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	if err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc123", "", ""); err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if gotFilename != "magnet:?xt=urn:btih:abc123" {
+		t.Errorf("filename: want magnet URI, got %q", gotFilename)
+	}
+}
+
+func TestAddTorrent_WithDownloadDir(t *testing.T) {
+	var gotDir string
+	srv := httptest.NewServer(rpcHandler(t, map[string]func(json.RawMessage) (int, interface{}){
+		"torrent-add": func(args json.RawMessage) (int, interface{}) {
+			var a map[string]interface{}
+			_ = json.Unmarshal(args, &a)
+			gotDir, _ = a["download-dir"].(string)
+			return http.StatusOK, rpcResponse{Result: "success"}
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	if err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", "/downloads/books"); err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if gotDir != "/downloads/books" {
+		t.Errorf("download-dir: want '/downloads/books', got %q", gotDir)
+	}
+}
+
+func TestAddTorrent_CategoryAsDir(t *testing.T) {
+	var gotDir string
+	srv := httptest.NewServer(rpcHandler(t, map[string]func(json.RawMessage) (int, interface{}){
+		"torrent-add": func(args json.RawMessage) (int, interface{}) {
+			var a map[string]interface{}
+			_ = json.Unmarshal(args, &a)
+			gotDir, _ = a["download-dir"].(string)
+			return http.StatusOK, rpcResponse{Result: "success"}
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	if err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "/data/books", ""); err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if gotDir != "/data/books" {
+		t.Errorf("download-dir: want '/data/books', got %q", gotDir)
+	}
+}
+
+func TestAddTorrent_Failure(t *testing.T) {
+	srv := httptest.NewServer(rpcHandler(t, map[string]func(json.RawMessage) (int, interface{}){
+		"torrent-add": func(_ json.RawMessage) (int, interface{}) {
+			return http.StatusOK, rpcResponse{Result: "invalid or corrupt torrent file"}
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	if err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:bad", "", ""); err == nil {
+		t.Fatal("expected error on non-success result")
+	}
+}
+
+func TestAddTorrentFile_Success(t *testing.T) {
+	var gotMetainfo string
+	srv := httptest.NewServer(rpcHandler(t, map[string]func(json.RawMessage) (int, interface{}){
+		"torrent-add": func(args json.RawMessage) (int, interface{}) {
+			var a map[string]interface{}
+			_ = json.Unmarshal(args, &a)
+			gotMetainfo, _ = a["metainfo"].(string)
+			return http.StatusOK, rpcResponse{Result: "success"}
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	data := []byte("fake torrent data")
+	if err := c.AddTorrentFile(context.Background(), data, "", ""); err != nil {
+		t.Fatalf("AddTorrentFile: %v", err)
+	}
+	if gotMetainfo == "" {
+		t.Error("expected metainfo in request")
+	}
+}
+
+func TestGetTorrents_Success(t *testing.T) {
+	srv := httptest.NewServer(rpcHandler(t, map[string]func(json.RawMessage) (int, interface{}){
+		"torrent-get": func(_ json.RawMessage) (int, interface{}) {
+			return http.StatusOK, map[string]interface{}{
+				"result": "success",
+				"arguments": map[string]interface{}{
+					"torrents": []Torrent{
+						{ID: 1, Name: "My Book", HashString: "abc123", Status: StatusDownloading, PercentDone: 0.5},
+						{ID: 2, Name: "Another Book", HashString: "def456", Status: StatusSeeding, PercentDone: 1.0},
+					},
+				},
+			}
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	torrents, err := c.GetTorrents(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetTorrents: %v", err)
+	}
+	if len(torrents) != 2 {
+		t.Fatalf("expected 2 torrents, got %d", len(torrents))
+	}
+	if torrents[0].HashString != "abc123" {
+		t.Errorf("first hash: want 'abc123', got %q", torrents[0].HashString)
+	}
+	if torrents[1].Name != "Another Book" {
+		t.Errorf("second name: want 'Another Book', got %q", torrents[1].Name)
+	}
+}
+
+func TestGetTorrents_Failure(t *testing.T) {
+	srv := httptest.NewServer(rpcHandler(t, map[string]func(json.RawMessage) (int, interface{}){
+		"torrent-get": func(_ json.RawMessage) (int, interface{}) {
+			return http.StatusOK, rpcResponse{Result: "some error"}
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	if _, err := c.GetTorrents(context.Background(), ""); err == nil {
+		t.Fatal("expected error on non-success result")
+	}
+}
+
+func TestDeleteTorrent_Success(t *testing.T) {
+	var gotIDs []interface{}
+	var gotDelete bool
+	srv := httptest.NewServer(rpcHandler(t, map[string]func(json.RawMessage) (int, interface{}){
+		"torrent-remove": func(args json.RawMessage) (int, interface{}) {
+			var a map[string]interface{}
+			_ = json.Unmarshal(args, &a)
+			gotIDs, _ = a["ids"].([]interface{})
+			gotDelete, _ = a["delete-local-data"].(bool)
+			return http.StatusOK, rpcResponse{Result: "success"}
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	if err := c.DeleteTorrent(context.Background(), "abc123", true); err != nil {
+		t.Fatalf("DeleteTorrent: %v", err)
+	}
+	if len(gotIDs) != 1 || gotIDs[0] != "abc123" {
+		t.Errorf("ids: want [abc123], got %v", gotIDs)
+	}
+	if !gotDelete {
+		t.Error("delete-local-data: want true, got false")
+	}
+}
+
+func TestDeleteTorrent_KeepFiles(t *testing.T) {
+	var gotDelete bool
+	srv := httptest.NewServer(rpcHandler(t, map[string]func(json.RawMessage) (int, interface{}){
+		"torrent-remove": func(args json.RawMessage) (int, interface{}) {
+			var a map[string]interface{}
+			_ = json.Unmarshal(args, &a)
+			gotDelete, _ = a["delete-local-data"].(bool)
+			return http.StatusOK, rpcResponse{Result: "success"}
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	_ = c.DeleteTorrent(context.Background(), "abc", false)
+	if gotDelete {
+		t.Error("delete-local-data: want false, got true")
+	}
+}
+
+func TestDeleteTorrent_Failure(t *testing.T) {
+	srv := httptest.NewServer(rpcHandler(t, map[string]func(json.RawMessage) (int, interface{}){
+		"torrent-remove": func(_ json.RawMessage) (int, interface{}) {
+			return http.StatusOK, rpcResponse{Result: "torrent not found"}
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	if err := c.DeleteTorrent(context.Background(), "abc", false); err == nil {
+		t.Fatal("expected error on non-success result")
+	}
+}
+
+// TestSessionTokenChallenge verifies that a 409 triggers session token acquisition.
+func TestSessionTokenChallenge(t *testing.T) {
+	requestCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.Header.Get("X-Transmission-Session-Id") != "my-session" {
+			w.Header().Set("X-Transmission-Session-Id", "my-session")
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rpcResponse{Result: "success"})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	if err := c.Test(context.Background()); err != nil {
+		t.Fatalf("expected retry to succeed: %v", err)
+	}
+	if requestCount != 2 {
+		t.Errorf("expected 2 requests (409 + retry), got %d", requestCount)
+	}
+	if c.sessionID != "my-session" {
+		t.Errorf("sessionID: want 'my-session', got %q", c.sessionID)
+	}
+}
+
+// TestBasicAuth verifies that credentials are sent when configured.
+func TestBasicAuth(t *testing.T) {
+	var gotUser, gotPass string
+	var gotAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Transmission-Session-Id") == "" {
+			w.Header().Set("X-Transmission-Session-Id", "s")
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		gotUser, gotPass, gotAuth = r.BasicAuth()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rpcResponse{Result: "success"})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "secret")
+	if err := c.Test(context.Background()); err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if !gotAuth {
+		t.Fatal("expected Basic auth header")
+	}
+	if gotUser != "admin" || gotPass != "secret" {
+		t.Errorf("auth: want admin/secret, got %s/%s", gotUser, gotPass)
+	}
+}
+
+// TestNoAuthWhenUsernameEmpty verifies no Basic auth when username is empty.
+func TestNoAuthWhenUsernameEmpty(t *testing.T) {
+	var gotAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Transmission-Session-Id") == "" {
+			w.Header().Set("X-Transmission-Session-Id", "s")
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		_, _, gotAuth = r.BasicAuth()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(rpcResponse{Result: "success"})
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "", "")
+	if err := c.Test(context.Background()); err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if gotAuth {
+		t.Error("did not expect Basic auth header when username is empty")
+	}
+}

--- a/internal/downloader/transmission/types.go
+++ b/internal/downloader/transmission/types.go
@@ -1,0 +1,26 @@
+package transmission
+
+// Torrent represents a single torrent as returned by the Transmission RPC API.
+type Torrent struct {
+	ID             int     `json:"id"`
+	Name           string  `json:"name"`
+	HashString     string  `json:"hashString"`
+	Status         int     `json:"status"`
+	PercentDone    float64 `json:"percentDone"`
+	RateDownload   int64   `json:"rateDownload"`
+	PeersConnected int     `json:"peersConnected"`
+	Error          int     `json:"error"`
+	ErrorString    string  `json:"errorString"`
+	DownloadDir    string  `json:"downloadDir"`
+}
+
+// Transmission torrent status constants.
+const (
+	StatusStopped      = 0
+	StatusCheckWait    = 1
+	StatusCheck        = 2
+	StatusDownloadWait = 3
+	StatusDownloading  = 4
+	StatusSeedWait     = 5
+	StatusSeeding      = 6
+)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
+	"github.com/vavallee/bindery/internal/downloader/transmission"
 	"github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/indexer/newznab"
@@ -233,14 +234,21 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	}
 
 	if best.Protocol == "torrent" {
-		qbt := qbittorrent.New(client.Host, client.Port, client.URLBase, client.APIKey, client.UseSSL)
-		if err := qbt.AddTorrent(ctx, best.NZBURL, client.Category, ""); err != nil {
-			slog.Error("SearchAndGrabBook: failed to send to qBittorrent", "title", best.Title, "error", err)
-			s.downloads.SetError(ctx, dl.ID, err.Error())
+		var addErr error
+		if client.Type == "transmission" {
+			tr := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+			addErr = tr.AddTorrent(ctx, best.NZBURL, client.Category, "")
+		} else {
+			qbt := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+			addErr = qbt.AddTorrent(ctx, best.NZBURL, client.Category, "")
+		}
+		if addErr != nil {
+			slog.Error("SearchAndGrabBook: failed to send to torrent client", "title", best.Title, "client", client.Type, "error", addErr)
+			s.downloads.SetError(ctx, dl.ID, addErr.Error())
 			return
 		}
 		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading)
-		slog.Info("sent to qBittorrent", "title", best.Title)
+		slog.Info("sent to torrent client", "title", best.Title, "client", client.Type)
 	} else {
 		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
 		resp, err := sab.AddURL(ctx, best.NZBURL, best.Title, client.Category, 0)


### PR DESCRIPTION
## Summary

- Adds Transmission as an alternative torrent download client alongside qBittorrent, closing #29
- New `internal/downloader/transmission/` package implementing the Transmission RPC protocol with 409 session-token challenge handling, optional HTTP Basic auth, and all required methods (torrent-add, torrent-get, torrent-remove, session-get)
- Updates DB layer to recognize `"transmission"` for virtual credential mapping and protocol-based client queries (`IN ('qbittorrent','transmission')`)
- Updates API test handler, queue grab dispatch, and scheduler auto-grab to select the correct client based on `client.Type`

## Files changed

| File | Change |
|---|---|
| `internal/downloader/transmission/client.go` | New — Transmission RPC client |
| `internal/downloader/transmission/types.go` | New — Torrent struct and status constants |
| `internal/downloader/transmission/client_test.go` | New — 17 tests covering all methods, session challenge, auth |
| `internal/db/download_clients.go` | Virtual credentials + protocol queries include `"transmission"` |
| `internal/api/download_clients.go` | Test handler dispatches to Transmission |
| `internal/api/queue.go` | Grab handler dispatches to Transmission for torrent protocol |
| `internal/scheduler/scheduler.go` | Auto-grab dispatches to Transmission for torrent protocol |

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/downloader/...` — all 42 tests pass (qBittorrent 19, SABnzbd 6, Transmission 17)
- [ ] Manual: configure a Transmission client in the UI, test connection, grab a torrent