### PR TITLE
chore(deploy): promote bindery to v1.7.0

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.6.0"
+  tag: "1.7.0"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Automated prod deploy: image tag `1.7.0`.