### PR TITLE
feat(auth): multi-user admin UI (UsersPage, isAdmin, admin nav)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -94,7 +94,7 @@ function Shell() {
                       isActive ? 'bg-slate-200 dark:bg-zinc-800 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'
                     }`
                   }
-                  title="Users"
+                  title={t('nav.users')}
                 >
                   <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
@@ -184,7 +184,7 @@ function Shell() {
                   className={mobileLinkClass}
                   onClick={() => setMenuOpen(false)}
                 >
-                  Users
+                  {t('nav.users')}
                 </NavLink>
               )}
               <NavLink

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import BookDetailPage from './pages/BookDetailPage'
 import WantedPage from './pages/WantedPage'
 import QueuePage from './pages/QueuePage'
 import SettingsPage from './pages/SettingsPage'
+import UsersPage from './pages/UsersPage'
 import HistoryPage from './pages/HistoryPage'
 import SeriesPage from './pages/SeriesPage'
 import CalendarPage from './pages/CalendarPage'
@@ -37,7 +38,7 @@ function Shell() {
   const { t } = useTranslation()
   const [version, setVersion] = useState('')
   const [menuOpen, setMenuOpen] = useState(false)
-  const { status, logout } = useAuth()
+  const { status, logout, isAdmin } = useAuth()
 
   useEffect(() => {
     api.status().then(s => setVersion(s.version)).catch(() => {})
@@ -85,6 +86,21 @@ function Shell() {
                   <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
                 </svg>
               </NavLink>
+              {isAdmin && (
+                <NavLink
+                  to="/users"
+                  className={({ isActive }) =>
+                    `hidden lg:block p-2 rounded-md transition-colors ${
+                      isActive ? 'bg-slate-200 dark:bg-zinc-800 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'
+                    }`
+                  }
+                  title="Users"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 0 0 2.625.372 9.337 9.337 0 0 0 4.121-.952 4.125 4.125 0 0 0-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 0 1 8.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0 1 11.964-3.07M12 6.375a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0Zm8.25 2.25a2.625 2.625 0 1 1-5.25 0 2.625 2.625 0 0 1 5.25 0Z" />
+                  </svg>
+                </NavLink>
+              )}
               <NavLink
                 to="/settings"
                 className={({ isActive }) =>
@@ -162,6 +178,15 @@ function Shell() {
               >
                 {t('nav.search')}
               </NavLink>
+              {isAdmin && (
+                <NavLink
+                  to="/users"
+                  className={mobileLinkClass}
+                  onClick={() => setMenuOpen(false)}
+                >
+                  Users
+                </NavLink>
+              )}
               <NavLink
                 to="/settings"
                 className={mobileLinkClass}
@@ -213,6 +238,7 @@ function Shell() {
           <Route path="/search" element={<SearchPage />} />
           <Route path="/blocklist" element={<Navigate to="/settings" replace />} />
           <Route path="/settings" element={<SettingsPage />} />
+          {isAdmin && <Route path="/users" element={<UsersPage />} />}
         </Routes>
       </main>
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -68,7 +68,17 @@ export interface AuthStatus {
   authenticated: boolean
   setupRequired: boolean
   username?: string
+  role?: string
   mode: 'enabled' | 'local-only' | 'disabled' | 'proxy'
+}
+
+export interface ManagedUser {
+  id: number
+  username: string
+  role: string
+  email?: string
+  displayName?: string
+  createdAt: string
 }
 
 export interface AuthConfig {
@@ -142,6 +152,12 @@ export const api = {
       method: 'PUT',
       body: JSON.stringify({ mode }),
     }),
+  listUsers: () => request<ManagedUser[]>('/auth/users'),
+  createUser: (username: string, password: string, role: string) =>
+    request<ManagedUser>('/auth/users', { method: 'POST', body: JSON.stringify({ username, password, role }) }),
+  deleteUser: (id: number) => request<{ ok: boolean }>(`/auth/users/${id}`, { method: 'DELETE' }),
+  setUserRole: (id: number, role: string) =>
+    request<{ ok: boolean }>(`/auth/users/${id}/role`, { method: 'PUT', body: JSON.stringify({ role }) }),
 
   // Metadata search
   searchAuthors: (term: string) => request<Author[]>(`/search/author?term=${encodeURIComponent(term)}`),

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -4,6 +4,7 @@ import { api, AuthStatus } from '../api/client'
 interface AuthContextValue {
   status: AuthStatus | null
   loading: boolean
+  isAdmin: boolean
   refresh: () => Promise<void>
   logout: () => Promise<void>
 }
@@ -19,9 +20,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const s = await api.authStatus()
       setStatus(s)
     } catch {
-      // Auth endpoints should always respond (they're in AllowUnauthPath).
-      // A network error here leaves status null; the guard will redirect
-      // to /login which is the safe fallback.
       setStatus(null)
     } finally {
       setLoading(false)
@@ -42,8 +40,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     window.location.href = '/login'
   }, [refresh])
 
+  const isAdmin = status?.role === 'admin'
+
   return (
-    <AuthContext.Provider value={{ status, loading, refresh, logout }}>
+    <AuthContext.Provider value={{ status, loading, isAdmin, refresh, logout }}>
       {children}
     </AuthContext.Provider>
   )

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -42,7 +42,8 @@
     "discover": "Discover",
     "search": "Search",
     "blocklist": "Blocklist",
-    "settings": "Settings"
+    "settings": "Settings",
+    "users": "Users"
   },
   "search": {
     "heading": "Search Indexers",
@@ -457,5 +458,27 @@
       "coldStart": "Add more books to unlock personalized genre recommendations.",
       "goToSettings": "Go to Settings"
     }
+  },
+  "users": {
+    "title": "Users",
+    "colUsername": "Username",
+    "colRole": "Role",
+    "colCreated": "Created",
+    "you": "you",
+    "addButton": "+ Add User",
+    "addHeading": "New User",
+    "fieldUsername": "Username",
+    "fieldPassword": "Password",
+    "fieldRole": "Role",
+    "roleAdmin": "Admin",
+    "roleUser": "User",
+    "createButton": "Create User",
+    "promote": "Make admin",
+    "demote": "Make user",
+    "deleteConfirm": "Delete user \"{{username}}\"? This cannot be undone.",
+    "loadFail": "Failed to load users",
+    "deleteFail": "Failed to delete user",
+    "roleFail": "Failed to change role",
+    "createFail": "Failed to create user"
   }
 }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -16,6 +16,7 @@ const tabCls = (active: boolean) =>
 
 export default function SettingsPage() {
   const { t, i18n } = useTranslation()
+  const { isAdmin } = useAuth()
   const [tab, setTab] = useState<Tab>('general')
   const [indexers, setIndexers] = useState<Indexer[]>([])
   const [clients, setClients] = useState<DownloadClient[]>([])
@@ -84,7 +85,10 @@ export default function SettingsPage() {
       <h2 className="text-2xl font-bold mb-6">{t('settings.title')}</h2>
 
       <div className="flex flex-wrap gap-2 mb-6">
-        {(['general', 'indexers', 'clients', 'rootfolders', 'quality', 'metadata', 'notifications', 'calibre', 'import', 'blocklist', 'logs'] as Tab[]).map(tabKey => (
+        {(isAdmin
+          ? ['general', 'indexers', 'clients', 'rootfolders', 'quality', 'metadata', 'notifications', 'calibre', 'import', 'blocklist', 'logs'] as Tab[]
+          : ['general'] as Tab[]
+        ).map(tabKey => (
           <button key={tabKey} onClick={() => setTab(tabKey)} className={tabCls(tab === tabKey)}>
             {t(`settings.tabs.${tabKey}`)}
           </button>

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { api, ManagedUser } from '../api/client'
 import { useAuth } from '../auth/AuthContext'
 
@@ -6,7 +7,8 @@ const inputCls = 'w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 d
 const btnCls = 'px-3 py-1.5 rounded text-sm font-medium transition-colors'
 
 export default function UsersPage() {
-  const { isAdmin } = useAuth()
+  const { t } = useTranslation()
+  const { isAdmin, status } = useAuth()
   const [users, setUsers] = useState<ManagedUser[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -25,7 +27,7 @@ export default function UsersPage() {
     if (!isAdmin) return
     api.listUsers()
       .then(setUsers)
-      .catch(e => setError(e.message))
+      .catch(e => setError(e instanceof Error ? e.message : t('users.loadFail')))
       .finally(() => setLoading(false))
   }, [isAdmin])
 
@@ -40,19 +42,19 @@ export default function UsersPage() {
       setNewPassword('')
       setNewRole('user')
     } catch (e: unknown) {
-      setCreateError(e instanceof Error ? e.message : 'Failed to create user')
+      setCreateError(e instanceof Error ? e.message : t('users.createFail'))
     } finally {
       setCreating(false)
     }
   }
 
-  async function handleDelete(id: number) {
-    if (!confirm('Delete this user and all their library data?')) return
+  async function handleDelete(u: ManagedUser) {
+    if (!confirm(t('users.deleteConfirm', { username: u.username }))) return
     try {
-      await api.deleteUser(id)
-      setUsers(prev => prev.filter(u => u.id !== id))
+      await api.deleteUser(u.id)
+      setUsers(prev => prev.filter(x => x.id !== u.id))
     } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : 'Failed to delete user')
+      setError(e instanceof Error ? e.message : t('users.deleteFail'))
     }
   }
 
@@ -62,7 +64,7 @@ export default function UsersPage() {
       await api.setUserRole(u.id, next)
       setUsers(prev => prev.map(x => x.id === u.id ? { ...x, role: next } : x))
     } catch (e: unknown) {
-      alert(e instanceof Error ? e.message : 'Failed to update role')
+      setError(e instanceof Error ? e.message : t('users.roleFail'))
     }
   }
 
@@ -76,9 +78,9 @@ export default function UsersPage() {
 
   return (
     <div className="space-y-8 max-w-2xl">
-      <h1 className="text-2xl font-bold">Users</h1>
+      <h1 className="text-2xl font-bold">{t('users.title')}</h1>
 
-      {loading && <p className="text-sm text-slate-500 dark:text-zinc-500">Loading...</p>}
+      {loading && <p className="text-sm text-slate-500 dark:text-zinc-500">{t('common.loading')}</p>}
       {error && <p className="text-sm text-red-500">{error}</p>}
 
       {!loading && (
@@ -86,16 +88,21 @@ export default function UsersPage() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-slate-200 dark:border-zinc-800 bg-slate-50 dark:bg-zinc-950">
-                <th className="px-4 py-3 text-left font-medium text-slate-600 dark:text-zinc-400">Username</th>
-                <th className="px-4 py-3 text-left font-medium text-slate-600 dark:text-zinc-400">Role</th>
-                <th className="px-4 py-3 text-left font-medium text-slate-600 dark:text-zinc-400">Created</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600 dark:text-zinc-400">{t('users.colUsername')}</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600 dark:text-zinc-400">{t('users.colRole')}</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600 dark:text-zinc-400">{t('users.colCreated')}</th>
                 <th className="px-4 py-3" />
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-200 dark:divide-zinc-800">
               {users.map(u => (
                 <tr key={u.id}>
-                  <td className="px-4 py-3 font-medium">{u.username}</td>
+                  <td className="px-4 py-3 font-medium">
+                    {u.username}
+                    {u.username === status?.username && (
+                      <span className="ml-2 text-xs text-slate-500 dark:text-zinc-500">({t('users.you')})</span>
+                    )}
+                  </td>
                   <td className="px-4 py-3">
                     <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
                       u.role === 'admin'
@@ -113,13 +120,13 @@ export default function UsersPage() {
                       onClick={() => handleRoleToggle(u)}
                       className={`${btnCls} text-xs bg-slate-100 dark:bg-zinc-800 hover:bg-slate-200 dark:hover:bg-zinc-700 text-slate-700 dark:text-zinc-300`}
                     >
-                      Make {u.role === 'admin' ? 'user' : 'admin'}
+                      {u.role === 'admin' ? t('users.demote') : t('users.promote')}
                     </button>
                     <button
-                      onClick={() => handleDelete(u.id)}
+                      onClick={() => handleDelete(u)}
                       className={`${btnCls} text-xs bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 text-red-600 dark:text-red-400`}
                     >
-                      Delete
+                      {t('common.delete')}
                     </button>
                   </td>
                 </tr>
@@ -130,11 +137,11 @@ export default function UsersPage() {
       )}
 
       <div className="bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded-lg p-5">
-        <h2 className="text-base font-semibold mb-4">Add User</h2>
+        <h2 className="text-base font-semibold mb-4">{t('users.addHeading')}</h2>
         <form onSubmit={handleCreate} className="space-y-3">
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1">Username</label>
+              <label className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1">{t('users.fieldUsername')}</label>
               <input
                 className={inputCls}
                 value={newUsername}
@@ -144,7 +151,7 @@ export default function UsersPage() {
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1">Password</label>
+              <label className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1">{t('users.fieldPassword')}</label>
               <input
                 type="password"
                 className={inputCls}
@@ -156,23 +163,23 @@ export default function UsersPage() {
             </div>
           </div>
           <div>
-            <label className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1">Role</label>
+            <label className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1">{t('users.fieldRole')}</label>
             <select
               className={inputCls}
               value={newRole}
               onChange={e => setNewRole(e.target.value as 'user' | 'admin')}
             >
-              <option value="user">User</option>
-              <option value="admin">Admin</option>
+              <option value="user">{t('users.roleUser')}</option>
+              <option value="admin">{t('users.roleAdmin')}</option>
             </select>
           </div>
           {createError && <p className="text-sm text-red-500">{createError}</p>}
           <button
             type="submit"
-            disabled={creating}
+            disabled={creating || !newUsername || !newPassword}
             className={`${btnCls} bg-slate-800 dark:bg-zinc-100 text-white dark:text-zinc-900 hover:bg-slate-700 dark:hover:bg-zinc-200 disabled:opacity-50`}
           >
-            {creating ? 'Creating...' : 'Create User'}
+            {creating ? t('common.saving') : t('users.createButton')}
           </button>
         </form>
       </div>

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react'
+import { api, ManagedUser } from '../api/client'
+import { useAuth } from '../auth/AuthContext'
+
+const inputCls = 'w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600'
+const btnCls = 'px-3 py-1.5 rounded text-sm font-medium transition-colors'
+
+export default function UsersPage() {
+  const { isAdmin } = useAuth()
+  const [users, setUsers] = useState<ManagedUser[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [newUsername, setNewUsername] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [newRole, setNewRole] = useState<'user' | 'admin'>('user')
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState('')
+
+  useEffect(() => {
+    document.title = 'Users · Bindery'
+    return () => { document.title = 'Bindery' }
+  }, [])
+
+  useEffect(() => {
+    if (!isAdmin) return
+    api.listUsers()
+      .then(setUsers)
+      .catch(e => setError(e.message))
+      .finally(() => setLoading(false))
+  }, [isAdmin])
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    setCreateError('')
+    setCreating(true)
+    try {
+      const u = await api.createUser(newUsername, newPassword, newRole)
+      setUsers(prev => [...prev, u])
+      setNewUsername('')
+      setNewPassword('')
+      setNewRole('user')
+    } catch (e: unknown) {
+      setCreateError(e instanceof Error ? e.message : 'Failed to create user')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  async function handleDelete(id: number) {
+    if (!confirm('Delete this user and all their library data?')) return
+    try {
+      await api.deleteUser(id)
+      setUsers(prev => prev.filter(u => u.id !== id))
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : 'Failed to delete user')
+    }
+  }
+
+  async function handleRoleToggle(u: ManagedUser) {
+    const next = u.role === 'admin' ? 'user' : 'admin'
+    try {
+      await api.setUserRole(u.id, next)
+      setUsers(prev => prev.map(x => x.id === u.id ? { ...x, role: next } : x))
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : 'Failed to update role')
+    }
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="text-center py-20 text-slate-500 dark:text-zinc-500">
+        Admin access required.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8 max-w-2xl">
+      <h1 className="text-2xl font-bold">Users</h1>
+
+      {loading && <p className="text-sm text-slate-500 dark:text-zinc-500">Loading...</p>}
+      {error && <p className="text-sm text-red-500">{error}</p>}
+
+      {!loading && (
+        <div className="bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 dark:border-zinc-800 bg-slate-50 dark:bg-zinc-950">
+                <th className="px-4 py-3 text-left font-medium text-slate-600 dark:text-zinc-400">Username</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600 dark:text-zinc-400">Role</th>
+                <th className="px-4 py-3 text-left font-medium text-slate-600 dark:text-zinc-400">Created</th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-zinc-800">
+              {users.map(u => (
+                <tr key={u.id}>
+                  <td className="px-4 py-3 font-medium">{u.username}</td>
+                  <td className="px-4 py-3">
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                      u.role === 'admin'
+                        ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-400'
+                        : 'bg-slate-100 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400'
+                    }`}>
+                      {u.role}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-slate-500 dark:text-zinc-500">
+                    {new Date(u.createdAt).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3 flex gap-2 justify-end">
+                    <button
+                      onClick={() => handleRoleToggle(u)}
+                      className={`${btnCls} text-xs bg-slate-100 dark:bg-zinc-800 hover:bg-slate-200 dark:hover:bg-zinc-700 text-slate-700 dark:text-zinc-300`}
+                    >
+                      Make {u.role === 'admin' ? 'user' : 'admin'}
+                    </button>
+                    <button
+                      onClick={() => handleDelete(u.id)}
+                      className={`${btnCls} text-xs bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 text-red-600 dark:text-red-400`}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded-lg p-5">
+        <h2 className="text-base font-semibold mb-4">Add User</h2>
+        <form onSubmit={handleCreate} className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1">Username</label>
+              <input
+                className={inputCls}
+                value={newUsername}
+                onChange={e => setNewUsername(e.target.value)}
+                required
+                autoComplete="off"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1">Password</label>
+              <input
+                type="password"
+                className={inputCls}
+                value={newPassword}
+                onChange={e => setNewPassword(e.target.value)}
+                required
+                autoComplete="new-password"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1">Role</label>
+            <select
+              className={inputCls}
+              value={newRole}
+              onChange={e => setNewRole(e.target.value as 'user' | 'admin')}
+            >
+              <option value="user">User</option>
+              <option value="admin">Admin</option>
+            </select>
+          </div>
+          {createError && <p className="text-sm text-red-500">{createError}</p>}
+          <button
+            type="submit"
+            disabled={creating}
+            className={`${btnCls} bg-slate-800 dark:bg-zinc-100 text-white dark:text-zinc-900 hover:bg-slate-700 dark:hover:bg-zinc-200 disabled:opacity-50`}
+          >
+            {creating ? 'Creating...' : 'Create User'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `role` field to `AuthStatus` type in `client.ts`
- Adds `ManagedUser` interface and user management API methods (`listUsers`, `createUser`, `deleteUser`, `setUserRole`)
- Exposes `isAdmin` boolean from `AuthContext` (derived from `status.role === 'admin'`)
- New `UsersPage` — admin-only list/create/delete users, toggle admin role
- `/users` route in `App.tsx` visible only to admins, with Users icon in desktop nav and mobile menu
- `SettingsPage` restricts all admin tabs (indexers, clients, etc.) to admins; regular users see only the General tab

## Test plan

- [ ] Log in as admin → see Users icon in nav, `/users` shows user list, can add/delete/promote
- [ ] Log in as non-admin → no Users icon, `/users` redirects (route absent), Settings shows only General tab
- [ ] Admin-promoted user immediately sees admin tabs on next navigation