### PR TITLE
feat: add {ASIN} naming token and ASIN-aware library scan

### DIFF
--- a/internal/importer/parser.go
+++ b/internal/importer/parser.go
@@ -11,6 +11,7 @@ type ParsedFile struct {
 	Title    string
 	Author   string
 	ISBN     string
+	ASIN     string
 	Year     string
 	Format   string // epub, mobi, pdf, etc.
 	FilePath string
@@ -21,6 +22,8 @@ var (
 	isbnRe = regexp.MustCompile(`(?:978|979)[-\s]?\d[-\s]?\d[-\s]?\d[-\s]?\d[-\s]?\d[-\s]?\d[-\s]?\d[-\s]?\d[-\s]?\d[-\s]?\d`)
 	// ISBN-10 pattern
 	isbn10Re = regexp.MustCompile(`\b\d{9}[\dXx]\b`)
+	// ASIN pattern: 10-char alphanumeric starting with B (Amazon identifier)
+	asinRe = regexp.MustCompile(`\bB[0-9A-Z]{9}\b`)
 	// Year pattern
 	yearRe = regexp.MustCompile(`\b(19|20)\d{2}\b`)
 	// Common separator patterns: "Title - Author" (spaces required around dash), "Title by Author"
@@ -53,6 +56,12 @@ func ParseFilename(path string) ParsedFile {
 	// Work with the base name without extension
 	name := filepath.Base(path)
 	name = strings.TrimSuffix(name, filepath.Ext(name))
+
+	// Extract ASIN if present and strip it so it doesn't pollute the title
+	if asin := asinRe.FindString(name); asin != "" {
+		p.ASIN = asin
+		name = strings.TrimSpace(asinRe.ReplaceAllString(name, " "))
+	}
 
 	// Extract ISBN if present
 	if isbn := isbnRe.FindString(name); isbn != "" {

--- a/internal/importer/parser_test.go
+++ b/internal/importer/parser_test.go
@@ -8,6 +8,7 @@ func TestParseFilename(t *testing.T) {
 		wantTitle  string
 		wantAuthor string
 		wantISBN   string
+		wantASIN   string
 		wantFormat string
 	}{
 		{
@@ -45,6 +46,21 @@ func TestParseFilename(t *testing.T) {
 			wantTitle:  "audiobook",
 			wantFormat: "m4b",
 		},
+		{
+			// ASIN in filename should be extracted and not pollute the title
+			input:      "The Sparrow B01LVSUORS - Mary Doria Russell.epub",
+			wantTitle:  "The Sparrow",
+			wantAuthor: "Mary Doria Russell",
+			wantASIN:   "B01LVSUORS",
+			wantFormat: "epub",
+		},
+		{
+			// Bare ASIN as the whole filename
+			input:      "B09H42KSJF.azw3",
+			wantTitle:  "",
+			wantASIN:   "B09H42KSJF",
+			wantFormat: "azw3",
+		},
 	}
 
 	for _, tt := range tests {
@@ -58,6 +74,9 @@ func TestParseFilename(t *testing.T) {
 			}
 			if tt.wantISBN != "" && p.ISBN != tt.wantISBN {
 				t.Errorf("isbn: got %q, want %q", p.ISBN, tt.wantISBN)
+			}
+			if tt.wantASIN != "" && p.ASIN != tt.wantASIN {
+				t.Errorf("asin: got %q, want %q", p.ASIN, tt.wantASIN)
 			}
 			if p.Format != tt.wantFormat {
 				t.Errorf("format: got %q, want %q", p.Format, tt.wantFormat)

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -66,6 +66,7 @@ func (r *Renamer) apply(template string, author *models.Author, book *models.Boo
 	result = strings.ReplaceAll(result, "{SortAuthor}", sanitizePath(authorSortName(authorName)))
 	result = strings.ReplaceAll(result, "{Title}", sanitizePath(book.Title))
 	result = strings.ReplaceAll(result, "{Year}", year)
+	result = strings.ReplaceAll(result, "{ASIN}", sanitizePath(book.ASIN))
 	result = strings.ReplaceAll(result, "{ext}", ext)
 	return result
 }

--- a/internal/importer/renamer_test.go
+++ b/internal/importer/renamer_test.go
@@ -66,6 +66,36 @@ func stringContains(s, sub string) bool {
 	return false
 }
 
+func TestRenamerASINToken(t *testing.T) {
+	r := NewRenamer("{Author}/{ASIN} - {Title}.{ext}")
+	releaseDate := time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)
+	author := &models.Author{Name: "Mary Doria Russell"}
+	book := &models.Book{
+		Title:       "The Sparrow",
+		ASIN:        "B01LVSUORS",
+		ReleaseDate: &releaseDate,
+	}
+
+	got := r.DestPath("/books", author, book, "book.epub")
+	want := filepath.Join("/books", "Mary Doria Russell", "B01LVSUORS - The Sparrow.epub")
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestRenamerASINTokenEmpty(t *testing.T) {
+	// {ASIN} with no ASIN on the book should produce an empty segment
+	r := NewRenamer("{ASIN}/{Title}.{ext}")
+	author := &models.Author{Name: "Author"}
+	book := &models.Book{Title: "Some Book"}
+
+	got := r.DestPath("/books", author, book, "book.epub")
+	want := filepath.Join("/books", "Some Book.epub")
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
 func TestMoveFile(t *testing.T) {
 	// Create temp source file
 	tmpDir := t.TempDir()

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -960,10 +960,29 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 			}
 		}
 
-		// Search existing books for a title + author match
+		// Search existing books for a match: ASIN takes priority over fuzzy title+author.
 		matched := false
-		if parsed.Title != "" {
-			detectedFmt := detectDownloadFormat([]string{path})
+		detectedFmt := detectDownloadFormat([]string{path})
+		if parsed.ASIN != "" {
+			for _, b := range allBooks {
+				if reconciledBooks[b.ID] {
+					continue
+				}
+				if b.Status == models.BookStatusWanted && b.ASIN == parsed.ASIN {
+					if err := s.books.SetFormatFilePath(ctx, b.ID, detectedFmt, path); err != nil {
+						slog.Error("library scan: failed to update book", "id", b.ID, "error", err)
+						continue
+					}
+					slog.Info("library scan: reconciled book via ASIN", "asin", parsed.ASIN, "title", b.Title, "path", path)
+					trackedPaths[cleanPath] = true
+					reconciledBooks[b.ID] = true
+					reconciled++
+					matched = true
+					break
+				}
+			}
+		}
+		if !matched && parsed.Title != "" {
 			for _, b := range allBooks {
 				if reconciledBooks[b.ID] {
 					continue


### PR DESCRIPTION
Closes #264.

## What

Two distinct problems reported in #264 are fixed together:

1. **`{ASIN}` was not a naming token** — users who store Kindle files by ASIN (e.g. under `{Author}/{ASIN}/`) had no way to build that path. `{ASIN}` now works alongside `{Author}`, `{Title}`, `{Year}`, etc.

2. **ASIN in filenames confused title extraction** — a file like `The Sparrow B01LVSUORS - Mary Doria Russell.epub` would pass `B01LVSUORS` through to the title matcher, causing the library scan to fail to reconcile it.

## Changes

**`internal/importer/parser.go`**
- Add `ASIN string` field to `ParsedFile`
- Add `asinRe` regex (`\bB[0-9A-Z]{9}\b`)
- Extract and strip the ASIN *before* title/author parsing so it doesn't pollute the title

**`internal/importer/renamer.go`**
- Add `{ASIN}` substitution in `apply()` — maps to `book.ASIN`, degrades to empty string when the book has no ASIN

**`internal/importer/scanner.go`**
- In the library-scan reconcile loop, try exact ASIN equality *before* fuzzy title+author matching — files named with a bare ASIN (`B09H42KSJF.azw3`) now match correctly

## Tests

- `TestParseFilename`: two new cases (ASIN inline with title/author, bare ASIN filename)
- `TestRenamerASINToken`: verifies `{ASIN}` substitution with a real ASIN
- `TestRenamerASINTokenEmpty`: verifies graceful degradation when `book.ASIN == ""`
- All existing tests pass (`go test ./...`)