### PR TITLE
feat: configurable login rate limit thresholds via env vars

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -145,8 +145,9 @@ func main() {
 		slog.Info("proxy auth mode: trusted proxies", "cidrs", trustedCIDRs)
 	}
 
-	// Login rate limiter: 5 failures / 15 min per IP, matches Sonarr's posture.
-	loginLimiter := auth.NewLoginLimiter(5, 15*time.Minute)
+	// Login rate limiter: thresholds are configurable via BINDERY_RATE_LIMIT_MAX_FAILURES
+	// and BINDERY_RATE_LIMIT_WINDOW_MINUTES; defaults match the original Sonarr-style posture.
+	loginLimiter := auth.NewLoginLimiter(cfg.RateLimitMaxFailures, time.Duration(cfg.RateLimitWindowMinutes)*time.Minute)
 
 	// Metadata providers
 	olClient := openlibrary.New()

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -136,6 +136,25 @@ func TestLoginLimiterResetOnSuccess(t *testing.T) {
 	}
 }
 
+// TestLoginLimiterConfigurableThreshold verifies that a limiter built with a
+// non-default max blocks exactly at that threshold, not at the hardcoded default of 5.
+func TestLoginLimiterConfigurableThreshold(t *testing.T) {
+	const customMax = 3
+	lim := NewLoginLimiter(customMax, time.Minute)
+	ip := "10.0.0.1"
+
+	for i := range customMax {
+		if !lim.Allow(ip) {
+			t.Fatalf("attempt %d should be allowed (max=%d)", i+1, customMax)
+		}
+		lim.Record(ip)
+	}
+	// Next attempt must be blocked at customMax, not at 5.
+	if lim.Allow(ip) {
+		t.Fatalf("attempt %d should be blocked (max=%d)", customMax+1, customMax)
+	}
+}
+
 func TestLoginLimiterExpiresOldEvents(t *testing.T) {
 	lim := NewLoginLimiter(2, 10*time.Millisecond)
 	ip := "1.2.3.4"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,11 @@ type Config struct {
 	OIDCRedirectBaseURL string // BINDERY_OIDC_REDIRECT_BASE_URL
 	// Log retention in days (BINDERY_LOG_RETENTION_DAYS, default 14).
 	LogRetentionDays int
+	// Login rate limit (per-IP sliding window).
+	// BINDERY_RATE_LIMIT_MAX_FAILURES  (default: 5)
+	// BINDERY_RATE_LIMIT_WINDOW_MINUTES (default: 15)
+	RateLimitMaxFailures    int
+	RateLimitWindowMinutes  int
 }
 
 // Load reads configuration from environment variables with sensible defaults.
@@ -54,7 +59,9 @@ func Load() *Config {
 		ProxyAuthHeader:     envOr("BINDERY_PROXY_AUTH_HEADER", "X-Forwarded-User"),
 		ProxyAutoProvision:  envBool("BINDERY_PROXY_AUTO_PROVISION", true),
 		OIDCRedirectBaseURL: envOr("BINDERY_OIDC_REDIRECT_BASE_URL", ""),
-		LogRetentionDays:    envInt("BINDERY_LOG_RETENTION_DAYS", 14),
+		LogRetentionDays:       envInt("BINDERY_LOG_RETENTION_DAYS", 14),
+		RateLimitMaxFailures:   envInt("BINDERY_RATE_LIMIT_MAX_FAILURES", 5),
+		RateLimitWindowMinutes: envInt("BINDERY_RATE_LIMIT_WINDOW_MINUTES", 15),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -111,3 +111,32 @@ func TestDefaultDataDir_FallsBackOnDirError(t *testing.T) {
 		t.Errorf("expected fallback /config on UserConfigDir error, got %s", got)
 	}
 }
+
+func TestRateLimitDefaults(t *testing.T) {
+	// Ensure no relevant env vars are set.
+	t.Setenv("BINDERY_RATE_LIMIT_MAX_FAILURES", "")
+	t.Setenv("BINDERY_RATE_LIMIT_WINDOW_MINUTES", "")
+
+	cfg := Load()
+
+	if cfg.RateLimitMaxFailures != 5 {
+		t.Errorf("default RateLimitMaxFailures = %d; want 5", cfg.RateLimitMaxFailures)
+	}
+	if cfg.RateLimitWindowMinutes != 15 {
+		t.Errorf("default RateLimitWindowMinutes = %d; want 15", cfg.RateLimitWindowMinutes)
+	}
+}
+
+func TestRateLimitFromEnv(t *testing.T) {
+	t.Setenv("BINDERY_RATE_LIMIT_MAX_FAILURES", "10")
+	t.Setenv("BINDERY_RATE_LIMIT_WINDOW_MINUTES", "30")
+
+	cfg := Load()
+
+	if cfg.RateLimitMaxFailures != 10 {
+		t.Errorf("RateLimitMaxFailures = %d; want 10", cfg.RateLimitMaxFailures)
+	}
+	if cfg.RateLimitWindowMinutes != 30 {
+		t.Errorf("RateLimitWindowMinutes = %d; want 30", cfg.RateLimitWindowMinutes)
+	}
+}


### PR DESCRIPTION
Fixes #428.

## Problem

The per-IP login rate limit (5 failures / 15 minutes) was hardcoded. Operators with shared egress IPs (VPN pools, corporate NAT), compliance requirements, or CI test suites hitting auth endpoints could not adjust the threshold without recompiling.

## Changes

Two new environment variables:

| Variable | Default | Description |
|---|---|---|
| `BINDERY_RATE_LIMIT_MAX_FAILURES` | `5` | Max failed login attempts before rate limiting |
| `BINDERY_RATE_LIMIT_WINDOW_MINUTES` | `15` | Rolling window in minutes |

Defaults match current behavior — no change for existing deployments.

## Testing

- Default values are applied when env vars are absent
- Custom values from env vars are respected
- Rate limiter blocks at the configured threshold