### PR TITLE
fix(hardcover): surface built-in shelves (Want to Read / Currently Reading / Read) in list picker

### DIFF
--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -386,7 +386,9 @@ func (c *Client) GetUserWishlist(ctx context.Context, limit int) ([]models.Recom
 
 // --- Authenticated list queries ---
 
-// HCList represents a Hardcover reading list.
+// HCList represents a Hardcover reading list or built-in shelf.
+// Built-in shelves use negative IDs: -1 Want to Read, -2 Currently Reading,
+// -3 Read, -4 Did Not Finish.
 type HCList struct {
 	ID         int    `json:"id"`
 	Name       string `json:"name"`
@@ -394,7 +396,36 @@ type HCList struct {
 	BooksCount int    `json:"booksCount"`
 }
 
-// GetUserLists returns the authenticated user's reading lists.
+// hcBuiltinShelves are the four standard Hardcover reading-status shelves.
+// They live in user_books (filtered by status_id), not in me.lists, so they
+// are injected as synthetic entries using negative IDs to avoid collision with
+// real list IDs.
+var hcBuiltinShelves = []HCList{
+	{ID: -1, Name: "Want to Read", Slug: "want-to-read"},
+	{ID: -2, Name: "Currently Reading", Slug: "currently-reading"},
+	{ID: -3, Name: "Read", Slug: "read"},
+	{ID: -4, Name: "Did Not Finish", Slug: "did-not-finish"},
+}
+
+// hcShelfStatusID maps a synthetic shelf list ID to its Hardcover status_id.
+func hcShelfStatusID(listID int) (int, bool) {
+	switch listID {
+	case -1:
+		return 1, true
+	case -2:
+		return 2, true
+	case -3:
+		return 3, true
+	case -4:
+		return 4, true
+	}
+	return 0, false
+}
+
+// GetUserLists returns the authenticated user's reading lists, prepended by
+// the four built-in Hardcover shelves (Want to Read, Currently Reading, Read,
+// Did Not Finish). Built-in shelves always appear even when the user has no
+// custom lists, which was the root cause of the "No lists found" report.
 func (c *Client) GetUserLists(ctx context.Context) ([]HCList, error) {
 	gql := `query GetUserLists {
 		me {
@@ -421,7 +452,8 @@ func (c *Client) GetUserLists(ctx context.Context) ([]HCList, error) {
 	if err := c.query(ctx, gql, nil, &resp); err != nil {
 		return nil, fmt.Errorf("hardcover get user lists: %w", err)
 	}
-	lists := make([]HCList, 0, len(resp.Data.Me.Lists))
+	lists := make([]HCList, 0, len(hcBuiltinShelves)+len(resp.Data.Me.Lists))
+	lists = append(lists, hcBuiltinShelves...)
 	for _, l := range resp.Data.Me.Lists {
 		lists = append(lists, HCList{
 			ID:         l.ID,
@@ -434,7 +466,11 @@ func (c *Client) GetUserLists(ctx context.Context) ([]HCList, error) {
 }
 
 // GetListBooks returns all books in the given list as Bindery models.
+// Negative listIDs refer to built-in Hardcover shelves (see hcBuiltinShelves).
 func (c *Client) GetListBooks(ctx context.Context, listID int) ([]models.Book, error) {
+	if statusID, ok := hcShelfStatusID(listID); ok {
+		return c.getShelfBooks(ctx, statusID)
+	}
 	gql := `query GetListBooks($id: Int!) {
 		list(id: $id) {
 			id
@@ -472,6 +508,46 @@ func (c *Client) GetListBooks(ctx context.Context, listID int) ([]models.Book, e
 	books := make([]models.Book, 0, len(resp.Data.List.ListBooks))
 	for _, lb := range resp.Data.List.ListBooks {
 		books = append(books, c.toBook(lb.Book))
+	}
+	return books, nil
+}
+
+// getShelfBooks fetches all books on a built-in Hardcover shelf by status_id.
+func (c *Client) getShelfBooks(ctx context.Context, statusID int) ([]models.Book, error) {
+	gql := `query GetShelfBooks($statusID: Int!) {
+		me {
+			user_books(where: {status_id: {_eq: $statusID}}, limit: 500) {
+				book {
+					id
+					title
+					slug
+					description
+					image { url }
+					release_year
+					ratings_count
+					rating
+					contributions {
+						author { id name slug }
+					}
+				}
+			}
+		}
+	}`
+	var resp struct {
+		Data struct {
+			Me struct {
+				UserBooks []struct {
+					Book hcBook `json:"book"`
+				} `json:"user_books"`
+			} `json:"me"`
+		} `json:"data"`
+	}
+	if err := c.query(ctx, gql, map[string]any{"statusID": statusID}, &resp); err != nil {
+		return nil, fmt.Errorf("hardcover get shelf books: %w", err)
+	}
+	books := make([]models.Book, 0, len(resp.Data.Me.UserBooks))
+	for _, ub := range resp.Data.Me.UserBooks {
+		books = append(books, c.toBook(ub.Book))
 	}
 	return books, nil
 }

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -1002,6 +1002,100 @@ func TestGetUserWishlist_HTTPError(t *testing.T) {
 	}
 }
 
+func TestGetUserLists_IncludesBuiltinShelves(t *testing.T) {
+	// When me.lists returns an empty array (user has no custom lists),
+	// GetUserLists must still return the 4 built-in shelf entries.
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body := `{"data":{"me":{"lists":[]}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	c = c.WithToken("hc-token")
+
+	lists, err := c.GetUserLists(context.Background())
+	if err != nil {
+		t.Fatalf("GetUserLists: %v", err)
+	}
+	if len(lists) != len(hcBuiltinShelves) {
+		t.Fatalf("want %d lists (built-ins only), got %d", len(hcBuiltinShelves), len(lists))
+	}
+	if lists[0].ID != -1 || lists[0].Name != "Want to Read" {
+		t.Errorf("first list = %+v, want {ID:-1, Name:Want to Read}", lists[0])
+	}
+}
+
+func TestGetUserLists_CustomListsAppendedAfterShelves(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body := `{"data":{"me":{"lists":[{"id":42,"name":"Favorites","slug":"favorites","books_count":7}]}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	c = c.WithToken("hc-token")
+
+	lists, err := c.GetUserLists(context.Background())
+	if err != nil {
+		t.Fatalf("GetUserLists: %v", err)
+	}
+	want := len(hcBuiltinShelves) + 1
+	if len(lists) != want {
+		t.Fatalf("want %d lists, got %d", want, len(lists))
+	}
+	last := lists[len(lists)-1]
+	if last.ID != 42 || last.Name != "Favorites" || last.BooksCount != 7 {
+		t.Errorf("custom list = %+v, want {ID:42, Name:Favorites, BooksCount:7}", last)
+	}
+}
+
+func TestGetListBooks_BuiltinShelfRoutesToUserBooks(t *testing.T) {
+	var gotVars map[string]any
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		var req gqlRequest
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		gotVars = req.Variables
+		resp := `{"data":{"me":{"user_books":[{"book":{"id":99,"title":"Dune","slug":"dune","contributions":[{"author":{"id":1,"name":"Frank Herbert","slug":"frank-herbert"}}]}}]}}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(resp)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	c = c.WithToken("hc-token")
+
+	books, err := c.GetListBooks(context.Background(), -1) // Want to Read
+	if err != nil {
+		t.Fatalf("GetListBooks shelf: %v", err)
+	}
+	if len(books) != 1 || books[0].Title != "Dune" {
+		t.Errorf("books = %+v, want [{Title:Dune}]", books)
+	}
+	if gotVars["statusID"] != float64(1) {
+		t.Errorf("statusID var = %v, want 1", gotVars["statusID"])
+	}
+}
+
+func TestHcShelfStatusID(t *testing.T) {
+	cases := []struct{ id, want int }{{-1, 1}, {-2, 2}, {-3, 3}, {-4, 4}}
+	for _, tc := range cases {
+		got, ok := hcShelfStatusID(tc.id)
+		if !ok || got != tc.want {
+			t.Errorf("hcShelfStatusID(%d) = %d,%v, want %d,true", tc.id, got, ok, tc.want)
+		}
+	}
+	if _, ok := hcShelfStatusID(0); ok {
+		t.Error("hcShelfStatusID(0) should return false")
+	}
+	if _, ok := hcShelfStatusID(42); ok {
+		t.Error("hcShelfStatusID(42) should return false")
+	}
+}
+
 func TestQuery_RequestFormat(t *testing.T) {
 	var gotBody []byte
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Problem

`me { lists }` in Hardcover's GraphQL API only returns **custom user-created lists**. The four standard shelves — Want to Read, Currently Reading, Read, Did Not Finish — are stored in `user_books` with `status_id` filters and are completely absent from that query.

Users who have never created a custom list saw **"No lists found"** in the Hardcover import list picker, even with hundreds of books on their shelves.

## Fix

- Inject the four built-in shelves as synthetic `HCList` entries with negative IDs (`-1` through `-4`) — they always appear at the top of the list picker, before any custom lists.
- `GetListBooks` detects a negative `listID`, maps it to its `status_id`, and fires a `user_books(where: {status_id: {_eq: N}})` query instead of the `list(id:)` query.
- Limit: 500 books per shelf (matches the existing `user_books` ceiling; most users are well under).

## Test plan

- [ ] New unit tests cover: built-in shelves always returned even when `me.lists` is empty, custom lists appended after shelves, `GetListBooks(-1)` fires `user_books` query with `statusID=1`, `hcShelfStatusID` mapping
- [ ] `go test ./internal/metadata/hardcover/...` passes
- [ ] User with only default shelves sees Want to Read / Currently Reading / Read / Did Not Finish in the Hardcover import picker
- [ ] User with custom lists sees shelves first, then their custom lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)