### PR TITLE
docs(release): write v1.9.4 CHANGELOG and bump chart tag to 1.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.9.4] — 2026-05-12
+
 ### Added
 
 - **Telemetry preview dashboard** — New `/stats/preview` page with interactive filters (time range, OS, deployment), version-adoption stacked area chart, retention cohorts, and per-distribution doughnut charts. Existing `/stats` is unchanged.

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.9.3"
+  tag: "1.9.4"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
## Summary

Minor release v1.9.4.

- **Added**: /stats/preview redesigned telemetry dashboard (#617)
- **Fixed**: qBittorrent connection-test error wording for 403/empty-body case (#618)

## Test plan

- [x] CHANGELOG dated 2026-05-12
- [x] charts/bindery/values.yaml bumped to "1.9.4"
- [ ] Manual: tag, deploy-prod recovery, telemetry LATEST_VERSION bump