### PR TITLE
feat: Transmission client, downloader adapter, Prowlarr Torznab fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ coverage.html
 
 # Frontend
 web/node_modules/
+web/coverage/
 web/dist/
 web/.vite/
 web/tsconfig.tsbuildinfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,51 @@ Feature release adding configurable import modes, an end-to-end smoke-test suite
 - **Root folders** — multiple root library paths can now be configured under **Settings → Root Folders**. Each author can be assigned to a specific root folder; unassigned authors continue to use the startup default path. Free disk space is shown next to each path.
 - **Language propagation into indexer queries** — search queries now include the author's metadata-profile language filter. For Prowlarr/Jackett, the allowed-language codes are appended to the query so foreign-language releases can be excluded on the indexer side as well as during metadata ingestion. The outgoing query string is visible at DEBUG level in the new log viewer.
 - **Language field from metadata providers** — Google Books and Hardcover now populate the `language` field on book records. Hardcover exposes language via the `editions` GraphQL node; Google Books via the `volumeInfo.language` JSON field. Language pills are surfaced in the Wanted page result rows when the indexer returns `<newznab:attr name="language">`.
+- **Bindery supports Transmission as a torrent downloader** alongside qBittorrent (torrent) and SABnzbd (usenet). Download dispatch and status handling are centralized through the downloader adapter layer.
+
+#### 1. Transmission Downloader Package
+- Location: `internal/downloader/transmission/`
+- Files:
+  - `client.go`:
+    - `New()`
+    - `Test()`
+    - `AddTorrent()`
+    - `GetTorrents()`
+    - `RemoveTorrent()`
+    - Handles Transmission session ID negotiation (`409` + `X-Transmission-Session-Id`)
+  - `types.go`:
+    - RPC payload types including torrent status fields and `errorString`
+
+#### 2. Database Changes
+- Migration: `internal/db/migrations/013_transmission.sql`
+  - Adds `downloads.torrent_id`
+  - Adds index on `downloads.torrent_id`
+- Migration: `internal/db/migrations/014_download_client_credentials.sql`
+  - Adds `download_clients.username` and `download_clients.password`
+  - Backfills credential clients from legacy storage (`url_base`/`api_key`) for compatibility
+
+#### 3. Model and Repository Updates
+- `internal/models/download.go`:
+  - `Download.TorrentID` for torrent remote IDs
+  - `DownloadClient.Username` and `DownloadClient.Password` persisted in dedicated DB columns
+- `internal/db/download_clients.go`:
+  - Reads/writes explicit `username`/`password` fields
+  - Keeps legacy fallback when older rows/payloads still carry credentials in `url_base`/`api_key`
+
+#### 4. Adapter and API Integration
+- `internal/downloader/adapter.go` dispatches by client type for:
+  - Connectivity tests
+  - Send download
+  - Remove download
+  - Live status overlay data
+- `internal/api/queue.go` and `internal/api/download_clients.go` use adapter-based client dispatch.
+
+#### 5. Scanner / Importer Integration
+- `internal/importer/scanner.go`:
+  - `checkTransmissionDownloads()` polls Transmission torrents via `torrent-get`
+  - Imports completed torrents into the library
+  - Failure behavior uses `errorString` for stopped torrents (details below)
+  - Cleanup warning logs include context (`clientType`, `remoteID`) for operations correlation
 - **End-to-end smoke test suite (closes [#97](https://github.com/vavallee/bindery/issues/97))** — `tests/smoke/smoke_test.go` boots the real binary against a scratch data directory and exercises the golden-path HTTP endpoints (health, auth, authors, books, settings, history, OPDS). Runs on every PR and main/development push via the `make smoke` target in CI. Catches wiring regressions (broken route registration, missing migration, bad frontend embed) that unit tests miss.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 ### Search & downloads
 - **Newznab + Torznab** — Query multiple Usenet and torrent indexers in parallel, deduplicated and ranked
-- **SABnzbd + qBittorrent** — Full support for both Usenet and torrent download clients
+- **SABnzbd, qBittorrent, Transmission** — Full support for both Usenet and torrent download clients
 - **Auto-grab** — Scheduler searches for wanted books every 12h and automatically grabs the best result. Adding a new author or flipping a book to `wanted` fires an immediate search — no waiting for the next scheduled pass. Toggle the global kill-switch at **Settings → General → Auto-grab** to pause all automatic grabbing without losing your monitored list.
 - **Interactive search** — Manual per-book search from the Wanted page with full result details; Grab button shows a spinner while in-flight and a ✓ on success
 - **Smart matching** — Four-tier query fallback (`t=book` → `surname+title` → `author+title` → title); word-boundary keyword matching; contiguous-phrase requirement for multi-word titles; dual-author-anchor for ambiguous short titles; subtitle-aware (`Title: Subtitle`)
@@ -190,6 +190,7 @@ No Goodreads scraping. All sources use documented, stable public APIs. Cover ima
 ### Download clients
 - **SABnzbd** — full support (NZB submission, queue/history polling, pause/resume/delete)
 - **qBittorrent** — WebUI API v2 with Username/Password auth (add magnet/URL, list/delete torrents)
+- **Transmission** - WebUI API with Username/Password auth (add magnet/URL, list/delete torrents)
 
 ### Indexers
 - **Newznab** (Usenet) — NZBGeek, NZBFinder, NZBPlanet, DrunkenSlug, etc.

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -304,13 +304,17 @@ func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.history != nil {
-		data, _ := json.Marshal(map[string]any{"paths": deletedPaths})
-		_ = h.history.Create(r.Context(), &models.HistoryEvent{
+		data, err := json.Marshal(map[string]any{"paths": deletedPaths})
+		if err != nil {
+			slog.Warn("failed to marshal deleted paths history event", "book_id", book.ID, "error", err)
+		} else if err := h.history.Create(r.Context(), &models.HistoryEvent{
 			BookID:      &book.ID,
 			EventType:   models.HistoryEventBookFileDeleted,
 			SourceTitle: book.Title,
 			Data:        string(data),
-		})
+		}); err != nil {
+			slog.Warn("failed to create deleted paths history event", "book_id", book.ID, "error", err)
+		}
 	}
 
 	writeJSON(w, http.StatusOK, book)

--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -9,8 +9,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
-	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
-	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
+	"github.com/vavallee/bindery/internal/downloader"
 	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -133,19 +132,9 @@ func (h *DownloadClientHandler) Test(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "download client not found"})
 		return
 	}
-
-	if client.Type == "qbittorrent" {
-		qbt := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
-		if err := qbt.Test(r.Context()); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-			return
-		}
-	} else {
-		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
-		if err := sab.Test(r.Context()); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-			return
-		}
+	if err := downloader.TestClient(r.Context(), client); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"message": "ok"})
 }

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -91,7 +91,7 @@ func streamZip(w http.ResponseWriter, srcDir string) {
 			return nil
 		}
 		defer f.Close()
-		_, _ = io.Copy(zf, f)
-		return nil
+		_, err = io.Copy(zf, f)
+		return err
 	})
 }

--- a/internal/api/library.go
+++ b/internal/api/library.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 
 	"github.com/vavallee/bindery/internal/db"
@@ -58,5 +59,7 @@ func (h *LibraryHandler) ScanStatus(w http.ResponseWriter, r *http.Request) {
 	// The value is already a JSON string — write it directly.
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(setting.Value))
+	if _, err := w.Write([]byte(setting.Value)); err != nil {
+		slog.Warn("failed to write library scan status", "error", err)
+	}
 }

--- a/internal/api/opds.go
+++ b/internal/api/opds.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/xml"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -138,10 +139,15 @@ func baseURL(r *http.Request) string {
 func writeOPDS(w http.ResponseWriter, feed opds.Feed) {
 	w.Header().Set("Content-Type", opds.ContentTypeFeed)
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(xml.Header))
+	if _, err := w.Write([]byte(xml.Header)); err != nil {
+		slog.Warn("failed to write OPDS header", "error", err)
+		return
+	}
 	enc := xml.NewEncoder(w)
 	enc.Indent("", "  ")
-	_ = enc.Encode(feed)
+	if err := enc.Encode(feed); err != nil {
+		slog.Warn("failed to encode OPDS feed", "error", err)
+	}
 }
 
 // writeOPDSError handles known builder errors (currently just ErrNotFound).

--- a/internal/api/opds_auth.go
+++ b/internal/api/opds_auth.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -56,7 +57,9 @@ func OPDSAuth(p auth.Provider, users *db.UserRepo) func(http.Handler) http.Handl
 			w.Header().Set("WWW-Authenticate", `Basic realm="Bindery OPDS"`)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
-			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+			if _, err := w.Write([]byte(`{"error":"unauthorized"}`)); err != nil {
+				slog.Warn("failed to write OPDS unauthorized response", "error", err)
+			}
 		})
 	}
 }

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -5,15 +5,11 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
-	"strconv"
-
-	"github.com/go-chi/chi/v5"
 
 	"fmt"
 
 	"github.com/vavallee/bindery/internal/db"
-	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
-	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
+	"github.com/vavallee/bindery/internal/downloader"
 	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -29,7 +25,7 @@ func NewQueueHandler(downloads *db.DownloadRepo, clients *db.DownloadClientRepo,
 	return &QueueHandler{downloads: downloads, clients: clients, books: books, history: history}
 }
 
-// QueueItem combines local download record with live SABnzbd status.
+// QueueItem combines local download record with live downloader status.
 type QueueItem struct {
 	models.Download
 	Percentage string `json:"percentage,omitempty"`
@@ -44,29 +40,62 @@ func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Overlay live SABnzbd status
 	items := make([]QueueItem, len(downloads))
 	for i, d := range downloads {
 		items[i] = QueueItem{Download: d}
 	}
 
-	client, err := h.clients.GetFirstEnabledByProtocol(r.Context(), "usenet")
-	if err == nil && client != nil && client.Type == "sabnzbd" {
-		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
-		queue, err := sab.GetQueue(r.Context())
-		if err == nil {
-			slotMap := make(map[string]sabnzbd.QueueSlot)
-			for _, slot := range queue.Slots {
-				slotMap[slot.NzoID] = slot
+	type liveStatusResult struct {
+		statuses      map[string]downloader.LiveStatus
+		usesTorrentID bool
+	}
+
+	statusByClientID := make(map[int64]liveStatusResult)
+	for i, item := range items {
+		if item.DownloadClientID == nil {
+			continue
+		}
+
+		clientID := *item.DownloadClientID
+		result, ok := statusByClientID[clientID]
+		if !ok {
+			client, err := h.clients.GetByID(r.Context(), clientID)
+			if err != nil || client == nil || !client.Enabled {
+				statusByClientID[clientID] = liveStatusResult{}
+				continue
 			}
-			for i, item := range items {
-				if item.SABnzbdNzoID != nil {
-					if slot, ok := slotMap[*item.SABnzbdNzoID]; ok {
-						items[i].Percentage = slot.Percentage
-						items[i].TimeLeft = slot.TimeLeft
-					}
-				}
+
+			statuses, usesTorrentID, err := downloader.GetLiveStatuses(r.Context(), client)
+			if err != nil {
+				statusByClientID[clientID] = liveStatusResult{}
+				continue
 			}
+
+			result = liveStatusResult{statuses: statuses, usesTorrentID: usesTorrentID}
+			statusByClientID[clientID] = result
+		}
+
+		if len(result.statuses) == 0 {
+			continue
+		}
+
+		var remoteID string
+		if result.usesTorrentID {
+			if item.TorrentID == nil {
+				continue
+			}
+			remoteID = *item.TorrentID
+		} else {
+			if item.SABnzbdNzoID == nil {
+				continue
+			}
+			remoteID = *item.SABnzbdNzoID
+		}
+
+		if status, ok := result.statuses[remoteID]; ok {
+			items[i].Percentage = status.Percentage
+			items[i].TimeLeft = status.TimeLeft
+			items[i].Speed = status.Speed
 		}
 	}
 
@@ -96,21 +125,23 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		req.Protocol = "usenet"
 	}
 
-	// Check for duplicate
-	existing, _ := h.downloads.GetByGUID(r.Context(), req.GUID)
+	existing, err := h.downloads.GetByGUID(r.Context(), req.GUID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
 	if existing != nil {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "already grabbed"})
 		return
 	}
 
-	// Select download client by protocol, preferring one that matches the media type
 	client, err := h.selectClient(r.Context(), req.Protocol, req.MediaType)
 	if err != nil || client == nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "no enabled download client configured"})
 		return
 	}
 
-	// Create download record
+	protocol := downloader.ProtocolForClient(client.Type)
 	dl := &models.Download{
 		GUID:             req.GUID,
 		BookID:           req.BookID,
@@ -120,7 +151,7 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		NZBURL:           req.NZBURL,
 		Size:             req.Size,
 		Status:           models.DownloadStatusQueued,
-		Protocol:         req.Protocol,
+		Protocol:         protocol,
 		Quality:          indexer.ParseRelease(req.Title).Format,
 	}
 	if err := h.downloads.Create(r.Context(), dl); err != nil {
@@ -128,38 +159,34 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Dispatch to the appropriate download client
-	if req.Protocol == "torrent" {
-		qbt := qbittorrent.New(client.Host, client.Port, client.URLBase, client.APIKey, client.UseSSL)
-		if err := qbt.AddTorrent(r.Context(), req.NZBURL, client.Category, ""); err != nil {
-			slog.Error("failed to send to qBittorrent", "error", err, "title", req.Title)
-			h.downloads.SetError(r.Context(), dl.ID, err.Error())
-			h.recordHistory(r.Context(), models.HistoryEventDownloadFailed, req.Title, req.BookID, map[string]interface{}{"guid": req.GUID, "message": err.Error()})
-			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send to qBittorrent: " + err.Error()})
-			return
+	sendRes, err := downloader.SendDownload(r.Context(), client, req.NZBURL, req.Title)
+	if err != nil {
+		slog.Error("failed to send download", "client_type", client.Type, "error", err, "title", req.Title)
+		if setErr := h.downloads.SetError(r.Context(), dl.ID, err.Error()); setErr != nil {
+			slog.Warn("failed to persist download error", "download_id", dl.ID, "error", setErr)
 		}
-		h.downloads.UpdateStatus(r.Context(), dl.ID, models.DownloadStatusDownloading)
-		dl.Status = models.DownloadStatusDownloading
-		slog.Info("download sent to qBittorrent", "title", req.Title)
-	} else {
-		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
-		resp, err := sab.AddURL(r.Context(), req.NZBURL, req.Title, client.Category, 0)
-		if err != nil {
-			slog.Error("failed to send to sabnzbd", "error", err, "title", req.Title)
-			h.downloads.SetError(r.Context(), dl.ID, err.Error())
-			h.recordHistory(r.Context(), models.HistoryEventDownloadFailed, req.Title, req.BookID, map[string]interface{}{"guid": req.GUID, "message": err.Error()})
-			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send to SABnzbd: " + err.Error()})
-			return
-		}
-		if len(resp.NzoIDs) > 0 {
-			nzoID := resp.NzoIDs[0]
-			h.downloads.SetNzoID(r.Context(), dl.ID, nzoID)
-			dl.SABnzbdNzoID = &nzoID
-		}
-		h.downloads.UpdateStatus(r.Context(), dl.ID, models.DownloadStatusDownloading)
-		dl.Status = models.DownloadStatusDownloading
-		slog.Info("download grabbed", "title", req.Title, "nzoId", dl.SABnzbdNzoID)
+		h.recordHistory(r.Context(), models.HistoryEventDownloadFailed, req.Title, req.BookID, map[string]interface{}{"guid": req.GUID, "message": err.Error()})
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send to downloader: " + err.Error()})
+		return
 	}
+
+	if remoteID := sendRes.RemoteID; remoteID != "" {
+		if sendRes.UsesTorrentID {
+			if err := h.downloads.SetTorrentID(r.Context(), dl.ID, remoteID); err != nil {
+				slog.Warn("failed to set torrent ID", "download_id", dl.ID, "error", err)
+			}
+			dl.TorrentID = &remoteID
+		} else {
+			if err := h.downloads.SetNzoID(r.Context(), dl.ID, remoteID); err != nil {
+				slog.Warn("failed to set NZO ID", "download_id", dl.ID, "error", err)
+			}
+			dl.SABnzbdNzoID = &remoteID
+		}
+	}
+	if err := h.downloads.UpdateStatus(r.Context(), dl.ID, models.DownloadStatusDownloading); err != nil {
+		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.DownloadStatusDownloading, "error", err)
+	}
+	dl.Status = models.DownloadStatusDownloading
 
 	h.recordHistory(r.Context(), models.HistoryEventGrabbed, req.Title, req.BookID, map[string]interface{}{
 		"guid":      req.GUID,
@@ -167,6 +194,7 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		"indexerId": req.IndexerID,
 	})
 
+	slog.Info("download grabbed", "title", req.Title, "client", client.Type)
 	writeJSON(w, http.StatusAccepted, dl)
 }
 
@@ -189,7 +217,11 @@ func (h *QueueHandler) recordHistory(ctx context.Context, eventType, sourceTitle
 	if h.history == nil {
 		return
 	}
-	dataJSON, _ := json.Marshal(data)
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		slog.Warn("failed to marshal history data", "event_type", eventType, "error", err)
+		return
+	}
 	evt := &models.HistoryEvent{
 		BookID:      bookID,
 		EventType:   eventType,
@@ -202,9 +234,16 @@ func (h *QueueHandler) recordHistory(ctx context.Context, eventType, sourceTitle
 }
 
 func (h *QueueHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
 
-	downloads, _ := h.downloads.List(r.Context())
+	downloads, err := h.downloads.List(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
 	var target *models.Download
 	for _, d := range downloads {
 		if d.ID == id {
@@ -217,27 +256,32 @@ func (h *QueueHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Remove from the appropriate download client
-	if target.Protocol == "torrent" {
-		// qBittorrent: we don't store a per-download torrent hash yet, so just
-		// remove the local record. Future work: store hash in Download and call qbt.DeleteTorrent.
-	} else if target.SABnzbdNzoID != nil {
-		client, err := h.clients.GetFirstEnabledByProtocol(r.Context(), "usenet")
+	if target.DownloadClientID != nil {
+		client, err := h.clients.GetByID(r.Context(), *target.DownloadClientID)
 		if err == nil && client != nil {
-			sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
-			_ = sab.Delete(r.Context(), *target.SABnzbdNzoID, true)
+			if err := downloader.RemoveDownload(r.Context(), client, target, true); err != nil {
+				slog.Warn("failed to remove download from client", "download_id", target.ID, "client_id", client.ID, "error", err)
+			}
+		} else if err != nil {
+			slog.Warn("failed to load download client", "download_id", target.ID, "client_id", *target.DownloadClientID, "error", err)
 		}
 	}
 
-	// Reset book status back to wanted so it reappears on the Wanted page
 	if target.BookID != nil {
-		book, _ := h.books.GetByID(r.Context(), *target.BookID)
-		if book != nil && (book.Status == models.BookStatusDownloading || book.Status == models.BookStatusDownloaded) {
+		book, err := h.books.GetByID(r.Context(), *target.BookID)
+		if err != nil {
+			slog.Warn("failed to load book for download delete", "download_id", target.ID, "book_id", *target.BookID, "error", err)
+		} else if book != nil && (book.Status == models.BookStatusDownloading || book.Status == models.BookStatusDownloaded) {
 			book.Status = models.BookStatusWanted
-			h.books.Update(r.Context(), book)
+			if err := h.books.Update(r.Context(), book); err != nil {
+				slog.Warn("failed to reset book status after download delete", "download_id", target.ID, "book_id", book.ID, "error", err)
+			}
 		}
 	}
 
-	h.downloads.Delete(r.Context(), id)
+	if err := h.downloads.Delete(r.Context(), id); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/api/queue_test.go
+++ b/internal/api/queue_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"testing"
 
@@ -27,14 +29,12 @@ func queueFixture(t *testing.T) (*QueueHandler, *sql.DB, *db.DownloadRepo, *db.D
 	return NewQueueHandler(downloads, clients, books, history), database, downloads, clients, books, context.Background()
 }
 
-// TestQueueGrab_RequiresGUIDAndURL — input validation is the first gate;
-// without it, we'd create an orphaned download row and then 502 on SAB.
 func TestQueueGrab_RequiresGUIDAndURL(t *testing.T) {
 	h, _, _, _, _, _ := queueFixture(t)
 	for _, body := range []string{
 		`{}`,
-		`{"guid":"abc"}`,                    // missing nzbUrl
-		`{"nzbUrl":"http://example/x.nzb"}`, // missing guid
+		`{"guid":"abc"}`,
+		`{"nzbUrl":"http://example/x.nzb"}`,
 	} {
 		rec := httptest.NewRecorder()
 		h.Grab(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/grab", bytes.NewBufferString(body)))
@@ -44,8 +44,6 @@ func TestQueueGrab_RequiresGUIDAndURL(t *testing.T) {
 	}
 }
 
-// TestQueueGrab_RejectsBadJSON keeps the handler from panicking on a
-// malformed client payload.
 func TestQueueGrab_RejectsBadJSON(t *testing.T) {
 	h, _, _, _, _, _ := queueFixture(t)
 	rec := httptest.NewRecorder()
@@ -55,9 +53,6 @@ func TestQueueGrab_RejectsBadJSON(t *testing.T) {
 	}
 }
 
-// TestQueueGrab_NoDownloadClient is the 400 path when the operator hasn't
-// enabled a download client yet. Without this guard the handler would NPE
-// on the nil client pointer.
 func TestQueueGrab_NoDownloadClient(t *testing.T) {
 	h, _, _, _, _, _ := queueFixture(t)
 	body := bytes.NewBufferString(`{"guid":"abc","nzbUrl":"http://example/x.nzb","title":"t"}`)
@@ -68,11 +63,8 @@ func TestQueueGrab_NoDownloadClient(t *testing.T) {
 	}
 }
 
-// TestQueueGrab_DuplicateGUID — the second Grab with the same guid must 409
-// so a double-click doesn't double-spend indexer hit counts.
 func TestQueueGrab_DuplicateGUID(t *testing.T) {
 	h, _, downloads, _, _, ctx := queueFixture(t)
-	// Pre-seed a download to simulate the prior grab.
 	if err := downloads.Create(ctx, &models.Download{
 		GUID: "dup-guid", Title: "T", Status: models.DownloadStatusDownloading, Protocol: "usenet",
 	}); err != nil {
@@ -86,8 +78,6 @@ func TestQueueGrab_DuplicateGUID(t *testing.T) {
 	}
 }
 
-// TestQueueDelete_NotFound — chi URL param resolution is handled by the
-// router; here we verify missing id → 404 rather than a silent 204.
 func TestQueueDelete_NotFound(t *testing.T) {
 	h, _, _, _, _, _ := queueFixture(t)
 	req := withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/queue/42", nil), "id", "42")
@@ -98,13 +88,8 @@ func TestQueueDelete_NotFound(t *testing.T) {
 	}
 }
 
-// TestQueueDelete_FlipsBookToWanted is the regression guard: deleting a
-// queued download that owns a book must reset the book to `wanted` so the
-// Wanted page re-surfaces it. Without this the book stays stuck in
-// `downloading` forever.
 func TestQueueDelete_FlipsBookToWanted(t *testing.T) {
 	h, database, downloads, _, books, ctx := queueFixture(t)
-	// Seed an author + book so the FK is satisfied.
 	a := &models.Author{ForeignID: "OL1", Name: "X", SortName: "X", MetadataProvider: "openlibrary", Monitored: true}
 	if err := db.NewAuthorRepo(database).Create(ctx, a); err != nil {
 		t.Fatal(err)
@@ -136,3 +121,315 @@ func TestQueueDelete_FlipsBookToWanted(t *testing.T) {
 		t.Errorf("book status should flip to wanted, got %q", got.Status)
 	}
 }
+
+func TestQueueListLiveOverlaySABnzbd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("mode") != "queue" {
+			t.Fatalf("expected mode=queue, got %s", r.URL.Query().Get("mode"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"queue": map[string]any{
+				"speed": "2.0 MB/s",
+				"slots": []map[string]any{{
+					"nzo_id":     "nzo123",
+					"percentage": "55",
+					"timeleft":   "0:10:00",
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	h := newQueueTestHandler(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := createTestDownloadClient(t, h, &models.DownloadClient{
+		Name:     "sab",
+		Type:     "sabnzbd",
+		Host:     host,
+		Port:     port,
+		APIKey:   "testkey",
+		Category: "books",
+		Enabled:  true,
+	})
+	createTestDownload(t, h, &models.Download{
+		GUID:             "guid-sab",
+		DownloadClientID: &client.ID,
+		Title:            "Sab Book",
+		NZBURL:           "https://example.com/book.nzb",
+		Status:           models.DownloadStatusDownloading,
+		Protocol:         "usenet",
+		SABnzbdNzoID:     strPtr("nzo123"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+	rr := httptest.NewRecorder()
+	h.List(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var items []QueueItem
+	if err := json.NewDecoder(rr.Body).Decode(&items); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].Percentage != "55" || items[0].TimeLeft != "0:10:00" || items[0].Speed != "2.0 MB/s" {
+		t.Fatalf("unexpected overlay: %+v", items[0])
+	}
+}
+
+func TestQueueListLiveOverlaySABnzbd_WithHigherPriorityTorrentClient(t *testing.T) {
+	sabSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("mode") != "queue" {
+			t.Fatalf("expected mode=queue, got %s", r.URL.Query().Get("mode"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"queue": map[string]any{
+				"speed": "1.5 MB/s",
+				"slots": []map[string]any{{
+					"nzo_id":     "nzo999",
+					"percentage": "66",
+					"timeleft":   "0:05:00",
+				}},
+			},
+		})
+	}))
+	defer sabSrv.Close()
+
+	transSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/transmission/rpc" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"arguments": map[string]any{"torrents": []map[string]any{}},
+			"result":    "success",
+		})
+	}))
+	defer transSrv.Close()
+
+	h := newQueueTestHandler(t)
+
+	transHost, transPort := testServerHostPort(t, transSrv.URL)
+	_ = createTestDownloadClient(t, h, &models.DownloadClient{
+		Name:     "trans-first",
+		Type:     "transmission",
+		Host:     transHost,
+		Port:     transPort,
+		Priority: 1,
+		Enabled:  true,
+	})
+
+	sabHost, sabPort := testServerHostPort(t, sabSrv.URL)
+	sabClient := createTestDownloadClient(t, h, &models.DownloadClient{
+		Name:     "sab-second",
+		Type:     "sabnzbd",
+		Host:     sabHost,
+		Port:     sabPort,
+		APIKey:   "testkey",
+		Priority: 2,
+		Enabled:  true,
+	})
+
+	createTestDownload(t, h, &models.Download{
+		GUID:             "guid-sab-2",
+		DownloadClientID: &sabClient.ID,
+		Title:            "Sab Book 2",
+		NZBURL:           "https://example.com/book2.nzb",
+		Status:           models.DownloadStatusDownloading,
+		Protocol:         "usenet",
+		SABnzbdNzoID:     strPtr("nzo999"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+	rr := httptest.NewRecorder()
+	h.List(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var items []QueueItem
+	if err := json.NewDecoder(rr.Body).Decode(&items); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].Percentage != "66" || items[0].TimeLeft != "0:05:00" || items[0].Speed != "1.5 MB/s" {
+		t.Fatalf("unexpected overlay when torrent client has higher priority: %+v", items[0])
+	}
+}
+
+func TestQueueListLiveOverlayTransmission(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/transmission/rpc" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"arguments": map[string]any{
+				"torrents": []map[string]any{{
+					"id":           7,
+					"percentDone":  0.42,
+					"eta":          125,
+					"rateDownload": 4096,
+				}},
+			},
+			"result": "success",
+		})
+	}))
+	defer srv.Close()
+
+	h := newQueueTestHandler(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := createTestDownloadClient(t, h, &models.DownloadClient{
+		Name:     "trans",
+		Type:     "transmission",
+		Host:     host,
+		Port:     port,
+		Username: "user",
+		Password: "pass",
+		Enabled:  true,
+	})
+	createTestDownload(t, h, &models.Download{
+		GUID:             "guid-trans",
+		DownloadClientID: &client.ID,
+		Title:            "Torrent Book",
+		NZBURL:           "magnet:?xt=urn:btih:abc",
+		Status:           models.DownloadStatusDownloading,
+		Protocol:         "torrent",
+		TorrentID:        strPtr("7"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+	rr := httptest.NewRecorder()
+	h.List(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var items []QueueItem
+	if err := json.NewDecoder(rr.Body).Decode(&items); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].Percentage != "42.0" {
+		t.Fatalf("unexpected percentage: %s", items[0].Percentage)
+	}
+	if items[0].TimeLeft == "" || items[0].Speed == "" {
+		t.Fatalf("expected timeLeft and speed, got %+v", items[0])
+	}
+}
+
+func TestQueueListLiveOverlayQbittorrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"hash":     "ABCDEF",
+				"progress": 0.9,
+				"eta":      300,
+			}})
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	h := newQueueTestHandler(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := createTestDownloadClient(t, h, &models.DownloadClient{
+		Name:     "qb",
+		Type:     "qbittorrent",
+		Host:     host,
+		Port:     port,
+		Username: "user",
+		Password: "pass",
+		Enabled:  true,
+	})
+	createTestDownload(t, h, &models.Download{
+		GUID:             "guid-qb",
+		DownloadClientID: &client.ID,
+		Title:            "QB Book",
+		NZBURL:           "magnet:?xt=urn:btih:abcdef",
+		Status:           models.DownloadStatusDownloading,
+		Protocol:         "torrent",
+		TorrentID:        strPtr("abcdef"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+	rr := httptest.NewRecorder()
+	h.List(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var items []QueueItem
+	if err := json.NewDecoder(rr.Body).Decode(&items); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].Percentage != "90.0" {
+		t.Fatalf("unexpected percentage: %s", items[0].Percentage)
+	}
+	if items[0].TimeLeft == "" {
+		t.Fatalf("expected timeLeft, got %+v", items[0])
+	}
+}
+
+func newQueueTestHandler(t *testing.T) *QueueHandler {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	return NewQueueHandler(db.NewDownloadRepo(database), db.NewDownloadClientRepo(database), nil, nil)
+}
+
+func createTestDownloadClient(t *testing.T, h *QueueHandler, client *models.DownloadClient) *models.DownloadClient {
+	t.Helper()
+	if err := h.clients.Create(context.Background(), client); err != nil {
+		t.Fatalf("create download client: %v", err)
+	}
+	return client
+}
+
+func createTestDownload(t *testing.T, h *QueueHandler, dl *models.Download) *models.Download {
+	t.Helper()
+	if err := h.downloads.Create(context.Background(), dl); err != nil {
+		t.Fatalf("create download: %v", err)
+	}
+	return dl
+}
+
+func testServerHostPort(t *testing.T, raw string) (string, int) {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	return u.Hostname(), port
+}
+
+func strPtr(v string) *string { return &v }

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/vavallee/bindery/internal/metadata"
@@ -80,5 +81,7 @@ func (h *SearchHandler) LookupByISBN(w http.ResponseWriter, r *http.Request) {
 func writeJSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(data)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		slog.Warn("failed to encode JSON response", "status", status, "error", err)
+	}
 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 )
 
@@ -117,7 +118,9 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
-			_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+			if _, err := w.Write([]byte(`{"error":"unauthorized"}`)); err != nil {
+				slog.Warn("failed to write unauthorized response", "error", err)
+			}
 		})
 	}
 }

--- a/internal/db/auth.go
+++ b/internal/db/auth.go
@@ -70,7 +70,10 @@ func (r *UserRepo) Create(ctx context.Context, username, passwordHash string) (*
 	if err != nil {
 		return nil, fmt.Errorf("create user: %w", err)
 	}
-	id, _ := res.LastInsertId()
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("get user id: %w", err)
+	}
 	return &User{ID: id, Username: username, PasswordHash: passwordHash, CreatedAt: now, UpdatedAt: now}, nil
 }
 

--- a/internal/db/author_aliases.go
+++ b/internal/db/author_aliases.go
@@ -88,8 +88,15 @@ func (r *AuthorAliasRepo) createTx(ctx context.Context, exec sqlExecutor, a *mod
 	if err != nil {
 		return fmt.Errorf("create alias %q: %w", name, err)
 	}
-	if affected, _ := result.RowsAffected(); affected > 0 {
-		id, _ := result.LastInsertId()
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("check alias insertion %q: %w", name, err)
+	}
+	if affected > 0 {
+		id, err := result.LastInsertId()
+		if err != nil {
+			return fmt.Errorf("get alias id %q: %w", name, err)
+		}
 		a.ID = id
 		a.Name = name
 		a.CreatedAt = now
@@ -181,7 +188,9 @@ func (r *AuthorAliasRepo) Merge(ctx context.Context, sourceID, targetID int64, o
 	if err != nil {
 		return nil, fmt.Errorf("reparent books: %w", err)
 	}
-	result.BooksReparented, _ = booksRes.RowsAffected()
+	if result.BooksReparented, err = booksRes.RowsAffected(); err != nil {
+		return nil, fmt.Errorf("count reparented books: %w", err)
+	}
 
 	// Migrate existing aliases on source to target. Because `name` is UNIQUE,
 	// a collision with a pre-existing alias on target would 2067 us; use
@@ -197,7 +206,9 @@ func (r *AuthorAliasRepo) Merge(ctx context.Context, sourceID, targetID int64, o
 	if err != nil {
 		return nil, fmt.Errorf("migrate aliases: %w", err)
 	}
-	result.AliasesMigrated, _ = migrateRes.RowsAffected()
+	if result.AliasesMigrated, err = migrateRes.RowsAffected(); err != nil {
+		return nil, fmt.Errorf("count migrated aliases: %w", err)
+	}
 
 	// Drop any source aliases that collided with an existing target alias —
 	// their name is already represented and the FK will cascade them when we
@@ -259,7 +270,10 @@ func insertMergeAlias(ctx context.Context, tx *sql.Tx, targetID int64, name, for
 	if err != nil {
 		return false, err
 	}
-	affected, _ := res.RowsAffected()
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("check alias insertion: %w", err)
+	}
 	return affected > 0, nil
 }
 

--- a/internal/db/blocklist.go
+++ b/internal/db/blocklist.go
@@ -26,7 +26,10 @@ func (r *BlocklistRepo) Create(ctx context.Context, e *models.BlocklistEntry) er
 	if err != nil {
 		return fmt.Errorf("create blocklist entry: %w", err)
 	}
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("get blocklist entry id: %w", err)
+	}
 	e.ID = id
 	e.CreatedAt = now
 	return nil

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -60,7 +60,10 @@ func (r *BookRepo) GetByForeignID(ctx context.Context, foreignID string) (*model
 
 func (r *BookRepo) Create(ctx context.Context, b *models.Book) error {
 	now := time.Now().UTC()
-	genresJSON, _ := json.Marshal(b.Genres)
+	genresJSON, err := json.Marshal(b.Genres)
+	if err != nil {
+		return fmt.Errorf("marshal book genres: %w", err)
+	}
 
 	mediaType := b.MediaType
 	if mediaType == "" {
@@ -95,14 +98,17 @@ func (r *BookRepo) Create(ctx context.Context, b *models.Book) error {
 
 func (r *BookRepo) Update(ctx context.Context, b *models.Book) error {
 	now := time.Now().UTC()
-	genresJSON, _ := json.Marshal(b.Genres)
+	genresJSON, err := json.Marshal(b.Genres)
+	if err != nil {
+		return fmt.Errorf("marshal book genres: %w", err)
+	}
 
 	mediaType := b.MediaType
 	if mediaType == "" {
 		mediaType = models.MediaTypeEbook
 	}
 
-	_, err := r.db.ExecContext(ctx, `
+	_, err = r.db.ExecContext(ctx, `
 		UPDATE books SET title=?, sort_title=?, original_title=?, description=?, image_url=?,
 		                 release_date=?, genres=?, average_rating=?, ratings_count=?,
 		                 monitored=?, status=?, any_edition_ok=?, selected_edition_id=?,

--- a/internal/db/custom_formats.go
+++ b/internal/db/custom_formats.go
@@ -58,21 +58,30 @@ func (r *CustomFormatRepo) GetByID(ctx context.Context, id int64) (*models.Custo
 }
 
 func (r *CustomFormatRepo) Create(ctx context.Context, cf *models.CustomFormat) error {
-	condJSON, _ := json.Marshal(cf.Conditions)
+	condJSON, err := json.Marshal(cf.Conditions)
+	if err != nil {
+		return fmt.Errorf("marshal custom format conditions: %w", err)
+	}
 	result, err := r.db.ExecContext(ctx,
 		"INSERT INTO custom_formats (name, conditions) VALUES (?, ?)",
 		cf.Name, string(condJSON))
 	if err != nil {
 		return fmt.Errorf("create custom format: %w", err)
 	}
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("get custom format id: %w", err)
+	}
 	cf.ID = id
 	return nil
 }
 
 func (r *CustomFormatRepo) Update(ctx context.Context, cf *models.CustomFormat) error {
-	condJSON, _ := json.Marshal(cf.Conditions)
-	_, err := r.db.ExecContext(ctx,
+	condJSON, err := json.Marshal(cf.Conditions)
+	if err != nil {
+		return fmt.Errorf("marshal custom format conditions: %w", err)
+	}
+	_, err = r.db.ExecContext(ctx,
 		"UPDATE custom_formats SET name=?, conditions=? WHERE id=?",
 		cf.Name, string(condJSON), cf.ID)
 	if err != nil {
@@ -96,7 +105,9 @@ func scanCustomFormat(rows *sql.Rows) (models.CustomFormat, error) {
 	if err != nil {
 		return cf, fmt.Errorf("scan custom format: %w", err)
 	}
-	_ = json.Unmarshal([]byte(condJSON), &cf.Conditions)
+	if err = json.Unmarshal([]byte(condJSON), &cf.Conditions); err != nil {
+		return cf, fmt.Errorf("unmarshal custom format conditions: %w", err)
+	}
 	if cf.Conditions == nil {
 		cf.Conditions = []models.CustomCondition{}
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -12,12 +12,6 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
-func testDB(t *testing.T) *context.Context {
-	t.Helper()
-	ctx := context.Background()
-	return &ctx
-}
-
 func TestPreflightCreatesMissingParent(t *testing.T) {
 	tmp := t.TempDir()
 	dbPath := filepath.Join(tmp, "nested", "sub", "bindery.db")
@@ -565,7 +559,7 @@ func TestPickClientForMediaType(t *testing.T) {
 	}
 }
 
-func TestDownloadClientRepoVirtualCredentials(t *testing.T) {
+func TestDownloadClientRepoCredentialFields(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {
 		t.Fatal(err)
@@ -575,7 +569,7 @@ func TestDownloadClientRepoVirtualCredentials(t *testing.T) {
 	ctx := context.Background()
 	repo := NewDownloadClientRepo(database)
 
-	// qBittorrent: Username/Password should round-trip via url_base/api_key columns
+	// qBittorrent: Username/Password should round-trip through dedicated fields.
 	qbt := &models.DownloadClient{
 		Name:     "My qBittorrent",
 		Type:     "qbittorrent",
@@ -599,12 +593,11 @@ func TestDownloadClientRepoVirtualCredentials(t *testing.T) {
 	if got.Password != "secret" {
 		t.Errorf("Password: want secret, got %q", got.Password)
 	}
-	// Raw storage columns should mirror the virtual fields
-	if got.URLBase != "admin" {
-		t.Errorf("URLBase (storage): want admin, got %q", got.URLBase)
+	if got.URLBase != "" {
+		t.Errorf("URLBase: want empty, got %q", got.URLBase)
 	}
-	if got.APIKey != "secret" {
-		t.Errorf("APIKey (storage): want secret, got %q", got.APIKey)
+	if got.APIKey != "" {
+		t.Errorf("APIKey: want empty for credential client, got %q", got.APIKey)
 	}
 
 	// sabnzbd: APIKey should survive as-is; Username/Password stay empty

--- a/internal/db/delay_profiles.go
+++ b/internal/db/delay_profiles.go
@@ -70,7 +70,10 @@ func (r *DelayProfileRepo) Create(ctx context.Context, p *models.DelayProfile) e
 	if err != nil {
 		return fmt.Errorf("create delay profile: %w", err)
 	}
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("get delay profile id: %w", err)
+	}
 	p.ID = id
 	return nil
 }

--- a/internal/db/download_clients.go
+++ b/internal/db/download_clients.go
@@ -15,31 +15,51 @@ type DownloadClientRepo struct {
 	db *sql.DB
 }
 
-func NewDownloadClientRepo(db *sql.DB) *DownloadClientRepo {
-	return &DownloadClientRepo{db: db}
+const downloadClientSelectColumns = `
+	id, name, type, host, port, api_key, use_ssl, url_base, username, password,
+	category, priority, enabled, created_at, updated_at`
+
+func isCredentialClient(clientType string) bool {
+	return clientType == "qbittorrent" || clientType == "transmission"
 }
 
-// populateVirtualCredentials maps the storage columns to the virtual Username/Password
-// fields for qBittorrent clients (which store credentials in url_base and api_key).
-func populateVirtualCredentials(c *models.DownloadClient) {
-	if c.Type == "qbittorrent" {
-		c.Username = c.URLBase
+func hydrateClientCredentials(c *models.DownloadClient) {
+	if isCredentialClient(c.Type) {
+		// Backward compatibility: older rows stored credentials in url_base/api_key.
+		if strings.TrimSpace(c.Username) == "" {
+			c.Username = strings.TrimSpace(c.URLBase)
+		}
+		if c.Password == "" {
+			c.Password = c.APIKey
+		}
+		return
+	}
+	// Non-credential clients should not expose username/password values.
+	c.Username = ""
+	c.Password = ""
+}
+
+func normalizeClientCredentialStorage(c *models.DownloadClient) {
+	if !isCredentialClient(c.Type) {
+		return
+	}
+	// Backward compatibility: accept legacy payloads that sent credentials in
+	// urlBase/apiKey.
+	if strings.TrimSpace(c.Username) == "" {
+		c.Username = strings.TrimSpace(c.URLBase)
+	}
+	if c.Password == "" && c.APIKey != "" {
 		c.Password = c.APIKey
 	}
 }
 
-// applyVirtualCredentials maps the virtual Username/Password fields back to the
-// storage columns for qBittorrent clients before writing to the database.
-func applyVirtualCredentials(c *models.DownloadClient) {
-	if c.Type == "qbittorrent" {
-		c.URLBase = c.Username
-		c.APIKey = c.Password
-	}
+func NewDownloadClientRepo(db *sql.DB) *DownloadClientRepo {
+	return &DownloadClientRepo{db: db}
 }
 
 func (r *DownloadClientRepo) List(ctx context.Context) ([]models.DownloadClient, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
+		SELECT `+downloadClientSelectColumns+`
 		FROM download_clients ORDER BY priority`)
 	if err != nil {
 		return nil, err
@@ -51,12 +71,13 @@ func (r *DownloadClientRepo) List(ctx context.Context) ([]models.DownloadClient,
 		var c models.DownloadClient
 		var enabled, useSSL int
 		if err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt); err != nil {
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+			&enabled, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
 		c.Enabled = enabled == 1
 		c.UseSSL = useSSL == 1
-		populateVirtualCredentials(&c)
+		hydrateClientCredentials(&c)
 		clients = append(clients, c)
 	}
 	return clients, rows.Err()
@@ -66,10 +87,11 @@ func (r *DownloadClientRepo) GetByID(ctx context.Context, id int64) (*models.Dow
 	var c models.DownloadClient
 	var enabled, useSSL int
 	err := r.db.QueryRowContext(ctx, `
-		SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
+		SELECT `+downloadClientSelectColumns+`
 		FROM download_clients WHERE id=?`, id).
 		Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt)
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+			&enabled, &c.CreatedAt, &c.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -78,7 +100,7 @@ func (r *DownloadClientRepo) GetByID(ctx context.Context, id int64) (*models.Dow
 	}
 	c.Enabled = enabled == 1
 	c.UseSSL = useSSL == 1
-	populateVirtualCredentials(&c)
+	hydrateClientCredentials(&c)
 	return &c, nil
 }
 
@@ -86,10 +108,11 @@ func (r *DownloadClientRepo) GetFirstEnabled(ctx context.Context) (*models.Downl
 	var c models.DownloadClient
 	var enabled, useSSL int
 	err := r.db.QueryRowContext(ctx, `
-		SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
+		SELECT `+downloadClientSelectColumns+`
 		FROM download_clients WHERE enabled=1 ORDER BY priority LIMIT 1`).
 		Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt)
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+			&enabled, &c.CreatedAt, &c.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -98,7 +121,7 @@ func (r *DownloadClientRepo) GetFirstEnabled(ctx context.Context) (*models.Downl
 	}
 	c.Enabled = enabled == 1
 	c.UseSSL = useSSL == 1
-	populateVirtualCredentials(&c)
+	hydrateClientCredentials(&c)
 	return &c, nil
 }
 
@@ -106,18 +129,25 @@ func (r *DownloadClientRepo) GetFirstEnabled(ctx context.Context) (*models.Downl
 // matches the given protocol ("usenet" → sabnzbd, "torrent" → qbittorrent).
 // Returns (nil, nil) if no matching client is configured.
 func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, protocol string) (*models.DownloadClient, error) {
-	clientType := "sabnzbd"
-	if protocol == "torrent" {
-		clientType = "qbittorrent"
-	}
-
 	var c models.DownloadClient
 	var enabled, useSSL int
-	err := r.db.QueryRowContext(ctx, `
-		SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
-		FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority LIMIT 1`, clientType).
-		Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt)
+	query := `
+		SELECT ` + downloadClientSelectColumns + `
+		FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority LIMIT 1`
+	var err error
+	if protocol == "torrent" {
+		err = r.db.QueryRowContext(ctx, `
+			SELECT `+downloadClientSelectColumns+`
+			FROM download_clients WHERE enabled=1 AND type IN (?, ?) ORDER BY priority LIMIT 1`, "qbittorrent", "transmission").
+			Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
+				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+				&enabled, &c.CreatedAt, &c.UpdatedAt)
+	} else {
+		err = r.db.QueryRowContext(ctx, query, "sabnzbd").
+			Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
+				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+				&enabled, &c.CreatedAt, &c.UpdatedAt)
+	}
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
@@ -126,7 +156,7 @@ func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, prot
 	}
 	c.Enabled = enabled == 1
 	c.UseSSL = useSSL == 1
-	populateVirtualCredentials(&c)
+	hydrateClientCredentials(&c)
 	return &c, nil
 }
 
@@ -134,13 +164,19 @@ func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, prot
 // ordered by priority. Used when multiple clients of the same type exist and
 // the caller needs to pick the best one by category.
 func (r *DownloadClientRepo) GetEnabledByProtocol(ctx context.Context, protocol string) ([]models.DownloadClient, error) {
-	clientType := "sabnzbd"
+	var (
+		rows *sql.Rows
+		err  error
+	)
 	if protocol == "torrent" {
-		clientType = "qbittorrent"
+		rows, err = r.db.QueryContext(ctx, `
+			SELECT `+downloadClientSelectColumns+`
+			FROM download_clients WHERE enabled=1 AND type IN (?, ?) ORDER BY priority`, "qbittorrent", "transmission")
+	} else {
+		rows, err = r.db.QueryContext(ctx, `
+			SELECT `+downloadClientSelectColumns+`
+			FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority`, "sabnzbd")
 	}
-	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at
-		FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority`, clientType)
 	if err != nil {
 		return nil, err
 	}
@@ -151,28 +187,32 @@ func (r *DownloadClientRepo) GetEnabledByProtocol(ctx context.Context, protocol 
 		var c models.DownloadClient
 		var enabled, useSSL int
 		if err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Category, &c.Priority, &enabled, &c.CreatedAt, &c.UpdatedAt); err != nil {
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+			&enabled, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
 		c.Enabled = enabled == 1
 		c.UseSSL = useSSL == 1
-		populateVirtualCredentials(&c)
+		hydrateClientCredentials(&c)
 		clients = append(clients, c)
 	}
 	return clients, rows.Err()
 }
 
 func (r *DownloadClientRepo) Create(ctx context.Context, c *models.DownloadClient) error {
-	applyVirtualCredentials(c)
+	normalizeClientCredentialStorage(c)
 	now := time.Now().UTC()
 	result, err := r.db.ExecContext(ctx, `
-		INSERT INTO download_clients (name, type, host, port, api_key, use_ssl, url_base, category, priority, enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Category, c.Priority, c.Enabled, now, now)
+		INSERT INTO download_clients (name, type, host, port, api_key, use_ssl, url_base, username, password, category, priority, enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Username, c.Password, c.Category, c.Priority, c.Enabled, now, now)
 	if err != nil {
 		return fmt.Errorf("create download client: %w", err)
 	}
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("get download client id: %w", err)
+	}
 	c.ID = id
 	c.CreatedAt = now
 	c.UpdatedAt = now
@@ -180,13 +220,13 @@ func (r *DownloadClientRepo) Create(ctx context.Context, c *models.DownloadClien
 }
 
 func (r *DownloadClientRepo) Update(ctx context.Context, c *models.DownloadClient) error {
-	applyVirtualCredentials(c)
+	normalizeClientCredentialStorage(c)
 	now := time.Now().UTC()
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE download_clients SET name=?, type=?, host=?, port=?, api_key=?, use_ssl=?,
-		                            url_base=?, category=?, priority=?, enabled=?, updated_at=?
+		                            url_base=?, username=?, password=?, category=?, priority=?, enabled=?, updated_at=?
 		WHERE id=?`,
-		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Category, c.Priority, c.Enabled, now, c.ID)
+		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Username, c.Password, c.Category, c.Priority, c.Enabled, now, c.ID)
 	return err
 }
 

--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -13,20 +13,25 @@ type DownloadRepo struct {
 	db *sql.DB
 }
 
+const downloadSelectColumns = `
+	id, guid, book_id, edition_id, indexer_id, download_client_id,
+	title, nzb_url, size, sabnzbd_nzo_id, torrent_id, status, protocol,
+	quality, indexer_flags, error_message, added_at, grabbed_at, completed_at, imported_at`
+
 func NewDownloadRepo(db *sql.DB) *DownloadRepo {
 	return &DownloadRepo{db: db}
 }
 
 func (r *DownloadRepo) List(ctx context.Context) ([]models.Download, error) {
-	return r.query(ctx, "SELECT * FROM downloads ORDER BY added_at DESC")
+	return r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads ORDER BY added_at DESC")
 }
 
 func (r *DownloadRepo) ListByStatus(ctx context.Context, status string) ([]models.Download, error) {
-	return r.query(ctx, "SELECT * FROM downloads WHERE status=? ORDER BY added_at DESC", status)
+	return r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads WHERE status=? ORDER BY added_at DESC", status)
 }
 
 func (r *DownloadRepo) GetByGUID(ctx context.Context, guid string) (*models.Download, error) {
-	dl, err := r.query(ctx, "SELECT * FROM downloads WHERE guid=?", guid)
+	dl, err := r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads WHERE guid=?", guid)
 	if err != nil || len(dl) == 0 {
 		return nil, err
 	}
@@ -34,7 +39,15 @@ func (r *DownloadRepo) GetByGUID(ctx context.Context, guid string) (*models.Down
 }
 
 func (r *DownloadRepo) GetByNzoID(ctx context.Context, nzoID string) (*models.Download, error) {
-	dl, err := r.query(ctx, "SELECT * FROM downloads WHERE sabnzbd_nzo_id=?", nzoID)
+	dl, err := r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads WHERE sabnzbd_nzo_id=?", nzoID)
+	if err != nil || len(dl) == 0 {
+		return nil, err
+	}
+	return &dl[0], nil
+}
+
+func (r *DownloadRepo) GetByTorrentID(ctx context.Context, torrentID string) (*models.Download, error) {
+	dl, err := r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads WHERE torrent_id=?", torrentID)
 	if err != nil || len(dl) == 0 {
 		return nil, err
 	}
@@ -45,16 +58,19 @@ func (r *DownloadRepo) Create(ctx context.Context, d *models.Download) error {
 	now := time.Now().UTC()
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO downloads (guid, book_id, edition_id, indexer_id, download_client_id,
-		                       title, nzb_url, size, sabnzbd_nzo_id, status, protocol,
+		                       title, nzb_url, size, sabnzbd_nzo_id, torrent_id, status, protocol,
 		                       quality, indexer_flags, error_message, added_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		d.GUID, d.BookID, d.EditionID, d.IndexerID, d.DownloadClientID,
-		d.Title, d.NZBURL, d.Size, d.SABnzbdNzoID, d.Status, d.Protocol,
+		d.Title, d.NZBURL, d.Size, d.SABnzbdNzoID, d.TorrentID, d.Status, d.Protocol,
 		d.Quality, d.IndexerFlags, d.ErrorMessage, now)
 	if err != nil {
 		return fmt.Errorf("create download: %w", err)
 	}
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("get download id: %w", err)
+	}
 	d.ID = id
 	d.AddedAt = now
 	return nil
@@ -85,6 +101,11 @@ func (r *DownloadRepo) SetNzoID(ctx context.Context, id int64, nzoID string) err
 	return err
 }
 
+func (r *DownloadRepo) SetTorrentID(ctx context.Context, id int64, torrentID string) error {
+	_, err := r.db.ExecContext(ctx, "UPDATE downloads SET torrent_id=? WHERE id=?", torrentID, id)
+	return err
+}
+
 func (r *DownloadRepo) SetError(ctx context.Context, id int64, errMsg string) error {
 	_, err := r.db.ExecContext(ctx,
 		"UPDATE downloads SET status=?, error_message=? WHERE id=?",
@@ -109,7 +130,7 @@ func (r *DownloadRepo) query(ctx context.Context, q string, args ...interface{})
 		var d models.Download
 		if err := rows.Scan(
 			&d.ID, &d.GUID, &d.BookID, &d.EditionID, &d.IndexerID, &d.DownloadClientID,
-			&d.Title, &d.NZBURL, &d.Size, &d.SABnzbdNzoID, &d.Status, &d.Protocol,
+			&d.Title, &d.NZBURL, &d.Size, &d.SABnzbdNzoID, &d.TorrentID, &d.Status, &d.Protocol,
 			&d.Quality, &d.IndexerFlags, &d.ErrorMessage,
 			&d.AddedAt, &d.GrabbedAt, &d.CompletedAt, &d.ImportedAt,
 		); err != nil {

--- a/internal/db/history.go
+++ b/internal/db/history.go
@@ -26,7 +26,10 @@ func (r *HistoryRepo) Create(ctx context.Context, e *models.HistoryEvent) error 
 	if err != nil {
 		return fmt.Errorf("create history event: %w", err)
 	}
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("get history event id: %w", err)
+	}
 	e.ID = id
 	e.CreatedAt = now
 	return nil

--- a/internal/db/indexers.go
+++ b/internal/db/indexers.go
@@ -39,7 +39,9 @@ func (r *IndexerRepo) List(ctx context.Context) ([]models.Indexer, error) {
 		}
 		idx.Enabled = enabled == 1
 		idx.SupportsSearch = supportsSearch == 1
-		_ = json.Unmarshal([]byte(catsJSON), &idx.Categories)
+		if err := json.Unmarshal([]byte(catsJSON), &idx.Categories); err != nil {
+			return nil, fmt.Errorf("unmarshal indexer categories: %w", err)
+		}
 		indexers = append(indexers, idx)
 	}
 	return indexers, rows.Err()
@@ -62,13 +64,18 @@ func (r *IndexerRepo) GetByID(ctx context.Context, id int64) (*models.Indexer, e
 	}
 	idx.Enabled = enabled == 1
 	idx.SupportsSearch = supportsSearch == 1
-	_ = json.Unmarshal([]byte(catsJSON), &idx.Categories)
+	if err = json.Unmarshal([]byte(catsJSON), &idx.Categories); err != nil {
+		return nil, fmt.Errorf("unmarshal indexer categories: %w", err)
+	}
 	return &idx, nil
 }
 
 func (r *IndexerRepo) Create(ctx context.Context, idx *models.Indexer) error {
 	now := time.Now().UTC()
-	catsJSON, _ := json.Marshal(idx.Categories)
+	catsJSON, err := json.Marshal(idx.Categories)
+	if err != nil {
+		return fmt.Errorf("marshal indexer categories: %w", err)
+	}
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO indexers (name, type, url, api_key, categories, priority, enabled, supports_search, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -77,7 +84,10 @@ func (r *IndexerRepo) Create(ctx context.Context, idx *models.Indexer) error {
 	if err != nil {
 		return fmt.Errorf("create indexer: %w", err)
 	}
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("get indexer id: %w", err)
+	}
 	idx.ID = id
 	idx.CreatedAt = now
 	idx.UpdatedAt = now
@@ -86,8 +96,11 @@ func (r *IndexerRepo) Create(ctx context.Context, idx *models.Indexer) error {
 
 func (r *IndexerRepo) Update(ctx context.Context, idx *models.Indexer) error {
 	now := time.Now().UTC()
-	catsJSON, _ := json.Marshal(idx.Categories)
-	_, err := r.db.ExecContext(ctx, `
+	catsJSON, err := json.Marshal(idx.Categories)
+	if err != nil {
+		return fmt.Errorf("marshal indexer categories: %w", err)
+	}
+	_, err = r.db.ExecContext(ctx, `
 		UPDATE indexers SET name=?, type=?, url=?, api_key=?, categories=?, priority=?,
 		                    enabled=?, supports_search=?, updated_at=?
 		WHERE id=?`,

--- a/internal/db/metadata_profiles.go
+++ b/internal/db/metadata_profiles.go
@@ -70,7 +70,10 @@ func (r *MetadataProfileRepo) Create(ctx context.Context, p *models.MetadataProf
 	if err != nil {
 		return fmt.Errorf("create metadata profile: %w", err)
 	}
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("get metadata profile id: %w", err)
+	}
 	p.ID = id
 	return nil
 }

--- a/internal/db/migrations/016_download_client_credentials.sql
+++ b/internal/db/migrations/016_download_client_credentials.sql
@@ -1,0 +1,23 @@
+-- +migrate Up
+
+-- Add dedicated credential columns for downloader clients that authenticate
+-- with username/password (qBittorrent, Transmission).
+ALTER TABLE download_clients ADD COLUMN username TEXT NOT NULL DEFAULT '';
+ALTER TABLE download_clients ADD COLUMN password TEXT NOT NULL DEFAULT '';
+
+-- Backfill from legacy storage where credentials were temporarily multiplexed
+-- into url_base/api_key.
+UPDATE download_clients
+SET username = url_base
+WHERE type IN ('qbittorrent', 'transmission')
+  AND TRIM(username) = ''
+  AND TRIM(url_base) != '';
+
+UPDATE download_clients
+SET password = api_key
+WHERE type IN ('qbittorrent', 'transmission')
+  AND password = ''
+  AND api_key != '';
+
+-- +migrate Down
+-- SQLite cannot drop columns without rebuilding the table; keep columns.

--- a/internal/db/migrations/017_transmission.sql
+++ b/internal/db/migrations/017_transmission.sql
@@ -1,0 +1,3 @@
+-- Add support for Transmission torrent client
+ALTER TABLE downloads ADD COLUMN torrent_id TEXT;
+CREATE INDEX idx_downloads_torrent_id ON downloads(torrent_id);

--- a/internal/db/quality_profiles.go
+++ b/internal/db/quality_profiles.go
@@ -65,7 +65,9 @@ func scanQualityProfile(rows *sql.Rows) (models.QualityProfile, error) {
 		return p, fmt.Errorf("scan quality profile: %w", err)
 	}
 	p.UpgradeAllowed = upgradeAllowed == 1
-	_ = json.Unmarshal([]byte(itemsJSON), &p.Items)
+	if err := json.Unmarshal([]byte(itemsJSON), &p.Items); err != nil {
+		return p, fmt.Errorf("unmarshal quality profile items: %w", err)
+	}
 	if p.Items == nil {
 		p.Items = []models.QualityItem{}
 	}

--- a/internal/db/tags.go
+++ b/internal/db/tags.go
@@ -40,7 +40,10 @@ func (r *TagRepo) Create(ctx context.Context, t *models.Tag) error {
 	if err != nil {
 		return fmt.Errorf("create tag: %w", err)
 	}
-	id, _ := result.LastInsertId()
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("get tag id: %w", err)
+	}
 	t.ID = id
 	return nil
 }

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -1,0 +1,222 @@
+// Package downloader provides a unified interface for dispatching download
+// requests to different download clients (SABnzbd, Transmission, qBittorrent).
+package downloader
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
+	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
+	"github.com/vavallee/bindery/internal/downloader/transmission"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+type LiveStatus struct {
+	Percentage string
+	TimeLeft   string
+	Speed      string
+}
+
+type SendResult struct {
+	RemoteID      string
+	Protocol      string
+	UsesTorrentID bool
+}
+
+func IsTorrentClient(clientType string) bool {
+	return clientType == "transmission" || clientType == "qbittorrent"
+}
+
+func ProtocolForClient(clientType string) string {
+	if IsTorrentClient(clientType) {
+		return "torrent"
+	}
+	return "usenet"
+}
+
+func TestClient(ctx context.Context, client *models.DownloadClient) error {
+	switch client.Type {
+	case "transmission":
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		return trans.Test(ctx)
+	case "qbittorrent":
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		return qb.Test(ctx)
+	default:
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		return sab.Test(ctx)
+	}
+}
+
+func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL, title string) (*SendResult, error) {
+	result := &SendResult{
+		Protocol:      ProtocolForClient(client.Type),
+		UsesTorrentID: IsTorrentClient(client.Type),
+	}
+
+	switch client.Type {
+	case "transmission":
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		// Transmission's download-dir must be an absolute path. The Category
+		// field is repurposed as an optional path override for Transmission; if
+		// the user left it as a bare label (e.g. "books") we pass "" so
+		// Transmission falls back to its own configured default directory.
+		transDL := client.Category
+		if !strings.HasPrefix(transDL, "/") {
+			transDL = ""
+		}
+		torrentID, err := trans.AddTorrent(ctx, sourceURL, transDL)
+		if err != nil {
+			return nil, err
+		}
+		if torrentID == 0 {
+			return nil, fmt.Errorf("downloader accepted request but did not return a trackable torrent ID")
+		}
+		result.RemoteID = strconv.FormatInt(torrentID, 10)
+		return result, nil
+	case "qbittorrent":
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		hash, err := qb.AddTorrent(ctx, sourceURL, client.Category, "")
+		if err != nil {
+			return nil, err
+		}
+		hash = strings.ToLower(strings.TrimSpace(hash))
+		if hash == "" {
+			return nil, fmt.Errorf("downloader accepted request but did not return a trackable torrent ID")
+		}
+		result.RemoteID = hash
+		return result, nil
+	default:
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		resp, err := sab.AddURL(ctx, sourceURL, title, client.Category, 0)
+		if err != nil {
+			return nil, err
+		}
+		if len(resp.NzoIDs) > 0 {
+			result.RemoteID = resp.NzoIDs[0]
+		}
+		return result, nil
+	}
+}
+
+func RemoveDownload(ctx context.Context, client *models.DownloadClient, dl *models.Download, deleteFiles bool) error {
+	switch client.Type {
+	case "transmission":
+		if dl.TorrentID == nil || *dl.TorrentID == "" {
+			return nil
+		}
+		torrentID, err := strconv.ParseInt(*dl.TorrentID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid transmission torrent id %q: %w", *dl.TorrentID, err)
+		}
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		return trans.RemoveTorrent(ctx, torrentID, deleteFiles)
+	case "qbittorrent":
+		if dl.TorrentID == nil || *dl.TorrentID == "" {
+			return nil
+		}
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		return qb.DeleteTorrent(ctx, *dl.TorrentID, deleteFiles)
+	default:
+		if dl.SABnzbdNzoID == nil || *dl.SABnzbdNzoID == "" {
+			return nil
+		}
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		return sab.Delete(ctx, *dl.SABnzbdNzoID, deleteFiles)
+	}
+}
+
+func GetLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[string]LiveStatus, bool, error) {
+	if IsTorrentClient(client.Type) {
+		statuses, err := getTorrentLiveStatuses(ctx, client)
+		return statuses, true, err
+	}
+	statuses, err := getSABLiveStatuses(ctx, client)
+	return statuses, false, err
+}
+
+func getSABLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[string]LiveStatus, error) {
+	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+	queue, err := sab.GetQueue(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]LiveStatus, len(queue.Slots))
+	for _, slot := range queue.Slots {
+		out[slot.NzoID] = LiveStatus{
+			Percentage: slot.Percentage,
+			TimeLeft:   slot.TimeLeft,
+			Speed:      queue.Speed,
+		}
+	}
+	return out, nil
+}
+
+func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[string]LiveStatus, error) {
+	if client.Type == "transmission" {
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		torrents, err := trans.GetTorrents(ctx, client.Category)
+		if err != nil {
+			return nil, err
+		}
+
+		out := make(map[string]LiveStatus, len(torrents))
+		for _, t := range torrents {
+			id := strconv.FormatInt(t.ID, 10)
+			out[id] = LiveStatus{
+				Percentage: fmt.Sprintf("%.1f", t.PercentDone*100),
+				TimeLeft:   etaToTimeLeft(t.ETA),
+				Speed:      bytesPerSecondToString(t.DownloadRate),
+			}
+		}
+		return out, nil
+	}
+
+	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	torrents, err := qb.GetTorrents(ctx, client.Category)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]LiveStatus, len(torrents))
+	for _, t := range torrents {
+		out[strings.ToLower(t.Hash)] = LiveStatus{
+			Percentage: fmt.Sprintf("%.1f", t.Progress*100),
+			TimeLeft:   etaToTimeLeft(int64(t.ETA)),
+		}
+	}
+	return out, nil
+}
+
+func etaToTimeLeft(etaSeconds int64) string {
+	if etaSeconds <= 0 {
+		return ""
+	}
+	h := etaSeconds / 3600
+	m := (etaSeconds % 3600) / 60
+	s := etaSeconds % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh %02dm", h, m)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm %02ds", m, s)
+	}
+	return fmt.Sprintf("%ds", s)
+}
+
+func bytesPerSecondToString(v int64) string {
+	if v <= 0 {
+		return ""
+	}
+	if v >= 1024*1024 {
+		return fmt.Sprintf("%.1f MB/s", float64(v)/float64(1024*1024))
+	}
+	if v >= 1024 {
+		return fmt.Sprintf("%.1f KB/s", float64(v)/1024)
+	}
+	return fmt.Sprintf("%d B/s", v)
+}

--- a/internal/downloader/adapter_test.go
+++ b/internal/downloader/adapter_test.go
@@ -1,0 +1,521 @@
+package downloader
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestProtocolForClient(t *testing.T) {
+	if got := ProtocolForClient("sabnzbd"); got != "usenet" {
+		t.Fatalf("expected usenet, got %q", got)
+	}
+	if got := ProtocolForClient("transmission"); got != "torrent" {
+		t.Fatalf("expected torrent, got %q", got)
+	}
+	if got := ProtocolForClient("qbittorrent"); got != "torrent" {
+		t.Fatalf("expected torrent, got %q", got)
+	}
+}
+
+func TestGetLiveStatusesSABnzbd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("mode") != "queue" {
+			t.Fatalf("expected mode=queue, got %s", r.URL.Query().Get("mode"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"queue": map[string]any{
+				"speed": "2.0 MB/s",
+				"slots": []map[string]any{{
+					"nzo_id":     "nzo123",
+					"percentage": "55",
+					"timeleft":   "0:10:00",
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "sabnzbd", Host: host, Port: port, APIKey: "k"}
+
+	statusByID, usesTorrentID, err := GetLiveStatuses(context.Background(), client)
+	if err != nil {
+		t.Fatalf("GetLiveStatuses: %v", err)
+	}
+	if usesTorrentID {
+		t.Fatalf("expected usesTorrentID=false for sabnzbd")
+	}
+	status, ok := statusByID["nzo123"]
+	if !ok {
+		t.Fatalf("expected nzo123 status")
+	}
+	if status.Percentage != "55" || status.TimeLeft != "0:10:00" || status.Speed != "2.0 MB/s" {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+}
+
+func TestGetLiveStatusesTransmission(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/transmission/rpc" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"arguments": map[string]any{
+				"torrents": []map[string]any{
+					{
+						"id":           7,
+						"percentDone":  0.42,
+						"eta":          125,
+						"rateDownload": 4096,
+						"downloadDir":  "/books",
+					},
+					{
+						"id":          99,
+						"percentDone": 1.0,
+						"downloadDir": "/other",
+					},
+				},
+			},
+			"result": "success",
+		})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+
+	// No category set — all torrents are returned.
+	client := &models.DownloadClient{Type: "transmission", Host: host, Port: port}
+	statusByID, usesTorrentID, err := GetLiveStatuses(context.Background(), client)
+	if err != nil {
+		t.Fatalf("GetLiveStatuses: %v", err)
+	}
+	if !usesTorrentID {
+		t.Fatalf("expected usesTorrentID=true for transmission")
+	}
+	if len(statusByID) != 2 {
+		t.Fatalf("expected 2 statuses with no category filter, got %d", len(statusByID))
+	}
+	status, ok := statusByID["7"]
+	if !ok {
+		t.Fatalf("expected torrent id 7 status")
+	}
+	if status.Percentage != "42.0" {
+		t.Fatalf("unexpected percentage: %s", status.Percentage)
+	}
+	if status.TimeLeft == "" || status.Speed == "" {
+		t.Fatalf("expected non-empty timeLeft/speed, got %+v", status)
+	}
+
+	// Category acts as a download-directory filter on shared Transmission instances.
+	clientFiltered := &models.DownloadClient{Type: "transmission", Host: host, Port: port, Category: "/books"}
+	filteredByID, _, err := GetLiveStatuses(context.Background(), clientFiltered)
+	if err != nil {
+		t.Fatalf("GetLiveStatuses with category: %v", err)
+	}
+	if len(filteredByID) != 1 {
+		t.Fatalf("expected 1 status when category=/books, got %d", len(filteredByID))
+	}
+	if _, ok := filteredByID["7"]; !ok {
+		t.Fatalf("expected torrent id 7 in filtered result")
+	}
+	if _, ok := filteredByID["99"]; ok {
+		t.Fatalf("torrent 99 (/other) should have been filtered out")
+	}
+}
+
+func TestGetLiveStatusesQbittorrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"hash":     "ABCDEF",
+				"progress": 0.9,
+				"eta":      300,
+			}})
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "qbittorrent", Host: host, Port: port, Username: "u", Password: "p"}
+
+	statusByID, usesTorrentID, err := GetLiveStatuses(context.Background(), client)
+	if err != nil {
+		t.Fatalf("GetLiveStatuses: %v", err)
+	}
+	if !usesTorrentID {
+		t.Fatalf("expected usesTorrentID=true for qbittorrent")
+	}
+	status, ok := statusByID["abcdef"]
+	if !ok {
+		t.Fatalf("expected normalized hash key")
+	}
+	if status.Percentage != "90.0" {
+		t.Fatalf("unexpected percentage: %s", status.Percentage)
+	}
+	if status.TimeLeft == "" {
+		t.Fatalf("expected non-empty timeLeft")
+	}
+}
+
+func TestFormattingHelpers(t *testing.T) {
+	if got := etaToTimeLeft(0); got != "" {
+		t.Fatalf("expected empty eta, got %q", got)
+	}
+	if got := etaToTimeLeft(3661); got != "1h 01m" {
+		t.Fatalf("unexpected eta format: %q", got)
+	}
+	if got := bytesPerSecondToString(0); got != "" {
+		t.Fatalf("expected empty speed, got %q", got)
+	}
+	if got := bytesPerSecondToString(1024); got != "1.0 KB/s" {
+		t.Fatalf("unexpected speed format: %q", got)
+	}
+}
+
+func serverHostPort(t *testing.T, raw string) (string, int) {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	host := u.Hostname()
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	return host, port
+}
+
+// ---------------------------------------------------------------------------
+// TestClient
+// ---------------------------------------------------------------------------
+
+func TestTestClient_SABnzbd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"categories": []string{"books"}})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "sabnzbd", Host: host, Port: port, APIKey: "k"}
+	if err := TestClient(context.Background(), client); err != nil {
+		t.Fatalf("TestClient: %v", err)
+	}
+}
+
+func TestTestClient_Transmission(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": "success", "arguments": map[string]any{}})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "transmission", Host: host, Port: port}
+	if err := TestClient(context.Background(), client); err != nil {
+		t.Fatalf("TestClient: %v", err)
+	}
+}
+
+func TestTestClient_Qbittorrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		default:
+			_, _ = w.Write([]byte("1.2.3"))
+		}
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "qbittorrent", Host: host, Port: port, Username: "u", Password: "p"}
+	if err := TestClient(context.Background(), client); err != nil {
+		t.Fatalf("TestClient: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SendDownload
+// ---------------------------------------------------------------------------
+
+func TestSendDownload_SABnzbd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": true, "nzo_ids": []string{"nzo42"}})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "sabnzbd", Host: host, Port: port, APIKey: "k"}
+	result, err := SendDownload(context.Background(), client, "https://example.com/file.nzb", "My Book")
+	if err != nil {
+		t.Fatalf("SendDownload: %v", err)
+	}
+	if result.RemoteID != "nzo42" {
+		t.Errorf("expected RemoteID=nzo42, got %q", result.RemoteID)
+	}
+	if result.Protocol != "usenet" {
+		t.Errorf("expected Protocol=usenet, got %q", result.Protocol)
+	}
+	if result.UsesTorrentID {
+		t.Error("expected UsesTorrentID=false for sabnzbd")
+	}
+}
+
+func TestSendDownload_SABnzbd_NoNzoID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": true, "nzo_ids": []string{}})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "sabnzbd", Host: host, Port: port, APIKey: "k"}
+	result, err := SendDownload(context.Background(), client, "https://example.com/file.nzb", "My Book")
+	if err != nil {
+		t.Fatalf("SendDownload: %v", err)
+	}
+	if result.RemoteID != "" {
+		t.Errorf("expected empty RemoteID, got %q", result.RemoteID)
+	}
+}
+
+func TestSendDownload_Transmission(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": "success",
+			"arguments": map[string]any{
+				"torrent-added": map[string]any{"id": 5, "name": "Book"},
+			},
+		})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "transmission", Host: host, Port: port}
+	result, err := SendDownload(context.Background(), client, "magnet:?xt=urn:btih:abc", "")
+	if err != nil {
+		t.Fatalf("SendDownload: %v", err)
+	}
+	if result.RemoteID != "5" {
+		t.Errorf("expected RemoteID=5, got %q", result.RemoteID)
+	}
+	if result.Protocol != "torrent" {
+		t.Errorf("expected Protocol=torrent, got %q", result.Protocol)
+	}
+	if !result.UsesTorrentID {
+		t.Error("expected UsesTorrentID=true for transmission")
+	}
+}
+
+func TestSendDownload_Transmission_ZeroID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": "success", "arguments": map[string]any{}})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "transmission", Host: host, Port: port}
+	if _, err := SendDownload(context.Background(), client, "magnet:?xt=urn:btih:abc", ""); err == nil {
+		t.Fatal("expected error when torrent ID is 0")
+	}
+}
+
+// TestSendDownload_Transmission_RelativeCategoryNotSentAsDownloadDir verifies
+// that a non-absolute Category value (the common default "books") is not
+// forwarded to Transmission as download-dir, which would cause
+// "download directory path is not absolute".
+func TestSendDownload_Transmission_RelativeCategoryNotSentAsDownloadDir(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": "success",
+			"arguments": map[string]any{
+				"torrent-added": map[string]any{"id": 3, "name": "Book"},
+			},
+		})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	// "books" is a relative label — must NOT be sent as download-dir
+	client := &models.DownloadClient{Type: "transmission", Host: host, Port: port, Category: "books"}
+	if _, err := SendDownload(context.Background(), client, "magnet:?xt=urn:btih:abc", ""); err != nil {
+		t.Fatalf("SendDownload: %v", err)
+	}
+	args, _ := gotBody["arguments"].(map[string]any)
+	if _, hasDir := args["download-dir"]; hasDir {
+		t.Errorf("download-dir should not be set for relative category %q, got args: %v", "books", args)
+	}
+}
+
+// TestSendDownload_Transmission_AbsoluteCategorySentAsDownloadDir verifies
+// that when Category is an absolute path it IS forwarded as download-dir.
+func TestSendDownload_Transmission_AbsoluteCategorySentAsDownloadDir(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": "success",
+			"arguments": map[string]any{
+				"torrent-added": map[string]any{"id": 4, "name": "Book"},
+			},
+		})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "transmission", Host: host, Port: port, Category: "/custom/books"}
+	if _, err := SendDownload(context.Background(), client, "magnet:?xt=urn:btih:abc", ""); err != nil {
+		t.Fatalf("SendDownload: %v", err)
+	}
+	args, _ := gotBody["arguments"].(map[string]any)
+	if dir, _ := args["download-dir"].(string); dir != "/custom/books" {
+		t.Errorf("expected download-dir=/custom/books, got %q", dir)
+	}
+}
+
+func TestSendDownload_Qbittorrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"hash": "ABCDEF123", "progress": 0.0},
+			})
+		}
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "qbittorrent", Host: host, Port: port, Username: "u", Password: "p"}
+	result, err := SendDownload(context.Background(), client, "magnet:?xt=urn:btih:ABCDEF123&dn=Book", "")
+	if err != nil {
+		t.Fatalf("SendDownload: %v", err)
+	}
+	if result.Protocol != "torrent" {
+		t.Errorf("expected Protocol=torrent, got %q", result.Protocol)
+	}
+	if !result.UsesTorrentID {
+		t.Error("expected UsesTorrentID=true for qbittorrent")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RemoveDownload
+// ---------------------------------------------------------------------------
+
+func TestRemoveDownload_SABnzbd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": true})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "sabnzbd", Host: host, Port: port, APIKey: "k"}
+	nzoID := "nzo99"
+	dl := &models.Download{SABnzbdNzoID: &nzoID}
+	if err := RemoveDownload(context.Background(), client, dl, false); err != nil {
+		t.Fatalf("RemoveDownload: %v", err)
+	}
+}
+
+func TestRemoveDownload_SABnzbd_NilNzoID(t *testing.T) {
+	client := &models.DownloadClient{Type: "sabnzbd"}
+	dl := &models.Download{SABnzbdNzoID: nil}
+	if err := RemoveDownload(context.Background(), client, dl, false); err != nil {
+		t.Fatalf("expected nil error for empty NzoID: %v", err)
+	}
+}
+
+func TestRemoveDownload_Transmission(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": "success", "arguments": map[string]any{}})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "transmission", Host: host, Port: port}
+	torrentID := "7"
+	dl := &models.Download{TorrentID: &torrentID}
+	if err := RemoveDownload(context.Background(), client, dl, false); err != nil {
+		t.Fatalf("RemoveDownload: %v", err)
+	}
+}
+
+func TestRemoveDownload_Transmission_NilID(t *testing.T) {
+	client := &models.DownloadClient{Type: "transmission"}
+	dl := &models.Download{TorrentID: nil}
+	if err := RemoveDownload(context.Background(), client, dl, false); err != nil {
+		t.Fatalf("expected nil error for nil TorrentID: %v", err)
+	}
+}
+
+func TestRemoveDownload_Transmission_InvalidID(t *testing.T) {
+	client := &models.DownloadClient{Type: "transmission"}
+	bad := "not-a-number"
+	dl := &models.Download{TorrentID: &bad}
+	if err := RemoveDownload(context.Background(), client, dl, false); err == nil {
+		t.Fatal("expected error for non-numeric torrent ID")
+	}
+}
+
+func TestRemoveDownload_Qbittorrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		default:
+			_, _ = w.Write([]byte(""))
+		}
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "qbittorrent", Host: host, Port: port, Username: "u", Password: "p"}
+	hash := "abc123"
+	dl := &models.Download{TorrentID: &hash}
+	if err := RemoveDownload(context.Background(), client, dl, true); err != nil {
+		t.Fatalf("RemoveDownload: %v", err)
+	}
+}
+
+func TestRemoveDownload_Qbittorrent_NilID(t *testing.T) {
+	client := &models.DownloadClient{Type: "qbittorrent"}
+	dl := &models.Download{TorrentID: nil}
+	if err := RemoveDownload(context.Background(), client, dl, false); err != nil {
+		t.Fatalf("expected nil error for nil TorrentID: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Formatter helpers — missing branches
+// ---------------------------------------------------------------------------
+
+func TestEtaToTimeLeft_SecondsOnly(t *testing.T) {
+	if got := etaToTimeLeft(45); got != "45s" {
+		t.Errorf("expected \"45s\", got %q", got)
+	}
+}
+
+func TestEtaToTimeLeft_MinutesAndSeconds(t *testing.T) {
+	if got := etaToTimeLeft(90); got != "1m 30s" {
+		t.Errorf("expected \"1m 30s\", got %q", got)
+	}
+}
+
+func TestBytesPerSecondToString_MB(t *testing.T) {
+	if got := bytesPerSecondToString(2 * 1024 * 1024); got != "2.0 MB/s" {
+		t.Errorf("expected \"2.0 MB/s\", got %q", got)
+	}
+}
+
+func TestBytesPerSecondToString_Bytes(t *testing.T) {
+	if got := bytesPerSecondToString(512); got != "512 B/s" {
+		t.Errorf("expected \"512 B/s\", got %q", got)
+	}
+}

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -92,8 +92,18 @@ func (c *Client) Test(ctx context.Context) error {
 	return nil
 }
 
-// AddTorrent submits a magnet link or torrent URL to qBittorrent for download.
-func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath string) error {
+// AddTorrent submits a magnet link or torrent URL to qBittorrent for download
+// and returns the torrent hash when it can be determined.
+func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath string) (string, error) {
+	// Snapshot existing hashes so we can detect newly-added items when the
+	// source URL is not a magnet with an explicit btih.
+	beforeSet := map[string]struct{}{}
+	if before, err := c.GetTorrents(ctx, category); err == nil {
+		for _, t := range before {
+			beforeSet[strings.ToLower(t.Hash)] = struct{}{}
+		}
+	}
+
 	form := url.Values{"urls": {magnetOrURL}}
 	if category != "" {
 		form.Set("category", category)
@@ -103,20 +113,20 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 	}
 
 	if err := c.ensureLoggedIn(ctx); err != nil {
-		return err
+		return "", err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		c.baseURL+"/api/v2/torrents/add",
 		strings.NewReader(form.Encode()))
 	if err != nil {
-		return fmt.Errorf("build add request: %w", err)
+		return "", fmt.Errorf("build add request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return fmt.Errorf("add torrent: %w", err)
+		return "", fmt.Errorf("add torrent: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -124,12 +134,52 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 	text := strings.TrimSpace(string(body))
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("add torrent HTTP %d: %s", resp.StatusCode, text)
+		return "", fmt.Errorf("add torrent HTTP %d: %s", resp.StatusCode, text)
 	}
 	if text != "Ok." {
-		return fmt.Errorf("add torrent failed: %s", text)
+		return "", fmt.Errorf("add torrent failed: %s", text)
 	}
-	return nil
+
+	if infoHash := infoHashFromMagnet(magnetOrURL); infoHash != "" {
+		return infoHash, nil
+	}
+
+	after, err := c.GetTorrents(ctx, category)
+	if err != nil {
+		return "", fmt.Errorf("add torrent accepted but hash lookup failed: %w", err)
+	}
+
+	var newest *Torrent
+	for i := range after {
+		t := &after[i]
+		h := strings.ToLower(t.Hash)
+		if _, seen := beforeSet[h]; seen {
+			continue
+		}
+		if newest == nil || t.AddedOn > newest.AddedOn {
+			newest = t
+		}
+	}
+	if newest != nil {
+		return strings.ToLower(newest.Hash), nil
+	}
+	return "", fmt.Errorf("add torrent accepted but hash could not be determined")
+}
+
+func infoHashFromMagnet(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "magnet" {
+		return ""
+	}
+	xt := u.Query().Get("xt")
+	if !strings.HasPrefix(strings.ToLower(xt), "urn:btih:") {
+		return ""
+	}
+	h := strings.TrimSpace(xt[len("urn:btih:"):])
+	if h == "" {
+		return ""
+	}
+	return strings.ToLower(h)
 }
 
 // GetTorrents returns all torrents in the given category (empty = all).

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -146,7 +146,7 @@ func TestAddTorrent_Success(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "admin", "pass")
-	if err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc123", "", ""); err != nil {
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc123", "", ""); err != nil {
 		t.Fatalf("AddTorrent: %v", err)
 	}
 }
@@ -167,7 +167,7 @@ func TestAddTorrent_WithCategoryAndSavePath(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "admin", "pass")
-	if err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "books", "/downloads"); err != nil {
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "books", "/downloads"); err != nil {
 		t.Fatalf("AddTorrent: %v", err)
 	}
 	if gotCategory != "books" {
@@ -190,7 +190,7 @@ func TestAddTorrent_FailsBody(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "admin", "pass")
-	if err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", ""); err == nil {
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", ""); err == nil {
 		t.Fatal("expected error on 'Fails.' body")
 	}
 }
@@ -208,7 +208,7 @@ func TestAddTorrent_HTTPError(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "admin", "pass")
-	if err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", ""); err == nil {
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", ""); err == nil {
 		t.Fatal("expected error on 400")
 	}
 }

--- a/internal/downloader/qbittorrent/types.go
+++ b/internal/downloader/qbittorrent/types.go
@@ -10,4 +10,5 @@ type Torrent struct {
 	Category string  `json:"category"`
 	SavePath string  `json:"save_path"`
 	ETA      int     `json:"eta"`
+	AddedOn  int64   `json:"added_on"`
 }

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -1,0 +1,324 @@
+// Package transmission provides a client for the Transmission BitTorrent daemon RPC API,
+// used to submit magnet/torrent URLs and poll status for torrent downloads.
+package transmission
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Client interacts with the Transmission RPC API.
+// Authentication is done via HTTP Basic Auth if credentials are provided.
+type Client struct {
+	baseURL   string
+	rpcURL    *url.URL
+	initErr   error
+	username  string
+	password  string
+	http      *http.Client
+	sessionID string
+	mu        sync.Mutex
+}
+
+// New creates a Transmission client.
+// username and password are optional for Transmission RPC authentication.
+func New(host string, port int, username, password string, useSSL bool) *Client {
+	scheme := "http"
+	if useSSL {
+		scheme = "https"
+	}
+
+	client := &Client{
+		username: username,
+		password: password,
+		http:     &http.Client{Timeout: 15 * time.Second},
+	}
+
+	rpcURL, err := buildRPCURL(scheme, host, port)
+	if err != nil {
+		client.initErr = err
+	} else {
+		client.rpcURL = rpcURL
+		client.baseURL = rpcURL.String()
+	}
+
+	client.http.CheckRedirect = client.checkRedirect
+
+	return client
+}
+
+// Test verifies connectivity by fetching session information.
+func (c *Client) Test(ctx context.Context) error {
+	req, err := c.buildRequest(ctx, "session-get", map[string]interface{}{})
+	if err != nil {
+		return err
+	}
+	_, err = c.doRequest(req)
+	return err
+}
+
+// AddTorrent submits a magnet link or torrent URL to Transmission for download.
+func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, downloadDir string) (int64, error) {
+	args := map[string]interface{}{
+		"filename": magnetOrURL,
+	}
+	if downloadDir != "" {
+		args["download-dir"] = downloadDir
+	}
+
+	req, err := c.buildRequest(ctx, "torrent-add", args)
+	if err != nil {
+		return 0, err
+	}
+	respBody, err := c.doRequest(req)
+	if err != nil {
+		return 0, err
+	}
+
+	var resp TorrentAddResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return 0, fmt.Errorf("decode add torrent response: %w", err)
+	}
+
+	if resp.Result != "success" {
+		return 0, fmt.Errorf("add torrent failed: %s", resp.Result)
+	}
+
+	// Return the ID of the added torrent (prefer newly added, fall back to duplicate)
+	if resp.Arguments.TorrentAdded.ID != 0 {
+		return resp.Arguments.TorrentAdded.ID, nil
+	}
+	if resp.Arguments.TorrentDuplicate.ID != 0 {
+		return resp.Arguments.TorrentDuplicate.ID, nil
+	}
+
+	return 0, fmt.Errorf("no torrent ID returned")
+}
+
+// GetTorrents returns torrents in the given download directory (empty = all).
+// On a shared Transmission instance, pass the client's configured download
+// directory so Bindery only sees its own torrents.
+func (c *Client) GetTorrents(ctx context.Context, downloadDir string) ([]Torrent, error) {
+	args := map[string]interface{}{
+		"fields": []string{"id", "hashString", "name", "totalSize", "downloadedEver",
+			"leftUntilDone", "status", "errorString", "rateDownload", "rateUpload", "eta",
+			"percentDone", "downloadDir", "labels"},
+	}
+
+	req, err := c.buildRequest(ctx, "torrent-get", args)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := c.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp TorrentGetResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("decode get torrents response: %w", err)
+	}
+
+	if resp.Result != "success" {
+		return nil, fmt.Errorf("get torrents failed: %s", resp.Result)
+	}
+
+	// Filter by download directory if provided
+	if downloadDir != "" {
+		filtered := make([]Torrent, 0)
+		for _, t := range resp.Arguments.Torrents {
+			if t.DownloadDir == downloadDir {
+				filtered = append(filtered, t)
+			}
+		}
+		return filtered, nil
+	}
+
+	return resp.Arguments.Torrents, nil
+}
+
+// RemoveTorrent removes a torrent by ID.
+func (c *Client) RemoveTorrent(ctx context.Context, torrentID int64, deleteFiles bool) error {
+	args := map[string]interface{}{
+		"ids": []int64{torrentID},
+	}
+	if deleteFiles {
+		args["delete-local-data"] = true
+	}
+
+	req, err := c.buildRequest(ctx, "torrent-remove", args)
+	if err != nil {
+		return err
+	}
+	_, err = c.doRequest(req)
+	return err
+}
+
+// buildRequest constructs a Transmission RPC request.
+func (c *Client) buildRequest(ctx context.Context, method string, args map[string]interface{}) (*http.Request, error) {
+	if c.initErr != nil {
+		return nil, c.initErr
+	}
+	if c.rpcURL == nil {
+		return nil, fmt.Errorf("transmission RPC URL is not configured")
+	}
+
+	payload := map[string]interface{}{
+		"method":    method,
+		"arguments": args,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal transmission request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build transmission request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Add session ID if we have it
+	c.mu.Lock()
+	if c.sessionID != "" {
+		req.Header.Set("X-Transmission-Session-Id", c.sessionID)
+	}
+	c.mu.Unlock()
+
+	// Add Basic Auth if credentials are provided
+	if c.username != "" || c.password != "" {
+		authStr := base64.StdEncoding.EncodeToString([]byte(c.username + ":" + c.password))
+		req.Header.Set("Authorization", "Basic "+authStr)
+	}
+
+	return req, nil
+}
+
+func buildRPCURL(scheme, host string, port int) (*url.URL, error) {
+	if err := validateHost(host); err != nil {
+		return nil, err
+	}
+	if port <= 0 || port > 65535 {
+		return nil, fmt.Errorf("invalid Transmission port %d", port)
+	}
+
+	return &url.URL{
+		Scheme: scheme,
+		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+		Path:   "/transmission/rpc",
+	}, nil
+}
+
+func validateHost(host string) error {
+	if strings.TrimSpace(host) == "" {
+		return fmt.Errorf("transmission host is empty")
+	}
+	if strings.Contains(host, "://") || strings.ContainsAny(host, "/?#@") {
+		return fmt.Errorf("transmission host must be a bare hostname or IP address")
+	}
+	return nil
+}
+
+// doRequest sends a request and handles the 409 conflict response (session ID update).
+func (c *Client) doRequest(req *http.Request) ([]byte, error) {
+	if err := c.validateRequestTarget(req.URL); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.http.Do(req) //nolint:gosec // req URL is pinned by buildRPCURL/validateRequestTarget and redirects are checked
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+
+	// Handle 409 Conflict - need to set session ID and retry
+	if resp.StatusCode == http.StatusConflict {
+		sessionID := resp.Header.Get("X-Transmission-Session-Id")
+		if sessionID != "" {
+			c.mu.Lock()
+			c.sessionID = sessionID
+			c.mu.Unlock()
+
+			// Retry the request with the new session ID
+			req2, err := c.copyRequest(req)
+			if err != nil {
+				return nil, err
+			}
+			if err := c.validateRequestTarget(req2.URL); err != nil {
+				return nil, err
+			}
+			resp2, err := c.http.Do(req2) //nolint:gosec // retry uses the same validated RPC target with only session header updated
+			if err != nil {
+				return nil, fmt.Errorf("retry request: %w", err)
+			}
+			defer resp2.Body.Close()
+
+			body, _ = io.ReadAll(io.LimitReader(resp2.Body, 1024*1024))
+			resp = resp2
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("transmission HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+func (c *Client) validateRequestTarget(target *url.URL) error {
+	if target == nil {
+		return fmt.Errorf("request target is nil")
+	}
+	if c.rpcURL == nil {
+		return fmt.Errorf("transmission RPC URL is not configured")
+	}
+	if target.Scheme != c.rpcURL.Scheme || target.Host != c.rpcURL.Host || target.Path != c.rpcURL.Path {
+		return fmt.Errorf("refusing transmission request to unexpected target: %s", target.Redacted())
+	}
+	return nil
+}
+
+func (c *Client) checkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return fmt.Errorf("stopped after too many redirects")
+	}
+	return c.validateRequestTarget(req.URL)
+}
+
+// copyRequest creates a copy of the request with a fresh body.
+func (c *Client) copyRequest(orig *http.Request) (*http.Request, error) {
+	if orig.GetBody == nil {
+		return nil, fmt.Errorf("cannot retry request: missing request body factory")
+	}
+	body, err := orig.GetBody()
+	if err != nil {
+		return nil, fmt.Errorf("rebuild retry body: %w", err)
+	}
+
+	req := orig.Clone(orig.Context())
+	req.Body = body
+	req.ContentLength = orig.ContentLength
+
+	// Update session ID header
+	c.mu.Lock()
+	if c.sessionID != "" {
+		req.Header.Set("X-Transmission-Session-Id", c.sessionID)
+	}
+	c.mu.Unlock()
+
+	return req, nil
+}

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -1,0 +1,364 @@
+package transmission
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// newTestClient creates a Client pointing at the given test server URL.
+func newTestClient(serverURL, username, password string) *Client {
+	c := New("localhost", 9091, username, password, false)
+	c.baseURL = serverURL
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		panic(err)
+	}
+	c.rpcURL = parsed
+	return c
+}
+
+func TestNew(t *testing.T) {
+	c := New("myhost", 9091, "admin", "secret", false)
+	if c.baseURL != "http://myhost:9091/transmission/rpc" {
+		t.Errorf("baseURL: want %q, got %q", "http://myhost:9091/transmission/rpc", c.baseURL)
+	}
+	if c.initErr != nil {
+		t.Fatalf("unexpected initErr: %v", c.initErr)
+	}
+	if c.username != "admin" || c.password != "secret" {
+		t.Error("credentials not stored correctly")
+	}
+
+	cs := New("securehost", 443, "u", "p", true)
+	if cs.baseURL != "https://securehost:443/transmission/rpc" {
+		t.Errorf("SSL baseURL: got %q", cs.baseURL)
+	}
+}
+
+func TestNew_InvalidHost(t *testing.T) {
+	c := New("http://bad-host", 9091, "admin", "secret", false)
+	if c.initErr == nil {
+		t.Fatal("expected invalid host to be rejected")
+	}
+	if err := c.Test(context.Background()); err == nil {
+		t.Fatal("expected client operations to fail when initialized with invalid host")
+	}
+}
+
+func TestTest_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if err := c.Test(context.Background()); err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+}
+
+func TestTest_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if err := c.Test(context.Background()); err == nil {
+		t.Fatal("expected error on 500")
+	}
+}
+
+func TestAddTorrent_NewTorrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{"torrent-added":{"id":42,"name":"My Book"}}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	id, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc123", "")
+	if err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if id != 42 {
+		t.Errorf("expected id=42, got %d", id)
+	}
+}
+
+func TestAddTorrent_DuplicateTorrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{"torrent-duplicate":{"id":7,"name":"Existing Book"}}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	id, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "")
+	if err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if id != 7 {
+		t.Errorf("expected duplicate id=7, got %d", id)
+	}
+}
+
+func TestAddTorrent_NoID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", ""); err == nil {
+		t.Fatal("expected error when no torrent ID returned")
+	}
+}
+
+func TestAddTorrent_FailResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"duplicate torrent","arguments":{}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", ""); err == nil {
+		t.Fatal("expected error on non-success result")
+	}
+}
+
+func TestAddTorrent_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", ""); err == nil {
+		t.Fatal("expected error on 403")
+	}
+}
+
+func TestAddTorrent_WithDownloadDir(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = func() ([]byte, error) {
+			buf := make([]byte, r.ContentLength)
+			_, _ = r.Body.Read(buf)
+			return buf, nil
+		}()
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{"torrent-added":{"id":9,"name":"Dir Book"}}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	id, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "/custom/dir")
+	if err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if id != 9 {
+		t.Errorf("expected id=9, got %d", id)
+	}
+	_ = gotBody // body inspection is optional in this style
+}
+
+func TestGetTorrents_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"result":"success",
+			"arguments":{
+				"torrents":[
+					{"id":1,"name":"Book A","percentDone":0.5,"status":2,"downloadDir":"/downloads"},
+					{"id":2,"name":"Book B","percentDone":1.0,"status":3,"downloadDir":"/downloads"}
+				]
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	torrents, err := c.GetTorrents(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetTorrents: %v", err)
+	}
+	if len(torrents) != 2 {
+		t.Fatalf("expected 2 torrents, got %d", len(torrents))
+	}
+	if torrents[0].Name != "Book A" {
+		t.Errorf("first name: want 'Book A', got %q", torrents[0].Name)
+	}
+	if torrents[1].PercentDone != 1.0 {
+		t.Errorf("second percentDone: want 1.0, got %f", torrents[1].PercentDone)
+	}
+}
+
+func TestGetTorrents_WithDir(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"result":"success",
+			"arguments":{
+				"torrents":[
+					{"id":1,"name":"Book A","downloadDir":"/books"},
+					{"id":2,"name":"Music","downloadDir":"/music"}
+				]
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	torrents, err := c.GetTorrents(context.Background(), "/books")
+	if err != nil {
+		t.Fatalf("GetTorrents: %v", err)
+	}
+	if len(torrents) != 1 {
+		t.Fatalf("expected 1 filtered torrent, got %d", len(torrents))
+	}
+	if torrents[0].DownloadDir != "/books" {
+		t.Errorf("unexpected downloadDir: %q", torrents[0].DownloadDir)
+	}
+}
+
+func TestGetTorrents_FailResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"no session","arguments":{}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if _, err := c.GetTorrents(context.Background(), ""); err == nil {
+		t.Fatal("expected error on non-success result")
+	}
+}
+
+func TestGetTorrents_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("not valid json"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if _, err := c.GetTorrents(context.Background(), ""); err == nil {
+		t.Fatal("expected error on invalid JSON")
+	}
+}
+
+func TestRemoveTorrent_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if err := c.RemoveTorrent(context.Background(), 42, false); err != nil {
+		t.Fatalf("RemoveTorrent: %v", err)
+	}
+}
+
+func TestRemoveTorrent_WithDeleteFiles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if err := c.RemoveTorrent(context.Background(), 42, true); err != nil {
+		t.Fatalf("RemoveTorrent with deleteFiles: %v", err)
+	}
+}
+
+func TestRemoveTorrent_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if err := c.RemoveTorrent(context.Background(), 42, false); err == nil {
+		t.Fatal("expected error on 500")
+	}
+}
+
+// TestSession_409Retry verifies that a 409 Conflict triggers a session-ID
+// update and a single transparent retry, matching Transmission's CSRF
+// protection protocol.
+func TestSession_409Retry(t *testing.T) {
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("X-Transmission-Session-Id", "new-session-token")
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		if r.Header.Get("X-Transmission-Session-Id") != "new-session-token" {
+			t.Errorf("expected session ID on retry, got %q", r.Header.Get("X-Transmission-Session-Id"))
+		}
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if err := c.Test(context.Background()); err != nil {
+		t.Fatalf("expected retry to succeed: %v", err)
+	}
+	if attempts != 2 {
+		t.Errorf("expected 2 attempts (initial + retry), got %d", attempts)
+	}
+}
+
+// TestSession_409NoHeader verifies that a 409 without a session header fails
+// rather than retrying infinitely.
+func TestSession_409NoHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if err := c.Test(context.Background()); err == nil {
+		t.Fatal("expected error when 409 has no session header")
+	}
+}
+
+func TestDoRequest_RejectsUnexpectedTarget(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/other", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	if _, err := c.doRequest(req); err == nil {
+		t.Fatal("expected unexpected target to be rejected")
+	}
+}
+
+func TestDoRequest_RejectsRedirectToDifferentTarget(t *testing.T) {
+	redirected := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirected = true
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{}}`))
+	}))
+	defer target.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	if err := c.Test(context.Background()); err == nil {
+		t.Fatal("expected redirect to different target to be rejected")
+	}
+	if redirected {
+		t.Fatal("unexpectedly followed redirect to different target")
+	}
+}

--- a/internal/downloader/transmission/types.go
+++ b/internal/downloader/transmission/types.go
@@ -1,0 +1,41 @@
+package transmission
+
+// Torrent represents a single torrent as returned by the Transmission RPC API.
+type Torrent struct {
+	ID             int64    `json:"id"`
+	HashString     string   `json:"hashString"`
+	Name           string   `json:"name"`
+	TotalSize      int64    `json:"totalSize"`
+	DownloadedEver int64    `json:"downloadedEver"`
+	LeftUntilDone  int64    `json:"leftUntilDone"`
+	Status         int      `json:"status"` // 0=stopped, 1=checking, 2=downloading, 3=seeding, 4=allocating, 5=checking, 6=stopped
+	ErrorString    string   `json:"errorString"`
+	DownloadRate   int64    `json:"rateDownload"`
+	UploadRate     int64    `json:"rateUpload"`
+	ETA            int64    `json:"eta"`
+	PercentDone    float64  `json:"percentDone"`
+	DownloadDir    string   `json:"downloadDir"`
+	Labels         []string `json:"labels"`
+}
+
+// TorrentAddResponse is returned when adding a torrent.
+type TorrentAddResponse struct {
+	Arguments struct {
+		TorrentAdded     Torrent `json:"torrent-added"`
+		TorrentDuplicate Torrent `json:"torrent-duplicate"`
+	} `json:"arguments"`
+	Result string `json:"result"`
+}
+
+// TorrentGetResponse is returned when getting torrent data.
+type TorrentGetResponse struct {
+	Arguments struct {
+		Torrents []Torrent `json:"torrents"`
+	} `json:"arguments"`
+	Result string `json:"result"`
+}
+
+// SimpleResponse is a generic response from Transmission RPC.
+type SimpleResponse struct {
+	Result string `json:"result"`
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/vavallee/bindery/internal/calibre"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
+	"github.com/vavallee/bindery/internal/downloader/transmission"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -228,6 +230,64 @@ func (s *Scanner) CheckDownloads(ctx context.Context) {
 		return
 	}
 
+	switch client.Type {
+	case "transmission":
+		s.checkTransmissionDownloads(ctx, client)
+	case "qbittorrent":
+		s.checkQbittorrentDownloads(ctx, client)
+	default:
+		s.checkSABnzbdDownloads(ctx, client)
+	}
+}
+
+func isTrackedTorrentDownloadForClient(dl models.Download, clientID int64) bool {
+	if dl.DownloadClientID == nil || *dl.DownloadClientID != clientID {
+		return false
+	}
+	if dl.TorrentID == nil {
+		return false
+	}
+	return dl.Status != models.DownloadStatusImported && dl.Status != models.DownloadStatusFailed
+}
+
+func (s *Scanner) setDownloadError(ctx context.Context, id int64, message string) {
+	if err := s.downloads.SetError(ctx, id, message); err != nil {
+		slog.Warn("failed to persist download error", "download_id", id, "error", err)
+	}
+}
+
+func (s *Scanner) updateDownloadStatus(ctx context.Context, id int64, status string) {
+	if err := s.downloads.UpdateStatus(ctx, id, status); err != nil {
+		slog.Warn("failed to update download status", "download_id", id, "status", status, "error", err)
+	}
+}
+
+func (s *Scanner) createHistoryEvent(ctx context.Context, eventType string, sourceTitle string, bookID *int64, data map[string]string) {
+	if s.history == nil {
+		return
+	}
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		slog.Warn("failed to marshal history event data", "event_type", eventType, "error", err)
+		return
+	}
+	if err := s.history.Create(ctx, &models.HistoryEvent{
+		BookID:      bookID,
+		EventType:   eventType,
+		SourceTitle: sourceTitle,
+		Data:        string(dataJSON),
+	}); err != nil {
+		slog.Warn("failed to create history event", "event_type", eventType, "error", err)
+	}
+}
+
+func (s *Scanner) markDownloadFailed(ctx context.Context, dl *models.Download, message string) {
+	s.setDownloadError(ctx, dl.ID, message)
+	s.createHistoryEvent(ctx, models.HistoryEventDownloadFailed, dl.Title, dl.BookID, map[string]string{"guid": dl.GUID, "message": message})
+}
+
+// checkSABnzbdDownloads polls SABnzbd for status changes.
+func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.DownloadClient) {
 	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
 
 	// Check history for completed downloads (no category filter — match by NZO ID)
@@ -251,29 +311,146 @@ func (s *Scanner) CheckDownloads(ctx context.Context) {
 					slog.Debug("remapped download path", "sab", slot.Path, "local", localPath)
 				}
 				slog.Info("download completed", "title", dl.Title, "path", localPath)
-				s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusCompleted)
-				s.tryImport(ctx, sab, dl, slot.NzoID, localPath)
+				s.updateDownloadStatus(ctx, dl.ID, models.DownloadStatusCompleted)
+				s.tryImportSABnzbd(ctx, sab, dl, slot.NzoID, localPath)
 			}
 		case "Failed":
 			if dl.Status != models.DownloadStatusFailed {
 				slog.Warn("download failed", "title", dl.Title, "message", slot.FailMessage)
-				s.downloads.SetError(ctx, dl.ID, slot.FailMessage)
-				eventData, _ := json.Marshal(map[string]string{"guid": dl.GUID, "message": slot.FailMessage})
-				s.history.Create(ctx, &models.HistoryEvent{
-					BookID:      dl.BookID,
-					EventType:   models.HistoryEventDownloadFailed,
-					SourceTitle: dl.Title,
-					Data:        string(eventData),
-				})
+				s.setDownloadError(ctx, dl.ID, slot.FailMessage)
+				s.createHistoryEvent(ctx, models.HistoryEventDownloadFailed, dl.Title, dl.BookID, map[string]string{"guid": dl.GUID, "message": slot.FailMessage})
 			}
 		}
 	}
 }
 
-// tryImport attempts to import a completed download into the library.
+// checkTransmissionDownloads polls Transmission for status changes.
+func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models.DownloadClient) {
+	trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+
+	// Get all torrents — Category is used as the download directory filter so
+	// Bindery only sees its own torrents on a shared Transmission instance.
+	torrents, err := trans.GetTorrents(ctx, client.Category)
+	if err != nil {
+		slog.Debug("failed to fetch Transmission torrents", "error", err)
+		return
+	}
+
+	// Get all active downloads from DB (not yet completed/imported)
+	allDownloads, err := s.downloads.List(ctx)
+	if err != nil {
+		slog.Debug("failed to list downloads", "error", err)
+		return
+	}
+	torrentsMap := make(map[string]transmission.Torrent)
+	for _, t := range torrents {
+		torrentsMap[fmt.Sprintf("%d", t.ID)] = t
+	}
+
+	for _, dl := range allDownloads {
+		if !isTrackedTorrentDownloadForClient(dl, client.ID) {
+			continue
+		}
+
+		torrent, ok := torrentsMap[*dl.TorrentID]
+		if !ok {
+			continue
+		}
+
+		// Status codes: 0=stopped, 1=checking, 2=downloading, 3=seeding, 4=allocating, 5=checking, 6=stopped
+		isComplete := torrent.Status == 3 || (torrent.PercentDone >= 1.0)
+		isStopped := torrent.Status == 0 || torrent.Status == 6
+		stopError := strings.TrimSpace(torrent.ErrorString)
+
+		if isComplete && (dl.Status == models.DownloadStatusDownloading || dl.Status == models.DownloadStatusQueued) {
+			// Download is complete
+			slog.Info("download completed", "title", dl.Title, "path", torrent.DownloadDir)
+			s.updateDownloadStatus(ctx, dl.ID, models.DownloadStatusCompleted)
+			s.tryImportTransmission(ctx, &dl, torrent.DownloadDir)
+		} else if isStopped && !isComplete && dl.Status != models.DownloadStatusFailed {
+			if stopError == "" {
+				// Transmission also reports user-paused torrents as stopped.
+				continue
+			}
+			slog.Warn("download failed", "title", dl.Title, "error", stopError)
+			s.markDownloadFailed(ctx, &dl, stopError)
+		}
+	}
+}
+
+// checkQbittorrentDownloads polls qBittorrent for status changes.
+func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.DownloadClient) {
+	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+
+	torrents, err := qb.GetTorrents(ctx, client.Category)
+	if err != nil {
+		slog.Debug("failed to fetch qBittorrent torrents", "error", err)
+		return
+	}
+
+	allDownloads, err := s.downloads.List(ctx)
+	if err != nil {
+		slog.Debug("failed to list downloads", "error", err)
+		return
+	}
+	torrentsMap := make(map[string]qbittorrent.Torrent)
+	for _, t := range torrents {
+		torrentsMap[strings.ToLower(t.Hash)] = t
+	}
+
+	for _, dl := range allDownloads {
+		if !isTrackedTorrentDownloadForClient(dl, client.ID) {
+			continue
+		}
+
+		torrent, ok := torrentsMap[strings.ToLower(*dl.TorrentID)]
+		if !ok {
+			continue
+		}
+
+		state := strings.ToLower(torrent.State)
+		isComplete := torrent.Progress >= 1.0 || strings.Contains(state, "upload") || strings.Contains(state, "stalledup") || strings.Contains(state, "checkingup")
+		isFailed := strings.Contains(state, "error")
+
+		if isComplete && (dl.Status == models.DownloadStatusDownloading || dl.Status == models.DownloadStatusQueued) {
+			downloadPath := torrent.SavePath
+			candidate := filepath.Join(torrent.SavePath, torrent.Name)
+			if _, err := os.Stat(candidate); err == nil {
+				downloadPath = candidate
+			}
+			downloadPath = s.remapper.Apply(downloadPath)
+
+			slog.Info("download completed", "title", dl.Title, "path", downloadPath)
+			s.updateDownloadStatus(ctx, dl.ID, models.DownloadStatusCompleted)
+			s.tryImportQbittorrent(ctx, &dl, downloadPath)
+		} else if isFailed && dl.Status != models.DownloadStatusFailed {
+			slog.Warn("download failed", "title", dl.Title, "state", torrent.State)
+			s.markDownloadFailed(ctx, &dl, "Torrent failed in qBittorrent")
+		}
+	}
+}
+
+// tryImportSABnzbd attempts to import a completed SABnzbd download into the library.
 // sab is used to clear the SABnzbd history entry once bindery has taken
 // ownership of the files; nzoID is the history slot's NZO identifier.
-func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models.Download, nzoID, downloadPath string) {
+func (s *Scanner) tryImportSABnzbd(ctx context.Context, sab *sabnzbd.Client, dl *models.Download, nzoID, downloadPath string) {
+	s.tryImportInternal(ctx, dl, downloadPath, "sabnzbd", nzoID, func() error {
+		// Clean up SABnzbd history
+		return sab.DeleteHistory(ctx, nzoID, false)
+	})
+}
+
+// tryImportTransmission attempts to import a completed Transmission download into the library.
+func (s *Scanner) tryImportTransmission(ctx context.Context, dl *models.Download, downloadPath string) {
+	s.tryImportInternal(ctx, dl, downloadPath, "transmission", safeRemoteID(dl.TorrentID), nil)
+}
+
+func (s *Scanner) tryImportQbittorrent(ctx context.Context, dl *models.Download, downloadPath string) {
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", safeRemoteID(dl.TorrentID), nil)
+}
+
+// tryImportInternal is the common import logic shared by SABnzbd and Transmission.
+func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, downloadPath, cleanupClientType, cleanupRemoteID string, cleanupFunc func() error) {
 	if s.libraryDir == "" {
 		slog.Warn("no library directory configured, skipping import")
 		return
@@ -281,7 +458,7 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 
 	// Find book files in the download path
 	var bookFiles []string
-	filepath.Walk(downloadPath, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(downloadPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			return nil
 		}
@@ -289,14 +466,16 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 			bookFiles = append(bookFiles, path)
 		}
 		return nil
-	})
+	}); err != nil {
+		slog.Warn("failed to walk download path", "path", downloadPath, "error", err)
+	}
 
 	if len(bookFiles) == 0 {
 		slog.Warn("no book files found in download", "path", downloadPath)
 		return
 	}
 
-	// Resolve the book and author for naming. Lookup errors are not fatal —
+	// Resolve the book and author for naming. Lookup errors are not fatal -
 	// we fall through to the "unmatched import" log below.
 	var book *models.Book
 	var author *models.Author
@@ -349,7 +528,7 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 				slog.Error("failed to update audiobook file path", "bookID", book.ID, "error", err)
 			}
 		}
-		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusImported)
+		s.updateDownloadStatus(ctx, dl.ID, models.DownloadStatusImported)
 		slog.Info("audiobook imported", "title", func() string {
 			if book != nil {
 				return book.Title
@@ -359,14 +538,12 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 
 		s.pushToCalibre(ctx, book, author, destDir)
 
-		eventData, _ := json.Marshal(map[string]string{"path": destDir})
-		s.history.Create(ctx, &models.HistoryEvent{
-			BookID:      dl.BookID,
-			EventType:   models.HistoryEventBookImported,
-			SourceTitle: dl.Title,
-			Data:        string(eventData),
-		})
-		s.clearSABHistory(ctx, sab, nzoID)
+		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destDir})
+		if cleanupFunc != nil {
+			if err := cleanupFunc(); err != nil {
+				slog.Warn("cleanup failed", cleanupWarnAttrs(cleanupClientType, cleanupRemoteID, err)...)
+			}
+		}
 		return
 	}
 
@@ -403,18 +580,12 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 		if err := s.books.SetFormatFilePath(ctx, book.ID, models.MediaTypeEbook, destPath); err != nil {
 			slog.Error("failed to update ebook file path", "bookID", book.ID, "error", err)
 		}
-		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusImported)
+		s.updateDownloadStatus(ctx, dl.ID, models.DownloadStatusImported)
 		slog.Info("book imported", "title", book.Title, "path", destPath)
 
 		s.pushToCalibre(ctx, book, author, destPath)
 
-		eventData, _ := json.Marshal(map[string]string{"path": destPath})
-		s.history.Create(ctx, &models.HistoryEvent{
-			BookID:      dl.BookID,
-			EventType:   models.HistoryEventBookImported,
-			SourceTitle: dl.Title,
-			Data:        string(eventData),
-		})
+		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destPath})
 	}
 
 	// A clean run leaves the download folder holding only non-book byproducts
@@ -427,21 +598,30 @@ func (s *Scanner) tryImport(ctx context.Context, sab *sabnzbd.Client, dl *models
 				slog.Warn("failed to remove download folder after import", "path", downloadPath, "error", err)
 			}
 		}
-		s.clearSABHistory(ctx, sab, nzoID)
+		if cleanupFunc != nil {
+			if err := cleanupFunc(); err != nil {
+				slog.Warn("cleanup failed", cleanupWarnAttrs(cleanupClientType, cleanupRemoteID, err)...)
+			}
+		}
 	}
 }
 
-// clearSABHistory tells SABnzbd to drop the history entry for a job bindery
-// has finished importing. deleteFiles=false because the importer has already
-// moved the contents; asking SAB to delete would either no-op or wipe files
-// that were moved cross-filesystem and are still resolving.
-func (s *Scanner) clearSABHistory(ctx context.Context, sab *sabnzbd.Client, nzoID string) {
-	if sab == nil || nzoID == "" {
-		return
+func safeRemoteID(id *string) string {
+	if id == nil {
+		return ""
 	}
-	if err := sab.DeleteHistory(ctx, nzoID, false); err != nil {
-		slog.Warn("failed to delete SABnzbd history entry", "nzoID", nzoID, "error", err)
+	return *id
+}
+
+func cleanupWarnAttrs(clientType, remoteID string, err error) []any {
+	attrs := []any{"error", err}
+	if clientType != "" {
+		attrs = append(attrs, "clientType", clientType)
 	}
+	if remoteID != "" {
+		attrs = append(attrs, "remoteID", remoteID)
+	}
+	return attrs
 }
 
 // detectDownloadFormat inspects a list of file paths and returns the media
@@ -467,7 +647,7 @@ func (s *Scanner) FindExisting(ctx context.Context, title, authorName string) st
 		return ""
 	}
 	var found string
-	filepath.Walk(s.libraryDir, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(s.libraryDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() || found != "" {
 			return nil
 		}
@@ -479,7 +659,9 @@ func (s *Scanner) FindExisting(ctx context.Context, title, authorName string) st
 			found = path
 		}
 		return nil
-	})
+	}); err != nil {
+		slog.Warn("failed to search library for existing file", "path", s.libraryDir, "error", err)
+	}
 	return found
 }
 
@@ -600,7 +782,7 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 
 	// Collect all book files on disk
 	var foundFiles []string
-	filepath.Walk(s.libraryDir, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(s.libraryDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			return nil
 		}
@@ -608,7 +790,9 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 			foundFiles = append(foundFiles, path)
 		}
 		return nil
-	})
+	}); err != nil {
+		slog.Warn("library scan walk encountered errors", "path", s.libraryDir, "error", err)
+	}
 
 	slog.Info("library scan found files", "path", s.libraryDir, "count", len(foundFiles))
 

--- a/internal/importer/scanner_extra_test.go
+++ b/internal/importer/scanner_extra_test.go
@@ -2,8 +2,13 @@ package importer
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
@@ -127,6 +132,141 @@ func TestScanLibrary_NonBookFilesIgnored(t *testing.T) {
 func TestCheckDownloads_NoEnabledClient(t *testing.T) {
 	s, _, _, ctx := scannerFixture(t, t.TempDir())
 	s.CheckDownloads(ctx) // no panic, no DB writes
+}
+
+func TestCheckTransmissionDownloads_StoppedWithoutErrorDoesNotFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/transmission/rpc" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": "success",
+			"arguments": map[string]any{
+				"torrents": []map[string]any{{
+					"id":          7,
+					"status":      0,
+					"percentDone": 0.4,
+					"downloadDir": "/downloads",
+					"errorString": "",
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	s, _, _, ctx := scannerFixture(t, t.TempDir())
+	host, port := scannerTestHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name:    "transmission",
+		Type:    "transmission",
+		Host:    host,
+		Port:    port,
+		Enabled: true,
+	}
+	if err := s.clients.Create(ctx, client); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	torrentID := "7"
+	dl := &models.Download{
+		GUID:             "guid-paused",
+		DownloadClientID: &client.ID,
+		Title:            "Paused Torrent",
+		NZBURL:           "magnet:?xt=urn:btih:abc",
+		Status:           models.DownloadStatusDownloading,
+		Protocol:         "torrent",
+		TorrentID:        &torrentID,
+	}
+	if err := s.downloads.Create(ctx, dl); err != nil {
+		t.Fatalf("create download: %v", err)
+	}
+
+	s.checkTransmissionDownloads(ctx, client)
+
+	got, err := s.downloads.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get by guid: %v", err)
+	}
+	if got.Status != models.DownloadStatusDownloading {
+		t.Fatalf("expected status to remain downloading, got %q", got.Status)
+	}
+	if got.ErrorMessage != "" {
+		t.Fatalf("expected no error message, got %q", got.ErrorMessage)
+	}
+}
+
+func TestCheckTransmissionDownloads_StoppedWithErrorMarksFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/transmission/rpc" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": "success",
+			"arguments": map[string]any{
+				"torrents": []map[string]any{{
+					"id":          9,
+					"status":      6,
+					"percentDone": 0.2,
+					"downloadDir": "/downloads",
+					"errorString": "tracker connection failed",
+				}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	s, _, _, ctx := scannerFixture(t, t.TempDir())
+	host, port := scannerTestHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name:    "transmission",
+		Type:    "transmission",
+		Host:    host,
+		Port:    port,
+		Enabled: true,
+	}
+	if err := s.clients.Create(ctx, client); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	torrentID := "9"
+	dl := &models.Download{
+		GUID:             "guid-errored",
+		DownloadClientID: &client.ID,
+		Title:            "Errored Torrent",
+		NZBURL:           "magnet:?xt=urn:btih:def",
+		Status:           models.DownloadStatusDownloading,
+		Protocol:         "torrent",
+		TorrentID:        &torrentID,
+	}
+	if err := s.downloads.Create(ctx, dl); err != nil {
+		t.Fatalf("create download: %v", err)
+	}
+
+	s.checkTransmissionDownloads(ctx, client)
+
+	got, err := s.downloads.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get by guid: %v", err)
+	}
+	if got.Status != models.DownloadStatusFailed {
+		t.Fatalf("expected status failed, got %q", got.Status)
+	}
+	if got.ErrorMessage != "tracker connection failed" {
+		t.Fatalf("expected error message from Transmission, got %q", got.ErrorMessage)
+	}
+}
+
+func scannerTestHostPort(t *testing.T, raw string) (string, int) {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	return u.Hostname(), port
 }
 
 // TestScanLibrary_NoDuplicateBookAssignment — regression test for issue #81.

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -23,16 +24,33 @@ type Client struct {
 
 // New creates a Newznab client for a specific indexer.
 func New(baseURL, apiKey string) *Client {
+	parsedURL := normalizeEndpointURL(baseURL)
+	resolvedAPIKey := strings.TrimSpace(apiKey)
+	if u, err := url.Parse(parsedURL); err == nil {
+		q := u.Query()
+		if resolvedAPIKey == "" {
+			if qKey := strings.TrimSpace(q.Get("apikey")); qKey != "" {
+				resolvedAPIKey = qKey
+			}
+		}
+		q.Del("apikey")
+		u.RawQuery = q.Encode()
+		parsedURL = strings.TrimRight(u.String(), "/")
+	}
+
 	return &Client{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		apiKey:  apiKey,
+		baseURL: parsedURL,
+		apiKey:  resolvedAPIKey,
 		http:    &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
 // Caps fetches the indexer capabilities.
 func (c *Client) Caps(ctx context.Context) (*capsResponse, error) {
-	u := fmt.Sprintf("%s/api?t=caps&apikey=%s", c.baseURL, url.QueryEscape(c.apiKey))
+	u, err := c.buildURL("caps", map[string]string{})
+	if err != nil {
+		return nil, fmt.Errorf("caps: %w", err)
+	}
 	var caps capsResponse
 	if err := c.getXML(ctx, u, &caps); err != nil {
 		return nil, fmt.Errorf("caps: %w", err)
@@ -43,8 +61,14 @@ func (c *Client) Caps(ctx context.Context) (*capsResponse, error) {
 // Search performs a general search with optional category filtering.
 func (c *Client) Search(ctx context.Context, query string, categories []int) ([]SearchResult, error) {
 	cats := intSliceToCSV(categories)
-	u := fmt.Sprintf("%s/api?t=search&apikey=%s&q=%s&cat=%s&limit=100",
-		c.baseURL, url.QueryEscape(c.apiKey), url.QueryEscape(query), cats)
+	u, err := c.buildURL("search", map[string]string{
+		"q":     query,
+		"cat":   cats,
+		"limit": "100",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("search: %w", err)
+	}
 
 	var rss rssResponse
 	if err := c.getXML(ctx, u, &rss); err != nil {
@@ -70,13 +94,17 @@ func (c *Client) BookSearch(ctx context.Context, title, author string, categorie
 
 	// Tier 1: structured t=book
 	if author != "" {
-		u := fmt.Sprintf("%s/api?t=book&apikey=%s&title=%s&author=%s&cat=%s&limit=100",
-			c.baseURL, url.QueryEscape(c.apiKey),
-			url.QueryEscape(queryTitle), url.QueryEscape(author), cats)
-
-		var rss rssResponse
-		if err := c.getXML(ctx, u, &rss); err == nil && len(rss.Channel.Items) > 0 && rss.Channel.Response.Total < 1000 {
-			return c.parseResults(rss.Channel.Items), nil
+		u, err := c.buildURL("book", map[string]string{
+			"title":  queryTitle,
+			"author": author,
+			"cat":    cats,
+			"limit":  "100",
+		})
+		if err == nil {
+			var rss rssResponse
+			if err := c.getXML(ctx, u, &rss); err == nil && len(rss.Channel.Items) > 0 && rss.Channel.Response.Total < 1000 {
+				return c.parseResults(rss.Channel.Items), nil
+			}
 		}
 	}
 
@@ -185,6 +213,67 @@ func (c *Client) getXML(ctx context.Context, rawURL string, target interface{}) 
 	}
 
 	return xml.NewDecoder(resp.Body).Decode(target)
+}
+
+func (c *Client) buildURL(command string, params map[string]string) (string, error) {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid indexer URL: %w", err)
+	}
+
+	q := u.Query()
+	q.Del("t")
+	q.Del("q")
+	q.Del("cat")
+	q.Del("limit")
+	q.Del("title")
+	q.Del("author")
+	q.Del("apikey")
+
+	q.Set("t", command)
+	for k, v := range params {
+		q.Set(k, v)
+	}
+	if c.apiKey != "" {
+		q.Set("apikey", c.apiKey)
+	}
+
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func normalizeEndpointURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return strings.TrimRight(trimmed, "/")
+	}
+
+	p := strings.TrimSpace(u.Path)
+	if p == "" || p == "/" {
+		u.Path = "/api"
+		u.RawPath = ""
+		return strings.TrimRight(u.String(), "/")
+	}
+
+	normalized := strings.TrimRight(path.Clean(p), "/")
+	if normalized == "" || normalized == "." {
+		normalized = "/api"
+	}
+	if !strings.HasPrefix(normalized, "/") {
+		normalized = "/" + normalized
+	}
+	if !strings.Contains(strings.ToLower(normalized), "torznab") && !strings.HasSuffix(strings.ToLower(normalized), "/api") {
+		normalized = strings.TrimRight(normalized, "/") + "/api"
+	}
+
+	u.Path = normalized
+	u.RawPath = ""
+	return strings.TrimRight(u.String(), "/")
 }
 
 func intSliceToCSV(ints []int) string {

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -158,5 +159,76 @@ func TestXMLNamespace(t *testing.T) {
 	}
 	if rss.Channel.Response.Total != 2 {
 		t.Errorf("expected total=2, got %d", rss.Channel.Response.Total)
+	}
+}
+
+func TestCapsWithFullTorznabEndpointURL(t *testing.T) {
+	var gotPath string
+	var gotQuery string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/xml")
+		w.Write([]byte(testCaps))
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL + "/1/api?apikey=from-url"
+	c := New(endpoint, "")
+	if _, err := c.Caps(context.Background()); err != nil {
+		t.Fatalf("caps: %v", err)
+	}
+
+	if gotPath != "/1/api" {
+		t.Fatalf("expected path /1/api, got %s", gotPath)
+	}
+	if !strings.Contains(gotQuery, "t=caps") {
+		t.Fatalf("expected t=caps in query, got %q", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "apikey=from-url") {
+		t.Fatalf("expected apikey from endpoint URL in query, got %q", gotQuery)
+	}
+}
+
+func TestCapsWithEndpointAndExplicitAPIKeyOverridesURL(t *testing.T) {
+	var gotQuery string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/xml")
+		w.Write([]byte(testCaps))
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL + "/1/api?apikey=from-url"
+	c := New(endpoint, "from-field")
+	if _, err := c.Caps(context.Background()); err != nil {
+		t.Fatalf("caps: %v", err)
+	}
+
+	if !strings.Contains(gotQuery, "apikey=from-field") {
+		t.Fatalf("expected explicit API key to be used, got %q", gotQuery)
+	}
+}
+
+func TestNewRootURLNormalizesToAPIPath(t *testing.T) {
+	c := New("https://prowlarr.local:9696", "abc")
+	if c.baseURL != "https://prowlarr.local:9696/api" {
+		t.Fatalf("expected normalized baseURL to include /api, got %s", c.baseURL)
+	}
+}
+
+func TestNewExtractsAPIKeyAndStripsItFromStoredBaseURL(t *testing.T) {
+	c := New("https://prowlarr.local:9696/1/api?apikey=from-url&foo=bar", "")
+
+	if c.apiKey != "from-url" {
+		t.Fatalf("expected API key extracted from URL, got %q", c.apiKey)
+	}
+	if strings.Contains(c.baseURL, "apikey=") {
+		t.Fatalf("expected stored baseURL not to contain apikey, got %s", c.baseURL)
+	}
+	if !strings.Contains(c.baseURL, "foo=bar") {
+		t.Fatalf("expected stored baseURL to preserve non-apikey query params, got %s", c.baseURL)
 	}
 }

--- a/internal/migrate/csv.go
+++ b/internal/migrate/csv.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/csv"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -128,7 +129,7 @@ func parseCSVRows(reader io.Reader) ([]csvRow, error) {
 	// commas); otherwise treat each line as a bare author name.
 	buf := bufio.NewReader(reader)
 	first, _, err := buf.ReadLine()
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return nil, nil
 	}
 	if err != nil {
@@ -137,7 +138,10 @@ func parseCSVRows(reader io.Reader) ([]csvRow, error) {
 	hasComma := strings.Contains(string(first), ",")
 
 	// Push the first line back in front of the rest.
-	remaining, _ := io.ReadAll(buf)
+	remaining, err := io.ReadAll(buf)
+	if err != nil {
+		return nil, fmt.Errorf("read csv remainder: %w", err)
+	}
 	combined := append(append([]byte{}, first...), '\n')
 	combined = append(combined, remaining...)
 

--- a/internal/migrate/readarr.go
+++ b/internal/migrate/readarr.go
@@ -158,7 +158,9 @@ type readarrSettings struct {
 
 func parseSettings(raw string) readarrSettings {
 	var s readarrSettings
-	_ = json.Unmarshal([]byte(raw), &s)
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		slog.Warn("failed to parse readarr settings JSON", "err", err)
+	}
 	return s
 }
 
@@ -247,20 +249,14 @@ func importReadarrDownloadClients(ctx context.Context, src *sql.DB, repo *db.Dow
 			cat = "books"
 		}
 
-		// For qBittorrent, Readarr's Username/Password fields carry creds;
-		// Bindery squashes credentials into the APIKey field for either
-		// client so we don't need a separate Password column.
-		apiKey := s.APIKey
-		if apiKey == "" {
-			apiKey = s.Password
-		}
-
 		c := &models.DownloadClient{
 			Name:     name,
 			Type:     t,
 			Host:     s.Host,
 			Port:     s.Port,
-			APIKey:   apiKey,
+			APIKey:   s.APIKey,
+			Username: s.Username,
+			Password: s.Password,
 			Category: cat,
 			UseSSL:   s.UseSsl,
 			Enabled:  enable,

--- a/internal/models/download.go
+++ b/internal/models/download.go
@@ -18,11 +18,8 @@ type DownloadClient struct {
 	UpdatedAt time.Time `json:"updatedAt"`
 
 	// Username and Password are used by download clients that authenticate with
-	// credentials rather than an API key (e.g. qBittorrent).
-	// Storage note: for qBittorrent, Username is persisted in the url_base column
-	// and Password is persisted in the api_key column of the download_clients table,
-	// since those fields are unused by qBittorrent. These virtual fields are
-	// populated by the application layer and are not stored as separate DB columns.
+	// credentials rather than an API key (e.g. qBittorrent, Transmission).
+	// These fields are persisted in dedicated download_clients table columns.
 	Username string `json:"username"`
 	Password string `json:"password"`
 }
@@ -38,6 +35,7 @@ type Download struct {
 	NZBURL           string     `json:"nzbUrl"`
 	Size             int64      `json:"size"`
 	SABnzbdNzoID     *string    `json:"sabnzbdNzoId"`
+	TorrentID        *string    `json:"torrentId"`
 	Status           string     `json:"status"`
 	Protocol         string     `json:"protocol"`
 	Quality          string     `json:"quality"`

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -10,8 +10,7 @@ import (
 	"github.com/robfig/cron/v3"
 
 	"github.com/vavallee/bindery/internal/db"
-	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
-	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
+	"github.com/vavallee/bindery/internal/downloader"
 	"github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/indexer/newznab"
@@ -189,14 +188,18 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 
 	lang := "en"
 	if s.settings != nil {
-		if langSetting, _ := s.settings.Get(ctx, "search.preferredLanguage"); langSetting != nil {
+		if langSetting, err := s.settings.Get(ctx, "search.preferredLanguage"); err != nil {
+			slog.Warn("failed to load preferred search language", "error", err)
+		} else if langSetting != nil {
 			lang = langSetting.Value
 		}
 	}
 
 	authorName := ""
 	if s.authors != nil {
-		if a, _ := s.authors.GetByID(ctx, book.AuthorID); a != nil {
+		if a, err := s.authors.GetByID(ctx, book.AuthorID); err != nil {
+			slog.Warn("failed to load author for search", "author_id", book.AuthorID, "error", err)
+		} else if a != nil {
 			authorName = a.Name
 		}
 	}
@@ -219,10 +222,20 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 
 	best := results[0]
 
-	candidates, _ := s.clients.GetEnabledByProtocol(ctx, best.Protocol)
+	candidates, err := s.clients.GetEnabledByProtocol(ctx, best.Protocol)
+	if err != nil {
+		slog.Warn("failed to list clients for protocol", "protocol", best.Protocol, "error", err)
+	}
 	client := db.PickClientForMediaType(candidates, mediaType)
 	if client == nil {
+		client, err = s.clients.GetFirstEnabled(ctx)
+		if err != nil {
+			slog.Warn("failed to load fallback download client", "error", err)
+		}
+	}
+	if client == nil {
 		slog.Warn("SearchAndGrabBook: no enabled download client for protocol", "book", book.Title, "protocol", best.Protocol)
+
 		return
 	}
 
@@ -237,7 +250,11 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		"size", best.Size,
 	)
 
-	existing, _ := s.downloads.GetByGUID(ctx, best.GUID)
+	existing, err := s.downloads.GetByGUID(ctx, best.GUID)
+	if err != nil {
+		slog.Warn("failed to check existing download", "guid", best.GUID, "error", err)
+		return
+	}
 	if existing != nil {
 		return
 	}
@@ -260,29 +277,29 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		return
 	}
 
-	if best.Protocol == "torrent" {
-		qbt := qbittorrent.New(client.Host, client.Port, client.URLBase, client.APIKey, client.UseSSL)
-		if err := qbt.AddTorrent(ctx, best.NZBURL, client.Category, ""); err != nil {
-			slog.Error("SearchAndGrabBook: failed to send to qBittorrent", "title", best.Title, "error", err)
-			s.downloads.SetError(ctx, dl.ID, err.Error())
-			return
+	sendRes, err := downloader.SendDownload(ctx, client, best.NZBURL, best.Title)
+	if err != nil {
+		slog.Error("SearchAndGrabBook: failed to send to downloader", "client", client.Type, "title", best.Title, "error", err)
+		if setErr := s.downloads.SetError(ctx, dl.ID, err.Error()); setErr != nil {
+			slog.Warn("failed to persist download error", "download_id", dl.ID, "error", setErr)
 		}
-		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading)
-		slog.Info("sent to qBittorrent", "title", best.Title)
-	} else {
-		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
-		resp, err := sab.AddURL(ctx, best.NZBURL, best.Title, client.Category, 0)
-		if err != nil {
-			slog.Error("SearchAndGrabBook: failed to send to SABnzbd", "title", best.Title, "error", err)
-			s.downloads.SetError(ctx, dl.ID, err.Error())
-			return
-		}
-		if len(resp.NzoIDs) > 0 {
-			s.downloads.SetNzoID(ctx, dl.ID, resp.NzoIDs[0])
-		}
-		s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading)
-		slog.Info("sent to SABnzbd", "title", best.Title)
+		return
 	}
+	if sendRes.RemoteID != "" {
+		if sendRes.UsesTorrentID {
+			if err := s.downloads.SetTorrentID(ctx, dl.ID, sendRes.RemoteID); err != nil {
+				slog.Warn("failed to set torrent ID", "download_id", dl.ID, "error", err)
+			}
+		} else {
+			if err := s.downloads.SetNzoID(ctx, dl.ID, sendRes.RemoteID); err != nil {
+				slog.Warn("failed to set NZO ID", "download_id", dl.ID, "error", err)
+			}
+		}
+	}
+	if err := s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading); err != nil {
+		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.DownloadStatusDownloading, "error", err)
+	}
+	slog.Info("sent to downloader", "client", client.Type, "title", best.Title)
 }
 
 func (s *Scheduler) searchWanted() {
@@ -292,7 +309,9 @@ func (s *Scheduler) searchWanted() {
 	// scheduled wanted-scan is skipped entirely — users manage grabs
 	// manually from the Wanted page.
 	if s.settings != nil {
-		if setting, _ := s.settings.Get(ctx, "autoGrab.enabled"); setting != nil && setting.Value == "false" {
+		if setting, err := s.settings.Get(ctx, "autoGrab.enabled"); err != nil {
+			slog.Warn("failed to load auto-grab setting", "error", err)
+		} else if setting != nil && setting.Value == "false" {
 			slog.Info("job: auto-grab disabled globally, skipping wanted search")
 			return
 		}
@@ -320,7 +339,13 @@ func filterBlocklisted(ctx context.Context, bl *db.BlocklistRepo, results []newz
 	}
 	out := make([]newznab.SearchResult, 0, len(results))
 	for _, r := range results {
-		if blocked, _ := bl.IsBlocked(ctx, r.GUID); !blocked {
+		blocked, err := bl.IsBlocked(ctx, r.GUID)
+		if err != nil {
+			slog.Warn("failed to check blocklist", "guid", r.GUID, "error", err)
+			out = append(out, r)
+			continue
+		}
+		if !blocked {
 			out = append(out, r)
 		}
 	}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -57,20 +57,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.10",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
@@ -1259,34 +1245,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@istanbuljs/schema": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
-      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2667,40 +2625,6 @@
         }
       }
     },
-    "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
-        "@bcoe/v8-coverage": "^1.0.2",
-        "ast-v8-to-istanbul": "^0.3.3",
-        "debug": "^4.4.1",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
-        "istanbul-reports": "^3.1.7",
-        "magic-string": "^0.30.17",
-        "magicast": "^0.3.5",
-        "std-env": "^3.9.0",
-        "test-exclude": "^7.0.1",
-        "tinyrainbow": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -3260,13 +3184,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
@@ -3723,39 +3640,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -3792,65 +3676,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3861,32 +3686,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -3948,13 +3747,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
-    },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
@@ -4059,16 +3851,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4092,76 +3874,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.23",
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -4611,93 +4323,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -4752,16 +4377,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -4847,13 +4462,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4897,36 +4505,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -5299,19 +4877,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
     },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5332,103 +4897,6 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true
-    },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -5496,97 +4964,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.21.7",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/test-exclude": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
-      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^10.4.1",
-        "minimatch": "^10.2.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/test-exclude/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6300,112 +5677,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -57,6 +57,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.10",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
@@ -1245,6 +1259,34 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2625,6 +2667,40 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -3184,6 +3260,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
@@ -3640,6 +3723,39 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -3676,6 +3792,65 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3686,6 +3861,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -3747,6 +3948,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
@@ -3851,6 +4059,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3874,6 +4092,76 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -4323,6 +4611,93 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -4377,6 +4752,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -4462,6 +4847,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4505,6 +4897,36 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -4877,6 +5299,19 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4897,6 +5332,103 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4964,6 +5496,97 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5677,6 +6300,112 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/web/src/components/AddAuthorModal.test.tsx
+++ b/web/src/components/AddAuthorModal.test.tsx
@@ -2,10 +2,27 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import AddAuthorModal from './AddAuthorModal'
 
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      const strings: Record<string, string> = {
+        'addAuthorModal.searchPlaceholder': 'Search by author name...',
+        'addAuthorModal.search': 'Search',
+        'addAuthorModal.noResults': 'No results found',
+      }
+      if (key === 'addAuthorModal.searchError') {
+        return `Could not reach the metadata provider - ${String(options?.error ?? '')}`
+      }
+      return strings[key] ?? key
+    },
+  }),
+}))
+
 // Mock the entire api/client module so no real HTTP calls are made.
 vi.mock('../api/client', () => ({
   api: {
     listMetadataProfiles: vi.fn().mockResolvedValue([]),
+    listRootFolders: vi.fn().mockResolvedValue([]),
     searchAuthors: vi.fn(),
     addAuthor: vi.fn(),
   },
@@ -21,6 +38,7 @@ describe('AddAuthorModal — search error handling', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(api.listMetadataProfiles).mockResolvedValue([])
+    vi.mocked(api.listRootFolders).mockResolvedValue([])
   })
 
   it('shows an error banner when the metadata provider is unreachable', async () => {

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -12,7 +12,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<Author[]>([])
   const [searching, setSearching] = useState(false)
-  const [searchError, setSearchError] = useState('')
+  const [searchError, setSearchError] = useState<string | null>(null)
   const [adding, setAdding] = useState<string | null>(null)
   const [profiles, setProfiles] = useState<MetadataProfile[]>([])
   const [profileId, setProfileId] = useState<number | null>(null)
@@ -37,7 +37,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const search = async () => {
     if (!query.trim()) return
     setSearching(true)
-    setSearchError('')
+    setSearchError(null)
     try {
       const authors = await api.searchAuthors(query)
       setResults(authors)

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1589,6 +1589,7 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
   const [url, setUrl] = useState(indexer.url)
   const [apiKey, setApiKey] = useState(indexer.apiKey)
   const [categories, setCategories] = useState((indexer.categories ?? [7020]).join(', '))
+  const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
     const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey, categories: parseCats(categories) })
@@ -1598,15 +1599,29 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
   return (
     <div className="mt-1 p-4 border border-slate-300 dark:border-zinc-700 rounded-lg bg-slate-200/50 dark:bg-zinc-800/50 space-y-3">
       <div className="flex gap-2">
-        <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
-        <select value={type} onChange={e => setType(e.target.value)} className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
-          <option value="newznab">Newznab (Usenet)</option>
-          <option value="torznab">Torznab (Torrent)</option>
-        </select>
+        <div className="flex-1">
+          <label className={labelCls}>Name</label>
+          <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
+        </div>
+        <div className="w-48">
+          <label className={labelCls}>Indexer Type</label>
+          <select value={type} onChange={e => setType(e.target.value)} className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
+            <option value="newznab">Newznab (Usenet)</option>
+            <option value="torznab">Torznab (Torrent)</option>
+          </select>
+        </div>
       </div>
-      <input value={url} onChange={e => setUrl(e.target.value)} placeholder="URL" className={inputCls} />
-      <input value={apiKey} onChange={e => setApiKey(e.target.value)} placeholder="API Key" type="password" className={inputCls} />
       <div>
+        <label className={labelCls}>URL</label>
+        <input value={url} onChange={e => setUrl(e.target.value)} placeholder="URL" className={inputCls} />
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Use a base Newznab URL (for example: https://api.nzbgeek.info) or a full Torznab endpoint (for example: http://prowlarr:9696/1/api).</p>
+      </div>
+      <div>
+        <label className={labelCls}>API Key</label>
+        <input value={apiKey} onChange={e => setApiKey(e.target.value)} placeholder="API Key" type="password" className={inputCls} />
+      </div>
+      <div>
+        <label className={labelCls}>Categories</label>
         <input value={categories} onChange={e => setCategories(e.target.value)} placeholder="Categories (e.g. 7020, 7120, 3030)" className={inputCls} />
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Comma-separated Newznab category IDs. 7020 = eBooks, 3030 = Audiobooks. Add custom IDs for indexers with non-standard categories (e.g. 7120 for German books).</p>
       </div>
@@ -1623,9 +1638,10 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
   const [type, setType] = useState(client.type || 'sabnzbd')
   const [host, setHost] = useState(client.host)
   const [port, setPort] = useState(String(client.port))
-  const [credential, setCredential] = useState(client.type === 'qbittorrent' ? (client.password || '') : (client.apiKey || ''))
+  const [credential, setCredential] = useState(client.type === 'qbittorrent' || client.type === 'transmission' ? (client.password || '') : (client.apiKey || ''))
   const [username, setUsername] = useState(client.username || '')
   const [category, setCategory] = useState(client.category)
+  const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const handleTypeChange = (newType: string) => {
     setType(newType)
@@ -1634,7 +1650,7 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
   }
 
   const submit = async () => {
-    const data = type === 'qbittorrent'
+    const data = type === 'qbittorrent' || type === 'transmission'
       ? { ...client, name, type, host, port: parseInt(port), username, password: credential, apiKey: '', category }
       : { ...client, name, type, host, port: parseInt(port), apiKey: credential, username: '', password: '', category }
     const updated = await api.updateDownloadClient(client.id, data)
@@ -1644,24 +1660,42 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
   return (
     <div className="mt-1 p-4 border border-slate-300 dark:border-zinc-700 rounded-lg bg-slate-200/50 dark:bg-zinc-800/50 space-y-3">
       <div className="flex gap-2">
-        <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
-        <select value={type} onChange={e => handleTypeChange(e.target.value)} className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
-          <option value="sabnzbd">SABnzbd</option>
-          <option value="qbittorrent">qBittorrent</option>
-        </select>
+        <div className="flex-1">
+          <label className={labelCls}>Name</label>
+          <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
+        </div>
+        <div className="w-40">
+          <label className={labelCls}>Client Type</label>
+          <select value={type} onChange={e => handleTypeChange(e.target.value)} className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
+            <option value="sabnzbd">SABnzbd</option>
+            <option value="qbittorrent">qBittorrent</option>
+            <option value="transmission">Transmission</option>
+          </select>
+        </div>
       </div>
       <div>
+        <label className={labelCls}>Connection</label>
         <div className="flex gap-2">
           <input value={host} onChange={e => setHost(e.target.value)} placeholder="Host" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
           <input value={port} onChange={e => setPort(e.target.value)} placeholder="Port" className="w-24 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
         </div>
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">In Docker, use the service/container name (e.g. <code className="font-mono">sabnzbd</code>) — not <code className="font-mono">localhost</code>.</p>
       </div>
-      {type === 'qbittorrent' && (
-        <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />
+      {(type === 'qbittorrent' || type === 'transmission') && (
+        <div>
+          <label className={labelCls}>Username</label>
+          <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />
+        </div>
       )}
-      <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' ? 'Password' : 'API Key'} type="password" className={inputCls} />
-      <input value={category} onChange={e => setCategory(e.target.value)} placeholder="Category" className={inputCls} />
+      <div>
+        <label className={labelCls}>{type === 'qbittorrent' || type === 'transmission' ? 'Password' : 'API Key'}</label>
+        <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' || type === 'transmission' ? 'Password' : 'API Key'} type="password" className={inputCls} />
+      </div>
+      <div>
+        <label className={labelCls}>{type === 'transmission' ? 'Download Directory' : 'Category'}</label>
+        <input value={category} onChange={e => setCategory(e.target.value)} placeholder={type === 'transmission' ? '/downloads (leave blank for default)' : 'Category'} className={inputCls} />
+        {type === 'transmission' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Optional absolute path override. Leave blank to use Transmission's configured default download directory.</p>}
+      </div>
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
         <button onClick={submit} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium">Save</button>
@@ -1727,6 +1761,7 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
   const [url, setUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [categories, setCategories] = useState('7020')
+  const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
     const idx = await api.addIndexer({ name, url, apiKey, type, categories: parseCats(categories), enabled: true })
@@ -1736,15 +1771,29 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
   return (
     <div className="mt-4 p-4 border border-slate-300 dark:border-zinc-700 rounded-lg bg-slate-200/50 dark:bg-zinc-800/50 space-y-3">
       <div className="flex gap-2">
-        <input value={name} onChange={e => setName(e.target.value)} placeholder="Name (e.g. NZBGeek)" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
-        <select value={type} onChange={e => setType(e.target.value as 'newznab' | 'torznab')} className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
-          <option value="newznab">Newznab</option>
-          <option value="torznab">Torznab</option>
-        </select>
+        <div className="flex-1">
+          <label className={labelCls}>Name</label>
+          <input value={name} onChange={e => setName(e.target.value)} placeholder="Name (e.g. NZBGeek)" className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
+        </div>
+        <div className="w-40">
+          <label className={labelCls}>Indexer Type</label>
+          <select value={type} onChange={e => setType(e.target.value as 'newznab' | 'torznab')} className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
+            <option value="newznab">Newznab</option>
+            <option value="torznab">Torznab</option>
+          </select>
+        </div>
       </div>
-      <input value={url} onChange={e => setUrl(e.target.value)} placeholder="URL (e.g. https://api.nzbgeek.info)" className={inputCls} />
-      <input value={apiKey} onChange={e => setApiKey(e.target.value)} placeholder="API Key" type="password" className={inputCls} />
       <div>
+        <label className={labelCls}>URL</label>
+        <input value={url} onChange={e => setUrl(e.target.value)} placeholder="URL (e.g. https://api.nzbgeek.info or http://prowlarr:9696/1/api)" className={inputCls} />
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">For Prowlarr, paste the Torznab endpoint URL (usually ending in /api) and API key.</p>
+      </div>
+      <div>
+        <label className={labelCls}>API Key</label>
+        <input value={apiKey} onChange={e => setApiKey(e.target.value)} placeholder="API Key" type="password" className={inputCls} />
+      </div>
+      <div>
+        <label className={labelCls}>Categories</label>
         <input value={categories} onChange={e => setCategories(e.target.value)} placeholder="Categories (e.g. 7020, 7120, 3030)" className={inputCls} />
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Comma-separated Newznab category IDs. 7020 = eBooks, 3030 = Audiobooks. Add custom IDs for indexers with non-standard categories (e.g. 7120 for German books).</p>
       </div>
@@ -1758,22 +1807,34 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
 
 function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c: DownloadClient) => void }) {
   const [name, setName] = useState('SABnzbd')
-  const [type, setType] = useState<'sabnzbd' | 'qbittorrent'>('sabnzbd')
+  const [type, setType] = useState<'sabnzbd' | 'qbittorrent' | 'transmission'>('sabnzbd')
   const [host, setHost] = useState('')
   const [port, setPort] = useState('8080')
   const [credential, setCredential] = useState('')
   const [username, setUsername] = useState('')
   const [category, setCategory] = useState('books')
+  const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
-  const handleTypeChange = (newType: 'sabnzbd' | 'qbittorrent') => {
+  const handleTypeChange = (newType: 'sabnzbd' | 'qbittorrent' | 'transmission') => {
     setType(newType)
     setCredential('')
     setUsername('')
-    setName(newType === 'qbittorrent' ? 'qBittorrent' : 'SABnzbd')
+    if (newType === 'qbittorrent') {
+      setName('qBittorrent')
+      setPort('8080')
+      return
+    }
+    if (newType === 'transmission') {
+      setName('Transmission')
+      setPort('9091')
+      return
+    }
+    setName('SABnzbd')
+    setPort('8080')
   }
 
   const submit = async () => {
-    const data = type === 'qbittorrent'
+    const data = type === 'qbittorrent' || type === 'transmission'
       ? { name, host, port: parseInt(port), username, password: credential, apiKey: '', category, type, enabled: true }
       : { name, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, type, enabled: true }
     const c = await api.addDownloadClient(data)
@@ -1783,24 +1844,42 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
   return (
     <div className="mt-4 p-4 border border-slate-300 dark:border-zinc-700 rounded-lg bg-slate-200/50 dark:bg-zinc-800/50 space-y-3">
       <div className="flex gap-2">
-        <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
-        <select value={type} onChange={e => handleTypeChange(e.target.value as 'sabnzbd' | 'qbittorrent')} className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
-          <option value="sabnzbd">SABnzbd</option>
-          <option value="qbittorrent">qBittorrent</option>
-        </select>
+        <div className="flex-1">
+          <label className={labelCls}>Name</label>
+          <input value={name} onChange={e => setName(e.target.value)} placeholder="Name" className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
+        </div>
+        <div className="w-40">
+          <label className={labelCls}>Client Type</label>
+          <select value={type} onChange={e => handleTypeChange(e.target.value as 'sabnzbd' | 'qbittorrent' | 'transmission')} className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
+            <option value="sabnzbd">SABnzbd</option>
+            <option value="qbittorrent">qBittorrent</option>
+            <option value="transmission">Transmission</option>
+          </select>
+        </div>
       </div>
       <div>
+        <label className={labelCls}>Connection</label>
         <div className="flex gap-2">
           <input value={host} onChange={e => setHost(e.target.value)} placeholder="Host" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
           <input value={port} onChange={e => setPort(e.target.value)} placeholder="Port" className="w-24 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
         </div>
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">In Docker, use the service/container name (e.g. <code className="font-mono">sabnzbd</code>) — not <code className="font-mono">localhost</code>.</p>
       </div>
-      {type === 'qbittorrent' && (
-        <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />
+      {(type === 'qbittorrent' || type === 'transmission') && (
+        <div>
+          <label className={labelCls}>Username</label>
+          <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />
+        </div>
       )}
-      <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' ? 'Password' : 'API Key'} type="password" className={inputCls} />
-      <input value={category} onChange={e => setCategory(e.target.value)} placeholder="Category" className={inputCls} />
+      <div>
+        <label className={labelCls}>{type === 'qbittorrent' || type === 'transmission' ? 'Password' : 'API Key'}</label>
+        <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' || type === 'transmission' ? 'Password' : 'API Key'} type="password" className={inputCls} />
+      </div>
+      <div>
+        <label className={labelCls}>{type === 'transmission' ? 'Download Directory' : 'Category'}</label>
+        <input value={category} onChange={e => setCategory(e.target.value)} placeholder={type === 'transmission' ? '/downloads (leave blank for default)' : 'Category'} className={inputCls} />
+        {type === 'transmission' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Optional absolute path override. Leave blank to use Transmission's configured default download directory.</p>}
+      </div>
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
         <button onClick={submit} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium">Save</button>


### PR DESCRIPTION
Rebased version of #99 by @dginther — all credit to the original author.

Rebased onto `development` to restore the `RecommendationEngine` interface that the original branch had removed.

## Summary
- Adds Transmission RPC client with 409 session-ID handshake, SSRF validation, test coverage
- Unified `internal/downloader/adapter.go` — single dispatch point for SABnzbd, qBittorrent, Transmission
- Significant `importer/scanner.go` refactor — cleaner polling, dedicated status helpers
- Prowlarr Torznab URL normalization fix (`/1/api` no longer becomes `/1/api/api`)
- DB migrations 016 (download client credentials) and 017 (Transmission torrent_id column)
- Frontend: Transmission-aware category/download-dir label in Settings

## Test plan
- [ ] `go build ./...` clean
- [ ] `go test -race ./internal/downloader/... ./internal/importer/... ./internal/indexer/...` passes
- [ ] Transmission, adapter, newznab tests all green
- [ ] Smoke test passes