### PR TITLE
fix(indexer): sign Newznab download URLs with apikey for Prowlarr-proxy (#531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Bindery are documented here. Format loosely follows
 ### Fixed
 
 - **ABS review search results are scrollable and keep book-author links intact** — No-match review author/book searches now show up to 10 scrollable matches instead of truncating after three, and selecting a book result auto-links its author before resolving the book when the review item does not already have a resolved author.
+- Newznab/Prowlarr-proxy: download enclosure URLs are now signed with the indexer apikey when the URL points at the indexer's own host, fixing NZBGet "empty NZB" rejections for Prowlarr-proxied Usenet indexers (#531).
 
 - **Enhanced Hardcover series controls are no longer hidden by default** (#596) — The deployment-wide `BINDERY_ENHANCED_HARDCOVER_API` flag now defaults to enabled, leaving the saved Hardcover token and **Settings -> General** admin toggle as the normal feature gates. Operators can still set the flag to `false` to disable the feature for an entire deployment.
 

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -18,15 +18,17 @@ import (
 
 // Client interacts with a single Newznab-compatible indexer.
 type Client struct {
-	baseURL string
-	apiKey  string
-	http    *http.Client
+	baseURL  string
+	baseHost string
+	apiKey   string
+	http     *http.Client
 }
 
 // New creates a Newznab client for a specific indexer.
 func New(baseURL, apiKey string) *Client {
 	parsedURL := normalizeEndpointURL(baseURL)
 	resolvedAPIKey := strings.TrimSpace(apiKey)
+	var baseHost string
 	if u, err := url.Parse(parsedURL); err == nil {
 		q := u.Query()
 		if resolvedAPIKey == "" {
@@ -37,13 +39,40 @@ func New(baseURL, apiKey string) *Client {
 		q.Del("apikey")
 		u.RawQuery = q.Encode()
 		parsedURL = strings.TrimRight(u.String(), "/")
+		baseHost = strings.ToLower(u.Host)
 	}
 
 	return &Client{
-		baseURL: parsedURL,
-		apiKey:  resolvedAPIKey,
-		http:    &http.Client{Timeout: 30 * time.Second},
+		baseURL:  parsedURL,
+		baseHost: baseHost,
+		apiKey:   resolvedAPIKey,
+		http:     &http.Client{Timeout: 30 * time.Second},
 	}
+}
+
+// signDownloadURL appends the indexer's apikey query parameter to a download
+// URL when, and only when, the URL points at the indexer's own host. This
+// fixes Prowlarr-proxy enclosure URLs (which omit the apikey and get rejected
+// by NZBGet as empty content) without leaking the apikey to third-party
+// direct-from-uploader links an indexer might return.
+func (c *Client) signDownloadURL(raw string) string {
+	if raw == "" || c.apiKey == "" {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	if !strings.EqualFold(u.Host, c.baseHost) {
+		return raw
+	}
+	q := u.Query()
+	if q.Get("apikey") != "" {
+		return raw
+	}
+	q.Set("apikey", c.apiKey)
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 // Caps fetches the indexer capabilities.
@@ -278,7 +307,7 @@ func (c *Client) parseResults(items []rssItem) []SearchResult {
 			GUID:    item.GUID.Value,
 			Title:   item.Title,
 			Size:    item.Enclosure.Length,
-			NZBURL:  item.Enclosure.URL,
+			NZBURL:  c.signDownloadURL(item.Enclosure.URL),
 			PubDate: item.PubDate,
 		}
 
@@ -305,7 +334,7 @@ func (c *Client) parseResults(items []rssItem) []SearchResult {
 		}
 
 		if r.NZBURL == "" {
-			r.NZBURL = item.Link
+			r.NZBURL = c.signDownloadURL(item.Link)
 		}
 
 		results = append(results, r)

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -3,8 +3,10 @@ package newznab
 import (
 	"context"
 	"encoding/xml"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -579,6 +581,97 @@ func TestNormalizeQueryTitle(t *testing.T) {
 		if got := NormalizeQueryTitle(c.in); got != c.want {
 			t.Errorf("NormalizeQueryTitle(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// TestSignDownloadURL covers the apikey-signing helper used to fix
+// Prowlarr-proxy NZBGet "empty NZB" rejections (#531). The apikey must be
+// appended to enclosure URLs that target the indexer's own host but never
+// to third-party hosts (would leak credentials) or URLs already carrying
+// an apikey (would clobber a valid one).
+func TestSignDownloadURL(t *testing.T) {
+	c := New("https://prowlarr.local:9696/1/api", "secret123")
+
+	t.Run("same host without apikey gets it appended", func(t *testing.T) {
+		raw := "https://prowlarr.local:9696/1/download?id=abc"
+		got := c.signDownloadURL(raw)
+		u, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if u.Query().Get("apikey") != "secret123" {
+			t.Errorf("expected apikey=secret123 appended, got %s", got)
+		}
+		if u.Query().Get("id") != "abc" {
+			t.Errorf("expected existing id=abc preserved, got %s", got)
+		}
+	})
+
+	t.Run("same host with existing apikey is left alone", func(t *testing.T) {
+		raw := "https://prowlarr.local:9696/1/download?id=abc&apikey=other"
+		got := c.signDownloadURL(raw)
+		u, err := url.Parse(got)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if u.Query().Get("apikey") != "other" {
+			t.Errorf("expected existing apikey preserved, got %s", got)
+		}
+	})
+
+	t.Run("different host does not get apikey appended", func(t *testing.T) {
+		raw := "https://third-party.example.com/getnzb/xyz?id=999"
+		got := c.signDownloadURL(raw)
+		if strings.Contains(got, "apikey=") {
+			t.Errorf("apikey leaked to third-party host: %s", got)
+		}
+		if got != raw {
+			t.Errorf("expected URL unchanged, got %s", got)
+		}
+	})
+}
+
+// TestParseResults_AppendsApikeyToEnclosure exercises the end-to-end
+// parse path with a Prowlarr-proxy-shaped RSS response: the indexer's
+// enclosure URLs lack the apikey, and parseResults must re-sign them so
+// downstream download clients (NZBGet) can authenticate.
+func TestParseResults_AppendsApikeyToEnclosure(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		// Build an RSS body whose enclosure URLs point back at the same host
+		// but carry no apikey — mirroring what Prowlarr returns when proxying
+		// a Newznab indexer.
+		body := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
+  <channel>
+    <newznab:response offset="0" total="1"/>
+    <item>
+      <title>Some Book</title>
+      <guid isPermaLink="true">prowlarr-1</guid>
+      <link>%s/1/download?id=prowlarr-1</link>
+      <enclosure url="%s/1/download?id=prowlarr-1" length="1024" type="application/x-nzb"/>
+      <newznab:attr name="category" value="7020"/>
+    </item>
+  </channel>
+</rss>`, srv.URL, srv.URL)
+		w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL+"/1/api", "the-key")
+	results, err := c.Search(context.Background(), "anything", nil)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !strings.Contains(results[0].NZBURL, "apikey=the-key") {
+		t.Errorf("expected enclosure NZBURL to be signed with apikey, got %s", results[0].NZBURL)
+	}
+	if !strings.Contains(results[0].NZBURL, "id=prowlarr-1") {
+		t.Errorf("expected enclosure NZBURL to preserve id query, got %s", results[0].NZBURL)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes #531. Prowlarr-proxied NZBGet downloads were getting empty content because the enclosure URL had no apikey.
- Apikey is conditionally appended **only** when the enclosure URL host matches the indexer's base host — won't leak apikey to third-party redirect targets.

## Changes

- `internal/indexer/newznab/client.go` — store `baseHost`; new `signDownloadURL` helper; apply in `parseResults` to enclosure (and link if used as fallback).
- `internal/indexer/newznab/client_test.go` — same-host append, idempotent on existing apikey, third-party host left alone, plus end-to-end RSS parse test.
- `CHANGELOG.md` — Fixed entry.

## Test plan

- [x] `go test ./internal/indexer/newznab/...`
- [x] `go vet ./...`
- [ ] Manual: grab a Prowlarr-proxied Usenet release once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)