### PR TITLE
fix(pagination): memoize reset() to stop page reverting to 1 on navigation (#161)

### DIFF
--- a/web/src/components/usePagination.ts
+++ b/web/src/components/usePagination.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 const SHARED_PAGE_SIZE_KEY = 'pageSize:shared'
 
@@ -33,7 +33,7 @@ export function usePagination<T>(items: T[], defaultPageSize = 50, storageKey?: 
   const safePage = Math.min(page, totalPages)
   const paged = useMemo(() => items.slice((safePage - 1) * pageSize, safePage * pageSize), [items, safePage, pageSize])
 
-  const reset = () => setPage(1)
+  const reset = useCallback(() => setPage(1), [])
 
   const handlePageSizeChange = (size: number) => {
     setPageSize(size)


### PR DESCRIPTION
## Root cause

`usePagination` defined `reset` as a plain inline function, creating a new reference on every render:

```ts
const reset = () => setPage(1)  // new reference each render
```

`AuthorsPage` (and potentially others) included `reset` in a `useEffect` dependency array:

```tsx
useEffect(() => { reset() }, [search, sort, monitoredFilter, reset])
```

**Sequence on "click page 2":**
1. `setPage(2)` called
2. Re-render — `usePagination` produces a new `reset` reference
3. Effect sees `reset` changed → fires → `setPage(1)`
4. Back to page 1 every time

## Fix

Wrap `reset` with `useCallback(fn, [])` so it has a stable identity across renders. The effect now only fires when search/sort/filter actually change.

## Test

Navigate to Authors with >50 authors → clicking any page button now works correctly.

Closes #161