### PR TITLE
security: backend hardening (B-H1, B-H2, B-H3, B-L1)

### DIFF
--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -9,11 +9,17 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 )
+
+// backupFilenameRe matches files produced by Create — "bindery_YYYYMMDD_HHMMSS.db".
+// Restore/Delete reject anything else so path-traversal tricks like "..%2Fetc"
+// or unrelated files under the backup dir can't be referenced by untrusted input.
+var backupFilenameRe = regexp.MustCompile(`^bindery_\d{8}_\d{6}\.db$`)
 
 type BackupHandler struct {
 	dbPath  string
@@ -103,8 +109,8 @@ func (h *BackupHandler) Create(w http.ResponseWriter, r *http.Request) {
 // Restore copies a backup file back to the DB path. Dangerous — requires confirmation header.
 func (h *BackupHandler) Restore(w http.ResponseWriter, r *http.Request) {
 	filename := chi.URLParam(r, "filename")
-	if filename == "" || strings.Contains(filename, "/") || strings.Contains(filename, "..") {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid filename"})
+	if !backupFilenameRe.MatchString(filename) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid backup filename"})
 		return
 	}
 
@@ -134,8 +140,8 @@ func (h *BackupHandler) Restore(w http.ResponseWriter, r *http.Request) {
 // Delete removes a backup file.
 func (h *BackupHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	filename := chi.URLParam(r, "filename")
-	if filename == "" || strings.Contains(filename, "/") || strings.Contains(filename, "..") {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid filename"})
+	if !backupFilenameRe.MatchString(filename) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid backup filename"})
 		return
 	}
 

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -39,8 +39,22 @@ type ImageProxyHandler struct {
 // <dataDir>/image-cache/.
 func NewImageProxyHandler(dataDir string) *ImageProxyHandler {
 	h := &ImageProxyHandler{
-		cacheDir:    filepath.Join(dataDir, "image-cache"),
-		client:      &http.Client{Timeout: 15 * time.Second},
+		cacheDir: filepath.Join(dataDir, "image-cache"),
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+			// Re-validate redirect targets — a permissive upstream could otherwise
+			// redirect from a public host into the LAN (cloud metadata, internal
+			// services) and leak the body back through the cache.
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if err := httpsec.ValidateOutboundURL(req.URL.String(), httpsec.PolicyStrict); err != nil {
+					return fmt.Errorf("redirect blocked: %w", err)
+				}
+				if len(via) >= 5 {
+					return fmt.Errorf("too many redirects")
+				}
+				return nil
+			},
+		},
 		validateURL: func(u string) error { return httpsec.ValidateOutboundURL(u, httpsec.PolicyStrict) },
 	}
 	go h.migrateFlatCache()

--- a/internal/api/prowlarr.go
+++ b/internal/api/prowlarr.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/prowlarr"
 )
@@ -63,6 +64,10 @@ func (h *ProwlarrHandler) Create(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "url is required"})
 		return
 	}
+	if err := httpsec.ValidateOutboundURL(p.URL, httpsec.PolicyLAN); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid indexer URL: " + err.Error()})
+		return
+	}
 	if p.Name == "" {
 		p.Name = "Prowlarr"
 	}
@@ -93,6 +98,10 @@ func (h *ProwlarrHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	existing.ID = id
+	if err := httpsec.ValidateOutboundURL(existing.URL, httpsec.PolicyLAN); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid indexer URL: " + err.Error()})
+		return
+	}
 	if err := h.instances.Update(r.Context(), existing); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return

--- a/internal/importer/helpers_test.go
+++ b/internal/importer/helpers_test.go
@@ -18,7 +18,10 @@ func TestAudiobookDestDir(t *testing.T) {
 	author := &models.Author{Name: "Ursula K. Le Guin"}
 	book := &models.Book{Title: "The Dispossessed", ReleaseDate: &releaseDate}
 
-	got := r.AudiobookDestDir("/audio", author, book)
+	got, err := r.AudiobookDestDir("/audio", author, book)
+	if err != nil {
+		t.Fatalf("AudiobookDestDir: %v", err)
+	}
 	want := filepath.Join("/audio", "Ursula K. Le Guin", "The Dispossessed (2020)")
 	if got != want {
 		t.Errorf("got  %q\nwant %q", got, want)
@@ -30,7 +33,10 @@ func TestAudiobookDestDir_NilAuthor(t *testing.T) {
 	// still land under a predictable folder rather than panicking.
 	r := NewRenamer("")
 	book := &models.Book{Title: "Mystery"}
-	got := r.AudiobookDestDir("/audio", nil, book)
+	got, err := r.AudiobookDestDir("/audio", nil, book)
+	if err != nil {
+		t.Fatalf("AudiobookDestDir: %v", err)
+	}
 	want := filepath.Join("/audio", "Unknown Author", "Mystery ()")
 	if got != want {
 		t.Errorf("got %q want %q", got, want)
@@ -41,7 +47,10 @@ func TestAudiobookDestDir_CustomTemplate(t *testing.T) {
 	r := NewRenamerWithAudiobook("", "Audiobooks/{SortAuthor}/{Title}")
 	author := &models.Author{Name: "Andy Weir"}
 	book := &models.Book{Title: "Project Hail Mary"}
-	got := r.AudiobookDestDir("/root", author, book)
+	got, err := r.AudiobookDestDir("/root", author, book)
+	if err != nil {
+		t.Fatalf("AudiobookDestDir: %v", err)
+	}
 	want := filepath.Join("/root", "Audiobooks", "Weir, Andy", "Project Hail Mary")
 	if got != want {
 		t.Errorf("got %q want %q", got, want)

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -40,16 +40,30 @@ func NewRenamerWithAudiobook(ebookTemplate, audiobookTemplate string) *Renamer {
 }
 
 // DestPath computes the destination path for an ebook file.
-func (r *Renamer) DestPath(rootFolder string, author *models.Author, book *models.Book, srcPath string) string {
+func (r *Renamer) DestPath(rootFolder string, author *models.Author, book *models.Book, srcPath string) (string, error) {
 	ext := strings.TrimPrefix(filepath.Ext(srcPath), ".")
-	return filepath.Join(rootFolder, r.apply(r.template, author, book, ext))
+	dest := filepath.Join(rootFolder, r.apply(r.template, author, book, ext))
+	return ensureContained(dest, rootFolder)
 }
 
 // AudiobookDestDir computes the destination directory into which an audiobook
 // download folder should be moved. The download's internal file structure is
 // preserved inside (multi-part m4b/mp3 + cover + cue sheet stay together).
-func (r *Renamer) AudiobookDestDir(rootFolder string, author *models.Author, book *models.Book) string {
-	return filepath.Join(rootFolder, r.apply(r.audiobookTemplate, author, book, ""))
+func (r *Renamer) AudiobookDestDir(rootFolder string, author *models.Author, book *models.Book) (string, error) {
+	dest := filepath.Join(rootFolder, r.apply(r.audiobookTemplate, author, book, ""))
+	return ensureContained(dest, rootFolder)
+}
+
+// ensureContained returns dest unchanged when it resolves inside baseDir; otherwise
+// it returns an error. This prevents book-derived path components (e.g. author or
+// title strings seeded from remote metadata) from escaping the configured library.
+func ensureContained(dest, baseDir string) (string, error) {
+	cleanDest := filepath.Clean(dest)
+	cleanBase := filepath.Clean(baseDir)
+	if !strings.HasPrefix(cleanDest, cleanBase+string(filepath.Separator)) && cleanDest != cleanBase {
+		return "", fmt.Errorf("destination path escapes base directory")
+	}
+	return cleanDest, nil
 }
 
 func (r *Renamer) apply(template string, author *models.Author, book *models.Book, ext string) string {
@@ -360,7 +374,23 @@ func sanitizePath(s string) string {
 		"/", "-", "\\", "-", ":", "-", "*", "", "?", "",
 		"\"", "", "<", "", ">", "", "|", "",
 	)
-	return strings.TrimSpace(replacer.Replace(s))
+	cleaned := strings.TrimSpace(replacer.Replace(s))
+	// Strip traversal components (".", "..", empties) so a single field can't
+	// contribute a segment that walks out of the library root even after
+	// character replacement.
+	parts := strings.Split(cleaned, string(filepath.Separator))
+	kept := parts[:0]
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || p == "." || p == ".." {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	if len(kept) == 0 {
+		return ""
+	}
+	return strings.Join(kept, string(filepath.Separator))
 }
 
 func authorSortName(name string) string {

--- a/internal/importer/renamer_test.go
+++ b/internal/importer/renamer_test.go
@@ -19,7 +19,10 @@ func TestRenamerDestPath(t *testing.T) {
 		ReleaseDate: &releaseDate,
 	}
 
-	got := r.DestPath("/books", author, book, "/downloads/complete/something.epub")
+	got, err := r.DestPath("/books", author, book, "/downloads/complete/something.epub")
+	if err != nil {
+		t.Fatalf("DestPath: %v", err)
+	}
 	want := filepath.Join("/books", "Test Author", "Dark Matter (2016)", "Dark Matter - Test Author.epub")
 	if got != want {
 		t.Errorf("got  %q\nwant %q", got, want)
@@ -31,7 +34,10 @@ func TestRenamerNoYear(t *testing.T) {
 	author := &models.Author{Name: "Author"}
 	book := &models.Book{Title: "Book Title"}
 
-	got := r.DestPath("/lib", author, book, "file.pdf")
+	got, err := r.DestPath("/lib", author, book, "file.pdf")
+	if err != nil {
+		t.Fatalf("DestPath: %v", err)
+	}
 	want := filepath.Join("/lib", "Author", "Book Title ()", "Book Title - Author.pdf")
 	if got != want {
 		t.Errorf("got  %q\nwant %q", got, want)
@@ -43,7 +49,10 @@ func TestRenamerSanitizesPath(t *testing.T) {
 	author := &models.Author{Name: "Author: Bad/Name"}
 	book := &models.Book{Title: "Title? With <Bad> Chars"}
 
-	got := r.DestPath("/lib", author, book, "test.epub")
+	got, err := r.DestPath("/lib", author, book, "test.epub")
+	if err != nil {
+		t.Fatalf("DestPath: %v", err)
+	}
 	// Verify path doesn't contain dangerous characters in the filename portion
 	base := filepath.Base(got)
 	for _, bad := range []string{":", "?", "<", ">"} {
@@ -76,7 +85,10 @@ func TestRenamerASINToken(t *testing.T) {
 		ReleaseDate: &releaseDate,
 	}
 
-	got := r.DestPath("/books", author, book, "book.epub")
+	got, err := r.DestPath("/books", author, book, "book.epub")
+	if err != nil {
+		t.Fatalf("DestPath: %v", err)
+	}
 	want := filepath.Join("/books", "Mary Doria Russell", "B01LVSUORS - The Sparrow.epub")
 	if got != want {
 		t.Errorf("got  %q\nwant %q", got, want)
@@ -89,7 +101,10 @@ func TestRenamerASINTokenEmpty(t *testing.T) {
 	author := &models.Author{Name: "Author"}
 	book := &models.Book{Title: "Some Book"}
 
-	got := r.DestPath("/books", author, book, "book.epub")
+	got, err := r.DestPath("/books", author, book, "book.epub")
+	if err != nil {
+		t.Fatalf("DestPath: %v", err)
+	}
 	want := filepath.Join("/books", "Some Book.epub")
 	if got != want {
 		t.Errorf("got  %q\nwant %q", got, want)

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -542,7 +542,13 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		if effLib := s.effectiveLibraryDir(ctx, author); effLib != s.libraryDir {
 			audiobookRoot = effLib
 		}
-		destDir := UniqueDir(s.renamer.AudiobookDestDir(audiobookRoot, author, book))
+		audiobookDest, destErr := s.renamer.AudiobookDestDir(audiobookRoot, author, book)
+		if destErr != nil {
+			slog.Error("failed to compute audiobook destination", "src", downloadPath, "error", destErr)
+			s.failImport(ctx, dl, models.StateImportBlocked, fmt.Sprintf("audiobook destination invalid: %v", destErr))
+			return
+		}
+		destDir := UniqueDir(audiobookDest)
 		mode := s.importMode(ctx)
 		slog.Info("importing audiobook folder", "src", downloadPath, "dst", destDir, "mode", mode)
 		// Single-file audiobook releases (e.g. a lone .m4b from a torrent) give
@@ -618,7 +624,13 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			continue
 		}
 
-		destPath := s.renamer.DestPath(s.effectiveLibraryDir(ctx, author), author, book, srcFile)
+		destPath, destErr := s.renamer.DestPath(s.effectiveLibraryDir(ctx, author), author, book, srcFile)
+		if destErr != nil {
+			slog.Error("failed to compute book destination", "src", srcFile, "error", destErr)
+			lastFileErr = destErr
+			failed++
+			continue
+		}
 		mode := s.importMode(ctx)
 		slog.Info("importing book", "src", srcFile, "dst", destPath, "mode", mode)
 


### PR DESCRIPTION
## Security fixes

- **B-H1**: Add httpsec.ValidateOutboundURL (PolicyLAN) to Prowlarr Create/Update handlers
- **B-H2**: sanitizePath now strips path traversal components; destination paths verified to stay within base dir
- **B-H3**: Backup restore/delete validate filename against strict regex instead of substring checks
- **B-L1**: Image proxy HTTP client re-validates redirect target URLs with PolicyStrict

Ref: security audit findings