### PR TITLE
fix: show friendly message when ISBN lookup returns no results

### DIFF
--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -71,7 +72,9 @@ func (h *SearchHandler) LookupByISBN(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if book == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no book found for ISBN"})
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"error": fmt.Sprintf("No book found for ISBN %s. Check the number, or try searching by title instead.", isbn),
+		})
 		return
 	}
 

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -5,6 +5,7 @@ package openlibrary
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,6 +17,11 @@ import (
 
 	"github.com/vavallee/bindery/internal/models"
 )
+
+// ErrNotFound signals a 404 from OpenLibrary. Callers use errors.Is to
+// distinguish "this ISBN/work doesn't exist in the catalog" from genuine
+// upstream failures so the UI can show a friendly message.
+var ErrNotFound = errors.New("not found")
 
 const (
 	baseURL   = "https://openlibrary.org"
@@ -343,6 +349,11 @@ func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, 
 	u := fmt.Sprintf("%s/isbn/%s.json", baseURL, isbn)
 	var resp isbnResponse
 	if err := c.getJSON(ctx, u, &resp); err != nil {
+		// Treat 404 as "no such ISBN" rather than an upstream error so the
+		// API layer can respond with a friendly message (issue #284).
+		if errors.Is(err, ErrNotFound) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("isbn lookup %s: %w", isbn, err)
 	}
 
@@ -381,6 +392,9 @@ func (c *Client) getJSON(ctx context.Context, rawURL string, target interface{})
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrNotFound
+	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -449,14 +449,20 @@ func TestGetBookByISBN_HTTP_FallbackNoWork(t *testing.T) {
 	}
 }
 
-func TestGetBookByISBN_HTTP_Error(t *testing.T) {
+// A 404 from OpenLibrary means "this ISBN is not in their catalog" — not an
+// upstream failure. GetBookByISBN returns (nil, nil) so the API layer can
+// respond with a user-friendly "no book found" message (see issue #284).
+func TestGetBookByISBN_HTTP_NotFound(t *testing.T) {
 	c := newClientWithStatus(t,
 		map[string]interface{}{"/isbn/0000000000.json": "not found"},
 		map[string]int{"/isbn/0000000000.json": http.StatusNotFound},
 	)
-	_, err := c.GetBookByISBN(context.Background(), "0000000000")
-	if err == nil {
-		t.Fatal("expected error on 404")
+	book, err := c.GetBookByISBN(context.Background(), "0000000000")
+	if err != nil {
+		t.Fatalf("expected nil error for 404, got %v", err)
+	}
+	if book != nil {
+		t.Fatalf("expected nil book for 404, got %+v", book)
 	}
 }
 


### PR DESCRIPTION
Fixes #284

## Root cause

When a user searches by an ISBN that is not in OpenLibrary's catalog, OL responds with HTTP 404. The OpenLibrary client wraps that as `isbn lookup <isbn>: HTTP 404: ...` and the API handler passes it through `writeUpstreamError`, which prefixes `"metadata provider unavailable: "`. The user sees:

> metadata provider unavailable: isbn lookup 9783458684367: HTTP 404: ...

That wording implies an outage when the real answer is simply "we don't know this ISBN."

## Fix

- Introduce an `ErrNotFound` sentinel in `internal/metadata/openlibrary` and map upstream 404s onto it.
- `GetBookByISBN` now translates `ErrNotFound` into `(nil, nil)` so the `LookupByISBN` handler's existing 404 branch fires instead of the upstream-error branch.
- Update that branch's message to include the ISBN value and nudge the user toward title search:
  > No book found for ISBN 9783458684367. Check the number, or try searching by title instead.
- Other upstream failures (5xx, timeouts, DNS) still flow through `writeUpstreamError` unchanged.

## Tests

- Renamed `TestGetBookByISBN_HTTP_Error` to `TestGetBookByISBN_HTTP_NotFound` and updated it to assert `(nil, nil)` on 404 (matches the new contract).
- `go test ./internal/metadata/openlibrary/ ./internal/api/` passes.