### PR TITLE
fix(scheduler): skip overlapping cron runs; stop swallowing two errors

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -101,7 +101,7 @@ func New(
 	blocklist *db.BlocklistRepo,
 ) *Scheduler {
 	return &Scheduler{
-		cron:      cron.New(cron.WithSeconds()),
+		cron:      cron.New(cron.WithSeconds(), cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger))),
 		scanner:   scanner,
 		searcher:  searcher,
 		meta:      meta,
@@ -417,7 +417,8 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 
 	candidates, err := s.clients.GetEnabledByProtocol(ctx, best.Protocol)
 	if err != nil {
-		slog.Warn("failed to list clients for protocol", "protocol", best.Protocol, "error", err)
+		slog.Error("SearchAndGrabBook: failed to list download clients", "protocol", best.Protocol, "error", err)
+		return
 	}
 	client := db.PickClientForMediaType(candidates, mediaType)
 	// No cross-protocol fallback: a usenet release must not be pushed to a
@@ -651,7 +652,10 @@ func (s *Scheduler) refreshMetadata() {
 		}
 		author.AverageRating = updated.AverageRating
 		author.RatingsCount = updated.RatingsCount
-		s.authors.Update(ctx, &author)
+		if err := s.authors.Update(ctx, &author); err != nil {
+			slog.Warn("failed to persist refreshed author", "author", author.Name, "error", err)
+			continue
+		}
 
 		slog.Debug("refreshed author", "author", author.Name)
 	}


### PR DESCRIPTION
## Summary

Three targeted hardening fixes from issue #707 — no scope creep:

- **(a) Self-overlap guard** — `cron.New` now uses `cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger))`. Any job whose previous invocation is still running is skipped instead of piling up a concurrent duplicate.
- **(b) `GetEnabledByProtocol` error swallowed** — previously the error was logged at Warn level and execution continued into the "no enabled download client" path, misattributing a DB/network failure as a config gap. Now returns early, logging at Error level with the actual cause.
- **(c) `authors.Update` error discarded** — the return value was silently ignored in `refreshMetadata`. Now checked; failures are logged at Warn with the author name and the loop continues so other authors still get updated.

## Deferred (per #707 scope discipline)

The following findings from #707 are **not** included here and remain open:

- `context.Background()` passed to every cron job — no context plumbing/cancellation wiring added.
- Untracked goroutines (e.g. the startup telemetry ping `go s.telemetry.Ping(...)`) — no WaitGroup changes.
- Dual-format search work — deferred.

Refs #707