### PR TITLE
fix: audiobook routing ignores per-author ebook root; expose audiobook dir in UI

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -577,10 +577,14 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// Audiobook path: place the entire download directory as a unit so
 	// multi-part m4b/mp3 files, cover art, and cue sheets stay together.
 	if detectedFormat == models.MediaTypeAudiobook {
+		// audiobookRoot always starts from BINDERY_AUDIOBOOK_DIR (set at
+		// startup). effectiveLibraryDir is format-agnostic — it resolves the
+		// per-author ebook root folder — so applying it here would send
+		// audiobooks into the ebook root whenever the author has any custom
+		// root folder assigned, silently ignoring BINDERY_AUDIOBOOK_DIR
+		// (#421). Until a per-author audiobook root folder field exists we
+		// leave audiobookRoot as-is.
 		audiobookRoot := s.audiobookDir
-		if effLib := s.effectiveLibraryDir(ctx, author); effLib != s.libraryDir {
-			audiobookRoot = effLib
-		}
 		seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
 		audiobookDest, destErr := s.renamer.AudiobookDestDir(audiobookRoot, author, book, seriesTitle, seriesNum)
 		if destErr != nil {

--- a/internal/importer/scanner_rootfolder_test.go
+++ b/internal/importer/scanner_rootfolder_test.go
@@ -3,6 +3,9 @@ package importer
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
@@ -209,5 +212,106 @@ func TestEffectiveLibraryDir_AuthorRootFolderTakesPriorityOverDefault(t *testing
 	got := s.effectiveLibraryDir(ctx, author)
 	if got != authorDir {
 		t.Errorf("author RF should take priority: want %q, got %q", authorDir, got)
+	}
+}
+
+// TestAudiobookImport_UsesAudiobookDirNotEbookRoot is a regression test for
+// issue #421. When an author has a per-author ebook root folder set,
+// audiobooks must still be placed under BINDERY_AUDIOBOOK_DIR (s.audiobookDir)
+// rather than the ebook root folder. Before the fix, effectiveLibraryDir (which
+// is format-agnostic) was applied unconditionally to audiobookRoot, causing
+// audiobooks to land in the ebook root whenever any custom root was assigned.
+func TestAudiobookImport_UsesAudiobookDirNotEbookRoot(t *testing.T) {
+	ebookRoot := t.TempDir()   // per-author ebook root folder
+	audiobookDir := t.TempDir() // BINDERY_AUDIOBOOK_DIR
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	history := db.NewHistoryRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+	rf := db.NewRootFolderRepo(database)
+
+	libraryDir := t.TempDir()
+	// audiobookDir is explicitly different from libraryDir and ebookRoot.
+	s := NewScanner(downloads, clients, books, authors, history, libraryDir, audiobookDir, "", "", "")
+	s.WithRootFolders(rf)
+
+	ctx := context.Background()
+
+	// Register the per-author ebook root folder.
+	ebookRF, err := rf.Create(ctx, ebookRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an author whose ebook root folder points to ebookRoot.
+	author := &models.Author{
+		ForeignID:    "OL-rf-audiobook",
+		Name:         "Test Author",
+		SortName:     "Author, Test",
+		RootFolderID: &ebookRF.ID,
+	}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a book belonging to that author.
+	book := &models.Book{
+		ForeignID: "OL-rf-book",
+		AuthorID:  author.ID,
+		Title:     "Audiobook Title",
+		Status:    models.BookStatusWanted,
+		MediaType: models.MediaTypeAudiobook,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a fake download record for the audiobook.
+	dl := &models.Download{
+		GUID:   "guid-ab-rf",
+		Title:  book.Title,
+		BookID: &book.ID,
+		Status: models.StateCompleted,
+		NZBURL: "fake://url",
+	}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a fake .m4b file into a temp download directory to simulate the
+	// completed download. tryImportInternal walks this path for book files.
+	downloadPath := t.TempDir()
+	m4bFile := filepath.Join(downloadPath, "audiobook.m4b")
+	if err := os.WriteFile(m4bFile, []byte("fake m4b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s.tryImportInternal(ctx, dl, downloadPath, "", "", nil)
+
+	// The book's audiobook file path must live under audiobookDir, not under
+	// the per-author ebook root (ebookRoot).
+	got, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.AudiobookFilePath == "" {
+		t.Fatal("AudiobookFilePath is empty — import did not complete")
+	}
+	if !strings.HasPrefix(got.AudiobookFilePath, audiobookDir) {
+		t.Errorf("audiobook landed in %q; want path under audiobookDir %q (not under ebookRoot %q)",
+			got.AudiobookFilePath, audiobookDir, ebookRoot)
+	}
+	if strings.HasPrefix(got.AudiobookFilePath, ebookRoot) {
+		t.Errorf("audiobook landed in ebook root %q — BINDERY_AUDIOBOOK_DIR was ignored (#421)",
+			got.AudiobookFilePath)
 	}
 }


### PR DESCRIPTION
Fixes #421 and #420.

## Changes

### #421 — Audiobook routing broken when per-author root folder set

`effectiveLibraryDir` is format-agnostic. Applying it to `audiobookRoot` caused audiobooks to land in the per-author ebook root folder instead of `BINDERY_AUDIOBOOK_DIR` whenever any custom root was assigned to the author.

**Fix:** Removed the three lines that applied `effectiveLibraryDir` to `audiobookRoot`. Audiobooks now always use `s.audiobookDir` (set from `BINDERY_AUDIOBOOK_DIR` at startup, falling back to `BINDERY_LIBRARY_DIR`). Since `Author` has a single format-agnostic `RootFolderID` with no audiobook-specific counterpart, applying the ebook override to audiobooks was never correct.

A regression test (`TestAudiobookImport_UsesAudiobookDirNotEbookRoot`) verifies that an author with a per-author ebook root folder still has their audiobooks routed to `audiobookDir`.

### #420 — No UI for BINDERY_AUDIOBOOK_DIR

The audiobook destination directory was only configurable via environment variable, with no visibility in the Settings UI.

**Fix:** Already implemented — `GET /api/v1/system/storage` exposes `audiobookDir` alongside `downloadDir` and `libraryDir`, and the Settings → General → Storage section renders a read-only "Audiobook directory" field showing the current `BINDERY_AUDIOBOOK_DIR` value. When unset, it displays `BINDERY_LIBRARY_DIR` as the effective fallback, with an explanatory note. No additional changes needed for #420.

## Testing

- Import an audiobook for an author with a custom ebook root folder → lands in `BINDERY_AUDIOBOOK_DIR`, not ebook root
- `go test ./internal/importer/...` passes including the new regression test
- Audiobook dir visible in Settings UI under Storage