### PR TITLE
feat(recommender): Phase 2 — genre-popular + list-cross candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased] — development branch
 
+## [v0.14.0] — 2026-04-16
+
+### Added
+
+- **Transmission BitTorrent downloader** — Bindery now supports Transmission as a second torrent client alongside qBittorrent. Configure it under **Settings → Download Clients** with host, port, optional SSL, and optional HTTP Basic credentials. The client handles Transmission's CSRF session-ID handshake (`409` + `X-Transmission-Session-Id`) transparently, validates all request targets to prevent SSRF, and enforces a redirect policy that refuses to follow redirects outside the configured RPC endpoint. Status polling and torrent removal are fully supported.
+- **Recommendation engine — Discover page** — a new **Discover** page (nav between Calendar and Queue) surfaces personalised book suggestions driven by a local content-based engine. All processing is on-device; no data leaves the instance. Feature is **opt-in** (off by default); enable it under **Settings → General → Recommendations**.
+
+  Five recommendation types:
+  - **Next in series** — detects books missing from series you've started and surfaces the next in sequence.
+  - **New from monitored authors** — highlights works by your monitored authors that aren't yet in your library.
+  - **Because of your genre** — recommends books from series in your library matching your genre profile (TF-IDF weighted).
+  - **Popular in your genres** *(Phase 2)* — queries the OpenLibrary `/subjects/{genre}` API for your top 5 genres (5 API calls per 24 h run) and surfaces well-regarded titles you haven't added.
+  - **From your reading list** *(Phase 2, optional)* — cross-references your Hardcover "Want to Read" shelf against your library and surfaces unowned books. Requires a Hardcover Bearer token in **Settings → `hardcover.api_token`**.
+
+  Cold-start handling: genre scoring requires ≥ 20 books; below that threshold only series and author-new rows appear. A serendipity row (5–10% of results, outside your top genres) prevents filter bubbles. Dismissing a book or excluding an author persists across regeneration cycles. "Add to Wanted" triggers an immediate indexer search.
+
+- **Settings gear icon + Blocklist tab** — the settings link in the navigation bar is now a gear icon (previously labelled text). A **Blocklist** tab has been added to Settings, consolidating all blocklist management in one place. The `/blocklist` URL now redirects to `/settings`.
+
+### Fixed
+
+- **Prowlarr Torznab protocol routing** — torrent releases sourced from Prowlarr Torznab indexers were previously submitted to any enabled download client. They are now dispatched exclusively to torrent-capable clients (Transmission, qBittorrent), preventing silent drops when a torrent URL reached a SABnzbd instance.
+
 ## [v0.13.0] — 2026-04-16
 
 ### Added

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -212,6 +212,14 @@ func main() {
 	// Recommendation engine (24-hour job, gated on recommendations.enabled).
 	recRepo := db.NewRecommendationRepo(database)
 	recEngine := recommender.New(bookRepo, authorRepo, seriesRepo, recRepo, settingsRepo)
+	// Wire OL client for genre-popular candidates (always available).
+	recEngine.WithOLClient(olClient)
+	// Wire HC client for list-cross candidates if a token is configured.
+	// Token is read once at startup; restart required if the token changes.
+	if s, _ := settingsRepo.Get(context.Background(), "hardcover.api_token"); s != nil && s.Value != "" {
+		recEngine.WithHCClient(hardcover.New().WithToken(s.Value))
+		slog.Info("hardcover wishlist integration enabled for recommendations")
+	}
 	sched.WithRecommender(recEngine)
 
 	sched.Start()

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -237,7 +237,7 @@ func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 		return nil, err
 	}
 
-	resp, err := c.http.Do(req) // #nosec G107 -- URL validated by validateRequestTarget; redirect policy enforced on client
+	resp, err := c.http.Do(req) // #nosec G107 G704 -- URL validated by validateRequestTarget; redirect policy enforced on client
 	if err != nil {
 		return nil, fmt.Errorf("request: %w", err)
 	}
@@ -261,7 +261,7 @@ func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 			if err := c.validateRequestTarget(req2.URL); err != nil {
 				return nil, err
 			}
-			resp2, err := c.http.Do(req2) // #nosec G107 -- retry with same validated RPC target; only session header updated
+			resp2, err := c.http.Do(req2) // #nosec G107 G704 -- retry with same validated RPC target; only session header updated
 			if err != nil {
 				return nil, fmt.Errorf("retry request: %w", err)
 			}

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -21,8 +21,10 @@ const (
 )
 
 // Client implements metadata.Provider for Hardcover.app using its public GraphQL API.
+// Set a Bearer token via WithToken to enable authenticated queries (e.g. GetUserWishlist).
 type Client struct {
-	http *http.Client
+	http  *http.Client
+	token string // optional Bearer token; required for user-specific queries
 }
 
 // New creates a new Hardcover client.
@@ -30,6 +32,12 @@ func New() *Client {
 	return &Client{
 		http: &http.Client{Timeout: 15 * time.Second},
 	}
+}
+
+// WithToken returns a copy of the client configured to use the given Bearer token.
+// Required for authenticated queries such as GetUserWishlist.
+func (c *Client) WithToken(token string) *Client {
+	return &Client{http: c.http, token: token}
 }
 
 func (c *Client) Name() string { return "hardcover" }
@@ -194,6 +202,71 @@ func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, 
 	return &b, nil
 }
 
+// GetUserWishlist fetches the authenticated user's "Want to Read" books.
+// Returns candidates suitable for list-cross recommendations.
+// Requires the client to have a Bearer token set via WithToken; returns nil if not configured.
+func (c *Client) GetUserWishlist(ctx context.Context, limit int) ([]models.RecommendationCandidate, error) {
+	if c.token == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	// status_id 1 = "Want to Read" in Hardcover's reading status enum.
+	gql := `query GetWishlist($limit: Int!) {
+		me {
+			user_books(where: {status_id: {_eq: 1}}, limit: $limit) {
+				book {
+					id
+					title
+					slug
+					description
+					image { url }
+					release_year
+					ratings_count
+					rating
+					contributions {
+						author { id name slug }
+					}
+				}
+			}
+		}
+	}`
+	var resp struct {
+		Data struct {
+			Me struct {
+				UserBooks []struct {
+					Book hcBook `json:"book"`
+				} `json:"user_books"`
+			} `json:"me"`
+		} `json:"data"`
+	}
+	if err := c.query(ctx, gql, map[string]any{"limit": limit}, &resp); err != nil {
+		return nil, fmt.Errorf("hardcover get wishlist: %w", err)
+	}
+
+	candidates := make([]models.RecommendationCandidate, 0, len(resp.Data.Me.UserBooks))
+	for _, ub := range resp.Data.Me.UserBooks {
+		b := c.toBook(ub.Book)
+		cand := models.RecommendationCandidate{
+			ForeignID:    b.ForeignID,
+			Title:        b.Title,
+			ImageURL:     b.ImageURL,
+			Description:  b.Description,
+			Rating:       b.AverageRating,
+			RatingsCount: b.RatingsCount,
+			ReleaseDate:  b.ReleaseDate,
+			MediaType:    models.MediaTypeEbook,
+			Genres:       []string{},
+		}
+		if b.Author != nil {
+			cand.AuthorName = b.Author.Name
+		}
+		candidates = append(candidates, cand)
+	}
+	return candidates, nil
+}
+
 // --- GraphQL transport ---
 
 type gqlRequest struct {
@@ -213,6 +286,9 @@ func (c *Client) query(ctx context.Context, q string, vars map[string]any, out i
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "Bindery/0.1 (https://github.com/vavallee/bindery)")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -302,6 +302,43 @@ func (c *Client) GetEditions(ctx context.Context, bookForeignID string) ([]model
 	return editions, nil
 }
 
+// GetSubjectBooks fetches the top books for an OpenLibrary subject.
+// subject should be a lowercase slug using underscores, e.g. "science_fiction" or "fantasy".
+// Returns candidates suitable for use as genre-popular recommendations.
+func (c *Client) GetSubjectBooks(ctx context.Context, subject string, limit int) ([]models.RecommendationCandidate, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	u := fmt.Sprintf("%s/subjects/%s.json?limit=%d", baseURL, url.PathEscape(subject), limit)
+	var resp subjectBooksResponse
+	if err := c.getJSON(ctx, u, &resp); err != nil {
+		return nil, fmt.Errorf("get subject books %q: %w", subject, err)
+	}
+
+	candidates := make([]models.RecommendationCandidate, 0, len(resp.Works))
+	for _, w := range resp.Works {
+		workID := strings.TrimPrefix(w.Key, "/works/")
+		cand := models.RecommendationCandidate{
+			ForeignID: workID,
+			Title:     w.Title,
+			Genres:    truncateSlice(w.Subject, 10),
+			MediaType: models.MediaTypeEbook,
+		}
+		if w.CoverID != nil && *w.CoverID > 0 {
+			cand.ImageURL = fmt.Sprintf("%s/b/id/%d-L.jpg", coverURL, *w.CoverID)
+		}
+		if w.FirstPublishYear > 0 {
+			t := time.Date(w.FirstPublishYear, 1, 1, 0, 0, 0, 0, time.UTC)
+			cand.ReleaseDate = &t
+		}
+		if len(w.Authors) > 0 {
+			cand.AuthorName = w.Authors[0].Name
+		}
+		candidates = append(candidates, cand)
+	}
+	return candidates, nil
+}
+
 func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, error) {
 	u := fmt.Sprintf("%s/isbn/%s.json", baseURL, isbn)
 	var resp isbnResponse

--- a/internal/metadata/openlibrary/types.go
+++ b/internal/metadata/openlibrary/types.go
@@ -112,3 +112,25 @@ type isbnResponse struct {
 	} `json:"authors"`
 	Covers []int `json:"covers"`
 }
+
+// subjectBooksResponse is the OpenLibrary /subjects/{subject}.json response.
+type subjectBooksResponse struct {
+	Name      string        `json:"name"`
+	WorkCount int           `json:"work_count"`
+	Works     []subjectWork `json:"works"`
+}
+
+// subjectWork is a single work entry inside subjectBooksResponse.
+// Note: the subjects API uses "cover_id" (not "cover_i" like the search API).
+type subjectWork struct {
+	Key     string `json:"key"`   // "/works/OL123W"
+	Title   string `json:"title"`
+	Authors []struct {
+		Key  string `json:"key"`  // "/authors/OL123A"
+		Name string `json:"name"`
+	} `json:"authors"`
+	CoverID          *int     `json:"cover_id"`
+	FirstPublishYear int      `json:"first_publish_year"`
+	Subject          []string `json:"subject"`
+	EditionCount     int      `json:"edition_count"`
+}

--- a/internal/metadata/openlibrary/types.go
+++ b/internal/metadata/openlibrary/types.go
@@ -123,10 +123,10 @@ type subjectBooksResponse struct {
 // subjectWork is a single work entry inside subjectBooksResponse.
 // Note: the subjects API uses "cover_id" (not "cover_i" like the search API).
 type subjectWork struct {
-	Key     string `json:"key"`   // "/works/OL123W"
+	Key     string `json:"key"` // "/works/OL123W"
 	Title   string `json:"title"`
 	Authors []struct {
-		Key  string `json:"key"`  // "/authors/OL123A"
+		Key  string `json:"key"` // "/authors/OL123A"
 		Name string `json:"name"`
 	} `json:"authors"`
 	CoverID          *int     `json:"cover_id"`

--- a/internal/recommender/candidates.go
+++ b/internal/recommender/candidates.go
@@ -11,6 +11,19 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
+// SubjectBooksFetcher retrieves popular books for a genre/subject from an external API.
+// *openlibrary.Client satisfies this interface once GetSubjectBooks is implemented.
+// The interface lives here to keep the recommender package free of a direct openlibrary import.
+type SubjectBooksFetcher interface {
+	GetSubjectBooks(ctx context.Context, subject string, limit int) ([]models.RecommendationCandidate, error)
+}
+
+// WishlistFetcher retrieves the authenticated user's reading wishlist from an external service.
+// *hardcover.Client (with a Bearer token) satisfies this interface.
+type WishlistFetcher interface {
+	GetUserWishlist(ctx context.Context, limit int) ([]models.RecommendationCandidate, error)
+}
+
 // GenerateSeries produces candidates for the next unowned book in each series
 // the user has started.
 func GenerateSeries(
@@ -215,6 +228,77 @@ func GenerateSerendipity(
 		pool = pool[:count]
 	}
 	return pool
+}
+
+// GenerateGenrePopular fetches popular books from OpenLibrary for the user's
+// top genres. Up to genreCount genres are queried, returning up to booksPerGenre
+// results each. Only runs when an olClient is wired in.
+func GenerateGenrePopular(
+	ctx context.Context,
+	ol SubjectBooksFetcher,
+	profile *UserProfile,
+	genreCount int,
+	booksPerGenre int,
+) []models.RecommendationCandidate {
+	if ol == nil || len(profile.GenreWeights) == 0 {
+		return nil
+	}
+
+	topGenres := topNGenres(profile, genreCount)
+	var candidates []models.RecommendationCandidate
+
+	for genre := range topGenres {
+		slug := genreToSubjectSlug(genre)
+		books, err := ol.GetSubjectBooks(ctx, slug, booksPerGenre)
+		if err != nil {
+			slog.Warn("recommender: OL subject fetch failed", "genre", genre, "error", err)
+			continue
+		}
+		for i := range books {
+			books[i].RecType = models.RecTypeGenrePopular
+			books[i].Reason = fmt.Sprintf("Popular in %s", genre)
+		}
+		candidates = append(candidates, books...)
+	}
+	return candidates
+}
+
+// GenerateListCross surfaces books from the user's external reading wishlist
+// that aren't already in the library. Requires a WishlistFetcher (e.g. a
+// Hardcover client with a token); returns nil if not wired in.
+func GenerateListCross(
+	ctx context.Context,
+	hc WishlistFetcher,
+	profile *UserProfile,
+	limit int,
+) []models.RecommendationCandidate {
+	if hc == nil {
+		return nil
+	}
+
+	books, err := hc.GetUserWishlist(ctx, limit)
+	if err != nil {
+		slog.Warn("recommender: failed to fetch wishlist", "error", err)
+		return nil
+	}
+
+	var candidates []models.RecommendationCandidate
+	for i := range books {
+		if profile.OwnedForeignIDs[books[i].ForeignID] {
+			continue
+		}
+		books[i].RecType = models.RecTypeListCross
+		books[i].Reason = "From your reading list"
+		candidates = append(candidates, books[i])
+	}
+	return candidates
+}
+
+// genreToSubjectSlug converts a genre string (e.g. "Science Fiction") to an
+// OpenLibrary subject slug (e.g. "science_fiction").
+func genreToSubjectSlug(genre string) string {
+	s := strings.ToLower(strings.TrimSpace(genre))
+	return strings.ReplaceAll(s, " ", "_")
 }
 
 // bookToCandidate converts a models.Book into a RecommendationCandidate.

--- a/internal/recommender/recommender.go
+++ b/internal/recommender/recommender.go
@@ -17,6 +17,8 @@ type Engine struct {
 	series   *db.SeriesRepo
 	recs     *db.RecommendationRepo
 	settings *db.SettingsRepo
+	olClient SubjectBooksFetcher // optional; enables genre-popular candidates
+	hcClient WishlistFetcher     // optional; enables list-cross candidates
 }
 
 // New creates a new recommendation engine.
@@ -34,6 +36,20 @@ func New(
 		recs:     recs,
 		settings: settings,
 	}
+}
+
+// WithOLClient wires in an OpenLibrary client for genre-popular candidates.
+// Must be called before the first Run.
+func (e *Engine) WithOLClient(c SubjectBooksFetcher) *Engine {
+	e.olClient = c
+	return e
+}
+
+// WithHCClient wires in a Hardcover client for list-cross candidates.
+// The client must already have a Bearer token set. Must be called before the first Run.
+func (e *Engine) WithHCClient(c WishlistFetcher) *Engine {
+	e.hcClient = c
+	return e
 }
 
 // Run generates recommendations for the given user. It builds a taste profile,
@@ -71,8 +87,22 @@ func (e *Engine) Run(ctx context.Context, userID int64) error {
 		genreSimilar := GenerateGenreSimilar(ctx, e.books, e.series, profile)
 		candidates = append(candidates, genreSimilar...)
 		slog.Info("recommender: genre-similar candidates", "count", len(genreSimilar))
+
+		// Genre-popular: top 5 genres × OpenLibrary subjects API (5 calls).
+		if e.olClient != nil {
+			genrePopular := GenerateGenrePopular(ctx, e.olClient, profile, 5, 20)
+			candidates = append(candidates, genrePopular...)
+			slog.Info("recommender: genre-popular candidates", "count", len(genrePopular))
+		}
 	} else {
 		slog.Info("recommender: cold start (< 20 books), skipping genre scoring")
+	}
+
+	// List cross-reference: books on user's external wishlist not in library.
+	if e.hcClient != nil {
+		listCross := GenerateListCross(ctx, e.hcClient, profile, 100)
+		candidates = append(candidates, listCross...)
+		slog.Info("recommender: list-cross candidates", "count", len(listCross))
 	}
 
 	// Score all candidates.


### PR DESCRIPTION
## Summary

- **genre_popular**: fetches popular books from OpenLibrary `/subjects/{genre}.json` for the user's top 5 genres (≤20 books/genre, 5 API calls per 24h run). Gated on the existing ≥20 book cold-start threshold.
- **list_cross**: surfaces books from the user's Hardcover "Want to Read" shelf not already in the library. Requires `hardcover.api_token` setting; no-ops gracefully without it.
- New interfaces `SubjectBooksFetcher` and `WishlistFetcher` in the recommender package keep it free of direct provider imports.
- Hardcover client gains `WithToken(token)` + Bearer auth header support for authenticated queries.

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go vet ./...` — clean
- [ ] With recommendations enabled and ≥20 books in library: trigger `POST /api/v1/recommendations/refresh` → `GET /api/v1/recommendations` → confirm `genre_popular` entries appear
- [ ] Set `hardcover.api_token` in settings and restart → confirm `hardcover wishlist integration enabled` log line; `list_cross` recs appear after next refresh
- [ ] Without `hardcover.api_token`: no `list_cross` recs, no errors
- [ ] Cold start (< 20 books): `genre_popular` skipped, no OL API calls