### PR TITLE
feat: add Deluge download client support

### DIFF
--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -1,5 +1,5 @@
 // Package downloader provides a unified interface for dispatching download
-// requests to different download clients (SABnzbd, NZBGet, Transmission, qBittorrent).
+// requests to different download clients (SABnzbd, NZBGet, Transmission, qBittorrent, Deluge).
 package downloader
 
 import (
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vavallee/bindery/internal/downloader/deluge"
 	"github.com/vavallee/bindery/internal/downloader/nzbget"
 	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
@@ -28,7 +29,7 @@ type SendResult struct {
 }
 
 func IsTorrentClient(clientType string) bool {
-	return clientType == "transmission" || clientType == "qbittorrent"
+	return clientType == "transmission" || clientType == "qbittorrent" || clientType == "deluge"
 }
 
 // IsNZBGetClient reports whether the given client type is NZBGet.
@@ -51,6 +52,9 @@ func TestClient(ctx context.Context, client *models.DownloadClient) error {
 	case "qbittorrent":
 		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
 		return qb.Test(ctx)
+	case "deluge":
+		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		return dl.Test(ctx)
 	case "nzbget":
 		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
 		return ng.Test(ctx)
@@ -98,6 +102,17 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		}
 		result.RemoteID = hash
 		return result, nil
+	case "deluge":
+		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		hash, err := dl.AddTorrent(ctx, sourceURL, client.Category)
+		if err != nil {
+			return nil, err
+		}
+		if hash == "" {
+			return nil, fmt.Errorf("downloader accepted request but did not return a trackable torrent ID")
+		}
+		result.RemoteID = hash
+		return result, nil
 	case "nzbget":
 		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
 		nzbID, err := ng.Add(ctx, sourceURL, title, client.Category, 0)
@@ -137,6 +152,12 @@ func RemoveDownload(ctx context.Context, client *models.DownloadClient, dl *mode
 		}
 		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
 		return qb.DeleteTorrent(ctx, *dl.TorrentID, deleteFiles)
+	case "deluge":
+		if dl.TorrentID == nil || *dl.TorrentID == "" {
+			return nil
+		}
+		delugeClient := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		return delugeClient.RemoveTorrent(ctx, *dl.TorrentID, deleteFiles)
 	case "nzbget":
 		if dl.SABnzbdNzoID == nil || *dl.SABnzbdNzoID == "" {
 			return nil
@@ -192,6 +213,19 @@ func GetStalledIDs(ctx context.Context, client *models.DownloadClient) (map[stri
 			// status 0 = stopped; treat stopped+error as stalled
 			if t.Status == 0 && strings.TrimSpace(t.ErrorString) != "" {
 				out[strconv.FormatInt(t.ID, 10)] = true
+			}
+		}
+		return out, true, nil
+	case "deluge":
+		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		torrents, err := dl.GetTorrents(ctx)
+		if err != nil {
+			return nil, true, err
+		}
+		out := make(map[string]bool, len(torrents))
+		for h, t := range torrents {
+			if strings.ToLower(t.State) == "error" {
+				out[h] = true
 			}
 		}
 		return out, true, nil
@@ -266,6 +300,23 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 			id := strconv.FormatInt(t.ID, 10)
 			out[id] = LiveStatus{
 				Percentage: fmt.Sprintf("%.1f", t.PercentDone*100),
+				TimeLeft:   etaToTimeLeft(t.ETA),
+				Speed:      bytesPerSecondToString(t.DownloadRate),
+			}
+		}
+		return out, nil
+	}
+
+	if client.Type == "deluge" {
+		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		torrents, err := dl.GetTorrents(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out := make(map[string]LiveStatus, len(torrents))
+		for h, t := range torrents {
+			out[h] = LiveStatus{
+				Percentage: fmt.Sprintf("%.1f", t.Progress),
 				TimeLeft:   etaToTimeLeft(t.ETA),
 				Speed:      bytesPerSecondToString(t.DownloadRate),
 			}

--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -241,18 +241,17 @@ func (c *Client) call(ctx context.Context, authenticated bool, method string, pa
 	body, err := c.doCall(ctx, method, params)
 	if err != nil {
 		// 401 means session expired — re-auth and retry once.
-		if strings.Contains(err.Error(), "HTTP 401") && authenticated {
-			c.mu.Lock()
-			c.loggedIn = false
-			c.mu.Unlock()
-			if loginErr := c.Login(ctx); loginErr != nil {
-				return loginErr
-			}
-			body, err = c.doCall(ctx, method, params)
-			if err != nil {
-				return err
-			}
-		} else {
+		if !strings.Contains(err.Error(), "HTTP 401") || !authenticated {
+			return err
+		}
+		c.mu.Lock()
+		c.loggedIn = false
+		c.mu.Unlock()
+		if loginErr := c.Login(ctx); loginErr != nil {
+			return loginErr
+		}
+		body, err = c.doCall(ctx, method, params)
+		if err != nil {
 			return err
 		}
 	}

--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -1,0 +1,304 @@
+// Package deluge provides a client for the Deluge Web UI JSON-RPC API,
+// used to submit magnet/torrent URLs and poll status for torrent downloads.
+package deluge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Client interacts with the Deluge Web UI JSON-RPC API.
+// Authentication is cookie-based: Login() posts auth.login which sets a
+// session cookie stored in the embedded http.Client's cookie jar.
+//
+// Field mapping for DownloadClient storage:
+//   - Password → password  (Deluge Web UI uses a single password, no username)
+//   - Category  → label    (applied via the label plugin after adding)
+type Client struct {
+	baseURL  string
+	password string
+	http     *http.Client
+	mu       sync.Mutex
+	loggedIn bool
+	reqID    atomic.Int64
+}
+
+type rpcRequest struct {
+	Method string `json:"method"`
+	Params []any  `json:"params"`
+	ID     int64  `json:"id"`
+}
+
+type rpcResponse struct {
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error"`
+	ID     int64           `json:"id"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// New creates a Deluge client.
+func New(host string, port int, password string, useSSL bool) *Client {
+	scheme := "http"
+	if useSSL {
+		scheme = "https"
+	}
+	jar, _ := cookiejar.New(nil)
+	return &Client{
+		baseURL:  fmt.Sprintf("%s://%s:%d", scheme, host, port),
+		password: password,
+		http:     &http.Client{Timeout: 15 * time.Second, Jar: jar},
+	}
+}
+
+// Login authenticates with the Deluge Web UI.
+func (c *Client) Login(ctx context.Context) error {
+	var result bool
+	if err := c.call(ctx, false, "auth.login", []any{c.password}, &result); err != nil {
+		return fmt.Errorf("deluge login: %w", err)
+	}
+	if !result {
+		return fmt.Errorf("deluge login failed: wrong password")
+	}
+	c.mu.Lock()
+	c.loggedIn = true
+	c.mu.Unlock()
+	return nil
+}
+
+// Test verifies connectivity by checking that the Web UI is reachable and
+// the password is correct.
+func (c *Client) Test(ctx context.Context) error {
+	if err := c.ensureLoggedIn(ctx); err != nil {
+		return fmt.Errorf("could not reach Deluge at %s — %w (in Docker use the service/container name, not localhost)", c.baseURL, err)
+	}
+	return nil
+}
+
+// AddTorrent submits a magnet link or torrent URL and returns the torrent hash.
+func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, label string) (string, error) {
+	if err := c.ensureLoggedIn(ctx); err != nil {
+		return "", err
+	}
+
+	var hash string
+	if strings.HasPrefix(strings.ToLower(magnetOrURL), "magnet:") {
+		h, err := c.addMagnet(ctx, magnetOrURL)
+		if err != nil {
+			return "", err
+		}
+		hash = h
+	} else {
+		h, err := c.addTorrentURL(ctx, magnetOrURL)
+		if err != nil {
+			return "", err
+		}
+		hash = h
+	}
+
+	hash = strings.ToLower(strings.TrimSpace(hash))
+	if hash == "" {
+		return "", fmt.Errorf("deluge accepted torrent but did not return a hash")
+	}
+
+	if label != "" {
+		// Label plugin is optional; ignore errors if it is not loaded.
+		_ = c.setLabel(ctx, hash, label)
+	}
+
+	return hash, nil
+}
+
+// addMagnet calls core.add_torrent_magnet which returns the hash directly.
+func (c *Client) addMagnet(ctx context.Context, magnet string) (string, error) {
+	var hash string
+	if err := c.call(ctx, true, "core.add_torrent_magnet", []any{magnet, map[string]any{}}, &hash); err != nil {
+		return "", fmt.Errorf("add magnet: %w", err)
+	}
+	return hash, nil
+}
+
+// addTorrentURL downloads the .torrent file via web.download_torrent_from_url
+// (which saves it to a temp path on the Deluge server), then adds it via
+// web.add_torrents. The hash is resolved by polling until the new torrent
+// appears in the status list.
+func (c *Client) addTorrentURL(ctx context.Context, torrentURL string) (string, error) {
+	// Snapshot existing hashes so we can identify the newly-added torrent.
+	beforeSet := map[string]struct{}{}
+	if before, err := c.GetTorrents(ctx); err == nil {
+		for h := range before {
+			beforeSet[strings.ToLower(h)] = struct{}{}
+		}
+	}
+
+	// Step 1: ask Deluge to download the .torrent file to a local tmp path.
+	var tmpPath string
+	if err := c.call(ctx, true, "web.download_torrent_from_url", []any{torrentURL, ""}, &tmpPath); err != nil {
+		return "", fmt.Errorf("download torrent from url: %w", err)
+	}
+
+	// Step 2: add the downloaded .torrent file.
+	addEntry := map[string]any{
+		"path":    tmpPath,
+		"options": map[string]any{},
+	}
+	var addResult any
+	if err := c.call(ctx, true, "web.add_torrents", []any{[]any{addEntry}}, &addResult); err != nil {
+		return "", fmt.Errorf("add torrents: %w", err)
+	}
+
+	// Poll until the new torrent appears — Deluge processes the file
+	// asynchronously and the hash may not be visible immediately.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		statuses, err := c.GetTorrents(ctx)
+		if err != nil {
+			return "", fmt.Errorf("add torrent accepted but hash lookup failed: %w", err)
+		}
+		for h := range statuses {
+			lh := strings.ToLower(h)
+			if _, seen := beforeSet[lh]; !seen {
+				return lh, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return "", fmt.Errorf("add torrent accepted but hash could not be determined")
+}
+
+// setLabel applies a label to a torrent via the Deluge label plugin.
+// Errors are intentionally swallowed by the caller — the plugin is optional.
+func (c *Client) setLabel(ctx context.Context, hash, label string) error {
+	var result any
+	return c.call(ctx, true, "label.set_torrent", []any{hash, label}, &result)
+}
+
+// GetTorrents returns status for all torrents, keyed by lower-cased hash.
+func (c *Client) GetTorrents(ctx context.Context) (map[string]TorrentStatus, error) {
+	fields := []string{"name", "hash", "progress", "state", "eta", "download_payload_rate"}
+	var raw map[string]TorrentStatus
+	if err := c.call(ctx, true, "core.get_torrents_status", []any{map[string]any{}, fields}, &raw); err != nil {
+		return nil, fmt.Errorf("get torrents status: %w", err)
+	}
+	out := make(map[string]TorrentStatus, len(raw))
+	for h, s := range raw {
+		out[strings.ToLower(h)] = s
+	}
+	return out, nil
+}
+
+// RemoveTorrent removes a torrent by hash, optionally deleting its data files.
+func (c *Client) RemoveTorrent(ctx context.Context, hash string, deleteFiles bool) error {
+	if err := c.ensureLoggedIn(ctx); err != nil {
+		return err
+	}
+	var result bool
+	if err := c.call(ctx, true, "core.remove_torrent", []any{hash, deleteFiles}, &result); err != nil {
+		return fmt.Errorf("remove torrent: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) ensureLoggedIn(ctx context.Context) error {
+	c.mu.Lock()
+	loggedIn := c.loggedIn
+	c.mu.Unlock()
+	if loggedIn {
+		return nil
+	}
+	return c.Login(ctx)
+}
+
+// call sends a JSON-RPC request to /json and unmarshals the result into out.
+// If authenticated is true and the session has expired (401), it re-logs in
+// and retries once.
+func (c *Client) call(ctx context.Context, authenticated bool, method string, params []any, out any) error {
+	if authenticated {
+		if err := c.ensureLoggedIn(ctx); err != nil {
+			return err
+		}
+	}
+
+	body, err := c.doCall(ctx, method, params)
+	if err != nil {
+		// 401 means session expired — re-auth and retry once.
+		if strings.Contains(err.Error(), "HTTP 401") && authenticated {
+			c.mu.Lock()
+			c.loggedIn = false
+			c.mu.Unlock()
+			if loginErr := c.Login(ctx); loginErr != nil {
+				return loginErr
+			}
+			body, err = c.doCall(ctx, method, params)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	if out != nil {
+		if err := json.Unmarshal(body, out); err != nil {
+			return fmt.Errorf("decode result for %s: %w", method, err)
+		}
+	}
+	return nil
+}
+
+func (c *Client) doCall(ctx context.Context, method string, params []any) (json.RawMessage, error) {
+	id := c.reqID.Add(1)
+	payload, err := json.Marshal(rpcRequest{Method: method, Params: params, ID: id})
+	if err != nil {
+		return nil, fmt.Errorf("marshal rpc request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/json", bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("POST /json: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("HTTP 401: session expired")
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+
+	var rpcResp rpcResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return nil, fmt.Errorf("decode rpc response: %w", err)
+	}
+	if rpcResp.Error != nil {
+		return nil, fmt.Errorf("rpc error %d: %s", rpcResp.Error.Code, rpcResp.Error.Message)
+	}
+	return rpcResp.Result, nil
+}

--- a/internal/downloader/deluge/client_test.go
+++ b/internal/downloader/deluge/client_test.go
@@ -30,9 +30,9 @@ func (s *delugeServer) handler() http.HandlerFunc {
 			return
 		}
 		var req struct {
-			Method string `json:"method"`
+			Method string            `json:"method"`
 			Params []json.RawMessage `json:"params"`
-			ID     int64  `json:"id"`
+			ID     int64             `json:"id"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, "bad request", http.StatusBadRequest)

--- a/internal/downloader/deluge/client_test.go
+++ b/internal/downloader/deluge/client_test.go
@@ -1,0 +1,242 @@
+package deluge_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/downloader/deluge"
+)
+
+// delugeServer is a minimal Deluge Web UI JSON-RPC stub.
+type delugeServer struct {
+	t        *testing.T
+	password string
+	torrents map[string]deluge.TorrentStatus // keyed by lower-cased hash
+
+	// optional overrides
+	loginErr     bool
+	addMagnetErr bool
+	removeFail   bool
+}
+
+func (s *delugeServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/json" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var req struct {
+			Method string `json:"method"`
+			Params []json.RawMessage `json:"params"`
+			ID     int64  `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		write := func(result any) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"result": result,
+				"error":  nil,
+				"id":     req.ID,
+			})
+		}
+		writeErr := func(msg string) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"result": nil,
+				"error":  map[string]any{"code": -1, "message": msg},
+				"id":     req.ID,
+			})
+		}
+
+		switch req.Method {
+		case "auth.login":
+			if s.loginErr {
+				writeErr("auth error")
+				return
+			}
+			var pw string
+			json.Unmarshal(req.Params[0], &pw)
+			write(pw == s.password)
+
+		case "core.add_torrent_magnet":
+			if s.addMagnetErr {
+				writeErr("add error")
+				return
+			}
+			var magnet string
+			json.Unmarshal(req.Params[0], &magnet)
+			// Extract hash from urn:btih:HASH
+			hash := "aabbccddeeff00112233445566778899aabbccdd"
+			if idx := strings.Index(strings.ToLower(magnet), "urn:btih:"); idx >= 0 {
+				hash = strings.ToLower(magnet[idx+9:])
+				if i := strings.Index(hash, "&"); i >= 0 {
+					hash = hash[:i]
+				}
+			}
+			s.torrents[hash] = deluge.TorrentStatus{Hash: hash, State: "Downloading", Progress: 0}
+			write(hash)
+
+		case "web.download_torrent_from_url":
+			write("/tmp/bindery_test.torrent")
+
+		case "web.add_torrents":
+			const newHash = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+			s.torrents[newHash] = deluge.TorrentStatus{Hash: newHash, State: "Downloading", Progress: 10}
+			write([]bool{true})
+
+		case "label.set_torrent":
+			write(nil)
+
+		case "core.get_torrents_status":
+			write(s.torrents)
+
+		case "core.remove_torrent":
+			var hash string
+			json.Unmarshal(req.Params[0], &hash)
+			delete(s.torrents, hash)
+			if s.removeFail {
+				writeErr("remove failed")
+				return
+			}
+			write(true)
+
+		default:
+			writeErr("unknown method: " + req.Method)
+		}
+	}
+}
+
+func newTestServer(t *testing.T, password string) (*httptest.Server, *delugeServer) {
+	t.Helper()
+	ds := &delugeServer{
+		t:        t,
+		password: password,
+		torrents: make(map[string]deluge.TorrentStatus),
+	}
+	srv := httptest.NewServer(ds.handler())
+	t.Cleanup(srv.Close)
+	return srv, ds
+}
+
+func clientFromServer(srv *httptest.Server, password string) *deluge.Client {
+	// Parse host/port from the test server URL.
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	parts := strings.SplitN(addr, ":", 2)
+	port := 80
+	if len(parts) == 2 {
+		_, _ = parts[1], &port
+		p := 0
+		for _, c := range parts[1] {
+			p = p*10 + int(c-'0')
+		}
+		port = p
+	}
+	return deluge.New(parts[0], port, password, false)
+}
+
+func TestLogin_Success(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	c := clientFromServer(srv, "secret")
+	if err := c.Login(context.Background()); err != nil {
+		t.Fatalf("expected login to succeed: %v", err)
+	}
+}
+
+func TestLogin_WrongPassword(t *testing.T) {
+	srv, _ := newTestServer(t, "secret")
+	c := clientFromServer(srv, "wrong")
+	if err := c.Login(context.Background()); err == nil {
+		t.Fatal("expected login to fail with wrong password")
+	}
+}
+
+func TestTest_Success(t *testing.T) {
+	srv, _ := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+	if err := c.Test(context.Background()); err != nil {
+		t.Fatalf("Test() failed: %v", err)
+	}
+}
+
+func TestAddTorrent_Magnet(t *testing.T) {
+	srv, ds := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+
+	magnet := "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd&dn=Test+Book"
+	hash, err := c.AddTorrent(context.Background(), magnet, "books")
+	if err != nil {
+		t.Fatalf("AddTorrent magnet: %v", err)
+	}
+	if hash != "aabbccddeeff00112233445566778899aabbccdd" {
+		t.Errorf("unexpected hash %q", hash)
+	}
+	if _, ok := ds.torrents[hash]; !ok {
+		t.Error("torrent not found in server after add")
+	}
+}
+
+func TestAddTorrent_URL(t *testing.T) {
+	srv, _ := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+
+	hash, err := c.AddTorrent(context.Background(), "http://indexer.example/torrent.torrent", "")
+	if err != nil {
+		t.Fatalf("AddTorrent URL: %v", err)
+	}
+	if hash == "" {
+		t.Error("expected non-empty hash")
+	}
+}
+
+func TestGetTorrents(t *testing.T) {
+	srv, ds := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+
+	ds.torrents["abc123"] = deluge.TorrentStatus{Hash: "abc123", State: "Downloading", Progress: 50}
+
+	torrents, err := c.GetTorrents(context.Background())
+	if err != nil {
+		t.Fatalf("GetTorrents: %v", err)
+	}
+	if _, ok := torrents["abc123"]; !ok {
+		t.Error("expected abc123 in torrents map")
+	}
+}
+
+func TestRemoveTorrent(t *testing.T) {
+	srv, ds := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+
+	ds.torrents["deadbeef"] = deluge.TorrentStatus{Hash: "deadbeef", State: "Seeding"}
+
+	if err := c.RemoveTorrent(context.Background(), "deadbeef", false); err != nil {
+		t.Fatalf("RemoveTorrent: %v", err)
+	}
+	if _, ok := ds.torrents["deadbeef"]; ok {
+		t.Error("torrent should have been removed")
+	}
+}
+
+func TestGetTorrents_StalledState(t *testing.T) {
+	srv, ds := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+
+	ds.torrents["errhash"] = deluge.TorrentStatus{Hash: "errhash", State: "Error"}
+	ds.torrents["goodhash"] = deluge.TorrentStatus{Hash: "goodhash", State: "Downloading"}
+
+	torrents, err := c.GetTorrents(context.Background())
+	if err != nil {
+		t.Fatalf("GetTorrents: %v", err)
+	}
+	if strings.ToLower(torrents["errhash"].State) != "error" {
+		t.Error("expected Error state")
+	}
+}

--- a/internal/downloader/deluge/types.go
+++ b/internal/downloader/deluge/types.go
@@ -4,8 +4,8 @@ package deluge
 type TorrentStatus struct {
 	Name         string  `json:"name"`
 	Hash         string  `json:"hash"`
-	Progress     float64 `json:"progress"`          // 0–100
-	State        string  `json:"state"`             // "Downloading", "Seeding", "Paused", "Error", etc.
-	ETA          int64   `json:"eta"`               // seconds remaining; -1 or 0 if unknown
+	Progress     float64 `json:"progress"`              // 0–100
+	State        string  `json:"state"`                 // "Downloading", "Seeding", "Paused", "Error", etc.
+	ETA          int64   `json:"eta"`                   // seconds remaining; -1 or 0 if unknown
 	DownloadRate int64   `json:"download_payload_rate"` // bytes/s
 }

--- a/internal/downloader/deluge/types.go
+++ b/internal/downloader/deluge/types.go
@@ -1,0 +1,11 @@
+package deluge
+
+// TorrentStatus holds the fields returned by core.get_torrents_status.
+type TorrentStatus struct {
+	Name         string  `json:"name"`
+	Hash         string  `json:"hash"`
+	Progress     float64 `json:"progress"`          // 0–100
+	State        string  `json:"state"`             // "Downloading", "Seeding", "Paused", "Error", etc.
+	ETA          int64   `json:"eta"`               // seconds remaining; -1 or 0 if unknown
+	DownloadRate int64   `json:"download_payload_rate"` // bytes/s
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -2291,7 +2291,8 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
   const [type, setType] = useState(client.type || 'sabnzbd')
   const [host, setHost] = useState(client.host)
   const [port, setPort] = useState(String(client.port))
-  const [credential, setCredential] = useState(client.type === 'qbittorrent' || client.type === 'transmission' || client.type === 'nzbget' ? (client.password || '') : (client.apiKey || ''))
+  const usesPassword = client.type === 'qbittorrent' || client.type === 'transmission' || client.type === 'nzbget' || client.type === 'deluge'
+  const [credential, setCredential] = useState(usesPassword ? (client.password || '') : (client.apiKey || ''))
   const [username, setUsername] = useState(client.username || '')
   const [category, setCategory] = useState(client.category)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
@@ -2302,9 +2303,12 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
     setUsername('')
   }
 
+  const isPasswordClient = (t: string) => t === 'qbittorrent' || t === 'transmission' || t === 'nzbget' || t === 'deluge'
+  const hasUsername = (t: string) => t === 'qbittorrent' || t === 'transmission' || t === 'nzbget'
+
   const submit = async () => {
-    const data = type === 'qbittorrent' || type === 'transmission' || type === 'nzbget'
-      ? { ...client, name, type, host, port: parseInt(port), username, password: credential, apiKey: '', category }
+    const data = isPasswordClient(type)
+      ? { ...client, name, type, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category }
       : { ...client, name, type, host, port: parseInt(port), apiKey: credential, username: '', password: '', category }
     const updated = await api.updateDownloadClient(client.id, data)
     onSaved(updated)
@@ -2324,6 +2328,7 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
             <option value="nzbget">NZBGet</option>
             <option value="qbittorrent">qBittorrent</option>
             <option value="transmission">Transmission</option>
+            <option value="deluge">Deluge</option>
           </select>
         </div>
       </div>
@@ -2335,20 +2340,21 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
         </div>
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">In Docker, use the service/container name (e.g. <code className="font-mono">nzbget</code>) — not <code className="font-mono">localhost</code>.</p>
       </div>
-      {(type === 'qbittorrent' || type === 'transmission' || type === 'nzbget') && (
+      {hasUsername(type) && (
         <div>
           <label className={labelCls}>Username</label>
           <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />
         </div>
       )}
       <div>
-        <label className={labelCls}>{type === 'qbittorrent' || type === 'transmission' || type === 'nzbget' ? 'Password' : 'API Key'}</label>
-        <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' || type === 'transmission' || type === 'nzbget' ? 'Password' : 'API Key'} type="password" className={inputCls} />
+        <label className={labelCls}>{isPasswordClient(type) ? 'Password' : 'API Key'}</label>
+        <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={isPasswordClient(type) ? 'Password' : 'API Key'} type="password" className={inputCls} />
       </div>
       <div>
-        <label className={labelCls}>{type === 'transmission' ? 'Download Directory' : 'Category'}</label>
-        <input value={category} onChange={e => setCategory(e.target.value)} placeholder={type === 'transmission' ? '/downloads (leave blank for default)' : 'Category'} className={inputCls} />
+        <label className={labelCls}>{type === 'transmission' ? 'Download Directory' : 'Category / Label'}</label>
+        <input value={category} onChange={e => setCategory(e.target.value)} placeholder={type === 'transmission' ? '/downloads (leave blank for default)' : 'books'} className={inputCls} />
         {type === 'transmission' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Optional absolute path override. Leave blank to use Transmission's configured default download directory.</p>}
+        {type === 'deluge' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Applied via the Deluge label plugin. Leave blank if the plugin is not installed.</p>}
       </div>
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
@@ -2461,7 +2467,7 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
 
 function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c: DownloadClient) => void }) {
   const [name, setName] = useState('SABnzbd')
-  const [type, setType] = useState<'sabnzbd' | 'nzbget' | 'qbittorrent' | 'transmission'>('sabnzbd')
+  const [type, setType] = useState<'sabnzbd' | 'nzbget' | 'qbittorrent' | 'transmission' | 'deluge'>('sabnzbd')
   const [host, setHost] = useState('')
   const [port, setPort] = useState('8080')
   const [credential, setCredential] = useState('')
@@ -2469,7 +2475,10 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
   const [category, setCategory] = useState('books')
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
-  const handleTypeChange = (newType: 'sabnzbd' | 'nzbget' | 'qbittorrent' | 'transmission') => {
+  const isPasswordClient = (t: string) => t === 'qbittorrent' || t === 'transmission' || t === 'nzbget' || t === 'deluge'
+  const hasUsername = (t: string) => t === 'qbittorrent' || t === 'transmission' || t === 'nzbget'
+
+  const handleTypeChange = (newType: 'sabnzbd' | 'nzbget' | 'qbittorrent' | 'transmission' | 'deluge') => {
     setType(newType)
     setCredential('')
     setUsername('')
@@ -2488,13 +2497,18 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
       setPort('9091')
       return
     }
+    if (newType === 'deluge') {
+      setName('Deluge')
+      setPort('8112')
+      return
+    }
     setName('SABnzbd')
     setPort('8080')
   }
 
   const submit = async () => {
-    const data = type === 'qbittorrent' || type === 'transmission' || type === 'nzbget'
-      ? { name, host, port: parseInt(port), username, password: credential, apiKey: '', category, type, enabled: true }
+    const data = isPasswordClient(type)
+      ? { name, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, type, enabled: true }
       : { name, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, type, enabled: true }
     const c = await api.addDownloadClient(data)
     onAdded(c)
@@ -2509,11 +2523,12 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
         </div>
         <div className="w-40">
           <label className={labelCls}>Client Type</label>
-          <select value={type} onChange={e => handleTypeChange(e.target.value as 'sabnzbd' | 'nzbget' | 'qbittorrent' | 'transmission')} className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
+          <select value={type} onChange={e => handleTypeChange(e.target.value as 'sabnzbd' | 'nzbget' | 'qbittorrent' | 'transmission' | 'deluge')} className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600">
             <option value="sabnzbd">SABnzbd</option>
             <option value="nzbget">NZBGet</option>
             <option value="qbittorrent">qBittorrent</option>
             <option value="transmission">Transmission</option>
+            <option value="deluge">Deluge</option>
           </select>
         </div>
       </div>
@@ -2525,20 +2540,21 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
         </div>
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">In Docker, use the service/container name (e.g. <code className="font-mono">nzbget</code>) — not <code className="font-mono">localhost</code>.</p>
       </div>
-      {(type === 'qbittorrent' || type === 'transmission' || type === 'nzbget') && (
+      {hasUsername(type) && (
         <div>
           <label className={labelCls}>Username</label>
           <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className={inputCls} />
         </div>
       )}
       <div>
-        <label className={labelCls}>{type === 'qbittorrent' || type === 'transmission' || type === 'nzbget' ? 'Password' : 'API Key'}</label>
-        <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={type === 'qbittorrent' || type === 'transmission' || type === 'nzbget' ? 'Password' : 'API Key'} type="password" className={inputCls} />
+        <label className={labelCls}>{isPasswordClient(type) ? 'Password' : 'API Key'}</label>
+        <input value={credential} onChange={e => setCredential(e.target.value)} placeholder={isPasswordClient(type) ? 'Password' : 'API Key'} type="password" className={inputCls} />
       </div>
       <div>
-        <label className={labelCls}>{type === 'transmission' ? 'Download Directory' : 'Category'}</label>
-        <input value={category} onChange={e => setCategory(e.target.value)} placeholder={type === 'transmission' ? '/downloads (leave blank for default)' : 'Category'} className={inputCls} />
+        <label className={labelCls}>{type === 'transmission' ? 'Download Directory' : 'Category / Label'}</label>
+        <input value={category} onChange={e => setCategory(e.target.value)} placeholder={type === 'transmission' ? '/downloads (leave blank for default)' : 'books'} className={inputCls} />
         {type === 'transmission' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Optional absolute path override. Leave blank to use Transmission's configured default download directory.</p>}
+        {type === 'deluge' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Applied via the Deluge label plugin. Leave blank if the plugin is not installed.</p>}
       </div>
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>


### PR DESCRIPTION
Closes #261

## Summary

- New `internal/downloader/deluge` package: cookie-based JSON-RPC client for the Deluge Web UI (`/json` endpoint)
- Magnet links use `core.add_torrent_magnet` (hash returned directly); torrent URLs use `web.download_torrent_from_url` + `web.add_torrents` with poll-based hash resolution (same pattern as qBittorrent)
- Labels applied after add via the `label` plugin; errors ignored gracefully when plugin is not installed
- Stall detection: torrents in `Error` state
- Full adapter surface wired: `TestClient`, `SendDownload`, `RemoveDownload`, `GetStalledIDs`, `GetLiveStatuses`
- Frontend: Deluge added to client type dropdowns in both Add and Edit forms (port defaults to 8112, no username field, label plugin hint text)

## Test plan

- [ ] `go test ./internal/downloader/...` — all pass (7 new Deluge tests covering login, add magnet, add URL, get torrents, remove, stall state)
- [ ] Add Deluge client in Settings UI — dropdown appears, port pre-fills to 8112, no username field shown, label hint visible
- [ ] Test connection button reaches Deluge and authenticates
- [ ] Grab a torrent release — download appears in Activity with live progress
- [ ] Remove a download — torrent removed from Deluge