### PR TITLE
web: clean up timer leaks in AuthSettings + DiscoverPage

### DIFF
--- a/web/src/pages/DiscoverPage.tsx
+++ b/web/src/pages/DiscoverPage.tsx
@@ -52,9 +52,17 @@ export default function DiscoverPage() {
     return () => { document.title = 'Bindery' }
   }, [])
 
+  // Auto-dismiss the toast 2.5s after it appears. Lives in an effect with
+  // cleanup so the timer is cleared if the page unmounts (or the toast is
+  // replaced) before it fires.
+  useEffect(() => {
+    if (!toast) return
+    const t = setTimeout(() => setToast(null), 2500)
+    return () => clearTimeout(t)
+  }, [toast])
+
   const showToast = (msg: string) => {
     setToast(msg)
-    setTimeout(() => setToast(null), 2500)
   }
 
   const grouped = useMemo(() => {

--- a/web/src/settings/AuthSettings.tsx
+++ b/web/src/settings/AuthSettings.tsx
@@ -166,6 +166,15 @@ function AddProviderForm({
       .catch(() => {})
   }, [])
 
+  // Reset the "copied" badge after 1.5s. Lives in an effect (rather than a
+  // bare setTimeout in the click handler) so it's cleared if the form
+  // unmounts before the timer fires.
+  useEffect(() => {
+    if (!copied) return
+    const t = setTimeout(() => setCopied(false), 1500)
+    return () => clearTimeout(t)
+  }, [copied])
+
   const trimmedId = id.trim()
   const callbackPreview = trimmedId
     ? redirectBase + callbackTemplate.replace('{id}', encodeURIComponent(trimmedId))
@@ -175,7 +184,6 @@ function AddProviderForm({
     try {
       await navigator.clipboard.writeText(callbackPreview)
       setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
     } catch {
       /* clipboard unavailable */
     }


### PR DESCRIPTION
## Summary

Two small, behavior-preserving frontend cleanups from a code-quality audit (safe-fix tier). Both replace a bare `setTimeout` in an event handler with a `useEffect` watching the relevant state, so the timer is cleared on unmount instead of firing into a stale setter.

- `web/src/settings/AuthSettings.tsx` — `AddProviderForm`'s "Copied" badge now resets from an effect keyed on `copied`, with `clearTimeout` cleanup. The click handler is just `setCopied(true)`.
- `web/src/pages/DiscoverPage.tsx` — toast auto-dismiss moves to an effect keyed on `toast`, with `clearTimeout` cleanup. `showToast` is just `setToast(msg)`. (The unrelated 2 s `setTimeout` in `handleRefresh` that delays a re-fetch is intentionally left alone — different purpose, not a leak.)

The third item from the original audit plan (`AddAuthorModal` `.catch` on `listMetadataProfiles` / `listRootFolders`) turned out to already be on `main`, so it is not part of this PR.

## Test plan

- [x] `npm --prefix web run lint` — no new errors (5 pre-existing warnings on `main`, none from these files)
- [x] `npm --prefix web run typecheck` — clean
- [x] `npm --prefix web test` — same 6 pre-existing `RecommendationCard` / `RecommendationRow` failures as `main`; no new breakage
- [ ] Manual: open the OIDC "Add provider" form, click Copy, verify the "Copied" label flips back after ~1.5 s; close the form mid-flight and verify no React warning in the console
- [ ] Manual: trigger a `Add to wanted` toast on Discover, navigate away before the 2.5 s elapses, verify no React warning

## Follow-ups (out of scope, flagging only)

The same bare-`setTimeout(() => setCopied(false), 1500)` pattern lives in two other files and is a candidate for a shared `useCopyToClipboard` hook in a follow-up PR:

- `web/src/components/SearchDebugPanel.tsx:21`
- `web/src/pages/SettingsPage.tsx:4348`

🤖 Generated with [Claude Code](https://claude.com/claude-code)