### PR TITLE
fix(search): match possessive-prefixed titles against releases that drop the apostrophe-s

### DIFF
--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -186,6 +186,23 @@ func sigWords(s string) []string {
 	return out
 }
 
+// sigWordsDepossessive is like sigWords but strips possessive "'s" as a suffix
+// before removing remaining apostrophes. This produces "clancy" from "clancy's"
+// rather than "clancys", matching releases that drop the possessive 's entirely
+// (e.g. "Tom Clancy Rainbow Six" for title "Tom Clancy's Rainbow Six").
+func sigWordsDepossessive(s string) []string {
+	var out []string
+	for _, w := range strings.Fields(strings.ToLower(s)) {
+		w = strings.ReplaceAll(w, "'s", "") // "clancy's" → "clancy"
+		w = strings.ReplaceAll(w, "'", "")  // remaining apostrophes
+		w = transliterateUmlauts(w)
+		if len(w) >= 3 && !stopWords[w] {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
 // primaryTitle returns the portion of title before the first colon (used for
 // subtitle handling — "Dune: Messiah" → "Dune"). If there's no colon the full
 // title is returned.
@@ -241,6 +258,9 @@ func titleMatchesResult(normResult string, titleKws []string, surname string, al
 //   - Titles with no significant words: fall back to the author surname alone.
 //   - Subtitle handling: if the title has "primary: subtitle", results matching
 //     either the primary-only or the full title form are accepted.
+//   - Possessive handling: if the standard form fails, also try keywords with
+//     possessive "'s" stripped entirely (e.g. "clancy" for "clancy's") to match
+//     releases that drop the possessive suffix rather than contracting it.
 //
 // Each result is evaluated independently. The previous batch-level
 // anyPhraseMatch gate (which disabled keyword fallback for the whole batch if
@@ -250,6 +270,7 @@ func titleMatchesResult(normResult string, titleKws []string, surname string, al
 func filterRelevant(results []newznab.SearchResult, title, author string) []newznab.SearchResult {
 	fullKws := sigWords(title)
 	primaryKws := sigWords(primaryTitle(title))
+	depossessiveKws := sigWordsDepossessive(title)
 	authorKws := sigWords(author)
 	surname := AuthorSurname(author)
 
@@ -274,7 +295,11 @@ func filterRelevant(results []newznab.SearchResult, title, author string) []newz
 		if !fullOK && len(primaryKws) > 0 && !sameKws(primaryKws, fullKws) {
 			primaryOK = titleMatchesResult(n, primaryKws, surname, true)
 		}
-		if fullOK || primaryOK {
+		depossessiveOK := false
+		if !fullOK && !primaryOK && !sameKws(fullKws, depossessiveKws) {
+			depossessiveOK = titleMatchesResult(n, depossessiveKws, surname, true)
+		}
+		if fullOK || primaryOK || depossessiveOK {
 			filtered = append(filtered, r)
 		}
 	}

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -179,6 +179,18 @@ func TestFilterRelevantApostrophe(t *testing.T) {
 			},
 			wantAny: "Douglas.Adams.Hitchhikers.Guide.to.the.Galaxy.epub",
 		},
+		{
+			// Possessive brand-prefix titles: releases drop the "'s" entirely
+			// ("Tom Clancy Rainbow Six") rather than contracting it ("Tom Clancys").
+			bookTitle: "Tom Clancy's Rainbow Six",
+			author:    "Tom Clancy",
+			releases: []string{
+				"Tom.Clancy.Rainbow.Six.epub",
+				"Tom.Clancy.-.Rainbow.Six.RETAIL.epub",
+				"Unrelated.Book.epub",
+			},
+			wantAny: "Tom.Clancy.Rainbow.Six.epub",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

Releases named `Tom Clancy Rainbow Six` were rejected as irrelevant for the title `Tom Clancy's Rainbow Six` because `sigWords` produced the token `clancys` (apostrophe stripped, `s` kept), and `clancys` never matched `clancy` in the normalised release string.

The existing apostrophe fix (#82) correctly handled `Ender's Game` → `enders` matching `Enders.Game.epub` (release keeps the `s`). The new case is where the release drops the `s` entirely — a pattern common with possessive author-name brand prefixes (`Tom Clancy's`, `Jack Ryan's`, etc.).

## Fix

Adds `sigWordsDepossessive` which strips `'s` as a possessive suffix before removing remaining apostrophes, producing `clancy` from `clancy's`. In `filterRelevant`, this form is tried as a third fallback after the existing full-title and primary-title forms, preserving backward compatibility with the `Ender's Game` → `Enders` case.

## Tests

- Adds a new case to `TestFilterRelevantApostrophe` covering `Tom Clancy's Rainbow Six`
- All existing apostrophe regression tests (`Ender's Game`, `The Handmaid's Tale`, `The Hitchhiker's Guide`) continue to pass

Closes #409.