### PR TITLE
security: gate X-Forwarded-For trust on BINDERY_TRUSTED_PROXY

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -43,6 +43,9 @@ env:
   # client into paths bindery can see. Needed when SAB and bindery run in
   # separate pods with different mount points for the same storage.
   BINDERY_DOWNLOAD_PATH_REMAP: /downloads:/media
+  # IP or CIDR of the reverse proxy in front of Bindery. When set, X-Forwarded-For
+  # is trusted only from that address. Required for local-only auth mode to be safe.
+  # BINDERY_TRUSTED_PROXY: "192.168.1.1"
 
 resources:
   requests:

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -306,7 +306,11 @@ func main() {
 	// Router
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
+	// BINDERY_TRUSTED_PROXY (optional): comma-separated IP/CIDR list of
+	// reverse proxies permitted to set X-Forwarded-For. When unset, XFF
+	// headers are ignored — required for local-only auth mode to be safe
+	// against on-network spoofing.
+	r.Use(trustedProxyMiddleware())
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Compress(5))
 	r.Use(api.SecurityHeaders)

--- a/cmd/bindery/proxy.go
+++ b/cmd/bindery/proxy.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// trustedProxyMiddleware returns a middleware that rewrites RemoteAddr from
+// X-Forwarded-For / X-Real-IP only when the direct peer is a configured
+// trusted proxy. Without a trusted proxy configured, forwarded headers are
+// ignored and the peer IP is used as-is — preventing XFF spoofing in
+// local-only auth mode.
+//
+// Configured via BINDERY_TRUSTED_PROXY: a comma-separated list of IPs or
+// CIDRs. Bare IPs are treated as /32 (IPv4) or /128 (IPv6).
+func trustedProxyMiddleware() func(http.Handler) http.Handler {
+	raw := os.Getenv("BINDERY_TRUSTED_PROXY")
+	if raw == "" {
+		// No trusted proxy — use peer IP as-is (safe default).
+		return func(next http.Handler) http.Handler { return next }
+	}
+
+	var trusted []*net.IPNet
+	for _, s := range strings.Split(raw, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if !strings.Contains(s, "/") {
+			if strings.Contains(s, ":") {
+				s += "/128"
+			} else {
+				s += "/32"
+			}
+		}
+		_, cidr, err := net.ParseCIDR(s)
+		if err != nil {
+			slog.Warn("BINDERY_TRUSTED_PROXY: invalid entry, skipping", "entry", s, "err", err)
+			continue
+		}
+		trusted = append(trusted, cidr)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			peerHost, _, _ := net.SplitHostPort(r.RemoteAddr)
+			peerIP := net.ParseIP(strings.Trim(peerHost, "[]"))
+			for _, cidr := range trusted {
+				if peerIP != nil && cidr.Contains(peerIP) {
+					middleware.RealIP(next).ServeHTTP(w, r)
+					return
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`chi.middleware.RealIP` was applied unconditionally, rewriting `RemoteAddr` from `X-Forwarded-For` for every request. This means an on-network attacker can set `X-Forwarded-For: 127.0.0.1` and bypass local-only auth mode — the same root cause as Sonarr CVE-2026-30975 (GHSA-h5qx-5hjf-7c9r, CVSS 8.1).

## Fix

Replace unconditional `middleware.RealIP` with a `trustedProxyMiddleware()` that only applies XFF rewriting when the direct peer IP matches `BINDERY_TRUSTED_PROXY` (a comma-separated IP/CIDR list).

**Default behaviour (no env var set):** forwarded headers are ignored; the peer IP is used as-is. This is safe for direct-access and single-hop deployments.

**With \`BINDERY_TRUSTED_PROXY=192.168.1.1\`:** XFF rewriting is applied only when the request arrives from that proxy. Operators behind nginx/Caddy/Traefik should set this to their proxy's LAN IP.

## Testing

- Without \`BINDERY_TRUSTED_PROXY\`: spoofed \`X-Forwarded-For\` headers are ignored.
- With \`BINDERY_TRUSTED_PROXY\` set to the proxy IP: legitimate forwarded IPs are honoured.