### PR TITLE
fix: credential normalization silent clear and missing write-path test

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -624,6 +624,90 @@ func TestDownloadClientRepoCredentialFields(t *testing.T) {
 	}
 }
 
+// TestNormalizeClientCredentialStorageWritePath covers the write-path guard in
+// normalizeClientCredentialStorage: a qBittorrent client saved with a bare
+// url_base and an empty api_key must read back with url_base preserved and
+// username NOT populated from it. (closes #422)
+func TestNormalizeClientCredentialStorageWritePath(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	repo := NewDownloadClientRepo(database)
+
+	// A client with a bare url_base path and no api_key — the write-path guard
+	// (normalizeClientCredentialStorage) must not migrate url_base into username
+	// because api_key is empty, which means this is not a legacy credential row.
+	qbt := &models.DownloadClient{
+		Name:    "qBittorrent bare url_base",
+		Type:    "qbittorrent",
+		Host:    "localhost",
+		Port:    8080,
+		URLBase: "qbit",
+		APIKey:  "", // empty — no migration should happen
+		Enabled: true,
+	}
+	if err := repo.Create(ctx, qbt); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, qbt.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	// url_base must be preserved exactly as written.
+	if got.URLBase != "qbit" {
+		t.Errorf("URLBase: want %q, got %q", "qbit", got.URLBase)
+	}
+	// username must NOT be populated from url_base when api_key is empty.
+	if got.Username != "" {
+		t.Errorf("Username: want empty (should not be populated from url_base when api_key is empty), got %q", got.Username)
+	}
+}
+
+// TestLegacyCredentialURLBase exercises legacyCredentialURLBase directly to
+// guard against regressions in the legacy-row detection logic. (closes #423)
+func TestLegacyCredentialURLBase(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		urlBase  string
+		apiKey   string
+		want     bool
+	}{
+		// Legacy row: username column is still empty, url_base held the username,
+		// api_key held the password.
+		{"empty username non-empty urlBase with apiKey", "", "admin", "secret", true},
+		// Legacy row: both fields kept in sync by old code.
+		{"username equals urlBase with apiKey", "admin", "admin", "secret", true},
+		// Modern row: distinct username and a real url_base path — must NOT fire.
+		{"distinct username and urlBase", "admin", "/qbit", "secret", false},
+		// Modern row: username set, url_base empty — already migrated.
+		{"username set urlBase empty", "admin", "", "secret", false},
+		// Both empty — nothing to migrate.
+		{"both empty", "", "", "", false},
+		// Whitespace-only urlBase does not count as a legacy row.
+		{"whitespace urlBase", "", "   ", "secret", false},
+		// Modern row: bare url_base but no api_key — client has a real url_base
+		// path but no password stored in the legacy location. Must NOT fire.
+		// This is the core regression from #423.
+		{"bare urlBase empty apiKey", "", "qbit", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := legacyCredentialURLBase(tt.username, tt.urlBase, tt.apiKey)
+			if got != tt.want {
+				t.Errorf("legacyCredentialURLBase(%q, %q, %q) = %v, want %v",
+					tt.username, tt.urlBase, tt.apiKey, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDownloadClientRepoGetEnabledByProtocol(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {

--- a/internal/db/download_clients.go
+++ b/internal/db/download_clients.go
@@ -23,11 +23,53 @@ func isCredentialClient(clientType string) bool {
 	return clientType == "qbittorrent" || clientType == "transmission"
 }
 
+// legacyCredentialURLBase reports whether a download-client row was written by
+// an older version of bindery that stored qBittorrent/Transmission credentials
+// in the url_base and api_key columns instead of the dedicated username and
+// password columns.
+//
+// Detection requires all three signals to agree:
+//   - username is empty or equals url_base (url_base held the username)
+//   - url_base is non-empty (there is actually something to migrate)
+//   - apiKey is non-empty (the legacy schema also stored password in api_key;
+//     if api_key is empty, the row is a modern client with a real url_base path,
+//     not a migrated credential pair)
+//
+// Scoping apiKey into the guard fixes the regression described in #423:
+// the previous implementation only looked at username and url_base, so a modern
+// client with a bare url_base (e.g. "qbit") and an empty api_key would be
+// misidentified as a legacy row and have its url_base silently cleared on read.
+func legacyCredentialURLBase(username, urlBase, apiKey string) bool {
+	trimmedURLBase := strings.TrimSpace(urlBase)
+	trimmedUsername := strings.TrimSpace(username)
+
+	// No url_base → nothing to migrate.
+	if trimmedURLBase == "" {
+		return false
+	}
+	// No api_key → modern row with a real url_base path; do not touch username.
+	if apiKey == "" {
+		return false
+	}
+	// Arm 1: url_base held the username; the dedicated column is still empty.
+	if trimmedUsername == "" {
+		return true
+	}
+	// Arm 2: both fields were kept in sync — the row was written by old code.
+	if trimmedUsername == trimmedURLBase {
+		return true
+	}
+	return false
+}
+
 func hydrateClientCredentials(c *models.DownloadClient) {
 	switch c.Type {
 	case "qbittorrent", "transmission":
 		// Backward compatibility: older rows stored credentials in url_base/api_key.
-		if strings.TrimSpace(c.Username) == "" {
+		// Only migrate when the row looks like a genuine legacy row (url_base and
+		// api_key both populated); leave modern rows with a real url_base path
+		// and dedicated username/password columns untouched. (closes #423)
+		if legacyCredentialURLBase(c.Username, c.URLBase, c.APIKey) {
 			c.Username = strings.TrimSpace(c.URLBase)
 		}
 		if c.Password == "" {
@@ -47,8 +89,10 @@ func normalizeClientCredentialStorage(c *models.DownloadClient) {
 		return
 	}
 	// Backward compatibility: accept legacy payloads that sent credentials in
-	// urlBase/apiKey.
-	if strings.TrimSpace(c.Username) == "" {
+	// urlBase/apiKey. Use the same legacyCredentialURLBase guard as the read
+	// path so that a client saved with a bare url_base and no api_key does not
+	// have its url_base silently migrated into username on write. (closes #422)
+	if legacyCredentialURLBase(c.Username, c.URLBase, c.APIKey) {
 		c.Username = strings.TrimSpace(c.URLBase)
 	}
 	if c.Password == "" && c.APIKey != "" {


### PR DESCRIPTION
Fixes #422 and #423.

## Changes

### #423 — legacyCredentialURLBase over-fires on modern rows

The previous inline logic in `hydrateClientCredentials` treated any qBittorrent/Transmission row with an empty `username` and a non-empty `url_base` as a legacy migrated credential row, regardless of whether `api_key` was populated. A user with a bare `url_base` like `qbit` and an empty `api_key` (a completely valid modern configuration) would have their `url_base` silently migrated into `username` on every read — effectively corrupting the stored value.

The fix extracts a `legacyCredentialURLBase(username, urlBase, apiKey string) bool` helper and tightens the detection: a genuine legacy row always has a non-empty `api_key` (the old schema stored the password there). An empty `api_key` is definitive evidence of a modern row with a real `url_base` path, so migration is skipped. The same guard is applied on the write path (`normalizeClientCredentialStorage`) for consistency.

### #422 — No test for normalizeClientCredentialStorage write-path

The write-path guard had no test coverage. A regression there would silently corrupt new download client rows on save without any test catching it.

Added `TestNormalizeClientCredentialStorageWritePath`: creates a qBittorrent client with bare `url_base = "qbit"` and empty `api_key`, saves it via `repo.Create`, reads it back, and asserts `url_base` is preserved as `"qbit"` and `username` is not populated from it.

Added `TestLegacyCredentialURLBase`: unit-tests all detection arms of the helper including the core regression case (`bare url_base + empty api_key → false`).

## Testing

All existing credential normalization tests pass. Two new tests added and green.