### PR TITLE
chore(deploy-dev): update to sha-e87b831 [manual]

### DIFF
--- a/charts/bindery/values-dev.yaml
+++ b/charts/bindery/values-dev.yaml
@@ -1,2 +1,2 @@
 image:
-  tag: "sha-e73f636"
+  tag: "sha-e87b831"


### PR DESCRIPTION
Manual recovery for CI run 25982068772 — the workflow's `gh pr create` failed silently (no local git context, no `--repo` flag). Branch + file commit are correct; this PR completes the dev deploy.