### PR TITLE
feat: recommendation engine (Phase 1)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/notifier"
 	"github.com/vavallee/bindery/internal/opds"
+	"github.com/vavallee/bindery/internal/recommender"
 	"github.com/vavallee/bindery/internal/scheduler"
 	"github.com/vavallee/bindery/internal/webui"
 )
@@ -207,6 +208,12 @@ func main() {
 	// Register the Calibre importer as the 24-hour sync job. The scheduler
 	// only fires the job when the syncer is non-nil, so no guard needed here.
 	sched.WithCalibreSyncer(calibreImporter)
+
+	// Recommendation engine (24-hour job, gated on recommendations.enabled).
+	recRepo := db.NewRecommendationRepo(database)
+	recEngine := recommender.New(bookRepo, authorRepo, seriesRepo, recRepo, settingsRepo)
+	sched.WithRecommender(recEngine)
+
 	sched.Start()
 	defer sched.Stop()
 
@@ -245,6 +252,7 @@ func main() {
 	calibreImportHandler := api.NewCalibreImportHandler(calibreImporter, func() calibre.Config {
 		return api.LoadCalibreConfig(settingsRepo)
 	})
+	recHandler := api.NewRecommendationHandler(recRepo, recEngine, authorRepo, bookRepo, sched)
 	imageProxyHandler := api.NewImageProxyHandler(cfg.DataDir)
 	migrateHandler := api.NewMigrateHandler(
 		authorRepo, indexerRepo, dlClientRepo, blocklistRepo, bookRepo, metaAgg,
@@ -379,6 +387,16 @@ func main() {
 		// Series
 		r.Get("/series", seriesHandler.List)
 		r.Get("/series/{id}", seriesHandler.Get)
+
+		// Recommendations
+		r.Get("/recommendations", recHandler.List)
+		r.Post("/recommendations/{id}/dismiss", recHandler.Dismiss)
+		r.Post("/recommendations/{id}/add", recHandler.Add)
+		r.Post("/recommendations/refresh", recHandler.Refresh)
+		r.Delete("/recommendations/dismissals", recHandler.ClearDismissals)
+		r.Get("/recommendations/exclude-author", recHandler.ListAuthorExclusions)
+		r.Post("/recommendations/exclude-author", recHandler.ExcludeAuthor)
+		r.Delete("/recommendations/exclude-author/{name}", recHandler.RemoveAuthorExclusion)
 
 		// Tags
 		r.Get("/tag", tagHandler.List)

--- a/internal/api/recommendations.go
+++ b/internal/api/recommendations.go
@@ -152,7 +152,7 @@ func (h *RecommendationHandler) Add(w http.ResponseWriter, r *http.Request) {
 
 	// Trigger search in background.
 	if h.searcher != nil {
-		go h.searcher.SearchAndGrabBook(context.Background(), *book)
+		go h.searcher.SearchAndGrabBook(context.Background(), *book) // #nosec G118 -- intentional: search must outlive the request
 	}
 
 	writeJSON(w, http.StatusCreated, book)

--- a/internal/api/recommendations.go
+++ b/internal/api/recommendations.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// RecommendationEngine is the interface for triggering a recommendation run.
+type RecommendationEngine interface {
+	Run(ctx context.Context, userID int64) error
+}
+
+// RecommendationHandler handles the /api/v1/recommendations endpoints.
+type RecommendationHandler struct {
+	recs     *db.RecommendationRepo
+	engine   RecommendationEngine
+	authors  *db.AuthorRepo
+	books    *db.BookRepo
+	searcher BookSearcher
+}
+
+// NewRecommendationHandler creates a new RecommendationHandler.
+func NewRecommendationHandler(
+	recs *db.RecommendationRepo,
+	engine RecommendationEngine,
+	authors *db.AuthorRepo,
+	books *db.BookRepo,
+	searcher BookSearcher,
+) *RecommendationHandler {
+	return &RecommendationHandler{
+		recs:     recs,
+		engine:   engine,
+		authors:  authors,
+		books:    books,
+		searcher: searcher,
+	}
+}
+
+// List returns non-dismissed recommendations for the current user.
+func (h *RecommendationHandler) List(w http.ResponseWriter, r *http.Request) {
+	recType := r.URL.Query().Get("type")
+
+	limit := 50
+	if l, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && l > 0 {
+		limit = l
+	}
+	offset := 0
+	if o, err := strconv.Atoi(r.URL.Query().Get("offset")); err == nil && o >= 0 {
+		offset = o
+	}
+
+	recs, err := h.recs.List(r.Context(), 1, recType, limit, offset)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if recs == nil {
+		recs = []models.Recommendation{}
+	}
+	writeJSON(w, http.StatusOK, recs)
+}
+
+// Dismiss marks a recommendation as dismissed.
+func (h *RecommendationHandler) Dismiss(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.recs.Dismiss(r.Context(), 1, id); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Add creates an author (if needed) and book from a recommendation, marks it
+// as wanted, and triggers an immediate search.
+func (h *RecommendationHandler) Add(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+
+	rec, err := h.recs.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if rec == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "recommendation not found"})
+		return
+	}
+
+	// Check if book already exists.
+	existing, _ := h.books.GetByForeignID(r.Context(), rec.ForeignID)
+	if existing != nil {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "book already exists"})
+		return
+	}
+
+	// Resolve or create the author.
+	var authorID int64
+	if rec.AuthorID != nil {
+		authorID = *rec.AuthorID
+	} else if rec.AuthorName != "" {
+		// Try to find an existing author by name.
+		authors, _ := h.authors.List(r.Context())
+		for _, a := range authors {
+			if a.Name == rec.AuthorName {
+				authorID = a.ID
+				break
+			}
+		}
+	}
+
+	if authorID == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "cannot resolve author for this recommendation"})
+		return
+	}
+
+	book := &models.Book{
+		ForeignID:     rec.ForeignID,
+		AuthorID:      authorID,
+		Title:         rec.Title,
+		Description:   rec.Description,
+		ImageURL:      rec.ImageURL,
+		AverageRating: rec.Rating,
+		RatingsCount:  rec.RatingsCount,
+		ReleaseDate:   rec.ReleaseDate,
+		Language:      rec.Language,
+		MediaType:     rec.MediaType,
+		Status:        models.BookStatusWanted,
+		Monitored:     true,
+	}
+
+	if err := h.books.Create(r.Context(), book); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// Dismiss the recommendation now that the book is added.
+	_ = h.recs.Dismiss(r.Context(), 1, id)
+
+	// Trigger search in background.
+	if h.searcher != nil {
+		go h.searcher.SearchAndGrabBook(context.Background(), *book)
+	}
+
+	writeJSON(w, http.StatusCreated, book)
+}
+
+// Refresh triggers a recommendation engine run in the background.
+func (h *RecommendationHandler) Refresh(w http.ResponseWriter, r *http.Request) {
+	go func() {
+		if err := h.engine.Run(context.Background(), 1); err != nil {
+			slog.Error("recommendation refresh failed", "error", err)
+		}
+	}()
+	writeJSON(w, http.StatusAccepted, map[string]string{"message": "refresh started"})
+}
+
+// ClearDismissals removes all dismissals for the current user.
+func (h *RecommendationHandler) ClearDismissals(w http.ResponseWriter, r *http.Request) {
+	if err := h.recs.ClearDismissals(r.Context(), 1); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListAuthorExclusions returns all excluded authors for the current user.
+func (h *RecommendationHandler) ListAuthorExclusions(w http.ResponseWriter, r *http.Request) {
+	exclusions, err := h.recs.ListAuthorExclusions(r.Context(), 1)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if exclusions == nil {
+		exclusions = []string{}
+	}
+	writeJSON(w, http.StatusOK, exclusions)
+}
+
+// ExcludeAuthor adds an author to the exclusion list.
+func (h *RecommendationHandler) ExcludeAuthor(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		AuthorName string `json:"authorName"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.AuthorName == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "authorName required"})
+		return
+	}
+
+	if err := h.recs.AddAuthorExclusion(r.Context(), 1, req.AuthorName); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+// RemoveAuthorExclusion removes an author from the exclusion list.
+func (h *RecommendationHandler) RemoveAuthorExclusion(w http.ResponseWriter, r *http.Request) {
+	name := chi.URLParam(r, "name")
+	if name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "author name required"})
+		return
+	}
+
+	if err := h.recs.RemoveAuthorExclusion(r.Context(), 1, name); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/db/migrations/015_recommendations.sql
+++ b/internal/db/migrations/015_recommendations.sql
@@ -1,0 +1,41 @@
+-- +migrate Up
+CREATE TABLE recommendations (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id       INTEGER NOT NULL DEFAULT 1,
+    foreign_id    TEXT NOT NULL,
+    rec_type      TEXT NOT NULL,
+    title         TEXT NOT NULL,
+    author_name   TEXT NOT NULL DEFAULT '',
+    author_id     INTEGER,
+    image_url     TEXT NOT NULL DEFAULT '',
+    description   TEXT NOT NULL DEFAULT '',
+    genres        TEXT NOT NULL DEFAULT '[]',
+    rating        REAL NOT NULL DEFAULT 0,
+    ratings_count INTEGER NOT NULL DEFAULT 0,
+    release_date  DATE,
+    language      TEXT NOT NULL DEFAULT '',
+    media_type    TEXT NOT NULL DEFAULT 'ebook',
+    score         REAL NOT NULL DEFAULT 0,
+    reason        TEXT NOT NULL DEFAULT '',
+    series_id     INTEGER,
+    series_pos    TEXT NOT NULL DEFAULT '',
+    dismissed     INTEGER NOT NULL DEFAULT 0,
+    batch_id      TEXT NOT NULL DEFAULT '',
+    created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_recommendations_user_score ON recommendations(user_id, score DESC);
+CREATE INDEX idx_recommendations_user_dismissed ON recommendations(user_id, dismissed);
+
+CREATE TABLE recommendation_dismissals (
+    user_id    INTEGER NOT NULL DEFAULT 1,
+    foreign_id TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, foreign_id)
+);
+
+CREATE TABLE recommendation_author_exclusions (
+    user_id     INTEGER NOT NULL DEFAULT 1,
+    author_name TEXT NOT NULL,
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, author_name)
+);

--- a/internal/db/recommendations.go
+++ b/internal/db/recommendations.go
@@ -1,0 +1,251 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// RecommendationRepo manages the recommendations, dismissals, and author
+// exclusions tables.
+type RecommendationRepo struct {
+	db *sql.DB
+}
+
+// NewRecommendationRepo creates a new RecommendationRepo.
+func NewRecommendationRepo(db *sql.DB) *RecommendationRepo {
+	return &RecommendationRepo{db: db}
+}
+
+// ReplaceBatch atomically replaces all recommendations for a user. Runs a
+// DELETE + INSERT inside a single transaction so readers never see a partial set.
+func (r *RecommendationRepo) ReplaceBatch(ctx context.Context, userID int64, candidates []models.RecommendationCandidate) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, "DELETE FROM recommendations WHERE user_id = ?", userID); err != nil {
+		return fmt.Errorf("delete old recs: %w", err)
+	}
+
+	now := time.Now().UTC()
+	batchID := fmt.Sprintf("%d-%d", userID, now.Unix())
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO recommendations (
+			user_id, foreign_id, rec_type, title, author_name, author_id,
+			image_url, description, genres, rating, ratings_count,
+			release_date, language, media_type, score, reason,
+			series_id, series_pos, batch_id, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	for _, c := range candidates {
+		genresJSON, _ := json.Marshal(c.Genres)
+		if genresJSON == nil {
+			genresJSON = []byte("[]")
+		}
+
+		_, err := stmt.ExecContext(ctx,
+			userID, c.ForeignID, c.RecType, c.Title, c.AuthorName, c.AuthorID,
+			c.ImageURL, c.Description, string(genresJSON), c.Rating, c.RatingsCount,
+			c.ReleaseDate, c.Language, c.MediaType, c.Score, c.Reason,
+			c.SeriesID, c.SeriesPos, batchID, now,
+		)
+		if err != nil {
+			return fmt.Errorf("insert rec %q: %w", c.Title, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// List returns non-dismissed recommendations for a user, ordered by score DESC.
+// An optional recType filter can be applied.
+func (r *RecommendationRepo) List(ctx context.Context, userID int64, recType string, limit, offset int) ([]models.Recommendation, error) {
+	q := "SELECT id, user_id, foreign_id, rec_type, title, author_name, author_id, image_url, description, genres, rating, ratings_count, release_date, language, media_type, score, reason, series_id, series_pos, dismissed, batch_id, created_at FROM recommendations WHERE user_id = ? AND dismissed = 0"
+	args := []any{userID}
+
+	if recType != "" {
+		q += " AND rec_type = ?"
+		args = append(args, recType)
+	}
+
+	q += " ORDER BY score DESC"
+
+	if limit > 0 {
+		q += " LIMIT ?"
+		args = append(args, limit)
+	}
+	if offset > 0 {
+		q += " OFFSET ?"
+		args = append(args, offset)
+	}
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list recommendations: %w", err)
+	}
+	defer rows.Close()
+
+	var recs []models.Recommendation
+	for rows.Next() {
+		var rec models.Recommendation
+		var dismissed int
+		err := rows.Scan(
+			&rec.ID, &rec.UserID, &rec.ForeignID, &rec.RecType,
+			&rec.Title, &rec.AuthorName, &rec.AuthorID,
+			&rec.ImageURL, &rec.Description, &rec.Genres,
+			&rec.Rating, &rec.RatingsCount, &rec.ReleaseDate,
+			&rec.Language, &rec.MediaType, &rec.Score, &rec.Reason,
+			&rec.SeriesID, &rec.SeriesPos, &dismissed, &rec.BatchID,
+			&rec.CreatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("scan recommendation: %w", err)
+		}
+		rec.Dismissed = dismissed != 0
+		recs = append(recs, rec)
+	}
+	return recs, rows.Err()
+}
+
+// GetByID returns a single recommendation by its ID.
+func (r *RecommendationRepo) GetByID(ctx context.Context, id int64) (*models.Recommendation, error) {
+	var rec models.Recommendation
+	var dismissed int
+	err := r.db.QueryRowContext(ctx,
+		"SELECT id, user_id, foreign_id, rec_type, title, author_name, author_id, image_url, description, genres, rating, ratings_count, release_date, language, media_type, score, reason, series_id, series_pos, dismissed, batch_id, created_at FROM recommendations WHERE id = ?",
+		id,
+	).Scan(
+		&rec.ID, &rec.UserID, &rec.ForeignID, &rec.RecType,
+		&rec.Title, &rec.AuthorName, &rec.AuthorID,
+		&rec.ImageURL, &rec.Description, &rec.Genres,
+		&rec.Rating, &rec.RatingsCount, &rec.ReleaseDate,
+		&rec.Language, &rec.MediaType, &rec.Score, &rec.Reason,
+		&rec.SeriesID, &rec.SeriesPos, &dismissed, &rec.BatchID,
+		&rec.CreatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get recommendation %d: %w", id, err)
+	}
+	rec.Dismissed = dismissed != 0
+	return &rec, nil
+}
+
+// Dismiss marks a recommendation as dismissed and records the dismissal in
+// the persistent dismissals table so it survives regeneration.
+func (r *RecommendationRepo) Dismiss(ctx context.Context, userID, recID int64) error {
+	// Get the recommendation to find its foreign_id.
+	rec, err := r.GetByID(ctx, recID)
+	if err != nil {
+		return err
+	}
+	if rec == nil {
+		return fmt.Errorf("recommendation %d not found", recID)
+	}
+
+	// Mark as dismissed.
+	if _, err := r.db.ExecContext(ctx,
+		"UPDATE recommendations SET dismissed = 1 WHERE id = ?", recID); err != nil {
+		return fmt.Errorf("dismiss rec %d: %w", recID, err)
+	}
+
+	// Persist in dismissals table.
+	if _, err := r.db.ExecContext(ctx,
+		"INSERT OR IGNORE INTO recommendation_dismissals (user_id, foreign_id) VALUES (?, ?)",
+		userID, rec.ForeignID); err != nil {
+		return fmt.Errorf("record dismissal: %w", err)
+	}
+
+	return nil
+}
+
+// IsDismissed checks whether a foreign_id has been dismissed by the user.
+func (r *RecommendationRepo) IsDismissed(ctx context.Context, userID int64, foreignID string) (bool, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM recommendation_dismissals WHERE user_id = ? AND foreign_id = ?",
+		userID, foreignID).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// ListDismissedIDs returns all dismissed foreign_ids for a user.
+func (r *RecommendationRepo) ListDismissedIDs(ctx context.Context, userID int64) (map[string]bool, error) {
+	rows, err := r.db.QueryContext(ctx,
+		"SELECT foreign_id FROM recommendation_dismissals WHERE user_id = ?", userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[string]bool)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		result[id] = true
+	}
+	return result, rows.Err()
+}
+
+// ClearDismissals removes all dismissals for a user.
+func (r *RecommendationRepo) ClearDismissals(ctx context.Context, userID int64) error {
+	_, err := r.db.ExecContext(ctx,
+		"DELETE FROM recommendation_dismissals WHERE user_id = ?", userID)
+	return err
+}
+
+// AddAuthorExclusion adds an author to the user's exclusion list.
+func (r *RecommendationRepo) AddAuthorExclusion(ctx context.Context, userID int64, authorName string) error {
+	_, err := r.db.ExecContext(ctx,
+		"INSERT OR IGNORE INTO recommendation_author_exclusions (user_id, author_name) VALUES (?, ?)",
+		userID, authorName)
+	return err
+}
+
+// RemoveAuthorExclusion removes an author from the user's exclusion list.
+func (r *RecommendationRepo) RemoveAuthorExclusion(ctx context.Context, userID int64, authorName string) error {
+	_, err := r.db.ExecContext(ctx,
+		"DELETE FROM recommendation_author_exclusions WHERE user_id = ? AND author_name = ?",
+		userID, authorName)
+	return err
+}
+
+// ListAuthorExclusions returns all excluded author names for a user.
+func (r *RecommendationRepo) ListAuthorExclusions(ctx context.Context, userID int64) ([]string, error) {
+	rows, err := r.db.QueryContext(ctx,
+		"SELECT author_name FROM recommendation_author_exclusions WHERE user_id = ? ORDER BY author_name",
+		userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	return names, rows.Err()
+}

--- a/internal/models/recommendation.go
+++ b/internal/models/recommendation.go
@@ -1,0 +1,62 @@
+package models
+
+import "time"
+
+// Recommendation type constants.
+const (
+	RecTypeSeries       = "series"
+	RecTypeAuthorNew    = "author_new"
+	RecTypeGenreSimilar = "genre_similar"
+	RecTypeGenrePopular = "genre_popular"
+	RecTypeListCross    = "list_cross"
+	RecTypeSerendipity  = "serendipity"
+)
+
+// Recommendation is a persisted book recommendation shown on the Discover page.
+type Recommendation struct {
+	ID           int64      `json:"id"`
+	UserID       int64      `json:"userId"`
+	ForeignID    string     `json:"foreignId"`
+	RecType      string     `json:"recType"`
+	Title        string     `json:"title"`
+	AuthorName   string     `json:"authorName"`
+	AuthorID     *int64     `json:"authorId,omitempty"`
+	ImageURL     string     `json:"imageUrl"`
+	Description  string     `json:"description"`
+	Genres       string     `json:"genres"`
+	Rating       float64    `json:"rating"`
+	RatingsCount int        `json:"ratingsCount"`
+	ReleaseDate  *time.Time `json:"releaseDate"`
+	Language     string     `json:"language"`
+	MediaType    string     `json:"mediaType"`
+	Score        float64    `json:"score"`
+	Reason       string     `json:"reason"`
+	SeriesID     *int64     `json:"seriesId,omitempty"`
+	SeriesPos    string     `json:"seriesPos"`
+	Dismissed    bool       `json:"dismissed"`
+	BatchID      string     `json:"batchId"`
+	CreatedAt    time.Time  `json:"createdAt"`
+}
+
+// RecommendationCandidate is the shared struct used by both the recommender
+// engine (to produce candidates) and the db layer (to persist them). Lives in
+// models to break the circular import between internal/recommender and internal/db.
+type RecommendationCandidate struct {
+	ForeignID    string
+	RecType      string
+	Title        string
+	AuthorName   string
+	AuthorID     *int64
+	ImageURL     string
+	Description  string
+	Genres       []string
+	Rating       float64
+	RatingsCount int
+	ReleaseDate  *time.Time
+	Language     string
+	MediaType    string
+	SeriesID     *int64
+	SeriesPos    string
+	Score        float64
+	Reason       string
+}

--- a/internal/recommender/candidates.go
+++ b/internal/recommender/candidates.go
@@ -1,0 +1,290 @@
+package recommender
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// GenerateSeries produces candidates for the next unowned book in each series
+// the user has started.
+func GenerateSeries(
+	ctx context.Context,
+	books *db.BookRepo,
+	series *db.SeriesRepo,
+	profile *UserProfile,
+) []models.RecommendationCandidate {
+	var candidates []models.RecommendationCandidate
+
+	for seriesID, state := range profile.SeriesState {
+		full, err := series.GetByID(ctx, seriesID)
+		if err != nil || full == nil {
+			continue
+		}
+
+		// Find next unowned book after the user's max position.
+		nextPos := state.MaxPosition + 1
+		for _, sb := range full.Books {
+			pos := parsePosition(sb.PositionInSeries)
+			if pos != nextPos || sb.Book == nil {
+				continue
+			}
+			if profile.OwnedForeignIDs[sb.Book.ForeignID] {
+				continue
+			}
+
+			c := bookToCandidate(sb.Book)
+			c.RecType = models.RecTypeSeries
+			c.Reason = fmt.Sprintf("Next in %s", state.SeriesTitle)
+			c.SeriesID = &seriesID
+			c.SeriesPos = sb.PositionInSeries
+			candidates = append(candidates, c)
+			break
+		}
+
+		// Also surface books that fill gaps.
+		for _, missingPos := range state.MissingPositions {
+			for _, sb := range full.Books {
+				pos := parsePosition(sb.PositionInSeries)
+				if pos != missingPos || sb.Book == nil {
+					continue
+				}
+				if profile.OwnedForeignIDs[sb.Book.ForeignID] {
+					continue
+				}
+
+				sid := seriesID
+				c := bookToCandidate(sb.Book)
+				c.RecType = models.RecTypeSeries
+				c.Reason = fmt.Sprintf("Missing from %s", state.SeriesTitle)
+				c.SeriesID = &sid
+				c.SeriesPos = sb.PositionInSeries
+				candidates = append(candidates, c)
+				break
+			}
+		}
+	}
+
+	return candidates
+}
+
+// GenerateAuthorNew produces candidates from monitored authors' works that
+// the user doesn't own yet.
+func GenerateAuthorNew(
+	ctx context.Context,
+	books *db.BookRepo,
+	authors *db.AuthorRepo,
+	profile *UserProfile,
+) []models.RecommendationCandidate {
+	var candidates []models.RecommendationCandidate
+
+	for authorID := range profile.MonitoredAuthors {
+		author, err := authors.GetByID(ctx, authorID)
+		if err != nil || author == nil {
+			continue
+		}
+
+		authorBooks, err := books.ListByAuthor(ctx, authorID)
+		if err != nil {
+			slog.Warn("recommender: failed to list books for author", "authorId", authorID, "error", err)
+			continue
+		}
+
+		for i := range authorBooks {
+			b := &authorBooks[i]
+			if profile.OwnedForeignIDs[b.ForeignID] {
+				continue
+			}
+			// Only recommend books with wanted or skipped status (they're in
+			// the DB but the user hasn't grabbed them yet).
+			if b.Status != models.BookStatusWanted && b.Status != models.BookStatusSkipped {
+				continue
+			}
+
+			c := bookToCandidate(b)
+			c.RecType = models.RecTypeAuthorNew
+			c.Reason = fmt.Sprintf("New from %s", author.Name)
+			c.AuthorID = &authorID
+			c.AuthorName = author.Name
+			candidates = append(candidates, c)
+		}
+	}
+
+	return candidates
+}
+
+// GenerateGenreSimilar produces candidates from series books that match the
+// user's genre profile but aren't owned yet.
+func GenerateGenreSimilar(
+	ctx context.Context,
+	books *db.BookRepo,
+	series *db.SeriesRepo,
+	profile *UserProfile,
+) []models.RecommendationCandidate {
+	var candidates []models.RecommendationCandidate
+
+	// Find the user's top genre for the reason string.
+	topGenre := topGenre(profile)
+
+	// Walk all series the user has started and find unowned books.
+	allSeries, err := series.List(ctx)
+	if err != nil {
+		return nil
+	}
+
+	for _, s := range allSeries {
+		full, err := series.GetByID(ctx, s.ID)
+		if err != nil || full == nil {
+			continue
+		}
+
+		for _, sb := range full.Books {
+			if sb.Book == nil || profile.OwnedForeignIDs[sb.Book.ForeignID] {
+				continue
+			}
+			// Skip books already covered by series candidates.
+			if _, inSeries := profile.SeriesState[s.ID]; inSeries {
+				continue
+			}
+
+			c := bookToCandidate(sb.Book)
+			c.RecType = models.RecTypeGenreSimilar
+			if topGenre != "" {
+				c.Reason = fmt.Sprintf("Because of your %s library", topGenre)
+			} else {
+				c.Reason = "Similar to books in your library"
+			}
+			candidates = append(candidates, c)
+		}
+	}
+
+	return candidates
+}
+
+// GenerateSerendipity samples random candidates from the available pool that
+// are outside the user's top-5 genres. This breaks filter bubbles.
+func GenerateSerendipity(
+	ctx context.Context,
+	books *db.BookRepo,
+	series *db.SeriesRepo,
+	profile *UserProfile,
+	count int,
+) []models.RecommendationCandidate {
+	top5 := topNGenres(profile, 5)
+
+	// Collect eligible books from series not started by the user.
+	var pool []models.RecommendationCandidate
+	allSeries, err := series.List(ctx)
+	if err != nil {
+		return nil
+	}
+
+	for _, s := range allSeries {
+		full, err := series.GetByID(ctx, s.ID)
+		if err != nil || full == nil {
+			continue
+		}
+
+		for _, sb := range full.Books {
+			if sb.Book == nil || profile.OwnedForeignIDs[sb.Book.ForeignID] {
+				continue
+			}
+
+			// Must be outside the user's top-5 genres.
+			if hasTopGenre(sb.Book.Genres, top5) {
+				continue
+			}
+
+			c := bookToCandidate(sb.Book)
+			c.RecType = models.RecTypeSerendipity
+			c.Reason = "Something different"
+			pool = append(pool, c)
+		}
+	}
+
+	// Shuffle and take up to count.
+	rand.Shuffle(len(pool), func(i, j int) {
+		pool[i], pool[j] = pool[j], pool[i]
+	})
+	if len(pool) > count {
+		pool = pool[:count]
+	}
+	return pool
+}
+
+// bookToCandidate converts a models.Book into a RecommendationCandidate.
+func bookToCandidate(b *models.Book) models.RecommendationCandidate {
+	c := models.RecommendationCandidate{
+		ForeignID:    b.ForeignID,
+		Title:        b.Title,
+		AuthorID:     &b.AuthorID,
+		ImageURL:     b.ImageURL,
+		Description:  b.Description,
+		Genres:       b.Genres,
+		Rating:       b.AverageRating,
+		RatingsCount: b.RatingsCount,
+		ReleaseDate:  b.ReleaseDate,
+		Language:     b.Language,
+		MediaType:    b.MediaType,
+	}
+	if c.MediaType == "" {
+		c.MediaType = models.MediaTypeEbook
+	}
+	return c
+}
+
+// topGenre returns the highest-weighted genre in the user's profile.
+func topGenre(p *UserProfile) string {
+	var best string
+	var bestW float64
+	for g, w := range p.GenreWeights {
+		if w > bestW {
+			bestW = w
+			best = g
+		}
+	}
+	return best
+}
+
+// topNGenres returns the top N genres by weight.
+func topNGenres(p *UserProfile, n int) map[string]bool {
+	type gw struct {
+		genre  string
+		weight float64
+	}
+	var all []gw
+	for g, w := range p.GenreWeights {
+		all = append(all, gw{g, w})
+	}
+	// Simple selection: find top N by iterating N times.
+	result := make(map[string]bool, n)
+	for range n {
+		var best int
+		var bestW float64 = -1
+		for i, g := range all {
+			if !result[g.genre] && g.weight > bestW {
+				bestW = g.weight
+				best = i
+			}
+		}
+		if bestW >= 0 {
+			result[all[best].genre] = true
+		}
+	}
+	return result
+}
+
+// hasTopGenre checks if any of the book's genres are in the top set.
+func hasTopGenre(genres []string, top map[string]bool) bool {
+	for _, g := range genres {
+		if top[strings.ToLower(strings.TrimSpace(g))] {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/recommender/profile.go
+++ b/internal/recommender/profile.go
@@ -1,0 +1,175 @@
+package recommender
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// junkGenres are OpenLibrary subjects that add noise, not signal.
+var junkGenres = map[string]bool{
+	"accessible book":  true,
+	"protected daisy":  true,
+	"in library":       true,
+	"large type books": true,
+	"nonfiction":       true,
+}
+
+// BuildProfile analyses the user's library and constructs a UserProfile used
+// for scoring recommendation candidates.
+func BuildProfile(
+	ctx context.Context,
+	userID int64,
+	books *db.BookRepo,
+	authors *db.AuthorRepo,
+	series *db.SeriesRepo,
+	recs *db.RecommendationRepo,
+	settings *db.SettingsRepo,
+) (*UserProfile, error) {
+	p := &UserProfile{
+		GenreWeights:        make(map[string]float64),
+		MonitoredAuthors:    make(map[int64]bool),
+		AuthorBookCounts:    make(map[int64]int),
+		SeriesState:         make(map[int64]SeriesState),
+		OwnedForeignIDs:     make(map[string]bool),
+		DismissedForeignIDs: make(map[string]bool),
+		ExcludedAuthors:     make(map[string]bool),
+		PreferredLanguage:   "en",
+	}
+
+	// Load preferred language from settings.
+	if settings != nil {
+		if s, _ := settings.Get(ctx, "search.preferredLanguage"); s != nil && s.Value != "" {
+			p.PreferredLanguage = s.Value
+		}
+	}
+
+	// Load all books to build the profile.
+	allBooks, err := books.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	p.TotalBooks = len(allBooks)
+
+	// Genre frequency counts and per-genre document counts (for IDF).
+	genreDocCount := make(map[string]int)
+
+	for _, b := range allBooks {
+		p.OwnedForeignIDs[b.ForeignID] = true
+		p.AuthorBookCounts[b.AuthorID]++
+
+		seen := make(map[string]bool)
+		for _, g := range b.Genres {
+			g = strings.ToLower(strings.TrimSpace(g))
+			if g == "" || junkGenres[g] {
+				continue
+			}
+			if !seen[g] {
+				genreDocCount[g]++
+				seen[g] = true
+			}
+		}
+	}
+	totalUniqueGenres := len(genreDocCount)
+
+	// Compute TF-IDF genre weights.
+	if p.TotalBooks > 0 && totalUniqueGenres > 0 {
+		for genre, docCount := range genreDocCount {
+			tf := float64(docCount) / float64(p.TotalBooks)
+			idf := math.Log(float64(totalUniqueGenres) / float64(docCount))
+			p.GenreWeights[genre] = tf * idf
+		}
+	}
+
+	// Build monitored authors set.
+	allAuthors, err := authors.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range allAuthors {
+		if a.Monitored {
+			p.MonitoredAuthors[a.ID] = true
+		}
+	}
+
+	// Build series state from all series with their books.
+	allSeries, err := series.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, s := range allSeries {
+		full, err := series.GetByID(ctx, s.ID)
+		if err != nil || full == nil || len(full.Books) < 2 {
+			continue
+		}
+
+		var maxPos float64
+		ownedPositions := make(map[float64]bool)
+		allPositions := make(map[float64]bool)
+
+		for _, sb := range full.Books {
+			pos := parsePosition(sb.PositionInSeries)
+			if pos <= 0 {
+				continue
+			}
+			allPositions[pos] = true
+			if sb.Book != nil && p.OwnedForeignIDs[sb.Book.ForeignID] {
+				ownedPositions[pos] = true
+				if pos > maxPos {
+					maxPos = pos
+				}
+			}
+		}
+
+		var missing []float64
+		for pos := range allPositions {
+			if !ownedPositions[pos] && pos <= maxPos {
+				missing = append(missing, pos)
+			}
+		}
+
+		if maxPos > 0 {
+			p.SeriesState[s.ID] = SeriesState{
+				SeriesID:         s.ID,
+				SeriesTitle:      s.Title,
+				MaxPosition:      maxPos,
+				MissingPositions: missing,
+			}
+		}
+	}
+
+	// Load dismissed foreign IDs.
+	dismissed, err := recs.ListDismissedIDs(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	p.DismissedForeignIDs = dismissed
+
+	// Load excluded authors.
+	excluded, err := recs.ListAuthorExclusions(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	for _, name := range excluded {
+		p.ExcludedAuthors[strings.ToLower(name)] = true
+	}
+
+	return p, nil
+}
+
+// parsePosition converts a series position string like "1", "2.5" to float64.
+// Returns 0 for empty or unparseable values.
+func parsePosition(s string) float64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+	return f
+}

--- a/internal/recommender/recommender.go
+++ b/internal/recommender/recommender.go
@@ -1,0 +1,145 @@
+package recommender
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// Engine orchestrates the recommendation pipeline.
+type Engine struct {
+	books    *db.BookRepo
+	authors  *db.AuthorRepo
+	series   *db.SeriesRepo
+	recs     *db.RecommendationRepo
+	settings *db.SettingsRepo
+}
+
+// New creates a new recommendation engine.
+func New(
+	books *db.BookRepo,
+	authors *db.AuthorRepo,
+	series *db.SeriesRepo,
+	recs *db.RecommendationRepo,
+	settings *db.SettingsRepo,
+) *Engine {
+	return &Engine{
+		books:    books,
+		authors:  authors,
+		series:   series,
+		recs:     recs,
+		settings: settings,
+	}
+}
+
+// Run generates recommendations for the given user. It builds a taste profile,
+// generates candidates from multiple sources, scores and ranks them, injects
+// serendipity picks, and persists the top 100.
+func (e *Engine) Run(ctx context.Context, userID int64) error {
+	// Check if recommendations are enabled.
+	if e.settings != nil {
+		s, _ := e.settings.Get(ctx, "recommendations.enabled")
+		if s == nil || s.Value != "true" {
+			slog.Info("recommender: disabled, skipping")
+			return nil
+		}
+	}
+
+	slog.Info("recommender: building profile", "userId", userID)
+	profile, err := BuildProfile(ctx, userID, e.books, e.authors, e.series, e.recs, e.settings)
+	if err != nil {
+		return err
+	}
+
+	var candidates []models.RecommendationCandidate
+
+	// Always generate series and author-new candidates.
+	series := GenerateSeries(ctx, e.books, e.series, profile)
+	candidates = append(candidates, series...)
+	slog.Info("recommender: series candidates", "count", len(series))
+
+	authorNew := GenerateAuthorNew(ctx, e.books, e.authors, profile)
+	candidates = append(candidates, authorNew...)
+	slog.Info("recommender: author-new candidates", "count", len(authorNew))
+
+	// Cold-start: skip genre scoring if < 20 books.
+	if profile.TotalBooks >= 20 {
+		genreSimilar := GenerateGenreSimilar(ctx, e.books, e.series, profile)
+		candidates = append(candidates, genreSimilar...)
+		slog.Info("recommender: genre-similar candidates", "count", len(genreSimilar))
+	} else {
+		slog.Info("recommender: cold start (< 20 books), skipping genre scoring")
+	}
+
+	// Score all candidates.
+	for i := range candidates {
+		candidates[i].Score = Score(candidates[i], profile)
+	}
+
+	// Sort by score descending.
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].Score > candidates[j].Score
+	})
+
+	// Determine serendipity allocation.
+	serendipityCount := 10
+	scoredCount := 90
+	if len(candidates) < 100 {
+		serendipityCount = max(1, len(candidates)/20) // ~5%
+		scoredCount = len(candidates)
+	}
+
+	// Truncate scored candidates.
+	if len(candidates) > scoredCount {
+		candidates = candidates[:scoredCount]
+	}
+
+	// Inject serendipity picks (only with enough books for genre data).
+	if profile.TotalBooks >= 20 {
+		serendipity := GenerateSerendipity(ctx, e.books, e.series, profile, serendipityCount)
+		for i := range serendipity {
+			serendipity[i].Score = Score(serendipity[i], profile)
+		}
+		candidates = append(candidates, serendipity...)
+		slog.Info("recommender: serendipity candidates", "count", len(serendipity))
+	}
+
+	// Hard-filter: remove already-owned, dismissed, or excluded-author candidates.
+	candidates = hardFilter(candidates, profile)
+
+	// Take top 100.
+	if len(candidates) > 100 {
+		candidates = candidates[:100]
+	}
+
+	slog.Info("recommender: persisting", "count", len(candidates), "userId", userID)
+	return e.recs.ReplaceBatch(ctx, userID, candidates)
+}
+
+// hardFilter removes candidates that should not be shown.
+func hardFilter(candidates []models.RecommendationCandidate, p *UserProfile) []models.RecommendationCandidate {
+	var filtered []models.RecommendationCandidate
+	seen := make(map[string]bool)
+	for _, c := range candidates {
+		if p.OwnedForeignIDs[c.ForeignID] {
+			continue
+		}
+		if p.DismissedForeignIDs[c.ForeignID] {
+			continue
+		}
+		if c.AuthorName != "" && p.ExcludedAuthors[strings.ToLower(c.AuthorName)] {
+			continue
+		}
+		// Deduplicate by foreign ID.
+		if seen[c.ForeignID] {
+			continue
+		}
+		seen[c.ForeignID] = true
+		filtered = append(filtered, c)
+	}
+	return filtered
+}

--- a/internal/recommender/scorer.go
+++ b/internal/recommender/scorer.go
@@ -1,0 +1,172 @@
+package recommender
+
+import (
+	"math"
+	"strings"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// Scoring weights.
+const (
+	weightGenre     = 0.30
+	weightAuthor    = 0.25
+	weightSeries    = 0.20
+	weightCommunity = 0.15
+	weightRecency   = 0.10
+
+	bonusSeries    = 0.15
+	bonusAuthorNew = 0.10
+)
+
+// Score computes a 0.0–1.0 relevance score for a candidate against the user's
+// profile. Higher is better.
+func Score(c models.RecommendationCandidate, p *UserProfile) float64 {
+	genre := genreScore(c, p)
+	author := authorScore(c, p)
+	series := seriesScore(c, p)
+	community := communityScore(c)
+	recency := recencyScore(c)
+
+	score := genre*weightGenre +
+		author*weightAuthor +
+		series*weightSeries +
+		community*weightCommunity +
+		recency*weightRecency
+
+	// Bonus for next-in-sequence series book.
+	if c.RecType == models.RecTypeSeries {
+		score += bonusSeries
+	}
+	// Bonus for new work from monitored author.
+	if c.RecType == models.RecTypeAuthorNew && c.AuthorID != nil && p.MonitoredAuthors[*c.AuthorID] {
+		score += bonusAuthorNew
+	}
+
+	return clamp(score)
+}
+
+// genreScore computes cosine similarity between the candidate's genre set
+// (binary vector) and the user's TF-IDF genre weights.
+func genreScore(c models.RecommendationCandidate, p *UserProfile) float64 {
+	if len(p.GenreWeights) == 0 || len(c.Genres) == 0 {
+		return 0
+	}
+
+	// Build candidate binary vector in the same genre space.
+	var dotProduct, candMag float64
+	for _, g := range c.Genres {
+		g = strings.ToLower(strings.TrimSpace(g))
+		if g == "" {
+			continue
+		}
+		candMag += 1.0 // binary: 1^2 = 1
+		if w, ok := p.GenreWeights[g]; ok {
+			dotProduct += w // w * 1
+		}
+	}
+
+	if candMag == 0 {
+		return 0
+	}
+
+	// Profile magnitude.
+	var profileMag float64
+	for _, w := range p.GenreWeights {
+		profileMag += w * w
+	}
+	profileMag = math.Sqrt(profileMag)
+	candMag = math.Sqrt(candMag)
+
+	if profileMag == 0 {
+		return 0
+	}
+
+	return dotProduct / (profileMag * candMag)
+}
+
+// authorScore returns an affinity score based on how many books the user has
+// from this author and whether the author is monitored.
+func authorScore(c models.RecommendationCandidate, p *UserProfile) float64 {
+	if c.AuthorID == nil {
+		return 0
+	}
+	aid := *c.AuthorID
+	if p.MonitoredAuthors[aid] {
+		return 1.0
+	}
+	count := p.AuthorBookCounts[aid]
+	if count >= 3 {
+		return 0.7
+	}
+	if count >= 1 {
+		return 0.4
+	}
+	return 0
+}
+
+// seriesScore rewards candidates that continue or fill gaps in a series the
+// user has started.
+func seriesScore(c models.RecommendationCandidate, p *UserProfile) float64 {
+	if c.SeriesID == nil {
+		return 0
+	}
+	state, ok := p.SeriesState[*c.SeriesID]
+	if !ok {
+		return 0
+	}
+
+	pos := parsePosition(c.SeriesPos)
+	if pos <= 0 {
+		return 0
+	}
+
+	// Next-in-sequence: one position after the user's max.
+	if pos == state.MaxPosition+1 {
+		return 1.0
+	}
+
+	// Fills a gap in the user's collection.
+	for _, missing := range state.MissingPositions {
+		if pos == missing {
+			return 0.5
+		}
+	}
+
+	return 0
+}
+
+// communityScore blends rating quality with rating quantity using a log scale.
+func communityScore(c models.RecommendationCandidate) float64 {
+	ratingNorm := math.Min(1.0, c.Rating/5.0)
+	countNorm := math.Log10(1+float64(c.RatingsCount)) / math.Log10(1001)
+	return ratingNorm * countNorm
+}
+
+// recencyScore applies linear decay: 1.0 for the current year, 0.3 at 20+
+// years ago. Returns 0.5 if no release date is available.
+func recencyScore(c models.RecommendationCandidate) float64 {
+	if c.ReleaseDate == nil {
+		return 0.5
+	}
+	yearsAgo := float64(time.Now().Year() - c.ReleaseDate.Year())
+	if yearsAgo < 0 {
+		yearsAgo = 0
+	}
+	if yearsAgo >= 20 {
+		return 0.3
+	}
+	// Linear from 1.0 (0 years) to 0.3 (20 years).
+	return 1.0 - (0.7/20.0)*yearsAgo
+}
+
+func clamp(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/internal/recommender/types.go
+++ b/internal/recommender/types.go
@@ -1,0 +1,26 @@
+// Package recommender implements Bindery's content-based book recommendation
+// engine. It analyses the user's library to build a taste profile, generates
+// candidates from series gaps, monitored-author works, and genre similarity,
+// scores them, and persists the top results for the Discover page.
+package recommender
+
+// SeriesState tracks a user's progress through a series.
+type SeriesState struct {
+	SeriesID         int64
+	SeriesTitle      string
+	MaxPosition      float64
+	MissingPositions []float64
+}
+
+// UserProfile captures the user's reading taste, built from their library.
+type UserProfile struct {
+	GenreWeights        map[string]float64
+	MonitoredAuthors    map[int64]bool
+	AuthorBookCounts    map[int64]int
+	SeriesState         map[int64]SeriesState
+	OwnedForeignIDs     map[string]bool
+	DismissedForeignIDs map[string]bool
+	ExcludedAuthors     map[string]bool
+	PreferredLanguage   string
+	TotalBooks          int
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -33,6 +33,12 @@ type bookSearcher interface {
 	SearchBook(ctx context.Context, indexers []models.Indexer, c indexer.MatchCriteria) []newznab.SearchResult
 }
 
+// RecommendationEngine is the narrow interface the scheduler calls to
+// regenerate recommendations. *recommender.Engine satisfies it.
+type RecommendationEngine interface {
+	Run(ctx context.Context, userID int64) error
+}
+
 // Scheduler runs background jobs on configurable intervals.
 type Scheduler struct {
 	cron     *cron.Cron
@@ -47,7 +53,8 @@ type Scheduler struct {
 	clients       *db.DownloadClientRepo
 	settings      *db.SettingsRepo
 	blocklist     *db.BlocklistRepo
-	calibreSyncer CalibreSyncer // optional; nil if Calibre is not configured
+	calibreSyncer CalibreSyncer        // optional; nil if Calibre is not configured
+	recommender   RecommendationEngine // optional; generates recommendations
 }
 
 // New creates a new scheduler.
@@ -84,6 +91,12 @@ func (s *Scheduler) WithCalibreSyncer(syncer CalibreSyncer) {
 	s.calibreSyncer = syncer
 }
 
+// WithRecommender registers a recommendation engine that runs every 24 hours.
+// Must be called before Start.
+func (s *Scheduler) WithRecommender(engine RecommendationEngine) {
+	s.recommender = engine
+}
+
 // Start registers and runs all background jobs.
 func (s *Scheduler) Start() {
 	// Check downloads every 15 seconds so completed imports land quickly
@@ -118,6 +131,21 @@ func (s *Scheduler) Start() {
 		s.cron.AddFunc("@every 24h", func() {
 			slog.Info("job: calibre library sync")
 			s.calibreSyncer.RunSync(context.Background())
+		})
+	}
+
+	// Generate recommendations every 24 hours when the engine is registered.
+	if s.recommender != nil {
+		s.cron.AddFunc("@every 24h", func() {
+			slog.Info("job: generate recommendations")
+			if s.settings != nil {
+				if setting, _ := s.settings.Get(context.Background(), "recommendations.enabled"); setting == nil || setting.Value != "true" {
+					return
+				}
+			}
+			if err := s.recommender.Run(context.Background(), 1); err != nil {
+				slog.Error("recommendation engine failed", "error", err)
+			}
 		})
 	}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import HistoryPage from './pages/HistoryPage'
 import SeriesPage from './pages/SeriesPage'
 import CalendarPage from './pages/CalendarPage'
 import BlocklistPage from './pages/BlocklistPage'
+import DiscoverPage from './pages/DiscoverPage'
 import Logo from './components/Logo'
 import { useTheme } from './theme'
 
@@ -28,6 +29,7 @@ const NAV_KEYS = [
   { to: '/history', key: 'history' },
   { to: '/series', key: 'series' },
   { to: '/calendar', key: 'calendar' },
+  { to: '/discover', key: 'discover' },
   { to: '/blocklist', key: 'blocklist' },
   { to: '/settings', key: 'settings' },
 ]
@@ -150,6 +152,7 @@ function Shell() {
           <Route path="/history" element={<HistoryPage />} />
           <Route path="/series" element={<SeriesPage />} />
           <Route path="/calendar" element={<CalendarPage />} />
+          <Route path="/discover" element={<DiscoverPage />} />
           <Route path="/blocklist" element={<BlocklistPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -218,6 +218,23 @@ export const api = {
   listRootFolders: () => request<RootFolder[]>('/rootfolder'),
   addRootFolder: (path: string) => request<RootFolder>('/rootfolder', { method: 'POST', body: JSON.stringify({ path }) }),
   deleteRootFolder: (id: number) => request<void>(`/rootfolder/${id}`, { method: 'DELETE' }),
+
+  // Recommendations
+  listRecommendations: (params?: { type?: string; limit?: number; offset?: number }) => {
+    const q = new URLSearchParams()
+    if (params?.type) q.set('type', params.type)
+    if (params?.limit) q.set('limit', String(params.limit))
+    if (params?.offset) q.set('offset', String(params.offset))
+    const qs = q.toString()
+    return request<Recommendation[]>(`/recommendations${qs ? '?' + qs : ''}`)
+  },
+  dismissRecommendation: (id: number) => request<void>(`/recommendations/${id}/dismiss`, { method: 'POST' }),
+  addRecommendation: (id: number) => request<void>(`/recommendations/${id}/add`, { method: 'POST' }),
+  refreshRecommendations: () => request<void>('/recommendations/refresh', { method: 'POST' }),
+  clearRecommendationDismissals: () => request<void>('/recommendations/dismissals', { method: 'DELETE' }),
+  listAuthorExclusions: () => request<string[]>('/recommendations/exclude-author'),
+  addAuthorExclusion: (authorName: string) => request<void>('/recommendations/exclude-author', { method: 'POST', body: JSON.stringify({ authorName }) }),
+  removeAuthorExclusion: (authorName: string) => request<void>(`/recommendations/exclude-author/${encodeURIComponent(authorName)}`, { method: 'DELETE' }),
 }
 
 // Types
@@ -505,6 +522,31 @@ export interface LogEntry {
   level: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
   msg: string
   attrs?: Record<string, string>
+}
+
+export interface Recommendation {
+  id: number
+  userId: number
+  foreignId: string
+  recType: string
+  title: string
+  authorName: string
+  authorId?: number
+  imageUrl: string
+  description: string
+  genres: string[]
+  rating: number
+  ratingsCount: number
+  releaseDate?: string
+  language: string
+  mediaType: string
+  score: number
+  reason: string
+  seriesId?: number
+  seriesPos: string
+  dismissed: boolean
+  batchId: string
+  createdAt: string
 }
 
 export type AuthorBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search'

--- a/web/src/components/RecommendationCard.tsx
+++ b/web/src/components/RecommendationCard.tsx
@@ -1,0 +1,123 @@
+import { useState, useRef, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Recommendation } from '../api/client'
+
+interface RecommendationCardProps {
+  rec: Recommendation
+  onDismiss: (id: number) => void
+  onAdd: (id: number) => void
+  onExcludeAuthor: (authorName: string) => void
+}
+
+export default function RecommendationCard({ rec, onDismiss, onAdd, onExcludeAuthor }: RecommendationCardProps) {
+  const { t } = useTranslation()
+  const [menuOpen, setMenuOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!menuOpen) return
+    const handleClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [menuOpen])
+
+  const imageUrl = rec.imageUrl
+    ? `/api/v1/images?url=${encodeURIComponent(rec.imageUrl)}`
+    : ''
+
+  const stars = Math.round(rec.rating * 2) / 2 // round to nearest 0.5
+
+  return (
+    <div className="flex-shrink-0 w-56 bg-slate-100 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+      {/* Cover image */}
+      <div className="h-36 bg-slate-200 dark:bg-zinc-800 flex items-center justify-center">
+        {imageUrl ? (
+          <img src={imageUrl} alt={rec.title} className="w-full h-full object-cover" />
+        ) : (
+          <svg className="w-10 h-10 text-slate-400 dark:text-zinc-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+          </svg>
+        )}
+      </div>
+
+      <div className="p-3">
+        {/* Title and author */}
+        <h4 className="font-medium text-sm truncate" title={rec.title}>{rec.title}</h4>
+        <p className="text-xs text-slate-500 dark:text-zinc-500 truncate">{rec.authorName}</p>
+
+        {/* Star rating */}
+        <div className="flex items-center gap-1 mt-1">
+          <div className="flex">
+            {[1, 2, 3, 4, 5].map(i => (
+              <svg
+                key={i}
+                className={`w-3 h-3 ${i <= stars ? 'text-amber-400' : i - 0.5 <= stars ? 'text-amber-400' : 'text-slate-300 dark:text-zinc-700'}`}
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
+                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+              </svg>
+            ))}
+          </div>
+          {rec.ratingsCount > 0 && (
+            <span className="text-[10px] text-slate-400 dark:text-zinc-600">({rec.ratingsCount})</span>
+          )}
+        </div>
+
+        {/* Genre tags */}
+        {rec.genres.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1.5">
+            {rec.genres.slice(0, 3).map(genre => (
+              <span key={genre} className="px-1.5 py-0.5 bg-slate-200 dark:bg-zinc-800 rounded text-[10px] text-slate-600 dark:text-zinc-400 truncate max-w-[80px]">
+                {genre}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Reason */}
+        <p className="text-[11px] text-emerald-600 dark:text-emerald-400 mt-2 line-clamp-2 italic">
+          {rec.reason}
+        </p>
+
+        {/* Actions */}
+        <div className="flex items-center gap-1.5 mt-2.5">
+          <button
+            onClick={() => onAdd(rec.id)}
+            className="flex-1 px-2 py-1.5 bg-emerald-600 hover:bg-emerald-500 text-white rounded text-xs font-medium transition-colors"
+          >
+            {t('discover.addToWanted')}
+          </button>
+          <button
+            onClick={() => onDismiss(rec.id)}
+            className="px-2 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs text-slate-600 dark:text-zinc-400 transition-colors"
+          >
+            {t('discover.dismiss')}
+          </button>
+          <div className="relative" ref={menuRef}>
+            <button
+              onClick={() => setMenuOpen(o => !o)}
+              className="px-1.5 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs text-slate-600 dark:text-zinc-400 transition-colors"
+            >
+              &middot;&middot;&middot;
+            </button>
+            {menuOpen && (
+              <div className="absolute right-0 bottom-full mb-1 w-48 bg-white dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-lg shadow-lg z-10">
+                <button
+                  onClick={() => { onExcludeAuthor(rec.authorName); setMenuOpen(false) }}
+                  className="w-full text-left px-3 py-2 text-xs text-slate-700 dark:text-zinc-300 hover:bg-slate-100 dark:hover:bg-zinc-700 rounded-lg transition-colors"
+                >
+                  {t('discover.dontSuggestAuthor', { author: rec.authorName })}
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/RecommendationRow.tsx
+++ b/web/src/components/RecommendationRow.tsx
@@ -1,0 +1,33 @@
+import { Recommendation } from '../api/client'
+import RecommendationCard from './RecommendationCard'
+
+interface RecommendationRowProps {
+  title: string
+  recommendations: Recommendation[]
+  onDismiss: (id: number) => void
+  onAdd: (id: number) => void
+  onExcludeAuthor: (authorName: string) => void
+}
+
+export default function RecommendationRow({ title, recommendations, onDismiss, onAdd, onExcludeAuthor }: RecommendationRowProps) {
+  if (recommendations.length === 0) return null
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-lg font-semibold">{title}</h3>
+      </div>
+      <div className="flex gap-3 overflow-x-auto pb-2 scrollbar-thin">
+        {recommendations.map(rec => (
+          <RecommendationCard
+            key={rec.id}
+            rec={rec}
+            onDismiss={onDismiss}
+            onAdd={onAdd}
+            onExcludeAuthor={onExcludeAuthor}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -38,6 +38,7 @@
     "calendar": "Kalender",
     "queue": "Warteschlange",
     "series": "Serien",
+    "discover": "Discover",
     "blocklist": "Blockliste",
     "settings": "Einstellungen"
   },
@@ -360,5 +361,29 @@
   "bulkActionBar": {
     "selected": "{{count}} ausgewählt",
     "clear": "Löschen"
+  },
+  "discover": {
+    "title": "Discover",
+    "subtitle": "Based on your library",
+    "refresh": "Refresh",
+    "refreshing": "Refreshing...",
+    "addToWanted": "Add to Wanted",
+    "dismiss": "Dismiss",
+    "dontSuggestAuthor": "Don't suggest {{author}}",
+    "addedToWanted": "Added to Wanted",
+    "rows": {
+      "series": "Next in series",
+      "author_new": "New from your authors",
+      "genre_similar": "Because of your library",
+      "serendipity": "You might not expect",
+      "genre_popular": "Popular in your genres",
+      "list_cross": "From your lists"
+    },
+    "empty": {
+      "noRecs": "Your library doesn't have enough data yet. Add authors and monitor them to get recommendations.",
+      "disabled": "Recommendations are disabled. Enable them in Settings to start discovering new books.",
+      "coldStart": "Add more books to unlock personalized genre recommendations.",
+      "goToSettings": "Go to Settings"
+    }
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -38,6 +38,7 @@
     "calendar": "Calendar",
     "queue": "Queue",
     "series": "Series",
+    "discover": "Discover",
     "blocklist": "Blocklist",
     "settings": "Settings"
   },
@@ -359,5 +360,29 @@
   "bulkActionBar": {
     "selected": "{{count}} selected",
     "clear": "Clear"
+  },
+  "discover": {
+    "title": "Discover",
+    "subtitle": "Based on your library",
+    "refresh": "Refresh",
+    "refreshing": "Refreshing...",
+    "addToWanted": "Add to Wanted",
+    "dismiss": "Dismiss",
+    "dontSuggestAuthor": "Don't suggest {{author}}",
+    "addedToWanted": "Added to Wanted",
+    "rows": {
+      "series": "Next in series",
+      "author_new": "New from your authors",
+      "genre_similar": "Because of your library",
+      "serendipity": "You might not expect",
+      "genre_popular": "Popular in your genres",
+      "list_cross": "From your lists"
+    },
+    "empty": {
+      "noRecs": "Your library doesn't have enough data yet. Add authors and monitor them to get recommendations.",
+      "disabled": "Recommendations are disabled. Enable them in Settings to start discovering new books.",
+      "coldStart": "Add more books to unlock personalized genre recommendations.",
+      "goToSettings": "Go to Settings"
+    }
   }
 }

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -38,6 +38,7 @@
     "calendar": "Calendrier",
     "queue": "File d'attente",
     "series": "Séries",
+    "discover": "Discover",
     "blocklist": "Liste de blocage",
     "settings": "Paramètres"
   },
@@ -360,5 +361,29 @@
   "bulkActionBar": {
     "selected": "{{count}} sélectionné(s)",
     "clear": "Effacer"
+  },
+  "discover": {
+    "title": "Discover",
+    "subtitle": "Based on your library",
+    "refresh": "Refresh",
+    "refreshing": "Refreshing...",
+    "addToWanted": "Add to Wanted",
+    "dismiss": "Dismiss",
+    "dontSuggestAuthor": "Don't suggest {{author}}",
+    "addedToWanted": "Added to Wanted",
+    "rows": {
+      "series": "Next in series",
+      "author_new": "New from your authors",
+      "genre_similar": "Because of your library",
+      "serendipity": "You might not expect",
+      "genre_popular": "Popular in your genres",
+      "list_cross": "From your lists"
+    },
+    "empty": {
+      "noRecs": "Your library doesn't have enough data yet. Add authors and monitor them to get recommendations.",
+      "disabled": "Recommendations are disabled. Enable them in Settings to start discovering new books.",
+      "coldStart": "Add more books to unlock personalized genre recommendations.",
+      "goToSettings": "Go to Settings"
+    }
   }
 }

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -38,6 +38,7 @@
     "calendar": "Kalender",
     "queue": "Wachtrij",
     "series": "Reeksen",
+    "discover": "Discover",
     "blocklist": "Blokkeerlijst",
     "settings": "Instellingen"
   },
@@ -360,5 +361,29 @@
   "bulkActionBar": {
     "selected": "{{count}} geselecteerd",
     "clear": "Wissen"
+  },
+  "discover": {
+    "title": "Discover",
+    "subtitle": "Based on your library",
+    "refresh": "Refresh",
+    "refreshing": "Refreshing...",
+    "addToWanted": "Add to Wanted",
+    "dismiss": "Dismiss",
+    "dontSuggestAuthor": "Don't suggest {{author}}",
+    "addedToWanted": "Added to Wanted",
+    "rows": {
+      "series": "Next in series",
+      "author_new": "New from your authors",
+      "genre_similar": "Because of your library",
+      "serendipity": "You might not expect",
+      "genre_popular": "Popular in your genres",
+      "list_cross": "From your lists"
+    },
+    "empty": {
+      "noRecs": "Your library doesn't have enough data yet. Add authors and monitor them to get recommendations.",
+      "disabled": "Recommendations are disabled. Enable them in Settings to start discovering new books.",
+      "coldStart": "Add more books to unlock personalized genre recommendations.",
+      "goToSettings": "Go to Settings"
+    }
   }
 }

--- a/web/src/pages/DiscoverPage.tsx
+++ b/web/src/pages/DiscoverPage.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { api, Recommendation } from '../api/client'
+import RecommendationRow from '../components/RecommendationRow'
+
+const ROW_ORDER: Array<{ type: string; labelKey: string }> = [
+  { type: 'series', labelKey: 'discover.rows.series' },
+  { type: 'author_new', labelKey: 'discover.rows.author_new' },
+  { type: 'genre_similar', labelKey: 'discover.rows.genre_similar' },
+  { type: 'serendipity', labelKey: 'discover.rows.serendipity' },
+  { type: 'genre_popular', labelKey: 'discover.rows.genre_popular' },
+  { type: 'list_cross', labelKey: 'discover.rows.list_cross' },
+]
+
+export default function DiscoverPage() {
+  const { t } = useTranslation()
+  const [recs, setRecs] = useState<Recommendation[]>([])
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [enabled, setEnabled] = useState<boolean | null>(null)
+  const [toast, setToast] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const data = await api.listRecommendations({ limit: 100 })
+      setRecs(data)
+    } catch {
+      setRecs([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const checkEnabled = useCallback(async () => {
+    try {
+      const settings = await api.listSettings()
+      const setting = settings.find(s => s.key === 'recommendations.enabled')
+      setEnabled(setting?.value === 'true')
+    } catch {
+      setEnabled(true) // assume enabled if settings check fails
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+    checkEnabled()
+  }, [load, checkEnabled])
+
+  const showToast = (msg: string) => {
+    setToast(msg)
+    setTimeout(() => setToast(null), 2500)
+  }
+
+  const grouped = useMemo(() => {
+    const map: Record<string, Recommendation[]> = {}
+    for (const rec of recs) {
+      if (!map[rec.recType]) map[rec.recType] = []
+      map[rec.recType].push(rec)
+    }
+    return map
+  }, [recs])
+
+  const handleDismiss = async (id: number) => {
+    setRecs(prev => prev.filter(r => r.id !== id))
+    try {
+      await api.dismissRecommendation(id)
+    } catch {
+      // optimistic — already removed from UI
+    }
+  }
+
+  const handleAdd = async (id: number) => {
+    setRecs(prev => prev.filter(r => r.id !== id))
+    showToast(t('discover.addedToWanted'))
+    try {
+      await api.addRecommendation(id)
+    } catch {
+      // optimistic — already removed from UI
+    }
+  }
+
+  const handleExcludeAuthor = async (authorName: string) => {
+    setRecs(prev => prev.filter(r => r.authorName !== authorName))
+    try {
+      await api.addAuthorExclusion(authorName)
+    } catch {
+      // optimistic — already removed from UI
+    }
+  }
+
+  const handleRefresh = async () => {
+    setRefreshing(true)
+    try {
+      await api.refreshRecommendations()
+      // Wait for background regeneration then re-fetch
+      setTimeout(() => {
+        load().finally(() => setRefreshing(false))
+      }, 2000)
+    } catch {
+      setRefreshing(false)
+    }
+  }
+
+  // Detect cold start: have series/author_new but no genre_similar/genre_popular
+  const hasSeries = (grouped['series']?.length ?? 0) > 0
+  const hasAuthorNew = (grouped['author_new']?.length ?? 0) > 0
+  const hasGenreSimilar = (grouped['genre_similar']?.length ?? 0) > 0
+  const hasGenrePopular = (grouped['genre_popular']?.length ?? 0) > 0
+  const isColdStart = (hasSeries || hasAuthorNew) && !hasGenreSimilar && !hasGenrePopular
+
+  const hasAnyRecs = recs.length > 0
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-2xl font-bold">{t('discover.title')}</h2>
+          <p className="text-sm text-slate-500 dark:text-zinc-500">{t('discover.subtitle')}</p>
+        </div>
+        <button
+          onClick={handleRefresh}
+          disabled={refreshing}
+          className="px-4 py-2 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded-lg text-sm font-medium disabled:opacity-50 transition-colors"
+        >
+          {refreshing ? t('discover.refreshing') : t('discover.refresh')}
+        </button>
+      </div>
+
+      {/* Toast */}
+      {toast && (
+        <div className="fixed bottom-6 right-6 z-50 px-4 py-2.5 bg-emerald-600 text-white rounded-lg shadow-lg text-sm font-medium animate-fade-in">
+          {toast}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-slate-600 dark:text-zinc-500">{t('common.loading')}</div>
+      ) : !hasAnyRecs && enabled === false ? (
+        /* Disabled state */
+        <div className="text-center py-20">
+          <svg className="w-16 h-16 mx-auto mb-4 text-slate-300 dark:text-zinc-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5.002 5.002 0 017.072 0" />
+          </svg>
+          <p className="text-slate-600 dark:text-zinc-400 mb-4">{t('discover.empty.disabled')}</p>
+          <Link
+            to="/settings"
+            className="inline-block px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg text-sm font-medium transition-colors"
+          >
+            {t('discover.empty.goToSettings')}
+          </Link>
+        </div>
+      ) : !hasAnyRecs ? (
+        /* Empty state — not enough data */
+        <div className="text-center py-20">
+          <svg className="w-16 h-16 mx-auto mb-4 text-slate-300 dark:text-zinc-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+          </svg>
+          <p className="text-slate-600 dark:text-zinc-400">{t('discover.empty.noRecs')}</p>
+        </div>
+      ) : (
+        <>
+          {/* Cold start note */}
+          {isColdStart && (
+            <div className="mb-6 px-4 py-3 bg-slate-100 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded-lg">
+              <p className="text-sm text-slate-500 dark:text-zinc-500">{t('discover.empty.coldStart')}</p>
+            </div>
+          )}
+
+          {/* Recommendation rows */}
+          {ROW_ORDER.map(row => (
+            <RecommendationRow
+              key={row.type}
+              title={t(row.labelKey)}
+              recommendations={grouped[row.type] ?? []}
+              onDismiss={handleDismiss}
+              onAdd={handleAdd}
+              onExcludeAuthor={handleExcludeAuthor}
+            />
+          ))}
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `internal/recommender/` package with TF-IDF content-based engine, series continuation, author new works, and serendipity candidates
- Adds DB migration 015 with user-scoped recommendations, dismissals, and author exclusion tables
- Adds `/api/v1/recommendations` endpoints (List, Dismiss, Add, Refresh, author exclusions)
- Adds Discover page with Netflix-style horizontal rows, RecommendationCard, RecommendationRow components
- Opt-in by default (`recommendations.enabled` setting defaults to false)
- User-scoped schema (user_id columns) for multi-user readiness

## Test plan
- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean  
- [ ] `go test -race ./...` passes
- [ ] `npm run build && npm run lint && npm run typecheck` clean
- [ ] Enable recommendations in Settings, trigger refresh, verify cards appear on /discover
- [ ] Dismiss a card — verify it disappears immediately (optimistic) and stays gone after page reload
- [ ] "Add to Wanted" — verify book appears on /wanted
- [ ] "Don't suggest [author]" — verify all cards for that author disappear