### PR TITLE
feat(grimmory): scaffold Grimmory integration

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -392,6 +392,7 @@ func main() {
 	logHandler := api.NewLogHandler(ring).WithLogRepo(logRepo)
 	prowlarrHandler := api.NewProwlarrHandler(prowlarrRepo, indexerRepo)
 	calibreHandler := api.NewCalibreHandler(settingsRepo)
+	grimmoryHandler := api.NewGrimmoryHandler(settingsRepo).WithVersion(version)
 	absHandler := api.NewABSHandler(settingsRepo).WithVersion(version)
 	absConflictHandler := api.NewABSConflictHandler(absConflictRepo, authorRepo, bookRepo)
 	absImportHandler := api.NewABSImportHandler(absImporter, func(ctx context.Context) api.ABSStoredConfig {
@@ -722,6 +723,11 @@ func main() {
 		// Library
 		r.Post("/library/scan", libraryHandler.Scan)
 		r.Get("/library/scan/status", libraryHandler.ScanStatus)
+
+		// Grimmory integration.
+		r.Get("/grimmory/config", grimmoryHandler.GetConfig)
+		r.Put("/grimmory/config", grimmoryHandler.SetConfig)
+		r.Post("/grimmory/test", grimmoryHandler.Test)
 
 		// Calibre integration — settings live under /setting/calibre.*,
 		// this endpoint just validates + probes the configured install.

--- a/internal/api/grimmory.go
+++ b/internal/api/grimmory.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/grimmory"
+)
+
+const (
+	SettingGrimmoryEnabled = "grimmory.enabled"
+	SettingGrimmoryBaseURL = "grimmory.base_url"
+	SettingGrimmoryAPIKey  = "grimmory.api_key" //nolint:gosec // #nosec G101 -- settings key name, not a credential value
+)
+
+// GrimmoryStoredConfig is the flat settings representation used by LoadGrimmoryConfig.
+type GrimmoryStoredConfig struct {
+	Enabled bool
+	BaseURL string
+	APIKey  string
+}
+
+// GrimmoryConfigResponse is the JSON response for GET /grimmory/config.
+type GrimmoryConfigResponse struct {
+	Enabled          bool   `json:"enabled"`
+	BaseURL          string `json:"baseUrl"`
+	APIKeyConfigured bool   `json:"apiKeyConfigured"`
+	ServerVersion    string `json:"serverVersion,omitempty"`
+}
+
+type grimmoryConfigRequest struct {
+	Enabled *bool   `json:"enabled"`
+	BaseURL *string `json:"baseUrl"`
+	APIKey  *string `json:"apiKey"`
+}
+
+type grimmoryTestResponse struct {
+	OK      bool   `json:"ok"`
+	Message string `json:"message"`
+	Version string `json:"version,omitempty"`
+}
+
+type grimmoryClientFactory func(baseURL, apiKey string) (*grimmory.Client, error)
+
+// GrimmoryHandler handles /api/grimmory/* endpoints.
+type GrimmoryHandler struct {
+	settings  *db.SettingsRepo
+	newFn     grimmoryClientFactory
+	userAgent string
+}
+
+// NewGrimmoryHandler returns a handler backed by the given settings repo.
+func NewGrimmoryHandler(settings *db.SettingsRepo) *GrimmoryHandler {
+	h := &GrimmoryHandler{
+		settings:  settings,
+		userAgent: grimmory.UserAgent(""),
+	}
+	h.newFn = func(baseURL, apiKey string) (*grimmory.Client, error) {
+		c, err := grimmory.NewClient(baseURL, apiKey)
+		if err != nil {
+			return nil, err
+		}
+		return c.WithUserAgent(h.userAgent), nil
+	}
+	return h
+}
+
+// WithVersion sets the Bindery version in the User-Agent.
+func (h *GrimmoryHandler) WithVersion(version string) *GrimmoryHandler {
+	h.userAgent = grimmory.UserAgent(version)
+	return h
+}
+
+// GetConfig returns the current Grimmory configuration (api key is redacted).
+func (h *GrimmoryHandler) GetConfig(w http.ResponseWriter, r *http.Request) {
+	cfg := LoadGrimmoryConfig(h.settings)
+	writeJSON(w, http.StatusOK, GrimmoryConfigResponse{
+		Enabled:          cfg.Enabled,
+		BaseURL:          cfg.BaseURL,
+		APIKeyConfigured: cfg.APIKey != "",
+	})
+}
+
+// SetConfig saves Grimmory connection settings.
+func (h *GrimmoryHandler) SetConfig(w http.ResponseWriter, r *http.Request) {
+	var req grimmoryConfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	ctx := r.Context()
+	set := func(key, val string) {
+		_ = h.settings.Set(ctx, key, val)
+	}
+
+	if req.Enabled != nil {
+		val := "false"
+		if *req.Enabled {
+			val = "true"
+		}
+		set(SettingGrimmoryEnabled, val)
+	}
+	if req.BaseURL != nil {
+		u, err := grimmory.NormalizeBaseURL(*req.BaseURL)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		set(SettingGrimmoryBaseURL, u)
+	}
+	if req.APIKey != nil {
+		k, err := grimmory.NormalizeAPIKey(*req.APIKey)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if k != "" {
+			set(SettingGrimmoryAPIKey, k)
+		}
+	}
+
+	cfg := LoadGrimmoryConfig(h.settings)
+	writeJSON(w, http.StatusOK, GrimmoryConfigResponse{
+		Enabled:          cfg.Enabled,
+		BaseURL:          cfg.BaseURL,
+		APIKeyConfigured: cfg.APIKey != "",
+	})
+}
+
+// Test probes the configured Grimmory server and returns version info.
+func (h *GrimmoryHandler) Test(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		BaseURL string `json:"baseUrl"`
+		APIKey  string `json:"apiKey"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	cfg := LoadGrimmoryConfig(h.settings)
+	baseURL := req.BaseURL
+	if baseURL == "" {
+		baseURL = cfg.BaseURL
+	}
+	apiKey := req.APIKey
+	if apiKey == "" {
+		apiKey = cfg.APIKey
+	}
+
+	client, err := h.newFn(baseURL, apiKey)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, grimmoryTestResponse{OK: false, Message: err.Error()})
+		return
+	}
+
+	status, err := client.Ping(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, grimmoryTestResponse{OK: false, Message: err.Error()})
+		return
+	}
+
+	msg := "Connected to Grimmory"
+	if status.Version != "" {
+		msg = "Connected to Grimmory " + status.Version
+	}
+	writeJSON(w, http.StatusOK, grimmoryTestResponse{OK: true, Message: msg, Version: status.Version})
+}
+
+// LoadGrimmoryConfig materialises a GrimmoryStoredConfig from the settings table.
+func LoadGrimmoryConfig(settings *db.SettingsRepo) GrimmoryStoredConfig {
+	ctx := context.Background()
+	get := func(key string) string {
+		s, _ := settings.Get(ctx, key)
+		if s == nil {
+			return ""
+		}
+		return s.Value
+	}
+	return GrimmoryStoredConfig{
+		Enabled: strings.EqualFold(get(SettingGrimmoryEnabled), "true"),
+		BaseURL: get(SettingGrimmoryBaseURL),
+		APIKey:  get(SettingGrimmoryAPIKey),
+	}
+}

--- a/internal/grimmory/client.go
+++ b/internal/grimmory/client.go
@@ -1,0 +1,165 @@
+// Package grimmory provides a client for the Grimmory self-hosted digital library API.
+// API reference: https://grimmory.org/docs/api (enable with API_DOCS_ENABLED=true).
+// NOTE: Grimmory's REST API is still maturing. Endpoint paths here are based on
+// the available OpenAPI docs and may change before a stable API freeze.
+package grimmory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	defaultTimeout   = 10 * time.Second
+	defaultUserAgent = "bindery/dev"
+)
+
+// APIError represents an HTTP error from the Grimmory API.
+type APIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	if e.Message == "" {
+		return fmt.Sprintf("grimmory api error (%d)", e.StatusCode)
+	}
+	return e.Message
+}
+
+// StatusResponse is the shape returned by GET /api/status.
+type StatusResponse struct {
+	Status  string `json:"status"`
+	Version string `json:"version,omitempty"`
+}
+
+// NormalizeBaseURL validates and canonicalises the user-supplied server URL.
+func NormalizeBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", errors.New("base_url is required")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("base_url %q: %w", raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("base_url %q must use http or https", raw)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("base_url %q is missing a host", raw)
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	if u.Path == "/" {
+		u.Path = ""
+	} else {
+		u.Path = strings.TrimRight(u.Path, "/")
+	}
+	return u.String(), nil
+}
+
+// NormalizeAPIKey strips whitespace and rejects control characters.
+func NormalizeAPIKey(raw string) (string, error) {
+	key := strings.TrimSpace(raw)
+	for _, r := range key {
+		if r < 0x20 || r == 0x7f {
+			return "", errors.New("api_key contains invalid control characters")
+		}
+	}
+	return key, nil
+}
+
+// UserAgent returns the Bindery User-Agent string to send to Grimmory.
+func UserAgent(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return defaultUserAgent
+	}
+	return "bindery/" + version
+}
+
+// Client is an HTTP client for the Grimmory REST API.
+type Client struct {
+	baseURL   string
+	apiKey    string
+	userAgent string
+	http      *http.Client
+}
+
+// NewClient constructs a Client after validating and normalising the provided credentials.
+func NewClient(baseURL, apiKey string) (*Client, error) {
+	u, err := NormalizeBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	k, err := NormalizeAPIKey(apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		baseURL:   u,
+		apiKey:    k,
+		userAgent: defaultUserAgent,
+		http: &http.Client{
+			Timeout: defaultTimeout,
+			Transport: &http.Transport{
+				DialContext: (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+			},
+		},
+	}, nil
+}
+
+// WithUserAgent overrides the User-Agent header sent with every request.
+func (c *Client) WithUserAgent(ua string) *Client {
+	c.userAgent = ua
+	return c
+}
+
+// Ping calls GET /api/status to verify connectivity and authentication.
+func (c *Client) Ping(ctx context.Context) (*StatusResponse, error) {
+	var resp StatusResponse
+	if err := c.do(ctx, http.MethodGet, "/api/status", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body io.Reader, out any) error {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("User-Agent", c.userAgent)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode >= 400 {
+		msg := strings.TrimSpace(string(raw))
+		if msg == "" {
+			msg = http.StatusText(resp.StatusCode)
+		}
+		return &APIError{StatusCode: resp.StatusCode, Message: msg}
+	}
+	if out != nil && len(raw) > 0 {
+		return json.Unmarshal(raw, out)
+	}
+	return nil
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -383,6 +383,13 @@ export const api = {
   calibreSyncStart: () => request<CalibreSyncProgress>('/calibre/sync', { method: 'POST' }),
   calibreSyncStatus: () => request<CalibreSyncProgress>('/calibre/sync/status'),
 
+  // Grimmory
+  grimmoryConfig: () => request<GrimmoryConfig>('/grimmory/config'),
+  grimmorySetConfig: (data: { enabled?: boolean; baseUrl?: string; apiKey?: string }) =>
+    request<GrimmoryConfig>('/grimmory/config', { method: 'PUT', body: JSON.stringify(data) }),
+  grimmoryTest: (data?: { baseUrl?: string; apiKey?: string }) =>
+    request<GrimmoryTestResult>('/grimmory/test', { method: 'POST', body: JSON.stringify(data ?? {}) }),
+
   // Audiobookshelf
   absConfig: () => request<ABSConfig>('/abs/config'),
   absSetConfig: (data: { baseUrl: string; label: string; enabled: boolean; libraryId: string; pathRemap: string; apiKey?: string }) =>
@@ -612,6 +619,18 @@ export interface CalibreSyncProgress {
   error?: string
   stats: CalibreSyncStats
   errors: CalibreSyncError[]
+}
+
+export interface GrimmoryConfig {
+  enabled: boolean
+  baseUrl: string
+  apiKeyConfigured: boolean
+}
+
+export interface GrimmoryTestResult {
+  ok: boolean
+  message: string
+  version?: string
 }
 
 export interface ABSConfig {

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -205,6 +205,7 @@
       "general": "Allgemein",
       "calibre": "Calibre",
       "abs": "Audiobookshelf",
+      "grimmory": "Grimmory",
       "blocklist": "Blockliste"
     },
     "indexers": {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -227,6 +227,7 @@
       "general": "General",
       "calibre": "Calibre",
       "abs": "Audiobookshelf",
+      "grimmory": "Grimmory",
       "blocklist": "Blocklist"
     },
     "indexers": {

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -226,6 +226,7 @@
       "general": "General",
       "calibre": "Calibre",
       "abs": "Audiobookshelf",
+      "grimmory": "Grimmory",
       "blocklist": "Lista de bloqueo"
     },
     "indexers": {

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -205,6 +205,7 @@
       "general": "Général",
       "calibre": "Calibre",
       "abs": "Audiobookshelf",
+      "grimmory": "Grimmory",
       "blocklist": "Liste de blocage"
     },
     "indexers": {

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -226,6 +226,7 @@
       "general": "Umum",
       "calibre": "Calibre",
       "abs": "Audiobookshelf",
+      "grimmory": "Grimmory",
       "blocklist": "Daftar blokir"
     },
     "indexers": {

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -205,6 +205,7 @@
       "general": "Algemeen",
       "calibre": "Calibre",
       "abs": "Audiobookshelf",
+      "grimmory": "Grimmory",
       "blocklist": "Blokkeerlijst"
     },
     "indexers": {

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -226,6 +226,7 @@
       "general": "Pangkalahatan",
       "calibre": "Calibre",
       "abs": "Audiobookshelf",
+      "grimmory": "Grimmory",
       "blocklist": "Blocklist"
     },
     "indexers": {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, ABSConfig, ABSImportProgress, ABSImportRun, ABSLibrary, ABSMetadataConflict, ABSReviewItem, ABSRollbackAction, ABSRollbackResult, ABSTestResult, AuthConfig, AuthStatus, BlocklistEntry, Indexer, IndexerTestResult, ProwlarrInstance, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, CalibreSyncProgress, RootFolder, LogEntry, ImportList, HardcoverList, HardcoverTestResult, Author, Book, SystemStatus } from '../api/client'
+import { api, ABSConfig, ABSImportProgress, ABSImportRun, ABSLibrary, ABSMetadataConflict, ABSReviewItem, ABSRollbackAction, ABSRollbackResult, ABSTestResult, GrimmoryConfig, GrimmoryTestResult, AuthConfig, AuthStatus, BlocklistEntry, Indexer, IndexerTestResult, ProwlarrInstance, DownloadClient, NotificationConfig, QualityProfile, MetadataProfile, CalibreImportProgress, CalibreSyncProgress, RootFolder, LogEntry, ImportList, HardcoverList, HardcoverTestResult, Author, Book, SystemStatus } from '../api/client'
 import AuthSettings from '../settings/AuthSettings'
 import Pagination from '../components/Pagination'
 import ABSConflictPanel from '../components/ABSAuthorConflictsPanel'
@@ -9,7 +9,7 @@ import ThemeToggle from '../components/ThemeToggle'
 import LanguageSwitcher from '../components/LanguageSwitcher'
 import { useAuth } from '../auth/AuthContext'
 
-type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import' | 'rootfolders' | 'logs' | 'blocklist' | 'calibre' | 'abs'
+type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import' | 'rootfolders' | 'logs' | 'blocklist' | 'calibre' | 'abs' | 'grimmory'
 
 const inputCls = 'w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600'
 const tabCls = (active: boolean) =>
@@ -106,7 +106,7 @@ export default function SettingsPage() {
 
       <div className="flex flex-wrap gap-2 mb-6">
         {(isAdmin
-          ? ['general', 'indexers', 'clients', 'rootfolders', 'quality', 'metadata', 'notifications', 'calibre', 'abs', 'import', 'blocklist', 'logs'] as Tab[]
+          ? ['general', 'indexers', 'clients', 'rootfolders', 'quality', 'metadata', 'notifications', 'calibre', 'abs', 'grimmory', 'import', 'blocklist', 'logs'] as Tab[]
           : ['general'] as Tab[]
         ).map(tabKey => (
           <button key={tabKey} onClick={() => setTab(tabKey)} className={tabCls(tab === tabKey)}>
@@ -780,6 +780,10 @@ export default function SettingsPage() {
 
       {tab === 'calibre' && (
         <CalibreTab />
+      )}
+
+      {tab === 'grimmory' && (
+        <GrimmoryTab />
       )}
 
       {tab === 'blocklist' && (
@@ -3097,6 +3101,139 @@ function GeneralTab() {
 
 function parseCats(s: string): number[] {
   return s.split(',').map(t => parseInt(t.trim(), 10)).filter(n => !isNaN(n))
+}
+
+function GrimmoryTab() {
+  const [config, setConfig] = useState<GrimmoryConfig | null>(null)
+  const [draft, setDraft] = useState({ baseUrl: '', apiKey: '', enabled: false })
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState<GrimmoryTestResult | null>(null)
+  const [testError, setTestError] = useState<string | null>(null)
+
+  useEffect(() => {
+    api.grimmoryConfig()
+      .then(cfg => {
+        setConfig(cfg)
+        setDraft({ baseUrl: cfg.baseUrl ?? '', apiKey: '', enabled: cfg.enabled })
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [])
+
+  const save = async () => {
+    setSaving(true)
+    setSaveError(null)
+    setTestResult(null)
+    try {
+      const payload: { enabled: boolean; baseUrl: string; apiKey?: string } = {
+        enabled: draft.enabled,
+        baseUrl: draft.baseUrl,
+      }
+      if (draft.apiKey) payload.apiKey = draft.apiKey
+      const next = await api.grimmorySetConfig(payload)
+      setConfig(next)
+      setDraft(prev => ({ ...prev, apiKey: '' }))
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const test = async () => {
+    setTesting(true)
+    setTestResult(null)
+    setTestError(null)
+    try {
+      const payload: { baseUrl?: string; apiKey?: string } = { baseUrl: draft.baseUrl }
+      if (draft.apiKey) payload.apiKey = draft.apiKey
+      const r = await api.grimmoryTest(payload)
+      setTestResult(r)
+    } catch (err) {
+      setTestError(err instanceof Error ? err.message : 'Test failed')
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  if (loading) return <div className="text-slate-600 dark:text-zinc-500">Loading…</div>
+
+  return (
+    <div className="space-y-6 max-w-lg">
+      <div>
+        <h3 className="text-lg font-semibold mb-1">Grimmory</h3>
+        <p className="text-xs text-slate-600 dark:text-zinc-500 mb-4">
+          Push newly imported books to a{' '}
+          <a href="https://grimmory.org" target="_blank" rel="noopener noreferrer" className="underline">Grimmory</a>{' '}
+          self-hosted library. Enable the Grimmory REST API (<code>API_DOCS_ENABLED=true</code>) and provide
+          your server URL and API token.
+        </p>
+      </div>
+
+      <label className="flex items-center gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={draft.enabled}
+          onChange={e => setDraft(prev => ({ ...prev, enabled: e.target.checked }))}
+          className="w-4 h-4 accent-emerald-500"
+        />
+        <span className="text-sm font-medium">Enable Grimmory integration</span>
+      </label>
+
+      <div className="space-y-3">
+        <div>
+          <label className="block text-xs font-medium mb-1">Server URL</label>
+          <input
+            type="text"
+            value={draft.baseUrl}
+            onChange={e => setDraft(prev => ({ ...prev, baseUrl: e.target.value }))}
+            placeholder="https://grimmory.example.com"
+            className={inputCls}
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium mb-1">
+            API Key{config?.apiKeyConfigured && !draft.apiKey ? ' (configured — leave blank to keep)' : ''}
+          </label>
+          <input
+            type="password"
+            value={draft.apiKey}
+            onChange={e => setDraft(prev => ({ ...prev, apiKey: e.target.value }))}
+            placeholder={config?.apiKeyConfigured ? '••••••••' : 'Paste API token here'}
+            className={inputCls}
+          />
+        </div>
+      </div>
+
+      <div className="flex gap-2 flex-wrap">
+        <button
+          onClick={save}
+          disabled={saving}
+          className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded text-sm font-medium"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          onClick={test}
+          disabled={testing || !draft.baseUrl}
+          className="px-4 py-2 bg-slate-200 dark:bg-zinc-700 hover:bg-slate-300 dark:hover:bg-zinc-600 disabled:opacity-50 rounded text-sm font-medium"
+        >
+          {testing ? 'Testing…' : 'Test Connection'}
+        </button>
+      </div>
+
+      {saveError && <p className="text-red-500 text-xs">{saveError}</p>}
+      {testError && <p className="text-red-500 text-xs">{testError}</p>}
+      {testResult && (
+        <p className={`text-xs ${testResult.ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-500'}`}>
+          {testResult.message}
+        </p>
+      )}
+    </div>
+  )
 }
 
 function CalibreTab() {


### PR DESCRIPTION
## Summary

Closes #497

Adds initial Grimmory self-hosted library integration following the ABS/Calibre HTTP client pattern:

- **`internal/grimmory/client.go`** — HTTP client with `NormalizeBaseURL`, `NormalizeAPIKey`, `UserAgent`, and `Ping` (GET `/api/status`). Bearer-token auth. API paths based on current Grimmory OpenAPI docs; flagged for update once API stabilises.
- **`internal/api/grimmory.go`** — `GrimmoryHandler` with `GetConfig` / `SetConfig` / `Test` endpoints. Settings stored as `grimmory.enabled`, `grimmory.base_url`, `grimmory.api_key`.
- **`cmd/bindery/main.go`** — Registers `GET/PUT /api/grimmory/config` and `POST /api/grimmory/test` under the admin-required group.
- **`web/src/pages/SettingsPage.tsx`** — `GrimmoryTab` with enabled toggle, Server URL, API Key fields, Save and Test Connection buttons.
- **`web/src/api/client.ts`** — `grimmoryConfig`, `grimmorySetConfig`, `grimmoryTest` API methods + `GrimmoryConfig` / `GrimmoryTestResult` types.
- All locale files — adds `settings.tabs.grimmory` key.

## Not in scope for this PR

- Post-import push (scanner hook) — depends on a stable Grimmory `/api/books` or equivalent endpoint
- Bidirectional metadata sync
- Conflict/review queue

## Test plan

- [ ] Build passes (`go build ./...`)
- [ ] Grimmory tab appears in Settings for admins
- [ ] Save persists config to DB (`grimmory.*` keys visible in `/api/settings`)
- [ ] Test Connection reaches a real Grimmory instance and reports version
- [ ] API key is redacted in `GET /grimmory/config` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)