### PR TITLE
fix(downloader): errcheck mw.Close and gofmt qbittorrent/nzbget clients

### DIFF
--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -20,8 +20,8 @@ import (
 
 // Client interacts with the NZBGet JSON-RPC API.
 type Client struct {
-	baseURL  string
-	http     *http.Client // NZBGet JSON-RPC transport
+	baseURL   string
+	http      *http.Client // NZBGet JSON-RPC transport
 	fetchHTTP *http.Client // used to fetch NZB content from indexers before submission
 	// username and password for HTTP Basic auth
 	username string

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -65,8 +65,8 @@ type Client struct {
 	password  string
 	http      *http.Client
 	fetchHTTP *http.Client // fetches .torrent file content on behalf of qBittorrent
-	mu        sync.Mutex  // guards loggedIn
-	addMu     sync.Mutex  // serialises AddTorrent: keeps before/after hash diff atomic
+	mu        sync.Mutex   // guards loggedIn
+	addMu     sync.Mutex   // serialises AddTorrent: keeps before/after hash diff atomic
 	loggedIn  bool
 }
 
@@ -82,10 +82,10 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 	jar, _ := cookiejar.New(nil)
 	return &Client{
 		fetchHTTP: &http.Client{Timeout: 60 * time.Second},
-		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
-		username: username,
-		password: password,
-		http:     &http.Client{Timeout: 15 * time.Second, Jar: jar},
+		baseURL:   fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
+		username:  username,
+		password:  password,
+		http:      &http.Client{Timeout: 15 * time.Second, Jar: jar},
 	}
 }
 
@@ -209,7 +209,9 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 		if savePath != "" {
 			_ = mw.WriteField("savepath", savePath)
 		}
-		mw.Close()
+		if err := mw.Close(); err != nil {
+			return "", fmt.Errorf("close multipart writer: %w", err)
+		}
 
 		req, err = http.NewRequestWithContext(ctx, http.MethodPost,
 			c.baseURL+"/api/v2/torrents/add", &buf)


### PR DESCRIPTION
Lint hotfix for issues introduced by #640.

- `qbittorrent/client.go`: check `mw.Close()` return value (errcheck), fix gofmt alignment on struct fields
- `nzbget/client.go`: fix gofmt alignment on struct fields

Unblocks #648 and #649 whose CI is failing on these pre-existing lint errors.