### PR TITLE
fix(a11y): add aria-labels to calendar prev/next month buttons

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -189,7 +189,9 @@
     "title": "Calendar",
     "today": "Today",
     "noReleases": "No monitored books releasing this month",
-    "releasingIn": "Releasing in {{month}} {{year}}"
+    "releasingIn": "Releasing in {{month}} {{year}}",
+    "prevMonth": "Previous month",
+    "nextMonth": "Next month"
   },
   "settings": {
     "title": "Settings",

--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -84,6 +84,7 @@ export default function CalendarPage() {
           )}
           <button
             onClick={prevMonth}
+            aria-label={t('calendar.prevMonth')}
             className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded transition-colors"
           >
             ‹
@@ -93,6 +94,7 @@ export default function CalendarPage() {
           </span>
           <button
             onClick={nextMonth}
+            aria-label={t('calendar.nextMonth')}
             className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded transition-colors"
           >
             ›


### PR DESCRIPTION
The calendar navigation buttons rendered only '‹' and '›' glyphs with no accessible label. Screen readers would announce these as 'less-than sign' or similar. Added aria-label via i18n keys (prevMonth/nextMonth).