### PR TITLE
fix(api): idempotent Approve/Blocklist, skip in-flight books in Fill series

### DIFF
--- a/internal/api/abs_review.go
+++ b/internal/api/abs_review.go
@@ -83,6 +83,13 @@ func (h *ABSReviewHandler) Approve(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "review item not found"})
 		return
 	}
+	// Reject re-approval of an item that has already left the pending state.
+	// Without this, a stale tab or a double-click re-runs ImportReview and
+	// imports the book a second time.
+	if item.Status != "pending" {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "review item is not pending (status: " + item.Status + ")"})
+		return
+	}
 
 	var payload abs.NormalizedLibraryItem
 	if err := json.Unmarshal([]byte(item.PayloadJSON), &payload); err != nil {

--- a/internal/api/history.go
+++ b/internal/api/history.go
@@ -88,6 +88,20 @@ func (h *HistoryHandler) Blocklist(w http.ResponseWriter, r *http.Request) {
 		guid = event.SourceTitle
 	}
 
+	// Idempotent: blocklisting the same release twice must not create a
+	// duplicate row. Create has no unique constraint to lean on.
+	if guid != "" {
+		blocked, err := h.blocklist.IsBlocked(r.Context(), guid)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		if blocked {
+			writeJSON(w, http.StatusOK, map[string]string{"status": "already blocklisted"})
+			return
+		}
+	}
+
 	entry := &models.BlocklistEntry{
 		BookID: event.BookID,
 		GUID:   guid,

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -404,7 +404,11 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *SeriesHandler) queueSeriesBook(ctx context.Context, b models.Book) (bool, error) {
-	if b.Status == models.BookStatusImported {
+	// Only act on books that are not already satisfied or in flight. Re-queuing
+	// a book that is downloading or downloaded would reset it to wanted and fire
+	// a second grab for a download already underway.
+	switch b.Status {
+	case models.BookStatusImported, models.BookStatusDownloading, models.BookStatusDownloaded:
 		return false, nil
 	}
 	if err := h.books.MarkWantedMonitored(ctx, b.ID); err != nil {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -97,7 +97,7 @@ export interface SystemStatus {
 }
 
 export interface AuthConfig {
-  mode: 'enabled' | 'local-only' | 'disabled'
+  mode: 'enabled' | 'local-only' | 'disabled' | 'proxy'
   apiKey: string
   username: string
 }
@@ -393,7 +393,6 @@ export const api = {
 
   // Calibre
   testCalibre: () => request<CalibreTestResult>('/calibre/test', { method: 'POST' }),
-  calibreTestPaths: () => request<{ ok: string; message: string }>('/calibre/test-paths', { method: 'POST' }),
   calibreImportStart: () => request<CalibreImportProgress>('/calibre/import', { method: 'POST' }),
   calibreImportStatus: () => request<CalibreImportProgress>('/calibre/import/status'),
   calibreSyncStart: () => request<CalibreSyncProgress>('/calibre/sync', { method: 'POST' }),


### PR DESCRIPTION
Low-complexity fixes from the package-by-package review — `Refs #715`.

## Fixed

- **`internal/api/abs_review.go` `Approve`** — rejects re-approval of a non-`pending` review item with `409 Conflict` instead of re-running `ImportReview`. Previously a stale tab or double-click imported the book twice.
- **`internal/api/series.go` `queueSeriesBook`** — "Fill series" now skips books already `downloading`/`downloaded`, not just `imported`. Previously an in-flight book was reset to `wanted` and grabbed a second time.
- **`internal/api/history.go` `Blocklist`** — returns `200 {"status":"already blocklisted"}` when the GUID is already present instead of inserting a duplicate `blocklist` row (the table has no unique constraint; uses the existing `IsBlocked` repo method).
- **`web/src/api/client.ts`** — removed the dead `calibreTestPaths` client (the `/calibre/test-paths` route does not exist); widened `AuthConfig.mode` to include `'proxy'`, which the API can return.

## Deferred (remain open on #715)

- The queue-delete and format-delete **data-loss** findings — they need a frontend keep-data option, not mechanical.
- `Book.Update` status validation — a behavior change that could reject currently-accepted input.
- The non-transactional `SetConfig`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/api/...`
- [x] `cd web && npm run typecheck`