### PR TITLE
feat(auth): Phase 1 — reverse-proxy SSO backend (#238 + #239)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,3 +271,50 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: make smoke
+
+  # Pre-deploy smoke: after the build job pushes a tagged image and ArgoCD
+  # rolls it out, wait for the app to report Healthy+Synced, then hit the
+  # live instance with a lightweight HTTP suite. Catches deploy-time issues
+  # (bad image, failed migration, missing secret) that build-time tests
+  # can't see. Only runs on tag pushes — main/development rollouts are
+  # already covered by the in-process `smoke` job above.
+  #
+  # Required repo secret: BINDERY_SMOKE_API_KEY — an API key provisioned on
+  # the live instance at https://bindery.autonomy.ninja with read access.
+  predeploy-smoke:
+    name: Pre-deploy smoke
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.25.9"
+      - name: Wait for ArgoCD to sync
+        env:
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER }}
+          ARGOCD_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          if [[ -z "$ARGOCD_SERVER" || -z "$ARGOCD_TOKEN" ]]; then
+            echo "ArgoCD secrets not set — skipping wait"
+            exit 0
+          fi
+          echo "Waiting for ArgoCD app 'bindery' to be Healthy+Synced..."
+          for i in $(seq 1 24); do
+            STATUS=$(curl -sf -H "Authorization: Bearer $ARGOCD_TOKEN" \
+              "$ARGOCD_SERVER/api/v1/applications/bindery" | \
+              python3 -c "import json,sys; d=json.load(sys.stdin); print(d['status']['health']['status'], d['status']['sync']['status'])" 2>/dev/null || echo "unknown unknown")
+            echo "  attempt $i: $STATUS"
+            [[ "$STATUS" == "Healthy Synced" ]] && echo "ArgoCD sync complete" && exit 0
+            sleep 10
+          done
+          echo "Timed out waiting for ArgoCD sync"
+          exit 1
+      - name: Run pre-deploy smoke tests
+        env:
+          BINDERY_URL: https://bindery.autonomy.ninja
+          BINDERY_API_KEY: ${{ secrets.BINDERY_SMOKE_API_KEY }}
+        run: make predeploy-smoke

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build dev test lint clean docker-build web-build web-dev help security helm-lint sbom smoke
+.PHONY: build dev test lint clean docker-build web-build web-dev help security helm-lint sbom smoke predeploy-smoke
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -67,6 +67,9 @@ helm-lint: ## Lint Helm chart + run helm-unittest cases
 
 smoke: build ## Boot the real binary and exercise the critical golden paths via HTTP
 	go test -count=1 -timeout=60s ./tests/smoke/...
+
+predeploy-smoke: ## Run pre-deploy smoke tests against a live instance (requires BINDERY_URL and BINDERY_API_KEY)
+	go test -v -count=1 -timeout=120s ./tests/predeploy/...
 
 sbom: build ## Generate an SPDX SBOM for the local binary
 	@command -v syft >/dev/null || (echo "syft not installed; see https://github.com/anchore/syft"; exit 1)

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -334,11 +334,11 @@ func main() {
 	// local-IP bypass when mode=local-only. Mode, key, and secret are sourced
 	// live from the DB so they can be rotated without a process restart.
 	authProvider := &dbAuthProvider{
-		settings:     settingsRepo,
-		users:        userRepo,
-		proxyHeader:  cfg.ProxyAuthHeader,
+		settings:       settingsRepo,
+		users:          userRepo,
+		proxyHeader:    cfg.ProxyAuthHeader,
 		proxyProvision: cfg.ProxyAutoProvision,
-		proxyCIDRs:   trustedCIDRs,
+		proxyCIDRs:     trustedCIDRs,
 	}
 
 	r.Route("/api/v1", func(r chi.Router) {
@@ -740,8 +740,8 @@ func (p *dbAuthProvider) SetupRequired() bool {
 	return err == nil && n == 0
 }
 
-func (p *dbAuthProvider) ProxyAuthHeader() string        { return p.proxyHeader }
-func (p *dbAuthProvider) ProxyAutoProvision() bool       { return p.proxyProvision }
+func (p *dbAuthProvider) ProxyAuthHeader() string         { return p.proxyHeader }
+func (p *dbAuthProvider) ProxyAutoProvision() bool        { return p.proxyProvision }
 func (p *dbAuthProvider) TrustedProxyCIDRs() []*net.IPNet { return p.proxyCIDRs }
 func (p *dbAuthProvider) UserProvisioner() auth.UserProvisioner {
 	return &dbUserProvisioner{users: p.users}

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -121,6 +122,20 @@ func main() {
 	if err := bootstrapAuth(ctxBoot, settingsRepo, cfg.APIKey); err != nil {
 		slog.Error("auth bootstrap failed", "error", err)
 		os.Exit(1)
+	}
+
+	// Parse trusted-proxy CIDRs once at startup (shared by trustedProxyMiddleware
+	// and the proxy-auth identity check).
+	trustedCIDRs := parseTrustedProxyCIDRs(os.Getenv("BINDERY_TRUSTED_PROXY"))
+
+	// Safety gate: proxy auth mode requires at least one trusted proxy CIDR so
+	// that the identity header cannot be forged by arbitrary LAN hosts.
+	if s, _ := settingsRepo.Get(ctxBoot, api.SettingAuthMode); s != nil && s.Value == string(auth.ModeProxy) {
+		if len(trustedCIDRs) == 0 {
+			slog.Error("proxy auth mode is active but BINDERY_TRUSTED_PROXY is empty — refusing to start (any host could forge the identity header)")
+			os.Exit(1)
+		}
+		slog.Info("proxy auth mode: trusted proxies", "cidrs", trustedCIDRs)
 	}
 
 	// Login rate limiter: 5 failures / 15 min per IP, matches Sonarr's posture.
@@ -318,7 +333,13 @@ func main() {
 	// Composite auth: session cookie (UI) OR API key (external apps) OR
 	// local-IP bypass when mode=local-only. Mode, key, and secret are sourced
 	// live from the DB so they can be rotated without a process restart.
-	authProvider := &dbAuthProvider{settings: settingsRepo, users: userRepo}
+	authProvider := &dbAuthProvider{
+		settings:     settingsRepo,
+		users:        userRepo,
+		proxyHeader:  cfg.ProxyAuthHeader,
+		proxyProvision: cfg.ProxyAutoProvision,
+		proxyCIDRs:   trustedCIDRs,
+	}
 
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(auth.Middleware(authProvider))
@@ -683,8 +704,11 @@ func bootstrapAuth(ctx context.Context, settings *db.SettingsRepo, envSeed strin
 // dbAuthProvider adapts the DB-backed settings + user repo to the minimal
 // auth.Provider interface consumed by auth.Middleware.
 type dbAuthProvider struct {
-	settings *db.SettingsRepo
-	users    *db.UserRepo
+	settings       *db.SettingsRepo
+	users          *db.UserRepo
+	proxyHeader    string
+	proxyProvision bool
+	proxyCIDRs     []*net.IPNet
 }
 
 func (p *dbAuthProvider) Mode() auth.Mode {
@@ -714,4 +738,34 @@ func (p *dbAuthProvider) SessionSecret() []byte {
 func (p *dbAuthProvider) SetupRequired() bool {
 	n, err := p.users.Count(context.Background())
 	return err == nil && n == 0
+}
+
+func (p *dbAuthProvider) ProxyAuthHeader() string        { return p.proxyHeader }
+func (p *dbAuthProvider) ProxyAutoProvision() bool       { return p.proxyProvision }
+func (p *dbAuthProvider) TrustedProxyCIDRs() []*net.IPNet { return p.proxyCIDRs }
+func (p *dbAuthProvider) UserProvisioner() auth.UserProvisioner {
+	return &dbUserProvisioner{users: p.users}
+}
+
+// dbUserProvisioner implements auth.UserProvisioner using the UserRepo.
+type dbUserProvisioner struct {
+	users *db.UserRepo
+}
+
+func (p *dbUserProvisioner) ResolveOrProvisionUser(ctx context.Context, username string, autoProvision bool) (int64, error) {
+	if autoProvision {
+		u, err := p.users.GetOrCreateByUsername(ctx, username)
+		if err != nil {
+			return 0, err
+		}
+		return u.ID, nil
+	}
+	u, err := p.users.GetByUsername(ctx, username)
+	if err != nil {
+		return 0, err
+	}
+	if u == nil {
+		return 0, nil
+	}
+	return u.ID, nil
 }

--- a/cmd/bindery/proxy.go
+++ b/cmd/bindery/proxy.go
@@ -10,21 +10,13 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
-// trustedProxyMiddleware returns a middleware that rewrites RemoteAddr from
-// X-Forwarded-For / X-Real-IP only when the direct peer is a configured
-// trusted proxy. Without a trusted proxy configured, forwarded headers are
-// ignored and the peer IP is used as-is — preventing XFF spoofing in
-// local-only auth mode.
-//
-// Configured via BINDERY_TRUSTED_PROXY: a comma-separated list of IPs or
-// CIDRs. Bare IPs are treated as /32 (IPv4) or /128 (IPv6).
-func trustedProxyMiddleware() func(http.Handler) http.Handler {
-	raw := os.Getenv("BINDERY_TRUSTED_PROXY")
+// parseTrustedProxyCIDRs parses a comma-separated list of IP/CIDR strings
+// (from BINDERY_TRUSTED_PROXY) into []*net.IPNet. Bare IPs are treated as
+// /32 (IPv4) or /128 (IPv6). Invalid entries are logged and skipped.
+func parseTrustedProxyCIDRs(raw string) []*net.IPNet {
 	if raw == "" {
-		// No trusted proxy — use peer IP as-is (safe default).
-		return func(next http.Handler) http.Handler { return next }
+		return nil
 	}
-
 	var trusted []*net.IPNet
 	for _, s := range strings.Split(raw, ",") {
 		s = strings.TrimSpace(s)
@@ -44,6 +36,23 @@ func trustedProxyMiddleware() func(http.Handler) http.Handler {
 			continue
 		}
 		trusted = append(trusted, cidr)
+	}
+	return trusted
+}
+
+// trustedProxyMiddleware returns a middleware that rewrites RemoteAddr from
+// X-Forwarded-For / X-Real-IP only when the direct peer is a configured
+// trusted proxy. Without a trusted proxy configured, forwarded headers are
+// ignored and the peer IP is used as-is — preventing XFF spoofing in
+// local-only auth mode.
+//
+// Configured via BINDERY_TRUSTED_PROXY: a comma-separated list of IPs or
+// CIDRs. Bare IPs are treated as /32 (IPv4) or /128 (IPv6).
+func trustedProxyMiddleware() func(http.Handler) http.Handler {
+	trusted := parseTrustedProxyCIDRs(os.Getenv("BINDERY_TRUSTED_PROXY"))
+	if len(trusted) == 0 {
+		// No trusted proxy — use peer IP as-is (safe default).
+		return func(next http.Handler) http.Handler { return next }
 	}
 
 	return func(next http.Handler) http.Handler {

--- a/internal/api/opds_test.go
+++ b/internal/api/opds_test.go
@@ -122,8 +122,8 @@ func (p *testProvider) SessionSecret() []byte {
 	return []byte(s.Value)
 }
 func (p *testProvider) SetupRequired() bool             { return false }
-func (p *testProvider) ProxyAuthHeader() string          { return "X-Forwarded-User" }
-func (p *testProvider) ProxyAutoProvision() bool         { return false }
+func (p *testProvider) ProxyAuthHeader() string         { return "X-Forwarded-User" }
+func (p *testProvider) ProxyAutoProvision() bool        { return false }
 func (p *testProvider) TrustedProxyCIDRs() []*net.IPNet { return nil }
 func (p *testProvider) UserProvisioner() auth.UserProvisioner {
 	return nil // proxy auth not exercised in these tests

--- a/internal/api/opds_test.go
+++ b/internal/api/opds_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/xml"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -120,7 +121,13 @@ func (p *testProvider) SessionSecret() []byte {
 	}
 	return []byte(s.Value)
 }
-func (p *testProvider) SetupRequired() bool { return false }
+func (p *testProvider) SetupRequired() bool             { return false }
+func (p *testProvider) ProxyAuthHeader() string          { return "X-Forwarded-User" }
+func (p *testProvider) ProxyAutoProvision() bool         { return false }
+func (p *testProvider) TrustedProxyCIDRs() []*net.IPNet { return nil }
+func (p *testProvider) UserProvisioner() auth.UserProvisioner {
+	return nil // proxy auth not exercised in these tests
+}
 
 // --- tests -------------------------------------------------------------------
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -151,16 +153,39 @@ func TestLoginLimiterExpiresOldEvents(t *testing.T) {
 // --- middleware integration --------------------------------------------------
 
 type fakeProvider struct {
-	mode   Mode
-	apiKey string
-	secret []byte
-	setup  bool
+	mode           Mode
+	apiKey         string
+	secret         []byte
+	setup          bool
+	proxyHeader    string
+	proxyProvision bool
+	proxyCIDRs     []*net.IPNet
+	provisioner    UserProvisioner
 }
 
-func (f *fakeProvider) Mode() Mode            { return f.mode }
-func (f *fakeProvider) APIKey() string        { return f.apiKey }
-func (f *fakeProvider) SessionSecret() []byte { return f.secret }
-func (f *fakeProvider) SetupRequired() bool   { return f.setup }
+func (f *fakeProvider) Mode() Mode                        { return f.mode }
+func (f *fakeProvider) APIKey() string                    { return f.apiKey }
+func (f *fakeProvider) SessionSecret() []byte             { return f.secret }
+func (f *fakeProvider) SetupRequired() bool               { return f.setup }
+func (f *fakeProvider) ProxyAuthHeader() string           { return f.proxyHeader }
+func (f *fakeProvider) ProxyAutoProvision() bool          { return f.proxyProvision }
+func (f *fakeProvider) TrustedProxyCIDRs() []*net.IPNet  { return f.proxyCIDRs }
+func (f *fakeProvider) UserProvisioner() UserProvisioner  { return f.provisioner }
+
+// staticProvisioner always returns the same user ID for any username.
+type staticProvisioner struct{ uid int64 }
+
+func (s *staticProvisioner) ResolveOrProvisionUser(_ context.Context, _ string, _ bool) (int64, error) {
+	return s.uid, nil
+}
+
+func mustParseCIDR(s string) *net.IPNet {
+	_, cidr, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return cidr
+}
 
 func TestMiddlewareAllowsHealthWithoutAuth(t *testing.T) {
 	p := &fakeProvider{mode: ModeEnabled}
@@ -283,5 +308,72 @@ func TestParseMode(t *testing.T) {
 	}
 	if m := ParseMode(""); m != ModeEnabled {
 		t.Errorf("empty mode should default to ModeEnabled, got %q", m)
+	}
+	if m := ParseMode("proxy"); m != ModeProxy {
+		t.Errorf("want ModeProxy, got %q", m)
+	}
+}
+
+// --- proxy mode tests --------------------------------------------------------
+
+func proxyProvider(trustedCIDR string, autoProvision bool, uid int64) *fakeProvider {
+	return &fakeProvider{
+		mode:           ModeProxy,
+		proxyHeader:    "X-Forwarded-User",
+		proxyProvision: autoProvision,
+		proxyCIDRs:     []*net.IPNet{mustParseCIDR(trustedCIDR)},
+		provisioner:    &staticProvisioner{uid: uid},
+	}
+}
+
+func TestProxyAuthTrustedIPWithHeader(t *testing.T) {
+	p := proxyProvider("10.0.0.0/8", true, 42)
+	mw := Middleware(p)
+	var gotUID int64
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotUID = UserIDFromContext(r.Context())
+	}))
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.RemoteAddr = "10.0.0.5:12345"
+	req.Header.Set("X-Forwarded-User", "alice")
+	h.ServeHTTP(nopWriter{}, req)
+	if gotUID != 42 {
+		t.Errorf("uid = %d; want 42", gotUID)
+	}
+}
+
+func TestProxyAuthUntrustedIPWithHeader(t *testing.T) {
+	p := proxyProvider("10.0.0.0/8", true, 42)
+	mw := Middleware(p)
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.RemoteAddr = "8.8.8.8:12345"
+	req.Header.Set("X-Forwarded-User", "alice")
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if called {
+		t.Fatal("untrusted IP with identity header must be rejected")
+	}
+	if w.status != http.StatusUnauthorized {
+		t.Errorf("status = %d; want 401", w.status)
+	}
+}
+
+func TestProxyAuthTrustedIPNoHeader(t *testing.T) {
+	p := proxyProvider("10.0.0.0/8", true, 42)
+	mw := Middleware(p)
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.RemoteAddr = "10.0.0.5:12345"
+	// No X-Forwarded-User header
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if called {
+		t.Fatal("trusted IP with no identity header must be rejected")
+	}
+	if w.status != http.StatusUnauthorized {
+		t.Errorf("status = %d; want 401", w.status)
 	}
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -163,14 +163,14 @@ type fakeProvider struct {
 	provisioner    UserProvisioner
 }
 
-func (f *fakeProvider) Mode() Mode                        { return f.mode }
-func (f *fakeProvider) APIKey() string                    { return f.apiKey }
-func (f *fakeProvider) SessionSecret() []byte             { return f.secret }
-func (f *fakeProvider) SetupRequired() bool               { return f.setup }
-func (f *fakeProvider) ProxyAuthHeader() string           { return f.proxyHeader }
-func (f *fakeProvider) ProxyAutoProvision() bool          { return f.proxyProvision }
+func (f *fakeProvider) Mode() Mode                       { return f.mode }
+func (f *fakeProvider) APIKey() string                   { return f.apiKey }
+func (f *fakeProvider) SessionSecret() []byte            { return f.secret }
+func (f *fakeProvider) SetupRequired() bool              { return f.setup }
+func (f *fakeProvider) ProxyAuthHeader() string          { return f.proxyHeader }
+func (f *fakeProvider) ProxyAutoProvision() bool         { return f.proxyProvision }
 func (f *fakeProvider) TrustedProxyCIDRs() []*net.IPNet  { return f.proxyCIDRs }
-func (f *fakeProvider) UserProvisioner() UserProvisioner  { return f.provisioner }
+func (f *fakeProvider) UserProvisioner() UserProvisioner { return f.provisioner }
 
 // staticProvisioner always returns the same user ID for any username.
 type staticProvisioner struct{ uid int64 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -3,7 +3,9 @@ package auth
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
+	"strings"
 )
 
 // Mode represents the auth posture. Matches Sonarr's "Authentication Required"
@@ -14,13 +16,14 @@ const (
 	ModeDisabled  Mode = "disabled"   // no auth check at all (not recommended; not the default)
 	ModeLocalOnly Mode = "local-only" // RFC1918 + loopback clients bypass
 	ModeEnabled   Mode = "enabled"    // everyone must authenticate
+	ModeProxy     Mode = "proxy"      // trust identity header from a configured upstream proxy
 )
 
 // ParseMode coerces a free-form string into a valid Mode; unknown values map
 // to ModeEnabled (fail-safe).
 func ParseMode(s string) Mode {
 	switch Mode(s) {
-	case ModeDisabled, ModeLocalOnly, ModeEnabled:
+	case ModeDisabled, ModeLocalOnly, ModeEnabled, ModeProxy:
 		return Mode(s)
 	default:
 		return ModeEnabled
@@ -37,6 +40,14 @@ func UserIDFromContext(ctx context.Context) int64 {
 	return v
 }
 
+// UserProvisioner resolves or creates a user by username. Used by proxy-auth.
+type UserProvisioner interface {
+	// ResolveOrProvisionUser returns the user ID for username, creating one if
+	// autoProvision is true and the user does not yet exist. Returns 0, nil when
+	// autoProvision is false and the user is not found.
+	ResolveOrProvisionUser(ctx context.Context, username string, autoProvision bool) (int64, error)
+}
+
 // Provider is the data the middleware needs at request time. Implemented by
 // main.go via a small adapter; keeps this package free of db imports.
 type Provider interface {
@@ -46,6 +57,17 @@ type Provider interface {
 	// SetupRequired reports whether no user exists yet (first-run). When true
 	// and the request is unauthenticated, /setup endpoints are allowed through.
 	SetupRequired() bool
+	// ProxyAuthHeader is the HTTP header carrying the upstream identity, e.g.
+	// "X-Forwarded-User". Only consulted when Mode() == ModeProxy.
+	ProxyAuthHeader() string
+	// ProxyAutoProvision controls whether unknown usernames are created on the
+	// fly when Mode() == ModeProxy.
+	ProxyAutoProvision() bool
+	// TrustedProxyCIDRs returns the parsed CIDR list for proxy-mode trust
+	// decisions. Callers must not mutate the returned slice.
+	TrustedProxyCIDRs() []*net.IPNet
+	// UserProvisioner returns the provisioner used in proxy-auth mode.
+	UserProvisioner() UserProvisioner
 }
 
 // AllowUnauthPath returns true for routes the middleware must always let
@@ -71,7 +93,8 @@ func AllowUnauthPath(path string) bool {
 //  4. Mode == local-only + local  — always allowed
 //  5. Valid X-Api-Key header or ?apikey= query — allowed
 //  6. Valid signed session cookie — allowed
-//  7. Otherwise                   — 401
+//  7. Mode == proxy: trusted peer IP + identity header → resolve/provision user
+//  8. Otherwise                   — 401
 func Middleware(p Provider) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -110,6 +133,20 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 				return
 			}
 
+			if mode == ModeProxy {
+				if uid, ok := resolveProxyIdentity(r, p); ok {
+					r = r.WithContext(context.WithValue(r.Context(), userIDCtxKey, uid))
+					next.ServeHTTP(w, r)
+					return
+				}
+				// Proxy mode — identity header present but source untrusted, or
+				// no header at all.
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+				return
+			}
+
 			// First-run escape hatch: before any user exists, the UI needs to
 			// reach /auth/setup without credentials. Those paths are already in
 			// AllowUnauthPath — any other path still 401s so random GETs can't
@@ -123,6 +160,59 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 			}
 		})
 	}
+}
+
+// resolveProxyIdentity checks whether the request carries a trusted upstream
+// identity header from a configured proxy IP. Returns (userID, true) on
+// success. Returns (0, false) when the header is missing or the source is
+// untrusted. A forged header from an untrusted IP is logged and rejected.
+func resolveProxyIdentity(r *http.Request, p Provider) (int64, bool) {
+	header := p.ProxyAuthHeader()
+	username := strings.TrimSpace(r.Header.Get(header))
+
+	peerIP := requestPeerIP(r)
+
+	trusted := isTrustedProxy(peerIP, p.TrustedProxyCIDRs())
+
+	if username != "" && !trusted {
+		slog.Warn("proxy auth: identity header from untrusted source — rejecting",
+			"header", header, "peer", peerIP)
+		return 0, false
+	}
+	if !trusted || username == "" {
+		return 0, false
+	}
+
+	uid, err := p.UserProvisioner().ResolveOrProvisionUser(r.Context(), username, p.ProxyAutoProvision())
+	if err != nil {
+		slog.Error("proxy auth: user provisioning failed", "username", username, "error", err)
+		return 0, false
+	}
+	if uid == 0 {
+		slog.Warn("proxy auth: user not found and auto-provisioning disabled", "username", username)
+		return 0, false
+	}
+	return uid, true
+}
+
+func isTrustedProxy(ip net.IP, cidrs []*net.IPNet) bool {
+	if ip == nil {
+		return false
+	}
+	for _, cidr := range cidrs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func requestPeerIP(r *http.Request) net.IP {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	return net.ParseIP(strings.Trim(host, "[]"))
 }
 
 // RequireXRequestedWith rejects non-GET/HEAD requests that lack the custom

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,8 @@ type Config struct {
 	AudiobookDir      string
 	DownloadPathRemap string
 	// Proxy SSO settings (Phase 1).
-	ProxyAuthHeader      string // BINDERY_PROXY_AUTH_HEADER
-	ProxyAutoProvision   bool   // BINDERY_PROXY_AUTO_PROVISION
+	ProxyAuthHeader    string // BINDERY_PROXY_AUTH_HEADER
+	ProxyAutoProvision bool   // BINDERY_PROXY_AUTO_PROVISION
 }
 
 // Load reads configuration from environment variables with sensible defaults.
@@ -37,16 +37,16 @@ type Config struct {
 // takes precedence and the env var becomes a no-op.
 func Load() *Config {
 	return &Config{
-		Port:              envOr("BINDERY_PORT", "8787"),
-		DBPath:            envOr("BINDERY_DB_PATH", defaultDBPath(runtime.GOOS, os.UserConfigDir)),
-		DataDir:           envOr("BINDERY_DATA_DIR", defaultDataDir(runtime.GOOS, os.UserConfigDir)),
-		LogLevel:          envOr("BINDERY_LOG_LEVEL", "info"),
-		APIKey:            envOr("BINDERY_API_KEY", ""),
-		DownloadDir:       envOr("BINDERY_DOWNLOAD_DIR", "/downloads"),
-		LibraryDir:        envOr("BINDERY_LIBRARY_DIR", "/books"),
-		AudiobookDir:      envOr("BINDERY_AUDIOBOOK_DIR", ""),
-		DownloadPathRemap: envOr("BINDERY_DOWNLOAD_PATH_REMAP", ""),
-		ProxyAuthHeader:   envOr("BINDERY_PROXY_AUTH_HEADER", "X-Forwarded-User"),
+		Port:               envOr("BINDERY_PORT", "8787"),
+		DBPath:             envOr("BINDERY_DB_PATH", defaultDBPath(runtime.GOOS, os.UserConfigDir)),
+		DataDir:            envOr("BINDERY_DATA_DIR", defaultDataDir(runtime.GOOS, os.UserConfigDir)),
+		LogLevel:           envOr("BINDERY_LOG_LEVEL", "info"),
+		APIKey:             envOr("BINDERY_API_KEY", ""),
+		DownloadDir:        envOr("BINDERY_DOWNLOAD_DIR", "/downloads"),
+		LibraryDir:         envOr("BINDERY_LIBRARY_DIR", "/books"),
+		AudiobookDir:       envOr("BINDERY_AUDIOBOOK_DIR", ""),
+		DownloadPathRemap:  envOr("BINDERY_DOWNLOAD_PATH_REMAP", ""),
+		ProxyAuthHeader:    envOr("BINDERY_PROXY_AUTH_HEADER", "X-Forwarded-User"),
 		ProxyAutoProvision: envBool("BINDERY_PROXY_AUTO_PROVISION", true),
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // Config holds the application configuration loaded from environment variables.
@@ -19,6 +20,9 @@ type Config struct {
 	LibraryDir        string
 	AudiobookDir      string
 	DownloadPathRemap string
+	// Proxy SSO settings (Phase 1).
+	ProxyAuthHeader      string // BINDERY_PROXY_AUTH_HEADER
+	ProxyAutoProvision   bool   // BINDERY_PROXY_AUTO_PROVISION
 }
 
 // Load reads configuration from environment variables with sensible defaults.
@@ -42,6 +46,8 @@ func Load() *Config {
 		LibraryDir:        envOr("BINDERY_LIBRARY_DIR", "/books"),
 		AudiobookDir:      envOr("BINDERY_AUDIOBOOK_DIR", ""),
 		DownloadPathRemap: envOr("BINDERY_DOWNLOAD_PATH_REMAP", ""),
+		ProxyAuthHeader:   envOr("BINDERY_PROXY_AUTH_HEADER", "X-Forwarded-User"),
+		ProxyAutoProvision: envBool("BINDERY_PROXY_AUTO_PROVISION", true),
 	}
 }
 
@@ -76,6 +82,17 @@ func defaultDataDir(goos string, userConfigDir func() (string, error)) string {
 func envOr(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
+	}
+	return fallback
+}
+
+func envBool(key string, fallback bool) bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	switch v {
+	case "false", "0", "no":
+		return false
+	case "true", "1", "yes":
+		return true
 	}
 	return fallback
 }

--- a/internal/db/auth.go
+++ b/internal/db/auth.go
@@ -92,3 +92,17 @@ func (r *UserRepo) UpdateUsername(ctx context.Context, id int64, username string
 	)
 	return err
 }
+
+// GetOrCreateByUsername returns the existing user with the given username, or
+// creates one (with an empty password hash — proxy-auth users never log in
+// with a local password). Used by the proxy-auth auto-provisioning path.
+func (r *UserRepo) GetOrCreateByUsername(ctx context.Context, username string) (*User, error) {
+	u, err := r.GetByUsername(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+	if u != nil {
+		return u, nil
+	}
+	return r.Create(ctx, username, "")
+}

--- a/tests/predeploy/predeploy_test.go
+++ b/tests/predeploy/predeploy_test.go
@@ -1,0 +1,167 @@
+// Package predeploy runs HTTP-level smoke checks against an already-running
+// bindery instance (typically the cluster deployment just promoted by
+// ArgoCD). It is pointed at a live URL via BINDERY_URL and authenticates
+// with BINDERY_API_KEY — both required. When either is missing the whole
+// suite is skipped so local `go test ./...` runs stay green.
+//
+// Unlike tests/smoke, this package boots no binary and touches no disk: it
+// is purely a post-rollout sanity check for wiring that unit tests can't
+// see (routes, auth, frontend embed, migrations applied).
+package predeploy_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const httpTimeout = 10 * time.Second
+
+func TestPreDeploy(t *testing.T) {
+	base := strings.TrimRight(os.Getenv("BINDERY_URL"), "/")
+	apiKey := os.Getenv("BINDERY_API_KEY")
+	if base == "" || apiKey == "" {
+		t.Skip("BINDERY_URL and BINDERY_API_KEY must be set for pre-deploy smoke")
+	}
+
+	t.Run("health endpoint returns ok", func(t *testing.T) {
+		resp, err := http.Get(base + "/api/v1/health")
+		if err != nil {
+			t.Fatalf("get health: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("auth status reports not setup-required", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/auth/status", apiKey)
+		var status struct {
+			SetupRequired bool `json:"setupRequired"`
+		}
+		if err := json.Unmarshal(body, &status); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+		if status.SetupRequired {
+			t.Errorf("live instance reports setupRequired=true — deployment is uninitialised")
+		}
+	})
+
+	t.Run("unauthenticated request returns 401", func(t *testing.T) {
+		resp, err := http.Get(base + "/api/v1/author")
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("author list returns array", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/author", apiKey)
+		var arr []map[string]any
+		if err := json.Unmarshal(body, &arr); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+	})
+
+	t.Run("book list returns array", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/book", apiKey)
+		var arr []map[string]any
+		if err := json.Unmarshal(body, &arr); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+	})
+
+	t.Run("settings list returns array", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/setting", apiKey)
+		var arr []map[string]any
+		if err := json.Unmarshal(body, &arr); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+	})
+
+	t.Run("search author endpoint is reachable", func(t *testing.T) {
+		req := mustReq(t, http.MethodGet, base+"/api/v1/search/author?term=test", apiKey)
+		resp := do(t, req)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Errorf("expected 200, got %d (body=%s)", resp.StatusCode, b)
+		}
+	})
+
+	t.Run("queue endpoint returns array", func(t *testing.T) {
+		body := getJSON(t, base+"/api/v1/queue", apiKey)
+		var arr []map[string]any
+		if err := json.Unmarshal(body, &arr); err != nil {
+			t.Fatalf("decode: %v (body=%s)", err, body)
+		}
+	})
+
+	t.Run("frontend serves HTML", func(t *testing.T) {
+		resp, err := http.Get(base + "/")
+		if err != nil {
+			t.Fatalf("get /: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		if !strings.Contains(strings.ToLower(string(body)), "<!doctype html") {
+			t.Errorf("/ did not return an HTML document\ngot: %s", truncate(body, 200))
+		}
+	})
+}
+
+func getJSON(t *testing.T, url, apiKey string) []byte {
+	t.Helper()
+	req := mustReq(t, http.MethodGet, url, apiKey)
+	resp := do(t, req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET %s: status %d (body=%s)", url, resp.StatusCode, body)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return body
+}
+
+func mustReq(t *testing.T, method, url, apiKey string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("X-Api-Key", apiKey)
+	return req
+}
+
+func do(t *testing.T, req *http.Request) *http.Response {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(req.Context(), httpTimeout)
+	t.Cleanup(cancel)
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	if err != nil {
+		t.Fatalf("%s %s: %v", req.Method, req.URL, err)
+	}
+	return resp
+}
+
+func truncate(b []byte, n int) string {
+	if len(b) <= n {
+		return string(b)
+	}
+	return string(b[:n]) + "…"
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -38,7 +38,7 @@ export interface AuthStatus {
   authenticated: boolean
   setupRequired: boolean
   username?: string
-  mode: 'enabled' | 'local-only' | 'disabled'
+  mode: 'enabled' | 'local-only' | 'disabled' | 'proxy'
 }
 
 export interface AuthConfig {

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -53,7 +53,8 @@
     "errorRequired": "Benutzername und Passwort sind erforderlich",
     "errorFailed": "Anmeldung fehlgeschlagen",
     "signOut": "Abmelden",
-    "signedInAs": "Angemeldet als"
+    "signedInAs": "Angemeldet als",
+    "proxyHint": "Melden Sie sich über Ihren SSO-Anbieter an"
   },
   "setup": {
     "title": "Ersteinrichtung",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -65,7 +65,8 @@
     "errorRequired": "Username and password are required",
     "errorFailed": "Login failed",
     "signOut": "Sign out",
-    "signedInAs": "Signed in as"
+    "signedInAs": "Signed in as",
+    "proxyHint": "Sign in via your SSO provider"
   },
   "setup": {
     "title": "First-run setup",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -65,7 +65,8 @@
     "errorRequired": "El usuario y la contraseña son obligatorios",
     "errorFailed": "Error al iniciar sesión",
     "signOut": "Cerrar sesión",
-    "signedInAs": "Sesión iniciada como"
+    "signedInAs": "Sesión iniciada como",
+    "proxyHint": "Inicie sesión a través de su proveedor SSO"
   },
   "setup": {
     "title": "Configuración inicial",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -53,7 +53,8 @@
     "errorRequired": "Nom d'utilisateur et mot de passe requis",
     "errorFailed": "Échec de la connexion",
     "signOut": "Se déconnecter",
-    "signedInAs": "Connecté en tant que"
+    "signedInAs": "Connecté en tant que",
+    "proxyHint": "Connectez-vous via votre fournisseur SSO"
   },
   "setup": {
     "title": "Configuration initiale",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -65,7 +65,8 @@
     "errorRequired": "Nama pengguna dan kata sandi wajib diisi",
     "errorFailed": "Login gagal",
     "signOut": "Keluar",
-    "signedInAs": "Masuk sebagai"
+    "signedInAs": "Masuk sebagai",
+    "proxyHint": "Masuk melalui penyedia SSO Anda"
   },
   "setup": {
     "title": "Pengaturan awal",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -53,7 +53,8 @@
     "errorRequired": "Gebruikersnaam en wachtwoord zijn vereist",
     "errorFailed": "Inloggen mislukt",
     "signOut": "Uitloggen",
-    "signedInAs": "Ingelogd als"
+    "signedInAs": "Ingelogd als",
+    "proxyHint": "Meld u aan via uw SSO-provider"
   },
   "setup": {
     "title": "Eerste installatie",

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -65,7 +65,8 @@
     "errorRequired": "Kailangan ang username at password",
     "errorFailed": "Nabigo ang pag-login",
     "signOut": "Mag-sign out",
-    "signedInAs": "Naka-sign in bilang"
+    "signedInAs": "Naka-sign in bilang",
+    "proxyHint": "Mag-sign in sa pamamagitan ng iyong SSO provider"
   },
   "setup": {
     "title": "Unang setup",

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -9,7 +9,7 @@ export default function LoginPage() {
   const { t } = useTranslation()
   const [error, setError] = useState('')
   const [submitting, setSubmitting] = useState(false)
-  const { refresh } = useAuth()
+  const { status, refresh } = useAuth()
   const navigate = useNavigate()
 
   // Read values from the form at submit time instead of React state.
@@ -37,6 +37,16 @@ export default function LoginPage() {
     } finally {
       setSubmitting(false)
     }
+  }
+
+  if (status?.mode === 'proxy') {
+    return (
+      <CardShell title={t('login.title')} subtitle="">
+        <p className="text-sm text-slate-600 dark:text-zinc-400 text-center py-2">
+          {t('login.proxyHint')}
+        </p>
+      </CardShell>
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary

- Adds `proxy` auth mode: trusts upstream identity header (`X-Forwarded-User` by default) only when the peer IP is in `BINDERY_TRUSTED_PROXY` CIDRs
- Forged headers from untrusted IPs are logged at WARN level and rejected with 401 — no silent drops
- Startup aborts if `mode=proxy` is persisted in the DB but `BINDERY_TRUSTED_PROXY` is empty (prevents the auth-bypass footgun)
- `GetOrCreateByUsername` added to `UserRepo` for auto-provisioning proxy users
- `BINDERY_PROXY_AUTH_HEADER` (default `X-Forwarded-User`) and `BINDERY_PROXY_AUTO_PROVISION` (default `true`) env vars
- `parseTrustedProxyCIDRs` extracted from the XFF middleware so the same CIDR list is shared with the proxy-auth identity check

## Test plan

- [x] `go test ./...` — all packages green
- [x] `make smoke` — smoke suite passes
- [x] Proxy middleware matrix: trusted IP + header → 200; untrusted IP + header → 401; trusted IP + no header → 401
- [ ] Manual: Traefik + Authelia forward-auth staging test (docs-writer unblocked to write `docs/auth-proxy.md`)

Closes #238, #239