### PR TITLE
fix(lint): gofmt struct field alignment in indexers_test.go

### DIFF
--- a/internal/api/indexers_test.go
+++ b/internal/api/indexers_test.go
@@ -290,12 +290,12 @@ func TestSearchBook_DualFormat_MediaTypeTagging(t *testing.T) {
 
 // slowSearcher records peak concurrency to verify parallel dispatch.
 type slowSearcher struct {
-	mu            sync.Mutex
-	inFlight      int
-	peakFlight    int
-	delay         time.Duration
-	ebookResults  []newznab.SearchResult
-	audioResults  []newznab.SearchResult
+	mu           sync.Mutex
+	inFlight     int
+	peakFlight   int
+	delay        time.Duration
+	ebookResults []newznab.SearchResult
+	audioResults []newznab.SearchResult
 }
 
 func (s *slowSearcher) SearchBookWithDebug(_ context.Context, _ []models.Indexer, c indexer.MatchCriteria) ([]newznab.SearchResult, *indexer.SearchDebug) {


### PR DESCRIPTION
Fixes gofmt alignment issue in the `slowSearcher` struct introduced by the #333 search-split work.

```
internal/api/indexers_test.go:293:1: File is not properly formatted (gofmt)
```

Six struct fields had one extra space column; `gofmt` normalises these to single-tab separation. No logic change.

This re-lands the formatting fix from the earlier direct push to `main` (`79b17b1`) through the proper PR flow.