### PR TITLE
feat: add direct indexer search page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import HistoryPage from './pages/HistoryPage'
 import SeriesPage from './pages/SeriesPage'
 import CalendarPage from './pages/CalendarPage'
 import DiscoverPage from './pages/DiscoverPage'
+import SearchPage from './pages/SearchPage'
 import Logo from './components/Logo'
 import { useTheme } from './theme'
 
@@ -29,6 +30,7 @@ const NAV_KEYS = [
   { to: '/series', key: 'series' },
   { to: '/calendar', key: 'calendar' },
   { to: '/discover', key: 'discover' },
+  { to: '/search', key: 'search' },
 ]
 
 function Shell() {
@@ -189,6 +191,7 @@ function Shell() {
           <Route path="/series" element={<SeriesPage />} />
           <Route path="/calendar" element={<CalendarPage />} />
           <Route path="/discover" element={<DiscoverPage />} />
+          <Route path="/search" element={<SearchPage />} />
           <Route path="/blocklist" element={<Navigate to="/settings" replace />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -40,7 +40,8 @@
     "series": "Serien",
     "discover": "Discover",
     "blocklist": "Blockliste",
-    "settings": "Einstellungen"
+    "settings": "Einstellungen",
+    "search": "Search"
   },
   "login": {
     "title": "Anmelden",
@@ -119,7 +120,6 @@
     "statusImported": "In Bibliothek",
     "statusSkipped": "Übersprungen",
     "audioLabel": "🎧 Audio",
-    "download": "Herunterladen",
     "downloadFile": "Datei herunterladen",
     "setEbook": "📖 Als E-Book setzen",
     "setAudiobook": "🎧 Als Hörbuch setzen",
@@ -393,5 +393,16 @@
       "coldStart": "Add more books to unlock personalized genre recommendations.",
       "goToSettings": "Go to Settings"
     }
+  },
+  "search": {
+    "heading": "Search Indexers",
+    "placeholder": "Title, author, or keyword…",
+    "submit": "Search",
+    "searching": "Searching…",
+    "noResults": "No results — try a different query or check your indexer configuration.",
+    "resultCount": "{{count}} results",
+    "grab": "Grab",
+    "grabbing": "Grabbing…",
+    "grabbed": "Grabbed"
   }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -40,8 +40,20 @@
     "queue": "Queue",
     "series": "Series",
     "discover": "Discover",
+    "search": "Search",
     "blocklist": "Blocklist",
     "settings": "Settings"
+  },
+  "search": {
+    "heading": "Search Indexers",
+    "placeholder": "Title, author, or keyword…",
+    "submit": "Search",
+    "searching": "Searching…",
+    "noResults": "No results — try a different query or check your indexer configuration.",
+    "resultCount": "{{count}} results",
+    "grab": "Grab",
+    "grabbing": "Grabbing…",
+    "grabbed": "Grabbed"
   },
   "login": {
     "title": "Sign in",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -40,7 +40,8 @@
     "series": "Séries",
     "discover": "Discover",
     "blocklist": "Liste de blocage",
-    "settings": "Paramètres"
+    "settings": "Paramètres",
+    "search": "Search"
   },
   "login": {
     "title": "Connexion",
@@ -119,7 +120,6 @@
     "statusImported": "En bibliothèque",
     "statusSkipped": "Ignoré",
     "audioLabel": "🎧 Audio",
-    "download": "Télécharger",
     "downloadFile": "Télécharger le fichier",
     "setEbook": "📖 Définir livre numérique",
     "setAudiobook": "🎧 Définir livre audio",
@@ -393,5 +393,16 @@
       "coldStart": "Add more books to unlock personalized genre recommendations.",
       "goToSettings": "Go to Settings"
     }
+  },
+  "search": {
+    "heading": "Search Indexers",
+    "placeholder": "Title, author, or keyword…",
+    "submit": "Search",
+    "searching": "Searching…",
+    "noResults": "No results — try a different query or check your indexer configuration.",
+    "resultCount": "{{count}} results",
+    "grab": "Grab",
+    "grabbing": "Grabbing…",
+    "grabbed": "Grabbed"
   }
 }

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -40,7 +40,8 @@
     "series": "Reeksen",
     "discover": "Discover",
     "blocklist": "Blokkeerlijst",
-    "settings": "Instellingen"
+    "settings": "Instellingen",
+    "search": "Search"
   },
   "login": {
     "title": "Inloggen",
@@ -119,7 +120,6 @@
     "statusImported": "In bibliotheek",
     "statusSkipped": "Overgeslagen",
     "audioLabel": "🎧 Audio",
-    "download": "Downloaden",
     "downloadFile": "Bestand downloaden",
     "setEbook": "📖 Instellen als e-boek",
     "setAudiobook": "🎧 Instellen als luisterboek",
@@ -393,5 +393,16 @@
       "coldStart": "Add more books to unlock personalized genre recommendations.",
       "goToSettings": "Go to Settings"
     }
+  },
+  "search": {
+    "heading": "Search Indexers",
+    "placeholder": "Title, author, or keyword…",
+    "submit": "Search",
+    "searching": "Searching…",
+    "noResults": "No results — try a different query or check your indexer configuration.",
+    "resultCount": "{{count}} results",
+    "grab": "Grab",
+    "grabbing": "Grabbing…",
+    "grabbed": "Grabbed"
   }
 }

--- a/web/src/pages/SearchPage.tsx
+++ b/web/src/pages/SearchPage.tsx
@@ -1,0 +1,130 @@
+import { useState, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api, SearchResult } from '../api/client'
+
+function formatSize(n: number): string {
+  if (!n || n <= 0) return ''
+  if (n >= 1073741824) return (n / 1073741824).toFixed(1) + ' GB'
+  if (n >= 1048576) return (n / 1048576).toFixed(0) + ' MB'
+  return (n / 1024).toFixed(0) + ' KB'
+}
+
+export default function SearchPage() {
+  const { t } = useTranslation()
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchResult[] | null>(null)
+  const [searching, setSearching] = useState(false)
+  const [grabbing, setGrabbing] = useState<string | null>(null)
+  const [grabbed, setGrabbed] = useState<Set<string>>(new Set())
+  const [error, setError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const search = async () => {
+    const q = query.trim()
+    if (!q) return
+    setSearching(true)
+    setError(null)
+    setResults(null)
+    try {
+      const r = await api.searchIndexers(q)
+      setResults(r)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Search failed')
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  const grab = async (r: SearchResult) => {
+    setGrabbing(r.guid)
+    setError(null)
+    try {
+      await api.grab({
+        guid: r.guid,
+        title: r.title,
+        nzbUrl: r.nzbUrl,
+        size: r.size,
+        protocol: r.protocol,
+      })
+      setGrabbed(prev => new Set(prev).add(r.guid))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Grab failed')
+    } finally {
+      setGrabbing(null)
+    }
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <h2 className="text-xl font-bold mb-6">{t('search.heading')}</h2>
+
+      <form
+        onSubmit={e => { e.preventDefault(); search() }}
+        className="flex gap-2 mb-6"
+      >
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          placeholder={t('search.placeholder')}
+          className="flex-1 bg-slate-100 dark:bg-zinc-900 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-500"
+          autoFocus
+        />
+        <button
+          type="submit"
+          disabled={searching || !query.trim()}
+          className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded text-sm font-medium"
+        >
+          {searching ? t('search.searching') : t('search.submit')}
+        </button>
+      </form>
+
+      {error && (
+        <div className="mb-4 px-3 py-2 bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300 rounded text-sm">
+          {error}
+        </div>
+      )}
+
+      {results !== null && results.length === 0 && (
+        <div className="text-center py-10 text-sm text-slate-500 dark:text-zinc-500 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+          {t('search.noResults')}
+        </div>
+      )}
+
+      {results !== null && results.length > 0 && (
+        <div>
+          <p className="text-xs text-slate-500 dark:text-zinc-500 mb-2">{t('search.resultCount', { count: results.length })}</p>
+          <div className="space-y-1">
+            {results.map(r => (
+              <div
+                key={r.guid}
+                className="flex items-center justify-between p-2 border border-slate-200 dark:border-zinc-800 rounded bg-slate-100 dark:bg-zinc-900 text-xs"
+              >
+                <div className="min-w-0 mr-3">
+                  <span className="truncate block text-slate-800 dark:text-zinc-200">{r.title}</span>
+                  <span className="text-slate-500 dark:text-zinc-500 truncate block">
+                    {r.indexerName}{r.size ? ` · ${formatSize(r.size)}` : ''}{r.grabs ? ` · ${r.grabs} grabs` : ''}
+                    {r.language && <span className="ml-2 uppercase">{r.language}</span>}
+                  </span>
+                </div>
+                {grabbed.has(r.guid) ? (
+                  <span className="px-3 py-2 text-emerald-600 dark:text-emerald-400 text-[11px] font-medium flex-shrink-0">
+                    {t('search.grabbed')}
+                  </span>
+                ) : (
+                  <button
+                    onClick={() => grab(r)}
+                    disabled={grabbing !== null}
+                    className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded text-[11px] font-medium flex-shrink-0"
+                  >
+                    {grabbing === r.guid ? t('search.grabbing') : t('search.grab')}
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #85

## What this does

Adds a **Search** nav item and `/search` route. Users can now type a title, author, or keyword and search all enabled indexers directly — no need to add an author first. Results show with a Grab button; grabbed items are marked inline so you can grab multiple from one query.

The backend was already complete — `GET /api/v1/indexer/search?q=` and `api.searchIndexers()` in the client both existed. This PR wires them into a dedicated page.

## Changes

- `web/src/pages/SearchPage.tsx` — new page (search input, results list, grab flow)
- `web/src/App.tsx` — Search added to `NAV_KEYS` and routes
- `web/src/i18n/locales/` — `nav.search` and `search.*` strings for en/fr/de/nl

## Test plan

- [ ] Search page appears in nav
- [ ] Typing a title and hitting Search returns results from configured indexers
- [ ] Grab button sends the download to the active download client
- [ ] Grabbed items show "Grabbed" and button disappears
- [ ] 0 results shows the no-results message
- [ ] `npx tsc --noEmit` passes