### PR TITLE
Issue/370

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **Arr-compatible queue endpoint for Harpoon integrations** (#370) — `GET /api/queue` now returns a Sonarr/Radarr-style queue payload with `totalRecords`, queue records, live `size`/`sizeleft`, downloader status, client name, remote download ID, protocol, optional pagination, and sorting. The existing `GET /api/v1/queue` UI response remains unchanged.
+
 ## [v1.2.6] — 2026-04-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -294,8 +294,9 @@ GET    /api/v1/author                    - list authors
 POST   /api/v1/author                    - add author (triggers async book fetch)
 GET    /api/v1/book?status=wanted        - filter books by status
 POST   /api/v1/book/{id}/search          - manual indexer search for a book
-GET    /api/v1/queue                     - active downloads with live SABnzbd overlay
+GET    /api/v1/queue                     - active downloads with live downloader overlay
 POST   /api/v1/queue/grab                - submit a search result to download client
+GET    /api/queue                        - *arr-compatible queue for external tools
 GET    /api/v1/history                   - grab/import/failure events
 POST   /api/v1/history/{id}/blocklist    - add a history event's release to the blocklist
 GET    /api/v1/blocklist                 - blocked releases

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -377,6 +377,14 @@ func main() {
 		proxyCIDRs:     trustedCIDRs,
 	}
 
+	r.Route("/api", func(r chi.Router) {
+		r.Use(auth.Middleware(authProvider))
+		r.Use(auth.RequireXRequestedWith)
+		r.Use(auth.RequireCSRFToken(authProvider.SessionSecret))
+
+		r.Get("/queue", queueHandler.ListArrCompatible)
+	})
+
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(auth.Middleware(authProvider))
 		r.Use(auth.RequireXRequestedWith)

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/vavallee/bindery/internal/db"
@@ -41,47 +44,68 @@ type QueueItem struct {
 	Speed      string `json:"speed,omitempty"`
 }
 
-func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
-	downloads, err := h.downloads.List(r.Context())
+type enrichedQueueItem struct {
+	Download   models.Download
+	ClientName string
+	RemoteID   string
+	Live       downloader.LiveStatus
+	HasLive    bool
+	PollFailed bool
+}
+
+type liveStatusResult struct {
+	client        *models.DownloadClient
+	statuses      map[string]downloader.LiveStatus
+	usesTorrentID bool
+	pollFailed    bool
+}
+
+func (h *QueueHandler) enrichedQueueItems(ctx context.Context) ([]enrichedQueueItem, error) {
+	downloads, err := h.downloads.List(ctx)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
+		return nil, err
 	}
 
-	items := make([]QueueItem, len(downloads))
+	items := make([]enrichedQueueItem, len(downloads))
 	for i, d := range downloads {
-		items[i] = QueueItem{Download: d}
-	}
-
-	type liveStatusResult struct {
-		statuses      map[string]downloader.LiveStatus
-		usesTorrentID bool
+		items[i] = enrichedQueueItem{
+			Download: d,
+			RemoteID: storedDownloadID(d),
+		}
 	}
 
 	statusByClientID := make(map[int64]liveStatusResult)
 	for i, item := range items {
-		if item.DownloadClientID == nil {
+		if item.Download.DownloadClientID == nil {
 			continue
 		}
 
-		clientID := *item.DownloadClientID
+		clientID := *item.Download.DownloadClientID
 		result, ok := statusByClientID[clientID]
 		if !ok {
-			client, err := h.clients.GetByID(r.Context(), clientID)
-			if err != nil || client == nil || !client.Enabled {
+			client, err := h.clients.GetByID(ctx, clientID)
+			if err != nil || client == nil {
 				statusByClientID[clientID] = liveStatusResult{}
 				continue
 			}
 
-			statuses, usesTorrentID, err := downloader.GetLiveStatuses(r.Context(), client)
-			if err != nil {
-				statusByClientID[clientID] = liveStatusResult{}
-				continue
+			result.client = client
+			if client.Enabled {
+				statuses, usesTorrentID, err := downloader.GetLiveStatuses(ctx, client)
+				if err != nil {
+					result.pollFailed = true
+				} else {
+					result.statuses = statuses
+					result.usesTorrentID = usesTorrentID
+				}
 			}
-
-			result = liveStatusResult{statuses: statuses, usesTorrentID: usesTorrentID}
 			statusByClientID[clientID] = result
 		}
+
+		if result.client != nil {
+			items[i].ClientName = result.client.Name
+		}
+		items[i].PollFailed = result.pollFailed
 
 		if len(result.statuses) == 0 {
 			continue
@@ -89,25 +113,286 @@ func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
 
 		var remoteID string
 		if result.usesTorrentID {
-			if item.TorrentID == nil {
+			if item.Download.TorrentID == nil {
 				continue
 			}
-			remoteID = *item.TorrentID
+			remoteID = strings.ToLower(*item.Download.TorrentID)
 		} else {
-			if item.SABnzbdNzoID == nil {
+			if item.Download.SABnzbdNzoID == nil {
 				continue
 			}
-			remoteID = *item.SABnzbdNzoID
+			remoteID = *item.Download.SABnzbdNzoID
 		}
 
+		items[i].RemoteID = remoteID
 		if status, ok := result.statuses[remoteID]; ok {
-			items[i].Percentage = status.Percentage
-			items[i].TimeLeft = status.TimeLeft
-			items[i].Speed = status.Speed
+			items[i].Live = status
+			items[i].HasLive = true
+		}
+	}
+
+	return items, nil
+}
+
+func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
+	enriched, err := h.enrichedQueueItems(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	items := make([]QueueItem, len(enriched))
+	for i, item := range enriched {
+		items[i] = QueueItem{Download: item.Download}
+		if item.HasLive {
+			items[i].Percentage = item.Live.Percentage
+			items[i].TimeLeft = item.Live.TimeLeft
+			items[i].Speed = item.Live.Speed
 		}
 	}
 
 	writeJSON(w, http.StatusOK, items)
+}
+
+type arrQueueResponse struct {
+	Page          int              `json:"page,omitempty"`
+	PageSize      int              `json:"pageSize,omitempty"`
+	SortKey       string           `json:"sortKey,omitempty"`
+	SortDirection string           `json:"sortDirection,omitempty"`
+	TotalRecords  int              `json:"totalRecords"`
+	Records       []arrQueueRecord `json:"records"`
+}
+
+type arrQueueRecord struct {
+	ID                    int64  `json:"id"`
+	BookID                int64  `json:"bookId"`
+	Title                 string `json:"title"`
+	Status                string `json:"status"`
+	TrackedDownloadStatus string `json:"trackedDownloadStatus"`
+	Size                  int64  `json:"size"`
+	SizeLeft              int64  `json:"sizeleft"`
+	DownloadClient        string `json:"downloadClient"`
+	DownloadID            string `json:"downloadId"`
+	Protocol              string `json:"protocol"`
+}
+
+// ListArrCompatible exposes a small Sonarr/Radarr-style queue payload for
+// external tools such as Harpoon. The existing /api/v1/queue UI shape remains
+// unchanged.
+func (h *QueueHandler) ListArrCompatible(w http.ResponseWriter, r *http.Request) {
+	enriched, err := h.enrichedQueueItems(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	records := make([]arrQueueRecord, len(enriched))
+	for i, item := range enriched {
+		bookID := int64(0)
+		if item.Download.BookID != nil {
+			bookID = *item.Download.BookID
+		}
+		records[i] = arrQueueRecord{
+			ID:                    item.Download.ID,
+			BookID:                bookID,
+			Title:                 item.Download.Title,
+			Status:                string(item.Download.Status),
+			TrackedDownloadStatus: trackedDownloadStatus(item),
+			Size:                  queueItemSize(item),
+			SizeLeft:              queueItemSizeLeft(item),
+			DownloadClient:        item.ClientName,
+			DownloadID:            item.RemoteID,
+			Protocol:              item.Download.Protocol,
+		}
+	}
+
+	opts := parseArrQueueOptions(r)
+	sortArrQueueRecords(records, opts.sortKey, opts.sortDirection)
+	total := len(records)
+	records = paginateArrQueueRecords(records, opts.page, opts.pageSize)
+
+	resp := arrQueueResponse{
+		TotalRecords: total,
+		Records:      records,
+	}
+	if opts.pageSize > 0 {
+		resp.Page = opts.page
+		resp.PageSize = opts.pageSize
+	}
+	if opts.sortKey != "" {
+		resp.SortKey = opts.sortKey
+		resp.SortDirection = opts.sortDirection
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+type arrQueueOptions struct {
+	page          int
+	pageSize      int
+	sortKey       string
+	sortDirection string
+}
+
+func parseArrQueueOptions(r *http.Request) arrQueueOptions {
+	q := r.URL.Query()
+	opts := arrQueueOptions{
+		page:          1,
+		sortKey:       strings.TrimSpace(q.Get("sortKey")),
+		sortDirection: strings.ToLower(strings.TrimSpace(q.Get("sortDirection"))),
+	}
+	if opts.sortDirection != "descending" && opts.sortDirection != "desc" {
+		opts.sortDirection = "ascending"
+	}
+	if page, err := strconv.Atoi(q.Get("page")); err == nil && page > 0 {
+		opts.page = page
+	}
+	if pageSize, err := strconv.Atoi(q.Get("pageSize")); err == nil && pageSize > 0 {
+		opts.pageSize = pageSize
+	}
+	return opts
+}
+
+func sortArrQueueRecords(records []arrQueueRecord, sortKey, sortDirection string) {
+	sortKey = strings.ToLower(sortKey)
+	if sortKey == "" {
+		return
+	}
+	desc := sortDirection == "descending" || sortDirection == "desc"
+	less := func(i, j int) bool {
+		a, b := records[i], records[j]
+		switch sortKey {
+		case "id":
+			return a.ID < b.ID
+		case "title":
+			return strings.ToLower(a.Title) < strings.ToLower(b.Title)
+		case "status":
+			return a.Status < b.Status
+		case "size":
+			return a.Size < b.Size
+		case "sizeleft":
+			return a.SizeLeft < b.SizeLeft
+		case "downloadclient":
+			return strings.ToLower(a.DownloadClient) < strings.ToLower(b.DownloadClient)
+		case "protocol":
+			return a.Protocol < b.Protocol
+		default:
+			return false
+		}
+	}
+	sort.SliceStable(records, func(i, j int) bool {
+		if desc {
+			return less(j, i)
+		}
+		return less(i, j)
+	})
+}
+
+func paginateArrQueueRecords(records []arrQueueRecord, page, pageSize int) []arrQueueRecord {
+	if pageSize <= 0 {
+		return records
+	}
+	if page <= 0 {
+		page = 1
+	}
+	if len(records) == 0 {
+		return []arrQueueRecord{}
+	}
+	if page > 1 && page-1 > (len(records)-1)/pageSize {
+		return []arrQueueRecord{}
+	}
+	start := (page - 1) * pageSize
+	end := len(records)
+	if pageSize < len(records)-start {
+		end = start + pageSize
+	}
+	return records[start:end]
+}
+
+func storedDownloadID(d models.Download) string {
+	if d.TorrentID != nil && *d.TorrentID != "" {
+		return *d.TorrentID
+	}
+	if d.SABnzbdNzoID != nil && *d.SABnzbdNzoID != "" {
+		return *d.SABnzbdNzoID
+	}
+	return ""
+}
+
+func trackedDownloadStatus(item enrichedQueueItem) string {
+	if item.Download.ErrorMessage != "" || liveStatusIsError(item.Live.Status) {
+		return "error"
+	}
+	switch item.Download.Status {
+	case models.StateFailed, models.StateImportFailed, models.StateImportBlocked:
+		return "error"
+	}
+	if item.PollFailed {
+		return "warning"
+	}
+	return "ok"
+}
+
+func liveStatusIsError(status string) bool {
+	status = strings.ToLower(status)
+	return strings.Contains(status, "error") || strings.Contains(status, "fail")
+}
+
+func queueItemSize(item enrichedQueueItem) int64 {
+	if item.HasLive && item.Live.Size > 0 {
+		return item.Live.Size
+	}
+	return item.Download.Size
+}
+
+func queueItemSizeLeft(item enrichedQueueItem) int64 {
+	if item.HasLive {
+		if item.Live.SizeLeft > 0 {
+			return item.Live.SizeLeft
+		}
+		if item.Live.Size > 0 {
+			return 0
+		}
+		if left, ok := sizeLeftFromPercentage(item.Download.Size, item.Live.Percentage); ok {
+			return left
+		}
+	}
+
+	switch item.Download.Status {
+	case models.StateCompleted, models.StateImportPending, models.StateImporting,
+		models.StateImported, models.StateFailed, models.StateImportFailed, models.StateImportBlocked:
+		return 0
+	default:
+		return item.Download.Size
+	}
+}
+
+func sizeLeftFromPercentage(size int64, percentage string) (int64, bool) {
+	if size <= 0 {
+		return 0, false
+	}
+	percentage = strings.TrimSpace(strings.TrimSuffix(percentage, "%"))
+	if percentage == "" {
+		return 0, false
+	}
+	pct, err := strconv.ParseFloat(percentage, 64)
+	if err != nil {
+		return 0, false
+	}
+	if pct <= 0 {
+		return size, true
+	}
+	if pct >= 100 {
+		return 0, true
+	}
+	left := int64(math.Round(float64(size) * (100 - pct) / 100))
+	if left < 0 {
+		return 0, true
+	}
+	if left > size {
+		return size, true
+	}
+	return left, true
 }
 
 // grabRequest is the payload for grab operations (HTTP handler and pending force-grab).

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -186,13 +186,16 @@ func (h *QueueHandler) ListArrCompatible(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	records := make([]arrQueueRecord, len(enriched))
-	for i, item := range enriched {
+	records := make([]arrQueueRecord, 0, len(enriched))
+	for _, item := range enriched {
+		if !includeArrQueueItem(item) {
+			continue
+		}
 		bookID := int64(0)
 		if item.Download.BookID != nil {
 			bookID = *item.Download.BookID
 		}
-		records[i] = arrQueueRecord{
+		records = append(records, arrQueueRecord{
 			ID:                    item.Download.ID,
 			BookID:                bookID,
 			Title:                 item.Download.Title,
@@ -203,7 +206,7 @@ func (h *QueueHandler) ListArrCompatible(w http.ResponseWriter, r *http.Request)
 			DownloadClient:        item.ClientName,
 			DownloadID:            item.RemoteID,
 			Protocol:              item.Download.Protocol,
-		}
+		})
 	}
 
 	opts := parseArrQueueOptions(r)
@@ -317,6 +320,10 @@ func storedDownloadID(d models.Download) string {
 		return *d.SABnzbdNzoID
 	}
 	return ""
+}
+
+func includeArrQueueItem(item enrichedQueueItem) bool {
+	return item.Download.Status != models.StateImported
 }
 
 func trackedDownloadStatus(item enrichedQueueItem) string {

--- a/internal/api/queue_test.go
+++ b/internal/api/queue_test.go
@@ -393,6 +393,266 @@ func TestQueueListLiveOverlayQbittorrent(t *testing.T) {
 	}
 }
 
+func TestQueueListArrCompatibleEmpty(t *testing.T) {
+	h := newQueueTestHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+	rr := httptest.NewRecorder()
+	h.ListArrCompatible(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp arrQueueResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.TotalRecords != 0 || len(resp.Records) != 0 {
+		t.Fatalf("expected empty queue response, got %+v", resp)
+	}
+}
+
+func TestQueueListArrCompatibleQbittorrentShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"hash":        "ABCDEF",
+				"progress":    0.5,
+				"eta":         300,
+				"size":        1048576,
+				"amount_left": 524288,
+				"state":       "downloading",
+			}})
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	h, database, _, _, books, ctx := queueFixture(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := createTestDownloadClient(t, h, &models.DownloadClient{
+		Name:     "qBittorrent",
+		Type:     "qbittorrent",
+		Host:     host,
+		Port:     port,
+		Username: "user",
+		Password: "pass",
+		Enabled:  true,
+	})
+	a := &models.Author{ForeignID: "OLQBA", Name: "Andy Weir", SortName: "Weir, Andy", MetadataProvider: "openlibrary", Monitored: true}
+	if err := db.NewAuthorRepo(database).Create(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	b := &models.Book{
+		ForeignID: "OLQBB", AuthorID: a.ID, Title: "Project Hail Mary", SortTitle: "project hail mary",
+		Status: models.BookStatusDownloading, Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+	createTestDownload(t, h, &models.Download{
+		GUID:             "guid-qb-arr",
+		BookID:           &b.ID,
+		DownloadClientID: &client.ID,
+		Title:            "Project Hail Mary",
+		NZBURL:           "magnet:?xt=urn:btih:abcdef",
+		Size:             999,
+		Status:           models.DownloadStatusDownloading,
+		Protocol:         "torrent",
+		TorrentID:        strPtr("abcdef"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue?page=1&pageSize=10", nil)
+	rr := httptest.NewRecorder()
+	h.ListArrCompatible(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp arrQueueResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.TotalRecords != 1 || resp.Page != 1 || resp.PageSize != 10 {
+		t.Fatalf("unexpected paging response: %+v", resp)
+	}
+	if len(resp.Records) != 1 {
+		t.Fatalf("expected one record, got %d", len(resp.Records))
+	}
+	rec := resp.Records[0]
+	if rec.ID == 0 || rec.BookID != b.ID || rec.Title != "Project Hail Mary" {
+		t.Fatalf("unexpected identity fields: %+v", rec)
+	}
+	if rec.Status != string(models.StateDownloading) || rec.TrackedDownloadStatus != "ok" {
+		t.Fatalf("unexpected status fields: %+v", rec)
+	}
+	if rec.Size != 1048576 || rec.SizeLeft != 524288 {
+		t.Fatalf("expected live size fields, got %+v", rec)
+	}
+	if rec.DownloadClient != "qBittorrent" || rec.DownloadID != "abcdef" || rec.Protocol != "torrent" {
+		t.Fatalf("unexpected client fields: %+v", rec)
+	}
+}
+
+func TestQueueListArrCompatiblePollFailureWarns(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	h := newQueueTestHandler(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := createTestDownloadClient(t, h, &models.DownloadClient{
+		Name:    "SABnzbd",
+		Type:    "sabnzbd",
+		Host:    host,
+		Port:    port,
+		APIKey:  "testkey",
+		Enabled: true,
+	})
+	createTestDownload(t, h, &models.Download{
+		GUID:             "guid-sab-warning",
+		DownloadClientID: &client.ID,
+		Title:            "Warning Book",
+		Size:             2048,
+		Status:           models.DownloadStatusDownloading,
+		Protocol:         "usenet",
+		SABnzbdNzoID:     strPtr("nzo-warning"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+	rr := httptest.NewRecorder()
+	h.ListArrCompatible(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp arrQueueResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Records) != 1 {
+		t.Fatalf("expected one record, got %d", len(resp.Records))
+	}
+	rec := resp.Records[0]
+	if rec.TrackedDownloadStatus != "warning" {
+		t.Fatalf("expected warning status, got %+v", rec)
+	}
+	if rec.SizeLeft != 2048 {
+		t.Fatalf("expected conservative sizeleft, got %+v", rec)
+	}
+}
+
+func TestQueueListArrCompatibleLocalErrorOutranksPollFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	h := newQueueTestHandler(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := createTestDownloadClient(t, h, &models.DownloadClient{
+		Name:    "SABnzbd",
+		Type:    "sabnzbd",
+		Host:    host,
+		Port:    port,
+		APIKey:  "testkey",
+		Enabled: true,
+	})
+	createTestDownload(t, h, &models.Download{
+		GUID:             "guid-local-error",
+		DownloadClientID: &client.ID,
+		Title:            "Failed Book",
+		Size:             2048,
+		Status:           models.StateFailed,
+		Protocol:         "usenet",
+		ErrorMessage:     "download failed",
+		SABnzbdNzoID:     strPtr("nzo-failed"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+	rr := httptest.NewRecorder()
+	h.ListArrCompatible(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp arrQueueResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Records) != 1 {
+		t.Fatalf("expected one record, got %d", len(resp.Records))
+	}
+	if resp.Records[0].TrackedDownloadStatus != "error" {
+		t.Fatalf("expected error status, got %+v", resp.Records[0])
+	}
+}
+
+func TestQueueListArrCompatiblePaginationAndSort(t *testing.T) {
+	h := newQueueTestHandler(t)
+	createTestDownload(t, h, &models.Download{
+		GUID: "guid-b", Title: "B Book", Size: 20,
+		Status: models.DownloadStatusDownloading, Protocol: "usenet",
+	})
+	createTestDownload(t, h, &models.Download{
+		GUID: "guid-a", Title: "A Book", Size: 10,
+		Status: models.DownloadStatusDownloading, Protocol: "usenet",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue?sortKey=title&sortDirection=ascending&page=2&pageSize=1", nil)
+	rr := httptest.NewRecorder()
+	h.ListArrCompatible(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp arrQueueResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.TotalRecords != 2 || resp.Page != 2 || resp.PageSize != 1 {
+		t.Fatalf("unexpected paging metadata: %+v", resp)
+	}
+	if len(resp.Records) != 1 || resp.Records[0].Title != "B Book" {
+		t.Fatalf("expected second sorted record, got %+v", resp.Records)
+	}
+}
+
+func TestQueueListArrCompatiblePaginationOverflow(t *testing.T) {
+	h := newQueueTestHandler(t)
+	createTestDownload(t, h, &models.Download{
+		GUID: "guid-overflow", Title: "Overflow Book", Size: 20,
+		Status: models.DownloadStatusDownloading, Protocol: "usenet",
+	})
+
+	maxInt := int(^uint(0) >> 1)
+	req := httptest.NewRequest(http.MethodGet, "/api/queue?page="+strconv.Itoa(maxInt)+"&pageSize=2", nil)
+	rr := httptest.NewRecorder()
+	h.ListArrCompatible(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp arrQueueResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.TotalRecords != 1 || len(resp.Records) != 0 {
+		t.Fatalf("expected empty overflow page with preserved total, got %+v", resp)
+	}
+}
+
 func newQueueTestHandler(t *testing.T) *QueueHandler {
 	t.Helper()
 	database, err := db.OpenMemory()

--- a/internal/api/queue_test.go
+++ b/internal/api/queue_test.go
@@ -597,6 +597,37 @@ func TestQueueListArrCompatibleLocalErrorOutranksPollFailure(t *testing.T) {
 	}
 }
 
+func TestQueueListArrCompatibleSkipsImportedDownloads(t *testing.T) {
+	h := newQueueTestHandler(t)
+	createTestDownload(t, h, &models.Download{
+		GUID: "guid-imported", Title: "Imported Book", Size: 20,
+		Status: models.StateImported, Protocol: "usenet",
+	})
+	createTestDownload(t, h, &models.Download{
+		GUID: "guid-active", Title: "Active Book", Size: 10,
+		Status: models.DownloadStatusDownloading, Protocol: "usenet",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+	rr := httptest.NewRecorder()
+	h.ListArrCompatible(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp arrQueueResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.TotalRecords != 1 || len(resp.Records) != 1 {
+		t.Fatalf("expected only active record, got %+v", resp)
+	}
+	if resp.Records[0].Title != "Active Book" {
+		t.Fatalf("expected active record, got %+v", resp.Records[0])
+	}
+}
+
 func TestQueueListArrCompatiblePaginationAndSort(t *testing.T) {
 	h := newQueueTestHandler(t)
 	createTestDownload(t, h, &models.Download{

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -5,6 +5,7 @@ package downloader
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -20,6 +21,9 @@ type LiveStatus struct {
 	Percentage string
 	TimeLeft   string
 	Speed      string
+	Size       int64
+	SizeLeft   int64
+	Status     string
 }
 
 type SendResult struct {
@@ -260,6 +264,9 @@ func getSABLiveStatuses(ctx context.Context, client *models.DownloadClient) (map
 			Percentage: slot.Percentage,
 			TimeLeft:   slot.TimeLeft,
 			Speed:      queue.Speed,
+			Size:       megabytesStringToBytes(slot.MB),
+			SizeLeft:   megabytesStringToBytes(slot.MBLeft),
+			Status:     slot.Status,
 		}
 	}
 	return out, nil
@@ -282,6 +289,9 @@ func getNZBGetLiveStatuses(ctx context.Context, client *models.DownloadClient) (
 		}
 		out[id] = LiveStatus{
 			Percentage: pct,
+			Size:       megabytesToBytes(g.FileSizeMB),
+			SizeLeft:   megabytesToBytes(g.RemainingSizeMB),
+			Status:     g.Status,
 		}
 	}
 	return out, nil
@@ -302,6 +312,9 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 				Percentage: fmt.Sprintf("%.1f", t.PercentDone*100),
 				TimeLeft:   etaToTimeLeft(t.ETA),
 				Speed:      bytesPerSecondToString(t.DownloadRate),
+				Size:       t.TotalSize,
+				SizeLeft:   t.LeftUntilDone,
+				Status:     strconv.Itoa(t.Status),
 			}
 		}
 		return out, nil
@@ -319,6 +332,9 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 				Percentage: fmt.Sprintf("%.1f", t.Progress),
 				TimeLeft:   etaToTimeLeft(t.ETA),
 				Speed:      bytesPerSecondToString(t.DownloadRate),
+				Size:       t.TotalSize,
+				SizeLeft:   maxInt64(t.TotalSize-t.TotalDone, 0),
+				Status:     t.State,
 			}
 		}
 		return out, nil
@@ -335,9 +351,43 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 		out[strings.ToLower(t.Hash)] = LiveStatus{
 			Percentage: fmt.Sprintf("%.1f", t.Progress*100),
 			TimeLeft:   etaToTimeLeft(int64(t.ETA)),
+			Speed:      bytesPerSecondToString(t.DLSpeed),
+			Size:       t.Size,
+			SizeLeft:   t.AmountLeft,
+			Status:     t.State,
 		}
 	}
 	return out, nil
+}
+
+func megabytesStringToBytes(s string) int64 {
+	s = strings.TrimSpace(strings.ReplaceAll(s, ",", ""))
+	if s == "" {
+		return 0
+	}
+	fields := strings.Fields(s)
+	if len(fields) > 0 {
+		s = fields[0]
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil || v <= 0 {
+		return 0
+	}
+	return megabytesToBytes(v)
+}
+
+func megabytesToBytes(v float64) int64 {
+	if v <= 0 {
+		return 0
+	}
+	return int64(math.Round(v * 1024 * 1024))
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func etaToTimeLeft(etaSeconds int64) string {

--- a/internal/downloader/adapter_test.go
+++ b/internal/downloader/adapter_test.go
@@ -37,6 +37,9 @@ func TestGetLiveStatusesSABnzbd(t *testing.T) {
 				"speed": "2.0 MB/s",
 				"slots": []map[string]any{{
 					"nzo_id":     "nzo123",
+					"status":     "Downloading",
+					"mb":         "10.0",
+					"mbleft":     "5.0",
 					"percentage": "55",
 					"timeleft":   "0:10:00",
 				}},
@@ -62,6 +65,9 @@ func TestGetLiveStatusesSABnzbd(t *testing.T) {
 	if status.Percentage != "55" || status.TimeLeft != "0:10:00" || status.Speed != "2.0 MB/s" {
 		t.Fatalf("unexpected status: %+v", status)
 	}
+	if status.Size != 10*1024*1024 || status.SizeLeft != 5*1024*1024 || status.Status != "Downloading" {
+		t.Fatalf("unexpected size/status overlay: %+v", status)
+	}
 }
 
 func TestGetLiveStatusesTransmission(t *testing.T) {
@@ -73,11 +79,14 @@ func TestGetLiveStatusesTransmission(t *testing.T) {
 			"arguments": map[string]any{
 				"torrents": []map[string]any{
 					{
-						"id":           7,
-						"percentDone":  0.42,
-						"eta":          125,
-						"rateDownload": 4096,
-						"downloadDir":  "/books",
+						"id":            7,
+						"percentDone":   0.42,
+						"totalSize":     1000,
+						"leftUntilDone": 580,
+						"status":        2,
+						"eta":           125,
+						"rateDownload":  4096,
+						"downloadDir":   "/books",
 					},
 					{
 						"id":          99,
@@ -115,6 +124,9 @@ func TestGetLiveStatusesTransmission(t *testing.T) {
 	if status.TimeLeft == "" || status.Speed == "" {
 		t.Fatalf("expected non-empty timeLeft/speed, got %+v", status)
 	}
+	if status.Size != 1000 || status.SizeLeft != 580 || status.Status != "2" {
+		t.Fatalf("unexpected size/status: %+v", status)
+	}
 
 	// Category acts as a download-directory filter on shared Transmission instances.
 	clientFiltered := &models.DownloadClient{Type: "transmission", Host: host, Port: port, Category: "/books"}
@@ -140,9 +152,13 @@ func TestGetLiveStatusesQbittorrent(t *testing.T) {
 			_, _ = w.Write([]byte("Ok."))
 		case "/api/v2/torrents/info":
 			_ = json.NewEncoder(w).Encode([]map[string]any{{
-				"hash":     "ABCDEF",
-				"progress": 0.9,
-				"eta":      300,
+				"hash":        "ABCDEF",
+				"progress":    0.9,
+				"eta":         300,
+				"size":        2000,
+				"amount_left": 200,
+				"state":       "downloading",
+				"dlspeed":     1024,
 			}})
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -169,6 +185,104 @@ func TestGetLiveStatusesQbittorrent(t *testing.T) {
 	}
 	if status.TimeLeft == "" {
 		t.Fatalf("expected non-empty timeLeft")
+	}
+	if status.Size != 2000 || status.SizeLeft != 200 || status.Status != "downloading" || status.Speed == "" {
+		t.Fatalf("unexpected size/status/speed: %+v", status)
+	}
+}
+
+func TestGetLiveStatusesNZBGet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Method != "listgroups" {
+			t.Fatalf("expected listgroups, got %q", req.Method)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result": []map[string]any{{
+				"NZBID":           101,
+				"Status":          "DOWNLOADING",
+				"FileSizeMB":      20.0,
+				"RemainingSizeMB": 2.5,
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "nzbget", Host: host, Port: port}
+
+	statusByID, usesTorrentID, err := GetLiveStatuses(context.Background(), client)
+	if err != nil {
+		t.Fatalf("GetLiveStatuses: %v", err)
+	}
+	if usesTorrentID {
+		t.Fatalf("expected usesTorrentID=false for nzbget")
+	}
+	status, ok := statusByID["101"]
+	if !ok {
+		t.Fatalf("expected NZBID 101 status")
+	}
+	if status.Size != 20*1024*1024 || status.SizeLeft != int64(2.5*1024*1024) || status.Status != "DOWNLOADING" {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+}
+
+func TestGetLiveStatusesDeluge(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/json" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var req struct {
+			Method string `json:"method"`
+			ID     int64  `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		var result any
+		switch req.Method {
+		case "auth.login":
+			result = true
+		case "core.get_torrents_status":
+			result = map[string]any{
+				"abc123": map[string]any{
+					"hash":                  "abc123",
+					"progress":              25.0,
+					"state":                 "Downloading",
+					"eta":                   60,
+					"download_payload_rate": 2048,
+					"total_size":            4000,
+					"total_done":            1000,
+				},
+			}
+		default:
+			t.Fatalf("unexpected method: %s", req.Method)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"result": result, "error": nil, "id": req.ID})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "deluge", Host: host, Port: port, Password: "pw"}
+
+	statusByID, usesTorrentID, err := GetLiveStatuses(context.Background(), client)
+	if err != nil {
+		t.Fatalf("GetLiveStatuses: %v", err)
+	}
+	if !usesTorrentID {
+		t.Fatalf("expected usesTorrentID=true for deluge")
+	}
+	status, ok := statusByID["abc123"]
+	if !ok {
+		t.Fatalf("expected abc123 status")
+	}
+	if status.Size != 4000 || status.SizeLeft != 3000 || status.Status != "Downloading" {
+		t.Fatalf("unexpected status: %+v", status)
 	}
 }
 

--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -217,7 +217,7 @@ func (c *Client) setLabel(ctx context.Context, hash, label string) error {
 
 // GetTorrents returns status for all torrents, keyed by lower-cased hash.
 func (c *Client) GetTorrents(ctx context.Context) (map[string]TorrentStatus, error) {
-	fields := []string{"name", "hash", "progress", "state", "eta", "download_payload_rate"}
+	fields := []string{"name", "hash", "progress", "state", "eta", "download_payload_rate", "total_size", "total_done"}
 	var raw map[string]TorrentStatus
 	if err := c.call(ctx, true, "core.get_torrents_status", []any{map[string]any{}, fields}, &raw); err != nil {
 		return nil, fmt.Errorf("get torrents status: %w", err)

--- a/internal/downloader/deluge/types.go
+++ b/internal/downloader/deluge/types.go
@@ -8,4 +8,6 @@ type TorrentStatus struct {
 	State        string  `json:"state"`                 // "Downloading", "Seeding", "Paused", "Error", etc.
 	ETA          int64   `json:"eta"`                   // seconds remaining; -1 or 0 if unknown
 	DownloadRate int64   `json:"download_payload_rate"` // bytes/s
+	TotalSize    int64   `json:"total_size"`
+	TotalDone    int64   `json:"total_done"`
 }

--- a/internal/downloader/qbittorrent/types.go
+++ b/internal/downloader/qbittorrent/types.go
@@ -2,13 +2,15 @@ package qbittorrent
 
 // Torrent represents a single torrent as returned by the qBittorrent WebUI API.
 type Torrent struct {
-	Hash     string  `json:"hash"`
-	Name     string  `json:"name"`
-	Size     int64   `json:"size"`
-	Progress float64 `json:"progress"`
-	State    string  `json:"state"`
-	Category string  `json:"category"`
-	SavePath string  `json:"save_path"`
-	ETA      int     `json:"eta"`
-	AddedOn  int64   `json:"added_on"`
+	Hash       string  `json:"hash"`
+	Name       string  `json:"name"`
+	Size       int64   `json:"size"`
+	AmountLeft int64   `json:"amount_left"`
+	Progress   float64 `json:"progress"`
+	State      string  `json:"state"`
+	Category   string  `json:"category"`
+	SavePath   string  `json:"save_path"`
+	ETA        int     `json:"eta"`
+	AddedOn    int64   `json:"added_on"`
+	DLSpeed    int64   `json:"dlspeed"`
 }


### PR DESCRIPTION
## Summary

- Adds `GET /api/queue`, an Arr-compatible queue endpoint for Harpoon and similar external tools.
- Returns queue records with live downloader-backed `size`, `sizeleft`, status, client name, remote download ID, and protocol where available.
- Keeps the existing `GET /api/v1/queue` UI response shape unchanged.
- Adds focused queue and downloader tests, plus an `[Unreleased]` changelog entry.

## Checklist

- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [ ] Wiki pages updated if user-facing behaviour changed

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [x] `cd web && npm run build`
