### PR TITLE
fix(calibre): surface save errors in UI and fix NFS path case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,22 +111,28 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
-      # Deploy: bump Helm chart image tag on main and development branches.
-      # ArgoCD can track either branch — switch targetRevision to flip
-      # between prod (main) and dev (development).
+      # Deploy: bump Helm chart image tag in development via the GitHub API.
+      # Always targets development regardless of which branch triggered the build —
+      # main is PR-gated so a direct git push is rejected by branch protection.
+      # ArgoCD watches development; tag bumps reach main naturally via merge.
       - name: Update Helm image tag
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           IMAGE_TAG="sha-${GITHUB_SHA::7}"
-          sed -i "s|tag:.*|tag: \"${IMAGE_TAG}\"|" charts/bindery/values.yaml
-      - name: Commit and push
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
-        run: |
-          git config user.name "vavallee"
-          git config user.email "75899046+vavallee@users.noreply.github.com"
-          git add charts/bindery/values.yaml
-          git diff --staged --quiet || git commit -m "chore(deploy): update bindery image to sha-${GITHUB_SHA::7} [skip ci]"
-          git push
+          FILE_PATH="charts/bindery/values.yaml"
+          FILE_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${FILE_PATH}" \
+            --jq .sha -f ref=development)
+          CONTENT=$(sed "s|tag:.*|tag: \"${IMAGE_TAG}\"|" "${FILE_PATH}" | base64 -w0)
+          gh api "repos/${GITHUB_REPOSITORY}/contents/${FILE_PATH}" \
+            -X PUT \
+            -f message="chore(deploy): update bindery image to ${IMAGE_TAG} [skip ci]" \
+            -f content="${CONTENT}" \
+            -f sha="${FILE_SHA}" \
+            -f branch="development" \
+            --silent
+          echo "Pushed ${IMAGE_TAG} to development/${FILE_PATH}"
 
       - name: Trigger Argo CD refresh
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,23 @@ jobs:
           git config user.email "75899046+vavallee@users.noreply.github.com"
           git add charts/bindery/values.yaml
           git diff --staged --quiet || git commit -m "chore(deploy): update bindery image to sha-${GITHUB_SHA::7} [skip ci]"
-          git push || true  # best-effort: branch protection may reject on development
+          git push
+
+      - name: Trigger Argo CD refresh
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/development'
+        env:
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
+          ARGOCD_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          if [ -z "${ARGOCD_SERVER:-}" ] || [ -z "${ARGOCD_TOKEN:-}" ]; then
+            echo "::warning::ARGOCD_SERVER or ARGOCD_TOKEN not configured — Argo will pick up changes on next poll"
+            exit 0
+          fi
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${ARGOCD_TOKEN}" \
+            "${ARGOCD_SERVER}/api/v1/applications/bindery?refresh=hard" \
+            && echo "Argo CD refresh triggered" \
+            || echo "::warning::Argo CD refresh trigger failed — Argo will pick up changes on next poll"
 
       # Create GitHub Release on tag push using the matching CHANGELOG section.
       # Idempotent: updates notes if a release for the tag already exists.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -82,7 +82,6 @@ jobs:
 
       - name: npm audit
         run: npm audit --audit-level=high --prefix web
-        continue-on-error: true
 
       - name: Install ESLint security tooling
         run: |
@@ -239,7 +238,7 @@ jobs:
           format: sarif
           output: trivy.sarif
           severity: CRITICAL,HIGH
-          exit-code: '0'
+          exit-code: '1'
 
       - name: Upload Trivy SARIF
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
@@ -255,7 +254,7 @@ jobs:
           image: bindery:scan
           output-format: sarif
           output-file: grype.sarif
-          fail-build: false
+          fail-build: true
 
       - name: Upload Grype SARIF
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ The `development` branch carries the in-flight feature set for the next release.
 
 - **Calibre library import (closes [#63](https://github.com/vavallee/bindery/issues/63))** — Bindery can now ingest an existing Calibre library via a new **Import library** button in Settings → General → Calibre. The importer opens Calibre's `metadata.db` read-only, streams authors / books / series / editions / ISBNs / covers, and upserts them into Bindery — deduplicating via `books.calibre_id` first and author-alias-aware title match second, so running the import twice is idempotent. Co-authors become alias rows on the canonical author. A polled progress endpoint (`GET /api/v1/calibre/import/status`) drives a live progress bar and a final summary of `{authorsAdded, booksAdded, editionsAdded, duplicatesMerged, skipped}`. A new **Sync on startup** toggle runs the same import on every boot (off by default).
 
+## [v0.16.0] — 2026-04-17
+
+Calibre library import, Settings reorganisation, stalled download detection, and image proxy hardening.
+
+### Added
+
+- **Calibre library import** ([#63](https://github.com/vavallee/bindery/issues/63)) — import books, authors, and editions from an existing Calibre `metadata.db` via Settings → Calibre → Library import. Incremental and idempotent; progress bar with live stats.
+- **Calibre Settings tab** — Calibre settings extracted from the General tab into a dedicated tab. Eliminates the duplicate `library_path` field; single shared path at the top used by both write integration and library import. Adds "Test paths" button for drop-folder mode (validates `metadata.db` readable, drop folder writable).
+- **Stalled download detection** ([#142](https://github.com/vavallee/bindery/issues/142)) — background job detects qBittorrent `stalledDL` torrents and Transmission stopped-with-error states. Automatically marks failed, blocklists the release, and triggers a re-search.
+
+### Fixed
+
+- **calibredb error messages** ([#160](https://github.com/vavallee/bindery/issues/160)) — "no such file or directory" now includes the path and explains the binary must be accessible inside the Bindery container, not just on the Docker host.
+- **Image proxy cache** ([#138](https://github.com/vavallee/bindery/issues/138)) — sharded cache directories, LRU eviction, and atomic writes prevent corruption on large libraries.
+- **Calibre import when write mode is off** — library import no longer incorrectly gated behind the write-mode toggle.
+- **Calibre crash recovery** — pod restarts between `Create` and `SetCalibreID` no longer produce duplicate book rows.
+- **Author sync duplicate constraint** — UNIQUE constraint on `books.foreign_id` during concurrent author syncs treated as benign skip.
+- **TOCTOU-safe file copy** — importer uses `os.Root` for directory copy/hardlink to prevent symlink traversal.
+
+### Upgrade notes
+
+- **Schema:** migration `018_calibre_sync.sql` adds tables for Calibre library import. Drop-in binary or image replacement is safe.
+
 ## [v0.8.0] — 2026-04-14
 
 Major feature release. Calibre users can finally automate the last mile — finished Bindery imports land in Calibre with no manual "Add books" step. Library curation gets a sharper tool: the author list stops fragmenting into "RR Haywood" / "R.R. Haywood" / "R R Haywood" duplicates, and the new **Merge authors** flow reunites them under one canonical row. Backend test coverage continues its climb, with `internal/api` and `internal/importer` both breaking 60%.

--- a/charts/bindery/templates/deployment.yaml
+++ b/charts/bindery/templates/deployment.yaml
@@ -58,12 +58,14 @@ spec:
             failureThreshold: 30
             periodSeconds: 5
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /api/v1/health
               port: http
             failureThreshold: 3
             periodSeconds: 10
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /api/v1/health
               port: http
             failureThreshold: 5
             initialDelaySeconds: 30

--- a/charts/bindery/templates/hooks/postsync-smoke.yaml
+++ b/charts/bindery/templates/hooks/postsync-smoke.yaml
@@ -37,10 +37,8 @@ spec:
             - |
               set -e
               echo "Running post-sync smoke test..."
-              STATUS=$(wget -q -O /dev/null -S --max-redirect=0 \
-                --timeout=10 \
-                "http://{{ include "bindery.fullname" . }}:{{ .Values.service.port }}/api/v1/health" \
-                2>&1 | grep "HTTP/" | awk '{print $2}' | head -1)
+              URL="http://{{ include "bindery.fullname" . }}:{{ .Values.service.port }}/api/v1/health"
+              STATUS=$(wget -q -S -O /dev/null -T 10 "$URL" 2>&1 | grep "HTTP/" | awk '{print $2}' | head -1)
               if [ "$STATUS" = "200" ]; then
                 echo "Health check passed (HTTP $STATUS)"
                 exit 0

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -105,7 +105,7 @@ hooks:
     # ArgoCD PostSync Job that probes /api/v1/health and fails the sync if
     # the endpoint doesn't return 200 within 10 seconds. Harmless outside
     # of ArgoCD (it's a one-shot Job that runs and exits).
-    enabled: false
+    enabled: true
     # Image used by the smoke-test container. Kept intentionally minimal
     # (busybox gives us wget + sh). Pin a digest in strict environments.
     image: busybox:1.37

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "sha-bfb19d8"
+  tag: "sha-439a631"
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -26,7 +26,7 @@ persistence:
 nfs:
   enabled: false
   server: ""
-  path: /volume1/media
+  path: /volume1/MEDIA
   mountPath: /media
 
 env:

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1473,12 +1473,13 @@ function CalibreTab() {
       .finally(() => setLoading(false))
   }, [])
 
-  const saveSetting = async (key: string) => {
+  const saveSetting = async (key: string): Promise<string | null> => {
     setSaving(key)
     try {
       await api.setSetting(key, settings[key] ?? '')
+      return null
     } catch (err) {
-      console.error(err)
+      return err instanceof Error ? err.message : 'Save failed'
     } finally {
       setSaving(null)
     }
@@ -1507,15 +1508,22 @@ function CalibreSection({
 }: {
   settings: Record<string, string>
   setSettings: (fn: (prev: Record<string, string>) => Record<string, string>) => void
-  saveSetting: (key: string) => Promise<void>
+  saveSetting: (key: string) => Promise<string | null>
   saving: string | null
 }) {
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null)
   const [testingPaths, setTestingPaths] = useState(false)
   const [testPathsResult, setTestPathsResult] = useState<{ ok: boolean; msg: string } | null>(null)
+  const [saveError, setSaveError] = useState<{ key: string; msg: string } | null>(null)
   const [importProgress, setImportProgress] = useState<CalibreImportProgress | null>(null)
   const [importError, setImportError] = useState<string | null>(null)
+
+  const saveSettingWithError = async (key: string) => {
+    setSaveError(null)
+    const err = await saveSetting(key)
+    if (err) setSaveError({ key, msg: err })
+  }
 
   // Legacy fallback: a pre-migration DB with `calibre.enabled=true` but no
   // mode set should still render as 'calibredb' so the user's existing
@@ -1641,13 +1649,16 @@ function CalibreSection({
                 className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
               />
               <button
-                onClick={() => saveSetting('calibre.library_path')}
+                onClick={() => saveSettingWithError('calibre.library_path')}
                 disabled={saving === 'calibre.library_path'}
                 className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
               >
                 {saving === 'calibre.library_path' ? 'Saving...' : 'Save'}
               </button>
             </div>
+            {saveError?.key === 'calibre.library_path' && (
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1">{saveError.msg}</p>
+            )}
           </div>
         )}
 
@@ -1663,13 +1674,16 @@ function CalibreSection({
                 className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
               />
               <button
-                onClick={() => saveSetting('calibre.binary_path')}
+                onClick={() => saveSettingWithError('calibre.binary_path')}
                 disabled={saving === 'calibre.binary_path'}
                 className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
               >
                 {saving === 'calibre.binary_path' ? 'Saving...' : 'Save'}
               </button>
             </div>
+            {saveError?.key === 'calibre.binary_path' && (
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1">{saveError.msg}</p>
+            )}
           </div>
         )}
 
@@ -1687,13 +1701,16 @@ function CalibreSection({
                 className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
               />
               <button
-                onClick={() => saveSetting('calibre.drop_folder_path')}
+                onClick={() => saveSettingWithError('calibre.drop_folder_path')}
                 disabled={saving === 'calibre.drop_folder_path'}
                 className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
               >
                 {saving === 'calibre.drop_folder_path' ? 'Saving...' : 'Save'}
               </button>
             </div>
+            {saveError?.key === 'calibre.drop_folder_path' && (
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1">{saveError.msg}</p>
+            )}
           </div>
         )}
 
@@ -1776,13 +1793,16 @@ function CalibreSection({
                     className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
                   />
                   <button
-                    onClick={() => saveSetting('calibre.library_path')}
+                    onClick={() => saveSettingWithError('calibre.library_path')}
                     disabled={saving === 'calibre.library_path'}
                     className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
                   >
                     {saving === 'calibre.library_path' ? 'Saving...' : 'Save'}
                   </button>
                 </div>
+                {saveError?.key === 'calibre.library_path' && (
+                  <p className="text-xs text-red-600 dark:text-red-400 mt-1">{saveError.msg}</p>
+                )}
               </div>
 
               <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary

- **Silent save failure** — `saveSetting` swallowed 400 errors from the backend (e.g. `library_path` validation failing because the path doesn't exist on the server). The user saw nothing, the field appeared saved but wasn't. Now the error is returned and displayed inline below the relevant field.
- **NFS path case** — default `values.yaml` had `/volume1/media` (lowercase); corrected to `/volume1/MEDIA` to match the NAS path on a case-sensitive Linux NFS mount.