### PR TITLE
chore(deploy): promote bindery to v1.8.1

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.8.0"
+  tag: "1.8.1"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Manual recovery for v1.8.1 deploy-prod (recurring race condition; see project memory).