### PR TITLE
chore(ci): scope security-events write to SARIF-uploading jobs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
   actions: read
 
 concurrency:
@@ -41,6 +40,9 @@ jobs:
     name: SAST – Go
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -69,6 +71,9 @@ jobs:
     name: SAST – Frontend
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -132,6 +137,9 @@ jobs:
     name: Secrets Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -156,6 +164,9 @@ jobs:
     name: IaC Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

- Move `security-events: write` from workflow-root in `.github/workflows/security.yml` to the four jobs that actually call `github/codeql-action/upload-sarif` (`sast-go`, `sast-frontend`, `secrets-scan`, `iac-scan`). `container-scan` already had its own job-level block. Workflow root now grants only `contents: read` + `actions: read`.
- The DAST (`dast-api`), `policy-test`, and `summary` jobs no longer hold `security-events: write` — they don't upload SARIF, so they didn't need it. Reduces blast radius from a compromised step in those jobs.

## SLSA provenance verdict (no change made)

OpenSSF Scorecard rates Signed-Releases 0/10 for recent tags. Investigation says **the workflow is correct and the Scorecard is on stale data**:

- `ci.yml` `image` job runs on every `refs/tags/v*` push (no `if:` gate), holds `id-token: write` + `attestations: write` + `packages: write` at job level (line 142-145), and the `actions/attest-build-provenance@v1` step at line 192-197 has no `if:` condition.
- Verified against v1.7.0 (workflow run 25532892707): `image` job succeeded, the action signed digest `sha256:d30869e2d0776370feb84038b5efa274f2fb412217e948161e1983afa4cfa518`, and `GET /repos/vavallee/bindery/attestations/sha256:<digest>` returns a valid in-toto DSSE bundle.
- No code change to `ci.yml`. If Scorecard still reports 0/10 after the next scan, it's a Scorecard methodology gap (likely it's looking at the goreleaser binary assets which aren't attested individually), not a workflow bug.

## OpenSSF Scorecard categories addressed

- **Token-Permissions** — workflow-root `permissions:` block tightened; only the jobs that need `security-events: write` now hold it.
- **SAST** / **SBOM** / **Signed-Releases** — verified-still-correct, no change.

## Test plan

- [ ] CI green on this PR (security.yml jobs still upload their SARIF reports successfully)
- [ ] Confirm Code scanning alerts continue to populate from gosec / ESLint / Semgrep / Gitleaks / Hadolint / Checkov / Trivy / Grype after merge
- [ ] Re-run Scorecard after the next tagged release to see if Signed-Releases score improves once the scanner picks up the existing attestation pipeline