### PR TITLE
chore(deploy): update bindery image to v1.1.0

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "sha-483b730"
+  tag: "v1.1.0"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Bumps the Helm chart image tag from `sha-483b730` to `v1.1.0` so ArgoCD deploys the release build.