### PR TITLE
feat(auth): admin password reset for local users

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -396,6 +396,7 @@ func main() {
 			r.Post("/auth/users", userMgmtHandler.Create)
 			r.Delete("/auth/users/{id}", userMgmtHandler.Delete)
 			r.Put("/auth/users/{id}/role", userMgmtHandler.SetRole)
+			r.Put("/auth/users/{id}/reset-password", userMgmtHandler.ResetPassword)
 		})
 
 		// Metadata search

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -397,6 +397,7 @@ func main() {
 			r.Delete("/auth/users/{id}", userMgmtHandler.Delete)
 			r.Put("/auth/users/{id}/role", userMgmtHandler.SetRole)
 			r.Put("/auth/users/{id}/reset-password", userMgmtHandler.ResetPassword)
+			r.Put("/auth/users/{id}/reset-password", userMgmtHandler.ResetPassword)
 		})
 
 		// Metadata search

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -397,7 +397,6 @@ func main() {
 			r.Delete("/auth/users/{id}", userMgmtHandler.Delete)
 			r.Put("/auth/users/{id}/role", userMgmtHandler.SetRole)
 			r.Put("/auth/users/{id}/reset-password", userMgmtHandler.ResetPassword)
-			r.Put("/auth/users/{id}/reset-password", userMgmtHandler.ResetPassword)
 		})
 
 		// Metadata search

--- a/internal/api/auth_users.go
+++ b/internal/api/auth_users.go
@@ -132,3 +132,34 @@ func (h *UserManagementHandler) SetRole(w http.ResponseWriter, r *http.Request) 
 	}
 	writeOK(w, map[string]any{"ok": true})
 }
+
+// ResetPassword sets a new password for a user (admin-only).
+// PUT /api/v1/auth/users/:id/reset-password
+func (h *UserManagementHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid id")
+		return
+	}
+	var body struct {
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid body")
+		return
+	}
+	if len(body.Password) < 8 {
+		writeErr(w, http.StatusBadRequest, "password must be at least 8 characters")
+		return
+	}
+	hash, err := auth.HashPassword(body.Password)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "hash password: "+err.Error())
+		return
+	}
+	if err := h.users.UpdatePassword(r.Context(), id, hash); err != nil {
+		writeErr(w, http.StatusInternalServerError, "update password: "+err.Error())
+		return
+	}
+	writeOK(w, map[string]any{"ok": true})
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -158,6 +158,8 @@ export const api = {
   deleteUser: (id: number) => request<{ ok: boolean }>(`/auth/users/${id}`, { method: 'DELETE' }),
   setUserRole: (id: number, role: string) =>
     request<{ ok: boolean }>(`/auth/users/${id}/role`, { method: 'PUT', body: JSON.stringify({ role }) }),
+  resetUserPassword: (id: number, password: string) =>
+    request<{ ok: boolean }>(`/auth/users/${id}/reset-password`, { method: 'PUT', body: JSON.stringify({ password }) }),
 
   // Metadata search
   searchAuthors: (term: string) => request<Author[]>(`/search/author?term=${encodeURIComponent(term)}`),

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -475,6 +475,7 @@
     "createButton": "Create User",
     "promote": "Make admin",
     "demote": "Make user",
+    "resetPassword": "Reset password",
     "deleteConfirm": "Delete user \"{{username}}\"? This cannot be undone.",
     "loadFail": "Failed to load users",
     "deleteFail": "Failed to delete user",

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -137,6 +137,12 @@ export default function UsersPage() {
                       {u.role === 'admin' ? t('users.demote') : t('users.promote')}
                     </button>
                     <button
+                      onClick={() => handleReset(u.id)}
+                      className={`${btnCls} text-xs bg-slate-100 dark:bg-zinc-800 hover:bg-slate-200 dark:hover:bg-zinc-700 text-slate-700 dark:text-zinc-300`}
+                    >
+                      {t('users.resetPassword')}
+                    </button>
+                    <button
                       onClick={() => handleDelete(u)}
                       className={`${btnCls} text-xs bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 text-red-600 dark:text-red-400`}
                     >

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -17,7 +17,7 @@ export default function UsersPage() {
   const [newRole, setNewRole] = useState<'user' | 'admin'>('user')
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState('')
-  const [resetError, setResetError] = useState<Record<number, string>>({})
+  const [, setResetError] = useState<Record<number, string>>({})
 
   useEffect(() => {
     document.title = 'Users · Bindery'

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -17,8 +17,6 @@ export default function UsersPage() {
   const [newRole, setNewRole] = useState<'user' | 'admin'>('user')
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState('')
-  const [resetingId, setResetingId] = useState<number | null>(null)
-  const [resetPassword, setResetPassword] = useState('')
   const [resetError, setResetError] = useState<Record<number, string>>({})
 
   useEffect(() => {
@@ -135,12 +133,6 @@ export default function UsersPage() {
                       className={`${btnCls} text-xs bg-slate-100 dark:bg-zinc-800 hover:bg-slate-200 dark:hover:bg-zinc-700 text-slate-700 dark:text-zinc-300`}
                     >
                       {u.role === 'admin' ? t('users.demote') : t('users.promote')}
-                    </button>
-                    <button
-                      onClick={() => handleReset(u.id)}
-                      className={`${btnCls} text-xs bg-slate-100 dark:bg-zinc-800 hover:bg-slate-200 dark:hover:bg-zinc-700 text-slate-700 dark:text-zinc-300`}
-                    >
-                      {t('users.resetPassword')}
                     </button>
                     <button
                       onClick={() => handleReset(u.id)}

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -17,6 +17,9 @@ export default function UsersPage() {
   const [newRole, setNewRole] = useState<'user' | 'admin'>('user')
   const [creating, setCreating] = useState(false)
   const [createError, setCreateError] = useState('')
+  const [resetingId, setResetingId] = useState<number | null>(null)
+  const [resetPassword, setResetPassword] = useState('')
+  const [resetError, setResetError] = useState<Record<number, string>>({})
 
   useEffect(() => {
     document.title = 'Users · Bindery'
@@ -65,6 +68,17 @@ export default function UsersPage() {
       setUsers(prev => prev.map(x => x.id === u.id ? { ...x, role: next } : x))
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : t('users.roleFail'))
+    }
+  }
+
+  async function handleReset(id: number) {
+    const pw = prompt('New password (min 8 characters):')
+    if (!pw) return
+    try {
+      await api.resetUserPassword(id, pw)
+      setResetError(prev => ({ ...prev, [id]: '' }))
+    } catch (e: unknown) {
+      setResetError(prev => ({ ...prev, [id]: e instanceof Error ? e.message : 'Failed' }))
     }
   }
 

--- a/web/src/pages/UsersPage.tsx
+++ b/web/src/pages/UsersPage.tsx
@@ -143,6 +143,12 @@ export default function UsersPage() {
                       {t('users.resetPassword')}
                     </button>
                     <button
+                      onClick={() => handleReset(u.id)}
+                      className={`${btnCls} text-xs bg-slate-100 dark:bg-zinc-800 hover:bg-slate-200 dark:hover:bg-zinc-700 text-slate-700 dark:text-zinc-300`}
+                    >
+                      {t('users.resetPassword')}
+                    </button>
+                    <button
                       onClick={() => handleDelete(u)}
                       className={`${btnCls} text-xs bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 text-red-600 dark:text-red-400`}
                     >


### PR DESCRIPTION
## Problem

Admins had no way to reset a user's password without direct SQLite access. Locked-out users in distroless/Kubernetes deployments had no self-service recovery path.

Closes #292.

## Changes

**Backend**
- `PUT /api/v1/auth/users/{id}/reset-password` — admin-only, requires `{password}` body (min 8 chars), hashes and updates via existing `UpdatePassword` repo method
- Route registered alongside other user management endpoints in `main.go`

**Frontend**
- `api.resetUserPassword(id, password)` added to `client.ts`
- "Reset password" button in the Users table (between role toggle and delete), uses `window.prompt` for the new password
- `users.resetPassword` i18n key

## Test plan

- [ ] Admin clicks Reset password, enters new password → user can log in with new password
- [ ] Short password (< 8 chars) → 400 error shown
- [ ] Non-admin cannot call the endpoint (admin middleware rejects)