### PR TITLE
fix(db): run each migration in a transaction

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -270,24 +270,13 @@ func reconcileMigrationVersions(database *sql.DB, entries []os.DirEntry) error {
 		indexToFilename[i+1] = fv
 	}
 
-	rows, err := database.Query("SELECT version FROM schema_migrations ORDER BY version")
+	// Read in a helper so the result set is fully closed before the rewrite
+	// transaction below — the pool is single-connection, so an open query
+	// would deadlock database.Begin().
+	recorded, err := readRecordedVersions(database)
 	if err != nil {
-		return fmt.Errorf("read schema_migrations for reconciliation: %w", err)
+		return err
 	}
-	var recorded []int
-	for rows.Next() {
-		var v int
-		if err := rows.Scan(&v); err != nil {
-			rows.Close()
-			return fmt.Errorf("scan schema_migrations version: %w", err)
-		}
-		recorded = append(recorded, v)
-	}
-	if err := rows.Err(); err != nil {
-		rows.Close()
-		return fmt.Errorf("iterate schema_migrations: %w", err)
-	}
-	rows.Close()
 
 	if len(recorded) == 0 {
 		return nil // fresh DB — nothing to reconcile
@@ -345,6 +334,29 @@ func reconcileMigrationVersions(database *sql.DB, entries []os.DirEntry) error {
 	}
 	slog.Info("reconciled schema_migrations to filename-based versions", "rows", len(recorded))
 	return nil
+}
+
+// readRecordedVersions returns every version in schema_migrations, ascending.
+// It exists as a separate function so the result set is closed (via defer)
+// before any caller starts a write transaction — the pool is single-connection.
+func readRecordedVersions(database *sql.DB) ([]int, error) {
+	rows, err := database.Query("SELECT version FROM schema_migrations ORDER BY version")
+	if err != nil {
+		return nil, fmt.Errorf("read schema_migrations for reconciliation: %w", err)
+	}
+	defer rows.Close()
+	var recorded []int
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			return nil, fmt.Errorf("scan schema_migrations version: %w", err)
+		}
+		recorded = append(recorded, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate schema_migrations: %w", err)
+	}
+	return recorded, nil
 }
 
 // applyMigration runs a single migration's statements and records it in

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -157,6 +158,23 @@ func setPragmas(db *sql.DB) error {
 	return nil
 }
 
+// migrationVersion parses the canonical version number from a migration
+// filename's numeric prefix (e.g. "011_calibre_mode.sql" -> 11). The version
+// is the filename number, NOT the position in the sorted slice: the migration
+// set has a gap at 010, so index-based numbering would offset every migration
+// from 011 onward and silently skip a future 010_*.sql file.
+func migrationVersion(filename string) (int, error) {
+	prefix, _, ok := strings.Cut(filename, "_")
+	if !ok {
+		return 0, fmt.Errorf("migration %q has no numeric prefix", filename)
+	}
+	v, err := strconv.Atoi(prefix)
+	if err != nil {
+		return 0, fmt.Errorf("migration %q has non-numeric prefix %q: %w", filename, prefix, err)
+	}
+	return v, nil
+}
+
 func migrate(database *sql.DB) error {
 	// Create a migrations tracking table
 	_, err := database.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -178,8 +196,19 @@ func migrate(database *sql.DB) error {
 		return entries[i].Name() < entries[j].Name()
 	})
 
-	for version, entry := range entries {
-		v := version + 1 // 1-indexed
+	// Older Bindery builds recorded schema_migrations.version as the 0-based
+	// slice index + 1 instead of the filename number. Reconcile any such DB to
+	// filename-based versions exactly once, before the apply loop, so neither
+	// scheme re-runs nor skips a migration. See reconcileMigrationVersions.
+	if err := reconcileMigrationVersions(database, entries); err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		v, err := migrationVersion(entry.Name())
+		if err != nil {
+			return err
+		}
 
 		// Check if already applied
 		var count int
@@ -202,40 +231,232 @@ func migrate(database *sql.DB) error {
 			return fmt.Errorf("read migration %s: %w", entry.Name(), err)
 		}
 
-		sqlStr := string(content)
-		if idx := strings.Index(sqlStr, "-- +migrate Down"); idx >= 0 {
-			sqlStr = sqlStr[:idx]
-		}
-		sqlStr = strings.Replace(sqlStr, "-- +migrate Up", "", 1)
-
-		// Execute each statement individually
-		for _, stmt := range strings.Split(sqlStr, ";") {
-			// Strip comment-only lines
-			lines := strings.Split(stmt, "\n")
-			var cleaned []string
-			for _, line := range lines {
-				trimmed := strings.TrimSpace(line)
-				if trimmed == "" || strings.HasPrefix(trimmed, "--") {
-					continue
-				}
-				cleaned = append(cleaned, line)
-			}
-			stmt = strings.TrimSpace(strings.Join(cleaned, "\n"))
-			if stmt == "" {
-				continue
-			}
-			if _, err := database.Exec(stmt); err != nil {
-				return fmt.Errorf("migration %d statement: %w\nSQL: %s", v, err, stmt)
-			}
-		}
-
-		if _, err := database.Exec("INSERT INTO schema_migrations (version) VALUES (?)", v); err != nil {
-			return fmt.Errorf("record migration %d: %w", v, err)
+		if err := applyMigration(database, v, entry.Name(), string(content)); err != nil {
+			return err
 		}
 		slog.Info("applied migration", "version", v, "file", entry.Name())
 	}
 
 	return nil
+}
+
+// reconcileMigrationVersions detects a schema_migrations table that was written
+// by the legacy index-based runner and rewrites its rows to filename-based
+// versions. The legacy runner stored version = (sorted slice index)+1; the
+// current runner stores version = the filename numeric prefix. Because the
+// migration set has a gap at 010, the two schemes diverge for every migration
+// from 011 onward.
+//
+// The reconciliation is safe and idempotent:
+//   - It only fires when the highest recorded version is consistent with the
+//     index scheme (<= migration count) AND inconsistent with the filename
+//     scheme (a row exists whose version is not a valid filename number).
+//   - The index->filename mapping is the sorted slice itself, so it is exact.
+//   - Once rewritten, all versions are valid filename numbers and the guard
+//     no longer fires.
+//
+// A fresh database has no schema_migrations rows and is left untouched.
+func reconcileMigrationVersions(database *sql.DB, entries []os.DirEntry) error {
+	// Build the set of valid filename-based versions, and the index->filename
+	// mapping (1-based index, matching the legacy +1 numbering).
+	filenameVersions := make(map[int]bool, len(entries))
+	indexToFilename := make(map[int]int, len(entries))
+	for i, entry := range entries {
+		fv, err := migrationVersion(entry.Name())
+		if err != nil {
+			return err
+		}
+		filenameVersions[fv] = true
+		indexToFilename[i+1] = fv
+	}
+
+	rows, err := database.Query("SELECT version FROM schema_migrations ORDER BY version")
+	if err != nil {
+		return fmt.Errorf("read schema_migrations for reconciliation: %w", err)
+	}
+	var recorded []int
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan schema_migrations version: %w", err)
+		}
+		recorded = append(recorded, v)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("iterate schema_migrations: %w", err)
+	}
+	rows.Close()
+
+	if len(recorded) == 0 {
+		return nil // fresh DB — nothing to reconcile
+	}
+
+	// If every recorded version is already a valid filename number, the DB is
+	// either fresh-on-new-runner or already reconciled. Leave it alone.
+	allFilenameBased := true
+	for _, v := range recorded {
+		if !filenameVersions[v] {
+			allFilenameBased = false
+			break
+		}
+	}
+	if allFilenameBased {
+		return nil
+	}
+
+	// At least one row is not a valid filename version. Only treat it as a
+	// legacy index-based DB if every recorded version is a valid index
+	// (1..len(entries)); otherwise the table is corrupt in a way we must not
+	// silently "fix".
+	for _, v := range recorded {
+		if v < 1 || v > len(entries) {
+			return fmt.Errorf(
+				"schema_migrations contains version %d that is neither a valid "+
+					"migration filename number nor a valid legacy index (1..%d); "+
+					"refusing to reconcile a corrupt migrations table",
+				v, len(entries))
+		}
+	}
+
+	// Every row is a valid legacy index. Rewrite them to filename versions in
+	// a single transaction. Rewrite in descending order so an intermediate
+	// (index, filename) pair can never collide with a not-yet-rewritten row.
+	tx, err := database.Begin()
+	if err != nil {
+		return fmt.Errorf("begin migration-version reconciliation: %w", err)
+	}
+	for i := len(recorded) - 1; i >= 0; i-- {
+		oldV := recorded[i]
+		newV := indexToFilename[oldV]
+		if newV == oldV {
+			continue
+		}
+		if _, err := tx.Exec(
+			"UPDATE schema_migrations SET version = ? WHERE version = ?", newV, oldV,
+		); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("reconcile migration version %d -> %d: %w", oldV, newV, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit migration-version reconciliation: %w", err)
+	}
+	slog.Info("reconciled schema_migrations to filename-based versions", "rows", len(recorded))
+	return nil
+}
+
+// applyMigration runs a single migration's statements and records it in
+// schema_migrations, all inside one transaction so a crash or error mid-way
+// leaves the database unchanged (no partial DDL, no missing version row).
+//
+// SQLite cannot change PRAGMA foreign_keys inside a transaction, so migrations
+// that need FK enforcement disabled for a table rebuild (007, 034) carry a
+// bare `PRAGMA foreign_keys=OFF/ON` line. Those lines are stripped from the
+// transactional body; instead FK enforcement is toggled OFF before BEGIN and
+// unconditionally restored to ON afterwards via defer — so a failed migration
+// can never leave FK enforcement off on the pooled connection.
+func applyMigration(database *sql.DB, version int, name, content string) (err error) {
+	statements, togglesForeignKeys := parseMigration(content)
+
+	if togglesForeignKeys {
+		if _, e := database.Exec("PRAGMA foreign_keys=OFF"); e != nil {
+			return fmt.Errorf("migration %d: disable foreign keys: %w", version, e)
+		}
+		// Restore FK enforcement no matter how this function returns. The
+		// pooled connection (MaxOpenConns=1) is shared for the process
+		// lifetime, so leaving it OFF would silently disable FK checks.
+		defer func() {
+			if _, e := database.Exec("PRAGMA foreign_keys=ON"); e != nil && err == nil {
+				err = fmt.Errorf("migration %d: restore foreign keys: %w", version, e)
+			}
+		}()
+	}
+
+	tx, err := database.Begin()
+	if err != nil {
+		return fmt.Errorf("migration %d: begin transaction: %w", version, err)
+	}
+	// Roll back on any early return. A no-op after a successful Commit.
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	for _, stmt := range statements {
+		if _, e := tx.Exec(stmt); e != nil {
+			return fmt.Errorf("migration %d statement: %w\nSQL: %s", version, e, stmt)
+		}
+	}
+
+	if togglesForeignKeys {
+		// Documented SQLite table-rebuild ordering: verify referential
+		// integrity before committing the FK-disabled rebuild.
+		var fkRows int
+		row := tx.QueryRow("SELECT COUNT(*) FROM pragma_foreign_key_check")
+		if e := row.Scan(&fkRows); e != nil {
+			return fmt.Errorf("migration %d: foreign_key_check: %w", version, e)
+		}
+		if fkRows > 0 {
+			return fmt.Errorf("migration %d: foreign_key_check found %d violation(s)", version, fkRows)
+		}
+	}
+
+	if _, e := tx.Exec("INSERT INTO schema_migrations (version) VALUES (?)", version); e != nil {
+		return fmt.Errorf("record migration %d: %w", version, e)
+	}
+
+	if e := tx.Commit(); e != nil {
+		return fmt.Errorf("migration %d: commit: %w", version, e)
+	}
+	return nil
+}
+
+// parseMigration splits a migration file's "Up" section into individual
+// executable statements. Bare `PRAGMA foreign_keys=ON/OFF` statements are
+// removed from the returned slice (they cannot run inside a transaction) and
+// reported via the second return value so the caller can toggle the pragma
+// outside the transaction.
+func parseMigration(content string) (statements []string, togglesForeignKeys bool) {
+	sqlStr := content
+	if idx := strings.Index(sqlStr, "-- +migrate Down"); idx >= 0 {
+		sqlStr = sqlStr[:idx]
+	}
+	sqlStr = strings.Replace(sqlStr, "-- +migrate Up", "", 1)
+
+	for _, stmt := range strings.Split(sqlStr, ";") {
+		// Strip comment-only lines
+		lines := strings.Split(stmt, "\n")
+		var cleaned []string
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || strings.HasPrefix(trimmed, "--") {
+				continue
+			}
+			cleaned = append(cleaned, line)
+		}
+		stmt = strings.TrimSpace(strings.Join(cleaned, "\n"))
+		if stmt == "" {
+			continue
+		}
+		// PRAGMA foreign_keys is a no-op inside a transaction; pull it out of
+		// the transactional body and signal the caller to handle it.
+		if isForeignKeysPragma(stmt) {
+			togglesForeignKeys = true
+			continue
+		}
+		statements = append(statements, stmt)
+	}
+	return statements, togglesForeignKeys
+}
+
+// isForeignKeysPragma reports whether stmt is a bare `PRAGMA foreign_keys=...`
+// statement, tolerating case and whitespace variations.
+func isForeignKeysPragma(stmt string) bool {
+	normalized := strings.ToLower(strings.Join(strings.Fields(stmt), ""))
+	return strings.HasPrefix(normalized, "pragmaforeign_keys=")
 }
 
 // multiuserPreFlight checks that the database is in a consistent state before

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -140,17 +141,11 @@ func TestMigrate033ABSReviewResolutionIdempotent(t *testing.T) {
 
 func migrationVersionForTest(t *testing.T, filename string) int {
 	t.Helper()
-	entries, err := migrationsFS.ReadDir("migrations")
+	v, err := migrationVersion(filename)
 	if err != nil {
-		t.Fatalf("read migrations: %v", err)
+		t.Fatalf("migration version for %s: %v", filename, err)
 	}
-	for i, entry := range entries {
-		if entry.Name() == filename {
-			return i + 1
-		}
-	}
-	t.Fatalf("migration %s not found", filename)
-	return 0
+	return v
 }
 
 // TestMigrate008_CalibreOnFreshDB verifies the v0.8.0 Calibre migration
@@ -1475,10 +1470,11 @@ func TestMigrate026_DedupBooks(t *testing.T) {
 		t.Fatal("insert history:", err)
 	}
 
-	// Re-run migrate (026 is position 25 in the sorted migration list and was
-	// already applied to the empty DB; roll back its marker so migrate() re-runs
-	// it against the seeded duplicate rows).
-	database.ExecContext(ctx, `DELETE FROM schema_migrations WHERE version=25`)
+	// Re-run migrate (026 was already applied to the empty DB; roll back its
+	// marker so migrate() re-runs it against the seeded duplicate rows). The
+	// version is the filename number, not the slice index.
+	v026 := migrationVersionForTest(t, "026_dedup_books.sql")
+	database.ExecContext(ctx, `DELETE FROM schema_migrations WHERE version=?`, v026)
 	if err := migrate(database); err != nil {
 		t.Fatal("re-run migrate:", err)
 	}
@@ -1508,4 +1504,290 @@ func TestMigrate026_DedupBooks(t *testing.T) {
 	if hBookID != idA {
 		t.Errorf("history.book_id: expected %d (winner), got %d", idA, hBookID)
 	}
+}
+
+// TestApplyMigrationRollsBackOnFailure verifies that a migration which fails
+// partway through leaves the database completely unchanged: no partial DDL and
+// no schema_migrations row. This is the core guarantee of finding 1.
+func TestApplyMigrationRollsBackOnFailure(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	// A migration whose first statement succeeds (creates a table) and whose
+	// second statement is invalid SQL. A non-transactional runner would leave
+	// rollback_probe behind; a transactional one must not.
+	const badMigration = `-- +migrate Up
+CREATE TABLE rollback_probe (id INTEGER PRIMARY KEY);
+THIS IS NOT VALID SQL;
+`
+	err = applyMigration(database, 9001, "9001_bad.sql", badMigration)
+	if err == nil {
+		t.Fatal("expected applyMigration to fail on invalid SQL")
+	}
+
+	// The table from the first statement must NOT exist — the tx rolled back.
+	var name string
+	qerr := database.QueryRow(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name='rollback_probe'",
+	).Scan(&name)
+	if qerr == nil {
+		t.Fatal("rollback_probe table survived a failed migration — not transactional")
+	}
+	if qerr != sql.ErrNoRows {
+		t.Fatalf("unexpected error checking for rollback_probe: %v", qerr)
+	}
+
+	// No schema_migrations row must have been recorded for the failed version.
+	var count int
+	if err := database.QueryRow(
+		"SELECT COUNT(*) FROM schema_migrations WHERE version = 9001",
+	).Scan(&count); err != nil {
+		t.Fatalf("count schema_migrations: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("failed migration recorded a schema_migrations row (count=%d)", count)
+	}
+}
+
+// TestApplyMigrationRestoresForeignKeysAfterFailure verifies that a migration
+// carrying `PRAGMA foreign_keys=OFF` which then fails still leaves FK
+// enforcement ON on the pooled connection. This is finding 4.
+func TestApplyMigrationRestoresForeignKeysAfterFailure(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	assertFKEnabled := func(stage string) {
+		t.Helper()
+		var on int
+		if err := database.QueryRow("PRAGMA foreign_keys").Scan(&on); err != nil {
+			t.Fatalf("read foreign_keys pragma (%s): %v", stage, err)
+		}
+		if on != 1 {
+			t.Fatalf("foreign_keys enforcement is OFF %s — finding 4 not fixed", stage)
+		}
+	}
+
+	assertFKEnabled("before migration")
+
+	// A migration that disables FKs (as 007/034 do) and then fails.
+	const badFKMigration = `-- +migrate Up
+PRAGMA foreign_keys=OFF;
+CREATE TABLE fk_probe (id INTEGER PRIMARY KEY);
+THIS IS NOT VALID SQL;
+`
+	err = applyMigration(database, 9002, "9002_bad_fk.sql", badFKMigration)
+	if err == nil {
+		t.Fatal("expected applyMigration to fail")
+	}
+
+	assertFKEnabled("after a failed FK-toggling migration")
+
+	// The probe table must also have been rolled back.
+	var name string
+	if qerr := database.QueryRow(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name='fk_probe'",
+	).Scan(&name); qerr != sql.ErrNoRows {
+		t.Fatalf("fk_probe table survived a failed migration (err=%v)", qerr)
+	}
+}
+
+// TestParseMigrationStripsForeignKeysPragma verifies that bare PRAGMA
+// foreign_keys statements are pulled out of the transactional statement list
+// and reported, while the real DDL is preserved.
+func TestParseMigrationStripsForeignKeysPragma(t *testing.T) {
+	content007, err := migrationsFS.ReadFile("migrations/007_downloads_fk_set_null.sql")
+	if err != nil {
+		t.Fatalf("read 007: %v", err)
+	}
+	stmts, toggles := parseMigration(string(content007))
+	if !toggles {
+		t.Fatal("007 should be detected as toggling foreign_keys")
+	}
+	for _, s := range stmts {
+		if isForeignKeysPragma(s) {
+			t.Fatalf("PRAGMA foreign_keys leaked into transactional statements: %q", s)
+		}
+	}
+
+	// 026 has no PRAGMA foreign_keys line, so it is fully covered by the
+	// transactional runner with no special handling (finding 3).
+	content026, err := migrationsFS.ReadFile("migrations/026_dedup_books.sql")
+	if err != nil {
+		t.Fatalf("read 026: %v", err)
+	}
+	_, toggles026 := parseMigration(string(content026))
+	if toggles026 {
+		t.Fatal("026 unexpectedly toggles foreign_keys")
+	}
+}
+
+// TestMigrationVersionIsFilenameNumber verifies the canonical version is the
+// filename prefix, not the slice index. With the 010 gap, migration 011 must
+// resolve to version 11 (finding 2).
+func TestMigrationVersionIsFilenameNumber(t *testing.T) {
+	cases := map[string]int{
+		"001_initial.sql":                    1,
+		"009_author_aliases.sql":             9,
+		"011_calibre_mode.sql":               11,
+		"040_download_client_path_remap.sql": 40,
+	}
+	for name, want := range cases {
+		got, err := migrationVersion(name)
+		if err != nil {
+			t.Errorf("migrationVersion(%q): %v", name, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("migrationVersion(%q) = %d, want %d", name, got, want)
+		}
+	}
+	if _, err := migrationVersion("noprefix.sql"); err == nil {
+		t.Error("expected error for filename without numeric prefix")
+	}
+}
+
+// TestReconcileMigrationVersions verifies that a database written by the
+// legacy index-based runner is rewritten to filename-based versions exactly
+// once, without re-running or skipping any migration (finding 2, safety).
+func TestReconcileMigrationVersions(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	entries, err := migrationsFS.ReadDir("migrations")
+	if err != nil {
+		t.Fatalf("read migrations: %v", err)
+	}
+	sortEntriesForTest(entries)
+
+	// Simulate a legacy DB: wipe schema_migrations and refill with index-based
+	// versions (1..N) as the old runner would have.
+	if _, err := database.Exec("DELETE FROM schema_migrations"); err != nil {
+		t.Fatalf("clear schema_migrations: %v", err)
+	}
+	for i := range entries {
+		if _, err := database.Exec(
+			"INSERT INTO schema_migrations (version) VALUES (?)", i+1,
+		); err != nil {
+			t.Fatalf("seed legacy version %d: %v", i+1, err)
+		}
+	}
+
+	// Reconcile.
+	if err := reconcileMigrationVersions(database, entries); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	// Every recorded version must now equal a filename number, and the count
+	// must be unchanged (no migration lost).
+	var count int
+	if err := database.QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != len(entries) {
+		t.Fatalf("row count changed during reconciliation: got %d want %d", count, len(entries))
+	}
+	for _, entry := range entries {
+		v, err := migrationVersion(entry.Name())
+		if err != nil {
+			t.Fatalf("migrationVersion: %v", err)
+		}
+		var n int
+		if err := database.QueryRow(
+			"SELECT COUNT(*) FROM schema_migrations WHERE version = ?", v,
+		).Scan(&n); err != nil {
+			t.Fatalf("count version %d: %v", v, err)
+		}
+		if n != 1 {
+			t.Fatalf("after reconciliation version %d (%s) has %d rows, want 1", v, entry.Name(), n)
+		}
+	}
+
+	// Reconciling again must be a no-op (idempotent).
+	if err := reconcileMigrationVersions(database, entries); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	// A full migrate() after reconciliation must not re-run anything: no
+	// "already exists" errors, and the count stays put.
+	if err := migrate(database); err != nil {
+		t.Fatalf("migrate after reconciliation re-ran a migration: %v", err)
+	}
+	if err := database.QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&count); err != nil {
+		t.Fatalf("count after migrate: %v", err)
+	}
+	if count != len(entries) {
+		t.Fatalf("migrate after reconciliation changed row count: got %d want %d", count, len(entries))
+	}
+}
+
+// TestReconcileMigrationVersionsLeavesFreshDB verifies a database already on
+// the filename-based scheme (or fresh) is untouched by reconciliation.
+func TestReconcileMigrationVersionsLeavesFreshDB(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	entries, err := migrationsFS.ReadDir("migrations")
+	if err != nil {
+		t.Fatalf("read migrations: %v", err)
+	}
+	sortEntriesForTest(entries)
+
+	before := make(map[int]bool)
+	rows, err := database.Query("SELECT version FROM schema_migrations")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		before[v] = true
+	}
+	rows.Close()
+
+	if err := reconcileMigrationVersions(database, entries); err != nil {
+		t.Fatalf("reconcile on already-filename-based DB: %v", err)
+	}
+
+	after := make(map[int]bool)
+	rows, err = database.Query("SELECT version FROM schema_migrations")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		after[v] = true
+	}
+	rows.Close()
+
+	if len(before) != len(after) {
+		t.Fatalf("reconciliation changed row count on a filename-based DB: %d -> %d", len(before), len(after))
+	}
+	for v := range before {
+		if !after[v] {
+			t.Fatalf("reconciliation dropped version %d on a filename-based DB", v)
+		}
+	}
+}
+
+func sortEntriesForTest(entries []os.DirEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1744,37 +1744,13 @@ func TestReconcileMigrationVersionsLeavesFreshDB(t *testing.T) {
 	}
 	sortEntriesForTest(entries)
 
-	before := make(map[int]bool)
-	rows, err := database.Query("SELECT version FROM schema_migrations")
-	if err != nil {
-		t.Fatalf("query: %v", err)
-	}
-	for rows.Next() {
-		var v int
-		if err := rows.Scan(&v); err != nil {
-			t.Fatalf("scan: %v", err)
-		}
-		before[v] = true
-	}
-	rows.Close()
+	before := versionSetForTest(t, database)
 
 	if err := reconcileMigrationVersions(database, entries); err != nil {
 		t.Fatalf("reconcile on already-filename-based DB: %v", err)
 	}
 
-	after := make(map[int]bool)
-	rows, err = database.Query("SELECT version FROM schema_migrations")
-	if err != nil {
-		t.Fatalf("query: %v", err)
-	}
-	for rows.Next() {
-		var v int
-		if err := rows.Scan(&v); err != nil {
-			t.Fatalf("scan: %v", err)
-		}
-		after[v] = true
-	}
-	rows.Close()
+	after := versionSetForTest(t, database)
 
 	if len(before) != len(after) {
 		t.Fatalf("reconciliation changed row count on a filename-based DB: %d -> %d", len(before), len(after))
@@ -1790,4 +1766,26 @@ func sortEntriesForTest(entries []os.DirEntry) {
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Name() < entries[j].Name()
 	})
+}
+
+// versionSetForTest returns every version recorded in schema_migrations.
+func versionSetForTest(t *testing.T, database *sql.DB) map[int]bool {
+	t.Helper()
+	rows, err := database.Query("SELECT version FROM schema_migrations")
+	if err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	defer rows.Close()
+	set := make(map[int]bool)
+	for rows.Next() {
+		var v int
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan version: %v", err)
+		}
+		set[v] = true
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate versions: %v", err)
+	}
+	return set
 }


### PR DESCRIPTION
## Summary

Implements the deferred findings of #712 in the `internal/db` migration runner. Finding 5 (last-admin TOCTOU) was already fixed separately and is untouched.

## Findings addressed

### Finding 1 — migrations not transactional — DONE
Each migration's full statement loop **and** its `schema_migrations` INSERT now run inside a single transaction (`applyMigration`). A crash or SQL error mid-migration rolls the whole thing back: no partial DDL, no orphaned/missing version row. The old runner `Exec`'d every statement separately, so a crash between 007's `DROP TABLE downloads` and the `RENAME` could lose the table permanently.

### Finding 3 — `026_dedup_books.sql` non-atomic — DONE (via finding 1)
`026` has **no** `PRAGMA foreign_keys` line, so its three CTE statements are fully covered by the transactional runner with no migration-file change needed. Confirmed by `TestParseMigrationStripsForeignKeysPragma`.

### Finding 4 — `PRAGMA foreign_keys=OFF` left on after failure — DONE
SQLite cannot change `PRAGMA foreign_keys` inside a transaction, so bare `PRAGMA foreign_keys=ON/OFF` lines (007, 034) are stripped from the transactional body. For those migrations FK enforcement is toggled OFF **before** `BEGIN` and unconditionally restored to ON via `defer` afterwards, so a failed migration can never leave FK checks disabled on the pooled (`MaxOpenConns=1`) connection. A `PRAGMA foreign_key_check` runs inside the tx before `COMMIT`, matching SQLite's documented table-rebuild ordering.

### Finding 2 — version recorded by slice index, not filename number — DONE
The recorded version is now the migration filename's numeric prefix (`migrationVersion`), not the 0-based slice index.

**This is the HIGH-RISK finding** — naively changing the scheme would make an existing DB re-run or skip migrations. It is implemented safely via a one-time reconciliation:

- `reconcileMigrationVersions` runs once before the apply loop. It detects a legacy index-based `schema_migrations` table and rewrites its rows to filename-based versions.
- The reconciliation is **guarded**: it only fires when every recorded row is a valid legacy index (`1..N`) but at least one is not a valid filename number. A DB already on the filename scheme, or a fresh DB, is left untouched.
- It **refuses** to "fix" a table that contains a version that is neither a valid filename number nor a valid index — that's surfaced as an error instead of silently mangling state.
- The index→filename mapping is derived from the sorted file list itself, so it is exact and tolerant of the existing `010` gap (and any future gap).
- It is idempotent — once rewritten, all versions are valid filename numbers and the guard no longer fires.

Net effect: neither the old nor the new scheme re-runs or skips a migration across the upgrade.

## Tests

Added to `db_test.go`:
- `TestApplyMigrationRollsBackOnFailure` — a failed migration leaves no partial DDL and no `schema_migrations` row
- `TestApplyMigrationRestoresForeignKeysAfterFailure` — FK enforcement stays ON after a failed FK-toggling migration
- `TestParseMigrationStripsForeignKeysPragma`
- `TestMigrationVersionIsFilenameNumber`
- `TestReconcileMigrationVersions` / `TestReconcileMigrationVersionsLeavesFreshDB`

Existing tests that hardcoded index-based versions (the 026 marker, `migrationVersionForTest`) were updated to the filename scheme.

## Verification

- `gofmt -w` applied
- `go build ./...` — passes
- `go vet ./internal/db/...` — passes
- `go test ./internal/db/...` — passes

Scope limited to `internal/db/` migration runner and tests; no migration `.sql` files needed changes.

Refs #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)