### PR TITLE
fix(chart): correct download path remap for SABnzbd NFS layout

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -42,7 +42,7 @@ env:
   # Comma-separated from:to pairs rewriting paths reported by the download
   # client into paths bindery can see. Needed when SAB and bindery run in
   # separate pods with different mount points for the same storage.
-  BINDERY_DOWNLOAD_PATH_REMAP: /downloads:/media/BOOKS/incoming
+  BINDERY_DOWNLOAD_PATH_REMAP: /downloads:/media
 
 resources:
   requests:


### PR DESCRIPTION
## Problem

SABnzbd mounts NFS \`/volume1/MEDIA\` at \`/downloads\`. Completed downloads land at \`/media/complete/<name>\` from Bindery's perspective. The previous remap \`/downloads:/media/BOOKS/incoming\` made Bindery look at \`/media/BOOKS/incoming/complete/<name>\` — a path that doesn't exist — so it logged "no book files found in download" and skipped every import.

## Fix

Changed remap to \`/downloads:/media\` so the path translation lines up with where SABnzbd actually puts files.