### PR TITLE
fix(search): default to no language filter instead of English-only

### DIFF
--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -215,11 +215,12 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 }
 
 // resolveAllowedLanguages returns the parsed allowed-language list for an
-// author's metadata profile, falling back to English-only if the profile
-// cannot be loaded (preserves existing filtering behaviour for new installs).
+// author's metadata profile. Returns empty (no filter) when the profile
+// cannot be loaded — imposing English-only as a fallback silently breaks
+// users whose indexers return language-tagged releases.
 func (h *IndexerHandler) resolveAllowedLanguages(ctx context.Context, author *models.Author) []string {
 	if h.profiles == nil {
-		return []string{"eng"}
+		return []string{}
 	}
 	id := models.DefaultMetadataProfileID
 	if author.MetadataProfileID != nil {
@@ -227,7 +228,7 @@ func (h *IndexerHandler) resolveAllowedLanguages(ctx context.Context, author *mo
 	}
 	p, err := h.profiles.GetByID(ctx, id)
 	if err != nil || p == nil {
-		return []string{"eng"}
+		return []string{}
 	}
 	return models.ParseAllowedLanguages(p.AllowedLanguages)
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -228,7 +228,7 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		}
 	}
 
-	lang := "en"
+	lang := ""
 	if s.settings != nil {
 		if langSetting, err := s.settings.Get(ctx, "search.preferredLanguage"); err != nil {
 			slog.Warn("failed to load preferred search language", "error", err)


### PR DESCRIPTION
## Problem

Closes #211.

Two places defaulted to English-only language filtering:

1. `internal/scheduler/scheduler.go` — `lang` was initialised to `"en"` before reading `search.preferredLanguage`. Any user without that setting got English-only filtering applied by the scheduler's auto-grab path.
2. `internal/api/indexers.go` `resolveAllowedLanguages` — returned `[]string{"eng"}` when the metadata profile couldn't be loaded, imposing English-only filtering silently.

Both caused `FilterByLanguage` to drop every release tagged GERMAN/DEUTSCH/etc, producing 0 results for users whose indexers language-tag their releases (e.g. Scenenzbs).

## Fix

- `lang := ""` (no filter) as the scheduler default; only set to a real value when `search.preferredLanguage` is configured.
- `resolveAllowedLanguages` returns `[]string{}` on profile load failure instead of `[]string{"eng"}`.

## Test plan

- [ ] German-language user with Scenenzbs-style indexer: search now returns results instead of 0
- [ ] English-only metadata profile still filters correctly (unit tests unchanged, all pass)
- [ ] `go test ./internal/indexer/... ./internal/api/... ./internal/scheduler/...` passes