### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to Bindery are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com) and versions follow
 [Semantic Versioning](https://semver.org).
 
-## [Unreleased] — development branch
+## [Unreleased]
 
-The `development` branch carries the in-flight feature set for the next release. Images are published as `ghcr.io/vavallee/bindery:development` and `:dev-<sha>`; point ArgoCD at the `development` branch to follow. Treat these features as beta — schema migrations are additive and safe, but UX may still shift before tagging.
+## [v1.2.0] — 2026-04-22
 
 ### Added
 
@@ -16,6 +16,7 @@ The `development` branch carries the in-flight feature set for the next release.
 
 ### Fixed
 
+- **Multi-file ebook downloads are now fully tracked** — Delete + files removes every file (mobi, epub, pdf, etc.) and rescan cannot re-claim orphan files. Library rescan now requires a matched file to live under the candidate book's configured root folder, preventing cross-author mismapping (#343).
 - **Ebook searches no longer include the parent Books category (7000)**, which could return comics and magazines. Affects Prowlarr-synced indexers: `filterCategoriesForMedia` now matches only the 702x ebook subcategory range (7020–7029) and 303x audiobook range (3030–3039), and the syncer drops parent categories (7000, 3000) at sync time and propagates category changes on re-sync. (#344)
 - **Author sync no longer creates duplicate book rows that differ only in edition suffix, whitespace, or Unicode normalization.** Existing duplicates are merged on upgrade. Search result filtering no longer drops valid releases when the book title contains a parenthesised edition qualifier (#283).
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindery-web",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Promotes `## [Unreleased]` → `## [v1.2.0] — 2026-04-22` in `CHANGELOG.md`
- Adds `## [Unreleased]` placeholder at the top
- Adds missing #343 (book_files / multi-file delete) to the Fixed section
- Bumps `web/package.json` version to `1.2.0`

## What's in v1.2.0

### Added
- Default library location configurable from Settings → General (#332)
- Search results split by media type (ebook / audiobook) for dual-format books (#333)
- Persistent log store with date-range/level/component filtering (#241)

### Fixed
- Multi-file ebook downloads fully tracked; delete removes all files; rescan respects root folder boundaries (#343)
- Ebook searches no longer pull broad parent category 7000 / comics / magazines (#344)
- Duplicate book rows from edition suffix / whitespace / Unicode normalization merged on upgrade (#283)

## Test plan

- [ ] `CHANGELOG.md` section `## [v1.2.0]` present and correctly formatted
- [ ] `go test ./...` and `npm run build --prefix web` pass
- [ ] After merge + tag: CI builds `ghcr.io/vavallee/bindery:v1.2.0` and GH Release created

🤖 Generated with [Claude Code](https://claude.com/claude-code)