### PR TITLE
feat(downloads): formalize download state machine (#141)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -228,7 +228,7 @@ func main() {
 	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).WithSettings(settingsRepo)
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, metadataProfileRepo, idxSearcher, settingsRepo, blocklistRepo)
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)
-	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo)
+	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo).WithNotifier(notif)
 	importScanner.WithSettings(settingsRepo)
 	importScanner.WithRootFolders(rootFolderRepo)
 	libraryHandler := api.NewLibraryHandler(importScanner).WithSettings(settingsRepo)

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -3,15 +3,15 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
-
-	"fmt"
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/downloader"
 	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/notifier"
 )
 
 type QueueHandler struct {
@@ -19,10 +19,17 @@ type QueueHandler struct {
 	clients   *db.DownloadClientRepo
 	books     *db.BookRepo
 	history   *db.HistoryRepo
+	notif     *notifier.Notifier
 }
 
 func NewQueueHandler(downloads *db.DownloadRepo, clients *db.DownloadClientRepo, books *db.BookRepo, history *db.HistoryRepo) *QueueHandler {
 	return &QueueHandler{downloads: downloads, clients: clients, books: books, history: history}
+}
+
+// WithNotifier attaches a notifier so grab/failure events fire webhooks.
+func (h *QueueHandler) WithNotifier(n *notifier.Notifier) *QueueHandler {
+	h.notif = n
+	return h
 }
 
 // QueueItem combines local download record with live downloader status.
@@ -150,7 +157,7 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		Title:            req.Title,
 		NZBURL:           req.NZBURL,
 		Size:             req.Size,
-		Status:           models.DownloadStatusQueued,
+		Status:           models.StateGrabbed,
 		Protocol:         protocol,
 		Quality:          indexer.ParseRelease(req.Title).Format,
 	}
@@ -165,7 +172,10 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		if setErr := h.downloads.SetError(r.Context(), dl.ID, err.Error()); setErr != nil {
 			slog.Warn("failed to persist download error", "download_id", dl.ID, "error", setErr)
 		}
-		h.recordHistory(r.Context(), models.HistoryEventDownloadFailed, req.Title, req.BookID, map[string]interface{}{"guid": req.GUID, "message": err.Error()})
+		h.recordHistory(r.Context(), models.HistoryEventDownloadFailed, req.Title, req.BookID, map[string]any{"guid": req.GUID, "message": err.Error()})
+		if h.notif != nil {
+			h.notif.Send(r.Context(), notifier.EventDownloadFailed, map[string]any{"title": req.Title, "message": err.Error()})
+		}
 		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send to downloader: " + err.Error()})
 		return
 	}
@@ -183,16 +193,19 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 			dl.SABnzbdNzoID = &remoteID
 		}
 	}
-	if err := h.downloads.UpdateStatus(r.Context(), dl.ID, models.DownloadStatusDownloading); err != nil {
-		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.DownloadStatusDownloading, "error", err)
+	if err := h.downloads.UpdateStatus(r.Context(), dl.ID, models.StateDownloading); err != nil {
+		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.StateDownloading, "error", err)
 	}
-	dl.Status = models.DownloadStatusDownloading
+	dl.Status = models.StateDownloading
 
-	h.recordHistory(r.Context(), models.HistoryEventGrabbed, req.Title, req.BookID, map[string]interface{}{
+	h.recordHistory(r.Context(), models.HistoryEventGrabbed, req.Title, req.BookID, map[string]any{
 		"guid":      req.GUID,
 		"size":      req.Size,
 		"indexerId": req.IndexerID,
 	})
+	if h.notif != nil {
+		h.notif.Send(r.Context(), notifier.EventGrabbed, map[string]any{"title": req.Title, "size": req.Size})
+	}
 
 	slog.Info("download grabbed", "title", req.Title, "client", client.Type)
 	writeJSON(w, http.StatusAccepted, dl)
@@ -213,7 +226,7 @@ func (h *QueueHandler) selectClient(ctx context.Context, protocol, mediaType str
 }
 
 // recordHistory is a helper to write a history event, swallowing errors.
-func (h *QueueHandler) recordHistory(ctx context.Context, eventType, sourceTitle string, bookID *int64, data interface{}) {
+func (h *QueueHandler) recordHistory(ctx context.Context, eventType, sourceTitle string, bookID *int64, data any) {
 	if h.history == nil {
 		return
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -740,7 +740,7 @@ func TestDownloadRepoCRUD(t *testing.T) {
 		Title:    "Some.Book.epub",
 		NZBURL:   "https://example.com/dl.nzb",
 		Size:     1024,
-		Status:   models.DownloadStatusQueued,
+		Status:   models.StateGrabbed,
 		Protocol: "usenet",
 	}
 	if err := repo.Create(ctx, dl); err != nil {
@@ -775,21 +775,28 @@ func TestDownloadRepoCRUD(t *testing.T) {
 	}
 
 	// ListByStatus
-	queued, _ := repo.ListByStatus(ctx, models.DownloadStatusQueued)
+	queued, _ := repo.ListByStatus(ctx, models.StateGrabbed)
 	if len(queued) != 1 {
 		t.Errorf("expected 1 queued, got %d", len(queued))
 	}
 
-	// UpdateStatus — each branch
-	for _, status := range []string{
-		models.DownloadStatusDownloading,
-		models.DownloadStatusCompleted,
-		models.DownloadStatusImported,
-		models.DownloadStatusFailed,
-	} {
-		if err := repo.UpdateStatus(ctx, dl.ID, status); err != nil {
-			t.Errorf("UpdateStatus(%q): %v", status, err)
+	// UpdateStatus — walk through valid transitions and verify each succeeds.
+	validSeq := []models.DownloadState{
+		models.StateDownloading,
+		models.StateCompleted,
+		models.StateImportPending,
+		models.StateImporting,
+		models.StateImported,
+	}
+	for _, next := range validSeq {
+		if err := repo.UpdateStatus(ctx, dl.ID, next); err != nil {
+			t.Errorf("UpdateStatus(%q): %v", next, err)
 		}
+	}
+
+	// UpdateStatus — invalid transition must return ErrInvalidTransition.
+	if err := repo.UpdateStatus(ctx, dl.ID, models.StateDownloading); err == nil {
+		t.Error("expected error for illegal transition imported→downloading")
 	}
 
 	// SetNzoID

--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -26,7 +26,7 @@ func (r *DownloadRepo) List(ctx context.Context) ([]models.Download, error) {
 	return r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads ORDER BY added_at DESC")
 }
 
-func (r *DownloadRepo) ListByStatus(ctx context.Context, status string) ([]models.Download, error) {
+func (r *DownloadRepo) ListByStatus(ctx context.Context, status models.DownloadState) ([]models.Download, error) {
 	return r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads WHERE status=? ORDER BY added_at DESC", status)
 }
 
@@ -76,24 +76,29 @@ func (r *DownloadRepo) Create(ctx context.Context, d *models.Download) error {
 	return nil
 }
 
-func (r *DownloadRepo) UpdateStatus(ctx context.Context, id int64, status string) error {
-	now := time.Now().UTC()
-	// Status-to-column allow-list. The SQL strings are fixed literals so no
-	// user input ever reaches the query text.
-	switch status {
-	case models.DownloadStatusDownloading:
-		_, err := r.db.ExecContext(ctx, "UPDATE downloads SET status=?, grabbed_at=? WHERE id=?", status, now, id)
-		return err
-	case models.DownloadStatusCompleted:
-		_, err := r.db.ExecContext(ctx, "UPDATE downloads SET status=?, completed_at=? WHERE id=?", status, now, id)
-		return err
-	case models.DownloadStatusImported:
-		_, err := r.db.ExecContext(ctx, "UPDATE downloads SET status=?, imported_at=? WHERE id=?", status, now, id)
-		return err
-	default:
-		_, err := r.db.ExecContext(ctx, "UPDATE downloads SET status=? WHERE id=?", status, id)
-		return err
+func (r *DownloadRepo) UpdateStatus(ctx context.Context, id int64, next models.DownloadState) error {
+	// Look up the current state to validate the transition.
+	var current models.DownloadState
+	err := r.db.QueryRowContext(ctx, "SELECT status FROM downloads WHERE id=?", id).Scan(&current)
+	if err != nil {
+		return fmt.Errorf("lookup current state: %w", err)
 	}
+	if !current.CanTransitionTo(next) {
+		return models.ErrInvalidTransition{From: current, To: next}
+	}
+
+	now := time.Now().UTC()
+	switch next {
+	case models.StateDownloading:
+		_, err = r.db.ExecContext(ctx, "UPDATE downloads SET status=?, grabbed_at=? WHERE id=?", next, now, id)
+	case models.StateCompleted:
+		_, err = r.db.ExecContext(ctx, "UPDATE downloads SET status=?, completed_at=? WHERE id=?", next, now, id)
+	case models.StateImported:
+		_, err = r.db.ExecContext(ctx, "UPDATE downloads SET status=?, imported_at=? WHERE id=?", next, now, id)
+	default:
+		_, err = r.db.ExecContext(ctx, "UPDATE downloads SET status=? WHERE id=?", next, id)
+	}
+	return err
 }
 
 func (r *DownloadRepo) SetNzoID(ctx context.Context, id int64, nzoID string) error {
@@ -109,7 +114,7 @@ func (r *DownloadRepo) SetTorrentID(ctx context.Context, id int64, torrentID str
 func (r *DownloadRepo) SetError(ctx context.Context, id int64, errMsg string) error {
 	_, err := r.db.ExecContext(ctx,
 		"UPDATE downloads SET status=?, error_message=? WHERE id=?",
-		models.DownloadStatusFailed, errMsg, id)
+		models.StateFailed, errMsg, id)
 	return err
 }
 

--- a/internal/db/downloads_coverage_test.go
+++ b/internal/db/downloads_coverage_test.go
@@ -18,7 +18,7 @@ func TestDownloadRepo_TorrentIDRoundTrip(t *testing.T) {
 
 	dl := &models.Download{
 		GUID: "torrent-guid", Title: "torrent.release", NZBURL: "magnet:?xt=urn:btih:abc",
-		Size: 2048, Status: models.DownloadStatusQueued, Protocol: "torrent",
+		Size: 2048, Status: models.StateGrabbed, Protocol: "torrent",
 	}
 	if err := repo.Create(ctx, dl); err != nil {
 		t.Fatalf("create: %v", err)

--- a/internal/db/migrations/020_download_states.sql
+++ b/internal/db/migrations/020_download_states.sql
@@ -1,0 +1,3 @@
+-- Normalize legacy "queued" status to "grabbed" and add new import-pipeline states.
+UPDATE downloads SET status = 'grabbed' WHERE status = 'queued';
+UPDATE downloads SET status = 'grabbed' WHERE status = 'paused';

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -179,7 +179,7 @@ func isTrackedTorrentDownloadForClient(dl models.Download, clientID int64) bool 
 	if dl.TorrentID == nil {
 		return false
 	}
-	return dl.Status != models.DownloadStatusImported && dl.Status != models.DownloadStatusFailed
+	return dl.Status != models.StateImported && dl.Status != models.StateFailed
 }
 
 func (s *Scanner) setDownloadError(ctx context.Context, id int64, message string) {
@@ -188,7 +188,7 @@ func (s *Scanner) setDownloadError(ctx context.Context, id int64, message string
 	}
 }
 
-func (s *Scanner) updateDownloadStatus(ctx context.Context, id int64, status string) {
+func (s *Scanner) updateDownloadStatus(ctx context.Context, id int64, status models.DownloadState) {
 	if err := s.downloads.UpdateStatus(ctx, id, status); err != nil {
 		slog.Warn("failed to update download status", "download_id", id, "status", status, "error", err)
 	}
@@ -237,17 +237,17 @@ func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.Down
 
 		switch slot.Status {
 		case "Completed":
-			if dl.Status == models.DownloadStatusDownloading || dl.Status == models.DownloadStatusQueued {
+			if dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed {
 				localPath := s.remapper.Apply(slot.Path)
 				if localPath != slot.Path {
 					slog.Debug("remapped download path", "sab", slot.Path, "local", localPath)
 				}
 				slog.Info("download completed", "title", dl.Title, "path", localPath)
-				s.updateDownloadStatus(ctx, dl.ID, models.DownloadStatusCompleted)
+				s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
 				s.tryImportSABnzbd(ctx, sab, dl, slot.NzoID, localPath)
 			}
 		case "Failed":
-			if dl.Status != models.DownloadStatusFailed {
+			if dl.Status != models.StateFailed {
 				slog.Warn("download failed", "title", dl.Title, "message", slot.FailMessage)
 				s.setDownloadError(ctx, dl.ID, slot.FailMessage)
 				s.createHistoryEvent(ctx, models.HistoryEventDownloadFailed, dl.Title, dl.BookID, map[string]string{"guid": dl.GUID, "message": slot.FailMessage})
@@ -294,12 +294,12 @@ func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models
 		isStopped := torrent.Status == 0 || torrent.Status == 6
 		stopError := strings.TrimSpace(torrent.ErrorString)
 
-		if isComplete && (dl.Status == models.DownloadStatusDownloading || dl.Status == models.DownloadStatusQueued) {
+		if isComplete && (dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed) {
 			// Download is complete
 			slog.Info("download completed", "title", dl.Title, "path", torrent.DownloadDir)
-			s.updateDownloadStatus(ctx, dl.ID, models.DownloadStatusCompleted)
+			s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
 			s.tryImportTransmission(ctx, &dl, torrent.DownloadDir)
-		} else if isStopped && !isComplete && dl.Status != models.DownloadStatusFailed {
+		} else if isStopped && !isComplete && dl.Status != models.StateFailed {
 			if stopError == "" {
 				// Transmission also reports user-paused torrents as stopped.
 				continue
@@ -344,7 +344,7 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 		isComplete := torrent.Progress >= 1.0 || strings.Contains(state, "upload") || strings.Contains(state, "stalledup") || strings.Contains(state, "checkingup")
 		isFailed := strings.Contains(state, "error")
 
-		if isComplete && (dl.Status == models.DownloadStatusDownloading || dl.Status == models.DownloadStatusQueued) {
+		if isComplete && (dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed) {
 			downloadPath := torrent.SavePath
 			candidate := filepath.Join(torrent.SavePath, torrent.Name)
 			if _, err := os.Stat(candidate); err == nil {
@@ -353,9 +353,9 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 			downloadPath = s.remapper.Apply(downloadPath)
 
 			slog.Info("download completed", "title", dl.Title, "path", downloadPath)
-			s.updateDownloadStatus(ctx, dl.ID, models.DownloadStatusCompleted)
+			s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
 			s.tryImportQbittorrent(ctx, &dl, downloadPath)
-		} else if isFailed && dl.Status != models.DownloadStatusFailed {
+		} else if isFailed && dl.Status != models.StateFailed {
 			slog.Warn("download failed", "title", dl.Title, "state", torrent.State)
 			s.markDownloadFailed(ctx, &dl, "Torrent failed in qBittorrent")
 		}
@@ -385,8 +385,12 @@ func (s *Scanner) tryImportQbittorrent(ctx context.Context, dl *models.Download,
 func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, downloadPath, cleanupClientType, cleanupRemoteID string, cleanupFunc func() error) {
 	if s.libraryDir == "" {
 		slog.Warn("no library directory configured, skipping import")
+		// Not writable/configured — needs user action before import can proceed.
+		s.updateDownloadStatus(ctx, dl.ID, models.StateImportBlocked)
 		return
 	}
+
+	s.updateDownloadStatus(ctx, dl.ID, models.StateImportPending)
 
 	// Find book files in the download path
 	var bookFiles []string
@@ -404,8 +408,12 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 
 	if len(bookFiles) == 0 {
 		slog.Warn("no book files found in download", "path", downloadPath)
+		// No files — retryable if the downloader hasn't flushed them yet.
+		s.updateDownloadStatus(ctx, dl.ID, models.StateImportFailed)
 		return
 	}
+
+	s.updateDownloadStatus(ctx, dl.ID, models.StateImporting)
 
 	// Resolve the book and author for naming. Lookup errors are not fatal -
 	// we fall through to the "unmatched import" log below.
@@ -453,6 +461,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		}
 		if dirErr != nil {
 			slog.Error("failed to import audiobook folder", "src", downloadPath, "mode", mode, "error", dirErr)
+			s.updateDownloadStatus(ctx, dl.ID, models.StateImportBlocked)
 			return
 		}
 		if book != nil {
@@ -460,7 +469,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 				slog.Error("failed to update audiobook file path", "bookID", book.ID, "error", err)
 			}
 		}
-		s.updateDownloadStatus(ctx, dl.ID, models.DownloadStatusImported)
+		s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
 		slog.Info("audiobook imported", "title", func() string {
 			if book != nil {
 				return book.Title
@@ -512,12 +521,19 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		if err := s.books.SetFormatFilePath(ctx, book.ID, models.MediaTypeEbook, destPath); err != nil {
 			slog.Error("failed to update ebook file path", "bookID", book.ID, "error", err)
 		}
-		s.updateDownloadStatus(ctx, dl.ID, models.DownloadStatusImported)
+		s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
 		slog.Info("book imported", "title", book.Title, "path", destPath)
 
 		s.pushToCalibre(ctx, book, author, destPath)
 
 		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destPath})
+	}
+
+	// If every file failed to copy/move, the destination is likely not writable —
+	// mark as blocked so the user knows manual intervention is needed.
+	if imported == 0 && failed > 0 {
+		s.updateDownloadStatus(ctx, dl.ID, models.StateImportBlocked)
+		return
 	}
 
 	// A clean run leaves the download folder holding only non-book byproducts

--- a/internal/models/download.go
+++ b/internal/models/download.go
@@ -25,34 +25,34 @@ type DownloadClient struct {
 }
 
 type Download struct {
-	ID               int64      `json:"id"`
-	GUID             string     `json:"guid"`
-	BookID           *int64     `json:"bookId"`
-	EditionID        *int64     `json:"editionId"`
-	IndexerID        *int64     `json:"indexerId"`
-	DownloadClientID *int64     `json:"downloadClientId"`
-	Title            string     `json:"title"`
-	NZBURL           string     `json:"nzbUrl"`
-	Size             int64      `json:"size"`
-	SABnzbdNzoID     *string    `json:"sabnzbdNzoId"`
-	TorrentID        *string    `json:"torrentId"`
-	Status           string     `json:"status"`
-	Protocol         string     `json:"protocol"`
-	Quality          string     `json:"quality"`
-	IndexerFlags     string     `json:"indexerFlags"`
-	ErrorMessage     string     `json:"errorMessage"`
-	AddedAt          time.Time  `json:"addedAt"`
-	GrabbedAt        *time.Time `json:"grabbedAt"`
-	CompletedAt      *time.Time `json:"completedAt"`
-	ImportedAt       *time.Time `json:"importedAt"`
+	ID               int64         `json:"id"`
+	GUID             string        `json:"guid"`
+	BookID           *int64        `json:"bookId"`
+	EditionID        *int64        `json:"editionId"`
+	IndexerID        *int64        `json:"indexerId"`
+	DownloadClientID *int64        `json:"downloadClientId"`
+	Title            string        `json:"title"`
+	NZBURL           string        `json:"nzbUrl"`
+	Size             int64         `json:"size"`
+	SABnzbdNzoID     *string       `json:"sabnzbdNzoId"`
+	TorrentID        *string       `json:"torrentId"`
+	Status           DownloadState `json:"status"`
+	Protocol         string        `json:"protocol"`
+	Quality          string        `json:"quality"`
+	IndexerFlags     string        `json:"indexerFlags"`
+	ErrorMessage     string        `json:"errorMessage"`
+	AddedAt          time.Time     `json:"addedAt"`
+	GrabbedAt        *time.Time    `json:"grabbedAt"`
+	CompletedAt      *time.Time    `json:"completedAt"`
+	ImportedAt       *time.Time    `json:"importedAt"`
 }
 
+// Legacy status aliases — callers should prefer the typed State* constants in
+// download_state.go. These are kept for any scanner comparisons that still use
+// the old names; they will be removed in a future cleanup.
 const (
-	DownloadStatusQueued      = "queued"
-	DownloadStatusDownloading = "downloading"
-	DownloadStatusPaused      = "paused"
-	DownloadStatusCompleted   = "completed"
-	DownloadStatusFailed      = "failed"
-	DownloadStatusImported    = "imported"
-	DownloadStatusDeleted     = "deleted"
+	DownloadStatusDownloading = StateDownloading
+	DownloadStatusCompleted   = StateCompleted
+	DownloadStatusFailed      = StateFailed
+	DownloadStatusImported    = StateImported
 )

--- a/internal/models/download_state.go
+++ b/internal/models/download_state.go
@@ -1,0 +1,49 @@
+package models
+
+import (
+	"fmt"
+	"slices"
+)
+
+// DownloadState is the typed state of a download record.
+type DownloadState string
+
+const (
+	StateGrabbed       DownloadState = "grabbed"
+	StateDownloading   DownloadState = "downloading"
+	StateCompleted     DownloadState = "completed"
+	StateImportPending DownloadState = "importPending"
+	StateImporting     DownloadState = "importing"
+	StateImported      DownloadState = "imported"
+	StateFailed        DownloadState = "failed"
+	StateImportFailed  DownloadState = "importFailed"
+	StateImportBlocked DownloadState = "importBlocked"
+)
+
+// validTransitions defines which state transitions are allowed.
+var validTransitions = map[DownloadState][]DownloadState{
+	StateGrabbed:       {StateDownloading, StateFailed},
+	StateDownloading:   {StateCompleted, StateFailed},
+	StateCompleted:     {StateImportPending, StateImportFailed},
+	StateImportPending: {StateImporting, StateImportFailed},
+	StateImporting:     {StateImported, StateImportFailed, StateImportBlocked},
+	StateImported:      {},
+	StateFailed:        {},
+	StateImportFailed:  {StateImportPending},
+	StateImportBlocked: {},
+}
+
+// CanTransitionTo reports whether a transition from s to next is valid.
+func (s DownloadState) CanTransitionTo(next DownloadState) bool {
+	return slices.Contains(validTransitions[s], next)
+}
+
+// ErrInvalidTransition is returned when an illegal state transition is attempted.
+type ErrInvalidTransition struct {
+	From DownloadState
+	To   DownloadState
+}
+
+func (e ErrInvalidTransition) Error() string {
+	return fmt.Sprintf("invalid download state transition: %s → %s", e.From, e.To)
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -309,7 +309,7 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		Title:            best.Title,
 		NZBURL:           best.NZBURL,
 		Size:             best.Size,
-		Status:           models.DownloadStatusQueued,
+		Status:           models.StateGrabbed,
 		Protocol:         best.Protocol,
 		Quality:          indexer.ParseRelease(best.Title).Format,
 	}
@@ -338,8 +338,8 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 			}
 		}
 	}
-	if err := s.downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading); err != nil {
-		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.DownloadStatusDownloading, "error", err)
+	if err := s.downloads.UpdateStatus(ctx, dl.ID, models.StateDownloading); err != nil {
+		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.StateDownloading, "error", err)
 	}
 	slog.Info("sent to downloader", "client", client.Type, "title", best.Title)
 }
@@ -460,7 +460,7 @@ func (s *Scheduler) checkStalledDownloads(ctx context.Context) {
 		}
 	}
 
-	active, err := s.downloads.ListByStatus(ctx, models.DownloadStatusDownloading)
+	active, err := s.downloads.ListByStatus(ctx, models.StateDownloading)
 	if err != nil || len(active) == 0 {
 		return
 	}

--- a/internal/scheduler/scheduler_coverage_test.go
+++ b/internal/scheduler/scheduler_coverage_test.go
@@ -236,7 +236,7 @@ func TestCheckStalledDownloads_NotYetOldEnough(t *testing.T) {
 	dl := &models.Download{
 		GUID:     "recent-guid",
 		Title:    "Recent",
-		Status:   models.DownloadStatusQueued,
+		Status:   models.StateGrabbed,
 		Protocol: "torrent",
 	}
 	if err := downloads.Create(ctx, dl); err != nil {
@@ -285,13 +285,13 @@ func TestCheckStalledDownloads_OldEnough_ReachesClientLookup(t *testing.T) {
 		GUID:             "old-guid",
 		DownloadClientID: &client.ID,
 		Title:            "Old Download",
-		Status:           models.DownloadStatusDownloading,
+		Status:           models.StateGrabbed,
 		Protocol:         "torrent",
 	}
 	if err := downloads.Create(ctx, dl); err != nil {
 		t.Fatalf("dl create: %v", err)
 	}
-	if err := downloads.UpdateStatus(ctx, dl.ID, models.DownloadStatusDownloading); err != nil {
+	if err := downloads.UpdateStatus(ctx, dl.ID, models.StateDownloading); err != nil {
 		t.Fatalf("update: %v", err)
 	}
 

--- a/internal/scheduler/scheduler_stall_test.go
+++ b/internal/scheduler/scheduler_stall_test.go
@@ -111,7 +111,7 @@ func TestCheckStalledDownloads_SkipsNewDownloads(t *testing.T) {
 
 	dl := &models.Download{
 		GUID: "g1", Title: "fresh", DownloadClientID: &client.ID,
-		Status: models.DownloadStatusQueued, Protocol: "torrent",
+		Status: models.StateGrabbed, Protocol: "torrent",
 	}
 	if err := downloadsRepo.Create(ctx, dl); err != nil {
 		t.Fatalf("create download: %v", err)
@@ -189,7 +189,7 @@ func TestCheckStalledDownloads_DisabledClientSkipped(t *testing.T) {
 	old := time.Now().UTC().Add(-3 * time.Hour)
 	dl := &models.Download{
 		GUID: "g-old", Title: "old", DownloadClientID: &client.ID,
-		Status: models.DownloadStatusQueued, Protocol: "torrent",
+		Status: models.StateGrabbed, Protocol: "torrent",
 	}
 	if err := downloadsRepo.Create(ctx, dl); err != nil {
 		t.Fatalf("create download: %v", err)
@@ -248,7 +248,7 @@ func TestCheckStalledDownloads_QBitNoStalls(t *testing.T) {
 	tid := "abcdef"
 	dl := &models.Download{
 		GUID: "g1", Title: "Active Book", DownloadClientID: &client.ID,
-		Status: models.DownloadStatusQueued, Protocol: "torrent",
+		Status: models.StateGrabbed, Protocol: "torrent",
 		TorrentID: &tid,
 	}
 	if err := downloadsRepo.Create(ctx, dl); err != nil {
@@ -343,7 +343,7 @@ func TestCheckStalledDownloads_QBitStalledTorrent(t *testing.T) {
 	dl := &models.Download{
 		GUID: "g-stalled", Title: "Stalled Release", BookID: &book.ID,
 		IndexerID: &idx.ID, DownloadClientID: &client.ID,
-		Status: models.DownloadStatusQueued, Protocol: "torrent",
+		Status: models.StateGrabbed, Protocol: "torrent",
 		TorrentID: &tid,
 	}
 	if err := downloadsRepo.Create(ctx, dl); err != nil {

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -28,11 +28,27 @@ export default function QueuePage() {
   }
 
   const statusColors: Record<string, string> = {
-    queued: 'text-slate-600 dark:text-zinc-400',
+    grabbed: 'text-slate-600 dark:text-zinc-400',
     downloading: 'text-blue-400',
-    completed: 'text-emerald-400',
-    failed: 'text-red-400',
+    completed: 'text-sky-400',
+    importPending: 'text-yellow-400',
+    importing: 'text-blue-400',
     imported: 'text-emerald-400',
+    failed: 'text-red-400',
+    importFailed: 'text-orange-400',
+    importBlocked: 'text-red-500',
+  }
+
+  const statusLabels: Record<string, string> = {
+    grabbed: 'Grabbed',
+    downloading: 'Downloading',
+    completed: 'Completed',
+    importPending: 'Import Pending',
+    importing: 'Importing',
+    imported: 'Imported',
+    failed: 'Failed',
+    importFailed: 'Import Failed',
+    importBlocked: 'Import Blocked',
   }
 
   const formatSize = (bytes: number) => {
@@ -59,7 +75,7 @@ export default function QueuePage() {
                 <h3 className="font-medium text-sm truncate">{item.title}</h3>
                 <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-xs">
                   <span className={statusColors[item.status] || 'text-slate-600 dark:text-zinc-400'}>
-                    {item.status}
+                    {statusLabels[item.status] ?? item.status}
                   </span>
                   <span className="text-slate-600 dark:text-zinc-500">{formatSize(item.size)}</span>
                   {item.percentage && (
@@ -72,6 +88,11 @@ export default function QueuePage() {
                     <span className="text-slate-500 dark:text-zinc-600">{item.protocol}</span>
                   )}
                 </div>
+                {item.status === 'importBlocked' && !item.errorMessage && (
+                  <div className="mt-1 text-xs text-red-500 bg-red-500/10 rounded px-2 py-1">
+                    Import blocked — manual intervention required (check library path permissions)
+                  </div>
+                )}
                 {item.errorMessage && (
                   <div className="mt-1 text-xs text-red-400 bg-red-400/10 rounded px-2 py-1">
                     {item.errorMessage}


### PR DESCRIPTION
## Summary

- Adds typed `DownloadState` with `CanTransitionTo()` and `ErrInvalidTransition` — illegal transitions are rejected before the DB write
- `Download.Status` changed from `string` to `DownloadState`; migration 020 normalises legacy `"queued"` rows to `"grabbed"`
- New import-pipeline states: `importPending` → `importing` → `imported`; `importFailed` (retryable, no files found) and `importBlocked` (non-writable destination, needs user action)
- `UpdateStatus` now validates every transition and stamps the correct timestamp column (`grabbed_at`, `completed_at`, `imported_at`)
- Queue handler and scanner now call `notifier.Send` on grabbed/failed events, wiring up the previously-unused webhook notifier
- Queue UI renders human-readable labels and distinct colours for all nine states; `importBlocked` items surface an action-required banner

## Test plan

- [ ] All existing tests pass (`go test ./internal/...`)
- [ ] `gofmt` clean
- [ ] TypeScript type check passes
- [ ] Create a download via the Wanted tab; verify status progresses: grabbed → downloading → completed → importPending → importing → imported
- [ ] Simulate a no-library-path config; verify status ends at `importBlocked` with the banner visible in Queue
- [ ] Verify illegal transition (e.g. imported → downloading) returns `ErrInvalidTransition`
- [ ] Webhook notification fires on grab and on failure