### PR TITLE
feat(web): persist auto-grab checkbox in Add Author dialog

### DIFF
--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -7,6 +7,18 @@ interface Props {
   onAdded: () => void
 }
 
+const AUTO_GRAB_STORAGE_KEY = 'addAuthor.autoGrab'
+
+function loadAutoGrabDefault(): boolean {
+  try {
+    const stored = localStorage.getItem(AUTO_GRAB_STORAGE_KEY)
+    if (stored === null) return true
+    return stored === 'true'
+  } catch {
+    return true
+  }
+}
+
 export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const { t } = useTranslation()
   const [query, setQuery] = useState('')
@@ -18,7 +30,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const [profileId, setProfileId] = useState<number | null>(null)
   const [rootFolders, setRootFolders] = useState<RootFolder[]>([])
   const [rootFolderId, setRootFolderId] = useState<number | null>(null)
-  const [searchOnAdd, setSearchOnAdd] = useState(true)
+  const [searchOnAdd, setSearchOnAdd] = useState(loadAutoGrabDefault)
 
   useEffect(() => {
     api.listMetadataProfiles().then(ps => {
@@ -60,6 +72,11 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
         metadataProfileId: profileId,
         rootFolderId: rootFolderId,
       })
+      try {
+        localStorage.setItem(AUTO_GRAB_STORAGE_KEY, String(searchOnAdd))
+      } catch {
+        // ignore storage failures (private mode, quota, etc.)
+      }
       onAdded()
       onClose()
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- Persist the Add Author dialog's auto-grab checkbox to `localStorage` under key `addAuthor.autoGrab`.
- Stored value is written only on successful submit; closing the dialog without submitting leaves the stored value unchanged.
- First-time users (no stored value) see the checkbox checked by default.

Closes #222

## Test plan
- [x] Existing `AddAuthorModal` tests still pass
- [ ] Manual: check box, submit, reopen dialog — still checked
- [ ] Manual: uncheck, submit, reopen — still unchecked
- [ ] Manual: toggle, close without submit — reopen shows prior stored value
- [ ] Manual: clear localStorage — reopen shows checkbox checked