### PR TITLE
feat(books): media-type selector on BookDetailPage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ### Fixed
 
-- **Mobile session cookie no longer evicted on app switch** — Login without "Remember me" now sets `Max-Age` on the session cookie (was previously a browser-session cookie with no expiry hint), so iOS Safari and Android Chrome don'''t drop it when the tab is backgrounded or the OS suspends the browser process. The 12-hour / 30-day durations were already encoded in `auth.SessionDurationShort` / `auth.SessionDuration` but never reached the wire on the short branch.
+- **Mobile session cookie no longer evicted on app switch** — Login without "Remember me" now sets `Max-Age` on the session cookie (was previously a browser-session cookie with no expiry hint), so iOS Safari and Android Chrome don't drop it when the tab is backgrounded or the OS suspends the browser process. The 12-hour / 30-day durations were already encoded in `auth.SessionDurationShort` / `auth.SessionDuration` but never reached the wire on the short branch.
 
 ## [v1.4.4] — 2026-05-06
 

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -1,11 +1,57 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { SearchResultsSection } from './BookDetailPage'
-import type { SearchResult } from '../api/client'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import BookDetailPage, { SearchResultsSection } from './BookDetailPage'
+import { api } from '../api/client'
+import type { Book, SearchResult } from '../api/client'
 
 vi.mock('../components/MediaBadge', () => ({
   default: ({ type }: { type?: string }) => <span data-testid={`badge-${type}`}>{type}</span>,
 }))
+
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getBook: vi.fn(),
+      listHistory: vi.fn(),
+      updateBook: vi.fn(),
+    },
+  }
+})
+
+function makeBook(overrides: Partial<Book> = {}): Book {
+  return {
+    id: 7,
+    foreignBookId: 'fb-7',
+    authorId: 42,
+    title: 'Mistborn',
+    description: '',
+    imageUrl: '',
+    releaseDate: undefined,
+    genres: [],
+    monitored: true,
+    status: 'imported',
+    filePath: '',
+    mediaType: 'ebook',
+    ebookFilePath: '',
+    audiobookFilePath: '',
+    excluded: false,
+    ...overrides,
+  }
+}
+
+function renderBookDetailPage() {
+  return render(
+    <MemoryRouter initialEntries={['/book/7']}>
+      <Routes>
+        <Route path="/book/:id" element={<BookDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
 
 function makeResult({ guid, title, ...rest }: Partial<SearchResult> & { guid: string }): SearchResult {
   return {
@@ -99,5 +145,48 @@ describe('SearchResultsSection — single-format book', () => {
       <SearchResultsSection results={results} bookMediaType="ebook" grabbing={null} onGrab={noop} />,
     )
     expect(container.querySelectorAll('button').length).toBe(20)
+  })
+})
+
+describe('BookDetailPage — media-type selector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.listHistory).mockResolvedValue([])
+  })
+
+  it('renders the selector with the current mediaType selected', async () => {
+    vi.mocked(api.getBook).mockResolvedValue(makeBook({ mediaType: 'ebook' }))
+    renderBookDetailPage()
+
+    const select = (await screen.findByLabelText('Format:')) as HTMLSelectElement
+    expect(select.value).toBe('ebook')
+  })
+
+  it('calls api.updateBook with the new mediaType on change', async () => {
+    vi.mocked(api.getBook).mockResolvedValue(makeBook({ mediaType: 'ebook' }))
+    vi.mocked(api.updateBook).mockResolvedValue(makeBook({ mediaType: 'both' }))
+    renderBookDetailPage()
+
+    const select = await screen.findByLabelText('Format:')
+    fireEvent.change(select, { target: { value: 'both' } })
+
+    await waitFor(() => expect(api.updateBook).toHaveBeenCalledWith(7, { mediaType: 'both' }))
+  })
+
+  it('updates local state on success so the dual-format panels appear', async () => {
+    vi.mocked(api.getBook).mockResolvedValue(makeBook({ mediaType: 'ebook' }))
+    vi.mocked(api.updateBook).mockResolvedValue(makeBook({ mediaType: 'both' }))
+    renderBookDetailPage()
+
+    const select = (await screen.findByLabelText('Format:')) as HTMLSelectElement
+    expect(screen.queryByText(/✓ on disk|needed/)).toBeNull()
+
+    fireEvent.change(select, { target: { value: 'both' } })
+
+    await waitFor(() => expect((select as HTMLSelectElement).value).toBe('both'))
+    // The dual-format panels (gated on mediaType === 'both') now render the
+    // "📖 Ebook ... needed" / "🎧 Audiobook ... needed" status pills.
+    const needed = await screen.findAllByText('needed')
+    expect(needed.length).toBe(2)
   })
 })

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -292,12 +292,6 @@ export default function BookDetailPage() {
   if (!book) return <div className="text-slate-600 dark:text-zinc-500">Book not found</div>
 
   const mt = book.mediaType || 'ebook'
-  const typeBtn = (type: 'ebook' | 'audiobook' | 'both') =>
-    `px-3 py-1.5 rounded text-sm font-medium transition-colors ${
-      mt === type
-        ? 'bg-emerald-600 text-white'
-        : 'bg-slate-200 dark:bg-zinc-800 text-slate-700 dark:text-zinc-300 hover:bg-slate-300 dark:hover:bg-zinc-700'
-    }`
 
   return (
     <div className="max-w-4xl">
@@ -424,10 +418,20 @@ export default function BookDetailPage() {
 
       <section className="mb-6 p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
         <h3 className="text-sm font-semibold mb-3 text-slate-800 dark:text-zinc-200">Format</h3>
-        <div className="flex gap-2 mb-4">
-          <button onClick={() => saveField({ mediaType: 'ebook' })} disabled={saving} className={typeBtn('ebook')}>📖 Ebook</button>
-          <button onClick={() => saveField({ mediaType: 'audiobook' })} disabled={saving} className={typeBtn('audiobook')}>🎧 Audiobook</button>
-          <button onClick={() => saveField({ mediaType: 'both' })} disabled={saving} className={typeBtn('both')}>📖🎧 Both</button>
+        <div className="flex items-center gap-2 mb-4">
+          <label htmlFor="book-media-type" className="text-xs text-slate-600 dark:text-zinc-400">Format:</label>
+          <select
+            id="book-media-type"
+            value={mt}
+            onChange={e => saveField({ mediaType: e.target.value as 'ebook' | 'audiobook' | 'both' })}
+            disabled={saving}
+            className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-2 py-1 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600 disabled:opacity-50"
+            title="Change media type"
+          >
+            <option value="ebook">📖 Ebook</option>
+            <option value="audiobook">🎧 Audiobook</option>
+            <option value="both">📖🎧 Both</option>
+          </select>
         </div>
 
         {mt === 'both' && (


### PR DESCRIPTION
## Summary

User reported on Reddit:

> If I wanted to change quality or from ebook to both without deleting an author and re-adding.

The Wanted page already had a media-type dropdown wired to `api.updateBook`. The backend `PUT /api/v1/book/{id}` has accepted `mediaType` (`ebook` / `audiobook` / `both`) for some time. But the Book Detail page only had quality / status / monitor controls — once a book progressed past wanted (downloaded, imported, …) it dropped off the Wanted list and there was no UI path to add the second format short of deleting and re-adding the author.

This PR adds a labeled `Format:` dropdown on the Book Detail page that mirrors the WantedPage select, replacing the three full-width Format buttons that lived in the same section. Selecting a new value calls `api.updateBook(id, { mediaType })` through the existing `saveField` helper, which already updates local state on success — so the dual-format status panels (and the ASIN/enrich block gated on `audiobook` / `both`) re-render in place.

No backend, no new dependencies, no i18n strings. The existing `📖 Ebook` / `🎧 Audiobook` / `📖🎧 Both` literals on the page are reused as the option labels.

## Test plan

- [x] `cd web && npm run lint` — 0 errors (5 pre-existing warnings unchanged)
- [x] `cd web && npm run typecheck` — clean
- [x] `cd web && npm test -- --run BookDetailPage` — 10 tests pass, including 3 new ones covering: selector renders with current `book.mediaType`, change calls `api.updateBook(id, { mediaType: 'both' })`, dual-format `needed` panels appear after successful update
- [ ] Manual: open a book in `imported` state, flip `ebook` → `both`, confirm the Ebook / Audiobook status pills appear and the ASIN row becomes visible
- [ ] Manual: flip back to `ebook`; confirm ASIN row disappears and there's no console error

🤖 Generated with [Claude Code](https://claude.com/claude-code)