### PR TITLE
chore(deploy): bump image tag to 1.2.3

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.2.2"
+  tag: "1.2.3"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Tracks v1.2.3 release — logs tab fix (#376).