### PR TITLE
fix(api): use WithoutCancel for detached OIDC provider reload

### DIFF
--- a/internal/api/auth_oidc.go
+++ b/internal/api/auth_oidc.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -402,8 +403,12 @@ func (h *OIDCHandler) SetProviders(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Reload async so the HTTP response isn't delayed by discovery.
+	// Use WithoutCancel so request-scoped values (logger, trace IDs) are
+	// preserved but the goroutine is not killed when the HTTP handler returns
+	// and cancels r.Context(), which would abort OIDC discovery mid-flight.
+	reloadCtx := context.WithoutCancel(r.Context())
 	go func() {
-		h.mgr.Reload(r.Context(), merged)
+		h.mgr.Reload(reloadCtx, merged)
 	}()
 	writeOK(w, map[string]any{"ok": true, "count": len(merged)})
 }


### PR DESCRIPTION
## Problem

`SetProviders` launches a goroutine to reload OIDC providers asynchronously so the HTTP response is not delayed by discovery. The goroutine was calling `h.mgr.Reload(r.Context(), merged)`, but `r.Context()` is cancelled the moment the handler returns. This meant every OIDC discovery request inside `Reload` failed immediately with `context.Canceled`, so provider configuration was never actually applied.

## Fix

Capture `context.WithoutCancel(r.Context())` before spawning the goroutine and pass that to `Reload` instead. This preserves any request-scoped values (structured logger, trace IDs) while detaching from the HTTP request's cancellation signal. The pattern is already used in `internal/api/abs_import.go` and `internal/api/calibre_import.go` for the same reason.

## Scope

Refs #709, finding 3 only.

- **Finding 1** (unverified-email account linking) — deferred, separate change.
- **Finding 2** (AllowedGroups enforcement gap) — deferred, separate change.