### PR TITLE
chore(release): bindery v1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.12.1] — 2026-05-19
+
 ### Added
 
-- **Hardcover edition metadata lookup** — Hardcover-backed books can now return edition-level metadata, including ISBNs, ASINs, publisher, format, page count, cover, language, and audiobook duration, using Hardcover's current editions query shape.
+- **Hardcover edition metadata lookup** (#686) — Hardcover-backed books can now return edition-level metadata, including ISBNs, ASINs, publisher, format, page count, cover, language, and audiobook duration, using Hardcover's current editions query shape.
 
 ### Fixed
 

--- a/charts/bindery/Chart.yaml
+++ b/charts/bindery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bindery
 description: Automated book download manager for Usenet and Torrents
 type: application
-version: 0.7.0
-appVersion: "1.12.0"
+version: 0.7.1
+appVersion: "1.12.1"
 home: https://github.com/vavallee/bindery
 sources:
   - https://github.com/vavallee/bindery

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindery-web",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.12.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Ships fixes for #665/#687 (canned-feed fallthrough), #690 (qBit v5 JSON), #675 (Prowlarr filters), plus Hardcover edition lookup (#686).