### PR TITLE
fix(downloader): resolve magnet redirects before sending to torrent client

### DIFF
--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -85,6 +85,17 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		UsesTorrentID: IsTorrentClient(client.Type),
 	}
 
+	// Pre-resolve indexer-provided URLs that 30x to a magnet target.
+	// Public torrent trackers proxied via Prowlarr commonly redirect
+	// to `magnet:?xt=...`, which BitTorrent clients can't follow as a
+	// redirect (they treat magnet: as a separate scheme, not a fetchable
+	// target). resolveTorrentSource walks redirects and returns the
+	// magnet directly so the download client can accept it. Failing
+	// soft: any error returns the original URL unchanged.
+	if IsTorrentClient(client.Type) {
+		sourceURL = resolveTorrentSource(ctx, sourceURL)
+	}
+
 	switch client.Type {
 	case "transmission":
 		trans := transmission.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)

--- a/internal/downloader/source_resolver.go
+++ b/internal/downloader/source_resolver.go
@@ -1,0 +1,86 @@
+package downloader
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// resolveTorrentSource normalises an indexer-supplied URL to whatever the
+// download client can actually consume.
+//
+// Public torrent indexers (1337x, TPB, Nyaa, RuTracker, etc.) when proxied
+// through Prowlarr's `/{indexerId}/download?...` endpoint commonly respond
+// with `HTTP 30x` and `Location: magnet:?xt=...`. BitTorrent clients
+// (Transmission, qBittorrent, Deluge) use libcurl-style HTTP fetchers that
+// follow HTTP-to-HTTP redirects but reject `magnet:` as a redirect target,
+// failing the grab with errors like `Couldn't fetch torrent: Moved
+// Permanently (301)`.
+//
+// Sonarr/Radarr handle this by pre-fetching the URL, following redirects,
+// and extracting the magnet from the `Location` header before handing it
+// to the download client. This function does the same: walk redirects up
+// to a small depth, return the first magnet we encounter, otherwise return
+// the original URL untouched (so torrent-file-bytes responses still work).
+//
+// All errors short-circuit to the original URL — failing soft means a
+// transient probe failure can never make a grab worse than the unfixed
+// upstream behaviour.
+func resolveTorrentSource(ctx context.Context, sourceURL string) string {
+	if !strings.HasPrefix(sourceURL, "http://") && !strings.HasPrefix(sourceURL, "https://") {
+		return sourceURL
+	}
+
+	// Don't follow redirects automatically — we need to inspect the
+	// Location header on each hop to spot a `magnet:` target.
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Timeout: 30 * time.Second,
+	}
+
+	current := sourceURL
+	for hops := 0; hops < 5; hops++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, current, nil)
+		if err != nil {
+			return sourceURL
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return sourceURL
+		}
+		// Drain + close so the connection can be re-used. We never need
+		// the body for redirect detection.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+			// 2xx (torrent file bytes) or 4xx/5xx (broken). Either way
+			// nothing to extract — the download client will handle the
+			// status appropriately.
+			return sourceURL
+		}
+		loc := resp.Header.Get("Location")
+		if loc == "" {
+			return sourceURL
+		}
+		if strings.HasPrefix(loc, "magnet:") {
+			slog.Debug("downloader: resolved indexer URL to magnet",
+				"original", sourceURL, "hops", hops+1)
+			return loc
+		}
+		// HTTP→HTTP redirect — follow another hop.
+		if !strings.HasPrefix(loc, "http://") && !strings.HasPrefix(loc, "https://") {
+			// Some other URI scheme we don't recognise (e.g. ftp://);
+			// safest to bail and let the download client try the
+			// original URL.
+			return sourceURL
+		}
+		current = loc
+	}
+	return sourceURL
+}

--- a/internal/downloader/source_resolver_test.go
+++ b/internal/downloader/source_resolver_test.go
@@ -1,0 +1,115 @@
+package downloader
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestResolveTorrentSource_PassesThroughMagnet(t *testing.T) {
+	const magnet = "magnet:?xt=urn:btih:abcdef1234567890abcdef1234567890abcdef12&dn=test"
+	got := resolveTorrentSource(context.Background(), magnet)
+	if got != magnet {
+		t.Fatalf("magnet input mutated: got %q want %q", got, magnet)
+	}
+}
+
+func TestResolveTorrentSource_PassesThroughNonHTTP(t *testing.T) {
+	const ftp = "ftp://example.com/file.torrent"
+	got := resolveTorrentSource(context.Background(), ftp)
+	if got != ftp {
+		t.Fatalf("non-HTTP input mutated: got %q want %q", got, ftp)
+	}
+}
+
+func TestResolveTorrentSource_PassesThroughTorrentBytes(t *testing.T) {
+	// Indexer responds with the .torrent file bytes inline (200 OK) — Bindery
+	// must NOT mangle the URL, the download client should handle it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-bittorrent")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("d8:announce..."))
+	}))
+	defer srv.Close()
+
+	got := resolveTorrentSource(context.Background(), srv.URL+"/foo.torrent")
+	if got != srv.URL+"/foo.torrent" {
+		t.Fatalf("200-OK url should be unchanged: got %q", got)
+	}
+}
+
+func TestResolveTorrentSource_ExtractsMagnetFrom301(t *testing.T) {
+	// The bug this whole helper exists to fix: Prowlarr-proxied URL
+	// 301-redirects to a magnet: target, BitTorrent clients can't follow.
+	const wantMagnet = "magnet:?xt=urn:btih:1234567890abcdef1234567890abcdef12345678&dn=The+Phoenix+Project"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, wantMagnet, http.StatusMovedPermanently)
+	}))
+	defer srv.Close()
+
+	got := resolveTorrentSource(context.Background(), srv.URL+"/dl?id=42")
+	if got != wantMagnet {
+		t.Fatalf("expected magnet extracted from 301 Location, got %q", got)
+	}
+}
+
+func TestResolveTorrentSource_ExtractsMagnetFrom302(t *testing.T) {
+	const wantMagnet = "magnet:?xt=urn:btih:fedcba0987654321fedcba0987654321fedcba09"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, wantMagnet, http.StatusFound)
+	}))
+	defer srv.Close()
+
+	got := resolveTorrentSource(context.Background(), srv.URL+"/dl")
+	if got != wantMagnet {
+		t.Fatalf("expected magnet extracted from 302 Location, got %q", got)
+	}
+}
+
+func TestResolveTorrentSource_FollowsHTTPChainToMagnet(t *testing.T) {
+	const wantMagnet = "magnet:?xt=urn:btih:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	// Final hop: 301 → magnet
+	finalSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, wantMagnet, http.StatusMovedPermanently)
+	}))
+	defer finalSrv.Close()
+	// First hop: 301 → finalSrv
+	firstSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, finalSrv.URL+"/step2", http.StatusMovedPermanently)
+	}))
+	defer firstSrv.Close()
+
+	got := resolveTorrentSource(context.Background(), firstSrv.URL+"/step1")
+	if got != wantMagnet {
+		t.Fatalf("expected magnet through 2-hop chain, got %q", got)
+	}
+}
+
+func TestResolveTorrentSource_BoundedRedirectLoop(t *testing.T) {
+	// Server that infinitely redirects to itself; we must not spin forever.
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, srv.URL+"/loop", http.StatusMovedPermanently)
+	}))
+	defer srv.Close()
+
+	got := resolveTorrentSource(context.Background(), srv.URL+"/loop")
+	// After the hop budget is exhausted we fall back to the original URL.
+	if !strings.HasPrefix(got, srv.URL) {
+		t.Fatalf("infinite-redirect should fall back to original URL, got %q", got)
+	}
+}
+
+func TestResolveTorrentSource_RedirectToFTPBailsOut(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "ftp://example.com/file.torrent", http.StatusMovedPermanently)
+	}))
+	defer srv.Close()
+
+	got := resolveTorrentSource(context.Background(), srv.URL+"/dl")
+	if got != srv.URL+"/dl" {
+		t.Fatalf("non-magnet/non-HTTP redirect should fall back to original URL, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

Public torrent indexers (1337x, TPB, Nyaa, RuTracker, etc.) when proxied through Prowlarr's `/{indexerId}/download?...` endpoint commonly respond with `HTTP 30x` and `Location: magnet:?xt=...`. BitTorrent clients (Transmission, qBittorrent, Deluge) follow HTTP-to-HTTP redirects but reject `magnet:` as a redirect target — failing the grab with errors like:

```
Couldn't fetch torrent: Moved Permanently (301)
```

Sonarr/Radarr handle this by pre-fetching the URL, walking redirects and extracting the magnet from the `Location` header before passing it to the download client. This change does the same for torrent-protocol clients in `SendDownload`.

## How

New `resolveTorrentSource` helper in `internal/downloader/source_resolver.go`:

- magnet:/non-HTTP URLs pass through unchanged
- walks up to 5 HTTP redirects looking for a `magnet:` target
- returns the magnet the first time one appears in `Location`
- falls back to the original URL on any error or non-magnet target (so torrent-file-bytes responses keep working unchanged)

Soft-fail design: a transient probe failure can never make a grab worse than current behaviour.

`SendDownload` calls it once, before the torrent-client switch:

\`\`\`go
if IsTorrentClient(client.Type) {
    sourceURL = resolveTorrentSource(ctx, sourceURL)
}
\`\`\`

## Tests

Eight new unit tests in `source_resolver_test.go` cover:

- magnet pass-through
- non-HTTP URI pass-through (e.g. ftp://)
- 200 OK torrent-file-bytes pass-through
- 301-to-magnet
- 302-to-magnet
- multi-hop HTTP-to-HTTP-to-magnet chain
- infinite-redirect bound (5 hops)
- non-magnet/non-HTTP redirect target bail-out

\`make test\` (run via golang:1.26.3-alpine container since the contributor doesn't have Go installed locally) — clean.

## Reproduction in the wild

Tested against a real Plexarr / CWA / Prowlarr / Transmission stack with 1337x + TPB indexers; pre-patch \`Citadel by Marko Kloos EPUB\`, \`Trouble on Paradise\`, \`Deathtrap\` all failed with the 301 error. Post-patch, the magnet is extracted from Prowlarr's redirect and Transmission accepts it.

## Compatibility

- No new dependencies (stdlib only)
- No config knobs added
- No-op for Usenet clients (\`IsTorrentClient\` gates the pre-resolve)
- No behaviour change for indexers that already serve magnet-direct or .torrent bytes inline

Happy to iterate if you'd prefer a different placement (e.g. inside each torrent client's \`AddTorrent\` instead of the adapter), naming, or a config flag to opt out.