### PR TITLE
feat(web): top-level ErrorBoundary (#530)

### DIFF
--- a/web/src/components/ErrorBoundary.test.tsx
+++ b/web/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ErrorBoundary from './ErrorBoundary'
+
+function Boom({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('kaboom')
+  return <div data-testid="ok">ok</div>
+}
+
+describe('ErrorBoundary', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // React logs caught errors to console.error; silence to keep test output clean.
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleError.mockRestore()
+  })
+
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByTestId('ok')).toBeInTheDocument()
+  })
+
+  it('renders fallback when child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+    expect(screen.getByText('kaboom')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument()
+  })
+
+  it('clicking Reload calls window.location.reload', () => {
+    const reload = vi.fn()
+    const original = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...original, reload, assign: vi.fn() },
+    })
+    try {
+      render(
+        <ErrorBoundary>
+          <Boom shouldThrow />
+        </ErrorBoundary>,
+      )
+      fireEvent.click(screen.getByRole('button', { name: 'Reload' }))
+      expect(reload).toHaveBeenCalledTimes(1)
+    } finally {
+      Object.defineProperty(window, 'location', { configurable: true, value: original })
+    }
+  })
+
+  it('toggles details when Show details is clicked', () => {
+    render(
+      <ErrorBoundary>
+        <Boom shouldThrow />
+      </ErrorBoundary>,
+    )
+    const btn = screen.getByRole('button', { name: 'Show details' })
+    fireEvent.click(btn)
+    expect(screen.getByRole('button', { name: 'Hide details' })).toBeInTheDocument()
+  })
+})

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,78 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+type Props = { children: ReactNode }
+type State = { hasError: boolean; error: Error | null; errorInfo: ErrorInfo | null; showDetails: boolean }
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null, errorInfo: null, showDetails: false }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ui crash', error, errorInfo.componentStack)
+    this.setState({ errorInfo })
+  }
+
+  private handleReload = () => {
+    window.location.reload()
+  }
+
+  private handleHome = () => {
+    window.location.assign('/')
+  }
+
+  private toggleDetails = () => {
+    this.setState(s => ({ showDetails: !s.showDetails }))
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children
+    const { error, errorInfo, showDetails } = this.state
+    return (
+      <div className="min-h-screen bg-slate-50 dark:bg-zinc-950 text-slate-900 dark:text-zinc-100 flex items-center justify-center p-4">
+        <div role="alert" className="max-w-xl w-full p-6 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-4">
+          <h1 className="text-lg font-bold tracking-tight">Something went wrong</h1>
+          <p className="text-sm text-slate-600 dark:text-zinc-400">
+            The page hit an unexpected error and couldn't render. You can try reloading or returning to the home page.
+          </p>
+          {error?.message && (
+            <pre className="text-xs font-mono p-3 rounded bg-slate-50 dark:bg-black border border-slate-200 dark:border-zinc-900 overflow-auto whitespace-pre-wrap break-words">
+              {error.message}
+            </pre>
+          )}
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={this.handleReload}
+              className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium text-white"
+            >
+              Reload
+            </button>
+            <button
+              onClick={this.handleHome}
+              className="px-3 py-1.5 bg-slate-300 dark:bg-zinc-700 hover:bg-slate-400 dark:hover:bg-zinc-600 rounded text-xs font-medium"
+            >
+              Go home
+            </button>
+            {(error?.stack || errorInfo?.componentStack) && (
+              <button
+                onClick={this.toggleDetails}
+                className="px-3 py-1.5 bg-slate-300 dark:bg-zinc-700 hover:bg-slate-400 dark:hover:bg-zinc-600 rounded text-xs font-medium"
+                aria-expanded={showDetails}
+              >
+                {showDetails ? 'Hide details' : 'Show details'}
+              </button>
+            )}
+          </div>
+          {showDetails && (
+            <pre className="text-xs font-mono p-3 rounded bg-slate-50 dark:bg-black border border-slate-200 dark:border-zinc-900 overflow-auto max-h-[40vh] whitespace-pre-wrap break-words">
+              {error?.stack}
+              {errorInfo?.componentStack}
+            </pre>
+          )}
+        </div>
+      </div>
+    )
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,9 +3,12 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import './i18n'
 import App from './App'
+import ErrorBoundary from './components/ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary

Adds a class-based `ErrorBoundary` at the React root so an uncaught render error no longer unmounts the whole tree (the symptom in #530: clicking Settings flashed the page, then the screen went dark and stayed dark until a hard reload).

- `web/src/components/ErrorBoundary.tsx` — class component using `getDerivedStateFromError` + `componentDidCatch`. Logs the error and component stack to `console.error`. Fallback is a card with the error message, Reload + Go home buttons, and a Show details toggle that reveals the stack.
- `web/src/main.tsx` — wraps `<App/>` so the boundary sits outside the router and catches any throw, including router-level ones.
- `web/src/components/ErrorBoundary.test.tsx` — covers the no-error pass-through, fallback render, Reload click, and the details toggle.

No new dependencies, no router changes, no telemetry endpoint invented (the issue called that out as optional and the endpoint doesn't exist yet — `console.error` is the floor).

Closes #530

## Test plan

- [x] `npm run lint` — no new errors (5 warnings pre-existed on main, none from new files)
- [x] `npm run typecheck` — clean
- [x] `npm test` — 4/4 new tests pass; the 6 pre-existing `RecommendationCard`/`RecommendationRow` failures are unchanged from main and unrelated
- [ ] Manual: throw inside a page (e.g. `SettingsPage`) and verify the recovery card renders instead of a blank dark page

🤖 Generated with [Claude Code](https://claude.com/claude-code)