### PR TITLE
fix(db): include NULL-owner authors in per-user list query

### DIFF
--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -27,8 +27,11 @@ func (r *AuthorRepo) List(ctx context.Context) ([]models.Author, error) {
 }
 
 const (
-	listAuthorsAll    = "SELECT " + authorSelectCols + " FROM authors ORDER BY sort_name"
-	listAuthorsByUser = "SELECT " + authorSelectCols + " FROM authors WHERE owner_user_id = ? ORDER BY sort_name"
+	listAuthorsAll = "SELECT " + authorSelectCols + " FROM authors ORDER BY sort_name"
+	// Include rows with NULL owner_user_id — these are authors created before the
+	// multi-user migration ran its backfill (migration 025) or imported without a
+	// user context. Excluding them causes the list to silently drop visible authors.
+	listAuthorsByUser = "SELECT " + authorSelectCols + " FROM authors WHERE owner_user_id = ? OR owner_user_id IS NULL ORDER BY sort_name"
 )
 
 func (r *AuthorRepo) ListByUser(ctx context.Context, userID int64) ([]models.Author, error) {


### PR DESCRIPTION
## Summary

- `ListByUser` excluded authors with `owner_user_id = NULL`, causing them to silently vanish from the Authors list view even though they're accessible by direct ID
- NULL rows are authors added before migration 025 backfilled `owner_user_id`, or authors imported without a user context
- Fix: extend the WHERE clause to `owner_user_id = ? OR owner_user_id IS NULL`

## Test plan

- [ ] Authors page shows all authors including ones accessible via `/author/{id}`
- [ ] Multi-user install: user A cannot see user B's authors (owner_user_id scoping still works)
- [ ] Single-user install: all authors appear regardless of when they were added
- [ ] `go test ./internal/db/...` passes

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)