### PR TITLE
fix(books): restore download link and fix legacy-path file deletion

### DIFF
--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -286,6 +286,15 @@ func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 		}
 		deletedPaths = append(deletedPaths, book.EbookFilePath)
 		book.EbookFilePath = ""
+	} else if deleteEbook && book.FilePath != "" {
+		// Legacy path: EbookFilePath is empty but FilePath is set.
+		// deleteEbook was set via the legacy-fallback branch above.
+		if err := removeBookPath(book.FilePath); err != nil {
+			slog.Error("failed to remove legacy file path", "id", id, "path", book.FilePath, "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		deletedPaths = append(deletedPaths, book.FilePath)
 	}
 
 	if deleteAudiobook && book.AudiobookFilePath != "" {

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -46,34 +46,43 @@ func (h *FileHandler) Download(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if book.FilePath == "" {
+	// Prefer the legacy FilePath, fall back to per-format columns for books
+	// created after the dual-format schema landed (migration 026+).
+	filePath := book.FilePath
+	if filePath == "" {
+		filePath = book.EbookFilePath
+	}
+	if filePath == "" {
+		filePath = book.AudiobookFilePath
+	}
+	if filePath == "" {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no file available for this book"})
 		return
 	}
 
 	// Defence-in-depth: refuse to serve paths that aren't under a configured
-	// library root, even if a tampered DB row or importer bug set FilePath
+	// library root, even if a tampered DB row or importer bug set a path
 	// to something outside the library (e.g. /etc/passwd, /config/*).
-	if !h.isAllowedPath(book.FilePath) {
+	if !h.isAllowedPath(filePath) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "access denied"})
 		return
 	}
 
-	info, err := os.Stat(book.FilePath)
+	info, err := os.Stat(filePath)
 	if err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "file not found on disk"})
 		return
 	}
 
 	if info.IsDir() {
-		streamZip(w, book.FilePath)
+		streamZip(w, filePath)
 		return
 	}
 
-	filename := filepath.Base(book.FilePath)
+	filename := filepath.Base(filePath)
 	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
 	w.Header().Set("Content-Length", strconv.FormatInt(info.Size(), 10))
-	http.ServeFile(w, r, book.FilePath)
+	http.ServeFile(w, r, filePath)
 }
 
 // isAllowedPath reports whether p falls under one of the configured library

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -295,7 +295,7 @@ export default function BookDetailPage() {
                 </div>
               )}
             </div>
-          ) : book.filePath ? (
+          ) : (book.filePath || book.ebookFilePath) ? (
             <div className="mt-3 flex items-center gap-4 text-sm">
               <a href={`/api/v1/book/${book.id}/file`} className="text-emerald-500 hover:text-emerald-400">
                 Download file
@@ -308,7 +308,7 @@ export default function BookDetailPage() {
               >
                 {deletingFile ? 'Deleting…' : 'Delete file'}
               </button>
-              <span className="text-xs text-slate-500 dark:text-zinc-500 break-all">{book.filePath}</span>
+              <span className="text-xs text-slate-500 dark:text-zinc-500 break-all">{book.filePath || book.ebookFilePath}</span>
             </div>
           ) : null}
           <div className="mt-3 flex items-center gap-3">


### PR DESCRIPTION
## Summary

Two related regressions from the dual-format (ebook/audiobook) schema:

- **Download 404 for new books** — `GET /api/v1/book/{id}/file` only checked the legacy `FilePath` column; books added after migration 026 have `EbookFilePath` set instead, so the endpoint returned 404. Now falls back: `FilePath` → `EbookFilePath` → `AudiobookFilePath`.
- **Delete file leaves zombie on disk** — `DELETE /book/{id}/file` on a legacy book set `deleteEbook=true` but then checked `book.EbookFilePath != ""` before calling `removeBookPath`, which was always false for legacy books. The DB column was cleared but the file was never removed. Fixed by adding a separate branch for the legacy-path case.
- **Download button hidden in UI** — Book detail page only showed the Download/Delete-file row when `book.filePath` was set; books with `ebookFilePath` got neither. Now shows for `filePath || ebookFilePath`.

## Test plan

- [ ] `GET /api/v1/book/{id}/file` returns file content for books with only `ebook_file_path` set
- [ ] `DELETE /book/{id}/file` on a legacy book actually removes the file from disk
- [ ] Book detail page shows "Download file" link for post-migration books (ebookFilePath set, filePath empty)
- [ ] Book detail page shows file path next to download link
- [ ] `go build ./...` passes

Closes #290, #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)