### PR TITLE
feat(pending): pending releases table + UI for delay-held results

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -100,6 +100,7 @@ func main() {
 	settingsRepo := db.NewSettingsRepo(database)
 	historyRepo := db.NewHistoryRepo(database)
 	blocklistRepo := db.NewBlocklistRepo(database)
+	pendingReleaseRepo := db.NewPendingReleaseRepo(database)
 	notificationRepo := db.NewNotificationRepo(database)
 	qualityProfileRepo := db.NewQualityProfileRepo(database)
 	seriesRepo := db.NewSeriesRepo(database)
@@ -225,6 +226,8 @@ func main() {
 	sched := scheduler.New(importScanner, idxSearcher, metaAgg,
 		authorRepo, bookRepo, indexerRepo, downloadRepo, dlClientRepo, settingsRepo, blocklistRepo)
 	sched.WithHistory(historyRepo)
+	sched.WithDelayProfiles(delayProfileRepo)
+	sched.WithPendingReleases(pendingReleaseRepo)
 	// Register the Calibre importer as the 24-hour sync job. The scheduler
 	// only fires the job when the syncer is non-nil, so no guard needed here.
 	sched.WithCalibreSyncer(calibreImporter)
@@ -258,6 +261,7 @@ func main() {
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, metadataProfileRepo, idxSearcher, settingsRepo, blocklistRepo)
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)
 	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo).WithNotifier(notif)
+	pendingHandler := api.NewPendingHandler(pendingReleaseRepo, queueHandler, downloadRepo, bookRepo)
 	importScanner.WithSettings(settingsRepo)
 	importScanner.WithRootFolders(rootFolderRepo)
 	libraryHandler := api.NewLibraryHandler(importScanner).WithSettings(settingsRepo)
@@ -401,6 +405,9 @@ func main() {
 		r.Get("/queue", queueHandler.List)
 		r.Post("/queue/grab", queueHandler.Grab)
 		r.Delete("/queue/{id}", queueHandler.Delete)
+		r.Get("/pending", pendingHandler.List)
+		r.Delete("/pending/{id}", pendingHandler.Delete)
+		r.Post("/pending/{id}/grab", pendingHandler.Grab)
 
 		// History
 		r.Get("/history", historyHandler.List)

--- a/internal/api/pending.go
+++ b/internal/api/pending.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// PendingHandler serves the pending releases API.
+type PendingHandler struct {
+	pending   *db.PendingReleaseRepo
+	queue     *QueueHandler
+	downloads *db.DownloadRepo
+	books     *db.BookRepo
+}
+
+// NewPendingHandler creates a PendingHandler.
+func NewPendingHandler(pending *db.PendingReleaseRepo, queue *QueueHandler, downloads *db.DownloadRepo, books *db.BookRepo) *PendingHandler {
+	return &PendingHandler{pending: pending, queue: queue, downloads: downloads, books: books}
+}
+
+// List returns all pending releases.
+func (h *PendingHandler) List(w http.ResponseWriter, r *http.Request) {
+	items, err := h.pending.List(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if items == nil {
+		items = []models.PendingRelease{}
+	}
+	writeJSON(w, http.StatusOK, items)
+}
+
+// Delete dismisses a pending release.
+func (h *PendingHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.pending.DeleteByID(r.Context(), id); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Grab force-grabs a pending release, bypassing delay profile.
+func (h *PendingHandler) Grab(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+
+	pr, err := h.pending.GetByID(r.Context(), id)
+	if err != nil || pr == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "pending release not found"})
+		return
+	}
+
+	// Deserialize the stored release JSON to get the full grab details.
+	var stored grabRequest
+	if err := json.Unmarshal([]byte(pr.ReleaseJSON), &stored); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "invalid stored release: " + err.Error()})
+		return
+	}
+
+	if h.queue == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "queue handler not available"})
+		return
+	}
+
+	// Look up the book's media type.
+	mediaType := "ebook"
+	if h.books != nil {
+		if book, err := h.books.GetByID(r.Context(), pr.BookID); err == nil && book != nil {
+			mediaType = book.MediaType
+		}
+	}
+	stored.BookID = pr.BookID
+	stored.MediaType = mediaType
+
+	dl, err := h.queue.grab(r.Context(), stored)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// Remove from pending on successful grab.
+	_ = h.pending.DeleteByGUID(r.Context(), pr.GUID)
+
+	writeJSON(w, http.StatusCreated, dl)
+}

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/downloader"
@@ -109,8 +110,21 @@ func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, items)
 }
 
+// grabRequest is the payload for grab operations (HTTP handler and pending force-grab).
+type grabRequest struct {
+	GUID      string `json:"guid"`
+	Title     string `json:"title"`
+	NZBURL    string `json:"nzbUrl"`
+	Size      int64  `json:"size"`
+	BookID    int64  `json:"bookId"`
+	IndexerID *int64 `json:"indexerId"`
+	Protocol  string `json:"protocol"`
+	MediaType string `json:"mediaType"`
+}
+
 func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
-	var req struct {
+	// Intermediate struct to handle optional bookId from the HTTP body.
+	var body struct {
 		GUID      string `json:"guid"`
 		Title     string `json:"title"`
 		NZBURL    string `json:"nzbUrl"`
@@ -120,16 +134,28 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		Protocol  string `json:"protocol"`
 		MediaType string `json:"mediaType"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 		return
 	}
-	if req.GUID == "" || req.NZBURL == "" {
+	if body.GUID == "" || body.NZBURL == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "guid and nzbUrl required"})
 		return
 	}
-	if req.Protocol == "" {
-		req.Protocol = "usenet"
+
+	var bookID int64
+	if body.BookID != nil {
+		bookID = *body.BookID
+	}
+	req := grabRequest{
+		GUID:      body.GUID,
+		Title:     body.Title,
+		NZBURL:    body.NZBURL,
+		Size:      body.Size,
+		BookID:    bookID,
+		IndexerID: body.IndexerID,
+		Protocol:  body.Protocol,
+		MediaType: body.MediaType,
 	}
 
 	existing, err := h.downloads.GetByGUID(r.Context(), req.GUID)
@@ -142,72 +168,17 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, err := h.selectClient(r.Context(), req.Protocol, req.MediaType)
-	if err != nil || client == nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "no enabled download client configured"})
-		return
-	}
-
-	protocol := downloader.ProtocolForClient(client.Type)
-	dl := &models.Download{
-		GUID:             req.GUID,
-		BookID:           req.BookID,
-		IndexerID:        req.IndexerID,
-		DownloadClientID: &client.ID,
-		Title:            req.Title,
-		NZBURL:           req.NZBURL,
-		Size:             req.Size,
-		Status:           models.StateGrabbed,
-		Protocol:         protocol,
-		Quality:          indexer.ParseRelease(req.Title).Format,
-	}
-	if err := h.downloads.Create(r.Context(), dl); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-
-	sendRes, err := downloader.SendDownload(r.Context(), client, req.NZBURL, req.Title)
+	dl, err := h.grab(r.Context(), req)
 	if err != nil {
-		slog.Error("failed to send download", "client_type", client.Type, "error", err, "title", req.Title)
-		if setErr := h.downloads.SetError(r.Context(), dl.ID, err.Error()); setErr != nil {
-			slog.Warn("failed to persist download error", "download_id", dl.ID, "error", setErr)
+		status := http.StatusBadGateway
+		if strings.Contains(err.Error(), "no enabled download client") {
+			status = http.StatusBadRequest
 		}
-		h.recordHistory(r.Context(), models.HistoryEventDownloadFailed, req.Title, req.BookID, map[string]any{"guid": req.GUID, "message": err.Error()})
-		if h.notif != nil {
-			h.notif.Send(r.Context(), notifier.EventDownloadFailed, map[string]any{"title": req.Title, "message": err.Error()})
-		}
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send to downloader: " + err.Error()})
+		writeJSON(w, status, map[string]string{"error": err.Error()})
 		return
 	}
 
-	if remoteID := sendRes.RemoteID; remoteID != "" {
-		if sendRes.UsesTorrentID {
-			if err := h.downloads.SetTorrentID(r.Context(), dl.ID, remoteID); err != nil {
-				slog.Warn("failed to set torrent ID", "download_id", dl.ID, "error", err)
-			}
-			dl.TorrentID = &remoteID
-		} else {
-			if err := h.downloads.SetNzoID(r.Context(), dl.ID, remoteID); err != nil {
-				slog.Warn("failed to set NZO ID", "download_id", dl.ID, "error", err)
-			}
-			dl.SABnzbdNzoID = &remoteID
-		}
-	}
-	if err := h.downloads.UpdateStatus(r.Context(), dl.ID, models.StateDownloading); err != nil {
-		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.StateDownloading, "error", err)
-	}
-	dl.Status = models.StateDownloading
-
-	h.recordHistory(r.Context(), models.HistoryEventGrabbed, req.Title, req.BookID, map[string]any{
-		"guid":      req.GUID,
-		"size":      req.Size,
-		"indexerId": req.IndexerID,
-	})
-	if h.notif != nil {
-		h.notif.Send(r.Context(), notifier.EventGrabbed, map[string]any{"title": req.Title, "size": req.Size})
-	}
-
-	slog.Info("download grabbed", "title", req.Title, "client", client.Type)
+	slog.Info("download grabbed", "title", req.Title)
 	writeJSON(w, http.StatusAccepted, dl)
 }
 
@@ -223,6 +194,77 @@ func (h *QueueHandler) selectClient(ctx context.Context, protocol, mediaType str
 		return nil, fmt.Errorf("no enabled %s download client configured", protocol)
 	}
 	return db.PickClientForMediaType(candidates, mediaType), nil
+}
+
+// grab executes the core grab logic: creates a download record and sends to the client.
+// It is called by both the HTTP Grab handler and PendingHandler.Grab.
+func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Download, error) {
+	if req.Protocol == "" {
+		req.Protocol = "usenet"
+	}
+	client, err := h.selectClient(ctx, req.Protocol, req.MediaType)
+	if err != nil || client == nil {
+		return nil, fmt.Errorf("no enabled download client configured")
+	}
+
+	protocol := downloader.ProtocolForClient(client.Type)
+	bookID := req.BookID
+	dl := &models.Download{
+		GUID:             req.GUID,
+		BookID:           &bookID,
+		IndexerID:        req.IndexerID,
+		DownloadClientID: &client.ID,
+		Title:            req.Title,
+		NZBURL:           req.NZBURL,
+		Size:             req.Size,
+		Status:           models.StateGrabbed,
+		Protocol:         protocol,
+		Quality:          indexer.ParseRelease(req.Title).Format,
+	}
+	if err := h.downloads.Create(ctx, dl); err != nil {
+		return nil, err
+	}
+
+	sendRes, err := downloader.SendDownload(ctx, client, req.NZBURL, req.Title)
+	if err != nil {
+		slog.Error("failed to send download", "client_type", client.Type, "error", err, "title", req.Title)
+		if setErr := h.downloads.SetError(ctx, dl.ID, err.Error()); setErr != nil {
+			slog.Warn("failed to persist download error", "download_id", dl.ID, "error", setErr)
+		}
+		h.recordHistory(ctx, models.HistoryEventDownloadFailed, req.Title, &bookID, map[string]any{"guid": req.GUID, "message": err.Error()})
+		if h.notif != nil {
+			h.notif.Send(ctx, notifier.EventDownloadFailed, map[string]any{"title": req.Title, "message": err.Error()})
+		}
+		return nil, fmt.Errorf("failed to send to downloader: %w", err)
+	}
+
+	if remoteID := sendRes.RemoteID; remoteID != "" {
+		if sendRes.UsesTorrentID {
+			if err := h.downloads.SetTorrentID(ctx, dl.ID, remoteID); err != nil {
+				slog.Warn("failed to set torrent ID", "download_id", dl.ID, "error", err)
+			}
+			dl.TorrentID = &remoteID
+		} else {
+			if err := h.downloads.SetNzoID(ctx, dl.ID, remoteID); err != nil {
+				slog.Warn("failed to set NZO ID", "download_id", dl.ID, "error", err)
+			}
+			dl.SABnzbdNzoID = &remoteID
+		}
+	}
+	if err := h.downloads.UpdateStatus(ctx, dl.ID, models.StateDownloading); err != nil {
+		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.StateDownloading, "error", err)
+	}
+	dl.Status = models.StateDownloading
+
+	h.recordHistory(ctx, models.HistoryEventGrabbed, req.Title, &bookID, map[string]any{
+		"guid":      req.GUID,
+		"size":      req.Size,
+		"indexerId": req.IndexerID,
+	})
+	if h.notif != nil {
+		h.notif.Send(ctx, notifier.EventGrabbed, map[string]any{"title": req.Title, "size": req.Size})
+	}
+	return dl, nil
 }
 
 // recordHistory is a helper to write a history event, swallowing errors.

--- a/internal/db/migrations/021_pending_releases.sql
+++ b/internal/db/migrations/021_pending_releases.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS pending_releases (
+    id           INTEGER PRIMARY KEY,
+    book_id      INTEGER NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+    title        TEXT NOT NULL,
+    indexer_id   INTEGER,
+    guid         TEXT NOT NULL UNIQUE,
+    protocol     TEXT NOT NULL,
+    size         INTEGER,
+    age_minutes  INTEGER,
+    quality      TEXT,
+    custom_score INTEGER NOT NULL DEFAULT 0,
+    reason       TEXT NOT NULL,
+    first_seen   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    release_json TEXT NOT NULL
+);

--- a/internal/db/pending_releases.go
+++ b/internal/db/pending_releases.go
@@ -1,0 +1,135 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// PendingReleaseRepo manages the pending_releases table.
+type PendingReleaseRepo struct {
+	db *sql.DB
+}
+
+// NewPendingReleaseRepo creates a new PendingReleaseRepo.
+func NewPendingReleaseRepo(db *sql.DB) *PendingReleaseRepo {
+	return &PendingReleaseRepo{db: db}
+}
+
+// Upsert inserts a pending release or ignores if the GUID already exists.
+func (r *PendingReleaseRepo) Upsert(ctx context.Context, pr *models.PendingRelease) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO pending_releases
+		  (book_id, title, indexer_id, guid, protocol, size, age_minutes, quality,
+		   custom_score, reason, first_seen, release_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(guid) DO UPDATE SET
+		  reason      = excluded.reason,
+		  age_minutes = excluded.age_minutes`,
+		pr.BookID, pr.Title, pr.IndexerID, pr.GUID, pr.Protocol,
+		pr.Size, pr.AgeMinutes, pr.Quality, pr.CustomScore,
+		pr.Reason, time.Now().UTC(), pr.ReleaseJSON,
+	)
+	return err
+}
+
+// List returns all pending releases ordered by first_seen descending.
+func (r *PendingReleaseRepo) List(ctx context.Context) ([]models.PendingRelease, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, book_id, title, indexer_id, guid, protocol, size, age_minutes,
+		       quality, custom_score, reason, first_seen, release_json
+		FROM pending_releases
+		ORDER BY first_seen DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPendingReleases(rows)
+}
+
+// ListByBook returns all pending releases for a specific book.
+func (r *PendingReleaseRepo) ListByBook(ctx context.Context, bookID int64) ([]models.PendingRelease, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, book_id, title, indexer_id, guid, protocol, size, age_minutes,
+		       quality, custom_score, reason, first_seen, release_json
+		FROM pending_releases WHERE book_id = ?
+		ORDER BY first_seen DESC`, bookID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPendingReleases(rows)
+}
+
+// GetByID returns a single pending release by its ID.
+func (r *PendingReleaseRepo) GetByID(ctx context.Context, id int64) (*models.PendingRelease, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, book_id, title, indexer_id, guid, protocol, size, age_minutes,
+		       quality, custom_score, reason, first_seen, release_json
+		FROM pending_releases WHERE id = ?`, id)
+	pr, err := scanPendingRelease(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	return pr, err
+}
+
+// DeleteByID removes a pending release.
+func (r *PendingReleaseRepo) DeleteByID(ctx context.Context, id int64) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM pending_releases WHERE id = ?`, id)
+	return err
+}
+
+// DeleteByGUID removes a pending release by GUID.
+func (r *PendingReleaseRepo) DeleteByGUID(ctx context.Context, guid string) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM pending_releases WHERE guid = ?`, guid)
+	return err
+}
+
+// DeleteByBook removes all pending releases for a book.
+func (r *PendingReleaseRepo) DeleteByBook(ctx context.Context, bookID int64) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM pending_releases WHERE book_id = ?`, bookID)
+	return err
+}
+
+func scanPendingReleases(rows *sql.Rows) ([]models.PendingRelease, error) {
+	var out []models.PendingRelease
+	for rows.Next() {
+		pr, err := scanPendingReleaseRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *pr)
+	}
+	return out, rows.Err()
+}
+
+func scanPendingRelease(row *sql.Row) (*models.PendingRelease, error) {
+	return scanPendingReleaseRow(row)
+}
+
+type pendingScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanPendingReleaseRow(s pendingScanner) (*models.PendingRelease, error) {
+	var pr models.PendingRelease
+	var indexerID sql.NullInt64
+	var quality sql.NullString
+	err := s.Scan(
+		&pr.ID, &pr.BookID, &pr.Title, &indexerID, &pr.GUID,
+		&pr.Protocol, &pr.Size, &pr.AgeMinutes, &quality,
+		&pr.CustomScore, &pr.Reason, &pr.FirstSeen, &pr.ReleaseJSON,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if indexerID.Valid {
+		pr.IndexerID = &indexerID.Int64
+	}
+	pr.Quality = quality.String
+	return &pr, nil
+}

--- a/internal/models/pending_release.go
+++ b/internal/models/pending_release.go
@@ -1,0 +1,23 @@
+package models
+
+import "time"
+
+// PendingRelease is an indexer result that was found but not yet grabbed,
+// typically because a delay profile timer has not expired. The full release
+// JSON is stored so it can be re-evaluated on subsequent scheduler sweeps
+// without another network round-trip to the indexer.
+type PendingRelease struct {
+	ID          int64     `json:"id"`
+	BookID      int64     `json:"bookId"`
+	Title       string    `json:"title"`
+	IndexerID   *int64    `json:"indexerId,omitempty"`
+	GUID        string    `json:"guid"`
+	Protocol    string    `json:"protocol"`
+	Size        int64     `json:"size"`
+	AgeMinutes  int       `json:"ageMinutes"`
+	Quality     string    `json:"quality,omitempty"`
+	CustomScore int       `json:"customScore"`
+	Reason      string    `json:"reason"`
+	FirstSeen   time.Time `json:"firstSeen"`
+	ReleaseJSON string    `json:"releaseJson"`
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -64,6 +64,8 @@ type Scheduler struct {
 	history       *db.HistoryRepo
 	settings      *db.SettingsRepo
 	blocklist     *db.BlocklistRepo
+	delayProfiles *db.DelayProfileRepo
+	pending       *db.PendingReleaseRepo
 	calibreSyncer CalibreSyncer        // optional; nil if Calibre is not configured
 	recommender   RecommendationEngine // optional; generates recommendations
 	hcSyncer      HCListSyncer         // optional; syncs Hardcover import lists
@@ -95,6 +97,18 @@ func New(
 		settings:  settings,
 		blocklist: blocklist,
 	}
+}
+
+// WithDelayProfiles attaches the delay profile repo used when evaluating releases.
+// Must be called before Start.
+func (s *Scheduler) WithDelayProfiles(dp *db.DelayProfileRepo) {
+	s.delayProfiles = dp
+}
+
+// WithPendingReleases attaches the pending releases repo so delay-rejected
+// results are stored for re-evaluation. Must be called before Start.
+func (s *Scheduler) WithPendingReleases(pr *db.PendingReleaseRepo) {
+	s.pending = pr
 }
 
 // WithHistory attaches a HistoryRepo so stall events can be recorded.
@@ -265,20 +279,36 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 			specs = append(specs, decision.NewBlocklistedSpec(entries))
 		}
 	}
+	var delayProfile *models.DelayProfile
+	if s.delayProfiles != nil {
+		if profiles, err := s.delayProfiles.List(ctx); err == nil && len(profiles) > 0 {
+			delayProfile = &profiles[0]
+			specs = append(specs, decision.DelayProfileSpec{Profile: delayProfile})
+		}
+	}
 	dm := decision.New(specs...)
 	releases := make([]decision.Release, len(results))
 	for i, res := range results {
 		releases[i] = decision.ReleaseFromSearchResult(res)
 	}
+
 	var best *newznab.SearchResult
 	for i, d := range dm.Evaluate(releases, book) {
 		if d.Approved {
 			best = &results[i]
 			break
 		}
+		// Store delay-rejected releases so they can be re-evaluated next sweep.
+		if s.pending != nil && strings.Contains(d.Rejection, "delay not met") {
+			s.storePending(ctx, book.ID, results[i], d.Rejection)
+		}
 	}
 	if best == nil {
-		return
+		// Re-evaluate any existing pending releases for this book with the current age.
+		best = s.checkPendingReleases(ctx, book, dm)
+		if best == nil {
+			return
+		}
 	}
 
 	candidates, err := s.clients.GetEnabledByProtocol(ctx, best.Protocol)
@@ -359,6 +389,63 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.StateDownloading, "error", err)
 	}
 	slog.Info("sent to downloader", "client", client.Type, "title", best.Title)
+	if s.pending != nil {
+		_ = s.pending.DeleteByBook(ctx, book.ID)
+	}
+}
+
+// storePending records a delay-rejected release in pending_releases.
+func (s *Scheduler) storePending(ctx context.Context, bookID int64, res newznab.SearchResult, reason string) {
+	blob, err := json.Marshal(res)
+	if err != nil {
+		return
+	}
+	pr := &models.PendingRelease{
+		BookID:      bookID,
+		Title:       res.Title,
+		GUID:        res.GUID,
+		Protocol:    res.Protocol,
+		Size:        res.Size,
+		AgeMinutes:  decision.PubDateToAge(res.PubDate),
+		Quality:     indexer.ParseRelease(res.Title).Format,
+		Reason:      reason,
+		ReleaseJSON: string(blob),
+	}
+	if res.IndexerID != 0 {
+		id := res.IndexerID
+		pr.IndexerID = &id
+	}
+	if err := s.pending.Upsert(ctx, pr); err != nil {
+		slog.Warn("failed to store pending release", "guid", res.GUID, "error", err)
+	}
+}
+
+// checkPendingReleases re-evaluates existing pending releases for a book.
+// If any now passes the decision engine it is returned for immediate grab.
+func (s *Scheduler) checkPendingReleases(ctx context.Context, book models.Book, dm *decision.DecisionMaker) *newznab.SearchResult {
+	if s.pending == nil {
+		return nil
+	}
+	pendingList, err := s.pending.ListByBook(ctx, book.ID)
+	if err != nil || len(pendingList) == 0 {
+		return nil
+	}
+
+	// Re-hydrate stored releases and re-evaluate with current age.
+	for i := range pendingList {
+		var res newznab.SearchResult
+		if err := json.Unmarshal([]byte(pendingList[i].ReleaseJSON), &res); err != nil {
+			continue
+		}
+		// Age is recalculated from PubDate by ReleaseFromSearchResult.
+		rel := decision.ReleaseFromSearchResult(res)
+		decisions := dm.Evaluate([]decision.Release{rel}, book)
+		if len(decisions) > 0 && decisions[0].Approved {
+			_ = s.pending.DeleteByID(ctx, pendingList[i].ID)
+			return &res
+		}
+	}
+	return nil
 }
 
 func (s *Scheduler) searchWanted() {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -166,6 +166,11 @@ export const api = {
   grab: (data: GrabRequest) => request<Download>('/queue/grab', { method: 'POST', body: JSON.stringify(data) }),
   deleteFromQueue: (id: number) => request<void>(`/queue/${id}`, { method: 'DELETE' }),
 
+  // Pending releases
+  listPending: () => request<PendingRelease[]>('/pending'),
+  dismissPending: (id: number) => request<void>(`/pending/${id}`, { method: 'DELETE' }),
+  grabPending: (id: number) => request<Download>(`/pending/${id}/grab`, { method: 'POST' }),
+
   // History
   listHistory: (params?: { bookId?: number; eventType?: string }) => {
     const q = new URLSearchParams()
@@ -377,6 +382,22 @@ export interface Indexer {
   categories: number[]
   enabled: boolean
   prowlarrInstanceId?: number
+}
+
+export interface PendingRelease {
+  id: number
+  bookId: number
+  title: string
+  indexerId?: number
+  guid: string
+  protocol: string
+  size: number
+  ageMinutes: number
+  quality?: string
+  customScore: number
+  reason: string
+  firstSeen: string
+  releaseJson: string
 }
 
 export interface ProwlarrInstance {

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -1,14 +1,22 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, QueueItem } from '../api/client'
+import { api, PendingRelease, QueueItem } from '../api/client'
 
 export default function QueuePage() {
   const { t } = useTranslation()
   const [queue, setQueue] = useState<QueueItem[]>([])
+  const [pending, setPending] = useState<PendingRelease[]>([])
   const [loading, setLoading] = useState(true)
+  const [grabbingPending, setGrabbingPending] = useState<number | null>(null)
 
   const load = () => {
-    api.listQueue().then(setQueue).catch(console.error).finally(() => setLoading(false))
+    Promise.all([
+      api.listQueue(),
+      api.listPending(),
+    ]).then(([q, p]) => {
+      setQueue(q)
+      setPending(p)
+    }).catch(console.error).finally(() => setLoading(false))
   }
 
   useEffect(() => {
@@ -25,6 +33,23 @@ export default function QueuePage() {
   const handleDelete = async (id: number) => {
     await api.deleteFromQueue(id)
     load()
+  }
+
+  const handleDismissPending = async (id: number) => {
+    await api.dismissPending(id).catch(console.error)
+    load()
+  }
+
+  const handleGrabPending = async (id: number) => {
+    setGrabbingPending(id)
+    try {
+      await api.grabPending(id)
+      load()
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setGrabbingPending(null)
+    }
   }
 
   const statusColors: Record<string, string> = {
@@ -63,58 +88,105 @@ export default function QueuePage() {
 
       {loading ? (
         <div className="text-slate-600 dark:text-zinc-500">{t('common.loading')}</div>
-      ) : queue.length === 0 ? (
+      ) : queue.length === 0 && pending.length === 0 ? (
         <div className="text-center py-16 text-slate-600 dark:text-zinc-500">
           <p>{t('queue.empty')}</p>
         </div>
       ) : (
-        <div className="space-y-2">
-          {queue.map(item => (
-            <div key={item.id} className="flex items-center justify-between p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
-              <div className="min-w-0 flex-1">
-                <h3 className="font-medium text-sm truncate">{item.title}</h3>
-                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-xs">
-                  <span className={statusColors[item.status] || 'text-slate-600 dark:text-zinc-400'}>
-                    {statusLabels[item.status] ?? item.status}
-                  </span>
-                  <span className="text-slate-600 dark:text-zinc-500">{formatSize(item.size)}</span>
-                  {item.percentage && (
-                    <span className="text-blue-400">{item.percentage}%</span>
-                  )}
-                  {item.timeLeft && (
-                    <span className="text-slate-600 dark:text-zinc-500">{t('queue.remaining', { time: item.timeLeft })}</span>
-                  )}
-                  {item.protocol && (
-                    <span className="text-slate-500 dark:text-zinc-600">{item.protocol}</span>
-                  )}
+        <div className="space-y-6">
+          {queue.length > 0 && (
+            <div className="space-y-2">
+              {queue.map(item => (
+                <div key={item.id} className="flex items-center justify-between p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+                  <div className="min-w-0 flex-1">
+                    <h3 className="font-medium text-sm truncate">{item.title}</h3>
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-xs">
+                      <span className={statusColors[item.status] || 'text-slate-600 dark:text-zinc-400'}>
+                        {statusLabels[item.status] ?? item.status}
+                      </span>
+                      <span className="text-slate-600 dark:text-zinc-500">{formatSize(item.size)}</span>
+                      {item.percentage && (
+                        <span className="text-blue-400">{item.percentage}%</span>
+                      )}
+                      {item.timeLeft && (
+                        <span className="text-slate-600 dark:text-zinc-500">{t('queue.remaining', { time: item.timeLeft })}</span>
+                      )}
+                      {item.protocol && (
+                        <span className="text-slate-500 dark:text-zinc-600">{item.protocol}</span>
+                      )}
+                    </div>
+                    {item.status === 'importBlocked' && !item.errorMessage && (
+                      <div className="mt-1 text-xs text-red-500 bg-red-500/10 rounded px-2 py-1">
+                        Import blocked — manual intervention required (check library path permissions)
+                      </div>
+                    )}
+                    {item.errorMessage && (
+                      <div className="mt-1 text-xs text-red-400 bg-red-400/10 rounded px-2 py-1">
+                        {item.errorMessage}
+                      </div>
+                    )}
+                    {item.percentage && (
+                      <div className="mt-2 h-1 bg-slate-200 dark:bg-zinc-800 rounded-full overflow-hidden">
+                        <div
+                          className="h-full bg-blue-500 transition-all"
+                          style={{ width: `${item.percentage}%` }}
+                        />
+                      </div>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => handleDelete(item.id)}
+                    className="ml-4 px-3 py-2 text-xs text-red-400 hover:text-red-300 flex-shrink-0 touch-manipulation"
+                  >
+                    {t('queue.remove')}
+                  </button>
                 </div>
-                {item.status === 'importBlocked' && !item.errorMessage && (
-                  <div className="mt-1 text-xs text-red-500 bg-red-500/10 rounded px-2 py-1">
-                    Import blocked — manual intervention required (check library path permissions)
-                  </div>
-                )}
-                {item.errorMessage && (
-                  <div className="mt-1 text-xs text-red-400 bg-red-400/10 rounded px-2 py-1">
-                    {item.errorMessage}
-                  </div>
-                )}
-                {item.percentage && (
-                  <div className="mt-2 h-1 bg-slate-200 dark:bg-zinc-800 rounded-full overflow-hidden">
-                    <div
-                      className="h-full bg-blue-500 transition-all"
-                      style={{ width: `${item.percentage}%` }}
-                    />
-                  </div>
-                )}
-              </div>
-              <button
-                onClick={() => handleDelete(item.id)}
-                className="ml-4 px-3 py-2 text-xs text-red-400 hover:text-red-300 flex-shrink-0 touch-manipulation"
-              >
-                {t('queue.remove')}
-              </button>
+              ))}
             </div>
-          ))}
+          )}
+
+          {pending.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-slate-600 dark:text-zinc-400 mb-2 flex items-center gap-2">
+                <span className="w-2 h-2 rounded-full bg-amber-400 inline-block" />
+                Pending Releases ({pending.length})
+              </h3>
+              <div className="space-y-2">
+                {pending.map(item => (
+                  <div key={item.id} className="flex items-center justify-between p-4 border border-amber-200 dark:border-amber-900/40 rounded-lg bg-amber-50 dark:bg-amber-950/20">
+                    <div className="min-w-0 flex-1">
+                      <h3 className="font-medium text-sm truncate">{item.title}</h3>
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-xs">
+                        <span className="text-amber-600 dark:text-amber-400">{item.reason}</span>
+                        {item.size > 0 && (
+                          <span className="text-slate-500 dark:text-zinc-500">{formatSize(item.size)}</span>
+                        )}
+                        {item.quality && (
+                          <span className="text-slate-500 dark:text-zinc-500">{item.quality}</span>
+                        )}
+                        <span className="text-slate-500 dark:text-zinc-500">{item.protocol}</span>
+                      </div>
+                    </div>
+                    <div className="ml-4 flex items-center gap-2 flex-shrink-0">
+                      <button
+                        onClick={() => handleGrabPending(item.id)}
+                        disabled={grabbingPending !== null}
+                        className="px-3 py-1.5 text-xs bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded font-medium"
+                      >
+                        {grabbingPending === item.id ? 'Grabbing…' : 'Grab Now'}
+                      </button>
+                      <button
+                        onClick={() => handleDismissPending(item.id)}
+                        className="px-3 py-1.5 text-xs text-slate-500 dark:text-zinc-500 hover:text-red-400 rounded"
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #140
Depends on: #218 (decision engine)

## Summary

- Adds `pending_releases` table (migration 021) to track indexer results held by a delay profile timer
- Scheduler stores delay-rejected releases and re-evaluates them each sweep; auto-grabs when delay expires
- API: `GET /pending`, `DELETE /pending/{id}`, `POST /pending/{id}/grab`
- Queue page shows a "Pending Releases" section with amber styling, Grab Now + Dismiss buttons
- Refactored `QueueHandler.grab()` into a shared internal method used by both HTTP grab and pending force-grab

## Test plan

- [ ] `go test ./...` passes
- [ ] `npm run typecheck --prefix web` clean
- [ ] Configure a delay profile, search for a book → results older than the delay are held in pending
- [ ] Queue page shows pending releases with reason text ("usenet delay not met — N min remaining")
- [ ] Grab Now bypasses delay; Dismiss removes the entry
- [ ] After delay expires, next scheduler sweep auto-grabs and removes from pending