### PR TITLE
fix(api): tie the recommendations background goroutine to the app lifecycle

### DIFF
--- a/internal/api/recommendations.go
+++ b/internal/api/recommendations.go
@@ -180,17 +180,21 @@ func (h *RecommendationHandler) Add(w http.ResponseWriter, r *http.Request) {
 	_ = h.recs.Dismiss(r.Context(), 1, id)
 
 	// Trigger search in background unless the file already exists on disk.
+	// Use the process-lifecycle context so the goroutine is cancelled on
+	// shutdown rather than running forever on context.Background(). See #550.
 	if h.searcher != nil && !fileFound {
-		go h.searcher.SearchAndGrabBook(context.Background(), *book) // #nosec G118 -- intentional: search must outlive the request
+		go h.searcher.SearchAndGrabBook(h.appCtx, *book) // #nosec G118 -- intentional: search must outlive the request
 	}
 
 	writeJSON(w, http.StatusCreated, book)
 }
 
 // Refresh triggers a recommendation engine run in the background.
+// The goroutine derives its context from the process-lifecycle context so it
+// is cancelled on shutdown instead of running on context.Background(). See #550.
 func (h *RecommendationHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	go func() {
-		if err := h.engine.Run(context.Background(), 1); err != nil {
+		if err := h.engine.Run(h.appCtx, 1); err != nil {
 			slog.Error("recommendation refresh failed", "error", err)
 		}
 	}()


### PR DESCRIPTION
## Summary

- Two goroutines in `RecommendationHandler` (`Add` and `Refresh`) were using `context.Background()`, giving them no cancellation path on process shutdown. They could hold DB connections and upstream HTTP sockets open indefinitely.
- The process-lifecycle infrastructure was already in place: `WithAppContext` stores an app-scoped context on the handler, and `main.go` already calls `.WithAppContext(appCtx)` when constructing the handler.
- Both goroutines now derive their context from `h.appCtx` instead of `context.Background()`, so SIGTERM/SIGINT cancels them during graceful shutdown.
- No `context.WithoutCancel` needed — neither goroutine requires request-scoped values, and the intent of #550 is app-lifecycle cancellation, not request isolation.

## Test plan

- [x] `gofmt -w` — no diff
- [x] `go build ./...` — clean
- [x] `go test ./internal/api/... ./cmd/...` — all pass (`ok github.com/vavallee/bindery/internal/api 11.775s`)
- [ ] Manually trigger a Refresh and kill the process mid-run; confirm the goroutine exits promptly

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)