### PR TITLE
feat(importer): Calibre-Web-Automated (CWA) ingest folder support (#417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **Calibre-Web-Automated (CWA) ingest** (#417) — A new
+  **Settings → General → Calibre-Web-Automated (CWA)** field configures a
+  shared ingest folder. When set, every successful ebook import is also
+  copied into that folder so a sibling
+  [CWA](https://github.com/crocodilestick/Calibre-Web-Automated) container
+  can auto-ingest it. Bindery keeps its own copy and never moves the file,
+  so a misconfigured CWA can't take bindery's library with it. No Calibre
+  runtime dependency is added to the bindery container — only the file
+  drop is in scope. Audiobook imports are unaffected since CWA is built
+  around ebook libraries.
+
 ### Fixed
 
 - **DNB search results couldn't be added to the wanted list** (#545) — DNB

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -66,6 +66,8 @@ The short version lives in the [README](../README.md#roadmap). ✅ items have la
 
 - ✅ **Split ebook / audiobook results in search** ([#333](https://github.com/vavallee/bindery/issues/333)) — when both ebook and audiobook indexers are enabled, the search results page shows only one media type at a time based on the active filter. A two-section layout (ebooks / audiobooks) would surface both in the same view so users can compare and grab from either without toggling.
 
+- ✅ **Calibre-Web-Automated (CWA) ingest** ([#417](https://github.com/vavallee/bindery/issues/417)) — when the operator runs CWA in a sibling container, bindery copies every successful ebook import into a configured shared ingest folder so CWA's auto-ingest picks it up automatically. Bindery keeps its own copy. No Calibre runtime dependency in the bindery container. Configured under **Settings → General → Calibre-Web-Automated (CWA)**.
+
 ## v2 horizon
 
 These items are too large or architectural for a minor release. They define the v2 milestone — the set of changes that would warrant a major version bump.
@@ -77,6 +79,8 @@ These items are too large or architectural for a minor release. They define the 
 - ~~**External database (MySQL / Postgres)** ([#86](https://github.com/vavallee/bindery/issues/86))~~ — **Won't do.** Closed as won't-fix; see the Planned section above.
 
 - ✅ **Persistent structured log store** ([#241](https://github.com/vavallee/bindery/issues/241), landed in development) — Persists log entries to SQLite (migration 026), survives restarts, queryable by date range / level / component / full-text. Retention defaults to 14 days and is configurable. The ring buffer remains as a fast in-process fallback when no DB is available.
+
+- **Soulseek as a download source** ([#417](https://github.com/vavallee/bindery/issues/417)) — Soulseek's slsk:// P2P protocol is stateful and session-oriented (handshake, peer discovery, queue, transfer, slot management) — fundamentally different shape from the fire-and-forget HTTP fetch of NZB/torrent/magnet that bindery's queue assumes today. Adding it requires a long-lived peer connection in the bindery process, a search-result schema rich enough to carry slsk peer/file/size metadata through the ranker and quality-profile machinery, and either a vendored slsk client (e.g. [slingamn/slsk](https://github.com/slingamn/slsk-client)) or a sidecar daemon with its own configuration story. Worth doing because of the genuinely strong content catalogue on the network, but not before the v2 milestone.
 
 ## Explicitly out of scope
 

--- a/internal/api/calibre.go
+++ b/internal/api/calibre.go
@@ -23,6 +23,12 @@ const (
 	SettingCalibrePluginAPIKey  = "calibre.plugin_api_key"
 )
 
+// SettingCWAIngestPath is the directory bindery copies finished ebook
+// imports into so a sibling Calibre-Web-Automated container can pick them
+// up via its own auto-ingest watcher. Empty disables the integration.
+// CWA reference: https://github.com/crocodilestick/Calibre-Web-Automated
+const SettingCWAIngestPath = "cwa.ingest_path"
+
 // CalibreHandler exposes the "test connection" endpoint for the Calibre
 // settings UI. Read/write of the calibre.* keys themselves go through the
 // generic /setting endpoints so the UI can reuse its existing plumbing;

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -240,6 +240,20 @@ func validateSettingValue(key, value string) error {
 		if info.Mode()&0o111 == 0 {
 			return fmt.Errorf("binary_path %q is not executable", value)
 		}
+	case SettingCWAIngestPath:
+		// Empty = disabled. Non-empty must resolve to an existing writable
+		// directory so a typo in the UI fails loudly here, not silently at
+		// import time when the post-import push tries to copy.
+		if value == "" {
+			return nil
+		}
+		info, err := os.Stat(value)
+		if err != nil {
+			return fmt.Errorf("cwa.ingest_path %q: %w (ensure the path is accessible inside the bindery container, check volume mounts)", value, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("cwa.ingest_path %q is not a directory", value)
+		}
 	case SettingCalibreMode:
 		// Canonical values only. An empty string falls through to the
 		// default (off) handled by LoadCalibreMode; anything else must

--- a/internal/db/migrations/036_cwa_ingest.sql
+++ b/internal/db/migrations/036_cwa_ingest.sql
@@ -1,0 +1,21 @@
+-- +migrate Up
+
+-- Calibre-Web-Automated (CWA) integration. CWA runs as a separate container
+-- (https://github.com/crocodilestick/Calibre-Web-Automated) and watches a
+-- shared "ingest" directory. Anything dropped there is automatically added
+-- to its Calibre library and removed from the ingest folder afterwards.
+--
+-- bindery's role: when an ebook import succeeds, also drop a copy of the
+-- final file into the configured CWA ingest directory. The copy is
+-- best-effort. Failure is logged but does not roll back bindery's import.
+-- We copy (not move) so bindery's own library stays intact regardless of
+-- what CWA does with its consumed copy.
+--
+-- cwa.ingest_path empty disables the integration. Default is empty so the
+-- migration is a no-op for users who don't care.
+INSERT OR IGNORE INTO settings (key, value) VALUES
+    ('cwa.ingest_path', '');
+
+-- +migrate Down
+-- Settings-row seeds are harmless if they linger, leave them in place on
+-- rollback. Downgrading the binary will simply ignore the new key.

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -176,6 +176,32 @@ func (s *Scanner) importMode(ctx context.Context) string {
 	}
 }
 
+// pushToCWA copies the just-imported file into the directory watched by a
+// sibling Calibre-Web-Automated container, when the cwa.ingest_path setting
+// is configured. CWA's auto-ingest deletes whatever lands in that folder
+// after processing, so we copy rather than move — bindery's own library
+// stays intact regardless. Failures are logged and swallowed; CWA sync is
+// best-effort and must never roll back an otherwise-good import.
+//
+// Only fires for ebook imports — CWA is built around ebook libraries
+// (Calibre under the hood); audiobook handoff is a separate problem.
+func (s *Scanner) pushToCWA(ctx context.Context, srcPath string) {
+	if s.settings == nil || srcPath == "" {
+		return
+	}
+	setting, err := s.settings.Get(ctx, "cwa.ingest_path")
+	if err != nil || setting == nil || setting.Value == "" {
+		return
+	}
+	ingestDir := setting.Value
+	dst := filepath.Join(ingestDir, filepath.Base(srcPath))
+	if err := CopyFileCtx(ctx, srcPath, dst); err != nil {
+		slog.Warn("cwa: copy to ingest folder failed", "src", srcPath, "dst", dst, "error", err)
+		return
+	}
+	slog.Info("cwa: file copied to ingest folder", "src", srcPath, "dst", dst)
+}
+
 // pushToCalibre mirrors a just-imported book into Calibre via calibredb add.
 // Failures are logged and swallowed — Calibre sync is best-effort and must
 // never roll back an otherwise-good Bindery import.
@@ -725,6 +751,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		slog.Info("book imported", "title", book.Title, "path", destPath)
 
 		s.pushToCalibre(ctx, book, author, destPath)
+		s.pushToCWA(ctx, destPath)
 
 		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destPath})
 	}

--- a/internal/importer/scanner_cwa_test.go
+++ b/internal/importer/scanner_cwa_test.go
@@ -1,0 +1,104 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// cwaFixture extends importScannerFixture with a SettingsRepo wired in,
+// since the cwa.ingest_path lookup goes through settings. Returns the
+// scanner, its settings repo (so tests can write cwa.ingest_path), the
+// configured ingest dir, and a path to a freshly written source file
+// inside the library dir that tests can hand to pushToCWA.
+func cwaFixture(t *testing.T) (s *Scanner, settings *db.SettingsRepo, ingestDir, srcPath string, ctx context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx = context.Background()
+	settings = db.NewSettingsRepo(database)
+	libraryDir := t.TempDir()
+	ingestDir = t.TempDir()
+
+	srcPath = filepath.Join(libraryDir, "Author A - Title T.epub")
+	if err := os.WriteFile(srcPath, []byte("epub bytes"), 0o644); err != nil {
+		t.Fatalf("seed src: %v", err)
+	}
+
+	s = NewScanner(
+		db.NewDownloadRepo(database), db.NewDownloadClientRepo(database),
+		db.NewBookRepo(database), db.NewAuthorRepo(database), db.NewHistoryRepo(database),
+		libraryDir, "", "", "", "",
+	)
+	s.WithSettings(settings)
+	return s, settings, ingestDir, srcPath, ctx
+}
+
+// TestPushToCWA_DisabledByEmptyPath: cwa.ingest_path unset is the default
+// for fresh installs and must be a no-op — no copy, no error.
+func TestPushToCWA_DisabledByEmptyPath(t *testing.T) {
+	s, _, ingestDir, srcPath, ctx := cwaFixture(t)
+	// Don't write the setting at all — value is "" by default.
+
+	s.pushToCWA(ctx, srcPath)
+
+	entries, _ := os.ReadDir(ingestDir)
+	if len(entries) != 0 {
+		t.Errorf("ingest dir should be empty when cwa.ingest_path is unset, got %d entries", len(entries))
+	}
+}
+
+// TestPushToCWA_NoSettings: scanner built without WithSettings (e.g. in
+// migrate-only invocations) must not panic on a nil settings repo.
+func TestPushToCWA_NoSettings(t *testing.T) {
+	s := NewScanner(nil, nil, nil, nil, nil, t.TempDir(), "", "", "", "")
+	// No WithSettings call — s.settings is nil.
+	s.pushToCWA(context.Background(), "/library/anything.epub") // must not panic
+}
+
+// TestPushToCWA_HappyPath: when cwa.ingest_path resolves to a writable dir,
+// the source file lands at <ingest>/<basename>.
+func TestPushToCWA_HappyPath(t *testing.T) {
+	s, settings, ingestDir, srcPath, ctx := cwaFixture(t)
+	if err := settings.Set(ctx, "cwa.ingest_path", ingestDir); err != nil {
+		t.Fatalf("set ingest path: %v", err)
+	}
+
+	s.pushToCWA(ctx, srcPath)
+
+	dst := filepath.Join(ingestDir, filepath.Base(srcPath))
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("ingest copy not found at %s: %v", dst, err)
+	}
+	if string(got) != "epub bytes" {
+		t.Errorf("ingest copy contents = %q, want %q", got, "epub bytes")
+	}
+	// Source must still exist — copy semantics, not move.
+	if _, err := os.Stat(srcPath); err != nil {
+		t.Errorf("source file removed after pushToCWA, expected copy semantics: %v", err)
+	}
+}
+
+// TestPushToCWA_MissingSourceSwallowed: if the source file disappears
+// between the import and the push (concurrent cleanup, NFS race, etc.)
+// the failure must be logged but not propagated — never roll back an
+// otherwise-good bindery import.
+func TestPushToCWA_MissingSourceSwallowed(t *testing.T) {
+	s, settings, ingestDir, srcPath, ctx := cwaFixture(t)
+	if err := settings.Set(ctx, "cwa.ingest_path", ingestDir); err != nil {
+		t.Fatalf("set ingest path: %v", err)
+	}
+
+	// Hand pushToCWA a path to a file that does not exist — CopyFileCtx
+	// should fail, the warn log should fire, and the function should
+	// return cleanly (no panic, no bubble).
+	s.pushToCWA(ctx, srcPath+".does-not-exist")
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -3767,6 +3767,37 @@ function CalibreSection({
         </div>
       </div>
 
+      <div className="bg-slate-100 dark:bg-zinc-900 rounded-lg p-5 border border-slate-300 dark:border-zinc-800">
+        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">Calibre-Web-Automated (CWA)</h3>
+        <p className="text-xs text-slate-600 dark:text-zinc-500 mb-4">
+          When set, every successful ebook import is also copied into this directory so a sibling{' '}
+          <a href="https://github.com/crocodilestick/Calibre-Web-Automated" target="_blank" rel="noopener noreferrer" className="text-emerald-700 dark:text-emerald-400 underline">CWA</a>{' '}
+          container can ingest it. Bindery keeps its own copy. Leave blank to disable.
+        </p>
+        <div>
+          <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Ingest folder path</label>
+          <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">Mount the same path into both containers. CWA's docs use <code className="text-[11px] bg-slate-200 dark:bg-zinc-800 px-1 rounded">/cwa-book-ingest</code>.</p>
+          <div className="flex gap-2">
+            <input
+              value={settings['cwa.ingest_path'] ?? ''}
+              onChange={e => setSettings(s => ({ ...s, 'cwa.ingest_path': e.target.value }))}
+              placeholder="/cwa-book-ingest"
+              className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+            />
+            <button
+              onClick={() => saveSettingWithError('cwa.ingest_path')}
+              disabled={saving === 'cwa.ingest_path'}
+              className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+            >
+              {saving === 'cwa.ingest_path' ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+          {saveError?.key === 'cwa.ingest_path' && (
+            <p className="text-xs text-red-600 dark:text-red-400 mt-1">{saveError.msg}</p>
+          )}
+        </div>
+      </div>
+
       {syncModalOpen && (
         <CalibreSyncModal
           progress={syncProgress}


### PR DESCRIPTION
## Summary

- Closes #417 — adds Calibre-Web-Automated (CWA) ingest support. Reporter clarified that CWA is a sibling container and only needs files dropped into a shared folder; no Calibre runtime in bindery itself.
- New setting **cwa.ingest_path**. When set, every successful ebook import is also copied to that directory (CWA's auto-ingest takes it from there). Bindery keeps its own copy.
- Audiobook imports are intentionally untouched (CWA is an ebook-library tool).
- Soulseek added to the v2 horizon section of ROADMAP with an honest note on why it's beyond a minor release (stateful P2P, vendored client or sidecar, slsk schema work).

## What changed

- **Migration 036_cwa_ingest.sql** — adds the new key, default empty (disabled).
- **internal/api/calibre.go** — SettingCWAIngestPath constant near the other Calibre keys.
- **internal/api/settings_handler.go** — validate the path on write (empty OK, non-empty must be an existing dir).
- **internal/importer/scanner.go** — new pushToCWA(ctx, srcPath) method using CopyFileCtx. Hooked at the ebook import site alongside pushToCalibre. Failures logged and swallowed (best-effort).
- **web/src/pages/SettingsPage.tsx** — new panel under Settings → General → Calibre-Web-Automated (CWA), single text input + Save.
- **docs/ROADMAP.md** — CWA shipped (Planned section); Soulseek added to v2 horizon with rationale.
- **CHANGELOG.md** — Unreleased entry under Added.

## Why copy and not move

CWA's docs (the reporter quoted them in #417): *"All files placed here are REMOVED AFTER PROCESSING"*. So if bindery moved instead of copied, a misconfigured or temporarily-broken CWA could swallow bindery's library copy. Copy semantics keep the failure modes independent.

## Test plan

- [x] go test ./... (full suite green; 4 new TestPushToCWA_* cases pass)
- [x] go vet ./...
- [x] go build ./...
- [x] npm --prefix web run typecheck (clean)
- [x] npm --prefix web run lint (5 pre-existing warnings, no new ones)
- [ ] Manual smoke (post-merge): set cwa.ingest_path to a writable dir, trigger an ebook import, confirm the file appears at <ingest>/<basename> AND remains in the bindery library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)