### PR TITLE
fix(downloader): add contextual hints to network test errors (#621)

### DIFF
--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 )
 
@@ -90,7 +91,7 @@ func (c *Client) Login(ctx context.Context) error {
 // the password is correct.
 func (c *Client) Test(ctx context.Context) error {
 	if err := c.ensureLoggedIn(ctx); err != nil {
-		return fmt.Errorf("could not reach Deluge at %s — %w (in Docker use the service/container name, not localhost)", c.baseURL, err)
+		return fmt.Errorf("could not reach Deluge at %s — %w%s", c.baseURL, err, nethint.ForErr(err))
 	}
 	return nil
 }

--- a/internal/downloader/deluge/client_test.go
+++ b/internal/downloader/deluge/client_test.go
@@ -3,11 +3,14 @@ package deluge_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -339,5 +342,87 @@ func TestAddTorrent_URL_HashLookupTimeout(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected ERROR log with 'timed out' message, got %d records", len(records))
+	}
+}
+
+// roundTripFunc is a test helper that implements http.RoundTripper via a function.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// delugeNetTimeoutErr is a minimal net.Error that signals a timeout.
+type delugeNetTimeoutErr struct{}
+
+func (e *delugeNetTimeoutErr) Error() string   { return "i/o timeout" }
+func (e *delugeNetTimeoutErr) Timeout() bool   { return true }
+func (e *delugeNetTimeoutErr) Temporary() bool { return true }
+
+// TestTest_DNSNotFound verifies that a DNS lookup failure on Deluge appends the
+// Docker network hint.
+func TestTest_DNSNotFound(t *testing.T) {
+	dnsErr := &net.DNSError{Name: "deluge-container", IsNotFound: true}
+	c := deluge.New("deluge-container", 8112, "pw", "", false)
+	c.SetHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("dial: %w", dnsErr)
+	}))
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "same Docker network") {
+		t.Errorf("expected Docker network hint, got: %q", err.Error())
+	}
+}
+
+// TestTest_ConnectionRefused verifies that ECONNREFUSED appends the port hint.
+func TestTest_ConnectionRefused(t *testing.T) {
+	c := deluge.New("127.0.0.1", 8112, "pw", "", false)
+	c.SetHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("dial tcp: %w", syscall.ECONNREFUSED)
+	}))
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "service may not be running") {
+		t.Errorf("expected port hint, got: %q", err.Error())
+	}
+}
+
+// TestTest_Timeout verifies that a timeout error appends the firewall hint.
+func TestTest_Timeout(t *testing.T) {
+	c := deluge.New("10.0.0.1", 8112, "pw", "", false)
+	c.SetHTTPTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, &delugeNetTimeoutErr{}
+	}))
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "firewall or proxy") {
+		t.Errorf("expected firewall hint, got: %q", err.Error())
+	}
+}
+
+// TestTest_ServerError_NoHint verifies that a server-side error (bad password,
+// HTTP 500, etc.) does NOT append any network hint.
+func TestTest_ServerError_NoHint(t *testing.T) {
+	srv, _ := newTestServer(t, "correct")
+	// Use the wrong password so the server rejects login (application error, not
+	// a transport failure).
+	c := clientFromServer(srv, "wrong")
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	for _, hint := range []string{"Docker network", "service may not be running", "firewall or proxy"} {
+		if strings.Contains(msg, hint) {
+			t.Errorf("server-side error must not produce hint %q; got: %q", hint, msg)
+		}
 	}
 }

--- a/internal/downloader/deluge/export_test.go
+++ b/internal/downloader/deluge/export_test.go
@@ -1,6 +1,9 @@
 package deluge
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 // HashPollTimeout exposes the package-level poll timeout for test overrides.
 var HashPollTimeout = &hashPollTimeout
@@ -11,4 +14,9 @@ func SetHashPollTimeout(d time.Duration) func() {
 	orig := hashPollTimeout
 	hashPollTimeout = d
 	return func() { hashPollTimeout = orig }
+}
+
+// SetHTTPTransport replaces the underlying http.Client transport for testing.
+func (c *Client) SetHTTPTransport(rt http.RoundTripper) {
+	c.http.Transport = rt
 }

--- a/internal/downloader/nethint/nethint.go
+++ b/internal/downloader/nethint/nethint.go
@@ -1,0 +1,44 @@
+// Package nethint classifies network errors and returns a short contextual
+// hint string to append to "could not reach …" messages shown to users.
+// The hints target the most common failure modes in Docker deployments.
+package nethint
+
+import (
+	"errors"
+	"net"
+	"syscall"
+)
+
+// ForErr inspects err and returns a hint string (with a leading space) that
+// can be appended directly to an error message. Returns an empty string when
+// the error does not match any known class.
+//
+// Classification priority (first match wins):
+//  1. net.DNSError with IsNotFound==true → Docker DNS hint
+//  2. syscall.ECONNREFUSED (or wrapped) → port-not-open hint
+//  3. net.Error with Timeout()==true → firewall/proxy hint
+func ForErr(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	// 1. DNS lookup failure — most likely a container name that isn't on the
+	//    same Docker network as Bindery.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+		return " (if using a container name, ensure both services are on the same Docker network)"
+	}
+
+	// 2. Connection refused — service is not listening on that port.
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return " (service may not be running on that port)"
+	}
+
+	// 3. Timeout — host is reachable but not responding (firewall, proxy, etc.).
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return " (host is reachable but not responding — check firewall or proxy)"
+	}
+
+	return ""
+}

--- a/internal/downloader/nethint/nethint_test.go
+++ b/internal/downloader/nethint/nethint_test.go
@@ -1,0 +1,73 @@
+package nethint_test
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/downloader/nethint"
+)
+
+func TestForErr_Nil(t *testing.T) {
+	if got := nethint.ForErr(nil); got != "" {
+		t.Errorf("ForErr(nil) = %q, want empty", got)
+	}
+}
+
+func TestForErr_DNSNotFound(t *testing.T) {
+	err := &net.DNSError{Name: "no-such-container", IsNotFound: true}
+	got := nethint.ForErr(err)
+	if got == "" {
+		t.Fatal("expected non-empty hint for DNS not-found error")
+	}
+	want := " (if using a container name, ensure both services are on the same Docker network)"
+	if got != want {
+		t.Errorf("ForErr(DNSNotFound) = %q, want %q", got, want)
+	}
+}
+
+// TestForErr_DNSTemporary verifies that a temporary DNS error (not IsNotFound)
+// does not produce the container-name hint — it may be a transient failure, not
+// a missing record.
+func TestForErr_DNSTemporary(t *testing.T) {
+	err := &net.DNSError{Name: "sabnzbd", IsNotFound: false, IsTimeout: true}
+	got := nethint.ForErr(err)
+	// Timeout DNS errors hit the timeout branch, not the DNS branch.
+	if got != "" && got != " (host is reachable but not responding — check firewall or proxy)" {
+		t.Errorf("ForErr(DNS timeout) = %q, want empty or timeout hint", got)
+	}
+}
+
+func TestForErr_ConnectionRefused(t *testing.T) {
+	err := fmt.Errorf("dial tcp: %w", syscall.ECONNREFUSED)
+	got := nethint.ForErr(err)
+	want := " (service may not be running on that port)"
+	if got != want {
+		t.Errorf("ForErr(ECONNREFUSED) = %q, want %q", got, want)
+	}
+}
+
+func TestForErr_Timeout(t *testing.T) {
+	err := &timeoutErr{}
+	got := nethint.ForErr(err)
+	want := " (host is reachable but not responding — check firewall or proxy)"
+	if got != want {
+		t.Errorf("ForErr(timeout) = %q, want %q", got, want)
+	}
+}
+
+func TestForErr_GenericError(t *testing.T) {
+	err := fmt.Errorf("HTTP 500: internal server error")
+	got := nethint.ForErr(err)
+	if got != "" {
+		t.Errorf("ForErr(generic) = %q, want empty", got)
+	}
+}
+
+// timeoutErr is a minimal net.Error that signals a timeout.
+type timeoutErr struct{}
+
+func (e *timeoutErr) Error() string   { return "i/o timeout" }
+func (e *timeoutErr) Timeout() bool   { return true }
+func (e *timeoutErr) Temporary() bool { return true }

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 )
 
@@ -44,7 +45,7 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 func (c *Client) Test(ctx context.Context) error {
 	var resp versionResponse
 	if err := c.call(ctx, "version", nil, &resp); err != nil {
-		return fmt.Errorf("could not reach NZBGet at %s — %w (in Docker use the service/container name, not localhost)", c.baseURL, err)
+		return fmt.Errorf("could not reach NZBGet at %s — %w%s", c.baseURL, err, nethint.ForErr(err))
 	}
 	if resp.Result == "" {
 		return fmt.Errorf("NZBGet returned empty version — check credentials")

--- a/internal/downloader/nzbget/client_test.go
+++ b/internal/downloader/nzbget/client_test.go
@@ -3,10 +3,14 @@ package nzbget
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -331,5 +335,96 @@ func TestBasicAuth(t *testing.T) {
 	}
 	if gotUser != "admin" || gotPass != "secret" {
 		t.Errorf("expected admin/secret, got %q/%q", gotUser, gotPass)
+	}
+}
+
+// roundTripFunc is a test helper that implements http.RoundTripper via a function.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// netTimeoutErr is a minimal net.Error that signals a timeout.
+type netTimeoutErr struct{}
+
+func (e *netTimeoutErr) Error() string   { return "i/o timeout" }
+func (e *netTimeoutErr) Timeout() bool   { return true }
+func (e *netTimeoutErr) Temporary() bool { return true }
+
+// TestTest_DNSNotFound verifies that a DNS lookup failure appends the Docker
+// network hint.
+func TestTest_DNSNotFound(t *testing.T) {
+	dnsErr := &net.DNSError{Name: "nzbget-container", IsNotFound: true}
+	c := New("nzbget-container", 6789, "u", "p", "", false)
+	c.http = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("dial: %w", dnsErr)
+		}),
+	}
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "same Docker network") {
+		t.Errorf("expected Docker network hint, got: %q", err.Error())
+	}
+}
+
+// TestTest_ConnectionRefused verifies that ECONNREFUSED appends the port hint.
+func TestTest_ConnectionRefused(t *testing.T) {
+	c := New("127.0.0.1", 6789, "u", "p", "", false)
+	c.http = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("dial tcp: %w", syscall.ECONNREFUSED)
+		}),
+	}
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "service may not be running") {
+		t.Errorf("expected port hint, got: %q", err.Error())
+	}
+}
+
+// TestTest_Timeout verifies that a timeout error appends the firewall hint.
+func TestTest_Timeout(t *testing.T) {
+	c := New("10.0.0.1", 6789, "u", "p", "", false)
+	c.http = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, &netTimeoutErr{}
+		}),
+	}
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "firewall or proxy") {
+		t.Errorf("expected firewall hint, got: %q", err.Error())
+	}
+}
+
+// TestTest_ServerError_NoHint verifies that a clean HTTP 500 does NOT append
+// any network hint (it's a server-side error, not a transport failure).
+func TestTest_ServerError_NoHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", "", false)
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	for _, hint := range []string{"Docker network", "service may not be running", "firewall or proxy"} {
+		if strings.Contains(msg, hint) {
+			t.Errorf("clean server error must not produce hint %q; got: %q", hint, msg)
+		}
 	}
 }

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 )
 
@@ -136,7 +137,7 @@ func (c *Client) Login(ctx context.Context) error {
 // Test verifies connectivity by fetching the application version. The error
 // wording adapts to the failure mode: auth/config issues (the server
 // responded but rejected us) get a targeted hint; transport failures (the
-// server didn't respond at all) get the Docker-networking hint.
+// server didn't respond at all) get a hint based on the error class.
 func (c *Client) Test(ctx context.Context) error {
 	if _, err := c.get(ctx, "/api/v2/app/version"); err != nil {
 		var authErr *AuthError
@@ -144,7 +145,7 @@ func (c *Client) Test(ctx context.Context) error {
 			// Server responded — this is an auth/config issue, not unreachable.
 			return fmt.Errorf("connected to qBittorrent at %s but %w", c.baseURL, err)
 		}
-		return fmt.Errorf("could not reach qBittorrent at %s — %w (in Docker use the service/container name, not localhost)", c.baseURL, err)
+		return fmt.Errorf("could not reach qBittorrent at %s — %w%s", c.baseURL, err, nethint.ForErr(err))
 	}
 	return nil
 }

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -807,5 +810,101 @@ func TestAddTorrent_HashLookupTimeout(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected ERROR log with 'timed out' message, got %d records", len(records))
+	}
+}
+
+// roundTripFunc is a test helper that implements http.RoundTripper via a function.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// qbNetTimeoutErr is a minimal net.Error that signals a timeout.
+type qbNetTimeoutErr struct{}
+
+func (e *qbNetTimeoutErr) Error() string   { return "i/o timeout" }
+func (e *qbNetTimeoutErr) Timeout() bool   { return true }
+func (e *qbNetTimeoutErr) Temporary() bool { return true }
+
+// newTransportClient creates a qBittorrent Client with a custom HTTP transport.
+func newTransportClient(transport http.RoundTripper) *Client {
+	c := New("fake-host", 8080, "admin", "pass", "", false)
+	c.http = &http.Client{Transport: transport, Jar: c.http.Jar}
+	return c
+}
+
+// TestTest_DNSNotFound verifies that a DNS lookup failure appends the Docker
+// network hint and does NOT misclassify it as an auth error.
+func TestTest_DNSNotFound(t *testing.T) {
+	dnsErr := &net.DNSError{Name: "qbittorrent-container", IsNotFound: true}
+	c := newTransportClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("dial: %w", dnsErr)
+	}))
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "connected to qBittorrent") {
+		t.Errorf("DNS failure must not be reported as auth error: %q", msg)
+	}
+	if !strings.Contains(msg, "same Docker network") {
+		t.Errorf("expected Docker network hint, got: %q", msg)
+	}
+}
+
+// TestTest_ConnectionRefused verifies that ECONNREFUSED appends the port hint.
+func TestTest_ConnectionRefused(t *testing.T) {
+	c := newTransportClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("dial tcp: %w", syscall.ECONNREFUSED)
+	}))
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "service may not be running") {
+		t.Errorf("expected port hint, got: %q", err.Error())
+	}
+}
+
+// TestTest_Timeout_QBit verifies that a timeout error appends the firewall hint.
+func TestTest_Timeout_QBit(t *testing.T) {
+	c := newTransportClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, &qbNetTimeoutErr{}
+	}))
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "firewall or proxy") {
+		t.Errorf("expected firewall hint, got: %q", err.Error())
+	}
+}
+
+// TestTest_ServerError_NoHint_QBit verifies that an HTTP 500 from the server
+// does NOT produce a network hint (qBittorrent responded, transport worked).
+func TestTest_ServerError_NoHint_QBit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		default:
+			http.Error(w, "server error", http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	for _, hint := range []string{"Docker network", "service may not be running", "firewall or proxy"} {
+		if strings.Contains(msg, hint) {
+			t.Errorf("server error must not produce hint %q; got: %q", hint, msg)
+		}
 	}
 }

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 )
 
@@ -38,7 +39,7 @@ func New(host string, port int, apiKey, urlBase string, useSSL bool) *Client {
 // Test verifies connectivity by fetching categories.
 func (c *Client) Test(ctx context.Context) error {
 	if _, err := c.GetCategories(ctx); err != nil {
-		return fmt.Errorf("could not reach SABnzbd at %s — %w (in Docker use the service/container name, not localhost)", c.baseURL, err)
+		return fmt.Errorf("could not reach SABnzbd at %s — %w%s", c.baseURL, err, nethint.ForErr(err))
 	}
 	return nil
 }

--- a/internal/downloader/sabnzbd/client_test.go
+++ b/internal/downloader/sabnzbd/client_test.go
@@ -3,8 +3,12 @@ package sabnzbd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -183,3 +187,96 @@ func TestTest(t *testing.T) {
 		t.Errorf("test should pass: %v", err)
 	}
 }
+
+// roundTripFunc is a test helper that implements http.RoundTripper via a function.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// TestTest_DNSNotFound verifies that a DNS lookup failure appends the Docker
+// network hint.
+func TestTest_DNSNotFound(t *testing.T) {
+	dnsErr := &net.DNSError{Name: "sabnzbd-container", IsNotFound: true}
+	c := New("sabnzbd-container", 8080, "key", "", false)
+	c.http = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("dial: %w", dnsErr)
+		}),
+	}
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "same Docker network") {
+		t.Errorf("expected Docker network hint, got: %q", msg)
+	}
+}
+
+// TestTest_ConnectionRefused verifies that ECONNREFUSED appends the port hint.
+func TestTest_ConnectionRefused(t *testing.T) {
+	c := New("127.0.0.1", 8080, "key", "", false)
+	c.http = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("dial tcp: %w", syscall.ECONNREFUSED)
+		}),
+	}
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "service may not be running") {
+		t.Errorf("expected port hint, got: %q", msg)
+	}
+}
+
+// TestTest_Timeout verifies that a timeout error appends the firewall hint.
+func TestTest_Timeout(t *testing.T) {
+	c := New("10.0.0.1", 8080, "key", "", false)
+	c.http = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, &netTimeoutErr{}
+		}),
+	}
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "firewall or proxy") {
+		t.Errorf("expected firewall hint, got: %q", msg)
+	}
+}
+
+// TestTest_ServerError verifies that a clean HTTP 500 does NOT append any hint.
+func TestTest_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := New("127.0.0.1", 0, "testkey", "", false)
+	c.baseURL = srv.URL
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	for _, hint := range []string{"Docker network", "service may not be running", "firewall or proxy"} {
+		if strings.Contains(msg, hint) {
+			t.Errorf("clean server error must not produce hint %q; got: %q", hint, msg)
+		}
+	}
+}
+
+// netTimeoutErr is a minimal net.Error that signals a timeout.
+type netTimeoutErr struct{}
+
+func (e *netTimeoutErr) Error() string   { return "i/o timeout" }
+func (e *netTimeoutErr) Timeout() bool   { return true }
+func (e *netTimeoutErr) Temporary() bool { return true }

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 )
 
@@ -68,8 +69,13 @@ func (c *Client) Test(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	_, err = c.doRequest(req)
-	return err
+	if _, err = c.doRequest(req); err != nil {
+		if hint := nethint.ForErr(err); hint != "" {
+			return fmt.Errorf("could not reach Transmission at %s — %w%s", c.baseURL, err, hint)
+		}
+		return err
+	}
+	return nil
 }
 
 // AddTorrent submits a magnet link or torrent URL to Transmission for download.

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -2,9 +2,13 @@ package transmission
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -360,5 +364,101 @@ func TestDoRequest_RejectsRedirectToDifferentTarget(t *testing.T) {
 	}
 	if redirected {
 		t.Fatal("unexpectedly followed redirect to different target")
+	}
+}
+
+// roundTripFunc is a test helper that implements http.RoundTripper via a function.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// netTimeoutErr is a minimal net.Error that signals a timeout.
+type netTimeoutErr struct{}
+
+func (e *netTimeoutErr) Error() string   { return "i/o timeout" }
+func (e *netTimeoutErr) Timeout() bool   { return true }
+func (e *netTimeoutErr) Temporary() bool { return true }
+
+// newTransportClient creates a test Client with a custom HTTP transport.
+// Unlike newTestClient, this does not short-circuit via a real server URL —
+// the transport is responsible for all responses.
+func newTransportClient(transport http.RoundTripper) *Client {
+	c := New("fake-host", 9091, "", "", "", false)
+	parsed, _ := url.Parse("http://fake-host:9091/transmission/rpc")
+	c.rpcURL = parsed
+	c.baseURL = parsed.String()
+	c.http = &http.Client{Transport: transport}
+	// CheckRedirect was set in New(); replace http.Client entirely so we keep
+	// the CheckRedirect behaviour by setting it again.
+	c.http.CheckRedirect = c.checkRedirect
+	return c
+}
+
+// TestTest_DNSNotFound verifies that a DNS lookup failure appends the Docker
+// network hint.
+func TestTest_DNSNotFound(t *testing.T) {
+	dnsErr := &net.DNSError{Name: "transmission-container", IsNotFound: true}
+	c := newTransportClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("dial: %w", dnsErr)
+	}))
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "same Docker network") {
+		t.Errorf("expected Docker network hint, got: %q", err.Error())
+	}
+}
+
+// TestTest_ConnectionRefused verifies that ECONNREFUSED appends the port hint.
+func TestTest_ConnectionRefused(t *testing.T) {
+	c := newTransportClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("dial tcp: %w", syscall.ECONNREFUSED)
+	}))
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "service may not be running") {
+		t.Errorf("expected port hint, got: %q", err.Error())
+	}
+}
+
+// TestTest_Timeout verifies that a timeout error appends the firewall hint.
+func TestTest_Timeout(t *testing.T) {
+	c := newTransportClient(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, &netTimeoutErr{}
+	}))
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "firewall or proxy") {
+		t.Errorf("expected firewall hint, got: %q", err.Error())
+	}
+}
+
+// TestTest_ServerError_NoHint verifies that a clean HTTP 500 does NOT append
+// any network hint.
+func TestTest_ServerError_NoHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	for _, hint := range []string{"Docker network", "service may not be running", "firewall or proxy"} {
+		if strings.Contains(msg, hint) {
+			t.Errorf("clean server error must not produce hint %q; got: %q", hint, msg)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Created shared `internal/downloader/nethint` package: classifies network errors (DNS not-found, connection refused, timeout) and returns a contextual hint string
- SABnzbd, NZBGet, Deluge, Transmission, qBittorrent: replaced static Docker-only hint with dynamic per-error hint
- DNS not-found → "if using a container name, ensure both services are on the same Docker network"
- Connection refused → "service may not be running on that port"
- Timeout → "host is reachable but not responding — check firewall or proxy"
- Other errors (HTTP 5xx, auth fail) → no hint appended

Closes #621

## Test plan

- [ ] `go test ./internal/downloader/...` — all pass
- [ ] `go build ./...` clean
- [ ] Manual: test-connection with a bogus container name → contextual hint visible

🤖 Generated with [Claude Code](https://claude.ai/claude-code)