### PR TITLE
fix: remove category filter from qBittorrent hash detection poll

### DIFF
--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -104,6 +104,12 @@ func (c *Client) Test(ctx context.Context) error {
 func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath string) (string, error) {
 	// Snapshot all existing hashes (unfiltered) so we can detect newly-added
 	// items regardless of which category qBittorrent assigns them initially.
+	// For indirect URLs (e.g. Prowlarr Torznab redirects), qBittorrent must
+	// follow the redirect and fetch the remote .torrent file before it assigns
+	// metadata and category. Polling with a category filter during this window
+	// returns nothing; the detection deadline expires and the hash is lost
+	// (#418). The before/after hash-set diff already uniquely identifies the
+	// new torrent, so the category filter is omitted from both polling calls.
 	beforeSet := map[string]struct{}{}
 	if before, err := c.GetTorrents(ctx, ""); err == nil {
 		for _, t := range before {


### PR DESCRIPTION
Fixes #418.

## Problem

When adding a torrent via a Prowlarr Torznab URL (or any indirect URL), qBittorrent must follow a redirect and fetch the remote `.torrent` file before it can assign metadata and category. The `AddTorrent` hash-detection loop polls with `GetTorrents(ctx, category)`, which returns nothing during this window. The 10-second deadline expires, the hash is never recorded, and the book stays stuck in history forever.

This was reported as #209 (closed) and #320 (closed as "fixed" but that addressed NZB misrouting, not this path). Still reproducible in v1.2.5.

## Fix

Remove the `category` argument from the two polling calls in `AddTorrent`. The before/after hash-set diff already uniquely identifies the new torrent — the category filter was redundant and introduced the race. The category is still submitted with the add request; only the two detection polls are changed.

## Testing

- Existing qBittorrent client tests pass
- Manually verified: torrent added via Torznab redirect URL now has its hash recorded correctly