### PR TITLE
fix(recommendations): emit empty genres arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Recommendations now return empty genre arrays instead of null** — Recommendation storage normalizes missing and legacy `null` genre values to `[]`, keeping API responses consistent for clients.
+
+### Chores
+
+- **Local check cleanup** — Restored downloader lint compliance and aligned the WantedPage test with optimistic unmonitor behavior so local checks can pass.
+
 ## [v1.10.0] — 2026-05-13
 
 ### Added

--- a/internal/db/recommendations.go
+++ b/internal/db/recommendations.go
@@ -52,13 +52,7 @@ func (r *RecommendationRepo) ReplaceBatch(ctx context.Context, userID int64, can
 	defer func() { _ = stmt.Close() }()
 
 	for _, c := range candidates {
-		genresJSON, err := json.Marshal(c.Genres)
-		if err != nil {
-			slog.Warn("recommendations: marshal genres", "error", err)
-		}
-		if genresJSON == nil {
-			genresJSON = []byte("[]")
-		}
+		genresJSON := marshalRecommendationGenres(c.Genres)
 
 		_, err = stmt.ExecContext(ctx,
 			userID, c.ForeignID, c.RecType, c.Title, c.AuthorName, c.AuthorID,
@@ -119,7 +113,7 @@ func (r *RecommendationRepo) List(ctx context.Context, userID int64, recType str
 		if err != nil {
 			return nil, fmt.Errorf("scan recommendation: %w", err)
 		}
-		_ = json.Unmarshal([]byte(genresJSON), &rec.Genres)
+		rec.Genres = unmarshalRecommendationGenres(genresJSON)
 		rec.Dismissed = dismissed != 0
 		recs = append(recs, rec)
 	}
@@ -149,9 +143,29 @@ func (r *RecommendationRepo) GetByID(ctx context.Context, id int64) (*models.Rec
 	if err != nil {
 		return nil, fmt.Errorf("get recommendation %d: %w", id, err)
 	}
-	_ = json.Unmarshal([]byte(genresJSON), &rec.Genres)
+	rec.Genres = unmarshalRecommendationGenres(genresJSON)
 	rec.Dismissed = dismissed != 0
 	return &rec, nil
+}
+
+func marshalRecommendationGenres(genres []string) []byte {
+	if genres == nil {
+		return []byte("[]")
+	}
+	genresJSON, err := json.Marshal(genres)
+	if err != nil {
+		slog.Warn("recommendations: marshal genres", "error", err)
+		return []byte("[]")
+	}
+	return genresJSON
+}
+
+func unmarshalRecommendationGenres(genresJSON string) []string {
+	var genres []string
+	if err := json.Unmarshal([]byte(genresJSON), &genres); err != nil || genres == nil {
+		return []string{}
+	}
+	return genres
 }
 
 // Dismiss marks a recommendation as dismissed and records the dismissal in

--- a/internal/db/recommendations_test.go
+++ b/internal/db/recommendations_test.go
@@ -1,0 +1,93 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestRecommendationRepoStoresNilGenresAsEmptyArray(t *testing.T) {
+	ctx := context.Background()
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	repo := NewRecommendationRepo(database)
+	if err := repo.ReplaceBatch(ctx, 1, []models.RecommendationCandidate{{
+		ForeignID: "ol:nil-genres",
+		RecType:   models.RecTypeSeries,
+		Title:     "Nil Genres",
+	}}); err != nil {
+		t.Fatalf("replace batch: %v", err)
+	}
+
+	var storedGenres string
+	if err := database.QueryRowContext(ctx, "SELECT genres FROM recommendations WHERE foreign_id = ?", "ol:nil-genres").Scan(&storedGenres); err != nil {
+		t.Fatalf("query stored genres: %v", err)
+	}
+	if storedGenres != "[]" {
+		t.Fatalf("stored genres = %q, want []", storedGenres)
+	}
+
+	recs, err := repo.List(ctx, 1, "", 10, 0)
+	if err != nil {
+		t.Fatalf("list recommendations: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("len(recs) = %d, want 1", len(recs))
+	}
+	if recs[0].Genres == nil {
+		t.Fatal("listed genres is nil, want empty slice")
+	}
+	if len(recs[0].Genres) != 0 {
+		t.Fatalf("len(genres) = %d, want 0", len(recs[0].Genres))
+	}
+}
+
+func TestRecommendationRepoReadsLegacyNullGenresAsEmptyArray(t *testing.T) {
+	ctx := context.Background()
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	_, err = database.ExecContext(ctx, `
+		INSERT INTO recommendations (user_id, foreign_id, rec_type, title, genres)
+		VALUES (1, 'ol:legacy-null-genres', 'series', 'Legacy Null Genres', 'null')`)
+	if err != nil {
+		t.Fatalf("insert legacy recommendation: %v", err)
+	}
+
+	repo := NewRecommendationRepo(database)
+	recs, err := repo.List(ctx, 1, "", 10, 0)
+	if err != nil {
+		t.Fatalf("list recommendations: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("len(recs) = %d, want 1", len(recs))
+	}
+	if recs[0].Genres == nil {
+		t.Fatal("listed legacy genres is nil, want empty slice")
+	}
+	if len(recs[0].Genres) != 0 {
+		t.Fatalf("len(legacy genres) = %d, want 0", len(recs[0].Genres))
+	}
+
+	rec, err := repo.GetByID(ctx, recs[0].ID)
+	if err != nil {
+		t.Fatalf("get recommendation: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("get recommendation returned nil")
+	}
+	if rec.Genres == nil {
+		t.Fatal("loaded legacy genres is nil, want empty slice")
+	}
+	if len(rec.Genres) != 0 {
+		t.Fatalf("len(loaded legacy genres) = %d, want 0", len(rec.Genres))
+	}
+}

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -20,8 +20,8 @@ import (
 
 // Client interacts with the NZBGet JSON-RPC API.
 type Client struct {
-	baseURL  string
-	http     *http.Client // NZBGet JSON-RPC transport
+	baseURL   string
+	http      *http.Client // NZBGet JSON-RPC transport
 	fetchHTTP *http.Client // used to fetch NZB content from indexers before submission
 	// username and password for HTTP Basic auth
 	username string

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -65,8 +65,8 @@ type Client struct {
 	password  string
 	http      *http.Client
 	fetchHTTP *http.Client // fetches .torrent file content on behalf of qBittorrent
-	mu        sync.Mutex  // guards loggedIn
-	addMu     sync.Mutex  // serialises AddTorrent: keeps before/after hash diff atomic
+	mu        sync.Mutex   // guards loggedIn
+	addMu     sync.Mutex   // serialises AddTorrent: keeps before/after hash diff atomic
 	loggedIn  bool
 }
 
@@ -82,10 +82,10 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 	jar, _ := cookiejar.New(nil)
 	return &Client{
 		fetchHTTP: &http.Client{Timeout: 60 * time.Second},
-		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
-		username: username,
-		password: password,
-		http:     &http.Client{Timeout: 15 * time.Second, Jar: jar},
+		baseURL:   fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
+		username:  username,
+		password:  password,
+		http:      &http.Client{Timeout: 15 * time.Second, Jar: jar},
 	}
 }
 
@@ -209,7 +209,9 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 		if savePath != "" {
 			_ = mw.WriteField("savepath", savePath)
 		}
-		mw.Close()
+		if err := mw.Close(); err != nil {
+			return "", fmt.Errorf("close multipart writer: %w", err)
+		}
 
 		req, err = http.NewRequestWithContext(ctx, http.MethodPost,
 			c.baseURL+"/api/v2/torrents/add", &buf)

--- a/web/src/pages/WantedPage.test.tsx
+++ b/web/src/pages/WantedPage.test.tsx
@@ -274,8 +274,8 @@ describe('WantedPage', () => {
     await screen.findByRole('link', { name: 'Dune' })
     fireEvent.click(screen.getByRole('button', { name: 'Unmonitor' }))
 
-    expect(screen.getByRole('button', { name: '…' })).toBeDisabled()
     expect(api.updateBook).toHaveBeenCalledWith(1, { monitored: false })
+    expect(screen.queryByRole('link', { name: 'Dune' })).not.toBeInTheDocument()
 
     await act(async () => {
       resolveUpdate({ ...book, monitored: false })


### PR DESCRIPTION
This PR addresses an error on the discovery page. Currently the discover page crashes when a recommendation has no genre metadata because the API returned `genres: null` while the frontend expects `genres` to always be an array. Recommendation cards call array methods/properties on that field, so a `null` value causes a runtime render error instead of showing the recommendation list.

## Summary
- Normalize recommendation genre storage and reads so missing or legacy `null` genres are returned as `[]`.
- Add recommendation repository regression coverage for nil and legacy `null` genre values.
- Restore local PR check cleanliness by fixing downloader lint issues and aligning the WantedPage unmonitor test with optimistic removal.

## Checklist

- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed - N/A, no env/config/upgrade path change
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [ ] Wiki pages updated if user-facing behaviour changed - N/A, no wiki update available or required for this response-shape fix

## Test plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `golangci-lint run --timeout=5m`
- [x] `govulncheck ./...`
- [x] `go test ./internal/db ./internal/downloader/nzbget ./internal/downloader/qbittorrent`
- [x] `go test ./cmd/... ./internal/...`
- [x] `npm run lint --prefix web` (passes with 5 existing warnings)
- [x] `npm run typecheck --prefix web`
- [x] `npm test --prefix web`
- [x] `npm run build --prefix web`
