### PR TITLE
fix(scanner): FindExisting now respects media_type when choosing library roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Bindery are documented here. Format loosely follows
 [Semantic Versioning](https://semver.org).
 
 
+## [Unreleased]
+
+### Fixed
+
+- **Library file matching now respects media type** (#488, #454) — `FindExisting` now picks the right library root based on the book's `media_type` instead of always walking `BINDERY_LIBRARY_DIR` first. Audiobook book rows are matched against `BINDERY_AUDIOBOOK_DIR` (with fallback to `BINDERY_LIBRARY_DIR` when the audiobook root is unset), ebook rows are matched against `BINDERY_LIBRARY_DIR`, and dual-format / unspecified rows preserve the prior behaviour of walking both roots with the ebook library first. Previously a same-titled ebook in `libraryDir` could be mis-attributed to an audiobook entry on rescan, and authors filtered to "audiobooks only" still had file lookups walk the ebook root.
+
 ## [v1.4.3] — 2026-05-06
 
 ### Fixed

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -932,7 +932,7 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 
 		// Check if the user already owns this book before queuing a download.
 		if h.finder != nil {
-			if existingPath := h.finder.FindExisting(ctx, b.Title, author.Name); existingPath != "" {
+			if existingPath := h.finder.FindExisting(ctx, b.Title, author.Name, b.MediaType); existingPath != "" {
 				slog.Info("library: found existing file, skipping auto-search", "title", b.Title, "path", existingPath)
 				_ = h.books.SetFilePath(ctx, b.ID, existingPath)
 				continue // don't auto-search for a book we already have

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -346,7 +346,7 @@ type stubLibraryFinder struct {
 	ownedPath  string
 }
 
-func (f *stubLibraryFinder) FindExisting(_ context.Context, title, _ string) string {
+func (f *stubLibraryFinder) FindExisting(_ context.Context, title, _, _ string) string {
 	if title == f.ownedTitle {
 		return f.ownedPath
 	}

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -18,9 +18,12 @@ type BookSearcher interface {
 }
 
 // LibraryFinder checks whether a book already exists in the local library.
-// Implemented by *importer.Scanner; a nil implementation is a no-op.
+// Implemented by *importer.Scanner; a nil implementation is a no-op. The
+// mediaType argument selects which library roots are searched (ebook vs
+// audiobook vs both) so a same-titled file in the wrong root cannot be
+// mis-attributed to a book of the opposite media type.
 type LibraryFinder interface {
-	FindExisting(ctx context.Context, title, authorName string) string
+	FindExisting(ctx context.Context, title, authorName, mediaType string) string
 }
 
 func contextBackground() context.Context {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -779,20 +779,37 @@ func detectDownloadFormat(files []string) string {
 }
 
 // FindExisting searches the library directories for a book file that matches
-// the given title and author. Both libraryDir (ebooks) and audiobookDir are
-// searched. Returns the first matching file path, or "" if none is found.
-// Intended to be called before auto-searching so books the user already owns
-// are not re-downloaded.
-func (s *Scanner) FindExisting(ctx context.Context, title, authorName string) string {
+// the given title and author. The mediaType argument selects which roots are
+// walked: MediaTypeEbook restricts to libraryDir, MediaTypeAudiobook restricts
+// to audiobookDir (falling back to libraryDir when audiobookDir is unset), and
+// MediaTypeBoth or an empty/unknown value walks both with libraryDir first.
+// Returns the first matching file path, or "" if none is found. Intended to be
+// called before auto-searching so books the user already owns are not
+// re-downloaded.
+func (s *Scanner) FindExisting(ctx context.Context, title, authorName, mediaType string) string {
 	if title == "" {
 		return ""
 	}
 	roots := make([]string, 0, 2)
-	if s.libraryDir != "" {
-		roots = append(roots, s.libraryDir)
-	}
-	if s.audiobookDir != "" && s.audiobookDir != s.libraryDir {
-		roots = append(roots, s.audiobookDir)
+	switch mediaType {
+	case models.MediaTypeEbook:
+		if s.libraryDir != "" {
+			roots = append(roots, s.libraryDir)
+		}
+	case models.MediaTypeAudiobook:
+		switch {
+		case s.audiobookDir != "":
+			roots = append(roots, s.audiobookDir)
+		case s.libraryDir != "":
+			roots = append(roots, s.libraryDir)
+		}
+	default:
+		if s.libraryDir != "" {
+			roots = append(roots, s.libraryDir)
+		}
+		if s.audiobookDir != "" && s.audiobookDir != s.libraryDir {
+			roots = append(roots, s.audiobookDir)
+		}
 	}
 	for _, root := range roots {
 		if found := s.findExistingInDir(root, title, authorName); found != "" {

--- a/internal/importer/scanner_findexisting_test.go
+++ b/internal/importer/scanner_findexisting_test.go
@@ -1,0 +1,113 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// findExistingFixture builds a Scanner with separate libraryDir / audiobookDir
+// and seeds each one with a same-titled file under the same author folder so
+// FindExisting must use the media-type hint to pick the right root.
+func findExistingFixture(t *testing.T, libraryDir, audiobookDir string) *Scanner {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return NewScanner(
+		db.NewDownloadRepo(database),
+		db.NewDownloadClientRepo(database),
+		db.NewBookRepo(database),
+		db.NewAuthorRepo(database),
+		db.NewHistoryRepo(database),
+		libraryDir, audiobookDir, "", "", "",
+	)
+}
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestFindExisting_EbookPicksLibraryRoot covers the symmetric half of #488: an
+// ebook entry with same-titled files in BOTH roots returns the libraryDir hit.
+func TestFindExisting_EbookPicksLibraryRoot(t *testing.T) {
+	libDir := t.TempDir()
+	abDir := t.TempDir()
+	ebookPath := filepath.Join(libDir, "Jane Doe", "Title - Jane Doe.epub")
+	audioPath := filepath.Join(abDir, "Jane Doe", "Title - Jane Doe.m4b")
+	writeFile(t, ebookPath)
+	writeFile(t, audioPath)
+
+	s := findExistingFixture(t, libDir, abDir)
+	got := s.FindExisting(context.Background(), "Title", "Jane Doe", models.MediaTypeEbook)
+	if got != ebookPath {
+		t.Errorf("ebook lookup: got %q, want %q", got, ebookPath)
+	}
+}
+
+// TestFindExisting_AudiobookPicksAudiobookRoot is the #488 case: an audiobook
+// book row must NOT be matched against a same-titled ebook in libraryDir.
+func TestFindExisting_AudiobookPicksAudiobookRoot(t *testing.T) {
+	libDir := t.TempDir()
+	abDir := t.TempDir()
+	ebookPath := filepath.Join(libDir, "Jane Doe", "Title - Jane Doe.epub")
+	audioPath := filepath.Join(abDir, "Jane Doe", "Title - Jane Doe.m4b")
+	writeFile(t, ebookPath)
+	writeFile(t, audioPath)
+
+	s := findExistingFixture(t, libDir, abDir)
+	got := s.FindExisting(context.Background(), "Title", "Jane Doe", models.MediaTypeAudiobook)
+	if got != audioPath {
+		t.Errorf("audiobook lookup: got %q, want %q", got, audioPath)
+	}
+}
+
+// TestFindExisting_BothWalksAllRoots preserves the pre-fix behaviour for
+// dual-format and unspecified entries: libraryDir is walked first, so an
+// ebook in libraryDir wins over an audiobook in audiobookDir.
+func TestFindExisting_BothWalksAllRoots(t *testing.T) {
+	libDir := t.TempDir()
+	abDir := t.TempDir()
+	ebookPath := filepath.Join(libDir, "Jane Doe", "Title - Jane Doe.epub")
+	audioPath := filepath.Join(abDir, "Jane Doe", "Title - Jane Doe.m4b")
+	writeFile(t, ebookPath)
+	writeFile(t, audioPath)
+
+	s := findExistingFixture(t, libDir, abDir)
+	got := s.FindExisting(context.Background(), "Title", "Jane Doe", models.MediaTypeBoth)
+	if got != ebookPath {
+		t.Errorf("both lookup: got %q, want %q", got, ebookPath)
+	}
+
+	gotEmpty := s.FindExisting(context.Background(), "Title", "Jane Doe", "")
+	if gotEmpty != ebookPath {
+		t.Errorf("empty media-type lookup: got %q, want %q", gotEmpty, ebookPath)
+	}
+}
+
+// TestFindExisting_AudiobookFallsBackToLibraryDir covers the seannymurrs case
+// (#454): audiobookDir is unset, so NewScanner aliases it to libraryDir, and
+// the audiobook lookup must still find a file under that single root.
+func TestFindExisting_AudiobookFallsBackToLibraryDir(t *testing.T) {
+	libDir := t.TempDir()
+	audioPath := filepath.Join(libDir, "Jane Doe", "Title - Jane Doe.m4b")
+	writeFile(t, audioPath)
+
+	s := findExistingFixture(t, libDir, "")
+	got := s.FindExisting(context.Background(), "Title", "Jane Doe", models.MediaTypeAudiobook)
+	if got != audioPath {
+		t.Errorf("audiobook fallback lookup: got %q, want %q", got, audioPath)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #488. Closes #454.

`Scanner.FindExisting` previously walked `libraryDir` first, then `audiobookDir`, and returned the first title+author hit regardless of the book's media type. Two consequences:

- **#488** — An audiobook book row could be tagged with the path of a same-titled ebook in `libraryDir` because the libraryDir walk wins.
- **#454** — When an author is set to "audiobooks only", file matching still walked the ebook root. The audiobooks-only filter is honored at OL ingestion (only audiobook rows are created) but `FindExisting` did not restrict the search.

## Fix

`LibraryFinder.FindExisting` gains a `mediaType string` parameter, and `Scanner.FindExisting` gates root selection on it: `ebook` walks only `libraryDir`, `audiobook` walks only `audiobookDir` (with fallback to `libraryDir` when the audiobook root is unset, since `BINDERY_AUDIOBOOK_DIR` is aliased to `BINDERY_LIBRARY_DIR` in `NewScanner`), and `both` / unspecified preserves the prior libraryDir-then-audiobookDir behaviour. The single caller (`internal/api/authors.go` in `FetchAuthorBooks`) passes `b.MediaType`.

## Tests

`internal/importer/scanner_findexisting_test.go` covers:
- `TestFindExisting_EbookPicksLibraryRoot` — ebook entry returns the libraryDir path even when an audiobook of the same title exists in audiobookDir.
- `TestFindExisting_AudiobookPicksAudiobookRoot` — the #488 case; audiobook entry returns the audiobookDir path, not the same-titled ebook in libraryDir.
- `TestFindExisting_BothWalksAllRoots` — `media_type=both` and `""` walk both roots with libraryDir winning first.
- `TestFindExisting_AudiobookFallsBackToLibraryDir` — when audiobookDir is unset (aliased to libraryDir), audiobook lookups still find the file under the single configured root.

## Test plan

- [x] `go test ./internal/importer/... ./internal/api/...` passes locally.
- [x] `go build ./...` clean.