### PR TITLE
fix(lint): gofmt prowlarr/client.go comment alignment

### DIFF
--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -40,8 +40,8 @@ func NewWithTimeout(baseURL, apiKey string, timeout time.Duration) *Client {
 type remoteIndexer struct {
 	ID             int    `json:"id"`
 	Name           string `json:"name"`
-	Enable         bool   `json:"enable"`    // Prowlarr's per-indexer enabled flag
-	Protocol       string `json:"protocol"`  // "usenet" or "torrent"
+	Enable         bool   `json:"enable"`   // Prowlarr's per-indexer enabled flag
+	Protocol       string `json:"protocol"` // "usenet" or "torrent"
 	SupportsSearch bool   `json:"supportsSearch"`
 	Categories     []struct {
 		ID int `json:"id"`


### PR DESCRIPTION
Backfill: PR #693 merged with a gofmt failure that was masked by admin merge.