### PR TITLE
fix(ui): add delete button to backup list

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -387,6 +387,7 @@ export const api = {
   // Backup
   listBackups: () => request<Array<{ name: string; size: number; modTime: string }>>('/backup'),
   createBackup: () => request<{ name: string; size: number; modTime: string }>('/backup', { method: 'POST' }),
+  deleteBackup: (filename: string) => request<void>(`/backup/${encodeURIComponent(filename)}`, { method: 'DELETE' }),
 
   // Calibre
   testCalibre: () => request<CalibreTestResult>('/calibre/test', { method: 'POST' }),

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -67,6 +67,7 @@ vi.mock('../api/client', async importOriginal => {
       testHardcover: vi.fn(),
       triggerLibraryScan: vi.fn(),
       createBackup: vi.fn(),
+      deleteBackup: vi.fn(),
       addRootFolder: vi.fn(),
       authConfig: vi.fn(),
       authSetMode: vi.fn(),
@@ -186,6 +187,7 @@ function seedSettingsMocks(options: {
     vi.mocked(api.setSetting).mockResolvedValue(undefined)
     vi.mocked(api.triggerLibraryScan).mockResolvedValue({ message: 'started' })
     vi.mocked(api.createBackup).mockResolvedValue({ name: 'bindery-backup.zip', size: 0, modTime: '' })
+    vi.mocked(api.deleteBackup).mockResolvedValue(undefined)
     vi.mocked(api.addRootFolder).mockImplementation(async path => makeRootFolder({ id: 99, path }))
     vi.mocked(api.testHardcover).mockResolvedValue({
       ok: true,
@@ -965,6 +967,25 @@ describe('SettingsPage', () => {
       await waitFor(() => expect(screen.queryByText('Client Actions')).not.toBeInTheDocument())
     } finally {
       alertSpy.mockRestore()
+    }
+  })
+
+  it('deletes a backup from the list', async () => {
+    const backup = { name: 'bindery_20260513_120000.db', size: 1024 * 512, modTime: new Date().toISOString() }
+    vi.mocked(api.listBackups).mockResolvedValue([backup])
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    try {
+      renderSettings()
+
+      expect(await screen.findByText(backup.name)).toBeInTheDocument()
+
+      const deleteBtn = screen.getByRole('button', { name: 'common.delete' })
+      fireEvent.click(deleteBtn)
+
+      await waitFor(() => expect(api.deleteBackup).toHaveBeenCalledWith(backup.name))
+      await waitFor(() => expect(screen.queryByText(backup.name)).not.toBeInTheDocument())
+    } finally {
+      confirmSpy.mockRestore()
     }
   })
 })

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -2381,6 +2381,7 @@ function GeneralTab() {
   const [saving, setSaving] = useState<string | null>(null)
   const [backups, setBackups] = useState<Array<{ name: string; size: number; modTime: string }>>([])
   const [creatingBackup, setCreatingBackup] = useState(false)
+  const [deletingBackup, setDeletingBackup] = useState<string | null>(null)
   const [scanningLibrary, setScanningLibrary] = useState(false)
   const [scanMessage, setScanMessage] = useState<string | null>(null)
   const scanStartedAt = useRef<number>(0)
@@ -2511,6 +2512,19 @@ function GeneralTab() {
       alert('Backup failed: ' + (err instanceof Error ? err.message : 'Unknown error'))
     } finally {
       setCreatingBackup(false)
+    }
+  }
+
+  const handleDeleteBackup = async (filename: string) => {
+    if (!confirm(`Delete backup ${filename}?`)) return
+    setDeletingBackup(filename)
+    try {
+      await api.deleteBackup(filename)
+      setBackups(prev => prev.filter(b => b.name !== filename))
+    } catch (err) {
+      alert('Delete failed: ' + (err instanceof Error ? err.message : 'Unknown error'))
+    } finally {
+      setDeletingBackup(null)
     }
   }
 
@@ -3178,9 +3192,18 @@ function GeneralTab() {
               <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">{t('settings.general.existingBackups')}</p>
               <ul className="space-y-1">
                 {backups.map(b => (
-                  <li key={b.name} className="text-xs text-slate-600 dark:text-zinc-400">
-                    <span className="font-mono">{b.name}</span>
-                    <span className="ml-2 text-slate-500 dark:text-zinc-500">{formatBackupSize(b.size)} · {formatRelativeTime(b.modTime)}</span>
+                  <li key={b.name} className="flex items-center justify-between text-xs text-slate-600 dark:text-zinc-400">
+                    <span>
+                      <span className="font-mono">{b.name}</span>
+                      <span className="ml-2 text-slate-500 dark:text-zinc-500">{formatBackupSize(b.size)} · {formatRelativeTime(b.modTime)}</span>
+                    </span>
+                    <button
+                      onClick={() => handleDeleteBackup(b.name)}
+                      disabled={deletingBackup === b.name}
+                      className="ml-4 text-red-600 dark:text-red-400 hover:underline disabled:opacity-50"
+                    >
+                      {deletingBackup === b.name ? '…' : t('common.delete')}
+                    </button>
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary

Closes #637.

`DELETE /api/v1/backup/{filename}` was already implemented and routed but never surfaced in the UI. Backup list items rendered as read-only — name, size, and age — with no way to remove obsolete entries.

- `api/client.ts`: add `deleteBackup(filename)`
- `SettingsPage`: `deletingBackup` state + `handleDeleteBackup` (confirm → call API → remove row); button disabled while in-flight
- `SettingsPage.test`: confirm → API call → row removed from DOM

## Test plan

- [ ] Create 2–3 backups, confirm each appears in the list
- [ ] Click Delete on one, confirm browser prompt, verify row disappears
- [ ] Dismiss the confirm prompt, verify nothing is deleted
- [ ] Verify Delete button shows `…` while request is in-flight (network throttle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)