### PR TITLE
fix(importer): add per-import timeout to prevent NFS copy stalls (#381)

### DIFF
--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -1,6 +1,7 @@
 package importer
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -349,7 +350,12 @@ func copyFileRooted(srcRoot, dstRoot *os.Root, rel string) error {
 	return out.Sync()
 }
 
-func copyFile(src, dst string) error {
+// copyFileCtx copies src to dst, returning ctx.Err() if the context is
+// cancelled before the copy completes. Closing the file descriptors on
+// cancellation encourages the blocking io.Copy goroutine to unblock on
+// Linux (including NFS); if it does not, the goroutine exits when the
+// process eventually closes those fds. Any partial dst is removed.
+func copyFileCtx(ctx context.Context, src, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {
 		return err
@@ -362,10 +368,98 @@ func copyFile(src, dst string) error {
 	}
 	defer out.Close()
 
-	if _, err := io.Copy(out, in); err != nil {
-		return err
+	type result struct{ err error }
+	ch := make(chan result, 1)
+	go func() {
+		_, copyErr := io.Copy(out, in)
+		if copyErr == nil {
+			copyErr = out.Sync()
+		}
+		ch <- result{copyErr}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			_ = os.Remove(dst)
+		}
+		return r.err
+	case <-ctx.Done():
+		_ = in.Close()
+		_ = out.Close()
+		_ = os.Remove(dst)
+		return ctx.Err()
 	}
-	return out.Sync()
+}
+
+func copyFile(src, dst string) error {
+	return copyFileCtx(context.Background(), src, dst)
+}
+
+// MoveFileCtx is like MoveFile but returns ctx.Err() if the context is
+// cancelled during the cross-filesystem copy phase.
+func MoveFileCtx(ctx context.Context, src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+
+	if err := copyFileCtx(ctx, src, dst); err != nil {
+		return fmt.Errorf("copy file: %w", err)
+	}
+
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		return fmt.Errorf("stat destination: %w", err)
+	}
+	if srcInfo.Size() != dstInfo.Size() {
+		_ = os.Remove(dst)
+		return fmt.Errorf("size mismatch: src=%d dst=%d", srcInfo.Size(), dstInfo.Size())
+	}
+
+	return os.Remove(src)
+}
+
+// CopyFileCtx is like CopyFile but returns ctx.Err() if the context is
+// cancelled during the copy.
+func CopyFileCtx(ctx context.Context, src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	return copyFileCtx(ctx, src, dst)
+}
+
+// MoveDirCtx is like MoveDir but returns ctx.Err() if the context is
+// cancelled. The background goroutine may still be running on NFS after
+// cancellation but will complete or be cleaned up on process restart.
+func MoveDirCtx(ctx context.Context, src, dst string) error {
+	ch := make(chan error, 1)
+	go func() { ch <- MoveDir(src, dst) }()
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// CopyDirCtx is like CopyDir but returns ctx.Err() if the context is cancelled.
+func CopyDirCtx(ctx context.Context, src, dst string) error {
+	ch := make(chan error, 1)
+	go func() { ch <- CopyDir(src, dst) }()
+	select {
+	case err := <-ch:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func sanitizePath(s string) string {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -519,6 +519,12 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 
 	s.updateDownloadStatus(ctx, dl.ID, models.StateImporting)
 
+	// Per-import timeout so a stalled NFS copy does not hold the download in
+	// StateImporting indefinitely. 30 minutes is generous for any realistic
+	// book file; the context-aware file operations return promptly when it fires.
+	importCtx, importCancel := context.WithTimeout(ctx, 30*time.Minute)
+	defer importCancel()
+
 	// Resolve the book and author for naming. Lookup errors are not fatal -
 	// we fall through to the "unmatched import" log below.
 	var book *models.Book
@@ -575,9 +581,9 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			case "hardlink":
 				dirErr = HardlinkDir(downloadPath, destDir)
 			case "copy":
-				dirErr = CopyDir(downloadPath, destDir)
+				dirErr = CopyDirCtx(importCtx, downloadPath, destDir)
 			default:
-				dirErr = MoveDir(downloadPath, destDir)
+				dirErr = MoveDirCtx(importCtx, downloadPath, destDir)
 			}
 		} else {
 			if err := os.MkdirAll(destDir, 0o750); err != nil {
@@ -588,9 +594,9 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 				case "hardlink":
 					dirErr = HardlinkFile(downloadPath, dstFile)
 				case "copy":
-					dirErr = CopyFile(downloadPath, dstFile)
+					dirErr = CopyFileCtx(importCtx, downloadPath, dstFile)
 				default:
-					dirErr = MoveFile(downloadPath, dstFile)
+					dirErr = MoveFileCtx(importCtx, downloadPath, dstFile)
 				}
 			}
 		}
@@ -648,9 +654,9 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		case "hardlink":
 			fileErr = HardlinkFile(srcFile, destPath)
 		case "copy":
-			fileErr = CopyFile(srcFile, destPath)
+			fileErr = CopyFileCtx(importCtx, srcFile, destPath)
 		default:
-			fileErr = MoveFile(srcFile, destPath)
+			fileErr = MoveFileCtx(importCtx, srcFile, destPath)
 		}
 		if fileErr != nil {
 			slog.Error("failed to import", "src", srcFile, "mode", mode, "error", fileErr)


### PR DESCRIPTION
## Summary

- `io.Copy` in `copyFile` (used by `MoveFile`/`CopyFile`) has no timeout, so an NFS stall holds the download in `StateImporting` indefinitely
- Adds `copyFileCtx(ctx, src, dst)` that runs the copy in a goroutine and returns `ctx.Err()` promptly on cancellation; closes file descriptors to encourage the blocked goroutine to unblock on Linux NFS
- Adds public `MoveFileCtx`, `CopyFileCtx`, `MoveDirCtx`, `CopyDirCtx` context-aware variants (existing signatures unchanged for backwards compat)
- In `tryImportInternal`, wraps all file operations in a `30-minute context.WithTimeout` so no NFS stall can hold a download in `StateImporting` past the deadline — it will transition to `StateImportBlocked` with a clear error

Fixes #381

## Test plan

- [ ] Existing importer tests pass (`go test ./internal/importer/...`)
- [ ] Normal import (same filesystem) still uses `os.Rename` fast path — unaffected
- [ ] NFS stall scenario: download stuck in StateImporting eventually transitions to StateImportBlocked after 30 min with "context deadline exceeded" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)