### PR TITLE
Add enhanced Hardcover series workflows for ABS imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,24 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **Enhanced series data via Hardcover** — Series can now be managed manually, linked to Hardcover series, and compared against the Hardcover catalog. The Series page shows present, missing, local-only, and uncertain books; missing catalog entries can be filled all at once or one row at a time, creating wanted/monitored book rows and queuing searches. The enhanced controls are gated behind `BINDERY_ENHANCED_HARDCOVER_API`, a saved Hardcover API token, and the admin setting in **Settings -> General**.
+
+### Fixed
+
+- **ABS imports require saved source configuration** — import and dry-run starts now use only the stored ABS configuration, and the UI blocks runs while ABS settings contain unsaved changes so previews and imports cannot run against one-off request overrides.
+- **Hardcover auto-linking requires local evidence** — automatic series linking now requires local book overlap or author agreement before accepting a high-confidence Hardcover candidate, and missing-book fill skips books that already exist as excluded titles.
+
+### Docs
+
+- Added user-facing Hardcover series wiki documentation and documented the enhanced Hardcover series migration, feature flag, token requirement, admin toggle, and production network expectations in the deployment guide.
+
 ## [v1.3.0] — 2026-05-05
 
 ### Added
 
 - **Audiobookshelf (ABS) import workflow** (#371) — Bindery can now connect to one ABS source, validate an API key, discover visible book libraries, and import ABS catalog metadata into shared authors, books, series, and ebook/audiobook editions. Imports support dry runs, persisted run history, rollback preview/rollback, low-confidence review queues, metadata conflict resolution, and path remaps when ABS and Bindery see the same files under different mount prefixes. Import quality is best when the ABS library already has strong metadata, especially ASIN coverage.
-- **Enhanced series data via Hardcover** — Series can now be managed manually, linked to Hardcover series, and compared against the Hardcover catalog. The Series page shows present, missing, local-only, and uncertain books; missing catalog entries can be filled all at once or one row at a time, creating wanted/monitored book rows and queuing searches. The enhanced controls are gated behind `BINDERY_ENHANCED_HARDCOVER_API`, a saved Hardcover API token, and the admin setting in **Settings -> General**.
 
 ### Changed
 
@@ -31,7 +43,6 @@ All notable changes to Bindery are documented here. Format loosely follows
 ### Docs
 
 - Added an ABS import guide and user-facing wiki documentation covering setup, required API-key access, path remaps, review flow, conflicts, rollback, and import-quality expectations.
-- Documented the enhanced Hardcover series data migration, feature flag, token requirement, admin toggle, and production network expectations in the deployment guide.
 
 ## [v1.2.7] — 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Bindery are documented here. Format loosely follows
 ### Added
 
 - **Audiobookshelf (ABS) import workflow** (#371) — Bindery can now connect to one ABS source, validate an API key, discover visible book libraries, and import ABS catalog metadata into shared authors, books, series, and ebook/audiobook editions. Imports support dry runs, persisted run history, rollback preview/rollback, low-confidence review queues, metadata conflict resolution, and path remaps when ABS and Bindery see the same files under different mount prefixes. Import quality is best when the ABS library already has strong metadata, especially ASIN coverage.
+- **Enhanced series data via Hardcover** — Series can now be managed manually, linked to Hardcover series, and compared against the Hardcover catalog. The Series page shows present, missing, local-only, and uncertain books; missing catalog entries can be filled all at once or one row at a time, creating wanted/monitored book rows and queuing searches. The enhanced controls are gated behind `BINDERY_ENHANCED_HARDCOVER_API`, a saved Hardcover API token, and the admin setting in **Settings -> General**.
 
 ### Changed
 
@@ -30,6 +31,7 @@ All notable changes to Bindery are documented here. Format loosely follows
 ### Docs
 
 - Added an ABS import guide and user-facing wiki documentation covering setup, required API-key access, path remaps, review flow, conflicts, rollback, and import-quality expectations.
+- Documented the enhanced Hardcover series data migration, feature flag, token requirement, admin toggle, and production network expectations in the deployment guide.
 
 ## [v1.2.7] — 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Otherwise the server responds with `401`. The API key lives in **Settings → Ge
 | **Quickstart** — first author to first grab in 10 minutes | [Wiki](https://github.com/vavallee/bindery/wiki/Quickstart) |
 | **Deployment** — Docker, Compose, k8s/Helm, binary, UID/GID, upgrades | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) |
 | **ABS import** — setup, path remap, review queue, rollback, and matching behavior | [docs/abs_import.md](docs/abs_import.md) |
+| **Enhanced Hardcover series** — token setup, series linking, catalog diffs, and missing-book fill | [docs/Hardcover-Series-Wiki.md](docs/Hardcover-Series-Wiki.md) |
 | **Calibre plugin bridge** — cross-container Calibre integration via the Bindery Bridge plugin | [docs/CALIBRE-PLUGIN.md](docs/CALIBRE-PLUGIN.md) |
 | **Roadmap** — planned work, scope notes, and explicitly-out-of-scope items (Z-Library, OpenBooks, etc.) | [docs/ROADMAP.md](docs/ROADMAP.md) |
 | **Contributing & CI checks** — dev setup, full quality/security matrix, local check suite | [CONTRIBUTING.md](CONTRIBUTING.md) |

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Bindery is configured through the web UI under **Settings**. Core env vars:
 | `BINDERY_DOWNLOAD_DIR` | `/downloads` | Where the download client places completed downloads |
 | `BINDERY_LIBRARY_DIR` | `/books` | Destination for imported ebook files |
 | `BINDERY_AUDIOBOOK_DIR` | falls back to `BINDERY_LIBRARY_DIR` | Destination for imported audiobook folders |
+| `BINDERY_ENHANCED_HARDCOVER_API` | `false` | Enables Hardcover-token-backed series search, linking, catalog diffs, and missing-book fill when also enabled in Settings |
 
 The full variable reference (path remapping, API key seeding, `BINDERY_PUID` / `BINDERY_PGID` sanity checks) is in **[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md#environment-variables)**.
 

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -626,9 +626,13 @@ func main() {
 
 		// Series
 		r.Get("/series", seriesHandler.List)
+		r.Post("/series", seriesHandler.Create)
 		r.Get("/series/hardcover/search", seriesHandler.SearchHardcover)
 		r.Get("/series/{id}", seriesHandler.Get)
+		r.Put("/series/{id}", seriesHandler.Update)
 		r.Patch("/series/{id}", seriesHandler.Monitor)
+		r.Delete("/series/{id}", seriesHandler.Delete)
+		r.Post("/series/{id}/books", seriesHandler.AddBook)
 		r.Post("/series/{id}/fill", seriesHandler.Fill)
 		r.Get("/series/{id}/hardcover-link", seriesHandler.GetHardcoverLink)
 		r.Post("/series/{id}/hardcover-link/auto", seriesHandler.AutoLinkHardcover)

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -232,7 +232,10 @@ func main() {
 	absImporter := abs.NewImporter(authorRepo, authorAliasRepo, bookRepo, editionRepo, seriesRepo, settingsRepo, absImportRunRepo, absImportRunEntityRepo, absProvenanceRepo, absReviewRepo, absConflictRepo).
 		WithVersion(version).
 		WithStoragePaths(cfg.LibraryDir, cfg.AudiobookDir, rootFolderRepo).
-		WithMetadata(metaAgg)
+		WithMetadata(metaAgg).
+		WithEnhancedHardcoverSeriesEnabled(func(ctx context.Context) bool {
+			return api.HardcoverFeatureStateFor(ctx, settingsRepo, cfg.EnhancedHardcoverAPI).EnhancedHardcoverAPI
+		})
 	if cfg.ABSFeatureEnabled {
 		storedABS := api.LoadABSConfig(ctxBoot, settingsRepo)
 		resumeCfg := abs.ImportConfig{

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"io/fs"
 	"log/slog"
 	"net"
@@ -170,10 +170,9 @@ func main() {
 		enrichers = append(enrichers, googlebooks.New(setting.Value))
 		slog.Info("google books enrichment enabled")
 	}
-	hcClient := hardcover.New()
-	if setting, _ := settingsRepo.Get(context.Background(), "hardcover.api_token"); setting != nil && setting.Value != "" {
-		hcClient = hcClient.WithToken(setting.Value)
-	}
+	hcClient := hardcover.New().WithTokenSource(func(ctx context.Context) string {
+		return api.GetHardcoverAPIToken(ctx, settingsRepo)
+	})
 	enrichers = append(enrichers, hcClient)
 	slog.Info("hardcover enrichment enabled")
 	enrichers = append(enrichers, dnb.New())
@@ -299,7 +298,7 @@ func main() {
 	recRepo := db.NewRecommendationRepo(database)
 	recEngine := recommender.New(bookRepo, authorRepo, seriesRepo, recRepo, settingsRepo)
 	recEngine.WithOLClient(olClient)
-	if s, _ := settingsRepo.Get(context.Background(), "hardcover.api_token"); s != nil && s.Value != "" {
+	if s, _ := settingsRepo.Get(context.Background(), api.SettingHardcoverAPIToken); s != nil && s.Value != "" {
 		recEngine.WithHCClient(hardcover.New().WithToken(s.Value))
 		slog.Info("hardcover wishlist integration enabled for recommendations")
 	}
@@ -363,7 +362,8 @@ func main() {
 	notificationHandler := api.NewNotificationHandler(notificationRepo, notif)
 	qualityProfileHandler := api.NewQualityProfileHandler(qualityProfileRepo)
 	settingsHandler := api.NewSettingsHandler(settingsRepo)
-	seriesHandler := api.NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metaAgg, sched)
+	seriesHandler := api.NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metaAgg, sched).
+		WithHardcoverFeatureSettings(settingsRepo, cfg.EnhancedHardcoverAPI)
 	tagHandler := api.NewTagHandler(tagRepo)
 	importListHandler := api.NewImportListHandler(importListRepo)
 	metadataProfileHandler := api.NewMetadataProfileHandler(metadataProfileRepo)
@@ -444,13 +444,27 @@ func main() {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"status":"ok","version":"` + version + `"}`))
 		})
-		r.Get("/system/status", func(w http.ResponseWriter, _ *http.Request) {
+		r.Get("/system/status", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			cacheBytes, _ := imageProxyHandler.CacheSize()
-			_, _ = fmt.Fprintf(w,
-				`{"version":"%s","commit":"%s","buildDate":"%s","imageCacheBytes":%d}`,
-				version, commit, date, cacheBytes,
-			)
+			hardcoverState := api.HardcoverFeatureStateFor(r.Context(), settingsRepo, cfg.EnhancedHardcoverAPI)
+			_ = json.NewEncoder(w).Encode(struct {
+				Version                         string `json:"version"`
+				Commit                          string `json:"commit"`
+				BuildDate                       string `json:"buildDate"`
+				ImageCacheBytes                 int64  `json:"imageCacheBytes"`
+				EnhancedHardcoverAPI            bool   `json:"enhancedHardcoverApi"`
+				HardcoverTokenConfigured        bool   `json:"hardcoverTokenConfigured"`
+				EnhancedHardcoverDisabledReason string `json:"enhancedHardcoverDisabledReason,omitempty"`
+			}{
+				Version:                         version,
+				Commit:                          commit,
+				BuildDate:                       date,
+				ImageCacheBytes:                 cacheBytes,
+				EnhancedHardcoverAPI:            hardcoverState.EnhancedHardcoverAPI,
+				HardcoverTokenConfigured:        hardcoverState.HardcoverTokenConfigured,
+				EnhancedHardcoverDisabledReason: hardcoverState.EnhancedHardcoverDisabledReason,
+			})
 		})
 
 		// Auth — status/login/logout/setup are always allowed through the

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -170,7 +170,11 @@ func main() {
 		enrichers = append(enrichers, googlebooks.New(setting.Value))
 		slog.Info("google books enrichment enabled")
 	}
-	enrichers = append(enrichers, hardcover.New())
+	hcClient := hardcover.New()
+	if setting, _ := settingsRepo.Get(context.Background(), "hardcover.api_token"); setting != nil && setting.Value != "" {
+		hcClient = hcClient.WithToken(setting.Value)
+	}
+	enrichers = append(enrichers, hcClient)
 	slog.Info("hardcover enrichment enabled")
 	enrichers = append(enrichers, dnb.New())
 	slog.Info("dnb enrichment enabled")

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -603,6 +603,7 @@ func main() {
 			r.Use(auth.RequireAdmin)
 			r.Put("/setting/{key}", settingsHandler.Set)
 			r.Delete("/setting/{key}", settingsHandler.Delete)
+			r.Post("/hardcover/test", settingsHandler.TestHardcover)
 			r.Get("/abs/config", absHandler.GetConfig)
 			if cfg.ABSFeatureEnabled {
 				r.Put("/abs/config", absHandler.SetConfig)

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -363,7 +363,7 @@ func main() {
 	notificationHandler := api.NewNotificationHandler(notificationRepo, notif)
 	qualityProfileHandler := api.NewQualityProfileHandler(qualityProfileRepo)
 	settingsHandler := api.NewSettingsHandler(settingsRepo)
-	seriesHandler := api.NewSeriesHandler(seriesRepo, bookRepo, sched)
+	seriesHandler := api.NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metaAgg, sched)
 	tagHandler := api.NewTagHandler(tagRepo)
 	importListHandler := api.NewImportListHandler(importListRepo)
 	metadataProfileHandler := api.NewMetadataProfileHandler(metadataProfileRepo)
@@ -611,9 +611,15 @@ func main() {
 
 		// Series
 		r.Get("/series", seriesHandler.List)
+		r.Get("/series/hardcover/search", seriesHandler.SearchHardcover)
 		r.Get("/series/{id}", seriesHandler.Get)
 		r.Patch("/series/{id}", seriesHandler.Monitor)
 		r.Post("/series/{id}/fill", seriesHandler.Fill)
+		r.Get("/series/{id}/hardcover-link", seriesHandler.GetHardcoverLink)
+		r.Post("/series/{id}/hardcover-link/auto", seriesHandler.AutoLinkHardcover)
+		r.Put("/series/{id}/hardcover-link", seriesHandler.PutHardcoverLink)
+		r.Delete("/series/{id}/hardcover-link", seriesHandler.DeleteHardcoverLink)
+		r.Get("/series/{id}/hardcover-diff", seriesHandler.HardcoverDiff)
 
 		// Recommendations
 		r.Get("/recommendations", recHandler.List)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -212,6 +212,7 @@ Multiple remaps are separated by commas: `BINDERY_DOWNLOAD_PATH_REMAP=/sab/compl
 | `BINDERY_LIBRARY_DIR` | `/books` | Destination for imported ebook files |
 | `BINDERY_AUDIOBOOK_DIR` | falls back to `BINDERY_LIBRARY_DIR` | Destination for imported audiobook folders |
 | `BINDERY_ABS_ENABLED` | `false` | Set to `true` to expose and enable the Audiobookshelf (ABS) feature surface. |
+| `BINDERY_ENHANCED_HARDCOVER_API` | `false` | Set to `true` to allow token-backed Hardcover series search, linking, catalog diffs, and missing-book fill after an admin enables the feature in Settings. |
 | `BINDERY_DOWNLOAD_PATH_REMAP` | _(empty)_ | Comma-separated `from:to` pairs rewriting paths reported by the download client into paths Bindery can access. Required when SABnzbd and Bindery mount the same storage at different paths. Longest-prefix match wins. See [Path remapping](#path-remapping-multi-container--multi-pod-setups). |
 | `BINDERY_PUID` | _(unset)_ | Sanity check — see [Running as a specific UID/GID](#running-as-a-specific-uidgid) |
 | `BINDERY_PGID` | _(unset)_ | Sanity check — same as `BINDERY_PUID` for the primary GID |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -244,6 +244,14 @@ On first launch Bindery bootstraps itself — **no environment variables are req
 
 **Outbound ABS requests:** ABS probes and imports send `User-Agent: bindery/<version>` to the configured ABS server. Development or unversioned builds use `bindery/dev`.
 
+### Enhanced Hardcover series data deployment note
+
+**Schema:** enhanced series data uses migration `035`, which creates `series_hardcover_links` and backfills links for existing series whose foreign ID already points at Hardcover. Take a normal SQLite backup before upgrading, then let Bindery apply the migration on startup.
+
+**Feature flag:** token-backed Hardcover series search, manual/automatic series linking, catalog diffs, and missing-book fill are disabled by default. Set `BINDERY_ENHANCED_HARDCOVER_API=true`, save a Hardcover API token in **Settings -> General**, then enable enhanced Hardcover series data in the same settings section. If any of those three requirements is missing, the enhanced endpoints return `404` and the UI hides the controls; existing local series data keeps working.
+
+**Operational note:** the enhanced fill action can create wanted/monitored book rows from the linked Hardcover catalog and immediately queue indexer searches. Make sure outbound HTTPS to Hardcover and your configured indexers is allowed before enabling it for production users.
+
 ### From v0.11.x to v0.12.0 (security posture)
 
 **Schema:** no changes. Drop-in binary or image replacement is safe.

--- a/docs/Hardcover-Series-Wiki.md
+++ b/docs/Hardcover-Series-Wiki.md
@@ -1,0 +1,78 @@
+# Enhanced Hardcover Series
+
+Bindery can use a saved Hardcover API token to improve the Series page with token-backed series search, manual and automatic Hardcover links, catalog diffs, and missing-book fill.
+
+This page is the user-facing companion to the deployment notes in [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md#enhanced-hardcover-series-data-deployment-note).
+
+## What It Does
+
+When enhanced Hardcover series data is enabled, Bindery can:
+
+- create, rename, monitor, and delete local series from the Series page
+- add existing Bindery books to a local series with a position number
+- search Hardcover for the matching catalog series
+- link or unlink a local series to a Hardcover series
+- compare the local series against the Hardcover catalog
+- show present, missing, local-only, and uncertain catalog entries
+- add one missing Hardcover book, or add all missing books for a linked series
+- create wanted and monitored book rows for missing catalog entries and queue searches for them
+
+Local series management remains available without the enhanced Hardcover feature. Hardcover-backed search, linking, catalog diffs, and catalog-based missing-book fill are hidden until all enablement requirements are met.
+
+## Before You Start
+
+Enhanced Hardcover series data requires three things:
+
+- `BINDERY_ENHANCED_HARDCOVER_API=true` in the Bindery environment
+- a saved Hardcover API token in `Settings -> General`
+- the **Enhanced Hardcover series** toggle enabled in `Settings -> General`
+
+If any requirement is missing, Bindery hides the enhanced controls and the enhanced API endpoints return `404`. Existing local series data keeps working.
+
+## Series Workflow
+
+1. Open **Series**.
+2. Create a series manually, or open an existing series populated from your library metadata.
+3. Use **Add Book** to attach existing Bindery books and set their series positions.
+4. Use **Search** to find a matching Hardcover series.
+5. Pick the correct Hardcover result, or remove a bad existing link.
+6. Open the linked series to load the Hardcover catalog diff.
+7. Use **add** on a single missing row, or **add all** / **Fill gaps** to queue every missing catalog entry.
+
+Added Hardcover books are created as wanted and monitored rows. Bindery then queues indexer searches the same way it does for other wanted books.
+
+## Automatic Links
+
+When you click **Search** on an unlinked series, Bindery first attempts an automatic match. It only auto-links when the top Hardcover candidate is confident, not ambiguous, and has local evidence:
+
+- matching local book titles or catalog overlap, or
+- author agreement with books already in the local series
+
+If that evidence is missing, Bindery shows candidates for manual selection instead of linking automatically.
+
+## Missing-Book Fill
+
+Missing-book fill uses the linked Hardcover catalog as the source of truth for missing entries. Bindery skips catalog books that already exist locally as excluded titles, so excluded books are not silently re-added.
+
+The fill action may create new authors and books from Hardcover metadata when the catalog entry is not already in Bindery. Those books are linked back to the series with the catalog position.
+
+## Known Behavior
+
+- Hardcover-backed controls require outbound HTTPS access to Hardcover.
+- The fill action can also contact configured indexers because it queues searches immediately.
+- A linked series can still have local-only or uncertain entries when local metadata does not cleanly match the Hardcover catalog.
+- Removing a Hardcover link does not delete the local series or local books.
+- Deleting a local series does not delete linked books from your library.
+
+## Troubleshooting
+
+- Enhanced controls are missing: confirm `BINDERY_ENHANCED_HARDCOVER_API=true`, save a Hardcover API token, then enable **Enhanced Hardcover series** in `Settings -> General`.
+- Hardcover test fails: verify the token at [Hardcover API settings](https://hardcover.app/account/api) and make sure Bindery can reach `hardcover.app`.
+- Search finds the wrong series: choose a different result manually, or remove the link and search again with a more specific local series name.
+- Fill gaps adds nothing: check whether the missing books already exist locally, are excluded, or whether the linked Hardcover catalog has no missing entries relative to the local series.
+- Searches are not queued after fill: verify your indexers and download-client search flow are working for normal wanted books.
+
+## See Also
+
+- [`docs/DEPLOYMENT.md`](./DEPLOYMENT.md#enhanced-hardcover-series-data-deployment-note)
+- [`CHANGELOG.md`](../CHANGELOG.md)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.9
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0
+	github.com/creditx/go-fuzzywuzzy v0.0.0-20190710081230-e795b6c0d97a
 	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/robfig/cron/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/coreos/go-oidc/v3 v3.18.0 h1:V9orjXynvu5wiC9SemFTWnG4F45v403aIcjWo0d41+A=
 github.com/coreos/go-oidc/v3 v3.18.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
+github.com/creditx/go-fuzzywuzzy v0.0.0-20190710081230-e795b6c0d97a h1:vYPG0GPD+lncLVx5czGx2xi63al9om+lbVAcHsrVvQc=
+github.com/creditx/go-fuzzywuzzy v0.0.0-20190710081230-e795b6c0d97a/go.mod h1:WQAEG6XgYMz1Tttk3sVMix6UKmfWrLYua4O0LUxo99g=
 github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8 h1:OtSeLS5y0Uy01jaKK4mA/WVIYtpzVm63vLVAPzJXigg=
 github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8/go.mod h1:apkPC/CR3s48O2D7Y++n1XWEpgPNNCjXYga3PPbJe2E=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/internal/abs/import_hardcover_series.go
+++ b/internal/abs/import_hardcover_series.go
@@ -1,0 +1,555 @@
+package abs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	fuzzy "github.com/creditx/go-fuzzywuzzy"
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/textutil"
+)
+
+type hardcoverSeriesQuery struct {
+	Title    string
+	Sequence string
+	FromABS  bool
+}
+
+type hardcoverSeriesCandidate struct {
+	Result      metadata.SeriesSearchResult
+	Catalog     *metadata.SeriesCatalog
+	Book        metadata.SeriesCatalogBook
+	Score       int
+	MatchedBy   string
+	SeriesScore int
+	TitleScore  int
+}
+
+func (i *Importer) matchHardcoverSeries(ctx context.Context, cfg ImportConfig, runID int64, author *models.Author, book *models.Book, item NormalizedLibraryItem, stats *ImportStats) (metadataMergeResult, int) {
+	if i.meta == nil || i.series == nil || i.books == nil || book == nil {
+		return metadataMergeResult{}, 0
+	}
+	queries := hardcoverSeriesQueries(item)
+	if len(queries) == 0 {
+		return metadataMergeResult{}, 0
+	}
+	authorName := primaryAuthorName(item)
+	if author != nil && strings.TrimSpace(author.Name) != "" {
+		authorName = strings.TrimSpace(author.Name)
+	}
+	candidates := make(map[string]hardcoverSeriesCandidate)
+	for _, query := range queries {
+		results, err := i.meta.SearchSeries(ctx, query.Title, 5)
+		if err != nil {
+			slog.Warn("abs import: hardcover series search failed", "itemID", item.ItemID, "query", query.Title, "error", err)
+			continue
+		}
+		for _, result := range results {
+			catalog, err := i.meta.GetSeriesCatalog(ctx, result.ForeignID)
+			if err != nil {
+				slog.Warn("abs import: hardcover series catalog failed", "itemID", item.ItemID, "series", result.ForeignID, "error", err)
+				continue
+			}
+			if catalog == nil {
+				continue
+			}
+			candidate, ok := evaluateHardcoverSeriesCandidate(query, authorName, item, result, catalog)
+			if !ok {
+				continue
+			}
+			key := catalog.ForeignID
+			if existing, exists := candidates[key]; !exists || candidate.Score > existing.Score {
+				candidates[key] = candidate
+			}
+		}
+	}
+	selected, ambiguous := selectHardcoverSeriesCandidate(candidates)
+	if ambiguous {
+		return metadataMergeResult{Messages: []string{"hardcover series link skipped: match was ambiguous"}}, 0
+	}
+	if selected == nil {
+		return metadataMergeResult{}, 0
+	}
+
+	created, matchedBy, err := i.upsertHardcoverSeries(ctx, cfg, runID, book.ID, selected.Catalog, selected.Book)
+	if err != nil {
+		slog.Warn("abs import: hardcover series link failed", "itemID", item.ItemID, "series", selected.Catalog.ForeignID, "error", err)
+		return metadataMergeResult{}, 0
+	}
+	if stats != nil {
+		if created {
+			stats.SeriesCreated++
+		} else if matchedBy != "" {
+			stats.SeriesLinked++
+		}
+	}
+
+	metaResult := metadataMergeResult{}
+	if !cfg.DryRun && selected.Book.Book.ForeignID != "" {
+		if mergeResult, err := i.mergeUpstreamBook(ctx, cfg, item, book, &selected.Book.Book, "hardcover_series"); err != nil {
+			slog.Warn("abs import: hardcover series metadata merge failed", "itemID", item.ItemID, "book", selected.Book.Book.ForeignID, "error", err)
+		} else {
+			metaResult = mergeResult
+		}
+	}
+	if !cfg.DryRun {
+		extra, err := i.linkExistingHardcoverCatalogBooks(ctx, cfg, runID, author, selected.Catalog, book.ID, created)
+		if err != nil {
+			slog.Warn("abs import: hardcover catalog existing-book linking failed", "itemID", item.ItemID, "series", selected.Catalog.ForeignID, "error", err)
+		} else if stats != nil {
+			stats.SeriesLinked += extra
+		}
+	}
+	if matchedBy != "" {
+		metaResult.Messages = append(metaResult.Messages, fmt.Sprintf("hardcover series linked by %s", selected.MatchedBy))
+	}
+	return metaResult, 1
+}
+
+func hardcoverSeriesQueries(item NormalizedLibraryItem) []hardcoverSeriesQuery {
+	queries := make([]hardcoverSeriesQuery, 0, len(item.Series)+1)
+	seen := map[string]struct{}{}
+	for _, series := range item.Series {
+		title := strings.TrimSpace(series.Name)
+		if title == "" {
+			continue
+		}
+		key := normalizeTitle(title)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		queries = append(queries, hardcoverSeriesQuery{
+			Title:    title,
+			Sequence: strings.TrimSpace(series.Sequence),
+			FromABS:  true,
+		})
+	}
+	if len(queries) > 0 {
+		return queries
+	}
+	if title := strings.TrimSpace(item.Title); title != "" {
+		queries = append(queries, hardcoverSeriesQuery{Title: title})
+	}
+	return queries
+}
+
+func evaluateHardcoverSeriesCandidate(query hardcoverSeriesQuery, authorName string, item NormalizedLibraryItem, result metadata.SeriesSearchResult, catalog *metadata.SeriesCatalog) (hardcoverSeriesCandidate, bool) {
+	if catalog == nil || catalog.ForeignID == "" || len(catalog.Books) == 0 {
+		return hardcoverSeriesCandidate{}, false
+	}
+	hcAuthor := firstNonEmpty(result.AuthorName, catalog.AuthorName)
+	authorScore := hardcoverAuthorScore(authorName, hcAuthor)
+	if strings.TrimSpace(authorName) != "" && strings.TrimSpace(hcAuthor) != "" && authorScore == 0 {
+		return hardcoverSeriesCandidate{}, false
+	}
+	matchedBook, titleScore, positionMatched, ok := matchHardcoverCatalogBook(item, query.Sequence, catalog.Books)
+	if !ok {
+		return hardcoverSeriesCandidate{}, false
+	}
+	seriesScore := 0
+	if query.FromABS {
+		seriesScore = shelfarrTitleScore(query.Title, firstNonEmpty(result.Title, catalog.Title))
+		if normalizeSeriesName(query.Title) == normalizeSeriesName(firstNonEmpty(result.Title, catalog.Title)) {
+			seriesScore = 100
+		}
+		if seriesScore < 80 {
+			return hardcoverSeriesCandidate{}, false
+		}
+	}
+	score := titleScore
+	matchedBy := "hardcover_title"
+	if positionMatched {
+		score += 25
+		matchedBy = "hardcover_position_title"
+	}
+	if query.FromABS {
+		score += seriesScore / 2
+		matchedBy = "hardcover_series_title"
+		if positionMatched {
+			matchedBy = "hardcover_series_position"
+		}
+	}
+	score += authorScore
+	if score < 105 {
+		return hardcoverSeriesCandidate{}, false
+	}
+	return hardcoverSeriesCandidate{
+		Result:      result,
+		Catalog:     catalog,
+		Book:        matchedBook,
+		Score:       score,
+		MatchedBy:   matchedBy,
+		SeriesScore: seriesScore,
+		TitleScore:  titleScore,
+	}, true
+}
+
+func matchHardcoverCatalogBook(item NormalizedLibraryItem, sequence string, books []metadata.SeriesCatalogBook) (metadata.SeriesCatalogBook, int, bool, bool) {
+	sequence = strings.TrimSpace(sequence)
+	bestScore := 0
+	var best metadata.SeriesCatalogBook
+	matches := 0
+	for _, book := range books {
+		positionMatched := sequence != "" && sameSeriesPosition(sequence, book.Position)
+		if sequence != "" && !positionMatched {
+			continue
+		}
+		score := shelfarrTitleScore(item.Title, firstNonEmpty(book.Title, book.Book.Title))
+		threshold := 88
+		if positionMatched {
+			threshold = 70
+		}
+		if score < threshold {
+			continue
+		}
+		if score > bestScore {
+			bestScore = score
+			best = book
+			matches = 1
+			continue
+		}
+		if score == bestScore {
+			matches++
+		}
+	}
+	if matches == 1 {
+		return best, bestScore, sequence != "" && sameSeriesPosition(sequence, best.Position), true
+	}
+	return metadata.SeriesCatalogBook{}, 0, false, false
+}
+
+func selectHardcoverSeriesCandidate(candidates map[string]hardcoverSeriesCandidate) (*hardcoverSeriesCandidate, bool) {
+	if len(candidates) == 0 {
+		return nil, false
+	}
+	ordered := make([]hardcoverSeriesCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		ordered = append(ordered, candidate)
+	}
+	sort.SliceStable(ordered, func(a, b int) bool {
+		if ordered[a].Score == ordered[b].Score {
+			return ordered[a].Catalog.ForeignID < ordered[b].Catalog.ForeignID
+		}
+		return ordered[a].Score > ordered[b].Score
+	})
+	if len(ordered) > 1 && ordered[0].Score-ordered[1].Score < 10 {
+		return nil, true
+	}
+	return &ordered[0], false
+}
+
+func (i *Importer) upsertHardcoverSeries(ctx context.Context, cfg ImportConfig, runID, bookID int64, catalog *metadata.SeriesCatalog, matchedBook metadata.SeriesCatalogBook) (bool, string, error) {
+	if catalog == nil || strings.TrimSpace(catalog.Title) == "" || strings.TrimSpace(catalog.ForeignID) == "" {
+		return false, "", nil
+	}
+	existing, err := i.series.GetByForeignID(ctx, catalog.ForeignID)
+	if err != nil {
+		return false, "", err
+	}
+	matchedBy := ""
+	if existing == nil {
+		match, ambiguous, err := i.findSeriesByTitle(ctx, catalog.Title)
+		if err != nil {
+			return false, "", err
+		}
+		if ambiguous {
+			return false, "", fmt.Errorf("ambiguous existing series match for %q", catalog.Title)
+		}
+		if match != nil {
+			existing = match
+			matchedBy = "normalized_title"
+			if shouldPromoteSeriesToHardcover(match, catalog) {
+				if prior, err := i.series.GetByForeignID(ctx, catalog.ForeignID); err != nil {
+					return false, "", err
+				} else if prior == nil {
+					if !cfg.DryRun {
+						if err := i.series.UpdateForeignID(ctx, existing.ID, catalog.ForeignID); err != nil {
+							return false, "", err
+						}
+					}
+					existing.ForeignID = catalog.ForeignID
+					matchedBy = "hardcover_promotion"
+				}
+			}
+		}
+	}
+	created := false
+	if existing == nil {
+		existing = &models.Series{
+			ForeignID:   catalog.ForeignID,
+			Title:       strings.TrimSpace(catalog.Title),
+			Description: "",
+		}
+		if !cfg.DryRun {
+			if err := i.series.CreateOrGet(ctx, existing); err != nil {
+				return false, "", err
+			}
+		}
+		created = true
+		matchedBy = "created"
+	}
+	localID := existing.ID
+	if cfg.DryRun && created {
+		localID = 0
+	}
+	metadata := map[string]any{
+		"bookId":          bookID,
+		"sequence":        strings.TrimSpace(matchedBook.Position),
+		"matchedBy":       "hardcover_series",
+		"hardcoverBookId": strings.TrimSpace(matchedBook.ForeignID),
+	}
+	linkExternalID := hardcoverSeriesLinkExternalID(catalog.ForeignID, bookID)
+	linkCreated := cfg.DryRun
+	if !cfg.DryRun {
+		var err error
+		linkCreated, err = i.series.LinkBookIfMissing(ctx, existing.ID, bookID, strings.TrimSpace(matchedBook.Position), true)
+		if err != nil {
+			return false, "", err
+		}
+		if linkCreated {
+			if err := i.upsertProvenance(ctx, &models.ABSProvenance{
+				SourceID:    cfg.SourceID,
+				LibraryID:   cfg.LibraryID,
+				EntityType:  entityTypeSeries,
+				ExternalID:  linkExternalID,
+				LocalID:     existing.ID,
+				ItemID:      "",
+				ImportRunID: ptrInt64(runID),
+			}); err != nil {
+				return false, "", err
+			}
+		}
+	}
+	outcome := itemOutcomeLinked
+	if created {
+		outcome = itemOutcomeCreated
+	}
+	if linkCreated {
+		_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, "", entityTypeSeries, linkExternalID, localID, outcome, metadata)
+	}
+	return created, matchedBy, nil
+}
+
+func (i *Importer) linkExistingHardcoverCatalogBooks(ctx context.Context, cfg ImportConfig, runID int64, author *models.Author, catalog *metadata.SeriesCatalog, importedBookID int64, createdSeries bool) (int, error) {
+	if catalog == nil || author == nil {
+		return 0, nil
+	}
+	seriesRow, err := i.series.GetByForeignID(ctx, catalog.ForeignID)
+	if err != nil {
+		return 0, err
+	}
+	if seriesRow == nil {
+		match, ambiguous, err := i.findSeriesByTitle(ctx, catalog.Title)
+		if err != nil || ambiguous {
+			return 0, err
+		}
+		seriesRow = match
+	}
+	if seriesRow == nil {
+		return 0, nil
+	}
+	linked := 0
+	for _, catalogBook := range catalog.Books {
+		localBook, err := i.findExistingHardcoverCatalogBook(ctx, author.ID, catalogBook)
+		if err != nil {
+			return linked, err
+		}
+		if localBook == nil || localBook.ID == importedBookID {
+			continue
+		}
+		if catalogBook.Book.Author != nil && textutil.MatchAuthorName(author.Name, catalogBook.Book.Author.Name).Kind == textutil.AuthorMatchNone {
+			continue
+		}
+		linkCreated, err := i.series.LinkBookIfMissing(ctx, seriesRow.ID, localBook.ID, strings.TrimSpace(catalogBook.Position), false)
+		if err != nil {
+			return linked, err
+		}
+		if !linkCreated {
+			continue
+		}
+		linkExternalID := hardcoverSeriesLinkExternalID(catalog.ForeignID, localBook.ID)
+		if err := i.upsertProvenance(ctx, &models.ABSProvenance{
+			SourceID:    cfg.SourceID,
+			LibraryID:   cfg.LibraryID,
+			EntityType:  entityTypeSeries,
+			ExternalID:  linkExternalID,
+			LocalID:     seriesRow.ID,
+			ItemID:      "",
+			ImportRunID: ptrInt64(runID),
+		}); err != nil {
+			return linked, err
+		}
+		outcome := itemOutcomeLinked
+		if createdSeries {
+			outcome = itemOutcomeCreated
+		}
+		_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, "", entityTypeSeries, linkExternalID, seriesRow.ID, outcome, map[string]any{
+			"bookId":          localBook.ID,
+			"sequence":        strings.TrimSpace(catalogBook.Position),
+			"matchedBy":       "hardcover_catalog_existing_book",
+			"hardcoverBookId": strings.TrimSpace(catalogBook.ForeignID),
+		})
+		linked++
+	}
+	return linked, nil
+}
+
+func (i *Importer) findExistingHardcoverCatalogBook(ctx context.Context, authorID int64, catalogBook metadata.SeriesCatalogBook) (*models.Book, error) {
+	if strings.TrimSpace(catalogBook.ForeignID) != "" {
+		existing, err := i.books.GetByForeignID(ctx, catalogBook.ForeignID)
+		if err != nil || existing != nil {
+			return existing, err
+		}
+	}
+	title := firstNonEmpty(catalogBook.Title, catalogBook.Book.Title)
+	match, ambiguous, err := i.findBookByNormalizedTitle(ctx, authorID, title)
+	if err != nil || ambiguous || match == nil {
+		return nil, err
+	}
+	if shelfarrTitleScore(match.Title, title) < 92 {
+		return nil, nil
+	}
+	return match, nil
+}
+
+func shouldPromoteSeriesToHardcover(existing *models.Series, catalog *metadata.SeriesCatalog) bool {
+	if existing == nil || catalog == nil {
+		return false
+	}
+	if !strings.HasPrefix(existing.ForeignID, "abs:series:") {
+		return false
+	}
+	return normalizeSeriesName(existing.Title) == normalizeSeriesName(catalog.Title)
+}
+
+func hardcoverSeriesLinkExternalID(seriesForeignID string, bookID int64) string {
+	seriesForeignID = strings.TrimSpace(seriesForeignID)
+	if bookID <= 0 {
+		return seriesForeignID + ":book:planned"
+	}
+	return fmt.Sprintf("%s:book:%d", seriesForeignID, bookID)
+}
+
+func hardcoverAuthorScore(absAuthor, hcAuthor string) int {
+	absAuthor = strings.TrimSpace(absAuthor)
+	hcAuthor = strings.TrimSpace(hcAuthor)
+	if absAuthor == "" || hcAuthor == "" {
+		return 0
+	}
+	match := textutil.MatchAuthorName(absAuthor, hcAuthor)
+	switch match.Kind {
+	case textutil.AuthorMatchExact:
+		return 30
+	case textutil.AuthorMatchFuzzyAuto:
+		return 20
+	default:
+		score := shelfarrTitleScore(absAuthor, hcAuthor)
+		if score >= 90 {
+			return 15
+		}
+		return 0
+	}
+}
+
+func sameSeriesPosition(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	af, aerr := strconv.ParseFloat(a, 64)
+	bf, berr := strconv.ParseFloat(b, 64)
+	return aerr == nil && berr == nil && math.Abs(af-bf) < 0.001
+}
+
+func normalizeSeriesName(name string) string {
+	normalized := normalizeTitle(name)
+	if normalized == "" {
+		return ""
+	}
+	suffixes := map[string]struct{}{
+		"series":     {},
+		"trilogy":    {},
+		"saga":       {},
+		"chronicles": {},
+		"cycle":      {},
+		"books":      {},
+		"novels":     {},
+	}
+	words := strings.Fields(normalized)
+	if len(words) > 1 {
+		if _, ok := suffixes[words[len(words)-1]]; ok {
+			words = words[:len(words)-1]
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+func shelfarrTitleScore(a, b string) int {
+	cleanA := shelfarrCleanTitle(a)
+	cleanB := shelfarrCleanTitle(b)
+	if cleanA == "" || cleanB == "" {
+		return 0
+	}
+	return maxInt(
+		fuzzy.TokenSetRatio(cleanA, cleanB),
+		fuzzy.TokenSortRatio(cleanA, cleanB),
+		fuzzy.Ratio(cleanA, cleanB),
+		fuzzy.PartialRatio(cleanA, cleanB),
+	)
+}
+
+func shelfarrCleanTitle(title string) string {
+	title = strings.ToLower(strings.TrimSpace(title))
+	if title == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range title {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+			b.WriteRune(r)
+		case unicode.IsSpace(r):
+			b.WriteRune(' ')
+		default:
+			b.WriteRune(' ')
+		}
+	}
+	noise := map[string]struct{}{
+		"a":     {},
+		"an":    {},
+		"the":   {},
+		"novel": {},
+		"book":  {},
+	}
+	words := strings.Fields(b.String())
+	out := words[:0]
+	for _, word := range words {
+		if _, ok := noise[word]; ok {
+			continue
+		}
+		out = append(out, word)
+	}
+	return strings.Join(out, " ")
+}
+
+func maxInt(values ...int) int {
+	max := 0
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
+}

--- a/internal/abs/import_hardcover_series.go
+++ b/internal/abs/import_hardcover_series.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math"
 	"sort"
-	"strconv"
 	"strings"
-	"unicode"
 
-	fuzzy "github.com/creditx/go-fuzzywuzzy"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/seriesmatch"
 	"github.com/vavallee/bindery/internal/textutil"
 )
 
@@ -300,6 +297,11 @@ func (i *Importer) upsertHardcoverSeries(ctx context.Context, cfg ImportConfig, 
 	if cfg.DryRun && created {
 		localID = 0
 	}
+	if !cfg.DryRun {
+		if err := i.ensureHardcoverSeriesLink(ctx, existing.ID, catalog); err != nil {
+			return false, "", err
+		}
+	}
 	metadata := map[string]any{
 		"bookId":          bookID,
 		"sequence":        strings.TrimSpace(matchedBook.Position),
@@ -336,6 +338,33 @@ func (i *Importer) upsertHardcoverSeries(ctx context.Context, cfg ImportConfig, 
 		_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, "", entityTypeSeries, linkExternalID, localID, outcome, metadata)
 	}
 	return created, matchedBy, nil
+}
+
+func (i *Importer) ensureHardcoverSeriesLink(ctx context.Context, seriesID int64, catalog *metadata.SeriesCatalog) error {
+	if i.series == nil || catalog == nil || seriesID == 0 {
+		return nil
+	}
+	existing, err := i.series.GetHardcoverLink(ctx, seriesID)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		return nil
+	}
+	bookCount := catalog.BookCount
+	if bookCount == 0 {
+		bookCount = len(catalog.Books)
+	}
+	return i.series.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+		SeriesID:            seriesID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      strings.TrimSpace(catalog.Title),
+		HardcoverAuthorName: strings.TrimSpace(catalog.AuthorName),
+		HardcoverBookCount:  bookCount,
+		Confidence:          0.8,
+		LinkedBy:            "auto",
+	})
 }
 
 func (i *Importer) linkExistingHardcoverCatalogBooks(ctx context.Context, cfg ImportConfig, runID int64, author *models.Author, catalog *metadata.SeriesCatalog, importedBookID int64, createdSeries bool) (int, error) {
@@ -460,96 +489,17 @@ func hardcoverAuthorScore(absAuthor, hcAuthor string) int {
 }
 
 func sameSeriesPosition(a, b string) bool {
-	a = strings.TrimSpace(a)
-	b = strings.TrimSpace(b)
-	if a == "" || b == "" {
-		return false
-	}
-	if a == b {
-		return true
-	}
-	af, aerr := strconv.ParseFloat(a, 64)
-	bf, berr := strconv.ParseFloat(b, 64)
-	return aerr == nil && berr == nil && math.Abs(af-bf) < 0.001
+	return seriesmatch.SamePosition(a, b)
 }
 
 func normalizeSeriesName(name string) string {
-	normalized := normalizeTitle(name)
-	if normalized == "" {
-		return ""
-	}
-	suffixes := map[string]struct{}{
-		"series":     {},
-		"trilogy":    {},
-		"saga":       {},
-		"chronicles": {},
-		"cycle":      {},
-		"books":      {},
-		"novels":     {},
-	}
-	words := strings.Fields(normalized)
-	if len(words) > 1 {
-		if _, ok := suffixes[words[len(words)-1]]; ok {
-			words = words[:len(words)-1]
-		}
-	}
-	return strings.Join(words, " ")
+	return seriesmatch.NormalizeSeriesName(name)
 }
 
 func shelfarrTitleScore(a, b string) int {
-	cleanA := shelfarrCleanTitle(a)
-	cleanB := shelfarrCleanTitle(b)
-	if cleanA == "" || cleanB == "" {
-		return 0
-	}
-	return maxInt(
-		fuzzy.TokenSetRatio(cleanA, cleanB),
-		fuzzy.TokenSortRatio(cleanA, cleanB),
-		fuzzy.Ratio(cleanA, cleanB),
-		fuzzy.PartialRatio(cleanA, cleanB),
-	)
+	return seriesmatch.TitleScore(a, b)
 }
 
 func shelfarrCleanTitle(title string) string {
-	title = strings.ToLower(strings.TrimSpace(title))
-	if title == "" {
-		return ""
-	}
-	var b strings.Builder
-	for _, r := range title {
-		switch {
-		case unicode.IsLetter(r), unicode.IsDigit(r):
-			b.WriteRune(r)
-		case unicode.IsSpace(r):
-			b.WriteRune(' ')
-		default:
-			b.WriteRune(' ')
-		}
-	}
-	noise := map[string]struct{}{
-		"a":     {},
-		"an":    {},
-		"the":   {},
-		"novel": {},
-		"book":  {},
-	}
-	words := strings.Fields(b.String())
-	out := words[:0]
-	for _, word := range words {
-		if _, ok := noise[word]; ok {
-			continue
-		}
-		out = append(out, word)
-	}
-	return strings.Join(out, " ")
-}
-
-func maxInt(values ...int) int {
-	max := 0
-	for _, value := range values {
-		if value > max {
-			max = value
-		}
-	}
-	return max
+	return seriesmatch.CleanTitle(title)
 }

--- a/internal/abs/import_hardcover_series.go
+++ b/internal/abs/import_hardcover_series.go
@@ -499,7 +499,3 @@ func normalizeSeriesName(name string) string {
 func shelfarrTitleScore(a, b string) int {
 	return seriesmatch.TitleScore(a, b)
 }
-
-func shelfarrCleanTitle(title string) string {
-	return seriesmatch.CleanTitle(title)
-}

--- a/internal/abs/import_hardcover_series.go
+++ b/internal/abs/import_hardcover_series.go
@@ -29,13 +29,13 @@ type hardcoverSeriesCandidate struct {
 	TitleScore  int
 }
 
-func (i *Importer) matchHardcoverSeries(ctx context.Context, cfg ImportConfig, runID int64, author *models.Author, book *models.Book, item NormalizedLibraryItem, stats *ImportStats) (metadataMergeResult, int) {
+func (i *Importer) matchHardcoverSeries(ctx context.Context, cfg ImportConfig, runID int64, author *models.Author, book *models.Book, item NormalizedLibraryItem, stats *ImportStats) (metadataMergeResult, seriesUpsertResult) {
 	if i.meta == nil || i.series == nil || i.books == nil || book == nil {
-		return metadataMergeResult{}, 0
+		return metadataMergeResult{}, seriesUpsertResult{}
 	}
 	queries := hardcoverSeriesQueries(item)
 	if len(queries) == 0 {
-		return metadataMergeResult{}, 0
+		return metadataMergeResult{}, seriesUpsertResult{}
 	}
 	authorName := primaryAuthorName(item)
 	if author != nil && strings.TrimSpace(author.Name) != "" {
@@ -69,23 +69,16 @@ func (i *Importer) matchHardcoverSeries(ctx context.Context, cfg ImportConfig, r
 	}
 	selected, ambiguous := selectHardcoverSeriesCandidate(candidates)
 	if ambiguous {
-		return metadataMergeResult{Messages: []string{"hardcover series link skipped: match was ambiguous"}}, 0
+		return metadataMergeResult{Messages: []string{"hardcover series link skipped: match was ambiguous"}}, seriesUpsertResult{}
 	}
 	if selected == nil {
-		return metadataMergeResult{}, 0
+		return metadataMergeResult{}, seriesUpsertResult{}
 	}
 
-	created, matchedBy, err := i.upsertHardcoverSeries(ctx, cfg, runID, book.ID, selected.Catalog, selected.Book)
+	seriesResult, err := i.upsertHardcoverSeries(ctx, cfg, runID, book.ID, item.ItemID, selected.Catalog, selected.Book, stats)
 	if err != nil {
 		slog.Warn("abs import: hardcover series link failed", "itemID", item.ItemID, "series", selected.Catalog.ForeignID, "error", err)
-		return metadataMergeResult{}, 0
-	}
-	if stats != nil {
-		if created {
-			stats.SeriesCreated++
-		} else if matchedBy != "" {
-			stats.SeriesLinked++
-		}
+		return metadataMergeResult{}, seriesUpsertResult{}
 	}
 
 	metaResult := metadataMergeResult{}
@@ -97,17 +90,17 @@ func (i *Importer) matchHardcoverSeries(ctx context.Context, cfg ImportConfig, r
 		}
 	}
 	if !cfg.DryRun {
-		extra, err := i.linkExistingHardcoverCatalogBooks(ctx, cfg, runID, author, selected.Catalog, book.ID, created)
+		extra, err := i.linkExistingHardcoverCatalogBooks(ctx, cfg, runID, author, selected.Catalog, book.ID, seriesResult.CreatedSeries)
 		if err != nil {
 			slog.Warn("abs import: hardcover catalog existing-book linking failed", "itemID", item.ItemID, "series", selected.Catalog.ForeignID, "error", err)
 		} else if stats != nil {
 			stats.SeriesLinked += extra
 		}
 	}
-	if matchedBy != "" {
+	if seriesResult.MatchedBy != "" {
 		metaResult.Messages = append(metaResult.Messages, fmt.Sprintf("hardcover series linked by %s", selected.MatchedBy))
 	}
-	return metaResult, 1
+	return metaResult, seriesResult
 }
 
 func hardcoverSeriesQueries(item NormalizedLibraryItem) []hardcoverSeriesQuery {
@@ -243,33 +236,33 @@ func selectHardcoverSeriesCandidate(candidates map[string]hardcoverSeriesCandida
 	return &ordered[0], false
 }
 
-func (i *Importer) upsertHardcoverSeries(ctx context.Context, cfg ImportConfig, runID, bookID int64, catalog *metadata.SeriesCatalog, matchedBook metadata.SeriesCatalogBook) (bool, string, error) {
+func (i *Importer) upsertHardcoverSeries(ctx context.Context, cfg ImportConfig, runID, bookID int64, itemID string, catalog *metadata.SeriesCatalog, matchedBook metadata.SeriesCatalogBook, stats *ImportStats) (seriesUpsertResult, error) {
 	if catalog == nil || strings.TrimSpace(catalog.Title) == "" || strings.TrimSpace(catalog.ForeignID) == "" {
-		return false, "", nil
+		return seriesUpsertResult{}, nil
 	}
 	existing, err := i.series.GetByForeignID(ctx, catalog.ForeignID)
 	if err != nil {
-		return false, "", err
+		return seriesUpsertResult{}, err
 	}
 	matchedBy := ""
 	if existing == nil {
 		match, ambiguous, err := i.findSeriesByTitle(ctx, catalog.Title)
 		if err != nil {
-			return false, "", err
+			return seriesUpsertResult{}, err
 		}
 		if ambiguous {
-			return false, "", fmt.Errorf("ambiguous existing series match for %q", catalog.Title)
+			return seriesUpsertResult{}, fmt.Errorf("ambiguous existing series match for %q", catalog.Title)
 		}
 		if match != nil {
 			existing = match
 			matchedBy = "normalized_title"
 			if shouldPromoteSeriesToHardcover(match, catalog) {
 				if prior, err := i.series.GetByForeignID(ctx, catalog.ForeignID); err != nil {
-					return false, "", err
+					return seriesUpsertResult{}, err
 				} else if prior == nil {
 					if !cfg.DryRun {
 						if err := i.series.UpdateForeignID(ctx, existing.ID, catalog.ForeignID); err != nil {
-							return false, "", err
+							return seriesUpsertResult{}, err
 						}
 					}
 					existing.ForeignID = catalog.ForeignID
@@ -280,6 +273,28 @@ func (i *Importer) upsertHardcoverSeries(ctx context.Context, cfg ImportConfig, 
 	}
 	created := false
 	if existing == nil {
+		if cfg.DryRun && stats != nil && stats.dryRunSeriesAlreadyPlanned(catalog.ForeignID, catalog.Title) {
+			countKey := seriesMembershipCountKey(0, catalog.Title, catalog.ForeignID, bookID, itemID)
+			membershipCreated := !stats.dryRunSeriesMembershipAlreadyPlanned(countKey)
+			membershipExternalID := seriesMembershipExternalID(catalog.ForeignID, bookID, itemID)
+			if membershipCreated {
+				_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, itemID, entityTypeSeries, membershipExternalID, 0, itemOutcomeLinked, map[string]any{
+					"bookId":          bookID,
+					"sequence":        strings.TrimSpace(matchedBook.Position),
+					"matchedBy":       "hardcover_series",
+					"hardcoverBookId": strings.TrimSpace(matchedBook.ForeignID),
+				})
+				stats.rememberDryRunSeriesMembership(countKey)
+			}
+			return seriesUpsertResult{
+				IdentityExternalID:   catalog.ForeignID,
+				MembershipExternalID: membershipExternalID,
+				CountKey:             countKey,
+				MembershipCreated:    membershipCreated,
+				Linked:               true,
+				MatchedBy:            "planned",
+			}, nil
+		}
 		existing = &models.Series{
 			ForeignID:   catalog.ForeignID,
 			Title:       strings.TrimSpace(catalog.Title),
@@ -287,7 +302,7 @@ func (i *Importer) upsertHardcoverSeries(ctx context.Context, cfg ImportConfig, 
 		}
 		if !cfg.DryRun {
 			if err := i.series.CreateOrGet(ctx, existing); err != nil {
-				return false, "", err
+				return seriesUpsertResult{}, err
 			}
 		}
 		created = true
@@ -297,9 +312,11 @@ func (i *Importer) upsertHardcoverSeries(ctx context.Context, cfg ImportConfig, 
 	if cfg.DryRun && created {
 		localID = 0
 	}
+	countKey := seriesMembershipCountKey(localID, catalog.Title, catalog.ForeignID, bookID, itemID)
+	membershipExternalID := seriesMembershipExternalID(catalog.ForeignID, bookID, itemID)
 	if !cfg.DryRun {
 		if err := i.ensureHardcoverSeriesLink(ctx, existing.ID, catalog); err != nil {
-			return false, "", err
+			return seriesUpsertResult{}, err
 		}
 	}
 	metadata := map[string]any{
@@ -308,25 +325,39 @@ func (i *Importer) upsertHardcoverSeries(ctx context.Context, cfg ImportConfig, 
 		"matchedBy":       "hardcover_series",
 		"hardcoverBookId": strings.TrimSpace(matchedBook.ForeignID),
 	}
-	linkExternalID := hardcoverSeriesLinkExternalID(catalog.ForeignID, bookID)
-	linkCreated := cfg.DryRun
-	if !cfg.DryRun {
+	linkCreated := false
+	if cfg.DryRun {
+		if stats == nil || !stats.dryRunSeriesMembershipAlreadyPlanned(countKey) {
+			linkCreated = true
+			outcome := itemOutcomeLinked
+			if created {
+				outcome = itemOutcomeCreated
+			}
+			_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, itemID, entityTypeSeries, membershipExternalID, localID, outcome, metadata)
+			if stats != nil {
+				stats.rememberDryRunSeriesMembership(countKey)
+			}
+		}
+		if created && stats != nil {
+			stats.rememberDryRunSeries(catalog.ForeignID, catalog.Title)
+		}
+	} else {
 		var err error
 		linkCreated, err = i.series.LinkBookIfMissing(ctx, existing.ID, bookID, strings.TrimSpace(matchedBook.Position), true)
 		if err != nil {
-			return false, "", err
+			return seriesUpsertResult{}, err
 		}
 		if linkCreated {
 			if err := i.upsertProvenance(ctx, &models.ABSProvenance{
 				SourceID:    cfg.SourceID,
 				LibraryID:   cfg.LibraryID,
 				EntityType:  entityTypeSeries,
-				ExternalID:  linkExternalID,
+				ExternalID:  membershipExternalID,
 				LocalID:     existing.ID,
-				ItemID:      "",
+				ItemID:      itemID,
 				ImportRunID: ptrInt64(runID),
 			}); err != nil {
-				return false, "", err
+				return seriesUpsertResult{}, err
 			}
 		}
 	}
@@ -334,10 +365,19 @@ func (i *Importer) upsertHardcoverSeries(ctx context.Context, cfg ImportConfig, 
 	if created {
 		outcome = itemOutcomeCreated
 	}
-	if linkCreated {
-		_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, "", entityTypeSeries, linkExternalID, localID, outcome, metadata)
+	if !cfg.DryRun && linkCreated {
+		_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, itemID, entityTypeSeries, membershipExternalID, localID, outcome, metadata)
 	}
-	return created, matchedBy, nil
+	return seriesUpsertResult{
+		SeriesID:             localID,
+		IdentityExternalID:   catalog.ForeignID,
+		MembershipExternalID: membershipExternalID,
+		CountKey:             countKey,
+		CreatedSeries:        created,
+		MembershipCreated:    linkCreated,
+		Linked:               true,
+		MatchedBy:            matchedBy,
+	}, nil
 }
 
 func (i *Importer) ensureHardcoverSeriesLink(ctx context.Context, seriesID int64, catalog *metadata.SeriesCatalog) error {
@@ -404,7 +444,7 @@ func (i *Importer) linkExistingHardcoverCatalogBooks(ctx context.Context, cfg Im
 		if !linkCreated {
 			continue
 		}
-		linkExternalID := hardcoverSeriesLinkExternalID(catalog.ForeignID, localBook.ID)
+		linkExternalID := seriesMembershipExternalID(catalog.ForeignID, localBook.ID, "")
 		if err := i.upsertProvenance(ctx, &models.ABSProvenance{
 			SourceID:    cfg.SourceID,
 			LibraryID:   cfg.LibraryID,
@@ -457,14 +497,6 @@ func shouldPromoteSeriesToHardcover(existing *models.Series, catalog *metadata.S
 		return false
 	}
 	return normalizeSeriesName(existing.Title) == normalizeSeriesName(catalog.Title)
-}
-
-func hardcoverSeriesLinkExternalID(seriesForeignID string, bookID int64) string {
-	seriesForeignID = strings.TrimSpace(seriesForeignID)
-	if bookID <= 0 {
-		return seriesForeignID + ":book:planned"
-	}
-	return fmt.Sprintf("%s:book:%d", seriesForeignID, bookID)
 }
 
 func hardcoverAuthorScore(absAuthor, hcAuthor string) int {

--- a/internal/abs/import_rollback.go
+++ b/internal/abs/import_rollback.go
@@ -134,9 +134,32 @@ func (i *Importer) rollback(ctx context.Context, runID int64, preview bool) (*Ro
 	type set map[int64]struct{}
 	deletedBooks := make(set)
 	createdBookEntities := make(map[int64]models.ABSImportRunEntity)
+	runCreatedSeries := make(set)
+	seriesIdentityEntities := make(set)
+	runSeriesMemberships := make(map[int64]set)
+	seriesDeleteMembershipEntityID := make(map[int64]int64)
 	for _, entity := range entities {
 		if entity.EntityType == entityTypeBook && entity.Outcome == itemOutcomeCreated && entity.LocalID != 0 {
 			createdBookEntities[entity.LocalID] = entity
+		}
+		if entity.EntityType != entityTypeSeries || entity.LocalID == 0 {
+			continue
+		}
+		metadata := runEntityMetadataData(entity.MetadataJSON)
+		bookID := metadataBookID(metadata)
+		if entity.Outcome == itemOutcomeCreated {
+			runCreatedSeries[entity.LocalID] = struct{}{}
+		}
+		if bookID > 0 {
+			if runSeriesMemberships[entity.LocalID] == nil {
+				runSeriesMemberships[entity.LocalID] = make(set)
+			}
+			runSeriesMemberships[entity.LocalID][bookID] = struct{}{}
+			if entity.Outcome == itemOutcomeCreated && entity.ID > seriesDeleteMembershipEntityID[entity.LocalID] {
+				seriesDeleteMembershipEntityID[entity.LocalID] = entity.ID
+			}
+		} else {
+			seriesIdentityEntities[entity.LocalID] = struct{}{}
 		}
 	}
 	for _, entity := range entities {
@@ -452,10 +475,27 @@ func (i *Importer) rollback(ctx context.Context, runID int64, preview bool) (*Ro
 				result.Actions = append(result.Actions, action)
 				continue
 			}
-			bookID, _ := metadata["bookId"].(float64)
+			bookID := metadataBookID(metadata)
 			if bookID > 0 {
 				action.Action = "unlink_series"
 				result.Stats.ActionsPlanned++
+				_, createdByRun := runCreatedSeries[entity.LocalID]
+				_, hasIdentityEntity := seriesIdentityEntities[entity.LocalID]
+				deleteSeries := false
+				if createdByRun && !hasIdentityEntity && seriesDeleteMembershipEntityID[entity.LocalID] == entity.ID {
+					remaining, err := i.remainingSeriesBooksAfterRunRollback(ctx, entity.LocalID, runSeriesMemberships[entity.LocalID])
+					if err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					if remaining <= 0 {
+						action.Action = "delete_series"
+						deleteSeries = true
+					}
+				}
 				if !preview {
 					if err := i.series.UnlinkBook(ctx, entity.LocalID, int64(bookID)); err != nil {
 						action.Action = "skip"
@@ -464,31 +504,14 @@ func (i *Importer) rollback(ctx context.Context, runID int64, preview bool) (*Ro
 						result.Actions = append(result.Actions, action)
 						continue
 					}
-				}
-				if entity.Outcome == itemOutcomeCreated {
-					books, err := i.series.ListBooksInSeries(ctx, entity.LocalID)
-					if err == nil {
-						remaining := len(books)
-						if bookID > 0 && remaining > 0 {
-							remaining--
+					if deleteSeries {
+						if err := i.series.Delete(ctx, entity.LocalID); err != nil {
+							action.Action = "skip"
+							action.Reason = err.Error()
+							result.Stats.Failed++
+							result.Actions = append(result.Actions, action)
+							continue
 						}
-						if remaining <= 0 {
-							if !preview {
-								if err := i.series.Delete(ctx, entity.LocalID); err != nil {
-									action.Action = "skip"
-									action.Reason = err.Error()
-									result.Stats.Failed++
-									result.Actions = append(result.Actions, action)
-									continue
-								}
-								result.Stats.EntitiesDeleted++
-							}
-							action.Action = "delete_series"
-						}
-					}
-				}
-				if !preview {
-					if action.Action == "delete_series" {
 						unlinked, err := i.deleteProvenanceByLocal(ctx, entity.EntityType, entity.LocalID)
 						if err != nil {
 							action.Action = "skip"
@@ -497,23 +520,62 @@ func (i *Importer) rollback(ctx context.Context, runID int64, preview bool) (*Ro
 							result.Actions = append(result.Actions, action)
 							continue
 						}
+						result.Stats.EntitiesDeleted++
 						result.Stats.ProvenanceUnlinked += unlinked
-					} else if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.LibraryID, entity.EntityType, entity.ExternalID); err == nil {
+					} else if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.LibraryID, entity.EntityType, entity.ExternalID); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					} else {
 						result.Stats.ProvenanceUnlinked++
 					}
 				}
 			} else {
 				action.Action = "unlink_provenance"
-				result.Stats.ActionsPlanned++
-				if !preview {
-					if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.LibraryID, entity.EntityType, entity.ExternalID); err != nil {
+				if entity.Outcome == itemOutcomeCreated {
+					remaining, err := i.remainingSeriesBooksAfterRunRollback(ctx, entity.LocalID, runSeriesMemberships[entity.LocalID])
+					if err != nil {
 						action.Action = "skip"
 						action.Reason = err.Error()
 						result.Stats.Failed++
 						result.Actions = append(result.Actions, action)
 						continue
 					}
-					result.Stats.ProvenanceUnlinked++
+					if remaining <= 0 {
+						action.Action = "delete_series"
+					}
+				}
+				result.Stats.ActionsPlanned++
+				if !preview {
+					if action.Action == "delete_series" {
+						if err := i.series.Delete(ctx, entity.LocalID); err != nil {
+							action.Action = "skip"
+							action.Reason = err.Error()
+							result.Stats.Failed++
+							result.Actions = append(result.Actions, action)
+							continue
+						}
+						unlinked, err := i.deleteProvenanceByLocal(ctx, entity.EntityType, entity.LocalID)
+						if err != nil {
+							action.Action = "skip"
+							action.Reason = err.Error()
+							result.Stats.Failed++
+							result.Actions = append(result.Actions, action)
+							continue
+						}
+						result.Stats.EntitiesDeleted++
+						result.Stats.ProvenanceUnlinked += unlinked
+					} else if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.LibraryID, entity.EntityType, entity.ExternalID); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					} else {
+						result.Stats.ProvenanceUnlinked++
+					}
 				}
 			}
 		default:
@@ -750,6 +812,37 @@ func (i *Importer) rollbackActionDisplayName(ctx context.Context, entity models.
 	}
 }
 
+func metadataBookID(metadata map[string]any) int64 {
+	switch value := metadata["bookId"].(type) {
+	case float64:
+		return int64(value)
+	case int64:
+		return value
+	case int:
+		return int64(value)
+	case json.Number:
+		parsed, _ := value.Int64()
+		return parsed
+	default:
+		return 0
+	}
+}
+
+func (i *Importer) remainingSeriesBooksAfterRunRollback(ctx context.Context, seriesID int64, runOwnedBookIDs map[int64]struct{}) (int, error) {
+	books, err := i.series.ListBooksInSeries(ctx, seriesID)
+	if err != nil {
+		return 0, err
+	}
+	remaining := 0
+	for _, book := range books {
+		if _, ok := runOwnedBookIDs[book.ID]; ok {
+			continue
+		}
+		remaining++
+	}
+	return remaining, nil
+}
+
 // rollbackEntityRank orders entities for rollback so children (editions) are
 // unwound before parents (books, series, authors). Editions first avoids
 // leaving dangling edition→book FK references while we restore the book;
@@ -762,10 +855,13 @@ func rollbackEntityRank(entity models.ABSImportRunEntity) int {
 	case entityTypeBook:
 		return 1
 	case entityTypeSeries:
-		return 2
-	case entityTypeAuthor:
+		if metadataBookID(runEntityMetadataData(entity.MetadataJSON)) > 0 {
+			return 2
+		}
 		return 3
-	default:
+	case entityTypeAuthor:
 		return 4
+	default:
+		return 5
 	}
 }

--- a/internal/abs/import_types.go
+++ b/internal/abs/import_types.go
@@ -24,6 +24,7 @@ const (
 	entityTypeSeries            = "series"
 	entityTypeEdition           = "edition"
 	providerAudiobookshelf      = "audiobookshelf"
+	providerHardcover           = "hardcover"
 	runStatusRunning            = "running"
 	runStatusCompleted          = "completed"
 	runStatusFailed             = "failed"

--- a/internal/abs/import_types.go
+++ b/internal/abs/import_types.go
@@ -44,6 +44,8 @@ type importClientFactory func(baseURL, apiKey string) (enumerationClient, error)
 
 type enumerateFunc func(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error)
 
+type enhancedHardcoverSeriesEnabledFunc func(context.Context) bool
+
 type ImportConfig struct {
 	SourceID  string
 	BaseURL   string
@@ -193,24 +195,25 @@ type metadataMergeResult struct {
 }
 
 type Importer struct {
-	authors      *db.AuthorRepo
-	aliases      *db.AuthorAliasRepo
-	books        *db.BookRepo
-	editions     *db.EditionRepo
-	series       *db.SeriesRepo
-	settings     *db.SettingsRepo
-	runs         *db.ABSImportRunRepo
-	runEntities  *db.ABSImportRunEntityRepo
-	provenance   *db.ABSProvenanceRepo
-	reviews      *db.ABSReviewItemRepo
-	conflicts    *db.ABSMetadataConflictRepo
-	meta         *metadata.Aggregator
-	newClient    importClientFactory
-	userAgent    string
-	enumerateFn  enumerateFunc
-	rootFolders  *db.RootFolderRepo
-	libraryDir   string
-	audiobookDir string
+	authors                *db.AuthorRepo
+	aliases                *db.AuthorAliasRepo
+	books                  *db.BookRepo
+	editions               *db.EditionRepo
+	series                 *db.SeriesRepo
+	settings               *db.SettingsRepo
+	runs                   *db.ABSImportRunRepo
+	runEntities            *db.ABSImportRunEntityRepo
+	provenance             *db.ABSProvenanceRepo
+	reviews                *db.ABSReviewItemRepo
+	conflicts              *db.ABSMetadataConflictRepo
+	meta                   *metadata.Aggregator
+	newClient              importClientFactory
+	hardcoverSeriesEnabled enhancedHardcoverSeriesEnabledFunc
+	userAgent              string
+	enumerateFn            enumerateFunc
+	rootFolders            *db.RootFolderRepo
+	libraryDir             string
+	audiobookDir           string
 
 	mu       sync.Mutex
 	running  bool

--- a/internal/abs/import_types.go
+++ b/internal/abs/import_types.go
@@ -117,6 +117,7 @@ type ImportStats struct {
 
 	dryRunSeriesExternalIDs map[string]struct{}
 	dryRunSeriesTitles      map[string]struct{}
+	dryRunSeriesMemberships map[string]struct{}
 }
 
 type ImportSourceSnapshot struct {

--- a/internal/abs/import_upserts.go
+++ b/internal/abs/import_upserts.go
@@ -379,6 +379,13 @@ func (i *Importer) enrichBook(ctx context.Context, cfg ImportConfig, item Normal
 		return metadataMergeResult{}, nil
 	}
 
+	return i.mergeUpstreamBook(ctx, cfg, item, book, full, matchedBy)
+}
+
+func (i *Importer) mergeUpstreamBook(ctx context.Context, cfg ImportConfig, item NormalizedLibraryItem, book *models.Book, full *models.Book, matchedBy string) (metadataMergeResult, error) {
+	if book == nil || full == nil {
+		return metadataMergeResult{}, nil
+	}
 	result := metadataMergeResult{Matched: 1}
 	changed := false
 	if full.ForeignID != "" && book.ForeignID != full.ForeignID {

--- a/internal/abs/import_upserts.go
+++ b/internal/abs/import_upserts.go
@@ -18,6 +18,17 @@ type bookUpsertResult struct {
 	matchedBy string
 }
 
+type seriesUpsertResult struct {
+	SeriesID             int64
+	IdentityExternalID   string
+	MembershipExternalID string
+	CountKey             string
+	CreatedSeries        bool
+	MembershipCreated    bool
+	Linked               bool
+	MatchedBy            string
+}
+
 func (i *Importer) resolveAuthor(ctx context.Context, cfg ImportConfig, runID int64, item NormalizedLibraryItem, allowCreate bool, matcher *authorMatcher) (*models.Author, bool, string, metadataMergeResult, error) {
 	if len(item.Authors) == 0 {
 		return nil, false, "", metadataMergeResult{}, errors.New("item has no authors")
@@ -799,20 +810,22 @@ func (i *Importer) applyBookFields(ctx context.Context, book *models.Book, autho
 	return i.books.Update(ctx, book)
 }
 
-func (i *Importer) upsertSeries(ctx context.Context, cfg ImportConfig, runID, bookID int64, ref NormalizedSeries, stats *ImportStats) (bool, string, error) {
+func (i *Importer) upsertSeries(ctx context.Context, cfg ImportConfig, runID, bookID int64, itemID string, ref NormalizedSeries, stats *ImportStats) (seriesUpsertResult, error) {
 	title := strings.TrimSpace(ref.Name)
 	if title == "" {
-		return false, "", nil
+		return seriesUpsertResult{}, nil
 	}
 	externalID := seriesExternalID(ref)
 	var existing *models.Series
+	var identityLink *models.ABSProvenance
 	if i.provenance != nil {
 		if link, err := i.provenance.GetByExternal(ctx, cfg.SourceID, cfg.LibraryID, entityTypeSeries, externalID); err != nil {
-			return false, "", err
+			return seriesUpsertResult{}, err
 		} else if link != nil {
+			identityLink = link
 			existing, err = i.series.GetByID(ctx, link.LocalID)
 			if err != nil {
-				return false, "", err
+				return seriesUpsertResult{}, err
 			}
 		}
 	}
@@ -820,10 +833,10 @@ func (i *Importer) upsertSeries(ctx context.Context, cfg ImportConfig, runID, bo
 	if existing == nil {
 		match, ambiguous, err := i.findSeriesByTitle(ctx, title)
 		if err != nil {
-			return false, "", err
+			return seriesUpsertResult{}, err
 		}
 		if ambiguous {
-			return false, "", fmt.Errorf("ambiguous existing series match for %q", title)
+			return seriesUpsertResult{}, fmt.Errorf("ambiguous existing series match for %q", title)
 		}
 		if match != nil {
 			existing = match
@@ -833,7 +846,25 @@ func (i *Importer) upsertSeries(ctx context.Context, cfg ImportConfig, runID, bo
 	created := false
 	if existing == nil {
 		if cfg.DryRun && stats != nil && stats.dryRunSeriesAlreadyPlanned(externalID, title) {
-			return i.recordPlannedSeries(ctx, cfg, runID, bookID, externalID, ref, false, "planned")
+			countKey := seriesMembershipCountKey(0, title, externalID, bookID, itemID)
+			membershipCreated := !stats.dryRunSeriesMembershipAlreadyPlanned(countKey)
+			membershipExternalID := seriesMembershipExternalID(externalID, bookID, itemID)
+			if membershipCreated {
+				metadata := map[string]any{
+					"bookId":   bookID,
+					"sequence": strings.TrimSpace(ref.Sequence),
+				}
+				_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, itemID, entityTypeSeries, membershipExternalID, 0, itemOutcomeLinked, metadata)
+				stats.rememberDryRunSeriesMembership(countKey)
+			}
+			return seriesUpsertResult{
+				IdentityExternalID:   externalID,
+				MembershipExternalID: membershipExternalID,
+				CountKey:             countKey,
+				MembershipCreated:    membershipCreated,
+				Linked:               true,
+				MatchedBy:            "planned",
+			}, nil
 		}
 		existing = &models.Series{
 			ForeignID:   absForeignID("series", cfg.LibraryID, externalID),
@@ -842,20 +873,51 @@ func (i *Importer) upsertSeries(ctx context.Context, cfg ImportConfig, runID, bo
 		}
 		if !cfg.DryRun {
 			if err := i.series.CreateOrGet(ctx, existing); err != nil {
-				return false, "", err
+				return seriesUpsertResult{}, err
 			}
 		}
 		created = true
 		matchedBy = "created"
 	}
+	localID := existing.ID
+	if cfg.DryRun && created {
+		localID = 0
+	}
+	countKey := seriesMembershipCountKey(localID, title, externalID, bookID, itemID)
+	membershipExternalID := seriesMembershipExternalID(externalID, bookID, itemID)
 	metadata := map[string]any{
 		"bookId":   bookID,
 		"sequence": strings.TrimSpace(ref.Sequence),
 	}
-	if !cfg.DryRun {
-		if err := i.series.LinkBook(ctx, existing.ID, bookID, strings.TrimSpace(ref.Sequence), true); err != nil {
-			return false, "", err
+	membershipCreated := false
+	if cfg.DryRun {
+		if stats == nil || !stats.dryRunSeriesMembershipAlreadyPlanned(countKey) {
+			membershipCreated = true
+			outcome := itemOutcomeLinked
+			if created {
+				outcome = itemOutcomeCreated
+			}
+			_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, itemID, entityTypeSeries, membershipExternalID, localID, outcome, metadata)
+			if stats != nil {
+				stats.rememberDryRunSeriesMembership(countKey)
+			}
 		}
+		if created && stats != nil {
+			stats.rememberDryRunSeries(externalID, title)
+		}
+		return seriesUpsertResult{
+			SeriesID:             localID,
+			IdentityExternalID:   externalID,
+			MembershipExternalID: membershipExternalID,
+			CountKey:             countKey,
+			CreatedSeries:        created,
+			MembershipCreated:    membershipCreated,
+			Linked:               true,
+			MatchedBy:            matchedBy,
+		}, nil
+	}
+	identityChanged := identityLink == nil || identityLink.LocalID != existing.ID
+	if identityChanged {
 		if err := i.upsertProvenance(ctx, &models.ABSProvenance{
 			SourceID:    cfg.SourceID,
 			LibraryID:   cfg.LibraryID,
@@ -865,35 +927,79 @@ func (i *Importer) upsertSeries(ctx context.Context, cfg ImportConfig, runID, bo
 			ItemID:      "",
 			ImportRunID: ptrInt64(runID),
 		}); err != nil {
-			return false, "", err
+			return seriesUpsertResult{}, err
 		}
+		outcome := itemOutcomeLinked
+		if created {
+			outcome = itemOutcomeCreated
+		}
+		_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, "", entityTypeSeries, externalID, existing.ID, outcome, map[string]any{
+			"matchedBy": matchedBy,
+			"identity":  true,
+		})
 	}
-	localID := existing.ID
-	if cfg.DryRun && created {
-		localID = 0
+	membershipCreated, err := i.series.LinkBookIfMissing(ctx, existing.ID, bookID, strings.TrimSpace(ref.Sequence), true)
+	if err != nil {
+		return seriesUpsertResult{}, err
 	}
-	outcome := itemOutcomeLinked
-	if created {
-		outcome = itemOutcomeCreated
+	if membershipCreated {
+		if err := i.upsertProvenance(ctx, &models.ABSProvenance{
+			SourceID:    cfg.SourceID,
+			LibraryID:   cfg.LibraryID,
+			EntityType:  entityTypeSeries,
+			ExternalID:  membershipExternalID,
+			LocalID:     existing.ID,
+			ItemID:      itemID,
+			ImportRunID: ptrInt64(runID),
+		}); err != nil {
+			return seriesUpsertResult{}, err
+		}
+		outcome := itemOutcomeLinked
+		if created {
+			outcome = itemOutcomeCreated
+		}
+		_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, itemID, entityTypeSeries, membershipExternalID, existing.ID, outcome, metadata)
 	}
-	_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, "", entityTypeSeries, externalID, localID, outcome, metadata)
-	if cfg.DryRun && created && stats != nil {
-		stats.rememberDryRunSeries(externalID, title)
-	}
-	return created, matchedBy, nil
+	return seriesUpsertResult{
+		SeriesID:             existing.ID,
+		IdentityExternalID:   externalID,
+		MembershipExternalID: membershipExternalID,
+		CountKey:             countKey,
+		CreatedSeries:        created,
+		MembershipCreated:    membershipCreated,
+		Linked:               true,
+		MatchedBy:            matchedBy,
+	}, nil
 }
 
-func (i *Importer) recordPlannedSeries(ctx context.Context, cfg ImportConfig, runID, bookID int64, externalID string, ref NormalizedSeries, created bool, matchedBy string) (bool, string, error) {
-	metadata := map[string]any{
-		"bookId":   bookID,
-		"sequence": strings.TrimSpace(ref.Sequence),
+func seriesMembershipExternalID(seriesExternalID string, bookID int64, itemID string) string {
+	seriesExternalID = strings.TrimSpace(seriesExternalID)
+	if bookID <= 0 {
+		itemID = strings.TrimSpace(itemID)
+		if itemID == "" {
+			return seriesExternalID + ":book:planned"
+		}
+		return seriesExternalID + ":item:" + itemID
 	}
-	outcome := itemOutcomeLinked
-	if created {
-		outcome = itemOutcomeCreated
+	return fmt.Sprintf("%s:book:%d", seriesExternalID, bookID)
+}
+
+func seriesMembershipCountKey(seriesID int64, title, externalID string, bookID int64, itemID string) string {
+	bookKey := strings.TrimSpace(itemID)
+	if bookID > 0 {
+		bookKey = fmt.Sprintf("book:%d", bookID)
+	} else if bookKey != "" {
+		bookKey = "item:" + bookKey
+	} else {
+		bookKey = "book:planned"
 	}
-	_ = i.recordRunEntity(ctx, runID, cfg, cfg.LibraryID, "", entityTypeSeries, externalID, 0, outcome, metadata)
-	return created, matchedBy, nil
+	if seriesID > 0 {
+		return fmt.Sprintf("series:%d:%s", seriesID, bookKey)
+	}
+	if titleKey := normalizeSeriesName(title); titleKey != "" {
+		return "title:" + titleKey + ":" + bookKey
+	}
+	return "external:" + strings.TrimSpace(externalID) + ":" + bookKey
 }
 
 func (s *ImportStats) dryRunSeriesAlreadyPlanned(externalID, title string) bool {
@@ -918,6 +1024,21 @@ func (s *ImportStats) rememberDryRunSeries(externalID, title string) {
 	}
 	s.dryRunSeriesExternalIDs[strings.TrimSpace(externalID)] = struct{}{}
 	s.dryRunSeriesTitles[normalizeTitle(title)] = struct{}{}
+}
+
+func (s *ImportStats) dryRunSeriesMembershipAlreadyPlanned(key string) bool {
+	if s == nil {
+		return false
+	}
+	_, ok := s.dryRunSeriesMemberships[strings.TrimSpace(key)]
+	return ok
+}
+
+func (s *ImportStats) rememberDryRunSeriesMembership(key string) {
+	if s.dryRunSeriesMemberships == nil {
+		s.dryRunSeriesMemberships = make(map[string]struct{})
+	}
+	s.dryRunSeriesMemberships[strings.TrimSpace(key)] = struct{}{}
 }
 
 func (i *Importer) findSeriesByTitle(ctx context.Context, title string) (*models.Series, bool, error) {

--- a/internal/abs/importer.go
+++ b/internal/abs/importer.go
@@ -517,6 +517,12 @@ func (i *Importer) importOne(ctx context.Context, cfg ImportConfig, runID int64,
 			stats.SeriesLinked++
 		}
 	}
+	seriesMeta, hardcoverSeriesCount := i.matchHardcoverSeries(ctx, cfg, runID, author, bookResult.row, item, stats)
+	stats.MetadataMatched += seriesMeta.Matched
+	stats.MetadataRelinked += seriesMeta.Relinked
+	stats.MetadataConflicts += seriesMeta.Conflicts
+	stats.MetadataAutoResolved += seriesMeta.AutoResolved
+	seriesCount += hardcoverSeriesCount
 	result.SeriesCount = seriesCount
 
 	addedEditions, err := i.upsertEditions(ctx, cfg, runID, bookResult.row.ID, item)
@@ -531,6 +537,7 @@ func (i *Importer) importOne(ctx context.Context, cfg ImportConfig, runID int64,
 	stats.PendingManual += reconcile.PendingManual
 	messages := append([]string{}, authorMeta.Messages...)
 	messages = append(messages, bookMeta.Messages...)
+	messages = append(messages, seriesMeta.Messages...)
 	if reconcile.Message != "" {
 		messages = append(messages, reconcile.Message)
 	}

--- a/internal/abs/importer.go
+++ b/internal/abs/importer.go
@@ -503,27 +503,36 @@ func (i *Importer) importOne(ctx context.Context, cfg ImportConfig, runID int64,
 		i.enrichAudiobookFromASIN(ctx, bookResult.row)
 	}
 
-	seriesCount := 0
+	seriesMemberships := map[string]struct{}{}
 	for _, series := range item.Series {
-		created, matchedBy, err := i.upsertSeries(ctx, cfg, runID, bookResult.row.ID, series, stats)
+		seriesResult, err := i.upsertSeries(ctx, cfg, runID, bookResult.row.ID, item.ItemID, series, stats)
 		if err != nil {
 			slog.Warn("abs import: series upsert failed", "itemID", item.ItemID, "series", series.Name, "error", err)
 			continue
 		}
-		seriesCount++
-		if created {
+		if seriesResult.Linked && seriesResult.CountKey != "" {
+			seriesMemberships[seriesResult.CountKey] = struct{}{}
+		}
+		if seriesResult.CreatedSeries {
 			stats.SeriesCreated++
-		} else if matchedBy != "" {
+		} else if seriesResult.MembershipCreated {
 			stats.SeriesLinked++
 		}
 	}
-	seriesMeta, hardcoverSeriesCount := i.matchHardcoverSeries(ctx, cfg, runID, author, bookResult.row, item, stats)
+	seriesMeta, hardcoverSeriesResult := i.matchHardcoverSeries(ctx, cfg, runID, author, bookResult.row, item, stats)
 	stats.MetadataMatched += seriesMeta.Matched
 	stats.MetadataRelinked += seriesMeta.Relinked
 	stats.MetadataConflicts += seriesMeta.Conflicts
 	stats.MetadataAutoResolved += seriesMeta.AutoResolved
-	seriesCount += hardcoverSeriesCount
-	result.SeriesCount = seriesCount
+	if hardcoverSeriesResult.Linked && hardcoverSeriesResult.CountKey != "" {
+		seriesMemberships[hardcoverSeriesResult.CountKey] = struct{}{}
+	}
+	if hardcoverSeriesResult.CreatedSeries {
+		stats.SeriesCreated++
+	} else if hardcoverSeriesResult.MembershipCreated {
+		stats.SeriesLinked++
+	}
+	result.SeriesCount = len(seriesMemberships)
 
 	addedEditions, err := i.upsertEditions(ctx, cfg, runID, bookResult.row.ID, item)
 	if err != nil {

--- a/internal/abs/importer.go
+++ b/internal/abs/importer.go
@@ -530,7 +530,7 @@ func (i *Importer) importOne(ctx context.Context, cfg ImportConfig, runID int64,
 	}
 	seriesMeta := metadataMergeResult{}
 	if i.enhancedHardcoverSeriesEnabled(ctx) {
-		hardcoverSeriesResult := seriesUpsertResult{}
+		var hardcoverSeriesResult seriesUpsertResult
 		seriesMeta, hardcoverSeriesResult = i.matchHardcoverSeries(ctx, cfg, runID, author, bookResult.row, item, stats)
 		stats.MetadataMatched += seriesMeta.Matched
 		stats.MetadataRelinked += seriesMeta.Relinked

--- a/internal/abs/importer.go
+++ b/internal/abs/importer.go
@@ -62,6 +62,11 @@ func (i *Importer) WithMetadata(meta *metadata.Aggregator) *Importer {
 	return i
 }
 
+func (i *Importer) WithEnhancedHardcoverSeriesEnabled(enabled func(context.Context) bool) *Importer {
+	i.hardcoverSeriesEnabled = enabled
+	return i
+}
+
 func (i *Importer) WithVersion(version string) *Importer {
 	i.userAgent = UserAgent(version)
 	return i
@@ -84,6 +89,10 @@ func (i *Importer) WithStoragePaths(libraryDir, audiobookDir string, rootFolders
 	}
 	i.rootFolders = rootFolders
 	return i
+}
+
+func (i *Importer) enhancedHardcoverSeriesEnabled(ctx context.Context) bool {
+	return i.hardcoverSeriesEnabled != nil && i.hardcoverSeriesEnabled(ctx)
 }
 
 func (i *Importer) Progress() ImportProgress {
@@ -519,18 +528,22 @@ func (i *Importer) importOne(ctx context.Context, cfg ImportConfig, runID int64,
 			stats.SeriesLinked++
 		}
 	}
-	seriesMeta, hardcoverSeriesResult := i.matchHardcoverSeries(ctx, cfg, runID, author, bookResult.row, item, stats)
-	stats.MetadataMatched += seriesMeta.Matched
-	stats.MetadataRelinked += seriesMeta.Relinked
-	stats.MetadataConflicts += seriesMeta.Conflicts
-	stats.MetadataAutoResolved += seriesMeta.AutoResolved
-	if hardcoverSeriesResult.Linked && hardcoverSeriesResult.CountKey != "" {
-		seriesMemberships[hardcoverSeriesResult.CountKey] = struct{}{}
-	}
-	if hardcoverSeriesResult.CreatedSeries {
-		stats.SeriesCreated++
-	} else if hardcoverSeriesResult.MembershipCreated {
-		stats.SeriesLinked++
+	seriesMeta := metadataMergeResult{}
+	if i.enhancedHardcoverSeriesEnabled(ctx) {
+		hardcoverSeriesResult := seriesUpsertResult{}
+		seriesMeta, hardcoverSeriesResult = i.matchHardcoverSeries(ctx, cfg, runID, author, bookResult.row, item, stats)
+		stats.MetadataMatched += seriesMeta.Matched
+		stats.MetadataRelinked += seriesMeta.Relinked
+		stats.MetadataConflicts += seriesMeta.Conflicts
+		stats.MetadataAutoResolved += seriesMeta.AutoResolved
+		if hardcoverSeriesResult.Linked && hardcoverSeriesResult.CountKey != "" {
+			seriesMemberships[hardcoverSeriesResult.CountKey] = struct{}{}
+		}
+		if hardcoverSeriesResult.CreatedSeries {
+			stats.SeriesCreated++
+		} else if hardcoverSeriesResult.MembershipCreated {
+			stats.SeriesLinked++
+		}
 	}
 	result.SeriesCount = len(seriesMemberships)
 

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -482,6 +482,8 @@ type stubABSMetadataProvider struct {
 	books                map[string]*models.Book
 	booksByISBN          map[string]*models.Book
 	works                map[string][]models.Book
+	series               map[string][]metadata.SeriesSearchResult
+	catalogs             map[string]*metadata.SeriesCatalog
 }
 
 func (p *stubABSMetadataProvider) Name() string { return "stub" }
@@ -520,6 +522,22 @@ func (p *stubABSMetadataProvider) GetAuthorWorks(_ context.Context, foreignID st
 		return nil, nil
 	}
 	return append([]models.Book(nil), p.works[foreignID]...), nil
+}
+func (p *stubABSMetadataProvider) SearchSeries(_ context.Context, query string, limit int) ([]metadata.SeriesSearchResult, error) {
+	if p.series == nil {
+		return nil, nil
+	}
+	results := append([]metadata.SeriesSearchResult(nil), p.series[query]...)
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+	return results, nil
+}
+func (p *stubABSMetadataProvider) GetSeriesCatalog(_ context.Context, foreignID string) (*metadata.SeriesCatalog, error) {
+	if p.catalogs == nil {
+		return nil, nil
+	}
+	return p.catalogs[foreignID], nil
 }
 
 func TestImporter_NormalizedAuthorMatchLinksExistingAuthor(t *testing.T) {
@@ -1975,6 +1993,318 @@ func TestImporter_DryRunCountsPlannedSeriesOnce(t *testing.T) {
 	}
 	if stats.SeriesCreated != 1 || stats.SeriesLinked != 1 {
 		t.Fatalf("dry-run series stats = %+v, want 1 created and 1 linked", stats)
+	}
+}
+
+func hardcoverSeriesABSItem() NormalizedLibraryItem {
+	item := sampleABSItem()
+	item.ItemID = "li-different-seasons"
+	item.Title = "1982 - Different Seasons (4 novellas - read by Frank Muller)"
+	item.Authors = []NormalizedAuthor{{ID: "author-stephen-king", Name: "Stephen King"}}
+	item.Series = nil
+	return item
+}
+
+func hardcoverSeriesProvider(query string, result metadata.SeriesSearchResult, catalog *metadata.SeriesCatalog) *stubABSMetadataProvider {
+	return &stubABSMetadataProvider{
+		series: map[string][]metadata.SeriesSearchResult{
+			query: {result},
+		},
+		catalogs: map[string]*metadata.SeriesCatalog{
+			result.ForeignID: catalog,
+		},
+	}
+}
+
+func TestImporter_HardcoverSeriesMatchLinksItemWithoutABSSeries(t *testing.T) {
+	t.Parallel()
+
+	importer, _, bookRepo, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	item := hardcoverSeriesABSItem()
+	catalog := &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:100",
+		ProviderID: "100",
+		Title:      "Different Seasons",
+		AuthorName: "Stephen King",
+		Books: []metadata.SeriesCatalogBook{
+			{
+				ForeignID: "hc:different-seasons",
+				Title:     "Different Seasons",
+				Position:  "1",
+				Book: models.Book{
+					ForeignID:        "hc:different-seasons",
+					Title:            "Different Seasons",
+					MetadataProvider: providerHardcover,
+					Author:           &models.Author{Name: "Stephen King"},
+				},
+			},
+		},
+	}
+	importer.WithMetadata(metadata.NewAggregator(hardcoverSeriesProvider(item.Title, metadata.SeriesSearchResult{
+		ForeignID:  "hc-series:100",
+		ProviderID: "100",
+		Title:      "Different Seasons",
+		AuthorName: "Stephen King",
+	}, catalog)))
+	runSingleABSImport(t, importer, item)
+
+	series, err := seriesRepo.GetByForeignID(context.Background(), "hc-series:100")
+	if err != nil {
+		t.Fatalf("GetByForeignID: %v", err)
+	}
+	if series == nil {
+		t.Fatal("expected Hardcover series")
+	}
+	hydrated, err := seriesRepo.GetByID(context.Background(), series.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if len(hydrated.Books) != 1 || hydrated.Books[0].PositionInSeries != "1" {
+		t.Fatalf("series books = %+v, want one linked at position 1", hydrated.Books)
+	}
+	books, err := bookRepo.ListIncludingExcluded(context.Background())
+	if err != nil {
+		t.Fatalf("List books: %v", err)
+	}
+	if len(books) != 1 || books[0].ForeignID != "hc:different-seasons" {
+		t.Fatalf("book relink = %+v, want hc:different-seasons", books)
+	}
+}
+
+func TestImporter_HardcoverSeriesMatchPromotesExactABSSeries(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	item := sampleABSItem()
+	item.ItemID = "li-all-systems-red"
+	item.Title = "All Systems Red"
+	item.Authors = []NormalizedAuthor{{ID: "author-martha-wells", Name: "Martha Wells"}}
+	item.Series = []NormalizedSeries{{Name: "The Murderbot Diaries", Sequence: "1"}}
+	catalog := &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:200",
+		ProviderID: "200",
+		Title:      "The Murderbot Diaries",
+		AuthorName: "Martha Wells",
+		Books: []metadata.SeriesCatalogBook{{
+			ForeignID: "hc:all-systems-red",
+			Title:     "All Systems Red",
+			Position:  "1",
+			Book: models.Book{
+				ForeignID:        "hc:all-systems-red",
+				Title:            "All Systems Red",
+				MetadataProvider: providerHardcover,
+				Author:           &models.Author{Name: "Martha Wells"},
+			},
+		}},
+	}
+	importer.WithMetadata(metadata.NewAggregator(hardcoverSeriesProvider("The Murderbot Diaries", metadata.SeriesSearchResult{
+		ForeignID:  "hc-series:200",
+		ProviderID: "200",
+		Title:      "The Murderbot Diaries",
+		AuthorName: "Martha Wells",
+	}, catalog)))
+	runSingleABSImport(t, importer, item)
+
+	series, err := seriesRepo.GetByForeignID(context.Background(), "hc-series:200")
+	if err != nil {
+		t.Fatalf("GetByForeignID: %v", err)
+	}
+	if series == nil {
+		t.Fatal("expected promoted Hardcover series")
+	}
+	all, err := seriesRepo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List series: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("series rows = %+v, want one promoted row", all)
+	}
+}
+
+func TestImporter_HardcoverSeriesAmbiguousCandidatesDoNotLink(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	item := hardcoverSeriesABSItem()
+	resultA := metadata.SeriesSearchResult{ForeignID: "hc-series:301", ProviderID: "301", Title: "Different Seasons", AuthorName: "Stephen King"}
+	resultB := metadata.SeriesSearchResult{ForeignID: "hc-series:302", ProviderID: "302", Title: "Different Seasons", AuthorName: "Stephen King"}
+	catalog := func(id string) *metadata.SeriesCatalog {
+		return &metadata.SeriesCatalog{
+			ForeignID:  id,
+			Title:      "Different Seasons",
+			AuthorName: "Stephen King",
+			Books: []metadata.SeriesCatalogBook{{
+				ForeignID: "hc:different-seasons",
+				Title:     "Different Seasons",
+				Position:  "1",
+				Book:      models.Book{ForeignID: "hc:different-seasons", Title: "Different Seasons", Author: &models.Author{Name: "Stephen King"}},
+			}},
+		}
+	}
+	importer.WithMetadata(metadata.NewAggregator(&stubABSMetadataProvider{
+		series: map[string][]metadata.SeriesSearchResult{
+			item.Title: {resultA, resultB},
+		},
+		catalogs: map[string]*metadata.SeriesCatalog{
+			resultA.ForeignID: catalog(resultA.ForeignID),
+			resultB.ForeignID: catalog(resultB.ForeignID),
+		},
+	}))
+	importer.enumerateFn = func(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		if err := fn(ctx, item); err != nil {
+			return EnumerationStats{}, err
+		}
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+	stats, err := importer.Run(context.Background(), ImportConfig{
+		SourceID:  DefaultSourceID,
+		BaseURL:   "https://abs.example.com",
+		APIKey:    "secret",
+		LibraryID: item.LibraryID,
+		Label:     "Shelf",
+		Enabled:   true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.SeriesCreated != 0 || stats.SeriesLinked != 0 {
+		t.Fatalf("series stats = %+v, want no links", stats)
+	}
+	series, err := seriesRepo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List series: %v", err)
+	}
+	if len(series) != 0 {
+		t.Fatalf("series = %+v, want none", series)
+	}
+}
+
+func TestImporter_HardcoverSeriesRerunIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	item := hardcoverSeriesABSItem()
+	catalog := &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:400",
+		Title:      "Different Seasons",
+		AuthorName: "Stephen King",
+		Books: []metadata.SeriesCatalogBook{{
+			ForeignID: "hc:different-seasons",
+			Title:     "Different Seasons",
+			Position:  "1",
+			Book:      models.Book{ForeignID: "hc:different-seasons", Title: "Different Seasons", Author: &models.Author{Name: "Stephen King"}},
+		}},
+	}
+	importer.WithMetadata(metadata.NewAggregator(hardcoverSeriesProvider(item.Title, metadata.SeriesSearchResult{
+		ForeignID: "hc-series:400", Title: "Different Seasons", AuthorName: "Stephen King",
+	}, catalog)))
+	runSingleABSImport(t, importer, item)
+	secondRunID := runSingleABSImport(t, importer, item)
+
+	series, err := seriesRepo.GetByForeignID(context.Background(), "hc-series:400")
+	if err != nil {
+		t.Fatalf("GetByForeignID: %v", err)
+	}
+	hydrated, err := seriesRepo.GetByID(context.Background(), series.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if len(hydrated.Books) != 1 {
+		t.Fatalf("series books = %+v, want one idempotent link", hydrated.Books)
+	}
+	if _, err := importer.Rollback(context.Background(), secondRunID); err != nil {
+		t.Fatalf("Rollback second run: %v", err)
+	}
+	hydrated, err = seriesRepo.GetByID(context.Background(), series.ID)
+	if err != nil {
+		t.Fatalf("GetByID after rollback: %v", err)
+	}
+	if hydrated == nil || len(hydrated.Books) != 1 {
+		t.Fatalf("series books after rollback = %+v, want original link preserved", hydrated)
+	}
+}
+
+func TestImporter_HardcoverSeriesDryRunPlansOnly(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	item := hardcoverSeriesABSItem()
+	catalog := &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:500",
+		Title:      "Different Seasons",
+		AuthorName: "Stephen King",
+		Books: []metadata.SeriesCatalogBook{{
+			ForeignID: "hc:different-seasons",
+			Title:     "Different Seasons",
+			Position:  "1",
+			Book:      models.Book{ForeignID: "hc:different-seasons", Title: "Different Seasons", Author: &models.Author{Name: "Stephen King"}},
+		}},
+	}
+	importer.WithMetadata(metadata.NewAggregator(hardcoverSeriesProvider(item.Title, metadata.SeriesSearchResult{
+		ForeignID: "hc-series:500", Title: "Different Seasons", AuthorName: "Stephen King",
+	}, catalog)))
+	importer.enumerateFn = func(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		if err := fn(ctx, item); err != nil {
+			return EnumerationStats{}, err
+		}
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+	stats, err := importer.Run(context.Background(), ImportConfig{
+		SourceID:  DefaultSourceID,
+		BaseURL:   "https://abs.example.com",
+		APIKey:    "secret",
+		LibraryID: item.LibraryID,
+		Label:     "Shelf",
+		Enabled:   true,
+		DryRun:    true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.SeriesCreated != 1 || stats.SeriesLinked != 0 {
+		t.Fatalf("dry-run series stats = %+v, want planned created link", stats)
+	}
+	series, err := seriesRepo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List series: %v", err)
+	}
+	if len(series) != 0 {
+		t.Fatalf("series = %+v, want no mutation", series)
+	}
+}
+
+func TestImporter_HardcoverSeriesRollbackRemovesLinks(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	item := hardcoverSeriesABSItem()
+	catalog := &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:600",
+		Title:      "Different Seasons",
+		AuthorName: "Stephen King",
+		Books: []metadata.SeriesCatalogBook{{
+			ForeignID: "hc:different-seasons",
+			Title:     "Different Seasons",
+			Position:  "1",
+			Book:      models.Book{ForeignID: "hc:different-seasons", Title: "Different Seasons", Author: &models.Author{Name: "Stephen King"}},
+		}},
+	}
+	importer.WithMetadata(metadata.NewAggregator(hardcoverSeriesProvider(item.Title, metadata.SeriesSearchResult{
+		ForeignID: "hc-series:600", Title: "Different Seasons", AuthorName: "Stephen King",
+	}, catalog)))
+	runID := runSingleABSImport(t, importer, item)
+	if series, err := seriesRepo.GetByForeignID(context.Background(), "hc-series:600"); err != nil || series == nil {
+		t.Fatalf("series before rollback = %+v err=%v, want present", series, err)
+	}
+	if _, err := importer.Rollback(context.Background(), runID); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	series, err := seriesRepo.GetByForeignID(context.Background(), "hc-series:600")
+	if err != nil {
+		t.Fatalf("GetByForeignID after rollback: %v", err)
+	}
+	if series != nil {
+		t.Fatalf("series after rollback = %+v, want deleted", series)
 	}
 }
 

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -2055,6 +2055,13 @@ func TestImporter_HardcoverSeriesMatchLinksItemWithoutABSSeries(t *testing.T) {
 	if series == nil {
 		t.Fatal("expected Hardcover series")
 	}
+	link, err := seriesRepo.GetHardcoverLink(context.Background(), series.ID)
+	if err != nil {
+		t.Fatalf("GetHardcoverLink: %v", err)
+	}
+	if link == nil || link.HardcoverSeriesID != "hc-series:100" || link.HardcoverBookCount != 1 {
+		t.Fatalf("hardcover link = %+v, want catalog link", link)
+	}
 	hydrated, err := seriesRepo.GetByID(context.Background(), series.ID)
 	if err != nil {
 		t.Fatalf("GetByID: %v", err)

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -2078,6 +2078,164 @@ func TestImporter_HardcoverSeriesMatchLinksItemWithoutABSSeries(t *testing.T) {
 	}
 }
 
+func TestImporter_HardcoverSeriesLinksExistingCatalogBookWithRollback(t *testing.T) {
+	t.Parallel()
+
+	importer, authorRepo, bookRepo, seriesRepo, _, provenanceRepo, _, _, _, _ := newABSImporterFixture(t)
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID:        "local:stephen-king",
+		Name:             "Stephen King",
+		SortName:         "King, Stephen",
+		Monitored:        true,
+		MetadataProvider: "manual",
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatalf("Create author: %v", err)
+	}
+	existingBook := &models.Book{
+		ForeignID:        "hc:skeleton-crew",
+		AuthorID:         author.ID,
+		Title:            "Skeleton Crew",
+		SortTitle:        "Skeleton Crew",
+		Status:           models.BookStatusWanted,
+		Monitored:        true,
+		AnyEditionOK:     true,
+		Language:         "eng",
+		MediaType:        models.MediaTypeEbook,
+		MetadataProvider: providerHardcover,
+	}
+	if err := bookRepo.Create(ctx, existingBook); err != nil {
+		t.Fatalf("Create existing book: %v", err)
+	}
+
+	item := hardcoverSeriesABSItem()
+	catalog := &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:existing-catalog-book",
+		ProviderID: "700",
+		Title:      "Different Seasons",
+		AuthorName: "Stephen King",
+		BookCount:  2,
+		Books: []metadata.SeriesCatalogBook{
+			{
+				ForeignID: "hc:different-seasons",
+				Title:     "Different Seasons",
+				Position:  "1",
+				Book: models.Book{
+					ForeignID:        "hc:different-seasons",
+					Title:            "Different Seasons",
+					MetadataProvider: providerHardcover,
+					Author:           &models.Author{Name: "Stephen King"},
+				},
+			},
+			{
+				ForeignID: "hc:skeleton-crew",
+				Title:     "Skeleton Crew",
+				Position:  "2",
+				Book: models.Book{
+					ForeignID:        "hc:skeleton-crew",
+					Title:            "Skeleton Crew",
+					MetadataProvider: providerHardcover,
+					Author:           &models.Author{Name: "Stephen King"},
+				},
+			},
+		},
+	}
+	importer.WithMetadata(metadata.NewAggregator(hardcoverSeriesProvider(item.Title, metadata.SeriesSearchResult{
+		ForeignID:  catalog.ForeignID,
+		ProviderID: catalog.ProviderID,
+		Title:      catalog.Title,
+		AuthorName: catalog.AuthorName,
+		BookCount:  catalog.BookCount,
+	}, catalog)))
+	importer.enumerateFn = func(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		if err := fn(ctx, item); err != nil {
+			return EnumerationStats{}, err
+		}
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+	stats, err := importer.Run(ctx, ImportConfig{
+		SourceID:  DefaultSourceID,
+		BaseURL:   "https://abs.example.com",
+		APIKey:    "secret",
+		LibraryID: item.LibraryID,
+		Label:     "Shelf",
+		Enabled:   true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.SeriesCreated != 1 || stats.SeriesLinked != 1 {
+		t.Fatalf("series stats = %+v, want created imported link and linked existing catalog book", stats)
+	}
+	runs, err := importer.RecentRuns(ctx, 1)
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("RecentRuns = %d err=%v, want 1 run", len(runs), err)
+	}
+	runID := runs[0].ID
+	series, err := seriesRepo.GetByForeignID(ctx, catalog.ForeignID)
+	if err != nil {
+		t.Fatalf("GetByForeignID: %v", err)
+	}
+	if series == nil {
+		t.Fatal("expected Hardcover series")
+	}
+	hydrated, err := seriesRepo.GetByID(ctx, series.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if len(hydrated.Books) != 2 {
+		t.Fatalf("series books = %+v, want imported book and existing catalog book", hydrated.Books)
+	}
+	foundExisting := false
+	for _, seriesBook := range hydrated.Books {
+		if seriesBook.BookID == existingBook.ID && seriesBook.PositionInSeries == "2" {
+			foundExisting = true
+		}
+	}
+	if !foundExisting {
+		t.Fatalf("series books = %+v, want existing catalog book linked at position 2", hydrated.Books)
+	}
+
+	linkExternalID := hardcoverSeriesLinkExternalID(catalog.ForeignID, existingBook.ID)
+	link, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, item.LibraryID, entityTypeSeries, linkExternalID)
+	if err != nil {
+		t.Fatalf("GetByExternal: %v", err)
+	}
+	if link == nil || link.LocalID != series.ID || link.ImportRunID == nil || *link.ImportRunID != runID {
+		t.Fatalf("series membership provenance = %+v, want run-owned link to series", link)
+	}
+
+	result, err := importer.Rollback(ctx, runID)
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if result.Stats.Failed != 0 {
+		t.Fatalf("rollback result = %+v, want no failures", result)
+	}
+	remainingBook, err := bookRepo.GetByID(ctx, existingBook.ID)
+	if err != nil {
+		t.Fatalf("GetByID existing book after rollback: %v", err)
+	}
+	if remainingBook == nil {
+		t.Fatal("existing catalog book was deleted by rollback")
+	}
+	series, err = seriesRepo.GetByForeignID(ctx, catalog.ForeignID)
+	if err != nil {
+		t.Fatalf("GetByForeignID after rollback: %v", err)
+	}
+	if series != nil {
+		t.Fatalf("series after rollback = %+v, want deleted after run-owned links removed", series)
+	}
+	link, err = provenanceRepo.GetByExternal(ctx, DefaultSourceID, item.LibraryID, entityTypeSeries, linkExternalID)
+	if err != nil {
+		t.Fatalf("GetByExternal after rollback: %v", err)
+	}
+	if link != nil {
+		t.Fatalf("series membership provenance after rollback = %+v, want nil", link)
+	}
+}
+
 func TestImporter_HardcoverSeriesMatchPromotesExactABSSeries(t *testing.T) {
 	t.Parallel()
 

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -112,6 +112,11 @@ func runSingleABSImport(t *testing.T, importer *Importer, item NormalizedLibrary
 	return runs[0].ID
 }
 
+func enableHardcoverSeriesMatching(t *testing.T, importer *Importer) {
+	t.Helper()
+	importer.WithEnhancedHardcoverSeriesEnabled(func(context.Context) bool { return true })
+}
+
 func TestImporter_ProgressResultsKeepsLatestHundredItems(t *testing.T) {
 	t.Parallel()
 
@@ -484,6 +489,7 @@ type stubABSMetadataProvider struct {
 	works                map[string][]models.Book
 	series               map[string][]metadata.SeriesSearchResult
 	catalogs             map[string]*metadata.SeriesCatalog
+	searchSeriesCalls    int
 }
 
 func (p *stubABSMetadataProvider) Name() string { return "stub" }
@@ -524,6 +530,7 @@ func (p *stubABSMetadataProvider) GetAuthorWorks(_ context.Context, foreignID st
 	return append([]models.Book(nil), p.works[foreignID]...), nil
 }
 func (p *stubABSMetadataProvider) SearchSeries(_ context.Context, query string, limit int) ([]metadata.SeriesSearchResult, error) {
+	p.searchSeriesCalls++
 	if p.series == nil {
 		return nil, nil
 	}
@@ -2200,10 +2207,54 @@ func hardcoverSeriesProvider(query string, result metadata.SeriesSearchResult, c
 	}
 }
 
+func TestImporter_HardcoverSeriesMatchSkippedWhenFeatureDisabled(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	item := hardcoverSeriesABSItem()
+	catalog := &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:disabled",
+		ProviderID: "disabled",
+		Title:      "Different Seasons",
+		AuthorName: "Stephen King",
+		Books: []metadata.SeriesCatalogBook{{
+			ForeignID: "hc:different-seasons",
+			Title:     "Different Seasons",
+			Position:  "1",
+			Book: models.Book{
+				ForeignID:        "hc:different-seasons",
+				Title:            "Different Seasons",
+				MetadataProvider: providerHardcover,
+				Author:           &models.Author{Name: "Stephen King"},
+			},
+		}},
+	}
+	provider := hardcoverSeriesProvider(item.Title, metadata.SeriesSearchResult{
+		ForeignID:  catalog.ForeignID,
+		ProviderID: catalog.ProviderID,
+		Title:      catalog.Title,
+		AuthorName: catalog.AuthorName,
+	}, catalog)
+	importer.WithMetadata(metadata.NewAggregator(provider))
+	runSingleABSImport(t, importer, item)
+
+	if provider.searchSeriesCalls != 0 {
+		t.Fatalf("SearchSeries calls = %d, want 0 when enhanced Hardcover series is disabled", provider.searchSeriesCalls)
+	}
+	series, err := seriesRepo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List series: %v", err)
+	}
+	if len(series) != 0 {
+		t.Fatalf("series = %+v, want no Hardcover series while feature is disabled", series)
+	}
+}
+
 func TestImporter_HardcoverSeriesMatchLinksItemWithoutABSSeries(t *testing.T) {
 	t.Parallel()
 
 	importer, _, bookRepo, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	enableHardcoverSeriesMatching(t, importer)
 	item := hardcoverSeriesABSItem()
 	catalog := &metadata.SeriesCatalog{
 		ForeignID:  "hc-series:100",
@@ -2266,6 +2317,7 @@ func TestImporter_HardcoverSeriesLinksExistingCatalogBookWithRollback(t *testing
 	t.Parallel()
 
 	importer, authorRepo, bookRepo, seriesRepo, _, provenanceRepo, _, _, _, _ := newABSImporterFixture(t)
+	enableHardcoverSeriesMatching(t, importer)
 	ctx := context.Background()
 	author := &models.Author{
 		ForeignID:        "local:stephen-king",
@@ -2424,6 +2476,7 @@ func TestImporter_HardcoverSeriesMatchPromotesExactABSSeries(t *testing.T) {
 	t.Parallel()
 
 	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	enableHardcoverSeriesMatching(t, importer)
 	item := sampleABSItem()
 	item.ItemID = "li-all-systems-red"
 	item.Title = "All Systems Red"
@@ -2497,6 +2550,7 @@ func TestImporter_HardcoverSeriesAmbiguousCandidatesDoNotLink(t *testing.T) {
 	t.Parallel()
 
 	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	enableHardcoverSeriesMatching(t, importer)
 	item := hardcoverSeriesABSItem()
 	resultA := metadata.SeriesSearchResult{ForeignID: "hc-series:301", ProviderID: "301", Title: "Different Seasons", AuthorName: "Stephen King"}
 	resultB := metadata.SeriesSearchResult{ForeignID: "hc-series:302", ProviderID: "302", Title: "Different Seasons", AuthorName: "Stephen King"}
@@ -2555,6 +2609,7 @@ func TestImporter_HardcoverSeriesRerunIsIdempotent(t *testing.T) {
 	t.Parallel()
 
 	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	enableHardcoverSeriesMatching(t, importer)
 	item := hardcoverSeriesABSItem()
 	catalog := &metadata.SeriesCatalog{
 		ForeignID:  "hc-series:400",
@@ -2600,6 +2655,7 @@ func TestImporter_HardcoverSeriesDryRunPlansOnly(t *testing.T) {
 	t.Parallel()
 
 	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	enableHardcoverSeriesMatching(t, importer)
 	item := hardcoverSeriesABSItem()
 	catalog := &metadata.SeriesCatalog{
 		ForeignID:  "hc-series:500",
@@ -2649,6 +2705,7 @@ func TestImporter_HardcoverSeriesRollbackRemovesLinks(t *testing.T) {
 	t.Parallel()
 
 	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	enableHardcoverSeriesMatching(t, importer)
 	item := hardcoverSeriesABSItem()
 	catalog := &metadata.SeriesCatalog{
 		ForeignID:  "hc-series:600",

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -2381,7 +2381,7 @@ func TestImporter_HardcoverSeriesLinksExistingCatalogBookWithRollback(t *testing
 		t.Fatalf("series books = %+v, want existing catalog book linked at position 2", hydrated.Books)
 	}
 
-	linkExternalID := hardcoverSeriesLinkExternalID(catalog.ForeignID, existingBook.ID)
+	linkExternalID := seriesMembershipExternalID(catalog.ForeignID, existingBook.ID, "")
 	link, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, item.LibraryID, entityTypeSeries, linkExternalID)
 	if err != nil {
 		t.Fatalf("GetByExternal: %v", err)

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -1996,6 +1996,190 @@ func TestImporter_DryRunCountsPlannedSeriesOnce(t *testing.T) {
 	}
 }
 
+func TestImporter_RepeatedABSSeriesRollbackUnlinksAllRunMemberships(t *testing.T) {
+	t.Parallel()
+
+	importer, authorRepo, bookRepo, seriesRepo, _, provenanceRepo, _, _, _, _ := newABSImporterFixture(t)
+	ctx := context.Background()
+	author := &models.Author{Name: "Repeat Author", SortName: "Author, Repeat", Monitored: true}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatalf("Create author: %v", err)
+	}
+	firstBook := &models.Book{
+		ForeignID:        "local:repeat:1",
+		AuthorID:         author.ID,
+		Title:            "Repeat One",
+		SortTitle:        "Repeat One",
+		Status:           models.BookStatusWanted,
+		AnyEditionOK:     true,
+		Language:         "eng",
+		MediaType:        models.MediaTypeAudiobook,
+		MetadataProvider: "local",
+	}
+	secondBook := &models.Book{
+		ForeignID:        "local:repeat:2",
+		AuthorID:         author.ID,
+		Title:            "Repeat Two",
+		SortTitle:        "Repeat Two",
+		Status:           models.BookStatusWanted,
+		AnyEditionOK:     true,
+		Language:         "eng",
+		MediaType:        models.MediaTypeAudiobook,
+		MetadataProvider: "local",
+	}
+	if err := bookRepo.Create(ctx, firstBook); err != nil {
+		t.Fatalf("Create first book: %v", err)
+	}
+	if err := bookRepo.Create(ctx, secondBook); err != nil {
+		t.Fatalf("Create second book: %v", err)
+	}
+
+	first := sampleABSItem()
+	first.ItemID = "li-repeat-series-1"
+	first.Title = firstBook.Title
+	first.Authors = []NormalizedAuthor{{ID: "author-repeat", Name: author.Name}}
+	first.Series = []NormalizedSeries{{ID: "series-repeat", Name: "Repeat Saga", Sequence: "1"}}
+	first.AudioFiles = []NormalizedAudioFile{{INO: "audio-repeat-series-1", Path: "/abs/repeat/one.m4b"}}
+	first.EbookPath = ""
+	first.EbookINO = ""
+	second := first
+	second.ItemID = "li-repeat-series-2"
+	second.Title = secondBook.Title
+	second.Series = []NormalizedSeries{{ID: "series-repeat", Name: "Repeat Saga", Sequence: "2"}}
+	second.AudioFiles = []NormalizedAudioFile{{INO: "audio-repeat-series-2", Path: "/abs/repeat/two.m4b"}}
+	items := []NormalizedLibraryItem{first, second}
+	importer.enumerateFn = func(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		for _, item := range items {
+			if err := fn(ctx, item); err != nil {
+				return EnumerationStats{}, err
+			}
+		}
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: len(items), ItemsNormalized: len(items)}, nil
+	}
+
+	stats, err := importer.Run(ctx, ImportConfig{
+		SourceID:  DefaultSourceID,
+		BaseURL:   "https://abs.example.com",
+		APIKey:    "secret",
+		LibraryID: first.LibraryID,
+		Label:     "Shelf",
+		Enabled:   true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.SeriesCreated != 1 || stats.SeriesLinked != 1 {
+		t.Fatalf("series stats = %+v, want one created series and one linked membership", stats)
+	}
+	runs, err := importer.RecentRuns(ctx, 1)
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("RecentRuns = %d err=%v, want 1 run", len(runs), err)
+	}
+	series, err := seriesRepo.GetByForeignID(ctx, absForeignID("series", first.LibraryID, "series-repeat"))
+	if err != nil {
+		t.Fatalf("GetByForeignID: %v", err)
+	}
+	if series == nil {
+		t.Fatal("expected imported series")
+	}
+	hydrated, err := seriesRepo.GetByID(ctx, series.ID)
+	if err != nil {
+		t.Fatalf("GetByID before rollback: %v", err)
+	}
+	if len(hydrated.Books) != 2 {
+		t.Fatalf("series books before rollback = %+v, want two run-owned memberships", hydrated.Books)
+	}
+
+	result, err := importer.Rollback(ctx, runs[0].ID)
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if result.Stats.Failed != 0 {
+		t.Fatalf("rollback result = %+v, want no failures", result)
+	}
+	books, err := bookRepo.ListIncludingExcluded(ctx)
+	if err != nil {
+		t.Fatalf("List books after rollback: %v", err)
+	}
+	if len(books) != 2 {
+		t.Fatalf("books after rollback = %d, want existing books preserved", len(books))
+	}
+	allSeries, err := seriesRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("List series after rollback: %v", err)
+	}
+	if len(allSeries) != 0 {
+		t.Fatalf("series after rollback = %+v, want empty imported series deleted", allSeries)
+	}
+	itemBookIDs := map[string]int64{
+		first.ItemID:  firstBook.ID,
+		second.ItemID: secondBook.ID,
+	}
+	for _, item := range items {
+		link, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, item.LibraryID, entityTypeSeries, seriesMembershipExternalID("series-repeat", itemBookIDs[item.ItemID], item.ItemID))
+		if err != nil {
+			t.Fatalf("GetByExternal membership: %v", err)
+		}
+		if link != nil {
+			t.Fatalf("series membership provenance for %s = %+v, want nil", item.ItemID, link)
+		}
+	}
+}
+
+func TestImporter_ABSSeriesRerunRollbackPreservesOriginalMembership(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, seriesRepo, _, _, _, _, _, _ := newABSImporterFixture(t)
+	ctx := context.Background()
+	item := sampleABSItem()
+	firstRunID := runSingleABSImport(t, importer, item)
+	if firstRunID == 0 {
+		t.Fatal("first run id is required")
+	}
+
+	importer.enumerateFn = func(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		if err := fn(ctx, item); err != nil {
+			return EnumerationStats{}, err
+		}
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+	stats, err := importer.Run(ctx, ImportConfig{
+		SourceID:  DefaultSourceID,
+		BaseURL:   "https://abs.example.com",
+		APIKey:    "secret",
+		LibraryID: item.LibraryID,
+		Label:     "Shelf",
+		Enabled:   true,
+	})
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if stats.SeriesCreated != 0 || stats.SeriesLinked != 0 {
+		t.Fatalf("second run series stats = %+v, want no new series ownership", stats)
+	}
+	runs, err := importer.RecentRuns(ctx, 1)
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("RecentRuns = %d err=%v, want second run", len(runs), err)
+	}
+	if _, err := importer.Rollback(ctx, runs[0].ID); err != nil {
+		t.Fatalf("Rollback second run: %v", err)
+	}
+	series, err := seriesRepo.GetByForeignID(ctx, absForeignID("series", item.LibraryID, item.Series[0].ID))
+	if err != nil {
+		t.Fatalf("GetByForeignID after rollback: %v", err)
+	}
+	if series == nil {
+		t.Fatal("series after second rollback = nil, want original series preserved")
+	}
+	hydrated, err := seriesRepo.GetByID(ctx, series.ID)
+	if err != nil {
+		t.Fatalf("GetByID after rollback: %v", err)
+	}
+	if len(hydrated.Books) != 1 {
+		t.Fatalf("series books after rollback = %+v, want original membership preserved", hydrated.Books)
+	}
+}
+
 func hardcoverSeriesABSItem() NormalizedLibraryItem {
 	item := sampleABSItem()
 	item.ItemID = "li-different-seasons"
@@ -2110,7 +2294,30 @@ func TestImporter_HardcoverSeriesMatchPromotesExactABSSeries(t *testing.T) {
 		Title:      "The Murderbot Diaries",
 		AuthorName: "Martha Wells",
 	}, catalog)))
-	runSingleABSImport(t, importer, item)
+	importer.enumerateFn = func(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		if err := fn(ctx, item); err != nil {
+			return EnumerationStats{}, err
+		}
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+	stats, err := importer.Run(context.Background(), ImportConfig{
+		SourceID:  DefaultSourceID,
+		BaseURL:   "https://abs.example.com",
+		APIKey:    "secret",
+		LibraryID: item.LibraryID,
+		Label:     "Shelf",
+		Enabled:   true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.SeriesCreated != 1 || stats.SeriesLinked != 0 {
+		t.Fatalf("series stats = %+v, want one created row and no duplicate Hardcover link count", stats)
+	}
+	progress := importer.Progress()
+	if len(progress.Results) != 1 || progress.Results[0].SeriesCount != 1 {
+		t.Fatalf("progress results = %+v, want one final series membership", progress.Results)
+	}
 
 	series, err := seriesRepo.GetByForeignID(context.Background(), "hc-series:200")
 	if err != nil {
@@ -2394,6 +2601,71 @@ func TestImporter_RollbackRemovesCreatedBatch(t *testing.T) {
 	}
 	if link != nil {
 		t.Fatalf("book provenance = %+v, want nil after rollback", link)
+	}
+}
+
+func TestImporter_RollbackKeepsRunCreatedSeriesWithUserMembership(t *testing.T) {
+	t.Parallel()
+
+	importer, authorRepo, bookRepo, seriesRepo, _, provenanceRepo, _, _, _, _ := newABSImporterFixture(t)
+	ctx := context.Background()
+	item := sampleABSItem()
+	runID := runSingleABSImport(t, importer, item)
+	series, err := seriesRepo.GetByForeignID(ctx, absForeignID("series", item.LibraryID, item.Series[0].ID))
+	if err != nil {
+		t.Fatalf("GetByForeignID before rollback: %v", err)
+	}
+	if series == nil {
+		t.Fatal("expected imported series before rollback")
+	}
+	authors, err := authorRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("List authors: %v", err)
+	}
+	if len(authors) != 1 {
+		t.Fatalf("authors = %d, want imported author", len(authors))
+	}
+	userBook := &models.Book{
+		ForeignID:        "manual:user-series-book",
+		AuthorID:         authors[0].ID,
+		Title:            "User Added Sequel",
+		SortTitle:        "User Added Sequel",
+		Status:           models.BookStatusWanted,
+		AnyEditionOK:     true,
+		Language:         "eng",
+		MediaType:        models.MediaTypeAudiobook,
+		MetadataProvider: "manual",
+	}
+	if err := bookRepo.Create(ctx, userBook); err != nil {
+		t.Fatalf("Create user book: %v", err)
+	}
+	if err := seriesRepo.LinkBook(ctx, series.ID, userBook.ID, "99", false); err != nil {
+		t.Fatalf("Link user book: %v", err)
+	}
+
+	result, err := importer.Rollback(ctx, runID)
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if result.Stats.Failed != 0 {
+		t.Fatalf("rollback result = %+v, want no failures", result)
+	}
+	surviving, err := seriesRepo.GetByID(ctx, series.ID)
+	if err != nil {
+		t.Fatalf("GetByID after rollback: %v", err)
+	}
+	if surviving == nil {
+		t.Fatal("series after rollback = nil, want kept because user membership remains")
+	}
+	if len(surviving.Books) != 1 || surviving.Books[0].BookID != userBook.ID {
+		t.Fatalf("series books after rollback = %+v, want only user-added membership", surviving.Books)
+	}
+	identity, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, item.LibraryID, entityTypeSeries, item.Series[0].ID)
+	if err != nil {
+		t.Fatalf("GetByExternal identity after rollback: %v", err)
+	}
+	if identity != nil {
+		t.Fatalf("series identity provenance = %+v, want nil after rollback keeps row", identity)
 	}
 }
 

--- a/internal/api/abs_import.go
+++ b/internal/api/abs_import.go
@@ -28,12 +28,7 @@ type ABSImportHandler struct {
 }
 
 type absImportStartRequest struct {
-	BaseURL   *string `json:"baseUrl"`
-	APIKey    *string `json:"apiKey"`
-	Label     *string `json:"label"`
-	LibraryID *string `json:"libraryId"`
-	Enabled   *bool   `json:"enabled"`
-	DryRun    *bool   `json:"dryRun"`
+	DryRun *bool `json:"dryRun"`
 }
 
 func NewABSImportHandler(importer absImporterAPI, loadCfg func(context.Context) ABSStoredConfig) *ABSImportHandler {
@@ -48,21 +43,6 @@ func (h *ABSImportHandler) Start(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 			return
-		}
-		if req.BaseURL != nil {
-			cfg.BaseURL = strings.TrimSpace(*req.BaseURL)
-		}
-		if req.APIKey != nil {
-			cfg.APIKey = strings.TrimSpace(*req.APIKey)
-		}
-		if req.Label != nil {
-			cfg.Label = strings.TrimSpace(*req.Label)
-		}
-		if req.LibraryID != nil {
-			cfg.LibraryID = strings.TrimSpace(*req.LibraryID)
-		}
-		if req.Enabled != nil {
-			cfg.Enabled = *req.Enabled
 		}
 	}
 	runCfg := abs.ImportConfig{

--- a/internal/api/abs_import_test.go
+++ b/internal/api/abs_import_test.go
@@ -74,7 +74,7 @@ func TestABSImportHandler_Start(t *testing.T) {
 	}
 }
 
-func TestABSImportHandler_StartUsesRequestOverridesAndStoredKeyFallback(t *testing.T) {
+func TestABSImportHandler_StartUsesStoredConfigAndIgnoresDraftOverrides(t *testing.T) {
 	t.Parallel()
 
 	stub := &stubABSImporter{progress: abs.ImportProgress{Running: true}}
@@ -83,28 +83,35 @@ func TestABSImportHandler_StartUsesRequestOverridesAndStoredKeyFallback(t *testi
 			BaseURL:   "https://stored.example.com",
 			APIKey:    "stored-secret",
 			Label:     "Stored Shelf",
-			LibraryID: "",
+			LibraryID: "lib-stored",
+			PathRemap: "/abs:/books",
 			Enabled:   true,
 		}
 	})
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/abs/import", bytes.NewBufferString(`{"baseUrl":"https://draft.example.com","libraryId":"lib-draft","label":"Draft Shelf","enabled":true}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/abs/import", bytes.NewBufferString(`{"baseUrl":"https://draft.example.com","apiKey":"draft-secret","libraryId":"lib-draft","label":"Draft Shelf","pathRemap":"/draft:/books","enabled":false}`))
 	h.Start(rec, req)
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusAccepted)
 	}
-	if stub.lastCfg.BaseURL != "https://draft.example.com" {
-		t.Fatalf("baseURL = %q, want draft override", stub.lastCfg.BaseURL)
+	if stub.lastCfg.BaseURL != "https://stored.example.com" {
+		t.Fatalf("baseURL = %q, want stored config", stub.lastCfg.BaseURL)
 	}
-	if stub.lastCfg.LibraryID != "lib-draft" {
-		t.Fatalf("libraryID = %q, want draft override", stub.lastCfg.LibraryID)
+	if stub.lastCfg.LibraryID != "lib-stored" {
+		t.Fatalf("libraryID = %q, want stored config", stub.lastCfg.LibraryID)
 	}
-	if stub.lastCfg.Label != "Draft Shelf" {
-		t.Fatalf("label = %q, want draft override", stub.lastCfg.Label)
+	if stub.lastCfg.Label != "Stored Shelf" {
+		t.Fatalf("label = %q, want stored config", stub.lastCfg.Label)
 	}
 	if stub.lastCfg.APIKey != "stored-secret" {
-		t.Fatalf("apiKey = %q, want stored fallback", stub.lastCfg.APIKey)
+		t.Fatalf("apiKey = %q, want stored config", stub.lastCfg.APIKey)
+	}
+	if stub.lastCfg.PathRemap != "/abs:/books" {
+		t.Fatalf("pathRemap = %q, want stored config", stub.lastCfg.PathRemap)
+	}
+	if !stub.lastCfg.Enabled {
+		t.Fatal("enabled = false, want stored config")
 	}
 }
 

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -26,6 +27,8 @@ var (
 	errNoMetadataMatch        = errors.New("no exact-name match in metadata provider")
 	errAmbiguousMetadataMatch = errors.New("multiple exact-name matches in metadata provider")
 )
+
+const authorAutoSearchConcurrency = 4
 
 type AuthorHandler struct {
 	authors  *db.AuthorRepo
@@ -754,8 +757,9 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 		}
 	}
 
-	// Use the dedicated author works endpoint for accurate results
-	books, err := h.meta.GetAuthorWorks(ctx, author.ForeignID)
+	// Use the dedicated author works endpoint for accurate results, with
+	// author-scoped supplemental providers when available.
+	books, err := h.meta.GetAuthorWorksForAuthor(ctx, *author)
 	if err != nil {
 		slog.Error("failed to fetch books", "author", author.Name, "error", err)
 		return
@@ -795,6 +799,9 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 	}
 
 	normalizedAuthor := strings.ToLower(strings.TrimSpace(author.Name))
+
+	searchQueue := make([]models.Book, 0)
+	autoSearchEnabled := autoSearch && h.searcher != nil && author.Monitored && h.isAutoGrabEnabled(ctx)
 
 	var added, skippedLang, skippedJunk int
 	for _, b := range books {
@@ -886,11 +893,40 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 
 		// Auto-search the freshly-added wanted book only when the per-add
 		// flag AND the global auto-grab kill-switch both say yes.
-		if autoSearch && h.searcher != nil && author.Monitored && h.isAutoGrabEnabled(ctx) {
-			h.searcher.SearchAndGrabBook(ctx, b)
+		if autoSearchEnabled {
+			searchQueue = append(searchQueue, b)
 		}
 	}
+	runBookSearches(ctx, h.searcher, searchQueue, authorAutoSearchConcurrency)
 	slog.Info("author books synced", "author", author.Name, "added", added, "skipped_language", skippedLang, "skipped_junk", skippedJunk, "total", len(books))
+}
+
+func runBookSearches(ctx context.Context, searcher BookSearcher, books []models.Book, concurrency int) {
+	if searcher == nil || len(books) == 0 {
+		return
+	}
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	for _, book := range books {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		}
+		book := book
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			searcher.SearchAndGrabBook(ctx, book)
+		}()
+	}
+	wg.Wait()
 }
 
 func (h *AuthorHandler) lookupUpstreamAuthorByName(ctx context.Context, name string) (*models.Author, error) {

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -162,7 +162,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 			if mediaType == "" {
 				mediaType = h.resolveDefaultMediaType(r.Context())
 			}
-			go h.FetchAuthorBooks(canonical, req.SearchOnAdd, mediaType)
+			h.fetchAuthorBooksAsync(canonical, req.SearchOnAdd, mediaType)
 			cleanAuthorDescription(canonical)
 			writeJSON(w, http.StatusOK, canonical)
 			return
@@ -198,7 +198,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	// Fetch and store books for this author. Always populate the catalogue;
 	// pass searchOnAdd so FetchAuthorBooks knows whether to also queue grabs.
-	go h.FetchAuthorBooks(author, req.SearchOnAdd, mediaType)
+	h.fetchAuthorBooksAsync(author, req.SearchOnAdd, mediaType)
 
 	cleanAuthorDescription(author)
 	writeJSON(w, http.StatusCreated, author)
@@ -208,6 +208,14 @@ func cleanAuthorDescription(author *models.Author) {
 	if author != nil {
 		author.Description = textutil.CleanDescription(author.Description)
 	}
+}
+
+func (h *AuthorHandler) fetchAuthorBooksAsync(author *models.Author, autoSearch bool, mediaType string) {
+	if author == nil {
+		return
+	}
+	snapshot := *author
+	go h.FetchAuthorBooks(&snapshot, autoSearch, mediaType)
 }
 
 func (h *AuthorHandler) fetchAuthorForCreate(ctx context.Context, foreignID, fallbackName string) (*models.Author, error) {
@@ -631,7 +639,7 @@ func (h *AuthorHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	// the user triggered it to refresh metadata, not to queue downloads.
 	// Newly-discovered books inherit the global default media type; rows
 	// that already exist keep whatever value they were created with.
-	go h.FetchAuthorBooks(author, false, h.resolveDefaultMediaType(r.Context()))
+	h.fetchAuthorBooksAsync(author, false, h.resolveDefaultMediaType(r.Context()))
 	writeJSON(w, http.StatusAccepted, map[string]string{"message": "refresh started"})
 }
 
@@ -1115,7 +1123,7 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 			author, _ = h.authors.GetByForeignID(ctx, req.ForeignAuthorID)
 		} else {
 			author = fetched
-			go h.FetchAuthorBooks(author, false, h.resolveDefaultMediaType(ctx))
+			h.fetchAuthorBooksAsync(author, false, h.resolveDefaultMediaType(ctx))
 		}
 	}
 	if author == nil {

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -37,6 +38,35 @@ func (s *searcherSpy) titles() []string {
 	out := make([]string, len(s.calls))
 	copy(out, s.calls)
 	return out
+}
+
+type concurrentSearcherSpy struct {
+	mu     sync.Mutex
+	calls  int
+	active int
+	max    int
+}
+
+func (s *concurrentSearcherSpy) SearchAndGrabBook(_ context.Context, _ models.Book) {
+	s.mu.Lock()
+	s.calls++
+	s.active++
+	if s.active > s.max {
+		s.max = s.active
+	}
+	s.mu.Unlock()
+
+	time.Sleep(20 * time.Millisecond)
+
+	s.mu.Lock()
+	s.active--
+	s.mu.Unlock()
+}
+
+func (s *concurrentSearcherSpy) stats() (int, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls, s.max
 }
 
 // stubMetaProvider is a fake metadata.Provider whose GetAuthorWorks returns
@@ -255,6 +285,57 @@ func TestFetchAuthorBooks_FiresSearchForMonitoredAuthor(t *testing.T) {
 	titles := spy.titles()
 	if len(titles) != 2 {
 		t.Fatalf("expected 2 searcher calls, got %d: %v", len(titles), titles)
+	}
+}
+
+func TestFetchAuthorBooks_AutoSearchUsesBoundedConcurrency(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL800A", Name: "Parallel Author", SortName: "Author, Parallel",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	works := make([]models.Book, 8)
+	for i := range works {
+		works[i] = models.Book{
+			ForeignID:        "OL80" + strconv.Itoa(i) + "W",
+			Title:            "Book " + strconv.Itoa(i),
+			SortTitle:        "book " + strconv.Itoa(i),
+			Language:         "eng",
+			Status:           models.BookStatusWanted,
+			Genres:           []string{},
+			MetadataProvider: "openlibrary",
+		}
+	}
+	stub := &stubMetaProvider{works: works}
+	agg := metadata.NewAggregator(stub)
+	spy := &concurrentSearcherSpy{}
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, spy)
+	h.FetchAuthorBooks(author, true, "")
+
+	calls, maxActive := spy.stats()
+	if calls != len(works) {
+		t.Fatalf("expected %d search calls, got %d", len(works), calls)
+	}
+	if maxActive > authorAutoSearchConcurrency {
+		t.Fatalf("max concurrent searches = %d, want <= %d", maxActive, authorAutoSearchConcurrency)
+	}
+	if maxActive < 2 {
+		t.Fatalf("expected searches to run concurrently, max active = %d", maxActive)
 	}
 }
 

--- a/internal/api/hardcover_feature.go
+++ b/internal/api/hardcover_feature.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"context"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/db"
+)
+
+const (
+	SettingHardcoverAPIToken              = "hardcover.api_token" //nolint:gosec // settings key name, not a credential value
+	SettingHardcoverEnhancedSeriesEnabled = "hardcover.enhanced_series_enabled"
+
+	HardcoverDisabledReasonEnvDisabled   = "env_disabled"
+	HardcoverDisabledReasonMissingToken  = "missing_token"
+	HardcoverDisabledReasonAdminDisabled = "admin_disabled"
+)
+
+type HardcoverFeatureState struct {
+	EnhancedHardcoverAPI            bool   `json:"enhancedHardcoverApi"`
+	HardcoverTokenConfigured        bool   `json:"hardcoverTokenConfigured"`
+	EnhancedHardcoverDisabledReason string `json:"enhancedHardcoverDisabledReason,omitempty"`
+}
+
+func GetHardcoverAPIToken(ctx context.Context, settings *db.SettingsRepo) string {
+	if settings == nil {
+		return ""
+	}
+	setting, _ := settings.Get(ctx, SettingHardcoverAPIToken)
+	if setting == nil {
+		return ""
+	}
+	return strings.TrimSpace(setting.Value)
+}
+
+func HardcoverFeatureStateFor(ctx context.Context, settings *db.SettingsRepo, envEnabled bool) HardcoverFeatureState {
+	tokenConfigured := GetHardcoverAPIToken(ctx, settings) != ""
+	adminEnabled := false
+	if settings != nil {
+		if setting, _ := settings.Get(ctx, SettingHardcoverEnhancedSeriesEnabled); setting != nil {
+			adminEnabled = strings.EqualFold(strings.TrimSpace(setting.Value), "true")
+		}
+	}
+
+	state := HardcoverFeatureState{HardcoverTokenConfigured: tokenConfigured}
+	switch {
+	case !envEnabled:
+		state.EnhancedHardcoverDisabledReason = HardcoverDisabledReasonEnvDisabled
+	case !tokenConfigured:
+		state.EnhancedHardcoverDisabledReason = HardcoverDisabledReasonMissingToken
+	case !adminEnabled:
+		state.EnhancedHardcoverDisabledReason = HardcoverDisabledReasonAdminDisabled
+	default:
+		state.EnhancedHardcoverAPI = true
+	}
+	return state
+}

--- a/internal/api/hardcover_feature.go
+++ b/internal/api/hardcover_feature.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata/hardcover"
 )
 
 const (
@@ -30,7 +31,7 @@ func GetHardcoverAPIToken(ctx context.Context, settings *db.SettingsRepo) string
 	if setting == nil {
 		return ""
 	}
-	return strings.TrimSpace(setting.Value)
+	return hardcover.NormalizeAPIToken(setting.Value)
 }
 
 func HardcoverFeatureStateFor(ctx context.Context, settings *db.SettingsRepo, envEnabled bool) HardcoverFeatureState {

--- a/internal/api/import_lists.go
+++ b/internal/api/import_lists.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -110,10 +109,11 @@ func (h *ImportListHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 // HardcoverLists returns the authenticated user's Hardcover reading lists.
 // GET /api/v1/importlist/hardcover/lists  (Authorization: Bearer <tok>)
+// The Hardcover client normalizes the token before forwarding it upstream.
 func (h *ImportListHandler) HardcoverLists(w http.ResponseWriter, r *http.Request) {
 	authHeader := r.Header.Get("Authorization")
-	token := strings.TrimPrefix(authHeader, "Bearer ")
-	if token == "" || token == authHeader {
+	token := hardcover.NormalizeAPIToken(authHeader)
+	if token == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing authorization header"})
 		return
 	}

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -97,6 +97,138 @@ func (h *SeriesHandler) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, s)
 }
 
+func (h *SeriesHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	title := strings.TrimSpace(body.Title)
+	if title == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "title is required"})
+		return
+	}
+	series, err := h.series.CreateManual(r.Context(), title)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusCreated, series)
+}
+
+func (h *SeriesHandler) Update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	title := strings.TrimSpace(body.Title)
+	if title == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "title is required"})
+		return
+	}
+	existing, err := h.series.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if existing == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "series not found"})
+		return
+	}
+	if err := h.series.UpdateTitle(r.Context(), id, title); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	updated, err := h.series.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (h *SeriesHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	existing, err := h.series.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if existing == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "series not found"})
+		return
+	}
+	if err := h.series.Delete(r.Context(), id); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *SeriesHandler) AddBook(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		BookID           int64  `json:"bookId"`
+		PositionInSeries string `json:"positionInSeries"`
+		PrimarySeries    *bool  `json:"primarySeries"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if body.BookID <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "bookId is required"})
+		return
+	}
+	series, err := h.series.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if series == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "series not found"})
+		return
+	}
+	book, err := h.books.GetByID(r.Context(), body.BookID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if book == nil || book.Excluded {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
+	primary := true
+	if body.PrimarySeries != nil {
+		primary = *body.PrimarySeries
+	}
+	if err := h.series.UpsertBookLink(r.Context(), id, body.BookID, body.PositionInSeries, primary); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	updated, err := h.series.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, updated)
+}
+
 // Monitor toggles the monitored flag on a series.
 func (h *SeriesHandler) Monitor(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -1036,7 +1036,7 @@ func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesI
 		if !ok {
 			continue
 		}
-		if _, err := h.ensureHardcoverCatalogBook(ctx, series.ID, catalog.AuthorName, catalogBook); err != nil {
+		if _, err := h.ensureHardcoverCatalogBook(ctx, series, catalog.AuthorName, catalogBook); err != nil {
 			return err
 		}
 	}
@@ -1076,7 +1076,7 @@ func (h *SeriesHandler) createMissingHardcoverBook(ctx context.Context, seriesID
 		if !ok {
 			return nil, errSeriesCatalogBookNotFound
 		}
-		return h.ensureHardcoverCatalogBook(ctx, series.ID, catalog.AuthorName, catalogBook)
+		return h.ensureHardcoverCatalogBook(ctx, series, catalog.AuthorName, catalogBook)
 	}
 	return nil, errSeriesCatalogBookNotFound
 }
@@ -1093,7 +1093,10 @@ func findCatalogBook(books []metadata.SeriesCatalogBook, foreignID, position str
 	return metadata.SeriesCatalogBook{}, false
 }
 
-func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, seriesID int64, fallbackAuthor string, catalogBook metadata.SeriesCatalogBook) (*models.Book, error) {
+func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *models.Series, fallbackAuthor string, catalogBook metadata.SeriesCatalogBook) (*models.Book, error) {
+	if series == nil {
+		return nil, errSeriesNotFound
+	}
 	book := catalogBook.Book
 	book.ForeignID = firstNonEmpty(book.ForeignID, catalogBook.ForeignID)
 	if book.ForeignID == "" {
@@ -1105,7 +1108,7 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, seriesID
 		if existing.Excluded {
 			return nil, nil
 		}
-		_, err := h.series.LinkBookIfMissing(ctx, seriesID, existing.ID, catalogBook.Position, true)
+		_, err := h.series.LinkBookIfMissing(ctx, series.ID, existing.ID, catalogBook.Position, true)
 		return existing, err
 	}
 
@@ -1133,9 +1136,12 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, seriesID
 	metadataProfileID := models.DefaultMetadataProfileID
 	author.MetadataProfileID = &metadataProfileID
 
-	storedAuthor, err := h.authors.GetByForeignID(ctx, author.ForeignID)
+	storedAuthor, skip, err := h.resolveHardcoverCatalogAuthor(ctx, series, author)
 	if err != nil {
 		return nil, err
+	}
+	if skip {
+		return nil, nil
 	}
 	if storedAuthor == nil {
 		if err := h.authors.Create(ctx, author); err != nil {
@@ -1155,7 +1161,7 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, seriesID
 				blockedByExcludedTitle = true
 				continue
 			}
-			_, err := h.series.LinkBookIfMissing(ctx, seriesID, existing.ID, catalogBook.Position, true)
+			_, err := h.series.LinkBookIfMissing(ctx, series.ID, existing.ID, catalogBook.Position, true)
 			return &existing, err
 		}
 	}
@@ -1179,10 +1185,94 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, seriesID
 	if err := h.books.Create(ctx, &book); err != nil {
 		return nil, err
 	}
-	if _, err := h.series.LinkBookIfMissing(ctx, seriesID, book.ID, catalogBook.Position, true); err != nil {
+	if _, err := h.series.LinkBookIfMissing(ctx, series.ID, book.ID, catalogBook.Position, true); err != nil {
 		return nil, err
 	}
 	return &book, nil
+}
+
+func (h *SeriesHandler) resolveHardcoverCatalogAuthor(ctx context.Context, series *models.Series, candidate *models.Author) (*models.Author, bool, error) {
+	if candidate == nil || h.authors == nil {
+		return nil, false, nil
+	}
+	if strings.TrimSpace(candidate.ForeignID) != "" {
+		author, err := h.authors.GetByForeignID(ctx, candidate.ForeignID)
+		if err != nil || author != nil {
+			return author, false, err
+		}
+	}
+	if strings.TrimSpace(candidate.Name) == "" {
+		return nil, false, nil
+	}
+	if author, ambiguous, err := h.matchSeriesAuthorByName(ctx, series, candidate.Name); err != nil || ambiguous || author != nil {
+		return author, ambiguous, err
+	}
+	return h.matchGlobalAuthorByName(ctx, candidate.Name)
+}
+
+func (h *SeriesHandler) matchSeriesAuthorByName(ctx context.Context, series *models.Series, name string) (*models.Author, bool, error) {
+	if series == nil || h.authors == nil {
+		return nil, false, nil
+	}
+	seen := map[int64]struct{}{}
+	var match *models.Author
+	for _, seriesBook := range series.Books {
+		var author *models.Author
+		if seriesBook.Book != nil && seriesBook.Book.AuthorID > 0 {
+			if _, ok := seen[seriesBook.Book.AuthorID]; ok {
+				continue
+			}
+			seen[seriesBook.Book.AuthorID] = struct{}{}
+			var err error
+			author, err = h.authors.GetByID(ctx, seriesBook.Book.AuthorID)
+			if err != nil {
+				return nil, false, err
+			}
+		} else if seriesBook.Book != nil && seriesBook.Book.Author != nil {
+			author = seriesBook.Book.Author
+		}
+		if author == nil || author.ID == 0 {
+			continue
+		}
+		if !trustedAuthorNameMatch(author, name) {
+			continue
+		}
+		if match != nil && match.ID != author.ID {
+			return nil, true, nil
+		}
+		match = author
+	}
+	return match, false, nil
+}
+
+func (h *SeriesHandler) matchGlobalAuthorByName(ctx context.Context, name string) (*models.Author, bool, error) {
+	if h.authors == nil {
+		return nil, false, nil
+	}
+	authors, err := h.authors.List(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	var match *models.Author
+	for idx := range authors {
+		if !trustedAuthorNameMatch(&authors[idx], name) {
+			continue
+		}
+		if match != nil && match.ID != authors[idx].ID {
+			return nil, true, nil
+		}
+		copy := authors[idx]
+		match = &copy
+	}
+	return match, false, nil
+}
+
+func trustedAuthorNameMatch(author *models.Author, name string) bool {
+	if author == nil {
+		return false
+	}
+	match := textutil.MatchAuthorName(author.Name, name)
+	return match.Kind == textutil.AuthorMatchExact || match.Kind == textutil.AuthorMatchFuzzyAuto
 }
 
 func hardcoverAuthorFallbackID(name string) string {

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -21,15 +21,46 @@ import (
 )
 
 type SeriesHandler struct {
-	series   *db.SeriesRepo
-	books    *db.BookRepo
-	authors  *db.AuthorRepo
-	meta     *metadata.Aggregator
-	searcher BookSearcher
+	series                      *db.SeriesRepo
+	books                       *db.BookRepo
+	authors                     *db.AuthorRepo
+	meta                        *metadata.Aggregator
+	searcher                    BookSearcher
+	settings                    *db.SettingsRepo
+	enhancedHardcoverEnvEnabled bool
 }
 
 func NewSeriesHandler(series *db.SeriesRepo, books *db.BookRepo, authors *db.AuthorRepo, meta *metadata.Aggregator, searcher BookSearcher) *SeriesHandler {
 	return &SeriesHandler{series: series, books: books, authors: authors, meta: meta, searcher: searcher}
+}
+
+func (h *SeriesHandler) WithHardcoverFeatureSettings(settings *db.SettingsRepo, envEnabled bool) *SeriesHandler {
+	h.settings = settings
+	h.enhancedHardcoverEnvEnabled = envEnabled
+	return h
+}
+
+func (h *SeriesHandler) hardcoverFeatureState(ctx context.Context) HardcoverFeatureState {
+	if h.settings == nil {
+		return HardcoverFeatureState{EnhancedHardcoverAPI: true, HardcoverTokenConfigured: true}
+	}
+	return HardcoverFeatureStateFor(ctx, h.settings, h.enhancedHardcoverEnvEnabled)
+}
+
+func (h *SeriesHandler) enhancedHardcoverEnabled(ctx context.Context) bool {
+	return h.hardcoverFeatureState(ctx).EnhancedHardcoverAPI
+}
+
+func (h *SeriesHandler) requireEnhancedHardcoverAPI(w http.ResponseWriter, r *http.Request) bool {
+	state := h.hardcoverFeatureState(r.Context())
+	if state.EnhancedHardcoverAPI {
+		return true
+	}
+	writeJSON(w, http.StatusNotFound, map[string]string{
+		"error":  "enhanced hardcover api disabled",
+		"reason": state.EnhancedHardcoverDisabledReason,
+	})
+	return false
 }
 
 func (h *SeriesHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -97,12 +128,14 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.createMissingHardcoverBooks(r.Context(), id); err != nil {
-		if errors.Is(err, errSeriesMetadataProvider) {
-			slog.Warn("series fill: failed to expand Hardcover catalog; continuing with local books", "seriesID", id, "error", err)
-		} else {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-			return
+	if h.enhancedHardcoverEnabled(r.Context()) {
+		if err := h.createMissingHardcoverBooks(r.Context(), id); err != nil {
+			if errors.Is(err, errSeriesMetadataProvider) {
+				slog.Warn("series fill: failed to expand Hardcover catalog; continuing with local books", "seriesID", id, "error", err)
+			} else {
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				return
+			}
 		}
 	}
 
@@ -187,6 +220,9 @@ type seriesHardcoverDiffResponse struct {
 var errSeriesMetadataProvider = errors.New("series metadata provider")
 
 func (h *SeriesHandler) SearchHardcover(w http.ResponseWriter, r *http.Request) {
+	if !h.requireEnhancedHardcoverAPI(w, r) {
+		return
+	}
 	term := strings.TrimSpace(r.URL.Query().Get("term"))
 	if term == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "term parameter required"})
@@ -214,6 +250,9 @@ func (h *SeriesHandler) SearchHardcover(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h *SeriesHandler) GetHardcoverLink(w http.ResponseWriter, r *http.Request) {
+	if !h.requireEnhancedHardcoverAPI(w, r) {
+		return
+	}
 	id, ok := parseID(w, r)
 	if !ok {
 		return
@@ -231,6 +270,9 @@ func (h *SeriesHandler) GetHardcoverLink(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *SeriesHandler) AutoLinkHardcover(w http.ResponseWriter, r *http.Request) {
+	if !h.requireEnhancedHardcoverAPI(w, r) {
+		return
+	}
 	id, ok := parseID(w, r)
 	if !ok {
 		return
@@ -288,6 +330,9 @@ func (h *SeriesHandler) AutoLinkHardcover(w http.ResponseWriter, r *http.Request
 }
 
 func (h *SeriesHandler) PutHardcoverLink(w http.ResponseWriter, r *http.Request) {
+	if !h.requireEnhancedHardcoverAPI(w, r) {
+		return
+	}
 	id, ok := parseID(w, r)
 	if !ok {
 		return
@@ -328,6 +373,9 @@ func (h *SeriesHandler) PutHardcoverLink(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *SeriesHandler) DeleteHardcoverLink(w http.ResponseWriter, r *http.Request) {
+	if !h.requireEnhancedHardcoverAPI(w, r) {
+		return
+	}
 	id, ok := parseID(w, r)
 	if !ok {
 		return
@@ -340,6 +388,9 @@ func (h *SeriesHandler) DeleteHardcoverLink(w http.ResponseWriter, r *http.Reque
 }
 
 func (h *SeriesHandler) HardcoverDiff(w http.ResponseWriter, r *http.Request) {
+	if !h.requireEnhancedHardcoverAPI(w, r) {
+		return
+	}
 	id, ok := parseID(w, r)
 	if !ok {
 		return
@@ -643,6 +694,9 @@ func localDiffBook(local models.SeriesBook) seriesHardcoverDiffBook {
 }
 
 func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesID int64) error {
+	if !h.enhancedHardcoverEnabled(ctx) {
+		return nil
+	}
 	if h.meta == nil || h.authors == nil {
 		return nil
 	}

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"sort"
@@ -252,7 +253,46 @@ func (h *SeriesHandler) Monitor(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]bool{"monitored": body.Monitored})
 }
 
-// Fill marks all non-imported books in a series as wanted and kicks off searches.
+type seriesFillRequest struct {
+	ForeignBookID string `json:"foreignBookId"`
+	ProviderID    string `json:"providerId"`
+	Position      string `json:"position"`
+}
+
+func (r *seriesFillRequest) normalize() {
+	r.ForeignBookID = strings.TrimSpace(r.ForeignBookID)
+	r.ProviderID = strings.TrimSpace(r.ProviderID)
+	r.Position = strings.TrimSpace(r.Position)
+}
+
+func (r seriesFillRequest) hasBookSelector() bool {
+	return r.ForeignBookID != "" || r.ProviderID != "" || r.Position != ""
+}
+
+func (r seriesFillRequest) matchesDiffBook(book seriesHardcoverDiffBook) bool {
+	matched := false
+	if r.ForeignBookID != "" {
+		if r.ForeignBookID != book.ForeignBookID {
+			return false
+		}
+		matched = true
+	}
+	if r.ProviderID != "" {
+		if r.ProviderID != book.ProviderID {
+			return false
+		}
+		matched = true
+	}
+	if r.Position != "" {
+		if !seriesmatch.SamePosition(r.Position, book.Position) {
+			return false
+		}
+		matched = true
+	}
+	return matched
+}
+
+// Fill marks non-imported books in a series as wanted and kicks off searches.
 func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 	if err != nil {
@@ -260,14 +300,59 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.enhancedHardcoverEnabled(r.Context()) {
-		if err := h.createMissingHardcoverBooks(r.Context(), id); err != nil {
+	var body seriesFillRequest
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			return
+		}
+	}
+	body.normalize()
+
+	if body.hasBookSelector() {
+		if !h.requireEnhancedHardcoverAPI(w, r) {
+			return
+		}
+		book, err := h.createMissingHardcoverBook(r.Context(), id, body)
+		if err != nil {
+			if errors.Is(err, errSeriesNotFound) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "series not found"})
+				return
+			}
+			if errors.Is(err, errSeriesCatalogBookNotFound) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "hardcover book not found in missing catalog"})
+				return
+			}
 			if errors.Is(err, errSeriesMetadataProvider) {
-				slog.Warn("series fill: failed to expand Hardcover catalog; continuing with local books", "seriesID", id, "error", err)
-			} else {
+				writeUpstreamError(w, err)
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+
+		queued := 0
+		if book != nil {
+			didQueue, err := h.queueSeriesBook(r.Context(), *book)
+			if err != nil {
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 				return
 			}
+			if didQueue {
+				queued = 1
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]int{"queued": queued})
+		return
+	}
+
+	if h.enhancedHardcoverEnabled(r.Context()) {
+		if err := h.createMissingHardcoverBooks(r.Context(), id); err != nil {
+			if !errors.Is(err, errSeriesMetadataProvider) {
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				return
+			}
+			slog.Warn("series fill: failed to expand Hardcover catalog; continuing with local books", "seriesID", id, "error", err)
 		}
 	}
 
@@ -279,20 +364,30 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 
 	queued := 0
 	for _, b := range books {
-		if b.Status == models.BookStatusImported {
-			continue
-		}
-		b.Status = models.BookStatusWanted
-		b.Monitored = true
-		if err := h.books.MarkWantedMonitored(r.Context(), b.ID); err != nil {
+		didQueue, err := h.queueSeriesBook(r.Context(), b)
+		if err != nil {
 			slog.Warn("series fill: failed to update book", "book", b.Title, "error", err)
 			continue
 		}
-		queued++
-		go h.searcher.SearchAndGrabBook(context.WithoutCancel(r.Context()), b)
+		if didQueue {
+			queued++
+		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]int{"queued": queued})
+}
+
+func (h *SeriesHandler) queueSeriesBook(ctx context.Context, b models.Book) (bool, error) {
+	if b.Status == models.BookStatusImported {
+		return false, nil
+	}
+	if err := h.books.MarkWantedMonitored(ctx, b.ID); err != nil {
+		return false, err
+	}
+	b.Status = models.BookStatusWanted
+	b.Monitored = true
+	go h.searcher.SearchAndGrabBook(context.WithoutCancel(ctx), b)
+	return true, nil
 }
 
 type seriesHardcoverSearchResult struct {
@@ -349,7 +444,11 @@ type seriesHardcoverDiffResponse struct {
 	MissingCount int                         `json:"missingCount"`
 }
 
-var errSeriesMetadataProvider = errors.New("series metadata provider")
+var (
+	errSeriesMetadataProvider    = errors.New("series metadata provider")
+	errSeriesNotFound            = errors.New("series not found")
+	errSeriesCatalogBookNotFound = errors.New("series catalog book not found")
+)
 
 func (h *SeriesHandler) SearchHardcover(w http.ResponseWriter, r *http.Request) {
 	if !h.requireEnhancedHardcoverAPI(w, r) {
@@ -689,7 +788,7 @@ func (h *SeriesHandler) linkFromRequest(ctx context.Context, seriesID int64, bod
 	}
 	catalog, err := h.meta.GetSeriesCatalog(ctx, body.ForeignID)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", errSeriesMetadataProvider, err)
+		return nil, fmt.Errorf("%w: %w", errSeriesMetadataProvider, err)
 	}
 	if catalog == nil {
 		return link, nil
@@ -841,7 +940,7 @@ func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesI
 	}
 	catalog, err := h.meta.GetSeriesCatalog(ctx, series.HardcoverLink.HardcoverSeriesID)
 	if err != nil {
-		return fmt.Errorf("%w: %v", errSeriesMetadataProvider, err)
+		return fmt.Errorf("%w: %w", errSeriesMetadataProvider, err)
 	}
 	if catalog == nil {
 		return nil
@@ -857,6 +956,44 @@ func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesI
 		}
 	}
 	return nil
+}
+
+func (h *SeriesHandler) createMissingHardcoverBook(ctx context.Context, seriesID int64, selector seriesFillRequest) (*models.Book, error) {
+	if h.meta == nil {
+		return nil, errors.New("metadata aggregator is not configured")
+	}
+	if h.authors == nil {
+		return nil, errors.New("author repository is not configured")
+	}
+	series, err := h.series.GetByID(ctx, seriesID)
+	if err != nil {
+		return nil, err
+	}
+	if series == nil {
+		return nil, errSeriesNotFound
+	}
+	if series.HardcoverLink == nil {
+		return nil, errSeriesCatalogBookNotFound
+	}
+	catalog, err := h.meta.GetSeriesCatalog(ctx, series.HardcoverLink.HardcoverSeriesID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errSeriesMetadataProvider, err)
+	}
+	if catalog == nil {
+		return nil, errSeriesCatalogBookNotFound
+	}
+	diff := buildHardcoverDiff(series, series.HardcoverLink, catalog)
+	for _, missing := range diff.Missing {
+		if !selector.matchesDiffBook(missing) {
+			continue
+		}
+		catalogBook, ok := findCatalogBook(catalog.Books, missing.ForeignBookID, missing.Position)
+		if !ok {
+			return nil, errSeriesCatalogBookNotFound
+		}
+		return h.ensureHardcoverCatalogBook(ctx, series.ID, catalog.AuthorName, catalogBook)
+	}
+	return nil, errSeriesCatalogBookNotFound
 }
 
 func findCatalogBook(books []metadata.SeriesCatalogBook, foreignID, position string) (metadata.SeriesCatalogBook, bool) {

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -3,24 +3,33 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/seriesmatch"
 )
 
 type SeriesHandler struct {
 	series   *db.SeriesRepo
 	books    *db.BookRepo
+	authors  *db.AuthorRepo
+	meta     *metadata.Aggregator
 	searcher BookSearcher
 }
 
-func NewSeriesHandler(series *db.SeriesRepo, books *db.BookRepo, searcher BookSearcher) *SeriesHandler {
-	return &SeriesHandler{series: series, books: books, searcher: searcher}
+func NewSeriesHandler(series *db.SeriesRepo, books *db.BookRepo, authors *db.AuthorRepo, meta *metadata.Aggregator, searcher BookSearcher) *SeriesHandler {
+	return &SeriesHandler{series: series, books: books, authors: authors, meta: meta, searcher: searcher}
 }
 
 func (h *SeriesHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -88,6 +97,15 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := h.createMissingHardcoverBooks(r.Context(), id); err != nil {
+		if errors.Is(err, errSeriesMetadataProvider) {
+			slog.Warn("series fill: failed to expand Hardcover catalog; continuing with local books", "seriesID", id, "error", err)
+		} else {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+	}
+
 	books, err := h.series.ListBooksInSeries(r.Context(), id)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -101,7 +119,7 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 		}
 		b.Status = models.BookStatusWanted
 		b.Monitored = true
-		if err := h.books.Update(r.Context(), &b); err != nil {
+		if err := h.books.MarkWantedMonitored(r.Context(), b.ID); err != nil {
 			slog.Warn("series fill: failed to update book", "book", b.Title, "error", err)
 			continue
 		}
@@ -110,4 +128,665 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]int{"queued": queued})
+}
+
+type seriesHardcoverSearchResult struct {
+	ForeignID    string   `json:"foreignId"`
+	ProviderID   string   `json:"providerId"`
+	Title        string   `json:"title"`
+	AuthorName   string   `json:"authorName"`
+	BookCount    int      `json:"bookCount"`
+	ReadersCount int      `json:"readersCount"`
+	Books        []string `json:"books"`
+	Confidence   float64  `json:"confidence,omitempty"`
+}
+
+type seriesHardcoverLinkRequest struct {
+	ForeignID  string  `json:"foreignId"`
+	ProviderID string  `json:"providerId"`
+	Title      string  `json:"title"`
+	AuthorName string  `json:"authorName"`
+	BookCount  int     `json:"bookCount"`
+	Confidence float64 `json:"confidence"`
+}
+
+type seriesHardcoverAutoResponse struct {
+	Linked     bool                          `json:"linked"`
+	Link       *models.SeriesHardcoverLink   `json:"link,omitempty"`
+	Candidates []seriesHardcoverSearchResult `json:"candidates"`
+	Reason     string                        `json:"reason,omitempty"`
+}
+
+type seriesHardcoverDiffBook struct {
+	ForeignBookID   string     `json:"foreignBookId"`
+	ProviderID      string     `json:"providerId"`
+	Title           string     `json:"title"`
+	Subtitle        string     `json:"subtitle,omitempty"`
+	Position        string     `json:"position"`
+	ImageURL        string     `json:"imageUrl,omitempty"`
+	AuthorName      string     `json:"authorName,omitempty"`
+	ReleaseDate     *time.Time `json:"releaseDate,omitempty"`
+	UsersCount      int        `json:"usersCount,omitempty"`
+	LocalBookID     *int64     `json:"localBookId,omitempty"`
+	LocalTitle      string     `json:"localTitle,omitempty"`
+	LocalStatus     string     `json:"localStatus,omitempty"`
+	MatchConfidence float64    `json:"matchConfidence,omitempty"`
+}
+
+type seriesHardcoverDiffResponse struct {
+	SeriesID     int64                       `json:"seriesId"`
+	Link         *models.SeriesHardcoverLink `json:"link"`
+	Present      []seriesHardcoverDiffBook   `json:"present"`
+	Missing      []seriesHardcoverDiffBook   `json:"missing"`
+	LocalOnly    []seriesHardcoverDiffBook   `json:"localOnly"`
+	Uncertain    []seriesHardcoverDiffBook   `json:"uncertain"`
+	PresentCount int                         `json:"presentCount"`
+	MissingCount int                         `json:"missingCount"`
+}
+
+var errSeriesMetadataProvider = errors.New("series metadata provider")
+
+func (h *SeriesHandler) SearchHardcover(w http.ResponseWriter, r *http.Request) {
+	term := strings.TrimSpace(r.URL.Query().Get("term"))
+	if term == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "term parameter required"})
+		return
+	}
+	limit := 10
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid limit"})
+			return
+		}
+		limit = parsed
+	}
+	if limit > 50 {
+		limit = 50
+	}
+
+	results, err := h.searchHardcoverSeries(r.Context(), term, limit)
+	if err != nil {
+		writeUpstreamError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, results)
+}
+
+func (h *SeriesHandler) GetHardcoverLink(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	link, err := h.series.GetHardcoverLink(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if link == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "hardcover link not found"})
+		return
+	}
+	writeJSON(w, http.StatusOK, link)
+}
+
+func (h *SeriesHandler) AutoLinkHardcover(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	series, err := h.series.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if series == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "series not found"})
+		return
+	}
+
+	results, err := h.searchHardcoverSeries(r.Context(), series.Title, 10)
+	if err != nil {
+		writeUpstreamError(w, err)
+		return
+	}
+	candidates, err := h.scoreHardcoverCandidates(r.Context(), series, results)
+	if err != nil {
+		writeUpstreamError(w, err)
+		return
+	}
+	if len(candidates) == 0 {
+		writeJSON(w, http.StatusOK, seriesHardcoverAutoResponse{Candidates: []seriesHardcoverSearchResult{}, Reason: "no candidates"})
+		return
+	}
+	top := candidates[0]
+	ambiguous := len(candidates) > 1 && top.Confidence-candidates[1].Confidence < 0.05
+	if top.Confidence < 0.70 || ambiguous {
+		reason := "low confidence"
+		if ambiguous {
+			reason = "ambiguous candidates"
+		}
+		writeJSON(w, http.StatusOK, seriesHardcoverAutoResponse{Candidates: candidates, Reason: reason})
+		return
+	}
+
+	link := &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   top.ForeignID,
+		HardcoverProviderID: top.ProviderID,
+		HardcoverTitle:      top.Title,
+		HardcoverAuthorName: top.AuthorName,
+		HardcoverBookCount:  top.BookCount,
+		Confidence:          top.Confidence,
+		LinkedBy:            "auto",
+	}
+	if err := h.series.UpsertHardcoverLink(r.Context(), link); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, seriesHardcoverAutoResponse{Linked: true, Link: link, Candidates: candidates})
+}
+
+func (h *SeriesHandler) PutHardcoverLink(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	if series, err := h.series.GetByID(r.Context(), id); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	} else if series == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "series not found"})
+		return
+	}
+
+	var body seriesHardcoverLinkRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	body.ForeignID = strings.TrimSpace(body.ForeignID)
+	if body.ForeignID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "foreignId is required"})
+		return
+	}
+
+	link, err := h.linkFromRequest(r.Context(), id, body, "manual")
+	if err != nil {
+		if errors.Is(err, errSeriesMetadataProvider) {
+			writeUpstreamError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := h.series.UpsertHardcoverLink(r.Context(), link); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, link)
+}
+
+func (h *SeriesHandler) DeleteHardcoverLink(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.series.DeleteHardcoverLink(r.Context(), id); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+func (h *SeriesHandler) HardcoverDiff(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	series, err := h.series.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if series == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "series not found"})
+		return
+	}
+	link := series.HardcoverLink
+	if link == nil {
+		link, err = h.series.GetHardcoverLink(r.Context(), id)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+	}
+	if link == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "hardcover link not found"})
+		return
+	}
+	catalog, err := h.hardcoverCatalog(r.Context(), link.HardcoverSeriesID)
+	if err != nil {
+		writeUpstreamError(w, err)
+		return
+	}
+	diff := buildHardcoverDiff(series, link, catalog)
+	writeJSON(w, http.StatusOK, diff)
+}
+
+func (h *SeriesHandler) searchHardcoverSeries(ctx context.Context, term string, limit int) ([]seriesHardcoverSearchResult, error) {
+	if h.meta == nil {
+		return nil, errors.New("metadata aggregator is not configured")
+	}
+	results, err := h.meta.SearchSeries(ctx, term, limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]seriesHardcoverSearchResult, 0, len(results))
+	for _, result := range results {
+		out = append(out, mapHardcoverSearchResult(result))
+	}
+	return out, nil
+}
+
+func mapHardcoverSearchResult(result metadata.SeriesSearchResult) seriesHardcoverSearchResult {
+	books := result.Books
+	if books == nil {
+		books = []string{}
+	}
+	return seriesHardcoverSearchResult{
+		ForeignID:    result.ForeignID,
+		ProviderID:   result.ProviderID,
+		Title:        result.Title,
+		AuthorName:   result.AuthorName,
+		BookCount:    result.BookCount,
+		ReadersCount: result.ReadersCount,
+		Books:        books,
+	}
+}
+
+func (h *SeriesHandler) scoreHardcoverCandidates(ctx context.Context, series *models.Series, results []seriesHardcoverSearchResult) ([]seriesHardcoverSearchResult, error) {
+	candidates := make([]seriesHardcoverSearchResult, 0, len(results))
+	for _, result := range results {
+		catalog, err := h.meta.GetSeriesCatalog(ctx, result.ForeignID)
+		if err != nil {
+			return nil, err
+		}
+		result.Confidence = scoreHardcoverCandidate(series, result, catalog)
+		if catalog != nil {
+			if result.Title == "" {
+				result.Title = catalog.Title
+			}
+			if result.AuthorName == "" {
+				result.AuthorName = catalog.AuthorName
+			}
+			if result.BookCount == 0 {
+				result.BookCount = catalog.BookCount
+			}
+		}
+		candidates = append(candidates, result)
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].Confidence > candidates[j].Confidence
+	})
+	return candidates, nil
+}
+
+func scoreHardcoverCandidate(series *models.Series, result seriesHardcoverSearchResult, catalog *metadata.SeriesCatalog) float64 {
+	if series == nil {
+		return 0
+	}
+	candidateTitle := result.Title
+	if catalog != nil && strings.TrimSpace(catalog.Title) != "" {
+		candidateTitle = catalog.Title
+	}
+	seriesTitleScore := seriesmatch.TitleScore(series.Title, candidateTitle)
+	if seriesmatch.NormalizeSeriesName(series.Title) == seriesmatch.NormalizeSeriesName(candidateTitle) {
+		seriesTitleScore = 100
+	}
+
+	bookTitleScore := 0
+	for _, title := range result.Books {
+		bookTitleScore = max(bookTitleScore, seriesmatch.TitleScore(series.Title, title))
+	}
+	if catalog != nil {
+		for _, book := range catalog.Books {
+			bookTitleScore = max(bookTitleScore, seriesmatch.TitleScore(series.Title, firstNonEmpty(book.Title, book.Book.Title)))
+		}
+	}
+
+	score := float64(seriesTitleScore)
+	if seriesTitleScore < 92 && bookTitleScore >= 92 {
+		score = 70
+	} else if bookTitleScore > 0 {
+		score = 0.75*float64(seriesTitleScore) + 0.25*float64(bookTitleScore)
+	}
+
+	if catalog != nil && len(series.Books) > 0 {
+		matches := 0
+		checked := 0
+		for _, local := range series.Books {
+			if local.Book == nil {
+				continue
+			}
+			checked++
+			if bestCatalogMatch(local, catalog.Books).score >= 85 {
+				matches++
+			}
+		}
+		if checked > 0 {
+			overlapScore := 65 + 30*(float64(matches)/float64(checked))
+			score = maxFloat(score, overlapScore)
+		}
+	}
+
+	if score > 100 {
+		score = 100
+	}
+	return score / 100
+}
+
+func (h *SeriesHandler) linkFromRequest(ctx context.Context, seriesID int64, body seriesHardcoverLinkRequest, linkedBy string) (*models.SeriesHardcoverLink, error) {
+	confidence := body.Confidence
+	if confidence <= 0 {
+		confidence = 1
+	}
+	link := &models.SeriesHardcoverLink{
+		SeriesID:            seriesID,
+		HardcoverSeriesID:   body.ForeignID,
+		HardcoverProviderID: firstNonEmpty(body.ProviderID, strings.TrimPrefix(body.ForeignID, "hc-series:")),
+		HardcoverTitle:      body.Title,
+		HardcoverAuthorName: body.AuthorName,
+		HardcoverBookCount:  body.BookCount,
+		Confidence:          confidence,
+		LinkedBy:            linkedBy,
+	}
+	if h.meta == nil {
+		return link, nil
+	}
+	catalog, err := h.meta.GetSeriesCatalog(ctx, body.ForeignID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errSeriesMetadataProvider, err)
+	}
+	if catalog == nil {
+		return link, nil
+	}
+	link.HardcoverSeriesID = catalog.ForeignID
+	link.HardcoverProviderID = catalog.ProviderID
+	link.HardcoverTitle = catalog.Title
+	link.HardcoverAuthorName = catalog.AuthorName
+	link.HardcoverBookCount = catalog.BookCount
+	return link, nil
+}
+
+func (h *SeriesHandler) hardcoverCatalog(ctx context.Context, foreignID string) (*metadata.SeriesCatalog, error) {
+	if h.meta == nil {
+		return nil, errors.New("metadata aggregator is not configured")
+	}
+	catalog, err := h.meta.GetSeriesCatalog(ctx, foreignID)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, fmt.Errorf("hardcover series %q not found", foreignID)
+	}
+	return catalog, nil
+}
+
+func buildHardcoverDiff(series *models.Series, link *models.SeriesHardcoverLink, catalog *metadata.SeriesCatalog) seriesHardcoverDiffResponse {
+	diff := seriesHardcoverDiffResponse{
+		SeriesID:  series.ID,
+		Link:      link,
+		Present:   []seriesHardcoverDiffBook{},
+		Missing:   []seriesHardcoverDiffBook{},
+		LocalOnly: []seriesHardcoverDiffBook{},
+		Uncertain: []seriesHardcoverDiffBook{},
+	}
+	matchedCatalog := make(map[int]struct{})
+	for _, local := range series.Books {
+		if local.Book == nil {
+			continue
+		}
+		match := bestCatalogMatch(local, catalog.Books)
+		localItem := localDiffBook(local)
+		if match.index < 0 {
+			diff.LocalOnly = append(diff.LocalOnly, localItem)
+			continue
+		}
+		item := catalogDiffBook(catalog.Books[match.index], catalog.AuthorName)
+		item.LocalBookID = &local.Book.ID
+		item.LocalTitle = local.Book.Title
+		item.LocalStatus = local.Book.Status
+		item.MatchConfidence = float64(match.score) / 100
+		if match.score >= 90 || match.foreignID {
+			diff.Present = append(diff.Present, item)
+			matchedCatalog[match.index] = struct{}{}
+		} else if match.score >= 70 {
+			diff.Uncertain = append(diff.Uncertain, item)
+			matchedCatalog[match.index] = struct{}{}
+		} else {
+			diff.LocalOnly = append(diff.LocalOnly, localItem)
+		}
+	}
+	for i, book := range catalog.Books {
+		if _, ok := matchedCatalog[i]; ok {
+			continue
+		}
+		diff.Missing = append(diff.Missing, catalogDiffBook(book, catalog.AuthorName))
+	}
+	diff.PresentCount = len(diff.Present)
+	diff.MissingCount = len(diff.Missing)
+	return diff
+}
+
+type catalogMatch struct {
+	index     int
+	score     int
+	foreignID bool
+}
+
+func bestCatalogMatch(local models.SeriesBook, books []metadata.SeriesCatalogBook) catalogMatch {
+	best := catalogMatch{index: -1}
+	if local.Book == nil {
+		return best
+	}
+	for i, candidate := range books {
+		foreignMatch := local.Book.ForeignID != "" && (local.Book.ForeignID == candidate.ForeignID || local.Book.ForeignID == candidate.Book.ForeignID)
+		score := 0
+		if foreignMatch {
+			score = 100
+		} else {
+			score = seriesmatch.TitleScore(local.Book.Title, firstNonEmpty(candidate.Title, candidate.Book.Title))
+			if seriesmatch.SamePosition(local.PositionInSeries, candidate.Position) && score >= 70 {
+				score = max(score, 90)
+			}
+		}
+		if score > best.score {
+			best = catalogMatch{index: i, score: score, foreignID: foreignMatch}
+		}
+	}
+	return best
+}
+
+func catalogDiffBook(book metadata.SeriesCatalogBook, fallbackAuthor string) seriesHardcoverDiffBook {
+	title := firstNonEmpty(book.Title, book.Book.Title)
+	author := fallbackAuthor
+	if book.Book.Author != nil && strings.TrimSpace(book.Book.Author.Name) != "" {
+		author = book.Book.Author.Name
+	}
+	return seriesHardcoverDiffBook{
+		ForeignBookID: firstNonEmpty(book.ForeignID, book.Book.ForeignID),
+		ProviderID:    book.ProviderID,
+		Title:         title,
+		Subtitle:      book.Subtitle,
+		Position:      book.Position,
+		ImageURL:      book.Book.ImageURL,
+		AuthorName:    author,
+		ReleaseDate:   book.Book.ReleaseDate,
+		UsersCount:    book.UsersCount,
+	}
+}
+
+func localDiffBook(local models.SeriesBook) seriesHardcoverDiffBook {
+	item := seriesHardcoverDiffBook{Position: local.PositionInSeries}
+	if local.Book == nil {
+		return item
+	}
+	item.ForeignBookID = local.Book.ForeignID
+	item.Title = local.Book.Title
+	item.ImageURL = local.Book.ImageURL
+	item.ReleaseDate = local.Book.ReleaseDate
+	item.LocalBookID = &local.Book.ID
+	item.LocalTitle = local.Book.Title
+	item.LocalStatus = local.Book.Status
+	return item
+}
+
+func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesID int64) error {
+	if h.meta == nil || h.authors == nil {
+		return nil
+	}
+	series, err := h.series.GetByID(ctx, seriesID)
+	if err != nil {
+		return err
+	}
+	if series == nil || series.HardcoverLink == nil {
+		return nil
+	}
+	catalog, err := h.meta.GetSeriesCatalog(ctx, series.HardcoverLink.HardcoverSeriesID)
+	if err != nil {
+		return fmt.Errorf("%w: %v", errSeriesMetadataProvider, err)
+	}
+	if catalog == nil {
+		return nil
+	}
+	diff := buildHardcoverDiff(series, series.HardcoverLink, catalog)
+	for _, missing := range diff.Missing {
+		catalogBook, ok := findCatalogBook(catalog.Books, missing.ForeignBookID, missing.Position)
+		if !ok {
+			continue
+		}
+		if _, err := h.ensureHardcoverCatalogBook(ctx, series.ID, catalog.AuthorName, catalogBook); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func findCatalogBook(books []metadata.SeriesCatalogBook, foreignID, position string) (metadata.SeriesCatalogBook, bool) {
+	for _, book := range books {
+		if foreignID != "" && (foreignID == book.ForeignID || foreignID == book.Book.ForeignID) {
+			return book, true
+		}
+		if seriesmatch.SamePosition(position, book.Position) {
+			return book, true
+		}
+	}
+	return metadata.SeriesCatalogBook{}, false
+}
+
+func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, seriesID int64, fallbackAuthor string, catalogBook metadata.SeriesCatalogBook) (*models.Book, error) {
+	book := catalogBook.Book
+	book.ForeignID = firstNonEmpty(book.ForeignID, catalogBook.ForeignID)
+	if book.ForeignID == "" {
+		book.ForeignID = "hc:" + catalogBook.ProviderID
+	}
+	if existing, err := h.books.GetByForeignID(ctx, book.ForeignID); err != nil {
+		return nil, err
+	} else if existing != nil {
+		_, err := h.series.LinkBookIfMissing(ctx, seriesID, existing.ID, catalogBook.Position, true)
+		return existing, err
+	}
+
+	author := book.Author
+	if author == nil {
+		author = &models.Author{
+			ForeignID:        hardcoverAuthorFallbackID(fallbackAuthor),
+			Name:             fallbackAuthor,
+			SortName:         sortName(fallbackAuthor),
+			MetadataProvider: "hardcover",
+		}
+	}
+	if strings.TrimSpace(author.Name) == "" {
+		author.Name = "Unknown Author"
+	}
+	if strings.TrimSpace(author.SortName) == "" {
+		author.SortName = sortName(author.Name)
+	}
+	if strings.TrimSpace(author.ForeignID) == "" {
+		author.ForeignID = hardcoverAuthorFallbackID(author.Name)
+	}
+	if strings.TrimSpace(author.MetadataProvider) == "" {
+		author.MetadataProvider = "hardcover"
+	}
+	metadataProfileID := models.DefaultMetadataProfileID
+	author.MetadataProfileID = &metadataProfileID
+
+	storedAuthor, err := h.authors.GetByForeignID(ctx, author.ForeignID)
+	if err != nil {
+		return nil, err
+	}
+	if storedAuthor == nil {
+		if err := h.authors.Create(ctx, author); err != nil {
+			return nil, err
+		}
+		storedAuthor = author
+	}
+
+	existingByTitle, err := h.books.ListByAuthorIncludingExcluded(ctx, storedAuthor.ID)
+	if err != nil {
+		return nil, err
+	}
+	for _, existing := range existingByTitle {
+		if seriesmatch.TitleScore(existing.Title, firstNonEmpty(book.Title, catalogBook.Title)) >= 92 {
+			_, err := h.series.LinkBookIfMissing(ctx, seriesID, existing.ID, catalogBook.Position, true)
+			return &existing, err
+		}
+	}
+
+	book.AuthorID = storedAuthor.ID
+	book.Author = nil
+	book.Title = firstNonEmpty(book.Title, catalogBook.Title)
+	book.SortTitle = firstNonEmpty(book.SortTitle, book.Title)
+	book.Status = models.BookStatusWanted
+	book.Monitored = true
+	book.AnyEditionOK = true
+	book.MediaType = firstNonEmpty(book.MediaType, models.MediaTypeEbook)
+	book.Language = firstNonEmpty(book.Language, "eng")
+	book.MetadataProvider = firstNonEmpty(book.MetadataProvider, "hardcover")
+	if book.Genres == nil {
+		book.Genres = []string{}
+	}
+	if err := h.books.Create(ctx, &book); err != nil {
+		return nil, err
+	}
+	if _, err := h.series.LinkBookIfMissing(ctx, seriesID, book.ID, catalogBook.Position, true); err != nil {
+		return nil, err
+	}
+	return &book, nil
+}
+
+func hardcoverAuthorFallbackID(name string) string {
+	key := strings.ReplaceAll(seriesmatch.CleanTitle(name), " ", "-")
+	if key == "" {
+		key = "unknown"
+	}
+	return "hc-author:" + key
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func maxFloat(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/seriesmatch"
+	"github.com/vavallee/bindery/internal/textutil"
 )
 
 type SeriesHandler struct {
@@ -30,6 +31,11 @@ type SeriesHandler struct {
 	settings                    *db.SettingsRepo
 	enhancedHardcoverEnvEnabled bool
 }
+
+const (
+	autoHardcoverLinkMinConfidence = 0.70
+	hardcoverNoEvidenceScoreCap    = autoHardcoverLinkMinConfidence - 0.01
+)
 
 func NewSeriesHandler(series *db.SeriesRepo, books *db.BookRepo, authors *db.AuthorRepo, meta *metadata.Aggregator, searcher BookSearcher) *SeriesHandler {
 	return &SeriesHandler{series: series, books: books, authors: authors, meta: meta, searcher: searcher}
@@ -534,7 +540,7 @@ func (h *SeriesHandler) AutoLinkHardcover(w http.ResponseWriter, r *http.Request
 	}
 	top := candidates[0]
 	ambiguous := len(candidates) > 1 && top.Confidence-candidates[1].Confidence < 0.05
-	if top.Confidence < 0.70 || ambiguous {
+	if top.Confidence < autoHardcoverLinkMinConfidence || ambiguous {
 		reason := "low confidence"
 		if ambiguous {
 			reason = "ambiguous candidates"
@@ -694,7 +700,6 @@ func (h *SeriesHandler) scoreHardcoverCandidates(ctx context.Context, series *mo
 		if err != nil {
 			return nil, err
 		}
-		result.Confidence = scoreHardcoverCandidate(series, result, catalog)
 		if catalog != nil {
 			if result.Title == "" {
 				result.Title = catalog.Title
@@ -706,12 +711,92 @@ func (h *SeriesHandler) scoreHardcoverCandidates(ctx context.Context, series *mo
 				result.BookCount = catalog.BookCount
 			}
 		}
+		result.Confidence = scoreHardcoverCandidate(series, result, catalog)
+		hasEvidence, err := h.hardcoverCandidateHasLocalEvidence(ctx, series, result, catalog)
+		if err != nil {
+			return nil, err
+		}
+		if !hasEvidence && result.Confidence >= autoHardcoverLinkMinConfidence {
+			result.Confidence = hardcoverNoEvidenceScoreCap
+		}
 		candidates = append(candidates, result)
 	}
 	sort.SliceStable(candidates, func(i, j int) bool {
 		return candidates[i].Confidence > candidates[j].Confidence
 	})
 	return candidates, nil
+}
+
+func (h *SeriesHandler) hardcoverCandidateHasLocalEvidence(ctx context.Context, series *models.Series, result seriesHardcoverSearchResult, catalog *metadata.SeriesCatalog) (bool, error) {
+	if series == nil {
+		return false, nil
+	}
+	if hardcoverCandidateHasBookOverlap(series, result, catalog) {
+		return true, nil
+	}
+	candidateAuthor := result.AuthorName
+	if catalog != nil && strings.TrimSpace(catalog.AuthorName) != "" {
+		candidateAuthor = catalog.AuthorName
+	}
+	if strings.TrimSpace(candidateAuthor) == "" {
+		return false, nil
+	}
+	return h.seriesHasAuthorAgreement(ctx, series, candidateAuthor)
+}
+
+func hardcoverCandidateHasBookOverlap(series *models.Series, result seriesHardcoverSearchResult, catalog *metadata.SeriesCatalog) bool {
+	if series == nil {
+		return false
+	}
+	for _, local := range series.Books {
+		if local.Book == nil {
+			continue
+		}
+		if catalog != nil && bestCatalogMatch(local, catalog.Books).score >= 85 {
+			return true
+		}
+		for _, title := range result.Books {
+			if seriesmatch.TitleScore(local.Book.Title, title) >= 85 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (h *SeriesHandler) seriesHasAuthorAgreement(ctx context.Context, series *models.Series, candidateAuthor string) (bool, error) {
+	if series == nil {
+		return false, nil
+	}
+	authorsByID := map[int64]string{}
+	for _, local := range series.Books {
+		if local.Book == nil {
+			continue
+		}
+		localAuthor := ""
+		if local.Book.Author != nil {
+			localAuthor = local.Book.Author.Name
+		}
+		if strings.TrimSpace(localAuthor) == "" && local.Book.AuthorID > 0 && h.authors != nil {
+			if cached, ok := authorsByID[local.Book.AuthorID]; ok {
+				localAuthor = cached
+			} else {
+				author, err := h.authors.GetByID(ctx, local.Book.AuthorID)
+				if err != nil {
+					return false, err
+				}
+				if author != nil {
+					localAuthor = author.Name
+				}
+				authorsByID[local.Book.AuthorID] = localAuthor
+			}
+		}
+		match := textutil.MatchAuthorName(localAuthor, candidateAuthor)
+		if match.Kind == textutil.AuthorMatchExact || match.Kind == textutil.AuthorMatchFuzzyAuto {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func scoreHardcoverCandidate(series *models.Series, result seriesHardcoverSearchResult, catalog *metadata.SeriesCatalog) float64 {
@@ -1017,6 +1102,9 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, seriesID
 	if existing, err := h.books.GetByForeignID(ctx, book.ForeignID); err != nil {
 		return nil, err
 	} else if existing != nil {
+		if existing.Excluded {
+			return nil, nil
+		}
 		_, err := h.series.LinkBookIfMissing(ctx, seriesID, existing.ID, catalogBook.Position, true)
 		return existing, err
 	}
@@ -1060,11 +1148,19 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, seriesID
 	if err != nil {
 		return nil, err
 	}
+	blockedByExcludedTitle := false
 	for _, existing := range existingByTitle {
 		if seriesmatch.TitleScore(existing.Title, firstNonEmpty(book.Title, catalogBook.Title)) >= 92 {
+			if existing.Excluded {
+				blockedByExcludedTitle = true
+				continue
+			}
 			_, err := h.series.LinkBookIfMissing(ctx, seriesID, existing.ID, catalogBook.Position, true)
 			return &existing, err
 		}
+	}
+	if blockedByExcludedTitle {
+		return nil, nil
 	}
 
 	book.AuthorID = storedAuthor.ID

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -24,7 +24,7 @@ func NewSeriesHandler(series *db.SeriesRepo, books *db.BookRepo, searcher BookSe
 }
 
 func (h *SeriesHandler) List(w http.ResponseWriter, r *http.Request) {
-	series, err := h.series.List(r.Context())
+	series, err := h.series.ListWithBooks(r.Context())
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -88,6 +88,9 @@ func TestSeriesListAndGet_WithData(t *testing.T) {
 	if len(list) != 1 {
 		t.Fatalf("expected 1 series, got %d", len(list))
 	}
+	if len(list[0].Books) != 1 || list[0].Books[0].BookID != book.ID {
+		t.Fatalf("expected linked book in series list, got %+v", list[0].Books)
+	}
 
 	// Get with books
 	rec = httptest.NewRecorder()

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -33,6 +33,8 @@ type stubSeriesProvider struct {
 	catalogs      map[string]*metadata.SeriesCatalog
 	searchErr     error
 	catalogErr    error
+	searchCalls   int
+	catalogCalls  int
 }
 
 func (s *stubSeriesProvider) Name() string { return "stub" }
@@ -62,10 +64,12 @@ func (s *stubSeriesProvider) GetBookByISBN(context.Context, string) (*models.Boo
 }
 
 func (s *stubSeriesProvider) SearchSeries(context.Context, string, int) ([]metadata.SeriesSearchResult, error) {
+	s.searchCalls++
 	return s.searchResults, s.searchErr
 }
 
 func (s *stubSeriesProvider) GetSeriesCatalog(_ context.Context, foreignID string) (*metadata.SeriesCatalog, error) {
+	s.catalogCalls++
 	if s.catalogErr != nil {
 		return nil, s.catalogErr
 	}
@@ -86,6 +90,25 @@ func seriesFixtureWithProvider(t *testing.T, provider *stubSeriesProvider, searc
 		searcher = &mockBookSearcher{}
 	}
 	return NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metadata.NewAggregator(provider), searcher), seriesRepo, authorRepo, bookRepo
+}
+
+func seriesFixtureWithProviderAndSettings(t *testing.T, provider *stubSeriesProvider, searcher BookSearcher, envEnabled bool) (*SeriesHandler, *db.SeriesRepo, *db.AuthorRepo, *db.BookRepo, *db.SettingsRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	seriesRepo := db.NewSeriesRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	if searcher == nil {
+		searcher = &mockBookSearcher{}
+	}
+	handler := NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metadata.NewAggregator(provider), searcher).
+		WithHardcoverFeatureSettings(settingsRepo, envEnabled)
+	return handler, seriesRepo, authorRepo, bookRepo, settingsRepo
 }
 
 func TestSeriesList_Empty(t *testing.T) {
@@ -227,6 +250,20 @@ func TestSeriesHardcoverSearchNormalizesNilBooks(t *testing.T) {
 	}
 }
 
+func TestSeriesHardcoverSearchDisabledByFeatureState(t *testing.T) {
+	provider := &stubSeriesProvider{}
+	h, _, _, _, _ := seriesFixtureWithProviderAndSettings(t, provider, nil, false)
+
+	rec := httptest.NewRecorder()
+	h.SearchHardcover(rec, httptest.NewRequest(http.MethodGet, "/api/v1/series/hardcover/search?term=stormlight", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when enhanced Hardcover API is disabled, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if provider.searchCalls != 0 {
+		t.Fatalf("provider should not be called when disabled, got %d calls", provider.searchCalls)
+	}
+}
+
 func TestSeriesAutoLinkHardcoverPersistsTopCandidate(t *testing.T) {
 	catalog := stormlightCatalog()
 	provider := &stubSeriesProvider{
@@ -310,6 +347,77 @@ func TestSeriesAutoLinkHardcoverAmbiguousNoop(t *testing.T) {
 	}
 	if link != nil {
 		t.Fatalf("expected no link, got %+v", link)
+	}
+}
+
+func TestSeriesFillSkipsHardcoverCatalogWhenFeatureDisabled(t *testing.T) {
+	catalog := stormlightCatalog()
+	provider := &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}
+	searcher := newMockBookSearcher()
+	h, seriesRepo, authorRepo, bookRepo, settingsRepo := seriesFixtureWithProviderAndSettings(t, provider, searcher, false)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	link := &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := settingsRepo.Set(ctx, SettingHardcoverAPIToken, "hc-secret"); err != nil {
+		t.Fatal(err)
+	}
+	if err := settingsRepo.Set(ctx, SettingHardcoverEnhancedSeriesEnabled, "true"); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{
+		ForeignID:        "hc:brandon-sanderson",
+		Name:             "Brandon Sanderson",
+		SortName:         "Sanderson, Brandon",
+		MetadataProvider: "hardcover",
+		Monitored:        true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID:        "hc:words-of-radiance",
+		AuthorID:         author.ID,
+		Title:            "Words of Radiance",
+		SortTitle:        "Words of Radiance",
+		Status:           models.BookStatusSkipped,
+		Genres:           []string{},
+		MetadataProvider: "hardcover",
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seriesRepo.LinkBookIfMissing(ctx, series.ID, book.ID, "2", true); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if provider.catalogCalls != 0 {
+		t.Fatalf("hardcover catalog should not be called while env disables enhanced API, got %d calls", provider.catalogCalls)
+	}
+	queued := searcher.waitForCall(t, time.Second)
+	if queued.ID != book.ID {
+		t.Fatalf("expected local linked book to be queued, got %+v", queued)
 	}
 }
 

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -599,6 +599,285 @@ func TestSeriesAutoLinkHardcoverAmbiguousNoop(t *testing.T) {
 	}
 }
 
+func TestSeriesPutHardcoverLinkPersistsManualLink(t *testing.T) {
+	catalog := stormlightCatalog()
+	provider := &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}
+	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, provider, nil)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+
+	body := bytes.NewBufferString(`{"foreignId":"hc-series:42","providerId":"draft","title":"Draft title","authorName":"Draft Author","bookCount":99,"confidence":0.4}`)
+	rec := httptest.NewRecorder()
+	h.PutHardcoverLink(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/api/v1/series/1/hardcover-link", body), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got models.SeriesHardcoverLink
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.HardcoverSeriesID != catalog.ForeignID || got.HardcoverTitle != catalog.Title || got.HardcoverBookCount != catalog.BookCount {
+		t.Fatalf("expected catalog-backed manual link, got %+v", got)
+	}
+	if got.LinkedBy != "manual" || got.Confidence != 0.4 {
+		t.Fatalf("expected manual confidence to persist, got %+v", got)
+	}
+	stored, err := seriesRepo.GetHardcoverLink(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored == nil || stored.HardcoverSeriesID != catalog.ForeignID {
+		t.Fatalf("expected stored link, got %+v", stored)
+	}
+}
+
+func TestSeriesPutHardcoverLinkInvalidRequests(t *testing.T) {
+	catalog := stormlightCatalog()
+	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, nil)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		id   string
+		body string
+		code int
+	}{
+		{name: "missing series", id: "999", body: `{"foreignId":"hc-series:42"}`, code: http.StatusNotFound},
+		{name: "invalid body", id: strconv.FormatInt(series.ID, 10), body: `{`, code: http.StatusBadRequest},
+		{name: "missing foreign id", id: strconv.FormatInt(series.ID, 10), body: `{"title":"Stormlight"}`, code: http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.PutHardcoverLink(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/api/v1/series/1/hardcover-link", bytes.NewBufferString(tt.body)), "id", tt.id))
+			if rec.Code != tt.code {
+				t.Fatalf("expected %d, got %d: %s", tt.code, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestSeriesPutHardcoverLinkProviderFailure(t *testing.T) {
+	catalog := stormlightCatalog()
+	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs:   map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+		catalogErr: errors.New("hardcover unavailable"),
+	}, nil)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.PutHardcoverLink(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/api/v1/series/1/hardcover-link", bytes.NewBufferString(`{"foreignId":"hc-series:42"}`)), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d: %s", rec.Code, rec.Body.String())
+	}
+	link, err := seriesRepo.GetHardcoverLink(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link != nil {
+		t.Fatalf("provider failure should not persist a link, got %+v", link)
+	}
+}
+
+func TestSeriesDeleteHardcoverLinkRemovesStoredLink(t *testing.T) {
+	catalog := stormlightCatalog()
+	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, nil)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.DeleteHardcoverLink(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/series/1/hardcover-link", nil), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	link, err := seriesRepo.GetHardcoverLink(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link != nil {
+		t.Fatalf("expected link to be deleted, got %+v", link)
+	}
+}
+
+func TestSeriesHardcoverDiffEndpoint(t *testing.T) {
+	catalog := stormlightCatalog()
+	catalog.Books = append(catalog.Books,
+		metadata.SeriesCatalogBook{
+			ForeignID:  "hc:words-of-radiance",
+			ProviderID: "102",
+			Title:      "Words of Radiance",
+			Position:   "2",
+			Book: models.Book{
+				ForeignID: "hc:words-of-radiance",
+				Title:     "Words of Radiance",
+				Author:    catalog.Books[0].Book.Author,
+			},
+		},
+		metadata.SeriesCatalogBook{
+			ForeignID:  "hc:oathbringer",
+			ProviderID: "103",
+			Title:      "Oathbringer",
+			Position:   "3",
+			Book: models.Book{
+				ForeignID: "hc:oathbringer",
+				Title:     "Oathbringer",
+				Author:    catalog.Books[0].Book.Author,
+			},
+		},
+	)
+	catalog.BookCount = len(catalog.Books)
+	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, nil)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{ForeignID: "hc:brandon-sanderson", Name: "Brandon Sanderson", SortName: "Sanderson, Brandon"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	books := []struct {
+		foreignID string
+		title     string
+		position  string
+	}{
+		{foreignID: "hc:the-way-of-kings", title: "The Way of Kings", position: "1"},
+		{foreignID: "local:radiant-words", title: "Radiant Words", position: ""},
+		{foreignID: "local:unrelated", title: "Completely Different Local Book", position: ""},
+	}
+	for _, item := range books {
+		book := &models.Book{
+			ForeignID: item.foreignID,
+			AuthorID:  author.ID,
+			Title:     item.title,
+			SortTitle: item.title,
+			Status:    models.BookStatusWanted,
+			Genres:    []string{},
+		}
+		if err := bookRepo.Create(ctx, book); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := seriesRepo.LinkBookIfMissing(ctx, series.ID, book.ID, item.position, true); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	h.HardcoverDiff(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/series/1/hardcover-diff", nil), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got seriesHardcoverDiffResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Present) != 1 || got.Present[0].ForeignBookID != "hc:the-way-of-kings" {
+		t.Fatalf("present = %+v, want The Way of Kings", got.Present)
+	}
+	if len(got.Uncertain) != 1 || got.Uncertain[0].ForeignBookID != "hc:words-of-radiance" {
+		t.Fatalf("uncertain = %+v, want Words of Radiance", got.Uncertain)
+	}
+	if len(got.LocalOnly) != 1 || got.LocalOnly[0].LocalTitle != "Completely Different Local Book" {
+		t.Fatalf("localOnly = %+v, want unrelated local book", got.LocalOnly)
+	}
+	if len(got.Missing) != 1 || got.Missing[0].ForeignBookID != "hc:oathbringer" || got.PresentCount != 1 || got.MissingCount != 1 {
+		t.Fatalf("missing/counts = %+v present=%d missing=%d, want Oathbringer and counts 1/1", got.Missing, got.PresentCount, got.MissingCount)
+	}
+}
+
+func TestSeriesHardcoverDiffEndpointErrors(t *testing.T) {
+	catalog := stormlightCatalog()
+	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs:   map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+		catalogErr: errors.New("hardcover unavailable"),
+	}, nil)
+	ctx := contextBackground()
+	linked := &models.Series{ForeignID: "manual:series:linked", Title: "Linked"}
+	if err := seriesRepo.Create(ctx, linked); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+		SeriesID:            linked.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	unlinked := &models.Series{ForeignID: "manual:series:unlinked", Title: "Unlinked"}
+	if err := seriesRepo.Create(ctx, unlinked); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		id   string
+		code int
+	}{
+		{name: "missing series", id: "999", code: http.StatusNotFound},
+		{name: "missing link", id: strconv.FormatInt(unlinked.ID, 10), code: http.StatusNotFound},
+		{name: "provider failure", id: strconv.FormatInt(linked.ID, 10), code: http.StatusBadGateway},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.HardcoverDiff(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/series/1/hardcover-diff", nil), "id", tt.id))
+			if rec.Code != tt.code {
+				t.Fatalf("expected %d, got %d: %s", tt.code, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestSeriesFillSkipsHardcoverCatalogWhenFeatureDisabled(t *testing.T) {
 	catalog := stormlightCatalog()
 	provider := &stubSeriesProvider{

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -2,12 +2,16 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -20,7 +24,68 @@ func seriesFixture(t *testing.T) (*SeriesHandler, *db.SeriesRepo, *db.AuthorRepo
 	t.Cleanup(func() { database.Close() })
 	repo := db.NewSeriesRepo(database)
 	bookRepo := db.NewBookRepo(database)
-	return NewSeriesHandler(repo, bookRepo, &mockBookSearcher{}), repo, db.NewAuthorRepo(database), bookRepo
+	authorRepo := db.NewAuthorRepo(database)
+	return NewSeriesHandler(repo, bookRepo, authorRepo, nil, &mockBookSearcher{}), repo, authorRepo, bookRepo
+}
+
+type stubSeriesProvider struct {
+	searchResults []metadata.SeriesSearchResult
+	catalogs      map[string]*metadata.SeriesCatalog
+	searchErr     error
+	catalogErr    error
+}
+
+func (s *stubSeriesProvider) Name() string { return "stub" }
+
+func (s *stubSeriesProvider) SearchAuthors(context.Context, string) ([]models.Author, error) {
+	return nil, nil
+}
+
+func (s *stubSeriesProvider) SearchBooks(context.Context, string) ([]models.Book, error) {
+	return nil, nil
+}
+
+func (s *stubSeriesProvider) GetAuthor(context.Context, string) (*models.Author, error) {
+	return nil, nil
+}
+
+func (s *stubSeriesProvider) GetBook(context.Context, string) (*models.Book, error) {
+	return nil, nil
+}
+
+func (s *stubSeriesProvider) GetEditions(context.Context, string) ([]models.Edition, error) {
+	return nil, nil
+}
+
+func (s *stubSeriesProvider) GetBookByISBN(context.Context, string) (*models.Book, error) {
+	return nil, nil
+}
+
+func (s *stubSeriesProvider) SearchSeries(context.Context, string, int) ([]metadata.SeriesSearchResult, error) {
+	return s.searchResults, s.searchErr
+}
+
+func (s *stubSeriesProvider) GetSeriesCatalog(_ context.Context, foreignID string) (*metadata.SeriesCatalog, error) {
+	if s.catalogErr != nil {
+		return nil, s.catalogErr
+	}
+	return s.catalogs[foreignID], nil
+}
+
+func seriesFixtureWithProvider(t *testing.T, provider *stubSeriesProvider, searcher BookSearcher) (*SeriesHandler, *db.SeriesRepo, *db.AuthorRepo, *db.BookRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	seriesRepo := db.NewSeriesRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	if searcher == nil {
+		searcher = &mockBookSearcher{}
+	}
+	return NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metadata.NewAggregator(provider), searcher), seriesRepo, authorRepo, bookRepo
 }
 
 func TestSeriesList_Empty(t *testing.T) {
@@ -102,5 +167,316 @@ func TestSeriesListAndGet_WithData(t *testing.T) {
 	json.NewDecoder(rec.Body).Decode(&got)
 	if len(got.Books) != 1 || got.Books[0].BookID != book.ID {
 		t.Errorf("expected linked book in series, got %+v", got.Books)
+	}
+}
+
+func TestSeriesHardcoverSearch(t *testing.T) {
+	provider := &stubSeriesProvider{
+		searchResults: []metadata.SeriesSearchResult{{
+			ForeignID:    "hc-series:42",
+			ProviderID:   "42",
+			Title:        "The Stormlight Archive",
+			AuthorName:   "Brandon Sanderson",
+			BookCount:    10,
+			ReadersCount: 19323,
+			Books:        []string{"The Way of Kings", "Words of Radiance"},
+		}},
+		catalogs: map[string]*metadata.SeriesCatalog{},
+	}
+	h, _, _, _ := seriesFixtureWithProvider(t, provider, nil)
+
+	rec := httptest.NewRecorder()
+	h.SearchHardcover(rec, httptest.NewRequest(http.MethodGet, "/api/v1/series/hardcover/search?term=stormlight", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got []seriesHardcoverSearchResult
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ForeignID != "hc-series:42" || got[0].BookCount != 10 {
+		t.Fatalf("unexpected search results: %+v", got)
+	}
+}
+
+func TestSeriesHardcoverSearchNormalizesNilBooks(t *testing.T) {
+	provider := &stubSeriesProvider{
+		searchResults: []metadata.SeriesSearchResult{{
+			ForeignID:  "hc-series:42",
+			ProviderID: "42",
+			Title:      "The Stormlight Archive",
+		}},
+		catalogs: map[string]*metadata.SeriesCatalog{},
+	}
+	h, _, _, _ := seriesFixtureWithProvider(t, provider, nil)
+
+	rec := httptest.NewRecorder()
+	h.SearchHardcover(rec, httptest.NewRequest(http.MethodGet, "/api/v1/series/hardcover/search?term=stormlight", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got []seriesHardcoverSearchResult
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one search result, got %+v", got)
+	}
+	if got[0].Books == nil {
+		t.Fatalf("expected books to encode as an empty array, got nil")
+	}
+}
+
+func TestSeriesAutoLinkHardcoverPersistsTopCandidate(t *testing.T) {
+	catalog := stormlightCatalog()
+	provider := &stubSeriesProvider{
+		searchResults: []metadata.SeriesSearchResult{{
+			ForeignID:  catalog.ForeignID,
+			ProviderID: catalog.ProviderID,
+			Title:      catalog.Title,
+			AuthorName: catalog.AuthorName,
+			BookCount:  catalog.BookCount,
+		}},
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}
+	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, provider, nil)
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(contextBackground(), series); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.AutoLinkHardcover(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/hardcover-link/auto", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response seriesHardcoverAutoResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if !response.Linked || response.Link == nil || response.Link.HardcoverSeriesID != catalog.ForeignID {
+		t.Fatalf("expected persisted auto link, got %+v", response)
+	}
+}
+
+func TestSeriesAutoLinkHardcoverAmbiguousNoop(t *testing.T) {
+	catalogA := &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:42",
+		ProviderID: "42",
+		Title:      "Rhythm of War",
+		AuthorName: "Brandon Sanderson",
+		BookCount:  1,
+		Books:      []metadata.SeriesCatalogBook{},
+	}
+	catalogB := &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:99",
+		ProviderID: "99",
+		Title:      "Rhythm of War",
+		AuthorName: "Brandon Sanderson",
+		BookCount:  0,
+		Books:      []metadata.SeriesCatalogBook{},
+	}
+	provider := &stubSeriesProvider{
+		searchResults: []metadata.SeriesSearchResult{
+			{ForeignID: catalogA.ForeignID, ProviderID: catalogA.ProviderID, Title: catalogA.Title, AuthorName: catalogA.AuthorName, BookCount: catalogA.BookCount},
+			{ForeignID: catalogB.ForeignID, ProviderID: catalogB.ProviderID, Title: catalogB.Title, AuthorName: catalogB.AuthorName},
+		},
+		catalogs: map[string]*metadata.SeriesCatalog{
+			catalogA.ForeignID: catalogA,
+			catalogB.ForeignID: catalogB,
+		},
+	}
+	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, provider, nil)
+	series := &models.Series{ForeignID: "ol-series:rhythm", Title: "Rhythm of War"}
+	if err := seriesRepo.Create(contextBackground(), series); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.AutoLinkHardcover(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/hardcover-link/auto", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response seriesHardcoverAutoResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Linked {
+		t.Fatalf("ambiguous result should not persist, got %+v", response)
+	}
+	link, err := seriesRepo.GetHardcoverLink(contextBackground(), series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link != nil {
+		t.Fatalf("expected no link, got %+v", link)
+	}
+}
+
+func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
+	catalog := stormlightCatalog()
+	searcher := newMockBookSearcher()
+	h, seriesRepo, _, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, searcher)
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(contextBackground(), series); err != nil {
+		t.Fatal(err)
+	}
+	link := &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}
+	if err := seriesRepo.UpsertHardcoverLink(contextBackground(), link); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]int
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["queued"] != 1 {
+		t.Fatalf("expected one queued book, got %+v", body)
+	}
+	queued := searcher.waitForCall(t, time.Second)
+	if queued.Title != "The Way of Kings" {
+		t.Fatalf("unexpected queued book: %+v", queued)
+	}
+	created, err := bookRepo.GetByForeignID(contextBackground(), "hc:the-way-of-kings")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created == nil {
+		t.Fatal("expected Hardcover book to be created")
+	}
+	if created.MetadataProvider != "hardcover" {
+		t.Fatalf("expected metadata provider to be preserved, got %q", created.MetadataProvider)
+	}
+	if !created.AnyEditionOK {
+		t.Fatal("expected anyEditionOk to be preserved")
+	}
+	books, err := seriesRepo.ListBooksInSeries(contextBackground(), series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(books) != 1 || books[0].ForeignID != "hc:the-way-of-kings" {
+		t.Fatalf("expected created book linked to series, got %+v", books)
+	}
+}
+
+func TestSeriesFillQueuesLocalBooksWhenHardcoverCatalogFails(t *testing.T) {
+	catalog := stormlightCatalog()
+	searcher := newMockBookSearcher()
+	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs:   map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+		catalogErr: errors.New("hardcover unavailable"),
+	}, searcher)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	link := &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, link); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{
+		ForeignID:        "hc:brandon-sanderson",
+		Name:             "Brandon Sanderson",
+		SortName:         "Sanderson, Brandon",
+		MetadataProvider: "hardcover",
+		Monitored:        true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID:        "hc:words-of-radiance",
+		AuthorID:         author.ID,
+		Title:            "Words of Radiance",
+		SortTitle:        "Words of Radiance",
+		Status:           models.BookStatusSkipped,
+		Genres:           []string{},
+		MetadataProvider: "hardcover",
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seriesRepo.LinkBookIfMissing(ctx, series.ID, book.ID, "2", true); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]int
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["queued"] != 1 {
+		t.Fatalf("expected one local book queued despite provider failure, got %+v", body)
+	}
+	queued := searcher.waitForCall(t, time.Second)
+	if queued.ID != book.ID || queued.Title != "Words of Radiance" {
+		t.Fatalf("unexpected queued book: %+v", queued)
+	}
+	updated, err := bookRepo.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated == nil || updated.Status != models.BookStatusWanted || !updated.Monitored {
+		t.Fatalf("expected local book marked wanted and monitored, got %+v", updated)
+	}
+}
+
+func stormlightCatalog() *metadata.SeriesCatalog {
+	book := models.Book{
+		ForeignID:        "hc:the-way-of-kings",
+		Title:            "The Way of Kings",
+		SortTitle:        "The Way of Kings",
+		MetadataProvider: "hardcover",
+		Author: &models.Author{
+			ForeignID:        "hc:brandon-sanderson",
+			Name:             "Brandon Sanderson",
+			SortName:         "Sanderson, Brandon",
+			MetadataProvider: "hardcover",
+		},
+	}
+	return &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:42",
+		ProviderID: "42",
+		Title:      "The Stormlight Archive",
+		AuthorName: "Brandon Sanderson",
+		BookCount:  1,
+		Books: []metadata.SeriesCatalogBook{{
+			ForeignID:  book.ForeignID,
+			ProviderID: "101",
+			Title:      book.Title,
+			Position:   "1",
+			UsersCount: 123,
+			Book:       book,
+		}},
 	}
 }

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -190,6 +192,149 @@ func TestSeriesListAndGet_WithData(t *testing.T) {
 	json.NewDecoder(rec.Body).Decode(&got)
 	if len(got.Books) != 1 || got.Books[0].BookID != book.ID {
 		t.Errorf("expected linked book in series, got %+v", got.Books)
+	}
+}
+
+func TestSeriesCreateUpdateDeleteAndLink(t *testing.T) {
+	h, seriesRepo, authorRepo, bookRepo := seriesFixture(t)
+	ctx := contextBackground()
+
+	createBody := bytes.NewBufferString(`{"title":"  Dune Chronicles  "}`)
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/series", createBody))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created models.Series
+	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+	if created.ID == 0 || created.Title != "Dune Chronicles" || !strings.HasPrefix(created.ForeignID, "manual:series:") {
+		t.Fatalf("unexpected created series: %+v", created)
+	}
+
+	updateBody := bytes.NewBufferString(`{"title":"Dune Saga"}`)
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/api/v1/series/1", updateBody), "id", strconv.FormatInt(created.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var updated models.Series
+	if err := json.NewDecoder(rec.Body).Decode(&updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Title != "Dune Saga" {
+		t.Fatalf("updated title = %q, want Dune Saga", updated.Title)
+	}
+
+	author := &models.Author{ForeignID: "OL1A", Name: "Frank Herbert", SortName: "Herbert, Frank"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{ForeignID: "OL1W", AuthorID: author.ID, Title: "Dune", SortTitle: "Dune", Status: models.BookStatusImported}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	linkBody := bytes.NewBufferString(`{"bookId":` + strconv.FormatInt(book.ID, 10) + `,"positionInSeries":"1","primarySeries":true}`)
+	rec = httptest.NewRecorder()
+	h.AddBook(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/books", linkBody), "id", strconv.FormatInt(created.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("link: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var linked models.Series
+	if err := json.NewDecoder(rec.Body).Decode(&linked); err != nil {
+		t.Fatal(err)
+	}
+	if len(linked.Books) != 1 || linked.Books[0].BookID != book.ID || linked.Books[0].PositionInSeries != "1" {
+		t.Fatalf("expected linked book, got %+v", linked.Books)
+	}
+
+	linkBody = bytes.NewBufferString(`{"bookId":` + strconv.FormatInt(book.ID, 10) + `,"positionInSeries":"1.5","primarySeries":false}`)
+	rec = httptest.NewRecorder()
+	h.AddBook(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/books", linkBody), "id", strconv.FormatInt(created.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("relink: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got, err := seriesRepo.GetByID(ctx, created.ID); err != nil || got == nil || len(got.Books) != 1 || got.Books[0].PositionInSeries != "1.5" || got.Books[0].PrimarySeries {
+		t.Fatalf("expected upserted link, got series=%+v err=%v", got, err)
+	}
+
+	rec = httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/series/1", nil), "id", strconv.FormatInt(created.ID, 10)))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete: expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got, err := bookRepo.GetByID(ctx, book.ID); err != nil || got == nil {
+		t.Fatalf("delete series should preserve linked book, got book=%+v err=%v", got, err)
+	}
+	deleted, err := seriesRepo.GetByID(ctx, created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted != nil {
+		t.Fatalf("expected series to be deleted, got %+v", deleted)
+	}
+}
+
+func TestSeriesManagementInvalidInput(t *testing.T) {
+	h, seriesRepo, _, _ := seriesFixture(t)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "ol-series:dune", Title: "Dune Chronicles"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		run  func(*httptest.ResponseRecorder)
+		code int
+	}{
+		{
+			name: "create empty title",
+			run: func(rec *httptest.ResponseRecorder) {
+				h.Create(rec, httptest.NewRequest(http.MethodPost, "/api/v1/series", bytes.NewBufferString(`{"title":" "}`)))
+			},
+			code: http.StatusBadRequest,
+		},
+		{
+			name: "update missing series",
+			run: func(rec *httptest.ResponseRecorder) {
+				h.Update(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/api/v1/series/999", bytes.NewBufferString(`{"title":"New"}`)), "id", "999"))
+			},
+			code: http.StatusNotFound,
+		},
+		{
+			name: "delete missing series",
+			run: func(rec *httptest.ResponseRecorder) {
+				h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/series/999", nil), "id", "999"))
+			},
+			code: http.StatusNotFound,
+		},
+		{
+			name: "link missing book",
+			run: func(rec *httptest.ResponseRecorder) {
+				h.AddBook(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/books", bytes.NewBufferString(`{"bookId":999}`)), "id", strconv.FormatInt(series.ID, 10)))
+			},
+			code: http.StatusNotFound,
+		},
+		{
+			name: "link invalid book id",
+			run: func(rec *httptest.ResponseRecorder) {
+				h.AddBook(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/books", bytes.NewBufferString(`{"bookId":0}`)), "id", strconv.FormatInt(series.ID, 10)))
+			},
+			code: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			tt.run(rec)
+			if rec.Code != tt.code {
+				t.Fatalf("expected %d, got %d: %s", tt.code, rec.Code, rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -628,6 +628,86 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 	}
 }
 
+func TestSeriesFillCreatesOnlyRequestedHardcoverBook(t *testing.T) {
+	catalog := stormlightCatalog()
+	catalog.Books = append(catalog.Books, metadata.SeriesCatalogBook{
+		ForeignID:  "hc:words-of-radiance",
+		ProviderID: "102",
+		Title:      "Words of Radiance",
+		Position:   "2",
+		UsersCount: 456,
+		Book: models.Book{
+			ForeignID:        "hc:words-of-radiance",
+			Title:            "Words of Radiance",
+			SortTitle:        "Words of Radiance",
+			MetadataProvider: "hardcover",
+			Author:           catalog.Books[0].Book.Author,
+		},
+	})
+	catalog.BookCount = len(catalog.Books)
+	searcher := newMockBookSearcher()
+	h, seriesRepo, _, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, searcher)
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(contextBackground(), series); err != nil {
+		t.Fatal(err)
+	}
+	link := &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}
+	if err := seriesRepo.UpsertHardcoverLink(contextBackground(), link); err != nil {
+		t.Fatal(err)
+	}
+
+	body := bytes.NewBufferString(`{"foreignBookId":"hc:words-of-radiance","providerId":"102","position":"2"}`)
+	rec := httptest.NewRecorder()
+	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", body), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response map[string]int
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response["queued"] != 1 {
+		t.Fatalf("expected one queued book, got %+v", response)
+	}
+	queued := searcher.waitForCall(t, time.Second)
+	if queued.Title != "Words of Radiance" {
+		t.Fatalf("unexpected queued book: %+v", queued)
+	}
+	searcher.assertNoCall(t, 50*time.Millisecond)
+	created, err := bookRepo.GetByForeignID(contextBackground(), "hc:words-of-radiance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created == nil {
+		t.Fatal("expected requested Hardcover book to be created")
+	}
+	notCreated, err := bookRepo.GetByForeignID(contextBackground(), "hc:the-way-of-kings")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notCreated != nil {
+		t.Fatalf("expected unrequested Hardcover book to remain missing, got %+v", notCreated)
+	}
+	books, err := seriesRepo.ListBooksInSeries(contextBackground(), series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(books) != 1 || books[0].ForeignID != "hc:words-of-radiance" {
+		t.Fatalf("expected only requested book linked to series, got %+v", books)
+	}
+}
+
 func TestSeriesFillQueuesLocalBooksWhenHardcoverCatalogFails(t *testing.T) {
 	catalog := stormlightCatalog()
 	searcher := newMockBookSearcher()

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -1011,6 +1011,103 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 	}
 }
 
+func TestSeriesFillReusesCrossProviderAuthorAndExistingBook(t *testing.T) {
+	catalog := stormlightCatalog()
+	searcher := newMockBookSearcher()
+	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, searcher)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{
+		ForeignID:        "ol:brandon-sanderson",
+		Name:             "Brandon Sanderson",
+		SortName:         "Sanderson, Brandon",
+		MetadataProvider: "openlibrary",
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	linkedLocalBook := &models.Book{
+		ForeignID:        "ol:words-of-radiance",
+		AuthorID:         author.ID,
+		Title:            "Words of Radiance",
+		SortTitle:        "Words of Radiance",
+		Status:           models.BookStatusImported,
+		Genres:           []string{},
+		MetadataProvider: "openlibrary",
+	}
+	if err := bookRepo.Create(ctx, linkedLocalBook); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seriesRepo.LinkBookIfMissing(ctx, series.ID, linkedLocalBook.ID, "2", true); err != nil {
+		t.Fatal(err)
+	}
+	existingBook := &models.Book{
+		ForeignID:        "ol:the-way-of-kings",
+		AuthorID:         author.ID,
+		Title:            "The Way of Kings",
+		SortTitle:        "The Way of Kings",
+		Status:           models.BookStatusSkipped,
+		Genres:           []string{},
+		MetadataProvider: "openlibrary",
+	}
+	if err := bookRepo.Create(ctx, existingBook); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", nil), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response map[string]int
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response["queued"] != 1 {
+		t.Fatalf("expected one queued existing book, got %+v", response)
+	}
+	queued := searcher.waitForCall(t, time.Second)
+	if queued.ID != existingBook.ID {
+		t.Fatalf("expected existing cross-provider book to be queued, got %+v", queued)
+	}
+	if hcAuthor, err := authorRepo.GetByForeignID(ctx, "hc:brandon-sanderson"); err != nil || hcAuthor != nil {
+		t.Fatalf("expected no duplicate Hardcover author, got author=%+v err=%v", hcAuthor, err)
+	}
+	if duplicate, err := bookRepo.GetByForeignID(ctx, "hc:the-way-of-kings"); err != nil || duplicate != nil {
+		t.Fatalf("expected no duplicate Hardcover book, got book=%+v err=%v", duplicate, err)
+	}
+	books, err := seriesRepo.ListBooksInSeries(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundExisting := false
+	for _, book := range books {
+		if book.ID == existingBook.ID {
+			foundExisting = true
+		}
+	}
+	if !foundExisting {
+		t.Fatalf("expected existing book linked to series, got %+v", books)
+	}
+}
+
 func TestSeriesFillSkipsExcludedHardcoverForeignIDMatch(t *testing.T) {
 	catalog := stormlightCatalog()
 	searcher := newMockBookSearcher()
@@ -1161,6 +1258,162 @@ func TestSeriesFillSkipsExcludedHardcoverTitleMatch(t *testing.T) {
 	}
 	if len(books) != 0 {
 		t.Fatalf("expected excluded title match to remain unlinked, got %+v", books)
+	}
+}
+
+func TestSeriesFillSkipsExcludedCrossProviderTitleMatch(t *testing.T) {
+	catalog := stormlightCatalog()
+	catalog.Books[0].ForeignID = "hc:the-way-of-kings-new"
+	catalog.Books[0].Book.ForeignID = "hc:the-way-of-kings-new"
+	searcher := newMockBookSearcher()
+	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, searcher)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{
+		ForeignID:        "ol:brandon-sanderson",
+		Name:             "Brandon Sanderson",
+		SortName:         "Sanderson, Brandon",
+		MetadataProvider: "openlibrary",
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	linkedLocalBook := &models.Book{
+		ForeignID:        "ol:words-of-radiance",
+		AuthorID:         author.ID,
+		Title:            "Words of Radiance",
+		SortTitle:        "Words of Radiance",
+		Status:           models.BookStatusImported,
+		Genres:           []string{},
+		MetadataProvider: "openlibrary",
+	}
+	if err := bookRepo.Create(ctx, linkedLocalBook); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seriesRepo.LinkBookIfMissing(ctx, series.ID, linkedLocalBook.ID, "2", true); err != nil {
+		t.Fatal(err)
+	}
+	excludedBook := &models.Book{
+		ForeignID:        "ol:the-way-of-kings",
+		AuthorID:         author.ID,
+		Title:            "The Way of Kings",
+		SortTitle:        "The Way of Kings",
+		Status:           models.BookStatusSkipped,
+		Genres:           []string{},
+		MetadataProvider: "openlibrary",
+	}
+	if err := bookRepo.Create(ctx, excludedBook); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.SetExcluded(ctx, excludedBook.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", nil), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response map[string]int
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response["queued"] != 0 {
+		t.Fatalf("expected no queued excluded book, got %+v", response)
+	}
+	searcher.assertNoCall(t, 50*time.Millisecond)
+	if hcAuthor, err := authorRepo.GetByForeignID(ctx, "hc:brandon-sanderson"); err != nil || hcAuthor != nil {
+		t.Fatalf("expected no duplicate Hardcover author, got author=%+v err=%v", hcAuthor, err)
+	}
+	if created, err := bookRepo.GetByForeignID(ctx, "hc:the-way-of-kings-new"); err != nil || created != nil {
+		t.Fatalf("expected no duplicate Hardcover book, got book=%+v err=%v", created, err)
+	}
+	books, err := seriesRepo.ListBooksInSeries(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(books) != 1 || books[0].ID != linkedLocalBook.ID {
+		t.Fatalf("expected only existing local series book to remain linked, got %+v", books)
+	}
+}
+
+func TestSeriesFillSkipsAmbiguousCrossProviderAuthorMatch(t *testing.T) {
+	catalog := stormlightCatalog()
+	searcher := newMockBookSearcher()
+	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, searcher)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, foreignID := range []string{"ol:brandon-sanderson", "manual:brandon-sanderson"} {
+		author := &models.Author{
+			ForeignID:        foreignID,
+			Name:             "Brandon Sanderson",
+			SortName:         "Sanderson, Brandon",
+			MetadataProvider: "manual",
+		}
+		if err := authorRepo.Create(ctx, author); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", nil), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response map[string]int
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response["queued"] != 0 {
+		t.Fatalf("expected no queued ambiguous author match, got %+v", response)
+	}
+	searcher.assertNoCall(t, 50*time.Millisecond)
+	if hcAuthor, err := authorRepo.GetByForeignID(ctx, "hc:brandon-sanderson"); err != nil || hcAuthor != nil {
+		t.Fatalf("expected no duplicate Hardcover author, got author=%+v err=%v", hcAuthor, err)
+	}
+	if created, err := bookRepo.GetByForeignID(ctx, "hc:the-way-of-kings"); err != nil || created != nil {
+		t.Fatalf("expected no Hardcover book creation, got book=%+v err=%v", created, err)
+	}
+	books, err := seriesRepo.ListBooksInSeries(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(books) != 0 {
+		t.Fatalf("expected no series links, got %+v", books)
 	}
 }
 

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -421,14 +421,39 @@ func TestSeriesAutoLinkHardcoverPersistsTopCandidate(t *testing.T) {
 		}},
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}
-	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, provider, nil)
+	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, provider, nil)
+	ctx := contextBackground()
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
-	if err := seriesRepo.Create(contextBackground(), series); err != nil {
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{
+		ForeignID:        "hc:brandon-sanderson",
+		Name:             "Brandon Sanderson",
+		SortName:         "Sanderson, Brandon",
+		MetadataProvider: "hardcover",
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID:        "hc:the-way-of-kings",
+		AuthorID:         author.ID,
+		Title:            "The Way of Kings",
+		SortTitle:        "The Way of Kings",
+		Status:           models.BookStatusWanted,
+		Genres:           []string{},
+		MetadataProvider: "hardcover",
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seriesRepo.LinkBookIfMissing(ctx, series.ID, book.ID, "1", true); err != nil {
 		t.Fatal(err)
 	}
 
 	rec := httptest.NewRecorder()
-	h.AutoLinkHardcover(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/hardcover-link/auto", nil), "id", "1"))
+	h.AutoLinkHardcover(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/hardcover-link/auto", nil), "id", strconv.FormatInt(series.ID, 10)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
@@ -438,6 +463,85 @@ func TestSeriesAutoLinkHardcoverPersistsTopCandidate(t *testing.T) {
 	}
 	if !response.Linked || response.Link == nil || response.Link.HardcoverSeriesID != catalog.ForeignID {
 		t.Fatalf("expected persisted auto link, got %+v", response)
+	}
+}
+
+func TestSeriesAutoLinkHardcoverRejectsExactTitleWrongAuthorWithoutOverlap(t *testing.T) {
+	catalog := &metadata.SeriesCatalog{
+		ForeignID:  "hc-series:wrong-author",
+		ProviderID: "wrong-author",
+		Title:      "Shared Series Title",
+		AuthorName: "Wrong Author",
+		BookCount:  1,
+		Books: []metadata.SeriesCatalogBook{{
+			ForeignID: "hc:unrelated-book",
+			Title:     "Unrelated Book",
+			Position:  "1",
+			Book:      models.Book{ForeignID: "hc:unrelated-book", Title: "Unrelated Book", Author: &models.Author{Name: "Wrong Author"}},
+		}},
+	}
+	provider := &stubSeriesProvider{
+		searchResults: []metadata.SeriesSearchResult{{
+			ForeignID:  catalog.ForeignID,
+			ProviderID: catalog.ProviderID,
+			Title:      catalog.Title,
+			AuthorName: catalog.AuthorName,
+			BookCount:  catalog.BookCount,
+		}},
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}
+	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, provider, nil)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "ol-series:shared", Title: "Shared Series Title"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{
+		ForeignID:        "hc:right-author",
+		Name:             "Right Author",
+		SortName:         "Author, Right",
+		MetadataProvider: "hardcover",
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID:        "hc:right-book",
+		AuthorID:         author.ID,
+		Title:            "Right Book",
+		SortTitle:        "Right Book",
+		Status:           models.BookStatusWanted,
+		Genres:           []string{},
+		MetadataProvider: "hardcover",
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := seriesRepo.LinkBookIfMissing(ctx, series.ID, book.ID, "1", true); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.AutoLinkHardcover(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/hardcover-link/auto", nil), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response seriesHardcoverAutoResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Linked {
+		t.Fatalf("wrong-author exact-title result should not persist, got %+v", response)
+	}
+	if len(response.Candidates) != 1 || response.Candidates[0].Confidence >= autoHardcoverLinkMinConfidence {
+		t.Fatalf("candidate confidence = %+v, want capped below auto-link threshold", response.Candidates)
+	}
+	link, err := seriesRepo.GetHardcoverLink(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link != nil {
+		t.Fatalf("expected no Hardcover link, got %+v", link)
 	}
 }
 
@@ -625,6 +729,159 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 	}
 	if len(books) != 1 || books[0].ForeignID != "hc:the-way-of-kings" {
 		t.Fatalf("expected created book linked to series, got %+v", books)
+	}
+}
+
+func TestSeriesFillSkipsExcludedHardcoverForeignIDMatch(t *testing.T) {
+	catalog := stormlightCatalog()
+	searcher := newMockBookSearcher()
+	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, searcher)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	link := &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, link); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{
+		ForeignID:        "hc:brandon-sanderson",
+		Name:             "Brandon Sanderson",
+		SortName:         "Sanderson, Brandon",
+		MetadataProvider: "hardcover",
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID:        "hc:the-way-of-kings",
+		AuthorID:         author.ID,
+		Title:            "The Way of Kings",
+		SortTitle:        "The Way of Kings",
+		Status:           models.BookStatusSkipped,
+		Genres:           []string{},
+		MetadataProvider: "hardcover",
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.SetExcluded(ctx, book.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	body := bytes.NewBufferString(`{"foreignBookId":"hc:the-way-of-kings","providerId":"101","position":"1"}`)
+	rec := httptest.NewRecorder()
+	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", body), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response map[string]int
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response["queued"] != 0 {
+		t.Fatalf("expected no queued excluded book, got %+v", response)
+	}
+	searcher.assertNoCall(t, 50*time.Millisecond)
+	books, err := seriesRepo.ListBooksInSeries(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(books) != 0 {
+		t.Fatalf("expected excluded foreign-id match to remain unlinked, got %+v", books)
+	}
+}
+
+func TestSeriesFillSkipsExcludedHardcoverTitleMatch(t *testing.T) {
+	catalog := stormlightCatalog()
+	catalog.Books[0].ForeignID = "hc:the-way-of-kings-new"
+	catalog.Books[0].Book.ForeignID = "hc:the-way-of-kings-new"
+	searcher := newMockBookSearcher()
+	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, searcher)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	link := &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, link); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{
+		ForeignID:        "hc:brandon-sanderson",
+		Name:             "Brandon Sanderson",
+		SortName:         "Sanderson, Brandon",
+		MetadataProvider: "hardcover",
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID:        "manual:excluded-way-of-kings",
+		AuthorID:         author.ID,
+		Title:            "The Way of Kings",
+		SortTitle:        "The Way of Kings",
+		Status:           models.BookStatusSkipped,
+		Genres:           []string{},
+		MetadataProvider: "manual",
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.SetExcluded(ctx, book.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	body := bytes.NewBufferString(`{"foreignBookId":"hc:the-way-of-kings-new","providerId":"101","position":"1"}`)
+	rec := httptest.NewRecorder()
+	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", body), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response map[string]int
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response["queued"] != 0 {
+		t.Fatalf("expected no queued excluded title match, got %+v", response)
+	}
+	searcher.assertNoCall(t, 50*time.Millisecond)
+	created, err := bookRepo.GetByForeignID(ctx, "hc:the-way-of-kings-new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created != nil {
+		t.Fatalf("expected excluded title match to block duplicate creation, got %+v", created)
+	}
+	books, err := seriesRepo.ListBooksInSeries(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(books) != 0 {
+		t.Fatalf("expected excluded title match to remain unlinked, got %+v", books)
 	}
 }
 

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -41,10 +41,14 @@ func NewSettingsHandler(settings *db.SettingsRepo) *SettingsHandler {
 // values are surfaced through the dedicated /auth/* endpoints instead.
 func isSecretSetting(key string) bool {
 	switch key {
-	case "auth.api_key", "auth.session_secret", "auth.mode", SettingABSAPIKey:
+	case "auth.api_key", "auth.session_secret", "auth.mode", SettingABSAPIKey, SettingHardcoverAPIToken:
 		return true
 	}
 	return false
+}
+
+func isWritableSecretSetting(key string) bool {
+	return key == SettingHardcoverAPIToken
 }
 
 func (h *SettingsHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -82,7 +86,7 @@ func (h *SettingsHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 func (h *SettingsHandler) Set(w http.ResponseWriter, r *http.Request) {
 	key := chi.URLParam(r, "key")
-	if isSecretSetting(key) {
+	if isSecretSetting(key) && !isWritableSecretSetting(key) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "use /auth/* endpoints for auth settings"})
 		return
 	}
@@ -93,20 +97,32 @@ func (h *SettingsHandler) Set(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 		return
 	}
-	if err := validateSettingValue(key, req.Value); err != nil {
+	value := normalizeSettingValue(key, req.Value)
+	if err := validateSettingValue(key, value); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
-	if err := h.settings.Set(r.Context(), key, req.Value); err != nil {
+	if err := h.settings.Set(r.Context(), key, value); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if isSecretSetting(key) {
+		writeJSON(w, http.StatusOK, map[string]string{"key": key, "value": ""})
 		return
 	}
 	s, err := h.settings.Get(r.Context(), key)
 	if err != nil || s == nil {
-		writeJSON(w, http.StatusOK, map[string]string{"key": key, "value": req.Value})
+		writeJSON(w, http.StatusOK, map[string]string{"key": key, "value": value})
 		return
 	}
 	writeJSON(w, http.StatusOK, s)
+}
+
+func normalizeSettingValue(key, value string) string {
+	if key == SettingHardcoverAPIToken {
+		return strings.TrimSpace(value)
+	}
+	return value
 }
 
 // validateSettingValue enforces per-key invariants on writes. We run this
@@ -116,6 +132,19 @@ func (h *SettingsHandler) Set(w http.ResponseWriter, r *http.Request) {
 // unchanged — the settings table stays schema-less for anything else.
 func validateSettingValue(key, value string) error {
 	switch key {
+	case SettingHardcoverAPIToken:
+		for _, r := range value {
+			if r < 0x20 || r == 0x7f {
+				return fmt.Errorf("hardcover.api_token contains invalid control characters")
+			}
+		}
+	case SettingHardcoverEnhancedSeriesEnabled:
+		if value == "" {
+			return nil
+		}
+		if !strings.EqualFold(value, "true") && !strings.EqualFold(value, "false") {
+			return fmt.Errorf("hardcover.enhanced_series_enabled %q is not one of: true, false", value)
+		}
 	case SettingCalibreLibraryPath:
 		// Empty = disabled / unset; reject only when the caller provided
 		// a non-empty string that doesn't resolve to an existing dir.

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -8,11 +9,13 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/vavallee/bindery/internal/abs"
 	"github.com/vavallee/bindery/internal/calibre"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata/hardcover"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -120,9 +123,68 @@ func (h *SettingsHandler) Set(w http.ResponseWriter, r *http.Request) {
 
 func normalizeSettingValue(key, value string) string {
 	if key == SettingHardcoverAPIToken {
-		return strings.TrimSpace(value)
+		return hardcover.NormalizeAPIToken(value)
 	}
 	return value
+}
+
+type HardcoverTestResponse struct {
+	OK               bool   `json:"ok"`
+	TokenConfigured  bool   `json:"tokenConfigured"`
+	SearchResults    int    `json:"searchResults"`
+	SampleSeriesID   string `json:"sampleSeriesId,omitempty"`
+	SampleTitle      string `json:"sampleTitle,omitempty"`
+	CatalogOK        bool   `json:"catalogOk"`
+	CatalogBookCount int    `json:"catalogBookCount,omitempty"`
+	Message          string `json:"message,omitempty"`
+	Error            string `json:"error,omitempty"`
+}
+
+func (h *SettingsHandler) TestHardcover(w http.ResponseWriter, r *http.Request) {
+	token := GetHardcoverAPIToken(r.Context(), h.settings)
+	result := HardcoverTestResponse{TokenConfigured: token != ""}
+	if token == "" {
+		result.Error = "hardcover API token is not configured"
+		writeJSON(w, http.StatusOK, result)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	client := hardcover.New().WithToken(token)
+	series, err := client.SearchSeries(ctx, "Dune", 3)
+	if err != nil {
+		result.Error = err.Error()
+		writeJSON(w, http.StatusOK, result)
+		return
+	}
+	result.SearchResults = len(series)
+	if len(series) == 0 {
+		result.Error = "Hardcover search returned no series for Dune"
+		writeJSON(w, http.StatusOK, result)
+		return
+	}
+
+	result.SampleSeriesID = series[0].ForeignID
+	result.SampleTitle = series[0].Title
+	catalog, err := client.GetSeriesCatalog(ctx, series[0].ForeignID)
+	if err != nil {
+		result.Error = err.Error()
+		writeJSON(w, http.StatusOK, result)
+		return
+	}
+	if catalog == nil {
+		result.Error = "Hardcover catalog lookup returned no series"
+		writeJSON(w, http.StatusOK, result)
+		return
+	}
+
+	result.CatalogOK = true
+	result.CatalogBookCount = len(catalog.Books)
+	result.OK = true
+	result.Message = fmt.Sprintf("Found %d series; catalog %q has %d books", result.SearchResults, catalog.Title, len(catalog.Books))
+	writeJSON(w, http.StatusOK, result)
 }
 
 // validateSettingValue enforces per-key invariants on writes. We run this

--- a/internal/api/settings_handler_test.go
+++ b/internal/api/settings_handler_test.go
@@ -42,6 +42,7 @@ func TestSettings_ListFiltersSecrets(t *testing.T) {
 		"auth.session_secret": "supersecret-hmac",
 		"auth.mode":           "enabled",
 		"abs.api_key":         "supersecret-abs",
+		"hardcover.api_token": "supersecret-hardcover",
 		"ui.theme":            "dark",
 		"importer.library":    "/books",
 	} {
@@ -60,7 +61,7 @@ func TestSettings_ListFiltersSecrets(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, s := range got {
-		if s.Key == "auth.api_key" || s.Key == "auth.session_secret" || s.Key == "auth.mode" || s.Key == "abs.api_key" {
+		if s.Key == "auth.api_key" || s.Key == "auth.session_secret" || s.Key == "auth.mode" || s.Key == "abs.api_key" || s.Key == "hardcover.api_token" {
 			t.Errorf("secret leaked through List: %s", s.Key)
 		}
 	}
@@ -191,6 +192,60 @@ func TestSettings_GetABSSecretReturns404(t *testing.T) {
 	h.Get(rec, req)
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected 404 for ABS secret Get, got %d", rec.Code)
+	}
+}
+
+func TestSettings_SetHardcoverTokenIsWriteOnly(t *testing.T) {
+	h, repo, ctx := settingsFixture(t)
+	req := withKey(httptest.NewRequest(http.MethodPut, "/api/v1/settings/"+SettingHardcoverAPIToken, bytes.NewBufferString(`{"value":"  hc-secret  "}`)), SettingHardcoverAPIToken)
+	rec := httptest.NewRecorder()
+	h.Set(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte("hc-secret")) {
+		t.Fatalf("hardcover token leaked through Set response: %s", rec.Body.String())
+	}
+	got, _ := repo.Get(ctx, SettingHardcoverAPIToken)
+	if got == nil || got.Value != "hc-secret" {
+		t.Fatalf("expected trimmed token persisted, got %+v", got)
+	}
+
+	getReq := withKey(httptest.NewRequest(http.MethodGet, "/api/v1/settings/"+SettingHardcoverAPIToken, nil), SettingHardcoverAPIToken)
+	getRec := httptest.NewRecorder()
+	h.Get(getRec, getReq)
+	if getRec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for Hardcover token Get, got %d", getRec.Code)
+	}
+}
+
+func TestHardcoverFeatureState(t *testing.T) {
+	_, repo, ctx := settingsFixture(t)
+
+	state := HardcoverFeatureStateFor(ctx, repo, false)
+	if state.EnhancedHardcoverAPI || state.EnhancedHardcoverDisabledReason != HardcoverDisabledReasonEnvDisabled {
+		t.Fatalf("env disabled state = %+v", state)
+	}
+
+	state = HardcoverFeatureStateFor(ctx, repo, true)
+	if state.EnhancedHardcoverAPI || state.EnhancedHardcoverDisabledReason != HardcoverDisabledReasonMissingToken {
+		t.Fatalf("missing token state = %+v", state)
+	}
+
+	if err := repo.Set(ctx, SettingHardcoverAPIToken, "hc-secret"); err != nil {
+		t.Fatal(err)
+	}
+	state = HardcoverFeatureStateFor(ctx, repo, true)
+	if state.EnhancedHardcoverAPI || !state.HardcoverTokenConfigured || state.EnhancedHardcoverDisabledReason != HardcoverDisabledReasonAdminDisabled {
+		t.Fatalf("admin disabled state = %+v", state)
+	}
+
+	if err := repo.Set(ctx, SettingHardcoverEnhancedSeriesEnabled, "true"); err != nil {
+		t.Fatal(err)
+	}
+	state = HardcoverFeatureStateFor(ctx, repo, true)
+	if !state.EnhancedHardcoverAPI || !state.HardcoverTokenConfigured || state.EnhancedHardcoverDisabledReason != "" {
+		t.Fatalf("enabled state = %+v", state)
 	}
 }
 

--- a/internal/api/settings_handler_test.go
+++ b/internal/api/settings_handler_test.go
@@ -197,7 +197,7 @@ func TestSettings_GetABSSecretReturns404(t *testing.T) {
 
 func TestSettings_SetHardcoverTokenIsWriteOnly(t *testing.T) {
 	h, repo, ctx := settingsFixture(t)
-	req := withKey(httptest.NewRequest(http.MethodPut, "/api/v1/settings/"+SettingHardcoverAPIToken, bytes.NewBufferString(`{"value":"  hc-secret  "}`)), SettingHardcoverAPIToken)
+	req := withKey(httptest.NewRequest(http.MethodPut, "/api/v1/settings/"+SettingHardcoverAPIToken, bytes.NewBufferString(`{"value":"  Authorization: Bearer Bearer hc-secret  "}`)), SettingHardcoverAPIToken)
 	rec := httptest.NewRecorder()
 	h.Set(rec, req)
 	if rec.Code != http.StatusOK {
@@ -208,7 +208,7 @@ func TestSettings_SetHardcoverTokenIsWriteOnly(t *testing.T) {
 	}
 	got, _ := repo.Get(ctx, SettingHardcoverAPIToken)
 	if got == nil || got.Value != "hc-secret" {
-		t.Fatalf("expected trimmed token persisted, got %+v", got)
+		t.Fatalf("expected normalized token persisted, got %+v", got)
 	}
 
 	getReq := withKey(httptest.NewRequest(http.MethodGet, "/api/v1/settings/"+SettingHardcoverAPIToken, nil), SettingHardcoverAPIToken)
@@ -216,6 +216,32 @@ func TestSettings_SetHardcoverTokenIsWriteOnly(t *testing.T) {
 	h.Get(getRec, getReq)
 	if getRec.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for Hardcover token Get, got %d", getRec.Code)
+	}
+}
+
+func TestGetHardcoverAPITokenNormalizesLegacyStoredValue(t *testing.T) {
+	_, repo, ctx := settingsFixture(t)
+	if err := repo.Set(ctx, SettingHardcoverAPIToken, "Authorization: Bearer hc-secret"); err != nil {
+		t.Fatal(err)
+	}
+	if got := GetHardcoverAPIToken(ctx, repo); got != "hc-secret" {
+		t.Fatalf("GetHardcoverAPIToken = %q, want hc-secret", got)
+	}
+}
+
+func TestSettings_TestHardcoverReportsMissingToken(t *testing.T) {
+	h, _, _ := settingsFixture(t)
+	rec := httptest.NewRecorder()
+	h.TestHardcover(rec, httptest.NewRequest(http.MethodPost, "/api/v1/hardcover/test", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got HardcoverTestResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.OK || got.TokenConfigured || got.Error == "" {
+		t.Fatalf("unexpected response: %+v", got)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,9 @@ type Config struct {
 	LibraryDir        string
 	AudiobookDir      string
 	ABSFeatureEnabled bool
-	DownloadPathRemap string
+	// Enhanced Hardcover series API (BINDERY_ENHANCED_HARDCOVER_API, default false).
+	EnhancedHardcoverAPI bool
+	DownloadPathRemap    string
 	// Proxy SSO settings (Phase 1).
 	ProxyAuthHeader    string // BINDERY_PROXY_AUTH_HEADER
 	ProxyAutoProvision bool   // BINDERY_PROXY_AUTO_PROVISION
@@ -57,6 +59,7 @@ func Load() *Config {
 		LibraryDir:             envOr("BINDERY_LIBRARY_DIR", "/books"),
 		AudiobookDir:           envOr("BINDERY_AUDIOBOOK_DIR", ""),
 		ABSFeatureEnabled:      envBool("BINDERY_ABS_ENABLED", false),
+		EnhancedHardcoverAPI:   envBool("BINDERY_ENHANCED_HARDCOVER_API", false),
 		DownloadPathRemap:      envOr("BINDERY_DOWNLOAD_PATH_REMAP", ""),
 		ProxyAuthHeader:        envOr("BINDERY_PROXY_AUTH_HEADER", "X-Forwarded-User"),
 		ProxyAutoProvision:     envBool("BINDERY_PROXY_AUTO_PROVISION", true),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,6 +21,9 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.ABSFeatureEnabled {
 		t.Error("expected ABS feature flag to default to disabled")
 	}
+	if cfg.EnhancedHardcoverAPI {
+		t.Error("expected enhanced Hardcover API to default to disabled")
+	}
 
 	// DBPath/DataDir are platform-dependent as of #7. CI runs on linux so
 	// here we only assert the linux invariant; per-platform coverage lives
@@ -39,6 +42,7 @@ func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("BINDERY_PORT", "9999")
 	t.Setenv("BINDERY_LOG_LEVEL", "debug")
 	t.Setenv("BINDERY_ABS_ENABLED", "true")
+	t.Setenv("BINDERY_ENHANCED_HARDCOVER_API", "true")
 
 	cfg := Load()
 
@@ -50,6 +54,9 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if !cfg.ABSFeatureEnabled {
 		t.Error("expected ABS feature flag to respect BINDERY_ABS_ENABLED=true")
+	}
+	if !cfg.EnhancedHardcoverAPI {
+		t.Error("expected enhanced Hardcover API to respect BINDERY_ENHANCED_HARDCOVER_API=true")
 	}
 }
 

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -167,6 +167,19 @@ func (r *BookRepo) Update(ctx context.Context, b *models.Book) error {
 	return nil
 }
 
+// MarkWantedMonitored updates only the fields needed to queue a book for
+// searching, preserving metadata that may not be present on sparse callers.
+func (r *BookRepo) MarkWantedMonitored(ctx context.Context, id int64) error {
+	now := time.Now().UTC()
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE books SET status = ?, monitored = 1, updated_at = ? WHERE id = ?`,
+		models.BookStatusWanted, now, id)
+	if err != nil {
+		return fmt.Errorf("mark book %d wanted: %w", id, err)
+	}
+	return nil
+}
+
 // AddBookFile records a new on-disk file in book_files and refreshes the
 // book's aggregate status. Multiple files for the same format are all tracked
 // (e.g. epub + mobi + pdf from a multi-file download).

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -56,7 +56,7 @@ func TestOpenMemory(t *testing.T) {
 	// Verify tables exist
 	tables := []string{"authors", "books", "series", "editions", "indexers",
 		"download_clients", "downloads", "root_folders", "quality_profiles",
-		"settings", "history", "abs_import_runs", "abs_provenance", "abs_metadata_conflicts", "schema_migrations"}
+		"settings", "history", "abs_import_runs", "abs_provenance", "abs_metadata_conflicts", "series_hardcover_links", "schema_migrations"}
 	for _, table := range tables {
 		var name string
 		err := db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name=?", table).Scan(&name)
@@ -115,7 +115,8 @@ func TestMigrate033ABSReviewResolutionIdempotent(t *testing.T) {
 		t.Fatalf("seed abs review queue row: %v", err)
 	}
 
-	if _, err := database.Exec(`DELETE FROM schema_migrations WHERE version = 33`); err != nil {
+	version := migrationVersionForTest(t, "033_abs_review_resolution.sql")
+	if _, err := database.Exec(`DELETE FROM schema_migrations WHERE version = ?`, version); err != nil {
 		t.Fatalf("clear migration 033 marker: %v", err)
 	}
 	if err := migrate(database); err != nil {
@@ -134,6 +135,21 @@ func TestMigrate033ABSReviewResolutionIdempotent(t *testing.T) {
 	if authorID != "author-1" || bookID != "book-1" || editedTitle != "Edited Title" {
 		t.Fatalf("resolution fields changed after rerun: author=%q book=%q edited=%q", authorID, bookID, editedTitle)
 	}
+}
+
+func migrationVersionForTest(t *testing.T, filename string) int {
+	t.Helper()
+	entries, err := migrationsFS.ReadDir("migrations")
+	if err != nil {
+		t.Fatalf("read migrations: %v", err)
+	}
+	for i, entry := range entries {
+		if entry.Name() == filename {
+			return i + 1
+		}
+	}
+	t.Fatalf("migration %s not found", filename)
+	return 0
 }
 
 // TestMigrate008_CalibreOnFreshDB verifies the v0.8.0 Calibre migration

--- a/internal/db/migrations/035_series_hardcover_links.sql
+++ b/internal/db/migrations/035_series_hardcover_links.sql
@@ -1,0 +1,47 @@
+-- +migrate Up
+
+CREATE TABLE IF NOT EXISTS series_hardcover_links (
+    id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+    series_id              INTEGER NOT NULL UNIQUE REFERENCES series(id) ON DELETE CASCADE,
+    hardcover_series_id    TEXT    NOT NULL,
+    hardcover_provider_id  TEXT    NOT NULL DEFAULT '',
+    hardcover_title        TEXT    NOT NULL DEFAULT '',
+    hardcover_author_name  TEXT    NOT NULL DEFAULT '',
+    hardcover_book_count   INTEGER NOT NULL DEFAULT 0,
+    link_confidence        REAL    NOT NULL DEFAULT 0,
+    linked_by              TEXT    NOT NULL DEFAULT 'auto',
+    linked_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at             DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at             DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_series_hardcover_links_series_id ON series_hardcover_links(series_id);
+CREATE INDEX IF NOT EXISTS idx_series_hardcover_links_hardcover_series_id ON series_hardcover_links(hardcover_series_id);
+
+INSERT OR IGNORE INTO series_hardcover_links (
+    series_id,
+    hardcover_series_id,
+    hardcover_provider_id,
+    hardcover_title,
+    link_confidence,
+    linked_by,
+    linked_at,
+    created_at,
+    updated_at
+)
+SELECT
+    id,
+    foreign_id,
+    REPLACE(foreign_id, 'hc-series:', ''),
+    title,
+    0.8,
+    'auto',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+FROM series
+WHERE foreign_id LIKE 'hc-series:%';
+
+-- +migrate Down
+
+DROP TABLE IF EXISTS series_hardcover_links;

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -138,6 +138,7 @@ func (r *SeriesRepo) hydrateHardcoverLinks(ctx context.Context, series []models.
 		placeholders = append(placeholders, "?")
 		args = append(args, s.ID)
 	}
+	//nolint:gosec // placeholders are generated from in-memory series IDs and values are still parameterized
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, series_id, hardcover_series_id, hardcover_provider_id, hardcover_title,
 		       hardcover_author_name, hardcover_book_count, link_confidence, linked_by,

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -138,13 +138,13 @@ func (r *SeriesRepo) hydrateHardcoverLinks(ctx context.Context, series []models.
 		placeholders = append(placeholders, "?")
 		args = append(args, s.ID)
 	}
-	//nolint:gosec // placeholders are generated from in-memory series IDs and values are still parameterized
-	rows, err := r.db.QueryContext(ctx, `
+	query := `
 		SELECT id, series_id, hardcover_series_id, hardcover_provider_id, hardcover_title,
 		       hardcover_author_name, hardcover_book_count, link_confidence, linked_by,
 		       linked_at, created_at, updated_at
 		FROM series_hardcover_links
-		WHERE series_id IN (`+strings.Join(placeholders, ",")+`)`, args...)
+		WHERE series_id IN (` + strings.Join(placeholders, ",") + `)` // #nosec G202 -- placeholders are generated from fixed ? tokens; series IDs remain bound args
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("list series hardcover links: %w", err)
 	}

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -36,7 +37,13 @@ func (r *SeriesRepo) List(ctx context.Context) ([]models.Series, error) {
 		s.Monitored = monitored == 1
 		series = append(series, s)
 	}
-	return series, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := r.hydrateHardcoverLinks(ctx, series); err != nil {
+		return nil, err
+	}
+	return series, nil
 }
 
 // ListWithBooks returns all series rows with their linked books populated.
@@ -112,7 +119,54 @@ func (r *SeriesRepo) ListWithBooks(ctx context.Context) ([]models.Series, error)
 			Book:             &book,
 		})
 	}
-	return series, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := r.hydrateHardcoverLinks(ctx, series); err != nil {
+		return nil, err
+	}
+	return series, nil
+}
+
+func (r *SeriesRepo) hydrateHardcoverLinks(ctx context.Context, series []models.Series) error {
+	if len(series) == 0 {
+		return nil
+	}
+	placeholders := make([]string, 0, len(series))
+	args := make([]any, 0, len(series))
+	for _, s := range series {
+		placeholders = append(placeholders, "?")
+		args = append(args, s.ID)
+	}
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, series_id, hardcover_series_id, hardcover_provider_id, hardcover_title,
+		       hardcover_author_name, hardcover_book_count, link_confidence, linked_by,
+		       linked_at, created_at, updated_at
+		FROM series_hardcover_links
+		WHERE series_id IN (`+strings.Join(placeholders, ",")+`)`, args...)
+	if err != nil {
+		return fmt.Errorf("list series hardcover links: %w", err)
+	}
+	defer rows.Close()
+
+	links := make(map[int64]models.SeriesHardcoverLink)
+	for rows.Next() {
+		link, err := scanSeriesHardcoverLink(rows)
+		if err != nil {
+			return err
+		}
+		links[link.SeriesID] = link
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for i := range series {
+		if link, ok := links[series[i].ID]; ok {
+			linkCopy := link
+			series[i].HardcoverLink = &linkCopy
+		}
+	}
+	return nil
 }
 
 func (r *SeriesRepo) SetMonitored(ctx context.Context, id int64, monitored bool) error {
@@ -204,7 +258,125 @@ func (r *SeriesRepo) GetByID(ctx context.Context, id int64) (*models.Series, err
 		s.Books = append(s.Books, sb)
 	}
 
-	return &s, bookRows.Err()
+	if err := bookRows.Err(); err != nil {
+		return nil, err
+	}
+	link, err := r.GetHardcoverLink(ctx, s.ID)
+	if err != nil {
+		return nil, err
+	}
+	s.HardcoverLink = link
+	return &s, nil
+}
+
+type seriesHardcoverLinkScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSeriesHardcoverLink(scanner seriesHardcoverLinkScanner) (models.SeriesHardcoverLink, error) {
+	var link models.SeriesHardcoverLink
+	err := scanner.Scan(
+		&link.ID,
+		&link.SeriesID,
+		&link.HardcoverSeriesID,
+		&link.HardcoverProviderID,
+		&link.HardcoverTitle,
+		&link.HardcoverAuthorName,
+		&link.HardcoverBookCount,
+		&link.Confidence,
+		&link.LinkedBy,
+		&link.LinkedAt,
+		&link.CreatedAt,
+		&link.UpdatedAt,
+	)
+	return link, err
+}
+
+func (r *SeriesRepo) GetHardcoverLink(ctx context.Context, seriesID int64) (*models.SeriesHardcoverLink, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, series_id, hardcover_series_id, hardcover_provider_id, hardcover_title,
+		       hardcover_author_name, hardcover_book_count, link_confidence, linked_by,
+		       linked_at, created_at, updated_at
+		FROM series_hardcover_links
+		WHERE series_id = ?`, seriesID)
+	link, err := scanSeriesHardcoverLink(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get series hardcover link %d: %w", seriesID, err)
+	}
+	return &link, nil
+}
+
+func (r *SeriesRepo) UpsertHardcoverLink(ctx context.Context, link *models.SeriesHardcoverLink) error {
+	if link == nil {
+		return nil
+	}
+	if link.SeriesID == 0 {
+		return errors.New("series id is required")
+	}
+	if strings.TrimSpace(link.HardcoverSeriesID) == "" {
+		return errors.New("hardcover series id is required")
+	}
+	now := time.Now().UTC()
+	if link.LinkedAt.IsZero() {
+		link.LinkedAt = now
+	}
+	if link.LinkedBy == "" {
+		link.LinkedBy = "manual"
+	}
+	if link.HardcoverProviderID == "" {
+		link.HardcoverProviderID = strings.TrimPrefix(link.HardcoverSeriesID, "hc-series:")
+	}
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO series_hardcover_links (
+			series_id, hardcover_series_id, hardcover_provider_id, hardcover_title,
+			hardcover_author_name, hardcover_book_count, link_confidence, linked_by,
+			linked_at, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(series_id) DO UPDATE SET
+			hardcover_series_id = excluded.hardcover_series_id,
+			hardcover_provider_id = excluded.hardcover_provider_id,
+			hardcover_title = excluded.hardcover_title,
+			hardcover_author_name = excluded.hardcover_author_name,
+			hardcover_book_count = excluded.hardcover_book_count,
+			link_confidence = excluded.link_confidence,
+			linked_by = excluded.linked_by,
+			linked_at = excluded.linked_at,
+			updated_at = excluded.updated_at`,
+		link.SeriesID,
+		link.HardcoverSeriesID,
+		link.HardcoverProviderID,
+		link.HardcoverTitle,
+		link.HardcoverAuthorName,
+		link.HardcoverBookCount,
+		link.Confidence,
+		link.LinkedBy,
+		link.LinkedAt,
+		now,
+		now,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert series hardcover link: %w", err)
+	}
+	stored, err := r.GetHardcoverLink(ctx, link.SeriesID)
+	if err != nil {
+		return err
+	}
+	if stored != nil {
+		*link = *stored
+	}
+	return nil
+}
+
+func (r *SeriesRepo) DeleteHardcoverLink(ctx context.Context, seriesID int64) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM series_hardcover_links WHERE series_id = ?`, seriesID)
+	if err != nil {
+		return fmt.Errorf("delete series hardcover link %d: %w", seriesID, err)
+	}
+	return nil
 }
 
 func (r *SeriesRepo) GetByForeignID(ctx context.Context, foreignID string) (*models.Series, error) {

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -178,6 +178,26 @@ func (r *SeriesRepo) SetMonitored(ctx context.Context, id int64, monitored bool)
 	return err
 }
 
+func (r *SeriesRepo) CreateManual(ctx context.Context, title string) (*models.Series, error) {
+	s := &models.Series{
+		ForeignID:   fmt.Sprintf("manual:series:%d", time.Now().UTC().UnixNano()),
+		Title:       strings.TrimSpace(title),
+		Description: "",
+	}
+	if err := r.Create(ctx, s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (r *SeriesRepo) UpdateTitle(ctx context.Context, id int64, title string) error {
+	_, err := r.db.ExecContext(ctx, "UPDATE series SET title=? WHERE id=?", strings.TrimSpace(title), id)
+	if err != nil {
+		return fmt.Errorf("update series %d title: %w", id, err)
+	}
+	return nil
+}
+
 // ListBooksInSeries returns all books linked to the given series, with status.
 func (r *SeriesRepo) ListBooksInSeries(ctx context.Context, seriesID int64) ([]models.Book, error) {
 	rows, err := r.db.QueryContext(ctx, `
@@ -470,6 +490,24 @@ func (r *SeriesRepo) LinkBookIfMissing(ctx context.Context, seriesID, bookID int
 	}
 	affected, _ := result.RowsAffected()
 	return affected > 0, nil
+}
+
+func (r *SeriesRepo) UpsertBookLink(ctx context.Context, seriesID, bookID int64, position string, primary bool) error {
+	primaryInt := 0
+	if primary {
+		primaryInt = 1
+	}
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO series_books (series_id, book_id, position_in_series, primary_series)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(series_id, book_id) DO UPDATE SET
+			position_in_series = excluded.position_in_series,
+			primary_series = excluded.primary_series`,
+		seriesID, bookID, strings.TrimSpace(position), primaryInt)
+	if err != nil {
+		return fmt.Errorf("upsert book %d in series %d: %w", bookID, seriesID, err)
+	}
+	return nil
 }
 
 func (r *SeriesRepo) UnlinkBook(ctx context.Context, seriesID, bookID int64) error {

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -39,6 +39,82 @@ func (r *SeriesRepo) List(ctx context.Context) ([]models.Series, error) {
 	return series, rows.Err()
 }
 
+// ListWithBooks returns all series rows with their linked books populated.
+func (r *SeriesRepo) ListWithBooks(ctx context.Context) ([]models.Series, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT s.id, s.foreign_id, s.title, s.description, s.monitored, s.created_at,
+		       sb.series_id, sb.book_id, sb.position_in_series, sb.primary_series,
+		       b.id, b.foreign_id, b.author_id, b.title, b.sort_title, b.status,
+		       b.monitored, b.image_url, b.release_date, b.created_at, b.updated_at
+		FROM series s
+		LEFT JOIN series_books sb ON sb.series_id = s.id
+		LEFT JOIN books b ON b.id = sb.book_id
+		ORDER BY s.title, CAST(NULLIF(sb.position_in_series, '') AS REAL), sb.position_in_series, b.sort_title`)
+	if err != nil {
+		return nil, fmt.Errorf("list series with books: %w", err)
+	}
+	defer rows.Close()
+
+	series := make([]models.Series, 0)
+	byID := make(map[int64]int)
+	for rows.Next() {
+		var s models.Series
+		var monitored int
+		var sbSeriesID, sbBookID, bookID, authorID sql.NullInt64
+		var position sql.NullString
+		var primarySeries, bookMonitored sql.NullInt64
+		var foreignID, title, sortTitle, status, imageURL sql.NullString
+		var releaseDate, bookCreatedAt, bookUpdatedAt sql.NullTime
+		if err := rows.Scan(
+			&s.ID, &s.ForeignID, &s.Title, &s.Description, &monitored, &s.CreatedAt,
+			&sbSeriesID, &sbBookID, &position, &primarySeries,
+			&bookID, &foreignID, &authorID, &title, &sortTitle, &status,
+			&bookMonitored, &imageURL, &releaseDate, &bookCreatedAt, &bookUpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan series with books: %w", err)
+		}
+		s.Monitored = monitored == 1
+
+		idx, ok := byID[s.ID]
+		if !ok {
+			idx = len(series)
+			series = append(series, s)
+			byID[s.ID] = idx
+		}
+		if !sbBookID.Valid || !bookID.Valid {
+			continue
+		}
+
+		book := models.Book{
+			ID:        bookID.Int64,
+			ForeignID: foreignID.String,
+			AuthorID:  authorID.Int64,
+			Title:     title.String,
+			SortTitle: sortTitle.String,
+			Status:    status.String,
+			Monitored: bookMonitored.Int64 == 1,
+			ImageURL:  imageURL.String,
+		}
+		if releaseDate.Valid {
+			book.ReleaseDate = &releaseDate.Time
+		}
+		if bookCreatedAt.Valid {
+			book.CreatedAt = bookCreatedAt.Time
+		}
+		if bookUpdatedAt.Valid {
+			book.UpdatedAt = bookUpdatedAt.Time
+		}
+		series[idx].Books = append(series[idx].Books, models.SeriesBook{
+			SeriesID:         sbSeriesID.Int64,
+			BookID:           sbBookID.Int64,
+			PositionInSeries: position.String,
+			PrimarySeries:    primarySeries.Int64 == 1,
+			Book:             &book,
+		})
+	}
+	return series, rows.Err()
+}
+
 func (r *SeriesRepo) SetMonitored(ctx context.Context, id int64, monitored bool) error {
 	val := 0
 	if monitored {

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -131,6 +131,33 @@ func (r *SeriesRepo) GetByID(ctx context.Context, id int64) (*models.Series, err
 	return &s, bookRows.Err()
 }
 
+func (r *SeriesRepo) GetByForeignID(ctx context.Context, foreignID string) (*models.Series, error) {
+	row := r.db.QueryRowContext(ctx,
+		"SELECT id, foreign_id, title, description, monitored, created_at FROM series WHERE foreign_id=?", foreignID)
+	var s models.Series
+	var monitored int
+	err := row.Scan(&s.ID, &s.ForeignID, &s.Title, &s.Description, &monitored, &s.CreatedAt)
+	s.Monitored = monitored == 1
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get series by foreign_id %s: %w", foreignID, err)
+	}
+	return &s, nil
+}
+
+func (r *SeriesRepo) UpdateForeignID(ctx context.Context, id int64, foreignID string) error {
+	if id == 0 {
+		return nil
+	}
+	_, err := r.db.ExecContext(ctx, "UPDATE series SET foreign_id=? WHERE id=?", foreignID, id)
+	if err != nil {
+		return fmt.Errorf("update series %d foreign_id: %w", id, err)
+	}
+	return nil
+}
+
 func (r *SeriesRepo) Create(ctx context.Context, s *models.Series) error {
 	now := time.Now().UTC()
 	result, err := r.db.ExecContext(ctx,
@@ -174,18 +201,27 @@ func (r *SeriesRepo) CreateOrGet(ctx context.Context, s *models.Series) error {
 // INSERT OR IGNORE makes the call idempotent: a second call with the same
 // pair is a no-op, which is safe for re-runs (e.g. reconcile-series).
 func (r *SeriesRepo) LinkBook(ctx context.Context, seriesID, bookID int64, position string, primary bool) error {
+	_, err := r.LinkBookIfMissing(ctx, seriesID, bookID, position, primary)
+	return err
+}
+
+// LinkBookIfMissing inserts a series_books row and reports whether it created
+// the membership. Callers that record rollback ownership should only claim
+// ownership when this returns true.
+func (r *SeriesRepo) LinkBookIfMissing(ctx context.Context, seriesID, bookID int64, position string, primary bool) (bool, error) {
 	primaryInt := 0
 	if primary {
 		primaryInt = 1
 	}
-	_, err := r.db.ExecContext(ctx,
+	result, err := r.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO series_books (series_id, book_id, position_in_series, primary_series)
 		 VALUES (?, ?, ?, ?)`,
 		seriesID, bookID, position, primaryInt)
 	if err != nil {
-		return fmt.Errorf("link book %d to series %d: %w", bookID, seriesID, err)
+		return false, fmt.Errorf("link book %d to series %d: %w", bookID, seriesID, err)
 	}
-	return nil
+	affected, _ := result.RowsAffected()
+	return affected > 0, nil
 }
 
 func (r *SeriesRepo) UnlinkBook(ctx context.Context, seriesID, bookID int64) error {

--- a/internal/db/series_test.go
+++ b/internal/db/series_test.go
@@ -168,3 +168,76 @@ func TestSeriesList(t *testing.T) {
 		t.Errorf("expected 2 series, got %d", len(list))
 	}
 }
+
+func TestSeriesHardcoverLinkCRUD(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	repo := NewSeriesRepo(database)
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "Stormlight Archive"}
+	if err := repo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+
+	link := &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   "hc-series:1",
+		HardcoverProviderID: "1",
+		HardcoverTitle:      "The Stormlight Archive",
+		HardcoverAuthorName: "Brandon Sanderson",
+		HardcoverBookCount:  10,
+		Confidence:          0.82,
+		LinkedBy:            "auto",
+	}
+	if err := repo.UpsertHardcoverLink(ctx, link); err != nil {
+		t.Fatalf("upsert link: %v", err)
+	}
+	if link.ID == 0 {
+		t.Fatal("expected stored link id")
+	}
+
+	got, err := repo.GetHardcoverLink(ctx, series.ID)
+	if err != nil {
+		t.Fatalf("get link: %v", err)
+	}
+	if got == nil || got.HardcoverTitle != "The Stormlight Archive" || got.LinkedBy != "auto" {
+		t.Fatalf("unexpected link: %+v", got)
+	}
+
+	list, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("list series: %v", err)
+	}
+	if list[0].HardcoverLink == nil || list[0].HardcoverLink.HardcoverSeriesID != "hc-series:1" {
+		t.Fatalf("expected hydrated link in list, got %+v", list[0].HardcoverLink)
+	}
+
+	link.HardcoverTitle = "Stormlight Archive"
+	link.LinkedBy = "manual"
+	link.Confidence = 1
+	if err := repo.UpsertHardcoverLink(ctx, link); err != nil {
+		t.Fatalf("update link: %v", err)
+	}
+	got, err = repo.GetHardcoverLink(ctx, series.ID)
+	if err != nil {
+		t.Fatalf("get updated link: %v", err)
+	}
+	if got.HardcoverTitle != "Stormlight Archive" || got.LinkedBy != "manual" || got.Confidence != 1 {
+		t.Fatalf("unexpected updated link: %+v", got)
+	}
+
+	if err := repo.DeleteHardcoverLink(ctx, series.ID); err != nil {
+		t.Fatalf("delete link: %v", err)
+	}
+	got, err = repo.GetHardcoverLink(ctx, series.ID)
+	if err != nil {
+		t.Fatalf("get deleted link: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected deleted link, got %+v", got)
+	}
+}

--- a/internal/db/series_test.go
+++ b/internal/db/series_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -130,6 +131,80 @@ func TestSeriesLinkBook(t *testing.T) {
 	}
 	if len(got.Books) != 0 {
 		t.Errorf("expected 0 series_books after book delete, got %d", len(got.Books))
+	}
+}
+
+func TestSeriesManualManagement(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OL1A", Name: "Frank Herbert", SortName: "Herbert, Frank",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OL1W", AuthorID: author.ID, Title: "Dune", SortTitle: "Dune",
+		Status: models.BookStatusImported, Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	series, err := seriesRepo.CreateManual(ctx, "  Dune Chronicles  ")
+	if err != nil {
+		t.Fatalf("CreateManual: %v", err)
+	}
+	if series.ID == 0 || series.Title != "Dune Chronicles" {
+		t.Fatalf("unexpected manual series: %+v", series)
+	}
+	if !strings.HasPrefix(series.ForeignID, "manual:series:") {
+		t.Fatalf("foreign id prefix: got %q, want manual:series:", series.ForeignID)
+	}
+
+	if err := seriesRepo.UpdateTitle(ctx, series.ID, "Dune Saga"); err != nil {
+		t.Fatalf("UpdateTitle: %v", err)
+	}
+	got, err := seriesRepo.GetByID(ctx, series.ID)
+	if err != nil {
+		t.Fatalf("GetByID after update: %v", err)
+	}
+	if got.Title != "Dune Saga" {
+		t.Fatalf("title = %q, want Dune Saga", got.Title)
+	}
+
+	if err := seriesRepo.UpsertBookLink(ctx, series.ID, book.ID, "1", true); err != nil {
+		t.Fatalf("first UpsertBookLink: %v", err)
+	}
+	if err := seriesRepo.UpsertBookLink(ctx, series.ID, book.ID, "1.5", false); err != nil {
+		t.Fatalf("second UpsertBookLink: %v", err)
+	}
+	got, err = seriesRepo.GetByID(ctx, series.ID)
+	if err != nil {
+		t.Fatalf("GetByID after link: %v", err)
+	}
+	if len(got.Books) != 1 {
+		t.Fatalf("expected one linked book, got %+v", got.Books)
+	}
+	if got.Books[0].PositionInSeries != "1.5" || got.Books[0].PrimarySeries {
+		t.Fatalf("expected updated link metadata, got %+v", got.Books[0])
+	}
+
+	if err := seriesRepo.Delete(ctx, series.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got, err := bookRepo.GetByID(ctx, book.ID); err != nil || got == nil {
+		t.Fatalf("delete series should preserve book, got book=%+v err=%v", got, err)
 	}
 }
 

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -5,6 +5,7 @@ package metadata
 import (
 	"context"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -206,6 +207,78 @@ func (a *Aggregator) GetBookByISBN(ctx context.Context, isbn string) (*models.Bo
 
 	a.cache.set(key, book)
 	return book, nil
+}
+
+// SearchSeries queries metadata providers that expose series catalog search.
+func (a *Aggregator) SearchSeries(ctx context.Context, query string, limit int) ([]SeriesSearchResult, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	key := "series-search:" + strings.ToLower(query) + ":" + strconv.Itoa(limit)
+	if cached, ok := a.cache.get(key); ok {
+		return cached.([]SeriesSearchResult), nil
+	}
+	var lastErr error
+	for _, provider := range a.seriesCatalogProviders() {
+		results, err := provider.SearchSeries(ctx, query, limit)
+		if err != nil {
+			lastErr = err
+			slog.Debug("series search failed", "error", err)
+			continue
+		}
+		if results == nil {
+			results = []SeriesSearchResult{}
+		}
+		a.cache.set(key, results)
+		return results, nil
+	}
+	return nil, lastErr
+}
+
+// GetSeriesCatalog fetches the ordered book catalog for a provider series.
+func (a *Aggregator) GetSeriesCatalog(ctx context.Context, foreignID string) (*SeriesCatalog, error) {
+	foreignID = strings.TrimSpace(foreignID)
+	if foreignID == "" {
+		return nil, nil
+	}
+	key := "series-catalog:" + foreignID
+	if cached, ok := a.cache.get(key); ok {
+		return cached.(*SeriesCatalog), nil
+	}
+	var lastErr error
+	for _, provider := range a.seriesCatalogProviders() {
+		catalog, err := provider.GetSeriesCatalog(ctx, foreignID)
+		if err != nil {
+			lastErr = err
+			slog.Debug("series catalog failed", "foreignID", foreignID, "error", err)
+			continue
+		}
+		if catalog != nil {
+			a.cache.set(key, catalog)
+		}
+		return catalog, nil
+	}
+	return nil, lastErr
+}
+
+func (a *Aggregator) seriesCatalogProviders() []SeriesCatalogProvider {
+	if a == nil {
+		return nil
+	}
+	providers := make([]SeriesCatalogProvider, 0, len(a.enrichers)+1)
+	if provider, ok := a.primary.(SeriesCatalogProvider); ok {
+		providers = append(providers, provider)
+	}
+	for _, enricher := range a.enrichers {
+		if provider, ok := enricher.(SeriesCatalogProvider); ok {
+			providers = append(providers, provider)
+		}
+	}
+	return providers
 }
 
 // enrichBook tries to fill in missing data from secondary providers.

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -4,6 +4,7 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -167,10 +168,15 @@ func (a *Aggregator) GetAuthorWorksForAuthor(ctx context.Context, author models.
 	}
 
 	authorName := strings.TrimSpace(author.Name)
+	supplementsComplete := true
 	if authorName != "" {
 		for _, provider := range a.authorWorksByNameProviders() {
 			supplemental, err := provider.GetAuthorWorksByName(ctx, authorName)
 			if err != nil {
+				supplementsComplete = false
+				if errors.Is(err, ErrProviderNotConfigured) {
+					continue
+				}
 				slog.Warn("author works supplement failed", "provider", provider.Name(), "author", authorName, "error", err)
 				continue
 			}
@@ -182,7 +188,9 @@ func (a *Aggregator) GetAuthorWorksForAuthor(ctx context.Context, author models.
 	}
 
 	a.enrichMissingAuthorWorkCovers(ctx, books)
-	a.cache.set(key, books)
+	if supplementsComplete {
+		a.cache.set(key, books)
+	}
 	return books, nil
 }
 

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/metadata/audible"
 	"github.com/vavallee/bindery/internal/metadata/audnex"
 	"github.com/vavallee/bindery/internal/models"
@@ -123,37 +124,157 @@ func (a *Aggregator) GetAuthor(ctx context.Context, foreignID string) (*models.A
 	return author, nil
 }
 
-// GetAuthorWorks fetches all works by an author using the dedicated OL endpoint.
+type worksProvider interface {
+	GetAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error)
+}
+
+type authorWorksByNameProvider interface {
+	Name() string
+	GetAuthorWorksByName(ctx context.Context, authorName string) ([]models.Book, error)
+}
+
+// GetAuthorWorks fetches all works by an author using the dedicated primary
+// provider endpoint. It retains the legacy foreign-ID-only behavior for tests
+// and existing callers; author ingestion should use GetAuthorWorksForAuthor so
+// enrichers can run author-scoped supplemental queries.
 func (a *Aggregator) GetAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error) {
 	key := "authorworks:" + authorForeignID
 	if cached, ok := a.cache.get(key); ok {
 		return cached.([]models.Book), nil
 	}
 
-	// Use the OL-specific method if available
-	type worksProvider interface {
-		GetAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error)
+	books, err := a.primaryAuthorWorks(ctx, authorForeignID)
+	if err != nil {
+		return nil, err
 	}
-	if wp, ok := a.primary.(worksProvider); ok {
-		books, err := wp.GetAuthorWorks(ctx, authorForeignID)
-		if err != nil {
-			return nil, err
-		}
-		// Enrich covers for works that OL's works endpoint left without one.
-		// OpenLibrary attaches cover IDs to editions, not always to works, so
-		// many works come back coverless. Google Books and Hardcover have much
-		// higher cover coverage and tend to return the dominant-language edition.
-		for i := range books {
-			if books[i].ImageURL == "" {
-				a.enrichBook(ctx, &books[i])
-			}
-		}
-		a.cache.set(key, books)
-		return books, nil
+	a.enrichMissingAuthorWorkCovers(ctx, books)
+	a.cache.set(key, books)
+	return books, nil
+}
+
+// GetAuthorWorksForAuthor fetches the primary provider's author works and
+// merges any author-scoped supplemental catalogs from enrichers before falling
+// back to per-title cover enrichment for remaining gaps.
+func (a *Aggregator) GetAuthorWorksForAuthor(ctx context.Context, author models.Author) ([]models.Book, error) {
+	key := "authorworks-author:" + author.ForeignID + ":" + strings.ToLower(strings.TrimSpace(author.Name))
+	if cached, ok := a.cache.get(key); ok {
+		return cached.([]models.Book), nil
 	}
 
-	// Fallback to search
+	books, err := a.primaryAuthorWorks(ctx, author.ForeignID)
+	if err != nil {
+		return nil, err
+	}
+
+	authorName := strings.TrimSpace(author.Name)
+	if authorName != "" {
+		for _, provider := range a.authorWorksByNameProviders() {
+			supplemental, err := provider.GetAuthorWorksByName(ctx, authorName)
+			if err != nil {
+				slog.Warn("author works supplement failed", "provider", provider.Name(), "author", authorName, "error", err)
+				continue
+			}
+			if len(supplemental) == 0 {
+				continue
+			}
+			books = mergeAuthorWorks(books, supplemental)
+		}
+	}
+
+	a.enrichMissingAuthorWorkCovers(ctx, books)
+	a.cache.set(key, books)
+	return books, nil
+}
+
+func (a *Aggregator) primaryAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error) {
+	if wp, ok := a.primary.(worksProvider); ok {
+		return wp.GetAuthorWorks(ctx, authorForeignID)
+	}
 	return a.primary.SearchBooks(ctx, authorForeignID)
+}
+
+func (a *Aggregator) authorWorksByNameProviders() []authorWorksByNameProvider {
+	if a == nil {
+		return nil
+	}
+	providers := make([]authorWorksByNameProvider, 0, len(a.enrichers))
+	for _, enricher := range a.enrichers {
+		if provider, ok := enricher.(authorWorksByNameProvider); ok {
+			providers = append(providers, provider)
+		}
+	}
+	return providers
+}
+
+func (a *Aggregator) enrichMissingAuthorWorkCovers(ctx context.Context, books []models.Book) {
+	for i := range books {
+		if books[i].ImageURL == "" {
+			a.enrichBook(ctx, &books[i])
+		}
+	}
+}
+
+func mergeAuthorWorks(primary, supplemental []models.Book) []models.Book {
+	books := make([]models.Book, 0, len(primary)+len(supplemental))
+	index := make(map[string]int, len(primary)+len(supplemental))
+	for _, book := range primary {
+		key := authorWorkMergeKey(book.Title)
+		if key != "" {
+			index[key] = len(books)
+		}
+		books = append(books, book)
+	}
+	for _, book := range supplemental {
+		key := authorWorkMergeKey(book.Title)
+		if key == "" {
+			continue
+		}
+		if pos, ok := index[key]; ok {
+			mergeAuthorWorkMetadata(&books[pos], book)
+			continue
+		}
+		index[key] = len(books)
+		books = append(books, book)
+	}
+	return books
+}
+
+func authorWorkMergeKey(title string) string {
+	key := indexer.NormalizeTitleForDedup(title)
+	if key != "" {
+		return key
+	}
+	return strings.ToLower(strings.TrimSpace(title))
+}
+
+func mergeAuthorWorkMetadata(dst *models.Book, src models.Book) {
+	if dst.ImageURL == "" {
+		dst.ImageURL = src.ImageURL
+	}
+	if dst.Description == "" {
+		dst.Description = src.Description
+	}
+	if dst.AverageRating == 0 {
+		dst.AverageRating = src.AverageRating
+	}
+	if dst.RatingsCount == 0 {
+		dst.RatingsCount = src.RatingsCount
+	}
+	if dst.ReleaseDate == nil {
+		dst.ReleaseDate = src.ReleaseDate
+	}
+	if len(dst.Genres) == 0 {
+		dst.Genres = src.Genres
+	}
+	if dst.DurationSeconds == 0 {
+		dst.DurationSeconds = src.DurationSeconds
+	}
+	if dst.ASIN == "" {
+		dst.ASIN = src.ASIN
+	}
+	if dst.MediaType == "" {
+		dst.MediaType = src.MediaType
+	}
 }
 
 func (a *Aggregator) GetBook(ctx context.Context, foreignID string) (*models.Book, error) {

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -220,7 +220,9 @@ func mergeAuthorWorks(primary, supplemental []models.Book) []models.Book {
 	for _, book := range primary {
 		key := authorWorkMergeKey(book.Title)
 		if key != "" {
-			index[key] = len(books)
+			if _, exists := index[key]; !exists {
+				index[key] = len(books)
+			}
 		}
 		books = append(books, book)
 	}

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -63,9 +63,11 @@ type mockAuthorWorksByNameProvider struct {
 	authorWorksByName    []models.Book
 	authorWorksByNameErr error
 	gotAuthorName        string
+	calls                int
 }
 
 func (m *mockAuthorWorksByNameProvider) GetAuthorWorksByName(_ context.Context, authorName string) ([]models.Book, error) {
+	m.calls++
 	m.gotAuthorName = authorName
 	return m.authorWorksByName, m.authorWorksByNameErr
 }
@@ -547,6 +549,121 @@ func TestAggregator_GetAuthorWorksForAuthor_ContinuesWhenSupplementFails(t *test
 	}
 	if len(got) != 1 || got[0].ForeignID != "OL1W" {
 		t.Fatalf("expected primary result after supplement failure, got %+v", got)
+	}
+}
+
+func TestAggregator_GetAuthorWorksForAuthor_DoesNotCacheUnconfiguredSupplement(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{
+			{ForeignID: "OL1W", Title: "Dune", ImageURL: "cover", MetadataProvider: "openlibrary"},
+		}},
+	}
+	hardcover := &mockAuthorWorksByNameProvider{
+		mockProvider:         mockProvider{name: "hardcover"},
+		authorWorksByNameErr: ErrProviderNotConfigured,
+	}
+	agg := &Aggregator{
+		primary:   primary,
+		enrichers: []Provider{hardcover},
+		cache:     newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL123A", Name: "Frank Herbert"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor: %v", err)
+	}
+	if len(got) != 1 || got[0].ForeignID != "OL1W" {
+		t.Fatalf("expected primary-only result, got %+v", got)
+	}
+
+	hardcover.authorWorksByNameErr = nil
+	hardcover.authorWorksByName = []models.Book{{ForeignID: "hc:children-of-dune", Title: "Children of Dune", MetadataProvider: "hardcover"}}
+	got, err = agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL123A", Name: "Frank Herbert"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor after config: %v", err)
+	}
+	if hardcover.calls != 2 {
+		t.Fatalf("supplement calls = %d, want 2", hardcover.calls)
+	}
+	if len(got) != 2 || got[1].ForeignID != "hc:children-of-dune" {
+		t.Fatalf("expected supplemental result after config, got %+v", got)
+	}
+}
+
+func TestAggregator_GetAuthorWorksForAuthor_DoesNotCacheFailedSupplement(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{
+			{ForeignID: "OL1W", Title: "Dune", ImageURL: "cover", MetadataProvider: "openlibrary"},
+		}},
+	}
+	hardcover := &mockAuthorWorksByNameProvider{
+		mockProvider:         mockProvider{name: "hardcover"},
+		authorWorksByNameErr: errors.New("hardcover unavailable"),
+	}
+	agg := &Aggregator{
+		primary:   primary,
+		enrichers: []Provider{hardcover},
+		cache:     newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL123A", Name: "Frank Herbert"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor: %v", err)
+	}
+	if len(got) != 1 || got[0].ForeignID != "OL1W" {
+		t.Fatalf("expected primary-only result, got %+v", got)
+	}
+
+	hardcover.authorWorksByNameErr = nil
+	hardcover.authorWorksByName = []models.Book{{ForeignID: "hc:dune-messiah", Title: "Dune Messiah", MetadataProvider: "hardcover"}}
+	got, err = agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL123A", Name: "Frank Herbert"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor after recovery: %v", err)
+	}
+	if hardcover.calls != 2 {
+		t.Fatalf("supplement calls = %d, want 2", hardcover.calls)
+	}
+	if len(got) != 2 || got[1].ForeignID != "hc:dune-messiah" {
+		t.Fatalf("expected supplemental result after recovery, got %+v", got)
+	}
+}
+
+func TestAggregator_GetAuthorWorksForAuthor_CachesSuccessfulSupplement(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{
+			{ForeignID: "OL1W", Title: "Dune", ImageURL: "cover", MetadataProvider: "openlibrary"},
+		}},
+	}
+	hardcover := &mockAuthorWorksByNameProvider{
+		mockProvider: mockProvider{name: "hardcover"},
+		authorWorksByName: []models.Book{
+			{ForeignID: "hc:children-of-dune", Title: "Children of Dune", MetadataProvider: "hardcover"},
+		},
+	}
+	agg := &Aggregator{
+		primary:   primary,
+		enrichers: []Provider{hardcover},
+		cache:     newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL123A", Name: "Frank Herbert"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected merged works, got %+v", got)
+	}
+
+	hardcover.authorWorksByName = nil
+	got, err = agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL123A", Name: "Frank Herbert"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor cached: %v", err)
+	}
+	if hardcover.calls != 1 {
+		t.Fatalf("supplement calls = %d, want 1", hardcover.calls)
+	}
+	if len(got) != 2 || got[1].ForeignID != "hc:children-of-dune" {
+		t.Fatalf("expected cached supplemental result, got %+v", got)
 	}
 }
 

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -58,6 +58,18 @@ func (m *mockWorksProvider) GetAuthorWorks(_ context.Context, _ string) ([]model
 	return m.authorWorks, m.authorWorksErr
 }
 
+type mockAuthorWorksByNameProvider struct {
+	mockProvider
+	authorWorksByName    []models.Book
+	authorWorksByNameErr error
+	gotAuthorName        string
+}
+
+func (m *mockAuthorWorksByNameProvider) GetAuthorWorksByName(_ context.Context, authorName string) ([]models.Book, error) {
+	m.gotAuthorName = authorName
+	return m.authorWorksByName, m.authorWorksByNameErr
+}
+
 func TestAggregator_SearchAuthors(t *testing.T) {
 	want := []models.Author{{Name: "Frank Herbert", ForeignID: "OL123A"}}
 	primary := &mockProvider{name: "ol", searchAuthors: want}
@@ -386,6 +398,115 @@ func TestAggregator_GetAuthorWorks_Cached(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].Title != "Ender's Game" {
 		t.Errorf("cached works mismatch: %+v", got)
+	}
+}
+
+func TestAggregator_GetAuthorWorksForAuthor_MergesSupplementalByTitle(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{
+			{ForeignID: "OL1W", Title: "Dune", MetadataProvider: "openlibrary"},
+		}},
+	}
+	hardcover := &mockAuthorWorksByNameProvider{
+		mockProvider: mockProvider{name: "hardcover"},
+		authorWorksByName: []models.Book{
+			{
+				ForeignID:        "hc:dune",
+				Title:            "Dune",
+				Description:      "A desert planet.",
+				ImageURL:         "https://img/dune.jpg",
+				AverageRating:    4.5,
+				RatingsCount:     1000,
+				MetadataProvider: "hardcover",
+			},
+			{ForeignID: "hc:children-of-dune", Title: "Children of Dune", MetadataProvider: "hardcover"},
+		},
+	}
+	agg := &Aggregator{
+		primary:   primary,
+		enrichers: []Provider{hardcover},
+		cache:     newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL123A", Name: "Frank Herbert"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor: %v", err)
+	}
+	if hardcover.gotAuthorName != "Frank Herbert" {
+		t.Fatalf("supplemental author name = %q", hardcover.gotAuthorName)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 merged works, got %d: %+v", len(got), got)
+	}
+	if got[0].ForeignID != "OL1W" || got[0].MetadataProvider != "openlibrary" {
+		t.Fatalf("primary identity should win duplicate title: %+v", got[0])
+	}
+	if got[0].ImageURL != "https://img/dune.jpg" || got[0].AverageRating != 4.5 || got[0].Description == "" {
+		t.Fatalf("supplemental metadata was not merged: %+v", got[0])
+	}
+	if got[1].ForeignID != "hc:children-of-dune" {
+		t.Fatalf("supplemental-only book missing: %+v", got[1])
+	}
+}
+
+func TestAggregator_GetAuthorWorksForAuthor_EnrichesMissingCoversAfterSupplement(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{
+			{ForeignID: "OL1W", Title: "Dune", MetadataProvider: "openlibrary"},
+			{ForeignID: "OL2W", Title: "Heretics of Dune", MetadataProvider: "openlibrary"},
+		}},
+	}
+	hardcover := &mockAuthorWorksByNameProvider{
+		mockProvider: mockProvider{name: "hardcover"},
+		authorWorksByName: []models.Book{
+			{ForeignID: "hc:dune", Title: "Dune", ImageURL: "https://img/dune.jpg", MetadataProvider: "hardcover"},
+		},
+	}
+	google := &mockProvider{
+		name:        "googlebooks",
+		searchBooks: []models.Book{{ImageURL: "https://books.google.com/heretics.jpg"}},
+	}
+	agg := &Aggregator{
+		primary:   primary,
+		enrichers: []Provider{hardcover, google},
+		cache:     newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL123A", Name: "Frank Herbert"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 works, got %d: %+v", len(got), got)
+	}
+	if got[0].ImageURL != "https://img/dune.jpg" {
+		t.Fatalf("matched supplemental cover was not merged: %+v", got[0])
+	}
+	if got[1].ImageURL != "https://books.google.com/heretics.jpg" {
+		t.Fatalf("missing cover was not enriched after supplement: %+v", got[1])
+	}
+}
+
+func TestAggregator_GetAuthorWorksForAuthor_ContinuesWhenSupplementFails(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{{ForeignID: "OL1W", Title: "Dune", ImageURL: "cover"}}},
+	}
+	hardcover := &mockAuthorWorksByNameProvider{
+		mockProvider:         mockProvider{name: "hardcover"},
+		authorWorksByNameErr: errors.New("hardcover unavailable"),
+	}
+	agg := &Aggregator{
+		primary:   primary,
+		enrichers: []Provider{hardcover},
+		cache:     newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL123A", Name: "Frank Herbert"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor: %v", err)
+	}
+	if len(got) != 1 || got[0].ForeignID != "OL1W" {
+		t.Fatalf("expected primary result after supplement failure, got %+v", got)
 	}
 }
 

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -449,6 +449,46 @@ func TestAggregator_GetAuthorWorksForAuthor_MergesSupplementalByTitle(t *testing
 	}
 }
 
+func TestAggregator_GetAuthorWorksForAuthor_MergesSupplementalIntoFirstDuplicateTitle(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{
+			{ForeignID: "OL1W", Title: "Dune", MetadataProvider: "openlibrary"},
+			{ForeignID: "OL2W", Title: "Dune", MetadataProvider: "openlibrary"},
+		}},
+	}
+	hardcover := &mockAuthorWorksByNameProvider{
+		mockProvider: mockProvider{name: "hardcover"},
+		authorWorksByName: []models.Book{
+			{
+				ForeignID:        "hc:dune",
+				Title:            "Dune",
+				ImageURL:         "https://img/dune.jpg",
+				AverageRating:    4.5,
+				MetadataProvider: "hardcover",
+			},
+		},
+	}
+	agg := &Aggregator{
+		primary:   primary,
+		enrichers: []Provider{hardcover},
+		cache:     newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL123A", Name: "Frank Herbert"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected duplicate primary works to remain for downstream dedup, got %d: %+v", len(got), got)
+	}
+	if got[0].ImageURL != "https://img/dune.jpg" || got[0].AverageRating != 4.5 {
+		t.Fatalf("first duplicate did not receive supplemental metadata: %+v", got[0])
+	}
+	if got[1].ImageURL != "" || got[1].AverageRating != 0 {
+		t.Fatalf("supplemental metadata merged into later duplicate: %+v", got[1])
+	}
+}
+
 func TestAggregator_GetAuthorWorksForAuthor_EnrichesMissingCoversAfterSupplement(t *testing.T) {
 	primary := &mockWorksProvider{
 		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -21,11 +21,38 @@ const (
 )
 
 // Client implements metadata.Provider for Hardcover.app using its public GraphQL API.
-// Set a Bearer token via WithToken or NewAuthenticated to enable authenticated queries.
+// Set an API token via WithToken or NewAuthenticated to enable authenticated queries.
 type Client struct {
 	http        *http.Client
-	token       string // optional Bearer token; required for user-specific queries
+	token       string // optional API token; required for user-specific queries
 	tokenSource func(context.Context) string
+}
+
+// NormalizeAPIToken accepts either the raw token copied from Hardcover or an
+// Authorization-style value such as "Bearer <token>" and returns the raw token.
+func NormalizeAPIToken(value string) string {
+	token := strings.TrimSpace(value)
+	for {
+		token = strings.Trim(strings.TrimSpace(token), `"'`+"`")
+		lower := strings.ToLower(token)
+		switch {
+		case strings.HasPrefix(lower, "authorization:"):
+			token = strings.TrimSpace(token[len("authorization:"):])
+			continue
+		case strings.HasPrefix(lower, "authorization="):
+			token = strings.TrimSpace(token[len("authorization="):])
+			continue
+		}
+		if strings.EqualFold(token, "Bearer") {
+			return ""
+		}
+		fields := strings.Fields(token)
+		if len(fields) < 2 || !strings.EqualFold(fields[0], "Bearer") {
+			break
+		}
+		token = strings.TrimSpace(token[len(fields[0]):])
+	}
+	return token
 }
 
 // New creates a new Hardcover client.
@@ -35,13 +62,13 @@ func New() *Client {
 	}
 }
 
-// WithToken returns a copy of the client configured to use the given Bearer token.
+// WithToken returns a copy of the client configured to use the given API token.
 // Required for authenticated queries such as GetUserWishlist.
 func (c *Client) WithToken(token string) *Client {
 	return &Client{http: c.http, token: token}
 }
 
-// WithTokenSource returns a copy of the client that resolves a Bearer token
+// WithTokenSource returns a copy of the client that resolves an API token
 // for each request. It is used for UI-managed credentials that can change
 // while the process is running.
 func (c *Client) WithTokenSource(source func(context.Context) string) *Client {
@@ -221,7 +248,7 @@ func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, 
 
 // GetUserWishlist fetches the authenticated user's "Want to Read" books.
 // Returns candidates suitable for list-cross recommendations.
-// Requires the client to have a Bearer token set via WithToken; returns nil if not configured.
+// Requires the client to have an API token set via WithToken; returns nil if not configured.
 func (c *Client) GetUserWishlist(ctx context.Context, limit int) ([]models.RecommendationCandidate, error) {
 	if c.token == "" {
 		return nil, nil
@@ -383,6 +410,11 @@ type gqlRequest struct {
 	Variables map[string]any `json:"variables,omitempty"`
 }
 
+type gqlError struct {
+	Message    string         `json:"message"`
+	Extensions map[string]any `json:"extensions,omitempty"`
+}
+
 func (c *Client) query(ctx context.Context, q string, vars map[string]any, out interface{}) error {
 	body, err := json.Marshal(gqlRequest{Query: q, Variables: vars})
 	if err != nil {
@@ -395,7 +427,7 @@ func (c *Client) query(ctx context.Context, q string, vars map[string]any, out i
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "Bindery/0.1 (https://github.com/vavallee/bindery)")
-	if token := c.bearerToken(ctx); token != "" {
+	if token := c.authorizationToken(ctx); token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
@@ -410,16 +442,47 @@ func (c *Client) query(ctx context.Context, q string, vars map[string]any, out i
 		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(b))
 	}
 
-	return json.NewDecoder(resp.Body).Decode(out)
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	var envelope struct {
+		Errors []gqlError `json:"errors"`
+	}
+	if err := json.Unmarshal(b, &envelope); err == nil && len(envelope.Errors) > 0 {
+		return fmt.Errorf("GraphQL: %s", formatGraphQLErrors(envelope.Errors))
+	}
+	return json.Unmarshal(b, out)
 }
 
-func (c *Client) bearerToken(ctx context.Context) string {
+func (c *Client) authorizationToken(ctx context.Context) string {
 	if c.tokenSource != nil {
-		if token := strings.TrimSpace(c.tokenSource(ctx)); token != "" {
+		if token := NormalizeAPIToken(c.tokenSource(ctx)); token != "" {
 			return token
 		}
 	}
-	return strings.TrimSpace(c.token)
+	return NormalizeAPIToken(c.token)
+}
+
+func formatGraphQLErrors(errors []gqlError) string {
+	if len(errors) == 0 {
+		return "unknown error"
+	}
+	parts := make([]string, 0, min(len(errors), 3))
+	for _, gqlErr := range errors {
+		msg := strings.TrimSpace(gqlErr.Message)
+		if msg == "" {
+			msg = "unknown error"
+		}
+		if code, ok := gqlErr.Extensions["code"].(string); ok && code != "" {
+			msg += " (" + code + ")"
+		}
+		parts = append(parts, msg)
+		if len(parts) == 3 {
+			break
+		}
+	}
+	return strings.Join(parts, "; ")
 }
 
 // --- Internal types for JSON mapping ---

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -23,8 +23,9 @@ const (
 // Client implements metadata.Provider for Hardcover.app using its public GraphQL API.
 // Set a Bearer token via WithToken or NewAuthenticated to enable authenticated queries.
 type Client struct {
-	http  *http.Client
-	token string // optional Bearer token; required for user-specific queries
+	http        *http.Client
+	token       string // optional Bearer token; required for user-specific queries
+	tokenSource func(context.Context) string
 }
 
 // New creates a new Hardcover client.
@@ -38,6 +39,13 @@ func New() *Client {
 // Required for authenticated queries such as GetUserWishlist.
 func (c *Client) WithToken(token string) *Client {
 	return &Client{http: c.http, token: token}
+}
+
+// WithTokenSource returns a copy of the client that resolves a Bearer token
+// for each request. It is used for UI-managed credentials that can change
+// while the process is running.
+func (c *Client) WithTokenSource(source func(context.Context) string) *Client {
+	return &Client{http: c.http, token: c.token, tokenSource: source}
 }
 
 // NewAuthenticated creates a new client that sends Authorization: Bearer <token>
@@ -387,8 +395,8 @@ func (c *Client) query(ctx context.Context, q string, vars map[string]any, out i
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "Bindery/0.1 (https://github.com/vavallee/bindery)")
-	if c.token != "" {
-		req.Header.Set("Authorization", "Bearer "+c.token)
+	if token := c.bearerToken(ctx); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	resp, err := c.http.Do(req)
@@ -403,6 +411,15 @@ func (c *Client) query(ctx context.Context, q string, vars map[string]any, out i
 	}
 
 	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func (c *Client) bearerToken(ctx context.Context) string {
+	if c.tokenSource != nil {
+		if token := strings.TrimSpace(c.tokenSource(ctx)); token != "" {
+			return token
+		}
+	}
+	return strings.TrimSpace(c.token)
 }
 
 // --- Internal types for JSON mapping ---

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -430,12 +430,14 @@ type hcContribution struct {
 type hcBook struct {
 	ID            int              `json:"id"`
 	Title         string           `json:"title"`
+	Subtitle      string           `json:"subtitle"`
 	Slug          string           `json:"slug"`
 	Description   string           `json:"description"`
 	Image         *hcImage         `json:"image"`
 	ReleaseYear   *int             `json:"release_year"`
 	RatingsCount  int              `json:"ratings_count"`
 	Rating        float64          `json:"rating"`
+	UsersCount    int              `json:"users_count"`
 	Contributions []hcContribution `json:"contributions"`
 }
 

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -151,8 +152,11 @@ func (c *Client) SearchBooks(ctx context.Context, query string) ([]models.Book, 
 // returns no supplemental results.
 func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([]models.Book, error) {
 	authorName = strings.TrimSpace(authorName)
-	if authorName == "" || c.authorizationToken(ctx) == "" {
+	if authorName == "" {
 		return nil, nil
+	}
+	if c.authorizationToken(ctx) == "" {
+		return nil, metadata.ErrProviderNotConfigured
 	}
 
 	gql := `query GetAuthorWorksByName($author: String!, $limit: Int!, $offset: Int!) {

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -18,6 +18,9 @@ import (
 const (
 	graphqlURL = "https://api.hardcover.app/v1/graphql"
 	idPrefix   = "hc:"
+
+	authorWorksPageSize = 100
+	authorWorksMaxBooks = 500
 )
 
 // Client implements metadata.Provider for Hardcover.app using its public GraphQL API.
@@ -138,6 +141,70 @@ func (c *Client) SearchBooks(ctx context.Context, query string) ([]models.Book, 
 	books := make([]models.Book, 0, len(resp.Data.Books))
 	for _, b := range resp.Data.Books {
 		books = append(books, c.toBook(b))
+	}
+	return books, nil
+}
+
+// GetAuthorWorksByName fetches canonical Hardcover books for an author in
+// page-sized batches. It requires a configured API token because Hardcover's
+// schema endpoints are token-backed in production; an unconfigured client
+// returns no supplemental results.
+func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([]models.Book, error) {
+	authorName = strings.TrimSpace(authorName)
+	if authorName == "" || c.authorizationToken(ctx) == "" {
+		return nil, nil
+	}
+
+	gql := `query GetAuthorWorksByName($author: String!, $limit: Int!, $offset: Int!) {
+		books(
+			where: {
+				canonical_id: {_is_null: true},
+				contributions: {author: {name: {_eq: $author}}}
+			},
+			limit: $limit,
+			offset: $offset,
+			order_by: {users_count: desc}
+		) {
+			id
+			title
+			subtitle
+			slug
+			description
+			image { url }
+			release_year
+			ratings_count
+			rating
+			users_count
+			genres
+			has_audiobook
+			has_ebook
+			audio_seconds
+			contributions {
+				author { id name slug }
+			}
+		}
+	}`
+
+	books := make([]models.Book, 0, authorWorksPageSize)
+	for offset := 0; offset < authorWorksMaxBooks; offset += authorWorksPageSize {
+		var resp struct {
+			Data struct {
+				Books []hcBook `json:"books"`
+			} `json:"data"`
+		}
+		if err := c.query(ctx, gql, map[string]any{
+			"author": authorName,
+			"limit":  authorWorksPageSize,
+			"offset": offset,
+		}, &resp); err != nil {
+			return nil, fmt.Errorf("hardcover get author works: %w", err)
+		}
+		for _, b := range resp.Data.Books {
+			books = append(books, c.toBook(b))
+		}
+		if len(resp.Data.Books) < authorWorksPageSize {
+			break
+		}
 	}
 	return books, nil
 }
@@ -518,6 +585,10 @@ type hcBook struct {
 	RatingsCount  int              `json:"ratings_count"`
 	Rating        float64          `json:"rating"`
 	UsersCount    int              `json:"users_count"`
+	Genres        []string         `json:"genres"`
+	HasAudiobook  bool             `json:"has_audiobook"`
+	HasEbook      bool             `json:"has_ebook"`
+	AudioSeconds  *int             `json:"audio_seconds"`
 	Contributions []hcContribution `json:"contributions"`
 }
 
@@ -558,12 +629,18 @@ func (c *Client) toBook(b hcBook) models.Book {
 		Status:           models.BookStatusWanted,
 		Genres:           []string{},
 	}
+	if len(b.Genres) > 0 {
+		bk.Genres = b.Genres
+	}
 	if b.Image != nil {
 		bk.ImageURL = b.Image.URL
 	}
 	if b.ReleaseYear != nil && *b.ReleaseYear > 0 {
 		t := time.Date(*b.ReleaseYear, 1, 1, 0, 0, 0, 0, time.UTC)
 		bk.ReleaseDate = &t
+	}
+	if b.AudioSeconds != nil && *b.AudioSeconds > 0 {
+		bk.DurationSeconds = *b.AudioSeconds
 	}
 	if len(b.Contributions) > 0 {
 		a := c.toAuthor(b.Contributions[0].Author)

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -240,6 +240,87 @@ func TestSearchBooks_HTTPError(t *testing.T) {
 	}
 }
 
+func TestGetAuthorWorksByName_WithToken(t *testing.T) {
+	var gotVars map[string]any
+	var gotAuth string
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		gotAuth = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		var req gqlRequest
+		_ = json.Unmarshal(body, &req)
+		gotVars = req.Variables
+		data := map[string]interface{}{
+			"books": []map[string]interface{}{
+				{
+					"id":            10,
+					"title":         "Dune",
+					"slug":          "dune",
+					"description":   "A desert planet.",
+					"image":         map[string]interface{}{"url": "https://img/dune.jpg"},
+					"release_year":  1965,
+					"ratings_count": 1000,
+					"rating":        4.5,
+					"users_count":   2000,
+					"genres":        []string{"Science Fiction"},
+					"has_audiobook": true,
+					"has_ebook":     false,
+					"audio_seconds": 7200,
+					"contributions": []map[string]interface{}{
+						{"author": map[string]interface{}{"id": 1, "name": "Frank Herbert", "slug": "frank-herbert"}},
+					},
+				},
+			},
+		}
+		return gqlResponse(t, http.StatusOK, data), nil
+	}).WithToken("hc-secret")
+
+	books, err := c.GetAuthorWorksByName(context.Background(), "Frank Herbert")
+	if err != nil {
+		t.Fatalf("GetAuthorWorksByName: %v", err)
+	}
+	if gotAuth != "Bearer hc-secret" {
+		t.Fatalf("Authorization = %q, want Bearer token", gotAuth)
+	}
+	if gotVars["author"] != "Frank Herbert" {
+		t.Fatalf("author variable = %v", gotVars["author"])
+	}
+	if len(books) != 1 {
+		t.Fatalf("books len = %d, want 1", len(books))
+	}
+	book := books[0]
+	if book.ForeignID != "hc:dune" || book.Title != "Dune" || book.ImageURL == "" {
+		t.Fatalf("unexpected book: %+v", book)
+	}
+	if book.DurationSeconds != 7200 {
+		t.Fatalf("DurationSeconds = %d, want 7200", book.DurationSeconds)
+	}
+	if len(book.Genres) != 1 || book.Genres[0] != "Science Fiction" {
+		t.Fatalf("Genres = %+v", book.Genres)
+	}
+	if book.MediaType != "" {
+		t.Fatalf("MediaType = %q, want empty author import default", book.MediaType)
+	}
+}
+
+func TestGetAuthorWorksByName_NoTokenSkipsRequest(t *testing.T) {
+	called := false
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		called = true
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{}), nil
+	})
+
+	books, err := c.GetAuthorWorksByName(context.Background(), "Frank Herbert")
+	if err != nil {
+		t.Fatalf("GetAuthorWorksByName: %v", err)
+	}
+	if called {
+		t.Fatal("expected no HTTP request without token")
+	}
+	if books != nil {
+		t.Fatalf("books = %+v, want nil", books)
+	}
+}
+
 func TestGetAuthor_Found(t *testing.T) {
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
 		data := map[string]interface{}{

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -3,10 +3,13 @@ package hardcover
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/vavallee/bindery/internal/metadata"
 )
 
 // testTransport routes all HTTP calls through a handler function.
@@ -310,8 +313,8 @@ func TestGetAuthorWorksByName_NoTokenSkipsRequest(t *testing.T) {
 	})
 
 	books, err := c.GetAuthorWorksByName(context.Background(), "Frank Herbert")
-	if err != nil {
-		t.Fatalf("GetAuthorWorksByName: %v", err)
+	if !errors.Is(err, metadata.ErrProviderNotConfigured) {
+		t.Fatalf("GetAuthorWorksByName error = %v, want ErrProviderNotConfigured", err)
 	}
 	if called {
 		t.Fatal("expected no HTTP request without token")

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -53,6 +53,62 @@ func TestName(t *testing.T) {
 	}
 }
 
+func TestNormalizeAPIToken(t *testing.T) {
+	cases := map[string]string{
+		"hc-secret":                         "hc-secret",
+		"Bearer hc-secret":                  "hc-secret",
+		"bearer hc-secret":                  "hc-secret",
+		"Bearer Bearer hc-secret":           "hc-secret",
+		" \n Bearer hc-secret \n\t":         "hc-secret",
+		`"Bearer hc-secret"`:                "hc-secret",
+		"Authorization: Bearer hc-secret":   "hc-secret",
+		"authorization: hc-secret":          "hc-secret",
+		"Authorization=Bearer Bearer token": "token",
+		"Bearer":                            "",
+		"Authorization: Bearer":             "",
+	}
+	for input, want := range cases {
+		if got := NormalizeAPIToken(input); got != want {
+			t.Errorf("NormalizeAPIToken(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestQuery_UsesNormalizedAuthorizationHeader(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		client *Client
+	}{
+		{name: "token", client: newMockClient(nil).WithToken("Bearer Bearer hc-secret")},
+		{name: "source", client: newMockClient(nil).WithTokenSource(func(context.Context) string { return "bearer hc-secret" })},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.client.http.Transport = &testTransport{handler: func(r *http.Request) (*http.Response, error) {
+				if got := r.Header.Get("Authorization"); got != "Bearer hc-secret" {
+					t.Fatalf("Authorization = %q, want Bearer hc-secret", got)
+				}
+				return gqlResponse(t, http.StatusOK, map[string]interface{}{"authors": []interface{}{}}), nil
+			}}
+			if _, err := tt.client.SearchAuthors(context.Background(), "nobody"); err != nil {
+				t.Fatalf("SearchAuthors: %v", err)
+			}
+		})
+	}
+}
+
+func TestQuery_GraphQLErrorsReturnError(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		return gqlResponse(t, http.StatusOK, `{"errors":[{"message":"Malformed Authorization header","extensions":{"code":"invalid-headers"}}]}`), nil
+	})
+	_, err := c.SearchAuthors(context.Background(), "Sanderson")
+	if err == nil {
+		t.Fatal("expected GraphQL error")
+	}
+	if !strings.Contains(err.Error(), "Malformed Authorization header") || !strings.Contains(err.Error(), "invalid-headers") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestSearchAuthors_Success(t *testing.T) {
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
 		data := map[string]interface{}{
@@ -420,6 +476,7 @@ func TestSearchSeries_ParsesResults(t *testing.T) {
 		gotVars = req.Variables
 		data := map[string]interface{}{
 			"search": map[string]interface{}{
+				"ids": []interface{}{123},
 				"results": map[string]interface{}{
 					"found": 1,
 					"hits": []map[string]interface{}{
@@ -456,6 +513,29 @@ func TestSearchSeries_ParsesResults(t *testing.T) {
 	}
 	if got.Title != "Foundation" || got.AuthorName != "Isaac Asimov" || got.BookCount != 7 || got.ReadersCount != 1000 {
 		t.Fatalf("unexpected result: %+v", got)
+	}
+}
+
+func TestSearchSeries_ErrorsWhenMatchesCannotBeMapped(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{
+			"search": map[string]interface{}{
+				"ids": []interface{}{123},
+				"results": map[string]interface{}{
+					"found": 1,
+					"hits": []map[string]interface{}{
+						{"document": map[string]interface{}{"name": "Dune"}},
+					},
+				},
+			},
+		}), nil
+	})
+	_, err := c.SearchSeries(context.Background(), "Dune", 5)
+	if err == nil {
+		t.Fatal("expected unmappable search response error")
+	}
+	if !strings.Contains(err.Error(), "no mappable series documents") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -411,6 +411,161 @@ func TestGetBookByISBN_HTTPError(t *testing.T) {
 	}
 }
 
+func TestSearchSeries_ParsesResults(t *testing.T) {
+	var gotVars map[string]any
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		var req gqlRequest
+		_ = json.Unmarshal(body, &req)
+		gotVars = req.Variables
+		data := map[string]interface{}{
+			"search": map[string]interface{}{
+				"results": map[string]interface{}{
+					"found": 1,
+					"hits": []map[string]interface{}{
+						{
+							"document": map[string]interface{}{
+								"id":                  123,
+								"name":                "Foundation",
+								"author_name":         "Isaac Asimov",
+								"primary_books_count": 7,
+								"readers_count":       1000,
+								"books":               []string{"Foundation", "Foundation and Empire"},
+							},
+						},
+					},
+				},
+			},
+		}
+		return gqlResponse(t, http.StatusOK, data), nil
+	})
+
+	results, err := c.SearchSeries(context.Background(), "Foundation", 5)
+	if err != nil {
+		t.Fatalf("SearchSeries: %v", err)
+	}
+	if gotVars["queryType"] != "Series" {
+		t.Fatalf("queryType = %v, want Series", gotVars["queryType"])
+	}
+	if len(results) != 1 {
+		t.Fatalf("results len = %d, want 1", len(results))
+	}
+	got := results[0]
+	if got.ForeignID != "hc-series:123" || got.ProviderID != "123" {
+		t.Fatalf("ids = %q/%q, want hc-series:123/123", got.ForeignID, got.ProviderID)
+	}
+	if got.Title != "Foundation" || got.AuthorName != "Isaac Asimov" || got.BookCount != 7 || got.ReadersCount != 1000 {
+		t.Fatalf("unexpected result: %+v", got)
+	}
+}
+
+func TestSearchSeries_ParsesStringResults(t *testing.T) {
+	encoded := `{"found":1,"hits":[{"document":{"id":"42","name":"Murderbot Diaries","books_count":6}}]}`
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{
+			"search": map[string]interface{}{"results": encoded},
+		}), nil
+	})
+
+	results, err := c.SearchSeries(context.Background(), "Murderbot", 10)
+	if err != nil {
+		t.Fatalf("SearchSeries: %v", err)
+	}
+	if len(results) != 1 || results[0].ForeignID != "hc-series:42" || results[0].BookCount != 6 {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestSearchSeries_HTTPError(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Body:       io.NopCloser(strings.NewReader("bad gateway")),
+			Header:     make(http.Header),
+		}, nil
+	})
+	if _, err := c.SearchSeries(context.Background(), "anything", 10); err == nil {
+		t.Fatal("expected error on 502")
+	}
+}
+
+func TestGetSeriesCatalog_ParsesAndDedupesBooks(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		data := map[string]interface{}{
+			"series_by_pk": map[string]interface{}{
+				"id":          123,
+				"name":        "Foundation",
+				"books_count": 3,
+				"author":      map[string]interface{}{"name": "Isaac Asimov"},
+				"book_series": []map[string]interface{}{
+					{
+						"position": 2,
+						"book": map[string]interface{}{
+							"id":          202,
+							"title":       "Foundation",
+							"slug":        "foundation-later",
+							"users_count": 10,
+						},
+					},
+					{
+						"position": 1,
+						"book": map[string]interface{}{
+							"id":          201,
+							"title":       "Foundation",
+							"subtitle":    "The First Book",
+							"slug":        "foundation",
+							"users_count": 100,
+						},
+					},
+					{
+						"position": 2,
+						"book": map[string]interface{}{
+							"id":    203,
+							"title": "Foundation and Empire",
+							"slug":  "foundation-and-empire",
+						},
+					},
+				},
+			},
+		}
+		return gqlResponse(t, http.StatusOK, data), nil
+	})
+
+	catalog, err := c.GetSeriesCatalog(context.Background(), "hc-series:123")
+	if err != nil {
+		t.Fatalf("GetSeriesCatalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatal("expected catalog")
+	}
+	if catalog.ForeignID != "hc-series:123" || catalog.Title != "Foundation" || catalog.AuthorName != "Isaac Asimov" {
+		t.Fatalf("unexpected catalog: %+v", catalog)
+	}
+	if len(catalog.Books) != 2 {
+		t.Fatalf("books len = %d, want 2: %+v", len(catalog.Books), catalog.Books)
+	}
+	if catalog.Books[0].ForeignID != "hc:foundation" || catalog.Books[0].Position != "1" {
+		t.Fatalf("first book = %+v, want deduped lower position Foundation", catalog.Books[0])
+	}
+	if catalog.Books[1].ForeignID != "hc:foundation-and-empire" || catalog.Books[1].Position != "2" {
+		t.Fatalf("second book = %+v", catalog.Books[1])
+	}
+}
+
+func TestGetSeriesCatalog_NotFound(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{"series_by_pk": nil}), nil
+	})
+
+	catalog, err := c.GetSeriesCatalog(context.Background(), "hc-series:999")
+	if err != nil {
+		t.Fatalf("GetSeriesCatalog: %v", err)
+	}
+	if catalog != nil {
+		t.Fatalf("expected nil catalog, got %+v", catalog)
+	}
+}
+
 func TestToAuthor_NoSlug_UsesID(t *testing.T) {
 	c := New()
 	a := c.toAuthor(hcAuthor{ID: 42, Name: "Unknown Author", Slug: ""})

--- a/internal/metadata/hardcover/series.go
+++ b/internal/metadata/hardcover/series.go
@@ -1,0 +1,324 @@
+package hardcover
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/indexer"
+	"github.com/vavallee/bindery/internal/metadata"
+)
+
+const seriesIDPrefix = "hc-series:"
+
+// SearchSeries searches Hardcover's catalog using the same search endpoint
+// Shelfarr uses for series discovery.
+func (c *Client) SearchSeries(ctx context.Context, query string, limit int) ([]metadata.SeriesSearchResult, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	gql := `query SearchSeries($query: String!, $queryType: String!, $perPage: Int!) {
+		search(query: $query, query_type: $queryType, per_page: $perPage) {
+			results
+		}
+	}`
+	var resp struct {
+		Data struct {
+			Search struct {
+				Results json.RawMessage `json:"results"`
+			} `json:"search"`
+		} `json:"data"`
+	}
+	if err := c.query(ctx, gql, map[string]any{
+		"query":     query,
+		"queryType": "Series",
+		"perPage":   limit,
+	}, &resp); err != nil {
+		return nil, fmt.Errorf("hardcover search series: %w", err)
+	}
+	return parseSeriesSearchResults(resp.Data.Search.Results), nil
+}
+
+// GetSeriesCatalog fetches the ordered books in a Hardcover series.
+func (c *Client) GetSeriesCatalog(ctx context.Context, foreignID string) (*metadata.SeriesCatalog, error) {
+	seriesID, err := hardcoverSeriesNumericID(foreignID)
+	if err != nil {
+		return nil, err
+	}
+	gql := `query GetBooksBySeries($seriesId: Int!) {
+		series_by_pk(id: $seriesId) {
+			id
+			name
+			author { name }
+			books_count
+			book_series(
+				order_by: {position: asc}
+				where: {book: {canonical_id: {_is_null: true}}}
+			) {
+				position
+				book {
+					id
+					title
+					subtitle
+					slug
+					description
+					users_count
+					image { url }
+					release_year
+					ratings_count
+					rating
+					contributions {
+						author { id name slug }
+					}
+				}
+			}
+		}
+	}`
+	var resp struct {
+		Data struct {
+			Series *hcSeriesCatalog `json:"series_by_pk"`
+		} `json:"data"`
+	}
+	if err := c.query(ctx, gql, map[string]any{"seriesId": seriesID}, &resp); err != nil {
+		return nil, fmt.Errorf("hardcover get series catalog: %w", err)
+	}
+	if resp.Data.Series == nil {
+		return nil, nil
+	}
+	return c.toSeriesCatalog(*resp.Data.Series), nil
+}
+
+type hcSeriesCatalog struct {
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	BooksCount int    `json:"books_count"`
+	Author     *struct {
+		Name string `json:"name"`
+	} `json:"author"`
+	BookSeries []struct {
+		Position any    `json:"position"`
+		Book     hcBook `json:"book"`
+	} `json:"book_series"`
+}
+
+type hcSeriesSearchEnvelope struct {
+	Found int                    `json:"found"`
+	Hits  []hcSeriesSearchResult `json:"hits"`
+}
+
+type hcSeriesSearchResult struct {
+	Document hcSeriesSearchDocument `json:"document"`
+}
+
+type hcSeriesSearchDocument struct {
+	ID                any      `json:"id"`
+	Name              string   `json:"name"`
+	AuthorName        string   `json:"author_name"`
+	PrimaryBooksCount int      `json:"primary_books_count"`
+	BooksCount        int      `json:"books_count"`
+	BookCount         int      `json:"book_count"`
+	ReadersCount      int      `json:"readers_count"`
+	Books             []string `json:"books"`
+}
+
+func parseSeriesSearchResults(raw json.RawMessage) []metadata.SeriesSearchResult {
+	raw = normalizeRawSearchResults(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var envelope hcSeriesSearchEnvelope
+	if err := json.Unmarshal(raw, &envelope); err == nil && len(envelope.Hits) > 0 {
+		out := make([]metadata.SeriesSearchResult, 0, len(envelope.Hits))
+		for _, hit := range envelope.Hits {
+			if result := seriesSearchDocumentToResult(hit.Document); result.ForeignID != "" {
+				out = append(out, result)
+			}
+		}
+		return out
+	}
+	var items []hcSeriesSearchResult
+	if err := json.Unmarshal(raw, &items); err == nil {
+		out := make([]metadata.SeriesSearchResult, 0, len(items))
+		for _, item := range items {
+			if result := seriesSearchDocumentToResult(item.Document); result.ForeignID != "" {
+				out = append(out, result)
+			}
+		}
+		return out
+	}
+	var docs []hcSeriesSearchDocument
+	if err := json.Unmarshal(raw, &docs); err == nil {
+		out := make([]metadata.SeriesSearchResult, 0, len(docs))
+		for _, doc := range docs {
+			if result := seriesSearchDocumentToResult(doc); result.ForeignID != "" {
+				out = append(out, result)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func normalizeRawSearchResults(raw json.RawMessage) json.RawMessage {
+	var encoded string
+	if err := json.Unmarshal(raw, &encoded); err == nil {
+		return json.RawMessage(encoded)
+	}
+	return raw
+}
+
+func seriesSearchDocumentToResult(doc hcSeriesSearchDocument) metadata.SeriesSearchResult {
+	id := seriesIDString(doc.ID)
+	if id == "" {
+		return metadata.SeriesSearchResult{}
+	}
+	count := doc.PrimaryBooksCount
+	if count == 0 {
+		count = doc.BooksCount
+	}
+	if count == 0 {
+		count = doc.BookCount
+	}
+	return metadata.SeriesSearchResult{
+		ForeignID:    seriesIDPrefix + id,
+		ProviderID:   id,
+		Title:        strings.TrimSpace(doc.Name),
+		AuthorName:   strings.TrimSpace(doc.AuthorName),
+		BookCount:    count,
+		ReadersCount: doc.ReadersCount,
+		Books:        doc.Books,
+	}
+}
+
+func (c *Client) toSeriesCatalog(series hcSeriesCatalog) *metadata.SeriesCatalog {
+	catalog := &metadata.SeriesCatalog{
+		ForeignID:  seriesIDPrefix + strconv.Itoa(series.ID),
+		ProviderID: strconv.Itoa(series.ID),
+		Title:      strings.TrimSpace(series.Name),
+		BookCount:  series.BooksCount,
+	}
+	if series.Author != nil {
+		catalog.AuthorName = strings.TrimSpace(series.Author.Name)
+	}
+	books := make([]metadata.SeriesCatalogBook, 0, len(series.BookSeries))
+	for _, entry := range series.BookSeries {
+		book := c.toBook(entry.Book)
+		position := formatSeriesPosition(entry.Position)
+		books = append(books, metadata.SeriesCatalogBook{
+			ForeignID:  book.ForeignID,
+			ProviderID: strconv.Itoa(entry.Book.ID),
+			Title:      strings.TrimSpace(entry.Book.Title),
+			Subtitle:   strings.TrimSpace(entry.Book.Subtitle),
+			Position:   position,
+			UsersCount: entry.Book.UsersCount,
+			Book:       book,
+		})
+	}
+	catalog.Books = dedupeSeriesCatalogBooks(books)
+	return catalog
+}
+
+func dedupeSeriesCatalogBooks(books []metadata.SeriesCatalogBook) []metadata.SeriesCatalogBook {
+	if len(books) < 2 {
+		return books
+	}
+	byTitle := make(map[string]metadata.SeriesCatalogBook, len(books))
+	order := make([]string, 0, len(books))
+	for _, book := range books {
+		key := indexer.NormalizeTitleForDedup(book.Title)
+		if key == "" {
+			key = strings.ToLower(strings.TrimSpace(book.Title))
+		}
+		existing, ok := byTitle[key]
+		if !ok {
+			byTitle[key] = book
+			order = append(order, key)
+			continue
+		}
+		if compareSeriesPosition(book.Position, existing.Position) < 0 {
+			byTitle[key] = book
+		}
+	}
+	out := make([]metadata.SeriesCatalogBook, 0, len(order))
+	for _, key := range order {
+		out = append(out, byTitle[key])
+	}
+	sort.SliceStable(out, func(a, b int) bool {
+		return compareSeriesPosition(out[a].Position, out[b].Position) < 0
+	})
+	return out
+}
+
+func compareSeriesPosition(a, b string) int {
+	af, aerr := strconv.ParseFloat(strings.TrimSpace(a), 64)
+	bf, berr := strconv.ParseFloat(strings.TrimSpace(b), 64)
+	switch {
+	case aerr == nil && berr == nil && af < bf:
+		return -1
+	case aerr == nil && berr == nil && af > bf:
+		return 1
+	case aerr == nil && berr != nil:
+		return -1
+	case aerr != nil && berr == nil:
+		return 1
+	default:
+		return strings.Compare(a, b)
+	}
+}
+
+func formatSeriesPosition(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(v)
+	case json.Number:
+		return strings.TrimRight(strings.TrimRight(v.String(), "0"), ".")
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}
+
+func hardcoverSeriesNumericID(foreignID string) (int, error) {
+	id := strings.TrimPrefix(strings.TrimSpace(foreignID), seriesIDPrefix)
+	if id == "" {
+		return 0, fmt.Errorf("hardcover series id is empty")
+	}
+	parsed, err := strconv.Atoi(id)
+	if err != nil {
+		return 0, fmt.Errorf("hardcover series id %q is not numeric: %w", foreignID, err)
+	}
+	return parsed, nil
+}
+
+func seriesIDString(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(v)
+	case json.Number:
+		return strings.TrimSpace(v.String())
+	case float64:
+		return strconv.FormatInt(int64(v), 10)
+	case int:
+		return strconv.Itoa(v)
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}

--- a/internal/metadata/hardcover/series.go
+++ b/internal/metadata/hardcover/series.go
@@ -26,12 +26,14 @@ func (c *Client) SearchSeries(ctx context.Context, query string, limit int) ([]m
 	}
 	gql := `query SearchSeries($query: String!, $queryType: String!, $perPage: Int!) {
 		search(query: $query, query_type: $queryType, per_page: $perPage) {
+			ids
 			results
 		}
 	}`
 	var resp struct {
 		Data struct {
 			Search struct {
+				IDs     []any           `json:"ids"`
 				Results json.RawMessage `json:"results"`
 			} `json:"search"`
 		} `json:"data"`
@@ -43,7 +45,17 @@ func (c *Client) SearchSeries(ctx context.Context, query string, limit int) ([]m
 	}, &resp); err != nil {
 		return nil, fmt.Errorf("hardcover search series: %w", err)
 	}
-	return parseSeriesSearchResults(resp.Data.Search.Results), nil
+	results := parseSeriesSearchResults(resp.Data.Search.Results)
+	if len(results) == 0 {
+		found := seriesSearchFoundCount(resp.Data.Search.Results)
+		if found == 0 {
+			found = len(resp.Data.Search.IDs)
+		}
+		if found > 0 {
+			return nil, fmt.Errorf("hardcover search series: response contained %d matches but no mappable series documents", found)
+		}
+	}
+	return results, nil
 }
 
 // GetSeriesCatalog fetches the ordered books in a Hardcover series.
@@ -172,6 +184,18 @@ func normalizeRawSearchResults(raw json.RawMessage) json.RawMessage {
 		return json.RawMessage(encoded)
 	}
 	return raw
+}
+
+func seriesSearchFoundCount(raw json.RawMessage) int {
+	raw = normalizeRawSearchResults(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return 0
+	}
+	var envelope hcSeriesSearchEnvelope
+	if err := json.Unmarshal(raw, &envelope); err == nil {
+		return envelope.Found
+	}
+	return 0
 }
 
 func seriesSearchDocumentToResult(doc hcSeriesSearchDocument) metadata.SeriesSearchResult {

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -212,11 +213,28 @@ func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, e
 // Both upstream calls are best-effort: as long as one returns, we proceed —
 // the other's failure is logged.
 func (c *Client) GetAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error) {
-	primary, primaryErr := c.authorWorksBackfill(ctx, authorForeignID)
+	var (
+		primary    []authorWorkEntry
+		primaryErr error
+		enrichment []models.Book
+		enrichErr  error
+		wg         sync.WaitGroup
+	)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		primary, primaryErr = c.authorWorksBackfill(ctx, authorForeignID)
+	}()
+	go func() {
+		defer wg.Done()
+		enrichment, enrichErr = c.searchAuthorWorks(ctx, authorForeignID)
+	}()
+	wg.Wait()
+
 	if primaryErr != nil {
 		slog.Warn("openlibrary: author works endpoint failed", "author", authorForeignID, "error", primaryErr)
 	}
-	enrichment, enrichErr := c.searchAuthorWorks(ctx, authorForeignID)
 	if enrichErr != nil {
 		slog.Debug("openlibrary: author search enrichment failed", "author", authorForeignID, "error", enrichErr)
 	}

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -6,7 +6,10 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // pathTransport routes HTTP calls by URL path to a handler map.
@@ -646,6 +649,52 @@ func TestGetAuthorWorks_HTTP(t *testing.T) {
 	}
 	if books[0].Author == nil || books[0].Author.ForeignID != "OL123A" {
 		t.Errorf("author reference not populated: %+v", books[0].Author)
+	}
+}
+
+func TestGetAuthorWorks_HTTP_FetchesSourcesConcurrently(t *testing.T) {
+	searchResp := searchRespForAuthor{Docs: []searchDocForAuthor{{Key: "/works/OL1W", Title: "Primary"}}}
+	worksResp := authorWorksResponse{Entries: []authorWorkEntry{{Key: "/works/OL1W", Title: "Primary"}}}
+
+	var mu sync.Mutex
+	var once sync.Once
+	var timedOut atomic.Bool
+	started := map[string]bool{}
+	bothStarted := make(chan struct{})
+	markStarted := func(path string) {
+		mu.Lock()
+		defer mu.Unlock()
+		started[path] = true
+		if started["/search"] && started["/authors/OL123A/works.json"] {
+			once.Do(func() { close(bothStarted) })
+		}
+	}
+	waitForPeer := func(path, body string) func(*http.Request) string {
+		return func(r *http.Request) string {
+			markStarted(path)
+			select {
+			case <-bothStarted:
+			case <-time.After(500 * time.Millisecond):
+				timedOut.Store(true)
+			}
+			return body
+		}
+	}
+
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/search":                    waitForPeer("/search", jsonStr(searchResp)),
+		"/authors/OL123A/works.json": waitForPeer("/authors/OL123A/works.json", jsonStr(worksResp)),
+	})
+
+	books, err := c.GetAuthorWorks(context.Background(), "OL123A")
+	if err != nil {
+		t.Fatalf("GetAuthorWorks: %v", err)
+	}
+	if timedOut.Load() {
+		t.Fatal("expected search and works requests to overlap")
+	}
+	if len(books) != 1 || books[0].Title != "Primary" {
+		t.Fatalf("unexpected books: %+v", books)
 	}
 }
 

--- a/internal/metadata/provider.go
+++ b/internal/metadata/provider.go
@@ -29,3 +29,42 @@ type Provider interface {
 	// GetBookByISBN looks up a book by ISBN-13 or ISBN-10.
 	GetBookByISBN(ctx context.Context, isbn string) (*models.Book, error)
 }
+
+// SeriesSearchResult is a provider-neutral series discovery result.
+type SeriesSearchResult struct {
+	ForeignID    string
+	ProviderID   string
+	Title        string
+	AuthorName   string
+	BookCount    int
+	ReadersCount int
+	Books        []string
+}
+
+// SeriesCatalog is an ordered provider catalog for a single series.
+type SeriesCatalog struct {
+	ForeignID  string
+	ProviderID string
+	Title      string
+	AuthorName string
+	BookCount  int
+	Books      []SeriesCatalogBook
+}
+
+// SeriesCatalogBook is a provider book entry with its position in a series.
+type SeriesCatalogBook struct {
+	ForeignID  string
+	ProviderID string
+	Title      string
+	Subtitle   string
+	Position   string
+	UsersCount int
+	Book       models.Book
+}
+
+// SeriesCatalogProvider is an optional metadata provider capability used by
+// importers that can safely link provider series without widening Provider.
+type SeriesCatalogProvider interface {
+	SearchSeries(ctx context.Context, query string, limit int) ([]SeriesSearchResult, error)
+	GetSeriesCatalog(ctx context.Context, foreignID string) (*SeriesCatalog, error)
+}

--- a/internal/metadata/provider.go
+++ b/internal/metadata/provider.go
@@ -2,9 +2,14 @@ package metadata
 
 import (
 	"context"
+	"errors"
 
 	"github.com/vavallee/bindery/internal/models"
 )
+
+// ErrProviderNotConfigured signals that an optional provider capability was
+// skipped because credentials or runtime configuration are missing.
+var ErrProviderNotConfigured = errors.New("metadata provider not configured")
 
 // Provider defines the interface that all metadata sources must implement.
 type Provider interface {

--- a/internal/models/series.go
+++ b/internal/models/series.go
@@ -11,7 +11,23 @@ type Series struct {
 	CreatedAt   time.Time `json:"createdAt"`
 
 	// Joined data
-	Books []SeriesBook `json:"books,omitempty"`
+	Books         []SeriesBook         `json:"books,omitempty"`
+	HardcoverLink *SeriesHardcoverLink `json:"hardcoverLink,omitempty"`
+}
+
+type SeriesHardcoverLink struct {
+	ID                  int64     `json:"id"`
+	SeriesID            int64     `json:"seriesId"`
+	HardcoverSeriesID   string    `json:"hardcoverSeriesId"`
+	HardcoverProviderID string    `json:"hardcoverProviderId"`
+	HardcoverTitle      string    `json:"hardcoverTitle"`
+	HardcoverAuthorName string    `json:"hardcoverAuthorName"`
+	HardcoverBookCount  int       `json:"hardcoverBookCount"`
+	Confidence          float64   `json:"confidence"`
+	LinkedBy            string    `json:"linkedBy"`
+	LinkedAt            time.Time `json:"linkedAt"`
+	CreatedAt           time.Time `json:"createdAt"`
+	UpdatedAt           time.Time `json:"updatedAt"`
 }
 
 type SeriesBook struct {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -73,6 +74,8 @@ type Scheduler struct {
 	logs          *db.LogRepo          // optional; enables periodic log retention trim
 	logRetainDays int                  // 0 = use default (14)
 }
+
+const scheduledWantedSearchConcurrency = 2
 
 // New creates a new scheduler.
 func New(
@@ -520,12 +523,44 @@ func (s *Scheduler) searchWanted() {
 		return
 	}
 
+	searchQueue := make([]models.Book, 0, len(wanted))
 	for _, book := range wanted {
 		if book.Excluded {
 			continue
 		}
-		s.SearchAndGrabBook(ctx, book)
+		searchQueue = append(searchQueue, book)
 	}
+	runBoundedBookTasks(ctx, searchQueue, scheduledWantedSearchConcurrency, func(ctx context.Context, book models.Book) {
+		s.SearchAndGrabBook(ctx, book)
+	})
+}
+
+func runBoundedBookTasks(ctx context.Context, books []models.Book, concurrency int, fn func(context.Context, models.Book)) {
+	if fn == nil || len(books) == 0 {
+		return
+	}
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+	for _, book := range books {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		}
+		book := book
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			fn(ctx, book)
+		}()
+	}
+	wg.Wait()
 }
 
 func (s *Scheduler) refreshMetadata() {

--- a/internal/scheduler/scheduler_jobs_test.go
+++ b/internal/scheduler/scheduler_jobs_test.go
@@ -2,6 +2,8 @@ package scheduler
 
 import (
 	"context"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -148,6 +150,41 @@ func TestSearchWanted_EmptyDB(t *testing.T) {
 	}
 	// Must not panic; returns immediately when no wanted books.
 	s.searchWanted()
+}
+
+func TestRunBoundedBookTasks_LimitsConcurrency(t *testing.T) {
+	books := make([]models.Book, 6)
+	for i := range books {
+		books[i] = models.Book{Title: "Book " + strconv.Itoa(i)}
+	}
+
+	var mu sync.Mutex
+	var calls, active, maxActive int
+	runBoundedBookTasks(context.Background(), books, 2, func(_ context.Context, _ models.Book) {
+		mu.Lock()
+		calls++
+		active++
+		if active > maxActive {
+			maxActive = active
+		}
+		mu.Unlock()
+
+		time.Sleep(20 * time.Millisecond)
+
+		mu.Lock()
+		active--
+		mu.Unlock()
+	})
+
+	if calls != len(books) {
+		t.Fatalf("calls = %d, want %d", calls, len(books))
+	}
+	if maxActive > 2 {
+		t.Fatalf("maxActive = %d, want <= 2", maxActive)
+	}
+	if maxActive < 2 {
+		t.Fatalf("expected parallel execution, maxActive = %d", maxActive)
+	}
 }
 
 // TestSearchWanted_ErrorPath exercises the error-return when the books repo

--- a/internal/seriesmatch/match.go
+++ b/internal/seriesmatch/match.go
@@ -1,0 +1,98 @@
+// Package seriesmatch contains title and position matching helpers shared by
+// Audiobookshelf import and user-triggered series linking.
+package seriesmatch
+
+import (
+	"math"
+	"strconv"
+	"strings"
+	"unicode"
+
+	fuzzy "github.com/creditx/go-fuzzywuzzy"
+	"github.com/vavallee/bindery/internal/indexer"
+)
+
+func SamePosition(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	af, aerr := strconv.ParseFloat(a, 64)
+	bf, berr := strconv.ParseFloat(b, 64)
+	return aerr == nil && berr == nil && math.Abs(af-bf) < 0.001
+}
+
+func NormalizeSeriesName(name string) string {
+	normalized := indexer.NormalizeTitleForDedup(strings.TrimSpace(name))
+	if normalized == "" {
+		return ""
+	}
+	suffixes := map[string]struct{}{
+		"series":     {},
+		"trilogy":    {},
+		"saga":       {},
+		"chronicles": {},
+		"cycle":      {},
+		"books":      {},
+		"novels":     {},
+	}
+	words := strings.Fields(normalized)
+	if len(words) > 1 {
+		if _, ok := suffixes[words[len(words)-1]]; ok {
+			words = words[:len(words)-1]
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+func TitleScore(a, b string) int {
+	cleanA := CleanTitle(a)
+	cleanB := CleanTitle(b)
+	if cleanA == "" || cleanB == "" {
+		return 0
+	}
+	return max(
+		fuzzy.TokenSetRatio(cleanA, cleanB),
+		fuzzy.TokenSortRatio(cleanA, cleanB),
+		fuzzy.Ratio(cleanA, cleanB),
+		fuzzy.PartialRatio(cleanA, cleanB),
+	)
+}
+
+func CleanTitle(title string) string {
+	title = strings.ToLower(strings.TrimSpace(title))
+	if title == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range title {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+			b.WriteRune(r)
+		case unicode.IsSpace(r):
+			b.WriteRune(' ')
+		default:
+			b.WriteRune(' ')
+		}
+	}
+	noise := map[string]struct{}{
+		"a":     {},
+		"an":    {},
+		"the":   {},
+		"novel": {},
+		"book":  {},
+	}
+	words := strings.Fields(b.String())
+	out := words[:0]
+	for _, word := range words {
+		if _, ok := noise[word]; ok {
+			continue
+		}
+		out = append(out, word)
+	}
+	return strings.Join(out, " ")
+}

--- a/tests/abscontract/contract_test.go
+++ b/tests/abscontract/contract_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/abs"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
 )
 
 func TestFixtureManifestMatchesPinnedBaseline(t *testing.T) {
@@ -130,8 +131,8 @@ func TestContractHarness_EnumeratesPagingAndDetailFallback(t *testing.T) {
 	if stats.PagesScanned != 3 {
 		t.Fatalf("pagesScanned = %d, want 3", stats.PagesScanned)
 	}
-	if stats.ItemsSeen != 5 || stats.ItemsNormalized != 5 {
-		t.Fatalf("stats = %+v, want 5 items seen/normalized", stats)
+	if stats.ItemsSeen != 6 || stats.ItemsNormalized != 6 {
+		t.Fatalf("stats = %+v, want 6 items seen/normalized", stats)
 	}
 	if stats.ItemsDetailFetched != 2 {
 		t.Fatalf("itemsDetailFetched = %d, want 2", stats.ItemsDetailFetched)
@@ -169,7 +170,7 @@ func TestContractHarness_ImporterDryRunAndIdempotentRerun(t *testing.T) {
 		t.Fatal(err)
 	}
 	harness := newFixtureABSHarness(t, cfg, manifest)
-	importer, authorRepo, bookRepo, _, runRepo := newContractImporterFixture(t)
+	importer, authorRepo, bookRepo, seriesRepo, _, runRepo := newContractImporterFixture(t)
 
 	dryRunStats, err := importer.Run(context.Background(), abs.ImportConfig{
 		SourceID:  abs.DefaultSourceID,
@@ -183,8 +184,8 @@ func TestContractHarness_ImporterDryRunAndIdempotentRerun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dry-run Run: %v", err)
 	}
-	if dryRunStats.BooksCreated != 3 || dryRunStats.AuthorsCreated != 3 || dryRunStats.ReviewQueued != 2 {
-		t.Fatalf("dry-run stats = %+v, want 3 created books/authors and 2 queued reviews", dryRunStats)
+	if dryRunStats.BooksCreated != 4 || dryRunStats.AuthorsCreated != 4 || dryRunStats.SeriesCreated != 2 || dryRunStats.SeriesLinked != 1 || dryRunStats.ReviewQueued != 2 {
+		t.Fatalf("dry-run stats = %+v, want 4 books/authors, 2 created series, 1 linked series membership, and 2 queued reviews", dryRunStats)
 	}
 
 	authors, err := authorRepo.List(context.Background())
@@ -213,15 +214,26 @@ func TestContractHarness_ImporterDryRunAndIdempotentRerun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commit Run: %v", err)
 	}
-	if commitStats.BooksCreated != 3 || commitStats.ReviewQueued != 2 {
-		t.Fatalf("commit stats = %+v, want 3 created books and 2 queued reviews", commitStats)
+	if commitStats.BooksCreated != 4 || commitStats.SeriesCreated != 2 || commitStats.SeriesLinked != 1 || commitStats.ReviewQueued != 2 {
+		t.Fatalf("commit stats = %+v, want 4 books, repeated series ownership, and 2 queued reviews", commitStats)
 	}
 	books, err = bookRepo.ListIncludingExcluded(context.Background())
 	if err != nil {
 		t.Fatalf("List books after commit: %v", err)
 	}
-	if len(books) != 3 {
-		t.Fatalf("books = %d, want 3 after commit", len(books))
+	if len(books) != 4 {
+		t.Fatalf("books = %d, want 4 after commit", len(books))
+	}
+	series, err := seriesRepo.ListWithBooks(context.Background())
+	if err != nil {
+		t.Fatalf("ListWithBooks after commit: %v", err)
+	}
+	assertContractSeriesCoverage(t, series)
+	runToRollback := int64(0)
+	if runs, err := runRepo.ListRecent(context.Background(), 1); err == nil && len(runs) == 1 {
+		runToRollback = runs[0].ID
+	} else {
+		t.Fatalf("ListRecent commit run = %d err=%v, want 1", len(runs), err)
 	}
 
 	rerunStats, err := importer.Run(context.Background(), abs.ImportConfig{
@@ -235,16 +247,21 @@ func TestContractHarness_ImporterDryRunAndIdempotentRerun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rerun Run: %v", err)
 	}
-	if rerunStats.BooksCreated != 0 {
-		t.Fatalf("rerun stats = %+v, want no new books", rerunStats)
+	if rerunStats.BooksCreated != 0 || rerunStats.SeriesCreated != 0 || rerunStats.SeriesLinked != 0 {
+		t.Fatalf("rerun stats = %+v, want no new books or series memberships", rerunStats)
 	}
 	books, err = bookRepo.ListIncludingExcluded(context.Background())
 	if err != nil {
 		t.Fatalf("List books after rerun: %v", err)
 	}
-	if len(books) != 3 {
-		t.Fatalf("books after rerun = %d, want 3", len(books))
+	if len(books) != 4 {
+		t.Fatalf("books after rerun = %d, want 4", len(books))
 	}
+	series, err = seriesRepo.ListWithBooks(context.Background())
+	if err != nil {
+		t.Fatalf("ListWithBooks after rerun: %v", err)
+	}
+	assertContractSeriesCoverage(t, series)
 
 	runs, err := runRepo.ListRecent(context.Background(), 3)
 	if err != nil {
@@ -254,8 +271,41 @@ func TestContractHarness_ImporterDryRunAndIdempotentRerun(t *testing.T) {
 		t.Fatalf("runs = %d, want 3", len(runs))
 	}
 	latestDryRun := abs.HydrateRun(runs[2])
-	if !latestDryRun.Summary.DryRun || latestDryRun.Summary.Stats.BooksCreated != 3 || latestDryRun.Summary.Stats.ReviewQueued != 2 {
+	if !latestDryRun.Summary.DryRun || latestDryRun.Summary.Stats.BooksCreated != 4 || latestDryRun.Summary.Stats.SeriesCreated != 2 || latestDryRun.Summary.Stats.SeriesLinked != 1 || latestDryRun.Summary.Stats.ReviewQueued != 2 {
 		t.Fatalf("dry-run summary = %+v", latestDryRun.Summary)
+	}
+	if rollback, err := importer.Rollback(context.Background(), runToRollback); err != nil {
+		t.Fatalf("Rollback commit run: %v", err)
+	} else if rollback.Stats.Failed != 0 {
+		t.Fatalf("rollback result = %+v, want no failures", rollback)
+	}
+	series, err = seriesRepo.ListWithBooks(context.Background())
+	if err != nil {
+		t.Fatalf("ListWithBooks after rollback: %v", err)
+	}
+	if len(series) != 0 {
+		t.Fatalf("series after rollback = %+v, want all fixture-created series removed", series)
+	}
+}
+
+func assertContractSeriesCoverage(t *testing.T, series []models.Series) {
+	t.Helper()
+
+	if len(series) != 2 {
+		t.Fatalf("series = %+v, want Stormlight plus repeated Murderbot series", series)
+	}
+	foundMurderbot := false
+	for _, item := range series {
+		if item.Title != "The Murderbot Diaries" {
+			continue
+		}
+		foundMurderbot = true
+		if len(item.Books) != 2 {
+			t.Fatalf("Murderbot books = %+v, want two repeated-series memberships", item.Books)
+		}
+	}
+	if !foundMurderbot {
+		t.Fatalf("series = %+v, want The Murderbot Diaries", series)
 	}
 }
 
@@ -270,7 +320,7 @@ func TestContractHarness_ImporterResumeFromFailedCheckpoint(t *testing.T) {
 	harness := newFixtureABSHarness(t, cfg, manifest)
 	harness.FailPage(1, 3)
 
-	importer, _, bookRepo, settingsRepo, runRepo := newContractImporterFixture(t)
+	importer, _, bookRepo, _, settingsRepo, runRepo := newContractImporterFixture(t)
 	_, err = importer.Run(context.Background(), abs.ImportConfig{
 		SourceID:  abs.DefaultSourceID,
 		BaseURL:   harness.BaseURL(),
@@ -316,16 +366,16 @@ func TestContractHarness_ImporterResumeFromFailedCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resume Run: %v", err)
 	}
-	if resumeStats.BooksCreated != 1 || resumeStats.ReviewQueued != 2 {
-		t.Fatalf("resume stats = %+v, want 1 newly created book and 2 queued reviews after resuming", resumeStats)
+	if resumeStats.BooksCreated != 2 || resumeStats.ReviewQueued != 2 {
+		t.Fatalf("resume stats = %+v, want 2 newly created books and 2 queued reviews after resuming", resumeStats)
 	}
 
 	books, err := bookRepo.ListIncludingExcluded(context.Background())
 	if err != nil {
 		t.Fatalf("List books after resume: %v", err)
 	}
-	if len(books) != 3 {
-		t.Fatalf("books after resume = %d, want 3", len(books))
+	if len(books) != 4 {
+		t.Fatalf("books after resume = %d, want 4", len(books))
 	}
 
 	runs, err := runRepo.ListRecent(context.Background(), 2)

--- a/tests/abscontract/fixture_server_test.go
+++ b/tests/abscontract/fixture_server_test.go
@@ -226,7 +226,7 @@ func (h *fixtureABSHarness) canAccessLibrary(apiKey, libraryID string) bool {
 	return false
 }
 
-func newContractImporterFixture(t *testing.T) (*abs.Importer, *db.AuthorRepo, *db.BookRepo, *db.SettingsRepo, *db.ABSImportRunRepo) {
+func newContractImporterFixture(t *testing.T) (*abs.Importer, *db.AuthorRepo, *db.BookRepo, *db.SeriesRepo, *db.SettingsRepo, *db.ABSImportRunRepo) {
 	t.Helper()
 
 	database, err := db.OpenMemory()
@@ -237,6 +237,7 @@ func newContractImporterFixture(t *testing.T) (*abs.Importer, *db.AuthorRepo, *d
 
 	authorRepo := db.NewAuthorRepo(database)
 	bookRepo := db.NewBookRepo(database)
+	seriesRepo := db.NewSeriesRepo(database)
 	settingsRepo := db.NewSettingsRepo(database)
 	runRepo := db.NewABSImportRunRepo(database)
 	importer := abs.NewImporter(
@@ -244,7 +245,7 @@ func newContractImporterFixture(t *testing.T) (*abs.Importer, *db.AuthorRepo, *d
 		db.NewAuthorAliasRepo(database),
 		bookRepo,
 		db.NewEditionRepo(database),
-		db.NewSeriesRepo(database),
+		seriesRepo,
 		settingsRepo,
 		runRepo,
 		db.NewABSImportRunEntityRepo(database),
@@ -252,7 +253,7 @@ func newContractImporterFixture(t *testing.T) (*abs.Importer, *db.AuthorRepo, *d
 		db.NewABSReviewItemRepo(database),
 		db.NewABSMetadataConflictRepo(database),
 	).WithStoragePaths(t.TempDir(), t.TempDir(), nil)
-	return importer, authorRepo, bookRepo, settingsRepo, runRepo
+	return importer, authorRepo, bookRepo, seriesRepo, settingsRepo, runRepo
 }
 
 func loadHarnessLibraries(t *testing.T) []abs.Library {
@@ -274,6 +275,7 @@ func loadHarnessItems(t *testing.T) []abs.LibraryItem {
 		loadSingleListItem(t, repoFixturePath("internal", "abs", "testdata", "library_items_missing_size_duration_page_v2_33_2.json")),
 		loadLibraryItemFixture(t, filepath.Join("testdata", "fixtures", "responses", "library_item_ebook_only_v2_33_2.json")),
 		loadLibraryItemFixture(t, filepath.Join("testdata", "fixtures", "responses", "library_item_series_linked_v2_33_2.json")),
+		loadLibraryItemFixture(t, filepath.Join("testdata", "fixtures", "responses", "library_item_series_repeat_v2_33_2.json")),
 	}
 	return items
 }

--- a/tests/abscontract/testdata/fixtures/manifest.json
+++ b/tests/abscontract/testdata/fixtures/manifest.json
@@ -45,6 +45,15 @@
       "expectsSeries": true
     },
     {
+      "id": "series-repeat-item",
+      "seedPath": "seed/series-repeat-item",
+      "expectedItemId": "li_series_repeat",
+      "expectedMediaType": "book",
+      "requiresDetail": false,
+      "accessibleToLimitedAccount": true,
+      "expectsSeries": true
+    },
+    {
       "id": "permission-limited-account",
       "seedPath": "seed/permission-limited-account",
       "expectedMediaType": "book",

--- a/tests/abscontract/testdata/fixtures/responses/library_item_series_repeat_v2_33_2.json
+++ b/tests/abscontract/testdata/fixtures/responses/library_item_series_repeat_v2_33_2.json
@@ -1,0 +1,53 @@
+{
+  "id": "li_series_repeat",
+  "libraryId": "lib-books",
+  "folderId": "fol-books",
+  "path": "/audiobooks/Martha Wells/Artificial Condition.m4b",
+  "relPath": "Martha Wells/Artificial Condition.m4b",
+  "isFile": true,
+  "mediaType": "book",
+  "media": {
+    "libraryItemId": "li_series_repeat",
+    "metadata": {
+      "title": "Artificial Condition",
+      "authors": [
+        {
+          "id": "au_martha_wells",
+          "name": "Martha Wells"
+        }
+      ],
+      "series": [
+        {
+          "id": "series_murderbot",
+          "name": "The Murderbot Diaries",
+          "sequence": "2"
+        }
+      ],
+      "genres": [
+        "Science Fiction"
+      ],
+      "publishedYear": "2018",
+      "publishedDate": "2018-05-08",
+      "publisher": "Tor.com",
+      "description": "A repeated-series audiobook fixture item for the ABS contract harness.",
+      "language": "en",
+      "isbn": "9781250186928",
+      "asin": "B07B2SG6H5"
+    },
+    "duration": 11987,
+    "size": 367890123,
+    "audioFiles": [
+      {
+        "ino": "ino_series_repeat",
+        "index": 1,
+        "path": "/audiobooks/Martha Wells/Artificial Condition.m4b",
+        "duration": 11987,
+        "size": 367890123,
+        "metadata": {
+          "filename": "Artificial Condition.m4b",
+          "ext": "m4b"
+        }
+      }
+    ]
+  }
+}

--- a/tests/abscontract/testdata/fixtures/seed/README.md
+++ b/tests/abscontract/testdata/fixtures/seed/README.md
@@ -9,6 +9,7 @@ Expected scenario directories:
 - `ebook-only-item`
 - `mixed-metadata-completeness`
 - `series-linked-item`
+- `series-repeat-item`
 - `permission-limited-account`
 
 Keep the manifest in the parent directory as the contract source of truth for scenario IDs and intended behavior.

--- a/tests/abscontract/testdata/fixtures/seed/series-repeat-item/README.md
+++ b/tests/abscontract/testdata/fixtures/seed/series-repeat-item/README.md
@@ -1,0 +1,1 @@
+Pinned seeded scenario for a second item in an existing ABS series.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -81,6 +81,16 @@ export interface ManagedUser {
   createdAt: string
 }
 
+export interface SystemStatus {
+  version: string
+  commit: string
+  buildDate: string
+  imageCacheBytes?: number
+  enhancedHardcoverApi: boolean
+  hardcoverTokenConfigured: boolean
+  enhancedHardcoverDisabledReason?: 'env_disabled' | 'missing_token' | 'admin_disabled' | string
+}
+
 export interface AuthConfig {
   mode: 'enabled' | 'local-only' | 'disabled'
   apiKey: string
@@ -104,7 +114,7 @@ export interface OidcProviderConfig {
 export const api = {
   // System
   health: () => request<{ status: string; version: string }>('/health'),
-  status: () => request<{ version: string; commit: string; buildDate: string }>('/system/status'),
+  status: () => request<SystemStatus>('/system/status'),
   getLogs: (params?: { level?: string; component?: string; from?: string; to?: string; q?: string; limit?: number; offset?: number }) => {
     const p: Record<string, string> = {}
     if (params?.level) p.level = params.level

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -296,6 +296,18 @@ export const api = {
   getSeries: (id: number) => request<Series>(`/series/${id}`),
   monitorSeries: (id: number, monitored: boolean) => request<{ monitored: boolean }>(`/series/${id}`, { method: 'PATCH', body: JSON.stringify({ monitored }) }),
   fillSeries: (id: number) => request<{ queued: number }>(`/series/${id}/fill`, { method: 'POST' }),
+  searchHardcoverSeries: (term: string, limit = 10) =>
+    request<SeriesHardcoverSearchResult[]>(`/series/hardcover/search?term=${encodeURIComponent(term)}&limit=${limit}`),
+  getSeriesHardcoverLink: (id: number) => request<SeriesHardcoverLink>(`/series/${id}/hardcover-link`),
+  autoLinkSeriesHardcover: (id: number) =>
+    request<SeriesHardcoverAutoResponse>(`/series/${id}/hardcover-link/auto`, { method: 'POST' }),
+  linkSeriesHardcover: (id: number, result: SeriesHardcoverSearchResult) =>
+    request<SeriesHardcoverLink>(`/series/${id}/hardcover-link`, {
+      method: 'PUT',
+      body: JSON.stringify(result),
+    }),
+  unlinkSeriesHardcover: (id: number) => request<{ success: boolean }>(`/series/${id}/hardcover-link`, { method: 'DELETE' }),
+  getSeriesHardcoverDiff: (id: number) => request<SeriesHardcoverDiff>(`/series/${id}/hardcover-diff`),
 
   // Tags
   listTags: () => request<Tag[]>('/tag'),
@@ -969,6 +981,66 @@ export interface QualityProfile {
   items: Array<{ quality: string; allowed: boolean }>
 }
 
+export interface SeriesHardcoverLink {
+  id: number
+  seriesId: number
+  hardcoverSeriesId: string
+  hardcoverProviderId: string
+  hardcoverTitle: string
+  hardcoverAuthorName: string
+  hardcoverBookCount: number
+  confidence: number
+  linkedBy: 'auto' | 'manual' | string
+  linkedAt: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface SeriesHardcoverSearchResult {
+  foreignId: string
+  providerId: string
+  title: string
+  authorName: string
+  bookCount: number
+  readersCount: number
+  books: string[]
+  confidence?: number
+}
+
+export interface SeriesHardcoverAutoResponse {
+  linked: boolean
+  link?: SeriesHardcoverLink
+  candidates: SeriesHardcoverSearchResult[]
+  reason?: string
+}
+
+export interface SeriesHardcoverDiffBook {
+  foreignBookId: string
+  providerId: string
+  title: string
+  subtitle?: string
+  position: string
+  imageUrl?: string
+  authorName?: string
+  releaseDate?: string
+  usersCount?: number
+  localBookId?: number
+  localTitle?: string
+  localStatus?: string
+  matchConfidence?: number
+}
+
+export interface SeriesHardcoverDiff {
+  seriesId: number
+  link: SeriesHardcoverLink
+  present: SeriesHardcoverDiffBook[]
+  missing: SeriesHardcoverDiffBook[]
+  localOnly: SeriesHardcoverDiffBook[]
+  uncertain: SeriesHardcoverDiffBook[]
+  presentCount: number
+  missingCount: number
+}
+
 export interface Series {
   id: number
   foreignSeriesId: string
@@ -981,6 +1053,7 @@ export interface Series {
     positionInSeries: string
     book?: Book
   }>
+  hardcoverLink?: SeriesHardcoverLink
 }
 
 export interface Tag {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -303,8 +303,13 @@ export const api = {
 
   // Series
   listSeries: () => request<Series[]>('/series'),
+  createSeries: (data: { title: string }) => request<Series>('/series', { method: 'POST', body: JSON.stringify(data) }),
   getSeries: (id: number) => request<Series>(`/series/${id}`),
+  updateSeries: (id: number, data: { title: string }) => request<Series>(`/series/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   monitorSeries: (id: number, monitored: boolean) => request<{ monitored: boolean }>(`/series/${id}`, { method: 'PATCH', body: JSON.stringify({ monitored }) }),
+  deleteSeries: (id: number) => request<void>(`/series/${id}`, { method: 'DELETE' }),
+  linkBookToSeries: (id: number, data: { bookId: number; positionInSeries: string; primarySeries: boolean }) =>
+    request<Series>(`/series/${id}/books`, { method: 'POST', body: JSON.stringify(data) }),
   fillSeries: (id: number) => request<{ queued: number }>(`/series/${id}/fill`, { method: 'POST' }),
   searchHardcoverSeries: (term: string, limit = 10) =>
     request<SeriesHardcoverSearchResult[]>(`/series/hardcover/search?term=${encodeURIComponent(term)}&limit=${limit}`),
@@ -1074,6 +1079,7 @@ export interface Series {
     seriesId: number
     bookId: number
     positionInSeries: string
+    primarySeries?: boolean
     book?: Book
   }>
   hardcoverLink?: SeriesHardcoverLink

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -310,7 +310,11 @@ export const api = {
   deleteSeries: (id: number) => request<void>(`/series/${id}`, { method: 'DELETE' }),
   linkBookToSeries: (id: number, data: { bookId: number; positionInSeries: string; primarySeries: boolean }) =>
     request<Series>(`/series/${id}/books`, { method: 'POST', body: JSON.stringify(data) }),
-  fillSeries: (id: number) => request<{ queued: number }>(`/series/${id}/fill`, { method: 'POST' }),
+  fillSeries: (id: number, book?: SeriesFillBookRequest) =>
+    request<{ queued: number }>(`/series/${id}/fill`, {
+      method: 'POST',
+      ...(book ? { body: JSON.stringify(book) } : {}),
+    }),
   searchHardcoverSeries: (term: string, limit = 10) =>
     request<SeriesHardcoverSearchResult[]>(`/series/hardcover/search?term=${encodeURIComponent(term)}&limit=${limit}`),
   getSeriesHardcoverLink: (id: number) => request<SeriesHardcoverLink>(`/series/${id}/hardcover-link`),
@@ -1040,6 +1044,12 @@ export interface SeriesHardcoverAutoResponse {
   link?: SeriesHardcoverLink
   candidates: SeriesHardcoverSearchResult[]
   reason?: string
+}
+
+export interface SeriesFillBookRequest {
+  foreignBookId?: string
+  providerId?: string
+  position?: string
 }
 
 export interface SeriesHardcoverDiffBook {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -328,6 +328,7 @@ export const api = {
   listSettings: () => request<Array<{ key: string; value: string }>>('/setting'),
   getSetting: (key: string) => request<{ key: string; value: string }>(`/setting/${key}`),
   setSetting: (key: string, value: string) => request<void>(`/setting/${key}`, { method: 'PUT', body: JSON.stringify({ value }) }),
+  testHardcover: () => request<HardcoverTestResult>('/hardcover/test', { method: 'POST' }),
 
   // Backup
   listBackups: () => request<string[]>('/backup'),
@@ -1004,6 +1005,18 @@ export interface SeriesHardcoverLink {
   linkedAt: string
   createdAt: string
   updatedAt: string
+}
+
+export interface HardcoverTestResult {
+  ok: boolean
+  tokenConfigured: boolean
+  searchResults: number
+  sampleSeriesId?: string
+  sampleTitle?: string
+  catalogOk: boolean
+  catalogBookCount?: number
+  message?: string
+  error?: string
 }
 
 export interface SeriesHardcoverSearchResult {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -359,7 +359,7 @@ export const api = {
     request<ABSTestResult>('/abs/test', { method: 'POST', body: JSON.stringify(data ?? {}) }),
   absLibraries: (data?: { baseUrl?: string; apiKey?: string }) =>
     request<ABSLibrary[]>('/abs/libraries', { method: 'POST', body: JSON.stringify(data ?? {}) }),
-  absImportStart: (data?: { baseUrl?: string; label?: string; enabled?: boolean; libraryId?: string; apiKey?: string; dryRun?: boolean }) =>
+  absImportStart: (data?: { dryRun?: boolean }) =>
     request<ABSImportProgress>('/abs/import', { method: 'POST', body: JSON.stringify(data ?? {}) }),
   absImportStatus: () => request<ABSImportProgress>('/abs/import/status'),
   absImportRuns: () => request<ABSImportRun[]>('/abs/import/runs'),

--- a/web/src/components/AddSeriesBookModal.tsx
+++ b/web/src/components/AddSeriesBookModal.tsx
@@ -1,0 +1,196 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { api, Author, Book, Series } from '../api/client'
+
+interface Props {
+  series: Series
+  onClose: () => void
+  onLinked: (series: Series) => void
+}
+
+export default function AddSeriesBookModal({ series, onClose, onLinked }: Props) {
+  const [books, setBooks] = useState<Book[]>([])
+  const [authors, setAuthors] = useState<Author[]>([])
+  const [loading, setLoading] = useState(true)
+  const [query, setQuery] = useState('')
+  const [bookId, setBookId] = useState('')
+  const [position, setPosition] = useState('')
+  const [primarySeries, setPrimarySeries] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    Promise.all([api.listBooks(), api.listAuthors()])
+      .then(([bookList, authorList]) => {
+        if (!active) return
+        setBooks(bookList)
+        setAuthors(authorList)
+      })
+      .catch(err => {
+        if (active) setError(err instanceof Error ? err.message : 'Failed to load books')
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+    return () => { active = false }
+  }, [])
+
+  const linkedBookIds = useMemo(() => new Set((series.books ?? []).map(entry => entry.bookId)), [series.books])
+
+  const authorNames = useMemo(() => {
+    const names = new Map<number, string>()
+    for (const author of authors) names.set(author.id, author.authorName)
+    return names
+  }, [authors])
+
+  const availableBooks = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    return books.filter(book => {
+      if (linkedBookIds.has(book.id)) return false
+      if (!q) return true
+      const authorName = book.author?.authorName || authorNames.get(book.authorId) || ''
+      return book.title.toLowerCase().includes(q) || authorName.toLowerCase().includes(q)
+    })
+  }, [authorNames, books, linkedBookIds, query])
+
+  const selectedBook = books.find(book => String(book.id) === bookId)
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!selectedBook) {
+      setError('Select a book')
+      return
+    }
+    const trimmedPosition = position.trim()
+    if (!trimmedPosition) {
+      setError('Position is required')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await api.linkBookToSeries(series.id, {
+        bookId: selectedBook.id,
+        positionInSeries: trimmedPosition,
+        primarySeries,
+      })
+      onLinked(updated)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add book')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50" onClick={onClose}>
+      <form
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Add book to ${series.title}`}
+        onSubmit={submit}
+        className="bg-slate-100 dark:bg-zinc-900 border border-slate-300 dark:border-zinc-700 rounded-lg w-full max-w-lg shadow-2xl max-h-[90vh] flex flex-col"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="p-4 border-b border-slate-200 dark:border-zinc-800">
+          <h3 className="text-lg font-semibold">Add Book to Series</h3>
+          <p className="text-xs text-slate-500 dark:text-zinc-500 mt-0.5 truncate">{series.title}</p>
+        </div>
+
+        <div className="p-4 flex-1 overflow-y-auto space-y-4">
+          <input
+            type="search"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search library books..."
+            className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+            autoFocus
+          />
+
+          <div className="space-y-2 max-h-64 overflow-y-auto">
+            {loading ? (
+              <p className="text-sm text-slate-600 dark:text-zinc-500 text-center py-4">Loading...</p>
+            ) : availableBooks.length === 0 ? (
+              <p className="text-sm text-slate-600 dark:text-zinc-500 text-center py-4">No matching books found.</p>
+            ) : (
+              availableBooks.map(book => {
+                const authorName = book.author?.authorName || authorNames.get(book.authorId) || ''
+                const selected = String(book.id) === bookId
+                return (
+                  <label
+                    key={book.id}
+                    className={`flex items-center gap-3 p-3 rounded-md cursor-pointer ${
+                      selected
+                        ? 'bg-emerald-500/10 ring-1 ring-emerald-500/40'
+                        : 'bg-slate-200/50 dark:bg-zinc-800/50 hover:bg-slate-200 dark:hover:bg-zinc-800'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="series-book"
+                      value={book.id}
+                      checked={selected}
+                      onChange={e => setBookId(e.target.value)}
+                      className="text-emerald-500 focus:ring-emerald-500"
+                    />
+                    {book.imageUrl ? (
+                      <img src={book.imageUrl} alt="" className="w-8 h-10 object-cover rounded flex-shrink-0" />
+                    ) : (
+                      <div className="w-8 h-10 bg-slate-300 dark:bg-zinc-700 rounded flex-shrink-0" />
+                    )}
+                    <span className="min-w-0">
+                      <span className="block text-sm font-medium truncate">{book.title}</span>
+                      {authorName && <span className="block text-xs text-slate-600 dark:text-zinc-500 truncate">{authorName}</span>}
+                    </span>
+                  </label>
+                )
+              })
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <label className="block text-sm">
+              <span className="block font-medium text-slate-700 dark:text-zinc-300 mb-1">Position</span>
+              <input
+                type="text"
+                value={position}
+                onChange={e => setPosition(e.target.value)}
+                placeholder="1"
+                className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+              />
+            </label>
+            <label className="flex items-center gap-2 text-sm mt-6">
+              <input
+                type="checkbox"
+                checked={primarySeries}
+                onChange={e => setPrimarySeries(e.target.checked)}
+                className="accent-emerald-500"
+              />
+              Primary series
+            </label>
+          </div>
+
+          {error && <p className="text-sm text-red-500">{error}</p>}
+        </div>
+
+        <div className="p-4 border-t border-slate-200 dark:border-zinc-800 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saving || !bookId || !position.trim()}
+            className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded-md text-sm font-medium"
+          >
+            {saving ? 'Adding...' : 'Add'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/web/src/components/HardcoverSeriesLinkModal.tsx
+++ b/web/src/components/HardcoverSeriesLinkModal.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useState } from 'react'
+import { api, Series, SeriesHardcoverLink, SeriesHardcoverSearchResult } from '../api/client'
+
+interface HardcoverSeriesLinkModalProps {
+  series: Series
+  initialResults?: SeriesHardcoverSearchResult[]
+  onClose: () => void
+  onLinked: (seriesId: number, link?: SeriesHardcoverLink) => void
+}
+
+function formatConfidence(value?: number) {
+  if (!value) return ''
+  return `${Math.round(value * 100)}%`
+}
+
+export default function HardcoverSeriesLinkModal({ series, initialResults, onClose, onLinked }: HardcoverSeriesLinkModalProps) {
+  const [query, setQuery] = useState(series.title)
+  const [results, setResults] = useState<SeriesHardcoverSearchResult[]>(initialResults ?? [])
+  const [selectedId, setSelectedId] = useState(initialResults?.[0]?.foreignId ?? '')
+  const [currentLink, setCurrentLink] = useState<SeriesHardcoverLink | null>(series.hardcoverLink ?? null)
+  const [searching, setSearching] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const currentLinkId = series.hardcoverLink?.id
+  const initialResultsCount = initialResults?.length ?? 0
+
+  useEffect(() => {
+    setQuery(series.title)
+    setResults(initialResults ?? [])
+    setSelectedId(initialResults?.[0]?.foreignId ?? '')
+    setCurrentLink(series.hardcoverLink ?? null)
+    setError(null)
+  }, [series.id, series.title, currentLinkId, initialResultsCount])
+
+  useEffect(() => {
+    let cancelled = false
+    api.getSeriesHardcoverLink(series.id)
+      .then(link => {
+        if (!cancelled) setCurrentLink(link)
+      })
+      .catch(() => {
+        if (!cancelled) setCurrentLink(series.hardcoverLink ?? null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [series.id, currentLinkId])
+
+  useEffect(() => {
+    const term = query.trim()
+    if (!term) {
+      setResults([])
+      setSelectedId('')
+      return
+    }
+    if (initialResultsCount > 0 && term === series.title) {
+      return
+    }
+    let cancelled = false
+    const timer = window.setTimeout(() => {
+      setSearching(true)
+      setError(null)
+      api.searchHardcoverSeries(term, 10)
+        .then(found => {
+          if (cancelled) return
+          setResults(found)
+          setSelectedId(prev => prev || found[0]?.foreignId || '')
+        })
+        .catch(err => {
+          if (cancelled) return
+          setResults([])
+          setSelectedId('')
+          setError(err instanceof Error ? err.message : 'Search failed')
+        })
+        .finally(() => {
+          if (!cancelled) setSearching(false)
+        })
+    }, 300)
+
+    return () => {
+      cancelled = true
+      window.clearTimeout(timer)
+    }
+  }, [query, series.id, series.title, initialResultsCount])
+
+  const selected = results.find(result => result.foreignId === selectedId)
+
+  const confirmSelection = async () => {
+    if (!selected) return
+    setSaving(true)
+    setError(null)
+    try {
+      const link = await api.linkSeriesHardcover(series.id, selected)
+      setCurrentLink(link)
+      onLinked(series.id, link)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to link series')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const removeLink = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      await api.unlinkSeriesHardcover(series.id)
+      setCurrentLink(null)
+      onLinked(series.id, undefined)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to remove link')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50" role="dialog" aria-modal="true" onClick={onClose}>
+      <div className="bg-slate-100 dark:bg-zinc-900 border border-slate-300 dark:border-zinc-700 rounded-lg w-full max-w-2xl shadow-2xl max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="p-4 border-b border-slate-200 dark:border-zinc-800 flex items-center justify-between gap-4">
+          <h3 className="text-lg font-semibold">Link to Hardcover Series</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-2xl leading-none text-slate-500 dark:text-zinc-500 hover:text-slate-900 dark:hover:text-white"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="p-4 flex-1 overflow-y-auto space-y-4">
+          {currentLink && (
+            <div className="rounded-md border border-sky-500/30 bg-sky-500/10 p-4">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-xs uppercase tracking-wide text-slate-600 dark:text-zinc-400">Currently linked</p>
+                  <p className="font-semibold truncate">{currentLink.hardcoverTitle}</p>
+                  {currentLink.hardcoverAuthorName && (
+                    <p className="text-xs text-slate-600 dark:text-zinc-400 mt-0.5">{currentLink.hardcoverAuthorName}</p>
+                  )}
+                </div>
+                <span className="text-xs px-2 py-1 rounded-full border border-sky-500/40 text-sky-700 dark:text-sky-300 flex-shrink-0">
+                  {currentLink.linkedBy === 'auto' ? 'Auto' : 'Manual'} {formatConfidence(currentLink.confidence)}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={removeLink}
+                disabled={saving}
+                className="mt-3 text-sm text-rose-600 dark:text-rose-400 hover:text-rose-500 disabled:opacity-50"
+              >
+                Remove Link
+              </button>
+            </div>
+          )}
+
+          <input
+            type="text"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search Hardcover series"
+            className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+            autoFocus
+          />
+
+          {error && <p className="text-sm text-rose-600 dark:text-rose-400">{error}</p>}
+
+          <div className="space-y-2">
+            {results.map(result => {
+              const selectedResult = selectedId === result.foreignId
+              const previewBooks = result.books ?? []
+              return (
+                <button
+                  key={result.foreignId}
+                  type="button"
+                  onClick={() => setSelectedId(result.foreignId)}
+                  className={`w-full text-left rounded-md border p-4 transition-colors ${
+                    selectedResult
+                      ? 'border-emerald-500 bg-emerald-500/10'
+                      : 'border-slate-300 dark:border-zinc-700 bg-slate-200/50 dark:bg-zinc-800/50 hover:bg-slate-200 dark:hover:bg-zinc-800'
+                  }`}
+                >
+                  <div className="flex items-start gap-3">
+                    <span className={`mt-1 h-4 w-4 rounded-full border flex-shrink-0 ${selectedResult ? 'border-emerald-500 bg-emerald-500' : 'border-slate-400 dark:border-zinc-500'}`} />
+                    <div className="min-w-0 flex-1">
+                      <div className="font-semibold truncate">{result.title}</div>
+                      <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-600 dark:text-zinc-400">
+                        {result.authorName && <span>{result.authorName}</span>}
+                        <span>{result.bookCount} {result.bookCount === 1 ? 'book' : 'books'}</span>
+                        {result.readersCount > 0 && <span>{result.readersCount.toLocaleString()} readers</span>}
+                        {result.confidence && <span>{formatConfidence(result.confidence)} match</span>}
+                      </div>
+                      {previewBooks.length > 0 && (
+                        <p className="mt-2 text-xs text-slate-600 dark:text-zinc-500 line-clamp-2 italic">
+                          {previewBooks.slice(0, 4).join(', ')}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              )
+            })}
+            {searching && <p className="text-sm text-slate-600 dark:text-zinc-500 text-center py-4">Searching...</p>}
+            {!searching && results.length === 0 && !error && (
+              <p className="text-sm text-slate-600 dark:text-zinc-500 text-center py-4">No Hardcover series found.</p>
+            )}
+          </div>
+        </div>
+
+        <div className="p-4 border-t border-slate-200 dark:border-zinc-800 flex justify-end gap-3">
+          <button type="button" onClick={onClose} className="px-4 py-2 text-sm text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white">
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={confirmSelection}
+            disabled={!selected || saving}
+            className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded-md text-sm font-medium"
+          >
+            {saving ? 'Saving...' : 'Confirm Selection'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/SeriesNameModal.tsx
+++ b/web/src/components/SeriesNameModal.tsx
@@ -1,0 +1,81 @@
+import { FormEvent, useState } from 'react'
+
+interface Props {
+  title: string
+  initialName?: string
+  submitLabel: string
+  onClose: () => void
+  onSubmit: (name: string) => Promise<void> | void
+}
+
+export default function SeriesNameModal({ title, initialName = '', submitLabel, onClose, onSubmit }: Props) {
+  const [name, setName] = useState(initialName)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    const trimmed = name.trim()
+    if (!trimmed) {
+      setError('Series name is required')
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      await onSubmit(trimmed)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save series')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50" onClick={onClose}>
+      <form
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        onSubmit={submit}
+        className="bg-slate-100 dark:bg-zinc-900 border border-slate-300 dark:border-zinc-700 rounded-lg w-full max-w-md shadow-2xl"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="p-4 border-b border-slate-200 dark:border-zinc-800">
+          <h3 className="text-lg font-semibold">{title}</h3>
+        </div>
+        <div className="p-4 space-y-3">
+          <label className="block text-sm font-medium text-slate-700 dark:text-zinc-300" htmlFor="series-name">
+            Name
+          </label>
+          <input
+            id="series-name"
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Series name"
+            className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+            autoFocus
+          />
+          {error && <p className="text-sm text-red-500">{error}</p>}
+        </div>
+        <div className="p-4 border-t border-slate-200 dark:border-zinc-800 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saving || !name.trim()}
+            className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded-md text-sm font-medium"
+          >
+            {saving ? 'Saving...' : submitLabel}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import AuthorDetailPage from './AuthorDetailPage'
-import { api, Author, Book } from '../api/client'
+import { api } from '../api/client'
+import type { Author, Book } from '../api/client'
 
 vi.mock('../api/client', async importOriginal => {
   const actual = await importOriginal<typeof import('../api/client')>()
@@ -12,22 +13,20 @@ vi.mock('../api/client', async importOriginal => {
       ...actual.api,
       getAuthor: vi.fn(),
       listBooks: vi.fn(),
+      listAuthors: vi.fn(),
+      refreshAuthor: vi.fn(),
+      updateAuthor: vi.fn(),
+      deleteAuthor: vi.fn(),
       searchAuthorWanted: vi.fn(),
     },
   }
 })
 
-vi.mock('../components/ViewToggle', () => ({ default: () => null }))
-
-vi.mock('../components/useView', () => ({
-  useView: () => ['grid', vi.fn()],
-}))
-
 const author: Author = {
   id: 42,
-  foreignAuthorId: 'OL1A',
-  authorName: 'Test Author',
-  sortName: 'Author, Test',
+  foreignAuthorId: 'OL123A',
+  authorName: 'Brandon Sanderson',
+  sortName: 'Sanderson, Brandon',
   description: '',
   imageUrl: '',
   disambiguation: '',
@@ -36,27 +35,53 @@ const author: Author = {
   monitored: true,
 }
 
-function book(overrides: Partial<Book>): Book {
+function makeBook(overrides: Partial<Book> & Pick<Book, 'id' | 'title' | 'status'>): Book {
+  const { id, title, status, ...rest } = overrides
   return {
-    id: 1,
-    foreignBookId: 'OL1W',
+    id,
+    foreignBookId: `book-${id}`,
     authorId: 42,
-    title: 'Wanted Book',
+    title,
     description: '',
     imageUrl: '',
+    releaseDate: undefined,
     genres: [],
     monitored: true,
-    status: 'wanted',
+    status,
     filePath: '',
     mediaType: 'ebook',
     ebookFilePath: '',
     audiobookFilePath: '',
     excluded: false,
-    ...overrides,
+    ...rest,
   }
 }
 
-function renderPage() {
+function installLocalStorageMock() {
+  const values = new Map<string, string>()
+  const storage = {
+    get length() {
+      return values.size
+    },
+    clear: vi.fn(() => values.clear()),
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(values.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key)
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value)
+    }),
+  } as Storage
+  Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true })
+  Object.defineProperty(window, 'localStorage', { value: storage, configurable: true })
+}
+
+function renderAuthorDetailPage(books: Book[], view: 'grid' | 'table' = 'grid') {
+  localStorage.setItem('bindery.view.author-detail', view)
+  vi.mocked(api.getAuthor).mockResolvedValue(author)
+  vi.mocked(api.listBooks).mockResolvedValue(books)
+
   return render(
     <MemoryRouter initialEntries={['/author/42']}>
       <Routes>
@@ -66,22 +91,26 @@ function renderPage() {
   )
 }
 
+function rowForTitle(title: string): HTMLElement {
+  const row = screen.getByText(title).closest('tr')
+  if (!row) throw new Error(`No row found for ${title}`)
+  return row
+}
+
 describe('AuthorDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(api.getAuthor).mockResolvedValue(author)
+    installLocalStorageMock()
     vi.mocked(api.searchAuthorWanted).mockResolvedValue({
       results: { '42': { ok: true } },
     })
   })
 
   it('searches all wanted books for the current author', async () => {
-    vi.mocked(api.listBooks).mockResolvedValue([
-      book({ id: 10, title: 'Wanted Book' }),
-      book({ id: 11, title: 'Imported Book', status: 'imported' }),
+    renderAuthorDetailPage([
+      makeBook({ id: 10, title: 'Wanted Book', status: 'wanted' }),
+      makeBook({ id: 11, title: 'Imported Book', status: 'imported' }),
     ])
-
-    renderPage()
 
     const button = await screen.findByRole('button', { name: 'Search all wanted' })
     expect(button).toBeEnabled()
@@ -92,12 +121,10 @@ describe('AuthorDetailPage', () => {
   })
 
   it('disables author search when there are no monitored wanted books', async () => {
-    vi.mocked(api.listBooks).mockResolvedValue([
-      book({ id: 10, title: 'Unmonitored Wanted Book', monitored: false }),
-      book({ id: 11, title: 'Imported Book', status: 'imported' }),
+    renderAuthorDetailPage([
+      makeBook({ id: 10, title: 'Unmonitored Wanted Book', status: 'wanted', monitored: false }),
+      makeBook({ id: 11, title: 'Imported Book', status: 'imported' }),
     ])
-
-    renderPage()
 
     const button = await screen.findByRole('button', { name: 'Search all wanted' })
     expect(button).toBeDisabled()
@@ -105,5 +132,73 @@ describe('AuthorDetailPage', () => {
     fireEvent.click(button)
 
     expect(api.searchAuthorWanted).not.toHaveBeenCalled()
+  })
+
+  it('keeps table metadata visible and repeats it in compact title rows', async () => {
+    renderAuthorDetailPage(
+      [
+        makeBook({
+          id: 101,
+          title: 'Firefight',
+          status: 'wanted',
+          mediaType: 'ebook',
+          releaseDate: '2008-01-01T00:00:00Z',
+        }),
+        makeBook({
+          id: 102,
+          title: 'Snapshot',
+          status: 'downloaded',
+          mediaType: 'audiobook',
+          releaseDate: '2023-10-10',
+        }),
+        makeBook({
+          id: 103,
+          title: 'Dual Format',
+          status: 'imported',
+          mediaType: 'both',
+          releaseDate: '2022-05-05',
+          excluded: true,
+        }),
+      ],
+      'table',
+    )
+
+    await screen.findByText('Firefight')
+    const table = screen.getByRole('table')
+
+    expect(table).toHaveClass('table-fixed')
+    expect(within(table).getByRole('columnheader', { name: 'Title' })).toHaveClass('sm:w-[46%]')
+    expect(within(table).getByRole('columnheader', { name: /Published/ })).toBeInTheDocument()
+    expect(within(table).getByRole('columnheader', { name: 'Type' })).toBeInTheDocument()
+    expect(within(table).getByRole('columnheader', { name: 'Status' })).toBeInTheDocument()
+
+    const firefightCells = within(rowForTitle('Firefight')).getAllByRole('cell')
+    expect(firefightCells).toHaveLength(4)
+    expect(firefightCells[0]).toHaveTextContent('Wanted')
+    expect(firefightCells[0]).toHaveTextContent('📖 Ebook')
+    expect(firefightCells[0]).toHaveTextContent('2008')
+    expect(firefightCells[0]).not.toHaveTextContent('2008-01-01')
+    expect(firefightCells[1]).toHaveTextContent('2008')
+    expect(firefightCells[1]).not.toHaveTextContent('2008-01-01')
+    expect(firefightCells[2]).toHaveTextContent('📖 Ebook')
+    expect(firefightCells[3]).toHaveTextContent('Wanted')
+
+    const snapshotCells = within(rowForTitle('Snapshot')).getAllByRole('cell')
+    expect(snapshotCells[0]).toHaveTextContent('Downloaded')
+    expect(snapshotCells[0]).toHaveTextContent('🎧 Audiobook')
+    expect(snapshotCells[0]).toHaveTextContent('2023')
+    expect(snapshotCells[1]).toHaveTextContent('2023')
+    expect(snapshotCells[2]).toHaveTextContent('🎧 Audiobook')
+    expect(snapshotCells[3]).toHaveTextContent('Downloaded')
+
+    const dualFormatCells = within(rowForTitle('Dual Format')).getAllByRole('cell')
+    expect(dualFormatCells[0]).toHaveTextContent('In Library')
+    expect(dualFormatCells[0]).toHaveTextContent('📖🎧 Both')
+    expect(dualFormatCells[0]).toHaveTextContent('2022')
+    expect(dualFormatCells[0]).toHaveTextContent('Excluded')
+    expect(dualFormatCells[1]).toHaveTextContent('2022')
+    expect(dualFormatCells[2]).toHaveTextContent('📖🎧 Both')
+    expect(dualFormatCells[3]).toHaveTextContent('In Library')
+    expect(dualFormatCells[3]).toHaveTextContent('Excluded')
   })
 })

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -13,6 +13,8 @@ const statusColors: Record<string, string> = {
   skipped: 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400',
 }
 
+const fallbackStatusColor = 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'
+
 const statusLabel: Record<string, string> = {
   wanted: 'Wanted',
   downloading: 'Downloading',
@@ -28,9 +30,19 @@ type DateSort = 'none' | 'asc' | 'desc'
 
 const TODAY = new Date().toISOString().slice(0, 10)
 
-function fmtDate(d?: string): string {
+function fmtPublishedYear(d?: string): string {
   if (!d) return '—'
-  return d.slice(0, 10)
+  return d.slice(0, 4)
+}
+
+function statusBadgeClass(status: string, base = 'inline-block px-2 py-0.5 rounded text-[10px] font-medium'): string {
+  return `${base} ${statusColors[status] || fallbackStatusColor}`
+}
+
+function mediaLabel(mediaType?: Book['mediaType']): string {
+  if (mediaType === 'audiobook') return '🎧 Audiobook'
+  if (mediaType === 'both') return '📖🎧 Both'
+  return '📖 Ebook'
 }
 
 export default function AuthorDetailPage() {
@@ -377,19 +389,19 @@ export default function AuthorDetailPage() {
         ) : view === 'table' ? (
           <div className="border border-slate-200 dark:border-zinc-800 rounded-lg overflow-hidden">
             <div className="overflow-x-auto">
-              <table className="w-full text-sm">
+              <table className="w-full table-fixed text-sm">
                 <thead>
                   <tr className="bg-slate-100 dark:bg-zinc-900 border-b border-slate-200 dark:border-zinc-800">
-                    <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Title</th>
+                    <th className="w-full sm:w-[46%] text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Title</th>
                     <th
-                      className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase cursor-pointer select-none hover:text-slate-900 dark:hover:text-white whitespace-nowrap"
+                      className="hidden sm:table-cell sm:w-28 text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase cursor-pointer select-none hover:text-slate-900 dark:hover:text-white whitespace-nowrap"
                       onClick={toggleDateSort}
                       title="Sort by publication date"
                     >
                       Published{dateSortIcon}
                     </th>
-                    <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase hidden sm:table-cell">Type</th>
-                    <th className="text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Status</th>
+                    <th className="hidden sm:table-cell sm:w-36 text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Type</th>
+                    <th className="hidden sm:table-cell sm:w-36 text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Status</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-200 dark:divide-zinc-800">
@@ -399,22 +411,40 @@ export default function AuthorDetailPage() {
                       className="bg-slate-100/50 dark:bg-zinc-900/50 hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 cursor-pointer"
                       onClick={() => (window.location.href = `/book/${book.id}`)}
                     >
-                      <td className="px-3 py-2">
-                        <Link to={`/book/${book.id}`} className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
+                      <td className="px-3 py-2 align-middle">
+                        <Link to={`/book/${book.id}`} className="flex items-center gap-2 min-w-0" onClick={e => e.stopPropagation()}>
                           {book.imageUrl ? (
                             <img src={book.imageUrl} alt="" className="w-6 h-9 object-cover rounded flex-shrink-0" />
                           ) : (
                             <div className="w-6 h-9 bg-slate-200 dark:bg-zinc-800 rounded flex-shrink-0" />
                           )}
-                          <span className="text-slate-800 dark:text-zinc-200 truncate">{book.title}</span>
+                          <span className="min-w-0 flex-1">
+                            <span className="block text-slate-800 dark:text-zinc-200 truncate">{book.title}</span>
+                            <span className="mt-1 flex flex-wrap items-center gap-1 sm:hidden">
+                              <span className={statusBadgeClass(book.status, 'inline-block px-1.5 py-0.5 rounded text-[10px] font-medium')}>
+                                {statusLabel[book.status] ?? book.status}
+                              </span>
+                              <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400">
+                                {mediaLabel(book.mediaType)}
+                              </span>
+                              <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400">
+                                {fmtPublishedYear(book.releaseDate)}
+                              </span>
+                              {book.excluded && (
+                                <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">
+                                  Excluded
+                                </span>
+                              )}
+                            </span>
+                          </span>
                         </Link>
                       </td>
-                      <td className="px-3 py-2 text-slate-600 dark:text-zinc-400 whitespace-nowrap">{fmtDate(book.releaseDate)}</td>
-                      <td className="px-3 py-2 text-xs whitespace-nowrap hidden sm:table-cell">
-                        {book.mediaType === 'audiobook' ? '🎧 Audiobook' : '📖 Ebook'}
+                      <td className="hidden sm:table-cell px-3 py-2 text-slate-600 dark:text-zinc-400 whitespace-nowrap align-middle">{fmtPublishedYear(book.releaseDate)}</td>
+                      <td className="hidden sm:table-cell px-3 py-2 text-xs whitespace-nowrap align-middle">
+                        {mediaLabel(book.mediaType)}
                       </td>
-                      <td className="px-3 py-2 whitespace-nowrap">
-                        <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
+                      <td className="hidden sm:table-cell px-3 py-2 whitespace-nowrap align-middle">
+                        <span className={statusBadgeClass(book.status)}>
                           {statusLabel[book.status] ?? book.status}
                         </span>
                         {book.excluded && (
@@ -449,7 +479,7 @@ export default function AuthorDetailPage() {
                 <div className="p-2">
                   <h4 className="text-xs font-medium truncate" title={book.title}>{book.title}</h4>
                   <div className="flex items-center gap-1 mt-1 flex-wrap">
-                    <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
+                    <span className={statusBadgeClass(book.status, 'px-1.5 py-0.5 rounded text-[10px] font-medium')}>
                       {statusLabel[book.status] ?? book.status}
                     </span>
                     {book.mediaType === 'audiobook' && (
@@ -460,7 +490,7 @@ export default function AuthorDetailPage() {
                     )}
                   </div>
                   {book.releaseDate && (
-                    <p className="text-[10px] text-slate-600 dark:text-zinc-500 mt-0.5">{fmtDate(book.releaseDate)}</p>
+                    <p className="text-[10px] text-slate-600 dark:text-zinc-500 mt-0.5">{fmtPublishedYear(book.releaseDate)}</p>
                   )}
                 </div>
               </Link>

--- a/web/src/pages/AuthorsPage.test.tsx
+++ b/web/src/pages/AuthorsPage.test.tsx
@@ -1,8 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import AuthorsPage from './AuthorsPage'
 import { api } from '../api/client'
+import type { Series } from '../api/client'
+
+const { navigateMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+}))
+
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  }
+})
 
 vi.mock('../api/client', async importOriginal => {
   const actual = await importOriginal<typeof import('../api/client')>()
@@ -55,7 +68,17 @@ describe('AuthorsPage', () => {
     vi.mocked(api.listAuthors).mockResolvedValue([])
   })
 
-  it('opens the add series flow from the authors toolbar', async () => {
+  it('creates a series from the authors toolbar and opens it on the series page', async () => {
+    const created: Series = {
+      id: 44,
+      foreignSeriesId: 'manual:series:44',
+      title: 'Dune Chronicles',
+      description: '',
+      monitored: false,
+      books: [],
+    }
+    vi.mocked(api.createSeries).mockResolvedValue(created)
+
     render(
       <MemoryRouter>
         <AuthorsPage />
@@ -63,7 +86,12 @@ describe('AuthorsPage', () => {
     )
 
     fireEvent.click(await screen.findByRole('button', { name: 'Add Series' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Add Series' })
+    fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'Dune Chronicles' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Add Series' }))
 
-    expect(await screen.findByRole('dialog', { name: 'Add Series' })).toBeInTheDocument()
+    await waitFor(() => expect(api.createSeries).toHaveBeenCalledWith({ title: 'Dune Chronicles' }))
+    expect(navigateMock).toHaveBeenCalledWith('/series', { state: { seriesId: created.id } })
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Add Series' })).not.toBeInTheDocument())
   })
 })

--- a/web/src/pages/AuthorsPage.test.tsx
+++ b/web/src/pages/AuthorsPage.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import AuthorsPage from './AuthorsPage'
+import { api } from '../api/client'
+
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listAuthors: vi.fn(),
+      createSeries: vi.fn(),
+    },
+  }
+})
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => {
+      const labels: Record<string, string> = {
+        'authors.title': 'Authors',
+        'authors.merge': 'Merge',
+        'authors.addAuthor': 'Add Author',
+        'authors.searchPlaceholder': 'Search authors...',
+        'authors.sortAZ': 'A-Z',
+        'authors.sortZA': 'Z-A',
+        'authors.sortRecent': 'Recent',
+        'authors.filterMonitored': 'Monitored:',
+        'authors.filterAll': 'All',
+        'authors.filterMonitoredOnly': 'Monitored',
+        'authors.filterUnmonitored': 'Unmonitored',
+        'authors.empty': 'No authors found',
+        'authors.emptyHint': 'Add an author to get started',
+      }
+      return labels[key] ?? fallback ?? key
+    },
+  }),
+}))
+
+vi.mock('../components/usePagination', () => ({
+  usePagination: <T,>(items: T[]) => ({
+    pageItems: items,
+    paginationProps: { page: 1, totalPages: 1, pageSize: 50, totalItems: items.length, onPageChange: vi.fn(), onPageSizeChange: vi.fn() },
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('../components/Pagination', () => ({ default: () => null }))
+
+describe('AuthorsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.listAuthors).mockResolvedValue([])
+  })
+
+  it('opens the add series flow from the authors toolbar', async () => {
+    render(
+      <MemoryRouter>
+        <AuthorsPage />
+      </MemoryRouter>,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add Series' }))
+
+    expect(await screen.findByRole('dialog', { name: 'Add Series' })).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState, useMemo } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { api, Author, MediaType } from '../api/client'
 import AddAuthorModal from '../components/AddAuthorModal'
 import AddBookModal from '../components/AddBookModal'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
+import SeriesNameModal from '../components/SeriesNameModal'
 import BulkActionBar from '../components/BulkActionBar'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
@@ -16,10 +17,12 @@ type MonitoredFilter = '' | 'monitored' | 'unmonitored'
 
 export default function AuthorsPage() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const [authors, setAuthors] = useState<Author[]>([])
   const [loading, setLoading] = useState(true)
   const [showAdd, setShowAdd] = useState(false)
   const [showAddBook, setShowAddBook] = useState(false)
+  const [showAddSeries, setShowAddSeries] = useState(false)
   const [showMerge, setShowMerge] = useState(false)
   const [search, setSearch] = useState('')
   const [sort, setSort] = useState<SortMode>('az')
@@ -146,6 +149,12 @@ export default function AuthorsPage() {
     }
   }
 
+  const handleCreateSeries = async (title: string) => {
+    const series = await api.createSeries({ title })
+    setShowAddSeries(false)
+    navigate('/series', { state: { seriesId: series.id } })
+  }
+
   const sortBtnCls = (active: boolean) =>
     `px-3 py-1 rounded-md text-xs font-medium transition-colors ${active ? 'bg-slate-300 dark:bg-zinc-700 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'}`
 
@@ -153,7 +162,7 @@ export default function AuthorsPage() {
     <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-bold">{t('authors.title')}</h2>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 flex-wrap justify-end">
           <ViewToggle view={view} onChange={setView} />
           <button
             onClick={() => setShowMerge(true)}
@@ -168,6 +177,12 @@ export default function AuthorsPage() {
             className="px-4 py-2 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded-md text-sm font-medium transition-colors"
           >
             Add Book
+          </button>
+          <button
+            onClick={() => setShowAddSeries(true)}
+            className="px-4 py-2 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded-md text-sm font-medium transition-colors"
+          >
+            Add Series
           </button>
           <button
             onClick={() => setShowAdd(true)}
@@ -372,6 +387,14 @@ export default function AuthorsPage() {
 
       {showAdd && <AddAuthorModal onClose={() => setShowAdd(false)} onAdded={load} />}
       {showAddBook && <AddBookModal onClose={() => setShowAddBook(false)} onAdded={() => setShowAddBook(false)} />}
+      {showAddSeries && (
+        <SeriesNameModal
+          title="Add Series"
+          submitLabel="Add Series"
+          onClose={() => setShowAddSeries(false)}
+          onSubmit={handleCreateSeries}
+        />
+      )}
       {showMerge && (
         <MergeAuthorsModal
           authors={authors}

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import SeriesPage from './SeriesPage'
 import { api } from '../api/client'
-import type { Series } from '../api/client'
+import type { Series, SystemStatus } from '../api/client'
 
 vi.mock('../api/client', async importOriginal => {
   const actual = await importOriginal<typeof import('../api/client')>()
@@ -11,6 +11,7 @@ vi.mock('../api/client', async importOriginal => {
     ...actual,
     api: {
       ...actual.api,
+      status: vi.fn(),
       listSeries: vi.fn(),
       monitorSeries: vi.fn(),
       fillSeries: vi.fn(),
@@ -24,8 +25,9 @@ vi.mock('../api/client', async importOriginal => {
   }
 })
 
-function renderSeriesPage(series: Series[]) {
+function renderSeriesPage(series: Series[], status: SystemStatus = { version: 'dev', commit: 'unknown', buildDate: '', enhancedHardcoverApi: true, hardcoverTokenConfigured: true }) {
   vi.mocked(api.listSeries).mockResolvedValue(series)
+  vi.mocked(api.status).mockResolvedValue(status)
   return render(
     <MemoryRouter>
       <SeriesPage />
@@ -36,8 +38,43 @@ function renderSeriesPage(series: Series[]) {
 describe('SeriesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(api.status).mockResolvedValue({ version: 'dev', commit: 'unknown', buildDate: '', enhancedHardcoverApi: true, hardcoverTokenConfigured: true })
     vi.mocked(api.getSeriesHardcoverLink).mockRejectedValue(new Error('not linked'))
     vi.mocked(api.searchHardcoverSeries).mockResolvedValue([])
+  })
+
+  it('hides Hardcover controls when enhanced Hardcover API is disabled', async () => {
+    renderSeriesPage([
+      {
+        id: 11,
+        foreignSeriesId: 'series-11',
+        title: 'The Stormlight Archive',
+        description: '',
+        monitored: true,
+        books: [],
+        hardcoverLink: {
+          id: 1,
+          seriesId: 11,
+          hardcoverSeriesId: 'hc-series:42',
+          hardcoverProviderId: '42',
+          hardcoverTitle: 'The Stormlight Archive',
+          hardcoverAuthorName: 'Brandon Sanderson',
+          hardcoverBookCount: 10,
+          confidence: 1,
+          linkedBy: 'manual',
+          linkedAt: '2026-01-01T00:00:00Z',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      },
+    ], { version: 'dev', commit: 'unknown', buildDate: '', enhancedHardcoverApi: false, hardcoverTokenConfigured: true, enhancedHardcoverDisabledReason: 'env_disabled' })
+
+    expect(await screen.findByRole('heading', { name: 'The Stormlight Archive' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /link/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Auto' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('heading', { name: 'The Stormlight Archive' }))
+    expect(screen.queryByText(/Hardcover:/)).not.toBeInTheDocument()
+    expect(api.getSeriesHardcoverDiff).not.toHaveBeenCalled()
   })
 
   it('links expanded series book rows to their book pages', async () => {

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -336,4 +336,64 @@ describe('SeriesPage', () => {
     }))
     expect(await screen.findByRole('link', { name: /Dune Messiah/ })).toHaveAttribute('href', '/book/102')
   })
+
+  it('adds only the selected Hardcover missing book from its row', async () => {
+    const hardcoverLink = {
+      id: 1,
+      seriesId: 40,
+      hardcoverSeriesId: 'hc-series:42',
+      hardcoverProviderId: '42',
+      hardcoverTitle: 'The Stormlight Archive',
+      hardcoverAuthorName: 'Brandon Sanderson',
+      hardcoverBookCount: 2,
+      confidence: 1,
+      linkedBy: 'manual',
+      linkedAt: '2026-01-01T00:00:00Z',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    }
+    const series: Series = {
+      id: 40,
+      foreignSeriesId: 'series-40',
+      title: 'The Stormlight Archive',
+      description: '',
+      monitored: true,
+      books: [],
+      hardcoverLink,
+    }
+    vi.mocked(api.getSeriesHardcoverDiff).mockResolvedValue({
+      seriesId: 40,
+      link: hardcoverLink,
+      present: [],
+      missing: [
+        {
+          foreignBookId: 'hc:words-of-radiance',
+          providerId: '102',
+          title: 'Words of Radiance',
+          position: '2',
+          authorName: 'Brandon Sanderson',
+        },
+      ],
+      localOnly: [],
+      uncertain: [],
+      presentCount: 0,
+      missingCount: 1,
+    })
+    vi.mocked(api.fillSeries).mockResolvedValue({ queued: 1 })
+
+    renderSeriesPage([series])
+
+    fireEvent.click(await screen.findByRole('heading', { name: 'The Stormlight Archive' }))
+    expect(await screen.findByRole('button', { name: 'add all' })).toBeInTheDocument()
+    const rowTitle = await screen.findByText('Words of Radiance')
+    const row = rowTitle.parentElement?.parentElement
+    if (!row) throw new Error('expected Hardcover missing book row')
+    fireEvent.click(within(row).getByRole('button', { name: 'add' }))
+
+    await waitFor(() => expect(api.fillSeries).toHaveBeenCalledWith(40, {
+      foreignBookId: 'hc:words-of-radiance',
+      providerId: '102',
+      position: '2',
+    }))
+  })
 })

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -14,6 +14,12 @@ vi.mock('../api/client', async importOriginal => {
       listSeries: vi.fn(),
       monitorSeries: vi.fn(),
       fillSeries: vi.fn(),
+      autoLinkSeriesHardcover: vi.fn(),
+      getSeriesHardcoverLink: vi.fn(),
+      searchHardcoverSeries: vi.fn(),
+      linkSeriesHardcover: vi.fn(),
+      unlinkSeriesHardcover: vi.fn(),
+      getSeriesHardcoverDiff: vi.fn(),
     },
   }
 })
@@ -30,6 +36,8 @@ function renderSeriesPage(series: Series[]) {
 describe('SeriesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(api.getSeriesHardcoverLink).mockRejectedValue(new Error('not linked'))
+    vi.mocked(api.searchHardcoverSeries).mockResolvedValue([])
   })
 
   it('links expanded series book rows to their book pages', async () => {
@@ -71,5 +79,75 @@ describe('SeriesPage', () => {
 
     const bookLink = screen.getByRole('link', { name: /Defiance of the Fall 2/ })
     expect(bookLink).toHaveAttribute('href', '/book/102')
+  })
+
+  it('opens the Hardcover series link modal from the Auto control', async () => {
+    vi.mocked(api.autoLinkSeriesHardcover).mockResolvedValue({
+      linked: false,
+      reason: 'low confidence',
+      candidates: [
+        {
+          foreignId: 'hc-series:42',
+          providerId: '42',
+          title: 'The Stormlight Archive',
+          authorName: 'Brandon Sanderson',
+          bookCount: 10,
+          readersCount: 19323,
+          books: null as unknown as string[],
+          confidence: 0.7,
+        },
+      ],
+    })
+
+    renderSeriesPage([
+      {
+        id: 9,
+        foreignSeriesId: 'series-9',
+        title: 'Rhythm of War',
+        description: '',
+        monitored: true,
+        books: [],
+      },
+    ])
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Auto' }))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('The Stormlight Archive')).toBeInTheDocument()
+    expect(screen.getByText('70% match')).toBeInTheDocument()
+  })
+
+  it('opens linked Hardcover series without auto-linking again', async () => {
+    renderSeriesPage([
+      {
+        id: 10,
+        foreignSeriesId: 'series-10',
+        title: 'The Stormlight Archive',
+        description: '',
+        monitored: true,
+        books: [],
+        hardcoverLink: {
+          id: 1,
+          seriesId: 10,
+          hardcoverSeriesId: 'hc-series:42',
+          hardcoverProviderId: '42',
+          hardcoverTitle: 'The Stormlight Archive',
+          hardcoverAuthorName: 'Brandon Sanderson',
+          hardcoverBookCount: 10,
+          confidence: 1,
+          linkedBy: 'manual',
+          linkedAt: '2026-01-01T00:00:00Z',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      },
+    ])
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Manual link' }))
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Currently linked')).toBeInTheDocument()
+    expect(screen.getByText('Brandon Sanderson')).toBeInTheDocument()
+    expect(api.autoLinkSeriesHardcover).not.toHaveBeenCalled()
   })
 })

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import SeriesPage from './SeriesPage'
+import { api } from '../api/client'
+import type { Series } from '../api/client'
+
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listSeries: vi.fn(),
+      monitorSeries: vi.fn(),
+      fillSeries: vi.fn(),
+    },
+  }
+})
+
+function renderSeriesPage(series: Series[]) {
+  vi.mocked(api.listSeries).mockResolvedValue(series)
+  return render(
+    <MemoryRouter>
+      <SeriesPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('SeriesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('links expanded series book rows to their book pages', async () => {
+    renderSeriesPage([
+      {
+        id: 7,
+        foreignSeriesId: 'series-7',
+        title: 'Defiance of the Fall',
+        description: '',
+        monitored: true,
+        books: [
+          {
+            seriesId: 7,
+            bookId: 102,
+            positionInSeries: '2',
+            book: {
+              id: 102,
+              foreignBookId: 'book-102',
+              authorId: 12,
+              title: 'Defiance of the Fall 2',
+              description: '',
+              imageUrl: '',
+              releaseDate: '2020-01-01',
+              genres: [],
+              monitored: true,
+              status: 'imported',
+              filePath: '',
+              mediaType: 'ebook',
+              ebookFilePath: '',
+              audiobookFilePath: '',
+              excluded: false,
+            },
+          },
+        ],
+      },
+    ])
+
+    fireEvent.click(await screen.findByRole('heading', { name: 'Defiance of the Fall' }))
+
+    const bookLink = screen.getByRole('link', { name: /Defiance of the Fall 2/ })
+    expect(bookLink).toHaveAttribute('href', '/book/102')
+  })
+})

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent, waitFor, within } from '@testing-library/rea
 import { MemoryRouter } from 'react-router-dom'
 import SeriesPage from './SeriesPage'
 import { api } from '../api/client'
-import type { Series, SystemStatus } from '../api/client'
+import type { Series, SeriesHardcoverLink, SeriesHardcoverSearchResult, SystemStatus } from '../api/client'
 
 vi.mock('../api/client', async importOriginal => {
   const actual = await importOriginal<typeof import('../api/client')>()
@@ -194,6 +194,95 @@ describe('SeriesPage', () => {
     expect(screen.getByText('Currently linked')).toBeInTheDocument()
     expect(screen.getByText('Brandon Sanderson')).toBeInTheDocument()
     expect(api.autoLinkSeriesHardcover).not.toHaveBeenCalled()
+  })
+
+  it('confirms a manually selected Hardcover link from the modal', async () => {
+    const result: SeriesHardcoverSearchResult = {
+      foreignId: 'hc-series:42',
+      providerId: '42',
+      title: 'The Stormlight Archive',
+      authorName: 'Brandon Sanderson',
+      bookCount: 10,
+      readersCount: 19323,
+      books: ['The Way of Kings'],
+      confidence: 0.68,
+    }
+    const link: SeriesHardcoverLink = {
+      id: 2,
+      seriesId: 12,
+      hardcoverSeriesId: result.foreignId,
+      hardcoverProviderId: result.providerId,
+      hardcoverTitle: result.title,
+      hardcoverAuthorName: result.authorName,
+      hardcoverBookCount: result.bookCount,
+      confidence: 1,
+      linkedBy: 'manual',
+      linkedAt: '2026-01-01T00:00:00Z',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(api.autoLinkSeriesHardcover).mockResolvedValue({
+      linked: false,
+      reason: 'low confidence',
+      candidates: [result],
+    })
+    vi.mocked(api.linkSeriesHardcover).mockResolvedValue(link)
+
+    renderSeriesPage([
+      {
+        id: 12,
+        foreignSeriesId: 'series-12',
+        title: 'Stormlight',
+        description: '',
+        monitored: true,
+        books: [],
+      },
+    ])
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Search' }))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Confirm Selection' }))
+
+    await waitFor(() => expect(api.linkSeriesHardcover).toHaveBeenCalledWith(12, result))
+    expect(await screen.findByRole('button', { name: 'Manual link' })).toBeInTheDocument()
+  })
+
+  it('removes an existing Hardcover link from the modal', async () => {
+    const hardcoverLink: SeriesHardcoverLink = {
+      id: 3,
+      seriesId: 13,
+      hardcoverSeriesId: 'hc-series:42',
+      hardcoverProviderId: '42',
+      hardcoverTitle: 'The Stormlight Archive',
+      hardcoverAuthorName: 'Brandon Sanderson',
+      hardcoverBookCount: 10,
+      confidence: 1,
+      linkedBy: 'manual',
+      linkedAt: '2026-01-01T00:00:00Z',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(api.getSeriesHardcoverLink).mockResolvedValue(hardcoverLink)
+    vi.mocked(api.unlinkSeriesHardcover).mockResolvedValue({ success: true })
+
+    renderSeriesPage([
+      {
+        id: 13,
+        foreignSeriesId: 'series-13',
+        title: 'The Stormlight Archive',
+        description: '',
+        monitored: true,
+        books: [],
+        hardcoverLink,
+      },
+    ])
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Manual link' }))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Remove Link' }))
+
+    await waitFor(() => expect(api.unlinkSeriesHardcover).toHaveBeenCalledWith(13))
+    await waitFor(() => expect(within(dialog).queryByText('Currently linked')).not.toBeInTheDocument())
   })
 
   it('creates a manual series from the page header', async () => {

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import SeriesPage from './SeriesPage'
 import { api } from '../api/client'
@@ -12,8 +12,14 @@ vi.mock('../api/client', async importOriginal => {
     api: {
       ...actual.api,
       status: vi.fn(),
+      listBooks: vi.fn(),
+      listAuthors: vi.fn(),
       listSeries: vi.fn(),
+      createSeries: vi.fn(),
+      updateSeries: vi.fn(),
+      deleteSeries: vi.fn(),
       monitorSeries: vi.fn(),
+      linkBookToSeries: vi.fn(),
       fillSeries: vi.fn(),
       autoLinkSeriesHardcover: vi.fn(),
       getSeriesHardcoverLink: vi.fn(),
@@ -39,6 +45,8 @@ describe('SeriesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(api.status).mockResolvedValue({ version: 'dev', commit: 'unknown', buildDate: '', enhancedHardcoverApi: true, hardcoverTokenConfigured: true })
+    vi.mocked(api.listBooks).mockResolvedValue([])
+    vi.mocked(api.listAuthors).mockResolvedValue([])
     vi.mocked(api.getSeriesHardcoverLink).mockRejectedValue(new Error('not linked'))
     vi.mocked(api.searchHardcoverSeries).mockResolvedValue([])
   })
@@ -71,7 +79,7 @@ describe('SeriesPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'The Stormlight Archive' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /link/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Auto' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Search' })).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('heading', { name: 'The Stormlight Archive' }))
     expect(screen.queryByText(/Hardcover:/)).not.toBeInTheDocument()
     expect(api.getSeriesHardcoverDiff).not.toHaveBeenCalled()
@@ -118,7 +126,7 @@ describe('SeriesPage', () => {
     expect(bookLink).toHaveAttribute('href', '/book/102')
   })
 
-  it('opens the Hardcover series link modal from the Auto control', async () => {
+  it('opens the Hardcover series link modal from the Search control', async () => {
     vi.mocked(api.autoLinkSeriesHardcover).mockResolvedValue({
       linked: false,
       reason: 'low confidence',
@@ -147,7 +155,7 @@ describe('SeriesPage', () => {
       },
     ])
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Auto' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Search' }))
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument()
     expect(screen.getByText('The Stormlight Archive')).toBeInTheDocument()
@@ -186,5 +194,146 @@ describe('SeriesPage', () => {
     expect(screen.getByText('Currently linked')).toBeInTheDocument()
     expect(screen.getByText('Brandon Sanderson')).toBeInTheDocument()
     expect(api.autoLinkSeriesHardcover).not.toHaveBeenCalled()
+  })
+
+  it('creates a manual series from the page header', async () => {
+    const created: Series = {
+      id: 15,
+      foreignSeriesId: 'manual:series:15',
+      title: 'Dune Chronicles',
+      description: '',
+      monitored: false,
+      books: [],
+    }
+    vi.mocked(api.listSeries).mockResolvedValueOnce([]).mockResolvedValueOnce([created])
+    vi.mocked(api.createSeries).mockResolvedValue(created)
+
+    renderSeriesPage([])
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add Series' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Add Series' })
+    fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'Dune Chronicles' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Add Series' }))
+
+    await waitFor(() => expect(api.createSeries).toHaveBeenCalledWith({ title: 'Dune Chronicles' }))
+    expect(await screen.findByRole('heading', { name: 'Dune Chronicles' })).toBeInTheDocument()
+  })
+
+  it('renames and deletes a series without deleting books from the UI', async () => {
+    const initial: Series = {
+      id: 20,
+      foreignSeriesId: 'manual:series:20',
+      title: 'Old Series',
+      description: '',
+      monitored: false,
+      books: [],
+    }
+    const renamed: Series = { ...initial, title: 'New Series' }
+    vi.mocked(api.updateSeries).mockResolvedValue(renamed)
+    vi.mocked(api.deleteSeries).mockResolvedValue(undefined)
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    renderSeriesPage([initial])
+
+    expect(await screen.findByRole('heading', { name: 'Old Series' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Rename Series' })
+    fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'New Series' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByRole('heading', { name: 'New Series' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(api.deleteSeries).toHaveBeenCalledWith(20))
+    expect(screen.queryByRole('heading', { name: 'New Series' })).not.toBeInTheDocument()
+    confirmSpy.mockRestore()
+  })
+
+  it('links an existing library book to an expanded series', async () => {
+    const series: Series = {
+      id: 30,
+      foreignSeriesId: 'manual:series:30',
+      title: 'Dune Chronicles',
+      description: '',
+      monitored: false,
+      books: [
+        {
+          seriesId: 30,
+          bookId: 101,
+          positionInSeries: '1',
+          primarySeries: true,
+          book: {
+            id: 101,
+            foreignBookId: 'book-101',
+            authorId: 12,
+            title: 'Dune',
+            description: '',
+            imageUrl: '',
+            genres: [],
+            monitored: true,
+            status: 'imported',
+            filePath: '',
+            mediaType: 'ebook',
+            ebookFilePath: '',
+            audiobookFilePath: '',
+            excluded: false,
+          },
+        },
+      ],
+    }
+    const candidate = {
+      id: 102,
+      foreignBookId: 'book-102',
+      authorId: 12,
+      title: 'Dune Messiah',
+      description: '',
+      imageUrl: '',
+      genres: [],
+      monitored: true,
+      status: 'wanted',
+      filePath: '',
+      mediaType: 'ebook' as const,
+      ebookFilePath: '',
+      audiobookFilePath: '',
+      excluded: false,
+    }
+    const updated: Series = {
+      ...series,
+      books: [...(series.books ?? []), { seriesId: 30, bookId: 102, positionInSeries: '2', primarySeries: true, book: candidate }],
+    }
+    vi.mocked(api.listBooks).mockResolvedValue([series.books![0].book!, candidate])
+    vi.mocked(api.listAuthors).mockResolvedValue([
+      {
+        id: 12,
+        foreignAuthorId: 'author-12',
+        authorName: 'Frank Herbert',
+        sortName: 'Herbert, Frank',
+        description: '',
+        imageUrl: '',
+        disambiguation: '',
+        ratingsCount: 0,
+        averageRating: 0,
+        monitored: true,
+      },
+    ])
+    vi.mocked(api.linkBookToSeries).mockResolvedValue(updated)
+
+    renderSeriesPage([series])
+
+    fireEvent.click(await screen.findByRole('heading', { name: 'Dune Chronicles' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add Book' }))
+    const dialog = await screen.findByRole('dialog', { name: 'Add book to Dune Chronicles' })
+
+    expect(within(dialog).queryByText('Dune')).not.toBeInTheDocument()
+    fireEvent.click(await within(dialog).findByLabelText(/Dune Messiah/))
+    fireEvent.change(within(dialog).getByLabelText('Position'), { target: { value: '2' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(api.linkBookToSeries).toHaveBeenCalledWith(30, {
+      bookId: 102,
+      positionInSeries: '2',
+      primarySeries: true,
+    }))
+    expect(await screen.findByRole('link', { name: /Dune Messiah/ })).toHaveAttribute('href', '/book/102')
   })
 })

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../api/client', async importOriginal => {
       createSeries: vi.fn(),
       updateSeries: vi.fn(),
       deleteSeries: vi.fn(),
+      deleteBook: vi.fn(),
       monitorSeries: vi.fn(),
       linkBookToSeries: vi.fn(),
       fillSeries: vi.fn(),
@@ -160,6 +161,71 @@ describe('SeriesPage', () => {
     expect(await screen.findByRole('dialog')).toBeInTheDocument()
     expect(screen.getByText('The Stormlight Archive')).toBeInTheDocument()
     expect(screen.getByText('70% match')).toBeInTheDocument()
+  })
+
+  it('auto-links a matching Hardcover series and loads its diff', async () => {
+    const link: SeriesHardcoverLink = {
+      id: 4,
+      seriesId: 14,
+      hardcoverSeriesId: 'hc-series:77',
+      hardcoverProviderId: '77',
+      hardcoverTitle: 'Mistborn',
+      hardcoverAuthorName: 'Brandon Sanderson',
+      hardcoverBookCount: 3,
+      confidence: 0.94,
+      linkedBy: 'auto',
+      linkedAt: '2026-01-01T00:00:00Z',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(api.autoLinkSeriesHardcover).mockResolvedValue({
+      linked: true,
+      link,
+      candidates: [],
+    })
+    vi.mocked(api.getSeriesHardcoverDiff).mockResolvedValue({
+      seriesId: 14,
+      link,
+      present: [],
+      missing: [
+        {
+          foreignBookId: 'hc:well-of-ascension',
+          providerId: '78',
+          title: 'The Well of Ascension',
+          position: '2',
+          authorName: 'Brandon Sanderson',
+        },
+      ],
+      localOnly: [],
+      uncertain: [],
+      presentCount: 2,
+      missingCount: 1,
+    })
+
+    renderSeriesPage([
+      {
+        id: 14,
+        foreignSeriesId: 'series-14',
+        title: 'Mistborn',
+        description: '',
+        monitored: true,
+        books: [],
+      },
+    ])
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Search' }))
+
+    await waitFor(() => expect(api.autoLinkSeriesHardcover).toHaveBeenCalledWith(14))
+    expect(await screen.findByRole('button', { name: 'Auto link' })).toBeInTheDocument()
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText('Currently linked')).toBeInTheDocument()
+    expect(within(dialog).getByText('Brandon Sanderson')).toBeInTheDocument()
+    await waitFor(() => expect(api.getSeriesHardcoverDiff).toHaveBeenCalledWith(14))
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Close' }))
+    fireEvent.click(screen.getByRole('heading', { name: 'Mistborn' }))
+
+    expect(await screen.findByText('2 matched · 1 missing')).toBeInTheDocument()
   })
 
   it('opens linked Hardcover series without auto-linking again', async () => {
@@ -308,34 +374,65 @@ describe('SeriesPage', () => {
     expect(await screen.findByRole('heading', { name: 'Dune Chronicles' })).toBeInTheDocument()
   })
 
-  it('renames and deletes a series without deleting books from the UI', async () => {
+  it('renames and deletes a series without deleting linked books', async () => {
     const initial: Series = {
       id: 20,
       foreignSeriesId: 'manual:series:20',
       title: 'Old Series',
       description: '',
       monitored: false,
-      books: [],
+      books: [
+        {
+          seriesId: 20,
+          bookId: 201,
+          positionInSeries: '1',
+          primarySeries: true,
+          book: {
+            id: 201,
+            foreignBookId: 'book-201',
+            authorId: 12,
+            title: 'Existing Linked Book',
+            description: '',
+            imageUrl: '',
+            genres: [],
+            monitored: true,
+            status: 'imported',
+            filePath: '',
+            mediaType: 'ebook',
+            ebookFilePath: '',
+            audiobookFilePath: '',
+            excluded: false,
+          },
+        },
+      ],
     }
     const renamed: Series = { ...initial, title: 'New Series' }
     vi.mocked(api.updateSeries).mockResolvedValue(renamed)
     vi.mocked(api.deleteSeries).mockResolvedValue(undefined)
+    vi.mocked(api.deleteBook).mockResolvedValue(undefined)
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
-    renderSeriesPage([initial])
+    try {
+      renderSeriesPage([initial])
 
-    expect(await screen.findByRole('heading', { name: 'Old Series' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
-    const dialog = await screen.findByRole('dialog', { name: 'Rename Series' })
-    fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'New Series' } })
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
+      expect(await screen.findByRole('heading', { name: 'Old Series' })).toBeInTheDocument()
+      fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+      const dialog = await screen.findByRole('dialog', { name: 'Rename Series' })
+      fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'New Series' } })
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }))
 
-    expect(await screen.findByRole('heading', { name: 'New Series' })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+      fireEvent.click(await screen.findByRole('heading', { name: 'New Series' }))
+      expect(await screen.findByRole('link', { name: /Existing Linked Book/ })).toHaveAttribute('href', '/book/201')
+      fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
 
-    await waitFor(() => expect(api.deleteSeries).toHaveBeenCalledWith(20))
-    expect(screen.queryByRole('heading', { name: 'New Series' })).not.toBeInTheDocument()
-    confirmSpy.mockRestore()
+      await waitFor(() => expect(api.deleteSeries).toHaveBeenCalledWith(20))
+      expect(api.deleteSeries).toHaveBeenCalledTimes(1)
+      expect(api.deleteBook).not.toHaveBeenCalled()
+      expect(confirmSpy).toHaveBeenCalledWith('Delete "New Series" from Series? Linked books will stay in your library.')
+      await waitFor(() => expect(screen.queryByRole('heading', { name: 'New Series' })).not.toBeInTheDocument())
+    } finally {
+      confirmSpy.mockRestore()
+    }
   })
 
   it('links an existing library book to an expanded series', async () => {

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { api, Series } from '../api/client'
+import { api, Series, SeriesHardcoverDiff, SeriesHardcoverLink, SeriesHardcoverSearchResult } from '../api/client'
+import HardcoverSeriesLinkModal from '../components/HardcoverSeriesLinkModal'
 
 export default function SeriesPage() {
   const [seriesList, setSeriesList] = useState<Series[]>([])
@@ -8,6 +9,13 @@ export default function SeriesPage() {
   const [expanded, setExpanded] = useState<number | null>(null)
   const [filling, setFilling] = useState<number | null>(null)
   const [fillResult, setFillResult] = useState<Record<number, string>>({})
+  const [linking, setLinking] = useState<number | null>(null)
+  const [linkResult, setLinkResult] = useState<Record<number, string>>({})
+  const [linkModalSeries, setLinkModalSeries] = useState<Series | null>(null)
+  const [linkModalResults, setLinkModalResults] = useState<SeriesHardcoverSearchResult[]>([])
+  const [diffs, setDiffs] = useState<Record<number, SeriesHardcoverDiff>>({})
+  const [diffLoading, setDiffLoading] = useState<Record<number, boolean>>({})
+  const [diffErrors, setDiffErrors] = useState<Record<number, string>>({})
 
   useEffect(() => {
     api.listSeries().then(setSeriesList).catch(console.error).finally(() => setLoading(false))
@@ -18,8 +26,37 @@ export default function SeriesPage() {
     return () => { document.title = 'Bindery' }
   }, [])
 
-  const toggleExpanded = (id: number) => {
-    setExpanded(prev => (prev === id ? null : id))
+  const refreshSeriesList = async () => {
+    const list = await api.listSeries()
+    setSeriesList(list)
+    return list
+  }
+
+  const loadHardcoverDiff = async (series: Series, force = false) => {
+    if (!series.hardcoverLink) return
+    if (!force && (diffs[series.id] || diffLoading[series.id])) return
+    setDiffLoading(prev => ({ ...prev, [series.id]: true }))
+    setDiffErrors(prev => {
+      const next = { ...prev }
+      delete next[series.id]
+      return next
+    })
+    try {
+      const diff = await api.getSeriesHardcoverDiff(series.id)
+      setDiffs(prev => ({ ...prev, [series.id]: diff }))
+    } catch (err) {
+      setDiffErrors(prev => ({ ...prev, [series.id]: err instanceof Error ? err.message : 'Failed to load Hardcover diff' }))
+    } finally {
+      setDiffLoading(prev => ({ ...prev, [series.id]: false }))
+    }
+  }
+
+  const toggleExpanded = (series: Series) => {
+    const opening = expanded !== series.id
+    setExpanded(opening ? series.id : null)
+    if (opening) {
+      void loadHardcoverDiff(series)
+    }
   }
 
   const toggleMonitor = async (series: Series) => {
@@ -33,10 +70,64 @@ export default function SeriesPage() {
     try {
       const r = await api.fillSeries(series.id)
       setFillResult(prev => ({ ...prev, [series.id]: r.queued === 0 ? 'Nothing to fill' : `${r.queued} book${r.queued === 1 ? '' : 's'} queued` }))
+      const list = await refreshSeriesList()
+      const updated = list.find(s => s.id === series.id)
+      if (updated?.hardcoverLink) {
+        await loadHardcoverDiff(updated, true)
+      }
     } catch {
       setFillResult(prev => ({ ...prev, [series.id]: 'Failed' }))
     } finally {
       setFilling(null)
+    }
+  }
+
+  const openHardcoverLink = async (series: Series) => {
+    setLinkResult(prev => {
+      const next = { ...prev }
+      delete next[series.id]
+      return next
+    })
+    if (series.hardcoverLink) {
+      setLinkModalResults([])
+      setLinkModalSeries(series)
+      return
+    }
+
+    setLinking(series.id)
+    try {
+      const response = await api.autoLinkSeriesHardcover(series.id)
+      const modalSeries = response.link ? { ...series, hardcoverLink: response.link } : series
+      setLinkModalResults(response.candidates ?? [])
+      setLinkModalSeries(modalSeries)
+      if (response.link) {
+        const link = response.link
+        setSeriesList(prev => prev.map(s => s.id === series.id ? { ...s, hardcoverLink: link } : s))
+        await loadHardcoverDiff(modalSeries, true)
+      } else if (response.reason) {
+        const reason = response.reason
+        setLinkResult(prev => ({ ...prev, [series.id]: reason }))
+      }
+    } catch (err) {
+      setLinkResult(prev => ({ ...prev, [series.id]: err instanceof Error ? err.message : 'Failed to search Hardcover' }))
+    } finally {
+      setLinking(null)
+    }
+  }
+
+  const handleHardcoverLinked = (seriesId: number, link?: SeriesHardcoverLink) => {
+    setSeriesList(prev => prev.map(series => series.id === seriesId ? { ...series, hardcoverLink: link } : series))
+    if (!link) {
+      setDiffs(prev => {
+        const next = { ...prev }
+        delete next[seriesId]
+        return next
+      })
+      return
+    }
+    const series = seriesList.find(item => item.id === seriesId)
+    if (series) {
+      void loadHardcoverDiff({ ...series, hardcoverLink: link }, true)
     }
   }
 
@@ -60,6 +151,11 @@ export default function SeriesPage() {
             const books = series.books ?? []
             const bookCount = books.length
             const gapCount = books.filter(b => b.book && b.book.status !== 'imported').length
+            const diff = diffs[series.id]
+            const hardcoverMissingEstimate = Math.max(0, (series.hardcoverLink?.hardcoverBookCount ?? 0) - bookCount)
+            const hardcoverMissingCount = diff?.missingCount ?? hardcoverMissingEstimate
+            const displayMissingCount = Math.max(gapCount, hardcoverMissingCount)
+            const fillNeeded = gapCount > 0 || hardcoverMissingCount > 0
             const isOpen = expanded === series.id
             const sortedBooks = [...books].sort((a, b) => {
               const posA = parseFloat(a.positionInSeries) || 0
@@ -71,7 +167,7 @@ export default function SeriesPage() {
               <div key={series.id} className="border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden">
                 <div
                   className="p-4 cursor-pointer hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 transition-colors"
-                  onClick={() => toggleExpanded(series.id)}
+                  onClick={() => toggleExpanded(series)}
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
@@ -81,9 +177,9 @@ export default function SeriesPage() {
                       )}
                     </div>
                     <div className="flex-shrink-0 flex items-center gap-2">
-                      {gapCount > 0 && (
+                      {displayMissingCount > 0 && (
                         <span className="text-xs text-amber-600 dark:text-amber-400 bg-amber-500/10 px-2 py-0.5 rounded-full">
-                          {gapCount} missing
+                          {displayMissingCount} missing
                         </span>
                       )}
                       <span className="text-xs text-slate-600 dark:text-zinc-500 bg-slate-200 dark:bg-zinc-800 px-2 py-0.5 rounded-full">
@@ -106,7 +202,19 @@ export default function SeriesPage() {
                   <span className="text-xs text-slate-600 dark:text-zinc-400">
                     {series.monitored ? 'Monitored' : 'Not monitored'}
                   </span>
-                  {gapCount > 0 && (
+                  <button
+                    onClick={() => openHardcoverLink(series)}
+                    disabled={linking === series.id}
+                    className={`text-xs px-2.5 py-1 rounded font-medium border disabled:opacity-50 ${
+                      series.hardcoverLink
+                        ? 'border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-300'
+                        : 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+                    }`}
+                    title={series.hardcoverLink ? `Linked to ${series.hardcoverLink.hardcoverTitle}` : 'Search Hardcover series'}
+                  >
+                    {linking === series.id ? 'Searching...' : series.hardcoverLink ? `${series.hardcoverLink.linkedBy === 'auto' ? 'Auto' : 'Manual'} link` : 'Auto'}
+                  </button>
+                  {fillNeeded && (
                     <button
                       onClick={() => fillGaps(series)}
                       disabled={filling === series.id}
@@ -117,6 +225,9 @@ export default function SeriesPage() {
                   )}
                   {fillResult[series.id] && (
                     <span className="ml-auto text-xs text-emerald-600 dark:text-emerald-400">{fillResult[series.id]}</span>
+                  )}
+                  {!fillResult[series.id] && linkResult[series.id] && (
+                    <span className="ml-auto text-xs text-slate-600 dark:text-zinc-400">{linkResult[series.id]}</span>
                   )}
                 </div>
 
@@ -171,10 +282,77 @@ export default function SeriesPage() {
                     No books in this series yet
                   </div>
                 )}
+
+                {isOpen && series.hardcoverLink && (
+                  <div className="border-t border-slate-200 dark:border-zinc-800 bg-slate-100/80 dark:bg-zinc-900/80">
+                    <div className="px-4 py-3 flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium truncate">Hardcover: {series.hardcoverLink.hardcoverTitle}</p>
+                        <p className="text-xs text-slate-600 dark:text-zinc-500">
+                          {diff ? `${diff.presentCount} matched · ${diff.missingCount} missing` : 'Checking Hardcover catalog...'}
+                        </p>
+                      </div>
+                      {(diff?.missingCount ?? 0) > 0 && (
+                        <button
+                          onClick={() => fillGaps(series)}
+                          disabled={filling === series.id}
+                          className="text-xs px-2.5 py-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded font-medium flex-shrink-0"
+                        >
+                          {filling === series.id ? 'Queuing...' : 'Fill gaps'}
+                        </button>
+                      )}
+                    </div>
+                    {diffLoading[series.id] && (
+                      <div className="px-4 pb-3 text-sm text-slate-600 dark:text-zinc-500">Loading Hardcover books...</div>
+                    )}
+                    {diffErrors[series.id] && (
+                      <div className="px-4 pb-3 text-sm text-rose-600 dark:text-rose-400">{diffErrors[series.id]}</div>
+                    )}
+                    {diff && diff.missing.length > 0 && (
+                      <div className="px-4 pb-4 space-y-2">
+                        {diff.missing.slice(0, 8).map(book => (
+                          <div key={`${book.foreignBookId}-${book.position}`} className="flex items-center gap-3 p-3 rounded-md bg-slate-200/50 dark:bg-zinc-800/50">
+                            <span className="text-xs text-slate-600 dark:text-zinc-500 w-10 flex-shrink-0 font-mono">
+                              #{book.position || '?'}
+                            </span>
+                            {book.imageUrl ? (
+                              <img src={book.imageUrl} alt={book.title} className="w-8 h-10 object-cover rounded flex-shrink-0" />
+                            ) : (
+                              <div className="w-8 h-10 bg-slate-200 dark:bg-zinc-800 rounded flex-shrink-0" />
+                            )}
+                            <div className="min-w-0">
+                              <p className="text-sm font-medium truncate">{book.title}</p>
+                              {book.authorName && <p className="text-xs text-slate-600 dark:text-zinc-500 truncate">{book.authorName}</p>}
+                            </div>
+                            <button
+                              onClick={() => fillGaps(series)}
+                              disabled={filling === series.id}
+                              className="ml-auto text-xs px-2.5 py-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded font-medium flex-shrink-0"
+                              title="Create missing Hardcover books and search indexers"
+                            >
+                              {filling === series.id ? '...' : 'Fill'}
+                            </button>
+                          </div>
+                        ))}
+                        {diff.missing.length > 8 && (
+                          <p className="text-xs text-slate-600 dark:text-zinc-500 px-1">{diff.missing.length - 8} more missing books</p>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             )
           })}
         </div>
+      )}
+      {linkModalSeries && (
+        <HardcoverSeriesLinkModal
+          series={linkModalSeries}
+          initialResults={linkModalResults}
+          onClose={() => setLinkModalSeries(null)}
+          onLinked={handleHardcoverLinked}
+        />
       )}
     </div>
   )

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { api, Series, SeriesHardcoverDiff, SeriesHardcoverLink, SeriesHardcoverSearchResult } from '../api/client'
+import { api, Series, SeriesHardcoverDiff, SeriesHardcoverLink, SeriesHardcoverSearchResult, SystemStatus } from '../api/client'
 import HardcoverSeriesLinkModal from '../components/HardcoverSeriesLinkModal'
 
 export default function SeriesPage() {
@@ -16,9 +16,17 @@ export default function SeriesPage() {
   const [diffs, setDiffs] = useState<Record<number, SeriesHardcoverDiff>>({})
   const [diffLoading, setDiffLoading] = useState<Record<number, boolean>>({})
   const [diffErrors, setDiffErrors] = useState<Record<number, string>>({})
+  const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null)
+  const enhancedHardcoverApi = systemStatus?.enhancedHardcoverApi ?? false
 
   useEffect(() => {
-    api.listSeries().then(setSeriesList).catch(console.error).finally(() => setLoading(false))
+    Promise.all([api.listSeries(), api.status()])
+      .then(([list, status]) => {
+        setSeriesList(list)
+        setSystemStatus(status)
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
   }, [])
 
   useEffect(() => {
@@ -33,6 +41,7 @@ export default function SeriesPage() {
   }
 
   const loadHardcoverDiff = async (series: Series, force = false) => {
+    if (!enhancedHardcoverApi) return
     if (!series.hardcoverLink) return
     if (!force && (diffs[series.id] || diffLoading[series.id])) return
     setDiffLoading(prev => ({ ...prev, [series.id]: true }))
@@ -72,7 +81,7 @@ export default function SeriesPage() {
       setFillResult(prev => ({ ...prev, [series.id]: r.queued === 0 ? 'Nothing to fill' : `${r.queued} book${r.queued === 1 ? '' : 's'} queued` }))
       const list = await refreshSeriesList()
       const updated = list.find(s => s.id === series.id)
-      if (updated?.hardcoverLink) {
+      if (enhancedHardcoverApi && updated?.hardcoverLink) {
         await loadHardcoverDiff(updated, true)
       }
     } catch {
@@ -83,6 +92,7 @@ export default function SeriesPage() {
   }
 
   const openHardcoverLink = async (series: Series) => {
+    if (!enhancedHardcoverApi) return
     setLinkResult(prev => {
       const next = { ...prev }
       delete next[series.id]
@@ -126,7 +136,7 @@ export default function SeriesPage() {
       return
     }
     const series = seriesList.find(item => item.id === seriesId)
-    if (series) {
+    if (enhancedHardcoverApi && series) {
       void loadHardcoverDiff({ ...series, hardcoverLink: link }, true)
     }
   }
@@ -152,8 +162,8 @@ export default function SeriesPage() {
             const bookCount = books.length
             const gapCount = books.filter(b => b.book && b.book.status !== 'imported').length
             const diff = diffs[series.id]
-            const hardcoverMissingEstimate = Math.max(0, (series.hardcoverLink?.hardcoverBookCount ?? 0) - bookCount)
-            const hardcoverMissingCount = diff?.missingCount ?? hardcoverMissingEstimate
+            const hardcoverMissingEstimate = enhancedHardcoverApi ? Math.max(0, (series.hardcoverLink?.hardcoverBookCount ?? 0) - bookCount) : 0
+            const hardcoverMissingCount = enhancedHardcoverApi ? (diff?.missingCount ?? hardcoverMissingEstimate) : 0
             const displayMissingCount = Math.max(gapCount, hardcoverMissingCount)
             const fillNeeded = gapCount > 0 || hardcoverMissingCount > 0
             const isOpen = expanded === series.id
@@ -202,18 +212,20 @@ export default function SeriesPage() {
                   <span className="text-xs text-slate-600 dark:text-zinc-400">
                     {series.monitored ? 'Monitored' : 'Not monitored'}
                   </span>
-                  <button
-                    onClick={() => openHardcoverLink(series)}
-                    disabled={linking === series.id}
-                    className={`text-xs px-2.5 py-1 rounded font-medium border disabled:opacity-50 ${
-                      series.hardcoverLink
-                        ? 'border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-300'
-                        : 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300'
-                    }`}
-                    title={series.hardcoverLink ? `Linked to ${series.hardcoverLink.hardcoverTitle}` : 'Search Hardcover series'}
-                  >
-                    {linking === series.id ? 'Searching...' : series.hardcoverLink ? `${series.hardcoverLink.linkedBy === 'auto' ? 'Auto' : 'Manual'} link` : 'Auto'}
-                  </button>
+                  {enhancedHardcoverApi && (
+                    <button
+                      onClick={() => openHardcoverLink(series)}
+                      disabled={linking === series.id}
+                      className={`text-xs px-2.5 py-1 rounded font-medium border disabled:opacity-50 ${
+                        series.hardcoverLink
+                          ? 'border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-300'
+                          : 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+                      }`}
+                      title={series.hardcoverLink ? `Linked to ${series.hardcoverLink.hardcoverTitle}` : 'Search Hardcover series'}
+                    >
+                      {linking === series.id ? 'Searching...' : series.hardcoverLink ? `${series.hardcoverLink.linkedBy === 'auto' ? 'Auto' : 'Manual'} link` : 'Auto'}
+                    </button>
+                  )}
                   {fillNeeded && (
                     <button
                       onClick={() => fillGaps(series)}
@@ -283,7 +295,7 @@ export default function SeriesPage() {
                   </div>
                 )}
 
-                {isOpen && series.hardcoverLink && (
+                {isOpen && enhancedHardcoverApi && series.hardcoverLink && (
                   <div className="border-t border-slate-200 dark:border-zinc-800 bg-slate-100/80 dark:bg-zinc-900/80">
                     <div className="px-4 py-3 flex items-center justify-between gap-3">
                       <div className="min-w-0">
@@ -346,7 +358,7 @@ export default function SeriesPage() {
           })}
         </div>
       )}
-      {linkModalSeries && (
+      {enhancedHardcoverApi && linkModalSeries && (
         <HardcoverSeriesLinkModal
           series={linkModalSeries}
           initialResults={linkModalResults}

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { api, Series } from '../api/client'
 
 export default function SeriesPage() {
@@ -122,7 +123,11 @@ export default function SeriesPage() {
                 {isOpen && bookCount > 0 && (
                   <div className="border-t border-slate-200 dark:border-zinc-800 divide-y divide-slate-200/50 dark:divide-zinc-800/50">
                     {sortedBooks.map(entry => (
-                      <div key={entry.bookId} className="flex items-center gap-3 px-4 py-3 bg-slate-100/80 dark:bg-zinc-900/80">
+                      <Link
+                        key={entry.bookId}
+                        to={`/book/${entry.bookId}`}
+                        className="flex items-center gap-3 px-4 py-3 bg-slate-100/80 dark:bg-zinc-900/80 hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 transition-colors"
+                      >
                         <span className="text-xs text-slate-600 dark:text-zinc-500 w-10 flex-shrink-0 font-mono">
                           #{entry.positionInSeries || '?'}
                         </span>
@@ -156,7 +161,7 @@ export default function SeriesPage() {
                             {entry.book.status}
                           </span>
                         )}
-                      </div>
+                      </Link>
                     ))}
                   </div>
                 )}

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { api, Series, SeriesHardcoverDiff, SeriesHardcoverLink, SeriesHardcoverSearchResult, SystemStatus } from '../api/client'
+import AddSeriesBookModal from '../components/AddSeriesBookModal'
 import HardcoverSeriesLinkModal from '../components/HardcoverSeriesLinkModal'
+import SeriesNameModal from '../components/SeriesNameModal'
 
 export default function SeriesPage() {
+  const location = useLocation()
   const [seriesList, setSeriesList] = useState<Series[]>([])
   const [loading, setLoading] = useState(true)
   const [expanded, setExpanded] = useState<number | null>(null)
@@ -17,17 +20,24 @@ export default function SeriesPage() {
   const [diffLoading, setDiffLoading] = useState<Record<number, boolean>>({})
   const [diffErrors, setDiffErrors] = useState<Record<number, string>>({})
   const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null)
+  const [showAddSeries, setShowAddSeries] = useState(false)
+  const [editingSeries, setEditingSeries] = useState<Series | null>(null)
+  const [bookModalSeries, setBookModalSeries] = useState<Series | null>(null)
   const enhancedHardcoverApi = systemStatus?.enhancedHardcoverApi ?? false
 
   useEffect(() => {
+    const state = location.state as { seriesId?: number } | null
     Promise.all([api.listSeries(), api.status()])
       .then(([list, status]) => {
         setSeriesList(list)
         setSystemStatus(status)
+        if (state?.seriesId) {
+          setExpanded(state.seriesId)
+        }
       })
       .catch(console.error)
       .finally(() => setLoading(false))
-  }, [])
+  }, [location.state])
 
   useEffect(() => {
     document.title = 'Series · Bindery'
@@ -38,6 +48,42 @@ export default function SeriesPage() {
     const list = await api.listSeries()
     setSeriesList(list)
     return list
+  }
+
+  const handleCreateSeries = async (title: string) => {
+    const series = await api.createSeries({ title })
+    await refreshSeriesList()
+    setExpanded(series.id)
+    setShowAddSeries(false)
+  }
+
+  const handleRenameSeries = async (title: string) => {
+    if (!editingSeries) return
+    const updated = await api.updateSeries(editingSeries.id, { title })
+    setSeriesList(prev => prev.map(series => series.id === updated.id ? { ...series, ...updated } : series))
+    setEditingSeries(null)
+  }
+
+  const deleteSeries = async (series: Series) => {
+    if (!confirm(`Delete "${series.title}" from Series? Linked books will stay in your library.`)) return
+    await api.deleteSeries(series.id)
+    setSeriesList(prev => prev.filter(item => item.id !== series.id))
+    setDiffs(prev => {
+      const next = { ...prev }
+      delete next[series.id]
+      return next
+    })
+    if (expanded === series.id) {
+      setExpanded(null)
+    }
+  }
+
+  const handleBookLinked = (updated: Series) => {
+    setSeriesList(prev => prev.map(series => series.id === updated.id ? updated : series))
+    setExpanded(updated.id)
+    if (enhancedHardcoverApi && updated.hardcoverLink) {
+      void loadHardcoverDiff(updated, true)
+    }
   }
 
   const loadHardcoverDiff = async (series: Series, force = false) => {
@@ -143,9 +189,17 @@ export default function SeriesPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between gap-3 flex-wrap mb-6">
         <h2 className="text-2xl font-bold">Series</h2>
-        <span className="text-sm text-slate-600 dark:text-zinc-500">{seriesList.length} series</span>
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-slate-600 dark:text-zinc-500">{seriesList.length} series</span>
+          <button
+            onClick={() => setShowAddSeries(true)}
+            className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 rounded-md text-sm font-medium transition-colors"
+          >
+            Add Series
+          </button>
+        </div>
       </div>
 
       {loading ? (
@@ -201,7 +255,7 @@ export default function SeriesPage() {
                 </div>
 
                 {/* Actions row */}
-                <div className="px-4 pb-3 flex items-center gap-3" onClick={e => e.stopPropagation()}>
+                <div className="px-4 pb-3 flex items-center gap-3 flex-wrap" onClick={e => e.stopPropagation()}>
                   <button
                     onClick={() => toggleMonitor(series)}
                     className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${series.monitored ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
@@ -223,9 +277,29 @@ export default function SeriesPage() {
                       }`}
                       title={series.hardcoverLink ? `Linked to ${series.hardcoverLink.hardcoverTitle}` : 'Search Hardcover series'}
                     >
-                      {linking === series.id ? 'Searching...' : series.hardcoverLink ? `${series.hardcoverLink.linkedBy === 'auto' ? 'Auto' : 'Manual'} link` : 'Auto'}
+                      {linking === series.id ? 'Searching...' : series.hardcoverLink ? `${series.hardcoverLink.linkedBy === 'auto' ? 'Auto' : 'Manual'} link` : 'Search'}
                     </button>
                   )}
+                  <button
+                    onClick={() => setEditingSeries(series)}
+                    className="text-xs px-2.5 py-1 rounded font-medium bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700"
+                  >
+                    Rename
+                  </button>
+                  {isOpen && (
+                    <button
+                      onClick={() => setBookModalSeries(series)}
+                      className="text-xs px-2.5 py-1 rounded font-medium bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700"
+                    >
+                      Add Book
+                    </button>
+                  )}
+                  <button
+                    onClick={() => deleteSeries(series)}
+                    className="text-xs px-2.5 py-1 rounded font-medium text-red-500 hover:text-red-400 hover:bg-red-500/10"
+                  >
+                    Delete
+                  </button>
                   {fillNeeded && (
                     <button
                       onClick={() => fillGaps(series)}
@@ -357,6 +431,30 @@ export default function SeriesPage() {
             )
           })}
         </div>
+      )}
+      {showAddSeries && (
+        <SeriesNameModal
+          title="Add Series"
+          submitLabel="Add Series"
+          onClose={() => setShowAddSeries(false)}
+          onSubmit={handleCreateSeries}
+        />
+      )}
+      {editingSeries && (
+        <SeriesNameModal
+          title="Rename Series"
+          initialName={editingSeries.title}
+          submitLabel="Save"
+          onClose={() => setEditingSeries(null)}
+          onSubmit={handleRenameSeries}
+        />
+      )}
+      {bookModalSeries && (
+        <AddSeriesBookModal
+          series={bookModalSeries}
+          onClose={() => setBookModalSeries(null)}
+          onLinked={handleBookLinked}
+        />
       )}
       {enhancedHardcoverApi && linkModalSeries && (
         <HardcoverSeriesLinkModal

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { api, Series, SeriesHardcoverDiff, SeriesHardcoverLink, SeriesHardcoverSearchResult, SystemStatus } from '../api/client'
+import { api, Series, SeriesFillBookRequest, SeriesHardcoverDiff, SeriesHardcoverDiffBook, SeriesHardcoverLink, SeriesHardcoverSearchResult, SystemStatus } from '../api/client'
 import AddSeriesBookModal from '../components/AddSeriesBookModal'
 import HardcoverSeriesLinkModal from '../components/HardcoverSeriesLinkModal'
 import SeriesNameModal from '../components/SeriesNameModal'
@@ -120,10 +120,15 @@ export default function SeriesPage() {
     setSeriesList(prev => prev.map(s => s.id === series.id ? { ...s, monitored: next } : s))
   }
 
-  const fillGaps = async (series: Series) => {
+  const fillGaps = async (series: Series, book?: SeriesHardcoverDiffBook) => {
     setFilling(series.id)
     try {
-      const r = await api.fillSeries(series.id)
+      const request: SeriesFillBookRequest | undefined = book ? {
+        foreignBookId: book.foreignBookId,
+        providerId: book.providerId,
+        position: book.position,
+      } : undefined
+      const r = await api.fillSeries(series.id, request)
       setFillResult(prev => ({ ...prev, [series.id]: r.queued === 0 ? 'Nothing to fill' : `${r.queued} book${r.queued === 1 ? '' : 's'} queued` }))
       const list = await refreshSeriesList()
       const updated = list.find(s => s.id === series.id)
@@ -384,7 +389,7 @@ export default function SeriesPage() {
                           disabled={filling === series.id}
                           className="text-xs px-2.5 py-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded font-medium flex-shrink-0"
                         >
-                          {filling === series.id ? 'Queuing...' : 'Fill gaps'}
+                          {filling === series.id ? 'Queuing...' : 'add all'}
                         </button>
                       )}
                     </div>
@@ -411,12 +416,12 @@ export default function SeriesPage() {
                               {book.authorName && <p className="text-xs text-slate-600 dark:text-zinc-500 truncate">{book.authorName}</p>}
                             </div>
                             <button
-                              onClick={() => fillGaps(series)}
+                              onClick={() => fillGaps(series, book)}
                               disabled={filling === series.id}
                               className="ml-auto text-xs px-2.5 py-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded font-medium flex-shrink-0"
-                              title="Create missing Hardcover books and search indexers"
+                              title="Add this missing Hardcover book and search indexers"
                             >
-                              {filling === series.id ? '...' : 'Fill'}
+                              {filling === series.id ? '...' : 'add'}
                             </button>
                           </div>
                         ))}

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -25,6 +25,13 @@ vi.mock('../api/client', async importOriginal => {
       listDownloadClients: vi.fn(),
       listProwlarr: vi.fn(),
       absConfig: vi.fn(),
+      absSetConfig: vi.fn(),
+      absLibraries: vi.fn(),
+      absImportStart: vi.fn(),
+      absImportStatus: vi.fn(),
+      absImportRuns: vi.fn(),
+      absReviewItems: vi.fn(),
+      absConflicts: vi.fn(),
       listSettings: vi.fn(),
       listBackups: vi.fn(),
       libraryScanStatus: vi.fn(),
@@ -45,6 +52,13 @@ describe('SettingsPage Hardcover API keys', () => {
     vi.mocked(api.listDownloadClients).mockResolvedValue([])
     vi.mocked(api.listProwlarr).mockResolvedValue([])
     vi.mocked(api.absConfig).mockResolvedValue({ featureEnabled: false, baseUrl: '', label: '', enabled: false, libraryId: '', pathRemap: '', apiKeyConfigured: false })
+    vi.mocked(api.absSetConfig).mockResolvedValue({ featureEnabled: false, baseUrl: '', label: '', enabled: false, libraryId: '', pathRemap: '', apiKeyConfigured: false })
+    vi.mocked(api.absLibraries).mockResolvedValue([])
+    vi.mocked(api.absImportStart).mockResolvedValue({ running: true, dryRun: true, processed: 0 })
+    vi.mocked(api.absImportStatus).mockResolvedValue({ running: false, processed: 0 })
+    vi.mocked(api.absImportRuns).mockResolvedValue([])
+    vi.mocked(api.absReviewItems).mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 })
+    vi.mocked(api.absConflicts).mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 })
     vi.mocked(api.listSettings).mockResolvedValue([{ key: 'hardcover.enhanced_series_enabled', value: 'false' }])
     vi.mocked(api.listBackups).mockResolvedValue([])
     vi.mocked(api.libraryScanStatus).mockRejectedValue(new Error('no scan'))
@@ -115,5 +129,54 @@ describe('SettingsPage Hardcover API keys', () => {
     })
     expect(await screen.findByText('Found 2 series; catalog "Dune" has 8 books')).toBeInTheDocument()
     expect(screen.queryByText('hc-secret')).not.toBeInTheDocument()
+  })
+
+  it('requires saved Audiobookshelf settings before starting an import', async () => {
+    vi.mocked(api.absConfig).mockResolvedValue({
+      featureEnabled: true,
+      baseUrl: 'https://abs.example.com',
+      label: 'Shelf',
+      enabled: true,
+      libraryId: 'lib-books',
+      pathRemap: '/abs:/books',
+      apiKeyConfigured: true,
+    })
+    vi.mocked(api.absSetConfig).mockImplementation(async data => ({
+      featureEnabled: true,
+      baseUrl: data.baseUrl,
+      label: data.label,
+      enabled: data.enabled,
+      libraryId: data.libraryId,
+      pathRemap: data.pathRemap,
+      apiKeyConfigured: true,
+    }))
+
+    render(<SettingsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.abs' }))
+    const preview = await screen.findByRole('button', { name: 'Preview changes' })
+    expect(preview).toBeEnabled()
+
+    fireEvent.change(screen.getByPlaceholderText('/audiobookshelf:/books/audiobookshelf,/abs:/books'), { target: { value: '/draft:/books' } })
+    expect(preview).toBeDisabled()
+    expect(screen.getByText('Save Audiobookshelf settings before starting an import so the run uses the stored source configuration.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save source' }))
+    await waitFor(() => {
+      expect(api.absSetConfig).toHaveBeenCalledWith({
+        baseUrl: 'https://abs.example.com',
+        apiKey: undefined,
+        label: 'Shelf',
+        enabled: true,
+        libraryId: 'lib-books',
+        pathRemap: '/draft:/books',
+      })
+    })
+    await waitFor(() => expect(preview).toBeEnabled())
+
+    fireEvent.click(preview)
+    await waitFor(() => {
+      expect(api.absImportStart).toHaveBeenCalledWith({ dryRun: true })
+    })
   })
 })

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../api/client', async importOriginal => {
       listRootFolders: vi.fn(),
       status: vi.fn(),
       setSetting: vi.fn(),
+      testHardcover: vi.fn(),
       authConfig: vi.fn(),
     },
   }
@@ -58,6 +59,16 @@ describe('SettingsPage Hardcover API keys', () => {
       enhancedHardcoverDisabledReason: 'env_disabled',
     })
     vi.mocked(api.setSetting).mockResolvedValue(undefined)
+    vi.mocked(api.testHardcover).mockResolvedValue({
+      ok: true,
+      tokenConfigured: true,
+      searchResults: 2,
+      sampleSeriesId: 'hc-series:1150',
+      sampleTitle: 'Dune',
+      catalogOk: true,
+      catalogBookCount: 8,
+      message: 'Found 2 series; catalog "Dune" has 8 books',
+    })
     vi.mocked(api.authConfig).mockResolvedValue({ mode: 'disabled', apiKey: 'key', username: 'admin' })
   })
 
@@ -84,5 +95,25 @@ describe('SettingsPage Hardcover API keys', () => {
     await waitFor(() => {
       expect(api.setSetting).toHaveBeenCalledWith('hardcover.enhanced_series_enabled', 'true')
     })
+  })
+
+  it('tests the configured Hardcover token without exposing it', async () => {
+    vi.mocked(api.status).mockResolvedValue({
+      version: 'dev',
+      commit: 'unknown',
+      buildDate: '',
+      enhancedHardcoverApi: true,
+      hardcoverTokenConfigured: true,
+    })
+
+    render(<SettingsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Test Hardcover API' }))
+
+    await waitFor(() => {
+      expect(api.testHardcover).toHaveBeenCalled()
+    })
+    expect(await screen.findByText('Found 2 series; catalog "Dune" has 8 books')).toBeInTheDocument()
+    expect(screen.queryByText('hc-secret')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import SettingsPage from './SettingsPage'
+import { api } from '../api/client'
+
+vi.mock('../settings/AuthSettings', () => ({ default: () => <div data-testid="auth-settings" /> }))
+vi.mock('../components/ThemeToggle', () => ({ default: () => <button type="button">Theme</button> }))
+vi.mock('../components/LanguageSwitcher', () => ({ default: () => <select aria-label="Language" /> }))
+vi.mock('../auth/AuthContext', () => ({
+  useAuth: () => ({ isAdmin: true }),
+}))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}))
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listIndexers: vi.fn(),
+      listDownloadClients: vi.fn(),
+      listProwlarr: vi.fn(),
+      absConfig: vi.fn(),
+      listSettings: vi.fn(),
+      listBackups: vi.fn(),
+      libraryScanStatus: vi.fn(),
+      getStorage: vi.fn(),
+      listRootFolders: vi.fn(),
+      status: vi.fn(),
+      setSetting: vi.fn(),
+      authConfig: vi.fn(),
+    },
+  }
+})
+
+describe('SettingsPage Hardcover API keys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.listIndexers).mockResolvedValue([])
+    vi.mocked(api.listDownloadClients).mockResolvedValue([])
+    vi.mocked(api.listProwlarr).mockResolvedValue([])
+    vi.mocked(api.absConfig).mockResolvedValue({ featureEnabled: false, baseUrl: '', label: '', enabled: false, libraryId: '', pathRemap: '', apiKeyConfigured: false })
+    vi.mocked(api.listSettings).mockResolvedValue([{ key: 'hardcover.enhanced_series_enabled', value: 'false' }])
+    vi.mocked(api.listBackups).mockResolvedValue([])
+    vi.mocked(api.libraryScanStatus).mockRejectedValue(new Error('no scan'))
+    vi.mocked(api.getStorage).mockResolvedValue({ downloadDir: '/downloads', libraryDir: '/books', audiobookDir: '' })
+    vi.mocked(api.listRootFolders).mockResolvedValue([])
+    vi.mocked(api.status).mockResolvedValue({
+      version: 'dev',
+      commit: 'unknown',
+      buildDate: '',
+      enhancedHardcoverApi: false,
+      hardcoverTokenConfigured: false,
+      enhancedHardcoverDisabledReason: 'env_disabled',
+    })
+    vi.mocked(api.setSetting).mockResolvedValue(undefined)
+    vi.mocked(api.authConfig).mockResolvedValue({ mode: 'disabled', apiKey: 'key', username: 'admin' })
+  })
+
+  it('adds a write-only Hardcover token field with API link', async () => {
+    render(<SettingsPage />)
+
+    expect(await screen.findByText('Hardcover API Token')).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: 'Create or copy a Hardcover API token' })
+    expect(link).toHaveAttribute('href', 'https://hardcover.app/account/api')
+
+    fireEvent.change(screen.getByPlaceholderText('Paste a Hardcover API token'), { target: { value: 'hc-secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save Hardcover API token' }))
+
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('hardcover.api_token', 'hc-secret')
+    })
+  })
+
+  it('persists the enhanced Hardcover admin toggle separately from effective status', async () => {
+    render(<SettingsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Toggle enhanced Hardcover series' }))
+
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('hardcover.enhanced_series_enabled', 'true')
+    })
+  })
+})

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, ABSConfig, ABSImportProgress, ABSImportRun, ABSLibrary, ABSMetadataConflict, ABSReviewItem, ABSRollbackAction, ABSRollbackResult, ABSTestResult, AuthConfig, AuthStatus, BlocklistEntry, Indexer, IndexerTestResult, ProwlarrInstance, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, CalibreSyncProgress, RootFolder, LogEntry, ImportList, HardcoverList, Author, Book, SystemStatus } from '../api/client'
+import { api, ABSConfig, ABSImportProgress, ABSImportRun, ABSLibrary, ABSMetadataConflict, ABSReviewItem, ABSRollbackAction, ABSRollbackResult, ABSTestResult, AuthConfig, AuthStatus, BlocklistEntry, Indexer, IndexerTestResult, ProwlarrInstance, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, CalibreSyncProgress, RootFolder, LogEntry, ImportList, HardcoverList, HardcoverTestResult, Author, Book, SystemStatus } from '../api/client'
 import AuthSettings from '../settings/AuthSettings'
 import Pagination from '../components/Pagination'
 import ABSConflictPanel from '../components/ABSAuthorConflictsPanel'
@@ -2335,6 +2335,7 @@ function GeneralTab() {
   const [storage, setStorage] = useState<{ downloadDir: string; libraryDir: string; audiobookDir: string } | null>(null)
   const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null)
   const [hardcoverToken, setHardcoverToken] = useState('')
+  const [hardcoverTestResult, setHardcoverTestResult] = useState<(HardcoverTestResult & { testing?: boolean }) | null>(null)
   const [rootFolders, setRootFolders] = useState<RootFolder[]>([])
   const [newDefaultFolderPath, setNewDefaultFolderPath] = useState('')
   const [newDefaultFolderError, setNewDefaultFolderError] = useState('')
@@ -2377,6 +2378,7 @@ function GeneralTab() {
 
   const saveHardcoverToken = async () => {
     setSaving('hardcover.api_token')
+    setHardcoverTestResult(null)
     try {
       await api.setSetting('hardcover.api_token', hardcoverToken.trim())
       setHardcoverToken('')
@@ -2390,6 +2392,7 @@ function GeneralTab() {
 
   const clearHardcoverToken = async () => {
     setSaving('hardcover.api_token')
+    setHardcoverTestResult(null)
     try {
       await api.setSetting('hardcover.api_token', '')
       setHardcoverToken('')
@@ -2398,6 +2401,28 @@ function GeneralTab() {
       console.error(err)
     } finally {
       setSaving(null)
+    }
+  }
+
+  const testHardcover = async () => {
+    setHardcoverTestResult({
+      ok: false,
+      tokenConfigured: hardcoverTokenConfigured,
+      searchResults: 0,
+      catalogOk: false,
+      testing: true,
+    })
+    try {
+      const result = await api.testHardcover()
+      setHardcoverTestResult(result)
+    } catch (err) {
+      setHardcoverTestResult({
+        ok: false,
+        tokenConfigured: hardcoverTokenConfigured,
+        searchResults: 0,
+        catalogOk: false,
+        error: err instanceof Error ? err.message : 'Hardcover API test failed',
+      })
     }
   }
 
@@ -2900,6 +2925,14 @@ function GeneralTab() {
                     {t('settings.general.hardcoverClearToken', 'Clear')}
                   </button>
                 )}
+                <button
+                  onClick={testHardcover}
+                  disabled={!hardcoverTokenConfigured || hardcoverTestResult?.testing || saving === 'hardcover.api_token'}
+                  className="px-3 py-2 bg-slate-300 dark:bg-zinc-700 hover:bg-slate-400 dark:hover:bg-zinc-600 rounded text-xs font-medium disabled:opacity-50"
+                  aria-label={t('settings.general.hardcoverTestApi', 'Test Hardcover API')}
+                >
+                  {hardcoverTestResult?.testing ? t('common.testing', 'Testing...') : t('common.test', 'Test')}
+                </button>
               </div>
               <a
                 href="https://hardcover.app/account/api"
@@ -2909,6 +2942,13 @@ function GeneralTab() {
               >
                 {t('settings.general.hardcoverApiTokenLink', 'Create or copy a Hardcover API token')}
               </a>
+              {hardcoverTestResult && !hardcoverTestResult.testing && (
+                <p className={`mt-1 text-xs ${hardcoverTestResult.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-rose-600 dark:text-rose-400'}`}>
+                  {hardcoverTestResult.ok
+                    ? (hardcoverTestResult.message || t('settings.general.hardcoverTestOk', 'Hardcover API connected.'))
+                    : (hardcoverTestResult.error || t('settings.general.hardcoverTestFailed', 'Hardcover API test failed.'))}
+                </p>
+              )}
             </div>
 
             <div className="flex items-center justify-between gap-4">

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1340,13 +1340,12 @@ function AudiobookshelfSection() {
     setImportError(null)
     setRollbackError(null)
     setRollbackResult(null)
+    if (hasUnsavedABSConfig) {
+      setImportError('Save Audiobookshelf settings before starting an import')
+      return
+    }
     try {
       const next = await api.absImportStart({
-        baseUrl: draft.baseUrl.trim(),
-        apiKey: draft.apiKey.trim() || undefined,
-        label: draft.label.trim() || 'Audiobookshelf',
-        enabled: draft.enabled,
-        libraryId: effectiveLibraryId,
         dryRun,
       })
       setImportProgress(next)
@@ -1528,7 +1527,19 @@ function AudiobookshelfSection() {
 
   const hasImportCredentials = Boolean(draft.apiKey.trim() || config?.apiKeyConfigured)
   const effectiveLibraryId = draft.libraryId || testResult?.defaultLibraryId || ''
-  const canStartImport = !importProgress?.running && draft.enabled && hasImportCredentials && Boolean(draft.baseUrl.trim()) && Boolean(effectiveLibraryId)
+  const savedBaseUrl = config?.baseUrl ?? ''
+  const savedLabel = config?.label || 'Audiobookshelf'
+  const savedLibraryId = config?.libraryId ?? ''
+  const savedPathRemap = config?.pathRemap ?? ''
+  const hasUnsavedABSConfig = Boolean(config) && (
+    draft.baseUrl.trim() !== savedBaseUrl.trim() ||
+    (draft.label.trim() || 'Audiobookshelf') !== savedLabel ||
+    draft.enabled !== config?.enabled ||
+    draft.libraryId !== savedLibraryId ||
+    draft.pathRemap.trim() !== savedPathRemap.trim() ||
+    Boolean(draft.apiKey.trim())
+  )
+  const canStartImport = !importProgress?.running && !hasUnsavedABSConfig && Boolean(config?.enabled) && Boolean(config?.apiKeyConfigured) && Boolean(savedBaseUrl.trim()) && Boolean(savedLibraryId)
   const absRunStatusLabel = (status: string) => {
     switch (status) {
       case 'rolled_back':
@@ -1729,6 +1740,7 @@ function AudiobookshelfSection() {
                 <button
                   onClick={() => startImport(true)}
                   disabled={!canStartImport}
+                  title={hasUnsavedABSConfig ? 'Save Audiobookshelf settings before starting an import' : undefined}
                   className="px-3 py-2 bg-slate-700 hover:bg-slate-600 rounded text-sm font-medium disabled:opacity-50"
                 >
                   Preview changes
@@ -1736,6 +1748,7 @@ function AudiobookshelfSection() {
                 <button
                   onClick={() => startImport(importDryRun)}
                   disabled={!canStartImport}
+                  title={hasUnsavedABSConfig ? 'Save Audiobookshelf settings before starting an import' : undefined}
                   className="px-4 py-2 bg-sky-600 hover:bg-sky-500 rounded text-sm font-medium disabled:opacity-50"
                 >
                   {importProgress?.running ? 'Running…' : importDryRun ? 'Run selected mode' : 'Import library'}
@@ -1744,7 +1757,12 @@ function AudiobookshelfSection() {
             </div>
           </div>
 
-          {!effectiveLibraryId && hasImportCredentials && (
+          {hasUnsavedABSConfig && (
+            <p className="text-[11px] text-amber-700 dark:text-amber-300">
+              Save Audiobookshelf settings before starting an import so the run uses the stored source configuration.
+            </p>
+          )}
+          {!hasUnsavedABSConfig && !effectiveLibraryId && hasImportCredentials && (
             <p className="text-[11px] text-amber-700 dark:text-amber-300">
               Choose a library or use "Test connection" / "List libraries" to load an accessible default library before starting an import.
             </p>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, ABSConfig, ABSImportProgress, ABSImportRun, ABSLibrary, ABSMetadataConflict, ABSReviewItem, ABSRollbackAction, ABSRollbackResult, ABSTestResult, AuthConfig, AuthStatus, BlocklistEntry, Indexer, IndexerTestResult, ProwlarrInstance, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, CalibreSyncProgress, RootFolder, LogEntry, ImportList, HardcoverList, Author, Book } from '../api/client'
+import { api, ABSConfig, ABSImportProgress, ABSImportRun, ABSLibrary, ABSMetadataConflict, ABSReviewItem, ABSRollbackAction, ABSRollbackResult, ABSTestResult, AuthConfig, AuthStatus, BlocklistEntry, Indexer, IndexerTestResult, ProwlarrInstance, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, CalibreSyncProgress, RootFolder, LogEntry, ImportList, HardcoverList, Author, Book, SystemStatus } from '../api/client'
 import AuthSettings from '../settings/AuthSettings'
 import Pagination from '../components/Pagination'
 import ABSConflictPanel from '../components/ABSAuthorConflictsPanel'
@@ -2333,6 +2333,8 @@ function GeneralTab() {
   const [scanMessage, setScanMessage] = useState<string | null>(null)
   const [lastScan, setLastScan] = useState<{ ran_at: string; files_found: number; reconciled: number; unmatched: number } | null>(null)
   const [storage, setStorage] = useState<{ downloadDir: string; libraryDir: string; audiobookDir: string } | null>(null)
+  const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null)
+  const [hardcoverToken, setHardcoverToken] = useState('')
   const [rootFolders, setRootFolders] = useState<RootFolder[]>([])
   const [newDefaultFolderPath, setNewDefaultFolderPath] = useState('')
   const [newDefaultFolderError, setNewDefaultFolderError] = useState('')
@@ -2350,13 +2352,63 @@ function GeneralTab() {
     api.listBackups().then(setBackups).catch(console.error)
     api.libraryScanStatus().then(setLastScan).catch(() => {/* no prior scan — ignore 404 */})
     api.getStorage().then(setStorage).catch(console.error)
+    api.status().then(setSystemStatus).catch(console.error)
     api.listRootFolders().then(setRootFolders).catch(console.error)
   }, [])
+
+  const refreshSystemStatus = async () => {
+    try {
+      setSystemStatus(await api.status())
+    } catch (err) {
+      console.error(err)
+    }
+  }
 
   const saveSetting = async (key: string) => {
     setSaving(key)
     try {
       await api.setSetting(key, settings[key] ?? '')
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  const saveHardcoverToken = async () => {
+    setSaving('hardcover.api_token')
+    try {
+      await api.setSetting('hardcover.api_token', hardcoverToken.trim())
+      setHardcoverToken('')
+      await refreshSystemStatus()
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  const clearHardcoverToken = async () => {
+    setSaving('hardcover.api_token')
+    try {
+      await api.setSetting('hardcover.api_token', '')
+      setHardcoverToken('')
+      await refreshSystemStatus()
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  const toggleEnhancedHardcover = async () => {
+    const current = (settings['hardcover.enhanced_series_enabled'] ?? 'false').toLowerCase()
+    const next = current === 'true' ? 'false' : 'true'
+    setSettings(s => ({ ...s, 'hardcover.enhanced_series_enabled': next }))
+    setSaving('hardcover.enhanced_series_enabled')
+    try {
+      await api.setSetting('hardcover.enhanced_series_enabled', next)
+      await refreshSystemStatus()
     } catch (err) {
       console.error(err)
     } finally {
@@ -2416,6 +2468,18 @@ function GeneralTab() {
   }
 
   if (loading) return <div className="text-slate-600 dark:text-zinc-500">{t('common.loading')}</div>
+
+  const enhancedHardcoverAdminEnabled = (settings['hardcover.enhanced_series_enabled'] ?? 'false').toLowerCase() === 'true'
+  const hardcoverTokenConfigured = systemStatus?.hardcoverTokenConfigured ?? false
+  const enhancedHardcoverEnabled = systemStatus?.enhancedHardcoverApi ?? false
+  const enhancedHardcoverReason = systemStatus?.enhancedHardcoverDisabledReason
+  const enhancedHardcoverStatus = enhancedHardcoverEnabled
+    ? t('settings.general.enhancedHardcoverStatusEnabled', 'Enabled')
+    : enhancedHardcoverReason === 'env_disabled'
+      ? t('settings.general.enhancedHardcoverStatusEnvDisabled', 'Disabled by BINDERY_ENHANCED_HARDCOVER_API=false.')
+      : enhancedHardcoverReason === 'missing_token'
+        ? t('settings.general.enhancedHardcoverStatusMissingToken', 'Add a Hardcover API token to enable this feature.')
+        : t('settings.general.enhancedHardcoverStatusAdminDisabled', 'Turn this on to enable enhanced series features.')
 
   return (
     <div className="space-y-8">
@@ -2792,6 +2856,81 @@ function GeneralTab() {
                 className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
               >
                 {saving === 'googlebooks.apiKey' ? t('common.saving') : t('common.save')}
+              </button>
+            </div>
+          </div>
+
+          <div className="border-t border-slate-200 dark:border-zinc-800 pt-4 space-y-3">
+            <div>
+              <div className="flex items-center justify-between gap-3 mb-1">
+                <label className="block text-xs text-slate-600 dark:text-zinc-400">
+                  {t('settings.general.hardcoverApiToken', 'Hardcover API Token')}
+                </label>
+                <span className={`text-[11px] font-medium ${hardcoverTokenConfigured ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-500 dark:text-zinc-500'}`}>
+                  {hardcoverTokenConfigured
+                    ? t('settings.general.hardcoverTokenConfigured', 'Token configured')
+                    : t('settings.general.hardcoverTokenNotConfigured', 'No token configured')}
+                </span>
+              </div>
+              <div className="flex gap-2">
+                <input
+                  value={hardcoverToken}
+                  onChange={e => setHardcoverToken(e.target.value)}
+                  placeholder={hardcoverTokenConfigured
+                    ? t('settings.general.hardcoverApiTokenConfiguredPlaceholder', 'Saved token is hidden. Enter a new token to rotate it.')
+                    : t('settings.general.hardcoverApiTokenPlaceholder', 'Paste a Hardcover API token')}
+                  type="password"
+                  className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+                />
+                <button
+                  onClick={saveHardcoverToken}
+                  disabled={saving === 'hardcover.api_token' || !hardcoverToken.trim()}
+                  className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+                  aria-label={t('settings.general.hardcoverSaveToken', 'Save Hardcover API token')}
+                >
+                  {saving === 'hardcover.api_token' ? t('common.saving') : t('common.save')}
+                </button>
+                {hardcoverTokenConfigured && (
+                  <button
+                    onClick={clearHardcoverToken}
+                    disabled={saving === 'hardcover.api_token'}
+                    className="px-3 py-2 bg-slate-300 dark:bg-zinc-700 hover:bg-slate-400 dark:hover:bg-zinc-600 rounded text-xs font-medium disabled:opacity-50"
+                    aria-label={t('settings.general.hardcoverClearToken', 'Clear Hardcover API token')}
+                  >
+                    {t('settings.general.hardcoverClearToken', 'Clear')}
+                  </button>
+                )}
+              </div>
+              <a
+                href="https://hardcover.app/account/api"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block mt-1 text-xs text-emerald-600 dark:text-emerald-400 hover:underline"
+              >
+                {t('settings.general.hardcoverApiTokenLink', 'Create or copy a Hardcover API token')}
+              </a>
+            </div>
+
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">
+                  {t('settings.general.enhancedHardcoverSeries', 'Enhanced Hardcover series')}
+                </label>
+                <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">
+                  {t('settings.general.enhancedHardcoverSeriesHint', 'Use Hardcover-backed series matching, catalog diffs, and missing-book fill.')}
+                </p>
+                <p className={`text-xs mt-1 ${enhancedHardcoverEnabled ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-600 dark:text-zinc-500'}`}>
+                  {enhancedHardcoverStatus}
+                </p>
+              </div>
+              <button
+                onClick={toggleEnhancedHardcover}
+                disabled={saving === 'hardcover.enhanced_series_enabled'}
+                className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 disabled:opacity-50 ${enhancedHardcoverAdminEnabled ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
+                title={enhancedHardcoverAdminEnabled ? t('common.disable') : t('common.enable')}
+                aria-label={t('settings.general.enhancedHardcoverToggle', 'Toggle enhanced Hardcover series')}
+              >
+                <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${enhancedHardcoverAdminEnabled ? 'translate-x-4' : ''}`} />
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Thanks for taking a look at another larger PR. I know this diff is bigger than ideal, so I wanted to make the scope and review path as clear as possible.

This PR expands the Series workflow with optional, token-gated Hardcover metadata support while preserving the existing local-only series behavior. The changes ended up being closely related because Hardcover series matching, missing-book fill, ABS import behavior, and author/title matching all share the same series and metadata resolution paths.

I expect this to be the last large PR from this batch of work; future follow-ups should be easier to split into smaller pieces.

### Enhanced Hardcover Data

- Adds token-gated Hardcover series support with env flag, saved token, admin toggle, and API token test flow.
- Adds Hardcover series search, manual/auto linking, unlinking, and catalog diffs for present, missing, local-only, and uncertain books.
- Adds migration-backed `series_hardcover_links` storage plus docs for setup, rollout, and production expectations.

### Series Improvements

- Adds manual series management: create, rename, delete, monitor, and add existing books with positions.
- Adds missing-book fill from linked Hardcover catalogs, including single-book add and add-all flows that queue searches.
- Improves ABS import series behavior with Hardcover evidence, safer auto-linking, saved-source imports, rollback coverage, and idempotent reruns.

### Author / Metadata Improvements

- Improves author/title matching and metadata merging so Hardcover-backed fills and ABS imports reuse better local matches.
- Adds safeguards for excluded books, ambiguous author matches, duplicate-title metadata, and partial author catalog caching.
- Improves author and series UI polish, including add-series access from Authors, linked series book rows, and responsive author tables.

## Suggested Review Order

1. Feature gating and setup: config, settings, token handling, system status, migration `035`, and deployment docs.
2. Hardcover metadata layer: series search, catalog lookup, provider parsing, aggregation, and matching helpers.
3. Series workflow: API, database methods, Series page UI, linking modals, catalog diff, and missing-book fill.
4. ABS import behavior: saved-source import start, Hardcover series evidence, rollback, and idempotency handling.
5. Tests and docs: backend tests, ABS contract coverage, frontend tests, changelog, deployment guide, and wiki-source docs.

## Validation

- Added backend coverage for Hardcover series linking, catalog diffs, missing-book fill, ABS import rollback/idempotency, and safer matching.
- Added frontend coverage for the Series, Authors, Settings, and Author Detail workflows.
- Deployed this branch locally and used the new ABS + Hardcover flows to confirm functionality.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed
    - Adds migration `035` for Hardcover series links and documents the upgrade path, feature flag, token requirement, admin toggle, and production network expectations.
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] Wiki pages updated if user-facing behaviour changed

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [x] `go test -count=1 ./tests/abscontract/...`
- [x] `cd web && npm test -- SeriesPage.test.tsx AuthorsPage.test.tsx SettingsPage.test.tsx AuthorDetailPage.test.tsx`
- [x] `cd web && npm run build`
- [x] Local markdown link check for `.github/pull_request_template.md`, `CHANGELOG.md`, `docs/DEPLOYMENT.md`, and wiki-source pages
