### PR TITLE
fix(db): make the last-admin guard atomic

### DIFF
--- a/internal/db/auth.go
+++ b/internal/db/auth.go
@@ -197,53 +197,85 @@ func (r *UserRepo) List(ctx context.Context) ([]User, error) {
 }
 
 // Delete removes a user by id. Returns an error if trying to delete the last admin.
+//
+// The last-admin guard (COUNT check + DELETE) runs inside a single transaction
+// to prevent a TOCTOU race where two concurrent callers both pass the count
+// check and both proceed, leaving zero admins.
 func (r *UserRepo) Delete(ctx context.Context, id int64) error {
-	// Guard: refuse to delete the last admin.
-	var adminCount int
-	if err := r.db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM users WHERE role='admin' AND id != ?", id,
-	).Scan(&adminCount); err != nil {
-		return fmt.Errorf("check admin count: %w", err)
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
 	}
+	defer tx.Rollback() //nolint:errcheck
+
 	// Check whether the target is an admin.
 	var targetRole string
-	if err := r.db.QueryRowContext(ctx, "SELECT role FROM users WHERE id=?", id).Scan(&targetRole); err != nil {
+	if err := tx.QueryRowContext(ctx, "SELECT role FROM users WHERE id=?", id).Scan(&targetRole); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil // already gone
 		}
 		return fmt.Errorf("get user role: %w", err)
 	}
-	if targetRole == "admin" && adminCount == 0 {
-		return fmt.Errorf("cannot delete the last admin user")
-	}
-	_, err := r.db.ExecContext(ctx, "DELETE FROM users WHERE id=?", id)
-	return err
-}
 
-// SetRole changes a user's role to "admin" or "user".
-func (r *UserRepo) SetRole(ctx context.Context, id int64, role string) error {
-	if role != "admin" && role != "user" {
-		return fmt.Errorf("invalid role %q: must be admin or user", role)
-	}
-	// Guard: refuse to demote the last admin.
-	if role == "user" {
+	if targetRole == "admin" {
+		// Guard: refuse to delete the last admin — count other admins while
+		// still inside the transaction so no concurrent mutation can sneak in.
 		var adminCount int
-		if err := r.db.QueryRowContext(ctx,
+		if err := tx.QueryRowContext(ctx,
 			"SELECT COUNT(*) FROM users WHERE role='admin' AND id != ?", id,
 		).Scan(&adminCount); err != nil {
 			return fmt.Errorf("check admin count: %w", err)
 		}
-		var targetRole string
-		if err := r.db.QueryRowContext(ctx, "SELECT role FROM users WHERE id=?", id).Scan(&targetRole); err != nil {
-			return fmt.Errorf("get user role: %w", err)
-		}
-		if targetRole == "admin" && adminCount == 0 {
-			return fmt.Errorf("cannot demote the last admin user")
+		if adminCount == 0 {
+			return fmt.Errorf("cannot delete the last admin user")
 		}
 	}
-	_, err := r.db.ExecContext(ctx,
-		"UPDATE users SET role=?, updated_at=? WHERE id=?", role, time.Now().UTC(), id)
-	return err
+
+	if _, err := tx.ExecContext(ctx, "DELETE FROM users WHERE id=?", id); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// SetRole changes a user's role to "admin" or "user".
+//
+// When demoting an admin to "user", the last-admin guard (COUNT check + UPDATE)
+// runs inside a single transaction to prevent a TOCTOU race.
+func (r *UserRepo) SetRole(ctx context.Context, id int64, role string) error {
+	if role != "admin" && role != "user" {
+		return fmt.Errorf("invalid role %q: must be admin or user", role)
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Guard: refuse to demote the last admin.
+	if role == "user" {
+		var targetRole string
+		if err := tx.QueryRowContext(ctx, "SELECT role FROM users WHERE id=?", id).Scan(&targetRole); err != nil {
+			return fmt.Errorf("get user role: %w", err)
+		}
+		if targetRole == "admin" {
+			var adminCount int
+			if err := tx.QueryRowContext(ctx,
+				"SELECT COUNT(*) FROM users WHERE role='admin' AND id != ?", id,
+			).Scan(&adminCount); err != nil {
+				return fmt.Errorf("check admin count: %w", err)
+			}
+			if adminCount == 0 {
+				return fmt.Errorf("cannot demote the last admin user")
+			}
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx,
+		"UPDATE users SET role=?, updated_at=? WHERE id=?", role, time.Now().UTC(), id); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // PromoteFirstUser sets role='admin' on the user with the lowest id, if any.

--- a/internal/db/auth_test.go
+++ b/internal/db/auth_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -64,6 +65,120 @@ func TestGetByEmail_Empty(t *testing.T) {
 	}
 	if got != nil {
 		t.Errorf("expected nil for empty email, got %+v", got)
+	}
+}
+
+// TestDeleteLastAdmin verifies that deleting the sole admin is rejected.
+func TestDeleteLastAdmin(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewUserRepo(database)
+
+	admin, err := repo.Create(ctx, "root", "pw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.PromoteFirstUser(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	err = repo.Delete(ctx, admin.ID)
+	if err == nil {
+		t.Fatal("expected error when deleting last admin, got nil")
+	}
+	if !strings.Contains(err.Error(), "last admin") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestDeleteLastAdmin_TwoAdmins verifies that deleting one of two admins succeeds.
+func TestDeleteLastAdmin_TwoAdmins(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewUserRepo(database)
+
+	a, err := repo.Create(ctx, "alice", "pw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.PromoteFirstUser(ctx); err != nil {
+		t.Fatal(err)
+	}
+	b, err := repo.Create(ctx, "bob", "pw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SetRole(ctx, b.ID, "admin"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.Delete(ctx, a.ID); err != nil {
+		t.Errorf("expected success deleting one of two admins: %v", err)
+	}
+}
+
+// TestSetRoleLastAdmin verifies that demoting the sole admin is rejected.
+func TestSetRoleLastAdmin(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewUserRepo(database)
+
+	admin, err := repo.Create(ctx, "root", "pw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.PromoteFirstUser(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	err = repo.SetRole(ctx, admin.ID, "user")
+	if err == nil {
+		t.Fatal("expected error when demoting last admin, got nil")
+	}
+	if !strings.Contains(err.Error(), "last admin") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestSetRoleLastAdmin_TwoAdmins verifies that demoting one of two admins succeeds.
+func TestSetRoleLastAdmin_TwoAdmins(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewUserRepo(database)
+
+	a, err := repo.Create(ctx, "alice", "pw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.PromoteFirstUser(ctx); err != nil {
+		t.Fatal(err)
+	}
+	b, err := repo.Create(ctx, "bob", "pw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SetRole(ctx, b.ID, "admin"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.SetRole(ctx, a.ID, "user"); err != nil {
+		t.Errorf("expected success demoting one of two admins: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`UserRepo.Delete` and `UserRepo.SetRole` both guard against removing the last admin with a `SELECT COUNT(*)` followed by a separate `DELETE`/`UPDATE`. Two concurrent callers can both pass the count check and then both proceed, leaving the system with zero admins — a classic TOCTOU race (finding 5 from issue #712).

## Fix

Wrap the count check and the mutation together in a single transaction (`BeginTx` / `Commit` / deferred `Rollback`) in both methods. This matches the style already used by `TagRepo.SetAuthorTags` and `RecommendationRepo.ReplaceBatch` in this package. With SQLite's `MaxOpenConns=1` the transaction also serialises concurrent calls, but the approach is correct for any SQL backend that provides `SERIALIZABLE` isolation.

Only the last-admin guard in `Delete` and `SetRole` is changed. No migrations, no other files.

## Tests

Four new unit tests added to `internal/db/auth_test.go`:

- `TestDeleteLastAdmin` — sole admin deletion is rejected
- `TestDeleteLastAdmin_TwoAdmins` — deleting one of two admins succeeds
- `TestSetRoleLastAdmin` — demoting the sole admin is rejected
- `TestSetRoleLastAdmin_TwoAdmins` — demoting one of two admins succeeds

`go test ./internal/db/...` passes.

## Out of scope

The migration-transaction findings from #712 are deferred to a separate PR — they carry higher risk and were explicitly excluded from this fix.

Refs #712