### PR TITLE
refactor(books): centralize post-create wanted book logic (#503)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -67,7 +67,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -race -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
@@ -103,7 +103,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
@@ -131,7 +131,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - run: go test -race ./cmd/... ./internal/...
 
@@ -275,7 +275,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -333,7 +333,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - name: Run ABS contract suite
         env:
@@ -356,7 +356,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
       - name: Wait for ArgoCD dev to sync
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
 
       - name: gosec (SARIF)
@@ -283,7 +283,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.9"
+          go-version: "1.25.10"
           cache: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -384,7 +384,8 @@ func main() {
 	qualityProfileHandler := api.NewQualityProfileHandler(qualityProfileRepo)
 	settingsHandler := api.NewSettingsHandler(settingsRepo)
 	seriesHandler := api.NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metaAgg, sched).
-		WithHardcoverFeatureSettings(settingsRepo, cfg.EnhancedHardcoverAPI)
+		WithHardcoverFeatureSettings(settingsRepo, cfg.EnhancedHardcoverAPI).
+		WithFinder(importScanner)
 	tagHandler := api.NewTagHandler(tagRepo)
 	importListHandler := api.NewImportListHandler(importListRepo)
 	metadataProfileHandler := api.NewMetadataProfileHandler(metadataProfileRepo)
@@ -414,7 +415,8 @@ func main() {
 		func() calibre.Config { return api.LoadCalibreConfig(settingsRepo) },
 		func() calibre.Mode { return api.LoadCalibreMode(settingsRepo) },
 	)
-	recHandler := api.NewRecommendationHandler(recRepo, recEngine, authorRepo, bookRepo, sched)
+	recHandler := api.NewRecommendationHandler(recRepo, recEngine, authorRepo, bookRepo, sched).
+		WithFinder(seriesRepo, importScanner)
 	imageProxyHandler := api.NewImageProxyHandler(cfg.DataDir)
 	imageProxyHandler.StartEviction(24 * time.Hour)
 	migrateHandler := api.NewMigrateHandler(

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vavallee/bindery
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -918,25 +918,8 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 		}
 		added++
 
-		// Populate series membership for this book.
-		for _, ref := range b.SeriesRefs {
-			s := &models.Series{ForeignID: ref.ForeignID, Title: ref.Title}
-			if err := h.series.CreateOrGet(ctx, s); err != nil {
-				slog.Warn("failed to upsert series", "series", ref.Title, "error", err)
-				continue
-			}
-			if err := h.series.LinkBook(ctx, s.ID, b.ID, ref.Position, ref.Primary); err != nil {
-				slog.Warn("failed to link book to series", "book", b.Title, "series", ref.Title, "error", err)
-			}
-		}
-
-		// Check if the user already owns this book before queuing a download.
-		if h.finder != nil {
-			if existingPath := h.finder.FindExisting(ctx, b.Title, author.Name, b.MediaType); existingPath != "" {
-				slog.Info("library: found existing file, skipping auto-search", "title", b.Title, "path", existingPath)
-				_ = h.books.SetFilePath(ctx, b.ID, existingPath)
-				continue // don't auto-search for a book we already have
-			}
+		if fileFound := handleNewWantedBook(ctx, h.books, h.series, h.finder, b, author.Name); fileFound {
+			continue // don't auto-search for a book we already have
 		}
 
 		// Auto-search the freshly-added wanted book only when the per-add
@@ -947,6 +930,40 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 	}
 	runBookSearches(ctx, h.searcher, searchQueue, authorAutoSearchConcurrency)
 	slog.Info("author books synced", "author", author.Name, "added", added, "skipped_language", skippedLang, "skipped_junk", skippedJunk, "total", len(books))
+}
+
+// handleNewWantedBook performs the post-create steps that every newly-created
+// wanted book requires regardless of the creation path:
+//  1. Link any provider series refs into the series/series_books tables.
+//  2. Check whether the user already owns the file via LibraryFinder; if so,
+//     record the path and return true so the caller can skip auto-search.
+//
+// Returns true when an existing file was found (caller must NOT auto-search),
+// false otherwise.
+func handleNewWantedBook(ctx context.Context, books *db.BookRepo, series *db.SeriesRepo, finder LibraryFinder, book models.Book, authorName string) (fileFound bool) {
+	// Populate series membership for this book.
+	if series != nil {
+		for _, ref := range book.SeriesRefs {
+			s := &models.Series{ForeignID: ref.ForeignID, Title: ref.Title}
+			if err := series.CreateOrGet(ctx, s); err != nil {
+				slog.Warn("failed to upsert series", "series", ref.Title, "error", err)
+				continue
+			}
+			if err := series.LinkBook(ctx, s.ID, book.ID, ref.Position, ref.Primary); err != nil {
+				slog.Warn("failed to link book to series", "book", book.Title, "series", ref.Title, "error", err)
+			}
+		}
+	}
+
+	// Check if the user already owns this book before queuing a download.
+	if finder != nil {
+		if existingPath := finder.FindExisting(ctx, book.Title, authorName, book.MediaType); existingPath != "" {
+			slog.Info("library: found existing file, skipping auto-search", "title", book.Title, "path", existingPath)
+			_ = books.SetFilePath(ctx, book.ID, existingPath)
+			return true
+		}
+	}
+	return false
 }
 
 func runBookSearches(ctx context.Context, searcher BookSearcher, books []models.Book, concurrency int) {

--- a/internal/api/recommendations.go
+++ b/internal/api/recommendations.go
@@ -24,7 +24,17 @@ type RecommendationHandler struct {
 	engine   RecommendationEngine
 	authors  *db.AuthorRepo
 	books    *db.BookRepo
+	series   *db.SeriesRepo
 	searcher BookSearcher
+	finder   LibraryFinder
+}
+
+// WithFinder attaches a LibraryFinder so that Add can check whether the
+// recommended book already exists on disk before queuing an auto-search.
+func (h *RecommendationHandler) WithFinder(series *db.SeriesRepo, finder LibraryFinder) *RecommendationHandler {
+	h.series = series
+	h.finder = finder
+	return h
 }
 
 // NewRecommendationHandler creates a new RecommendationHandler.
@@ -147,11 +157,13 @@ func (h *RecommendationHandler) Add(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	fileFound := handleNewWantedBook(r.Context(), h.books, h.series, h.finder, *book, rec.AuthorName)
+
 	// Dismiss the recommendation now that the book is added.
 	_ = h.recs.Dismiss(r.Context(), 1, id)
 
-	// Trigger search in background.
-	if h.searcher != nil {
+	// Trigger search in background unless the file already exists on disk.
+	if h.searcher != nil && !fileFound {
 		go h.searcher.SearchAndGrabBook(context.Background(), *book) // #nosec G118 -- intentional: search must outlive the request
 	}
 

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -29,6 +29,7 @@ type SeriesHandler struct {
 	meta                        *metadata.Aggregator
 	searcher                    BookSearcher
 	settings                    *db.SettingsRepo
+	finder                      LibraryFinder
 	enhancedHardcoverEnvEnabled bool
 }
 
@@ -45,6 +46,13 @@ func NewSeriesHandler(series *db.SeriesRepo, books *db.BookRepo, authors *db.Aut
 func (h *SeriesHandler) WithHardcoverFeatureSettings(settings *db.SettingsRepo, envEnabled bool) *SeriesHandler {
 	h.settings = settings
 	h.enhancedHardcoverEnvEnabled = envEnabled
+	return h
+}
+
+// WithFinder attaches a LibraryFinder so that ensureHardcoverCatalogBook can
+// check whether a newly-created wanted book already exists on disk.
+func (h *SeriesHandler) WithFinder(f LibraryFinder) *SeriesHandler {
+	h.finder = f
 	return h
 }
 
@@ -1200,6 +1208,7 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *
 	if _, err := h.series.LinkBookIfMissing(ctx, series.ID, book.ID, catalogBook.Position, true); err != nil {
 		return nil, err
 	}
+	handleNewWantedBook(ctx, h.books, h.series, h.finder, book, storedAuthor.Name)
 	return &book, nil
 }
 


### PR DESCRIPTION
## Summary

- **What was duplicated:** After creating a wanted book in `FetchAuthorBooks`, two post-create steps ran inline: linking provider series refs into the `series`/`series_books` tables, and checking `LibraryFinder` to see if the file already exists on disk (setting `file_path` and skipping auto-search if so). Neither step ran for books created via `RecommendationHandler.Add` or `SeriesHandler.ensureHardcoverCatalogBook`.

- **What was extracted:** A new package-level helper `handleNewWantedBook(ctx, books, series, finder, book, authorName) bool` in `internal/api/authors.go`. It performs both steps and returns `true` when an existing file was found (so the caller can skip queuing a search).

- **Call sites now using the helper:**
  - `FetchAuthorBooks` (the original source — inline block replaced with a call)
  - `RecommendationHandler.Add` — gains series-ref linking and library file matching; a new `WithFinder(series, finder)` method wires in the deps
  - `SeriesHandler.ensureHardcoverCatalogBook` — gains library file matching; a new `WithFinder(finder)` method wires in the dep
  - Both handlers are wired in `cmd/bindery/main.go` with `importScanner` (the production `LibraryFinder`)

- Pure refactor — no behaviour change in `FetchAuthorBooks`. The helper is nil-safe for both `series` and `finder`.

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)