### PR TITLE
fix(auth): gate CSRF exemption on verified API-key auth, not param presence

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -534,10 +534,69 @@ func TestRequireCSRFToken_AllowsMutationWithAPIKey(t *testing.T) {
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
 	req, _ := http.NewRequest("POST", "/api/v1/author", nil)
-	req.Header.Set("X-Api-Key", "apikey-value")
+	// A request whose key Middleware already verified carries the
+	// AuthedViaAPIKey context flag. The CSRF guard exempts it on that flag.
+	req = req.WithContext(WithAPIKeyAuth(req.Context()))
 	h.ServeHTTP(nopWriter{}, req)
 	if !called {
-		t.Fatal("POST with API key must bypass CSRF check")
+		t.Fatal("POST with verified API key must bypass CSRF check")
+	}
+}
+
+// TestRequireCSRFToken_BogusAPIKeyDoesNotBypassCSRF is the core regression test
+// for #708 finding 3. A request with a *bogus* ?apikey= (or X-Api-Key) was
+// previously exempted from CSRF purely because the parameter was present, even
+// though the bogus key fails verification and the request authenticates via the
+// session cookie. After the fix the exemption keys off the verified-auth
+// context flag, which a bogus key never sets, so the CSRF token is enforced.
+func TestRequireCSRFToken_BogusAPIKeyDoesNotBypassCSRF(t *testing.T) {
+	secret := testSecret32
+	sessionVal, err := SignSession(secret, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	mw := RequireCSRFToken(func() []byte { return secret })
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+
+	// Bogus apikey in the query string, real session cookie, NO CSRF token.
+	// Crucially: no AuthedViaAPIKey flag in context (Middleware never set it
+	// because the key would fail subtle.ConstantTimeCompare).
+	req, _ := http.NewRequest("POST", "/api/v1/author?apikey=bogus-not-the-real-key", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessionVal})
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if called {
+		t.Fatal("POST with bogus ?apikey= and a session cookie must NOT bypass CSRF (#708)")
+	}
+	if w.status != http.StatusForbidden {
+		t.Errorf("status = %d; want 403", w.status)
+	}
+}
+
+// TestRequireCSRFToken_BogusAPIKeyHeaderDoesNotBypassCSRF mirrors the above for
+// a bogus X-Api-Key *header* — the header is no exemption either; only the
+// verified-auth context flag is.
+func TestRequireCSRFToken_BogusAPIKeyHeaderDoesNotBypassCSRF(t *testing.T) {
+	secret := testSecret32
+	sessionVal, err := SignSession(secret, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	mw := RequireCSRFToken(func() []byte { return secret })
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+
+	req, _ := http.NewRequest("DELETE", "/api/v1/author/1", nil)
+	req.Header.Set("X-Api-Key", "bogus-not-the-real-key")
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessionVal})
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if called {
+		t.Fatal("DELETE with bogus X-Api-Key and a session cookie must NOT bypass CSRF (#708)")
+	}
+	if w.status != http.StatusForbidden {
+		t.Errorf("status = %d; want 403", w.status)
 	}
 }
 
@@ -610,24 +669,34 @@ func TestRequireXRequestedWith_BlocksMutationWithoutHeader(t *testing.T) {
 	}
 }
 
-func TestRequireXRequestedWith_AllowsMutationWithAPIKeyHeader(t *testing.T) {
+func TestRequireXRequestedWith_AllowsMutationWithVerifiedAPIKey(t *testing.T) {
 	called := false
 	h := RequireXRequestedWith(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
 	req, _ := http.NewRequest("POST", "/api/v1/queue/grab", nil)
-	req.Header.Set("X-Api-Key", "some-api-key")
+	// Verified-API-key requests carry the AuthedViaAPIKey context flag set by
+	// Middleware; RequireXRequestedWith exempts them on that flag.
+	req = req.WithContext(WithAPIKeyAuth(req.Context()))
 	h.ServeHTTP(nopWriter{}, req)
 	if !called {
-		t.Fatal("POST with X-Api-Key must bypass RequireXRequestedWith")
+		t.Fatal("POST authenticated via verified API key must bypass RequireXRequestedWith")
 	}
 }
 
-func TestRequireXRequestedWith_AllowsMutationWithAPIKeyQuery(t *testing.T) {
+// TestRequireXRequestedWith_BogusAPIKeyDoesNotBypass is the #708 finding-3
+// regression test for the X-Requested-With guard: a bogus ?apikey= must not
+// exempt a mutating request from the X-Requested-With requirement.
+func TestRequireXRequestedWith_BogusAPIKeyDoesNotBypass(t *testing.T) {
 	called := false
 	h := RequireXRequestedWith(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
-	req, _ := http.NewRequest("DELETE", "/api/v1/queue/1?apikey=some-api-key", nil)
-	h.ServeHTTP(nopWriter{}, req)
-	if !called {
-		t.Fatal("DELETE with ?apikey= must bypass RequireXRequestedWith")
+	// Bogus apikey, no verified-auth context flag, no X-Requested-With header.
+	req, _ := http.NewRequest("DELETE", "/api/v1/queue/1?apikey=bogus-key", nil)
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if called {
+		t.Fatal("DELETE with bogus ?apikey= must NOT bypass RequireXRequestedWith (#708)")
+	}
+	if w.status != http.StatusForbidden {
+		t.Errorf("status = %d; want 403", w.status)
 	}
 }
 
@@ -803,5 +872,162 @@ func TestCSRFStack_BrowserSessionWithoutCSRFTokenIsRejected(t *testing.T) {
 	}
 	if rw.status != http.StatusForbidden {
 		t.Errorf("status = %d; want 403", rw.status)
+	}
+}
+
+// --- #708 finding 3: bogus ?apikey= must not switch CSRF off (full stack) ----
+//
+// Exercises the real middleware chain (Middleware → RequireXRequestedWith →
+// RequireCSRFToken) to prove that a request with a *bogus* apikey parameter is
+// no longer exempted from the CSRF guards just because the parameter is
+// present. Before the fix, requestAPIKey(r) != "" short-circuited both guards;
+// the bogus key then failed verification in Middleware and the request
+// authenticated via the session cookie — executing with CSRF fully disabled.
+
+func TestCSRFStack_BogusAPIKeyWithSessionStillRequiresCSRF(t *testing.T) {
+	secret := stackSecret32
+	p := &fakeProvider{mode: ModeEnabled, apiKey: "the-real-key", secret: secret}
+	called := false
+	stack := buildCSRFStack(p, secret, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+
+	sessionVal, err := SignSession(secret, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// Attacker-style request: bogus apikey, victim's session cookie rides
+	// along, browser header present, but NO CSRF token. The bogus key fails
+	// subtle.ConstantTimeCompare, so the request authenticates via the cookie
+	// and must be held to the CSRF token requirement.
+	req, _ := http.NewRequest("POST", "/api/v1/queue/grab?apikey=bogus", nil)
+	req.Header.Set("X-Requested-With", "bindery-ui")
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessionVal})
+	req.RemoteAddr = "8.8.8.8:12345"
+	rw := &captureWriter{}
+	stack.ServeHTTP(rw, req)
+	if called {
+		t.Fatal("bogus ?apikey= must not exempt a session-cookie POST from CSRF (#708)")
+	}
+	if rw.status != http.StatusForbidden {
+		t.Errorf("status = %d; want 403", rw.status)
+	}
+}
+
+func TestCSRFStack_BogusAPIKeyHeaderWithSessionStillRequiresXRW(t *testing.T) {
+	secret := stackSecret32
+	p := &fakeProvider{mode: ModeEnabled, apiKey: "the-real-key", secret: secret}
+	called := false
+	stack := buildCSRFStack(p, secret, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+
+	sessionVal, err := SignSession(secret, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	// Bogus X-Api-Key header, session cookie, no X-Requested-With header.
+	// RequireXRequestedWith must still reject it.
+	req, _ := http.NewRequest("POST", "/api/v1/queue/grab", nil)
+	req.Header.Set("X-Api-Key", "bogus")
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessionVal})
+	req.RemoteAddr = "8.8.8.8:12345"
+	rw := &captureWriter{}
+	stack.ServeHTTP(rw, req)
+	if called {
+		t.Fatal("bogus X-Api-Key must not exempt a session-cookie POST from X-Requested-With (#708)")
+	}
+	if rw.status != http.StatusForbidden {
+		t.Errorf("status = %d; want 403", rw.status)
+	}
+}
+
+// --- #708 finding 4a: ?apikey= accepted only for safe methods ---------------
+
+// TestMiddleware_APIKeyInQueryRejectedForMutation verifies that a valid key
+// supplied via the ?apikey= query parameter no longer authenticates a mutating
+// request. The key must be sent in the X-Api-Key header for POST/PUT/DELETE so
+// it does not leak into proxy logs, browser history, or Referer headers.
+func TestMiddleware_APIKeyInQueryRejectedForMutation(t *testing.T) {
+	p := &fakeProvider{mode: ModeEnabled, apiKey: "correct-key"}
+	mw := Middleware(p)
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest("POST", "/api/v1/author?apikey=correct-key", nil)
+	w := &captureWriter{}
+	h.ServeHTTP(w, req)
+	if called {
+		t.Fatal("valid key via ?apikey= must NOT authenticate a POST (#708 finding 4a)")
+	}
+	if w.status != http.StatusUnauthorized {
+		t.Errorf("status = %d; want 401", w.status)
+	}
+}
+
+// TestMiddleware_APIKeyInHeaderAcceptedForMutation is the companion: the header
+// remains the supported way to authenticate a mutating request with a key.
+func TestMiddleware_APIKeyInHeaderAcceptedForMutation(t *testing.T) {
+	p := &fakeProvider{mode: ModeEnabled, apiKey: "correct-key"}
+	mw := Middleware(p)
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest("POST", "/api/v1/author", nil)
+	req.Header.Set("X-Api-Key", "correct-key")
+	h.ServeHTTP(nopWriter{}, req)
+	if !called {
+		t.Fatal("valid key via X-Api-Key header must authenticate a POST")
+	}
+}
+
+// TestMiddleware_APIKeyInQueryAcceptedForSafeMethod confirms the documented
+// read-only ?apikey= workflow (OPDS readers, GET integrations) still works.
+func TestMiddleware_APIKeyInQueryAcceptedForSafeMethod(t *testing.T) {
+	p := &fakeProvider{mode: ModeEnabled, apiKey: "correct-key"}
+	mw := Middleware(p)
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest("GET", "/api/v1/author?apikey=correct-key", nil)
+	h.ServeHTTP(nopWriter{}, req)
+	if !called {
+		t.Fatal("valid key via ?apikey= must still authenticate a GET")
+	}
+}
+
+// TestMiddleware_VerifiedAPIKeySetsContextFlag verifies that a verified key
+// sets the AuthedViaAPIKey context flag the CSRF guards depend on.
+func TestMiddleware_VerifiedAPIKeySetsContextFlag(t *testing.T) {
+	p := &fakeProvider{mode: ModeEnabled, apiKey: "correct-key"}
+	mw := Middleware(p)
+	var viaKey bool
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		viaKey = AuthedViaAPIKey(r.Context())
+	}))
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.Header.Set("X-Api-Key", "correct-key")
+	h.ServeHTTP(nopWriter{}, req)
+	if !viaKey {
+		t.Fatal("verified API-key request must set the AuthedViaAPIKey context flag")
+	}
+}
+
+// TestMiddleware_SessionAuthDoesNotSetAPIKeyFlag verifies a session-cookie
+// request never gets the API-key flag — otherwise it would skip CSRF.
+func TestMiddleware_SessionAuthDoesNotSetAPIKeyFlag(t *testing.T) {
+	secret := testSecret32
+	p := &fakeProvider{mode: ModeEnabled, secret: secret}
+	sessionVal, err := SignSession(secret, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	mw := Middleware(p)
+	var viaKey bool
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		viaKey = AuthedViaAPIKey(r.Context())
+	}))
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessionVal})
+	h.ServeHTTP(nopWriter{}, req)
+	if viaKey {
+		t.Fatal("session-cookie request must NOT set the AuthedViaAPIKey flag")
 	}
 }

--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -30,8 +30,16 @@ func ValidCSRFToken(secret []byte, r *http.Request, token string) bool {
 }
 
 // RequireCSRFToken rejects state-mutating requests that lack a valid
-// X-CSRF-Token header. Exempt: API-key requests, safe methods, AllowUnauthPath
-// routes (login, logout, setup…), and requests with no session cookie.
+// X-CSRF-Token header. Exempt: verified-API-key requests, safe methods,
+// AllowUnauthPath routes (login, logout, setup…), and requests with no session
+// cookie.
+//
+// The API-key exemption keys off the AuthedViaAPIKey context flag, which
+// Middleware sets only after subtle.ConstantTimeCompare confirms the key. A
+// request carrying a *bogus* ?apikey= no longer skips the CSRF check: it fails
+// key verification, falls through to cookie auth, and is held to the token
+// requirement like any other session request (#708 finding 3). This depends on
+// auth.Middleware running before this middleware — see cmd/bindery/main.go.
 func RequireCSRFToken(secret func() []byte) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -39,7 +47,7 @@ func RequireCSRFToken(secret func() []byte) func(http.Handler) http.Handler {
 			case http.MethodGet, http.MethodHead, http.MethodOptions:
 				// safe methods — no mutation risk
 			default:
-				if requestAPIKey(r) == "" && !AllowUnauthPath(r.URL.Path) {
+				if !AuthedViaAPIKey(r.Context()) && !AllowUnauthPath(r.URL.Path) {
 					if c, err := r.Cookie(SessionCookieName); err == nil && c.Value != "" {
 						tok := r.Header.Get("X-CSRF-Token")
 						if !ValidCSRFToken(secret(), r, tok) {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -41,7 +41,7 @@ const (
 	// The CSRF and X-Requested-With guards consult this flag to decide whether
 	// to exempt the request — never the mere presence of an apikey parameter,
 	// which an attacker can forge to switch the CSRF layer off (#708).
-	viaAPIKeyCtxKey ctxKey = "auth.via_api_key"
+	viaAPIKeyCtxKey ctxKey = "auth.via_api_key" //nolint:gosec // context key name, not a credential
 )
 
 // AuthedViaAPIKey reports whether the request was authenticated by a verified

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -36,7 +36,28 @@ type ctxKey string
 const (
 	userIDCtxKey   ctxKey = "auth.user_id"
 	userRoleCtxKey ctxKey = "auth.user_role"
+	// viaAPIKeyCtxKey marks a request whose identity was established by a
+	// *verified* API key (subtle.ConstantTimeCompare passed in Middleware).
+	// The CSRF and X-Requested-With guards consult this flag to decide whether
+	// to exempt the request — never the mere presence of an apikey parameter,
+	// which an attacker can forge to switch the CSRF layer off (#708).
+	viaAPIKeyCtxKey ctxKey = "auth.via_api_key"
 )
+
+// AuthedViaAPIKey reports whether the request was authenticated by a verified
+// API key. False for session-cookie, proxy, local-only, or disabled-mode
+// requests — and false for requests carrying a *bogus* apikey parameter that
+// failed key verification and fell through to cookie auth.
+func AuthedViaAPIKey(ctx context.Context) bool {
+	v, _ := ctx.Value(viaAPIKeyCtxKey).(bool)
+	return v
+}
+
+// WithAPIKeyAuth returns a context marked as authenticated via a verified API
+// key. Exported only so tests can construct the same state Middleware sets.
+func WithAPIKeyAuth(ctx context.Context) context.Context {
+	return context.WithValue(ctx, viaAPIKeyCtxKey, true)
+}
 
 // UserIDFromContext returns the authenticated user ID (0 if unauthenticated).
 func UserIDFromContext(ctx context.Context) int64 {
@@ -187,7 +208,14 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 				// API key authentication is always treated as admin. Set the role
 				// so RequireAdmin-protected endpoints are accessible without a
 				// session cookie (Bug 11: misleading "admin role required" 403).
-				r = r.WithContext(context.WithValue(r.Context(), userRoleCtxKey, "admin"))
+				ctx := context.WithValue(r.Context(), userRoleCtxKey, "admin")
+				// Mark the request as API-key-authenticated. The CSRF and
+				// X-Requested-With guards downstream key their exemption off
+				// this verified flag, not the presence of an apikey parameter
+				// (#708 finding 3). A request reaches this branch only after
+				// subtle.ConstantTimeCompare confirmed the key.
+				ctx = context.WithValue(ctx, viaAPIKeyCtxKey, true)
+				r = r.WithContext(ctx)
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -285,7 +313,11 @@ func requestPeerIP(r *http.Request) net.IP {
 //
 // API-key-authenticated requests are exempt: CSRF requires a cookie to be the
 // authentication mechanism, so requests carrying an explicit API key are not
-// vulnerable and do not need the header.
+// vulnerable and do not need the header. The exemption keys off the
+// AuthedViaAPIKey context flag, which Middleware sets only after the key has
+// been *verified* — a bogus ?apikey= parameter no longer disables the check
+// (#708 finding 3). For this to work, auth.Middleware MUST run before this
+// middleware in the chain (it does — see cmd/bindery/main.go).
 func RequireXRequestedWith(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
@@ -296,7 +328,7 @@ func RequireXRequestedWith(next http.Handler) http.Handler {
 			// session cookie to protect against CSRF at those points, so
 			// requiring the header is pure friction for non-browser clients.
 			// This mirrors the identical exemption in RequireCSRFToken.
-			if requestAPIKey(r) == "" && !AllowUnauthPath(r.URL.Path) && r.Header.Get("X-Requested-With") != "bindery-ui" {
+			if !AuthedViaAPIKey(r.Context()) && !AllowUnauthPath(r.URL.Path) && r.Header.Get("X-Requested-With") != "bindery-ui" {
 				w.Header().Set("Content-Type", "application/json")
 				http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
 				return
@@ -306,9 +338,32 @@ func RequireXRequestedWith(next http.Handler) http.Handler {
 	})
 }
 
+// safeMethod reports whether the HTTP method is non-mutating (read-only).
+// The ?apikey= query parameter is honoured only for these methods.
+func safeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	default:
+		return false
+	}
+}
+
+// requestAPIKey extracts the API key supplied with the request.
+//
+// The X-Api-Key header is always honoured. The ?apikey= query parameter is
+// honoured ONLY for safe (read-only) methods: a key in the URL leaks into
+// proxy access logs, browser history, and Referer headers, so it must not be
+// usable to authorise a state-changing POST/PUT/DELETE/PATCH. Mutations must
+// send the key in the header instead (#708 finding 4a). All documented client
+// workflows (curl examples, OPDS readers, integrations) already use the header
+// for mutations or the query param only for GET, so this does not break them.
 func requestAPIKey(r *http.Request) string {
 	if k := r.Header.Get("X-Api-Key"); k != "" {
 		return k
 	}
-	return r.URL.Query().Get("apikey")
+	if safeMethod(r.Method) {
+		return r.URL.Query().Get("apikey")
+	}
+	return ""
 }


### PR DESCRIPTION
Implements the deferred findings 3 and 4 of #708 (findings 1 and 2 — moving two admin routes behind `RequireAdmin` — were already done in #717).

## Finding 3 — CSRF / X-Requested-With exemption bypass

`RequireCSRFToken` (`internal/auth/csrf.go`) and `RequireXRequestedWith` (`internal/auth/middleware.go`) skipped their checks whenever `requestAPIKey(r) != ""`. But `requestAPIKey` only tests that an `apikey` parameter is *present*, not that it is valid. A request with a bogus `?apikey=` therefore skipped both CSRF guards, then failed key verification in `Middleware` (`subtle.ConstantTimeCompare`) and fell through to session-cookie auth — executing, authenticated, with the app's CSRF layer fully disabled.

The exemption now keys off *successful* API-key authentication:
- `Middleware` sets an unexported `viaAPIKeyCtxKey` context flag on the verified branch (after `subtle.ConstantTimeCompare` passes).
- `RequireCSRFToken` and `RequireXRequestedWith` consult that flag via `AuthedViaAPIKey(ctx)` instead of `requestAPIKey(r)`.

**Middleware order:** `auth.Middleware` already runs *before* `RequireXRequestedWith` and `RequireCSRFToken` in both the `/api` and `/api/v1` chains (`cmd/bindery/main.go:557-559` / `565-567`), so the context flag is visible downstream. **No reordering was needed** — `main.go` is unchanged.

## Finding 4a — API key accepted from the query string for mutations

`requestAPIKey` now honours the `?apikey=` query parameter only for safe methods (GET/HEAD/OPTIONS); mutating methods must send the key in the `X-Api-Key` header. A key in the URL leaks into proxy access logs, browser history, and `Referer` headers, so it must not authorise a state-changing request.

All documented client workflows already use the header for mutations (every `curl` example in `docs/API.md`) or the query parameter only for GET (OPDS readers — all `/opds` routes are GET and use a separate auth handler). This does not break the documented API. The blanket-admin role grant is left as-is per the issue scope (mapping keys to user identities is out of scope).

## Tests

- A bogus `?apikey=` / bogus `X-Api-Key` no longer skips CSRF or X-Requested-With — standalone and full-stack (`Middleware → RequireXRequestedWith → RequireCSRFToken`) variants.
- A valid key via `?apikey=` is rejected for POST (401) but still accepted for GET.
- The verified-auth context flag is set for key auth and not for session auth.
- Existing tests that relied on raw param presence were updated to set the verified-auth flag.

`gofmt -w`, `go build ./...`, and `go test ./internal/auth/... ./internal/api/... ./cmd/...` all pass.

Refs #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)