### PR TITLE
fix(logs): propagate runtime log level change to DB handler

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -449,7 +449,7 @@ func main() {
 	bulkHandler := api.NewBulkHandler(authorRepo, bookRepo, blocklistRepo, sched)
 	backupHandler := api.NewBackupHandler(cfg.DBPath, cfg.DataDir)
 	rootFolderHandler := api.NewRootFolderHandler(rootFolderRepo)
-	logHandler := api.NewLogHandler(ring).WithLogRepo(logRepo)
+	logHandler := api.NewLogHandler(ring).WithLogRepo(logRepo).WithDBLogHandler(logDBHandler)
 	prowlarrHandler := api.NewProwlarrHandler(prowlarrRepo, indexerRepo).WithSettings(settingsRepo)
 	calibreHandler := api.NewCalibreHandler(settingsRepo)
 	grimmoryHandler := api.NewGrimmoryHandler(settingsRepo).WithVersion(version)

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -15,8 +15,9 @@ import (
 // LogHandler exposes the log store over HTTP. When a LogRepo is attached it
 // queries the persistent database; otherwise it falls back to the ring buffer.
 type LogHandler struct {
-	ring *logbuf.Ring
-	logs *db.LogRepo // optional persistent store
+	ring   *logbuf.Ring
+	logs   *db.LogRepo     // optional persistent store
+	dblog  *db.LogHandler  // optional; kept in sync with ring level
 }
 
 func NewLogHandler(ring *logbuf.Ring) *LogHandler {
@@ -27,6 +28,13 @@ func NewLogHandler(ring *logbuf.Ring) *LogHandler {
 // database when date/component/search filters are supplied.
 func (h *LogHandler) WithLogRepo(logs *db.LogRepo) *LogHandler {
 	h.logs = logs
+	return h
+}
+
+// WithDBLogHandler stores a reference to the DB slog handler so that
+// SetLevel propagates to it alongside the ring buffer.
+func (h *LogHandler) WithDBLogHandler(dblog *db.LogHandler) *LogHandler {
+	h.dblog = dblog
 	return h
 }
 
@@ -137,6 +145,9 @@ func (h *LogHandler) SetLevel(w http.ResponseWriter, r *http.Request) {
 	}
 	level := parseLevel(req.Level)
 	h.ring.SetLevel(level)
+	if h.dblog != nil {
+		h.dblog.SetLevel(level)
+	}
 	writeJSON(w, http.StatusOK, map[string]string{"level": level.String()})
 }
 

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -15,9 +15,9 @@ import (
 // LogHandler exposes the log store over HTTP. When a LogRepo is attached it
 // queries the persistent database; otherwise it falls back to the ring buffer.
 type LogHandler struct {
-	ring   *logbuf.Ring
-	logs   *db.LogRepo     // optional persistent store
-	dblog  *db.LogHandler  // optional; kept in sync with ring level
+	ring  *logbuf.Ring
+	logs  *db.LogRepo    // optional persistent store
+	dblog *db.LogHandler // optional; kept in sync with ring level
 }
 
 func NewLogHandler(ring *logbuf.Ring) *LogHandler {

--- a/internal/api/logs_test.go
+++ b/internal/api/logs_test.go
@@ -245,3 +245,31 @@ func TestLogGetLevel(t *testing.T) {
 		t.Errorf("expected WARN, got %q", out["level"])
 	}
 }
+
+func TestLogSetLevel_PropagatestoDBHandler(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ring := logbuf.New(100)
+	dbHandler := db.NewLogSlogHandler(db.NewLogRepo(database), slog.LevelInfo)
+	t.Cleanup(func() { dbHandler.Stop(context.Background()) })
+
+	h := NewLogHandler(ring).WithDBLogHandler(dbHandler)
+
+	body := bytes.NewBufferString(`{"level":"debug"}`)
+	rec := httptest.NewRecorder()
+	h.SetLevel(rec, httptest.NewRequest(http.MethodPut, "/system/loglevel", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ring.Level() != slog.LevelDebug {
+		t.Errorf("ring level: want DEBUG, got %s", ring.Level())
+	}
+	if dbHandler.Level() != slog.LevelDebug {
+		t.Errorf("dbHandler level: want DEBUG, got %s", dbHandler.Level())
+	}
+}

--- a/internal/db/log_handler.go
+++ b/internal/db/log_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -18,7 +19,9 @@ type LogHandler struct {
 	repo     *LogRepo
 	ch       chan LogEntry
 	preAttrs []slog.Attr
-	level    slog.Level
+	// levelVar is shared (by pointer) between the root handler and all children
+	// created via WithAttrs, so a single SetLevel call propagates everywhere.
+	levelVar *atomic.Int64
 	// wg is non-nil only on the root handler returned by NewLogSlogHandler.
 	// Child handlers from WithAttrs share repo+ch but must not own the wg or
 	// the close-channel responsibility.
@@ -28,23 +31,37 @@ type LogHandler struct {
 // NewLogSlogHandler returns a non-blocking slog.Handler backed by repo.
 // Call Stop to flush in-flight entries and shut the drain goroutine down.
 func NewLogSlogHandler(repo *LogRepo, minLevel slog.Level) *LogHandler {
+	lv := &atomic.Int64{}
+	lv.Store(int64(minLevel))
 	h := &LogHandler{
-		repo:  repo,
-		ch:    make(chan LogEntry, logHandlerBufSize),
-		level: minLevel,
-		wg:    &sync.WaitGroup{},
+		repo:     repo,
+		ch:       make(chan LogEntry, logHandlerBufSize),
+		levelVar: lv,
+		wg:       &sync.WaitGroup{},
 	}
 	h.wg.Add(1)
 	go h.drain()
 	return h
 }
 
+// SetLevel changes the minimum level recorded to the database. Safe to call
+// concurrently; takes effect immediately for both the root handler and any
+// child handlers created via WithAttrs.
+func (h *LogHandler) SetLevel(l slog.Level) {
+	h.levelVar.Store(int64(l))
+}
+
+// Level returns the current minimum level.
+func (h *LogHandler) Level() slog.Level {
+	return slog.Level(h.levelVar.Load())
+}
+
 func (h *LogHandler) Enabled(_ context.Context, level slog.Level) bool {
-	return level >= h.level
+	return level >= h.Level()
 }
 
 func (h *LogHandler) Handle(_ context.Context, rec slog.Record) error {
-	if rec.Level < h.level {
+	if rec.Level < h.Level() {
 		return nil
 	}
 
@@ -95,8 +112,9 @@ func (h *LogHandler) Handle(_ context.Context, rec slog.Record) error {
 
 func (h *LogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	combined := append(append([]slog.Attr{}, h.preAttrs...), attrs...)
+	// Share levelVar so SetLevel on the root propagates to all children.
 	// Intentionally do NOT propagate wg: only the root handler owns shutdown.
-	return &LogHandler{repo: h.repo, ch: h.ch, preAttrs: combined, level: h.level}
+	return &LogHandler{repo: h.repo, ch: h.ch, preAttrs: combined, levelVar: h.levelVar}
 }
 
 func (h *LogHandler) WithGroup(_ string) slog.Handler {

--- a/internal/db/log_handler_test.go
+++ b/internal/db/log_handler_test.go
@@ -107,6 +107,59 @@ func TestLogHandlerStop(t *testing.T) {
 	}
 }
 
+func TestLogHandler_SetLevelAndLevel(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	h := NewLogSlogHandler(NewLogRepo(database), slog.LevelInfo)
+	defer h.Stop(context.Background())
+
+	if h.Level() != slog.LevelInfo {
+		t.Errorf("initial level: want INFO, got %s", h.Level())
+	}
+
+	h.SetLevel(slog.LevelDebug)
+
+	if h.Level() != slog.LevelDebug {
+		t.Errorf("after SetLevel: want DEBUG, got %s", h.Level())
+	}
+	if !h.Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("Enabled(DEBUG) should be true after SetLevel(DEBUG)")
+	}
+}
+
+func TestLogHandler_SetLevelPropagatestoWithAttrsChild(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	h := NewLogSlogHandler(NewLogRepo(database), slog.LevelInfo)
+	defer h.Stop(context.Background())
+
+	child := h.WithAttrs([]slog.Attr{slog.String("component", "test")})
+
+	// Child starts at parent's level.
+	if child.Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("child should not be enabled for DEBUG before SetLevel")
+	}
+
+	// Changing parent level propagates to child via shared atomic.
+	h.SetLevel(slog.LevelDebug)
+	if !child.Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("child should be enabled for DEBUG after parent SetLevel(DEBUG)")
+	}
+
+	h.SetLevel(slog.LevelWarn)
+	if child.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("child should not be enabled for INFO after parent SetLevel(WARN)")
+	}
+}
+
 func TestLogSlogHandler_DropsOnFullChannel(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -20,8 +20,8 @@ import (
 
 // Client interacts with the NZBGet JSON-RPC API.
 type Client struct {
-	baseURL  string
-	http     *http.Client // NZBGet JSON-RPC transport
+	baseURL   string
+	http      *http.Client // NZBGet JSON-RPC transport
 	fetchHTTP *http.Client // used to fetch NZB content from indexers before submission
 	// username and password for HTTP Basic auth
 	username string

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -65,8 +65,8 @@ type Client struct {
 	password  string
 	http      *http.Client
 	fetchHTTP *http.Client // fetches .torrent file content on behalf of qBittorrent
-	mu        sync.Mutex  // guards loggedIn
-	addMu     sync.Mutex  // serialises AddTorrent: keeps before/after hash diff atomic
+	mu        sync.Mutex   // guards loggedIn
+	addMu     sync.Mutex   // serialises AddTorrent: keeps before/after hash diff atomic
 	loggedIn  bool
 }
 
@@ -82,10 +82,10 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 	jar, _ := cookiejar.New(nil)
 	return &Client{
 		fetchHTTP: &http.Client{Timeout: 60 * time.Second},
-		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
-		username: username,
-		password: password,
-		http:     &http.Client{Timeout: 15 * time.Second, Jar: jar},
+		baseURL:   fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
+		username:  username,
+		password:  password,
+		http:      &http.Client{Timeout: 15 * time.Second, Jar: jar},
 	}
 }
 
@@ -209,7 +209,7 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 		if savePath != "" {
 			_ = mw.WriteField("savepath", savePath)
 		}
-		mw.Close()
+		_ = mw.Close()
 
 		req, err = http.NewRequestWithContext(ctx, http.MethodPost,
 			c.baseURL+"/api/v2/torrents/add", &buf)

--- a/internal/indexer/debug.go
+++ b/internal/indexer/debug.go
@@ -143,6 +143,11 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 			mu.Unlock()
 
 			slog.Debug("indexer returned results", "indexer", idx.Name, "count", len(hits))
+			if slog.Default().Enabled(ctx, slog.LevelDebug) {
+				for _, h := range hits {
+					slog.Debug("indexer result", "indexer", idx.Name, "title", h.Title, "author", h.Author)
+				}
+			}
 		}(idx, entry)
 	}
 	wg.Wait()

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"path"
@@ -100,6 +101,8 @@ func (c *Client) Search(ctx context.Context, query string, categories []int) ([]
 		return nil, fmt.Errorf("search: %w", err)
 	}
 
+	slog.Debug("indexer query", "url", redactAPIKey(u))
+
 	var rss rssResponse
 	if err := c.getXML(ctx, u, &rss); err != nil {
 		return nil, fmt.Errorf("search: %w", err)
@@ -131,10 +134,13 @@ func (c *Client) BookSearch(ctx context.Context, title, author string, categorie
 			"limit":  "100",
 		})
 		if err == nil {
+			slog.Debug("indexer query", "tier", 1, "url", redactAPIKey(u))
 			var rss rssResponse
 			if err := c.getXML(ctx, u, &rss); err == nil && len(rss.Channel.Items) > 0 && rss.Channel.Response.Total < 1000 {
+				slog.Debug("indexer query tier matched", "tier", 1, "count", len(rss.Channel.Items))
 				return c.parseResults(rss.Channel.Items), nil
 			}
+			slog.Debug("indexer query tier fallthrough", "tier", 1, "items", len(rss.Channel.Items))
 		}
 	}
 
@@ -142,6 +148,7 @@ func (c *Client) BookSearch(ctx context.Context, title, author string, categorie
 	if surname != "" && !strings.EqualFold(surname, author) {
 		results, err := c.Search(ctx, surname+" "+queryTitle, categories)
 		if err == nil && len(results) > 0 {
+			slog.Debug("indexer query tier matched", "tier", 2, "count", len(results))
 			return results, nil
 		}
 	}
@@ -150,12 +157,29 @@ func (c *Client) BookSearch(ctx context.Context, title, author string, categorie
 	if author != "" {
 		results, err := c.Search(ctx, author+" "+queryTitle, categories)
 		if err == nil && len(results) > 0 {
+			slog.Debug("indexer query tier matched", "tier", 3, "count", len(results))
 			return results, nil
 		}
 	}
 
 	// Tier 4: title only
+	slog.Debug("indexer query tier 4 (title only)", "title", queryTitle)
 	return c.Search(ctx, queryTitle, categories)
+}
+
+// redactAPIKey replaces the apikey query parameter value with *** so URLs
+// can be logged without leaking credentials.
+func redactAPIKey(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	if q.Get("apikey") != "" {
+		q.Set("apikey", "***")
+		u.RawQuery = q.Encode()
+	}
+	return u.String()
 }
 
 // primaryTitleForQuery returns the portion of a book title before a colon,

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -675,6 +675,38 @@ func TestParseResults_AppendsApikeyToEnclosure(t *testing.T) {
 	}
 }
 
+func TestRedactAPIKey(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "replaces apikey value",
+			in:   "https://indexer.local/api?t=book&apikey=supersecret&title=Dune",
+			want: "https://indexer.local/api?apikey=%2A%2A%2A&t=book&title=Dune",
+		},
+		{
+			name: "no apikey param left unchanged",
+			in:   "https://indexer.local/api?t=search&q=Dune",
+			want: "https://indexer.local/api?t=search&q=Dune",
+		},
+		{
+			name: "invalid URL returned as-is",
+			in:   "://not a url",
+			want: "://not a url",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := redactAPIKey(c.in)
+			if got != c.want {
+				t.Errorf("redactAPIKey(%q)\n got  %q\n want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
 func TestPrimaryTitleForQuery_NormalizesAndDropsSubtitle(t *testing.T) {
 	cases := []struct {
 		in, want string

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -1,9 +1,14 @@
 package indexer
 
 import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/indexer/newznab"
+	"github.com/vavallee/bindery/internal/models"
 )
 
 func resultTitles(rs []newznab.SearchResult) []string {
@@ -950,3 +955,49 @@ func equalSlices(a, b []string) bool {
 	}
 	return true
 }
+
+// TestSearchBookWithDebug_PerResultLogging verifies that the per-result debug
+// log lines in SearchBookWithDebug are executed when the slog level is DEBUG.
+func TestSearchBookWithDebug_PerResultLogging(t *testing.T) {
+	const rssBody = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
+  <channel>
+    <newznab:response offset="0" total="1"/>
+    <item>
+      <title>Life Ascending Nick Lane</title>
+      <guid isPermaLink="false">guid-1</guid>
+      <enclosure url="https://fake/dl/1" length="1000" type="application/x-nzb"/>
+      <newznab:attr name="author" value="Nick Lane"/>
+    </item>
+  </channel>
+</rss>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		w.Write([]byte(rssBody))
+	}))
+	defer srv.Close()
+
+	// Set global slog to debug so the Enabled check in SearchBookWithDebug fires.
+	orig := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(nopWriter{}, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+
+	idxs := []models.Indexer{{ID: 1, Name: "test", URL: srv.URL, Enabled: true, Categories: []int{7020}}}
+	results, dbg := NewSearcher().SearchBookWithDebug(context.Background(), idxs, MatchCriteria{
+		Title:  "Life Ascending",
+		Author: "Nick Lane",
+	})
+
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if dbg == nil {
+		t.Fatal("expected non-nil debug info")
+	}
+}
+
+// nopWriter discards all log output during tests.
+type nopWriter struct{}
+
+func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }


### PR DESCRIPTION
## Problem

\`PUT /system/loglevel\` (the GUI log level toggle) only called \`ring.SetLevel()\`. The UI log viewer always reads from the **database** — the \`useDB = true\` branch fires unconditionally when a \`LogRepo\` is attached. The database-backed \`db.LogHandler\` had a plain \`slog.Level\` field set once at startup from \`BINDERY_LOG_LEVEL\` with no runtime mutation path.

Result: switching to \`debug\` in the GUI had zero visible effect on the log viewer. Only \`BINDERY_LOG_LEVEL=debug\` at process start worked.

## Root cause

- \`api.LogHandler.SetLevel\` → only \`h.ring.SetLevel(level)\` — \`db.LogHandler\` never updated
- \`db.LogHandler.level\` was a plain \`slog.Level\`, not safe to mutate concurrently and never exposed as settable
- \`api.LogHandler\` held no reference to \`db.LogHandler\`

## Fix

- Convert \`db.LogHandler.level\` to \`*atomic.Int64\` shared between the root handler and all \`WithAttrs\` children — a single \`SetLevel\` call propagates immediately to every handler in the tree.
- Add \`SetLevel\`/\`Level\` accessors to \`db.LogHandler\`.
- Add \`WithDBLogHandler(*db.LogHandler)\` to \`api.LogHandler\` so \`SetLevel\` updates both the ring and the DB handler in one call.
- Wire \`WithDBLogHandler(logDBHandler)\` in \`main.go\`.

Also adds per-tier query URL logging (API key redacted) and per-result title/author logging in \`SearchBookWithDebug\`, so switching to debug in the GUI immediately surfaces what each indexer was queried with and what it returned.

## Test plan

- [x] \`go test ./internal/db/... ./internal/api/...\` passes
- [x] Start with default log level; open log viewer — only INFO+ entries visible
- [x] Change log level to \`debug\` via GUI (Settings → System); trigger a book search
- [x] Refresh log viewer - \`debug\` entries appear (indexer query URLs, result counts, per-result titles/authors)
- [x] Restart; confirm level reverts to startup default