### PR TITLE
fix(abs): improve review search matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **ABS review search results are scrollable and keep book-author links intact** — No-match review author/book searches now show up to 10 scrollable matches instead of truncating after three, and selecting a book result auto-links its author before resolving the book when the review item does not already have a resolved author.
+
 ## [v1.9.1] — 2026-05-11
 
 ### Fixed

--- a/web/src/pages/SettingsPage.absReview.test.tsx
+++ b/web/src/pages/SettingsPage.absReview.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import SettingsPage from './SettingsPage'
 import { api } from '../api/client'
 import type { ABSReviewItem, Author, Book } from '../api/client'
@@ -33,6 +33,8 @@ vi.mock('../api/client', async importOriginal => {
       absImportRuns: vi.fn(),
       absReviewItems: vi.fn(),
       absConflicts: vi.fn(),
+      resolveAbsReviewAuthor: vi.fn(),
+      resolveAbsReviewBook: vi.fn(),
       searchAuthors: vi.fn(),
       searchBooks: vi.fn(),
       listSettings: vi.fn(),
@@ -129,6 +131,7 @@ describe('SettingsPage ABS review search', () => {
     vi.mocked(api.absImportStatus).mockResolvedValue({ running: false, processed: 0 })
     vi.mocked(api.absImportRuns).mockResolvedValue([])
     vi.mocked(api.absConflicts).mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 })
+    vi.mocked(api.resolveAbsReviewAuthor).mockResolvedValue({ updated: 1 })
     vi.mocked(api.searchAuthors).mockResolvedValue([])
     vi.mocked(api.searchBooks).mockResolvedValue([])
     vi.mocked(api.listSettings).mockResolvedValue([{ key: 'hardcover.enhanced_series_enabled', value: 'false' }])
@@ -192,4 +195,76 @@ describe('SettingsPage ABS review search', () => {
     expect(firstBook?.parentElement).toHaveClass('max-h-48', 'overflow-y-auto')
   })
 
+  it('auto-links the selected book author before resolving the book', async () => {
+    const item = makeReviewItem()
+    const author = makeAuthor(42, {
+      foreignAuthorId: 'OL42A',
+      authorName: 'Martha Wells',
+    })
+    const book = makeBook(1, {
+      foreignBookId: 'OL1W',
+      title: 'All Systems Red',
+      author,
+    })
+    vi.mocked(api.searchBooks).mockResolvedValue([book])
+    vi.mocked(api.resolveAbsReviewBook).mockResolvedValue({
+      ...item,
+      resolvedAuthorForeignId: 'OL42A',
+      resolvedAuthorName: 'Martha Wells',
+      resolvedBookForeignId: 'OL1W',
+      resolvedBookTitle: 'All Systems Red',
+    })
+
+    await renderABSReview([item])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Book' }))
+    fireEvent.click(await screen.findByRole('button', { name: /All Systems Red/ }))
+
+    await waitFor(() => {
+      expect(api.resolveAbsReviewAuthor).toHaveBeenCalledWith(1, {
+        foreignAuthorId: 'OL42A',
+        authorName: 'Martha Wells',
+        applyTo: 'same_author',
+      })
+      expect(api.resolveAbsReviewBook).toHaveBeenCalledWith(1, {
+        foreignBookId: 'OL1W',
+        title: 'All Systems Red',
+        editedTitle: 'All Systems Red',
+      })
+    })
+    expect(vi.mocked(api.resolveAbsReviewAuthor).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(api.resolveAbsReviewBook).mock.invocationCallOrder[0],
+    )
+  })
+
+  it('does not auto-link the selected book author when one is already resolved', async () => {
+    const item = makeReviewItem({
+      resolvedAuthorForeignId: 'OL-existing',
+      resolvedAuthorName: 'Existing Author',
+    })
+    const book = makeBook(1, {
+      foreignBookId: 'OL1W',
+      title: 'All Systems Red',
+      author: makeAuthor(42, {
+        foreignAuthorId: 'OL42A',
+        authorName: 'Martha Wells',
+      }),
+    })
+    vi.mocked(api.searchBooks).mockResolvedValue([book])
+    vi.mocked(api.resolveAbsReviewBook).mockResolvedValue({
+      ...item,
+      resolvedBookForeignId: 'OL1W',
+      resolvedBookTitle: 'All Systems Red',
+    })
+
+    await renderABSReview([item])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Book' }))
+    fireEvent.click(await screen.findByRole('button', { name: /All Systems Red/ }))
+
+    await waitFor(() => {
+      expect(api.resolveAbsReviewBook).toHaveBeenCalled()
+    })
+    expect(api.resolveAbsReviewAuthor).not.toHaveBeenCalled()
+  })
 })

--- a/web/src/pages/SettingsPage.absReview.test.tsx
+++ b/web/src/pages/SettingsPage.absReview.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import SettingsPage from './SettingsPage'
+import { api } from '../api/client'
+import type { ABSReviewItem, Author, Book } from '../api/client'
+
+vi.mock('../settings/AuthSettings', () => ({ default: () => <div data-testid="auth-settings" /> }))
+vi.mock('../components/ThemeToggle', () => ({ default: () => <button type="button">Theme</button> }))
+vi.mock('../components/LanguageSwitcher', () => ({ default: () => <select aria-label="Language" /> }))
+vi.mock('../auth/AuthContext', () => ({
+  useAuth: () => ({ isAdmin: true }),
+}))
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+    i18n: { changeLanguage: vi.fn() },
+  }),
+}))
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      listIndexers: vi.fn(),
+      listDownloadClients: vi.fn(),
+      listProwlarr: vi.fn(),
+      absConfig: vi.fn(),
+      absSetConfig: vi.fn(),
+      absLibraries: vi.fn(),
+      absImportStart: vi.fn(),
+      absImportStatus: vi.fn(),
+      absImportRuns: vi.fn(),
+      absReviewItems: vi.fn(),
+      absConflicts: vi.fn(),
+      searchAuthors: vi.fn(),
+      searchBooks: vi.fn(),
+      listSettings: vi.fn(),
+      listBackups: vi.fn(),
+      libraryScanStatus: vi.fn(),
+      getStorage: vi.fn(),
+      listRootFolders: vi.fn(),
+      status: vi.fn(),
+      setSetting: vi.fn(),
+      testHardcover: vi.fn(),
+      authConfig: vi.fn(),
+    },
+  }
+})
+
+const makeAuthor = (index: number, overrides: Partial<Author> = {}): Author => ({
+  id: index,
+  foreignAuthorId: `author-${index}`,
+  authorName: `Author ${index}`,
+  sortName: `Author ${index}`,
+  description: '',
+  imageUrl: '',
+  disambiguation: '',
+  ratingsCount: 0,
+  averageRating: 0,
+  monitored: true,
+  ...overrides,
+})
+
+const makeBook = (index: number, overrides: Partial<Book> = {}): Book => ({
+  id: index,
+  foreignBookId: `book-${index}`,
+  authorId: 100 + index,
+  title: `Book ${index}`,
+  description: '',
+  imageUrl: '',
+  genres: [],
+  monitored: true,
+  status: 'wanted',
+  filePath: '',
+  mediaType: 'audiobook',
+  ebookFilePath: '',
+  audiobookFilePath: '',
+  excluded: false,
+  author: makeAuthor(100 + index, { authorName: `Book Author ${index}` }),
+  ...overrides,
+})
+
+const makeReviewItem = (overrides: Partial<ABSReviewItem> = {}): ABSReviewItem => ({
+  id: 1,
+  sourceId: 'default',
+  libraryId: 'lib-books',
+  itemId: 'item-1',
+  title: 'All Systems Red',
+  primaryAuthor: 'Martha Wells',
+  asin: '',
+  mediaType: 'audiobook',
+  reviewReason: 'unmatched_author',
+  payloadJson: '{}',
+  fileMappingFound: false,
+  latestRunId: null,
+  status: 'pending',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  ...overrides,
+})
+
+describe('SettingsPage ABS review search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.listIndexers).mockResolvedValue([])
+    vi.mocked(api.listDownloadClients).mockResolvedValue([])
+    vi.mocked(api.listProwlarr).mockResolvedValue([])
+    vi.mocked(api.absConfig).mockResolvedValue({
+      featureEnabled: true,
+      baseUrl: 'https://abs.example.com',
+      label: 'Shelf',
+      enabled: true,
+      libraryId: 'lib-books',
+      pathRemap: '',
+      apiKeyConfigured: true,
+    })
+    vi.mocked(api.absSetConfig).mockResolvedValue({
+      featureEnabled: true,
+      baseUrl: 'https://abs.example.com',
+      label: 'Shelf',
+      enabled: true,
+      libraryId: 'lib-books',
+      pathRemap: '',
+      apiKeyConfigured: true,
+    })
+    vi.mocked(api.absLibraries).mockResolvedValue([])
+    vi.mocked(api.absImportStart).mockResolvedValue({ running: true, dryRun: true, processed: 0 })
+    vi.mocked(api.absImportStatus).mockResolvedValue({ running: false, processed: 0 })
+    vi.mocked(api.absImportRuns).mockResolvedValue([])
+    vi.mocked(api.absConflicts).mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 })
+    vi.mocked(api.searchAuthors).mockResolvedValue([])
+    vi.mocked(api.searchBooks).mockResolvedValue([])
+    vi.mocked(api.listSettings).mockResolvedValue([{ key: 'hardcover.enhanced_series_enabled', value: 'false' }])
+    vi.mocked(api.listBackups).mockResolvedValue([])
+    vi.mocked(api.libraryScanStatus).mockRejectedValue(new Error('no scan'))
+    vi.mocked(api.getStorage).mockResolvedValue({ downloadDir: '/downloads', libraryDir: '/books', audiobookDir: '' })
+    vi.mocked(api.listRootFolders).mockResolvedValue([])
+    vi.mocked(api.status).mockResolvedValue({
+      version: 'dev',
+      commit: 'unknown',
+      buildDate: '',
+      enhancedHardcoverApi: false,
+      hardcoverTokenConfigured: false,
+    })
+    vi.mocked(api.setSetting).mockResolvedValue(undefined)
+    vi.mocked(api.testHardcover).mockResolvedValue({
+      ok: true,
+      tokenConfigured: true,
+      searchResults: 0,
+      catalogOk: true,
+      message: 'ok',
+    })
+    vi.mocked(api.authConfig).mockResolvedValue({ mode: 'disabled', apiKey: 'key', username: 'admin' })
+  })
+
+  const renderABSReview = async (items: ABSReviewItem[]) => {
+    vi.mocked(api.absReviewItems).mockResolvedValue({
+      items,
+      total: items.length,
+      limit: 50,
+      offset: 0,
+    })
+
+    render(<SettingsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.abs' }))
+    await screen.findByText('No-match books')
+  }
+
+  it('shows capped scrollable author and book results', async () => {
+    const item = makeReviewItem()
+    vi.mocked(api.searchAuthors).mockResolvedValue(Array.from({ length: 12 }, (_, index) => makeAuthor(index + 1)))
+    vi.mocked(api.searchBooks).mockResolvedValue(Array.from({ length: 12 }, (_, index) => makeBook(index + 1)))
+
+    await renderABSReview([item])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Author' }))
+
+    const firstAuthor = await screen.findByRole('button', { name: 'Author 1' })
+    expect(screen.getByRole('button', { name: 'Author 4' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Author 10' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Author 11' })).not.toBeInTheDocument()
+    expect(firstAuthor.parentElement).toHaveClass('max-h-48', 'overflow-y-auto')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Book' }))
+
+    const firstBook = (await screen.findByText('Book 1')).closest('button')
+    expect(screen.getByText('Book 4')).toBeInTheDocument()
+    expect(screen.getByText('Book 10')).toBeInTheDocument()
+    expect(screen.queryByText('Book 11')).not.toBeInTheDocument()
+    expect(firstBook?.parentElement).toHaveClass('max-h-48', 'overflow-y-auto')
+  })
+
+})

--- a/web/src/pages/SettingsPage.absReview.test.tsx
+++ b/web/src/pages/SettingsPage.absReview.test.tsx
@@ -137,7 +137,7 @@ describe('SettingsPage ABS review search', () => {
     vi.mocked(api.listSettings).mockResolvedValue([{ key: 'hardcover.enhanced_series_enabled', value: 'false' }])
     vi.mocked(api.listBackups).mockResolvedValue([])
     vi.mocked(api.libraryScanStatus).mockRejectedValue(new Error('no scan'))
-    vi.mocked(api.getStorage).mockResolvedValue({ downloadDir: '/downloads', libraryDir: '/books', audiobookDir: '' })
+    vi.mocked(api.getStorage).mockResolvedValue({ downloadDir: '/downloads', audiobookDownloadDir: '', libraryDir: '/books', audiobookDir: '' })
     vi.mocked(api.listRootFolders).mockResolvedValue([])
     vi.mocked(api.status).mockResolvedValue({
       version: 'dev',

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1497,7 +1497,16 @@ function AudiobookshelfSection() {
     setReviewActionId(item.id)
     setReviewError(null)
     const editedTitle = (bookQueries[item.id] ?? item.editedTitle ?? item.title).trim()
+    const authorForeignId = book.author?.foreignAuthorId?.trim() ?? ''
+    const authorName = book.author?.authorName?.trim() ?? ''
     try {
+      if (!item.resolvedAuthorForeignId?.trim() && authorForeignId && authorName) {
+        await api.resolveAbsReviewAuthor(item.id, {
+          foreignAuthorId: authorForeignId,
+          authorName,
+          applyTo: 'same_author',
+        })
+      }
       const updated = await api.resolveAbsReviewBook(item.id, {
         foreignBookId: book.foreignBookId,
         title: book.title,

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../auth/AuthContext'
 type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import' | 'rootfolders' | 'logs' | 'blocklist' | 'calibre' | 'abs' | 'grimmory'
 
 const inputCls = 'w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600'
+const absReviewResultLimit = 10
 const tabCls = (active: boolean) =>
   `px-4 py-2 rounded-md text-sm font-medium transition-colors ${active ? 'bg-slate-200 dark:bg-zinc-800 text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'}`
 
@@ -2077,18 +2078,22 @@ function AudiobookshelfSection() {
                           {authorSearchId === item.id ? 'Searching...' : 'Author'}
                         </button>
                       </div>
-                      {(authorResults[item.id] ?? []).slice(0, 3).map(author => (
-                        <button
-                          key={author.foreignAuthorId}
-                          type="button"
-                          onClick={() => resolveReviewAuthor(item, author)}
-                          disabled={reviewActionId === item.id}
-                          className="w-full text-left rounded border border-slate-200 dark:border-zinc-800 bg-white/70 dark:bg-zinc-950/40 px-2 py-1.5 text-xs hover:border-emerald-400 disabled:opacity-50"
-                        >
-                          <span className="block font-medium text-slate-800 dark:text-zinc-200 truncate">{author.authorName}</span>
-                          {author.disambiguation && <span className="block text-[11px] text-slate-500 dark:text-zinc-500 truncate">{author.disambiguation}</span>}
-                        </button>
-                      ))}
+                      {(authorResults[item.id] ?? []).length > 0 && (
+                        <div className="max-h-48 space-y-2 overflow-y-auto pr-1">
+                          {(authorResults[item.id] ?? []).slice(0, absReviewResultLimit).map(author => (
+                            <button
+                              key={author.foreignAuthorId}
+                              type="button"
+                              onClick={() => resolveReviewAuthor(item, author)}
+                              disabled={reviewActionId === item.id}
+                              className="w-full text-left rounded border border-slate-200 dark:border-zinc-800 bg-white/70 dark:bg-zinc-950/40 px-2 py-1.5 text-xs hover:border-emerald-400 disabled:opacity-50"
+                            >
+                              <span className="block font-medium text-slate-800 dark:text-zinc-200 truncate">{author.authorName}</span>
+                              {author.disambiguation && <span className="block text-[11px] text-slate-500 dark:text-zinc-500 truncate">{author.disambiguation}</span>}
+                            </button>
+                          ))}
+                        </div>
+                      )}
                     </div>
                     <div className="space-y-2">
                       <div className="flex gap-2">
@@ -2106,18 +2111,22 @@ function AudiobookshelfSection() {
                           {bookSearchId === item.id ? 'Searching...' : 'Book'}
                         </button>
                       </div>
-                      {(bookResults[item.id] ?? []).slice(0, 3).map(book => (
-                        <button
-                          key={book.foreignBookId}
-                          type="button"
-                          onClick={() => resolveReviewBook(item, book)}
-                          disabled={reviewActionId === item.id}
-                          className="w-full text-left rounded border border-slate-200 dark:border-zinc-800 bg-white/70 dark:bg-zinc-950/40 px-2 py-1.5 text-xs hover:border-emerald-400 disabled:opacity-50"
-                        >
-                          <span className="block font-medium text-slate-800 dark:text-zinc-200 truncate">{book.title}</span>
-                          {book.author?.authorName && <span className="block text-[11px] text-slate-500 dark:text-zinc-500 truncate">{book.author.authorName}</span>}
-                        </button>
-                      ))}
+                      {(bookResults[item.id] ?? []).length > 0 && (
+                        <div className="max-h-48 space-y-2 overflow-y-auto pr-1">
+                          {(bookResults[item.id] ?? []).slice(0, absReviewResultLimit).map(book => (
+                            <button
+                              key={book.foreignBookId}
+                              type="button"
+                              onClick={() => resolveReviewBook(item, book)}
+                              disabled={reviewActionId === item.id}
+                              className="w-full text-left rounded border border-slate-200 dark:border-zinc-800 bg-white/70 dark:bg-zinc-950/40 px-2 py-1.5 text-xs hover:border-emerald-400 disabled:opacity-50"
+                            >
+                              <span className="block font-medium text-slate-800 dark:text-zinc-200 truncate">{book.title}</span>
+                              {book.author?.authorName && <span className="block text-[11px] text-slate-500 dark:text-zinc-500 truncate">{book.author.authorName}</span>}
+                            </button>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   </div>
                   <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary

- Show up to 10 scrollable author/book search matches in the ABS no-match review queue.
- Auto-link the selected book's author before resolving the book when the review item has no resolved author.
- Add focused ABS review tests and an `[Unreleased]` changelog entry.

## Checklist

- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed - N/A, no deployment/config surface changed
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [ ] Wiki pages updated if user-facing behaviour changed - N/A for this narrow review-queue fix

## Test plan

- [x] `git diff --check upstream/main...HEAD`
- [x] `gofmt -l .`
- [x] `npm test -- SettingsPage.absReview.test.tsx`
- [x] `npm ci`
- [x] `npm run lint` (passes with existing warnings)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `GOTOOLCHAIN=go1.25.10 GOCACHE=<tmp>/bindery-gocache go vet ./...`
- [x] `GOTOOLCHAIN=go1.25.10 GOCACHE=<tmp>/bindery-gocache GOLANGCI_LINT_CACHE=<tmp>/bindery-golangci-cache <tmp>/bindery-bin/golangci-lint run --timeout=5m`
- [x] `GOTOOLCHAIN=go1.25.10 GOCACHE=<tmp>/bindery-gocache <tmp>/bindery-bin/govulncheck ./...`
- [x] `GOTOOLCHAIN=go1.25.10 GOCACHE=<tmp>/bindery-gocache go test ./cmd/... ./internal/...`
