### PR TITLE
fix(indexer): normalize the query title in the search-debug relevance path

### DIFF
--- a/internal/indexer/debug.go
+++ b/internal/indexer/debug.go
@@ -195,6 +195,10 @@ func filterUsenetJunkDebug(results []newznab.SearchResult) ([]newznab.SearchResu
 // filterRelevantDebug is filterRelevant instrumented to record each drop with
 // the keyword set that failed to match.
 func filterRelevantDebug(results []newznab.SearchResult, title, author string, aliases []string) ([]newznab.SearchResult, []FilterDebug) {
+	// Strip edition qualifiers ("(German Edition)" etc.) and normalize smart
+	// quotes before tokenizing — mirrors the first step of filterRelevant so
+	// both paths produce identical keyword sets.
+	title = newznab.NormalizeQueryTitle(title)
 	// Strip possessive author prefix before keyword extraction (mirrors filterRelevant).
 	title = stripPossessivePrefix(title, author)
 	fullKws := newznab.SigWords(title)

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -1009,6 +1009,44 @@ func TestSearchBookWithDebug_PerResultLogging(t *testing.T) {
 	}
 }
 
+// TestFilterRelevantDebugEditionQualifierParity verifies that
+// filterRelevantDebug and filterRelevant agree on which results to keep for a
+// title that carries a parenthesised edition qualifier — the bug reported in
+// #713 (finding 4) caused filterRelevantDebug to fabricate relevance-rejections
+// because it did not call NormalizeQueryTitle before tokenizing.
+func TestFilterRelevantDebugEditionQualifierParity(t *testing.T) {
+	releases := []string{
+		"Herta.Mueller.Die.Stille.ist.ein.Geraeusch.epub",
+		"Die.Stille.ist.ein.Geraeusch.Mueller.epub",
+		"Some.Unrelated.Noise.epub",
+	}
+	results := toResults(releases...)
+	title := "Die Stille ist ein Geräusch (German Edition)"
+	author := "Herta Müller"
+
+	kept := filterRelevant(results, title, author, nil)
+	keptDebug, _ := filterRelevantDebug(results, title, author, nil)
+
+	keptTitles := resultTitles(kept)
+	keptDebugTitles := resultTitles(keptDebug)
+
+	if len(keptTitles) != len(keptDebugTitles) {
+		t.Fatalf("filterRelevant kept %v but filterRelevantDebug kept %v — paths diverge", keptTitles, keptDebugTitles)
+	}
+	for _, r := range keptTitles {
+		found := false
+		for _, d := range keptDebugTitles {
+			if r == d {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("filterRelevant kept %q but filterRelevantDebug did not", r)
+		}
+	}
+}
+
 // nopWriter discards all log output during tests.
 type nopWriter struct{}
 


### PR DESCRIPTION
## Problem

`filterRelevant` (`internal/indexer/searcher.go`) calls `newznab.NormalizeQueryTitle` as its first step, stripping parenthesised edition qualifiers like `(German Edition)` and normalizing smart quotes before tokenizing. `filterRelevantDebug` (`internal/indexer/debug.go`) was missing that call.

As a result, edition qualifiers were passed raw to `SigWords` and produced spurious keywords such as `"(german"` that never match any release name. The search-debug panel therefore showed fabricated relevance-rejections for books whose metadata titles carry such qualifiers.

## Fix

Insert the identical `newznab.NormalizeQueryTitle(title)` call as the first statement in `filterRelevantDebug`, before `stripPossessivePrefix`, so both code paths produce identical keyword sets.

## Tests

Added `TestFilterRelevantDebugEditionQualifierParity`: asserts that `filterRelevant` and `filterRelevantDebug` agree on which results to keep for the title `"Die Stille ist ein Geräusch (German Edition)"`. This test fails on the old code and passes with the fix. All existing `./internal/indexer/...` tests continue to pass.

Refs #713 (finding 4 of 4). Findings 1–3 are deferred and will be addressed separately.