### PR TITLE
test(downloader): cover download client edge-case matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Download client edge-case coverage** (#431) — Added hermetic matrix tests for RemoteID normalization, live status error mapping, poll failures, unreachable clients, context deadlines, and qBittorrent unfiltered hash polling. Transmission queue overlays now surface non-empty `errorString` values as error statuses.
+
 ## [v1.2.7] — 2026-05-04
 
 ### Added

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -314,7 +314,7 @@ func paginateArrQueueRecords(records []arrQueueRecord, page, pageSize int) []arr
 
 func storedDownloadID(d models.Download) string {
 	if d.TorrentID != nil && *d.TorrentID != "" {
-		return *d.TorrentID
+		return strings.ToLower(*d.TorrentID)
 	}
 	if d.SABnzbdNzoID != nil && *d.SABnzbdNzoID != "" {
 		return *d.SABnzbdNzoID
@@ -342,7 +342,13 @@ func trackedDownloadStatus(item enrichedQueueItem) string {
 
 func liveStatusIsError(status string) bool {
 	status = strings.ToLower(status)
-	return strings.Contains(status, "error") || strings.Contains(status, "fail")
+	if strings.Contains(status, "error") || strings.Contains(status, "fail") {
+		return true
+	}
+	if n, err := strconv.Atoi(status); err == nil {
+		return n == 16 || n == 32
+	}
+	return false
 }
 
 func queueItemSize(item enrichedQueueItem) int64 {

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -342,13 +342,7 @@ func trackedDownloadStatus(item enrichedQueueItem) string {
 
 func liveStatusIsError(status string) bool {
 	status = strings.ToLower(status)
-	if strings.Contains(status, "error") || strings.Contains(status, "fail") {
-		return true
-	}
-	if n, err := strconv.Atoi(status); err == nil {
-		return n == 16 || n == 32
-	}
-	return false
+	return strings.Contains(status, "error") || strings.Contains(status, "fail")
 }
 
 func queueItemSize(item enrichedQueueItem) int64 {

--- a/internal/api/queue_test.go
+++ b/internal/api/queue_test.go
@@ -500,6 +500,326 @@ func TestQueueListArrCompatibleQbittorrentShape(t *testing.T) {
 	}
 }
 
+func TestQueueListArrCompatibleLiveStatusMatrix(t *testing.T) {
+	newStatusServer := func(t *testing.T, clientType, remoteID string, errorState bool) *httptest.Server {
+		t.Helper()
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch clientType {
+			case "sabnzbd":
+				status := "Downloading"
+				if errorState {
+					status = "Failed"
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"queue": map[string]any{
+						"slots": []map[string]any{{
+							"nzo_id":     remoteID,
+							"status":     status,
+							"mb":         "10.0",
+							"mbleft":     "5.0",
+							"percentage": "50",
+						}},
+					},
+				})
+			case "nzbget":
+				nzbID, err := strconv.Atoi(remoteID)
+				if err != nil {
+					t.Fatalf("bad NZBGet remote ID: %v", err)
+				}
+				status := "DOWNLOADING"
+				if errorState {
+					status = "FAILURE/UNPACK"
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"result": []map[string]any{{
+						"NZBID":           nzbID,
+						"Status":          status,
+						"FileSizeMB":      10.0,
+						"RemainingSizeMB": 5.0,
+					}},
+				})
+			case "transmission":
+				status := 2
+				if errorState {
+					status = 16
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"arguments": map[string]any{
+						"torrents": []map[string]any{{
+							"id":            7,
+							"status":        status,
+							"percentDone":   0.5,
+							"totalSize":     1000,
+							"leftUntilDone": 500,
+						}},
+					},
+					"result": "success",
+				})
+			case "qbittorrent":
+				switch r.URL.Path {
+				case "/api/v2/auth/login":
+					_, _ = w.Write([]byte("Ok."))
+				case "/api/v2/torrents/info":
+					state := "downloading"
+					if errorState {
+						state = "error"
+					}
+					_ = json.NewEncoder(w).Encode([]map[string]any{{
+						"hash":        remoteID,
+						"state":       state,
+						"progress":    0.5,
+						"size":        1000,
+						"amount_left": 500,
+					}})
+				default:
+					t.Fatalf("unexpected qBittorrent path: %s", r.URL.Path)
+				}
+			case "deluge":
+				var req struct {
+					Method string `json:"method"`
+					ID     int64  `json:"id"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Fatalf("decode Deluge request: %v", err)
+				}
+				var result any
+				switch req.Method {
+				case "auth.login":
+					result = true
+				case "core.get_torrents_status":
+					state := "Downloading"
+					if errorState {
+						state = "Error"
+					}
+					result = map[string]any{
+						remoteID: map[string]any{
+							"hash":       remoteID,
+							"state":      state,
+							"progress":   50.0,
+							"total_size": 1000,
+							"total_done": 500,
+						},
+					}
+				default:
+					t.Fatalf("unexpected Deluge method: %s", req.Method)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{"result": result, "error": nil, "id": req.ID})
+			default:
+				t.Fatalf("unsupported client type: %s", clientType)
+			}
+		}))
+	}
+
+	tests := []struct {
+		name       string
+		clientType string
+		remoteID   string
+		torrent    bool
+		errorState bool
+		want       string
+	}{
+		{name: "sabnzbd healthy", clientType: "sabnzbd", remoteID: "nzo-sab", want: "ok"},
+		{name: "sabnzbd error", clientType: "sabnzbd", remoteID: "nzo-sab", errorState: true, want: "error"},
+		{name: "nzbget healthy", clientType: "nzbget", remoteID: "101", want: "ok"},
+		{name: "nzbget error", clientType: "nzbget", remoteID: "101", errorState: true, want: "error"},
+		{name: "transmission healthy", clientType: "transmission", remoteID: "7", torrent: true, want: "ok"},
+		{name: "transmission error", clientType: "transmission", remoteID: "7", torrent: true, errorState: true, want: "error"},
+		{name: "qbittorrent healthy", clientType: "qbittorrent", remoteID: "abcdef", torrent: true, want: "ok"},
+		{name: "qbittorrent error", clientType: "qbittorrent", remoteID: "abcdef", torrent: true, errorState: true, want: "error"},
+		{name: "deluge healthy", clientType: "deluge", remoteID: "abcdef", torrent: true, want: "ok"},
+		{name: "deluge error", clientType: "deluge", remoteID: "abcdef", torrent: true, errorState: true, want: "error"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newStatusServer(t, tc.clientType, tc.remoteID, tc.errorState)
+			defer srv.Close()
+
+			h := newQueueTestHandler(t)
+			host, port := testServerHostPort(t, srv.URL)
+			client := createTestDownloadClient(t, h, &models.DownloadClient{
+				Name:     tc.clientType,
+				Type:     tc.clientType,
+				Host:     host,
+				Port:     port,
+				APIKey:   "testkey",
+				Username: "user",
+				Password: "pass",
+				Enabled:  true,
+			})
+			dl := &models.Download{
+				GUID:             "guid-" + tc.name,
+				DownloadClientID: &client.ID,
+				Title:            "Matrix Book",
+				NZBURL:           "https://example.com/download",
+				Size:             1000,
+				Status:           models.DownloadStatusDownloading,
+				Protocol:         "usenet",
+			}
+			if tc.torrent {
+				dl.Protocol = "torrent"
+				dl.TorrentID = strPtr(tc.remoteID)
+			} else {
+				dl.SABnzbdNzoID = strPtr(tc.remoteID)
+			}
+			createTestDownload(t, h, dl)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+			rr := httptest.NewRecorder()
+			h.ListArrCompatible(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+			}
+			var resp arrQueueResponse
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if len(resp.Records) != 1 {
+				t.Fatalf("expected one record, got %+v", resp)
+			}
+			if resp.Records[0].TrackedDownloadStatus != tc.want {
+				t.Fatalf("trackedDownloadStatus: want %q, got %+v", tc.want, resp.Records[0])
+			}
+		})
+	}
+}
+
+func TestQueueListArrCompatiblePollFailureMatrix(t *testing.T) {
+	tests := []struct {
+		name       string
+		clientType string
+		remoteID   string
+		torrent    bool
+	}{
+		{name: "sabnzbd", clientType: "sabnzbd", remoteID: "nzo-sab"},
+		{name: "nzbget", clientType: "nzbget", remoteID: "101"},
+		{name: "transmission", clientType: "transmission", remoteID: "7", torrent: true},
+		{name: "qbittorrent", clientType: "qbittorrent", remoteID: "abcdef", torrent: true},
+		{name: "deluge", clientType: "deluge", remoteID: "abcdef", torrent: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "down", http.StatusBadGateway)
+			}))
+			defer srv.Close()
+
+			h := newQueueTestHandler(t)
+			host, port := testServerHostPort(t, srv.URL)
+			client := createTestDownloadClient(t, h, &models.DownloadClient{
+				Name:     tc.clientType,
+				Type:     tc.clientType,
+				Host:     host,
+				Port:     port,
+				APIKey:   "testkey",
+				Username: "user",
+				Password: "pass",
+				Enabled:  true,
+			})
+			dl := &models.Download{
+				GUID:             "guid-warning-" + tc.name,
+				DownloadClientID: &client.ID,
+				Title:            "Warning Book",
+				NZBURL:           "https://example.com/download",
+				Size:             2048,
+				Status:           models.DownloadStatusDownloading,
+				Protocol:         "usenet",
+			}
+			if tc.torrent {
+				dl.Protocol = "torrent"
+				dl.TorrentID = strPtr(tc.remoteID)
+			} else {
+				dl.SABnzbdNzoID = strPtr(tc.remoteID)
+			}
+			createTestDownload(t, h, dl)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+			rr := httptest.NewRecorder()
+			h.ListArrCompatible(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+			}
+			var resp arrQueueResponse
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if len(resp.Records) != 1 {
+				t.Fatalf("expected one record, got %+v", resp)
+			}
+			if resp.Records[0].TrackedDownloadStatus != "warning" {
+				t.Fatalf("expected warning status, got %+v", resp.Records[0])
+			}
+			if resp.Records[0].SizeLeft != 2048 {
+				t.Fatalf("expected conservative sizeleft, got %+v", resp.Records[0])
+			}
+		})
+	}
+}
+
+func TestQueueListArrCompatibleRemoteIDNormalization(t *testing.T) {
+	tests := []struct {
+		name       string
+		clientType string
+		torrentID  *string
+		nzoID      *string
+		want       string
+	}{
+		{name: "qbittorrent torrent ID", clientType: "qbittorrent", torrentID: strPtr("ABCDEF"), want: "abcdef"},
+		{name: "deluge torrent ID", clientType: "deluge", torrentID: strPtr("123ABC"), want: "123abc"},
+		{name: "sabnzbd nzo ID", clientType: "sabnzbd", nzoID: strPtr("NZOABC"), want: "NZOABC"},
+		{name: "nzbget ID", clientType: "nzbget", nzoID: strPtr("NZBABC"), want: "NZBABC"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newQueueTestHandler(t)
+			client := createTestDownloadClient(t, h, &models.DownloadClient{
+				Name:    tc.clientType,
+				Type:    tc.clientType,
+				Host:    "127.0.0.1",
+				Port:    1,
+				Enabled: false,
+			})
+			protocol := "usenet"
+			if tc.torrentID != nil {
+				protocol = "torrent"
+			}
+			createTestDownload(t, h, &models.Download{
+				GUID:             "guid-normalize-" + tc.name,
+				DownloadClientID: &client.ID,
+				Title:            "Remote ID Book",
+				NZBURL:           "https://example.com/download",
+				Size:             100,
+				Status:           models.DownloadStatusDownloading,
+				Protocol:         protocol,
+				TorrentID:        tc.torrentID,
+				SABnzbdNzoID:     tc.nzoID,
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/api/queue", nil)
+			rr := httptest.NewRecorder()
+			h.ListArrCompatible(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+			}
+			var resp arrQueueResponse
+			if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if len(resp.Records) != 1 {
+				t.Fatalf("expected one record, got %+v", resp)
+			}
+			if resp.Records[0].DownloadID != tc.want {
+				t.Fatalf("downloadId: want %q, got %+v", tc.want, resp.Records[0])
+			}
+		})
+	}
+}
+
 func TestQueueListArrCompatiblePollFailureWarns(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "down", http.StatusBadGateway)

--- a/internal/api/queue_test.go
+++ b/internal/api/queue_test.go
@@ -540,14 +540,17 @@ func TestQueueListArrCompatibleLiveStatusMatrix(t *testing.T) {
 				})
 			case "transmission":
 				status := 2
+				errorString := ""
 				if errorState {
-					status = 16
+					status = 0
+					errorString = "No data found! Ensure your drives are connected"
 				}
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"arguments": map[string]any{
 						"torrents": []map[string]any{{
 							"id":            7,
 							"status":        status,
+							"errorString":   errorString,
 							"percentDone":   0.5,
 							"totalSize":     1000,
 							"leftUntilDone": 500,

--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -58,6 +59,7 @@ func (r *DownloadRepo) GetByNzoID(ctx context.Context, nzoID string) (*models.Do
 }
 
 func (r *DownloadRepo) GetByTorrentID(ctx context.Context, torrentID string) (*models.Download, error) {
+	torrentID = strings.ToLower(torrentID)
 	dl, err := r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads WHERE torrent_id=?", torrentID)
 	if err != nil || len(dl) == 0 {
 		return nil, err
@@ -118,6 +120,7 @@ func (r *DownloadRepo) SetNzoID(ctx context.Context, id int64, nzoID string) err
 }
 
 func (r *DownloadRepo) SetTorrentID(ctx context.Context, id int64, torrentID string) error {
+	torrentID = strings.ToLower(torrentID)
 	_, err := r.db.ExecContext(ctx, "UPDATE downloads SET torrent_id=? WHERE id=?", torrentID, id)
 	return err
 }

--- a/internal/db/downloads_coverage_test.go
+++ b/internal/db/downloads_coverage_test.go
@@ -33,8 +33,9 @@ func TestDownloadRepo_TorrentIDRoundTrip(t *testing.T) {
 		t.Errorf("expected nil for unset torrent_id, got %+v", got)
 	}
 
-	// Set and look up.
-	if err := repo.SetTorrentID(ctx, dl.ID, "hash123"); err != nil {
+	// Set and look up. Torrent hashes are normalized to lowercase at the
+	// storage boundary so older mixed-case IDs still compare consistently.
+	if err := repo.SetTorrentID(ctx, dl.ID, "HASH123"); err != nil {
 		t.Fatalf("SetTorrentID: %v", err)
 	}
 	got, err = repo.GetByTorrentID(ctx, "hash123")
@@ -46,6 +47,13 @@ func TestDownloadRepo_TorrentIDRoundTrip(t *testing.T) {
 	}
 	if got.TorrentID == nil || *got.TorrentID != "hash123" {
 		t.Errorf("TorrentID not populated: %v", got.TorrentID)
+	}
+	got, err = repo.GetByTorrentID(ctx, "HASH123")
+	if err != nil {
+		t.Fatalf("GetByTorrentID uppercase: %v", err)
+	}
+	if got == nil || got.ID != dl.ID {
+		t.Errorf("GetByTorrentID uppercase unexpected: %+v", got)
 	}
 }
 

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -24,24 +24,17 @@ type LiveStatus struct {
 	Size       int64
 	SizeLeft   int64
 	// Status is an optional client-specific status string. For Transmission,
-	// this is the integer torrent status code serialised via strconv.Itoa
-	// (e.g. "16" = error, "32" = isolated-error).
+	// non-empty errorString values are exposed as error statuses; otherwise the
+	// integer torrent status code is serialised via strconv.Itoa.
 	Status string
 }
 
 // liveStatusIsError reports whether ls represents an error state.
-// It handles both human-readable strings (e.g. qBittorrent "error") and
-// Transmission's integer status codes (16 = error, 32 = isolated-error).
+// It handles human-readable strings from clients such as qBittorrent, Deluge,
+// SABnzbd, NZBGet, and Transmission errorString overlays.
 func liveStatusIsError(ls LiveStatus) bool {
 	s := strings.ToLower(ls.Status)
-	if strings.Contains(s, "error") || strings.Contains(s, "fail") {
-		return true
-	}
-	// Transmission encodes status as an integer string; check known error codes.
-	if n, err := strconv.Atoi(ls.Status); err == nil {
-		return n == 16 || n == 32
-	}
-	return false
+	return strings.Contains(s, "error") || strings.Contains(s, "fail")
 }
 
 type SendResult struct {
@@ -326,13 +319,17 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 		out := make(map[string]LiveStatus, len(torrents))
 		for _, t := range torrents {
 			id := strconv.FormatInt(t.ID, 10)
+			status := strconv.Itoa(t.Status)
+			if errString := strings.TrimSpace(t.ErrorString); errString != "" {
+				status = "error: " + errString
+			}
 			out[id] = LiveStatus{
 				Percentage: fmt.Sprintf("%.1f", t.PercentDone*100),
 				TimeLeft:   etaToTimeLeft(t.ETA),
 				Speed:      bytesPerSecondToString(t.DownloadRate),
 				Size:       t.TotalSize,
 				SizeLeft:   t.LeftUntilDone,
-				Status:     strconv.Itoa(t.Status),
+				Status:     status,
 			}
 		}
 		return out, nil

--- a/internal/downloader/adapter_test.go
+++ b/internal/downloader/adapter_test.go
@@ -3,11 +3,13 @@ package downloader
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -357,6 +359,81 @@ func TestTestClient_Qbittorrent(t *testing.T) {
 	client := &models.DownloadClient{Type: "qbittorrent", Host: host, Port: port, Username: "u", Password: "p"}
 	if err := TestClient(context.Background(), client); err != nil {
 		t.Fatalf("TestClient: %v", err)
+	}
+}
+
+func TestTestClient_ConnectionFailureMatrix(t *testing.T) {
+	tests := []struct {
+		name       string
+		clientType string
+	}{
+		{name: "SABnzbd", clientType: "sabnzbd"},
+		{name: "NZBGet", clientType: "nzbget"},
+		{name: "Transmission", clientType: "transmission"},
+		{name: "qBittorrent", clientType: "qbittorrent"},
+		{name: "Deluge", clientType: "deluge"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			host, port := serverHostPort(t, srv.URL)
+			srv.Close()
+
+			client := &models.DownloadClient{
+				Type:     tc.clientType,
+				Host:     host,
+				Port:     port,
+				APIKey:   "testkey",
+				Username: "user",
+				Password: "pass",
+			}
+			if err := TestClient(context.Background(), client); err == nil {
+				t.Fatal("expected connection failure error, got nil")
+			}
+		})
+	}
+}
+
+func TestTestClient_TimeoutMatrix(t *testing.T) {
+	tests := []struct {
+		name       string
+		clientType string
+	}{
+		{name: "SABnzbd", clientType: "sabnzbd"},
+		{name: "NZBGet", clientType: "nzbget"},
+		{name: "Transmission", clientType: "transmission"},
+		{name: "qBittorrent", clientType: "qbittorrent"},
+		{name: "Deluge", clientType: "deluge"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				time.Sleep(200 * time.Millisecond)
+			}))
+			defer srv.Close()
+
+			host, port := serverHostPort(t, srv.URL)
+			client := &models.DownloadClient{
+				Type:     tc.clientType,
+				Host:     host,
+				Port:     port,
+				APIKey:   "testkey",
+				Username: "user",
+				Password: "pass",
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+			defer cancel()
+
+			err := TestClient(ctx, client)
+			if err == nil {
+				t.Fatal("expected timeout error, got nil")
+			}
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("expected context deadline exceeded, got %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/downloader/adapter_test.go
+++ b/internal/downloader/adapter_test.go
@@ -715,18 +715,18 @@ func TestBytesPerSecondToString_Bytes(t *testing.T) {
 // liveStatusIsError — issue #426
 // ---------------------------------------------------------------------------
 
-func TestLiveStatusIsError_TransmissionIntegerCodes(t *testing.T) {
+func TestLiveStatusIsError_StatusStrings(t *testing.T) {
 	tests := []struct {
 		status string
 		want   bool
 	}{
-		// Transmission error codes
-		{"16", true}, // TR_STATUS_CHECK_WAIT (error)
-		{"32", true}, // TR_STATUS_ISOLATED_ERROR
-		{"0", false}, // stopped but not an error code
+		// Transmission integer statuses are not error codes; failures are
+		// surfaced through errorString overlays.
+		{"0", false}, // stopped
 		{"3", false}, // seeding
 		{"2", false}, // downloading
-		// String-based statuses (qBittorrent, Deluge)
+		{"error: No data found", true},
+		// String-based statuses (qBittorrent, Deluge, SABnzbd, NZBGet)
 		{"error", true},
 		{"Error", true},
 		{"stalledDL", false},
@@ -743,7 +743,7 @@ func TestLiveStatusIsError_TransmissionIntegerCodes(t *testing.T) {
 	}
 }
 
-func TestGetLiveStatusesTransmission_PopulatesStatus(t *testing.T) {
+func TestGetLiveStatusesTransmission_UsesErrorStringStatus(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"arguments": map[string]any{
@@ -751,7 +751,8 @@ func TestGetLiveStatusesTransmission_PopulatesStatus(t *testing.T) {
 					{
 						"id":          10,
 						"percentDone": 0.5,
-						"status":      16, // Transmission error code
+						"status":      0,
+						"errorString": "No data found! Ensure your drives are connected",
 					},
 				},
 			},
@@ -770,10 +771,10 @@ func TestGetLiveStatusesTransmission_PopulatesStatus(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected torrent id 10 in status map")
 	}
-	if ls.Status != "16" {
-		t.Errorf("expected Status=%q, got %q", "16", ls.Status)
+	if ls.Status != "error: No data found! Ensure your drives are connected" {
+		t.Errorf("unexpected Status=%q", ls.Status)
 	}
 	if !liveStatusIsError(ls) {
-		t.Error("expected liveStatusIsError to return true for Transmission status 16")
+		t.Error("expected liveStatusIsError to return true for Transmission errorString")
 	}
 }

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -463,6 +463,7 @@ func TestAddTorrent_HashFoundUnderDifferentCategory(t *testing.T) {
 	var setCategoryHash, setCategoryValue string
 	var mu sync.Mutex
 	added := false // becomes true after /torrents/add is called
+	infoQueries := []string{}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -474,6 +475,15 @@ func TestAddTorrent_HashFoundUnderDifferentCategory(t *testing.T) {
 			mu.Unlock()
 			_, _ = w.Write([]byte("Ok."))
 		case "/api/v2/torrents/info":
+			mu.Lock()
+			infoQueries = append(infoQueries, r.URL.RawQuery)
+			mu.Unlock()
+			if r.URL.Query().Get("category") != "" {
+				// A category-filtered lookup would reproduce the race from #418:
+				// qBittorrent can expose the hash before category metadata lands.
+				_, _ = w.Write([]byte("[]"))
+				return
+			}
 			mu.Lock()
 			isAdded := added
 			mu.Unlock()
@@ -522,6 +532,17 @@ func TestAddTorrent_HashFoundUnderDifferentCategory(t *testing.T) {
 	}
 	if gotSetCatVal != "books" {
 		t.Errorf("setCategory category: want %q, got %q", "books", gotSetCatVal)
+	}
+	mu.Lock()
+	gotInfoQueries := append([]string(nil), infoQueries...)
+	mu.Unlock()
+	if len(gotInfoQueries) == 0 {
+		t.Fatal("expected torrent info to be polled")
+	}
+	for _, rawQuery := range gotInfoQueries {
+		if rawQuery != "" {
+			t.Errorf("torrent info poll should be unfiltered, got query %q", rawQuery)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #431.

- Adds hermetic matrix coverage for SABnzbd, NZBGet, Transmission, qBittorrent, and Deluge queue live-status handling, including healthy/error status mapping and poll failures.
- Covers RemoteID normalization for torrent clients, lowercases torrent IDs at the storage/queue boundary, and preserves Usenet NZO IDs.
- Adds connection-failure and context-timeout coverage for all download client connectivity checks, plus qBittorrent category-race coverage that asserts hash polling stays unfiltered.
- Surfaces Transmission `errorString` values as live error statuses so queue records report the failure state accurately.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (N/A: none changed)
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] Wiki pages updated if user-facing behaviour changed

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [x] `cd web && npm run build`
