### PR TITLE
chore(deploy): update bindery to v1.1.4

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.1.3"
+  tag: "1.1.4"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Automated: bump Helm chart image tag to `1.1.4`.