### PR TITLE
feat(ui): set per-page document.title for browser tab identification

### DIFF
--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -99,6 +99,13 @@ export default function AuthorDetailPage() {
   }, [dateSort])
 
   useEffect(() => {
+    if (author?.authorName) {
+      document.title = `${author.authorName} · Bindery`
+      return () => { document.title = 'Bindery' }
+    }
+  }, [author?.authorName])
+
+  useEffect(() => {
     let cancelled = false
     setLoading(true)
     Promise.all([

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -92,6 +92,11 @@ export default function AuthorsPage() {
     if (selectAllRef.current) selectAllRef.current.indeterminate = somePageSelected
   }, [somePageSelected])
 
+  useEffect(() => {
+    document.title = 'Authors · Bindery'
+    return () => { document.title = 'Bindery' }
+  }, [])
+
   const toggleSelect = (id: number) => {
     setSelectedIds(prev => {
       const next = new Set(prev)

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -45,6 +45,13 @@ export default function BookDetailPage() {
   const [togglingExclude, setTogglingExclude] = useState(false)
 
   useEffect(() => {
+    if (book?.title) {
+      document.title = `${book.title} · Bindery`
+      return () => { document.title = 'Bindery' }
+    }
+  }, [book?.title])
+
+  useEffect(() => {
     let cancelled = false
     setLoading(true)
     Promise.all([

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -92,6 +92,11 @@ export default function BooksPage() {
     if (selectAllRef.current) selectAllRef.current.indeterminate = somePageSelected
   }, [somePageSelected])
 
+  useEffect(() => {
+    document.title = 'Books · Bindery'
+    return () => { document.title = 'Bindery' }
+  }, [])
+
   const toggleSelect = (id: number) => {
     setSelectedIds(prev => {
       const next = new Set(prev)

--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -30,6 +30,11 @@ export default function CalendarPage() {
     api.listBooks().then(setBooks).catch(console.error).finally(() => setLoading(false))
   }, [])
 
+  useEffect(() => {
+    document.title = 'Calendar · Bindery'
+    return () => { document.title = 'Bindery' }
+  }, [])
+
   const prevMonth = () => {
     if (viewMonth === 0) { setViewMonth(11); setViewYear(y => y - 1) }
     else setViewMonth(m => m - 1)

--- a/web/src/pages/DiscoverPage.tsx
+++ b/web/src/pages/DiscoverPage.tsx
@@ -47,6 +47,11 @@ export default function DiscoverPage() {
     checkEnabled()
   }, [load, checkEnabled])
 
+  useEffect(() => {
+    document.title = 'Discover · Bindery'
+    return () => { document.title = 'Bindery' }
+  }, [])
+
   const showToast = (msg: string) => {
     setToast(msg)
     setTimeout(() => setToast(null), 2500)

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -63,6 +63,11 @@ export default function HistoryPage() {
 
   useEffect(() => { load() }, [load])
 
+  useEffect(() => {
+    document.title = 'History · Bindery'
+    return () => { document.title = 'Bindery' }
+  }, [])
+
   const handleFilterChange = (val: string) => {
     setTypeFilter(val)
     setLoading(true)

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -17,6 +17,11 @@ export default function QueuePage() {
     return () => clearInterval(interval)
   }, [])
 
+  useEffect(() => {
+    document.title = 'Queue · Bindery'
+    return () => { document.title = 'Bindery' }
+  }, [])
+
   const handleDelete = async (id: number) => {
     await api.deleteFromQueue(id)
     load()

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -10,6 +10,11 @@ export default function SeriesPage() {
     api.listSeries().then(setSeriesList).catch(console.error).finally(() => setLoading(false))
   }, [])
 
+  useEffect(() => {
+    document.title = 'Series · Bindery'
+    return () => { document.title = 'Bindery' }
+  }, [])
+
   const toggleExpanded = (id: number) => {
     setExpanded(prev => (prev === id ? null : id))
   }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -42,6 +42,11 @@ export default function SettingsPage() {
   }, [])
 
   useEffect(() => {
+    document.title = 'Settings · Bindery'
+    return () => { document.title = 'Bindery' }
+  }, [])
+
+  useEffect(() => {
     if (tab === 'notifications') api.listNotifications().then(setNotifications).catch(console.error)
     if (tab === 'quality') api.listQualityProfiles().then(setQualityProfiles).catch(console.error)
     if (tab === 'metadata') api.listMetadataProfiles().then(setMetadataProfiles).catch(console.error)

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -110,6 +110,11 @@ export default function WantedPage() {
     if (selectAllRef.current) selectAllRef.current.indeterminate = somePageSelected
   }, [somePageSelected])
 
+  useEffect(() => {
+    document.title = 'Wanted · Bindery'
+    return () => { document.title = 'Bindery' }
+  }, [])
+
   const toggleSelect = (id: number) => {
     setSelectedIds(prev => {
       const next = new Set(prev)


### PR DESCRIPTION
All tabs previously showed 'Bindery' making it impossible to distinguish multiple open pages at a glance. Each page now sets a descriptive title (e.g. 'Books · Bindery', 'Settings · Bindery'). Detail pages (author, book) set the title once the entity name loads. Title resets to 'Bindery' on unmount.