### PR TITLE
fix(auth): recheck auth status when tab regains visibility

### DIFF
--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -30,6 +30,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => { refresh() }, [refresh])
 
+  useEffect(() => {
+    const onVisible = () => { if (document.visibilityState === 'visible') refresh() }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => document.removeEventListener('visibilitychange', onVisible)
+  }, [refresh])
+
   const logout = useCallback(async () => {
     try { await api.authLogout() } catch { /* ignore — we're clearing state anyway */ }
     await refresh()


### PR DESCRIPTION
Auth status was only fetched on app mount. If a session expires while the tab is backgrounded (e.g. overnight), the user would get silent 401s on their next action rather than a clean redirect to login. Adding a visibilitychange listener that calls refresh() whenever the tab becomes visible again ensures the guard can redirect promptly.