### PR TITLE
fix(api): return proper error response on Readarr DB import failure

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -641,8 +641,11 @@ func main() {
 		r.Get("/calibre/sync/status", calibreSyncHandler.Status)
 
 		// Migration imports (CSV of author names, or Readarr SQLite DB).
+		// The Readarr import is async — POST returns 202 immediately and the
+		// UI polls GET /migrate/readarr/status to track completion.
 		r.Post("/migrate/csv", migrateHandler.ImportCSV)
 		r.Post("/migrate/readarr", migrateHandler.ImportReadarr)
+		r.Get("/migrate/readarr/status", migrateHandler.ImportReadarrStatus)
 
 		// Image proxy — caches external cover images locally so the browser
 		// never leaks the user's IP to Goodreads / OpenLibrary / etc.

--- a/internal/api/migrate.go
+++ b/internal/api/migrate.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -59,6 +61,11 @@ type MigrateHandler struct {
 	// onNewAuthor fires in a goroutine for each newly-imported author so
 	// the book-fetch-on-add behaviour from the AddAuthor flow is preserved.
 	onNewAuthor func(author *models.Author)
+
+	// readarrImporter manages async Readarr DB imports so the HTTP handler
+	// can return 202 immediately instead of blocking for minutes while
+	// OpenLibrary metadata is resolved for each author.
+	readarrImporter *migrate.ReadarrImporter
 }
 
 func NewMigrateHandler(
@@ -74,6 +81,9 @@ func NewMigrateHandler(
 		authors: authors, indexers: indexers, clients: clients,
 		blocklist: blocklist, books: books, meta: meta,
 		onNewAuthor: onNewAuthor,
+		readarrImporter: migrate.NewReadarrImporter(
+			authors, indexers, clients, blocklist, meta, onNewAuthor,
+		),
 	}
 }
 
@@ -97,11 +107,18 @@ func (h *MigrateHandler) ImportCSV(w http.ResponseWriter, r *http.Request) {
 }
 
 // ImportReadarr accepts a multipart form with a "file" field containing
-// readarr.db (SQLite). It's saved to a temp file (sqlite driver wants a
-// path), imported, then deleted.
+// readarr.db (SQLite). The file is spooled to a temp path and the import
+// is kicked off asynchronously so the HTTP connection is not held open for
+// the duration — large libraries with many authors require one or more
+// OpenLibrary round-trips per author and can easily exceed server write
+// timeouts, producing a silent "NetworkError" in the browser.
+//
+// Returns 202 Accepted with an initial progress snapshot. The UI must poll
+// GET /api/v1/migrate/readarr/status to track completion.
 func (h *MigrateHandler) ImportReadarr(w http.ResponseWriter, r *http.Request) {
 	file, err := acceptUpload(w, r, 1<<30) // 1 GB cap — readarr.db is usually < 100 MB
 	if err != nil {
+		slog.Error("readarr import: upload rejected", "error", err)
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
@@ -109,29 +126,50 @@ func (h *MigrateHandler) ImportReadarr(w http.ResponseWriter, r *http.Request) {
 
 	tmp, err := os.CreateTemp(uploadTempDir(), "readarr-*.db")
 	if err != nil {
+		slog.Error("readarr import: create temp file failed", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "create temp: " + err.Error()})
 		return
 	}
 	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
+
 	if _, err := io.Copy(tmp, file); err != nil {
 		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		slog.Error("readarr import: spool upload failed", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "write temp: " + err.Error()})
 		return
 	}
 	if err := tmp.Close(); err != nil {
-		slog.Error("failed to close temp file", "path", tmpPath, "error", err)
-	}
-
-	result, err := migrate.ImportReadarr(
-		r.Context(), tmpPath,
-		h.authors, h.indexers, h.clients, h.blocklist, h.meta, h.onNewAuthor,
-	)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		slog.Error("readarr import: close temp file failed", "path", tmpPath, "error", err)
+		_ = os.Remove(tmpPath)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "close temp: " + err.Error()})
 		return
 	}
-	writeJSON(w, http.StatusOK, result)
+
+	// context.WithoutCancel ensures the import goroutine is not cancelled
+	// when the HTTP response is sent — same pattern as calibre/import.
+	err = h.readarrImporter.Start(context.WithoutCancel(r.Context()), tmpPath)
+	switch {
+	case errors.Is(err, migrate.ErrAlreadyRunning):
+		// Clean up the spool file we just wrote since the import won't run.
+		_ = os.Remove(tmpPath)
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	case err != nil:
+		_ = os.Remove(tmpPath)
+		slog.Error("readarr import: failed to start", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, h.readarrImporter.Progress())
+}
+
+// ImportReadarrStatus returns the current progress of an in-flight or
+// recently completed Readarr import. Cheap stateless poll — callers may
+// hit this as frequently as they like.
+func (h *MigrateHandler) ImportReadarrStatus(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, h.readarrImporter.Progress())
 }
 
 // acceptUpload reads a multipart "file" field with a size cap, returning

--- a/internal/api/migrate_test.go
+++ b/internal/api/migrate_test.go
@@ -10,9 +10,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/migrate"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -136,16 +138,115 @@ func TestUploadTempDir_CreatesDirNextToDB(t *testing.T) {
 	}
 }
 
+// TestMigrate_ImportReadarr_InvalidDB verifies that uploading garbage bytes
+// (not a valid SQLite file) returns 202 Accepted immediately (the import is
+// async) and that polling the status endpoint eventually shows an error —
+// rather than the handler silently dropping the connection and causing a
+// "NetworkError when attempting to fetch resource" in the browser (issue #398).
 func TestMigrate_ImportReadarr_InvalidDB(t *testing.T) {
 	h := migrateFixture(t, &stubProvider{})
 
-	// Valid multipart with garbage bytes — the SQLite driver should reject it.
+	// Upload garbage bytes — the SQLite driver should reject them once the
+	// goroutine opens the file, but the HTTP handler must return 202 first.
 	body, ct := multipartBody(t, "file", "readarr.db", "not a real sqlite file")
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/migrate/readarr", body)
 	req.Header.Set("Content-Type", ct)
 	rec := httptest.NewRecorder()
 	h.ImportReadarr(rec, req)
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("bad sqlite: expected 400, got %d", rec.Code)
+
+	// The handler must respond 202 immediately — never a network-level close.
+	if rec.Code != http.StatusAccepted {
+		t.Errorf("invalid db: expected 202 Accepted (async), got %d body=%s",
+			rec.Code, rec.Body.String())
+	}
+
+	// Body must decode as ReadarrProgress with Running=true.
+	var progress migrate.ReadarrProgress
+	if err := json.NewDecoder(rec.Body).Decode(&progress); err != nil {
+		t.Fatalf("decode progress: %v", err)
+	}
+	if !progress.Running {
+		t.Errorf("expected progress.Running=true immediately after start, got %+v", progress)
+	}
+	if progress.StartedAt.IsZero() {
+		t.Errorf("expected StartedAt to be set, got zero")
+	}
+
+	// Poll status until the goroutine finishes (invalid SQLite → fast error).
+	deadline := time.Now().Add(5 * time.Second)
+	var finalProgress migrate.ReadarrProgress
+	for time.Now().Before(deadline) {
+		srec := httptest.NewRecorder()
+		h.ImportReadarrStatus(srec, httptest.NewRequest(http.MethodGet, "/api/v1/migrate/readarr/status", nil))
+		if srec.Code != http.StatusOK {
+			t.Fatalf("status: expected 200, got %d", srec.Code)
+		}
+		var p migrate.ReadarrProgress
+		if err := json.NewDecoder(srec.Body).Decode(&p); err != nil {
+			t.Fatalf("decode status: %v", err)
+		}
+		if !p.Running {
+			finalProgress = p
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// The import must have finished with an error (bad SQLite).
+	if finalProgress.Running {
+		t.Fatal("import did not finish within 5 seconds")
+	}
+	if finalProgress.Error == "" {
+		t.Errorf("expected an error for invalid SQLite, got empty error field: %+v", finalProgress)
+	}
+	if finalProgress.FinishedAt == nil {
+		t.Error("expected FinishedAt to be set after completion")
+	}
+}
+
+// TestMigrate_ImportReadarr_ConflictOnDoubleSubmit checks that a second
+// concurrent upload is rejected with 409 Conflict when an import is already
+// running, and that the temp file is cleaned up.
+func TestMigrate_ImportReadarr_ConflictOnDoubleSubmit(t *testing.T) {
+	h := migrateFixture(t, &stubProvider{})
+
+	sendRequest := func() *httptest.ResponseRecorder {
+		body, ct := multipartBody(t, "file", "readarr.db", "not a real sqlite file")
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/migrate/readarr", body)
+		req.Header.Set("Content-Type", ct)
+		rec := httptest.NewRecorder()
+		h.ImportReadarr(rec, req)
+		return rec
+	}
+
+	// First request must be accepted.
+	first := sendRequest()
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first request: expected 202, got %d", first.Code)
+	}
+
+	// Immediately send a second — should hit the already-running guard.
+	second := sendRequest()
+	if second.Code != http.StatusConflict {
+		t.Errorf("second request: expected 409, got %d body=%s", second.Code, second.Body.String())
+	}
+}
+
+// TestMigrate_ImportReadarrStatus_BeforeFirstRun checks the status endpoint
+// before any import has been kicked off returns 200 with Running=false.
+func TestMigrate_ImportReadarrStatus_BeforeFirstRun(t *testing.T) {
+	h := migrateFixture(t, &stubProvider{})
+
+	rec := httptest.NewRecorder()
+	h.ImportReadarrStatus(rec, httptest.NewRequest(http.MethodGet, "/api/v1/migrate/readarr/status", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	var p migrate.ReadarrProgress
+	if err := json.NewDecoder(rec.Body).Decode(&p); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if p.Running {
+		t.Errorf("expected Running=false before any import, got %+v", p)
 	}
 }

--- a/internal/migrate/readarr_importer.go
+++ b/internal/migrate/readarr_importer.go
@@ -1,0 +1,124 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// ErrAlreadyRunning is returned by ReadarrImporter.Start when a previous
+// import is still in progress. The API layer maps this to 409 Conflict.
+var ErrAlreadyRunning = errors.New("readarr import already running")
+
+// ReadarrProgress is the poll shape for GET /api/v1/migrate/readarr/status.
+type ReadarrProgress struct {
+	Running    bool           `json:"running"`
+	StartedAt  time.Time      `json:"startedAt"`
+	Message    string         `json:"message,omitempty"`
+	Error      string         `json:"error,omitempty"`
+	FinishedAt *time.Time     `json:"finishedAt,omitempty"`
+	Result     *ReadarrResult `json:"result,omitempty"`
+}
+
+// ReadarrImporter manages async execution of a Readarr DB import. A single
+// instance is shared between the Start and Status HTTP handlers; the mutex
+// ensures only one import runs at a time and the progress field is safe to
+// read concurrently from the Status poller.
+type ReadarrImporter struct {
+	authors     *db.AuthorRepo
+	indexers    *db.IndexerRepo
+	clients     *db.DownloadClientRepo
+	blocklist   *db.BlocklistRepo
+	meta        *metadata.Aggregator
+	onNewAuthor func(*models.Author)
+
+	mu       sync.Mutex
+	running  bool
+	progress ReadarrProgress
+}
+
+// NewReadarrImporter wires the repos the import writes to.
+func NewReadarrImporter(
+	authors *db.AuthorRepo,
+	indexers *db.IndexerRepo,
+	clients *db.DownloadClientRepo,
+	blocklist *db.BlocklistRepo,
+	meta *metadata.Aggregator,
+	onNewAuthor func(*models.Author),
+) *ReadarrImporter {
+	return &ReadarrImporter{
+		authors:     authors,
+		indexers:    indexers,
+		clients:     clients,
+		blocklist:   blocklist,
+		meta:        meta,
+		onNewAuthor: onNewAuthor,
+	}
+}
+
+// Progress returns a snapshot of the current (or most recent) import.
+// Safe to call at any time.
+func (imp *ReadarrImporter) Progress() ReadarrProgress {
+	imp.mu.Lock()
+	defer imp.mu.Unlock()
+	return imp.progress
+}
+
+// Start kicks off the import of the SQLite file at tmpPath in a goroutine
+// and returns immediately. The goroutine owns tmpPath and deletes it on
+// completion regardless of outcome. ctx must outlive the HTTP request that
+// triggered it (pass context.WithoutCancel so the import survives
+// response-send). Returns ErrAlreadyRunning (→ 409) if a previous import
+// is still in progress.
+func (imp *ReadarrImporter) Start(ctx context.Context, tmpPath string) error {
+	imp.mu.Lock()
+	if imp.running {
+		imp.mu.Unlock()
+		return ErrAlreadyRunning
+	}
+	imp.running = true
+	imp.progress = ReadarrProgress{
+		Running:   true,
+		StartedAt: time.Now(),
+		Message:   "import started — this may take several minutes",
+	}
+	imp.mu.Unlock()
+
+	go func() {
+		defer os.Remove(tmpPath) // always clean up the spool file
+
+		slog.Info("readarr import: starting", "tmpPath", tmpPath)
+		res, err := ImportReadarr(ctx, tmpPath,
+			imp.authors, imp.indexers, imp.clients, imp.blocklist, imp.meta, imp.onNewAuthor)
+
+		now := time.Now()
+		imp.mu.Lock()
+		imp.running = false
+		imp.progress.Running = false
+		imp.progress.FinishedAt = &now
+		if err != nil {
+			slog.Error("readarr import: failed", "error", err)
+			imp.progress.Error = err.Error()
+			imp.progress.Message = ""
+		} else {
+			slog.Info("readarr import: complete",
+				"authors_added", res.Authors.Added,
+				"indexers_added", res.Indexers.Added,
+				"clients_added", res.DownloadClients.Added,
+				"blocklist_added", res.Blocklist.Added,
+			)
+			imp.progress.Result = res
+			imp.progress.Message = "import complete"
+		}
+		imp.mu.Unlock()
+	}()
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Fixes #398 — "NetworkError when attempting to fetch resource" on Readarr DB upload with nothing in the logs.

**Root cause:** `ImportReadarr` ran synchronously inside the HTTP handler. For a large Readarr database the handler makes one or more OpenLibrary API calls per author. The HTTP server has a 120-second `WriteTimeout`. When the import takes longer, the server kills the connection before any response byte is written — the browser sees a bare NetworkError and the server logs nothing, because the handler was mid-work rather than in an error path.

**Fix — async import with a status endpoint (same pattern as `calibre/import`):**

- `POST /api/v1/migrate/readarr` now spools the upload to a temp file and immediately returns `202 Accepted` with a `ReadarrProgress` JSON snapshot. The import runs in a goroutine that owns the temp file and deletes it on completion.
- `GET /api/v1/migrate/readarr/status` (new) lets the UI poll progress until `running` becomes false, then surface `result` (on success) or `error` (on failure).
- `context.WithoutCancel` ensures the import goroutine is not cancelled when the HTTP response is sent (same guard used by the Calibre importer).
- All error paths in the upload phase (bad multipart, temp-file failure, concurrent import) now return a JSON error body and are logged via `slog`.

**New `ReadarrImporter` in `internal/migrate`** — owns the mutex, goroutine, and progress state. Identical structural contract to `calibre.Importer`.

## Test plan

- `TestMigrate_ImportReadarr_InvalidDB` — uploads garbage bytes, asserts 202 immediately, polls status until done, asserts `error` field is non-empty. This is the regression test for #398.
- `TestMigrate_ImportReadarr_ConflictOnDoubleSubmit` — second concurrent upload gets 409.
- `TestMigrate_ImportReadarrStatus_BeforeFirstRun` — status returns 200 with `running=false` before any import.
- Existing tests (`BadMultipart`, CSV tests, `readarr_test.go` suite) all still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)