### PR TITLE
fix(ui): roll back WantedPage optimistic updates on API failure (#551)

### DIFF
--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useMemo } from 'react'
+import { useEffect, useRef, useState, useMemo, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { api, Book, SearchResult } from '../api/client'
@@ -21,6 +21,7 @@ export default function WantedPage() {
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
   const [bulkBusy, setBulkBusy] = useState(false)
   const [showExcluded, setShowExcluded] = useState(false)
+  const [toast, setToast] = useState<string | null>(null)
   const selectAllRef = useRef<HTMLInputElement>(null)
 
   const load = () => {
@@ -30,6 +31,14 @@ export default function WantedPage() {
   useEffect(() => {
     load()
   }, [showExcluded])
+
+  useEffect(() => {
+    if (!toast) return
+    const timer = setTimeout(() => setToast(null), 2500)
+    return () => clearTimeout(timer)
+  }, [toast])
+
+  const showToast = useCallback((msg: string) => { setToast(msg) }, [])
 
   const filtered = useMemo(() => {
     if (!search.trim()) return books
@@ -64,11 +73,13 @@ export default function WantedPage() {
 
   const unmonitor = async (book: Book) => {
     setUnmonitoringId(book.id)
+    const prev = books
+    setBooks(books.filter(b => b.id !== book.id))
     try {
       await api.updateBook(book.id, { monitored: false })
-      setBooks(books.filter(b => b.id !== book.id))
-    } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to unmonitor')
+    } catch {
+      setBooks(prev)
+      showToast("Couldn't update wanted list — reverted.")
     } finally {
       setUnmonitoringId(null)
     }
@@ -149,6 +160,11 @@ export default function WantedPage() {
 
   return (
     <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
+      {toast && (
+        <div className="fixed bottom-6 right-6 z-50 px-4 py-2.5 bg-red-600 text-white rounded-lg shadow-lg text-sm font-medium animate-fade-in">
+          {toast}
+        </div>
+      )}
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-bold">{t('wanted.title')}</h2>
         <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary

- Converted the `unmonitor` optimistic update in WantedPage to capture pre-update state before mutating
- On API failure: restores pre-update state and shows a red toast ("Couldn't update wanted list — reverted.")
- Toast follows the existing `useEffect`/`setTimeout` dismiss pattern from DiscoverPage

Closes #551

## Test plan

- [ ] `npm run build` clean
- [ ] Force a 500 from the wanted API in dev → state reverts, toast appears

🤖 Generated with [Claude Code](https://claude.ai/claude-code)