### PR TITLE
fix: add .opus to book and audio-tag extension lists

### DIFF
--- a/internal/importer/audiotag.go
+++ b/internal/importer/audiotag.go
@@ -14,7 +14,7 @@ import (
 // falls back to filename parsing without paying the open/seek cost.
 var audioTagExtensions = map[string]bool{
 	".mp3": true, ".m4a": true, ".m4b": true,
-	".flac": true, ".ogg": true,
+	".flac": true, ".ogg": true, ".opus": true,
 }
 
 // AudioTags is the subset of embedded audio metadata the library scanner

--- a/internal/importer/audiotag_test.go
+++ b/internal/importer/audiotag_test.go
@@ -19,6 +19,8 @@ func TestIsAudioTagFile(t *testing.T) {
 		{"/lib/a.m4a", true},
 		{"/lib/a.flac", true},
 		{"/lib/a.ogg", true},
+		{"/lib/a.opus", true},
+		{"/lib/a.OPUS", true},
 		{"/lib/a.epub", false},
 		{"/lib/a.pdf", false},
 		{"/lib/a", false},

--- a/internal/importer/parser.go
+++ b/internal/importer/parser.go
@@ -52,7 +52,7 @@ var bookExtensions = map[string]bool{
 	".epub": true, ".mobi": true, ".azw3": true, ".azw": true,
 	".pdf": true, ".djvu": true, ".cbr": true, ".cbz": true,
 	".fb2": true, ".lit": true, ".txt": true, ".rtf": true,
-	".mp3": true, ".m4a": true, ".m4b": true, ".flac": true, ".ogg": true,
+	".mp3": true, ".m4a": true, ".m4b": true, ".flac": true, ".ogg": true, ".opus": true,
 }
 
 // ParseFilename extracts book metadata from a filename or directory name.

--- a/internal/importer/parser_test.go
+++ b/internal/importer/parser_test.go
@@ -96,6 +96,8 @@ func TestIsBookFile(t *testing.T) {
 		{"book.azw3", true},
 		{"audiobook.m4b", true},
 		{"audio.mp3", true},
+		{"audio.opus", true},
+		{"audio.OPUS", true},
 		{"image.jpg", false},
 		{"readme.md", false},
 		{"file.nzb", false},


### PR DESCRIPTION
## Summary

- `.opus` was missing from `bookExtensions` in `parser.go`, causing `IsBookFile` to return `false` for all `.opus` files — the library scanner silently skipped them, producing zero matches for AudioBookShelf libraries that store content as `.opus`
- `.opus` was also missing from `audioTagExtensions` in `audiotag.go`, so embedded Vorbis comment tags (title, artist, ASIN) would never be read even if the file were found
- This was inconsistent with `detectDownloadFormat` in `scanner.go`, which already listed `.opus` as an audio extension for import routing
- Fixes #499

## Test plan

- [ ] `go test ./internal/importer/... -run TestIsBookFile` passes (two new `.opus` / `.OPUS` cases added)
- [ ] `go test ./internal/importer/... -run TestIsAudioTagFile` passes (two new `.opus` / `.OPUS` cases added)
- [ ] `go test ./internal/importer/...` passes in full
- [ ] Manual: place a `.opus` file under `BINDERY_LIBRARY_DIR` and trigger a library scan — it is now found and matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)