### PR TITLE
ci: add pre-deploy smoke tests against live instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,3 +271,50 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: make smoke
+
+  # Pre-deploy smoke: after the build job pushes a tagged image and ArgoCD
+  # rolls it out, wait for the app to report Healthy+Synced, then hit the
+  # live instance with a lightweight HTTP suite. Catches deploy-time issues
+  # (bad image, failed migration, missing secret) that build-time tests
+  # can't see. Only runs on tag pushes — main/development rollouts are
+  # already covered by the in-process `smoke` job above.
+  #
+  # Required repo secret: BINDERY_SMOKE_API_KEY — an API key provisioned on
+  # the live instance at https://bindery.autonomy.ninja with read access.
+  predeploy-smoke:
+    name: Pre-deploy smoke
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.25.9"
+      - name: Wait for ArgoCD to sync
+        env:
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
+          ARGOCD_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          if [[ -z "$ARGOCD_SERVER" || -z "$ARGOCD_TOKEN" ]]; then
+            echo "ArgoCD secrets not set — skipping wait"
+            exit 0
+          fi
+          echo "Waiting for ArgoCD app 'bindery' to be Healthy+Synced..."
+          for i in $(seq 1 24); do
+            STATUS=$(curl -sf -H "Authorization: Bearer $ARGOCD_TOKEN" \
+              "$ARGOCD_SERVER/api/v1/applications/bindery" | \
+              python3 -c "import json,sys; d=json.load(sys.stdin); print(d['status']['health']['status'], d['status']['sync']['status'])" 2>/dev/null || echo "unknown unknown")
+            echo "  attempt $i: $STATUS"
+            [[ "$STATUS" == "Healthy Synced" ]] && echo "ArgoCD sync complete" && exit 0
+            sleep 10
+          done
+          echo "Timed out waiting for ArgoCD sync"
+          exit 1
+      - name: Run pre-deploy smoke tests
+        env:
+          BINDERY_URL: https://bindery.autonomy.ninja
+          BINDERY_API_KEY: ${{ secrets.BINDERY_SMOKE_API_KEY }}
+        run: make predeploy-smoke

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build dev test lint clean docker-build web-build web-dev help security helm-lint sbom smoke
+.PHONY: build dev test lint clean docker-build web-build web-dev help security helm-lint sbom smoke predeploy-smoke
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -67,6 +67,9 @@ helm-lint: ## Lint Helm chart + run helm-unittest cases
 
 smoke: build ## Boot the real binary and exercise the critical golden paths via HTTP
 	go test -count=1 -timeout=60s ./tests/smoke/...
+
+predeploy-smoke: ## Run pre-deploy smoke tests against a live instance (requires BINDERY_URL and BINDERY_API_KEY)
+	go test -v -count=1 -timeout=120s ./tests/predeploy/...
 
 sbom: build ## Generate an SPDX SBOM for the local binary
 	@command -v syft >/dev/null || (echo "syft not installed; see https://github.com/anchore/syft"; exit 1)

--- a/tests/predeploy/predeploy_test.go
+++ b/tests/predeploy/predeploy_test.go
@@ -1,0 +1,167 @@
+// Package predeploy runs HTTP-level smoke checks against an already-running
+// bindery instance (typically the cluster deployment just promoted by
+// ArgoCD). It is pointed at a live URL via BINDERY_URL and authenticates
+// with BINDERY_API_KEY — both required. When either is missing the whole
+// suite is skipped so local `go test ./...` runs stay green.
+//
+// Unlike tests/smoke, this package boots no binary and touches no disk: it
+// is purely a post-rollout sanity check for wiring that unit tests can't
+// see (routes, auth, frontend embed, migrations applied).
+package predeploy_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const httpTimeout = 10 * time.Second
+
+func TestPreDeploy(t *testing.T) {
+	base := strings.TrimRight(os.Getenv("BINDERY_URL"), "/")
+	apiKey := os.Getenv("BINDERY_API_KEY")
+	if base == "" || apiKey == "" {
+		t.Skip("BINDERY_URL and BINDERY_API_KEY must be set for pre-deploy smoke")
+	}
+
+	t.Run("health endpoint returns ok", func(t *testing.T) {
+		resp, err := http.Get(base + "/api/v1/health")
+		if err != nil {
+			t.Fatalf("get health: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("auth status reports not setup-required", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/auth/status", apiKey)
+		var status struct {
+			SetupRequired bool `json:"setupRequired"`
+		}
+		if err := json.Unmarshal(body, &status); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+		if status.SetupRequired {
+			t.Errorf("live instance reports setupRequired=true — deployment is uninitialised")
+		}
+	})
+
+	t.Run("unauthenticated request returns 401", func(t *testing.T) {
+		resp, err := http.Get(base + "/api/v1/author")
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("author list returns array", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/author", apiKey)
+		var arr []map[string]any
+		if err := json.Unmarshal(body, &arr); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+	})
+
+	t.Run("book list returns array", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/book", apiKey)
+		var arr []map[string]any
+		if err := json.Unmarshal(body, &arr); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+	})
+
+	t.Run("settings list returns array", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/setting", apiKey)
+		var arr []map[string]any
+		if err := json.Unmarshal(body, &arr); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+	})
+
+	t.Run("search author endpoint is reachable", func(t *testing.T) {
+		req := mustReq(t, http.MethodGet, base+"/api/v1/search/author?term=test", apiKey)
+		resp := do(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Errorf("expected 200, got %d (body=%s)", resp.StatusCode, b)
+		}
+	})
+
+	t.Run("queue endpoint returns array", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/queue", apiKey)
+		var arr []map[string]any
+		if err := json.Unmarshal(body, &arr); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+	})
+
+	t.Run("frontend serves HTML", func(t *testing.T) {
+		resp, err := http.Get(base + "/")
+		if err != nil {
+			t.Fatalf("get /: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(strings.ToLower(string(body)), "<!doctype html") {
+			t.Errorf("/ did not return an HTML document\ngot: %s", truncate(body, 200))
+		}
+	})
+}
+
+func getJSON(t *testing.T, url, apiKey string) []byte {
+	t.Helper()
+	req := mustReq(t, http.MethodGet, url, apiKey)
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET %s: status %d (body=%s)", url, resp.StatusCode, body)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return body
+}
+
+func mustReq(t *testing.T, method, url, apiKey string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("X-Api-Key", apiKey)
+	return req
+}
+
+func do(t *testing.T, req *http.Request) *http.Response {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(req.Context(), httpTimeout)
+	t.Cleanup(cancel)
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		t.Fatalf("%s %s: %v", req.Method, req.URL, err)
+	}
+	return resp
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}


### PR DESCRIPTION
## Summary

Adds a post-deploy HTTP smoke suite that runs against the live cluster instance after an ArgoCD rollout. Catches deploy-time regressions (bad image, failed migration, missing runtime secret) that the existing in-process `tests/smoke` suite cannot see.

- **`tests/predeploy/predeploy_test.go`** — new package. Boots no binary; purely an HTTP client pointed at `BINDERY_URL` with `BINDERY_API_KEY`. Skips if either is missing, so local `go test ./...` stays green. Subtests cover health, auth status (`setupRequired=false`), 401 on missing key, author/book/settings/queue list shapes, `/api/v1/search/author?term=test` reachability, and the embedded frontend serving `<!doctype html>`.
- **`Makefile`** — new `predeploy-smoke` target wrapping `go test ./tests/predeploy/...` with a 120s timeout.
- **`.github/workflows/ci.yml`** — new `predeploy-smoke` job. Depends on `build`, runs only on `refs/tags/*`, polls the ArgoCD API until the `bindery` app reports `Healthy Synced` (24 attempts x 10s = 4 min budget), then executes `make predeploy-smoke` against `https://bindery.autonomy.ninja`.

## Required repo secret

`BINDERY_SMOKE_API_KEY` — an API key provisioned on the live instance with read access. The job will fail on the HTTP calls until this secret is added. `ARGOCD_SERVER` / `ARGOCD_TOKEN` are already configured (re-used from the existing refresh step).

## Test plan

- [x] `go build ./tests/predeploy/...` — compiles
- [x] `go vet ./tests/predeploy/...` — clean
- [x] CI YAML parses (python yaml.safe_load)
- [ ] Tag a release once `BINDERY_SMOKE_API_KEY` is set and confirm the job waits on ArgoCD then passes
- [ ] Confirm the job is skipped on branch pushes / PRs (tag gate)