### PR TITLE
fix(dedup): strip post-colon subtitle so editions with/without subtitle dedup correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Bindery are documented here. Format loosely follows
 ### Fixed
 
 - **Library file matching now respects media type** (#488, #454) — `FindExisting` now picks the right library root based on the book's `media_type` instead of always walking `BINDERY_LIBRARY_DIR` first. Audiobook book rows are matched against `BINDERY_AUDIOBOOK_DIR` (with fallback to `BINDERY_LIBRARY_DIR` when the audiobook root is unset), ebook rows are matched against `BINDERY_LIBRARY_DIR`, and dual-format / unspecified rows preserve the prior behaviour of walking both roots with the ebook library first. Previously a same-titled ebook in `libraryDir` could be mis-attributed to an audiobook entry on rescan, and authors filtered to "audiobooks only" still had file lookups walk the ebook root.
+- **Edition dedup now strips subtitles** (#458) — Author sync no longer creates duplicate rows when OpenLibrary returns the same work twice with different subtitle handling — typically the audiobook drops the post-colon subtitle while the ebook keeps it (e.g. *Carl's Doomsday Scenario* vs. *Carl's Doomsday Scenario: Dungeon Crawler Carl, Book 2*). `NormalizeTitleForDedup` now drops a `: subtitle` tail when the colon is followed by whitespace, so both editions collapse to the same key and the existing v1.3.1 dual-format upgrade path is taken instead of inserting a duplicate.
 
 ## [v1.4.3] — 2026-05-06
 

--- a/internal/indexer/dedup.go
+++ b/internal/indexer/dedup.go
@@ -21,14 +21,31 @@ import (
 //  2. newznab.NormalizeQueryTitle — folds smart quotes to ASCII, strips a
 //     trailing parenthesised edition qualifier ("(German Edition)" etc.),
 //     and collapses internal whitespace.
-//  3. strings.ToLower — case-insensitive match.
-//  4. transliterateUmlauts — maps ä→ae, ö→oe, ü→ue, ß→ss so that
+//  3. stripSubtitle — drops a ": subtitle" tail so editions that differ
+//     only in whether the subtitle is present (audiobooks often drop it)
+//     produce the same key.
+//  4. strings.ToLower — case-insensitive match.
+//  5. transliterateUmlauts — maps ä→ae, ö→oe, ü→ue, ß→ss so that
 //     "Geraeusch" from a release title compares equal to "Geräusch" from
 //     the metadata provider.
 func NormalizeTitleForDedup(title string) string {
 	title = norm.NFC.String(title)
 	title = newznab.NormalizeQueryTitle(title)
+	title = stripSubtitle(title)
 	title = strings.ToLower(title)
 	title = transliterateUmlauts(title)
+	return title
+}
+
+// stripSubtitle removes a trailing ": subtitle" segment when the colon is
+// followed by whitespace. Collapses editions that vary only in whether the
+// subtitle is present (e.g. audiobook drops it, ebook keeps it). Compact
+// titles like "foo:bar" with no whitespace after the colon are left intact.
+func stripSubtitle(title string) string {
+	for i := 0; i < len(title)-1; i++ {
+		if title[i] == ':' && (title[i+1] == ' ' || title[i+1] == '\t') {
+			return strings.TrimSpace(title[:i])
+		}
+	}
 	return title
 }

--- a/internal/indexer/dedup_test.go
+++ b/internal/indexer/dedup_test.go
@@ -59,6 +59,21 @@ func TestNormalizeTitleForDedup(t *testing.T) {
 			in:   "Die Stille ist ein Geraeusch",
 			want: "die stille ist ein geraeusch",
 		},
+		{
+			name: "post-colon subtitle stripped",
+			in:   "Carl's Doomsday Scenario: Dungeon Crawler Carl, Book 2",
+			want: "carl's doomsday scenario",
+		},
+		{
+			name: "title without colon unchanged",
+			in:   "Carl's Doomsday Scenario",
+			want: "carl's doomsday scenario",
+		},
+		{
+			name: "colon without trailing whitespace preserved",
+			in:   "foo:bar",
+			want: "foo:bar",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -78,6 +93,7 @@ func TestNormalizeTitleForDedup_Symmetric(t *testing.T) {
 		{"Dune (Unabridged)", "Dune"},
 		{"  Moby Dick  ", "Moby Dick"},
 		{"Öde Wälder (German Edition)", "Öde Wälder"},
+		{"Carl's Doomsday Scenario", "Carl's Doomsday Scenario: Dungeon Crawler Carl, Book 2"},
 	}
 	for _, pair := range pairs {
 		k1 := NormalizeTitleForDedup(pair[0])


### PR DESCRIPTION
## Summary

- Author sync was creating duplicate book rows when OpenLibrary returned the same work with different subtitle handling — typically the audiobook drops the post-colon subtitle while the ebook keeps it (the issue reporter's example: *Carl's Doomsday Scenario* vs. *Carl's Doomsday Scenario: Dungeon Crawler Carl, Book 2*).
- The v1.3.1 dual-format upgrade path (#448) already handles this correctly, but it only triggers when `NormalizeTitleForDedup` produces the same key for both editions. Without subtitle stripping, the two titles produced different keys.
- `NormalizeTitleForDedup` now drops a `: subtitle` tail when the colon is followed by whitespace. Compact titles like `foo:bar` are left intact, so this is conservative.

Closes #458

## Test plan

- [x] `go test ./internal/indexer/... ./internal/api/...` — passes
- [x] New unit tests cover the Carl's Doomsday case, no-colon titles unchanged, and `foo:bar` (no whitespace) preserved
- [x] Symmetric pair test verifies both edition forms collapse to the same dedup key

🤖 Generated with [Claude Code](https://claude.com/claude-code)