### PR TITLE
fix: exempt API-key requests from CSRF header check

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -129,13 +129,17 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 // CSRF header. Browsers cannot set this header in cross-site requests, so a
 // CSRF attacker cannot cause a mutating request to be accepted even if the
 // session cookie rides along via SameSite=Lax.
+//
+// API-key-authenticated requests are exempt: CSRF requires a cookie to be the
+// authentication mechanism, so requests carrying an explicit API key are not
+// vulnerable and do not need the header.
 func RequireXRequestedWith(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet, http.MethodHead, http.MethodOptions:
 			// safe methods — pass through
 		default:
-			if r.Header.Get("X-Requested-With") != "bindery-ui" {
+			if requestAPIKey(r) == "" && r.Header.Get("X-Requested-With") != "bindery-ui" {
 				w.Header().Set("Content-Type", "application/json")
 				http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
 				return


### PR DESCRIPTION
## Problem

`RequireXRequestedWith` was enforcing `X-Requested-With: bindery-ui` on all non-GET mutations, including those authenticated via `X-Api-Key` or `?apikey=`. This broke the smoke test (`calibre_import_400s_when_library_unconfigured` got 403 instead of 400) and would also break any API/script integrations using key-based auth.

## Fix

Skip the CSRF header check when the request carries an API key. CSRF via the custom header is a defence for cookie-authenticated sessions only — API key auth is already CSRF-immune because the key must be explicitly supplied in the request.

## Behaviour after fix

| Auth method | Mutation without `X-Requested-With` |
|-------------|--------------------------------------|
| Cookie session | 403 Forbidden |
| API key (`X-Api-Key` / `?apikey=`) | Passes through (CSRF n/a) |