### PR TITLE
fix(meta): cross-provider author resolution for DNB add-book (#545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ### Fixed
 
+- **DNB search results couldn't be added to the wanted list** (#545) — DNB
+  bib records expose author *names* but not author IDs, so every result had
+  the Add button greyed out with a misleading "try a more specific search"
+  hint. The fix extracts ISBN(s) from MARC 020 in DNB records and adds a
+  cross-provider author resolver: when a search result lacks a foreign
+  author ID, the backend looks up the ISBN in OpenLibrary and rewrites the
+  request to use OL's canonical author/book identity. Books that resolve
+  end up under their OpenLibrary record (with OL's title and metadata);
+  books with no OL match return a clear "add the author manually first"
+  error instead of silently failing.
 - **Telemetry chart hides the freshly cut release** — `/stats` truncated the
   version chart to top-8 by count, so a brand-new release with one or two
   installs disappeared into `(other)` until it organically out-ranked older

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -1142,6 +1143,15 @@ func dedupeAuthorQueries(values []string) []string {
 // If the author is not yet in Bindery it is added as unmonitored and its
 // books are fetched in the background; the endpoint then polls until the
 // requested book appears and marks it monitored before responding.
+//
+// foreignAuthorId is optional. When omitted (typical for DNB search results,
+// which don't expose author IDs), the handler resolves the author by looking
+// up the book's ISBN against every metadata provider and picking the first
+// hit that carries a real author ID — almost always OpenLibrary. When that
+// resolution succeeds, both foreignBookId and foreignAuthorId are rewritten
+// to the resolved provider's IDs so the rest of the existing flow works as
+// before. When it fails, the request is rejected with a friendly hint about
+// adding the author manually first.
 func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ForeignBookID   string `json:"foreignBookId"`
@@ -1153,12 +1163,35 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 		return
 	}
-	if req.ForeignBookID == "" || req.ForeignAuthorID == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "foreignBookId and foreignAuthorId required"})
+	if req.ForeignBookID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "foreignBookId required"})
 		return
 	}
 
 	ctx := r.Context()
+
+	if req.ForeignAuthorID == "" {
+		resolved, err := h.resolveAuthorForBook(ctx, req.ForeignBookID)
+		if err != nil {
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+			return
+		}
+		if resolved == nil {
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+				"error": "Author metadata unavailable for this result. Add the author manually first (Authors → Add Author by name), then try again.",
+			})
+			return
+		}
+		// Rewrite the request so the existing fetch+poll flow targets the
+		// canonical provider's IDs. The user sees the canonical record (e.g.
+		// the OpenLibrary version) in their library; the original DNB record
+		// is dropped because bindery's author/book identity is single-source.
+		req.ForeignBookID = resolved.ForeignID
+		req.ForeignAuthorID = resolved.Author.ForeignID
+		if req.AuthorName == "" {
+			req.AuthorName = resolved.Author.Name
+		}
+	}
 
 	// 1. Find or create the author (unmonitored if new so we don't auto-want all books).
 	author, _ := h.authors.GetByForeignID(ctx, req.ForeignAuthorID)
@@ -1234,6 +1267,43 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusCreated, book)
+}
+
+// resolveAuthorForBook looks up the foreign book by primary metadata
+// provider, walks its editions for an ISBN, then asks the aggregator to find
+// the same ISBN in any provider that exposes a real author ID. Returns nil
+// when no ISBN is found or no provider can place the author. This is the
+// fallback path for AddBook when the search result didn't carry a
+// foreignAuthorId — currently the case for every DNB result.
+func (h *AuthorHandler) resolveAuthorForBook(ctx context.Context, foreignBookID string) (*models.Book, error) {
+	primaryBook, err := h.meta.GetBook(ctx, foreignBookID)
+	if err != nil {
+		return nil, fmt.Errorf("look up book metadata: %w", err)
+	}
+	if primaryBook == nil {
+		return nil, nil
+	}
+	for _, ed := range primaryBook.Editions {
+		var isbn string
+		switch {
+		case ed.ISBN13 != nil && *ed.ISBN13 != "":
+			isbn = *ed.ISBN13
+		case ed.ISBN10 != nil && *ed.ISBN10 != "":
+			isbn = *ed.ISBN10
+		}
+		if isbn == "" {
+			continue
+		}
+		resolved, err := h.meta.ResolveBookByISBN(ctx, isbn)
+		if err != nil {
+			slog.Debug("resolveAuthorForBook: provider lookup failed", "isbn", isbn, "error", err)
+			continue
+		}
+		if resolved != nil {
+			return resolved, nil
+		}
+	}
+	return nil, nil
 }
 
 // saveAlternateNames persists any latin-script OL alternate names from

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -357,6 +357,32 @@ func (a *Aggregator) GetBookByISBN(ctx context.Context, isbn string) (*models.Bo
 	return book, nil
 }
 
+// ResolveBookByISBN walks every provider (primary first, then enrichers) and
+// returns the first hit whose author carries a usable foreignAuthorId. Used
+// at add-time when the user picked a search result from a provider that
+// doesn't expose author IDs (notably DNB), so we can fall back to a stronger
+// provider for the author identity rather than synthesising an ID locally.
+//
+// Returns (nil, nil) when no provider has the ISBN — the caller should treat
+// that as "couldn't resolve" and surface a friendly error to the user.
+// A provider error on one source is logged at debug level and treated as a
+// miss, so a single flaky provider doesn't block resolution.
+func (a *Aggregator) ResolveBookByISBN(ctx context.Context, isbn string) (*models.Book, error) {
+	providers := append([]Provider{a.primary}, a.enrichers...)
+	for _, p := range providers {
+		book, err := p.GetBookByISBN(ctx, isbn)
+		if err != nil {
+			slog.Debug("resolve isbn: provider failed", "provider", p.Name(), "isbn", isbn, "error", err)
+			continue
+		}
+		if book == nil || book.Author == nil || book.Author.ForeignID == "" {
+			continue
+		}
+		return book, nil
+	}
+	return nil, nil
+}
+
 // SearchSeries queries metadata providers that expose series catalog search.
 func (a *Aggregator) SearchSeries(ctx context.Context, query string, limit int) ([]SeriesSearchResult, error) {
 	query = strings.TrimSpace(query)

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -1079,3 +1079,80 @@ func newTestAggregator(primary Provider) *Aggregator {
 		cache:   newTTLCache(time.Minute),
 	}
 }
+
+func TestResolveBookByISBN_PrimaryHasAuthorID(t *testing.T) {
+	primary := &mockProvider{
+		name: "openlibrary",
+		getByISBN: &models.Book{
+			ForeignID: "OL9780441A",
+			Author:    &models.Author{ForeignID: "OL12345A", Name: "Frank Herbert"},
+		},
+	}
+	a := &Aggregator{primary: primary, cache: newTTLCache(time.Minute)}
+	book, err := a.ResolveBookByISBN(context.Background(), "9780441013593")
+	if err != nil {
+		t.Fatalf("ResolveBookByISBN: %v", err)
+	}
+	if book == nil || book.Author == nil || book.Author.ForeignID != "OL12345A" {
+		t.Errorf("expected primary's author OL12345A, got %+v", book)
+	}
+}
+
+func TestResolveBookByISBN_FallsThroughToEnricherWhenPrimaryHasNoAuthorID(t *testing.T) {
+	// Primary returns the book but with no author.ForeignID — typical of the
+	// DNB-as-primary configuration that prompted this method.
+	primary := &mockProvider{
+		name: "dnb",
+		getByISBN: &models.Book{
+			ForeignID: "dnb:1234567890",
+			Author:    &models.Author{Name: "Cornelia Funke"}, // no ForeignID
+		},
+	}
+	enricher := &mockProvider{
+		name: "openlibrary",
+		getByISBN: &models.Book{
+			ForeignID: "OL999A",
+			Author:    &models.Author{ForeignID: "OL12345A", Name: "Cornelia Funke"},
+		},
+	}
+	a := &Aggregator{primary: primary, enrichers: []Provider{enricher}, cache: newTTLCache(time.Minute)}
+	book, err := a.ResolveBookByISBN(context.Background(), "9783499015717")
+	if err != nil {
+		t.Fatalf("ResolveBookByISBN: %v", err)
+	}
+	if book == nil || book.Author == nil || book.Author.ForeignID != "OL12345A" {
+		t.Errorf("expected enricher's author OL12345A, got %+v", book)
+	}
+}
+
+func TestResolveBookByISBN_AllProvidersMiss(t *testing.T) {
+	primary := &mockProvider{name: "dnb"}                           // returns nil
+	enricher := &mockProvider{name: "openlibrary", getByISBN: nil} // also nil
+	a := &Aggregator{primary: primary, enrichers: []Provider{enricher}, cache: newTTLCache(time.Minute)}
+	book, err := a.ResolveBookByISBN(context.Background(), "9999999999999")
+	if err != nil {
+		t.Fatalf("ResolveBookByISBN: %v", err)
+	}
+	if book != nil {
+		t.Errorf("expected nil book on full miss, got %+v", book)
+	}
+}
+
+func TestResolveBookByISBN_ProviderErrorIsTreatedAsMiss(t *testing.T) {
+	primary := &mockProvider{name: "dnb", getByISBNErr: errors.New("upstream 503")}
+	enricher := &mockProvider{
+		name: "openlibrary",
+		getByISBN: &models.Book{
+			ForeignID: "OL999A",
+			Author:    &models.Author{ForeignID: "OL12345A", Name: "Frank Herbert"},
+		},
+	}
+	a := &Aggregator{primary: primary, enrichers: []Provider{enricher}, cache: newTTLCache(time.Minute)}
+	book, err := a.ResolveBookByISBN(context.Background(), "9780441013593")
+	if err != nil {
+		t.Fatalf("ResolveBookByISBN: %v", err)
+	}
+	if book == nil || book.Author.ForeignID != "OL12345A" {
+		t.Errorf("expected fallback to enricher after primary error, got %+v", book)
+	}
+}

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -1126,7 +1126,7 @@ func TestResolveBookByISBN_FallsThroughToEnricherWhenPrimaryHasNoAuthorID(t *tes
 }
 
 func TestResolveBookByISBN_AllProvidersMiss(t *testing.T) {
-	primary := &mockProvider{name: "dnb"}                           // returns nil
+	primary := &mockProvider{name: "dnb"}                          // returns nil
 	enricher := &mockProvider{name: "openlibrary", getByISBN: nil} // also nil
 	a := &Aggregator{primary: primary, enrichers: []Provider{enricher}, cache: newTTLCache(time.Minute)}
 	book, err := a.ResolveBookByISBN(context.Background(), "9999999999999")

--- a/internal/metadata/dnb/client.go
+++ b/internal/metadata/dnb/client.go
@@ -253,7 +253,50 @@ func recordToBook(rec marcRecord) *models.Book {
 		}
 	}
 
+	// ISBN(s) from MARC 020 $a. The field can repeat once per edition format
+	// (paperback / hardcover / ebook), and the value typically contains a
+	// qualifier in parentheses ("9783499015717 (pbk)"). Extract every digit
+	// run, classify into ISBN-13 / ISBN-10, and surface as Editions so the
+	// add-book endpoint can use them for cross-provider author resolution
+	// when the DNB record has only an author name and no foreign author ID.
+	for _, raw := range rec.subfieldAll("020", "a") {
+		digits := stripISBNQualifier(raw)
+		if digits == "" {
+			continue
+		}
+		ed := models.Edition{}
+		switch len(digits) {
+		case 13:
+			ed.ISBN13 = &digits
+		case 10:
+			ed.ISBN10 = &digits
+		default:
+			continue
+		}
+		b.Editions = append(b.Editions, ed)
+	}
+
 	return b
+}
+
+// stripISBNQualifier extracts the digit-run from a MARC 020 $a value. Real
+// values look like "9783499015717", "3-499-01571-X", or
+// "9783499015717 (pbk.)" — keep the digits (and a trailing X for ISBN-10
+// check digits), drop everything else.
+func stripISBNQualifier(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		} else if r == 'X' || r == 'x' {
+			// ISBN-10 check digit can be 'X' (value 10).
+			b.WriteRune('X')
+		} else if b.Len() > 0 && (r == ' ' || r == '(' || r == ',') {
+			// Stop at the first delimiter after digits — qualifier text follows.
+			break
+		}
+	}
+	return b.String()
 }
 
 func recordToAuthor(rec marcRecord) *models.Author {

--- a/internal/metadata/dnb/client_test.go
+++ b/internal/metadata/dnb/client_test.go
@@ -83,6 +83,25 @@ const marcNoID = `<record xmlns="http://www.loc.gov/MARC21/slim">
   </datafield>
 </record>`
 
+// marcWithISBNs carries two MARC 020 entries — a paperback ISBN-13 with a
+// trailing qualifier ("(pbk.)") and an ISBN-10 with hyphens — to exercise
+// stripISBNQualifier across both forms.
+const marcWithISBNs = `<record xmlns="http://www.loc.gov/MARC21/slim">
+  <controlfield tag="001">2222</controlfield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">9783499015717 (pbk.)</subfield>
+  </datafield>
+  <datafield tag="020" ind1=" " ind2=" ">
+    <subfield code="a">3-499-01571-X</subfield>
+  </datafield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Funke, Cornelia,</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Tintenherz</subfield>
+  </datafield>
+</record>`
+
 // --- Tests ---
 
 func TestName(t *testing.T) {
@@ -569,5 +588,47 @@ func TestGetAuthorWorks_ForeignID_NumLookupFails(t *testing.T) {
 	}
 	if len(books) == 0 {
 		t.Errorf("expected at least 1 book from fallback, got 0")
+	}
+}
+
+func TestSearchBooks_ExtractsISBNsFromMARC020(t *testing.T) {
+	c := mockXMLClient(sruXMLN("1", marcWithISBNs), http.StatusOK)
+	books, err := c.SearchBooks(context.Background(), "Tintenherz")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	b := books[0]
+	if len(b.Editions) != 2 {
+		t.Fatalf("expected 2 editions (one per ISBN), got %d", len(b.Editions))
+	}
+	if b.Editions[0].ISBN13 == nil || *b.Editions[0].ISBN13 != "9783499015717" {
+		t.Errorf("Editions[0].ISBN13 = %v, want 9783499015717", b.Editions[0].ISBN13)
+	}
+	if b.Editions[0].ISBN10 != nil {
+		t.Errorf("Editions[0].ISBN10 should be nil for an ISBN-13 row, got %v", *b.Editions[0].ISBN10)
+	}
+	if b.Editions[1].ISBN10 == nil || *b.Editions[1].ISBN10 != "349901571X" {
+		t.Errorf("Editions[1].ISBN10 = %v, want 349901571X", b.Editions[1].ISBN10)
+	}
+}
+
+func TestStripISBNQualifier(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"9783499015717", "9783499015717"},
+		{"9783499015717 (pbk.)", "9783499015717"},
+		{"3-499-01571-X", "349901571X"},
+		{"  9783446123456  ", "9783446123456"},
+		{"978 3 446 12345 6", "978"}, // first delimiter ends the run — accepted limitation
+		{"", ""},
+		{"no digits here", ""},
+		{"349901571x", "349901571X"}, // lowercase x normalized
+	}
+	for _, tc := range cases {
+		if got := stripISBNQualifier(tc.in); got != tc.want {
+			t.Errorf("stripISBNQualifier(%q) = %q, want %q", tc.in, got, tc.want)
+		}
 	}
 }

--- a/internal/metadata/dnb/types.go
+++ b/internal/metadata/dnb/types.go
@@ -67,3 +67,21 @@ func (r marcRecord) subfield(tag, code string) string {
 	}
 	return ""
 }
+
+// subfieldAll returns every $<code> value across every datafield with the
+// given tag. Used for repeated MARC fields like 020 (ISBN) where a single
+// bib record can carry one entry per edition (paperback / hardcover / ebook).
+func (r marcRecord) subfieldAll(tag, code string) []string {
+	var out []string
+	for _, df := range r.DataFields {
+		if df.Tag != tag {
+			continue
+		}
+		for _, sf := range df.Subfields {
+			if sf.Code == code {
+				out = append(out, sf.Value)
+			}
+		}
+	}
+	return out
+}

--- a/web/src/components/AddBookModal.tsx
+++ b/web/src/components/AddBookModal.tsx
@@ -38,12 +38,14 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
   }
 
   const addBook = async (book: Book) => {
-    if (!book.foreignBookId || !book.author?.foreignAuthorId) return
+    if (!book.foreignBookId || !book.author?.authorName) return
     setAdding(book.foreignBookId)
     try {
       const created = await api.addBook({
         foreignBookId: book.foreignBookId,
-        foreignAuthorId: book.author.foreignAuthorId,
+        // foreignAuthorId may be empty (e.g. DNB results) — the backend
+        // resolves the author by ISBN against OpenLibrary in that case.
+        foreignAuthorId: book.author.foreignAuthorId ?? '',
         authorName: book.author.authorName,
         searchOnAdd,
       })
@@ -102,7 +104,9 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
               const key = book.foreignBookId || book.title
               const isAdded = added.has(book.foreignBookId)
               const isAdding = adding === book.foreignBookId
-              const canAdd = !!book.author?.foreignAuthorId
+              // Author *name* is enough — when foreignAuthorId is missing
+              // (DNB results), the backend resolves it by ISBN at add-time.
+              const canAdd = !!book.author?.authorName
               return (
                 <div key={key} className="flex items-center gap-3 p-3 rounded-md bg-slate-200/50 dark:bg-zinc-800/50 hover:bg-slate-200 dark:hover:bg-zinc-800">
                   {book.imageUrl && (
@@ -121,7 +125,7 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
                     onClick={() => addBook(book)}
                     disabled={isAdded || isAdding || !canAdd}
                     className={`px-3 py-1 rounded text-xs font-medium flex-shrink-0 ${isAdded ? 'bg-emerald-700 text-white opacity-75 cursor-default' : 'bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50'}`}
-                    title={!canAdd ? 'Author metadata unavailable — try a more specific search' : undefined}
+                    title={!canAdd ? 'Author name missing on this result' : undefined}
                   >
                     {isAdded ? 'Added ✓' : isAdding ? 'Adding…' : 'Add'}
                   </button>


### PR DESCRIPTION
## Summary

- Fixes #545 — DNB search results couldn't be added to the wanted list because every result hit the frontend's `canAdd = !!book.author?.foreignAuthorId` gate, which DNB never satisfies (DNB bib records carry author *names* but not IDs).
- The fix is **cross-provider author resolution at add time**, not synthetic IDs in the DB. Concern from triage was that synthetic IDs would block future Hardcover migration; this approach keeps the DB clean.

## What changed

- **DNB**: `recordToBook` now extracts ISBN(s) from MARC 020 and surfaces them as `Editions`. Multi-format records (one entry per paperback / hardcover / ebook) round-trip. New `stripISBNQualifier` handles wire forms like `"9783499015717 (pbk.)"` and `"3-499-01571-X"`.
- **Aggregator**: new `ResolveBookByISBN(ctx, isbn)` walks every provider (primary first, then enrichers) and returns the first hit whose author carries a real `foreignAuthorId`. Provider errors are logged at debug and treated as misses so one flaky source doesn't block.
- **API**: `AddBook` accepts an empty `foreignAuthorId`. When empty, the handler loads the book, walks its editions for an ISBN, calls the resolver, and rewrites both IDs so the existing fetch+poll flow targets the canonical provider's identity.
- **Frontend**: `canAdd` keys on author *name*, not foreign ID. Misleading "try a more specific search" tooltip removed.
- **Failure path**: when resolution can't place the author, returns 422 with `"Author metadata unavailable for this result. Add the author manually first (Authors → Add Author by name), then try again."` — a concrete next step, not a dead end.

## Trade-off worth flagging

When resolution succeeds, the user sees the **canonical (typically OpenLibrary) record** in their library, not the original DNB record they searched for. Title, description, and language may differ from the DNB version. This is consistent with bindery's single-source author/book identity model — every other ingestion path (author-works fetch, indexer search, recommendations) assumes OL identity. Documented in the new handler comment.

DNB-only books (no OpenLibrary match) are blocked at add-time with the friendly error above. Realistic for obscure German publications. Beats a fake `dnb-name:` ID rotting in the DB forever.

## Test plan

- [x] `go test ./internal/metadata/dnb/ -v -run 'TestSearchBooks_ExtractsISBN|TestStripISBN'` — pass
- [x] `go test ./internal/metadata/ -v -run TestResolveBookByISBN` — 4 new cases pass
- [x] `go test ./...` — full Go suite green
- [x] `go vet ./...` — clean
- [x] `npm --prefix web run lint && npm --prefix web run typecheck` — typecheck clean, 5 pre-existing warnings (unrelated)
- [x] `npm --prefix web test` — 99 pass / 6 pre-existing failures (RecommendationCard/Row, untouched)
- [ ] **Manual smoke** (post-merge, when image deploys): user with DNB-as-primary searches an ISBN that exists in both DNB and OL → Add succeeds, book lands under OL identity. ISBN that exists only in DNB → friendly 422 with the manual-add hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)