### PR TITLE
fix(hardcover): use plural lists root field for list sync (#562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 - **Enhanced Hardcover series controls are no longer hidden by default** (#596) — The deployment-wide `BINDERY_ENHANCED_HARDCOVER_API` flag now defaults to enabled, leaving the saved Hardcover token and **Settings -> General** admin toggle as the normal feature gates. Operators can still set the flag to `false` to disable the feature for an entire deployment.
 
+- Hardcover list sync now uses the plural `lists(where:)` root field; the singular `list(id:)` query was rejected by Hardcover's GraphQL schema (#562).
+
 ## [v1.9.1] — 2026-05-11
 
 ### Fixed

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -484,7 +484,7 @@ func (c *Client) GetListBooks(ctx context.Context, listID int) ([]models.Book, e
 		return c.getShelfBooks(ctx, statusID)
 	}
 	gql := `query GetListBooks($id: Int!) {
-		list(id: $id) {
+		lists(where: {id: {_eq: $id}}, limit: 1) {
 			id
 			name
 			slug
@@ -507,18 +507,21 @@ func (c *Client) GetListBooks(ctx context.Context, listID int) ([]models.Book, e
 	}`
 	var resp struct {
 		Data struct {
-			List struct {
+			Lists []struct {
 				ListBooks []struct {
 					Book hcBook `json:"book"`
 				} `json:"list_books"`
-			} `json:"list"`
+			} `json:"lists"`
 		} `json:"data"`
 	}
 	if err := c.query(ctx, gql, map[string]any{"id": listID}, &resp); err != nil {
 		return nil, fmt.Errorf("hardcover get list books: %w", err)
 	}
-	books := make([]models.Book, 0, len(resp.Data.List.ListBooks))
-	for _, lb := range resp.Data.List.ListBooks {
+	if len(resp.Data.Lists) == 0 {
+		return nil, nil
+	}
+	books := make([]models.Book, 0, len(resp.Data.Lists[0].ListBooks))
+	for _, lb := range resp.Data.Lists[0].ListBooks {
 		books = append(books, c.toBook(lb.Book))
 	}
 	return books, nil

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -1082,6 +1082,39 @@ func TestGetListBooks_BuiltinShelfRoutesToUserBooks(t *testing.T) {
 	}
 }
 
+func TestGetListBooks_PositiveID(t *testing.T) {
+	var gotVars map[string]any
+	var gotQuery string
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		var req gqlRequest
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		gotVars = req.Variables
+		gotQuery = req.Query
+		resp := `{"data":{"lists":[{"id":42,"name":"Favorites","slug":"favorites","list_books":[{"book":{"id":99,"title":"Dune","slug":"dune","contributions":[{"author":{"id":1,"name":"Frank Herbert","slug":"frank-herbert"}}]}}]}]}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(resp)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	c = c.WithToken("hc-token")
+
+	books, err := c.GetListBooks(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("GetListBooks: %v", err)
+	}
+	if len(books) != 1 || books[0].Title != "Dune" {
+		t.Errorf("books = %+v, want [{Title:Dune}]", books)
+	}
+	if gotVars["id"] != float64(42) {
+		t.Errorf("id var = %v, want 42", gotVars["id"])
+	}
+	if !strings.Contains(gotQuery, "lists(where:") {
+		t.Errorf("query should use plural lists(where:) field, got: %q", gotQuery)
+	}
+}
+
 func TestHcShelfStatusID(t *testing.T) {
 	cases := []struct{ id, want int }{{-1, 1}, {-2, 2}, {-3, 3}, {-4, 4}}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- Fixes #562. Hardcover Sync Now was broken for every custom list since v1.1.0.
- Root cause: query used singular `list(id:)`; Hardcover only exposes `lists(where:)` plural.

## Changes

- `internal/metadata/hardcover/client.go` — rewrite `GetListBooks` query to use `lists(where: {id: {_eq: $id}}, limit: 1)` and update response struct + accessor.
- `internal/metadata/hardcover/client_test.go` — new test exercising the positive-ID path with a stubbed GraphQL response.
- `CHANGELOG.md` — entry under `[Unreleased]` Fixed.

## Test plan

- [x] `go test ./internal/metadata/hardcover/...`
- [x] `go vet ./...`
- [ ] Manual: Sync Now against a real Hardcover list once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)