### PR TITLE
fix(scanner): FindExisting searches audiobookDir and enforces author-folder scope

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -603,21 +603,52 @@ func detectDownloadFormat(files []string) string {
 	return models.MediaTypeEbook
 }
 
-// FindExisting searches the library directory for a book file that matches
-// the given title and author. Returns the first matching file path, or ""
-// if none is found. Intended to be called before auto-searching so books
-// the user already owns are not re-downloaded.
+// FindExisting searches the library directories for a book file that matches
+// the given title and author. Both libraryDir (ebooks) and audiobookDir are
+// searched. Returns the first matching file path, or "" if none is found.
+// Intended to be called before auto-searching so books the user already owns
+// are not re-downloaded.
 func (s *Scanner) FindExisting(ctx context.Context, title, authorName string) string {
-	if s.libraryDir == "" || title == "" {
+	if title == "" {
 		return ""
 	}
+	roots := make([]string, 0, 2)
+	if s.libraryDir != "" {
+		roots = append(roots, s.libraryDir)
+	}
+	if s.audiobookDir != "" && s.audiobookDir != s.libraryDir {
+		roots = append(roots, s.audiobookDir)
+	}
+	for _, root := range roots {
+		if found := s.findExistingInDir(root, title, authorName); found != "" {
+			return found
+		}
+	}
+	return ""
+}
+
+// findExistingInDir walks a single root directory looking for a book file
+// whose title matches and whose parent directory agrees with the expected
+// author, preventing cross-author false matches.
+func (s *Scanner) findExistingInDir(root, title, authorName string) string {
 	var found string
-	if err := filepath.Walk(s.libraryDir, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() || found != "" {
 			return nil
 		}
 		if !IsBookFile(path) {
 			return nil
+		}
+		// Author-folder pre-filter: the first directory under root must match
+		// the expected author. This prevents a file under books/David Wong/
+		// from being matched as a Matt Dinniman book.
+		if authorName != "" {
+			if rel, relErr := filepath.Rel(root, path); relErr == nil {
+				parts := strings.SplitN(rel, string(filepath.Separator), 2)
+				if len(parts) >= 2 && !authorMatch(authorName, parts[0]) {
+					return nil
+				}
+			}
 		}
 		parsed := ParseFilename(path)
 		if titleMatch(parsed.Title, title) && authorMatch(authorName, parsed.Author) {
@@ -625,7 +656,7 @@ func (s *Scanner) FindExisting(ctx context.Context, title, authorName string) st
 		}
 		return nil
 	}); err != nil {
-		slog.Warn("failed to search library for existing file", "path", s.libraryDir, "error", err)
+		slog.Warn("failed to search library for existing file", "path", root, "error", err)
 	}
 	return found
 }


### PR DESCRIPTION
## Summary

Two bugs in `FindExisting` (`internal/importer/scanner.go`):

**Bug 1 (#454):** Only `libraryDir` was walked. Audiobooks already present in `audiobookDir` were never detected as already-owned, so the scanner would queue a re-download even when the file existed. `FindExisting` now searches both `libraryDir` and `audiobookDir`.

**Bug 2 (#442):** No author-folder pre-filter. A file under `books/David Wong/This Book Is Full of Spiders.epub` could be matched as a Matt Dinniman book because the walk was unrestricted and the title similarity threshold was met. Now the first directory component under each root is checked against the expected author via `authorMatch` before doing any title comparison — a file in a directory that doesn't match the expected author is skipped.

## Changes

- Refactors `FindExisting` to delegate to a new `findExistingInDir` helper
- `FindExisting` iterates over both roots (skipping duplicates when `audiobookDir == libraryDir`)
- `findExistingInDir` adds the author-folder pre-filter using `filepath.Rel` + `strings.SplitN`

## Tests

All existing importer and API tests pass (`go test ./internal/importer/... ./internal/api/...`).

Closes #454. Partial fix for #442 (cross-author file matches in library scan).