### PR TITLE
test(metadata): live ISBN provider integration tests (extracted from #515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Bindery are documented here. Format loosely follows
 ### Added
 
 - **Discord stats voice channels** — A k8s CronJob in `deploy/discord-stats.yaml` updates three Discord voice channels every 10 minutes with live active-install count, latest released version, and GitHub star count. Powered by a new `/stats.json` JSON endpoint on the telemetry server. Setup steps in `deploy/README.md`.
+- **Live ISBN provider integration tests** — New torture-corpus tests (`BINDERY_INTEGRATION=1` to run) exercise the aggregator's ISBN fallback chain against real DNB / OpenLibrary / GoogleBooks / Hardcover endpoints. Useful for catching upstream schema drift; skipped by default to avoid CI flake. Extracted from #515.
 
 ### Fixed
 

--- a/internal/metadata/isbn_provider_live_test.go
+++ b/internal/metadata/isbn_provider_live_test.go
@@ -1,0 +1,282 @@
+package metadata_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/metadata/dnb"
+	"github.com/vavallee/bindery/internal/metadata/googlebooks"
+	"github.com/vavallee/bindery/internal/metadata/hardcover"
+	"github.com/vavallee/bindery/internal/metadata/openlibrary"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+const liveISBNProviderCallDelay = 250 * time.Millisecond
+
+type isbnTortureCase struct {
+	id                      string
+	providers               []string
+	isbnInputs              []string
+	expectedOpenLibraryWork string
+}
+
+type isbnDirectProvider struct {
+	name     string
+	provider metadata.Provider
+	skip     string
+}
+
+func TestLiveISBNProviderFallbackTortureCorpus(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	ol := openlibrary.New()
+	gb := googlebooks.New(os.Getenv(googleBooksAPIKeyEnv))
+	dn := dnb.New()
+	providers := []metadata.Provider{gb, dn}
+	if token := os.Getenv(binderyHardcoverAPITokenEnv); token != "" {
+		providers = append(providers, hardcover.New().WithToken(token))
+	}
+	agg := metadata.NewAggregator(ol, providers...)
+
+	for _, tc := range isbnTortureCorpus() {
+		t.Run(tc.id, func(t *testing.T) {
+			for _, isbnInput := range tc.isbnInputs {
+				t.Run(fmt.Sprintf("aggregator/%q", isbnInput), func(t *testing.T) {
+					ctx, cancel := context.WithTimeout(context.Background(), liveProviderTestTimeout)
+					t.Cleanup(cancel)
+
+					got, err := agg.GetBookByISBN(ctx, isbnInput)
+					sleepAfterLiveISBNProviderCall()
+					if err != nil {
+						skipIfLiveProviderUnavailableError(t, "aggregator", err)
+						t.Fatalf("GetBookByISBN(%q): %v", isbnInput, err)
+					}
+					if tc.expectedOpenLibraryWork == "" {
+						t.Logf("GetBookByISBN(%q) = %s; fixture has no expected_openlibrary_work", isbnInput, describeLiveISBNBook(got))
+						return
+					}
+					if got == nil {
+						t.Fatalf("GetBookByISBN(%q) = nil, want OpenLibrary work %s", isbnInput, tc.expectedOpenLibraryWork)
+					}
+					if got.MetadataProvider != "openlibrary" || got.ForeignID != tc.expectedOpenLibraryWork {
+						t.Fatalf("GetBookByISBN(%q) = %s, want provider=%q foreignID=%q", isbnInput, describeLiveISBNBook(got), "openlibrary", tc.expectedOpenLibraryWork)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestLiveDirectISBNProvidersTortureCorpus(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	directProviders := []isbnDirectProvider{
+		{name: "googlebooks", provider: googlebooks.New(os.Getenv(googleBooksAPIKeyEnv))},
+		{name: "dnb", provider: dnb.New()},
+	}
+	if token := os.Getenv(binderyHardcoverAPITokenEnv); token != "" {
+		directProviders = append(directProviders, isbnDirectProvider{name: "hardcover", provider: hardcover.New().WithToken(token)})
+	} else {
+		directProviders = append(directProviders, isbnDirectProvider{name: "hardcover", skip: "set " + binderyHardcoverAPITokenEnv + " to run Hardcover live ISBN lookups"})
+	}
+
+	for _, tc := range isbnTortureCorpus() {
+		t.Run(tc.id, func(t *testing.T) {
+			for _, directProvider := range directProviders {
+				if !isbnCaseHasProvider(tc, directProvider.name) {
+					continue
+				}
+				t.Run(directProvider.name, func(t *testing.T) {
+					if directProvider.skip != "" {
+						t.Skip(directProvider.skip)
+					}
+					for _, isbnInput := range tc.isbnInputs {
+						t.Run(fmt.Sprintf("%q", isbnInput), func(t *testing.T) {
+							ctx, cancel := context.WithTimeout(context.Background(), liveProviderTestTimeout)
+							t.Cleanup(cancel)
+
+							got, err := directProvider.provider.GetBookByISBN(ctx, isbnInput)
+							sleepAfterLiveISBNProviderCall()
+							if err != nil {
+								skipIfLiveProviderUnavailableError(t, directProvider.name, err)
+								t.Fatalf("%s.GetBookByISBN(%q): %v", directProvider.name, isbnInput, err)
+							}
+							if got == nil {
+								t.Fatalf("%s.GetBookByISBN(%q) = nil, want upstream provider result", directProvider.name, isbnInput)
+							}
+							t.Logf("%s.GetBookByISBN(%q) = %s", directProvider.name, isbnInput, describeLiveISBNBook(got))
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func sleepAfterLiveISBNProviderCall() {
+	time.Sleep(liveISBNProviderCallDelay)
+}
+
+func isbnCaseHasProvider(tc isbnTortureCase, provider string) bool {
+	for _, got := range tc.providers {
+		if got == provider {
+			return true
+		}
+	}
+	return false
+}
+
+func describeLiveISBNBook(book *models.Book) string {
+	if book == nil {
+		return "<nil>"
+	}
+	author := ""
+	if book.Author != nil {
+		author = book.Author.Name
+	}
+	return fmt.Sprintf("title=%q author=%q provider=%q foreignID=%q", book.Title, author, book.MetadataProvider, book.ForeignID)
+}
+
+func isbnTortureCorpus() []isbnTortureCase {
+	return []isbnTortureCase{
+		{
+			id:        "phm_ascii_subtitle_google_hardcover_ol",
+			providers: []string{"openlibrary", "googlebooks", "hardcover"},
+			isbnInputs: []string{
+				"9780593135204",
+				"978-0-593-13520-4",
+				"978 0 593 13520 4",
+				"0593135202",
+				" 9780593135204 ",
+			},
+			expectedOpenLibraryWork: "OL21745884W",
+		},
+		{
+			id:        "dune_german_ol_google_dnb_isbn10_x",
+			providers: []string{"openlibrary", "googlebooks", "dnb", "hardcover"},
+			isbnInputs: []string{
+				"9783453305236",
+				"978-3-453-30523-6",
+				"978 3 453 30523 6",
+				"345330523X",
+				"3-453-30523-X",
+				"345330523x",
+			},
+			expectedOpenLibraryWork: "OL893415W",
+		},
+		{
+			id:        "dune_german_dnb_new_translation_title_noise",
+			providers: []string{"dnb", "googlebooks", "hardcover"},
+			isbnInputs: []string{
+				"9783453323131",
+				"978-3-453-32313-1",
+				"9783453321229",
+				"978-3-453-32122-9",
+				"9783453317178",
+			},
+			expectedOpenLibraryWork: "OL893415W",
+		},
+		{
+			id:        "cien_anos_spanish_accents_bilingual",
+			providers: []string{"openlibrary", "googlebooks", "hardcover"},
+			isbnInputs: []string{
+				"9780307474728",
+				"978-0-307-47472-8",
+				"978 0 307 47472 8",
+				"0307474720",
+			},
+			expectedOpenLibraryWork: "OL274505W",
+		},
+		{
+			id:        "santi_chinese_simplified_transliteration",
+			providers: []string{"openlibrary", "googlebooks", "hardcover"},
+			isbnInputs: []string{
+				"9787536692930",
+				"978-7-5366-9293-0",
+				"978 7 5366 9293 0",
+				"7536692935",
+				"9780765377067",
+				"978-0-7653-7706-7",
+			},
+			expectedOpenLibraryWork: "OL17267881W",
+		},
+		{
+			id:        "huozhe_chinese_short_title",
+			providers: []string{"openlibrary", "googlebooks", "hardcover"},
+			isbnInputs: []string{
+				"9787544210966",
+				"978-7-5442-1096-6",
+				"978 7 5442 1096 6",
+				"7544210960",
+			},
+			expectedOpenLibraryWork: "OL20903102W",
+		},
+		{
+			id:        "awlad_haratina_arabic_rtl_translations",
+			providers: []string{"openlibrary", "googlebooks", "hardcover"},
+			isbnInputs: []string{
+				"9789770915349",
+				"978-977-09-1534-9",
+				"978 977 09 1534 9",
+				"9770915343",
+			},
+			expectedOpenLibraryWork: "OL1599698W",
+		},
+		{
+			id:        "master_margarita_cyrillic_translated",
+			providers: []string{"openlibrary", "googlebooks", "hardcover"},
+			isbnInputs: []string{
+				"9785170878840",
+				"978-5-170-87884-0",
+				"978 5 170 87884 0",
+				"5170878842",
+			},
+			expectedOpenLibraryWork: "OL676009W",
+		},
+		{
+			id:        "vorleser_dnb_german_generic_english_title",
+			providers: []string{"dnb", "googlebooks", "hardcover"},
+			isbnInputs: []string{
+				"9783257060652",
+				"978-3-257-06065-2",
+				"9783257070668",
+				"978-3-257-07066-8",
+			},
+		},
+		{
+			id:        "kafka_verwandlung_dnb_google_umlaut_translation",
+			providers: []string{"openlibrary", "googlebooks", "dnb", "hardcover"},
+			isbnInputs: []string{
+				"9783596258758",
+				"978-3-596-25875-8",
+				"3596258758",
+				"9783125560291",
+				"978-3-12-556029-1",
+			},
+		},
+		{
+			id:        "name_of_the_wind_hardcover_exact_isbn",
+			providers: []string{"hardcover", "googlebooks", "openlibrary"},
+			isbnInputs: []string{
+				"9780756404741",
+				"978-0-7564-0474-1",
+				"978 0 7564 0474 1",
+				"0756404746",
+			},
+			expectedOpenLibraryWork: "OL8479867W",
+		},
+		{
+			id:        "godel_escher_bach_punctuation_diacritic",
+			providers: []string{"openlibrary", "googlebooks", "hardcover"},
+			isbnInputs: []string{
+				"9780465026562",
+				"978-0-465-02656-2",
+				"978 0 465 02656 2",
+			},
+		},
+	}
+}

--- a/internal/metadata/live_provider_test.go
+++ b/internal/metadata/live_provider_test.go
@@ -1,0 +1,389 @@
+package metadata_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/indexer"
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/metadata/dnb"
+	"github.com/vavallee/bindery/internal/metadata/googlebooks"
+	"github.com/vavallee/bindery/internal/metadata/hardcover"
+	"github.com/vavallee/bindery/internal/metadata/openlibrary"
+	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/textutil"
+)
+
+const liveProviderTestTimeout = 45 * time.Second
+
+type liveProvider struct {
+	name    string
+	envSkip string
+	lookup  func(context.Context, string) (*models.Book, error)
+}
+
+type liveWorkCase struct {
+	name            string
+	isbn            string
+	canonicalTitle  string
+	canonicalAuthor string
+	expects         map[string]liveBookExpectation
+}
+
+type liveBookExpectation struct {
+	title     string
+	author    string
+	foreignID string
+}
+
+type openLibraryNoISBN struct {
+	*openlibrary.Client
+}
+
+func (o openLibraryNoISBN) GetBookByISBN(context.Context, string) (*models.Book, error) {
+	return nil, nil
+}
+
+func TestLiveProviderISBNLookups(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	providers := []liveProvider{
+		{
+			name: "openlibrary",
+			lookup: func(ctx context.Context, isbn string) (*models.Book, error) {
+				return openlibrary.New().GetBookByISBN(ctx, isbn)
+			},
+		},
+		{
+			name: "googlebooks",
+			lookup: func(ctx context.Context, isbn string) (*models.Book, error) {
+				return googlebooks.New(os.Getenv(googleBooksAPIKeyEnv)).GetBookByISBN(ctx, isbn)
+			},
+		},
+		{
+			name:    "hardcover",
+			envSkip: binderyHardcoverAPITokenEnv,
+			lookup: func(ctx context.Context, isbn string) (*models.Book, error) {
+				return hardcover.New().WithToken(os.Getenv(binderyHardcoverAPITokenEnv)).GetBookByISBN(ctx, isbn)
+			},
+		},
+	}
+
+	for _, tc := range liveWorkCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, provider := range providers {
+				want, ok := tc.expects[provider.name]
+				if !ok {
+					continue
+				}
+				t.Run(provider.name, func(t *testing.T) {
+					if provider.envSkip != "" && os.Getenv(provider.envSkip) == "" {
+						t.Skipf("skipping %s live ISBN lookup; set %s", provider.name, provider.envSkip)
+					}
+					ctx, cancel := context.WithTimeout(context.Background(), liveProviderTestTimeout)
+					t.Cleanup(cancel)
+
+					book, err := provider.lookup(ctx, tc.isbn)
+					if err != nil {
+						skipIfLiveProviderUnavailableError(t, provider.name, err)
+						t.Fatalf("GetBookByISBN(%s): %v", tc.isbn, err)
+					}
+					assertLiveBook(t, book, provider.name, want)
+					assertCanonicalWork(t, book, tc.canonicalTitle, tc.canonicalAuthor)
+				})
+			}
+		})
+	}
+}
+
+func TestLiveDNBISBNLookups(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	for _, tt := range []struct {
+		name      string
+		isbn      string
+		title     string
+		author    string
+		foreignID string
+	}{
+		{
+			name:      "strunz-fitness",
+			isbn:      "9783453198975",
+			title:     "Fit wie Tiger, Panther & Co. oder was man von den Tieren lernen kann",
+			author:    "Ulrich Strunz",
+			foreignID: "dnb:1011317877",
+		},
+		{
+			name:      "elbenthal-saga",
+			isbn:      "9783423625668",
+			title:     "Elbenthal-Saga",
+			author:    "Ivo Pala",
+			foreignID: "dnb:1034321560",
+		},
+		{
+			name:      "manhattan-karma",
+			isbn:      "9783518462553",
+			title:     "Manhattan-Karma: ein Leonid-McGill-Roman",
+			author:    "Walter Mosley",
+			foreignID: "dnb:1008350516",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), liveProviderTestTimeout)
+			t.Cleanup(cancel)
+
+			book, err := dnb.New().GetBookByISBN(ctx, tt.isbn)
+			if err != nil {
+				skipIfLiveProviderUnavailableError(t, "dnb", err)
+				t.Fatalf("GetBookByISBN(%s): %v", tt.isbn, err)
+			}
+			assertLiveBook(t, book, "dnb", liveBookExpectation{
+				title:     tt.title,
+				author:    tt.author,
+				foreignID: tt.foreignID,
+			})
+		})
+	}
+}
+
+func TestLiveAggregatorCanonicalizesSecondaryISBNHitToOpenLibrary(t *testing.T) {
+	skipUnlessIntegration(t)
+
+	for _, tt := range []struct {
+		name            string
+		isbn            string
+		canonicalTitle  string
+		canonicalAuthor string
+		foreignID       string
+	}{
+		{
+			name:            "project-hail-mary",
+			isbn:            "9780593135204",
+			canonicalTitle:  "Project Hail Mary",
+			canonicalAuthor: "Andy Weir",
+			foreignID:       "OL21745884W",
+		},
+		{
+			name:            "dune",
+			isbn:            "9780441172719",
+			canonicalTitle:  "Dune",
+			canonicalAuthor: "Frank Herbert",
+			foreignID:       "OL893415W",
+		},
+		{
+			name:            "left-hand-of-darkness",
+			isbn:            "9780441478125",
+			canonicalTitle:  "The Left Hand of Darkness",
+			canonicalAuthor: "Ursula K. Le Guin",
+			foreignID:       "OL59800W",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), liveProviderTestTimeout)
+			t.Cleanup(cancel)
+
+			agg := metadata.NewAggregator(openLibraryNoISBN{Client: openlibrary.New()}, googlebooks.New(os.Getenv(googleBooksAPIKeyEnv)))
+			book, err := agg.GetBookByISBN(ctx, tt.isbn)
+			if err != nil {
+				skipIfLiveProviderUnavailableError(t, "googlebooks", err)
+				t.Fatalf("GetBookByISBN(%s): %v", tt.isbn, err)
+			}
+			assertLiveBook(t, book, "openlibrary", liveBookExpectation{
+				title:     tt.canonicalTitle,
+				author:    tt.canonicalAuthor,
+				foreignID: tt.foreignID,
+			})
+		})
+	}
+}
+
+func liveWorkCases() []liveWorkCase {
+	return []liveWorkCase{
+		{
+			name:            "project-hail-mary-isbn13",
+			isbn:            "9780593135204",
+			canonicalTitle:  "Project Hail Mary",
+			canonicalAuthor: "Andy Weir",
+			expects: map[string]liveBookExpectation{
+				"openlibrary": {title: "Project Hail Mary", author: "Andy Weir", foreignID: "OL21745884W"},
+				"googlebooks": {title: "Project Hail Mary", author: "Andy Weir"},
+				"hardcover":   {title: "Project Hail Mary", author: "Andy Weir", foreignID: "hc:project-hail-mary"},
+			},
+		},
+		{
+			name:            "project-hail-mary-isbn10",
+			isbn:            "0593135202",
+			canonicalTitle:  "Project Hail Mary",
+			canonicalAuthor: "Andy Weir",
+			expects: map[string]liveBookExpectation{
+				"openlibrary": {title: "Project Hail Mary", author: "Andy Weir", foreignID: "OL21745884W"},
+				"googlebooks": {title: "Project Hail Mary", author: "Andy Weir"},
+				"hardcover":   {title: "Project Hail Mary", author: "Andy Weir", foreignID: "hc:project-hail-mary"},
+			},
+		},
+		{
+			name:            "dune-isbn13",
+			isbn:            "9780441172719",
+			canonicalTitle:  "Dune",
+			canonicalAuthor: "Frank Herbert",
+			expects: map[string]liveBookExpectation{
+				"openlibrary": {title: "Dune", author: "Frank Herbert", foreignID: "OL893415W"},
+				"googlebooks": {title: "Dune", author: "Frank Herbert"},
+				"hardcover":   {title: "Dune", author: "Frank Herbert", foreignID: "hc:dune"},
+			},
+		},
+		{
+			name:            "dune-isbn10",
+			isbn:            "0441172717",
+			canonicalTitle:  "Dune",
+			canonicalAuthor: "Frank Herbert",
+			expects: map[string]liveBookExpectation{
+				"openlibrary": {title: "Dune", author: "Frank Herbert", foreignID: "OL893415W"},
+				"googlebooks": {title: "Dune", author: "Frank Herbert"},
+				"hardcover":   {title: "Dune", author: "Frank Herbert", foreignID: "hc:dune"},
+			},
+		},
+		{
+			name:            "name-of-the-wind-isbn13",
+			isbn:            "9780756404741",
+			canonicalTitle:  "The Name of the Wind",
+			canonicalAuthor: "Patrick Rothfuss",
+			expects: map[string]liveBookExpectation{
+				"openlibrary": {title: "The Name of the Wind", author: "Patrick Rothfuss"},
+				"googlebooks": {title: "The Name of the Wind", author: "Patrick Rothfuss"},
+				"hardcover":   {title: "The Name of the Wind", author: "Patrick Rothfuss", foreignID: "hc:the-name-of-the-wind"},
+			},
+		},
+		{
+			name:            "name-of-the-wind-isbn10",
+			isbn:            "0756404746",
+			canonicalTitle:  "The Name of the Wind",
+			canonicalAuthor: "Patrick Rothfuss",
+			expects: map[string]liveBookExpectation{
+				"openlibrary": {title: "The Name of the Wind", author: "Patrick Rothfuss"},
+				"googlebooks": {title: "The Name of the Wind", author: "Patrick Rothfuss"},
+				"hardcover":   {title: "The Name of the Wind", author: "Patrick Rothfuss", foreignID: "hc:the-name-of-the-wind"},
+			},
+		},
+		{
+			name:            "to-kill-a-mockingbird",
+			isbn:            "9780061120084",
+			canonicalTitle:  "To Kill a Mockingbird",
+			canonicalAuthor: "Harper Lee",
+			expects: map[string]liveBookExpectation{
+				"openlibrary": {title: "To Kill a Mockingbird", author: "Harper Lee", foreignID: "OL3140822W"},
+				"googlebooks": {title: "To Kill a Mockingbird", author: "Harper Lee"},
+				"hardcover":   {title: "To Kill A Mockingbird", author: "Harper Lee", foreignID: "hc:to-kill-a-mockingbird"},
+			},
+		},
+		{
+			name:            "the-hunger-games",
+			isbn:            "9780439023528",
+			canonicalTitle:  "The Hunger Games",
+			canonicalAuthor: "Suzanne Collins",
+			expects: map[string]liveBookExpectation{
+				"openlibrary": {title: "The Hunger Games", author: "Suzanne Collins", foreignID: "OL5735363W"},
+				"googlebooks": {title: "The Hunger Games", author: "Suzanne Collins"},
+				"hardcover":   {title: "The Hunger Games", author: "Suzanne Collins", foreignID: "hc:the-hunger-games"},
+			},
+		},
+		{
+			name:            "the-da-vinci-code",
+			isbn:            "9780307277671",
+			canonicalTitle:  "The Da Vinci Code",
+			canonicalAuthor: "Dan Brown",
+			expects: map[string]liveBookExpectation{
+				"openlibrary": {title: "The Da Vinci Code", author: "Dan Brown", foreignID: "OL76837W"},
+				"googlebooks": {title: "The Da Vinci Code", author: "Dan Brown"},
+				"hardcover":   {title: "The Da Vinci Code", author: "Dan Brown", foreignID: "hc:the-da-vinci-code"},
+			},
+		},
+		{
+			name:            "the-body-keeps-the-score",
+			isbn:            "9780143127741",
+			canonicalTitle:  "The Body Keeps the Score",
+			canonicalAuthor: "Bessel van der Kolk",
+			expects: map[string]liveBookExpectation{
+				"openlibrary": {title: "The Body Keeps the Score", author: "Bessel van der Kolk", foreignID: "OL18147687W"},
+				"googlebooks": {title: "The Body Keeps the Score", author: "Bessel A. Van der Kolk"},
+				"hardcover":   {title: "The Body Keeps the Score: Brain, Mind, and Body in the Healing of Trauma", author: "Bessel van der Kolk", foreignID: "hc:the-body-keeps-the-score"},
+			},
+		},
+		{
+			name:            "the-left-hand-of-darkness",
+			isbn:            "9780441478125",
+			canonicalTitle:  "The Left Hand of Darkness",
+			canonicalAuthor: "Ursula K. Le Guin",
+			expects: map[string]liveBookExpectation{
+				"openlibrary": {title: "The Left Hand of Darkness", author: "Ursula K. Le Guin", foreignID: "OL59800W"},
+				"googlebooks": {title: "The Left Hand of Darkness", author: "Ursula K. Le Guin"},
+				"hardcover":   {title: "The Left Hand of Darkness", author: "Ursula K. Le Guin", foreignID: "hc:the-left-hand-of-darkness"},
+			},
+		},
+	}
+}
+
+func skipUnlessIntegration(t *testing.T) {
+	t.Helper()
+	if os.Getenv(binderyIntegrationEnv) != "1" {
+		t.Skip("skipping live metadata test; set BINDERY_INTEGRATION=1 to run")
+	}
+}
+
+func assertLiveBook(t *testing.T, book *models.Book, provider string, want liveBookExpectation) {
+	t.Helper()
+	if book == nil {
+		t.Fatal("book = nil, want live provider result")
+	}
+	if book.ForeignID == "" {
+		t.Fatal("ForeignID is empty")
+	}
+	if want.foreignID != "" && book.ForeignID != want.foreignID {
+		t.Fatalf("ForeignID = %q, want %q", book.ForeignID, want.foreignID)
+	}
+	if book.MetadataProvider != provider {
+		t.Fatalf("MetadataProvider = %q, want %q", book.MetadataProvider, provider)
+	}
+	if want.title != "" && book.Title != want.title {
+		t.Fatalf("Title = %q, want %q", book.Title, want.title)
+	}
+	if book.Author == nil {
+		t.Fatalf("Author = nil, want %q", want.author)
+	}
+	if want.author != "" && book.Author.Name != want.author {
+		t.Fatalf("Author.Name = %q, want %q", book.Author.Name, want.author)
+	}
+}
+
+func assertCanonicalWork(t *testing.T, book *models.Book, title, author string) {
+	t.Helper()
+	gotTitle := normalizedLiveTitle(book.Title)
+	wantTitle := normalizedLiveTitle(title)
+	if !sameLiveWorkTitle(gotTitle, wantTitle) {
+		t.Fatalf("canonical title = %q (%q), want %q", gotTitle, book.Title, wantTitle)
+	}
+	if match := textutil.MatchAuthorName(book.Author.Name, author); match.Kind != textutil.AuthorMatchExact && match.Kind != textutil.AuthorMatchFuzzyAuto {
+		t.Fatalf("canonical author = %q, want %q (match=%+v)", book.Author.Name, author, match)
+	}
+}
+
+func normalizedLiveTitle(title string) string {
+	return strings.TrimSpace(indexer.NormalizeTitleForDedup(title))
+}
+
+func sameLiveWorkTitle(got, want string) bool {
+	if got == want {
+		return true
+	}
+	if !strings.HasPrefix(got, want) {
+		return false
+	}
+	suffix := strings.TrimPrefix(got, want)
+	return strings.HasPrefix(suffix, " ") ||
+		strings.HasPrefix(suffix, ":") ||
+		strings.HasPrefix(suffix, "-") ||
+		strings.HasPrefix(suffix, "(")
+}


### PR DESCRIPTION
## Summary

Extracted from #515 (which is being closed as superseded). These two test files stand on their own and don't depend on #515's broader changes — they exercise main's existing aggregator API (v1.9.0 #590 + v1.9.3 #609).

Original author: @magrhino (kept as co-author).

## What lands

- `internal/metadata/isbn_provider_live_test.go` — aggregator fallback chain torture corpus.
- `internal/metadata/live_provider_test.go` — direct per-provider ISBN lookups + the `skipUnlessIntegration(t)` helper.
- `CHANGELOG.md` — Added entry.

## Why opt-in

Tests hit real DNB / OpenLibrary / GoogleBooks / Hardcover endpoints, so they're rate-limit-prone and dependent on upstream data shape. Default test runs skip them via `BINDERY_INTEGRATION=1` gate. Devs run them deliberately when touching the metadata aggregator or provider clients.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./internal/metadata/...` (without BINDERY_INTEGRATION → tests skip cleanly)
- [ ] Manual: one-off integration run with BINDERY_INTEGRATION=1 to confirm corpus still matches upstream data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)