### PR TITLE
fix: CSRF blocks login with stale session cookie

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -411,16 +411,17 @@ func TestRequireCSRFToken_AllowsSafeMethod(t *testing.T) {
 	}
 }
 
-func TestRequireCSRFToken_AllowsMutationWithoutSessionCookie(t *testing.T) {
+func TestRequireCSRFToken_AllowsUnauthPath(t *testing.T) {
 	secret := []byte("s")
 	mw := RequireCSRFToken(func() []byte { return secret })
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
-	// No session cookie → not cookie-authenticated (e.g. POST /auth/login); must pass through.
+	// AllowUnauthPath routes must always pass through, even with a stale session cookie.
 	req, _ := http.NewRequest("POST", "/api/v1/auth/login", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: "stale-cookie-value"})
 	h.ServeHTTP(nopWriter{}, req)
 	if !called {
-		t.Fatal("POST without session cookie must pass through — CSRF only applies to cookie-auth sessions")
+		t.Fatal("POST to AllowUnauthPath must pass through regardless of session cookie")
 	}
 }
 

--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -30,10 +30,8 @@ func ValidCSRFToken(secret []byte, r *http.Request, token string) bool {
 }
 
 // RequireCSRFToken rejects state-mutating requests that lack a valid
-// X-CSRF-Token header. Requests authenticated via API key are exempt because
-// CSRF only threatens cookie-based auth. GET / HEAD / OPTIONS are safe methods
-// and are always passed through. Requests with no session cookie are also
-// exempt — they are not cookie-authenticated (e.g. POST /auth/login).
+// X-CSRF-Token header. Exempt: API-key requests, safe methods, AllowUnauthPath
+// routes (login, logout, setup…), and requests with no session cookie.
 func RequireCSRFToken(secret func() []byte) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -41,17 +39,15 @@ func RequireCSRFToken(secret func() []byte) func(http.Handler) http.Handler {
 			case http.MethodGet, http.MethodHead, http.MethodOptions:
 				// safe methods — no mutation risk
 			default:
-				if requestAPIKey(r) == "" {
-					// No session cookie → not a cookie-authenticated request; CSRF doesn't apply.
-					if c, err := r.Cookie(SessionCookieName); err != nil || c.Value == "" {
-						break
-					}
-					tok := r.Header.Get("X-CSRF-Token")
-					if !ValidCSRFToken(secret(), r, tok) {
-						w.Header().Set("Content-Type", "application/json")
-						w.WriteHeader(http.StatusForbidden)
-						_, _ = w.Write([]byte(`{"error":"invalid or missing CSRF token"}`))
-						return
+				if requestAPIKey(r) == "" && !AllowUnauthPath(r.URL.Path) {
+					if c, err := r.Cookie(SessionCookieName); err == nil && c.Value != "" {
+						tok := r.Header.Get("X-CSRF-Token")
+						if !ValidCSRFToken(secret(), r, tok) {
+							w.Header().Set("Content-Type", "application/json")
+							w.WriteHeader(http.StatusForbidden)
+							_, _ = w.Write([]byte(`{"error":"invalid or missing CSRF token"}`))
+							return
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Problem

A stale session cookie (from a previous session or a logout that raced) causes `RequireCSRFToken` to fire on `POST /auth/login` — the cookie is present so the no-cookie early-exit doesn't help, but there's no CSRF token because the user hasn't logged in yet.

## Fix

Add `!AllowUnauthPath(r.URL.Path)` to the CSRF enforcement condition. Login, logout, setup, and OIDC endpoints are already explicitly public; they cannot be targeted by CSRF (CSRF requires the victim to be authenticated), so skipping the check there is both correct and safe.

```go
if requestAPIKey(r) == "" && !AllowUnauthPath(r.URL.Path) {
    if c, err := r.Cookie(SessionCookieName); err == nil && c.Value != "" {
        // enforce X-CSRF-Token
    }
}
```

## Test

`TestRequireCSRFToken_AllowsUnauthPath` — sends a stale session cookie on `POST /auth/login` and verifies the request passes through.

Follows #299 (no-cookie fix). Completes the fix for the production login blocker.