### PR TITLE
backend: graceful log shutdown, propagate dropped errors, fix Content-Disposition

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -109,6 +109,13 @@ func main() {
 	logRepo := db.NewLogRepo(database)
 	logDBHandler := db.NewLogSlogHandler(logRepo, level)
 	slog.SetDefault(slog.New(logbuf.NewTee(logbuf.NewTee(stdoutHandler, ring), logDBHandler)))
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := logDBHandler.Stop(shutdownCtx); err != nil {
+			slog.Warn("log handler shutdown timed out", "error", err)
+		}
+	}()
 
 	authorRepo := db.NewAuthorRepo(database)
 	authorAliasRepo := db.NewAuthorAliasRepo(database)

--- a/internal/api/auth_oidc.go
+++ b/internal/api/auth_oidc.go
@@ -305,7 +305,11 @@ func (h *OIDCHandler) SetProviders(w http.ResponseWriter, r *http.Request) {
 	// Load existing providers so we can preserve secrets not re-submitted.
 	var existing []oidc.ProviderConfig
 	if s, _ := h.settings.Get(ctx, SettingOIDCProviders); s != nil && s.Value != "" {
-		existing, _ = oidc.ParseProviders(s.Value)
+		var perr error
+		existing, perr = oidc.ParseProviders(s.Value)
+		if perr != nil {
+			slog.Warn("auth_oidc: parse providers", "error", perr)
+		}
 	}
 	existingByID := make(map[string]oidc.ProviderConfig, len(existing))
 	for _, e := range existing {

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -851,7 +851,9 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 			if b.RatingsCount > 0 && (existing.RatingsCount == 0 || b.RatingsCount > existing.RatingsCount) {
 				existing.RatingsCount = b.RatingsCount
 				existing.AverageRating = b.AverageRating
-				_ = h.books.Update(ctx, existing)
+				if err := h.books.Update(ctx, existing); err != nil {
+					slog.Warn("authors: update during dedup", "error", err, "book_id", existing.ID)
+				}
 			}
 			continue
 		}
@@ -881,7 +883,9 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 					existing.RatingsCount = b.RatingsCount
 					existing.AverageRating = b.AverageRating
 				}
-				_ = h.books.Update(ctx, existing)
+				if err := h.books.Update(ctx, existing); err != nil {
+					slog.Warn("authors: update during dedup", "error", err, "book_id", existing.ID)
+				}
 			case canUpgradeToBoth(existing.MediaType, b.MediaType):
 				// One Work is ebook, the other is audiobook — merge into a single
 				// dual-format row instead of creating a second book entry.
@@ -900,7 +904,9 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 				if b.RatingsCount > 0 && (existing.RatingsCount == 0 || b.RatingsCount > existing.RatingsCount) {
 					existing.RatingsCount = b.RatingsCount
 					existing.AverageRating = b.AverageRating
-					_ = h.books.Update(ctx, existing)
+					if err := h.books.Update(ctx, existing); err != nil {
+						slog.Warn("authors: update during dedup", "error", err, "book_id", existing.ID)
+					}
 				}
 			}
 			continue
@@ -959,7 +965,9 @@ func handleNewWantedBook(ctx context.Context, books *db.BookRepo, series *db.Ser
 	if finder != nil {
 		if existingPath := finder.FindExisting(ctx, book.Title, authorName, book.MediaType); existingPath != "" {
 			slog.Info("library: found existing file, skipping auto-search", "title", book.Title, "path", existingPath)
-			_ = books.SetFilePath(ctx, book.ID, existingPath)
+			if err := books.SetFilePath(ctx, book.ID, existingPath); err != nil {
+				slog.Warn("authors: record existing file path", "error", err, "book_id", book.ID)
+			}
 			return true
 		}
 	}

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -80,9 +81,37 @@ func (h *FileHandler) Download(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filename := filepath.Base(filePath)
-	w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	w.Header().Set("Content-Disposition", contentDisposition(filename))
 	w.Header().Set("Content-Length", strconv.FormatInt(info.Size(), 10))
 	http.ServeFile(w, r, filePath)
+}
+
+// contentDisposition builds an RFC 6266 / RFC 5987 attachment header that
+// works for both ASCII-clean and Unicode filenames. The legacy filename=
+// parameter carries an ASCII-only fallback for ancient clients; the
+// filename*= parameter carries the original UTF-8 percent-encoded for
+// anything modern (every browser since ~2010).
+func contentDisposition(name string) string {
+	ascii := asciiFallback(name)
+	disp := `attachment; filename="` + strings.ReplaceAll(ascii, `"`, `\"`) + `"`
+	disp += `; filename*=UTF-8''` + url.PathEscape(name)
+	return disp
+}
+
+// asciiFallback returns name with non-ASCII bytes replaced by '_' so it
+// is safe to embed in the legacy quoted filename= parameter. Quotes and
+// backslashes are preserved (and escaped by the caller).
+func asciiFallback(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		if r > 0x7e || r < 0x20 {
+			b.WriteByte('_')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // isAllowedPath reports whether p falls under one of the configured library

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
@@ -105,6 +107,45 @@ func TestFileDownload_EbookFile(t *testing.T) {
 	}
 	if cd := rec.Header().Get("Content-Disposition"); cd == "" {
 		t.Errorf("expected Content-Disposition header")
+	}
+}
+
+func TestFileDownload_NonASCIIFilename(t *testing.T) {
+	h, books, author, ctx := fileFixture(t)
+	tmp := t.TempDir()
+	name := "日本語.epub"
+	path := filepath.Join(tmp, name)
+	if err := os.WriteFile(path, []byte("epub bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{ForeignID: "OL-JP", AuthorID: author.ID, Title: "T"}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.SetFilePath(ctx, book.ID, path); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/file/1/download", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	cd := rec.Header().Get("Content-Disposition")
+	// RFC 5987 filename* parameter must carry the percent-encoded UTF-8 name.
+	if !strings.Contains(cd, "filename*=UTF-8''") {
+		t.Errorf("Content-Disposition missing filename* param: %q", cd)
+	}
+	encoded := url.PathEscape(name)
+	if !strings.Contains(cd, encoded) {
+		t.Errorf("Content-Disposition missing percent-encoded name %q: %q", encoded, cd)
+	}
+	// And the legacy filename= parameter must not contain raw non-ASCII bytes.
+	for _, r := range cd {
+		if r > 0x7e {
+			t.Errorf("Content-Disposition contains non-ASCII byte %U: %q", r, cd)
+			break
+		}
 	}
 }
 

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -160,7 +160,9 @@ func (h *ImageProxyHandler) Serve(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", ct)
 	w.Header().Set("Cache-Control", "public, max-age=2592000")
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
-	_, _ = w.Write(body)
+	if _, err := w.Write(body); err != nil {
+		slog.Warn("imageproxy: write response", "error", err)
+	}
 }
 
 // hexKeyRe matches a 64-character lowercase hex string (sha256 output).

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -239,12 +240,16 @@ func (r *BookRepo) refreshBookStatus(ctx context.Context, bookID int64) error {
 	// This bypasses the COALESCE legacy-column fallback in bookColumns so
 	// removing the last book_files entry correctly clears the field.
 	var ebookPath, audiobookPath string
-	_ = r.db.QueryRowContext(ctx,
+	if err := r.db.QueryRowContext(ctx,
 		`SELECT COALESCE(path,'') FROM book_files WHERE book_id=? AND format='ebook' ORDER BY id LIMIT 1`,
-		bookID).Scan(&ebookPath)
-	_ = r.db.QueryRowContext(ctx,
+		bookID).Scan(&ebookPath); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("refreshBookStatus: read ebook path: %w", err)
+	}
+	if err := r.db.QueryRowContext(ctx,
 		`SELECT COALESCE(path,'') FROM book_files WHERE book_id=? AND format='audiobook' ORDER BY id LIMIT 1`,
-		bookID).Scan(&audiobookPath)
+		bookID).Scan(&audiobookPath); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("refreshBookStatus: read audiobook path: %w", err)
+	}
 
 	b.EbookFilePath = ebookPath
 	b.AudiobookFilePath = audiobookPath

--- a/internal/db/log_handler.go
+++ b/internal/db/log_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 )
 
@@ -18,16 +19,22 @@ type LogHandler struct {
 	ch       chan LogEntry
 	preAttrs []slog.Attr
 	level    slog.Level
+	// wg is non-nil only on the root handler returned by NewLogSlogHandler.
+	// Child handlers from WithAttrs share repo+ch but must not own the wg or
+	// the close-channel responsibility.
+	wg *sync.WaitGroup
 }
 
 // NewLogSlogHandler returns a non-blocking slog.Handler backed by repo.
-// Call Start to begin draining; call Stop to flush and shut down.
+// Call Stop to flush in-flight entries and shut the drain goroutine down.
 func NewLogSlogHandler(repo *LogRepo, minLevel slog.Level) *LogHandler {
 	h := &LogHandler{
 		repo:  repo,
 		ch:    make(chan LogEntry, logHandlerBufSize),
 		level: minLevel,
+		wg:    &sync.WaitGroup{},
 	}
+	h.wg.Add(1)
 	go h.drain()
 	return h
 }
@@ -40,6 +47,12 @@ func (h *LogHandler) Handle(_ context.Context, rec slog.Record) error {
 	if rec.Level < h.level {
 		return nil
 	}
+
+	// Send on a closed channel panics — even with the default branch in the
+	// select below (default fires when the channel is full, not when closed).
+	// Stop closes h.ch on shutdown, after which any late Handle call would
+	// otherwise crash the process. Recover and drop instead.
+	defer func() { _ = recover() }()
 
 	component := ""
 	fields := map[string]string{}
@@ -82,6 +95,7 @@ func (h *LogHandler) Handle(_ context.Context, rec slog.Record) error {
 
 func (h *LogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	combined := append(append([]slog.Attr{}, h.preAttrs...), attrs...)
+	// Intentionally do NOT propagate wg: only the root handler owns shutdown.
 	return &LogHandler{repo: h.repo, ch: h.ch, preAttrs: combined, level: h.level}
 }
 
@@ -90,7 +104,34 @@ func (h *LogHandler) WithGroup(_ string) slog.Handler {
 }
 
 func (h *LogHandler) drain() {
+	if h.wg != nil {
+		defer h.wg.Done()
+	}
 	for e := range h.ch {
 		_ = h.repo.Insert(context.Background(), e)
+	}
+}
+
+// Stop closes the log channel and blocks until the drain goroutine has
+// flushed any in-flight entries. Safe to call once on the root handler;
+// calling on a child returned by WithAttrs is a no-op. ctx bounds the wait;
+// if it expires before drain finishes, Stop returns ctx.Err and the
+// remaining entries are abandoned.
+func (h *LogHandler) Stop(ctx context.Context) error {
+	if h.wg == nil {
+		// Child handler — no shutdown responsibility.
+		return nil
+	}
+	close(h.ch)
+	done := make(chan struct{})
+	go func() {
+		h.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }

--- a/internal/db/log_handler_test.go
+++ b/internal/db/log_handler_test.go
@@ -59,6 +59,54 @@ func TestLogSlogHandler_MirrorsToDBAndRing(t *testing.T) {
 	}
 }
 
+func TestLogHandlerStop(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	repo := NewLogRepo(database)
+	h := NewLogSlogHandler(repo, slog.LevelDebug)
+
+	const n = 25
+	for i := 0; i < n; i++ {
+		rec := slog.NewRecord(time.Now(), slog.LevelInfo, "stop-test", 0)
+		rec.AddAttrs(slog.String("component", "stoptest"))
+		if err := h.Handle(context.Background(), rec); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := h.Stop(ctx); err != nil {
+		t.Fatalf("Stop returned error: %v", err)
+	}
+
+	// Verify all entries were persisted.
+	entries, err := repo.Query(context.Background(), LogFilter{Limit: n + 5})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(entries) != n {
+		t.Errorf("expected %d entries persisted, got %d", n, len(entries))
+	}
+
+	// Calling Handle after Stop must not panic — record is dropped.
+	rec := slog.NewRecord(time.Now(), slog.LevelInfo, "after-stop", 0)
+	if err := h.Handle(context.Background(), rec); err != nil {
+		t.Errorf("Handle after Stop: unexpected error %v", err)
+	}
+
+	// Stop on a child handler returned by WithAttrs is a no-op (does not
+	// re-close the channel).
+	child := h.WithAttrs([]slog.Attr{slog.String("k", "v")}).(*LogHandler)
+	if err := child.Stop(context.Background()); err != nil {
+		t.Errorf("child.Stop returned error: %v", err)
+	}
+}
+
 func TestLogSlogHandler_DropsOnFullChannel(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {

--- a/internal/db/recommendations.go
+++ b/internal/db/recommendations.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -51,12 +52,15 @@ func (r *RecommendationRepo) ReplaceBatch(ctx context.Context, userID int64, can
 	defer func() { _ = stmt.Close() }()
 
 	for _, c := range candidates {
-		genresJSON, _ := json.Marshal(c.Genres)
+		genresJSON, err := json.Marshal(c.Genres)
+		if err != nil {
+			slog.Warn("recommendations: marshal genres", "error", err)
+		}
 		if genresJSON == nil {
 			genresJSON = []byte("[]")
 		}
 
-		_, err := stmt.ExecContext(ctx,
+		_, err = stmt.ExecContext(ctx,
 			userID, c.ForeignID, c.RecType, c.Title, c.AuthorName, c.AuthorID,
 			c.ImageURL, c.Description, string(genresJSON), c.Rating, c.RatingsCount,
 			c.ReleaseDate, c.Language, c.MediaType, c.Score, c.Reason,

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -271,7 +271,10 @@ func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 			}
 			defer resp2.Body.Close()
 
-			body, _ = io.ReadAll(io.LimitReader(resp2.Body, 1024*1024))
+			body, err = io.ReadAll(io.LimitReader(resp2.Body, 1024*1024))
+			if err != nil {
+				return nil, fmt.Errorf("transmission: read retry body: %w", err)
+			}
 			resp = resp2
 		}
 	}

--- a/internal/prowlarr/syncer.go
+++ b/internal/prowlarr/syncer.go
@@ -137,7 +137,9 @@ func (s *Syncer) Sync(ctx context.Context, instanceID int64) (SyncResult, error)
 		}
 	}
 
-	_ = s.instances.SetLastSyncAt(ctx, instanceID, time.Now())
+	if err := s.instances.SetLastSyncAt(ctx, instanceID, time.Now()); err != nil {
+		slog.Warn("prowlarr: persist sync timestamp", "error", err, "instance_id", instanceID)
+	}
 	slog.Info("prowlarr sync complete", "instance_id", instanceID, "result", result.String())
 	return result, nil
 }


### PR DESCRIPTION
## Summary

Safe-fix tier from a code-quality audit. Four real bug fixes plus five logging-only additions; no observable behavior change except where called out.

**Real fixes**

- **`internal/db/log_handler.go`** — `LogHandler` documented a `Stop` method that didn't exist; the drain goroutine leaked for the process lifetime and any buffered records were lost on exit. Added `Stop(ctx)` that closes the channel and waits on a `sync.WaitGroup`. Wired a `defer logDBHandler.Stop(...)` (5s timeout) into `cmd/bindery/main.go` next to the existing `defer database.Close()` / `defer sched.Stop()` block.
  - Subtlety: `WithAttrs` returns a child handler that shares `repo`+`ch` — only the root carries `wg`, and `Stop` on a child is a no-op so we never double-close.
  - Send-on-closed-channel still panics even when guarded by a `default` case (default fires on full, not closed). Added `defer func(){ _ = recover() }()` to `Handle` so a late log call after `Stop` is dropped, not fatal.
- **`internal/downloader/transmission/client.go`** — the 409-retry path read the response body with `body, _ = io.ReadAll(...)`, so a torn read produced a silently-corrupted slice that downstream code then JSON-decoded. Propagate the error.
- **`internal/db/books.go`** — `refreshBookStatus` ran two `QueryRowContext(...).Scan(&path)` and discarded the error. A transient SQLite lock or corruption would zero `EbookFilePath` / `AudiobookFilePath` for the book. Now distinguishes `sql.ErrNoRows` (legitimate empty) from real errors and returns the latter.
- **`internal/api/files.go`** — `Content-Disposition` was just `attachment; filename="<basename>"`, which produces broken filenames for non-ASCII titles. Now emits both the legacy ASCII-fallback `filename=` and the RFC 5987 `filename*=UTF-8''<percent-encoded>` parameters. New test (`TestFileDownload_NonASCIIFilename`) covers `日本語.epub`.

**Logging-only (silent error drops -> `slog.Warn`)**

- `internal/api/imageproxy.go` — response write error
- `internal/api/auth_oidc.go` — provider parse error in `SetProviders`
- `internal/api/authors.go` — four ignored Update/SetFilePath calls in the dedup loop (the audit listed line 962 as an `Update` call, but it's actually a `SetFilePath` — kept the same warn pattern)
- `internal/db/recommendations.go` — `json.Marshal(genres)` error (also fixed a redeclaration the new `err :=` introduced; loop now uses `err =` for the subsequent `ExecContext`)
- `internal/prowlarr/syncer.go` — ignored `SetLastSyncAt` error

## Test plan

- [x] `go test -race ./...` — all green (~7m total)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] New `TestLogHandlerStop` covers: N records persisted on Stop, Stop returns nil within deadline, Handle after Stop is safe (no panic), child handler Stop is a no-op
- [x] New `TestFileDownload_NonASCIIFilename` asserts `filename*=UTF-8''` is present, the percent-encoded name is in the header, and no raw non-ASCII bytes leak into the legacy `filename=` parameter
- [ ] Smoke: tail container logs after rolling restart and confirm the new `slog.Warn` lines surface only when something actually fails (not on the happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)