### PR TITLE
fix(qbittorrent): surface useful errors for IP-ban and host-validation rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 - **Telemetry preview dashboard** — New `/stats/preview` page with interactive filters (time range, OS, deployment), version-adoption stacked area chart, retention cohorts, and per-distribution doughnut charts. Existing `/stats` is unchanged.
 
+### Fixed
+
+- **qBittorrent connection-test error messages are no longer misleading** — When qBit returned `HTTP 403` with an empty body (the shape of an IP ban after repeated failed logins), bindery previously surfaced `qBittorrent login failed: ` (empty) wrapped with `could not reach qBittorrent at … (in Docker use the service/container name, not localhost)`. The "could not reach" hint and Docker-name hint only apply to actual transport failures, not to a server that responded with a rejection. The qBittorrent client now returns a typed `*AuthError` carrying the HTTP status and body; `Test()` rewords accordingly (`connected to qBittorrent at … but qBittorrent auth failed (HTTP 403, empty body): your IP is most likely banned…`) so the user knows where to look. Bad credentials and host-header rejection get their own targeted hints.
+
 ## [v1.9.3] — 2026-05-12
 
 ### Fixed

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -5,6 +5,7 @@ package qbittorrent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -17,6 +18,31 @@ import (
 
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 )
+
+// AuthError signals that qBittorrent responded but rejected the login.
+// Test() inspects this type via errors.As so it can avoid wrapping auth
+// failures with the misleading "could not reach + use container name"
+// hint that only applies to actual transport failures.
+type AuthError struct {
+	Status int
+	Body   string
+}
+
+func (e *AuthError) Error() string {
+	switch {
+	case e.Status == http.StatusForbidden && e.Body == "":
+		return "qBittorrent auth failed (HTTP 403, empty body): your IP is most likely banned after repeated failed logins. " +
+			"Clear it in qBit (Tools → Options → Web UI → IP filtering, or the banlist in qBittorrent.conf — restart of qBit may not clear it because the banlist is persisted)."
+	case e.Status == http.StatusOK && e.Body == "Fails.":
+		return "qBittorrent auth failed: credentials rejected (check the WebUI username/password matches what's saved in bindery)."
+	case e.Status == http.StatusForbidden:
+		return fmt.Sprintf("qBittorrent auth failed (HTTP 403): %s — host-header validation may be rejecting bindery; disable it in Tools → Options → Web UI, or whitelist the bindery container's hostname.", e.Body)
+	case e.Status != http.StatusOK:
+		return fmt.Sprintf("qBittorrent auth failed (HTTP %d): %s", e.Status, e.Body)
+	default:
+		return fmt.Sprintf("qBittorrent auth failed: %s", e.Body)
+	}
+}
 
 // hashPollTimeout is the maximum time to wait for a newly-added torrent's hash
 // to appear in the unfiltered torrent list.
@@ -83,7 +109,7 @@ func (c *Client) Login(ctx context.Context) error {
 	text := strings.TrimSpace(string(body))
 
 	if resp.StatusCode != http.StatusOK || text == "Fails." {
-		return fmt.Errorf("qBittorrent login failed: %s", text)
+		return &AuthError{Status: resp.StatusCode, Body: text}
 	}
 
 	c.mu.Lock()
@@ -92,9 +118,17 @@ func (c *Client) Login(ctx context.Context) error {
 	return nil
 }
 
-// Test verifies connectivity by fetching the application version.
+// Test verifies connectivity by fetching the application version. The error
+// wording adapts to the failure mode: auth/config issues (the server
+// responded but rejected us) get a targeted hint; transport failures (the
+// server didn't respond at all) get the Docker-networking hint.
 func (c *Client) Test(ctx context.Context) error {
 	if _, err := c.get(ctx, "/api/v2/app/version"); err != nil {
+		var authErr *AuthError
+		if errors.As(err, &authErr) {
+			// Server responded — this is an auth/config issue, not unreachable.
+			return fmt.Errorf("connected to qBittorrent at %s but %w", c.baseURL, err)
+		}
 		return fmt.Errorf("could not reach qBittorrent at %s — %w (in Docker use the service/container name, not localhost)", c.baseURL, err)
 	}
 	return nil

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -3,6 +3,7 @@ package qbittorrent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -194,6 +195,87 @@ func TestLogin_BadStatus(t *testing.T) {
 	c := newTestClient(srv.URL, "admin", "pass")
 	if err := c.Login(context.Background()); err == nil {
 		t.Fatal("expected error on 500 response")
+	}
+}
+
+// TestLogin_AuthError_BadCreds covers the "200 + Fails." path. Bindery
+// should return an *AuthError that surfaces the credentials hint.
+func TestLogin_AuthError_BadCreds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("Fails."))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "bad", "creds")
+	err := c.Login(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var authErr *AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected *AuthError, got %T: %v", err, err)
+	}
+	if authErr.Status != http.StatusOK || authErr.Body != "Fails." {
+		t.Errorf("AuthError fields: got status=%d body=%q", authErr.Status, authErr.Body)
+	}
+	if !strings.Contains(err.Error(), "credentials rejected") {
+		t.Errorf("expected credentials hint, got %q", err.Error())
+	}
+}
+
+// TestLogin_AuthError_BanEmpty403 covers the qBit IP-ban shape: HTTP 403
+// with an empty body. Pre-fix this surfaced as "qBittorrent login failed: "
+// (nothing useful). Now should explain IP-ban + how to clear it.
+func TestLogin_AuthError_BanEmpty403(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	err := c.Login(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var authErr *AuthError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected *AuthError, got %T: %v", err, err)
+	}
+	if authErr.Status != http.StatusForbidden || authErr.Body != "" {
+		t.Errorf("AuthError fields: got status=%d body=%q", authErr.Status, authErr.Body)
+	}
+	if !strings.Contains(err.Error(), "IP is most likely banned") {
+		t.Errorf("expected IP-ban hint, got %q", err.Error())
+	}
+}
+
+// TestTest_AuthErrorDoesNotMisdirect proves Test() no longer wraps auth
+// failures with the "could not reach + use container name" hint that only
+// makes sense for actual transport failures.
+func TestTest_AuthErrorDoesNotMisdirect(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/auth/login" {
+			w.WriteHeader(http.StatusForbidden) // simulate IP ban
+			return
+		}
+		t.Errorf("unexpected path: %s", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "could not reach") {
+		t.Errorf("auth failure must not be reported as 'could not reach': %q", msg)
+	}
+	if !strings.Contains(msg, "connected to qBittorrent") {
+		t.Errorf("expected 'connected to qBittorrent at ... but ...' wording: %q", msg)
+	}
+	if !strings.Contains(msg, "IP is most likely banned") {
+		t.Errorf("expected the underlying AuthError hint to propagate: %q", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

The qBittorrent connection-test error wording was actively misleading. From a Discord report tonight: a user's bindery container was IP-banned by qBit after repeated failed test connections (default: 5 fails → 1h ban, persisted to disk). bindery surfaced:

\`\`\`
could not reach qBittorrent at http://qbittorrent:8080 —
  qBittorrent login failed: (in Docker use the service/container name)
\`\`\`

Three things wrong with that:
1. The server **did** respond (just with a 403 + empty body). Not "could not reach".
2. The trailing \`%s\` for an empty body produced \`qBittorrent login failed: \` — no signal about what went wrong.
3. The "in Docker use the service/container name" hint only applies to transport failures; here it sent the user chasing a non-issue.

## What changed

- New \`*AuthError\` type in \`internal/downloader/qbittorrent/client.go\` carrying the HTTP status and body. \`Error()\` produces case-specific hints:
  - \`403 + empty body\` → IP-ban hint with the qBit settings location to clear it (banlist persists to disk through container restarts)
  - \`200 + "Fails."\` → credentials-mismatch hint
  - \`other 403\` → host-header validation hint
  - \`other non-2xx\` → status + body verbatim
- \`Test()\` now uses \`errors.As\` to distinguish auth failures from transport failures. Auth path: \`connected to qBittorrent at … but qBittorrent auth failed (HTTP 403, empty body): your IP is most likely banned …\`. Transport path: unchanged ("could not reach …").
- Tests: three new in \`client_test.go\` lock in (a) bad-creds branch, (b) IP-ban-shape branch, (c) Test() no longer misdirects on auth failures.

## Out of scope (acknowledged)

The same wording problem exists for SABnzbd / NZBGet / Deluge / Transmission clients (\`could not reach X — %w (in Docker use the service/container name, not localhost)\`). They wrap differently and the failure modes vary; keeping this PR focused on qBittorrent where the bug actually bit a user tonight. Follow-up issue worth filing.

## Test plan

- [x] \`go test ./internal/downloader/qbittorrent/\` — 30+ tests pass including 3 new
- [x] \`go vet ./...\` clean
- [ ] Manual: trigger the failure modes against a real qBit instance once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)