### PR TITLE
fix(authors): scope duplicate check to current user, repair orphaned owner_user_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.9.1] — 2026-05-11
+
+### Fixed
+
+- **Author list no longer hides authors after user re-creation** — The "author already exists" duplicate check was global-scoped while the author list filtered by `owner_user_id`. Authors whose `owner_user_id` pointed to a deleted or re-created user were permanently invisible in the list but blocked re-addition. The check is now user-scoped so it agrees with what the list shows. A new migration (039) resets orphaned `owner_user_id` values to NULL so those authors become visible to all users immediately on upgrade.
+
+- **Canonical author name search now scoped to current user** — The name-deduplication path during author creation previously searched the global author pool, which could conflict with authors belonging to other users in multi-user setups.
+
 ## [v1.9.0] — 2026-05-11
 
 ### Added

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -129,8 +129,11 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if already exists
-	existing, _ := h.authors.GetByForeignID(r.Context(), req.ForeignID)
+	// Check if already exists — use user-scoped lookup so this agrees with the
+	// author list, which filters by owner_user_id. A global GetByForeignID
+	// would block re-creation of authors orphaned under a different user ID.
+	userID := auth.UserIDFromContext(r.Context())
+	existing, _ := h.authors.GetByForeignIDForUser(r.Context(), req.ForeignID, userID)
 	if existing != nil {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "author already exists"})
 		return
@@ -142,7 +145,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if author.ForeignID != "" {
-		if existing, _ := h.authors.GetByForeignID(r.Context(), author.ForeignID); existing != nil {
+		if existing, _ := h.authors.GetByForeignIDForUser(r.Context(), author.ForeignID, userID); existing != nil {
 			h.writeCanonicalAuthorConflict(w, existing, "author already exists")
 			return
 		}
@@ -371,7 +374,7 @@ func (h *AuthorHandler) findAuthorByNameOrAliasExcluding(ctx context.Context, ex
 	if name == "" {
 		return nil, false, nil
 	}
-	authors, err := h.authors.List(ctx)
+	authors, err := h.authors.ListByUser(ctx, auth.UserIDFromContext(ctx))
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -90,6 +90,27 @@ func (r *AuthorRepo) GetByForeignID(ctx context.Context, foreignID string) (*mod
 	return &a, nil
 }
 
+// GetByForeignIDForUser returns the author with the given foreign_id that is
+// visible to userID — i.e. owned by that user or with a NULL owner. When
+// userID is 0 the search is global (same as GetByForeignID).
+func (r *AuthorRepo) GetByForeignIDForUser(ctx context.Context, foreignID string, userID int64) (*models.Author, error) {
+	if userID == 0 {
+		return r.GetByForeignID(ctx, foreignID)
+	}
+	row := r.db.QueryRowContext(ctx, `
+		SELECT `+authorSelectCols+`
+		FROM authors WHERE foreign_id = ? AND (owner_user_id = ? OR owner_user_id IS NULL)`, foreignID, userID)
+
+	a, err := scanAuthorRow(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get author by foreign_id %s: %w", foreignID, err)
+	}
+	return &a, nil
+}
+
 func (r *AuthorRepo) Create(ctx context.Context, a *models.Author) error {
 	return r.CreateForUser(ctx, a, 0)
 }

--- a/internal/db/migrations/039_orphan_author_reassign.sql
+++ b/internal/db/migrations/039_orphan_author_reassign.sql
@@ -1,0 +1,8 @@
+-- Reassign authors whose owner_user_id points to a deleted user to NULL so
+-- they become visible to all users. This fixes installs where the admin user
+-- was deleted and recreated (gaining a new ID), leaving pre-existing authors
+-- permanently invisible despite blocking re-creation via the duplicate check.
+UPDATE authors
+SET owner_user_id = NULL
+WHERE owner_user_id IS NOT NULL
+  AND owner_user_id NOT IN (SELECT id FROM users);


### PR DESCRIPTION
## Summary

- Adds `GetByForeignIDForUser` to `AuthorRepo` — user-scoped variant of `GetByForeignID` that adds `AND (owner_user_id = ? OR owner_user_id IS NULL)` when a userID is provided.
- Fixes the Create handler's duplicate-existence check (lines 133, 145) to use the user-scoped variant so it agrees with what the author list shows.
- Fixes `findAuthorByNameOrAliasExcluding` to search `ListByUser` instead of the global `List`, preventing cross-user canonical-name conflicts.
- Adds migration 039 that resets `owner_user_id` to NULL for rows pointing at non-existent users, making them visible to all users via the existing `OR owner_user_id IS NULL` clause.

## Root cause

Migration 025 backfilled all existing authors to `owner_user_id = 1`. If user 1 was later deleted and recreated (gaining a new ID), those authors became permanently invisible in the list but still blocked re-creation because the duplicate check was global. The list and the duplicate check disagreed on what "exists" meant.

## Test plan

- [ ] `go test ./internal/db/... ./internal/api/...` — passes
- [ ] Migration 039 runs cleanly on the production DB (no errors in startup logs)
- [ ] Leigh Bardugo and other previously-invisible authors now appear in the author list
- [ ] "Author already exists" no longer fires for authors the user can see in their list
- [ ] `SELECT COUNT(*) FROM authors WHERE owner_user_id NOT IN (SELECT id FROM users) AND owner_user_id IS NOT NULL` returns 0 post-migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)