### PR TITLE
fix(api): require admin for API-key regeneration and OIDC provider management

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -592,10 +592,8 @@ func main() {
 		r.Post("/auth/setup", authHandler.Setup)
 		r.Get("/auth/config", authHandler.GetConfig)
 		r.Post("/auth/password", authHandler.ChangePassword)
-		r.Post("/auth/apikey/regenerate", authHandler.RegenerateAPIKey)
 		// OIDC — login/callback are unauthenticated; provider management requires auth.
 		r.Get("/auth/oidc/providers", oidcHandler.GetProviders)
-		r.Put("/auth/oidc/providers", oidcHandler.SetProviders)
 		r.Get("/auth/oidc/redirect-base", oidcHandler.GetRedirectBase)
 		r.Post("/auth/oidc/test-discovery", oidcHandler.TestDiscovery)
 		r.Get("/auth/oidc/{provider}/login", oidcHandler.Login)
@@ -603,6 +601,8 @@ func main() {
 		// Admin-only auth mutations.
 		r.Group(func(r chi.Router) {
 			r.Use(auth.RequireAdmin)
+			r.Post("/auth/apikey/regenerate", authHandler.RegenerateAPIKey)
+			r.Put("/auth/oidc/providers", oidcHandler.SetProviders)
 			r.Put("/auth/mode", authHandler.SetMode)
 			r.Get("/auth/users", userMgmtHandler.List)
 			r.Post("/auth/users", userMgmtHandler.Create)


### PR DESCRIPTION
## Problem

Two state-changing auth routes were registered **outside** the `RequireAdmin` middleware group, allowing any authenticated (non-admin) user to:

1. **Finding 1** — `POST /auth/apikey/regenerate`: regenerate any user's API key, invalidating existing sessions and enabling session hijack.
2. **Finding 2** — `PUT /auth/oidc/providers`: overwrite the OIDC provider configuration, redirecting OAuth flows to an attacker-controlled IdP.

## Fix

Both routes are moved into the existing `r.Group` block that applies `auth.RequireAdmin`, consistent with other admin-only mutations (`PUT /auth/mode`, user-management endpoints). The change is a pure route-registration move — no handler logic is altered.

Read-only OIDC routes (`GET /auth/oidc/providers`, `redirect-base`, `test-discovery`, `login`, `callback`) are unaffected and remain outside the admin group.

## Deferred

- **Finding 3** — CSRF bypass via `?apikey=` query parameter: requires non-mechanical middleware rework; deferred.
- **Finding 4** — API-key admin scoping (keys tied to user rather than admin scope): requires schema + handler changes; deferred.

## Testing

`go build ./...` and `go test ./cmd/... ./internal/api/...` pass cleanly.

Refs #708 — findings 1 and 2 fixed in this PR; findings 3 and 4 deferred.