### PR TITLE
fix(ci): add --repo to gh pr create/merge in deploy-dev job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,12 +247,21 @@ jobs:
               -f branch="${DEPLOY_BRANCH}"
           fi
 
+          # --repo is required because this job does not check out the
+          # repository, so gh has no local git context to infer the target
+          # from. Without it, `gh pr create` exits 1 with "not a git
+          # repository: .git" and the 2>/dev/null mask hides that error;
+          # the subsequent `gh pr merge` then fails for the same reason
+          # (and orphans the auto/dev-deploy-<sha> branch with the right
+          # content but no PR). The deploy-prod job below already has the
+          # --repo flag; this brings deploy-dev in line.
           gh pr create \
+            --repo "${GITHUB_REPOSITORY}" \
             --head "${DEPLOY_BRANCH}" \
             --base development \
             --title "chore(deploy-dev): update to ${IMAGE_TAG}" \
             --body "Automated dev deploy: image tag \`${IMAGE_TAG}\`." 2>/dev/null || true
-          gh pr merge "${DEPLOY_BRANCH}" --squash --admin --delete-branch
+          gh pr merge "${DEPLOY_BRANCH}" --repo "${GITHUB_REPOSITORY}" --squash --admin --delete-branch
           echo "bindery-dev image tag updated to ${IMAGE_TAG}"
 
       - name: Trigger ArgoCD dev refresh


### PR DESCRIPTION
## Summary
- Add `--repo "${GITHUB_REPOSITORY}"` to `gh pr create` and `gh pr merge` in the `deploy-dev` job.
- `deploy-prod` already has these flags; this brings `deploy-dev` in line.

## Why this is needed
The `deploy-dev` job has no `actions/checkout` step, so `gh` CLI has no local git context to infer the target repo from. Without `--repo`:

1. `gh pr create` exits 1 with `not a git repository: .git`
2. The `2>/dev/null || true` swallows the failure silently
3. `gh pr merge` then fails for the same reason
4. The auto-deploy branch (`auto/dev-deploy-<sha>`) is left orphaned on the remote with the correct content, but no PR was opened or merged
5. ArgoCD never sees the new image tag → bindery-dev never updates

## Past incidents
- CI run [25982068772](https://github.com/vavallee/bindery/actions/runs/25982068772) (issue #667 dev deploy) — recovered manually via PR #673
- CI run 25904633451 (v1.11.1 prod deploy) — `auto/prod-deploy-1.11.1` branch is still orphaned, prod is stuck on `1.11.0`

## Test plan
- [ ] Next push to `development` should run the `deploy-dev` job to completion
- [ ] An auto-deploy PR should appear, get squash-merged automatically, and the branch deleted
- [ ] ArgoCD `bindery-dev` should sync to the new image tag without manual intervention