### PR TITLE
feat(hardcover): import reading lists as Wanted books (#106)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vavallee/bindery/internal/calibre"
 	"github.com/vavallee/bindery/internal/config"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/hardcoverlistsyncer"
 	"github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/logbuf"
@@ -222,6 +223,10 @@ func main() {
 	}
 	sched.WithRecommender(recEngine)
 
+	// Register the Hardcover list syncer (24-hour job).
+	hcSyncer := hardcoverlistsyncer.New(importListRepo, authorRepo, bookRepo)
+	sched.WithHardcoverSyncer(hcSyncer)
+
 	sched.Start()
 	defer sched.Stop()
 
@@ -415,6 +420,7 @@ func main() {
 		// Import lists
 		r.Get("/importlist", importListHandler.List)
 		r.Post("/importlist", importListHandler.Create)
+		r.Get("/importlist/hardcover/lists", importListHandler.HardcoverLists)
 		r.Get("/importlist/{id}", importListHandler.Get)
 		r.Put("/importlist/{id}", importListHandler.Update)
 		r.Delete("/importlist/{id}", importListHandler.Delete)

--- a/internal/api/import_lists.go
+++ b/internal/api/import_lists.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata/hardcover"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -104,6 +105,23 @@ func (h *ImportListHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// HardcoverLists returns the authenticated user's Hardcover reading lists.
+// GET /api/v1/importlist/hardcover/lists?token=<tok>
+func (h *ImportListHandler) HardcoverLists(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "token query parameter required"})
+		return
+	}
+	client := hardcover.NewAuthenticated(token)
+	lists, err := client.GetUserLists(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, lists)
 }
 
 // --- Exclusions ---

--- a/internal/db/import_lists.go
+++ b/internal/db/import_lists.go
@@ -38,6 +38,36 @@ func (r *ImportListRepo) List(ctx context.Context) ([]models.ImportList, error) 
 	return lists, rows.Err()
 }
 
+func (r *ImportListRepo) ListByType(ctx context.Context, listType string) ([]models.ImportList, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, name, type, url, api_key, root_folder_id, quality_profile_id,
+		       monitor_new, auto_add, enabled, last_sync_at, created_at, updated_at
+		FROM import_lists WHERE type=? AND enabled=1 ORDER BY name`, listType)
+	if err != nil {
+		return nil, fmt.Errorf("list import lists by type: %w", err)
+	}
+	defer rows.Close()
+
+	var lists []models.ImportList
+	for rows.Next() {
+		il, err := scanImportList(rows)
+		if err != nil {
+			return nil, err
+		}
+		lists = append(lists, il)
+	}
+	return lists, rows.Err()
+}
+
+func (r *ImportListRepo) UpdateLastSyncAt(ctx context.Context, id int64) error {
+	now := time.Now().UTC()
+	_, err := r.db.ExecContext(ctx, "UPDATE import_lists SET last_sync_at=?, updated_at=? WHERE id=?", now, now, id)
+	if err != nil {
+		return fmt.Errorf("update last_sync_at for import list %d: %w", id, err)
+	}
+	return nil
+}
+
 func (r *ImportListRepo) GetByID(ctx context.Context, id int64) (*models.ImportList, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, type, url, api_key, root_folder_id, quality_profile_id,

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -1,0 +1,192 @@
+// Package hardcoverlistsyncer syncs Hardcover reading lists into Bindery's
+// book catalogue as "wanted" books.
+package hardcoverlistsyncer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata/hardcover"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// ListSyncer syncs enabled Hardcover import lists into Bindery's book catalogue.
+type ListSyncer struct {
+	importLists *db.ImportListRepo
+	authors     *db.AuthorRepo
+	books       *db.BookRepo
+}
+
+// New creates a new ListSyncer.
+func New(importLists *db.ImportListRepo, authors *db.AuthorRepo, books *db.BookRepo) *ListSyncer {
+	return &ListSyncer{
+		importLists: importLists,
+		authors:     authors,
+		books:       books,
+	}
+}
+
+// Sync processes all enabled import lists of type "hardcover".
+func (s *ListSyncer) Sync(ctx context.Context) error {
+	lists, err := s.importLists.ListByType(ctx, "hardcover")
+	if err != nil {
+		return fmt.Errorf("list hardcover import lists: %w", err)
+	}
+	if len(lists) == 0 {
+		slog.Debug("no enabled hardcover import lists")
+		return nil
+	}
+
+	var firstErr error
+	for _, il := range lists {
+		if err := s.syncList(ctx, il); err != nil {
+			slog.Error("hardcover list sync failed", "list", il.Name, "error", err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if err := s.importLists.UpdateLastSyncAt(ctx, il.ID); err != nil {
+			slog.Error("failed to update last_sync_at", "list", il.Name, "error", err)
+		}
+	}
+	return firstErr
+}
+
+func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
+	client := hardcover.NewAuthenticated(il.APIKey)
+
+	// Resolve the list by slug
+	userLists, err := client.GetUserLists(ctx)
+	if err != nil {
+		return fmt.Errorf("get user lists: %w", err)
+	}
+
+	var listID int
+	for _, ul := range userLists {
+		if ul.Slug == il.URL {
+			listID = ul.ID
+			break
+		}
+	}
+	if listID == 0 {
+		return fmt.Errorf("list with slug %q not found in user's Hardcover lists", il.URL)
+	}
+
+	books, err := client.GetListBooks(ctx, listID)
+	if err != nil {
+		return fmt.Errorf("get list books: %w", err)
+	}
+
+	slog.Info("syncing hardcover list", "list", il.Name, "slug", il.URL, "books", len(books))
+
+	for _, book := range books {
+		if book.ForeignID == "" {
+			continue
+		}
+
+		// Skip if already tracked
+		existing, _ := s.books.GetByForeignID(ctx, book.ForeignID)
+		if existing != nil {
+			slog.Debug("book already tracked, skipping", "title", book.Title, "foreignID", book.ForeignID)
+			continue
+		}
+
+		// Look up or create the author
+		authorID, err := s.ensureAuthor(ctx, &book)
+		if err != nil {
+			slog.Warn("failed to ensure author for book", "title", book.Title, "error", err)
+			continue
+		}
+
+		book.AuthorID = authorID
+		book.Monitored = true
+		book.Status = models.BookStatusWanted
+		if book.Genres == nil {
+			book.Genres = []string{}
+		}
+
+		if err := s.books.Create(ctx, &book); err != nil {
+			if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+				slog.Debug("book already exists (race)", "title", book.Title)
+				continue
+			}
+			slog.Warn("failed to create book", "title", book.Title, "error", err)
+			continue
+		}
+		slog.Info("imported book from hardcover list", "title", book.Title, "author_id", authorID)
+	}
+
+	return nil
+}
+
+// ensureAuthor looks up the author by foreign ID, creating a minimal record if
+// missing. Returns the author's database ID.
+func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book) (int64, error) {
+	if book.Author == nil {
+		return 0, fmt.Errorf("book %q has no author metadata", book.Title)
+	}
+
+	existing, err := s.authors.GetByForeignID(ctx, book.Author.ForeignID)
+	if err != nil {
+		return 0, err
+	}
+	if existing != nil {
+		return existing.ID, nil
+	}
+
+	// Create a minimal author record
+	author := book.Author
+	author.Monitored = true
+	author.MetadataProvider = "hardcover"
+	if author.SortName == "" {
+		author.SortName = sortName(author.Name)
+	}
+
+	if err := s.authors.Create(ctx, author); err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			// Race: author created between our check and insert
+			existing, _ = s.authors.GetByForeignID(ctx, author.ForeignID)
+			if existing != nil {
+				return existing.ID, nil
+			}
+		}
+		return 0, fmt.Errorf("create author %q: %w", author.Name, err)
+	}
+	slog.Info("created author from hardcover list", "name", author.Name, "foreignID", author.ForeignID)
+	return author.ID, nil
+}
+
+func sortName(name string) string {
+	parts := strings.Fields(name)
+	if len(parts) < 2 {
+		return name
+	}
+	last := parts[len(parts)-1]
+	rest := strings.Join(parts[:len(parts)-1], " ")
+	return last + ", " + rest
+}
+
+// HCListSyncer is satisfied by *ListSyncer — the scheduler uses this
+// interface to avoid a direct import of this package.
+type HCListSyncer interface {
+	Sync(ctx context.Context) error
+}
+
+// Ensure ListSyncer implements HCListSyncer at compile time.
+var _ HCListSyncer = (*ListSyncer)(nil)
+
+// RunSync implements the scheduler.CalibreSyncer-style signature so the
+// scheduler can call a single method with no return value, ignoring errors
+// (they are already logged inside Sync).
+func (s *ListSyncer) RunSync(ctx context.Context) {
+	if err := s.Sync(ctx); err != nil {
+		slog.Error("hardcover list sync error (top-level)", "error", err)
+	}
+}
+
+// Ensure *ListSyncer satisfies the narrow RunSync shape used by the scheduler.
+var _ interface{ RunSync(context.Context) } = (*ListSyncer)(nil)

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -21,7 +21,7 @@ const (
 )
 
 // Client implements metadata.Provider for Hardcover.app using its public GraphQL API.
-// Set a Bearer token via WithToken to enable authenticated queries (e.g. GetUserWishlist).
+// Set a Bearer token via WithToken or NewAuthenticated to enable authenticated queries.
 type Client struct {
 	http  *http.Client
 	token string // optional Bearer token; required for user-specific queries
@@ -38,6 +38,15 @@ func New() *Client {
 // Required for authenticated queries such as GetUserWishlist.
 func (c *Client) WithToken(token string) *Client {
 	return &Client{http: c.http, token: token}
+}
+
+// NewAuthenticated creates a new client that sends Authorization: Bearer <token>
+// for authenticated queries (e.g. reading user lists).
+func NewAuthenticated(token string) *Client {
+	return &Client{
+		http:  &http.Client{Timeout: 15 * time.Second},
+		token: token,
+	}
 }
 
 func (c *Client) Name() string { return "hardcover" }
@@ -265,6 +274,98 @@ func (c *Client) GetUserWishlist(ctx context.Context, limit int) ([]models.Recom
 		candidates = append(candidates, cand)
 	}
 	return candidates, nil
+}
+
+// --- Authenticated list queries ---
+
+// HCList represents a Hardcover reading list.
+type HCList struct {
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	Slug       string `json:"slug"`
+	BooksCount int    `json:"booksCount"`
+}
+
+// GetUserLists returns the authenticated user's reading lists.
+func (c *Client) GetUserLists(ctx context.Context) ([]HCList, error) {
+	gql := `query GetUserLists {
+		me {
+			lists {
+				id
+				name
+				slug
+				books_count
+			}
+		}
+	}`
+	var resp struct {
+		Data struct {
+			Me struct {
+				Lists []struct {
+					ID         int    `json:"id"`
+					Name       string `json:"name"`
+					Slug       string `json:"slug"`
+					BooksCount int    `json:"books_count"`
+				} `json:"lists"`
+			} `json:"me"`
+		} `json:"data"`
+	}
+	if err := c.query(ctx, gql, nil, &resp); err != nil {
+		return nil, fmt.Errorf("hardcover get user lists: %w", err)
+	}
+	lists := make([]HCList, 0, len(resp.Data.Me.Lists))
+	for _, l := range resp.Data.Me.Lists {
+		lists = append(lists, HCList{
+			ID:         l.ID,
+			Name:       l.Name,
+			Slug:       l.Slug,
+			BooksCount: l.BooksCount,
+		})
+	}
+	return lists, nil
+}
+
+// GetListBooks returns all books in the given list as Bindery models.
+func (c *Client) GetListBooks(ctx context.Context, listID int) ([]models.Book, error) {
+	gql := `query GetListBooks($id: Int!) {
+		list(id: $id) {
+			id
+			name
+			slug
+			list_books {
+				book {
+					id
+					title
+					slug
+					description
+					image { url }
+					release_year
+					ratings_count
+					rating
+					contributions {
+						author { id name slug }
+					}
+				}
+			}
+		}
+	}`
+	var resp struct {
+		Data struct {
+			List struct {
+				ListBooks []struct {
+					Book hcBook `json:"book"`
+				} `json:"list_books"`
+			} `json:"list"`
+		} `json:"data"`
+	}
+	if err := c.query(ctx, gql, map[string]any{"id": listID}, &resp); err != nil {
+		return nil, fmt.Errorf("hardcover get list books: %w", err)
+	}
+	books := make([]models.Book, 0, len(resp.Data.List.ListBooks))
+	for _, lb := range resp.Data.List.ListBooks {
+		books = append(books, c.toBook(lb.Book))
+	}
+	return books, nil
 }
 
 // --- GraphQL transport ---

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -38,6 +38,12 @@ type RecommendationEngine interface {
 	Run(ctx context.Context, userID int64) error
 }
 
+// HCListSyncer is the interface the scheduler calls to sync Hardcover import
+// lists. Implemented by *hardcoverlistsyncer.ListSyncer.
+type HCListSyncer interface {
+	Sync(ctx context.Context) error
+}
+
 // Scheduler runs background jobs on configurable intervals.
 type Scheduler struct {
 	cron     *cron.Cron
@@ -54,6 +60,7 @@ type Scheduler struct {
 	blocklist     *db.BlocklistRepo
 	calibreSyncer CalibreSyncer        // optional; nil if Calibre is not configured
 	recommender   RecommendationEngine // optional; generates recommendations
+	hcSyncer      HCListSyncer         // optional; syncs Hardcover import lists
 }
 
 // New creates a new scheduler.
@@ -94,6 +101,12 @@ func (s *Scheduler) WithCalibreSyncer(syncer CalibreSyncer) {
 // Must be called before Start.
 func (s *Scheduler) WithRecommender(engine RecommendationEngine) {
 	s.recommender = engine
+}
+
+// WithHardcoverSyncer registers a Hardcover list syncer that runs every 24
+// hours to import books from the user's Hardcover reading lists.
+func (s *Scheduler) WithHardcoverSyncer(syncer HCListSyncer) {
+	s.hcSyncer = syncer
 }
 
 // Start registers and runs all background jobs.
@@ -144,6 +157,16 @@ func (s *Scheduler) Start() {
 			}
 			if err := s.recommender.Run(context.Background(), 1); err != nil {
 				slog.Error("recommendation engine failed", "error", err)
+			}
+		})
+	}
+
+	// Sync Hardcover import lists every 24 hours.
+	if s.hcSyncer != nil {
+		s.cron.AddFunc("@every 24h", func() {
+			slog.Info("job: sync hardcover lists")
+			if err := s.hcSyncer.Sync(context.Background()); err != nil {
+				slog.Error("hardcover list sync failed", "error", err)
 			}
 		})
 	}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -203,6 +203,13 @@ export const api = {
   calibreImportStart: () => request<CalibreImportProgress>('/calibre/import', { method: 'POST' }),
   calibreImportStatus: () => request<CalibreImportProgress>('/calibre/import/status'),
 
+  // Import lists
+  listImportLists: () => request<ImportList[]>('/importlist'),
+  addImportList: (data: Partial<ImportList>) => request<ImportList>('/importlist', { method: 'POST', body: JSON.stringify(data) }),
+  updateImportList: (id: number, data: Partial<ImportList>) => request<ImportList>(`/importlist/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  deleteImportList: (id: number) => request<void>(`/importlist/${id}`, { method: 'DELETE' }),
+  hardcoverLists: (token: string) => request<HardcoverList[]>(`/importlist/hardcover/lists?token=${encodeURIComponent(token)}`),
+
   // Metadata Profiles
   listMetadataProfiles: () => request<MetadataProfile[]>('/metadataprofile'),
   addMetadataProfile: (data: Partial<MetadataProfile>) => request<MetadataProfile>('/metadataprofile', { method: 'POST', body: JSON.stringify(data) }),
@@ -521,6 +528,29 @@ export interface RootFolder {
   path: string
   freeSpace: number
   createdAt: string
+}
+
+export interface ImportList {
+  id: number
+  name: string
+  type: string
+  url: string
+  apiKey: string
+  rootFolderId?: number | null
+  qualityProfileId?: number | null
+  monitorNew: boolean
+  autoAdd: boolean
+  enabled: boolean
+  lastSyncAt?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface HardcoverList {
+  id: number
+  name: string
+  slug: string
+  booksCount: number
 }
 
 export interface LogEntry {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -332,7 +332,21 @@
       "resultAdded": "added",
       "resultSkipped": "skipped (already exist)",
       "resultFailed": "failed",
-      "showFailures": "Show {{count}} failures"
+      "showFailures": "Show {{count}} failures",
+      "hardcoverHeading": "Hardcover reading lists",
+      "hardcoverDescription": "Sync books from your Hardcover reading lists. Books are imported as Wanted and checked every 24 hours.",
+      "hardcoverAddButton": "+ Add Hardcover List",
+      "hardcoverName": "Name",
+      "hardcoverNamePlaceholder": "e.g. To Read",
+      "hardcoverToken": "API Token",
+      "hardcoverTokenPlaceholder": "Hardcover API token",
+      "hardcoverList": "List",
+      "hardcoverListPlaceholder": "Enter token to load lists",
+      "hardcoverListLoading": "Loading lists...",
+      "hardcoverNoLists": "No lists found",
+      "hardcoverEmpty": "No Hardcover import lists configured.",
+      "hardcoverLastSync": "Last sync: {{date}}",
+      "hardcoverNeverSynced": "Never synced"
     }
   },
   "addAuthorModal": {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, AuthConfig, AuthStatus, BlocklistEntry, Indexer, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, RootFolder, LogEntry } from '../api/client'
+import { api, AuthConfig, AuthStatus, BlocklistEntry, Indexer, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, RootFolder, LogEntry, ImportList, HardcoverList } from '../api/client'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
 import ThemeToggle from '../components/ThemeToggle'
@@ -891,11 +891,181 @@ function ImportTab() {
         )}
       </section>
 
+      <HardcoverListsSection />
+
       {err && (
         <div className="px-3 py-2 bg-red-100 dark:bg-red-950/30 border border-red-300 dark:border-red-900 rounded text-sm text-red-800 dark:text-red-300">
           {err}
         </div>
       )}
+    </div>
+  )
+}
+
+function HardcoverListsSection() {
+  const { t } = useTranslation()
+  const [lists, setLists] = useState<ImportList[]>([])
+  const [showAdd, setShowAdd] = useState(false)
+
+  useEffect(() => {
+    api.listImportLists().then(all => setLists(all.filter(l => l.type === 'hardcover'))).catch(console.error)
+  }, [])
+
+  const handleDelete = async (id: number) => {
+    await api.deleteImportList(id)
+    setLists(prev => prev.filter(l => l.id !== id))
+  }
+
+  const handleToggle = async (il: ImportList) => {
+    const updated = await api.updateImportList(il.id, { ...il, enabled: !il.enabled })
+    setLists(prev => prev.map(l => l.id === il.id ? updated : l))
+  }
+
+  return (
+    <section>
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="text-base font-semibold text-slate-800 dark:text-zinc-200">{t('settings.import.hardcoverHeading')}</h3>
+        <button onClick={() => setShowAdd(true)} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium">
+          {t('settings.import.hardcoverAddButton')}
+        </button>
+      </div>
+      <p className="text-xs text-slate-600 dark:text-zinc-500 mb-3">
+        {t('settings.import.hardcoverDescription')}
+      </p>
+
+      {lists.length === 0 && !showAdd && (
+        <p className="text-sm text-slate-500 dark:text-zinc-600">{t('settings.import.hardcoverEmpty')}</p>
+      )}
+
+      {lists.map(il => (
+        <div key={il.id} className="flex items-center justify-between p-3 mb-2 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">{il.name}</span>
+              <span className="text-[10px] px-1.5 py-0.5 bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400 rounded">{il.url}</span>
+            </div>
+            <div className="text-xs text-slate-500 dark:text-zinc-600 mt-0.5">
+              {il.lastSyncAt
+                ? t('settings.import.hardcoverLastSync', { date: new Date(il.lastSyncAt).toLocaleString() })
+                : t('settings.import.hardcoverNeverSynced')}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 ml-3">
+            <button
+              onClick={() => handleToggle(il)}
+              className={`text-xs px-2 py-1 rounded ${il.enabled ? 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-400' : 'bg-slate-200 dark:bg-zinc-800 text-slate-500 dark:text-zinc-500'}`}
+            >
+              {il.enabled ? t('common.enable') : t('common.disable')}
+            </button>
+            <button onClick={() => handleDelete(il.id)} className="text-xs text-red-600 dark:text-red-400 hover:underline">{t('common.delete')}</button>
+          </div>
+        </div>
+      ))}
+
+      {showAdd && (
+        <AddHardcoverListForm
+          onSaved={il => { setLists(prev => [...prev, il]); setShowAdd(false) }}
+          onCancel={() => setShowAdd(false)}
+        />
+      )}
+    </section>
+  )
+}
+
+function AddHardcoverListForm({ onSaved, onCancel }: { onSaved: (il: ImportList) => void; onCancel: () => void }) {
+  const { t } = useTranslation()
+  const [name, setName] = useState('')
+  const [token, setToken] = useState('')
+  const [hcLists, setHcLists] = useState<HardcoverList[]>([])
+  const [selectedSlug, setSelectedSlug] = useState('')
+  const [loadingLists, setLoadingLists] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const fetchLists = (tok: string) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (!tok.trim()) { setHcLists([]); return }
+    debounceRef.current = setTimeout(async () => {
+      setLoadingLists(true)
+      try {
+        const lists = await api.hardcoverLists(tok)
+        setHcLists(lists)
+        if (lists.length > 0 && !selectedSlug) setSelectedSlug(lists[0].slug)
+      } catch (e) {
+        setHcLists([])
+        setError(e instanceof Error ? e.message : 'Failed to load lists')
+      } finally {
+        setLoadingLists(false)
+      }
+    }, 500)
+  }
+
+  const handleTokenChange = (tok: string) => {
+    setToken(tok)
+    setError(null)
+    fetchLists(tok)
+  }
+
+  const handleSave = async () => {
+    if (!name.trim() || !token.trim() || !selectedSlug) return
+    setSaving(true)
+    setError(null)
+    try {
+      const il = await api.addImportList({
+        name: name.trim(),
+        type: 'hardcover',
+        apiKey: token.trim(),
+        url: selectedSlug,
+        enabled: true,
+        monitorNew: true,
+        autoAdd: true,
+      })
+      onSaved(il)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-3">
+      <div>
+        <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('settings.import.hardcoverName')}</label>
+        <input className={inputCls} placeholder={t('settings.import.hardcoverNamePlaceholder')} value={name} onChange={e => setName(e.target.value)} />
+      </div>
+      <div>
+        <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('settings.import.hardcoverToken')}</label>
+        <input className={inputCls} type="password" placeholder={t('settings.import.hardcoverTokenPlaceholder')} value={token} onChange={e => handleTokenChange(e.target.value)} />
+      </div>
+      <div>
+        <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('settings.import.hardcoverList')}</label>
+        {loadingLists ? (
+          <p className="text-xs text-slate-500">{t('settings.import.hardcoverListLoading')}</p>
+        ) : hcLists.length > 0 ? (
+          <select className={inputCls} value={selectedSlug} onChange={e => setSelectedSlug(e.target.value)}>
+            {hcLists.map(l => (
+              <option key={l.slug} value={l.slug}>{l.name} ({l.booksCount} books)</option>
+            ))}
+          </select>
+        ) : (
+          <p className="text-xs text-slate-500">{token ? t('settings.import.hardcoverNoLists') : t('settings.import.hardcoverListPlaceholder')}</p>
+        )}
+      </div>
+      {error && <p className="text-xs text-red-600 dark:text-red-400">{error}</p>}
+      <div className="flex gap-2">
+        <button
+          onClick={handleSave}
+          disabled={saving || !name.trim() || !token.trim() || !selectedSlug}
+          className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded text-xs font-medium"
+        >
+          {saving ? t('common.saving') : t('common.save')}
+        </button>
+        <button onClick={onCancel} className="px-3 py-1.5 bg-slate-300 dark:bg-zinc-700 hover:bg-slate-400 dark:hover:bg-zinc-600 rounded text-xs font-medium">
+          {t('common.cancel')}
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Extends the Hardcover GraphQL client with optional Bearer-token auth and two new queries (`GetUserLists`, `GetListBooks`) — existing unauthenticated enrichment is untouched
- Adds `internal/hardcoverlistsyncer` package: resolves lists by slug, deduplicates by `foreign_id`, creates author + book records as `monitored=true, status=wanted`
- Wires a `@every 24h` scheduler job via `WithHardcoverSyncer` to auto-sync enabled Hardcover import lists
- Adds `GET /api/v1/importlist/hardcover/lists?token=<tok>` so the UI can show a list picker
- Adds `ListByType` and `UpdateLastSyncAt` to `ImportListRepo`
- Frontend: new "Hardcover reading lists" section in Settings > Import with token input, debounced list dropdown, enable/disable toggle, and delete

Closes #106

## Test plan

- [ ] Create a Hardcover account, generate an API token
- [ ] Go to Settings > Import, click "+ Add Hardcover List"
- [ ] Enter the token — verify the list dropdown populates after ~500ms
- [ ] Select a list, give it a name, save
- [ ] Verify the import list appears in the section with "Never synced"
- [ ] Wait for the 24h job or trigger manually — verify books appear as Wanted
- [ ] Toggle enable/disable and delete — verify CRUD works
- [ ] Verify existing unauthenticated hardcover enrichment still works
- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `cd web && npm run build` passes