### PR TITLE
fix(logs): json tags on db.LogEntry so logs tab renders

### DIFF
--- a/internal/db/logs.go
+++ b/internal/db/logs.go
@@ -12,12 +12,12 @@ import (
 
 // LogEntry is a single persisted log record.
 type LogEntry struct {
-	ID        int64
-	TS        time.Time
-	Level     string
-	Component string
-	Message   string
-	Fields    map[string]string
+	ID        int64             `json:"id"`
+	TS        time.Time         `json:"ts"`
+	Level     string            `json:"level"`
+	Component string            `json:"component"`
+	Message   string            `json:"message"`
+	Fields    map[string]string `json:"fields"`
 }
 
 // LogFilter controls which rows are returned by LogRepo.Query.


### PR DESCRIPTION
## Problem

Clicking the logs icon (Settings → Logs tab) showed a blank screen despite the API returning data.

## Root cause

`db.LogEntry` had no `json:""` tags, so Go serialized field names as PascalCase (`ID`, `TS`, `Level`, `Component`, `Message`, `Fields`). The TypeScript interface expected camelCase (`id`, `ts`, `level`, `component`, `message`, `fields`). Every field access in the render loop came back `undefined`, so rows were empty.

The ring-buffer shape (`logbuf.Entry`) already had correct tags — only the DB-backed path was broken.

## Fix

Six `json:""` tags on `db.LogEntry`. Tests unchanged — they round-trip through Go structs so the decoder's case-insensitivity masked the issue in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)