### PR TITLE
fix(telemetry): pin latest release into /stats version chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Telemetry chart hides the freshly cut release** — `/stats` truncated the
+  version chart to top-8 by count, so a brand-new release with one or two
+  installs disappeared into `(other)` until it organically out-ranked older
+  versions (sometimes weeks). The chart now pins the configured
+  `LATEST_VERSION` into the visible region and annotates it `(latest)` so
+  newly cut releases are immediately visible to anyone watching adoption.
+
 ## [v1.8.0] — 2026-05-09
 
 ### Added

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -571,11 +571,36 @@ func paletteColor(i int) string { return chartPalette[i%len(chartPalette)] }
 // renderBarChart returns inline SVG for a horizontal bar chart with a legend.
 // Each bucket gets its own colour from chartPalette so the swatch in the
 // legend column matches the bar.
-func renderBarChart(buckets []statsBucket, maxBars int) string {
+//
+// When pinLabel is non-empty and matches a bucket that would otherwise fall
+// into the "(other)" tail, the pinned bucket is swapped into the last visible
+// slot so a freshly cut release stays visible before it organically reaches
+// top-N. The pinned row's legend is suffixed with " (latest)". Buckets with
+// pinLabel already in the visible region are annotated but not reordered.
+func renderBarChart(buckets []statsBucket, maxBars int, pinLabel string) string {
 	if len(buckets) == 0 {
 		return `<p class="empty">No data yet.</p>`
 	}
 	if maxBars > 0 && len(buckets) > maxBars {
+		// Copy so we can mutate without surprising the caller (other charts
+		// reuse the same slices indirectly via stable-sort in handleStatsPage).
+		work := make([]statsBucket, len(buckets))
+		copy(work, buckets)
+		buckets = work
+
+		if pinLabel != "" {
+			pinIdx := -1
+			for i := maxBars; i < len(buckets); i++ {
+				if buckets[i].Label == pinLabel {
+					pinIdx = i
+					break
+				}
+			}
+			if pinIdx >= 0 {
+				buckets[maxBars-1], buckets[pinIdx] = buckets[pinIdx], buckets[maxBars-1]
+			}
+		}
+
 		// Collapse the long tail into an "(other)" bucket so the chart
 		// doesn't grow unbounded with every release sha.
 		head := buckets[:maxBars]
@@ -602,11 +627,15 @@ func renderBarChart(buckets []statsBucket, maxBars int) string {
 		if max > 0 {
 			pct = b.Count * 100 / max
 		}
+		label := b.Label
+		if pinLabel != "" && b.Label == pinLabel {
+			label = b.Label + " (latest)"
+		}
 		fmt.Fprintf(&sb,
 			`<tr><td class="legend-cell"><span class="swatch" style="background:%s"></span>%s</td>`+
 				`<td class="bar-cell"><div class="bar" style="width:%d%%;background:%s"></div></td>`+
 				`<td class="count-cell">%d</td></tr>`,
-			colour, html.EscapeString(b.Label), pct, colour, b.Count)
+			colour, html.EscapeString(label), pct, colour, b.Count)
 	}
 	sb.WriteString(`</table></div>`)
 	return sb.String()
@@ -777,10 +806,10 @@ func (s *server) handleStatsPage(w http.ResponseWriter, r *http.Request) {
 </body>
 </html>`,
 		d.Active30d, d.Total,
-		renderBarChart(d.Versions, 8),
-		renderBarChart(d.OS, 0),
-		renderBarChart(d.Arch, 0),
-		renderBarChart(d.Deploy, 0),
+		renderBarChart(d.Versions, 8, normalizeVersion(s.latestVersion)),
+		renderBarChart(d.OS, 0, ""),
+		renderBarChart(d.Arch, 0, ""),
+		renderBarChart(d.Deploy, 0, ""),
 		renderSparkline(d.Daily),
 		time.Now().UTC().Format("2006-01-02 15:04 MST"),
 	); err != nil {

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestIsReleaseVersion(t *testing.T) {
 	cases := []struct {
@@ -26,5 +29,78 @@ func TestIsReleaseVersion(t *testing.T) {
 		if got := isReleaseVersion(tc.version); got != tc.want {
 			t.Errorf("isReleaseVersion(%q) = %v, want %v", tc.version, got, tc.want)
 		}
+	}
+}
+
+// Top-9 buckets (8 visible + sha overflow tail) used by the pin tests below.
+// "1.8.0" sits at index 8, beyond the maxBars=8 cutoff, so without pinning
+// it would be folded into "(other)".
+func chartFixture() []statsBucket {
+	return []statsBucket{
+		{"1.6.0", 34},
+		{"sha-a4aeaf0", 24},
+		{"sha-09ef045", 19},
+		{"1.7.0", 11},
+		{"sha-6a433d5", 10},
+		{"sha-83faf3b", 10},
+		{"sha-0c4544f", 4},
+		{"sha-dd31a9f", 3},
+		{"1.8.0", 1},
+		{"sha-zzzzzzz", 1},
+	}
+}
+
+func TestRenderBarChartPinsFreshRelease(t *testing.T) {
+	html := renderBarChart(chartFixture(), 8, "1.8.0")
+	if !strings.Contains(html, "1.8.0 (latest)") {
+		t.Errorf("expected pinned row labelled `1.8.0 (latest)`, got:\n%s", html)
+	}
+	// Without the pin "1.8.0" would be inside (other)=2; the swap should
+	// displace sha-dd31a9f (count=3) to the tail so (other) becomes 3+1=4.
+	if !strings.Contains(html, `<td class="count-cell">4</td>`) {
+		t.Errorf("expected (other) count 4 after swap; chart:\n%s", html)
+	}
+}
+
+func TestRenderBarChartNoPinLabelKeepsLegacyBehaviour(t *testing.T) {
+	html := renderBarChart(chartFixture(), 8, "")
+	if strings.Contains(html, "(latest)") {
+		t.Errorf("did not expect any (latest) annotation when pinLabel is empty:\n%s", html)
+	}
+	// (other) should be the natural tail sum: 1.8.0 (1) + sha-zzzzzzz (1) = 2.
+	if !strings.Contains(html, `<td class="count-cell">2</td>`) {
+		t.Errorf("expected (other) count 2 with no pin; chart:\n%s", html)
+	}
+}
+
+func TestRenderBarChartPinAlreadyVisible(t *testing.T) {
+	// 1.7.0 is at index 3 — already visible. Should be annotated but not moved
+	// (no swap, no change to tail).
+	html := renderBarChart(chartFixture(), 8, "1.7.0")
+	if !strings.Contains(html, "1.7.0 (latest)") {
+		t.Errorf("expected `1.7.0 (latest)` annotation when pinLabel is in head:\n%s", html)
+	}
+	if !strings.Contains(html, `<td class="count-cell">2</td>`) {
+		t.Errorf("expected unchanged (other) count 2 when pin is already visible; chart:\n%s", html)
+	}
+}
+
+func TestRenderBarChartPinMissingFromBuckets(t *testing.T) {
+	// pinLabel that doesn't appear at all is a no-op (next release before
+	// any install has reported it).
+	html := renderBarChart(chartFixture(), 8, "1.9.0")
+	if strings.Contains(html, "(latest)") {
+		t.Errorf("did not expect (latest) annotation when pin is absent:\n%s", html)
+	}
+	if !strings.Contains(html, `<td class="count-cell">2</td>`) {
+		t.Errorf("expected unchanged (other) count 2 when pin missing; chart:\n%s", html)
+	}
+}
+
+func TestRenderBarChartDoesNotMutateInput(t *testing.T) {
+	in := chartFixture()
+	_ = renderBarChart(in, 8, "1.8.0")
+	if in[7].Label != "sha-dd31a9f" || in[8].Label != "1.8.0" {
+		t.Errorf("renderBarChart mutated caller's slice: %+v", in)
 	}
 }


### PR DESCRIPTION
## Summary

- `/stats` version chart truncates to top-8 + `(other)`. Freshly cut releases with low install counts fall into the tail and stay invisible until they organically out-rank older versions — sometimes weeks. v1.8.0 was tagged today and immediately disappeared into `(other)`.
- Pin the configured `LATEST_VERSION` into the last visible chart slot when it would otherwise be in the tail, and annotate it ` (latest)` so it's distinguishable from organic top-N entries.
- No behaviour change when `pinLabel` is empty (OS / arch / deploy charts), absent from data, or already in top-N (apart from the annotation in that last case).
- Caller's slice is not mutated (verified by test).

## How it looks

For the current `/stats` snapshot (1.6.0=34, sha-a4aeaf0=24, ..., sha-dd31a9f=3, **1.8.0=1** in the tail), the chart now shows:

```
1.6.0          ████████████████  34
sha-a4aeaf0    ████████████      24
sha-09ef045    █████████         19
1.7.0          █████             11
sha-6a433d5    █████             10
sha-83faf3b    █████             10
sha-0c4544f    ██                 4
1.8.0 (latest) ▌                  1
(other)        ██                 4
```

(The displaced sha-dd31a9f at count=3 moves into `(other)`, which becomes 3+1=4.)

## Test plan

- [x] `go test ./cmd/telemetry-server/ -v` — 6 tests pass (1 existing + 5 new)
- [x] `go vet ./cmd/telemetry-server/`
- [x] `go build ./cmd/telemetry-server/`
- [ ] Verify on https://api.getbindery.dev/stats once the ping-server image rebuilds and redeploys — `1.8.0 (latest)` should appear as the rightmost visible bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)