### PR TITLE
test(series): cover Codecov follow-up gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Chores
+
+- **Series Codecov follow-up coverage** (#475) — Added targeted tests for series API edge cases, repository hydration and linking behavior, metadata aggregator series catalog fallback/cache behavior, and series matching helpers after gaps were noticed in the Codecov report for PR #459.
+
 ## [v1.7.0] — 2026-05-08
 
 ### Added

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -36,6 +36,8 @@ type stubSeriesProvider struct {
 	searchErr     error
 	catalogErr    error
 	searchCalls   int
+	searchLimits  []int
+	searchQueries []string
 	catalogCalls  int
 }
 
@@ -65,8 +67,10 @@ func (s *stubSeriesProvider) GetBookByISBN(context.Context, string) (*models.Boo
 	return nil, nil
 }
 
-func (s *stubSeriesProvider) SearchSeries(context.Context, string, int) ([]metadata.SeriesSearchResult, error) {
+func (s *stubSeriesProvider) SearchSeries(_ context.Context, query string, limit int) ([]metadata.SeriesSearchResult, error) {
 	s.searchCalls++
+	s.searchQueries = append(s.searchQueries, query)
+	s.searchLimits = append(s.searchLimits, limit)
 	return s.searchResults, s.searchErr
 }
 
@@ -375,6 +379,54 @@ func TestSeriesManagementRejectsOverlongTitle(t *testing.T) {
 	}
 }
 
+func TestSeriesMonitorEndpoint(t *testing.T) {
+	h, seriesRepo, _, _ := seriesFixture(t)
+	ctx := contextBackground()
+	series := &models.Series{ForeignID: "manual:stormlight", Title: "Stormlight Archive"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Monitor(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/api/v1/series/1/monitor", bytes.NewBufferString(`{"monitored":true}`)), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var response map[string]bool
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if !response["monitored"] {
+		t.Fatalf("response = %+v, want monitored true", response)
+	}
+	updated, err := seriesRepo.GetByID(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated == nil || !updated.Monitored {
+		t.Fatalf("stored series = %+v, want monitored", updated)
+	}
+
+	tests := []struct {
+		name string
+		id   string
+		body string
+		code int
+	}{
+		{name: "invalid id", id: "abc", body: `{"monitored":true}`, code: http.StatusBadRequest},
+		{name: "invalid body", id: strconv.FormatInt(series.ID, 10), body: `{`, code: http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.Monitor(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/api/v1/series/1/monitor", bytes.NewBufferString(tt.body)), "id", tt.id))
+			if rec.Code != tt.code {
+				t.Fatalf("expected %d, got %d: %s", tt.code, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestSeriesHardcoverSearch(t *testing.T) {
 	provider := &stubSeriesProvider{
 		searchResults: []metadata.SeriesSearchResult{{
@@ -443,6 +495,57 @@ func TestSeriesHardcoverSearchDisabledByFeatureState(t *testing.T) {
 	}
 	if provider.searchCalls != 0 {
 		t.Fatalf("provider should not be called when disabled, got %d calls", provider.searchCalls)
+	}
+}
+
+func TestSeriesHardcoverSearchValidationAndProviderErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		code int
+	}{
+		{name: "missing term", url: "/api/v1/series/hardcover/search", code: http.StatusBadRequest},
+		{name: "invalid limit", url: "/api/v1/series/hardcover/search?term=stormlight&limit=abc", code: http.StatusBadRequest},
+		{name: "zero limit", url: "/api/v1/series/hardcover/search?term=stormlight&limit=0", code: http.StatusBadRequest},
+		{name: "negative limit", url: "/api/v1/series/hardcover/search?term=stormlight&limit=-1", code: http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &stubSeriesProvider{}
+			h, _, _, _ := seriesFixtureWithProvider(t, provider, nil)
+			rec := httptest.NewRecorder()
+			h.SearchHardcover(rec, httptest.NewRequest(http.MethodGet, tt.url, nil))
+			if rec.Code != tt.code {
+				t.Fatalf("expected %d, got %d: %s", tt.code, rec.Code, rec.Body.String())
+			}
+			if provider.searchCalls != 0 {
+				t.Fatalf("provider should not be called for invalid request, got %d calls", provider.searchCalls)
+			}
+		})
+	}
+
+	provider := &stubSeriesProvider{searchErr: errors.New("hardcover unavailable")}
+	h, _, _, _ := seriesFixtureWithProvider(t, provider, nil)
+	rec := httptest.NewRecorder()
+	h.SearchHardcover(rec, httptest.NewRequest(http.MethodGet, "/api/v1/series/hardcover/search?term=stormlight", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("provider error: expected 502, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	provider = &stubSeriesProvider{
+		searchResults: []metadata.SeriesSearchResult{{ForeignID: "hc-series:42", ProviderID: "42", Title: "Stormlight"}},
+	}
+	h, _, _, _ = seriesFixtureWithProvider(t, provider, nil)
+	rec = httptest.NewRecorder()
+	h.SearchHardcover(rec, httptest.NewRequest(http.MethodGet, "/api/v1/series/hardcover/search?term=stormlight&limit=99", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("limit cap: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(provider.searchLimits) != 1 || provider.searchLimits[0] != 50 {
+		t.Fatalf("search limits = %+v, want capped limit 50", provider.searchLimits)
+	}
+	if len(provider.searchQueries) != 1 || provider.searchQueries[0] != "stormlight" {
+		t.Fatalf("search queries = %+v, want stormlight", provider.searchQueries)
 	}
 }
 
@@ -731,6 +834,76 @@ func TestSeriesPutHardcoverLinkProviderFailure(t *testing.T) {
 	}
 }
 
+func TestSeriesGetHardcoverLinkEndpoint(t *testing.T) {
+	catalog := stormlightCatalog()
+	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, nil)
+	ctx := contextBackground()
+	linked := &models.Series{ForeignID: "manual:series:linked", Title: "Linked"}
+	if err := seriesRepo.Create(ctx, linked); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+		SeriesID:            linked.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	unlinked := &models.Series{ForeignID: "manual:series:unlinked", Title: "Unlinked"}
+	if err := seriesRepo.Create(ctx, unlinked); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.GetHardcoverLink(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/series/1/hardcover-link", nil), "id", strconv.FormatInt(linked.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got models.SeriesHardcoverLink
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.HardcoverSeriesID != catalog.ForeignID {
+		t.Fatalf("link = %+v, want %s", got, catalog.ForeignID)
+	}
+
+	tests := []struct {
+		name string
+		id   string
+		code int
+	}{
+		{name: "missing link", id: strconv.FormatInt(unlinked.ID, 10), code: http.StatusNotFound},
+		{name: "invalid id", id: "abc", code: http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.GetHardcoverLink(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/series/1/hardcover-link", nil), "id", tt.id))
+			if rec.Code != tt.code {
+				t.Fatalf("expected %d, got %d: %s", tt.code, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestSeriesGetHardcoverLinkDisabledByFeatureState(t *testing.T) {
+	provider := &stubSeriesProvider{}
+	h, _, _, _, _ := seriesFixtureWithProviderAndSettings(t, provider, nil, false)
+
+	rec := httptest.NewRecorder()
+	h.GetHardcoverLink(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/series/1/hardcover-link", nil), "id", "1"))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when enhanced Hardcover API is disabled, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestSeriesDeleteHardcoverLinkRemovesStoredLink(t *testing.T) {
 	catalog := stormlightCatalog()
 	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
@@ -913,6 +1086,109 @@ func TestSeriesHardcoverDiffEndpointErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSeriesFillEndpointErrors(t *testing.T) {
+	t.Run("invalid id", func(t *testing.T) {
+		h, _, _, _ := seriesFixture(t)
+		rec := httptest.NewRecorder()
+		h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/abc/fill", nil), "id", "abc"))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("invalid body", func(t *testing.T) {
+		h, _, _, _ := seriesFixture(t)
+		rec := httptest.NewRecorder()
+		h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", bytes.NewBufferString(`{`)), "id", "1"))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("selector feature disabled", func(t *testing.T) {
+		provider := &stubSeriesProvider{}
+		h, _, _, _, _ := seriesFixtureWithProviderAndSettings(t, provider, nil, false)
+		rec := httptest.NewRecorder()
+		h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", bytes.NewBufferString(`{"foreignBookId":"hc:missing"}`)), "id", "1"))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if provider.catalogCalls != 0 {
+			t.Fatalf("provider should not be called when feature is disabled, got %d calls", provider.catalogCalls)
+		}
+	})
+
+	t.Run("requested book not found", func(t *testing.T) {
+		catalog := stormlightCatalog()
+		h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
+			catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+		}, nil)
+		ctx := contextBackground()
+		series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
+		if err := seriesRepo.Create(ctx, series); err != nil {
+			t.Fatal(err)
+		}
+		if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+			SeriesID:            series.ID,
+			HardcoverSeriesID:   catalog.ForeignID,
+			HardcoverProviderID: catalog.ProviderID,
+			HardcoverTitle:      catalog.Title,
+			HardcoverBookCount:  catalog.BookCount,
+			Confidence:          1,
+			LinkedBy:            "manual",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		rec := httptest.NewRecorder()
+		h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", bytes.NewBufferString(`{"foreignBookId":"hc:not-there"}`)), "id", strconv.FormatInt(series.ID, 10)))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("missing link", func(t *testing.T) {
+		h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{}, nil)
+		series := &models.Series{ForeignID: "manual:series:unlinked", Title: "Unlinked"}
+		if err := seriesRepo.Create(contextBackground(), series); err != nil {
+			t.Fatal(err)
+		}
+		rec := httptest.NewRecorder()
+		h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", bytes.NewBufferString(`{"position":"1"}`)), "id", strconv.FormatInt(series.ID, 10)))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		catalog := stormlightCatalog()
+		h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
+			catalogs:   map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+			catalogErr: errors.New("hardcover unavailable"),
+		}, nil)
+		ctx := contextBackground()
+		series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
+		if err := seriesRepo.Create(ctx, series); err != nil {
+			t.Fatal(err)
+		}
+		if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+			SeriesID:            series.ID,
+			HardcoverSeriesID:   catalog.ForeignID,
+			HardcoverProviderID: catalog.ProviderID,
+			HardcoverTitle:      catalog.Title,
+			HardcoverBookCount:  catalog.BookCount,
+			Confidence:          1,
+			LinkedBy:            "manual",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		rec := httptest.NewRecorder()
+		h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", bytes.NewBufferString(`{"position":"1"}`)), "id", strconv.FormatInt(series.ID, 10)))
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("expected 502, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
 }
 
 func TestSeriesFillSkipsHardcoverCatalogWhenFeatureDisabled(t *testing.T) {

--- a/internal/db/series_test.go
+++ b/internal/db/series_test.go
@@ -316,3 +316,293 @@ func TestSeriesHardcoverLinkCRUD(t *testing.T) {
 		t.Fatalf("expected deleted link, got %+v", got)
 	}
 }
+
+func TestSeriesListWithBooksHydratesBooksAndHardcoverLinks(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	empty := &models.Series{ForeignID: "manual:empty", Title: "Empty Series"}
+	if err := seriesRepo.Create(ctx, empty); err != nil {
+		t.Fatal(err)
+	}
+	linked := &models.Series{ForeignID: "manual:stormlight", Title: "Stormlight Archive"}
+	if err := seriesRepo.Create(ctx, linked); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{ForeignID: "hc:brandon-sanderson", Name: "Brandon Sanderson", SortName: "Sanderson, Brandon"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "hc:the-way-of-kings", AuthorID: author.ID, Title: "The Way of Kings", SortTitle: "The Way of Kings",
+		Status: models.BookStatusWanted, Monitored: true, Genres: []string{},
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, linked.ID, book.ID, "1", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.UpsertHardcoverLink(ctx, &models.SeriesHardcoverLink{
+		SeriesID:            linked.ID,
+		HardcoverSeriesID:   "hc-series:42",
+		HardcoverProviderID: "42",
+		HardcoverTitle:      "The Stormlight Archive",
+		HardcoverAuthorName: "Brandon Sanderson",
+		HardcoverBookCount:  10,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := seriesRepo.ListWithBooks(ctx)
+	if err != nil {
+		t.Fatalf("ListWithBooks: %v", err)
+	}
+	byID := make(map[int64]models.Series, len(got))
+	for _, series := range got {
+		byID[series.ID] = series
+	}
+	if len(byID) != 2 {
+		t.Fatalf("series count = %d, want 2: %+v", len(byID), got)
+	}
+	if len(byID[empty.ID].Books) != 0 {
+		t.Fatalf("empty series books = %+v, want none", byID[empty.ID].Books)
+	}
+	hydrated := byID[linked.ID]
+	if len(hydrated.Books) != 1 || hydrated.Books[0].Book == nil || hydrated.Books[0].Book.Title != "The Way of Kings" {
+		t.Fatalf("hydrated books = %+v, want linked book", hydrated.Books)
+	}
+	if hydrated.Books[0].PositionInSeries != "1" || !hydrated.Books[0].PrimarySeries {
+		t.Fatalf("series book metadata = %+v, want position 1 primary", hydrated.Books[0])
+	}
+	if hydrated.HardcoverLink == nil || hydrated.HardcoverLink.HardcoverSeriesID != "hc-series:42" {
+		t.Fatalf("hydrated link = %+v, want hc-series:42", hydrated.HardcoverLink)
+	}
+}
+
+func TestSeriesMonitoringAndBookLinks(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	series := &models.Series{ForeignID: "manual:murderbot", Title: "Murderbot Diaries"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.SetMonitored(ctx, series.ID, true); err != nil {
+		t.Fatalf("SetMonitored true: %v", err)
+	}
+	gotSeries, err := seriesRepo.GetByID(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotSeries == nil || !gotSeries.Monitored {
+		t.Fatalf("monitored series = %+v, want monitored", gotSeries)
+	}
+
+	author := &models.Author{ForeignID: "ol:martha-wells", Name: "Martha Wells", SortName: "Wells, Martha"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "ol:all-systems-red", AuthorID: author.ID, Title: "All Systems Red", SortTitle: "All Systems Red",
+		Status: models.BookStatusWanted, Monitored: true, Genres: []string{},
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, series.ID, book.ID, "1", true); err != nil {
+		t.Fatal(err)
+	}
+	books, err := seriesRepo.ListBooksInSeries(ctx, series.ID)
+	if err != nil {
+		t.Fatalf("ListBooksInSeries: %v", err)
+	}
+	if len(books) != 1 || books[0].ID != book.ID || books[0].Status != models.BookStatusWanted || !books[0].Monitored {
+		t.Fatalf("series books = %+v, want linked wanted monitored book", books)
+	}
+
+	if err := seriesRepo.UnlinkBook(ctx, series.ID, book.ID); err != nil {
+		t.Fatalf("UnlinkBook: %v", err)
+	}
+	books, err = seriesRepo.ListBooksInSeries(ctx, series.ID)
+	if err != nil {
+		t.Fatalf("ListBooksInSeries after unlink: %v", err)
+	}
+	if len(books) != 0 {
+		t.Fatalf("series books after unlink = %+v, want none", books)
+	}
+}
+
+func TestSeriesForeignIDAndPrimarySeriesLookup(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	if got, err := seriesRepo.GetByForeignID(ctx, "missing"); err != nil || got != nil {
+		t.Fatalf("missing GetByForeignID = %+v err=%v, want nil", got, err)
+	}
+	series := &models.Series{ForeignID: "abs:series:old", Title: "The Expanse"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	got, err := seriesRepo.GetByForeignID(ctx, "abs:series:old")
+	if err != nil {
+		t.Fatalf("GetByForeignID old: %v", err)
+	}
+	if got == nil || got.ID != series.ID {
+		t.Fatalf("GetByForeignID old = %+v, want series %d", got, series.ID)
+	}
+	if err := seriesRepo.UpdateForeignID(ctx, series.ID, "hc-series:expanse"); err != nil {
+		t.Fatalf("UpdateForeignID: %v", err)
+	}
+	if got, err := seriesRepo.GetByForeignID(ctx, "abs:series:old"); err != nil || got != nil {
+		t.Fatalf("old foreign id after update = %+v err=%v, want nil", got, err)
+	}
+	got, err = seriesRepo.GetByForeignID(ctx, "hc-series:expanse")
+	if err != nil {
+		t.Fatalf("GetByForeignID updated: %v", err)
+	}
+	if got == nil || got.ID != series.ID || got.ForeignID != "hc-series:expanse" {
+		t.Fatalf("GetByForeignID updated = %+v, want updated series", got)
+	}
+
+	author := &models.Author{ForeignID: "ol:james-corey", Name: "James S. A. Corey", SortName: "Corey, James S. A."}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "ol:leviathan-wakes", AuthorID: author.ID, Title: "Leviathan Wakes", SortTitle: "Leviathan Wakes",
+		Status: models.BookStatusWanted, Genres: []string{},
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, series.ID, book.ID, "1", true); err != nil {
+		t.Fatal(err)
+	}
+	title, position, err := seriesRepo.GetPrimarySeriesForBook(ctx, book.ID)
+	if err != nil {
+		t.Fatalf("GetPrimarySeriesForBook: %v", err)
+	}
+	if title != "The Expanse" || position != "1" {
+		t.Fatalf("primary series = %q/%q, want The Expanse/1", title, position)
+	}
+	title, position, err = seriesRepo.GetPrimarySeriesForBook(ctx, book.ID+999)
+	if err != nil {
+		t.Fatalf("GetPrimarySeriesForBook missing: %v", err)
+	}
+	if title != "" || position != "" {
+		t.Fatalf("missing primary series = %q/%q, want empty", title, position)
+	}
+}
+
+func TestSeriesGetBookBySeriesPosition(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	author := &models.Author{ForeignID: "ol:james-corey", Name: "James S. A. Corey", SortName: "Corey, James S. A."}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	wanted := &models.Book{
+		ForeignID: "ol:leviathan-wakes", AuthorID: author.ID, Title: "Leviathan Wakes", SortTitle: "Leviathan Wakes",
+		Status: models.BookStatusWanted, Monitored: true, Genres: []string{},
+	}
+	if err := bookRepo.Create(ctx, wanted); err != nil {
+		t.Fatal(err)
+	}
+	imported := &models.Book{
+		ForeignID: "ol:calibans-war", AuthorID: author.ID, Title: "Caliban's War", SortTitle: "Caliban's War",
+		Status: models.BookStatusImported, Monitored: true, Genres: []string{},
+	}
+	if err := bookRepo.Create(ctx, imported); err != nil {
+		t.Fatal(err)
+	}
+	series := &models.Series{ForeignID: "manual:expanse", Title: "The Expanse"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, series.ID, wanted.ID, "1", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, series.ID, imported.ID, "2", true); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := seriesRepo.GetBookBySeriesPosition(ctx, " the expanse ", "1")
+	if err != nil {
+		t.Fatalf("GetBookBySeriesPosition wanted: %v", err)
+	}
+	if got == nil || got.ID != wanted.ID {
+		t.Fatalf("wanted match = %+v, want book %d", got, wanted.ID)
+	}
+	got, err = seriesRepo.GetBookBySeriesPosition(ctx, "The Expanse", "99")
+	if err != nil {
+		t.Fatalf("GetBookBySeriesPosition missing: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("missing position = %+v, want nil", got)
+	}
+	got, err = seriesRepo.GetBookBySeriesPosition(ctx, "The Expanse", "2")
+	if err != nil {
+		t.Fatalf("GetBookBySeriesPosition imported: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("imported position = %+v, want nil because only wanted books qualify", got)
+	}
+
+	duplicateSeries := &models.Series{ForeignID: "manual:expanse-duplicate", Title: " the expanse "}
+	if err := seriesRepo.Create(ctx, duplicateSeries); err != nil {
+		t.Fatal(err)
+	}
+	duplicateBook := &models.Book{
+		ForeignID: "ol:leviathan-wakes-duplicate", AuthorID: author.ID, Title: "Leviathan Wakes", SortTitle: "Leviathan Wakes",
+		Status: models.BookStatusWanted, Monitored: true, Genres: []string{},
+	}
+	if err := bookRepo.Create(ctx, duplicateBook); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, duplicateSeries.ID, duplicateBook.ID, "1", true); err != nil {
+		t.Fatal(err)
+	}
+	got, err = seriesRepo.GetBookBySeriesPosition(ctx, "The Expanse", "1")
+	if err != nil {
+		t.Fatalf("GetBookBySeriesPosition ambiguous: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("ambiguous position = %+v, want nil", got)
+	}
+}

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -72,6 +72,35 @@ func (m *mockAuthorWorksByNameProvider) GetAuthorWorksByName(_ context.Context, 
 	return m.authorWorksByName, m.authorWorksByNameErr
 }
 
+type mockSeriesCatalogProvider struct {
+	mockProvider
+	searchSeriesResults []SeriesSearchResult
+	searchSeriesErr     error
+	searchSeriesCalls   int
+	searchSeriesQueries []string
+	searchSeriesLimits  []int
+	catalogs            map[string]*SeriesCatalog
+	catalogErr          error
+	catalogCalls        int
+	catalogIDs          []string
+}
+
+func (m *mockSeriesCatalogProvider) SearchSeries(_ context.Context, query string, limit int) ([]SeriesSearchResult, error) {
+	m.searchSeriesCalls++
+	m.searchSeriesQueries = append(m.searchSeriesQueries, query)
+	m.searchSeriesLimits = append(m.searchSeriesLimits, limit)
+	return m.searchSeriesResults, m.searchSeriesErr
+}
+
+func (m *mockSeriesCatalogProvider) GetSeriesCatalog(_ context.Context, foreignID string) (*SeriesCatalog, error) {
+	m.catalogCalls++
+	m.catalogIDs = append(m.catalogIDs, foreignID)
+	if m.catalogErr != nil {
+		return nil, m.catalogErr
+	}
+	return m.catalogs[foreignID], nil
+}
+
 func TestAggregator_SearchAuthors(t *testing.T) {
 	want := []models.Author{{Name: "Frank Herbert", ForeignID: "OL123A"}}
 	primary := &mockProvider{name: "ol", searchAuthors: want}
@@ -338,6 +367,154 @@ func TestAggregator_GetBookByISBN_NilBook(t *testing.T) {
 	}
 	if got != nil {
 		t.Errorf("expected nil for missing ISBN, got %+v", got)
+	}
+}
+
+func TestAggregator_SearchSeries_EdgeCases(t *testing.T) {
+	agg := newTestAggregator(&mockProvider{name: "ol"})
+
+	got, err := agg.SearchSeries(context.Background(), "  ", 10)
+	if err != nil {
+		t.Fatalf("SearchSeries empty query: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("empty query = %+v, want nil", got)
+	}
+
+	got, err = agg.SearchSeries(context.Background(), "Dune", 10)
+	if err != nil {
+		t.Fatalf("SearchSeries without providers: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("without providers = %+v, want nil", got)
+	}
+}
+
+func TestAggregator_SearchSeries_FallbackDefaultLimitAndCache(t *testing.T) {
+	primary := &mockSeriesCatalogProvider{
+		mockProvider:    mockProvider{name: "primary"},
+		searchSeriesErr: errors.New("primary unavailable"),
+	}
+	enricher := &mockSeriesCatalogProvider{
+		mockProvider: mockProvider{name: "enricher"},
+		searchSeriesResults: []SeriesSearchResult{{
+			ForeignID:  "hc-series:1",
+			ProviderID: "1",
+			Title:      "Dune",
+		}},
+	}
+	agg := &Aggregator{
+		primary:   primary,
+		enrichers: []Provider{enricher},
+		cache:     newTTLCache(time.Minute),
+	}
+
+	got, err := agg.SearchSeries(context.Background(), "  Dune  ", 0)
+	if err != nil {
+		t.Fatalf("SearchSeries: %v", err)
+	}
+	if len(got) != 1 || got[0].ForeignID != "hc-series:1" {
+		t.Fatalf("unexpected results: %+v", got)
+	}
+	if primary.searchSeriesCalls != 1 || enricher.searchSeriesCalls != 1 {
+		t.Fatalf("provider calls primary=%d enricher=%d, want 1/1", primary.searchSeriesCalls, enricher.searchSeriesCalls)
+	}
+	if primary.searchSeriesQueries[0] != "Dune" || primary.searchSeriesLimits[0] != 10 {
+		t.Fatalf("primary query/limit = %q/%d, want Dune/10", primary.searchSeriesQueries[0], primary.searchSeriesLimits[0])
+	}
+	if enricher.searchSeriesQueries[0] != "Dune" || enricher.searchSeriesLimits[0] != 10 {
+		t.Fatalf("enricher query/limit = %q/%d, want Dune/10", enricher.searchSeriesQueries[0], enricher.searchSeriesLimits[0])
+	}
+
+	enricher.searchSeriesResults = nil
+	got, err = agg.SearchSeries(context.Background(), "Dune", 10)
+	if err != nil {
+		t.Fatalf("SearchSeries cached: %v", err)
+	}
+	if len(got) != 1 || primary.searchSeriesCalls != 1 || enricher.searchSeriesCalls != 1 {
+		t.Fatalf("cached lookup got=%+v calls primary=%d enricher=%d, want cached result and no new calls", got, primary.searchSeriesCalls, enricher.searchSeriesCalls)
+	}
+}
+
+func TestAggregator_GetSeriesCatalog_EdgeCases(t *testing.T) {
+	agg := newTestAggregator(&mockProvider{name: "ol"})
+
+	got, err := agg.GetSeriesCatalog(context.Background(), "  ")
+	if err != nil {
+		t.Fatalf("GetSeriesCatalog empty id: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("empty id = %+v, want nil", got)
+	}
+
+	got, err = agg.GetSeriesCatalog(context.Background(), "hc-series:missing")
+	if err != nil {
+		t.Fatalf("GetSeriesCatalog without providers: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("without providers = %+v, want nil", got)
+	}
+}
+
+func TestAggregator_GetSeriesCatalog_FallbackAndCache(t *testing.T) {
+	catalog := &SeriesCatalog{ForeignID: "hc-series:1", ProviderID: "1", Title: "Dune"}
+	primary := &mockSeriesCatalogProvider{
+		mockProvider: mockProvider{name: "primary"},
+		catalogErr:   errors.New("primary unavailable"),
+	}
+	enricher := &mockSeriesCatalogProvider{
+		mockProvider: mockProvider{name: "enricher"},
+		catalogs:     map[string]*SeriesCatalog{catalog.ForeignID: catalog},
+	}
+	agg := &Aggregator{
+		primary:   primary,
+		enrichers: []Provider{enricher},
+		cache:     newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetSeriesCatalog(context.Background(), "  hc-series:1  ")
+	if err != nil {
+		t.Fatalf("GetSeriesCatalog: %v", err)
+	}
+	if got == nil || got.Title != "Dune" {
+		t.Fatalf("unexpected catalog: %+v", got)
+	}
+	if primary.catalogCalls != 1 || enricher.catalogCalls != 1 {
+		t.Fatalf("provider calls primary=%d enricher=%d, want 1/1", primary.catalogCalls, enricher.catalogCalls)
+	}
+	if primary.catalogIDs[0] != "hc-series:1" || enricher.catalogIDs[0] != "hc-series:1" {
+		t.Fatalf("catalog ids primary=%q enricher=%q, want trimmed id", primary.catalogIDs[0], enricher.catalogIDs[0])
+	}
+
+	enricher.catalogs = nil
+	got, err = agg.GetSeriesCatalog(context.Background(), "hc-series:1")
+	if err != nil {
+		t.Fatalf("GetSeriesCatalog cached: %v", err)
+	}
+	if got == nil || got.Title != "Dune" || primary.catalogCalls != 1 || enricher.catalogCalls != 1 {
+		t.Fatalf("cached catalog=%+v calls primary=%d enricher=%d, want cached result and no new calls", got, primary.catalogCalls, enricher.catalogCalls)
+	}
+}
+
+func TestAggregator_SeriesCatalogProviders_Order(t *testing.T) {
+	primary := &mockSeriesCatalogProvider{mockProvider: mockProvider{name: "primary"}}
+	plainEnricher := &mockProvider{name: "plain"}
+	seriesEnricher := &mockSeriesCatalogProvider{mockProvider: mockProvider{name: "series"}}
+	agg := &Aggregator{
+		primary:   primary,
+		enrichers: []Provider{plainEnricher, seriesEnricher},
+		cache:     newTTLCache(time.Minute),
+	}
+
+	providers := agg.seriesCatalogProviders()
+	if len(providers) != 2 {
+		t.Fatalf("providers len = %d, want 2", len(providers))
+	}
+	if providers[0] != primary || providers[1] != seriesEnricher {
+		t.Fatalf("provider order = %#v, want primary then series enricher", providers)
+	}
+	if providers := (*Aggregator)(nil).seriesCatalogProviders(); providers != nil {
+		t.Fatalf("nil aggregator providers = %+v, want nil", providers)
 	}
 }
 

--- a/internal/seriesmatch/match_test.go
+++ b/internal/seriesmatch/match_test.go
@@ -1,0 +1,86 @@
+package seriesmatch
+
+import "testing"
+
+func TestSamePosition(t *testing.T) {
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{name: "exact", a: "1", b: "1", want: true},
+		{name: "trimmed exact", a: " 1 ", b: "\t1\n", want: true},
+		{name: "numeric equivalent", a: "1.0", b: "1", want: true},
+		{name: "decimal tolerance", a: "1.0009", b: "1", want: true},
+		{name: "empty left", a: "", b: "1", want: false},
+		{name: "empty right", a: "1", b: "", want: false},
+		{name: "same non numeric", a: "prelude", b: "prelude", want: true},
+		{name: "different non numeric", a: "prelude", b: "1", want: false},
+		{name: "different numeric", a: "1", b: "2", want: false},
+		{name: "outside tolerance", a: "1.01", b: "1", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SamePosition(tt.a, tt.b); got != tt.want {
+				t.Fatalf("SamePosition(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeSeriesName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "trims and lowercases", input: "  The Stormlight Archive  ", want: "the stormlight archive"},
+		{name: "strips series suffix", input: "The Stormlight Archive Series", want: "the stormlight archive"},
+		{name: "strips trilogy suffix", input: "Red Rising Trilogy", want: "red rising"},
+		{name: "strips saga suffix", input: "The Expanse Saga", want: "the expanse"},
+		{name: "strips chronicles suffix", input: "Narnia Chronicles", want: "narnia"},
+		{name: "keeps single word suffix term", input: "Saga", want: "saga"},
+		{name: "keeps names without configured suffix", input: "Wayward Children", want: "wayward children"},
+		{name: "empty", input: "  ", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeSeriesName(tt.input); got != tt.want {
+				t.Fatalf("NormalizeSeriesName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanTitle(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "removes articles punctuation and novel noise", input: "The Way-of-Kings: A Novel!", want: "way of kings"},
+		{name: "removes book noise", input: "Book 1: Leviathan Wakes", want: "1 leviathan wakes"},
+		{name: "collapses whitespace", input: "  Words   of   Radiance  ", want: "words of radiance"},
+		{name: "empty", input: "  ", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CleanTitle(tt.input); got != tt.want {
+				t.Fatalf("CleanTitle(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTitleScore(t *testing.T) {
+	if got := TitleScore("", "Dune"); got != 0 {
+		t.Fatalf("empty title score = %d, want 0", got)
+	}
+	if got := TitleScore("The Way of Kings: A Novel", "Way of Kings"); got < 95 {
+		t.Fatalf("equivalent title score = %d, want at least 95", got)
+	}
+	if got := TitleScore("The Way of Kings", "Words of Radiance"); got >= 70 {
+		t.Fatalf("unrelated title score = %d, want below 70", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add follow-up tests for series API endpoint edge cases, repository hydration/linking behavior, metadata aggregator series catalog fallback/cache behavior, and series matching helpers.
- Add an `[Unreleased]` changelog entry for the test-only coverage work.
- These are coverage gaps noticed in the Codecov report for PR #459; no runtime behavior changes intended.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (not applicable: no env/config/upgrade changes)
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] Wiki pages updated if user-facing behaviour changed (not applicable: test-only changes)

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [ ] `cd web && npm run build` (not run: no frontend changes)
- [x] `git diff --check`