### PR TITLE
chore(deploy): promote bindery to 1.11.0 [skip ci]

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.10.0"
+  tag: "1.11.0"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Automated prod deploy for v1.11.0 — recover from deploy-prod race.