### PR TITLE
fix(downloader): SSRF guard on NZBGet fetch; redact SABnzbd API key in errors

### DIFF
--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
+	"github.com/vavallee/bindery/internal/httpsec"
 )
 
 // Client interacts with the NZBGet JSON-RPC API.
@@ -24,8 +25,9 @@ type Client struct {
 	http      *http.Client // NZBGet JSON-RPC transport
 	fetchHTTP *http.Client // used to fetch NZB content from indexers before submission
 	// username and password for HTTP Basic auth
-	username string
-	password string
+	username       string
+	password       string
+	validateNZBURL func(string) error // injectable for tests; nil uses httpsec.ValidateOutboundURL
 }
 
 // New creates a NZBGet client. urlBase is the optional reverse-proxy
@@ -42,6 +44,9 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 		password:  password,
 		http:      &http.Client{Timeout: 15 * time.Second},
 		fetchHTTP: &http.Client{Timeout: 60 * time.Second},
+		validateNZBURL: func(raw string) error {
+			return httpsec.ValidateOutboundURL(raw, httpsec.PolicyLAN)
+		},
 	}
 }
 
@@ -84,7 +89,17 @@ func (c *Client) Add(ctx context.Context, nzbURL, name, category string, priorit
 	return resp.Result, nil
 }
 
+func (c *Client) validateNZBFetchURL(raw string) error {
+	if c.validateNZBURL == nil {
+		return httpsec.ValidateOutboundURL(raw, httpsec.PolicyLAN)
+	}
+	return c.validateNZBURL(raw)
+}
+
 func (c *Client) fetchNZBContent(ctx context.Context, nzbURL string) ([]byte, error) {
+	if err := c.validateNZBFetchURL(nzbURL); err != nil {
+		return nil, fmt.Errorf("fetch nzb: %w", err)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, nzbURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("fetch nzb: %w", err)

--- a/internal/downloader/nzbget/client_test.go
+++ b/internal/downloader/nzbget/client_test.go
@@ -94,6 +94,11 @@ func TestTest_EmptyVersion(t *testing.T) {
 
 const testNZBContent = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE nzb PUBLIC "-//newzBin//DTD NZB 1.1//EN" "http://www.newzbin.com/DTD/nzb/nzb-1.1.dtd"><nzb></nzb>`
 
+// allowNZBFetch bypasses the SSRF guard for loopback test servers.
+func allowNZBFetch(c *Client) {
+	c.validateNZBURL = func(string) error { return nil }
+}
+
 // TestAdd verifies that Add fetches NZB content from the indexer and submits it
 // as base64 to NZBGet's append RPC (rather than sending a URL for NZBGet to
 // fetch itself, which fails when NZBGet can't reach the indexer).
@@ -114,6 +119,7 @@ func TestAdd(t *testing.T) {
 
 	host, port := serverHostPort(t, nzbgetSrv.URL)
 	c := New(host, port, "user", "pass", "", false)
+	allowNZBFetch(c)
 
 	id, err := c.Add(context.Background(), indexerSrv.URL+"/file.nzb", "Test Book", "books", 0)
 	if err != nil {
@@ -159,6 +165,7 @@ func TestAdd_Rejected(t *testing.T) {
 
 	host, port := serverHostPort(t, nzbgetSrv.URL)
 	c := New(host, port, "", "", "", false)
+	allowNZBFetch(c)
 
 	_, err := c.Add(context.Background(), indexerSrv.URL+"/bad.nzb", "Bad NZB", "books", 0)
 	if err == nil {
@@ -184,6 +191,7 @@ func TestAdd_FetchFailure(t *testing.T) {
 
 	host, port := serverHostPort(t, nzbgetSrv.URL)
 	c := New(host, port, "", "", "", false)
+	allowNZBFetch(c)
 
 	_, err := c.Add(context.Background(), indexerSrv.URL+"/file.nzb", "Book", "books", 0)
 	if err == nil {
@@ -191,6 +199,27 @@ func TestAdd_FetchFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "401") {
 		t.Errorf("expected HTTP 401 in error, got: %v", err)
+	}
+}
+
+// TestAdd_SSRFBlocked verifies that fetchNZBContent rejects loopback/private URLs
+// when the SSRF guard is active (i.e. not bypassed for tests).
+func TestAdd_SSRFBlocked(t *testing.T) {
+	nzbgetSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("NZBGet must not be called when SSRF guard blocks the indexer URL")
+	}))
+	defer nzbgetSrv.Close()
+
+	host, port := serverHostPort(t, nzbgetSrv.URL)
+	c := New(host, port, "", "", "", false)
+	// Do NOT call allowNZBFetch — the guard must be active.
+
+	_, err := c.Add(context.Background(), "http://127.0.0.1:9999/file.nzb", "Book", "books", 0)
+	if err == nil {
+		t.Fatal("expected SSRF guard to block loopback URL")
+	}
+	if !strings.Contains(err.Error(), "url not allowed") {
+		t.Errorf("expected 'url not allowed' in error, got: %v", err)
 	}
 }
 

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -161,6 +161,21 @@ func (c *Client) DeleteHistory(ctx context.Context, nzoID string, deleteFiles bo
 	return c.apiCall(ctx, params, &resp)
 }
 
+// redactAPIURL returns a copy of rawURL with the "apikey" query parameter
+// replaced by "REDACTED", safe for use in error messages and logs.
+func redactAPIURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "[unparseable url]"
+	}
+	q := parsed.Query()
+	if q.Get("apikey") != "" {
+		q.Set("apikey", "REDACTED")
+		parsed.RawQuery = q.Encode()
+	}
+	return parsed.String()
+}
+
 func (c *Client) apiCall(ctx context.Context, params url.Values, target interface{}) error {
 	params.Set("apikey", c.apiKey)
 	params.Set("output", "json")
@@ -168,12 +183,12 @@ func (c *Client) apiCall(ctx context.Context, params url.Values, target interfac
 	u := fmt.Sprintf("%s/api?%s", c.baseURL, params.Encode())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("build request for %s: %w", redactAPIURL(u), err)
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("request to %s: %w", redactAPIURL(u), err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
## Summary

- **Finding 2 (NZBGet SSRF):** `fetchNZBContent` fetched any user-supplied NZB URL with no validation, enabling SSRF to loopback or link-local addresses. Added `httpsec.ValidateOutboundURL(..., httpsec.PolicyLAN)` — the same guard the qBittorrent client uses — before the HTTP request. The validator is stored in an injectable `validateNZBURL` field on the struct so tests can bypass it for loopback servers. Added `TestAdd_SSRFBlocked` to exercise the guard path.

- **Finding 3 (SABnzbd API key leak):** `apiCall` built the full API URL including the `apikey` query parameter, then exposed it verbatim in errors returned from `http.NewRequestWithContext` and `http.Client.Do`. Added `redactAPIURL` which parses the URL and masks `apikey=REDACTED` before formatting any error message. The actual request URL sent over the wire is unchanged.

Refs #711

Finding 1 (DNS-rebinding) from #711 is deferred — it requires a more involved solution (custom dialer or resolver hook) and is tracked separately.