### PR TITLE
fix(indexer): match non-latin author names via latin-script aliases (#380)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -248,6 +248,7 @@ func main() {
 	sched := scheduler.New(importScanner, idxSearcher, metaAgg,
 		authorRepo, bookRepo, indexerRepo, downloadRepo, dlClientRepo, settingsRepo, blocklistRepo)
 	sched.WithHistory(historyRepo)
+	sched.WithAliases(authorAliasRepo)
 	sched.WithDelayProfiles(delayProfileRepo)
 	sched.WithPendingReleases(pendingReleaseRepo)
 	// Register the Calibre importer as the 24-hour sync job. The scheduler
@@ -292,7 +293,7 @@ func main() {
 	authorHandler := api.NewAuthorHandler(authorRepo, authorAliasRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched).WithFinder(importScanner)
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
 	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).WithSettings(settingsRepo).WithDownloads(downloadRepo)
-	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, metadataProfileRepo, idxSearcher, settingsRepo, blocklistRepo)
+	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, metadataProfileRepo, idxSearcher, settingsRepo, blocklistRepo).WithAliases(authorAliasRepo)
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)
 	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo).WithNotifier(notif)
 	pendingHandler := api.NewPendingHandler(pendingReleaseRepo, queueHandler, downloadRepo, bookRepo)

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -178,6 +178,11 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Persist any OL alternate names as alias rows so non-latin primary names
+	// (e.g. "村上春樹") get their latin-script alternates ("Haruki Murakami")
+	// indexed for release-name matching.
+	h.saveAlternateNames(r.Context(), author)
+
 	// Resolve effective media type for books created under this author:
 	// explicit request value wins, else the global default.media_type
 	// setting, else ebook (backwards compat).
@@ -654,6 +659,35 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusCreated, book)
+}
+
+// saveAlternateNames persists any latin-script OL alternate names from
+// author.AlternateNames into the author_aliases table. This lets non-latin
+// primary names (e.g. "村上春樹") be matched against latin-script release
+// names (e.g. "Murakami") during indexer searches.
+func (h *AuthorHandler) saveAlternateNames(ctx context.Context, author *models.Author) {
+	if h.aliases == nil || len(author.AlternateNames) == 0 {
+		return
+	}
+	for _, name := range author.AlternateNames {
+		if !isAllASCII(name) {
+			continue
+		}
+		alias := &models.AuthorAlias{AuthorID: author.ID, Name: name}
+		if err := h.aliases.Create(ctx, alias); err != nil {
+			slog.Debug("saveAlternateNames: could not save alias", "name", name, "authorId", author.ID, "error", err)
+		}
+	}
+}
+
+// isAllASCII returns true when every byte of s is a 7-bit ASCII character.
+func isAllASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] > 127 {
+			return false
+		}
+	}
+	return true
 }
 
 func (h *AuthorHandler) resolveAllowedLanguages(ctx context.Context, author *models.Author) ([]string, bool) {

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -47,6 +47,7 @@ type IndexerHandler struct {
 	indexers  *db.IndexerRepo
 	books     *db.BookRepo
 	authors   *db.AuthorRepo
+	aliases   *db.AuthorAliasRepo
 	profiles  *db.MetadataProfileRepo
 	searcher  indexerSearcher
 	settings  *db.SettingsRepo
@@ -60,6 +61,12 @@ func NewIndexerHandler(indexers *db.IndexerRepo, books *db.BookRepo, authors *db
 		searcher: searcher, settings: settings, blocklist: blocklist,
 		lastDebug: &lastDebugStore{},
 	}
+}
+
+// WithAliases attaches the author alias repo used to populate AuthorAliases in MatchCriteria.
+func (h *IndexerHandler) WithAliases(aliases *db.AuthorAliasRepo) *IndexerHandler {
+	h.aliases = aliases
+	return h
 }
 
 func (h *IndexerHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -233,12 +240,20 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve author name and metadata profile for better search results.
+	// Resolve author name, metadata profile and aliases for better search results.
 	authorName := ""
 	var allowedLangs []string
+	var authorAliases []string
 	if author, err := h.authors.GetByID(r.Context(), book.AuthorID); err == nil && author != nil {
 		authorName = author.Name
 		allowedLangs = h.resolveAllowedLanguages(r.Context(), author)
+		if h.aliases != nil {
+			if aliases, err := h.aliases.ListByAuthor(r.Context(), author.ID); err == nil {
+				for _, a := range aliases {
+					authorAliases = append(authorAliases, a.Name)
+				}
+			}
+		}
 	}
 
 	crit := indexer.MatchCriteria{
@@ -247,6 +262,7 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 		MediaType:        book.MediaType,
 		ASIN:             book.ASIN,
 		AllowedLanguages: allowedLangs,
+		AuthorAliases:    authorAliases,
 	}
 	if book.ReleaseDate != nil {
 		crit.Year = book.ReleaseDate.Year()

--- a/internal/indexer/debug.go
+++ b/internal/indexer/debug.go
@@ -157,7 +157,7 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 	dbg.Filters = append(dbg.Filters, junkFilters...)
 	dbg.Pipeline.AfterUsenetJunk = len(results)
 
-	results, relFilters := filterRelevantDebug(results, c.Title, c.Author)
+	results, relFilters := filterRelevantDebug(results, c.Title, c.Author, c.AuthorAliases)
 	dbg.Filters = append(dbg.Filters, relFilters...)
 	dbg.Pipeline.AfterRelevance = len(results)
 
@@ -189,11 +189,29 @@ func filterUsenetJunkDebug(results []newznab.SearchResult) ([]newznab.SearchResu
 
 // filterRelevantDebug is filterRelevant instrumented to record each drop with
 // the keyword set that failed to match.
-func filterRelevantDebug(results []newznab.SearchResult, title, author string) ([]newznab.SearchResult, []FilterDebug) {
+func filterRelevantDebug(results []newznab.SearchResult, title, author string, aliases []string) ([]newznab.SearchResult, []FilterDebug) {
 	fullKws := sigWords(title)
 	primaryKws := sigWords(primaryTitle(title))
 	authorKws := sigWords(author)
 	surname := AuthorSurname(author)
+
+	surnames := []string{surname}
+	if !isAllASCIILower(surname) {
+		for _, alias := range aliases {
+			if s := AuthorSurname(alias); s != "" && isAllASCIILower(s) {
+				surnames = append(surnames, s)
+			}
+		}
+	}
+
+	tryMatch := func(n string, kws []string) bool {
+		for _, sn := range surnames {
+			if titleMatchesResult(n, kws, sn, true) {
+				return true
+			}
+		}
+		return false
+	}
 
 	if len(fullKws) == 0 && len(primaryKws) == 0 && len(authorKws) == 0 {
 		return results, nil
@@ -208,10 +226,10 @@ func filterRelevantDebug(results []newznab.SearchResult, title, author string) (
 	var dropped []FilterDebug
 	for i, r := range results {
 		n := normTitles[i]
-		fullOK := titleMatchesResult(n, fullKws, surname, true)
+		fullOK := tryMatch(n, fullKws)
 		primaryOK := false
 		if !fullOK && len(primaryKws) > 0 && !sameKws(primaryKws, fullKws) {
-			primaryOK = titleMatchesResult(n, primaryKws, surname, true)
+			primaryOK = tryMatch(n, primaryKws)
 		}
 		if fullOK || primaryOK {
 			filtered = append(filtered, r)

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -39,6 +39,7 @@ type MatchCriteria struct {
 	ASIN             string   // for audiobook ASIN anchoring
 	MediaType        string   // models.MediaTypeEbook or models.MediaTypeAudiobook
 	AllowedLanguages []string // from author's MetadataProfile; empty = no filter
+	AuthorAliases    []string // alternate names (e.g. latin-script romanisations for non-latin authors)
 }
 
 // filterCategoriesForMedia returns the subset of configured indexer
@@ -114,7 +115,7 @@ func (s *Searcher) SearchBook(ctx context.Context, indexers []models.Indexer, c 
 
 	results = dedupe(results)
 	results = filterUsenetJunk(results)
-	results = filterRelevant(results, c.Title, c.Author)
+	results = filterRelevant(results, c.Title, c.Author, c.AuthorAliases)
 	rankResults(results, c)
 	return results
 }
@@ -247,7 +248,7 @@ func titleMatchesResult(normResult string, titleKws []string, surname string, al
 // any result happened to phrase-match) caused correctly-titled releases to be
 // dropped when an abbreviated result set the gate — e.g. "Name.Wind.epub"
 // enabling strict mode that then rejected "Name.of.the.Wind.epub".
-func filterRelevant(results []newznab.SearchResult, title, author string) []newznab.SearchResult {
+func filterRelevant(results []newznab.SearchResult, title, author string, aliases []string) []newznab.SearchResult {
 	// Strip edition qualifiers ("(German Edition)" etc.) and normalize
 	// smart quotes before tokenizing, so they don't become spurious keywords.
 	title = newznab.NormalizeQueryTitle(title)
@@ -255,6 +256,28 @@ func filterRelevant(results []newznab.SearchResult, title, author string) []newz
 	primaryKws := sigWords(primaryTitle(title))
 	authorKws := sigWords(author)
 	surname := AuthorSurname(author)
+
+	// Build candidate surnames. When the primary surname is non-ASCII (e.g.
+	// "春樹" for "村上春樹"), also include surnames from any latin-script
+	// aliases (e.g. "murakami" from "Haruki Murakami") so release names
+	// romanised by indexers are not incorrectly filtered out.
+	surnames := []string{surname}
+	if !isAllASCIILower(surname) {
+		for _, alias := range aliases {
+			if s := AuthorSurname(alias); s != "" && isAllASCIILower(s) {
+				surnames = append(surnames, s)
+			}
+		}
+	}
+
+	tryMatch := func(n string, kws []string) bool {
+		for _, sn := range surnames {
+			if titleMatchesResult(n, kws, sn, true) {
+				return true
+			}
+		}
+		return false
+	}
 
 	if len(fullKws) == 0 && len(primaryKws) == 0 && len(authorKws) == 0 {
 		return results
@@ -272,16 +295,28 @@ func filterRelevant(results []newznab.SearchResult, title, author string) []newz
 
 		// allowFallback=true: each result gets phrase match first, then keyword
 		// fallback if the phrase fails. No batch-level gate.
-		fullOK := titleMatchesResult(n, fullKws, surname, true)
+		fullOK := tryMatch(n, fullKws)
 		primaryOK := false
 		if !fullOK && len(primaryKws) > 0 && !sameKws(primaryKws, fullKws) {
-			primaryOK = titleMatchesResult(n, primaryKws, surname, true)
+			primaryOK = tryMatch(n, primaryKws)
 		}
 		if fullOK || primaryOK {
 			filtered = append(filtered, r)
 		}
 	}
 	return filtered
+}
+
+// isAllASCIILower returns true when every byte in the lowercased s is 7-bit ASCII.
+// AuthorSurname already returns lowercase, so this is equivalent to checking
+// whether the surname string contains only ASCII characters.
+func isAllASCIILower(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] > 127 {
+			return false
+		}
+	}
+	return true
 }
 
 func sameKws(a, b []string) bool {

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -41,7 +41,7 @@ func TestFilterRelevantTheSparrow(t *testing.T) {
 		"The.Hempcrete.Book.William.Stanwix.Alex.Sparrow.epub",
 		"Dark.Horse.Blade.Of.The.Immortal.Vol.18.The.Sparrow.Net.Comic.eBook",
 	)
-	got := filterRelevant(results, "The Sparrow", "Mary Doria Russell")
+	got := filterRelevant(results, "The Sparrow", "Mary Doria Russell", nil)
 
 	if !contains(got, "Mary.Doria.Russell.-.The.Sparrow.1996.RETAIL.EPUB") {
 		t.Errorf("expected Russell's Sparrow to be kept, got %v", resultTitles(got))
@@ -68,7 +68,7 @@ func TestFilterRelevantWordBoundary(t *testing.T) {
 		"sparrows.russell.epub",
 		"the.sparrow.russell.epub",
 	)
-	got := filterRelevant(results, "The Sparrow", "Mary Doria Russell")
+	got := filterRelevant(results, "The Sparrow", "Mary Doria Russell", nil)
 	if contains(got, "sparrowhawk.by.russell.epub") {
 		t.Error("must not match 'sparrowhawk' for 'sparrow' keyword")
 	}
@@ -87,7 +87,7 @@ func TestFilterRelevantMultiWordPhrase(t *testing.T) {
 		"On.The.Road.Again.Willie.Nelson.epub",
 		"The.Road.To.Wigan.Pier.Orwell.epub",
 	)
-	got := filterRelevant(results, "The Road", "Cormac McCarthy")
+	got := filterRelevant(results, "The Road", "Cormac McCarthy", nil)
 
 	if !contains(got, "Cormac.McCarthy.-.The.Road.2006.epub") {
 		t.Error("expected McCarthy's The Road to pass")
@@ -118,7 +118,7 @@ func TestFilterRelevantSubtitle(t *testing.T) {
 		"Dune.Messiah.Herbert.epub",
 		"Frank.Herbert.Dune.epub", // primary-title-only match
 	)
-	got := filterRelevant(results, "Dune: Messiah", "Frank Herbert")
+	got := filterRelevant(results, "Dune: Messiah", "Frank Herbert", nil)
 	for _, title := range []string{
 		"Frank.Herbert.Dune.Messiah.epub",
 		"Dune.Messiah.Herbert.epub",
@@ -132,7 +132,7 @@ func TestFilterRelevantSubtitle(t *testing.T) {
 
 func TestFilterRelevantNoResults(t *testing.T) {
 	// Empty input → empty output, no panic.
-	got := filterRelevant(nil, "The Sparrow", "Russell")
+	got := filterRelevant(nil, "The Sparrow", "Russell", nil)
 	if len(got) != 0 {
 		t.Errorf("expected empty, got %v", got)
 	}
@@ -182,7 +182,7 @@ func TestFilterRelevantApostrophe(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		got := filterRelevant(toResults(tc.releases...), tc.bookTitle, tc.author)
+		got := filterRelevant(toResults(tc.releases...), tc.bookTitle, tc.author, nil)
 		if !contains(got, tc.wantAny) {
 			t.Errorf("filterRelevant(%q, %q): expected %q in results, got %v",
 				tc.bookTitle, tc.author, tc.wantAny, resultTitles(got))
@@ -202,7 +202,7 @@ func TestFilterRelevantEditionQualifier(t *testing.T) {
 		"Die.Stille.ist.ein.Geraeusch.Mueller.epub",
 		"Some.Unrelated.Noise.epub",
 	)
-	got := filterRelevant(results, "Die Stille ist ein Geräusch (German Edition)", "Herta Müller")
+	got := filterRelevant(results, "Die Stille ist ein Geräusch (German Edition)", "Herta Müller", nil)
 	if !contains(got, "Herta.Mueller.Die.Stille.ist.ein.Geraeusch.epub") {
 		t.Errorf("expected full-title release to pass, got %v", resultTitles(got))
 	}
@@ -505,7 +505,7 @@ func TestFilterRelevantAnyPhraseMatchTrap(t *testing.T) {
 		"Name.Wind.Rothfuss.epub", // abbreviated — phrase-matches ["name","wind"]
 		"Completely.Unrelated.Book.epub",
 	)
-	got := filterRelevant(results, "The Name of the Wind", "Patrick Rothfuss")
+	got := filterRelevant(results, "The Name of the Wind", "Patrick Rothfuss", nil)
 
 	if !contains(got, "Patrick.Rothfuss.-.The.Name.of.the.Wind.EPUB") {
 		t.Errorf("correct release dropped by anyPhraseMatch trap; got %v", resultTitles(got))
@@ -531,7 +531,7 @@ func TestFilterRelevantStopWordsBetweenKeywords(t *testing.T) {
 		"Lord.of.the.Rings.Unabridged.m4b",
 		"Unrelated.Fantasy.Novel.epub",
 	)
-	got := filterRelevant(results, "The Lord of the Rings", "J.R.R. Tolkien")
+	got := filterRelevant(results, "The Lord of the Rings", "J.R.R. Tolkien", nil)
 
 	for _, title := range []string{
 		"J.R.R.Tolkien.-.The.Lord.of.the.Rings.EPUB",
@@ -645,10 +645,46 @@ func TestFilterRelevantGermanUmlauts(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		got := filterRelevant(toResults(tc.releases...), tc.bookTitle, tc.author)
+		got := filterRelevant(toResults(tc.releases...), tc.bookTitle, tc.author, nil)
 		if !contains(got, tc.wantAny) {
 			t.Errorf("filterRelevant(%q, %q): want %q in results, got %v",
 				tc.bookTitle, tc.author, tc.wantAny, resultTitles(got))
 		}
+	}
+}
+
+// TestFilterRelevantNonLatinAuthor verifies that releases whose author token is
+// romanised are accepted when the primary author name is non-latin but a
+// latin-script alias is provided. The alias surname is needed for single-keyword
+// titles (where filterRelevant requires the surname alongside the keyword to
+// prevent false positives).
+func TestFilterRelevantNonLatinAuthor(t *testing.T) {
+	// "Silence" by 遠藤周作 (Shusaku Endo): 1 significant keyword → surname required.
+	releases := []string{
+		"Endo.Silence.epub",
+		"Shusaku.Endo.Silence.m4b",
+		"Silence.epub",
+		"Unrelated.Noise.epub",
+	}
+	results := toResults(releases...)
+
+	// Without aliases, the non-latin surname ("作" from 遠藤周作) never appears in
+	// any release name, so author-anchored matches are missed.
+	withoutAliases := filterRelevant(results, "Silence", "遠藤周作", nil)
+	if contains(withoutAliases, "Endo.Silence.epub") {
+		t.Error("without aliases, romanised-surname release should not pass for non-latin primary name")
+	}
+
+	// With the latin alias, "endo" is extracted as an alias surname and the
+	// author-anchored releases pass.
+	aliases := []string{"Shusaku Endo"}
+	withAliases := filterRelevant(results, "Silence", "遠藤周作", aliases)
+	for _, want := range []string{"Endo.Silence.epub", "Shusaku.Endo.Silence.m4b"} {
+		if !contains(withAliases, want) {
+			t.Errorf("with alias, expected %q to pass; got %v", want, resultTitles(withAliases))
+		}
+	}
+	if contains(withAliases, "Unrelated.Noise.epub") {
+		t.Error("unrelated result should still be filtered out even with aliases")
 	}
 }

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -139,6 +139,8 @@ func (c *Client) GetAuthor(ctx context.Context, foreignID string) (*models.Autho
 		a.ImageURL = fmt.Sprintf("%s/a/id/%d-L.jpg", coverURL, resp.Photos[0])
 	}
 
+	a.AlternateNames = resp.AlternateNames
+
 	return a, nil
 }
 

--- a/internal/models/author.go
+++ b/internal/models/author.go
@@ -27,6 +27,10 @@ type Author struct {
 	Books      []Book        `json:"books,omitempty"`
 	Statistics *AuthorStats  `json:"statistics,omitempty"`
 	Aliases    []AuthorAlias `json:"aliases,omitempty"`
+
+	// Transient: populated from the metadata provider during add/refresh; not stored in DB.
+	// Used to seed author_aliases so non-latin primary names get latin-script alternates.
+	AlternateNames []string `json:"-"`
 }
 
 type AuthorStats struct {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -66,6 +66,7 @@ type Scheduler struct {
 	blocklist     *db.BlocklistRepo
 	delayProfiles *db.DelayProfileRepo
 	pending       *db.PendingReleaseRepo
+	aliases       *db.AuthorAliasRepo  // optional; used for non-latin author matching
 	calibreSyncer CalibreSyncer        // optional; nil if Calibre is not configured
 	recommender   RecommendationEngine // optional; generates recommendations
 	hcSyncer      HCListSyncer         // optional; syncs Hardcover import lists
@@ -117,6 +118,12 @@ func (s *Scheduler) WithPendingReleases(pr *db.PendingReleaseRepo) {
 // Must be called before Start.
 func (s *Scheduler) WithHistory(h *db.HistoryRepo) {
 	s.history = h
+}
+
+// WithAliases attaches the author alias repo used to populate AuthorAliases
+// in MatchCriteria for non-latin author name matching. Must be called before Start.
+func (s *Scheduler) WithAliases(aliases *db.AuthorAliasRepo) {
+	s.aliases = aliases
 }
 
 // WithCalibreSyncer registers a CalibreSyncer that the scheduler will call
@@ -287,18 +294,27 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	}
 
 	authorName := ""
+	var authorAliases []string
 	if s.authors != nil {
 		if a, err := s.authors.GetByID(ctx, book.AuthorID); err != nil {
 			slog.Warn("failed to load author for search", "author_id", book.AuthorID, "error", err)
 		} else if a != nil {
 			authorName = a.Name
+			if s.aliases != nil {
+				if aliases, err := s.aliases.ListByAuthor(ctx, a.ID); err == nil {
+					for _, al := range aliases {
+						authorAliases = append(authorAliases, al.Name)
+					}
+				}
+			}
 		}
 	}
 	crit := indexer.MatchCriteria{
-		Title:     book.Title,
-		Author:    authorName,
-		MediaType: mediaType,
-		ASIN:      book.ASIN,
+		Title:         book.Title,
+		Author:        authorName,
+		MediaType:     mediaType,
+		ASIN:          book.ASIN,
+		AuthorAliases: authorAliases,
 	}
 	if book.ReleaseDate != nil {
 		crit.Year = book.ReleaseDate.Year()


### PR DESCRIPTION
## Summary

- `AuthorSurname("村上春樹")` returns `"春樹"` — a non-ASCII token that never appears in romanised release names like `"Murakami.Kafka.Shore.epub"`
- Single-keyword titles require the author surname alongside the keyword to avoid false positives; this silently dropped all correctly-titled releases for non-latin authors
- The `author_aliases` table already exists for manual merges but OL `alternate_names` were never persisted, so aliases were empty for auto-added non-latin authors

**Fix is two parts:**

1. **Populate aliases automatically**: `OL GetAuthor` now surfaces `AlternateNames` into a transient `Author.AlternateNames` field; `AuthorHandler.Create` saves any ASCII-only entries (e.g. "Haruki Murakami") to `author_aliases` right after creating the author row

2. **Use aliases in search**: `filterRelevant` / `filterRelevantDebug` build a candidate surname list — when the primary surname is non-ASCII, also extract ASCII surnames from `AuthorAliases` and accept on first hit; `IndexerHandler` and `Scheduler` populate `MatchCriteria.AuthorAliases` from the alias repo

- `WithAliases` setter on both `IndexerHandler` and `Scheduler`; wired in `main.go` with the existing `authorAliasRepo`
- Manually-created aliases (via the Merge flow) continue to work — they're in the same table

Fixes #380

## Test plan

- [ ] All tests pass (`go test ./...`)
- [ ] New `TestFilterRelevantNonLatinAuthor` validates single-keyword title matching with non-latin primary author + latin alias
- [ ] Add author "村上春樹" (OL: OL233462A) → check `author_aliases` table gains "Haruki Murakami"
- [ ] Manual search for a 1-keyword book by a non-latin author returns results previously filtered away

🤖 Generated with [Claude Code](https://claude.com/claude-code)