### PR TITLE
chore(deploy): update bindery image to v1.1.1

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.1.0"
+  tag: "1.1.1"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Bumps the Helm chart image tag from `1.1.0` to `v1.1.1` so ArgoCD deploys the security patch release.