### PR TITLE
fix(calibre): populate language, enrich author ratings, upgrade calibre stubs on OL match

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -384,6 +384,12 @@ func (h *AuthorHandler) relinkCalibreAuthor(ctx context.Context, author *models.
 	if full.Disambiguation != "" {
 		author.Disambiguation = full.Disambiguation
 	}
+	if full.RatingsCount > 0 {
+		author.RatingsCount = full.RatingsCount
+	}
+	if full.AverageRating > 0 {
+		author.AverageRating = full.AverageRating
+	}
 	if err := h.authors.Update(ctx, author); err != nil {
 		return err
 	}
@@ -443,11 +449,13 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 	// default) and parse its allowed_languages CSV. Nil means "no filter".
 	allowedLangs, unknownFail := h.resolveAllowedLanguages(ctx, author)
 
-	// Track titles we've already added (case-insensitive) to avoid OL duplicates
+	// Track titles we've already added (case-insensitive) to avoid OL duplicates.
+	// The value is a pointer to the existing book so we can enrich calibre-imported
+	// stubs with the OL foreign ID and language when they title-match an OL record.
 	existingBooks, _ := h.books.ListByAuthor(ctx, author.ID)
-	seenTitles := make(map[string]bool)
-	for _, eb := range existingBooks {
-		seenTitles[strings.ToLower(eb.Title)] = true
+	seenTitles := make(map[string]*models.Book)
+	for i := range existingBooks {
+		seenTitles[strings.ToLower(existingBooks[i].Title)] = &existingBooks[i]
 	}
 
 	normalizedAuthor := strings.ToLower(strings.TrimSpace(author.Name))
@@ -491,11 +499,21 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 			continue
 		}
 
-		// Skip duplicate titles (OpenLibrary often has multiple works for the same book)
-		if seenTitles[normalizedTitle] {
+		// Skip duplicate titles (OpenLibrary often has multiple works for the same book).
+		// Exception: if the matching book is a calibre stub (calibre: ForeignID),
+		// upgrade it in place with the real OL foreign ID and language so it shows
+		// metadata without creating a second row.
+		if stub := seenTitles[normalizedTitle]; stub != nil {
+			if strings.HasPrefix(stub.ForeignID, "calibre:") {
+				stub.ForeignID = b.ForeignID
+				if stub.Language == "" && b.Language != "" {
+					stub.Language = b.Language
+				}
+				_ = h.books.Update(ctx, stub)
+			}
 			continue
 		}
-		seenTitles[normalizedTitle] = true
+		seenTitles[normalizedTitle] = &b
 
 		if err := h.books.Create(ctx, &b); err != nil {
 			// A UNIQUE constraint on foreign_id means the book was already

--- a/internal/calibre/importer.go
+++ b/internal/calibre/importer.go
@@ -437,6 +437,7 @@ func (i *Importer) upsertBook(ctx context.Context, author *models.Author, cb Cal
 		Title:            cb.Title,
 		SortTitle:        firstNonEmpty(cb.SortTitle, cb.Title),
 		ReleaseDate:      cb.PublishDate,
+		Language:         cb.Language,
 		Monitored:        true,
 		Status:           models.BookStatusImported,
 		AnyEditionOK:     true,
@@ -469,6 +470,9 @@ func (i *Importer) applyBookFields(ctx context.Context, book *models.Book, cb Ca
 		book.FilePath = cb.Formats[0].AbsolutePath
 		book.Status = models.BookStatusImported
 	}
+	if cb.Language != "" && book.Language == "" {
+		book.Language = cb.Language
+	}
 	if book.MetadataProvider == "" {
 		book.MetadataProvider = "calibre"
 	}
@@ -489,6 +493,10 @@ func (i *Importer) upsertEdition(ctx context.Context, book *models.Book, cb Cali
 	}
 
 	isbn13 := ptrStringIfNonEmpty(cb.ISBN)
+	lang := cb.Language
+	if lang == "" {
+		lang = "eng" // fallback when Calibre library has no language set
+	}
 	e := &models.Edition{
 		ForeignID:   foreignID,
 		BookID:      book.ID,
@@ -497,7 +505,7 @@ func (i *Importer) upsertEdition(ctx context.Context, book *models.Book, cb Cali
 		Publisher:   "",
 		PublishDate: cb.PublishDate,
 		Format:      strings.ToUpper(f.Format),
-		Language:    "eng",
+		Language:    lang,
 		ImageURL:    cb.CoverPath,
 		IsEbook:     true,
 		Monitored:   true,

--- a/internal/calibre/reader.go
+++ b/internal/calibre/reader.go
@@ -36,6 +36,7 @@ type CalibreBook struct {
 	SortTitle   string
 	PublishDate *time.Time
 	ISBN        string
+	Language    string // ISO 639-2 code from Calibre's languages table; empty if unset
 	Authors     []CalibreAuthor
 	Series      *CalibreSeries
 	Formats     []CalibreFormat
@@ -161,6 +162,11 @@ func (r *Reader) Books(ctx context.Context, fn func(CalibreBook) error) error {
 			return err
 		}
 
+		cb.Language, err = r.loadLanguage(ctx, cb.CalibreID)
+		if err != nil {
+			return err
+		}
+
 		if cover := filepath.Join(cb.LibraryPath, "cover.jpg"); fileExists(cover) {
 			cb.CoverPath = cover
 		}
@@ -280,6 +286,33 @@ func (r *Reader) loadISBN(ctx context.Context, bookID int64) (string, error) {
 		return "", fmt.Errorf("load isbn for book %d: %w", bookID, err)
 	}
 	return isbn, nil
+}
+
+// loadLanguage returns the primary ISO 639-2 language code for the book from
+// Calibre's languages table, or empty string if none is set. Calibre stores
+// codes as three-letter ISO 639-2 strings (e.g. "eng", "deu", "fra") which
+// are the same format Bindery uses, so no translation is needed.
+func (r *Reader) loadLanguage(ctx context.Context, bookID int64) (string, error) {
+	var lang string
+	row := r.db.QueryRowContext(ctx, `
+		SELECT l.lang_code
+		FROM books_languages_link bll
+		JOIN languages l ON l.id = bll.lang_code
+		WHERE bll.book = ?
+		ORDER BY bll.item_order
+		LIMIT 1`, bookID)
+	err := row.Scan(&lang)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		// Older Calibre libraries (pre-0.7.x) don't have the languages table.
+		if strings.Contains(err.Error(), "no such table") {
+			return "", nil
+		}
+		return "", fmt.Errorf("load language for book %d: %w", bookID, err)
+	}
+	return lang, nil
 }
 
 // parseCalibreDate tolerates the three pubdate formats Calibre has shipped:


### PR DESCRIPTION
## Summary

Three issues surfaced by Calibre library import + Refresh Metadata flow (#314):

- **Language unknown on all imported books** — `CalibreBook` had no `Language` field and the reader never queried `books_languages_link`. Book rows were created with `language=""`, editions were hardcoded to `"eng"`. Reader now reads the primary ISO 639-2 code from Calibre's languages table (fails gracefully for older Calibre libraries that predate the table). Language flows through to both the book row and the edition row.

- **Author ratings missing after relink** — `relinkCalibreAuthor` fetched the full OL author record but only copied `image_url`, `description`, and `sort_name`. `ratings_count` and `average_rating` are now copied as well.

- **Duplicate/stub books after Refresh Metadata** — `FetchAuthorBooks` skipped title-matched books with a bare `continue`, so calibre-imported stubs (`ForeignID = "calibre:book:N"`, no language, no OL ID) were never upgraded when OpenLibrary returned the same title. The `seenTitles` map now stores a book pointer; when the match is a calibre stub, it is updated in-place with the OL `ForeignID` and language before skipping second-row creation.

## Test plan

- [ ] Import a Calibre library — books show correct language (not "Language unknown") for books that have a language set in Calibre
- [ ] Import a Calibre library where books have no language — no error, books import cleanly
- [ ] Click Refresh Metadata on a Calibre-imported author — author gains image/description/ratings
- [ ] Click Refresh Metadata on a Calibre-imported author — no duplicate book rows; existing Calibre stubs get their ForeignID upgraded to the OL ID
- [ ] `go test ./internal/calibre/... ./internal/api/...` passes

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)