### PR TITLE
feat(lifecycle): thread a process-lifecycle context to background workers

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -353,8 +353,19 @@ func main() {
 		}
 	}
 
+	// Process-lifecycle context. Unlike a per-request context this is not tied
+	// to any single HTTP request; it is cancelled when the process receives
+	// SIGINT/SIGTERM (graceful shutdown). Long-lived background goroutines —
+	// the scheduler's cron jobs and the recommendations goroutine — should
+	// derive from this so they observe shutdown instead of running against a
+	// context that never cancels. This commit only threads appCtx into the
+	// scheduler and the recommendation handler; converting the existing
+	// context.Background() call sites to use it is the job of #707 and #550.
+	appCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	// Scheduler
-	sched := scheduler.New(importScanner, idxSearcher, metaAgg,
+	sched := scheduler.New(appCtx, importScanner, idxSearcher, metaAgg,
 		authorRepo, bookRepo, indexerRepo, downloadRepo, dlClientRepo, settingsRepo, blocklistRepo)
 	sched.WithHistory(historyRepo)
 	sched.WithAliases(authorAliasRepo)
@@ -496,7 +507,8 @@ func main() {
 		func() calibre.Mode { return api.LoadCalibreMode(settingsRepo) },
 	)
 	recHandler := api.NewRecommendationHandler(recRepo, recEngine, authorRepo, bookRepo, sched).
-		WithFinder(seriesRepo, importScanner)
+		WithFinder(seriesRepo, importScanner).
+		WithAppContext(appCtx)
 	imageProxyHandler := api.NewImageProxyHandler(cfg.DataDir)
 	imageProxyHandler.StartEviction(24 * time.Hour)
 	migrateHandler := api.NewMigrateHandler(
@@ -921,9 +933,6 @@ func main() {
 		slog.Info("serving under path prefix", "urlBase", cfg.URLBase)
 	}
 
-	sigCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
 	gracePeriod := 30 * time.Second
 	if v := os.Getenv("BINDERY_SHUTDOWN_GRACE"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
@@ -953,7 +962,7 @@ func main() {
 			slog.Error("server failed", "error", err)
 			os.Exit(1)
 		}
-	case <-sigCtx.Done():
+	case <-appCtx.Done():
 		slog.Info("received shutdown signal, draining…")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), gracePeriod)
 		defer cancel()

--- a/internal/api/recommendations.go
+++ b/internal/api/recommendations.go
@@ -27,6 +27,12 @@ type RecommendationHandler struct {
 	series   *db.SeriesRepo
 	searcher BookSearcher
 	finder   LibraryFinder
+
+	// appCtx is the process-lifecycle context: not tied to any single HTTP
+	// request but cancelled when the process shuts down. Background work
+	// kicked off from a handler (which must outlive the request) will derive
+	// from it instead of context.Background() — see #550. Never nil.
+	appCtx context.Context
 }
 
 // WithFinder attaches a LibraryFinder so that Add can check whether the
@@ -34,6 +40,16 @@ type RecommendationHandler struct {
 func (h *RecommendationHandler) WithFinder(series *db.SeriesRepo, finder LibraryFinder) *RecommendationHandler {
 	h.series = series
 	h.finder = finder
+	return h
+}
+
+// WithAppContext attaches the process-lifecycle context so that background
+// work started from a request handler can be tied to process shutdown rather
+// than to context.Background(). A nil ctx is tolerated and ignored. See #550.
+func (h *RecommendationHandler) WithAppContext(ctx context.Context) *RecommendationHandler {
+	if ctx != nil {
+		h.appCtx = ctx
+	}
 	return h
 }
 
@@ -51,6 +67,7 @@ func NewRecommendationHandler(
 		authors:  authors,
 		books:    books,
 		searcher: searcher,
+		appCtx:   context.Background(),
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -59,6 +59,12 @@ type TelemetryPinger interface {
 
 // Scheduler runs background jobs on configurable intervals.
 type Scheduler struct {
+	// appCtx is the process-lifecycle context: it is not tied to any single
+	// HTTP request but is cancelled when the process shuts down. Background
+	// jobs that should observe shutdown will derive from it (see #707). It is
+	// never nil — New falls back to context.Background() when given a nil ctx.
+	appCtx context.Context
+
 	cron     *cron.Cron
 	scanner  *importer.Scanner
 	searcher bookSearcher
@@ -88,7 +94,14 @@ type Scheduler struct {
 const scheduledWantedSearchConcurrency = 2
 
 // New creates a new scheduler.
+//
+// appCtx is the process-lifecycle context — a context that is not tied to any
+// single HTTP request but is cancelled when the process shuts down. It is
+// stored on the Scheduler so background jobs can later derive request-free,
+// shutdown-aware contexts from it (see #707). A nil appCtx is tolerated and
+// replaced with context.Background().
 func New(
+	appCtx context.Context,
 	scanner *importer.Scanner,
 	searcher *indexer.Searcher,
 	meta *metadata.Aggregator,
@@ -100,7 +113,11 @@ func New(
 	settings *db.SettingsRepo,
 	blocklist *db.BlocklistRepo,
 ) *Scheduler {
+	if appCtx == nil {
+		appCtx = context.Background()
+	}
 	return &Scheduler{
+		appCtx:    appCtx,
 		cron:      cron.New(cron.WithSeconds(), cron.WithChain(cron.SkipIfStillRunning(cron.DefaultLogger))),
 		scanner:   scanner,
 		searcher:  searcher,

--- a/internal/scheduler/scheduler_jobs_test.go
+++ b/internal/scheduler/scheduler_jobs_test.go
@@ -63,12 +63,15 @@ func TestNew_Construction(t *testing.T) {
 	settings := db.NewSettingsRepo(database)
 	blocklist := db.NewBlocklistRepo(database)
 
-	s := New(nil, nil, nil, authors, books, indexers, downloads, clients, settings, blocklist)
+	s := New(context.Background(), nil, nil, nil, authors, books, indexers, downloads, clients, settings, blocklist)
 	if s == nil {
 		t.Fatal("New returned nil")
 	}
 	if s.cron == nil {
 		t.Fatal("cron field not initialized")
+	}
+	if s.appCtx == nil {
+		t.Fatal("appCtx field not initialized")
 	}
 	if s.authors != authors {
 		t.Error("authors repo not assigned")


### PR DESCRIPTION
## What

Introduces an explicit **process-lifecycle context** and threads it into the background workers that need it. This is a foundation PR — plumbing only.

A process-lifecycle context is a `context.Context` that is **not tied to any single HTTP request** but **is cancelled when the process shuts down** (SIGINT/SIGTERM).

## Why

`cmd/bindery/main.go` already had a `signal.NotifyContext(...)` graceful-shutdown context, but it was created *late* — after the scheduler was constructed and started and after every API handler was built. Background goroutines therefore had no handle on it. As a result:

- scheduler cron jobs run against `context.Background()` (#707)
- a recommendations goroutine runs against `context.Background()` (#550)

both of which never cancel, so that work cannot observe process shutdown.

## What changed

- `cmd/bindery/main.go`: the `signal.NotifyContext` is created earlier (as `appCtx`) so it exists before the scheduler and handlers are built. The existing graceful-shutdown `select` still drives `srv.Shutdown`; it now selects on `appCtx.Done()`. No second context is introduced.
- `scheduler.New`: new first parameter `appCtx context.Context`, stored as `Scheduler.appCtx`. Nil is tolerated (falls back to `context.Background()`).
- `RecommendationHandler`: new `WithAppContext(ctx)` builder method (mirrors the existing `WithFinder` pattern), stored as the `appCtx` field; constructor defaults the field to `context.Background()`.
- `internal/scheduler/scheduler_jobs_test.go`: updated for the new `New` signature.

## What this PR deliberately does NOT do

It does **not** change any existing goroutine. Every `context.Background()` call site in `internal/scheduler` and `internal/api/recommendations.go` is left exactly as-is. Converting those to consume `appCtx` is the job of the follow-up issues — this PR just makes the lifecycle context reachable.

## Verification

- `gofmt -w` on all touched files
- `go build ./...` — passes
- `go test ./cmd/... ./internal/scheduler/... ./internal/api/...` — passes

Refs #707
Refs #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)