### PR TITLE
feat(metadata): add Hardcover edition lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **Hardcover edition metadata lookup** — Hardcover-backed books can now return edition-level metadata, including ISBNs, ASINs, publisher, format, page count, cover, language, and audiobook duration, using Hardcover's current editions query shape.
+
 ## [v1.12.0] — 2026-05-18
 
 ### Added

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -25,6 +25,8 @@ const (
 
 	authorWorksPageSize = 100
 	authorWorksMaxBooks = 500
+	editionsPageSize    = 100
+	editionsMaxCount    = 1000
 
 	hardcoverSuccessResponseBodyLimit = 8 << 20
 )
@@ -313,15 +315,95 @@ func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, e
 	return &b, nil
 }
 
-// GetEditions is not supported by Hardcover.
-func (c *Client) GetEditions(_ context.Context, _ string) ([]models.Edition, error) {
-	return nil, nil
+func (c *Client) GetEditions(ctx context.Context, bookForeignID string) ([]models.Edition, error) {
+	id := strings.TrimSpace(strings.TrimPrefix(bookForeignID, idPrefix))
+	if id == "" {
+		return nil, nil
+	}
+
+	gql := `query GetEditions($slug: String!, $limit: Int!, $offset: Int!) {
+		editions(
+			where: {book: {slug: {_eq: $slug}}},
+			limit: $limit,
+			offset: $offset,
+			order_by: {id: asc}
+		) {
+			id
+			title
+			isbn_10
+			isbn_13
+			asin
+			publisher { name }
+			release_date
+			release_year
+			physical_format
+			edition_format
+			edition_information
+			pages
+			image { url }
+			language { language }
+			reading_format { format }
+			audio_seconds
+			book { title }
+		}
+	}`
+	vars := map[string]any{"slug": id}
+	if numericID, ok := hardcoverNumericID(id); ok {
+		gql = `query GetEditions($bookID: Int!, $limit: Int!, $offset: Int!) {
+		editions(
+			where: {book_id: {_eq: $bookID}},
+			limit: $limit,
+			offset: $offset,
+			order_by: {id: asc}
+		) {
+			id
+			title
+			isbn_10
+			isbn_13
+			asin
+			publisher { name }
+			release_date
+			release_year
+			physical_format
+			edition_format
+			edition_information
+			pages
+			image { url }
+			language { language }
+			reading_format { format }
+			audio_seconds
+			book { title }
+		}
+	}`
+		vars = map[string]any{"bookID": numericID}
+	}
+
+	editions := make([]models.Edition, 0, editionsPageSize)
+	for offset := 0; offset < editionsMaxCount; offset += editionsPageSize {
+		vars["limit"] = editionsPageSize
+		vars["offset"] = offset
+		var resp struct {
+			Data struct {
+				Editions []hcEdition `json:"editions"`
+			} `json:"data"`
+		}
+		if err := c.query(ctx, gql, vars, &resp); err != nil {
+			return nil, fmt.Errorf("hardcover get editions: %w", err)
+		}
+		for _, e := range resp.Data.Editions {
+			editions = append(editions, hardcoverEditionToModel(e))
+		}
+		if len(resp.Data.Editions) < editionsPageSize {
+			break
+		}
+	}
+	return editions, nil
 }
 
 func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, error) {
 	gql := `query GetBookByISBN($isbn: String!) {
 		editions(where: {_or: [{isbn_10: {_eq: $isbn}}, {isbn_13: {_eq: $isbn}}]}, limit: 1) {
-			language { iso_639_1 }
+			language { language }
 			book {
 				id
 				title
@@ -353,8 +435,8 @@ func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, 
 	}
 	ed := resp.Data.Editions[0]
 	b := c.toBook(ed.Book)
-	if ed.Language != nil && ed.Language.ISO6391 != "" {
-		b.Language = ed.Language.ISO6391
+	if language := hardcoverLanguageName(ed.Language); language != "" {
+		b.Language = language
 	}
 	return &b, nil
 }
@@ -699,7 +781,15 @@ type hcImage struct {
 }
 
 type hcLanguage struct {
-	ISO6391 string `json:"iso_639_1"`
+	Language string `json:"language"`
+}
+
+type hcPublisher struct {
+	Name string `json:"name"`
+}
+
+type hcReadingFormat struct {
+	Format string `json:"format"`
 }
 
 type hcAuthor struct {
@@ -729,6 +819,28 @@ type hcBook struct {
 	AudioSeconds  *int             `json:"audio_seconds"`
 	Contributions []hcContribution `json:"contributions"`
 	AuthorNames   []string         `json:"author_names"`
+}
+
+type hcEdition struct {
+	ID                 int              `json:"id"`
+	Title              string           `json:"title"`
+	ISBN10             string           `json:"isbn_10"`
+	ISBN13             string           `json:"isbn_13"`
+	ASIN               string           `json:"asin"`
+	Publisher          *hcPublisher     `json:"publisher"`
+	ReleaseDate        string           `json:"release_date"`
+	ReleaseYear        *int             `json:"release_year"`
+	PhysicalFormat     string           `json:"physical_format"`
+	EditionFormat      string           `json:"edition_format"`
+	EditionInformation string           `json:"edition_information"`
+	Pages              *int             `json:"pages"`
+	Image              *hcImage         `json:"image"`
+	Language           *hcLanguage      `json:"language"`
+	ReadingFormat      *hcReadingFormat `json:"reading_format"`
+	AudioSeconds       *int             `json:"audio_seconds"`
+	Book               *struct {
+		Title string `json:"title"`
+	} `json:"book"`
 }
 
 type hcAuthorSearchEnvelope struct {
@@ -1041,6 +1153,179 @@ func (c *Client) toBook(b hcBook) models.Book {
 		}
 	}
 	return bk
+}
+
+func hardcoverEditionToModel(e hcEdition) models.Edition {
+	title := strings.TrimSpace(e.Title)
+	if title == "" && e.Book != nil {
+		title = strings.TrimSpace(e.Book.Title)
+	}
+	format := firstNonEmpty(e.PhysicalFormat, e.EditionFormat, hardcoverReadingFormat(e))
+	ed := models.Edition{
+		ForeignID:   idPrefix + strconv.Itoa(e.ID),
+		Title:       title,
+		Publisher:   hardcoverPublisherName(e.Publisher),
+		PublishDate: parseHardcoverEditionDate(e.ReleaseDate, e.ReleaseYear),
+		Format:      format,
+		NumPages:    positiveIntPtr(e.Pages),
+		Language:    hardcoverLanguageName(e.Language),
+		ImageURL:    hardcoverImageURL(e.Image),
+		IsEbook:     hardcoverEditionIsEbook(format, hardcoverReadingFormat(e)),
+		EditionInfo: strings.TrimSpace(e.EditionInformation),
+		Monitored:   true,
+	}
+	ed.ISBN10 = nonEmptyStringPtr(e.ISBN10)
+	ed.ISBN13 = nonEmptyStringPtr(e.ISBN13)
+	ed.ASIN = nonEmptyStringPtr(e.ASIN)
+	return ed
+}
+
+func parseHardcoverEditionDate(releaseDate string, releaseYear *int) *time.Time {
+	releaseDate = strings.TrimSpace(releaseDate)
+	if releaseDate != "" {
+		for _, layout := range []string{"2006-01-02", time.RFC3339} {
+			t, err := time.Parse(layout, releaseDate)
+			if err == nil {
+				return &t
+			}
+		}
+	}
+	if releaseYear != nil && *releaseYear > 0 {
+		t := time.Date(*releaseYear, 1, 1, 0, 0, 0, 0, time.UTC)
+		return &t
+	}
+	return nil
+}
+
+func hardcoverEditionIsEbook(values ...string) bool {
+	for _, value := range values {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		if normalized == "" {
+			continue
+		}
+		if strings.Contains(normalized, "ebook") ||
+			strings.Contains(normalized, "e-book") ||
+			strings.Contains(normalized, "kindle") {
+			return true
+		}
+	}
+	return false
+}
+
+func hardcoverReadingFormat(e hcEdition) string {
+	if e.ReadingFormat == nil {
+		return ""
+	}
+	return strings.TrimSpace(e.ReadingFormat.Format)
+}
+
+func hardcoverPublisherName(publisher *hcPublisher) string {
+	if publisher == nil {
+		return ""
+	}
+	return strings.TrimSpace(publisher.Name)
+}
+
+func hardcoverLanguageName(language *hcLanguage) string {
+	if language == nil {
+		return ""
+	}
+	code := strings.ToLower(strings.TrimSpace(language.Language))
+	if code == "" {
+		return ""
+	}
+	if mapped, ok := hardcoverLanguageAliases[code]; ok {
+		return mapped
+	}
+	return code
+}
+
+var hardcoverLanguageAliases = map[string]string{
+	"english":    "eng",
+	"en":         "eng",
+	"german":     "ger",
+	"de":         "ger",
+	"deu":        "ger",
+	"french":     "fre",
+	"fr":         "fre",
+	"fra":        "fre",
+	"spanish":    "spa",
+	"es":         "spa",
+	"italian":    "ita",
+	"it":         "ita",
+	"dutch":      "dut",
+	"nl":         "dut",
+	"nld":        "dut",
+	"portuguese": "por",
+	"pt":         "por",
+	"japanese":   "jpn",
+	"ja":         "jpn",
+	"russian":    "rus",
+	"ru":         "rus",
+	"chinese":    "chi",
+	"zh":         "chi",
+	"danish":     "dan",
+	"da":         "dan",
+	"swedish":    "swe",
+	"sv":         "swe",
+	"norwegian":  "nor",
+	"no":         "nor",
+	"polish":     "pol",
+	"pl":         "pol",
+	"finnish":    "fin",
+	"fi":         "fin",
+	"hindi":      "hin",
+	"hi":         "hin",
+	"turkish":    "tur",
+	"tr":         "tur",
+	"arabic":     "ara",
+	"ar":         "ara",
+	"korean":     "kor",
+	"ko":         "kor",
+	"czech":      "cze",
+	"cs":         "cze",
+	"greek":      "gre",
+	"el":         "gre",
+	"hungarian":  "hun",
+	"hu":         "hun",
+	"romanian":   "rum",
+	"ro":         "rum",
+	"catalan":    "cat",
+	"ca":         "cat",
+	"latin":      "lat",
+	"la":         "lat",
+}
+
+func hardcoverImageURL(image *hcImage) string {
+	if image == nil {
+		return ""
+	}
+	return strings.TrimSpace(image.URL)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func nonEmptyStringPtr(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func positiveIntPtr(value *int) *int {
+	if value == nil || *value <= 0 {
+		return nil
+	}
+	n := *value
+	return &n
 }
 
 func sortName(name string) string {

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -723,14 +723,261 @@ func TestGetBook_NotFound(t *testing.T) {
 	}
 }
 
-func TestGetEditions_AlwaysNil(t *testing.T) {
-	c := New()
-	editions, err := c.GetEditions(context.Background(), "any-id")
+func TestGetEditions_MapsGraphQLResponse(t *testing.T) {
+	var gotQuery string
+	var gotVars map[string]any
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		var req gqlRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotQuery = req.Query
+		gotVars = req.Variables
+		data := map[string]interface{}{
+			"editions": []map[string]interface{}{
+				{
+					"id":                  123,
+					"title":               "Dune Deluxe",
+					"isbn_10":             "0441172717",
+					"isbn_13":             "9780441172719",
+					"asin":                "B0036S4B2G",
+					"publisher":           map[string]interface{}{"name": "Ace Books"},
+					"release_date":        "1965-08-01",
+					"release_year":        1965,
+					"physical_format":     "Hardcover",
+					"edition_format":      "Anniversary Edition",
+					"edition_information": "50th anniversary",
+					"pages":               412,
+					"image":               map[string]interface{}{"url": "https://img.example/dune.jpg"},
+					"language":            map[string]interface{}{"language": "English"},
+					"reading_format":      map[string]interface{}{"format": "Physical"},
+					"book":                map[string]interface{}{"title": "Dune"},
+				},
+			},
+		}
+		return gqlResponse(t, http.StatusOK, data), nil
+	})
+
+	editions, err := c.GetEditions(context.Background(), "hc:dune")
 	if err != nil {
 		t.Fatalf("GetEditions: %v", err)
 	}
-	if editions != nil {
-		t.Errorf("expected nil, got %v", editions)
+	if len(editions) != 1 {
+		t.Fatalf("expected 1 edition, got %d", len(editions))
+	}
+	if strings.Contains(gotQuery, "iso_639_1") {
+		t.Fatalf("GetEditions query uses unsupported language field: %s", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "book: {slug: {_eq: $slug}}") {
+		t.Fatalf("GetEditions slug query did not filter by book slug: %s", gotQuery)
+	}
+	if gotVars["slug"] != "dune" {
+		t.Fatalf("slug variable = %#v, want dune", gotVars["slug"])
+	}
+	if gotVars["limit"] != float64(editionsPageSize) {
+		t.Fatalf("limit variable = %#v, want %d", gotVars["limit"], editionsPageSize)
+	}
+	if gotVars["offset"] != float64(0) {
+		t.Fatalf("offset variable = %#v, want 0", gotVars["offset"])
+	}
+	e := editions[0]
+	if e.ForeignID != "hc:123" {
+		t.Errorf("ForeignID = %q, want hc:123", e.ForeignID)
+	}
+	if e.Title != "Dune Deluxe" {
+		t.Errorf("Title = %q, want Dune Deluxe", e.Title)
+	}
+	if e.ISBN10 == nil || *e.ISBN10 != "0441172717" {
+		t.Errorf("ISBN10 = %v, want 0441172717", e.ISBN10)
+	}
+	if e.ISBN13 == nil || *e.ISBN13 != "9780441172719" {
+		t.Errorf("ISBN13 = %v, want 9780441172719", e.ISBN13)
+	}
+	if e.ASIN == nil || *e.ASIN != "B0036S4B2G" {
+		t.Errorf("ASIN = %v, want B0036S4B2G", e.ASIN)
+	}
+	if e.Publisher != "Ace Books" {
+		t.Errorf("Publisher = %q, want Ace Books", e.Publisher)
+	}
+	if e.PublishDate == nil || e.PublishDate.Format("2006-01-02") != "1965-08-01" {
+		t.Errorf("PublishDate = %v, want 1965-08-01", e.PublishDate)
+	}
+	if e.Format != "Hardcover" {
+		t.Errorf("Format = %q, want Hardcover", e.Format)
+	}
+	if e.NumPages == nil || *e.NumPages != 412 {
+		t.Errorf("NumPages = %v, want 412", e.NumPages)
+	}
+	if e.ImageURL != "https://img.example/dune.jpg" {
+		t.Errorf("ImageURL = %q, want cover URL", e.ImageURL)
+	}
+	if e.Language != "eng" {
+		t.Errorf("Language = %q, want eng", e.Language)
+	}
+	if e.EditionInfo != "50th anniversary" {
+		t.Errorf("EditionInfo = %q, want 50th anniversary", e.EditionInfo)
+	}
+	if !e.Monitored {
+		t.Error("Monitored = false, want true")
+	}
+	if e.IsEbook {
+		t.Error("IsEbook = true, want false")
+	}
+}
+
+func TestGetEditions_FormatFallbacks(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		data := map[string]interface{}{
+			"editions": []map[string]interface{}{
+				{
+					"id":             124,
+					"title":          "",
+					"release_year":   2021,
+					"edition_format": "Kindle Edition",
+					"reading_format": map[string]interface{}{"format": "Ebook"},
+					"book":           map[string]interface{}{"title": "Dune"},
+				},
+				{
+					"id":             125,
+					"title":          "Dune Audio",
+					"reading_format": map[string]interface{}{"format": "Audiobook"},
+					"audio_seconds":  3600,
+				},
+			},
+		}
+		return gqlResponse(t, http.StatusOK, data), nil
+	})
+
+	editions, err := c.GetEditions(context.Background(), "hc:dune")
+	if err != nil {
+		t.Fatalf("GetEditions: %v", err)
+	}
+	if len(editions) != 2 {
+		t.Fatalf("expected 2 editions, got %d", len(editions))
+	}
+	ebook := editions[0]
+	if ebook.Title != "Dune" {
+		t.Errorf("fallback title = %q, want Dune", ebook.Title)
+	}
+	if ebook.Format != "Kindle Edition" {
+		t.Errorf("ebook Format = %q, want Kindle Edition", ebook.Format)
+	}
+	if !ebook.IsEbook {
+		t.Error("Kindle edition should be marked as ebook")
+	}
+	if ebook.PublishDate == nil || ebook.PublishDate.Format("2006-01-02") != "2021-01-01" {
+		t.Errorf("PublishDate = %v, want 2021-01-01", ebook.PublishDate)
+	}
+	audio := editions[1]
+	if audio.Format != "Audiobook" {
+		t.Errorf("audio Format = %q, want Audiobook", audio.Format)
+	}
+	if audio.IsEbook {
+		t.Error("audiobook should not be marked as ebook")
+	}
+}
+
+func TestGetEditions_NumericIDUsesBookID(t *testing.T) {
+	var gotQuery string
+	var gotVars map[string]any
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		var req gqlRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotQuery = req.Query
+		gotVars = req.Variables
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{"editions": []interface{}{}}), nil
+	})
+
+	editions, err := c.GetEditions(context.Background(), "hc:312460")
+	if err != nil {
+		t.Fatalf("GetEditions: %v", err)
+	}
+	if len(editions) != 0 {
+		t.Fatalf("expected no editions, got %d", len(editions))
+	}
+	if gotVars["bookID"] != float64(312460) {
+		t.Fatalf("bookID variable = %#v, want 312460", gotVars["bookID"])
+	}
+	if _, ok := gotVars["slug"]; ok {
+		t.Fatalf("slug variable present for numeric lookup: %#v", gotVars["slug"])
+	}
+	if !strings.Contains(gotQuery, "book_id: {_eq: $bookID}") {
+		t.Fatalf("query did not use book_id lookup: %s", gotQuery)
+	}
+	if strings.Contains(gotQuery, "iso_639_1") {
+		t.Fatalf("GetEditions query uses unsupported language field: %s", gotQuery)
+	}
+}
+
+func TestGetEditions_Paginates(t *testing.T) {
+	var offsets []int
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		var req gqlRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		offset := int(req.Variables["offset"].(float64))
+		offsets = append(offsets, offset)
+		count := editionsPageSize
+		if offset > 0 {
+			count = 1
+		}
+		editions := make([]map[string]interface{}, 0, count)
+		for i := 0; i < count; i++ {
+			editions = append(editions, map[string]interface{}{
+				"id":    offset + i + 1,
+				"title": "Edition",
+			})
+		}
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{"editions": editions}), nil
+	})
+
+	editions, err := c.GetEditions(context.Background(), "hc:dune")
+	if err != nil {
+		t.Fatalf("GetEditions: %v", err)
+	}
+	if len(editions) != editionsPageSize+1 {
+		t.Fatalf("edition count = %d, want %d", len(editions), editionsPageSize+1)
+	}
+	if len(offsets) != 2 || offsets[0] != 0 || offsets[1] != editionsPageSize {
+		t.Fatalf("offsets = %v, want [0 %d]", offsets, editionsPageSize)
+	}
+}
+
+func TestGetEditions_GraphQLError(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		return gqlResponse(t, http.StatusOK, `{"errors":[{"message":"field not found"}]}`), nil
+	})
+
+	_, err := c.GetEditions(context.Background(), "hc:dune")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "hardcover get editions") {
+		t.Fatalf("error = %v, want hardcover get editions wrapper", err)
+	}
+}
+
+func TestGetEditions_HTTPError(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader("forbidden")),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	_, err := c.GetEditions(context.Background(), "hc:dune")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "hardcover get editions") {
+		t.Fatalf("error = %v, want hardcover get editions wrapper", err)
 	}
 }
 
@@ -763,11 +1010,18 @@ func TestGetBookByISBN_Found(t *testing.T) {
 }
 
 func TestGetBookByISBN_WithLanguage(t *testing.T) {
+	var gotQuery string
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		var req gqlRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		gotQuery = req.Query
 		data := map[string]interface{}{
 			"editions": []map[string]interface{}{
 				{
-					"language": map[string]interface{}{"iso_639_1": "de"},
+					"language": map[string]interface{}{"language": "German"},
 					"book": map[string]interface{}{
 						"id":    88,
 						"title": "Der Herr der Ringe",
@@ -786,8 +1040,14 @@ func TestGetBookByISBN_WithLanguage(t *testing.T) {
 	if book == nil {
 		t.Fatal("expected non-nil book")
 	}
-	if book.Language != "de" {
-		t.Errorf("Language: want 'de', got %q", book.Language)
+	if strings.Contains(gotQuery, "iso_639_1") {
+		t.Fatalf("GetBookByISBN query uses unsupported language field: %s", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "language { language }") {
+		t.Fatalf("GetBookByISBN query did not request language field: %s", gotQuery)
+	}
+	if book.Language != "ger" {
+		t.Errorf("Language: want 'ger', got %q", book.Language)
 	}
 }
 
@@ -1385,6 +1645,28 @@ func TestHcShelfStatusID(t *testing.T) {
 	}
 	if _, ok := hcShelfStatusID(42); ok {
 		t.Error("hcShelfStatusID(42) should return false")
+	}
+}
+
+func TestHardcoverLanguageName_NormalizesNamesAndCodes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   *hcLanguage
+		want string
+	}{
+		{name: "nil", in: nil, want: ""},
+		{name: "blank", in: &hcLanguage{Language: " "}, want: ""},
+		{name: "english name", in: &hcLanguage{Language: "English"}, want: "eng"},
+		{name: "german name", in: &hcLanguage{Language: "German"}, want: "ger"},
+		{name: "two letter code", in: &hcLanguage{Language: "de"}, want: "ger"},
+		{name: "three letter code", in: &hcLanguage{Language: "fre"}, want: "fre"},
+		{name: "unknown", in: &hcLanguage{Language: "Klingon"}, want: "klingon"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hardcoverLanguageName(tc.in); got != tc.want {
+				t.Errorf("hardcoverLanguageName(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This is PR 2 in a stacked series.

Stack:
1. vavallee/bindery#672 - Restore Hardcover API compatibility
2. This PR - Add Hardcover edition lookup
3. vavallee/bindery#691 - Harden Hardcover series and shelf mapping
4. vavallee/bindery#776 - Split Hardcover client responsibilities
5. vavallee/bindery#789 - Fix Hardcover import list sync reliability

This PR is based on `main` and should be reviewed after vavallee/bindery#672.

## Summary

Hardcover's current API exposes edition metadata in a usable shape, and the compatibility work in the preceding PR makes it practical to consume that data. This PR adds Hardcover edition lookup so Bindery can enrich books with edition-level identifiers and format details.

- Implement `GetEditions` for Hardcover-backed books.
- Map Hardcover edition ISBN, ASIN, publisher, format, page count, cover, language, and audiobook duration fields into Bindery edition models.
- Support slug and numeric Hardcover book IDs for edition lookup.
- Update Hardcover ISBN language mapping to use the current language field shape.

## Checklist

- [x] Tests added or updated
- [x] N/A - `docs/DEPLOYMENT.md` unchanged; no env vars, config, or upgrade path changed
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] N/A - no wiki pages updated

## Test plan

- [x] `go test ./internal/metadata/hardcover`
- [x] `go test ./internal/metadata/...`
- [x] `go test ./cmd/... ./internal/...`
- [ ] `cd web && npm run build` - not run; Go metadata-only change
