### PR TITLE
chore: bump chart default tag to 1.2.6

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.2.3"
+  tag: "1.2.6"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Updates `charts/bindery/values.yaml` default image tag from 1.2.3 → 1.2.6 so the production ArgoCD app (which reads `values.yaml` from `main`) deploys the correct release.