### PR TITLE
fix(downloader): SABnzbd tracking, Deluge add race, qBittorrent retry status

### DIFF
--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -340,7 +340,7 @@ func includeArrQueueItem(item enrichedQueueItem) bool {
 }
 
 func trackedDownloadStatus(item enrichedQueueItem) string {
-	if item.Download.ErrorMessage != "" || liveStatusIsError(item.Live.Status) {
+	if item.Download.ErrorMessage != "" || downloader.LiveStatusIsError(item.Live.Status) {
 		return "error"
 	}
 	switch item.Download.Status {
@@ -351,11 +351,6 @@ func trackedDownloadStatus(item enrichedQueueItem) string {
 		return "warning"
 	}
 	return "ok"
-}
-
-func liveStatusIsError(status string) bool {
-	status = strings.ToLower(status)
-	return strings.Contains(status, "error") || strings.Contains(status, "fail")
 }
 
 func queueItemSize(item enrichedQueueItem) int64 {

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -30,12 +30,15 @@ type LiveStatus struct {
 	Status string
 }
 
-// liveStatusIsError reports whether ls represents an error state.
-// It handles human-readable strings from clients such as qBittorrent, Deluge,
-// SABnzbd, NZBGet, and Transmission errorString overlays.
-func liveStatusIsError(ls LiveStatus) bool {
-	s := strings.ToLower(ls.Status)
-	return strings.Contains(s, "error") || strings.Contains(s, "fail")
+// LiveStatusIsError reports whether a client status string represents an error
+// state. It handles human-readable strings from qBittorrent (including the
+// "missingFiles" state), Deluge, SABnzbd, NZBGet, and Transmission
+// errorString overlays.
+func LiveStatusIsError(status string) bool {
+	s := strings.ToLower(status)
+	return strings.Contains(s, "error") ||
+		strings.Contains(s, "fail") ||
+		s == "missingfiles"
 }
 
 type SendResult struct {
@@ -154,9 +157,10 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		if err != nil {
 			return nil, err
 		}
-		if len(resp.NzoIDs) > 0 {
-			result.RemoteID = resp.NzoIDs[0]
+		if len(resp.NzoIDs) == 0 || strings.TrimSpace(resp.NzoIDs[0]) == "" {
+			return nil, fmt.Errorf("SABnzbd accepted the download but did not return a trackable NZO id")
 		}
+		result.RemoteID = resp.NzoIDs[0]
 		return result, nil
 	}
 }

--- a/internal/downloader/adapter_test.go
+++ b/internal/downloader/adapter_test.go
@@ -468,18 +468,18 @@ func TestSendDownload_SABnzbd(t *testing.T) {
 }
 
 func TestSendDownload_SABnzbd_NoNzoID(t *testing.T) {
+	// SABnzbd may report status:true but return an empty nzo_ids slice.
+	// This is not a usable success — the download becomes untrackable.
+	// SendDownload must return an error rather than a silent empty RemoteID.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"status": true, "nzo_ids": []string{}})
 	}))
 	defer srv.Close()
 	host, port := serverHostPort(t, srv.URL)
 	client := &models.DownloadClient{Type: "sabnzbd", Host: host, Port: port, APIKey: "k"}
-	result, err := SendDownload(context.Background(), client, "https://example.com/file.nzb", "My Book")
-	if err != nil {
-		t.Fatalf("SendDownload: %v", err)
-	}
-	if result.RemoteID != "" {
-		t.Errorf("expected empty RemoteID, got %q", result.RemoteID)
+	_, err := SendDownload(context.Background(), client, "https://example.com/file.nzb", "My Book")
+	if err == nil {
+		t.Fatal("expected an error when SABnzbd returns no NZO id, got nil")
 	}
 }
 
@@ -775,11 +775,13 @@ func TestLiveStatusIsError_StatusStrings(t *testing.T) {
 		{"failed", true},
 		{"Failed", true},
 		{"", false},
+		// qBittorrent missingFiles state
+		{"missingFiles", true},
+		{"missingfiles", true},
 	}
 	for _, tc := range tests {
-		ls := LiveStatus{Status: tc.status}
-		if got := liveStatusIsError(ls); got != tc.want {
-			t.Errorf("liveStatusIsError(%q) = %v, want %v", tc.status, got, tc.want)
+		if got := LiveStatusIsError(tc.status); got != tc.want {
+			t.Errorf("LiveStatusIsError(%q) = %v, want %v", tc.status, got, tc.want)
 		}
 	}
 }
@@ -815,7 +817,7 @@ func TestGetLiveStatusesTransmission_UsesErrorStringStatus(t *testing.T) {
 	if ls.Status != "error: No data found! Ensure your drives are connected" {
 		t.Errorf("unexpected Status=%q", ls.Status)
 	}
-	if !liveStatusIsError(ls) {
-		t.Error("expected liveStatusIsError to return true for Transmission errorString")
+	if !LiveStatusIsError(ls.Status) {
+		t.Error("expected LiveStatusIsError to return true for Transmission errorString")
 	}
 }

--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -35,7 +35,8 @@ type Client struct {
 	baseURL  string
 	password string
 	http     *http.Client
-	mu       sync.Mutex
+	mu       sync.Mutex // guards loggedIn
+	addMu    sync.Mutex // serialises addTorrentURL: keeps before/after hash diff atomic
 	loggedIn bool
 	reqID    atomic.Int64
 }
@@ -143,7 +144,14 @@ func (c *Client) addMagnet(ctx context.Context, magnet string) (string, error) {
 // (which saves it to a temp path on the Deluge server), then adds it via
 // web.add_torrents. The hash is resolved by polling the unfiltered torrent
 // list until a new hash (not in beforeSet) appears.
+//
+// addMu serialises concurrent calls so that each goroutine's before-snapshot →
+// submit → poll sequence is atomic. Without it two concurrent calls both
+// snapshot the same beforeSet, then cross-assign hashes.
 func (c *Client) addTorrentURL(ctx context.Context, torrentURL, label string) (string, error) {
+	c.addMu.Lock()
+	defer c.addMu.Unlock()
+
 	// Snapshot all existing hashes so we can identify the newly-added torrent.
 	beforeSet := map[string]struct{}{}
 	if before, err := c.GetTorrents(ctx); err == nil {

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -622,6 +622,10 @@ func (c *Client) get(ctx context.Context, path string) ([]byte, error) {
 			return nil, fmt.Errorf("GET %s (retry): %w", path, err)
 		}
 		defer resp2.Body.Close()
+		if resp2.StatusCode != http.StatusOK {
+			body2, _ := io.ReadAll(io.LimitReader(resp2.Body, 512))
+			return nil, fmt.Errorf("HTTP %d: %s", resp2.StatusCode, string(body2))
+		}
 		return io.ReadAll(resp2.Body)
 	}
 


### PR DESCRIPTION
## Fixes for issue #714 (all four findings)

### (a) SABnzbd empty NZO id — `internal/downloader/adapter.go`

`SendDownload` previously returned success with an empty `RemoteID` when
SABnzbd responded `status:true` but omitted `nzo_ids`. The download record
was then permanently untrackable. Now returns an error instead. The existing
`TestSendDownload_SABnzbd_NoNzoID` is inverted to assert the error.

### (b) Deluge concurrent-add race — `internal/downloader/deluge/client.go`

Added `addMu sync.Mutex` to `Client` (mirroring `qbittorrent.Client`) and
`Lock`/`defer Unlock` at the top of `addTorrentURL`. Without this, two
concurrent calls snapshot the same `beforeSet`, both submit torrents, and then
cross-assign hashes via the before/after diff. The magnet path (`addMagnet`)
returns the hash directly from the RPC response and does not need the lock.

### (c) qBittorrent retry missing status check — `internal/downloader/qbittorrent/client.go`

`get()` re-logs in after a 403 and retries, but was returning `resp2`'s body
without checking `resp2.StatusCode`. Added the same non-200 guard that the
first response already had, returning an `HTTP %d` error.

### (d) Consolidate `liveStatusIsError` — `internal/downloader/adapter.go`, `internal/api/queue.go`

The unexported `liveStatusIsError(LiveStatus)` in `adapter.go` and the
private `liveStatusIsError(string)` in `queue.go` are replaced by a single
exported `downloader.LiveStatusIsError(string)`. The new function also
recognises the qBittorrent `missingFiles` state as an error. `queue.go`'s
caller is updated to use `downloader.LiveStatusIsError`.

Closes #714

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)