### PR TITLE
fix(metadata): fail closed on unknown language when profile restricts it

### DIFF
--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -240,8 +240,8 @@ func TestFetchAuthorBooks_FiresSearchForMonitoredAuthor(t *testing.T) {
 
 	stub := &stubMetaProvider{
 		works: []models.Book{
-			{ForeignID: "OL501W", Title: "First Book", SortTitle: "first book", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
-			{ForeignID: "OL502W", Title: "Second Book", SortTitle: "second book", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+			{ForeignID: "OL501W", Title: "First Book", SortTitle: "first book", Language: "eng", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+			{ForeignID: "OL502W", Title: "Second Book", SortTitle: "second book", Language: "eng", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
 		},
 	}
 	agg := metadata.NewAggregator(stub)
@@ -296,8 +296,8 @@ func TestFetchAuthorBooks_SkipsSearchForOwnedBooks(t *testing.T) {
 
 	stub := &stubMetaProvider{
 		works: []models.Book{
-			{ForeignID: "OL701W", Title: "Already Owned", SortTitle: "already owned", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
-			{ForeignID: "OL702W", Title: "Not Yet Owned", SortTitle: "not yet owned", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+			{ForeignID: "OL701W", Title: "Already Owned", SortTitle: "already owned", Language: "eng", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+			{ForeignID: "OL702W", Title: "Not Yet Owned", SortTitle: "not yet owned", Language: "eng", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
 		},
 	}
 	agg := metadata.NewAggregator(stub)

--- a/internal/models/language.go
+++ b/internal/models/language.go
@@ -34,15 +34,17 @@ func ParseAllowedLanguages(csv string) []string {
 }
 
 // IsLanguageAllowed returns true if code matches any entry in allowed, or if
-// allowed is empty (filter disabled) or code is empty (source didn't report a
-// language — we'd rather keep a book than drop it on missing data).
+// allowed is empty (filter disabled). When allowed is non-empty and code is
+// empty (source didn't report a language), the book is rejected — failing
+// closed prevents non-English editions from slipping through when OL omits
+// language data at the work level.
 func IsLanguageAllowed(code string, allowed []string) bool {
 	if len(allowed) == 0 {
 		return true
 	}
 	code = strings.ToLower(strings.TrimSpace(code))
 	if code == "" {
-		return true
+		return false
 	}
 	return slices.Contains(allowed, code)
 }

--- a/internal/models/language_test.go
+++ b/internal/models/language_test.go
@@ -38,7 +38,7 @@ func TestIsLanguageAllowed(t *testing.T) {
 		want    bool
 	}{
 		{"eng", nil, true},               // no filter
-		{"", []string{"eng"}, true},      // unknown language = keep
+		{"", []string{"eng"}, false},     // unknown language = reject when filter active
 		{"eng", []string{"eng"}, true},   // exact match
 		{"ENG", []string{"eng"}, true},   // case-insensitive
 		{" eng ", []string{"eng"}, true}, // whitespace-tolerant


### PR DESCRIPTION
Fixes #224.

`IsLanguageAllowed` was passing books with `Language=""` through even when the metadata profile required a specific language. OL doesn't populate language at the work level, so most works had an empty field and silently bypassed the filter.

Now rejects when `allowedLanguages` is set and language is unknown — the OL client already does a best-effort search-index lookup, so this only catches works the index doesn't cover.

Tests updated to use explicit `Language: "eng"` in stubs that go through an English-only profile.