### PR TITLE
fix(auth): re-hydrate CSRF token on page reload

### DIFF
--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
-import { api, AuthStatus } from '../api/client'
+import { api, AuthStatus, initCSRF } from '../api/client'
 
 interface AuthContextValue {
   status: AuthStatus | null
@@ -19,6 +19,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       const s = await api.authStatus()
       setStatus(s)
+      // Re-hydrate CSRF token after page reload: authLogin() calls initCSRF,
+      // but a subsequent reload keeps the session cookie without the token
+      // in JS memory, so mutating requests would 403 until the next login.
+      if (s.authenticated) {
+        await initCSRF()
+      }
     } catch {
       setStatus(null)
     } finally {


### PR DESCRIPTION
## Summary
- CSRF token lived only in the JS module variable and was populated only in `authLogin()`. On page reload, the session cookie was still valid (so the user stayed signed in) but the in-memory `csrfToken` was empty — every mutating request went out without `X-CSRF-Token` and got 403 "invalid or missing CSRF token".
- Fix: after `authStatus()` confirms the session is live in `AuthProvider.refresh`, call `initCSRF()` so `GET /auth/csrf` runs on boot and re-derives the double-submit token.

Fixes the CSRF half of #314.

## Test plan
- [ ] Log in, reload the page, click Refresh Metadata on an author → succeeds (previously 403)
- [ ] Log in fresh → CSRF still works (regression check)
- [ ] Log out → csrfToken cleared; next login re-initialises