### PR TITLE
chore(argocd): update reference application.yaml with NFS overlay

### DIFF
--- a/argocd/application.yaml
+++ b/argocd/application.yaml
@@ -26,6 +26,10 @@ spec:
           entryPoints:
             - internal-https
           certResolver: internal
+        nfs:
+          enabled: true
+          server: 192.168.1.4
+          path: /volume1/MEDIA
   destination:
     server: https://kubernetes.default.svc
     namespace: default


### PR DESCRIPTION
Keeps the in-repo reference in sync with the live homelab deployment. The authoritative ArgoCD Application lives in vavallee/homelab — this is documentation only.