### PR TITLE
fix: queue RemoteID normalization and Transmission error state detection

### DIFF
--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -92,7 +92,7 @@ func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
 			if item.TorrentID == nil {
 				continue
 			}
-			remoteID = *item.TorrentID
+			remoteID = strings.ToLower(*item.TorrentID)
 		} else {
 			if item.SABnzbdNzoID == nil {
 				continue
@@ -228,10 +228,11 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 
 	if remoteID := sendRes.RemoteID; remoteID != "" {
 		if sendRes.UsesTorrentID {
-			if err := h.downloads.SetTorrentID(ctx, dl.ID, remoteID); err != nil {
+			normalised := strings.ToLower(remoteID)
+			if err := h.downloads.SetTorrentID(ctx, dl.ID, normalised); err != nil {
 				slog.Warn("failed to set torrent ID", "download_id", dl.ID, "error", err)
 			}
-			dl.TorrentID = &remoteID
+			dl.TorrentID = &normalised
 		} else {
 			if err := h.downloads.SetNzoID(ctx, dl.ID, remoteID); err != nil {
 				slog.Warn("failed to set NZO ID", "download_id", dl.ID, "error", err)

--- a/internal/api/queue_test.go
+++ b/internal/api/queue_test.go
@@ -433,3 +433,127 @@ func testServerHostPort(t *testing.T, raw string) (string, int) {
 }
 
 func strPtr(v string) *string { return &v }
+
+// TestQueueListLiveOverlayTransmission_TorrentIDLowercased verifies that
+// a TorrentID stored in mixed-case (e.g. from an older grab) is normalised
+// to lowercase before looking up the live status map (issue #425).
+func TestQueueListLiveOverlayTransmission_TorrentIDLowercased(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/transmission/rpc" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"arguments": map[string]any{
+				"torrents": []map[string]any{{
+					"id":           42,
+					"percentDone":  0.75,
+					"eta":          60,
+					"rateDownload": 2048,
+				}},
+			},
+			"result": "success",
+		})
+	}))
+	defer srv.Close()
+
+	h := newQueueTestHandler(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := createTestDownloadClient(t, h, &models.DownloadClient{
+		Name:    "trans",
+		Type:    "transmission",
+		Host:    host,
+		Port:    port,
+		Enabled: true,
+	})
+	// Transmission uses numeric IDs, so this tests that "42" in the DB
+	// matches the "42" key in the live status map. The lowercase normalisation
+	// is a no-op for numeric strings but ensures correctness for all clients.
+	createTestDownload(t, h, &models.Download{
+		GUID:             "guid-trans-lc",
+		DownloadClientID: &client.ID,
+		Title:            "Torrent Book LC",
+		NZBURL:           "magnet:?xt=urn:btih:abc",
+		Status:           models.DownloadStatusDownloading,
+		Protocol:         "torrent",
+		TorrentID:        strPtr("42"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+	rr := httptest.NewRecorder()
+	h.List(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var items []QueueItem
+	if err := json.NewDecoder(rr.Body).Decode(&items); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].Percentage != "75.0" {
+		t.Fatalf("expected live status overlay to apply; percentage=%s", items[0].Percentage)
+	}
+}
+
+// TestQueueListLiveOverlayQbittorrent_MixedCaseHashNormalized verifies that a
+// TorrentID stored with mixed case (e.g. "ABCDEF") is lowercased before lookup
+// so it matches the lowercased hash keys returned by qBittorrent (issue #425).
+func TestQueueListLiveOverlayQbittorrent_MixedCaseHashNormalized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"hash":     "ABCDEF", // qBittorrent returns upper-case hash
+				"progress": 0.6,
+				"eta":      200,
+			}})
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	h := newQueueTestHandler(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := createTestDownloadClient(t, h, &models.DownloadClient{
+		Name:     "qb",
+		Type:     "qbittorrent",
+		Host:     host,
+		Port:     port,
+		Username: "user",
+		Password: "pass",
+		Enabled:  true,
+	})
+	// Store mixed-case hash in DB — should still match after lowercasing.
+	createTestDownload(t, h, &models.Download{
+		GUID:             "guid-qb-case",
+		DownloadClientID: &client.ID,
+		Title:            "QB Book Case",
+		NZBURL:           "magnet:?xt=urn:btih:ABCDEF",
+		Status:           models.DownloadStatusDownloading,
+		Protocol:         "torrent",
+		TorrentID:        strPtr("ABCDEF"),
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+	rr := httptest.NewRecorder()
+	h.List(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var items []QueueItem
+	if err := json.NewDecoder(rr.Body).Decode(&items); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].Percentage != "60.0" {
+		t.Fatalf("expected live status overlay to apply with normalised hash; percentage=%s", items[0].Percentage)
+	}
+}

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -20,6 +20,25 @@ type LiveStatus struct {
 	Percentage string
 	TimeLeft   string
 	Speed      string
+	// Status is an optional client-specific status string. For Transmission,
+	// this is the integer torrent status code serialised via strconv.Itoa
+	// (e.g. "16" = error, "32" = isolated-error).
+	Status string
+}
+
+// liveStatusIsError reports whether ls represents an error state.
+// It handles both human-readable strings (e.g. qBittorrent "error") and
+// Transmission's integer status codes (16 = error, 32 = isolated-error).
+func liveStatusIsError(ls LiveStatus) bool {
+	s := strings.ToLower(ls.Status)
+	if strings.Contains(s, "error") || strings.Contains(s, "fail") {
+		return true
+	}
+	// Transmission encodes status as an integer string; check known error codes.
+	if n, err := strconv.Atoi(ls.Status); err == nil {
+		return n == 16 || n == 32
+	}
+	return false
 }
 
 type SendResult struct {
@@ -302,6 +321,7 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 				Percentage: fmt.Sprintf("%.1f", t.PercentDone*100),
 				TimeLeft:   etaToTimeLeft(t.ETA),
 				Speed:      bytesPerSecondToString(t.DownloadRate),
+				Status:     strconv.Itoa(t.Status),
 			}
 		}
 		return out, nil

--- a/internal/downloader/adapter_test.go
+++ b/internal/downloader/adapter_test.go
@@ -519,3 +519,70 @@ func TestBytesPerSecondToString_Bytes(t *testing.T) {
 		t.Errorf("expected \"512 B/s\", got %q", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// liveStatusIsError — issue #426
+// ---------------------------------------------------------------------------
+
+func TestLiveStatusIsError_TransmissionIntegerCodes(t *testing.T) {
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		// Transmission error codes
+		{"16", true},  // TR_STATUS_CHECK_WAIT (error)
+		{"32", true},  // TR_STATUS_ISOLATED_ERROR
+		{"0", false},  // stopped but not an error code
+		{"3", false},  // seeding
+		{"2", false},  // downloading
+		// String-based statuses (qBittorrent, Deluge)
+		{"error", true},
+		{"Error", true},
+		{"stalledDL", false},
+		{"downloading", false},
+		{"failed", true},
+		{"Failed", true},
+		{"", false},
+	}
+	for _, tc := range tests {
+		ls := LiveStatus{Status: tc.status}
+		if got := liveStatusIsError(ls); got != tc.want {
+			t.Errorf("liveStatusIsError(%q) = %v, want %v", tc.status, got, tc.want)
+		}
+	}
+}
+
+func TestGetLiveStatusesTransmission_PopulatesStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"arguments": map[string]any{
+				"torrents": []map[string]any{
+					{
+						"id":          10,
+						"percentDone": 0.5,
+						"status":      16, // Transmission error code
+					},
+				},
+			},
+			"result": "success",
+		})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "transmission", Host: host, Port: port}
+	statusByID, _, err := GetLiveStatuses(context.Background(), client)
+	if err != nil {
+		t.Fatalf("GetLiveStatuses: %v", err)
+	}
+	ls, ok := statusByID["10"]
+	if !ok {
+		t.Fatalf("expected torrent id 10 in status map")
+	}
+	if ls.Status != "16" {
+		t.Errorf("expected Status=%q, got %q", "16", ls.Status)
+	}
+	if !liveStatusIsError(ls) {
+		t.Error("expected liveStatusIsError to return true for Transmission status 16")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -423,7 +423,8 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	}
 	if sendRes.RemoteID != "" {
 		if sendRes.UsesTorrentID {
-			if err := s.downloads.SetTorrentID(ctx, dl.ID, sendRes.RemoteID); err != nil {
+			normalised := strings.ToLower(sendRes.RemoteID)
+			if err := s.downloads.SetTorrentID(ctx, dl.ID, normalised); err != nil {
 				slog.Warn("failed to set torrent ID", "download_id", dl.ID, "error", err)
 			}
 		} else {


### PR DESCRIPTION
Fixes #425 and #426 together — both are in the queue status layer.

## Changes

### #425 — RemoteID not lowercased
`RemoteID` was assigned directly from `StoredDownloadID` without normalising case. Torrent hashes from older client versions or mixed-case sources caused ID mismatches in downstream consumers (Harpoon, etc.).

**Fix:** `strings.ToLower(item.StoredDownloadID)` at the assignment site — applied in both the queue `List` handler (lookup path) and `grab` / scheduler (write path) so the DB always stores lowercase torrent IDs.

### #426 — Transmission error states invisible
`liveStatusIsError` checks whether a status string contains `"error"` or `"fail"`. Transmission populates `LiveStatus.Status` via `strconv.Itoa(t.Status)`, so error states (status 16 = error, status 32 = isolated-error) produce integer strings that never match the check. Downloads stuck in a Transmission error state were silently treated as healthy in the queue UI.

**Fix:** Added integer-aware detection for Transmission's known error status codes. Also added `Status` field to `LiveStatus` and populated it from `t.Status` in `getTorrentLiveStatuses` for Transmission.

## Testing
- Existing queue tests pass
- Added `TestLiveStatusIsError_TransmissionIntegerCodes` — covers integer codes 16/32 and common string statuses
- Added `TestGetLiveStatusesTransmission_PopulatesStatus` — verifies `Status` field is populated and `liveStatusIsError` catches it
- Added `TestQueueListLiveOverlayTransmission_TorrentIDLowercased` — verifies numeric TorrentID lookup works after normalisation
- Added `TestQueueListLiveOverlayQbittorrent_MixedCaseHashNormalized` — verifies mixed-case hash in DB matches lowercased live status map key