### PR TITLE
fix(importer): allow StateImportFailed to transition to Blocked/Importing on retry

### DIFF
--- a/internal/models/download_state.go
+++ b/internal/models/download_state.go
@@ -29,7 +29,7 @@ var validTransitions = map[DownloadState][]DownloadState{
 	StateImporting:     {StateImported, StateImportFailed, StateImportBlocked},
 	StateImported:      {},
 	StateFailed:        {},
-	StateImportFailed:  {StateImportPending},
+	StateImportFailed:  {StateImportPending, StateImportBlocked, StateImporting},
 	StateImportBlocked: {},
 }
 

--- a/internal/models/download_state_test.go
+++ b/internal/models/download_state_test.go
@@ -1,0 +1,41 @@
+package models
+
+import "testing"
+
+func TestCanTransitionTo(t *testing.T) {
+	cases := []struct {
+		from DownloadState
+		to   DownloadState
+		want bool
+	}{
+		// Normal forward path
+		{StateGrabbed, StateDownloading, true},
+		{StateDownloading, StateCompleted, true},
+		{StateCompleted, StateImportPending, true},
+		{StateImportPending, StateImporting, true},
+		{StateImporting, StateImported, true},
+		{StateImporting, StateImportFailed, true},
+		{StateImporting, StateImportBlocked, true},
+
+		// Retry path from StateImportFailed (issue #706 finding 4)
+		{StateImportFailed, StateImportPending, true},
+		{StateImportFailed, StateImportBlocked, true},
+		{StateImportFailed, StateImporting, true},
+
+		// Terminal states have no outgoing transitions
+		{StateImported, StateImporting, false},
+		{StateFailed, StateGrabbed, false},
+		{StateImportBlocked, StateImporting, false},
+
+		// No backwards transitions
+		{StateImported, StateImportPending, false},
+		{StateImportFailed, StateImported, false},
+		{StateImportFailed, StateCompleted, false},
+	}
+	for _, c := range cases {
+		got := c.from.CanTransitionTo(c.to)
+		if got != c.want {
+			t.Errorf("(%s).CanTransitionTo(%s) = %v, want %v", c.from, c.to, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`validTransitions[StateImportFailed]` only contained `StateImportPending`. The retry path (Bug #7) re-enters `tryImport*` from `StateImportFailed` and immediately calls:

- `updateDownloadStatus(ctx, dl.ID, StateImporting)` — to mark the retry in progress
- `failImport(ctx, dl, StateImportBlocked, ...)` — when the retry hits a blocking condition

Both paths go through `DownloadRepo.UpdateStatus` / `SetErrorWithStatus`, which enforce `CanTransitionTo`. Because neither `StateImporting` nor `StateImportBlocked` was an allowed target from `StateImportFailed`, those writes silently returned `ErrInvalidTransition`. The result: retries consumed the retry counter but never updated the stored status, and blocked-status reasons were never persisted.

## Fix

Add `StateImportBlocked` and `StateImporting` to the allowed targets of `StateImportFailed` in `validTransitions` (`internal/models/download_state.go`). `StateImportPending` (already present) is unchanged. `StateImportBlocked` itself remains terminal — no new outgoing edges added there.

## Tests

New table-driven test `TestCanTransitionTo` in `internal/models/download_state_test.go` covers the retry transitions and verifies no unintended paths are opened.

```
ok  github.com/vavallee/bindery/internal/importer  2.308s
ok  github.com/vavallee/bindery/internal/models    0.003s
```

## Scope

Refs #706 (finding 4 only). Findings 1, 2, 3, and 5 are intentionally deferred and not addressed here.