### PR TITLE
fix(series): require admin for series mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Bindery are documented here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com) and versions follow
 [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Fixed
+
+- **Manual series mutations require admin role** (#468) — Authenticated non-admin users can no longer create, update, monitor, delete, fill, or link series to Hardcover. Read-only series endpoints remain available to authenticated users.
 
 ## [v1.4.1] — 2026-05-06
 

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -651,20 +651,7 @@ func main() {
 		})
 
 		// Series
-		r.Get("/series", seriesHandler.List)
-		r.Post("/series", seriesHandler.Create)
-		r.Get("/series/hardcover/search", seriesHandler.SearchHardcover)
-		r.Get("/series/{id}", seriesHandler.Get)
-		r.Put("/series/{id}", seriesHandler.Update)
-		r.Patch("/series/{id}", seriesHandler.Monitor)
-		r.Delete("/series/{id}", seriesHandler.Delete)
-		r.Post("/series/{id}/books", seriesHandler.AddBook)
-		r.Post("/series/{id}/fill", seriesHandler.Fill)
-		r.Get("/series/{id}/hardcover-link", seriesHandler.GetHardcoverLink)
-		r.Post("/series/{id}/hardcover-link/auto", seriesHandler.AutoLinkHardcover)
-		r.Put("/series/{id}/hardcover-link", seriesHandler.PutHardcoverLink)
-		r.Delete("/series/{id}/hardcover-link", seriesHandler.DeleteHardcoverLink)
-		r.Get("/series/{id}/hardcover-diff", seriesHandler.HardcoverDiff)
+		registerSeriesRoutes(r, seriesHandler)
 
 		// Recommendations
 		r.Get("/recommendations", recHandler.List)

--- a/cmd/bindery/series_routes.go
+++ b/cmd/bindery/series_routes.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+)
+
+type seriesRouteHandler interface {
+	List(http.ResponseWriter, *http.Request)
+	Create(http.ResponseWriter, *http.Request)
+	SearchHardcover(http.ResponseWriter, *http.Request)
+	Get(http.ResponseWriter, *http.Request)
+	Update(http.ResponseWriter, *http.Request)
+	Monitor(http.ResponseWriter, *http.Request)
+	Delete(http.ResponseWriter, *http.Request)
+	AddBook(http.ResponseWriter, *http.Request)
+	Fill(http.ResponseWriter, *http.Request)
+	GetHardcoverLink(http.ResponseWriter, *http.Request)
+	AutoLinkHardcover(http.ResponseWriter, *http.Request)
+	PutHardcoverLink(http.ResponseWriter, *http.Request)
+	DeleteHardcoverLink(http.ResponseWriter, *http.Request)
+	HardcoverDiff(http.ResponseWriter, *http.Request)
+}
+
+func registerSeriesRoutes(r chi.Router, seriesHandler seriesRouteHandler) {
+	r.Get("/series", seriesHandler.List)
+	r.Get("/series/hardcover/search", seriesHandler.SearchHardcover)
+	r.Get("/series/{id}", seriesHandler.Get)
+	r.Get("/series/{id}/hardcover-link", seriesHandler.GetHardcoverLink)
+	r.Get("/series/{id}/hardcover-diff", seriesHandler.HardcoverDiff)
+
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAdmin)
+		r.Post("/series", seriesHandler.Create)
+		r.Put("/series/{id}", seriesHandler.Update)
+		r.Patch("/series/{id}", seriesHandler.Monitor)
+		r.Delete("/series/{id}", seriesHandler.Delete)
+		r.Post("/series/{id}/books", seriesHandler.AddBook)
+		r.Post("/series/{id}/fill", seriesHandler.Fill)
+		r.Post("/series/{id}/hardcover-link/auto", seriesHandler.AutoLinkHardcover)
+		r.Put("/series/{id}/hardcover-link", seriesHandler.PutHardcoverLink)
+		r.Delete("/series/{id}/hardcover-link", seriesHandler.DeleteHardcoverLink)
+	})
+}

--- a/cmd/bindery/series_routes_test.go
+++ b/cmd/bindery/series_routes_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+)
+
+type stubSeriesRouteHandler struct {
+	called []string
+}
+
+func (h *stubSeriesRouteHandler) record(name string, w http.ResponseWriter) {
+	h.called = append(h.called, name)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *stubSeriesRouteHandler) List(w http.ResponseWriter, _ *http.Request) {
+	h.record("list", w)
+}
+
+func (h *stubSeriesRouteHandler) Create(w http.ResponseWriter, _ *http.Request) {
+	h.record("create", w)
+}
+
+func (h *stubSeriesRouteHandler) SearchHardcover(w http.ResponseWriter, _ *http.Request) {
+	h.record("search-hardcover", w)
+}
+
+func (h *stubSeriesRouteHandler) Get(w http.ResponseWriter, _ *http.Request) {
+	h.record("get", w)
+}
+
+func (h *stubSeriesRouteHandler) Update(w http.ResponseWriter, _ *http.Request) {
+	h.record("update", w)
+}
+
+func (h *stubSeriesRouteHandler) Monitor(w http.ResponseWriter, _ *http.Request) {
+	h.record("monitor", w)
+}
+
+func (h *stubSeriesRouteHandler) Delete(w http.ResponseWriter, _ *http.Request) {
+	h.record("delete", w)
+}
+
+func (h *stubSeriesRouteHandler) AddBook(w http.ResponseWriter, _ *http.Request) {
+	h.record("add-book", w)
+}
+
+func (h *stubSeriesRouteHandler) Fill(w http.ResponseWriter, _ *http.Request) {
+	h.record("fill", w)
+}
+
+func (h *stubSeriesRouteHandler) GetHardcoverLink(w http.ResponseWriter, _ *http.Request) {
+	h.record("get-hardcover-link", w)
+}
+
+func (h *stubSeriesRouteHandler) AutoLinkHardcover(w http.ResponseWriter, _ *http.Request) {
+	h.record("auto-link-hardcover", w)
+}
+
+func (h *stubSeriesRouteHandler) PutHardcoverLink(w http.ResponseWriter, _ *http.Request) {
+	h.record("put-hardcover-link", w)
+}
+
+func (h *stubSeriesRouteHandler) DeleteHardcoverLink(w http.ResponseWriter, _ *http.Request) {
+	h.record("delete-hardcover-link", w)
+}
+
+func (h *stubSeriesRouteHandler) HardcoverDiff(w http.ResponseWriter, _ *http.Request) {
+	h.record("hardcover-diff", w)
+}
+
+func TestSeriesMutationRoutesRequireAdmin(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "create series", method: http.MethodPost, path: "/series"},
+		{name: "update series", method: http.MethodPut, path: "/series/1"},
+		{name: "monitor series", method: http.MethodPatch, path: "/series/1"},
+		{name: "delete series", method: http.MethodDelete, path: "/series/1"},
+		{name: "add book", method: http.MethodPost, path: "/series/1/books"},
+		{name: "fill series", method: http.MethodPost, path: "/series/1/fill"},
+		{name: "auto link hardcover", method: http.MethodPost, path: "/series/1/hardcover-link/auto"},
+		{name: "put hardcover link", method: http.MethodPut, path: "/series/1/hardcover-link"},
+		{name: "delete hardcover link", method: http.MethodDelete, path: "/series/1/hardcover-link"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &stubSeriesRouteHandler{}
+			router := chi.NewRouter()
+			registerSeriesRoutes(router, handler)
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req = req.WithContext(auth.WithUserRole(req.Context(), "user"))
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d; want %d", rec.Code, http.StatusForbidden)
+			}
+			if len(handler.called) != 0 {
+				t.Fatalf("handler called for non-admin request: %v", handler.called)
+			}
+		})
+	}
+}
+
+func TestSeriesMutationRoutesAllowAdmin(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		called string
+	}{
+		{name: "create series", method: http.MethodPost, path: "/series", called: "create"},
+		{name: "update series", method: http.MethodPut, path: "/series/1", called: "update"},
+		{name: "monitor series", method: http.MethodPatch, path: "/series/1", called: "monitor"},
+		{name: "delete series", method: http.MethodDelete, path: "/series/1", called: "delete"},
+		{name: "add book", method: http.MethodPost, path: "/series/1/books", called: "add-book"},
+		{name: "fill series", method: http.MethodPost, path: "/series/1/fill", called: "fill"},
+		{name: "auto link hardcover", method: http.MethodPost, path: "/series/1/hardcover-link/auto", called: "auto-link-hardcover"},
+		{name: "put hardcover link", method: http.MethodPut, path: "/series/1/hardcover-link", called: "put-hardcover-link"},
+		{name: "delete hardcover link", method: http.MethodDelete, path: "/series/1/hardcover-link", called: "delete-hardcover-link"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &stubSeriesRouteHandler{}
+			router := chi.NewRouter()
+			registerSeriesRoutes(router, handler)
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req = req.WithContext(auth.WithUserRole(req.Context(), "admin"))
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d; want %d", rec.Code, http.StatusNoContent)
+			}
+			if len(handler.called) != 1 || handler.called[0] != tt.called {
+				t.Fatalf("called = %v; want [%s]", handler.called, tt.called)
+			}
+		})
+	}
+}
+
+func TestSeriesReadRoutesAllowNonAdmin(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		called string
+	}{
+		{name: "list series", path: "/series", called: "list"},
+		{name: "search hardcover", path: "/series/hardcover/search", called: "search-hardcover"},
+		{name: "get series", path: "/series/1", called: "get"},
+		{name: "get hardcover link", path: "/series/1/hardcover-link", called: "get-hardcover-link"},
+		{name: "hardcover diff", path: "/series/1/hardcover-diff", called: "hardcover-diff"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &stubSeriesRouteHandler{}
+			router := chi.NewRouter()
+			registerSeriesRoutes(router, handler)
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req = req.WithContext(auth.WithUserRole(req.Context(), "user"))
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d; want %d", rec.Code, http.StatusNoContent)
+			}
+			if len(handler.called) != 1 || handler.called[0] != tt.called {
+				t.Fatalf("called = %v; want [%s]", handler.called, tt.called)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Closes #468.
- Moves manual series mutation routes behind `auth.RequireAdmin` while keeping read-only series endpoints available to authenticated users.
- Adds route-registration tests covering non-admin rejection, admin access, and non-admin read access.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (N/A - no env vars, config, deployment, or upgrade path changed)
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] Wiki pages updated if user-facing behaviour changed (N/A - no wiki files in checkout; behavior is covered by the changelog)

## Test plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go test ./cmd/bindery ./internal/auth ./internal/api`
- [x] `go test ./cmd/... ./internal/...`
- [x] `/Users/ryanjones/go/bin/golangci-lint run ./cmd/bindery ./internal/auth ./internal/api --timeout=5m`
- [x] `env CGO_ENABLED=0 /go/bin/govulncheck ./...`
- [x] `cd web && npm ci`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run typecheck`
- [x] `cd web && npm run build`
- [x] `cd web && npm test`

Notes:

- Full `/go/bin/golangci-lint run ./... --timeout=5m` currently fails on the rebased `upstream/main` telemetry server code in `cmd/telemetry-server/main.go` with existing `gosec`, `noctx`, and `rowserrcheck` findings unrelated to this branch.
