### PR TITLE
fix(downloader): apply url_base to download-client base URL (#369)

### DIFF
--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -47,19 +47,19 @@ func ProtocolForClient(clientType string) string {
 func TestClient(ctx context.Context, client *models.DownloadClient) error {
 	switch client.Type {
 	case "transmission":
-		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		return trans.Test(ctx)
 	case "qbittorrent":
-		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		return qb.Test(ctx)
 	case "deluge":
-		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		dl := deluge.New(client.Host, client.Port, client.Password, client.URLBase, client.UseSSL)
 		return dl.Test(ctx)
 	case "nzbget":
-		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		return ng.Test(ctx)
 	default:
-		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.URLBase, client.UseSSL)
 		return sab.Test(ctx)
 	}
 }
@@ -72,7 +72,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 
 	switch client.Type {
 	case "transmission":
-		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		// Transmission's download-dir must be an absolute path. The Category
 		// field is repurposed as an optional path override for Transmission; if
 		// the user left it as a bare label (e.g. "books") we pass "" so
@@ -91,7 +91,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		result.RemoteID = strconv.FormatInt(torrentID, 10)
 		return result, nil
 	case "qbittorrent":
-		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		hash, err := qb.AddTorrent(ctx, sourceURL, client.Category, "")
 		if err != nil {
 			return nil, err
@@ -103,7 +103,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		result.RemoteID = hash
 		return result, nil
 	case "deluge":
-		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		dl := deluge.New(client.Host, client.Port, client.Password, client.URLBase, client.UseSSL)
 		hash, err := dl.AddTorrent(ctx, sourceURL, client.Category)
 		if err != nil {
 			return nil, err
@@ -114,7 +114,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		result.RemoteID = hash
 		return result, nil
 	case "nzbget":
-		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		nzbID, err := ng.Add(ctx, sourceURL, title, client.Category, 0)
 		if err != nil {
 			return nil, err
@@ -122,7 +122,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		result.RemoteID = strconv.Itoa(nzbID)
 		return result, nil
 	default:
-		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.URLBase, client.UseSSL)
 		resp, err := sab.AddURL(ctx, sourceURL, title, client.Category, 0)
 		if err != nil {
 			return nil, err
@@ -144,19 +144,19 @@ func RemoveDownload(ctx context.Context, client *models.DownloadClient, dl *mode
 		if err != nil {
 			return fmt.Errorf("invalid transmission torrent id %q: %w", *dl.TorrentID, err)
 		}
-		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		return trans.RemoveTorrent(ctx, torrentID, deleteFiles)
 	case "qbittorrent":
 		if dl.TorrentID == nil || *dl.TorrentID == "" {
 			return nil
 		}
-		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		return qb.DeleteTorrent(ctx, *dl.TorrentID, deleteFiles)
 	case "deluge":
 		if dl.TorrentID == nil || *dl.TorrentID == "" {
 			return nil
 		}
-		delugeClient := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		delugeClient := deluge.New(client.Host, client.Port, client.Password, client.URLBase, client.UseSSL)
 		return delugeClient.RemoveTorrent(ctx, *dl.TorrentID, deleteFiles)
 	case "nzbget":
 		if dl.SABnzbdNzoID == nil || *dl.SABnzbdNzoID == "" {
@@ -166,13 +166,13 @@ func RemoveDownload(ctx context.Context, client *models.DownloadClient, dl *mode
 		if err != nil {
 			return err
 		}
-		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		return ng.Remove(ctx, nzbID)
 	default:
 		if dl.SABnzbdNzoID == nil || *dl.SABnzbdNzoID == "" {
 			return nil
 		}
-		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.URLBase, client.UseSSL)
 		return sab.Delete(ctx, *dl.SABnzbdNzoID, deleteFiles)
 	}
 }
@@ -189,7 +189,7 @@ func RemoveDownload(ctx context.Context, client *models.DownloadClient, dl *mode
 func GetStalledIDs(ctx context.Context, client *models.DownloadClient) (map[string]bool, bool, error) {
 	switch client.Type {
 	case "qbittorrent":
-		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		torrents, err := qb.GetTorrents(ctx, client.Category)
 		if err != nil {
 			return nil, true, err
@@ -203,7 +203,7 @@ func GetStalledIDs(ctx context.Context, client *models.DownloadClient) (map[stri
 		}
 		return out, true, nil
 	case "transmission":
-		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		torrents, err := trans.GetTorrents(ctx, client.Category)
 		if err != nil {
 			return nil, true, err
@@ -217,7 +217,7 @@ func GetStalledIDs(ctx context.Context, client *models.DownloadClient) (map[stri
 		}
 		return out, true, nil
 	case "deluge":
-		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		dl := deluge.New(client.Host, client.Port, client.Password, client.URLBase, client.UseSSL)
 		torrents, err := dl.GetTorrents(ctx)
 		if err != nil {
 			return nil, true, err
@@ -248,7 +248,7 @@ func GetLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[st
 }
 
 func getSABLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[string]LiveStatus, error) {
-	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.URLBase, client.UseSSL)
 	queue, err := sab.GetQueue(ctx)
 	if err != nil {
 		return nil, err
@@ -266,7 +266,7 @@ func getSABLiveStatuses(ctx context.Context, client *models.DownloadClient) (map
 }
 
 func getNZBGetLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[string]LiveStatus, error) {
-	ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 	groups, err := ng.GetQueue(ctx)
 	if err != nil {
 		return nil, err
@@ -289,7 +289,7 @@ func getNZBGetLiveStatuses(ctx context.Context, client *models.DownloadClient) (
 
 func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[string]LiveStatus, error) {
 	if client.Type == "transmission" {
-		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		torrents, err := trans.GetTorrents(ctx, client.Category)
 		if err != nil {
 			return nil, err
@@ -308,7 +308,7 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 	}
 
 	if client.Type == "deluge" {
-		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		dl := deluge.New(client.Host, client.Port, client.Password, client.URLBase, client.UseSSL)
 		torrents, err := dl.GetTorrents(ctx)
 		if err != nil {
 			return nil, err
@@ -324,7 +324,7 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 		return out, nil
 	}
 
-	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 	torrents, err := qb.GetTorrents(ctx, client.Category)
 	if err != nil {
 		return nil, err

--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/vavallee/bindery/internal/downloader/urlbase"
 )
 
 // hashPollTimeout is the maximum time to wait for a newly-added torrent's hash
@@ -54,15 +56,16 @@ type rpcError struct {
 	Message string `json:"message"`
 }
 
-// New creates a Deluge client.
-func New(host string, port int, password string, useSSL bool) *Client {
+// New creates a Deluge client. urlBase is the optional reverse-proxy
+// subpath that is appended between host:port and the json endpoint.
+func New(host string, port int, password, urlBase string, useSSL bool) *Client {
 	scheme := "http"
 	if useSSL {
 		scheme = "https"
 	}
 	jar, _ := cookiejar.New(nil)
 	return &Client{
-		baseURL:  fmt.Sprintf("%s://%s:%d", scheme, host, port),
+		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
 		password: password,
 		http:     &http.Client{Timeout: 15 * time.Second, Jar: jar},
 	}

--- a/internal/downloader/deluge/client_test.go
+++ b/internal/downloader/deluge/client_test.go
@@ -164,7 +164,7 @@ func clientFromServer(srv *httptest.Server, password string) *deluge.Client {
 		}
 		port = p
 	}
-	return deluge.New(parts[0], port, password, false)
+	return deluge.New(parts[0], port, password, "", false)
 }
 
 func TestLogin_Success(t *testing.T) {

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/vavallee/bindery/internal/downloader/urlbase"
 )
 
 // Client interacts with the NZBGet JSON-RPC API.
@@ -22,15 +24,16 @@ type Client struct {
 	password string
 }
 
-// New creates a NZBGet client.
-// NZBGet's JSON-RPC endpoint is http://user:pass@host:port/jsonrpc.
-func New(host string, port int, username, password string, useSSL bool) *Client {
+// New creates a NZBGet client. urlBase is the optional reverse-proxy
+// subpath that is appended before NZBGet's /jsonrpc endpoint.
+// NZBGet's JSON-RPC endpoint is http://user:pass@host:port[/url_base]/jsonrpc.
+func New(host string, port int, username, password, urlBase string, useSSL bool) *Client {
 	scheme := "http"
 	if useSSL {
 		scheme = "https"
 	}
 	return &Client{
-		baseURL:  fmt.Sprintf("%s://%s:%d/jsonrpc", scheme, host, port),
+		baseURL:  fmt.Sprintf("%s://%s:%d%s/jsonrpc", scheme, host, port, urlbase.Normalize(urlBase)),
 		username: username,
 		password: password,
 		http:     &http.Client{Timeout: 15 * time.Second},

--- a/internal/downloader/nzbget/client_test.go
+++ b/internal/downloader/nzbget/client_test.go
@@ -47,7 +47,7 @@ func TestTest_Success(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "user", "pass", false)
+	c := New(host, port, "user", "pass", "", false)
 
 	if err := c.Test(context.Background()); err != nil {
 		t.Fatalf("Test should pass: %v", err)
@@ -62,7 +62,7 @@ func TestTest_AuthFailure(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "bad", "creds", false)
+	c := New(host, port, "bad", "creds", "", false)
 
 	err := c.Test(context.Background())
 	if err == nil {
@@ -79,7 +79,7 @@ func TestTest_EmptyVersion(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", "", false)
 
 	err := c.Test(context.Background())
 	if err == nil {
@@ -97,7 +97,7 @@ func TestAdd(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "user", "pass", false)
+	c := New(host, port, "user", "pass", "", false)
 
 	id, err := c.Add(context.Background(), "https://example.com/file.nzb", "Test Book", "books", 0)
 	if err != nil {
@@ -119,7 +119,7 @@ func TestAdd_Rejected(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", "", false)
 
 	_, err := c.Add(context.Background(), "https://example.com/bad.nzb", "Bad NZB", "books", 0)
 	if err == nil {
@@ -151,7 +151,7 @@ func TestGetQueue(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", "", false)
 
 	groups, err := c.GetQueue(context.Background())
 	if err != nil {
@@ -200,7 +200,7 @@ func TestGetHistory(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", "", false)
 
 	items, err := c.GetHistory(context.Background())
 	if err != nil {
@@ -227,7 +227,7 @@ func TestRemove(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", "", false)
 
 	if err := c.Remove(context.Background(), 101); err != nil {
 		t.Fatalf("Remove: %v", err)
@@ -254,7 +254,7 @@ func TestRemoveHistory(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", "", false)
 
 	if err := c.RemoveHistory(context.Background(), 202); err != nil {
 		t.Fatalf("RemoveHistory: %v", err)
@@ -324,7 +324,7 @@ func TestBasicAuth(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "admin", "secret", false)
+	c := New(host, port, "admin", "secret", "", false)
 
 	if err := c.Test(context.Background()); err != nil {
 		t.Fatalf("Test: %v", err)

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/vavallee/bindery/internal/downloader/urlbase"
 )
 
 // hashPollTimeout is the maximum time to wait for a newly-added torrent's hash
@@ -27,7 +29,7 @@ var hashPollTimeout = 30 * time.Second
 //
 // Field mapping for DownloadClient storage:
 //   - APIKey  → password  (qBittorrent uses username/password, not an API key)
-//   - URLBase → username  (reused since qBittorrent ignores URL base)
+//   - URLBase → reverse-proxy subpath, appended to baseURL (#369)
 type Client struct {
 	baseURL  string
 	username string
@@ -37,10 +39,10 @@ type Client struct {
 	loggedIn bool
 }
 
-// New creates a qBittorrent client.
-// username and password map to the DownloadClient's URLBase and APIKey fields
-// respectively (see comment on the Client struct).
-func New(host string, port int, username, password string, useSSL bool) *Client {
+// New creates a qBittorrent client. urlBase is the optional reverse-proxy
+// subpath (e.g. "/qbit") that will be appended between the host:port and
+// the standard /api/v2 endpoints; leave it empty for a direct connection.
+func New(host string, port int, username, password, urlBase string, useSSL bool) *Client {
 	scheme := "http"
 	if useSSL {
 		scheme = "https"
@@ -48,7 +50,7 @@ func New(host string, port int, username, password string, useSSL bool) *Client 
 
 	jar, _ := cookiejar.New(nil)
 	return &Client{
-		baseURL:  fmt.Sprintf("%s://%s:%d", scheme, host, port),
+		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
 		username: username,
 		password: password,
 		http:     &http.Client{Timeout: 15 * time.Second, Jar: jar},

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -36,13 +36,13 @@ func (lc *logCatcher) Records() []slog.Record {
 
 // newTestClient creates a Client pointing at the given test server URL.
 func newTestClient(serverURL, username, password string) *Client {
-	c := New("localhost", 8080, username, password, false)
+	c := New("localhost", 8080, username, password, "", false)
 	c.baseURL = serverURL
 	return c
 }
 
 func TestNew(t *testing.T) {
-	c := New("myhost", 8080, "admin", "secret", false)
+	c := New("myhost", 8080, "admin", "secret", "", false)
 	if c.baseURL != "http://myhost:8080" {
 		t.Errorf("baseURL: want %q, got %q", "http://myhost:8080", c.baseURL)
 	}
@@ -53,7 +53,7 @@ func TestNew(t *testing.T) {
 		t.Error("should not be logged in on construction")
 	}
 
-	cs := New("securehost", 443, "u", "p", true)
+	cs := New("securehost", 443, "u", "p", "", true)
 	if cs.baseURL != "https://securehost:443" {
 		t.Errorf("SSL baseURL: got %q", cs.baseURL)
 	}

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/vavallee/bindery/internal/downloader/urlbase"
 )
 
 // Client interacts with the SABnzbd API.
@@ -19,14 +21,15 @@ type Client struct {
 	http    *http.Client
 }
 
-// New creates a SABnzbd client.
-func New(host string, port int, apiKey string, useSSL bool) *Client {
+// New creates a SABnzbd client. urlBase is the optional reverse-proxy
+// subpath that is appended between host:port and the /api endpoint.
+func New(host string, port int, apiKey, urlBase string, useSSL bool) *Client {
 	scheme := "http"
 	if useSSL {
 		scheme = "https"
 	}
 	return &Client{
-		baseURL: fmt.Sprintf("%s://%s:%d", scheme, host, port),
+		baseURL: fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
 		apiKey:  apiKey,
 		http:    &http.Client{Timeout: 15 * time.Second},
 	}

--- a/internal/downloader/sabnzbd/client_test.go
+++ b/internal/downloader/sabnzbd/client_test.go
@@ -23,7 +23,7 @@ func TestAddURL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", "", false)
 	c.baseURL = srv.URL
 
 	resp, err := c.AddURL(context.Background(), "https://example.com/nzb/123", "Test Book", "books", 0)
@@ -61,7 +61,7 @@ func TestGetQueue(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", "", false)
 	c.baseURL = srv.URL
 
 	queue, err := c.GetQueue(context.Background())
@@ -99,7 +99,7 @@ func TestGetHistory(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", "", false)
 	c.baseURL = srv.URL
 
 	history, err := c.GetHistory(context.Background(), "books", 20)
@@ -122,7 +122,7 @@ func TestGetCategories(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", "", false)
 	c.baseURL = srv.URL
 
 	cats, err := c.GetCategories(context.Background())
@@ -146,7 +146,7 @@ func TestDeleteHistory(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", "", false)
 	c.baseURL = srv.URL
 
 	if err := c.DeleteHistory(context.Background(), "SABnzbd_nzo_def456", false); err != nil {
@@ -175,7 +175,7 @@ func TestTest(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", "", false)
 	c.baseURL = srv.URL
 
 	err := c.Test(context.Background())

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/vavallee/bindery/internal/downloader/urlbase"
 )
 
 // Client interacts with the Transmission RPC API.
@@ -33,7 +35,9 @@ type Client struct {
 
 // New creates a Transmission client.
 // username and password are optional for Transmission RPC authentication.
-func New(host string, port int, username, password string, useSSL bool) *Client {
+// urlBase is the optional reverse-proxy subpath appended before Transmission's
+// /transmission/rpc endpoint.
+func New(host string, port int, username, password, urlBase string, useSSL bool) *Client {
 	scheme := "http"
 	if useSSL {
 		scheme = "https"
@@ -45,7 +49,7 @@ func New(host string, port int, username, password string, useSSL bool) *Client 
 		http:     &http.Client{Timeout: 15 * time.Second},
 	}
 
-	rpcURL, err := buildRPCURL(scheme, host, port)
+	rpcURL, err := buildRPCURL(scheme, host, port, urlBase)
 	if err != nil {
 		client.initErr = err
 	} else {
@@ -206,7 +210,7 @@ func (c *Client) buildRequest(ctx context.Context, method string, args map[strin
 	return req, nil
 }
 
-func buildRPCURL(scheme, host string, port int) (*url.URL, error) {
+func buildRPCURL(scheme, host string, port int, urlBase string) (*url.URL, error) {
 	if err := validateHost(host); err != nil {
 		return nil, err
 	}
@@ -217,7 +221,7 @@ func buildRPCURL(scheme, host string, port int) (*url.URL, error) {
 	return &url.URL{
 		Scheme: scheme,
 		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
-		Path:   "/transmission/rpc",
+		Path:   urlbase.Normalize(urlBase) + "/transmission/rpc",
 	}, nil
 }
 

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -10,7 +10,7 @@ import (
 
 // newTestClient creates a Client pointing at the given test server URL.
 func newTestClient(serverURL, username, password string) *Client {
-	c := New("localhost", 9091, username, password, false)
+	c := New("localhost", 9091, username, password, "", false)
 	c.baseURL = serverURL
 	parsed, err := url.Parse(serverURL)
 	if err != nil {
@@ -21,7 +21,7 @@ func newTestClient(serverURL, username, password string) *Client {
 }
 
 func TestNew(t *testing.T) {
-	c := New("myhost", 9091, "admin", "secret", false)
+	c := New("myhost", 9091, "admin", "secret", "", false)
 	if c.baseURL != "http://myhost:9091/transmission/rpc" {
 		t.Errorf("baseURL: want %q, got %q", "http://myhost:9091/transmission/rpc", c.baseURL)
 	}
@@ -32,14 +32,14 @@ func TestNew(t *testing.T) {
 		t.Error("credentials not stored correctly")
 	}
 
-	cs := New("securehost", 443, "u", "p", true)
+	cs := New("securehost", 443, "u", "p", "", true)
 	if cs.baseURL != "https://securehost:443/transmission/rpc" {
 		t.Errorf("SSL baseURL: got %q", cs.baseURL)
 	}
 }
 
 func TestNew_InvalidHost(t *testing.T) {
-	c := New("http://bad-host", 9091, "admin", "secret", false)
+	c := New("http://bad-host", 9091, "admin", "secret", "", false)
 	if c.initErr == nil {
 		t.Fatal("expected invalid host to be rejected")
 	}

--- a/internal/downloader/urlbase/urlbase.go
+++ b/internal/downloader/urlbase/urlbase.go
@@ -1,0 +1,37 @@
+package urlbase
+
+import "strings"
+
+// Normalize returns a URL-base prefix guaranteed to be either empty or
+// a single-leading-slash, no-trailing-slash string that can be appended
+// to a "scheme://host:port" base URL.
+//
+// The normalization handles the forms operators commonly type into the
+// DownloadClient form — "qbit", "/qbit", "/qbit/", "https://.../qbit"
+// (from which only the path is retained) — and collapses empty and
+// whitespace-only values to the empty string, preserving the pre-#369
+// behaviour when url_base is unset.
+func Normalize(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	// Drop an accidental scheme://host prefix: some users paste the full
+	// reverse-proxy URL and expect only the path segment to survive.
+	if i := strings.Index(s, "://"); i >= 0 {
+		rest := s[i+3:]
+		if j := strings.Index(rest, "/"); j >= 0 {
+			s = rest[j:]
+		} else {
+			s = ""
+		}
+	}
+	s = strings.TrimRight(s, "/")
+	if s == "" {
+		return ""
+	}
+	if !strings.HasPrefix(s, "/") {
+		s = "/" + s
+	}
+	return s
+}

--- a/internal/downloader/urlbase/urlbase_test.go
+++ b/internal/downloader/urlbase/urlbase_test.go
@@ -1,0 +1,32 @@
+package urlbase
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"/", ""},
+		{"//", ""},
+		{"qbit", "/qbit"},
+		{"/qbit", "/qbit"},
+		{"/qbit/", "/qbit"},
+		{"qbit/", "/qbit"},
+		{"  /qbit  ", "/qbit"},
+		{"/nested/path", "/nested/path"},
+		{"nested/path/", "/nested/path"},
+		// Paste-a-full-URL form: keep only the path component.
+		{"https://proxy.example.com/qbit", "/qbit"},
+		{"http://h.example:8080/abc/", "/abc"},
+		{"https://host.only/", ""},
+		{"https://host.only", ""},
+	}
+	for _, c := range cases {
+		if got := Normalize(c.in); got != c.want {
+			t.Errorf("Normalize(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -258,7 +258,7 @@ func (s *Scanner) markDownloadFailed(ctx context.Context, dl *models.Download, m
 
 // checkSABnzbdDownloads polls SABnzbd for status changes.
 func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.DownloadClient) {
-	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.URLBase, client.UseSSL)
 
 	// Check history for completed downloads (no category filter — match by NZO ID)
 	history, err := sab.GetHistory(ctx, "", 50)
@@ -296,7 +296,7 @@ func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.Down
 
 // checkNZBGetDownloads polls NZBGet for status changes using its JSON-RPC API.
 func (s *Scanner) checkNZBGetDownloads(ctx context.Context, client *models.DownloadClient) {
-	ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 
 	// Check history for completed/failed downloads (matched by NZBID stored as sabnzbd_nzo_id).
 	history, err := ng.GetHistory(ctx)
@@ -344,7 +344,7 @@ func (s *Scanner) tryImportNZBGet(ctx context.Context, ng *nzbget.Client, dl *mo
 
 // checkTransmissionDownloads polls Transmission for status changes.
 func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models.DownloadClient) {
-	trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 
 	// Get all torrents — Category is used as the download directory filter so
 	// Bindery only sees its own torrents on a shared Transmission instance.
@@ -398,7 +398,7 @@ func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models
 
 // checkQbittorrentDownloads polls qBittorrent for status changes.
 func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.DownloadClient) {
-	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 
 	torrents, err := qb.GetTorrents(ctx, client.Category)
 	if err != nil {


### PR DESCRIPTION
## Summary

Every downloader client (qbittorrent, transmission, deluge, nzbget, sabnzbd) built its connection URL from `host:port` only. The `url_base` column is read from the DB into `DownloadClient.URLBase` but never interpolated into the URL, so operators running an *arr-compatible client behind a reverse-proxy subpath (e.g. Host `192.168.1.10:8080`, URL Base `/qbit`) saw Bindery connect to `http://192.168.1.10:8080/api/...` instead of `http://192.168.1.10:8080/qbit/api/...`.

## Fix

- New `internal/downloader/urlbase` helper that normalises user input: trims whitespace, enforces a single leading slash, strips trailing slashes, and tolerates a pasted full URL by keeping only the path segment.
- Thread a `urlBase` parameter through each client's `New` constructor and apply the normalised prefix to `baseURL` / Transmission's RPC `Path`.
- Update every call site in `internal/downloader/adapter.go` and `internal/importer/scanner.go` to pass `client.URLBase`.
- Update all in-package test helpers so the signature changes stay compile-clean.
- Empty / whitespace `url_base` collapses to `""`, preserving the pre-#369 URL shape for deployments without a proxy.

Fixes #369

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full suite green, including the existing per-client tests (deluge / nzbget / qbittorrent / sabnzbd / transmission) and the new `internal/downloader/urlbase` table-test
- [x] Manually traced each `New` call site in `adapter.go` and `scanner.go` to confirm `client.URLBase` is wired in