### PR TITLE
fix(metadata): revert OpenLibrary search to /search.json (FastAPI endpoint)

### DIFF
--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -72,9 +72,11 @@ func (c *Client) SearchAuthors(ctx context.Context, query string) ([]models.Auth
 }
 
 func (c *Client) SearchBooks(ctx context.Context, query string) ([]models.Book, error) {
-	// OpenLibrary migrated /search.json to FastAPI. The new endpoint is /search
-	// which accepts the same query parameters and returns the same JSON shape.
-	u := fmt.Sprintf("%s/search?q=%s&fields=key,title,author_name,author_key,first_publish_year,cover_i,isbn,subject&limit=20",
+	// OpenLibrary's JSON search API is /search.json (now backed by FastAPI).
+	// /search (without .json) is the HTML web-UI path (Solr-backed) and
+	// returns HTTP 500 "DEPRECATED ENDPOINT ACCESSED" for API consumers
+	// since their FastAPI rollout completed (see issue #462, follow-up to #408).
+	u := fmt.Sprintf("%s/search.json?q=%s&fields=key,title,author_name,author_key,first_publish_year,cover_i,isbn,subject&limit=20",
 		baseURL, url.QueryEscape(query))
 	var resp searchResponse
 	if err := c.getJSON(ctx, u, &resp); err != nil {
@@ -304,10 +306,11 @@ func (c *Client) GetAuthorWorks(ctx context.Context, authorForeignID string) ([]
 // Series membership is not in the search response — callers get it from
 // authorWorksBackfill (the /authors/{id}/works endpoint).
 //
-// Uses the /search endpoint (FastAPI, current) rather than the deprecated
-// /search.json (Solr, which now returns HTTP 500; see issue #408).
+// Uses /search.json (FastAPI-backed JSON API). /search without .json is the
+// HTML web-UI path still served by Solr, which returns HTTP 500
+// "DEPRECATED ENDPOINT ACCESSED" for API consumers (issue #462).
 func (c *Client) searchAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error) {
-	u := fmt.Sprintf("%s/search?author_key=%s&fields=key,title,language,edition_count,first_publish_year,cover_i,subject&limit=200",
+	u := fmt.Sprintf("%s/search.json?author_key=%s&fields=key,title,language,edition_count,first_publish_year,cover_i,subject&limit=200",
 		baseURL, authorForeignID)
 	var resp struct {
 		Docs []struct {

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -151,7 +151,7 @@ func TestSearchBooks_HTTP(t *testing.T) {
 		},
 	}
 	c := newClientWithPaths(t, map[string]interface{}{
-		"/search": jsonStr(resp),
+		"/search.json": jsonStr(resp),
 	})
 
 	books, err := c.SearchBooks(context.Background(), "Dune")
@@ -194,7 +194,7 @@ func TestSearchBooks_HTTP_NoAuthorKey(t *testing.T) {
 		},
 	}
 	c := newClientWithPaths(t, map[string]interface{}{
-		"/search": jsonStr(resp),
+		"/search.json": jsonStr(resp),
 	})
 
 	books, err := c.SearchBooks(context.Background(), "test")
@@ -214,8 +214,8 @@ func TestSearchBooks_HTTP_NoAuthorKey(t *testing.T) {
 
 func TestSearchBooks_HTTP_Error(t *testing.T) {
 	c := newClientWithStatus(t,
-		map[string]interface{}{"/search": "error"},
-		map[string]int{"/search": http.StatusInternalServerError},
+		map[string]interface{}{"/search.json": "error"},
+		map[string]int{"/search.json": http.StatusInternalServerError},
 	)
 	_, err := c.SearchBooks(context.Background(), "dune")
 	if err == nil {
@@ -616,7 +616,7 @@ func TestGetAuthorWorks_HTTP(t *testing.T) {
 
 	c := newClientWithPaths(t, map[string]interface{}{
 		"/authors/OL123A/works.json": jsonStr(worksResp),
-		"/search":                    jsonStr(searchResp),
+		"/search.json":                    jsonStr(searchResp),
 	})
 
 	books, err := c.GetAuthorWorks(context.Background(), "OL123A")
@@ -666,7 +666,7 @@ func TestGetAuthorWorks_HTTP_WorksEndpointFillsMissingSearchEntries(t *testing.T
 	}
 	c := newClientWithPaths(t, map[string]interface{}{
 		"/authors/OL123A/works.json": jsonStr(worksResp),
-		"/search":                    jsonStr(searchResp),
+		"/search.json":                    jsonStr(searchResp),
 	})
 
 	books, err := c.GetAuthorWorks(context.Background(), "OL123A")
@@ -696,7 +696,7 @@ func TestGetAuthorWorks_HTTP_SearchFallbackWhenWorksEmpty(t *testing.T) {
 	}
 	c := newClientWithPaths(t, map[string]interface{}{
 		"/authors/OL123A/works.json": jsonStr(authorWorksResponse{}),
-		"/search":                    jsonStr(searchResp),
+		"/search.json":                    jsonStr(searchResp),
 	})
 	books, err := c.GetAuthorWorks(context.Background(), "OL123A")
 	if err != nil {
@@ -725,7 +725,7 @@ func TestGetAuthorWorks_HTTP_ObjectSeries(t *testing.T) {
 
 	c := newClientWithPaths(t, map[string]interface{}{
 		"/authors/OL999A/works.json": worksBody,
-		"/search":                    searchBody,
+		"/search.json":                    searchBody,
 	})
 
 	books, err := c.GetAuthorWorks(context.Background(), "OL999A")
@@ -755,11 +755,11 @@ func TestGetAuthorWorks_HTTP_Error(t *testing.T) {
 	c := newClientWithStatus(t,
 		map[string]interface{}{
 			"/authors/OL404A/works.json": "error",
-			"/search":                    "error",
+			"/search.json":                    "error",
 		},
 		map[string]int{
 			"/authors/OL404A/works.json": http.StatusInternalServerError,
-			"/search":                    http.StatusInternalServerError,
+			"/search.json":                    http.StatusInternalServerError,
 		},
 	)
 	_, err := c.GetAuthorWorks(context.Background(), "OL404A")
@@ -781,10 +781,10 @@ func TestGetAuthorWorks_HTTP_SearchEnrichmentFailure(t *testing.T) {
 	c := newClientWithStatus(t,
 		map[string]interface{}{
 			"/authors/OL1A/works.json": jsonStr(worksResp),
-			"/search":                  "oops",
+			"/search.json":                  "oops",
 		},
 		map[string]int{
-			"/search": http.StatusInternalServerError,
+			"/search.json": http.StatusInternalServerError,
 		},
 	)
 	books, err := c.GetAuthorWorks(context.Background(), "OL1A")
@@ -814,7 +814,7 @@ func TestGetAuthorWorks_HTTP_LangPreferEng(t *testing.T) {
 	}
 	c := newClientWithPaths(t, map[string]interface{}{
 		"/authors/OL999A/works.json": jsonStr(worksResp),
-		"/search":                    jsonStr(searchResp),
+		"/search.json":                    jsonStr(searchResp),
 	})
 
 	books, err := c.GetAuthorWorks(context.Background(), "OL999A")
@@ -846,7 +846,7 @@ func TestGetAuthorWorks_HTTP_NoiseFilter(t *testing.T) {
 	}
 	c := newClientWithPaths(t, map[string]interface{}{
 		"/authors/OL5A/works.json": jsonStr(worksResp),
-		"/search":                  jsonStr(searchRespForAuthor{}),
+		"/search.json":                  jsonStr(searchRespForAuthor{}),
 	})
 	books, err := c.GetAuthorWorks(context.Background(), "OL5A")
 	if err != nil {
@@ -870,7 +870,7 @@ func TestGetAuthorWorks_HTTP_NoiseFilterSearchEnrichment(t *testing.T) {
 				{Key: "/works/OL1W", Title: "Real Book"},
 			},
 		}),
-		"/search": jsonStr(searchRespForAuthor{
+		"/search.json": jsonStr(searchRespForAuthor{
 			Docs: []searchDocForAuthor{
 				{Key: "/works/OL1W", Title: "Real Book", Language: []string{"eng"}},
 				// These noise entries only appear in search (not in works) and must be dropped.


### PR DESCRIPTION
## Root cause

Issue #462 reports title search failing with:

> `metadata provider unavailable: search books: HTTP 500: DEPRECATED ENDPOINT ACCESSED: /search. This endpoint has been migrated to FastAPI and should not be accessed in production.`

ISBN lookup continues to work, which isolates this to `SearchBooks` (and the `searchAuthorWorks` enrichment pass in `GetAuthorWorks`).

Both call sites currently hit `https://openlibrary.org/search?...`. That path is the **HTML web UI search page**, still Solr-backed, which now returns HTTP 500 for API consumers once the FastAPI migration completed.

The **JSON API** is `https://openlibrary.org/search.json?...` — the same query parameters, same response shape, now backed by FastAPI.

## Why this is confusing

The #438 fix (for issue #408) switched from `/search.json` to `/search` because at that point *both* paths were returning 500 from Solr. The assumption was that `/search` (no extension) was the FastAPI endpoint — it wasn't. OpenLibrary's Solr routing emits the same 500 for any path it no longer handles, so the migration front moved: `/search.json` recovered on FastAPI first, then Solr started emitting 500s on `/search` (the HTML path, which was never the right API target).

## Fix

Two lines: `%s/search?` → `%s/search.json?` in `SearchBooks` and `searchAuthorWorks`. Fifteen HTTP-layer test mock keys updated from `"/search"` to `"/search.json"`.

## Test plan

- [x] `go test ./internal/metadata/openlibrary/...` — 15 HTTP-layer tests, all pass
- [x] `go test ./...` — all packages green

Closes #462.