### PR TITLE
fix(deploy): strip v prefix from bindery image tag

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "v1.1.0"
+  tag: "1.1.0"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
## Problem

ArgoCD cannot pull the bindery image — it 404s trying to fetch `ghcr.io/vavallee/bindery:v1.1.0`.

## Root cause

`docker/metadata-action` strips the leading `v` from semver git tags by default, so the image was actually pushed as `ghcr.io/vavallee/bindery:1.1.0`. PR #322 set `values.yaml` to `v1.1.0`, assuming the v was preserved.

Verified from the v1.1.0 build logs (run 24698711395):

\`\`\`
DOCKER_METADATA_OUTPUT_TAGS: ghcr.io/vavallee/bindery:1.1.0
pushing manifest for ghcr.io/vavallee/bindery:1.1.0@sha256:f6bbfec...
\`\`\`

## Fix

Drop the `v` in `charts/bindery/values.yaml` to match what actually exists in GHCR. Follow-up: either add `enable=true` to the `{{major}}.{{minor}}.{{patch}}` rule so the v is preserved, or keep this shape and remember to strip v in future bumps.