### PR TITLE
fix(qbittorrent): fetch torrent content in Bindery, submit via multipart

### DIFF
--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -3,12 +3,14 @@
 package qbittorrent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -58,13 +60,14 @@ var hashPollTimeout = 30 * time.Second
 //   - APIKey  → password  (qBittorrent uses username/password, not an API key)
 //   - URLBase → reverse-proxy subpath, appended to baseURL (#369)
 type Client struct {
-	baseURL  string
-	username string
-	password string
-	http     *http.Client
-	mu       sync.Mutex // guards loggedIn
-	addMu    sync.Mutex // serialises AddTorrent: keeps before/after hash diff atomic
-	loggedIn bool
+	baseURL   string
+	username  string
+	password  string
+	http      *http.Client
+	fetchHTTP *http.Client // fetches .torrent file content on behalf of qBittorrent
+	mu        sync.Mutex  // guards loggedIn
+	addMu     sync.Mutex  // serialises AddTorrent: keeps before/after hash diff atomic
+	loggedIn  bool
 }
 
 // New creates a qBittorrent client. urlBase is the optional reverse-proxy
@@ -78,6 +81,7 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 
 	jar, _ := cookiejar.New(nil)
 	return &Client{
+		fetchHTTP: &http.Client{Timeout: 60 * time.Second},
 		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
 		username: username,
 		password: password,
@@ -176,25 +180,60 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 		}
 	}
 
-	form := url.Values{"urls": {magnetOrURL}}
-	if category != "" {
-		form.Set("category", category)
-	}
-	if savePath != "" {
-		form.Set("savepath", savePath)
-	}
-
 	if err := c.ensureLoggedIn(ctx); err != nil {
 		return "", err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		c.baseURL+"/api/v2/torrents/add",
-		strings.NewReader(form.Encode()))
-	if err != nil {
-		return "", fmt.Errorf("build add request: %w", err)
+	var req *http.Request
+	if strings.HasPrefix(magnetOrURL, "http://") || strings.HasPrefix(magnetOrURL, "https://") {
+		// Fetch the .torrent content in Bindery so qBittorrent never needs to
+		// reach the indexer URL directly (which may be a Docker-only hostname
+		// like prowlarr:9696 that qBittorrent can't resolve from its network).
+		content, err := c.fetchTorrentContent(magnetOrURL)
+		if err != nil {
+			return "", fmt.Errorf("fetch torrent content: %w", err)
+		}
+
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		fw, err := mw.CreateFormFile("torrents", "upload.torrent")
+		if err != nil {
+			return "", fmt.Errorf("build multipart: %w", err)
+		}
+		if _, err := fw.Write(content); err != nil {
+			return "", fmt.Errorf("write torrent content: %w", err)
+		}
+		if category != "" {
+			_ = mw.WriteField("category", category)
+		}
+		if savePath != "" {
+			_ = mw.WriteField("savepath", savePath)
+		}
+		mw.Close()
+
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost,
+			c.baseURL+"/api/v2/torrents/add", &buf)
+		if err != nil {
+			return "", fmt.Errorf("build add request: %w", err)
+		}
+		req.Header.Set("Content-Type", mw.FormDataContentType())
+	} else {
+		form := url.Values{"urls": {magnetOrURL}}
+		if category != "" {
+			form.Set("category", category)
+		}
+		if savePath != "" {
+			form.Set("savepath", savePath)
+		}
+		var err error
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost,
+			c.baseURL+"/api/v2/torrents/add",
+			strings.NewReader(form.Encode()))
+		if err != nil {
+			return "", fmt.Errorf("build add request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -286,6 +325,20 @@ func infoHashFromMagnet(raw string) string {
 		return ""
 	}
 	return strings.ToLower(h)
+}
+
+// fetchTorrentContent downloads a .torrent file URL and returns its raw bytes.
+// It limits the response to 50 MiB to guard against runaway reads.
+func (c *Client) fetchTorrentContent(rawURL string) ([]byte, error) {
+	resp, err := c.fetchHTTP.Get(rawURL) //nolint:noctx
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("indexer returned HTTP %d", resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 50<<20))
 }
 
 // GetTorrents returns all torrents in the given category (empty = all).

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -15,6 +16,21 @@ import (
 	"testing"
 	"time"
 )
+
+// fakeTorrentContent is minimal bencoded content used across tests.
+const fakeTorrentContent = "d8:announce27:http://tracker.example.com/ae"
+
+// newFakeIndexer returns a test server that serves fakeTorrentContent at /torrent.
+func newFakeIndexer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/torrent" {
+			_, _ = w.Write([]byte(fakeTorrentContent))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
 
 // TestAddTorrent_ConcurrentUniqueHashes is a regression test for Bug 2.
 // When AddTorrent is called concurrently (e.g. during a bulk grab), each call
@@ -63,6 +79,9 @@ func TestAddTorrent_ConcurrentUniqueHashes(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	indexer := newFakeIndexer(t)
+	defer indexer.Close()
+
 	c := newTestClient(srv.URL, "admin", "pass")
 	c.loggedIn = true
 
@@ -77,7 +96,7 @@ func TestAddTorrent_ConcurrentUniqueHashes(t *testing.T) {
 			defer wg.Done()
 			results[i], errs[i] = c.AddTorrent(
 				context.Background(),
-				"http://example.com/book.torrent",
+				indexer.URL+"/torrent",
 				"", "",
 			)
 		}()
@@ -452,6 +471,158 @@ func TestAddTorrent_HTTPError(t *testing.T) {
 	}
 }
 
+// TestAddTorrent_TorrentURL_SubmitsMultipart verifies that an http URL causes
+// Bindery to fetch the torrent content and submit it via multipart rather than
+// passing the URL to qBittorrent (which may not be able to reach the indexer).
+func TestAddTorrent_TorrentURL_SubmitsMultipart(t *testing.T) {
+	var gotMultipart bool
+	var gotTorrentContent []byte
+	var mu sync.Mutex
+	added := false
+
+	indexer := newFakeIndexer(t)
+	defer indexer.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			ct := r.Header.Get("Content-Type")
+			if strings.HasPrefix(ct, "multipart/form-data") {
+				gotMultipart = true
+				mr, err := r.MultipartReader()
+				if err != nil {
+					t.Errorf("parse multipart: %v", err)
+					break
+				}
+				for {
+					part, err := mr.NextPart()
+					if err == io.EOF {
+						break
+					}
+					if err != nil {
+						t.Errorf("next part: %v", err)
+						break
+					}
+					if part.FormName() == "torrents" {
+						gotTorrentContent, _ = io.ReadAll(part)
+					}
+				}
+			}
+			mu.Lock()
+			added = true
+			mu.Unlock()
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			mu.Lock()
+			isAdded := added
+			mu.Unlock()
+			if isAdded {
+				_, _ = w.Write([]byte(`[{"hash":"aabbccdd","name":"test","added_on":1000}]`))
+			} else {
+				_, _ = w.Write([]byte("[]"))
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	if _, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "", ""); err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if !gotMultipart {
+		t.Error("expected multipart/form-data submission for http URL, got url-encoded form")
+	}
+	if string(gotTorrentContent) != fakeTorrentContent {
+		t.Errorf("torrent content: want %q, got %q", fakeTorrentContent, string(gotTorrentContent))
+	}
+}
+
+// TestAddTorrent_TorrentURL_WithCategoryAndSavePath verifies that category and
+// savepath are included in the multipart body when submitting a torrent URL.
+func TestAddTorrent_TorrentURL_WithCategoryAndSavePath(t *testing.T) {
+	var gotCategory, gotSavePath string
+	var mu sync.Mutex
+	added := false
+
+	indexer := newFakeIndexer(t)
+	defer indexer.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			if err := r.ParseMultipartForm(1 << 20); err == nil {
+				gotCategory = r.FormValue("category")
+				gotSavePath = r.FormValue("savepath")
+			}
+			mu.Lock()
+			added = true
+			mu.Unlock()
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			mu.Lock()
+			isAdded := added
+			mu.Unlock()
+			if isAdded {
+				_, _ = w.Write([]byte(`[{"hash":"aabbccdd","name":"test","added_on":1000}]`))
+			} else {
+				_, _ = w.Write([]byte("[]"))
+			}
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	if _, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "books", "/downloads"); err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if gotCategory != "books" {
+		t.Errorf("category: want %q, got %q", "books", gotCategory)
+	}
+	if gotSavePath != "/downloads" {
+		t.Errorf("savepath: want %q, got %q", "/downloads", gotSavePath)
+	}
+}
+
+// TestAddTorrent_TorrentURL_FetchFailure verifies that a non-200 from the
+// indexer is returned as an error and qBittorrent is never contacted.
+func TestAddTorrent_TorrentURL_FetchFailure(t *testing.T) {
+	qbitCalled := false
+
+	indexer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer indexer.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			qbitCalled = true
+			_, _ = w.Write([]byte("Ok."))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	_, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "", "")
+	if err == nil {
+		t.Fatal("expected error when indexer returns 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error should mention 401, got: %v", err)
+	}
+	if qbitCalled {
+		t.Error("qBittorrent should not be contacted when torrent fetch fails")
+	}
+}
+
 func TestGetTorrents_Success(t *testing.T) {
 	want := []Torrent{
 		{Hash: "abc123", Name: "My Book", Size: 1024, Progress: 0.5, State: "downloading", Category: "books"},
@@ -729,8 +900,11 @@ func TestAddTorrent_HashFoundUnderDifferentCategory(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	indexer := newFakeIndexer(t)
+	defer indexer.Close()
+
 	c := newTestClient(srv.URL, "admin", "pass")
-	hash, err := c.AddTorrent(context.Background(), "http://example.com/book.torrent", "books", "")
+	hash, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "books", "")
 	if err != nil {
 		t.Fatalf("AddTorrent: %v", err)
 	}
@@ -788,8 +962,11 @@ func TestAddTorrent_HashLookupTimeout(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	indexer := newFakeIndexer(t)
+	defer indexer.Close()
+
 	c := newTestClient(srv.URL, "admin", "pass")
-	_, err := c.AddTorrent(context.Background(), "http://example.com/book.torrent", "books", "")
+	_, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "books", "")
 	if err == nil {
 		t.Fatal("expected error on timeout, got nil")
 	}


### PR DESCRIPTION
## Summary

- Bindery now fetches `.torrent` file content itself for http/https URLs before submitting to qBittorrent
- Content is sent via `multipart/form-data` (`torrents` field) instead of passing the URL in `urls`
- qBittorrent never needs to reach the indexer directly, fixing silent grab failures when Prowlarr uses a Docker-internal hostname (e.g. `prowlarr:9696`) that qBittorrent can't resolve from its own network context
- Magnet links are unchanged — they still use the url-encoded form path

Mirrors the fix applied to NZBGet in #531.

Closes #639.

## Test plan
- [ ] All existing qBittorrent tests pass
- [ ] New `TestAddTorrent_TorrentURL_SubmitsMultipart` — verifies multipart body and torrent content for http URLs
- [ ] New `TestAddTorrent_TorrentURL_WithCategoryAndSavePath` — verifies category/savepath in multipart
- [ ] New `TestAddTorrent_TorrentURL_FetchFailure` — indexer 401 returns error, qBit never contacted

🤖 Generated with [Claude Code](https://claude.com/claude-code)