### PR TITLE
feat(series): monitor flag + Fill gaps action

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -271,7 +271,7 @@ func main() {
 	notificationHandler := api.NewNotificationHandler(notificationRepo, notif)
 	qualityProfileHandler := api.NewQualityProfileHandler(qualityProfileRepo)
 	settingsHandler := api.NewSettingsHandler(settingsRepo)
-	seriesHandler := api.NewSeriesHandler(seriesRepo)
+	seriesHandler := api.NewSeriesHandler(seriesRepo, bookRepo, sched)
 	tagHandler := api.NewTagHandler(tagRepo)
 	importListHandler := api.NewImportListHandler(importListRepo)
 	metadataProfileHandler := api.NewMetadataProfileHandler(metadataProfileRepo)
@@ -440,6 +440,8 @@ func main() {
 		// Series
 		r.Get("/series", seriesHandler.List)
 		r.Get("/series/{id}", seriesHandler.Get)
+		r.Patch("/series/{id}", seriesHandler.Monitor)
+		r.Post("/series/{id}/fill", seriesHandler.Fill)
 
 		// Recommendations
 		r.Get("/recommendations", recHandler.List)

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -11,11 +14,13 @@ import (
 )
 
 type SeriesHandler struct {
-	series *db.SeriesRepo
+	series   *db.SeriesRepo
+	books    *db.BookRepo
+	searcher BookSearcher
 }
 
-func NewSeriesHandler(series *db.SeriesRepo) *SeriesHandler {
-	return &SeriesHandler{series: series}
+func NewSeriesHandler(series *db.SeriesRepo, books *db.BookRepo, searcher BookSearcher) *SeriesHandler {
+	return &SeriesHandler{series: series, books: books, searcher: searcher}
 }
 
 func (h *SeriesHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -50,4 +55,59 @@ func (h *SeriesHandler) Get(w http.ResponseWriter, r *http.Request) {
 		s.Books = []models.SeriesBook{}
 	}
 	writeJSON(w, http.StatusOK, s)
+}
+
+// Monitor toggles the monitored flag on a series.
+func (h *SeriesHandler) Monitor(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		return
+	}
+
+	var body struct {
+		Monitored bool `json:"monitored"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	if err := h.series.SetMonitored(r.Context(), id, body.Monitored); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"monitored": body.Monitored})
+}
+
+// Fill marks all non-imported books in a series as wanted and kicks off searches.
+func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		return
+	}
+
+	books, err := h.series.ListBooksInSeries(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	queued := 0
+	for _, b := range books {
+		if b.Status == models.BookStatusImported {
+			continue
+		}
+		b.Status = models.BookStatusWanted
+		b.Monitored = true
+		if err := h.books.Update(r.Context(), &b); err != nil {
+			slog.Warn("series fill: failed to update book", "book", b.Title, "error", err)
+			continue
+		}
+		queued++
+		go h.searcher.SearchAndGrabBook(context.Background(), b)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]int{"queued": queued})
 }

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -19,7 +19,8 @@ func seriesFixture(t *testing.T) (*SeriesHandler, *db.SeriesRepo, *db.AuthorRepo
 	}
 	t.Cleanup(func() { database.Close() })
 	repo := db.NewSeriesRepo(database)
-	return NewSeriesHandler(repo), repo, db.NewAuthorRepo(database), db.NewBookRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	return NewSeriesHandler(repo, bookRepo, &mockBookSearcher{}), repo, db.NewAuthorRepo(database), bookRepo
 }
 
 func TestSeriesList_Empty(t *testing.T) {

--- a/internal/db/migrations/022_series_monitored.sql
+++ b/internal/db/migrations/022_series_monitored.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE series ADD COLUMN monitored INTEGER NOT NULL DEFAULT 0;
+
+-- +migrate Down
+-- SQLite does not support DROP COLUMN in older versions; migration is non-reversible.

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -20,7 +20,7 @@ func NewSeriesRepo(db *sql.DB) *SeriesRepo {
 
 func (r *SeriesRepo) List(ctx context.Context) ([]models.Series, error) {
 	rows, err := r.db.QueryContext(ctx,
-		"SELECT id, foreign_id, title, description, created_at FROM series ORDER BY title")
+		"SELECT id, foreign_id, title, description, monitored, created_at FROM series ORDER BY title")
 	if err != nil {
 		return nil, fmt.Errorf("list series: %w", err)
 	}
@@ -29,20 +29,66 @@ func (r *SeriesRepo) List(ctx context.Context) ([]models.Series, error) {
 	var series []models.Series
 	for rows.Next() {
 		var s models.Series
-		if err := rows.Scan(&s.ID, &s.ForeignID, &s.Title, &s.Description, &s.CreatedAt); err != nil {
+		var monitored int
+		if err := rows.Scan(&s.ID, &s.ForeignID, &s.Title, &s.Description, &monitored, &s.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan series: %w", err)
 		}
+		s.Monitored = monitored == 1
 		series = append(series, s)
 	}
 	return series, rows.Err()
 }
 
+func (r *SeriesRepo) SetMonitored(ctx context.Context, id int64, monitored bool) error {
+	val := 0
+	if monitored {
+		val = 1
+	}
+	_, err := r.db.ExecContext(ctx, "UPDATE series SET monitored=? WHERE id=?", val, id)
+	return err
+}
+
+// ListBooksInSeries returns all books linked to the given series, with status.
+func (r *SeriesRepo) ListBooksInSeries(ctx context.Context, seriesID int64) ([]models.Book, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT b.id, b.foreign_id, b.author_id, b.title, b.sort_title, b.status, b.monitored,
+		       b.image_url, b.release_date, b.language, b.media_type, b.created_at, b.updated_at
+		FROM series_books sb
+		JOIN books b ON b.id = sb.book_id
+		WHERE sb.series_id = ?`, seriesID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var books []models.Book
+	for rows.Next() {
+		var b models.Book
+		var monitored int
+		var releaseDate sql.NullTime
+		if err := rows.Scan(
+			&b.ID, &b.ForeignID, &b.AuthorID, &b.Title, &b.SortTitle, &b.Status, &monitored,
+			&b.ImageURL, &releaseDate, &b.Language, &b.MediaType, &b.CreatedAt, &b.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		b.Monitored = monitored == 1
+		if releaseDate.Valid {
+			b.ReleaseDate = &releaseDate.Time
+		}
+		books = append(books, b)
+	}
+	return books, rows.Err()
+}
+
 func (r *SeriesRepo) GetByID(ctx context.Context, id int64) (*models.Series, error) {
 	row := r.db.QueryRowContext(ctx,
-		"SELECT id, foreign_id, title, description, created_at FROM series WHERE id=?", id)
+		"SELECT id, foreign_id, title, description, monitored, created_at FROM series WHERE id=?", id)
 
 	var s models.Series
-	err := row.Scan(&s.ID, &s.ForeignID, &s.Title, &s.Description, &s.CreatedAt)
+	var monitored int
+	err := row.Scan(&s.ID, &s.ForeignID, &s.Title, &s.Description, &monitored, &s.CreatedAt)
+	s.Monitored = monitored == 1
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -1,5 +1,5 @@
 // Package downloader provides a unified interface for dispatching download
-// requests to different download clients (SABnzbd, Transmission, qBittorrent).
+// requests to different download clients (SABnzbd, NZBGet, Transmission, qBittorrent).
 package downloader
 
 import (
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vavallee/bindery/internal/downloader/nzbget"
 	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
 	"github.com/vavallee/bindery/internal/downloader/transmission"
@@ -30,6 +31,11 @@ func IsTorrentClient(clientType string) bool {
 	return clientType == "transmission" || clientType == "qbittorrent"
 }
 
+// IsNZBGetClient reports whether the given client type is NZBGet.
+func IsNZBGetClient(clientType string) bool {
+	return clientType == "nzbget"
+}
+
 func ProtocolForClient(clientType string) string {
 	if IsTorrentClient(clientType) {
 		return "torrent"
@@ -45,6 +51,9 @@ func TestClient(ctx context.Context, client *models.DownloadClient) error {
 	case "qbittorrent":
 		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
 		return qb.Test(ctx)
+	case "nzbget":
+		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		return ng.Test(ctx)
 	default:
 		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
 		return sab.Test(ctx)
@@ -89,6 +98,14 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		}
 		result.RemoteID = hash
 		return result, nil
+	case "nzbget":
+		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		nzbID, err := ng.Add(ctx, sourceURL, title, client.Category, 0)
+		if err != nil {
+			return nil, err
+		}
+		result.RemoteID = strconv.Itoa(nzbID)
+		return result, nil
 	default:
 		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
 		resp, err := sab.AddURL(ctx, sourceURL, title, client.Category, 0)
@@ -120,6 +137,16 @@ func RemoveDownload(ctx context.Context, client *models.DownloadClient, dl *mode
 		}
 		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
 		return qb.DeleteTorrent(ctx, *dl.TorrentID, deleteFiles)
+	case "nzbget":
+		if dl.SABnzbdNzoID == nil || *dl.SABnzbdNzoID == "" {
+			return nil
+		}
+		nzbID, err := nzbget.ParseNZBID(*dl.SABnzbdNzoID)
+		if err != nil {
+			return err
+		}
+		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		return ng.Remove(ctx, nzbID)
 	default:
 		if dl.SABnzbdNzoID == nil || *dl.SABnzbdNzoID == "" {
 			return nil
@@ -178,6 +205,10 @@ func GetLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[st
 		statuses, err := getTorrentLiveStatuses(ctx, client)
 		return statuses, true, err
 	}
+	if IsNZBGetClient(client.Type) {
+		statuses, err := getNZBGetLiveStatuses(ctx, client)
+		return statuses, false, err
+	}
 	statuses, err := getSABLiveStatuses(ctx, client)
 	return statuses, false, err
 }
@@ -195,6 +226,28 @@ func getSABLiveStatuses(ctx context.Context, client *models.DownloadClient) (map
 			Percentage: slot.Percentage,
 			TimeLeft:   slot.TimeLeft,
 			Speed:      queue.Speed,
+		}
+	}
+	return out, nil
+}
+
+func getNZBGetLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[string]LiveStatus, error) {
+	ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	groups, err := ng.GetQueue(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]LiveStatus, len(groups))
+	for _, g := range groups {
+		id := strconv.Itoa(g.NZBID)
+		pct := ""
+		if g.FileSizeMB > 0 {
+			done := g.FileSizeMB - g.RemainingSizeMB
+			pct = fmt.Sprintf("%.1f", done/g.FileSizeMB*100)
+		}
+		out[id] = LiveStatus{
+			Percentage: pct,
 		}
 	}
 	return out, nil

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -1,0 +1,169 @@
+// Package nzbget provides a client for the NZBGet JSON-RPC API, used to
+// submit NZB URLs and poll queue/history for Usenet downloads.
+package nzbget
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Client interacts with the NZBGet JSON-RPC API.
+type Client struct {
+	baseURL string
+	http    *http.Client
+	// username and password for HTTP Basic auth
+	username string
+	password string
+}
+
+// New creates a NZBGet client.
+// NZBGet's JSON-RPC endpoint is http://user:pass@host:port/jsonrpc.
+func New(host string, port int, username, password string, useSSL bool) *Client {
+	scheme := "http"
+	if useSSL {
+		scheme = "https"
+	}
+	return &Client{
+		baseURL:  fmt.Sprintf("%s://%s:%d/jsonrpc", scheme, host, port),
+		username: username,
+		password: password,
+		http:     &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// Test verifies connectivity by calling the "version" RPC method.
+func (c *Client) Test(ctx context.Context) error {
+	var resp versionResponse
+	if err := c.call(ctx, "version", nil, &resp); err != nil {
+		return fmt.Errorf("could not reach NZBGet at %s — %w (in Docker use the service/container name, not localhost)", c.baseURL, err)
+	}
+	if resp.Result == "" {
+		return fmt.Errorf("NZBGet returned empty version — check credentials")
+	}
+	return nil
+}
+
+// Add submits an NZB by URL to NZBGet and returns the NZBID as a string.
+// The priority parameter maps to NZBGet priorities: 0=normal, 100=high, -100=low.
+func (c *Client) Add(ctx context.Context, nzbURL, name, category string, priority int) (int, error) {
+	// append params: name, url, category, priority, dupecheck, dupekey, dupescore,
+	//                ppparameters (array), addtoTop, addpaused, urlpassword, postscript
+	params := []any{name, nzbURL, category, priority, false, "", 0, []any{}, false, false, "", ""}
+	var resp appendResponse
+	if err := c.call(ctx, "append", params, &resp); err != nil {
+		return 0, fmt.Errorf("add nzb: %w", err)
+	}
+	if resp.Result <= 0 {
+		return 0, fmt.Errorf("NZBGet rejected download (returned id %d)", resp.Result)
+	}
+	return resp.Result, nil
+}
+
+// GetQueue returns the active download groups from NZBGet.
+func (c *Client) GetQueue(ctx context.Context) ([]Group, error) {
+	var resp listGroupsResponse
+	if err := c.call(ctx, "listgroups", []any{0}, &resp); err != nil {
+		return nil, fmt.Errorf("get queue: %w", err)
+	}
+	return resp.Result, nil
+}
+
+// GetHistory returns completed and failed downloads from NZBGet.
+// hidden=false returns only visible (non-hidden) history items.
+func (c *Client) GetHistory(ctx context.Context) ([]HistoryItem, error) {
+	var resp historyResponse
+	if err := c.call(ctx, "history", []any{false}, &resp); err != nil {
+		return nil, fmt.Errorf("get history: %w", err)
+	}
+	return resp.Result, nil
+}
+
+// Remove permanently deletes a download (queue or history) by NZBID.
+// It uses the "DeleteFinal" command which removes both the download and its files
+// from the queue or history. For already-completed downloads use RemoveHistory.
+func (c *Client) Remove(ctx context.Context, nzbID int) error {
+	var resp editQueueResponse
+	if err := c.call(ctx, "editqueue", []any{"DeleteFinal", "", []int{nzbID}}, &resp); err != nil {
+		return fmt.Errorf("remove nzb %d: %w", nzbID, err)
+	}
+	return nil
+}
+
+// RemoveHistory removes a completed/failed item from NZBGet history by NZBID.
+func (c *Client) RemoveHistory(ctx context.Context, nzbID int) error {
+	var resp editQueueResponse
+	if err := c.call(ctx, "editqueue", []any{"HistoryDelete", "", []int{nzbID}}, &resp); err != nil {
+		return fmt.Errorf("remove history %d: %w", nzbID, err)
+	}
+	return nil
+}
+
+// ParseNZBID parses a string NZBID (as stored in the DB) back to an int.
+func ParseNZBID(s string) (int, error) {
+	id, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid nzbget id %q: %w", s, err)
+	}
+	return id, nil
+}
+
+// IsSuccess reports whether a NZBGet history status string represents a
+// successful download. NZBGet reports "SUCCESS" for clean downloads and
+// various "SUCCESS/..." sub-statuses.
+func IsSuccess(status string) bool {
+	return len(status) >= 7 && status[:7] == "SUCCESS"
+}
+
+// IsFailure reports whether a NZBGet history status string represents a
+// failed download.
+func IsFailure(status string) bool {
+	return len(status) >= 7 && status[:7] == "FAILURE" ||
+		status == "DELETED" ||
+		(len(status) >= 6 && status[:6] == "SCRIPT")
+}
+
+func (c *Client) call(ctx context.Context, method string, params []any, target any) error {
+	if params == nil {
+		params = []any{}
+	}
+	reqBody := rpcRequest{
+		Method: method,
+		Params: params,
+		ID:     1,
+	}
+	buf, err := json.Marshal(reqBody)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL, bytes.NewReader(buf))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("authentication failed — check username and password")
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	return json.NewDecoder(resp.Body).Decode(target)
+}

--- a/internal/downloader/nzbget/client_test.go
+++ b/internal/downloader/nzbget/client_test.go
@@ -1,0 +1,335 @@
+package nzbget
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+)
+
+// serverHostPort parses a test server URL into host and port.
+func serverHostPort(t *testing.T, raw string) (string, int) {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	host := u.Hostname()
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	return host, port
+}
+
+// decodeRequest parses the incoming JSON-RPC body and returns the method name.
+func decodeRequest(t *testing.T, r *http.Request) rpcRequest {
+	t.Helper()
+	var req rpcRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Fatalf("decode rpc request: %v", err)
+	}
+	return req
+}
+
+// TestTest_Success verifies that Test passes when NZBGet returns a version string.
+func TestTest_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRequest(t, r)
+		if req.Method != "version" {
+			t.Errorf("expected method=version, got %q", req.Method)
+		}
+		json.NewEncoder(w).Encode(versionResponse{Result: "21.1"})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "user", "pass", false)
+
+	if err := c.Test(context.Background()); err != nil {
+		t.Fatalf("Test should pass: %v", err)
+	}
+}
+
+// TestTest_AuthFailure verifies that Test returns an error on HTTP 401.
+func TestTest_AuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "bad", "creds", false)
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error on auth failure")
+	}
+}
+
+// TestTest_EmptyVersion verifies that Test returns an error when NZBGet returns
+// an empty result (e.g. misconfigured or wrong endpoint).
+func TestTest_EmptyVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(versionResponse{Result: ""})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", false)
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error on empty version")
+	}
+}
+
+// TestAdd verifies that Add sends the correct JSON-RPC request and returns the NZBID.
+func TestAdd(t *testing.T) {
+	var gotReq rpcRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReq = decodeRequest(t, r)
+		json.NewEncoder(w).Encode(appendResponse{Result: 42})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "user", "pass", false)
+
+	id, err := c.Add(context.Background(), "https://example.com/file.nzb", "Test Book", "books", 0)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if id != 42 {
+		t.Errorf("expected NZBID=42, got %d", id)
+	}
+	if gotReq.Method != "append" {
+		t.Errorf("expected method=append, got %q", gotReq.Method)
+	}
+}
+
+// TestAdd_Rejected verifies that Add returns an error when NZBGet rejects the download.
+func TestAdd_Rejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(appendResponse{Result: 0})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", false)
+
+	_, err := c.Add(context.Background(), "https://example.com/bad.nzb", "Bad NZB", "books", 0)
+	if err == nil {
+		t.Fatal("expected error when NZBGet rejects download")
+	}
+}
+
+// TestGetQueue verifies that GetQueue parses active download groups.
+func TestGetQueue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRequest(t, r)
+		if req.Method != "listgroups" {
+			t.Errorf("expected method=listgroups, got %q", req.Method)
+		}
+		json.NewEncoder(w).Encode(listGroupsResponse{
+			Result: []Group{
+				{
+					NZBID:           101,
+					NZBName:         "Interesting Book",
+					Status:          "DOWNLOADING",
+					Category:        "books",
+					FileSizeMB:      250.0,
+					RemainingSizeMB: 125.0,
+					ActiveDownloads: 4,
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", false)
+
+	groups, err := c.GetQueue(context.Background())
+	if err != nil {
+		t.Fatalf("GetQueue: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if groups[0].NZBID != 101 {
+		t.Errorf("expected NZBID=101, got %d", groups[0].NZBID)
+	}
+	if groups[0].Status != "DOWNLOADING" {
+		t.Errorf("expected status DOWNLOADING, got %q", groups[0].Status)
+	}
+	if groups[0].ActiveDownloads != 4 {
+		t.Errorf("expected 4 active downloads, got %d", groups[0].ActiveDownloads)
+	}
+}
+
+// TestGetHistory verifies that GetHistory returns success and failure items.
+func TestGetHistory(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRequest(t, r)
+		if req.Method != "history" {
+			t.Errorf("expected method=history, got %q", req.Method)
+		}
+		json.NewEncoder(w).Encode(historyResponse{
+			Result: []HistoryItem{
+				{
+					NZBID:      201,
+					NZBName:    "Good Book",
+					Status:     "SUCCESS/ALL",
+					Category:   "books",
+					FileSizeMB: 300.0,
+					DestDir:    "/downloads/complete/books/Good Book",
+				},
+				{
+					NZBID:    202,
+					NZBName:  "Bad Book",
+					Status:   "FAILURE/UNPACK",
+					Category: "books",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", false)
+
+	items, err := c.GetHistory(context.Background())
+	if err != nil {
+		t.Fatalf("GetHistory: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 history items, got %d", len(items))
+	}
+	if !IsSuccess(items[0].Status) {
+		t.Errorf("expected SUCCESS status for item 0, got %q", items[0].Status)
+	}
+	if !IsFailure(items[1].Status) {
+		t.Errorf("expected FAILURE status for item 1, got %q", items[1].Status)
+	}
+}
+
+// TestRemove verifies that Remove sends the DeleteFinal editqueue command.
+func TestRemove(t *testing.T) {
+	var gotReq rpcRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReq = decodeRequest(t, r)
+		json.NewEncoder(w).Encode(editQueueResponse{Result: true})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", false)
+
+	if err := c.Remove(context.Background(), 101); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if gotReq.Method != "editqueue" {
+		t.Errorf("expected method=editqueue, got %q", gotReq.Method)
+	}
+	// Verify first param is "DeleteFinal"
+	if len(gotReq.Params) == 0 {
+		t.Fatal("expected params in editqueue request")
+	}
+	if gotReq.Params[0] != "DeleteFinal" {
+		t.Errorf("expected DeleteFinal command, got %v", gotReq.Params[0])
+	}
+}
+
+// TestRemoveHistory verifies that RemoveHistory sends the HistoryDelete command.
+func TestRemoveHistory(t *testing.T) {
+	var gotReq rpcRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReq = decodeRequest(t, r)
+		json.NewEncoder(w).Encode(editQueueResponse{Result: true})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", false)
+
+	if err := c.RemoveHistory(context.Background(), 202); err != nil {
+		t.Fatalf("RemoveHistory: %v", err)
+	}
+	if gotReq.Params[0] != "HistoryDelete" {
+		t.Errorf("expected HistoryDelete command, got %v", gotReq.Params[0])
+	}
+}
+
+// TestParseNZBID verifies ID parsing.
+func TestParseNZBID(t *testing.T) {
+	id, err := ParseNZBID("42")
+	if err != nil || id != 42 {
+		t.Fatalf("ParseNZBID: got id=%d err=%v", id, err)
+	}
+	if _, err := ParseNZBID("abc"); err == nil {
+		t.Fatal("expected error for non-numeric ID")
+	}
+}
+
+// TestIsSuccess and TestIsFailure verify the status helper functions.
+func TestIsSuccess(t *testing.T) {
+	cases := []struct {
+		status  string
+		success bool
+	}{
+		{"SUCCESS/ALL", true},
+		{"SUCCESS", true},
+		{"FAILURE/UNPACK", false},
+		{"DELETED", false},
+		{"DOWNLOADING", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsSuccess(tc.status); got != tc.success {
+			t.Errorf("IsSuccess(%q) = %v, want %v", tc.status, got, tc.success)
+		}
+	}
+}
+
+func TestIsFailure(t *testing.T) {
+	cases := []struct {
+		status  string
+		failure bool
+	}{
+		{"FAILURE/UNPACK", true},
+		{"FAILURE/PAR", true},
+		{"DELETED", true},
+		{"SUCCESS/ALL", false},
+		{"DOWNLOADING", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsFailure(tc.status); got != tc.failure {
+			t.Errorf("IsFailure(%q) = %v, want %v", tc.status, got, tc.failure)
+		}
+	}
+}
+
+// TestBasicAuth verifies that the client sends HTTP Basic auth credentials.
+func TestBasicAuth(t *testing.T) {
+	var gotUser, gotPass string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser, gotPass, _ = r.BasicAuth()
+		json.NewEncoder(w).Encode(versionResponse{Result: "21.0"})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "admin", "secret", false)
+
+	if err := c.Test(context.Background()); err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if gotUser != "admin" || gotPass != "secret" {
+		t.Errorf("expected admin/secret, got %q/%q", gotUser, gotPass)
+	}
+}

--- a/internal/downloader/nzbget/types.go
+++ b/internal/downloader/nzbget/types.go
@@ -1,0 +1,58 @@
+package nzbget
+
+// rpcRequest is the JSON-RPC request envelope.
+type rpcRequest struct {
+	Method string `json:"method"`
+	Params []any  `json:"params"`
+	ID     int    `json:"id"`
+}
+
+// versionResponse is the result of calling the "version" method.
+type versionResponse struct {
+	Result string `json:"result"`
+}
+
+// appendResponse is the result of calling the "append" method.
+// NZBGet returns the NZBID (positive integer) on success, or 0 on failure.
+type appendResponse struct {
+	Result int `json:"result"`
+}
+
+// editQueueResponse is the result of calling "editqueue".
+type editQueueResponse struct {
+	Result bool `json:"result"`
+}
+
+// Group represents an active download in NZBGet's queue (listgroups).
+type Group struct {
+	NZBID         int    `json:"NZBID"`
+	NZBName       string `json:"NZBName"`
+	Status        string `json:"Status"`
+	Category      string `json:"Category"`
+	FileSizeMB    float64 `json:"FileSizeMB"`
+	RemainingSizeMB float64 `json:"RemainingSizeMB"`
+	DownloadedSizeMB float64 `json:"DownloadedSizeMB"`
+	ActiveDownloads int    `json:"ActiveDownloads"`
+	URL           string `json:"URL"`
+}
+
+// listGroupsResponse is the result of calling "listgroups".
+type listGroupsResponse struct {
+	Result []Group `json:"result"`
+}
+
+// HistoryItem represents a completed/failed download in NZBGet's history.
+type HistoryItem struct {
+	NZBID        int    `json:"NZBID"`
+	NZBName      string `json:"NZBName"`
+	Status       string `json:"Status"`
+	Category     string `json:"Category"`
+	FileSizeMB   float64 `json:"FileSizeMB"`
+	DestDir      string `json:"DestDir"`
+	URL          string `json:"URL"`
+}
+
+// historyResponse is the result of calling "history".
+type historyResponse struct {
+	Result []HistoryItem `json:"result"`
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -11,11 +11,13 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/vavallee/bindery/internal/calibre"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/downloader/nzbget"
 	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
 	"github.com/vavallee/bindery/internal/downloader/transmission"
@@ -169,6 +171,8 @@ func (s *Scanner) CheckDownloads(ctx context.Context) {
 		s.checkTransmissionDownloads(ctx, client)
 	case "qbittorrent":
 		s.checkQbittorrentDownloads(ctx, client)
+	case "nzbget":
+		s.checkNZBGetDownloads(ctx, client)
 	default:
 		s.checkSABnzbdDownloads(ctx, client)
 	}
@@ -256,6 +260,54 @@ func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.Down
 			}
 		}
 	}
+}
+
+// checkNZBGetDownloads polls NZBGet for status changes using its JSON-RPC API.
+func (s *Scanner) checkNZBGetDownloads(ctx context.Context, client *models.DownloadClient) {
+	ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+
+	// Check history for completed/failed downloads (matched by NZBID stored as sabnzbd_nzo_id).
+	history, err := ng.GetHistory(ctx)
+	if err != nil {
+		slog.Debug("failed to fetch NZBGet history", "error", err)
+		return
+	}
+
+	for _, item := range history {
+		nzbIDStr := strconv.Itoa(item.NZBID)
+		dl, err := s.downloads.GetByNzoID(ctx, nzbIDStr)
+		if err != nil || dl == nil {
+			continue
+		}
+
+		if nzbget.IsSuccess(item.Status) {
+			if dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed {
+				localPath := s.remapper.Apply(item.DestDir)
+				if localPath != item.DestDir {
+					slog.Debug("remapped download path", "nzbget", item.DestDir, "local", localPath)
+				}
+				slog.Info("download completed", "title", dl.Title, "path", localPath)
+				s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
+				s.tryImportNZBGet(ctx, ng, dl, item.NZBID, localPath)
+			}
+		} else if nzbget.IsFailure(item.Status) {
+			if dl.Status != models.StateFailed {
+				msg := fmt.Sprintf("NZBGet reported status: %s", item.Status)
+				slog.Warn("download failed", "title", dl.Title, "status", item.Status)
+				s.setDownloadError(ctx, dl.ID, msg)
+				s.createHistoryEvent(ctx, models.HistoryEventDownloadFailed, dl.Title, dl.BookID, map[string]string{"guid": dl.GUID, "message": msg})
+			}
+		}
+	}
+}
+
+// tryImportNZBGet attempts to import a completed NZBGet download into the library.
+// ng is used to clean up the NZBGet history entry once bindery has taken ownership.
+func (s *Scanner) tryImportNZBGet(ctx context.Context, ng *nzbget.Client, dl *models.Download, nzbID int, downloadPath string) {
+	nzbIDStr := strconv.Itoa(nzbID)
+	s.tryImportInternal(ctx, dl, downloadPath, "nzbget", nzbIDStr, func() error {
+		return ng.RemoveHistory(ctx, nzbID)
+	})
 }
 
 // checkTransmissionDownloads polls Transmission for status changes.

--- a/internal/models/series.go
+++ b/internal/models/series.go
@@ -7,6 +7,7 @@ type Series struct {
 	ForeignID   string    `json:"foreignSeriesId"`
 	Title       string    `json:"title"`
 	Description string    `json:"description"`
+	Monitored   bool      `json:"monitored"`
 	CreatedAt   time.Time `json:"createdAt"`
 
 	// Joined data

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -200,6 +200,8 @@ export const api = {
   // Series
   listSeries: () => request<Series[]>('/series'),
   getSeries: (id: number) => request<Series>(`/series/${id}`),
+  monitorSeries: (id: number, monitored: boolean) => request<{ monitored: boolean }>(`/series/${id}`, { method: 'PATCH', body: JSON.stringify({ monitored }) }),
+  fillSeries: (id: number) => request<{ queued: number }>(`/series/${id}/fill`, { method: 'POST' }),
 
   // Tags
   listTags: () => request<Tag[]>('/tag'),
@@ -521,6 +523,7 @@ export interface Series {
   foreignSeriesId: string
   title: string
   description: string
+  monitored: boolean
   books?: Array<{
     seriesId: number
     bookId: number

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -5,6 +5,8 @@ export default function SeriesPage() {
   const [seriesList, setSeriesList] = useState<Series[]>([])
   const [loading, setLoading] = useState(true)
   const [expanded, setExpanded] = useState<number | null>(null)
+  const [filling, setFilling] = useState<number | null>(null)
+  const [fillResult, setFillResult] = useState<Record<number, string>>({})
 
   useEffect(() => {
     api.listSeries().then(setSeriesList).catch(console.error).finally(() => setLoading(false))
@@ -17,6 +19,24 @@ export default function SeriesPage() {
 
   const toggleExpanded = (id: number) => {
     setExpanded(prev => (prev === id ? null : id))
+  }
+
+  const toggleMonitor = async (series: Series) => {
+    const next = !series.monitored
+    await api.monitorSeries(series.id, next)
+    setSeriesList(prev => prev.map(s => s.id === series.id ? { ...s, monitored: next } : s))
+  }
+
+  const fillGaps = async (series: Series) => {
+    setFilling(series.id)
+    try {
+      const r = await api.fillSeries(series.id)
+      setFillResult(prev => ({ ...prev, [series.id]: r.queued === 0 ? 'Nothing to fill' : `${r.queued} book${r.queued === 1 ? '' : 's'} queued` }))
+    } catch {
+      setFillResult(prev => ({ ...prev, [series.id]: 'Failed' }))
+    } finally {
+      setFilling(null)
+    }
   }
 
   return (
@@ -36,15 +56,15 @@ export default function SeriesPage() {
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {seriesList.map(series => {
-            const bookCount = series.books?.length ?? 0
+            const books = series.books ?? []
+            const bookCount = books.length
+            const gapCount = books.filter(b => b.book && b.book.status !== 'imported').length
             const isOpen = expanded === series.id
-            const sortedBooks = series.books
-              ? [...series.books].sort((a, b) => {
-                  const posA = parseFloat(a.positionInSeries) || 0
-                  const posB = parseFloat(b.positionInSeries) || 0
-                  return posA - posB
-                })
-              : []
+            const sortedBooks = [...books].sort((a, b) => {
+              const posA = parseFloat(a.positionInSeries) || 0
+              const posB = parseFloat(b.positionInSeries) || 0
+              return posA - posB
+            })
 
             return (
               <div key={series.id} className="border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden">
@@ -60,12 +80,43 @@ export default function SeriesPage() {
                       )}
                     </div>
                     <div className="flex-shrink-0 flex items-center gap-2">
+                      {gapCount > 0 && (
+                        <span className="text-xs text-amber-600 dark:text-amber-400 bg-amber-500/10 px-2 py-0.5 rounded-full">
+                          {gapCount} missing
+                        </span>
+                      )}
                       <span className="text-xs text-slate-600 dark:text-zinc-500 bg-slate-200 dark:bg-zinc-800 px-2 py-0.5 rounded-full">
                         {bookCount} {bookCount === 1 ? 'book' : 'books'}
                       </span>
                       <span className="text-slate-500 dark:text-zinc-600 text-xs">{isOpen ? '▲' : '▼'}</span>
                     </div>
                   </div>
+                </div>
+
+                {/* Actions row */}
+                <div className="px-4 pb-3 flex items-center gap-3" onClick={e => e.stopPropagation()}>
+                  <button
+                    onClick={() => toggleMonitor(series)}
+                    className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${series.monitored ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
+                    title={series.monitored ? 'Stop monitoring' : 'Monitor series'}
+                  >
+                    <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${series.monitored ? 'translate-x-4' : ''}`} />
+                  </button>
+                  <span className="text-xs text-slate-600 dark:text-zinc-400">
+                    {series.monitored ? 'Monitored' : 'Not monitored'}
+                  </span>
+                  {gapCount > 0 && (
+                    <button
+                      onClick={() => fillGaps(series)}
+                      disabled={filling === series.id}
+                      className="ml-auto text-xs px-2.5 py-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded font-medium"
+                    >
+                      {filling === series.id ? 'Queuing…' : 'Fill gaps'}
+                    </button>
+                  )}
+                  {fillResult[series.id] && (
+                    <span className="ml-auto text-xs text-emerald-600 dark:text-emerald-400">{fillResult[series.id]}</span>
+                  )}
                 </div>
 
                 {isOpen && bookCount > 0 && (

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1993,7 +1993,7 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
   const [type, setType] = useState(client.type || 'sabnzbd')
   const [host, setHost] = useState(client.host)
   const [port, setPort] = useState(String(client.port))
-  const [credential, setCredential] = useState(client.type === 'qbittorrent' || client.type === 'transmission' ? (client.password || '') : (client.apiKey || ''))
+  const [credential, setCredential] = useState(client.type === 'qbittorrent' || client.type === 'transmission' || client.type === 'nzbget' ? (client.password || '') : (client.apiKey || ''))
   const [username, setUsername] = useState(client.username || '')
   const [category, setCategory] = useState(client.category)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
@@ -2005,7 +2005,7 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
   }
 
   const submit = async () => {
-    const data = type === 'qbittorrent' || type === 'transmission'
+    const data = type === 'qbittorrent' || type === 'transmission' || type === 'nzbget'
       ? { ...client, name, type, host, port: parseInt(port), username, password: credential, apiKey: '', category }
       : { ...client, name, type, host, port: parseInt(port), apiKey: credential, username: '', password: '', category }
     const updated = await api.updateDownloadClient(client.id, data)
@@ -2023,6 +2023,7 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
           <label className={labelCls}>Client Type</label>
           <select value={type} onChange={e => handleTypeChange(e.target.value)} className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
             <option value="sabnzbd">SABnzbd</option>
+            <option value="nzbget">NZBGet</option>
             <option value="qbittorrent">qBittorrent</option>
             <option value="transmission">Transmission</option>
           </select>
@@ -2034,17 +2035,17 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
           <input value={host} onChange={e => setHost(e.target.value)} placeholder="Host" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
           <input value={port} onChange={e => setPort(e.target.value)} placeholder="Port" className="w-24 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
         </div>
-        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">In Docker, use the service/container name (e.g. <code className="font-mono">sabnzbd</code>) — not <code className="font-mono">localhost</code>.</p>
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">In Docker, use the service/container name (e.g. <code className="font-mono">nzbget</code>) — not <code className="font-mono">localhost</code>.</p>
       </div>
-      {(type === 'qbittorrent' || type === 'transmission') && (
+      {(type === 'qbittorrent' || type === 'transmission' || type === 'nzbget') && (
         <div>
           <label className={labelCls}>Username</label>
           <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />
         </div>
       )}
       <div>
-        <label className={labelCls}>{type === 'qbittorrent' || type === 'transmission' ? 'Password' : 'API Key'}</label>
-        <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' || type === 'transmission' ? 'Password' : 'API Key'} type="password" className={inputCls} />
+        <label className={labelCls}>{type === 'qbittorrent' || type === 'transmission' || type === 'nzbget' ? 'Password' : 'API Key'}</label>
+        <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' || type === 'transmission' || type === 'nzbget' ? 'Password' : 'API Key'} type="password" className={inputCls} />
       </div>
       <div>
         <label className={labelCls}>{type === 'transmission' ? 'Download Directory' : 'Category'}</label>
@@ -2162,7 +2163,7 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
 
 function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c: DownloadClient) => void }) {
   const [name, setName] = useState('SABnzbd')
-  const [type, setType] = useState<'sabnzbd' | 'qbittorrent' | 'transmission'>('sabnzbd')
+  const [type, setType] = useState<'sabnzbd' | 'nzbget' | 'qbittorrent' | 'transmission'>('sabnzbd')
   const [host, setHost] = useState('')
   const [port, setPort] = useState('8080')
   const [credential, setCredential] = useState('')
@@ -2170,10 +2171,15 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
   const [category, setCategory] = useState('books')
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
-  const handleTypeChange = (newType: 'sabnzbd' | 'qbittorrent' | 'transmission') => {
+  const handleTypeChange = (newType: 'sabnzbd' | 'nzbget' | 'qbittorrent' | 'transmission') => {
     setType(newType)
     setCredential('')
     setUsername('')
+    if (newType === 'nzbget') {
+      setName('NZBGet')
+      setPort('6789')
+      return
+    }
     if (newType === 'qbittorrent') {
       setName('qBittorrent')
       setPort('8080')
@@ -2189,7 +2195,7 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
   }
 
   const submit = async () => {
-    const data = type === 'qbittorrent' || type === 'transmission'
+    const data = type === 'qbittorrent' || type === 'transmission' || type === 'nzbget'
       ? { name, host, port: parseInt(port), username, password: credential, apiKey: '', category, type, enabled: true }
       : { name, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, type, enabled: true }
     const c = await api.addDownloadClient(data)
@@ -2205,8 +2211,9 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
         </div>
         <div className="w-40">
           <label className={labelCls}>Client Type</label>
-          <select value={type} onChange={e => handleTypeChange(e.target.value as 'sabnzbd' | 'qbittorrent' | 'transmission')} className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
+          <select value={type} onChange={e => handleTypeChange(e.target.value as 'sabnzbd' | 'nzbget' | 'qbittorrent' | 'transmission')} className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
             <option value="sabnzbd">SABnzbd</option>
+            <option value="nzbget">NZBGet</option>
             <option value="qbittorrent">qBittorrent</option>
             <option value="transmission">Transmission</option>
           </select>
@@ -2218,17 +2225,17 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
           <input value={host} onChange={e => setHost(e.target.value)} placeholder="Host" className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
           <input value={port} onChange={e => setPort(e.target.value)} placeholder="Port" className="w-24 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600" />
         </div>
-        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">In Docker, use the service/container name (e.g. <code className="font-mono">sabnzbd</code>) — not <code className="font-mono">localhost</code>.</p>
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">In Docker, use the service/container name (e.g. <code className="font-mono">nzbget</code>) — not <code className="font-mono">localhost</code>.</p>
       </div>
-      {(type === 'qbittorrent' || type === 'transmission') && (
+      {(type === 'qbittorrent' || type === 'transmission' || type === 'nzbget') && (
         <div>
           <label className={labelCls}>Username</label>
           <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />
         </div>
       )}
       <div>
-        <label className={labelCls}>{type === 'qbittorrent' || type === 'transmission' ? 'Password' : 'API Key'}</label>
-        <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' || type === 'transmission' ? 'Password' : 'API Key'} type="password" className={inputCls} />
+        <label className={labelCls}>{type === 'qbittorrent' || type === 'transmission' || type === 'nzbget' ? 'Password' : 'API Key'}</label>
+        <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' || type === 'transmission' || type === 'nzbget' ? 'Password' : 'API Key'} type="password" className={inputCls} />
       </div>
       <div>
         <label className={labelCls}>{type === 'transmission' ? 'Download Directory' : 'Category'}</label>


### PR DESCRIPTION
Closes #224 (partial — addresses the gap-filling UX).

Two additions to the Series page:

**Monitor toggle** — per-series flag (persisted in DB). Sets the stage for future automation (e.g. auto-add new entries when an author sync finds a new book in a monitored series).

**Fill gaps button** — appears when a series has non-imported books. Marks them all wanted and kicks off indexer searches immediately. Gap count badge ("N missing") is visible on collapsed cards so users can spot holes without expanding.

Backend: `PATCH /series/{id}` for monitoring, `POST /series/{id}/fill` for gap fill.