### PR TITLE
chore(release): bindery v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,16 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.12.0] — 2026-05-18
+
 ### Added
 
-- **Calibre metadata handoff** — Calibre pushes now carry Bindery book, author, edition, series, identifier, language, rating, description, and cover metadata through both `calibredb` and metadata-capable Bindery Bridge plugin syncs, with legacy plugin fallback preserved.
+- **Calibre metadata handoff** (#668) — Calibre pushes now carry Bindery book, author, edition, series, identifier, language, rating, description, and cover metadata through both `calibredb` and metadata-capable Bindery Bridge plugin syncs, with legacy plugin fallback preserved.
 
 ### Fixed
 
-- **qBittorrent imports recover from mismatched container paths without re-downloading** — Download clients now support per-client path remaps, qBittorrent grabs are sent with the expected category save path, and Settings surfaces qBittorrent category path health warnings. Queue items stuck in `importFailed` can also be retried after fixing storage/path settings.
-- **Calibre ID reuse** — Plugin sync no longer reuses a stored source-library Calibre ID when pushing into a different Calibre library.
+- **qBittorrent imports recover from mismatched container paths without re-downloading** (#641) — Download clients now support per-client path remaps, qBittorrent grabs are sent with the expected category save path, and Settings surfaces qBittorrent category path health warnings. Queue items stuck in `importFailed` can also be retried after fixing storage/path settings.
+- **Calibre ID reuse** (#668) — Plugin sync no longer reuses a stored source-library Calibre ID when pushing into a different Calibre library.
 - **Hardcover supplemental author sync restored** (#669) — Hardcover removed fields from its GraphQL `books` shape and blocked `_ilike` searches, causing author page enrichment to fail with validation or 403 errors. Bindery now uses Hardcover's current search operation and avoids the removed author-work fields.
 
 ## [v1.11.2] — 2026-05-17

--- a/charts/bindery/Chart.yaml
+++ b/charts/bindery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bindery
 description: Automated book download manager for Usenet and Torrents
 type: application
-version: 0.6.0
-appVersion: "1.11.0"
+version: 0.7.0
+appVersion: "1.12.0"
 home: https://github.com/vavallee/bindery
 sources:
   - https://github.com/vavallee/bindery

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindery-web",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Bump `appVersion` to 1.12.0 (chart `0.7.0`, web `1.12.0`)
- Finalize CHANGELOG `[v1.12.0]` section dated 2026-05-18

## Ships

- **Calibre metadata handoff** (#668) — full metadata passed to calibredb + plugin
- **qBittorrent path-remap recovery** (#641) — per-client remaps + category save-path + importFailed retry
- **Calibre cross-library ID guard** (#668) — plugin sync no longer reuses source-library calibre_id
- **Hardcover API compatibility** (#672, closes #669) — `_ilike` → `search` op + dropped removed fields

## Test plan

- [x] `go build ./...`
- [x] `cd web && npm run build`