### PR TITLE
fix(ci): add linux/arm64 to Docker build platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
Fixes #404.

## What changed

In `.github/workflows/ci.yml`, the `docker/build-push-action` step in the `image` job previously only targeted `linux/amd64`. This PR changes the `platforms` field to:

```
platforms: linux/amd64,linux/arm64
```

## Why

Users on Apple Silicon (M1/M2/M3 Macs) and Raspberry Pi (arm64/v8) were seeing image pull errors because no arm64 manifest was published. With this change, both architectures are built and pushed to GHCR in a single multi-platform manifest.

## Notes

- `docker/setup-buildx-action` is already present in the workflow (required for multi-platform builds via QEMU emulation) — no additional setup needed.
- The distroless base image already publishes both `linux/amd64` and `linux/arm64` layers, so no Dockerfile changes are required.
- Build time will increase slightly due to cross-compilation via QEMU, but the GitHub Actions cache (`type=gha`) will mitigate repeat builds.