### PR TITLE
feat: polish Calibre Test connection feedback (#262)

### DIFF
--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1728,6 +1728,7 @@ function CalibreSection({
 
   const saveSettingWithError = async (key: string) => {
     setSaveError(null)
+    setTestResult(null)
     const err = await saveSetting(key)
     if (err) setSaveError({ key, msg: err })
   }
@@ -1819,11 +1820,16 @@ function CalibreSection({
   const runTest = async () => {
     setTesting(true)
     setTestResult(null)
+    const isPlugin = mode === 'plugin'
     try {
       const r = await api.testCalibre()
-      setTestResult({ ok: true, msg: `${r.message}${r.version ? ' — ' + r.version : ''}` })
+      const prefix = isPlugin ? '✓ Plugin reachable' : '✓ calibredb reachable'
+      const detail = r.version || r.message
+      setTestResult({ ok: true, msg: detail ? `${prefix} — ${detail}` : prefix })
     } catch (err) {
-      setTestResult({ ok: false, msg: err instanceof Error ? err.message : 'Test failed' })
+      const reason = err instanceof Error ? err.message : 'Test failed'
+      const prefix = isPlugin ? '✗ Could not reach plugin' : '✗ calibredb unreachable'
+      setTestResult({ ok: false, msg: `${prefix} — ${reason}` })
     } finally {
       setTesting(false)
     }


### PR DESCRIPTION
Fixes #262

## Summary

The Settings → Calibre section already had a Test connection button wired to `POST /api/v1/calibre/test`, but the feedback didn't match the format spelled out in #262 and stuck around after editing the URL / API key.

This PR brings the inline result in line with the issue:

- Prefixes success with `✓` and failure with `✗` so the outcome is legible at a glance.
- Leads the success line with `Plugin reachable` in plugin mode and `calibredb reachable` in calibredb mode, followed by the version string from the backend (`calibredb plugin v0.2.0 (Calibre 9.7.0)`).
- Leads the failure line with `Could not reach plugin` / `calibredb unreachable`, followed by the backend error (e.g. `connection refused`).
- Clears the stale test result as soon as the user saves any `calibre.*` field, so a stale green banner can't outlive the config it described.

## Test plan

- [ ] Settings → Calibre, plugin mode: click Test with valid URL/key → success banner matches spec.
- [ ] Same tab, bad URL or API key → red banner with reason.
- [ ] After a failed Test, edit plugin URL and click Save → banner clears.
- [ ] calibredb mode with a valid binary path → success banner reads `✓ calibredb reachable — …`.