### PR TITLE
docs: update CHANGELOG and DEPLOYMENT for post-v1.10.0 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 - **Recommendations now return empty genre arrays instead of null** — Recommendation storage normalizes missing and legacy `null` genre values to `[]`, keeping API responses consistent for clients.
 
+- **qBittorrent Docker hostname fix** (#640) — Bindery now fetches .torrent content itself and submits it to qBittorrent via multipart/form-data. Fixes setups where qBittorrent runs in a separate container and cannot resolve the Prowlarr/indexer internal hostname (e.g. `prowlarr:9696`). No config change needed.
+
+- **NZBGet Docker hostname fix** (#531) — Bindery now fetches the NZB file itself and sends it to NZBGet as base64-encoded content. Same fix as #640 for Usenet: NZBGet in a separate container no longer needs to reach the indexer URL directly. No config change needed.
+
+- **Non-standard indexer category passthrough** (#636) — Category IDs outside the standard 7xxx/3xxx ranges (e.g. MaM-style IDs) are now forwarded to the indexer unchanged instead of being dropped. Fixes searches returning no results on niche indexers with custom category numbering.
+
+- **Backup delete button in Settings → General → Backup** (#638) — Backup entries now have a delete button in the UI. Previously backups could only be removed by SSHing into the container.
+
+- **Log level toggle now propagates to log viewer** (#651) — Switching to DEBUG in Settings → System now immediately affects the log viewer. Previously only `BINDERY_LOG_LEVEL=debug` at startup had any visible effect.
+
+- **Discover page no longer crashes on books with no genre metadata** (#645) — The Recommendations page handles `genres: null` from the API gracefully instead of throwing a runtime render error.
+
+### Improved
+
+- **Book list query performance** (#648) — Book list queries now use a single CTE JOIN instead of correlated subqueries (previously 2N SQLite queries for N books). Noticeable speedup for libraries with more than a few hundred books.
+
+- **Download client form shows inline errors on save failure** (#649) — The Save button in the Add/Edit Download Client forms now displays an inline error message when the API call fails, rather than appearing to do nothing.
+
+### Internal
+
+- **Test coverage for grimmory and hardcoverlistsyncer** (#652) — Added unit and HTTP test coverage for `internal/grimmory` (0% → 93%) and `internal/hardcoverlistsyncer` (13% → 20%).
+
 ### Chores
 
 - **Local check cleanup** — Restored downloader lint compliance and aligned the WantedPage test with optimistic unmonitor behavior so local checks can pass.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -241,6 +241,7 @@ Multiple remaps are separated by commas: `BINDERY_DOWNLOAD_PATH_REMAP=/sab/compl
 | `BINDERY_NOTIFICATIONS_ALLOW_PRIVATE` | _(unset)_ | Set to `1` to flip outbound webhook SSRF policy from Strict to LAN, allowing RFC1918 targets. Use when ntfy / Home Assistant / Gotify live on your private network. Loopback, link-local, and cloud-metadata endpoints stay blocked. |
 | `BINDERY_RATE_LIMIT_MAX_FAILURES` | `5` | Maximum failed login attempts per IP before the account is locked for the rate-limit window. |
 | `BINDERY_RATE_LIMIT_WINDOW_MINUTES` | `15` | Duration in minutes of the per-IP login rate-limit window. After the window expires the failure counter resets. |
+| `BINDERY_SHUTDOWN_GRACE` | `30` | Seconds to drain in-flight HTTP requests after receiving SIGTERM or SIGINT before the process exits. Increase if your load balancer / Kubernetes sends long-lived SSE or WebSocket connections. |
 
 ## Indexer / Prowlarr URLs
 
@@ -282,6 +283,16 @@ On first launch Bindery bootstraps itself — **no environment variables are req
 **Feature flag:** token-backed Hardcover series search, manual/automatic series linking, catalog diffs, and missing-book fill are available by default at deployment time, but still require a saved Hardcover API token in **Settings -> General** and the enhanced Hardcover series toggle in the same settings section. Set `BINDERY_ENHANCED_HARDCOVER_API=false` only when you need to disable the enhanced endpoints and hide the UI controls for an entire deployment. Existing local series data keeps working when the feature is disabled.
 
 **Operational note:** the enhanced fill action can create wanted/monitored book rows from the linked Hardcover catalog and immediately queue indexer searches. Make sure outbound HTTPS to Hardcover and your configured indexers is allowed before enabling it for production users.
+
+### From v1.9.x to v1.10.0
+
+**Schema:** migration `040` adds `path_remap TEXT` to `download_clients`. Non-destructive; no action required.
+
+**Docker/container networking — qBittorrent and NZBGet** — If you previously saw qBittorrent or NZBGet silently fail to grab torrent/NZB files when using Prowlarr or other indexers with Docker-internal hostnames (e.g. `prowlarr:9696`), this is fixed. Bindery now fetches the content itself and forwards it directly to the download client — qBittorrent and NZBGet never need to resolve the indexer URL.
+
+**Graceful shutdown** — `BINDERY_SHUTDOWN_GRACE` (default `30s`) controls how long the server drains in-flight requests after SIGTERM. `kubectl rollout restart` no longer drops in-flight requests.
+
+**Log level UI toggle** — The log level toggle in Settings → System now immediately affects the log viewer (previously only `BINDERY_LOG_LEVEL` at startup worked).
 
 ### From v0.11.x to v0.12.0 (security posture)
 


### PR DESCRIPTION
Populates [Unreleased] CHANGELOG with 9 post-v1.10.0 fixes/improvements; adds BINDERY_SHUTDOWN_GRACE to env var table; adds v1.9.x→v1.10.0 upgrade note covering Docker networking fix and graceful shutdown.

## Summary

- **CHANGELOG.md** — fills the empty `[Unreleased]` section with all 9 merged items: qBittorrent/NZBGet Docker hostname fixes (#640, #531), non-standard category passthrough (#636), backup delete button (#638), log level toggle propagation (#651), Discover null-genres crash (#645), book list CTE query perf (#648), download client inline errors (#649), and grimmory/hardcoverlistsyncer test coverage (#652)
- **docs/DEPLOYMENT.md** — adds `BINDERY_SHUTDOWN_GRACE` to the environment variables table (after `BINDERY_RATE_LIMIT_WINDOW_MINUTES`)
- **docs/DEPLOYMENT.md** — adds a `### From v1.9.x to v1.10.0` upgrade note covering the Docker networking fix for qBittorrent/NZBGet, graceful shutdown, and the log level UI toggle

## Test plan

- [ ] `grep "BINDERY_SHUTDOWN_GRACE" docs/DEPLOYMENT.md` returns two hits (table row + upgrade note)
- [ ] `grep "Unreleased" CHANGELOG.md` shows the section is non-empty
- [ ] CHANGELOG entries match the style of adjacent v1.10.0 entries (bold summary, parenthetical issue ref, one sentence)
- [ ] No build required — docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)