### PR TITLE
fix(importer): stat parent dir so the hardlink import mode is reachable

### DIFF
--- a/internal/importer/import_mode_test.go
+++ b/internal/importer/import_mode_test.go
@@ -195,6 +195,40 @@ func TestImportMode_DefaultHardlinkSameDevice(t *testing.T) {
 	}
 }
 
+// TestImportMode_DefaultHardlinkSameDevice_DstNotExist is the regression test
+// for the bug fixed in #705 (finding 5): importMode must choose "hardlink" when
+// src and dst share a filesystem even if the destination path does not yet exist.
+// Before the fix, sameDevice statted the not-yet-created dst directly, always
+// got an error, and fell back to "copy" — making the hardlink path unreachable.
+func TestImportMode_DefaultHardlinkSameDevice_DstNotExist(t *testing.T) {
+	dir := t.TempDir()
+	// src exists; dst is a deeply nested path that has never been created.
+	src := filepath.Join(dir, "downloads", "audiobook")
+	dst := filepath.Join(dir, "library", "Author", "Book", "audiobook")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Intentionally do NOT create dst or any of its parents under "library/".
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	sr := db.NewSettingsRepo(database)
+	s := &Scanner{}
+	s.WithSettings(sr)
+
+	// Both paths are under the same tempdir (same filesystem). With no
+	// import.mode setting and a non-existent destination, importMode must still
+	// return "hardlink" by statting dst's nearest existing ancestor.
+	got := s.importMode(context.Background(), src, dst)
+	if got != "hardlink" {
+		t.Errorf("non-existent dst same-device: importMode = %q, want %q (hardlink path unreachable — bug #705 finding 5 regression)", got, "hardlink")
+	}
+}
+
 // TestImportMode_Settings exercises all branches of importMode when a real
 // SettingsRepo is attached: "copy", "hardlink", unknown value, and absent key.
 func TestImportMode_Settings(t *testing.T) {

--- a/internal/importer/samedevice_unix.go
+++ b/internal/importer/samedevice_unix.go
@@ -4,11 +4,32 @@ package importer
 
 import (
 	"os"
+	"path/filepath"
 	"syscall"
 )
 
+// statExisting stats path p, walking up to the nearest existing ancestor
+// directory when p itself does not exist yet. This allows comparing the device
+// of a not-yet-created destination path against an already-existing source.
+func statExisting(p string) (os.FileInfo, error) {
+	for {
+		fi, err := os.Stat(p)
+		if err == nil {
+			return fi, nil
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			// Reached filesystem root with no success.
+			return nil, err
+		}
+		p = parent
+	}
+}
+
 // sameDevice reports whether a and b reside on the same filesystem by
-// comparing their OS device IDs. Returns false on any stat error.
+// comparing their OS device IDs. When b does not exist, its nearest existing
+// ancestor directory is used so that not-yet-created destination paths are
+// handled correctly. Returns false on any stat error.
 func sameDevice(a, b string) bool {
 	if a == "" || b == "" {
 		return false
@@ -17,7 +38,7 @@ func sameDevice(a, b string) bool {
 	if err != nil {
 		return false
 	}
-	bi, err := os.Stat(b)
+	bi, err := statExisting(b)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
## Problem

`sameDevice` in `internal/importer/samedevice_unix.go` called `os.Stat` directly on the destination path. On a first import the destination file or directory does not yet exist, so `os.Stat` always returned an error. `sameDevice` then returned `false`, causing `importMode` to always fall back to `"copy"` — the `"hardlink"` branch was completely unreachable even when source and destination resided on the same filesystem and no explicit `import.mode` setting was configured.

## Fix

Introduce `statExisting(p string)`, which walks up `filepath.Dir` until it reaches a path that exists. Replace the direct `os.Stat(b)` call in `sameDevice` with `statExisting(b)`. When `b` does not yet exist, the comparison is made against its nearest existing ancestor directory, which is on the same device as `b` would be. Existing call sites that already pass live paths (e.g. `s.libraryDir`) are unaffected because `os.Stat` succeeds on the first iteration.

## Test

`TestImportMode_DefaultHardlinkSameDevice_DstNotExist` is added as a regression test: it passes a non-existent deeply-nested destination path and asserts `importMode` returns `"hardlink"` when src and dst share a filesystem.

`go test ./internal/importer/...` — all pass.

## Scope

Refs #705 (finding 5 only).

The four data-loss findings in #705 (unsafe move/cleanup ordering) are intentionally deferred and are **not** addressed here.