### PR TITLE
fix(ci): resolve OpenSSF Scorecard downloadThenRun finding and update SECURITY.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,9 +346,10 @@ jobs:
           fi
           echo "Waiting for ArgoCD app 'bindery-dev' to be Healthy+Synced..."
           for i in $(seq 1 24); do
+            # jq avoids a curl|python3 pipe flagged by OpenSSF Scorecard downloadThenRun
             STATUS=$(curl -sf -H "Authorization: Bearer $ARGOCD_TOKEN" \
-              "$ARGOCD_SERVER/api/v1/applications/bindery-dev" | \
-              python3 -c "import json,sys; d=json.load(sys.stdin); print(d['status']['health']['status'], d['status']['sync']['status'])" 2>/dev/null || echo "unknown unknown")
+              "$ARGOCD_SERVER/api/v1/applications/bindery-dev" 2>/dev/null | \
+              jq -r '"\(.status.health.status) \(.status.sync.status)"' 2>/dev/null || echo "unknown unknown")
             echo "  attempt $i: $STATUS"
             [[ "$STATUS" == "Healthy Synced" ]] && echo "ArgoCD dev sync complete" && exit 0
             sleep 10

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,8 +9,8 @@ Only the latest minor release receives security fixes. Older minors do not.
 
 | Version | Supported |
 | ------- | --------- |
-| 0.12.x  | Yes       |
-| < 0.12  | No        |
+| 1.2.x   | Yes       |
+| < 1.2   | No        |
 
 ## Reporting a vulnerability
 
@@ -87,7 +87,7 @@ CSP, cookie Secure auto-detect, container hardening, CI scans).
 - **Kubernetes**: dedicated ServiceAccount with token automount disabled,
   API key sourced from a Secret, optional NetworkPolicy.
 - **CI**: gosec, govulncheck, semgrep, gitleaks, ESLint security, Trivy,
-  Grype, Dockle, Syft SBOM, ZAP baseline, OpenSSF Scorecard, helm-unittest
+  Grype, Syft SBOM, ZAP baseline, OpenSSF Scorecard, Checkov, helm-unittest
   — SARIF uploaded to the Security tab; weekly rerun on a cron.
 - **Supply chain**: SLSA build provenance via
   `actions/attest-build-provenance`, verifiable with


### PR DESCRIPTION
## Summary

- Replaces `curl | python3 -c` in the predeploy-smoke ArgoCD wait step with `curl | jq`, eliminating the only open **error-severity** OpenSSF Scorecard finding (`PinnedDependencies / downloadThenRun`). `jq` is pre-installed on all GitHub-hosted Ubuntu runners.
- Updates `SECURITY.md` version support table from stale `0.12.x` to current `1.2.x`.
- Corrects the CI scanner list in `SECURITY.md`: removes `Dockle` (removed in v1.2.4) and adds `Checkov` (added in the security workflow).

## Why this matters

The Scorecard workflow has been failing every run because the SARIF upload contains this one error-severity alert. With it resolved, the workflow should complete successfully and publish a passing score to scorecard.dev.

## Test plan
- [ ] OpenSSF Scorecard workflow passes on this branch
- [ ] Predeploy smoke step still polls ArgoCD correctly (logic unchanged; `jq -r '"\(.status.health.status) \(.status.sync.status)"'` produces the same `"Healthy Synced"` output that the previous python3 one-liner did)

🤖 Generated with [Claude Code](https://claude.com/claude-code)