### PR TITLE
security: harden API key compare, pin GHA + base images, dedicate telemetry client

### DIFF
--- a/.github/workflows/ping-server.yml
+++ b/.github/workflows/ping-server.yml
@@ -16,23 +16,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: cmd/telemetry-server/Dockerfile

--- a/cmd/telemetry-server/Dockerfile
+++ b/cmd/telemetry-server/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /telemetry-server ./cmd/telemetry-server
 
-FROM alpine:3.21
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 RUN apk add --no-cache sqlite && adduser -D -u 1000 app
 USER app
 COPY --from=builder /telemetry-server /telemetry-server

--- a/internal/api/opds_auth.go
+++ b/internal/api/opds_auth.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/subtle"
 	"log/slog"
 	"net"
 	"net/http"
@@ -36,7 +37,7 @@ func OPDSAuth(p auth.Provider, users *db.UserRepo, limiter *auth.LoginLimiter) f
 				next.ServeHTTP(w, r)
 				return
 			}
-			if key := opdsAPIKey(r); key != "" && key == p.APIKey() {
+			if key := opdsAPIKey(r); key != "" && subtle.ConstantTimeCompare([]byte(key), []byte(p.APIKey())) == 1 {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"crypto/subtle"
 	"log/slog"
 	"net"
 	"net/http"
@@ -163,7 +164,7 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
-			if key := requestAPIKey(r); key != "" && key == p.APIKey() {
+			if key := requestAPIKey(r); key != "" && subtle.ConstantTimeCompare([]byte(key), []byte(p.APIKey())) == 1 {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -41,6 +41,14 @@ const (
 // fill up with throwaway version buckets, one per CI commit.
 var releaseVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
 
+// pingClient is a dedicated HTTP client for the telemetry ping path. We avoid
+// http.DefaultClient so that other code mutating DefaultClient (transport,
+// timeout, jar) can't reach into our request, and so the per-request 10s
+// context deadline is backstopped by an explicit transport-level timeout.
+var pingClient = &http.Client{
+	Timeout: timeout, // 10s — same as the context deadline; belt-and-suspenders
+}
+
 // isReleaseVersion reports whether v looks like a semver release tag.
 func isReleaseVersion(v string) bool {
 	return releaseVersionPattern.MatchString(v)
@@ -110,7 +118,7 @@ func (c *Client) Ping(ctx context.Context) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := pingClient.Do(req)
 	if err != nil {
 		slog.Debug("telemetry: ping failed", "error", err)
 		return


### PR DESCRIPTION
## Summary

Four safe-fix items from a code-quality audit, plus one extra discovered while auditing:

- **`internal/auth/middleware.go`** — replace `key == p.APIKey()` with `subtle.ConstantTimeCompare` on the API key middleware path to close the timing-leak side channel. The `key != ""` short-circuit stays before the constant-time call so requests without a key don't allocate a slice (and don't telegraph the real key's length to a side-channel observer).
- **`internal/api/opds_auth.go`** — *(extra; found via grep while implementing the above)* identical `==` API key comparison in the OPDS middleware path. Same fix applied.
- **`cmd/telemetry-server/Dockerfile`** — pin `golang:1.25-alpine` and `alpine:3.21` to their content-addressable digests so a tag rotation can't silently swap the base image.
- **`.github/workflows/ping-server.yml`** — pin all 5 GitHub Actions (`checkout`, `docker/login-action`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/build-push-action`) to full 40-char commit SHAs, matching the SHAs already used in `ci.yml` so the two workflows stay in lockstep. `setup-qemu-action` is the one action not present in `ci.yml`; pinned to current `v3` tag SHA from upstream (`c7c5346…`).
- **`internal/telemetry/client.go`** — replace shared `http.DefaultClient` with a package-local `*http.Client{Timeout: timeout}` so other code mutating `DefaultClient` can't reach into the ping path, and the 10s context deadline is backstopped by an explicit transport-level timeout.

No behaviour change beyond the documented intent of each fix.

## Test plan

- [x] `go test ./internal/auth/... ./internal/telemetry/... ./cmd/telemetry-server/... ./internal/api/...` — all pass
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [ ] CI on this PR (lint + smoke + validate-go + validate-frontend) green
- [ ] After merge, next push to `cmd/telemetry-server/**` triggers `ping-server.yml` and the pinned actions/digests resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>