### PR TITLE
fix(lint): gofmt three files

### DIFF
--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -15,9 +15,9 @@ import (
 // LogHandler exposes the log store over HTTP. When a LogRepo is attached it
 // queries the persistent database; otherwise it falls back to the ring buffer.
 type LogHandler struct {
-	ring   *logbuf.Ring
-	logs   *db.LogRepo     // optional persistent store
-	dblog  *db.LogHandler  // optional; kept in sync with ring level
+	ring  *logbuf.Ring
+	logs  *db.LogRepo    // optional persistent store
+	dblog *db.LogHandler // optional; kept in sync with ring level
 }
 
 func NewLogHandler(ring *logbuf.Ring) *LogHandler {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -171,12 +171,12 @@ func TestAuthPolicyDefaults(t *testing.T) {
 // TestAuthPolicyFromEnv verifies explicit values override the defaults.
 func TestAuthPolicyFromEnv(t *testing.T) {
 	cases := []struct {
-		localAuth   string
+		localAuth     string
 		autoProvision string
-		emailLink   string
-		wantLocal   bool
-		wantProv    bool
-		wantLink    bool
+		emailLink     string
+		wantLocal     bool
+		wantProv      bool
+		wantLink      bool
 	}{
 		{"false", "false", "true", false, false, true},
 		{"0", "0", "1", false, false, true},

--- a/internal/indexer/newznab/types.go
+++ b/internal/indexer/newznab/types.go
@@ -73,17 +73,17 @@ type capsCategory struct {
 
 // SearchResult is the domain type for an indexer search result.
 type SearchResult struct {
-	GUID        string `json:"guid"`
-	IndexerID   int64  `json:"indexerId"`
-	IndexerName string `json:"indexerName"`
-	Title       string `json:"title"`
-	Size        int64  `json:"size"`
-	PubDate     string `json:"pubDate"`
-	NZBURL      string `json:"nzbUrl"`
-	Category    string `json:"category"`
-	Grabs       int    `json:"grabs"`
-	Author      string `json:"author"`
-	BookTitle   string `json:"bookTitle"`
+	GUID            string `json:"guid"`
+	IndexerID       int64  `json:"indexerId"`
+	IndexerName     string `json:"indexerName"`
+	Title           string `json:"title"`
+	Size            int64  `json:"size"`
+	PubDate         string `json:"pubDate"`
+	NZBURL          string `json:"nzbUrl"`
+	Category        string `json:"category"`
+	Grabs           int    `json:"grabs"`
+	Author          string `json:"author"`
+	BookTitle       string `json:"bookTitle"`
 	Protocol        string `json:"protocol"`            // "usenet" or "torrent"
 	Language        string `json:"language,omitempty"`  // ISO 639-1 from newznab:attr language (when present)
 	MediaType       string `json:"mediaType,omitempty"` // "ebook" or "audiobook"; set for dual-format book searches


### PR DESCRIPTION
Fixes gofmt violations in `internal/api/logs.go`, `internal/config/config_test.go`, and `internal/indexer/newznab/types.go` caught by CI on the v1.11.0 tag run.