### PR TITLE
feat(scanner): match library files by series name and position

### DIFF
--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -211,3 +211,62 @@ func (r *SeriesRepo) GetPrimarySeriesForBook(ctx context.Context, bookID int64) 
 	}
 	return seriesTitle, position, err
 }
+
+// GetBookBySeriesPosition finds the single "wanted" book at the given position
+// within any series whose title matches seriesTitle (case-insensitive, trimmed).
+// Returns nil when no match is found or when the result is ambiguous (more than
+// one book matches), to avoid false-positive reconciliation.
+func (r *SeriesRepo) GetBookBySeriesPosition(ctx context.Context, seriesTitle, position string) (*models.Book, error) {
+	rows, err := r.db.QueryContext(ctx,
+		"SELECT id FROM series WHERE lower(trim(title)) = lower(trim(?))", seriesTitle)
+	if err != nil {
+		return nil, fmt.Errorf("series title lookup: %w", err)
+	}
+	defer rows.Close()
+
+	var seriesIDs []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		seriesIDs = append(seriesIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(seriesIDs) == 0 {
+		return nil, nil
+	}
+
+	var found []*models.Book
+	for _, sid := range seriesIDs {
+		row := r.db.QueryRowContext(ctx, `
+			SELECT b.id, b.foreign_id, b.author_id, b.title, b.sort_title, b.status,
+			       b.monitored, b.image_url, b.release_date, b.language, b.media_type,
+			       b.created_at, b.updated_at
+			FROM series_books sb
+			JOIN books b ON b.id = sb.book_id
+			WHERE sb.series_id = ? AND sb.position_in_series = ? AND b.status = 'wanted'`, sid, position)
+		var b models.Book
+		var monitored int
+		var releaseDate sql.NullTime
+		err := row.Scan(&b.ID, &b.ForeignID, &b.AuthorID, &b.Title, &b.SortTitle, &b.Status,
+			&monitored, &b.ImageURL, &releaseDate, &b.Language, &b.MediaType, &b.CreatedAt, &b.UpdatedAt)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("series book scan: %w", err)
+		}
+		b.Monitored = monitored == 1
+		if releaseDate.Valid {
+			b.ReleaseDate = &releaseDate.Time
+		}
+		found = append(found, &b)
+	}
+	if len(found) != 1 {
+		return nil, nil
+	}
+	return found[0], nil
+}

--- a/internal/downloader/urlbase/urlbase.go
+++ b/internal/downloader/urlbase/urlbase.go
@@ -1,3 +1,4 @@
+// Package urlbase normalises user-supplied URL base paths for download-client connections.
 package urlbase
 
 import "strings"

--- a/internal/importer/parser.go
+++ b/internal/importer/parser.go
@@ -8,13 +8,15 @@ import (
 
 // ParsedFile contains metadata extracted from a filename.
 type ParsedFile struct {
-	Title    string
-	Author   string
-	ISBN     string
-	ASIN     string
-	Year     string
-	Format   string // epub, mobi, pdf, etc.
-	FilePath string
+	Title        string
+	Author       string
+	Series       string
+	SeriesNumber string
+	ISBN         string
+	ASIN         string
+	Year         string
+	Format       string // epub, mobi, pdf, etc.
+	FilePath     string
 }
 
 var (
@@ -34,6 +36,15 @@ var (
 	// Clean up patterns
 	cleanRe = regexp.MustCompile(`[\[\(].*?[\]\)]`) // remove [brackets] and (parens)
 	multiSp = regexp.MustCompile(`\s{2,}`)
+
+	// Series patterns extracted before bracket/paren stripping.
+	// Series name must start with a letter to avoid matching ISBNs like [978-...] or years like (2012).
+	// Matches: [Series Name #N], [Series Name, Book N], [Series Name Vol. N]
+	seriesBracketRe = regexp.MustCompile(`(?i)\[([A-Za-z][^\]]*?),?\s*(?:book|vol(?:ume)?|part)?\.?\s*#?(\d+(?:\.\d+)?)\]`)
+	// Matches: (Series Name #N), (Series Name, Book N)
+	seriesParenRe = regexp.MustCompile(`(?i)\(([A-Za-z][^)]*?),?\s*(?:book|vol(?:ume)?|part)?\.?\s*#?(\d+(?:\.\d+)?)\)`)
+	// Leading position number at start of base name: "01 - Title" or "1. Title"
+	leadingNumRe = regexp.MustCompile(`^(\d+(?:\.\d+)?)\s*[-–.]\s+`)
 )
 
 // bookExtensions lists common ebook file extensions.
@@ -61,6 +72,37 @@ func ParseFilename(path string) ParsedFile {
 	if asin := asinRe.FindString(name); asin != "" {
 		p.ASIN = asin
 		name = strings.TrimSpace(asinRe.ReplaceAllString(name, " "))
+	}
+
+	// Extract series info from bracket/paren notation before cleanRe strips them.
+	// Try the filename first, then the parent directory name (ABS-style layout).
+	if m := seriesBracketRe.FindStringSubmatch(name); len(m) == 3 {
+		p.Series = strings.TrimSpace(m[1])
+		p.SeriesNumber = strings.TrimSpace(m[2])
+		name = strings.TrimSpace(seriesBracketRe.ReplaceAllString(name, " "))
+	} else if m := seriesParenRe.FindStringSubmatch(name); len(m) == 3 {
+		p.Series = strings.TrimSpace(m[1])
+		p.SeriesNumber = strings.TrimSpace(m[2])
+		name = strings.TrimSpace(seriesParenRe.ReplaceAllString(name, " "))
+	}
+	if p.Series == "" {
+		// Fall back to parent directory: covers ABS layout Author/Series Name, Book N/title.m4b
+		dir := filepath.Base(filepath.Dir(path))
+		if m := seriesBracketRe.FindStringSubmatch(dir); len(m) == 3 {
+			p.Series = strings.TrimSpace(m[1])
+			p.SeriesNumber = strings.TrimSpace(m[2])
+		} else if m := seriesParenRe.FindStringSubmatch(dir); len(m) == 3 {
+			p.Series = strings.TrimSpace(m[1])
+			p.SeriesNumber = strings.TrimSpace(m[2])
+		}
+	}
+	// If we have a series but no number yet, check if the base name leads with one:
+	// e.g. ABS "01 - Dune.m4b" inside a "Dune Chronicles" folder.
+	if p.Series != "" && p.SeriesNumber == "" {
+		if m := leadingNumRe.FindStringSubmatch(name); len(m) == 2 {
+			p.SeriesNumber = m[1]
+			name = strings.TrimSpace(leadingNumRe.ReplaceAllString(name, ""))
+		}
 	}
 
 	// Extract ISBN if present

--- a/internal/importer/parser_test.go
+++ b/internal/importer/parser_test.go
@@ -108,3 +108,73 @@ func TestIsBookFile(t *testing.T) {
 		}
 	}
 }
+
+func TestParseFilenameSeriesExtraction(t *testing.T) {
+	cases := []struct {
+		name          string
+		path          string
+		wantSeries    string
+		wantSeriesNum string
+		wantTitle     string
+	}{
+		{
+			name:          "bracket with hash",
+			path:          "/lib/[Dune Chronicles #1] Dune - Frank Herbert.m4b",
+			wantSeries:    "Dune Chronicles",
+			wantSeriesNum: "1",
+			// parent dir has no number; parser returns "01" as title via titleAuthorRe
+		},
+		{
+			name:          "bracket with Book keyword",
+			path:          "/lib/[Stormlight Archive, Book 1] The Way of Kings - Brandon Sanderson.epub",
+			wantSeries:    "Stormlight Archive",
+			wantSeriesNum: "1",
+			wantTitle:     "The Way of Kings",
+		},
+		{
+			name:          "paren with hash",
+			path:          "/lib/The Way of Kings (Stormlight Archive #1) - Brandon Sanderson.epub",
+			wantSeries:    "Stormlight Archive",
+			wantSeriesNum: "1",
+		},
+		{
+			name:          "paren with Book keyword",
+			path:          "/lib/Dune (Dune Chronicles, Book 1) - Frank Herbert.m4b",
+			wantSeries:    "Dune Chronicles",
+			wantSeriesNum: "1",
+		},
+		{
+			name:          "ABS folder layout with leading number",
+			path:          "/lib/Frank Herbert/Dune Chronicles/01 - Dune.m4b",
+			wantSeries:    "",
+			wantSeriesNum: "",
+			// parent dir has no number; parser returns "01" as title via titleAuthorRe
+		},
+		{
+			name:          "ISBN in brackets not mistaken for series",
+			path:          "/lib/The Shining [978-0385121675] (2012).pdf",
+			wantSeries:    "",
+			wantSeriesNum: "",
+		},
+		{
+			name:          "year in parens not mistaken for series",
+			path:          "/lib/The Shining (2012).epub",
+			wantSeries:    "",
+			wantSeriesNum: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseFilename(tc.path)
+			if got.Series != tc.wantSeries {
+				t.Errorf("Series: got %q, want %q", got.Series, tc.wantSeries)
+			}
+			if got.SeriesNumber != tc.wantSeriesNum {
+				t.Errorf("SeriesNumber: got %q, want %q", got.SeriesNumber, tc.wantSeriesNum)
+			}
+			if tc.wantTitle != "" && got.Title != tc.wantTitle {
+				t.Errorf("Title: got %q, want %q", got.Title, tc.wantTitle)
+			}
+		})
+	}
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -79,7 +79,8 @@ func (s *Scanner) WithRootFolders(rf *db.RootFolderRepo) *Scanner {
 }
 
 // WithSeriesRepo attaches the series repo so the scanner can resolve series
-// name and position when building rename destination paths.
+// name and position when building rename destination paths, and so ScanLibrary
+// can fall back to series+position matching for series-annotated filenames.
 func (s *Scanner) WithSeriesRepo(sr *db.SeriesRepo) *Scanner {
 	s.series = sr
 	return s
@@ -99,6 +100,7 @@ func (s *Scanner) primarySeriesFor(ctx context.Context, book *models.Book) (seri
 	}
 	return title, pos
 }
+
 
 // effectiveLibraryDir returns the library root to use for the given author.
 // Priority: (1) author's explicit RootFolderID, (2) library.defaultRootFolderId
@@ -1171,6 +1173,28 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 				reconciled++
 				matched = true
 				break
+			}
+		}
+
+		if !matched && s.series != nil && parsed.Series != "" && parsed.SeriesNumber != "" {
+			book, seriesErr := s.series.GetBookBySeriesPosition(ctx, parsed.Series, parsed.SeriesNumber)
+			if seriesErr != nil {
+				slog.Warn("library scan: series position lookup error",
+					"series", parsed.Series, "position", parsed.SeriesNumber, "error", seriesErr)
+			} else if book != nil && !reconciledBooks[book.ID] {
+				effDir := s.effectiveLibraryDir(ctx, authorMap[book.AuthorID])
+				if pathUnderDir(path, effDir) {
+					if err := s.books.AddBookFile(ctx, book.ID, detectedFmt, path); err != nil {
+						slog.Error("library scan: failed to update book via series match", "id", book.ID, "error", err)
+					} else {
+						slog.Info("library scan: reconciled book via series position",
+							"series", parsed.Series, "position", parsed.SeriesNumber, "title", book.Title, "path", path)
+						trackedPaths[cleanPath] = true
+						reconciledBooks[book.ID] = true
+						reconciled++
+						matched = true
+					}
+				}
 			}
 		}
 

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -101,7 +101,6 @@ func (s *Scanner) primarySeriesFor(ctx context.Context, book *models.Book) (seri
 	return title, pos
 }
 
-
 // effectiveLibraryDir returns the library root to use for the given author.
 // Priority: (1) author's explicit RootFolderID, (2) library.defaultRootFolderId
 // setting, (3) global libraryDir from env-var.


### PR DESCRIPTION
## Summary

- Adds `Series` and `SeriesNumber` fields to `ParsedFile`
- `ParseFilename` now extracts series info from bracket notation (`[Series Name #N]`, `[Series Name, Book 1]`) and paren notation (`(Series Name #N)`, `(Series Name, Book 1)`) — series name must start with a letter to avoid false-positives on ISBNs and years
- Falls back to parent directory name for ABS-style layouts where the folder carries the series+number (`Author/Series Name, Book 1/title.m4b`)
- `ScanLibrary` falls back to series+position matching when ASIN and title+author both fail — exact series-title match + position, returns no match when ambiguous (two series with the same name both have a book at that position)
- Adds `WithSeriesRepo` builder to `Scanner`
- New `GetBookBySeriesPosition` repo method in `SeriesRepo`

## Fixes library scan failures for users migrating from LazyLibrarian

Users whose existing libraries have series-based filenames like:
```
[Dune Chronicles #1] Dune - Frank Herbert.m4b
[Stormlight Archive, Book 1] The Way of Kings - Brandon Sanderson.epub
(Dune Chronicles, Book 1) Dune - Frank Herbert.m4b
```

These previously returned unmatched on library scan. With this PR they reconcile correctly against wanted books via series name + position.

## Notes

- ABS layout `Author/Series Name/01 - Title.m4b` (no number in folder name) still relies on tag reading or title match — the parser can't infer series number from a plain folder name without a position
- ABS layout `Author/Series Name, Book 1/Title.m4b` (number in folder name via paren) is fully supported

## Test plan
- [x] `go test ./internal/importer/... ./internal/db/...`