### PR TITLE
fix(pagination): share page size across tabs

### DIFF
--- a/web/src/components/usePagination.ts
+++ b/web/src/components/usePagination.ts
@@ -1,23 +1,32 @@
 import { useMemo, useState } from 'react'
 
+const SHARED_PAGE_SIZE_KEY = 'pageSize:shared'
+
+function readStoredPageSize(storageKey: string | undefined): number | null {
+  const keys = storageKey ? [`pageSize:${storageKey}`, SHARED_PAGE_SIZE_KEY] : [SHARED_PAGE_SIZE_KEY]
+  for (const key of keys) {
+    const stored = localStorage.getItem(key)
+    if (stored) {
+      const n = parseInt(stored, 10)
+      if (!isNaN(n) && n > 0) return n
+    }
+  }
+  return null
+}
+
 /**
  * usePagination: client-side slicing helper.
  * Pass the full filtered list; get back the visible page + props for Pagination.
  *
  * storageKey: when provided, page size is persisted to localStorage under that
- * key so the user's preference survives navigation and page reloads.
+ * key so the user's preference survives navigation and page reloads. A shared
+ * key is also written so that when the user first visits a new tab, they see
+ * the page size they last picked elsewhere.
  */
 export function usePagination<T>(items: T[], defaultPageSize = 50, storageKey?: string) {
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(() => {
-    if (storageKey) {
-      const stored = localStorage.getItem(`pageSize:${storageKey}`)
-      if (stored) {
-        const n = parseInt(stored, 10)
-        if (!isNaN(n) && n > 0) return n
-      }
-    }
-    return defaultPageSize
+    return readStoredPageSize(storageKey) ?? defaultPageSize
   })
 
   const totalPages = Math.max(1, Math.ceil(items.length / pageSize))
@@ -32,6 +41,7 @@ export function usePagination<T>(items: T[], defaultPageSize = 50, storageKey?: 
     if (storageKey) {
       localStorage.setItem(`pageSize:${storageKey}`, String(size))
     }
+    localStorage.setItem(SHARED_PAGE_SIZE_KEY, String(size))
   }
 
   return {


### PR DESCRIPTION
## Summary

Addresses the \"page size resets when I switch tabs\" UX issue. The per-page `pageSize:<tab>` key is preserved, but on first visit to a tab we now fall back to a shared `pageSize:shared` key so the user's last choice carries across Authors / Books / Wanted / History / Blocklist.

## Behaviour

- First-time visit to a tab: reads `pageSize:<tab>` first, then `pageSize:shared`, then default (50).
- Changing page size on any tab writes to both `pageSize:<tab>` and `pageSize:shared`.
- Existing per-tab choices continue to win — no retroactive flattening.

## Test plan

- [ ] Fresh localStorage: set page size to 100 on Authors, navigate to Books — should open at 100.
- [ ] Set 25 on Wanted, 100 on Books — each tab remembers its own value.
- [ ] Reload browser — both values persist.