### PR TITLE
chore(deploy): update bindery image to 1.1.2

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.1.1"
+  tag: "1.1.2"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Bumps the Helm chart image tag to 1.1.2 so ArgoCD (watching main) deploys the v1.1.2 release.