### PR TITLE
fix(indexer): fall through tier 1 when indexer returns a canned category feed

### DIFF
--- a/internal/indexer/debug.go
+++ b/internal/indexer/debug.go
@@ -197,9 +197,9 @@ func filterUsenetJunkDebug(results []newznab.SearchResult) ([]newznab.SearchResu
 func filterRelevantDebug(results []newznab.SearchResult, title, author string, aliases []string) ([]newznab.SearchResult, []FilterDebug) {
 	// Strip possessive author prefix before keyword extraction (mirrors filterRelevant).
 	title = stripPossessivePrefix(title, author)
-	fullKws := sigWords(title)
-	primaryKws := sigWords(primaryTitle(title))
-	authorKws := sigWords(author)
+	fullKws := newznab.SigWords(title)
+	primaryKws := newznab.SigWords(primaryTitle(title))
+	authorKws := newznab.SigWords(author)
 	surname := AuthorSurname(author)
 
 	authorTokenSets := [][]string{authorTokens(author)}

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -139,10 +139,19 @@ func (c *Client) BookSearch(ctx context.Context, title, author string, categorie
 			slog.Debug("indexer query", "tier", 1, "url", redactAPIKey(u))
 			var rss rssResponse
 			if err := c.getXML(ctx, u, &rss); err == nil && len(rss.Channel.Items) > 0 && rss.Channel.Response.Total < 1000 {
-				slog.Debug("indexer query tier matched", "tier", 1, "count", len(rss.Channel.Items))
-				return c.parseResults(rss.Channel.Items), nil
+				parsed := c.parseResults(rss.Channel.Items)
+				if titleHasRelevantResult(queryTitle, parsed) {
+					slog.Debug("indexer query tier matched", "tier", 1, "count", len(parsed))
+					return parsed, nil
+				}
+				// Indexer returned a fixed category feed that ignored title/author
+				// (Jackett/AudioBookBay pattern). Fall through to text-search tiers.
+				slog.Debug("indexer query tier 1 canned feed, falling through",
+					"count", len(parsed),
+					"words_checked", SigWords(queryTitle))
+			} else {
+				slog.Debug("indexer query tier fallthrough", "tier", 1, "items", len(rss.Channel.Items))
 			}
-			slog.Debug("indexer query tier fallthrough", "tier", 1, "items", len(rss.Channel.Items))
 		}
 	}
 
@@ -229,6 +238,27 @@ func authorSurname(author string) string {
 		return ""
 	}
 	return fields[len(fields)-1]
+}
+
+// titleHasRelevantResult returns true when at least one result's title
+// contains at least one significant word from queryTitle (as determined by
+// SigWords). A false return means the indexer likely returned a fixed
+// category feed that ignored the search params (Jackett/AudioBookBay
+// pattern), so callers should fall through to text-search tiers.
+func titleHasRelevantResult(queryTitle string, results []SearchResult) bool {
+	words := SigWords(queryTitle)
+	if len(words) == 0 {
+		return true // query has no checkable words; assume results are valid
+	}
+	for _, r := range results {
+		combined := strings.ToLower(r.Title + " " + r.BookTitle)
+		for _, w := range words {
+			if strings.Contains(combined, w) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Test verifies the indexer is reachable and the API key is valid.

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -721,3 +721,125 @@ func TestPrimaryTitleForQuery_NormalizesAndDropsSubtitle(t *testing.T) {
 		}
 	}
 }
+
+func TestSigWords(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"Life Ascending", []string{"life", "ascending"}},
+		{"Dark Matter", []string{"dark", "matter"}},
+		// stopwords and short words excluded
+		{"The It", nil},
+		// 3-char minimum: "war" included, "it" excluded
+		{"It War", []string{"war"}},
+		// stopword excluded even at sufficient length
+		{"the and for", nil},
+		// apostrophe stripped: "Ender's" → "enders"
+		{"Ender's Game", []string{"enders", "game"}},
+		// German umlaut transliteration
+		{"Märchen", []string{"maerchen"}},
+	}
+	for _, c := range cases {
+		got := SigWords(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("SigWords(%q) = %v, want %v", c.in, got, c.want)
+			continue
+		}
+		for i, w := range c.want {
+			if got[i] != w {
+				t.Errorf("SigWords(%q)[%d] = %q, want %q", c.in, i, got[i], w)
+			}
+		}
+	}
+}
+
+func TestTitleHasRelevantResult(t *testing.T) {
+	matching := []SearchResult{
+		{Title: "Nick.Lane.Life.Ascending.Evolution", BookTitle: ""},
+	}
+	canned := []SearchResult{
+		{Title: "Stephen.King.It", BookTitle: ""},
+		{Title: "Neil.Gaiman.Good.Omens", BookTitle: ""},
+	}
+
+	if !titleHasRelevantResult("Life Ascending", matching) {
+		t.Error("expected true for results containing 'life' and 'ascending'")
+	}
+	if titleHasRelevantResult("Life Ascending", canned) {
+		t.Error("expected false for canned results that don't contain query words")
+	}
+	// Empty query words (all stopwords/short) → always valid
+	if !titleHasRelevantResult("The It", canned) {
+		t.Error("expected true when query has no significant words")
+	}
+	// BookTitle field is also checked
+	withBookTitle := []SearchResult{{Title: "random release", BookTitle: "Life Ascending"}}
+	if !titleHasRelevantResult("Life Ascending", withBookTitle) {
+		t.Error("expected true when BookTitle contains query word")
+	}
+}
+
+// TestBookSearch_Tier1FallsBackOnCannedFeed simulates a Jackett/AudioBookBay
+// indexer that always returns the same canned category results for t=book
+// regardless of the title/author params. The canned results do not contain
+// any significant word from the search title, so tier 1 should be rejected
+// and the search should fall through to tier 2 (surname + title).
+func TestBookSearch_Tier1FallsBackOnCannedFeed(t *testing.T) {
+	var queries []url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.Query())
+		w.Header().Set("Content-Type", "application/xml")
+		q := r.URL.Query()
+		if q.Get("t") == "book" {
+			// Canned feed: results that have nothing to do with the query.
+			w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
+  <channel>
+    <newznab:response offset="0" total="18"/>
+    <item><title>Stephen.King.It.mp3</title><guid isPermaLink="true">canned-1</guid>
+      <enclosure url="https://example.com/canned-1" length="1" type="application/x-nzb"/>
+    </item>
+    <item><title>Neil.Gaiman.Good.Omens.epub</title><guid isPermaLink="true">canned-2</guid>
+      <enclosure url="https://example.com/canned-2" length="1" type="application/x-nzb"/>
+    </item>
+  </channel>
+</rss>`))
+			return
+		}
+		// Tier 2: q="Lane Life Ascending" — return a relevant result.
+		if q.Get("t") == "search" && strings.Contains(q.Get("q"), "Lane") {
+			w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
+  <channel>
+    <newznab:response offset="0" total="1"/>
+    <item><title>Nick.Lane.Life.Ascending.epub</title><guid isPermaLink="true">relevant-1</guid>
+      <enclosure url="https://example.com/relevant-1" length="1" type="application/x-nzb"/>
+    </item>
+  </channel>
+</rss>`))
+			return
+		}
+		w.Write([]byte(`<?xml version="1.0"?><rss xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/"><channel><newznab:response total="0"/></channel></rss>`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "testkey")
+	results, err := c.BookSearch(context.Background(), "Life Ascending", "Nick Lane", []int{7020})
+	if err != nil {
+		t.Fatalf("BookSearch: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 relevant result, got %d", len(results))
+	}
+	if results[0].Title != "Nick.Lane.Life.Ascending.epub" {
+		t.Errorf("unexpected result title %q", results[0].Title)
+	}
+	// Tier 1 must have been tried (t=book) then rejected, so at least 2 requests total.
+	if len(queries) < 2 {
+		t.Fatalf("expected at least 2 requests (tier 1 + tier 2), got %d", len(queries))
+	}
+	if queries[0].Get("t") != "book" {
+		t.Errorf("expected first request to be t=book, got t=%s", queries[0].Get("t"))
+	}
+}

--- a/internal/indexer/newznab/words.go
+++ b/internal/indexer/newznab/words.go
@@ -1,0 +1,39 @@
+package newznab
+
+import "strings"
+
+// stopWords are common English words excluded from keyword significance checks.
+// Must stay in sync with the set used by filterRelevant in the indexer package.
+var stopWords = map[string]bool{
+	"the": true, "a": true, "an": true, "and": true, "or": true,
+	"of": true, "in": true, "to": true, "by": true, "for": true,
+	"with": true, "at": true, "from": true, "is": true, "it": true,
+	"as": true, "on": true, "be": true,
+}
+
+// SigWords returns the meaningful (non-stop, 3+ char) words from s.
+// Apostrophes are stripped so "Ender's" produces the token "enders",
+// matching the apostrophe-free form used in most release names.
+// German umlauts are transliterated (ä→ae etc.) to match NormalizeRelease.
+func SigWords(s string) []string {
+	var out []string
+	for _, w := range strings.Fields(strings.ToLower(s)) {
+		w = strings.ReplaceAll(w, "'", "")
+		w = transliterateUmlauts(w)
+		if len(w) >= 3 && !stopWords[w] {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+// transliterateUmlauts maps German umlaut characters to their common ASCII
+// two-letter equivalents (ä→ae, ö→oe, ü→ue, ß→ss). Must be called after
+// strings.ToLower so only the lowercase forms need to be handled.
+func transliterateUmlauts(s string) string {
+	s = strings.ReplaceAll(s, "ä", "ae")
+	s = strings.ReplaceAll(s, "ö", "oe")
+	s = strings.ReplaceAll(s, "ü", "ue")
+	s = strings.ReplaceAll(s, "ß", "ss")
+	return s
+}

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -180,29 +180,6 @@ func (s *Searcher) SearchQuery(ctx context.Context, indexers []models.Indexer, q
 	return results
 }
 
-// stopWords are common English words excluded from keyword significance checks.
-var stopWords = map[string]bool{
-	"the": true, "a": true, "an": true, "and": true, "or": true,
-	"of": true, "in": true, "to": true, "by": true, "for": true,
-	"with": true, "at": true, "from": true, "is": true, "it": true,
-	"as": true, "on": true, "be": true,
-}
-
-// sigWords returns the meaningful (non-stop, 3+ char) words from s.
-// Apostrophes are stripped so "Ender's" produces the token "enders",
-// matching the apostrophe-free form used in most release names.
-// German umlauts are transliterated (ä→ae etc.) to match NormalizeRelease.
-func sigWords(s string) []string {
-	var out []string
-	for _, w := range strings.Fields(strings.ToLower(s)) {
-		w = strings.ReplaceAll(w, "'", "") // "ender's" → "enders"
-		w = transliterateUmlauts(w)
-		if len(w) >= 3 && !stopWords[w] {
-			out = append(out, w)
-		}
-	}
-	return out
-}
 
 // primaryTitle returns the portion of title before the first colon (used for
 // subtitle handling — "Dune: Messiah" → "Dune"). If there's no colon the full
@@ -369,9 +346,9 @@ func filterRelevant(results []newznab.SearchResult, title, author string, aliase
 	// preventing "clancys" from becoming a keyword that fails to match releases
 	// like "Tom Clancy - Rainbow Six". See issue #409.
 	title = stripPossessivePrefix(title, author)
-	fullKws := sigWords(title)
-	primaryKws := sigWords(primaryTitle(title))
-	authorKws := sigWords(author)
+	fullKws := newznab.SigWords(title)
+	primaryKws := newznab.SigWords(primaryTitle(title))
+	authorKws := newznab.SigWords(author)
 	surname := AuthorSurname(author)
 
 	// Build candidate author token sets. The primary set is from `author`. When

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -180,7 +180,6 @@ func (s *Searcher) SearchQuery(ctx context.Context, indexers []models.Indexer, q
 	return results
 }
 
-
 // primaryTitle returns the portion of title before the first colon (used for
 // subtitle handling — "Dune: Messiah" → "Dune"). If there's no colon the full
 // title is returned.


### PR DESCRIPTION
Closes #665.

## What

Some Torznab indexers (observed with Jackett proxying AudioBookBay) advertise `book-search` support but silently ignore the `title` and `author` params on `t=book` queries, returning a fixed category feed regardless of what was searched. The existing `Total < 1000` guard does not catch this — the canned 18-result feed passes it — so the same books are returned for every search.

## How

After tier 1 returns results, `titleHasRelevantResult()` checks whether at least one result title contains a significant word from the query title. If none match, the response is treated as a canned feed and the search falls through to the text-search tiers (surname+title → full-author+title → title-only), which honour the query string properly.

`SigWords` is extracted into `newznab/words.go` (same tokeniser as `filterRelevant` — 3+ char, stopword-filtered, apostrophe-stripped, umlaut-transliterated) and the existing callers in `searcher.go` and `debug.go` are updated to use it. This avoids duplicating the tokenisation logic and prevents a circular import.

## Tests

- `TestBookSearch_Tier1FallsBackOnCannedFeed` — fake indexer returns unrelated canned results for `t=book`; verifies the search falls through to tier 2 and returns the relevant result
- `TestTitleHasRelevantResult` — unit test for the relevance check
- `TestSigWords` — unit test for the tokeniser including apostrophe and umlaut cases