### PR TITLE
feat(settings): improve plugin API key field UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
 
+## [v0.18.1] — 2026-04-17
+
+### Changed
+
+- **Plugin API key field UX** ([#221](https://github.com/vavallee/bindery/pull/221)) — the API key field in Settings → Calibre (plugin mode) now has a show/hide toggle (eye icon) and a **Generate** button that fills the field with a cryptographically random 32-byte hex key (`crypto.getRandomValues`). `autoComplete="off"` prevents browsers from injecting saved passwords. Paste is unrestricted.
+
 ## [v0.18.0] — 2026-04-17
 
 Calibre plugin integration mode, decision engine, pending releases, and state machine for downloads.

--- a/docs/CALIBRE-PLUGIN.md
+++ b/docs/CALIBRE-PLUGIN.md
@@ -80,7 +80,7 @@ Open **Calibre → Preferences → Plugins → User plugins → Bindery Bridge �
 |---------|-------------------|-------|
 | **Listen port** | `8099` | Any free port works |
 | **Bind host** | `0.0.0.0` | Required for cross-pod access; `127.0.0.1` only works on bare-metal |
-| **API key** | (generate one) | `openssl rand -hex 32` |
+| **API key** | (generate one) | Use the **Generate** button in Bindery → Settings → Calibre, or run `openssl rand -hex 32` |
 
 After saving, the dialog restarts the HTTP server in-place — no Calibre
 restart needed.
@@ -119,7 +119,7 @@ In Bindery: **Settings → Calibre**:
 | **Mode** | `plugin` |
 | **Library path** | Path to the Calibre library root inside Bindery's container (e.g. `/media/BOOKS`) |
 | **Plugin URL** | `http://calibre.<namespace>.svc.cluster.local:8099` |
-| **Plugin API key** | The key you set in step 2 |
+| **Plugin API key** | The key you set in step 2 — paste it here, or click **Generate** to create a new one |
 
 Click **Test connection** — it calls `GET /v1/health` and should return the
 plugin version and Calibre version.

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1609,6 +1609,7 @@ function CalibreSection({
   const [saveError, setSaveError] = useState<{ key: string; msg: string } | null>(null)
   const [importProgress, setImportProgress] = useState<CalibreImportProgress | null>(null)
   const [importError, setImportError] = useState<string | null>(null)
+  const [showPluginApiKey, setShowPluginApiKey] = useState(false)
 
   const saveSettingWithError = async (key: string) => {
     setSaveError(null)
@@ -1796,13 +1797,47 @@ function CalibreSection({
               Bearer token configured in the plugin&rsquo;s Calibre Preferences dialog.
             </p>
             <div className="flex gap-2">
-              <input
-                type="password"
-                value={settings['calibre.plugin_api_key'] ?? ''}
-                onChange={e => setSettings(s => ({ ...s, 'calibre.plugin_api_key': e.target.value }))}
-                placeholder="plugin api key"
-                className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
-              />
+              <div className="relative flex-1">
+                <input
+                  type={showPluginApiKey ? 'text' : 'password'}
+                  value={settings['calibre.plugin_api_key'] ?? ''}
+                  onChange={e => setSettings(s => ({ ...s, 'calibre.plugin_api_key': e.target.value }))}
+                  placeholder="plugin api key"
+                  autoComplete="off"
+                  className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 pr-9 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPluginApiKey(v => !v)}
+                  className="absolute inset-y-0 right-0 flex items-center px-2.5 text-slate-500 dark:text-zinc-400 hover:text-slate-700 dark:hover:text-zinc-200"
+                  title={showPluginApiKey ? 'Hide key' : 'Show key'}
+                >
+                  {showPluginApiKey ? (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                    </svg>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                    </svg>
+                  )}
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  const bytes = new Uint8Array(32)
+                  crypto.getRandomValues(bytes)
+                  const key = Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('')
+                  setSettings(s => ({ ...s, 'calibre.plugin_api_key': key }))
+                  setShowPluginApiKey(true)
+                }}
+                className="px-3 py-2 bg-slate-200 dark:bg-zinc-700 hover:bg-slate-300 dark:hover:bg-zinc-600 border border-slate-300 dark:border-zinc-600 rounded text-xs font-medium text-slate-700 dark:text-zinc-200"
+                title="Generate a random 32-byte key"
+              >
+                Generate
+              </button>
               <button
                 onClick={() => saveSettingWithError('calibre.plugin_api_key')}
                 disabled={saving === 'calibre.plugin_api_key'}


### PR DESCRIPTION
## Summary

- **Show/hide toggle** — eye icon button inside the field; starts masked, click to reveal. Uses inline SVG (no icon library dependency).
- **Generate button** — fills the field with a `crypto.getRandomValues(32)` hex key and reveals it so the user can copy before saving.
- **`autoComplete="off"`** — prevents browsers from injecting saved passwords into the API key field.

## Test plan

- [ ] Navigate to Settings → Calibre, set mode to `plugin`
- [ ] API key field renders masked by default
- [ ] Eye icon toggles between masked and visible
- [ ] Generate button fills the field with a 64-char hex string and reveals it
- [ ] Paste works in both masked and revealed states
- [ ] Save persists the key; reload confirms it is retained (masked)