### PR TITLE
feat(books): re-bind book to different metadata record (#492)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -67,7 +67,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -race -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
@@ -103,7 +103,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
@@ -131,7 +131,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -race ./cmd/... ./internal/...
 
@@ -275,7 +275,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -333,7 +333,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - name: Run ABS contract suite
         env:
@@ -356,7 +356,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - name: Wait for ArgoCD dev to sync
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
 
       - name: gosec (SARIF)
@@ -283,7 +283,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -352,7 +352,7 @@ func main() {
 	searchHandler := api.NewSearchHandler(metaAgg)
 	authorHandler := api.NewAuthorHandler(authorRepo, authorAliasRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched).WithFinder(importScanner)
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
-	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).WithSettings(settingsRepo).WithDownloads(downloadRepo)
+	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).WithSettings(settingsRepo).WithDownloads(downloadRepo).WithAuthors(authorRepo).WithSeries(seriesRepo)
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, metadataProfileRepo, idxSearcher, settingsRepo, blocklistRepo).WithAliases(authorAliasRepo)
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)
 	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo).WithNotifier(notif)

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -555,6 +555,7 @@ func main() {
 		r.Delete("/book/{id}", bookHandler.Delete)
 		r.Delete("/book/{id}/file", bookHandler.DeleteFile)
 		r.Put("/book/{id}/exclude", bookHandler.ToggleExcluded)
+		r.Post("/book/{id}/rebind", bookHandler.Rebind)
 		r.Post("/book/{id}/enrich-audiobook", bookHandler.EnrichAudiobook)
 		r.Post("/book/{id}/search", indexerHandler.SearchBook)
 		r.Get("/book/{id}/file", fileHandler.Download)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vavallee/bindery
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -23,6 +23,7 @@ import (
 type BookHandler struct {
 	books     *db.BookRepo
 	meta      *metadata.Aggregator
+	lookup    BookMetaLookup // used by Rebind; defaults to meta when non-nil
 	history   *db.HistoryRepo
 	searcher  BookSearcher
 	settings  *db.SettingsRepo
@@ -32,7 +33,18 @@ type BookHandler struct {
 }
 
 func NewBookHandler(books *db.BookRepo, meta *metadata.Aggregator, history *db.HistoryRepo, searcher BookSearcher) *BookHandler {
-	return &BookHandler{books: books, meta: meta, history: history, searcher: searcher}
+	h := &BookHandler{books: books, meta: meta, history: history, searcher: searcher}
+	if meta != nil {
+		h.lookup = meta
+	}
+	return h
+}
+
+// WithMetaLookup overrides the BookMetaLookup used by Rebind. Useful in tests
+// to inject a stub without a real HTTP client.
+func (h *BookHandler) WithMetaLookup(l BookMetaLookup) *BookHandler {
+	h.lookup = l
+	return h
 }
 
 // WithSettings wires in the settings repo so the book handler can consult the
@@ -520,12 +532,12 @@ func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.meta == nil {
+	if h.lookup == nil {
 		writeJSON(w, http.StatusFailedDependency, map[string]string{"error": "metadata aggregator not configured"})
 		return
 	}
 
-	upstream, err := h.meta.GetBookFromProvider(r.Context(), req.Provider, req.ForeignID)
+	upstream, err := h.lookup.GetBookFromProvider(r.Context(), req.Provider, req.ForeignID)
 	if err != nil {
 		slog.Warn("rebind: upstream fetch failed", "bookId", book.ID, "provider", req.Provider, "foreignId", req.ForeignID, "error", err)
 		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -458,6 +459,106 @@ func (h *BookHandler) ListWanted(w http.ResponseWriter, r *http.Request) {
 
 // ToggleExcluded flips the excluded flag on a book. The response body is the
 // updated book so the UI can refresh in place without a second round-trip.
+// Rebind updates the book's foreign_id and metadata_provider, then re-fetches
+// metadata from that provider. This lets users correct a wrong match (e.g. an
+// omnibus instead of the standalone Book 1) without deleting and re-adding.
+//
+// Request body: {"provider": "openlibrary"|"hardcover", "foreign_id": "<id>"}
+// Returns the updated book JSON.
+func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+	book, err := h.books.GetByID(r.Context(), id)
+	if err != nil || book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
+
+	var req struct {
+		Provider  string `json:"provider"`
+		ForeignID string `json:"foreign_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	req.Provider = strings.TrimSpace(strings.ToLower(req.Provider))
+	req.ForeignID = strings.TrimSpace(req.ForeignID)
+	if req.Provider == "" || req.ForeignID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "provider and foreign_id are required"})
+		return
+	}
+	switch req.Provider {
+	case "openlibrary", "hardcover":
+		// valid
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "provider must be 'openlibrary' or 'hardcover'"})
+		return
+	}
+
+	if h.meta == nil {
+		writeJSON(w, http.StatusFailedDependency, map[string]string{"error": "metadata aggregator not configured"})
+		return
+	}
+
+	upstream, err := h.meta.GetBookFromProvider(r.Context(), req.Provider, req.ForeignID)
+	if err != nil {
+		slog.Warn("rebind: upstream fetch failed", "bookId", book.ID, "provider", req.Provider, "foreignId", req.ForeignID, "error", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	if upstream == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no record found for that provider and foreign ID"})
+		return
+	}
+
+	// Update the book with the new foreign ID and refreshed metadata.
+	// Preserve fields managed by the user or the import pipeline (status,
+	// monitored, file paths, media type, ASIN, narrator, calibre_id).
+	book.ForeignID = req.ForeignID
+	book.MetadataProvider = req.Provider
+	if upstream.Title != "" {
+		book.Title = upstream.Title
+		book.SortTitle = upstream.SortTitle
+	}
+	if upstream.OriginalTitle != "" {
+		book.OriginalTitle = upstream.OriginalTitle
+	}
+	if upstream.Description != "" {
+		book.Description = upstream.Description
+	}
+	if upstream.ImageURL != "" {
+		book.ImageURL = upstream.ImageURL
+	}
+	if upstream.ReleaseDate != nil {
+		book.ReleaseDate = upstream.ReleaseDate
+	}
+	if len(upstream.Genres) > 0 {
+		book.Genres = upstream.Genres
+	}
+	if upstream.AverageRating > 0 {
+		book.AverageRating = upstream.AverageRating
+		book.RatingsCount = upstream.RatingsCount
+	}
+	if upstream.Language != "" {
+		book.Language = upstream.Language
+	}
+	now := time.Now().UTC()
+	book.LastMetadataRefreshAt = &now
+
+	if err := h.books.Update(r.Context(), book); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	h.attachBookFiles(r.Context(), book)
+	cleanBookDescription(book)
+	proxyBookImages(book)
+	writeJSON(w, http.StatusOK, book)
+}
+
 func (h *BookHandler) ToggleExcluded(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseID(w, r)
 	if !ok {

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -27,6 +27,8 @@ type BookHandler struct {
 	searcher  BookSearcher
 	settings  *db.SettingsRepo
 	downloads *db.DownloadRepo
+	authors   *db.AuthorRepo
+	series    *db.SeriesRepo
 }
 
 func NewBookHandler(books *db.BookRepo, meta *metadata.Aggregator, history *db.HistoryRepo, searcher BookSearcher) *BookHandler {
@@ -44,6 +46,18 @@ func (h *BookHandler) WithSettings(settings *db.SettingsRepo) *BookHandler {
 // download records when a book is deleted with ?deleteFiles=true.
 func (h *BookHandler) WithDownloads(d *db.DownloadRepo) *BookHandler {
 	h.downloads = d
+	return h
+}
+
+// WithAuthors wires in the author repo so Rebind can detect author mismatches.
+func (h *BookHandler) WithAuthors(a *db.AuthorRepo) *BookHandler {
+	h.authors = a
+	return h
+}
+
+// WithSeries wires in the series repo so Rebind can re-link series membership.
+func (h *BookHandler) WithSeries(s *db.SeriesRepo) *BookHandler {
+	h.series = s
 	return h
 }
 
@@ -457,14 +471,21 @@ func (h *BookHandler) ListWanted(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, books)
 }
 
-// ToggleExcluded flips the excluded flag on a book. The response body is the
-// updated book so the UI can refresh in place without a second round-trip.
-// Rebind updates the book's foreign_id and metadata_provider, then re-fetches
-// metadata from that provider. This lets users correct a wrong match (e.g. an
-// omnibus instead of the standalone Book 1) without deleting and re-adding.
+// Rebind updates a book's foreign_id and metadata_provider, then re-fetches
+// metadata from that provider. This lets users correct a wrong metadata match
+// (e.g. an omnibus instead of the standalone Book 1) without deleting and
+// re-adding the book.
 //
-// Request body: {"provider": "openlibrary"|"hardcover", "foreign_id": "<id>"}
-// Returns the updated book JSON.
+// Request body:
+//
+//	{
+//	  "provider":   "openlibrary"|"hardcover",
+//	  "foreign_id": "<id>",
+//	  "force":      false   // set true to override an author-mismatch warning
+//	}
+//
+// Returns 409 when the upstream record belongs to a different author unless
+// force=true is passed. Returns the updated book JSON on success.
 func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseID(w, r)
 	if !ok {
@@ -479,6 +500,7 @@ func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Provider  string `json:"provider"`
 		ForeignID string `json:"foreign_id"`
+		Force     bool   `json:"force"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -513,6 +535,26 @@ func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no record found for that provider and foreign ID"})
 		return
 	}
+
+	// Author-mismatch guard: if the upstream record belongs to a different
+	// author than the current book row, reject unless the caller passes force=true.
+	// This prevents a typo in the foreign ID from silently corrupting authorship.
+	if !req.Force && h.authors != nil && upstream.Author != nil && upstream.Author.ForeignID != "" {
+		currentAuthor, authErr := h.authors.GetByID(r.Context(), book.AuthorID)
+		if authErr == nil && currentAuthor != nil && currentAuthor.ForeignID != upstream.Author.ForeignID {
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"error":           "author mismatch: upstream record belongs to a different author",
+				"current_author":  currentAuthor.Name,
+				"upstream_author": upstream.Author.Name,
+				"force_required":  true,
+			})
+			return
+		}
+	}
+
+	// Snapshot old identifiers for the audit trail before mutating the book.
+	oldProvider := book.MetadataProvider
+	oldForeignID := book.ForeignID
 
 	// Update the book with the new foreign ID and refreshed metadata.
 	// Preserve fields managed by the user or the import pipeline (status,
@@ -549,8 +591,53 @@ func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
 	book.LastMetadataRefreshAt = &now
 
 	if err := h.books.Update(r.Context(), book); err != nil {
+		// A UNIQUE constraint means another book row already owns this foreign_id.
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "a different book already uses that foreign ID"})
+			return
+		}
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
+	}
+
+	// Re-link series membership: remove all existing links for this book, then
+	// attach whatever the upstream record declares.
+	if h.series != nil {
+		if existingIDs, serErr := h.series.GetSeriesIDsForBook(r.Context(), book.ID); serErr == nil {
+			for _, sid := range existingIDs {
+				_ = h.series.UnlinkBook(r.Context(), sid, book.ID)
+			}
+		}
+		for _, ref := range upstream.SeriesRefs {
+			s := &models.Series{ForeignID: ref.ForeignID, Title: ref.Title}
+			if err := h.series.CreateOrGet(r.Context(), s); err != nil {
+				slog.Warn("rebind: failed to upsert series", "series", ref.Title, "error", err)
+				continue
+			}
+			if err := h.series.LinkBook(r.Context(), s.ID, book.ID, ref.Position, ref.Primary); err != nil {
+				slog.Warn("rebind: failed to link book to series", "book", book.Title, "series", ref.Title, "error", err)
+			}
+		}
+	}
+
+	// Audit trail: record old and new identifiers so the operation is reversible
+	// by hand and visible in the activity history.
+	if h.history != nil {
+		type rebindData struct {
+			OldProvider  string `json:"oldProvider"`
+			OldForeignID string `json:"oldForeignId"`
+			NewProvider  string `json:"newProvider"`
+			NewForeignID string `json:"newForeignId"`
+		}
+		if data, jerr := json.Marshal(rebindData{oldProvider, oldForeignID, req.Provider, req.ForeignID}); jerr == nil {
+			bookID := book.ID
+			_ = h.history.Create(r.Context(), &models.HistoryEvent{
+				BookID:      &bookID,
+				EventType:   models.HistoryEventBookRebound,
+				SourceTitle: book.Title,
+				Data:        string(data),
+			})
+		}
 	}
 
 	h.attachBookFiles(r.Context(), book)

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -17,6 +17,13 @@ type BookSearcher interface {
 	SearchAndGrabBook(ctx context.Context, book models.Book)
 }
 
+// BookMetaLookup fetches a single book record from a named provider,
+// bypassing the TTL cache. Implemented by *metadata.Aggregator; kept as an
+// interface so the Rebind handler can be tested without a real HTTP client.
+type BookMetaLookup interface {
+	GetBookFromProvider(ctx context.Context, provider, foreignID string) (*models.Book, error)
+}
+
 // LibraryFinder checks whether a book already exists in the local library.
 // Implemented by *importer.Scanner; a nil implementation is a no-op. The
 // mediaType argument selects which library roots are searched (ebook vs

--- a/internal/api/rebind_test.go
+++ b/internal/api/rebind_test.go
@@ -1,0 +1,281 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// stubLookup is a BookMetaLookup whose behaviour is controlled per-test.
+type stubLookup struct {
+	book *models.Book
+	err  error
+}
+
+func (s *stubLookup) GetBookFromProvider(_ context.Context, _, _ string) (*models.Book, error) {
+	return s.book, s.err
+}
+
+// rebindFixture wires up a BookHandler with in-memory repos, one author, and
+// one wanted book, then returns them for use in Rebind tests.
+func rebindFixture(t *testing.T) (*BookHandler, *db.BookRepo, *db.AuthorRepo, *db.SeriesRepo, *models.Author, *models.Book, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	series := db.NewSeriesRepo(database)
+	history := db.NewHistoryRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OL1A", Name: "Test Author", SortName: "Author, Test",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	book := &models.Book{
+		ForeignID: "OL1W", AuthorID: author.ID, Title: "Wrong Book",
+		SortTitle: "Wrong Book", Status: models.BookStatusWanted,
+		MetadataProvider: "openlibrary", Monitored: true, Genres: []string{},
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewBookHandler(books, nil, history, nil).WithAuthors(authors).WithSeries(series)
+	return h, books, authors, series, author, book, ctx
+}
+
+func rebindRequest(bookID int64, body any) *http.Request {
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/book/"+strconv.FormatInt(bookID, 10)+"/rebind", bytes.NewReader(b))
+	return withURLParam(req, "id", strconv.FormatInt(bookID, 10))
+}
+
+func TestRebind_HappyPath(t *testing.T) {
+	h, books, _, _, author, book, ctx := rebindFixture(t)
+	h.WithMetaLookup(&stubLookup{book: &models.Book{
+		Title: "Correct Book", SortTitle: "Correct Book",
+		Description: "The real one.", Genres: []string{"Fantasy"},
+		Author: &models.Author{ForeignID: author.ForeignID, Name: author.Name},
+	}})
+
+	rec := httptest.NewRecorder()
+	h.Rebind(rec, rebindRequest(book.ID, map[string]any{
+		"provider": "openlibrary", "foreign_id": "OL2W",
+	}))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	updated, _ := books.GetByID(ctx, book.ID)
+	if updated.ForeignID != "OL2W" {
+		t.Errorf("foreign_id not updated: got %q", updated.ForeignID)
+	}
+	if updated.Title != "Correct Book" {
+		t.Errorf("title not updated: got %q", updated.Title)
+	}
+}
+
+func TestRebind_BookNotFound(t *testing.T) {
+	h, _, _, _, _, _, _ := rebindFixture(t)
+	h.WithMetaLookup(&stubLookup{book: &models.Book{Title: "X"}})
+
+	rec := httptest.NewRecorder()
+	h.Rebind(rec, rebindRequest(99999, map[string]any{"provider": "openlibrary", "foreign_id": "OL2W"}))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("want 404, got %d", rec.Code)
+	}
+}
+
+func TestRebind_InvalidProvider(t *testing.T) {
+	h, _, _, _, _, book, _ := rebindFixture(t)
+	h.WithMetaLookup(&stubLookup{book: &models.Book{Title: "X"}})
+
+	rec := httptest.NewRecorder()
+	h.Rebind(rec, rebindRequest(book.ID, map[string]any{"provider": "goodreads", "foreign_id": "123"}))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", rec.Code)
+	}
+}
+
+func TestRebind_MissingForeignID(t *testing.T) {
+	h, _, _, _, _, book, _ := rebindFixture(t)
+	h.WithMetaLookup(&stubLookup{book: &models.Book{Title: "X"}})
+
+	rec := httptest.NewRecorder()
+	h.Rebind(rec, rebindRequest(book.ID, map[string]any{"provider": "openlibrary", "foreign_id": "   "}))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", rec.Code)
+	}
+}
+
+func TestRebind_NilAggregator_Returns424(t *testing.T) {
+	h, _, _, _, _, book, _ := rebindFixture(t)
+	// h.lookup is nil — no WithMetaLookup call
+
+	rec := httptest.NewRecorder()
+	h.Rebind(rec, rebindRequest(book.ID, map[string]any{"provider": "openlibrary", "foreign_id": "OL2W"}))
+	if rec.Code != http.StatusFailedDependency {
+		t.Errorf("want 424, got %d", rec.Code)
+	}
+}
+
+func TestRebind_ProviderError_Returns502(t *testing.T) {
+	h, _, _, _, _, book, _ := rebindFixture(t)
+	h.WithMetaLookup(&stubLookup{err: errors.New("upstream timeout")})
+
+	rec := httptest.NewRecorder()
+	h.Rebind(rec, rebindRequest(book.ID, map[string]any{"provider": "openlibrary", "foreign_id": "OL2W"}))
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("want 502, got %d", rec.Code)
+	}
+}
+
+func TestRebind_AuthorMismatch_Rejected(t *testing.T) {
+	h, _, _, _, _, book, _ := rebindFixture(t)
+	h.WithMetaLookup(&stubLookup{book: &models.Book{
+		Title: "Different Author's Book",
+		Author: &models.Author{ForeignID: "OL_OTHER_A", Name: "Someone Else"},
+	}})
+
+	rec := httptest.NewRecorder()
+	h.Rebind(rec, rebindRequest(book.ID, map[string]any{
+		"provider": "openlibrary", "foreign_id": "OL3W", "force": false,
+	}))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("want 409 on author mismatch, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["force_required"] != true {
+		t.Errorf("expected force_required=true in body: %v", body)
+	}
+}
+
+func TestRebind_AuthorMismatch_ForceOverrides(t *testing.T) {
+	h, _, _, _, _, book, _ := rebindFixture(t)
+	h.WithMetaLookup(&stubLookup{book: &models.Book{
+		Title: "Different Author's Book",
+		Author: &models.Author{ForeignID: "OL_OTHER_A", Name: "Someone Else"},
+	}})
+
+	rec := httptest.NewRecorder()
+	h.Rebind(rec, rebindRequest(book.ID, map[string]any{
+		"provider": "openlibrary", "foreign_id": "OL3W", "force": true,
+	}))
+	if rec.Code != http.StatusOK {
+		t.Errorf("want 200 with force=true, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRebind_SeriesRelinked(t *testing.T) {
+	h, _, _, series, author, book, ctx := rebindFixture(t)
+
+	// Seed an existing series link that should be cleared on rebind.
+	oldSeries := &models.Series{ForeignID: "SER_OLD", Title: "Old Series"}
+	if err := series.CreateOrGet(ctx, oldSeries); err != nil {
+		t.Fatal(err)
+	}
+	if err := series.LinkBook(ctx, oldSeries.ID, book.ID, "1", true); err != nil {
+		t.Fatal(err)
+	}
+
+	h.WithMetaLookup(&stubLookup{book: &models.Book{
+		Title: "New Title",
+		Author: &models.Author{ForeignID: author.ForeignID},
+		SeriesRefs: []models.SeriesRef{
+			{ForeignID: "SER_NEW", Title: "New Series", Position: "2", Primary: true},
+		},
+	}})
+
+	rec := httptest.NewRecorder()
+	h.Rebind(rec, rebindRequest(book.ID, map[string]any{"provider": "openlibrary", "foreign_id": "OL4W"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	oldIDs, _ := series.GetSeriesIDsForBook(ctx, book.ID)
+	for _, id := range oldIDs {
+		if id == oldSeries.ID {
+			t.Errorf("old series link %d should have been removed", oldSeries.ID)
+		}
+	}
+
+	title, pos, err := series.GetPrimarySeriesForBook(ctx, book.ID)
+	if err != nil || title != "New Series" || pos != "2" {
+		t.Errorf("new series not linked correctly: title=%q pos=%q err=%v", title, pos, err)
+	}
+}
+
+func TestRebind_HistoryEventWritten(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	series := db.NewSeriesRepo(database)
+	history := db.NewHistoryRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OL1A", Name: "Author", SortName: "Author",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OL1W", AuthorID: author.ID, Title: "Old Title",
+		SortTitle: "Old Title", Status: models.BookStatusWanted,
+		MetadataProvider: "openlibrary", Monitored: true, Genres: []string{},
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewBookHandler(books, nil, history, nil).WithAuthors(authors).WithSeries(series)
+	h.WithMetaLookup(&stubLookup{book: &models.Book{
+		Title:  "New Title",
+		Author: &models.Author{ForeignID: author.ForeignID},
+	}})
+
+	rec := httptest.NewRecorder()
+	h.Rebind(rec, rebindRequest(book.ID, map[string]any{"provider": "openlibrary", "foreign_id": "OL5W"}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	events, err := history.ListByBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, e := range events {
+		if e.EventType == models.HistoryEventBookRebound {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a %q history event, got %v", models.HistoryEventBookRebound, events)
+	}
+}

--- a/internal/api/rebind_test.go
+++ b/internal/api/rebind_test.go
@@ -150,7 +150,7 @@ func TestRebind_ProviderError_Returns502(t *testing.T) {
 func TestRebind_AuthorMismatch_Rejected(t *testing.T) {
 	h, _, _, _, _, book, _ := rebindFixture(t)
 	h.WithMetaLookup(&stubLookup{book: &models.Book{
-		Title: "Different Author's Book",
+		Title:  "Different Author's Book",
 		Author: &models.Author{ForeignID: "OL_OTHER_A", Name: "Someone Else"},
 	}})
 
@@ -171,7 +171,7 @@ func TestRebind_AuthorMismatch_Rejected(t *testing.T) {
 func TestRebind_AuthorMismatch_ForceOverrides(t *testing.T) {
 	h, _, _, _, _, book, _ := rebindFixture(t)
 	h.WithMetaLookup(&stubLookup{book: &models.Book{
-		Title: "Different Author's Book",
+		Title:  "Different Author's Book",
 		Author: &models.Author{ForeignID: "OL_OTHER_A", Name: "Someone Else"},
 	}})
 
@@ -197,7 +197,7 @@ func TestRebind_SeriesRelinked(t *testing.T) {
 	}
 
 	h.WithMetaLookup(&stubLookup{book: &models.Book{
-		Title: "New Title",
+		Title:  "New Title",
 		Author: &models.Author{ForeignID: author.ForeignID},
 		SeriesRefs: []models.SeriesRef{
 			{ForeignID: "SER_NEW", Title: "New Series", Position: "2", Primary: true},

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -519,6 +519,24 @@ func (r *SeriesRepo) UnlinkBook(ctx context.Context, seriesID, bookID int64) err
 	return nil
 }
 
+// GetSeriesIDsForBook returns the IDs of every series the book currently belongs to.
+func (r *SeriesRepo) GetSeriesIDsForBook(ctx context.Context, bookID int64) ([]int64, error) {
+	rows, err := r.db.QueryContext(ctx, `SELECT series_id FROM series_books WHERE book_id = ?`, bookID)
+	if err != nil {
+		return nil, fmt.Errorf("get series for book %d: %w", bookID, err)
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 func (r *SeriesRepo) Delete(ctx context.Context, id int64) error {
 	_, err := r.db.ExecContext(ctx, "DELETE FROM series WHERE id=?", id)
 	if err != nil {

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -287,6 +287,23 @@ func mergeAuthorWorkMetadata(dst *models.Book, src models.Book) {
 	}
 }
 
+// GetBookFromProvider fetches a single book by foreign ID from the named
+// provider ("openlibrary" or "hardcover"). It bypasses the TTL cache so the
+// rebind flow always gets a fresh record. Returns ErrProviderNotConfigured
+// when no matching provider is found.
+func (a *Aggregator) GetBookFromProvider(ctx context.Context, providerName, foreignID string) (*models.Book, error) {
+	providerName = strings.TrimSpace(strings.ToLower(providerName))
+	if a.primary.Name() == providerName {
+		return a.primary.GetBook(ctx, foreignID)
+	}
+	for _, enricher := range a.enrichers {
+		if enricher.Name() == providerName {
+			return enricher.GetBook(ctx, foreignID)
+		}
+	}
+	return nil, ErrProviderNotConfigured
+}
+
 func (a *Aggregator) GetBook(ctx context.Context, foreignID string) (*models.Book, error) {
 	key := "book:" + foreignID
 	if cached, ok := a.cache.get(key); ok {

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -77,4 +77,5 @@ const (
 	HistoryEventBookFileDeleted      = "bookFileDeleted"
 	HistoryEventDownloadStalled      = "downloadStalled"
 	HistoryEventDownloadRequeued     = "downloadRequeued"
+	HistoryEventBookRebound          = "bookRebound"
 )

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -253,8 +253,8 @@ export const api = {
   getLastSearchDebug: () => request<SearchDebug>(`/search/last-debug`),
   enrichAudiobook: (id: number) => request<Book>(`/book/${id}/enrich-audiobook`, { method: 'POST' }),
   toggleExcluded: (id: number) => request<Book>(`/book/${id}/exclude`, { method: 'PUT' }),
-  rebindBook: (id: number, provider: 'openlibrary' | 'hardcover', foreignId: string) =>
-    request<Book>(`/book/${id}/rebind`, { method: 'POST', body: JSON.stringify({ provider, foreign_id: foreignId }) }),
+  rebindBook: (id: number, provider: 'openlibrary' | 'hardcover', foreignId: string, force = false) =>
+    request<Book>(`/book/${id}/rebind`, { method: 'POST', body: JSON.stringify({ provider, foreign_id: foreignId, force }) }),
 
   // Wanted
   listWanted: (opts?: { includeExcluded?: boolean }) => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -253,6 +253,8 @@ export const api = {
   getLastSearchDebug: () => request<SearchDebug>(`/search/last-debug`),
   enrichAudiobook: (id: number) => request<Book>(`/book/${id}/enrich-audiobook`, { method: 'POST' }),
   toggleExcluded: (id: number) => request<Book>(`/book/${id}/exclude`, { method: 'PUT' }),
+  rebindBook: (id: number, provider: 'openlibrary' | 'hardcover', foreignId: string) =>
+    request<Book>(`/book/${id}/rebind`, { method: 'POST', body: JSON.stringify({ provider, foreign_id: foreignId }) }),
 
   // Wanted
   listWanted: (opts?: { includeExcluded?: boolean }) => {

--- a/web/src/components/RebindModal.tsx
+++ b/web/src/components/RebindModal.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { api, Book } from '../api/client'
+
+interface Props {
+  book: Book
+  onClose: () => void
+  onSuccess: (updated: Book) => void
+}
+
+export default function RebindModal({ book, onClose, onSuccess }: Props) {
+  const [provider, setProvider] = useState<'openlibrary' | 'hardcover'>('openlibrary')
+  const [foreignId, setForeignId] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = foreignId.trim()
+    if (!trimmed) {
+      setError('Foreign ID is required')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const updated = await api.rebindBook(book.id, provider, trimmed)
+      onSuccess(updated)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Re-bind failed')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-700 rounded-lg shadow-xl p-6 w-full max-w-md mx-4"
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 className="text-base font-semibold mb-1 text-slate-900 dark:text-white">Re-bind metadata</h2>
+        <p className="text-xs text-slate-500 dark:text-zinc-400 mb-4">
+          Override the upstream record for <span className="font-medium text-slate-700 dark:text-zinc-200">{book.title}</span>.
+          Enter the provider and the exact foreign ID of the correct record.
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-xs font-medium text-slate-700 dark:text-zinc-300 mb-1">
+              Provider
+            </label>
+            <select
+              value={provider}
+              onChange={e => setProvider(e.target.value as 'openlibrary' | 'hardcover')}
+              disabled={submitting}
+              className="w-full bg-slate-100 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-1.5 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-500 disabled:opacity-50"
+            >
+              <option value="openlibrary">OpenLibrary</option>
+              <option value="hardcover">Hardcover</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-slate-700 dark:text-zinc-300 mb-1">
+              Foreign ID
+            </label>
+            <input
+              type="text"
+              value={foreignId}
+              onChange={e => setForeignId(e.target.value)}
+              placeholder={provider === 'openlibrary' ? 'e.g. OL12345W' : 'e.g. hc:12345'}
+              disabled={submitting}
+              className="w-full bg-slate-100 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-1.5 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-500 disabled:opacity-50"
+              autoFocus
+            />
+            <p className="mt-1 text-xs text-slate-500 dark:text-zinc-500">
+              {provider === 'openlibrary'
+                ? 'Find the Work ID on openlibrary.org (e.g. OL12345W from the URL).'
+                : 'Use the Hardcover book slug or numeric ID prefixed with "hc:".'}
+            </p>
+          </div>
+
+          {error && (
+            <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="px-4 py-1.5 text-sm rounded bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !foreignId.trim()}
+              className="px-4 py-1.5 text-sm rounded bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 font-medium"
+            >
+              {submitting ? 'Re-binding…' : 'Re-bind'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/RebindModal.tsx
+++ b/web/src/components/RebindModal.tsx
@@ -1,6 +1,11 @@
 import { useState } from 'react'
 import { api, Book } from '../api/client'
 
+interface AuthorMismatch {
+  currentAuthor: string
+  upstreamAuthor: string
+}
+
 interface Props {
   book: Book
   onClose: () => void
@@ -12,9 +17,9 @@ export default function RebindModal({ book, onClose, onSuccess }: Props) {
   const [foreignId, setForeignId] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [mismatch, setMismatch] = useState<AuthorMismatch | null>(null)
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const submit = async (force: boolean) => {
     const trimmed = foreignId.trim()
     if (!trimmed) {
       setError('Foreign ID is required')
@@ -22,14 +27,33 @@ export default function RebindModal({ book, onClose, onSuccess }: Props) {
     }
     setSubmitting(true)
     setError(null)
+    setMismatch(null)
     try {
-      const updated = await api.rebindBook(book.id, provider, trimmed)
+      const updated = await api.rebindBook(book.id, provider, trimmed, force)
       onSuccess(updated)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Re-bind failed')
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 409) {
+        const body = err as { body?: { force_required?: boolean; current_author?: string; upstream_author?: string; error?: string } }
+        if (body.body?.force_required) {
+          setMismatch({
+            currentAuthor: body.body.current_author ?? '',
+            upstreamAuthor: body.body.upstream_author ?? '',
+          })
+          setSubmitting(false)
+          return
+        }
+        setError(body.body?.error ?? 'Conflict')
+      } else {
+        setError(err instanceof Error ? err.message : 'Re-bind failed')
+      }
     } finally {
       setSubmitting(false)
     }
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    submit(false)
   }
 
   return (
@@ -44,64 +68,95 @@ export default function RebindModal({ book, onClose, onSuccess }: Props) {
           Enter the provider and the exact foreign ID of the correct record.
         </p>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-xs font-medium text-slate-700 dark:text-zinc-300 mb-1">
-              Provider
-            </label>
-            <select
-              value={provider}
-              onChange={e => setProvider(e.target.value as 'openlibrary' | 'hardcover')}
-              disabled={submitting}
-              className="w-full bg-slate-100 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-1.5 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-500 disabled:opacity-50"
-            >
-              <option value="openlibrary">OpenLibrary</option>
-              <option value="hardcover">Hardcover</option>
-            </select>
+        {mismatch ? (
+          <div className="space-y-4">
+            <div className="rounded bg-amber-50 dark:bg-amber-950/40 border border-amber-300 dark:border-amber-700 p-3 text-xs text-amber-800 dark:text-amber-300">
+              <p className="font-semibold mb-1">Author mismatch</p>
+              <p>
+                The upstream record belongs to <span className="font-medium">{mismatch.upstreamAuthor}</span>, but this
+                book is currently attributed to <span className="font-medium">{mismatch.currentAuthor}</span>.
+              </p>
+              <p className="mt-1">Are you sure you want to re-bind anyway?</p>
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setMismatch(null)}
+                disabled={submitting}
+                className="px-4 py-1.5 text-sm rounded bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => submit(true)}
+                disabled={submitting}
+                className="px-4 py-1.5 text-sm rounded bg-amber-600 hover:bg-amber-500 disabled:opacity-50 font-medium text-white"
+              >
+                {submitting ? 'Re-binding…' : 'Re-bind anyway'}
+              </button>
+            </div>
           </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-xs font-medium text-slate-700 dark:text-zinc-300 mb-1">
+                Provider
+              </label>
+              <select
+                value={provider}
+                onChange={e => setProvider(e.target.value as 'openlibrary' | 'hardcover')}
+                disabled={submitting}
+                className="w-full bg-slate-100 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-1.5 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-500 disabled:opacity-50"
+              >
+                <option value="openlibrary">OpenLibrary</option>
+                <option value="hardcover">Hardcover</option>
+              </select>
+            </div>
 
-          <div>
-            <label className="block text-xs font-medium text-slate-700 dark:text-zinc-300 mb-1">
-              Foreign ID
-            </label>
-            <input
-              type="text"
-              value={foreignId}
-              onChange={e => setForeignId(e.target.value)}
-              placeholder={provider === 'openlibrary' ? 'e.g. OL12345W' : 'e.g. hc:12345'}
-              disabled={submitting}
-              className="w-full bg-slate-100 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-1.5 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-500 disabled:opacity-50"
-              autoFocus
-            />
-            <p className="mt-1 text-xs text-slate-500 dark:text-zinc-500">
-              {provider === 'openlibrary'
-                ? 'Find the Work ID on openlibrary.org (e.g. OL12345W from the URL).'
-                : 'Use the Hardcover book slug or numeric ID prefixed with "hc:".'}
-            </p>
-          </div>
+            <div>
+              <label className="block text-xs font-medium text-slate-700 dark:text-zinc-300 mb-1">
+                Foreign ID
+              </label>
+              <input
+                type="text"
+                value={foreignId}
+                onChange={e => setForeignId(e.target.value)}
+                placeholder={provider === 'openlibrary' ? 'e.g. OL12345W' : 'e.g. hc:12345'}
+                disabled={submitting}
+                className="w-full bg-slate-100 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-1.5 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-500 disabled:opacity-50"
+                autoFocus
+              />
+              <p className="mt-1 text-xs text-slate-500 dark:text-zinc-500">
+                {provider === 'openlibrary'
+                  ? 'Find the Work ID on openlibrary.org (e.g. OL12345W from the URL).'
+                  : 'Use the Hardcover book slug or numeric ID prefixed with "hc:".'}
+              </p>
+            </div>
 
-          {error && (
-            <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
-          )}
+            {error && (
+              <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+            )}
 
-          <div className="flex justify-end gap-2 pt-1">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={submitting}
-              className="px-4 py-1.5 text-sm rounded bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 disabled:opacity-50"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={submitting || !foreignId.trim()}
-              className="px-4 py-1.5 text-sm rounded bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 font-medium"
-            >
-              {submitting ? 'Re-binding…' : 'Re-bind'}
-            </button>
-          </div>
-        </form>
+            <div className="flex justify-end gap-2 pt-1">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={submitting}
+                className="px-4 py-1.5 text-sm rounded bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !foreignId.trim()}
+                className="px-4 py-1.5 text-sm rounded bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 font-medium"
+              >
+                {submitting ? 'Re-binding…' : 'Re-bind'}
+              </button>
+            </div>
+          </form>
+        )}
       </div>
     </div>
   )

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { api, Book, HistoryEvent, SearchResult, SearchDebug } from '../api/client'
 import SearchDebugPanel from '../components/SearchDebugPanel'
 import MediaBadge from '../components/MediaBadge'
+import RebindModal from '../components/RebindModal'
 
 function formatSize(n: number): string {
   if (!n || n <= 0) return ''
@@ -116,6 +117,7 @@ export default function BookDetailPage() {
   const [deletingFile, setDeletingFile] = useState(false)
   const [deletingBook, setDeletingBook] = useState(false)
   const [togglingExclude, setTogglingExclude] = useState(false)
+  const [showRebind, setShowRebind] = useState(false)
 
   useEffect(() => {
     if (book?.title) {
@@ -383,7 +385,7 @@ export default function BookDetailPage() {
               <span className="text-xs text-slate-500 dark:text-zinc-500 break-all">{book.filePath || book.ebookFilePath}</span>
             </div>
           ) : null}
-          <div className="mt-3 flex items-center gap-3">
+          <div className="mt-3 flex items-center gap-3 flex-wrap">
             <button
               onClick={toggleExclude}
               disabled={togglingExclude}
@@ -399,6 +401,13 @@ export default function BookDetailPage() {
             {book.excluded && (
               <span className="text-xs text-amber-600 dark:text-amber-400 font-medium">Excluded from searches</span>
             )}
+            <button
+              onClick={() => setShowRebind(true)}
+              className="text-xs font-medium px-3 py-1.5 rounded bg-slate-200 dark:bg-zinc-800 text-slate-700 dark:text-zinc-300 hover:bg-slate-300 dark:hover:bg-zinc-700"
+              title="Point this book at a different upstream metadata record"
+            >
+              Re-bind
+            </button>
             <button
               onClick={deleteBook}
               disabled={deletingBook || deletingFile}
@@ -533,6 +542,17 @@ export default function BookDetailPage() {
             ))}
           </div>
         </section>
+      )}
+
+      {showRebind && (
+        <RebindModal
+          book={book}
+          onClose={() => setShowRebind(false)}
+          onSuccess={updated => {
+            setBook(updated)
+            setShowRebind(false)
+          }}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Problem

When OpenLibrary or Hardcover returns the wrong record for a book (e.g. an omnibus instead of the standalone Book 1), there was no way to correct it. Users had to delete the book and re-add it manually, losing status, history, and file associations.

## What was added

### Backend
- **`GET /api/v1/books/{id}/rebind`** (`POST`) — accepts `{"provider": "openlibrary"|"hardcover", "foreign_id": "<id>"}`, validates inputs, fetches the upstream record from the named provider, updates `foreign_id` + `metadata_provider` + all refreshable metadata fields (title, description, cover, release date, genres, ratings, language), stamps `last_metadata_refresh_at`, and returns the updated book JSON.
- **`Aggregator.GetBookFromProvider`** — new method on the metadata aggregator that routes a single-book fetch to the correct provider by name, bypassing the TTL cache so rebind always gets a fresh record.
- Route wired in `cmd/bindery/main.go` alongside the other book mutation endpoints (behind the same auth middleware).

### Frontend
- **`RebindModal`** component (`web/src/components/RebindModal.tsx`) — small modal with a provider dropdown (OpenLibrary / Hardcover) and a foreign ID text input, with inline error display and a contextual placeholder hint.
- **Re-bind button** added to the book detail page header actions row, next to Exclude and Delete.
- **`api.rebindBook`** method added to `web/src/api/client.ts`.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/...` passes (all packages green)
- [ ] `npm run typecheck --prefix web` passes
- [ ] Open a book detail page — Re-bind button visible next to Exclude
- [ ] Click Re-bind, select OpenLibrary, enter a valid Work ID (e.g. `OL45804W`) — book title/cover/description update
- [ ] Enter an invalid foreign ID — 404 error displayed inline in the modal
- [ ] Enter a malformed provider — 400 error
- [ ] File paths, status, monitored flag, and ASIN are preserved after rebind

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)