### PR TITLE
chore(deps): bump golang to 1.26.3 — fix 8 stdlib CVEs blocking Container Scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY web/ .
 RUN npm run build
 
 # Stage 2: Build Go binary (native on BUILDPLATFORM, cross-compile to TARGETOS/TARGETARCH)
-FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine@sha256:f44b851aa23dfa219d18db6eab743203245429d355cb619cf96a2ffe2a84ba7a AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
## Summary

Bumps the runtime build image from \`golang:1.26.2-alpine\` to \`golang:1.26.3-alpine\`, picking up the Go 1.26.3 stdlib security release (2026-05-07) that patches the CVEs Trivy has been reporting against every recent main image.

## Why

Container Scan (Trivy, CRITICAL+HIGH gating) has been **failing on every main commit since the binary started linking the affected stdlib versions** (#519, #521, #522, #526, #527, #528, #529 all show red Container Scan). Eight stdlib CVEs are reported in the bindery binary itself; all are fixed in 1.26.3:

- CVE-2026-42499 — \`net/mail\` quadratic concat (CWE-407)
- CVE-2026-39820 — \`net/mail\` ParseAddress/ParseAddressList DoS
- CVE-2026-39825 — \`net/http/httputil\` ReverseProxy query forwarding
- CVE-2026-39826 — \`html/template\` script-tag escaping
- CVE-2026-39823 — URL escaping (CVE-2026-27142 follow-up)
- CVE-2026-33814 — HTTP/2 SETTINGS infinite loop
- CVE-2026-33811 — \`LookupCNAME\` cgo
- CVE-2026-39836 — \`net.Dial\` NUL byte panic on Windows

Source: https://groups.google.com/g/golang-announce/c/qcCIEXso47M

## Verification

- Digest \`sha256:f44b851a...\` verified locally via \`docker pull\`.
- Container Scan should turn green on this PR's CI run.
- Once green and merged, will rebase #536 to inherit the fix.

## Test plan

- [ ] CI green (lint, validate, smoke)
- [ ] **Container Scan green** (the whole point of this PR)
- [ ] All Security workflow jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)