### PR TITLE
fix(hardcover): enable enhanced series by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 - **ABS review search results are scrollable and keep book-author links intact** — No-match review author/book searches now show up to 10 scrollable matches instead of truncating after three, and selecting a book result auto-links its author before resolving the book when the review item does not already have a resolved author.
 
+- **Enhanced Hardcover series controls are no longer hidden by default** (#596) — The deployment-wide `BINDERY_ENHANCED_HARDCOVER_API` flag now defaults to enabled, leaving the saved Hardcover token and **Settings -> General** admin toggle as the normal feature gates. Operators can still set the flag to `false` to disable the feature for an entire deployment.
+
 ## [v1.9.1] — 2026-05-11
 
 ### Fixed

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -233,7 +233,7 @@ Multiple remaps are separated by commas: `BINDERY_DOWNLOAD_PATH_REMAP=/sab/compl
 | `BINDERY_AUDIOBOOK_DOWNLOAD_DIR` | falls back to `BINDERY_DOWNLOAD_DIR` | Separate watch folder for audiobook downloads; set this when your download client routes audiobook grabs to a dedicated category/path |
 | `BINDERY_LIBRARY_DIR` | `/books` | Destination for imported ebook files |
 | `BINDERY_AUDIOBOOK_DIR` | falls back to `BINDERY_LIBRARY_DIR` | Destination for imported audiobook folders |
-| `BINDERY_ENHANCED_HARDCOVER_API` | `false` | Set to `true` to allow token-backed Hardcover series search, linking, catalog diffs, and missing-book fill after an admin enables the feature in Settings. |
+| `BINDERY_ENHANCED_HARDCOVER_API` | `true` | Set to `false` to disable token-backed Hardcover series search, linking, catalog diffs, and missing-book fill even when an admin enables the feature in Settings. |
 | `BINDERY_DOWNLOAD_PATH_REMAP` | _(empty)_ | Comma-separated `from:to` pairs rewriting paths reported by the download client into paths Bindery can access. Required when SABnzbd and Bindery mount the same storage at different paths. Longest-prefix match wins. See [Path remapping](#path-remapping-multi-container--multi-pod-setups). |
 | `BINDERY_PUID` | _(unset)_ | Sanity check — see [Running as a specific UID/GID](#running-as-a-specific-uidgid) |
 | `BINDERY_PGID` | _(unset)_ | Sanity check — same as `BINDERY_PUID` for the primary GID |
@@ -279,7 +279,7 @@ On first launch Bindery bootstraps itself — **no environment variables are req
 
 **Schema:** enhanced series data uses migration `035`, which creates `series_hardcover_links` and backfills links for existing series whose foreign ID already points at Hardcover. Take a normal SQLite backup before upgrading, then let Bindery apply the migration on startup.
 
-**Feature flag:** token-backed Hardcover series search, manual/automatic series linking, catalog diffs, and missing-book fill are disabled by default. Set `BINDERY_ENHANCED_HARDCOVER_API=true`, save a Hardcover API token in **Settings -> General**, then enable enhanced Hardcover series data in the same settings section. If any of those three requirements is missing, the enhanced endpoints return `404` and the UI hides the controls; existing local series data keeps working.
+**Feature flag:** token-backed Hardcover series search, manual/automatic series linking, catalog diffs, and missing-book fill are available by default at deployment time, but still require a saved Hardcover API token in **Settings -> General** and the enhanced Hardcover series toggle in the same settings section. Set `BINDERY_ENHANCED_HARDCOVER_API=false` only when you need to disable the enhanced endpoints and hide the UI controls for an entire deployment. Existing local series data keeps working when the feature is disabled.
 
 **Operational note:** the enhanced fill action can create wanted/monitored book rows from the linked Hardcover catalog and immediately queue indexer searches. Make sure outbound HTTPS to Hardcover and your configured indexers is allowed before enabling it for production users.
 

--- a/docs/Hardcover-Series-Wiki.md
+++ b/docs/Hardcover-Series-Wiki.md
@@ -21,13 +21,12 @@ Local series management remains available without the enhanced Hardcover feature
 
 ## Before You Start
 
-Enhanced Hardcover series data requires three things:
+Enhanced Hardcover series data requires:
 
-- `BINDERY_ENHANCED_HARDCOVER_API=true` in the Bindery environment
 - a saved Hardcover API token in `Settings -> General`
 - the **Enhanced Hardcover series** toggle enabled in `Settings -> General`
 
-If any requirement is missing, Bindery hides the enhanced controls and the enhanced API endpoints return `404`. Existing local series data keeps working.
+If either requirement is missing, Bindery hides the enhanced controls and the enhanced API endpoints return `404`. Existing local series data keeps working. Operators can still disable the feature for the whole deployment with `BINDERY_ENHANCED_HARDCOVER_API=false`.
 
 ## Series Workflow
 
@@ -66,7 +65,7 @@ The fill action may create new authors and books from Hardcover metadata when th
 
 ## Troubleshooting
 
-- Enhanced controls are missing: confirm `BINDERY_ENHANCED_HARDCOVER_API=true`, save a Hardcover API token, then enable **Enhanced Hardcover series** in `Settings -> General`.
+- Enhanced controls are missing: save a Hardcover API token, then enable **Enhanced Hardcover series** in `Settings -> General`. If your operator disabled the deployment-wide feature flag, they must remove `BINDERY_ENHANCED_HARDCOVER_API=false` and restart Bindery.
 - Hardcover test fails: verify the token at [Hardcover API settings](https://hardcover.app/account/api) and make sure Bindery can reach `hardcover.app`.
 - Search finds the wrong series: choose a different result manually, or remove the link and search again with a more specific local series name.
 - Fill gaps adds nothing: check whether the missing books already exist locally, are excluded, or whether the linked Hardcover catalog has no missing entries relative to the local series.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	AudiobookDownloadDir string
 	LibraryDir           string
 	AudiobookDir         string
-	// Enhanced Hardcover series API (BINDERY_ENHANCED_HARDCOVER_API, default false).
+	// Enhanced Hardcover series API (BINDERY_ENHANCED_HARDCOVER_API, default true).
 	EnhancedHardcoverAPI bool
 	DownloadPathRemap    string
 	// Proxy SSO settings (Phase 1).
@@ -66,7 +66,7 @@ func Load() *Config {
 		AudiobookDownloadDir:   envOr("BINDERY_AUDIOBOOK_DOWNLOAD_DIR", ""),
 		LibraryDir:             envOr("BINDERY_LIBRARY_DIR", "/books"),
 		AudiobookDir:           envOr("BINDERY_AUDIOBOOK_DIR", ""),
-		EnhancedHardcoverAPI:   envBool("BINDERY_ENHANCED_HARDCOVER_API", false),
+		EnhancedHardcoverAPI:   envBool("BINDERY_ENHANCED_HARDCOVER_API", true),
 		DownloadPathRemap:      envOr("BINDERY_DOWNLOAD_PATH_REMAP", ""),
 		ProxyAuthHeader:        envOr("BINDERY_PROXY_AUTH_HEADER", "X-Forwarded-User"),
 		ProxyAutoProvision:     envBool("BINDERY_PROXY_AUTO_PROVISION", true),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,8 +18,8 @@ func TestLoadDefaults(t *testing.T) {
 	if cfg.LogLevel != "info" {
 		t.Errorf("expected default log level info, got %s", cfg.LogLevel)
 	}
-	if cfg.EnhancedHardcoverAPI {
-		t.Error("expected enhanced Hardcover API to default to disabled")
+	if !cfg.EnhancedHardcoverAPI {
+		t.Error("expected enhanced Hardcover API to default to enabled")
 	}
 
 	// DBPath/DataDir are platform-dependent as of #7. CI runs on linux so
@@ -38,7 +38,7 @@ func TestLoadDefaults(t *testing.T) {
 func TestLoadFromEnv(t *testing.T) {
 	t.Setenv("BINDERY_PORT", "9999")
 	t.Setenv("BINDERY_LOG_LEVEL", "debug")
-	t.Setenv("BINDERY_ENHANCED_HARDCOVER_API", "true")
+	t.Setenv("BINDERY_ENHANCED_HARDCOVER_API", "false")
 
 	cfg := Load()
 
@@ -48,8 +48,8 @@ func TestLoadFromEnv(t *testing.T) {
 	if cfg.LogLevel != "debug" {
 		t.Errorf("expected log level debug, got %s", cfg.LogLevel)
 	}
-	if !cfg.EnhancedHardcoverAPI {
-		t.Error("expected enhanced Hardcover API to respect BINDERY_ENHANCED_HARDCOVER_API=true")
+	if cfg.EnhancedHardcoverAPI {
+		t.Error("expected enhanced Hardcover API to respect BINDERY_ENHANCED_HARDCOVER_API=false")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Default `BINDERY_ENHANCED_HARDCOVER_API` to enabled so saved Hardcover token plus the Settings admin toggle are the normal enhanced-series gates.
- Keep `BINDERY_ENHANCED_HARDCOVER_API=false` as a deployment-wide opt-out and update deployment/wiki docs to match.
- Update the config test to cover the explicit opt-out path.

Closes #596

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] Wiki pages updated if user-facing behaviour changed

## Test plan

- [x] `go test ./internal/config ./internal/api`
- [x] `gofmt -l internal/config/config.go internal/config/config_test.go`
- [x] `go vet ./...`
- [x] `go test ./cmd/... ./internal/...`
