### PR TITLE
fix(indexers): fix crash when no Prowlarr instances configured

### DIFF
--- a/internal/api/prowlarr.go
+++ b/internal/api/prowlarr.go
@@ -29,6 +29,9 @@ func (h *ProwlarrHandler) List(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	if items == nil {
+		items = []models.ProwlarrInstance{}
+	}
 	writeJSON(w, http.StatusOK, items)
 }
 

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -42,7 +42,7 @@ export default function SettingsPage() {
   useEffect(() => {
     api.listIndexers().then(setIndexers).catch(console.error)
     api.listDownloadClients().then(setClients).catch(console.error)
-    api.listProwlarr().then(setProwlarrInstances).catch(console.error)
+    api.listProwlarr().then(r => setProwlarrInstances(r ?? [])).catch(console.error)
   }, [])
 
   useEffect(() => {
@@ -216,7 +216,7 @@ export default function SettingsPage() {
                             const r = await api.syncProwlarr(p.id)
                             setProwlarrSyncResult(prev => ({ ...prev, [p.id]: `Synced — added ${r.added}, updated ${r.updated}, removed ${r.removed}` }))
                             api.listIndexers().then(setIndexers).catch(console.error)
-                            api.listProwlarr().then(setProwlarrInstances).catch(console.error)
+                            api.listProwlarr().then(r => setProwlarrInstances(r ?? [])).catch(console.error)
                           } catch (err: unknown) {
                             alert(err instanceof Error ? err.message : 'Sync failed')
                           }


### PR DESCRIPTION
Fixes #225.

Go marshals a nil slice as `null`, so `/api/v1/prowlarr` returned `null` instead of `[]` for users without Prowlarr configured. React set `prowlarrInstances` to `null`, then `prowlarrInstances.length` threw when the Indexers tab rendered, crashing the whole app.

- Backend: return `[]` when the slice is nil (same guard the Indexer handler already had)
- Frontend: defensive `?? []` when setting state