### PR TITLE
feat(search): add book directly by title or ISBN

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -311,6 +311,7 @@ func main() {
 		// Authors
 		r.Get("/author", authorHandler.List)
 		r.Post("/author", authorHandler.Create)
+		r.Post("/author/book", authorHandler.AddBook)
 		r.Post("/author/bulk", bulkHandler.AuthorsBulk)
 		r.Get("/author/{id}", authorHandler.Get)
 		r.Put("/author/{id}", authorHandler.Update)

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -400,9 +400,6 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool)
 	slog.Info("author books synced", "author", author.Name, "added", added, "skipped_language", skippedLang, "skipped_junk", skippedJunk, "total", len(books))
 }
 
-// resolveAllowedLanguages returns the parsed allowed-language set for an
-// author's metadata profile. Authors without an explicit profile use the
-// seeded "Standard" profile (id=1). If neither can be loaded we fall back to
 // AddBook adds a single book to the wanted list by its metadata foreign ID.
 // If the author is not yet in Bindery it is added as unmonitored and its
 // books are fetched in the background; the endpoint then polls until the
@@ -445,13 +442,12 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 		def := models.DefaultMetadataProfileID
 		fetched.MetadataProfileID = &def
 		if err := h.authors.Create(ctx, fetched); err != nil {
-			if strings.Contains(err.Error(), "UNIQUE constraint failed") {
-				// Race: another request created it between our check and insert.
-				author, _ = h.authors.GetByForeignID(ctx, req.ForeignAuthorID)
-			} else {
+			if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 				return
 			}
+			// Race: another request created it between our check and insert.
+			author, _ = h.authors.GetByForeignID(ctx, req.ForeignAuthorID)
 		} else {
 			author = fetched
 			go h.FetchAuthorBooks(author, false)
@@ -496,15 +492,12 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 
 	// 4. Optionally trigger an indexer search.
 	if req.SearchOnAdd && h.searcher != nil {
-		go h.searcher.SearchAndGrabBook(context.Background(), *book)
+		go h.searcher.SearchAndGrabBook(contextBackground(), *book)
 	}
 
 	writeJSON(w, http.StatusCreated, book)
 }
 
-// English-only so existing behaviour is preserved; returning nil here would
-// silently disable the filter, which is the opposite of what users with a
-// default install expect.
 func (h *AuthorHandler) resolveAllowedLanguages(ctx context.Context, author *models.Author) []string {
 	id := models.DefaultMetadataProfileID
 	if author.MetadataProfileID != nil {

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -402,6 +403,105 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool)
 // resolveAllowedLanguages returns the parsed allowed-language set for an
 // author's metadata profile. Authors without an explicit profile use the
 // seeded "Standard" profile (id=1). If neither can be loaded we fall back to
+// AddBook adds a single book to the wanted list by its metadata foreign ID.
+// If the author is not yet in Bindery it is added as unmonitored and its
+// books are fetched in the background; the endpoint then polls until the
+// requested book appears and marks it monitored before responding.
+func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ForeignBookID   string `json:"foreignBookId"`
+		ForeignAuthorID string `json:"foreignAuthorId"`
+		AuthorName      string `json:"authorName"`
+		SearchOnAdd     bool   `json:"searchOnAdd"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if req.ForeignBookID == "" || req.ForeignAuthorID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "foreignBookId and foreignAuthorId required"})
+		return
+	}
+
+	ctx := r.Context()
+
+	// 1. Find or create the author (unmonitored if new so we don't auto-want all books).
+	author, _ := h.authors.GetByForeignID(ctx, req.ForeignAuthorID)
+	if author == nil {
+		name := req.AuthorName
+		if name == "" {
+			name = req.ForeignAuthorID
+		}
+		fetched, err := h.meta.GetAuthor(ctx, req.ForeignAuthorID)
+		if err != nil || fetched == nil {
+			fetched = &models.Author{
+				ForeignID:        req.ForeignAuthorID,
+				Name:             name,
+				SortName:         sortName(name),
+				MetadataProvider: "openlibrary",
+			}
+		}
+		fetched.Monitored = false
+		def := models.DefaultMetadataProfileID
+		fetched.MetadataProfileID = &def
+		if err := h.authors.Create(ctx, fetched); err != nil {
+			if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+				// Race: another request created it between our check and insert.
+				author, _ = h.authors.GetByForeignID(ctx, req.ForeignAuthorID)
+			} else {
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				return
+			}
+		} else {
+			author = fetched
+			go h.FetchAuthorBooks(author, false)
+		}
+	}
+	if author == nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not resolve author"})
+		return
+	}
+
+	// 2. Poll until the book appears (FetchAuthorBooks runs asynchronously).
+	deadline := time.Now().Add(15 * time.Second)
+	var book *models.Book
+	for {
+		b, _ := h.books.GetByForeignID(ctx, req.ForeignBookID)
+		if b != nil {
+			book = b
+			break
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			writeJSON(w, http.StatusGatewayTimeout, map[string]string{"error": "request cancelled"})
+			return
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+
+	if book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found after author sync — try again shortly"})
+		return
+	}
+
+	// 3. Mark the book monitored (wanted).
+	book.Monitored = true
+	if err := h.books.Update(ctx, book); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// 4. Optionally trigger an indexer search.
+	if req.SearchOnAdd && h.searcher != nil {
+		go h.searcher.SearchAndGrabBook(context.Background(), *book)
+	}
+
+	writeJSON(w, http.StatusCreated, book)
+}
+
 // English-only so existing behaviour is preserved; returning nil here would
 // silently disable the filter, which is the opposite of what users with a
 // default install expect.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -83,6 +83,10 @@ export const api = {
   searchBooks: (term: string) => request<Book[]>(`/search/book?term=${encodeURIComponent(term)}`),
   lookupISBN: (isbn: string) => request<Book>(`/book/lookup?isbn=${encodeURIComponent(isbn)}`),
 
+  // Add a single book to wanted (adds author silently if new)
+  addBook: (data: { foreignBookId: string; foreignAuthorId: string; authorName?: string; searchOnAdd?: boolean }) =>
+    request<Book>('/author/book', { method: 'POST', body: JSON.stringify(data) }),
+
   // Authors
   listAuthors: () => request<Author[]>('/author'),
   getAuthor: (id: number) => request<Author>(`/author/${id}`),

--- a/web/src/components/AddBookModal.tsx
+++ b/web/src/components/AddBookModal.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react'
+import { api, Book } from '../api/client'
+
+interface Props {
+  onClose: () => void
+  onAdded: (book: Book) => void
+}
+
+export default function AddBookModal({ onClose, onAdded }: Props) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<Book[]>([])
+  const [searching, setSearching] = useState(false)
+  const [searchError, setSearchError] = useState<string | null>(null)
+  const [adding, setAdding] = useState<string | null>(null)
+  const [added, setAdded] = useState<Set<string>>(new Set())
+  const [searchOnAdd, setSearchOnAdd] = useState(true)
+
+  const search = async () => {
+    const q = query.trim()
+    if (!q) return
+    setSearching(true)
+    setSearchError(null)
+    try {
+      // ISBN lookup takes priority when the query looks like an ISBN.
+      if (/^97[89]\d{10}$|^\d{9}[\dX]$/.test(q.replace(/[-\s]/g, ''))) {
+        const book = await api.lookupISBN(q.replace(/[-\s]/g, ''))
+        setResults([book])
+      } else {
+        const books = await api.searchBooks(q)
+        setResults(books)
+      }
+    } catch (err) {
+      setSearchError(err instanceof Error ? err.message : 'Search failed')
+      setResults([])
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  const addBook = async (book: Book) => {
+    if (!book.foreignBookId || !book.author?.foreignAuthorId) return
+    setAdding(book.foreignBookId)
+    try {
+      const created = await api.addBook({
+        foreignBookId: book.foreignBookId,
+        foreignAuthorId: book.author.foreignAuthorId,
+        authorName: book.author.authorName,
+        searchOnAdd,
+      })
+      setAdded(prev => new Set(prev).add(book.foreignBookId))
+      onAdded(created)
+    } catch (err: unknown) {
+      alert(err instanceof Error ? err.message : 'Failed to add book')
+    } finally {
+      setAdding(null)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50" onClick={onClose}>
+      <div className="bg-slate-100 dark:bg-zinc-900 border border-slate-300 dark:border-zinc-700 rounded-lg w-full max-w-lg shadow-2xl max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="p-4 border-b border-slate-200 dark:border-zinc-800">
+          <h3 className="text-lg font-semibold">Add Book</h3>
+          <p className="text-xs text-slate-500 dark:text-zinc-500 mt-0.5">Search by title or ISBN to add a specific book to your wanted list.</p>
+        </div>
+
+        <div className="p-4 flex-1 overflow-y-auto">
+          <label className="flex items-start gap-2 text-sm mb-3 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={searchOnAdd}
+              onChange={e => setSearchOnAdd(e.target.checked)}
+              className="accent-emerald-500 mt-0.5 flex-shrink-0"
+            />
+            <span>
+              <span className="font-medium">Search indexers after adding</span>
+              <span className="block text-xs text-slate-600 dark:text-zinc-400 mt-0.5">Attempt to grab the book automatically once it's added to wanted.</span>
+            </span>
+          </label>
+
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && search()}
+              placeholder="Title or ISBN (e.g. Dune, 9780441478125)"
+              className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+              autoFocus
+            />
+            <button
+              onClick={search}
+              disabled={searching || !query.trim()}
+              className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded-md text-sm font-medium"
+            >
+              {searching ? 'Searching…' : 'Search'}
+            </button>
+          </div>
+
+          <div className="mt-4 space-y-2 max-h-[50vh] overflow-y-auto">
+            {results.map(book => {
+              const key = book.foreignBookId || book.title
+              const isAdded = added.has(book.foreignBookId)
+              const isAdding = adding === book.foreignBookId
+              const canAdd = !!book.author?.foreignAuthorId
+              return (
+                <div key={key} className="flex items-center gap-3 p-3 rounded-md bg-slate-200/50 dark:bg-zinc-800/50 hover:bg-slate-200 dark:hover:bg-zinc-800">
+                  {book.imageUrl && (
+                    <img src={book.imageUrl} alt="" className="w-10 h-14 object-cover rounded flex-shrink-0" />
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-sm truncate">{book.title}</div>
+                    {book.author && (
+                      <div className="text-xs text-slate-600 dark:text-zinc-500">{book.author.authorName}</div>
+                    )}
+                    {book.releaseDate && (
+                      <div className="text-xs text-slate-500 dark:text-zinc-600">{new Date(book.releaseDate).getFullYear()}</div>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => addBook(book)}
+                    disabled={isAdded || isAdding || !canAdd}
+                    className={`px-3 py-1 rounded text-xs font-medium flex-shrink-0 ${isAdded ? 'bg-emerald-700 text-white opacity-75 cursor-default' : 'bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50'}`}
+                    title={!canAdd ? 'Author metadata unavailable — try a more specific search' : undefined}
+                  >
+                    {isAdded ? 'Added ✓' : isAdding ? 'Adding…' : 'Add'}
+                  </button>
+                </div>
+              )
+            })}
+            {searchError && (
+              <p className="text-sm text-red-400 text-center py-4">{searchError}</p>
+            )}
+            {results.length === 0 && !searching && !searchError && query && (
+              <p className="text-sm text-slate-600 dark:text-zinc-500 text-center py-4">No results found.</p>
+            )}
+          </div>
+        </div>
+
+        <div className="p-4 border-t border-slate-200 dark:border-zinc-800 flex justify-end">
+          <button onClick={onClose} className="px-4 py-2 text-sm text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white">Close</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { api, Author } from '../api/client'
 import AddAuthorModal from '../components/AddAuthorModal'
+import AddBookModal from '../components/AddBookModal'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
 import BulkActionBar from '../components/BulkActionBar'
 import Pagination from '../components/Pagination'
@@ -18,6 +19,7 @@ export default function AuthorsPage() {
   const [authors, setAuthors] = useState<Author[]>([])
   const [loading, setLoading] = useState(true)
   const [showAdd, setShowAdd] = useState(false)
+  const [showAddBook, setShowAddBook] = useState(false)
   const [showMerge, setShowMerge] = useState(false)
   const [search, setSearch] = useState('')
   const [sort, setSort] = useState<SortMode>('az')
@@ -140,6 +142,12 @@ export default function AuthorsPage() {
             title={t('authors.mergeTip')}
           >
             {t('authors.merge')}
+          </button>
+          <button
+            onClick={() => setShowAddBook(true)}
+            className="px-4 py-2 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded-md text-sm font-medium transition-colors"
+          >
+            Add Book
           </button>
           <button
             onClick={() => setShowAdd(true)}
@@ -340,6 +348,7 @@ export default function AuthorsPage() {
       />
 
       {showAdd && <AddAuthorModal onClose={() => setShowAdd(false)} onAdded={load} />}
+      {showAddBook && <AddBookModal onClose={() => setShowAddBook(false)} onAdded={() => setShowAddBook(false)} />}
       {showMerge && (
         <MergeAuthorsModal
           authors={authors}


### PR DESCRIPTION
## Summary

Closes #85.

New **Add Book** button on the Authors page opens a search modal. Users can find a specific book by title or ISBN and add just that book to their wanted list — no need to add the whole author first.

- **ISBN detection** — if the query looks like an ISBN-10/13, uses the dedicated lookup endpoint instead of a title search
- **Unmonitored author** — if the author isn't in Bindery yet, they're added with `monitored: false` so the rest of their catalogue doesn't flood the wanted list
- **Async book wait** — `FetchAuthorBooks` runs in the background; the endpoint polls up to 15 s for the specific book to appear, then marks it monitored
- **Search on add** — optional toggle to trigger an indexer search immediately

## Changes

| File | What |
|---|---|
| `internal/api/authors.go` — `AddBook` | Find/create author → poll for book → mark monitored |
| `cmd/bindery/main.go` | `POST /author/book` route |
| `web/src/api/client.ts` | `addBook` method |
| `web/src/components/AddBookModal.tsx` | Search modal: title/ISBN input, cover thumbnails, per-row Add buttons |
| `web/src/pages/AuthorsPage.tsx` | "Add Book" button + modal wiring |

## Test plan

- [ ] Search "Dune" → Frank Herbert books appear; click Add → book appears in Wanted
- [ ] ISBN search `9780441478125` → lookup by ISBN works
- [ ] If author already in Bindery, adding their book still works (no duplicate author)
- [ ] If author not in Bindery, they're added with `monitored: false`
- [ ] `go test ./internal/api/...` passes
- [ ] `npm run typecheck --prefix web` passes