### PR TITLE
feat(renamer): add {Series} and {SeriesNumber} naming tokens

### DIFF
--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -195,3 +195,19 @@ func (r *SeriesRepo) Delete(ctx context.Context, id int64) error {
 	}
 	return nil
 }
+
+// GetPrimarySeriesForBook returns the title and position of the primary series
+// for the given book. Returns ("", "", nil) when the book has no primary series.
+func (r *SeriesRepo) GetPrimarySeriesForBook(ctx context.Context, bookID int64) (seriesTitle, position string, err error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT s.title, sb.position_in_series
+		FROM series_books sb
+		JOIN series s ON s.id = sb.series_id
+		WHERE sb.book_id = ? AND sb.primary_series = 1
+		LIMIT 1`, bookID)
+	err = row.Scan(&seriesTitle, &position)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", "", nil
+	}
+	return seriesTitle, position, err
+}

--- a/internal/importer/helpers_test.go
+++ b/internal/importer/helpers_test.go
@@ -18,7 +18,7 @@ func TestAudiobookDestDir(t *testing.T) {
 	author := &models.Author{Name: "Ursula K. Le Guin"}
 	book := &models.Book{Title: "The Dispossessed", ReleaseDate: &releaseDate}
 
-	got, err := r.AudiobookDestDir("/audio", author, book)
+	got, err := r.AudiobookDestDir("/audio", author, book, "", "")
 	if err != nil {
 		t.Fatalf("AudiobookDestDir: %v", err)
 	}
@@ -33,7 +33,7 @@ func TestAudiobookDestDir_NilAuthor(t *testing.T) {
 	// still land under a predictable folder rather than panicking.
 	r := NewRenamer("")
 	book := &models.Book{Title: "Mystery"}
-	got, err := r.AudiobookDestDir("/audio", nil, book)
+	got, err := r.AudiobookDestDir("/audio", nil, book, "", "")
 	if err != nil {
 		t.Fatalf("AudiobookDestDir: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestAudiobookDestDir_CustomTemplate(t *testing.T) {
 	r := NewRenamerWithAudiobook("", "Audiobooks/{SortAuthor}/{Title}")
 	author := &models.Author{Name: "Andy Weir"}
 	book := &models.Book{Title: "Project Hail Mary"}
-	got, err := r.AudiobookDestDir("/root", author, book)
+	got, err := r.AudiobookDestDir("/root", author, book, "", "")
 	if err != nil {
 		t.Fatalf("AudiobookDestDir: %v", err)
 	}

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -41,17 +41,20 @@ func NewRenamerWithAudiobook(ebookTemplate, audiobookTemplate string) *Renamer {
 }
 
 // DestPath computes the destination path for an ebook file.
-func (r *Renamer) DestPath(rootFolder string, author *models.Author, book *models.Book, srcPath string) (string, error) {
+// series and seriesNumber are the book's primary series title and position
+// (empty strings for standalone books without a series).
+func (r *Renamer) DestPath(rootFolder string, author *models.Author, book *models.Book, series, seriesNumber, srcPath string) (string, error) {
 	ext := strings.TrimPrefix(filepath.Ext(srcPath), ".")
-	dest := filepath.Join(rootFolder, r.apply(r.template, author, book, ext))
+	dest := filepath.Join(rootFolder, r.apply(r.template, author, book, series, seriesNumber, ext))
 	return ensureContained(dest, rootFolder)
 }
 
 // AudiobookDestDir computes the destination directory into which an audiobook
 // download folder should be moved. The download's internal file structure is
 // preserved inside (multi-part m4b/mp3 + cover + cue sheet stay together).
-func (r *Renamer) AudiobookDestDir(rootFolder string, author *models.Author, book *models.Book) (string, error) {
-	dest := filepath.Join(rootFolder, r.apply(r.audiobookTemplate, author, book, ""))
+// series and seriesNumber are the book's primary series title and position.
+func (r *Renamer) AudiobookDestDir(rootFolder string, author *models.Author, book *models.Book, series, seriesNumber string) (string, error) {
+	dest := filepath.Join(rootFolder, r.apply(r.audiobookTemplate, author, book, series, seriesNumber, ""))
 	return ensureContained(dest, rootFolder)
 }
 
@@ -67,7 +70,7 @@ func ensureContained(dest, baseDir string) (string, error) {
 	return cleanDest, nil
 }
 
-func (r *Renamer) apply(template string, author *models.Author, book *models.Book, ext string) string {
+func (r *Renamer) apply(template string, author *models.Author, book *models.Book, series, seriesNumber, ext string) string {
 	year := ""
 	if book.ReleaseDate != nil {
 		year = fmt.Sprintf("%d", book.ReleaseDate.Year())
@@ -82,6 +85,8 @@ func (r *Renamer) apply(template string, author *models.Author, book *models.Boo
 	result = strings.ReplaceAll(result, "{Title}", sanitizePath(book.Title))
 	result = strings.ReplaceAll(result, "{Year}", year)
 	result = strings.ReplaceAll(result, "{ASIN}", sanitizePath(book.ASIN))
+	result = strings.ReplaceAll(result, "{Series}", sanitizePath(series))
+	result = strings.ReplaceAll(result, "{SeriesNumber}", sanitizePath(seriesNumber))
 	result = strings.ReplaceAll(result, "{ext}", ext)
 	return result
 }

--- a/internal/importer/renamer_test.go
+++ b/internal/importer/renamer_test.go
@@ -19,7 +19,7 @@ func TestRenamerDestPath(t *testing.T) {
 		ReleaseDate: &releaseDate,
 	}
 
-	got, err := r.DestPath("/books", author, book, "/downloads/complete/something.epub")
+	got, err := r.DestPath("/books", author, book, "", "", "/downloads/complete/something.epub")
 	if err != nil {
 		t.Fatalf("DestPath: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestRenamerNoYear(t *testing.T) {
 	author := &models.Author{Name: "Author"}
 	book := &models.Book{Title: "Book Title"}
 
-	got, err := r.DestPath("/lib", author, book, "file.pdf")
+	got, err := r.DestPath("/lib", author, book, "", "", "file.pdf")
 	if err != nil {
 		t.Fatalf("DestPath: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestRenamerSanitizesPath(t *testing.T) {
 	author := &models.Author{Name: "Author: Bad/Name"}
 	book := &models.Book{Title: "Title? With <Bad> Chars"}
 
-	got, err := r.DestPath("/lib", author, book, "test.epub")
+	got, err := r.DestPath("/lib", author, book, "", "", "test.epub")
 	if err != nil {
 		t.Fatalf("DestPath: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestRenamerASINToken(t *testing.T) {
 		ReleaseDate: &releaseDate,
 	}
 
-	got, err := r.DestPath("/books", author, book, "book.epub")
+	got, err := r.DestPath("/books", author, book, "", "", "book.epub")
 	if err != nil {
 		t.Fatalf("DestPath: %v", err)
 	}
@@ -101,11 +101,58 @@ func TestRenamerASINTokenEmpty(t *testing.T) {
 	author := &models.Author{Name: "Author"}
 	book := &models.Book{Title: "Some Book"}
 
-	got, err := r.DestPath("/books", author, book, "book.epub")
+	got, err := r.DestPath("/books", author, book, "", "", "book.epub")
 	if err != nil {
 		t.Fatalf("DestPath: %v", err)
 	}
 	want := filepath.Join("/books", "Some Book.epub")
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestRenamerSeriesTokens(t *testing.T) {
+	r := NewRenamer("{Author}/{Series}/{SeriesNumber} - {Title}.{ext}")
+	releaseDate := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	author := &models.Author{Name: "Frank Herbert"}
+	book := &models.Book{Title: "Dune", ReleaseDate: &releaseDate}
+
+	got, err := r.DestPath("/books", author, book, "Dune Chronicles", "1", "book.m4b")
+	if err != nil {
+		t.Fatalf("DestPath: %v", err)
+	}
+	want := filepath.Join("/books", "Frank Herbert", "Dune Chronicles", "1 - Dune.m4b")
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestRenamerSeriesTokensEmpty(t *testing.T) {
+	// No series — {Series} and {SeriesNumber} produce empty segments, stripped by sanitizePath
+	r := NewRenamer("{Author}/{Series}/{Title}.{ext}")
+	author := &models.Author{Name: "Author"}
+	book := &models.Book{Title: "Standalone"}
+
+	got, err := r.DestPath("/books", author, book, "", "", "book.epub")
+	if err != nil {
+		t.Fatalf("DestPath: %v", err)
+	}
+	want := filepath.Join("/books", "Author", "Standalone.epub")
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestRenamerAudiobookSeriesTokens(t *testing.T) {
+	r := NewRenamerWithAudiobook("", "{Author}/{Series}/{SeriesNumber} - {Title}")
+	author := &models.Author{Name: "Brandon Sanderson"}
+	book := &models.Book{Title: "The Way of Kings"}
+
+	got, err := r.AudiobookDestDir("/audiobooks", author, book, "Stormlight Archive", "1")
+	if err != nil {
+		t.Fatalf("AudiobookDestDir: %v", err)
+	}
+	want := filepath.Join("/audiobooks", "Brandon Sanderson", "Stormlight Archive", "1 - The Way of Kings")
 	if got != want {
 		t.Errorf("got  %q\nwant %q", got, want)
 	}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -38,6 +38,7 @@ type Scanner struct {
 	authors      *db.AuthorRepo
 	history      *db.HistoryRepo
 	rootFolders  *db.RootFolderRepo
+	series       *db.SeriesRepo
 	renamer      *Renamer
 	remapper     *Remapper
 	calibreAdder calibreAdder
@@ -75,6 +76,28 @@ func NewScanner(downloads *db.DownloadRepo, clients *db.DownloadClientRepo,
 func (s *Scanner) WithRootFolders(rf *db.RootFolderRepo) *Scanner {
 	s.rootFolders = rf
 	return s
+}
+
+// WithSeriesRepo attaches the series repo so the scanner can resolve series
+// name and position when building rename destination paths.
+func (s *Scanner) WithSeriesRepo(sr *db.SeriesRepo) *Scanner {
+	s.series = sr
+	return s
+}
+
+// primarySeriesFor returns the primary series title and position for the given
+// book. Returns empty strings when the series repo is not configured or the
+// book has no primary series.
+func (s *Scanner) primarySeriesFor(ctx context.Context, book *models.Book) (seriesTitle, seriesNumber string) {
+	if s.series == nil || book == nil {
+		return "", ""
+	}
+	title, pos, err := s.series.GetPrimarySeriesForBook(ctx, book.ID)
+	if err != nil {
+		slog.Warn("renamer: failed to load primary series", "bookID", book.ID, "error", err)
+		return "", ""
+	}
+	return title, pos
 }
 
 // effectiveLibraryDir returns the library root to use for the given author.
@@ -557,7 +580,8 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		if effLib := s.effectiveLibraryDir(ctx, author); effLib != s.libraryDir {
 			audiobookRoot = effLib
 		}
-		audiobookDest, destErr := s.renamer.AudiobookDestDir(audiobookRoot, author, book)
+		seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
+		audiobookDest, destErr := s.renamer.AudiobookDestDir(audiobookRoot, author, book, seriesTitle, seriesNum)
 		if destErr != nil {
 			slog.Error("failed to compute audiobook destination", "src", downloadPath, "error", destErr)
 			s.failImport(ctx, dl, models.StateImportBlocked, fmt.Sprintf("audiobook destination invalid: %v", destErr))
@@ -639,7 +663,8 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			continue
 		}
 
-		destPath, destErr := s.renamer.DestPath(s.effectiveLibraryDir(ctx, author), author, book, srcFile)
+		seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
+		destPath, destErr := s.renamer.DestPath(s.effectiveLibraryDir(ctx, author), author, book, seriesTitle, seriesNum, srcFile)
 		if destErr != nil {
 			slog.Error("failed to compute book destination", "src", srcFile, "error", destErr)
 			lastFileErr = destErr


### PR DESCRIPTION
## Summary

- Adds `{Series}` and `{SeriesNumber}` tokens to the file renamer template engine
- Both ebook (`DestPath`) and audiobook (`AudiobookDestDir`) paths support the new tokens
- Series values come from the book's primary series via new `GetPrimarySeriesForBook` DB method
- Empty series (standalone books) render as empty strings — `sanitizePath` empty-segment stripping prevents broken paths
- Adds `WithSeriesRepo` builder to `Scanner` so series data can be injected at startup

## Example templates

Audiobook layout matching Audiobookshelf conventions:
```
{Author}/{Series}/{SeriesNumber} - {Title}
```

Ebook layout with series subfolder:
```
{Author}/{Series}/{SeriesNumber} - {Title}.{ext}
```

## Test plan
- [x] `go test ./internal/importer/... ./internal/db/...`