### PR TITLE
fix(authors): stamp owner_user_id on create so authors appear in the tab

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -167,7 +167,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		author.MetadataProfileID = &def
 	}
 
-	if err := h.authors.Create(r.Context(), author); err != nil {
+	if err := h.authors.CreateForUser(r.Context(), author, auth.UserIDFromContext(r.Context())); err != nil {
 		slog.Error("create author failed", "foreign_id", req.ForeignID, "error", err)
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
 			writeJSON(w, http.StatusConflict, map[string]string{"error": "author already exists"})
@@ -597,7 +597,7 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 		fetched.Monitored = false
 		def := models.DefaultMetadataProfileID
 		fetched.MetadataProfileID = &def
-		if err := h.authors.Create(ctx, fetched); err != nil {
+		if err := h.authors.CreateForUser(ctx, fetched, auth.UserIDFromContext(ctx)); err != nil {
 			if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 				return


### PR DESCRIPTION
## Summary

Fixes #339 — Authors tab shows "No authors yet" even though the author row exists in the DB.

**Root cause:** `AuthorRepo.Create()` always called `CreateForUser` with `ownerUserID = 0`, which stores `NULL` in `owner_user_id`. The `List` handler filters by the authenticated user's ID (`WHERE owner_user_id = ?`), so newly-created authors never matched — they were invisible in the Authors tab while Books and Wanted populated fine (those views don't filter by user).

**Fix:** Both creation sites in the API layer now call `CreateForUser` with the user ID extracted from the request context:
- `AuthorHandler.Create` (the explicit Add Author flow)  
- `AuthorHandler.AddBook` (the implicit create-on-demand path when adding a book whose author isn't in the DB yet)

The `OR owner_user_id IS NULL` fallback already added to `listAuthorsByUser` in main remains as a safety net for any rows created before this fix.

## Test plan

- [ ] Fresh install: add an author → author appears in Authors tab immediately
- [ ] Add a book via AddBook for an author not yet in DB → author appears in Authors tab
- [ ] Existing installs with NULL `owner_user_id` rows still show authors (covered by the `IS NULL` fallback)
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)