### PR TITLE
fix(ui): version badge links to GitHub release, footer links to repo

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -86,9 +86,18 @@ function Shell() {
                 </svg>
               </NavLink>
               {version && (
-                <span className="hidden lg:block text-xs text-slate-500 dark:text-zinc-600 whitespace-nowrap">
-                  {/^\d+\.\d+/.test(version) ? `v${version}` : version}
-                </span>
+                /^\d+\.\d+/.test(version) ? (
+                  <a
+                    href={`https://github.com/vavallee/bindery/releases/tag/v${version}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="hidden lg:block text-xs text-slate-500 dark:text-zinc-600 hover:underline whitespace-nowrap"
+                  >
+                    {`v${version}`}
+                  </a>
+                ) : (
+                  <span className="hidden lg:block text-xs text-slate-500 dark:text-zinc-600 whitespace-nowrap">{version}</span>
+                )
               )}
               {status?.authenticated && status.mode !== 'disabled' && (
                 <button
@@ -142,9 +151,18 @@ function Shell() {
             </nav>
             <div className="flex items-center justify-between px-4 py-2 border-t border-slate-200 dark:border-zinc-800">
               {version && (
-                <span className="text-xs text-slate-500 dark:text-zinc-600">
-                  {/^\d+\.\d+/.test(version) ? `v${version}` : version}
-                </span>
+                /^\d+\.\d+/.test(version) ? (
+                  <a
+                    href={`https://github.com/vavallee/bindery/releases/tag/v${version}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-slate-500 dark:text-zinc-600 hover:underline"
+                  >
+                    {`v${version}`}
+                  </a>
+                ) : (
+                  <span className="text-xs text-slate-500 dark:text-zinc-600">{version}</span>
+                )
               )}
               {status?.authenticated && status.mode !== 'disabled' && (
                 <button
@@ -179,7 +197,7 @@ function Shell() {
       <footer className="border-t border-slate-200 dark:border-zinc-800 mt-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-center gap-2">
           <a
-            href="https://github.com/vavallee"
+            href="https://github.com/vavallee/bindery"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-2 text-slate-500 dark:text-zinc-600 hover:text-slate-700 dark:hover:text-zinc-300 transition-colors text-xs"
@@ -187,7 +205,7 @@ function Shell() {
             <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
             </svg>
-            vavallee
+            vavallee/bindery
           </a>
         </div>
       </footer>


### PR DESCRIPTION
Two small link fixes:
- Version string in sidebar/drawer becomes a link to the tagged release on GitHub (only when version is a semver string)
- Footer GitHub link pointed to the user profile instead of the repo; corrected to vavallee/bindery