### PR TITLE
security: auth hardening (F-H1, F-H2, B-M3)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -318,6 +318,7 @@ func main() {
 
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(auth.Middleware(authProvider))
+		r.Use(auth.RequireXRequestedWith)
 
 		// System
 		r.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
@@ -550,7 +551,7 @@ func main() {
 	opdsBuilder := opds.NewBuilder(opds.Config{Title: "Bindery", PageSize: 50}, bookRepo, authorRepo, seriesRepo)
 	opdsHandler := api.NewOPDSHandler(opdsBuilder, bookRepo, fileHandler)
 	r.Route("/opds", func(r chi.Router) {
-		r.Use(api.OPDSAuth(authProvider, userRepo))
+		r.Use(api.OPDSAuth(authProvider, userRepo, loginLimiter))
 		r.Get("/", opdsHandler.Root)
 		r.Get("/authors", opdsHandler.Authors)
 		r.Get("/authors/{id}", opdsHandler.Author)

--- a/internal/api/import_lists.go
+++ b/internal/api/import_lists.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -108,11 +109,12 @@ func (h *ImportListHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 // HardcoverLists returns the authenticated user's Hardcover reading lists.
-// GET /api/v1/importlist/hardcover/lists?token=<tok>
+// GET /api/v1/importlist/hardcover/lists  (Authorization: Bearer <tok>)
 func (h *ImportListHandler) HardcoverLists(w http.ResponseWriter, r *http.Request) {
-	token := r.URL.Query().Get("token")
-	if token == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "token query parameter required"})
+	authHeader := r.Header.Get("Authorization")
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+	if token == "" || token == authHeader {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing authorization header"})
 		return
 	}
 	client := hardcover.NewAuthenticated(token)

--- a/internal/api/opds_auth.go
+++ b/internal/api/opds_auth.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 
@@ -22,7 +23,7 @@ import (
 //
 // The realm ("Bindery OPDS") is what shows in the client's credential
 // prompt; keep it descriptive so users know which server is asking.
-func OPDSAuth(p auth.Provider, users *db.UserRepo) func(http.Handler) http.Handler {
+func OPDSAuth(p auth.Provider, users *db.UserRepo, limiter *auth.LoginLimiter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			mode := p.Mode()
@@ -46,10 +47,22 @@ func OPDSAuth(p auth.Provider, users *db.UserRepo) func(http.Handler) http.Handl
 				}
 			}
 			if username, password, ok := r.BasicAuth(); ok && users != nil {
+				ip := opdsClientIP(r)
+				if limiter != nil && !limiter.Allow(ip) {
+					w.Header().Set("WWW-Authenticate", `Basic realm="Bindery OPDS"`)
+					http.Error(w, "too many attempts", http.StatusTooManyRequests)
+					return
+				}
 				u, err := users.GetByUsername(r.Context(), strings.TrimSpace(username))
 				if err == nil && u != nil && auth.VerifyPassword(password, u.PasswordHash) {
+					if limiter != nil {
+						limiter.Reset(ip)
+					}
 					next.ServeHTTP(w, r)
 					return
+				}
+				if limiter != nil {
+					limiter.Record(ip)
 				}
 			}
 
@@ -62,6 +75,14 @@ func OPDSAuth(p auth.Provider, users *db.UserRepo) func(http.Handler) http.Handl
 			}
 		})
 	}
+}
+
+func opdsClientIP(r *http.Request) string {
+	host := r.RemoteAddr
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return strings.Trim(host, "[]")
 }
 
 func opdsAPIKey(r *http.Request) string {

--- a/internal/api/opds_test.go
+++ b/internal/api/opds_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -79,7 +80,7 @@ func opdsFixture(t *testing.T) (*chi.Mux, *db.UserRepo, *db.SettingsRepo, string
 
 	r := chi.NewRouter()
 	r.Route("/opds", func(r chi.Router) {
-		r.Use(OPDSAuth(p, users))
+		r.Use(OPDSAuth(p, users, auth.NewLoginLimiter(5, 15*time.Minute)))
 		r.Get("/", h.Root)
 		r.Get("/authors", h.Authors)
 		r.Get("/authors/{id}", h.Author)

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -125,6 +125,26 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 	}
 }
 
+// RequireXRequestedWith rejects non-GET/HEAD requests that lack the custom
+// CSRF header. Browsers cannot set this header in cross-site requests, so a
+// CSRF attacker cannot cause a mutating request to be accepted even if the
+// session cookie rides along via SameSite=Lax.
+func RequireXRequestedWith(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			// safe methods — pass through
+		default:
+			if r.Header.Get("X-Requested-With") != "bindery-ui" {
+				w.Header().Set("Content-Type", "application/json")
+				http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func requestAPIKey(r *http.Request) string {
 	if k := r.Header.Get("X-Api-Key"); k != "" {
 		return k

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6,10 +6,19 @@ const BASE = '/api/v1'
 const PUBLIC_PATHS = new Set(['/login', '/setup'])
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  // Merge caller-supplied headers on top of the defaults so we can't lose
+  // the CSRF header if a caller passes their own `headers`.
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    'X-Requested-With': 'bindery-ui',
+  })
+  if (options?.headers) {
+    new Headers(options.headers).forEach((v, k) => headers.set(k, v))
+  }
   const res = await fetch(`${BASE}${path}`, {
     credentials: 'include', // send + accept the session cookie
-    headers: { 'Content-Type': 'application/json' },
     ...options,
+    headers,
   })
   if (res.status === 401 && !PUBLIC_PATHS.has(window.location.pathname)) {
     // Session expired or missing — punt to login. The router there will
@@ -233,7 +242,10 @@ export const api = {
   addImportList: (data: Partial<ImportList>) => request<ImportList>('/importlist', { method: 'POST', body: JSON.stringify(data) }),
   updateImportList: (id: number, data: Partial<ImportList>) => request<ImportList>(`/importlist/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   deleteImportList: (id: number) => request<void>(`/importlist/${id}`, { method: 'DELETE' }),
-  hardcoverLists: (token: string) => request<HardcoverList[]>(`/importlist/hardcover/lists?token=${encodeURIComponent(token)}`),
+  hardcoverLists: (token: string) =>
+    request<HardcoverList[]>('/importlist/hardcover/lists', {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
 
   // Metadata Profiles
   listMetadataProfiles: () => request<MetadataProfile[]>('/metadataprofile'),


### PR DESCRIPTION
## Security fixes

- **F-H1**: All state-changing API requests require `X-Requested-With: bindery-ui` header; server enforces on `/api/v1` subrouter
- **F-H2**: Hardcover API token moved from URL query parameter to `Authorization: Bearer` request header
- **B-M3**: OPDS Basic-auth endpoint now goes through the login rate limiter (was unbounded before)

Ref: security audit findings