### PR TITLE
fix(newznab): surface indexer errors and tighten canned-feed detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.12.2] — 2026-05-20
+
+### Fixed
+
+- **Searches for titles containing a common word no longer return zero results** (#699) — The tier-1 canned-feed detector accepted a Jackett/AudioBookBay category feed whenever *any* significant query word coincidentally appeared in *any* result. For a title like *Life Ascending*, the common word "life" matched an unrelated canned title, so the canned feed was accepted as a tier-1 hit and the relevance filter then rejected all of it — leaving the user with zero results instead of falling through to text-search tiers. The detector now requires every significant query word to appear in at least one result before accepting a tier-1 response.
+- **Newznab/Torznab indexer errors are surfaced with their own code and description** (#698) — When an indexer returns a top-level `<error code="N" description="...">` element (bad API key, rate limit, site disabled, …) instead of an `<rss>` feed, Bindery reported the raw XML decoder error `expected element type <rss> but have <error>`. The Search debug panel now shows the indexer's actual error, e.g. `indexer error 500: Request limit reached`.
+
 ## [v1.12.1] — 2026-05-19
 
 ### Added

--- a/charts/bindery/Chart.yaml
+++ b/charts/bindery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bindery
 description: Automated book download manager for Usenet and Torrents
 type: application
-version: 0.7.1
-appVersion: "1.12.1"
+version: 0.7.2
+appVersion: "1.12.2"
 home: https://github.com/vavallee/bindery
 sources:
   - https://github.com/vavallee/bindery

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -3,6 +3,7 @@
 package newznab
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"fmt"
@@ -240,25 +241,47 @@ func authorSurname(author string) string {
 	return fields[len(fields)-1]
 }
 
-// titleHasRelevantResult returns true when at least one result's title
-// contains at least one significant word from queryTitle (as determined by
-// SigWords). A false return means the indexer likely returned a fixed
-// category feed that ignored the search params (Jackett/AudioBookBay
-// pattern), so callers should fall through to text-search tiers.
+// titleHasRelevantResult returns true when *every* significant word of
+// queryTitle (as determined by SigWords) appears in at least one result —
+// the words may be spread across different results, not all in one. A false
+// return means the indexer likely returned a fixed category feed that ignored
+// the search params (Jackett/AudioBookBay pattern), so callers should fall
+// through to text-search tiers.
+//
+// The earlier "any sig-word in any result" check was too weak: for a query
+// like "Life Ascending", the common word "life" coincidentally matches an
+// unrelated title in AudioBookBay's canned feed, so the whole canned feed was
+// accepted as a tier-1 hit. The downstream relevance filter then rejected all
+// of it, leaving the user with zero results instead of falling through (#699).
+// A genuine t=book response covers every query word; a canned feed only
+// matches words by coincidence and rarely covers all of them. The failure
+// mode of this stricter check is a benign false negative — fall through to
+// text-search tiers — which beats a false positive that empties the results.
+//
+// Single-sig-word titles (e.g. "Dune") remain inherently ambiguous: there is
+// no second word to disambiguate a coincidental canned-feed match.
 func titleHasRelevantResult(queryTitle string, results []SearchResult) bool {
 	words := SigWords(queryTitle)
 	if len(words) == 0 {
 		return true // query has no checkable words; assume results are valid
 	}
-	for _, r := range results {
-		combined := strings.ToLower(r.Title + " " + r.BookTitle)
-		for _, w := range words {
-			if strings.Contains(combined, w) {
-				return true
+	combined := make([]string, len(results))
+	for i, r := range results {
+		combined[i] = strings.ToLower(r.Title + " " + r.BookTitle)
+	}
+	for _, w := range words {
+		found := false
+		for _, c := range combined {
+			if strings.Contains(c, w) {
+				found = true
+				break
 			}
 		}
+		if !found {
+			return false
+		}
 	}
-	return false
+	return true
 }
 
 // Test verifies the indexer is reachable and the API key is valid.
@@ -411,12 +434,69 @@ func (c *Client) getXML(ctx context.Context, rawURL string, target interface{}) 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		return fmt.Errorf("read indexer response: %w", err)
 	}
 
-	return xml.NewDecoder(resp.Body).Decode(target)
+	// Newznab/Torznab indexers report failures (bad API key, rate limit, site
+	// disabled, …) as a top-level <error code="N" description="..."/> element
+	// instead of an <rss> feed — on either a 2xx or an error status. Surface
+	// the indexer's own code and description rather than leaking the XML
+	// decoder's unhelpful "expected element type <rss> but have <error>".
+	if nzErr := parseNewznabError(body); nzErr != nil {
+		return nzErr
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		snippet := strings.TrimSpace(string(body))
+		if len(snippet) > 512 {
+			snippet = snippet[:512]
+		}
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, snippet)
+	}
+
+	return xml.Unmarshal(body, target)
+}
+
+// parseNewznabError returns a non-nil error when body is a Newznab/Torznab
+// <error> response, formatted with the indexer's own code and description.
+// It returns nil for any other document — including a normal <rss> feed or
+// non-XML content — so callers proceed with their usual decoding.
+func parseNewznabError(body []byte) error {
+	dec := xml.NewDecoder(bytes.NewReader(body))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil // not XML, or no start element — let the caller decide
+		}
+		start, ok := tok.(xml.StartElement)
+		if !ok {
+			continue // skip the prolog, comments, and whitespace
+		}
+		if !strings.EqualFold(start.Name.Local, "error") {
+			return nil // root is <rss> or something else; not an error response
+		}
+		var code, desc string
+		for _, attr := range start.Attr {
+			switch strings.ToLower(attr.Name.Local) {
+			case "code":
+				code = strings.TrimSpace(attr.Value)
+			case "description":
+				desc = strings.TrimSpace(attr.Value)
+			}
+		}
+		switch {
+		case code == "" && desc == "":
+			return nil // a bare <error/> tells us nothing actionable
+		case desc == "":
+			return fmt.Errorf("indexer error %s", code)
+		case code == "":
+			return fmt.Errorf("indexer error: %s", desc)
+		default:
+			return fmt.Errorf("indexer error %s: %s", code, desc)
+		}
+	}
 }
 
 func (c *Client) buildURL(command string, params map[string]string) (string, error) {

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -540,6 +540,65 @@ func TestGetXML_SurfacesNon200(t *testing.T) {
 	}
 }
 
+// TestParseNewznabError verifies the helper recognises Newznab/Torznab
+// <error> responses and leaves normal documents alone (#698).
+func TestParseNewznabError(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string // substring expected in the error; "" means nil error
+	}{
+		{"rate limit", `<?xml version="1.0" encoding="UTF-8"?><error code="500" description="Request limit reached"/>`, "500"},
+		{"bad credentials", `<error code="100" description="Incorrect user credentials"/>`, "Incorrect user credentials"},
+		{"description only", `<error description="site offline"/>`, "site offline"},
+		{"code only", `<error code="910"/>`, "910"},
+		{"normal rss feed", `<?xml version="1.0"?><rss version="2.0"><channel></channel></rss>`, ""},
+		{"non-xml body", `not xml at all`, ""},
+		{"bare error element", `<error/>`, ""},
+		{"empty body", ``, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := parseNewznabError([]byte(tc.body))
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestSearch_SurfacesNewznabError verifies a Newznab <error> response — which
+// indexers return with HTTP 200 — is surfaced with the indexer's own code and
+// description rather than the raw XML decoder error (#698).
+func TestSearch_SurfacesNewznabError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><error code="500" description="Request limit reached"/>`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "testkey")
+	_, err := c.Search(context.Background(), "anything", nil)
+	if err == nil {
+		t.Fatal("expected error on <error> response, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") || !strings.Contains(err.Error(), "Request limit reached") {
+		t.Errorf("expected error with indexer code and description, got %v", err)
+	}
+	if strings.Contains(err.Error(), "expected element type") {
+		t.Errorf("raw XML decoder error leaked instead of being translated: %v", err)
+	}
+}
+
 // TestBuildURL_StripsStaleQueryParams verifies that baseURL-embedded
 // query params for t/q/cat/limit are wiped before new ones are added,
 // preventing duplicated keys like t=caps&t=search.
@@ -777,6 +836,27 @@ func TestTitleHasRelevantResult(t *testing.T) {
 	withBookTitle := []SearchResult{{Title: "random release", BookTitle: "Life Ascending"}}
 	if !titleHasRelevantResult("Life Ascending", withBookTitle) {
 		t.Error("expected true when BookTitle contains query word")
+	}
+
+	// Regression for #699: a canned feed where one common query word ("life")
+	// coincidentally appears but the other ("ascending") is absent from every
+	// result must be rejected, not accepted on the strength of the single hit.
+	cannedPartialMatch := []SearchResult{
+		{Title: "This Precious Life - Tibetan Buddhist Teachings"},
+		{Title: "Bring Me the Rhinoceros - Zen Koans That Will Save Your Life"},
+		{Title: "The Beginning After The End, 12"},
+	}
+	if titleHasRelevantResult("Life Ascending", cannedPartialMatch) {
+		t.Error("expected false: 'ascending' is absent from every result (#699)")
+	}
+
+	// Sig-words spread across different results (not all in one) still count.
+	spread := []SearchResult{
+		{Title: "A book about Life"},
+		{Title: "Something Ascending into the sky"},
+	}
+	if !titleHasRelevantResult("Life Ascending", spread) {
+		t.Error("expected true when each sig-word appears in some result")
 	}
 }
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindery-web",
   "private": true,
-  "version": "1.12.1",
+  "version": "1.12.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Two Newznab/Torznab search-quality bugs, both causing silent or cryptic failures. Ships as **v1.12.2**.

### #699 — canned feed false positive → zero results

The tier-1 canned-feed detector (`titleHasRelevantResult`, added in #687) accepted a Jackett/AudioBookBay category feed whenever **any one** significant query word coincidentally appeared in **any** result. For a search like *Life Ascending*, the common word `"life"` matched an unrelated canned title, the canned feed was accepted as a tier-1 hit, and the downstream relevance filter then rejected all of it — the user got **zero results** instead of falling through to the text-search tiers that would have found the book.

The detector now requires **every** significant query word to appear in at least one result (words may be spread across different results) before accepting a tier-1 response. The failure mode is now a benign false negative — fall through to text-search tiers — which beats a false positive that empties the result set.

### #698 — newznab `<error>` leaks XML parser error

When an indexer returns a top-level `<error code="N" description="...">` element (bad API key, rate limit, site disabled, …) instead of an `<rss>` feed, Bindery surfaced the raw XML decoder error `expected element type <rss> but have <error>`. `getXML` now detects the `<error>` element and surfaces the indexer's own code and description, e.g. `indexer error 500: Request limit reached`.

## Changes

- `internal/indexer/newznab/client.go` — rewrite `titleHasRelevantResult` (all-words-covered); add `parseNewznabError`; `getXML` buffers the body, checks for `<error>`, then decodes.
- `internal/indexer/newznab/client_test.go` — `#699` regression cases in `TestTitleHasRelevantResult`; new `TestParseNewznabError` and `TestSearch_SurfacesNewznabError`.
- `CHANGELOG.md`, `charts/bindery/Chart.yaml`, `web/package.json` — v1.12.2 bump.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/indexer/...`
- [x] `gofmt -l internal/indexer/newznab/` — clean

Closes #698
Closes #699