### PR TITLE
fix(telemetry): only ping for semver release versions

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -35,6 +35,18 @@ import (
 
 var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
+// releaseVersionPattern matches semver-shaped release tags ("1.7.0", "v1.7.0").
+// Older Bindery clients (before the corresponding client-side filter) still
+// ping with non-release labels like "sha-abc1234", "dev-abc1234", and the
+// git-describe "v1.7.0-3-gabc1234" form for commits past a tag. Drop those
+// here so the version histogram doesn't grow a row per CI commit.
+var releaseVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
+// isReleaseVersion reports whether v looks like a semver release tag.
+func isReleaseVersion(v string) bool {
+	return releaseVersionPattern.MatchString(v)
+}
+
 type server struct {
 	db            *sql.DB
 	latestVersion string
@@ -304,10 +316,14 @@ func (s *server) handlePing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req.Version = normalizeVersion(req.Version)
-	// Reject locally-built `dev` pings — overwhelmingly developer testing
-	// against throwaway DBs, which generates a fresh install_id on every run.
-	// Newer clients skip these on the client side; old clients land here.
-	if req.Version == "dev" {
+	// Reject pings from non-release builds — the literal "dev" (local
+	// `go run` / `go build` with no -ldflags), CI's "sha-abc1234" and
+	// "dev-abc1234" interim images, and "v1.7.0-3-gabc1234" git-describe
+	// labels for commits past a tag. Each of those becomes its own row
+	// in the version histogram, and the install_id is overwhelmingly
+	// throwaway (CI / dev containers that recreate the DB on every run).
+	// Newer clients skip these client-side; older clients land here.
+	if !isReleaseVersion(req.Version) {
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(pingResponse{LatestVersion: s.latestVersion})
 		return

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import "testing"
+
+func TestIsReleaseVersion(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"v1.7.0", true},
+		{"1.7.0", true},
+		{"v0.0.1", true},
+		{"v10.20.30", true},
+
+		{"dev", false},
+		{"dev-abc1234", false},
+		{"sha-abc1234", false},
+		{"v1.7.0-3-gabc1234", false},
+		{"v1.7.0-rc.1", false},
+		{"", false},
+		{"latest", false},
+		{"v1.7", false},
+		{"1.7.0.1", false},
+	}
+	for _, tc := range cases {
+		if got := isReleaseVersion(tc.version); got != tc.want {
+			t.Errorf("isReleaseVersion(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"regexp"
 	"runtime"
 	"time"
 
@@ -31,6 +32,19 @@ const (
 	settingInstallID = "telemetry.install_id"
 	timeout          = 10 * time.Second
 )
+
+// releaseVersionPattern matches semver-shaped release tags ("1.7.0", "v1.7.0").
+// CI builds inject non-matching strings — the literal "dev" when the binary
+// has no -ldflags, "sha-abc1234" / "dev-abc1234" for non-release branches,
+// and "v1.7.0-3-gabc1234" (git describe form) for commits past a tag — and
+// we want those builds to skip the ping so the active-install chart doesn't
+// fill up with throwaway version buckets, one per CI commit.
+var releaseVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
+// isReleaseVersion reports whether v looks like a semver release tag.
+func isReleaseVersion(v string) bool {
+	return releaseVersionPattern.MatchString(v)
+}
 
 // Client sends anonymous usage pings and surfaces the latest published version.
 type Client struct {
@@ -60,15 +74,19 @@ func (c *Client) Ping(ctx context.Context) {
 		return
 	}
 
-	// Skip pings from local dev builds. The version string defaults to "dev"
-	// when the binary is built without the goreleaser/docker -ldflags version
-	// injection — i.e. `go run ./cmd/bindery` or a fresh `go build`. Most of
-	// those runs are testing/coding sessions that recreate the DB (and the
-	// install_id) repeatedly, which inflates the active count with throwaway
-	// UUIDs. Set BINDERY_TELEMETRY_FORCE=1 to override (e.g. when smoke-testing
+	// Skip pings from non-release builds. CI tags interim images with
+	// strings like "sha-abc1234" (non-release branches), "dev-abc1234"
+	// (development branch), and "v1.7.0-3-gabc1234" (git describe for
+	// commits past a tag); local builds with no -ldflags inject the
+	// literal "dev". Each unique label becomes its own row in the version
+	// histogram on api.getbindery.dev/stats — and most of those installs
+	// are throwaway dev/CI containers that recreate the DB (and the
+	// install_id) on every run, inflating active counts.
+	//
+	// Set BINDERY_TELEMETRY_FORCE=1 to override (e.g. when smoke-testing
 	// the ping path against a local telemetry-server).
-	if c.version == "dev" && os.Getenv("BINDERY_TELEMETRY_FORCE") == "" {
-		slog.Debug("telemetry: skipping ping for dev build")
+	if !isReleaseVersion(c.version) && os.Getenv("BINDERY_TELEMETRY_FORCE") == "" {
+		slog.Debug("telemetry: skipping ping for non-release build", "version", c.version)
 		return
 	}
 

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1,0 +1,35 @@
+package telemetry
+
+import "testing"
+
+func TestIsReleaseVersion(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		// Release tags — both with and without the leading "v" since the
+		// docker image build keeps "v1.7.0" while goreleaser strips it.
+		{"v1.7.0", true},
+		{"1.7.0", true},
+		{"v0.0.1", true},
+		{"v10.20.30", true},
+
+		// Non-release labels CI emits today.
+		{"dev", false},               // go run / go build with no -ldflags
+		{"dev-abc1234", false},       // development branch interim image
+		{"sha-abc1234", false},       // non-release branch interim image
+		{"v1.7.0-3-gabc1234", false}, // git describe form (commits past a tag)
+		{"v1.7.0-rc.1", false},       // pre-release (not currently used; safe to revisit)
+		{"", false},                  // misconfigured / empty
+		{"latest", false},            // image-tag style, not a real version
+		{"v1.7", false},              // truncated
+		{"1.7.0.1", false},           // four-component, not semver
+		{"v1.7.0 ", false},           // whitespace-padded
+		{"main", false},              // branch name accidentally injected
+	}
+	for _, tc := range cases {
+		if got := isReleaseVersion(tc.version); got != tc.want {
+			t.Errorf("isReleaseVersion(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## The bug

The dev-build suppression at \`internal/telemetry/client.go:70\` only matched the literal \`dev\` string:

\`\`\`go
if c.version == "dev" && os.Getenv(\"BINDERY_TELEMETRY_FORCE\") == \"\" { return }
\`\`\`

But CI tags interim images with version labels that aren't \`dev\`. From \`.github/workflows/ci.yml:171-177\`:

\`\`\`bash
if described=\$(git describe --tags --match 'v*' --always 2>/dev/null) && [[ \"\$described\" == v* ]]; then
  echo \"version=\${described}\" >> \"\$GITHUB_OUTPUT\"     # → v1.7.0 OR v1.7.0-3-gabc1234
elif [[ \"\$GITHUB_REF\" == refs/heads/development ]]; then
  echo \"version=dev-\${short}\" >> \"\$GITHUB_OUTPUT\"     # → dev-abc1234
else
  echo \"version=sha-\${short}\" >> \"\$GITHUB_OUTPUT\"     # → sha-abc1234
fi
\`\`\`

Each unique label becomes its own row in the \`installs\` table, so the version histogram on \`api.getbindery.dev/stats\` accumulates a long tail of one-off CI builds. The cosmetic \`(other)\` bucket in \`renderBarChart\` was hiding it on the chart but the rows were still in the DB.

## Fix

Both client and server now require the version to match \`^v?\d+\.\d+\.\d+\$\`:

- **Client** (\`internal/telemetry/client.go\`): pings short-circuit for any non-release version, not just literal \`dev\`. Same \`BINDERY_TELEMETRY_FORCE=1\` escape hatch as before.
- **Server** (\`cmd/telemetry-server/main.go\`): mirrors the same filter in \`handlePing\`. Older clients already in the wild keep pinging with sha-tagged versions and won't get the client fix until they upgrade — the server filter stops the DB pollution even before users upgrade.

## Test plan

- [x] New unit tests in \`internal/telemetry/client_test.go\` and \`cmd/telemetry-server/main_test.go\` cover \`v1.7.0\` / \`1.7.0\` (allow), \`dev\`, \`dev-abc1234\`, \`sha-abc1234\`, \`v1.7.0-3-gabc1234\`, empty, \`latest\`, \`v1.7\`, \`1.7.0.1\` (block).
- [x] \`go test ./internal/telemetry/ ./cmd/telemetry-server/\` green
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)