### PR TITLE
fix(abs): scan trigger after audiobook import, MISSING reconciliation, history format field

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -246,6 +246,23 @@ func main() {
 		slog.Info("audiobook download dir configured", "path", cfg.AudiobookDownloadDir)
 	}
 
+	// Wire ABS post-import scan notification (Bug #10). The notifier reads ABS
+	// config from settings at call time so that config changes (URL, API key,
+	// library ID) take effect without restarting Bindery.
+	importScanner.WithABSNotifier(
+		abs.NewScanNotifier(settingsRepo),
+		func() string {
+			cfg := api.LoadABSConfig(context.Background(), settingsRepo)
+			if !cfg.Enabled {
+				return ""
+			}
+			if cfg.AudiobooksLibraryID != "" {
+				return cfg.AudiobooksLibraryID
+			}
+			return cfg.LibraryID
+		},
+	)
+
 	modeResolver := func() calibre.Mode { return api.LoadCalibreMode(settingsRepo) }
 	calibreCfg := api.LoadCalibreConfig(settingsRepo)
 	currentMode := api.LoadCalibreMode(settingsRepo)

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -256,9 +256,6 @@ func main() {
 			if !cfg.Enabled {
 				return ""
 			}
-			if cfg.AudiobooksLibraryID != "" {
-				return cfg.AudiobooksLibraryID
-			}
 			return cfg.LibraryID
 		},
 	)

--- a/internal/abs/client.go
+++ b/internal/abs/client.go
@@ -166,6 +166,18 @@ func (c *Client) ListLibraryItems(ctx context.Context, libraryID string, page, l
 	return &out, nil
 }
 
+// ScanLibrary triggers an ABS library folder scan. ABS will walk all folders
+// configured for the library and surface any newly-added items. This is called
+// after a successful audiobook import so the item appears in ABS promptly
+// rather than waiting for the next scheduled scan (Bug #10).
+func (c *Client) ScanLibrary(ctx context.Context, libraryID string) error {
+	libraryID = strings.TrimSpace(libraryID)
+	if libraryID == "" {
+		return errors.New("library_id is required")
+	}
+	return c.doJSON(ctx, http.MethodPost, "/api/libraries/"+url.PathEscape(libraryID)+"/scan", nil, nil)
+}
+
 func (c *Client) GetLibraryItem(ctx context.Context, id string) (*LibraryItem, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {

--- a/internal/abs/client_test.go
+++ b/internal/abs/client_test.go
@@ -229,6 +229,44 @@ func TestClientGetLibraryItem_UsesExpandedAuthorsQuery(t *testing.T) {
 	}
 }
 
+func TestClientScanLibrary_PostsToCorrectEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(srv.URL, "secret-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.ScanLibrary(context.Background(), "lib-audiobooks"); err != nil {
+		t.Fatalf("ScanLibrary: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/libraries/lib-audiobooks/scan" {
+		t.Errorf("path = %q, want /api/libraries/lib-audiobooks/scan", gotPath)
+	}
+}
+
+func TestClientScanLibrary_EmptyLibraryIDReturnsError(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient("http://abs.example.com", "secret-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.ScanLibrary(context.Background(), ""); err == nil {
+		t.Fatal("expected error for empty library_id")
+	}
+}
+
 func TestShouldRetry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/abs/scan_notifier.go
+++ b/internal/abs/scan_notifier.go
@@ -1,0 +1,44 @@
+package abs
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// ScanNotifier triggers an ABS library scan after a successful audiobook
+// import (Bug #10). It reads ABS credentials from the settings DB at call
+// time so that config changes take effect without restarting Bindery.
+type ScanNotifier struct {
+	settings *db.SettingsRepo
+}
+
+// NewScanNotifier returns a ScanNotifier backed by the given settings repo.
+func NewScanNotifier(settings *db.SettingsRepo) *ScanNotifier {
+	return &ScanNotifier{settings: settings}
+}
+
+// ScanLibrary triggers an ABS folder scan for the given library. If ABS is
+// not configured (empty base_url or api_key), the call is a no-op.
+func (n *ScanNotifier) ScanLibrary(ctx context.Context, libraryID string) error {
+	baseURL := n.getSetting(ctx, "abs.base_url")
+	apiKey := n.getSetting(ctx, "abs.api_key")
+	if baseURL == "" || apiKey == "" {
+		slog.Debug("abs: ScanNotifier skipped — ABS not configured")
+		return nil
+	}
+	client, err := NewClient(baseURL, apiKey)
+	if err != nil {
+		return err
+	}
+	return client.ScanLibrary(ctx, libraryID)
+}
+
+func (n *ScanNotifier) getSetting(ctx context.Context, key string) string {
+	s, err := n.settings.Get(ctx, key)
+	if err != nil || s == nil {
+		return ""
+	}
+	return s.Value
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -31,6 +31,14 @@ type calibreAdder interface {
 	Add(ctx context.Context, filePath string) (int64, error)
 }
 
+// absNotifier is called after a successful audiobook import to trigger an
+// Audiobookshelf library scan so the new item is surfaced promptly rather than
+// waiting for the next scheduled ABS scan (which defaults to every 24 h).
+// Failures are best-effort — the import is never rolled back on ABS errors.
+type absNotifier interface {
+	ScanLibrary(ctx context.Context, libraryID string) error
+}
+
 // Scanner checks for completed downloads and imports them into the library.
 type Scanner struct {
 	downloads            *db.DownloadRepo
@@ -48,6 +56,8 @@ type Scanner struct {
 	libraryDir           string
 	audiobookDir         string
 	audiobookDownloadDir string
+	absLib               absNotifier
+	absLibraryIDFn       func() string
 }
 
 // NewScanner creates an import scanner. downloadPathRemap is an optional
@@ -148,6 +158,33 @@ func (s *Scanner) WithCalibre(mode func() calibre.Mode, adder calibreAdder) *Sca
 	s.calibreMode = mode
 	s.calibreAdder = adder
 	return s
+}
+
+// WithABSNotifier attaches an Audiobookshelf scan notifier. libraryIDFn is
+// called at import time to retrieve the current ABS audiobook library ID;
+// returning an empty string disables the notification for that import.
+func (s *Scanner) WithABSNotifier(n absNotifier, libraryIDFn func() string) *Scanner {
+	s.absLib = n
+	s.absLibraryIDFn = libraryIDFn
+	return s
+}
+
+// pushToABS triggers an ABS library scan after a successful audiobook import.
+// Failures are logged and swallowed — ABS sync is best-effort and must never
+// roll back an otherwise-good Bindery import.
+func (s *Scanner) pushToABS(ctx context.Context) {
+	if s.absLib == nil || s.absLibraryIDFn == nil {
+		return
+	}
+	libraryID := s.absLibraryIDFn()
+	if libraryID == "" {
+		return
+	}
+	if err := s.absLib.ScanLibrary(ctx, libraryID); err != nil {
+		slog.Warn("abs: library scan after audiobook import failed", "libraryID", libraryID, "error", err)
+		return
+	}
+	slog.Info("abs: triggered library scan after audiobook import", "libraryID", libraryID)
 }
 
 // WithSettings attaches a SettingsRepo to the scanner so scan results can be
@@ -784,6 +821,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		}(), "path", destDir)
 
 		s.pushToCalibre(ctx, book, author, destDir)
+		s.pushToABS(ctx)
 
 		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destDir})
 		if cleanupFunc != nil {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -823,7 +823,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		s.pushToCalibre(ctx, book, author, destDir)
 		s.pushToABS(ctx)
 
-		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destDir})
+		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destDir, "format": models.MediaTypeAudiobook})
 		if cleanupFunc != nil {
 			if err := cleanupFunc(); err != nil {
 				slog.Warn("cleanup failed", cleanupWarnAttrs(cleanupClientType, cleanupRemoteID, err)...)
@@ -881,7 +881,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		s.pushToCalibre(ctx, book, author, destPath)
 		s.pushToCWA(ctx, destPath)
 
-		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destPath})
+		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destPath, "format": models.MediaTypeEbook})
 	}
 
 	// If every file failed to copy/move, the destination is likely not writable —

--- a/internal/importer/scanner_abs_test.go
+++ b/internal/importer/scanner_abs_test.go
@@ -1,0 +1,175 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// fakeABSNotifier records every ScanLibrary call so tests can assert that
+// the Scanner triggers an ABS scan after a successful audiobook import.
+type fakeABSNotifier struct {
+	scanCalls []string // libraryID passed to each ScanLibrary call
+	err       error
+}
+
+func (f *fakeABSNotifier) ScanLibrary(_ context.Context, libraryID string) error {
+	f.scanCalls = append(f.scanCalls, libraryID)
+	return f.err
+}
+
+// absAudiobookFixture sets up an in-memory DB with a real author, book, and
+// download record so that tryImportInternal can run the full audiobook path
+// without panicking on a nil book pointer.
+func absAudiobookFixture(t *testing.T, audiobookDir string) (
+	s *Scanner,
+	dl *models.Download,
+	dlRepo *db.DownloadRepo,
+	ctx context.Context,
+) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx = context.Background()
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+	dlRepo = db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+
+	libraryDir := t.TempDir()
+	s = NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, audiobookDir, "", "", "")
+
+	author := &models.Author{ForeignID: "OL-abs-test", Name: "Blake Crouch", SortName: "Crouch, Blake"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OL-abs-book",
+		AuthorID:  author.ID,
+		Title:     "Recursion",
+		Status:    models.BookStatusWanted,
+		MediaType: models.MediaTypeAudiobook,
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	dl = &models.Download{
+		GUID:   "guid-abs-notify-test",
+		Title:  book.Title,
+		BookID: &book.ID,
+		Status: models.StateCompleted,
+		NZBURL: "fake://url",
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	return s, dl, dlRepo, ctx
+}
+
+// TestTryImportInternal_NotifiesABSAfterAudiobookImport is the regression test
+// for Bug #10: after a successful audiobook import, Bindery must trigger an ABS
+// library scan so the new item is surfaced promptly rather than waiting for the
+// next scheduled ABS scan (which defaults to every 24 h).
+func TestTryImportInternal_NotifiesABSAfterAudiobookImport(t *testing.T) {
+	t.Parallel()
+
+	audiobookDir := t.TempDir()
+	downloadPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(downloadPath, "book.m4b"), []byte("audio-data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, dl, _, ctx := absAudiobookFixture(t, audiobookDir)
+
+	notifier := &fakeABSNotifier{}
+	const wantLibraryID = "lib-audiobooks-123"
+	s.WithABSNotifier(notifier, func() string { return wantLibraryID })
+
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil)
+
+	if len(notifier.scanCalls) != 1 {
+		t.Fatalf("expected 1 ScanLibrary call after audiobook import, got %d", len(notifier.scanCalls))
+	}
+	if notifier.scanCalls[0] != wantLibraryID {
+		t.Errorf("ScanLibrary called with libraryID=%q, want %q", notifier.scanCalls[0], wantLibraryID)
+	}
+}
+
+// TestTryImportInternal_DoesNotNotifyABSForEbookImport verifies that the ABS
+// notifier is NOT called when an ebook (not an audiobook) is imported.
+func TestTryImportInternal_DoesNotNotifyABSForEbookImport(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	downloadPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(downloadPath, "dune.epub"), []byte("epub-data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, "", "", "", "")
+
+	notifier := &fakeABSNotifier{}
+	s.WithABSNotifier(notifier, func() string { return "lib-audiobooks-123" })
+
+	dl := &models.Download{
+		Title:  "Dune",
+		GUID:   "test-guid-ebook",
+		Status: models.StateCompleted,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil)
+
+	if len(notifier.scanCalls) != 0 {
+		t.Fatalf("expected 0 ScanLibrary calls for ebook import, got %d: %v", len(notifier.scanCalls), notifier.scanCalls)
+	}
+}
+
+// TestTryImportInternal_ABSNotifySkippedWhenNoLibraryID verifies that when the
+// ABS library ID resolver returns an empty string (ABS not configured), the
+// notifier is not called and the import succeeds normally.
+func TestTryImportInternal_ABSNotifySkippedWhenNoLibraryID(t *testing.T) {
+	t.Parallel()
+
+	audiobookDir := t.TempDir()
+	downloadPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(downloadPath, "recursion.m4b"), []byte("audio"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, dl, _, ctx := absAudiobookFixture(t, audiobookDir)
+
+	notifier := &fakeABSNotifier{}
+	// Library ID resolver returns "" — ABS not configured.
+	s.WithABSNotifier(notifier, func() string { return "" })
+
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil)
+
+	if len(notifier.scanCalls) != 0 {
+		t.Fatalf("expected 0 ScanLibrary calls when libraryID is empty, got %d", len(notifier.scanCalls))
+	}
+}

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -2,6 +2,7 @@ package importer
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -289,5 +290,76 @@ func TestImportInternal_ThreeFileBundle_TracksAllInBookFiles(t *testing.T) {
 	}
 	if len(files) != 3 {
 		t.Errorf("want 3 book_files rows for epub+mobi+pdf bundle, got %d", len(files))
+	}
+}
+
+// TestTryImportInternal_HistoryEventIncludesFormat is the regression test for
+// Bug #13. When an ebook is imported for a media_type='both' book the
+// bookImported history event must carry a "format" field so the user can see
+// which format was actually imported — without it the queue shows "imported"
+// with no indication that the audiobook half is still missing.
+func TestTryImportInternal_HistoryEventIncludesFormat(t *testing.T) {
+	libDir := t.TempDir()
+	dlDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dlDir, "book.epub"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	historyRepo := db.NewHistoryRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OLA-B13", Name: "Author B13", SortName: "B13, Author",
+		Monitored: true, MetadataProvider: "openlibrary",
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OLB-B13", AuthorID: author.ID,
+		Title: "Both Format Book", SortTitle: "Both Format Book",
+		Status: models.BookStatusWanted, Monitored: true, AnyEditionOK: true,
+		MediaType: models.MediaTypeBoth, MetadataProvider: "openlibrary",
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	dl := &models.Download{
+		GUID: "b13-guid", Title: "Both Format Book", BookID: &book.ID,
+		Status: models.StateCompleted,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, historyRepo, libDir, "", "", "", "")
+	s.tryImportInternal(ctx, dl, dlDir, "", "", nil)
+
+	events, err := historyRepo.ListByType(ctx, models.HistoryEventBookImported)
+	if err != nil {
+		t.Fatalf("list history events: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("Bug #13: no bookImported history event was created")
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal([]byte(events[0].Data), &data); err != nil {
+		t.Fatalf("unmarshal history event data: %v", err)
+	}
+	if got := data["format"]; got != models.MediaTypeEbook {
+		t.Errorf("Bug #13: history event missing format field: got %q, want %q — user cannot tell ebook vs audiobook was imported", got, models.MediaTypeEbook)
 	}
 }


### PR DESCRIPTION
## Summary

- Closes #581 — bindery triggers ABS library scan after successful audiobook import
- Closes #583 — ABS scan after move-mode import resolves MISSING status
- Closes #584 — `bookImported` history events include the `format` field for `media_type='both'` books

## Test plan

- `go test ./internal/abs/... ./internal/db/... ./internal/importer/...` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)