### PR TITLE
docs(release): write v1.9.3 CHANGELOG and bump chart tag to 1.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.9.3] — 2026-05-12
+
 ### Fixed
 
 - **DNB add-by-ISBN no longer fails for German books with no OpenLibrary coverage** (#608) — DNB results now carry a stable author ForeignID (GND from MARC 100 $0 when present, otherwise a synthetic `dnb:author:<name-slug>`). When a canonical author (OpenLibrary / Hardcover) later arrives for the same SortName, the synthetic DNB row is migrated in place so the user keeps a single author record. Previously the add flow returned 422 "Author metadata unavailable" whenever no canonical provider had the ISBN.

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.9.2"
+  tag: "1.9.3"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
## Summary

Patch release v1.9.3 — DNB add-by-ISBN fix for German books that have no OpenLibrary coverage.

Closes #608.

## Test plan

- [x] #609 CI-green and admin-merged
- [x] CHANGELOG entry covers the change
- [x] `charts/bindery/values.yaml` bumped to "1.9.3"
- [ ] Manual: tag, deploy-prod recovery, telemetry LATEST_VERSION bump
- [ ] Manual: add a known-DNB-only ISBN once deployed (e.g. 978-3-8373-9555-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)