### PR TITLE
docs: add Discord invite to README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest. Bindery is a single-maintainer project that takes PRs, issues, and feedback via [GitHub](https://github.com/vavallee/bindery/issues). The goal is a small, reliable, audited codebase — PRs that narrow the diff and tighten guarantees are preferred over PRs that add surface area.
 
+For quick questions about dev setup, build failures, or whether an idea fits scope, the Discord server is usually faster than opening an issue: [discord.gg/RpuYYRM9cZ](https://discord.gg/RpuYYRM9cZ). **Do not** post security vulnerabilities there — see [Reporting security issues](#reporting-security-issues) below.
+
 ## Prerequisites
 
 - Go 1.25+

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <a href="https://github.com/vavallee/bindery/pkgs/container/bindery"><img src="https://img.shields.io/badge/ghcr.io-vavallee%2Fbindery-blue" alt="Docker" /></a>
   <a href="https://goreportcard.com/report/github.com/vavallee/bindery"><img src="https://goreportcard.com/badge/github.com/vavallee/bindery" alt="Go Report Card" /></a>
   <a href="https://github.com/vavallee/bindery/blob/main/LICENSE"><img src="https://img.shields.io/github/license/vavallee/bindery" alt="License" /></a>
+  <a href="https://discord.gg/RpuYYRM9cZ"><img src="https://img.shields.io/badge/Discord-BINDERY-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
 ---
@@ -315,6 +316,14 @@ Otherwise the server responds with `401`. The API key lives in **Settings → Ge
 | **Troubleshooting** — permission-denied, path-remap, import failures | [Wiki](https://github.com/vavallee/bindery/wiki/Troubleshooting) |
 | **Indexer & download-client recipes** — NZBGeek / DrunkenSlug / Prowlarr / Jackett / SAB / qBit tips | [Wiki](https://github.com/vavallee/bindery/wiki/Indexer-and-downloader-recipes) |
 | **Migrating from Readarr** — step-by-step with known failure modes | [Wiki](https://github.com/vavallee/bindery/wiki/Migrating-from-Readarr) |
+
+## Community
+
+- **Discord** — real-time help, setup questions, release chat: [discord.gg/RpuYYRM9cZ](https://discord.gg/RpuYYRM9cZ). The `#support` channel is the best place to ask; `#changelog` is updated on every release.
+- **GitHub Issues** — bug reports and feature requests: [issues](https://github.com/vavallee/bindery/issues).
+- **GitHub Discussions** — open-ended design questions, show-and-tell, integration recipes: [discussions](https://github.com/vavallee/bindery/discussions).
+
+Please keep security reports out of Discord and public issues — see [SECURITY.md](SECURITY.md) for the private disclosure channel.
 
 ## Security
 


### PR DESCRIPTION
## Summary

Adds the BINDERY Discord server ([discord.gg/RpuYYRM9cZ](https://discord.gg/RpuYYRM9cZ)) to the two surfaces most likely to be read by new users and would-be contributors.

- **README.md**
  - Discord badge in the top badge row, consistent with the existing shields.io style.
  - New **Community** section between _Documentation_ and _Security_ listing Discord, GitHub Issues, and GitHub Discussions as distinct support channels, with a pointer to `#support` / `#changelog`.
  - Explicit reminder that security reports should go through SECURITY.md, not Discord or public issues.
- **CONTRIBUTING.md**
  - Short pointer under the intro telling contributors Discord is the fast path for dev-setup, build, or scope questions, with the same security-report caveat.
- **SECURITY.md** — intentionally untouched; the existing private-disclosure process stands.

## Invite details

- URL: https://discord.gg/RpuYYRM9cZ
- Target channel: `#general` (`1493709535536484589`)
- `max_age=0`, `max_uses=0` — permanent, unlimited uses. Revocable from Discord server settings if it ever needs to be rotated.

## Test plan

- [ ] Render README.md on the branch view on GitHub, confirm Discord badge renders and the Community section appears between Documentation and Security.
- [ ] Click the invite from a signed-out browser and confirm it lands on BINDERY `#general`.
- [ ] Render CONTRIBUTING.md, confirm the Discord line sits between the intro paragraph and Prerequisites.