### PR TITLE
feat(server): graceful SIGTERM/SIGINT shutdown with configurable drain (#559)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -9,8 +9,10 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -891,6 +893,16 @@ func main() {
 		slog.Info("serving under path prefix", "urlBase", cfg.URLBase)
 	}
 
+	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	gracePeriod := 30 * time.Second
+	if v := os.Getenv("BINDERY_SHUTDOWN_GRACE"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			gracePeriod = d
+		}
+	}
+
 	addr := ":" + cfg.Port
 	slog.Info("listening", "addr", addr)
 	srv := &http.Server{
@@ -901,9 +913,26 @@ func main() {
 		WriteTimeout:      120 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
-	if err := srv.ListenAndServe(); err != nil {
-		slog.Error("server failed", "error", err)
-		os.Exit(1)
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.ListenAndServe()
+	}()
+
+	select {
+	case err := <-serveErr:
+		if err != nil && err != http.ErrServerClosed {
+			slog.Error("server failed", "error", err)
+			os.Exit(1)
+		}
+	case <-sigCtx.Done():
+		slog.Info("received shutdown signal, draining…")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), gracePeriod)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			slog.Warn("server shutdown did not complete cleanly", "error", err)
+		}
+		slog.Info("shutdown complete")
 	}
 }
 

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -921,7 +922,7 @@ func main() {
 
 	select {
 	case err := <-serveErr:
-		if err != nil && err != http.ErrServerClosed {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			slog.Error("server failed", "error", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Summary

- Wires `signal.NotifyContext` for `SIGTERM`/`SIGINT` in `cmd/bindery/main.go`
- HTTP server drains in-flight requests via `srv.Shutdown(ctx)` with configurable grace period
- Background workers (cron scheduler, log handler) complete naturally via existing `defer` chains
- `BINDERY_SHUTDOWN_GRACE` env var controls grace period (default `30s`, parses as `time.Duration`)
- Logs "received shutdown signal, draining…" and "shutdown complete" on signal

Closes #559

## Test plan

- [ ] `go build ./...` clean
- [ ] `go test ./...` green
- [ ] `kubectl rollout restart deployment/bindery` in dev — no in-flight 502s during drain

🤖 Generated with [Claude Code](https://claude.ai/claude-code)