### PR TITLE
security: validate file download path against configured library roots

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -265,7 +265,7 @@ func main() {
 	importScanner.WithSettings(settingsRepo)
 	importScanner.WithRootFolders(rootFolderRepo)
 	libraryHandler := api.NewLibraryHandler(importScanner).WithSettings(settingsRepo)
-	fileHandler := api.NewFileHandler(bookRepo)
+	fileHandler := api.NewFileHandler(bookRepo, cfg.LibraryDir, cfg.AudiobookDir)
 	historyHandler := api.NewHistoryHandler(historyRepo, blocklistRepo)
 	blocklistHandler := api.NewBlocklistHandler(blocklistRepo)
 	notificationHandler := api.NewNotificationHandler(notificationRepo, notif)

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -15,11 +15,18 @@ import (
 )
 
 type FileHandler struct {
-	books *db.BookRepo
+	books        *db.BookRepo
+	allowedRoots []string
 }
 
-func NewFileHandler(books *db.BookRepo) *FileHandler {
-	return &FileHandler{books: books}
+func NewFileHandler(books *db.BookRepo, allowedRoots ...string) *FileHandler {
+	var roots []string
+	for _, r := range allowedRoots {
+		if r != "" {
+			roots = append(roots, filepath.Clean(r))
+		}
+	}
+	return &FileHandler{books: books, allowedRoots: roots}
 }
 
 // Download serves the book's content for browser download.
@@ -44,6 +51,14 @@ func (h *FileHandler) Download(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Defence-in-depth: refuse to serve paths that aren't under a configured
+	// library root, even if a tampered DB row or importer bug set FilePath
+	// to something outside the library (e.g. /etc/passwd, /config/*).
+	if !h.isAllowedPath(book.FilePath) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "access denied"})
+		return
+	}
+
 	info, err := os.Stat(book.FilePath)
 	if err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "file not found on disk"})
@@ -59,6 +74,28 @@ func (h *FileHandler) Download(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
 	w.Header().Set("Content-Length", strconv.FormatInt(info.Size(), 10))
 	http.ServeFile(w, r, book.FilePath)
+}
+
+// isAllowedPath reports whether p falls under one of the configured library
+// roots. Paths are compared after filepath.Clean so trailing slashes and
+// `..` traversal don't bypass the check. If no roots are configured the
+// handler falls back to allowing any path — this preserves behaviour for
+// installs that haven't set BINDERY_LIBRARY_DIR and for tests that wire
+// the handler without roots.
+func (h *FileHandler) isAllowedPath(p string) bool {
+	if len(h.allowedRoots) == 0 {
+		return true
+	}
+	p = filepath.Clean(p)
+	for _, root := range h.allowedRoots {
+		if root == "" || root == "." {
+			continue
+		}
+		if p == root || strings.HasPrefix(p, root+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
 }
 
 // streamZip writes a zip archive of every regular file under srcDir to the


### PR DESCRIPTION
## Problem

`internal/api/files.go` called `http.ServeFile(w, r, book.FilePath)` with the raw path from the database, with no check that the path falls within a library directory. A tampered database entry or importer bug could cause the endpoint to serve arbitrary files readable by the process (e.g. `/etc/passwd`, config files).

## Fix

Add an `isAllowedPath` check on `FileHandler` that:
1. Cleans the path with `filepath.Clean`
2. Asserts it has a prefix matching one of the configured library roots (`BINDERY_LIBRARY_DIR`, `BINDERY_AUDIOBOOK_DIR`)
3. Returns 403 if no root matches

This is defence-in-depth on top of the importer's existing path validation.

## Impact

- No behaviour change for correctly-stored paths (all legitimate `FilePath` values are already under the library root)
- Paths outside configured roots → 403 instead of serving the file