### PR TITLE
chore: v0.15.0 prep — docs, test coverage, and UI tests

### DIFF
--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -462,6 +462,186 @@ func TestSortName(t *testing.T) {
 	}
 }
 
+// --- WithToken / GetUserWishlist ---
+
+func TestWithToken(t *testing.T) {
+	c := New()
+	if c.token != "" {
+		t.Errorf("fresh client should have no token, got %q", c.token)
+	}
+	c2 := c.WithToken("secret-jwt")
+	if c2.token != "secret-jwt" {
+		t.Errorf("WithToken: want 'secret-jwt', got %q", c2.token)
+	}
+	// Original client must be unchanged.
+	if c.token != "" {
+		t.Errorf("WithToken should return a copy; original mutated to %q", c.token)
+	}
+	// Shared underlying HTTP client.
+	if c.http != c2.http {
+		t.Error("expected WithToken to share the underlying http.Client")
+	}
+}
+
+func TestGetUserWishlist_NoToken(t *testing.T) {
+	// Without a token, GetUserWishlist must return (nil, nil) without calling the API.
+	called := false
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		called = true
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{}), nil
+	})
+
+	candidates, err := c.GetUserWishlist(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("GetUserWishlist: %v", err)
+	}
+	if candidates != nil {
+		t.Errorf("expected nil candidates without token, got %v", candidates)
+	}
+	if called {
+		t.Error("GetUserWishlist must not call the API without a token")
+	}
+}
+
+func TestGetUserWishlist_Success(t *testing.T) {
+	var gotAuth string
+	year := 2019
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		gotAuth = r.Header.Get("Authorization")
+		data := map[string]interface{}{
+			"me": map[string]interface{}{
+				"user_books": []map[string]interface{}{
+					{
+						"book": map[string]interface{}{
+							"id":            101,
+							"title":         "Project Hail Mary",
+							"slug":          "project-hail-mary",
+							"description":   "An astronaut wakes up alone.",
+							"release_year":  year,
+							"rating":        4.7,
+							"ratings_count": 50000,
+							"image":         map[string]interface{}{"url": "https://img.example.com/phm.jpg"},
+							"contributions": []map[string]interface{}{
+								{"author": map[string]interface{}{"id": 7, "name": "Andy Weir", "slug": "andy-weir"}},
+							},
+						},
+					},
+					{
+						"book": map[string]interface{}{
+							"id":    102,
+							"title": "Dune",
+							"slug":  "dune",
+						},
+					},
+				},
+			},
+		}
+		return gqlResponse(t, http.StatusOK, data), nil
+	})
+	c = c.WithToken("my-jwt")
+
+	candidates, err := c.GetUserWishlist(context.Background(), 100)
+	if err != nil {
+		t.Fatalf("GetUserWishlist: %v", err)
+	}
+	if gotAuth != "Bearer my-jwt" {
+		t.Errorf("Authorization header: want 'Bearer my-jwt', got %q", gotAuth)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(candidates))
+	}
+
+	first := candidates[0]
+	if first.ForeignID != "hc:project-hail-mary" {
+		t.Errorf("ForeignID: want 'hc:project-hail-mary', got %q", first.ForeignID)
+	}
+	if first.Title != "Project Hail Mary" {
+		t.Errorf("Title: want 'Project Hail Mary', got %q", first.Title)
+	}
+	if first.AuthorName != "Andy Weir" {
+		t.Errorf("AuthorName: want 'Andy Weir', got %q", first.AuthorName)
+	}
+	if first.Rating != 4.7 {
+		t.Errorf("Rating: want 4.7, got %f", first.Rating)
+	}
+	if first.RatingsCount != 50000 {
+		t.Errorf("RatingsCount: want 50000, got %d", first.RatingsCount)
+	}
+	if first.ReleaseDate == nil || first.ReleaseDate.Year() != 2019 {
+		t.Errorf("ReleaseDate: expected 2019, got %v", first.ReleaseDate)
+	}
+	if first.MediaType != "ebook" {
+		t.Errorf("MediaType: want 'ebook', got %q", first.MediaType)
+	}
+	if first.ImageURL != "https://img.example.com/phm.jpg" {
+		t.Errorf("ImageURL: got %q", first.ImageURL)
+	}
+
+	// Second candidate: no contributions/image → empty author, empty URL.
+	second := candidates[1]
+	if second.AuthorName != "" {
+		t.Errorf("second AuthorName should be empty, got %q", second.AuthorName)
+	}
+	if second.ImageURL != "" {
+		t.Errorf("second ImageURL should be empty, got %q", second.ImageURL)
+	}
+}
+
+func TestGetUserWishlist_DefaultLimit(t *testing.T) {
+	// limit <= 0 must be coerced to 100 in the GraphQL variables.
+	var gotVars map[string]any
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		var req gqlRequest
+		_ = json.Unmarshal(body, &req)
+		gotVars = req.Variables
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{
+			"me": map[string]interface{}{"user_books": []interface{}{}},
+		}), nil
+	})
+	c = c.WithToken("t")
+
+	_, err := c.GetUserWishlist(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("GetUserWishlist: %v", err)
+	}
+	// JSON numbers decode as float64.
+	if v, ok := gotVars["limit"].(float64); !ok || v != 100 {
+		t.Errorf("limit variable: want 100, got %v", gotVars["limit"])
+	}
+}
+
+func TestGetUserWishlist_Empty(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{
+			"me": map[string]interface{}{"user_books": []interface{}{}},
+		}), nil
+	}).WithToken("t")
+
+	candidates, err := c.GetUserWishlist(context.Background(), 50)
+	if err != nil {
+		t.Fatalf("GetUserWishlist: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Errorf("expected 0 candidates, got %d", len(candidates))
+	}
+}
+
+func TestGetUserWishlist_HTTPError(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body:       io.NopCloser(strings.NewReader("bad token")),
+			Header:     make(http.Header),
+		}, nil
+	}).WithToken("bad-token")
+
+	_, err := c.GetUserWishlist(context.Background(), 10)
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+}
+
 func TestQuery_RequestFormat(t *testing.T) {
 	var gotBody []byte
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -659,6 +659,146 @@ func TestGetAuthorWorks_HTTP_LangPreferEng(t *testing.T) {
 	}
 }
 
+// --- GetSubjectBooks ---
+
+func TestGetSubjectBooks_HTTP(t *testing.T) {
+	coverID := 99999
+	resp := subjectBooksResponse{
+		Name:      "Fantasy",
+		WorkCount: 2,
+		Works: []subjectWork{
+			{
+				Key:              "/works/OL1111W",
+				Title:            "Popular Fantasy",
+				CoverID:          &coverID,
+				FirstPublishYear: 2015,
+				Subject:          []string{"Fantasy", "Adventure"},
+				Authors: []struct {
+					Key  string `json:"key"`
+					Name string `json:"name"`
+				}{
+					{Key: "/authors/OL10A", Name: "Famous Author"},
+				},
+			},
+			{
+				Key:   "/works/OL2222W",
+				Title: "No Cover Work",
+			},
+		},
+	}
+
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/subjects/fantasy.json": jsonStr(resp),
+	})
+
+	candidates, err := c.GetSubjectBooks(context.Background(), "fantasy", 20)
+	if err != nil {
+		t.Fatalf("GetSubjectBooks: %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(candidates))
+	}
+
+	first := candidates[0]
+	if first.ForeignID != "OL1111W" {
+		t.Errorf("ForeignID: want 'OL1111W', got %q", first.ForeignID)
+	}
+	if first.Title != "Popular Fantasy" {
+		t.Errorf("Title: want 'Popular Fantasy', got %q", first.Title)
+	}
+	if first.AuthorName != "Famous Author" {
+		t.Errorf("AuthorName: want 'Famous Author', got %q", first.AuthorName)
+	}
+	if first.ReleaseDate == nil || first.ReleaseDate.Year() != 2015 {
+		t.Errorf("ReleaseDate: expected 2015, got %v", first.ReleaseDate)
+	}
+	if !strings.Contains(first.ImageURL, "99999") {
+		t.Errorf("ImageURL should contain cover ID 99999, got %q", first.ImageURL)
+	}
+	if first.MediaType != "ebook" {
+		t.Errorf("MediaType: want 'ebook', got %q", first.MediaType)
+	}
+	if len(first.Genres) != 2 {
+		t.Errorf("Genres: want 2, got %d", len(first.Genres))
+	}
+
+	// Second candidate: no cover, no authors.
+	second := candidates[1]
+	if second.ImageURL != "" {
+		t.Errorf("second ImageURL should be empty, got %q", second.ImageURL)
+	}
+	if second.AuthorName != "" {
+		t.Errorf("second AuthorName should be empty, got %q", second.AuthorName)
+	}
+}
+
+func TestGetSubjectBooks_HTTP_DefaultLimit(t *testing.T) {
+	// Limit <= 0 defaults to 20. Assert the URL passed to the server contains limit=20.
+	var gotURL string
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/subjects/scifi.json": func(r *http.Request) string {
+			gotURL = r.URL.String()
+			return jsonStr(subjectBooksResponse{})
+		},
+	})
+
+	_, err := c.GetSubjectBooks(context.Background(), "scifi", 0)
+	if err != nil {
+		t.Fatalf("GetSubjectBooks: %v", err)
+	}
+	if !strings.Contains(gotURL, "limit=20") {
+		t.Errorf("URL should default limit to 20, got %q", gotURL)
+	}
+}
+
+func TestGetSubjectBooks_HTTP_Error(t *testing.T) {
+	c := newClientWithStatus(t,
+		map[string]interface{}{"/subjects/horror.json": "oops"},
+		map[string]int{"/subjects/horror.json": http.StatusInternalServerError},
+	)
+	_, err := c.GetSubjectBooks(context.Background(), "horror", 5)
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+}
+
+func TestGetSubjectBooks_HTTP_Empty(t *testing.T) {
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/subjects/obscure.json": jsonStr(subjectBooksResponse{Name: "Obscure"}),
+	})
+	candidates, err := c.GetSubjectBooks(context.Background(), "obscure", 5)
+	if err != nil {
+		t.Fatalf("GetSubjectBooks: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Errorf("expected 0 candidates, got %d", len(candidates))
+	}
+}
+
+func TestGetSubjectBooks_HTTP_NegativeCover(t *testing.T) {
+	// OpenLibrary sometimes returns cover_id=-1 meaning "no cover". Must not build a URL.
+	negCover := -1
+	resp := subjectBooksResponse{
+		Works: []subjectWork{
+			{Key: "/works/OL9W", Title: "No Cover", CoverID: &negCover},
+		},
+	}
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/subjects/romance.json": jsonStr(resp),
+	})
+
+	candidates, err := c.GetSubjectBooks(context.Background(), "romance", 5)
+	if err != nil {
+		t.Fatalf("GetSubjectBooks: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(candidates))
+	}
+	if candidates[0].ImageURL != "" {
+		t.Errorf("negative cover ID should produce empty ImageURL, got %q", candidates[0].ImageURL)
+	}
+}
+
 // --- Helper functions ---
 
 func TestName_OL(t *testing.T) {

--- a/internal/recommender/candidates_test.go
+++ b/internal/recommender/candidates_test.go
@@ -1,0 +1,268 @@
+package recommender
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestGenreToSubjectSlug(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"Science Fiction", "science_fiction"},
+		{"FANTASY", "fantasy"},
+		{"  horror  ", "horror"},
+		{"Young Adult", "young_adult"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := genreToSubjectSlug(tt.in); got != tt.want {
+			t.Errorf("genreToSubjectSlug(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestParsePosition(t *testing.T) {
+	tests := []struct {
+		in   string
+		want float64
+	}{
+		{"", 0},
+		{"1", 1},
+		{"2.5", 2.5},
+		{"  3  ", 3},
+		{"not-a-number", 0},
+	}
+	for _, tt := range tests {
+		if got := parsePosition(tt.in); got != tt.want {
+			t.Errorf("parsePosition(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestBookToCandidate(t *testing.T) {
+	aid := int64(5)
+	b := &models.Book{
+		ForeignID:     "OL1W",
+		Title:         "Test",
+		AuthorID:      aid,
+		ImageURL:      "https://img",
+		Description:   "desc",
+		Genres:        []string{"fantasy"},
+		AverageRating: 4.2,
+		RatingsCount:  100,
+		Language:      "eng",
+		MediaType:     models.MediaTypeAudiobook,
+	}
+	c := bookToCandidate(b)
+	if c.ForeignID != "OL1W" || c.Title != "Test" {
+		t.Errorf("basic fields not copied: %+v", c)
+	}
+	if c.AuthorID == nil || *c.AuthorID != 5 {
+		t.Errorf("AuthorID not copied: %v", c.AuthorID)
+	}
+	if c.Rating != 4.2 || c.RatingsCount != 100 {
+		t.Errorf("rating fields not copied: %v / %d", c.Rating, c.RatingsCount)
+	}
+	if c.MediaType != models.MediaTypeAudiobook {
+		t.Errorf("MediaType: want %q, got %q", models.MediaTypeAudiobook, c.MediaType)
+	}
+
+	// Empty MediaType defaults to ebook.
+	b2 := &models.Book{ForeignID: "x", Title: "y"}
+	if got := bookToCandidate(b2); got.MediaType != models.MediaTypeEbook {
+		t.Errorf("default MediaType: got %q, want ebook", got.MediaType)
+	}
+}
+
+func TestTopGenre(t *testing.T) {
+	p := &UserProfile{GenreWeights: map[string]float64{
+		"fantasy": 0.9, "scifi": 0.5, "romance": 0.3,
+	}}
+	if got := topGenre(p); got != "fantasy" {
+		t.Errorf("want 'fantasy', got %q", got)
+	}
+
+	// Empty profile
+	empty := &UserProfile{GenreWeights: map[string]float64{}}
+	if got := topGenre(empty); got != "" {
+		t.Errorf("empty profile: want '', got %q", got)
+	}
+}
+
+func TestTopNGenres(t *testing.T) {
+	p := &UserProfile{GenreWeights: map[string]float64{
+		"a": 1.0, "b": 0.9, "c": 0.8, "d": 0.1, "e": 0.05,
+	}}
+	top3 := topNGenres(p, 3)
+	if len(top3) != 3 {
+		t.Fatalf("expected 3 genres, got %d", len(top3))
+	}
+	for _, g := range []string{"a", "b", "c"} {
+		if !top3[g] {
+			t.Errorf("missing expected genre %q", g)
+		}
+	}
+
+	// Request more than available → return all
+	all := topNGenres(p, 100)
+	if len(all) != 5 {
+		t.Errorf("expected 5 genres, got %d", len(all))
+	}
+}
+
+func TestHasTopGenre(t *testing.T) {
+	top := map[string]bool{"fantasy": true, "scifi": true}
+	if !hasTopGenre([]string{"Fantasy"}, top) {
+		t.Error("case-insensitive match should succeed")
+	}
+	if !hasTopGenre([]string{"romance", "  SCIFI  "}, top) {
+		t.Error("trimmed/cased match should succeed")
+	}
+	if hasTopGenre([]string{"romance", "horror"}, top) {
+		t.Error("no overlap should return false")
+	}
+	if hasTopGenre(nil, top) {
+		t.Error("nil slice should return false")
+	}
+}
+
+// --- GenerateGenrePopular ---
+
+type fakeSubjectFetcher struct {
+	called    []string // subjects requested
+	responses map[string][]models.RecommendationCandidate
+	err       error
+}
+
+func (f *fakeSubjectFetcher) GetSubjectBooks(_ context.Context, subject string, _ int) ([]models.RecommendationCandidate, error) {
+	f.called = append(f.called, subject)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.responses[subject], nil
+}
+
+func TestGenerateGenrePopular_NilClient(t *testing.T) {
+	got := GenerateGenrePopular(context.Background(), nil, &UserProfile{GenreWeights: map[string]float64{"x": 1}}, 5, 20)
+	if got != nil {
+		t.Errorf("expected nil for nil client, got %v", got)
+	}
+}
+
+func TestGenerateGenrePopular_EmptyProfile(t *testing.T) {
+	f := &fakeSubjectFetcher{}
+	got := GenerateGenrePopular(context.Background(), f, &UserProfile{GenreWeights: map[string]float64{}}, 5, 20)
+	if got != nil {
+		t.Errorf("expected nil for empty profile, got %v", got)
+	}
+	if len(f.called) != 0 {
+		t.Errorf("fetcher should not have been called, got %v", f.called)
+	}
+}
+
+func TestGenerateGenrePopular_Success(t *testing.T) {
+	f := &fakeSubjectFetcher{
+		responses: map[string][]models.RecommendationCandidate{
+			"fantasy": {
+				{ForeignID: "OL1W", Title: "Book 1"},
+				{ForeignID: "OL2W", Title: "Book 2"},
+			},
+		},
+	}
+	profile := &UserProfile{
+		GenreWeights: map[string]float64{"fantasy": 1.0},
+	}
+	got := GenerateGenrePopular(context.Background(), f, profile, 1, 20)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(got))
+	}
+	for _, c := range got {
+		if c.RecType != models.RecTypeGenrePopular {
+			t.Errorf("RecType: want %q, got %q", models.RecTypeGenrePopular, c.RecType)
+		}
+		if c.Reason == "" {
+			t.Error("expected non-empty Reason")
+		}
+	}
+	if len(f.called) != 1 || f.called[0] != "fantasy" {
+		t.Errorf("fetcher should be called with 'fantasy', got %v", f.called)
+	}
+}
+
+func TestGenerateGenrePopular_FetchError(t *testing.T) {
+	f := &fakeSubjectFetcher{err: errors.New("boom")}
+	profile := &UserProfile{GenreWeights: map[string]float64{"fantasy": 1.0}}
+	// Errors must be swallowed; we get an empty (but not nil-panic) result.
+	got := GenerateGenrePopular(context.Background(), f, profile, 1, 20)
+	if len(got) != 0 {
+		t.Errorf("expected no candidates on error, got %d", len(got))
+	}
+}
+
+// --- GenerateListCross ---
+
+type fakeWishlistFetcher struct {
+	called int
+	books  []models.RecommendationCandidate
+	err    error
+}
+
+func (f *fakeWishlistFetcher) GetUserWishlist(_ context.Context, _ int) ([]models.RecommendationCandidate, error) {
+	f.called++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.books, nil
+}
+
+func TestGenerateListCross_NilClient(t *testing.T) {
+	got := GenerateListCross(context.Background(), nil, &UserProfile{}, 50)
+	if got != nil {
+		t.Errorf("expected nil for nil client, got %v", got)
+	}
+}
+
+func TestGenerateListCross_FilterOwned(t *testing.T) {
+	f := &fakeWishlistFetcher{
+		books: []models.RecommendationCandidate{
+			{ForeignID: "OL1W", Title: "Want 1"},
+			{ForeignID: "OL2W", Title: "Own Already"}, // filtered
+			{ForeignID: "OL3W", Title: "Want 3"},
+		},
+	}
+	profile := &UserProfile{
+		OwnedForeignIDs: map[string]bool{"OL2W": true},
+	}
+	got := GenerateListCross(context.Background(), f, profile, 50)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 candidates after filtering, got %d", len(got))
+	}
+	for _, c := range got {
+		if c.RecType != models.RecTypeListCross {
+			t.Errorf("RecType: want %q, got %q", models.RecTypeListCross, c.RecType)
+		}
+		if c.ForeignID == "OL2W" {
+			t.Error("owned book should have been filtered out")
+		}
+	}
+}
+
+func TestGenerateListCross_FetchError(t *testing.T) {
+	f := &fakeWishlistFetcher{err: errors.New("nope")}
+	got := GenerateListCross(context.Background(), f, &UserProfile{}, 50)
+	if got != nil {
+		t.Errorf("expected nil on fetch error, got %v", got)
+	}
+}
+
+func TestGenerateListCross_EmptyResult(t *testing.T) {
+	f := &fakeWishlistFetcher{books: []models.RecommendationCandidate{}}
+	got := GenerateListCross(context.Background(), f, &UserProfile{}, 50)
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %d", len(got))
+	}
+}

--- a/internal/recommender/profile_test.go
+++ b/internal/recommender/profile_test.go
@@ -1,0 +1,222 @@
+package recommender
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// profileFixtures holds repos and a user ID backing a fresh in-memory DB.
+type profileFixtures struct {
+	books    *db.BookRepo
+	authors  *db.AuthorRepo
+	series   *db.SeriesRepo
+	recs     *db.RecommendationRepo
+	settings *db.SettingsRepo
+	userID   int64
+}
+
+func newProfileFixtures(t *testing.T) profileFixtures {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	users := db.NewUserRepo(database)
+	u, err := users.Create(context.Background(), "alice", "hash")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	return profileFixtures{
+		books:    db.NewBookRepo(database),
+		authors:  db.NewAuthorRepo(database),
+		series:   db.NewSeriesRepo(database),
+		recs:     db.NewRecommendationRepo(database),
+		settings: db.NewSettingsRepo(database),
+		userID:   u.ID,
+	}
+}
+
+func seedAuthor(t *testing.T, f profileFixtures, name, foreignID string, monitored bool) *models.Author {
+	t.Helper()
+	a := &models.Author{
+		ForeignID:        foreignID,
+		Name:             name,
+		SortName:         name,
+		MetadataProvider: "openlibrary",
+		Monitored:        monitored,
+	}
+	if err := f.authors.Create(context.Background(), a); err != nil {
+		t.Fatalf("create author: %v", err)
+	}
+	return a
+}
+
+func seedBook(t *testing.T, f profileFixtures, authorID int64, foreignID, title string, genres []string) *models.Book {
+	t.Helper()
+	b := &models.Book{
+		ForeignID:        foreignID,
+		AuthorID:         authorID,
+		Title:            title,
+		SortTitle:        title,
+		Genres:           genres,
+		Status:           models.BookStatusWanted,
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := f.books.Create(context.Background(), b); err != nil {
+		t.Fatalf("create book: %v", err)
+	}
+	return b
+}
+
+func TestBuildProfile_Empty(t *testing.T) {
+	f := newProfileFixtures(t)
+	p, err := BuildProfile(context.Background(), f.userID, f.books, f.authors, f.series, f.recs, f.settings)
+	if err != nil {
+		t.Fatalf("BuildProfile: %v", err)
+	}
+	if p.TotalBooks != 0 {
+		t.Errorf("TotalBooks: want 0, got %d", p.TotalBooks)
+	}
+	if len(p.GenreWeights) != 0 {
+		t.Errorf("GenreWeights should be empty, got %v", p.GenreWeights)
+	}
+	if p.PreferredLanguage != "en" {
+		t.Errorf("PreferredLanguage default: want 'en', got %q", p.PreferredLanguage)
+	}
+}
+
+func TestBuildProfile_GenreWeights(t *testing.T) {
+	f := newProfileFixtures(t)
+	a := seedAuthor(t, f, "Author A", "OL1A", false)
+	seedBook(t, f, a.ID, "OL1W", "B1", []string{"Fantasy", "Adventure"})
+	seedBook(t, f, a.ID, "OL2W", "B2", []string{"Fantasy"})
+	// Junk genre should be skipped.
+	seedBook(t, f, a.ID, "OL3W", "B3", []string{"Accessible Book", "Romance"})
+
+	p, err := BuildProfile(context.Background(), f.userID, f.books, f.authors, f.series, f.recs, f.settings)
+	if err != nil {
+		t.Fatalf("BuildProfile: %v", err)
+	}
+
+	if p.TotalBooks != 3 {
+		t.Errorf("TotalBooks: want 3, got %d", p.TotalBooks)
+	}
+
+	// Junk genre filtered out.
+	if _, ok := p.GenreWeights["accessible book"]; ok {
+		t.Error("junk genre 'accessible book' should not appear in weights")
+	}
+	// Fantasy appears in 2/3 books so it's weighted.
+	if p.GenreWeights["fantasy"] == 0 {
+		t.Error("expected non-zero weight for 'fantasy'")
+	}
+	// All genres are lowercased.
+	for g := range p.GenreWeights {
+		if g == "" {
+			t.Error("blank genre key")
+		}
+	}
+}
+
+func TestBuildProfile_OwnedAndAuthorCounts(t *testing.T) {
+	f := newProfileFixtures(t)
+	a := seedAuthor(t, f, "Prolific", "OL_PROLIFIC", true)
+	b := seedAuthor(t, f, "One Hit", "OL_ONEHIT", false)
+	seedBook(t, f, a.ID, "OL1W", "B1", []string{"fantasy"})
+	seedBook(t, f, a.ID, "OL2W", "B2", []string{"fantasy"})
+	seedBook(t, f, b.ID, "OL3W", "B3", []string{"romance"})
+
+	p, err := BuildProfile(context.Background(), f.userID, f.books, f.authors, f.series, f.recs, f.settings)
+	if err != nil {
+		t.Fatalf("BuildProfile: %v", err)
+	}
+	if !p.OwnedForeignIDs["OL1W"] || !p.OwnedForeignIDs["OL2W"] || !p.OwnedForeignIDs["OL3W"] {
+		t.Errorf("OwnedForeignIDs missing entries: %v", p.OwnedForeignIDs)
+	}
+	if p.AuthorBookCounts[a.ID] != 2 {
+		t.Errorf("Prolific book count: want 2, got %d", p.AuthorBookCounts[a.ID])
+	}
+	if p.AuthorBookCounts[b.ID] != 1 {
+		t.Errorf("OneHit book count: want 1, got %d", p.AuthorBookCounts[b.ID])
+	}
+	if !p.MonitoredAuthors[a.ID] {
+		t.Errorf("expected Prolific (ID=%d) to be monitored", a.ID)
+	}
+	if p.MonitoredAuthors[b.ID] {
+		t.Errorf("OneHit (ID=%d) should not be monitored", b.ID)
+	}
+}
+
+func TestBuildProfile_PreferredLanguageFromSettings(t *testing.T) {
+	f := newProfileFixtures(t)
+	if err := f.settings.Set(context.Background(), "search.preferredLanguage", "de"); err != nil {
+		t.Fatalf("set setting: %v", err)
+	}
+
+	p, err := BuildProfile(context.Background(), f.userID, f.books, f.authors, f.series, f.recs, f.settings)
+	if err != nil {
+		t.Fatalf("BuildProfile: %v", err)
+	}
+	if p.PreferredLanguage != "de" {
+		t.Errorf("PreferredLanguage: want 'de', got %q", p.PreferredLanguage)
+	}
+}
+
+func TestBuildProfile_DismissedAndExclusions(t *testing.T) {
+	f := newProfileFixtures(t)
+	ctx := context.Background()
+
+	// Create a rec row, dismiss it.
+	cand := models.RecommendationCandidate{
+		ForeignID: "OLDISMISSED",
+		RecType:   models.RecTypeAuthorNew,
+		Title:     "Dismissed Book",
+	}
+	if err := f.recs.ReplaceBatch(ctx, f.userID, []models.RecommendationCandidate{cand}); err != nil {
+		t.Fatalf("replace batch: %v", err)
+	}
+	recs, err := f.recs.List(ctx, f.userID, "", 10, 0)
+	if err != nil {
+		t.Fatalf("list recs: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 rec, got %d", len(recs))
+	}
+	if err := f.recs.Dismiss(ctx, f.userID, recs[0].ID); err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+
+	// Exclude an author.
+	if err := f.recs.AddAuthorExclusion(ctx, f.userID, "Bad Author"); err != nil {
+		t.Fatalf("add exclusion: %v", err)
+	}
+
+	p, err := BuildProfile(ctx, f.userID, f.books, f.authors, f.series, f.recs, f.settings)
+	if err != nil {
+		t.Fatalf("BuildProfile: %v", err)
+	}
+	if !p.DismissedForeignIDs["OLDISMISSED"] {
+		t.Errorf("dismissed foreign ID should appear: %v", p.DismissedForeignIDs)
+	}
+	// Excluded authors are stored lowercased.
+	if !p.ExcludedAuthors["bad author"] {
+		t.Errorf("excluded authors should include 'bad author', got %v", p.ExcludedAuthors)
+	}
+}
+
+func TestParsePosition_ProfilePackage(t *testing.T) {
+	// Covers parsePosition through a separate check in the profile package.
+	if parsePosition("") != 0 {
+		t.Error("empty should be 0")
+	}
+	if parsePosition("1.5") != 1.5 {
+		t.Error("1.5 should parse")
+	}
+}

--- a/internal/recommender/scorer_test.go
+++ b/internal/recommender/scorer_test.go
@@ -1,0 +1,304 @@
+package recommender
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestClamp(t *testing.T) {
+	tests := []struct {
+		in, want float64
+	}{
+		{-0.5, 0},
+		{0, 0},
+		{0.5, 0.5},
+		{1, 1},
+		{2.0, 1},
+	}
+	for _, tt := range tests {
+		if got := clamp(tt.in); got != tt.want {
+			t.Errorf("clamp(%v) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestGenreScore_EmptyProfile(t *testing.T) {
+	p := &UserProfile{GenreWeights: map[string]float64{}}
+	c := models.RecommendationCandidate{Genres: []string{"fantasy"}}
+	if got := genreScore(c, p); got != 0 {
+		t.Errorf("empty profile should return 0, got %v", got)
+	}
+}
+
+func TestGenreScore_EmptyCandidate(t *testing.T) {
+	p := &UserProfile{GenreWeights: map[string]float64{"fantasy": 0.5}}
+	c := models.RecommendationCandidate{Genres: nil}
+	if got := genreScore(c, p); got != 0 {
+		t.Errorf("empty candidate genres should return 0, got %v", got)
+	}
+}
+
+func TestGenreScore_PerfectMatch(t *testing.T) {
+	p := &UserProfile{
+		GenreWeights: map[string]float64{"fantasy": 1.0},
+	}
+	c := models.RecommendationCandidate{Genres: []string{"fantasy"}}
+	got := genreScore(c, p)
+	if math.Abs(got-1.0) > 1e-9 {
+		t.Errorf("perfect overlap should give 1.0, got %v", got)
+	}
+}
+
+func TestGenreScore_CaseInsensitive(t *testing.T) {
+	p := &UserProfile{GenreWeights: map[string]float64{"fantasy": 1.0}}
+	c := models.RecommendationCandidate{Genres: []string{"  FANTASY  "}}
+	got := genreScore(c, p)
+	if math.Abs(got-1.0) > 1e-9 {
+		t.Errorf("case-insensitive match should give 1.0, got %v", got)
+	}
+}
+
+func TestGenreScore_NoOverlap(t *testing.T) {
+	p := &UserProfile{GenreWeights: map[string]float64{"fantasy": 1.0, "scifi": 1.0}}
+	c := models.RecommendationCandidate{Genres: []string{"romance"}}
+	if got := genreScore(c, p); got != 0 {
+		t.Errorf("no overlap should give 0, got %v", got)
+	}
+}
+
+func TestGenreScore_EmptyStringGenre(t *testing.T) {
+	p := &UserProfile{GenreWeights: map[string]float64{"fantasy": 1.0}}
+	c := models.RecommendationCandidate{Genres: []string{"", "   "}}
+	if got := genreScore(c, p); got != 0 {
+		t.Errorf("all-blank genres should return 0, got %v", got)
+	}
+}
+
+func TestAuthorScore(t *testing.T) {
+	aid := int64(42)
+	tests := []struct {
+		name string
+		c    models.RecommendationCandidate
+		p    *UserProfile
+		want float64
+	}{
+		{
+			name: "nil author",
+			c:    models.RecommendationCandidate{},
+			p:    &UserProfile{},
+			want: 0,
+		},
+		{
+			name: "monitored",
+			c:    models.RecommendationCandidate{AuthorID: &aid},
+			p:    &UserProfile{MonitoredAuthors: map[int64]bool{42: true}},
+			want: 1.0,
+		},
+		{
+			name: "3+ books",
+			c:    models.RecommendationCandidate{AuthorID: &aid},
+			p:    &UserProfile{AuthorBookCounts: map[int64]int{42: 5}},
+			want: 0.7,
+		},
+		{
+			name: "1 book",
+			c:    models.RecommendationCandidate{AuthorID: &aid},
+			p:    &UserProfile{AuthorBookCounts: map[int64]int{42: 1}},
+			want: 0.4,
+		},
+		{
+			name: "unknown",
+			c:    models.RecommendationCandidate{AuthorID: &aid},
+			p:    &UserProfile{AuthorBookCounts: map[int64]int{}},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := authorScore(tt.c, tt.p); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSeriesScore(t *testing.T) {
+	sid := int64(7)
+	profile := &UserProfile{
+		SeriesState: map[int64]SeriesState{
+			7: {SeriesID: 7, MaxPosition: 3, MissingPositions: []float64{2}},
+		},
+	}
+
+	tests := []struct {
+		name string
+		c    models.RecommendationCandidate
+		want float64
+	}{
+		{
+			name: "nil series id",
+			c:    models.RecommendationCandidate{},
+			want: 0,
+		},
+		{
+			name: "series not in state",
+			c:    models.RecommendationCandidate{SeriesID: func() *int64 { x := int64(99); return &x }(), SeriesPos: "1"},
+			want: 0,
+		},
+		{
+			name: "invalid position",
+			c:    models.RecommendationCandidate{SeriesID: &sid, SeriesPos: "abc"},
+			want: 0,
+		},
+		{
+			name: "next in sequence",
+			c:    models.RecommendationCandidate{SeriesID: &sid, SeriesPos: "4"},
+			want: 1.0,
+		},
+		{
+			name: "fills gap",
+			c:    models.RecommendationCandidate{SeriesID: &sid, SeriesPos: "2"},
+			want: 0.5,
+		},
+		{
+			name: "random position",
+			c:    models.RecommendationCandidate{SeriesID: &sid, SeriesPos: "8"},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := seriesScore(tt.c, profile); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommunityScore(t *testing.T) {
+	// No ratings: should be 0
+	c := models.RecommendationCandidate{Rating: 0, RatingsCount: 0}
+	if got := communityScore(c); got != 0 {
+		t.Errorf("zero ratings: got %v, want 0", got)
+	}
+
+	// Max rating + 1000 ratings ≈ 1.0
+	c = models.RecommendationCandidate{Rating: 5.0, RatingsCount: 1000}
+	got := communityScore(c)
+	if got < 0.99 || got > 1.01 {
+		t.Errorf("max-ratings score: got %v, want ~1.0", got)
+	}
+
+	// Should monotonically increase with count
+	low := communityScore(models.RecommendationCandidate{Rating: 4.0, RatingsCount: 10})
+	high := communityScore(models.RecommendationCandidate{Rating: 4.0, RatingsCount: 100})
+	if high <= low {
+		t.Errorf("more ratings should score higher: low=%v high=%v", low, high)
+	}
+}
+
+func TestRecencyScore(t *testing.T) {
+	// No date: neutral
+	c := models.RecommendationCandidate{}
+	if got := recencyScore(c); got != 0.5 {
+		t.Errorf("no date: got %v, want 0.5", got)
+	}
+
+	// This year: 1.0
+	thisYear := time.Date(time.Now().Year(), 6, 1, 0, 0, 0, 0, time.UTC)
+	c = models.RecommendationCandidate{ReleaseDate: &thisYear}
+	if got := recencyScore(c); got != 1.0 {
+		t.Errorf("current year: got %v, want 1.0", got)
+	}
+
+	// 20 years ago: 0.3
+	old := time.Date(time.Now().Year()-20, 1, 1, 0, 0, 0, 0, time.UTC)
+	c = models.RecommendationCandidate{ReleaseDate: &old}
+	if got := recencyScore(c); got != 0.3 {
+		t.Errorf("20 years ago: got %v, want 0.3", got)
+	}
+
+	// Very old: clamped at 0.3
+	ancient := time.Date(1800, 1, 1, 0, 0, 0, 0, time.UTC)
+	c = models.RecommendationCandidate{ReleaseDate: &ancient}
+	if got := recencyScore(c); got != 0.3 {
+		t.Errorf("ancient: got %v, want 0.3", got)
+	}
+
+	// Future year: clamp to 0 years ago, should be 1.0.
+	future := time.Date(time.Now().Year()+5, 1, 1, 0, 0, 0, 0, time.UTC)
+	c = models.RecommendationCandidate{ReleaseDate: &future}
+	if got := recencyScore(c); got != 1.0 {
+		t.Errorf("future date: got %v, want 1.0", got)
+	}
+}
+
+func TestScore_SeriesBonus(t *testing.T) {
+	sid := int64(1)
+	profile := &UserProfile{
+		SeriesState: map[int64]SeriesState{
+			1: {SeriesID: 1, MaxPosition: 1},
+		},
+	}
+	c := models.RecommendationCandidate{
+		RecType:   models.RecTypeSeries,
+		SeriesID:  &sid,
+		SeriesPos: "2",
+	}
+	got := Score(c, profile)
+	if got <= 0.2 {
+		t.Errorf("series next-in-sequence should score well (got %v)", got)
+	}
+	if got > 1.0 {
+		t.Errorf("score should be clamped to <= 1.0, got %v", got)
+	}
+}
+
+func TestScore_AuthorNewBonus(t *testing.T) {
+	aid := int64(42)
+	profile := &UserProfile{
+		MonitoredAuthors: map[int64]bool{42: true},
+	}
+	c := models.RecommendationCandidate{
+		RecType:  models.RecTypeAuthorNew,
+		AuthorID: &aid,
+	}
+	withBonus := Score(c, profile)
+	// Without monitored-author bonus
+	c2 := c
+	profile2 := &UserProfile{}
+	without := Score(c2, profile2)
+	if withBonus <= without {
+		t.Errorf("author-new bonus should lift score: with=%v without=%v", withBonus, without)
+	}
+}
+
+func TestScore_ClampedToOne(t *testing.T) {
+	// Construct a candidate that maxes out every sub-score to exercise the clamp.
+	aid := int64(1)
+	sid := int64(1)
+	now := time.Now()
+	c := models.RecommendationCandidate{
+		RecType:      models.RecTypeSeries,
+		AuthorID:     &aid,
+		SeriesID:     &sid,
+		SeriesPos:    "2",
+		Genres:       []string{"fantasy"},
+		Rating:       5.0,
+		RatingsCount: 10000,
+		ReleaseDate:  &now,
+	}
+	profile := &UserProfile{
+		GenreWeights:     map[string]float64{"fantasy": 1.0},
+		MonitoredAuthors: map[int64]bool{1: true},
+		SeriesState:      map[int64]SeriesState{1: {SeriesID: 1, MaxPosition: 1}},
+	}
+	got := Score(c, profile)
+	if got > 1.0 || got < 0 {
+		t.Errorf("Score must be in [0,1], got %v", got)
+	}
+}

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import App from './App'
+
+// Mock all heavy page components so we only exercise Shell layout.
+vi.mock('./pages/AuthorsPage', () => ({ default: () => <div data-testid="page-authors" /> }))
+vi.mock('./pages/BooksPage', () => ({ default: () => <div data-testid="page-books" /> }))
+vi.mock('./pages/WantedPage', () => ({ default: () => <div data-testid="page-wanted" /> }))
+vi.mock('./pages/QueuePage', () => ({ default: () => <div data-testid="page-queue" /> }))
+vi.mock('./pages/HistoryPage', () => ({ default: () => <div data-testid="page-history" /> }))
+vi.mock('./pages/SeriesPage', () => ({ default: () => <div data-testid="page-series" /> }))
+vi.mock('./pages/CalendarPage', () => ({ default: () => <div data-testid="page-calendar" /> }))
+vi.mock('./pages/DiscoverPage', () => ({ default: () => <div data-testid="page-discover" /> }))
+vi.mock('./pages/SettingsPage', () => ({ default: () => <div data-testid="page-settings" /> }))
+vi.mock('./pages/LoginPage', () => ({ default: () => <div data-testid="page-login" /> }))
+vi.mock('./pages/SetupPage', () => ({ default: () => <div data-testid="page-setup" /> }))
+vi.mock('./pages/AuthorDetailPage', () => ({ default: () => <div /> }))
+vi.mock('./pages/BookDetailPage', () => ({ default: () => <div /> }))
+
+vi.mock('./auth/AuthGuard', () => ({ default: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+vi.mock('./auth/AuthContext', () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useAuth: () => ({ status: { authenticated: false, mode: 'disabled', setupRequired: false }, logout: vi.fn() }),
+}))
+
+vi.mock('./api/client', () => ({
+  api: {
+    status: vi.fn().mockResolvedValue({ version: '0.15.0', commit: 'abc', buildDate: '' }),
+  },
+}))
+
+vi.mock('./theme', () => ({ useTheme: () => {} }))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const m: Record<string, string> = {
+        'nav.authors': 'Authors', 'nav.books': 'Books', 'nav.wanted': 'Wanted',
+        'nav.queue': 'Queue', 'nav.history': 'History', 'nav.series': 'Series',
+        'nav.calendar': 'Calendar', 'nav.discover': 'Discover', 'nav.settings': 'Settings',
+        'login.signOut': 'Sign out', 'login.signedInAs': 'Signed in as',
+      }
+      return m[key] ?? key
+    },
+  }),
+}))
+
+function renderShell() {
+  return render(<App />)
+}
+
+describe('Shell — desktop navigation', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('renders all 8 nav links in the desktop nav bar', () => {
+    renderShell()
+    const desktopNav = document.querySelector('nav.hidden.lg\\:flex')
+    expect(desktopNav).not.toBeNull()
+    const links = desktopNav!.querySelectorAll('a')
+    expect(links.length).toBe(8)
+    const labels = Array.from(links).map(l => l.textContent)
+    expect(labels).toContain('Authors')
+    expect(labels).toContain('Books')
+    expect(labels).toContain('Wanted')
+    expect(labels).toContain('Discover')
+    expect(labels).toContain('Calendar')
+  })
+
+  it('desktop nav has hidden lg:flex classes for responsive visibility', () => {
+    renderShell()
+    const nav = document.querySelector('nav.hidden.lg\\:flex')
+    expect(nav).not.toBeNull()
+    expect(nav!.className).toContain('hidden')
+    expect(nav!.className).toContain('lg:flex')
+  })
+
+  it('settings gear icon is in the desktop header (hidden on mobile)', () => {
+    renderShell()
+    const settingsLink = document.querySelector('a[title="Settings"].hidden.lg\\:block')
+    expect(settingsLink).not.toBeNull()
+  })
+})
+
+describe('Shell — mobile navigation', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('renders a hamburger toggle button for mobile', () => {
+    renderShell()
+    expect(screen.getByRole('button', { name: /toggle menu/i })).toBeInTheDocument()
+  })
+
+  it('hamburger button has lg:hidden class', () => {
+    renderShell()
+    const btn = screen.getByRole('button', { name: /toggle menu/i })
+    expect(btn.className).toContain('lg:hidden')
+  })
+
+  it('mobile menu is hidden by default', () => {
+    renderShell()
+    expect(document.querySelector('div.lg\\:hidden > nav')).toBeNull()
+  })
+
+  it('opens mobile menu when hamburger is clicked', () => {
+    renderShell()
+    fireEvent.click(screen.getByRole('button', { name: /toggle menu/i }))
+    const mobileNav = document.querySelector('div.lg\\:hidden > nav')
+    expect(mobileNav).not.toBeNull()
+  })
+
+  it('mobile menu contains all nav links including Settings', () => {
+    renderShell()
+    fireEvent.click(screen.getByRole('button', { name: /toggle menu/i }))
+    const mobileNav = document.querySelector('div.lg\\:hidden > nav')!
+    const links = Array.from(mobileNav.querySelectorAll('a')).map(l => l.textContent)
+    expect(links).toContain('Authors')
+    expect(links).toContain('Discover')
+    expect(links).toContain('Settings')
+    expect(links.length).toBe(9) // 8 main + Settings
+  })
+
+  it('closes mobile menu when a nav link is clicked', () => {
+    renderShell()
+    fireEvent.click(screen.getByRole('button', { name: /toggle menu/i }))
+    const mobileNav = document.querySelector('div.lg\\:hidden > nav')!
+    expect(mobileNav).not.toBeNull()
+
+    fireEvent.click(mobileNav.querySelector('a')!)
+    expect(document.querySelector('div.lg\\:hidden > nav')).toBeNull()
+  })
+
+  it('toggles hamburger icon between open/close SVG paths', () => {
+    renderShell()
+    const btn = screen.getByRole('button', { name: /toggle menu/i })
+
+    // Before open: shows "hamburger" path (three horizontal lines)
+    expect(btn.innerHTML).toContain('M4 6h16M4 12h16M4 18h16')
+
+    fireEvent.click(btn)
+    // After open: shows "X" path
+    expect(btn.innerHTML).toContain('M6 18L18 6M6 6l12 12')
+
+    fireEvent.click(btn)
+    // Closed again: back to hamburger
+    expect(btn.innerHTML).toContain('M4 6h16M4 12h16M4 18h16')
+  })
+})

--- a/web/src/components/Pagination.test.tsx
+++ b/web/src/components/Pagination.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import Pagination from './Pagination'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => ({ 'pagination.previous': 'Previous', 'pagination.next': 'Next' }[key] ?? key),
+  }),
+}))
+
+const defaults = {
+  page: 1,
+  totalPages: 5,
+  pageSize: 25,
+  totalItems: 120,
+  onPageChange: vi.fn(),
+  onPageSizeChange: vi.fn(),
+}
+
+describe('Pagination', () => {
+  it('returns nothing when totalItems is 0', () => {
+    const { container } = render(<Pagination {...defaults} totalItems={0} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows correct item range for page 1', () => {
+    render(<Pagination {...defaults} page={1} pageSize={25} totalItems={120} />)
+    expect(screen.getByText('1–25 of 120')).toBeInTheDocument()
+  })
+
+  it('shows correct item range for last page', () => {
+    render(<Pagination {...defaults} page={5} pageSize={25} totalItems={120} />)
+    expect(screen.getByText('101–120 of 120')).toBeInTheDocument()
+  })
+
+  it('disables Previous and first-page buttons on page 1', () => {
+    render(<Pagination {...defaults} page={1} />)
+    expect(screen.getByRole('button', { name: '«' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /‹.*Previous/i })).toBeDisabled()
+  })
+
+  it('disables Next and last-page buttons on the last page', () => {
+    render(<Pagination {...defaults} page={5} totalPages={5} />)
+    expect(screen.getByRole('button', { name: '»' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /Next.*›/i })).toBeDisabled()
+  })
+
+  it('calls onPageChange with correct page when a page button is clicked', () => {
+    const onPageChange = vi.fn()
+    render(<Pagination {...defaults} page={1} totalPages={5} onPageChange={onPageChange} />)
+    fireEvent.click(screen.getByRole('button', { name: '3' }))
+    expect(onPageChange).toHaveBeenCalledWith(3)
+  })
+
+  it('calls onPageChange(page-1) when Previous is clicked', () => {
+    const onPageChange = vi.fn()
+    render(<Pagination {...defaults} page={3} totalPages={5} onPageChange={onPageChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /‹.*Previous/i }))
+    expect(onPageChange).toHaveBeenCalledWith(2)
+  })
+
+  it('calls onPageChange(page+1) when Next is clicked', () => {
+    const onPageChange = vi.fn()
+    render(<Pagination {...defaults} page={3} totalPages={5} onPageChange={onPageChange} />)
+    fireEvent.click(screen.getByRole('button', { name: /Next.*›/i }))
+    expect(onPageChange).toHaveBeenCalledWith(4)
+  })
+
+  it('calls onPageChange(1) when first-page button is clicked', () => {
+    const onPageChange = vi.fn()
+    render(<Pagination {...defaults} page={3} totalPages={5} onPageChange={onPageChange} />)
+    fireEvent.click(screen.getByRole('button', { name: '«' }))
+    expect(onPageChange).toHaveBeenCalledWith(1)
+  })
+
+  it('calls onPageChange(totalPages) when last-page button is clicked', () => {
+    const onPageChange = vi.fn()
+    render(<Pagination {...defaults} page={3} totalPages={5} onPageChange={onPageChange} />)
+    fireEvent.click(screen.getByRole('button', { name: '»' }))
+    expect(onPageChange).toHaveBeenCalledWith(5)
+  })
+
+  it('shows ellipsis when totalPages > 7 and page is in the middle', () => {
+    render(<Pagination {...defaults} page={5} totalPages={10} />)
+    const ellipses = screen.getAllByText('…')
+    expect(ellipses.length).toBe(2) // one before, one after
+  })
+
+  it('shows no ellipsis when totalPages <= 7', () => {
+    render(<Pagination {...defaults} page={4} totalPages={7} />)
+    expect(screen.queryByText('…')).toBeNull()
+    // All 7 page buttons present
+    for (let i = 1; i <= 7; i++) {
+      expect(screen.getByRole('button', { name: String(i) })).toBeInTheDocument()
+    }
+  })
+
+  it('calls onPageSizeChange when page size selector changes', () => {
+    const onPageSizeChange = vi.fn()
+    render(<Pagination {...defaults} onPageSizeChange={onPageSizeChange} />)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '50' } })
+    expect(onPageSizeChange).toHaveBeenCalledWith(50)
+  })
+
+  it('renders custom pageSizeOptions', () => {
+    render(<Pagination {...defaults} pageSizeOptions={[10, 20, 30]} />)
+    const select = screen.getByRole('combobox')
+    const options = Array.from(select.querySelectorAll('option')).map(o => o.value)
+    expect(options).toEqual(['10', '20', '30'])
+  })
+
+  it('highlights the active page button', () => {
+    render(<Pagination {...defaults} page={2} totalPages={5} />)
+    const activeBtn = screen.getByRole('button', { name: '2' })
+    expect(activeBtn.className).toContain('bg-slate-300')
+    const inactiveBtn = screen.getByRole('button', { name: '3' })
+    expect(inactiveBtn.className).not.toContain('bg-slate-300')
+  })
+
+  // Mobile layout: stacks vertically (flex-col) and switches to row on sm breakpoint
+  it('has flex-col base class for mobile stacking', () => {
+    const { container } = render(<Pagination {...defaults} />)
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.className).toContain('flex-col')
+    expect(wrapper.className).toContain('sm:flex-row')
+  })
+})

--- a/web/src/components/RecommendationCard.test.tsx
+++ b/web/src/components/RecommendationCard.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import RecommendationCard from './RecommendationCard'
+import { Recommendation } from '../api/client'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (key === 'discover.dontSuggestAuthor') return `Don't suggest ${String(opts?.author ?? '')}`
+      return {
+        'discover.addToWanted': 'Add to Wanted',
+        'discover.dismiss': 'Dismiss',
+      }[key] ?? key
+    },
+  }),
+}))
+
+const baseRec: Recommendation = {
+  id: 1,
+  userId: 1,
+  foreignId: 'ol:test',
+  recType: 'series',
+  title: 'Test Book',
+  authorName: 'Jane Author',
+  imageUrl: '',
+  description: 'A great book',
+  genres: ['Fantasy', 'Adventure', 'Magic'],
+  rating: 4.0,
+  ratingsCount: 1200,
+  language: 'en',
+  mediaType: 'ebook',
+  score: 0.85,
+  reason: 'Next in the series',
+  seriesPos: '2',
+  dismissed: false,
+  batchId: 'b1',
+  createdAt: '2026-01-01T00:00:00Z',
+}
+
+describe('RecommendationCard — rendering', () => {
+  it('renders title, author and reason', () => {
+    render(<RecommendationCard rec={baseRec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
+    expect(screen.getByText('Test Book')).toBeInTheDocument()
+    expect(screen.getByText('Jane Author')).toBeInTheDocument()
+    expect(screen.getByText('Next in the series')).toBeInTheDocument()
+  })
+
+  it('shows a placeholder book icon when no imageUrl', () => {
+    render(<RecommendationCard rec={baseRec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
+    expect(screen.queryByRole('img')).toBeNull()
+    // SVG placeholder should be in the cover area
+    const coverArea = document.querySelector('.h-36 svg')
+    expect(coverArea).not.toBeNull()
+  })
+
+  it('renders an img tag when imageUrl is set', () => {
+    const rec = { ...baseRec, imageUrl: 'https://example.com/cover.jpg' }
+    render(<RecommendationCard rec={rec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
+    const img = screen.getByRole('img', { name: 'Test Book' })
+    expect(img).toBeInTheDocument()
+    expect(img.getAttribute('src')).toContain(encodeURIComponent('https://example.com/cover.jpg'))
+  })
+
+  it('shows up to 3 genre tags', () => {
+    const rec = { ...baseRec, genres: ['Fantasy', 'Adventure', 'Magic', 'Epic', 'Quest'] }
+    render(<RecommendationCard rec={rec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
+    expect(screen.getByText('Fantasy')).toBeInTheDocument()
+    expect(screen.getByText('Adventure')).toBeInTheDocument()
+    expect(screen.getByText('Magic')).toBeInTheDocument()
+    expect(screen.queryByText('Epic')).toBeNull()
+    expect(screen.queryByText('Quest')).toBeNull()
+  })
+
+  it('shows no genre tags when genres array is empty', () => {
+    const rec = { ...baseRec, genres: [] }
+    const { container } = render(<RecommendationCard rec={rec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
+    expect(container.querySelector('.flex.flex-wrap.gap-1')).toBeNull()
+  })
+
+  it('shows ratings count when > 0', () => {
+    render(<RecommendationCard rec={baseRec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
+    expect(screen.getByText('(1200)')).toBeInTheDocument()
+  })
+
+  it('hides ratings count when ratingsCount is 0', () => {
+    const rec = { ...baseRec, ratingsCount: 0 }
+    render(<RecommendationCard rec={rec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
+    expect(screen.queryByText(/\(\d+\)/)).toBeNull()
+  })
+})
+
+describe('RecommendationCard — actions', () => {
+  const onDismiss = vi.fn()
+  const onAdd = vi.fn()
+  const onExcludeAuthor = vi.fn()
+
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('calls onAdd with rec.id when "Add to Wanted" is clicked', () => {
+    render(<RecommendationCard rec={baseRec} onDismiss={onDismiss} onAdd={onAdd} onExcludeAuthor={onExcludeAuthor} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Add to Wanted' }))
+    expect(onAdd).toHaveBeenCalledWith(1)
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('calls onDismiss with rec.id when "Dismiss" is clicked', () => {
+    render(<RecommendationCard rec={baseRec} onDismiss={onDismiss} onAdd={onAdd} onExcludeAuthor={onExcludeAuthor} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(onDismiss).toHaveBeenCalledWith(1)
+    expect(onAdd).not.toHaveBeenCalled()
+  })
+
+  it('"···" button opens the author exclusion dropdown', () => {
+    render(<RecommendationCard rec={baseRec} onDismiss={onDismiss} onAdd={onAdd} onExcludeAuthor={onExcludeAuthor} />)
+    expect(screen.queryByText(/Don't suggest Jane Author/)).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: '···' }))
+    expect(screen.getByText("Don't suggest Jane Author")).toBeInTheDocument()
+  })
+
+  it('"···" button toggles dropdown closed on second click', () => {
+    render(<RecommendationCard rec={baseRec} onDismiss={onDismiss} onAdd={onAdd} onExcludeAuthor={onExcludeAuthor} />)
+    const menuBtn = screen.getByRole('button', { name: '···' })
+    fireEvent.click(menuBtn)
+    fireEvent.click(menuBtn)
+    expect(screen.queryByText(/Don't suggest/)).toBeNull()
+  })
+
+  it('calls onExcludeAuthor and closes dropdown when "Don\'t suggest author" is clicked', () => {
+    render(<RecommendationCard rec={baseRec} onDismiss={onDismiss} onAdd={onAdd} onExcludeAuthor={onExcludeAuthor} />)
+    fireEvent.click(screen.getByRole('button', { name: '···' }))
+    fireEvent.click(screen.getByText("Don't suggest Jane Author"))
+    expect(onExcludeAuthor).toHaveBeenCalledWith('Jane Author')
+    expect(screen.queryByText(/Don't suggest/)).toBeNull()
+  })
+
+  it('closes the dropdown when clicking outside', () => {
+    render(
+      <div>
+        <RecommendationCard rec={baseRec} onDismiss={onDismiss} onAdd={onAdd} onExcludeAuthor={onExcludeAuthor} />
+        <div data-testid="outside">outside</div>
+      </div>
+    )
+    fireEvent.click(screen.getByRole('button', { name: '···' }))
+    expect(screen.getByText("Don't suggest Jane Author")).toBeInTheDocument()
+
+    fireEvent.mouseDown(screen.getByTestId('outside'))
+    expect(screen.queryByText(/Don't suggest/)).toBeNull()
+  })
+})
+
+describe('RecommendationCard — responsive layout', () => {
+  it('has a fixed width class for horizontal scroll within rows', () => {
+    const { container } = render(<RecommendationCard rec={baseRec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
+    const card = container.firstChild as HTMLElement
+    expect(card.className).toContain('flex-shrink-0')
+    expect(card.className).toContain('w-56')
+  })
+
+  it('cover image area has a fixed height suitable for both mobile and desktop', () => {
+    const { container } = render(<RecommendationCard rec={baseRec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
+    const coverArea = container.querySelector('.h-36')
+    expect(coverArea).not.toBeNull()
+  })
+})

--- a/web/src/components/RecommendationRow.test.tsx
+++ b/web/src/components/RecommendationRow.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import RecommendationRow from './RecommendationRow'
+import { Recommendation } from '../api/client'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (key === 'discover.dontSuggestAuthor') return `Don't suggest ${String(opts?.author ?? '')}`
+      return { 'discover.addToWanted': 'Add to Wanted', 'discover.dismiss': 'Dismiss' }[key] ?? key
+    },
+  }),
+}))
+
+const makeRec = (id: number, title: string): Recommendation => ({
+  id,
+  userId: 1,
+  foreignId: `ol:${id}`,
+  recType: 'series',
+  title,
+  authorName: `Author ${id}`,
+  imageUrl: '',
+  description: '',
+  genres: [],
+  rating: 3.5,
+  ratingsCount: 0,
+  language: 'en',
+  mediaType: 'ebook',
+  score: 0.5,
+  reason: 'Test reason',
+  seriesPos: '',
+  dismissed: false,
+  batchId: 'b1',
+  createdAt: '2026-01-01T00:00:00Z',
+})
+
+describe('RecommendationRow', () => {
+  it('returns nothing when recommendations array is empty', () => {
+    const { container } = render(
+      <RecommendationRow title="Series" recommendations={[]} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the row title', () => {
+    render(
+      <RecommendationRow title="Next in Series" recommendations={[makeRec(1, 'Book One')]} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />
+    )
+    expect(screen.getByText('Next in Series')).toBeInTheDocument()
+  })
+
+  it('renders a card for each recommendation', () => {
+    const recs = [makeRec(1, 'Alpha'), makeRec(2, 'Beta'), makeRec(3, 'Gamma')]
+    render(
+      <RecommendationRow title="Row" recommendations={recs} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />
+    )
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+    expect(screen.getByText('Gamma')).toBeInTheDocument()
+  })
+
+  it('has overflow-x-auto class for horizontal scroll on mobile', () => {
+    const { container } = render(
+      <RecommendationRow title="Row" recommendations={[makeRec(1, 'X')]} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />
+    )
+    expect(container.querySelector('.overflow-x-auto')).not.toBeNull()
+  })
+
+  it('passes onDismiss through to each card', () => {
+    const onDismiss = vi.fn()
+    render(
+      <RecommendationRow title="Row" recommendations={[makeRec(7, 'Dismissible')]} onDismiss={onDismiss} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(onDismiss).toHaveBeenCalledWith(7)
+  })
+
+  it('passes onAdd through to each card', () => {
+    const onAdd = vi.fn()
+    render(
+      <RecommendationRow title="Row" recommendations={[makeRec(9, 'Addable')]} onDismiss={vi.fn()} onAdd={onAdd} onExcludeAuthor={vi.fn()} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Add to Wanted' }))
+    expect(onAdd).toHaveBeenCalledWith(9)
+  })
+})


### PR DESCRIPTION
## Summary

- **Docs**: ROADMAP updated with v0.14.0 shipped items and new planned items synthesized from open issues; README adds Discover/recommendations section; CONTRIBUTING updated for new packages
- **Backend tests**: Recommender package (scorer, candidates, profile builder), OpenLibrary `GetSubjectBooks`, Hardcover `GetUserWishlist` — coverage up to recommender 47.6%, openlibrary 96.2%, hardcover 96.3%
- **Frontend UI tests**: 50 new tests across `App.test.tsx`, `Pagination.test.tsx`, `RecommendationCard.test.tsx`, `RecommendationRow.test.tsx` covering desktop nav, mobile hamburger menu, pagination logic, card interactions, and responsive layout classes

## Test plan

- [ ] CI passes (lint, validate, smoke, SAST)
- [ ] `go test ./internal/recommender/... ./internal/metadata/...` — all new backend tests green
- [ ] `cd web && npm test` — 50/50 tests pass, typecheck clean
- [ ] `npm run lint` — no errors (pre-existing AuthContext warning only)