### PR TITLE
feat(oidc): reduce first-time-setup friction — auto redirect URL, callback URL display, discovery test

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -344,7 +344,8 @@ func main() {
 	oidcResolveBase := func(r *http.Request) string {
 		return api.ResolveOIDCRedirectBase(r, cfg.OIDCRedirectBaseURL, trustedCIDRs)
 	}
-	oidcHandler := api.NewOIDCHandler(oidcMgr, userRepo, settingsRepo, authHandler, oidcResolveBase)
+	oidcHandler := api.NewOIDCHandler(oidcMgr, userRepo, settingsRepo, authHandler, oidcResolveBase).
+		WithBaseConfigured(cfg.OIDCRedirectBaseURL != "")
 	userMgmtHandler := api.NewUserManagementHandler(userRepo)
 	searchHandler := api.NewSearchHandler(metaAgg)
 	authorHandler := api.NewAuthorHandler(authorRepo, authorAliasRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched).WithFinder(importScanner)

--- a/internal/api/auth_oidc.go
+++ b/internal/api/auth_oidc.go
@@ -27,16 +27,31 @@ var oidcProviderIDRe = regexp.MustCompile(`^[a-z0-9_-]{1,32}$`)
 // which honors the configured BINDERY_OIDC_REDIRECT_BASE_URL env var first
 // and falls back to forwarded headers from a trusted proxy. Tests can supply
 // a fixed-value resolver.
+//
+// baseConfigured is true when BINDERY_OIDC_REDIRECT_BASE_URL was explicitly
+// set, false when the base URL will be derived from request headers. Used by
+// GetRedirectBase to tell the UI whether to show a "URL may not match" warning.
 type OIDCHandler struct {
-	mgr         *oidc.Manager
-	users       *db.UserRepo
-	settings    *db.SettingsRepo
-	auth        *AuthHandler
-	resolveBase func(*http.Request) string
+	mgr            *oidc.Manager
+	users          *db.UserRepo
+	settings       *db.SettingsRepo
+	auth           *AuthHandler
+	resolveBase    func(*http.Request) string
+	baseConfigured bool
 }
 
 func NewOIDCHandler(mgr *oidc.Manager, users *db.UserRepo, settings *db.SettingsRepo, auth *AuthHandler, resolveBase func(*http.Request) string) *OIDCHandler {
 	return &OIDCHandler{mgr: mgr, users: users, settings: settings, auth: auth, resolveBase: resolveBase}
+}
+
+// WithBaseConfigured sets the baseConfigured flag, indicating that
+// BINDERY_OIDC_REDIRECT_BASE_URL was explicitly configured. When false,
+// GetRedirectBase signals the UI to display a warning that the callback URL
+// shown may not match what the IdP receives (because it is derived from
+// request headers, which can vary).
+func (h *OIDCHandler) WithBaseConfigured(configured bool) *OIDCHandler {
+	h.baseConfigured = configured
+	return h
 }
 
 // Login initiates the Authorization Code + PKCE flow.
@@ -233,6 +248,11 @@ func (h *OIDCHandler) GetRedirectBase(w http.ResponseWriter, r *http.Request) {
 	writeOK(w, map[string]any{
 		"base":          h.resolveBase(r),
 		"callback_path": oidc.CallbackPath("{id}"),
+		// configured is true when BINDERY_OIDC_REDIRECT_BASE_URL was explicitly
+		// set. When false, the base URL is derived from request headers (forwarded
+		// or Host) and the UI should warn that the value shown may differ from
+		// what the IdP actually receives.
+		"configured": h.baseConfigured,
 	})
 }
 

--- a/internal/api/auth_oidc_test.go
+++ b/internal/api/auth_oidc_test.go
@@ -28,6 +28,7 @@ func TestGetRedirectBase(t *testing.T) {
 	var got struct {
 		Base         string `json:"base"`
 		CallbackPath string `json:"callback_path"`
+		Configured   bool   `json:"configured"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("parse body: %v (body=%s)", err, rec.Body.String())
@@ -37,6 +38,33 @@ func TestGetRedirectBase(t *testing.T) {
 	}
 	if got.CallbackPath != "/api/v1/auth/oidc/{id}/callback" {
 		t.Fatalf("callback_path=%q, want /api/v1/auth/oidc/{id}/callback", got.CallbackPath)
+	}
+	// default: WithBaseConfigured not called, so configured=false
+	if got.Configured {
+		t.Fatal("configured=true, want false (WithBaseConfigured not called)")
+	}
+}
+
+// TestGetRedirectBase_Configured verifies that WithBaseConfigured(true) causes
+// the endpoint to report configured=true, telling the UI not to show the
+// "BINDERY_OIDC_REDIRECT_BASE_URL not set" warning.
+func TestGetRedirectBase_Configured(t *testing.T) {
+	mgr := oidc.NewManager()
+	h := NewOIDCHandler(mgr, nil, nil, nil, func(_ *http.Request) string {
+		return "https://bindery.example.com"
+	}).WithBaseConfigured(true)
+
+	rec := httptest.NewRecorder()
+	h.GetRedirectBase(rec, httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/redirect-base", nil))
+
+	var got struct {
+		Configured bool `json:"configured"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	if !got.Configured {
+		t.Fatal("configured=false, want true (WithBaseConfigured(true) was called)")
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -151,7 +151,7 @@ export const api = {
   // callback URLs (resolved from the current request) plus the path template
   // with `{id}` placeholder. The settings UI uses these to live-render the
   // redirect URI as the admin types the provider id.
-  oidcRedirectBase: () => request<{ base: string; callback_path: string }>('/auth/oidc/redirect-base'),
+  oidcRedirectBase: () => request<{ base: string; callback_path: string; configured: boolean }>('/auth/oidc/redirect-base'),
   // Probes <issuer>/.well-known/openid-configuration server-side. ok=false
   // means the IdP is unreachable / wrong / not OIDC; the error string is
   // safe to render directly. issuer_mismatch=true is the silent killer for

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -419,6 +419,7 @@
       "fieldCallbackUrl": "Callback URL (register this in your IdP)",
       "callbackUrlEmpty": "Enter an ID above to preview the callback URL",
       "callbackUrlHint": "Copy this exact URL into your identity provider's redirect URI / callback URL field. Mismatches cause redirect_uri_mismatch errors.",
+      "callbackUrlNotConfiguredWarning": "BINDERY_OIDC_REDIRECT_BASE_URL is not set — the callback URL shown may not match what the IdP receives. Set this env var to the public URL of your Bindery instance.",
       "callbackUrlCopy": "Copy",
       "callbackUrlCopied": "Copied",
       "statusOk": "Ready",

--- a/web/src/settings/AuthSettings.tsx
+++ b/web/src/settings/AuthSettings.tsx
@@ -150,6 +150,8 @@ function AddProviderForm({
     typeof window !== 'undefined' ? window.location.origin : ''
   )
   const [callbackTemplate, setCallbackTemplate] = useState('/api/v1/auth/oidc/{id}/callback')
+  // undefined = still loading, true = env var set, false = derived from headers
+  const [baseConfigured, setBaseConfigured] = useState<boolean | undefined>(undefined)
   const [copied, setCopied] = useState(false)
 
   useEffect(() => {
@@ -157,6 +159,9 @@ function AddProviderForm({
       .then(rb => {
         if (rb.base) setRedirectBase(rb.base)
         if (rb.callback_path) setCallbackTemplate(rb.callback_path)
+        // Older backends omit `configured`; treat as true (no warning) to
+        // avoid alarming users on deploys that predate this field.
+        setBaseConfigured(rb.configured !== false)
       })
       .catch(() => {})
   }, [])
@@ -228,6 +233,11 @@ function AddProviderForm({
         <p className="text-[11px] text-slate-500 dark:text-zinc-500 mt-1">
           {t('settings.oidc.callbackUrlHint')}
         </p>
+        {baseConfigured === false && (
+          <p className="text-[11px] text-amber-700 dark:text-amber-400 mt-1">
+            {t('settings.oidc.callbackUrlNotConfiguredWarning')}
+          </p>
+        )}
       </div>
       <IssuerField value={issuer} onChange={setIssuer} />
 


### PR DESCRIPTION
## Summary

Implements the three OIDC UX improvements from issue #460 to eliminate the most common admin pain points during first-time setup:

- **Auto-derive redirect base URL from forwarded headers** — `ResolveOIDCRedirectBase` implements a full precedence chain: explicit `BINDERY_OIDC_REDIRECT_BASE_URL` > `X-Forwarded-Proto` + `X-Forwarded-Host` from a trusted proxy CIDR (same trust boundary as proxy-auth mode) > request `Host` header. A startup `slog.Warn` fires when OIDC providers are loaded but neither the env var nor trusted-proxy CIDRs are configured, alerting the operator before a user hits the broken redirect.

- **Live callback URL display in the provider form UI** — `AddProviderForm` fetches `GET /api/v1/auth/oidc/redirect-base` on mount and renders a read-only *"Callback URL (register this in your IdP)"* field with a copy-to-clipboard button. The URL updates live as the admin types the provider ID. `GetRedirectBase` now includes a `configured: bool` field so the UI can display a warning when `BINDERY_OIDC_REDIRECT_BASE_URL` is unset (meaning the shown URL is derived from request headers and may not match what the IdP actually receives).

- **"Test discovery" button on the provider form** — `IssuerField` adds a **Test** button next to the issuer input. On click it POSTs to `POST /api/v1/auth/oidc/test-discovery` which fetches `<issuer>/.well-known/openid-configuration` server-side with SSRF guards (http/https only, 8 s timeout, 256 KB body cap) and returns discovered metadata. Issuer mismatch — where the IdP's reported issuer differs from the entered URL — is flagged with an amber warning, surfacing the silent killer for Authentik per-provider mode and Keycloak realm paths.

## Changes

| File | What changed |
|---|---|
| `internal/api/auth_oidc.go` | Added `baseConfigured` field + `WithBaseConfigured()` builder; `GetRedirectBase` now includes `"configured"` in response |
| `internal/api/auth_oidc_test.go` | Added `TestGetRedirectBase_Configured` test; updated existing test to assert `configured=false` default |
| `cmd/bindery/main.go` | Wires `WithBaseConfigured(cfg.OIDCRedirectBaseURL != "")` |
| `web/src/api/client.ts` | `oidcRedirectBase` return type gains `configured: boolean` |
| `web/src/settings/AuthSettings.tsx` | `AddProviderForm` tracks `baseConfigured` state; renders amber warning when `configured === false` |
| `web/src/i18n/locales/en.json` | Adds `callbackUrlNotConfiguredWarning` key |

## Test plan

- [ ] `go test ./internal/api/ ./internal/auth/oidc/ ./internal/config/` passes
- [ ] `go build ./...` passes
- [ ] With `BINDERY_OIDC_REDIRECT_BASE_URL` unset: startup log shows warning when providers are configured; Settings form shows amber warning under the callback URL field
- [ ] With env var set: no warning shown in UI or logs
- [ ] Clicking **Test** next to the issuer field with a valid IdP URL shows discovered endpoints and a green "Discovery succeeded" message
- [ ] Issuer mismatch (e.g. Authentik provider URL) shows amber warning with the discovered vs. entered issuer
- [ ] Callback URL field updates live as the provider ID is typed; copy button works

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)