### PR TITLE
docs: auth, multi-user, and v1 upgrade guides

### DIFF
--- a/docs/auth-multiuser.md
+++ b/docs/auth-multiuser.md
@@ -1,0 +1,126 @@
+# Multi-User & v1.0 Upgrade Guide
+
+Bindery v1.0 introduces per-user library scoping and CSRF hardening. Every author, book, download, and profile is now owned by a user. Existing single-user installs are automatically migrated — all data is assigned to the original admin user (user ID 1) and behaviour is unchanged.
+
+## What changes
+
+- Each user has their own authors, books, downloads, quality profiles, metadata profiles, and root folders.
+- Two roles: `admin` (full access, manages users and system settings) and `user` (own library only).
+- The first account created via `/setup` is `admin`. OIDC-auto-provisioned users get the `user` role unless their IdP group matches `allowed_admin_groups`.
+- Admin endpoints (`GET/POST/DELETE /auth/users`, indexer/download client settings) require the `admin` role.
+- CSRF protection upgraded from `X-Requested-With` header check to double-submit token (`GET /auth/csrf` + `X-CSRF-Token` header on mutations). API-key requests are exempt.
+
+## Before you upgrade
+
+**Take a database backup first. Migration 019 is a one-way door on SQLite.**
+
+```bash
+# Via API
+curl -X POST -H "X-Api-Key: <key>" http://bindery:8787/api/v1/backup
+
+# Via UI
+Settings → General → Backup → Create backup
+```
+
+Bindery also runs a pre-migration integrity check that counts orphaned rows and aborts cleanly with a repair hint if any are found. Fix any reported orphans before proceeding.
+
+**Rehearse on a snapshot (recommended for prod installs):**
+
+```bash
+# Copy your bindery.db to a test environment and boot the new binary against it
+cp /config/bindery.db /tmp/bindery-test.db
+BINDERY_DB_PATH=/tmp/bindery-test.db ./bindery
+# Verify: all authors/books load under user 1 with zero data loss
+```
+
+## Upgrade steps
+
+1. Stop the current Bindery process.
+2. Backup (see above).
+3. Replace the binary or update the image tag.
+4. Start Bindery. Migration `019_multiuser.sql` runs automatically inside a transaction.
+5. On success, startup logs emit `migration 019 complete; all rows backfilled to user_id=1`.
+6. Verify: open the UI, confirm your library loads normally.
+
+If migration fails (e.g. due to orphaned rows), Bindery logs the error and exits cleanly — the database is not left in a half-migrated state because the migration runs in a transaction.
+
+## Single-user installs
+
+No action required beyond the backup and upgrade steps above. Your library is transparently owned by user 1. You will see no behavioural change unless you add additional users.
+
+## User management
+
+### Creating users
+
+Admin only. **Settings → Users → Add user**, or:
+
+```
+POST /api/v1/auth/users
+{"username": "alice", "password": "...", "role": "user"}
+```
+
+OIDC users are auto-provisioned on first login and assigned the `user` role.
+
+### Listing users
+
+```
+GET /api/v1/auth/users
+```
+
+Returns id, username, role, and last-seen timestamp. Passwords and OIDC credentials are not returned.
+
+### Deleting users
+
+```
+DELETE /api/v1/auth/users/{id}
+```
+
+Deleting a user does not delete their library data. Reassign or clean up data from the admin UI before deleting.
+
+### Roles
+
+| Role | Can do |
+|------|--------|
+| `admin` | Everything: manage users, indexers, download clients, system settings, all users' data |
+| `user` | Own library only: authors, books, downloads, profiles within their account |
+
+## CSRF tokens
+
+Bindery v1.0 replaces the `X-Requested-With` header check with a double-submit CSRF token for session-cookie-authenticated requests.
+
+**For browser-based use:** the UI handles this automatically — no action required.
+
+**For API scripts using session cookies:** fetch a token before mutations:
+
+```bash
+TOKEN=$(curl -s -b bindery_session=<cookie> http://bindery:8787/api/v1/auth/csrf | jq -r .token)
+curl -X POST -b bindery_session=<cookie> -H "X-CSRF-Token: $TOKEN" ...
+```
+
+**For API scripts using `X-Api-Key`:** CSRF tokens are not required — API-key requests are exempt. Your existing scripts continue to work unchanged.
+
+## Settings UI changes
+
+Settings is now split into two tabs:
+
+- **My Account** — API key, password, notification preferences (visible to all users)
+- **Admin** — Indexers, download clients, quality/metadata profiles, users list (admin only)
+
+## Rollback
+
+Migration `019_multiuser.sql` cannot be trivially reversed on SQLite (SQLite does not support `DROP COLUMN`). Treat this upgrade as a one-way door.
+
+**Rollback posture:** if you need to revert, restore from the pre-upgrade snapshot and run the previous binary. Data written after the upgrade is not recoverable from the snapshot.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Migration fails at startup: `orphaned rows detected` | Rows in `downloads` or other tables with broken foreign keys from earlier bugs | Follow the repair hint in the log (a `DELETE` or `UPDATE` query is printed). Rerun migration after fixing. |
+| Migration fails mid-run and Bindery exits | Unexpected schema state | The migration runs in a transaction — the database is not corrupted. Restore from backup, fix reported issue, retry. |
+| All data missing after upgrade | Upgrade applied to wrong database file | Check `BINDERY_DB_PATH` in your config. Ensure the backup and the running DB are the same file. |
+| User A can see User B's books via API | A repo method is missing `userID` filter (bug) | File a bug with the exact API endpoint. As a workaround, restrict access with the `user` role (not admin). |
+| `403 Forbidden` on API mutation (was working before) | CSRF token now required for session-cookie requests | Switch to API-key auth (`X-Api-Key`), which is CSRF-exempt. Or fetch a token from `GET /auth/csrf`. |
+| OIDC user auto-provisioned but should be admin | `allowed_admin_groups` not set for OIDC provider | Add the IdP group name to `allowed_admin_groups` in the OIDC provider config. Existing provisioned users need manual role update via `PUT /api/v1/auth/users/{id}`. |
+| Cannot delete a user — data still present | Delete user API does not delete library data | Manually reassign or remove the user's authors/books first, then delete the user. |
+| Session secret rotation logs everyone out | Expected behaviour when rotating to force global logout | Warn users before rotating. Session revocation per-user is planned for a future release. |

--- a/docs/auth-oidc.md
+++ b/docs/auth-oidc.md
@@ -1,0 +1,288 @@
+# OIDC Authentication
+
+Bindery v0.24.0 adds native OpenID Connect (Authorization Code + PKCE). Users sign in via Google, GitHub, Authelia, Authentik, Keycloak, or any OIDC-compliant provider. Local password login continues to work alongside OIDC.
+
+## How it works
+
+Bindery acts as an OIDC Relying Party. On login, it redirects to the provider, exchanges the code for tokens, validates the ID token, and maps the user by `(issuer, sub)` — not by email or username, which can change. On first login the user is auto-provisioned as a Bindery account.
+
+Sessions are issued using the same HMAC-signed cookie as password login. OIDC sits in front of session issuance — the rest of Bindery is unaware of the auth path.
+
+## Prerequisites
+
+- Bindery is reachable at a stable base URL (needed for the callback URL).
+- You have an OIDC application configured at your IdP with the redirect URI: `<BINDERY_OIDC_REDIRECT_BASE_URL>/api/v1/auth/oidc/<provider-id>/callback`.
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BINDERY_OIDC_REDIRECT_BASE_URL` | _(required)_ | Public base URL Bindery is reachable at (e.g. `https://bindery.example.com`). Used to construct OIDC callback URLs. Required when Bindery is behind a reverse proxy. |
+
+## Redirect URL construction
+
+The callback URL registered in your IdP must exactly match what Bindery sends during the authorization redirect. Bindery constructs it as:
+
+```
+<BINDERY_OIDC_REDIRECT_BASE_URL>/api/v1/auth/oidc/<provider-id>/callback
+```
+
+For example, with `BINDERY_OIDC_REDIRECT_BASE_URL=https://bindery.example.com` and provider id `google`:
+
+```
+https://bindery.example.com/api/v1/auth/oidc/google/callback
+```
+
+**Behind a reverse proxy:** Bindery cannot detect its own public URL — it only knows the port it listens on. Always set `BINDERY_OIDC_REDIRECT_BASE_URL` to the public-facing URL your proxy exposes, including scheme and any path prefix. Omitting this env var causes Bindery to construct the callback URL from the internal `Host` header, which will not match your IdP registration and will result in a redirect loop or `redirect_uri_mismatch` error.
+
+**Path prefix example** (Bindery mounted at `/bindery/`):
+
+```
+BINDERY_OIDC_REDIRECT_BASE_URL=https://example.com/bindery
+# → callback: https://example.com/bindery/api/v1/auth/oidc/<id>/callback
+```
+
+## Adding a provider
+
+Providers are configured in **Settings → Security → OIDC Providers** (admin only). Each provider has:
+
+| Field | Description |
+|-------|-------------|
+| `id` | Short identifier used in callback URL path (e.g. `google`, `authelia`). |
+| `name` | Display name shown on the login button. |
+| `issuer` | OIDC discovery URL base (e.g. `https://accounts.google.com`). |
+| `client_id` | From your IdP app registration. |
+| `client_secret` | From your IdP app registration. Stored in the `settings` table — treat the database as sensitive. |
+| `scopes` | Space-separated scopes (e.g. `openid email profile`). |
+| `allowed_groups` | Optional. Comma-separated IdP groups/roles that are allowed to log in. Empty = allow all authenticated users. |
+
+Providers can also be set directly via the `settings` table key `auth.oidc.providers` (JSON array) for scripted deploys.
+
+### `client_secret` write-only semantics
+
+`client_secret` is **never returned** by `GET /api/v1/settings/auth/oidc/providers` — it is write-only. The `PUT` endpoint uses secret-preservation semantics so the Settings UI (which only fetches public config) cannot accidentally blank a secret it never had access to:
+
+| `client_secret` in PUT body | Effect |
+|-----------------------------|--------|
+| Non-empty string | Secret updated to the new value |
+| Empty string `""` or field absent | Existing secret preserved unchanged |
+| Empty string on a **new** provider (POST) | Rejected with `400 Bad Request` |
+
+To rotate a secret without touching other fields:
+
+```bash
+curl -X PUT http://bindery:8787/api/v1/settings/auth/oidc/providers/google \
+  -H "X-Api-Key: <admin-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"id": "google", "client_secret": "<new-secret>"}'
+```
+
+To update scopes or groups without disturbing the secret, omit `client_secret` from the body entirely.
+
+## Google
+
+1. Go to [Google Cloud Console → APIs & Services → Credentials → Create OAuth 2.0 Client](https://console.cloud.google.com/apis/credentials).
+2. Application type: **Web application**.
+3. Authorized redirect URIs: `https://bindery.example.com/api/v1/auth/oidc/google/callback`.
+4. Add provider in Bindery:
+
+```json
+{
+  "id": "google",
+  "name": "Google",
+  "issuer": "https://accounts.google.com",
+  "client_id": "<your-client-id>.apps.googleusercontent.com",
+  "client_secret": "<your-client-secret>",
+  "scopes": "openid email profile"
+}
+```
+
+## GitHub (via Dex)
+
+GitHub's OAuth2 implementation does not expose an OIDC discovery endpoint, so Bindery cannot use it directly. The recommended bridge is [Dex](https://dexidp.io/) with its GitHub connector.
+
+**1. Register a GitHub OAuth App** at github.com → Settings → Developer settings → OAuth Apps. Set the callback URL to your Dex instance: `https://dex.example.com/callback`.
+
+**2. Configure Dex:**
+
+```yaml
+# dex/config.yaml
+issuer: https://dex.example.com
+
+connectors:
+  - type: github
+    id: github
+    name: GitHub
+    config:
+      clientID: <github-oauth-app-client-id>
+      clientSecret: <github-oauth-app-client-secret>
+      redirectURI: https://dex.example.com/callback
+      orgs:
+        - name: your-github-org   # optional: restrict to org members
+
+staticClients:
+  - id: bindery
+    secret: <dex-client-secret>
+    name: Bindery
+    redirectURIs:
+      - https://bindery.example.com/api/v1/auth/oidc/github/callback
+```
+
+**3. Add provider in Bindery:**
+
+```json
+{
+  "id": "github",
+  "name": "GitHub",
+  "issuer": "https://dex.example.com",
+  "client_id": "bindery",
+  "client_secret": "<dex-client-secret>",
+  "scopes": "openid email profile"
+}
+```
+
+The `sub` claim in Dex's tokens is the GitHub user ID (numeric, stable — does not change on username rename).
+
+## Authelia
+
+Authelia exposes a native OIDC provider in v4.34+. Register a client:
+
+```yaml
+# authelia/configuration.yml
+identity_providers:
+  oidc:
+    clients:
+      - id: bindery
+        secret: '$plaintext$<your-secret>'
+        authorization_policy: one_factor
+        redirect_uris:
+          - https://bindery.example.com/api/v1/auth/oidc/authelia/callback
+        scopes:
+          - openid
+          - email
+          - profile
+          - groups
+```
+
+Bindery provider config:
+
+```json
+{
+  "id": "authelia",
+  "name": "Authelia",
+  "issuer": "https://auth.example.com",
+  "client_id": "bindery",
+  "client_secret": "<your-secret>",
+  "scopes": "openid email profile groups",
+  "allowed_groups": "bindery-users"
+}
+```
+
+## Authentik
+
+1. In Authentik admin, create a **Provider → OAuth2/OpenID Provider**.
+2. Set redirect URI: `https://bindery.example.com/api/v1/auth/oidc/authentik/callback`.
+3. Create an **Application** linked to the provider.
+
+```json
+{
+  "id": "authentik",
+  "name": "Authentik",
+  "issuer": "https://auth.example.com/application/o/<app-slug>/",
+  "client_id": "<your-client-id>",
+  "client_secret": "<your-client-secret>",
+  "scopes": "openid email profile"
+}
+```
+
+## Keycloak
+
+1. In the Keycloak admin console, select your realm and go to **Clients → Create client**.
+2. **Client type:** OpenID Connect. **Client ID:** `bindery`.
+3. Enable **Client authentication** (confidential client).
+4. Under **Valid redirect URIs**, add: `https://bindery.example.com/api/v1/auth/oidc/keycloak/callback`.
+5. Save, then go to the **Credentials** tab and copy the client secret.
+6. To restrict login to a specific group, create a Keycloak group (e.g. `bindery-users`), assign users to it, and map it to the token via **Client scopes → groups** mapper.
+
+Add provider in Bindery:
+
+```json
+{
+  "id": "keycloak",
+  "name": "Keycloak",
+  "issuer": "https://keycloak.example.com/realms/<your-realm>",
+  "client_id": "bindery",
+  "client_secret": "<your-secret>",
+  "scopes": "openid email profile groups",
+  "allowed_groups": "/bindery-users"
+}
+```
+
+The `issuer` must include the realm path. Keycloak groups in the token are prefixed with `/` (e.g. `/bindery-users`) — match this exactly in `allowed_groups`.
+
+## JWKS caching
+
+Bindery caches the IdP's JWKS (public keys) to avoid a round-trip to the identity provider on every token validation. The cache is refreshed automatically on cache miss or key rotation. This means:
+- Token validation is fast and does not hit the IdP per-request.
+- If you rotate IdP signing keys, Bindery will re-fetch on the next cache miss (typically within minutes).
+
+## Multi-provider note: sub re-use
+
+Two different IdPs can emit the same `sub` value for different users. Bindery's user mapping key is `(issuer, sub)`, not `sub` alone — so collisions across providers are impossible by design.
+
+## Session and logout caveat
+
+OIDC logout from the IdP does **not** immediately log the user out of Bindery. This is a known limitation.
+
+Bindery issues its own HMAC-signed session cookie when OIDC login succeeds. That cookie is independent of the IdP session — revoking the IdP session, signing out of the IdP, or disabling the user in the IdP has no effect on the Bindery cookie until it expires naturally (~12 hours for a short-lived session, up to 30 days if "Remember me" is checked).
+
+**Mitigations:**
+
+- **Shorten cookie lifetime** — reduce the session TTL in **Settings → General → Security → Session lifetime** so stale sessions expire sooner.
+- **Force global logout** — rotate the session secret in **Settings → General → Security → Rotate session secret**. This invalidates every active Bindery session immediately for all users. Use for security incidents.
+- **Per-user logout** (not yet available) — a `sessions` table with per-session revocation is planned for a future release. Until then, global secret rotation is the only way to evict a specific user.
+
+## Client secret storage
+
+OIDC client secrets are stored as plaintext in the `settings` table — the same posture as indexer API keys and download client passwords. This is an accepted trade-off for a self-hosted application: all sensitive values are in one place, and protecting the database file protects everything.
+
+**What this means in practice:**
+- Anyone with read access to `bindery.db` can extract OIDC client secrets.
+- Protect the database file: `chmod 600 /config/bindery.db`, ensure the volume mount is not world-readable, and restrict `kubectl exec` / `docker exec` access to the container.
+- The Bindery backup API (`POST /api/v1/backup`) creates a copy of the database — treat backup files with the same care.
+
+An env-var reference pattern (reading secrets from environment variables rather than storing them in the DB) is planned for a future release.
+
+## Helm / Kubernetes
+
+```yaml
+# values.yaml
+env:
+  BINDERY_OIDC_REDIRECT_BASE_URL: "https://bindery.example.com"
+```
+
+Provider configuration lives in the database (Settings UI or `settings` table), not in the Helm chart, to avoid storing client secrets in values files.
+
+## Rollback
+
+Migration `018_oidc.sql` is additive-only (nullable columns). Rolling back the binary is safe — the columns remain in place and are ignored by older versions.
+
+## See also
+
+- [docs/troubleshooting-auth.md](troubleshooting-auth.md) — consolidated symptom→cause→fix table for all auth phases
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Browser loops between Bindery login and IdP without completing | `BINDERY_OIDC_REDIRECT_BASE_URL` mismatch — IdP receives a callback URL that doesn't match its registration | Set `BINDERY_OIDC_REDIRECT_BASE_URL` to the exact public URL your proxy exposes (including scheme, domain, and any path prefix). The value must match the redirect URI registered in your IdP character-for-character. See [Redirect URL construction](#redirect-url-construction). |
+| `redirect_uri_mismatch` error from IdP on callback | Callback URL sent by Bindery does not match the URI registered in the IdP | Same cause as redirect loop. Confirm `BINDERY_OIDC_REDIRECT_BASE_URL` is set and correct. Copy the exact URL from the IdP error message and register it. |
+| `state mismatch` or `nonce mismatch` error on callback | State/nonce cookie set during login redirect was lost or altered before the callback arrived | Two common causes: (1) reverse proxy strips `Set-Cookie` response headers — ensure `Set-Cookie` passes through unchanged; (2) login and callback served on different domains or subdomains — the session cookie won't be sent cross-domain. Both must use the same origin. With path-prefix deployments, verify the cookie `Path` attribute is not restricted. |
+| `invalid_client` or `unauthorized_client` from IdP on callback | Client ID / secret mismatch, or redirect URI not registered | Verify the redirect URI in your IdP exactly matches `<BINDERY_OIDC_REDIRECT_BASE_URL>/api/v1/auth/oidc/<id>/callback`. Check client ID and secret. |
+| Login button does not appear on login page | Provider not configured, or OIDC settings not saved | Check **Settings → Security → OIDC Providers**. Verify the provider record has `issuer`, `client_id`, `client_secret` set. |
+| `issuer mismatch` in token validation | Bindery's configured `issuer` does not match the `iss` claim in the ID token | For Keycloak, issuer includes the realm: `https://keycloak.example.com/realms/<realm>`. For Authentik, it includes the app slug. Use `BINDERY_LOG_LEVEL=debug` to log the received `iss` value. |
+| Two different real users map to the same Bindery account | Two providers emitting the same `sub` for different people | This cannot happen — Bindery keys on `(issuer, sub)`, not `sub` alone. If it does occur, file a bug. |
+| OIDC logout from IdP doesn't log out of Bindery | Session cookie is independent of IdP session; cookie TTL is ~12h or up to 30d | Rotate session secret in **Settings → General → Security** to force global logout. Shorten session TTL to reduce window. Per-user revocation is planned for a future release. |
+| `connection refused` or timeout fetching discovery URL | IdP not reachable from Bindery container/pod at startup | Check network policy / firewall. Bindery must reach `<issuer>/.well-known/openid-configuration`. Test with `curl` from inside the container. |
+| JWKS fetch fails after IdP key rotation | Stale cached JWKS | Restart Bindery to force re-fetch. The cache auto-refreshes on miss in subsequent versions. |
+| `allowed_groups` filter blocks all users | Group claim name or format differs from config value | Enable `BINDERY_LOG_LEVEL=debug` to log decoded ID token claims. Keycloak groups are prefixed with `/` (e.g. `/bindery-users`); match this exactly. |

--- a/docs/auth-proxy.md
+++ b/docs/auth-proxy.md
@@ -1,0 +1,182 @@
+# Reverse-Proxy SSO Authentication
+
+Bindery v0.23.0 adds a `proxy` auth mode that delegates identity to an upstream reverse proxy — Authelia, Authentik, Keycloak, Google, GitHub, or any system that sets a trusted identity header.
+
+> **Security warning:** Proxy mode is only safe if your Bindery instance is not directly reachable from untrusted networks. Any client that can reach Bindery and forge `X-Forwarded-User` without going through your proxy can authenticate as any user. Use firewall rules or network policy to enforce this.
+
+## How it works
+
+When `mode=proxy`, Bindery reads an identity header (default `X-Forwarded-User`) on every request. If the request arrives from a trusted proxy IP and the header is present, Bindery resolves or auto-provisions a user by that username and issues a session.
+
+**Bindery refuses to start in proxy mode if `BINDERY_TRUSTED_PROXY` is empty** — this is intentional. The startup log emits the trusted CIDR list so you can verify it in `kubectl logs` or `docker logs`.
+
+## Prerequisites
+
+- Your reverse proxy is the sole path into Bindery from untrusted networks.
+- You know the proxy container/pod IP or CIDR (`BINDERY_TRUSTED_PROXY`).
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BINDERY_TRUSTED_PROXY` | _(required in proxy mode)_ | Comma-separated CIDRs or IPs of trusted upstream proxies (e.g. `10.0.0.0/8,172.16.0.0/12`). Bindery refuses to start in proxy mode if this is empty. |
+| `BINDERY_PROXY_AUTH_HEADER` | `X-Forwarded-User` | Header name Bindery reads for the authenticated username. |
+| `BINDERY_PROXY_AUTO_PROVISION` | `true` | When `true`, a Bindery user is created on first login if none exists for that username. Set to `false` to require users to exist before they can log in. |
+
+## Enabling proxy mode
+
+1. Set `BINDERY_TRUSTED_PROXY` to your proxy's IP/CIDR.
+2. Set auth mode to `proxy` via **Settings → General → Security → Authentication Mode**, or via the API:
+   ```
+   PUT /api/v1/auth/mode
+   {"mode": "proxy"}
+   ```
+3. Confirm in startup logs: `trusted proxies: [<your CIDRs>]`.
+
+The login page hides the password form and shows "Sign in via your SSO provider" when proxy mode is active.
+
+## Traefik + Authelia
+
+```yaml
+# docker-compose.yml
+services:
+  authelia:
+    image: authelia/authelia:latest
+    # ... your Authelia config
+
+  bindery:
+    image: ghcr.io/vavallee/bindery:latest
+    environment:
+      BINDERY_TRUSTED_PROXY: "172.20.0.0/16"   # Docker network CIDR
+      BINDERY_PROXY_AUTH_HEADER: "Remote-User"   # Authelia's default header
+    labels:
+      traefik.http.routers.bindery.middlewares: authelia@docker
+      traefik.http.middlewares.authelia.forwardauth.address: http://authelia:9091/api/verify?rd=https://auth.example.com/
+      traefik.http.middlewares.authelia.forwardauth.trustForwardHeader: "true"
+      traefik.http.middlewares.authelia.forwardauth.authResponseHeaders: "Remote-User,Remote-Groups,Remote-Name,Remote-Email"
+```
+
+Authelia sets `Remote-User` (not `X-Forwarded-User`) by default. Either set `BINDERY_PROXY_AUTH_HEADER=Remote-User` or configure Authelia to use a different header name.
+
+## Caddy + Authentik
+
+```caddyfile
+bindery.example.com {
+    forward_auth authentik:9000 {
+        uri /outpost.goauthentik.io/auth/caddy
+        copy_headers X-Authentik-Username X-Authentik-Groups X-Authentik-Email
+    }
+    reverse_proxy bindery:8787
+}
+```
+
+```yaml
+# bindery env
+BINDERY_TRUSTED_PROXY: "172.20.0.0/16"
+BINDERY_PROXY_AUTH_HEADER: "X-Authentik-Username"
+```
+
+## nginx + Authelia (`auth_request`)
+
+```nginx
+# nginx.conf
+server {
+    listen 443 ssl http2;
+    server_name bindery.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/bindery.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/bindery.example.com/privkey.pem;
+
+    # Internal endpoint nginx uses to verify the session with Authelia
+    location = /authelia {
+        internal;
+        proxy_pass http://authelia:9091/api/verify;
+        proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
+        proxy_set_header Content-Length "";
+        proxy_pass_request_body off;
+    }
+
+    location / {
+        auth_request /authelia;
+        # Forward the authenticated username header Authelia sets on success
+        auth_request_set $user $upstream_http_remote_user;
+        proxy_set_header Remote-User $user;
+
+        proxy_pass http://bindery:8787;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+```yaml
+# bindery env
+BINDERY_TRUSTED_PROXY: "10.0.0.0/8"        # nginx container/server IP range
+BINDERY_PROXY_AUTH_HEADER: "Remote-User"    # header set by auth_request_set above
+```
+
+## Kubernetes (Helm)
+
+```yaml
+# values.yaml
+env:
+  BINDERY_TRUSTED_PROXY: "10.0.0.0/8"
+  BINDERY_PROXY_AUTH_HEADER: "X-Forwarded-User"
+  BINDERY_PROXY_AUTO_PROVISION: "true"
+```
+
+For Traefik Ingress with Authelia forward auth middleware, annotate the Bindery Ingress:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bindery
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: default-authelia@kubernetescrd
+```
+
+## Header choice: stability matters
+
+Auto-provisioning ties a Bindery user row to the username in the header. If your IdP can change a user's username (e.g. email rename in Authentik), a new Bindery user gets created and the old user's data becomes inaccessible.
+
+Prefer a **stable, opaque** identifier over a mutable display name or email address. Many proxies set `X-Forwarded-Preferred-Username` from an OIDC `preferred_username` claim — this is still a display name and can change. Use a UUID or internal user ID instead.
+
+| IdP | Recommended approach |
+|-----|---------------------|
+| Authelia | `Remote-User` maps to the Authelia username. Stable if you never rename accounts; if you do, configure a custom header mapping to the internal UUID. |
+| Authentik | Configure a property mapping that exposes the user's UUID in a custom header (e.g. `X-Authentik-UID`), then set `BINDERY_PROXY_AUTH_HEADER=X-Authentik-UID`. The default `X-Authentik-Username` changes on rename. |
+| Keycloak | Add a custom mapper in Keycloak that passes the `sub` claim (a stable UUID) in a request header, then point `BINDERY_PROXY_AUTH_HEADER` at it. |
+| nginx auth_request | Use `auth_request_set` to forward whichever stable header your IdP provides (see nginx example above). |
+
+Avoid using email as the identity header — email addresses change and are not guaranteed unique across IdPs.
+
+If a rename happens and an orphaned user is created, an admin can merge users from **Settings → Users**.
+
+## Rollback
+
+Proxy mode is a binary change — no schema migration is involved. To revert:
+
+```
+PUT /api/v1/auth/mode
+{"mode": "enabled"}
+```
+
+Remove or unset `BINDERY_TRUSTED_PROXY`. Restart Bindery. Users keep their accounts; they will need to log in with a password.
+
+## See also
+
+- [docs/troubleshooting-auth.md](troubleshooting-auth.md) — consolidated symptom→cause→fix table for all auth phases
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Bindery refuses to start: `proxy mode requires BINDERY_TRUSTED_PROXY` | `BINDERY_TRUSTED_PROXY` is empty | Set `BINDERY_TRUSTED_PROXY` to your proxy's IP or CIDR. Proxy mode will not start without it — this is intentional to prevent auth bypass. |
+| Every request returns `401 Unauthorized` | Source IP not in `BINDERY_TRUSTED_PROXY` | Check startup log for `trusted proxies: [...]`. The request source IP must match. In Docker, use the bridge network CIDR, not the container IP. |
+| Every request returns `401 Unauthorized` | Header name mismatch | Authelia uses `Remote-User`; Authentik uses `X-Authentik-Username`. Set `BINDERY_PROXY_AUTH_HEADER` to match your proxy's output. Inspect request headers at the Bindery container with `BINDERY_LOG_LEVEL=debug`. |
+| Login page still shows password form | Auth mode not set to `proxy` | `GET /api/v1/auth/status` — confirm `"mode": "proxy"`. If not, set it via Settings or the API. |
+| New user created on every IdP username change | Mutable identifier in header | Switch to a stable IdP identifier (see "Header choice" above). Merge orphaned users from Settings → Users. |
+| `X-Forwarded-User: admin` accepted from an untrusted LAN host | `BINDERY_TRUSTED_PROXY` too broad (e.g. `0.0.0.0/0`) | Tighten the CIDR to only your proxy's IP or pod subnet. Verify with `kubectl logs` or `docker logs` that the trusted CIDR list is correct. |
+| OIDC logout from IdP doesn't log out of Bindery | Session cookie is HMAC-signed; no per-session revocation | Session expires at cookie TTL. To force logout: regenerate the session secret in Settings → General → Security (invalidates all sessions). A revocation list is planned for a future release. |

--- a/docs/multi-user.md
+++ b/docs/multi-user.md
@@ -1,0 +1,123 @@
+# Multi-User
+
+Bindery v1.0 introduces per-user library scoping. Every author, book, download, quality profile, metadata profile, and root folder is owned by a specific user. Users log in with their own credentials and see only their own library.
+
+For upgrade instructions and migration steps, see [docs/upgrade-v2.md](upgrade-v2.md).
+
+## Role model
+
+Two roles exist: `admin` and `user`.
+
+- The **first account** created through the `/setup` wizard is always `admin`.
+- Users created by an admin via Settings → Users default to the `user` role.
+- OIDC auto-provisioned users get the `user` role unless their IdP group matches `allowed_admin_groups` in the provider config (see [docs/auth-oidc.md](auth-oidc.md)).
+- An admin can change any user's role at any time: **Settings → Users → Edit**, or `PUT /api/v1/auth/users/{id}` with `{"role": "admin"}`.
+
+### Capability matrix
+
+| Action | `admin` | `user` |
+|--------|:-------:|:------:|
+| View and manage own authors/books/downloads | Yes | Yes |
+| View and manage own quality/metadata profiles | Yes | Yes |
+| View and manage own root folders | Yes | Yes |
+| Change own password and API key | Yes | Yes |
+| Configure own notification preferences | Yes | Yes |
+| View other users' library data | Yes | No |
+| Manage other users' library data | Yes | No |
+| Create, edit, delete users | Yes | No |
+| Change user roles | Yes | No |
+| Configure indexers | Yes | No |
+| Configure download clients | Yes | No |
+| Configure system-wide settings | Yes | No |
+| View admin settings tabs in UI | Yes | No |
+| Trigger system-level operations (backup, scan, migrate) | Yes | No |
+
+## User management
+
+### Creating a user
+
+**Settings → Users → Add user** (admin only), or via API:
+
+```bash
+curl -X POST http://bindery:8787/api/v1/auth/users \
+  -H "X-Api-Key: <admin-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"username": "alice", "password": "correct-horse-battery", "role": "user"}'
+```
+
+OIDC users are created automatically on first login — no pre-creation needed unless `BINDERY_PROXY_AUTO_PROVISION=false`.
+
+### Listing users
+
+```bash
+curl http://bindery:8787/api/v1/auth/users \
+  -H "X-Api-Key: <admin-api-key>"
+```
+
+Returns: `[{"id": 1, "username": "admin", "role": "admin", "last_seen": "..."}]`. Passwords and OIDC credentials are never returned.
+
+### Updating a user
+
+```bash
+# Promote to admin
+curl -X PUT http://bindery:8787/api/v1/auth/users/2 \
+  -H "X-Api-Key: <admin-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"role": "admin"}'
+```
+
+### Deleting a user
+
+```bash
+curl -X DELETE http://bindery:8787/api/v1/auth/users/2 \
+  -H "X-Api-Key: <admin-api-key>"
+```
+
+Deleting a user does **not** delete their library data. Authors, books, and downloads owned by that user remain in the database but become inaccessible through the normal UI. Reassign or remove the user's data before deleting:
+
+1. Go to **Settings → Users → [user] → Library** to view their content.
+2. Delete or reassign authors and books as needed.
+3. Then delete the user.
+
+## Settings UI layout
+
+Settings is split into two tabs post-v1.0:
+
+- **My Account** — API key, password change, notification preferences. Visible to all users.
+- **Admin** — Indexers, download clients, quality profiles, metadata profiles, users list, system settings. Visible to `admin` role only. Non-admins who navigate to an admin URL receive a 403.
+
+## CSRF tokens
+
+v1.0 replaces the `X-Requested-With` header check with a proper double-submit CSRF token on all session-cookie-authenticated mutations.
+
+**Browser users:** the UI handles this transparently.
+
+**API scripts using session cookies:** fetch a token first:
+
+```bash
+TOKEN=$(curl -s -b "bindery_session=<value>" \
+  http://bindery:8787/api/v1/auth/csrf | jq -r .token)
+
+curl -X POST http://bindery:8787/api/v1/author \
+  -b "bindery_session=<value>" \
+  -H "X-CSRF-Token: $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Ursula K. Le Guin"}'
+```
+
+**API scripts using `X-Api-Key`:** CSRF is not required — API-key requests bypass the check entirely. Existing automation continues to work without changes.
+
+## See also
+
+- [docs/troubleshooting-auth.md](troubleshooting-auth.md) — consolidated symptom→cause→fix table for all auth phases
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| User B can see User A's authors or books via the API | A repo query is missing the `userID` filter — this is a bug | File a bug report with the exact endpoint URL and response. As a workaround, ensure user B does not have the `admin` role (admins can access all users' data by design). |
+| Data remains after a user is deleted | `DELETE /auth/users/{id}` does not cascade to library data | Reassign or delete the user's authors and books before deleting the user account (see "Deleting a user" above). |
+| `403 Forbidden` on an API call that worked before v1.0 | Session-cookie mutations now require `X-CSRF-Token` | Switch callers to `X-Api-Key` auth (CSRF-exempt), or add a `GET /auth/csrf` preflight to your script (see "CSRF tokens" above). |
+| Admin locked out — no admin account exists or all admins deleted | User row has `role='user'` or all admin rows were removed | Recover via direct DB update (no Bindery restart needed if you can write to the DB file): `sqlite3 /config/bindery.db "UPDATE users SET role='admin' WHERE username='<your-username>';"` — or in Kubernetes: `kubectl exec deploy/bindery -- sqlite3 /config/bindery.db "UPDATE users SET role='admin' WHERE id=1;"` |
+| OIDC user auto-provisioned as `user` but should be `admin` | `allowed_admin_groups` not configured for the OIDC provider | Add the IdP group name to `allowed_admin_groups` in the provider config. Promote the existing account manually: `PUT /api/v1/auth/users/{id}` with `{"role": "admin"}`. |
+| Non-admin user can reach admin settings page in UI | Browser cached a pre-v1.0 session or route bundle | Hard-refresh the page (`Ctrl+Shift+R`). If it persists, log out and back in. The backend enforces role checks regardless of what the UI renders. |

--- a/docs/troubleshooting-auth.md
+++ b/docs/troubleshooting-auth.md
@@ -1,0 +1,37 @@
+# Auth Troubleshooting
+
+Quick-reference for every auth-related symptom across all three auth phases. Each row maps to a risk mitigation identified during design — the "fix" column is what the mitigation actually looks like at runtime.
+
+For setup guides, see the per-feature docs linked at the bottom.
+
+## Symptom → cause → fix
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Bindery refuses to start: `proxy mode requires BINDERY_TRUSTED_PROXY` | Proxy mode was enabled but `BINDERY_TRUSTED_PROXY` is empty — Bindery refuses to start rather than silently allow any IP to set the identity header | Set `BINDERY_TRUSTED_PROXY` to your proxy's IP or CIDR (e.g. `172.20.0.0/16` for Docker bridge, `10.0.0.0/8` for Kubernetes pods). Bindery logs the effective CIDR list at startup so you can verify it. |
+| Any LAN host can forge `X-Forwarded-User: admin` and get in | `BINDERY_TRUSTED_PROXY` is too broad (e.g. `0.0.0.0/0`) or empty while mode is somehow `proxy` | Tighten to only your proxy's IP or pod subnet. Confirm effective CIDR in startup log: `trusted proxies: [...]`. Firewall rules should ensure Bindery is unreachable except via the proxy. |
+| `401 Unauthorized` after successful SSO login | Source IP not in `BINDERY_TRUSTED_PROXY`, or identity header name mismatch | (1) Check startup log for trusted CIDR — the request source IP (Traefik/Caddy container, not browser) must match. (2) Confirm `BINDERY_PROXY_AUTH_HEADER` matches what the proxy sends: Authelia → `Remote-User`; Authentik → `X-Authentik-Username`. Enable `BINDERY_LOG_LEVEL=debug` to log both. |
+| New Bindery user created every time a user renames their IdP account | Auto-provisioning keys on a mutable username/email header; rename produces a new row and orphans the old user's data | Use a stable, opaque identifier: Authelia internal UUID, Authentik user UUID, Keycloak `sub` claim. Configure `BINDERY_PROXY_AUTH_HEADER` to point at that header. Admin can merge orphaned users from **Settings → Users**. See [docs/auth-proxy.md — Header choice](auth-proxy.md#header-choice-stability-matters). |
+| Two users at different IdPs map to the same Bindery account | Two providers can emit the same `sub` value for different people | This cannot happen by design — Bindery's user-mapping key is the composite `(oidc_issuer, oidc_sub)`, not `oidc_sub` alone. If you observe it, it is a bug; file an issue. |
+| OIDC logout from IdP does not log out of Bindery | Bindery's HMAC-signed session cookie is independent of the IdP session; revoking the IdP session has no effect until the cookie TTL expires (~12h short-lived, up to 30d with "Remember me") | **Known limitation.** Mitigations: (1) shorten session TTL in Settings → General → Security; (2) rotate the session secret in Settings → General → Security → Rotate session secret — this immediately invalidates all active sessions. Per-user revocation is planned for a future release. |
+| Rotating the session secret logs everyone out at once | The session secret is shared; rotating it is a global operation with no per-session granularity | Expected behaviour when used to force a global logout. Warn users before rotating. Per-session revocation is planned. |
+| OIDC client secret visible to anyone with DB read access | Client secrets are stored as plaintext in the `settings` table — same posture as indexer API keys | **Known limitation.** Protect `bindery.db` with `chmod 600`; restrict `kubectl exec` / `docker exec` access; treat backup files as sensitive. An env-var secret-ref pattern is planned for a future release. |
+| User B can see User A's authors or books via API | A repository query is missing the `userID` filter — this is a bug; the `QueryScope` helper in the repo layer should catch it | File a bug report with the exact endpoint URL and response body. As a workaround, ensure user B does not have the `admin` role (admins can access all users' data by design). The two-user integration test matrix is the backstop to detect regressions. |
+| `403 Forbidden` on API mutations that worked before v1.0 | CSRF double-submit token is now required for session-cookie-authenticated mutations | Switch the caller to `X-Api-Key` auth (exempt from CSRF), or add a `GET /api/v1/auth/csrf` preflight: `TOKEN=$(curl -s -b bindery_session=... http://bindery:8787/api/v1/auth/csrf \| jq -r .token)` then pass `-H "X-CSRF-Token: $TOKEN"`. |
+| Existing API-key scripts break after v1.0 CSRF rollout | CSRF token incorrectly required on `X-Api-Key` requests | This should not happen — CSRF only applies when auth is session-cookie-based; `X-Api-Key` requests bypass it. If it does occur, it is a bug; file an issue. |
+| Migration `019_multiuser.sql` fails mid-run | Orphaned rows (broken foreign keys from earlier bugs) prevent the `NOT NULL owner_user_id` backfill | The migration runs in a transaction — the DB is not corrupted on failure. Check the startup log for the printed repair query (typically a `DELETE FROM downloads WHERE book_id NOT IN (...)`). Run it, then restart. Always take a backup before upgrading — see [docs/upgrade-v2.md](upgrade-v2.md). |
+| All data missing after v1.0 upgrade | Migration ran against the wrong database file | Confirm `BINDERY_DB_PATH` points to the correct file. Restore from the pre-upgrade backup. |
+| Admin locked out — no admin account reachable | All user rows have `role='user'`, or admin account was deleted | Direct DB repair (no restart needed): `sqlite3 /config/bindery.db "UPDATE users SET role='admin' WHERE username='<name>';"` — Kubernetes: `kubectl exec deploy/bindery -- sqlite3 /config/bindery.db "UPDATE users SET role='admin' WHERE id=1;"` |
+
+## Per-feature docs
+
+| Topic | Doc |
+|-------|-----|
+| Proxy SSO setup (Traefik/Authelia, Caddy/Authentik, nginx) | [docs/auth-proxy.md](auth-proxy.md) |
+| OIDC setup (Google, GitHub, Authelia, Authentik, Keycloak) | [docs/auth-oidc.md](auth-oidc.md) |
+| Multi-user roles, user management, CSRF tokens | [docs/multi-user.md](multi-user.md) |
+| v1.0 upgrade: backup, dry-run, kubectl cp, rollback | [docs/upgrade-v2.md](upgrade-v2.md) |
+| Wiki: step-by-step Authelia howto | [Wiki — Authelia forward-auth](https://github.com/vavallee/bindery/wiki/Howto-Authelia-proxy-auth) |
+| Wiki: step-by-step Authentik howto | [Wiki — Authentik forward-auth](https://github.com/vavallee/bindery/wiki/Howto-Authentik-proxy-auth) |
+| Wiki: proxy login troubleshooting walkthrough | [Wiki — Troubleshoot proxy login](https://github.com/vavallee/bindery/wiki/Howto-Troubleshoot-proxy-login) |
+| Wiki: full troubleshooting reference | [Wiki — Troubleshooting](https://github.com/vavallee/bindery/wiki/Troubleshooting) |

--- a/docs/upgrade-v2.md
+++ b/docs/upgrade-v2.md
@@ -1,0 +1,195 @@
+# Upgrading to v1.0 (multi-user migration)
+
+> **Migration 019 is a one-way door on SQLite.** There is no automated rollback. Take a verified backup before you start.
+
+v1.0 runs migration `019_multiuser.sql`, which adds `owner_user_id` to every user-owned table and backfills all existing rows to `user_id=1`. The migration runs inside a transaction — if it fails, the database is not left in a half-migrated state and Bindery exits cleanly with a repair hint.
+
+Single-user installs are unaffected in practice: all data remains owned by user 1 and behaviour is identical post-upgrade.
+
+## Step 1 — Take a verified backup
+
+### Docker / binary
+
+```bash
+# Via API (creates a timestamped .db copy in BINDERY_DATA_DIR)
+curl -X POST -H "X-Api-Key: <key>" http://bindery:8787/api/v1/backup
+
+# Via UI
+Settings → General → Backup → Create backup
+
+# Verify it was written
+ls -lh /config/bindery_backup_*.db
+```
+
+### Kubernetes
+
+Copy the database file out of the PVC **before** stopping Bindery. With the pod still running:
+
+```bash
+# Find the pod name
+kubectl get pods -l app=bindery
+
+# Copy bindery.db from the PVC to your local machine
+kubectl cp bindery-0:/config/bindery.db ./bindery-pre-v1.db
+
+# Confirm the copy is non-zero and readable
+sqlite3 ./bindery-pre-v1.db "SELECT count(*) FROM books;"
+```
+
+Store `bindery-pre-v1.db` somewhere safe. This is your rollback point.
+
+## Step 2 — Dry-run the migration on a copy
+
+Run the new binary against a copy of your production database before touching the real one. This confirms the migration completes cleanly on your data.
+
+### Docker dry-run
+
+```bash
+# Copy the live DB
+cp /config/bindery.db /tmp/bindery-dryrun.db
+
+# Run the new image against the copy (read-write, but isolated)
+docker run --rm \
+  -e BINDERY_DB_PATH=/tmp/bindery-dryrun.db \
+  -v /tmp:/tmp \
+  ghcr.io/vavallee/bindery:v1.0.0 \
+  bindery migrate --dry-run
+
+# Or just boot it — migration runs at startup, Bindery will exit after if no port is exposed
+docker run --rm \
+  -e BINDERY_DB_PATH=/tmp/bindery-dryrun.db \
+  -e BINDERY_PORT=18787 \
+  -v /tmp:/tmp \
+  -p 18787:18787 \
+  ghcr.io/vavallee/bindery:v1.0.0
+```
+
+Check the logs for `migration 019 complete; all rows backfilled to user_id=1`. If the migration fails on the copy, Bindery logs the error and the specific repair query needed.
+
+### Kubernetes dry-run
+
+```bash
+# Spin up a one-off pod against the backup copy (copy it into a temp PVC or emptyDir)
+kubectl run bindery-dryrun --rm -it --restart=Never \
+  --image=ghcr.io/vavallee/bindery:v1.0.0 \
+  --env="BINDERY_DB_PATH=/tmp/bindery-dryrun.db" \
+  --overrides='{"spec":{"volumes":[{"name":"tmp","emptyDir":{}}],"containers":[{"name":"bindery-dryrun","volumeMounts":[{"name":"tmp","mountPath":"/tmp"}]}]}}' \
+  -- sh -c "cp /config/bindery.db /tmp/bindery-dryrun.db && bindery"
+```
+
+Or, more practically: copy the DB locally, run the binary locally, verify integrity:
+
+```bash
+# Pull and run the new binary locally against the backup
+BINDERY_DB_PATH=./bindery-pre-v1.db ./bindery-v1.0.0 &
+sleep 3
+curl -s http://localhost:8787/api/v1/author | jq 'length'   # should match pre-upgrade count
+curl -s http://localhost:8787/api/v1/book  | jq 'length'
+kill %1
+```
+
+### Integrity check queries
+
+After the dry-run completes, verify data integrity directly:
+
+```bash
+DB=./bindery-pre-v1.db   # or /config/bindery.db post-upgrade
+
+# All rows should have owner_user_id = 1
+sqlite3 $DB "SELECT count(*) FROM authors WHERE owner_user_id IS NULL;"   # expect 0
+sqlite3 $DB "SELECT count(*) FROM books   WHERE owner_user_id IS NULL;"   # expect 0
+sqlite3 $DB "SELECT count(*) FROM downloads WHERE owner_user_id IS NULL;" # expect 0
+
+# Row counts should match pre-upgrade
+sqlite3 $DB "SELECT count(*) FROM authors;"
+sqlite3 $DB "SELECT count(*) FROM books;"
+```
+
+## Step 3 — Upgrade
+
+### Docker / binary
+
+```bash
+# 1. Stop Bindery
+docker stop bindery   # or kill the process
+
+# 2. Backup is already done (Step 1)
+
+# 3. Pull the new image / replace the binary
+docker pull ghcr.io/vavallee/bindery:v1.0.0
+
+# 4. Start — migration runs automatically
+docker start bindery
+
+# 5. Tail logs to confirm
+docker logs -f bindery | grep -E "migration|error"
+# Expect: migration 019 complete; all rows backfilled to user_id=1
+```
+
+### Kubernetes (Helm)
+
+```bash
+# 1. Copy DB out of PVC (Step 1, already done)
+
+# 2. Update the image tag
+helm upgrade bindery charts/bindery \
+  --set image.tag=v1.0.0 \
+  --reuse-values
+
+# 3. Watch the rollout
+kubectl rollout status deployment/bindery
+
+# 4. Confirm migration in logs
+kubectl logs deployment/bindery | grep -E "migration|error"
+```
+
+## Step 4 — Verify
+
+```bash
+# UI: open Bindery, confirm library loads normally
+# API: spot-check row counts match pre-upgrade
+curl -s -H "X-Api-Key: <key>" http://bindery:8787/api/v1/author | jq 'length'
+curl -s -H "X-Api-Key: <key>" http://bindery:8787/api/v1/book   | jq 'length'
+```
+
+Check **Settings → Users** — you should see your original admin account listed with role `admin`.
+
+## Rollback
+
+**There is no automated rollback for migration 019.** SQLite does not support `DROP COLUMN`, so the `owner_user_id` columns cannot be removed by reverting the binary.
+
+To roll back: restore from the backup taken in Step 1.
+
+### Docker / binary rollback
+
+```bash
+docker stop bindery
+cp /config/bindery_backup_<timestamp>.db /config/bindery.db
+docker run ... ghcr.io/vavallee/bindery:v0.24.0   # previous image
+```
+
+### Kubernetes rollback
+
+```bash
+# Copy the backup back into the PVC
+kubectl cp ./bindery-pre-v1.db bindery-0:/config/bindery.db
+
+# Roll back the Helm release
+helm rollback bindery
+```
+
+Data written to Bindery between the upgrade and the rollback will be lost — it was scoped to the new schema and is not recoverable from the pre-upgrade snapshot.
+
+## See also
+
+- [docs/troubleshooting-auth.md](troubleshooting-auth.md) — consolidated symptom→cause→fix table covering migration failures and all auth phases
+
+## Troubleshooting migration failures
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Startup fails: `orphaned rows detected in downloads` | Rows in `downloads` reference non-existent book or user IDs from earlier bugs | Follow the repair query printed in the log. Typically: `DELETE FROM downloads WHERE book_id NOT IN (SELECT id FROM books);` Re-run after fixing. |
+| Startup fails: `migration 019: constraint violation` | A table has rows that conflict with the new `NOT NULL owner_user_id` constraint in a way the backfill didn't catch | Run the dry-run against a copy, examine the exact error, and apply the suggested fix. Always restore from backup before retrying on the live DB. |
+| Migration exits mid-run, DB appears corrupted | Should not happen — migration runs in a transaction | Confirm by opening the DB with `sqlite3 /config/bindery.db ".schema authors"`. If `owner_user_id` column is absent, the migration rolled back cleanly. Restore from backup and investigate the error in logs before retrying. |
+| All data appears under the wrong user post-migration | Backfill wrote to a different DB file than expected | Confirm `BINDERY_DB_PATH` points to the correct file. Check `sqlite3 /config/bindery.db "SELECT count(*) FROM authors;"` against your pre-upgrade count. |
+| Admin account missing after migration | User table had the account but role column was not set | `sqlite3 /config/bindery.db "UPDATE users SET role='admin' WHERE id=1;"` — this is safe to run on a live instance. |


### PR DESCRIPTION
## Summary

Adds six documentation guides covering the auth and multi-user features shipping in v1.0.

- `docs/auth-multiuser.md` — combined multi-user + v1.0 upgrade overview: role model, CSRF change, backup prerequisite, migration 019 summary.
- `docs/auth-oidc.md` — OIDC (Authorization Code + PKCE) setup: env vars, redirect URI, `(issuer, sub)` mapping, per-provider admin group configuration.
- `docs/auth-proxy.md` — reverse-proxy SSO (`mode=proxy`): trusted proxy CIDR requirement, identity header configuration, security warning about direct reachability.
- `docs/multi-user.md` — per-user library scoping reference: role capability matrix, admin vs user scope, cross-reference to upgrade guide.
- `docs/troubleshooting-auth.md` — symptom / cause / fix table across all three auth phases (proxy, OIDC, multi-user), including CSRF 403s and OIDC logout caveat.
- `docs/upgrade-v2.md` — step-by-step v1.0 upgrade runbook: backup verification, migration 019 (one-way on SQLite), post-upgrade checks.

## Test plan

- [ ] Render the six new files on GitHub and confirm tables/links display correctly
- [ ] Verify cross-doc links resolve (`multi-user.md` → `upgrade-v2.md`, `troubleshooting-auth.md` → `auth-proxy.md#header-choice-stability-matters`, etc.)
- [ ] Team-lead merges in coordination with the v1.0.3 release