### PR TITLE
fix(hardcover): unmarshal data.me as array (fixes lists fetch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -67,7 +67,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -race -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
@@ -103,7 +103,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
@@ -131,7 +131,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -race ./cmd/... ./internal/...
 
@@ -275,7 +275,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -333,7 +333,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - name: Run ABS contract suite
         env:
@@ -356,7 +356,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - name: Wait for ArgoCD dev to sync
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
 
       - name: gosec (SARIF)
@@ -283,7 +283,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vavallee/bindery
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -351,7 +351,7 @@ func (c *Client) GetUserWishlist(ctx context.Context, limit int) ([]models.Recom
 	}`
 	var resp struct {
 		Data struct {
-			Me struct {
+			Me []struct {
 				UserBooks []struct {
 					Book hcBook `json:"book"`
 				} `json:"user_books"`
@@ -361,9 +361,12 @@ func (c *Client) GetUserWishlist(ctx context.Context, limit int) ([]models.Recom
 	if err := c.query(ctx, gql, map[string]any{"limit": limit}, &resp); err != nil {
 		return nil, fmt.Errorf("hardcover get wishlist: %w", err)
 	}
+	if len(resp.Data.Me) == 0 {
+		return nil, nil
+	}
 
-	candidates := make([]models.RecommendationCandidate, 0, len(resp.Data.Me.UserBooks))
-	for _, ub := range resp.Data.Me.UserBooks {
+	candidates := make([]models.RecommendationCandidate, 0, len(resp.Data.Me[0].UserBooks))
+	for _, ub := range resp.Data.Me[0].UserBooks {
 		b := c.toBook(ub.Book)
 		cand := models.RecommendationCandidate{
 			ForeignID:    b.ForeignID,
@@ -439,7 +442,7 @@ func (c *Client) GetUserLists(ctx context.Context) ([]HCList, error) {
 	}`
 	var resp struct {
 		Data struct {
-			Me struct {
+			Me []struct {
 				Lists []struct {
 					ID         int    `json:"id"`
 					Name       string `json:"name"`
@@ -452,9 +455,18 @@ func (c *Client) GetUserLists(ctx context.Context) ([]HCList, error) {
 	if err := c.query(ctx, gql, nil, &resp); err != nil {
 		return nil, fmt.Errorf("hardcover get user lists: %w", err)
 	}
-	lists := make([]HCList, 0, len(hcBuiltinShelves)+len(resp.Data.Me.Lists))
+	var customLists []struct {
+		ID         int    `json:"id"`
+		Name       string `json:"name"`
+		Slug       string `json:"slug"`
+		BooksCount int    `json:"books_count"`
+	}
+	if len(resp.Data.Me) > 0 {
+		customLists = resp.Data.Me[0].Lists
+	}
+	lists := make([]HCList, 0, len(hcBuiltinShelves)+len(customLists))
 	lists = append(lists, hcBuiltinShelves...)
-	for _, l := range resp.Data.Me.Lists {
+	for _, l := range customLists {
 		lists = append(lists, HCList{
 			ID:         l.ID,
 			Name:       l.Name,
@@ -535,7 +547,7 @@ func (c *Client) getShelfBooks(ctx context.Context, statusID int) ([]models.Book
 	}`
 	var resp struct {
 		Data struct {
-			Me struct {
+			Me []struct {
 				UserBooks []struct {
 					Book hcBook `json:"book"`
 				} `json:"user_books"`
@@ -545,8 +557,11 @@ func (c *Client) getShelfBooks(ctx context.Context, statusID int) ([]models.Book
 	if err := c.query(ctx, gql, map[string]any{"statusID": statusID}, &resp); err != nil {
 		return nil, fmt.Errorf("hardcover get shelf books: %w", err)
 	}
-	books := make([]models.Book, 0, len(resp.Data.Me.UserBooks))
-	for _, ub := range resp.Data.Me.UserBooks {
+	if len(resp.Data.Me) == 0 {
+		return nil, nil
+	}
+	books := make([]models.Book, 0, len(resp.Data.Me[0].UserBooks))
+	for _, ub := range resp.Data.Me[0].UserBooks {
 		books = append(books, c.toBook(ub.Book))
 	}
 	return books, nil

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -869,28 +869,30 @@ func TestGetUserWishlist_Success(t *testing.T) {
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
 		gotAuth = r.Header.Get("Authorization")
 		data := map[string]interface{}{
-			"me": map[string]interface{}{
-				"user_books": []map[string]interface{}{
-					{
-						"book": map[string]interface{}{
-							"id":            101,
-							"title":         "Project Hail Mary",
-							"slug":          "project-hail-mary",
-							"description":   "An astronaut wakes up alone.",
-							"release_year":  year,
-							"rating":        4.7,
-							"ratings_count": 50000,
-							"image":         map[string]interface{}{"url": "https://img.example.com/phm.jpg"},
-							"contributions": []map[string]interface{}{
-								{"author": map[string]interface{}{"id": 7, "name": "Andy Weir", "slug": "andy-weir"}},
+			"me": []map[string]interface{}{
+				{
+					"user_books": []map[string]interface{}{
+						{
+							"book": map[string]interface{}{
+								"id":            101,
+								"title":         "Project Hail Mary",
+								"slug":          "project-hail-mary",
+								"description":   "An astronaut wakes up alone.",
+								"release_year":  year,
+								"rating":        4.7,
+								"ratings_count": 50000,
+								"image":         map[string]interface{}{"url": "https://img.example.com/phm.jpg"},
+								"contributions": []map[string]interface{}{
+									{"author": map[string]interface{}{"id": 7, "name": "Andy Weir", "slug": "andy-weir"}},
+								},
 							},
 						},
-					},
-					{
-						"book": map[string]interface{}{
-							"id":    102,
-							"title": "Dune",
-							"slug":  "dune",
+						{
+							"book": map[string]interface{}{
+								"id":    102,
+								"title": "Dune",
+								"slug":  "dune",
+							},
 						},
 					},
 				},
@@ -956,7 +958,7 @@ func TestGetUserWishlist_DefaultLimit(t *testing.T) {
 		_ = json.Unmarshal(body, &req)
 		gotVars = req.Variables
 		return gqlResponse(t, http.StatusOK, map[string]interface{}{
-			"me": map[string]interface{}{"user_books": []interface{}{}},
+			"me": []map[string]interface{}{{"user_books": []interface{}{}}},
 		}), nil
 	})
 	c = c.WithToken("t")
@@ -974,7 +976,7 @@ func TestGetUserWishlist_DefaultLimit(t *testing.T) {
 func TestGetUserWishlist_Empty(t *testing.T) {
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
 		return gqlResponse(t, http.StatusOK, map[string]interface{}{
-			"me": map[string]interface{}{"user_books": []interface{}{}},
+			"me": []map[string]interface{}{{"user_books": []interface{}{}}},
 		}), nil
 	}).WithToken("t")
 
@@ -1006,7 +1008,7 @@ func TestGetUserLists_IncludesBuiltinShelves(t *testing.T) {
 	// When me.lists returns an empty array (user has no custom lists),
 	// GetUserLists must still return the 4 built-in shelf entries.
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
-		body := `{"data":{"me":{"lists":[]}}}`
+		body := `{"data":{"me":[{"lists":[]}]}}`
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(body)),
@@ -1029,7 +1031,7 @@ func TestGetUserLists_IncludesBuiltinShelves(t *testing.T) {
 
 func TestGetUserLists_CustomListsAppendedAfterShelves(t *testing.T) {
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
-		body := `{"data":{"me":{"lists":[{"id":42,"name":"Favorites","slug":"favorites","books_count":7}]}}}`
+		body := `{"data":{"me":[{"lists":[{"id":42,"name":"Favorites","slug":"favorites","books_count":7}]}]}}`
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(body)),
@@ -1059,7 +1061,7 @@ func TestGetListBooks_BuiltinShelfRoutesToUserBooks(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(body, &req)
 		gotVars = req.Variables
-		resp := `{"data":{"me":{"user_books":[{"book":{"id":99,"title":"Dune","slug":"dune","contributions":[{"author":{"id":1,"name":"Frank Herbert","slug":"frank-herbert"}}]}}]}}}`
+		resp := `{"data":{"me":[{"user_books":[{"book":{"id":99,"title":"Dune","slug":"dune","contributions":[{"author":{"id":1,"name":"Frank Herbert","slug":"frank-herbert"}}]}}]}]}}`
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(resp)),


### PR DESCRIPTION
## Summary

- **Root cause:** The Hardcover GraphQL API returns `data.me` as a JSON array, but all three Go response structs that decoded `me` (`GetUserWishlist`, `GetUserLists`, `getShelfBooks`) used a plain `struct`, causing `json: cannot unmarshal array into Go struct field` at runtime.
- **Fix:** Changed each `Me struct { ... }` field to `Me []struct { ... }` and updated the consumption sites to take `[0]` (guarded by a length check). Updated all test fixtures to send `me` as a single-element array, matching the real API shape.
- Fixes #489

## Test plan

- [x] `go build ./...` — clean build
- [x] `go test ./internal/metadata/hardcover/... ./internal/...` — all packages pass
- [x] Existing `TestGetUserLists_*`, `TestGetUserWishlist_*`, `TestGetListBooks_BuiltinShelfRoutesToUserBooks` tests updated to use array-shaped `me` and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)