### PR TITLE
feat(indexer): wire Priority field into release scoring (#534)

### DIFF
--- a/internal/indexer/newznab/types.go
+++ b/internal/indexer/newznab/types.go
@@ -84,7 +84,8 @@ type SearchResult struct {
 	Grabs       int    `json:"grabs"`
 	Author      string `json:"author"`
 	BookTitle   string `json:"bookTitle"`
-	Protocol    string `json:"protocol"`            // "usenet" or "torrent"
-	Language    string `json:"language,omitempty"`  // ISO 639-1 from newznab:attr language (when present)
-	MediaType   string `json:"mediaType,omitempty"` // "ebook" or "audiobook"; set for dual-format book searches
+	Protocol        string `json:"protocol"`            // "usenet" or "torrent"
+	Language        string `json:"language,omitempty"`  // ISO 639-1 from newznab:attr language (when present)
+	MediaType       string `json:"mediaType,omitempty"` // "ebook" or "audiobook"; set for dual-format book searches
+	IndexerPriority int    `json:"indexerPriority"`     // copied from models.Indexer.Priority; higher wins
 }

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -116,6 +116,7 @@ func (s *Searcher) SearchBook(ctx context.Context, indexers []models.Indexer, c 
 				hits[i].IndexerID = idx.ID
 				hits[i].IndexerName = idx.Name
 				hits[i].Protocol = protocol
+				hits[i].IndexerPriority = idx.Priority
 			}
 
 			mu.Lock()
@@ -163,6 +164,7 @@ func (s *Searcher) SearchQuery(ctx context.Context, indexers []models.Indexer, q
 				hits[i].IndexerID = idx.ID
 				hits[i].IndexerName = idx.Name
 				hits[i].Protocol = protocol
+				hits[i].IndexerPriority = idx.Priority
 			}
 
 			mu.Lock()
@@ -563,6 +565,11 @@ func scoreResult(r newznab.SearchResult, c MatchCriteria) float64 {
 	if c.ASIN != "" && strings.Contains(strings.ToUpper(r.Title), strings.ToUpper(c.ASIN)) {
 		score += 250
 	}
+
+	// Indexer priority: each priority point adds directly to the score so a
+	// higher-priority indexer wins ties and can outweigh small quality gaps.
+	// Default priority is 0, so deployments that never configure it are unaffected.
+	score += float64(r.IndexerPriority)
 
 	return score
 }

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -391,6 +391,18 @@ func TestRankResultsManyItemsOrdering(t *testing.T) {
 	}
 }
 
+func TestRankResultsIndexerPriority(t *testing.T) {
+	// Two otherwise-identical releases; the one from the higher-priority indexer
+	// must sort first regardless of insertion order.
+	low := newznab.SearchResult{Title: "Project.Hail.Mary.EPUB", IndexerPriority: 10}
+	high := newznab.SearchResult{Title: "Project.Hail.Mary.EPUB", IndexerPriority: 50}
+	results := []newznab.SearchResult{low, high}
+	rankResults(results, MatchCriteria{Title: "Project Hail Mary"})
+	if results[0].IndexerPriority != 50 {
+		t.Errorf("expected higher-priority indexer first, got priority=%d", results[0].IndexerPriority)
+	}
+}
+
 func TestFilterUsenetJunk(t *testing.T) {
 	junk := []string{
 		`NMR: Project Hail Mary - Andy Weir - 2021 [12/22] - "Andy Weir - 2021 - Project Hail Mary.part09.rar" yEnc`,


### PR DESCRIPTION
`Indexer.Priority` has been in the schema and model since the beginning but was never read by the ranker — every indexer scored identically regardless of configured priority. This gives it real semantics.

## Changes

- `internal/indexer/newznab/types.go` — add `IndexerPriority int` to `SearchResult`
- `internal/indexer/searcher.go` — stamp `idx.Priority` onto results in both fan-out loops; add `float64(r.IndexerPriority)` to `scoreResult`
- `internal/indexer/searcher_test.go` — `TestRankResultsIndexerPriority`: two identical releases, higher-priority indexer wins

## Behaviour

Each priority point adds directly to the composite score (~same weight as 1 quality point). A Usenet indexer at priority 50 will beat a torrent indexer at priority 0 for equal-quality releases, and can outweigh small quality gaps. Deployments that never configure priority see no change (default is 0).

To prefer Usenet: set Usenet indexers to a higher priority number in Settings → Indexers.

Closes #534.

## Test plan

- [ ] `go test ./internal/indexer/...` passes
- [ ] Set a Usenet indexer to priority 50, torrent to 0 — search returns Usenet result first for equivalent releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)