### PR TITLE
fix(auth): set login form method to POST

### DIFF
--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -41,7 +41,7 @@ export default function LoginPage() {
 
   return (
     <CardShell title={t('login.title')} subtitle="">
-      <form onSubmit={submit} className="space-y-4">
+      <form onSubmit={submit} method="post" className="space-y-4">
         <Field label={t('login.username')}>
           <input
             type="text"


### PR DESCRIPTION
HTML form default method is GET. The login form submits credentials via JS fetch (onSubmit handler), but the explicit method attribute is missing — browsers may treat the form as GET which can expose credentials in URLs on fallback. Adds method="post" to be explicit.