### PR TITLE
chore(deploy): promote bindery to v1.8.0

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.7.0"
+  tag: "1.8.0"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Manual recovery for v1.8.0 deploy-prod. Same race condition that hit v1.7.0: deploy-prod step in CI created the branch + values.yaml change, but the gh pr create -> gh pr merge sequence failed (PR not found by gh CLI immediately after creation).