### PR TITLE
feat(abs): remove BINDERY_ABS_ENABLED feature flag

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -238,22 +238,20 @@ func main() {
 		WithEnhancedHardcoverSeriesEnabled(func(ctx context.Context) bool {
 			return api.HardcoverFeatureStateFor(ctx, settingsRepo, cfg.EnhancedHardcoverAPI).EnhancedHardcoverAPI
 		})
-	if cfg.ABSFeatureEnabled {
-		storedABS := api.LoadABSConfig(ctxBoot, settingsRepo)
-		resumeCfg := abs.ImportConfig{
-			SourceID:  abs.DefaultSourceID,
-			BaseURL:   storedABS.BaseURL,
-			APIKey:    storedABS.APIKey,
-			LibraryID: storedABS.LibraryID,
-			PathRemap: storedABS.PathRemap,
-			Label:     storedABS.Label,
-			Enabled:   storedABS.Enabled,
-		}
-		if resumed, err := absImporter.ResumeInterrupted(ctxBoot, resumeCfg); err != nil {
-			slog.Warn("abs interrupted import resume skipped", "error", err)
-		} else if resumed {
-			slog.Info("abs interrupted import resumed from checkpoint")
-		}
+	storedABS := api.LoadABSConfig(ctxBoot, settingsRepo)
+	resumeCfg := abs.ImportConfig{
+		SourceID:  abs.DefaultSourceID,
+		BaseURL:   storedABS.BaseURL,
+		APIKey:    storedABS.APIKey,
+		LibraryID: storedABS.LibraryID,
+		PathRemap: storedABS.PathRemap,
+		Label:     storedABS.Label,
+		Enabled:   storedABS.Enabled,
+	}
+	if resumed, err := absImporter.ResumeInterrupted(ctxBoot, resumeCfg); err != nil {
+		slog.Warn("abs interrupted import resume skipped", "error", err)
+	} else if resumed {
+		slog.Info("abs interrupted import resumed from checkpoint")
 	}
 	if syncOnStartup(settingsRepo) {
 		cfg := api.LoadCalibreConfig(settingsRepo)
@@ -393,7 +391,7 @@ func main() {
 	logHandler := api.NewLogHandler(ring).WithLogRepo(logRepo)
 	prowlarrHandler := api.NewProwlarrHandler(prowlarrRepo, indexerRepo)
 	calibreHandler := api.NewCalibreHandler(settingsRepo)
-	absHandler := api.NewABSHandler(settingsRepo).WithVersion(version).WithFeatureEnabled(cfg.ABSFeatureEnabled)
+	absHandler := api.NewABSHandler(settingsRepo).WithVersion(version)
 	absConflictHandler := api.NewABSConflictHandler(absConflictRepo, authorRepo, bookRepo)
 	absImportHandler := api.NewABSImportHandler(absImporter, func(ctx context.Context) api.ABSStoredConfig {
 		return api.LoadABSConfig(ctx, settingsRepo)
@@ -636,23 +634,21 @@ func main() {
 			r.Delete("/setting/{key}", settingsHandler.Delete)
 			r.Post("/hardcover/test", settingsHandler.TestHardcover)
 			r.Get("/abs/config", absHandler.GetConfig)
-			if cfg.ABSFeatureEnabled {
-				r.Put("/abs/config", absHandler.SetConfig)
-				r.Post("/abs/test", absHandler.Test)
-				r.Post("/abs/libraries", absHandler.Libraries)
-				r.Post("/abs/import", absImportHandler.Start)
-				r.Get("/abs/import/status", absImportHandler.Status)
-				r.Get("/abs/import/runs", absImportHandler.Runs)
-				r.Post("/abs/import/runs/{runID}/rollback/preview", absImportHandler.RollbackPreview)
-				r.Post("/abs/import/runs/{runID}/rollback", absImportHandler.Rollback)
-				r.Get("/abs/review", absReviewHandler.List)
-				r.Post("/abs/review/{id}/approve", absReviewHandler.Approve)
-				r.Post("/abs/review/{id}/resolve-author", absReviewHandler.ResolveAuthor)
-				r.Post("/abs/review/{id}/resolve-book", absReviewHandler.ResolveBook)
-				r.Post("/abs/review/{id}/dismiss", absReviewHandler.Dismiss)
-				r.Get("/abs/conflicts", absConflictHandler.List)
-				r.Post("/abs/conflicts/{id}/resolve", absConflictHandler.Resolve)
-			}
+			r.Put("/abs/config", absHandler.SetConfig)
+			r.Post("/abs/test", absHandler.Test)
+			r.Post("/abs/libraries", absHandler.Libraries)
+			r.Post("/abs/import", absImportHandler.Start)
+			r.Get("/abs/import/status", absImportHandler.Status)
+			r.Get("/abs/import/runs", absImportHandler.Runs)
+			r.Post("/abs/import/runs/{runID}/rollback/preview", absImportHandler.RollbackPreview)
+			r.Post("/abs/import/runs/{runID}/rollback", absImportHandler.Rollback)
+			r.Get("/abs/review", absReviewHandler.List)
+			r.Post("/abs/review/{id}/approve", absReviewHandler.Approve)
+			r.Post("/abs/review/{id}/resolve-author", absReviewHandler.ResolveAuthor)
+			r.Post("/abs/review/{id}/resolve-book", absReviewHandler.ResolveBook)
+			r.Post("/abs/review/{id}/dismiss", absReviewHandler.Dismiss)
+			r.Get("/abs/conflicts", absConflictHandler.List)
+			r.Post("/abs/conflicts/{id}/resolve", absConflictHandler.Resolve)
 		})
 
 		// Series

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -211,7 +211,6 @@ Multiple remaps are separated by commas: `BINDERY_DOWNLOAD_PATH_REMAP=/sab/compl
 | `BINDERY_DOWNLOAD_DIR` | `/downloads` | Where the download client places completed downloads |
 | `BINDERY_LIBRARY_DIR` | `/books` | Destination for imported ebook files |
 | `BINDERY_AUDIOBOOK_DIR` | falls back to `BINDERY_LIBRARY_DIR` | Destination for imported audiobook folders |
-| `BINDERY_ABS_ENABLED` | `false` | Set to `true` to expose and enable the Audiobookshelf (ABS) feature surface. |
 | `BINDERY_ENHANCED_HARDCOVER_API` | `false` | Set to `true` to allow token-backed Hardcover series search, linking, catalog diffs, and missing-book fill after an admin enables the feature in Settings. |
 | `BINDERY_DOWNLOAD_PATH_REMAP` | _(empty)_ | Comma-separated `from:to` pairs rewriting paths reported by the download client into paths Bindery can access. Required when SABnzbd and Bindery mount the same storage at different paths. Longest-prefix match wins. See [Path remapping](#path-remapping-multi-container--multi-pod-setups). |
 | `BINDERY_PUID` | _(unset)_ | Sanity check — see [Running as a specific UID/GID](#running-as-a-specific-uidgid) |
@@ -239,8 +238,6 @@ On first launch Bindery bootstraps itself — **no environment variables are req
 ### ABS import deployment note
 
 **Schema:** ABS import uses migrations `029` through `033`. They create five ABS tables: `abs_import_runs`, `abs_provenance`, `abs_metadata_conflicts`, `abs_import_run_entities`, and `abs_review_queue`. Migration `031` also adds `dry_run`, `source_config_json`, and `checkpoint_json` to `abs_import_runs`; migration `033` is currently a no-op compatibility migration. Take a normal SQLite backup before upgrading, then let Bindery apply the migrations on startup.
-
-**Feature flag:** ABS is disabled by default. Set `BINDERY_ABS_ENABLED=true` before startup to expose and enable the ABS feature surface.
 
 **Outbound ABS requests:** ABS probes and imports send `User-Agent: bindery/<version>` to the configured ABS server. Development or unversioned builds use `bindery/dev`.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,14 +12,14 @@ import (
 
 // Config holds the application configuration loaded from environment variables.
 type Config struct {
-	Port              string
-	DBPath            string
-	DataDir           string
-	LogLevel          string
-	APIKey            string
-	DownloadDir       string
-	LibraryDir        string
-	AudiobookDir      string
+	Port         string
+	DBPath       string
+	DataDir      string
+	LogLevel     string
+	APIKey       string
+	DownloadDir  string
+	LibraryDir   string
+	AudiobookDir string
 	// Enhanced Hardcover series API (BINDERY_ENHANCED_HARDCOVER_API, default false).
 	EnhancedHardcoverAPI bool
 	DownloadPathRemap    string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,6 @@ type Config struct {
 	DownloadDir       string
 	LibraryDir        string
 	AudiobookDir      string
-	ABSFeatureEnabled bool
 	// Enhanced Hardcover series API (BINDERY_ENHANCED_HARDCOVER_API, default false).
 	EnhancedHardcoverAPI bool
 	DownloadPathRemap    string
@@ -58,7 +57,6 @@ func Load() *Config {
 		DownloadDir:            envOr("BINDERY_DOWNLOAD_DIR", "/downloads"),
 		LibraryDir:             envOr("BINDERY_LIBRARY_DIR", "/books"),
 		AudiobookDir:           envOr("BINDERY_AUDIOBOOK_DIR", ""),
-		ABSFeatureEnabled:      envBool("BINDERY_ABS_ENABLED", false),
 		EnhancedHardcoverAPI:   envBool("BINDERY_ENHANCED_HARDCOVER_API", false),
 		DownloadPathRemap:      envOr("BINDERY_DOWNLOAD_PATH_REMAP", ""),
 		ProxyAuthHeader:        envOr("BINDERY_PROXY_AUTH_HEADER", "X-Forwarded-User"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,9 +18,6 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.LogLevel != "info" {
 		t.Errorf("expected default log level info, got %s", cfg.LogLevel)
 	}
-	if cfg.ABSFeatureEnabled {
-		t.Error("expected ABS feature flag to default to disabled")
-	}
 	if cfg.EnhancedHardcoverAPI {
 		t.Error("expected enhanced Hardcover API to default to disabled")
 	}
@@ -41,7 +38,6 @@ func TestLoadDefaults(t *testing.T) {
 func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("BINDERY_PORT", "9999")
 	t.Setenv("BINDERY_LOG_LEVEL", "debug")
-	t.Setenv("BINDERY_ABS_ENABLED", "true")
 	t.Setenv("BINDERY_ENHANCED_HARDCOVER_API", "true")
 
 	cfg := Load()
@@ -51,9 +47,6 @@ func TestLoadFromEnv(t *testing.T) {
 	}
 	if cfg.LogLevel != "debug" {
 		t.Errorf("expected log level debug, got %s", cfg.LogLevel)
-	}
-	if !cfg.ABSFeatureEnabled {
-		t.Error("expected ABS feature flag to respect BINDERY_ABS_ENABLED=true")
 	}
 	if !cfg.EnhancedHardcoverAPI {
 		t.Error("expected enhanced Hardcover API to respect BINDERY_ENHANCED_HARDCOVER_API=true")

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -19,7 +19,6 @@ export default function SettingsPage() {
   const { t, i18n } = useTranslation()
   const { isAdmin } = useAuth()
   const [tab, setTab] = useState<Tab>('general')
-  const [absFeatureEnabled, setAbsFeatureEnabled] = useState(false)
   const [indexers, setIndexers] = useState<Indexer[]>([])
   const [clients, setClients] = useState<DownloadClient[]>([])
   const [notifications, setNotifications] = useState<NotificationConfig[]>([])
@@ -72,19 +71,6 @@ export default function SettingsPage() {
     }
   }, [tab]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    if (!isAdmin) return
-    api.absConfig()
-      .then(cfg => setAbsFeatureEnabled(cfg.featureEnabled))
-      .catch(() => setAbsFeatureEnabled(false))
-  }, [isAdmin])
-
-  useEffect(() => {
-    if (!absFeatureEnabled && tab === 'abs') {
-      setTab('general')
-    }
-  }, [absFeatureEnabled, tab])
-
   const fetchLogs = (page = 0) => {
     api.getLogs({
       level: logFilter !== 'all' ? logFilter : undefined,
@@ -120,7 +106,7 @@ export default function SettingsPage() {
 
       <div className="flex flex-wrap gap-2 mb-6">
         {(isAdmin
-          ? ['general', 'indexers', 'clients', 'rootfolders', 'quality', 'metadata', 'notifications', 'calibre', ...(absFeatureEnabled ? ['abs'] : []), 'import', 'blocklist', 'logs'] as Tab[]
+          ? ['general', 'indexers', 'clients', 'rootfolders', 'quality', 'metadata', 'notifications', 'calibre', 'abs', 'import', 'blocklist', 'logs'] as Tab[]
           : ['general'] as Tab[]
         ).map(tabKey => (
           <button key={tabKey} onClick={() => setTab(tabKey)} className={tabCls(tab === tabKey)}>


### PR DESCRIPTION
## Summary

- Removes the `BINDERY_ABS_ENABLED` env-var gate — ABS is now always enabled
- All ABS routes registered unconditionally; interrupted-import resume runs on every boot
- Removes `absFeatureEnabled` state from `SettingsPage`; ABS tab always appears for admins
- Drops `BINDERY_ABS_ENABLED` from `docs/DEPLOYMENT.md`

Closes #500

## Test plan

- [ ] Build passes (`go build ./...`)
- [ ] Settings page shows ABS tab without setting any env var
- [ ] ABS config GET/PUT, test, import, review, conflict routes all reachable
- [ ] Existing ABS config in DB survives restart; interrupted import resumes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)