### PR TITLE
Codex/searchauthor 410

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **Author detail search-all-wanted action** (#410) — the Author Detail page now has a **Search all wanted** button that queues searches for that author's monitored wanted books, disables itself when there is nothing searchable, and surfaces bulk-search errors inline. Author bulk search now also skips unmonitored wanted books so explicit per-book unmonitor decisions are respected.
+
 ## [v1.2.6] — 2026-04-25
 
 ### Fixed

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -109,7 +109,7 @@ func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
 			if h.searcher != nil {
 				bgCtx := contextBackground()
 				for _, b := range books {
-					if b.Status == models.BookStatusWanted {
+					if b.Status == models.BookStatusWanted && b.Monitored {
 						b := b
 						go h.searcher.SearchAndGrabBook(bgCtx, b)
 					}

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -274,14 +274,20 @@ func TestAuthorsBulk_Search_FiresSearcherForWantedBooks(t *testing.T) {
 	searcher := newMockBookSearcher()
 	h, _, books, author, ctx := bulkFixtureWithSearcher(t, searcher)
 
-	// One wanted book + one imported book; only wanted should be searched.
+	// One monitored wanted book, one unmonitored wanted book, and one imported
+	// book; only the monitored wanted book should be searched.
 	mustCreateBook(t, books, ctx, &models.Book{
 		ForeignID: "OL_BK1", AuthorID: author.ID, Title: "Wanted Book",
 		SortTitle: "wanted book", Status: models.BookStatusWanted,
 		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
 	})
 	mustCreateBook(t, books, ctx, &models.Book{
-		ForeignID: "OL_BK2", AuthorID: author.ID, Title: "Imported Book",
+		ForeignID: "OL_BK2", AuthorID: author.ID, Title: "Unmonitored Wanted Book",
+		SortTitle: "unmonitored wanted book", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: false,
+	})
+	mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "OL_BK3", AuthorID: author.ID, Title: "Imported Book",
 		SortTitle: "imported book", Status: models.BookStatusImported,
 		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
 	})
@@ -297,7 +303,7 @@ func TestAuthorsBulk_Search_FiresSearcherForWantedBooks(t *testing.T) {
 	if got.Title != "Wanted Book" {
 		t.Errorf("expected search for 'Wanted Book', got %q", got.Title)
 	}
-	// Imported book must not trigger a search.
+	// Imported and unmonitored wanted books must not trigger a search.
 	searcher.assertNoCall(t, 50*time.Millisecond)
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -220,6 +220,8 @@ export const api = {
   // Bulk actions
   bulkActionAuthors: (ids: number[], action: AuthorBulkAction, mediaType?: MediaType) =>
     request<BulkResult>('/author/bulk', { method: 'POST', body: JSON.stringify({ ids, action, ...(mediaType ? { mediaType } : {}) }) }),
+  searchAuthorWanted: (id: number) =>
+    request<BulkResult>('/author/bulk', { method: 'POST', body: JSON.stringify({ ids: [id], action: 'search' }) }),
   bulkActionBooks: (ids: number[], action: BookBulkAction, mediaType?: MediaType) =>
     request<BulkResult>('/book/bulk', { method: 'POST', body: JSON.stringify({ ids, action, ...(mediaType ? { mediaType } : {}) }) }),
   bulkActionWanted: (ids: number[], action: WantedBulkAction) =>

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import AuthorDetailPage from './AuthorDetailPage'
+import { api, Author, Book } from '../api/client'
+
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getAuthor: vi.fn(),
+      listBooks: vi.fn(),
+      searchAuthorWanted: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../components/ViewToggle', () => ({ default: () => null }))
+
+vi.mock('../components/useView', () => ({
+  useView: () => ['grid', vi.fn()],
+}))
+
+const author: Author = {
+  id: 42,
+  foreignAuthorId: 'OL1A',
+  authorName: 'Test Author',
+  sortName: 'Author, Test',
+  description: '',
+  imageUrl: '',
+  disambiguation: '',
+  ratingsCount: 0,
+  averageRating: 0,
+  monitored: true,
+}
+
+function book(overrides: Partial<Book>): Book {
+  return {
+    id: 1,
+    foreignBookId: 'OL1W',
+    authorId: 42,
+    title: 'Wanted Book',
+    description: '',
+    imageUrl: '',
+    genres: [],
+    monitored: true,
+    status: 'wanted',
+    filePath: '',
+    mediaType: 'ebook',
+    ebookFilePath: '',
+    audiobookFilePath: '',
+    excluded: false,
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/author/42']}>
+      <Routes>
+        <Route path="/author/:id" element={<AuthorDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('AuthorDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.getAuthor).mockResolvedValue(author)
+    vi.mocked(api.searchAuthorWanted).mockResolvedValue({
+      results: { '42': { ok: true } },
+    })
+  })
+
+  it('searches all wanted books for the current author', async () => {
+    vi.mocked(api.listBooks).mockResolvedValue([
+      book({ id: 10, title: 'Wanted Book' }),
+      book({ id: 11, title: 'Imported Book', status: 'imported' }),
+    ])
+
+    renderPage()
+
+    const button = await screen.findByRole('button', { name: 'Search all wanted' })
+    expect(button).toBeEnabled()
+
+    fireEvent.click(button)
+
+    await waitFor(() => expect(api.searchAuthorWanted).toHaveBeenCalledWith(42))
+  })
+
+  it('disables author search when there are no monitored wanted books', async () => {
+    vi.mocked(api.listBooks).mockResolvedValue([
+      book({ id: 10, title: 'Unmonitored Wanted Book', monitored: false }),
+      book({ id: 11, title: 'Imported Book', status: 'imported' }),
+    ])
+
+    renderPage()
+
+    const button = await screen.findByRole('button', { name: 'Search all wanted' })
+    expect(button).toBeDisabled()
+
+    fireEvent.click(button)
+
+    expect(api.searchAuthorWanted).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -43,6 +43,7 @@ export default function AuthorDetailPage() {
   const [allAuthors, setAllAuthors] = useState<Author[]>([])
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
+  const [searchingWanted, setSearchingWanted] = useState(false)
   const [showMerge, setShowMerge] = useState(false)
   const [showExcluded, setShowExcluded] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -143,6 +144,25 @@ export default function AuthorDetailPage() {
     }
   }
 
+  const handleSearchWanted = async () => {
+    if (!author) return
+    const searchableWantedCount = books.filter(b => b.status === 'wanted' && b.monitored && !b.excluded).length
+    if (searchableWantedCount === 0) return
+    setSearchingWanted(true)
+    setError(null)
+    try {
+      const res = await api.searchAuthorWanted(author.id)
+      const item = res.results[String(author.id)]
+      if (item && !item.ok) {
+        throw new Error(item.error || 'Search failed')
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Search failed')
+    } finally {
+      setSearchingWanted(false)
+    }
+  }
+
   const handleDelete = async () => {
     if (!author) return
     const withFiles = books.filter(b => b.filePath)
@@ -180,10 +200,11 @@ export default function AuthorDetailPage() {
   if (loading) return <div className="text-slate-600 dark:text-zinc-500">Loading…</div>
   if (!author) return <div className="text-slate-600 dark:text-zinc-500">Author not found</div>
 
+  const searchableWantedCount = books.filter(b => b.status === 'wanted' && b.monitored && !b.excluded).length
   const counts = {
     total: books.length,
     imported: books.filter(b => b.status === 'imported').length,
-    wanted: books.filter(b => b.status === 'wanted').length,
+    wanted: searchableWantedCount,
     audiobook: books.filter(b => b.mediaType === 'audiobook').length,
   }
 
@@ -238,6 +259,14 @@ export default function AuthorDetailPage() {
               className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium disabled:opacity-50"
             >
               {refreshing ? 'Refreshing…' : 'Refresh metadata'}
+            </button>
+            <button
+              onClick={handleSearchWanted}
+              disabled={searchingWanted || searchableWantedCount === 0}
+              className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium disabled:opacity-50"
+              title={searchableWantedCount === 0 ? 'No wanted books to search' : `Search ${searchableWantedCount} wanted book${searchableWantedCount === 1 ? '' : 's'}`}
+            >
+              {searchingWanted ? 'Searching…' : 'Search all wanted'}
             </button>
             <button
               onClick={() => {


### PR DESCRIPTION
## Summary

Adds an Author Detail **Search all wanted** button for quickly kicking off searches for an author's monitored wanted books.

- Queues author bulk search from the Author Detail page
- Disables the button when there are no monitored wanted books to search
- Shows bulk-search errors inline
- Updates author bulk search to skip unmonitored wanted books
- Adds backend and frontend coverage

Closes #410.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (not applicable)
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] Wiki pages updated if user-facing behaviour changed (not applicable)

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [x] `cd web && npm run build`
