### PR TITLE
chore(release): bindery v1.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.12.3] — 2026-05-20
+
 ### Security
 
 - **API-key regeneration and OIDC provider management now require an admin account** (#717) — `POST /auth/apikey/regenerate` and `PUT /auth/oidc/providers` sat outside the admin-only route group, so any signed-in non-admin user could rewrite OIDC config or regenerate the API key and read it back — and the API key grants admin access. Both routes are now behind the admin check.

--- a/charts/bindery/Chart.yaml
+++ b/charts/bindery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bindery
 description: Automated book download manager for Usenet and Torrents
 type: application
-version: 0.7.2
-appVersion: "1.12.2"
+version: 0.7.3
+appVersion: "1.12.3"
 home: https://github.com/vavallee/bindery
 sources:
   - https://github.com/vavallee/bindery

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindery-web",
   "private": true,
-  "version": "1.12.2",
+  "version": "1.12.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch release **v1.12.3** — the 11 fixes from the package-by-package review (PRs #716–#726).

- `[Unreleased]` → `[v1.12.3] — 2026-05-20`
- `charts/bindery/Chart.yaml`: version 0.7.2 → 0.7.3, appVersion 1.12.2 → 1.12.3
- `web/package.json`: 1.12.2 → 1.12.3

Highlights: admin-route gating for API-key/OIDC management, NZBGet SSRF guard + SABnzbd key redaction, session-secret fail-closed, hardlink import mode reachable again, scheduler overlap guard, last-admin atomicity. Full list in CHANGELOG.md.