### PR TITLE
fix(qbittorrent): poll unfiltered torrent list + 30s timeout + verbose error (#363)

### DIFF
--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -14,6 +15,8 @@ import (
 	"sync"
 	"time"
 )
+
+const addTorrentTimeout = 30 * time.Second
 
 // Client interacts with the qBittorrent WebUI API v2.
 // Authentication is cookie-based: Login() obtains a SID cookie which is
@@ -98,7 +101,7 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 	// Snapshot existing hashes so we can detect newly-added items when the
 	// source URL is not a magnet with an explicit btih.
 	beforeSet := map[string]struct{}{}
-	if before, err := c.GetTorrents(ctx, category); err == nil {
+	if before, err := c.GetTorrents(ctx, ""); err == nil {
 		for _, t := range before {
 			beforeSet[strings.ToLower(t.Hash)] = struct{}{}
 		}
@@ -147,16 +150,21 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 	// Poll until the new torrent appears — qBittorrent must fetch and parse
 	// the .torrent file before the hash is visible, which can take a second
 	// or two for remote URLs (e.g. Prowlarr Torznab redirects).
-	deadline := time.Now().Add(10 * time.Second)
+	// Poll the full unfiltered list so we find the torrent even if qBittorrent
+	// assigns a different category than requested before our rename lands.
+	deadline := time.Now().Add(addTorrentTimeout)
+	var afterHashes []string
 	for {
-		after, err := c.GetTorrents(ctx, category)
+		after, err := c.GetTorrents(ctx, "")
 		if err != nil {
 			return "", fmt.Errorf("add torrent accepted but hash lookup failed: %w", err)
 		}
+		afterHashes = afterHashes[:0]
 		var newest *Torrent
 		for i := range after {
 			t := &after[i]
 			h := strings.ToLower(t.Hash)
+			afterHashes = append(afterHashes, h)
 			if _, seen := beforeSet[h]; seen {
 				continue
 			}
@@ -176,6 +184,14 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 		case <-time.After(500 * time.Millisecond):
 		}
 	}
+	beforeHashes := make([]string, 0, len(beforeSet))
+	for h := range beforeSet {
+		beforeHashes = append(beforeHashes, h)
+	}
+	slog.Error("add torrent: hash resolution timed out",
+		"before_hashes", beforeHashes,
+		"after_hashes", afterHashes,
+		"category", category)
 	return "", fmt.Errorf("add torrent accepted but hash could not be determined")
 }
 

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // newTestClient creates a Client pointing at the given test server URL.
@@ -427,5 +428,102 @@ func TestEnsureLoggedIn_NotLoggedIn(t *testing.T) {
 	}
 	if loginCount != 1 {
 		t.Errorf("Login should be called once when not logged in; called %d times", loginCount)
+	}
+}
+
+// TestAddTorrent_DifferentCategory verifies that AddTorrent can resolve the hash
+// even when qBittorrent assigns the torrent a different category than requested.
+// This exercises the fix for #363: the poll loop must use the unfiltered torrent
+// list, not the category-filtered one.
+func TestAddTorrent_DifferentCategory(t *testing.T) {
+	const requestedCategory = "books"
+	const actualCategory = "default" // qBittorrent assigns a different category
+
+	newTorrent := Torrent{
+		Hash:     "deadbeef1234",
+		Name:     "Some Book",
+		Category: actualCategory, // different from what Bindery requested
+		AddedOn:  1000,
+	}
+	afterBody, _ := json.Marshal([]Torrent{newTorrent})
+
+	// infoCallCount tracks how many times /torrents/info is called.
+	// The first call is the "before" snapshot (returns empty); subsequent calls
+	// are poll iterations (return the new torrent under a different category).
+	infoCallCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			// No category filter expected — poll must use unfiltered list.
+			if r.URL.Query().Get("category") != "" {
+				t.Errorf("poll should not filter by category, got query: %s", r.URL.RawQuery)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			infoCallCount++
+			if infoCallCount == 1 {
+				// First call: before-snapshot — return empty list.
+				_, _ = w.Write([]byte("[]"))
+			} else {
+				// Subsequent calls: poll — return the new torrent.
+				_, _ = w.Write(afterBody)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	// Use a non-magnet URL so the code falls through to the poll loop.
+	hash, err := c.AddTorrent(context.Background(), "http://example.com/file.torrent", requestedCategory, "")
+	if err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if !strings.EqualFold(hash, newTorrent.Hash) {
+		t.Errorf("hash: want %q, got %q", strings.ToLower(newTorrent.Hash), hash)
+	}
+}
+
+// TestAddTorrent_Timeout verifies that AddTorrent returns an error when the
+// poll loop exhausts its deadline without finding a new torrent.
+// The timeout is forced by using a context that is already cancelled.
+func TestAddTorrent_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			// Never return the new torrent — always empty list.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	// Override the package-level timeout to something very short so the test
+	// doesn't take 30 seconds.
+	orig := addTorrentTimeout
+	// addTorrentTimeout is a const so we use a cancelled context instead to
+	// force an immediate context-cancellation error path, which is equivalent
+	// for our purposes: we verify AddTorrent returns an error when it can't
+	// resolve the hash.
+	_ = orig
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	_, err := c.AddTorrent(ctx, "http://example.com/file.torrent", "books", "")
+	if err == nil {
+		t.Fatal("expected error when torrent hash cannot be resolved before timeout")
 	}
 }

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -795,11 +795,10 @@ func jaroWinkler(s1, s2 string) float64 {
 	// Jaro-Winkler prefix bonus (p=0.1, up to 4 chars).
 	prefix := 0
 	for i := 0; i < l1 && i < l2 && i < 4; i++ {
-		if r1[i] == r2[i] {
-			prefix++
-		} else {
+		if r1[i] != r2[i] {
 			break
 		}
+		prefix++
 	}
 	return jaro + float64(prefix)*0.1*(1-jaro)
 }

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -207,11 +207,11 @@ func TestPushToCalibre_NilResolver(t *testing.T) {
 func TestJaroWinkler(t *testing.T) {
 	cases := []struct {
 		s1, s2 string
-		wantGE  float64
-		wantLT  float64
+		wantGE float64
+		wantLT float64
 	}{
 		{"Das Echo der Schuld", "Das Echo der Schuld", 1.0, 0},
-		{"Das Echo der Schuld", "das echo der schuld", 0, 1.0},      // case-sensitive; callers normalise
+		{"Das Echo der Schuld", "das echo der schuld", 0, 1.0}, // case-sensitive; callers normalise
 		{"Das Echo der Schuld", "Completely Different Book Title", 0, 0.85},
 		{"The Great Gatsby", "The Great Gatsby", 1.0, 0},
 		{"1984", "1984", 1.0, 0},


### PR DESCRIPTION
Closes #363

## Summary

- `AddTorrent` now calls `GetTorrents(ctx, "")` (no category filter) for both the before-snapshot and the poll loop, so the new torrent is visible even when qBittorrent assigns a different category before Bindery's rename lands
- Deadline extended from 10 s to 30 s via the new `addTorrentTimeout` const
- On timeout, a structured `slog.Error` is emitted with `before_hashes`, `after_hashes`, and `category` for easier debugging

## Test plan

- `TestAddTorrent_DifferentCategory`: mock server returns the torrent under a different category than requested; confirms hash is resolved correctly and no category query param is sent during poll
- `TestAddTorrent_Timeout`: mock server never returns a new torrent; confirms an error is returned after the context deadline
- All existing qbittorrent and downloader tests continue to pass