### PR TITLE
fix: create destination directory before audiobook import (#248)

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -536,14 +536,39 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		destDir := UniqueDir(s.renamer.AudiobookDestDir(audiobookRoot, author, book))
 		mode := s.importMode(ctx)
 		slog.Info("importing audiobook folder", "src", downloadPath, "dst", destDir, "mode", mode)
+		// Single-file audiobook releases (e.g. a lone .m4b from a torrent) give
+		// us a file path rather than a folder. MoveDir/CopyDir/HardlinkDir all
+		// reject non-directory sources, so place the file inside destDir.
+		srcInfo, statErr := os.Stat(downloadPath)
+		if statErr != nil {
+			slog.Error("failed to stat audiobook source", "src", downloadPath, "error", statErr)
+			s.failImport(ctx, dl, models.StateImportBlocked, fmt.Sprintf("audiobook source unavailable: %v", statErr))
+			return
+		}
 		var dirErr error
-		switch mode {
-		case "hardlink":
-			dirErr = HardlinkDir(downloadPath, destDir)
-		case "copy":
-			dirErr = CopyDir(downloadPath, destDir)
-		default:
-			dirErr = MoveDir(downloadPath, destDir)
+		if srcInfo.IsDir() {
+			switch mode {
+			case "hardlink":
+				dirErr = HardlinkDir(downloadPath, destDir)
+			case "copy":
+				dirErr = CopyDir(downloadPath, destDir)
+			default:
+				dirErr = MoveDir(downloadPath, destDir)
+			}
+		} else {
+			if err := os.MkdirAll(destDir, 0o750); err != nil {
+				dirErr = fmt.Errorf("create audiobook dest dir: %w", err)
+			} else {
+				dstFile := filepath.Join(destDir, filepath.Base(downloadPath))
+				switch mode {
+				case "hardlink":
+					dirErr = HardlinkFile(downloadPath, dstFile)
+				case "copy":
+					dirErr = CopyFile(downloadPath, dstFile)
+				default:
+					dirErr = MoveFile(downloadPath, dstFile)
+				}
+			}
 		}
 		if dirErr != nil {
 			slog.Error("failed to import audiobook folder", "src", downloadPath, "mode", mode, "error", dirErr)


### PR DESCRIPTION
## Summary
- Single-file audiobook releases (e.g. a lone `.m4b` from a torrent) surfaced in `tryImportInternal` as a file path rather than a folder. `MoveDir`/`CopyDir`/`HardlinkDir` all reject non-directory sources, so the importer errored with `source is not a directory` and the computed destination (`.../Author/Title ()`) was never created.
- Stat the source up-front: when it is a regular file, `os.MkdirAll` the audiobook `destDir` and route through the per-file `MoveFile`/`CopyFile`/`HardlinkFile` into it. Directory sources keep the existing folder-preserving path (multi-part releases, cover art, cue sheets still land together).

## Notes on secondary wrong-book-matching report
The #248 report also mentions DCC content ending up in a Harry Potter folder. That is a release→book mapping issue (search/grab layer), not the file-copy layer — the file copy does exactly what `dl.BookID` asked for. Diagnosing which release got grabbed for which book needs a reproducer or logs that weren't in the report, so it is intentionally out of scope for this PR.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/importer/`
- [ ] Manual: grab a single-file `.m4b` audiobook; confirm the destination folder is created and the file lands inside it.
- [ ] Manual: grab a multi-part audiobook folder; confirm folder contents (m4b parts, cover, cue) still land together.

Fixes #248