### PR TITLE
fix(metadata): harden Hardcover series and shelf mapping

### DIFF
--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vavallee/bindery/internal/isbnutil"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/useragent"
@@ -521,7 +522,9 @@ type HCList struct {
 	BooksCount int    `json:"booksCount"`
 }
 
-// hcBuiltinShelves are the four standard Hardcover reading-status shelves.
+// hcBuiltinShelves are the four Hardcover reading-status shelves Bindery
+// exposes for list sync. Hardcover status_id 4 is Paused, which is not exposed
+// as a synthetic list because existing list sync behavior only surfaces DNF.
 // They live in user_books (filtered by status_id), not in me.lists, so they
 // are injected as synthetic entries using negative IDs to avoid collision with
 // real list IDs.
@@ -542,7 +545,7 @@ func hcShelfStatusID(listID int) (int, bool) {
 	case -3:
 		return 3, true
 	case -4:
-		return 4, true
+		return 5, true
 	}
 	return 0, false
 }
@@ -816,9 +819,13 @@ type hcBook struct {
 	Rating        float64          `json:"rating"`
 	UsersCount    int              `json:"users_count"`
 	Genres        []string         `json:"genres"`
+	ISBNs         []string         `json:"isbns"`
+	HasAudiobook  bool             `json:"has_audiobook"`
+	HasEbook      bool             `json:"has_ebook"`
 	AudioSeconds  *int             `json:"audio_seconds"`
 	Contributions []hcContribution `json:"contributions"`
 	AuthorNames   []string         `json:"author_names"`
+	SeriesRefs    []models.SeriesRef
 }
 
 type hcEdition struct {
@@ -871,18 +878,25 @@ type hcBookSearchHit struct {
 }
 
 type hcBookSearchDocument struct {
-	ID            any                    `json:"id"`
-	Title         string                 `json:"title"`
-	Slug          string                 `json:"slug"`
-	Description   string                 `json:"description"`
-	Image         any                    `json:"image"`
-	ImageURL      string                 `json:"image_url"`
-	CachedImage   any                    `json:"cached_image"`
-	ReleaseYear   any                    `json:"release_year"`
-	RatingsCount  any                    `json:"ratings_count"`
-	Rating        any                    `json:"rating"`
-	Contributions []hcSearchContribution `json:"contributions"`
-	AuthorNames   []string               `json:"author_names"`
+	ID                     any                    `json:"id"`
+	Title                  string                 `json:"title"`
+	Slug                   string                 `json:"slug"`
+	Description            string                 `json:"description"`
+	Image                  any                    `json:"image"`
+	ImageURL               string                 `json:"image_url"`
+	CachedImage            any                    `json:"cached_image"`
+	ReleaseYear            any                    `json:"release_year"`
+	RatingsCount           any                    `json:"ratings_count"`
+	Rating                 any                    `json:"rating"`
+	ISBNs                  any                    `json:"isbns"`
+	Genres                 any                    `json:"genres"`
+	HasAudiobook           any                    `json:"has_audiobook"`
+	HasEbook               any                    `json:"has_ebook"`
+	FeaturedSeries         any                    `json:"featured_series"`
+	FeaturedSeriesID       any                    `json:"featured_series_id"`
+	FeaturedSeriesPosition any                    `json:"featured_series_position"`
+	Contributions          []hcSearchContribution `json:"contributions"`
+	AuthorNames            []string               `json:"author_names"`
 }
 
 type hcSearchContribution struct {
@@ -997,6 +1011,11 @@ func bookSearchDocumentToBook(doc hcBookSearchDocument) (hcBook, bool) {
 		ReleaseYear:   searchIntPtr(doc.ReleaseYear),
 		RatingsCount:  searchIntValue(doc.RatingsCount),
 		Rating:        searchFloatValue(doc.Rating),
+		ISBNs:         searchISBNList(doc.ISBNs),
+		Genres:        searchStringList(doc.Genres, nil),
+		HasAudiobook:  searchBool(doc.HasAudiobook),
+		HasEbook:      searchBool(doc.HasEbook),
+		SeriesRefs:    searchSeriesRefs(doc.FeaturedSeries, doc.FeaturedSeriesID, doc.FeaturedSeriesPosition),
 		Contributions: make([]hcContribution, 0, len(doc.Contributions)),
 		AuthorNames:   doc.AuthorNames,
 	}
@@ -1085,6 +1104,160 @@ func searchFloatValue(value any) float64 {
 	}
 }
 
+func searchISBNList(value any) []string {
+	return searchStringList(value, isbnutil.Normalize)
+}
+
+func searchStringList(value any, normalize func(string) string) []string {
+	var out []string
+	seen := make(map[string]struct{})
+	var add func(any)
+	add = func(item any) {
+		switch v := item.(type) {
+		case nil:
+			return
+		case []any:
+			for _, elem := range v {
+				add(elem)
+			}
+		case []string:
+			for _, elem := range v {
+				add(elem)
+			}
+		case string:
+			value := strings.TrimSpace(v)
+			if strings.HasPrefix(value, "[") {
+				var nested []any
+				if err := json.Unmarshal([]byte(value), &nested); err == nil {
+					add(nested)
+					return
+				}
+			}
+			if normalize != nil {
+				value = normalize(value)
+			}
+			value = strings.TrimSpace(value)
+			if value == "" {
+				return
+			}
+			key := strings.ToLower(value)
+			if _, ok := seen[key]; ok {
+				return
+			}
+			seen[key] = struct{}{}
+			out = append(out, value)
+		case json.Number:
+			add(v.String())
+		default:
+			add(searchScalarString(v))
+		}
+	}
+	add(value)
+	return out
+}
+
+func searchBool(value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return false
+	case bool:
+		return v
+	case string:
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "1", "t", "true", "y", "yes":
+			return true
+		default:
+			return false
+		}
+	case json.Number:
+		i, err := strconv.Atoi(v.String())
+		return err == nil && i != 0
+	case float64:
+		return v != 0
+	case int:
+		return v != 0
+	default:
+		return searchBool(searchScalarString(v))
+	}
+}
+
+func searchSeriesRefs(seriesValue, idValue, positionValue any) []models.SeriesRef {
+	title, id := searchFeaturedSeries(seriesValue)
+	if id == "" {
+		id = searchNumericSeriesID(idValue)
+	}
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return nil
+	}
+	if id == "" {
+		return nil
+	}
+	return []models.SeriesRef{{
+		ForeignID: seriesIDPrefix + id,
+		Title:     title,
+		Position:  formatSeriesPosition(positionValue),
+		Primary:   true,
+	}}
+}
+
+func searchFeaturedSeries(value any) (string, string) {
+	switch v := value.(type) {
+	case nil:
+		return "", ""
+	case string:
+		return strings.TrimSpace(v), ""
+	case map[string]any:
+		title := firstNonEmpty(
+			searchScalarString(v["name"]),
+			searchScalarString(v["title"]),
+			searchScalarString(v["series"]),
+		)
+		id := firstNonEmpty(
+			searchNumericSeriesID(v["id"]),
+			searchNumericSeriesID(v["series_id"]),
+		)
+		return title, id
+	case []any:
+		for _, item := range v {
+			title, id := searchFeaturedSeries(item)
+			if strings.TrimSpace(title) != "" {
+				return title, id
+			}
+		}
+	}
+	return "", ""
+}
+
+func searchNumericSeriesID(value any) string {
+	id, ok := searchInt(value)
+	if !ok || id <= 0 {
+		return ""
+	}
+	return strconv.Itoa(id)
+}
+
+func searchScalarString(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(v)
+	case json.Number:
+		return strings.TrimSpace(v.String())
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
+}
+
 // --- Converters ---
 
 func (c *Client) toAuthor(a hcAuthor) models.Author {
@@ -1121,9 +1294,19 @@ func (c *Client) toBook(b hcBook) models.Book {
 		Monitored:        true,
 		Status:           models.BookStatusWanted,
 		Genres:           []string{},
+		ISBNs:            b.ISBNs,
+		SeriesRefs:       b.SeriesRefs,
 	}
 	if len(b.Genres) > 0 {
 		bk.Genres = b.Genres
+	}
+	switch {
+	case b.HasAudiobook && b.HasEbook:
+		bk.MediaType = models.MediaTypeBoth
+	case b.HasAudiobook:
+		bk.MediaType = models.MediaTypeAudiobook
+	case b.HasEbook:
+		bk.MediaType = models.MediaTypeEbook
 	}
 	if b.Image != nil {
 		bk.ImageURL = b.Image.URL

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"math"
 	"net/http"
 	"strconv"
@@ -1160,8 +1161,32 @@ func searchStringList(value any, normalize func(string) string) []string {
 			out = append(out, value)
 		case json.Number:
 			add(v.String())
+		case float64:
+			add(strconv.FormatFloat(v, 'f', -1, 64))
+		case float32:
+			add(strconv.FormatFloat(float64(v), 'f', -1, 32))
+		case int:
+			add(strconv.Itoa(v))
+		case int8:
+			add(strconv.FormatInt(int64(v), 10))
+		case int16:
+			add(strconv.FormatInt(int64(v), 10))
+		case int32:
+			add(strconv.FormatInt(int64(v), 10))
+		case int64:
+			add(strconv.FormatInt(v, 10))
+		case uint:
+			add(strconv.FormatUint(uint64(v), 10))
+		case uint8:
+			add(strconv.FormatUint(uint64(v), 10))
+		case uint16:
+			add(strconv.FormatUint(uint64(v), 10))
+		case uint32:
+			add(strconv.FormatUint(uint64(v), 10))
+		case uint64:
+			add(strconv.FormatUint(v, 10))
 		default:
-			add(searchScalarString(v))
+			return
 		}
 	}
 	add(value)
@@ -1203,6 +1228,7 @@ func searchSeriesRefs(seriesValue, idValue, positionValue any) []models.SeriesRe
 		return nil
 	}
 	if id == "" {
+		slog.Debug("dropping Hardcover search series ref without numeric id", "title", title, "id", idValue)
 		return nil
 	}
 	return []models.SeriesRef{{

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -32,6 +32,17 @@ const (
 	hardcoverSuccessResponseBodyLimit = 8 << 20
 )
 
+// Hardcover documents user_books.status_id values in its official API docs:
+// https://github.com/hardcoverapp/hardcover-docs/blob/31aaa75774ec560312222e5834322c71b79dbb5b/src/content/docs/api/GraphQL/Schemas/UserBooks.mdx#L12-L21
+const (
+	hcStatusWantToRead       = 1
+	hcStatusCurrentlyReading = 2
+	hcStatusRead             = 3
+	hcStatusPaused           = 4
+	hcStatusDidNotFinish     = 5
+	hcStatusIgnored          = 6
+)
+
 // Client implements metadata.Provider for Hardcover.app using its public GraphQL API.
 // Set an API token via WithToken or NewAuthenticated to enable authenticated queries.
 type Client struct {
@@ -452,10 +463,9 @@ func (c *Client) GetUserWishlist(ctx context.Context, limit int) ([]models.Recom
 	if limit <= 0 {
 		limit = 100
 	}
-	// status_id 1 = "Want to Read" in Hardcover's reading status enum.
-	gql := `query GetWishlist($limit: Int!) {
+	gql := `query GetWishlist($limit: Int!, $statusID: Int!) {
 		me {
-			user_books(where: {status_id: {_eq: 1}}, limit: $limit) {
+			user_books(where: {status_id: {_eq: $statusID}}, limit: $limit) {
 				book {
 					id
 					title
@@ -472,6 +482,7 @@ func (c *Client) GetUserWishlist(ctx context.Context, limit int) ([]models.Recom
 			}
 		}
 	}`
+	vars := map[string]any{"limit": limit, "statusID": hcStatusWantToRead}
 	var resp struct {
 		Data struct {
 			Me []struct {
@@ -481,7 +492,7 @@ func (c *Client) GetUserWishlist(ctx context.Context, limit int) ([]models.Recom
 			} `json:"me"`
 		} `json:"data"`
 	}
-	if err := c.query(ctx, gql, map[string]any{"limit": limit}, &resp); err != nil {
+	if err := c.query(ctx, gql, vars, &resp); err != nil {
 		return nil, fmt.Errorf("hardcover get wishlist: %w", err)
 	}
 	if len(resp.Data.Me) == 0 {
@@ -522,9 +533,10 @@ type HCList struct {
 	BooksCount int    `json:"booksCount"`
 }
 
-// hcBuiltinShelves are the four Hardcover reading-status shelves Bindery
-// exposes for list sync. Hardcover status_id 4 is Paused, which is not exposed
-// as a synthetic list because existing list sync behavior only surfaces DNF.
+// hcBuiltinShelves are the four Hardcover reading-status shelves Bindery exposes
+// for list sync. Hardcover also defines Paused (hcStatusPaused), which is not
+// exposed as a synthetic list because existing list sync behavior only surfaces
+// DNF.
 // They live in user_books (filtered by status_id), not in me.lists, so they
 // are injected as synthetic entries using negative IDs to avoid collision with
 // real list IDs.
@@ -539,13 +551,13 @@ var hcBuiltinShelves = []HCList{
 func hcShelfStatusID(listID int) (int, bool) {
 	switch listID {
 	case -1:
-		return 1, true
+		return hcStatusWantToRead, true
 	case -2:
-		return 2, true
+		return hcStatusCurrentlyReading, true
 	case -3:
-		return 3, true
+		return hcStatusRead, true
 	case -4:
-		return 5, true
+		return hcStatusDidNotFinish, true
 	}
 	return 0, false
 }

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -208,6 +208,8 @@ func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([
 			rating
 			users_count
 			audio_seconds
+			default_audio_edition_id
+			default_ebook_edition_id
 			contributions {
 				author { id name slug }
 			}
@@ -289,6 +291,8 @@ func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, e
 			release_year
 			ratings_count
 			rating
+			default_audio_edition_id
+			default_ebook_edition_id
 			contributions {
 				author { id name slug }
 			}
@@ -306,6 +310,8 @@ func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, e
 				release_year
 				ratings_count
 				rating
+				default_audio_edition_id
+				default_ebook_edition_id
 				contributions {
 					author { id name slug }
 				}
@@ -426,6 +432,8 @@ func (c *Client) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, 
 				release_year
 				ratings_count
 				rating
+				default_audio_edition_id
+				default_ebook_edition_id
 				contributions {
 					author { id name slug }
 				}
@@ -636,6 +644,8 @@ func (c *Client) GetListBooks(ctx context.Context, listID int) ([]models.Book, e
 					release_year
 					ratings_count
 					rating
+					default_audio_edition_id
+					default_ebook_edition_id
 					contributions {
 						author { id name slug }
 					}
@@ -679,6 +689,8 @@ func (c *Client) getShelfBooks(ctx context.Context, statusID int) ([]models.Book
 					release_year
 					ratings_count
 					rating
+					default_audio_edition_id
+					default_ebook_edition_id
 					contributions {
 						author { id name slug }
 					}
@@ -821,24 +833,26 @@ type hcContribution struct {
 }
 
 type hcBook struct {
-	ID            int              `json:"id"`
-	Title         string           `json:"title"`
-	Subtitle      string           `json:"subtitle"`
-	Slug          string           `json:"slug"`
-	Description   string           `json:"description"`
-	Image         *hcImage         `json:"image"`
-	ReleaseYear   *int             `json:"release_year"`
-	RatingsCount  int              `json:"ratings_count"`
-	Rating        float64          `json:"rating"`
-	UsersCount    int              `json:"users_count"`
-	Genres        []string         `json:"genres"`
-	ISBNs         []string         `json:"isbns"`
-	HasAudiobook  bool             `json:"has_audiobook"`
-	HasEbook      bool             `json:"has_ebook"`
-	AudioSeconds  *int             `json:"audio_seconds"`
-	Contributions []hcContribution `json:"contributions"`
-	AuthorNames   []string         `json:"author_names"`
-	SeriesRefs    []models.SeriesRef
+	ID                    int              `json:"id"`
+	Title                 string           `json:"title"`
+	Subtitle              string           `json:"subtitle"`
+	Slug                  string           `json:"slug"`
+	Description           string           `json:"description"`
+	Image                 *hcImage         `json:"image"`
+	ReleaseYear           *int             `json:"release_year"`
+	RatingsCount          int              `json:"ratings_count"`
+	Rating                float64          `json:"rating"`
+	UsersCount            int              `json:"users_count"`
+	Genres                []string         `json:"genres"`
+	ISBNs                 []string         `json:"isbns"`
+	HasAudiobook          bool             `json:"has_audiobook"`
+	HasEbook              bool             `json:"has_ebook"`
+	AudioSeconds          *int             `json:"audio_seconds"`
+	DefaultAudioEditionID *int             `json:"default_audio_edition_id"`
+	DefaultEbookEditionID *int             `json:"default_ebook_edition_id"`
+	Contributions         []hcContribution `json:"contributions"`
+	AuthorNames           []string         `json:"author_names"`
+	SeriesRefs            []models.SeriesRef
 }
 
 type hcEdition struct {
@@ -1338,12 +1352,14 @@ func (c *Client) toBook(b hcBook) models.Book {
 	if len(b.Genres) > 0 {
 		bk.Genres = b.Genres
 	}
+	hasAudiobook := b.HasAudiobook || hasPositiveInt(b.DefaultAudioEditionID)
+	hasEbook := b.HasEbook || hasPositiveInt(b.DefaultEbookEditionID)
 	switch {
-	case b.HasAudiobook && b.HasEbook:
+	case hasAudiobook && hasEbook:
 		bk.MediaType = models.MediaTypeBoth
-	case b.HasAudiobook:
+	case hasAudiobook:
 		bk.MediaType = models.MediaTypeAudiobook
-	case b.HasEbook:
+	case hasEbook:
 		bk.MediaType = models.MediaTypeEbook
 	}
 	if b.Image != nil {
@@ -1374,6 +1390,10 @@ func (c *Client) toBook(b hcBook) models.Book {
 		}
 	}
 	return bk
+}
+
+func hasPositiveInt(value *int) bool {
+	return value != nil && *value > 0
 }
 
 func hardcoverEditionToModel(e hcEdition) models.Edition {

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -471,6 +471,48 @@ func TestSearchBooks_ParsesSupplementalPayloadMetadata(t *testing.T) {
 	}
 }
 
+func TestSearchBooks_DropsNonScalarGenres(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		assertSearchRequest(t, r, "Book", "dune")
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{
+			"search": map[string]interface{}{
+				"results": map[string]interface{}{
+					"hits": []map[string]interface{}{
+						{
+							"document": map[string]interface{}{
+								"id":    42,
+								"title": "Dune",
+								"slug":  "dune",
+								"genres": []interface{}{
+									"Science Fiction",
+									true,
+									map[string]interface{}{"name": "Fantasy"},
+									[]interface{}{
+										"Classic",
+										false,
+										map[string]interface{}{"name": "Space Opera"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}), nil
+	})
+
+	books, err := c.SearchBooks(context.Background(), "dune")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	if !slices.Equal(books[0].Genres, []string{"Science Fiction", "Classic"}) {
+		t.Fatalf("Genres = %+v", books[0].Genres)
+	}
+}
+
 func TestSearchSeriesRefsRequiresHardcoverSeriesID(t *testing.T) {
 	for _, tt := range []struct {
 		name        string

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -1615,6 +1615,9 @@ func TestGetUserWishlist_DefaultLimit(t *testing.T) {
 	if v, ok := gotVars["limit"].(float64); !ok || v != 100 {
 		t.Errorf("limit variable: want 100, got %v", gotVars["limit"])
 	}
+	if v, ok := gotVars["statusID"].(float64); !ok || v != hcStatusWantToRead {
+		t.Errorf("statusID variable: want %d, got %v", hcStatusWantToRead, gotVars["statusID"])
+	}
 }
 
 func TestGetUserWishlist_Empty(t *testing.T) {

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -644,6 +644,11 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 				t.Fatalf("query requested search-only Hardcover field %q: %s", field, req.Query)
 			}
 		}
+		for _, field := range []string{"default_audio_edition_id", "default_ebook_edition_id"} {
+			if !strings.Contains(req.Query, field) {
+				t.Fatalf("query did not request Hardcover format field %q: %s", field, req.Query)
+			}
+		}
 		gotVars = req.Variables
 		data := map[string]interface{}{
 			"books": []map[string]interface{}{
@@ -1478,6 +1483,56 @@ func TestToBook_NoSlug_UsesID(t *testing.T) {
 	b := c.toBook(hcBook{ID: 99, Title: "Slug-less Book", Slug: ""})
 	if b.ForeignID != "hc:99" {
 		t.Errorf("ForeignID: want 'hc:99', got %q", b.ForeignID)
+	}
+}
+
+func TestToBook_DefaultEditionIDsSetMediaType(t *testing.T) {
+	c := New()
+	audioID := 10
+	ebookID := 20
+	cases := []struct {
+		name string
+		book hcBook
+		want string
+	}{
+		{
+			name: "both",
+			book: hcBook{
+				DefaultAudioEditionID: &audioID,
+				DefaultEbookEditionID: &ebookID,
+			},
+			want: models.MediaTypeBoth,
+		},
+		{
+			name: "audiobook",
+			book: hcBook{
+				DefaultAudioEditionID: &audioID,
+			},
+			want: models.MediaTypeAudiobook,
+		},
+		{
+			name: "ebook",
+			book: hcBook{
+				DefaultEbookEditionID: &ebookID,
+			},
+			want: models.MediaTypeEbook,
+		},
+		{
+			name: "neither",
+			book: hcBook{},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.book.ID = 1
+			tc.book.Title = "Format Test"
+			tc.book.Slug = "format-test"
+			got := c.toBook(tc.book)
+			if got.MediaType != tc.want {
+				t.Fatalf("MediaType = %q, want %q", got.MediaType, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -6,10 +6,12 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
 )
 
 // testTransport routes all HTTP calls through a handler function.
@@ -369,7 +371,7 @@ func TestSearchBooks_Success(t *testing.T) {
 }
 
 func TestSearchBooks_ParsesStringResultsAndAuthorNames(t *testing.T) {
-	encoded := `{"found":1,"hits":[{"document":{"id":"312460","title":"Dune","slug":"dune","description":"A desert planet.","release_year":"1965","rating":"4.4","ratings_count":"12000","image_url":"https://img.example.com/dune.jpg","author_names":["Frank Herbert"]}}]}`
+	encoded := `{"found":1,"hits":[{"document":{"id":"312460","title":"Dune","slug":"dune","description":"A desert planet.","release_year":"1965","rating":"4.4","ratings_count":"12000","image_url":"https://img.example.com/dune.jpg","isbns":["978-0-441-17271-9","9780441172719","0441172717"],"genres":["Science Fiction"," science fiction ","Classic"],"has_audiobook":"true","has_ebook":"true","featured_series":"Dune Chronicles","featured_series_position":"1","author_names":["Frank Herbert"]}}]}`
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
 		assertSearchRequest(t, r, "Book", "dune")
 		return gqlResponse(t, http.StatusOK, map[string]interface{}{
@@ -396,6 +398,126 @@ func TestSearchBooks_ParsesStringResultsAndAuthorNames(t *testing.T) {
 	}
 	if book.AverageRating != 4.4 || book.RatingsCount != 12000 {
 		t.Errorf("rating/count = %f/%d, want 4.4/12000", book.AverageRating, book.RatingsCount)
+	}
+	if !slices.Equal(book.ISBNs, []string{"9780441172719", "0441172717"}) {
+		t.Errorf("ISBNs = %+v", book.ISBNs)
+	}
+	if !slices.Equal(book.Genres, []string{"Science Fiction", "Classic"}) {
+		t.Errorf("Genres = %+v", book.Genres)
+	}
+	if book.MediaType != models.MediaTypeBoth {
+		t.Errorf("MediaType = %q, want %q", book.MediaType, models.MediaTypeBoth)
+	}
+	if len(book.SeriesRefs) != 0 {
+		t.Fatalf("SeriesRefs len = %d, want 0 without Hardcover series id", len(book.SeriesRefs))
+	}
+}
+
+func TestSearchBooks_ParsesSupplementalPayloadMetadata(t *testing.T) {
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		assertSearchRequest(t, r, "Book", "way of kings")
+		return gqlResponse(t, http.StatusOK, map[string]interface{}{
+			"search": map[string]interface{}{
+				"results": map[string]interface{}{
+					"found": 1,
+					"hits": []map[string]interface{}{
+						{
+							"document": map[string]interface{}{
+								"id":                       42,
+								"title":                    "The Way of Kings",
+								"slug":                     "the-way-of-kings",
+								"isbns":                    []interface{}{"978-0-7653-2635-5", "0765326353", "9780765326355"},
+								"genres":                   []interface{}{"Fantasy", " fantasy ", ""},
+								"has_audiobook":            true,
+								"has_ebook":                false,
+								"featured_series":          map[string]interface{}{"name": "The Stormlight Archive"},
+								"featured_series_id":       103,
+								"featured_series_position": 1.5,
+								"author_names":             []interface{}{"", "Brandon Sanderson"},
+							},
+						},
+					},
+				},
+			},
+		}), nil
+	})
+
+	books, err := c.SearchBooks(context.Background(), "way of kings")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(books))
+	}
+	book := books[0]
+	if book.Author == nil || book.Author.Name != "Brandon Sanderson" {
+		t.Fatalf("Author = %+v, want Brandon Sanderson", book.Author)
+	}
+	if !slices.Equal(book.ISBNs, []string{"9780765326355", "0765326353"}) {
+		t.Errorf("ISBNs = %+v", book.ISBNs)
+	}
+	if !slices.Equal(book.Genres, []string{"Fantasy"}) {
+		t.Errorf("Genres = %+v", book.Genres)
+	}
+	if book.MediaType != models.MediaTypeAudiobook {
+		t.Errorf("MediaType = %q, want %q", book.MediaType, models.MediaTypeAudiobook)
+	}
+	if len(book.SeriesRefs) != 1 {
+		t.Fatalf("SeriesRefs len = %d, want 1", len(book.SeriesRefs))
+	}
+	ref := book.SeriesRefs[0]
+	if ref.ForeignID != "hc-series:103" || ref.Title != "The Stormlight Archive" || ref.Position != "1.5" || !ref.Primary {
+		t.Errorf("SeriesRef = %+v", ref)
+	}
+}
+
+func TestSearchSeriesRefsRequiresHardcoverSeriesID(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		seriesValue any
+		idValue     any
+		want        string
+	}{
+		{
+			name:        "string title only",
+			seriesValue: "Dune Chronicles",
+		},
+		{
+			name:        "slug only",
+			seriesValue: map[string]any{"name": "Dune Chronicles", "slug": "dune-chronicles"},
+		},
+		{
+			name:        "non numeric id",
+			seriesValue: "Dune Chronicles",
+			idValue:     "dune-chronicles",
+		},
+		{
+			name:        "featured series id",
+			seriesValue: "Dune Chronicles",
+			idValue:     "103",
+			want:        "hc-series:103",
+		},
+		{
+			name:        "map numeric id",
+			seriesValue: map[string]any{"name": "Dune Chronicles", "id": float64(103), "slug": "dune-chronicles"},
+			want:        "hc-series:103",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			refs := searchSeriesRefs(tt.seriesValue, tt.idValue, "1")
+			if tt.want == "" {
+				if len(refs) != 0 {
+					t.Fatalf("SeriesRefs len = %d, want 0: %+v", len(refs), refs)
+				}
+				return
+			}
+			if len(refs) != 1 {
+				t.Fatalf("SeriesRefs len = %d, want 1", len(refs))
+			}
+			if refs[0].ForeignID != tt.want {
+				t.Fatalf("ForeignID = %q, want %q", refs[0].ForeignID, tt.want)
+			}
+		})
 	}
 }
 
@@ -474,6 +596,11 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 		}
 		if strings.Contains(req.Query, "cached_tags") {
 			t.Fatalf("query requested Hardcover tags as genres: %s", req.Query)
+		}
+		for _, field := range []string{"isbns", "has_audiobook", "has_ebook", "featured_series"} {
+			if strings.Contains(req.Query, field) {
+				t.Fatalf("query requested search-only Hardcover field %q: %s", field, req.Query)
+			}
 		}
 		gotVars = req.Variables
 		data := map[string]interface{}{
@@ -1541,8 +1668,16 @@ func TestGetUserLists_IncludesBuiltinShelves(t *testing.T) {
 	if len(lists) != len(hcBuiltinShelves) {
 		t.Fatalf("want %d lists (built-ins only), got %d", len(hcBuiltinShelves), len(lists))
 	}
-	if lists[0].ID != -1 || lists[0].Name != "Want to Read" {
-		t.Errorf("first list = %+v, want {ID:-1, Name:Want to Read}", lists[0])
+	want := []HCList{
+		{ID: -1, Name: "Want to Read", Slug: "want-to-read"},
+		{ID: -2, Name: "Currently Reading", Slug: "currently-reading"},
+		{ID: -3, Name: "Read", Slug: "read"},
+		{ID: -4, Name: "Did Not Finish", Slug: "did-not-finish"},
+	}
+	for i, wantShelf := range want {
+		if lists[i] != wantShelf {
+			t.Errorf("list[%d] = %+v, want %+v", i, lists[i], wantShelf)
+		}
 	}
 }
 
@@ -1572,30 +1707,45 @@ func TestGetUserLists_CustomListsAppendedAfterShelves(t *testing.T) {
 }
 
 func TestGetListBooks_BuiltinShelfRoutesToUserBooks(t *testing.T) {
-	var gotVars map[string]any
-	c := newMockClient(func(r *http.Request) (*http.Response, error) {
-		var req gqlRequest
-		body, _ := io.ReadAll(r.Body)
-		_ = json.Unmarshal(body, &req)
-		gotVars = req.Variables
-		resp := `{"data":{"me":[{"user_books":[{"book":{"id":99,"title":"Dune","slug":"dune","contributions":[{"author":{"id":1,"name":"Frank Herbert","slug":"frank-herbert"}}]}}]}]}}`
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(resp)),
-			Header:     make(http.Header),
-		}, nil
-	})
-	c = c.WithToken("hc-token")
+	cases := []struct {
+		name         string
+		listID       int
+		wantStatusID int
+	}{
+		{name: "want to read", listID: -1, wantStatusID: 1},
+		{name: "currently reading", listID: -2, wantStatusID: 2},
+		{name: "read", listID: -3, wantStatusID: 3},
+		{name: "did not finish", listID: -4, wantStatusID: 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotVars map[string]any
+			c := newMockClient(func(r *http.Request) (*http.Response, error) {
+				var req gqlRequest
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &req)
+				gotVars = req.Variables
+				resp := `{"data":{"me":[{"user_books":[{"book":{"id":99,"title":"Dune","slug":"dune","contributions":[{"author":{"id":1,"name":"Frank Herbert","slug":"frank-herbert"}}]}}]}]}}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(resp)),
+					Header:     make(http.Header),
+				}, nil
+			})
+			c = c.WithToken("hc-token")
 
-	books, err := c.GetListBooks(context.Background(), -1) // Want to Read
-	if err != nil {
-		t.Fatalf("GetListBooks shelf: %v", err)
-	}
-	if len(books) != 1 || books[0].Title != "Dune" {
-		t.Errorf("books = %+v, want [{Title:Dune}]", books)
-	}
-	if gotVars["statusID"] != float64(1) {
-		t.Errorf("statusID var = %v, want 1", gotVars["statusID"])
+			books, err := c.GetListBooks(context.Background(), tc.listID)
+			if err != nil {
+				t.Fatalf("GetListBooks shelf: %v", err)
+			}
+			if len(books) != 1 || books[0].Title != "Dune" {
+				t.Errorf("books = %+v, want [{Title:Dune}]", books)
+			}
+			wantStatusID := float64(tc.wantStatusID)
+			if gotVars["statusID"] != wantStatusID {
+				t.Errorf("statusID var = %v, want %v", gotVars["statusID"], wantStatusID)
+			}
+		})
 	}
 }
 
@@ -1633,18 +1783,32 @@ func TestGetListBooks_PositiveID(t *testing.T) {
 }
 
 func TestHcShelfStatusID(t *testing.T) {
-	cases := []struct{ id, want int }{{-1, 1}, {-2, 2}, {-3, 3}, {-4, 4}}
+	cases := []struct {
+		name string
+		id   int
+		want int
+	}{
+		{name: "want to read", id: -1, want: 1},
+		{name: "currently reading", id: -2, want: 2},
+		{name: "read", id: -3, want: 3},
+		{name: "did not finish", id: -4, want: 5},
+	}
 	for _, tc := range cases {
-		got, ok := hcShelfStatusID(tc.id)
-		if !ok || got != tc.want {
-			t.Errorf("hcShelfStatusID(%d) = %d,%v, want %d,true", tc.id, got, ok, tc.want)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := hcShelfStatusID(tc.id)
+			if !ok || got != tc.want {
+				t.Errorf("hcShelfStatusID(%d) = %d,%v, want %d,true", tc.id, got, ok, tc.want)
+			}
+		})
 	}
 	if _, ok := hcShelfStatusID(0); ok {
 		t.Error("hcShelfStatusID(0) should return false")
 	}
 	if _, ok := hcShelfStatusID(42); ok {
 		t.Error("hcShelfStatusID(42) should return false")
+	}
+	if _, ok := hcShelfStatusID(-5); ok {
+		t.Error("hcShelfStatusID(-5) should return false")
 	}
 }
 

--- a/internal/metadata/hardcover/series.go
+++ b/internal/metadata/hardcover/series.go
@@ -86,6 +86,8 @@ func (c *Client) GetSeriesCatalog(ctx context.Context, foreignID string) (*metad
 					release_year
 					ratings_count
 					rating
+					default_audio_edition_id
+					default_ebook_edition_id
 					contributions {
 						author { id name slug }
 					}


### PR DESCRIPTION
This is PR 3 in a stacked series.

Stack:
1. vavallee/bindery#672 - Restore Hardcover API compatibility
2. vavallee/bindery#686 - Add Hardcover edition lookup
3. This PR - Harden Hardcover series and shelf mapping
4. vavallee/bindery#776 - Split Hardcover client responsibilities
5. vavallee/bindery#789 - Fix Hardcover import list sync reliability

This PR is based on `main` and should be reviewed after vavallee/bindery#686.

## Summary

Hardcover search results now expose series and shelf details differently than the older GraphQL paths Bindery originally targeted. This PR tightens the new metadata mapping so Bindery only persists stable numeric Hardcover series IDs and uses the current status ID for the built-in Did Not Finish shelf.

- Require numeric Hardcover series IDs before creating Bindery series references from search results.
- Preserve current search-result series metadata when a stable Hardcover series ID is available.
- Map Hardcover's Did Not Finish shelf to the current status ID.
- Expand regression coverage for series ID parsing and shelf status mapping.

## Checklist

- [x] Tests added or updated
- [x] N/A - `docs/DEPLOYMENT.md` unchanged; no env vars, config, or upgrade path changed
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] N/A - no wiki pages updated

## Test plan

- [x] `go test ./internal/metadata/hardcover`
- [x] `go test ./internal/metadata/...`
- [x] `go test ./cmd/... ./internal/...`
- [ ] `cd web && npm run build` - not run; Go metadata-only change
