### PR TITLE
feat: Push all to Calibre sync button (#253)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -286,6 +286,12 @@ func main() {
 	calibreImportHandler := api.NewCalibreImportHandler(calibreImporter, func() calibre.Config {
 		return api.LoadCalibreConfig(settingsRepo)
 	})
+	calibreSyncer := calibre.NewSyncer(bookRepo)
+	calibreSyncHandler := api.NewCalibreSyncHandler(
+		calibreSyncer,
+		func() calibre.Config { return api.LoadCalibreConfig(settingsRepo) },
+		func() calibre.Mode { return api.LoadCalibreMode(settingsRepo) },
+	)
 	recHandler := api.NewRecommendationHandler(recRepo, recEngine, authorRepo, bookRepo, sched)
 	imageProxyHandler := api.NewImageProxyHandler(cfg.DataDir)
 	imageProxyHandler.StartEviction(24 * time.Hour)
@@ -519,6 +525,12 @@ func main() {
 		// the UI polls Status while it runs.
 		r.Post("/calibre/import", calibreImportHandler.Start)
 		r.Get("/calibre/import/status", calibreImportHandler.Status)
+
+		// Calibre bulk push (write side). Iterates every imported book and
+		// POSTs its file to the plugin; 409 Conflict is treated as
+		// idempotent. Single-job policy — second call returns 409.
+		r.Post("/calibre/sync", calibreSyncHandler.Start)
+		r.Get("/calibre/sync/status", calibreSyncHandler.Status)
 
 		// Migration imports (CSV of author names, or Readarr SQLite DB).
 		r.Post("/migrate/csv", migrateHandler.ImportCSV)

--- a/internal/api/calibre_sync.go
+++ b/internal/api/calibre_sync.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/vavallee/bindery/internal/calibre"
+)
+
+// CalibreSyncHandler exposes POST /calibre/sync (start a bulk push of
+// every imported book into Calibre) and GET /calibre/sync/status (poll
+// the job's progress). Routes sit behind the normal auth middleware.
+type CalibreSyncHandler struct {
+	syncer   syncerAPI
+	loadCfg  func() calibre.Config
+	loadMode func() calibre.Mode
+}
+
+// syncerAPI is the subset of *calibre.Syncer the API touches so tests can
+// swap in a stub without wiring the full repo stack.
+type syncerAPI interface {
+	Start(ctx context.Context, cfg calibre.Config, mode calibre.Mode) error
+	Progress() calibre.SyncProgress
+}
+
+func NewCalibreSyncHandler(s syncerAPI, loadCfg func() calibre.Config, loadMode func() calibre.Mode) *CalibreSyncHandler {
+	return &CalibreSyncHandler{syncer: s, loadCfg: loadCfg, loadMode: loadMode}
+}
+
+// Start is POST /api/v1/calibre/sync. Validates that plugin mode is
+// selected and the plugin URL is set, then kicks off the bulk-push
+// goroutine. 202 Accepted with the initial progress snapshot so the UI
+// can go straight into polling.
+//
+// context.WithoutCancel is critical: the syncer walks every imported
+// book and issues one HTTP call per book — cancelling on response-send
+// would routinely leave the job half-finished.
+func (h *CalibreSyncHandler) Start(w http.ResponseWriter, r *http.Request) {
+	mode := h.loadMode()
+	if mode != calibre.ModePlugin {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "calibre mode is not 'plugin' — bulk sync only targets the Bindery Bridge plugin"})
+		return
+	}
+	cfg := h.loadCfg()
+	if cfg.PluginURL == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "calibre plugin_url is empty"})
+		return
+	}
+
+	err := h.syncer.Start(context.WithoutCancel(r.Context()), cfg, mode)
+	switch {
+	case errors.Is(err, calibre.ErrSyncAlreadyRunning):
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	case errors.Is(err, calibre.ErrSyncModeNotPlugin):
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	case err != nil:
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusAccepted, h.syncer.Progress())
+}
+
+// Status is GET /api/v1/calibre/sync/status. Cheap, stateless poll.
+func (h *CalibreSyncHandler) Status(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, h.syncer.Progress())
+}

--- a/internal/calibre/plugin_client.go
+++ b/internal/calibre/plugin_client.go
@@ -4,11 +4,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 )
+
+// ErrAlreadyInCalibre is returned by PluginClient.Add when the plugin
+// reports the book is already present (HTTP 409 Conflict). Callers that
+// treat duplicate pushes as idempotent — e.g. the "Push all to Calibre"
+// bulk sync — can errors.Is-check this sentinel instead of parsing the
+// response body.
+var ErrAlreadyInCalibre = errors.New("plugin client: book already in Calibre library")
 
 // PluginClient calls the Bindery Bridge Calibre plugin's HTTP API
 // (protocol /v1/, see bindery-plugins/docs/protocol.md). It implements the
@@ -71,8 +79,15 @@ func (c *PluginClient) addWithRetry(ctx context.Context, filePath string, retrie
 		Duplicate bool   `json:"duplicate"`
 		Error     string `json:"error"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil && resp.StatusCode < 400 {
 		return 0, fmt.Errorf("plugin client: decode response: %w", err)
+	}
+	if resp.StatusCode == http.StatusConflict {
+		// 409 → book is already in the Calibre library. Surface the
+		// existing id (when the plugin includes it) so the caller can
+		// persist the linkage, but wrap ErrAlreadyInCalibre so idempotent
+		// callers can distinguish this from a real failure.
+		return result.ID, ErrAlreadyInCalibre
 	}
 	if resp.StatusCode >= 400 {
 		return 0, fmt.Errorf("plugin client: server error %d: %s", resp.StatusCode, result.Error)

--- a/internal/calibre/syncer.go
+++ b/internal/calibre/syncer.go
@@ -1,0 +1,250 @@
+package calibre
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// SyncError is a per-book failure entry returned to the UI.
+type SyncError struct {
+	BookID int64  `json:"bookId"`
+	Title  string `json:"title"`
+	Path   string `json:"path,omitempty"`
+	Reason string `json:"reason"`
+}
+
+// SyncStats summarises one bulk-push run. Totals are cumulative across
+// every imported book with a file path; `Pushed` counts newly-added,
+// `AlreadyInCalibre` counts 409 Conflict responses (treated as success
+// for idempotency), and `Failed` counts everything else.
+type SyncStats struct {
+	Total            int `json:"total"`
+	Processed        int `json:"processed"`
+	Pushed           int `json:"pushed"`
+	AlreadyInCalibre int `json:"alreadyInCalibre"`
+	Failed           int `json:"failed"`
+}
+
+// SyncProgress is the polled shape for /calibre/sync/status. Running=false
+// with a non-nil FinishedAt means the last run is complete; Running=false
+// with StartedAt zero means nothing has been run yet this process.
+type SyncProgress struct {
+	Running    bool        `json:"running"`
+	StartedAt  time.Time   `json:"startedAt"`
+	FinishedAt *time.Time  `json:"finishedAt,omitempty"`
+	Message    string      `json:"message,omitempty"`
+	Error      string      `json:"error,omitempty"`
+	Stats      SyncStats   `json:"stats"`
+	Errors     []SyncError `json:"errors"`
+}
+
+// pluginPusher captures the subset of *PluginClient the syncer needs, so
+// tests can inject a fake without standing up an HTTP server.
+type pluginPusher interface {
+	Add(ctx context.Context, filePath string) (int64, error)
+}
+
+// BookLister is the subset of *db.BookRepo the syncer uses. Keeps the
+// dependency narrow for tests.
+type BookLister interface {
+	ListByStatus(ctx context.Context, status string) ([]models.Book, error)
+	SetCalibreID(ctx context.Context, id, calibreID int64) error
+}
+
+// Syncer orchestrates the "Push all to Calibre" bulk job. One sync runs
+// at a time — a second call returns ErrSyncAlreadyRunning. Progress is
+// mutex-protected and can be polled concurrently with the running job.
+type Syncer struct {
+	books    BookLister
+	newClient func(cfg Config) pluginPusher
+
+	mu       sync.Mutex
+	running  bool
+	progress SyncProgress
+}
+
+// NewSyncer wires a syncer against the books repo. The plugin client is
+// built per-run from the current settings so mode/URL changes take effect
+// without restarting Bindery.
+func NewSyncer(books BookLister) *Syncer {
+	return &Syncer{
+		books: books,
+		newClient: func(cfg Config) pluginPusher {
+			return NewPluginClient(cfg.PluginURL, cfg.PluginAPIKey)
+		},
+	}
+}
+
+// ErrSyncAlreadyRunning is returned when Start is called while a previous
+// sync is still executing. Maps to 409 Conflict at the API layer.
+var ErrSyncAlreadyRunning = errors.New("calibre sync already running")
+
+// ErrSyncModeNotPlugin is returned when Start is called while the Calibre
+// integration is not in plugin mode — bulk push only makes sense against
+// the plugin, not the calibredb CLI (which already lives next to the
+// library file on the Bindery host).
+var ErrSyncModeNotPlugin = errors.New("calibre sync requires mode=plugin")
+
+// Running reports whether a sync is currently in flight.
+func (s *Syncer) Running() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.running
+}
+
+// Progress returns a snapshot of the current (or most recent) sync.
+func (s *Syncer) Progress() SyncProgress {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Defensive copy of the slice so a later append by the worker does
+	// not mutate a snapshot already handed to the HTTP layer.
+	snap := s.progress
+	if len(s.progress.Errors) > 0 {
+		snap.Errors = append([]SyncError(nil), s.progress.Errors...)
+	}
+	return snap
+}
+
+// Start launches a sync in the background. Caller passes
+// context.WithoutCancel(r.Context()) so the HTTP response-send doesn't
+// cancel the long-running job.
+func (s *Syncer) Start(ctx context.Context, cfg Config, mode Mode) error {
+	if mode != ModePlugin {
+		return ErrSyncModeNotPlugin
+	}
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return ErrSyncAlreadyRunning
+	}
+	s.running = true
+	s.progress = SyncProgress{
+		Running:   true,
+		StartedAt: time.Now().UTC(),
+		Message:   "listing imported books…",
+		Errors:    []SyncError{},
+	}
+	s.mu.Unlock()
+
+	go s.run(ctx, cfg)
+	return nil
+}
+
+func (s *Syncer) run(ctx context.Context, cfg Config) {
+	defer func() {
+		now := time.Now().UTC()
+		s.mu.Lock()
+		s.progress.Running = false
+		s.progress.FinishedAt = &now
+		s.running = false
+		s.mu.Unlock()
+	}()
+
+	books, err := s.books.ListByStatus(ctx, models.BookStatusImported)
+	if err != nil {
+		s.fail("list imported books: " + err.Error())
+		return
+	}
+
+	// Restrict to books that actually have a file on disk. A book row with
+	// status=imported but empty file_path means the importer crashed or the
+	// file was deleted out from under us — nothing to push.
+	eligible := make([]models.Book, 0, len(books))
+	for i := range books {
+		if pushPath(&books[i]) != "" {
+			eligible = append(eligible, books[i])
+		}
+	}
+
+	s.setProgress(func(p *SyncProgress) {
+		p.Stats.Total = len(eligible)
+		if len(eligible) == 0 {
+			p.Message = "no imported books with files to push"
+		} else {
+			p.Message = "pushing books to Calibre…"
+		}
+	})
+
+	client := s.newClient(cfg)
+
+	for i := range eligible {
+		if err := ctx.Err(); err != nil {
+			s.fail("cancelled: " + err.Error())
+			return
+		}
+		b := &eligible[i]
+		path := pushPath(b)
+		id, addErr := client.Add(ctx, path)
+		switch {
+		case addErr == nil:
+			if id > 0 {
+				if perr := s.books.SetCalibreID(ctx, b.ID, id); perr != nil {
+					slog.Warn("calibre sync: persist calibre_id failed", "bookId", b.ID, "calibreId", id, "error", perr)
+				}
+			}
+			s.setProgress(func(p *SyncProgress) {
+				p.Stats.Pushed++
+				p.Stats.Processed++
+			})
+		case errors.Is(addErr, ErrAlreadyInCalibre):
+			if id > 0 {
+				if perr := s.books.SetCalibreID(ctx, b.ID, id); perr != nil {
+					slog.Warn("calibre sync: persist calibre_id failed", "bookId", b.ID, "calibreId", id, "error", perr)
+				}
+			}
+			s.setProgress(func(p *SyncProgress) {
+				p.Stats.AlreadyInCalibre++
+				p.Stats.Processed++
+			})
+		default:
+			s.setProgress(func(p *SyncProgress) {
+				p.Stats.Failed++
+				p.Stats.Processed++
+				p.Errors = append(p.Errors, SyncError{
+					BookID: b.ID,
+					Title:  b.Title,
+					Path:   path,
+					Reason: addErr.Error(),
+				})
+			})
+		}
+	}
+
+	s.setProgress(func(p *SyncProgress) {
+		p.Message = "done"
+	})
+	slog.Info("calibre sync complete",
+		"total", len(eligible),
+		"pushed", s.progress.Stats.Pushed,
+		"alreadyInCalibre", s.progress.Stats.AlreadyInCalibre,
+		"failed", s.progress.Stats.Failed)
+}
+
+// pushPath returns the on-disk path to send to Calibre for the given
+// book, preferring the ebook-specific column (populated by dual-format
+// imports) and falling back to the legacy single file_path.
+func pushPath(b *models.Book) string {
+	if b.EbookFilePath != "" {
+		return b.EbookFilePath
+	}
+	return b.FilePath
+}
+
+func (s *Syncer) fail(msg string) {
+	slog.Error("calibre sync failed", "error", msg)
+	s.setProgress(func(p *SyncProgress) {
+		p.Error = msg
+		p.Message = "failed"
+	})
+}
+
+func (s *Syncer) setProgress(mutate func(*SyncProgress)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	mutate(&s.progress)
+}

--- a/internal/calibre/syncer_test.go
+++ b/internal/calibre/syncer_test.go
@@ -1,0 +1,142 @@
+package calibre
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// waitUntil polls the predicate every millisecond until it returns true or
+// the deadline elapses. Used to wait for the Syncer's background goroutine
+// to reach/leave a state without busy-spinning without yielding.
+func waitUntil(t *testing.T, timeout time.Duration, pred func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pred() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", timeout)
+}
+
+// fakeBookLister is a test double for the syncer's BookLister dependency.
+// Captures SetCalibreID calls so we can assert that both fresh pushes and
+// 409-conflict responses persist the id when one is returned.
+type fakeBookLister struct {
+	books []models.Book
+	mu    sync.Mutex
+	set   map[int64]int64 // bookID → calibreID
+}
+
+func (f *fakeBookLister) ListByStatus(_ context.Context, _ string) ([]models.Book, error) {
+	return f.books, nil
+}
+
+func (f *fakeBookLister) SetCalibreID(_ context.Context, id, calibreID int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.set == nil {
+		f.set = map[int64]int64{}
+	}
+	f.set[id] = calibreID
+	return nil
+}
+
+// fakePusher is an inline pluginPusher that dispatches per-path behaviour
+// so we can verify pushed / already_in_calibre / failed all get counted
+// correctly inside one sync run.
+type fakePusher struct {
+	calls map[string]func() (int64, error)
+}
+
+func (f *fakePusher) Add(_ context.Context, path string) (int64, error) {
+	fn, ok := f.calls[path]
+	if !ok {
+		return 0, errors.New("unexpected path")
+	}
+	return fn()
+}
+
+func TestSyncer_Start_MixedOutcomesCountedCorrectly(t *testing.T) {
+	books := &fakeBookLister{
+		books: []models.Book{
+			{ID: 1, Title: "Fresh", FilePath: "/l/fresh.epub"},
+			{ID: 2, Title: "Duplicate", FilePath: "/l/dup.epub"},
+			{ID: 3, Title: "Broken", FilePath: "/l/broken.epub"},
+			{ID: 4, Title: "NoFile"}, // must be filtered out by the syncer
+		},
+	}
+	pusher := &fakePusher{calls: map[string]func() (int64, error){
+		"/l/fresh.epub":   func() (int64, error) { return 101, nil },
+		"/l/dup.epub":     func() (int64, error) { return 202, ErrAlreadyInCalibre },
+		"/l/broken.epub":  func() (int64, error) { return 0, errors.New("boom") },
+	}}
+
+	s := NewSyncer(books)
+	// Inject the fake pusher in place of the real HTTP client factory.
+	s.newClient = func(_ Config) pluginPusher { return pusher }
+
+	if err := s.Start(context.Background(), Config{}, ModePlugin); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	waitUntil(t, 2*time.Second, func() bool { return !s.Running() })
+	p := s.Progress()
+	if p.Stats.Total != 3 { // book 4 has no file path; excluded
+		t.Errorf("Total: got %d, want 3", p.Stats.Total)
+	}
+	if p.Stats.Pushed != 1 {
+		t.Errorf("Pushed: got %d, want 1", p.Stats.Pushed)
+	}
+	if p.Stats.AlreadyInCalibre != 1 {
+		t.Errorf("AlreadyInCalibre: got %d, want 1", p.Stats.AlreadyInCalibre)
+	}
+	if p.Stats.Failed != 1 {
+		t.Errorf("Failed: got %d, want 1", p.Stats.Failed)
+	}
+	if len(p.Errors) != 1 || p.Errors[0].BookID != 3 {
+		t.Errorf("Errors: got %+v, want one entry for book 3", p.Errors)
+	}
+	if books.set[1] != 101 {
+		t.Errorf("expected fresh book to persist calibre_id=101, got %d", books.set[1])
+	}
+	if books.set[2] != 202 {
+		t.Errorf("expected duplicate book to persist calibre_id=202 from 409 response, got %d", books.set[2])
+	}
+}
+
+func TestSyncer_Start_RejectsNonPluginMode(t *testing.T) {
+	s := NewSyncer(&fakeBookLister{})
+	if err := s.Start(context.Background(), Config{}, ModeCalibredb); !errors.Is(err, ErrSyncModeNotPlugin) {
+		t.Errorf("want ErrSyncModeNotPlugin, got %v", err)
+	}
+}
+
+func TestSyncer_Start_RejectsConcurrentRuns(t *testing.T) {
+	// Feed the first run one book whose push blocks, so the second Start
+	// observes running=true. Use a channel instead of a sleep to keep the
+	// test deterministic.
+	release := make(chan struct{})
+	books := &fakeBookLister{books: []models.Book{{ID: 1, Title: "A", FilePath: "/x"}}}
+	pusher := &fakePusher{calls: map[string]func() (int64, error){
+		"/x": func() (int64, error) { <-release; return 1, nil },
+	}}
+	s := NewSyncer(books)
+	s.newClient = func(_ Config) pluginPusher { return pusher }
+
+	if err := s.Start(context.Background(), Config{}, ModePlugin); err != nil {
+		t.Fatalf("first start: %v", err)
+	}
+	waitUntil(t, time.Second, s.Running)
+	if err := s.Start(context.Background(), Config{}, ModePlugin); !errors.Is(err, ErrSyncAlreadyRunning) {
+		t.Errorf("second start: want ErrSyncAlreadyRunning, got %v", err)
+	}
+	close(release)
+	waitUntil(t, 2*time.Second, func() bool { return !s.Running() })
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -149,6 +149,15 @@ func (s *Scanner) pushCalibreAdd(ctx context.Context, book *models.Book, path st
 		if errors.Is(err, calibre.ErrDisabled) {
 			return
 		}
+		if errors.Is(err, calibre.ErrAlreadyInCalibre) {
+			slog.Info("calibre: book already in library", "mode", mode, "bookId", book.ID, "path", path, "calibreId", id)
+			if id > 0 {
+				if perr := s.books.SetCalibreID(ctx, book.ID, id); perr != nil {
+					slog.Warn("calibre: persist calibre_id failed", "bookId", book.ID, "calibreId", id, "error", perr)
+				}
+			}
+			return
+		}
 		slog.Warn("calibre: add failed, continuing", "mode", mode, "bookId", book.ID, "path", path, "error", err)
 		return
 	}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -224,6 +224,8 @@ export const api = {
   calibreTestPaths: () => request<{ ok: string; message: string }>('/calibre/test-paths', { method: 'POST' }),
   calibreImportStart: () => request<CalibreImportProgress>('/calibre/import', { method: 'POST' }),
   calibreImportStatus: () => request<CalibreImportProgress>('/calibre/import/status'),
+  calibreSyncStart: () => request<CalibreSyncProgress>('/calibre/sync', { method: 'POST' }),
+  calibreSyncStatus: () => request<CalibreSyncProgress>('/calibre/sync/status'),
 
   // Import lists
   listImportLists: () => request<ImportList[]>('/importlist'),
@@ -375,6 +377,36 @@ export interface CalibreImportProgress {
   message?: string
   error?: string
   stats?: CalibreImportStats
+}
+
+// CalibreSyncError is one failed push entry returned by /calibre/sync/status.
+export interface CalibreSyncError {
+  bookId: number
+  title: string
+  path?: string
+  reason: string
+}
+
+// CalibreSyncStats summarises one bulk-push run. Pushed = newly added;
+// alreadyInCalibre = 409 Conflict (treated as success for idempotency);
+// failed = everything else.
+export interface CalibreSyncStats {
+  total: number
+  processed: number
+  pushed: number
+  alreadyInCalibre: number
+  failed: number
+}
+
+// CalibreSyncProgress is the polled shape for /calibre/sync/status.
+export interface CalibreSyncProgress {
+  running: boolean
+  startedAt?: string
+  finishedAt?: string
+  message?: string
+  error?: string
+  stats: CalibreSyncStats
+  errors: CalibreSyncError[]
 }
 
 export interface Indexer {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, AuthConfig, AuthStatus, BlocklistEntry, Indexer, IndexerTestResult, ProwlarrInstance, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, RootFolder, LogEntry, ImportList, HardcoverList } from '../api/client'
+import { api, AuthConfig, AuthStatus, BlocklistEntry, Indexer, IndexerTestResult, ProwlarrInstance, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, CalibreSyncProgress, RootFolder, LogEntry, ImportList, HardcoverList } from '../api/client'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
 import ThemeToggle from '../components/ThemeToggle'
@@ -1680,6 +1680,10 @@ function CalibreSection({
   const [saveError, setSaveError] = useState<{ key: string; msg: string } | null>(null)
   const [importProgress, setImportProgress] = useState<CalibreImportProgress | null>(null)
   const [importError, setImportError] = useState<string | null>(null)
+  const [syncProgress, setSyncProgress] = useState<CalibreSyncProgress | null>(null)
+  const [syncError, setSyncError] = useState<string | null>(null)
+  const [syncModalOpen, setSyncModalOpen] = useState(false)
+  const [bridgeReachable, setBridgeReachable] = useState<boolean | null>(null)
 
   const saveSettingWithError = async (key: string) => {
     setSaveError(null)
@@ -1706,7 +1710,31 @@ function CalibreSection({
   // the live bar instead of a dead "Import library" button.
   useEffect(() => {
     api.calibreImportStatus().then(setImportProgress).catch(() => {})
+    api.calibreSyncStatus().then(p => {
+      setSyncProgress(p)
+      // If a sync is already running when the tab mounts, surface the
+      // modal so the user can watch it finish instead of wondering what
+      // the disabled button is doing.
+      if (p.running) setSyncModalOpen(true)
+    }).catch(() => {})
   }, [])
+
+  // Silently probe plugin reachability so the "Push all to Calibre"
+  // button can enable/disable without the user having to click Test
+  // first. Re-probes whenever mode, url, or api key changes.
+  const pluginURL = settings['calibre.plugin_url'] ?? ''
+  const pluginKey = settings['calibre.plugin_api_key'] ?? ''
+  useEffect(() => {
+    if (mode !== 'plugin' || !pluginURL) {
+      setBridgeReachable(null)
+      return
+    }
+    let cancelled = false
+    api.testCalibre()
+      .then(() => { if (!cancelled) setBridgeReachable(true) })
+      .catch(() => { if (!cancelled) setBridgeReachable(false) })
+    return () => { cancelled = true }
+  }, [mode, pluginURL, pluginKey])
 
   // Poll while an import is running.
   useEffect(() => {
@@ -1717,6 +1745,15 @@ function CalibreSection({
     return () => clearInterval(id)
   }, [importProgress?.running])
 
+  // Poll while a bulk sync is running. 2s matches the task spec.
+  useEffect(() => {
+    if (!syncProgress?.running) return
+    const id = setInterval(() => {
+      api.calibreSyncStatus().then(setSyncProgress).catch(() => {})
+    }, 2000)
+    return () => clearInterval(id)
+  }, [syncProgress?.running])
+
   const startImport = async () => {
     setImportError(null)
     try {
@@ -1724,6 +1761,17 @@ function CalibreSection({
       setImportProgress(p)
     } catch (err) {
       setImportError(err instanceof Error ? err.message : 'Import failed to start')
+    }
+  }
+
+  const startSync = async () => {
+    setSyncError(null)
+    setSyncModalOpen(true)
+    try {
+      const p = await api.calibreSyncStart()
+      setSyncProgress(p)
+    } catch (err) {
+      setSyncError(err instanceof Error ? err.message : 'Push failed to start')
     }
   }
 
@@ -1902,6 +1950,32 @@ function CalibreSection({
           </div>
         )}
 
+        {/* Bulk push: Bindery → Calibre (plugin only). Pushes every imported
+            book's on-disk file to the plugin; 409 is treated as idempotent. */}
+        {mode === 'plugin' && (
+          <div className="pt-3 border-t border-slate-200 dark:border-zinc-800">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">Push all to Calibre</label>
+                <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">
+                  Send every imported book in Bindery to the Calibre Bridge plugin. Books already in Calibre are skipped (idempotent).
+                </p>
+                {bridgeReachable === false && (
+                  <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">Bridge not reachable — check plugin URL / API key above.</p>
+                )}
+              </div>
+              <button
+                onClick={startSync}
+                disabled={syncProgress?.running || bridgeReachable !== true}
+                className="px-4 py-2 bg-sky-600 hover:bg-sky-500 rounded text-sm font-medium disabled:opacity-50 flex-shrink-0"
+                title={bridgeReachable !== true ? 'Enable plugin mode and verify the bridge is reachable first' : ''}
+              >
+                {syncProgress?.running ? 'Pushing…' : 'Push all to Calibre'}
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* Library import (read side): Calibre → Bindery */}
         <div className="pt-3 border-t border-slate-200 dark:border-zinc-800 space-y-3">
           <div className="flex items-center justify-between">
@@ -2005,7 +2079,118 @@ function CalibreSection({
           )}
         </div>
       </div>
+
+      {syncModalOpen && (
+        <CalibreSyncModal
+          progress={syncProgress}
+          error={syncError}
+          onClose={() => setSyncModalOpen(false)}
+        />
+      )}
     </section>
+  )
+}
+
+// CalibreSyncModal renders the live progress of a bulk "Push all to
+// Calibre" job. Stays open while running; once finished, the user
+// dismisses it explicitly so they can read the per-book error list.
+function CalibreSyncModal({
+  progress,
+  error,
+  onClose,
+}: {
+  progress: CalibreSyncProgress | null
+  error: string | null
+  onClose: () => void
+}) {
+  const stats = progress?.stats
+  const total = stats?.total ?? 0
+  const processed = stats?.processed ?? 0
+  const pct = total > 0 ? Math.min(100, (processed / total) * 100) : 0
+  const running = !!progress?.running
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true">
+      <div className="w-full max-w-xl rounded-lg bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 shadow-xl">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200 dark:border-zinc-800">
+          <h3 className="text-base font-semibold text-slate-800 dark:text-zinc-100">Push all to Calibre</h3>
+          <button
+            onClick={onClose}
+            disabled={running}
+            className="text-slate-500 hover:text-slate-700 dark:text-zinc-400 dark:hover:text-zinc-200 disabled:opacity-40"
+            title={running ? 'Wait for the push to finish' : 'Close'}
+          >
+            ✕
+          </button>
+        </div>
+        <div className="p-4 space-y-3">
+          {error && (
+            <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+          )}
+          {progress && (
+            <>
+              <div className="flex justify-between text-xs text-slate-600 dark:text-zinc-400">
+                <span>{progress.message || (running ? 'Working…' : 'Idle')}</span>
+                <span>{processed} / {total || '?'}</span>
+              </div>
+              <div className="h-1.5 bg-slate-200 dark:bg-zinc-800 rounded overflow-hidden">
+                <div className="h-full bg-sky-600 transition-[width] duration-300" style={{ width: `${pct}%` }} />
+              </div>
+              <div className="grid grid-cols-3 gap-2 text-xs">
+                <div className="rounded border border-slate-200 dark:border-zinc-800 px-2 py-1.5">
+                  <div className="text-slate-600 dark:text-zinc-500">Pushed</div>
+                  <div className="font-semibold text-emerald-600 dark:text-emerald-400">{stats?.pushed ?? 0}</div>
+                </div>
+                <div className="rounded border border-slate-200 dark:border-zinc-800 px-2 py-1.5">
+                  <div className="text-slate-600 dark:text-zinc-500">Already in Calibre</div>
+                  <div className="font-semibold text-slate-700 dark:text-zinc-300">{stats?.alreadyInCalibre ?? 0}</div>
+                </div>
+                <div className="rounded border border-slate-200 dark:border-zinc-800 px-2 py-1.5">
+                  <div className="text-slate-600 dark:text-zinc-500">Failed</div>
+                  <div className="font-semibold text-red-600 dark:text-red-400">{stats?.failed ?? 0}</div>
+                </div>
+              </div>
+              {!running && progress.error && (
+                <p className="text-xs text-red-600 dark:text-red-400">Sync failed: {progress.error}</p>
+              )}
+              {!running && progress.finishedAt && !progress.error && (
+                <p className="text-xs text-emerald-600 dark:text-emerald-400">
+                  Done — pushed {stats?.pushed ?? 0}, already in Calibre {stats?.alreadyInCalibre ?? 0}, failed {stats?.failed ?? 0}.
+                </p>
+              )}
+              {progress.errors && progress.errors.length > 0 && (
+                <div className="mt-2 max-h-48 overflow-y-auto rounded border border-slate-200 dark:border-zinc-800">
+                  <table className="w-full text-xs">
+                    <thead className="bg-slate-100 dark:bg-zinc-800 sticky top-0">
+                      <tr>
+                        <th className="text-left px-2 py-1 text-slate-600 dark:text-zinc-400 font-medium">Title</th>
+                        <th className="text-left px-2 py-1 text-slate-600 dark:text-zinc-400 font-medium">Reason</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {progress.errors.map((e, i) => (
+                        <tr key={`${e.bookId}-${i}`} className="border-t border-slate-200 dark:border-zinc-800">
+                          <td className="px-2 py-1 text-slate-800 dark:text-zinc-200">{e.title || `#${e.bookId}`}</td>
+                          <td className="px-2 py-1 text-red-600 dark:text-red-400">{e.reason}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+        <div className="px-4 py-3 border-t border-slate-200 dark:border-zinc-800 flex justify-end">
+          <button
+            onClick={onClose}
+            disabled={running}
+            className="px-3 py-1.5 bg-slate-600 hover:bg-slate-500 rounded text-sm font-medium disabled:opacity-50 text-white"
+          >
+            {running ? 'Running…' : 'Close'}
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- Adds **Settings → Calibre → Push all to Calibre** button that iterates every imported book with a file on disk and POSTs it to the Bindery Bridge plugin. 409 Conflict from the plugin is treated as "already in Calibre" (idempotent), so the action is safe to re-run.
- New backend endpoints: `POST /api/v1/calibre/sync` (kicks off a single background job; returns 409 if one is already running) and `GET /api/v1/calibre/sync/status` (progress + stats + per-book error list). Rejects non-plugin modes with 400.
- Live-progress modal polls every 2s and shows pushed / already-in-Calibre / failed counters and a per-book error table.

## Implementation notes
- `internal/calibre/plugin_client.go`: 409 now maps to a new `ErrAlreadyInCalibre` sentinel so both the bulk syncer **and** the existing at-import push can distinguish duplicates from real failures. If the plugin returns an id on 409 we still persist it onto the book row.
- `internal/calibre/syncer.go`: mutex-guarded single-job orchestrator, defensive copy of the errors slice on `Progress()` so polling HTTP snapshots don't race the worker goroutine.
- Button is auto-disabled until a silent `Test connection` probe confirms the bridge is reachable; re-probes on URL/key change.

Closes #253.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — full suite green, including 3 new tests covering mixed success/409/failure counts, non-plugin rejection, and concurrent-start rejection
- [x] `tsc --noEmit` clean
- [ ] Manual smoke: click button with plugin running → modal shows progress and completion summary
- [ ] Manual smoke: click button with plugin unreachable → button disabled, warning shown
- [ ] Manual smoke: kick off sync, poll status from a second tab → both converge to the same completion state
- [ ] Manual smoke: re-run after completion → previously-pushed books counted as `alreadyInCalibre`, not `failed`