### PR TITLE
fix(recommender): detect and exclude box sets, omnibuses, and anthology contributions

### DIFF
--- a/internal/recommender/candidates.go
+++ b/internal/recommender/candidates.go
@@ -294,6 +294,25 @@ func GenerateListCross(
 	return candidates
 }
 
+// looksLikeCollection returns true when the title appears to describe a box
+// set, omnibus, anthology, or other multi-work collection rather than a single
+// book. The check is intentionally broad: some false positives (e.g. "Complete
+// Guide to Go Programming") are acceptable to keep the logic simple.
+func looksLikeCollection(title string) bool {
+	lower := strings.ToLower(title)
+	keywords := []string{
+		"complete", "collected", "omnibus", "boxed set", "box set", "anthology",
+		"the best of", "stories of", "tales of", "(omnibus)", "(collection)",
+		"complete works", "complete collection",
+	}
+	for _, kw := range keywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
 // genreToSubjectSlug converts a genre string (e.g. "Science Fiction") to an
 // OpenLibrary subject slug (e.g. "science_fiction").
 func genreToSubjectSlug(genre string) string {

--- a/internal/recommender/candidates_test.go
+++ b/internal/recommender/candidates_test.go
@@ -8,6 +8,27 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
+func TestLooksLikeCollection(t *testing.T) {
+	tests := []struct {
+		title string
+		want  bool
+	}{
+		{"The Complete Asimov Stories", true},
+		{"Collected Poems", true},
+		{"Dune Omnibus", true},
+		{"Box Set: Stormlight Archive", true},
+		{"The Best of Philip K. Dick", true},
+		{"Dune", false},
+		{"Complete Guide to Go Programming", true}, // false positive we accept
+		{"The Collected Works of Terry Pratchett, Vol. 3", true},
+	}
+	for _, tt := range tests {
+		if got := looksLikeCollection(tt.title); got != tt.want {
+			t.Errorf("looksLikeCollection(%q) = %v, want %v", tt.title, got, tt.want)
+		}
+	}
+}
+
 func TestGenreToSubjectSlug(t *testing.T) {
 	tests := []struct {
 		in, want string

--- a/internal/recommender/recommender.go
+++ b/internal/recommender/recommender.go
@@ -175,6 +175,9 @@ func hardFilter(candidates []models.RecommendationCandidate, p *UserProfile) []m
 		if c.RatingsCount >= 50 && c.Rating > 0 && c.Rating < 3.0 {
 			continue
 		}
+		if looksLikeCollection(c.Title) {
+			continue
+		}
 		// Deduplicate by foreign ID.
 		if seen[c.ForeignID] {
 			continue


### PR DESCRIPTION
## Summary

- Adds `looksLikeCollection(title string) bool` to `internal/recommender/candidates.go`; returns true when the title (case-insensitive) contains any of: `complete`, `collected`, `omnibus`, `boxed set`, `box set`, `anthology`, `the best of`, `stories of`, `tales of`, `(omnibus)`, `(collection)`, `complete works`, `complete collection`
- Wires the check into `hardFilter` in `internal/recommender/recommender.go` so matching candidates are suppressed from the Discover page
- Adds `TestLooksLikeCollection` in `candidates_test.go` covering 8 cases (7 matches, 1 clean title)

Closes #361

## Test plan

- [ ] `go test ./internal/recommender/...` passes
- [ ] Titles like "Dune Omnibus", "The Complete Asimov Stories", "Box Set: Stormlight Archive" do not surface in Discover
- [ ] Clean single-book titles like "Dune" are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)