### PR TITLE
fix(auth): redirect authenticated users away from /login

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { api } from './api/client'
 import { AuthProvider, useAuth } from './auth/AuthContext'
 import AuthGuard from './auth/AuthGuard'
+import PublicOnlyRoute from './auth/PublicOnlyRoute'
 import LoginPage from './pages/LoginPage'
 import SetupPage from './pages/SetupPage'
 import AuthorsPage from './pages/AuthorsPage'
@@ -276,8 +277,22 @@ function App() {
     <BrowserRouter>
       <AuthProvider>
         <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/setup" element={<SetupPage />} />
+          <Route
+            path="/login"
+            element={
+              <PublicOnlyRoute mode="login">
+                <LoginPage />
+              </PublicOnlyRoute>
+            }
+          />
+          <Route
+            path="/setup"
+            element={
+              <PublicOnlyRoute mode="setup">
+                <SetupPage />
+              </PublicOnlyRoute>
+            }
+          />
           <Route
             path="/*"
             element={

--- a/web/src/auth/PublicOnlyRoute.test.tsx
+++ b/web/src/auth/PublicOnlyRoute.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import PublicOnlyRoute from './PublicOnlyRoute'
+import type { AuthStatus } from '../api/client'
+
+// We swap the useAuth implementation per-test via vi.mock + a mutable holder.
+// AuthContext is otherwise untouched; this keeps the test focused on the
+// route-guard's decision tree without spinning up the real provider.
+let mockAuth: { status: AuthStatus | null; loading: boolean } = {
+  status: null,
+  loading: false,
+}
+
+vi.mock('./AuthContext', () => ({
+  useAuth: () => mockAuth,
+}))
+
+function renderAt(path: string, mode: 'login' | 'setup') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/" element={<div data-testid="home" />} />
+        <Route path="/setup" element={<div data-testid="setup" />} />
+        <Route
+          path="/login"
+          element={
+            <PublicOnlyRoute mode={mode}>
+              <div data-testid="login-page" />
+            </PublicOnlyRoute>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('PublicOnlyRoute — login mode', () => {
+  it('redirects authenticated users away from /login to /', () => {
+    mockAuth = {
+      loading: false,
+      status: { authenticated: true, setupRequired: false, mode: 'enabled' },
+    }
+    renderAt('/login', 'login')
+    expect(screen.getByTestId('home')).toBeInTheDocument()
+    expect(screen.queryByTestId('login-page')).toBeNull()
+  })
+
+  it('renders the login page for unauthenticated users', () => {
+    mockAuth = {
+      loading: false,
+      status: { authenticated: false, setupRequired: false, mode: 'enabled' },
+    }
+    renderAt('/login', 'login')
+    expect(screen.getByTestId('login-page')).toBeInTheDocument()
+  })
+
+  it('shows the loading placeholder while auth status is in flight (no flash redirect)', () => {
+    mockAuth = { loading: true, status: null }
+    renderAt('/login', 'login')
+    expect(screen.queryByTestId('login-page')).toBeNull()
+    expect(screen.queryByTestId('home')).toBeNull()
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument()
+  })
+
+  it('routes to /setup when setup is still required, even on /login', () => {
+    mockAuth = {
+      loading: false,
+      status: { authenticated: false, setupRequired: true, mode: 'enabled' },
+    }
+    renderAt('/login', 'login')
+    expect(screen.getByTestId('setup')).toBeInTheDocument()
+    expect(screen.queryByTestId('login-page')).toBeNull()
+  })
+})

--- a/web/src/auth/PublicOnlyRoute.tsx
+++ b/web/src/auth/PublicOnlyRoute.tsx
@@ -1,0 +1,56 @@
+import { ReactNode } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from './AuthContext'
+
+// PublicOnlyRoute is the inverse of AuthGuard: it wraps routes that should
+// only ever render for users who aren't yet signed in (e.g. /login, /setup).
+// Decision tree mirrors AuthGuard:
+//
+//   loading → render the same quiet placeholder (avoids a login-page flash on
+//             refresh while /api/v1/auth/status is in flight)
+//   setup required & route is not /setup → force /setup
+//   authenticated & setup not required → redirect home
+//   otherwise → render children
+//
+// `mode`:
+//   'login'  — redirect home if already authenticated
+//   'setup'  — redirect home once setup is no longer required (i.e. an admin
+//              account exists), or to /setup if we're on /login but setup is
+//              still pending. The latter is already handled by AuthGuard for
+//              authed routes; here we keep /setup itself stable.
+export default function PublicOnlyRoute({
+  children,
+  mode,
+}: {
+  children: ReactNode
+  mode: 'login' | 'setup'
+}) {
+  const { status, loading } = useAuth()
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-slate-500 dark:text-zinc-500 text-sm">
+        Loading…
+      </div>
+    )
+  }
+
+  if (mode === 'login') {
+    if (status?.setupRequired) {
+      return <Navigate to="/setup" replace />
+    }
+    if (status?.authenticated) {
+      return <Navigate to="/" replace />
+    }
+  }
+
+  if (mode === 'setup') {
+    // Setup page should disappear once setup is complete. If the user is
+    // already authenticated or setup is no longer required, bounce home.
+    if (!status?.setupRequired) {
+      return <Navigate to="/" replace />
+    }
+  }
+
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary
- Adds `PublicOnlyRoute`, the inverse of `AuthGuard`, and wraps `/login` and `/setup` in it so an already-authenticated session never sees a stale login/setup screen.
- Mirrors `AuthGuard`'s loading-state placeholder so a refresh doesn't briefly flash the login page (or a redirect) before `/api/v1/auth/status` resolves.
- No changes to `AuthGuard`, `AuthContext`, `LoginPage`, or `SetupPage`; this is a route-level addition only.

## Repro (from #493)
1. Sign in.
2. Navigate directly to `/login`.
3. Before this change, Bindery rendered the login form. After this change, the user is redirected to `/`.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (no new warnings/errors)
- [x] New `web/src/auth/PublicOnlyRoute.test.tsx` covers the four branches: authenticated → `/`, unauthenticated → renders, loading → placeholder (no flash), `setupRequired` → `/setup`

Closes #493