### PR TITLE
feat(oidc): track failed providers, retry on demand, surface status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ### Fixed
 
+- **OIDC providers no longer silently dropped after failed startup discovery** (#461) — Providers whose discovery fails during `Reload()` are now tracked in a separate failed-providers map instead of being silently logged-and-forgotten. `GET /api/v1/auth/oidc/providers` returns a per-provider `status` block (`"ok"` / `"failed"` with the last error and timestamp) so admins can diagnose without grepping logs. The first login attempt for a failed provider triggers an on-demand re-discovery (rate-limited to once per 30s), so transient startup failures (e.g. pod recreated before IdP is reachable) recover automatically without an admin restart.
 - **ABS imports require saved source configuration** — import and dry-run starts now use only the stored ABS configuration, and the UI blocks runs while ABS settings contain unsaved changes so previews and imports cannot run against one-off request overrides.
 - **Hardcover auto-linking requires local evidence** — automatic series linking now requires local book overlap or author agreement before accepting a high-confidence Hardcover candidate, and missing-book fill skips books that already exist as excluded titles.
 

--- a/docs/auth-oidc.md
+++ b/docs/auth-oidc.md
@@ -226,6 +226,41 @@ Bindery caches the IdP's JWKS (public keys) to avoid a round-trip to the identit
 - Token validation is fast and does not hit the IdP per-request.
 - If you rotate IdP signing keys, Bindery will re-fetch on the next cache miss (typically within minutes).
 
+## Provider load status and on-demand recovery
+
+Bindery performs OIDC discovery (`<issuer>/.well-known/openid-configuration`) when providers are loaded — at startup and whenever an admin saves the provider list. If discovery fails for a provider (e.g. the IdP is briefly unreachable while Bindery's pod is starting), the provider is recorded as **failed** instead of being dropped silently. Two consequences:
+
+1. `GET /api/v1/auth/oidc/providers` returns a `status` block per provider:
+
+    ```json
+    [
+      {
+        "id": "authentik",
+        "name": "Authentik",
+        "issuer": "https://auth.example.com/application/o/bindery/",
+        "client_id": "...",
+        "scopes": ["openid", "email", "profile"],
+        "status": { "state": "ok" }
+      },
+      {
+        "id": "google",
+        "name": "Google",
+        "issuer": "https://accounts.google.com",
+        "client_id": "...",
+        "scopes": ["openid", "email", "profile"],
+        "status": {
+          "state": "failed",
+          "last_error": "oidc discovery for \"https://accounts.google.com\": context canceled",
+          "last_attempt": "2026-05-05T22:25:42Z"
+        }
+      }
+    ]
+    ```
+
+2. The **first login attempt** for a failed provider triggers an on-demand re-discovery, rate-limited to once per 30 seconds per provider. If discovery now succeeds, the provider transitions to `ok` and the login flow continues normally. If it still fails, the user gets the same `unknown oidc provider` error as before, and the failed entry's `last_error` and `last_attempt` are updated for the admin to inspect.
+
+The login page only renders **Sign in with X** buttons for providers in `ok` state — failed providers are intentionally hidden so users don't click into a flow that's guaranteed to error.
+
 ## Multi-provider note: sub re-use
 
 Two different IdPs can emit the same `sub` value for different users. Bindery's user mapping key is `(issuer, sub)`, not `sub` alone — so collisions across providers are impossible by design.

--- a/internal/api/auth_oidc.go
+++ b/internal/api/auth_oidc.go
@@ -57,7 +57,7 @@ func (h *OIDCHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authURL, err := h.mgr.AuthURL(providerID, state, nonce, verifier)
+	authURL, err := h.mgr.AuthURL(r.Context(), providerID, state, nonce, verifier)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err.Error())
 		return
@@ -167,8 +167,19 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/", http.StatusFound)
 }
 
+// providerWithStatus pairs the public config of a configured provider with
+// its current runtime status (loaded vs failed-discovery). Status is decided
+// from the in-memory manager state, not the DB — a provider configured in the
+// DB but missing from the manager is "failed" and unusable for login until it
+// recovers (see EnsureLoaded).
+type providerWithStatus struct {
+	oidc.ProviderPublicConfig
+	Status *oidc.Status `json:"status,omitempty"`
+}
+
 // GetProviders returns the configured OIDC provider list (id + name only,
-// no secrets). Used by the login page to render "Sign in with X" buttons.
+// no secrets) with a per-provider runtime status block. Used by the admin
+// settings UI; the public login page only needs id+name and ignores the rest.
 // GET /api/v1/auth/oidc/providers
 func (h *OIDCHandler) GetProviders(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -182,9 +193,12 @@ func (h *OIDCHandler) GetProviders(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, "parse providers: "+err.Error())
 		return
 	}
-	out := make([]oidc.ProviderPublicConfig, 0, len(ps))
+	out := make([]providerWithStatus, 0, len(ps))
 	for _, p := range ps {
-		out = append(out, p.Public())
+		out = append(out, providerWithStatus{
+			ProviderPublicConfig: p.Public(),
+			Status:               h.mgr.Status(p.ID),
+		})
 	}
 	writeOK(w, out)
 }

--- a/internal/auth/oidc/provider.go
+++ b/internal/auth/oidc/provider.go
@@ -19,6 +19,12 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// retryMinInterval is the minimum gap between on-demand re-discovery attempts
+// for a single provider. Shorter gives faster recovery; longer protects the
+// IdP from a hammered login button. Exposed as a package var so tests can
+// override it without sleeping.
+var retryMinInterval = 30 * time.Second
+
 // ProviderConfig is the internal representation persisted to the settings
 // table. It includes the client secret and must never be marshalled directly
 // to an API response — use ProviderPublicConfig for that.
@@ -77,11 +83,24 @@ type Claims struct {
 	Groups            []string
 }
 
+// Status is the runtime state of a configured provider as far as the manager
+// knows. "ok" means the provider's verifier and oauth2 config are loaded and
+// ready; "failed" means OIDC discovery did not succeed and the provider is
+// not currently usable for login.
+type Status struct {
+	State       string    `json:"state"`                  // "ok" | "failed"
+	LastError   string    `json:"last_error,omitempty"`   // populated when state=="failed"
+	LastAttempt time.Time `json:"last_attempt,omitempty"` // last time discovery was tried
+}
+
 // Manager holds per-provider OIDC verifiers and oauth2 configs, keyed by
-// provider ID. It is rebuilt when the settings change.
+// provider ID. It is rebuilt when the settings change. Providers whose
+// initial discovery fails are kept in `failed` so admins can see them and
+// so login attempts can trigger an on-demand retry.
 type Manager struct {
 	mu           sync.RWMutex
 	providers    map[string]*entry
+	failed       map[string]*failedEntry
 	redirectBase string
 }
 
@@ -91,20 +110,30 @@ type entry struct {
 	oauth2   oauth2.Config
 }
 
+type failedEntry struct {
+	cfg         ProviderConfig
+	lastErr     error
+	lastAttempt time.Time
+}
+
 func NewManager(redirectBase string) *Manager {
 	return &Manager{
 		providers:    make(map[string]*entry),
+		failed:       make(map[string]*failedEntry),
 		redirectBase: redirectBase,
 	}
 }
 
 // Reload replaces the provider set from a fresh config slice. Providers that
-// haven't changed keep their verifier (and therefore JWKS cache).
+// haven't changed keep their verifier (and therefore JWKS cache). Providers
+// whose discovery fails are recorded in the failed map (instead of silently
+// dropped) so the admin UI can surface them and EnsureLoaded can retry.
 func (m *Manager) Reload(ctx context.Context, cfgs []ProviderConfig) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	next := make(map[string]*entry, len(cfgs))
+	nextFailed := make(map[string]*failedEntry)
 	for _, cfg := range cfgs {
 		// Re-use the existing entry if config is identical (preserves JWKS cache).
 		if e, ok := m.providers[cfg.ID]; ok && configEqual(e.cfg, cfg) {
@@ -113,12 +142,14 @@ func (m *Manager) Reload(ctx context.Context, cfgs []ProviderConfig) {
 		}
 		e, err := m.buildEntry(ctx, cfg)
 		if err != nil {
-			slog.Error("oidc: failed to initialise provider, skipping", "id", cfg.ID, "error", err)
+			slog.Error("oidc: failed to initialise provider", "id", cfg.ID, "error", err)
+			nextFailed[cfg.ID] = &failedEntry{cfg: cfg, lastErr: err, lastAttempt: time.Now()}
 			continue
 		}
 		next[cfg.ID] = e
 	}
 	m.providers = next
+	m.failed = nextFailed
 }
 
 func (m *Manager) buildEntry(ctx context.Context, cfg ProviderConfig) (*entry, error) {
@@ -141,6 +172,67 @@ func (m *Manager) buildEntry(ctx context.Context, cfg ProviderConfig) (*entry, e
 	return &entry{cfg: cfg, verifier: verifier, oauth2: oc}, nil
 }
 
+// EnsureLoaded attempts on-demand re-discovery for a provider that is in the
+// failed map, rate-limited by retryMinInterval to protect the IdP from a
+// hammered login button. No-op if the provider is already loaded or unknown.
+// Errors are recorded on the failed entry; this function never returns one.
+func (m *Manager) EnsureLoaded(ctx context.Context, id string) {
+	m.mu.RLock()
+	if _, ok := m.providers[id]; ok {
+		m.mu.RUnlock()
+		return
+	}
+	f, isFailed := m.failed[id]
+	m.mu.RUnlock()
+	if !isFailed {
+		return
+	}
+	if time.Since(f.lastAttempt) < retryMinInterval {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Re-check after acquiring the write lock — another goroutine may have
+	// won the race and either loaded the provider or just attempted retry.
+	if _, ok := m.providers[id]; ok {
+		return
+	}
+	f, isFailed = m.failed[id]
+	if !isFailed || time.Since(f.lastAttempt) < retryMinInterval {
+		return
+	}
+
+	f.lastAttempt = time.Now()
+	e, err := m.buildEntry(ctx, f.cfg)
+	if err != nil {
+		f.lastErr = err
+		slog.Warn("oidc: on-demand re-discovery failed", "id", id, "error", err)
+		return
+	}
+	m.providers[id] = e
+	delete(m.failed, id)
+	slog.Info("oidc: provider recovered via on-demand re-discovery", "id", id)
+}
+
+// Status returns the runtime status of a configured provider. For providers
+// that aren't configured at all, returns nil.
+func (m *Manager) Status(id string) *Status {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if _, ok := m.providers[id]; ok {
+		return &Status{State: "ok"}
+	}
+	if f, ok := m.failed[id]; ok {
+		s := &Status{State: "failed", LastAttempt: f.lastAttempt}
+		if f.lastErr != nil {
+			s.LastError = f.lastErr.Error()
+		}
+		return s
+	}
+	return nil
+}
+
 // Get returns the entry for a provider ID, or nil if not found.
 func (m *Manager) Get(id string) *entry {
 	m.mu.RLock()
@@ -148,7 +240,9 @@ func (m *Manager) Get(id string) *entry {
 	return m.providers[id]
 }
 
-// List returns all configured provider configs (for the login page).
+// List returns all configured provider configs (for the login page). Includes
+// only providers that successfully loaded — failed providers are intentionally
+// hidden from the login page since clicking their button would error out.
 func (m *Manager) List() []ProviderConfig {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -161,7 +255,10 @@ func (m *Manager) List() []ProviderConfig {
 
 // AuthURL returns the Authorization Code + PKCE redirect URL for the provider.
 // state and codeVerifier are caller-generated; nonce is embedded in the URL.
-func (m *Manager) AuthURL(id, state, nonce, codeVerifier string) (string, error) {
+// If the provider is in the failed map, AuthURL first triggers an on-demand
+// re-discovery attempt (rate-limited) before checking again.
+func (m *Manager) AuthURL(ctx context.Context, id, state, nonce, codeVerifier string) (string, error) {
+	m.EnsureLoaded(ctx, id)
 	e := m.Get(id)
 	if e == nil {
 		return "", fmt.Errorf("unknown oidc provider %q", id)
@@ -177,6 +274,7 @@ func (m *Manager) AuthURL(id, state, nonce, codeVerifier string) (string, error)
 // Exchange completes the code exchange and validates the ID token.
 // Returns the verified Claims on success.
 func (m *Manager) Exchange(ctx context.Context, id, code, nonce, codeVerifier string) (*Claims, error) {
+	m.EnsureLoaded(ctx, id)
 	e := m.Get(id)
 	if e == nil {
 		return nil, fmt.Errorf("unknown oidc provider %q", id)

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -1,6 +1,12 @@
 package oidc
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -111,6 +117,244 @@ func TestNewNonceUnique(t *testing.T) {
 	b, _ := NewNonce()
 	if a == b {
 		t.Fatal("two nonces should differ")
+	}
+}
+
+// --- Reload failure tracking + on-demand retry -----------------------------
+//
+// These exercise the resilience contract: Reload must record (not drop)
+// providers whose discovery fails, and EnsureLoaded must retry them at most
+// once per retryMinInterval until they succeed.
+
+// fakeIDP is a minimal OIDC discovery endpoint that flips between failing and
+// succeeding under test control. It only implements /.well-known/openid-configuration —
+// enough for gooidc.NewProvider to succeed; nothing further is exercised.
+type fakeIDP struct {
+	*httptest.Server
+	failing atomic.Bool
+}
+
+func newFakeIDP() *fakeIDP {
+	f := &fakeIDP{}
+	f.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/.well-known/openid-configuration") {
+			http.NotFound(w, r)
+			return
+		}
+		if f.failing.Load() {
+			http.Error(w, "down", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 f.URL,
+			"authorization_endpoint": f.URL + "/authorize",
+			"token_endpoint":         f.URL + "/token",
+			"jwks_uri":               f.URL + "/jwks",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+			"response_types_supported":              []string{"code"},
+			"subject_types_supported":               []string{"public"},
+		})
+	}))
+	return f
+}
+
+func TestReload_FailedProviderRecorded(t *testing.T) {
+	idp := newFakeIDP()
+	defer idp.Close()
+	idp.failing.Store(true)
+
+	mgr := NewManager("https://bindery.example.com")
+	cfg := ProviderConfig{ID: "x", Name: "X", Issuer: idp.URL, ClientID: "cid", ClientSecret: "sec"}
+	mgr.Reload(context.Background(), []ProviderConfig{cfg})
+
+	if mgr.Get("x") != nil {
+		t.Fatal("provider should not be loaded when discovery fails")
+	}
+	st := mgr.Status("x")
+	if st == nil {
+		t.Fatal("status should exist for a configured-but-failed provider")
+	}
+	if st.State != "failed" {
+		t.Fatalf("want state=failed, got %q", st.State)
+	}
+	if st.LastError == "" {
+		t.Fatal("LastError should be populated on failed discovery")
+	}
+	if st.LastAttempt.IsZero() {
+		t.Fatal("LastAttempt should be set on failed discovery")
+	}
+}
+
+func TestStatus_LoadedProviderReportsOk(t *testing.T) {
+	idp := newFakeIDP()
+	defer idp.Close()
+
+	mgr := NewManager("https://bindery.example.com")
+	mgr.Reload(context.Background(), []ProviderConfig{
+		{ID: "y", Name: "Y", Issuer: idp.URL, ClientID: "cid", ClientSecret: "sec"},
+	})
+
+	st := mgr.Status("y")
+	if st == nil || st.State != "ok" {
+		t.Fatalf("want state=ok, got %+v", st)
+	}
+	if mgr.Status("nonexistent") != nil {
+		t.Fatal("Status should be nil for a provider that was never configured")
+	}
+}
+
+func TestEnsureLoaded_RetryRespectsInterval(t *testing.T) {
+	idp := newFakeIDP()
+	defer idp.Close()
+	idp.failing.Store(true)
+
+	// Speed up retry interval so the test doesn't sleep 30s.
+	prev := retryMinInterval
+	retryMinInterval = 50 * time.Millisecond
+	defer func() { retryMinInterval = prev }()
+
+	mgr := NewManager("https://bindery.example.com")
+	mgr.Reload(context.Background(), []ProviderConfig{
+		{ID: "z", Name: "Z", Issuer: idp.URL, ClientID: "cid", ClientSecret: "sec"},
+	})
+	if mgr.Get("z") != nil {
+		t.Fatal("expected initial discovery to fail")
+	}
+
+	// Bring the IdP back up and immediately try EnsureLoaded — within the
+	// retry interval, it must NOT attempt another discovery.
+	idp.failing.Store(false)
+	firstAttempt := mgr.Status("z").LastAttempt
+	mgr.EnsureLoaded(context.Background(), "z")
+	if mgr.Get("z") != nil {
+		t.Fatal("EnsureLoaded should not have retried within retryMinInterval")
+	}
+	if mgr.Status("z").LastAttempt != firstAttempt {
+		t.Fatal("LastAttempt should be unchanged when retry is rate-limited")
+	}
+
+	// After the interval elapses, EnsureLoaded triggers re-discovery and
+	// the provider transitions to loaded.
+	time.Sleep(retryMinInterval + 20*time.Millisecond)
+	mgr.EnsureLoaded(context.Background(), "z")
+	if mgr.Get("z") == nil {
+		t.Fatal("EnsureLoaded should have recovered the provider after the interval")
+	}
+	if mgr.Status("z").State != "ok" {
+		t.Fatalf("recovered provider should report ok, got %+v", mgr.Status("z"))
+	}
+}
+
+func TestEnsureLoaded_NoOpForUnknown(t *testing.T) {
+	mgr := NewManager("https://bindery.example.com")
+	// Should not panic, should not log, should not touch internal maps.
+	mgr.EnsureLoaded(context.Background(), "nope")
+	if mgr.Get("nope") != nil {
+		t.Fatal("unknown provider must not be created by EnsureLoaded")
+	}
+}
+
+func TestAuthURL_TriggersRetryForFailedProvider(t *testing.T) {
+	idp := newFakeIDP()
+	defer idp.Close()
+	idp.failing.Store(true)
+
+	prev := retryMinInterval
+	retryMinInterval = 1 * time.Millisecond
+	defer func() { retryMinInterval = prev }()
+
+	mgr := NewManager("https://bindery.example.com")
+	mgr.Reload(context.Background(), []ProviderConfig{
+		{ID: "p", Name: "P", Issuer: idp.URL, ClientID: "cid", ClientSecret: "sec"},
+	})
+
+	// Bring IdP back up. Sleep past the retry interval so EnsureLoaded
+	// will take a fresh attempt the next time it's called.
+	idp.failing.Store(false)
+	time.Sleep(5 * time.Millisecond)
+
+	verifier, _ := NewVerifier()
+	url, err := mgr.AuthURL(context.Background(), "p", "state", "nonce", verifier)
+	if err != nil {
+		t.Fatalf("AuthURL should have succeeded after on-demand retry: %v", err)
+	}
+	if url == "" {
+		t.Fatal("AuthURL returned empty URL")
+	}
+}
+
+func TestAuthURL_StillFailsWhenIdPDown(t *testing.T) {
+	idp := newFakeIDP()
+	defer idp.Close()
+	idp.failing.Store(true)
+
+	prev := retryMinInterval
+	retryMinInterval = 1 * time.Millisecond
+	defer func() { retryMinInterval = prev }()
+
+	mgr := NewManager("https://bindery.example.com")
+	mgr.Reload(context.Background(), []ProviderConfig{
+		{ID: "q", Name: "Q", Issuer: idp.URL, ClientID: "cid", ClientSecret: "sec"},
+	})
+	time.Sleep(5 * time.Millisecond)
+
+	verifier, _ := NewVerifier()
+	_, err := mgr.AuthURL(context.Background(), "q", "state", "nonce", verifier)
+	if err == nil {
+		t.Fatal("AuthURL should fail when IdP is still down after retry attempt")
+	}
+	if !strings.Contains(err.Error(), "unknown oidc provider") {
+		t.Fatalf("expected unknown-provider error, got: %v", err)
+	}
+}
+
+func TestReload_RecoversPreviouslyFailedProvider(t *testing.T) {
+	idp := newFakeIDP()
+	defer idp.Close()
+	idp.failing.Store(true)
+
+	mgr := NewManager("https://bindery.example.com")
+	cfg := ProviderConfig{ID: "r", Name: "R", Issuer: idp.URL, ClientID: "cid", ClientSecret: "sec"}
+	mgr.Reload(context.Background(), []ProviderConfig{cfg})
+	if mgr.Status("r").State != "failed" {
+		t.Fatal("setup: provider should start in failed state")
+	}
+
+	// IdP comes back up, admin saves settings again (or any other Reload trigger).
+	idp.failing.Store(false)
+	mgr.Reload(context.Background(), []ProviderConfig{cfg})
+
+	if mgr.Status("r").State != "ok" {
+		t.Fatalf("Reload should have recovered the provider, got %+v", mgr.Status("r"))
+	}
+	if _, stillFailed := mgr.failed["r"]; stillFailed {
+		t.Fatal("recovered provider must be removed from the failed map")
+	}
+}
+
+func TestReload_RemovesStaleProviders(t *testing.T) {
+	idp := newFakeIDP()
+	defer idp.Close()
+
+	mgr := NewManager("https://bindery.example.com")
+	mgr.Reload(context.Background(), []ProviderConfig{
+		{ID: "keep", Name: "K", Issuer: idp.URL, ClientID: "cid", ClientSecret: "sec"},
+		{ID: "drop", Name: "D", Issuer: idp.URL, ClientID: "cid", ClientSecret: "sec"},
+	})
+	if mgr.Get("drop") == nil {
+		t.Fatal("setup: both providers should be loaded")
+	}
+
+	// Settings now contain only "keep".
+	mgr.Reload(context.Background(), []ProviderConfig{
+		{ID: "keep", Name: "K", Issuer: idp.URL, ClientID: "cid", ClientSecret: "sec"},
+	})
+	if mgr.Get("drop") != nil {
+		t.Fatal("removed provider should be gone from loaded map")
+	}
+	if mgr.Status("drop") != nil {
+		t.Fatal("removed provider should not appear in status either")
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -97,9 +97,18 @@ export interface AuthConfig {
   username: string
 }
 
+export interface OidcProviderStatus {
+  state: 'ok' | 'failed'
+  last_error?: string
+  last_attempt?: string
+}
+
 export interface OidcProvider {
   id: string
   name: string
+  // Optional runtime status. Present on responses from a backend that
+  // tracks failed-discovery state; absent for older backends.
+  status?: OidcProviderStatus
 }
 
 export interface OidcProviderConfig {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -410,7 +410,9 @@
       "fieldIssuer": "Issuer URL",
       "fieldClientId": "Client ID",
       "fieldClientSecret": "Client Secret",
-      "fieldScopes": "Scopes"
+      "fieldScopes": "Scopes",
+      "statusOk": "Ready",
+      "statusFailed": "Discovery failed"
     }
   },
   "addAuthorModal": {

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -14,7 +14,12 @@ export default function LoginPage() {
   const navigate = useNavigate()
 
   useEffect(() => {
-    api.oidcProviders().then(setOidcProviders).catch(() => setOidcProviders([]))
+    api.oidcProviders()
+      // Hide providers that failed startup discovery so users don't click
+      // into a flow that's guaranteed to error. Older backends omit `status`
+      // entirely — fall through and show those buttons unfiltered.
+      .then(ps => setOidcProviders(ps.filter(p => !p.status || p.status.state === 'ok')))
+      .catch(() => setOidcProviders([]))
   }, [])
 
   // Read values from the form at submit time instead of React state.

--- a/web/src/settings/AuthSettings.tsx
+++ b/web/src/settings/AuthSettings.tsx
@@ -47,7 +47,10 @@ export default function AuthSettings() {
       const nextIds = [...displayed.map(p => p.id), cfg.id]
       const nextConfigs = new Map(fullConfigs).set(cfg.id, cfg)
       await api.oidcSetProviders(buildPutPayload(nextIds).map(p => nextConfigs.get(p.id) ?? p))
+      // Status will populate on next GET; the row briefly renders without a
+      // badge until then, which is acceptable. Re-fetch async to refresh it.
       setDisplayed(ps => [...ps, { id: cfg.id, name: cfg.name }])
+      api.oidcProviders().then(setDisplayed).catch(() => {})
       setFullConfigs(nextConfigs)
       setShowAdd(false)
     } catch (e) {
@@ -72,14 +75,33 @@ export default function AuthSettings() {
         )}
 
         {displayed.map(p => (
-          <div key={p.id} className="flex items-center justify-between py-2 border-b border-slate-200 dark:border-zinc-800 last:border-0">
-            <div>
-              <span className="text-sm font-medium text-slate-800 dark:text-zinc-200">{p.name}</span>
+          <div key={p.id} className="flex items-start justify-between py-2 border-b border-slate-200 dark:border-zinc-800 last:border-0 gap-3">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-slate-800 dark:text-zinc-200">{p.name}</span>
+                {p.status?.state === 'failed' ? (
+                  <span
+                    title={p.status.last_error}
+                    className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300"
+                  >
+                    {t('settings.oidc.statusFailed')}
+                  </span>
+                ) : p.status?.state === 'ok' ? (
+                  <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300">
+                    {t('settings.oidc.statusOk')}
+                  </span>
+                ) : null}
+              </div>
+              {p.status?.state === 'failed' && p.status.last_error && (
+                <p className="text-xs text-red-600 dark:text-red-400 mt-1 break-all">
+                  {p.status.last_error}
+                </p>
+              )}
             </div>
             <button
               onClick={() => remove(p.id)}
               disabled={saving}
-              className="text-xs text-red-600 dark:text-red-400 hover:underline disabled:opacity-50"
+              className="text-xs text-red-600 dark:text-red-400 hover:underline disabled:opacity-50 shrink-0"
             >
               {t('common.remove')}
             </button>


### PR DESCRIPTION
Closes #461.

## Summary

OIDC providers whose discovery failed during `Reload()` were silently dropped from the in-memory manager. Admins had no signal beyond a single ERROR log line, and login stayed broken until the pod was manually restarted — even after the IdP came back up.

This PR implements the *cheap* and *medium* options from #461 (surface failure + retry on demand). The *better* option (background retry goroutine) is intentionally deferred — on-demand retry covers the common case (login arrives → recover) without spending a goroutine, and the implementation surface for background retry is small enough to add later if needed.

## What's in the PR

**Backend (`internal/auth/oidc/provider.go`)**
- `Manager.failed` map records `(cfg, lastErr, lastAttempt)` for providers whose discovery failed instead of dropping them silently.
- `Manager.EnsureLoaded(ctx, id)` retries on-demand, rate-limited by `retryMinInterval` (30s default) so a hammered login button can't DDoS the IdP. Wired into `AuthURL` and `Exchange` so the first login attempt after the IdP recovers transparently transitions the provider from failed → ok.
- `Manager.Status(id)` exposes runtime state (`ok` / `failed`) with last error and timestamp.
- `Reload` retries failed entries on every save, so an explicit re-save also works as a recovery path.

**API (`internal/api/auth_oidc.go`)**
- `GET /api/v1/auth/oidc/providers` now embeds a per-provider `status` block alongside the existing public config — admins can diagnose without grepping logs.
- `Manager.AuthURL` now takes `ctx` (touches the only caller — the Login handler).

**Frontend**
- `AuthSettings.tsx` shows a red badge + error text on failed providers; green "Ready" badge on healthy ones.
- `LoginPage.tsx` filters out failed providers from the SSO button list. Older backends that don't return `status` fall through and show all providers (no regression).
- Added two i18n keys (`statusOk`, `statusFailed`) to `en.json`. Other locales fall back to English until translated.

## Tests

8 new tests using a `httptest`-backed fake IdP that flips between failing and succeeding under test control:

- `TestReload_FailedProviderRecorded` — failed entries land in the `failed` map, not silently dropped.
- `TestStatus_LoadedProviderReportsOk` — `Status` returns nil/ok/failed correctly.
- `TestEnsureLoaded_RetryRespectsInterval` — second attempt within `retryMinInterval` is a no-op; after the interval, retry runs.
- `TestEnsureLoaded_NoOpForUnknown` — `EnsureLoaded` for an unknown id is a no-op.
- `TestAuthURL_TriggersRetryForFailedProvider` — login flow recovers a failed provider on demand.
- `TestAuthURL_StillFailsWhenIdPDown` — login flow returns the unchanged user-facing error when retry doesn't help.
- `TestReload_RecoversPreviouslyFailedProvider` — saving settings while the IdP is back up recovers the provider.
- `TestReload_RemovesStaleProviders` — removing a provider from settings clears it from both maps.

Existing tests still pass; no behavior change for the happy path.

## Backward compatibility

- API: `status` is an additive field; older clients ignore it.
- Frontend: `OidcProvider.status` is optional. Older backends omit it; the login page treats absence as "show the provider" to preserve current behavior.
- Behavior: For a provider that never had a discovery failure, this PR is a no-op — the only change is that the failed-provider path no longer leaks the configuration into the void.

🤖 Generated with [Claude Code](https://claude.com/claude-code)