### PR TITLE
fix(scanner): reconcile ebooks in comma-suffix sort folders (Title, A / Title, The)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -67,7 +67,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -race -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
@@ -103,7 +103,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
@@ -131,7 +131,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -race ./cmd/... ./internal/...
 
@@ -275,7 +275,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -333,7 +333,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - name: Run ABS contract suite
         env:
@@ -356,7 +356,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - name: Wait for ArgoCD dev to sync
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
 
       - name: gosec (SARIF)
@@ -283,7 +283,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vavallee/bindery
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -872,6 +872,33 @@ func (s *Scanner) findExistingInDir(root, title, authorName string) string {
 	return found
 }
 
+// normalizeTitle lowercases a title, converts comma-suffix article form to
+// leading-article form, then strips the leading article so that all three
+// representations of the same title compare equal:
+//
+//	"A Darker Shade of Magic"       → "darker shade of magic"
+//	"Darker Shade of Magic, A"      → "darker shade of magic"
+//	"The Fragile Threads of Power"  → "fragile threads of power"
+//	"Fragile Threads of Power, The" → "fragile threads of power"
+func normalizeTitle(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	// Invert comma-suffix form: check ", an" before ", a" to avoid prefix collision.
+	for _, art := range []string{", the", ", an", ", a"} {
+		if strings.HasSuffix(s, art) {
+			s = art[2:] + " " + s[:len(s)-len(art)]
+			break
+		}
+	}
+	// Strip leading article; check "an " before "a " for the same reason.
+	for _, art := range []string{"the ", "an ", "a "} {
+		if strings.HasPrefix(s, art) {
+			s = s[len(art):]
+			break
+		}
+	}
+	return s
+}
+
 // titleMatch returns true when bookTitle and parsedTitle refer to the same work.
 // It handles numeric titles (1984, 2001), article normalization ("Title, The"),
 // and uses dynamic overlap thresholds so short titles still match correctly.
@@ -880,25 +907,8 @@ func titleMatch(bookTitle, parsedTitle string) bool {
 		return false
 	}
 
-	// norm lowercases, handles "Title, The" inversion, and strips leading articles.
-	norm := func(s string) string {
-		s = strings.ToLower(strings.TrimSpace(s))
-		// Normalize "Title, The" → "the title" (comma-article inversion)
-		if idx := strings.LastIndex(s, ", the"); idx != -1 && idx == len(s)-5 {
-			s = "the " + s[:idx]
-		}
-		// Strip leading article for comparison
-		for _, art := range []string{"the ", "a ", "an "} {
-			if strings.HasPrefix(s, art) {
-				s = s[len(art):]
-				break
-			}
-		}
-		return s
-	}
-
 	// Fast path: exact match after normalization
-	if norm(bookTitle) == norm(parsedTitle) {
+	if normalizeTitle(bookTitle) == normalizeTitle(parsedTitle) {
 		return true
 	}
 
@@ -1155,8 +1165,10 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 				}
 				// Require Jaro-Winkler >= 0.85 on normalised titles to prevent
 				// low-confidence matches from reconciling the wrong book after a
-				// delete+rescan cycle (#343).
-				jwScore := textutil.JaroWinkler(strings.ToLower(b.Title), strings.ToLower(parsed.Title))
+				// delete+rescan cycle (#343). normalizeTitle strips leading articles
+				// and inverts comma-suffix sort form ("Title, A" → "title") so that
+				// librarian-sorted folders reconcile correctly (#513).
+				jwScore := textutil.JaroWinkler(normalizeTitle(b.Title), normalizeTitle(parsed.Title))
 				if b.Status != models.BookStatusWanted ||
 					jwScore < 0.85 ||
 					!authorMatch(authorNames[b.AuthorID], parsed.Author) {

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -14,6 +14,31 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
+func TestNormalizeTitle(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		// Leading-article forms are stripped
+		{"A Darker Shade of Magic", "darker shade of magic"},
+		{"An Ember in the Ashes", "ember in the ashes"},
+		{"The Fragile Threads of Power", "fragile threads of power"},
+		// Comma-suffix forms are inverted then stripped
+		{"Darker Shade of Magic, A", "darker shade of magic"},
+		{"Ember in the Ashes, An", "ember in the ashes"},
+		{"Fragile Threads of Power, The", "fragile threads of power"},
+		// No article — unchanged (lowercased)
+		{"Project Hail Mary", "project hail mary"},
+		// Already normalised
+		{"darker shade of magic", "darker shade of magic"},
+	}
+	for _, tt := range tests {
+		if got := normalizeTitle(tt.in); got != tt.want {
+			t.Errorf("normalizeTitle(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestTitleMatch(t *testing.T) {
 	tests := []struct {
 		bookTitle   string
@@ -38,8 +63,10 @@ func TestTitleMatch(t *testing.T) {
 		{"1984", "1984", true},
 		{"1984", "George Orwell 1984", true},
 
-		// Article inversion: "Lord of the Rings, The" normalises to same as "The Lord of the Rings"
+		// Article inversion: comma-suffix form matches leading-article DB title
 		{"The Lord of the Rings", "Lord of the Rings, The", true},
+		{"A Darker Shade of Magic", "Darker Shade of Magic, A", true},
+		{"An Ember in the Ashes", "Ember in the Ashes, An", true},
 
 		// Dots in parsed title are split on non-alnum — "Project.Hail.Mary" yields 3 tokens
 		{"Project Hail Mary", "Project.Hail.Mary", true},


### PR DESCRIPTION
Fixes #513.

## Root cause

`ScanLibrary` compared titles via `JaroWinkler(strings.ToLower(b.Title), strings.ToLower(parsed.Title))` — no article normalisation. A file at `Darker Shade of Magic, A.epub` parses to `parsed.Title = "Darker Shade of Magic, A"`. Compared against the DB title `"A Darker Shade of Magic"`, the JW score falls below the 0.85 threshold and the file lands in the unmatched bucket, leaving the book `wanted` despite the ebook being on disk.

A secondary bug: the `norm()` closure in `titleMatch` (used by `FindExisting`) already handled `, the` inversion but silently missed `, a` and `, an`.

## Fix

Extract `norm()` into a package-level `normalizeTitle` that:
1. Inverts all three comma-suffix forms — `, the` / `, an` / `, a` (checked longest-first to avoid prefix collision)
2. Strips the resulting leading article

Use it in both `titleMatch` (removing the inline closure) and the `ScanLibrary` JW comparison. After normalisation, all three representations reduce to the same bare string and score 1.0.

```
normalizeTitle("A Darker Shade of Magic")       → "darker shade of magic"
normalizeTitle("Darker Shade of Magic, A")      → "darker shade of magic"
normalizeTitle("The Fragile Threads of Power")  → "fragile threads of power"
normalizeTitle("Fragile Threads of Power, The") → "fragile threads of power"
```

## Tests

- `TestNormalizeTitle` — covers all six normalisation cases (leading article + comma-suffix, all three articles)
- `TestTitleMatch` — added `, A` and `, An` cases alongside the existing `, The` case

## Test plan
- [ ] `go test ./internal/importer/...` passes
- [ ] Library scan on a filesystem with `Title, A` / `Title, An` / `Title, The` folders reconciles the expected books
- [ ] Books already reconciled via exact or JW match are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)