### PR TITLE
Fix/qbittorrent v5 referer auth

### DIFF
--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -72,6 +72,8 @@ func (c *Client) Login(ctx context.Context) error {
 		return fmt.Errorf("build login request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// qBittorrent v5.x rejects login requests without a matching Referer header (CSRF protection).
+	req.Header.Set("Referer", c.baseURL)
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -72,7 +72,8 @@ func (c *Client) Login(ctx context.Context) error {
 		return fmt.Errorf("build login request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	// qBittorrent v5.x rejects login requests without a matching Referer header (CSRF protection).
+	// qBittorrent v5.x requires both Origin and Referer for CSRF protection on the login endpoint.
+	req.Header.Set("Origin", c.baseURL)
 	req.Header.Set("Referer", c.baseURL)
 
 	resp, err := c.http.Do(req)
@@ -84,8 +85,15 @@ func (c *Client) Login(ctx context.Context) error {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
 	text := strings.TrimSpace(string(body))
 
+	// qBittorrent v4.x returns 200 "Ok." on success; v5.x returns 204 No Content.
+	if resp.StatusCode == http.StatusNoContent {
+		c.mu.Lock()
+		c.loggedIn = true
+		c.mu.Unlock()
+		return nil
+	}
 	if resp.StatusCode != http.StatusOK || text == "Fails." {
-		return fmt.Errorf("qBittorrent login failed: %s", text)
+		return fmt.Errorf("qBittorrent login failed (HTTP %d): %s", resp.StatusCode, text)
 	}
 
 	c.mu.Lock()

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -197,6 +197,49 @@ func TestLogin_BadStatus(t *testing.T) {
 	}
 }
 
+// TestLogin_V5_NoContent verifies that qBittorrent v5.x's 204 No Content
+// login response is treated as a success.
+func TestLogin_V5_NoContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/auth/login" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	if err := c.Login(context.Background()); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if !c.loggedIn {
+		t.Error("loggedIn should be true after 204 response")
+	}
+}
+
+// TestLogin_SendsCSRFHeaders verifies that Origin and Referer headers are sent
+// on the login request, as required by qBittorrent v5.x CSRF protection.
+func TestLogin_SendsCSRFHeaders(t *testing.T) {
+	var gotOrigin, gotReferer string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/auth/login" {
+			gotOrigin = r.Header.Get("Origin")
+			gotReferer = r.Header.Get("Referer")
+			_, _ = w.Write([]byte("Ok."))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	_ = c.Login(context.Background())
+	if gotOrigin != srv.URL {
+		t.Errorf("Origin: want %q, got %q", srv.URL, gotOrigin)
+	}
+	if gotReferer != srv.URL {
+		t.Errorf("Referer: want %q, got %q", srv.URL, gotReferer)
+	}
+}
+
 func TestTest_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {


### PR DESCRIPTION
Fix qBittorrent v5.x login compatibility

Problem

qBittorrent v5.x introduced two breaking changes to the /api/v2/auth/login endpoint that caused the connection test to fail with an empty error body:

  1. CSRF protection ; the login endpoint now requires Origin and Referer headers matching the server URL. Requests without them are rejected silently.
  2. Success response changed ; v5.x returns 204 No Content on successful login instead of 200 Ok. The old check treated 204 as a failure.

  Changes

 - internal/downloader/qbittorrent/client.go 
   send Origin and Referer headers on the login request; accept 204 No Content as a successful login response alongside the
   existing 200 Ok. path
   include the HTTP status code in login failure errors to aid diagnosis.
 - internal/downloader/qbittorrent/client_test.go 
   add TestLogin_V5_NoContent and TestLogin_SendsCSRFHeaders to cover the new behaviour.

  Testing

  Verified against a live qBittorrent v5 instance behind a reverse proxy. All existing unit tests pass.

