### PR TITLE
fix: skip header row in CSV author import

### DIFF
--- a/internal/migrate/csv.go
+++ b/internal/migrate/csv.go
@@ -150,8 +150,17 @@ func parseCSVRows(reader io.Reader) ([]csvRow, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Common header field names — if the first record's first cell matches
+		// one of these, the row is a column-label header and must be skipped.
+		headerFields := map[string]bool{
+			"name": true, "author": true, "author name": true,
+			"monitored": true, "searchonadd": true,
+		}
 		out := make([]csvRow, 0, len(records))
-		for _, rec := range records {
+		for i, rec := range records {
+			if i == 0 && len(rec) > 0 && headerFields[strings.ToLower(strings.TrimSpace(rec[0]))] {
+				continue
+			}
 			out = append(out, rowFromFields(rec))
 		}
 		return out, nil

--- a/internal/migrate/csv_test.go
+++ b/internal/migrate/csv_test.go
@@ -139,6 +139,21 @@ func TestParseCSVRows(t *testing.T) {
 			},
 		},
 		{
+			name: "csv with header row skipped",
+			in:   "Author Name,Monitored,SearchOnAdd\nAndy Weir,true,false\nIsaac Asimov,false,true\n",
+			want: []csvRow{
+				{name: "Andy Weir", monitored: true, searchOnAdd: false},
+				{name: "Isaac Asimov", monitored: false, searchOnAdd: true},
+			},
+		},
+		{
+			name: "csv with 'name' header skipped",
+			in:   "name,monitored\nN. K. Jemisin,true\n",
+			want: []csvRow{
+				{name: "N. K. Jemisin", monitored: true, searchOnAdd: false},
+			},
+		},
+		{
 			name: "empty input",
 			in:   "",
 			want: nil,


### PR DESCRIPTION
Fixes #419.

## Problem

`parseCSVRows` treated every row as data, including header rows. A CSV with a header like `Author Name,Monitored,SearchOnAdd` imported a phantom author called "Author Name" with `searchOnAdd=true`, triggering an async OpenLibrary fetch for the column label string.

## Fix

Detect common header field names (`name`, `author`, `author name`, `monitored`, `searchonadd`) in the first row and skip it. Plain-list CSVs (no header, just one name per line or per row) are unaffected.

## Testing

Added a test: CSV with header row + real author rows → header is skipped, authors are parsed correctly.