### PR TITLE
fix(metadata): DNB add-by-ISBN works without OpenLibrary coverage (#608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **DNB add-by-ISBN no longer fails for German books with no OpenLibrary coverage** (#608) — DNB results now carry a stable author ForeignID (GND from MARC 100 $0 when present, otherwise a synthetic `dnb:author:<name-slug>`). When a canonical author (OpenLibrary / Hardcover) later arrives for the same SortName, the synthetic DNB row is migrated in place so the user keeps a single author record. Previously the add flow returned 422 "Author metadata unavailable" whenever no canonical provider had the ISBN.
+
 ## [v1.9.2] — 2026-05-12
 
 ### Fixed

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1215,16 +1215,41 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 		fetched.Monitored = false
 		def := models.DefaultMetadataProfileID
 		fetched.MetadataProfileID = &def
-		if err := h.authors.CreateForUser(ctx, fetched, auth.UserIDFromContext(ctx)); err != nil {
-			if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
-				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-				return
+
+		// Dedupe path: if a canonical provider (OL / Hardcover / …) is being
+		// added for a SortName previously persisted as a synthetic DNB-only
+		// row, migrate that row in place rather than creating a duplicate.
+		// The synthetic row was created because the DNB record had only an
+		// author name (no GND link, no OL coverage). Now that a canonical
+		// identity exists, collapse the two onto a single primary key so
+		// the user keeps one author with all their books attached.
+		if !strings.HasPrefix(fetched.ForeignID, "dnb:") {
+			ownerID := auth.UserIDFromContext(ctx)
+			if existing, lookupErr := h.authors.GetByDNBSyntheticName(ctx, fetched.SortName, ownerID); lookupErr == nil && existing != nil {
+				if err := h.authors.UpgradeSyntheticDNB(ctx, existing.ForeignID, fetched); err != nil {
+					slog.Debug("AddBook: upgrade synthetic DNB author failed", "from", existing.ForeignID, "to", fetched.ForeignID, "error", err)
+				} else {
+					// Re-fetch the row by its new canonical ForeignID so subsequent
+					// steps see the upgraded record (ID preserved).
+					if upgraded, getErr := h.authors.GetByForeignID(ctx, fetched.ForeignID); getErr == nil && upgraded != nil {
+						author = upgraded
+					}
+				}
 			}
-			// Race: another request created it between our check and insert.
-			author, _ = h.authors.GetByForeignID(ctx, req.ForeignAuthorID)
-		} else {
-			author = fetched
-			h.fetchAuthorBooksAsync(author, false, h.resolveDefaultMediaType(ctx))
+		}
+
+		if author == nil {
+			if err := h.authors.CreateForUser(ctx, fetched, auth.UserIDFromContext(ctx)); err != nil {
+				if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
+					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+					return
+				}
+				// Race: another request created it between our check and insert.
+				author, _ = h.authors.GetByForeignID(ctx, req.ForeignAuthorID)
+			} else {
+				author = fetched
+				h.fetchAuthorBooksAsync(author, false, h.resolveDefaultMediaType(ctx))
+			}
 		}
 	}
 	if author == nil {

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -143,6 +143,85 @@ func (r *AuthorRepo) CreateForUser(ctx context.Context, a *models.Author, ownerU
 	return nil
 }
 
+// GetByDNBSyntheticName returns the synthetic DNB-only author row (one whose
+// foreign_id starts with "dnb:author:") that matches the given sort_name
+// case-insensitively and is visible to userID. Returns (nil, nil) when none
+// exists.
+//
+// This is used by AddBook to detect when a canonical author (OpenLibrary /
+// Hardcover) is being added for a SortName that was previously persisted as
+// a synthetic DNB row — see UpgradeSyntheticDNB.
+//
+// When userID is 0 the lookup is unscoped; in practice multi-user installs
+// always pass the requesting user's ID so they don't migrate another user's
+// row.
+func (r *AuthorRepo) GetByDNBSyntheticName(ctx context.Context, sortName string, userID int64) (*models.Author, error) {
+	if sortName == "" {
+		return nil, nil
+	}
+	var (
+		row *sql.Row
+		q   = `SELECT ` + authorSelectCols + `
+			FROM authors
+			WHERE foreign_id LIKE 'dnb:author:%' AND LOWER(sort_name) = LOWER(?)`
+	)
+	if userID == 0 {
+		row = r.db.QueryRowContext(ctx, q, sortName)
+	} else {
+		q += ` AND (owner_user_id = ? OR owner_user_id IS NULL)`
+		row = r.db.QueryRowContext(ctx, q, sortName, userID)
+	}
+	a, err := scanAuthorRow(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get author by dnb-synthetic sort_name %q: %w", sortName, err)
+	}
+	return &a, nil
+}
+
+// UpgradeSyntheticDNB migrates a synthetic DNB-only author row to a canonical
+// provider identity. The row identified by currentForeignID has its
+// foreign_id, metadata_provider and (when non-empty in target) descriptive
+// fields replaced. Existing relations (books, aliases) keep pointing at the
+// same primary-key row so the user keeps one author record.
+//
+// currentForeignID is matched by exact equality; pass the value previously
+// returned by GetByDNBSyntheticName. target carries the canonical fields.
+// Returns an error only on a SQL failure — a no-op update (e.g. row gone)
+// is silent.
+func (r *AuthorRepo) UpgradeSyntheticDNB(ctx context.Context, currentForeignID string, target *models.Author) error {
+	if currentForeignID == "" || target == nil || target.ForeignID == "" {
+		return fmt.Errorf("upgrade synthetic dnb: missing currentForeignID or target")
+	}
+	now := time.Now().UTC()
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE authors
+		SET foreign_id        = ?,
+		    name              = COALESCE(NULLIF(?, ''), name),
+		    sort_name         = COALESCE(NULLIF(?, ''), sort_name),
+		    description       = CASE WHEN ? != '' THEN ? ELSE description END,
+		    image_url         = CASE WHEN ? != '' THEN ? ELSE image_url END,
+		    disambiguation    = CASE WHEN ? != '' THEN ? ELSE disambiguation END,
+		    metadata_provider = COALESCE(NULLIF(?, ''), metadata_provider),
+		    updated_at        = ?
+		WHERE foreign_id = ?`,
+		target.ForeignID,                       // foreign_id =
+		target.Name,                            // name = COALESCE(NULLIF(?,''), name)
+		target.SortName,                        // sort_name = COALESCE(NULLIF(?,''), sort_name)
+		target.Description, target.Description, // description CASE WHEN ? != '' THEN ?
+		target.ImageURL, target.ImageURL, // image_url
+		target.Disambiguation, target.Disambiguation, // disambiguation
+		target.MetadataProvider, // metadata_provider = COALESCE(NULLIF(?,''), metadata_provider)
+		now,                     // updated_at
+		currentForeignID)        // WHERE foreign_id = ?
+	if err != nil {
+		return fmt.Errorf("upgrade synthetic dnb author %q -> %q: %w", currentForeignID, target.ForeignID, err)
+	}
+	return nil
+}
+
 func (r *AuthorRepo) Update(ctx context.Context, a *models.Author) error {
 	now := time.Now().UTC()
 	_, err := r.db.ExecContext(ctx, `

--- a/internal/db/authors_test.go
+++ b/internal/db/authors_test.go
@@ -1,0 +1,270 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestAuthorRepo_GetByDNBSyntheticName_NoMatch confirms a benign nil/nil
+// return when nothing in the table has a synthetic DNB foreign_id matching
+// the requested sort_name.
+func TestAuthorRepo_GetByDNBSyntheticName_NoMatch(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	// Seed an OL author — must NOT be returned.
+	if err := repo.Create(ctx, &models.Author{
+		ForeignID: "OL-A1", Name: "Frank Herbert", SortName: "Herbert, Frank",
+		MetadataProvider: "openlibrary",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	got, err := repo.GetByDNBSyntheticName(ctx, "Herbert, Frank", 0)
+	if err != nil {
+		t.Fatalf("GetByDNBSyntheticName: %v", err)
+	}
+	if got != nil {
+		t.Errorf("OL-prefixed author should not match dnb:author: filter, got %+v", got)
+	}
+}
+
+// TestAuthorRepo_GetByDNBSyntheticName_MatchesSyntheticOnly verifies the
+// foreign_id LIKE 'dnb:author:%' guard: rows with dnb:gnd: or other prefixes
+// are not considered synthetic, only dnb:author:<slug> rows are eligible for
+// the dedupe upgrade path.
+func TestAuthorRepo_GetByDNBSyntheticName_MatchesSyntheticOnly(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	// Seed: one synthetic DNB, one GND-backed DNB, one OL.
+	for _, a := range []*models.Author{
+		{ForeignID: "dnb:author:thomas-muller", Name: "Thomas Müller", SortName: "Müller, Thomas", MetadataProvider: "dnb"},
+		{ForeignID: "dnb:gnd:118585665", Name: "Heiner Müller", SortName: "Müller, Heiner", MetadataProvider: "dnb"},
+		{ForeignID: "OL-Z", Name: "Other Author", SortName: "Author, Other", MetadataProvider: "openlibrary"},
+	} {
+		if err := repo.Create(ctx, a); err != nil {
+			t.Fatalf("seed %s: %v", a.ForeignID, err)
+		}
+	}
+
+	// Synthetic match: lookup is case-insensitive.
+	got, err := repo.GetByDNBSyntheticName(ctx, "müller, thomas", 0)
+	if err != nil {
+		t.Fatalf("GetByDNBSyntheticName: %v", err)
+	}
+	if got == nil || got.ForeignID != "dnb:author:thomas-muller" {
+		t.Fatalf("expected synthetic Thomas Müller, got %+v", got)
+	}
+
+	// GND-backed must NOT match the synthetic filter.
+	got, err = repo.GetByDNBSyntheticName(ctx, "Müller, Heiner", 0)
+	if err != nil {
+		t.Fatalf("GetByDNBSyntheticName(Heiner): %v", err)
+	}
+	if got != nil {
+		t.Errorf("GND-backed row should not match synthetic filter, got %+v", got)
+	}
+}
+
+// TestAuthorRepo_GetByDNBSyntheticName_UserScope confirms a user only sees
+// synthetic rows they own (or unowned rows from pre-multiuser data); a
+// different user's synthetic row must not surface.
+func TestAuthorRepo_GetByDNBSyntheticName_UserScope(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	users := NewUserRepo(database)
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	u1, err := users.Create(ctx, "alice", "h1")
+	if err != nil {
+		t.Fatalf("create alice: %v", err)
+	}
+	u2, err := users.Create(ctx, "bob", "h2")
+	if err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+
+	if err := repo.CreateForUser(ctx, &models.Author{
+		ForeignID: "dnb:author:thomas-muller", Name: "Thomas Müller",
+		SortName: "Müller, Thomas", MetadataProvider: "dnb",
+	}, u1.ID); err != nil {
+		t.Fatalf("seed alice synthetic: %v", err)
+	}
+
+	// Alice can see her row.
+	got, err := repo.GetByDNBSyntheticName(ctx, "Müller, Thomas", u1.ID)
+	if err != nil {
+		t.Fatalf("alice lookup: %v", err)
+	}
+	if got == nil {
+		t.Fatal("alice should see her synthetic author")
+	}
+
+	// Bob must NOT see Alice's row.
+	got, err = repo.GetByDNBSyntheticName(ctx, "Müller, Thomas", u2.ID)
+	if err != nil {
+		t.Fatalf("bob lookup: %v", err)
+	}
+	if got != nil {
+		t.Errorf("bob should not see alice's synthetic author, got %+v", got)
+	}
+}
+
+// TestAuthorRepo_UpgradeSyntheticDNB_RowUpdatedInPlace is the core dedupe
+// test: a synthetic DNB author row is replaced in place by a canonical
+// OpenLibrary identity. Books that reference the original author_id keep
+// working because the primary key doesn't change.
+func TestAuthorRepo_UpgradeSyntheticDNB_RowUpdatedInPlace(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	synthetic := &models.Author{
+		ForeignID: "dnb:author:frank-herbert", Name: "Frank Herbert",
+		SortName: "Herbert, Frank", MetadataProvider: "dnb",
+	}
+	if err := repo.Create(ctx, synthetic); err != nil {
+		t.Fatalf("seed synthetic: %v", err)
+	}
+	originalID := synthetic.ID
+
+	canonical := &models.Author{
+		ForeignID:        "OL12345A",
+		Name:             "Frank Herbert", // unchanged
+		SortName:         "Herbert, Frank",
+		Description:      "American science-fiction author.",
+		ImageURL:         "https://covers.openlibrary.org/a/id/foo.jpg",
+		MetadataProvider: "openlibrary",
+	}
+	if err := repo.UpgradeSyntheticDNB(ctx, synthetic.ForeignID, canonical); err != nil {
+		t.Fatalf("UpgradeSyntheticDNB: %v", err)
+	}
+
+	got, err := repo.GetByForeignID(ctx, "OL12345A")
+	if err != nil {
+		t.Fatalf("GetByForeignID after upgrade: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected row with canonical foreign_id to exist after upgrade")
+	}
+	if got.ID != originalID {
+		t.Errorf("primary key changed: want %d, got %d (in-place update broken)", originalID, got.ID)
+	}
+	if got.MetadataProvider != "openlibrary" {
+		t.Errorf("MetadataProvider not migrated: got %q", got.MetadataProvider)
+	}
+	if got.Description == "" || got.ImageURL == "" {
+		t.Errorf("descriptive fields not copied: %+v", got)
+	}
+
+	// The old synthetic row must be gone.
+	old, _ := repo.GetByForeignID(ctx, "dnb:author:frank-herbert")
+	if old != nil {
+		t.Errorf("old synthetic row should be gone, got %+v", old)
+	}
+}
+
+// TestAuthorRepo_UpgradeSyntheticDNB_PreservesExistingDescriptiveFields
+// guards the CASE WHEN behaviour: when the target has empty descriptive
+// columns, the existing row's values are kept rather than blanked.
+func TestAuthorRepo_UpgradeSyntheticDNB_PreservesExistingDescriptiveFields(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	if err := repo.Create(ctx, &models.Author{
+		ForeignID:        "dnb:author:x-y",
+		Name:             "X Y",
+		SortName:         "Y, X",
+		Description:      "kept",
+		ImageURL:         "kept.jpg",
+		Disambiguation:   "kept-disamb",
+		MetadataProvider: "dnb",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := repo.UpgradeSyntheticDNB(ctx, "dnb:author:x-y", &models.Author{
+		ForeignID:        "OL-X",
+		Name:             "X Y",
+		SortName:         "Y, X",
+		MetadataProvider: "openlibrary",
+		// Description / ImageURL / Disambiguation deliberately empty.
+	}); err != nil {
+		t.Fatalf("UpgradeSyntheticDNB: %v", err)
+	}
+
+	got, err := repo.GetByForeignID(ctx, "OL-X")
+	if err != nil || got == nil {
+		t.Fatalf("post-upgrade fetch: %v, got=%+v", err, got)
+	}
+	if got.Description != "kept" || got.ImageURL != "kept.jpg" || got.Disambiguation != "kept-disamb" {
+		t.Errorf("descriptive fields blanked instead of preserved: %+v", got)
+	}
+}
+
+// TestAuthorRepo_UpgradeSyntheticDNB_BadArgs guards against silent no-ops
+// from caller mistakes.
+func TestAuthorRepo_UpgradeSyntheticDNB_BadArgs(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	if err := repo.UpgradeSyntheticDNB(ctx, "", &models.Author{ForeignID: "OL-X"}); err == nil {
+		t.Error("expected error when currentForeignID is empty")
+	}
+	if err := repo.UpgradeSyntheticDNB(ctx, "dnb:author:x", nil); err == nil {
+		t.Error("expected error when target is nil")
+	}
+	if err := repo.UpgradeSyntheticDNB(ctx, "dnb:author:x", &models.Author{}); err == nil {
+		t.Error("expected error when target.ForeignID is empty")
+	}
+}
+
+// Sanity: ensure the LIKE pattern in GetByDNBSyntheticName actually uses the
+// "dnb:author:" prefix (not just any "dnb:" or any prefix at all) so we
+// don't accidentally try to upgrade a real DNB control-number row later.
+func TestAuthorRepo_GetByDNBSyntheticName_LikePatternConstants(t *testing.T) {
+	// The query is private — this is a documentation-grade assertion that
+	// the prefix is the intended one. If the prefix in the SQL is changed,
+	// also update the production prefix in dnb client and api handler.
+	const wantPrefix = "dnb:author:"
+	if !strings.HasPrefix(wantPrefix, "dnb:author:") {
+		t.Fatalf("synthetic prefix changed unexpectedly: %q", wantPrefix)
+	}
+}

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -280,3 +280,54 @@ func TestAggregator_GetEditions_Cached(t *testing.T) {
 		t.Errorf("cached editions mismatch: %+v", got)
 	}
 }
+
+// TestAggregator_ResolveBookByISBN_AcceptsDNBWithSyntheticAuthorID is the
+// regression test for #608: prior to the DNB-author-foreign-id fix, the
+// aggregator silently dropped DNB-only ISBN hits because Author.ForeignID
+// was empty. Now that DNB populates a synthetic "dnb:gnd:" (or
+// "dnb:author:") ForeignID, ResolveBookByISBN must accept it.
+func TestAggregator_ResolveBookByISBN_AcceptsDNBWithSyntheticAuthorID(t *testing.T) {
+	primary := &mockProvider{name: "openlibrary"} // OL doesn't have this ISBN.
+	dnb := &mockProvider{name: "dnb", getByISBN: &models.Book{
+		ForeignID: "dnb:bib-001",
+		Title:     "Der Wüstenplanet",
+		Author: &models.Author{
+			ForeignID:        "dnb:gnd:118585665",
+			Name:             "Frank Herbert",
+			SortName:         "Herbert, Frank",
+			MetadataProvider: "dnb",
+		},
+	}}
+	agg := newTestAggregator(primary, dnb)
+
+	got, err := agg.ResolveBookByISBN(context.Background(), "9783453198975")
+	if err != nil {
+		t.Fatalf("ResolveBookByISBN: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected DNB result with synthetic author ForeignID to be accepted, got nil")
+	}
+	if got.Author == nil || got.Author.ForeignID != "dnb:gnd:118585665" {
+		t.Errorf("unexpected resolved author: %+v", got.Author)
+	}
+}
+
+// TestAggregator_ResolveBookByISBN_StillSkipsResultsWithoutAuthorID guards
+// the inverse: a provider that genuinely returns a book without any author
+// ForeignID is still dropped, so the caller sees nil instead of a placeholder
+// row it can't persist.
+func TestAggregator_ResolveBookByISBN_StillSkipsResultsWithoutAuthorID(t *testing.T) {
+	primary := &mockProvider{name: "openlibrary", getByISBN: &models.Book{
+		Title:  "Title Only",
+		Author: &models.Author{Name: "Unknown", ForeignID: ""},
+	}}
+	agg := newTestAggregator(primary)
+
+	got, err := agg.ResolveBookByISBN(context.Background(), "9780000000000")
+	if err != nil {
+		t.Fatalf("ResolveBookByISBN: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil when no provider has an author ForeignID, got %+v", got)
+	}
+}

--- a/internal/metadata/dnb/client.go
+++ b/internal/metadata/dnb/client.go
@@ -21,6 +21,8 @@ import (
 	"time"
 	"unicode"
 
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -80,12 +82,22 @@ func (c *Client) SearchBooks(ctx context.Context, query string) ([]models.Book, 
 	return books, nil
 }
 
-// GetAuthor is not supported by the DNB SRU endpoint. DNB's public SRU
+// GetAuthor is largely unsupported by the DNB SRU endpoint. DNB's public SRU
 // interface does not expose an authority record lookup by ID — author records
 // in DNB live in a separate GND (Gemeinsame Normdatei) catalog that is not
 // queryable by the same SRU endpoint. Callers that need the full author record
 // must use SearchAuthors and pick the best match.
-func (c *Client) GetAuthor(_ context.Context, _ string) (*models.Author, error) {
+//
+// However, when recordToBook synthesises an author ForeignID ("dnb:gnd:<id>"
+// or "dnb:author:<slug>") the aggregator's prefix-based dispatch will route
+// any subsequent GetAuthor here. We return (nil, nil) for those synthetic
+// IDs so the AddBook fallback can construct an Author from name without
+// the call erroring out. Real DNB control numbers ("dnb:<digits>") keep the
+// original "not supported" behaviour for callers that still pass them.
+func (c *Client) GetAuthor(_ context.Context, foreignID string) (*models.Author, error) {
+	if strings.HasPrefix(foreignID, "dnb:gnd:") || strings.HasPrefix(foreignID, "dnb:author:") {
+		return nil, nil
+	}
 	return nil, fmt.Errorf("dnb does not support author lookup by ID")
 }
 
@@ -243,10 +255,25 @@ func recordToBook(rec marcRecord) *models.Book {
 		b.ReleaseDate = t
 	}
 
-	// Main entry personal name (100 $a). MARC format is "Last, First".
+	// Main entry personal name (100 $a). MARC format is "Last, First". Pair
+	// it with the linked-authority identifier from $0 (GND) when present, or
+	// synthesise a stable name-slug ID otherwise so the aggregator's "drop
+	// results without an author ForeignID" guard does not silently swallow
+	// the DNB result.
 	if marcName := marcClean(rec.subfield("100", "a")); marcName != "" {
 		displayName := invertMARCName(marcName)
+		foreignID := ""
+		for _, raw := range rec.subfieldAll("100", "0") {
+			if gnd := extractGND(raw); gnd != "" {
+				foreignID = "dnb:gnd:" + gnd
+				break
+			}
+		}
+		if foreignID == "" {
+			foreignID = "dnb:author:" + slug(displayName)
+		}
 		b.Author = &models.Author{
+			ForeignID:        foreignID,
 			Name:             displayName,
 			SortName:         marcName, // already in "Last, First" sort form
 			MetadataProvider: "dnb",
@@ -347,6 +374,87 @@ func invertMARCName(marc string) string {
 		return last
 	}
 	return first + " " + last
+}
+
+// extractGND returns the bare GND (Gemeinsame Normdatei) identifier from a
+// MARC 100 $0 authority-link value. DNB records use two conventional forms:
+//
+//   - "(DE-588)1234567X"     — parenthesised authority-source prefix
+//   - "http://d-nb.info/gnd/1234567X" — URL form
+//
+// Both encode the same authority record. Returns "" when neither form is
+// present (e.g. an empty $0, or a non-GND authority like ISNI/VIAF).
+func extractGND(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	// URL form takes precedence: "…/gnd/<id>". We accept any case for the
+	// path segment to tolerate "GND" or trailing path noise.
+	if idx := strings.Index(strings.ToLower(raw), "/gnd/"); idx != -1 {
+		rest := raw[idx+len("/gnd/"):]
+		return trimGNDID(rest)
+	}
+	// Parenthesised form: "(DE-588)<id>" or "(DE-101) <id>" with whitespace.
+	if strings.HasPrefix(raw, "(") {
+		if end := strings.IndexByte(raw, ')'); end != -1 {
+			authority := strings.TrimSpace(raw[1:end])
+			if strings.EqualFold(authority, "DE-588") {
+				return trimGNDID(strings.TrimSpace(raw[end+1:]))
+			}
+		}
+	}
+	return ""
+}
+
+// trimGNDID strips trailing slashes / whitespace / non-ID punctuation from a
+// candidate GND identifier. GND IDs are 9–10 chars: digits with an optional
+// trailing check character (digit or 'X').
+func trimGNDID(s string) string {
+	s = strings.TrimSpace(s)
+	// Stop at first path/query/fragment delimiter — guards against trailing
+	// path noise on URL-form values.
+	for _, sep := range []string{"/", "?", "#", " "} {
+		if idx := strings.Index(s, sep); idx != -1 {
+			s = s[:idx]
+		}
+	}
+	return s
+}
+
+// slug returns a lowercase ASCII-folded version of name with any run of
+// non-alphanumeric characters collapsed to "-". Leading/trailing hyphens are
+// trimmed. Used to synthesise a stable author ForeignID when the DNB record
+// has no GND authority link (so the aggregator can persist + dedupe DNB-only
+// authors).
+//
+// Example: "Müller, Thomas" → "muller-thomas".
+func slug(name string) string {
+	folded := norm.NFD.String(strings.TrimSpace(name))
+	var b strings.Builder
+	b.Grow(len(folded))
+	prevDash := false
+	for _, r := range folded {
+		switch {
+		case unicode.Is(unicode.Mn, r):
+			// Combining mark from NFD decomposition — drop, keeping the base letter.
+			continue
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+			prevDash = false
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash && b.Len() > 0 {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	out := b.String()
+	out = strings.TrimRight(out, "-")
+	return out
 }
 
 // parseYear extracts the first 4-digit year from a MARC date string such as

--- a/internal/metadata/dnb/client_test.go
+++ b/internal/metadata/dnb/client_test.go
@@ -615,6 +615,150 @@ func TestSearchBooks_ExtractsISBNsFromMARC020(t *testing.T) {
 	}
 }
 
+// marcWithGND has a 100 $0 carrying the parenthesised DE-588 form. Used to
+// verify recordToBook lifts the GND authority ID into Author.ForeignID.
+const marcWithGND = `<record xmlns="http://www.loc.gov/MARC21/slim">
+  <controlfield tag="001">7777</controlfield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Funke, Cornelia,</subfield>
+    <subfield code="0">(DE-588)123456789</subfield>
+    <subfield code="0">(DE-101)abc</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Tintenherz</subfield>
+  </datafield>
+</record>`
+
+// marcWithGNDURL uses the URL form of the GND authority link.
+const marcWithGNDURL = `<record xmlns="http://www.loc.gov/MARC21/slim">
+  <controlfield tag="001">8888</controlfield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Müller, Heiner,</subfield>
+    <subfield code="0">http://d-nb.info/gnd/118585665</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Werke</subfield>
+  </datafield>
+</record>`
+
+// marcSyntheticAuthor has 100 $a but no $0; recordToBook should fall back
+// to a "dnb:author:<slug>" ForeignID derived from the display name.
+const marcSyntheticAuthor = `<record xmlns="http://www.loc.gov/MARC21/slim">
+  <controlfield tag="001">9001</controlfield>
+  <datafield tag="100" ind1="1" ind2=" ">
+    <subfield code="a">Müller, Thomas,</subfield>
+  </datafield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">Ein Buch</subfield>
+  </datafield>
+</record>`
+
+func TestExtractGND(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"(DE-588)1234567X", "1234567X"},
+		{"(DE-588)118585665", "118585665"},
+		{" (DE-588) 99999X ", "99999X"},
+		{"http://d-nb.info/gnd/1234567X", "1234567X"},
+		{"https://d-nb.info/gnd/118585665", "118585665"},
+		{"http://d-nb.info/gnd/118585665/about", "118585665"},
+		{"", ""},
+		{"(DE-101)abc", ""}, // wrong authority code → not a GND value
+		{"(ISNI)0000000123456789", ""},
+		{"random nonsense", ""},
+		{"http://example.com/foo/bar", ""},
+	}
+	for _, tc := range cases {
+		got := extractGND(tc.in)
+		if got != tc.want {
+			t.Errorf("extractGND(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSlug(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Frank Herbert", "frank-herbert"},
+		{"Müller, Thomas", "muller-thomas"},
+		{"Heiner Müller", "heiner-muller"},
+		{"  J.R.R.   Tolkien  ", "j-r-r-tolkien"},
+		{"Anonyme – Auteur", "anonyme-auteur"},
+		{"García Márquez", "garcia-marquez"},
+		{"", ""},
+		{"---", ""},
+	}
+	for _, tc := range cases {
+		got := slug(tc.in)
+		if got != tc.want {
+			t.Errorf("slug(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRecordToBook_AuthorForeignID_FromGND(t *testing.T) {
+	c := mockXMLClient(sruXMLN("1", marcWithGND), http.StatusOK)
+	books, err := c.SearchBooks(context.Background(), "Tintenherz")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	b := books[0]
+	if b.Author == nil {
+		t.Fatal("expected Author to be populated")
+	}
+	if b.Author.ForeignID != "dnb:gnd:123456789" {
+		t.Errorf("Author.ForeignID = %q, want dnb:gnd:123456789", b.Author.ForeignID)
+	}
+}
+
+func TestRecordToBook_AuthorForeignID_FromGNDURL(t *testing.T) {
+	c := mockXMLClient(sruXMLN("1", marcWithGNDURL), http.StatusOK)
+	books, err := c.SearchBooks(context.Background(), "Werke")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 || books[0].Author == nil {
+		t.Fatalf("expected 1 book with author, got %+v", books)
+	}
+	if books[0].Author.ForeignID != "dnb:gnd:118585665" {
+		t.Errorf("Author.ForeignID = %q, want dnb:gnd:118585665", books[0].Author.ForeignID)
+	}
+}
+
+func TestRecordToBook_AuthorForeignID_SyntheticWhenNoAuthorityLink(t *testing.T) {
+	c := mockXMLClient(sruXMLN("1", marcSyntheticAuthor), http.StatusOK)
+	books, err := c.SearchBooks(context.Background(), "Müller")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 || books[0].Author == nil {
+		t.Fatalf("expected 1 book with author, got %+v", books)
+	}
+	if books[0].Author.ForeignID != "dnb:author:thomas-muller" {
+		t.Errorf("Author.ForeignID = %q, want dnb:author:thomas-muller", books[0].Author.ForeignID)
+	}
+}
+
+// TestGetAuthor_SyntheticIDsReturnNil verifies that the prefix-based
+// aggregator dispatch can safely route GetAuthor calls for synthetic DNB
+// author IDs without producing an error — the caller will construct an
+// Author from name in that path.
+func TestGetAuthor_SyntheticIDsReturnNil(t *testing.T) {
+	cases := []string{"dnb:gnd:118585665", "dnb:author:frank-herbert"}
+	for _, id := range cases {
+		got, err := New().GetAuthor(context.Background(), id)
+		if err != nil {
+			t.Errorf("GetAuthor(%q): unexpected error: %v", id, err)
+		}
+		if got != nil {
+			t.Errorf("GetAuthor(%q): expected nil, got %+v", id, got)
+		}
+	}
+}
+
 func TestStripISBNQualifier(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"9783499015717", "9783499015717"},


### PR DESCRIPTION
## Summary

- Fixes #608. DNB-only ISBN adds failed with 422 because DNB never set Author.ForeignID and no other provider had the ISBN.
- Now DNB synthesises a stable ForeignID (GND when MARC $0 is populated, otherwise dnb:author:<slug>) and the aggregator accepts the result.
- When a canonical author (OL / Hardcover) later arrives for the same SortName, the synthetic row is migrated in place.

## Changes

- internal/metadata/dnb/client.go — extractGND helper; recordToBook populates dnb:gnd: or dnb:author: ForeignID; GetAuthor returns (nil, nil) for synthetic prefixes so aggregator dispatch doesn't error.
- internal/metadata/aggregator_test.go — regression test that DNB-only ResolveBookByISBN result is accepted.
- internal/db/authors.go — GetByDNBSyntheticName, UpgradeSyntheticDNB methods (user-scoped, in-place row update preserves book FK).
- internal/db/authors_test.go — coverage for the new repo methods.
- internal/api/authors.go — dedupe path during AddBook author creation.
- CHANGELOG.md — Fixed entry under [Unreleased].

## Test plan

- [x] go test ./internal/metadata/... ./internal/api/... ./internal/db/...
- [x] go vet ./...
- [x] gofmt -l internal/ (clean)
- [ ] Manual: add one of the user's reported ISBNs (e.g. 978-3-8373-9555-6) once deployed; confirm author + book created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)