### PR TITLE
chore(ci): reduce friction and wall-clock time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,10 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - run: make smoke
 
-  # PR-only: validates tests + frontend build (with race detector for correctness)
-  validate:
+  # PR-only: Go race-detector tests and frontend build run in parallel so
+  # neither blocks the other.
+  validate-go:
+    name: validate (Go)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
@@ -74,6 +76,15 @@ jobs:
           flags: backend
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  validate-frontend:
+    name: validate (frontend)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
@@ -337,3 +348,51 @@ jobs:
             exit 0
           fi
           make predeploy-smoke
+
+  # ── Discord release announcement ───────────────────────────────────────────
+  notify-discord:
+    name: Notify Discord
+    needs: [goreleaser, image]
+    if: startsWith(github.ref, 'refs/tags/v') && needs.goreleaser.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Post release announcement
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          python3 - <<'EOF'
+          import json, os, re, urllib.request
+
+          version = os.environ["VERSION"]
+          webhook = os.environ["DISCORD_WEBHOOK"]
+
+          with open("CHANGELOG.md") as f:
+              content = f.read()
+
+          # Extract the section for this version
+          pattern = rf"## \[{re.escape(version)}\][^\n]*\n(.*?)(?=\n## \[|\Z)"
+          m = re.search(pattern, content, re.DOTALL)
+          notes = m.group(1).strip() if m else ""
+
+          # Trim to a readable length (Discord 2000-char limit)
+          if len(notes) > 900:
+              notes = notes[:900].rsplit("\n", 1)[0] + "\n…"
+
+          body = f"**Bindery {version}** is out!"
+          if notes:
+              body += f"\n\n{notes}"
+          body += f"\n\n<https://github.com/vavallee/bindery/releases/tag/{version}>"
+
+          payload = json.dumps({"content": body}).encode()
+          req = urllib.request.Request(
+              webhook, data=payload,
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          urllib.request.urlopen(req)
+          print(f"Discord notified for {version}")
+          EOF

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,25 @@ name: Security
 on:
   push:
     branches: [main, development]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'CHANGELOG*'
+      - 'CONTRIBUTING*'
+      - 'README*'
+      - 'LICENSE*'
+      - 'CODE_OF_CONDUCT*'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'CHANGELOG*'
+      - 'CONTRIBUTING*'
+      - 'README*'
+      - 'LICENSE*'
+      - 'CODE_OF_CONDUCT*'
+      - '.github/ISSUE_TEMPLATE/**'
   schedule:
     # Weekly Monday 06:00 UTC
     - cron: '0 6 * * 1'
@@ -18,7 +36,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ── Go SAST: gosec + govulncheck + golangci-lint ────────────────────────────
+  # ── Go SAST: gosec only — golangci-lint and govulncheck run in ci.yml lint ──
   sast-go:
     name: SAST – Go
     runs-on: ubuntu-latest
@@ -29,15 +47,7 @@ jobs:
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.9"
-
-      - name: Cache Go modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
-          restore-keys: go-mod-
+          cache: true
 
       - name: gosec (SARIF)
         uses: securego/gosec@64b97151cd7b978abdf8d2f1159a4e9096a12c2b # master
@@ -53,18 +63,6 @@ jobs:
         with:
           sarif_file: gosec.sarif
           category: gosec
-
-      - name: govulncheck
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
-        with:
-          version: v2.11.4
-          args: --timeout=5m
-          only-new-issues: false
 
   # ── Frontend SAST: Semgrep + npm audit + ESLint security ───────────────────
   sast-frontend:
@@ -136,8 +134,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
@@ -153,7 +149,7 @@ jobs:
           sarif_file: results.sarif
           category: gitleaks
 
-  # ── IaC scan: Hadolint + Helm lint + Kubesec + Checkov ────────────────────
+  # ── IaC scan: Hadolint + Helm lint + Checkov ──────────────────────────────
   iac-scan:
     name: IaC Scan
     runs-on: ubuntu-latest
@@ -184,16 +180,6 @@ jobs:
       - name: Helm lint
         run: helm lint --strict charts/bindery
 
-      - name: Render Helm templates for kubesec
-        run: |
-          helm template bindery charts/bindery > /tmp/rendered-manifests.yaml
-
-      - name: Kubesec scan
-        run: |
-          docker run --rm -v /tmp:/tmp kubesec/kubesec:v2 scan /tmp/rendered-manifests.yaml \
-            > /tmp/kubesec-results.json || true
-          cat /tmp/kubesec-results.json
-
       - name: Checkov
         uses: bridgecrewio/checkov-action@de2bfaecd21d58ef232e0d2a3391c33c32c460d7 # master
         with:
@@ -211,7 +197,7 @@ jobs:
           sarif_file: checkov.sarif
           category: checkov
 
-  # ── Container scan: Trivy + Grype + Dockle + Syft SBOM ───────────────────
+  # ── Container scan: Trivy + Grype + Syft SBOM ────────────────────────────
   container-scan:
     name: Container Scan
     runs-on: ubuntu-latest
@@ -222,17 +208,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Cache Go modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
-          restore-keys: go-mod-
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - name: Build image
-        run: docker build -t bindery:scan .
+      - name: Build image (with layer cache)
+        run: |
+          docker buildx build \
+            --load \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
+            -t bindery:scan \
+            .
 
       - name: Trivy vulnerability scan (SARIF)
         uses: aquasecurity/trivy-action@1994662b5555670344cd84d29ed3cad4bd26f31c # master
@@ -266,14 +251,6 @@ jobs:
           sarif_file: grype.sarif
           category: grype
 
-      - name: Dockle CIS Docker benchmark
-        run: |
-          docker run --rm \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            goodwithtech/dockle:latest \
-            --exit-code 0 --exit-level warn \
-            bindery:scan
-
       - name: Syft SBOM – SPDX
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
@@ -302,18 +279,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Cache Go modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: go-mod-${{ hashFiles('go.sum') }}
-          restore-keys: go-mod-
-
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.9"
+          cache: true
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -398,11 +367,11 @@ jobs:
 
           | Job | Status |
           |-----|--------|
-          | SAST – Go (gosec, govulncheck, golangci-lint) | ${{ needs.sast-go.result }} |
+          | SAST – Go (gosec) | ${{ needs.sast-go.result }} |
           | SAST – Frontend (Semgrep, npm audit, ESLint) | ${{ needs.sast-frontend.result }} |
           | Secrets Scan (Gitleaks) | ${{ needs.secrets-scan.result }} |
-          | IaC Scan (Hadolint, Helm lint, Kubesec, Checkov) | ${{ needs.iac-scan.result }} |
-          | Container Scan (Trivy, Grype, Dockle, Syft SBOM) | ${{ needs.container-scan.result }} |
+          | IaC Scan (Hadolint, Helm lint, Checkov) | ${{ needs.iac-scan.result }} |
+          | Container Scan (Trivy, Grype, Syft SBOM) | ${{ needs.container-scan.result }} |
           | DAST – ZAP Baseline | ${{ needs.dast-api.result }} |
           | Helm Policy Tests | ${{ needs.policy-test.result }} |
 


### PR DESCRIPTION
## What this does

Addresses the CI audit: deduplicates redundant tooling, speeds up the PR critical path, adds Docker layer caching, narrows security scan triggers, and wires up a Discord release announcement.

## Changes

### ci.yml

**Split `validate` → `validate-go` + `validate-frontend` (parallel)**
The race-detector test suite and the frontend build ran sequentially in a single job. Now they're separate jobs that run in parallel. PR critical-path drops from ~253 s to ~180 s.

**Add `notify-discord` job**
Posts a release announcement (with the CHANGELOG section for the tag) to the Discord server after a successful tag release. Uses `DISCORD_RELEASE_WEBHOOK` repo secret. Fires only when `goreleaser` succeeds.

### security.yml

| Change | Reason |
|--------|--------|
| Remove golangci-lint + govulncheck from `sast-go` | Both already run in `ci.yml → lint`. ~60 s saved per scan with no new signal. gosec SARIF upload kept. |
| Add BuildKit GHA cache to `container-scan` docker build | Previously rebuilt from scratch every run. Warm cache skips unchanged layers (~60–90 s saved). |
| Add `paths-ignore` for doc-only changes | Markdown, CHANGELOG, CONTRIBUTING, LICENSE, issue templates no longer trigger the full security suite. |
| Remove `fetch-depth: 0` from Gitleaks | Action scans only new PR commits by default; full history clone was unnecessary. |
| Remove Kubesec | Output discarded with `\|\| true` — zero signal surfaced. |
| Remove Dockle | Run with `--exit-code 0`, impossible to fail. Trivy + Checkov cover the same ground. |

## Test plan
- [ ] PR checks pass on this PR (validates the parallel validate split + security changes)
- [ ] On next tag push: `notify-discord` fires and posts to the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)