### PR TITLE
fix(books): books without release date sort to top of oldest — push to end instead

### DIFF
--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -69,14 +69,16 @@ export default function BooksPage() {
     if (sort === 'title-az') list = [...list].sort((a, b) => a.title.localeCompare(b.title))
     else if (sort === 'title-za') list = [...list].sort((a, b) => b.title.localeCompare(a.title))
     else if (sort === 'date-new') list = [...list].sort((a, b) => {
-      const da = a.releaseDate ? new Date(a.releaseDate).getTime() : 0
-      const db = b.releaseDate ? new Date(b.releaseDate).getTime() : 0
-      return db - da
+      if (!a.releaseDate && !b.releaseDate) return 0
+      if (!a.releaseDate) return 1
+      if (!b.releaseDate) return -1
+      return new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime()
     })
     else if (sort === 'date-old') list = [...list].sort((a, b) => {
-      const da = a.releaseDate ? new Date(a.releaseDate).getTime() : 0
-      const db = b.releaseDate ? new Date(b.releaseDate).getTime() : 0
-      return da - db
+      if (!a.releaseDate && !b.releaseDate) return 0
+      if (!a.releaseDate) return 1
+      if (!b.releaseDate) return -1
+      return new Date(a.releaseDate).getTime() - new Date(b.releaseDate).getTime()
     })
     return list
   }, [books, statusFilter, mediaFilter, search, sort])


### PR DESCRIPTION
## Problem

Books with no `releaseDate` were assigned epoch-0 (`new Date(...).getTime() === 0`) and sorted as if they were from 1970. On the "oldest first" sort they flooded the top of the list, making the sort effectively useless for any library with unwanted or unreleased books.

## Fix

Null-date books now sort to the **end** regardless of direction: newest-first puts them last, oldest-first puts them last. This matches how most media managers handle missing dates.

Closes part of #46.