### PR TITLE
fix(migrate): add entry and error logging to readarr import handler

### DIFF
--- a/internal/api/migrate.go
+++ b/internal/api/migrate.go
@@ -100,8 +100,10 @@ func (h *MigrateHandler) ImportCSV(w http.ResponseWriter, r *http.Request) {
 // readarr.db (SQLite). It's saved to a temp file (sqlite driver wants a
 // path), imported, then deleted.
 func (h *MigrateHandler) ImportReadarr(w http.ResponseWriter, r *http.Request) {
+	slog.Info("readarr import started", "content_length", r.ContentLength)
 	file, err := acceptUpload(w, r, 1<<30) // 1 GB cap — readarr.db is usually < 100 MB
 	if err != nil {
+		slog.Warn("readarr upload rejected", "error", err)
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}


### PR DESCRIPTION
## Summary

When a readarr.db upload fails, there are currently no server-side log entries. This makes it impossible to distinguish a Go-level failure from a proxy/network rejection (the most common cause — nginx default `client_max_body_size` is 1 MB).

Adds:
- `slog.Info("readarr import started", "content_length", r.ContentLength)` at handler entry, so any future report can immediately confirm whether the request reached the Go server
- `slog.Warn("readarr upload rejected", ...)` on `acceptUpload` failure, surfacing multipart parse errors or size-limit rejections

Refs #398 (root cause is a reverse proxy body-size limit; documented in the issue close comment).