### PR TITLE
chore(unraid): add Community Applications template

### DIFF
--- a/.github/unraid/README.md
+++ b/.github/unraid/README.md
@@ -1,0 +1,42 @@
+# Unraid Community Applications template
+
+`bindery.xml` is the template Unraid's Community Applications plugin reads to
+render the install page for Bindery. Two feeds carry it:
+
+- **Community-maintained (fast track):** mirrored at
+  [`selfhosters/unRAID-CA-templates`](https://github.com/selfhosters/unRAID-CA-templates).
+  Lands within a day of a PR merging there.
+- **First-party (this file):** registered with
+  [`Squidly271/AppFeed`](https://github.com/Squidly271/AppFeed). The plugin
+  fetches this raw URL directly and shows Bindery as "by vavallee".
+
+## Updating on release
+
+The `<Repository>` tag is `:latest`, so most releases need no template
+change — Unraid users get the new image by clicking "Force Update". Edit
+the template only when:
+
+- The container surface changes — new env var, new port, new required
+  volume, removed env var. Mirror the change here and in
+  `selfhosters/unRAID-CA-templates`.
+- A default needs to change — e.g. switching the default `BINDERY_*`
+  flag from `false` to `true`.
+- Major version bumps where the template's description should mention
+  new headline features.
+
+When you do edit, also bump the corresponding entry in the selfhosters
+fork. The two files should stay in lock-step apart from the
+`<TemplateURL>` value, which differs per feed.
+
+## Validating
+
+```bash
+xmllint --noout .github/unraid/bindery.xml
+curl -sI "https://raw.githubusercontent.com/vavallee/bindery/main/.github/assets/logo.png" | head -1
+```
+
+If you have an Unraid box (or a VM): Apps → "Click here to add a missing
+application" → paste the raw URL of `bindery.xml`. The form should render
+1 port, 4 paths, 3 always-visible env vars, and a handful of advanced
+ones. Click Apply, watch the container come up, hit
+`http://<unraid-ip>:8787/`.

--- a/.github/unraid/bindery.xml
+++ b/.github/unraid/bindery.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>bindery</Name>
+  <Repository>ghcr.io/vavallee/bindery:latest</Repository>
+  <Registry>https://github.com/vavallee/bindery/pkgs/container/bindery</Registry>
+  <Network>bridge</Network>
+  <Privileged>false</Privileged>
+  <Support>https://discord.gg/RpuYYRM9cZ</Support>
+  <Project>https://github.com/vavallee/bindery</Project>
+  <Overview>Bindery is a self-hosted ebook and audiobook automation server. Search OpenLibrary, Hardcover, and DNB for books and authors; monitor authors and series; hand requests to your *arr-style indexers and download client (NZB or torrent); import completed files into your library with proper metadata; serve an OPDS 1.2 catalogue to e-readers. Distroless image, Apache 2.0.&#xD;
+&#xD;
+First-run: open the WebUI to create an admin account. No env vars required for auth.&#xD;
+&#xD;
+Default user is 99:100. If you change PUID/PGID, also change the --user value in Extra Parameters; the container will fail fast if they don't match.</Overview>
+  <Category>MediaApp:Books MediaServer:Other Tools:Utilities</Category>
+  <WebUI>http://[IP]:[PORT:8787]/</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/vavallee/bindery/main/.github/unraid/bindery.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/vavallee/bindery/main/.github/assets/logo.png</Icon>
+  <ExtraParams>--user 99:100</ExtraParams>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled/>
+  <DonateText/>
+  <DonateLink/>
+  <Requires/>
+  <Config Name="WebUI" Target="8787" Default="8787" Mode="tcp" Description="HTTP port for the web interface, API, and OPDS catalogue." Type="Port" Display="always" Required="true" Mask="false">8787</Config>
+  <Config Name="Config" Target="/config" Default="/mnt/user/appdata/bindery" Mode="rw" Description="SQLite database, image cache, and backups. Must persist across container restarts." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/bindery</Config>
+  <Config Name="Books" Target="/books" Default="/mnt/user/Books" Mode="rw" Description="Imported ebook library root. Bindery moves/copies/hardlinks files here from Downloads after import." Type="Path" Display="always" Required="false" Mask="false">/mnt/user/Books</Config>
+  <Config Name="Audiobooks" Target="/audiobooks" Default="" Mode="rw" Description="Optional separate root for imported audiobook folders. Leave blank to keep audiobooks under /books. If you map a path here, also set BINDERY_AUDIOBOOK_DIR=/audiobooks below." Type="Path" Display="always" Required="false" Mask="false"/>
+  <Config Name="Downloads" Target="/downloads" Default="/mnt/user/downloads/bindery" Mode="rw" Description="Watch folder for completed downloads. Should match the path SABnzbd / qBittorrent writes to." Type="Path" Display="always" Required="false" Mask="false">/mnt/user/downloads/bindery</Config>
+  <Config Name="Log Level" Target="BINDERY_LOG_LEVEL" Default="info" Mode="" Description="Log verbosity: debug, info, warn, error." Type="Variable" Display="always" Required="false" Mask="false">info</Config>
+  <Config Name="PUID" Target="BINDERY_PUID" Default="99" Mode="" Description="UID the container will validate against. Must match the UID half of the --user flag in Extra Parameters. Default 99 = Unraid 'nobody'." Type="Variable" Display="always" Required="false" Mask="false">99</Config>
+  <Config Name="PGID" Target="BINDERY_PGID" Default="100" Mode="" Description="GID the container will validate against. Must match the GID half of the --user flag in Extra Parameters. Default 100 = Unraid 'users'." Type="Variable" Display="always" Required="false" Mask="false">100</Config>
+  <Config Name="Audiobook Directory" Target="BINDERY_AUDIOBOOK_DIR" Default="" Mode="" Description="Set to /audiobooks if you mapped a separate Audiobooks path above. If blank, audiobooks are imported into /books alongside ebooks." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="URL Base" Target="BINDERY_URL_BASE" Default="" Mode="" Description="Subpath prefix when hosting behind a reverse proxy at /bindery (e.g. SWAG / Nginx Proxy Manager). Leave blank for root." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Trusted Proxies" Target="BINDERY_TRUSTED_PROXY" Default="" Mode="" Description="Comma-separated CIDR list of reverse proxies allowed to set X-Forwarded-* headers. Required if you rely on X-Forwarded-For for auth or rate limits." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Cookie Secure" Target="BINDERY_COOKIE_SECURE" Default="auto" Mode="" Description="Session cookie Secure flag: auto (detect TLS via X-Forwarded-Proto), always, or never." Type="Variable" Display="advanced" Required="false" Mask="false">auto</Config>
+  <Config Name="Download Path Remap" Target="BINDERY_DOWNLOAD_PATH_REMAP" Default="" Mode="" Description="Comma-separated from:to pairs, used when SABnzbd / qBittorrent reports a path that doesn't match what Bindery sees. Example: /downloads:/data/downloads" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Allow Private Webhook URLs" Target="BINDERY_NOTIFICATIONS_ALLOW_PRIVATE" Default="false" Mode="" Description="Set to 1 to allow webhook destinations on RFC1918 networks (ntfy / Home Assistant on the LAN). Default false blocks them as SSRF protection." Type="Variable" Display="advanced" Required="false" Mask="false">false</Config>
+  <Config Name="API Key Seed" Target="BINDERY_API_KEY" Default="" Mode="" Description="One-time seed for the persisted API key. Leave blank to let Bindery generate one on first boot; rotate from the WebUI afterwards." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+</Container>

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -53,6 +53,26 @@ helm install bindery charts/bindery \
 
 See [`charts/bindery/values.yaml`](../charts/bindery/values.yaml) for all configuration options.
 
+## Unraid (Community Applications)
+
+Bindery ships a Community Applications template at
+[`.github/unraid/bindery.xml`](../.github/unraid/bindery.xml). Once the
+template is registered with the CA feed, Unraid users can install Bindery
+from the **Apps** tab. Until then, paste the raw URL into Apps → "Click
+here to add a missing application":
+
+```
+https://raw.githubusercontent.com/vavallee/bindery/main/.github/unraid/bindery.xml
+```
+
+Defaults the template provides: bridge networking, port `8787`,
+`--user 99:100` (Unraid's `nobody:users`), and four mounts —
+`/mnt/user/appdata/bindery → /config`, `/mnt/user/Books → /books`,
+`/mnt/user/Audiobooks → /audiobooks` (optional), and
+`/mnt/user/downloads/bindery → /downloads`. If you change `BINDERY_PUID`
+or `BINDERY_PGID`, also change the matching half of `--user` in **Extra
+Parameters** — the container fail-fast-validates the pair on startup.
+
 ## Binary
 
 Pre-built archives are attached to every [Release](https://github.com/vavallee/bindery/releases) for:


### PR DESCRIPTION
## Summary

- Adds `.github/unraid/bindery.xml` — the Unraid Community Applications template that the CA plugin reads to render Bindery's install page.
- Adds `.github/unraid/README.md` — maintainer notes on when to bump the template and how it's wired into the two CA feeds.
- Adds an Unraid section to `docs/DEPLOYMENT.md` linking to the raw template URL for users who want to install before the template lands in CA's index.

The template defaults to:

- bridge networking, port `8787`
- `--user 99:100` (Unraid's `nobody:users`) pre-filled in Extra Parameters
- four path mounts: `/config`, `/books`, `/audiobooks` (optional), `/downloads`
- 3 always-visible env vars (`BINDERY_LOG_LEVEL`, `BINDERY_PUID`, `BINDERY_PGID`)
- 7 advanced env vars (`BINDERY_AUDIOBOOK_DIR`, `BINDERY_URL_BASE`, `BINDERY_TRUSTED_PROXY`, `BINDERY_COOKIE_SECURE`, `BINDERY_DOWNLOAD_PATH_REMAP`, `BINDERY_NOTIFICATIONS_ALLOW_PRIVATE`, `BINDERY_API_KEY`)

`BINDERY_PUID`/`BINDERY_PGID` are validated against the running UID/GID by `cmd/bindery/uidcheck.go` — if a user changes one of those env vars without updating `--user`, the container exits at startup with a clear error rather than failing later on a permissions issue.

No code changes; every env var the template references already exists in `internal/config/config.go`. Submitted in tandem with: a PR to `selfhosters/unRAID-CA-templates` (community fast track) and an issue at `Squidly271/AppFeed` (first-party listing).

## Test plan

- [x] `python3 -c "import xml.etree.ElementTree; ..."` parses without error
- [x] Icon URL responds 200 with `image/png`, 512x512 square
- [x] Every env var in the template traces to `internal/config/config.go` or `cmd/bindery/uidcheck.go`
- [ ] Live install on Unraid box / VM (deferred — needs a host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)