### PR TITLE
fix(openlibrary): handle object-typed series entries (Pierce Brown fix)

### DIFF
--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -610,6 +610,47 @@ func TestGetAuthorWorks_HTTP(t *testing.T) {
 	}
 }
 
+// TestGetAuthorWorks_HTTP_ObjectSeries covers the schema variance seen with
+// Pierce Brown where OpenLibrary returns series as [{key,title}] objects
+// instead of plain strings. The parser should not error and should extract the
+// title when present.
+func TestGetAuthorWorks_HTTP_ObjectSeries(t *testing.T) {
+	worksBody := `{
+		"size": 1,
+		"entries": [{
+			"key": "/works/OL12345W",
+			"title": "Red Rising",
+			"series": [{"key": "/works/OL9999W", "title": "Red Rising #1"}]
+		}]
+	}`
+	langResp := `{"docs":[{"key":"/works/OL12345W","language":["eng"]}]}`
+
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/authors/OL999A/works.json": worksBody,
+		"/search.json":               langResp,
+	})
+
+	books, err := c.GetAuthorWorks(context.Background(), "OL999A")
+	if err != nil {
+		t.Fatalf("GetAuthorWorks with object series: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	if books[0].Title != "Red Rising" {
+		t.Errorf("title: want 'Red Rising', got %q", books[0].Title)
+	}
+	if len(books[0].SeriesRefs) != 1 {
+		t.Errorf("expected 1 series ref, got %d", len(books[0].SeriesRefs))
+	}
+	if books[0].SeriesRefs[0].Title != "Red Rising" {
+		t.Errorf("series title: want 'Red Rising', got %q", books[0].SeriesRefs[0].Title)
+	}
+	if books[0].SeriesRefs[0].Position != "1" {
+		t.Errorf("series position: want '1', got %q", books[0].SeriesRefs[0].Position)
+	}
+}
+
 func TestGetAuthorWorks_HTTP_Error(t *testing.T) {
 	c := newClientWithStatus(t,
 		map[string]interface{}{"/authors/OL404A/works.json": "error"},

--- a/internal/metadata/openlibrary/types.go
+++ b/internal/metadata/openlibrary/types.go
@@ -1,6 +1,38 @@
 package openlibrary
 
+import "encoding/json"
+
 // OpenLibrary API response types
+
+// flexStringSlice unmarshals a JSON array whose elements may be plain strings
+// or objects (e.g. {"key": "...", "title": "..."}). Strings are kept as-is;
+// objects are decoded by extracting the "title" field when present, otherwise
+// they are skipped. This handles schema variance in the OpenLibrary works API.
+type flexStringSlice []string
+
+func (f *flexStringSlice) UnmarshalJSON(data []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for _, elem := range raw {
+		var s string
+		if err := json.Unmarshal(elem, &s); err == nil {
+			*f = append(*f, s)
+			continue
+		}
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(elem, &obj); err == nil {
+			if titleRaw, ok := obj["title"]; ok {
+				var title string
+				if err := json.Unmarshal(titleRaw, &title); err == nil && title != "" {
+					*f = append(*f, title)
+				}
+			}
+		}
+	}
+	return nil
+}
 
 type searchResponse struct {
 	NumFound int         `json:"numFound"`
@@ -43,22 +75,22 @@ type authorWorksResponse struct {
 }
 
 type authorWorkEntry struct {
-	Key         string      `json:"key"` // "/works/OL123W"
-	Title       string      `json:"title"`
-	Description interface{} `json:"description"`
-	Covers      []int       `json:"covers"`
-	Subjects    []string    `json:"subjects"`
-	Series      []string    `json:"series"`
+	Key         string          `json:"key"` // "/works/OL123W"
+	Title       string          `json:"title"`
+	Description interface{}     `json:"description"`
+	Covers      []int           `json:"covers"`
+	Subjects    []string        `json:"subjects"`
+	Series      flexStringSlice `json:"series"`
 }
 
 type workResponse struct {
-	Key         string       `json:"key"` // "/works/OL123W"
-	Title       string       `json:"title"`
-	Description interface{}  `json:"description"` // can be string or {type, value}
-	Covers      []int        `json:"covers"`
-	Subjects    []string     `json:"subjects"`
-	Authors     []workAuthor `json:"authors"`
-	Series      []string     `json:"series"`
+	Key         string          `json:"key"` // "/works/OL123W"
+	Title       string          `json:"title"`
+	Description interface{}     `json:"description"` // can be string or {type, value}
+	Covers      []int           `json:"covers"`
+	Subjects    []string        `json:"subjects"`
+	Authors     []workAuthor    `json:"authors"`
+	Series      flexStringSlice `json:"series"`
 }
 
 type workAuthor struct {


### PR DESCRIPTION
## Summary
- OpenLibrary's works API occasionally returns `series` as an array of objects (`[{"key": "...", "title": "..."}]`) instead of plain strings
- This caused a JSON unmarshal error for Pierce Brown (`OL7621609A`) and likely other authors, silently failing the entire author-works sync
- Introduces `flexStringSlice`, a custom `json.Unmarshaler` that accepts both formats: strings are kept as-is, objects have their `title` field extracted

## Test plan
- [ ] `go test ./internal/metadata/openlibrary/...` — new `TestGetAuthorWorks_HTTP_ObjectSeries` covers the object-array case end-to-end
- [ ] Full suite passes: `go test ./...`
- [ ] After deploy: add Pierce Brown in Bindery UI — books should sync instead of logging `failed to fetch books`