### PR TITLE
feat(scheduler): stalled download detection and automatic re-grab

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -466,6 +466,7 @@ func main() {
 		// Calibre integration — settings live under /setting/calibre.*,
 		// this endpoint just validates + probes the configured install.
 		r.Post("/calibre/test", calibreHandler.Test)
+		r.Post("/calibre/test-paths", calibreHandler.TestPaths)
 
 		// Calibre library import (read side). Start is fire-and-forget;
 		// the UI polls Status while it runs.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -206,6 +206,7 @@ func main() {
 	// Scheduler
 	sched := scheduler.New(importScanner, idxSearcher, metaAgg,
 		authorRepo, bookRepo, indexerRepo, downloadRepo, dlClientRepo, settingsRepo, blocklistRepo)
+	sched.WithHistory(historyRepo)
 	// Register the Calibre importer as the 24-hour sync job. The scheduler
 	// only fires the job when the syncer is non-nil, so no guard needed here.
 	sched.WithCalibreSyncer(calibreImporter)

--- a/internal/api/calibre.go
+++ b/internal/api/calibre.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/vavallee/bindery/internal/calibre"
@@ -150,5 +152,39 @@ func (h *CalibreHandler) Test(w http.ResponseWriter, r *http.Request) {
 		"ok":      "true",
 		"version": version,
 		"message": "calibredb reachable",
+	})
+}
+
+// TestPaths validates the drop-folder mode paths: checks that metadata.db is
+// readable at library_path and that drop_folder_path is writable.
+func (h *CalibreHandler) TestPaths(w http.ResponseWriter, r *http.Request) {
+	cfg := LoadDropFolderConfig(h.settings)
+	if cfg.LibraryPath == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "library_path is not set"})
+		return
+	}
+	metaDB := filepath.Join(cfg.LibraryPath, "metadata.db")
+	if _, err := os.Stat(metaDB); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("metadata.db not found at %s: %v", metaDB, err),
+		})
+		return
+	}
+	if cfg.DropFolderPath == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "drop_folder_path is not set"})
+		return
+	}
+	tmp, err := os.CreateTemp(cfg.DropFolderPath, ".bindery-test-*")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("drop folder not writable: %v", err),
+		})
+		return
+	}
+	tmp.Close()
+	os.Remove(tmp.Name())
+	writeJSON(w, http.StatusOK, map[string]string{
+		"ok":      "true",
+		"message": "library path readable · drop folder writable",
 	})
 }

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -129,6 +129,50 @@ func RemoveDownload(ctx context.Context, client *models.DownloadClient, dl *mode
 	}
 }
 
+// GetStalledIDs returns the set of remote IDs the client reports as stalled.
+// For qBittorrent this is the `stalledDL` state; for Transmission it is
+// torrents stopped with a non-empty error string. SABnzbd has no stall
+// concept — its failures are already surfaced as Failed-status NZBs in the
+// existing checkSABnzbdDownloads path.
+//
+// Keys for torrent clients are lower-cased hash strings; for SABnzbd they
+// would be NZO IDs (but SABnzbd always returns nil here). The second return
+// value matches GetLiveStatuses: true when IDs are torrent hashes.
+func GetStalledIDs(ctx context.Context, client *models.DownloadClient) (map[string]bool, bool, error) {
+	switch client.Type {
+	case "qbittorrent":
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		torrents, err := qb.GetTorrents(ctx, client.Category)
+		if err != nil {
+			return nil, true, err
+		}
+		out := make(map[string]bool, len(torrents))
+		for _, t := range torrents {
+			state := strings.ToLower(t.State)
+			if state == "stalleddl" {
+				out[strings.ToLower(t.Hash)] = true
+			}
+		}
+		return out, true, nil
+	case "transmission":
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		torrents, err := trans.GetTorrents(ctx, client.Category)
+		if err != nil {
+			return nil, true, err
+		}
+		out := make(map[string]bool, len(torrents))
+		for _, t := range torrents {
+			// status 0 = stopped; treat stopped+error as stalled
+			if t.Status == 0 && strings.TrimSpace(t.ErrorString) != "" {
+				out[strconv.FormatInt(t.ID, 10)] = true
+			}
+		}
+		return out, true, nil
+	default:
+		return nil, false, nil
+	}
+}
+
 func GetLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[string]LiveStatus, bool, error) {
 	if IsTorrentClient(client.Type) {
 		statuses, err := getTorrentLiveStatuses(ctx, client)

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -75,4 +75,6 @@ const (
 	HistoryEventBookRenamed          = "bookRenamed"
 	HistoryEventDownloadFolderImport = "downloadFolderImported"
 	HistoryEventBookFileDeleted      = "bookFileDeleted"
+	HistoryEventDownloadStalled      = "downloadStalled"
+	HistoryEventDownloadRequeued     = "downloadRequeued"
 )

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -5,8 +5,11 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/robfig/cron/v3"
 
@@ -57,6 +60,7 @@ type Scheduler struct {
 	indexers      *db.IndexerRepo
 	downloads     *db.DownloadRepo
 	clients       *db.DownloadClientRepo
+	history       *db.HistoryRepo
 	settings      *db.SettingsRepo
 	blocklist     *db.BlocklistRepo
 	calibreSyncer CalibreSyncer        // optional; nil if Calibre is not configured
@@ -92,6 +96,12 @@ func New(
 	}
 }
 
+// WithHistory attaches a HistoryRepo so stall events can be recorded.
+// Must be called before Start.
+func (s *Scheduler) WithHistory(h *db.HistoryRepo) {
+	s.history = h
+}
+
 // WithCalibreSyncer registers a CalibreSyncer that the scheduler will call
 // every 24 hours when Calibre is configured. Must be called before Start.
 func (s *Scheduler) WithCalibreSyncer(syncer CalibreSyncer) {
@@ -119,6 +129,14 @@ func (s *Scheduler) Start() {
 	s.cron.AddFunc("@every 15s", func() {
 		slog.Debug("job: check downloads")
 		s.scanner.CheckDownloads(context.Background())
+	})
+
+	// Stall detection runs every 5 minutes. Checking every 15s would be
+	// noisy for a condition that changes slowly; 5 minutes is frequent
+	// enough to act well within any reasonable stall timeout.
+	s.cron.AddFunc("@every 5m", func() {
+		slog.Debug("job: check stalled downloads")
+		s.checkStalledDownloads(context.Background())
 	})
 
 	// Search for wanted books every 12 hours
@@ -416,4 +434,142 @@ func (s *Scheduler) refreshMetadata() {
 
 		slog.Debug("refreshed author", "author", author.Name)
 	}
+}
+
+// stallTimeoutDefault is the duration a download must be in the downloading
+// state before it can be considered stalled. Configurable via the
+// stall.timeout_minutes setting (default 120 minutes / 2 hours).
+const stallTimeoutDefault = 120 * time.Minute
+
+// checkStalledDownloads detects downloads that have been stuck in
+// "downloading" state for longer than the stall timeout and handles them:
+// the release is marked failed, added to the blocklist so it won't be
+// re-grabbed, and a fresh search is triggered for the same book.
+//
+// Detection uses the download client's native stall signal where available
+// (qBittorrent: stalledDL state; Transmission: stopped with error). For
+// SABnzbd the existing Failed-state detection in CheckDownloads already
+// covers failures, so this job adds nothing for usenet downloads.
+func (s *Scheduler) checkStalledDownloads(ctx context.Context) {
+	timeout := stallTimeoutDefault
+	if s.settings != nil {
+		if v, _ := s.settings.Get(ctx, "stall.timeout_minutes"); v != nil {
+			if mins, err := strconv.Atoi(v.Value); err == nil && mins > 0 {
+				timeout = time.Duration(mins) * time.Minute
+			}
+		}
+	}
+
+	active, err := s.downloads.ListByStatus(ctx, models.DownloadStatusDownloading)
+	if err != nil || len(active) == 0 {
+		return
+	}
+
+	cutoff := time.Now().UTC().Add(-timeout)
+
+	// Group downloads by client to avoid fetching stall status per-download.
+	byClient := make(map[int64][]models.Download)
+	for _, dl := range active {
+		if dl.DownloadClientID == nil || dl.GrabbedAt == nil {
+			continue
+		}
+		if dl.GrabbedAt.After(cutoff) {
+			continue // not old enough yet
+		}
+		byClient[*dl.DownloadClientID] = append(byClient[*dl.DownloadClientID], dl)
+	}
+
+	for clientID, dls := range byClient {
+		client, err := s.clients.GetByID(ctx, clientID)
+		if err != nil || client == nil || !client.Enabled {
+			continue
+		}
+
+		stalledIDs, _, err := downloader.GetStalledIDs(ctx, client)
+		if err != nil {
+			slog.Debug("stall check: failed to fetch stalled IDs", "client", client.Name, "error", err)
+			continue
+		}
+		if len(stalledIDs) == 0 {
+			continue
+		}
+
+		for _, dl := range dls {
+			if dl.TorrentID == nil {
+				continue
+			}
+			if !stalledIDs[strings.ToLower(*dl.TorrentID)] {
+				continue
+			}
+			slog.Warn("stall detected",
+				"title", dl.Title,
+				"grabbed_at", dl.GrabbedAt,
+				"client", client.Name,
+			)
+			s.handleStalledDownload(ctx, &dl)
+		}
+	}
+}
+
+// handleStalledDownload marks a download as failed, records history, adds the
+// release to the blocklist, and triggers a fresh search for the same book.
+func (s *Scheduler) handleStalledDownload(ctx context.Context, dl *models.Download) {
+	reason := "stalled: no peers / no download progress"
+
+	// Mark failed in DB.
+	if err := s.downloads.SetError(ctx, dl.ID, reason); err != nil {
+		slog.Warn("stall: failed to set error", "download_id", dl.ID, "error", err)
+	}
+
+	// Record history event.
+	if s.history != nil {
+		data, _ := json.Marshal(map[string]string{"guid": dl.GUID, "message": reason})
+		_ = s.history.Create(ctx, &models.HistoryEvent{
+			BookID:      dl.BookID,
+			EventType:   models.HistoryEventDownloadStalled,
+			SourceTitle: dl.Title,
+			Data:        string(data),
+		})
+	}
+
+	// Blocklist the release so the next search skips it.
+	if s.blocklist != nil && dl.IndexerID != nil {
+		entry := &models.BlocklistEntry{
+			BookID:    dl.BookID,
+			GUID:      dl.GUID,
+			Title:     dl.Title,
+			IndexerID: dl.IndexerID,
+			Reason:    reason,
+		}
+		if err := s.blocklist.Create(ctx, entry); err != nil {
+			slog.Warn("stall: failed to add to blocklist", "guid", dl.GUID, "error", err)
+		}
+	}
+
+	// Trigger a fresh search if auto-grab is enabled.
+	if dl.BookID == nil {
+		return
+	}
+	if s.settings != nil {
+		if v, _ := s.settings.Get(ctx, "autoGrab.enabled"); v != nil && v.Value == "false" {
+			return
+		}
+	}
+	book, err := s.books.GetByID(ctx, *dl.BookID)
+	if err != nil || book == nil {
+		return
+	}
+	slog.Info("stall: triggering re-search", "title", dl.Title, "book_id", *dl.BookID)
+
+	if s.history != nil {
+		data, _ := json.Marshal(map[string]string{"guid": dl.GUID, "message": "stalled release removed, re-searching"})
+		_ = s.history.Create(ctx, &models.HistoryEvent{
+			BookID:      dl.BookID,
+			EventType:   models.HistoryEventDownloadRequeued,
+			SourceTitle: dl.Title,
+			Data:        string(data),
+		})
+	}
+
+	go s.SearchAndGrabBook(ctx, *book)
 }

--- a/internal/scheduler/scheduler_jobs_test.go
+++ b/internal/scheduler/scheduler_jobs_test.go
@@ -77,10 +77,10 @@ func TestNew_Construction(t *testing.T) {
 	}
 }
 
-// TestStart_RegistersFourJobs verifies that Start() registers exactly 4 cron entries
-// and that Stop() completes cleanly. No jobs fire during this test because all
-// intervals are ≥15 s and we stop immediately after start.
-func TestStart_RegistersFourJobs(t *testing.T) {
+// TestStart_RegistersBaseJobs verifies that Start() registers the expected
+// number of cron entries and that Stop() completes cleanly. No jobs fire
+// during this test because all intervals are ≥15 s and we stop immediately.
+func TestStart_RegistersBaseJobs(t *testing.T) {
 	s := &Scheduler{
 		cron: cron.New(cron.WithSeconds()),
 		// All other fields are nil; closures capture them but are not called
@@ -90,8 +90,11 @@ func TestStart_RegistersFourJobs(t *testing.T) {
 	entries := s.cron.Entries()
 	s.Stop()
 
-	if len(entries) != 4 {
-		t.Errorf("expected 4 cron entries after Start(), got %d", len(entries))
+	// Base jobs: check-downloads (15s), stall-detection (5m), search-wanted (12h),
+	// refresh-metadata (24h), scan-library (6h).
+	const wantJobs = 5
+	if len(entries) != wantJobs {
+		t.Errorf("expected %d cron entries after Start(), got %d", wantJobs, len(entries))
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -200,6 +200,7 @@ export const api = {
 
   // Calibre
   testCalibre: () => request<CalibreTestResult>('/calibre/test', { method: 'POST' }),
+  calibreTestPaths: () => request<{ ok: string; message: string }>('/calibre/test-paths', { method: 'POST' }),
   calibreImportStart: () => request<CalibreImportProgress>('/calibre/import', { method: 'POST' }),
   calibreImportStatus: () => request<CalibreImportProgress>('/calibre/import/status'),
 

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -198,6 +198,7 @@
       "rootfolders": "Stammordner",
       "logs": "Protokolle",
       "general": "Allgemein",
+      "calibre": "Calibre",
       "blocklist": "Blockliste"
     },
     "indexers": {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -203,6 +203,7 @@
       "rootfolders": "Root Folders",
       "logs": "Logs",
       "general": "General",
+      "calibre": "Calibre",
       "blocklist": "Blocklist"
     },
     "indexers": {

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -198,6 +198,7 @@
       "rootfolders": "Dossiers racines",
       "logs": "Journaux",
       "general": "Général",
+      "calibre": "Calibre",
       "blocklist": "Liste de blocage"
     },
     "indexers": {

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -198,6 +198,7 @@
       "rootfolders": "Hoofdmappen",
       "logs": "Logboeken",
       "general": "Algemeen",
+      "calibre": "Calibre",
       "blocklist": "Blokkeerlijst"
     },
     "indexers": {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -7,7 +7,7 @@ import ThemeToggle from '../components/ThemeToggle'
 import LanguageSwitcher from '../components/LanguageSwitcher'
 import { useAuth } from '../auth/AuthContext'
 
-type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import' | 'rootfolders' | 'logs' | 'blocklist'
+type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import' | 'rootfolders' | 'logs' | 'blocklist' | 'calibre'
 
 const inputCls = 'w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600'
 const tabCls = (active: boolean) =>
@@ -73,7 +73,7 @@ export default function SettingsPage() {
       <h2 className="text-2xl font-bold mb-6">{t('settings.title')}</h2>
 
       <div className="flex flex-wrap gap-2 mb-6">
-        {(['general', 'indexers', 'clients', 'rootfolders', 'quality', 'metadata', 'notifications', 'import', 'blocklist', 'logs'] as Tab[]).map(tabKey => (
+        {(['general', 'indexers', 'clients', 'rootfolders', 'quality', 'metadata', 'notifications', 'calibre', 'import', 'blocklist', 'logs'] as Tab[]).map(tabKey => (
           <button key={tabKey} onClick={() => setTab(tabKey)} className={tabCls(tab === tabKey)}>
             {t(`settings.tabs.${tabKey}`)}
           </button>
@@ -558,6 +558,10 @@ export default function SettingsPage() {
 
       {tab === 'general' && (
         <GeneralTab />
+      )}
+
+      {tab === 'calibre' && (
+        <CalibreTab />
       )}
 
       {tab === 'blocklist' && (
@@ -1181,84 +1185,6 @@ function GeneralTab() {
         </div>
       </section>
 
-      {/* Downloads */}
-      <section>
-        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.downloads')}</h3>
-        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-3">
-          <div>
-            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('settings.general.preferredLanguage')}</label>
-            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">{t('settings.general.preferredLanguageHint')}</p>
-            <div className="flex gap-2">
-              <select
-                value={settings['search.preferredLanguage'] ?? 'en'}
-                onChange={e => setSettings(s => ({ ...s, 'search.preferredLanguage': e.target.value }))}
-                className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
-              >
-                <option value="any">{t('settings.general.preferredLanguageAny')}</option>
-                <option value="en">{t('settings.general.preferredLanguageEn')}</option>
-              </select>
-              <button
-                onClick={() => saveSetting('search.preferredLanguage')}
-                disabled={saving === 'search.preferredLanguage'}
-                className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
-              >
-                {saving === 'search.preferredLanguage' ? t('common.saving') : t('common.save')}
-              </button>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Auto-grab */}
-      <section>
-        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.autoGrab')}</h3>
-        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
-          <div className="flex items-center justify-between">
-            <div>
-              <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">{t('settings.general.autoGrabLabel')}</label>
-              <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">{t('settings.general.autoGrabHint')}</p>
-            </div>
-            <button
-              onClick={async () => {
-                const current = (settings['autoGrab.enabled'] ?? 'true').toLowerCase()
-                const next = current === 'false' ? 'true' : 'false'
-                setSettings(s => ({ ...s, 'autoGrab.enabled': next }))
-                await api.setSetting('autoGrab.enabled', next).catch(console.error)
-              }}
-              className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${(settings['autoGrab.enabled'] ?? 'true') !== 'false' ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
-              title={(settings['autoGrab.enabled'] ?? 'true') !== 'false' ? t('common.disable') : t('common.enable')}
-            >
-              <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${(settings['autoGrab.enabled'] ?? 'true') !== 'false' ? 'translate-x-4' : ''}`} />
-            </button>
-          </div>
-        </div>
-      </section>
-
-      {/* Recommendations */}
-      <section>
-        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.recommendations')}</h3>
-        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
-          <div className="flex items-center justify-between">
-            <div>
-              <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">{t('settings.general.recommendationsLabel')}</label>
-              <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">{t('settings.general.recommendationsHint')}</p>
-            </div>
-            <button
-              onClick={async () => {
-                const current = (settings['recommendations.enabled'] ?? 'false').toLowerCase()
-                const next = current === 'true' ? 'false' : 'true'
-                setSettings(s => ({ ...s, 'recommendations.enabled': next }))
-                await api.setSetting('recommendations.enabled', next).catch(console.error)
-              }}
-              className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${(settings['recommendations.enabled'] ?? 'false') === 'true' ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
-              title={(settings['recommendations.enabled'] ?? 'false') === 'true' ? t('common.disable') : t('common.enable')}
-            >
-              <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${(settings['recommendations.enabled'] ?? 'false') === 'true' ? 'translate-x-4' : ''}`} />
-            </button>
-          </div>
-        </div>
-      </section>
-
       {/* Naming */}
       <section>
         <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.fileNaming')}</h3>
@@ -1329,29 +1255,28 @@ function GeneralTab() {
         </div>
       </section>
 
-      {/* Security */}
-      <SecuritySection />
-
-      {/* API Keys */}
+      {/* Downloads */}
       <section>
-        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.apiKeys')}</h3>
-        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-4">
+        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.downloads')}</h3>
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-3">
           <div>
-            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('settings.general.googleBooksKey')}</label>
+            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('settings.general.preferredLanguage')}</label>
+            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">{t('settings.general.preferredLanguageHint')}</p>
             <div className="flex gap-2">
-              <input
-                value={settings['googlebooks.apiKey'] ?? ''}
-                onChange={e => setSettings(s => ({ ...s, 'googlebooks.apiKey': e.target.value }))}
-                placeholder="AIza..."
-                type="password"
+              <select
+                value={settings['search.preferredLanguage'] ?? 'en'}
+                onChange={e => setSettings(s => ({ ...s, 'search.preferredLanguage': e.target.value }))}
                 className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
-              />
+              >
+                <option value="any">{t('settings.general.preferredLanguageAny')}</option>
+                <option value="en">{t('settings.general.preferredLanguageEn')}</option>
+              </select>
               <button
-                onClick={() => saveSetting('googlebooks.apiKey')}
-                disabled={saving === 'googlebooks.apiKey'}
+                onClick={() => saveSetting('search.preferredLanguage')}
+                disabled={saving === 'search.preferredLanguage'}
                 className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
               >
-                {saving === 'googlebooks.apiKey' ? t('common.saving') : t('common.save')}
+                {saving === 'search.preferredLanguage' ? t('common.saving') : t('common.save')}
               </button>
             </div>
           </div>
@@ -1394,6 +1319,85 @@ function GeneralTab() {
         </div>
       </section>
 
+      {/* Auto-grab */}
+      <section>
+        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.autoGrab')}</h3>
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+          <div className="flex items-center justify-between">
+            <div>
+              <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">{t('settings.general.autoGrabLabel')}</label>
+              <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">{t('settings.general.autoGrabHint')}</p>
+            </div>
+            <button
+              onClick={async () => {
+                const current = (settings['autoGrab.enabled'] ?? 'true').toLowerCase()
+                const next = current === 'false' ? 'true' : 'false'
+                setSettings(s => ({ ...s, 'autoGrab.enabled': next }))
+                await api.setSetting('autoGrab.enabled', next).catch(console.error)
+              }}
+              className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${(settings['autoGrab.enabled'] ?? 'true') !== 'false' ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
+              title={(settings['autoGrab.enabled'] ?? 'true') !== 'false' ? t('common.disable') : t('common.enable')}
+            >
+              <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${(settings['autoGrab.enabled'] ?? 'true') !== 'false' ? 'translate-x-4' : ''}`} />
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* Recommendations */}
+      <section>
+        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.recommendations')}</h3>
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+          <div className="flex items-center justify-between">
+            <div>
+              <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">{t('settings.general.recommendationsLabel')}</label>
+              <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">{t('settings.general.recommendationsHint')}</p>
+            </div>
+            <button
+              onClick={async () => {
+                const current = (settings['recommendations.enabled'] ?? 'false').toLowerCase()
+                const next = current === 'true' ? 'false' : 'true'
+                setSettings(s => ({ ...s, 'recommendations.enabled': next }))
+                await api.setSetting('recommendations.enabled', next).catch(console.error)
+              }}
+              className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${(settings['recommendations.enabled'] ?? 'false') === 'true' ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
+              title={(settings['recommendations.enabled'] ?? 'false') === 'true' ? t('common.disable') : t('common.enable')}
+            >
+              <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${(settings['recommendations.enabled'] ?? 'false') === 'true' ? 'translate-x-4' : ''}`} />
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* Security */}
+      <SecuritySection />
+
+      {/* API Keys */}
+      <section>
+        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.apiKeys')}</h3>
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-4">
+          <div>
+            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('settings.general.googleBooksKey')}</label>
+            <div className="flex gap-2">
+              <input
+                value={settings['googlebooks.apiKey'] ?? ''}
+                onChange={e => setSettings(s => ({ ...s, 'googlebooks.apiKey': e.target.value }))}
+                placeholder="AIza..."
+                type="password"
+                className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+              />
+              <button
+                onClick={() => saveSetting('googlebooks.apiKey')}
+                disabled={saving === 'googlebooks.apiKey'}
+                className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+              >
+                {saving === 'googlebooks.apiKey' ? t('common.saving') : t('common.save')}
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* OPDS */}
       <section>
         <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.opds')}</h3>
@@ -1415,14 +1419,6 @@ function GeneralTab() {
           </div>
         </div>
       </section>
-
-      {/* Calibre */}
-      <CalibreSection
-        settings={settings}
-        setSettings={setSettings}
-        saveSetting={saveSetting}
-        saving={saving}
-      />
 
       {/* Backup */}
       <section>
@@ -1461,6 +1457,42 @@ function parseCats(s: string): number[] {
   return s.split(',').map(t => parseInt(t.trim(), 10)).filter(n => !isNaN(n))
 }
 
+function CalibreTab() {
+  const [settings, setSettings] = useState<Record<string, string>>({})
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState<string | null>(null)
+
+  useEffect(() => {
+    api.listSettings()
+      .then(list => {
+        const map: Record<string, string> = {}
+        list.forEach(s => { map[s.key] = s.value })
+        setSettings(map)
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [])
+
+  const saveSetting = async (key: string) => {
+    setSaving(key)
+    try {
+      await api.setSetting(key, settings[key] ?? '')
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  if (loading) return <div className="text-slate-600 dark:text-zinc-500">Loading…</div>
+
+  return (
+    <div className="space-y-8">
+      <CalibreSection settings={settings} setSettings={setSettings} saveSetting={saveSetting} saving={saving} />
+    </div>
+  )
+}
+
 // CalibreSection renders the calibre.* settings fields plus a Test button
 // that hits /calibre/test. The Mode radio picks between two integration
 // flows: `calibredb` shells out to the CLI (requires Calibre on the host),
@@ -1480,6 +1512,8 @@ function CalibreSection({
 }) {
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null)
+  const [testingPaths, setTestingPaths] = useState(false)
+  const [testPathsResult, setTestPathsResult] = useState<{ ok: boolean; msg: string } | null>(null)
   const [importProgress, setImportProgress] = useState<CalibreImportProgress | null>(null)
   const [importError, setImportError] = useState<string | null>(null)
 
@@ -1533,6 +1567,19 @@ function CalibreSection({
       setTestResult({ ok: false, msg: err instanceof Error ? err.message : 'Test failed' })
     } finally {
       setTesting(false)
+    }
+  }
+
+  const runTestPaths = async () => {
+    setTestingPaths(true)
+    setTestPathsResult(null)
+    try {
+      const r = await api.calibreTestPaths()
+      setTestPathsResult({ ok: true, msg: r.message })
+    } catch (err) {
+      setTestPathsResult({ ok: false, msg: err instanceof Error ? err.message : 'Test failed' })
+    } finally {
+      setTestingPaths(false)
     }
   }
 
@@ -1665,6 +1712,25 @@ function CalibreSection({
               className="px-4 py-2 bg-slate-600 hover:bg-slate-500 rounded text-sm font-medium disabled:opacity-50 flex-shrink-0"
             >
               {testing ? 'Testing…' : 'Test connection'}
+            </button>
+          </div>
+        )}
+
+        {mode === 'drop_folder' && (
+          <div className="flex items-center justify-between pt-1 border-t border-slate-200 dark:border-zinc-800">
+            <div className="text-xs">
+              {testPathsResult && (
+                <span className={testPathsResult.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}>
+                  {testPathsResult.msg}
+                </span>
+              )}
+            </div>
+            <button
+              onClick={runTestPaths}
+              disabled={testingPaths}
+              className="px-4 py-2 bg-slate-600 hover:bg-slate-500 rounded text-sm font-medium disabled:opacity-50 flex-shrink-0"
+            >
+              {testingPaths ? 'Testing…' : 'Test paths'}
             </button>
           </div>
         )}


### PR DESCRIPTION
## Summary

Closes #142

- **Detection job** runs every 5 minutes, checks all downloads in `downloading` state that were grabbed longer ago than the stall timeout (default 2 hours, configurable via `stall.timeout_minutes` setting)
- **qBittorrent**: detects `stalledDL` state (no peers / seeds available) — the most reliable signal; requires both the state AND the timeout to prevent false positives on temporarily-slow peers
- **Transmission**: detects stopped torrents with a non-empty `errorString`
- **SABnzbd**: not needed — existing `checkSABnzbdDownloads` already surfaces failed NZBs as `Failed` status

## Response when stall confirmed

1. Mark download `Failed` with reason `"stalled: no peers / no download progress"`
2. Record `downloadStalled` history event (new event type)
3. Blocklist the release GUID so the same broken release isn't grabbed again
4. If `autoGrab.enabled` is not `false`, call `SearchAndGrabBook` to find a fresh source; record `downloadRequeued` history event

## New pieces

| File | Change |
|------|--------|
| `internal/downloader/adapter.go` | `GetStalledIDs` — queries client and returns stalled remote IDs without touching the live-status map |
| `internal/scheduler/scheduler.go` | `checkStalledDownloads` + `handleStalledDownload`; `WithHistory` setter; 5-min cron job |
| `internal/models/settings.go` | `HistoryEventDownloadStalled`, `HistoryEventDownloadRequeued` constants |
| `cmd/bindery/main.go` | Wire `sched.WithHistory(historyRepo)` |

## Test plan

- [ ] Add a qBittorrent torrent that has no seeds → confirm it appears as `stalledDL` in qBit UI
- [ ] Wait for stall timeout (or temporarily set `stall.timeout_minutes=1` in the DB) → confirm download transitions to `Failed` in Bindery queue
- [ ] Confirm the release GUID appears in Blocklist
- [ ] Confirm a new grab appears in History / Queue (if a new result is found)
- [ ] Confirm `downloadStalled` and `downloadRequeued` events appear in History
- [ ] Downloads not yet past the timeout remain `downloading` — no false positives