### PR TITLE
feat(calibre): export bindery metadata during handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **Calibre metadata handoff** — Calibre pushes now carry Bindery book, author, edition, series, identifier, language, rating, description, and cover metadata through both `calibredb` and metadata-capable Bindery Bridge plugin syncs, with legacy plugin fallback preserved.
+
 ### Fixed
 
 - **qBittorrent imports recover from mismatched container paths without re-downloading** — Download clients now support per-client path remaps, qBittorrent grabs are sent with the expected category save path, and Settings surfaces qBittorrent category path health warnings. Queue items stuck in `importFailed` can also be retried after fixing storage/path settings.
+- **Calibre ID reuse** — Plugin sync no longer reuses a stored source-library Calibre ID when pushing into a different Calibre library.
 
 ## [v1.11.2] — 2026-05-17
 

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -489,7 +489,7 @@ func main() {
 	calibreImportHandler := api.NewCalibreImportHandler(calibreImporter, func() calibre.Config {
 		return api.LoadCalibreConfig(settingsRepo)
 	})
-	calibreSyncer := calibre.NewSyncer(bookRepo)
+	calibreSyncer := calibre.NewSyncer(bookRepo).WithMetadata(authorRepo, editionRepo)
 	calibreSyncHandler := api.NewCalibreSyncHandler(
 		calibreSyncer,
 		func() calibre.Config { return api.LoadCalibreConfig(settingsRepo) },

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -437,6 +438,8 @@ func main() {
 	importScanner.WithSettings(settingsRepo)
 	importScanner.WithRootFolders(rootFolderRepo)
 	importScanner.WithSeriesRepo(seriesRepo)
+	importScanner.WithEditions(editionRepo)
+	importScanner.WithCalibreCoverCache(filepath.Join(cfg.DataDir, "calibre-covers"))
 
 	// Startup check: warn if the configured default root folder no longer exists on disk.
 	if s, _ := settingsRepo.Get(ctxBoot, api.SettingDefaultLibraryRootFolderID); s != nil && s.Value != "" {

--- a/internal/calibre/client.go
+++ b/internal/calibre/client.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"regexp"
@@ -66,21 +67,24 @@ func (c *Client) binary() string {
 	return "calibredb"
 }
 
-// Add runs `calibredb add --with-library <lib> <file>` and returns the
-// Calibre book id assigned to the newly ingested file. A non-zero id is
-// always returned on success so callers can persist the mapping.
+// Add runs `calibredb add --with-library <lib> <metadata...> <file>` and
+// returns the Calibre book id assigned to the newly ingested file. A non-zero
+// id is always returned on success so callers can persist the mapping.
 //
 // calibredb's add output is unstructured plaintext — it does not offer a
 // machine-readable format for add — so we regex the "Added book ids: N"
 // line that has been stable across Calibre releases since ~2.x.
-func (c *Client) Add(ctx context.Context, filePath string) (int64, error) {
+func (c *Client) Add(ctx context.Context, filePath string, meta Metadata) (int64, error) {
 	if !c.Enabled() {
 		return 0, ErrDisabled
 	}
 	if c.cfg.LibraryPath == "" {
 		return 0, errors.New("calibre library_path is not configured")
 	}
-	out, err := c.run(ctx, c.binary(), "add", "--with-library", c.cfg.LibraryPath, filePath)
+	args := []string{"add", "--with-library", c.cfg.LibraryPath}
+	args = append(args, meta.addArgs()...)
+	args = append(args, filePath)
+	out, err := c.run(ctx, c.binary(), args...)
 	if err != nil {
 		return 0, fmt.Errorf("calibredb add: %w: %s", err, strings.TrimSpace(string(out)))
 	}
@@ -88,7 +92,27 @@ func (c *Client) Add(ctx context.Context, filePath string) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("calibredb add: %w: %s", err, strings.TrimSpace(string(out)))
 	}
+	if err := c.setMetadata(ctx, id, meta); err != nil {
+		slog.Warn("calibredb set_metadata failed; continuing with added book",
+			"calibreId", id, "path", filePath, "error", err)
+	}
 	return id, nil
+}
+
+func (c *Client) setMetadata(ctx context.Context, id int64, meta Metadata) error {
+	fields := meta.setFields()
+	if len(fields) == 0 {
+		return nil
+	}
+	args := []string{"set_metadata", "--with-library", c.cfg.LibraryPath, strconv.FormatInt(id, 10)}
+	for _, field := range fields {
+		args = append(args, "--field", field)
+	}
+	out, err := c.run(ctx, c.binary(), args...)
+	if err != nil {
+		return fmt.Errorf("calibredb set_metadata: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 // Test probes the configured binary by asking for its version. A successful

--- a/internal/calibre/client_test.go
+++ b/internal/calibre/client_test.go
@@ -14,16 +14,34 @@ import (
 // to table-test argument construction without requiring calibredb on the
 // CI machine.
 type fakeRunner struct {
-	stdout []byte
-	err    error
-	bin    string
-	args   []string
+	stdout  []byte
+	err     error
+	bin     string
+	args    []string
+	calls   []runnerCall
+	results []runnerResult
 }
 
 func (f *fakeRunner) run(_ context.Context, name string, args ...string) ([]byte, error) {
 	f.bin = name
 	f.args = args
+	f.calls = append(f.calls, runnerCall{bin: name, args: append([]string(nil), args...)})
+	if len(f.results) > 0 {
+		res := f.results[0]
+		f.results = f.results[1:]
+		return []byte(res.stdout), res.err
+	}
 	return f.stdout, f.err
+}
+
+type runnerCall struct {
+	bin  string
+	args []string
+}
+
+type runnerResult struct {
+	stdout string
+	err    error
 }
 
 func newTestClient(cfg Config, out string, runErr error) (*Client, *fakeRunner) {
@@ -35,7 +53,7 @@ func newTestClient(cfg Config, out string, runErr error) (*Client, *fakeRunner) 
 
 func TestAdd_DisabledReturnsErrDisabled(t *testing.T) {
 	c := New(Config{Enabled: false})
-	_, err := c.Add(context.Background(), "/tmp/x.epub")
+	_, err := c.Add(context.Background(), "/tmp/x.epub", Metadata{})
 	if !errors.Is(err, ErrDisabled) {
 		t.Fatalf("expected ErrDisabled, got %v", err)
 	}
@@ -78,7 +96,7 @@ func TestAdd_ArgConstruction(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			c, fr := newTestClient(tc.cfg, "Added book ids: 42\n", nil)
-			id, err := c.Add(context.Background(), tc.file)
+			id, err := c.Add(context.Background(), tc.file, Metadata{})
 			if err != nil {
 				t.Fatalf("Add: %v", err)
 			}
@@ -100,9 +118,106 @@ func TestAdd_ArgConstruction(t *testing.T) {
 	}
 }
 
+func TestAdd_WithMetadataBuildsAddAndSetMetadataArgs(t *testing.T) {
+	c := New(Config{Enabled: true, LibraryPath: "/calibre/lib"})
+	fr := &fakeRunner{results: []runnerResult{
+		{stdout: "Added book ids: 42\n"},
+		{stdout: ""},
+	}}
+	c.run = fr.run
+
+	meta := Metadata{
+		Title:         "Dune",
+		Authors:       []string{"Frank Herbert"},
+		AuthorSort:    "Herbert, Frank",
+		Description:   "Desert planet.",
+		Publisher:     "Ace",
+		PublishedDate: "1965-08-01",
+		Genres:        []string{"Science Fiction", "Classics"},
+		Language:      "en",
+		Series:        "Dune Chronicles",
+		SeriesIndex:   "1",
+		Rating:        4.6,
+		Identifiers: map[string]string{
+			"asin":    "B000FC1BN8",
+			"bindery": "123",
+			"isbn":    "9780441172719",
+		},
+		CoverPath: "/covers/dune.jpg",
+	}
+	id, err := c.Add(context.Background(), "/library/dune.epub", meta)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if id != 42 {
+		t.Fatalf("id = %d, want 42", id)
+	}
+	if len(fr.calls) != 2 {
+		t.Fatalf("calls = %d, want 2: %+v", len(fr.calls), fr.calls)
+	}
+	wantAdd := []string{
+		"add", "--with-library", "/calibre/lib",
+		"--title", "Dune",
+		"--authors", "Frank Herbert",
+		"--cover", "/covers/dune.jpg",
+		"--identifier", "asin:B000FC1BN8",
+		"--identifier", "bindery:123",
+		"--identifier", "isbn:9780441172719",
+		"--languages", "en",
+		"--series", "Dune Chronicles",
+		"--series-index", "1",
+		"--tags", "Science Fiction,Classics",
+		"/library/dune.epub",
+	}
+	assertArgs(t, fr.calls[0].args, wantAdd)
+
+	wantSet := []string{
+		"set_metadata", "--with-library", "/calibre/lib", "42",
+		"--field", "comments:Desert planet.",
+		"--field", "author_sort:Herbert, Frank",
+		"--field", "publisher:Ace",
+		"--field", "pubdate:1965-08-01",
+		"--field", "rating:4.6",
+		"--field", "languages:en",
+		"--field", "tags:Science Fiction,Classics",
+		"--field", "series:Dune Chronicles",
+		"--field", "series_index:1",
+	}
+	assertArgs(t, fr.calls[1].args, wantSet)
+}
+
+func TestAdd_SetMetadataFailureStillReturnsAddedID(t *testing.T) {
+	c := New(Config{Enabled: true, LibraryPath: "/calibre/lib"})
+	fr := &fakeRunner{results: []runnerResult{
+		{stdout: "Added book ids: 42\n"},
+		{stdout: "bad field", err: errors.New("boom")},
+	}}
+	c.run = fr.run
+
+	id, err := c.Add(context.Background(), "/library/dune.epub", Metadata{Description: "x"})
+	if err != nil {
+		t.Fatalf("Add should ignore set_metadata failure, got %v", err)
+	}
+	if id != 42 {
+		t.Fatalf("id = %d, want 42", id)
+	}
+}
+
+func assertArgs(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("arg[%d] = %q, want %q\nall args: %#v", i, got[i], want[i], got)
+		}
+	}
+}
+
 func TestAdd_EmptyLibraryPath(t *testing.T) {
 	c, _ := newTestClient(Config{Enabled: true}, "", nil)
-	_, err := c.Add(context.Background(), "/x.epub")
+	_, err := c.Add(context.Background(), "/x.epub", Metadata{})
 	if err == nil || !strings.Contains(err.Error(), "library_path") {
 		t.Fatalf("expected library_path error, got %v", err)
 	}
@@ -110,7 +225,7 @@ func TestAdd_EmptyLibraryPath(t *testing.T) {
 
 func TestAdd_ParsesMultiIDList(t *testing.T) {
 	c, _ := newTestClient(Config{Enabled: true, LibraryPath: "/lib"}, "Added book ids: 7, 8, 9\n", nil)
-	id, err := c.Add(context.Background(), "/x.epub")
+	id, err := c.Add(context.Background(), "/x.epub", Metadata{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +237,7 @@ func TestAdd_ParsesMultiIDList(t *testing.T) {
 func TestAdd_WrapsRunnerError(t *testing.T) {
 	runErr := errors.New("boom")
 	c, _ := newTestClient(Config{Enabled: true, LibraryPath: "/lib"}, "calibredb: not found", runErr)
-	_, err := c.Add(context.Background(), "/x.epub")
+	_, err := c.Add(context.Background(), "/x.epub", Metadata{})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -136,7 +251,7 @@ func TestAdd_WrapsRunnerError(t *testing.T) {
 
 func TestAdd_UnparseableOutput(t *testing.T) {
 	c, _ := newTestClient(Config{Enabled: true, LibraryPath: "/lib"}, "Some unrelated chatter", nil)
-	_, err := c.Add(context.Background(), "/x.epub")
+	_, err := c.Add(context.Background(), "/x.epub", Metadata{})
 	if err == nil || !strings.Contains(err.Error(), "Added book ids") {
 		t.Fatalf("expected parse error mentioning Added book ids, got %v", err)
 	}

--- a/internal/calibre/client_test.go
+++ b/internal/calibre/client_test.go
@@ -176,7 +176,7 @@ func TestAdd_WithMetadataBuildsAddAndSetMetadataArgs(t *testing.T) {
 		"--field", "comments:Desert planet.",
 		"--field", "author_sort:Herbert, Frank",
 		"--field", "publisher:Ace",
-		"--field", "pubdate:1965-08-01",
+		"--field", "pubdate:1965-08-01T00:00:00+00:00",
 		"--field", "rating:4.6",
 		"--field", "languages:en",
 		"--field", "tags:Science Fiction,Classics",

--- a/internal/calibre/identifiers.go
+++ b/internal/calibre/identifiers.go
@@ -1,0 +1,100 @@
+package calibre
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+var openLibraryEditionIDRe = regexp.MustCompile(`^OL\d+M$`)
+
+// IdentifiersForBook returns the Calibre identifier map that can be derived
+// from the local book row and, when available, the specific edition being
+// handed off. It intentionally does not perform provider lookups or backfills.
+func IdentifiersForBook(book *models.Book, edition *models.Edition) map[string]string {
+	if book == nil {
+		return nil
+	}
+	out := map[string]string{}
+	setIdentifier(out, "bindery", strconv.FormatInt(book.ID, 10))
+	addProviderIdentifier(out, book.MetadataProvider, book.ForeignID)
+	setIdentifier(out, "asin", book.ASIN)
+
+	if edition != nil {
+		setIdentifier(out, "isbn", firstIdentifierValue(edition.ISBN13, edition.ISBN10))
+		if edition.ASIN != nil {
+			setIdentifier(out, "asin", *edition.ASIN)
+		}
+		if id := openLibraryEditionIdentifier(edition.ForeignID); id != "" {
+			setIdentifier(out, "openlibrary_edition", id)
+		}
+	}
+	return out
+}
+
+func addProviderIdentifier(out map[string]string, provider, foreignID string) {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	foreignID = strings.TrimSpace(foreignID)
+	if provider == "" || foreignID == "" {
+		return
+	}
+
+	typ := provider
+	val := foreignID
+	switch provider {
+	case "googlebooks", "google":
+		typ = "google"
+		val = trimIdentifierPrefix(val, "gb:")
+	case "dnb":
+		val = trimIdentifierPrefix(val, "dnb:")
+	case "hardcover":
+		val = trimIdentifierPrefix(val, "hc:")
+	case "openlibrary":
+		val = normalizeOpenLibraryIdentifier(val)
+	}
+	setIdentifier(out, typ, val)
+}
+
+func setIdentifier(out map[string]string, typ, val string) {
+	typ = cleanIdentifierType(typ)
+	val = cleanIdentifierValue(val)
+	if typ == "" || val == "" {
+		return
+	}
+	out[typ] = val
+}
+
+func firstIdentifierValue(values ...*string) string {
+	for _, v := range values {
+		if v != nil && strings.TrimSpace(*v) != "" {
+			return strings.TrimSpace(*v)
+		}
+	}
+	return ""
+}
+
+func openLibraryEditionIdentifier(foreignID string) string {
+	id := normalizeOpenLibraryIdentifier(foreignID)
+	if openLibraryEditionIDRe.MatchString(id) {
+		return id
+	}
+	return ""
+}
+
+func normalizeOpenLibraryIdentifier(value string) string {
+	value = strings.TrimSpace(value)
+	value = trimIdentifierPrefix(value, "openlibrary:")
+	value = trimIdentifierPrefix(value, "/works/")
+	value = trimIdentifierPrefix(value, "/books/")
+	return value
+}
+
+func trimIdentifierPrefix(value, prefix string) string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(strings.ToLower(value), strings.ToLower(prefix)) {
+		return strings.TrimSpace(value[len(prefix):])
+	}
+	return value
+}

--- a/internal/calibre/metadata.go
+++ b/internal/calibre/metadata.go
@@ -23,7 +23,10 @@ const (
 	coverDirMode  = 0o750
 )
 
-var identifierTypeRe = regexp.MustCompile(`[^a-z0-9_-]+`)
+var (
+	identifierTypeRe    = regexp.MustCompile(`[^a-z0-9_-]+`)
+	calibredbDateOnlyRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+)
 
 // Metadata is the Bindery-owned metadata contract passed to every Calibre
 // handoff. It represents the Calibre database fields Bindery can populate
@@ -101,7 +104,7 @@ func (m Metadata) setFields() []string {
 		fields = append(fields, "publisher:"+v)
 	}
 	if v := strings.TrimSpace(m.PublishedDate); v != "" {
-		fields = append(fields, "pubdate:"+v)
+		fields = append(fields, "pubdate:"+formatCalibredbPubdate(v))
 	}
 	if m.Rating > 0 {
 		fields = append(fields, "rating:"+strconv.FormatFloat(m.Rating, 'f', -1, 64))
@@ -119,6 +122,14 @@ func (m Metadata) setFields() []string {
 		fields = append(fields, "series_index:"+v)
 	}
 	return fields
+}
+
+func formatCalibredbPubdate(v string) string {
+	v = strings.TrimSpace(v)
+	if calibredbDateOnlyRe.MatchString(v) {
+		return v + "T00:00:00+00:00"
+	}
+	return v
 }
 
 func cleanList(in []string) []string {

--- a/internal/calibre/metadata.go
+++ b/internal/calibre/metadata.go
@@ -1,0 +1,350 @@
+package calibre
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vavallee/bindery/internal/httpsec"
+)
+
+const (
+	coverMaxBytes = 10 * 1024 * 1024
+	coverFileMode = 0o640
+	coverDirMode  = 0o750
+)
+
+var identifierTypeRe = regexp.MustCompile(`[^a-z0-9_-]+`)
+
+// Metadata is the Bindery-owned metadata contract passed to every Calibre
+// handoff. It represents the Calibre database fields Bindery can populate
+// from its own book, author, edition, and series records.
+type Metadata struct {
+	Title         string            `json:"title,omitempty"`
+	Authors       []string          `json:"authors,omitempty"`
+	AuthorSort    string            `json:"authorSort,omitempty"`
+	Description   string            `json:"description,omitempty"`
+	Publisher     string            `json:"publisher,omitempty"`
+	PublishedDate string            `json:"publishedDate,omitempty"`
+	Genres        []string          `json:"genres,omitempty"`
+	Language      string            `json:"language,omitempty"`
+	Series        string            `json:"series,omitempty"`
+	SeriesIndex   string            `json:"seriesIndex,omitempty"`
+	Rating        float64           `json:"rating,omitempty"`
+	Identifiers   map[string]string `json:"identifiers,omitempty"`
+	CoverPath     string            `json:"coverPath,omitempty"`
+}
+
+func (m Metadata) empty() bool {
+	return strings.TrimSpace(m.Title) == "" &&
+		len(m.Authors) == 0 &&
+		strings.TrimSpace(m.AuthorSort) == "" &&
+		strings.TrimSpace(m.Description) == "" &&
+		strings.TrimSpace(m.Publisher) == "" &&
+		strings.TrimSpace(m.PublishedDate) == "" &&
+		len(m.Genres) == 0 &&
+		strings.TrimSpace(m.Language) == "" &&
+		strings.TrimSpace(m.Series) == "" &&
+		strings.TrimSpace(m.SeriesIndex) == "" &&
+		m.Rating <= 0 &&
+		len(m.Identifiers) == 0 &&
+		strings.TrimSpace(m.CoverPath) == ""
+}
+
+func (m Metadata) addArgs() []string {
+	args := make([]string, 0, 18)
+	if v := strings.TrimSpace(m.Title); v != "" {
+		args = append(args, "--title", v)
+	}
+	if authors := cleanList(m.Authors); len(authors) > 0 {
+		args = append(args, "--authors", strings.Join(authors, " & "))
+	}
+	if v := strings.TrimSpace(m.CoverPath); v != "" {
+		args = append(args, "--cover", v)
+	}
+	for _, ident := range identifierArgs(m.Identifiers) {
+		args = append(args, "--identifier", ident)
+	}
+	if v := strings.TrimSpace(m.Language); v != "" {
+		args = append(args, "--languages", v)
+	}
+	if v := strings.TrimSpace(m.Series); v != "" {
+		args = append(args, "--series", v)
+	}
+	if v := strings.TrimSpace(m.SeriesIndex); v != "" {
+		args = append(args, "--series-index", v)
+	}
+	if tags := cleanList(m.Genres); len(tags) > 0 {
+		args = append(args, "--tags", strings.Join(tags, ","))
+	}
+	return args
+}
+
+func (m Metadata) setFields() []string {
+	fields := make([]string, 0, 10)
+	if v := strings.TrimSpace(m.Description); v != "" {
+		fields = append(fields, "comments:"+v)
+	}
+	if v := strings.TrimSpace(m.AuthorSort); v != "" {
+		fields = append(fields, "author_sort:"+v)
+	}
+	if v := strings.TrimSpace(m.Publisher); v != "" {
+		fields = append(fields, "publisher:"+v)
+	}
+	if v := strings.TrimSpace(m.PublishedDate); v != "" {
+		fields = append(fields, "pubdate:"+v)
+	}
+	if m.Rating > 0 {
+		fields = append(fields, "rating:"+strconv.FormatFloat(m.Rating, 'f', -1, 64))
+	}
+	if v := strings.TrimSpace(m.Language); v != "" {
+		fields = append(fields, "languages:"+v)
+	}
+	if tags := cleanList(m.Genres); len(tags) > 0 {
+		fields = append(fields, "tags:"+strings.Join(tags, ","))
+	}
+	if v := strings.TrimSpace(m.Series); v != "" {
+		fields = append(fields, "series:"+v)
+	}
+	if v := strings.TrimSpace(m.SeriesIndex); v != "" {
+		fields = append(fields, "series_index:"+v)
+	}
+	return fields
+}
+
+func cleanList(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	seen := map[string]struct{}{}
+	for _, v := range in {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		key := strings.ToLower(v)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+func identifierArgs(in map[string]string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(in))
+	for k := range in {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make([]string, 0, len(in))
+	for _, key := range keys {
+		typ := cleanIdentifierType(key)
+		val := cleanIdentifierValue(in[key])
+		if typ == "" || val == "" {
+			continue
+		}
+		out = append(out, typ+":"+val)
+	}
+	return out
+}
+
+func cleanIdentifierType(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = identifierTypeRe.ReplaceAllString(s, "_")
+	return strings.Trim(s, "_")
+}
+
+func cleanIdentifierValue(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, ",", " ")
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// NormalizeLanguageForCalibre converts common ISO-639-2 and provider-specific
+// language values into the short codes Calibre documents for CLI metadata
+// updates. Unknown ISO-639-2 values are returned lowercased; Calibre accepts
+// many ISO language values beyond the examples in its manual.
+func NormalizeLanguageForCalibre(code string) string {
+	code = strings.ToLower(strings.TrimSpace(code))
+	if code == "" {
+		return ""
+	}
+	switch code {
+	case "eng":
+		return "en"
+	case "fre", "fra":
+		return "fr"
+	case "ger", "deu":
+		return "de"
+	case "spa":
+		return "es"
+	case "ita":
+		return "it"
+	case "por":
+		return "pt"
+	case "dut", "nld":
+		return "nl"
+	case "swe":
+		return "sv"
+	case "dan":
+		return "da"
+	case "nor":
+		return "no"
+	case "fin":
+		return "fi"
+	case "rus":
+		return "ru"
+	case "jpn":
+		return "ja"
+	case "chi", "zho":
+		return "zh"
+	case "kor":
+		return "ko"
+	case "pol":
+		return "pl"
+	case "tur":
+		return "tr"
+	case "ukr":
+		return "uk"
+	case "ara":
+		return "ar"
+	case "ind":
+		return "id"
+	case "tgl", "fil":
+		return "tl"
+	default:
+		return code
+	}
+}
+
+func FormatPublishedDate(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.UTC().Format("2006-01-02")
+}
+
+// MaterializeCover fetches an external cover into cacheDir and returns a local
+// path Calibre can consume. It validates outbound URLs to avoid SSRF and keeps
+// failures non-fatal for callers.
+func MaterializeCover(ctx context.Context, cacheDir, rawURL string) (string, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if cacheDir == "" || rawURL == "" {
+		return "", nil
+	}
+	if err := httpsec.ValidateOutboundURL(rawURL, httpsec.PolicyStrict); err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(rawURL))
+	key := fmt.Sprintf("%x", sum)
+	if existing, ok := findExistingCover(cacheDir, key); ok {
+		return existing, nil
+	}
+
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if err := httpsec.ValidateOutboundURL(req.URL.String(), httpsec.PolicyStrict); err != nil {
+				return fmt.Errorf("redirect blocked: %w", err)
+			}
+			if len(via) >= 5 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("cover returned status %d", resp.StatusCode)
+	}
+	ct := resp.Header.Get("Content-Type")
+	ext := coverExt(ct)
+	if ext == "" {
+		return "", fmt.Errorf("cover response is not an image")
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, coverMaxBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if len(body) > coverMaxBytes {
+		return "", fmt.Errorf("cover exceeds %d bytes", coverMaxBytes)
+	}
+	if err := os.MkdirAll(cacheDir, coverDirMode); err != nil {
+		return "", err
+	}
+	dst := filepath.Join(cacheDir, key+ext)
+	tmp, err := os.CreateTemp(cacheDir, ".cover-*")
+	if err != nil {
+		return "", err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return "", err
+	}
+	if err := tmp.Chmod(coverFileMode); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return "", err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return "", err
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		_ = os.Remove(tmpName)
+		return "", err
+	}
+	return dst, nil
+}
+
+func findExistingCover(cacheDir, key string) (string, bool) {
+	for _, ext := range []string{".jpg", ".png", ".webp", ".gif"} {
+		path := filepath.Join(cacheDir, key+ext)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func coverExt(contentType string) string {
+	contentType = strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	switch contentType {
+	case "image/jpeg", "image/jpg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/webp":
+		return ".webp"
+	case "image/gif":
+		return ".gif"
+	default:
+		return ""
+	}
+}

--- a/internal/calibre/metadata.go
+++ b/internal/calibre/metadata.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -83,7 +84,7 @@ func (m Metadata) addArgs() []string {
 	if v := strings.TrimSpace(m.Series); v != "" {
 		args = append(args, "--series", v)
 	}
-	if v := strings.TrimSpace(m.SeriesIndex); v != "" {
+	if v := cleanCalibreSeriesIndex(m.SeriesIndex); v != "" {
 		args = append(args, "--series-index", v)
 	}
 	if tags := cleanList(m.Genres); len(tags) > 0 {
@@ -118,10 +119,22 @@ func (m Metadata) setFields() []string {
 	if v := strings.TrimSpace(m.Series); v != "" {
 		fields = append(fields, "series:"+v)
 	}
-	if v := strings.TrimSpace(m.SeriesIndex); v != "" {
+	if v := cleanCalibreSeriesIndex(m.SeriesIndex); v != "" {
 		fields = append(fields, "series_index:"+v)
 	}
 	return fields
+}
+
+func cleanCalibreSeriesIndex(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
+		return ""
+	}
+	return strconv.FormatFloat(f, 'f', -1, 64)
 }
 
 func formatCalibredbPubdate(v string) string {

--- a/internal/calibre/metadata_test.go
+++ b/internal/calibre/metadata_test.go
@@ -29,6 +29,26 @@ func TestNormalizeLanguageForCalibre(t *testing.T) {
 	}
 }
 
+func TestFormatCalibredbPubdate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"date only", "1965-08-01", "1965-08-01T00:00:00+00:00"},
+		{"timestamp", "1965-08-01T00:00:00+00:00", "1965-08-01T00:00:00+00:00"},
+		{"blank", "   ", ""},
+		{"unexpected", "August 1965", "August 1965"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatCalibredbPubdate(tt.in); got != tt.want {
+				t.Fatalf("formatCalibredbPubdate(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIdentifiersForBook_UsesPresentBookAndEditionData(t *testing.T) {
 	editionASIN := "B000FC1BN8"
 	edition := &models.Edition{

--- a/internal/calibre/metadata_test.go
+++ b/internal/calibre/metadata_test.go
@@ -1,0 +1,25 @@
+package calibre
+
+import "testing"
+
+func TestNormalizeLanguageForCalibre(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"eng", "en"},
+		{"fre", "fr"},
+		{"fra", "fr"},
+		{"ger", "de"},
+		{"deu", "de"},
+		{"EN", "en"},
+		{"  spa  ", "es"},
+		{"cat", "cat"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := NormalizeLanguageForCalibre(tt.in); got != tt.want {
+			t.Errorf("NormalizeLanguageForCalibre(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/calibre/metadata_test.go
+++ b/internal/calibre/metadata_test.go
@@ -49,6 +49,26 @@ func TestFormatCalibredbPubdate(t *testing.T) {
 	}
 }
 
+func TestCalibredbSeriesIndexSkipsNonNumericValues(t *testing.T) {
+	meta := Metadata{Series: "Discworld", SeriesIndex: "Book 2"}
+	if got, want := meta.addArgs(), []string{"--series", "Discworld"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("addArgs = %#v, want %#v", got, want)
+	}
+	if got, want := meta.setFields(), []string{"series:Discworld"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("setFields = %#v, want %#v", got, want)
+	}
+}
+
+func TestCalibredbSeriesIndexKeepsNumericValues(t *testing.T) {
+	meta := Metadata{Series: "Dune Chronicles", SeriesIndex: " 1.5 "}
+	if got, want := meta.addArgs(), []string{"--series", "Dune Chronicles", "--series-index", "1.5"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("addArgs = %#v, want %#v", got, want)
+	}
+	if got, want := meta.setFields(), []string{"series:Dune Chronicles", "series_index:1.5"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("setFields = %#v, want %#v", got, want)
+	}
+}
+
 func TestIdentifiersForBook_UsesPresentBookAndEditionData(t *testing.T) {
 	editionASIN := "B000FC1BN8"
 	edition := &models.Edition{

--- a/internal/calibre/metadata_test.go
+++ b/internal/calibre/metadata_test.go
@@ -1,6 +1,11 @@
 package calibre
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
 
 func TestNormalizeLanguageForCalibre(t *testing.T) {
 	tests := []struct {
@@ -23,3 +28,76 @@ func TestNormalizeLanguageForCalibre(t *testing.T) {
 		}
 	}
 }
+
+func TestIdentifiersForBook_UsesPresentBookAndEditionData(t *testing.T) {
+	editionASIN := "B000FC1BN8"
+	edition := &models.Edition{
+		ForeignID: "/books/OL999M",
+		ISBN13:    strPtr("9780441172719"),
+		ISBN10:    strPtr("0441172717"),
+		ASIN:      &editionASIN,
+	}
+	book := &models.Book{
+		ID:               42,
+		ForeignID:        "/works/OL123W",
+		MetadataProvider: "openlibrary",
+		ASIN:             "BOOKASIN",
+	}
+
+	got := IdentifiersForBook(book, edition)
+	want := map[string]string{
+		"asin":                "B000FC1BN8",
+		"bindery":             "42",
+		"isbn":                "9780441172719",
+		"openlibrary":         "OL123W",
+		"openlibrary_edition": "OL999M",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("IdentifiersForBook = %#v, want %#v", got, want)
+	}
+}
+
+func TestIdentifiersForBook_NormalizesProviderIdentifiers(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  string
+		foreignID string
+		wantType  string
+		wantValue string
+	}{
+		{"hardcover", "hardcover", "hc:dune", "hardcover", "dune"},
+		{"googlebooks", "googlebooks", "gb:zyTCAlFPjgYC", "google", "zyTCAlFPjgYC"},
+		{"google", "google", "gb:zyTCAlFPjgYC", "google", "zyTCAlFPjgYC"},
+		{"dnb", "dnb", "dnb:123456789", "dnb", "123456789"},
+		{"fallback", "Other.Provider", " provider:value ", "other_provider", "provider:value"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IdentifiersForBook(&models.Book{
+				ID:               7,
+				ForeignID:        tt.foreignID,
+				MetadataProvider: tt.provider,
+			}, nil)
+			if got[tt.wantType] != tt.wantValue {
+				t.Fatalf("identifier %q = %q, want %q in %#v", tt.wantType, got[tt.wantType], tt.wantValue, got)
+			}
+			if got["bindery"] != "7" {
+				t.Fatalf("bindery identifier = %q, want 7", got["bindery"])
+			}
+		})
+	}
+}
+
+func TestIdentifierArgs_CleansAndSortsIdentifiers(t *testing.T) {
+	got := identifierArgs(map[string]string{
+		"Google Books": " gb:abc,123 ",
+		"isbn":         " 9780441172719 ",
+		"empty":        "",
+	})
+	want := []string{"google_books:gb:abc 123", "isbn:9780441172719"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("identifierArgs = %#v, want %#v", got, want)
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/calibre/plugin_client.go
+++ b/internal/calibre/plugin_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -39,15 +40,16 @@ func NewPluginClient(baseURL, apiKey string) *PluginClient {
 	}
 }
 
-// Add POSTs the file path to the plugin and returns the Calibre book id.
+// Add POSTs the file path and Bindery metadata to the plugin and returns the
+// Calibre book id.
 // Retries once on 503 (library swap in progress); all other non-2xx
 // statuses surface immediately.
-func (c *PluginClient) Add(ctx context.Context, filePath string) (int64, error) {
-	return c.addWithRetry(ctx, filePath, 1)
+func (c *PluginClient) Add(ctx context.Context, filePath string, meta Metadata) (int64, error) {
+	return c.addWithRetry(ctx, filePath, meta, 1, false)
 }
 
-func (c *PluginClient) addWithRetry(ctx context.Context, filePath string, retries int) (int64, error) {
-	body, _ := json.Marshal(map[string]string{"path": filePath})
+func (c *PluginClient) addWithRetry(ctx context.Context, filePath string, meta Metadata, retries int, legacyPayload bool) (int64, error) {
+	body, _ := json.Marshal(pluginAddRequest{Path: filePath, Metadata: &meta, Legacy: legacyPayload})
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/books", bytes.NewReader(body))
 	if err != nil {
 		return 0, err
@@ -68,7 +70,7 @@ func (c *PluginClient) addWithRetry(ctx context.Context, filePath string, retrie
 			return 0, ctx.Err()
 		case <-time.After(2 * time.Second):
 		}
-		return c.addWithRetry(ctx, filePath, retries-1)
+		return c.addWithRetry(ctx, filePath, meta, retries-1, legacyPayload)
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
 		return 0, fmt.Errorf("plugin client: authentication failed — check api_key in Settings → Calibre")
@@ -82,6 +84,11 @@ func (c *PluginClient) addWithRetry(ctx context.Context, filePath string, retrie
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil && resp.StatusCode < 400 {
 		return 0, fmt.Errorf("plugin client: decode response: %w", err)
 	}
+	if !legacyPayload && !meta.empty() && (resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnprocessableEntity) {
+		slog.Warn("plugin client: metadata payload rejected; retrying legacy path-only payload",
+			"status", resp.StatusCode, "error", result.Error)
+		return c.addWithRetry(ctx, filePath, Metadata{}, retries, true)
+	}
 	if resp.StatusCode == http.StatusConflict {
 		// 409 → book is already in the Calibre library. Surface the
 		// existing id (when the plugin includes it) so the caller can
@@ -93,6 +100,24 @@ func (c *PluginClient) addWithRetry(ctx context.Context, filePath string, retrie
 		return 0, fmt.Errorf("plugin client: server error %d: %s", resp.StatusCode, result.Error)
 	}
 	return result.ID, nil
+}
+
+type pluginAddRequest struct {
+	Path     string    `json:"path"`
+	Metadata *Metadata `json:"metadata,omitempty"`
+	Legacy   bool      `json:"-"`
+}
+
+func (r pluginAddRequest) MarshalJSON() ([]byte, error) {
+	if r.Legacy || r.Metadata == nil || r.Metadata.empty() {
+		return json.Marshal(struct {
+			Path string `json:"path"`
+		}{Path: r.Path})
+	}
+	return json.Marshal(struct {
+		Path     string   `json:"path"`
+		Metadata Metadata `json:"metadata"`
+	}{Path: r.Path, Metadata: *r.Metadata})
 }
 
 // Health probes GET /v1/health and returns a human-readable version

--- a/internal/calibre/plugin_client.go
+++ b/internal/calibre/plugin_client.go
@@ -197,6 +197,18 @@ func (c *PluginClient) Health(ctx context.Context) (string, error) {
 	return fmt.Sprintf("calibredb plugin v%s (Calibre %s)", h.PluginVersion, h.CalibreVersion), nil
 }
 
+// Library probes the plugin's active Calibre library path. The returned path is
+// from the Calibre/plugin runtime, so direct path comparison is only reliable
+// when Bindery and Calibre mount the same library at the same container path.
+func (c *PluginClient) Library(ctx context.Context) (string, error) {
+	h, err := c.fetchHealth(ctx)
+	if err != nil {
+		return "", err
+	}
+	c.cacheCapabilities(h)
+	return h.Library, nil
+}
+
 func (c *PluginClient) fetchHealth(ctx context.Context) (pluginHealth, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/health", nil)
 	if err != nil {

--- a/internal/calibre/plugin_client.go
+++ b/internal/calibre/plugin_client.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -19,6 +20,8 @@ import (
 // response body.
 var ErrAlreadyInCalibre = errors.New("plugin client: book already in Calibre library")
 
+const pluginCapabilityBookMetadata = "book_metadata"
+
 // PluginClient calls the Bindery Bridge Calibre plugin's HTTP API
 // (protocol /v1/, see bindery-plugins/docs/protocol.md). It implements the
 // importer's calibreAdder interface so the scanner can swap it in when the
@@ -27,6 +30,11 @@ type PluginClient struct {
 	baseURL string
 	apiKey  string
 	http    *http.Client
+
+	capMu                 sync.Mutex
+	capabilitiesLoaded    bool
+	supportsBookMetadata  bool
+	metadataWarningLogged bool
 }
 
 // NewPluginClient builds a client against the plugin's base URL (e.g.
@@ -45,7 +53,17 @@ func NewPluginClient(baseURL, apiKey string) *PluginClient {
 // Retries once on 503 (library swap in progress); all other non-2xx
 // statuses surface immediately.
 func (c *PluginClient) Add(ctx context.Context, filePath string, meta Metadata) (int64, error) {
-	return c.addWithRetry(ctx, filePath, meta, 1, false)
+	legacyPayload := false
+	if !meta.empty() {
+		supported, err := c.supportsMetadata(ctx)
+		if err != nil {
+			c.warnMetadataUnavailable("plugin client: metadata capability probe failed; sending metadata and will retry legacy payload if rejected", "error", err)
+		} else if !supported {
+			c.warnMetadataUnavailable("plugin client: plugin does not advertise metadata support; upgrade Bindery Bridge to export metadata")
+			legacyPayload = true
+		}
+	}
+	return c.addWithRetry(ctx, filePath, meta, 1, legacyPayload)
 }
 
 func (c *PluginClient) addWithRetry(ctx context.Context, filePath string, meta Metadata, retries int, legacyPayload bool) (int64, error) {
@@ -120,33 +138,86 @@ func (r pluginAddRequest) MarshalJSON() ([]byte, error) {
 	}{Path: r.Path, Metadata: *r.Metadata})
 }
 
+type pluginHealth struct {
+	PluginVersion  string   `json:"plugin_version"`
+	CalibreVersion string   `json:"calibre_version"`
+	Library        string   `json:"library"`
+	Capabilities   []string `json:"capabilities"`
+}
+
+func (c *PluginClient) supportsMetadata(ctx context.Context) (bool, error) {
+	c.capMu.Lock()
+	defer c.capMu.Unlock()
+	if c.capabilitiesLoaded {
+		return c.supportsBookMetadata, nil
+	}
+	h, err := c.fetchHealth(ctx)
+	if err != nil {
+		return false, err
+	}
+	c.cacheCapabilitiesLocked(h)
+	return c.supportsBookMetadata, nil
+}
+
+func (c *PluginClient) warnMetadataUnavailable(msg string, args ...any) {
+	c.capMu.Lock()
+	defer c.capMu.Unlock()
+	if c.metadataWarningLogged {
+		return
+	}
+	c.metadataWarningLogged = true
+	slog.Warn(msg, args...)
+}
+
+func (c *PluginClient) cacheCapabilities(h pluginHealth) {
+	c.capMu.Lock()
+	defer c.capMu.Unlock()
+	c.cacheCapabilitiesLocked(h)
+}
+
+func (c *PluginClient) cacheCapabilitiesLocked(h pluginHealth) {
+	c.capabilitiesLoaded = true
+	c.supportsBookMetadata = false
+	for _, cap := range h.Capabilities {
+		if cap == pluginCapabilityBookMetadata {
+			c.supportsBookMetadata = true
+			return
+		}
+	}
+}
+
 // Health probes GET /v1/health and returns a human-readable version
 // string for the Settings → Test button.
 func (c *PluginClient) Health(ctx context.Context) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/health", nil)
+	h, err := c.fetchHealth(ctx)
 	if err != nil {
 		return "", err
+	}
+	c.cacheCapabilities(h)
+	return fmt.Sprintf("calibredb plugin v%s (Calibre %s)", h.PluginVersion, h.CalibreVersion), nil
+}
+
+func (c *PluginClient) fetchHealth(ctx context.Context) (pluginHealth, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/health", nil)
+	if err != nil {
+		return pluginHealth{}, err
 	}
 	req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	req.Header.Set("User-Agent", "bindery plugin-api/v1")
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("plugin client: health: %w", err)
+		return pluginHealth{}, fmt.Errorf("plugin client: health: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusUnauthorized {
-		return "", fmt.Errorf("plugin client: authentication failed — check api_key in Settings → Calibre")
+		return pluginHealth{}, fmt.Errorf("plugin client: authentication failed — check api_key in Settings → Calibre")
 	}
 	if resp.StatusCode >= 400 {
-		return "", fmt.Errorf("plugin client: health: server error %d", resp.StatusCode)
+		return pluginHealth{}, fmt.Errorf("plugin client: health: server error %d", resp.StatusCode)
 	}
-	var h struct {
-		PluginVersion  string `json:"plugin_version"`
-		CalibreVersion string `json:"calibre_version"`
-		Library        string `json:"library"`
-	}
+	var h pluginHealth
 	if err := json.NewDecoder(resp.Body).Decode(&h); err != nil {
-		return "", fmt.Errorf("plugin client: decode health: %w", err)
+		return pluginHealth{}, fmt.Errorf("plugin client: decode health: %w", err)
 	}
-	return fmt.Sprintf("calibredb plugin v%s (Calibre %s)", h.PluginVersion, h.CalibreVersion), nil
+	return h, nil
 }

--- a/internal/calibre/plugin_client_test.go
+++ b/internal/calibre/plugin_client_test.go
@@ -2,6 +2,7 @@ package calibre
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,13 +19,23 @@ func TestPluginClient_AddHappyPath(t *testing.T) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
 			t.Errorf("Authorization = %q", got)
 		}
+		var body struct {
+			Path     string   `json:"path"`
+			Metadata Metadata `json:"metadata"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.Path != "/library/book.epub" || body.Metadata.Title != "Dune" {
+			t.Fatalf("body = %+v, want path and metadata", body)
+		}
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte(`{"id":42,"duplicate":false}`))
 	}))
 	defer srv.Close()
 
 	c := NewPluginClient(srv.URL, "test-key")
-	id, err := c.Add(context.Background(), "/library/book.epub")
+	id, err := c.Add(context.Background(), "/library/book.epub", Metadata{Title: "Dune"})
 	if err != nil {
 		t.Fatalf("Add returned error: %v", err)
 	}
@@ -51,7 +62,7 @@ func TestPluginClient_Add503RetrySucceeds(t *testing.T) {
 	// but long enough to allow the 2s sleep + second request.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	id, err := c.Add(ctx, "/a.epub")
+	id, err := c.Add(ctx, "/a.epub", Metadata{})
 	if err != nil {
 		t.Fatalf("Add: %v", err)
 	}
@@ -71,7 +82,7 @@ func TestPluginClient_Add401ReturnsDescriptiveError(t *testing.T) {
 	defer srv.Close()
 
 	c := NewPluginClient(srv.URL, "bad")
-	_, err := c.Add(context.Background(), "/a.epub")
+	_, err := c.Add(context.Background(), "/a.epub", Metadata{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -97,6 +108,43 @@ func TestPluginClient_Health(t *testing.T) {
 	}
 	if !strings.Contains(got, "0.1.0") || !strings.Contains(got, "9.7") {
 		t.Errorf("version string = %q", got)
+	}
+}
+
+func TestPluginClient_AddRetriesLegacyPayloadWhenMetadataRejected(t *testing.T) {
+	var bodies []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		bodies = append(bodies, body)
+		if len(bodies) == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"unknown field metadata"}`))
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":99}`))
+	}))
+	defer srv.Close()
+
+	c := NewPluginClient(srv.URL, "k")
+	id, err := c.Add(context.Background(), "/a.epub", Metadata{Title: "Dune"})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if id != 99 {
+		t.Fatalf("id = %d, want 99", id)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("bodies = %d, want 2", len(bodies))
+	}
+	if _, ok := bodies[0]["metadata"]; !ok {
+		t.Fatalf("first body missing metadata: %+v", bodies[0])
+	}
+	if _, ok := bodies[1]["metadata"]; ok {
+		t.Fatalf("legacy retry should omit metadata: %+v", bodies[1])
 	}
 }
 

--- a/internal/calibre/plugin_client_test.go
+++ b/internal/calibre/plugin_client_test.go
@@ -13,6 +13,11 @@ import (
 
 func TestPluginClient_AddHappyPath(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/health" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"plugin_version":"0.5.0","calibre_version":"9.8","library":"/books","capabilities":["book_metadata"]}`))
+			return
+		}
 		if r.Method != http.MethodPost || r.URL.Path != "/v1/books" {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -41,6 +46,79 @@ func TestPluginClient_AddHappyPath(t *testing.T) {
 	}
 	if id != 42 {
 		t.Errorf("id = %d, want 42", id)
+	}
+}
+
+func TestPluginClient_AddOmitsMetadataWhenCapabilityMissing(t *testing.T) {
+	var posted map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/health" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"plugin_version":"0.4.0","calibre_version":"9.7","library":"/books"}`))
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/books" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":42,"duplicate":false}`))
+	}))
+	defer srv.Close()
+
+	c := NewPluginClient(srv.URL, "test-key")
+	id, err := c.Add(context.Background(), "/library/book.epub", Metadata{Title: "Dune"})
+	if err != nil {
+		t.Fatalf("Add returned error: %v", err)
+	}
+	if id != 42 {
+		t.Errorf("id = %d, want 42", id)
+	}
+	if posted["path"] != "/library/book.epub" {
+		t.Fatalf("posted path = %v", posted["path"])
+	}
+	if _, ok := posted["metadata"]; ok {
+		t.Fatalf("metadata should be omitted for old plugin health response: %+v", posted)
+	}
+}
+
+func TestPluginClient_AddSendsMetadataWhenCapabilityProbeFails(t *testing.T) {
+	var posted struct {
+		Path     string   `json:"path"`
+		Metadata Metadata `json:"metadata"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/health" {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"library swap"}`))
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/books" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":42,"duplicate":false}`))
+	}))
+	defer srv.Close()
+
+	c := NewPluginClient(srv.URL, "test-key")
+	id, err := c.Add(context.Background(), "/library/book.epub", Metadata{Title: "Dune"})
+	if err != nil {
+		t.Fatalf("Add returned error: %v", err)
+	}
+	if id != 42 {
+		t.Errorf("id = %d, want 42", id)
+	}
+	if posted.Path != "/library/book.epub" {
+		t.Fatalf("posted path = %q", posted.Path)
+	}
+	if posted.Metadata.Title != "Dune" {
+		t.Fatalf("posted metadata title = %q, want Dune", posted.Metadata.Title)
 	}
 }
 
@@ -114,6 +192,11 @@ func TestPluginClient_Health(t *testing.T) {
 func TestPluginClient_AddRetriesLegacyPayloadWhenMetadataRejected(t *testing.T) {
 	var bodies []map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/health" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"plugin_version":"0.5.0","calibre_version":"9.8","library":"/books","capabilities":["book_metadata"]}`))
+			return
+		}
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode body: %v", err)

--- a/internal/calibre/syncer.go
+++ b/internal/calibre/syncer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -46,7 +48,7 @@ type SyncProgress struct {
 // pluginPusher captures the subset of *PluginClient the syncer needs, so
 // tests can inject a fake without standing up an HTTP server.
 type pluginPusher interface {
-	Add(ctx context.Context, filePath string) (int64, error)
+	Add(ctx context.Context, filePath string, meta Metadata) (int64, error)
 }
 
 // BookLister is the subset of *db.BookRepo the syncer uses. Keeps the
@@ -179,7 +181,21 @@ func (s *Syncer) run(ctx context.Context, cfg Config) {
 		}
 		b := &eligible[i]
 		path := pushPath(b)
-		id, addErr := client.Add(ctx, path)
+		meta := Metadata{
+			Title:    b.Title,
+			Language: NormalizeLanguageForCalibre(b.Language),
+			Genres:   b.Genres,
+			Identifiers: map[string]string{
+				"bindery": strconv.FormatInt(b.ID, 10),
+			},
+		}
+		if strings.TrimSpace(b.ASIN) != "" {
+			meta.Identifiers["asin"] = b.ASIN
+		}
+		if strings.TrimSpace(b.MetadataProvider) != "" && strings.TrimSpace(b.ForeignID) != "" {
+			meta.Identifiers[b.MetadataProvider] = b.ForeignID
+		}
+		id, addErr := client.Add(ctx, path, meta)
 		switch {
 		case addErr == nil:
 			if id > 0 {

--- a/internal/calibre/syncer.go
+++ b/internal/calibre/syncer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -56,11 +58,25 @@ type BookLister interface {
 	SetCalibreID(ctx context.Context, id, calibreID int64) error
 }
 
+// AuthorGetter is the subset of *db.AuthorRepo used to add author metadata
+// to plugin sync requests.
+type AuthorGetter interface {
+	GetByID(ctx context.Context, id int64) (*models.Author, error)
+}
+
+// EditionLister is the subset of *db.EditionRepo used to identify the
+// specific edition for the file being pushed.
+type EditionLister interface {
+	ListByBook(ctx context.Context, bookID int64) ([]models.Edition, error)
+}
+
 // Syncer orchestrates the "Push all to Calibre" bulk job. One sync runs
 // at a time — a second call returns ErrSyncAlreadyRunning. Progress is
 // mutex-protected and can be polled concurrently with the running job.
 type Syncer struct {
 	books     BookLister
+	authors   AuthorGetter
+	editions  EditionLister
 	newClient func(cfg Config) pluginPusher
 
 	mu       sync.Mutex
@@ -78,6 +94,15 @@ func NewSyncer(books BookLister) *Syncer {
 			return NewPluginClient(cfg.PluginURL, cfg.PluginAPIKey)
 		},
 	}
+}
+
+// WithMetadata attaches optional repositories used to enrich plugin sync
+// requests. Keeping this separate preserves the narrow constructor used in
+// tests while production can export authors and edition identifiers.
+func (s *Syncer) WithMetadata(authors AuthorGetter, editions EditionLister) *Syncer {
+	s.authors = authors
+	s.editions = editions
+	return s
 }
 
 // ErrSyncAlreadyRunning is returned when Start is called while a previous
@@ -179,11 +204,19 @@ func (s *Syncer) run(ctx context.Context, cfg Config) {
 		}
 		b := &eligible[i]
 		path := pushPath(b)
-		meta := Metadata{
-			Title:       b.Title,
-			Language:    NormalizeLanguageForCalibre(b.Language),
-			Genres:      b.Genres,
-			Identifiers: IdentifiersForBook(b, nil),
+		meta, err := s.metadataForBook(ctx, b, path)
+		if err != nil {
+			s.setProgress(func(p *SyncProgress) {
+				p.Stats.Failed++
+				p.Stats.Processed++
+				p.Errors = append(p.Errors, SyncError{
+					BookID: b.ID,
+					Title:  b.Title,
+					Path:   path,
+					Reason: err.Error(),
+				})
+			})
+			continue
 		}
 		id, addErr := client.Add(ctx, path, meta)
 		switch {
@@ -239,6 +272,84 @@ func pushPath(b *models.Book) string {
 		return b.EbookFilePath
 	}
 	return b.FilePath
+}
+
+func (s *Syncer) metadataForBook(ctx context.Context, b *models.Book, path string) (Metadata, error) {
+	edition, err := s.editionForPath(ctx, b, path)
+	if err != nil {
+		return Metadata{}, err
+	}
+	authors, authorSort, err := s.authorMetadata(ctx, b)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return Metadata{
+		Title:       b.Title,
+		Authors:     authors,
+		AuthorSort:  authorSort,
+		Language:    NormalizeLanguageForCalibre(b.Language),
+		Genres:      b.Genres,
+		Identifiers: IdentifiersForBook(b, edition),
+	}, nil
+}
+
+func (s *Syncer) authorMetadata(ctx context.Context, b *models.Book) ([]string, string, error) {
+	if b.Author != nil && strings.TrimSpace(b.Author.Name) != "" {
+		return []string{strings.TrimSpace(b.Author.Name)}, strings.TrimSpace(b.Author.SortName), nil
+	}
+	if s.authors == nil || b.AuthorID == 0 {
+		return nil, "", nil
+	}
+	author, err := s.authors.GetByID(ctx, b.AuthorID)
+	if err != nil {
+		return nil, "", err
+	}
+	if author == nil || strings.TrimSpace(author.Name) == "" {
+		return nil, "", nil
+	}
+	return []string{strings.TrimSpace(author.Name)}, strings.TrimSpace(author.SortName), nil
+}
+
+func (s *Syncer) editionForPath(ctx context.Context, b *models.Book, path string) (*models.Edition, error) {
+	if s.editions == nil {
+		return nil, nil
+	}
+	editions, err := s.editions.ListByBook(ctx, b.ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(editions) == 0 {
+		return nil, nil
+	}
+
+	ext := strings.TrimPrefix(filepath.Ext(path), ".")
+	if ext != "" {
+		format := strings.ToUpper(strings.TrimSpace(ext))
+		var firstFormatMatch *models.Edition
+		for i := range editions {
+			if strings.ToUpper(strings.TrimSpace(editions[i].Format)) != format {
+				continue
+			}
+			if b.SelectedEditionID != nil && editions[i].ID == *b.SelectedEditionID {
+				return &editions[i], nil
+			}
+			if firstFormatMatch == nil {
+				firstFormatMatch = &editions[i]
+			}
+		}
+		if firstFormatMatch != nil {
+			return firstFormatMatch, nil
+		}
+	}
+
+	if b.SelectedEditionID != nil {
+		for i := range editions {
+			if editions[i].ID == *b.SelectedEditionID {
+				return &editions[i], nil
+			}
+		}
+	}
+	return &editions[0], nil
 }
 
 func (s *Syncer) fail(msg string) {

--- a/internal/calibre/syncer.go
+++ b/internal/calibre/syncer.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -182,18 +180,10 @@ func (s *Syncer) run(ctx context.Context, cfg Config) {
 		b := &eligible[i]
 		path := pushPath(b)
 		meta := Metadata{
-			Title:    b.Title,
-			Language: NormalizeLanguageForCalibre(b.Language),
-			Genres:   b.Genres,
-			Identifiers: map[string]string{
-				"bindery": strconv.FormatInt(b.ID, 10),
-			},
-		}
-		if strings.TrimSpace(b.ASIN) != "" {
-			meta.Identifiers["asin"] = b.ASIN
-		}
-		if strings.TrimSpace(b.MetadataProvider) != "" && strings.TrimSpace(b.ForeignID) != "" {
-			meta.Identifiers[b.MetadataProvider] = b.ForeignID
+			Title:       b.Title,
+			Language:    NormalizeLanguageForCalibre(b.Language),
+			Genres:      b.Genres,
+			Identifiers: IdentifiersForBook(b, nil),
 		}
 		id, addErr := client.Add(ctx, path, meta)
 		switch {

--- a/internal/calibre/syncer.go
+++ b/internal/calibre/syncer.go
@@ -49,6 +49,7 @@ type SyncProgress struct {
 // tests can inject a fake without standing up an HTTP server.
 type pluginPusher interface {
 	Add(ctx context.Context, filePath string, meta Metadata) (int64, error)
+	Library(ctx context.Context) (string, error)
 }
 
 // BookLister is the subset of *db.BookRepo the syncer uses. Keeps the
@@ -196,6 +197,7 @@ func (s *Syncer) run(ctx context.Context, cfg Config) {
 	})
 
 	client := s.newClient(cfg)
+	sameLibrary := sameCalibreLibrary(ctx, cfg, client)
 
 	for i := range eligible {
 		if err := ctx.Err(); err != nil {
@@ -204,7 +206,7 @@ func (s *Syncer) run(ctx context.Context, cfg Config) {
 		}
 		b := &eligible[i]
 		path := pushPath(b)
-		meta, err := s.metadataForBook(ctx, b, path)
+		meta, err := s.metadataForBook(ctx, b, path, sameLibrary)
 		if err != nil {
 			s.setProgress(func(p *SyncProgress) {
 				p.Stats.Failed++
@@ -221,20 +223,16 @@ func (s *Syncer) run(ctx context.Context, cfg Config) {
 		id, addErr := client.Add(ctx, path, meta)
 		switch {
 		case addErr == nil:
-			if id > 0 {
-				if perr := s.books.SetCalibreID(ctx, b.ID, id); perr != nil {
-					slog.Warn("calibre sync: persist calibre_id failed", "bookId", b.ID, "calibreId", id, "error", perr)
-				}
+			if perr := s.persistCalibreID(ctx, b, id, sameLibrary); perr != nil {
+				slog.Warn("calibre sync: persist calibre_id failed", "bookId", b.ID, "calibreId", id, "error", perr)
 			}
 			s.setProgress(func(p *SyncProgress) {
 				p.Stats.Pushed++
 				p.Stats.Processed++
 			})
 		case errors.Is(addErr, ErrAlreadyInCalibre):
-			if id > 0 {
-				if perr := s.books.SetCalibreID(ctx, b.ID, id); perr != nil {
-					slog.Warn("calibre sync: persist calibre_id failed", "bookId", b.ID, "calibreId", id, "error", perr)
-				}
+			if perr := s.persistCalibreID(ctx, b, id, sameLibrary); perr != nil {
+				slog.Warn("calibre sync: persist calibre_id failed", "bookId", b.ID, "calibreId", id, "error", perr)
 			}
 			s.setProgress(func(p *SyncProgress) {
 				p.Stats.AlreadyInCalibre++
@@ -274,7 +272,7 @@ func pushPath(b *models.Book) string {
 	return b.FilePath
 }
 
-func (s *Syncer) metadataForBook(ctx context.Context, b *models.Book, path string) (Metadata, error) {
+func (s *Syncer) metadataForBook(ctx context.Context, b *models.Book, path string, sameLibrary bool) (Metadata, error) {
 	edition, err := s.editionForPath(ctx, b, path)
 	if err != nil {
 		return Metadata{}, err
@@ -283,13 +281,17 @@ func (s *Syncer) metadataForBook(ctx context.Context, b *models.Book, path strin
 	if err != nil {
 		return Metadata{}, err
 	}
+	identifiers := IdentifiersForBook(b, edition)
+	if !sameLibrary && isCalibreOrigin(b) {
+		delete(identifiers, "calibre")
+	}
 	return Metadata{
 		Title:       b.Title,
 		Authors:     authors,
 		AuthorSort:  authorSort,
 		Language:    NormalizeLanguageForCalibre(b.Language),
 		Genres:      b.Genres,
-		Identifiers: IdentifiersForBook(b, edition),
+		Identifiers: identifiers,
 	}, nil
 }
 
@@ -350,6 +352,51 @@ func (s *Syncer) editionForPath(ctx context.Context, b *models.Book, path string
 		}
 	}
 	return &editions[0], nil
+}
+
+func (s *Syncer) persistCalibreID(ctx context.Context, b *models.Book, id int64, sameLibrary bool) error {
+	if id <= 0 {
+		return nil
+	}
+	if isCalibreOrigin(b) && !sameLibrary {
+		slog.Debug("calibre sync: not overwriting source calibre_id with target library id",
+			"bookId", b.ID, "targetCalibreId", id)
+		return nil
+	}
+	return s.books.SetCalibreID(ctx, b.ID, id)
+}
+
+func sameCalibreLibrary(ctx context.Context, cfg Config, client pluginPusher) bool {
+	source := cleanLibraryPath(cfg.LibraryPath)
+	if source == "" {
+		return false
+	}
+	target, err := client.Library(ctx)
+	if err != nil {
+		slog.Warn("calibre sync: target library identity unavailable; treating plugin target as separate from import source", "error", err)
+		return false
+	}
+	target = cleanLibraryPath(target)
+	if target == "" {
+		return false
+	}
+	return source == target
+}
+
+func cleanLibraryPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	return filepath.Clean(path)
+}
+
+func isCalibreOrigin(b *models.Book) bool {
+	if b == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(b.MetadataProvider), "calibre") ||
+		strings.HasPrefix(strings.ToLower(strings.TrimSpace(b.ForeignID)), "calibre:book:")
 }
 
 func (s *Syncer) fail(msg string) {

--- a/internal/calibre/syncer_test.go
+++ b/internal/calibre/syncer_test.go
@@ -48,6 +48,22 @@ func (f *fakeBookLister) SetCalibreID(_ context.Context, id, calibreID int64) er
 	return nil
 }
 
+type fakeAuthorGetter struct {
+	authors map[int64]*models.Author
+}
+
+func (f fakeAuthorGetter) GetByID(_ context.Context, id int64) (*models.Author, error) {
+	return f.authors[id], nil
+}
+
+type fakeEditionLister struct {
+	editions map[int64][]models.Edition
+}
+
+func (f fakeEditionLister) ListByBook(_ context.Context, bookID int64) ([]models.Edition, error) {
+	return f.editions[bookID], nil
+}
+
 // fakePusher is an inline pluginPusher that dispatches per-path behaviour
 // so we can verify pushed / already_in_calibre / failed all get counted
 // correctly inside one sync run.
@@ -125,15 +141,18 @@ func TestSyncer_Start_MixedOutcomesCountedCorrectly(t *testing.T) {
 	}
 }
 
-func TestSyncer_Start_PassesPresentBookIdentifiers(t *testing.T) {
+func TestSyncer_Start_PassesPresentBookEditionAndAuthorMetadata(t *testing.T) {
+	editionASIN := "B000FC1BN8"
+	isbn := "9780441172719"
 	books := &fakeBookLister{
 		books: []models.Book{{
 			ID:               42,
+			AuthorID:         7,
 			Title:            "Dune",
 			FilePath:         "/l/dune.epub",
 			ForeignID:        "gb:zyTCAlFPjgYC",
 			MetadataProvider: "googlebooks",
-			ASIN:             "B000FC1BN8",
+			ASIN:             "BOOKASIN",
 		}},
 	}
 	pusher := &fakePusher{calls: map[string]func() (int64, error){
@@ -141,6 +160,21 @@ func TestSyncer_Start_PassesPresentBookIdentifiers(t *testing.T) {
 	}}
 
 	s := NewSyncer(books)
+	s.WithMetadata(
+		fakeAuthorGetter{authors: map[int64]*models.Author{
+			7: {ID: 7, Name: "Frank Herbert", SortName: "Herbert, Frank"},
+		}},
+		fakeEditionLister{editions: map[int64][]models.Edition{
+			42: {{
+				ID:        99,
+				BookID:    42,
+				ForeignID: "/books/OL999M",
+				Format:    "EPUB",
+				ISBN13:    &isbn,
+				ASIN:      &editionASIN,
+			}},
+		}},
+	)
 	s.newClient = func(_ Config) pluginPusher { return pusher }
 
 	if err := s.Start(context.Background(), Config{}, ModePlugin); err != nil {
@@ -156,13 +190,69 @@ func TestSyncer_Start_PassesPresentBookIdentifiers(t *testing.T) {
 		t.Fatalf("google identifier = %q, want zyTCAlFPjgYC", meta.Identifiers["google"])
 	}
 	if meta.Identifiers["asin"] != "B000FC1BN8" {
-		t.Fatalf("asin identifier = %q, want B000FC1BN8", meta.Identifiers["asin"])
+		t.Fatalf("asin identifier = %q, want edition ASIN", meta.Identifiers["asin"])
 	}
-	if _, ok := meta.Identifiers["isbn"]; ok {
-		t.Fatalf("syncer should not invent edition isbn identifier: %+v", meta.Identifiers)
+	if meta.Identifiers["isbn"] != "9780441172719" {
+		t.Fatalf("isbn identifier = %q, want edition ISBN", meta.Identifiers["isbn"])
 	}
-	if _, ok := meta.Identifiers["openlibrary_edition"]; ok {
-		t.Fatalf("syncer should not invent edition identifier: %+v", meta.Identifiers)
+	if meta.Identifiers["openlibrary_edition"] != "OL999M" {
+		t.Fatalf("openlibrary_edition identifier = %q, want OL999M", meta.Identifiers["openlibrary_edition"])
+	}
+	if len(meta.Authors) != 1 || meta.Authors[0] != "Frank Herbert" {
+		t.Fatalf("authors = %#v, want Frank Herbert", meta.Authors)
+	}
+	if meta.AuthorSort != "Herbert, Frank" {
+		t.Fatalf("author sort = %q, want Herbert, Frank", meta.AuthorSort)
+	}
+}
+
+func TestSyncer_Start_DifferentiatesSameTitleByAuthorAndISBN(t *testing.T) {
+	blakeISBN := "9780140422153"
+	sextonISBN := "9781504034364"
+	books := &fakeBookLister{
+		books: []models.Book{
+			{ID: 1, AuthorID: 10, Title: "The Complete Poems", FilePath: "/l/blake.epub"},
+			{ID: 2, AuthorID: 20, Title: "The Complete Poems", FilePath: "/l/sexton.azw3"},
+		},
+	}
+	pusher := &fakePusher{calls: map[string]func() (int64, error){
+		"/l/blake.epub":  func() (int64, error) { return 301, nil },
+		"/l/sexton.azw3": func() (int64, error) { return 302, nil },
+	}}
+
+	s := NewSyncer(books).WithMetadata(
+		fakeAuthorGetter{authors: map[int64]*models.Author{
+			10: {ID: 10, Name: "William Blake", SortName: "Blake, William"},
+			20: {ID: 20, Name: "Anne Sexton", SortName: "Sexton, Anne"},
+		}},
+		fakeEditionLister{editions: map[int64][]models.Edition{
+			1: {{ID: 101, BookID: 1, Title: "The Complete Poems", Format: "EPUB", ISBN13: &blakeISBN}},
+			2: {{ID: 201, BookID: 2, Title: "The Complete Poems", Format: "AZW3", ISBN13: &sextonISBN}},
+		}},
+	)
+	s.newClient = func(_ Config) pluginPusher { return pusher }
+
+	if err := s.Start(context.Background(), Config{}, ModePlugin); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitUntil(t, 2*time.Second, func() bool { return !s.Running() })
+
+	blake := pusher.meta("/l/blake.epub")
+	sexton := pusher.meta("/l/sexton.azw3")
+	if got := blake.Identifiers["isbn"]; got != blakeISBN {
+		t.Fatalf("Blake isbn = %q, want %s", got, blakeISBN)
+	}
+	if got := sexton.Identifiers["isbn"]; got != sextonISBN {
+		t.Fatalf("Sexton isbn = %q, want %s", got, sextonISBN)
+	}
+	if len(blake.Authors) != 1 || blake.Authors[0] != "William Blake" {
+		t.Fatalf("Blake authors = %#v", blake.Authors)
+	}
+	if len(sexton.Authors) != 1 || sexton.Authors[0] != "Anne Sexton" {
+		t.Fatalf("Sexton authors = %#v", sexton.Authors)
+	}
+	if blake.Identifiers["isbn"] == sexton.Identifiers["isbn"] {
+		t.Fatalf("same-title books exported with identical ISBN metadata: Blake=%+v Sexton=%+v", blake, sexton)
 	}
 }
 

--- a/internal/calibre/syncer_test.go
+++ b/internal/calibre/syncer_test.go
@@ -68,9 +68,11 @@ func (f fakeEditionLister) ListByBook(_ context.Context, bookID int64) ([]models
 // so we can verify pushed / already_in_calibre / failed all get counted
 // correctly inside one sync run.
 type fakePusher struct {
-	calls map[string]func() (int64, error)
-	mu    sync.Mutex
-	metas map[string]Metadata
+	calls      map[string]func() (int64, error)
+	library    string
+	libraryErr error
+	mu         sync.Mutex
+	metas      map[string]Metadata
 }
 
 func (f *fakePusher) Add(_ context.Context, path string, meta Metadata) (int64, error) {
@@ -85,6 +87,10 @@ func (f *fakePusher) Add(_ context.Context, path string, meta Metadata) (int64, 
 		return 0, errors.New("unexpected path")
 	}
 	return fn()
+}
+
+func (f *fakePusher) Library(_ context.Context) (string, error) {
+	return f.library, f.libraryErr
 }
 
 func (f *fakePusher) meta(path string) Metadata {
@@ -256,6 +262,91 @@ func TestSyncer_Start_DifferentiatesSameTitleByAuthorAndISBN(t *testing.T) {
 	}
 }
 
+func TestSyncer_Start_DoesNotReuseSourceCalibreIDForDifferentTargetLibrary(t *testing.T) {
+	isbn := "9781504034364"
+	books := &fakeBookLister{
+		books: []models.Book{{
+			ID:               1,
+			AuthorID:         20,
+			Title:            "The Complete Poems",
+			FilePath:         "/source/Anne Sexton/The Complete Poems.azw3",
+			ForeignID:        "calibre:book:2767",
+			MetadataProvider: "calibre",
+			CalibreID:        int64Ptr(2767),
+		}},
+	}
+	pusher := &fakePusher{
+		library: "/target-calibre",
+		calls: map[string]func() (int64, error){
+			"/source/Anne Sexton/The Complete Poems.azw3": func() (int64, error) { return 101, nil },
+		},
+	}
+
+	s := NewSyncer(books).WithMetadata(
+		fakeAuthorGetter{authors: map[int64]*models.Author{
+			20: {ID: 20, Name: "Anne Sexton", SortName: "Sexton, Anne"},
+		}},
+		fakeEditionLister{editions: map[int64][]models.Edition{
+			1: {{ID: 201, BookID: 1, Title: "The Complete Poems", Format: "AZW3", ISBN13: &isbn}},
+		}},
+	)
+	s.newClient = func(_ Config) pluginPusher { return pusher }
+
+	if err := s.Start(context.Background(), Config{LibraryPath: "/source-calibre"}, ModePlugin); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitUntil(t, 2*time.Second, func() bool { return !s.Running() })
+
+	if _, ok := books.set[1]; ok {
+		t.Fatalf("source calibre_id was overwritten for a different target library: %+v", books.set)
+	}
+	meta := pusher.meta("/source/Anne Sexton/The Complete Poems.azw3")
+	if _, ok := meta.Identifiers["calibre"]; ok {
+		t.Fatalf("source calibre identifier leaked into different target library payload: %+v", meta.Identifiers)
+	}
+	if meta.Identifiers["isbn"] != isbn {
+		t.Fatalf("isbn identifier = %q, want %s", meta.Identifiers["isbn"], isbn)
+	}
+	if meta.Identifiers["bindery"] != "1" {
+		t.Fatalf("bindery identifier = %q, want 1", meta.Identifiers["bindery"])
+	}
+}
+
+func TestSyncer_Start_PersistsCalibreIDForSameTargetLibrary(t *testing.T) {
+	books := &fakeBookLister{
+		books: []models.Book{{
+			ID:               1,
+			Title:            "Existing",
+			FilePath:         "/library/existing.epub",
+			ForeignID:        "calibre:book:2767",
+			MetadataProvider: "calibre",
+			CalibreID:        int64Ptr(2767),
+		}},
+	}
+	pusher := &fakePusher{
+		library: "/library",
+		calls: map[string]func() (int64, error){
+			"/library/existing.epub": func() (int64, error) { return 2767, ErrAlreadyInCalibre },
+		},
+	}
+
+	s := NewSyncer(books)
+	s.newClient = func(_ Config) pluginPusher { return pusher }
+
+	if err := s.Start(context.Background(), Config{LibraryPath: "/library"}, ModePlugin); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitUntil(t, 2*time.Second, func() bool { return !s.Running() })
+
+	if books.set[1] != 2767 {
+		t.Fatalf("same-library calibre_id should be persisted, got %+v", books.set)
+	}
+	meta := pusher.meta("/library/existing.epub")
+	if meta.Identifiers["calibre"] != "calibre:book:2767" {
+		t.Fatalf("same-library calibre identifier = %q", meta.Identifiers["calibre"])
+	}
+}
+
 func TestSyncer_Start_RejectsNonPluginMode(t *testing.T) {
 	s := NewSyncer(&fakeBookLister{})
 	if err := s.Start(context.Background(), Config{}, ModeCalibredb); !errors.Is(err, ErrSyncModeNotPlugin) {
@@ -285,3 +376,5 @@ func TestSyncer_Start_RejectsConcurrentRuns(t *testing.T) {
 	close(release)
 	waitUntil(t, 2*time.Second, func() bool { return !s.Running() })
 }
+
+func int64Ptr(v int64) *int64 { return &v }

--- a/internal/calibre/syncer_test.go
+++ b/internal/calibre/syncer_test.go
@@ -53,14 +53,28 @@ func (f *fakeBookLister) SetCalibreID(_ context.Context, id, calibreID int64) er
 // correctly inside one sync run.
 type fakePusher struct {
 	calls map[string]func() (int64, error)
+	mu    sync.Mutex
+	metas map[string]Metadata
 }
 
-func (f *fakePusher) Add(_ context.Context, path string, _ Metadata) (int64, error) {
+func (f *fakePusher) Add(_ context.Context, path string, meta Metadata) (int64, error) {
+	f.mu.Lock()
+	if f.metas == nil {
+		f.metas = map[string]Metadata{}
+	}
+	f.metas[path] = meta
+	f.mu.Unlock()
 	fn, ok := f.calls[path]
 	if !ok {
 		return 0, errors.New("unexpected path")
 	}
 	return fn()
+}
+
+func (f *fakePusher) meta(path string) Metadata {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.metas[path]
 }
 
 func TestSyncer_Start_MixedOutcomesCountedCorrectly(t *testing.T) {
@@ -108,6 +122,47 @@ func TestSyncer_Start_MixedOutcomesCountedCorrectly(t *testing.T) {
 	}
 	if books.set[2] != 202 {
 		t.Errorf("expected duplicate book to persist calibre_id=202 from 409 response, got %d", books.set[2])
+	}
+}
+
+func TestSyncer_Start_PassesPresentBookIdentifiers(t *testing.T) {
+	books := &fakeBookLister{
+		books: []models.Book{{
+			ID:               42,
+			Title:            "Dune",
+			FilePath:         "/l/dune.epub",
+			ForeignID:        "gb:zyTCAlFPjgYC",
+			MetadataProvider: "googlebooks",
+			ASIN:             "B000FC1BN8",
+		}},
+	}
+	pusher := &fakePusher{calls: map[string]func() (int64, error){
+		"/l/dune.epub": func() (int64, error) { return 101, nil },
+	}}
+
+	s := NewSyncer(books)
+	s.newClient = func(_ Config) pluginPusher { return pusher }
+
+	if err := s.Start(context.Background(), Config{}, ModePlugin); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitUntil(t, 2*time.Second, func() bool { return !s.Running() })
+
+	meta := pusher.meta("/l/dune.epub")
+	if meta.Identifiers["bindery"] != "42" {
+		t.Fatalf("bindery identifier = %q, want 42", meta.Identifiers["bindery"])
+	}
+	if meta.Identifiers["google"] != "zyTCAlFPjgYC" {
+		t.Fatalf("google identifier = %q, want zyTCAlFPjgYC", meta.Identifiers["google"])
+	}
+	if meta.Identifiers["asin"] != "B000FC1BN8" {
+		t.Fatalf("asin identifier = %q, want B000FC1BN8", meta.Identifiers["asin"])
+	}
+	if _, ok := meta.Identifiers["isbn"]; ok {
+		t.Fatalf("syncer should not invent edition isbn identifier: %+v", meta.Identifiers)
+	}
+	if _, ok := meta.Identifiers["openlibrary_edition"]; ok {
+		t.Fatalf("syncer should not invent edition identifier: %+v", meta.Identifiers)
 	}
 }
 

--- a/internal/calibre/syncer_test.go
+++ b/internal/calibre/syncer_test.go
@@ -55,7 +55,7 @@ type fakePusher struct {
 	calls map[string]func() (int64, error)
 }
 
-func (f *fakePusher) Add(_ context.Context, path string) (int64, error) {
+func (f *fakePusher) Add(_ context.Context, path string, _ Metadata) (int64, error) {
 	fn, ok := f.calls[path]
 	if !ok {
 		return 0, errors.New("unexpected path")

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -320,28 +320,14 @@ func (s *Scanner) calibreMetadata(ctx context.Context, book *models.Book, author
 		SeriesIndex:   seriesNum,
 		PublishedDate: calibre.FormatPublishedDate(book.ReleaseDate),
 		Rating:        book.AverageRating,
-		Identifiers: map[string]string{
-			"bindery": strconv.FormatInt(book.ID, 10),
-		},
+		Identifiers:   calibre.IdentifiersForBook(book, edition),
 	}
 	if author != nil {
 		meta.Authors = []string{author.Name}
 		meta.AuthorSort = author.SortName
 	}
-	if provider := strings.TrimSpace(book.MetadataProvider); provider != "" && strings.TrimSpace(book.ForeignID) != "" {
-		meta.Identifiers[provider] = book.ForeignID
-	}
-	if strings.TrimSpace(book.ASIN) != "" {
-		meta.Identifiers["asin"] = book.ASIN
-	}
 	imageURL := book.ImageURL
 	if edition != nil {
-		if isbn := firstString(edition.ISBN13, edition.ISBN10); isbn != "" {
-			meta.Identifiers["isbn"] = isbn
-		}
-		if edition.ASIN != nil && strings.TrimSpace(*edition.ASIN) != "" {
-			meta.Identifiers["asin"] = *edition.ASIN
-		}
 		if strings.TrimSpace(edition.Publisher) != "" {
 			meta.Publisher = edition.Publisher
 		}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -27,10 +27,10 @@ import (
 	"github.com/vavallee/bindery/internal/textutil"
 )
 
-// calibreAdder mirrors a just-imported file into Calibre by shelling out to
-// `calibredb add`. The scanner only invokes it when mode=calibredb.
+// calibreAdder mirrors a just-imported file into Calibre via calibredb or the
+// Bindery Bridge plugin. The scanner only invokes it when Calibre mode is on.
 type calibreAdder interface {
-	Add(ctx context.Context, filePath string) (int64, error)
+	Add(ctx context.Context, filePath string, meta calibre.Metadata) (int64, error)
 }
 
 // absNotifier is called after a successful audiobook import to trigger an
@@ -47,6 +47,7 @@ type Scanner struct {
 	clients              *db.DownloadClientRepo
 	books                *db.BookRepo
 	authors              *db.AuthorRepo
+	editions             *db.EditionRepo
 	history              *db.HistoryRepo
 	rootFolders          *db.RootFolderRepo
 	series               *db.SeriesRepo
@@ -54,6 +55,7 @@ type Scanner struct {
 	remapper             *Remapper
 	calibreAdder         calibreAdder
 	calibreMode          func() calibre.Mode
+	calibreCoverCacheDir string
 	settings             *db.SettingsRepo
 	libraryDir           string
 	audiobookDir         string
@@ -118,6 +120,13 @@ func (s *Scanner) WithSeriesRepo(sr *db.SeriesRepo) *Scanner {
 	return s
 }
 
+// WithEditions attaches the edition repo so Calibre handoffs can prefer the
+// selected or downloaded edition's ISBN, publisher, date, cover, and language.
+func (s *Scanner) WithEditions(er *db.EditionRepo) *Scanner {
+	s.editions = er
+	return s
+}
+
 // primarySeriesFor returns the primary series title and position for the given
 // book. Returns empty strings when the series repo is not configured or the
 // book has no primary series.
@@ -159,6 +168,13 @@ func (s *Scanner) effectiveLibraryDir(ctx context.Context, author *models.Author
 func (s *Scanner) WithCalibre(mode func() calibre.Mode, adder calibreAdder) *Scanner {
 	s.calibreMode = mode
 	s.calibreAdder = adder
+	return s
+}
+
+// WithCalibreCoverCache configures a writable cache directory for remote cover
+// images that need to be materialized before calibredb can consume them.
+func (s *Scanner) WithCalibreCoverCache(dir string) *Scanner {
+	s.calibreCoverCacheDir = dir
 	return s
 }
 
@@ -249,25 +265,25 @@ func (s *Scanner) pushToCWA(ctx context.Context, srcPath string) {
 // pushToCalibre mirrors a just-imported book into Calibre via calibredb add.
 // Failures are logged and swallowed — Calibre sync is best-effort and must
 // never roll back an otherwise-good Bindery import.
-func (s *Scanner) pushToCalibre(ctx context.Context, book *models.Book, _ *models.Author, path string) {
+func (s *Scanner) pushToCalibre(ctx context.Context, book *models.Book, author *models.Author, edition *models.Edition, seriesTitle, seriesNum, path string) {
 	if s.calibreMode == nil || book == nil {
 		return
 	}
 	mode := s.calibreMode()
 	if mode == calibre.ModeCalibredb || mode == calibre.ModePlugin {
-		s.pushCalibreAdd(ctx, book, path, mode)
+		s.pushCalibreAdd(ctx, book, s.calibreMetadata(ctx, book, author, edition, seriesTitle, seriesNum, mode), path, mode)
 	}
 }
 
 // pushCalibreAdd invokes the configured adder (calibredb CLI or plugin HTTP
 // client) and persists the resulting calibre_id. Failures are best-effort —
 // logged and swallowed so Bindery's own import stays good.
-func (s *Scanner) pushCalibreAdd(ctx context.Context, book *models.Book, path string, mode calibre.Mode) {
+func (s *Scanner) pushCalibreAdd(ctx context.Context, book *models.Book, meta calibre.Metadata, path string, mode calibre.Mode) {
 	if s.calibreAdder == nil {
 		slog.Debug("calibre: adder is nil, skipping", "mode", mode, "bookId", book.ID)
 		return
 	}
-	id, err := s.calibreAdder.Add(ctx, path)
+	id, err := s.calibreAdder.Add(ctx, path, meta)
 	if err != nil {
 		if errors.Is(err, calibre.ErrDisabled) {
 			return
@@ -289,6 +305,120 @@ func (s *Scanner) pushCalibreAdd(ctx context.Context, book *models.Book, path st
 		return
 	}
 	slog.Info("calibre: book mirrored", "mode", mode, "bookId", book.ID, "calibreId", id, "path", path)
+}
+
+func (s *Scanner) calibreMetadata(ctx context.Context, book *models.Book, author *models.Author, edition *models.Edition, seriesTitle, seriesNum string, mode calibre.Mode) calibre.Metadata {
+	if book == nil {
+		return calibre.Metadata{}
+	}
+	meta := calibre.Metadata{
+		Title:         book.Title,
+		Description:   book.Description,
+		Genres:        book.Genres,
+		Language:      calibre.NormalizeLanguageForCalibre(book.Language),
+		Series:        seriesTitle,
+		SeriesIndex:   seriesNum,
+		PublishedDate: calibre.FormatPublishedDate(book.ReleaseDate),
+		Rating:        book.AverageRating,
+		Identifiers: map[string]string{
+			"bindery": strconv.FormatInt(book.ID, 10),
+		},
+	}
+	if author != nil {
+		meta.Authors = []string{author.Name}
+		meta.AuthorSort = author.SortName
+	}
+	if provider := strings.TrimSpace(book.MetadataProvider); provider != "" && strings.TrimSpace(book.ForeignID) != "" {
+		meta.Identifiers[provider] = book.ForeignID
+	}
+	if strings.TrimSpace(book.ASIN) != "" {
+		meta.Identifiers["asin"] = book.ASIN
+	}
+	imageURL := book.ImageURL
+	if edition != nil {
+		if isbn := firstString(edition.ISBN13, edition.ISBN10); isbn != "" {
+			meta.Identifiers["isbn"] = isbn
+		}
+		if edition.ASIN != nil && strings.TrimSpace(*edition.ASIN) != "" {
+			meta.Identifiers["asin"] = *edition.ASIN
+		}
+		if strings.TrimSpace(edition.Publisher) != "" {
+			meta.Publisher = edition.Publisher
+		}
+		if edition.PublishDate != nil {
+			meta.PublishedDate = calibre.FormatPublishedDate(edition.PublishDate)
+		}
+		if strings.TrimSpace(edition.Language) != "" {
+			meta.Language = calibre.NormalizeLanguageForCalibre(edition.Language)
+		}
+		if strings.TrimSpace(edition.ImageURL) != "" {
+			imageURL = edition.ImageURL
+		}
+	}
+	if mode == calibre.ModeCalibredb {
+		if coverPath, err := calibre.MaterializeCover(ctx, s.calibreCoverCacheDir, imageURL); err != nil {
+			slog.Debug("calibre: cover materialization skipped", "bookId", book.ID, "error", err)
+		} else if coverPath != "" {
+			meta.CoverPath = coverPath
+		}
+	}
+	return meta
+}
+
+func firstString(values ...*string) string {
+	for _, v := range values {
+		if v != nil && strings.TrimSpace(*v) != "" {
+			return strings.TrimSpace(*v)
+		}
+	}
+	return ""
+}
+
+func (s *Scanner) resolveCalibreEdition(ctx context.Context, dl *models.Download, book *models.Book) *models.Edition {
+	if s.editions == nil || book == nil {
+		return nil
+	}
+	editions, err := s.editions.ListByBook(ctx, book.ID)
+	if err != nil {
+		slog.Debug("calibre: failed to list editions for metadata", "bookId", book.ID, "error", err)
+		return nil
+	}
+	if len(editions) == 0 {
+		return nil
+	}
+	if dl != nil && dl.EditionID != nil {
+		if ed := findEditionByID(editions, *dl.EditionID); ed != nil {
+			return ed
+		}
+	}
+	if book.SelectedEditionID != nil {
+		if ed := findEditionByID(editions, *book.SelectedEditionID); ed != nil {
+			return ed
+		}
+	}
+	for i := range editions {
+		if editionHasCalibreMetadata(editions[i]) {
+			return &editions[i]
+		}
+	}
+	return &editions[0]
+}
+
+func findEditionByID(editions []models.Edition, id int64) *models.Edition {
+	for i := range editions {
+		if editions[i].ID == id {
+			return &editions[i]
+		}
+	}
+	return nil
+}
+
+func editionHasCalibreMetadata(e models.Edition) bool {
+	return firstString(e.ISBN13, e.ISBN10, e.ASIN) != "" ||
+		strings.TrimSpace(e.Publisher) != "" ||
+		e.PublishDate != nil ||
+		strings.TrimSpace(e.Language) != "" ||
+		strings.TrimSpace(e.ImageURL) != ""
 }
 
 // importRetryLimit is the maximum number of times CheckDownloads will
@@ -739,6 +869,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// we fall through to the "unmatched import" log below.
 	var book *models.Book
 	var author *models.Author
+	var edition *models.Edition
 	if dl.BookID != nil {
 		b, err := s.books.GetByID(ctx, *dl.BookID)
 		if err != nil {
@@ -751,6 +882,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			} else {
 				author = a
 			}
+			edition = s.resolveCalibreEdition(ctx, dl, book)
 		}
 	}
 
@@ -833,7 +965,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			return dl.Title
 		}(), "path", destDir)
 
-		s.pushToCalibre(ctx, book, author, destDir)
+		s.pushToCalibre(ctx, book, author, edition, seriesTitle, seriesNum, destDir)
 		s.pushToABS(ctx)
 
 		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destDir, "format": models.MediaTypeAudiobook})
@@ -891,7 +1023,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
 		slog.Info("book imported", "title", book.Title, "path", destPath)
 
-		s.pushToCalibre(ctx, book, author, destPath)
+		s.pushToCalibre(ctx, book, author, edition, seriesTitle, seriesNum, destPath)
 		s.pushToCWA(ctx, destPath)
 
 		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destPath, "format": models.MediaTypeEbook})

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -2,13 +2,16 @@ package importer
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/vavallee/bindery/internal/calibre"
 	"github.com/vavallee/bindery/internal/db"
@@ -94,12 +97,14 @@ func TestTitleMatch(t *testing.T) {
 // wiring change surfaces here rather than in a live import.
 type fakeCalibreAdder struct {
 	calls  []string
+	metas  []calibre.Metadata
 	nextID int64
 	err    error
 }
 
-func (f *fakeCalibreAdder) Add(_ context.Context, path string) (int64, error) {
+func (f *fakeCalibreAdder) Add(_ context.Context, path string, meta calibre.Metadata) (int64, error) {
 	f.calls = append(f.calls, path)
+	f.metas = append(f.metas, meta)
 	return f.nextID, f.err
 }
 
@@ -145,7 +150,7 @@ func TestPushToCalibre_ModeOff(t *testing.T) {
 	fc := &fakeCalibreAdder{nextID: 99}
 	s.WithCalibre(modeFn(calibre.ModeOff), fc)
 
-	s.pushToCalibre(ctx, book, author, "/library/book.epub")
+	s.pushToCalibre(ctx, book, author, nil, "", "", "/library/book.epub")
 
 	if len(fc.calls) != 0 {
 		t.Errorf("Add must not be called when mode=off, got %v", fc.calls)
@@ -161,10 +166,13 @@ func TestPushToCalibre_ModeCalibredbHappyPath(t *testing.T) {
 	fc := &fakeCalibreAdder{nextID: 1234}
 	s.WithCalibre(modeFn(calibre.ModeCalibredb), fc)
 
-	s.pushToCalibre(ctx, book, author, "/library/book.epub")
+	s.pushToCalibre(ctx, book, author, nil, "", "", "/library/book.epub")
 
 	if len(fc.calls) != 1 || fc.calls[0] != "/library/book.epub" {
 		t.Errorf("Add calls = %v", fc.calls)
+	}
+	if len(fc.metas) != 1 || fc.metas[0].Title != "Title T" || len(fc.metas[0].Authors) != 1 || fc.metas[0].Authors[0] != "Author A" {
+		t.Errorf("metadata = %+v, want book title and author", fc.metas)
 	}
 	got, _ := bookRepo.GetByID(ctx, book.ID)
 	if got.CalibreID == nil || *got.CalibreID != 1234 {
@@ -179,7 +187,7 @@ func TestPushToCalibre_CalibredbFailDoesNotPoison(t *testing.T) {
 	fc := &fakeCalibreAdder{err: errors.New("exec: calibredb: not found")}
 	s.WithCalibre(modeFn(calibre.ModeCalibredb), fc)
 
-	s.pushToCalibre(ctx, book, author, "/library/book.epub")
+	s.pushToCalibre(ctx, book, author, nil, "", "", "/library/book.epub")
 
 	got, _ := bookRepo.GetByID(ctx, book.ID)
 	if got.CalibreID != nil {
@@ -194,7 +202,7 @@ func TestPushToCalibre_ErrDisabledSilent(t *testing.T) {
 	fc := &fakeCalibreAdder{err: calibre.ErrDisabled}
 	s.WithCalibre(modeFn(calibre.ModeCalibredb), fc)
 
-	s.pushToCalibre(ctx, book, author, "/library/book.epub")
+	s.pushToCalibre(ctx, book, author, nil, "", "", "/library/book.epub")
 
 	got, _ := bookRepo.GetByID(ctx, book.ID)
 	if got.CalibreID != nil {
@@ -217,7 +225,7 @@ func TestPushToCalibre_ModePluginHappyPath(t *testing.T) {
 	client := calibre.NewPluginClient(srv.URL, "test-key")
 	s.WithCalibre(modeFn(calibre.ModePlugin), client)
 
-	s.pushToCalibre(ctx, book, author, "/library/book.epub")
+	s.pushToCalibre(ctx, book, author, nil, "", "", "/library/book.epub")
 
 	got, _ := bookRepo.GetByID(ctx, book.ID)
 	if got.CalibreID == nil || *got.CalibreID != 5678 {
@@ -231,8 +239,136 @@ func TestPushToCalibre_ModePluginHappyPath(t *testing.T) {
 func TestPushToCalibre_NilResolver(t *testing.T) {
 	s, _, book, author, ctx := importScannerFixture(t)
 	// No WithCalibre call.
-	s.pushToCalibre(ctx, book, author, "/library/book.epub") // must not panic
+	s.pushToCalibre(ctx, book, author, nil, "", "", "/library/book.epub") // must not panic
 }
+
+func TestCalibreMetadata_PrefersEditionFieldsAndMapsSeries(t *testing.T) {
+	ctx := context.Background()
+	published := time.Date(2020, 3, 4, 0, 0, 0, 0, time.UTC)
+	release := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	asin := "B000FC1BN8"
+	book := &models.Book{
+		ID:               42,
+		ForeignID:        "OL123W",
+		Title:            "Dune",
+		Description:      "Desert planet.",
+		ReleaseDate:      &release,
+		Genres:           []string{"Science Fiction", "Classics"},
+		AverageRating:    4.6,
+		Language:         "eng",
+		ASIN:             "BOOKASIN",
+		MetadataProvider: "openlibrary",
+	}
+	author := &models.Author{Name: "Frank Herbert", SortName: "Herbert, Frank"}
+	edition := &models.Edition{
+		ISBN13:      strPtr("9780441172719"),
+		ASIN:        &asin,
+		Publisher:   "Ace",
+		PublishDate: &published,
+		Language:    "ger",
+		ImageURL:    "",
+	}
+
+	s := NewScanner(nil, nil, nil, nil, nil, t.TempDir(), "", "", "", "")
+	meta := s.calibreMetadata(ctx, book, author, edition, "Dune Chronicles", "1", calibre.ModeCalibredb)
+
+	if meta.Title != "Dune" || len(meta.Authors) != 1 || meta.Authors[0] != "Frank Herbert" {
+		t.Fatalf("basic metadata = %+v", meta)
+	}
+	if meta.AuthorSort != "Herbert, Frank" || meta.Description != "Desert planet." {
+		t.Fatalf("author/description metadata = %+v", meta)
+	}
+	if meta.Language != "de" {
+		t.Fatalf("Language = %q, want de from edition language", meta.Language)
+	}
+	if meta.PublishedDate != "2020-03-04" {
+		t.Fatalf("PublishedDate = %q, want edition date", meta.PublishedDate)
+	}
+	if meta.Publisher != "Ace" || meta.Series != "Dune Chronicles" || meta.SeriesIndex != "1" {
+		t.Fatalf("publisher/series metadata = %+v", meta)
+	}
+	if meta.Identifiers["isbn"] != "9780441172719" {
+		t.Fatalf("isbn identifier = %q", meta.Identifiers["isbn"])
+	}
+	if meta.Identifiers["asin"] != "B000FC1BN8" {
+		t.Fatalf("asin identifier = %q, want edition ASIN", meta.Identifiers["asin"])
+	}
+	if meta.Identifiers["bindery"] != "42" || meta.Identifiers["openlibrary"] != "OL123W" {
+		t.Fatalf("provider identifiers = %+v", meta.Identifiers)
+	}
+}
+
+func TestCalibreMetadata_CoverPathOnlyForCalibredb(t *testing.T) {
+	ctx := context.Background()
+	cacheDir := t.TempDir()
+	imageURL := "https://93.184.216.34/cover.jpg"
+	sum := sha256.Sum256([]byte(imageURL))
+	coverPath := filepath.Join(cacheDir, fmt.Sprintf("%x.jpg", sum))
+	if err := os.WriteFile(coverPath, []byte("cached cover"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	book := &models.Book{
+		ID:       42,
+		Title:    "Dune",
+		ImageURL: imageURL,
+		Genres:   []string{},
+	}
+	s := NewScanner(nil, nil, nil, nil, nil, t.TempDir(), "", "", "", "").WithCalibreCoverCache(cacheDir)
+
+	calibredbMeta := s.calibreMetadata(ctx, book, nil, nil, "", "", calibre.ModeCalibredb)
+	if calibredbMeta.CoverPath != coverPath {
+		t.Fatalf("calibredb CoverPath = %q, want %q", calibredbMeta.CoverPath, coverPath)
+	}
+
+	pluginMeta := s.calibreMetadata(ctx, book, nil, nil, "", "", calibre.ModePlugin)
+	if pluginMeta.CoverPath != "" {
+		t.Fatalf("plugin CoverPath = %q, want empty", pluginMeta.CoverPath)
+	}
+}
+
+func TestResolveCalibreEdition_PrefersDownloadThenSelected(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	editionRepo := db.NewEditionRepo(database)
+	author := &models.Author{ForeignID: "A", Name: "Author", SortName: "Author", Monitored: true}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{ForeignID: "B", AuthorID: author.ID, Title: "Book", SortTitle: "Book", Monitored: true, Status: models.BookStatusWanted, Genres: []string{}}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	selected := &models.Edition{ForeignID: "E1", BookID: book.ID, Title: "Selected", ISBN13: strPtr("111"), IsEbook: true}
+	downloaded := &models.Edition{ForeignID: "E2", BookID: book.ID, Title: "Downloaded", ISBN13: strPtr("222"), IsEbook: true}
+	if err := editionRepo.Upsert(ctx, selected); err != nil {
+		t.Fatal(err)
+	}
+	if err := editionRepo.Upsert(ctx, downloaded); err != nil {
+		t.Fatal(err)
+	}
+	book.SelectedEditionID = &selected.ID
+
+	s := NewScanner(nil, nil, bookRepo, authorRepo, nil, t.TempDir(), "", "", "", "").WithEditions(editionRepo)
+	dl := &models.Download{EditionID: &downloaded.ID}
+	got := s.resolveCalibreEdition(ctx, dl, book)
+	if got == nil || got.ID != downloaded.ID {
+		t.Fatalf("download edition = %+v, want %d", got, downloaded.ID)
+	}
+	got = s.resolveCalibreEdition(ctx, &models.Download{}, book)
+	if got == nil || got.ID != selected.ID {
+		t.Fatalf("selected edition = %+v, want %d", got, selected.ID)
+	}
+}
+
+func strPtr(s string) *string { return &s }
 
 // TestImportInternal_ThreeFileBundle_TracksAllInBookFiles verifies the #343
 // fix: importing a multi-format download (epub + mobi + pdf) stores a

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -261,6 +261,7 @@ func TestCalibreMetadata_PrefersEditionFieldsAndMapsSeries(t *testing.T) {
 	}
 	author := &models.Author{Name: "Frank Herbert", SortName: "Herbert, Frank"}
 	edition := &models.Edition{
+		ForeignID:   "OL999M",
 		ISBN13:      strPtr("9780441172719"),
 		ASIN:        &asin,
 		Publisher:   "Ace",
@@ -295,6 +296,43 @@ func TestCalibreMetadata_PrefersEditionFieldsAndMapsSeries(t *testing.T) {
 	}
 	if meta.Identifiers["bindery"] != "42" || meta.Identifiers["openlibrary"] != "OL123W" {
 		t.Fatalf("provider identifiers = %+v", meta.Identifiers)
+	}
+	if meta.Identifiers["openlibrary_edition"] != "OL999M" {
+		t.Fatalf("openlibrary edition identifier = %q, want OL999M", meta.Identifiers["openlibrary_edition"])
+	}
+}
+
+func TestCalibreMetadata_NormalizesPresentProviderIdentifiers(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name      string
+		provider  string
+		foreignID string
+		wantType  string
+		wantValue string
+	}{
+		{"openlibrary", "openlibrary", "/works/OL123W", "openlibrary", "OL123W"},
+		{"hardcover", "hardcover", "hc:dune", "hardcover", "dune"},
+		{"googlebooks", "googlebooks", "gb:zyTCAlFPjgYC", "google", "zyTCAlFPjgYC"},
+		{"dnb", "dnb", "dnb:123456789", "dnb", "123456789"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			book := &models.Book{
+				ID:               42,
+				ForeignID:        tt.foreignID,
+				Title:            "Dune",
+				MetadataProvider: tt.provider,
+			}
+			s := NewScanner(nil, nil, nil, nil, nil, t.TempDir(), "", "", "", "")
+			meta := s.calibreMetadata(ctx, book, nil, nil, "", "", calibre.ModePlugin)
+			if meta.Identifiers[tt.wantType] != tt.wantValue {
+				t.Fatalf("identifier %q = %q, want %q in %+v", tt.wantType, meta.Identifiers[tt.wantType], tt.wantValue, meta.Identifiers)
+			}
+			if meta.Identifiers["bindery"] != "42" {
+				t.Fatalf("bindery identifier = %q, want 42", meta.Identifiers["bindery"])
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR teaches Bindery's Calibre handoff paths to export the metadata Bindery already knows, so Calibre/plugin imports do not arrive as bare files that need manual cleanup. It also keeps plugin sync safe across multiple Calibre libraries by not reusing source-library Calibre IDs when the configured target library differs.

- Add a Calibre metadata contract, identifier normalization, language/date cleanup, and SSRF-checked cover materialization for `calibredb` handoffs.
- Send metadata to Bindery Bridge plugins that advertise support, with legacy fallback for older plugins.
- Populate metadata from book, author, edition, and series records during importer pushes and bulk Calibre syncs.
- Add focused Calibre/importer tests for metadata payloads, plugin capability fallback, edition identifiers, series indexes, and Calibre ID persistence.

## Sister PR

This PR has a sister PR in the Bindery plugin repository for the Bindery Bridge metadata-capable payload support.

- https://github.com/vavallee/bindery-plugins/pull/4

## Checklist

- [x] Tests added or updated
- [x] N/A - `docs/DEPLOYMENT.md` not updated; no env vars, config, or upgrade path changed
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] N/A - wiki pages not updated here; plugin-side follow-up belongs with the sister PR

## Test plan

- [x] `gofmt -l .`
- [x] `go test ./internal/calibre ./internal/importer`
- [x] `go test ./cmd/... ./internal/...`
- [x] `go vet ./...`
- [x] `golangci-lint run --timeout=5m`
- [x] `govulncheck ./...`
- [x] `git diff --check`
- [x] N/A - `cd web && npm run build` not run; no frontend changes
