### PR TITLE
fix(recommender): filter candidates by preferred language

### DIFF
--- a/internal/recommender/recommender.go
+++ b/internal/recommender/recommender.go
@@ -164,6 +164,9 @@ func hardFilter(candidates []models.RecommendationCandidate, p *UserProfile) []m
 		if c.AuthorName != "" && p.ExcludedAuthors[strings.ToLower(c.AuthorName)] {
 			continue
 		}
+		if p.PreferredLanguage != "" && c.Language != "" && c.Language != p.PreferredLanguage {
+			continue
+		}
 		// Deduplicate by foreign ID.
 		if seen[c.ForeignID] {
 			continue


### PR DESCRIPTION
Closes #359

## Problem

`hardFilter` removed owned, dismissed, and excluded-author candidates
but never checked language. A user with `PreferredLanguage = "en"` would
receive French, Spanish, etc. recommendations alongside English ones
even when foreign-language books were not in their library.

## Fix

Added a three-clause language guard inside `hardFilter`:

```go
if p.PreferredLanguage != "" && c.Language != "" && c.Language != p.PreferredLanguage {
    continue
}
```

Both ends are guarded with a non-empty check so that:
- Users who haven't set a preferred language see no change.
- Candidates without a language tag (empty string) pass through, avoiding
  silent suppression when metadata is absent.

## Test plan
- [ ] `go test ./internal/recommender/...` passes
- [ ] Discover page shows only the expected language when `search.preferredLanguage` is configured
- [ ] Candidates with no language tag (`Language == ""`) still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)