### PR TITLE
feat(library): surface unmatched files in Settings UI after scan

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1188,7 +1188,7 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 	slog.Info("library scan found files", "paths", []string{s.libraryDir, s.audiobookDir}, "count", len(foundFiles))
 
 	if len(foundFiles) == 0 {
-		s.writeScanResult(ctx, len(foundFiles), 0, 0, 0)
+		s.writeScanResult(ctx, len(foundFiles), 0, 0, 0, nil)
 		return
 	}
 
@@ -1230,6 +1230,7 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 	// the correct earlier assignment.
 	reconciledBooks := make(map[int64]bool)
 
+	var unmatchedFiles []unmatchedFile
 	var reconciled, unmatched, tagReadFailed int
 	for _, path := range foundFiles {
 		// Skip files already tracked, or files inside a tracked directory
@@ -1375,25 +1376,56 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		if !matched {
 			slog.Debug("library scan: unmatched file", "path", path, "parsedTitle", parsed.Title, "parsedAuthor", parsed.Author)
 			unmatched++
+			// Collect up to 1000 unmatched entries for UI display
+			if len(unmatchedFiles) < 1000 {
+				unmatchedFiles = append(unmatchedFiles, unmatchedFile{
+					Path:         path,
+					ParsedTitle:  parsed.Title,
+					ParsedAuthor: parsed.Author,
+				})
+			}
 		}
 	}
 
 	slog.Info("library scan complete", "path", s.libraryDir, "bookFiles", len(foundFiles),
 		"reconciled", reconciled, "unmatched", unmatched, "tagReadFailed", tagReadFailed)
 
-	s.writeScanResult(ctx, len(foundFiles), reconciled, unmatched, tagReadFailed)
+	s.writeScanResult(ctx, len(foundFiles), reconciled, unmatched, tagReadFailed, unmatchedFiles)
+}
+
+// unmatchedFile represents a file that could not be reconciled during library scan.
+type unmatchedFile struct {
+	Path         string `json:"path"`
+	ParsedTitle  string `json:"parsed_title"`
+	ParsedAuthor string `json:"parsed_author"`
 }
 
 // writeScanResult persists the scan summary to the settings table under
 // "library.lastScan" so the UI can surface the result without polling logs.
-func (s *Scanner) writeScanResult(ctx context.Context, filesFound, reconciled, unmatched, tagReadFailed int) {
+func (s *Scanner) writeScanResult(ctx context.Context, filesFound, reconciled, unmatched, tagReadFailed int, unmatchedFiles []unmatchedFile) {
 	if s.settings == nil {
 		return
 	}
+
+	// Marshal unmatched files to JSON
+	var unmatchedJSON string
+	if len(unmatchedFiles) > 0 {
+		bytes, err := json.Marshal(unmatchedFiles)
+		if err != nil {
+			slog.Warn("library scan: failed to marshal unmatched files", "error", err)
+			unmatchedJSON = "[]"
+		} else {
+			unmatchedJSON = string(bytes)
+		}
+	} else {
+		unmatchedJSON = "[]"
+	}
+
 	payload := fmt.Sprintf(
-		`{"ran_at":%q,"files_found":%d,"reconciled":%d,"unmatched":%d,"tag_read_failed":%d}`,
+		`{"ran_at":%q,"files_found":%d,"reconciled":%d,"unmatched":%d,"tag_read_failed":%d,"unmatched_files":%s}`,
 		time.Now().UTC().Format(time.RFC3339),
 		filesFound, reconciled, unmatched, tagReadFailed,
+		unmatchedJSON,
 	)
 	if err := s.settings.Set(ctx, "library.lastScan", payload); err != nil {
 		slog.Warn("library scan: failed to persist scan result", "error", err)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -301,7 +301,14 @@ export const api = {
 
   // Library
   triggerLibraryScan: () => request<{ message: string }>('/library/scan', { method: 'POST' }),
-  libraryScanStatus: () => request<{ ran_at: string; files_found: number; reconciled: number; unmatched: number }>('/library/scan/status'),
+  libraryScanStatus: () => request<{
+    ran_at: string
+    files_found: number
+    reconciled: number
+    unmatched: number
+    tag_read_failed?: number
+    unmatched_files?: Array<{ path: string; parsed_title: string; parsed_author: string }>
+  }>('/library/scan/status'),
 
   // Queue
   listQueue: () => request<QueueItem[]>('/queue'),

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -2365,7 +2365,14 @@ function GeneralTab() {
   const [creatingBackup, setCreatingBackup] = useState(false)
   const [scanningLibrary, setScanningLibrary] = useState(false)
   const [scanMessage, setScanMessage] = useState<string | null>(null)
-  const [lastScan, setLastScan] = useState<{ ran_at: string; files_found: number; reconciled: number; unmatched: number } | null>(null)
+  const [lastScan, setLastScan] = useState<{
+    ran_at: string
+    files_found: number
+    reconciled: number
+    unmatched: number
+    tag_read_failed?: number
+    unmatched_files?: Array<{ path: string; parsed_title: string; parsed_author: string }>
+  } | null>(null)
   const [storage, setStorage] = useState<{ downloadDir: string; audiobookDownloadDir: string; libraryDir: string; audiobookDir: string } | null>(null)
   const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null)
   const [hardcoverToken, setHardcoverToken] = useState('')
@@ -2749,6 +2756,33 @@ function GeneralTab() {
               <p className="mt-1 text-slate-500 dark:text-zinc-500">
                 {new Date(lastScan.ran_at).toLocaleString()}
               </p>
+              {lastScan.unmatched_files && lastScan.unmatched_files.length > 0 && (
+                <details className="mt-3">
+                  <summary className="cursor-pointer font-medium text-slate-700 dark:text-zinc-300 hover:text-slate-900 dark:hover:text-zinc-100">
+                    Unmatched files ({lastScan.unmatched_files.length}{lastScan.unmatched > 1000 ? ' of ' + lastScan.unmatched : ''})
+                  </summary>
+                  <div className="mt-2 max-h-80 overflow-y-auto border border-slate-200 dark:border-zinc-800 rounded bg-slate-50 dark:bg-zinc-950/50">
+                    <table className="w-full text-xs">
+                      <thead className="sticky top-0 bg-slate-100 dark:bg-zinc-900 border-b border-slate-200 dark:border-zinc-800">
+                        <tr>
+                          <th className="text-left p-2 font-medium">Path</th>
+                          <th className="text-left p-2 font-medium">Parsed Title</th>
+                          <th className="text-left p-2 font-medium">Parsed Author</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {lastScan.unmatched_files.map((file, idx) => (
+                          <tr key={idx} className="border-b border-slate-100 dark:border-zinc-900 hover:bg-slate-100 dark:hover:bg-zinc-900/50">
+                            <td className="p-2 font-mono text-xs break-all">{file.path}</td>
+                            <td className="p-2">{file.parsed_title || '—'}</td>
+                            <td className="p-2">{file.parsed_author || '—'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </details>
+              )}
             </div>
           )}
         </div>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -2759,7 +2759,7 @@ function GeneralTab() {
               {lastScan.unmatched_files && lastScan.unmatched_files.length > 0 && (
                 <details className="mt-3">
                   <summary className="cursor-pointer font-medium text-slate-700 dark:text-zinc-300 hover:text-slate-900 dark:hover:text-zinc-100">
-                    Unmatched files ({lastScan.unmatched_files.length}{lastScan.unmatched > 1000 ? ' of ' + lastScan.unmatched : ''})
+                    Unmatched files ({lastScan.unmatched_files.length}{lastScan.unmatched_files.length >= 1000 && lastScan.unmatched > 1000 ? ' of ' + lastScan.unmatched : ''})
                   </summary>
                   <div className="mt-2 max-h-80 overflow-y-auto border border-slate-200 dark:border-zinc-800 rounded bg-slate-50 dark:bg-zinc-950/50">
                     <table className="w-full text-xs">


### PR DESCRIPTION
## Summary
- Extended library scan to collect up to 1000 unmatched file entries (path, parsed title, parsed author) and include them in the scan result JSON stored via `library.lastScan` setting
- Added `unmatched_files` field to the `libraryScanStatus` API response type
- Added a collapsible table in the Settings page that displays unmatched files after a scan, with a truncation indicator when the total exceeds 1000

Closes #535

## Test plan
- `go test ./internal/importer/...` passes
- `npm run typecheck` passes (zero TypeScript errors)
- Trigger a library scan with known unmatched files and verify the collapsible panel appears in Settings with correct path/title/author columns