### PR TITLE
fix(auth): export session error sentinels and enforce minimum secret length

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -172,7 +172,9 @@ func (h *AuthHandler) Setup(w http.ResponseWriter, r *http.Request) {
 	}
 	u.Role = "admin"
 	// Log the user in immediately.
-	h.issueSession(w, r, ctx, u.ID, true)
+	if !h.issueSession(w, r, ctx, u.ID, true) {
+		return
+	}
 	slog.Info("first-run setup complete", "username", u.Username)
 	writeOK(w, map[string]any{"ok": true})
 }
@@ -205,7 +207,9 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.limiter.Reset(ip)
-	h.issueSession(w, r, ctx, u.ID, req.RememberMe)
+	if !h.issueSession(w, r, ctx, u.ID, req.RememberMe) {
+		return
+	}
 	writeOK(w, map[string]any{"ok": true, "username": u.Username})
 }
 
@@ -392,13 +396,24 @@ func (h *AuthHandler) sessionSecret(ctx context.Context) []byte {
 	return []byte(s.Value)
 }
 
-func (h *AuthHandler) issueSession(w http.ResponseWriter, r *http.Request, ctx context.Context, userID int64, rememberMe bool) {
+// issueSession signs and sets the session cookie. It returns true on success.
+// On failure it writes a 500 error response and returns false — callers must
+// return immediately without writing any further response.
+func (h *AuthHandler) issueSession(w http.ResponseWriter, r *http.Request, ctx context.Context, userID int64, rememberMe bool) bool {
 	dur := auth.SessionDurationShort
 	if rememberMe {
 		dur = auth.SessionDuration
 	}
 	exp := time.Now().Add(dur)
-	value := auth.SignSession(h.sessionSecret(ctx), userID, exp)
+	value, err := auth.SignSession(h.sessionSecret(ctx), userID, exp)
+	if err != nil {
+		// Secret is absent or too short — fail closed rather than issue a
+		// forgeable token. This should never happen in practice because
+		// bootstrapAuth seeds a 32-byte secret before any requests are served,
+		// and the server exits if bootstrapAuth fails.
+		writeErr(w, http.StatusInternalServerError, "session signing unavailable")
+		return false
+	}
 
 	var secure bool
 	switch CookieSecureMode() {
@@ -423,6 +438,7 @@ func (h *AuthHandler) issueSession(w http.ResponseWriter, r *http.Request, ctx c
 		cookie.Expires = exp
 	}
 	http.SetCookie(w, cookie)
+	return true
 }
 
 func (h *AuthHandler) listAllUsers(ctx context.Context) ([]*db.User, error) {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"testing"
@@ -47,10 +48,16 @@ func TestVerifyPasswordRejectsMalformed(t *testing.T) {
 	}
 }
 
+// testSecret32 is a 32-byte secret suitable for session signing in tests.
+var testSecret32 = []byte("test-secret-32bytes-for-testing!")
+
 func TestSessionSignAndVerifyRoundtrip(t *testing.T) {
-	secret := []byte("test-secret-not-for-production")
+	secret := testSecret32
 	exp := time.Now().Add(time.Hour)
-	cookie := SignSession(secret, 42, exp)
+	cookie, err := SignSession(secret, 42, exp)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
 	uid, err := VerifySession(secret, cookie)
 	if err != nil {
 		t.Fatalf("verify: %v", err)
@@ -61,8 +68,11 @@ func TestSessionSignAndVerifyRoundtrip(t *testing.T) {
 }
 
 func TestSessionRejectsTamperedPayload(t *testing.T) {
-	secret := []byte("test-secret-not-for-production")
-	cookie := SignSession(secret, 1, time.Now().Add(time.Hour))
+	secret := testSecret32
+	cookie, err := SignSession(secret, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
 	// Swap the user id in the payload without re-signing.
 	tampered := "v1.9999." + cookie[len("v1.1."):]
 	if _, err := VerifySession(secret, tampered); err == nil {
@@ -71,17 +81,65 @@ func TestSessionRejectsTamperedPayload(t *testing.T) {
 }
 
 func TestSessionRejectsWrongSecret(t *testing.T) {
-	cookie := SignSession([]byte("one"), 1, time.Now().Add(time.Hour))
-	if _, err := VerifySession([]byte("two"), cookie); err == nil {
+	secretA := []byte("secret-A-for-signing-32bytes!!!!") // 32 bytes
+	secretB := []byte("secret-B-for-verify-32bytes!!!!")  // 32 bytes
+	cookie, err := SignSession(secretA, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if _, err := VerifySession(secretB, cookie); err == nil {
 		t.Fatal("verify accepted cookie signed with a different secret")
 	}
 }
 
 func TestSessionRejectsExpired(t *testing.T) {
-	secret := []byte("s")
-	cookie := SignSession(secret, 1, time.Now().Add(-time.Second))
+	secret := testSecret32
+	cookie, err := SignSession(secret, 1, time.Now().Add(-time.Second))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
 	if _, err := VerifySession(secret, cookie); err == nil {
 		t.Fatal("verify accepted an expired cookie")
+	}
+}
+
+func TestSessionRejectsShortSecret(t *testing.T) {
+	if _, err := SignSession([]byte("tooshort"), 1, time.Now().Add(time.Hour)); err == nil {
+		t.Fatal("SignSession must reject a secret shorter than 32 bytes")
+	}
+	if _, err := VerifySession([]byte("tooshort"), "v1.1.9999999999.AAAA"); err == nil {
+		t.Fatal("VerifySession must reject a secret shorter than 32 bytes")
+	}
+	if _, err := VerifySession(nil, "v1.1.9999999999.AAAA"); err == nil {
+		t.Fatal("VerifySession must reject a nil secret")
+	}
+}
+
+func TestSessionSentinelErrors(t *testing.T) {
+	secret := testSecret32
+
+	// Expired cookie must wrap ErrSessionExpired.
+	cookie, err := SignSession(secret, 1, time.Now().Add(-time.Second))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	_, err = VerifySession(secret, cookie)
+	if !errors.Is(err, ErrSessionExpired) {
+		t.Errorf("expired cookie: want errors.Is(err, ErrSessionExpired); got %v", err)
+	}
+
+	// Tampered cookie must wrap ErrSessionInvalid.
+	good, _ := SignSession(secret, 1, time.Now().Add(time.Hour))
+	tampered := "v1.9999." + good[len("v1.1."):]
+	_, err = VerifySession(secret, tampered)
+	if !errors.Is(err, ErrSessionInvalid) {
+		t.Errorf("tampered cookie: want errors.Is(err, ErrSessionInvalid); got %v", err)
+	}
+
+	// Short secret must wrap ErrSessionInvalid.
+	_, err = VerifySession([]byte("short"), good)
+	if !errors.Is(err, ErrSessionInvalid) {
+		t.Errorf("short secret: want errors.Is(err, ErrSessionInvalid); got %v", err)
 	}
 }
 
@@ -275,7 +333,7 @@ func TestMiddlewareAcceptsAPIKeyInQuery(t *testing.T) {
 }
 
 func TestMiddlewareAcceptsValidSessionCookie(t *testing.T) {
-	secret := []byte("hmac-secret")
+	secret := testSecret32
 	p := &fakeProvider{mode: ModeEnabled, secret: secret}
 	mw := Middleware(p)
 	var gotUID int64
@@ -283,7 +341,11 @@ func TestMiddlewareAcceptsValidSessionCookie(t *testing.T) {
 		gotUID = UserIDFromContext(r.Context())
 	}))
 	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
-	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: SignSession(secret, 7, time.Now().Add(time.Hour))})
+	cookie, err := SignSession(secret, 7, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: cookie})
 	h.ServeHTTP(nopWriter{}, req)
 	if gotUID != 7 {
 		t.Errorf("uid = %d; want 7", gotUID)
@@ -445,8 +507,11 @@ func TestRequireCSRFToken_AllowsUnauthPath(t *testing.T) {
 }
 
 func TestRequireCSRFToken_BlocksMutationWithSessionButNoToken(t *testing.T) {
-	secret := []byte("s")
-	sessionVal := SignSession(secret, 1, time.Now().Add(time.Hour))
+	secret := testSecret32
+	sessionVal, err := SignSession(secret, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
 	mw := RequireCSRFToken(func() []byte { return secret })
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
@@ -477,8 +542,11 @@ func TestRequireCSRFToken_AllowsMutationWithAPIKey(t *testing.T) {
 }
 
 func TestRequireCSRFToken_AllowsMutationWithValidToken(t *testing.T) {
-	secret := []byte("test-secret")
-	sessionVal := SignSession(secret, 1, time.Now().Add(time.Hour))
+	secret := testSecret32
+	sessionVal, err := SignSession(secret, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
 	token := MakeCSRFToken(secret, sessionVal)
 
 	mw := RequireCSRFToken(func() []byte { return secret })
@@ -494,8 +562,11 @@ func TestRequireCSRFToken_AllowsMutationWithValidToken(t *testing.T) {
 }
 
 func TestRequireCSRFToken_BlocksMutationWithWrongToken(t *testing.T) {
-	secret := []byte("test-secret")
-	sessionVal := SignSession(secret, 1, time.Now().Add(time.Hour))
+	secret := testSecret32
+	sessionVal, err := SignSession(secret, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
 
 	mw := RequireCSRFToken(func() []byte { return secret })
 	called := false
@@ -587,8 +658,11 @@ func buildCSRFStack(p Provider, secret []byte, inner http.Handler) http.Handler 
 	)
 }
 
+// stackSecret32 is a 32-byte secret for CSRF stack tests.
+var stackSecret32 = []byte("stack-secret-32-bytes-for-tests!")
+
 func TestCSRFStack_APIKeyRequestPassesAllGuards(t *testing.T) {
-	secret := []byte("stack-secret")
+	secret := stackSecret32
 	p := &fakeProvider{mode: ModeEnabled, apiKey: "harpoon-key", secret: secret}
 	called := false
 	stack := buildCSRFStack(p, secret, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -611,7 +685,7 @@ func TestCSRFStack_APIKeyRequestPassesAllGuards(t *testing.T) {
 }
 
 func TestCSRFStack_APIKeyGrabPassesAllGuards(t *testing.T) {
-	secret := []byte("stack-secret")
+	secret := stackSecret32
 	p := &fakeProvider{mode: ModeEnabled, apiKey: "harpoon-key", secret: secret}
 	called := false
 	stack := buildCSRFStack(p, secret, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -665,7 +739,7 @@ func TestRequireXRequestedWith_AllowsSetupEndpoint(t *testing.T) {
 // Regression test for Bug 11: API key auth bypasses CSRF but then fails at
 // the role check with a misleading "admin role required" 403.
 func TestAPIKeyAuthGrantsAdminRole(t *testing.T) {
-	secret := []byte("stack-secret")
+	secret := stackSecret32
 	p := &fakeProvider{mode: ModeEnabled, apiKey: "my-api-key", secret: secret}
 
 	called := false
@@ -688,7 +762,7 @@ func TestAPIKeyAuthGrantsAdminRole(t *testing.T) {
 // TestAPIKeyAuthRoleVisibleInContext verifies that the admin role is present in
 // the request context when API key auth is used, so handlers can inspect it.
 func TestAPIKeyAuthRoleVisibleInContext(t *testing.T) {
-	secret := []byte("stack-secret")
+	secret := stackSecret32
 	p := &fakeProvider{mode: ModeEnabled, apiKey: "my-api-key", secret: secret}
 
 	var gotRole string
@@ -705,7 +779,7 @@ func TestAPIKeyAuthRoleVisibleInContext(t *testing.T) {
 }
 
 func TestCSRFStack_BrowserSessionWithoutCSRFTokenIsRejected(t *testing.T) {
-	secret := []byte("stack-secret")
+	secret := stackSecret32
 	p := &fakeProvider{mode: ModeEnabled, apiKey: "harpoon-key", secret: secret}
 	called := false
 	stack := buildCSRFStack(p, secret, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
@@ -713,7 +787,10 @@ func TestCSRFStack_BrowserSessionWithoutCSRFTokenIsRejected(t *testing.T) {
 	}))
 
 	// Browser session cookie present but no CSRF token — CSRF attack scenario.
-	sessionVal := SignSession(secret, 1, time.Now().Add(time.Hour))
+	sessionVal, err := SignSession(secret, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
 	req, _ := http.NewRequest("POST", "/api/v1/queue/grab", nil)
 	req.Header.Set("X-Requested-With", "bindery-ui")
 	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessionVal})

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -22,41 +22,64 @@ const (
 	SessionDuration      = 30 * 24 * time.Hour // when "remember me" is checked
 	SessionDurationShort = 12 * time.Hour      // browser-session equivalent when not
 	sessionCookieVersion = "v1"
+
+	// minSecretLen is the minimum length (in bytes) required for a session
+	// signing secret. Shorter secrets are rejected fail-closed.
+	minSecretLen = 32
+)
+
+// Sentinel errors returned (wrapped) by VerifySession and SignSession.
+// Callers can use errors.Is to distinguish expiry from tamper/format failures.
+//
+//   - ErrSessionExpired  — the cookie is structurally valid but its expiry has passed.
+//   - ErrSessionInvalid  — the cookie is malformed, has a bad signature, or the
+//     session secret is absent / too short to be safe.
+var (
+	ErrSessionExpired = errors.New("session expired")
+	ErrSessionInvalid = errors.New("session invalid")
 )
 
 // SignSession returns a signed cookie value for the given user that expires at exp.
-func SignSession(secret []byte, userID int64, exp time.Time) string {
+// It returns an error if secret is nil or shorter than minSecretLen bytes.
+func SignSession(secret []byte, userID int64, exp time.Time) (string, error) {
+	if len(secret) < minSecretLen {
+		return "", fmt.Errorf("sign session: %w", ErrSessionInvalid)
+	}
 	payload := fmt.Sprintf("%s.%d.%d", sessionCookieVersion, userID, exp.Unix())
 	mac := hmacSum(secret, payload)
-	return payload + "." + base64.RawURLEncoding.EncodeToString(mac)
+	return payload + "." + base64.RawURLEncoding.EncodeToString(mac), nil
 }
 
 // VerifySession returns the user id carried by a valid, unexpired signed cookie,
 // or an error on any tamper/expiry/parse failure.
+// It returns ErrSessionInvalid (wrapped) when secret is absent/too short.
 func VerifySession(secret []byte, cookie string) (int64, error) {
+	if len(secret) < minSecretLen {
+		return 0, fmt.Errorf("verify session: %w", ErrSessionInvalid)
+	}
 	parts := strings.Split(cookie, ".")
 	if len(parts) != 4 || parts[0] != sessionCookieVersion {
-		return 0, errors.New("malformed session")
+		return 0, fmt.Errorf("malformed session: %w", ErrSessionInvalid)
 	}
 	userID, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
-		return 0, errors.New("bad user id")
+		return 0, fmt.Errorf("bad user id: %w", ErrSessionInvalid)
 	}
 	expUnix, err := strconv.ParseInt(parts[2], 10, 64)
 	if err != nil {
-		return 0, errors.New("bad expiry")
+		return 0, fmt.Errorf("bad expiry: %w", ErrSessionInvalid)
 	}
 	payload := strings.Join(parts[:3], ".")
 	want := hmacSum(secret, payload)
 	got, err := base64.RawURLEncoding.DecodeString(parts[3])
 	if err != nil {
-		return 0, errors.New("bad signature encoding")
+		return 0, fmt.Errorf("bad signature encoding: %w", ErrSessionInvalid)
 	}
 	if !hmac.Equal(got, want) {
-		return 0, errors.New("bad signature")
+		return 0, fmt.Errorf("bad signature: %w", ErrSessionInvalid)
 	}
 	if time.Now().Unix() > expUnix {
-		return 0, errors.New("expired")
+		return 0, fmt.Errorf("cookie expired: %w", ErrSessionExpired)
 	}
 	return userID, nil
 }


### PR DESCRIPTION
## Summary

Addresses two low-complexity security findings from #710.

### (a) Exported session error sentinels

`VerifySession` previously returned unexported `errors.New(...)` values (\"expired\", \"bad signature\", \"malformed session\", etc.) that callers could not distinguish via `errors.Is`. This commit exports two sentinels in `internal/auth/session.go`:

- `ErrSessionExpired` — the cookie is structurally valid but past its expiry timestamp
- `ErrSessionInvalid` — covers all tamper/format/missing-or-short-secret failures (grouped under one sentinel as the caller rarely needs to distinguish these)

All error returns in `VerifySession` are now wrapped with `fmt.Errorf("...: %w", sentinel)`. Existing call sites in `middleware.go` and `opds_auth.go` only check `err == nil` and are unaffected.

### (b) Session-secret fail-closed guard

`sessionSecret()` returns `nil`/empty when the DB row is absent; `SignSession`/`VerifySession` previously operated under a zero-length HMAC key, producing forgeable-but-accepted tokens.

A minimum secret length of 32 bytes is now enforced: both `SignSession` and `VerifySession` return `ErrSessionInvalid` (wrapped) when the secret is shorter than the threshold. `SignSession` signature changed to `(string, error)`. `issueSession` now returns `bool`; callers check it and return early, preventing a double response write.

**Seeding guarantee confirmed:** `bootstrapAuth()` in `cmd/bindery/main.go` (line 169) generates a 32-byte random secret and writes it to the DB before any HTTP handler is registered (server starts at line 947). `os.Exit(1)` is called if `bootstrapAuth` fails, so a missing secret cannot occur in normal operation. Part (b) is therefore safe to land.

### Deferred (out of scope)

- XFF-spoofing (#710 finding 3) — deferred
- Session-secret key rotation (#710 finding 4) — deferred

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/auth/... ./internal/api/...` — all pass
- [x] New tests: `TestSessionRejectsShortSecret`, `TestSessionSentinelErrors`
- [x] Updated existing tests to use ≥32-byte secrets now that `SignSession` enforces the minimum

Refs #710