### PR TITLE
fix: CSRF middleware blocks login (production blocker)

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -411,17 +411,32 @@ func TestRequireCSRFToken_AllowsSafeMethod(t *testing.T) {
 	}
 }
 
-func TestRequireCSRFToken_BlocksMutationWithoutToken(t *testing.T) {
+func TestRequireCSRFToken_AllowsMutationWithoutSessionCookie(t *testing.T) {
 	secret := []byte("s")
 	mw := RequireCSRFToken(func() []byte { return secret })
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
-	// Simulate a cross-origin POST: no session cookie, no CSRF token.
+	// No session cookie → not cookie-authenticated (e.g. POST /auth/login); must pass through.
+	req, _ := http.NewRequest("POST", "/api/v1/auth/login", nil)
+	h.ServeHTTP(nopWriter{}, req)
+	if !called {
+		t.Fatal("POST without session cookie must pass through — CSRF only applies to cookie-auth sessions")
+	}
+}
+
+func TestRequireCSRFToken_BlocksMutationWithSessionButNoToken(t *testing.T) {
+	secret := []byte("s")
+	sessionVal := SignSession(secret, 1, time.Now().Add(time.Hour))
+	mw := RequireCSRFToken(func() []byte { return secret })
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	// Session cookie present but no CSRF token — cross-origin attack scenario.
 	req, _ := http.NewRequest("POST", "/api/v1/author", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessionVal})
 	w := &captureWriter{}
 	h.ServeHTTP(w, req)
 	if called {
-		t.Fatal("POST without CSRF token and no API key must be rejected")
+		t.Fatal("POST with session cookie but no CSRF token must be rejected")
 	}
 	if w.status != http.StatusForbidden {
 		t.Errorf("status = %d; want 403", w.status)

--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -32,7 +32,8 @@ func ValidCSRFToken(secret []byte, r *http.Request, token string) bool {
 // RequireCSRFToken rejects state-mutating requests that lack a valid
 // X-CSRF-Token header. Requests authenticated via API key are exempt because
 // CSRF only threatens cookie-based auth. GET / HEAD / OPTIONS are safe methods
-// and are always passed through.
+// and are always passed through. Requests with no session cookie are also
+// exempt — they are not cookie-authenticated (e.g. POST /auth/login).
 func RequireCSRFToken(secret func() []byte) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -41,6 +42,10 @@ func RequireCSRFToken(secret func() []byte) func(http.Handler) http.Handler {
 				// safe methods — no mutation risk
 			default:
 				if requestAPIKey(r) == "" {
+					// No session cookie → not a cookie-authenticated request; CSRF doesn't apply.
+					if c, err := r.Cookie(SessionCookieName); err != nil || c.Value == "" {
+						break
+					}
 					tok := r.Header.Get("X-CSRF-Token")
 					if !ValidCSRFToken(secret(), r, tok) {
 						w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Problem

`RequireCSRFToken` wraps all of `/api/v1`, including `POST /auth/login`. Before this fix, any POST without a session cookie was rejected with 403 — meaning users could not log in at all.

## Root cause

`ValidCSRFToken` returns `false` when no session cookie is present (correct behaviour), but `RequireCSRFToken` was calling it unconditionally for all non-safe-method requests, treating the false return as a CSRF violation rather than "not applicable".

## Fix

In the non-safe-method branch, bail out early with `break` when no session cookie is present. CSRF only threatens authenticated cookie sessions — no cookie means no session to protect.

```go
// No session cookie → not a cookie-authenticated request; CSRF doesn't apply.
if c, err := r.Cookie(SessionCookieName); err != nil || c.Value == "" {
    break
}
```

## Tests

- `TestRequireCSRFToken_AllowsMutationWithoutSessionCookie` — POST with no cookie passes through
- `TestRequireCSRFToken_BlocksMutationWithSessionButNoToken` — POST with session cookie but no CSRF token is correctly rejected (403)

Fixes production blocker introduced by #296.