### PR TITLE
test(web): expand frontend component coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 - **Canonical author name search now scoped to current user** — The name-deduplication path during author creation previously searched the global author pool, which could conflict with authors belonging to other users in multi-user setups.
 
+### Chores
+
+- **Frontend regression coverage expanded** (#427) — Added MSW-backed tests for login, CSRF handling, auth state/guards, Book Detail search/grab flows, and Wanted page search/grab/bulk actions.
+
 ## [v1.9.0] — 2026-05-11
 
 ### Added
@@ -339,12 +343,6 @@ All notable changes to Bindery are documented here. Format loosely follows
 - **Series title inputs now have an API length limit** (#469) — Manual series creation and title updates now reject titles longer than 500 bytes before writing to SQLite, preventing oversized titles from being stored through the HTTP API.
 - **Hardcover GraphQL success responses are bounded** (#470) — Successful Hardcover responses are now read through an 8 MiB cap so a misbehaving upstream cannot force unbounded memory growth before JSON parsing.
 - **Add-author search no longer hides valid author results when the query matches a book title** — Results whose name exactly matches a known book title and whose disambiguation points to that book's real author are now placed behind a reveal button rather than silently dropped.
-
-## [Unreleased]
-
-### Chores
-
-- **Frontend regression coverage expanded** (#427) — Added MSW-backed tests for login, CSRF handling, auth state/guards, Book Detail search/grab flows, and Wanted page search/grab/bulk actions.
 
 ## [v1.4.3] — 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,12 @@ All notable changes to Bindery are documented here. Format loosely follows
 - **Hardcover GraphQL success responses are bounded** (#470) — Successful Hardcover responses are now read through an 8 MiB cap so a misbehaving upstream cannot force unbounded memory growth before JSON parsing.
 - **Add-author search no longer hides valid author results when the query matches a book title** — Results whose name exactly matches a known book title and whose disambiguation points to that book's real author are now placed behind a reveal button rather than silently dropped.
 
+## [Unreleased]
+
+### Chores
+
+- **Frontend regression coverage expanded** (#427) — Added MSW-backed tests for login, CSRF handling, auth state/guards, Book Detail search/grab flows, and Wanted page search/grab/bulk actions.
+
 ## [v1.4.3] — 2026-05-06
 
 ### Fixed

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
         "jsdom": "^29.1.0",
+        "msw": "^2.14.3",
         "postcss": "^8.5.14",
         "tailwindcss": "^4.2.4",
         "typescript": "~6.0.3",
@@ -718,6 +719,93 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
+      "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
+      "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -763,6 +851,31 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.8",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.8.tgz",
+      "integrity": "sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -781,6 +894,31 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.129.0",
@@ -1541,6 +1679,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -1558,6 +1706,23 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.2",
@@ -1991,6 +2156,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -2155,6 +2336,51 @@
         "node": ">=18"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2288,6 +2514,13 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
       "integrity": "sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==",
       "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.2",
@@ -2562,6 +2795,33 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2663,6 +2923,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2694,6 +2964,34 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/headers-polyfill/node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
@@ -2808,6 +3106,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2819,6 +3127,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -3318,6 +3633,61 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/msw": {
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.3.tgz",
+      "integrity": "sha512-kk8G5cocVlJ4wsKMGZegn2H6XLOEKjbA+nSJE2354e/SRp4mDicCHUYnMXpymzVcVDCs+GUAsmNqSn+yHv4T2A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3375,6 +3745,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -3436,6 +3813,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -3637,6 +4021,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3646,6 +4040,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0",
@@ -3747,6 +4148,19 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3762,12 +4176,57 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -3786,6 +4245,19 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.3.0",
@@ -3941,6 +4413,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -3987,6 +4475,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4326,6 +4831,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -4341,11 +4864,50 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
     "jsdom": "^29.1.0",
+    "msw": "^2.14.3",
     "postcss": "^8.5.14",
     "tailwindcss": "^4.2.4",
     "typescript": "~6.0.3",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -2,6 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import App from './App'
 
+const { authState, logoutMock } = vi.hoisted(() => ({
+  authState: {
+    value: {
+      status: { authenticated: false, mode: 'disabled', setupRequired: false },
+      logout: vi.fn(),
+      isAdmin: false,
+    },
+  },
+  logoutMock: vi.fn(),
+}))
+
 // Mock all heavy page components so we only exercise Shell layout.
 vi.mock('./pages/AuthorsPage', () => ({ default: () => <div data-testid="page-authors" /> }))
 vi.mock('./pages/BooksPage', () => ({ default: () => <div data-testid="page-books" /> }))
@@ -20,7 +31,7 @@ vi.mock('./pages/BookDetailPage', () => ({ default: () => <div /> }))
 vi.mock('./auth/AuthGuard', () => ({ default: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
 vi.mock('./auth/AuthContext', () => ({
   AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  useAuth: () => ({ status: { authenticated: false, mode: 'disabled', setupRequired: false }, logout: vi.fn() }),
+  useAuth: () => authState.value,
 }))
 
 vi.mock('./api/client', () => ({
@@ -50,9 +61,35 @@ function renderShell() {
   return render(<App />)
 }
 
-describe('Shell — desktop navigation', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+beforeEach(() => {
+  vi.clearAllMocks()
+  logoutMock.mockReset()
+  authState.value = {
+    status: { authenticated: false, mode: 'disabled', setupRequired: false },
+    logout: logoutMock,
+    isAdmin: false,
+  }
+  window.history.pushState(null, '', '/')
+})
 
+describe('App auth routes', () => {
+  it('redirects authenticated users away from the login route', () => {
+    authState.value = {
+      status: { authenticated: true, setupRequired: false, mode: 'enabled' },
+      logout: logoutMock,
+      isAdmin: true,
+    }
+    window.history.pushState(null, '', '/login')
+
+    renderShell()
+
+    expect(screen.queryByTestId('page-login')).not.toBeInTheDocument()
+    expect(screen.getByTestId('page-authors')).toBeInTheDocument()
+    expect(window.location.pathname).toBe('/')
+  })
+})
+
+describe('Shell — desktop navigation', () => {
   it('renders all 8 nav links in the desktop nav bar', () => {
     renderShell()
     const desktopNav = document.querySelector('nav.hidden.lg\\:flex')
@@ -83,8 +120,6 @@ describe('Shell — desktop navigation', () => {
 })
 
 describe('Shell — mobile navigation', () => {
-  beforeEach(() => { vi.clearAllMocks() })
-
   it('renders a hamburger toggle button for mobile', () => {
     renderShell()
     expect(screen.getByRole('button', { name: /toggle menu/i })).toBeInTheDocument()

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -23,7 +23,17 @@ vi.mock('./pages/SeriesPage', () => ({ default: () => <div data-testid="page-ser
 vi.mock('./pages/CalendarPage', () => ({ default: () => <div data-testid="page-calendar" /> }))
 vi.mock('./pages/DiscoverPage', () => ({ default: () => <div data-testid="page-discover" /> }))
 vi.mock('./pages/SettingsPage', () => ({ default: () => <div data-testid="page-settings" /> }))
-vi.mock('./pages/LoginPage', () => ({ default: () => <div data-testid="page-login" /> }))
+vi.mock('./pages/LoginPage', async () => {
+  const { Navigate } = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    default: () => {
+      const status = authState.value.status
+      if (status?.setupRequired) return <Navigate to="/setup" replace />
+      if (status?.authenticated) return <Navigate to="/" replace />
+      return <div data-testid="page-login" />
+    },
+  }
+})
 vi.mock('./pages/SetupPage', () => ({ default: () => <div data-testid="page-setup" /> }))
 vi.mock('./pages/AuthorDetailPage', () => ({ default: () => <div /> }))
 vi.mock('./pages/BookDetailPage', () => ({ default: () => <div /> }))

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { apiUrl, server } from '../test/msw'
+
+async function loadClient() {
+  vi.resetModules()
+  return import('./client')
+}
+
+function clearCSRFCookie() {
+  document.cookie = 'bindery_csrf=; Max-Age=0; path=/'
+}
+
+describe('api/client CSRF handling', () => {
+  beforeEach(() => {
+    clearCSRFCookie()
+    window.history.pushState(null, '', '/')
+  })
+
+  it('fetches and stores the JSON CSRF token for mutating requests', async () => {
+    const csrfRequests: Array<{ credentials: RequestCredentials; requestedWith: string | null }> = []
+    let logoutCSRF: string | null = null
+
+    server.use(
+      http.get(apiUrl('/auth/csrf'), ({ request }) => {
+        csrfRequests.push({
+          credentials: request.credentials,
+          requestedWith: request.headers.get('x-requested-with'),
+        })
+        return HttpResponse.json({ csrfToken: 'json-token' })
+      }),
+      http.post(apiUrl('/auth/logout'), ({ request }) => {
+        logoutCSRF = request.headers.get('x-csrf-token')
+        return HttpResponse.json({ ok: true })
+      }),
+    )
+
+    const { api, initCSRF } = await loadClient()
+
+    await initCSRF()
+    await api.authLogout()
+
+    expect(csrfRequests).toEqual([{ credentials: 'include', requestedWith: 'bindery-ui' }])
+    expect(logoutCSRF).toBe('json-token')
+  })
+
+  it('does not send a CSRF token on safe requests', async () => {
+    let authStatusCSRF: string | null = null
+
+    server.use(
+      http.get(apiUrl('/auth/csrf'), () => HttpResponse.json({ csrfToken: 'safe-token' })),
+      http.get(apiUrl('/auth/status'), ({ request }) => {
+        authStatusCSRF = request.headers.get('x-csrf-token')
+        return HttpResponse.json({
+          authenticated: true,
+          setupRequired: false,
+          username: 'admin',
+          role: 'admin',
+          mode: 'enabled',
+        })
+      }),
+    )
+
+    const { api, initCSRF } = await loadClient()
+
+    await initCSRF()
+    await api.authStatus()
+
+    expect(authStatusCSRF).toBeNull()
+  })
+
+  it('refreshes CSRF after login for the next mutation', async () => {
+    let loginBody: unknown
+    let logoutCSRF: string | null = null
+
+    server.use(
+      http.post(apiUrl('/auth/login'), async ({ request }) => {
+        loginBody = await request.json()
+        return HttpResponse.json({ ok: true, username: 'alice' })
+      }),
+      http.get(apiUrl('/auth/csrf'), () => HttpResponse.json({ csrfToken: 'post-login-token' })),
+      http.post(apiUrl('/auth/logout'), ({ request }) => {
+        logoutCSRF = request.headers.get('x-csrf-token')
+        return HttpResponse.json({ ok: true })
+      }),
+    )
+
+    const { api } = await loadClient()
+
+    await api.authLogin('alice', 'secret', true)
+    await api.authLogout()
+
+    expect(loginBody).toEqual({ username: 'alice', password: 'secret', rememberMe: true })
+    expect(logoutCSRF).toBe('post-login-token')
+  })
+
+  it('falls back to the CSRF cookie when the endpoint omits a token', async () => {
+    let logoutCSRF: string | null = null
+    document.cookie = 'bindery_csrf=cookie-token; path=/'
+
+    server.use(
+      http.get(apiUrl('/auth/csrf'), () => HttpResponse.json({})),
+      http.post(apiUrl('/auth/logout'), ({ request }) => {
+        logoutCSRF = request.headers.get('x-csrf-token')
+        return HttpResponse.json({ ok: true })
+      }),
+    )
+
+    const { api, initCSRF } = await loadClient()
+
+    await initCSRF()
+    await api.authLogout()
+
+    expect(logoutCSRF).toBe('cookie-token')
+  })
+})

--- a/web/src/auth/AuthContext.test.tsx
+++ b/web/src/auth/AuthContext.test.tsx
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { AuthProvider, useAuth } from './AuthContext'
+import { apiUrl, server } from '../test/msw'
+import { makeAuthStatus } from '../test-utils'
+
+function AuthProbe() {
+  const { status, loading, isAdmin, refresh, logout } = useAuth()
+
+  return (
+    <div>
+      <div data-testid="loading">{String(loading)}</div>
+      <div data-testid="status">
+        {status ? `${status.authenticated ? 'authenticated' : 'anonymous'}:${status.mode}:${status.role ?? ''}` : 'none'}
+      </div>
+      <div data-testid="admin">{String(isAdmin)}</div>
+      <button type="button" onClick={() => { void refresh() }}>Refresh</button>
+      <button type="button" onClick={() => { void logout() }}>Logout</button>
+    </div>
+  )
+}
+
+function renderAuthProvider() {
+  return render(
+    <AuthProvider>
+      <AuthProbe />
+    </AuthProvider>,
+  )
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.history.pushState(null, '', '/')
+  })
+
+  it('loads auth status on mount', async () => {
+    let statusHits = 0
+    server.use(
+      http.get(apiUrl('/auth/status'), () => {
+        statusHits += 1
+        return HttpResponse.json(makeAuthStatus())
+      }),
+    )
+
+    renderAuthProvider()
+
+    expect(screen.getByTestId('loading')).toHaveTextContent('true')
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'))
+    expect(screen.getByTestId('status')).toHaveTextContent('anonymous:enabled:')
+    expect(statusHits).toBe(1)
+  })
+
+  it('hydrates CSRF when the loaded status is authenticated', async () => {
+    let csrfHits = 0
+    server.use(
+      http.get(apiUrl('/auth/status'), () => HttpResponse.json(makeAuthStatus({
+        authenticated: true,
+        username: 'admin',
+        role: 'admin',
+      }))),
+      http.get(apiUrl('/auth/csrf'), () => {
+        csrfHits += 1
+        return HttpResponse.json({ csrfToken: 'auth-token' })
+      }),
+    )
+
+    renderAuthProvider()
+
+    await screen.findByText('authenticated:enabled:admin')
+    expect(screen.getByTestId('admin')).toHaveTextContent('true')
+    expect(csrfHits).toBe(1)
+  })
+
+  it('does not hydrate CSRF for an unauthenticated status', async () => {
+    let csrfHits = 0
+    server.use(
+      http.get(apiUrl('/auth/status'), () => HttpResponse.json(makeAuthStatus())),
+      http.get(apiUrl('/auth/csrf'), () => {
+        csrfHits += 1
+        return HttpResponse.json({ csrfToken: 'unused' })
+      }),
+    )
+
+    renderAuthProvider()
+
+    await screen.findByText('anonymous:enabled:')
+    expect(csrfHits).toBe(0)
+  })
+
+  it('clears status and ends loading when status loading fails', async () => {
+    server.use(
+      http.get(apiUrl('/auth/status'), () => HttpResponse.json({ error: 'offline' }, { status: 503 })),
+    )
+
+    renderAuthProvider()
+
+    await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'))
+    expect(screen.getByTestId('status')).toHaveTextContent('none')
+  })
+
+  it('refreshes auth status when the document becomes visible', async () => {
+    let statusHits = 0
+    server.use(
+      http.get(apiUrl('/auth/status'), () => {
+        statusHits += 1
+        return HttpResponse.json(makeAuthStatus())
+      }),
+    )
+
+    renderAuthProvider()
+
+    await waitFor(() => expect(statusHits).toBe(1))
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    await waitFor(() => expect(statusHits).toBe(2))
+  })
+
+  it('logs out through the API and refreshes local status', async () => {
+    let statusHits = 0
+    let logoutHits = 0
+    server.use(
+      http.get(apiUrl('/auth/status'), () => {
+        statusHits += 1
+        return HttpResponse.json(
+          statusHits === 1
+            ? makeAuthStatus({ authenticated: true, username: 'admin', role: 'admin' })
+            : makeAuthStatus(),
+        )
+      }),
+      http.get(apiUrl('/auth/csrf'), () => HttpResponse.json({ csrfToken: 'logout-token' })),
+      http.post(apiUrl('/auth/logout'), () => {
+        logoutHits += 1
+        return HttpResponse.json({ ok: true })
+      }),
+    )
+    renderAuthProvider()
+
+    await screen.findByText('authenticated:enabled:admin')
+    window.history.pushState(null, '', '/login')
+    fireEvent.click(screen.getByRole('button', { name: 'Logout' }))
+
+    await waitFor(() => expect(logoutHits).toBe(1))
+    await waitFor(() => expect(statusHits).toBe(2))
+    expect(screen.getByTestId('status')).toHaveTextContent('anonymous:enabled:')
+  })
+})

--- a/web/src/auth/AuthGuard.test.tsx
+++ b/web/src/auth/AuthGuard.test.tsx
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Route, Routes } from 'react-router-dom'
+import { screen } from '@testing-library/react'
+import AuthGuard from './AuthGuard'
+import { makeAuthStatus, renderWithRouter } from '../test-utils'
+
+const { authState } = vi.hoisted(() => ({
+  authState: {
+    value: {
+      status: null as unknown,
+      loading: false,
+    },
+  },
+}))
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => authState.value,
+}))
+
+function renderGuard(initialEntries = ['/']) {
+  return renderWithRouter(
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <AuthGuard>
+            <div>Protected content</div>
+          </AuthGuard>
+        }
+      />
+      <Route path="/setup" element={<div>Setup page</div>} />
+      <Route path="/login" element={<div>Login page</div>} />
+    </Routes>,
+    { initialEntries },
+  )
+}
+
+describe('AuthGuard', () => {
+  beforeEach(() => {
+    authState.value = {
+      status: null,
+      loading: false,
+    }
+  })
+
+  it('renders a loading placeholder while auth status is loading', () => {
+    authState.value = {
+      status: null,
+      loading: true,
+    }
+
+    renderGuard()
+
+    expect(screen.getByText(/loading/i)).toBeInTheDocument()
+  })
+
+  it('redirects to setup when setup is required', () => {
+    authState.value = {
+      status: makeAuthStatus({ setupRequired: true }),
+      loading: false,
+    }
+
+    renderGuard()
+
+    expect(screen.getByText('Setup page')).toBeInTheDocument()
+  })
+
+  it('redirects to login when the user is not authenticated', () => {
+    authState.value = {
+      status: makeAuthStatus({ authenticated: false, setupRequired: false }),
+      loading: false,
+    }
+
+    renderGuard()
+
+    expect(screen.getByText('Login page')).toBeInTheDocument()
+  })
+
+  it('renders children when the user is authenticated', () => {
+    authState.value = {
+      status: makeAuthStatus({ authenticated: true, username: 'admin', role: 'admin' }),
+      loading: false,
+    }
+
+    renderGuard()
+
+    expect(screen.getByText('Protected content')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/RecommendationCard.test.tsx
+++ b/web/src/components/RecommendationCard.test.tsx
@@ -49,7 +49,7 @@ describe('RecommendationCard — rendering', () => {
     render(<RecommendationCard rec={baseRec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
     expect(screen.queryByRole('img')).toBeNull()
     // SVG placeholder should be in the cover area
-    const coverArea = document.querySelector('.h-36 svg')
+    const coverArea = document.querySelector('.aspect-\\[2\\/3\\] svg')
     expect(coverArea).not.toBeNull()
   })
 
@@ -61,12 +61,12 @@ describe('RecommendationCard — rendering', () => {
     expect(img.getAttribute('src')).toContain(encodeURIComponent('https://example.com/cover.jpg'))
   })
 
-  it('shows up to 3 genre tags', () => {
+  it('shows up to 2 genre tags', () => {
     const rec = { ...baseRec, genres: ['Fantasy', 'Adventure', 'Magic', 'Epic', 'Quest'] }
     render(<RecommendationCard rec={rec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
     expect(screen.getByText('Fantasy')).toBeInTheDocument()
     expect(screen.getByText('Adventure')).toBeInTheDocument()
-    expect(screen.getByText('Magic')).toBeInTheDocument()
+    expect(screen.queryByText('Magic')).toBeNull()
     expect(screen.queryByText('Epic')).toBeNull()
     expect(screen.queryByText('Quest')).toBeNull()
   })
@@ -149,16 +149,18 @@ describe('RecommendationCard — actions', () => {
 })
 
 describe('RecommendationCard — responsive layout', () => {
-  it('has a fixed width class for horizontal scroll within rows', () => {
+  it('uses a fluid card for the recommendation grid', () => {
     const { container } = render(<RecommendationCard rec={baseRec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
     const card = container.firstChild as HTMLElement
-    expect(card.className).toContain('flex-shrink-0')
-    expect(card.className).toContain('w-56')
+    expect(card.className).toContain('flex')
+    expect(card.className).toContain('flex-col')
+    expect(card.className).not.toContain('flex-shrink-0')
+    expect(card.className).not.toContain('w-56')
   })
 
-  it('cover image area has a fixed height suitable for both mobile and desktop', () => {
+  it('cover image area keeps a portrait aspect ratio', () => {
     const { container } = render(<RecommendationCard rec={baseRec} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />)
-    const coverArea = container.querySelector('.h-36')
+    const coverArea = container.querySelector('.aspect-\\[2\\/3\\]')
     expect(coverArea).not.toBeNull()
   })
 })

--- a/web/src/components/RecommendationCard.tsx
+++ b/web/src/components/RecommendationCard.tsx
@@ -99,6 +99,7 @@ export default function RecommendationCard({ rec, onDismiss, onAdd, onExcludeAut
           <button
             onClick={() => onDismiss(rec.id)}
             className="px-2 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs text-slate-600 dark:text-zinc-400 transition-colors"
+            aria-label={t('discover.dismiss')}
             title={t('discover.dismiss')}
           >
             ✕

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -1,13 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import BookDetailPage, { SearchResultsSection } from './BookDetailPage'
 import { api } from '../api/client'
-import type { Book, SearchResult } from '../api/client'
-
-vi.mock('../components/MediaBadge', () => ({
-  default: ({ type }: { type?: string }) => <span data-testid={`badge-${type}`}>{type}</span>,
-}))
+import type { Author, Book, Download, HistoryEvent, Indexer, SearchResult } from '../api/client'
 
 vi.mock('../api/client', async importOriginal => {
   const actual = await importOriginal<typeof import('../api/client')>()
@@ -17,41 +13,17 @@ vi.mock('../api/client', async importOriginal => {
       ...actual.api,
       getBook: vi.fn(),
       listHistory: vi.fn(),
+      searchBook: vi.fn(),
+      listIndexers: vi.fn(),
+      grab: vi.fn(),
       updateBook: vi.fn(),
     },
   }
 })
 
-function makeBook(overrides: Partial<Book> = {}): Book {
-  return {
-    id: 7,
-    foreignBookId: 'fb-7',
-    authorId: 42,
-    title: 'Mistborn',
-    description: '',
-    imageUrl: '',
-    releaseDate: undefined,
-    genres: [],
-    monitored: true,
-    status: 'imported',
-    filePath: '',
-    mediaType: 'ebook',
-    ebookFilePath: '',
-    audiobookFilePath: '',
-    excluded: false,
-    ...overrides,
-  }
-}
-
-function renderBookDetailPage() {
-  return render(
-    <MemoryRouter initialEntries={['/book/7']}>
-      <Routes>
-        <Route path="/book/:id" element={<BookDetailPage />} />
-      </Routes>
-    </MemoryRouter>,
-  )
-}
+vi.mock('../components/MediaBadge', () => ({
+  default: ({ type }: { type?: string }) => <span data-testid={`badge-${type}`}>{type}</span>,
+}))
 
 function makeResult({ guid, title, ...rest }: Partial<SearchResult> & { guid: string }): SearchResult {
   return {
@@ -67,7 +39,103 @@ function makeResult({ guid, title, ...rest }: Partial<SearchResult> & { guid: st
   }
 }
 
+const author: Author = {
+  id: 7,
+  foreignAuthorId: 'author-7',
+  authorName: 'Brandon Sanderson',
+  sortName: 'Sanderson, Brandon',
+  description: '',
+  imageUrl: '',
+  disambiguation: '',
+  ratingsCount: 0,
+  averageRating: 0,
+  monitored: true,
+}
+
+function makeBook(overrides: Partial<Book> = {}): Book {
+  return {
+    id: 42,
+    foreignBookId: 'book-42',
+    authorId: author.id,
+    title: 'The Final Empire',
+    description: 'A skaa thief joins a rebellion.',
+    imageUrl: '',
+    releaseDate: '2006-07-17T00:00:00Z',
+    genres: [],
+    monitored: true,
+    status: 'wanted',
+    filePath: '',
+    mediaType: 'ebook',
+    ebookFilePath: '',
+    audiobookFilePath: '',
+    excluded: false,
+    language: 'en',
+    author,
+    ...overrides,
+  }
+}
+
+function makeHistory(overrides: Partial<HistoryEvent> = {}): HistoryEvent {
+  return {
+    id: 99,
+    bookId: 42,
+    eventType: 'grabbed',
+    sourceTitle: 'The Final Empire release',
+    data: '{}',
+    createdAt: '2026-05-01T12:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeIndexer(overrides: Partial<Indexer> = {}): Indexer {
+  return {
+    id: 1,
+    name: 'Indexer One',
+    type: 'newznab',
+    url: 'https://indexer.example.com',
+    apiKey: 'test-key',
+    categories: [7020],
+    enabled: true,
+    ...overrides,
+  }
+}
+
+function makeDownload(overrides: Partial<Download> = {}): Download {
+  return {
+    id: 5,
+    guid: 'download-guid',
+    title: 'Downloaded release',
+    status: 'queued',
+    size: 1048576,
+    protocol: 'usenet',
+    errorMessage: '',
+    ...overrides,
+  }
+}
+
+function renderBookDetailPage() {
+  return render(
+    <MemoryRouter initialEntries={['/book/42']}>
+      <Routes>
+        <Route path="/book/:id" element={<BookDetailPage />} />
+        <Route path="/settings" element={<div>Settings Page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
 const noop = () => {}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  document.title = 'Bindery'
+  vi.mocked(api.getBook).mockResolvedValue(makeBook())
+  vi.mocked(api.listHistory).mockResolvedValue([])
+  vi.mocked(api.searchBook).mockResolvedValue({ results: [], debug: null })
+  vi.mocked(api.listIndexers).mockResolvedValue([])
+  vi.mocked(api.grab).mockResolvedValue(makeDownload())
+  vi.mocked(api.updateBook).mockImplementation(async (_id, patch) => makeBook(patch))
+})
 
 describe('SearchResultsSection — dual-format book', () => {
   it('renders separate Ebooks and Audiobooks sections', () => {
@@ -148,14 +216,140 @@ describe('SearchResultsSection — single-format book', () => {
   })
 })
 
-describe('BookDetailPage — media-type selector', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    vi.mocked(api.listHistory).mockResolvedValue([])
+describe('BookDetailPage', () => {
+  it('loads book details and history', async () => {
+    vi.mocked(api.listHistory).mockResolvedValue([makeHistory()])
+
+    renderBookDetailPage()
+
+    expect(await screen.findByRole('heading', { name: 'The Final Empire' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Brandon Sanderson' })).toBeInTheDocument()
+    expect(screen.getByText('A skaa thief joins a rebellion.')).toBeInTheDocument()
+    expect(screen.getByText('The Final Empire release')).toBeInTheDocument()
+    expect(api.getBook).toHaveBeenCalledWith(42)
+    expect(api.listHistory).toHaveBeenCalledWith({ bookId: 42 })
+  })
+
+  it('searches and renders grouped result metadata', async () => {
+    vi.mocked(api.getBook).mockResolvedValue(makeBook({ mediaType: 'both' }))
+    vi.mocked(api.listIndexers).mockResolvedValue([makeIndexer()])
+    vi.mocked(api.searchBook).mockResolvedValue({
+      results: [
+        makeResult({
+          guid: 'ebook-guid',
+          title: 'The Final Empire EPUB',
+          indexerName: 'Ebook Indexer',
+          size: 1048576,
+          grabs: 2,
+          mediaType: 'ebook',
+          rejection: 'Wrong language',
+          approved: false,
+        }),
+        makeResult({
+          guid: 'audio-guid',
+          title: 'The Final Empire MP3',
+          indexerName: 'Audio Indexer',
+          size: 2147483648,
+          grabs: 8,
+          mediaType: 'audiobook',
+        }),
+      ],
+      debug: null,
+    })
+
+    renderBookDetailPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Search ebook + audiobook indexers' }))
+
+    await waitFor(() => expect(api.searchBook).toHaveBeenCalledWith(42))
+    expect(screen.getByText('Ebooks (1)')).toBeInTheDocument()
+    expect(screen.getByText('Audiobooks (1)')).toBeInTheDocument()
+    expect(screen.getByText('The Final Empire EPUB')).toBeInTheDocument()
+    expect(screen.getByText('The Final Empire MP3')).toBeInTheDocument()
+    expect(screen.getByText(/Ebook Indexer/)).toBeInTheDocument()
+    expect(screen.getByText(/1 MB/)).toBeInTheDocument()
+    expect(screen.getByText(/2 grabs/)).toBeInTheDocument()
+    expect(screen.getByText(/Wrong language/)).toBeInTheDocument()
+    expect(screen.getByText(/Audio Indexer/)).toBeInTheDocument()
+    expect(screen.getByText(/2.0 GB/)).toBeInTheDocument()
+    expect(screen.getByText(/8 grabs/)).toBeInTheDocument()
+    expect(api.listIndexers).toHaveBeenCalled()
+  })
+
+  it('shows an empty search state when no indexers are configured', async () => {
+    vi.mocked(api.listIndexers).mockResolvedValue([])
+    vi.mocked(api.searchBook).mockResolvedValue({ results: [], debug: null })
+
+    renderBookDetailPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Search ebook indexers' }))
+
+    expect(await screen.findByText(/No indexers configured/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/settings')
+  })
+
+  it('shows an empty search state when configured indexers return no results', async () => {
+    vi.mocked(api.listIndexers).mockResolvedValue([makeIndexer()])
+    vi.mocked(api.searchBook).mockResolvedValue({ results: [], debug: null })
+
+    renderBookDetailPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Search ebook indexers' }))
+
+    expect(await screen.findByText(/No results on any indexer/)).toBeInTheDocument()
+  })
+
+  it('grabs a result, refreshes book and history, and clears results', async () => {
+    let resolveGrab: (download: Download) => void = () => {}
+    vi.mocked(api.getBook)
+      .mockResolvedValueOnce(makeBook())
+      .mockResolvedValueOnce(makeBook({ status: 'downloading' }))
+    vi.mocked(api.listHistory)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([makeHistory({ sourceTitle: 'Grab refreshed history' })])
+    vi.mocked(api.listIndexers).mockResolvedValue([makeIndexer()])
+    vi.mocked(api.searchBook).mockResolvedValue({
+      results: [
+        makeResult({
+          guid: 'grab-guid',
+          title: 'Grab Me',
+          nzbUrl: 'https://indexer.example.com/grab-guid.nzb',
+          size: 2147483648,
+          grabs: 4,
+          protocol: 'torrent',
+        }),
+      ],
+      debug: null,
+    })
+    vi.mocked(api.grab).mockImplementation(() => new Promise(resolve => { resolveGrab = resolve }))
+
+    renderBookDetailPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Search ebook indexers' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Grab' }))
+
+    expect(screen.getByRole('button', { name: 'Grabbing…' })).toBeDisabled()
+    expect(api.grab).toHaveBeenCalledWith({
+      guid: 'grab-guid',
+      title: 'Grab Me',
+      nzbUrl: 'https://indexer.example.com/grab-guid.nzb',
+      size: 2147483648,
+      bookId: 42,
+      protocol: 'torrent',
+      mediaType: 'ebook',
+    })
+
+    resolveGrab(makeDownload({ guid: 'grab-guid', title: 'Grab Me', protocol: 'torrent' }))
+
+    await waitFor(() => expect(api.getBook).toHaveBeenCalledTimes(2))
+    expect(api.listHistory).toHaveBeenLastCalledWith({ bookId: 42 })
+    expect(await screen.findByText('Grab refreshed history')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('Grab Me')).not.toBeInTheDocument())
   })
 
   it('renders the selector with the current mediaType selected', async () => {
     vi.mocked(api.getBook).mockResolvedValue(makeBook({ mediaType: 'ebook' }))
+
     renderBookDetailPage()
 
     const select = (await screen.findByLabelText('Format:')) as HTMLSelectElement
@@ -165,17 +359,19 @@ describe('BookDetailPage — media-type selector', () => {
   it('calls api.updateBook with the new mediaType on change', async () => {
     vi.mocked(api.getBook).mockResolvedValue(makeBook({ mediaType: 'ebook' }))
     vi.mocked(api.updateBook).mockResolvedValue(makeBook({ mediaType: 'both' }))
+
     renderBookDetailPage()
 
     const select = await screen.findByLabelText('Format:')
     fireEvent.change(select, { target: { value: 'both' } })
 
-    await waitFor(() => expect(api.updateBook).toHaveBeenCalledWith(7, { mediaType: 'both' }))
+    await waitFor(() => expect(api.updateBook).toHaveBeenCalledWith(42, { mediaType: 'both' }))
   })
 
   it('updates local state on success so the dual-format panels appear', async () => {
     vi.mocked(api.getBook).mockResolvedValue(makeBook({ mediaType: 'ebook' }))
     vi.mocked(api.updateBook).mockResolvedValue(makeBook({ mediaType: 'both' }))
+
     renderBookDetailPage()
 
     const select = (await screen.findByLabelText('Format:')) as HTMLSelectElement
@@ -183,9 +379,7 @@ describe('BookDetailPage — media-type selector', () => {
 
     fireEvent.change(select, { target: { value: 'both' } })
 
-    await waitFor(() => expect((select as HTMLSelectElement).value).toBe('both'))
-    // The dual-format panels (gated on mediaType === 'both') now render the
-    // "📖 Ebook ... needed" / "🎧 Audiobook ... needed" status pills.
+    await waitFor(() => expect(select.value).toBe('both'))
     const needed = await screen.findAllByText('needed')
     expect(needed.length).toBe(2)
   })

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -109,6 +109,7 @@ function makeDownload(overrides: Partial<Download> = {}): Download {
     size: 1048576,
     protocol: 'usenet',
     errorMessage: '',
+    addedAt: '2026-05-01T12:00:00Z',
     ...overrides,
   }
 }

--- a/web/src/pages/HistoryPage.test.tsx
+++ b/web/src/pages/HistoryPage.test.tsx
@@ -1,0 +1,233 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import HistoryPage from './HistoryPage'
+import { api } from '../api/client'
+import type { BlocklistEntry, HistoryEvent } from '../api/client'
+
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listHistory: vi.fn(),
+      deleteHistory: vi.fn(),
+      blocklistFromHistory: vi.fn(),
+    },
+  }
+})
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const labels: Record<string, string> = {
+        'common.loading': 'Loading...',
+        'history.title': 'History',
+        'history.allEventTypes': 'All event types',
+        'history.empty': 'No history events found',
+        'history.colEvent': 'Event',
+        'history.colSourceTitle': 'Source Title',
+        'history.colType': 'Type',
+        'history.colSize': 'Size',
+        'history.colDate': 'Date',
+        'history.blocklist': 'Blocklist',
+        'history.delete': 'Delete',
+      }
+      return labels[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('../components/usePagination', () => ({
+  usePagination: <T,>(items: T[]) => ({
+    pageItems: items,
+    paginationProps: {
+      page: 1,
+      totalPages: 1,
+      pageSize: 100,
+      totalItems: items.length,
+      onPageChange: vi.fn(),
+      onPageSizeChange: vi.fn(),
+    },
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('../components/Pagination', () => ({ default: () => null }))
+
+function makeHistory(overrides: Partial<HistoryEvent> = {}): HistoryEvent {
+  return {
+    id: 1,
+    bookId: 42,
+    eventType: 'grabbed',
+    sourceTitle: 'Dune EPUB',
+    data: '{}',
+    createdAt: '2026-05-01T12:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeBlocklistEntry(overrides: Partial<BlocklistEntry> = {}): BlocklistEntry {
+  return {
+    id: 20,
+    bookId: 42,
+    guid: 'blocked-guid',
+    title: 'Blocked Release',
+    reason: 'Blocked from history',
+    createdAt: '2026-05-01T12:00:00Z',
+    ...overrides,
+  }
+}
+
+function renderHistoryPage() {
+  return render(
+    <MemoryRouter>
+      <HistoryPage />
+    </MemoryRouter>,
+  )
+}
+
+function desktopTable() {
+  return screen.getByRole('table')
+}
+
+async function findDesktopTable() {
+  return screen.findByRole('table')
+}
+
+function rowFor(text: string) {
+  const cellText = within(desktopTable()).getByText(text)
+  return cellText.closest('tr')!
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  document.title = 'Bindery'
+  vi.mocked(api.listHistory).mockResolvedValue([])
+  vi.mocked(api.deleteHistory).mockResolvedValue(undefined)
+  vi.mocked(api.blocklistFromHistory).mockResolvedValue(makeBlocklistEntry())
+})
+
+describe('HistoryPage', () => {
+  it('renders history rows with parsed details, media type, and size', async () => {
+    vi.mocked(api.listHistory).mockResolvedValue([
+      makeHistory({
+        id: 1,
+        eventType: 'grabbed',
+        sourceTitle: 'Dune EPUB',
+        data: JSON.stringify({ path: '/library/Dune.epub', size: 1048576 }),
+      }),
+      makeHistory({
+        id: 2,
+        eventType: 'downloadFailed',
+        sourceTitle: 'Dune MP3',
+        data: JSON.stringify({ message: 'Download client rejected release', size: 2147483648 }),
+      }),
+      makeHistory({
+        id: 3,
+        eventType: 'bookImported',
+        sourceTitle: '',
+        data: JSON.stringify({ size: 0 }),
+      }),
+    ])
+
+    renderHistoryPage()
+
+    const table = await findDesktopTable()
+    expect(await within(table).findByText('Dune EPUB')).toBeInTheDocument()
+
+    const ebookRow = rowFor('Dune EPUB')
+    expect(within(ebookRow).getByText('grabbed')).toBeInTheDocument()
+    expect(within(ebookRow).getByText('/library/Dune.epub')).toBeInTheDocument()
+    expect(within(ebookRow).getByText('📖 Ebook')).toBeInTheDocument()
+    expect(within(ebookRow).getByText('1 MB')).toBeInTheDocument()
+
+    const audioRow = rowFor('Dune MP3')
+    expect(within(audioRow).getByText('downloadFailed')).toBeInTheDocument()
+    expect(within(audioRow).getByText('Download client rejected release')).toBeInTheDocument()
+    expect(within(audioRow).getByText('🎧 Audiobook')).toBeInTheDocument()
+    expect(within(audioRow).getByText('2.0 GB')).toBeInTheDocument()
+
+    const importedRow = rowFor('bookImported')
+    expect(within(importedRow).getAllByText('—').length).toBeGreaterThan(0)
+  })
+
+  it('filters history by event type', async () => {
+    vi.mocked(api.listHistory)
+      .mockResolvedValueOnce([
+        makeHistory({ id: 1, eventType: 'grabbed', sourceTitle: 'Grabbed Release' }),
+        makeHistory({ id: 2, eventType: 'downloadFailed', sourceTitle: 'Failed Release' }),
+      ])
+      .mockResolvedValueOnce([
+        makeHistory({ id: 2, eventType: 'downloadFailed', sourceTitle: 'Failed Release' }),
+      ])
+
+    renderHistoryPage()
+
+    const table = await findDesktopTable()
+    expect(await within(table).findByText('Grabbed Release')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'downloadFailed' } })
+
+    await waitFor(() => expect(api.listHistory).toHaveBeenLastCalledWith({ eventType: 'downloadFailed' }))
+    expect(await within(desktopTable()).findByText('Failed Release')).toBeInTheDocument()
+    await waitFor(() => expect(within(desktopTable()).queryByText('Grabbed Release')).not.toBeInTheDocument())
+  })
+
+  it('blocklists blocklistable events and removes them from local history', async () => {
+    vi.mocked(api.listHistory).mockResolvedValue([
+      makeHistory({ id: 7, eventType: 'importFailed', sourceTitle: 'Blocklist Me' }),
+      makeHistory({ id: 8, eventType: 'bookImported', sourceTitle: 'Keep Me' }),
+    ])
+
+    renderHistoryPage()
+
+    const targetRow = (await within(await findDesktopTable()).findByText('Blocklist Me')).closest('tr')!
+    fireEvent.click(within(targetRow).getByRole('button', { name: 'Blocklist' }))
+
+    await waitFor(() => expect(api.blocklistFromHistory).toHaveBeenCalledWith(7))
+    await waitFor(() => expect(within(desktopTable()).queryByText('Blocklist Me')).not.toBeInTheDocument())
+    expect(within(desktopTable()).getByText('Keep Me')).toBeInTheDocument()
+  })
+
+  it('deletes history events and removes them from local history', async () => {
+    vi.mocked(api.listHistory).mockResolvedValue([
+      makeHistory({ id: 11, eventType: 'grabbed', sourceTitle: 'Delete Me' }),
+      makeHistory({ id: 12, eventType: 'bookImported', sourceTitle: 'Keep Me' }),
+    ])
+
+    renderHistoryPage()
+
+    const targetRow = (await within(await findDesktopTable()).findByText('Delete Me')).closest('tr')!
+    fireEvent.click(within(targetRow).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(api.deleteHistory).toHaveBeenCalledWith(11))
+    await waitFor(() => expect(within(desktopTable()).queryByText('Delete Me')).not.toBeInTheDocument())
+    expect(within(desktopTable()).getByText('Keep Me')).toBeInTheDocument()
+  })
+
+  it('renders only delete actions for non-blocklistable events', async () => {
+    vi.mocked(api.listHistory).mockResolvedValue([
+      makeHistory({ id: 21, eventType: 'bookImported', sourceTitle: 'Imported Release' }),
+      makeHistory({ id: 22, eventType: 'deleted', sourceTitle: 'Deleted Release' }),
+    ])
+
+    renderHistoryPage()
+
+    const importedRow = (await within(await findDesktopTable()).findByText('Imported Release')).closest('tr')!
+    const deletedRow = rowFor('Deleted Release')
+
+    expect(within(importedRow).queryByRole('button', { name: 'Blocklist' })).not.toBeInTheDocument()
+    expect(within(importedRow).getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+    expect(within(deletedRow).queryByRole('button', { name: 'Blocklist' })).not.toBeInTheDocument()
+    expect(within(deletedRow).getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+  })
+
+  it('renders the empty history state', async () => {
+    renderHistoryPage()
+
+    expect(await screen.findByText('No history events found')).toBeInTheDocument()
+    expect(api.listHistory).toHaveBeenCalledWith(undefined)
+  })
+})

--- a/web/src/pages/LoginPage.test.tsx
+++ b/web/src/pages/LoginPage.test.tsx
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import LoginPage from './LoginPage'
+import { apiUrl, server } from '../test/msw'
+import { makeAuthStatus, renderWithRouter } from '../test-utils'
+
+const { navigateMock, refreshMock, authState } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  refreshMock: vi.fn(),
+  authState: { status: null as unknown },
+}))
+
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  }
+})
+
+vi.mock('../auth/AuthContext', () => ({
+  useAuth: () => ({
+    status: authState.status,
+    refresh: refreshMock,
+  }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (key === 'login.signInWith') return `Sign in with ${String(options?.name ?? '')}`
+      const strings: Record<string, string> = {
+        'login.title': 'Sign in',
+        'login.username': 'Username',
+        'login.password': 'Password',
+        'login.rememberMe': 'Remember me on this device for 30 days',
+        'login.submit': 'Sign in',
+        'login.submitting': 'Signing in...',
+        'login.errorRequired': 'Username and password are required',
+        'login.errorFailed': 'Login failed',
+        'login.proxyHint': 'Sign in via your SSO provider',
+        'login.orLocal': 'or',
+      }
+      return strings[key] ?? key
+    },
+  }),
+}))
+
+function useOidcProviders(providers: unknown[] = []) {
+  server.use(
+    http.get(apiUrl('/auth/oidc/providers'), () => HttpResponse.json(providers)),
+  )
+}
+
+function renderLoginPage() {
+  return renderWithRouter(<LoginPage />, { initialEntries: ['/login'] })
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.history.pushState(null, '', '/login')
+    authState.status = null
+    refreshMock.mockResolvedValue(undefined)
+    useOidcProviders()
+  })
+
+  it('requires username and password before submitting', () => {
+    let loginHit = false
+    server.use(
+      http.post(apiUrl('/auth/login'), () => {
+        loginHit = true
+        return HttpResponse.json({ ok: true, username: 'alice' })
+      }),
+    )
+
+    renderLoginPage()
+
+    const form = screen.getByRole('button', { name: 'Sign in' }).closest('form')
+    if (!form) throw new Error('Login form was not rendered')
+    fireEvent.submit(form)
+
+    expect(screen.getByText('Username and password are required')).toBeInTheDocument()
+    expect(loginHit).toBe(false)
+  })
+
+  it('submits DOM form values, refreshes auth state, and navigates home', async () => {
+    let loginBody: unknown
+
+    server.use(
+      http.post(apiUrl('/auth/login'), async ({ request }) => {
+        loginBody = await request.json()
+        return HttpResponse.json({ ok: true, username: 'alice' })
+      }),
+      http.get(apiUrl('/auth/csrf'), () => HttpResponse.json({ csrfToken: 'fresh-token' })),
+    )
+
+    renderLoginPage()
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: ' alice ' } })
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+
+    await waitFor(() => {
+      expect(loginBody).toEqual({ username: 'alice', password: 'secret', rememberMe: true })
+    })
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+    expect(navigateMock).toHaveBeenCalledWith('/', { replace: true })
+  })
+
+  it('shows an API error when login fails', async () => {
+    server.use(
+      http.post(apiUrl('/auth/login'), () => HttpResponse.json({ error: 'bad credentials' }, { status: 401 })),
+    )
+
+    renderLoginPage()
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'alice' } })
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'wrong' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+
+    expect(await screen.findByText('bad credentials')).toBeInTheDocument()
+    expect(refreshMock).not.toHaveBeenCalled()
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('renders only usable OIDC providers with encoded login links', async () => {
+    useOidcProviders([
+      { id: 'ok/provider', name: 'Company SSO', status: { state: 'ok' } },
+      { id: 'failed', name: 'Broken SSO', status: { state: 'failed' } },
+      { id: 'legacy', name: 'Legacy SSO' },
+    ])
+
+    renderLoginPage()
+
+    const company = await screen.findByRole('link', { name: 'Sign in with Company SSO' })
+    expect(company).toHaveAttribute('href', '/api/v1/auth/oidc/ok%2Fprovider/login')
+    expect(screen.getByRole('link', { name: 'Sign in with Legacy SSO' })).toHaveAttribute(
+      'href',
+      '/api/v1/auth/oidc/legacy/login',
+    )
+    expect(screen.queryByText('Sign in with Broken SSO')).not.toBeInTheDocument()
+  })
+
+  it('renders the proxy sign-in hint instead of the local form', () => {
+    authState.status = makeAuthStatus({ mode: 'proxy' })
+
+    renderLoginPage()
+
+    expect(screen.getByText('Sign in via your SSO provider')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Username')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/LoginPage.test.tsx
+++ b/web/src/pages/LoginPage.test.tsx
@@ -85,6 +85,14 @@ describe('LoginPage', () => {
     expect(loginHit).toBe(false)
   })
 
+  it('does not render the login form for an authenticated session', () => {
+    authState.status = makeAuthStatus({ authenticated: true, username: 'alice', role: 'admin' })
+
+    renderLoginPage()
+
+    expect(screen.queryByRole('button', { name: 'Sign in' })).not.toBeInTheDocument()
+  })
+
   it('submits DOM form values, refreshes auth state, and navigates home', async () => {
     let loginBody: unknown
 

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { api, OidcProvider } from '../api/client'
 import { useAuth } from '../auth/AuthContext'
@@ -47,6 +47,13 @@ export default function LoginPage() {
     } finally {
       setSubmitting(false)
     }
+  }
+
+  if (status?.setupRequired) {
+    return <Navigate to="/setup" replace />
+  }
+  if (status?.authenticated) {
+    return <Navigate to="/" replace />
   }
 
   if (status?.mode === 'proxy') {

--- a/web/src/pages/QueuePage.test.tsx
+++ b/web/src/pages/QueuePage.test.tsx
@@ -1,0 +1,282 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import QueuePage from './QueuePage'
+import { api } from '../api/client'
+import type { Download, PendingRelease, QueueItem } from '../api/client'
+
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listQueue: vi.fn(),
+      listPending: vi.fn(),
+      deleteFromQueue: vi.fn(),
+      dismissPending: vi.fn(),
+      grabPending: vi.fn(),
+    },
+  }
+})
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (key === 'queue.remaining') return `${String(options?.time)} remaining`
+      const labels: Record<string, string> = {
+        'common.loading': 'Loading...',
+        'queue.title': 'Queue',
+        'queue.empty': 'Queue is empty',
+        'queue.remove': 'Remove',
+      }
+      return labels[key] ?? key
+    },
+  }),
+}))
+
+function makeQueueItem(overrides: Partial<QueueItem> = {}): QueueItem {
+  return {
+    id: 1,
+    guid: 'queue-guid',
+    title: 'Queued Release',
+    status: 'downloading',
+    size: 1048576,
+    protocol: 'usenet',
+    errorMessage: '',
+    ...overrides,
+  }
+}
+
+function makePendingRelease(overrides: Partial<PendingRelease> = {}): PendingRelease {
+  return {
+    id: 10,
+    bookId: 42,
+    title: 'Pending Release',
+    guid: 'pending-guid',
+    protocol: 'torrent',
+    size: 1572864,
+    ageMinutes: 30,
+    quality: 'EPUB',
+    customScore: 100,
+    reason: 'Waiting for better quality',
+    firstSeen: '2026-05-01T12:00:00Z',
+    releaseJson: '{}',
+    ...overrides,
+  }
+}
+
+function makeDownload(overrides: Partial<Download> = {}): Download {
+  return {
+    id: 99,
+    guid: 'download-guid',
+    title: 'Grabbed Pending Release',
+    status: 'queued',
+    size: 1572864,
+    protocol: 'torrent',
+    errorMessage: '',
+    ...overrides,
+  }
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {}
+  let reject: (reason?: unknown) => void = () => {}
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function renderQueuePage() {
+  return render(
+    <MemoryRouter>
+      <QueuePage />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  document.title = 'Bindery'
+  vi.mocked(api.listQueue).mockResolvedValue([])
+  vi.mocked(api.listPending).mockResolvedValue([])
+  vi.mocked(api.deleteFromQueue).mockResolvedValue(undefined)
+  vi.mocked(api.dismissPending).mockResolvedValue(undefined)
+  vi.mocked(api.grabPending).mockResolvedValue(makeDownload())
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('QueuePage', () => {
+  it('renders loading and then the empty queue state', async () => {
+    const queueLoad = deferred<QueueItem[]>()
+    const pendingLoad = deferred<PendingRelease[]>()
+    vi.mocked(api.listQueue).mockReturnValue(queueLoad.promise)
+    vi.mocked(api.listPending).mockReturnValue(pendingLoad.promise)
+
+    renderQueuePage()
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+
+    await act(async () => {
+      queueLoad.resolve([])
+      pendingLoad.resolve([])
+      await Promise.resolve()
+    })
+
+    expect(await screen.findByText('Queue is empty')).toBeInTheDocument()
+  })
+
+  it('renders queue statuses, progress, fallback errors, and error prefixes', async () => {
+    vi.mocked(api.listQueue).mockResolvedValue([
+      makeQueueItem({
+        id: 1,
+        title: 'Dune EPUB',
+        status: 'downloading',
+        size: 2147483648,
+        percentage: '45',
+        timeLeft: '12 minutes',
+        protocol: 'usenet',
+      }),
+      makeQueueItem({
+        id: 2,
+        title: 'Blocked Import',
+        status: 'importBlocked',
+        size: 512000,
+        protocol: 'torrent',
+      }),
+      makeQueueItem({
+        id: 3,
+        title: 'Failed Import',
+        status: 'importFailed',
+        size: 1048576,
+        errorMessage: 'Missing target folder',
+      }),
+      makeQueueItem({
+        id: 4,
+        title: 'Failed Download',
+        status: 'failed',
+        size: 1048576,
+        errorMessage: 'Client rejected download',
+      }),
+    ])
+
+    const { container } = renderQueuePage()
+
+    expect(await screen.findByText('Dune EPUB')).toBeInTheDocument()
+    const duneCard = screen.getByText('Dune EPUB').closest('div')!.parentElement!
+    expect(within(duneCard).getByText('Downloading')).toBeInTheDocument()
+    expect(within(duneCard).getByText('2.0 GB')).toBeInTheDocument()
+    expect(within(duneCard).getByText('45%')).toBeInTheDocument()
+    expect(within(duneCard).getByText('12 minutes remaining')).toBeInTheDocument()
+    expect(within(duneCard).getByText('usenet')).toBeInTheDocument()
+    expect(screen.getByText('Import Blocked')).toBeInTheDocument()
+    expect(screen.getByText(/Import blocked — manual intervention required/)).toBeInTheDocument()
+    expect(screen.getByText('Import Failed')).toBeInTheDocument()
+    expect(screen.getByText('Import failed:')).toBeInTheDocument()
+    expect(screen.getByText('Missing target folder')).toBeInTheDocument()
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText('Error:')).toBeInTheDocument()
+    expect(screen.getByText('Client rejected download')).toBeInTheDocument()
+    expect(container.querySelector('[style="width: 45%;"]')).toBeInTheDocument()
+  })
+
+  it('renders pending releases and supports grabbing a pending release', async () => {
+    let resolveGrab: (download: Download) => void = () => {}
+    vi.mocked(api.listPending)
+      .mockResolvedValueOnce([makePendingRelease()])
+      .mockResolvedValueOnce([])
+    vi.mocked(api.grabPending).mockImplementation(() => new Promise(resolve => { resolveGrab = resolve }))
+
+    renderQueuePage()
+
+    expect(await screen.findByText('Pending Releases (1)')).toBeInTheDocument()
+    expect(screen.getByText('Pending Release')).toBeInTheDocument()
+    expect(screen.getByText('Waiting for better quality')).toBeInTheDocument()
+    expect(screen.getByText('1.5 MB')).toBeInTheDocument()
+    expect(screen.getByText('EPUB')).toBeInTheDocument()
+    expect(screen.getByText('torrent')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Grab Now' }))
+    expect(screen.getByRole('button', { name: 'Grabbing…' })).toBeDisabled()
+    expect(api.grabPending).toHaveBeenCalledWith(10)
+
+    await act(async () => {
+      resolveGrab(makeDownload())
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(api.listPending).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('Queue is empty')).toBeInTheDocument()
+  })
+
+  it('dismisses a pending release and reloads pending releases', async () => {
+    vi.mocked(api.listPending)
+      .mockResolvedValueOnce([makePendingRelease({ id: 11, title: 'Dismiss Me' })])
+      .mockResolvedValueOnce([])
+
+    renderQueuePage()
+
+    const pendingTitle = await screen.findByText('Dismiss Me')
+    const pendingCard = pendingTitle.closest('div')!.parentElement!
+    fireEvent.click(within(pendingCard).getByRole('button', { name: 'Dismiss' }))
+
+    await waitFor(() => expect(api.dismissPending).toHaveBeenCalledWith(11))
+    await waitFor(() => expect(api.listPending).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('Queue is empty')).toBeInTheDocument()
+  })
+
+  it('deletes a queue item and reloads the queue', async () => {
+    vi.mocked(api.listQueue)
+      .mockResolvedValueOnce([makeQueueItem({ id: 7, title: 'Remove Me' })])
+      .mockResolvedValueOnce([])
+
+    renderQueuePage()
+
+    const item = await screen.findByText('Remove Me')
+    const card = item.closest('div')!.parentElement!
+    fireEvent.click(within(card).getByRole('button', { name: 'Remove' }))
+
+    await waitFor(() => expect(api.deleteFromQueue).toHaveBeenCalledWith(7))
+    await waitFor(() => expect(api.listQueue).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('Queue is empty')).toBeInTheDocument()
+  })
+
+  it('polls the queue every five seconds and clears the interval on unmount', async () => {
+    vi.useFakeTimers()
+
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    vi.mocked(api.listQueue).mockResolvedValue([])
+    vi.mocked(api.listPending).mockResolvedValue([])
+
+    const { unmount } = renderQueuePage()
+
+    expect(api.listQueue).toHaveBeenCalledTimes(1)
+    expect(api.listPending).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+      await Promise.resolve()
+    })
+
+    expect(api.listQueue).toHaveBeenCalledTimes(2)
+    expect(api.listPending).toHaveBeenCalledTimes(2)
+
+    unmount()
+
+    expect(clearIntervalSpy).toHaveBeenCalled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+      await Promise.resolve()
+    })
+
+    expect(api.listQueue).toHaveBeenCalledTimes(2)
+    expect(api.listPending).toHaveBeenCalledTimes(2)
+    clearIntervalSpy.mockRestore()
+  })
+})

--- a/web/src/pages/QueuePage.test.tsx
+++ b/web/src/pages/QueuePage.test.tsx
@@ -44,6 +44,7 @@ function makeQueueItem(overrides: Partial<QueueItem> = {}): QueueItem {
     size: 1048576,
     protocol: 'usenet',
     errorMessage: '',
+    addedAt: '2026-05-01T12:00:00Z',
     ...overrides,
   }
 }
@@ -75,6 +76,7 @@ function makeDownload(overrides: Partial<Download> = {}): Download {
     size: 1572864,
     protocol: 'torrent',
     errorMessage: '',
+    addedAt: '2026-05-01T12:00:00Z',
     ...overrides,
   }
 }

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -435,6 +435,7 @@ describe('SettingsPage', () => {
     await waitFor(() => expect(api.authSetMode).toHaveBeenCalledWith('local-only'))
     expect(mockAuthContext.refresh).toHaveBeenCalled()
     await waitFor(() => expect(api.authConfig).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(sectionForHeading('Security').getByRole('combobox')).toHaveValue('local-only'))
   })
 
   it('shows, copies, and regenerates the security API key', async () => {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import SettingsPage from './SettingsPage'
-import { api } from '../api/client'
+import { api, type DownloadClient, type Indexer, type ProwlarrInstance, type SystemStatus } from '../api/client'
 
 vi.mock('../settings/AuthSettings', () => ({ default: () => <div data-testid="auth-settings" /> }))
 vi.mock('../components/ThemeToggle', () => ({ default: () => <button type="button">Theme</button> }))
@@ -11,7 +11,7 @@ vi.mock('../auth/AuthContext', () => ({
 }))
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback ?? _key,
+    t: (key: string, fallback?: unknown) => typeof fallback === 'string' ? fallback : key,
     i18n: { changeLanguage: vi.fn() },
   }),
 }))
@@ -22,8 +22,20 @@ vi.mock('../api/client', async importOriginal => {
     api: {
       ...actual.api,
       listIndexers: vi.fn(),
+      addIndexer: vi.fn(),
+      updateIndexer: vi.fn(),
+      deleteIndexer: vi.fn(),
+      testIndexer: vi.fn(),
       listDownloadClients: vi.fn(),
+      addDownloadClient: vi.fn(),
+      updateDownloadClient: vi.fn(),
+      deleteDownloadClient: vi.fn(),
+      testDownloadClient: vi.fn(),
       listProwlarr: vi.fn(),
+      addProwlarr: vi.fn(),
+      syncProwlarr: vi.fn(),
+      testProwlarr: vi.fn(),
+      deleteProwlarr: vi.fn(),
       absConfig: vi.fn(),
       absSetConfig: vi.fn(),
       absLibraries: vi.fn(),
@@ -45,12 +57,82 @@ vi.mock('../api/client', async importOriginal => {
   }
 })
 
-describe('SettingsPage Hardcover API keys', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    vi.mocked(api.listIndexers).mockResolvedValue([])
-    vi.mocked(api.listDownloadClients).mockResolvedValue([])
-    vi.mocked(api.listProwlarr).mockResolvedValue([])
+const defaultStatus: SystemStatus = {
+  version: 'dev',
+  commit: 'unknown',
+  buildDate: '',
+  enhancedHardcoverApi: false,
+  hardcoverTokenConfigured: false,
+  enhancedHardcoverDisabledReason: 'env_disabled',
+}
+
+function makeIndexer(overrides: Partial<Indexer> = {}): Indexer {
+  return {
+    id: 1,
+    name: 'NZBGeek',
+    type: 'newznab',
+    url: 'https://nzbgeek.example.com',
+    apiKey: 'indexer-key',
+    categories: [7020],
+    enabled: true,
+    ...overrides,
+  }
+}
+
+function makeProwlarr(overrides: Partial<ProwlarrInstance> = {}): ProwlarrInstance {
+  return {
+    id: 10,
+    name: 'Prowlarr',
+    url: 'http://prowlarr:9696',
+    apiKey: 'prowlarr-key',
+    syncOnStartup: true,
+    enabled: true,
+    ...overrides,
+  }
+}
+
+function makeClient(overrides: Partial<DownloadClient> = {}): DownloadClient {
+  return {
+    id: 20,
+    name: 'SABnzbd',
+    type: 'sabnzbd',
+    host: 'sabnzbd',
+    port: 8080,
+    apiKey: 'sab-key',
+    username: '',
+    password: '',
+    useSsl: false,
+    urlBase: '',
+    category: 'books',
+    enabled: true,
+    ...overrides,
+  }
+}
+
+function seedSettingsMocks(options: {
+  indexers?: Indexer[]
+  clients?: DownloadClient[]
+  prowlarr?: ProwlarrInstance[]
+  status?: SystemStatus
+} = {}) {
+  vi.mocked(api.listIndexers).mockResolvedValue(options.indexers ?? [])
+  vi.mocked(api.addIndexer).mockImplementation(async data => makeIndexer({ id: 100, ...data }))
+  vi.mocked(api.updateIndexer).mockImplementation(async (id, data) => makeIndexer({ ...data, id }))
+  vi.mocked(api.deleteIndexer).mockResolvedValue(undefined)
+  vi.mocked(api.testIndexer).mockResolvedValue({ ok: true, status: 200, categories: 12, bookSearch: true, latencyMs: 34, searchResults: 2 })
+
+  vi.mocked(api.listDownloadClients).mockResolvedValue(options.clients ?? [])
+  vi.mocked(api.addDownloadClient).mockImplementation(async data => makeClient({ id: 200, ...data }))
+  vi.mocked(api.updateDownloadClient).mockImplementation(async (id, data) => makeClient({ ...data, id }))
+  vi.mocked(api.deleteDownloadClient).mockResolvedValue(undefined)
+  vi.mocked(api.testDownloadClient).mockResolvedValue({ message: 'ok' })
+
+  vi.mocked(api.listProwlarr).mockResolvedValue(options.prowlarr ?? [])
+  vi.mocked(api.addProwlarr).mockImplementation(async data => makeProwlarr({ id: 300, ...data }))
+  vi.mocked(api.syncProwlarr).mockResolvedValue({ added: 0, updated: 0, removed: 0 })
+  vi.mocked(api.testProwlarr).mockResolvedValue({ ok: 'true', version: '1.0.0' })
+  vi.mocked(api.deleteProwlarr).mockResolvedValue(undefined)
+
     vi.mocked(api.absConfig).mockResolvedValue({ featureEnabled: false, baseUrl: '', label: '', enabled: false, libraryId: '', pathRemap: '', apiKeyConfigured: false })
     vi.mocked(api.absSetConfig).mockResolvedValue({ featureEnabled: false, baseUrl: '', label: '', enabled: false, libraryId: '', pathRemap: '', apiKeyConfigured: false })
     vi.mocked(api.absLibraries).mockResolvedValue([])
@@ -64,14 +146,7 @@ describe('SettingsPage Hardcover API keys', () => {
     vi.mocked(api.libraryScanStatus).mockRejectedValue(new Error('no scan'))
     vi.mocked(api.getStorage).mockResolvedValue({ downloadDir: '/downloads', audiobookDownloadDir: '', libraryDir: '/books', audiobookDir: '' })
     vi.mocked(api.listRootFolders).mockResolvedValue([])
-    vi.mocked(api.status).mockResolvedValue({
-      version: 'dev',
-      commit: 'unknown',
-      buildDate: '',
-      enhancedHardcoverApi: false,
-      hardcoverTokenConfigured: false,
-      enhancedHardcoverDisabledReason: 'env_disabled',
-    })
+    vi.mocked(api.status).mockResolvedValue(options.status ?? defaultStatus)
     vi.mocked(api.setSetting).mockResolvedValue(undefined)
     vi.mocked(api.testHardcover).mockResolvedValue({
       ok: true,
@@ -84,10 +159,29 @@ describe('SettingsPage Hardcover API keys', () => {
       message: 'Found 2 series; catalog "Dune" has 8 books',
     })
     vi.mocked(api.authConfig).mockResolvedValue({ mode: 'disabled', apiKey: 'key', username: 'admin' })
+}
+
+function renderSettings(options?: Parameters<typeof seedSettingsMocks>[0]) {
+  if (options) seedSettingsMocks(options)
+  return render(<SettingsPage />)
+}
+
+async function openIndexersTab() {
+  fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.indexers' }))
+}
+
+async function openClientsTab() {
+  fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.clients' }))
+}
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    seedSettingsMocks()
   })
 
   it('adds a write-only Hardcover token field with API link', async () => {
-    render(<SettingsPage />)
+    renderSettings()
 
     expect(await screen.findByText('Hardcover API Token')).toBeInTheDocument()
     const link = screen.getByRole('link', { name: 'Create or copy a Hardcover API token' })
@@ -102,7 +196,7 @@ describe('SettingsPage Hardcover API keys', () => {
   })
 
   it('persists the enhanced Hardcover admin toggle separately from effective status', async () => {
-    render(<SettingsPage />)
+    renderSettings()
 
     fireEvent.click(await screen.findByRole('button', { name: 'Toggle enhanced Hardcover series' }))
 
@@ -120,7 +214,7 @@ describe('SettingsPage Hardcover API keys', () => {
       hardcoverTokenConfigured: true,
     })
 
-    render(<SettingsPage />)
+    renderSettings()
 
     fireEvent.click(await screen.findByRole('button', { name: 'Test Hardcover API' }))
 
@@ -151,7 +245,7 @@ describe('SettingsPage Hardcover API keys', () => {
       apiKeyConfigured: true,
     }))
 
-    render(<SettingsPage />)
+    renderSettings()
 
     fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.abs' }))
     const preview = await screen.findByRole('button', { name: 'Preview changes' })
@@ -178,5 +272,335 @@ describe('SettingsPage Hardcover API keys', () => {
     await waitFor(() => {
       expect(api.absImportStart).toHaveBeenCalledWith({ dryRun: true })
     })
+  })
+
+  it('adds an indexer with parsed categories', async () => {
+    renderSettings()
+    await openIndexersTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.indexers.addButton' }))
+    fireEvent.change(screen.getByPlaceholderText('Name (e.g. NZBGeek)'), { target: { value: 'SceneNZBs' } })
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'torznab' } })
+    fireEvent.change(screen.getByPlaceholderText('URL (e.g. https://api.nzbgeek.info or http://prowlarr:9696/1/api)'), { target: { value: 'http://prowlarr:9696/1/api' } })
+    fireEvent.change(screen.getByPlaceholderText('API Key'), { target: { value: 'scene-key' } })
+    fireEvent.change(screen.getByDisplayValue('7020'), { target: { value: '7020, 7120, bad, 3030' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(api.addIndexer).toHaveBeenCalledWith({
+        name: 'SceneNZBs',
+        url: 'http://prowlarr:9696/1/api',
+        apiKey: 'scene-key',
+        type: 'torznab',
+        categories: [7020, 7120, 3030],
+        enabled: true,
+      })
+    })
+    expect(await screen.findByText('SceneNZBs')).toBeInTheDocument()
+  })
+
+  it('edits an indexer while preserving existing fields', async () => {
+    const indexer = makeIndexer({ id: 7, name: 'Old Indexer', categories: [7020, 3030], enabled: true })
+
+    renderSettings({ indexers: [indexer] })
+    await openIndexersTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+    fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'DrunkenSlug' } })
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'torznab' } })
+    fireEvent.change(screen.getByPlaceholderText('URL'), { target: { value: 'https://slug.example.com/api' } })
+    fireEvent.change(screen.getByPlaceholderText('API Key'), { target: { value: 'slug-key' } })
+    fireEvent.change(screen.getByDisplayValue('7020, 3030'), { target: { value: '7020, bad, 3030' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(api.updateIndexer).toHaveBeenCalledWith(7, {
+        ...indexer,
+        name: 'DrunkenSlug',
+        type: 'torznab',
+        url: 'https://slug.example.com/api',
+        apiKey: 'slug-key',
+        categories: [7020, 3030],
+      })
+    })
+    expect(await screen.findByText('DrunkenSlug')).toBeInTheDocument()
+  })
+
+  it('toggles and deletes an indexer', async () => {
+    const indexer = makeIndexer({ id: 8, name: 'Toggle Indexer', enabled: true })
+    vi.mocked(api.updateIndexer).mockResolvedValue({ ...indexer, enabled: false })
+
+    renderSettings({ indexers: [indexer] })
+    await openIndexersTab()
+
+    fireEvent.click(screen.getByTitle('common.disable'))
+    await waitFor(() => {
+      expect(api.updateIndexer).toHaveBeenCalledWith(8, { ...indexer, enabled: false })
+    })
+    expect(await screen.findByTitle('common.enable')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.delete' }))
+    await waitFor(() => expect(api.deleteIndexer).toHaveBeenCalledWith(8))
+    await waitFor(() => expect(screen.queryByText('Toggle Indexer')).not.toBeInTheDocument())
+  })
+
+  it('renders indexer test success, warning, and failure states', async () => {
+    const indexer = makeIndexer({ id: 9, name: 'Probe Indexer' })
+
+    renderSettings({ indexers: [indexer] })
+    await openIndexersTab()
+
+    vi.mocked(api.testIndexer).mockResolvedValueOnce({ ok: true, status: 200, categories: 12, bookSearch: true, latencyMs: 20, searchResults: 3 })
+    fireEvent.click(screen.getByRole('button', { name: 'common.test' }))
+    await waitFor(() => expect(api.testIndexer).toHaveBeenCalledWith(9))
+    expect(await screen.findByText('settings.indexers.testOk')).toBeInTheDocument()
+
+    vi.mocked(api.testIndexer).mockResolvedValueOnce({ ok: true, status: 200, categories: 12, bookSearch: true, latencyMs: 20, searchResults: 0, searchError: 'no book results' })
+    fireEvent.click(screen.getByRole('button', { name: 'common.test' }))
+    expect(await screen.findByText(/settings\.indexers\.testWarn/)).toBeInTheDocument()
+    expect(screen.getByText(/no book results/)).toBeInTheDocument()
+
+    vi.mocked(api.testIndexer).mockRejectedValueOnce(new Error('bad key'))
+    fireEvent.click(screen.getByRole('button', { name: 'common.test' }))
+    expect(await screen.findByText('settings.indexers.testFail')).toBeInTheDocument()
+  })
+
+  it('adds Prowlarr and immediately syncs refreshed indexers', async () => {
+    const added = makeProwlarr({ id: 31, name: 'Main Prowlarr', url: 'http://prowlarr:9696' })
+    vi.mocked(api.addProwlarr).mockResolvedValue(added)
+    vi.mocked(api.syncProwlarr).mockResolvedValue({ added: 2, updated: 1, removed: 0 })
+    vi.mocked(api.listProwlarr).mockResolvedValueOnce([]).mockResolvedValueOnce([{ ...added, lastSyncAt: '2026-05-06T12:00:00Z' }])
+
+    renderSettings()
+    await openIndexersTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Prowlarr' }))
+    fireEvent.change(screen.getByPlaceholderText('Prowlarr'), { target: { value: 'Main Prowlarr' } })
+    fireEvent.change(screen.getByPlaceholderText('http://prowlarr:9696'), { target: { value: 'http://prowlarr:9696' } })
+    fireEvent.change(screen.getByPlaceholderText('API Key'), { target: { value: 'prowlarr-secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save & sync' }))
+
+    await waitFor(() => {
+      expect(api.addProwlarr).toHaveBeenCalledWith({
+        name: 'Main Prowlarr',
+        url: 'http://prowlarr:9696',
+        apiKey: 'prowlarr-secret',
+        syncOnStartup: true,
+        enabled: true,
+      })
+    })
+    await waitFor(() => expect(api.syncProwlarr).toHaveBeenCalledWith(31))
+    await waitFor(() => expect(api.listProwlarr).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(api.listIndexers).toHaveBeenCalledTimes(2))
+  })
+
+  it('keeps a newly added Prowlarr instance when immediate sync fails', async () => {
+    const added = makeProwlarr({ id: 32, name: 'Fallback Prowlarr' })
+    vi.mocked(api.addProwlarr).mockResolvedValue(added)
+    vi.mocked(api.syncProwlarr).mockRejectedValue(new Error('sync failed'))
+
+    renderSettings()
+    await openIndexersTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Prowlarr' }))
+    fireEvent.change(screen.getByPlaceholderText('Prowlarr'), { target: { value: 'Fallback Prowlarr' } })
+    fireEvent.change(screen.getByPlaceholderText('http://prowlarr:9696'), { target: { value: 'http://prowlarr:9696' } })
+    fireEvent.change(screen.getByPlaceholderText('API Key'), { target: { value: 'prowlarr-secret' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save & sync' }))
+
+    await waitFor(() => expect(api.syncProwlarr).toHaveBeenCalledWith(32))
+    expect(await screen.findByText('Fallback Prowlarr')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Save & sync' })).not.toBeInTheDocument()
+  })
+
+  it('tests, syncs, and deletes an existing Prowlarr instance', async () => {
+    const prowlarr = makeProwlarr({ id: 33, name: 'Library Prowlarr', lastSyncAt: '2026-05-06T12:00:00Z' })
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    try {
+      renderSettings({ prowlarr: [prowlarr], indexers: [makeIndexer({ id: 11, prowlarrInstanceId: 33 })] })
+      vi.mocked(api.syncProwlarr).mockResolvedValue({ added: 1, updated: 2, removed: 3 })
+      vi.mocked(api.listProwlarr).mockResolvedValue([{ ...prowlarr, lastSyncAt: '2026-05-06T13:00:00Z' }])
+      await openIndexersTab()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Test' }))
+      await waitFor(() => expect(api.testProwlarr).toHaveBeenCalledWith(33))
+      expect(alertSpy).toHaveBeenCalledWith('Connected — Prowlarr 1.0.0')
+
+      fireEvent.click(screen.getByRole('button', { name: 'Sync now' }))
+      await waitFor(() => expect(api.syncProwlarr).toHaveBeenCalledWith(33))
+      expect(await screen.findByText(/Synced.*added 1, updated 2, removed 3/)).toBeInTheDocument()
+      await waitFor(() => expect(api.listIndexers).toHaveBeenCalledTimes(2))
+      await waitFor(() => expect(api.listProwlarr).toHaveBeenCalledTimes(2))
+
+      fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+      await waitFor(() => expect(api.deleteProwlarr).toHaveBeenCalledWith(33))
+      expect(confirmSpy).toHaveBeenCalledWith('Delete Prowlarr instance "Library Prowlarr" and all its synced indexers?')
+      await waitFor(() => expect(screen.queryByText('Library Prowlarr')).not.toBeInTheDocument())
+    } finally {
+      alertSpy.mockRestore()
+      confirmSpy.mockRestore()
+    }
+  })
+
+  it('adds a SABnzbd download client with API key, SSL, URL Base, and category mapping', async () => {
+    renderSettings()
+    await openClientsTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.clients.addButton' }))
+    fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'SAB Books' } })
+    fireEvent.change(screen.getByPlaceholderText('Host'), { target: { value: 'sabnzbd' } })
+    fireEvent.change(screen.getByPlaceholderText('Port'), { target: { value: '8085' } })
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Use SSL' }))
+    fireEvent.change(screen.getByPlaceholderText('/sabnzbd'), { target: { value: ' /sab ' } })
+    fireEvent.change(screen.getByPlaceholderText('API Key'), { target: { value: 'sab-secret' } })
+    fireEvent.change(screen.getByDisplayValue('books'), { target: { value: 'ebooks' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(api.addDownloadClient).toHaveBeenCalledWith({
+        name: 'SAB Books',
+        host: 'sabnzbd',
+        port: 8085,
+        apiKey: 'sab-secret',
+        username: '',
+        password: '',
+        category: 'ebooks',
+        type: 'sabnzbd',
+        enabled: true,
+        useSsl: true,
+        urlBase: '/sab',
+      })
+    })
+    expect(await screen.findByText('SAB Books')).toBeInTheDocument()
+  })
+
+  it('updates add-client defaults and clears stale credentials when switching types', async () => {
+    renderSettings()
+    await openClientsTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.clients.addButton' }))
+    fireEvent.change(screen.getByPlaceholderText('API Key'), { target: { value: 'stale-key' } })
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'nzbget' } })
+    expect(screen.getByPlaceholderText('Name')).toHaveValue('NZBGet')
+    expect(screen.getByPlaceholderText('Port')).toHaveValue('6789')
+    expect(screen.getByPlaceholderText('Username')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Password')).toHaveValue('')
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'qbittorrent' } })
+    expect(screen.getByPlaceholderText('Name')).toHaveValue('qBittorrent')
+    expect(screen.getByPlaceholderText('Port')).toHaveValue('8080')
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'transmission' } })
+    expect(screen.getByPlaceholderText('Name')).toHaveValue('Transmission')
+    expect(screen.getByPlaceholderText('Port')).toHaveValue('9091')
+    expect(screen.getByText('Download Directory')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'deluge' } })
+    expect(screen.getByPlaceholderText('Name')).toHaveValue('Deluge')
+    expect(screen.getByPlaceholderText('Port')).toHaveValue('8112')
+    expect(screen.getByText('Category / Label')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Username')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    { type: 'nzbget', name: 'NZBGet', port: 6789, username: 'nzb-user', password: 'nzb-pass', category: 'books' },
+    { type: 'qbittorrent', name: 'qBittorrent', port: 8080, username: 'qbit-user', password: 'qbit-pass', category: 'ebooks' },
+    { type: 'transmission', name: 'Transmission', port: 9091, username: 'tr-user', password: 'tr-pass', category: '/downloads/books' },
+    { type: 'deluge', name: 'Deluge', port: 8112, username: '', password: 'deluge-pass', category: 'books-audio' },
+  ])('maps $name download client credentials on add', async ({ type, name, port, username, password, category }) => {
+    renderSettings()
+    await openClientsTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.clients.addButton' }))
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: type } })
+    fireEvent.change(screen.getByPlaceholderText('Host'), { target: { value: `${type}.local` } })
+    if (username) {
+      fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: username } })
+    }
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: password } })
+    fireEvent.change(screen.getByDisplayValue('books'), { target: { value: category } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(api.addDownloadClient).toHaveBeenCalledWith({
+        name,
+        host: `${type}.local`,
+        port,
+        username,
+        password,
+        apiKey: '',
+        category,
+        type,
+        enabled: true,
+        useSsl: false,
+        urlBase: '',
+      })
+    })
+  })
+
+  it('edits a download client with credential remapping, SSL, URL Base, and category updates', async () => {
+    const client = makeClient({ id: 44, name: 'Old SAB', host: 'sab-old', apiKey: 'old-api' })
+
+    renderSettings({ clients: [client] })
+    await openClientsTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+    fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'qBit Books' } })
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'qbittorrent' } })
+    fireEvent.change(screen.getByPlaceholderText('Host'), { target: { value: 'qbittorrent' } })
+    fireEvent.change(screen.getByPlaceholderText('Port'), { target: { value: '8081' } })
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Use SSL' }))
+    fireEvent.change(screen.getByPlaceholderText('/sabnzbd'), { target: { value: ' /qbittorrent ' } })
+    fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'qbit-user' } })
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'qbit-pass' } })
+    fireEvent.change(screen.getByDisplayValue('books'), { target: { value: 'ebooks' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(api.updateDownloadClient).toHaveBeenCalledWith(44, {
+        ...client,
+        name: 'qBit Books',
+        type: 'qbittorrent',
+        host: 'qbittorrent',
+        port: 8081,
+        username: 'qbit-user',
+        password: 'qbit-pass',
+        apiKey: '',
+        category: 'ebooks',
+        useSsl: true,
+        urlBase: '/qbittorrent',
+      })
+    })
+    expect(await screen.findByText('qBit Books')).toBeInTheDocument()
+  })
+
+  it('toggles, tests, and deletes a download client', async () => {
+    const client = makeClient({ id: 45, name: 'Client Actions', enabled: true })
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    vi.mocked(api.updateDownloadClient).mockResolvedValue({ ...client, enabled: false })
+
+    try {
+      renderSettings({ clients: [client] })
+      await openClientsTab()
+
+      fireEvent.click(screen.getByTitle('common.disable'))
+      await waitFor(() => {
+        expect(api.updateDownloadClient).toHaveBeenCalledWith(45, { ...client, enabled: false })
+      })
+      expect(await screen.findByTitle('common.enable')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'common.test' }))
+      await waitFor(() => expect(api.testDownloadClient).toHaveBeenCalledWith(45))
+      expect(alertSpy).toHaveBeenCalledWith('common.connOk')
+
+      fireEvent.click(screen.getByRole('button', { name: 'common.delete' }))
+      await waitFor(() => expect(api.deleteDownloadClient).toHaveBeenCalledWith(45))
+      await waitFor(() => expect(screen.queryByText('Client Actions')).not.toBeInTheDocument())
+    } finally {
+      alertSpy.mockRestore()
+    }
   })
 })

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1,13 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import SettingsPage from './SettingsPage'
-import { api, type DownloadClient, type Indexer, type ProwlarrInstance, type SystemStatus } from '../api/client'
+import { api, type DownloadClient, type Indexer, type OidcProvider, type ProwlarrInstance, type RootFolder, type SystemStatus } from '../api/client'
 
-vi.mock('../settings/AuthSettings', () => ({ default: () => <div data-testid="auth-settings" /> }))
+const mockAuthContext = vi.hoisted(() => ({
+  status: {
+    authenticated: true,
+    setupRequired: false,
+    username: 'admin',
+    role: 'admin',
+    mode: 'enabled' as const,
+  },
+  loading: false,
+  isAdmin: true,
+  refresh: vi.fn(),
+  logout: vi.fn(),
+}))
+
 vi.mock('../components/ThemeToggle', () => ({ default: () => <button type="button">Theme</button> }))
 vi.mock('../components/LanguageSwitcher', () => ({ default: () => <select aria-label="Language" /> }))
 vi.mock('../auth/AuthContext', () => ({
-  useAuth: () => ({ isAdmin: true }),
+  useAuth: () => mockAuthContext,
 }))
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -52,7 +65,17 @@ vi.mock('../api/client', async importOriginal => {
       status: vi.fn(),
       setSetting: vi.fn(),
       testHardcover: vi.fn(),
+      triggerLibraryScan: vi.fn(),
+      createBackup: vi.fn(),
+      addRootFolder: vi.fn(),
       authConfig: vi.fn(),
+      authSetMode: vi.fn(),
+      authRegenerateApiKey: vi.fn(),
+      authChangePassword: vi.fn(),
+      oidcProviders: vi.fn(),
+      oidcSetProviders: vi.fn(),
+      oidcRedirectBase: vi.fn(),
+      oidcTestDiscovery: vi.fn(),
     },
   }
 })
@@ -109,11 +132,24 @@ function makeClient(overrides: Partial<DownloadClient> = {}): DownloadClient {
   }
 }
 
+function makeRootFolder(overrides: Partial<RootFolder> = {}): RootFolder {
+  return {
+    id: 1,
+    path: '/books',
+    freeSpace: 1024,
+    createdAt: '2026-05-06T12:00:00Z',
+    ...overrides,
+  }
+}
+
 function seedSettingsMocks(options: {
   indexers?: Indexer[]
   clients?: DownloadClient[]
   prowlarr?: ProwlarrInstance[]
   status?: SystemStatus
+  settings?: Array<{ key: string; value: string }>
+  rootFolders?: RootFolder[]
+  oidcProviders?: OidcProvider[]
 } = {}) {
   vi.mocked(api.listIndexers).mockResolvedValue(options.indexers ?? [])
   vi.mocked(api.addIndexer).mockImplementation(async data => makeIndexer({ id: 100, ...data }))
@@ -141,13 +177,16 @@ function seedSettingsMocks(options: {
     vi.mocked(api.absImportRuns).mockResolvedValue([])
     vi.mocked(api.absReviewItems).mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 })
     vi.mocked(api.absConflicts).mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 })
-    vi.mocked(api.listSettings).mockResolvedValue([{ key: 'hardcover.enhanced_series_enabled', value: 'false' }])
+    vi.mocked(api.listSettings).mockResolvedValue(options.settings ?? [{ key: 'hardcover.enhanced_series_enabled', value: 'false' }])
     vi.mocked(api.listBackups).mockResolvedValue([])
     vi.mocked(api.libraryScanStatus).mockRejectedValue(new Error('no scan'))
     vi.mocked(api.getStorage).mockResolvedValue({ downloadDir: '/downloads', audiobookDownloadDir: '', libraryDir: '/books', audiobookDir: '' })
-    vi.mocked(api.listRootFolders).mockResolvedValue([])
+    vi.mocked(api.listRootFolders).mockResolvedValue(options.rootFolders ?? [])
     vi.mocked(api.status).mockResolvedValue(options.status ?? defaultStatus)
     vi.mocked(api.setSetting).mockResolvedValue(undefined)
+    vi.mocked(api.triggerLibraryScan).mockResolvedValue({ message: 'started' })
+    vi.mocked(api.createBackup).mockResolvedValue({ filename: 'bindery-backup.zip' })
+    vi.mocked(api.addRootFolder).mockImplementation(async path => makeRootFolder({ id: 99, path }))
     vi.mocked(api.testHardcover).mockResolvedValue({
       ok: true,
       tokenConfigured: true,
@@ -158,7 +197,22 @@ function seedSettingsMocks(options: {
       catalogBookCount: 8,
       message: 'Found 2 series; catalog "Dune" has 8 books',
     })
-    vi.mocked(api.authConfig).mockResolvedValue({ mode: 'disabled', apiKey: 'key', username: 'admin' })
+    vi.mocked(api.authConfig).mockResolvedValue({ mode: 'enabled', apiKey: 'key', username: 'admin' })
+    vi.mocked(api.authSetMode).mockResolvedValue({ mode: 'enabled' })
+    vi.mocked(api.authRegenerateApiKey).mockResolvedValue({ apiKey: 'rotated-key' })
+    vi.mocked(api.authChangePassword).mockResolvedValue({ ok: true })
+    vi.mocked(api.oidcProviders).mockResolvedValue(options.oidcProviders ?? [])
+    vi.mocked(api.oidcSetProviders).mockResolvedValue(undefined)
+    vi.mocked(api.oidcRedirectBase).mockResolvedValue({ base: 'http://localhost', callback_path: '/api/v1/auth/oidc/{id}/callback' })
+    vi.mocked(api.oidcTestDiscovery).mockResolvedValue({
+      ok: true,
+      discovered: {
+        issuer: 'https://accounts.example.com',
+        authorization_endpoint: 'https://accounts.example.com/auth',
+        token_endpoint: 'https://accounts.example.com/token',
+        scopes_supported: ['openid', 'email', 'profile'],
+      },
+    })
 }
 
 function renderSettings(options?: Parameters<typeof seedSettingsMocks>[0]) {
@@ -174,9 +228,29 @@ async function openClientsTab() {
   fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.clients' }))
 }
 
+function sectionForHeading(name: string) {
+  const heading = screen.getByRole('heading', { name })
+  const section = heading.closest('section')
+  if (!section) throw new Error(`No section found for heading: ${name}`)
+  return within(section as HTMLElement)
+}
+
 describe('SettingsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAuthContext.status = {
+      authenticated: true,
+      setupRequired: false,
+      username: 'admin',
+      role: 'admin',
+      mode: 'enabled',
+    }
+    mockAuthContext.loading = false
+    mockAuthContext.isAdmin = true
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    })
     seedSettingsMocks()
   })
 
@@ -223,6 +297,294 @@ describe('SettingsPage', () => {
     })
     expect(await screen.findByText('Found 2 series; catalog "Dune" has 8 books')).toBeInTheDocument()
     expect(screen.queryByText('hc-secret')).not.toBeInTheDocument()
+  })
+
+  it('persists import mode, naming templates, and preferred language', async () => {
+    renderSettings({
+      settings: [
+        { key: 'import.mode', value: 'move' },
+        { key: 'naming.bookTemplate', value: '{OldBook}' },
+        { key: 'naming_template_audiobook', value: '{OldAudio}' },
+        { key: 'search.preferredLanguage', value: 'en' },
+        { key: 'hardcover.enhanced_series_enabled', value: 'false' },
+      ],
+    })
+
+    expect(await screen.findByText('Import Mode')).toBeInTheDocument()
+    const fileNaming = sectionForHeading('settings.general.fileNaming')
+
+    fireEvent.click(fileNaming.getByRole('button', { name: 'Copy' }))
+    await waitFor(() => expect(api.setSetting).toHaveBeenCalledWith('import.mode', 'copy'))
+
+    fireEvent.change(fileNaming.getByPlaceholderText('{Author}/{Title} ({Year})/{Title} - {Author}.{ext}'), {
+      target: { value: '{Author}/{Title}/{Title}.{ext}' },
+    })
+    fireEvent.click(fileNaming.getAllByRole('button', { name: 'common.save' })[0])
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('naming.bookTemplate', '{Author}/{Title}/{Title}.{ext}')
+    })
+
+    fireEvent.change(fileNaming.getByPlaceholderText('{Author}/{Title} ({Year})'), {
+      target: { value: '{Author}/{Title}' },
+    })
+    fireEvent.click(fileNaming.getAllByRole('button', { name: 'common.save' })[1])
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('naming_template_audiobook', '{Author}/{Title}')
+    })
+
+    const downloads = sectionForHeading('settings.general.downloads')
+    fireEvent.change(downloads.getByRole('combobox'), { target: { value: 'any' } })
+    fireEvent.click(downloads.getByRole('button', { name: 'common.save' }))
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('search.preferredLanguage', 'any')
+    })
+  })
+
+  it('refreshes library scan status', async () => {
+    vi.mocked(api.libraryScanStatus)
+      .mockResolvedValueOnce({ ran_at: new Date(Date.now() - 10_000).toISOString(), files_found: 2, reconciled: 1, unmatched: 1 })
+      .mockResolvedValueOnce({ ran_at: new Date(Date.now() + 10_000).toISOString(), files_found: 9, reconciled: 5, unmatched: 4 })
+
+    renderSettings()
+
+    expect(await screen.findByText('settings.general.lastScan')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+
+    const library = sectionForHeading('settings.general.library')
+    fireEvent.click(library.getByRole('button', { name: 'settings.general.scanLibraryButton' }))
+
+    await waitFor(() => expect(api.triggerLibraryScan).toHaveBeenCalled())
+    await waitFor(() => expect(api.libraryScanStatus).toHaveBeenCalledTimes(2), { timeout: 2500 })
+    expect(await screen.findByText('9', {}, { timeout: 2500 })).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
+  })
+
+  it('persists default root folder and media type choices', async () => {
+    const existing = makeRootFolder({ id: 7, path: '/mnt/books' })
+    const added = makeRootFolder({ id: 8, path: '/mnt/audiobooks' })
+
+    renderSettings({
+      rootFolders: [existing],
+      settings: [
+        { key: 'library.defaultRootFolderId', value: '' },
+        { key: 'default.media_type', value: 'ebook' },
+        { key: 'hardcover.enhanced_series_enabled', value: 'false' },
+      ],
+    })
+    vi.mocked(api.addRootFolder).mockResolvedValue(added)
+
+    await screen.findByRole('heading', { name: 'Default library location' })
+    const defaultLocation = sectionForHeading('Default library location')
+
+    fireEvent.change(defaultLocation.getByRole('combobox'), { target: { value: '7' } })
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('library.defaultRootFolderId', '7')
+    })
+
+    fireEvent.click(defaultLocation.getByRole('button', { name: '+ Add root folder' }))
+    fireEvent.change(defaultLocation.getByPlaceholderText('/mnt/books'), { target: { value: ' /mnt/audiobooks ' } })
+    fireEvent.click(defaultLocation.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(api.addRootFolder).toHaveBeenCalledWith('/mnt/audiobooks'))
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('library.defaultRootFolderId', '8')
+    })
+    expect(defaultLocation.getByRole('combobox')).toHaveValue('8')
+
+    const authorDefaults = sectionForHeading('Author defaults')
+    fireEvent.change(authorDefaults.getByRole('combobox'), { target: { value: 'audiobook' } })
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('default.media_type', 'audiobook')
+    })
+  })
+
+  it('persists auto-grab and recommendations toggles', async () => {
+    renderSettings({
+      settings: [
+        { key: 'autoGrab.enabled', value: 'true' },
+        { key: 'recommendations.enabled', value: 'false' },
+        { key: 'hardcover.enhanced_series_enabled', value: 'false' },
+      ],
+    })
+
+    await screen.findByRole('heading', { name: 'settings.general.autoGrab' })
+
+    fireEvent.click(sectionForHeading('settings.general.autoGrab').getByTitle('common.disable'))
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('autoGrab.enabled', 'false')
+    })
+
+    fireEvent.click(sectionForHeading('settings.general.recommendations').getByTitle('common.enable'))
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('recommendations.enabled', 'true')
+    })
+  })
+
+  it('persists authentication mode changes and refreshes auth status', async () => {
+    vi.mocked(api.authConfig)
+      .mockResolvedValueOnce({ mode: 'enabled', apiKey: 'api-secret', username: 'admin' })
+      .mockResolvedValue({ mode: 'local-only', apiKey: 'api-secret', username: 'admin' })
+    vi.mocked(api.authSetMode).mockResolvedValue({ mode: 'local-only' })
+
+    renderSettings()
+
+    await screen.findByRole('heading', { name: 'Security' })
+    fireEvent.change(sectionForHeading('Security').getByRole('combobox'), { target: { value: 'local-only' } })
+
+    await waitFor(() => expect(api.authSetMode).toHaveBeenCalledWith('local-only'))
+    expect(mockAuthContext.refresh).toHaveBeenCalled()
+    await waitFor(() => expect(api.authConfig).toHaveBeenCalledTimes(2))
+  })
+
+  it('shows, copies, and regenerates the security API key', async () => {
+    vi.mocked(api.authConfig).mockResolvedValue({ mode: 'enabled', apiKey: 'api-secret', username: 'admin' })
+    vi.mocked(api.authRegenerateApiKey).mockResolvedValue({ apiKey: 'rotated-secret' })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    try {
+      renderSettings()
+
+      await screen.findByRole('heading', { name: 'Security' })
+      const security = sectionForHeading('Security')
+      expect(security.queryByText('api-secret')).not.toBeInTheDocument()
+
+      fireEvent.click(security.getByRole('button', { name: 'Show' }))
+      expect(security.getByText('api-secret')).toBeInTheDocument()
+      fireEvent.click(security.getByRole('button', { name: 'Hide' }))
+      expect(security.queryByText('api-secret')).not.toBeInTheDocument()
+
+      fireEvent.click(security.getByRole('button', { name: 'Copy' }))
+      await waitFor(() => {
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('api-secret')
+      })
+      expect(await security.findByRole('button', { name: 'Copied' })).toBeInTheDocument()
+
+      fireEvent.click(security.getByRole('button', { name: 'Regenerate' }))
+      await waitFor(() => expect(api.authRegenerateApiKey).toHaveBeenCalled())
+      expect(confirmSpy).toHaveBeenCalledWith('Regenerate the API key? Existing integrations using the old key will stop working.')
+      expect(await security.findByText('rotated-secret')).toBeInTheDocument()
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+
+  it('validates and submits password changes', async () => {
+    renderSettings()
+
+    await screen.findByRole('heading', { name: 'Security' })
+    const security = sectionForHeading('Security')
+    const current = security.getByPlaceholderText('Current password')
+    const next = security.getByPlaceholderText('New password')
+    const confirm = security.getByPlaceholderText('Confirm new password')
+    const submit = security.getByRole('button', { name: 'Change password' })
+
+    fireEvent.change(current, { target: { value: 'old-password' } })
+    fireEvent.change(next, { target: { value: 'long-enough' } })
+    fireEvent.change(confirm, { target: { value: 'different' } })
+    fireEvent.click(submit)
+
+    expect(await security.findByText('New passwords do not match')).toBeInTheDocument()
+    expect(api.authChangePassword).not.toHaveBeenCalled()
+
+    fireEvent.change(next, { target: { value: 'short' } })
+    fireEvent.change(confirm, { target: { value: 'short' } })
+    fireEvent.click(submit)
+
+    expect(await security.findByText('Password must be at least 8 characters')).toBeInTheDocument()
+    expect(api.authChangePassword).not.toHaveBeenCalled()
+
+    fireEvent.change(next, { target: { value: 'long-enough' } })
+    fireEvent.change(confirm, { target: { value: 'long-enough' } })
+    fireEvent.click(submit)
+
+    await waitFor(() => {
+      expect(api.authChangePassword).toHaveBeenCalledWith('old-password', 'long-enough')
+    })
+    expect(await security.findByText('Password updated')).toBeInTheDocument()
+    expect(current).toHaveValue('')
+    expect(next).toHaveValue('')
+    expect(confirm).toHaveValue('')
+  })
+
+  it('renders OIDC empty state and adds a provider with callback preview', async () => {
+    vi.mocked(api.oidcRedirectBase).mockResolvedValue({
+      base: 'https://bindery.example.com',
+      callback_path: '/api/v1/auth/oidc/{id}/callback',
+    })
+
+    renderSettings()
+
+    expect(await screen.findByText('settings.oidc.empty')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'settings.oidc.addButton' }))
+
+    const form = screen.getByText('settings.oidc.addHeading').closest('form')
+    if (!form) throw new Error('OIDC add form not found')
+    const oidcForm = within(form)
+    const inputs = Array.from(form.querySelectorAll('input')) as HTMLInputElement[]
+
+    fireEvent.change(oidcForm.getByPlaceholderText('google'), { target: { value: ' okta ' } })
+    fireEvent.change(oidcForm.getByPlaceholderText('Google'), { target: { value: ' Okta ' } })
+    expect(await screen.findByText('https://bindery.example.com/api/v1/auth/oidc/okta/callback')).toBeInTheDocument()
+    fireEvent.change(oidcForm.getByPlaceholderText('https://accounts.google.com'), {
+      target: { value: ' https://issuer.example.com ' },
+    })
+    fireEvent.change(inputs[3], { target: { value: ' client-id ' } })
+    fireEvent.change(inputs[4], { target: { value: ' client-secret ' } })
+    fireEvent.change(inputs[5], { target: { value: 'openid email profile groups' } })
+
+    const add = oidcForm.getByRole('button', { name: 'settings.oidc.addSave' })
+    expect(add).toBeEnabled()
+    fireEvent.click(add)
+
+    await waitFor(() => {
+      expect(api.oidcSetProviders).toHaveBeenCalledWith([
+        {
+          id: 'okta',
+          name: 'Okta',
+          issuer: 'https://issuer.example.com',
+          client_id: 'client-id',
+          client_secret: 'client-secret',
+          scopes: ['openid', 'email', 'profile', 'groups'],
+        },
+      ])
+    })
+  })
+
+  it('persists external API key controls without exposing stored Hardcover secrets', async () => {
+    renderSettings({
+      status: {
+        version: 'dev',
+        commit: 'unknown',
+        buildDate: '',
+        enhancedHardcoverApi: false,
+        hardcoverTokenConfigured: true,
+        enhancedHardcoverDisabledReason: 'admin_disabled',
+      },
+      settings: [
+        { key: 'googlebooks.apiKey', value: '' },
+        { key: 'hardcover.enhanced_series_enabled', value: 'false' },
+      ],
+    })
+
+    await screen.findByRole('heading', { name: 'settings.general.apiKeys' })
+    const apiKeys = sectionForHeading('settings.general.apiKeys')
+
+    fireEvent.change(apiKeys.getByPlaceholderText('AIza...'), { target: { value: 'AIza-test-key' } })
+    fireEvent.click(apiKeys.getByRole('button', { name: 'common.save' }))
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('googlebooks.apiKey', 'AIza-test-key')
+    })
+
+    expect(apiKeys.getByText('Token configured')).toBeInTheDocument()
+    expect(apiKeys.getByPlaceholderText('Saved token is hidden. Enter a new token to rotate it.')).toHaveValue('')
+    expect(apiKeys.queryByText('stored-hc-secret')).not.toBeInTheDocument()
+    expect(apiKeys.getByRole('button', { name: 'Save Hardcover API token' })).toBeDisabled()
+
+    fireEvent.click(apiKeys.getByRole('button', { name: 'Clear Hardcover API token' }))
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('hardcover.api_token', '')
+    })
   })
 
   it('requires saved Audiobookshelf settings before starting an import', async () => {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -203,7 +203,7 @@ function seedSettingsMocks(options: {
     vi.mocked(api.authChangePassword).mockResolvedValue({ ok: true })
     vi.mocked(api.oidcProviders).mockResolvedValue(options.oidcProviders ?? [])
     vi.mocked(api.oidcSetProviders).mockResolvedValue(undefined)
-    vi.mocked(api.oidcRedirectBase).mockResolvedValue({ base: 'http://localhost', callback_path: '/api/v1/auth/oidc/{id}/callback' })
+    vi.mocked(api.oidcRedirectBase).mockResolvedValue({ base: 'http://localhost', callback_path: '/api/v1/auth/oidc/{id}/callback', configured: true })
     vi.mocked(api.oidcTestDiscovery).mockResolvedValue({
       ok: true,
       discovered: {
@@ -512,6 +512,7 @@ describe('SettingsPage', () => {
     vi.mocked(api.oidcRedirectBase).mockResolvedValue({
       base: 'https://bindery.example.com',
       callback_path: '/api/v1/auth/oidc/{id}/callback',
+      configured: true,
     })
 
     renderSettings()

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -185,7 +185,7 @@ function seedSettingsMocks(options: {
     vi.mocked(api.status).mockResolvedValue(options.status ?? defaultStatus)
     vi.mocked(api.setSetting).mockResolvedValue(undefined)
     vi.mocked(api.triggerLibraryScan).mockResolvedValue({ message: 'started' })
-    vi.mocked(api.createBackup).mockResolvedValue({ filename: 'bindery-backup.zip' })
+    vi.mocked(api.createBackup).mockResolvedValue({ name: 'bindery-backup.zip', size: 0, modTime: '' })
     vi.mocked(api.addRootFolder).mockImplementation(async path => makeRootFolder({ id: 99, path }))
     vi.mocked(api.testHardcover).mockResolvedValue({
       ok: true,

--- a/web/src/pages/WantedPage.test.tsx
+++ b/web/src/pages/WantedPage.test.tsx
@@ -1,0 +1,311 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import WantedPage from './WantedPage'
+import { api } from '../api/client'
+import type { Author, Book, Download, SearchResult } from '../api/client'
+
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listWanted: vi.fn(),
+      searchBook: vi.fn(),
+      grab: vi.fn(),
+      updateBook: vi.fn(),
+      bulkActionWanted: vi.fn(),
+    },
+  }
+})
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (key === 'wanted.countLabel') return `${String(options?.filtered)} of ${String(options?.total)}`
+      if (key === 'wanted.selectBook') return `Select ${String(options?.title)}`
+      if (key === 'bulkActionBar.selected') return `${String(options?.count)} selected`
+
+      const labels: Record<string, string> = {
+        'wanted.title': 'Wanted',
+        'wanted.searchPlaceholder': 'Search by title or author...',
+        'wanted.empty': 'No wanted books. Add an author to start tracking.',
+        'wanted.noMatch': 'No books match your search.',
+        'wanted.showExcluded': 'Show excluded',
+        'wanted.searching': 'Searching...',
+        'wanted.noIndexerResults': 'No results found on any indexer.',
+        'wanted.ebookNeeded': '📖 needed',
+        'wanted.audiobookNeeded': '🎧 needed',
+        'wanted.ebookDone': '📖 ✓',
+        'wanted.audiobookDone': '🎧 ✓',
+        'wanted.unmonitorHint': 'Stop monitoring this book',
+        'wanted.excluded': 'Excluded',
+        'wanted.grab': 'Grab',
+        'wanted.grabbing': 'Grabbing…',
+        'wanted.grabbed': '✓ Grabbed',
+        'common.loading': 'Loading...',
+        'common.search': 'Search',
+        'common.unmonitor': 'Unmonitor',
+        'common.blocklist': 'Blocklist',
+        'common.selectAllPage': 'Select all on this page',
+        'books.mediaEbook': '📖 Ebook',
+        'books.mediaAudiobook': '🎧 Audiobook',
+        'books.mediaBoth': '📖🎧 Both',
+        'bulkActionBar.clear': 'Clear',
+      }
+      return labels[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('../components/usePagination', () => ({
+  usePagination: <T,>(items: T[]) => ({
+    pageItems: items,
+    paginationProps: {
+      page: 1,
+      totalPages: 1,
+      pageSize: 50,
+      totalItems: items.length,
+      onPageChange: vi.fn(),
+      onPageSizeChange: vi.fn(),
+    },
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('../components/Pagination', () => ({ default: () => null }))
+
+const author: Author = {
+  id: 20,
+  foreignAuthorId: 'author-20',
+  authorName: 'Frank Herbert',
+  sortName: 'Herbert, Frank',
+  description: '',
+  imageUrl: '',
+  disambiguation: '',
+  ratingsCount: 0,
+  averageRating: 0,
+  monitored: true,
+}
+
+function makeBook(overrides: Partial<Book> & Pick<Book, 'id' | 'title'>): Book {
+  const { id, title, ...rest } = overrides
+  return {
+    id,
+    foreignBookId: `book-${id}`,
+    authorId: author.id,
+    title,
+    description: '',
+    imageUrl: '',
+    releaseDate: undefined,
+    genres: [],
+    monitored: true,
+    status: 'wanted',
+    filePath: '',
+    mediaType: 'ebook',
+    ebookFilePath: '',
+    audiobookFilePath: '',
+    excluded: false,
+    author,
+    ...rest,
+  }
+}
+
+function makeResult({ guid, title, ...rest }: Partial<SearchResult> & { guid: string; title: string }): SearchResult {
+  return {
+    guid,
+    title,
+    indexerName: 'Wanted Indexer',
+    size: 1572864,
+    nzbUrl: 'https://indexer.example.com/release.nzb',
+    grabs: 12,
+    pubDate: '2026-05-01',
+    protocol: 'usenet',
+    ...rest,
+  }
+}
+
+function makeDownload(overrides: Partial<Download> = {}): Download {
+  return {
+    id: 44,
+    guid: 'download-guid',
+    title: 'Queued release',
+    status: 'queued',
+    size: 1572864,
+    protocol: 'usenet',
+    errorMessage: '',
+    ...overrides,
+  }
+}
+
+function renderWantedPage() {
+  return render(
+    <MemoryRouter>
+      <WantedPage />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  document.title = 'Bindery'
+  vi.mocked(api.listWanted).mockResolvedValue([])
+  vi.mocked(api.searchBook).mockResolvedValue({ results: [], debug: null })
+  vi.mocked(api.grab).mockResolvedValue(makeDownload())
+  vi.mocked(api.updateBook).mockImplementation(async (id, patch) => makeBook({ id, title: 'Updated Book', ...patch }))
+  vi.mocked(api.bulkActionWanted).mockResolvedValue({ results: {} })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('WantedPage', () => {
+  it('renders the empty wanted list state', async () => {
+    renderWantedPage()
+
+    expect(await screen.findByText('No wanted books. Add an author to start tracking.')).toBeInTheDocument()
+    expect(screen.getByText('0 of 0')).toBeInTheDocument()
+    expect(api.listWanted).toHaveBeenCalledWith({ includeExcluded: false })
+  })
+
+  it('searches a wanted book and renders result metadata', async () => {
+    const book = makeBook({ id: 1, title: 'Dune' })
+    vi.mocked(api.listWanted).mockResolvedValue([book])
+    vi.mocked(api.searchBook).mockResolvedValue({
+      results: [
+        makeResult({
+          guid: 'dune-release',
+          title: 'Dune 2026 EPUB',
+          indexerName: 'Arrakis Indexer',
+          language: 'en',
+        }),
+      ],
+      debug: null,
+    })
+
+    renderWantedPage()
+
+    await screen.findByRole('link', { name: 'Dune' })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+    await waitFor(() => expect(api.searchBook).toHaveBeenCalledWith(1))
+    expect(await screen.findByText('Dune 2026 EPUB')).toBeInTheDocument()
+    expect(screen.getByText(/Arrakis Indexer/)).toBeInTheDocument()
+    expect(screen.getByText(/1.5 MB/)).toBeInTheDocument()
+    expect(screen.getByText(/12 grabs/)).toBeInTheDocument()
+    expect(screen.getByText('en')).toBeInTheDocument()
+  })
+
+  it('renders the no-results message after an empty search', async () => {
+    vi.mocked(api.listWanted).mockResolvedValue([makeBook({ id: 1, title: 'Dune' })])
+    vi.mocked(api.searchBook).mockResolvedValue({ results: [], debug: null })
+
+    renderWantedPage()
+
+    await screen.findByRole('link', { name: 'Dune' })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+
+    expect(await screen.findByText('No results found on any indexer.')).toBeInTheDocument()
+  })
+
+  it('grabs a result, shows transient states, and refreshes wanted books', async () => {
+    const book = makeBook({ id: 1, title: 'Dune' })
+    let resolveGrab: (download: Download) => void = () => {}
+    vi.mocked(api.listWanted)
+      .mockResolvedValueOnce([book])
+      .mockResolvedValueOnce([])
+    vi.mocked(api.searchBook).mockResolvedValue({
+      results: [
+        makeResult({
+          guid: 'dune-release',
+          title: 'Dune 2026 EPUB',
+          nzbUrl: 'https://indexer.example.com/dune.nzb',
+        }),
+      ],
+      debug: null,
+    })
+    vi.mocked(api.grab).mockImplementation(() => new Promise(resolve => { resolveGrab = resolve }))
+
+    renderWantedPage()
+
+    await screen.findByRole('link', { name: 'Dune' })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Grab' }))
+
+    expect(screen.getByRole('button', { name: 'Grabbing…' })).toBeDisabled()
+    expect(api.grab).toHaveBeenCalledWith({
+      guid: 'dune-release',
+      title: 'Dune 2026 EPUB',
+      nzbUrl: 'https://indexer.example.com/dune.nzb',
+      size: 1572864,
+      bookId: 1,
+      protocol: 'usenet',
+      mediaType: 'ebook',
+    })
+
+    vi.useFakeTimers()
+    await act(async () => {
+      resolveGrab(makeDownload({ guid: 'dune-release', title: 'Dune 2026 EPUB' }))
+    })
+
+    expect(screen.getByRole('button', { name: '✓ Grabbed' })).toBeDisabled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(1200)
+      await Promise.resolve()
+    })
+
+    expect(api.listWanted).toHaveBeenCalledTimes(2)
+    expect(screen.queryByText('Dune 2026 EPUB')).not.toBeInTheDocument()
+    expect(screen.getByText('No wanted books. Add an author to start tracking.')).toBeInTheDocument()
+  })
+
+  it('unmonitors a single wanted book and removes it from the list', async () => {
+    const book = makeBook({ id: 1, title: 'Dune' })
+    let resolveUpdate: (book: Book) => void = () => {}
+    vi.mocked(api.listWanted).mockResolvedValue([book])
+    vi.mocked(api.updateBook).mockImplementation(() => new Promise(resolve => { resolveUpdate = resolve }))
+
+    renderWantedPage()
+
+    await screen.findByRole('link', { name: 'Dune' })
+    fireEvent.click(screen.getByRole('button', { name: 'Unmonitor' }))
+
+    expect(screen.getByRole('button', { name: '…' })).toBeDisabled()
+    expect(api.updateBook).toHaveBeenCalledWith(1, { monitored: false })
+
+    await act(async () => {
+      resolveUpdate({ ...book, monitored: false })
+    })
+
+    await waitFor(() => expect(screen.queryByRole('link', { name: 'Dune' })).not.toBeInTheDocument())
+    expect(screen.getByText('No wanted books. Add an author to start tracking.')).toBeInTheDocument()
+  })
+
+  it.each([
+    ['Search', 'search'],
+    ['Unmonitor', 'unmonitor'],
+    ['Blocklist', 'blocklist'],
+  ] as const)('runs the bulk %s action and refreshes the list', async (label, action) => {
+    vi.mocked(api.listWanted).mockResolvedValue([
+      makeBook({ id: 1, title: 'Dune' }),
+      makeBook({ id: 2, title: 'Hyperion' }),
+    ])
+
+    renderWantedPage()
+
+    await screen.findByRole('link', { name: 'Dune' })
+    fireEvent.click(screen.getByTitle('Select Dune'))
+    fireEvent.click(screen.getByTitle('Select Hyperion'))
+
+    const bulkBar = screen.getByText('2 selected').closest('div')
+    if (!bulkBar) throw new Error('Bulk action bar was not rendered')
+    fireEvent.click(within(bulkBar).getByRole('button', { name: label }))
+
+    await waitFor(() => expect(api.bulkActionWanted).toHaveBeenCalledWith([1, 2], action))
+    await waitFor(() => expect(api.listWanted).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText('2 selected')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/WantedPage.test.tsx
+++ b/web/src/pages/WantedPage.test.tsx
@@ -289,10 +289,19 @@ describe('WantedPage', () => {
     ['Unmonitor', 'unmonitor'],
     ['Blocklist', 'blocklist'],
   ] as const)('runs the bulk %s action and refreshes the list', async (label, action) => {
-    vi.mocked(api.listWanted).mockResolvedValue([
+    const initialBooks = [
       makeBook({ id: 1, title: 'Dune' }),
       makeBook({ id: 2, title: 'Hyperion' }),
-    ])
+    ]
+    const refreshedBooks = action === 'search'
+      ? [
+          makeBook({ id: 1, title: 'Dune Refreshed' }),
+          makeBook({ id: 2, title: 'Hyperion Refreshed' }),
+        ]
+      : []
+    vi.mocked(api.listWanted)
+      .mockResolvedValueOnce(initialBooks)
+      .mockResolvedValueOnce(refreshedBooks)
 
     renderWantedPage()
 
@@ -307,5 +316,13 @@ describe('WantedPage', () => {
     await waitFor(() => expect(api.bulkActionWanted).toHaveBeenCalledWith([1, 2], action))
     await waitFor(() => expect(api.listWanted).toHaveBeenCalledTimes(2))
     expect(screen.queryByText('2 selected')).not.toBeInTheDocument()
+    if (action === 'search') {
+      expect(await screen.findByRole('link', { name: 'Dune Refreshed' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Hyperion Refreshed' })).toBeInTheDocument()
+    } else {
+      expect(await screen.findByText('No wanted books. Add an author to start tracking.')).toBeInTheDocument()
+    }
+    expect(screen.queryByRole('link', { name: 'Dune' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Hyperion' })).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/WantedPage.test.tsx
+++ b/web/src/pages/WantedPage.test.tsx
@@ -135,6 +135,7 @@ function makeDownload(overrides: Partial<Download> = {}): Download {
     size: 1572864,
     protocol: 'usenet',
     errorMessage: '',
+    addedAt: '2026-05-01T12:00:00Z',
     ...overrides,
   }
 }

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -1,1 +1,34 @@
 import '@testing-library/jest-dom'
+import { afterAll, afterEach, beforeAll } from 'vitest'
+import { server } from './test/msw'
+
+const originalFetch = globalThis.fetch
+let mswFetch = originalFetch
+
+function resolveRelativeApiURL(input: RequestInfo | URL): RequestInfo | URL {
+  if (typeof input === 'string' && input.startsWith('/api/')) {
+    return new URL(input, 'http://localhost').toString()
+  }
+  return input
+}
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' })
+  mswFetch = globalThis.fetch
+
+  const fetchWithRelativeApiURLs: typeof fetch = (input, init) =>
+    mswFetch(resolveRelativeApiURL(input), init)
+
+  globalThis.fetch = fetchWithRelativeApiURLs
+  Object.defineProperty(window, 'fetch', { value: fetchWithRelativeApiURLs, configurable: true })
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+  globalThis.fetch = originalFetch
+  Object.defineProperty(window, 'fetch', { value: originalFetch, configurable: true })
+})

--- a/web/src/test-utils.tsx
+++ b/web/src/test-utils.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement, ReactNode } from 'react'
+import type { RenderOptions } from '@testing-library/react'
+import type { AuthStatus } from './api/client'
+
+interface RenderWithRouterOptions extends Omit<RenderOptions, 'wrapper'> {
+  initialEntries?: string[]
+}
+
+export function renderWithRouter(
+  ui: ReactElement,
+  { initialEntries = ['/'], ...options }: RenderWithRouterOptions = {},
+) {
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+  }
+
+  return render(ui, { wrapper: Wrapper, ...options })
+}
+
+export function makeAuthStatus(overrides: Partial<AuthStatus> = {}): AuthStatus {
+  return {
+    authenticated: false,
+    setupRequired: false,
+    mode: 'enabled',
+    ...overrides,
+  }
+}

--- a/web/src/test/msw.ts
+++ b/web/src/test/msw.ts
@@ -1,0 +1,9 @@
+import { setupServer } from 'msw/node'
+
+const API_BASE = 'http://localhost/api/v1'
+
+export const server = setupServer()
+
+export function apiUrl(path: string): string {
+  return `${API_BASE}${path.startsWith('/') ? path : `/${path}`}`
+}


### PR DESCRIPTION
## Summary

- Add MSW-backed Vitest coverage for CSRF token handling, auth status hydration, auth guards, local login, and OIDC login links.
- Add Book Detail and Wanted page coverage for search, no-result states, grabs, list refreshes, and bulk wanted actions.
- Refs #427 by filling the auth, book-detail, and wanted-flow coverage gaps; settings-form and download-queue coverage remain for a follow-up PR.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (N/A - frontend test coverage only)
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] Wiki pages updated if user-facing behaviour changed (N/A - no user-facing behavior change)

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [x] `cd web && npm test`
- [x] `cd web && npm run lint` (passes with existing warnings)
- [x] `cd web && npm run typecheck`
- [x] `cd web && npm run build`
