### PR TITLE
feat(discover): replace horizontal scroll with responsive grid layout

### DIFF
--- a/web/src/components/RecommendationCard.tsx
+++ b/web/src/components/RecommendationCard.tsx
@@ -29,12 +29,12 @@ export default function RecommendationCard({ rec, onDismiss, onAdd, onExcludeAut
     ? `/api/v1/images?url=${encodeURIComponent(rec.imageUrl)}`
     : ''
 
-  const stars = Math.round(rec.rating * 2) / 2 // round to nearest 0.5
+  const stars = Math.round(rec.rating * 2) / 2
 
   return (
-    <div className="flex-shrink-0 w-56 bg-slate-100 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded-lg overflow-hidden">
-      {/* Cover image */}
-      <div className="h-36 bg-slate-200 dark:bg-zinc-800 flex items-center justify-center">
+    <div className="bg-slate-100 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded-lg overflow-hidden flex flex-col">
+      {/* Cover — portrait aspect ratio matching the book grid */}
+      <div className="aspect-[2/3] bg-slate-200 dark:bg-zinc-800 relative flex items-center justify-center flex-shrink-0">
         {imageUrl ? (
           <img src={imageUrl} alt={rec.title} className="w-full h-full object-cover" />
         ) : (
@@ -42,50 +42,54 @@ export default function RecommendationCard({ rec, onDismiss, onAdd, onExcludeAut
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
           </svg>
         )}
+        {/* Reason badge overlaid on the image */}
+        <span className="absolute bottom-0 left-0 right-0 px-2 py-1 bg-gradient-to-t from-black/70 to-transparent text-[10px] text-white italic line-clamp-2 leading-tight">
+          {rec.reason}
+        </span>
       </div>
 
-      <div className="p-3">
+      <div className="p-3 flex flex-col flex-1">
         {/* Title and author */}
-        <h4 className="font-medium text-sm truncate" title={rec.title}>{rec.title}</h4>
-        <p className="text-xs text-slate-500 dark:text-zinc-500 truncate">{rec.authorName}</p>
+        <h4 className="font-medium text-sm leading-snug line-clamp-2" title={rec.title}>{rec.title}</h4>
+        <p className="text-xs text-slate-500 dark:text-zinc-500 truncate mt-0.5">{rec.authorName}</p>
 
         {/* Star rating */}
-        <div className="flex items-center gap-1 mt-1">
-          <div className="flex">
-            {[1, 2, 3, 4, 5].map(i => (
-              <svg
-                key={i}
-                className={`w-3 h-3 ${i <= stars ? 'text-amber-400' : i - 0.5 <= stars ? 'text-amber-400' : 'text-slate-300 dark:text-zinc-700'}`}
-                fill="currentColor"
-                viewBox="0 0 20 20"
-              >
-                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-              </svg>
-            ))}
+        {rec.rating > 0 && (
+          <div className="flex items-center gap-1 mt-1.5">
+            <div className="flex">
+              {[1, 2, 3, 4, 5].map(i => (
+                <svg
+                  key={i}
+                  className={`w-3 h-3 ${i <= stars ? 'text-amber-400' : 'text-slate-300 dark:text-zinc-700'}`}
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                </svg>
+              ))}
+            </div>
+            {rec.ratingsCount > 0 && (
+              <span className="text-[10px] text-slate-400 dark:text-zinc-600">({rec.ratingsCount})</span>
+            )}
           </div>
-          {rec.ratingsCount > 0 && (
-            <span className="text-[10px] text-slate-400 dark:text-zinc-600">({rec.ratingsCount})</span>
-          )}
-        </div>
+        )}
 
         {/* Genre tags */}
         {rec.genres.length > 0 && (
           <div className="flex flex-wrap gap-1 mt-1.5">
-            {rec.genres.slice(0, 3).map(genre => (
-              <span key={genre} className="px-1.5 py-0.5 bg-slate-200 dark:bg-zinc-800 rounded text-[10px] text-slate-600 dark:text-zinc-400 truncate max-w-[80px]">
+            {rec.genres.slice(0, 2).map(genre => (
+              <span key={genre} className="px-1.5 py-0.5 bg-slate-200 dark:bg-zinc-800 rounded text-[10px] text-slate-600 dark:text-zinc-400 truncate max-w-[90px]">
                 {genre}
               </span>
             ))}
           </div>
         )}
 
-        {/* Reason */}
-        <p className="text-[11px] text-emerald-600 dark:text-emerald-400 mt-2 line-clamp-2 italic">
-          {rec.reason}
-        </p>
+        {/* Spacer pushes actions to bottom */}
+        <div className="flex-1" />
 
         {/* Actions */}
-        <div className="flex items-center gap-1.5 mt-2.5">
+        <div className="flex items-center gap-1.5 mt-3">
           <button
             onClick={() => onAdd(rec.id)}
             className="flex-1 px-2 py-1.5 bg-emerald-600 hover:bg-emerald-500 text-white rounded text-xs font-medium transition-colors"
@@ -95,8 +99,9 @@ export default function RecommendationCard({ rec, onDismiss, onAdd, onExcludeAut
           <button
             onClick={() => onDismiss(rec.id)}
             className="px-2 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs text-slate-600 dark:text-zinc-400 transition-colors"
+            title={t('discover.dismiss')}
           >
-            {t('discover.dismiss')}
+            ✕
           </button>
           <div className="relative" ref={menuRef}>
             <button

--- a/web/src/components/RecommendationRow.tsx
+++ b/web/src/components/RecommendationRow.tsx
@@ -13,11 +13,9 @@ export default function RecommendationRow({ title, recommendations, onDismiss, o
   if (recommendations.length === 0) return null
 
   return (
-    <div className="mb-6">
-      <div className="flex items-center justify-between mb-3">
-        <h3 className="text-lg font-semibold">{title}</h3>
-      </div>
-      <div className="flex gap-3 overflow-x-auto pb-2 scrollbar-thin">
+    <div className="mb-8">
+      <h3 className="text-base font-semibold mb-3 text-slate-700 dark:text-zinc-300">{title}</h3>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
         {recommendations.map(rec => (
           <RecommendationCard
             key={rec.id}


### PR DESCRIPTION
## Summary

- **RecommendationRow**: replaces the `overflow-x-auto` horizontal flex container with a `grid grid-cols-2 sm:3 md:4 lg:5 xl:6` grid, matching the BooksPage grid pattern
- **RecommendationCard**: portrait orientation with `aspect-[2/3]` cover image instead of fixed `h-36` landscape thumbnail; reason text overlaid as a gradient badge on the image; star rating hidden when `rating === 0`; dismiss shrunk to a ✕ icon

## Before / After

**Before:** each recommendation section was a horizontally-scrollable strip of 224px-wide landscape cards — out of place next to every other page.

**After:** each section renders a responsive grid of portrait book cards, consistent with the Books and Wanted pages.

Section headers (Series, New from authors, Genre popular, …) are kept so the grouping context is still visible.

## Test plan

- [ ] Open Discover with recommendations present — cards appear in a grid, not a horizontal scroll
- [ ] Resize window — grid reflows through 2→3→4→5→6 columns
- [ ] Dismiss (✕) and "Add to Wanted" buttons still work
- [ ] "Don't suggest author" menu still works
- [ ] Empty sections still hidden (unchanged logic)
- [ ] Empty-state and disabled-state screens still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)