### PR TITLE
fix(discover): wrapping grid layout instead of horizontal scroll

### DIFF
--- a/web/src/components/RecommendationRow.test.tsx
+++ b/web/src/components/RecommendationRow.test.tsx
@@ -59,11 +59,17 @@ describe('RecommendationRow', () => {
     expect(screen.getByText('Gamma')).toBeInTheDocument()
   })
 
-  it('has overflow-x-auto class for horizontal scroll on mobile', () => {
+  it('uses a responsive wrapping grid layout', () => {
     const { container } = render(
       <RecommendationRow title="Row" recommendations={[makeRec(1, 'X')]} onDismiss={vi.fn()} onAdd={vi.fn()} onExcludeAuthor={vi.fn()} />
     )
-    expect(container.querySelector('.overflow-x-auto')).not.toBeNull()
+    const grid = container.querySelector('.grid')
+    expect(grid).not.toBeNull()
+    expect(grid?.className).toContain('grid-cols-1')
+    expect(grid?.className).toContain('sm:grid-cols-2')
+    expect(grid?.className).toContain('lg:grid-cols-3')
+    expect(grid?.className).toContain('xl:grid-cols-4')
+    expect(container.querySelector('.overflow-x-auto')).toBeNull()
   })
 
   it('passes onDismiss through to each card', () => {

--- a/web/src/components/RecommendationRow.tsx
+++ b/web/src/components/RecommendationRow.tsx
@@ -15,7 +15,7 @@ export default function RecommendationRow({ title, recommendations, onDismiss, o
   return (
     <div className="mb-8">
       <h3 className="text-base font-semibold mb-3 text-slate-700 dark:text-zinc-300">{title}</h3>
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
         {recommendations.map(rec => (
           <RecommendationCard
             key={rec.id}


### PR DESCRIPTION
## Summary
- Swap `RecommendationRow` layout from the dense 2/3/4/5/6-column grid to the issue's target `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4`, matching the Authors tab pattern.
- Update `RecommendationRow.test.tsx` to assert the responsive grid classes; remove the stale `overflow-x-auto` assertion.

Closes #347

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` clean (warnings unchanged from main)
- [x] Updated grid test passes; one pre-existing unrelated test failure remains untouched