### PR TITLE
fix(authors): silence UNIQUE constraint on duplicate book during sync

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -359,6 +359,11 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool)
 		seenTitles[normalizedTitle] = true
 
 		if err := h.books.Create(ctx, &b); err != nil {
+			// A UNIQUE constraint on foreign_id means the book was already
+			// created by a concurrent or earlier sync — treat as a benign skip.
+			if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+				continue
+			}
 			slog.Warn("failed to create book", "title", b.Title, "error", err)
 			continue
 		}


### PR DESCRIPTION
## Summary
- Treats `UNIQUE constraint failed: books.foreign_id` in `FetchAuthorBooks` as a benign skip (book already exists) rather than a logged warning
- Fixes the flood of "failed to create book" warnings when an author sync runs twice in quick succession (e.g. initial add + manual refresh)

## Root cause
SQLite snapshot isolation: if the second sync goroutine opens a read transaction before the first sync's `Create` calls commit, `GetByForeignID` returns nil. The subsequent `Create` sees the latest committed state and hits the UNIQUE constraint. The first sync's books are still there — the second sync is just redundant.

## Test plan
- [ ] Add author → immediately click refresh icon → no "failed to create book" warnings in logs
- [ ] Author detail page shows books correctly after both syncs