### PR TITLE
feat(abs): support selecting multiple libraries

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -264,15 +264,15 @@ func main() {
 
 	// Wire ABS post-import scan notification (Bug #10). The notifier reads ABS
 	// config from settings at call time so that config changes (URL, API key,
-	// library ID) take effect without restarting Bindery.
+	// library IDs) take effect without restarting Bindery.
 	importScanner.WithABSNotifier(
 		abs.NewScanNotifier(settingsRepo),
-		func() string {
+		func() []string {
 			cfg := api.LoadABSConfig(context.Background(), settingsRepo)
 			if !cfg.Enabled {
-				return ""
+				return nil
 			}
-			return cfg.LibraryID
+			return cfg.LibraryIDs
 		},
 	)
 
@@ -306,13 +306,14 @@ func main() {
 		})
 	storedABS := api.LoadABSConfig(ctxBoot, settingsRepo)
 	resumeCfg := abs.ImportConfig{
-		SourceID:  abs.DefaultSourceID,
-		BaseURL:   storedABS.BaseURL,
-		APIKey:    storedABS.APIKey,
-		LibraryID: storedABS.LibraryID,
-		PathRemap: storedABS.PathRemap,
-		Label:     storedABS.Label,
-		Enabled:   storedABS.Enabled,
+		SourceID:   abs.DefaultSourceID,
+		BaseURL:    storedABS.BaseURL,
+		APIKey:     storedABS.APIKey,
+		LibraryID:  storedABS.LibraryID,
+		LibraryIDs: storedABS.LibraryIDs,
+		PathRemap:  storedABS.PathRemap,
+		Label:      storedABS.Label,
+		Enabled:    storedABS.Enabled,
 	}
 	if resumed, err := absImporter.ResumeInterrupted(ctxBoot, resumeCfg); err != nil {
 		slog.Warn("abs interrupted import resume skipped", "error", err)

--- a/docs/ABS-Import-Wiki.md
+++ b/docs/ABS-Import-Wiki.md
@@ -6,7 +6,7 @@ This page is the user-facing companion to [`docs/abs_import.md`](./abs_import.md
 
 ## What It Does
 
-The current ABS importer supports one configured ABS source and one selected target book library at a time. From that source, Bindery can:
+The current ABS importer supports one configured ABS source and one or more selected target book libraries at a time. From that source, Bindery can:
 
 - test API-key access and discover the ABS book libraries visible to that key
 - import the ABS catalog metadata it can read for each visible item
@@ -49,8 +49,8 @@ A good pre-import cleanup pass in ABS is worth it. If your library already has s
 
 ## Before You Start
 
-- Use an ABS API key for a user that can see the target book library. ABS admin access is not required. The key only needs permission to authenticate and read the library you plan to import.
-- Pick the one ABS book library you want to import from.
+- Use an ABS API key for a user that can see the target book libraries. ABS admin access is not required. The key only needs permission to authenticate and read the libraries you plan to import.
+- Pick the ABS book libraries you want to import from.
 - If ABS and Bindery see the same storage under different mount prefixes, configure path remaps such as `/audiobookshelf:/books/audiobookshelf`.
 - Path remaps are prefix rewrites. The left side is the path prefix ABS reports, and the right side is the path prefix Bindery can actually read. Bindery applies the rewrite before checking whether the resolved file lives under a Bindery-visible library root.
 - If you want the best initial match rate, it helps to make sure your ABS library metadata is already in good shape before importing.
@@ -58,9 +58,9 @@ A good pre-import cleanup pass in ABS is worth it. If your library already has s
 ## Import Flow
 
 1. Open `Settings -> ABS`.
-2. Save the ABS base URL, API key, label, target book library, and any optional path remaps. Saving stores normalized settings without contacting ABS.
+2. Save the ABS base URL, API key, label, target book libraries, and any optional path remaps. Saving stores normalized settings without contacting ABS.
 3. Test the connection and list available book libraries.
-4. Pick a book library from the list, or keep a known library ID if you entered one manually.
+4. Pick one or more book libraries from the list, or keep known saved library IDs until listing succeeds.
 5. Start a dry run if you want a safe first pass.
 6. Start the import.
 7. Review any queued items or metadata conflicts.
@@ -77,7 +77,8 @@ Bindery deliberately fails safe when matching is unclear.
 ## Known Behavior
 
 - Only one ABS source is supported in the current MVP.
-- Only one selected ABS book library is imported per run.
+- Selected ABS book libraries are imported sequentially. Each selected library creates its own import run, rollback scope, and summary.
+- If one selected library fails, later libraries are not started and earlier completed library runs are preserved.
 - Saving settings does not test the ABS server. Use **Test connection** or **List libraries** when you want live validation.
 - The library selector shows book libraries only, and imports reject non-book library or item responses before scanning.
 - Imports are asynchronous.
@@ -86,8 +87,8 @@ Bindery deliberately fails safe when matching is unclear.
 
 ## Troubleshooting
 
-- Connection test or library listing fails: verify the saved ABS base URL, API key, and that the key can see the target book library.
-- Import rejects the selected library: use **List libraries** and choose a book library. Podcast or other non-book ABS libraries are not imported.
+- Connection test or library listing fails: verify the saved ABS base URL, API key, and that the key can see the target book libraries.
+- Import rejects a selected library: use **List libraries** and choose book libraries. Podcast or other non-book ABS libraries are not imported.
 - Files are not attaching after import: check path remaps and make sure the ABS-reported paths resolve under a Bindery-visible library root.
 - Too many review items: improve ABS metadata quality first, especially ASIN coverage and author/title consistency, then rerun.
 - Unexpected metadata disagreements: resolve them from the conflicts panel instead of rerunning until the same field flips back and forth.

--- a/docs/abs_import.md
+++ b/docs/abs_import.md
@@ -10,7 +10,7 @@ The ABS importer lets an admin:
 
 - configure one ABS source
 - test API-key access and discover visible book libraries
-- select a single target book library
+- select one or more target book libraries from that source
 - import ABS metadata into Bindery
 - review import runs, dry-runs, rollback previews, and review/conflict items
 
@@ -71,11 +71,14 @@ Bootstrap:
 
 1. An admin saves ABS settings under the `abs.*` keys. `PUT /api/v1/abs/config` normalizes and stores local settings without contacting ABS.
 2. The UI can explicitly probe the ABS instance to validate auth and list accessible book libraries. Probes require a saved base URL and use either a request API-key override or the stored write-only key.
-3. `POST /api/v1/abs/import` starts an async import using the stored config plus any request overrides.
-4. The importer validates that the selected library response is for a book library, rejects non-book items, and fetches detail payloads when list data is incomplete.
-5. Each normalized ABS item is mapped into Bindery authors, books, series, editions, provenance, and optional review/conflict records.
-6. Progress is exposed through `GET /api/v1/abs/import/status`.
-7. Completed runs are persisted and surfaced through recent-runs and rollback endpoints.
+3. `POST /api/v1/abs/import` starts an async import using the stored config.
+4. The importer processes selected libraries sequentially in saved order. Each library receives its own `abs_import_runs` row, source snapshot, checkpoint updates, summary, rollback scope, and provenance keyed by that library ID.
+5. The importer validates that each selected library response is for a book library, rejects non-book items, and fetches detail payloads when list data is incomplete.
+6. If a library import fails, the active run is marked failed and later libraries are not started. Completed earlier library runs remain intact.
+7. Interrupted-run resume restarts at the checkpointed library and then continues the remaining saved libraries in order.
+8. Each normalized ABS item is mapped into Bindery authors, books, series, editions, provenance, and optional review/conflict records.
+9. Progress is exposed through `GET /api/v1/abs/import/status`.
+10. Completed runs are persisted and surfaced through recent-runs and rollback endpoints.
 
 ## Mapping Rules
 
@@ -159,16 +162,19 @@ When a path is visible and valid, Bindery records it through the normal book-fil
 
 ## Storage Model
 
-Config is stored in existing settings rows for the single-source MVP:
+Config is stored in existing settings rows for the single ABS source:
 
 - `abs.base_url`
 - `abs.api_key`
 - `abs.library_id`
+- `abs.library_ids`
 - `abs.enabled`
 - `abs.label`
 - `abs.path_remap`
 
-Saving config validates local syntax only. It does not authorize against ABS or verify the selected library ID; `POST /api/v1/abs/test`, `POST /api/v1/abs/libraries`, and import enumeration handle live ABS validation.
+`abs.library_ids` stores the ordered selected library IDs as JSON. `abs.library_id` remains the compatibility field and mirrors the first selected library. When `abs.library_ids` is empty or missing, Bindery falls back to `abs.library_id`.
+
+Saving config validates local syntax only. It does not authorize against ABS or verify selected library IDs; `POST /api/v1/abs/test`, `POST /api/v1/abs/libraries`, and import enumeration handle live ABS validation.
 
 Run and provenance persistence adds these tables:
 

--- a/internal/abs/import_rollback.go
+++ b/internal/abs/import_rollback.go
@@ -232,6 +232,31 @@ func (i *Importer) rollback(ctx context.Context, runID int64, preview bool) (*Ro
 				result.Actions = append(result.Actions, action)
 				continue
 			}
+			retainLocal, err := i.hasProvenanceOutsideRun(ctx, entity.EntityType, entity.LocalID, runID)
+			if err != nil {
+				action.Action = "skip"
+				action.Reason = err.Error()
+				result.Stats.Failed++
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			if retainLocal {
+				action.Action = "unlink_provenance"
+				action.Reason = "local book retained because another ABS import link references it"
+				result.Stats.ActionsPlanned++
+				if !preview {
+					if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.LibraryID, entity.EntityType, entity.ExternalID); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					result.Stats.ProvenanceUnlinked++
+				}
+				result.Actions = append(result.Actions, action)
+				continue
+			}
 			action.Action = "delete_book"
 			result.Stats.ActionsPlanned++
 			if !preview {
@@ -360,9 +385,44 @@ func (i *Importer) rollback(ctx context.Context, runID int64, preview bool) (*Ro
 				continue
 			}
 			if remaining > 0 {
+				action.Action = "unlink_provenance"
+				action.Reason = "local author retained because it still has linked books"
+				result.Stats.ActionsPlanned++
+				if !preview {
+					if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.LibraryID, entity.EntityType, entity.ExternalID); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					result.Stats.ProvenanceUnlinked++
+				}
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			retainLocal, err := i.hasProvenanceOutsideRun(ctx, entity.EntityType, entity.LocalID, runID)
+			if err != nil {
 				action.Action = "skip"
-				action.Reason = "author still has linked books"
-				result.Stats.Skipped++
+				action.Reason = err.Error()
+				result.Stats.Failed++
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			if retainLocal {
+				action.Action = "unlink_provenance"
+				action.Reason = "local author retained because another ABS import link references it"
+				result.Stats.ActionsPlanned++
+				if !preview {
+					if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.LibraryID, entity.EntityType, entity.ExternalID); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					result.Stats.ProvenanceUnlinked++
+				}
 				result.Actions = append(result.Actions, action)
 				continue
 			}
@@ -479,6 +539,49 @@ func (i *Importer) rollback(ctx context.Context, runID int64, preview bool) (*Ro
 			if bookID > 0 {
 				action.Action = "unlink_series"
 				result.Stats.ActionsPlanned++
+				retainMembership, err := i.hasMatchingProvenanceOutsideRun(ctx, entity, runID)
+				if err != nil {
+					action.Action = "skip"
+					action.Reason = err.Error()
+					result.Stats.Failed++
+					result.Actions = append(result.Actions, action)
+					continue
+				}
+				if !retainMembership {
+					retainBook, err := i.hasProvenanceOutsideRun(ctx, entityTypeBook, int64(bookID), runID)
+					if err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					retainSeries, err := i.hasProvenanceOutsideRun(ctx, entity.EntityType, entity.LocalID, runID)
+					if err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					retainMembership = retainBook && retainSeries
+				}
+				if retainMembership {
+					action.Action = "unlink_provenance"
+					action.Reason = "series membership retained because another ABS import link references it"
+					if !preview {
+						if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.LibraryID, entity.EntityType, entity.ExternalID); err != nil {
+							action.Action = "skip"
+							action.Reason = err.Error()
+							result.Stats.Failed++
+							result.Actions = append(result.Actions, action)
+							continue
+						}
+						result.Stats.ProvenanceUnlinked++
+					}
+					result.Actions = append(result.Actions, action)
+					continue
+				}
 				_, createdByRun := runCreatedSeries[entity.LocalID]
 				_, hasIdentityEntity := seriesIdentityEntities[entity.LocalID]
 				deleteSeries := false
@@ -491,7 +594,15 @@ func (i *Importer) rollback(ctx context.Context, runID int64, preview bool) (*Ro
 						result.Actions = append(result.Actions, action)
 						continue
 					}
-					if remaining <= 0 {
+					retainSeries, err := i.hasProvenanceOutsideRun(ctx, entity.EntityType, entity.LocalID, runID)
+					if err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					if remaining <= 0 && !retainSeries {
 						action.Action = "delete_series"
 						deleteSeries = true
 					}
@@ -535,6 +646,30 @@ func (i *Importer) rollback(ctx context.Context, runID int64, preview bool) (*Ro
 			} else {
 				action.Action = "unlink_provenance"
 				if entity.Outcome == itemOutcomeCreated {
+					retainSeries, err := i.hasProvenanceOutsideRun(ctx, entity.EntityType, entity.LocalID, runID)
+					if err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					if retainSeries {
+						action.Reason = "local series retained because another ABS import link references it"
+						result.Stats.ActionsPlanned++
+						if !preview {
+							if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.LibraryID, entity.EntityType, entity.ExternalID); err != nil {
+								action.Action = "skip"
+								action.Reason = err.Error()
+								result.Stats.Failed++
+								result.Actions = append(result.Actions, action)
+								continue
+							}
+							result.Stats.ProvenanceUnlinked++
+						}
+						result.Actions = append(result.Actions, action)
+						continue
+					}
 					remaining, err := i.remainingSeriesBooksAfterRunRollback(ctx, entity.LocalID, runSeriesMemberships[entity.LocalID])
 					if err != nil {
 						action.Action = "skip"
@@ -826,6 +961,41 @@ func metadataBookID(metadata map[string]any) int64 {
 	default:
 		return 0
 	}
+}
+
+func (i *Importer) hasProvenanceOutsideRun(ctx context.Context, entityType string, localID, runID int64) (bool, error) {
+	if i.provenance == nil || localID == 0 {
+		return false, nil
+	}
+	links, err := i.provenance.ListByLocal(ctx, entityType, localID)
+	if err != nil {
+		return false, err
+	}
+	for _, link := range links {
+		if link.ImportRunID == nil || *link.ImportRunID != runID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (i *Importer) hasMatchingProvenanceOutsideRun(ctx context.Context, entity models.ABSImportRunEntity, runID int64) (bool, error) {
+	if i.provenance == nil || entity.LocalID == 0 {
+		return false, nil
+	}
+	links, err := i.provenance.ListByLocal(ctx, entity.EntityType, entity.LocalID)
+	if err != nil {
+		return false, err
+	}
+	for _, link := range links {
+		if link.ExternalID != entity.ExternalID {
+			continue
+		}
+		if link.ImportRunID == nil || *link.ImportRunID != runID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (i *Importer) remainingSeriesBooksAfterRunRollback(ctx context.Context, seriesID int64, runOwnedBookIDs map[int64]struct{}) (int, error) {

--- a/internal/abs/import_types.go
+++ b/internal/abs/import_types.go
@@ -47,14 +47,15 @@ type enumerateFunc func(ctx context.Context, libraryID string, fn func(context.C
 type enhancedHardcoverSeriesEnabledFunc func(context.Context) bool
 
 type ImportConfig struct {
-	SourceID  string
-	BaseURL   string
-	APIKey    string
-	LibraryID string
-	PathRemap string
-	Label     string
-	Enabled   bool
-	DryRun    bool
+	SourceID   string
+	BaseURL    string
+	APIKey     string
+	LibraryID  string
+	LibraryIDs []string
+	PathRemap  string
+	Label      string
+	Enabled    bool
+	DryRun     bool
 }
 
 func (c ImportConfig) normalized() ImportConfig {
@@ -65,6 +66,10 @@ func (c ImportConfig) normalized() ImportConfig {
 	c.BaseURL = strings.TrimSpace(c.BaseURL)
 	c.APIKey = strings.TrimSpace(c.APIKey)
 	c.LibraryID = strings.TrimSpace(c.LibraryID)
+	c.LibraryIDs = normalizeLibraryIDs(c.LibraryID, c.LibraryIDs)
+	if c.LibraryID == "" && len(c.LibraryIDs) > 0 {
+		c.LibraryID = c.LibraryIDs[0]
+	}
 	c.PathRemap = strings.TrimSpace(c.PathRemap)
 	c.Label = strings.TrimSpace(c.Label)
 	if c.Label == "" {
@@ -87,8 +92,8 @@ func (c ImportConfig) Validate() error {
 	if _, err := NormalizeAPIKey(c.APIKey); err != nil {
 		return err
 	}
-	if c.LibraryID == "" {
-		return errors.New("abs library_id is empty")
+	if len(c.LibraryIDs) == 0 {
+		return errors.New("abs library_ids is empty")
 	}
 	return nil
 }
@@ -123,13 +128,14 @@ type ImportStats struct {
 }
 
 type ImportSourceSnapshot struct {
-	SourceID  string `json:"sourceId"`
-	Label     string `json:"label"`
-	BaseURL   string `json:"baseUrl"`
-	LibraryID string `json:"libraryId"`
-	PathRemap string `json:"pathRemap,omitempty"`
-	Enabled   bool   `json:"enabled"`
-	DryRun    bool   `json:"dryRun"`
+	SourceID   string   `json:"sourceId"`
+	Label      string   `json:"label"`
+	BaseURL    string   `json:"baseUrl"`
+	LibraryID  string   `json:"libraryId"`
+	LibraryIDs []string `json:"libraryIds,omitempty"`
+	PathRemap  string   `json:"pathRemap,omitempty"`
+	Enabled    bool     `json:"enabled"`
+	DryRun     bool     `json:"dryRun"`
 }
 
 type ImportSummary struct {

--- a/internal/abs/import_utils.go
+++ b/internal/abs/import_utils.go
@@ -134,6 +134,29 @@ func dedupeStrings(values []string) []string {
 	return out
 }
 
+func normalizeLibraryIDs(primary string, values []string) []string {
+	primary = strings.TrimSpace(primary)
+	out := make([]string, 0, len(values)+1)
+	seen := make(map[string]struct{}, len(values)+1)
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	if primary != "" {
+		if _, ok := seen[primary]; !ok {
+			out = append([]string{primary}, out...)
+		}
+	}
+	return out
+}
+
 func normalizeLanguage(language string) string {
 	return strings.ToLower(strings.TrimSpace(language))
 }

--- a/internal/abs/import_utils_test.go
+++ b/internal/abs/import_utils_test.go
@@ -1,0 +1,15 @@
+package abs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeLibraryIDsPrependsLegacyPrimary(t *testing.T) {
+	t.Parallel()
+
+	got := normalizeLibraryIDs(" lib-legacy ", []string{" lib-books ", "lib-audio", "lib-books", ""})
+	if got, want := strings.Join(got, ","), "lib-legacy,lib-books,lib-audio"; got != want {
+		t.Fatalf("library ids = %q, want %q", got, want)
+	}
+}

--- a/internal/abs/importer.go
+++ b/internal/abs/importer.go
@@ -264,7 +264,6 @@ func (i *Importer) Run(ctx context.Context, cfg ImportConfig) (*ImportStats, err
 func (i *Importer) run(ctx context.Context, cfg ImportConfig) *ImportStats {
 	stats := &ImportStats{}
 	cfg = cfg.normalized()
-	summary := ImportSummary{DryRun: cfg.DryRun, Stats: *stats}
 	defer func() {
 		now := time.Now().UTC()
 		i.mu.Lock()
@@ -297,6 +296,35 @@ func (i *Importer) run(ctx context.Context, cfg ImportConfig) *ImportStats {
 		return stats
 	}
 
+	libraryIDs := cfg.LibraryIDs
+	startLibraryID := resumeLibraryIDFromCheckpoint(ctx, i.settings, libraryIDs, cfg.LibraryID)
+	startIndex := libraryStartIndex(libraryIDs, startLibraryID)
+	for idx := startIndex; idx < len(libraryIDs); idx++ {
+		libCfg := cfg
+		libCfg.LibraryID = libraryIDs[idx]
+		libCfg.LibraryIDs = libraryIDs
+		if _, err := i.runLibrary(ctx, libCfg, authorMatcher, stats); err != nil {
+			i.fail(err)
+			return stats
+		}
+	}
+
+	if i.settings != nil && !cfg.DryRun {
+		if err := i.settings.Set(ctx, SettingABSLastImportAt, time.Now().UTC().Format(time.RFC3339)); err != nil {
+			slog.Warn("abs import: persist last_import_at failed", "error", err)
+		}
+	}
+	i.setProgress(func(p *ImportProgress) {
+		p.Checkpoint = nil
+		p.ResumedFromCheckpoint = false
+		p.Message = importDoneMessage(cfg.DryRun)
+	})
+	return stats
+}
+
+func (i *Importer) runLibrary(ctx context.Context, cfg ImportConfig, authorMatcher *authorMatcher, totalStats *ImportStats) (*ImportStats, error) {
+	before := snapshotImportStats(totalStats)
+	summary := ImportSummary{DryRun: cfg.DryRun}
 	if checkpoint, err := loadImportCheckpoint(ctx, i.settings); err == nil && checkpoint != nil && checkpoint.LibraryID == cfg.LibraryID {
 		i.setProgress(func(p *ImportProgress) {
 			p.ResumedFromCheckpoint = true
@@ -313,13 +341,11 @@ func (i *Importer) run(ctx context.Context, cfg ImportConfig) *ImportStats {
 
 	sourceConfigJSON, err := encodeJSON(sourceSnapshot(cfg))
 	if err != nil {
-		i.fail(fmt.Errorf("encode abs import source config: %w", err))
-		return stats
+		return diffImportStats(before, totalStats), fmt.Errorf("encode abs import source config: %w", err)
 	}
 	checkpointJSON, err := encodeJSON(summary.Checkpoint)
 	if err != nil {
-		i.fail(fmt.Errorf("encode abs import checkpoint: %w", err))
-		return stats
+		return diffImportStats(before, totalStats), fmt.Errorf("encode abs import checkpoint: %w", err)
 	}
 	run := &models.ABSImportRun{
 		SourceID:         cfg.SourceID,
@@ -334,8 +360,7 @@ func (i *Importer) run(ctx context.Context, cfg ImportConfig) *ImportStats {
 	}
 	if i.runs != nil {
 		if err := i.runs.Create(ctx, run); err != nil {
-			i.fail(err)
-			return stats
+			return diffImportStats(before, totalStats), err
 		}
 		i.setProgress(func(p *ImportProgress) { p.RunID = run.ID })
 	}
@@ -344,10 +369,10 @@ func (i *Importer) run(ctx context.Context, cfg ImportConfig) *ImportStats {
 	if err != nil {
 		if run.ID != 0 && i.runs != nil {
 			summary.Error = err.Error()
+			summary.Stats = *diffImportStats(before, totalStats)
 			_ = i.runs.Finish(ctx, run.ID, runStatusFailed, summary)
 		}
-		i.fail(err)
-		return stats
+		return diffImportStats(before, totalStats), err
 	}
 
 	enumStats, err := enumFn(ctx, cfg.LibraryID, func(ctx context.Context, item NormalizedLibraryItem) error {
@@ -357,7 +382,7 @@ func (i *Importer) run(ctx context.Context, cfg ImportConfig) *ImportStats {
 		i.setProgress(func(p *ImportProgress) {
 			p.Message = importItemMessage(cfg.DryRun, firstNonEmpty(item.Title, item.ItemID))
 		})
-		result := i.importOne(ctx, cfg, run.ID, item, stats, allowImmediateImport(item), authorMatcher)
+		result := i.importOne(ctx, cfg, run.ID, item, totalStats, allowImmediateImport(item), authorMatcher)
 		i.setProgress(func(p *ImportProgress) {
 			p.Processed++
 			p.Results = appendImportProgressResult(p.Results, result)
@@ -369,27 +394,22 @@ func (i *Importer) run(ctx context.Context, cfg ImportConfig) *ImportStats {
 			if checkpoint, checkpointErr := loadImportCheckpoint(ctx, i.settings); checkpointErr == nil {
 				summary.Checkpoint = checkpoint
 			}
-			summary.Stats = *stats
+			summary.Stats = *diffImportStats(before, totalStats)
 			summary.Error = err.Error()
 			_ = i.runs.Finish(ctx, run.ID, runStatusFailed, summary)
 		}
-		i.fail(err)
-		return stats
+		return diffImportStats(before, totalStats), err
 	}
 
-	stats.LibrariesScanned = 1
-	stats.PagesScanned = enumStats.PagesScanned
-	stats.ItemsSeen = enumStats.ItemsSeen
-	stats.ItemsNormalized = enumStats.ItemsNormalized
-	stats.ItemsDetailFetched = enumStats.ItemsDetailFetched
+	totalStats.LibrariesScanned++
+	totalStats.PagesScanned += enumStats.PagesScanned
+	totalStats.ItemsSeen += enumStats.ItemsSeen
+	totalStats.ItemsNormalized += enumStats.ItemsNormalized
+	totalStats.ItemsDetailFetched += enumStats.ItemsDetailFetched
 
-	if i.settings != nil && !cfg.DryRun {
-		if err := i.settings.Set(ctx, SettingABSLastImportAt, time.Now().UTC().Format(time.RFC3339)); err != nil {
-			slog.Warn("abs import: persist last_import_at failed", "error", err)
-		}
-	}
 	summary.Checkpoint = nil
-	summary.Stats = *stats
+	libStats := diffImportStats(before, totalStats)
+	summary.Stats = *libStats
 	if run.ID != 0 && i.runs != nil {
 		if err := i.runs.Finish(ctx, run.ID, runStatusCompleted, summary); err != nil {
 			slog.Warn("abs import: finish run failed", "runID", run.ID, "error", err)
@@ -398,23 +418,85 @@ func (i *Importer) run(ctx context.Context, cfg ImportConfig) *ImportStats {
 	slog.Info("abs import complete",
 		"libraryID", cfg.LibraryID,
 		"dryRun", cfg.DryRun,
-		"pagesScanned", stats.PagesScanned,
-		"itemsSeen", stats.ItemsSeen,
-		"authorsCreated", stats.AuthorsCreated,
-		"booksCreated", stats.BooksCreated,
-		"booksLinked", stats.BooksLinked,
-		"booksUpdated", stats.BooksUpdated,
-		"seriesCreated", stats.SeriesCreated,
-		"seriesLinked", stats.SeriesLinked,
-		"editionsAdded", stats.EditionsAdded,
-		"skipped", stats.Skipped,
-		"failed", stats.Failed)
-	i.setProgress(func(p *ImportProgress) {
-		p.Checkpoint = nil
-		p.ResumedFromCheckpoint = false
-		p.Message = importDoneMessage(cfg.DryRun)
-	})
-	return stats
+		"pagesScanned", libStats.PagesScanned,
+		"itemsSeen", libStats.ItemsSeen,
+		"authorsCreated", libStats.AuthorsCreated,
+		"booksCreated", libStats.BooksCreated,
+		"booksLinked", libStats.BooksLinked,
+		"booksUpdated", libStats.BooksUpdated,
+		"seriesCreated", libStats.SeriesCreated,
+		"seriesLinked", libStats.SeriesLinked,
+		"editionsAdded", libStats.EditionsAdded,
+		"skipped", libStats.Skipped,
+		"failed", libStats.Failed)
+	return libStats, nil
+}
+
+func libraryStartIndex(libraryIDs []string, current string) int {
+	current = strings.TrimSpace(current)
+	if current == "" {
+		return 0
+	}
+	for idx, libraryID := range libraryIDs {
+		if libraryID == current {
+			return idx
+		}
+	}
+	return 0
+}
+
+func resumeLibraryIDFromCheckpoint(ctx context.Context, settings *db.SettingsRepo, libraryIDs []string, fallback string) string {
+	checkpoint, err := loadImportCheckpoint(ctx, settings)
+	if err != nil || checkpoint == nil {
+		return fallback
+	}
+	checkpointLibraryID := strings.TrimSpace(checkpoint.LibraryID)
+	if checkpointLibraryID == "" {
+		return fallback
+	}
+	for _, libraryID := range libraryIDs {
+		if libraryID == checkpointLibraryID {
+			return checkpointLibraryID
+		}
+	}
+	return fallback
+}
+
+func snapshotImportStats(stats *ImportStats) ImportStats {
+	if stats == nil {
+		return ImportStats{}
+	}
+	return *stats
+}
+
+func diffImportStats(before ImportStats, after *ImportStats) *ImportStats {
+	if after == nil {
+		return &ImportStats{}
+	}
+	return &ImportStats{
+		LibrariesScanned:     after.LibrariesScanned - before.LibrariesScanned,
+		PagesScanned:         after.PagesScanned - before.PagesScanned,
+		ItemsSeen:            after.ItemsSeen - before.ItemsSeen,
+		ItemsNormalized:      after.ItemsNormalized - before.ItemsNormalized,
+		ItemsDetailFetched:   after.ItemsDetailFetched - before.ItemsDetailFetched,
+		AuthorsCreated:       after.AuthorsCreated - before.AuthorsCreated,
+		AuthorsLinked:        after.AuthorsLinked - before.AuthorsLinked,
+		BooksCreated:         after.BooksCreated - before.BooksCreated,
+		BooksLinked:          after.BooksLinked - before.BooksLinked,
+		BooksUpdated:         after.BooksUpdated - before.BooksUpdated,
+		SeriesCreated:        after.SeriesCreated - before.SeriesCreated,
+		SeriesLinked:         after.SeriesLinked - before.SeriesLinked,
+		EditionsAdded:        after.EditionsAdded - before.EditionsAdded,
+		OwnedMarked:          after.OwnedMarked - before.OwnedMarked,
+		PendingManual:        after.PendingManual - before.PendingManual,
+		ReviewQueued:         after.ReviewQueued - before.ReviewQueued,
+		MetadataMatched:      after.MetadataMatched - before.MetadataMatched,
+		MetadataRelinked:     after.MetadataRelinked - before.MetadataRelinked,
+		MetadataConflicts:    after.MetadataConflicts - before.MetadataConflicts,
+		MetadataAutoResolved: after.MetadataAutoResolved - before.MetadataAutoResolved,
+		Skipped:              after.Skipped - before.Skipped,
+		Failed:               after.Failed - before.Failed,
+	}
 }
 
 func (i *Importer) resolveEnumerator(cfg ImportConfig, runID int64) (enumerateFunc, error) {
@@ -704,14 +786,16 @@ func appendImportProgressResult(results []ImportItemResult, result ImportItemRes
 }
 
 func sourceSnapshot(cfg ImportConfig) ImportSourceSnapshot {
+	cfg = cfg.normalized()
 	return ImportSourceSnapshot{
-		SourceID:  cfg.SourceID,
-		Label:     cfg.Label,
-		BaseURL:   cfg.BaseURL,
-		LibraryID: cfg.LibraryID,
-		PathRemap: cfg.PathRemap,
-		Enabled:   cfg.Enabled,
-		DryRun:    cfg.DryRun,
+		SourceID:   cfg.SourceID,
+		Label:      cfg.Label,
+		BaseURL:    cfg.BaseURL,
+		LibraryID:  cfg.LibraryID,
+		LibraryIDs: cfg.LibraryIDs,
+		PathRemap:  cfg.PathRemap,
+		Enabled:    cfg.Enabled,
+		DryRun:     cfg.DryRun,
 	}
 }
 
@@ -765,7 +849,8 @@ func resumeConfigFromRun(run models.ABSImportRun, fallback ImportConfig) ImportC
 	if hasSource {
 		cfg.SourceID = firstNonEmpty(source.SourceID, run.SourceID, cfg.SourceID)
 		cfg.BaseURL = firstNonEmpty(source.BaseURL, run.BaseURL, cfg.BaseURL)
-		cfg.LibraryID = firstNonEmpty(source.LibraryID, run.LibraryID, cfg.LibraryID)
+		cfg.LibraryID = firstNonEmpty(run.LibraryID, source.LibraryID, cfg.LibraryID)
+		cfg.LibraryIDs = normalizeLibraryIDs(cfg.LibraryID, source.LibraryIDs)
 		cfg.Label = firstNonEmpty(source.Label, run.SourceLabel, cfg.Label)
 		cfg.PathRemap = source.PathRemap
 	} else {

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -3,6 +3,7 @@ package abs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -72,6 +73,53 @@ func sampleABSItem() NormalizedLibraryItem {
 		EbookPath:       "/abs/Project Hail Mary/book.epub",
 		EbookINO:        "ebook-1",
 		DurationSeconds: 57600,
+	}
+}
+
+type fakeEnumerationClient struct {
+	pages map[string]map[int]*LibraryItemsPage
+	errs  map[string]map[int]error
+}
+
+func (f *fakeEnumerationClient) ListLibraryItems(_ context.Context, libraryID string, page, limit int) (*LibraryItemsPage, error) {
+	if byPage := f.errs[libraryID]; byPage != nil {
+		if err := byPage[page]; err != nil {
+			return nil, err
+		}
+	}
+	if byPage := f.pages[libraryID]; byPage != nil {
+		if resp := byPage[page]; resp != nil {
+			return resp, nil
+		}
+	}
+	return &LibraryItemsPage{MediaType: "book", Page: page, Limit: limit, Total: page * limit}, nil
+}
+
+func (f *fakeEnumerationClient) GetLibraryItem(context.Context, string) (*LibraryItem, error) {
+	return nil, errors.New("unexpected detail fetch")
+}
+
+func sampleLibraryItemForLibrary(libraryID, itemID, title string) LibraryItem {
+	duration := 3600.0
+	size := int64(1024)
+	return LibraryItem{
+		ID:        itemID,
+		LibraryID: libraryID,
+		IsFile:    true,
+		MediaType: "book",
+		Media: BookMedia{
+			Metadata: BookMetadata{
+				Title:   title,
+				Authors: []Author{{ID: "author-" + itemID, Name: "Author " + itemID}},
+				ASIN:    "ASIN-" + itemID,
+			},
+			Duration: &duration,
+			Size:     &size,
+			AudioFiles: []AudioFile{{
+				INO:  "audio-" + itemID,
+				Path: "/abs/" + itemID + ".m4b",
+			}},
+		},
 	}
 }
 
@@ -181,6 +229,238 @@ func TestImporter_ProgressResultsKeepsLatestHundredItems(t *testing.T) {
 	}
 }
 
+func TestImporter_RunEnumeratesConfiguredLibrariesInOrder(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, _, _, _, runRepo, _, _, _ := newABSImporterFixture(t)
+	var enumerated []string
+	importer.enumerateFn = func(_ context.Context, libraryID string, _ func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		enumerated = append(enumerated, libraryID)
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+
+	stats, err := importer.Run(context.Background(), ImportConfig{
+		SourceID:   DefaultSourceID,
+		BaseURL:    "https://abs.example.com",
+		APIKey:     "secret",
+		LibraryIDs: []string{"lib-books", "lib-audio"},
+		Label:      "Shelf",
+		Enabled:    true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := strings.Join(enumerated, ","), "lib-books,lib-audio"; got != want {
+		t.Fatalf("enumerated = %q, want %q", got, want)
+	}
+	if stats.LibrariesScanned != 2 || stats.PagesScanned != 2 || stats.ItemsSeen != 2 {
+		t.Fatalf("stats = %+v, want aggregate counts for two libraries", stats)
+	}
+	runs, err := runRepo.ListRecent(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListRecent: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("run records = %d, want 2", len(runs))
+	}
+	seen := map[string]bool{}
+	for _, run := range runs {
+		seen[run.LibraryID] = true
+		hydrated := HydrateRun(run)
+		if len(hydrated.Source.LibraryIDs) != 2 {
+			t.Fatalf("run %d source libraryIds = %v, want both configured libraries", run.ID, hydrated.Source.LibraryIDs)
+		}
+		if hydrated.Summary.Stats.LibrariesScanned != 1 {
+			t.Fatalf("run %d summary stats = %+v, want per-library summary", run.ID, hydrated.Summary.Stats)
+		}
+	}
+	if !seen["lib-books"] || !seen["lib-audio"] {
+		t.Fatalf("run libraries = %+v, want lib-books and lib-audio", seen)
+	}
+}
+
+func TestImporter_RunStopsWhenSecondLibraryFails(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, _, _, _, runRepo, _, _, _ := newABSImporterFixture(t)
+	failErr := errors.New("abs page failed")
+	var enumerated []string
+	importer.enumerateFn = func(_ context.Context, libraryID string, _ func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		enumerated = append(enumerated, libraryID)
+		if libraryID == "lib-audio" {
+			return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, failErr
+		}
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+
+	stats, err := importer.Run(context.Background(), ImportConfig{
+		SourceID:   DefaultSourceID,
+		BaseURL:    "https://abs.example.com",
+		APIKey:     "secret",
+		LibraryIDs: []string{"lib-books", "lib-audio", "lib-extra"},
+		Label:      "Shelf",
+		Enabled:    true,
+	})
+	if err == nil || !strings.Contains(err.Error(), failErr.Error()) {
+		t.Fatalf("Run error = %v, want %v", err, failErr)
+	}
+	if got, want := strings.Join(enumerated, ","), "lib-books,lib-audio"; got != want {
+		t.Fatalf("enumerated = %q, want %q", got, want)
+	}
+	if stats.LibrariesScanned != 1 {
+		t.Fatalf("stats = %+v, want only completed library counted", stats)
+	}
+	runs, err := runRepo.ListRecent(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListRecent: %v", err)
+	}
+	statuses := map[string]string{}
+	for _, run := range runs {
+		statuses[run.LibraryID] = run.Status
+	}
+	if statuses["lib-books"] != runStatusCompleted || statuses["lib-audio"] != runStatusFailed {
+		t.Fatalf("statuses = %+v, want completed books and failed audio", statuses)
+	}
+	if _, ok := statuses["lib-extra"]; ok {
+		t.Fatalf("lib-extra run exists after earlier failure: %+v", statuses)
+	}
+}
+
+func TestImporter_RunStartsAtConfiguredLibraryWithinLibraryIDs(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, _, _, _, _, _, _, _ := newABSImporterFixture(t)
+	var enumerated []string
+	importer.enumerateFn = func(_ context.Context, libraryID string, _ func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		enumerated = append(enumerated, libraryID)
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+
+	if _, err := importer.Run(context.Background(), ImportConfig{
+		SourceID:   DefaultSourceID,
+		BaseURL:    "https://abs.example.com",
+		APIKey:     "secret",
+		LibraryID:  "lib-audio",
+		LibraryIDs: []string{"lib-books", "lib-audio", "lib-extra"},
+		Label:      "Shelf",
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := strings.Join(enumerated, ","), "lib-audio,lib-extra"; got != want {
+		t.Fatalf("enumerated = %q, want %q", got, want)
+	}
+}
+
+func TestImporter_RunStartsAtPersistedCheckpointLibraryWithinLibraryIDs(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, _, _, _, _, _, _, _ := newABSImporterFixture(t)
+	checkpoint := ImportCheckpoint{
+		LibraryID:  "lib-audio",
+		Page:       2,
+		LastItemID: "li-before-retry",
+		PageSize:   50,
+		UpdatedAt:  time.Now().UTC(),
+	}
+	if err := importer.settings.Set(context.Background(), SettingABSImportCheckpoint, mustJSONForTest(t, checkpoint)); err != nil {
+		t.Fatalf("Set checkpoint: %v", err)
+	}
+	var enumerated []string
+	importer.enumerateFn = func(_ context.Context, libraryID string, _ func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		enumerated = append(enumerated, libraryID)
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+
+	if _, err := importer.Run(context.Background(), ImportConfig{
+		SourceID:   DefaultSourceID,
+		BaseURL:    "https://abs.example.com",
+		APIKey:     "secret",
+		LibraryID:  "lib-books",
+		LibraryIDs: []string{"lib-books", "lib-audio", "lib-extra"},
+		Label:      "Shelf",
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := strings.Join(enumerated, ","), "lib-audio,lib-extra"; got != want {
+		t.Fatalf("enumerated = %q, want %q", got, want)
+	}
+}
+
+func TestImporter_RunStoresCheckpointOnCurrentLibraryRun(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, _, _, _, runRepo, _, _, _ := newABSImporterFixture(t)
+	client := &fakeEnumerationClient{
+		pages: map[string]map[int]*LibraryItemsPage{
+			"lib-books": {
+				0: {MediaType: "book", Page: 0, Limit: 50, Total: 0},
+			},
+			"lib-audio": {
+				0: {
+					MediaType: "book",
+					Page:      0,
+					Limit:     1,
+					Total:     2,
+					Results:   []LibraryItem{sampleLibraryItemForLibrary("lib-audio", "li-audio", "Audio Book")},
+				},
+			},
+		},
+		errs: map[string]map[int]error{
+			"lib-audio": {1: errors.New("page 1 failed")},
+		},
+	}
+	importer.newClient = func(string, string) (enumerationClient, error) {
+		return client, nil
+	}
+
+	_, err := importer.Run(context.Background(), ImportConfig{
+		SourceID:   DefaultSourceID,
+		BaseURL:    "https://abs.example.com",
+		APIKey:     "secret",
+		LibraryIDs: []string{"lib-books", "lib-audio"},
+		Label:      "Shelf",
+		Enabled:    true,
+	})
+	if err == nil {
+		t.Fatal("Run error = nil, want failure from lib-audio")
+	}
+	runs, err := runRepo.ListRecent(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListRecent: %v", err)
+	}
+	var audioRun, booksRun *models.ABSImportRun
+	for idx := range runs {
+		switch runs[idx].LibraryID {
+		case "lib-audio":
+			audioRun = &runs[idx]
+		case "lib-books":
+			booksRun = &runs[idx]
+		}
+	}
+	if booksRun == nil || booksRun.Status != runStatusCompleted {
+		t.Fatalf("books run = %+v, want completed", booksRun)
+	}
+	if audioRun == nil || audioRun.Status != runStatusFailed {
+		t.Fatalf("audio run = %+v, want failed", audioRun)
+	}
+	checkpoint, err := decodeImportCheckpoint(audioRun.CheckpointJSON)
+	if err != nil {
+		t.Fatalf("decode audio checkpoint: %v", err)
+	}
+	if checkpoint == nil || checkpoint.LibraryID != "lib-audio" {
+		t.Fatalf("audio checkpoint = %+v, want lib-audio", checkpoint)
+	}
+	booksCheckpoint, err := decodeImportCheckpoint(booksRun.CheckpointJSON)
+	if err != nil {
+		t.Fatalf("decode books checkpoint: %v", err)
+	}
+	if booksCheckpoint != nil {
+		t.Fatalf("books checkpoint = %+v, want cleared completed checkpoint", booksCheckpoint)
+	}
+}
+
 func TestImporter_ResumeInterruptedStartsFromPersistedCheckpoint(t *testing.T) {
 	t.Parallel()
 
@@ -286,6 +566,89 @@ func TestImporter_ResumeInterruptedStartsFromPersistedCheckpoint(t *testing.T) {
 	}
 
 	close(release)
+	deadline := time.After(time.Second)
+	for importer.Running() {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for resumed import to finish")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func TestImporter_ResumeInterruptedContinuesRemainingLibraries(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, _, _, _, runRepo, _, _, _ := newABSImporterFixture(t)
+	checkpoint := ImportCheckpoint{
+		LibraryID:  "lib-audio",
+		Page:       2,
+		LastItemID: "li-before-restart",
+		PageSize:   50,
+		UpdatedAt:  time.Now().UTC(),
+	}
+	run := &models.ABSImportRun{
+		SourceID:    DefaultSourceID,
+		SourceLabel: "Shelf",
+		BaseURL:     "https://abs.example.com",
+		LibraryID:   "lib-audio",
+		Status:      runStatusRunning,
+		DryRun:      true,
+		SourceConfigJSON: mustJSONForTest(t, sourceSnapshot(ImportConfig{
+			SourceID:   DefaultSourceID,
+			BaseURL:    "https://abs.example.com",
+			LibraryID:  "lib-audio",
+			LibraryIDs: []string{"lib-books", "lib-audio", "lib-extra"},
+			Label:      "Shelf",
+			Enabled:    true,
+			DryRun:     true,
+		})),
+		CheckpointJSON: mustJSONForTest(t, checkpoint),
+		SummaryJSON:    "{}",
+	}
+	if err := runRepo.Create(context.Background(), run); err != nil {
+		t.Fatalf("Create interrupted run: %v", err)
+	}
+
+	enumerated := make(chan string, 3)
+	importer.enumerateFn = func(_ context.Context, libraryID string, _ func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		enumerated <- libraryID
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+
+	resumed, err := importer.ResumeInterrupted(context.Background(), ImportConfig{
+		SourceID: DefaultSourceID,
+		APIKey:   "secret",
+		Enabled:  true,
+		BaseURL:  "https://current-settings.example.com",
+		Label:    "Current Settings",
+	})
+	if err != nil {
+		t.Fatalf("ResumeInterrupted: %v", err)
+	}
+	if !resumed {
+		t.Fatal("ResumeInterrupted resumed = false, want true")
+	}
+
+	var got []string
+	for len(got) < 2 {
+		select {
+		case libraryID := <-enumerated:
+			got = append(got, libraryID)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for resumed libraries; got %v", got)
+		}
+	}
+	if joined := strings.Join(got, ","); joined != "lib-audio,lib-extra" {
+		t.Fatalf("resumed libraries = %q, want lib-audio,lib-extra", joined)
+	}
+	select {
+	case extra := <-enumerated:
+		t.Fatalf("unexpected resumed library %q", extra)
+	default:
+	}
+
 	deadline := time.After(time.Second)
 	for importer.Running() {
 		select {

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -3659,6 +3659,188 @@ func TestImporter_RollbackDeletesCreatedEntitiesAfterSameRunRelink(t *testing.T)
 	}
 }
 
+func TestImporter_RollbackFirstLibraryPreservesSecondLibrarySharedBook(t *testing.T) {
+	t.Parallel()
+
+	importer, authorRepo, bookRepo, seriesRepo, _, provenanceRepo, _, _, _, _ := newABSImporterFixture(t)
+	ctx := context.Background()
+	first := sampleABSItem()
+	first.LibraryID = "lib-books"
+	first.ItemID = "li-books"
+	first.Title = "Shared Library Book"
+	first.ASIN = "ASIN-LIB-BOOKS"
+	first.Authors = []NormalizedAuthor{{ID: "author-shared", Name: "Shared Author"}}
+	first.Series = []NormalizedSeries{{ID: "series-shared", Name: "Shared Series", Sequence: "1"}}
+	first.AudioFiles = []NormalizedAudioFile{{INO: "audio-books", Path: "/abs/books/shared.m4b"}}
+	first.EbookPath = ""
+	first.EbookINO = ""
+	second := first
+	second.LibraryID = "lib-audio"
+	second.ItemID = "li-audio"
+	second.ASIN = "ASIN-LIB-AUDIO"
+	second.AudioFiles = []NormalizedAudioFile{{INO: "audio-audio", Path: "/abs/audio/shared.m4b"}}
+	items := map[string]NormalizedLibraryItem{
+		first.LibraryID:  first,
+		second.LibraryID: second,
+	}
+	importer.enumerateFn = func(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		item, ok := items[libraryID]
+		if !ok {
+			return EnumerationStats{}, fmt.Errorf("unexpected library %q", libraryID)
+		}
+		if err := fn(ctx, item); err != nil {
+			return EnumerationStats{}, err
+		}
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1, ItemsDetailFetched: 1}, nil
+	}
+
+	if _, err := importer.Run(ctx, ImportConfig{
+		SourceID:  DefaultSourceID,
+		BaseURL:   "https://abs.example.com",
+		APIKey:    "secret",
+		LibraryID: first.LibraryID,
+		Label:     "Shelf",
+		Enabled:   true,
+	}); err != nil {
+		t.Fatalf("Run first library: %v", err)
+	}
+	if _, err := importer.Run(ctx, ImportConfig{
+		SourceID:  DefaultSourceID,
+		BaseURL:   "https://abs.example.com",
+		APIKey:    "secret",
+		LibraryID: second.LibraryID,
+		Label:     "Shelf",
+		Enabled:   true,
+	}); err != nil {
+		t.Fatalf("Run second library: %v", err)
+	}
+
+	runs, err := importer.RecentRuns(ctx, 10)
+	if err != nil {
+		t.Fatalf("RecentRuns: %v", err)
+	}
+	runIDs := map[string]int64{}
+	for _, run := range runs {
+		runIDs[run.LibraryID] = run.ID
+	}
+	if runIDs[first.LibraryID] == 0 || runIDs[second.LibraryID] == 0 {
+		t.Fatalf("run IDs = %+v, want runs for both libraries", runIDs)
+	}
+	books, err := bookRepo.ListIncludingExcluded(ctx)
+	if err != nil {
+		t.Fatalf("List books before rollback: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("books before rollback = %d, want shared local book", len(books))
+	}
+	bookID := books[0].ID
+	bookLinks, err := provenanceRepo.ListByLocal(ctx, entityTypeBook, bookID)
+	if err != nil {
+		t.Fatalf("ListByLocal book before rollback: %v", err)
+	}
+	if len(bookLinks) != 2 {
+		t.Fatalf("book links before rollback = %+v, want both libraries linked", bookLinks)
+	}
+	authors, err := authorRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("List authors before rollback: %v", err)
+	}
+	if len(authors) != 1 {
+		t.Fatalf("authors before rollback = %d, want shared local author", len(authors))
+	}
+	authorID := authors[0].ID
+	authorLinks, err := provenanceRepo.ListByLocal(ctx, entityTypeAuthor, authorID)
+	if err != nil {
+		t.Fatalf("ListByLocal author before rollback: %v", err)
+	}
+	if len(authorLinks) != 2 {
+		t.Fatalf("author links before rollback = %+v, want both libraries linked", authorLinks)
+	}
+	allSeries, err := seriesRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("List series before rollback: %v", err)
+	}
+	if len(allSeries) != 1 {
+		t.Fatalf("series before rollback = %d, want shared local series", len(allSeries))
+	}
+	seriesID := allSeries[0].ID
+
+	result, err := importer.Rollback(ctx, runIDs[first.LibraryID])
+	if err != nil {
+		t.Fatalf("Rollback first library: %v", err)
+	}
+	if result.Stats.Failed != 0 {
+		t.Fatalf("rollback result = %+v, want no failures", result)
+	}
+	books, err = bookRepo.ListIncludingExcluded(ctx)
+	if err != nil {
+		t.Fatalf("List books after rollback: %v", err)
+	}
+	if len(books) != 1 || books[0].ID != bookID {
+		t.Fatalf("books after rollback = %+v, want shared local book retained", books)
+	}
+	firstBookLink, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, first.LibraryID, entityTypeBook, first.ItemID)
+	if err != nil {
+		t.Fatalf("Get first book link after rollback: %v", err)
+	}
+	if firstBookLink != nil {
+		t.Fatalf("first book link after rollback = %+v, want removed", firstBookLink)
+	}
+	secondBookLink, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, second.LibraryID, entityTypeBook, second.ItemID)
+	if err != nil {
+		t.Fatalf("Get second book link after rollback: %v", err)
+	}
+	if secondBookLink == nil || secondBookLink.LocalID != bookID {
+		t.Fatalf("second book link after rollback = %+v, want retained local book %d", secondBookLink, bookID)
+	}
+	firstAuthorLink, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, first.LibraryID, entityTypeAuthor, "author-shared")
+	if err != nil {
+		t.Fatalf("Get first author link after rollback: %v", err)
+	}
+	if firstAuthorLink != nil {
+		t.Fatalf("first author link after rollback = %+v, want removed", firstAuthorLink)
+	}
+	secondAuthorLink, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, second.LibraryID, entityTypeAuthor, "author-shared")
+	if err != nil {
+		t.Fatalf("Get second author link after rollback: %v", err)
+	}
+	if secondAuthorLink == nil || secondAuthorLink.LocalID != authorID {
+		t.Fatalf("second author link after rollback = %+v, want retained local author %d", secondAuthorLink, authorID)
+	}
+	series, err := seriesRepo.GetByID(ctx, seriesID)
+	if err != nil {
+		t.Fatalf("Get series after rollback: %v", err)
+	}
+	if series == nil {
+		t.Fatal("series after rollback = nil, want shared local series retained")
+	}
+	if len(series.Books) != 1 || series.Books[0].BookID != bookID {
+		t.Fatalf("series books after rollback = %+v, want shared local book retained", series.Books)
+	}
+	seriesLinkExternalID := seriesMembershipExternalID("series-shared", bookID, first.ItemID)
+	firstSeriesLink, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, first.LibraryID, entityTypeSeries, seriesLinkExternalID)
+	if err != nil {
+		t.Fatalf("Get first series link after rollback: %v", err)
+	}
+	if firstSeriesLink != nil {
+		t.Fatalf("first series link after rollback = %+v, want removed", firstSeriesLink)
+	}
+	firstSeriesIdentity, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, first.LibraryID, entityTypeSeries, "series-shared")
+	if err != nil {
+		t.Fatalf("Get first series identity after rollback: %v", err)
+	}
+	if firstSeriesIdentity != nil {
+		t.Fatalf("first series identity after rollback = %+v, want removed", firstSeriesIdentity)
+	}
+	secondSeriesIdentity, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, second.LibraryID, entityTypeSeries, "series-shared")
+	if err != nil {
+		t.Fatalf("Get second series identity after rollback: %v", err)
+	}
+	if secondSeriesIdentity == nil || secondSeriesIdentity.LocalID != seriesID {
+		t.Fatalf("second series identity after rollback = %+v, want retained local series %d", secondSeriesIdentity, seriesID)
+	}
+}
+
 func TestImporter_RollbackRestoresExistingBookMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -3368,6 +3368,99 @@ func TestImporter_RollbackRemovesCreatedBatch(t *testing.T) {
 	}
 }
 
+func TestImporter_RollbackSecondLibraryPreservesFirstLibraryImport(t *testing.T) {
+	t.Parallel()
+
+	importer, _, bookRepo, _, _, provenanceRepo, _, _, _, _ := newABSImporterFixture(t)
+	ctx := context.Background()
+	itemForLibrary := func(libraryID, itemID, title string) NormalizedLibraryItem {
+		item := sampleABSItem()
+		item.LibraryID = libraryID
+		item.ItemID = itemID
+		item.Title = title
+		item.ASIN = "ASIN-" + itemID
+		item.Authors = []NormalizedAuthor{{ID: "author-" + itemID, Name: "Author " + title}}
+		item.Series = []NormalizedSeries{{ID: "series-" + itemID, Name: "Series " + title, Sequence: "1"}}
+		item.AudioFiles = []NormalizedAudioFile{{INO: "audio-" + itemID, Path: "/abs/" + itemID + ".m4b"}}
+		item.EbookPath = "/abs/" + itemID + ".epub"
+		item.EbookINO = "ebook-" + itemID
+		return item
+	}
+	first := itemForLibrary("lib-books", "li-books", "Books Library Title")
+	second := itemForLibrary("lib-audio", "li-audio", "Audio Library Title")
+	items := map[string]NormalizedLibraryItem{
+		first.LibraryID:  first,
+		second.LibraryID: second,
+	}
+	importer.enumerateFn = func(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		item, ok := items[libraryID]
+		if !ok {
+			return EnumerationStats{}, fmt.Errorf("unexpected library %q", libraryID)
+		}
+		if err := fn(ctx, item); err != nil {
+			return EnumerationStats{}, err
+		}
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+
+	if _, err := importer.Run(ctx, ImportConfig{
+		SourceID:   DefaultSourceID,
+		BaseURL:    "https://abs.example.com",
+		APIKey:     "secret",
+		LibraryIDs: []string{first.LibraryID, second.LibraryID},
+		Label:      "Shelf",
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	runs, err := importer.RecentRuns(ctx, 10)
+	if err != nil {
+		t.Fatalf("RecentRuns: %v", err)
+	}
+	runIDs := map[string]int64{}
+	for _, run := range runs {
+		runIDs[run.LibraryID] = run.ID
+	}
+	if runIDs[first.LibraryID] == 0 || runIDs[second.LibraryID] == 0 {
+		t.Fatalf("run IDs = %+v, want runs for both libraries", runIDs)
+	}
+
+	if _, err := importer.Rollback(ctx, runIDs[second.LibraryID]); err != nil {
+		t.Fatalf("Rollback second library: %v", err)
+	}
+
+	firstBook, err := bookRepo.GetByForeignID(ctx, absForeignID("book", first.LibraryID, first.ItemID))
+	if err != nil {
+		t.Fatalf("GetByForeignID first book: %v", err)
+	}
+	if firstBook == nil {
+		t.Fatal("first library book was removed by second library rollback")
+	}
+	firstLink, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, first.LibraryID, entityTypeBook, first.ItemID)
+	if err != nil {
+		t.Fatalf("GetByExternal first book: %v", err)
+	}
+	if firstLink == nil {
+		t.Fatal("first library provenance was removed by second library rollback")
+	}
+
+	secondBook, err := bookRepo.GetByForeignID(ctx, absForeignID("book", second.LibraryID, second.ItemID))
+	if err != nil {
+		t.Fatalf("GetByForeignID second book: %v", err)
+	}
+	if secondBook != nil {
+		t.Fatalf("second library book = %+v, want removed by rollback", secondBook)
+	}
+	secondLink, err := provenanceRepo.GetByExternal(ctx, DefaultSourceID, second.LibraryID, entityTypeBook, second.ItemID)
+	if err != nil {
+		t.Fatalf("GetByExternal second book: %v", err)
+	}
+	if secondLink != nil {
+		t.Fatalf("second library provenance = %+v, want removed by rollback", secondLink)
+	}
+}
+
 func TestImporter_RollbackKeepsRunCreatedSeriesWithUserMembership(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/abs.go
+++ b/internal/api/abs.go
@@ -15,12 +15,13 @@ import (
 )
 
 const (
-	SettingABSBaseURL   = "abs.base_url"
-	SettingABSAPIKey    = "abs.api_key" //nolint:gosec // #nosec G101 -- settings key name, not a credential value
-	SettingABSLibraryID = "abs.library_id"
-	SettingABSEnabled   = "abs.enabled"
-	SettingABSLabel     = "abs.label"
-	SettingABSPathRemap = "abs.path_remap"
+	SettingABSBaseURL    = "abs.base_url"
+	SettingABSAPIKey     = "abs.api_key" //nolint:gosec // #nosec G101 -- settings key name, not a credential value
+	SettingABSLibraryID  = "abs.library_id"
+	SettingABSLibraryIDs = "abs.library_ids"
+	SettingABSEnabled    = "abs.enabled"
+	SettingABSLabel      = "abs.label"
+	SettingABSPathRemap  = "abs.path_remap"
 )
 
 type absClient interface {
@@ -38,22 +39,24 @@ type ABSHandler struct {
 }
 
 type ABSConfigResponse struct {
-	FeatureEnabled   bool   `json:"featureEnabled"`
-	BaseURL          string `json:"baseUrl"`
-	Label            string `json:"label"`
-	Enabled          bool   `json:"enabled"`
-	LibraryID        string `json:"libraryId"`
-	PathRemap        string `json:"pathRemap"`
-	APIKeyConfigured bool   `json:"apiKeyConfigured"`
+	FeatureEnabled   bool     `json:"featureEnabled"`
+	BaseURL          string   `json:"baseUrl"`
+	Label            string   `json:"label"`
+	Enabled          bool     `json:"enabled"`
+	LibraryID        string   `json:"libraryId"`
+	LibraryIDs       []string `json:"libraryIds"`
+	PathRemap        string   `json:"pathRemap"`
+	APIKeyConfigured bool     `json:"apiKeyConfigured"`
 }
 
 type absConfigRequest struct {
-	BaseURL   *string `json:"baseUrl"`
-	Label     *string `json:"label"`
-	Enabled   *bool   `json:"enabled"`
-	LibraryID *string `json:"libraryId"`
-	PathRemap *string `json:"pathRemap"`
-	APIKey    *string `json:"apiKey"`
+	BaseURL    *string   `json:"baseUrl"`
+	Label      *string   `json:"label"`
+	Enabled    *bool     `json:"enabled"`
+	LibraryID  *string   `json:"libraryId"`
+	LibraryIDs *[]string `json:"libraryIds"`
+	PathRemap  *string   `json:"pathRemap"`
+	APIKey     *string   `json:"apiKey"`
 }
 
 type absProbeRequest struct {
@@ -151,8 +154,19 @@ func (h *ABSHandler) SetConfig(w http.ResponseWriter, r *http.Request) {
 		label = "Audiobookshelf"
 	}
 	libraryID := current.LibraryID
+	libraryIDs := append([]string(nil), current.LibraryIDs...)
 	if req.LibraryID != nil {
 		libraryID = strings.TrimSpace(*req.LibraryID)
+	}
+	if req.LibraryIDs != nil {
+		libraryIDs = normalizeABSLibraryIDs("", *req.LibraryIDs)
+		if len(libraryIDs) > 0 {
+			libraryID = libraryIDs[0]
+		} else {
+			libraryID = ""
+		}
+	} else if req.LibraryID != nil {
+		libraryIDs = normalizeABSLibraryIDs(libraryID, nil)
 	}
 	pathRemap := current.PathRemap
 	if req.PathRemap != nil {
@@ -163,6 +177,12 @@ func (h *ABSHandler) SetConfig(w http.ResponseWriter, r *http.Request) {
 		enabled = *req.Enabled
 	}
 
+	libraryIDsJSON, err := json.Marshal(libraryIDs)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
 	// Persist every settings row atomically. A mid-write failure must not
 	// leave a half-applied config (e.g. enabled=true with a stale library ID).
 	kvs := []db.SettingKV{
@@ -170,6 +190,7 @@ func (h *ABSHandler) SetConfig(w http.ResponseWriter, r *http.Request) {
 		{Key: SettingABSLabel, Value: label},
 		{Key: SettingABSEnabled, Value: boolString(enabled)},
 		{Key: SettingABSLibraryID, Value: libraryID},
+		{Key: SettingABSLibraryIDs, Value: string(libraryIDsJSON)},
 		{Key: SettingABSPathRemap, Value: pathRemap},
 	}
 	if req.APIKey != nil && strings.TrimSpace(*req.APIKey) != "" {
@@ -185,8 +206,10 @@ func (h *ABSHandler) SetConfig(w http.ResponseWriter, r *http.Request) {
 		Label:            label,
 		Enabled:          enabled,
 		LibraryID:        libraryID,
+		LibraryIDs:       libraryIDs,
 		PathRemap:        pathRemap,
 		APIKeyConfigured: apiKey != "",
+		FeatureEnabled:   h.featureEnabled,
 	})
 }
 
@@ -244,12 +267,13 @@ func (h *ABSHandler) Libraries(w http.ResponseWriter, r *http.Request) {
 }
 
 type ABSStoredConfig struct {
-	BaseURL   string
-	APIKey    string
-	Label     string
-	LibraryID string
-	PathRemap string
-	Enabled   bool
+	BaseURL    string
+	APIKey     string
+	Label      string
+	LibraryID  string
+	LibraryIDs []string
+	PathRemap  string
+	Enabled    bool
 }
 
 func LoadABSConfig(ctx context.Context, settings *db.SettingsRepo) ABSStoredConfig {
@@ -264,13 +288,22 @@ func LoadABSConfig(ctx context.Context, settings *db.SettingsRepo) ABSStoredConf
 	if label == "" {
 		label = "Audiobookshelf"
 	}
+	libraryID := get(SettingABSLibraryID)
+	rawLibraryIDs := get(SettingABSLibraryIDs)
+	libraryIDs := decodeABSLibraryIDs(rawLibraryIDs)
+	if strings.TrimSpace(rawLibraryIDs) == "" || len(libraryIDs) == 0 {
+		libraryIDs = normalizeABSLibraryIDs(libraryID, libraryIDs)
+	} else {
+		libraryID = libraryIDs[0]
+	}
 	return ABSStoredConfig{
-		BaseURL:   get(SettingABSBaseURL),
-		APIKey:    get(SettingABSAPIKey),
-		Label:     label,
-		LibraryID: get(SettingABSLibraryID),
-		PathRemap: get(SettingABSPathRemap),
-		Enabled:   strings.EqualFold(get(SettingABSEnabled), "true"),
+		BaseURL:    get(SettingABSBaseURL),
+		APIKey:     get(SettingABSAPIKey),
+		Label:      label,
+		LibraryID:  libraryID,
+		LibraryIDs: libraryIDs,
+		PathRemap:  get(SettingABSPathRemap),
+		Enabled:    strings.EqualFold(get(SettingABSEnabled), "true"),
 	}
 }
 
@@ -286,6 +319,7 @@ func (h *ABSHandler) loadConfig(ctx context.Context) ABSConfigResponse {
 		Label:            cfg.Label,
 		Enabled:          cfg.Enabled,
 		LibraryID:        cfg.LibraryID,
+		LibraryIDs:       cfg.LibraryIDs,
 		PathRemap:        cfg.PathRemap,
 		APIKeyConfigured: cfg.APIKey != "",
 	}
@@ -322,6 +356,41 @@ func (h *ABSHandler) newConfiguredClient(baseURL, apiKey string) (absClient, err
 		return nil, errors.New("api_key is required")
 	}
 	return h.newFn(baseURL, apiKey)
+}
+
+func decodeABSLibraryIDs(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	var values []string
+	if err := json.Unmarshal([]byte(raw), &values); err != nil {
+		return nil
+	}
+	return values
+}
+
+func normalizeABSLibraryIDs(primary string, values []string) []string {
+	primary = strings.TrimSpace(primary)
+	out := make([]string, 0, len(values)+1)
+	seen := make(map[string]struct{}, len(values)+1)
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	if primary != "" {
+		if _, ok := seen[primary]; !ok {
+			out = append([]string{primary}, out...)
+		}
+	}
+	return out
 }
 
 func (h *ABSHandler) writeProbeError(w http.ResponseWriter, logMsg, baseURL string, err error) {

--- a/internal/api/abs_import.go
+++ b/internal/api/abs_import.go
@@ -46,13 +46,14 @@ func (h *ABSImportHandler) Start(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	runCfg := abs.ImportConfig{
-		SourceID:  abs.DefaultSourceID,
-		BaseURL:   cfg.BaseURL,
-		APIKey:    cfg.APIKey,
-		LibraryID: cfg.LibraryID,
-		PathRemap: cfg.PathRemap,
-		Label:     cfg.Label,
-		Enabled:   cfg.Enabled,
+		SourceID:   abs.DefaultSourceID,
+		BaseURL:    cfg.BaseURL,
+		APIKey:     cfg.APIKey,
+		LibraryID:  cfg.LibraryID,
+		LibraryIDs: cfg.LibraryIDs,
+		PathRemap:  cfg.PathRemap,
+		Label:      cfg.Label,
+		Enabled:    cfg.Enabled,
 	}
 	if req.DryRun != nil {
 		runCfg.DryRun = *req.DryRun

--- a/internal/api/abs_import_test.go
+++ b/internal/api/abs_import_test.go
@@ -54,11 +54,12 @@ func TestABSImportHandler_Start(t *testing.T) {
 			t.Fatalf("load config context value = %v, want request", ctx.Value(key))
 		}
 		return ABSStoredConfig{
-			BaseURL:   "https://abs.example.com",
-			APIKey:    "secret",
-			Label:     "Shelf",
-			LibraryID: "lib-books",
-			Enabled:   true,
+			BaseURL:    "https://abs.example.com",
+			APIKey:     "secret",
+			Label:      "Shelf",
+			LibraryID:  "lib-books",
+			LibraryIDs: []string{"lib-books", "lib-audio"},
+			Enabled:    true,
 		}
 	})
 
@@ -71,6 +72,9 @@ func TestABSImportHandler_Start(t *testing.T) {
 	}
 	if stub.lastCfg.LibraryID != "lib-books" || stub.lastCfg.BaseURL != "https://abs.example.com" {
 		t.Fatalf("cfg = %+v", stub.lastCfg)
+	}
+	if got := stub.lastCfg.LibraryIDs; len(got) != 2 || got[0] != "lib-books" || got[1] != "lib-audio" {
+		t.Fatalf("libraryIDs = %v, want stored ordered libraries", got)
 	}
 }
 

--- a/internal/api/abs_review.go
+++ b/internal/api/abs_review.go
@@ -45,13 +45,14 @@ func (h *ABSReviewHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 	cfg := h.loadCfg(r.Context())
 	runCfg := abs.ImportConfig{
-		SourceID:  abs.DefaultSourceID,
-		BaseURL:   cfg.BaseURL,
-		APIKey:    cfg.APIKey,
-		LibraryID: strings.TrimSpace(cfg.LibraryID),
-		PathRemap: cfg.PathRemap,
-		Label:     cfg.Label,
-		Enabled:   cfg.Enabled,
+		SourceID:   abs.DefaultSourceID,
+		BaseURL:    cfg.BaseURL,
+		APIKey:     cfg.APIKey,
+		LibraryID:  strings.TrimSpace(cfg.LibraryID),
+		LibraryIDs: cfg.LibraryIDs,
+		PathRemap:  cfg.PathRemap,
+		Label:      cfg.Label,
+		Enabled:    cfg.Enabled,
 	}
 	for idx := range items {
 		var payload abs.NormalizedLibraryItem
@@ -100,13 +101,14 @@ func (h *ABSReviewHandler) Approve(w http.ResponseWriter, r *http.Request) {
 
 	cfg := h.loadCfg(r.Context())
 	runCfg := abs.ImportConfig{
-		SourceID:  strings.TrimSpace(item.SourceID),
-		BaseURL:   cfg.BaseURL,
-		APIKey:    cfg.APIKey,
-		LibraryID: strings.TrimSpace(item.LibraryID),
-		PathRemap: cfg.PathRemap,
-		Label:     cfg.Label,
-		Enabled:   cfg.Enabled,
+		SourceID:   strings.TrimSpace(item.SourceID),
+		BaseURL:    cfg.BaseURL,
+		APIKey:     cfg.APIKey,
+		LibraryID:  strings.TrimSpace(item.LibraryID),
+		LibraryIDs: cfg.LibraryIDs,
+		PathRemap:  cfg.PathRemap,
+		Label:      cfg.Label,
+		Enabled:    cfg.Enabled,
 	}
 	if err := runCfg.Validate(); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})

--- a/internal/api/abs_test.go
+++ b/internal/api/abs_test.go
@@ -129,9 +129,105 @@ func TestABSSetConfigSavesLibraryIDWithoutLiveProbe(t *testing.T) {
 	if got == nil || got.Value != "lib_books" {
 		t.Fatalf("library id not persisted: %+v", got)
 	}
+	got, _ = repo.Get(ctx, SettingABSLibraryIDs)
+	if got == nil || got.Value != `["lib_books"]` {
+		t.Fatalf("library ids not persisted: %+v", got)
+	}
 	got, _ = repo.Get(ctx, SettingABSAPIKey)
 	if got == nil || got.Value != "secret" {
 		t.Fatalf("api key not persisted: %+v", got)
+	}
+}
+
+func TestABSSetConfigPersistsLibraryIDs(t *testing.T) {
+	h, repo, ctx := absFixture(t, nil)
+
+	body := bytes.NewBufferString(`{"baseUrl":"https://abs.example.com/","apiKey":"secret","libraryIds":["lib_books","lib_audio","lib_books"],"enabled":true,"label":"Shelf"}`)
+	rec := httptest.NewRecorder()
+	h.SetConfig(rec, httptest.NewRequest(http.MethodPut, "/api/v1/abs/config", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	assertSettingValue(t, repo, ctx, SettingABSLibraryID, "lib_books")
+	assertSettingValue(t, repo, ctx, SettingABSLibraryIDs, `["lib_books","lib_audio"]`)
+
+	var cfg ABSConfigResponse
+	if err := json.NewDecoder(rec.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if cfg.LibraryID != "lib_books" {
+		t.Fatalf("libraryId = %q, want lib_books", cfg.LibraryID)
+	}
+	if got, want := strings.Join(cfg.LibraryIDs, ","), "lib_books,lib_audio"; got != want {
+		t.Fatalf("libraryIds = %q, want %q", got, want)
+	}
+}
+
+func TestABSGetConfigFallsBackToLegacyLibraryID(t *testing.T) {
+	h, repo, ctx := absFixture(t, nil)
+	if err := repo.Set(ctx, SettingABSLibraryID, "lib_legacy"); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.GetConfig(rec, httptest.NewRequest(http.MethodGet, "/api/v1/abs/config", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d", rec.Code)
+	}
+	var cfg ABSConfigResponse
+	if err := json.NewDecoder(rec.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if cfg.LibraryID != "lib_legacy" {
+		t.Fatalf("libraryId = %q, want lib_legacy", cfg.LibraryID)
+	}
+	if got, want := strings.Join(cfg.LibraryIDs, ","), "lib_legacy"; got != want {
+		t.Fatalf("libraryIds = %q, want %q", got, want)
+	}
+}
+
+func TestABSGetConfigFallsBackToLegacyLibraryIDWhenLibraryIDsEmpty(t *testing.T) {
+	h, repo, ctx := absFixture(t, nil)
+	if err := repo.Set(ctx, SettingABSLibraryID, "lib_legacy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Set(ctx, SettingABSLibraryIDs, "[]"); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.GetConfig(rec, httptest.NewRequest(http.MethodGet, "/api/v1/abs/config", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d", rec.Code)
+	}
+	var cfg ABSConfigResponse
+	if err := json.NewDecoder(rec.Body).Decode(&cfg); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if cfg.LibraryID != "lib_legacy" {
+		t.Fatalf("libraryId = %q, want lib_legacy", cfg.LibraryID)
+	}
+	if got, want := strings.Join(cfg.LibraryIDs, ","), "lib_legacy"; got != want {
+		t.Fatalf("libraryIds = %q, want %q", got, want)
+	}
+}
+
+func TestABSSetConfigAllowsEmptyLibraryIDs(t *testing.T) {
+	h, repo, ctx := absFixture(t, nil)
+
+	body := bytes.NewBufferString(`{"baseUrl":"https://abs.example.com/","apiKey":"secret","libraryIds":[],"enabled":true,"label":"Shelf"}`)
+	rec := httptest.NewRecorder()
+	h.SetConfig(rec, httptest.NewRequest(http.MethodPut, "/api/v1/abs/config", body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	assertSettingValue(t, repo, ctx, SettingABSLibraryID, "")
+	assertSettingValue(t, repo, ctx, SettingABSLibraryIDs, `[]`)
+	cfg := LoadABSConfig(ctx, repo)
+	if cfg.LibraryID != "" || len(cfg.LibraryIDs) != 0 {
+		t.Fatalf("cfg libraries = %q/%v, want empty", cfg.LibraryID, cfg.LibraryIDs)
 	}
 }
 

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -63,7 +63,7 @@ type Scanner struct {
 	audiobookDir         string
 	audiobookDownloadDir string
 	absLib               absNotifier
-	absLibraryIDFn       func() string
+	absLibraryIDsFn      func() []string
 }
 
 // NewScanner creates an import scanner. downloadPathRemap is an optional
@@ -180,12 +180,12 @@ func (s *Scanner) WithCalibreCoverCache(dir string) *Scanner {
 	return s
 }
 
-// WithABSNotifier attaches an Audiobookshelf scan notifier. libraryIDFn is
-// called at import time to retrieve the current ABS audiobook library ID;
-// returning an empty string disables the notification for that import.
-func (s *Scanner) WithABSNotifier(n absNotifier, libraryIDFn func() string) *Scanner {
+// WithABSNotifier attaches an Audiobookshelf scan notifier. libraryIDsFn is
+// called at import time to retrieve the current ABS audiobook library IDs;
+// returning an empty slice disables the notification for that import.
+func (s *Scanner) WithABSNotifier(n absNotifier, libraryIDsFn func() []string) *Scanner {
 	s.absLib = n
-	s.absLibraryIDFn = libraryIDFn
+	s.absLibraryIDsFn = libraryIDsFn
 	return s
 }
 
@@ -193,18 +193,33 @@ func (s *Scanner) WithABSNotifier(n absNotifier, libraryIDFn func() string) *Sca
 // Failures are logged and swallowed — ABS sync is best-effort and must never
 // roll back an otherwise-good Bindery import.
 func (s *Scanner) pushToABS(ctx context.Context) {
-	if s.absLib == nil || s.absLibraryIDFn == nil {
+	if s.absLib == nil || s.absLibraryIDsFn == nil {
 		return
 	}
-	libraryID := s.absLibraryIDFn()
-	if libraryID == "" {
-		return
+	for _, libraryID := range uniqueNonEmptyStrings(s.absLibraryIDsFn()) {
+		if err := s.absLib.ScanLibrary(ctx, libraryID); err != nil {
+			slog.Warn("abs: library scan after audiobook import failed", "libraryID", libraryID, "error", err)
+			continue
+		}
+		slog.Info("abs: triggered library scan after audiobook import", "libraryID", libraryID)
 	}
-	if err := s.absLib.ScanLibrary(ctx, libraryID); err != nil {
-		slog.Warn("abs: library scan after audiobook import failed", "libraryID", libraryID, "error", err)
-		return
+}
+
+func uniqueNonEmptyStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
 	}
-	slog.Info("abs: triggered library scan after audiobook import", "libraryID", libraryID)
+	return out
 }
 
 // WithSettings attaches a SettingsRepo to the scanner so scan results can be

--- a/internal/importer/scanner_abs_test.go
+++ b/internal/importer/scanner_abs_test.go
@@ -92,7 +92,7 @@ func TestTryImportInternal_NotifiesABSAfterAudiobookImport(t *testing.T) {
 
 	notifier := &fakeABSNotifier{}
 	const wantLibraryID = "lib-audiobooks-123"
-	s.WithABSNotifier(notifier, func() string { return wantLibraryID })
+	s.WithABSNotifier(notifier, func() []string { return []string{wantLibraryID} })
 
 	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil)
 
@@ -101,6 +101,30 @@ func TestTryImportInternal_NotifiesABSAfterAudiobookImport(t *testing.T) {
 	}
 	if notifier.scanCalls[0] != wantLibraryID {
 		t.Errorf("ScanLibrary called with libraryID=%q, want %q", notifier.scanCalls[0], wantLibraryID)
+	}
+}
+
+func TestTryImportInternal_NotifiesAllConfiguredABSLibraries(t *testing.T) {
+	t.Parallel()
+
+	audiobookDir := t.TempDir()
+	downloadPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(downloadPath, "book.m4b"), []byte("audio-data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, dl, _, ctx := absAudiobookFixture(t, audiobookDir)
+
+	notifier := &fakeABSNotifier{}
+	s.WithABSNotifier(notifier, func() []string { return []string{"lib-books", "lib-audio", "lib-books", ""} })
+
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil)
+
+	if got, want := len(notifier.scanCalls), 2; got != want {
+		t.Fatalf("ScanLibrary calls = %d, want %d: %v", got, want, notifier.scanCalls)
+	}
+	if notifier.scanCalls[0] != "lib-books" || notifier.scanCalls[1] != "lib-audio" {
+		t.Fatalf("ScanLibrary calls = %v, want lib-books then lib-audio", notifier.scanCalls)
 	}
 }
 
@@ -131,7 +155,7 @@ func TestTryImportInternal_DoesNotNotifyABSForEbookImport(t *testing.T) {
 	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, "", "", "", "")
 
 	notifier := &fakeABSNotifier{}
-	s.WithABSNotifier(notifier, func() string { return "lib-audiobooks-123" })
+	s.WithABSNotifier(notifier, func() []string { return []string{"lib-audiobooks-123"} })
 
 	dl := &models.Download{
 		Title:  "Dune",
@@ -165,7 +189,7 @@ func TestTryImportInternal_ABSNotifySkippedWhenNoLibraryID(t *testing.T) {
 
 	notifier := &fakeABSNotifier{}
 	// Library ID resolver returns "" — ABS not configured.
-	s.WithABSNotifier(notifier, func() string { return "" })
+	s.WithABSNotifier(notifier, func() []string { return nil })
 
 	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil)
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -436,7 +436,7 @@ export const api = {
 
   // Audiobookshelf
   absConfig: () => request<ABSConfig>('/abs/config'),
-  absSetConfig: (data: { baseUrl: string; label: string; enabled: boolean; libraryId: string; pathRemap: string; apiKey?: string }) =>
+  absSetConfig: (data: { baseUrl: string; label: string; enabled: boolean; libraryId: string; libraryIds?: string[]; pathRemap: string; apiKey?: string }) =>
     request<ABSConfig>('/abs/config', { method: 'PUT', body: JSON.stringify(data) }),
   absTest: (data?: { baseUrl?: string; apiKey?: string }) =>
     request<ABSTestResult>('/abs/test', { method: 'POST', body: JSON.stringify(data ?? {}) }),
@@ -686,6 +686,7 @@ export interface ABSConfig {
   label: string
   enabled: boolean
   libraryId: string
+  libraryIds?: string[]
   pathRemap: string
   apiKeyConfigured: boolean
 }
@@ -799,6 +800,7 @@ export interface ABSImportRun {
     label: string
     baseUrl: string
     libraryId: string
+    libraryIds?: string[]
     pathRemap?: string
     enabled: boolean
     dryRun: boolean

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -171,8 +171,8 @@ function seedSettingsMocks(options: {
   vi.mocked(api.testProwlarr).mockResolvedValue({ ok: 'true', version: '1.0.0' })
   vi.mocked(api.deleteProwlarr).mockResolvedValue(undefined)
 
-    vi.mocked(api.absConfig).mockResolvedValue({ featureEnabled: false, baseUrl: '', label: '', enabled: false, libraryId: '', pathRemap: '', apiKeyConfigured: false })
-    vi.mocked(api.absSetConfig).mockResolvedValue({ featureEnabled: false, baseUrl: '', label: '', enabled: false, libraryId: '', pathRemap: '', apiKeyConfigured: false })
+    vi.mocked(api.absConfig).mockResolvedValue({ featureEnabled: false, baseUrl: '', label: '', enabled: false, libraryId: '', libraryIds: [], pathRemap: '', apiKeyConfigured: false })
+    vi.mocked(api.absSetConfig).mockResolvedValue({ featureEnabled: false, baseUrl: '', label: '', enabled: false, libraryId: '', libraryIds: [], pathRemap: '', apiKeyConfigured: false })
     vi.mocked(api.absLibraries).mockResolvedValue([])
     vi.mocked(api.absImportStart).mockResolvedValue({ running: true, dryRun: true, processed: 0 })
     vi.mocked(api.absImportStatus).mockResolvedValue({ running: false, processed: 0 })
@@ -275,8 +275,9 @@ describe('SettingsPage', () => {
   it('persists the enhanced Hardcover admin toggle separately from effective status', async () => {
     renderSettings()
 
-    await screen.findByText('Hardcover API Token')
-    fireEvent.click(sectionForHeading('settings.general.apiKeys').getByTitle('common.enable'))
+    await screen.findByRole('heading', { name: 'settings.general.apiKeys' })
+    const apiKeys = sectionForHeading('settings.general.apiKeys')
+    fireEvent.click(apiKeys.getByTitle('common.enable'))
 
     await waitFor(() => {
       expect(api.setSetting).toHaveBeenCalledWith('hardcover.enhanced_series_enabled', 'true')
@@ -600,6 +601,7 @@ describe('SettingsPage', () => {
       label: 'Shelf',
       enabled: true,
       libraryId: 'lib-books',
+      libraryIds: ['lib-books'],
       pathRemap: '/abs:/books',
       apiKeyConfigured: true,
     })
@@ -609,6 +611,7 @@ describe('SettingsPage', () => {
       label: data.label,
       enabled: data.enabled,
       libraryId: data.libraryId,
+      libraryIds: data.libraryIds ?? [data.libraryId],
       pathRemap: data.pathRemap,
       apiKeyConfigured: true,
     }))
@@ -631,6 +634,7 @@ describe('SettingsPage', () => {
         label: 'Shelf',
         enabled: true,
         libraryId: 'lib-books',
+        libraryIds: ['lib-books'],
         pathRemap: '/draft:/books',
       })
     })
@@ -640,6 +644,112 @@ describe('SettingsPage', () => {
     await waitFor(() => {
       expect(api.absImportStart).toHaveBeenCalledWith({ dryRun: true })
     })
+  })
+
+  it('uses a multi-library selector instead of the old Audiobookshelf library dropdown', async () => {
+    vi.mocked(api.absConfig).mockResolvedValue({
+      featureEnabled: true,
+      baseUrl: 'https://abs.example.com',
+      label: 'Shelf',
+      enabled: true,
+      libraryId: 'lib-books',
+      libraryIds: ['lib-books', 'lib-audio'],
+      pathRemap: '/abs:/books',
+      apiKeyConfigured: true,
+    })
+    vi.mocked(api.absLibraries).mockResolvedValue([
+      { id: 'lib-books', name: 'Books', mediaType: 'book', icon: '', provider: 'local', folders: [] },
+      { id: 'lib-audio', name: 'Audiobooks', mediaType: 'book', icon: '', provider: 'audible', folders: [] },
+    ])
+
+    renderSettings()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.abs' }))
+    expect(await screen.findByRole('heading', { name: 'Libraries' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Library')).not.toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: /Books/ })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: /Audiobooks/ })).toBeChecked()
+  })
+
+  it('saves all selected Audiobookshelf libraries', async () => {
+    vi.mocked(api.absConfig).mockResolvedValue({
+      featureEnabled: true,
+      baseUrl: 'https://abs.example.com',
+      label: 'Shelf',
+      enabled: true,
+      libraryId: 'lib-books',
+      libraryIds: ['lib-books'],
+      pathRemap: '/abs:/books',
+      apiKeyConfigured: true,
+    })
+    vi.mocked(api.absLibraries).mockResolvedValue([
+      { id: 'lib-books', name: 'Books', mediaType: 'book', icon: '', provider: 'local', folders: [] },
+      { id: 'lib-audio', name: 'Audiobooks', mediaType: 'book', icon: '', provider: 'audible', folders: [] },
+    ])
+    vi.mocked(api.absSetConfig).mockImplementation(async data => ({
+      featureEnabled: true,
+      baseUrl: data.baseUrl,
+      label: data.label,
+      enabled: data.enabled,
+      libraryId: data.libraryId,
+      libraryIds: data.libraryIds ?? [],
+      pathRemap: data.pathRemap,
+      apiKeyConfigured: true,
+    }))
+
+    renderSettings()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.abs' }))
+    fireEvent.click(await screen.findByRole('checkbox', { name: /Audiobooks/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save source' }))
+
+    await waitFor(() => {
+      expect(api.absSetConfig).toHaveBeenCalledWith({
+        baseUrl: 'https://abs.example.com',
+        apiKey: undefined,
+        label: 'Shelf',
+        enabled: true,
+        libraryId: 'lib-books',
+        libraryIds: ['lib-books', 'lib-audio'],
+        pathRemap: '/abs:/books',
+      })
+    })
+  })
+
+  it('keeps ABS import disabled until selected libraries are saved', async () => {
+    vi.mocked(api.absConfig).mockResolvedValue({
+      featureEnabled: true,
+      baseUrl: 'https://abs.example.com',
+      label: 'Shelf',
+      enabled: true,
+      libraryId: '',
+      libraryIds: [],
+      pathRemap: '/abs:/books',
+      apiKeyConfigured: true,
+    })
+    vi.mocked(api.absLibraries).mockResolvedValue([
+      { id: 'lib-books', name: 'Books', mediaType: 'book', icon: '', provider: 'local', folders: [] },
+    ])
+    vi.mocked(api.absSetConfig).mockImplementation(async data => ({
+      featureEnabled: true,
+      baseUrl: data.baseUrl,
+      label: data.label,
+      enabled: data.enabled,
+      libraryId: data.libraryId,
+      libraryIds: data.libraryIds ?? [],
+      pathRemap: data.pathRemap,
+      apiKeyConfigured: true,
+    }))
+
+    renderSettings()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.abs' }))
+    const preview = await screen.findByRole('button', { name: 'Preview changes' })
+    expect(preview).toBeDisabled()
+    fireEvent.click(await screen.findByRole('checkbox', { name: /Books/ }))
+    expect(preview).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Save source' }))
+    await waitFor(() => expect(preview).toBeEnabled())
   })
 
   it('adds an indexer with parsed categories', async () => {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import SettingsPage from './SettingsPage'
-import { api, type DownloadClient, type Indexer, type OidcProvider, type ProwlarrInstance, type RootFolder, type SystemStatus } from '../api/client'
+import { api, type ABSImportRun, type DownloadClient, type Indexer, type OidcProvider, type ProwlarrInstance, type RootFolder, type SystemStatus } from '../api/client'
 
 const mockAuthContext = vi.hoisted(() => ({
   status: {
@@ -141,6 +141,57 @@ function makeRootFolder(overrides: Partial<RootFolder> = {}): RootFolder {
     freeSpace: 1024,
     createdAt: '2026-05-06T12:00:00Z',
     ...overrides,
+  }
+}
+
+function makeABSImportRun(id: number, libraryId: string): ABSImportRun {
+  return {
+    id,
+    sourceId: 'abs',
+    sourceLabel: 'Shelf',
+    baseUrl: 'https://abs.example.com',
+    libraryId,
+    status: 'completed',
+    dryRun: false,
+    startedAt: '2026-05-20T14:00:00Z',
+    source: {
+      sourceId: 'abs',
+      label: 'Shelf',
+      baseUrl: 'https://abs.example.com',
+      libraryId,
+      libraryIds: ['lib-books', 'lib-audio'],
+      pathRemap: '',
+      enabled: true,
+      dryRun: false,
+    },
+    summary: {
+      dryRun: false,
+      resumedFromCheckpoint: false,
+      stats: {
+        librariesScanned: 1,
+        pagesScanned: 1,
+        itemsSeen: 0,
+        itemsNormalized: 0,
+        itemsDetailFetched: 0,
+        authorsCreated: 0,
+        authorsLinked: 0,
+        booksCreated: 0,
+        booksLinked: 0,
+        booksUpdated: 0,
+        seriesCreated: 0,
+        seriesLinked: 0,
+        editionsAdded: 0,
+        ownedMarked: 0,
+        pendingManual: 0,
+        reviewQueued: 0,
+        metadataMatched: 0,
+        metadataRelinked: 0,
+        metadataConflicts: 0,
+        metadataAutoResolved: 0,
+        skipped: 0,
+        failed: 0,
+      },
+    },
   }
 }
 
@@ -669,6 +720,34 @@ describe('SettingsPage', () => {
     expect(screen.queryByLabelText('Library')).not.toBeInTheDocument()
     expect(screen.getByRole('checkbox', { name: /Books/ })).toBeChecked()
     expect(screen.getByRole('checkbox', { name: /Audiobooks/ })).toBeChecked()
+  })
+
+  it('labels recent Audiobookshelf import runs by library', async () => {
+    vi.mocked(api.absConfig).mockResolvedValue({
+      featureEnabled: true,
+      baseUrl: 'https://abs.example.com',
+      label: 'Shelf',
+      enabled: true,
+      libraryId: 'lib-books',
+      libraryIds: ['lib-books', 'lib-audio'],
+      pathRemap: '/abs:/books',
+      apiKeyConfigured: true,
+    })
+    vi.mocked(api.absLibraries).mockResolvedValue([
+      { id: 'lib-books', name: 'Books', mediaType: 'book', icon: '', provider: 'local', folders: [] },
+      { id: 'lib-audio', name: 'Audiobooks', mediaType: 'book', icon: '', provider: 'audible', folders: [] },
+    ])
+    vi.mocked(api.absImportRuns).mockResolvedValue([
+      makeABSImportRun(42, 'lib-books'),
+      makeABSImportRun(43, 'lib-audio'),
+    ])
+
+    renderSettings()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.abs' }))
+
+    expect(await screen.findByText(/Shelf · Books \(lib-books\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Shelf · Audiobooks \(lib-audio\)/)).toBeInTheDocument()
   })
 
   it('saves all selected Audiobookshelf libraries', async () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -16,6 +16,27 @@ const ADMIN_TABS: Tab[] = ['indexers', 'clients', 'notifications', 'quality', 'm
 const inputCls = 'w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600'
 const absReviewResultLimit = 10
 
+function uniqueTrimmed(values: string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const value of values) {
+    const trimmed = value.trim()
+    if (!trimmed || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    out.push(trimmed)
+  }
+  return out
+}
+
+function absConfigLibraryIds(config: ABSConfig): string[] {
+  return uniqueTrimmed(config.libraryIds?.length ? config.libraryIds : config.libraryId ? [config.libraryId] : [])
+}
+
+function sameStrings(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  return a.every((value, idx) => value === b[idx])
+}
+
 function SettingsNavLink({ tab, active, onSelect, label }: { tab: Tab; active: Tab; onSelect: (t: Tab) => void; label: string }) {
   return (
     <button
@@ -1297,7 +1318,7 @@ function ABSTab() {
 
 function AudiobookshelfSection() {
   const [config, setConfig] = useState<ABSConfig | null>(null)
-  const [draft, setDraft] = useState({ baseUrl: '', apiKey: '', label: 'Audiobookshelf', enabled: false, libraryId: '', pathRemap: '' })
+  const [draft, setDraft] = useState({ baseUrl: '', apiKey: '', label: 'Audiobookshelf', enabled: false, libraryIds: [] as string[], pathRemap: '' })
   const [libraries, setLibraries] = useState<ABSLibrary[]>([])
   const [showAuthorConflicts, setShowAuthorConflicts] = useState(true)
   const [showReviewItems, setShowReviewItems] = useState(true)
@@ -1340,7 +1361,7 @@ function AudiobookshelfSection() {
       apiKey: '',
       label: next.label || 'Audiobookshelf',
       enabled: next.enabled,
-      libraryId: next.libraryId ?? '',
+      libraryIds: absConfigLibraryIds(next),
       pathRemap: next.pathRemap ?? '',
     }))
   }
@@ -1379,9 +1400,6 @@ function AudiobookshelfSection() {
     try {
       const next = await api.absLibraries(payload)
       setLibraries(next)
-      if (next.length > 0 && !next.some(lib => lib.id === draft.libraryId) && !draft.libraryId) {
-        setDraft(prev => ({ ...prev, libraryId: next[0].id }))
-      }
     } catch (err: unknown) {
       setLibraryError(err instanceof Error ? err.message : 'Failed to load libraries')
     } finally {
@@ -1431,12 +1449,14 @@ function AudiobookshelfSection() {
     setSaving(true)
     setSaveError(null)
     try {
+      const libraryIds = uniqueTrimmed(draft.libraryIds)
       const next = await api.absSetConfig({
         baseUrl: draft.baseUrl.trim(),
         apiKey: draft.apiKey.trim() || undefined,
         label: draft.label.trim() || 'Audiobookshelf',
         enabled: draft.enabled,
-        libraryId: draft.libraryId,
+        libraryId: libraryIds[0] ?? '',
+        libraryIds,
         pathRemap: draft.pathRemap.trim(),
       })
       applyConfig(next)
@@ -1458,7 +1478,7 @@ function AudiobookshelfSection() {
       const next = await api.absTest(probePayload())
       setTestResult(next)
       if (next.defaultLibraryId) {
-        setDraft(prev => prev.libraryId ? prev : { ...prev, libraryId: next.defaultLibraryId })
+        setDraft(prev => prev.libraryIds.length ? prev : { ...prev, libraryIds: [next.defaultLibraryId] })
       }
       if (draft.baseUrl.trim() && (draft.apiKey.trim() || config?.apiKeyConfigured)) {
         loadLibraries(probePayload()).catch(() => {})
@@ -1669,20 +1689,26 @@ function AudiobookshelfSection() {
   }
 
   const hasImportCredentials = Boolean(draft.apiKey.trim() || config?.apiKeyConfigured)
-  const effectiveLibraryId = draft.libraryId || testResult?.defaultLibraryId || ''
+  const effectiveLibraryIds = draft.libraryIds.length > 0 ? draft.libraryIds : testResult?.defaultLibraryId ? [testResult.defaultLibraryId] : []
   const savedBaseUrl = config?.baseUrl ?? ''
   const savedLabel = config?.label || 'Audiobookshelf'
-  const savedLibraryId = config?.libraryId ?? ''
+  const savedLibraryIds = config ? absConfigLibraryIds(config) : []
   const savedPathRemap = config?.pathRemap ?? ''
   const hasUnsavedABSConfig = Boolean(config) && (
     draft.baseUrl.trim() !== savedBaseUrl.trim() ||
     (draft.label.trim() || 'Audiobookshelf') !== savedLabel ||
     draft.enabled !== config?.enabled ||
-    draft.libraryId !== savedLibraryId ||
+    !sameStrings(uniqueTrimmed(draft.libraryIds), savedLibraryIds) ||
     draft.pathRemap.trim() !== savedPathRemap.trim() ||
     Boolean(draft.apiKey.trim())
   )
-  const canStartImport = !importProgress?.running && !hasUnsavedABSConfig && Boolean(config?.enabled) && Boolean(config?.apiKeyConfigured) && Boolean(savedBaseUrl.trim()) && Boolean(savedLibraryId)
+  const canStartImport = !importProgress?.running && !hasUnsavedABSConfig && Boolean(config?.enabled) && Boolean(config?.apiKeyConfigured) && Boolean(savedBaseUrl.trim()) && savedLibraryIds.length > 0
+  const libraryRows = [
+    ...libraries,
+    ...draft.libraryIds
+      .filter(id => !libraries.some(lib => lib.id === id))
+      .map(id => ({ id, name: id, mediaType: 'book', icon: '', provider: '', folders: [] } as ABSLibrary)),
+  ]
   const absRunStatusLabel = (status: string) => {
     switch (status) {
       case 'rolled_back':
@@ -1731,11 +1757,11 @@ function AudiobookshelfSection() {
         <div>
           <h3 className="text-base font-semibold text-slate-800 dark:text-zinc-200">Audiobookshelf</h3>
           <p className="text-xs text-slate-600 dark:text-zinc-500 mt-1">
-            Configure one ABS source, test API-key auth, pick a single book library, then import ABS metadata into the Bindery catalog.
+            Configure one ABS source, test API-key auth, pick book libraries, then import ABS metadata into the Bindery catalog.
           </p>
           {draft.enabled && (
             <p className="text-[11px] text-sky-700 dark:text-sky-300 mt-1 max-w-xl">
-              For better initial matching, it helps to review the ABS library first and match audiobooks to Audible sources so ASINs are already present before import.
+              For better initial matching, it helps to review the selected ABS libraries first and match audiobooks to Audible sources so ASINs are already present before import.
             </p>
           )}
         </div>
@@ -1747,6 +1773,62 @@ function AudiobookshelfSection() {
         >
           <span className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${draft.enabled ? 'translate-x-5' : ''}`} />
         </button>
+      </div>
+
+      <div className="mb-4 p-3 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-50 dark:bg-zinc-950">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h4 className="text-sm font-medium text-slate-800 dark:text-zinc-200">Libraries</h4>
+            <p className="text-[11px] text-slate-600 dark:text-zinc-500 mt-0.5">
+              Select each ABS book library to import from this source.
+            </p>
+          </div>
+          <span className="text-[11px] text-slate-500 dark:text-zinc-500 whitespace-nowrap">
+            {draft.libraryIds.length} selected
+          </span>
+        </div>
+        {libraryRows.length > 0 ? (
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {libraryRows.map(lib => {
+              const checked = draft.libraryIds.includes(lib.id)
+              return (
+                <label
+                  key={lib.id}
+                  className={`flex items-center gap-3 rounded border px-3 py-2 text-sm cursor-pointer transition-colors ${
+                    checked
+                      ? 'border-emerald-500/70 bg-emerald-500/10 text-slate-900 dark:text-zinc-100'
+                      : 'border-slate-200 dark:border-zinc-800 bg-slate-100 dark:bg-zinc-900 text-slate-700 dark:text-zinc-300'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={e => {
+                      const selected = e.target.checked
+                      setDraft(prev => {
+                        const next = selected
+                          ? [...prev.libraryIds, lib.id]
+                          : prev.libraryIds.filter(id => id !== lib.id)
+                        return { ...prev, libraryIds: uniqueTrimmed(next) }
+                      })
+                    }}
+                  />
+                  <span className="min-w-0">
+                    <span className="block truncate font-medium">{lib.name || lib.id}</span>
+                    <span className="block truncate text-[11px] text-slate-500 dark:text-zinc-500">
+                      {lib.provider ? `${lib.provider} · ${lib.id}` : lib.id}
+                    </span>
+                  </span>
+                </label>
+              )
+            })}
+          </div>
+        ) : (
+          <p className="mt-3 text-xs text-slate-500 dark:text-zinc-500">
+            No libraries selected. Use Test connection or List libraries to discover accessible book libraries.
+          </p>
+        )}
+        {libraryError && <div className="mt-2 text-sm text-red-600 dark:text-red-400">{libraryError}</div>}
       </div>
 
       <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-4">
@@ -1782,8 +1864,8 @@ function AudiobookshelfSection() {
           />
           <p className="text-[11px] text-slate-500 dark:text-zinc-500 mt-1">
             {config?.apiKeyConfigured
-              ? 'A key is already stored and stays write-only. Leaving this blank keeps the saved key. Use a key for a user that can access the target book library; ABS admin permissions are not required.'
-              : 'Use a key for a user that can access the target book library. ABS admin permissions are not required, and the saved key never comes back to the browser after you store it.'}
+              ? 'A key is already stored and stays write-only. Leaving this blank keeps the saved key. Use a key for a user that can access the selected book libraries; ABS admin permissions are not required.'
+              : 'Use a key for a user that can access the selected book libraries. ABS admin permissions are not required, and the saved key never comes back to the browser after you store it.'}
           </p>
         </div>
 
@@ -1797,32 +1879,6 @@ function AudiobookshelfSection() {
         {saveError && <div className="text-sm text-red-600 dark:text-red-400">{saveError}</div>}
         {testError && <div className="text-sm text-red-600 dark:text-red-400">{testError}</div>}
         {libraryError && <div className="text-sm text-red-600 dark:text-red-400">{libraryError}</div>}
-
-        {(libraries.length > 0 || draft.libraryId) && (
-          <div>
-            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Library</label>
-            <select
-              value={draft.libraryId}
-              onChange={e => setDraft(prev => ({ ...prev, libraryId: e.target.value }))}
-              className={inputCls}
-            >
-              <option value="">Select a library</option>
-              {libraries.map(lib => (
-                <option key={lib.id} value={lib.id}>
-                  {lib.name}{lib.provider ? ` · ${lib.provider}` : ''}
-                </option>
-              ))}
-            </select>
-            <p className="text-[11px] text-slate-500 dark:text-zinc-500 mt-1">
-              Save stores the selected library without contacting ABS. Use “List libraries” to show book libraries; imports reject non-book libraries before scanning.
-            </p>
-            {draft.libraryId && !libraries.some(lib => lib.id === draft.libraryId) && (
-              <p className="text-[11px] text-amber-600 dark:text-amber-400 mt-1">
-                Saved library ID: {draft.libraryId}. Click “List libraries” to refresh the selectable list.
-              </p>
-            )}
-          </div>
-        )}
 
         <PathRemapField
           id="abs-path-remap"
@@ -1862,7 +1918,7 @@ function AudiobookshelfSection() {
             <div>
               <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">Catalog import</label>
               <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">
-                Import authors, books, series, and editions from the selected ABS library. Shared filesystem paths are reconciled into Bindery ownership automatically; when ABS and Bindery use different mount prefixes, add a path translation above. Non-visible paths stay metadata-only and are counted for manual follow-up.
+                Import authors, books, series, and editions from the selected ABS libraries. Shared filesystem paths are reconciled into Bindery ownership automatically; when ABS and Bindery use different mount prefixes, add a path translation above. Non-visible paths stay metadata-only and are counted for manual follow-up.
               </p>
             </div>
             <div className="flex flex-col items-end gap-2 flex-shrink-0">
@@ -1889,7 +1945,7 @@ function AudiobookshelfSection() {
                   title={hasUnsavedABSConfig ? 'Save Audiobookshelf settings before starting an import' : undefined}
                   className="px-4 py-2 bg-sky-600 hover:bg-sky-500 rounded text-sm font-medium disabled:opacity-50"
                 >
-                  {importProgress?.running ? 'Running…' : importDryRun ? 'Run selected mode' : 'Import library'}
+                  {importProgress?.running ? 'Running…' : importDryRun ? 'Run selected mode' : 'Import libraries'}
                 </button>
               </div>
             </div>
@@ -1900,9 +1956,9 @@ function AudiobookshelfSection() {
               Save Audiobookshelf settings before starting an import so the run uses the stored source configuration.
             </p>
           )}
-          {!hasUnsavedABSConfig && !effectiveLibraryId && hasImportCredentials && (
+          {!hasUnsavedABSConfig && effectiveLibraryIds.length === 0 && hasImportCredentials && (
             <p className="text-[11px] text-amber-700 dark:text-amber-300">
-              Choose a library or use "Test connection" / "List libraries" to load an accessible default library before starting an import.
+              Choose at least one library or use "Test connection" / "List libraries" to load accessible book libraries before starting an import.
             </p>
           )}
 

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1709,6 +1709,7 @@ function AudiobookshelfSection() {
       .filter(id => !libraries.some(lib => lib.id === id))
       .map(id => ({ id, name: id, mediaType: 'book', icon: '', provider: '', folders: [] } as ABSLibrary)),
   ]
+  const libraryNameById = new Map(libraryRows.map(lib => [lib.id, lib.name || lib.id]))
   const absRunStatusLabel = (status: string) => {
     switch (status) {
       case 'rolled_back':
@@ -1720,6 +1721,13 @@ function AudiobookshelfSection() {
       default:
         return status.replace(/_/g, ' ')
     }
+  }
+  const absRunLibraryLabel = (run: ABSImportRun) => {
+    const libraryId = (run.libraryId || run.source.libraryId || '').trim()
+    if (!libraryId) return 'Unknown library'
+    const name = libraryNameById.get(libraryId)?.trim()
+    if (name && name !== libraryId) return `${name} (${libraryId})`
+    return libraryId
   }
   const rollbackActionName = (action: ABSRollbackAction) => action.displayName?.trim() || action.externalId
 
@@ -2090,7 +2098,7 @@ function AudiobookshelfSection() {
                       Run #{run.id} · {run.dryRun ? 'Dry-run' : 'Live import'} · {absRunStatusLabel(run.status)}
                     </p>
                     <p className="text-[11px] text-slate-500 dark:text-zinc-500">
-                      {new Date(run.startedAt).toLocaleString()} · {run.source.label || run.sourceLabel}
+                      {new Date(run.startedAt).toLocaleString()} · {run.source.label || run.sourceLabel} · {absRunLibraryLabel(run)}
                     </p>
                   </div>
                   {!run.dryRun && (


### PR DESCRIPTION
## Summary

Purpose: Closes #580 by letting one Audiobookshelf source import from multiple selected book libraries, so setups with separate Books and Audiobooks libraries no longer have to choose one library ID. The change preserves the legacy `abs.library_id` compatibility field while adding ordered `libraryIds` config, sequential per-library import runs, and UI/docs coverage for selecting more than one ABS book library.

- Store normalized selected ABS library IDs and keep `libraryId` mirrored to the first selected ID for compatibility.
- Process selected libraries in saved order with one run, summary, checkpoint, rollback scope, and provenance set per library.
- Replace the ABS settings dropdown with a multi-library selector and update ABS import docs.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (N/A - no env vars, deployment config, or upgrade path changed)
- [x] `CHANGELOG.md` updated if applicable (N/A - changelog entries are release-time only for feature work)
- [x] Wiki pages updated if user-facing behaviour changed (`docs/ABS-Import-Wiki.md` updated)

## Test plan

- [x] `go test ./internal/abs ./internal/api ./internal/importer ./cmd/bindery`
- [x] `go test ./cmd/... ./internal/...`
- [x] `cd web && npm test -- SettingsPage.test.tsx`
- [x] `cd web && npm run typecheck`
- [x] `cd web && npm run build`
- [x] `cd web && npm run lint` (passes with existing warnings outside this change)
- [x] `cd web && npm test`
- [x] `gofmt -l` on changed Go files
- [x] `git diff --check`

Rebase validation on 2026-05-18:

- [x] `go test ./internal/importer ./internal/abs ./internal/api ./cmd/bindery`
- [x] `cd web && npm test -- SettingsPage.test.tsx`
- [x] `git diff --check`
