### PR TITLE
chore(deploy): promote bindery to 1.12.2

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.12.1"
+  tag: "1.12.2"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Manual recovery for the failing `Deploy to prod` CI job (the known deploy-prod race). The v1.12.2 image was built by goreleaser in the release run; this bumps `charts/bindery/values.yaml` to `1.12.2` so ArgoCD self-syncs prod.