### PR TITLE
fix(auth): run proxy identity resolution before allow-unauth check (#560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 - Backup creation no longer crashes the Settings page; updated frontend types and rendering to match the API response shape (#594).
 
 - **ABS review search results are scrollable and keep book-author links intact** — No-match review author/book searches now show up to 10 scrollable matches instead of truncating after three, and selecting a book result auto-links its author before resolving the book when the review item does not already have a resolved author.
+
 - Newznab/Prowlarr-proxy: download enclosure URLs are now signed with the indexer apikey when the URL points at the indexer's own host, fixing NZBGet "empty NZB" rejections for Prowlarr-proxied Usenet indexers (#531).
+
+- Proxy auth: `/api/v1/auth/status` now honors the configured proxy header from trusted CIDRs; previously the allow-unauth fast-path bypassed proxy identity resolution (#560).
 
 - **Enhanced Hardcover series controls are no longer hidden by default** (#596) — The deployment-wide `BINDERY_ENHANCED_HARDCOVER_API` flag now defaults to enabled, leaving the saved Hardcover token and **Settings -> General** admin toggle as the normal feature gates. Operators can still set the flag to `false` to disable the feature for an entire deployment.
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -127,13 +127,16 @@ func AllowUnauthPath(path string) bool {
 //
 //  1. Always try to resolve identity from a valid session cookie, so handlers
 //     on unauth-allowed paths (e.g. /auth/status) can still see who's logged in.
-//  2. Health / auth endpoints — always allowed through
-//  3. Mode == disabled            — always allowed
-//  4. Mode == local-only + local  — always allowed
-//  5. Valid X-Api-Key header or ?apikey= query — allowed
-//  6. Valid signed session cookie — allowed
-//  7. Mode == proxy: trusted peer IP + identity header → resolve/provision user
-//  8. Otherwise                   — 401
+//  2. In proxy mode, also try to resolve identity from the configured proxy
+//     header (gated by trusted-proxy CIDR), so /auth/status reports the
+//     proxy-authed user instead of always returning authenticated:false (#560).
+//  3. Health / auth endpoints — always allowed through
+//  4. Mode == disabled            — always allowed
+//  5. Mode == local-only + local  — always allowed
+//  6. Valid X-Api-Key header or ?apikey= query — allowed
+//  7. Valid signed session cookie — allowed
+//  8. Mode == proxy: trusted peer IP + identity header → resolve/provision user
+//  9. Otherwise                   — 401
 func Middleware(p Provider) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -149,13 +152,29 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 					cookieValid = true
 				}
 			}
+
+			// In proxy mode, resolve the upstream identity header up-front as
+			// well — gated by the trusted-proxy CIDR check inside
+			// resolveProxyIdentity. This must run before the AllowUnauthPath
+			// short-circuit so /auth/status (which is in that list) sees the
+			// authenticated user (#560). Untrusted sources are rejected inside
+			// resolveProxyIdentity, so a spoofed header from a public IP still
+			// returns (0, false) and we drop through unchanged.
+			mode := p.Mode()
+			proxyValid := false
+			if !cookieValid && mode == ModeProxy {
+				if uid, ok := resolveProxyIdentity(r, p); ok {
+					ctx = context.WithValue(ctx, userIDCtxKey, uid)
+					ctx = context.WithValue(ctx, userRoleCtxKey, p.UserRole(ctx, uid))
+					proxyValid = true
+				}
+			}
 			r = r.WithContext(ctx)
 
 			if AllowUnauthPath(r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
 			}
-			mode := p.Mode()
 			if mode == ModeDisabled {
 				next.ServeHTTP(w, r)
 				return
@@ -178,10 +197,8 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 			}
 
 			if mode == ModeProxy {
-				if uid, ok := resolveProxyIdentity(r, p); ok {
-					pctx := context.WithValue(r.Context(), userIDCtxKey, uid)
-					pctx = context.WithValue(pctx, userRoleCtxKey, p.UserRole(pctx, uid))
-					r = r.WithContext(pctx)
+				if proxyValid {
+					// Identity already attached above; just continue.
 					next.ServeHTTP(w, r)
 					return
 				}

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,0 +1,148 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+)
+
+// Regression tests for #560: /api/v1/auth/status was in the AllowUnauthPath
+// list and the middleware short-circuited there before proxy identity
+// resolution ran, so a valid X-Forwarded-User from a trusted CIDR never made
+// it onto the request context. The status handler then reported
+// authenticated:false, leaving proxy-authed users stuck on the login screen.
+//
+// The fix runs proxy header resolution up-front (alongside the cookie check)
+// and only attaches identity when the source IP is in the trusted-proxy CIDR
+// list — so an untrusted caller still cannot spoof proxy auth.
+
+// TestProxyAuthStatusPathTrustedIPSetsContext verifies the positive case: a
+// trusted CIDR (0.0.0.0/0) plus a valid X-Forwarded-User header on a request
+// to /api/v1/auth/status must attach the user id to the context, so the
+// status handler can report authenticated:true.
+func TestProxyAuthStatusPathTrustedIPSetsContext(t *testing.T) {
+	p := proxyProvider("0.0.0.0/0", true, 99)
+	mw := Middleware(p)
+	var gotUID int64
+	var gotRole string
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		called = true
+		gotUID = UserIDFromContext(r.Context())
+		gotRole = UserRoleFromContext(r.Context())
+	}))
+	req, _ := http.NewRequest("GET", "/api/v1/auth/status", nil)
+	req.RemoteAddr = "203.0.113.42:54321" // any source — 0.0.0.0/0 trusts everyone
+	req.Header.Set("X-Forwarded-User", "alice")
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if !called {
+		t.Fatal("handler must be invoked for /auth/status")
+	}
+	if gotUID != 99 {
+		t.Errorf("uid = %d; want 99 — proxy identity must reach the handler context", gotUID)
+	}
+	if gotRole != "admin" {
+		t.Errorf("role = %q; want \"admin\"", gotRole)
+	}
+}
+
+// TestProxyAuthStatusPathUntrustedIPIgnoresHeader confirms the spoofing
+// guard: when the request source is outside the trusted-proxy CIDR, the
+// header is dropped even on an AllowUnauthPath. The handler still runs (the
+// path is in the unauth list) but no identity is attached, so the status
+// handler will return authenticated:false.
+func TestProxyAuthStatusPathUntrustedIPIgnoresHeader(t *testing.T) {
+	p := proxyProvider("127.0.0.1/32", true, 99)
+	mw := Middleware(p)
+	var gotUID int64
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		called = true
+		gotUID = UserIDFromContext(r.Context())
+	}))
+	req, _ := http.NewRequest("GET", "/api/v1/auth/status", nil)
+	req.RemoteAddr = "1.2.3.4:54321" // outside trusted CIDR
+	req.Header.Set("X-Forwarded-User", "alice")
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if !called {
+		t.Fatal("/auth/status is in AllowUnauthPath — handler must still run")
+	}
+	if gotUID != 0 {
+		t.Errorf("uid = %d; want 0 — spoofed header from untrusted IP must not attach identity", gotUID)
+	}
+}
+
+// TestProxyAuthStatusPathModeMismatchIgnoresHeader confirms that proxy
+// identity resolution is gated by Mode == ModeProxy. In any other mode the
+// proxy header is ignored even from a trusted CIDR.
+func TestProxyAuthStatusPathModeMismatchIgnoresHeader(t *testing.T) {
+	// Build a provider with everything proxy-ish set, but mode = enabled.
+	p := proxyProvider("0.0.0.0/0", true, 99)
+	p.mode = ModeEnabled
+	mw := Middleware(p)
+	var gotUID int64
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		called = true
+		gotUID = UserIDFromContext(r.Context())
+	}))
+	req, _ := http.NewRequest("GET", "/api/v1/auth/status", nil)
+	req.RemoteAddr = "10.0.0.5:54321"
+	req.Header.Set("X-Forwarded-User", "alice")
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if !called {
+		t.Fatal("/auth/status must be reachable")
+	}
+	if gotUID != 0 {
+		t.Errorf("uid = %d; want 0 — proxy header must be ignored when mode != proxy", gotUID)
+	}
+}
+
+// TestProxyAuthRegularPathTrustedIPStillAuthenticates is a belt-and-braces
+// check that the refactor did not break the existing proxy-mode flow for
+// non-AllowUnauthPath routes: a trusted IP with a valid header on /api/v1/author
+// must still reach the handler with identity attached.
+func TestProxyAuthRegularPathTrustedIPStillAuthenticates(t *testing.T) {
+	p := proxyProvider("10.0.0.0/8", true, 42)
+	mw := Middleware(p)
+	var gotUID int64
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		called = true
+		gotUID = UserIDFromContext(r.Context())
+	}))
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.RemoteAddr = "10.0.0.5:12345"
+	req.Header.Set("X-Forwarded-User", "alice")
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if !called {
+		t.Fatal("trusted-IP proxy auth must still pass for non-unauth paths")
+	}
+	if gotUID != 42 {
+		t.Errorf("uid = %d; want 42", gotUID)
+	}
+}
+
+// TestProxyAuthRegularPathUntrustedIPStill401s mirrors the existing
+// TestProxyAuthUntrustedIPWithHeader test through the new code path to
+// confirm the auth gate for non-AllowUnauthPath routes is unchanged.
+func TestProxyAuthRegularPathUntrustedIPStill401s(t *testing.T) {
+	p := proxyProvider("10.0.0.0/8", true, 42)
+	mw := Middleware(p)
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.RemoteAddr = "8.8.8.8:12345"
+	req.Header.Set("X-Forwarded-User", "alice")
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if called {
+		t.Fatal("untrusted source must still be rejected on protected paths after the #560 refactor")
+	}
+	if w.status != http.StatusUnauthorized {
+		t.Errorf("status = %d; want 401", w.status)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes #560. Proxy auth mode was completely non-functional: `/api/v1/auth/status` always returned `authenticated:false`, so the SPA never let the proxy-authed user past the login screen.
- Root cause: the allow-unauth fast-path ran before proxy identity resolution, and `/auth/status` is in that list.

## Changes

- `internal/auth/middleware.go` — reorder so proxy header → user resolution runs before allow-unauth early return. Trusted-proxy CIDR gating preserved.
- `internal/auth/middleware_test.go` — positive test (trusted CIDR, valid header → authenticated) and negative tests (untrusted IP, wrong mode).
- `CHANGELOG.md` — Fixed entry.

## Test plan

- [x] `go test ./internal/auth/...`
- [x] `go test ./internal/api/...`
- [x] `go vet ./...`
- [ ] Manual: `curl -H 'X-Forwarded-User: alice' http://prod/api/v1/auth/status` once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)