### PR TITLE
[codex] Fix add-author search rejecting book-title matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,11 @@ All notable changes to Bindery are documented here. Format loosely follows
 ### Fixed
 
 - **Manual series mutations require admin role** (#468) — Authenticated non-admin users can no longer create, update, monitor, delete, fill, or link series to Hardcover. Read-only series endpoints remain available to authenticated users.
-
-## [Unreleased]
-
-### Fixed
-
 - **Library file matching now respects media type** (#488, #454) — `FindExisting` now picks the right library root based on the book's `media_type` instead of always walking `BINDERY_LIBRARY_DIR` first. Audiobook book rows are matched against `BINDERY_AUDIOBOOK_DIR` (with fallback to `BINDERY_LIBRARY_DIR` when the audiobook root is unset), ebook rows are matched against `BINDERY_LIBRARY_DIR`, and dual-format / unspecified rows preserve the prior behaviour of walking both roots with the ebook library first. Previously a same-titled ebook in `libraryDir` could be mis-attributed to an audiobook entry on rescan, and authors filtered to "audiobooks only" still had file lookups walk the ebook root.
 - **Edition dedup now strips subtitles** (#458) — Author sync no longer creates duplicate rows when OpenLibrary returns the same work twice with different subtitle handling — typically the audiobook drops the post-colon subtitle while the ebook keeps it (e.g. *Carl's Doomsday Scenario* vs. *Carl's Doomsday Scenario: Dungeon Crawler Carl, Book 2*). `NormalizeTitleForDedup` now drops a `: subtitle` tail when the colon is followed by whitespace, so both editions collapse to the same key and the existing v1.3.1 dual-format upgrade path is taken instead of inserting a duplicate.
 - **Series title inputs now have an API length limit** (#469) — Manual series creation and title updates now reject titles longer than 500 bytes before writing to SQLite, preventing oversized titles from being stored through the HTTP API.
 - **Hardcover GraphQL success responses are bounded** (#470) — Successful Hardcover responses are now read through an 8 MiB cap so a misbehaving upstream cannot force unbounded memory growth before JSON parsing.
+- **Add-author search no longer accepts book-title matches** — Search results that come back from OpenLibrary as works/books are filtered out of the Add Author modal, preventing some books from being added as authors.
 
 ## [v1.4.3] — 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to Bindery are documented here. Format loosely follows
 - **Edition dedup now strips subtitles** (#458) — Author sync no longer creates duplicate rows when OpenLibrary returns the same work twice with different subtitle handling — typically the audiobook drops the post-colon subtitle while the ebook keeps it (e.g. *Carl's Doomsday Scenario* vs. *Carl's Doomsday Scenario: Dungeon Crawler Carl, Book 2*). `NormalizeTitleForDedup` now drops a `: subtitle` tail when the colon is followed by whitespace, so both editions collapse to the same key and the existing v1.3.1 dual-format upgrade path is taken instead of inserting a duplicate.
 - **Series title inputs now have an API length limit** (#469) — Manual series creation and title updates now reject titles longer than 500 bytes before writing to SQLite, preventing oversized titles from being stored through the HTTP API.
 - **Hardcover GraphQL success responses are bounded** (#470) — Successful Hardcover responses are now read through an 8 MiB cap so a misbehaving upstream cannot force unbounded memory growth before JSON parsing.
-- **Add-author search no longer accepts book-title matches** — Search results that come back from OpenLibrary as works/books are filtered out of the Add Author modal, preventing some books from being added as authors.
+- **Add-author search no longer hides valid author results when the query matches a book title** — Results whose name exactly matches a known book title and whose disambiguation points to that book's real author are now placed behind a reveal button rather than silently dropped.
 
 ## [v1.4.3] — 2026-05-06
 

--- a/web/src/components/AddAuthorModal.test.tsx
+++ b/web/src/components/AddAuthorModal.test.tsx
@@ -14,6 +14,10 @@ vi.mock('react-i18next', () => ({
       if (key === 'addAuthorModal.searchError') {
         return `Could not reach the metadata provider - ${String(options?.error ?? '')}`
       }
+      if (key === 'addAuthorModal.showHiddenResults') {
+        const count = Number(options?.count ?? 0)
+        return `Show ${count} hidden result${count === 1 ? '' : 's'}`
+      }
       return strings[key] ?? key
     },
   }),
@@ -26,12 +30,50 @@ vi.mock('../api/client', () => ({
     listRootFolders: vi.fn().mockResolvedValue([]),
     getSetting: vi.fn().mockResolvedValue({ key: 'default.media_type', value: 'ebook' }),
     searchAuthors: vi.fn(),
+    searchBooks: vi.fn(),
     addAuthor: vi.fn(),
   },
 }))
 
 // Import after the mock is set up so we get the mocked version.
 import { api } from '../api/client'
+import type { Author, Book } from '../api/client'
+
+function author(overrides: Partial<Author>): Author {
+  return {
+    id: 1,
+    foreignAuthorId: 'OL_AUTHOR_A',
+    authorName: 'Author',
+    sortName: 'Author',
+    description: '',
+    imageUrl: '',
+    disambiguation: '',
+    ratingsCount: 0,
+    averageRating: 0,
+    monitored: true,
+    ...overrides,
+  }
+}
+
+function book(overrides: Partial<Book>): Book {
+  return {
+    id: 1,
+    foreignBookId: 'OL_BOOK_W',
+    authorId: 1,
+    title: 'Book',
+    description: '',
+    imageUrl: '',
+    genres: [],
+    monitored: true,
+    status: 'wanted',
+    filePath: '',
+    mediaType: 'ebook',
+    ebookFilePath: '',
+    audiobookFilePath: '',
+    excluded: false,
+    ...overrides,
+  }
+}
 
 describe('AddAuthorModal — search error handling', () => {
   const onClose = vi.fn()
@@ -42,6 +84,8 @@ describe('AddAuthorModal — search error handling', () => {
     vi.mocked(api.listMetadataProfiles).mockResolvedValue([])
     vi.mocked(api.listRootFolders).mockResolvedValue([])
     vi.mocked(api.getSetting).mockResolvedValue({ key: 'default.media_type', value: 'ebook' })
+    vi.mocked(api.searchBooks).mockResolvedValue([])
+    vi.mocked(api.addAuthor).mockResolvedValue(author({}))
   })
 
   it('shows an error banner when the metadata provider is unreachable', async () => {
@@ -172,5 +216,125 @@ describe('AddAuthorModal — search error handling', () => {
       foreignAuthorId: 'OL26320A',
       authorName: 'J.R.R. Tolkien',
     }))
+  })
+
+  it('hides likely book-title results by default and reveals them on request', async () => {
+    const hiddenAuthor = author({
+      foreignAuthorId: 'OL_BAD_TITLE_A',
+      authorName: 'Romeo and Juliet',
+      disambiguation: 'William Shakespeare',
+    })
+    vi.mocked(api.searchAuthors).mockResolvedValue([hiddenAuthor])
+    vi.mocked(api.searchBooks).mockResolvedValue([
+      book({
+        title: 'Romeo and Juliet',
+        author: author({
+          foreignAuthorId: 'OL_SHAKESPEARE_A',
+          authorName: 'William Shakespeare',
+        }),
+      }),
+    ])
+
+    render(<AddAuthorModal onClose={onClose} onAdded={onAdded} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Search by author name...'), {
+      target: { value: 'Romeo and Juliet' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+
+    const revealButton = await screen.findByRole('button', { name: /show 1 hidden result/i })
+    expect(screen.queryByText('Romeo and Juliet')).not.toBeInTheDocument()
+
+    fireEvent.click(revealButton)
+    expect(screen.getByText('Romeo and Juliet')).toBeInTheDocument()
+  })
+
+  it('allows revealed hidden results to be added', async () => {
+    const hiddenAuthor = author({
+      foreignAuthorId: 'OL_BAD_TITLE_A',
+      authorName: 'Romeo and Juliet',
+      disambiguation: 'William Shakespeare',
+    })
+    vi.mocked(api.searchAuthors).mockResolvedValue([hiddenAuthor])
+    vi.mocked(api.searchBooks).mockResolvedValue([
+      book({
+        title: 'Romeo and Juliet',
+        author: author({
+          foreignAuthorId: 'OL_SHAKESPEARE_A',
+          authorName: 'William Shakespeare',
+        }),
+      }),
+    ])
+
+    render(<AddAuthorModal onClose={onClose} onAdded={onAdded} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Search by author name...'), {
+      target: { value: 'Romeo and Juliet' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /show 1 hidden result/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    await waitFor(() =>
+      expect(api.addAuthor).toHaveBeenCalledWith(expect.objectContaining({
+        foreignAuthorId: 'OL_BAD_TITLE_A',
+        authorName: 'Romeo and Juliet',
+      }))
+    )
+    expect(onAdded).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('keeps regular author results visible while hiding only the title-shaped result', async () => {
+    const visibleAuthor = author({
+      foreignAuthorId: 'OL_SHAKESPEARE_A',
+      authorName: 'William Shakespeare',
+      disambiguation: 'Romeo and Juliet',
+    })
+    const hiddenAuthor = author({
+      foreignAuthorId: 'OL_BAD_TITLE_A',
+      authorName: 'Romeo and Juliet',
+      disambiguation: 'William Shakespeare',
+    })
+    vi.mocked(api.searchAuthors).mockResolvedValue([visibleAuthor, hiddenAuthor])
+    vi.mocked(api.searchBooks).mockResolvedValue([
+      book({
+        title: 'Romeo and Juliet',
+        author: visibleAuthor,
+      }),
+    ])
+
+    render(<AddAuthorModal onClose={onClose} onAdded={onAdded} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Search by author name...'), {
+      target: { value: 'Romeo and Juliet' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+
+    await waitFor(() => expect(screen.getByText('William Shakespeare')).toBeInTheDocument())
+    expect(screen.queryByText('Romeo and Juliet')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /show 1 hidden result/i })).toBeInTheDocument()
+  })
+
+  it('keeps author results visible when the book guard lookup fails', async () => {
+    vi.mocked(api.searchAuthors).mockResolvedValue([
+      author({
+        foreignAuthorId: 'OL_BAD_TITLE_A',
+        authorName: 'Romeo and Juliet',
+        disambiguation: 'William Shakespeare',
+      }),
+    ])
+    vi.mocked(api.searchBooks).mockRejectedValue(new Error('book search down'))
+
+    render(<AddAuthorModal onClose={onClose} onAdded={onAdded} />)
+
+    fireEvent.change(screen.getByPlaceholderText('Search by author name...'), {
+      target: { value: 'Romeo and Juliet' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+
+    await waitFor(() => expect(screen.getByText('Romeo and Juliet')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: /hidden result/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/could not reach/i)).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, Author, MediaType, MetadataProfile, RootFolder } from '../api/client'
+import { splitAuthorSearchResults } from './addAuthorTitleGuard'
 
 interface Props {
   onClose: () => void
@@ -23,6 +24,8 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const { t } = useTranslation()
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<Author[]>([])
+  const [hiddenResults, setHiddenResults] = useState<Author[]>([])
+  const [showHiddenResults, setShowHiddenResults] = useState(false)
   const [searching, setSearching] = useState(false)
   const [searchError, setSearchError] = useState<string | null>(null)
   const [adding, setAdding] = useState<string | null>(null)
@@ -57,15 +60,23 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   }, [])
 
   const search = async () => {
-    if (!query.trim()) return
+    const q = query.trim()
+    if (!q) return
     setSearching(true)
     setSearchError(null)
+    setShowHiddenResults(false)
     try {
-      const authors = await api.searchAuthors(query)
-      setResults(authors)
+      const [authors, books] = await Promise.all([
+        api.searchAuthors(q),
+        api.searchBooks(q).catch(() => []),
+      ])
+      const split = splitAuthorSearchResults(authors, books, q)
+      setResults(split.visible)
+      setHiddenResults(split.hidden)
     } catch (err) {
       setSearchError(err instanceof Error ? err.message : 'Search failed — try again')
       setResults([])
+      setHiddenResults([])
     } finally {
       setSearching(false)
     }
@@ -180,7 +191,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
           </div>
 
           <div className="mt-4 max-h-80 overflow-y-auto space-y-2">
-            {results.map(author => (
+            {(showHiddenResults ? [...results, ...hiddenResults] : results).map(author => (
               <div
                 key={author.foreignAuthorId}
                 className="flex items-center justify-between p-3 rounded-md bg-slate-200/50 dark:bg-zinc-800/50 hover:bg-slate-200 dark:hover:bg-zinc-800"
@@ -202,10 +213,22 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
                 </button>
               </div>
             ))}
+            {hiddenResults.length > 0 && !showHiddenResults && (
+              <button
+                type="button"
+                onClick={() => setShowHiddenResults(true)}
+                className="w-full px-3 py-2 rounded-md border border-slate-300 dark:border-zinc-700 text-xs font-medium text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/60 dark:hover:bg-zinc-800/60 transition-colors"
+              >
+                {t('addAuthorModal.showHiddenResults', {
+                  count: hiddenResults.length,
+                  defaultValue: `Show ${hiddenResults.length} hidden result${hiddenResults.length === 1 ? '' : 's'}`,
+                })}
+              </button>
+            )}
             {searchError && (
               <p className="text-sm text-red-400 text-center py-4">{t('addAuthorModal.searchError', { error: searchError })}</p>
             )}
-            {results.length === 0 && !searching && !searchError && query && (
+            {results.length === 0 && hiddenResults.length === 0 && !searching && !searchError && query && (
               <p className="text-sm text-slate-600 dark:text-zinc-500 text-center py-4">{t('addAuthorModal.noResults')}</p>
             )}
           </div>

--- a/web/src/components/addAuthorTitleGuard.test.ts
+++ b/web/src/components/addAuthorTitleGuard.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import type { Author, Book } from '../api/client'
+import { splitAuthorSearchResults } from './addAuthorTitleGuard'
+
+function makeAuthor(overrides: Partial<Author>): Author {
+  return {
+    id: 1,
+    foreignAuthorId: 'OL_AUTHOR_A',
+    authorName: 'Author',
+    sortName: 'Author',
+    description: '',
+    imageUrl: '',
+    disambiguation: '',
+    ratingsCount: 0,
+    averageRating: 0,
+    monitored: true,
+    ...overrides,
+  }
+}
+
+function makeBook(overrides: Partial<Book>): Book {
+  return {
+    id: 1,
+    foreignBookId: 'OL_BOOK_W',
+    authorId: 1,
+    title: 'Book',
+    description: '',
+    imageUrl: '',
+    genres: [],
+    monitored: true,
+    status: 'wanted',
+    filePath: '',
+    mediaType: 'ebook',
+    ebookFilePath: '',
+    audiobookFilePath: '',
+    excluded: false,
+    ...overrides,
+  }
+}
+
+describe('splitAuthorSearchResults', () => {
+  it('hides an exact book-title author inversion', () => {
+    const candidate = makeAuthor({
+      foreignAuthorId: 'OL_BAD_TITLE_A',
+      authorName: 'Romeo and Juliet',
+      disambiguation: 'William Shakespeare',
+    })
+    const book = makeBook({
+      title: 'Romeo and Juliet',
+      author: makeAuthor({
+        foreignAuthorId: 'OL_SHAKESPEARE_A',
+        authorName: 'William Shakespeare',
+      }),
+    })
+
+    const split = splitAuthorSearchResults([candidate], [book], 'Romeo and Juliet')
+
+    expect(split.visible).toEqual([])
+    expect(split.hidden).toEqual([candidate])
+  })
+
+  it('preserves legitimate author results with exact-name searches', () => {
+    const author = makeAuthor({
+      foreignAuthorId: 'OL_SHAKESPEARE_A',
+      authorName: 'William Shakespeare',
+      disambiguation: 'Romeo and Juliet',
+    })
+    const book = makeBook({
+      title: 'Romeo and Juliet',
+      author,
+    })
+
+    const split = splitAuthorSearchResults([author], [book], 'William Shakespeare')
+
+    expect(split.visible).toEqual([author])
+    expect(split.hidden).toEqual([])
+  })
+
+  it('preserves results when book metadata lacks author data', () => {
+    const candidate = makeAuthor({
+      foreignAuthorId: 'OL_BAD_TITLE_A',
+      authorName: 'Romeo and Juliet',
+      disambiguation: 'William Shakespeare',
+    })
+    const book = makeBook({ title: 'Romeo and Juliet' })
+
+    const split = splitAuthorSearchResults([candidate], [book], 'Romeo and Juliet')
+
+    expect(split.visible).toEqual([candidate])
+    expect(split.hidden).toEqual([])
+  })
+
+  it('preserves results when candidate and book author IDs match', () => {
+    const candidate = makeAuthor({
+      foreignAuthorId: 'OL_SHAKESPEARE_A',
+      authorName: 'Romeo and Juliet',
+      disambiguation: 'William Shakespeare',
+    })
+    const book = makeBook({
+      title: 'Romeo and Juliet',
+      author: makeAuthor({
+        foreignAuthorId: 'OL_SHAKESPEARE_A',
+        authorName: 'William Shakespeare',
+      }),
+    })
+
+    const split = splitAuthorSearchResults([candidate], [book], 'Romeo and Juliet')
+
+    expect(split.visible).toEqual([candidate])
+    expect(split.hidden).toEqual([])
+  })
+
+  it('does not hide partial or merely similar title matches', () => {
+    const candidate = makeAuthor({
+      foreignAuthorId: 'OL_ROMEO_A',
+      authorName: 'Romeo',
+      disambiguation: 'William Shakespeare',
+    })
+    const book = makeBook({
+      title: 'Romeo and Juliet',
+      author: makeAuthor({
+        foreignAuthorId: 'OL_SHAKESPEARE_A',
+        authorName: 'William Shakespeare',
+      }),
+    })
+
+    const split = splitAuthorSearchResults([candidate], [book], 'Romeo')
+
+    expect(split.visible).toEqual([candidate])
+    expect(split.hidden).toEqual([])
+  })
+})

--- a/web/src/components/addAuthorTitleGuard.ts
+++ b/web/src/components/addAuthorTitleGuard.ts
@@ -1,0 +1,59 @@
+import type { Author, Book } from '../api/client'
+
+export interface AuthorResultSplit {
+  visible: Author[]
+  hidden: Author[]
+}
+
+function normalizeMetadataText(value: string | undefined): string {
+  return (value ?? '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .replace(/\s+/g, ' ')
+}
+
+function isDifferentKnownAuthor(candidate: Author, bookAuthor: Author): boolean {
+  if (!candidate.foreignAuthorId || !bookAuthor.foreignAuthorId) return false
+  return candidate.foreignAuthorId !== bookAuthor.foreignAuthorId
+}
+
+export function isLikelyBookTitleAuthorResult(candidate: Author, exactBookMatches: Book[], query: string): boolean {
+  const normalizedCandidateName = normalizeMetadataText(candidate.authorName)
+  if (normalizedCandidateName === '' || normalizedCandidateName !== normalizeMetadataText(query)) {
+    return false
+  }
+
+  const normalizedTopWork = normalizeMetadataText(candidate.disambiguation)
+  if (normalizedTopWork === '') return false
+
+  return exactBookMatches.some(book => {
+    if (!book.author) return false
+    return (
+      isDifferentKnownAuthor(candidate, book.author) &&
+      normalizedTopWork === normalizeMetadataText(book.author.authorName)
+    )
+  })
+}
+
+export function splitAuthorSearchResults(authors: Author[], books: Book[], query: string): AuthorResultSplit {
+  const normalizedQuery = normalizeMetadataText(query)
+  if (normalizedQuery === '') return { visible: authors, hidden: [] }
+
+  const exactBookMatches = books.filter(book => normalizeMetadataText(book.title) === normalizedQuery)
+  if (exactBookMatches.length === 0) return { visible: authors, hidden: [] }
+
+  const visible: Author[] = []
+  const hidden: Author[] = []
+  for (const author of authors) {
+    if (isLikelyBookTitleAuthorResult(author, exactBookMatches, query)) {
+      hidden.push(author)
+    } else {
+      visible.push(author)
+    }
+  }
+
+  return { visible, hidden }
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -447,6 +447,8 @@
     "booksTooltip": "OpenLibrary's raw work count. The actual catalogue added will be smaller after deduplication, language filtering, and junk-title removal.",
     "ratings": "{{count}} ratings",
     "noResults": "No results found",
+    "showHiddenResults_one": "Show {{count}} hidden result",
+    "showHiddenResults_other": "Show {{count}} hidden results",
     "searchError": "Could not reach the metadata provider — {{error}}",
     "addFail": "Failed to add author"
   },


### PR DESCRIPTION
## Summary

Fixes the bug where some books could be added as authors from the Add Author modal.

OpenLibrary search can return work/book records alongside real author records. This change filters out book-title matches before they can be selected as authors, adds focused frontend coverage for the guard and modal behavior, adds the user-facing rejection copy, and records the fix in `CHANGELOG.md` under `[Unreleased]`.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (not applicable; no env vars, config, or upgrade path changed)
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] Wiki pages updated if user-facing behaviour changed (not applicable; this is a narrow Add Author validation bug fix with no wiki workflow changes needed)

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [x] `cd web && npm run build`
- [x] `cd web && npm test -- AddAuthorModal.test.tsx addAuthorTitleGuard.test.ts`
