### PR TITLE
fix(search): union ebook+audiobook for 'both' and normalize query titles (#249, #250)

### DIFF
--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -213,7 +213,22 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 		crit.Year = book.ReleaseDate.Year()
 	}
 
-	results := h.searcher.SearchBook(r.Context(), idxs, crit)
+	// For dual-format books (media_type='both'), run one search per format so
+	// each uses its own category tree (7xxx for ebooks, 3xxx for audiobooks).
+	// A single "both" search falls through to the ebook branch in
+	// filterCategoriesForMedia, silently dropping all audiobook results.
+	var results []newznab.SearchResult
+	if book.MediaType == models.MediaTypeBoth {
+		ebookCrit := crit
+		ebookCrit.MediaType = models.MediaTypeEbook
+		audioCrit := crit
+		audioCrit.MediaType = models.MediaTypeAudiobook
+		results = h.searcher.SearchBook(r.Context(), idxs, ebookCrit)
+		results = append(results, h.searcher.SearchBook(r.Context(), idxs, audioCrit)...)
+		results = indexer.DedupeResults(results)
+	} else {
+		results = h.searcher.SearchBook(r.Context(), idxs, crit)
+	}
 
 	// Build decision specs.
 	var specs []decision.Specification

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -131,11 +132,40 @@ func (c *Client) BookSearch(ctx context.Context, title, author string, categorie
 // primaryTitleForQuery returns the portion of a book title before a colon,
 // so "Dune: Messiah" queries as "Dune". Indexers rarely have the subtitle
 // in the release name and including it can cause all-keyword-match failures.
+//
+// The title is also normalized so two book rows that differ only in
+// incidental metadata (leading/trailing whitespace, collapsed interior
+// whitespace, smart-quote variants, parenthesised language suffixes like
+// "(German Edition)") produce identical queries. Without this, ingesting
+// the same work from multiple metadata providers yields two rows that
+// search differently — see issue #250.
 func primaryTitleForQuery(title string) string {
 	if i := strings.Index(title, ":"); i > 0 {
-		return strings.TrimSpace(title[:i])
+		title = title[:i]
 	}
-	return title
+	return NormalizeQueryTitle(title)
+}
+
+// parenSuffixRe matches a trailing parenthesised qualifier used by metadata
+// providers to distinguish editions of the same work, e.g. "(German Edition)",
+// "(Unabridged)", "(2nd ed.)". Indexers almost never carry these qualifiers
+// in the release name, so including them reliably zeros out the result set.
+var parenSuffixRe = regexp.MustCompile(`\s*\([^)]*\)\s*$`)
+
+// NormalizeQueryTitle strips incidental differences that would cause two
+// metadata-provider rows for the same work to generate different indexer
+// queries: Unicode smart quotes are folded to ASCII, whitespace is trimmed
+// and collapsed, and a single trailing parenthesised qualifier is removed.
+// Called by primaryTitleForQuery and exported so ingestion paths can use
+// the same normalization for title-based deduplication.
+func NormalizeQueryTitle(title string) string {
+	title = strings.NewReplacer(
+		"\u2018", "'", "\u2019", "'",
+		"\u201C", `"`, "\u201D", `"`,
+		"\u2013", "-", "\u2014", "-",
+	).Replace(title)
+	title = parenSuffixRe.ReplaceAllString(title, "")
+	return strings.Join(strings.Fields(title), " ")
 }
 
 func authorSurname(author string) string {

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -563,3 +563,36 @@ func TestBuildURL_StripsStaleQueryParams(t *testing.T) {
 		t.Errorf("expected apikey=key in built URL, got %s", u)
 	}
 }
+
+func TestNormalizeQueryTitle(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"Die Stille ist ein Geräusch", "Die Stille ist ein Geräusch"},
+		{"  Die Stille  ist   ein Geräusch  ", "Die Stille ist ein Geräusch"},
+		{"Die Stille ist ein Geräusch (German Edition)", "Die Stille ist ein Geräusch"},
+		{"Dicke Freundinnen (Unabridged)", "Dicke Freundinnen"},
+		{"Ender\u2019s Game", "Ender's Game"},
+		{"Title \u2014 Subtitle", "Title - Subtitle"},
+	}
+	for _, c := range cases {
+		if got := NormalizeQueryTitle(c.in); got != c.want {
+			t.Errorf("NormalizeQueryTitle(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPrimaryTitleForQuery_NormalizesAndDropsSubtitle(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"Dune: Messiah", "Dune"},
+		{"  Dune  ", "Dune"},
+		{"Die Stille ist ein Geräusch (ger)", "Die Stille ist ein Geräusch"},
+	}
+	for _, c := range cases {
+		if got := primaryTitleForQuery(c.in); got != c.want {
+			t.Errorf("primaryTitleForQuery(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -293,6 +293,13 @@ func sameKws(a, b []string) bool {
 	return true
 }
 
+// DedupeResults removes duplicate search results (by GUID, falling back to
+// title+URL when the GUID is empty). Callers fanning out multiple SearchBook
+// calls (e.g. dual-format books) use this to merge the per-format result sets.
+func DedupeResults(results []newznab.SearchResult) []newznab.SearchResult {
+	return dedupe(results)
+}
+
 func dedupe(results []newznab.SearchResult) []newznab.SearchResult {
 	seen := make(map[string]bool)
 	deduped := make([]newznab.SearchResult, 0, len(results))


### PR DESCRIPTION
## Summary

- **#249** — For books with `media_type='both'`, the indexer search previously returned 0 results because `filterCategoriesForMedia` only recognizes `"ebook"` or `"audiobook"`; the `"both"` value fell through to the ebook branch and audiobook categories were silently dropped. The API `SearchBook` handler now fans out into two `Searcher.SearchBook` calls (one per format) and unions the results, deduped by GUID via the newly-exported `indexer.DedupeResults`.
- **#250** — Two book rows for the same title returned different indexer results because the search query was built directly from `book.Title`, so cosmetic differences (trailing parenthesised qualifiers like `(German Edition)`, smart quotes, collapsed whitespace) across metadata providers produced different queries. `primaryTitleForQuery` now runs the title through a new `NormalizeQueryTitle` helper that folds smart quotes, collapses whitespace, and strips a single trailing parenthesised qualifier. Two rows for the same work now issue identical queries.

## Root causes

1. `filterCategoriesForMedia` in `internal/indexer/searcher.go` branches only on `mediaType == "audiobook"`, so anything else — including `"both"` — gets book-tree categories. The scheduler already fans out per format in `SearchAndGrabBook`; the manual-search HTTP path did not.
2. Query construction in `internal/indexer/newznab/client.go` took `book.Title` verbatim (modulo the colon split for subtitles). Ingestion from different metadata providers for the same work can leave whitespace / parenthesised-qualifier differences in the stored title.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/indexer/...` — includes two new tests for `NormalizeQueryTitle` and `primaryTitleForQuery`.
- [ ] Manual: add a dual-format book and click Search — confirm the result list contains both ebook and audiobook releases.
- [ ] Manual: ingest the same book from two providers (or contrive two rows with differing titles like `"Foo"` and `"Foo (German Edition)"`) and confirm they now issue identical indexer queries.

Fixes #249, fixes #250.