### PR TITLE
fix(qbittorrent): recover imports after path remaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **qBittorrent imports recover from mismatched container paths without re-downloading** — Download clients now support per-client path remaps, qBittorrent grabs are sent with the expected category save path, and Settings surfaces qBittorrent category path health warnings. Queue items stuck in `importFailed` can also be retried after fixing storage/path settings.
+
 ## [v1.11.2] — 2026-05-17
 
 ### Fixed

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -686,6 +686,7 @@ func main() {
 		// Queue
 		r.Get("/queue", queueHandler.List)
 		r.Post("/queue/grab", queueHandler.Grab)
+		r.Post("/queue/{id}/retry-import", queueHandler.RetryImport)
 		r.Delete("/queue/{id}", queueHandler.Delete)
 		r.Get("/pending", pendingHandler.List)
 		r.Delete("/pending/{id}", pendingHandler.Delete)

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vavallee/bindery/internal/calibre"
 	"github.com/vavallee/bindery/internal/config"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/downloader"
 	"github.com/vavallee/bindery/internal/hardcoverlistsyncer"
 	"github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/indexer"
@@ -358,6 +359,7 @@ func main() {
 	sched.WithAliases(authorAliasRepo)
 	sched.WithDelayProfiles(delayProfileRepo)
 	sched.WithPendingReleases(pendingReleaseRepo)
+	sched.WithStoragePaths(cfg.DownloadDir, cfg.AudiobookDownloadDir)
 	// Register the Calibre importer as the 24-hour sync job. The scheduler
 	// only fires the job when the syncer is non-nil, so no guard needed here.
 	sched.WithCalibreSyncer(calibreImporter)
@@ -419,8 +421,18 @@ func main() {
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
 	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).WithSettings(settingsRepo).WithDownloads(downloadRepo).WithAuthors(authorRepo).WithSeries(seriesRepo)
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, metadataProfileRepo, idxSearcher, settingsRepo, blocklistRepo).WithAliases(authorAliasRepo)
-	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo)
-	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo).WithNotifier(notif)
+	downloadHealth := downloader.NewHealthStore()
+	if clients, err := dlClientRepo.List(ctxBoot); err == nil {
+		downloader.RefreshDownloadClientHealthAsync(context.Background(), downloadHealth, clients, cfg.DownloadDir, cfg.AudiobookDownloadDir)
+	} else {
+		slog.Warn("download client startup health check skipped", "error", err)
+	}
+	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo).
+		WithHealth(downloadHealth).
+		WithStoragePaths(cfg.DownloadDir, cfg.AudiobookDownloadDir)
+	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo).
+		WithNotifier(notif).
+		WithStoragePaths(cfg.DownloadDir, cfg.AudiobookDownloadDir)
 	pendingHandler := api.NewPendingHandler(pendingReleaseRepo, queueHandler, downloadRepo, bookRepo)
 	importScanner.WithSettings(settingsRepo)
 	importScanner.WithRootFolders(rootFolderRepo)

--- a/docs/API.md
+++ b/docs/API.md
@@ -99,6 +99,7 @@ POST   /api/v1/downloadclient/{id}/test           probe connectivity (admin)
 
 GET    /api/v1/queue                              active downloads with live downloader overlay
 POST   /api/v1/queue/grab                         submit a search result to the download client
+POST   /api/v1/queue/{id}/retry-import           retry an importFailed item without re-downloading
 DELETE /api/v1/queue/{id}                         remove (also from downloader)
 
 GET    /api/v1/pending                            grabs awaiting delay-profile clearance

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -190,16 +190,20 @@ spec:
 
 When Bindery and your download client run in **separate containers**, they typically mount the same storage volume at different paths. Bindery needs to read the files the download client just completed, but the path the client reports (e.g. `/downloads/complete/My.Book`) doesn't exist inside Bindery's container.
 
-Set `BINDERY_DOWNLOAD_PATH_REMAP` to a comma-separated list of `from:to` pairs. Bindery applies a longest-prefix match to every path the download client reports, replacing the matched prefix before it tries to access the file.
+Set a download-client path remap in **Settings → Download clients** or set the global `BINDERY_DOWNLOAD_PATH_REMAP` fallback to a comma-separated list of `from:to` pairs. Bindery applies a longest-prefix match to every path the download client reports, replacing the matched prefix before it tries to access the file. A per-client remap takes precedence when it matches the reported path; the global env var still applies as a fallback.
 
-**Common scenario — SABnzbd and Bindery on the same NAS storage, different mount points:**
+Per-client remaps are stored on each download client, so separate qBittorrent / SABnzbd / NZBGet instances can map different mount points. Existing download clients keep an empty remap after upgrade, which preserves the previous global-only behavior until you add a client-specific value.
+
+For a per-client remap, open **Settings → Download clients**, edit the client, and set **Download client path remap**. The left side is the path the client reports; the right side is the path Bindery can read. For qBittorrent this normally means mapping the qBittorrent category save path or torrent content path to Bindery's download mount. Example: if qBittorrent reports `/downloads/books/My.Book` and Bindery sees that same folder as `/media/books/My.Book`, set `/downloads:/media/books`.
+
+**Common scenario — SABnzbd or qBittorrent and Bindery on the same NAS storage, different mount points:**
 
 | Container | NAS path | Mount point |
 |-----------|----------|-------------|
-| SABnzbd | `/volume1/MEDIA` | `/downloads` |
+| Download client | `/volume1/MEDIA` | `/downloads` |
 | Bindery | `/volume1/MEDIA` | `/media` |
 
-SABnzbd reports `/downloads/complete/My.Book`; Bindery remaps to `/media/complete/My.Book`.
+The download client reports `/downloads/complete/My.Book`; Bindery remaps to `/media/complete/My.Book`.
 
 ### Docker Compose
 
@@ -231,7 +235,11 @@ nfs:
   mountPath: /media
 ```
 
-Multiple remaps are separated by commas: `BINDERY_DOWNLOAD_PATH_REMAP=/sab/complete:/media/complete,/sab/incomplete:/media/incomplete`. Longest prefix wins, so more-specific rules take precedence over shorter ones.
+Multiple remaps are separated by commas: `BINDERY_DOWNLOAD_PATH_REMAP=/sab/complete:/media/complete,/qbit:/media/qbit`. Longest prefix wins, so more-specific rules take precedence over shorter ones.
+
+For qBittorrent, Bindery also sends a save path when submitting torrent grabs. If a per-client remap is configured, Bindery inversely maps `BINDERY_DOWNLOAD_DIR` or `BINDERY_AUDIOBOOK_DOWNLOAD_DIR` back to qBittorrent's mount point before submitting the torrent. The Settings page checks the configured qBittorrent category and warns when its save path does not map to Bindery's expected download folder.
+
+After fixing a path or category mismatch, use **Queue → Retry import** on an `importFailed` item. This is also the right action after manually moving the completed torrent in qBittorrent to a path Bindery can read. Bindery resets the import retry counter and imports from the existing completed download, so the release does not need to be grabbed or downloaded again.
 
 ## Environment variables
 
@@ -248,7 +256,7 @@ Multiple remaps are separated by commas: `BINDERY_DOWNLOAD_PATH_REMAP=/sab/compl
 | `BINDERY_LIBRARY_DIR` | `/books` | Destination for imported ebook files |
 | `BINDERY_AUDIOBOOK_DIR` | falls back to `BINDERY_LIBRARY_DIR` | Destination for imported audiobook folders |
 | `BINDERY_ENHANCED_HARDCOVER_API` | `true` | Set to `false` to disable token-backed Hardcover series search, linking, catalog diffs, and missing-book fill even when an admin enables the feature in Settings. |
-| `BINDERY_DOWNLOAD_PATH_REMAP` | _(empty)_ | Comma-separated `from:to` pairs rewriting paths reported by the download client into paths Bindery can access. Required when SABnzbd and Bindery mount the same storage at different paths. Longest-prefix match wins. See [Path remapping](#path-remapping-multi-container--multi-pod-setups). |
+| `BINDERY_DOWNLOAD_PATH_REMAP` | _(empty)_ | Global comma-separated `from:to` pairs rewriting paths reported by download clients into paths Bindery can access. Per-client path remaps in Settings take precedence when they match. Longest-prefix match wins. See [Path remapping](#path-remapping-multi-container--multi-pod-setups). |
 | `BINDERY_PUID` | _(unset)_ | Sanity check — see [Running as a specific UID/GID](#running-as-a-specific-uidgid) |
 | `BINDERY_PGID` | _(unset)_ | Sanity check — same as `BINDERY_PUID` for the primary GID |
 | `BINDERY_COOKIE_SECURE` | `auto` | Session cookie `Secure` flag policy. `auto` (default) flips the flag on when TLS is detected directly or via `X-Forwarded-Proto: https`; `always` forces it on (use when your reverse proxy doesn't forward the header); `never` forces it off (legacy plain-HTTP installs). |

--- a/internal/abs/import_files.go
+++ b/internal/abs/import_files.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	bindimporter "github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/pathmap"
 )
 
 type ownershipReconcileResult struct {
@@ -135,7 +135,7 @@ func (i *Importer) remapABSPath(cfg ImportConfig, candidatePath string) string {
 	if candidatePath == "" || strings.TrimSpace(cfg.PathRemap) == "" {
 		return candidatePath
 	}
-	return bindimporter.ParseRemap(cfg.PathRemap).Apply(candidatePath)
+	return pathmap.Parse(cfg.PathRemap).Apply(candidatePath)
 }
 
 func (i *Importer) bookAlreadyTracksPath(ctx context.Context, bookID int64, format, path string) (bool, error) {

--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -152,5 +152,5 @@ func (h *DownloadClientHandler) Test(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"message": "ok"})
+	writeJSON(w, http.StatusOK, map[string]string{"message": "Connection verified"})
 }

--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -43,11 +45,25 @@ func downloadClientURL(c *models.DownloadClient) string {
 }
 
 type DownloadClientHandler struct {
-	clients *db.DownloadClientRepo
+	clients              *db.DownloadClientRepo
+	health               *downloader.HealthStore
+	downloadDir          string
+	audiobookDownloadDir string
 }
 
 func NewDownloadClientHandler(clients *db.DownloadClientRepo) *DownloadClientHandler {
 	return &DownloadClientHandler{clients: clients}
+}
+
+func (h *DownloadClientHandler) WithHealth(store *downloader.HealthStore) *DownloadClientHandler {
+	h.health = store
+	return h
+}
+
+func (h *DownloadClientHandler) WithStoragePaths(downloadDir, audiobookDownloadDir string) *DownloadClientHandler {
+	h.downloadDir = downloadDir
+	h.audiobookDownloadDir = audiobookDownloadDir
+	return h
 }
 
 func (h *DownloadClientHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -59,6 +75,7 @@ func (h *DownloadClientHandler) List(w http.ResponseWriter, r *http.Request) {
 	if clients == nil {
 		clients = []models.DownloadClient{}
 	}
+	h.attachHealth(clients)
 	writeJSON(w, http.StatusOK, clients)
 }
 
@@ -69,6 +86,7 @@ func (h *DownloadClientHandler) Get(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "download client not found"})
 		return
 	}
+	h.attachClientHealth(client)
 	writeJSON(w, http.StatusOK, client)
 }
 
@@ -101,6 +119,8 @@ func (h *DownloadClientHandler) Create(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	h.refreshClientHealthAsync(c)
+	h.attachClientHealth(&c)
 	writeJSON(w, http.StatusCreated, c)
 }
 
@@ -129,6 +149,8 @@ func (h *DownloadClientHandler) Update(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	h.refreshClientHealthAsync(c)
+	h.attachClientHealth(&c)
 	writeJSON(w, http.StatusOK, c)
 }
 
@@ -137,6 +159,9 @@ func (h *DownloadClientHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if err := h.clients.Delete(r.Context(), id); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
+	}
+	if h.health != nil {
+		h.health.Delete(id)
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -152,5 +177,55 @@ func (h *DownloadClientHandler) Test(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"message": "Connection verified"})
+	health := h.refreshClientHealth(r.Context(), client)
+	resp := struct {
+		Message string                       `json:"message"`
+		Health  *models.DownloadClientHealth `json:"health,omitempty"`
+	}{
+		Message: "Connection verified",
+		Health:  health,
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *DownloadClientHandler) attachHealth(clients []models.DownloadClient) {
+	for i := range clients {
+		h.attachClientHealth(&clients[i])
+	}
+}
+
+func (h *DownloadClientHandler) attachClientHealth(client *models.DownloadClient) {
+	if h.health == nil || client == nil {
+		return
+	}
+	h.health.Attach(client)
+}
+
+func (h *DownloadClientHandler) refreshClientHealthAsync(client models.DownloadClient) {
+	if h.health == nil {
+		return
+	}
+	if client.Type != "qbittorrent" || !client.Enabled {
+		h.health.Delete(client.ID)
+		return
+	}
+	h.health.Set(client.ID, downloader.CheckingHealth())
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		h.health.Set(client.ID, downloader.CheckDownloadClientHealth(ctx, &client, h.downloadDir, h.audiobookDownloadDir))
+	}()
+}
+
+func (h *DownloadClientHandler) refreshClientHealth(ctx context.Context, client *models.DownloadClient) *models.DownloadClientHealth {
+	if h.health == nil || client == nil {
+		return nil
+	}
+	if client.Type != "qbittorrent" || !client.Enabled {
+		h.health.Delete(client.ID)
+		return nil
+	}
+	health := downloader.CheckDownloadClientHealth(ctx, client, h.downloadDir, h.audiobookDownloadDir)
+	h.health.Set(client.ID, health)
+	return &health
 }

--- a/internal/api/download_clients_test.go
+++ b/internal/api/download_clients_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
@@ -144,5 +147,60 @@ func TestDownloadClientTest_NotFound(t *testing.T) {
 	h.Test(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/downloadclient/999/test", nil), "id", "999"))
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected 404 for missing client, got %d", rec.Code)
+	}
+}
+
+func TestDownloadClientTest_SuccessMessage(t *testing.T) {
+	qbit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/app/version":
+			_, _ = w.Write([]byte("5.1.4"))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer qbit.Close()
+	u, err := url.Parse(qbit.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h, clients := downloadClientFixture(t)
+	client := &models.DownloadClient{
+		Name:     "qBit",
+		Type:     "qbittorrent",
+		Host:     host,
+		Port:     port,
+		Username: "u",
+		Password: "p",
+		Enabled:  true,
+	}
+	if err := clients.Create(context.Background(), client); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Test(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/downloadclient/1/test", nil), "id", "1"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out["message"] != "Connection verified" {
+		t.Errorf("message: want Connection verified, got %q", out["message"])
 	}
 }

--- a/internal/api/download_clients_test.go
+++ b/internal/api/download_clients_test.go
@@ -46,7 +46,7 @@ func TestDownloadClientCRUD(t *testing.T) {
 
 	// Create — valid. Use RFC1918 IP literal so the SSRF validator's LAN
 	// policy accepts it without needing DNS in the test environment.
-	body := `{"name":"My SAB","host":"10.10.10.10","port":8080,"type":"sabnzbd","apiKey":"key1","enabled":true}`
+	body := `{"name":"My SAB","host":"10.10.10.10","port":8080,"type":"sabnzbd","apiKey":"key1","pathRemap":"/remote:/local","enabled":true}`
 	rec := httptest.NewRecorder()
 	h.Create(rec, httptest.NewRequest(http.MethodPost, "/downloadclient", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusCreated {
@@ -56,6 +56,9 @@ func TestDownloadClientCRUD(t *testing.T) {
 	json.NewDecoder(rec.Body).Decode(&created)
 	if created.ID == 0 {
 		t.Fatal("expected non-zero ID after create")
+	}
+	if created.PathRemap != "/remote:/local" {
+		t.Fatalf("pathRemap = %q", created.PathRemap)
 	}
 
 	// List — should have one entry
@@ -83,7 +86,7 @@ func TestDownloadClientCRUD(t *testing.T) {
 	}
 
 	// Update
-	update := `{"name":"Updated SAB","host":"10.10.10.11","port":8080,"type":"sabnzbd","apiKey":"key2","enabled":false}`
+	update := `{"name":"Updated SAB","host":"10.10.10.11","port":8080,"type":"sabnzbd","apiKey":"key2","pathRemap":"/remote2:/local2","enabled":false}`
 	rec = httptest.NewRecorder()
 	h.Update(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/downloadclient/1", bytes.NewBufferString(update)), "id", idStr))
 	if rec.Code != http.StatusOK {
@@ -92,6 +95,9 @@ func TestDownloadClientCRUD(t *testing.T) {
 	got, _ := clients.GetByID(ctx, created.ID)
 	if got == nil {
 		t.Fatal("expected client still exists after update")
+	}
+	if got.PathRemap != "/remote2:/local2" {
+		t.Errorf("updated pathRemap = %q", got.PathRemap)
 	}
 
 	// Delete
@@ -196,11 +202,14 @@ func TestDownloadClientTest_SuccessMessage(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-	var out map[string]string
+	var out struct {
+		Message string                       `json:"message"`
+		Health  *models.DownloadClientHealth `json:"health"`
+	}
 	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if out["message"] != "Connection verified" {
-		t.Errorf("message: want Connection verified, got %q", out["message"])
+	if out.Message != "Connection verified" {
+		t.Errorf("message: want Connection verified, got %q", out.Message)
 	}
 }

--- a/internal/api/pending.go
+++ b/internal/api/pending.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/vavallee/bindery/internal/db"
@@ -84,6 +85,10 @@ func (h *PendingHandler) Grab(w http.ResponseWriter, r *http.Request) {
 
 	dl, err := h.queue.grab(r.Context(), stored)
 	if err != nil {
+		if errors.Is(err, errAlreadyGrabbed) {
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "already grabbed"})
+			return
+		}
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -17,6 +18,8 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/notifier"
 )
+
+var errAlreadyGrabbed = errors.New("already grabbed")
 
 type QueueHandler struct {
 	downloads            *db.DownloadRepo
@@ -438,17 +441,11 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	existing, err := h.downloads.GetByGUID(r.Context(), req.GUID)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-	if existing != nil {
+	dl, err := h.grab(r.Context(), req)
+	if errors.Is(err, errAlreadyGrabbed) {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "already grabbed"})
 		return
 	}
-
-	dl, err := h.grab(r.Context(), req)
 	if err != nil {
 		status := http.StatusBadGateway
 		if strings.Contains(err.Error(), "no enabled download client") {
@@ -460,6 +457,29 @@ func (h *QueueHandler) Grab(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("download grabbed", "title", req.Title)
 	writeJSON(w, http.StatusAccepted, dl)
+}
+
+func (h *QueueHandler) RetryImport(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+
+	accepted, found, err := h.downloads.ResetImportRetry(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "download not found"})
+		return
+	}
+	if !accepted {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "download is not in importFailed state"})
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, map[string]bool{"ok": true})
 }
 
 // selectClient picks the best enabled client for the given protocol and media type.
@@ -482,6 +502,14 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 	if req.Protocol == "" {
 		req.Protocol = "usenet"
 	}
+	existing, err := h.downloads.GetByGUID(ctx, req.GUID)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil && existing.Status != models.StateFailed {
+		return nil, errAlreadyGrabbed
+	}
+
 	client, err := h.selectClient(ctx, req.Protocol, req.MediaType)
 	if err != nil || client == nil {
 		return nil, fmt.Errorf("no enabled download client configured")
@@ -499,9 +527,22 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 	if indexerID != nil && *indexerID == 0 {
 		indexerID = nil
 	}
+	editionID := (*int64)(nil)
+	indexerFlags := ""
+	if existing != nil {
+		if bookID == nil {
+			bookID = existing.BookID
+		}
+		if indexerID == nil {
+			indexerID = existing.IndexerID
+		}
+		editionID = existing.EditionID
+		indexerFlags = existing.IndexerFlags
+	}
 	dl := &models.Download{
 		GUID:             req.GUID,
 		BookID:           bookID,
+		EditionID:        editionID,
 		IndexerID:        indexerID,
 		DownloadClientID: &client.ID,
 		Title:            req.Title,
@@ -510,8 +551,18 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 		Status:           models.StateGrabbed,
 		Protocol:         protocol,
 		Quality:          indexer.ParseRelease(req.Title).Format,
+		IndexerFlags:     indexerFlags,
 	}
-	if err := h.downloads.Create(ctx, dl); err != nil {
+	if existing != nil {
+		dl.ID = existing.ID
+		ok, err := h.downloads.RetryFailed(ctx, dl)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, errAlreadyGrabbed
+		}
+	} else if err := h.downloads.Create(ctx, dl); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -19,11 +19,13 @@ import (
 )
 
 type QueueHandler struct {
-	downloads *db.DownloadRepo
-	clients   *db.DownloadClientRepo
-	books     *db.BookRepo
-	history   *db.HistoryRepo
-	notif     *notifier.Notifier
+	downloads            *db.DownloadRepo
+	clients              *db.DownloadClientRepo
+	books                *db.BookRepo
+	history              *db.HistoryRepo
+	notif                *notifier.Notifier
+	downloadDir          string
+	audiobookDownloadDir string
 }
 
 func NewQueueHandler(downloads *db.DownloadRepo, clients *db.DownloadClientRepo, books *db.BookRepo, history *db.HistoryRepo) *QueueHandler {
@@ -33,6 +35,14 @@ func NewQueueHandler(downloads *db.DownloadRepo, clients *db.DownloadClientRepo,
 // WithNotifier attaches a notifier so grab/failure events fire webhooks.
 func (h *QueueHandler) WithNotifier(n *notifier.Notifier) *QueueHandler {
 	h.notif = n
+	return h
+}
+
+// WithStoragePaths attaches the process-level download roots used when sending
+// torrent clients an explicit save path.
+func (h *QueueHandler) WithStoragePaths(downloadDir, audiobookDownloadDir string) *QueueHandler {
+	h.downloadDir = downloadDir
+	h.audiobookDownloadDir = audiobookDownloadDir
 	return h
 }
 
@@ -505,7 +515,11 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 		return nil, err
 	}
 
-	sendRes, err := downloader.SendDownload(ctx, client, req.NZBURL, req.Title)
+	sendRes, err := downloader.SendDownload(ctx, client, req.NZBURL, req.Title, downloader.SendOptions{
+		MediaType:            req.MediaType,
+		DownloadDir:          h.downloadDir,
+		AudiobookDownloadDir: h.audiobookDownloadDir,
+	})
 	if err != nil {
 		slog.Error("failed to send download", "client_type", client.Type, "error", err, "title", req.Title)
 		if setErr := h.downloads.SetError(ctx, dl.ID, err.Error()); setErr != nil {

--- a/internal/api/queue_test.go
+++ b/internal/api/queue_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
@@ -64,17 +65,281 @@ func TestQueueGrab_NoDownloadClient(t *testing.T) {
 }
 
 func TestQueueGrab_DuplicateGUID(t *testing.T) {
-	h, _, downloads, _, _, ctx := queueFixture(t)
-	if err := downloads.Create(ctx, &models.Download{
-		GUID: "dup-guid", Title: "T", Status: models.DownloadStatusDownloading, Protocol: "usenet",
-	}); err != nil {
-		t.Fatal(err)
+	for _, status := range []models.DownloadState{models.StateGrabbed, models.StateDownloading} {
+		t.Run(string(status), func(t *testing.T) {
+			h, _, downloads, _, _, ctx := queueFixture(t)
+			if err := downloads.Create(ctx, &models.Download{
+				GUID: "dup-guid", Title: "T", Status: status, Protocol: "usenet",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			body := bytes.NewBufferString(`{"guid":"dup-guid","nzbUrl":"http://example/x.nzb","title":"T"}`)
+			rec := httptest.NewRecorder()
+			h.Grab(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/grab", body))
+			if rec.Code != http.StatusConflict {
+				t.Errorf("expected 409, got %d", rec.Code)
+			}
+		})
 	}
-	body := bytes.NewBufferString(`{"guid":"dup-guid","nzbUrl":"http://example/x.nzb","title":"T"}`)
+}
+
+func TestQueueGrab_RetriesFailedGUID(t *testing.T) {
+	addCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("mode") != "addurl" {
+			t.Fatalf("expected mode=addurl, got %s", r.URL.Query().Get("mode"))
+		}
+		addCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":  true,
+			"nzo_ids": []string{"nzo-retry"},
+		})
+	}))
+	defer srv.Close()
+
+	h, database, downloads, clients, books, ctx := queueFixture(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name:    "sab",
+		Type:    "sabnzbd",
+		Host:    host,
+		Port:    port,
+		Enabled: true,
+	}
+	if err := clients.Create(ctx, client); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	author := &models.Author{
+		ForeignID:        "retry-author",
+		Name:             "Retry Author",
+		SortName:         "Retry Author",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+		QualityProfileID: nil,
+		RootFolderID:     nil,
+	}
+	if err := db.NewAuthorRepo(database).Create(ctx, author); err != nil {
+		t.Fatalf("create author: %v", err)
+	}
+	book := &models.Book{
+		ForeignID:        "retry-book",
+		AuthorID:         author.ID,
+		Title:            "Retry Book",
+		SortTitle:        "retry book",
+		Genres:           []string{},
+		Status:           models.BookStatusWanted,
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatalf("create book: %v", err)
+	}
+	edition := &models.Edition{
+		ForeignID: "retry-edition",
+		BookID:    book.ID,
+		Title:     "Retry Edition",
+		Format:    "epub",
+		Language:  "eng",
+		IsEbook:   true,
+		Monitored: true,
+	}
+	if err := db.NewEditionRepo(database).Upsert(ctx, edition); err != nil {
+		t.Fatalf("create edition: %v", err)
+	}
+	idx := &models.Indexer{
+		Name:           "Retry Indexer",
+		Type:           "newznab",
+		URL:            "https://indexer.example",
+		Categories:     []int{7000},
+		Enabled:        true,
+		SupportsSearch: true,
+	}
+	if err := db.NewIndexerRepo(database).Create(ctx, idx); err != nil {
+		t.Fatalf("create indexer: %v", err)
+	}
+	existing := &models.Download{
+		GUID:         "retry-guid",
+		BookID:       &book.ID,
+		EditionID:    &edition.ID,
+		IndexerID:    &idx.ID,
+		Title:        "Old Title",
+		NZBURL:       "http://example/old.nzb",
+		Size:         1,
+		SABnzbdNzoID: strPtr("old-nzo"),
+		Status:       models.StateFailed,
+		Protocol:     "usenet",
+		IndexerFlags: "freeleech",
+		ErrorMessage: "old failure",
+	}
+	if err := downloads.Create(ctx, existing); err != nil {
+		t.Fatalf("create failed download: %v", err)
+	}
+
+	body := bytes.NewBufferString(`{"guid":"retry-guid","nzbUrl":"http://example/new.nzb","title":"New Title","size":42}`)
 	rec := httptest.NewRecorder()
 	h.Grab(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/grab", body))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if addCalls != 1 {
+		t.Fatalf("expected one downloader add call, got %d", addCalls)
+	}
+	got, err := downloads.GetByGUID(ctx, "retry-guid")
+	if err != nil || got == nil {
+		t.Fatalf("reload download: %v", err)
+	}
+	if got.ID != existing.ID {
+		t.Fatalf("expected retry to reuse download row %d, got %d", existing.ID, got.ID)
+	}
+	if got.Status != models.StateDownloading {
+		t.Fatalf("expected downloading after successful retry, got %q", got.Status)
+	}
+	if got.Title != "New Title" || got.NZBURL != "http://example/new.nzb" || got.Size != 42 {
+		t.Fatalf("retry did not refresh release fields: %+v", got)
+	}
+	if got.BookID == nil || *got.BookID != book.ID {
+		t.Fatalf("expected retry to preserve book ID %d, got %v", book.ID, got.BookID)
+	}
+	if got.EditionID == nil || *got.EditionID != edition.ID {
+		t.Fatalf("expected retry to preserve edition ID %d, got %v", edition.ID, got.EditionID)
+	}
+	if got.IndexerID == nil || *got.IndexerID != idx.ID {
+		t.Fatalf("expected retry to preserve indexer ID %d, got %v", idx.ID, got.IndexerID)
+	}
+	if got.IndexerFlags != "freeleech" {
+		t.Fatalf("expected retry to preserve indexer flags, got %q", got.IndexerFlags)
+	}
+	if got.SABnzbdNzoID == nil || *got.SABnzbdNzoID != "nzo-retry" {
+		t.Fatalf("expected new NZO ID, got %v", got.SABnzbdNzoID)
+	}
+	if got.ErrorMessage != "" {
+		t.Fatalf("expected error message cleared, got %q", got.ErrorMessage)
+	}
+}
+
+func TestQueueGrab_FailedRetryFailureRemainsRetryable(t *testing.T) {
+	addCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api" || r.URL.Query().Get("mode") != "addurl" {
+			t.Fatalf("unexpected SAB request: %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+		addCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": false})
+	}))
+	defer srv.Close()
+
+	h, _, downloads, clients, _, ctx := queueFixture(t)
+	host, port := testServerHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name:    "sab",
+		Type:    "sabnzbd",
+		Host:    host,
+		Port:    port,
+		Enabled: true,
+	}
+	if err := clients.Create(ctx, client); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	if err := downloads.Create(ctx, &models.Download{
+		GUID: "retry-fail-guid", Title: "Old Title", NZBURL: "http://example/old.nzb",
+		Status: models.StateFailed, Protocol: "usenet", ErrorMessage: "old failure",
+	}); err != nil {
+		t.Fatalf("create failed download: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		body := bytes.NewBufferString(`{"guid":"retry-fail-guid","nzbUrl":"http://example/new.nzb","title":"New Title"}`)
+		rec := httptest.NewRecorder()
+		h.Grab(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/grab", body))
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("attempt %d: expected 502, got %d: %s", i+1, rec.Code, rec.Body.String())
+		}
+	}
+	if addCalls != 2 {
+		t.Fatalf("expected failed row to stay retryable; add calls=%d", addCalls)
+	}
+	got, err := downloads.GetByGUID(ctx, "retry-fail-guid")
+	if err != nil || got == nil {
+		t.Fatalf("reload download: %v", err)
+	}
+	if got.Status != models.StateFailed {
+		t.Fatalf("expected retry failure to remain failed, got %q", got.Status)
+	}
+	if !strings.Contains(got.ErrorMessage, "SABnzbd rejected download") {
+		t.Fatalf("expected persisted retry error, got %q", got.ErrorMessage)
+	}
+}
+
+func TestQueueRetryImport_AcceptsImportFailed(t *testing.T) {
+	h, database, downloads, _, _, ctx := queueFixture(t)
+	dl := &models.Download{
+		GUID:         "import-retry-guid",
+		Title:        "Import Retry",
+		NZBURL:       "http://example/retry.nzb",
+		Status:       models.StateImportFailed,
+		Protocol:     "usenet",
+		ErrorMessage: "path did not resolve",
+	}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatalf("create import failed download: %v", err)
+	}
+	if _, err := database.ExecContext(ctx, "UPDATE downloads SET import_retry_count=? WHERE id=?", 3, dl.ID); err != nil {
+		t.Fatalf("seed retry count: %v", err)
+	}
+
+	req := withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/queue/"+strconv.FormatInt(dl.ID, 10)+"/retry-import", nil), "id", strconv.FormatInt(dl.ID, 10))
+	rec := httptest.NewRecorder()
+	h.RetryImport(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]bool
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !body["ok"] {
+		t.Fatalf("expected ok=true, got %v", body)
+	}
+	got, err := downloads.GetByGUID(ctx, "import-retry-guid")
+	if err != nil || got == nil {
+		t.Fatalf("reload download: %v", err)
+	}
+	if got.Status != models.StateImportFailed || got.ImportRetryCount != 0 || got.ErrorMessage != "path did not resolve" {
+		t.Fatalf("unexpected retry state: status=%q retry=%d error=%q", got.Status, got.ImportRetryCount, got.ErrorMessage)
+	}
+}
+
+func TestQueueRetryImport_NotFound(t *testing.T) {
+	h, _, _, _, _, _ := queueFixture(t)
+	req := withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/queue/999/retry-import", nil), "id", "999")
+	rec := httptest.NewRecorder()
+	h.RetryImport(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestQueueRetryImport_RejectsNonImportFailed(t *testing.T) {
+	h, _, downloads, _, _, ctx := queueFixture(t)
+	dl := &models.Download{
+		GUID:     "completed-guid",
+		Title:    "Already Completed",
+		NZBURL:   "http://example/completed.nzb",
+		Status:   models.StateCompleted,
+		Protocol: "usenet",
+	}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatalf("create completed download: %v", err)
+	}
+
+	req := withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/queue/"+strconv.FormatInt(dl.ID, 10)+"/retry-import", nil), "id", strconv.FormatInt(dl.ID, 10))
+	rec := httptest.NewRecorder()
+	h.RetryImport(rec, req)
 	if rec.Code != http.StatusConflict {
-		t.Errorf("expected 409, got %d", rec.Code)
+		t.Fatalf("expected 409, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/vavallee/bindery/internal/pathmap"
 )
 
 // Validate checks the configuration for known conflict patterns and invalid
@@ -155,16 +157,5 @@ func validateAbsURL(envVar, raw string) error {
 // comma-separated list of "from:to" pairs. It only validates the format —
 // whether the paths actually resolve is left to the importer.
 func validateDownloadPathRemap(raw string) error {
-	pairs := strings.Split(raw, ",")
-	for i, pair := range pairs {
-		pair = strings.TrimSpace(pair)
-		if pair == "" {
-			continue
-		}
-		parts := strings.SplitN(pair, ":", 2)
-		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
-			return fmt.Errorf("pair %d %q is not in 'from:to' format", i+1, pair)
-		}
-	}
-	return nil
+	return pathmap.Validate(raw)
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -998,6 +999,178 @@ func TestDownloadRepoCRUD(t *testing.T) {
 	list, _ = repo.List(ctx)
 	if len(list) != 0 {
 		t.Errorf("expected 0 downloads after delete, got %d", len(list))
+	}
+}
+
+func TestDownloadRepoRetryFailed(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewDownloadRepo(database)
+
+	oldNzoID := "old-nzo"
+	oldTorrentID := "old-torrent"
+	dl := &models.Download{
+		GUID:         "retry-guid",
+		Title:        "Old Title",
+		NZBURL:       "https://example.com/old.nzb",
+		Size:         100,
+		SABnzbdNzoID: &oldNzoID,
+		TorrentID:    &oldTorrentID,
+		Status:       models.StateFailed,
+		Protocol:     "usenet",
+		Quality:      "epub",
+		ErrorMessage: "old failure",
+	}
+	if err := repo.Create(ctx, dl); err != nil {
+		t.Fatalf("create failed download: %v", err)
+	}
+	oldTime := time.Now().UTC().Add(-2 * time.Hour)
+	if _, err := database.ExecContext(ctx, `
+		UPDATE downloads
+		SET grabbed_at=?, completed_at=?, imported_at=?, import_retry_count=?
+		WHERE id=?`, oldTime, oldTime, oldTime, 3, dl.ID); err != nil {
+		t.Fatalf("seed retry metadata: %v", err)
+	}
+
+	retry := &models.Download{
+		ID:       dl.ID,
+		Title:    "New Title",
+		NZBURL:   "https://example.com/new.nzb",
+		Size:     200,
+		Status:   models.StateGrabbed,
+		Protocol: "usenet",
+		Quality:  "m4b",
+	}
+	ok, err := repo.RetryFailed(ctx, retry)
+	if err != nil {
+		t.Fatalf("RetryFailed: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected failed row to be claimed")
+	}
+
+	got, err := repo.GetByGUID(ctx, "retry-guid")
+	if err != nil || got == nil {
+		t.Fatalf("reload download: %v", err)
+	}
+	if got.Status != models.StateGrabbed {
+		t.Fatalf("expected grabbed retry state, got %q", got.Status)
+	}
+	if got.Title != "New Title" || got.NZBURL != "https://example.com/new.nzb" || got.Size != 200 || got.Quality != "m4b" {
+		t.Fatalf("retry did not refresh release fields: %+v", got)
+	}
+	if got.SABnzbdNzoID != nil || got.TorrentID != nil {
+		t.Fatalf("expected remote IDs cleared, got nzo=%v torrent=%v", got.SABnzbdNzoID, got.TorrentID)
+	}
+	if got.ErrorMessage != "" {
+		t.Fatalf("expected error message cleared, got %q", got.ErrorMessage)
+	}
+	if got.GrabbedAt != nil || got.CompletedAt != nil || got.ImportedAt != nil {
+		t.Fatalf("expected timestamps cleared, got grabbed=%v completed=%v imported=%v", got.GrabbedAt, got.CompletedAt, got.ImportedAt)
+	}
+	if got.ImportRetryCount != 0 {
+		t.Fatalf("expected retry count reset, got %d", got.ImportRetryCount)
+	}
+
+	ok, err = repo.RetryFailed(ctx, retry)
+	if err != nil {
+		t.Fatalf("second RetryFailed: %v", err)
+	}
+	if ok {
+		t.Fatal("expected non-failed row not to be claimed")
+	}
+}
+
+func TestDownloadRepoResetImportRetry(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewDownloadRepo(database)
+
+	nzoID := "old-nzo"
+	torrentID := "old-torrent"
+	dl := &models.Download{
+		GUID:         "import-retry-guid",
+		Title:        "Import Retry",
+		NZBURL:       "https://example.com/retry.nzb",
+		Size:         100,
+		SABnzbdNzoID: &nzoID,
+		TorrentID:    &torrentID,
+		Status:       models.StateImportFailed,
+		Protocol:     "usenet",
+		Quality:      "epub",
+		ErrorMessage: "visible import failure",
+	}
+	if err := repo.Create(ctx, dl); err != nil {
+		t.Fatalf("create import failed download: %v", err)
+	}
+	oldTime := time.Now().UTC().Add(-2 * time.Hour)
+	if _, err := database.ExecContext(ctx, `
+		UPDATE downloads
+		SET grabbed_at=?, completed_at=?, imported_at=?, import_retry_count=?
+		WHERE id=?`, oldTime, oldTime, oldTime, 3, dl.ID); err != nil {
+		t.Fatalf("seed import retry metadata: %v", err)
+	}
+
+	accepted, found, err := repo.ResetImportRetry(ctx, dl.ID)
+	if err != nil {
+		t.Fatalf("ResetImportRetry: %v", err)
+	}
+	if !accepted || !found {
+		t.Fatalf("ResetImportRetry accepted=%v found=%v, want true true", accepted, found)
+	}
+
+	got, err := repo.GetByGUID(ctx, "import-retry-guid")
+	if err != nil || got == nil {
+		t.Fatalf("reload download: %v", err)
+	}
+	if got.Status != models.StateImportFailed {
+		t.Fatalf("status changed to %q, want importFailed", got.Status)
+	}
+	if got.ImportRetryCount != 0 {
+		t.Fatalf("import retry count = %d, want 0", got.ImportRetryCount)
+	}
+	if got.ErrorMessage != "visible import failure" {
+		t.Fatalf("error message changed to %q", got.ErrorMessage)
+	}
+	if got.SABnzbdNzoID == nil || *got.SABnzbdNzoID != nzoID || got.TorrentID == nil || *got.TorrentID != torrentID {
+		t.Fatalf("remote IDs changed, got nzo=%v torrent=%v", got.SABnzbdNzoID, got.TorrentID)
+	}
+	if got.GrabbedAt == nil || got.CompletedAt == nil || got.ImportedAt == nil {
+		t.Fatalf("timestamps changed, got grabbed=%v completed=%v imported=%v", got.GrabbedAt, got.CompletedAt, got.ImportedAt)
+	}
+
+	nonFailed := &models.Download{
+		GUID:     "not-import-failed",
+		Title:    "Not Import Failed",
+		NZBURL:   "https://example.com/not-failed.nzb",
+		Status:   models.StateCompleted,
+		Protocol: "usenet",
+	}
+	if err := repo.Create(ctx, nonFailed); err != nil {
+		t.Fatalf("create completed download: %v", err)
+	}
+	accepted, found, err = repo.ResetImportRetry(ctx, nonFailed.ID)
+	if err != nil {
+		t.Fatalf("ResetImportRetry non-failed: %v", err)
+	}
+	if accepted || !found {
+		t.Fatalf("ResetImportRetry non-failed accepted=%v found=%v, want false true", accepted, found)
+	}
+
+	accepted, found, err = repo.ResetImportRetry(ctx, 999999)
+	if err != nil {
+		t.Fatalf("ResetImportRetry missing: %v", err)
+	}
+	if accepted || found {
+		t.Fatalf("ResetImportRetry missing accepted=%v found=%v, want false false", accepted, found)
 	}
 }
 

--- a/internal/db/download_clients.go
+++ b/internal/db/download_clients.go
@@ -17,7 +17,7 @@ type DownloadClientRepo struct {
 
 const downloadClientSelectColumns = `
 	id, name, type, host, port, api_key, use_ssl, url_base, username, password,
-	category, priority, enabled, created_at, updated_at`
+	category, path_remap, priority, enabled, created_at, updated_at`
 
 func isCredentialClient(clientType string) bool {
 	return clientType == "qbittorrent" || clientType == "transmission"
@@ -111,7 +111,7 @@ func (r *DownloadClientRepo) List(ctx context.Context) ([]models.DownloadClient,
 		var c models.DownloadClient
 		var enabled, useSSL int
 		if err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
 			&enabled, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
@@ -130,7 +130,7 @@ func (r *DownloadClientRepo) GetByID(ctx context.Context, id int64) (*models.Dow
 		SELECT `+downloadClientSelectColumns+`
 		FROM download_clients WHERE id=?`, id).
 		Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
 			&enabled, &c.CreatedAt, &c.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -151,7 +151,7 @@ func (r *DownloadClientRepo) GetFirstEnabled(ctx context.Context) (*models.Downl
 		SELECT `+downloadClientSelectColumns+`
 		FROM download_clients WHERE enabled=1 ORDER BY priority LIMIT 1`).
 		Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
 			&enabled, &c.CreatedAt, &c.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -177,14 +177,14 @@ func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, prot
 			SELECT `+downloadClientSelectColumns+`
 			FROM download_clients WHERE enabled=1 AND type IN (?, ?, ?) ORDER BY priority LIMIT 1`, "qbittorrent", "transmission", "deluge").
 			Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
 				&enabled, &c.CreatedAt, &c.UpdatedAt)
 	} else {
 		err = r.db.QueryRowContext(ctx, `
 			SELECT `+downloadClientSelectColumns+`
 			FROM download_clients WHERE enabled=1 AND type IN (?, ?) ORDER BY priority LIMIT 1`, "sabnzbd", "nzbget").
 			Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
 				&enabled, &c.CreatedAt, &c.UpdatedAt)
 	}
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -226,7 +226,7 @@ func (r *DownloadClientRepo) GetEnabledByProtocol(ctx context.Context, protocol 
 		var c models.DownloadClient
 		var enabled, useSSL int
 		if err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.Priority,
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
 			&enabled, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
@@ -242,9 +242,9 @@ func (r *DownloadClientRepo) Create(ctx context.Context, c *models.DownloadClien
 	normalizeClientCredentialStorage(c)
 	now := time.Now().UTC()
 	result, err := r.db.ExecContext(ctx, `
-		INSERT INTO download_clients (name, type, host, port, api_key, use_ssl, url_base, username, password, category, priority, enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Username, c.Password, c.Category, c.Priority, c.Enabled, now, now)
+		INSERT INTO download_clients (name, type, host, port, api_key, use_ssl, url_base, username, password, category, path_remap, priority, enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Username, c.Password, c.Category, c.PathRemap, c.Priority, c.Enabled, now, now)
 	if err != nil {
 		return fmt.Errorf("create download client: %w", err)
 	}
@@ -263,9 +263,9 @@ func (r *DownloadClientRepo) Update(ctx context.Context, c *models.DownloadClien
 	now := time.Now().UTC()
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE download_clients SET name=?, type=?, host=?, port=?, api_key=?, use_ssl=?,
-		                            url_base=?, username=?, password=?, category=?, priority=?, enabled=?, updated_at=?
+		                            url_base=?, username=?, password=?, category=?, path_remap=?, priority=?, enabled=?, updated_at=?
 		WHERE id=?`,
-		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Username, c.Password, c.Category, c.Priority, c.Enabled, now, c.ID)
+		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Username, c.Password, c.Category, c.PathRemap, c.Priority, c.Enabled, now, c.ID)
 	return err
 }
 

--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -88,6 +89,85 @@ func (r *DownloadRepo) Create(ctx context.Context, d *models.Download) error {
 	d.ID = id
 	d.AddedAt = now
 	return nil
+}
+
+// RetryFailed atomically claims an existing failed download for a manual retry.
+// It returns false when the row is no longer in the failed state.
+func (r *DownloadRepo) RetryFailed(ctx context.Context, d *models.Download) (bool, error) {
+	now := time.Now().UTC()
+	result, err := r.db.ExecContext(ctx, `
+		UPDATE downloads
+		SET book_id=?,
+		    edition_id=?,
+		    indexer_id=?,
+		    download_client_id=?,
+		    title=?,
+		    nzb_url=?,
+		    size=?,
+		    sabnzbd_nzo_id=NULL,
+		    torrent_id=NULL,
+		    status=?,
+		    protocol=?,
+		    quality=?,
+		    indexer_flags=?,
+		    error_message='',
+		    added_at=?,
+		    grabbed_at=NULL,
+		    completed_at=NULL,
+		    imported_at=NULL,
+		    import_retry_count=0
+		WHERE id=? AND status=?`,
+		d.BookID, d.EditionID, d.IndexerID, d.DownloadClientID,
+		d.Title, d.NZBURL, d.Size, models.StateGrabbed, d.Protocol,
+		d.Quality, d.IndexerFlags, now, d.ID, models.StateFailed)
+	if err != nil {
+		return false, fmt.Errorf("retry failed download: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("retry failed download rows affected: %w", err)
+	}
+	if affected == 0 {
+		return false, nil
+	}
+	d.Status = models.StateGrabbed
+	d.SABnzbdNzoID = nil
+	d.TorrentID = nil
+	d.ErrorMessage = ""
+	d.AddedAt = now
+	d.GrabbedAt = nil
+	d.CompletedAt = nil
+	d.ImportedAt = nil
+	d.ImportRetryCount = 0
+	return true, nil
+}
+
+// ResetImportRetry atomically re-enables scanner retries for a download stuck
+// in StateImportFailed. It returns accepted=false when the row exists but is in
+// another state, and found=false when no row exists.
+func (r *DownloadRepo) ResetImportRetry(ctx context.Context, id int64) (accepted bool, found bool, err error) {
+	result, err := r.db.ExecContext(ctx,
+		"UPDATE downloads SET import_retry_count=0 WHERE id=? AND status=?",
+		id, models.StateImportFailed)
+	if err != nil {
+		return false, false, fmt.Errorf("reset import retry: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, false, fmt.Errorf("reset import retry rows affected: %w", err)
+	}
+	if affected > 0 {
+		return true, true, nil
+	}
+
+	var existingID int64
+	if err := r.db.QueryRowContext(ctx, "SELECT id FROM downloads WHERE id=?", id).Scan(&existingID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, false, nil
+		}
+		return false, false, fmt.Errorf("lookup download for import retry: %w", err)
+	}
+	return false, true, nil
 }
 
 func (r *DownloadRepo) UpdateStatus(ctx context.Context, id int64, next models.DownloadState) error {

--- a/internal/db/migrations/040_download_client_path_remap.sql
+++ b/internal/db/migrations/040_download_client_path_remap.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+-- Per-download-client path remapping. This is intentionally separate from
+-- abs.path_remap because ABS and download clients may report different mount
+-- prefixes for the same storage.
+ALTER TABLE download_clients ADD COLUMN path_remap TEXT NOT NULL DEFAULT '';

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vavallee/bindery/internal/downloader/sabnzbd"
 	"github.com/vavallee/bindery/internal/downloader/transmission"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/pathmap"
 )
 
 type LiveStatus struct {
@@ -41,6 +42,12 @@ type SendResult struct {
 	RemoteID      string
 	Protocol      string
 	UsesTorrentID bool
+}
+
+type SendOptions struct {
+	MediaType            string
+	DownloadDir          string
+	AudiobookDownloadDir string
 }
 
 func IsTorrentClient(clientType string) bool {
@@ -79,7 +86,11 @@ func TestClient(ctx context.Context, client *models.DownloadClient) error {
 	}
 }
 
-func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL, title string) (*SendResult, error) {
+func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL, title string, options ...SendOptions) (*SendResult, error) {
+	var opts SendOptions
+	if len(options) > 0 {
+		opts = options[0]
+	}
 	result := &SendResult{
 		Protocol:      ProtocolForClient(client.Type),
 		UsesTorrentID: IsTorrentClient(client.Type),
@@ -107,7 +118,8 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		return result, nil
 	case "qbittorrent":
 		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
-		hash, err := qb.AddTorrent(ctx, sourceURL, client.Category, "")
+		savePath := qbitSavePath(client, opts)
+		hash, err := qb.AddTorrent(ctx, sourceURL, client.Category, savePath)
 		if err != nil {
 			return nil, err
 		}
@@ -147,6 +159,14 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		}
 		return result, nil
 	}
+}
+
+func qbitSavePath(client *models.DownloadClient, opts SendOptions) string {
+	localPath := TargetDownloadDir(opts.MediaType, opts.DownloadDir, opts.AudiobookDownloadDir)
+	if strings.TrimSpace(localPath) == "" {
+		return ""
+	}
+	return pathmap.Parse(client.PathRemap).ApplyInverse(localPath)
 }
 
 func RemoveDownload(ctx context.Context, client *models.DownloadClient, dl *models.Download, deleteFiles bool) error {

--- a/internal/downloader/adapter_test.go
+++ b/internal/downloader/adapter_test.go
@@ -350,8 +350,12 @@ func TestTestClient_Qbittorrent(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/v2/auth/login":
 			_, _ = w.Write([]byte("Ok."))
-		default:
+		case "/api/v2/app/version":
 			_, _ = w.Write([]byte("1.2.3"))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
 	defer srv.Close()

--- a/internal/downloader/adapter_test.go
+++ b/internal/downloader/adapter_test.go
@@ -576,11 +576,14 @@ func TestSendDownload_Transmission_AbsoluteCategorySentAsDownloadDir(t *testing.
 }
 
 func TestSendDownload_Qbittorrent(t *testing.T) {
+	var gotSavePath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v2/auth/login":
 			_, _ = w.Write([]byte("Ok."))
 		case "/api/v2/torrents/add":
+			_ = r.ParseForm()
+			gotSavePath = r.FormValue("savepath")
 			_, _ = w.Write([]byte("Ok."))
 		case "/api/v2/torrents/info":
 			_ = json.NewEncoder(w).Encode([]map[string]any{
@@ -590,16 +593,50 @@ func TestSendDownload_Qbittorrent(t *testing.T) {
 	}))
 	defer srv.Close()
 	host, port := serverHostPort(t, srv.URL)
-	client := &models.DownloadClient{Type: "qbittorrent", Host: host, Port: port, Username: "u", Password: "p"}
-	result, err := SendDownload(context.Background(), client, "magnet:?xt=urn:btih:ABCDEF123&dn=Book", "")
+	client := &models.DownloadClient{Type: "qbittorrent", Host: host, Port: port, Username: "u", Password: "p", PathRemap: "/media:/books"}
+	result, err := SendDownload(context.Background(), client, "magnet:?xt=urn:btih:ABCDEF123&dn=Book", "", SendOptions{
+		MediaType:   models.MediaTypeEbook,
+		DownloadDir: "/books/downloads",
+	})
 	if err != nil {
 		t.Fatalf("SendDownload: %v", err)
+	}
+	if gotSavePath != "/media/downloads" {
+		t.Errorf("savepath: want /media/downloads, got %q", gotSavePath)
 	}
 	if result.Protocol != "torrent" {
 		t.Errorf("expected Protocol=torrent, got %q", result.Protocol)
 	}
 	if !result.UsesTorrentID {
 		t.Error("expected UsesTorrentID=true for qbittorrent")
+	}
+}
+
+func TestSendDownload_QbittorrentAudiobookSavePath(t *testing.T) {
+	var gotSavePath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			_ = r.ParseForm()
+			gotSavePath = r.FormValue("savepath")
+			_, _ = w.Write([]byte("Ok."))
+		}
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{Type: "qbittorrent", Host: host, Port: port, Username: "u", Password: "p", PathRemap: "/media:/books"}
+	_, err := SendDownload(context.Background(), client, "magnet:?xt=urn:btih:ABCDEF123&dn=Book", "", SendOptions{
+		MediaType:            models.MediaTypeAudiobook,
+		DownloadDir:          "/books/downloads",
+		AudiobookDownloadDir: "/books/audio-downloads",
+	})
+	if err != nil {
+		t.Fatalf("SendDownload: %v", err)
+	}
+	if gotSavePath != "/media/audio-downloads" {
+		t.Errorf("savepath: want /media/audio-downloads, got %q", gotSavePath)
 	}
 }
 

--- a/internal/downloader/health.go
+++ b/internal/downloader/health.go
@@ -1,0 +1,158 @@
+package downloader
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
+	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/pathmap"
+)
+
+const (
+	HealthOK       = "ok"
+	HealthChecking = "checking"
+	HealthError    = "error"
+)
+
+// HealthStore keeps non-persistent download-client health diagnostics.
+type HealthStore struct {
+	mu   sync.RWMutex
+	byID map[int64]models.DownloadClientHealth
+}
+
+func NewHealthStore() *HealthStore {
+	return &HealthStore{byID: make(map[int64]models.DownloadClientHealth)}
+}
+
+func (s *HealthStore) Set(id int64, health models.DownloadClientHealth) {
+	if s == nil || id == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.byID[id] = health
+}
+
+func (s *HealthStore) Delete(id int64) {
+	if s == nil || id == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.byID, id)
+}
+
+func (s *HealthStore) Get(id int64) *models.DownloadClientHealth {
+	if s == nil || id == 0 {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	health, ok := s.byID[id]
+	if !ok {
+		return nil
+	}
+	return &health
+}
+
+func (s *HealthStore) Attach(client *models.DownloadClient) {
+	if s == nil || client == nil {
+		return
+	}
+	client.Health = s.Get(client.ID)
+}
+
+func CheckingHealth() models.DownloadClientHealth {
+	return models.DownloadClientHealth{Status: HealthChecking, Message: "Checking qBittorrent category path"}
+}
+
+func RefreshDownloadClientHealthAsync(parent context.Context, store *HealthStore, clients []models.DownloadClient, downloadDir, audiobookDownloadDir string) {
+	if store == nil {
+		return
+	}
+	for i := range clients {
+		client := clients[i]
+		if !client.Enabled || client.Type != "qbittorrent" {
+			continue
+		}
+		store.Set(client.ID, CheckingHealth())
+		go func() {
+			ctx, cancel := context.WithTimeout(parent, 15*time.Second)
+			defer cancel()
+			store.Set(client.ID, CheckDownloadClientHealth(ctx, &client, downloadDir, audiobookDownloadDir))
+		}()
+	}
+}
+
+func CheckDownloadClientHealth(ctx context.Context, client *models.DownloadClient, downloadDir, audiobookDownloadDir string) models.DownloadClientHealth {
+	if client == nil || client.Type != "qbittorrent" {
+		return models.DownloadClientHealth{Status: HealthOK, Message: "Download client path check not required"}
+	}
+	return checkQbittorrentCategoryPath(ctx, client, downloadDir, audiobookDownloadDir)
+}
+
+func ExpectedDownloadDirForClient(client *models.DownloadClient, downloadDir, audiobookDownloadDir string) string {
+	if client == nil {
+		return strings.TrimSpace(downloadDir)
+	}
+	if strings.Contains(strings.ToLower(client.Category), "audio") && strings.TrimSpace(audiobookDownloadDir) != "" {
+		return strings.TrimSpace(audiobookDownloadDir)
+	}
+	return strings.TrimSpace(downloadDir)
+}
+
+func TargetDownloadDir(mediaType, downloadDir, audiobookDownloadDir string) string {
+	if mediaType == models.MediaTypeAudiobook && strings.TrimSpace(audiobookDownloadDir) != "" {
+		return strings.TrimSpace(audiobookDownloadDir)
+	}
+	return strings.TrimSpace(downloadDir)
+}
+
+func checkQbittorrentCategoryPath(ctx context.Context, client *models.DownloadClient, downloadDir, audiobookDownloadDir string) models.DownloadClientHealth {
+	category := strings.TrimSpace(client.Category)
+	if category == "" {
+		return healthError("qBittorrent category is empty; configure a category with a save path")
+	}
+	expected := filepath.Clean(ExpectedDownloadDirForClient(client, downloadDir, audiobookDownloadDir))
+	if expected == "." || expected == "" {
+		return healthError("Bindery download directory is empty; check BINDERY_DOWNLOAD_DIR")
+	}
+
+	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
+	categories, err := qb.GetCategories(ctx)
+	if err != nil {
+		return healthError(fmt.Sprintf("qBittorrent category path check failed: %v", err))
+	}
+	qbCategory, ok := categories[category]
+	if !ok {
+		return healthError(fmt.Sprintf("qBittorrent category %q was not found; create it with save path %q", category, expected))
+	}
+
+	savePath := strings.TrimSpace(qbCategory.SavePath)
+	if savePath == "" {
+		message := fmt.Sprintf("qBittorrent category %q has no save path; expected %q", category, expected)
+		if defaultPath, err := qb.GetDefaultSavePath(ctx); err == nil && strings.TrimSpace(defaultPath) != "" {
+			message += fmt.Sprintf(" and qBittorrent default is %q", strings.TrimSpace(defaultPath))
+		}
+		return healthError(message)
+	}
+
+	localPath := filepath.Clean(pathmap.Parse(client.PathRemap).Apply(savePath))
+	if localPath != expected {
+		return healthError(fmt.Sprintf("qBittorrent category %q saves to %q, which maps to %q; expected %q", category, savePath, localPath, expected))
+	}
+
+	return models.DownloadClientHealth{
+		Status:  HealthOK,
+		Message: fmt.Sprintf("qBittorrent category %q saves to %q", category, savePath),
+	}
+}
+
+func healthError(message string) models.DownloadClientHealth {
+	return models.DownloadClientHealth{Status: HealthError, Message: message}
+}

--- a/internal/downloader/health_test.go
+++ b/internal/downloader/health_test.go
@@ -1,0 +1,87 @@
+package downloader
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestCheckDownloadClientHealth_QBittorrentCategoryPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		categories string
+		wantStatus string
+		wantText   string
+	}{
+		{
+			name:       "remapped category path matches",
+			categories: `{"books":{"name":"books","savePath":"/media/downloads"}}`,
+			wantStatus: HealthOK,
+		},
+		{
+			name:       "missing category",
+			categories: `{}`,
+			wantStatus: HealthError,
+			wantText:   "was not found",
+		},
+		{
+			name:       "empty category path reports default",
+			categories: `{"books":{"name":"books","savePath":""}}`,
+			wantStatus: HealthError,
+			wantText:   "qBittorrent default is",
+		},
+		{
+			name:       "mismatched category path",
+			categories: `{"books":{"name":"books","savePath":"/media/other"}}`,
+			wantStatus: HealthError,
+			wantText:   `expected "/books/downloads"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v2/auth/login":
+					_, _ = w.Write([]byte("Ok."))
+				case "/api/v2/torrents/categories":
+					_, _ = w.Write([]byte(tc.categories))
+				case "/api/v2/app/defaultSavePath":
+					_, _ = w.Write([]byte("/media/default"))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer srv.Close()
+
+			host, port := serverHostPort(t, srv.URL)
+			client := &models.DownloadClient{
+				Type:      "qbittorrent",
+				Host:      host,
+				Port:      port,
+				Username:  "u",
+				Password:  "p",
+				Category:  "books",
+				PathRemap: "/media:/books",
+			}
+			got := CheckDownloadClientHealth(context.Background(), client, "/books/downloads", "")
+			if got.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q; message=%s", got.Status, tc.wantStatus, got.Message)
+			}
+			if tc.wantText != "" && !strings.Contains(got.Message, tc.wantText) {
+				t.Fatalf("message %q does not contain %q", got.Message, tc.wantText)
+			}
+		})
+	}
+}
+
+func TestExpectedDownloadDirForClient_AudiobookCategory(t *testing.T) {
+	client := &models.DownloadClient{Category: "audiobooks"}
+	if got := ExpectedDownloadDirForClient(client, "/books/downloads", "/books/audio-downloads"); got != "/books/audio-downloads" {
+		t.Fatalf("expected audiobook download dir, got %q", got)
+	}
+}

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -468,6 +468,34 @@ func (c *Client) GetTorrents(ctx context.Context, category string) ([]Torrent, e
 	return torrents, nil
 }
 
+// GetCategories returns all configured qBittorrent categories keyed by name.
+func (c *Client) GetCategories(ctx context.Context) (map[string]Category, error) {
+	data, err := c.get(ctx, "/api/v2/torrents/categories")
+	if err != nil {
+		return nil, err
+	}
+	var categories map[string]Category
+	if err := json.Unmarshal(data, &categories); err != nil {
+		return nil, fmt.Errorf("decode categories: %w", err)
+	}
+	for name, category := range categories {
+		if category.Name == "" {
+			category.Name = name
+			categories[name] = category
+		}
+	}
+	return categories, nil
+}
+
+// GetDefaultSavePath returns qBittorrent's default save path.
+func (c *Client) GetDefaultSavePath(ctx context.Context) (string, error) {
+	data, err := c.get(ctx, "/api/v2/app/defaultSavePath")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
 // DeleteTorrent removes a torrent by hash, optionally deleting its files.
 func (c *Client) DeleteTorrent(ctx context.Context, hash string, deleteFiles bool) error {
 	deleteFilesStr := "false"

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
+	"github.com/vavallee/bindery/internal/httpsec"
 )
 
 // AuthError signals that qBittorrent responded but rejected the login.
@@ -51,6 +52,10 @@ func (e *AuthError) Error() string {
 // to appear in the unfiltered torrent list.
 var hashPollTimeout = 30 * time.Second
 
+// maxTorrentFileBytes caps the torrent payload Bindery will fetch before
+// uploading it to qBittorrent.
+var maxTorrentFileBytes int64 = 50 << 20
+
 // Client interacts with the qBittorrent WebUI API v2.
 // Authentication is cookie-based: Login() obtains a SID cookie which is
 // stored in the embedded http.Client's cookie jar and sent automatically on
@@ -60,14 +65,14 @@ var hashPollTimeout = 30 * time.Second
 //   - APIKey  → password  (qBittorrent uses username/password, not an API key)
 //   - URLBase → reverse-proxy subpath, appended to baseURL (#369)
 type Client struct {
-	baseURL   string
-	username  string
-	password  string
-	http      *http.Client
-	fetchHTTP *http.Client // fetches .torrent file content on behalf of qBittorrent
-	mu        sync.Mutex   // guards loggedIn
-	addMu     sync.Mutex   // serialises AddTorrent: keeps before/after hash diff atomic
-	loggedIn  bool
+	baseURL            string
+	username           string
+	password           string
+	http               *http.Client
+	validateTorrentURL func(string) error
+	mu                 sync.Mutex // guards loggedIn
+	addMu              sync.Mutex // serialises AddTorrent: keeps before/after hash diff atomic
+	loggedIn           bool
 }
 
 // New creates a qBittorrent client. urlBase is the optional reverse-proxy
@@ -81,11 +86,13 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 
 	jar, _ := cookiejar.New(nil)
 	return &Client{
-		fetchHTTP: &http.Client{Timeout: 60 * time.Second},
-		baseURL:   fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
-		username:  username,
-		password:  password,
-		http:      &http.Client{Timeout: 15 * time.Second, Jar: jar},
+		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
+		username: username,
+		password: password,
+		http:     &http.Client{Timeout: 15 * time.Second, Jar: jar},
+		validateTorrentURL: func(raw string) error {
+			return httpsec.ValidateOutboundURL(raw, httpsec.PolicyLAN)
+		},
 	}
 }
 
@@ -185,40 +192,63 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 	}
 
 	var req *http.Request
+	submitted := magnetOrURL
 	if strings.HasPrefix(magnetOrURL, "http://") || strings.HasPrefix(magnetOrURL, "https://") {
 		// Fetch the .torrent content in Bindery so qBittorrent never needs to
 		// reach the indexer URL directly (which may be a Docker-only hostname
 		// like prowlarr:9696 that qBittorrent can't resolve from its network).
-		content, err := c.fetchTorrentContent(magnetOrURL)
+		fetched, err := c.fetchTorrentContent(ctx, magnetOrURL)
 		if err != nil {
 			return "", fmt.Errorf("fetch torrent content: %w", err)
 		}
 
-		var buf bytes.Buffer
-		mw := multipart.NewWriter(&buf)
-		fw, err := mw.CreateFormFile("torrents", "upload.torrent")
-		if err != nil {
-			return "", fmt.Errorf("build multipart: %w", err)
-		}
-		if _, err := fw.Write(content); err != nil {
-			return "", fmt.Errorf("write torrent content: %w", err)
-		}
-		if category != "" {
-			_ = mw.WriteField("category", category)
-		}
-		if savePath != "" {
-			_ = mw.WriteField("savepath", savePath)
-		}
-		if err := mw.Close(); err != nil {
-			return "", fmt.Errorf("close multipart writer: %w", err)
-		}
+		if fetched.magnetURL != "" {
+			submitted = fetched.magnetURL
+			form := url.Values{"urls": {fetched.magnetURL}}
+			if category != "" {
+				form.Set("category", category)
+			}
+			if savePath != "" {
+				form.Set("savepath", savePath)
+			}
+			req, err = http.NewRequestWithContext(ctx, http.MethodPost,
+				c.baseURL+"/api/v2/torrents/add",
+				strings.NewReader(form.Encode()))
+			if err != nil {
+				return "", fmt.Errorf("build add request: %w", err)
+			}
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		} else {
+			var buf bytes.Buffer
+			mw := multipart.NewWriter(&buf)
+			fw, err := mw.CreateFormFile("torrents", "upload.torrent")
+			if err != nil {
+				return "", fmt.Errorf("build multipart: %w", err)
+			}
+			if _, err := fw.Write(fetched.data); err != nil {
+				return "", fmt.Errorf("write torrent content: %w", err)
+			}
+			if category != "" {
+				if err := mw.WriteField("category", category); err != nil {
+					return "", fmt.Errorf("write torrent category: %w", err)
+				}
+			}
+			if savePath != "" {
+				if err := mw.WriteField("savepath", savePath); err != nil {
+					return "", fmt.Errorf("write torrent savepath: %w", err)
+				}
+			}
+			if err := mw.Close(); err != nil {
+				return "", fmt.Errorf("close multipart: %w", err)
+			}
 
-		req, err = http.NewRequestWithContext(ctx, http.MethodPost,
-			c.baseURL+"/api/v2/torrents/add", &buf)
-		if err != nil {
-			return "", fmt.Errorf("build add request: %w", err)
+			req, err = http.NewRequestWithContext(ctx, http.MethodPost,
+				c.baseURL+"/api/v2/torrents/add", &buf)
+			if err != nil {
+				return "", fmt.Errorf("build add request: %w", err)
+			}
+			req.Header.Set("Content-Type", mw.FormDataContentType())
 		}
-		req.Header.Set("Content-Type", mw.FormDataContentType())
 	} else {
 		form := url.Values{"urls": {magnetOrURL}}
 		if category != "" {
@@ -253,7 +283,7 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 		return "", fmt.Errorf("add torrent failed: %s", text)
 	}
 
-	if infoHash := infoHashFromMagnet(magnetOrURL); infoHash != "" {
+	if infoHash := infoHashFromMagnet(submitted); infoHash != "" {
 		return infoHash, nil
 	}
 
@@ -329,18 +359,94 @@ func infoHashFromMagnet(raw string) string {
 	return strings.ToLower(h)
 }
 
+type fetchedTorrentContent struct {
+	data      []byte
+	magnetURL string
+}
+
 // fetchTorrentContent downloads a .torrent file URL and returns its raw bytes.
-// It limits the response to 50 MiB to guard against runaway reads.
-func (c *Client) fetchTorrentContent(rawURL string) ([]byte, error) {
-	resp, err := c.fetchHTTP.Get(rawURL) //nolint:noctx
+// It limits the response size and validates each redirect target before fetch.
+func (c *Client) fetchTorrentContent(ctx context.Context, rawURL string) (*fetchedTorrentContent, error) {
+	current := rawURL
+	fetchClient := &http.Client{
+		Transport: c.http.Transport,
+		Timeout:   c.http.Timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	for redirects := 0; redirects <= 5; redirects++ {
+		if err := c.validateTorrentFetchURL(current); err != nil {
+			return nil, err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, current, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build torrent fetch request: %w", err)
+		}
+		req.Header.Set("Accept", "application/x-bittorrent")
+
+		resp, err := fetchClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode < http.StatusBadRequest {
+			location := resp.Header.Get("Location")
+			_, _ = io.Copy(io.Discard, resp.Body)
+			if err := resp.Body.Close(); err != nil {
+				return nil, fmt.Errorf("close redirect body: %w", err)
+			}
+			if location == "" {
+				return nil, fmt.Errorf("redirect without location")
+			}
+			if strings.HasPrefix(strings.ToLower(location), "magnet:") {
+				return &fetchedTorrentContent{magnetURL: location}, nil
+			}
+			next, err := req.URL.Parse(location)
+			if err != nil {
+				return nil, fmt.Errorf("invalid redirect location: %w", err)
+			}
+			if next.Scheme != "http" && next.Scheme != "https" {
+				return nil, fmt.Errorf("unsupported redirect scheme %q", next.Scheme)
+			}
+			current = next.String()
+			continue
+		}
+
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("indexer returned HTTP %d", resp.StatusCode)
+		}
+		data, err := readLimited(resp.Body, maxTorrentFileBytes)
+		if err != nil {
+			return nil, err
+		}
+		if len(data) == 0 {
+			return nil, fmt.Errorf("empty torrent response")
+		}
+		return &fetchedTorrentContent{data: data}, nil
+	}
+
+	return nil, fmt.Errorf("too many redirects")
+}
+
+func (c *Client) validateTorrentFetchURL(raw string) error {
+	if c.validateTorrentURL == nil {
+		return httpsec.ValidateOutboundURL(raw, httpsec.PolicyLAN)
+	}
+	return c.validateTorrentURL(raw)
+}
+
+func readLimited(r io.Reader, maxBytes int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("indexer returned HTTP %d", resp.StatusCode)
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("torrent response exceeds %d bytes", maxBytes)
 	}
-	return io.ReadAll(io.LimitReader(resp.Body, 50<<20))
+	return data, nil
 }
 
 // GetTorrents returns all torrents in the given category (empty = all).

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -441,6 +441,35 @@ func TestAddTorrent_WithCategoryAndSavePath(t *testing.T) {
 	}
 }
 
+func TestGetCategories_NormalizesSavePathKeys(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/categories":
+			_, _ = w.Write([]byte(`{
+				"books":{"name":"books","savePath":"/media/books"},
+				"audiobooks":{"name":"audiobooks","save_path":"/media/audio"}
+			}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	cats, err := c.GetCategories(context.Background())
+	if err != nil {
+		t.Fatalf("GetCategories: %v", err)
+	}
+	if cats["books"].SavePath != "/media/books" {
+		t.Errorf("books save path = %q", cats["books"].SavePath)
+	}
+	if cats["audiobooks"].SavePath != "/media/audio" {
+		t.Errorf("audiobooks save path = %q", cats["audiobooks"].SavePath)
+	}
+}
+
 func TestAddTorrent_FailsBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -83,6 +83,7 @@ func TestAddTorrent_ConcurrentUniqueHashes(t *testing.T) {
 	defer indexer.Close()
 
 	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
 	c.loggedIn = true
 
 	var wg sync.WaitGroup
@@ -145,6 +146,10 @@ func newTestClient(serverURL, username, password string) *Client {
 	c := New("localhost", 8080, username, password, "", false)
 	c.baseURL = serverURL
 	return c
+}
+
+func allowTorrentFetch(c *Client) {
+	c.validateTorrentURL = func(string) error { return nil }
 }
 
 func TestNew(t *testing.T) {
@@ -530,6 +535,7 @@ func TestAddTorrent_TorrentURL_SubmitsMultipart(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
 	if _, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "", ""); err != nil {
 		t.Fatalf("AddTorrent: %v", err)
 	}
@@ -578,6 +584,7 @@ func TestAddTorrent_TorrentURL_WithCategoryAndSavePath(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
 	if _, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "books", "/downloads"); err != nil {
 		t.Fatalf("AddTorrent: %v", err)
 	}
@@ -611,6 +618,7 @@ func TestAddTorrent_TorrentURL_FetchFailure(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
 	_, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "", "")
 	if err == nil {
 		t.Fatal("expected error when indexer returns 401")
@@ -620,6 +628,120 @@ func TestAddTorrent_TorrentURL_FetchFailure(t *testing.T) {
 	}
 	if qbitCalled {
 		t.Error("qBittorrent should not be contacted when torrent fetch fails")
+	}
+}
+
+func TestAddTorrent_TorrentURL_RedirectToMagnetUsesURLForm(t *testing.T) {
+	const magnet = "magnet:?xt=urn:btih:ABCDEF123&dn=Book"
+	indexer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, magnet, http.StatusFound)
+	}))
+	defer indexer.Close()
+
+	var gotURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			if err := r.ParseForm(); err != nil {
+				t.Fatal(err)
+			}
+			gotURL = r.FormValue("urls")
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte("[]"))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
+	hash, err := c.AddTorrent(context.Background(), indexer.URL+"/redirect", "books", "")
+	if err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if hash != "abcdef123" {
+		t.Errorf("hash: want abcdef123, got %q", hash)
+	}
+	if gotURL != magnet {
+		t.Errorf("urls field: want %q, got %q", magnet, gotURL)
+	}
+}
+
+func TestAddTorrent_TorrentURL_OversizedResponseDoesNotCallQbitAdd(t *testing.T) {
+	orig := maxTorrentFileBytes
+	maxTorrentFileBytes = 8
+	t.Cleanup(func() { maxTorrentFileBytes = orig })
+
+	indexer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("123456789"))
+	}))
+	defer indexer.Close()
+
+	qbitCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			qbitCalled = true
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte("[]"))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
+	_, err := c.AddTorrent(context.Background(), indexer.URL+"/too-large.torrent", "", "")
+	if err == nil {
+		t.Fatal("expected oversized response error")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected oversized error, got: %v", err)
+	}
+	if qbitCalled {
+		t.Error("qBittorrent should not be contacted when torrent fetch is oversized")
+	}
+}
+
+func TestAddTorrent_TorrentURL_DefaultValidationRejectsLoopbackBeforeFetch(t *testing.T) {
+	indexerCalled := false
+	indexer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		indexerCalled = true
+		_, _ = w.Write([]byte(fakeTorrentContent))
+	}))
+	defer indexer.Close()
+
+	qbitAddCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			qbitAddCalled = true
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte("[]"))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	_, err := c.AddTorrent(context.Background(), indexer.URL+"/blocked.torrent", "", "")
+	if err == nil {
+		t.Fatal("expected loopback URL validation failure")
+	}
+	if !strings.Contains(err.Error(), "url not allowed") {
+		t.Errorf("expected URL validation error, got: %v", err)
+	}
+	if indexerCalled {
+		t.Error("indexer URL must not be fetched after validation failure")
+	}
+	if qbitAddCalled {
+		t.Error("qBittorrent add endpoint should not be contacted after validation failure")
 	}
 }
 
@@ -904,6 +1026,7 @@ func TestAddTorrent_HashFoundUnderDifferentCategory(t *testing.T) {
 	defer indexer.Close()
 
 	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
 	hash, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "books", "")
 	if err != nil {
 		t.Fatalf("AddTorrent: %v", err)
@@ -966,6 +1089,7 @@ func TestAddTorrent_HashLookupTimeout(t *testing.T) {
 	defer indexer.Close()
 
 	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
 	_, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "books", "")
 	if err == nil {
 		t.Fatal("expected error on timeout, got nil")

--- a/internal/downloader/qbittorrent/types.go
+++ b/internal/downloader/qbittorrent/types.go
@@ -1,5 +1,7 @@
 package qbittorrent
 
+import "encoding/json"
+
 // Torrent represents a single torrent as returned by the qBittorrent WebUI API.
 type Torrent struct {
 	Hash        string  `json:"hash"`
@@ -14,4 +16,33 @@ type Torrent struct {
 	ETA         int     `json:"eta"`
 	AddedOn     int64   `json:"added_on"`
 	DLSpeed     int64   `json:"dlspeed"`
+}
+
+// Category represents a qBittorrent category. Different qBittorrent versions
+// have used different JSON keys for the category save path, so UnmarshalJSON
+// accepts all observed variants and normalizes them to SavePath.
+type Category struct {
+	Name     string `json:"name"`
+	SavePath string `json:"savePath"`
+}
+
+func (c *Category) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Name          string `json:"name"`
+		SavePath      string `json:"savePath"`
+		SavePathSnake string `json:"save_path"`
+		DownloadPath  string `json:"download_path"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	c.Name = raw.Name
+	c.SavePath = raw.SavePath
+	if c.SavePath == "" {
+		c.SavePath = raw.SavePathSnake
+	}
+	if c.SavePath == "" {
+		c.SavePath = raw.DownloadPath
+	}
+	return nil
 }

--- a/internal/importer/remap.go
+++ b/internal/importer/remap.go
@@ -1,77 +1,9 @@
 package importer
 
-import (
-	"path/filepath"
-	"strings"
-)
+import "github.com/vavallee/bindery/internal/pathmap"
 
-// Remapper rewrites paths reported by the download client into paths visible
-// inside bindery's own filesystem. Needed when the download client and bindery
-// run in separate containers/pods that mount the same storage at different
-// mount points — SABnzbd may report `/downloads/complete/X` while bindery sees
-// the same files at `/media/complete/X`.
-//
-// Rules are applied by longest source prefix first, so more-specific mappings
-// win over broader ones regardless of declaration order.
-type Remapper struct {
-	rules []remapRule
-}
+// Remapper is kept as a compatibility alias for importer tests and callers.
+type Remapper = pathmap.Remapper
 
-type remapRule struct {
-	from string
-	to   string
-}
-
-// ParseRemap accepts a comma-separated list of `from:to` pairs, e.g.
-// `/downloads:/media,/srv/sab:/mnt/sab`. Empty or malformed entries are
-// skipped. A nil-safe zero Remapper is returned on empty input; Apply on
-// a zero Remapper returns the path unchanged.
-func ParseRemap(spec string) *Remapper {
-	r := &Remapper{}
-	for entry := range strings.SplitSeq(spec, ",") {
-		entry = strings.TrimSpace(entry)
-		if entry == "" {
-			continue
-		}
-		colon := strings.Index(entry, ":")
-		if colon <= 0 || colon == len(entry)-1 {
-			continue
-		}
-		from := strings.TrimRight(strings.TrimSpace(entry[:colon]), "/")
-		to := strings.TrimRight(strings.TrimSpace(entry[colon+1:]), "/")
-		if from == "" || to == "" {
-			continue
-		}
-		r.rules = append(r.rules, remapRule{from: from, to: to})
-	}
-	// Sort longest prefix first so specific rules beat general ones.
-	for i := 1; i < len(r.rules); i++ {
-		for j := i; j > 0 && len(r.rules[j].from) > len(r.rules[j-1].from); j-- {
-			r.rules[j], r.rules[j-1] = r.rules[j-1], r.rules[j]
-		}
-	}
-	return r
-}
-
-// Apply rewrites p according to the first matching rule. A rule matches when
-// p is exactly the source prefix or when it starts with source prefix + "/".
-// If no rule matches (or the Remapper is nil/empty), p is returned unchanged.
-func (r *Remapper) Apply(p string) string {
-	if r == nil || len(r.rules) == 0 || p == "" {
-		return p
-	}
-	for _, rule := range r.rules {
-		if p == rule.from {
-			return rule.to
-		}
-		if strings.HasPrefix(p, rule.from+"/") {
-			return filepath.Join(rule.to, strings.TrimPrefix(p, rule.from))
-		}
-	}
-	return p
-}
-
-// Empty reports whether the remapper has no rules.
-func (r *Remapper) Empty() bool {
-	return r == nil || len(r.rules) == 0
-}
+// ParseRemap is kept as a compatibility wrapper for existing importer callers.
+var ParseRemap = pathmap.Parse

--- a/internal/importer/remap_test.go
+++ b/internal/importer/remap_test.go
@@ -1,6 +1,10 @@
 package importer
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
 
 func TestRemapperApply(t *testing.T) {
 	tests := []struct {
@@ -54,6 +58,18 @@ func TestRemapperNilSafe(t *testing.T) {
 func TestParseRemapSkipsJunk(t *testing.T) {
 	r := ParseRemap(",,:,foo:,:bar,   ,")
 	if !r.Empty() {
-		t.Errorf("expected empty remapper, got %+v", r.rules)
+		t.Error("expected empty remapper")
+	}
+}
+
+func TestScannerRemapDownloadClientPath(t *testing.T) {
+	s := NewScanner(nil, nil, nil, nil, nil, "/library", "", "", "", "/global:/local-global")
+
+	client := &models.DownloadClient{PathRemap: "/remote:/local"}
+	if got := s.remapDownloadClientPath(client, "/remote/downloads/book"); got != "/local/downloads/book" {
+		t.Fatalf("client remap = %q, want /local/downloads/book", got)
+	}
+	if got := s.remapDownloadClientPath(client, "/global/downloads/book"); got != "/local-global/downloads/book" {
+		t.Fatalf("global fallback remap = %q, want /local-global/downloads/book", got)
 	}
 }

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -398,7 +398,7 @@ func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.Down
 		switch slot.Status {
 		case "Completed":
 			if dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed {
-				localPath := s.remapper.Apply(slot.Path)
+				localPath := s.remapDownloadClientPath(client, slot.Path)
 				if localPath != slot.Path {
 					slog.Debug("remapped download path", "sab", slot.Path, "local", localPath)
 				}
@@ -407,7 +407,7 @@ func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.Down
 				s.tryImportSABnzbd(ctx, sab, dl, slot.NzoID, localPath)
 			} else if dl.Status == models.StateImportFailed && dl.ImportRetryCount < importRetryLimit {
 				// Bug #7: retry a previously failed import.
-				localPath := s.remapper.Apply(slot.Path)
+				localPath := s.remapDownloadClientPath(client, slot.Path)
 				slog.Info("retrying failed import", "title", dl.Title, "path", localPath,
 					"attempt", dl.ImportRetryCount+1, "limit", importRetryLimit)
 				if err := s.downloads.IncrementImportRetryCount(ctx, dl.ID); err != nil {
@@ -445,7 +445,7 @@ func (s *Scanner) checkNZBGetDownloads(ctx context.Context, client *models.Downl
 
 		if nzbget.IsSuccess(item.Status) {
 			if dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed {
-				localPath := s.remapper.Apply(item.DestDir)
+				localPath := s.remapDownloadClientPath(client, item.DestDir)
 				if localPath != item.DestDir {
 					slog.Debug("remapped download path", "nzbget", item.DestDir, "local", localPath)
 				}
@@ -454,7 +454,7 @@ func (s *Scanner) checkNZBGetDownloads(ctx context.Context, client *models.Downl
 				s.tryImportNZBGet(ctx, ng, dl, item.NZBID, localPath)
 			} else if dl.Status == models.StateImportFailed && dl.ImportRetryCount < importRetryLimit {
 				// Bug #7: retry a previously failed import.
-				localPath := s.remapper.Apply(item.DestDir)
+				localPath := s.remapDownloadClientPath(client, item.DestDir)
 				slog.Info("retrying failed import", "title", dl.Title, "path", localPath,
 					"attempt", dl.ImportRetryCount+1, "limit", importRetryLimit)
 				if err := s.downloads.IncrementImportRetryCount(ctx, dl.ID); err != nil {
@@ -522,17 +522,19 @@ func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models
 
 		if isComplete && (dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed) {
 			// Download is complete
-			slog.Info("download completed", "title", dl.Title, "path", torrent.DownloadDir)
+			downloadPath := s.remapDownloadClientPath(client, torrent.DownloadDir)
+			slog.Info("download completed", "title", dl.Title, "path", downloadPath)
 			s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
-			s.tryImportTransmission(ctx, &dl, torrent.DownloadDir)
+			s.tryImportTransmission(ctx, &dl, downloadPath)
 		} else if isComplete && dl.Status == models.StateImportFailed && dl.ImportRetryCount < importRetryLimit {
 			// Bug #7: retry a previously failed import.
-			slog.Info("retrying failed import", "title", dl.Title, "path", torrent.DownloadDir,
+			downloadPath := s.remapDownloadClientPath(client, torrent.DownloadDir)
+			slog.Info("retrying failed import", "title", dl.Title, "path", downloadPath,
 				"attempt", dl.ImportRetryCount+1, "limit", importRetryLimit)
 			if err := s.downloads.IncrementImportRetryCount(ctx, dl.ID); err != nil {
 				slog.Warn("failed to increment import retry count", "download_id", dl.ID, "error", err)
 			}
-			s.tryImportTransmission(ctx, &dl, torrent.DownloadDir)
+			s.tryImportTransmission(ctx, &dl, downloadPath)
 		} else if isStopped && !isComplete && dl.Status != models.StateFailed {
 			if stopError == "" {
 				// Transmission also reports user-paused torrents as stopped.
@@ -592,7 +594,7 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 					"name", torrent.Name)
 				continue
 			}
-			downloadPath := s.remapper.Apply(rawPath)
+			downloadPath := s.remapDownloadClientPath(client, rawPath)
 
 			slog.Info("download completed", "title", dl.Title, "path", downloadPath)
 			s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
@@ -610,7 +612,7 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 					"attempt", dl.ImportRetryCount+1)
 				continue
 			}
-			downloadPath := s.remapper.Apply(rawPath)
+			downloadPath := s.remapDownloadClientPath(client, rawPath)
 			slog.Info("retrying failed import", "title", dl.Title, "path", downloadPath,
 				"attempt", dl.ImportRetryCount+1, "limit", importRetryLimit)
 			if err := s.downloads.IncrementImportRetryCount(ctx, dl.ID); err != nil {
@@ -641,6 +643,15 @@ func (s *Scanner) tryImportTransmission(ctx context.Context, dl *models.Download
 
 func (s *Scanner) tryImportQbittorrent(ctx context.Context, dl *models.Download, downloadPath string) {
 	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", safeRemoteID(dl.TorrentID), nil)
+}
+
+func (s *Scanner) remapDownloadClientPath(client *models.DownloadClient, rawPath string) string {
+	if client != nil && strings.TrimSpace(client.PathRemap) != "" {
+		if localPath := ParseRemap(client.PathRemap).Apply(rawPath); localPath != rawPath {
+			return localPath
+		}
+	}
+	return s.remapper.Apply(rawPath)
 }
 
 // resolveQbitContentPath returns the on-disk content path for a completed torrent.

--- a/internal/models/download.go
+++ b/internal/models/download.go
@@ -3,25 +3,32 @@ package models
 import "time"
 
 type DownloadClient struct {
-	ID        int64     `json:"id"`
-	Name      string    `json:"name"`
-	Type      string    `json:"type"`
-	Host      string    `json:"host"`
-	Port      int       `json:"port"`
-	APIKey    string    `json:"apiKey"`
-	UseSSL    bool      `json:"useSsl"`
-	URLBase   string    `json:"urlBase"`
-	Category  string    `json:"category"`
-	Priority  int       `json:"priority"`
-	Enabled   bool      `json:"enabled"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	ID        int64                 `json:"id"`
+	Name      string                `json:"name"`
+	Type      string                `json:"type"`
+	Host      string                `json:"host"`
+	Port      int                   `json:"port"`
+	APIKey    string                `json:"apiKey"`
+	UseSSL    bool                  `json:"useSsl"`
+	URLBase   string                `json:"urlBase"`
+	Category  string                `json:"category"`
+	PathRemap string                `json:"pathRemap"`
+	Priority  int                   `json:"priority"`
+	Enabled   bool                  `json:"enabled"`
+	CreatedAt time.Time             `json:"createdAt"`
+	UpdatedAt time.Time             `json:"updatedAt"`
+	Health    *DownloadClientHealth `json:"health,omitempty"`
 
 	// Username and Password are used by download clients that authenticate with
 	// credentials rather than an API key (e.g. qBittorrent, Transmission).
 	// These fields are persisted in dedicated download_clients table columns.
 	Username string `json:"username"`
 	Password string `json:"password"`
+}
+
+type DownloadClientHealth struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
 }
 
 type Download struct {

--- a/internal/pathmap/remap.go
+++ b/internal/pathmap/remap.go
@@ -1,0 +1,126 @@
+// Package pathmap rewrites paths between external service mount points and
+// Bindery-visible mount points.
+package pathmap
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// Remapper rewrites paths according to comma-separated from:to prefix rules.
+// Rules are applied by longest source prefix first, so more-specific mappings
+// win over broader ones regardless of declaration order.
+type Remapper struct {
+	rules []remapRule
+}
+
+type remapRule struct {
+	from string
+	to   string
+}
+
+// Parse accepts a comma-separated list of `from:to` pairs, e.g.
+// `/downloads:/media,/srv/sab:/mnt/sab`. Empty or malformed entries are
+// skipped. A nil-safe zero Remapper is returned on empty input.
+func Parse(spec string) *Remapper {
+	r := &Remapper{}
+	for entry := range strings.SplitSeq(spec, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		colon := strings.Index(entry, ":")
+		if colon <= 0 || colon == len(entry)-1 {
+			continue
+		}
+		from := cleanPrefix(entry[:colon])
+		to := cleanPrefix(entry[colon+1:])
+		if from == "" || to == "" {
+			continue
+		}
+		r.rules = append(r.rules, remapRule{from: from, to: to})
+	}
+	r.sort()
+	return r
+}
+
+// Validate checks that spec is a comma-separated list of non-empty from:to
+// pairs. It validates format only, not filesystem existence.
+func Validate(spec string) error {
+	for i, pair := range strings.Split(spec, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		parts := strings.SplitN(pair, ":", 2)
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+			return fmt.Errorf("pair %d %q is not in 'from:to' format", i+1, pair)
+		}
+	}
+	return nil
+}
+
+// Apply rewrites p according to the first matching from prefix. A rule matches
+// when p is exactly the source prefix or when it starts with source prefix + "/".
+// If no rule matches, p is returned unchanged.
+func (r *Remapper) Apply(p string) string {
+	if r == nil || len(r.rules) == 0 || p == "" {
+		return p
+	}
+	for _, rule := range r.rules {
+		if p == rule.from {
+			return rule.to
+		}
+		if strings.HasPrefix(p, rule.from+"/") {
+			return filepath.Join(rule.to, strings.TrimPrefix(p, rule.from))
+		}
+	}
+	return p
+}
+
+// ApplyInverse rewrites p in the opposite direction, from a Bindery-visible
+// path back to the external service mount point.
+func (r *Remapper) ApplyInverse(p string) string {
+	if r == nil || len(r.rules) == 0 || p == "" {
+		return p
+	}
+	var best *remapRule
+	for _, rule := range r.rules {
+		if p == rule.to || strings.HasPrefix(p, rule.to+"/") {
+			if best == nil || len(rule.to) > len(best.to) {
+				rule := rule
+				best = &rule
+			}
+		}
+	}
+	if best != nil {
+		if p == best.to {
+			return best.from
+		}
+		return filepath.Join(best.from, strings.TrimPrefix(p, best.to))
+	}
+	return p
+}
+
+// Empty reports whether the remapper has no rules.
+func (r *Remapper) Empty() bool {
+	return r == nil || len(r.rules) == 0
+}
+
+func (r *Remapper) sort() {
+	for i := 1; i < len(r.rules); i++ {
+		for j := i; j > 0 && len(r.rules[j].from) > len(r.rules[j-1].from); j-- {
+			r.rules[j], r.rules[j-1] = r.rules[j-1], r.rules[j]
+		}
+	}
+}
+
+func cleanPrefix(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimRight(value, "/")
+	if value == "" {
+		return ""
+	}
+	return value
+}

--- a/internal/pathmap/remap_test.go
+++ b/internal/pathmap/remap_test.go
@@ -1,0 +1,31 @@
+package pathmap
+
+import "testing"
+
+func TestRemapperApplyAndInverse(t *testing.T) {
+	r := Parse("/media/downloads:/books/downloads,/media:/books")
+
+	if got := r.Apply("/media/downloads/A"); got != "/books/downloads/A" {
+		t.Fatalf("Apply longest prefix = %q, want /books/downloads/A", got)
+	}
+	if got := r.ApplyInverse("/books/downloads/A"); got != "/media/downloads/A" {
+		t.Fatalf("ApplyInverse longest prefix = %q, want /media/downloads/A", got)
+	}
+}
+
+func TestRemapperApplyInversePrefersLongestLocalPrefix(t *testing.T) {
+	r := Parse("/external/long:/books,/x:/books/downloads")
+
+	if got := r.ApplyInverse("/books/downloads/A"); got != "/x/A" {
+		t.Fatalf("ApplyInverse longest local prefix = %q, want /x/A", got)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	if err := Validate("/media:/books, /abs:/audiobooks"); err != nil {
+		t.Fatalf("Validate valid spec: %v", err)
+	}
+	if err := Validate("nodivider"); err == nil {
+		t.Fatal("Validate invalid spec expected error")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -64,23 +64,25 @@ type Scheduler struct {
 	searcher bookSearcher
 	meta     *metadata.Aggregator
 
-	authors       *db.AuthorRepo
-	books         *db.BookRepo
-	indexers      *db.IndexerRepo
-	downloads     *db.DownloadRepo
-	clients       *db.DownloadClientRepo
-	history       *db.HistoryRepo
-	settings      *db.SettingsRepo
-	blocklist     *db.BlocklistRepo
-	delayProfiles *db.DelayProfileRepo
-	pending       *db.PendingReleaseRepo
-	aliases       *db.AuthorAliasRepo  // optional; used for non-latin author matching
-	calibreSyncer CalibreSyncer        // optional; nil if Calibre is not configured
-	recommender   RecommendationEngine // optional; generates recommendations
-	hcSyncer      HCListSyncer         // optional; syncs Hardcover import lists
-	telemetry     TelemetryPinger      // optional; sends daily anonymous install ping
-	logs          *db.LogRepo          // optional; enables periodic log retention trim
-	logRetainDays int                  // 0 = use default (14)
+	authors              *db.AuthorRepo
+	books                *db.BookRepo
+	indexers             *db.IndexerRepo
+	downloads            *db.DownloadRepo
+	clients              *db.DownloadClientRepo
+	history              *db.HistoryRepo
+	settings             *db.SettingsRepo
+	blocklist            *db.BlocklistRepo
+	delayProfiles        *db.DelayProfileRepo
+	pending              *db.PendingReleaseRepo
+	aliases              *db.AuthorAliasRepo  // optional; used for non-latin author matching
+	calibreSyncer        CalibreSyncer        // optional; nil if Calibre is not configured
+	recommender          RecommendationEngine // optional; generates recommendations
+	hcSyncer             HCListSyncer         // optional; syncs Hardcover import lists
+	telemetry            TelemetryPinger      // optional; sends daily anonymous install ping
+	logs                 *db.LogRepo          // optional; enables periodic log retention trim
+	logRetainDays        int                  // 0 = use default (14)
+	downloadDir          string
+	audiobookDownloadDir string
 }
 
 const scheduledWantedSearchConcurrency = 2
@@ -135,6 +137,13 @@ func (s *Scheduler) WithHistory(h *db.HistoryRepo) {
 // in MatchCriteria for non-latin author name matching. Must be called before Start.
 func (s *Scheduler) WithAliases(aliases *db.AuthorAliasRepo) {
 	s.aliases = aliases
+}
+
+// WithStoragePaths attaches the process-level download roots used when sending
+// torrent clients an explicit save path.
+func (s *Scheduler) WithStoragePaths(downloadDir, audiobookDownloadDir string) {
+	s.downloadDir = downloadDir
+	s.audiobookDownloadDir = audiobookDownloadDir
 }
 
 // WithCalibreSyncer registers a CalibreSyncer that the scheduler will call
@@ -458,7 +467,11 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		return
 	}
 
-	sendRes, err := downloader.SendDownload(ctx, client, best.NZBURL, best.Title)
+	sendRes, err := downloader.SendDownload(ctx, client, best.NZBURL, best.Title, downloader.SendOptions{
+		MediaType:            mediaType,
+		DownloadDir:          s.downloadDir,
+		AudiobookDownloadDir: s.audiobookDownloadDir,
+	})
 	if err != nil {
 		slog.Error("SearchAndGrabBook: failed to send to downloader", "client", client.Type, "title", best.Title, "error", err)
 		if setErr := s.downloads.SetError(ctx, dl.ID, err.Error()); setErr != nil {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -314,6 +314,7 @@ export const api = {
   // Queue
   listQueue: () => request<QueueItem[]>('/queue'),
   grab: (data: GrabRequest) => request<Download>('/queue/grab', { method: 'POST', body: JSON.stringify(data) }),
+  retryImport: (id: number) => request<{ ok: boolean }>(`/queue/${id}/retry-import`, { method: 'POST' }),
   deleteFromQueue: (id: number) => request<void>(`/queue/${id}`, { method: 'DELETE' }),
 
   // Pending releases

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -298,7 +298,7 @@ export const api = {
   addDownloadClient: (data: Partial<DownloadClient>) => request<DownloadClient>('/downloadclient', { method: 'POST', body: JSON.stringify(data) }),
   updateDownloadClient: (id: number, data: Partial<DownloadClient>) => request<DownloadClient>(`/downloadclient/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   deleteDownloadClient: (id: number) => request<void>(`/downloadclient/${id}`, { method: 'DELETE' }),
-  testDownloadClient: (id: number) => request<{ message: string }>(`/downloadclient/${id}/test`, { method: 'POST' }),
+  testDownloadClient: (id: number) => request<{ message: string; health?: DownloadClientHealth }>(`/downloadclient/${id}/test`, { method: 'POST' }),
 
   // Library
   triggerLibraryScan: () => request<{ message: string }>('/library/scan', { method: 'POST' }),
@@ -920,7 +920,14 @@ export interface DownloadClient {
   useSsl: boolean
   urlBase: string
   category: string
+  pathRemap?: string
   enabled: boolean
+  health?: DownloadClientHealth
+}
+
+export interface DownloadClientHealth {
+  status: 'ok' | 'checking' | 'error'
+  message: string
 }
 
 export interface Download {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -191,6 +191,10 @@
     "title": "Queue",
     "empty": "Queue is empty",
     "remaining": "{{time}} remaining",
+    "retryImport": "Retry import",
+    "retryingImport": "Retrying…",
+    "retryImportHint": "After fixing the path remap or moving the completed files in the download client, retry import to reuse the existing download.",
+    "retryImportError": "Retry failed: {{error}}",
     "remove": "Remove"
   },
   "blocklist": {

--- a/web/src/pages/QueuePage.test.tsx
+++ b/web/src/pages/QueuePage.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../api/client', async importOriginal => {
       listQueue: vi.fn(),
       listPending: vi.fn(),
       deleteFromQueue: vi.fn(),
+      retryImport: vi.fn(),
       dismissPending: vi.fn(),
       grabPending: vi.fn(),
     },
@@ -29,6 +30,10 @@ vi.mock('react-i18next', () => ({
         'queue.title': 'Queue',
         'queue.empty': 'Queue is empty',
         'queue.remove': 'Remove',
+        'queue.retryImport': 'Retry import',
+        'queue.retryingImport': 'Retrying…',
+        'queue.retryImportHint': 'After fixing the path remap or moving the completed files in the download client, retry import to reuse the existing download.',
+        'queue.retryImportError': `Retry failed: ${String(options?.error)}`,
       }
       return labels[key] ?? key
     },
@@ -105,6 +110,7 @@ beforeEach(() => {
   vi.mocked(api.listQueue).mockResolvedValue([])
   vi.mocked(api.listPending).mockResolvedValue([])
   vi.mocked(api.deleteFromQueue).mockResolvedValue(undefined)
+  vi.mocked(api.retryImport).mockResolvedValue({ ok: true })
   vi.mocked(api.dismissPending).mockResolvedValue(undefined)
   vi.mocked(api.grabPending).mockResolvedValue(makeDownload())
 })
@@ -181,10 +187,57 @@ describe('QueuePage', () => {
     expect(screen.getByText('Import Failed')).toBeInTheDocument()
     expect(screen.getByText('Import failed:')).toBeInTheDocument()
     expect(screen.getByText('Missing target folder')).toBeInTheDocument()
+    expect(screen.getByText(/After fixing the path remap/)).toBeInTheDocument()
     expect(screen.getByText('Failed')).toBeInTheDocument()
     expect(screen.getByText('Error:')).toBeInTheDocument()
     expect(screen.getByText('Client rejected download')).toBeInTheDocument()
+    expect(screen.getAllByRole('button', { name: 'Retry import' })).toHaveLength(1)
     expect(container.querySelector('[style="width: 45%;"]')).toBeInTheDocument()
+  })
+
+  it('retries an import-failed queue item and reloads the queue', async () => {
+    const retry = deferred<{ ok: boolean }>()
+    vi.mocked(api.listQueue)
+      .mockResolvedValueOnce([makeQueueItem({
+        id: 3,
+        title: 'Retry Me',
+        status: 'importFailed',
+        errorMessage: 'Missing target folder',
+      })])
+      .mockResolvedValueOnce([])
+    vi.mocked(api.retryImport).mockReturnValue(retry.promise)
+
+    renderQueuePage()
+
+    expect(await screen.findByText('Retry Me')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry import' }))
+    expect(api.retryImport).toHaveBeenCalledWith(3)
+    expect(screen.getByRole('button', { name: 'Retrying…' })).toBeDisabled()
+
+    await act(async () => {
+      retry.resolve({ ok: true })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => expect(api.listQueue).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('Queue is empty')).toBeInTheDocument()
+  })
+
+  it('shows an inline error when retrying an import fails', async () => {
+    vi.mocked(api.listQueue).mockResolvedValue([makeQueueItem({
+      id: 4,
+      title: 'Retry Fails',
+      status: 'importFailed',
+      errorMessage: 'Missing target folder',
+    })])
+    vi.mocked(api.retryImport).mockRejectedValue(new Error('download is not in importFailed state'))
+
+    renderQueuePage()
+
+    expect(await screen.findByText('Retry Fails')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry import' }))
+
+    expect(await screen.findByText('Retry failed: download is not in importFailed state')).toBeInTheDocument()
   })
 
   it('renders pending releases and supports grabbing a pending release', async () => {

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -8,6 +8,8 @@ export default function QueuePage() {
   const [pending, setPending] = useState<PendingRelease[]>([])
   const [loading, setLoading] = useState(true)
   const [grabbingPending, setGrabbingPending] = useState<number | null>(null)
+  const [retryingImportIds, setRetryingImportIds] = useState<Set<number>>(() => new Set())
+  const [retryImportErrors, setRetryImportErrors] = useState<Record<number, string>>({})
 
   const load = () => {
     Promise.all([
@@ -49,6 +51,34 @@ export default function QueuePage() {
       console.error(e)
     } finally {
       setGrabbingPending(null)
+    }
+  }
+
+  const clearRetryImportError = (id: number) => {
+    setRetryImportErrors(prev => {
+      const next = { ...prev }
+      delete next[id]
+      return next
+    })
+  }
+
+  const handleRetryImport = async (id: number) => {
+    setRetryingImportIds(prev => new Set(prev).add(id))
+    clearRetryImportError(id)
+    try {
+      await api.retryImport(id)
+      load()
+    } catch (e) {
+      setRetryImportErrors(prev => ({
+        ...prev,
+        [id]: e instanceof Error ? e.message : 'Retry failed',
+      }))
+    } finally {
+      setRetryingImportIds(prev => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
     }
   }
 
@@ -171,6 +201,16 @@ export default function QueuePage() {
                         {item.errorMessage}
                       </div>
                     )}
+                    {item.status === 'importFailed' && (
+                      <div className="mt-1 text-xs text-slate-600 dark:text-zinc-400 bg-slate-200/70 dark:bg-zinc-800/70 rounded px-2 py-1 break-words">
+                        {t('queue.retryImportHint')}
+                      </div>
+                    )}
+                    {retryImportErrors[item.id] && (
+                      <div className="mt-1 text-xs text-red-600 dark:text-red-400 bg-red-400/10 rounded px-2 py-1 break-words">
+                        {t('queue.retryImportError', { error: retryImportErrors[item.id] })}
+                      </div>
+                    )}
                     {item.percentage && (
                       <div className="mt-2 h-1 bg-slate-200 dark:bg-zinc-800 rounded-full overflow-hidden">
                         <div
@@ -180,12 +220,24 @@ export default function QueuePage() {
                       </div>
                     )}
                   </div>
-                  <button
-                    onClick={() => handleDelete(item.id)}
-                    className="ml-4 px-3 py-2 text-xs text-red-400 hover:text-red-300 flex-shrink-0 touch-manipulation"
-                  >
-                    {t('queue.remove')}
-                  </button>
+                  <div className="ml-4 flex flex-col sm:flex-row items-end sm:items-center gap-2 flex-shrink-0">
+                    {item.status === 'importFailed' && (
+                      <button
+                        onClick={() => handleRetryImport(item.id)}
+                        disabled={retryingImportIds.has(item.id)}
+                        title={t('queue.retryImportHint')}
+                        className="px-3 py-2 text-xs bg-sky-600 hover:bg-sky-500 disabled:opacity-50 rounded font-medium touch-manipulation"
+                      >
+                        {retryingImportIds.has(item.id) ? t('queue.retryingImport') : t('queue.retryImport')}
+                      </button>
+                    )}
+                    <button
+                      onClick={() => handleDelete(item.id)}
+                      className="px-3 py-2 text-xs text-red-400 hover:text-red-300 touch-manipulation"
+                    >
+                      {t('queue.remove')}
+                    </button>
+                  </div>
                 </div>
               ))}
             </div>

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -275,7 +275,8 @@ describe('SettingsPage', () => {
   it('persists the enhanced Hardcover admin toggle separately from effective status', async () => {
     renderSettings()
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Toggle enhanced Hardcover series' }))
+    await screen.findByText('Hardcover API Token')
+    fireEvent.click(sectionForHeading('settings.general.apiKeys').getByTitle('common.enable'))
 
     await waitFor(() => {
       expect(api.setSetting).toHaveBeenCalledWith('hardcover.enhanced_series_enabled', 'true')
@@ -707,6 +708,7 @@ describe('SettingsPage', () => {
     expect(await screen.findByTitle('common.enable')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'common.delete' }))
+    fireEvent.click(screen.getByRole('button', { name: 'common.yes' }))
     await waitFor(() => expect(api.deleteIndexer).toHaveBeenCalledWith(8))
     await waitFor(() => expect(screen.queryByText('Toggle Indexer')).not.toBeInTheDocument())
   })
@@ -782,7 +784,6 @@ describe('SettingsPage', () => {
 
   it('tests, syncs, and deletes an existing Prowlarr instance', async () => {
     const prowlarr = makeProwlarr({ id: 33, name: 'Library Prowlarr', lastSyncAt: '2026-05-06T12:00:00Z' })
-    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
 
     try {
@@ -793,7 +794,7 @@ describe('SettingsPage', () => {
 
       fireEvent.click(screen.getByRole('button', { name: 'Test' }))
       await waitFor(() => expect(api.testProwlarr).toHaveBeenCalledWith(33))
-      expect(alertSpy).toHaveBeenCalledWith('Connected — Prowlarr 1.0.0')
+      expect(await screen.findByText('Connected — Prowlarr 1.0.0')).toBeInTheDocument()
 
       fireEvent.click(screen.getByRole('button', { name: 'Sync now' }))
       await waitFor(() => expect(api.syncProwlarr).toHaveBeenCalledWith(33))
@@ -806,7 +807,6 @@ describe('SettingsPage', () => {
       expect(confirmSpy).toHaveBeenCalledWith('Delete Prowlarr instance "Library Prowlarr" and all its synced indexers?')
       await waitFor(() => expect(screen.queryByText('Library Prowlarr')).not.toBeInTheDocument())
     } finally {
-      alertSpy.mockRestore()
       confirmSpy.mockRestore()
     }
   })
@@ -965,30 +965,26 @@ describe('SettingsPage', () => {
 
   it('toggles, tests, and deletes a download client', async () => {
     const client = makeClient({ id: 45, name: 'Client Actions', enabled: true })
-    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
     vi.mocked(api.updateDownloadClient).mockResolvedValue({ ...client, enabled: false })
 
-    try {
-      renderSettings({ clients: [client] })
-      await openClientsTab()
+    renderSettings({ clients: [client] })
+    await openClientsTab()
 
-      fireEvent.click(screen.getByTitle('common.disable'))
-      await waitFor(() => {
-        expect(api.updateDownloadClient).toHaveBeenCalledWith(45, { ...client, enabled: false })
-      })
-      expect(await screen.findByTitle('common.enable')).toBeInTheDocument()
+    fireEvent.click(screen.getByTitle('common.disable'))
+    await waitFor(() => {
+      expect(api.updateDownloadClient).toHaveBeenCalledWith(45, { ...client, enabled: false })
+    })
+    expect(await screen.findByTitle('common.enable')).toBeInTheDocument()
 
-      vi.mocked(api.testDownloadClient).mockResolvedValue({ message: 'Connection verified' })
-      fireEvent.click(screen.getByRole('button', { name: 'common.test' }))
-      await waitFor(() => expect(api.testDownloadClient).toHaveBeenCalledWith(45))
-      expect(alertSpy).toHaveBeenCalledWith('common.connOk')
+    vi.mocked(api.testDownloadClient).mockResolvedValue({ message: 'Connection verified' })
+    fireEvent.click(screen.getByRole('button', { name: 'common.test' }))
+    await waitFor(() => expect(api.testDownloadClient).toHaveBeenCalledWith(45))
+    expect(await screen.findByText('common.connOk')).toBeInTheDocument()
 
-      fireEvent.click(screen.getByRole('button', { name: 'common.delete' }))
-      await waitFor(() => expect(api.deleteDownloadClient).toHaveBeenCalledWith(45))
-      await waitFor(() => expect(screen.queryByText('Client Actions')).not.toBeInTheDocument())
-    } finally {
-      alertSpy.mockRestore()
-    }
+    fireEvent.click(screen.getByRole('button', { name: 'common.delete' }))
+    fireEvent.click(screen.getByRole('button', { name: 'common.yes' }))
+    await waitFor(() => expect(api.deleteDownloadClient).toHaveBeenCalledWith(45))
+    await waitFor(() => expect(screen.queryByText('Client Actions')).not.toBeInTheDocument())
   })
 
   it('shows error message when adding a download client fails', async () => {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -128,6 +128,7 @@ function makeClient(overrides: Partial<DownloadClient> = {}): DownloadClient {
     useSsl: false,
     urlBase: '',
     category: 'books',
+    pathRemap: '',
     enabled: true,
     ...overrides,
   }
@@ -822,6 +823,7 @@ describe('SettingsPage', () => {
     fireEvent.change(screen.getByPlaceholderText('/sabnzbd'), { target: { value: ' /sab ' } })
     fireEvent.change(screen.getByPlaceholderText('API Key'), { target: { value: 'sab-secret' } })
     fireEvent.change(screen.getByDisplayValue('books'), { target: { value: 'ebooks' } })
+    fireEvent.change(screen.getByLabelText('Download client path remap'), { target: { value: ' /media:/books ' } })
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
@@ -833,6 +835,7 @@ describe('SettingsPage', () => {
         username: '',
         password: '',
         category: 'ebooks',
+        pathRemap: '/media:/books',
         type: 'sabnzbd',
         enabled: true,
         useSsl: true,
@@ -899,6 +902,7 @@ describe('SettingsPage', () => {
         password,
         apiKey: '',
         category,
+        pathRemap: '',
         type,
         enabled: true,
         useSsl: false,
@@ -923,6 +927,7 @@ describe('SettingsPage', () => {
     fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'qbit-user' } })
     fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'qbit-pass' } })
     fireEvent.change(screen.getByDisplayValue('books'), { target: { value: 'ebooks' } })
+    fireEvent.change(screen.getByLabelText('Download client path remap'), { target: { value: ' /media:/books ' } })
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
@@ -936,11 +941,26 @@ describe('SettingsPage', () => {
         password: 'qbit-pass',
         apiKey: '',
         category: 'ebooks',
+        pathRemap: '/media:/books',
         useSsl: true,
         urlBase: '/qbittorrent',
       })
     })
     expect(await screen.findByText('qBit Books')).toBeInTheDocument()
+  })
+
+  it('shows qBittorrent path health errors under the client', async () => {
+    const client = makeClient({
+      id: 46,
+      name: 'qBit Books',
+      type: 'qbittorrent',
+      health: { status: 'error', message: 'qBittorrent category "books" saves to "/media/downloads"; expected "/books/downloads"' },
+    })
+
+    renderSettings({ clients: [client] })
+    await openClientsTab()
+
+    expect(await screen.findByText(/expected "\/books\/downloads"/)).toBeInTheDocument()
   })
 
   it('toggles, tests, and deletes a download client', async () => {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -958,6 +958,7 @@ describe('SettingsPage', () => {
       })
       expect(await screen.findByTitle('common.enable')).toBeInTheDocument()
 
+      vi.mocked(api.testDownloadClient).mockResolvedValue({ message: 'Connection verified' })
       fireEvent.click(screen.getByRole('button', { name: 'common.test' }))
       await waitFor(() => expect(api.testDownloadClient).toHaveBeenCalledWith(45))
       expect(alertSpy).toHaveBeenCalledWith('common.connOk')

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -47,6 +47,32 @@ function Toggle({ checked, onChange, title, disabled }: { checked: boolean; onCh
   )
 }
 
+function PathRemapField({ id, label, value, onChange, placeholder, help }: { id: string; label: string; value: string; onChange: (value: string) => void; placeholder: string; help: string }) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{label}</label>
+      <textarea
+        id={id}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        rows={3}
+        placeholder={placeholder}
+        className={inputCls}
+      />
+      <p className="text-[11px] text-slate-500 dark:text-zinc-500 mt-1">
+        {help} Use comma-separated <code className="text-[10px] bg-slate-200 dark:bg-zinc-800 px-1 rounded">from:to</code> prefix rewrites.
+      </p>
+    </div>
+  )
+}
+
+function downloadClientPathRemapHelp(type: string) {
+  if (type === 'qbittorrent') {
+    return "Map the path qBittorrent reports to the path Bindery can read. Example: if qBittorrent shows /downloads/books but Bindery sees that folder at /media/books, use /downloads:/media/books. Bindery also uses this in reverse when sending new torrents."
+  }
+  return "Optional and separate from ABS remaps. Use when this download client reports paths under a different mount than Bindery."
+}
+
 export default function SettingsPage() {
   const { t, i18n } = useTranslation()
   const { isAdmin } = useAuth()
@@ -417,7 +443,10 @@ export default function SettingsPage() {
                       <button
                         onClick={async () => {
                           try {
-                            await api.testDownloadClient(c.id)
+                            const result = await api.testDownloadClient(c.id)
+                            if (result.health) {
+                              setClients(prev => prev.map(x => x.id === c.id ? { ...x, health: result.health } : x))
+                            }
                             setClientTestResult(prev => ({ ...prev, [c.id]: { ok: true, msg: t('common.connOk') } }))
                           } catch (err: unknown) {
                             setClientTestResult(prev => ({ ...prev, [c.id]: { ok: false, msg: t('common.connFail', { error: err instanceof Error ? err.message : 'Unknown error' }) } }))
@@ -447,6 +476,11 @@ export default function SettingsPage() {
                       )}
                     </div>
                   </div>
+                  {c.type === 'qbittorrent' && c.health?.status === 'error' && (
+                    <div className="mt-1 px-3 py-2 bg-red-100 text-red-800 dark:bg-red-950/30 dark:text-red-300 border border-red-300 dark:border-red-900 rounded text-xs">
+                      {c.health.message}
+                    </div>
+                  )}
                   {editingClient === c.id && (
                     <EditClientForm
                       client={c}
@@ -1785,19 +1819,14 @@ function AudiobookshelfSection() {
           </div>
         )}
 
-        <div>
-          <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Path translation</label>
-          <textarea
-            value={draft.pathRemap}
-            onChange={e => setDraft(prev => ({ ...prev, pathRemap: e.target.value }))}
-            rows={3}
-            placeholder="/audiobookshelf:/books/audiobookshelf,/abs:/books"
-            className={inputCls}
-          />
-          <p className="text-[11px] text-slate-500 dark:text-zinc-500 mt-1">
-            Optional. Use comma-separated <code className="text-[10px] bg-slate-200 dark:bg-zinc-800 px-1 rounded">from:to</code> prefix rewrites when ABS reports shared-storage paths that Bindery sees under a different mount.
-          </p>
-        </div>
+        <PathRemapField
+          id="abs-path-remap"
+          label="ABS path remap"
+          value={draft.pathRemap}
+          onChange={value => setDraft(prev => ({ ...prev, pathRemap: value }))}
+          placeholder="/audiobookshelf:/books/audiobookshelf,/abs:/books"
+          help="Optional and separate from download-client remaps. Use when ABS reports shared-storage paths that Bindery sees under a different mount."
+        />
 
         <div className="flex flex-wrap gap-2">
           <button
@@ -4165,6 +4194,7 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
   const [category, setCategory] = useState(client.category)
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [pathRemap, setPathRemap] = useState(client.pathRemap || '')
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const handleTypeChange = (newType: string) => {
@@ -4178,8 +4208,8 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
 
   const submit = async () => {
     const data = isPasswordClient(type)
-      ? { ...client, name, type, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, useSsl: useSSL, urlBase: urlBase.trim() }
-      : { ...client, name, type, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, useSsl: useSSL, urlBase: urlBase.trim() }
+      ? { ...client, name, type, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, pathRemap: pathRemap.trim(), useSsl: useSSL, urlBase: urlBase.trim() }
+      : { ...client, name, type, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, pathRemap: pathRemap.trim(), useSsl: useSSL, urlBase: urlBase.trim() }
     setSaving(true)
     setSaveError(null)
     try {
@@ -4249,6 +4279,14 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
         {type === 'transmission' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Optional absolute path override. Leave blank to use Transmission's configured default download directory.</p>}
         {type === 'deluge' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Applied via the Deluge label plugin. Leave blank if the plugin is not installed.</p>}
       </div>
+      <PathRemapField
+        id={`edit-client-path-remap-${client.id}`}
+        label="Download client path remap"
+        value={pathRemap}
+        onChange={setPathRemap}
+        placeholder={type === 'qbittorrent' ? '/downloads:/media/books' : '/media:/books'}
+        help={downloadClientPathRemapHelp(type)}
+      />
       {saveError && <p className="text-sm text-red-500">{saveError}</p>}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
@@ -4371,6 +4409,7 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
   const [category, setCategory] = useState('books')
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [pathRemap, setPathRemap] = useState('')
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const isPasswordClient = (t: string) => t === 'qbittorrent' || t === 'transmission' || t === 'nzbget' || t === 'deluge'
@@ -4406,8 +4445,8 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
 
   const submit = async () => {
     const data = isPasswordClient(type)
-      ? { name, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
-      : { name, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
+      ? { name, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, pathRemap: pathRemap.trim(), type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
+      : { name, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, pathRemap: pathRemap.trim(), type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
     setSaving(true)
     setSaveError(null)
     try {
@@ -4477,6 +4516,14 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
         {type === 'transmission' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Optional absolute path override. Leave blank to use Transmission's configured default download directory.</p>}
         {type === 'deluge' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Applied via the Deluge label plugin. Leave blank if the plugin is not installed.</p>}
       </div>
+      <PathRemapField
+        id="add-client-path-remap"
+        label="Download client path remap"
+        value={pathRemap}
+        onChange={setPathRemap}
+        placeholder={type === 'qbittorrent' ? '/downloads:/media/books' : '/media:/books'}
+        help={downloadClientPathRemapHelp(type)}
+      />
       {saveError && <p className="text-sm text-red-500">{saveError}</p>}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>


### PR DESCRIPTION
## Summary

- Harden qBittorrent torrent URL submission for Docker/container-networked setups where qBittorrent cannot resolve the indexer URL directly. Bindery still fetches the torrent payload internally, then uploads it to qBittorrent, while preserving qBittorrent category and save-path metadata.
- Add the small follow-up fixes around that internal torrent fetch/upload path: redirect-to-magnet handling, bounded torrent response reads, redirect body cleanup, explicit multipart field error handling, and hash detection from the submitted magnet when a redirect resolves to one.
- Add per-download-client path remaps persisted on download clients and exposed in Settings. Import scanning now applies the matching client remap before the global fallback, and qBittorrent grabs inverse-map Bindery's ebook/audiobook download directory into qBittorrent's save path.
- Add user-facing Settings guidance for qBittorrent path mapping direction: qBittorrent-reported path on the left, Bindery-readable path on the right, with qBittorrent-specific examples and reverse-save-path behavior called out.
- Add qBittorrent category path health checks. Settings now surfaces category/save-path mismatches, missing categories, empty category save paths, and the qBittorrent default save path when useful.
- Add recovery paths for failed queue work: failed grabs can retry the same download row without losing book/edition/indexer context, and `importFailed` queue items can reset import retries so users can fix path/category config or manually move completed torrent files, then import from the existing download.
- Update Queue, API docs, deployment docs, changelog, backend tests, frontend tests, and lint/security readiness fixes for the new behavior.

## Security and validation notes

- Torrent fetch URLs are validated with Bindery's outbound URL policy before the initial fetch and before each redirect target is followed.
- Non-HTTP(S) redirects are rejected unless the redirect is a magnet URI, which is submitted through qBittorrent's URL form path instead of being fetched as a network resource.
- Torrent responses are capped before upload to qBittorrent, and qBittorrent is not contacted when the fetch fails, returns an oversized body, or is rejected by URL validation.
- qBittorrent category JSON decoding accepts the observed save-path key variants (`savePath`, `save_path`, `download_path`) so health checks work across qBittorrent versions.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] Wiki pages updated if user-facing behaviour changed 

## Test plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `golangci-lint run --timeout=5m`
- [x] `GOCACHE=<tmp-cache> govulncheck ./...`
- [x] `go test ./internal/pathmap ./internal/importer ./internal/downloader ./internal/downloader/qbittorrent ./internal/api ./internal/db ./internal/scheduler`
- [x] `go test ./internal/downloader/qbittorrent ./internal/downloader/nzbget`
- [x] `go test ./cmd/... ./internal/...`
- [x] `cd web && npm test -- QueuePage SettingsPage`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run typecheck`
- [x] `cd web && npm run build`
- [x] `cd web && npm test`

Not run locally: `docker buildx build --platform linux/amd64,linux/arm64 -t bindery:local .`; `goreleaser release --snapshot --clean`.