### PR TITLE
feat(calibre): retry on import failure + scheduler catch-up + manual sync endpoint

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -170,14 +170,19 @@ func main() {
 	modeResolver := func() calibre.Mode { return api.LoadCalibreMode(settingsRepo) }
 	calibreCfg := api.LoadCalibreConfig(settingsRepo)
 	currentMode := api.LoadCalibreMode(settingsRepo)
+	var calibreAdderForScheduler interface {
+		Add(ctx context.Context, path string) (int64, error)
+	}
 	if currentMode == calibre.ModePlugin {
 		pluginClient := calibre.NewPluginClient(calibreCfg.PluginURL, calibreCfg.PluginAPIKey)
 		importScanner.WithCalibre(modeResolver, pluginClient)
+		calibreAdderForScheduler = pluginClient
 		slog.Info("calibre integration enabled", "mode", "plugin", "url", calibreCfg.PluginURL)
 	} else {
 		calibreClient := calibre.New(calibreCfg)
 		importScanner.WithCalibre(modeResolver, calibreClient)
 		if currentMode == calibre.ModeCalibredb {
+			calibreAdderForScheduler = calibreClient
 			slog.Info("calibre integration enabled", "mode", "calibredb")
 		}
 	}
@@ -225,9 +230,10 @@ func main() {
 	sched := scheduler.New(importScanner, idxSearcher, metaAgg,
 		authorRepo, bookRepo, indexerRepo, downloadRepo, dlClientRepo, settingsRepo, blocklistRepo)
 	sched.WithHistory(historyRepo)
-	// Register the Calibre importer as the 24-hour sync job. The scheduler
-	// only fires the job when the syncer is non-nil, so no guard needed here.
 	sched.WithCalibreSyncer(calibreImporter)
+	if calibreAdderForScheduler != nil {
+		sched.WithCalibreAdder(calibreAdderForScheduler)
+	}
 
 	// Recommendation engine (24-hour job, gated on recommendations.enabled).
 	recRepo := db.NewRecommendationRepo(database)
@@ -279,6 +285,10 @@ func main() {
 	logHandler := api.NewLogHandler(ring)
 	prowlarrHandler := api.NewProwlarrHandler(prowlarrRepo, indexerRepo)
 	calibreHandler := api.NewCalibreHandler(settingsRepo)
+	calibreHandler.WithBookRepo(bookRepo)
+	if calibreAdderForScheduler != nil {
+		calibreHandler.WithAdder(calibreAdderForScheduler)
+	}
 	calibreImportHandler := api.NewCalibreImportHandler(calibreImporter, func() calibre.Config {
 		return api.LoadCalibreConfig(settingsRepo)
 	})
@@ -359,6 +369,7 @@ func main() {
 		r.Delete("/book/{id}/file", bookHandler.DeleteFile)
 		r.Put("/book/{id}/exclude", bookHandler.ToggleExcluded)
 		r.Post("/book/{id}/enrich-audiobook", bookHandler.EnrichAudiobook)
+		r.Post("/book/{id}/calibre-sync", calibreHandler.CalibreSync)
 		r.Post("/book/{id}/search", indexerHandler.SearchBook)
 		r.Get("/book/{id}/file", fileHandler.Download)
 

--- a/internal/api/calibre.go
+++ b/internal/api/calibre.go
@@ -1,11 +1,15 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+
+	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/calibre"
 	"github.com/vavallee/bindery/internal/db"
@@ -23,16 +27,75 @@ const (
 	SettingCalibrePluginAPIKey  = "calibre.plugin_api_key"
 )
 
-// CalibreHandler exposes the "test connection" endpoint for the Calibre
-// settings UI. Read/write of the calibre.* keys themselves go through the
-// generic /setting endpoints so the UI can reuse its existing plumbing;
-// this handler just validates and probes.
+// calibreAdder is the narrow interface CalibreHandler uses to push a book.
+// Satisfied by *calibre.Client and *calibre.PluginClient.
+type calibreAdder interface {
+	Add(ctx context.Context, path string) (int64, error)
+}
+
+// CalibreHandler exposes the "test connection" and "sync book" endpoints for
+// the Calibre settings UI.
 type CalibreHandler struct {
 	settings *db.SettingsRepo
+	books    *db.BookRepo
+	adder    calibreAdder
 }
 
 func NewCalibreHandler(settings *db.SettingsRepo) *CalibreHandler {
 	return &CalibreHandler{settings: settings}
+}
+
+// WithBookRepo attaches a BookRepo so CalibreSync can look up books.
+func (h *CalibreHandler) WithBookRepo(books *db.BookRepo) {
+	h.books = books
+}
+
+// WithAdder attaches the calibre adder so CalibreSync can push books.
+func (h *CalibreHandler) WithAdder(adder calibreAdder) {
+	h.adder = adder
+}
+
+// CalibreSync manually re-pushes a single book to Calibre. Used to recover
+// books that failed at import time because the plugin was unreachable.
+// POST /api/v1/book/{id}/calibre-sync
+func (h *CalibreHandler) CalibreSync(w http.ResponseWriter, r *http.Request) {
+	if h.adder == nil || h.books == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "calibre integration not configured"})
+		return
+	}
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid book id"})
+		return
+	}
+	book, err := h.books.GetByID(r.Context(), id)
+	if err != nil || book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
+	path := book.EbookFilePath
+	if path == "" {
+		path = book.AudiobookFilePath
+	}
+	if path == "" {
+		path = book.FilePath
+	}
+	if path == "" {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "book has no file path"})
+		return
+	}
+	calibreID, err := h.adder.Add(r.Context(), path)
+	if err != nil {
+		slog.Warn("calibre: manual sync failed", "bookId", id, "path", path, "error", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := h.books.SetCalibreID(r.Context(), id, calibreID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	slog.Info("calibre: manual sync succeeded", "bookId", id, "calibreId", calibreID)
+	writeJSON(w, http.StatusOK, map[string]string{"calibre_id": strconv.FormatInt(calibreID, 10)})
 }
 
 // LoadCalibreConfig materialises a calibre.Config from the settings table.

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -201,6 +201,16 @@ func (r *BookRepo) SetCalibreID(ctx context.Context, id, calibreID int64) error 
 	return err
 }
 
+// ListImportedMissingCalibreID returns all imported books that have a file
+// path but no calibre_id. Used by the scheduler's catch-up job to retry
+// Calibre notifications that failed at import time.
+func (r *BookRepo) ListImportedMissingCalibreID(ctx context.Context) ([]models.Book, error) {
+	return r.query(ctx,
+		"SELECT "+bookColumns+" FROM books WHERE status = 'imported' AND calibre_id IS NULL"+
+			" AND (file_path != '' OR ebook_file_path != '' OR audiobook_file_path != '')",
+		nil)
+}
+
 // GetByCalibreID returns the Bindery book row that currently points at the
 // given Calibre book id, or nil if none. The library import flow uses this
 // as its primary idempotency key — a second import pass sees the existing

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -135,19 +135,34 @@ func (s *Scanner) pushToCalibre(ctx context.Context, book *models.Book, _ *model
 }
 
 // pushCalibreAdd invokes the configured adder (calibredb CLI or plugin HTTP
-// client) and persists the resulting calibre_id. Failures are best-effort —
-// logged and swallowed so Bindery's own import stays good.
+// client) and persists the resulting calibre_id. Up to 3 attempts with
+// short backoff handle transient plugin unavailability (e.g. in-place server
+// restart after a config save). Failures are still best-effort — logged and
+// swallowed so Bindery's own import stays good. The scheduler's
+// syncMissingCalibreIDs catch-up job will retry any that still fail.
 func (s *Scanner) pushCalibreAdd(ctx context.Context, book *models.Book, path string, mode calibre.Mode) {
 	if s.calibreAdder == nil {
 		slog.Debug("calibre: adder is nil, skipping", "mode", mode, "bookId", book.ID)
 		return
 	}
-	id, err := s.calibreAdder.Add(ctx, path)
+	const maxAttempts = 3
+	backoff := []time.Duration{time.Second, 2 * time.Second}
+	var id int64
+	var err error
+	for attempt := range maxAttempts {
+		id, err = s.calibreAdder.Add(ctx, path)
+		if err == nil || errors.Is(err, calibre.ErrDisabled) {
+			break
+		}
+		if attempt < len(backoff) {
+			time.Sleep(backoff[attempt])
+		}
+	}
 	if err != nil {
 		if errors.Is(err, calibre.ErrDisabled) {
 			return
 		}
-		slog.Warn("calibre: add failed, continuing", "mode", mode, "bookId", book.ID, "path", path, "error", err)
+		slog.Warn("calibre: add failed after retries, continuing", "mode", mode, "bookId", book.ID, "path", path, "error", err)
 		return
 	}
 	if err := s.books.SetCalibreID(ctx, book.ID, id); err != nil {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -29,6 +29,13 @@ type CalibreSyncer interface {
 	RunSync(ctx context.Context)
 }
 
+// CalibreAdder is the narrow interface the scheduler uses to push individual
+// books to Calibre. Both *calibre.Client (calibredb) and *calibre.PluginClient
+// satisfy it; the interface avoids a direct dependency on the calibre package.
+type CalibreAdder interface {
+	Add(ctx context.Context, path string) (int64, error)
+}
+
 // bookSearcher is the narrow interface the scheduler uses for indexer
 // searches. *indexer.Searcher satisfies it; the interface keeps the scheduler
 // testable without real network calls.
@@ -64,6 +71,7 @@ type Scheduler struct {
 	settings      *db.SettingsRepo
 	blocklist     *db.BlocklistRepo
 	calibreSyncer CalibreSyncer        // optional; nil if Calibre is not configured
+	calibreAdder  CalibreAdder         // optional; retries books with no calibre_id
 	recommender   RecommendationEngine // optional; generates recommendations
 	hcSyncer      HCListSyncer         // optional; syncs Hardcover import lists
 }
@@ -106,6 +114,12 @@ func (s *Scheduler) WithHistory(h *db.HistoryRepo) {
 // every 24 hours when Calibre is configured. Must be called before Start.
 func (s *Scheduler) WithCalibreSyncer(syncer CalibreSyncer) {
 	s.calibreSyncer = syncer
+}
+
+// WithCalibreAdder registers an adder used by the catch-up job that retries
+// imported books with no calibre_id. Must be called before Start.
+func (s *Scheduler) WithCalibreAdder(adder CalibreAdder) {
+	s.calibreAdder = adder
 }
 
 // WithRecommender registers a recommendation engine that runs every 24 hours.
@@ -162,6 +176,15 @@ func (s *Scheduler) Start() {
 		s.cron.AddFunc("@every 24h", func() {
 			slog.Info("job: calibre library sync")
 			s.calibreSyncer.RunSync(context.Background())
+		})
+	}
+
+	// Retry imported books with no calibre_id every 6 hours. Handles cases
+	// where the Calibre plugin was unreachable at import time.
+	if s.calibreAdder != nil {
+		s.cron.AddFunc("@every 6h", func() {
+			slog.Info("job: calibre catch-up sync")
+			s.syncMissingCalibreIDs(context.Background())
 		})
 	}
 
@@ -572,4 +595,44 @@ func (s *Scheduler) handleStalledDownload(ctx context.Context, dl *models.Downlo
 	}
 
 	go s.SearchAndGrabBook(ctx, *book)
+}
+
+// syncMissingCalibreIDs finds all imported books with no calibre_id and
+// re-pushes them to Calibre. Runs every 6 hours to catch imports that failed
+// because the Calibre plugin was temporarily unreachable.
+func (s *Scheduler) syncMissingCalibreIDs(ctx context.Context) {
+	if s.calibreAdder == nil || s.books == nil {
+		return
+	}
+	books, err := s.books.ListImportedMissingCalibreID(ctx)
+	if err != nil {
+		slog.Warn("calibre catch-up: list failed", "error", err)
+		return
+	}
+	if len(books) == 0 {
+		return
+	}
+	slog.Info("calibre catch-up: retrying books", "count", len(books))
+	for _, book := range books {
+		path := book.EbookFilePath
+		if path == "" {
+			path = book.AudiobookFilePath
+		}
+		if path == "" {
+			path = book.FilePath
+		}
+		if path == "" {
+			continue
+		}
+		id, err := s.calibreAdder.Add(ctx, path)
+		if err != nil {
+			slog.Warn("calibre catch-up: add failed", "bookId", book.ID, "path", path, "error", err)
+			continue
+		}
+		if err := s.books.SetCalibreID(ctx, book.ID, id); err != nil {
+			slog.Warn("calibre catch-up: persist calibre_id failed", "bookId", book.ID, "error", err)
+			continue
+		}
+		slog.Info("calibre catch-up: book mirrored", "bookId", book.ID, "calibreId", id)
+	}
 }


### PR DESCRIPTION
## Problem

When the Calibre plugin is temporarily unreachable at import time (pod restart, in-place config save restarting the HTTP server), the book lands in the library but never gets added to Calibre. There was no retry and no recovery path other than a manual `kubectl exec` curl.

Discovered when Life of Pi imported at 23:56 UTC while the plugin was down, leaving `calibre_id = NULL` on the book row.

## Solution — three layers

### 1. Import-time retry
`pushCalibreAdd` now retries up to 3 times with 1s → 2s backoff before giving up. Handles transient blips (the most common failure mode: plugin HTTP server restarting after a config save).

### 2. Scheduler catch-up (every 6h)
`syncMissingCalibreIDs` finds all `status=imported, calibre_id IS NULL` books with a file path and re-pushes them. Silent automatic recovery — books that slipped through the retry window self-heal within 6 hours.

### 3. Manual re-trigger endpoint
`POST /api/v1/book/{id}/calibre-sync` — pushes a specific book to Calibre on demand and persists the resulting `calibre_id`. For immediate recovery without waiting for the scheduler.

## Changes

| File | What |
|------|------|
| `internal/importer/scanner.go` | 3-attempt retry with 1s/2s backoff in `pushCalibreAdd` |
| `internal/db/books.go` | `ListImportedMissingCalibreID` query for catch-up job |
| `internal/scheduler/scheduler.go` | `CalibreAdder` interface, `WithCalibreAdder`, `syncMissingCalibreIDs`, 6h cron entry |
| `internal/api/calibre.go` | `CalibreSync` handler (`POST /book/{id}/calibre-sync`) |
| `cmd/bindery/main.go` | Wire adder into scheduler and handler |

## Test plan

- [ ] Import a book with plugin URL pointing at a dead endpoint → confirm 3 attempts logged, then "add failed after retries"
- [ ] Fix plugin URL → within 6h (or manually trigger scheduler) → book gets `calibre_id`
- [ ] `POST /api/v1/book/131/calibre-sync` with plugin reachable → returns `{"calibre_id": "..."}`, book row updated
- [ ] `POST /api/v1/book/{id}/calibre-sync` when integration is off → 503
- [ ] `POST /api/v1/book/{id}/calibre-sync` on book with no file path → 422
- [ ] All existing tests pass