### PR TITLE
fix(downloader): apply url_base when constructing client URLs

### DIFF
--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -47,19 +47,19 @@ func ProtocolForClient(clientType string) string {
 func TestClient(ctx context.Context, client *models.DownloadClient) error {
 	switch client.Type {
 	case "transmission":
-		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		return trans.Test(ctx)
 	case "qbittorrent":
-		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		return qb.Test(ctx)
 	case "deluge":
-		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL, client.URLBase)
 		return dl.Test(ctx)
 	case "nzbget":
-		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		return ng.Test(ctx)
 	default:
-		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL, client.URLBase)
 		return sab.Test(ctx)
 	}
 }
@@ -72,7 +72,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 
 	switch client.Type {
 	case "transmission":
-		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		// Transmission's download-dir must be an absolute path. The Category
 		// field is repurposed as an optional path override for Transmission; if
 		// the user left it as a bare label (e.g. "books") we pass "" so
@@ -91,7 +91,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		result.RemoteID = strconv.FormatInt(torrentID, 10)
 		return result, nil
 	case "qbittorrent":
-		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		hash, err := qb.AddTorrent(ctx, sourceURL, client.Category, "")
 		if err != nil {
 			return nil, err
@@ -103,7 +103,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		result.RemoteID = hash
 		return result, nil
 	case "deluge":
-		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL, client.URLBase)
 		hash, err := dl.AddTorrent(ctx, sourceURL, client.Category)
 		if err != nil {
 			return nil, err
@@ -114,7 +114,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		result.RemoteID = hash
 		return result, nil
 	case "nzbget":
-		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		nzbID, err := ng.Add(ctx, sourceURL, title, client.Category, 0)
 		if err != nil {
 			return nil, err
@@ -122,7 +122,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		result.RemoteID = strconv.Itoa(nzbID)
 		return result, nil
 	default:
-		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL, client.URLBase)
 		resp, err := sab.AddURL(ctx, sourceURL, title, client.Category, 0)
 		if err != nil {
 			return nil, err
@@ -144,19 +144,19 @@ func RemoveDownload(ctx context.Context, client *models.DownloadClient, dl *mode
 		if err != nil {
 			return fmt.Errorf("invalid transmission torrent id %q: %w", *dl.TorrentID, err)
 		}
-		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		return trans.RemoveTorrent(ctx, torrentID, deleteFiles)
 	case "qbittorrent":
 		if dl.TorrentID == nil || *dl.TorrentID == "" {
 			return nil
 		}
-		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		return qb.DeleteTorrent(ctx, *dl.TorrentID, deleteFiles)
 	case "deluge":
 		if dl.TorrentID == nil || *dl.TorrentID == "" {
 			return nil
 		}
-		delugeClient := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		delugeClient := deluge.New(client.Host, client.Port, client.Password, client.UseSSL, client.URLBase)
 		return delugeClient.RemoveTorrent(ctx, *dl.TorrentID, deleteFiles)
 	case "nzbget":
 		if dl.SABnzbdNzoID == nil || *dl.SABnzbdNzoID == "" {
@@ -166,13 +166,13 @@ func RemoveDownload(ctx context.Context, client *models.DownloadClient, dl *mode
 		if err != nil {
 			return err
 		}
-		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		return ng.Remove(ctx, nzbID)
 	default:
 		if dl.SABnzbdNzoID == nil || *dl.SABnzbdNzoID == "" {
 			return nil
 		}
-		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL, client.URLBase)
 		return sab.Delete(ctx, *dl.SABnzbdNzoID, deleteFiles)
 	}
 }
@@ -189,7 +189,7 @@ func RemoveDownload(ctx context.Context, client *models.DownloadClient, dl *mode
 func GetStalledIDs(ctx context.Context, client *models.DownloadClient) (map[string]bool, bool, error) {
 	switch client.Type {
 	case "qbittorrent":
-		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		torrents, err := qb.GetTorrents(ctx, client.Category)
 		if err != nil {
 			return nil, true, err
@@ -203,7 +203,7 @@ func GetStalledIDs(ctx context.Context, client *models.DownloadClient) (map[stri
 		}
 		return out, true, nil
 	case "transmission":
-		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		torrents, err := trans.GetTorrents(ctx, client.Category)
 		if err != nil {
 			return nil, true, err
@@ -217,7 +217,7 @@ func GetStalledIDs(ctx context.Context, client *models.DownloadClient) (map[stri
 		}
 		return out, true, nil
 	case "deluge":
-		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL, client.URLBase)
 		torrents, err := dl.GetTorrents(ctx)
 		if err != nil {
 			return nil, true, err
@@ -248,7 +248,7 @@ func GetLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[st
 }
 
 func getSABLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[string]LiveStatus, error) {
-	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL, client.URLBase)
 	queue, err := sab.GetQueue(ctx)
 	if err != nil {
 		return nil, err
@@ -266,7 +266,7 @@ func getSABLiveStatuses(ctx context.Context, client *models.DownloadClient) (map
 }
 
 func getNZBGetLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[string]LiveStatus, error) {
-	ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 	groups, err := ng.GetQueue(ctx)
 	if err != nil {
 		return nil, err
@@ -289,7 +289,7 @@ func getNZBGetLiveStatuses(ctx context.Context, client *models.DownloadClient) (
 
 func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) (map[string]LiveStatus, error) {
 	if client.Type == "transmission" {
-		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 		torrents, err := trans.GetTorrents(ctx, client.Category)
 		if err != nil {
 			return nil, err
@@ -308,7 +308,7 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 	}
 
 	if client.Type == "deluge" {
-		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL)
+		dl := deluge.New(client.Host, client.Port, client.Password, client.UseSSL, client.URLBase)
 		torrents, err := dl.GetTorrents(ctx)
 		if err != nil {
 			return nil, err
@@ -324,7 +324,7 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 		return out, nil
 	}
 
-	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 	torrents, err := qb.GetTorrents(ctx, client.Category)
 	if err != nil {
 		return nil, err

--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -55,14 +55,18 @@ type rpcError struct {
 }
 
 // New creates a Deluge client.
-func New(host string, port int, password string, useSSL bool) *Client {
+func New(host string, port int, password string, useSSL bool, urlBase string) *Client {
 	scheme := "http"
 	if useSSL {
 		scheme = "https"
 	}
+	base := strings.TrimRight(strings.TrimSpace(urlBase), "/")
+	if base != "" && !strings.HasPrefix(base, "/") {
+		base = "/" + base
+	}
 	jar, _ := cookiejar.New(nil)
 	return &Client{
-		baseURL:  fmt.Sprintf("%s://%s:%d", scheme, host, port),
+		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, base),
 		password: password,
 		http:     &http.Client{Timeout: 15 * time.Second, Jar: jar},
 	}

--- a/internal/downloader/deluge/client_test.go
+++ b/internal/downloader/deluge/client_test.go
@@ -164,7 +164,7 @@ func clientFromServer(srv *httptest.Server, password string) *deluge.Client {
 		}
 		port = p
 	}
-	return deluge.New(parts[0], port, password, false)
+	return deluge.New(parts[0], port, password, false, "")
 }
 
 func TestLogin_Success(t *testing.T) {

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -24,13 +25,17 @@ type Client struct {
 
 // New creates a NZBGet client.
 // NZBGet's JSON-RPC endpoint is http://user:pass@host:port/jsonrpc.
-func New(host string, port int, username, password string, useSSL bool) *Client {
+func New(host string, port int, username, password string, useSSL bool, urlBase string) *Client {
 	scheme := "http"
 	if useSSL {
 		scheme = "https"
 	}
+	base := strings.TrimRight(strings.TrimSpace(urlBase), "/")
+	if base != "" && !strings.HasPrefix(base, "/") {
+		base = "/" + base
+	}
 	return &Client{
-		baseURL:  fmt.Sprintf("%s://%s:%d/jsonrpc", scheme, host, port),
+		baseURL:  fmt.Sprintf("%s://%s:%d%s/jsonrpc", scheme, host, port, base),
 		username: username,
 		password: password,
 		http:     &http.Client{Timeout: 15 * time.Second},

--- a/internal/downloader/nzbget/client_test.go
+++ b/internal/downloader/nzbget/client_test.go
@@ -47,7 +47,7 @@ func TestTest_Success(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "user", "pass", false)
+	c := New(host, port, "user", "pass", false, "")
 
 	if err := c.Test(context.Background()); err != nil {
 		t.Fatalf("Test should pass: %v", err)
@@ -62,7 +62,7 @@ func TestTest_AuthFailure(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "bad", "creds", false)
+	c := New(host, port, "bad", "creds", false, "")
 
 	err := c.Test(context.Background())
 	if err == nil {
@@ -79,7 +79,7 @@ func TestTest_EmptyVersion(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", false, "")
 
 	err := c.Test(context.Background())
 	if err == nil {
@@ -97,7 +97,7 @@ func TestAdd(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "user", "pass", false)
+	c := New(host, port, "user", "pass", false, "")
 
 	id, err := c.Add(context.Background(), "https://example.com/file.nzb", "Test Book", "books", 0)
 	if err != nil {
@@ -119,7 +119,7 @@ func TestAdd_Rejected(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", false, "")
 
 	_, err := c.Add(context.Background(), "https://example.com/bad.nzb", "Bad NZB", "books", 0)
 	if err == nil {
@@ -151,7 +151,7 @@ func TestGetQueue(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", false, "")
 
 	groups, err := c.GetQueue(context.Background())
 	if err != nil {
@@ -200,7 +200,7 @@ func TestGetHistory(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", false, "")
 
 	items, err := c.GetHistory(context.Background())
 	if err != nil {
@@ -227,7 +227,7 @@ func TestRemove(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", false, "")
 
 	if err := c.Remove(context.Background(), 101); err != nil {
 		t.Fatalf("Remove: %v", err)
@@ -254,7 +254,7 @@ func TestRemoveHistory(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "", "", false)
+	c := New(host, port, "", "", false, "")
 
 	if err := c.RemoveHistory(context.Background(), 202); err != nil {
 		t.Fatalf("RemoveHistory: %v", err)
@@ -324,7 +324,7 @@ func TestBasicAuth(t *testing.T) {
 	defer srv.Close()
 
 	host, port := serverHostPort(t, srv.URL)
-	c := New(host, port, "admin", "secret", false)
+	c := New(host, port, "admin", "secret", false, "")
 
 	if err := c.Test(context.Background()); err != nil {
 		t.Fatalf("Test: %v", err)

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -24,10 +24,6 @@ var hashPollTimeout = 30 * time.Second
 // Authentication is cookie-based: Login() obtains a SID cookie which is
 // stored in the embedded http.Client's cookie jar and sent automatically on
 // subsequent requests.
-//
-// Field mapping for DownloadClient storage:
-//   - APIKey  → password  (qBittorrent uses username/password, not an API key)
-//   - URLBase → username  (reused since qBittorrent ignores URL base)
 type Client struct {
 	baseURL  string
 	username string
@@ -38,17 +34,18 @@ type Client struct {
 }
 
 // New creates a qBittorrent client.
-// username and password map to the DownloadClient's URLBase and APIKey fields
-// respectively (see comment on the Client struct).
-func New(host string, port int, username, password string, useSSL bool) *Client {
+func New(host string, port int, username, password string, useSSL bool, urlBase string) *Client {
 	scheme := "http"
 	if useSSL {
 		scheme = "https"
 	}
-
+	base := strings.TrimRight(strings.TrimSpace(urlBase), "/")
+	if base != "" && !strings.HasPrefix(base, "/") {
+		base = "/" + base
+	}
 	jar, _ := cookiejar.New(nil)
 	return &Client{
-		baseURL:  fmt.Sprintf("%s://%s:%d", scheme, host, port),
+		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, base),
 		username: username,
 		password: password,
 		http:     &http.Client{Timeout: 15 * time.Second, Jar: jar},

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -36,13 +36,13 @@ func (lc *logCatcher) Records() []slog.Record {
 
 // newTestClient creates a Client pointing at the given test server URL.
 func newTestClient(serverURL, username, password string) *Client {
-	c := New("localhost", 8080, username, password, false)
+	c := New("localhost", 8080, username, password, false, "")
 	c.baseURL = serverURL
 	return c
 }
 
 func TestNew(t *testing.T) {
-	c := New("myhost", 8080, "admin", "secret", false)
+	c := New("myhost", 8080, "admin", "secret", false, "")
 	if c.baseURL != "http://myhost:8080" {
 		t.Errorf("baseURL: want %q, got %q", "http://myhost:8080", c.baseURL)
 	}
@@ -53,7 +53,7 @@ func TestNew(t *testing.T) {
 		t.Error("should not be logged in on construction")
 	}
 
-	cs := New("securehost", 443, "u", "p", true)
+	cs := New("securehost", 443, "u", "p", true, "")
 	if cs.baseURL != "https://securehost:443" {
 		t.Errorf("SSL baseURL: got %q", cs.baseURL)
 	}

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -20,13 +21,17 @@ type Client struct {
 }
 
 // New creates a SABnzbd client.
-func New(host string, port int, apiKey string, useSSL bool) *Client {
+func New(host string, port int, apiKey string, useSSL bool, urlBase string) *Client {
 	scheme := "http"
 	if useSSL {
 		scheme = "https"
 	}
+	base := strings.TrimRight(strings.TrimSpace(urlBase), "/")
+	if base != "" && !strings.HasPrefix(base, "/") {
+		base = "/" + base
+	}
 	return &Client{
-		baseURL: fmt.Sprintf("%s://%s:%d", scheme, host, port),
+		baseURL: fmt.Sprintf("%s://%s:%d%s", scheme, host, port, base),
 		apiKey:  apiKey,
 		http:    &http.Client{Timeout: 15 * time.Second},
 	}

--- a/internal/downloader/sabnzbd/client_test.go
+++ b/internal/downloader/sabnzbd/client_test.go
@@ -23,7 +23,7 @@ func TestAddURL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", false, "")
 	c.baseURL = srv.URL
 
 	resp, err := c.AddURL(context.Background(), "https://example.com/nzb/123", "Test Book", "books", 0)
@@ -61,7 +61,7 @@ func TestGetQueue(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", false, "")
 	c.baseURL = srv.URL
 
 	queue, err := c.GetQueue(context.Background())
@@ -99,7 +99,7 @@ func TestGetHistory(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", false, "")
 	c.baseURL = srv.URL
 
 	history, err := c.GetHistory(context.Background(), "books", 20)
@@ -122,7 +122,7 @@ func TestGetCategories(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", false, "")
 	c.baseURL = srv.URL
 
 	cats, err := c.GetCategories(context.Background())
@@ -146,7 +146,7 @@ func TestDeleteHistory(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", false, "")
 	c.baseURL = srv.URL
 
 	if err := c.DeleteHistory(context.Background(), "SABnzbd_nzo_def456", false); err != nil {
@@ -175,7 +175,7 @@ func TestTest(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("127.0.0.1", 0, "testkey", false)
+	c := New("127.0.0.1", 0, "testkey", false, "")
 	c.baseURL = srv.URL
 
 	err := c.Test(context.Background())

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -33,7 +33,7 @@ type Client struct {
 
 // New creates a Transmission client.
 // username and password are optional for Transmission RPC authentication.
-func New(host string, port int, username, password string, useSSL bool) *Client {
+func New(host string, port int, username, password string, useSSL bool, urlBase string) *Client {
 	scheme := "http"
 	if useSSL {
 		scheme = "https"
@@ -45,7 +45,7 @@ func New(host string, port int, username, password string, useSSL bool) *Client 
 		http:     &http.Client{Timeout: 15 * time.Second},
 	}
 
-	rpcURL, err := buildRPCURL(scheme, host, port)
+	rpcURL, err := buildRPCURL(scheme, host, port, urlBase)
 	if err != nil {
 		client.initErr = err
 	} else {
@@ -206,7 +206,7 @@ func (c *Client) buildRequest(ctx context.Context, method string, args map[strin
 	return req, nil
 }
 
-func buildRPCURL(scheme, host string, port int) (*url.URL, error) {
+func buildRPCURL(scheme, host string, port int, urlBase string) (*url.URL, error) {
 	if err := validateHost(host); err != nil {
 		return nil, err
 	}
@@ -214,10 +214,15 @@ func buildRPCURL(scheme, host string, port int) (*url.URL, error) {
 		return nil, fmt.Errorf("invalid Transmission port %d", port)
 	}
 
+	base := strings.TrimRight(strings.TrimSpace(urlBase), "/")
+	if base != "" && !strings.HasPrefix(base, "/") {
+		base = "/" + base
+	}
+
 	return &url.URL{
 		Scheme: scheme,
 		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
-		Path:   "/transmission/rpc",
+		Path:   base + "/transmission/rpc",
 	}, nil
 }
 

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -10,7 +10,7 @@ import (
 
 // newTestClient creates a Client pointing at the given test server URL.
 func newTestClient(serverURL, username, password string) *Client {
-	c := New("localhost", 9091, username, password, false)
+	c := New("localhost", 9091, username, password, false, "")
 	c.baseURL = serverURL
 	parsed, err := url.Parse(serverURL)
 	if err != nil {
@@ -21,7 +21,7 @@ func newTestClient(serverURL, username, password string) *Client {
 }
 
 func TestNew(t *testing.T) {
-	c := New("myhost", 9091, "admin", "secret", false)
+	c := New("myhost", 9091, "admin", "secret", false, "")
 	if c.baseURL != "http://myhost:9091/transmission/rpc" {
 		t.Errorf("baseURL: want %q, got %q", "http://myhost:9091/transmission/rpc", c.baseURL)
 	}
@@ -32,14 +32,14 @@ func TestNew(t *testing.T) {
 		t.Error("credentials not stored correctly")
 	}
 
-	cs := New("securehost", 443, "u", "p", true)
+	cs := New("securehost", 443, "u", "p", true, "")
 	if cs.baseURL != "https://securehost:443/transmission/rpc" {
 		t.Errorf("SSL baseURL: got %q", cs.baseURL)
 	}
 }
 
 func TestNew_InvalidHost(t *testing.T) {
-	c := New("http://bad-host", 9091, "admin", "secret", false)
+	c := New("http://bad-host", 9091, "admin", "secret", false, "")
 	if c.initErr == nil {
 		t.Fatal("expected invalid host to be rejected")
 	}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -258,7 +258,7 @@ func (s *Scanner) markDownloadFailed(ctx context.Context, dl *models.Download, m
 
 // checkSABnzbdDownloads polls SABnzbd for status changes.
 func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.DownloadClient) {
-	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL)
+	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.UseSSL, client.URLBase)
 
 	// Check history for completed downloads (no category filter — match by NZO ID)
 	history, err := sab.GetHistory(ctx, "", 50)
@@ -296,7 +296,7 @@ func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.Down
 
 // checkNZBGetDownloads polls NZBGet for status changes using its JSON-RPC API.
 func (s *Scanner) checkNZBGetDownloads(ctx context.Context, client *models.DownloadClient) {
-	ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 
 	// Check history for completed/failed downloads (matched by NZBID stored as sabnzbd_nzo_id).
 	history, err := ng.GetHistory(ctx)
@@ -344,7 +344,7 @@ func (s *Scanner) tryImportNZBGet(ctx context.Context, ng *nzbget.Client, dl *mo
 
 // checkTransmissionDownloads polls Transmission for status changes.
 func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models.DownloadClient) {
-	trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 
 	// Get all torrents — Category is used as the download directory filter so
 	// Bindery only sees its own torrents on a shared Transmission instance.
@@ -398,7 +398,7 @@ func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models
 
 // checkQbittorrentDownloads polls qBittorrent for status changes.
 func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.DownloadClient) {
-	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL)
+	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.UseSSL, client.URLBase)
 
 	torrents, err := qb.GetTorrents(ctx, client.Category)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Each downloader's `New()` constructor now accepts a `urlBase string` parameter and incorporates it into the `baseURL` used for all HTTP requests
- URL base normalisation (ensure leading `/`, strip trailing `/`, ignore blank) is applied inline in each constructor — no shared helper needed since each package is self-contained
- The old `qbittorrent` workaround comment ("URLBase → username (reused since qBittorrent ignores URL base)") is removed now that the field is properly threaded through
- All call sites in `internal/downloader/adapter.go` and `internal/importer/scanner.go` pass `client.URLBase`
- All test files updated to match the new function signatures (added `""` as the last argument to preserve existing test behaviour)

Closes #369

## Packages changed

| Package | Change |
|---|---|
| `sabnzbd` | `New(host, port, apiKey, useSSL, urlBase)` — base prepended before `/api` |
| `nzbget` | `New(host, port, user, pass, useSSL, urlBase)` — base prepended before `/jsonrpc` |
| `qbittorrent` | `New(host, port, user, pass, useSSL, urlBase)` — base prepended before `/api/v2/...` paths |
| `transmission` | `New(host, port, user, pass, useSSL, urlBase)` + `buildRPCURL` updated — base prepended before `/transmission/rpc` |
| `deluge` | `New(host, port, pass, useSSL, urlBase)` — base prepended before `/json` |

## Test plan

- [ ] `go build ./...` — compiles clean
- [ ] `go test ./internal/downloader/...` — all 6 packages pass
- [ ] Manual: configure a SABnzbd (or any client) behind a reverse proxy at `/sabnzbd`; set URL Base to `/sabnzbd`; verify API calls reach the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)