### PR TITLE
fix(auth): exempt auth endpoints from X-Requested-With gate; wire admin role on API key path

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -23,6 +23,8 @@ A request is allowed if **any** of the following holds:
 
 Otherwise the server returns `401`. Browser sessions also need a CSRF double-submit token on mutating requests (`POST` / `PUT` / `DELETE`); API-key clients are exempt from CSRF.
 
+Non-browser clients (curl, scripts, mobile apps) authenticating via API key do **not** need to send an `X-Requested-With: bindery-ui` header — that header is required only for browser sessions to satisfy the CSRF gate. The auth endpoints listed above (`/auth/login`, `/auth/logout`, `/auth/setup`, `/auth/status`, `/auth/csrf`) are exempt from the `X-Requested-With` check entirely, since there is no session to protect at that stage.
+
 The API key lives in **Settings → General → Security**. Regenerating it invalidates every existing consumer.
 
 ## Endpoint catalogue (selection)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -659,6 +659,51 @@ func TestRequireXRequestedWith_AllowsSetupEndpoint(t *testing.T) {
 	}
 }
 
+// TestAPIKeyAuthGrantsAdminRole verifies that a request authenticated via a
+// valid API key is granted admin role in the context, so RequireAdmin-protected
+// endpoints are reachable without a session cookie.
+// Regression test for Bug 11: API key auth bypasses CSRF but then fails at
+// the role check with a misleading "admin role required" 403.
+func TestAPIKeyAuthGrantsAdminRole(t *testing.T) {
+	secret := []byte("stack-secret")
+	p := &fakeProvider{mode: ModeEnabled, apiKey: "my-api-key", secret: secret}
+
+	called := false
+	stack := Middleware(p)(
+		RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		})),
+	)
+
+	req, _ := http.NewRequest("POST", "/api/v1/settings/auth/mode", nil)
+	req.Header.Set("X-Api-Key", "my-api-key")
+	rw := &captureWriter{}
+	stack.ServeHTTP(rw, req)
+	if !called {
+		t.Fatalf("API-key POST to admin-protected endpoint must reach the handler; got status %d", rw.status)
+	}
+}
+
+// TestAPIKeyAuthRoleVisibleInContext verifies that the admin role is present in
+// the request context when API key auth is used, so handlers can inspect it.
+func TestAPIKeyAuthRoleVisibleInContext(t *testing.T) {
+	secret := []byte("stack-secret")
+	p := &fakeProvider{mode: ModeEnabled, apiKey: "my-api-key", secret: secret}
+
+	var gotRole string
+	stack := Middleware(p)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotRole = UserRoleFromContext(r.Context())
+	}))
+
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.Header.Set("X-Api-Key", "my-api-key")
+	stack.ServeHTTP(nopWriter{}, req)
+	if gotRole != "admin" {
+		t.Errorf("role in context = %q; want \"admin\"", gotRole)
+	}
+}
+
 func TestCSRFStack_BrowserSessionWithoutCSRFTokenIsRejected(t *testing.T) {
 	secret := []byte("stack-secret")
 	p := &fakeProvider{mode: ModeEnabled, apiKey: "harpoon-key", secret: secret}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -630,6 +630,35 @@ func TestCSRFStack_APIKeyGrabPassesAllGuards(t *testing.T) {
 	}
 }
 
+// TestRequireXRequestedWith_AllowsLoginEndpoint verifies that POST /api/v1/auth/login
+// passes through RequireXRequestedWith without the custom header. Before a session
+// exists there is no cookie to CSRF-protect, so blocking the login endpoint from plain
+// curl/scripts is pure friction with no security benefit.
+// Regression test for Bug 4: login unreachable from non-browser clients.
+func TestRequireXRequestedWith_AllowsLoginEndpoint(t *testing.T) {
+	called := false
+	h := RequireXRequestedWith(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	// No X-Requested-With, no API key — plain curl.
+	h.ServeHTTP(nopWriter{}, req)
+	if !called {
+		t.Fatal("POST /api/v1/auth/login must not be blocked by RequireXRequestedWith — no session to CSRF-protect")
+	}
+}
+
+// TestRequireXRequestedWith_AllowsSetupEndpoint mirrors the login case for the
+// first-run /auth/setup endpoint. Setup creates the very first user; there is
+// no authenticated session and therefore no CSRF risk.
+func TestRequireXRequestedWith_AllowsSetupEndpoint(t *testing.T) {
+	called := false
+	h := RequireXRequestedWith(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/auth/setup", nil)
+	h.ServeHTTP(nopWriter{}, req)
+	if !called {
+		t.Fatal("POST /api/v1/auth/setup must not be blocked by RequireXRequestedWith")
+	}
+}
+
 func TestCSRFStack_BrowserSessionWithoutCSRFTokenIsRejected(t *testing.T) {
 	secret := []byte("stack-secret")
 	p := &fakeProvider{mode: ModeEnabled, apiKey: "harpoon-key", secret: secret}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -165,6 +165,10 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 				return
 			}
 			if key := requestAPIKey(r); key != "" && subtle.ConstantTimeCompare([]byte(key), []byte(p.APIKey())) == 1 {
+				// API key authentication is always treated as admin. Set the role
+				// so RequireAdmin-protected endpoints are accessible without a
+				// session cookie (Bug 11: misleading "admin role required" 403).
+				r = r.WithContext(context.WithValue(r.Context(), userRoleCtxKey, "admin"))
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -271,7 +271,11 @@ func RequireXRequestedWith(next http.Handler) http.Handler {
 		case http.MethodGet, http.MethodHead, http.MethodOptions:
 			// safe methods — pass through
 		default:
-			if requestAPIKey(r) == "" && r.Header.Get("X-Requested-With") != "bindery-ui" {
+			// Auth endpoints (login, setup, logout…) are exempt: there is no
+			// session cookie to protect against CSRF at those points, so
+			// requiring the header is pure friction for non-browser clients.
+			// This mirrors the identical exemption in RequireCSRFToken.
+			if requestAPIKey(r) == "" && !AllowUnauthPath(r.URL.Path) && r.Header.Get("X-Requested-With") != "bindery-ui" {
 				w.Header().Set("Content-Type", "application/json")
 				http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
 				return


### PR DESCRIPTION
## Summary

- Closes #575 — auth endpoints no longer reject requests missing the `X-Requested-With: bindery-ui` header; non-browser clients (curl, mobile apps, integrations) can authenticate without this undocumented header
- Closes #582 — API key authentication now correctly sets the admin role in the request context; `RequireAdmin` middleware no longer returns 403 for valid API keys

## Details

**Bug #575**: The `RequireXRequestedWith` gate was applied too broadly — it blocked the login endpoint itself for non-browser clients. Auth endpoints are now exempted.

**Bug #582**: API key auth path now calls `r.WithContext(context.WithValue(..., userRoleCtxKey, "admin"))` after `subtle.ConstantTimeCompare` verification (constant-time compare already in place from #555; this adds only the role wiring).

## Test plan

- `go test ./internal/auth/... ./internal/api/...` ✓
- Manual smoke: curl with API key to admin endpoint → 200; curl login without X-Requested-With → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)