### PR TITLE
fix(qbittorrent): support v5.x login (CSRF + 204) — extracted from #616

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **qBittorrent v5.x login now works** (#616) — qBit 5.0 introduced two breaking changes to `/api/v2/auth/login` that v1.9.4 and earlier didn't handle: (1) CSRF protection requires matching `Origin` and `Referer` headers (without them, login is silently rejected — the empty-body 403 that v1.9.4 surfaced as an IP-ban hint); (2) successful login returns `204 No Content` instead of `200 OK` + body `Ok.`. Bindery now sends both headers on every login request (v4.x ignores them, so the change is version-safe) and accepts `204` as success alongside the v4.x `200`. Original fix and tests authored by @statte.
+
 ## [v1.9.4] — 2026-05-12
 
 ### Added

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -98,6 +98,12 @@ func (c *Client) Login(ctx context.Context) error {
 		return fmt.Errorf("build login request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// qBittorrent v5.x enforces CSRF protection on /auth/login and rejects
+	// requests without matching Origin and Referer headers (often silently —
+	// the empty-body 403 that motivated AuthError above). v4.x ignores these
+	// headers, so setting them is safe across versions.
+	req.Header.Set("Origin", c.baseURL)
+	req.Header.Set("Referer", c.baseURL)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -107,6 +113,15 @@ func (c *Client) Login(ctx context.Context) error {
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
 	text := strings.TrimSpace(string(body))
+
+	// qBittorrent v4.x returns `200 OK` + body "Ok." on a successful login;
+	// v5.x returns `204 No Content` with an empty body. Accept both.
+	if resp.StatusCode == http.StatusNoContent {
+		c.mu.Lock()
+		c.loggedIn = true
+		c.mu.Unlock()
+		return nil
+	}
 
 	if resp.StatusCode != http.StatusOK || text == "Fails." {
 		return &AuthError{Status: resp.StatusCode, Body: text}

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -198,6 +198,52 @@ func TestLogin_BadStatus(t *testing.T) {
 	}
 }
 
+// TestLogin_V5_NoContent verifies that qBittorrent v5.x's `204 No Content`
+// login response is treated as a success (v4.x returned `200 OK` + "Ok.").
+func TestLogin_V5_NoContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/auth/login" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	if err := c.Login(context.Background()); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if !c.loggedIn {
+		t.Error("loggedIn should be true after 204 response")
+	}
+}
+
+// TestLogin_SendsCSRFHeaders verifies that Origin and Referer headers are
+// sent on every login request, as required by qBittorrent v5.x CSRF checks.
+// v4.x ignores these headers, so setting them is safe across versions.
+func TestLogin_SendsCSRFHeaders(t *testing.T) {
+	var gotOrigin, gotReferer string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/auth/login" {
+			gotOrigin = r.Header.Get("Origin")
+			gotReferer = r.Header.Get("Referer")
+			_, _ = w.Write([]byte("Ok."))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	if err := c.Login(context.Background()); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if gotOrigin != srv.URL {
+		t.Errorf("Origin: want %q, got %q", srv.URL, gotOrigin)
+	}
+	if gotReferer != srv.URL {
+		t.Errorf("Referer: want %q, got %q", srv.URL, gotReferer)
+	}
+}
+
 // TestLogin_AuthError_BadCreds covers the "200 + Fails." path. Bindery
 // should return an *AuthError that surfaces the credentials hint.
 func TestLogin_AuthError_BadCreds(t *testing.T) {


### PR DESCRIPTION
## Summary

Lands @statte's PR #616 onto current main. #616 has been sitting open since 20:06 UTC yesterday with the actual root-cause fix for qBit v5.x auth failures; v1.9.4 #618 (also today) shipped a misleading-error-wording fix that masked but didn't solve the same problem.

## What this fixes

qBittorrent 5.0 introduced two breaking changes to `/api/v2/auth/login`:

1. **CSRF protection**: v5.x requires matching `Origin` and `Referer` headers. Login without them is silently rejected (non-2xx + empty body — the shape #618 attributed to IP bans).
2. **Success response**: v5.x returns `204 No Content` instead of v4.x's `200 OK` + body `Ok.`. Bindery's code rejected `204` as a failure.

## Changes

- `internal/downloader/qbittorrent/client.go` — set `Origin` and `Referer` headers on every login request (v4.x ignores them); accept `204` as success alongside `200 + "Ok."`.
- `internal/downloader/qbittorrent/client_test.go` — new `TestLogin_V5_NoContent` and `TestLogin_SendsCSRFHeaders` from @statte.
- v1.9.4's `*AuthError` type and `Test()` rewording (#618) are preserved for the remaining legitimate non-2xx/non-204 failure paths.

## Why this PR rather than merging #616 directly

#616 conflicts with #618 (which I shipped today not knowing #616 existed — the Discord notification workflow #613 didn't fire on it, separate bug). Rather than ask @statte to rebase 6-hour-old work, I hybrid-merged here and credited them as primary co-author on the commit. Closes #616.

## Test plan

- [x] `go test ./internal/downloader/qbittorrent/` — 7 Login tests pass including 2 new
- [x] `go vet ./...` clean
- [ ] Manual: connection test from bindery to a qBit v5.x instance once deployed (Discord report from Zoso this evening should be unblocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)