### PR TITLE
fix(metadata): skip calibre-native authors on metadata refresh (#164)

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -292,6 +292,14 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool)
 	ctx := contextBackground()
 	slog.Info("fetching books for author", "author", author.Name, "foreignId", author.ForeignID)
 
+	// Calibre-imported authors carry a synthetic "calibre:author:N" foreign ID
+	// that has no counterpart in OL/Hardcover. Attempting to fetch works for
+	// them always produces a 404; skip silently.
+	if strings.HasPrefix(author.ForeignID, "calibre:") {
+		slog.Debug("skipping metadata fetch for calibre-native author", "author", author.Name, "foreignId", author.ForeignID)
+		return
+	}
+
 	// Use the dedicated author works endpoint for accurate results
 	books, err := h.meta.GetAuthorWorks(ctx, author.ForeignID)
 	if err != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,6 +6,7 @@ package scheduler
 import (
 	"context"
 	"log/slog"
+	"strings"
 
 	"github.com/robfig/cron/v3"
 
@@ -389,6 +390,12 @@ func (s *Scheduler) refreshMetadata() {
 
 	for _, author := range authors {
 		if !author.Monitored {
+			continue
+		}
+
+		// Calibre-imported authors have synthetic "calibre:author:N" IDs with
+		// no counterpart in OL/Hardcover; skip to avoid noisy 404 errors.
+		if strings.HasPrefix(author.ForeignID, "calibre:") {
 			continue
 		}
 


### PR DESCRIPTION
## Problem

Authors imported via Calibre sync are created with a synthetic `ForeignID` of the form `calibre:author:N`. These IDs have no counterpart in OpenLibrary or Hardcover.

When "Refresh Metadata" was triggered (manually from the author page, or by the scheduled 24h job), the system would call `GetAuthorWorks("calibre:author:667")` which hits OpenLibrary at `/authors/calibre:author:667/works.json` — a guaranteed HTTP 404 logged as an ERROR on every refresh cycle for every Calibre user.

## Fix

Guard both code paths:

- **`FetchAuthorBooks`** (API handler — manual refresh and on-add): early return with a debug-level log when `ForeignID` starts with `calibre:`
- **`refreshMetadata`** (scheduler — 24h scheduled job): skip the author entirely for the same reason

Neither path has anything to fetch for these authors; the correct long-term solution is a "re-identify" flow that lets users link a Calibre author to their OL/HC entry, but that's a separate feature.

Closes #164