### PR TITLE
feat: CSRF double-submit token protection (#240)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -355,6 +355,7 @@ func main() {
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(auth.Middleware(authProvider))
 		r.Use(auth.RequireXRequestedWith)
+		r.Use(auth.RequireCSRFToken(authProvider.SessionSecret))
 
 		// System
 		r.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
@@ -374,6 +375,7 @@ func main() {
 		// middleware (see auth.AllowUnauthPath). The config + mutation
 		// endpoints below sit behind it.
 		r.Get("/auth/status", authHandler.Status)
+		r.Get("/auth/csrf", authHandler.CSRF)
 		r.Post("/auth/login", authHandler.Login)
 		r.Post("/auth/logout", authHandler.Logout)
 		r.Post("/auth/setup", authHandler.Setup)

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -280,6 +280,43 @@ func (h *AuthHandler) RegenerateAPIKey(w http.ResponseWriter, r *http.Request) {
 	writeOK(w, map[string]any{"apiKey": key})
 }
 
+// CSRF issues (or re-issues) a double-submit CSRF token bound to the caller's
+// session cookie. The token is returned as JSON and also set as a readable
+// (non-HttpOnly) cookie so the frontend JS can read it. Unauthenticated
+// callers receive a 200 with an empty token — they have no session to bind to,
+// so the cookie-absent check in RequireCSRFToken will reject mutations anyway.
+func (h *AuthHandler) CSRF(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	c, err := r.Cookie(auth.SessionCookieName)
+	if err != nil || c.Value == "" {
+		writeOK(w, map[string]any{"csrfToken": ""})
+		return
+	}
+	secret := h.sessionSecret(ctx)
+	token := auth.MakeCSRFToken(secret, c.Value)
+
+	var secure bool
+	switch CookieSecureMode() {
+	case "always":
+		secure = true
+	case "never":
+		secure = false
+	default:
+		secure = r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
+	}
+
+	// Readable (no HttpOnly) so JS can access it.
+	http.SetCookie(w, &http.Cookie{
+		Name:     auth.CSRFCookieName,
+		Value:    token,
+		Path:     "/",
+		HttpOnly: false,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   secure,
+	})
+	writeOK(w, map[string]any{"csrfToken": token})
+}
+
 // SetMode persists the auth mode setting.
 func (h *AuthHandler) SetMode(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -377,3 +377,102 @@ func TestProxyAuthTrustedIPNoHeader(t *testing.T) {
 		t.Errorf("status = %d; want 401", w.status)
 	}
 }
+
+// --- CSRF tests --------------------------------------------------------
+
+func TestMakeCSRFToken_DifferentSessionsDiffer(t *testing.T) {
+	secret := []byte("test-secret")
+	tok1 := MakeCSRFToken(secret, "session-value-a")
+	tok2 := MakeCSRFToken(secret, "session-value-b")
+	if tok1 == tok2 {
+		t.Fatal("tokens for different sessions must differ")
+	}
+}
+
+func TestMakeCSRFToken_SameInputsSameOutput(t *testing.T) {
+	secret := []byte("test-secret")
+	tok1 := MakeCSRFToken(secret, "session-value")
+	tok2 := MakeCSRFToken(secret, "session-value")
+	if tok1 != tok2 {
+		t.Fatal("same inputs must produce the same token")
+	}
+}
+
+func TestRequireCSRFToken_AllowsSafeMethod(t *testing.T) {
+	secret := []byte("s")
+	mw := RequireCSRFToken(func() []byte { return secret })
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	h.ServeHTTP(nopWriter{}, req)
+	if !called {
+		t.Fatal("GET must pass without CSRF token")
+	}
+}
+
+func TestRequireCSRFToken_BlocksMutationWithoutToken(t *testing.T) {
+	secret := []byte("s")
+	mw := RequireCSRFToken(func() []byte { return secret })
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	// Simulate a cross-origin POST: no session cookie, no CSRF token.
+	req, _ := http.NewRequest("POST", "/api/v1/author", nil)
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if called {
+		t.Fatal("POST without CSRF token and no API key must be rejected")
+	}
+	if w.status != http.StatusForbidden {
+		t.Errorf("status = %d; want 403", w.status)
+	}
+}
+
+func TestRequireCSRFToken_AllowsMutationWithAPIKey(t *testing.T) {
+	secret := []byte("s")
+	mw := RequireCSRFToken(func() []byte { return secret })
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest("POST", "/api/v1/author", nil)
+	req.Header.Set("X-Api-Key", "apikey-value")
+	h.ServeHTTP(nopWriter{}, req)
+	if !called {
+		t.Fatal("POST with API key must bypass CSRF check")
+	}
+}
+
+func TestRequireCSRFToken_AllowsMutationWithValidToken(t *testing.T) {
+	secret := []byte("test-secret")
+	sessionVal := SignSession(secret, 1, time.Now().Add(time.Hour))
+	token := MakeCSRFToken(secret, sessionVal)
+
+	mw := RequireCSRFToken(func() []byte { return secret })
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest("DELETE", "/api/v1/author/1", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessionVal})
+	req.Header.Set("X-CSRF-Token", token)
+	h.ServeHTTP(nopWriter{}, req)
+	if !called {
+		t.Fatal("DELETE with valid CSRF token must pass")
+	}
+}
+
+func TestRequireCSRFToken_BlocksMutationWithWrongToken(t *testing.T) {
+	secret := []byte("test-secret")
+	sessionVal := SignSession(secret, 1, time.Now().Add(time.Hour))
+
+	mw := RequireCSRFToken(func() []byte { return secret })
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest("PUT", "/api/v1/author/1", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessionVal})
+	req.Header.Set("X-CSRF-Token", "bad-token")
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if called {
+		t.Fatal("PUT with wrong CSRF token must be rejected")
+	}
+	if w.status != http.StatusForbidden {
+		t.Errorf("status = %d; want 403", w.status)
+	}
+}

--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+)
+
+const CSRFCookieName = "bindery_csrf"
+
+// MakeCSRFToken derives a double-submit CSRF token from the raw session cookie
+// value and the session secret. Binding the token to the session value means
+// it is automatically invalidated when the session rotates.
+func MakeCSRFToken(secret []byte, sessionValue string) string {
+	h := hmac.New(sha256.New, secret)
+	h.Write([]byte("csrf:" + sessionValue))
+	return base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+}
+
+// ValidCSRFToken reports whether the supplied token matches what we would
+// derive from the session cookie present on r.
+func ValidCSRFToken(secret []byte, r *http.Request, token string) bool {
+	c, err := r.Cookie(SessionCookieName)
+	if err != nil || c.Value == "" {
+		return false
+	}
+	want := MakeCSRFToken(secret, c.Value)
+	return hmac.Equal([]byte(token), []byte(want))
+}
+
+// RequireCSRFToken rejects state-mutating requests that lack a valid
+// X-CSRF-Token header. Requests authenticated via API key are exempt because
+// CSRF only threatens cookie-based auth. GET / HEAD / OPTIONS are safe methods
+// and are always passed through.
+func RequireCSRFToken(secret func() []byte) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet, http.MethodHead, http.MethodOptions:
+				// safe methods — no mutation risk
+			default:
+				if requestAPIKey(r) == "" {
+					tok := r.Header.Get("X-CSRF-Token")
+					if !ValidCSRFToken(secret(), r, tok) {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusForbidden)
+						_, _ = w.Write([]byte(`{"error":"invalid or missing CSRF token"}`))
+						return
+					}
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -79,6 +79,7 @@ func AllowUnauthPath(path string) bool {
 		"/api/v1/auth/login",
 		"/api/v1/auth/logout",
 		"/api/v1/auth/setup",
+		"/api/v1/auth/csrf",
 		"/api/v1/auth/oidc/providers":
 		return true
 	}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -5,6 +5,32 @@ const BASE = '/api/v1'
 // try to redirect to /login from the login/setup pages themselves.
 const PUBLIC_PATHS = new Set(['/login', '/setup'])
 
+// CSRF double-submit token, fetched once on init and refreshed after login.
+let csrfToken = ''
+
+// Read from the bindery_csrf cookie (set by GET /auth/csrf).
+function readCSRFCookie(): string {
+  const m = document.cookie.match(/(?:^|;\s*)bindery_csrf=([^;]+)/)
+  return m ? decodeURIComponent(m[1]) : ''
+}
+
+export async function initCSRF(): Promise<void> {
+  try {
+    const res = await fetch(`${BASE}/auth/csrf`, {
+      credentials: 'include',
+      headers: { 'X-Requested-With': 'bindery-ui' },
+    })
+    if (res.ok) {
+      const data = await res.json()
+      csrfToken = data.csrfToken || readCSRFCookie()
+    }
+  } catch {
+    // Non-fatal — mutations will fail with 403 if still missing.
+  }
+}
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   // Merge caller-supplied headers on top of the defaults so we can't lose
   // the CSRF header if a caller passes their own `headers`.
@@ -12,6 +38,10 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     'Content-Type': 'application/json',
     'X-Requested-With': 'bindery-ui',
   })
+  const method = (options?.method ?? 'GET').toUpperCase()
+  if (!SAFE_METHODS.has(method) && csrfToken) {
+    headers.set('X-CSRF-Token', csrfToken)
+  }
   if (options?.headers) {
     new Headers(options.headers).forEach((v, k) => headers.set(k, v))
   }
@@ -81,12 +111,19 @@ export const api = {
   oidcProviders: () => request<OidcProvider[]>('/auth/oidc/providers'),
   oidcSetProviders: (providers: OidcProviderConfig[]) =>
     request<void>('/auth/oidc/providers', { method: 'PUT', body: JSON.stringify(providers) }),
-  authLogin: (username: string, password: string, rememberMe: boolean) =>
-    request<{ ok: boolean; username: string }>('/auth/login', {
+  authLogin: async (username: string, password: string, rememberMe: boolean) => {
+    const res = await request<{ ok: boolean; username: string }>('/auth/login', {
       method: 'POST',
       body: JSON.stringify({ username, password, rememberMe }),
-    }),
-  authLogout: () => request<{ ok: boolean }>('/auth/logout', { method: 'POST' }),
+    })
+    await initCSRF()
+    return res
+  },
+  authLogout: async () => {
+    const res = await request<{ ok: boolean }>('/auth/logout', { method: 'POST' })
+    csrfToken = ''
+    return res
+  },
   authSetup: (username: string, password: string) =>
     request<{ ok: boolean }>('/auth/setup', {
       method: 'POST',


### PR DESCRIPTION
## Summary

- `GET /auth/csrf` issues a double-submit CSRF token (HMAC-SHA256 of the session cookie value keyed by the session secret), returned as JSON and set as a readable `bindery_csrf` cookie
- `RequireCSRFToken` middleware enforces `X-CSRF-Token` header on all state-mutating routes (POST/PUT/PATCH/DELETE); requests authenticated via API key are exempt (same split as the existing `X-Requested-With` check)
- `X-Requested-With: bindery-ui` retained as belt-and-suspenders
- Frontend `web/src/api/client.ts`: exported `initCSRF()` fetches and caches the token; all mutation requests inject `X-CSRF-Token`; token refreshed after login, cleared after logout

## Security model

Token is derived deterministically from `HMAC(sessionSecret, "csrf:" + sessionCookieValue)` — no server-side state required. Token is automatically invalidated when the session rotates or the secret changes. Unauthenticated callers receive an empty token; `ValidCSRFToken` requires the session cookie to be present, so they cannot forge a valid pair.

## Test plan

- [ ] `go test ./internal/auth/... -run TestRequireCSRFToken` — 5 cases: safe method bypass, cross-origin POST rejection (no token + no API key → 403), API-key exemption, valid token acceptance, wrong token rejection
- [ ] `go test ./internal/auth/... -run TestMakeCSRFToken` — token determinism and session-binding
- [ ] Manual: log in, open DevTools, confirm `bindery_csrf` cookie is set (readable, not HttpOnly); confirm mutations succeed; confirm a POST without the header returns 403