### PR TITLE
fix(telemetry): open redirect, rate-limit key, env opt-out

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -20,6 +20,7 @@ import (
 	"html"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -72,6 +73,7 @@ type statsResponse struct {
 func main() {
 	dbPath := env("DB_PATH", "/data/telemetry.db")
 	addr := env("ADDR", ":8080")
+	canonicalHost := env("CANONICAL_HOST", "")
 	latestVersion := env("LATEST_VERSION", "v1.4.3")
 	statsToken := env("STATS_TOKEN", "")
 
@@ -147,7 +149,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:         addr,
-		Handler:      secureHeaders(mux),
+		Handler:      secureHeaders(canonicalHost, mux),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  120 * time.Second,
@@ -161,11 +163,18 @@ func main() {
 
 // secureHeaders adds security response headers and rejects non-HTTPS requests
 // (when running behind Traefik, X-Forwarded-Proto carries the original scheme).
-func secureHeaders(next http.Handler) http.Handler {
+// host is the canonical public hostname (CANONICAL_HOST env var); when set it
+// is used in the HTTPS redirect instead of the request's Host header, which a
+// client could otherwise set to an arbitrary domain (open redirect).
+func secureHeaders(host string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Reject plain HTTP when the request came through the public ingress.
 		if r.Header.Get("X-Forwarded-Proto") == "http" {
-			http.Redirect(w, r, "https://"+r.Host+r.RequestURI, http.StatusMovedPermanently)
+			target := host
+			if target == "" {
+				target = r.Host
+			}
+			http.Redirect(w, r, "https://"+target+r.RequestURI, http.StatusMovedPermanently)
 			return
 		}
 		w.Header().Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
@@ -789,6 +798,11 @@ func realIP(r *http.Request) string {
 		if ip := strings.TrimSpace(parts[len(parts)-1]); ip != "" {
 			return ip
 		}
+	}
+	// RemoteAddr is "IP:port"; strip the port so each unique client IP gets
+	// one rate-limit bucket regardless of which ephemeral port it connects from.
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
 	}
 	return r.RemoteAddr
 }

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -114,6 +114,11 @@ func (c *Client) Ping(ctx context.Context) {
 }
 
 func (c *Client) isEnabled(ctx context.Context) bool {
+	// BINDERY_TELEMETRY_DISABLED=true lets users opt out before any DB setting
+	// exists (e.g. on first boot, before the startup ping would fire).
+	if os.Getenv("BINDERY_TELEMETRY_DISABLED") == "true" {
+		return false
+	}
 	s, _ := c.settings.Get(ctx, settingEnabled)
 	if s == nil {
 		return true // default on


### PR DESCRIPTION
Fixes #482.

## Summary

- **Open redirect (G710)**: `secureHeaders` built the HTTPS redirect from `r.Host`, which an attacker controls via the HTTP Host header. Added `CANONICAL_HOST` env var; the redirect uses it when set, falls back to `r.Host` otherwise so existing deployments need no config change.
- **Rate-limiter keying on IP:port**: `realIP()` fell back to `r.RemoteAddr` which is `"IP:port"`. Each new TCP connection from the same client got a distinct bucket key, allowing the one-ping-per-hour limit to be bypassed by cycling connections. Strip the port with `net.SplitHostPort`.
- **`BINDERY_TELEMETRY_DISABLED` ignored on first boot**: `isEnabled()` only checked the persisted DB setting, so the documented env-var opt-out had no effect before the first DB write. Check the env var first.

The three remaining lint issues in `cmd/telemetry-server` (`defer os.RemoveAll`, `fmt.Fprintf`, G202 SQL concat) are already addressed in #498 and are intentionally not touched here.

## Test plan

- [ ] `go build ./cmd/telemetry-server/... ./internal/telemetry/...` passes
- [ ] `golangci-lint run ./internal/telemetry/... ./cmd/telemetry-server/...` reports no new issues from this diff
- [ ] Deploy with `CANONICAL_HOST=api.getbindery.dev` — HTTP request with spoofed `Host: evil.com` redirects to `https://api.getbindery.dev/...`, not `https://evil.com/...`
- [ ] Deploy without `CANONICAL_HOST` — existing redirect behaviour unchanged
- [ ] Start with `BINDERY_TELEMETRY_DISABLED=true` and no DB — no install ID created, no ping sent