### PR TITLE
fix(recommender): anchor recency score to library median year

### DIFF
--- a/internal/recommender/profile.go
+++ b/internal/recommender/profile.go
@@ -3,6 +3,7 @@ package recommender
 import (
 	"context"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -54,6 +55,7 @@ func BuildProfile(
 		return nil, err
 	}
 	p.TotalBooks = len(allBooks)
+	p.LibraryMedianYear = medianReleaseYear(allBooks)
 
 	// Genre frequency counts and per-genre document counts (for IDF).
 	genreDocCount := make(map[string]int)
@@ -161,6 +163,22 @@ func BuildProfile(
 	}
 
 	return p, nil
+}
+
+// medianReleaseYear returns the median publication year across all books that
+// have a non-nil ReleaseDate. Returns 0 when no dated books exist.
+func medianReleaseYear(books []models.Book) int {
+	years := make([]int, 0, len(books))
+	for _, b := range books {
+		if b.ReleaseDate != nil {
+			years = append(years, b.ReleaseDate.Year())
+		}
+	}
+	if len(years) == 0 {
+		return 0
+	}
+	sort.Ints(years)
+	return years[len(years)/2]
 }
 
 // parsePosition converts a series position string like "1", "2.5" to float64.

--- a/internal/recommender/scorer.go
+++ b/internal/recommender/scorer.go
@@ -3,7 +3,6 @@ package recommender
 import (
 	"math"
 	"strings"
-	"time"
 
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -13,8 +12,8 @@ const (
 	weightGenre     = 0.30
 	weightAuthor    = 0.25
 	weightSeries    = 0.20
-	weightCommunity = 0.15
-	weightRecency   = 0.10
+	weightCommunity = 0.10
+	weightRecency   = 0.15
 
 	bonusSeries    = 0.15
 	bonusAuthorNew = 0.10
@@ -27,7 +26,7 @@ func Score(c models.RecommendationCandidate, p *UserProfile) float64 {
 	author := authorScore(c, p)
 	series := seriesScore(c, p)
 	community := communityScore(c)
-	recency := recencyScore(c)
+	recency := recencyScore(c, p.LibraryMedianYear)
 
 	score := genre*weightGenre +
 		author*weightAuthor +
@@ -144,21 +143,23 @@ func communityScore(c models.RecommendationCandidate) float64 {
 	return ratingNorm * countNorm
 }
 
-// recencyScore applies linear decay: 1.0 for the current year, 0.3 at 20+
-// years ago. Returns 0.5 if no release date is available.
-func recencyScore(c models.RecommendationCandidate) float64 {
-	if c.ReleaseDate == nil {
+// recencyScore applies linear decay relative to the user's library median
+// publication year. A candidate published in the same year as the median
+// scores 1.0; one published 30+ years before the median scores 0.1.
+// Returns 0.5 if no release date is available or medianYear is 0.
+func recencyScore(c models.RecommendationCandidate, medianYear int) float64 {
+	if c.ReleaseDate == nil || medianYear == 0 {
 		return 0.5
 	}
-	yearsAgo := float64(time.Now().Year() - c.ReleaseDate.Year())
-	if yearsAgo < 0 {
-		yearsAgo = 0
+	yearsBeforeMedian := float64(medianYear - c.ReleaseDate.Year())
+	if yearsBeforeMedian < 0 {
+		yearsBeforeMedian = 0
 	}
-	if yearsAgo >= 20 {
-		return 0.3
+	if yearsBeforeMedian >= 30 {
+		return 0.1
 	}
-	// Linear from 1.0 (0 years) to 0.3 (20 years).
-	return 1.0 - (0.7/20.0)*yearsAgo
+	// Linear from 1.0 (at or after median) to 0.1 (30 years before median).
+	return 1.0 - (0.9/30.0)*yearsBeforeMedian
 }
 
 func clamp(v float64) float64 {

--- a/internal/recommender/scorer_test.go
+++ b/internal/recommender/scorer_test.go
@@ -202,38 +202,47 @@ func TestCommunityScore(t *testing.T) {
 }
 
 func TestRecencyScore(t *testing.T) {
-	// No date: neutral
+	const median = 2010
+
+	// No date: neutral regardless of median.
 	c := models.RecommendationCandidate{}
-	if got := recencyScore(c); got != 0.5 {
+	if got := recencyScore(c, median); got != 0.5 {
 		t.Errorf("no date: got %v, want 0.5", got)
 	}
 
-	// This year: 1.0
-	thisYear := time.Date(time.Now().Year(), 6, 1, 0, 0, 0, 0, time.UTC)
-	c = models.RecommendationCandidate{ReleaseDate: &thisYear}
-	if got := recencyScore(c); got != 1.0 {
-		t.Errorf("current year: got %v, want 1.0", got)
+	// medianYear == 0: neutral regardless of release date.
+	d := time.Date(2010, 6, 1, 0, 0, 0, 0, time.UTC)
+	c = models.RecommendationCandidate{ReleaseDate: &d}
+	if got := recencyScore(c, 0); got != 0.5 {
+		t.Errorf("zero median: got %v, want 0.5", got)
 	}
 
-	// 20 years ago: 0.3
-	old := time.Date(time.Now().Year()-20, 1, 1, 0, 0, 0, 0, time.UTC)
-	c = models.RecommendationCandidate{ReleaseDate: &old}
-	if got := recencyScore(c); got != 0.3 {
-		t.Errorf("20 years ago: got %v, want 0.3", got)
+	// Same year as median: 1.0
+	same := time.Date(median, 6, 1, 0, 0, 0, 0, time.UTC)
+	c = models.RecommendationCandidate{ReleaseDate: &same}
+	if got := recencyScore(c, median); got != 1.0 {
+		t.Errorf("median year: got %v, want 1.0", got)
 	}
 
-	// Very old: clamped at 0.3
+	// 30 years before median: floor 0.1
+	floor := time.Date(median-30, 1, 1, 0, 0, 0, 0, time.UTC)
+	c = models.RecommendationCandidate{ReleaseDate: &floor}
+	if got := recencyScore(c, median); got != 0.1 {
+		t.Errorf("30 years before median: got %v, want 0.1", got)
+	}
+
+	// More than 30 years before median: clamped at 0.1
 	ancient := time.Date(1800, 1, 1, 0, 0, 0, 0, time.UTC)
 	c = models.RecommendationCandidate{ReleaseDate: &ancient}
-	if got := recencyScore(c); got != 0.3 {
-		t.Errorf("ancient: got %v, want 0.3", got)
+	if got := recencyScore(c, median); got != 0.1 {
+		t.Errorf("ancient: got %v, want 0.1", got)
 	}
 
-	// Future year: clamp to 0 years ago, should be 1.0.
-	future := time.Date(time.Now().Year()+5, 1, 1, 0, 0, 0, 0, time.UTC)
-	c = models.RecommendationCandidate{ReleaseDate: &future}
-	if got := recencyScore(c); got != 1.0 {
-		t.Errorf("future date: got %v, want 1.0", got)
+	// Newer than median: clamp yearsBeforeMedian to 0, should be 1.0.
+	newer := time.Date(median+5, 1, 1, 0, 0, 0, 0, time.UTC)
+	c = models.RecommendationCandidate{ReleaseDate: &newer}
+	if got := recencyScore(c, median); got != 1.0 {
+		t.Errorf("newer than median: got %v, want 1.0", got)
 	}
 }
 

--- a/internal/recommender/types.go
+++ b/internal/recommender/types.go
@@ -23,4 +23,5 @@ type UserProfile struct {
 	ExcludedAuthors     map[string]bool
 	PreferredLanguage   string
 	TotalBooks          int
+	LibraryMedianYear   int
 }


### PR DESCRIPTION
Closes #357

## Problem

`recencyScore` used `time.Now().Year()` as its absolute anchor. A user
whose library is dominated by pre-2000 classics would still receive heavy
penalties for any book published before ~2005, pushing recommendations
toward modern works regardless of taste.

## Fix

**`types.go`** — added `LibraryMedianYear int` to `UserProfile`.

**`profile.go`** — `BuildProfile` now computes the median publication
year across all library books that have a non-nil `ReleaseDate` and
stores it in `p.LibraryMedianYear`. Books without dates are excluded
from the calculation (they still appear in the library).

**`scorer.go`**
- `recencyScore(c, medianYear int)` — anchored to the library median
  instead of `time.Now()`. A candidate published in the same year as the
  median scores 1.0; 30 years before the median scores 0.1. Missing
  `ReleaseDate` or `medianYear == 0` returns the neutral 0.5.
- Window widened from 20 → 30 years; floor lowered from 0.3 → 0.1 to
  give finer differentiation within a library era.
- `weightRecency` 0.10 → 0.15; `weightCommunity` 0.15 → 0.10.

## Test plan
- [ ] `go test ./internal/recommender/...` passes
- [ ] `TestRecencyScore` covers: no date, zero median, same-as-median,
  floor at 30 years, ancient (clamped), newer than median

🤖 Generated with [Claude Code](https://claude.com/claude-code)