### PR TITLE
ui+settings: Prowlarr error visibility, loopback docs, Hardcover manual sync

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -412,7 +412,7 @@ func main() {
 		WithHardcoverFeatureSettings(settingsRepo, cfg.EnhancedHardcoverAPI).
 		WithFinder(importScanner)
 	tagHandler := api.NewTagHandler(tagRepo)
-	importListHandler := api.NewImportListHandler(importListRepo)
+	importListHandler := api.NewImportListHandler(importListRepo, hcSyncer)
 	metadataProfileHandler := api.NewMetadataProfileHandler(metadataProfileRepo)
 	delayProfileHandler := api.NewDelayProfileHandler(delayProfileRepo)
 	customFormatHandler := api.NewCustomFormatHandler(customFormatRepo)
@@ -710,6 +710,7 @@ func main() {
 		r.Get("/importlist/{id}", importListHandler.Get)
 		r.Put("/importlist/{id}", importListHandler.Update)
 		r.Delete("/importlist/{id}", importListHandler.Delete)
+		r.Post("/importlist/{id}/sync", importListHandler.Sync)
 
 		// Import list exclusions
 		r.Get("/importlistexclusion", importListHandler.ListExclusions)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -242,6 +242,18 @@ Multiple remaps are separated by commas: `BINDERY_DOWNLOAD_PATH_REMAP=/sab/compl
 | `BINDERY_RATE_LIMIT_MAX_FAILURES` | `5` | Maximum failed login attempts per IP before the account is locked for the rate-limit window. |
 | `BINDERY_RATE_LIMIT_WINDOW_MINUTES` | `15` | Duration in minutes of the per-IP login rate-limit window. After the window expires the failure counter resets. |
 
+## Indexer / Prowlarr URLs
+
+URLs entered for **Settings → Indexers** and **Settings → Indexers → Add Prowlarr** are validated against an SSRF policy that **blocks loopback** (`127.0.0.0/8`, `::1`), link-local (`169.254/16`, `fe80::/10`), and cloud-metadata endpoints (e.g. `169.254.169.254`). RFC1918 ranges (`10/8`, `172.16/12`, `192.168/16`) are allowed.
+
+This means `http://localhost:9696` and `http://127.0.0.1:9696` are **rejected** even when Prowlarr runs on the same host. Use one of the following instead:
+
+- **Same Docker network** — use the service name: `http://prowlarr:9696`.
+- **Same host, different containers** — use the host's LAN IP: `http://192.168.x.y:9696`.
+- **Bare-metal both processes** — use the host's LAN IP, or have Prowlarr listen on a non-loopback interface.
+
+The rejection is intentional: a confused-deputy request from Bindery to a loopback URL would let any logged-in user probe services running locally on the Bindery host. There is no env-var escape hatch — if you need it for a controlled test environment, [open an issue](https://github.com/vavallee/bindery/issues/new) describing the use case.
+
 ## First-run setup
 
 On first launch Bindery bootstraps itself — **no environment variables are required for auth.**

--- a/internal/api/import_lists.go
+++ b/internal/api/import_lists.go
@@ -1,23 +1,34 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/hardcoverlistsyncer"
 	"github.com/vavallee/bindery/internal/metadata/hardcover"
 	"github.com/vavallee/bindery/internal/models"
 )
 
-type ImportListHandler struct {
-	repo *db.ImportListRepo
+// HardcoverListSyncer is the narrow surface ImportListHandler needs for the
+// manual "Sync now" affordance. Implemented by *hardcoverlistsyncer.ListSyncer.
+type HardcoverListSyncer interface {
+	SyncOne(ctx context.Context, id int64) error
 }
 
-func NewImportListHandler(repo *db.ImportListRepo) *ImportListHandler {
-	return &ImportListHandler{repo: repo}
+type ImportListHandler struct {
+	repo   *db.ImportListRepo
+	hcSync HardcoverListSyncer
+}
+
+func NewImportListHandler(repo *db.ImportListRepo, hcSync HardcoverListSyncer) *ImportListHandler {
+	return &ImportListHandler{repo: repo, hcSync: hcSync}
 }
 
 func (h *ImportListHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -168,4 +179,36 @@ func (h *ImportListHandler) DeleteExclusion(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// Sync triggers a manual sync of a single import list. Hardcover lists run
+// the full hardcoverlistsyncer.SyncOne path; other list types are rejected
+// with 400 since no other type has a syncer wired here yet.
+// POST /api/v1/importlist/{id}/sync
+func (h *ImportListHandler) Sync(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		return
+	}
+	if h.hcSync == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "hardcover syncer not configured"})
+		return
+	}
+
+	// Sync is a few GraphQL hops; bound the request lifetime so a hung upstream
+	// doesn't tie up the connection forever.
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	switch err := h.hcSync.SyncOne(ctx, id); {
+	case err == nil:
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	case errors.Is(err, hardcoverlistsyncer.ErrNotFound):
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+	case errors.Is(err, hardcoverlistsyncer.ErrWrongType):
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+	default:
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+	}
 }

--- a/internal/api/import_lists_test.go
+++ b/internal/api/import_lists_test.go
@@ -18,7 +18,7 @@ func importListFixture(t *testing.T) *ImportListHandler {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { database.Close() })
-	return NewImportListHandler(db.NewImportListRepo(database))
+	return NewImportListHandler(db.NewImportListRepo(database), nil)
 }
 
 func TestImportListList_Empty(t *testing.T) {

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -4,6 +4,7 @@ package hardcoverlistsyncer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -55,6 +56,36 @@ func (s *ListSyncer) Sync(ctx context.Context) error {
 	}
 	return firstErr
 }
+
+// SyncOne syncs a single hardcover import list by ID. Used by the manual
+// "Sync now" UI affordance. Returns ErrNotFound if the list doesn't exist,
+// ErrWrongType if it's not a hardcover list, or the underlying sync error.
+func (s *ListSyncer) SyncOne(ctx context.Context, id int64) error {
+	il, err := s.importLists.GetByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("load import list %d: %w", id, err)
+	}
+	if il == nil {
+		return ErrNotFound
+	}
+	if il.Type != "hardcover" {
+		return ErrWrongType
+	}
+	if err := s.syncList(ctx, *il); err != nil {
+		return err
+	}
+	if err := s.importLists.UpdateLastSyncAt(ctx, il.ID); err != nil {
+		slog.Error("failed to update last_sync_at", "list", il.Name, "error", err)
+	}
+	return nil
+}
+
+// Sentinel errors for SyncOne so the API handler can map them to HTTP status
+// codes without string-matching.
+var (
+	ErrNotFound  = errors.New("import list not found")
+	ErrWrongType = errors.New("import list is not a hardcover list")
+)
 
 func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 	client := hardcover.NewAuthenticated(il.APIKey)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -436,6 +436,7 @@ export const api = {
   addImportList: (data: Partial<ImportList>) => request<ImportList>('/importlist', { method: 'POST', body: JSON.stringify(data) }),
   updateImportList: (id: number, data: Partial<ImportList>) => request<ImportList>(`/importlist/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   deleteImportList: (id: number) => request<void>(`/importlist/${id}`, { method: 'DELETE' }),
+  syncImportList: (id: number) => request<{ status: string }>(`/importlist/${id}/sync`, { method: 'POST' }),
   hardcoverLists: (token: string) =>
     request<HardcoverList[]>('/importlist/hardcover/lists', {
       headers: { Authorization: `Bearer ${token}` },

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -4628,20 +4628,29 @@ function AddProwlarrForm({ onClose, onAdded }: { onClose: () => void; onAdded: (
   const [apiKey, setApiKey] = useState('')
   const [syncOnStartup, setSyncOnStartup] = useState(true)
   const [syncing, setSyncing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
     setSyncing(true)
+    setError(null)
+    let p: ProwlarrInstance
     try {
-      const p = await api.addProwlarr({ name, url, apiKey, syncOnStartup, enabled: true })
-      // Auto-sync immediately so the user sees indexers appear right away.
-      try {
-        await api.syncProwlarr(p.id)
-        const updated = await api.listProwlarr()
-        onAdded(updated.find(i => i.id === p.id) ?? p)
-      } catch {
-        onAdded(p)
-      }
+      p = await api.addProwlarr({ name, url, apiKey, syncOnStartup, enabled: true })
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Save failed')
+      setSyncing(false)
+      return
+    }
+    // Save succeeded — auto-sync so indexers appear right away. Sync failures
+    // are non-fatal: the instance is already persisted, the user can retry sync
+    // from the row's button.
+    try {
+      await api.syncProwlarr(p.id)
+      const updated = await api.listProwlarr()
+      onAdded(updated.find(i => i.id === p.id) ?? p)
+    } catch {
+      onAdded(p)
     } finally {
       setSyncing(false)
     }
@@ -4673,6 +4682,9 @@ function AddProwlarrForm({ onClose, onAdded }: { onClose: () => void; onAdded: (
         </button>
         <span className="text-xs text-slate-600 dark:text-zinc-400">Sync on startup</span>
       </div>
+      {error && (
+        <div className="text-xs text-red-600 dark:text-red-400 break-words">{error}</div>
+      )}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
         <button onClick={submit} disabled={!url || !apiKey || syncing} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium disabled:opacity-50">

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -2166,6 +2166,8 @@ function HardcoverListsSection() {
   const { t } = useTranslation()
   const [lists, setLists] = useState<ImportList[]>([])
   const [showAdd, setShowAdd] = useState(false)
+  const [syncingId, setSyncingId] = useState<number | null>(null)
+  const [syncError, setSyncError] = useState<{ id: number; message: string } | null>(null)
 
   useEffect(() => {
     api.listImportLists().then(all => setLists(all.filter(l => l.type === 'hardcover'))).catch(console.error)
@@ -2179,6 +2181,20 @@ function HardcoverListsSection() {
   const handleToggle = async (il: ImportList) => {
     const updated = await api.updateImportList(il.id, { ...il, enabled: !il.enabled })
     setLists(prev => prev.map(l => l.id === il.id ? updated : l))
+  }
+
+  const handleSync = async (id: number) => {
+    setSyncingId(id)
+    setSyncError(null)
+    try {
+      await api.syncImportList(id)
+      const all = await api.listImportLists()
+      setLists(all.filter(l => l.type === 'hardcover'))
+    } catch (e: unknown) {
+      setSyncError({ id, message: e instanceof Error ? e.message : 'Sync failed' })
+    } finally {
+      setSyncingId(null)
+    }
   }
 
   return (
@@ -2209,8 +2225,18 @@ function HardcoverListsSection() {
                 ? t('settings.import.hardcoverLastSync', { date: new Date(il.lastSyncAt).toLocaleString() })
                 : t('settings.import.hardcoverNeverSynced')}
             </div>
+            {syncError?.id === il.id && (
+              <div className="text-xs text-red-600 dark:text-red-400 mt-1 break-words">{syncError.message}</div>
+            )}
           </div>
           <div className="flex items-center gap-2 ml-3">
+            <button
+              onClick={() => handleSync(il.id)}
+              disabled={syncingId === il.id}
+              className="text-xs px-2 py-1 rounded bg-slate-200 dark:bg-zinc-800 text-slate-700 dark:text-zinc-300 hover:bg-slate-300 dark:hover:bg-zinc-700 disabled:opacity-50"
+            >
+              {syncingId === il.id ? 'Syncing…' : 'Sync now'}
+            </button>
             <button
               onClick={() => handleToggle(il)}
               className={`text-xs px-2 py-1 rounded ${il.enabled ? 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-400' : 'bg-slate-200 dark:bg-zinc-800 text-slate-500 dark:text-zinc-500'}`}


### PR DESCRIPTION
Three small changes that came out of the same Discord triage session. Independent but bundled because they're all in the same files / area.

## 1. Add Prowlarr form silently swallowed API errors

Reported: a user added a Prowlarr instance, hit *Save & Sync*, and on returning to Settings saw an empty Prowlarr list with no error anywhere.

`AddProwlarrForm.submit` (`web/src/pages/SettingsPage.tsx`) had no `catch` on the outer `api.addProwlarr(...)` call. Failures became unhandled promise rejections — button stopped spinning, no message rendered, the modal stayed open or got dismissed, nothing was persisted. This masked every API error, not just the loopback case.

Fix: separate try/catch around `addProwlarr` so a save failure renders error text in the form. Sync failures stay non-fatal (instance already persisted; user can retry from the row).

## 2. Document the loopback rejection for indexer URLs

`internal/api/prowlarr.go:67` runs `httpsec.ValidateOutboundURL(p.URL, httpsec.PolicyLAN)`, which blocks loopback. Users entering `http://localhost:9696` or `http://127.0.0.1:9696` (very common — Prowlarr on the same host) get a clean `400 \"url not allowed: points to loopback address\"` from the API.

The policy itself is intentional SSRF defense, so this is documented in DEPLOYMENT.md rather than relaxed. New \"Indexer / Prowlarr URLs\" section explains the rejection and lists supported alternatives (docker service name, LAN IP).

## 3. Manual sync trigger for Hardcover import lists

Reported: *\"I'd love to be able to manually initiate a Hardcover list sync. Is the 24 hour sync tempo imposed by Hardcover, or is that flexible within Bindery?\"*

24h is a Bindery default — Hardcover's rate limits operate on per-minute scale, a list sync is a small handful of GraphQL calls. Adds the manual trigger; cadence stays as-is.

Mirrors the existing per-Prowlarr sync shape (`POST /prowlarr/{id}/sync` + button per row).

**Backend**
- `ListSyncer.SyncOne(ctx, id)` — loads the list, validates type==\"hardcover\", reuses the existing private syncList path, updates `last_sync_at`.
- Sentinel errors (`ErrNotFound`, `ErrWrongType`) so the handler maps to 404 / 400 without string-matching.
- New `HardcoverListSyncer` interface on `ImportListHandler`; `Sync` handler bounded with 60-second timeout.
- Route: `POST /importlist/{id}/sync`. Wired in `cmd/bindery/main.go`.

**Frontend**
- `api.syncImportList(id)` client method.
- Per-row \"Sync now\" button on each Hardcover list. Disabled in flight, refreshes the list afterward so `lastSyncAt` updates, surfaces the API error inline if sync fails.

## Out of scope

- `AddIndexerForm` (`SettingsPage.tsx:4054`) has the same zero-error-handling shape as the Prowlarr form had. Deliberately left for a follow-up.
- Configurable sync cadence — out of scope per current ask; 24h default stays.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean
- [x] `npm run typecheck --prefix web` clean
- [ ] Manual: with Prowlarr at `http://localhost:9696`, click *Save & Sync* — error \"invalid indexer URL: ...loopback...\" renders in red below the form fields, button re-enables, modal stays open
- [ ] Manual: fix URL to a service-name / LAN IP — error clears, instance saves, sync runs, indexers populate
- [ ] Manual: add valid Prowlarr but kill its container before *Save & Sync* — instance saves, sync error swallowed (existing behaviour), instance shows with 0 indexers, retry sync from row works
- [ ] Manual: existing Hardcover list — click *Sync now*, button shows \"Syncing…\", row's last-synced timestamp updates after success
- [ ] Manual: revoke the Hardcover token, click *Sync now* — inline error renders under the row, last-synced timestamp unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)