### PR TITLE
feat(release): auto-bump bindery-ping LATEST_VERSION on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Bump bindery-ping LATEST_VERSION
+        if: ${{ secrets.HETZ1_KUBECONFIG != '' }}
+        env:
+          KUBECONFIG_B64: ${{ secrets.HETZ1_KUBECONFIG }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          echo "$KUBECONFIG_B64" | base64 -d > /tmp/kc
+          KUBECONFIG=/tmp/kc kubectl -n bindery-ping set env deployment/bindery-ping \
+            LATEST_VERSION="$VERSION"
+          rm -f /tmp/kc
+
   # Pinned ABS compatibility suite. Runs self-contained against the
   # repository's seeded Phase 6 fixture harness and can optionally target a
   # real pinned ABS instance when the env vars below are provided.


### PR DESCRIPTION
## Summary

- After a `v*` release tag, automatically updates the `LATEST_VERSION` env var on the `bindery-ping` deployment in the `bindery-ping` namespace via kubectl
- Eliminates the manual `auto/prod-deploy-X.Y.Z` PR + kubectl step after each release
- Gated by `secrets.HETZ1_KUBECONFIG` — no-ops silently if the secret isn't set, so the workflow remains safe on forks

## Prerequisites

Add `HETZ1_KUBECONFIG` as a GitHub Actions secret (base64-encoded kubeconfig for the hetz1 cluster).

## Test plan

- [ ] Add `HETZ1_KUBECONFIG` secret to GitHub repo settings
- [ ] Tag a release and verify the `goreleaser` job's new step updates `LATEST_VERSION` on hetz1
- [ ] Confirm `api.getbindery.dev/stats` shows the new version without manual intervention

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)