### PR TITLE
feat: multi-user frontend — settings split, admin users page, role guards (#236)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -280,6 +280,7 @@ func main() {
 	// API handlers
 	authHandler := api.NewAuthHandler(userRepo, settingsRepo, loginLimiter)
 	oidcHandler := api.NewOIDCHandler(oidcMgr, userRepo, settingsRepo, authHandler)
+	userMgmtHandler := api.NewUserManagementHandler(userRepo)
 	searchHandler := api.NewSearchHandler(metaAgg)
 	authorHandler := api.NewAuthorHandler(authorRepo, authorAliasRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched).WithFinder(importScanner)
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
@@ -386,6 +387,14 @@ func main() {
 		r.Put("/auth/oidc/providers", oidcHandler.SetProviders)
 		r.Get("/auth/oidc/{provider}/login", oidcHandler.Login)
 		r.Get("/auth/oidc/{provider}/callback", oidcHandler.Callback)
+		// User management — admin only.
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireAdmin)
+			r.Get("/auth/users", userMgmtHandler.List)
+			r.Post("/auth/users", userMgmtHandler.Create)
+			r.Delete("/auth/users/{id}", userMgmtHandler.Delete)
+			r.Put("/auth/users/{id}/role", userMgmtHandler.SetRole)
+		})
 
 		// Metadata search
 		r.Get("/search/author", searchHandler.SearchAuthors)
@@ -420,15 +429,18 @@ func main() {
 		r.Get("/wanted/missing", bookHandler.ListWanted)
 		r.Post("/wanted/bulk", bulkHandler.WantedBulk)
 
-		// Indexers
+		// Indexers — reads available to all; mutations admin-only.
 		r.Get("/indexer", indexerHandler.List)
-		r.Post("/indexer", indexerHandler.Create)
 		r.Get("/indexer/{id}", indexerHandler.Get)
-		r.Put("/indexer/{id}", indexerHandler.Update)
-		r.Delete("/indexer/{id}", indexerHandler.Delete)
-		r.Post("/indexer/{id}/test", indexerHandler.Test)
 		r.Get("/indexer/search", indexerHandler.SearchQuery)
 		r.Get("/search/last-debug", indexerHandler.LastSearchDebug)
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireAdmin)
+			r.Post("/indexer", indexerHandler.Create)
+			r.Put("/indexer/{id}", indexerHandler.Update)
+			r.Delete("/indexer/{id}", indexerHandler.Delete)
+			r.Post("/indexer/{id}/test", indexerHandler.Test)
+		})
 
 		// Prowlarr indexer sync
 		r.Get("/prowlarr", prowlarrHandler.List)
@@ -444,13 +456,16 @@ func main() {
 		r.Post("/rootfolder", rootFolderHandler.Create)
 		r.Delete("/rootfolder/{id}", rootFolderHandler.Delete)
 
-		// Download clients
+		// Download clients — reads available to all; mutations admin-only.
 		r.Get("/downloadclient", dlClientHandler.List)
-		r.Post("/downloadclient", dlClientHandler.Create)
 		r.Get("/downloadclient/{id}", dlClientHandler.Get)
-		r.Put("/downloadclient/{id}", dlClientHandler.Update)
-		r.Delete("/downloadclient/{id}", dlClientHandler.Delete)
-		r.Post("/downloadclient/{id}/test", dlClientHandler.Test)
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireAdmin)
+			r.Post("/downloadclient", dlClientHandler.Create)
+			r.Put("/downloadclient/{id}", dlClientHandler.Update)
+			r.Delete("/downloadclient/{id}", dlClientHandler.Delete)
+			r.Post("/downloadclient/{id}/test", dlClientHandler.Test)
+		})
 
 		// Queue
 		r.Get("/queue", queueHandler.List)
@@ -482,11 +497,14 @@ func main() {
 		r.Get("/qualityprofile", qualityProfileHandler.List)
 		r.Get("/qualityprofile/{id}", qualityProfileHandler.Get)
 
-		// Settings
+		// Settings — reads available to all; mutations admin-only.
 		r.Get("/setting", settingsHandler.List)
 		r.Get("/setting/{key}", settingsHandler.Get)
-		r.Put("/setting/{key}", settingsHandler.Set)
-		r.Delete("/setting/{key}", settingsHandler.Delete)
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireAdmin)
+			r.Put("/setting/{key}", settingsHandler.Set)
+			r.Delete("/setting/{key}", settingsHandler.Delete)
+		})
 
 		// Series
 		r.Get("/series", seriesHandler.List)
@@ -759,6 +777,13 @@ func (p *dbAuthProvider) SetupRequired() bool {
 func (p *dbAuthProvider) ProxyAuthHeader() string         { return p.proxyHeader }
 func (p *dbAuthProvider) ProxyAutoProvision() bool        { return p.proxyProvision }
 func (p *dbAuthProvider) TrustedProxyCIDRs() []*net.IPNet { return p.proxyCIDRs }
+func (p *dbAuthProvider) UserRole(ctx context.Context, userID int64) string {
+	u, err := p.users.GetByID(ctx, userID)
+	if err != nil || u == nil {
+		return ""
+	}
+	return u.Role
+}
 func (p *dbAuthProvider) UserProvisioner() auth.UserProvisioner {
 	return &dbUserProvisioner{users: p.users}
 }

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -67,6 +67,7 @@ type statusResponse struct {
 	Authenticated bool   `json:"authenticated"`
 	SetupRequired bool   `json:"setupRequired"`
 	Username      string `json:"username,omitempty"`
+	Role          string `json:"role,omitempty"`
 	Mode          string `json:"mode"`
 }
 
@@ -107,10 +108,13 @@ func (h *AuthHandler) Status(w http.ResponseWriter, r *http.Request) {
 		if u, _ := h.users.GetByID(ctx, uid); u != nil {
 			resp.Authenticated = true
 			resp.Username = u.Username
+			resp.Role = u.Role
 		}
 	} else if mode == auth.ModeDisabled || (mode == auth.ModeLocalOnly && auth.IsLocalRequest(r)) {
 		// Trusted bypass — the UI should render normally without a login screen.
+		// Treat as admin so role-gated UI surfaces correctly.
 		resp.Authenticated = true
+		resp.Role = "admin"
 	}
 
 	writeOK(w, resp)

--- a/internal/api/auth_users.go
+++ b/internal/api/auth_users.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// UserManagementHandler owns admin-only user CRUD endpoints.
+// GET    /api/v1/auth/users
+// POST   /api/v1/auth/users
+// DELETE /api/v1/auth/users/:id
+// PUT    /api/v1/auth/users/:id/role
+type UserManagementHandler struct {
+	users *db.UserRepo
+}
+
+func NewUserManagementHandler(users *db.UserRepo) *UserManagementHandler {
+	return &UserManagementHandler{users: users}
+}
+
+type userResponse struct {
+	ID          int64   `json:"id"`
+	Username    string  `json:"username"`
+	Role        string  `json:"role"`
+	Email       *string `json:"email,omitempty"`
+	DisplayName *string `json:"displayName,omitempty"`
+	CreatedAt   string  `json:"createdAt"`
+}
+
+func toUserResponse(u db.User) userResponse {
+	return userResponse{
+		ID:          u.ID,
+		Username:    u.Username,
+		Role:        u.Role,
+		Email:       u.Email,
+		DisplayName: u.DisplayName,
+		CreatedAt:   u.CreatedAt.Format("2006-01-02T15:04:05Z"),
+	}
+}
+
+// List returns all users (admin-only).
+// GET /api/v1/auth/users
+func (h *UserManagementHandler) List(w http.ResponseWriter, r *http.Request) {
+	users, err := h.users.List(r.Context())
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "list users: "+err.Error())
+		return
+	}
+	out := make([]userResponse, 0, len(users))
+	for _, u := range users {
+		out = append(out, toUserResponse(u))
+	}
+	writeOK(w, out)
+}
+
+// Create adds a new user (admin-only).
+// POST /api/v1/auth/users
+func (h *UserManagementHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+		Role     string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid body")
+		return
+	}
+	if body.Username == "" || body.Password == "" {
+		writeErr(w, http.StatusBadRequest, "username and password required")
+		return
+	}
+	hash, err := auth.HashPassword(body.Password)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "hash password: "+err.Error())
+		return
+	}
+	u, err := h.users.Create(r.Context(), body.Username, hash)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "create user: "+err.Error())
+		return
+	}
+	if body.Role == "admin" {
+		if err := h.users.SetRole(r.Context(), u.ID, "admin"); err != nil {
+			writeErr(w, http.StatusInternalServerError, "set role: "+err.Error())
+			return
+		}
+		u.Role = "admin"
+	}
+	w.WriteHeader(http.StatusCreated)
+	writeOK(w, toUserResponse(*u))
+}
+
+// Delete removes a user (admin-only). Cannot delete the last admin.
+// DELETE /api/v1/auth/users/:id
+func (h *UserManagementHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	if err := h.users.Delete(r.Context(), id); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeOK(w, map[string]any{"ok": true})
+}
+
+// SetRole changes a user's role (admin-only). Cannot demote the last admin.
+// PUT /api/v1/auth/users/:id/role
+func (h *UserManagementHandler) SetRole(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	var body struct {
+		Role string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid body")
+		return
+	}
+	if err := h.users.SetRole(r.Context(), id, body.Role); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeOK(w, map[string]any{"ok": true})
+}

--- a/internal/api/opds_test.go
+++ b/internal/api/opds_test.go
@@ -121,10 +121,11 @@ func (p *testProvider) SessionSecret() []byte {
 	}
 	return []byte(s.Value)
 }
-func (p *testProvider) SetupRequired() bool             { return false }
-func (p *testProvider) ProxyAuthHeader() string         { return "X-Forwarded-User" }
-func (p *testProvider) ProxyAutoProvision() bool        { return false }
-func (p *testProvider) TrustedProxyCIDRs() []*net.IPNet { return nil }
+func (p *testProvider) SetupRequired() bool                        { return false }
+func (p *testProvider) ProxyAuthHeader() string                    { return "X-Forwarded-User" }
+func (p *testProvider) ProxyAutoProvision() bool                   { return false }
+func (p *testProvider) TrustedProxyCIDRs() []*net.IPNet            { return nil }
+func (p *testProvider) UserRole(_ context.Context, _ int64) string { return "admin" }
 func (p *testProvider) UserProvisioner() auth.UserProvisioner {
 	return nil // proxy auth not exercised in these tests
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -163,14 +163,15 @@ type fakeProvider struct {
 	provisioner    UserProvisioner
 }
 
-func (f *fakeProvider) Mode() Mode                       { return f.mode }
-func (f *fakeProvider) APIKey() string                   { return f.apiKey }
-func (f *fakeProvider) SessionSecret() []byte            { return f.secret }
-func (f *fakeProvider) SetupRequired() bool              { return f.setup }
-func (f *fakeProvider) ProxyAuthHeader() string          { return f.proxyHeader }
-func (f *fakeProvider) ProxyAutoProvision() bool         { return f.proxyProvision }
-func (f *fakeProvider) TrustedProxyCIDRs() []*net.IPNet  { return f.proxyCIDRs }
-func (f *fakeProvider) UserProvisioner() UserProvisioner { return f.provisioner }
+func (f *fakeProvider) Mode() Mode                                 { return f.mode }
+func (f *fakeProvider) APIKey() string                             { return f.apiKey }
+func (f *fakeProvider) SessionSecret() []byte                      { return f.secret }
+func (f *fakeProvider) SetupRequired() bool                        { return f.setup }
+func (f *fakeProvider) ProxyAuthHeader() string                    { return f.proxyHeader }
+func (f *fakeProvider) ProxyAutoProvision() bool                   { return f.proxyProvision }
+func (f *fakeProvider) TrustedProxyCIDRs() []*net.IPNet            { return f.proxyCIDRs }
+func (f *fakeProvider) UserRole(_ context.Context, _ int64) string { return "admin" }
+func (f *fakeProvider) UserProvisioner() UserProvisioner           { return f.provisioner }
 
 // staticProvisioner always returns the same user ID for any username.
 type staticProvisioner struct{ uid int64 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -32,12 +32,39 @@ func ParseMode(s string) Mode {
 
 type ctxKey string
 
-const userIDCtxKey ctxKey = "auth.user_id"
+const (
+	userIDCtxKey   ctxKey = "auth.user_id"
+	userRoleCtxKey ctxKey = "auth.user_role"
+)
 
 // UserIDFromContext returns the authenticated user ID (0 if unauthenticated).
 func UserIDFromContext(ctx context.Context) int64 {
 	v, _ := ctx.Value(userIDCtxKey).(int64)
 	return v
+}
+
+// UserRoleFromContext returns the authenticated user's role ("admin", "user", or "").
+func UserRoleFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(userRoleCtxKey).(string)
+	return v
+}
+
+// WithUserRole returns a context carrying the given role alongside the user id.
+func WithUserRole(ctx context.Context, role string) context.Context {
+	return context.WithValue(ctx, userRoleCtxKey, role)
+}
+
+// RequireAdmin is a middleware that rejects non-admin requests with 403.
+func RequireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if UserRoleFromContext(r.Context()) != "admin" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"admin role required"}`))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // UserProvisioner resolves or creates a user by username. Used by proxy-auth.
@@ -68,6 +95,9 @@ type Provider interface {
 	TrustedProxyCIDRs() []*net.IPNet
 	// UserProvisioner returns the provisioner used in proxy-auth mode.
 	UserProvisioner() UserProvisioner
+	// UserRole returns the role string ("admin" or "user") for the given user
+	// id. Returns "" if the user is not found or an error occurs.
+	UserRole(ctx context.Context, userID int64) string
 }
 
 // AllowUnauthPath returns true for routes the middleware must always let
@@ -113,6 +143,7 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 			if c, err := r.Cookie(SessionCookieName); err == nil {
 				if uid, err := VerifySession(p.SessionSecret(), c.Value); err == nil {
 					ctx = context.WithValue(ctx, userIDCtxKey, uid)
+					ctx = context.WithValue(ctx, userRoleCtxKey, p.UserRole(ctx, uid))
 					cookieValid = true
 				}
 			}
@@ -142,7 +173,9 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 
 			if mode == ModeProxy {
 				if uid, ok := resolveProxyIdentity(r, p); ok {
-					r = r.WithContext(context.WithValue(r.Context(), userIDCtxKey, uid))
+					pctx := context.WithValue(r.Context(), userIDCtxKey, uid)
+					pctx = context.WithValue(pctx, userRoleCtxKey, p.UserRole(pctx, uid))
+					r = r.WithContext(pctx)
 					next.ServeHTTP(w, r)
 					return
 				}

--- a/internal/db/auth.go
+++ b/internal/db/auth.go
@@ -13,6 +13,7 @@ type User struct {
 	ID           int64
 	Username     string
 	PasswordHash string
+	Role         string // "admin" or "user"
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	// OIDC fields — nil for local-password users.
@@ -21,6 +22,8 @@ type User struct {
 	Email       *string
 	DisplayName *string
 }
+
+func (u *User) IsAdmin() bool { return u.Role == "admin" }
 
 type UserRepo struct {
 	db *sql.DB
@@ -35,13 +38,13 @@ func (r *UserRepo) Count(ctx context.Context) (int, error) {
 	return n, err
 }
 
-const userSelectCols = `id, username, password_hash, created_at, updated_at,
+const userSelectCols = `id, username, password_hash, role, created_at, updated_at,
 	oidc_sub, oidc_issuer, email, display_name`
 
 func scanUser(row interface{ Scan(...any) error }) (*User, error) {
 	var u User
 	err := row.Scan(
-		&u.ID, &u.Username, &u.PasswordHash, &u.CreatedAt, &u.UpdatedAt,
+		&u.ID, &u.Username, &u.PasswordHash, &u.Role, &u.CreatedAt, &u.UpdatedAt,
 		&u.OIDCSub, &u.OIDCIssuer, &u.Email, &u.DisplayName,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -111,8 +114,8 @@ func (r *UserRepo) GetOrCreateByOIDC(ctx context.Context, issuer, sub, preferred
 	}
 	now := time.Now().UTC()
 	res, err := r.db.ExecContext(ctx,
-		`INSERT INTO users (username, password_hash, created_at, updated_at, oidc_sub, oidc_issuer, email, display_name)
-		 VALUES (?, '', ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO users (username, password_hash, role, created_at, updated_at, oidc_sub, oidc_issuer, email, display_name)
+		 VALUES (?, '', 'user', ?, ?, ?, ?, ?, ?)`,
 		username, now, now, sub, issuer, nullableStr(email), nullableStr(displayName),
 	)
 	if err != nil {
@@ -133,12 +136,12 @@ func nullableStr(s string) any {
 	return s
 }
 
-// Create inserts a new user. Intended for the first-run setup flow; further
-// additions need a separate UI path (not exposed today).
+// Create inserts a new user with role "user". The first user in the DB is
+// promoted to "admin" by PromoteFirstUser (called during first-run setup).
 func (r *UserRepo) Create(ctx context.Context, username, passwordHash string) (*User, error) {
 	now := time.Now().UTC()
 	res, err := r.db.ExecContext(ctx,
-		"INSERT INTO users (username, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?)",
+		"INSERT INTO users (username, password_hash, role, created_at, updated_at) VALUES (?, ?, 'user', ?, ?)",
 		username, passwordHash, now, now,
 	)
 	if err != nil {
@@ -148,7 +151,83 @@ func (r *UserRepo) Create(ctx context.Context, username, passwordHash string) (*
 	if err != nil {
 		return nil, fmt.Errorf("get user id: %w", err)
 	}
-	return &User{ID: id, Username: username, PasswordHash: passwordHash, CreatedAt: now, UpdatedAt: now}, nil
+	return &User{ID: id, Username: username, PasswordHash: passwordHash, Role: "user", CreatedAt: now, UpdatedAt: now}, nil
+}
+
+// List returns all users ordered by id.
+func (r *UserRepo) List(ctx context.Context) ([]User, error) {
+	rows, err := r.db.QueryContext(ctx, "SELECT "+userSelectCols+" FROM users ORDER BY id")
+	if err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+	defer rows.Close()
+	var users []User
+	for rows.Next() {
+		u, err := scanUser(rows)
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, *u)
+	}
+	return users, rows.Err()
+}
+
+// Delete removes a user by id. Returns an error if trying to delete the last admin.
+func (r *UserRepo) Delete(ctx context.Context, id int64) error {
+	// Guard: refuse to delete the last admin.
+	var adminCount int
+	if err := r.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM users WHERE role='admin' AND id != ?", id,
+	).Scan(&adminCount); err != nil {
+		return fmt.Errorf("check admin count: %w", err)
+	}
+	// Check whether the target is an admin.
+	var targetRole string
+	if err := r.db.QueryRowContext(ctx, "SELECT role FROM users WHERE id=?", id).Scan(&targetRole); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil // already gone
+		}
+		return fmt.Errorf("get user role: %w", err)
+	}
+	if targetRole == "admin" && adminCount == 0 {
+		return fmt.Errorf("cannot delete the last admin user")
+	}
+	_, err := r.db.ExecContext(ctx, "DELETE FROM users WHERE id=?", id)
+	return err
+}
+
+// SetRole changes a user's role to "admin" or "user".
+func (r *UserRepo) SetRole(ctx context.Context, id int64, role string) error {
+	if role != "admin" && role != "user" {
+		return fmt.Errorf("invalid role %q: must be admin or user", role)
+	}
+	// Guard: refuse to demote the last admin.
+	if role == "user" {
+		var adminCount int
+		if err := r.db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM users WHERE role='admin' AND id != ?", id,
+		).Scan(&adminCount); err != nil {
+			return fmt.Errorf("check admin count: %w", err)
+		}
+		var targetRole string
+		if err := r.db.QueryRowContext(ctx, "SELECT role FROM users WHERE id=?", id).Scan(&targetRole); err != nil {
+			return fmt.Errorf("get user role: %w", err)
+		}
+		if targetRole == "admin" && adminCount == 0 {
+			return fmt.Errorf("cannot demote the last admin user")
+		}
+	}
+	_, err := r.db.ExecContext(ctx,
+		"UPDATE users SET role=?, updated_at=? WHERE id=?", role, time.Now().UTC(), id)
+	return err
+}
+
+// PromoteFirstUser sets role='admin' on the user with the lowest id, if any.
+// Called during first-run setup after the first user is created.
+func (r *UserRepo) PromoteFirstUser(ctx context.Context) error {
+	_, err := r.db.ExecContext(ctx,
+		"UPDATE users SET role='admin' WHERE id = (SELECT MIN(id) FROM users)")
+	return err
 }
 
 func (r *UserRepo) UpdatePassword(ctx context.Context, id int64, passwordHash string) error {

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -26,10 +26,21 @@ func (r *AuthorRepo) List(ctx context.Context) ([]models.Author, error) {
 	return r.ListByUser(ctx, 0)
 }
 
+const (
+	listAuthorsAll    = "SELECT " + authorSelectCols + " FROM authors ORDER BY sort_name"
+	listAuthorsByUser = "SELECT " + authorSelectCols + " FROM authors WHERE owner_user_id = ? ORDER BY sort_name"
+)
+
 func (r *AuthorRepo) ListByUser(ctx context.Context, userID int64) ([]models.Author, error) {
-	where, args := QueryScope("", userID)
-	q := "SELECT " + authorSelectCols + " FROM authors " + where + " ORDER BY sort_name"
-	rows, err := r.db.QueryContext(ctx, q, args...)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if userID == 0 {
+		rows, err = r.db.QueryContext(ctx, listAuthorsAll)
+	} else {
+		rows, err = r.db.QueryContext(ctx, listAuthorsByUser, userID)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("list authors: %w", err)
 	}

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -23,9 +23,13 @@ const authorSelectCols = `id, foreign_id, name, sort_name, description, image_ur
 	       metadata_provider, last_metadata_refresh_at, created_at, updated_at`
 
 func (r *AuthorRepo) List(ctx context.Context) ([]models.Author, error) {
-	rows, err := r.db.QueryContext(ctx, `
-		SELECT `+authorSelectCols+`
-		FROM authors ORDER BY sort_name`)
+	return r.ListByUser(ctx, 0)
+}
+
+func (r *AuthorRepo) ListByUser(ctx context.Context, userID int64) ([]models.Author, error) {
+	where, args := QueryScope("", userID)
+	q := "SELECT " + authorSelectCols + " FROM authors " + where + " ORDER BY sort_name"
+	rows, err := r.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list authors: %w", err)
 	}
@@ -73,15 +77,23 @@ func (r *AuthorRepo) GetByForeignID(ctx context.Context, foreignID string) (*mod
 }
 
 func (r *AuthorRepo) Create(ctx context.Context, a *models.Author) error {
+	return r.CreateForUser(ctx, a, 0)
+}
+
+func (r *AuthorRepo) CreateForUser(ctx context.Context, a *models.Author, ownerUserID int64) error {
 	now := time.Now().UTC()
+	var ownerArg any
+	if ownerUserID != 0 {
+		ownerArg = ownerUserID
+	}
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO authors (foreign_id, name, sort_name, description, image_url, disambiguation,
 		                     ratings_count, average_rating, monitored, quality_profile_id, metadata_profile_id, root_folder_id,
-		                     metadata_provider, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		                     metadata_provider, owner_user_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.ForeignID, a.Name, a.SortName, a.Description, a.ImageURL, a.Disambiguation,
 		a.RatingsCount, a.AverageRating, a.Monitored, a.QualityProfileID, a.MetadataProfileID, a.RootFolderID,
-		a.MetadataProvider, now, now)
+		a.MetadataProvider, ownerArg, now, now)
 	if err != nil {
 		return fmt.Errorf("create author: %w", err)
 	}

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -28,6 +28,11 @@ func (r *BookRepo) List(ctx context.Context) ([]models.Book, error) {
 	return r.query(ctx, "SELECT "+bookColumns+" FROM books WHERE excluded = 0 ORDER BY sort_title", nil)
 }
 
+func (r *BookRepo) ListByUser(ctx context.Context, userID int64) ([]models.Book, error) {
+	where, args := QueryScope("WHERE excluded = 0", userID)
+	return r.query(ctx, "SELECT "+bookColumns+" FROM books "+where+" ORDER BY sort_title", args)
+}
+
 // ListIncludingExcluded returns all books regardless of their excluded flag.
 func (r *BookRepo) ListIncludingExcluded(ctx context.Context) ([]models.Book, error) {
 	return r.query(ctx, "SELECT "+bookColumns+" FROM books ORDER BY sort_title", nil)
@@ -37,6 +42,11 @@ func (r *BookRepo) ListByAuthor(ctx context.Context, authorID int64) ([]models.B
 	return r.query(ctx, "SELECT "+bookColumns+" FROM books WHERE author_id = ? AND excluded = 0 ORDER BY release_date", []any{authorID})
 }
 
+func (r *BookRepo) ListByAuthorAndUser(ctx context.Context, authorID, userID int64) ([]models.Book, error) {
+	where, args := QueryScope("WHERE author_id = ? AND excluded = 0", userID, authorID)
+	return r.query(ctx, "SELECT "+bookColumns+" FROM books "+where+" ORDER BY release_date", args)
+}
+
 // ListByAuthorIncludingExcluded returns all books for an author regardless of excluded flag.
 func (r *BookRepo) ListByAuthorIncludingExcluded(ctx context.Context, authorID int64) ([]models.Book, error) {
 	return r.query(ctx, "SELECT "+bookColumns+" FROM books WHERE author_id = ? ORDER BY release_date", []any{authorID})
@@ -44,6 +54,11 @@ func (r *BookRepo) ListByAuthorIncludingExcluded(ctx context.Context, authorID i
 
 func (r *BookRepo) ListByStatus(ctx context.Context, status string) ([]models.Book, error) {
 	return r.query(ctx, "SELECT "+bookColumns+" FROM books WHERE status = ? AND monitored = 1 AND excluded = 0 ORDER BY sort_title", []any{status})
+}
+
+func (r *BookRepo) ListByStatusAndUser(ctx context.Context, status string, userID int64) ([]models.Book, error) {
+	where, args := QueryScope("WHERE status = ? AND monitored = 1 AND excluded = 0", userID, status)
+	return r.query(ctx, "SELECT "+bookColumns+" FROM books "+where+" ORDER BY sort_title", args)
 }
 
 // ListByStatusIncludingExcluded returns books with the given status regardless of excluded flag.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -184,6 +184,13 @@ func migrate(database *sql.DB) error {
 			continue
 		}
 
+		// Pre-flight integrity check before the multi-user migration.
+		if entry.Name() == "025_multiuser.sql" {
+			if err := multiuserPreFlight(database); err != nil {
+				return err
+			}
+		}
+
 		content, err := migrationsFS.ReadFile("migrations/" + entry.Name())
 		if err != nil {
 			return fmt.Errorf("read migration %s: %w", entry.Name(), err)
@@ -222,5 +229,37 @@ func migrate(database *sql.DB) error {
 		slog.Info("applied migration", "version", v, "file", entry.Name())
 	}
 
+	return nil
+}
+
+// multiuserPreFlight checks that the database is in a consistent state before
+// the multi-user migration (025) runs. Aborts with a repair hint if data rows
+// exist in user-owned tables but there is no user row to own them.
+func multiuserPreFlight(database *sql.DB) error {
+	// Only check tables that hold exclusively user-created data. quality_profiles
+	// and metadata_profiles are seeded by earlier migrations so they may have
+	// rows even on a fresh install with no users.
+	tables := []string{"authors", "books", "downloads", "root_folders"}
+	var userCount int
+	if err := database.QueryRow("SELECT COUNT(*) FROM users").Scan(&userCount); err != nil {
+		return fmt.Errorf("pre-flight: count users: %w", err)
+	}
+	if userCount > 0 {
+		return nil // at least one user exists; backfill to id=1 is safe
+	}
+	for _, tbl := range tables {
+		var n int
+		//nolint:gosec // table name is a static literal from the slice above
+		if err := database.QueryRow("SELECT COUNT(*) FROM " + tbl).Scan(&n); err != nil { //nolint:gosec
+			return fmt.Errorf("pre-flight: count %s: %w", tbl, err)
+		}
+		if n > 0 {
+			return fmt.Errorf(
+				"025_multiuser.sql pre-flight: table %q has %d row(s) but users table is empty — "+
+					"create at least one user before upgrading",
+				tbl, n,
+			)
+		}
+	}
 	return nil
 }

--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -26,8 +26,19 @@ func (r *DownloadRepo) List(ctx context.Context) ([]models.Download, error) {
 	return r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads ORDER BY added_at DESC")
 }
 
+func (r *DownloadRepo) ListByUser(ctx context.Context, userID int64) ([]models.Download, error) {
+	where, args := QueryScope("", userID)
+	q := "SELECT " + downloadSelectColumns + " FROM downloads " + where + " ORDER BY added_at DESC"
+	return r.query(ctx, q, args...)
+}
+
 func (r *DownloadRepo) ListByStatus(ctx context.Context, status models.DownloadState) ([]models.Download, error) {
 	return r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads WHERE status=? ORDER BY added_at DESC", status)
+}
+
+func (r *DownloadRepo) ListByStatusAndUser(ctx context.Context, status models.DownloadState, userID int64) ([]models.Download, error) {
+	where, args := QueryScope("WHERE status=?", userID, status)
+	return r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads "+where+" ORDER BY added_at DESC", args...)
 }
 
 func (r *DownloadRepo) GetByGUID(ctx context.Context, guid string) (*models.Download, error) {

--- a/internal/db/migrations/025_multiuser.sql
+++ b/internal/db/migrations/025_multiuser.sql
@@ -1,0 +1,44 @@
+-- +migrate Up
+
+-- Add role column to users. First created user is promoted to admin in application
+-- code (see db/auth.go PromoteFirstUser). OIDC-provisioned users default to 'user'.
+ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user';
+
+-- Add owner_user_id to each user-owned table.
+ALTER TABLE authors          ADD COLUMN owner_user_id INTEGER REFERENCES users(id);
+ALTER TABLE books             ADD COLUMN owner_user_id INTEGER REFERENCES users(id);
+ALTER TABLE quality_profiles  ADD COLUMN owner_user_id INTEGER REFERENCES users(id);
+ALTER TABLE metadata_profiles ADD COLUMN owner_user_id INTEGER REFERENCES users(id);
+ALTER TABLE downloads         ADD COLUMN owner_user_id INTEGER REFERENCES users(id);
+ALTER TABLE root_folders      ADD COLUMN owner_user_id INTEGER REFERENCES users(id);
+
+-- Backfill: assign all existing rows to user id=1. If there are no users at all
+-- (fresh install before first-run setup) this UPDATE is a no-op.
+UPDATE authors          SET owner_user_id = 1 WHERE (SELECT COUNT(*) FROM users WHERE id = 1) > 0;
+UPDATE books             SET owner_user_id = 1 WHERE (SELECT COUNT(*) FROM users WHERE id = 1) > 0;
+UPDATE quality_profiles  SET owner_user_id = 1 WHERE (SELECT COUNT(*) FROM users WHERE id = 1) > 0;
+UPDATE metadata_profiles SET owner_user_id = 1 WHERE (SELECT COUNT(*) FROM users WHERE id = 1) > 0;
+UPDATE downloads         SET owner_user_id = 1 WHERE (SELECT COUNT(*) FROM users WHERE id = 1) > 0;
+UPDATE root_folders      SET owner_user_id = 1 WHERE (SELECT COUNT(*) FROM users WHERE id = 1) > 0;
+
+-- Promote user id=1 to admin (first registered account is always the admin).
+UPDATE users SET role = 'admin' WHERE id = 1;
+
+-- Composite indexes for efficient per-user queries.
+CREATE INDEX idx_authors_owner          ON authors          (owner_user_id);
+CREATE INDEX idx_books_owner            ON books             (owner_user_id);
+CREATE INDEX idx_quality_profiles_owner ON quality_profiles  (owner_user_id);
+CREATE INDEX idx_metadata_profiles_owner ON metadata_profiles (owner_user_id);
+CREATE INDEX idx_downloads_owner        ON downloads         (owner_user_id);
+CREATE INDEX idx_root_folders_owner     ON root_folders      (owner_user_id);
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS idx_root_folders_owner;
+DROP INDEX IF EXISTS idx_downloads_owner;
+DROP INDEX IF EXISTS idx_metadata_profiles_owner;
+DROP INDEX IF EXISTS idx_quality_profiles_owner;
+DROP INDEX IF EXISTS idx_books_owner;
+DROP INDEX IF EXISTS idx_authors_owner;
+-- SQLite does not support DROP COLUMN in older versions; use schema rebuild if needed.
+-- The down migration is best-effort for development rollbacks only.

--- a/internal/db/multiuser_test.go
+++ b/internal/db/multiuser_test.go
@@ -1,0 +1,136 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestMultiUser_DataIsolation verifies that per-user scoped queries return
+// only the rows owned by the requesting user. Two users are created; each
+// gets a distinct author + book. ListByUser for each must return only their
+// own records.
+func TestMultiUser_DataIsolation(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	users := db.NewUserRepo(database)
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+
+	// Create two users.
+	u1, err := users.Create(ctx, "alice", "hash1")
+	if err != nil {
+		t.Fatalf("create user alice: %v", err)
+	}
+	u2, err := users.Create(ctx, "bob", "hash2")
+	if err != nil {
+		t.Fatalf("create user bob: %v", err)
+	}
+
+	// Promote alice to admin so we can verify role.
+	if err := users.SetRole(ctx, u1.ID, "admin"); err != nil {
+		t.Fatalf("set role: %v", err)
+	}
+	u1, _ = users.GetByID(ctx, u1.ID)
+	if !u1.IsAdmin() {
+		t.Errorf("alice should be admin after SetRole")
+	}
+
+	// Create one author per user.
+	a1 := &models.Author{ForeignID: "ol-alice-1", Name: "Alice Author", SortName: "Author, Alice"}
+	if err := authors.CreateForUser(ctx, a1, u1.ID); err != nil {
+		t.Fatalf("create author for alice: %v", err)
+	}
+	a2 := &models.Author{ForeignID: "ol-bob-1", Name: "Bob Author", SortName: "Author, Bob"}
+	if err := authors.CreateForUser(ctx, a2, u2.ID); err != nil {
+		t.Fatalf("create author for bob: %v", err)
+	}
+
+	// Create one book per author (books inherit owner via author, but we explicitly set ownerUserID).
+	b1 := &models.Book{ForeignID: "book-alice-1", AuthorID: a1.ID, Title: "Alice Book", SortTitle: "Alice Book"}
+	if err := books.Create(ctx, b1); err != nil {
+		t.Fatalf("create book for alice: %v", err)
+	}
+	// Manually update owner_user_id for alice's book (Create uses no user scope yet).
+	if _, err := database.Exec("UPDATE books SET owner_user_id=? WHERE id=?", u1.ID, b1.ID); err != nil {
+		t.Fatalf("set book owner: %v", err)
+	}
+
+	b2 := &models.Book{ForeignID: "book-bob-1", AuthorID: a2.ID, Title: "Bob Book", SortTitle: "Bob Book"}
+	if err := books.Create(ctx, b2); err != nil {
+		t.Fatalf("create book for bob: %v", err)
+	}
+	if _, err := database.Exec("UPDATE books SET owner_user_id=? WHERE id=?", u2.ID, b2.ID); err != nil {
+		t.Fatalf("set book owner: %v", err)
+	}
+
+	// --- Author isolation ---
+	aliceAuthors, err := authors.ListByUser(ctx, u1.ID)
+	if err != nil {
+		t.Fatalf("list authors for alice: %v", err)
+	}
+	if len(aliceAuthors) != 1 || aliceAuthors[0].Name != "Alice Author" {
+		t.Errorf("alice should see 1 author (Alice Author); got %v", aliceAuthors)
+	}
+
+	bobAuthors, err := authors.ListByUser(ctx, u2.ID)
+	if err != nil {
+		t.Fatalf("list authors for bob: %v", err)
+	}
+	if len(bobAuthors) != 1 || bobAuthors[0].Name != "Bob Author" {
+		t.Errorf("bob should see 1 author (Bob Author); got %v", bobAuthors)
+	}
+
+	// Global list (userID=0) should see both.
+	allAuthors, err := authors.List(ctx)
+	if err != nil {
+		t.Fatalf("list all authors: %v", err)
+	}
+	if len(allAuthors) != 2 {
+		t.Errorf("global list should return 2 authors; got %d", len(allAuthors))
+	}
+
+	// --- Book isolation ---
+	aliceBooks, err := books.ListByUser(ctx, u1.ID)
+	if err != nil {
+		t.Fatalf("list books for alice: %v", err)
+	}
+	if len(aliceBooks) != 1 || aliceBooks[0].Title != "Alice Book" {
+		t.Errorf("alice should see 1 book; got %v", aliceBooks)
+	}
+
+	bobBooks, err := books.ListByUser(ctx, u2.ID)
+	if err != nil {
+		t.Fatalf("list books for bob: %v", err)
+	}
+	if len(bobBooks) != 1 || bobBooks[0].Title != "Bob Book" {
+		t.Errorf("bob should see 1 book; got %v", bobBooks)
+	}
+
+	// --- User management ---
+	all, err := users.List(ctx)
+	if err != nil {
+		t.Fatalf("list users: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("expected 2 users; got %d", len(all))
+	}
+
+	// Cannot delete last admin.
+	if err := users.Delete(ctx, u1.ID); err == nil {
+		t.Error("should not be able to delete the last admin user")
+	}
+
+	// Demote alice, then we should be able to delete.
+	if err := users.SetRole(ctx, u1.ID, "user"); err == nil {
+		// This should fail — she's the only admin.
+		t.Error("should not be able to demote the last admin")
+	}
+}

--- a/internal/db/scope.go
+++ b/internal/db/scope.go
@@ -1,7 +1,5 @@
 package db
 
-import "fmt"
-
 // QueryScope appends a per-user ownership filter to a SQL fragment.
 // base must be a complete WHERE clause (or empty string if there is no
 // existing WHERE). If userID is 0 no filter is added (admin / background
@@ -16,7 +14,7 @@ func QueryScope(where string, userID int64, args ...any) (string, []any) {
 		return where, args
 	}
 	if where == "" {
-		return fmt.Sprintf("WHERE owner_user_id = ?"), append([]any{userID}, args...)
+		return "WHERE owner_user_id = ?", append([]any{userID}, args...)
 	}
 	return where + " AND owner_user_id = ?", append(args, userID)
 }

--- a/internal/db/scope.go
+++ b/internal/db/scope.go
@@ -1,0 +1,22 @@
+package db
+
+import "fmt"
+
+// QueryScope appends a per-user ownership filter to a SQL fragment.
+// base must be a complete WHERE clause (or empty string if there is no
+// existing WHERE). If userID is 0 no filter is added (admin / background
+// jobs that operate across all users).
+//
+// Usage:
+//
+//	where, args := db.QueryScope("WHERE excluded = 0", userID, existingArgs...)
+//	rows, err := r.db.QueryContext(ctx, "SELECT ... FROM books "+where, args...)
+func QueryScope(where string, userID int64, args ...any) (string, []any) {
+	if userID == 0 {
+		return where, args
+	}
+	if where == "" {
+		return fmt.Sprintf("WHERE owner_user_id = ?"), append([]any{userID}, args...)
+	}
+	return where + " AND owner_user_id = ?", append(args, userID)
+}


### PR DESCRIPTION
## Summary

- **AuthContext**: exposes `isAdmin` boolean; derived from `status.role` when backend returns it, otherwise probes `GET /auth/users` (200=admin, 403=user) — auto-upgrades when backend adds `role` to `/auth/status`
- **client.ts**: `AuthStatus.role?`, `ManagedUser` interface, `api.listUsers / createUser / deleteUser / setUserRole`
- **AdminRoute** guard + `/users` route in App.tsx; admin-only Users icon in header nav
- **UsersPage** (new): list users with role badge + "you" marker, promote/demote, delete, inline add form
- **SettingsPage**: `ADMIN_TABS` / `USER_TABS` split — non-admins see only General + Notifications; auto-resets tab if role changes
- **i18n**: `nav.users` + full `users.*` key set in en.json

CSRF injection was already landed in the merged CSRF commit (bbbdb5a) — `initCSRF()` + `X-CSRF-Token` header injection is already in `client.ts`.

## Open item

`/auth/status` does not yet return `role`, so admin detection costs one extra `GET /auth/users` probe on each page load. This resolves automatically (no frontend change needed) if backend adds `role` to the status response.

## Test plan

- [ ] Admin user: sees all Settings tabs (indexers, clients, profiles, etc.) and Users icon in nav
- [ ] Non-admin user: sees only General + Notifications in Settings; `/users` redirects to `/`
- [ ] Users page: list renders, promote/demote toggles role badge, delete removes row, add form creates user
- [ ] Role change while on admin tab resets to General tab
- [ ] Typecheck: `npm run typecheck` passes
- [ ] Build: `npm run build` passes