### PR TITLE
fix(qbittorrent,prowlarr): qBit v5 add-torrent JSON + Prowlarr sync filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to Bindery are documented here. Format loosely follows
 ### Fixed
 
 - **Torznab indexers returning canned category feeds no longer block searches** (#665, #687) — Tier-1 `t=book` results that ignore the title/author params (Jackett/AudioBookBay pattern) are detected by a keyword-relevance check; the search now falls through to text-search tiers instead of returning the same canned results for every query.
+- **qBittorrent 5.x grabs no longer surface as failed when the add succeeded** (#690) — qBittorrent v5 returns a JSON body from `POST /api/v2/torrents/add` (`{"success_count":1,"added_torrent_ids":[...]}`) instead of the plaintext `Ok.` v4 returned; Bindery was treating the JSON as a failure. The client now accepts either shape and uses `added_torrent_ids[0]` as the infohash directly when available.
+- **Prowlarr sync no longer imports unrelated, disabled, or non-search indexers** (#675) — Indexers disabled in Prowlarr, without `supportsSearch`, or with no ebook/audiobook categories are now skipped during sync. Previously every indexer Prowlarr returned was created in Bindery and would respawn if deleted.
 
 ## [v1.12.0] — 2026-05-18
 

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -273,16 +273,35 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	text := strings.TrimSpace(string(body))
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("add torrent HTTP %d: %s", resp.StatusCode, text)
 	}
+
+	// qBittorrent v4.x: plaintext body "Ok." on success, anything else is failure.
+	// qBittorrent v5.x: JSON body {"added_torrent_ids":[...],"success_count":N,...}.
+	// Accept either shape; on v5 prefer added_torrent_ids[0] as the infohash so we
+	// can skip the hash-poll fallback when the API already returned the hash.
+	v5Hash := ""
 	if text != "Ok." {
-		return "", fmt.Errorf("add torrent failed: %s", text)
+		var v5 struct {
+			AddedTorrentIDs []string `json:"added_torrent_ids"`
+			SuccessCount    int      `json:"success_count"`
+			FailureCount    int      `json:"failure_count"`
+		}
+		if err := json.Unmarshal(body, &v5); err != nil || (v5.SuccessCount == 0 && len(v5.AddedTorrentIDs) == 0) {
+			return "", fmt.Errorf("add torrent failed: %s", text)
+		}
+		if len(v5.AddedTorrentIDs) > 0 {
+			v5Hash = strings.ToLower(strings.TrimSpace(v5.AddedTorrentIDs[0]))
+		}
 	}
 
+	if v5Hash != "" {
+		return v5Hash, nil
+	}
 	if infoHash := infoHashFromMagnet(submitted); infoHash != "" {
 		return infoHash, nil
 	}

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -119,6 +119,71 @@ func TestAddTorrent_ConcurrentUniqueHashes(t *testing.T) {
 	}
 }
 
+// TestAddTorrent_V5JSONResponse is a regression test for #690.
+// qBittorrent 5.x returns a JSON body from POST /api/v2/torrents/add instead
+// of the plaintext "Ok." that v4 returned. The legacy check rejected the JSON
+// even though the add succeeded, causing every grab to surface as failed.
+// The fix accepts either shape: plaintext "Ok." (v4) or JSON with success_count
+// >= 1 or non-empty added_torrent_ids (v5). When v5 returns the hash inline,
+// we use it directly and skip the hash-poll.
+func TestAddTorrent_V5JSONResponse(t *testing.T) {
+	const v5Hash = "cccccccccccccccccccccccccccccccccccccccc"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"added_torrent_ids":["` + v5Hash + `"],"failure_count":0,"pending_count":0,"success_count":1}`))
+		}
+	}))
+	defer srv.Close()
+
+	indexer := newFakeIndexer(t)
+	defer indexer.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
+	c.loggedIn = true
+
+	got, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error on v5 JSON response: %v", err)
+	}
+	if got != v5Hash {
+		t.Errorf("hash from added_torrent_ids: want %q, got %q", v5Hash, got)
+	}
+}
+
+// TestAddTorrent_V5JSONResponse_FailureCount verifies that a v5 JSON body with
+// success_count=0 and an empty added_torrent_ids is correctly treated as a
+// failure, not accepted on the basis of being JSON.
+func TestAddTorrent_V5JSONResponse_FailureCount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"added_torrent_ids":[],"failure_count":1,"pending_count":0,"success_count":0}`))
+		}
+	}))
+	defer srv.Close()
+
+	indexer := newFakeIndexer(t)
+	defer indexer.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
+	c.loggedIn = true
+
+	_, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "", "")
+	if err == nil {
+		t.Fatal("expected failure for success_count=0 / empty added_torrent_ids, got nil")
+	}
+}
+
 // logCatcher captures slog records for test assertions.
 type logCatcher struct {
 	mu      sync.Mutex

--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -40,7 +40,8 @@ func NewWithTimeout(baseURL, apiKey string, timeout time.Duration) *Client {
 type remoteIndexer struct {
 	ID             int    `json:"id"`
 	Name           string `json:"name"`
-	Protocol       string `json:"protocol"` // "usenet" or "torrent"
+	Enable         bool   `json:"enable"`    // Prowlarr's per-indexer enabled flag
+	Protocol       string `json:"protocol"`  // "usenet" or "torrent"
 	SupportsSearch bool   `json:"supportsSearch"`
 	Categories     []struct {
 		ID int `json:"id"`
@@ -52,6 +53,7 @@ type remoteIndexer struct {
 type IndexerInfo struct {
 	ProwlarrID     int
 	Name           string
+	Enable         bool
 	Protocol       string
 	TorznabURL     string
 	APIKey         string
@@ -84,6 +86,7 @@ func (c *Client) FetchIndexers(ctx context.Context) ([]IndexerInfo, error) {
 		infos = append(infos, IndexerInfo{
 			ProwlarrID:     ri.ID,
 			Name:           ri.Name,
+			Enable:         ri.Enable,
 			Protocol:       ri.Protocol,
 			TorznabURL:     torznabURL,
 			APIKey:         c.apiKey,

--- a/internal/prowlarr/syncer.go
+++ b/internal/prowlarr/syncer.go
@@ -71,11 +71,28 @@ func (s *Syncer) Sync(ctx context.Context, instanceID int64) (SyncResult, error)
 	seen := map[int]struct{}{}
 
 	for _, ri := range remotes {
-		seen[ri.ProwlarrID] = struct{}{}
+		// Skip indexers that aren't book-relevant. Issue #675: previously
+		// every indexer Prowlarr returned was created in Bindery, including
+		// ones disabled in Prowlarr, ones that don't support search, and
+		// ones with no ebook/audiobook categories. Users then deleted them
+		// manually and watched them reappear on the next sync.
 		cats := filterCategoriesForMedia(ri.Categories)
-		if len(cats) == 0 {
-			cats = []int{7020}
+		switch {
+		case !ri.Enable:
+			slog.Debug("prowlarr sync: skipping disabled indexer",
+				"name", ri.Name, "prowlarr_id", ri.ProwlarrID)
+			continue
+		case !ri.SupportsSearch:
+			slog.Debug("prowlarr sync: skipping indexer with no search support",
+				"name", ri.Name, "prowlarr_id", ri.ProwlarrID)
+			continue
+		case len(cats) == 0:
+			slog.Debug("prowlarr sync: skipping indexer with no book/audiobook categories",
+				"name", ri.Name, "prowlarr_id", ri.ProwlarrID,
+				"categories", ri.Categories)
+			continue
 		}
+		seen[ri.ProwlarrID] = struct{}{}
 
 		pID := ri.ProwlarrID
 		instID := instanceID

--- a/internal/prowlarr/syncer_extra_test.go
+++ b/internal/prowlarr/syncer_extra_test.go
@@ -30,7 +30,7 @@ func TestSyncer_FetchError(t *testing.T) {
 }
 
 func TestSyncer_ListError(t *testing.T) {
-	srv := prowlarrStub(t, `[{"id":1,"name":"T","protocol":"torrent","supportsSearch":true}]`)
+	srv := prowlarrStub(t, `[{"id":1,"name":"T","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`)
 	defer srv.Close()
 
 	store := &fakeIndexerStore{listErr: errors.New("db failure")}
@@ -42,9 +42,10 @@ func TestSyncer_ListError(t *testing.T) {
 	}
 }
 
-func TestSyncer_DefaultCategoriesWhenEmpty(t *testing.T) {
-	// No categories in remote → syncer must default to [7020].
-	srv := prowlarrStub(t, `[{"id":5,"name":"Tracker","protocol":"torrent","supportsSearch":true,"categories":[]}]`)
+func TestSyncer_SkipsIndexerWithNoBookCategories(t *testing.T) {
+	// Issue #675: an indexer with no ebook/audiobook categories must be
+	// skipped, not auto-promoted into Bindery with a fake [7020] category.
+	srv := prowlarrStub(t, `[{"id":5,"name":"Tracker","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[]}]`)
 	defer srv.Close()
 
 	store := &fakeIndexerStore{}
@@ -53,12 +54,41 @@ func TestSyncer_DefaultCategoriesWhenEmpty(t *testing.T) {
 	if _, err := syncer.Sync(context.Background(), 1); err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
-	if len(store.created) != 1 {
-		t.Fatalf("expected 1 created, got %d", len(store.created))
+	if len(store.created) != 0 {
+		t.Errorf("expected 0 created (no book/audiobook categories), got %d", len(store.created))
 	}
-	cats := store.created[0].Categories
-	if len(cats) != 1 || cats[0] != 7020 {
-		t.Errorf("Categories = %v, want [7020]", cats)
+}
+
+func TestSyncer_SkipsDisabledIndexer(t *testing.T) {
+	// Issue #675: an indexer disabled in Prowlarr must not be added to Bindery.
+	srv := prowlarrStub(t, `[{"id":6,"name":"DisabledIdx","enable":false,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`)
+	defer srv.Close()
+
+	store := &fakeIndexerStore{}
+	syncer := NewSyncer(New(srv.URL, "k"), store, fakeInstanceStore{})
+
+	if _, err := syncer.Sync(context.Background(), 1); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(store.created) != 0 {
+		t.Errorf("expected 0 created (indexer disabled), got %d", len(store.created))
+	}
+}
+
+func TestSyncer_SkipsIndexerWithoutSearchSupport(t *testing.T) {
+	// Issue #675: an indexer without search support is useless for book lookup
+	// and must not be added to Bindery.
+	srv := prowlarrStub(t, `[{"id":7,"name":"NoSearch","enable":true,"protocol":"torrent","supportsSearch":false,"categories":[{"id":7020}]}]`)
+	defer srv.Close()
+
+	store := &fakeIndexerStore{}
+	syncer := NewSyncer(New(srv.URL, "k"), store, fakeInstanceStore{})
+
+	if _, err := syncer.Sync(context.Background(), 1); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(store.created) != 0 {
+		t.Errorf("expected 0 created (no search support), got %d", len(store.created))
 	}
 }
 
@@ -70,7 +100,7 @@ func TestSyncer_RemovesStaleIndexer(t *testing.T) {
 		{ID: 10, Name: "Active", Type: "torznab", URL: "http://h/1/api", ProwlarrInstanceID: &instID, ProwlarrIndexerID: &pID1},
 		{ID: 11, Name: "Stale", Type: "torznab", URL: "http://h/2/api", ProwlarrInstanceID: &instID, ProwlarrIndexerID: &pID2},
 	}
-	srv := prowlarrStub(t, `[{"id":1,"name":"Active","protocol":"torrent","supportsSearch":true}]`)
+	srv := prowlarrStub(t, `[{"id":1,"name":"Active","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`)
 	defer srv.Close()
 
 	// Update the Active indexer URL to match what the client will compute.
@@ -93,7 +123,7 @@ func TestSyncer_RemovesStaleIndexer(t *testing.T) {
 
 func TestSyncer_CreateErrorIsLogged(t *testing.T) {
 	// Create failure must be logged but not returned as an error.
-	srv := prowlarrStub(t, `[{"id":3,"name":"New","protocol":"torrent","supportsSearch":true}]`)
+	srv := prowlarrStub(t, `[{"id":3,"name":"New","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`)
 	defer srv.Close()
 
 	store := &fakeIndexerStore{createErr: errors.New("insert failed")}
@@ -139,7 +169,7 @@ func TestSyncer_UpdateErrorIsLogged(t *testing.T) {
 		{ID: 5, Name: "OldName", Type: "torznab", URL: "http://old/7/api",
 			ProwlarrInstanceID: &instID, ProwlarrIndexerID: &pID},
 	}
-	srv := prowlarrStub(t, `[{"id":7,"name":"NewName","protocol":"torrent","supportsSearch":true}]`)
+	srv := prowlarrStub(t, `[{"id":7,"name":"NewName","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`)
 	defer srv.Close()
 
 	store := &fakeIndexerStore{existing: existing, updateErr: errors.New("update failed")}
@@ -162,8 +192,8 @@ func TestSyncer_MixedAddUpdateRemove(t *testing.T) {
 		{ID: 11, Name: "Stale", Type: "torznab", ProwlarrInstanceID: &instID, ProwlarrIndexerID: &pID2},
 	}
 	srv := prowlarrStub(t, `[
-		{"id":1,"name":"NewName","protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]},
-		{"id":3,"name":"Added","protocol":"torrent","supportsSearch":false,"categories":[{"id":7000}]}
+		{"id":1,"name":"NewName","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]},
+		{"id":3,"name":"Added","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7000}]}
 	]`)
 	defer srv.Close()
 

--- a/internal/prowlarr/syncer_test.go
+++ b/internal/prowlarr/syncer_test.go
@@ -122,8 +122,8 @@ func TestIndexerTypeForProtocol(t *testing.T) {
 
 func TestSyncer_CreatesNewznabForUsenetIndexers(t *testing.T) {
 	srv := prowlarrStub(t, `[
-		{"id":1,"name":"NZBHydra","protocol":"usenet","supportsSearch":true,"categories":[{"id":7020}]},
-		{"id":2,"name":"PrivateTracker","protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}
+		{"id":1,"name":"NZBHydra","enable":true,"protocol":"usenet","supportsSearch":true,"categories":[{"id":7020}]},
+		{"id":2,"name":"PrivateTracker","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}
 	]`)
 	defer srv.Close()
 
@@ -161,7 +161,7 @@ func TestSyncer_CorrectsMisTypedExistingIndexer(t *testing.T) {
 		ProwlarrInstanceID: &instID,
 		ProwlarrIndexerID:  &pID,
 	}}
-	srv := prowlarrStub(t, `[{"id":42,"name":"NZBHydra","protocol":"usenet","supportsSearch":true,"categories":[{"id":7020}]}]`)
+	srv := prowlarrStub(t, `[{"id":42,"name":"NZBHydra","enable":true,"protocol":"usenet","supportsSearch":true,"categories":[{"id":7020}]}]`)
 	defer srv.Close()
 
 	store := &fakeIndexerStore{existing: existing}
@@ -180,7 +180,7 @@ func TestSyncer_CorrectsMisTypedExistingIndexer(t *testing.T) {
 
 func TestSyncer_WidensParentOnlyCategory(t *testing.T) {
 	// Prowlarr reports [7000] only — syncer must store [7020], not [7000] or [].
-	srv := prowlarrStub(t, `[{"id":9,"name":"GenericBooks","protocol":"torrent","supportsSearch":true,"categories":[{"id":7000}]}]`)
+	srv := prowlarrStub(t, `[{"id":9,"name":"GenericBooks","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7000}]}]`)
 	defer srv.Close()
 
 	store := &fakeIndexerStore{}
@@ -211,7 +211,7 @@ func TestSyncer_PropagatesChangedCategories(t *testing.T) {
 		ProwlarrInstanceID: &instID,
 		ProwlarrIndexerID:  &pID,
 	}}
-	srv := prowlarrStub(t, `[{"id":10,"name":"IndexerA","protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`)
+	srv := prowlarrStub(t, `[{"id":10,"name":"IndexerA","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`)
 	defer srv.Close()
 	existing[0].URL = srv.URL + "/10/api"
 
@@ -243,7 +243,7 @@ func TestSyncer_NoUpdateWhenNothingChanged(t *testing.T) {
 		ProwlarrInstanceID: &instID,
 		ProwlarrIndexerID:  &pID,
 	}}
-	srv := prowlarrStub(t, `[{"id":7,"name":"TrackerX","protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`)
+	srv := prowlarrStub(t, `[{"id":7,"name":"TrackerX","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`)
 	defer srv.Close()
 	existing[0].URL = srv.URL + "/7/api"
 


### PR DESCRIPTION
## Summary

Two small, user-facing fixes bundled for v1.12.1.

### #690 — qBittorrent v5.x JSON add-torrent response

`internal/downloader/qbittorrent/client.go` only accepted plaintext `Ok.` as success (v4 shape). qBit v5 returns JSON:
```json
{"added_torrent_ids":["..."],"failure_count":0,"pending_count":0,"success_count":1}
```
Bindery flagged this as a failed grab even though the torrent was added and downloading. Now accepts either shape and uses `added_torrent_ids[0]` as the infohash when available (skips the hash-poll). New tests cover both v5 success and v5 failure_count > 0 shapes.

Closes #690.

### #675 — Prowlarr sync filters

The Prowlarr syncer fetched every indexer Prowlarr returned and created it in Bindery, including:
- Indexers disabled in Prowlarr (`enable: false`)
- Indexers without search support (`supportsSearch: false`)
- Indexers with no ebook/audiobook categories

Users deleted them manually and watched them reappear next sync. The fix adds Prowlarr's `enable` field to the client model and filters at the syncer.

Closes #675.

## Checklist

- [x] Tests added or updated
- [x] N/A - no env vars, config, or upgrade path changed
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] N/A - no wiki pages

## Test plan

- [x] `go test ./internal/downloader/qbittorrent/...`
- [x] `go test ./internal/prowlarr/...`
- [x] `go build ./...`