### PR TITLE
feat(authors): edit modal on AuthorDetailPage for quality / metadata / root folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ All notable changes to Bindery are documented here. Format loosely follows
 ### Added
 
 - **Book Detail page now exposes the media-type selector** — Imported and downloaded books can now be flipped between ebook / audiobook / both directly from the Book Detail page. Previously this was only available on the Wanted page, so once a book progressed past wanted there was no UI path to add the second format short of deleting and re-adding the author.
+- **Author Detail page now has an Edit modal** — Quality profile, metadata profile, and root folder are now editable from the Author Detail page; previously the only way to change them was to delete the author and re-add. Triggered from a new Edit button next to the existing actions.
 
 ### Fixed
 
-- **Mobile session cookie no longer evicted on app switch** — Login without "Remember me" now sets `Max-Age` on the session cookie (was previously a browser-session cookie with no expiry hint), so iOS Safari and Android Chrome don't drop it when the tab is backgrounded or the OS suspends the browser process. The 12-hour / 30-day durations were already encoded in `auth.SessionDurationShort` / `auth.SessionDuration` but never reached the wire on the short branch.
+- **Mobile session cookie no longer evicted on app switch** — Login without "Remember me" now sets `Max-Age` on the session cookie (was previously a browser-session cookie with no expiry hint), so iOS Safari and Android Chrome don'''t drop it when the tab is backgrounded or the OS suspends the browser process. The 12-hour / 30-day durations were already encoded in `auth.SessionDurationShort` / `auth.SessionDuration` but never reached the wire on the short branch.
 
 ## [v1.4.4] — 2026-05-06
 

--- a/web/src/components/EditAuthorModal.test.tsx
+++ b/web/src/components/EditAuthorModal.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import EditAuthorModal from './EditAuthorModal'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+vi.mock('../api/client', () => ({
+  api: {
+    listQualityProfiles: vi.fn(),
+    listMetadataProfiles: vi.fn(),
+    listRootFolders: vi.fn(),
+    updateAuthor: vi.fn(),
+  },
+}))
+
+import { api } from '../api/client'
+import type { Author, MetadataProfile, QualityProfile, RootFolder } from '../api/client'
+
+const baseAuthor: Author = {
+  id: 42,
+  foreignAuthorId: 'OL123A',
+  authorName: 'Brandon Sanderson',
+  sortName: 'Sanderson, Brandon',
+  description: '',
+  imageUrl: '',
+  disambiguation: '',
+  ratingsCount: 0,
+  averageRating: 0,
+  monitored: true,
+  qualityProfileId: 1,
+  metadataProfileId: 10,
+  rootFolderId: 100,
+}
+
+const qualityProfiles: QualityProfile[] = [
+  { id: 1, name: 'Any', upgradeAllowed: true, cutoff: 'EPUB', items: [] },
+  { id: 2, name: 'EPUB Only', upgradeAllowed: false, cutoff: 'EPUB', items: [] },
+]
+
+const metadataProfiles: MetadataProfile[] = [
+  { id: 10, name: 'Standard', minPopularity: 0, minPages: 0, skipMissingDate: false, skipMissingIsbn: false, skipPartBooks: false, allowedLanguages: 'eng', unknownLanguageBehavior: 'pass' },
+  { id: 11, name: 'English Only', minPopularity: 0, minPages: 0, skipMissingDate: false, skipMissingIsbn: false, skipPartBooks: false, allowedLanguages: 'eng', unknownLanguageBehavior: 'fail' },
+]
+
+const rootFolders: RootFolder[] = [
+  { id: 100, path: '/library/ebooks', freeSpace: 0, createdAt: '' },
+  { id: 101, path: '/library/audiobooks', freeSpace: 0, createdAt: '' },
+]
+
+describe('EditAuthorModal', () => {
+  const onClose = vi.fn()
+  const onSaved = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.listQualityProfiles).mockResolvedValue(qualityProfiles)
+    vi.mocked(api.listMetadataProfiles).mockResolvedValue(metadataProfiles)
+    vi.mocked(api.listRootFolders).mockResolvedValue(rootFolders)
+    vi.mocked(api.updateAuthor).mockImplementation(async (_id, patch) => ({
+      ...baseAuthor,
+      ...patch,
+    }))
+  })
+
+  async function getSelects() {
+    // Wait for profiles to load — once they do all three selects render.
+    await screen.findByRole('option', { name: 'Any' })
+    const selects = screen.getAllByRole('combobox') as HTMLSelectElement[]
+    expect(selects).toHaveLength(3)
+    const [quality, metadata, root] = selects
+    return { quality, metadata, root }
+  }
+
+  it('opens with the current author values prefilled', async () => {
+    render(<EditAuthorModal author={baseAuthor} onClose={onClose} onSaved={onSaved} />)
+
+    const { quality, metadata, root } = await getSelects()
+    expect(quality.value).toBe('1')
+    expect(metadata.value).toBe('10')
+    expect(root.value).toBe('100')
+  })
+
+  it('only sends the fields that actually changed', async () => {
+    render(<EditAuthorModal author={baseAuthor} onClose={onClose} onSaved={onSaved} />)
+
+    const { quality } = await getSelects()
+    fireEvent.change(quality, { target: { value: '2' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(api.updateAuthor).toHaveBeenCalledTimes(1))
+    expect(api.updateAuthor).toHaveBeenCalledWith(42, { qualityProfileId: 2 })
+    // Unchanged fields must not be in the patch.
+    const callArg = vi.mocked(api.updateAuthor).mock.calls[0][1] as Record<string, unknown>
+    expect('metadataProfileId' in callArg).toBe(false)
+    expect('rootFolderId' in callArg).toBe(false)
+  })
+
+  it('passes the updated author to onSaved after a successful save', async () => {
+    render(<EditAuthorModal author={baseAuthor} onClose={onClose} onSaved={onSaved} />)
+
+    const { root } = await getSelects()
+    fireEvent.change(root, { target: { value: '101' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1))
+    const passed = onSaved.mock.calls[0][0] as Author
+    expect(passed.rootFolderId).toBe(101)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes on cancel without calling updateAuthor', async () => {
+    render(<EditAuthorModal author={baseAuthor} onClose={onClose} onSaved={onSaved} />)
+
+    await getSelects()
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(api.updateAuthor).not.toHaveBeenCalled()
+    expect(onSaved).not.toHaveBeenCalled()
+  })
+
+  it('skips the API call when nothing changed and just closes', async () => {
+    render(<EditAuthorModal author={baseAuthor} onClose={onClose} onSaved={onSaved} />)
+
+    await getSelects()
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+    expect(api.updateAuthor).not.toHaveBeenCalled()
+    expect(onSaved).not.toHaveBeenCalled()
+  })
+
+  it('shows an error message when save fails', async () => {
+    vi.mocked(api.updateAuthor).mockRejectedValue(new Error('HTTP 500: server error'))
+
+    render(<EditAuthorModal author={baseAuthor} onClose={onClose} onSaved={onSaved} />)
+
+    const { metadata } = await getSelects()
+    fireEvent.change(metadata, { target: { value: '11' } })
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(screen.getByText(/HTTP 500/i)).toBeInTheDocument())
+    expect(onSaved).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/EditAuthorModal.tsx
+++ b/web/src/components/EditAuthorModal.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api, Author, MetadataProfile, QualityProfile, RootFolder } from '../api/client'
+
+interface Props {
+  author: Author
+  onClose: () => void
+  onSaved: (author: Author) => void
+}
+
+export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
+  const { t } = useTranslation()
+
+  const [qualityProfiles, setQualityProfiles] = useState<QualityProfile[]>([])
+  const [metadataProfiles, setMetadataProfiles] = useState<MetadataProfile[]>([])
+  const [rootFolders, setRootFolders] = useState<RootFolder[]>([])
+
+  const [qualityProfileId, setQualityProfileId] = useState<number | null>(author.qualityProfileId ?? null)
+  const [metadataProfileId, setMetadataProfileId] = useState<number | null>(author.metadataProfileId ?? null)
+  const [rootFolderId, setRootFolderId] = useState<number | null>(author.rootFolderId ?? null)
+
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all([
+      api.listQualityProfiles().catch(() => [] as QualityProfile[]),
+      api.listMetadataProfiles().catch(() => [] as MetadataProfile[]),
+      api.listRootFolders().catch(() => [] as RootFolder[]),
+    ])
+      .then(([qps, mps, rfs]) => {
+        if (cancelled) return
+        setQualityProfiles(qps)
+        setMetadataProfiles(mps)
+        setRootFolders(rfs)
+      })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  const save = async () => {
+    // Build a patch with only the fields that actually changed — sending
+    // unchanged values is functionally fine but produces noisy log lines.
+    const patch: Partial<Author> = {}
+    if (qualityProfileId !== (author.qualityProfileId ?? null)) {
+      patch.qualityProfileId = qualityProfileId
+    }
+    if (metadataProfileId !== (author.metadataProfileId ?? null)) {
+      patch.metadataProfileId = metadataProfileId
+    }
+    if (rootFolderId !== (author.rootFolderId ?? null)) {
+      patch.rootFolderId = rootFolderId
+    }
+
+    if (Object.keys(patch).length === 0) {
+      onClose()
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await api.updateAuthor(author.id, patch)
+      onSaved(updated)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('editAuthorModal.saveFail', 'Failed to save'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center p-4 z-50" onClick={onClose}>
+      <div className="bg-slate-100 dark:bg-zinc-900 border border-slate-300 dark:border-zinc-700 rounded-lg w-full max-w-lg shadow-2xl max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="p-4 border-b border-slate-200 dark:border-zinc-800">
+          <h3 className="text-lg font-semibold">{t('editAuthorModal.title', 'Edit Author')}</h3>
+          <p className="text-xs text-slate-600 dark:text-zinc-500 mt-1">{author.authorName}</p>
+        </div>
+
+        <div className="p-4 flex-1 overflow-y-auto">
+          {loading ? (
+            <p className="text-sm text-slate-600 dark:text-zinc-500">{t('common.loading', 'Loading...')}</p>
+          ) : (
+            <>
+              {qualityProfiles.length > 0 && (
+                <div className="mb-3">
+                  <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('editAuthorModal.qualityProfile', 'Quality profile')}</label>
+                  <select
+                    value={qualityProfileId ?? ''}
+                    onChange={e => setQualityProfileId(e.target.value ? Number(e.target.value) : null)}
+                    className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+                  >
+                    {qualityProfiles.map(p => (
+                      <option key={p.id} value={p.id}>{p.name}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+              {metadataProfiles.length > 0 && (
+                <div className="mb-3">
+                  <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('editAuthorModal.metadataProfile', 'Metadata profile')}</label>
+                  <select
+                    value={metadataProfileId ?? ''}
+                    onChange={e => setMetadataProfileId(e.target.value ? Number(e.target.value) : null)}
+                    className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+                  >
+                    {metadataProfiles.map(p => (
+                      <option key={p.id} value={p.id}>{p.name}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+              {rootFolders.length > 0 && (
+                <div className="mb-3">
+                  <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('editAuthorModal.rootFolder', 'Root folder')}</label>
+                  <select
+                    value={rootFolderId ?? ''}
+                    onChange={e => setRootFolderId(e.target.value ? Number(e.target.value) : null)}
+                    className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+                  >
+                    {rootFolders.map(rf => (
+                      <option key={rf.id} value={rf.id}>{rf.path}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+              {error && (
+                <p className="text-sm text-red-600 dark:text-red-400 mt-2">{error}</p>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="p-4 border-t border-slate-200 dark:border-zinc-800 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="px-4 py-2 text-sm text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white disabled:opacity-50"
+          >
+            {t('common.cancel', 'Cancel')}
+          </button>
+          <button
+            onClick={save}
+            disabled={loading || saving}
+            className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded-md text-sm font-medium text-white"
+          >
+            {saving ? t('common.saving', 'Saving...') : t('common.save', 'Save')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { api, Author, Book } from '../api/client'
 import ViewToggle from '../components/ViewToggle'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
+import EditAuthorModal from '../components/EditAuthorModal'
 import { useView } from '../components/useView'
 
 const statusColors: Record<string, string> = {
@@ -57,6 +58,7 @@ export default function AuthorDetailPage() {
   const [refreshing, setRefreshing] = useState(false)
   const [searchingWanted, setSearchingWanted] = useState(false)
   const [showMerge, setShowMerge] = useState(false)
+  const [showEdit, setShowEdit] = useState(false)
   const [showExcluded, setShowExcluded] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -281,6 +283,13 @@ export default function AuthorDetailPage() {
               {searchingWanted ? 'Searching…' : 'Search all wanted'}
             </button>
             <button
+              onClick={() => setShowEdit(true)}
+              className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium"
+              title="Edit quality, metadata, and root folder"
+            >
+              Edit
+            </button>
+            <button
               onClick={() => {
                 if (allAuthors.length === 0) api.listAuthors().then(setAllAuthors).catch(console.error)
                 setShowMerge(true)
@@ -315,6 +324,14 @@ export default function AuthorDetailPage() {
           )}
         </div>
       </div>
+
+      {showEdit && (
+        <EditAuthorModal
+          author={author}
+          onClose={() => setShowEdit(false)}
+          onSaved={updated => setAuthor(updated)}
+        />
+      )}
 
       {showMerge && allAuthors.length > 0 && (
         <MergeAuthorsModal


### PR DESCRIPTION
## Summary

A user [reported on Reddit](https://www.reddit.com/r/Readarr/) that there was no way to change quality, metadata profile, or root folder for an author once added — the only workaround was deleting and re-adding. Backend `PUT /api/v1/author/{id}` already accepted these fields (`internal/api/authors.go:480-513`), but the UI only exposed the monitor toggle.

This PR adds an Edit button to the Author Detail page that opens a modal with dropdowns for:

- Quality profile
- Metadata profile
- Root folder

The "Monitored" toggle stays where it is; the modal is only for the previously un-editable fields. The patch sent to the backend includes only fields that actually changed.

## Test plan

- [ ] Open an author's detail page, click Edit, change the metadata profile, save — page should reflect the new selection without a reload
- [ ] Open Edit and click Cancel — no API call, modal closes
- [ ] Open Edit and click Save without changes — no API call, modal closes
- [ ] Trigger a backend error (e.g. set the read-only DB env var) and verify the inline error message renders without closing the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)