### PR TITLE
fix(search): split ebook / audiobook sections in interactive search results (#333)

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -795,11 +795,10 @@ func jaroWinkler(s1, s2 string) float64 {
 	// Jaro-Winkler prefix bonus (p=0.1, up to 4 chars).
 	prefix := 0
 	for i := 0; i < l1 && i < l2 && i < 4; i++ {
-		if r1[i] == r2[i] {
-			prefix++
-		} else {
+		if r1[i] != r2[i] {
 			break
 		}
+		prefix++
 	}
 	return jaro + float64(prefix)*0.1*(1-jaro)
 }

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -207,11 +207,11 @@ func TestPushToCalibre_NilResolver(t *testing.T) {
 func TestJaroWinkler(t *testing.T) {
 	cases := []struct {
 		s1, s2 string
-		wantGE  float64
-		wantLT  float64
+		wantGE float64
+		wantLT float64
 	}{
 		{"Das Echo der Schuld", "Das Echo der Schuld", 1.0, 0},
-		{"Das Echo der Schuld", "das echo der schuld", 0, 1.0},      // case-sensitive; callers normalise
+		{"Das Echo der Schuld", "das echo der schuld", 0, 1.0}, // case-sensitive; callers normalise
 		{"Das Echo der Schuld", "Completely Different Book Title", 0, 0.85},
 		{"The Great Gatsby", "The Great Gatsby", 1.0, 0},
 		{"1984", "1984", 1.0, 0},

--- a/internal/indexer/newznab/types.go
+++ b/internal/indexer/newznab/types.go
@@ -86,4 +86,5 @@ type SearchResult struct {
 	BookTitle   string `json:"bookTitle"`
 	Protocol    string `json:"protocol"`           // "usenet" or "torrent"
 	Language    string `json:"language,omitempty"` // ISO 639-1 from newznab:attr language (when present)
+	MediaType   string `json:"mediaType,omitempty"` // "ebook" or "audiobook" — set when the search was media-type-specific
 }

--- a/internal/indexer/newznab/types.go
+++ b/internal/indexer/newznab/types.go
@@ -84,7 +84,7 @@ type SearchResult struct {
 	Grabs       int    `json:"grabs"`
 	Author      string `json:"author"`
 	BookTitle   string `json:"bookTitle"`
-	Protocol    string `json:"protocol"`           // "usenet" or "torrent"
-	Language    string `json:"language,omitempty"` // ISO 639-1 from newznab:attr language (when present)
+	Protocol    string `json:"protocol"`            // "usenet" or "torrent"
+	Language    string `json:"language,omitempty"`  // ISO 639-1 from newznab:attr language (when present)
 	MediaType   string `json:"mediaType,omitempty"` // "ebook" or "audiobook" — set when the search was media-type-specific
 }

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -72,7 +72,54 @@ func filterCategoriesForMedia(cats []int, mediaType string) []int {
 
 // SearchBook queries all enabled indexers and returns deduplicated, filtered,
 // ranked results.
+//
+// When c.MediaType is "both", two parallel passes are run — one for ebook and
+// one for audiobook — and each result is tagged with its MediaType so the
+// caller can render them in separate sections. In single-type mode the results
+// are tagged with c.MediaType directly.
 func (s *Searcher) SearchBook(ctx context.Context, indexers []models.Indexer, c MatchCriteria) []newznab.SearchResult {
+	if c.MediaType == models.MediaTypeBoth {
+		// Run ebook and audiobook passes concurrently, preserving per-type
+		// ranking so each section is independently ordered.
+		var (
+			ebookResults     []newznab.SearchResult
+			audiobookResults []newznab.SearchResult
+			wg               sync.WaitGroup
+		)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			ec := c
+			ec.MediaType = models.MediaTypeEbook
+			res := s.searchBookSingle(ctx, indexers, ec)
+			for i := range res {
+				res[i].MediaType = models.MediaTypeEbook
+			}
+			ebookResults = res
+		}()
+		go func() {
+			defer wg.Done()
+			ac := c
+			ac.MediaType = models.MediaTypeAudiobook
+			res := s.searchBookSingle(ctx, indexers, ac)
+			for i := range res {
+				res[i].MediaType = models.MediaTypeAudiobook
+			}
+			audiobookResults = res
+		}()
+		wg.Wait()
+		return append(ebookResults, audiobookResults...)
+	}
+
+	results := s.searchBookSingle(ctx, indexers, c)
+	for i := range results {
+		results[i].MediaType = c.MediaType
+	}
+	return results
+}
+
+// searchBookSingle executes one media-type pass across all enabled indexers.
+func (s *Searcher) searchBookSingle(ctx context.Context, indexers []models.Indexer, c MatchCriteria) []newznab.SearchResult {
 	var (
 		mu      sync.Mutex
 		results []newznab.SearchResult

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -427,7 +427,8 @@ export interface SearchResult {
   grabs: number
   pubDate: string
   protocol: string  // "usenet" or "torrent"
-  language?: string // ISO 639-1 from newznab:attr language (when present)
+  language?: string  // ISO 639-1 from newznab:attr language (when present)
+  mediaType?: string // "ebook" or "audiobook" — present when the book mediaType is specific
 }
 
 export interface AddAuthorRequest {

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { api, Book, HistoryEvent, SearchResult } from '../api/client'
+import MediaBadge from '../components/MediaBadge'
 
 function formatSize(n: number): string {
   if (!n || n <= 0) return ''
@@ -406,30 +407,56 @@ export default function BookDetailPage() {
         </div>
       )}
 
-      {results !== null && results.length > 0 && (
-        <section className="mb-6">
-          <h3 className="text-sm font-semibold mb-2 text-slate-800 dark:text-zinc-200">Results ({results.length})</h3>
-          <div className="space-y-1">
-            {results.slice(0, 20).map(r => (
-              <div key={r.guid} className="flex items-center justify-between p-2 bg-slate-100 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded text-xs">
-                <div className="min-w-0 mr-3">
-                  <span className="truncate block text-slate-800 dark:text-zinc-200">{r.title}</span>
-                  <span className="text-slate-500 dark:text-zinc-500 truncate block">
-                    {r.indexerName} · {formatSize(r.size)} · {r.grabs} grabs
-                  </span>
-                </div>
-                <button
-                  onClick={() => grab(r)}
-                  disabled={grabbing !== null}
-                  className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded text-[11px] font-medium flex-shrink-0"
-                >
-                  {grabbing === r.guid ? 'Grabbing…' : 'Grab'}
-                </button>
+      {results !== null && results.length > 0 && (() => {
+        const ebooks = results.filter(r => r.mediaType === 'ebook')
+        const audiobooks = results.filter(r => r.mediaType === 'audiobook')
+        const hasBothTypes = ebooks.length > 0 && audiobooks.length > 0
+
+        const renderRow = (r: SearchResult) => (
+          <div key={r.guid} className="flex items-center justify-between p-2 bg-slate-100 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded text-xs">
+            <div className="min-w-0 mr-3">
+              <div className="flex items-center gap-1.5 mb-0.5">
+                {!hasBothTypes && r.mediaType && (
+                  <MediaBadge type={r.mediaType as 'ebook' | 'audiobook'} />
+                )}
+                <span className="truncate text-slate-800 dark:text-zinc-200">{r.title}</span>
               </div>
-            ))}
+              <span className="text-slate-500 dark:text-zinc-500 truncate block">
+                {r.indexerName} · {formatSize(r.size)} · {r.grabs} grabs
+              </span>
+            </div>
+            <button
+              onClick={() => grab(r)}
+              disabled={grabbing !== null}
+              className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded text-[11px] font-medium flex-shrink-0"
+            >
+              {grabbing === r.guid ? 'Grabbing…' : 'Grab'}
+            </button>
           </div>
-        </section>
-      )}
+        )
+
+        if (hasBothTypes) {
+          return (
+            <div className="mb-6 space-y-4">
+              <section>
+                <h3 className="text-sm font-semibold mb-2 text-slate-800 dark:text-zinc-200">📖 Ebook results ({ebooks.length})</h3>
+                <div className="space-y-1">{ebooks.slice(0, 20).map(renderRow)}</div>
+              </section>
+              <section>
+                <h3 className="text-sm font-semibold mb-2 text-slate-800 dark:text-zinc-200">🎧 Audiobook results ({audiobooks.length})</h3>
+                <div className="space-y-1">{audiobooks.slice(0, 20).map(renderRow)}</div>
+              </section>
+            </div>
+          )
+        }
+
+        return (
+          <section className="mb-6">
+            <h3 className="text-sm font-semibold mb-2 text-slate-800 dark:text-zinc-200">Results ({results.length})</h3>
+            <div className="space-y-1">{results.slice(0, 20).map(renderRow)}</div>
+          </section>
+        )
+      })()}
 
       {events.length > 0 && (
         <section>

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -5,6 +5,7 @@ import { api, Book, SearchResult } from '../api/client'
 import BulkActionBar from '../components/BulkActionBar'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
+import MediaBadge from '../components/MediaBadge'
 
 export default function WantedPage() {
   const { t } = useTranslation()
@@ -279,36 +280,64 @@ export default function WantedPage() {
                   </div>
                 )}
 
-                {showResults === book.id && results.length > 0 && (
-                  <div className="mt-1 mb-3 space-y-1">
-                    {results.slice(0, 10).map(r => (
-                      <div key={r.guid} className="flex items-center justify-between p-2 bg-slate-200/50 dark:bg-zinc-800/50 rounded text-xs">
-                        <div className="min-w-0 mr-3">
-                          <span className="truncate block">{r.title}</span>
-                          <span className="text-slate-600 dark:text-zinc-500 truncate block">
-                            {r.indexerName} &middot; {formatSize(r.size)} &middot; {r.grabs} grabs
-                            {r.language && (
-                              <span className="ml-1.5 inline-block px-1 py-0 rounded bg-slate-300 dark:bg-zinc-700 text-[9px] font-medium uppercase tracking-wide">{r.language}</span>
-                            )}
-                          </span>
+                {showResults === book.id && results.length > 0 && (() => {
+                  const ebooks = results.filter(r => r.mediaType === 'ebook')
+                  const audiobooks = results.filter(r => r.mediaType === 'audiobook')
+                  const hasBothTypes = ebooks.length > 0 && audiobooks.length > 0
+
+                  const renderResultRow = (r: SearchResult) => (
+                    <div key={r.guid} className="flex items-center justify-between p-2 bg-slate-200/50 dark:bg-zinc-800/50 rounded text-xs">
+                      <div className="min-w-0 mr-3">
+                        <div className="flex items-center gap-1.5 mb-0.5">
+                          {!hasBothTypes && r.mediaType && (
+                            <MediaBadge type={r.mediaType as 'ebook' | 'audiobook'} />
+                          )}
+                          <span className="truncate">{r.title}</span>
                         </div>
-                        <button
-                          onClick={() => grab(r, book)}
-                          disabled={grabbingGuid === r.guid || grabbedGuid === r.guid}
-                          className={`px-2 py-2 rounded text-[10px] font-medium flex-shrink-0 touch-manipulation transition-colors disabled:cursor-default ${
-                            grabbedGuid === r.guid
-                              ? 'bg-emerald-700 text-emerald-200'
-                              : grabbingGuid === r.guid
-                              ? 'bg-emerald-600/60 text-white/70'
-                              : 'bg-emerald-600 hover:bg-emerald-500 text-white'
-                          }`}
-                        >
-                          {grabbedGuid === r.guid ? t('wanted.grabbed') : grabbingGuid === r.guid ? t('wanted.grabbing') : t('wanted.grab')}
-                        </button>
+                        <span className="text-slate-600 dark:text-zinc-500 truncate block">
+                          {r.indexerName} &middot; {formatSize(r.size)} &middot; {r.grabs} grabs
+                          {r.language && (
+                            <span className="ml-1.5 inline-block px-1 py-0 rounded bg-slate-300 dark:bg-zinc-700 text-[9px] font-medium uppercase tracking-wide">{r.language}</span>
+                          )}
+                        </span>
                       </div>
-                    ))}
-                  </div>
-                )}
+                      <button
+                        onClick={() => grab(r, book)}
+                        disabled={grabbingGuid === r.guid || grabbedGuid === r.guid}
+                        className={`px-2 py-2 rounded text-[10px] font-medium flex-shrink-0 touch-manipulation transition-colors disabled:cursor-default ${
+                          grabbedGuid === r.guid
+                            ? 'bg-emerald-700 text-emerald-200'
+                            : grabbingGuid === r.guid
+                            ? 'bg-emerald-600/60 text-white/70'
+                            : 'bg-emerald-600 hover:bg-emerald-500 text-white'
+                        }`}
+                      >
+                        {grabbedGuid === r.guid ? t('wanted.grabbed') : grabbingGuid === r.guid ? t('wanted.grabbing') : t('wanted.grab')}
+                      </button>
+                    </div>
+                  )
+
+                  if (hasBothTypes) {
+                    return (
+                      <div className="mt-1 mb-3 space-y-3">
+                        <div>
+                          <p className="text-xs font-semibold mb-1 text-slate-700 dark:text-zinc-300">📖 Ebook results ({ebooks.length})</p>
+                          <div className="space-y-1">{ebooks.slice(0, 10).map(renderResultRow)}</div>
+                        </div>
+                        <div>
+                          <p className="text-xs font-semibold mb-1 text-slate-700 dark:text-zinc-300">🎧 Audiobook results ({audiobooks.length})</p>
+                          <div className="space-y-1">{audiobooks.slice(0, 10).map(renderResultRow)}</div>
+                        </div>
+                      </div>
+                    )
+                  }
+
+                  return (
+                    <div className="mt-1 mb-3 space-y-1">
+                      {results.slice(0, 10).map(renderResultRow)}
+                    </div>
+                  )
+                })()}
               </div>
             ))}
           </div>

--- a/web/src/pages/__tests__/BookDetailPage.test.tsx
+++ b/web/src/pages/__tests__/BookDetailPage.test.tsx
@@ -27,6 +27,7 @@ vi.mock('../../api/client', () => ({
 }))
 
 import { api } from '../../api/client'
+import type { SearchResult } from '../../api/client'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -50,7 +51,7 @@ const baseBook = {
   author: { id: 1, foreignAuthorId: 'OL1A', authorName: 'Author Name', sortName: 'Name, Author', description: '', imageUrl: '', disambiguation: '', ratingsCount: 0, averageRating: 0, monitored: true },
 }
 
-const makeResult = (overrides: Partial<ReturnType<typeof makeResult>>) => ({
+const makeResult = (overrides: Partial<SearchResult>) => ({
   guid: 'guid-' + Math.random(),
   indexerName: 'TestIndexer',
   title: 'Test.Release.epub',

--- a/web/src/pages/__tests__/BookDetailPage.test.tsx
+++ b/web/src/pages/__tests__/BookDetailPage.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import BookDetailPage from '../BookDetailPage'
+
+// ---------------------------------------------------------------------------
+// Static mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('../../api/client', () => ({
+  api: {
+    getBook: vi.fn(),
+    listHistory: vi.fn(),
+    searchBook: vi.fn(),
+    listIndexers: vi.fn(),
+    updateBook: vi.fn(),
+    deleteBook: vi.fn(),
+    deleteBookFile: vi.fn(),
+    enrichAudiobook: vi.fn(),
+    toggleExcluded: vi.fn(),
+    grab: vi.fn(),
+  },
+}))
+
+import { api } from '../../api/client'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const baseBook = {
+  id: 42,
+  foreignBookId: 'OL123W',
+  authorId: 1,
+  title: 'Test Book',
+  description: '',
+  imageUrl: '',
+  genres: [],
+  monitored: true,
+  status: 'wanted',
+  filePath: '',
+  mediaType: 'ebook' as const,
+  ebookFilePath: '',
+  audiobookFilePath: '',
+  excluded: false,
+  author: { id: 1, foreignAuthorId: 'OL1A', authorName: 'Author Name', sortName: 'Name, Author', description: '', imageUrl: '', disambiguation: '', ratingsCount: 0, averageRating: 0, monitored: true },
+}
+
+const makeResult = (overrides: Partial<ReturnType<typeof makeResult>>) => ({
+  guid: 'guid-' + Math.random(),
+  indexerName: 'TestIndexer',
+  title: 'Test.Release.epub',
+  size: 1048576,
+  nzbUrl: 'https://example.com/nzb',
+  grabs: 5,
+  pubDate: '',
+  protocol: 'usenet' as const,
+  language: undefined,
+  mediaType: 'ebook',
+  ...overrides,
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/book/42']}>
+      <Routes>
+        <Route path="/book/:id" element={<BookDetailPage />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('BookDetailPage — search results section', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.getBook).mockResolvedValue(baseBook)
+    vi.mocked(api.listHistory).mockResolvedValue([])
+    vi.mocked(api.listIndexers).mockResolvedValue([{ id: 1, name: 'TestIndexer', type: 'newznab', url: 'https://x', apiKey: 'key', categories: [7020], enabled: true }])
+  })
+
+  it('renders two labelled sections when results contain both ebook and audiobook items', async () => {
+    vi.mocked(api.searchBook).mockResolvedValue([
+      makeResult({ guid: 'e1', title: 'Book.epub', mediaType: 'ebook' }),
+      makeResult({ guid: 'e2', title: 'Book.2.epub', mediaType: 'ebook' }),
+      makeResult({ guid: 'a1', title: 'Book.m4b', mediaType: 'audiobook' }),
+      makeResult({ guid: 'a2', title: 'Book.mp3', mediaType: 'audiobook' }),
+    ])
+
+    renderPage()
+
+    // Wait for the h2 book title heading to load (the page renders the title twice — once in
+    // an image placeholder div and once in the h2; use the heading role to disambiguate)
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Test Book' })).toBeInTheDocument())
+
+    // Click the search button (label varies by media type — match on the word "Search")
+    fireEvent.click(screen.getByRole('button', { name: /search.*indexers/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/📖 Ebook results/)).toBeInTheDocument()
+    )
+    expect(screen.getByText(/🎧 Audiobook results/)).toBeInTheDocument()
+
+    // Count markers in each heading
+    expect(screen.getByText(/📖 Ebook results \(2\)/)).toBeInTheDocument()
+    expect(screen.getByText(/🎧 Audiobook results \(2\)/)).toBeInTheDocument()
+
+    // All four titles should be rendered
+    expect(screen.getByText('Book.epub')).toBeInTheDocument()
+    expect(screen.getByText('Book.2.epub')).toBeInTheDocument()
+    expect(screen.getByText('Book.m4b')).toBeInTheDocument()
+    expect(screen.getByText('Book.mp3')).toBeInTheDocument()
+  })
+
+  it('renders a single results section when all results are ebook type', async () => {
+    vi.mocked(api.searchBook).mockResolvedValue([
+      makeResult({ guid: 'e1', title: 'Book.epub', mediaType: 'ebook' }),
+      makeResult({ guid: 'e2', title: 'Book.mobi', mediaType: 'ebook' }),
+    ])
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Test Book' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /search.*indexers/i }))
+
+    await waitFor(() => expect(screen.getByText('Book.epub')).toBeInTheDocument())
+
+    // Single unified section, no split headings
+    expect(screen.queryByText(/📖 Ebook results/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/🎧 Audiobook results/)).not.toBeInTheDocument()
+    expect(screen.getByText(/Results \(2\)/)).toBeInTheDocument()
+  })
+
+  it('renders a single results section when all results are audiobook type', async () => {
+    vi.mocked(api.searchBook).mockResolvedValue([
+      makeResult({ guid: 'a1', title: 'Book.m4b', mediaType: 'audiobook' }),
+    ])
+
+    renderPage()
+
+    await waitFor(() => expect(screen.getByRole('heading', { name: 'Test Book' })).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /search.*indexers/i }))
+
+    await waitFor(() => expect(screen.getByText('Book.m4b')).toBeInTheDocument())
+
+    expect(screen.queryByText(/📖 Ebook results/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/🎧 Audiobook results/)).not.toBeInTheDocument()
+    expect(screen.getByText(/Results \(1\)/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- When a book's mediaType is `both`, the interactive search now runs two parallel indexer passes (ebook + audiobook) and stamps each `SearchResult` with its `MediaType`
- `BookDetailPage` and `WantedPage` detect mixed results and render two labelled sections — `📖 Ebook results (N)` and `🎧 Audiobook results (N)` — instead of one flat list
- Single-type results fall back to the previous flat list (no regression); each row shows a `MediaBadge` in single-type mode
- 3 new vitest tests cover the split + single-type scenarios

Closes #333

## Test plan

- [ ] Go tests: `go test ./internal/indexer/...` — all pass
- [ ] Frontend tests: `cd web && npx vitest run` — all 53 pass
- [ ] Manual: search a book with mediaType `both` — confirm two sections appear
- [ ] Manual: search a book with mediaType `ebook` — confirm single section, badge shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)