### PR TITLE
fix(books): exclude unmonitored books from Wanted filter (#382)

### DIFF
--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -50,7 +50,7 @@ export default function BooksPage() {
 
   const filtered = useMemo(() => {
     let list = books
-    if (statusFilter) list = list.filter(b => b.status === statusFilter)
+    if (statusFilter) list = list.filter(b => b.status === statusFilter && (statusFilter !== 'wanted' || b.monitored))
     if (mediaFilter) {
       list = list.filter(b => {
         const mt = b.mediaType || 'ebook'


### PR DESCRIPTION
## Summary

- Books synced from an unmonitored author get `status='wanted'` but `monitored=false`
- The Books page client-side filter was checking only `b.status === 'wanted'`, so these books appeared in the Wanted view
- The `/wanted` page already filters by `monitored=1` server-side; this aligns the Books page to match

**One-line change**: `BooksPage.tsx` line 53 now also requires `b.monitored` when `statusFilter === 'wanted'`

Fixes #382

## Test plan

- [ ] Add an author with Monitored = off, let OL sync add books → those books do not appear in Books → Wanted
- [ ] Add an author with Monitored = on → wanted books still appear as expected
- [ ] Switching to any other status filter (e.g. "downloaded", "failed") is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)