### PR TITLE
feat(importer): surface import failure reason in Queue/History UI

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -822,6 +822,19 @@ func TestDownloadRepoCRUD(t *testing.T) {
 		t.Errorf("SetError: %v", err)
 	}
 
+	// SetErrorWithStatus — transitions from StateFailed must reject (no valid
+	// transitions from StateFailed) but setting to the same state should succeed.
+	if err := repo.SetErrorWithStatus(ctx, dl.ID, models.StateFailed, "still broken"); err != nil {
+		t.Errorf("SetErrorWithStatus same-state: %v", err)
+	}
+	got, getErr := repo.GetByGUID(ctx, dl.GUID)
+	if getErr != nil || got == nil {
+		t.Fatalf("reload after SetErrorWithStatus: %v", getErr)
+	}
+	if got.ErrorMessage != "still broken" {
+		t.Errorf("expected error message persisted, got %q", got.ErrorMessage)
+	}
+
 	// Delete
 	if err := repo.Delete(ctx, dl.ID); err != nil {
 		t.Fatalf("delete: %v", err)

--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -118,6 +118,23 @@ func (r *DownloadRepo) SetError(ctx context.Context, id int64, errMsg string) er
 	return err
 }
 
+// SetErrorWithStatus transitions the download to the given failure state and
+// persists the error message. Use this for import failures (StateImportFailed,
+// StateImportBlocked) so the user can see why an import didn't complete.
+func (r *DownloadRepo) SetErrorWithStatus(ctx context.Context, id int64, status models.DownloadState, errMsg string) error {
+	var current models.DownloadState
+	if err := r.db.QueryRowContext(ctx, "SELECT status FROM downloads WHERE id=?", id).Scan(&current); err != nil {
+		return fmt.Errorf("lookup current state: %w", err)
+	}
+	if current != status && !current.CanTransitionTo(status) {
+		return models.ErrInvalidTransition{From: current, To: status}
+	}
+	_, err := r.db.ExecContext(ctx,
+		"UPDATE downloads SET status=?, error_message=? WHERE id=?",
+		status, errMsg, id)
+	return err
+}
+
 func (r *DownloadRepo) Delete(ctx context.Context, id int64) error {
 	_, err := r.db.ExecContext(ctx, "DELETE FROM downloads WHERE id=?", id)
 	return err

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -200,6 +200,20 @@ func (s *Scanner) updateDownloadStatus(ctx context.Context, id int64, status mod
 	}
 }
 
+// failImport records an import failure with a user-facing reason. It persists
+// the status + message and emits an importFailed history event so the cause
+// is visible in the Queue/History UI.
+func (s *Scanner) failImport(ctx context.Context, dl *models.Download, status models.DownloadState, reason string) {
+	if err := s.downloads.SetErrorWithStatus(ctx, dl.ID, status, reason); err != nil {
+		slog.Warn("failed to persist import error", "download_id", dl.ID, "status", status, "error", err)
+	}
+	s.createHistoryEvent(ctx, models.HistoryEventImportFailed, dl.Title, dl.BookID, map[string]string{
+		"guid":    dl.GUID,
+		"message": reason,
+		"status":  string(status),
+	})
+}
+
 func (s *Scanner) createHistoryEvent(ctx context.Context, eventType string, sourceTitle string, bookID *int64, data map[string]string) {
 	if s.history == nil {
 		return
@@ -440,7 +454,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	if s.libraryDir == "" {
 		slog.Warn("no library directory configured, skipping import")
 		// Not writable/configured — needs user action before import can proceed.
-		s.updateDownloadStatus(ctx, dl.ID, models.StateImportBlocked)
+		s.failImport(ctx, dl, models.StateImportBlocked, "no library directory configured — set one in Settings")
 		return
 	}
 
@@ -463,7 +477,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	if len(bookFiles) == 0 {
 		slog.Warn("no book files found in download", "path", downloadPath)
 		// No files — retryable if the downloader hasn't flushed them yet.
-		s.updateDownloadStatus(ctx, dl.ID, models.StateImportFailed)
+		s.failImport(ctx, dl, models.StateImportFailed, fmt.Sprintf("no book files found in %q", downloadPath))
 		return
 	}
 
@@ -515,7 +529,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		}
 		if dirErr != nil {
 			slog.Error("failed to import audiobook folder", "src", downloadPath, "mode", mode, "error", dirErr)
-			s.updateDownloadStatus(ctx, dl.ID, models.StateImportBlocked)
+			s.failImport(ctx, dl, models.StateImportBlocked, fmt.Sprintf("audiobook %s failed: %v", mode, dirErr))
 			return
 		}
 		if book != nil {
@@ -543,6 +557,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	}
 
 	var imported, failed int
+	var lastFileErr error
 	for _, srcFile := range bookFiles {
 		if book == nil {
 			// Try to match from filename
@@ -567,6 +582,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		if fileErr != nil {
 			slog.Error("failed to import", "src", srcFile, "mode", mode, "error", fileErr)
 			failed++
+			lastFileErr = fileErr
 			continue
 		}
 		imported++
@@ -586,7 +602,18 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// If every file failed to copy/move, the destination is likely not writable —
 	// mark as blocked so the user knows manual intervention is needed.
 	if imported == 0 && failed > 0 {
-		s.updateDownloadStatus(ctx, dl.ID, models.StateImportBlocked)
+		reason := fmt.Sprintf("all %d file(s) failed to import", failed)
+		if lastFileErr != nil {
+			reason = fmt.Sprintf("%s: %v", reason, lastFileErr)
+		}
+		s.failImport(ctx, dl, models.StateImportBlocked, reason)
+		return
+	}
+
+	// Matched nothing — no book resolved and nothing imported. Surface that
+	// so the user can manually intervene rather than seeing a silent queue.
+	if imported == 0 && failed == 0 && book == nil {
+		s.failImport(ctx, dl, models.StateImportFailed, "could not match any book to this download — check the release title")
 		return
 	}
 

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -121,7 +121,14 @@ export default function QueuePage() {
                       </div>
                     )}
                     {item.errorMessage && (
-                      <div className="mt-1 text-xs text-red-400 bg-red-400/10 rounded px-2 py-1">
+                      <div className="mt-1 text-xs text-red-400 bg-red-400/10 rounded px-2 py-1 break-words">
+                        <span className="font-medium">
+                          {item.status === 'importFailed'
+                            ? 'Import failed: '
+                            : item.status === 'importBlocked'
+                            ? 'Import blocked: '
+                            : 'Error: '}
+                        </span>
                         {item.errorMessage}
                       </div>
                     )}


### PR DESCRIPTION
## Summary

Closes #229

When a download finished in the client but the import step failed, Bindery
silently moved the row to `importFailed` / `importBlocked` without recording
*why*. The user had to read server logs to find out.

- `DownloadRepo.SetErrorWithStatus` — transitions into a failure state and
  persists the error message atomically (still honours the state machine).
- `internal/importer/scanner.go` — each import failure path (no library dir,
  no book files, audiobook move failure, all-files-failed, unmatched book)
  now calls a new `failImport` helper that:
  - persists the reason to `downloads.error_message`
  - emits an `importFailed` history event with the same reason
- `web/src/pages/QueuePage.tsx` — labels the error row with the state so the
  user sees "Import failed: ..." / "Import blocked: ..." instead of a bare
  message. The History tab already renders the reason from the event data.

No schema change: `error_message` already exists on `downloads`, and
`StateImportFailed` / `StateImportBlocked` are already part of the state
machine.

## Test plan

- [x] `go test ./internal/db/ ./internal/importer/ ./internal/api/`
- [x] `tsc --noEmit`
- [ ] Manual: configure a library dir that is read-only, grab a release, observe the Queue row shows "Import blocked: ..." and the History tab gets an `importFailed` entry.