### PR TITLE
feat: global default media type + bulk update (#246, #247)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -292,7 +292,9 @@ func main() {
 	migrateHandler := api.NewMigrateHandler(
 		authorRepo, indexerRepo, dlClientRepo, blocklistRepo, bookRepo, metaAgg,
 		// Bulk imports always populate the catalogue but never auto-grab.
-		func(a *models.Author) { authorHandler.FetchAuthorBooks(a, false) },
+		// Pass an empty media type so the handler falls back to the global
+		// default.media_type setting for each newly-created book.
+		func(a *models.Author) { authorHandler.FetchAuthorBooks(a, false, "") },
 	)
 
 	// Router

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -99,6 +99,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		RootFolderID      *int64 `json:"rootFolderId"`
 		Monitored         bool   `json:"monitored"`
 		SearchOnAdd       bool   `json:"searchOnAdd"`
+		MediaType         string `json:"mediaType"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -167,9 +168,17 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve effective media type for books created under this author:
+	// explicit request value wins, else the global default.media_type
+	// setting, else ebook (backwards compat).
+	mediaType := req.MediaType
+	if mediaType == "" {
+		mediaType = h.resolveDefaultMediaType(r.Context())
+	}
+
 	// Fetch and store books for this author. Always populate the catalogue;
 	// pass searchOnAdd so FetchAuthorBooks knows whether to also queue grabs.
-	go h.FetchAuthorBooks(author, req.SearchOnAdd)
+	go h.FetchAuthorBooks(author, req.SearchOnAdd, mediaType)
 
 	writeJSON(w, http.StatusCreated, author)
 }
@@ -272,8 +281,30 @@ func (h *AuthorHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 
 	// Manual refresh always repopulates the catalogue but never auto-grabs —
 	// the user triggered it to refresh metadata, not to queue downloads.
-	go h.FetchAuthorBooks(author, false)
+	// Newly-discovered books inherit the global default media type; rows
+	// that already exist keep whatever value they were created with.
+	go h.FetchAuthorBooks(author, false, h.resolveDefaultMediaType(r.Context()))
 	writeJSON(w, http.StatusAccepted, map[string]string{"message": "refresh started"})
+}
+
+// resolveDefaultMediaType reads the global default.media_type setting and
+// falls back to ebook when unset so fresh installs keep the historical
+// behaviour. An invalid stored value — should never happen because writes
+// are validated — also falls back to ebook.
+func (h *AuthorHandler) resolveDefaultMediaType(ctx context.Context) string {
+	if h.settings == nil {
+		return models.MediaTypeEbook
+	}
+	s, _ := h.settings.Get(ctx, SettingDefaultMediaType)
+	if s == nil || s.Value == "" {
+		return models.MediaTypeEbook
+	}
+	switch s.Value {
+	case models.MediaTypeEbook, models.MediaTypeAudiobook, models.MediaTypeBoth:
+		return s.Value
+	default:
+		return models.MediaTypeEbook
+	}
 }
 
 // isAutoGrabEnabled reads the autoGrab.enabled setting. Defaults to true when
@@ -289,7 +320,10 @@ func (h *AuthorHandler) isAutoGrabEnabled(ctx context.Context) bool {
 	return s.Value != "false"
 }
 
-func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool) {
+// FetchAuthorBooks populates the author's catalogue from the metadata provider.
+// mediaType is applied to each newly-created book when the provider didn't
+// return one; pass an empty string to accept whatever the provider set.
+func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool, mediaType string) {
 	ctx := contextBackground()
 	slog.Info("fetching books for author", "author", author.Name, "foreignId", author.ForeignID)
 
@@ -325,6 +359,13 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool)
 	for _, b := range books {
 		b.AuthorID = author.ID
 		b.Monitored = author.Monitored
+		// Apply the caller-provided default media type when the provider
+		// didn't set one. Never overwrite an explicit value — the audiobook
+		// enrichment flow relies on provider-supplied audiobook rows coming
+		// through with MediaType=audiobook already.
+		if mediaType != "" && b.MediaType == "" {
+			b.MediaType = mediaType
+		}
 
 		// Filter out OpenLibrary "works" whose title is empty or is just the
 		// author name — a recurring OL data-quality problem where the Work
@@ -450,7 +491,7 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 			author, _ = h.authors.GetByForeignID(ctx, req.ForeignAuthorID)
 		} else {
 			author = fetched
-			go h.FetchAuthorBooks(author, false)
+			go h.FetchAuthorBooks(author, false, h.resolveDefaultMediaType(ctx))
 		}
 	}
 	if author == nil {

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -248,7 +248,7 @@ func TestFetchAuthorBooks_FiresSearchForMonitoredAuthor(t *testing.T) {
 	spy := &searcherSpy{}
 
 	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, spy)
-	h.FetchAuthorBooks(author, true)
+	h.FetchAuthorBooks(author, true, "")
 
 	titles := spy.titles()
 	if len(titles) != 2 {
@@ -308,7 +308,7 @@ func TestFetchAuthorBooks_SkipsSearchForOwnedBooks(t *testing.T) {
 	}
 
 	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, spy).WithFinder(finder)
-	h.FetchAuthorBooks(author, true)
+	h.FetchAuthorBooks(author, true, "")
 
 	titles := spy.titles()
 	// Only "Not Yet Owned" should have triggered a search.
@@ -372,7 +372,7 @@ func TestFetchAuthorBooks_SkipsSearchWhenNotMonitored(t *testing.T) {
 	spy := &searcherSpy{}
 
 	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, spy)
-	h.FetchAuthorBooks(author, true)
+	h.FetchAuthorBooks(author, true, "")
 
 	if titles := spy.titles(); len(titles) != 0 {
 		t.Errorf("expected no searcher calls for unmonitored author, got %v", titles)

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -41,14 +41,18 @@ type bulkResponse struct {
 
 // AuthorsBulk handles POST /api/v1/author/bulk.
 //
-// Supported actions: "monitor", "unmonitor", "delete", "search".
+// Supported actions: "monitor", "unmonitor", "delete", "search", "set_media_type".
 // "search" fires an async indexer search for every wanted book belonging
 // to each requested author and always returns ok:true immediately (the search
 // outcome is visible in History).
+// "set_media_type" requires a "mediaType" field ("ebook"|"audiobook"|"both")
+// and applies it to every book belonging to each author — the companion
+// mass-migration action for the global default.media_type setting.
 func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		IDs    []int64 `json:"ids"`
-		Action string  `json:"action"`
+		IDs       []int64 `json:"ids"`
+		Action    string  `json:"action"`
+		MediaType string  `json:"mediaType"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -60,10 +64,18 @@ func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch req.Action {
-	case "monitor", "unmonitor", "delete", "search":
+	case "monitor", "unmonitor", "delete", "search", "set_media_type":
 	default:
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown action: " + req.Action})
 		return
+	}
+	if req.Action == "set_media_type" {
+		switch req.MediaType {
+		case models.MediaTypeEbook, models.MediaTypeAudiobook, models.MediaTypeBoth:
+		default:
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "mediaType must be 'ebook', 'audiobook', or 'both'"})
+			return
+		}
 	}
 
 	resp := bulkResponse{Results: make(map[string]bulkItemResult, len(req.IDs))}
@@ -102,6 +114,11 @@ func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
 						go h.searcher.SearchAndGrabBook(bgCtx, b)
 					}
 				}
+			}
+		case "set_media_type":
+			if err := h.setAuthorBooksMediaType(r.Context(), id, req.MediaType); err != nil {
+				resp.Results[key] = bulkItemResult{Error: err.Error()}
+				continue
 			}
 		}
 		resp.Results[key] = bulkItemResult{OK: true}
@@ -268,6 +285,37 @@ func (h *BulkHandler) setBookMediaType(ctx context.Context, id int64, mediaType 
 	}
 	book.MediaType = mediaType
 	return h.books.Update(ctx, book)
+}
+
+// setAuthorBooksMediaType applies the given media type to every book in an
+// author's catalogue. Used by the Authors page bulk action so a user
+// switching their whole library from ebook to audiobook (or vice versa)
+// doesn't have to touch each book individually. The author must exist;
+// books already carrying the target value are still rewritten (cheap no-op
+// update rather than a dedicated WHERE clause so callers don't have to
+// understand SQLite semantics).
+func (h *BulkHandler) setAuthorBooksMediaType(ctx context.Context, authorID int64, mediaType string) error {
+	author, err := h.authors.GetByID(ctx, authorID)
+	if err != nil {
+		return err
+	}
+	if author == nil {
+		return fmt.Errorf("author not found")
+	}
+	books, err := h.books.ListByAuthor(ctx, authorID)
+	if err != nil {
+		return fmt.Errorf("list books: %w", err)
+	}
+	for i := range books {
+		if books[i].MediaType == mediaType {
+			continue
+		}
+		books[i].MediaType = mediaType
+		if err := h.books.Update(ctx, &books[i]); err != nil {
+			return fmt.Errorf("update book %d: %w", books[i].ID, err)
+		}
+	}
+	return nil
 }
 
 // skipBook marks a wanted book as unmonitored and skipped so it is removed

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -130,6 +130,47 @@ func TestAuthorsBulk_Delete(t *testing.T) {
 	}
 }
 
+func TestAuthorsBulk_SetMediaType(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	// Two books under this author, both currently ebook.
+	mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "OL_A", AuthorID: author.ID, Title: "A",
+		SortTitle: "a", MediaType: models.MediaTypeEbook,
+		Genres: []string{}, MetadataProvider: "openlibrary",
+	})
+	mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "OL_B", AuthorID: author.ID, Title: "B",
+		SortTitle: "b", MediaType: models.MediaTypeEbook,
+		Genres: []string{}, MetadataProvider: "openlibrary",
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"set_media_type","mediaType":"audiobook"}`, author.ID)
+	rec := postBulk(t, h.AuthorsBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, _ := books.ListByAuthor(ctx, author.ID)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 books, got %d", len(got))
+	}
+	for _, b := range got {
+		if b.MediaType != models.MediaTypeAudiobook {
+			t.Errorf("book %q: expected audiobook, got %q", b.Title, b.MediaType)
+		}
+	}
+}
+
+func TestAuthorsBulk_SetMediaType_Invalid(t *testing.T) {
+	h, _, _, author, _ := bulkFixture(t)
+	body := fmt.Sprintf(`{"ids":[%d],"action":"set_media_type","mediaType":"videogame"}`, author.ID)
+	rec := postBulk(t, h.AuthorsBulk, body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
 func TestAuthorsBulk_Search_FiresSearcherForWantedBooks(t *testing.T) {
 	searcher := newMockBookSearcher()
 	h, _, books, author, ctx := bulkFixtureWithSearcher(t, searcher)

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -13,6 +13,12 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
+// SettingDefaultMediaType is the KV key for the global media-type default
+// applied to authors created without an explicit mediaType. Value is one of
+// models.MediaTypeEbook / MediaTypeAudiobook / MediaTypeBoth; empty or
+// unset falls back to ebook for backwards compatibility.
+const SettingDefaultMediaType = "default.media_type"
+
 type SettingsHandler struct {
 	settings *db.SettingsRepo
 }
@@ -138,6 +144,18 @@ func validateSettingValue(key, value string) error {
 		}
 		if !calibre.Mode(value).Valid() {
 			return fmt.Errorf("calibre.mode %q is not one of: off, calibredb, plugin", value)
+		}
+	case SettingDefaultMediaType:
+		// Empty falls back to ebook at read time; only validate non-empty
+		// writes so a typo in the UI can't silently disable the default.
+		if value == "" {
+			return nil
+		}
+		switch value {
+		case models.MediaTypeEbook, models.MediaTypeAudiobook, models.MediaTypeBoth:
+			return nil
+		default:
+			return fmt.Errorf("default.media_type %q is not one of: ebook, audiobook, both", value)
 		}
 	case SettingCalibrePluginURL:
 		if value == "" {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -129,8 +129,8 @@ export const api = {
   },
 
   // Bulk actions
-  bulkActionAuthors: (ids: number[], action: AuthorBulkAction) =>
-    request<BulkResult>('/author/bulk', { method: 'POST', body: JSON.stringify({ ids, action }) }),
+  bulkActionAuthors: (ids: number[], action: AuthorBulkAction, mediaType?: MediaType) =>
+    request<BulkResult>('/author/bulk', { method: 'POST', body: JSON.stringify({ ids, action, ...(mediaType ? { mediaType } : {}) }) }),
   bulkActionBooks: (ids: number[], action: BookBulkAction, mediaType?: MediaType) =>
     request<BulkResult>('/book/bulk', { method: 'POST', body: JSON.stringify({ ids, action, ...(mediaType ? { mediaType } : {}) }) }),
   bulkActionWanted: (ids: number[], action: WantedBulkAction) =>
@@ -475,6 +475,7 @@ export interface AddAuthorRequest {
   metadataProfileId?: number | null
   qualityProfileId?: number | null
   rootFolderId?: number | null
+  mediaType?: MediaType
 }
 
 export interface GrabRequest {
@@ -643,7 +644,7 @@ export interface Recommendation {
   createdAt: string
 }
 
-export type AuthorBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search'
+export type AuthorBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search' | 'set_media_type'
 export type BookBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search' | 'set_media_type'
 export type WantedBulkAction = 'search' | 'blocklist' | 'unmonitor'
 

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, Author, MetadataProfile, RootFolder } from '../api/client'
+import { api, Author, MediaType, MetadataProfile, RootFolder } from '../api/client'
 
 interface Props {
   onClose: () => void
@@ -31,6 +31,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const [rootFolders, setRootFolders] = useState<RootFolder[]>([])
   const [rootFolderId, setRootFolderId] = useState<number | null>(null)
   const [searchOnAdd, setSearchOnAdd] = useState(loadAutoGrabDefault)
+  const [mediaType, setMediaType] = useState<MediaType>('ebook')
 
   useEffect(() => {
     api.listMetadataProfiles().then(ps => {
@@ -44,6 +45,15 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
       setRootFolders(rfs)
       if (rfs.length > 0) setRootFolderId(rfs[0].id)
     }).catch(console.error)
+    // Seed the media-type dropdown with the global default setting so the
+    // user only has to override it when they want something different.
+    api.getSetting('default.media_type')
+      .then(s => {
+        if (s.value === 'ebook' || s.value === 'audiobook' || s.value === 'both') {
+          setMediaType(s.value)
+        }
+      })
+      .catch(() => { /* 404 = unset; keep ebook default */ })
   }, [])
 
   const search = async () => {
@@ -71,6 +81,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
         searchOnAdd,
         metadataProfileId: profileId,
         rootFolderId: rootFolderId,
+        mediaType,
       })
       try {
         localStorage.setItem(AUTO_GRAB_STORAGE_KEY, String(searchOnAdd))
@@ -122,6 +133,20 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
               </select>
             </div>
           )}
+          <div className="mb-3">
+            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">
+              {t('addAuthorModal.mediaType', 'Media type')}
+            </label>
+            <select
+              value={mediaType}
+              onChange={e => setMediaType(e.target.value as MediaType)}
+              className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+            >
+              <option value="ebook">{t('mediaType.ebook', 'Ebook')}</option>
+              <option value="audiobook">{t('mediaType.audiobook', 'Audiobook')}</option>
+              <option value="both">{t('mediaType.both', 'Both')}</option>
+            </select>
+          </div>
           <label className="flex items-start gap-2 text-sm mb-3 cursor-pointer select-none">
             <input
               type="checkbox"

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { api, Author } from '../api/client'
+import { api, Author, MediaType } from '../api/client'
 import AddAuthorModal from '../components/AddAuthorModal'
 import AddBookModal from '../components/AddBookModal'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
@@ -117,6 +117,26 @@ export default function AuthorsPage() {
     setBulkBusy(true)
     try {
       await api.bulkActionAuthors([...selectedIds], action)
+      clearSelection()
+      load()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Bulk action failed')
+    } finally {
+      setBulkBusy(false)
+    }
+  }
+
+  const runBulkSetMediaType = async (mediaType: MediaType) => {
+    if (selectedIds.size === 0) return
+    const confirmMsg = t('authors.bulkSetMediaTypeConfirm', {
+      count: selectedIds.size,
+      mediaType: t(`mediaType.${mediaType}`, mediaType),
+      defaultValue: `Set the media type for every book of {{count}} selected authors to {{mediaType}}? This rewrites existing book rows and may re-evaluate wanted/missing status.`,
+    })
+    if (!confirm(confirmMsg)) return
+    setBulkBusy(true)
+    try {
+      await api.bulkActionAuthors([...selectedIds], 'set_media_type', mediaType)
       clearSelection()
       load()
     } catch (err) {
@@ -343,6 +363,9 @@ export default function AuthorsPage() {
           { label: t('common.monitor'), onClick: () => runBulk('monitor') },
           { label: t('common.unmonitor'), onClick: () => runBulk('unmonitor') },
           { label: t('common.search'), onClick: () => runBulk('search') },
+          { label: t('authors.bulkSetEbook', 'Set ebook'), onClick: () => runBulkSetMediaType('ebook') },
+          { label: t('authors.bulkSetAudiobook', 'Set audiobook'), onClick: () => runBulkSetMediaType('audiobook') },
+          { label: t('authors.bulkSetBoth', 'Set both'), onClick: () => runBulkSetMediaType('both') },
           { label: t('common.delete'), onClick: () => runBulk('delete'), variant: 'danger' },
         ]}
       />

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1487,6 +1487,32 @@ function GeneralTab() {
         </div>
       </section>
 
+      {/* Author defaults */}
+      <section>
+        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.authorDefaults', 'Author defaults')}</h3>
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+          <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200 mb-1">
+            {t('settings.general.defaultMediaTypeLabel', 'Default media type')}
+          </label>
+          <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
+            {t('settings.general.defaultMediaTypeHint', 'Applied to new authors when no explicit choice is made. Existing authors are unaffected — use the Authors page bulk action to migrate them.')}
+          </p>
+          <select
+            value={settings['default.media_type'] ?? 'ebook'}
+            onChange={async e => {
+              const next = e.target.value
+              setSettings(s => ({ ...s, 'default.media_type': next }))
+              await api.setSetting('default.media_type', next).catch(console.error)
+            }}
+            className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+          >
+            <option value="ebook">{t('mediaType.ebook', 'Ebook')}</option>
+            <option value="audiobook">{t('mediaType.audiobook', 'Audiobook')}</option>
+            <option value="both">{t('mediaType.both', 'Both')}</option>
+          </select>
+        </div>
+      </section>
+
       {/* Auto-grab */}
       <section>
         <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.autoGrab')}</h3>


### PR DESCRIPTION
## Summary

Resolves #246 and #247 together — they share the media-type plumbing.

- **#246 — Global default media type.** New `default.media_type` KV setting (`ebook` | `audiobook` | `both`, default `ebook`). `POST /api/v1/author` falls back to it when no explicit `mediaType` is in the body. Exposed in Settings → Author defaults. Add Author modal seeds its dropdown from the setting.
- **#247 — Bulk-update media type.** `POST /api/v1/author/bulk` gains `action: set_media_type` with `mediaType`. Authors page selection bar adds *Set ebook / audiobook / both* buttons (with confirmation). Applies the chosen type to every book under each selected author.

### Backend notes
- `FetchAuthorBooks` now takes a `mediaType` default; it only fills it in when the provider didn't return one, so audiobook rows coming from Audnexus-enriched flows keep their explicit `audiobook` value.
- `Refresh`, `AddBook`, and the migrate-handler entrypoint pass the resolved default.
- Invalid setting values (typos) are rejected at write time; a corrupt stored value falls back to `ebook` at read time.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/api/ -run TestAuthorsBulk -count=1`
- [x] `go test ./internal/api/ -count=1`
- [x] `npx tsc --noEmit` in `web/`
- [x] `npm run build` in `web/`
- [ ] Manual: set default to `audiobook` in Settings, add a new author, confirm their books land as `audiobook`
- [ ] Manual: select several authors, click *Set audiobook*, confirm their existing books flip