### PR TITLE
fix: NZBGet protocol selector, imageproxy race, CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           args: --timeout=5m
       - name: govulncheck
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          go install golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77
           govulncheck ./...
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -8,9 +8,7 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 # Promotes a tagged release from dev to production by opening a PR that bumps
 # charts/bindery/values.yaml on main. ArgoCD prod app picks up the change when
@@ -18,6 +16,9 @@ permissions:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -57,7 +57,8 @@ stopwords = [
   "placeholder",
   "REPLACE_ME",
   "YOUR_KEY_HERE",
-  "test-only"
+  "test-only",
+  "test-secret-"
 ]
 # Paths excluded globally from all rules.
 paths = [

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -31,7 +31,7 @@ func newAuthFixture(t *testing.T) (*AuthHandler, *db.UserRepo, *db.SettingsRepo,
 	ctx := context.Background()
 	// Session secret must exist before any issueSession call — production
 	// seeds this at bootstrap, tests must do the same or verification fails.
-	if err := settings.Set(ctx, SettingAuthSessionSecret, "test-secret-32-bytes-long-enough"); err != nil {
+	if err := settings.Set(ctx, SettingAuthSessionSecret, "test-secret-32-bytes-long-enough"); err != nil { // gitleaks:allow
 		t.Fatal(err)
 	}
 	lim := auth.NewLoginLimiter(5, 15*time.Minute)

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -132,15 +132,28 @@ func (h *ImageProxyHandler) Serve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Write to cache (best-effort — a write failure is not fatal).
-	// Atomic: write to .tmp, then rename so readers never see partial files.
+	// Unique temp files prevent concurrent goroutines serving the same URL from
+	// clobbering each other mid-write before the atomic rename.
 	if mkErr := os.MkdirAll(filepath.Dir(imgFile), imageDirMode); mkErr == nil { // #nosec G301 G304 G703 -- path derived from sha256(url), not user input
-		tmp := imgFile + ".tmp"
-		if err := os.WriteFile(tmp, body, imageCacheMode); err == nil { // #nosec
-			_ = os.Rename(tmp, imgFile) // #nosec
+		if f, ferr := os.CreateTemp(filepath.Dir(imgFile), ".img-*"); ferr == nil { // #nosec G304
+			if _, werr := f.Write(body); werr == nil {
+				_ = f.Chmod(imageCacheMode)
+				f.Close()
+				_ = os.Rename(f.Name(), imgFile) // #nosec G304
+			} else {
+				f.Close()
+				_ = os.Remove(f.Name())
+			}
 		}
-		ctTmp := ctFile + ".tmp"
-		if err := os.WriteFile(ctTmp, []byte(ct), imageCacheMode); err == nil { // #nosec
-			_ = os.Rename(ctTmp, ctFile) // #nosec
+		if f, ferr := os.CreateTemp(filepath.Dir(imgFile), ".ct-*"); ferr == nil { // #nosec G304
+			if _, werr := f.Write([]byte(ct)); werr == nil {
+				_ = f.Chmod(imageCacheMode)
+				f.Close()
+				_ = os.Rename(f.Name(), ctFile) // #nosec G304
+			} else {
+				f.Close()
+				_ = os.Remove(f.Name())
+			}
 		}
 	}
 

--- a/internal/db/download_clients.go
+++ b/internal/db/download_clients.go
@@ -24,7 +24,8 @@ func isCredentialClient(clientType string) bool {
 }
 
 func hydrateClientCredentials(c *models.DownloadClient) {
-	if isCredentialClient(c.Type) {
+	switch c.Type {
+	case "qbittorrent", "transmission":
 		// Backward compatibility: older rows stored credentials in url_base/api_key.
 		if strings.TrimSpace(c.Username) == "" {
 			c.Username = strings.TrimSpace(c.URLBase)
@@ -32,11 +33,13 @@ func hydrateClientCredentials(c *models.DownloadClient) {
 		if c.Password == "" {
 			c.Password = c.APIKey
 		}
-		return
+	case "nzbget", "deluge":
+		// These clients use username/password directly — preserve as stored.
+	default:
+		// SABnzbd authenticates via api_key, not username/password.
+		c.Username = ""
+		c.Password = ""
 	}
-	// Non-credential clients should not expose username/password values.
-	c.Username = ""
-	c.Password = ""
 }
 
 func normalizeClientCredentialStorage(c *models.DownloadClient) {
@@ -131,19 +134,18 @@ func (r *DownloadClientRepo) GetFirstEnabled(ctx context.Context) (*models.Downl
 func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, protocol string) (*models.DownloadClient, error) {
 	var c models.DownloadClient
 	var enabled, useSSL int
-	query := `
-		SELECT ` + downloadClientSelectColumns + `
-		FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority LIMIT 1`
 	var err error
 	if protocol == "torrent" {
 		err = r.db.QueryRowContext(ctx, `
 			SELECT `+downloadClientSelectColumns+`
-			FROM download_clients WHERE enabled=1 AND type IN (?, ?) ORDER BY priority LIMIT 1`, "qbittorrent", "transmission").
+			FROM download_clients WHERE enabled=1 AND type IN (?, ?, ?) ORDER BY priority LIMIT 1`, "qbittorrent", "transmission", "deluge").
 			Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
 				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
 				&enabled, &c.CreatedAt, &c.UpdatedAt)
 	} else {
-		err = r.db.QueryRowContext(ctx, query, "sabnzbd").
+		err = r.db.QueryRowContext(ctx, `
+			SELECT `+downloadClientSelectColumns+`
+			FROM download_clients WHERE enabled=1 AND type IN (?, ?) ORDER BY priority LIMIT 1`, "sabnzbd", "nzbget").
 			Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
 				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
 				&enabled, &c.CreatedAt, &c.UpdatedAt)
@@ -171,11 +173,11 @@ func (r *DownloadClientRepo) GetEnabledByProtocol(ctx context.Context, protocol 
 	if protocol == "torrent" {
 		rows, err = r.db.QueryContext(ctx, `
 			SELECT `+downloadClientSelectColumns+`
-			FROM download_clients WHERE enabled=1 AND type IN (?, ?) ORDER BY priority`, "qbittorrent", "transmission")
+			FROM download_clients WHERE enabled=1 AND type IN (?, ?, ?) ORDER BY priority`, "qbittorrent", "transmission", "deluge")
 	} else {
 		rows, err = r.db.QueryContext(ctx, `
 			SELECT `+downloadClientSelectColumns+`
-			FROM download_clients WHERE enabled=1 AND type=? ORDER BY priority`, "sabnzbd")
+			FROM download_clients WHERE enabled=1 AND type IN (?, ?) ORDER BY priority`, "sabnzbd", "nzbget")
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- **NZBGet completely broken for grabs** — `GetFirstEnabledByProtocol` and `GetEnabledByProtocol` only queried `sabnzbd` for the `usenet` protocol; NZBGet rows were never returned. Any user with only NZBGet configured got "no enabled download clients" on every grab. Added `nzbget` to both usenet IN-lists.
- **NZBGet credentials zeroed on read** — `hydrateClientCredentials` blanked `username`/`password` for all non-qBit/Transmission clients, silently wiping NZBGet auth before it reached the adapter. Fixed with a `switch` so nzbget/deluge pass credentials through as-is.
- **Deluge missing from torrent protocol query** — both protocol-selector functions were also missing `deluge` from the torrent `IN` list. Fixed in the same pass.
- **Imageproxy concurrent-write race** (`TestImageProxy_ConcurrentSameURL` failing on v1.2.5 tag CI) — all goroutines serving the same URL wrote to the shared `imgFile+".tmp"` path; one goroutine's `O_TRUNC` open could zero the file while another renamed it into the cache. Replaced fixed `.tmp` paths with `os.CreateTemp()` so each goroutine gets a unique temp file. Test now passes under `-race`.
- **Gitleaks false positive silenced** — `internal/api/auth_test.go` session-secret fixture string was flagging the Security workflow on every push. Added `# gitleaks:allow` inline and `test-secret-` to `.gitleaks.toml` stopwords.
- **OpenSSF Scorecard fixes** — scoped `promote.yml` token permissions to job level (was top-level `contents: write`); pinned `govulncheck` install to commit hash instead of semver tag to resolve `downloadThenRun`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/db/... ./internal/api/...` — pass
- [x] `go test -race -run TestImageProxy ./internal/api/...` — pass (was failing before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)