### PR TITLE
fix(metadata): restore Hardcover API compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 - **qBittorrent imports recover from mismatched container paths without re-downloading** — Download clients now support per-client path remaps, qBittorrent grabs are sent with the expected category save path, and Settings surfaces qBittorrent category path health warnings. Queue items stuck in `importFailed` can also be retried after fixing storage/path settings.
 - **Calibre ID reuse** — Plugin sync no longer reuses a stored source-library Calibre ID when pushing into a different Calibre library.
+- **Hardcover supplemental author sync restored** (#669) — Hardcover removed fields from its GraphQL `books` shape and blocked `_ilike` searches, causing author page enrichment to fail with validation or 403 errors. Bindery now uses Hardcover's current search operation and avoids the removed author-work fields.
 
 ## [v1.11.2] — 2026-05-17
 

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -8,7 +8,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -94,56 +96,64 @@ func NewAuthenticated(token string) *Client {
 func (c *Client) Name() string { return "hardcover" }
 
 func (c *Client) SearchAuthors(ctx context.Context, query string) ([]models.Author, error) {
-	gql := `query SearchAuthors($query: String!) {
-		authors(where: {name: {_ilike: $query}}, limit: 20) {
-			id
-			name
-			slug
-			bio
-			image { url }
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+	gql := `query SearchAuthors($query: String!, $queryType: String!, $perPage: Int!) {
+		search(query: $query, query_type: $queryType, per_page: $perPage) {
+			results
 		}
 	}`
 	var resp struct {
 		Data struct {
-			Authors []hcAuthor `json:"authors"`
+			Search struct {
+				Results json.RawMessage `json:"results"`
+			} `json:"search"`
 		} `json:"data"`
 	}
-	if err := c.query(ctx, gql, map[string]any{"query": "%" + query + "%"}, &resp); err != nil {
+	if err := c.query(ctx, gql, map[string]any{
+		"query":     query,
+		"queryType": "Author",
+		"perPage":   20,
+	}, &resp); err != nil {
 		return nil, fmt.Errorf("hardcover search authors: %w", err)
 	}
-	authors := make([]models.Author, 0, len(resp.Data.Authors))
-	for _, a := range resp.Data.Authors {
+	docs := parseAuthorSearchResults(resp.Data.Search.Results)
+	authors := make([]models.Author, 0, len(docs))
+	for _, a := range docs {
 		authors = append(authors, c.toAuthor(a))
 	}
 	return authors, nil
 }
 
 func (c *Client) SearchBooks(ctx context.Context, query string) ([]models.Book, error) {
-	gql := `query SearchBooks($query: String!) {
-		books(where: {title: {_ilike: $query}}, limit: 20) {
-			id
-			title
-			slug
-			description
-			image { url }
-			release_year
-			ratings_count
-			rating
-			contributions {
-				author { id name slug }
-			}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+	gql := `query SearchBooks($query: String!, $queryType: String!, $perPage: Int!) {
+		search(query: $query, query_type: $queryType, per_page: $perPage) {
+			results
 		}
 	}`
 	var resp struct {
 		Data struct {
-			Books []hcBook `json:"books"`
+			Search struct {
+				Results json.RawMessage `json:"results"`
+			} `json:"search"`
 		} `json:"data"`
 	}
-	if err := c.query(ctx, gql, map[string]any{"query": "%" + query + "%"}, &resp); err != nil {
+	if err := c.query(ctx, gql, map[string]any{
+		"query":     query,
+		"queryType": "Book",
+		"perPage":   20,
+	}, &resp); err != nil {
 		return nil, fmt.Errorf("hardcover search books: %w", err)
 	}
-	books := make([]models.Book, 0, len(resp.Data.Books))
-	for _, b := range resp.Data.Books {
+	docs := parseBookSearchResults(resp.Data.Search.Results)
+	books := make([]models.Book, 0, len(docs))
+	for _, b := range docs {
 		books = append(books, c.toBook(b))
 	}
 	return books, nil
@@ -182,9 +192,6 @@ func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([
 			ratings_count
 			rating
 			users_count
-			genres
-			has_audiobook
-			has_ebook
 			audio_seconds
 			contributions {
 				author { id name slug }
@@ -217,7 +224,7 @@ func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([
 }
 
 func (c *Client) GetAuthor(ctx context.Context, foreignID string) (*models.Author, error) {
-	slug := strings.TrimPrefix(foreignID, idPrefix)
+	id := strings.TrimPrefix(foreignID, idPrefix)
 	gql := `query GetAuthor($slug: String!) {
 		authors(where: {slug: {_eq: $slug}}, limit: 1) {
 			id
@@ -227,12 +234,25 @@ func (c *Client) GetAuthor(ctx context.Context, foreignID string) (*models.Autho
 			image { url }
 		}
 	}`
+	vars := map[string]any{"slug": id}
+	if numericID, ok := hardcoverNumericID(id); ok {
+		gql = `query GetAuthor($id: Int!) {
+			authors(where: {id: {_eq: $id}}, limit: 1) {
+				id
+				name
+				slug
+				bio
+				image { url }
+			}
+		}`
+		vars = map[string]any{"id": numericID}
+	}
 	var resp struct {
 		Data struct {
 			Authors []hcAuthor `json:"authors"`
 		} `json:"data"`
 	}
-	if err := c.query(ctx, gql, map[string]any{"slug": slug}, &resp); err != nil {
+	if err := c.query(ctx, gql, vars, &resp); err != nil {
 		return nil, fmt.Errorf("hardcover get author: %w", err)
 	}
 	if len(resp.Data.Authors) == 0 {
@@ -243,7 +263,7 @@ func (c *Client) GetAuthor(ctx context.Context, foreignID string) (*models.Autho
 }
 
 func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, error) {
-	slug := strings.TrimPrefix(foreignID, idPrefix)
+	id := strings.TrimPrefix(foreignID, idPrefix)
 	gql := `query GetBook($slug: String!) {
 		books(where: {slug: {_eq: $slug}}, limit: 1) {
 			id
@@ -259,12 +279,31 @@ func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, e
 			}
 		}
 	}`
+	vars := map[string]any{"slug": id}
+	if numericID, ok := hardcoverNumericID(id); ok {
+		gql = `query GetBook($id: Int!) {
+			books(where: {id: {_eq: $id}}, limit: 1) {
+				id
+				title
+				slug
+				description
+				image { url }
+				release_year
+				ratings_count
+				rating
+				contributions {
+					author { id name slug }
+				}
+			}
+		}`
+		vars = map[string]any{"id": numericID}
+	}
 	var resp struct {
 		Data struct {
 			Books []hcBook `json:"books"`
 		} `json:"data"`
 	}
-	if err := c.query(ctx, gql, map[string]any{"slug": slug}, &resp); err != nil {
+	if err := c.query(ctx, gql, vars, &resp); err != nil {
 		return nil, fmt.Errorf("hardcover get book: %w", err)
 	}
 	if len(resp.Data.Books) == 0 {
@@ -687,10 +726,251 @@ type hcBook struct {
 	Rating        float64          `json:"rating"`
 	UsersCount    int              `json:"users_count"`
 	Genres        []string         `json:"genres"`
-	HasAudiobook  bool             `json:"has_audiobook"`
-	HasEbook      bool             `json:"has_ebook"`
 	AudioSeconds  *int             `json:"audio_seconds"`
 	Contributions []hcContribution `json:"contributions"`
+	AuthorNames   []string         `json:"author_names"`
+}
+
+type hcAuthorSearchEnvelope struct {
+	Hits []hcAuthorSearchHit `json:"hits"`
+}
+
+type hcAuthorSearchHit struct {
+	Document hcAuthorSearchDocument `json:"document"`
+}
+
+type hcAuthorSearchDocument struct {
+	ID          any    `json:"id"`
+	Name        string `json:"name"`
+	Slug        string `json:"slug"`
+	Bio         string `json:"bio"`
+	Description string `json:"description"`
+	Image       any    `json:"image"`
+	ImageURL    string `json:"image_url"`
+	CachedImage any    `json:"cached_image"`
+}
+
+type hcBookSearchEnvelope struct {
+	Hits []hcBookSearchHit `json:"hits"`
+}
+
+type hcBookSearchHit struct {
+	Document hcBookSearchDocument `json:"document"`
+}
+
+type hcBookSearchDocument struct {
+	ID            any                    `json:"id"`
+	Title         string                 `json:"title"`
+	Slug          string                 `json:"slug"`
+	Description   string                 `json:"description"`
+	Image         any                    `json:"image"`
+	ImageURL      string                 `json:"image_url"`
+	CachedImage   any                    `json:"cached_image"`
+	ReleaseYear   any                    `json:"release_year"`
+	RatingsCount  any                    `json:"ratings_count"`
+	Rating        any                    `json:"rating"`
+	Contributions []hcSearchContribution `json:"contributions"`
+	AuthorNames   []string               `json:"author_names"`
+}
+
+type hcSearchContribution struct {
+	Author hcAuthorSearchDocument `json:"author"`
+}
+
+func parseAuthorSearchResults(raw json.RawMessage) []hcAuthor {
+	raw = normalizeRawSearchResults(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var envelope hcAuthorSearchEnvelope
+	if err := json.Unmarshal(raw, &envelope); err == nil && len(envelope.Hits) > 0 {
+		return authorSearchHitsToAuthors(envelope.Hits)
+	}
+	var hits []hcAuthorSearchHit
+	if err := json.Unmarshal(raw, &hits); err == nil {
+		return authorSearchHitsToAuthors(hits)
+	}
+	var docs []hcAuthorSearchDocument
+	if err := json.Unmarshal(raw, &docs); err == nil {
+		authors := make([]hcAuthor, 0, len(docs))
+		for _, doc := range docs {
+			if author, ok := authorSearchDocumentToAuthor(doc); ok {
+				authors = append(authors, author)
+			}
+		}
+		return authors
+	}
+	return nil
+}
+
+func parseBookSearchResults(raw json.RawMessage) []hcBook {
+	raw = normalizeRawSearchResults(raw)
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var envelope hcBookSearchEnvelope
+	if err := json.Unmarshal(raw, &envelope); err == nil && len(envelope.Hits) > 0 {
+		return bookSearchHitsToBooks(envelope.Hits)
+	}
+	var hits []hcBookSearchHit
+	if err := json.Unmarshal(raw, &hits); err == nil {
+		return bookSearchHitsToBooks(hits)
+	}
+	var docs []hcBookSearchDocument
+	if err := json.Unmarshal(raw, &docs); err == nil {
+		books := make([]hcBook, 0, len(docs))
+		for _, doc := range docs {
+			if book, ok := bookSearchDocumentToBook(doc); ok {
+				books = append(books, book)
+			}
+		}
+		return books
+	}
+	return nil
+}
+
+func authorSearchHitsToAuthors(hits []hcAuthorSearchHit) []hcAuthor {
+	authors := make([]hcAuthor, 0, len(hits))
+	for _, hit := range hits {
+		if author, ok := authorSearchDocumentToAuthor(hit.Document); ok {
+			authors = append(authors, author)
+		}
+	}
+	return authors
+}
+
+func bookSearchHitsToBooks(hits []hcBookSearchHit) []hcBook {
+	books := make([]hcBook, 0, len(hits))
+	for _, hit := range hits {
+		if book, ok := bookSearchDocumentToBook(hit.Document); ok {
+			books = append(books, book)
+		}
+	}
+	return books
+}
+
+func authorSearchDocumentToAuthor(doc hcAuthorSearchDocument) (hcAuthor, bool) {
+	name := strings.TrimSpace(doc.Name)
+	id, _ := searchInt(doc.ID)
+	slug := strings.TrimSpace(doc.Slug)
+	if name == "" || (slug == "" && id <= 0) {
+		return hcAuthor{}, false
+	}
+	bio := strings.TrimSpace(doc.Bio)
+	if bio == "" {
+		bio = strings.TrimSpace(doc.Description)
+	}
+	return hcAuthor{
+		ID:    id,
+		Name:  name,
+		Slug:  slug,
+		Bio:   bio,
+		Image: searchImage(doc.Image, doc.ImageURL, doc.CachedImage),
+	}, true
+}
+
+func bookSearchDocumentToBook(doc hcBookSearchDocument) (hcBook, bool) {
+	title := strings.TrimSpace(doc.Title)
+	id, _ := searchInt(doc.ID)
+	slug := strings.TrimSpace(doc.Slug)
+	if title == "" || (slug == "" && id <= 0) {
+		return hcBook{}, false
+	}
+	book := hcBook{
+		ID:            id,
+		Title:         title,
+		Slug:          slug,
+		Description:   strings.TrimSpace(doc.Description),
+		Image:         searchImage(doc.Image, doc.ImageURL, doc.CachedImage),
+		ReleaseYear:   searchIntPtr(doc.ReleaseYear),
+		RatingsCount:  searchIntValue(doc.RatingsCount),
+		Rating:        searchFloatValue(doc.Rating),
+		Contributions: make([]hcContribution, 0, len(doc.Contributions)),
+		AuthorNames:   doc.AuthorNames,
+	}
+	for _, contribution := range doc.Contributions {
+		author, ok := authorSearchDocumentToAuthor(contribution.Author)
+		if ok {
+			book.Contributions = append(book.Contributions, hcContribution{Author: author})
+		}
+	}
+	return book, true
+}
+
+func searchImage(values ...any) *hcImage {
+	for _, value := range values {
+		switch v := value.(type) {
+		case nil:
+			continue
+		case string:
+			if url := strings.TrimSpace(v); url != "" {
+				return &hcImage{URL: url}
+			}
+		case map[string]any:
+			if url, ok := v["url"].(string); ok && strings.TrimSpace(url) != "" {
+				return &hcImage{URL: strings.TrimSpace(url)}
+			}
+			if url, ok := v["image_url"].(string); ok && strings.TrimSpace(url) != "" {
+				return &hcImage{URL: strings.TrimSpace(url)}
+			}
+		}
+	}
+	return nil
+}
+
+func searchIntPtr(value any) *int {
+	i, ok := searchInt(value)
+	if !ok {
+		return nil
+	}
+	return &i
+}
+
+func searchIntValue(value any) int {
+	i, _ := searchInt(value)
+	return i
+}
+
+func searchInt(value any) (int, bool) {
+	switch v := value.(type) {
+	case nil:
+		return 0, false
+	case int:
+		return v, true
+	case float64:
+		if v != math.Trunc(v) {
+			return 0, false
+		}
+		i, err := strconv.Atoi(strconv.FormatFloat(v, 'f', 0, 64))
+		return i, err == nil
+	case json.Number:
+		i, err := strconv.Atoi(v.String())
+		return i, err == nil
+	case string:
+		i, err := strconv.Atoi(strings.TrimSpace(v))
+		return i, err == nil
+	default:
+		i, err := strconv.Atoi(seriesIDString(v))
+		return i, err == nil
+	}
+}
+
+func searchFloatValue(value any) float64 {
+	switch v := value.(type) {
+	case nil:
+		return 0
+	case float64:
+		return v
+	case json.Number:
+		f, _ := strconv.ParseFloat(v.String(), 64)
+		return f
+	case string:
+		f, _ := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		return f
+	default:
+		f, _ := strconv.ParseFloat(seriesIDString(v), 64)
+		return f
+	}
 }
 
 // --- Converters ---
@@ -746,6 +1026,19 @@ func (c *Client) toBook(b hcBook) models.Book {
 	if len(b.Contributions) > 0 {
 		a := c.toAuthor(b.Contributions[0].Author)
 		bk.Author = &a
+	} else if len(b.AuthorNames) > 0 {
+		for _, authorName := range b.AuthorNames {
+			name := strings.TrimSpace(authorName)
+			if name == "" {
+				continue
+			}
+			bk.Author = &models.Author{
+				Name:             name,
+				SortName:         sortName(name),
+				MetadataProvider: "hardcover",
+			}
+			break
+		}
 	}
 	return bk
 }
@@ -758,4 +1051,16 @@ func sortName(name string) string {
 	last := parts[len(parts)-1]
 	rest := strings.Join(parts[:len(parts)-1], " ")
 	return last + ", " + rest
+}
+
+func hardcoverNumericID(value string) (int, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+	id, err := strconv.Atoi(value)
+	if err != nil || id <= 0 {
+		return 0, false
+	}
+	return id, true
 }

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -70,6 +70,34 @@ func newMockClient(handler func(*http.Request) (*http.Response, error)) *Client 
 	}
 }
 
+func assertSearchRequest(t *testing.T, r *http.Request, queryType, query string) {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	var req gqlRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	if strings.Contains(req.Query, "_ilike") {
+		t.Fatalf("search query still uses _ilike: %s", req.Query)
+	}
+	if !strings.Contains(req.Query, "search(query: $query") {
+		t.Fatalf("search query does not use Hardcover search operation: %s", req.Query)
+	}
+	if got := req.Variables["queryType"]; got != queryType {
+		t.Fatalf("queryType = %v, want %s", got, queryType)
+	}
+	if got := req.Variables["query"]; got != query {
+		t.Fatalf("query = %v, want %s", got, query)
+	}
+	perPage, ok := req.Variables["perPage"].(float64)
+	if !ok || perPage != 20 {
+		t.Fatalf("perPage = %v, want 20", req.Variables["perPage"])
+	}
+}
+
 func TestName(t *testing.T) {
 	c := New()
 	if c.Name() != "hardcover" {
@@ -111,7 +139,11 @@ func TestQuery_UsesNormalizedAuthorizationHeader(t *testing.T) {
 				if got := r.Header.Get("Authorization"); got != "Bearer hc-secret" {
 					t.Fatalf("Authorization = %q, want Bearer hc-secret", got)
 				}
-				return gqlResponse(t, http.StatusOK, map[string]interface{}{"authors": []interface{}{}}), nil
+				return gqlResponse(t, http.StatusOK, map[string]interface{}{
+					"search": map[string]interface{}{
+						"results": map[string]interface{}{"found": 0, "hits": []interface{}{}},
+					},
+				}), nil
 			}}
 			if _, err := tt.client.SearchAuthors(context.Background(), "nobody"); err != nil {
 				t.Fatalf("SearchAuthors: %v", err)
@@ -155,15 +187,23 @@ func TestQuery_SuccessResponseBodyReadIsBounded(t *testing.T) {
 
 func TestSearchAuthors_Success(t *testing.T) {
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		assertSearchRequest(t, r, "Author", "Sanderson")
 		data := map[string]interface{}{
-			"authors": []map[string]interface{}{
-				{
-					"id":   1,
-					"name": "Brandon Sanderson",
-					"slug": "brandon-sanderson",
-					"bio":  "Fantasy author",
-					"image": map[string]interface{}{
-						"url": "https://example.com/bs.jpg",
+			"search": map[string]interface{}{
+				"results": map[string]interface{}{
+					"found": 1,
+					"hits": []map[string]interface{}{
+						{
+							"document": map[string]interface{}{
+								"id":   1,
+								"name": "Brandon Sanderson",
+								"slug": "brandon-sanderson",
+								"bio":  "Fantasy author",
+								"image": map[string]interface{}{
+									"url": "https://example.com/bs.jpg",
+								},
+							},
+						},
 					},
 				},
 			},
@@ -189,9 +229,41 @@ func TestSearchAuthors_Success(t *testing.T) {
 	}
 }
 
+func TestSearchAuthors_ParsesStringResults(t *testing.T) {
+	encoded := `{"found":1,"hits":[{"document":{"id":"80626","name":"J.K. Rowling","description":"Author","image_url":"https://example.com/jkr.jpg"}}]}`
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		assertSearchRequest(t, r, "Author", "rowling")
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{
+			"search": map[string]interface{}{"results": encoded},
+		}), nil
+	})
+
+	authors, err := c.SearchAuthors(context.Background(), "rowling")
+	if err != nil {
+		t.Fatalf("SearchAuthors: %v", err)
+	}
+	if len(authors) != 1 {
+		t.Fatalf("expected 1 author, got %d", len(authors))
+	}
+	if authors[0].ForeignID != "hc:80626" {
+		t.Errorf("ForeignID: want 'hc:80626', got %q", authors[0].ForeignID)
+	}
+	if authors[0].Description != "Author" {
+		t.Errorf("Description: want fallback description, got %q", authors[0].Description)
+	}
+	if authors[0].ImageURL != "https://example.com/jkr.jpg" {
+		t.Errorf("ImageURL: got %q", authors[0].ImageURL)
+	}
+}
+
 func TestSearchAuthors_Empty(t *testing.T) {
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
-		return gqlResponse(t, http.StatusOK, map[string]interface{}{"authors": []interface{}{}}), nil
+		assertSearchRequest(t, r, "Author", "nobody")
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{
+			"search": map[string]interface{}{
+				"results": map[string]interface{}{"found": 0, "hits": []interface{}{}},
+			},
+		}), nil
 	})
 
 	authors, err := c.SearchAuthors(context.Background(), "nobody")
@@ -200,6 +272,25 @@ func TestSearchAuthors_Empty(t *testing.T) {
 	}
 	if len(authors) != 0 {
 		t.Errorf("expected 0 authors, got %d", len(authors))
+	}
+}
+
+func TestSearchAuthors_BlankQuerySkipsAPI(t *testing.T) {
+	called := false
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		called = true
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{}), nil
+	})
+
+	authors, err := c.SearchAuthors(context.Background(), "   ")
+	if err != nil {
+		t.Fatalf("SearchAuthors: %v", err)
+	}
+	if len(authors) != 0 {
+		t.Fatalf("expected no authors, got %d", len(authors))
+	}
+	if called {
+		t.Fatal("expected blank query not to call API")
 	}
 }
 
@@ -221,19 +312,27 @@ func TestSearchAuthors_HTTPError(t *testing.T) {
 func TestSearchBooks_Success(t *testing.T) {
 	year := 2001
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		assertSearchRequest(t, r, "Book", "Mistborn")
 		data := map[string]interface{}{
-			"books": []map[string]interface{}{
-				{
-					"id":            42,
-					"title":         "Mistborn",
-					"slug":          "mistborn",
-					"description":   "A fantasy novel",
-					"release_year":  year,
-					"rating":        4.2,
-					"ratings_count": 8000,
-					"image":         map[string]interface{}{"url": "https://img.example.com/m.jpg"},
-					"contributions": []map[string]interface{}{
-						{"author": map[string]interface{}{"id": 1, "name": "Brandon Sanderson", "slug": "brandon-sanderson"}},
+			"search": map[string]interface{}{
+				"results": map[string]interface{}{
+					"found": 1,
+					"hits": []map[string]interface{}{
+						{
+							"document": map[string]interface{}{
+								"id":            42,
+								"title":         "Mistborn",
+								"slug":          "mistborn",
+								"description":   "A fantasy novel",
+								"release_year":  year,
+								"rating":        4.2,
+								"ratings_count": 8000,
+								"image":         map[string]interface{}{"url": "https://img.example.com/m.jpg"},
+								"contributions": []map[string]interface{}{
+									{"author": map[string]interface{}{"id": 1, "name": "Brandon Sanderson", "slug": "brandon-sanderson"}},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -269,6 +368,84 @@ func TestSearchBooks_Success(t *testing.T) {
 	}
 }
 
+func TestSearchBooks_ParsesStringResultsAndAuthorNames(t *testing.T) {
+	encoded := `{"found":1,"hits":[{"document":{"id":"312460","title":"Dune","slug":"dune","description":"A desert planet.","release_year":"1965","rating":"4.4","ratings_count":"12000","image_url":"https://img.example.com/dune.jpg","author_names":["Frank Herbert"]}}]}`
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		assertSearchRequest(t, r, "Book", "dune")
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{
+			"search": map[string]interface{}{"results": encoded},
+		}), nil
+	})
+
+	books, err := c.SearchBooks(context.Background(), "dune")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	book := books[0]
+	if book.ForeignID != "hc:dune" || book.Title != "Dune" {
+		t.Fatalf("unexpected book: %+v", book)
+	}
+	if book.ReleaseDate == nil || book.ReleaseDate.Year() != 1965 {
+		t.Errorf("ReleaseDate: expected year 1965, got %v", book.ReleaseDate)
+	}
+	if book.Author == nil || book.Author.Name != "Frank Herbert" || book.Author.ForeignID != "" {
+		t.Errorf("Author: %+v", book.Author)
+	}
+	if book.AverageRating != 4.4 || book.RatingsCount != 12000 {
+		t.Errorf("rating/count = %f/%d, want 4.4/12000", book.AverageRating, book.RatingsCount)
+	}
+}
+
+func TestSearchBooks_SkipsUnmappableHits(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		assertSearchRequest(t, r, "Book", "Dune")
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{
+			"search": map[string]interface{}{
+				"results": map[string]interface{}{
+					"found": 2,
+					"hits": []map[string]interface{}{
+						{"document": map[string]interface{}{"title": "No ID"}},
+						{"document": map[string]interface{}{"id": 42, "title": "Dune"}},
+					},
+				},
+			},
+		}), nil
+	})
+
+	books, err := c.SearchBooks(context.Background(), "Dune")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 mappable book, got %d", len(books))
+	}
+	if books[0].ForeignID != "hc:42" {
+		t.Errorf("ForeignID: want 'hc:42', got %q", books[0].ForeignID)
+	}
+}
+
+func TestSearchBooks_BlankQuerySkipsAPI(t *testing.T) {
+	called := false
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		called = true
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{}), nil
+	})
+
+	books, err := c.SearchBooks(context.Background(), "   ")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 0 {
+		t.Fatalf("expected no books, got %d", len(books))
+	}
+	if called {
+		t.Fatal("expected blank query not to call API")
+	}
+}
+
 func TestSearchBooks_HTTPError(t *testing.T) {
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -292,6 +469,12 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		var req gqlRequest
 		_ = json.Unmarshal(body, &req)
+		if strings.Contains(req.Query, "genres") {
+			t.Fatalf("query requested removed Hardcover books.genres field: %s", req.Query)
+		}
+		if strings.Contains(req.Query, "cached_tags") {
+			t.Fatalf("query requested Hardcover tags as genres: %s", req.Query)
+		}
 		gotVars = req.Variables
 		data := map[string]interface{}{
 			"books": []map[string]interface{}{
@@ -305,9 +488,6 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 					"ratings_count": 1000,
 					"rating":        4.5,
 					"users_count":   2000,
-					"genres":        []string{"Science Fiction"},
-					"has_audiobook": true,
-					"has_ebook":     false,
 					"audio_seconds": 7200,
 					"contributions": []map[string]interface{}{
 						{"author": map[string]interface{}{"id": 1, "name": "Frank Herbert", "slug": "frank-herbert"}},
@@ -338,7 +518,7 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 	if book.DurationSeconds != 7200 {
 		t.Fatalf("DurationSeconds = %d, want 7200", book.DurationSeconds)
 	}
-	if len(book.Genres) != 1 || book.Genres[0] != "Science Fiction" {
+	if len(book.Genres) != 0 {
 		t.Fatalf("Genres = %+v", book.Genres)
 	}
 	if book.MediaType != "" {
@@ -388,6 +568,41 @@ func TestGetAuthor_Found(t *testing.T) {
 	// ForeignID strips "hc:" for the query but toAuthor re-adds it
 	if author.ForeignID != "hc:neil-gaiman" {
 		t.Errorf("ForeignID: want 'hc:neil-gaiman', got %q", author.ForeignID)
+	}
+}
+
+func TestGetAuthor_NumericID(t *testing.T) {
+	var gotVars map[string]any
+	var gotQuery string
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		var req gqlRequest
+		_ = json.Unmarshal(body, &req)
+		gotQuery = req.Query
+		gotVars = req.Variables
+		data := map[string]interface{}{
+			"authors": []map[string]interface{}{
+				{"id": 5, "name": "Neil Gaiman", "slug": "neil-gaiman", "bio": "Writer", "image": nil},
+			},
+		}
+		return gqlResponse(t, http.StatusOK, data), nil
+	})
+
+	author, err := c.GetAuthor(context.Background(), "hc:5")
+	if err != nil {
+		t.Fatalf("GetAuthor: %v", err)
+	}
+	if author == nil || author.ForeignID != "hc:neil-gaiman" {
+		t.Fatalf("author = %+v, want slug-backed author", author)
+	}
+	if gotVars["id"] != float64(5) && gotVars["id"] != 5 {
+		t.Fatalf("id variable = %#v, want 5", gotVars["id"])
+	}
+	if _, ok := gotVars["slug"]; ok {
+		t.Fatalf("slug variable present for numeric lookup: %#v", gotVars["slug"])
+	}
+	if !strings.Contains(gotQuery, "id: {_eq: $id}") {
+		t.Fatalf("query did not use id lookup: %s", gotQuery)
 	}
 }
 
@@ -449,6 +664,48 @@ func TestGetBook_Found(t *testing.T) {
 	}
 	if book.ForeignID != "hc:american-gods" {
 		t.Errorf("ForeignID: want 'hc:american-gods', got %q", book.ForeignID)
+	}
+}
+
+func TestGetBook_NumericID(t *testing.T) {
+	var gotVars map[string]any
+	var gotQuery string
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		var req gqlRequest
+		_ = json.Unmarshal(body, &req)
+		gotQuery = req.Query
+		gotVars = req.Variables
+		data := map[string]interface{}{
+			"books": []map[string]interface{}{
+				{
+					"id":            99,
+					"title":         "American Gods",
+					"slug":          "american-gods",
+					"description":   "A novel about gods in America.",
+					"rating":        4.1,
+					"ratings_count": 12000,
+				},
+			},
+		}
+		return gqlResponse(t, http.StatusOK, data), nil
+	})
+
+	book, err := c.GetBook(context.Background(), "hc:99")
+	if err != nil {
+		t.Fatalf("GetBook: %v", err)
+	}
+	if book == nil || book.ForeignID != "hc:american-gods" {
+		t.Fatalf("book = %+v, want slug-backed book", book)
+	}
+	if gotVars["id"] != float64(99) && gotVars["id"] != 99 {
+		t.Fatalf("id variable = %#v, want 99", gotVars["id"])
+	}
+	if _, ok := gotVars["slug"]; ok {
+		t.Fatalf("slug variable present for numeric lookup: %#v", gotVars["slug"])
+	}
+	if !strings.Contains(gotQuery, "id: {_eq: $id}") {
+		t.Fatalf("query did not use id lookup: %s", gotQuery)
 	}
 }
 


### PR DESCRIPTION
This is PR 1 in a stacked series.

Stack:
1. This PR - Restore Hardcover API compatibility
2. vavallee/bindery#686 - Add Hardcover edition lookup
3. vavallee/bindery#691 - Harden Hardcover series and shelf mapping
4. vavallee/bindery#776 - Split Hardcover client responsibilities
5. vavallee/bindery#789 - Fix Hardcover import list sync reliability

This PR is based on `main` and should be reviewed first.

## Summary

Loading supplemental author data from Hardcover started failing because Hardcover removed fields from its GraphQL `books` shape and now blocks the `_ilike` search operations Bindery used. This restores the author enrichment path for issue #669 by moving search to Hardcover's current search operation and avoiding removed author-work fields. Issue #669 also revealed a newer Hardcover API result shape that unlocks better metadata possibilities, so I plan to add more enrichment work in future PRs.

- Replace Hardcover author and book `_ilike` queries with the documented `search(...)` operation.
- Parse current Hardcover search hit payloads into Bindery author and book models.
- Remove unsupported author-work fields from the supplemental author sync query.
- Support numeric Hardcover author/book IDs returned by the newer search payload.

Closes #669

## Checklist

- [x] Tests added or updated
- [x] N/A - `docs/DEPLOYMENT.md` unchanged; no env vars, config, or upgrade path changed
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] N/A - no wiki pages updated

## Test plan

- [x] `go test ./internal/metadata/hardcover`
- [x] `go test ./internal/metadata/...`
- [x] `go test ./cmd/... ./internal/...`
- [ ] `cd web && npm run build` - not run; Go metadata-only change
