### PR TITLE
chore(deploy): promote bindery to 1.12.1 [skip ci]

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.12.0"
+  tag: "1.12.1"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Manual recovery: deploy-prod CI auto-merge failed (known race per project_deploy_prod_race).