### PR TITLE
sec: fix multi-user isolation and privilege-escalation vulnerabilities

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -383,15 +383,15 @@ func main() {
 		r.Get("/auth/config", authHandler.GetConfig)
 		r.Post("/auth/password", authHandler.ChangePassword)
 		r.Post("/auth/apikey/regenerate", authHandler.RegenerateAPIKey)
-		r.Put("/auth/mode", authHandler.SetMode)
 		// OIDC — login/callback are unauthenticated; provider management requires auth.
 		r.Get("/auth/oidc/providers", oidcHandler.GetProviders)
 		r.Put("/auth/oidc/providers", oidcHandler.SetProviders)
 		r.Get("/auth/oidc/{provider}/login", oidcHandler.Login)
 		r.Get("/auth/oidc/{provider}/callback", oidcHandler.Callback)
-		// User management — admin only.
+		// Admin-only auth mutations.
 		r.Group(func(r chi.Router) {
 			r.Use(auth.RequireAdmin)
+			r.Put("/auth/mode", authHandler.SetMode)
 			r.Get("/auth/users", userMgmtHandler.List)
 			r.Post("/auth/users", userMgmtHandler.Create)
 			r.Delete("/auth/users/{id}", userMgmtHandler.Delete)

--- a/cmd/bindery/proxy.go
+++ b/cmd/bindery/proxy.go
@@ -40,20 +40,27 @@ func parseTrustedProxyCIDRs(raw string) []*net.IPNet {
 	return trusted
 }
 
+// proxyHeaders is the set of forwarded headers that only a trusted proxy
+// should be allowed to set. They are stripped from every request that does
+// not originate from a configured trusted proxy, preventing spoofing of
+// OPDS base URLs, HSTS detection, and session-cookie Secure flags.
+var proxyHeaders = []string{
+	"X-Forwarded-For",
+	"X-Forwarded-Proto",
+	"X-Forwarded-Host",
+	"X-Real-IP",
+}
+
 // trustedProxyMiddleware returns a middleware that rewrites RemoteAddr from
 // X-Forwarded-For / X-Real-IP only when the direct peer is a configured
-// trusted proxy. Without a trusted proxy configured, forwarded headers are
-// ignored and the peer IP is used as-is — preventing XFF spoofing in
-// local-only auth mode.
+// trusted proxy. When the peer is not trusted, all forwarded headers are
+// stripped so downstream handlers cannot be spoofed via X-Forwarded-Proto
+// or X-Forwarded-Host.
 //
 // Configured via BINDERY_TRUSTED_PROXY: a comma-separated list of IPs or
 // CIDRs. Bare IPs are treated as /32 (IPv4) or /128 (IPv6).
 func trustedProxyMiddleware() func(http.Handler) http.Handler {
 	trusted := parseTrustedProxyCIDRs(os.Getenv("BINDERY_TRUSTED_PROXY"))
-	if len(trusted) == 0 {
-		// No trusted proxy — use peer IP as-is (safe default).
-		return func(next http.Handler) http.Handler { return next }
-	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -64,6 +71,12 @@ func trustedProxyMiddleware() func(http.Handler) http.Handler {
 					middleware.RealIP(next).ServeHTTP(w, r)
 					return
 				}
+			}
+			// Peer is not a trusted proxy — strip all forwarded headers so
+			// they cannot influence scheme/host detection downstream.
+			r = r.Clone(r.Context())
+			for _, h := range proxyHeaders {
+				r.Header.Del(h)
 			}
 			next.ServeHTTP(w, r)
 		})

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -263,8 +263,11 @@ func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 func (h *AuthHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	resp := authConfigResponse{
-		Mode:   string(h.mode(ctx)),
-		APIKey: h.apiKey(ctx),
+		Mode: string(h.mode(ctx)),
+	}
+	// Only expose the API key to admin users — it grants full access.
+	if auth.UserRoleFromContext(ctx) == "admin" {
+		resp.APIKey = h.apiKey(ctx)
 	}
 	if uid := auth.UserIDFromContext(ctx); uid != 0 {
 		if u, _ := h.users.GetByID(ctx, uid); u != nil {

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
@@ -47,7 +48,9 @@ func (h *AuthorHandler) WithFinder(f LibraryFinder) *AuthorHandler {
 }
 
 func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
-	authors, err := h.authors.List(r.Context())
+	ctx := r.Context()
+	userID := auth.UserIDFromContext(ctx)
+	authors, err := h.authors.ListByUser(ctx, userID)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return


### PR DESCRIPTION
## Summary

Security fixes for findings from the multi-user audit:

- **API key leaked to non-admins** — `GET /api/v1/auth/config` returned the global API key to any authenticated user; key is now redacted unless the caller has `role=admin`
- **Cross-user author visibility** — `GET /api/v1/author` returned all rows regardless of `owner_user_id`; list is now scoped to the authenticated user's ID
- **Non-admin auth mode escalation** — `PUT /api/v1/auth/mode` lacked a `RequireAdmin` guard; a regular user could switch to `local-only`, bypassing authentication for all unauthenticated localhost requests
- **Untrusted `X-Forwarded-*` headers** — `trustedProxyMiddleware` only protected `X-Forwarded-For`; `X-Forwarded-Proto` and `X-Forwarded-Host` were accepted from any client, allowing OPDS link injection and spurious HSTS headers; now all forwarded headers are stripped from untrusted peers

## Test plan

- [ ] `GET /api/v1/auth/config` as non-admin returns `"apiKey": ""`
- [ ] `GET /api/v1/auth/config` as admin returns the key
- [ ] `GET /api/v1/author` as alice only returns alice-owned authors
- [ ] `PUT /api/v1/auth/mode` as non-admin returns `403 {"error":"admin role required"}`
- [ ] OPDS `<link href>` with spoofed `X-Forwarded-Host` uses server's real host (no `BINDERY_TRUSTED_PROXY` set)
- [ ] With `BINDERY_TRUSTED_PROXY` set and request from trusted IP, `X-Forwarded-Host` is honoured normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)