### PR TITLE
fix(calibre): sync Push-all reachability with Test-connection result

### DIFF
--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1834,10 +1834,15 @@ function CalibreSection({
       const prefix = isPlugin ? '✓ Plugin reachable' : '✓ calibredb reachable'
       const detail = r.version || r.message
       setTestResult({ ok: true, msg: detail ? `${prefix} — ${detail}` : prefix })
+      // Mirror into bridgeReachable so the Push-all button flips to enabled
+      // on a successful manual test, without waiting for the silent probe
+      // to re-fire (which only triggers on mode/url/key *changes*).
+      if (isPlugin) setBridgeReachable(true)
     } catch (err) {
       const reason = err instanceof Error ? err.message : 'Test failed'
       const prefix = isPlugin ? '✗ Could not reach plugin' : '✗ calibredb unreachable'
       setTestResult({ ok: false, msg: `${prefix} — ${reason}` })
+      if (isPlugin) setBridgeReachable(false)
     } finally {
       setTesting(false)
     }


### PR DESCRIPTION
## Summary

- On the Calibre settings page, clicking **Test connection** would turn green while **Push all to Calibre** still said "Bridge not reachable" and stayed disabled.
- Root cause: the two indicators are backed by different React state. `bridgeReachable` is updated only by a silent probe whose `useEffect` dep array is `[mode, pluginURL, pluginKey]`. `Save` on a text field doesn't change those values — typing already did — so after the initial `false` probe for an unconfigured plugin, `bridgeReachable` never re-evaluates, and the manual `runTest` didn't touch it.
- Fix: have `runTest` mirror its outcome into `setBridgeReachable` when `mode === 'plugin'`, so a successful test immediately enables the Push-all button without a page reload.

## Test plan

- [ ] Fresh install, `calibre.mode = plugin`, plugin URL/key unset → Push-all is disabled with "Bridge not reachable" (unchanged behaviour).
- [ ] Enter a correct plugin URL + API key, Save each → click **Test connection** → green ✓, Push-all button becomes enabled (previously required a page refresh).
- [ ] Enter an incorrect URL/key → click Test → red ✗, Push-all disabled with the amber warning.
- [ ] Switch `mode` to `calibredb` → Test still runs; `bridgeReachable` is not touched (it's reset to `null` by the existing effect), Push-all remains hidden/disabled as before.
- [ ] `npm run typecheck`, `npm run lint`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)