### PR TITLE
fix: extend indexer test to run a real search probe

### DIFF
--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -161,18 +161,20 @@ func (h *IndexerHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// IndexerTestResponse summarizes a lightweight connectivity probe. The
+// IndexerTestResponse summarizes a connectivity and search probe. The
 // handler always returns HTTP 200 on a reachable-but-failed probe (e.g. 401
 // from the upstream indexer) so the UI can render the specific error inline
 // instead of a generic "request failed" toast.
 type IndexerTestResponse struct {
-	OK         bool   `json:"ok"`
-	Status     int    `json:"status"`
-	Categories int    `json:"categories"`
-	BookSearch bool   `json:"bookSearch"`
-	LatencyMs  int64  `json:"latencyMs"`
-	Message    string `json:"message,omitempty"`
-	Error      string `json:"error,omitempty"`
+	OK            bool   `json:"ok"`
+	Status        int    `json:"status"`
+	Categories    int    `json:"categories"`
+	BookSearch    bool   `json:"bookSearch"`
+	LatencyMs     int64  `json:"latencyMs"`
+	SearchResults int    `json:"searchResults"`
+	SearchError   string `json:"searchError,omitempty"`
+	Message       string `json:"message,omitempty"`
+	Error         string `json:"error,omitempty"`
 }
 
 func (h *IndexerHandler) Test(w http.ResponseWriter, r *http.Request) {
@@ -189,10 +191,12 @@ func (h *IndexerHandler) Test(w http.ResponseWriter, r *http.Request) {
 	client := newznab.New(idx.URL, idx.APIKey)
 	probe := client.Probe(r.Context())
 	resp := IndexerTestResponse{
-		Status:     probe.Status,
-		Categories: probe.Categories,
-		BookSearch: probe.BookSearch,
-		LatencyMs:  probe.LatencyMs,
+		Status:        probe.Status,
+		Categories:    probe.Categories,
+		BookSearch:    probe.BookSearch,
+		LatencyMs:     probe.LatencyMs,
+		SearchResults: probe.SearchResults,
+		SearchError:   probe.SearchError,
 	}
 	if probe.Error != "" {
 		resp.Error = probe.Error

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -182,21 +182,27 @@ func (c *Client) Test(ctx context.Context) error {
 	return err
 }
 
-// ProbeResult summarizes a lightweight connectivity check against the indexer.
+// ProbeResult summarizes a connectivity and search check against the indexer.
 type ProbeResult struct {
 	Status        int    `json:"status"`
 	Categories    int    `json:"categories"`
 	BookSearch    bool   `json:"bookSearch"`
 	GeneralSearch bool   `json:"generalSearch"`
 	LatencyMs     int64  `json:"latencyMs"`
+	SearchResults int    `json:"searchResults"` // results from the test search query
+	SearchError   string `json:"searchError,omitempty"`
 	Error         string `json:"error,omitempty"`
 }
 
-// Probe performs a capabilities fetch and returns a structured summary
-// (HTTP status, category count, latency) without writing anything to the
-// database. The response is the zero-cost "t=caps" endpoint described in
-// https://github.com/Sonarr/Sonarr/wiki/Implementing-a-New-Indexer — it is
-// safe to call from a "Test" button and never creates queue entries.
+// Probe performs a capabilities fetch followed by a lightweight test search,
+// returning a structured summary without writing anything to the database.
+//
+// The two-step approach catches a class of misconfiguration that caps-only
+// probes miss: an indexer can report HTTP 200 and valid capabilities while
+// still returning zero results for every query (wrong API key permissions,
+// no books indexed, category mismatch). The test search uses "t=search&q=book"
+// against the configured book categories and records how many results came
+// back so the UI can warn when connectivity succeeds but searches return nothing.
 func (c *Client) Probe(ctx context.Context) ProbeResult {
 	u, err := c.buildURL("caps", map[string]string{})
 	if err != nil {
@@ -232,7 +238,37 @@ func (c *Client) Probe(ctx context.Context) ProbeResult {
 	result.Categories = len(caps.Categories.Categories)
 	result.BookSearch = strings.EqualFold(caps.Searching.BookSearch.Available, "yes")
 	result.GeneralSearch = strings.EqualFold(caps.Searching.Search.Available, "yes")
+
+	// Run a real test search against the book categories to catch the case
+	// where caps succeeds but actual queries return nothing.
+	hits, err := c.Search(ctx, "book", bookCategoriesFromCaps(caps))
+	if err != nil {
+		result.SearchError = err.Error()
+	} else {
+		result.SearchResults = len(hits)
+	}
+
 	return result
+}
+
+// bookCategoriesFromCaps extracts 7xxx (ebook) category IDs from a caps
+// response. Falls back to [7020] when none are advertised so the test
+// search always targets book content.
+func bookCategoriesFromCaps(caps capsResponse) []int {
+	var out []int
+	for _, cat := range caps.Categories.Categories {
+		id, err := strconv.Atoi(cat.ID)
+		if err != nil {
+			continue
+		}
+		if id/1000 == 7 {
+			out = append(out, id)
+		}
+	}
+	if len(out) == 0 {
+		return []int{7020}
+	}
+	return out
 }
 
 func (c *Client) parseResults(items []rssItem) []SearchResult {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -427,6 +427,8 @@ export interface IndexerTestResult {
   categories: number
   bookSearch: boolean
   latencyMs: number
+  searchResults: number
+  searchError?: string
   message?: string
   error?: string
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -216,7 +216,8 @@
       "empty": "No indexers configured. Add a Newznab indexer to search for books.",
       "connectionOk": "Connection successful!",
       "connectionFail": "Test failed: {{error}}",
-      "testOk": "Connected — HTTP {{status}}, {{categories}} categories, responded in {{latency}} ms",
+      "testOk": "Connected — HTTP {{status}}, {{categories}} categories, {{results}} results in test search, {{latency}} ms",
+      "testWarn": "Connected — but test search returned 0 results. Check your API key permissions and category IDs (HTTP {{status}}, {{categories}} categories, {{latency}} ms)",
       "testFail": "Error: {{error}}"
     },
     "clients": {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -127,12 +127,12 @@ export default function SettingsPage() {
                       <button
                         disabled={indexerTestResults[idx.id]?.testing}
                         onClick={async () => {
-                          setIndexerTestResults(prev => ({ ...prev, [idx.id]: { ...(prev[idx.id] ?? { ok: false, status: 0, categories: 0, bookSearch: false, latencyMs: 0 }), testing: true } }))
+                          setIndexerTestResults(prev => ({ ...prev, [idx.id]: { ...(prev[idx.id] ?? { ok: false, status: 0, categories: 0, bookSearch: false, latencyMs: 0, searchResults: 0 }), testing: true } }))
                           try {
                             const r = await api.testIndexer(idx.id)
                             setIndexerTestResults(prev => ({ ...prev, [idx.id]: { ...r, testing: false } }))
                           } catch (err: unknown) {
-                            setIndexerTestResults(prev => ({ ...prev, [idx.id]: { ok: false, status: 0, categories: 0, bookSearch: false, latencyMs: 0, error: err instanceof Error ? err.message : 'Request failed', testing: false } }))
+                            setIndexerTestResults(prev => ({ ...prev, [idx.id]: { ok: false, status: 0, categories: 0, bookSearch: false, latencyMs: 0, searchResults: 0, error: err instanceof Error ? err.message : 'Request failed', testing: false } }))
                           }
                         }}
                         className="text-xs text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white disabled:opacity-50"
@@ -150,29 +150,28 @@ export default function SettingsPage() {
                       </button>
                     </div>
                   </div>
-                  {indexerTestResults[idx.id] && !indexerTestResults[idx.id].testing && (
-                    <div
-                      role="status"
-                      className={`mt-2 px-3 py-2 rounded text-xs flex items-center gap-2 ${indexerTestResults[idx.id].ok ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300' : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'}`}
-                    >
-                      <span className={`inline-block w-2 h-2 rounded-full ${indexerTestResults[idx.id].ok ? 'bg-emerald-500' : 'bg-red-500'}`} />
-                      {indexerTestResults[idx.id].ok ? (
-                        <span>
-                          {t('settings.indexers.testOk', {
-                            status: indexerTestResults[idx.id].status,
-                            categories: indexerTestResults[idx.id].categories,
-                            latency: indexerTestResults[idx.id].latencyMs,
-                          })}
-                        </span>
-                      ) : (
-                        <span>
-                          {t('settings.indexers.testFail', {
-                            error: indexerTestResults[idx.id].error ?? 'Unknown error',
-                          })}
-                        </span>
-                      )}
-                    </div>
-                  )}
+                  {indexerTestResults[idx.id] && !indexerTestResults[idx.id].testing && (() => {
+                    const r = indexerTestResults[idx.id]
+                    const warn = r.ok && r.searchResults === 0
+                    const colorCls = !r.ok
+                      ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+                      : warn
+                        ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
+                        : 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
+                    const dotCls = !r.ok ? 'bg-red-500' : warn ? 'bg-amber-500' : 'bg-emerald-500'
+                    return (
+                      <div role="status" className={`mt-2 px-3 py-2 rounded text-xs flex items-center gap-2 ${colorCls}`}>
+                        <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${dotCls}`} />
+                        {!r.ok ? (
+                          <span>{t('settings.indexers.testFail', { error: r.error ?? 'Unknown error' })}</span>
+                        ) : warn ? (
+                          <span>{t('settings.indexers.testWarn', { status: r.status, categories: r.categories, latency: r.latencyMs })}{r.searchError ? ` — ${r.searchError}` : ''}</span>
+                        ) : (
+                          <span>{t('settings.indexers.testOk', { status: r.status, categories: r.categories, latency: r.latencyMs, results: r.searchResults })}</span>
+                        )}
+                      </div>
+                    )
+                  })()}
                   {editingIndexer === idx.id && (
                     <EditIndexerForm
                       indexer={idx}


### PR DESCRIPTION
## Problem

Users report "Getting a success message for all my indexer tests, but not finding anything when searching." The previous test only called `t=caps`, which confirms HTTP connectivity but not that searches work. An indexer can return HTTP 200 + valid caps while returning zero results for every query — wrong API key permissions, misconfigured categories, or nothing indexed.

## Solution

`Probe()` now runs a `t=search&q=book` against the book categories advertised in caps after the connectivity check. The result count flows through to the UI with three states:

- **Green**: connected + test search returned N results (working)
- **Amber**: connected but 0 results — directs user to check API key permissions and category IDs
- **Red**: connectivity failure (unchanged)

## Changes

- `internal/indexer/newznab/client.go` — `Probe()` runs a real search after caps; `ProbeResult` gains `SearchResults int` and `SearchError string`
- `internal/api/indexers.go` — `IndexerTestResponse` passes the new fields through
- `web/src/api/client.ts` — `IndexerTestResult` type updated
- `web/src/pages/SettingsPage.tsx` — three-state result display (green/amber/red)
- `web/src/i18n/locales/en.json` — new `testWarn` and updated `testOk` strings

## Test plan

- [ ] Indexer with correct config → green, shows result count
- [ ] Indexer with wrong API key that still returns caps → amber warning
- [ ] Indexer unreachable → red (unchanged)
- [ ] `go test ./internal/indexer/...` passes