### PR TITLE
feat(discord): stats voice channels bot + /stats.json endpoint

### DIFF
--- a/.github/workflows/discord-stats.yml
+++ b/.github/workflows/discord-stats.yml
@@ -1,0 +1,44 @@
+name: Discord Stats
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - cmd/discord-stats/**
+      - .github/workflows/discord-stats.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build and push
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: cmd/discord-stats/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/bindery-discord-stats:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ Thumbs.db
 embeddeddolt/
 /cmd/telemetry-server/telemetry-server
 /telemetry-server
+/cmd/discord-stats/discord-stats
+/discord-stats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **Discord stats voice channels** — A k8s CronJob in `deploy/discord-stats.yaml` updates three Discord voice channels every 10 minutes with live active-install count, latest released version, and GitHub star count. Powered by a new `/stats.json` JSON endpoint on the telemetry server. Setup steps in `deploy/README.md`.
+
 ## [v1.9.5] — 2026-05-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The full endpoint catalogue, authentication rules (API key, session cookie, loca
 
 ## Community
 
-- **Discord** — real-time help, setup questions, release chat: [discord.gg/RpuYYRM9cZ](https://discord.gg/RpuYYRM9cZ). The `#support` channel is the best place to ask; `#changelog` is updated on every release.
+- **Discord** — real-time help, setup questions, release chat: [discord.gg/RpuYYRM9cZ](https://discord.gg/RpuYYRM9cZ). The `#support` channel is the best place to ask; `#changelog` is updated on every release. The three read-only voice channels at the top of the server show live active-install count, latest release, and GitHub star count, refreshed from the telemetry API every 10 minutes.
 - **GitHub Issues** — bug reports and feature requests: [issues](https://github.com/vavallee/bindery/issues).
 - **GitHub Discussions** — open-ended design questions, show-and-tell, integration recipes: [discussions](https://github.com/vavallee/bindery/discussions).
 

--- a/cmd/discord-stats/Dockerfile
+++ b/cmd/discord-stats/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.25-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /discord-stats ./cmd/discord-stats
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=builder /discord-stats /discord-stats
+ENTRYPOINT ["/discord-stats"]

--- a/cmd/discord-stats/main.go
+++ b/cmd/discord-stats/main.go
@@ -185,7 +185,7 @@ func renameChannel(ctx context.Context, c *http.Client, token, id, want string) 
 		}
 		// Drain & close so the connection can be reused on retry.
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		resp.Body.Close()
+		_ = resp.Body.Close()
 
 		switch {
 		case resp.StatusCode >= 200 && resp.StatusCode < 300:

--- a/cmd/discord-stats/main.go
+++ b/cmd/discord-stats/main.go
@@ -1,0 +1,259 @@
+// discord-stats is a tiny one-shot binary that updates three Discord voice
+// channel names with live Bindery telemetry numbers and GitHub stars.
+//
+// It is intended to run as a Kubernetes CronJob every 10 minutes — Discord
+// allows at most 2 channel renames per 10-minute window per channel, so the
+// cron schedule matches the rate limit by construction. Each tick:
+//
+//  1. Fetches active install count + latest version from BINDERY_STATS_URL.
+//  2. Fetches GitHub stargazer count from the public repo API.
+//  3. For each channel, compares the desired name to the current name and
+//     PATCHes only when they differ — every idempotent tick costs 3 GETs and
+//     0 PATCHes against the renames-per-10min budget.
+//
+// The binary uses only the standard library on purpose; we don't need a
+// gateway connection or anything beyond a few REST calls.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	discordAPI    = "https://discord.com/api/v10"
+	githubAPI     = "https://api.github.com"
+	httpTimeout   = 15 * time.Second
+	defaultStats  = "https://api.getbindery.dev/stats.json"
+	defaultRepo   = "vavallee/bindery"
+	userAgent     = "bindery-discord-stats (+https://github.com/vavallee/bindery)"
+	maxRetryAfter = 30 * time.Second // cap the sleep before giving up on a 429
+)
+
+type statsJSON struct {
+	Active int    `json:"active"`
+	Total  int    `json:"total"`
+	Latest string `json:"latest"`
+}
+
+type ghRepo struct {
+	Stargazers int `json:"stargazers_count"`
+}
+
+type discordChannel struct {
+	Name string `json:"name"`
+}
+
+func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+
+	token := mustEnv("DISCORD_BOT_TOKEN")
+	activeID := mustEnv("DISCORD_ACTIVE_CHANNEL_ID")
+	latestID := mustEnv("DISCORD_LATEST_CHANNEL_ID")
+	starsID := mustEnv("DISCORD_STARS_CHANNEL_ID")
+	statsURL := envOr("BINDERY_STATS_URL", defaultStats)
+	repo := envOr("GITHUB_REPO", defaultRepo)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	client := &http.Client{Timeout: httpTimeout}
+
+	stats, statsErr := fetchStats(ctx, client, statsURL)
+	if statsErr != nil {
+		slog.Error("fetch stats", "url", statsURL, "error", statsErr)
+		// Continue: stars-only update is still worthwhile.
+	} else {
+		slog.Info("stats", "active", stats.Active, "latest", stats.Latest)
+	}
+
+	stars, starsErr := fetchStars(ctx, client, repo)
+	if starsErr != nil {
+		slog.Error("fetch stars", "repo", repo, "error", starsErr)
+	} else {
+		slog.Info("stars", "count", stars)
+	}
+
+	type update struct {
+		label string
+		id    string
+		name  string
+		ok    bool
+	}
+	var updates []update
+	if stats != nil {
+		updates = append(updates,
+			update{"active", activeID, fmt.Sprintf("📊 Active: %d", stats.Active), true},
+			update{"latest", latestID, fmt.Sprintf("📦 Latest: %s", stats.Latest), true},
+		)
+	} else {
+		updates = append(updates,
+			update{"active", activeID, "", false},
+			update{"latest", latestID, "", false},
+		)
+	}
+	updates = append(updates,
+		update{"stars", starsID, fmt.Sprintf("⭐ Stars: %d", stars), starsErr == nil},
+	)
+
+	for _, u := range updates {
+		if !u.ok {
+			slog.Warn("skip channel: upstream fetch failed", "channel", u.label)
+			continue
+		}
+		if err := renameChannel(ctx, client, token, u.id, u.name); err != nil {
+			slog.Error("rename channel", "channel", u.label, "id", u.id, "name", u.name, "error", err)
+			continue
+		}
+	}
+	// Exit 0 even on partial failure — the next cron tick will catch up, and we
+	// don't want a transient Discord 5xx to alert on the CronJob itself.
+}
+
+// fetchStats GETs the Bindery telemetry /stats.json payload.
+func fetchStats(ctx context.Context, c *http.Client, url string) (*statsJSON, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("stats: HTTP %d", resp.StatusCode)
+	}
+	var s statsJSON
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		return nil, fmt.Errorf("stats: decode: %w", err)
+	}
+	return &s, nil
+}
+
+// fetchStars GETs the GitHub repo metadata and returns the star count.
+func fetchStars(ctx context.Context, c *http.Client, repo string) (int, error) {
+	url := githubAPI + "/repos/" + repo
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := c.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return 0, fmt.Errorf("github: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	var r ghRepo
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return 0, fmt.Errorf("github: decode: %w", err)
+	}
+	return r.Stargazers, nil
+}
+
+// renameChannel reads the current channel name and PATCHes it only when the
+// desired name differs. Handles Discord 429 once via Retry-After.
+func renameChannel(ctx context.Context, c *http.Client, token, id, want string) error {
+	current, err := getChannelName(ctx, c, token, id)
+	if err != nil {
+		return fmt.Errorf("read current name: %w", err)
+	}
+	if current == want {
+		slog.Info("channel already up-to-date", "id", id, "name", want)
+		return nil
+	}
+	slog.Info("renaming channel", "id", id, "from", current, "to", want)
+
+	body, _ := json.Marshal(discordChannel{Name: want})
+	for attempt := 0; attempt < 2; attempt++ {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodPatch, discordAPI+"/channels/"+id, bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bot "+token)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", userAgent)
+		resp, err := c.Do(req)
+		if err != nil {
+			return err
+		}
+		// Drain & close so the connection can be reused on retry.
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		resp.Body.Close()
+
+		switch {
+		case resp.StatusCode >= 200 && resp.StatusCode < 300:
+			return nil
+		case resp.StatusCode == http.StatusTooManyRequests:
+			wait := parseRetryAfter(resp.Header.Get("Retry-After"))
+			if wait > maxRetryAfter {
+				return fmt.Errorf("discord 429: Retry-After=%s exceeds cap", wait)
+			}
+			slog.Warn("discord 429, sleeping", "wait", wait, "id", id)
+			select {
+			case <-time.After(wait):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		default:
+			return fmt.Errorf("discord PATCH HTTP %d: %s", resp.StatusCode, string(respBody))
+		}
+	}
+	return errors.New("discord 429: gave up after one retry")
+}
+
+// getChannelName fetches just the current channel's name. We rely on Discord
+// to return a JSON object; we only decode the one field we need.
+func getChannelName(ctx context.Context, c *http.Client, token, id string) (string, error) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, discordAPI+"/channels/"+id, nil)
+	req.Header.Set("Authorization", "Bot "+token)
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := c.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return "", fmt.Errorf("discord GET HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	var ch discordChannel
+	if err := json.NewDecoder(resp.Body).Decode(&ch); err != nil {
+		return "", fmt.Errorf("discord GET decode: %w", err)
+	}
+	return ch.Name, nil
+}
+
+// parseRetryAfter accepts either an integer seconds value (the form Discord
+// uses) or a float; fall back to 5s on any parse failure.
+func parseRetryAfter(v string) time.Duration {
+	if v == "" {
+		return 5 * time.Second
+	}
+	if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+		return time.Duration(f * float64(time.Second))
+	}
+	return 5 * time.Second
+}
+
+func mustEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		slog.Error("required env var missing", "key", key)
+		os.Exit(1)
+	}
+	return v
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -6,6 +6,7 @@
 //
 //	GET  /               — welcome page with logo and GitHub link
 //	GET  /stats          — public dashboard with version/OS/arch charts
+//	GET  /stats.json     — public JSON snapshot {active,total,latest} for bots
 //	POST /api/ping       — upsert install record, return latest version (rate-limited)
 //	GET  /api/stats      — active/total counts + version breakdown (token-gated)
 //	GET  /api/backup     — sqlite VACUUM INTO snapshot of installs DB (token-gated)
@@ -82,6 +83,15 @@ type statsResponse struct {
 	Versions  map[string]int `json:"versions"`
 }
 
+// statsJSON is the response shape for the public /stats.json endpoint. It
+// surfaces the three numbers the Discord stats bot (and any future scraper)
+// needs without requiring the full /api/stats token-gated payload.
+type statsJSON struct {
+	Active int    `json:"active"` // 30-day active install count
+	Total  int    `json:"total"`  // all-time install count
+	Latest string `json:"latest"` // latest released version, e.g. "v1.9.5"
+}
+
 func main() {
 	dbPath := env("DB_PATH", "/data/telemetry.db")
 	addr := env("ADDR", ":8080")
@@ -152,6 +162,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", s.handleHome)
 	mux.HandleFunc("GET /stats", s.handleStatsPage)
+	mux.HandleFunc("GET /stats.json", s.handleStatsJSON)
 	mux.HandleFunc("GET /stats/preview", s.handlePreviewPage)
 	mux.HandleFunc("POST /api/ping", s.handlePing)
 	mux.HandleFunc("GET /api/stats", s.handleStats)
@@ -636,6 +647,37 @@ func (s *server) handleStats(w http.ResponseWriter, r *http.Request) {
 		Total:     d.Total,
 		Versions:  versions,
 	})
+}
+
+// handleStatsJSON returns a small public JSON payload with active install
+// count, total install count, and the configured latest version. It does NOT
+// run the full computeStats pipeline (versions, OS, arch, longevity, etc.)
+// because callers like the Discord stats bot only need three numbers and hit
+// the endpoint every 10 minutes. The two COUNT(*) queries mirror the head of
+// computeStats — keeping them inline avoids dragging the heavy aggregation
+// path onto this hot, unauthenticated endpoint.
+func (s *server) handleStatsJSON(w http.ResponseWriter, r *http.Request) {
+	cutoff := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	var resp statsJSON
+	if err := s.db.QueryRowContext(r.Context(),
+		`SELECT COUNT(*) FROM installs WHERE last_seen >= ?`, cutoff,
+	).Scan(&resp.Active); err != nil {
+		slog.Error("stats.json: active count", "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if err := s.db.QueryRowContext(r.Context(),
+		`SELECT COUNT(*) FROM installs`,
+	).Scan(&resp.Total); err != nil {
+		slog.Error("stats.json: total count", "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	resp.Latest = s.latestVersion
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=60")
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // handleBackup streams a consistent snapshot of the installs database. Uses

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -1,8 +1,16 @@
 package main
 
 import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestIsReleaseVersion(t *testing.T) {
@@ -102,5 +110,75 @@ func TestRenderBarChartDoesNotMutateInput(t *testing.T) {
 	_ = renderBarChart(in, 8, "1.8.0")
 	if in[7].Label != "sha-dd31a9f" || in[8].Label != "1.8.0" {
 		t.Errorf("renderBarChart mutated caller's slice: %+v", in)
+	}
+}
+
+// newTestServer spins up an in-memory SQLite DB with the installs schema
+// matching the production migration, ready for handler tests.
+func newTestServer(t *testing.T, latest string) *server {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := db.ExecContext(context.Background(), `CREATE TABLE installs (
+		install_id  TEXT PRIMARY KEY,
+		version     TEXT NOT NULL,
+		os          TEXT NOT NULL,
+		arch        TEXT NOT NULL,
+		first_seen  DATETIME NOT NULL,
+		last_seen   DATETIME NOT NULL,
+		deploy      TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	return &server{db: db, latestVersion: latest}
+}
+
+func TestHandleStatsJSON(t *testing.T) {
+	s := newTestServer(t, "v1.9.5")
+	now := time.Now().UTC()
+	// Two recently-active installs and one stale (>30 days old) install.
+	rows := []struct {
+		id        string
+		firstSeen time.Time
+		lastSeen  time.Time
+	}{
+		{"11111111-1111-1111-1111-111111111111", now.Add(-40 * 24 * time.Hour), now.Add(-1 * time.Hour)},
+		{"22222222-2222-2222-2222-222222222222", now.Add(-5 * 24 * time.Hour), now.Add(-2 * 24 * time.Hour)},
+		{"33333333-3333-3333-3333-333333333333", now.Add(-90 * 24 * time.Hour), now.Add(-45 * 24 * time.Hour)}, // stale
+	}
+	for _, r := range rows {
+		if _, err := s.db.ExecContext(context.Background(),
+			`INSERT INTO installs (install_id, version, os, arch, first_seen, last_seen, deploy)
+			 VALUES (?, '1.9.5', 'linux', 'amd64', ?, ?, 'docker')`,
+			r.id, r.firstSeen, r.lastSeen); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/stats.json", nil)
+	rec := httptest.NewRecorder()
+	s.handleStatsJSON(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got statsJSON
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	if got.Active != 2 {
+		t.Errorf("Active = %d, want 2", got.Active)
+	}
+	if got.Total != 3 {
+		t.Errorf("Total = %d, want 3", got.Total)
+	}
+	if got.Latest != "v1.9.5" {
+		t.Errorf("Latest = %q, want v1.9.5", got.Latest)
 	}
 }

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,62 @@
+# Deploy manifests
+
+Auxiliary Kubernetes manifests applied outside the main Helm chart. The
+primary bindery app and telemetry/ping server are deployed through their
+own charts (`charts/bindery`) and the `bindery-ping` Deployment; manifests
+in this directory cover small companion services.
+
+## `discord-stats.yaml` — Discord stats voice channels
+
+A CronJob that runs every 10 minutes on the `hetz1` cluster in the
+`bindery-ping` namespace. It updates three Discord voice channels with live
+numbers:
+
+- `📊 Active: <30d-active install count>`
+- `📦 Latest: <latest released version>`
+- `⭐ Stars: <GitHub star count>`
+
+Telemetry data comes from `https://api.getbindery.dev/stats.json` (served by
+`cmd/telemetry-server`). Stars come from the public GitHub repo API
+(unauthenticated, well under the 60 req/hour limit at one call every 10 min).
+
+### Setup
+
+1. Create a Discord application at <https://discord.com/developers>, add a
+   Bot, and copy its token.
+2. Bot permissions: `Manage Channels` only (least privilege — the bot does
+   not need anything else).
+3. Add the bot to the bindery server using an OAuth URL with `bot` scope
+   and the `Manage Channels` permission.
+4. Create three voice channels in the server (e.g. `📊 Active`,
+   `📦 Latest`, `⭐ Stars` — the bot overwrites the names on first run).
+5. Get each channel's ID: Discord Settings → Advanced → enable Developer
+   Mode, then right-click each voice channel → Copy ID.
+6. Create the k8s secret holding the bot token and the three channel IDs:
+
+   ```bash
+   kubectl --context hetz1 -n bindery-ping create secret generic discord-stats \
+     --from-literal=bot_token=<TOKEN> \
+     --from-literal=active_channel_id=<ID> \
+     --from-literal=latest_channel_id=<ID> \
+     --from-literal=stars_channel_id=<ID>
+   ```
+
+7. Apply the manifest:
+
+   ```bash
+   kubectl --context hetz1 apply -f deploy/discord-stats.yaml
+   ```
+
+8. Force the first run (don't wait 10 min):
+
+   ```bash
+   kubectl --context hetz1 -n bindery-ping create job \
+     --from=cronjob/discord-stats discord-stats-manual
+   ```
+
+### Notes on rate limits
+
+Discord allows 2 channel renames per 10 minutes per channel. The cron is
+scheduled `*/10 * * * *` so we are never close to the cap; in addition, the
+bot reads the current name first and only PATCHes when it differs, so
+quiescent ticks cost zero renames.

--- a/deploy/discord-stats.yaml
+++ b/deploy/discord-stats.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: discord-stats
+  namespace: bindery-ping
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0  # do not retry on failure — next tick handles it
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: discord-stats
+              image: ghcr.io/vavallee/bindery-discord-stats:latest
+              imagePullPolicy: Always
+              env:
+                - name: DISCORD_BOT_TOKEN
+                  valueFrom:
+                    secretKeyRef: { name: discord-stats, key: bot_token }
+                - name: DISCORD_ACTIVE_CHANNEL_ID
+                  valueFrom:
+                    secretKeyRef: { name: discord-stats, key: active_channel_id }
+                - name: DISCORD_LATEST_CHANNEL_ID
+                  valueFrom:
+                    secretKeyRef: { name: discord-stats, key: latest_channel_id }
+                - name: DISCORD_STARS_CHANNEL_ID
+                  valueFrom:
+                    secretKeyRef: { name: discord-stats, key: stars_channel_id }
+              resources:
+                limits: { cpu: 100m, memory: 64Mi }
+                requests: { cpu: 10m, memory: 16Mi }
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 65532
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities: { drop: [ALL] }
+                seccompProfile: { type: RuntimeDefault }


### PR DESCRIPTION
## Summary

Three Discord voice channels in the bindery server that show live numbers as their channel name:

- 📊 Active: <30d active install count>
- 📦 Latest: <latest released version>
- ⭐ Stars: <GitHub star count>

A k8s CronJob updates them every 10 minutes via Discord's REST API. Powered by a new `/stats.json` endpoint on the telemetry server (which is also useful for any future structured integration).

## What's new

- `cmd/discord-stats/` — small Go binary (~230 LOC, stdlib only) that fetches the data and PATCHes the three voice channels. Reads current name first and skips the PATCH when it already matches, so quiescent ticks cost zero renames against Discord's 2/10min budget.
- `cmd/telemetry-server/main.go` — new `/stats.json` handler returning `{active, total, latest}`. Public (unauthenticated), uses two cheap `COUNT(*)` queries rather than running the full `computeStats` aggregation.
- `.github/workflows/discord-stats.yml` — multi-arch build pushed to `ghcr.io/vavallee/bindery-discord-stats:latest`.
- `deploy/discord-stats.yaml` — k8s CronJob (every 10 min) for the hetz1 cluster, namespace `bindery-ping`.
- `deploy/README.md` — 8-step setup checklist for the Discord bot token, channels, and k8s secret.

## Discord rate limit handling

- Cron is `*/10 * * * *` to match the 2-renames-per-10-min cap.
- Bot GETs current channel name before each PATCH — idempotent ticks cost zero renames.
- 429 responses are retried once after honouring `Retry-After` (capped at 30s). Anything beyond that, log a warning and let the next tick recover. Process exits 0 on partial failure.

## Test plan

- [x] `go build`, `go vet`, `gofmt -l cmd/`, `go test ./cmd/telemetry-server/` — clean
- [x] New unit test covers `/stats.json` against an in-memory SQLite DB with active vs. stale fixtures.
- [ ] Deploy: apply manifest + secret on hetz1, force first run, watch channel names update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)