### PR TITLE
chore(release): promote to v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.11.0] — 2026-05-14
+
+### Added
+
+- **SSO-only mode and OIDC account controls** (#654) — Three new env vars: `BINDERY_LOCAL_AUTH_ENABLED` (default `true`) disables password login entirely when set to `false`; `BINDERY_OIDC_AUTO_PROVISION` (default `true`) prevents automatic account creation for unknown OIDC users when set to `false`; `BINDERY_OIDC_EMAIL_LINK` (default `false`) links an unknown OIDC identity to an existing account by email on first login. Deployments that don't set these vars are unaffected.
+
+- **Indexer priority now applied to release scoring** (#656) — The `Priority` field on indexers (Settings → Indexers) previously had no effect. It now adds directly to the composite release score, so a higher-priority indexer wins ties and can outweigh small quality differences. Set Usenet indexers to a higher priority than torrent indexers to prefer Usenet when both have matching releases.
+
 ### Fixed
 
 - **Recommendations now return empty genre arrays instead of null** — Recommendation storage normalizes missing and legacy `null` genre values to `[]`, keeping API responses consistent for clients.

--- a/charts/bindery/Chart.yaml
+++ b/charts/bindery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bindery
 description: Automated book download manager for Usenet and Torrents
 type: application
-version: 0.5.0
-appVersion: "0.22.0"
+version: 0.6.0
+appVersion: "1.11.0"
 home: https://github.com/vavallee/bindery
 sources:
   - https://github.com/vavallee/bindery

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindery-web",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## v1.11.0

### Added
- SSO-only mode and OIDC account controls (`BINDERY_LOCAL_AUTH_ENABLED`, `BINDERY_OIDC_AUTO_PROVISION`, `BINDERY_OIDC_EMAIL_LINK`) (#654)
- Indexer priority now applied to release scoring (#656)

### Fixed
- qBittorrent/NZBGet Docker hostname fix (#640, #531)
- Non-standard indexer category passthrough (#636)
- Backup delete button (#638)
- Log level toggle propagation (#651)
- Discover page null genres crash (#645)

### Improved
- Book list CTE query performance (#648)
- Download client inline errors (#649)

### Internal
- grimmory/hardcoverlistsyncer test coverage (#652)