### PR TITLE
fix(auth): require verified email for OIDC linking and enforce AllowedGroups

### DIFF
--- a/internal/api/auth_oidc.go
+++ b/internal/api/auth_oidc.go
@@ -211,6 +211,28 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enforce the provider's AllowedGroups policy. When AllowedGroups is
+	// configured (non-empty), a login is only admitted if the IdP's `groups`
+	// claim intersects it; an empty AllowedGroups means "allow all" and the
+	// check is a no-op. This is fail-closed by design: if the IdP is not
+	// sending a `groups` claim, or sends a different group name than what is
+	// configured, every login is rejected — the admin must fix the IdP scope
+	// mapping or the configured group name.
+	if cfg, ok := h.mgr.ProviderConfig(providerID); ok && len(cfg.AllowedGroups) > 0 {
+		if !oidc.GroupsAllowed(cfg.AllowedGroups, claims.Groups) {
+			slog.Warn("oidc: login rejected by AllowedGroups policy",
+				"provider", providerID, // #nosec -- providerID validated by oidcProviderIDRe at handler entry
+				"sub", sanitizeLog(claims.Sub),
+				"user_groups", len(claims.Groups),
+				"allowed_groups", strings.Join(cfg.AllowedGroups, ","),
+			)
+			writeErr(w, http.StatusForbidden,
+				"access denied: your account is not a member of an allowed group for this provider "+
+					"(check the provider's allowed_groups setting and that the IdP is sending a 'groups' claim)")
+			return
+		}
+	}
+
 	// 1. Look up by (issuer, sub)
 	user, err := h.users.GetByOIDC(ctx, claims.Issuer, claims.Sub)
 	if err != nil {
@@ -219,8 +241,23 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 2. Email-link: try to match an existing user by email
-	if user == nil && h.oidcEmailLink && claims.Email != "" {
+	// 2. Email-link: try to match an existing user by email.
+	//
+	// SECURITY: only ever link by email when the IdP asserts the address is
+	// verified (`email_verified == true`). Linking binds the OIDC
+	// (issuer, sub) pair to an existing Bindery account — potentially an
+	// admin account — so an unverified `email` claim is an account-takeover
+	// vector: an attacker who can set an arbitrary unverified email at a
+	// trusted IdP could otherwise claim a victim's account. If the email is
+	// unverified (or the IdP omits `email_verified`), skip linking and fall
+	// through to normal provisioning-by-subject below.
+	if user == nil && h.oidcEmailLink && claims.Email != "" && !claims.EmailVerified {
+		slog.Warn("oidc: skipping email-link for unverified email claim",
+			"provider", providerID, // #nosec -- providerID validated by oidcProviderIDRe at handler entry
+			"sub", sanitizeLog(claims.Sub),
+			"reason", "IdP did not assert email_verified=true; falling through to subject-based provisioning")
+	}
+	if user == nil && h.oidcEmailLink && claims.Email != "" && claims.EmailVerified {
 		byEmail, err := h.users.GetByEmail(ctx, claims.Email)
 		if err != nil {
 			slog.Error("oidc: email lookup failed", "error", err)

--- a/internal/api/auth_oidc_callback_test.go
+++ b/internal/api/auth_oidc_callback_test.go
@@ -1,0 +1,391 @@
+package api
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/auth/oidc"
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// fakeIdP is a minimal OIDC identity provider for tests: it serves a discovery
+// document, a JWKS, and a token endpoint that returns an RS256-signed ID token
+// whose claims the test controls. It lets the OIDC callback path be exercised
+// end to end without a real IdP.
+type fakeIdP struct {
+	server *httptest.Server
+	key    *rsa.PrivateKey
+	kid    string
+	// claims is the claim set baked into the ID token returned by /token.
+	claims map[string]any
+}
+
+func newFakeIdP(t *testing.T) *fakeIdP {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	idp := &fakeIdP{key: key, kid: "test-key-1"}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		base := "http://" + r.Host
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 base,
+			"authorization_endpoint": base + "/authorize",
+			"token_endpoint":         base + "/token",
+			"jwks_uri":               base + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{idp.jwk()},
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		base := "http://" + r.Host
+		idToken := idp.signIDToken(t, base)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "fake-access-token",
+			"token_type":   "Bearer",
+			"id_token":     idToken,
+		})
+	})
+
+	idp.server = httptest.NewServer(mux)
+	t.Cleanup(idp.server.Close)
+	return idp
+}
+
+func b64u(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+// jwk renders the public key in JWK form for the JWKS endpoint.
+func (f *fakeIdP) jwk() map[string]any {
+	pub := f.key.PublicKey
+	return map[string]any{
+		"kty": "RSA",
+		"kid": f.kid,
+		"alg": "RS256",
+		"use": "sig",
+		"n":   b64u(pub.N.Bytes()),
+		"e":   b64u(big.NewInt(int64(pub.E)).Bytes()),
+	}
+}
+
+// signIDToken builds and RS256-signs an ID token with f.claims, filling in the
+// standard registered claims (iss/aud/exp/iat) so the go-oidc verifier accepts
+// it. The "aud" claim is set to the test client ID.
+func (f *fakeIdP) signIDToken(t *testing.T, issuer string) string {
+	t.Helper()
+	header := map[string]any{"alg": "RS256", "typ": "JWT", "kid": f.kid}
+	claims := map[string]any{
+		"iss": issuer,
+		"aud": "test-client-id",
+		"exp": time.Now().Add(5 * time.Minute).Unix(),
+		"iat": time.Now().Unix(),
+	}
+	for k, v := range f.claims {
+		claims[k] = v
+	}
+	hb, err := json.Marshal(header)
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+	cb, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	signingInput := b64u(hb) + "." + b64u(cb)
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, f.key, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatalf("sign id token: %v", err)
+	}
+	return signingInput + "." + b64u(sig)
+}
+
+// newCallbackTestHandler wires an OIDCHandler against a real in-memory DB and a
+// loaded provider pointing at the given fake IdP. allowedGroups and emailLink
+// configure the two policies under test.
+func newCallbackTestHandler(t *testing.T, idp *fakeIdP, allowedGroups []string, emailLink bool) (*OIDCHandler, *db.UserRepo, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	ctx := context.Background()
+
+	users := db.NewUserRepo(database)
+	settings := db.NewSettingsRepo(database)
+	// Seed a session secret so issueSession can sign a cookie.
+	if err := settings.Set(ctx, SettingAuthSessionSecret, strings.Repeat("x", 32)); err != nil {
+		t.Fatalf("seed session secret: %v", err)
+	}
+
+	authH := NewAuthHandler(users, settings, auth.NewLoginLimiter(10, time.Minute))
+
+	mgr := oidc.NewManager()
+	cfg := oidc.ProviderConfig{
+		ID:            "test",
+		Name:          "Test IdP",
+		Issuer:        idp.server.URL,
+		ClientID:      "test-client-id",
+		ClientSecret:  "test-secret",
+		AllowedGroups: allowedGroups,
+	}
+	mgr.Reload(ctx, []oidc.ProviderConfig{cfg})
+	if mgr.Get("test") == nil {
+		t.Fatalf("provider failed to load against fake IdP at %s", idp.server.URL)
+	}
+
+	h := NewOIDCHandler(mgr, users, settings, authH, func(_ *http.Request) string {
+		return "https://bindery.example.com"
+	}).WithOIDCEmailLink(emailLink)
+	return h, users, ctx
+}
+
+// doCallback drives the Callback handler with a valid flow cookie + state/code.
+func doCallback(t *testing.T, h *OIDCHandler) *httptest.ResponseRecorder {
+	t.Helper()
+	state := "test-state"
+	nonce := "test-nonce"
+	verifier := "test-verifier-aaaaaaaaaaaaaaaaaaaaaaaa"
+	flowVal, err := oidc.EncodeFlowState(state, nonce, verifier, "https://bindery.example.com")
+	if err != nil {
+		t.Fatalf("encode flow state: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/auth/oidc/test/callback?state="+url.QueryEscape(state)+"&code=test-code", nil)
+	req.AddCookie(&http.Cookie{Name: oidcFlowCookie, Value: flowVal})
+	// Inject the chi URL param the handler reads via chi.URLParam.
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("provider", "test")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rec := httptest.NewRecorder()
+	h.Callback(rec, req)
+	return rec
+}
+
+// --- Finding 2: AllowedGroups enforcement -----------------------------------
+
+// TestCallback_AllowedGroups_InGroup verifies a user whose `groups` claim
+// intersects AllowedGroups is admitted (auto-provisioned, session issued).
+func TestCallback_AllowedGroups_InGroup(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.claims = map[string]any{
+		"sub":            "user-in-group",
+		"nonce":          "test-nonce",
+		"email":          "ingroup@example.com",
+		"email_verified": true,
+		"groups":         []string{"staff", "bindery-users"},
+	}
+	h, _, _ := newCallbackTestHandler(t, idp, []string{"bindery-users"}, false)
+
+	rec := doCallback(t, h)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302 (in-group user should be admitted); body=%s", rec.Code, rec.Body.String())
+	}
+	if !hasSessionCookie(rec) {
+		t.Fatal("expected a session cookie to be issued for the admitted user")
+	}
+}
+
+// TestCallback_AllowedGroups_OutOfGroup verifies a user whose `groups` claim
+// does not intersect AllowedGroups is rejected with 403.
+func TestCallback_AllowedGroups_OutOfGroup(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.claims = map[string]any{
+		"sub":            "user-out-of-group",
+		"nonce":          "test-nonce",
+		"email":          "outgroup@example.com",
+		"email_verified": true,
+		"groups":         []string{"staff", "contractors"},
+	}
+	h, _, _ := newCallbackTestHandler(t, idp, []string{"bindery-users"}, false)
+
+	rec := doCallback(t, h)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d, want 403 (out-of-group user must be rejected); body=%s", rec.Code, rec.Body.String())
+	}
+	if hasSessionCookie(rec) {
+		t.Fatal("a rejected login must not receive a session cookie")
+	}
+}
+
+// TestCallback_AllowedGroups_NoGroupsClaim verifies that when AllowedGroups is
+// configured but the IdP sends no `groups` claim at all, the login is rejected
+// (fail-closed) — the admin must fix the IdP scope mapping.
+func TestCallback_AllowedGroups_NoGroupsClaim(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.claims = map[string]any{
+		"sub":            "user-no-groups",
+		"nonce":          "test-nonce",
+		"email":          "nogroups@example.com",
+		"email_verified": true,
+		// no "groups" claim
+	}
+	h, _, _ := newCallbackTestHandler(t, idp, []string{"bindery-users"}, false)
+
+	rec := doCallback(t, h)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d, want 403 (missing groups claim must fail closed); body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestCallback_AllowedGroups_Empty verifies that with no AllowedGroups
+// configured, group membership is not checked and any user is admitted.
+func TestCallback_AllowedGroups_Empty(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.claims = map[string]any{
+		"sub":            "user-any",
+		"nonce":          "test-nonce",
+		"email":          "any@example.com",
+		"email_verified": true,
+		"groups":         []string{"whatever"},
+	}
+	h, _, _ := newCallbackTestHandler(t, idp, nil, false)
+
+	rec := doCallback(t, h)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302 (empty AllowedGroups means allow all); body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// --- Finding 1: verified-email requirement for OIDC linking -----------------
+
+// TestCallback_EmailLink_VerifiedEmail verifies that with oidcEmailLink enabled
+// and a verified email, an unknown OIDC subject is linked to the pre-existing
+// Bindery account that owns that email.
+func TestCallback_EmailLink_VerifiedEmail(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.claims = map[string]any{
+		"sub":            "attacker-or-legit-sub",
+		"nonce":          "test-nonce",
+		"email":          "victim@example.com",
+		"email_verified": true,
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, true)
+
+	// Pre-create the account that owns victim@example.com via a *different*
+	// OIDC issuer/sub so GetByOIDC for the callback's (issuer,sub) returns nil.
+	existing, err := users.GetOrCreateByOIDC(ctx, "https://other-issuer.example", "other-sub",
+		"victim", "victim@example.com", "Victim")
+	if err != nil {
+		t.Fatalf("seed existing user: %v", err)
+	}
+
+	rec := doCallback(t, h)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302 (verified email should link); body=%s", rec.Code, rec.Body.String())
+	}
+
+	// The callback's (issuer, sub) must now resolve to the existing account.
+	linked, err := users.GetByOIDC(ctx, idp.server.URL, "attacker-or-legit-sub")
+	if err != nil {
+		t.Fatalf("GetByOIDC after link: %v", err)
+	}
+	if linked == nil || linked.ID != existing.ID {
+		t.Fatalf("expected the OIDC subject to be linked to user %d, got %+v", existing.ID, linked)
+	}
+}
+
+// TestCallback_EmailLink_UnverifiedEmail is the security regression test for
+// finding 1: an unverified `email` claim must NOT link to an existing account.
+// Instead the login falls through to subject-based provisioning, creating a
+// brand-new account distinct from the victim's.
+func TestCallback_EmailLink_UnverifiedEmail(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.claims = map[string]any{
+		"sub":            "attacker-sub",
+		"nonce":          "test-nonce",
+		"email":          "victim@example.com",
+		"email_verified": false, // attacker-controlled, unverified
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, true)
+
+	victim, err := users.GetOrCreateByOIDC(ctx, "https://other-issuer.example", "victim-sub",
+		"victim", "victim@example.com", "Victim")
+	if err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+
+	rec := doCallback(t, h)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302 (login falls through to provisioning); body=%s", rec.Code, rec.Body.String())
+	}
+
+	// The attacker's (issuer, sub) must resolve to a NEW account, not the victim.
+	got, err := users.GetByOIDC(ctx, idp.server.URL, "attacker-sub")
+	if err != nil {
+		t.Fatalf("GetByOIDC after callback: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a new account to be provisioned for the attacker's subject")
+	}
+	if got.ID == victim.ID {
+		t.Fatal("SECURITY: unverified email claim was linked to the victim's account — account takeover")
+	}
+}
+
+// TestCallback_EmailLink_MissingEmailVerifiedClaim verifies that an IdP which
+// omits `email_verified` entirely is treated as unverified (fail-closed): no
+// linking, fall through to provisioning a separate account.
+func TestCallback_EmailLink_MissingEmailVerifiedClaim(t *testing.T) {
+	idp := newFakeIdP(t)
+	idp.claims = map[string]any{
+		"sub":   "no-emailverified-sub",
+		"nonce": "test-nonce",
+		"email": "victim@example.com",
+		// no "email_verified" claim at all
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, true)
+
+	victim, err := users.GetOrCreateByOIDC(ctx, "https://other-issuer.example", "victim-sub-2",
+		"victim2", "victim@example.com", "Victim")
+	if err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+
+	rec := doCallback(t, h)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	got, err := users.GetByOIDC(ctx, idp.server.URL, "no-emailverified-sub")
+	if err != nil {
+		t.Fatalf("GetByOIDC: %v", err)
+	}
+	if got == nil || got.ID == victim.ID {
+		t.Fatal("absent email_verified claim must not link to the victim's account")
+	}
+}
+
+func hasSessionCookie(rec *httptest.ResponseRecorder) bool {
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == auth.SessionCookieName && c.Value != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/auth_oidc_callback_test.go
+++ b/internal/api/auth_oidc_callback_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/vavallee/bindery/internal/db"
 )
 
-// fakeIdP is a minimal OIDC identity provider for tests: it serves a discovery
+// fakeIDP is a minimal OIDC identity provider for tests: it serves a discovery
 // document, a JWKS, and a token endpoint that returns an RS256-signed ID token
 // whose claims the test controls. It lets the OIDC callback path be exercised
 // end to end without a real IdP.
-type fakeIdP struct {
+type fakeIDP struct {
 	server *httptest.Server
 	key    *rsa.PrivateKey
 	kid    string
@@ -35,13 +35,13 @@ type fakeIdP struct {
 	claims map[string]any
 }
 
-func newFakeIdP(t *testing.T) *fakeIdP {
+func newFakeIDP(t *testing.T) *fakeIDP {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("generate RSA key: %v", err)
 	}
-	idp := &fakeIdP{key: key, kid: "test-key-1"}
+	idp := &fakeIDP{key: key, kid: "test-key-1"}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
@@ -79,7 +79,7 @@ func newFakeIdP(t *testing.T) *fakeIdP {
 func b64u(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
 
 // jwk renders the public key in JWK form for the JWKS endpoint.
-func (f *fakeIdP) jwk() map[string]any {
+func (f *fakeIDP) jwk() map[string]any {
 	pub := f.key.PublicKey
 	return map[string]any{
 		"kty": "RSA",
@@ -94,7 +94,7 @@ func (f *fakeIdP) jwk() map[string]any {
 // signIDToken builds and RS256-signs an ID token with f.claims, filling in the
 // standard registered claims (iss/aud/exp/iat) so the go-oidc verifier accepts
 // it. The "aud" claim is set to the test client ID.
-func (f *fakeIdP) signIDToken(t *testing.T, issuer string) string {
+func (f *fakeIDP) signIDToken(t *testing.T, issuer string) string {
 	t.Helper()
 	header := map[string]any{"alg": "RS256", "typ": "JWT", "kid": f.kid}
 	claims := map[string]any{
@@ -126,7 +126,7 @@ func (f *fakeIdP) signIDToken(t *testing.T, issuer string) string {
 // newCallbackTestHandler wires an OIDCHandler against a real in-memory DB and a
 // loaded provider pointing at the given fake IdP. allowedGroups and emailLink
 // configure the two policies under test.
-func newCallbackTestHandler(t *testing.T, idp *fakeIdP, allowedGroups []string, emailLink bool) (*OIDCHandler, *db.UserRepo, context.Context) {
+func newCallbackTestHandler(t *testing.T, idp *fakeIDP, allowedGroups []string, emailLink bool) (*OIDCHandler, *db.UserRepo, context.Context) {
 	t.Helper()
 	database, err := db.OpenMemory()
 	if err != nil {
@@ -193,7 +193,7 @@ func doCallback(t *testing.T, h *OIDCHandler) *httptest.ResponseRecorder {
 // TestCallback_AllowedGroups_InGroup verifies a user whose `groups` claim
 // intersects AllowedGroups is admitted (auto-provisioned, session issued).
 func TestCallback_AllowedGroups_InGroup(t *testing.T) {
-	idp := newFakeIdP(t)
+	idp := newFakeIDP(t)
 	idp.claims = map[string]any{
 		"sub":            "user-in-group",
 		"nonce":          "test-nonce",
@@ -215,7 +215,7 @@ func TestCallback_AllowedGroups_InGroup(t *testing.T) {
 // TestCallback_AllowedGroups_OutOfGroup verifies a user whose `groups` claim
 // does not intersect AllowedGroups is rejected with 403.
 func TestCallback_AllowedGroups_OutOfGroup(t *testing.T) {
-	idp := newFakeIdP(t)
+	idp := newFakeIDP(t)
 	idp.claims = map[string]any{
 		"sub":            "user-out-of-group",
 		"nonce":          "test-nonce",
@@ -238,7 +238,7 @@ func TestCallback_AllowedGroups_OutOfGroup(t *testing.T) {
 // configured but the IdP sends no `groups` claim at all, the login is rejected
 // (fail-closed) — the admin must fix the IdP scope mapping.
 func TestCallback_AllowedGroups_NoGroupsClaim(t *testing.T) {
-	idp := newFakeIdP(t)
+	idp := newFakeIDP(t)
 	idp.claims = map[string]any{
 		"sub":            "user-no-groups",
 		"nonce":          "test-nonce",
@@ -257,7 +257,7 @@ func TestCallback_AllowedGroups_NoGroupsClaim(t *testing.T) {
 // TestCallback_AllowedGroups_Empty verifies that with no AllowedGroups
 // configured, group membership is not checked and any user is admitted.
 func TestCallback_AllowedGroups_Empty(t *testing.T) {
-	idp := newFakeIdP(t)
+	idp := newFakeIDP(t)
 	idp.claims = map[string]any{
 		"sub":            "user-any",
 		"nonce":          "test-nonce",
@@ -279,7 +279,7 @@ func TestCallback_AllowedGroups_Empty(t *testing.T) {
 // and a verified email, an unknown OIDC subject is linked to the pre-existing
 // Bindery account that owns that email.
 func TestCallback_EmailLink_VerifiedEmail(t *testing.T) {
-	idp := newFakeIdP(t)
+	idp := newFakeIDP(t)
 	idp.claims = map[string]any{
 		"sub":            "attacker-or-legit-sub",
 		"nonce":          "test-nonce",
@@ -316,7 +316,7 @@ func TestCallback_EmailLink_VerifiedEmail(t *testing.T) {
 // Instead the login falls through to subject-based provisioning, creating a
 // brand-new account distinct from the victim's.
 func TestCallback_EmailLink_UnverifiedEmail(t *testing.T) {
-	idp := newFakeIdP(t)
+	idp := newFakeIDP(t)
 	idp.claims = map[string]any{
 		"sub":            "attacker-sub",
 		"nonce":          "test-nonce",
@@ -353,7 +353,7 @@ func TestCallback_EmailLink_UnverifiedEmail(t *testing.T) {
 // omits `email_verified` entirely is treated as unverified (fail-closed): no
 // linking, fall through to provisioning a separate account.
 func TestCallback_EmailLink_MissingEmailVerifiedClaim(t *testing.T) {
-	idp := newFakeIdP(t)
+	idp := newFakeIDP(t)
 	idp.claims = map[string]any{
 		"sub":   "no-emailverified-sub",
 		"nonce": "test-nonce",

--- a/internal/auth/oidc/provider.go
+++ b/internal/auth/oidc/provider.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -74,10 +75,18 @@ func ParseProviders(raw string) ([]ProviderConfig, error) {
 }
 
 // Claims extracted from a validated ID token.
+//
+// EmailVerified reflects the IdP's `email_verified` claim. It is only
+// meaningful when Email is non-empty; an IdP that omits the claim entirely
+// leaves it false. Callers MUST NOT treat Email as a trusted identifier for
+// account linking unless EmailVerified is true — an attacker who can set an
+// arbitrary unverified `email` at a trusted IdP could otherwise take over an
+// existing Bindery account.
 type Claims struct {
 	Sub               string
 	Issuer            string
 	Email             string
+	EmailVerified     bool
 	PreferredUsername string
 	Name              string
 	Groups            []string
@@ -253,6 +262,19 @@ func (m *Manager) Get(id string) *entry {
 	return m.providers[id]
 }
 
+// ProviderConfig returns the loaded config for a provider ID, or false if the
+// provider is not currently loaded. Used by the callback handler to read
+// policy fields (e.g. AllowedGroups) after a successful token exchange.
+func (m *Manager) ProviderConfig(id string) (ProviderConfig, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	e, ok := m.providers[id]
+	if !ok {
+		return ProviderConfig{}, false
+	}
+	return e.cfg, true
+}
+
 // List returns all configured provider configs (for the login page). Includes
 // only providers that successfully loaded — failed providers are intentionally
 // hidden from the login page since clicking their button would error out.
@@ -317,11 +339,12 @@ func (m *Manager) Exchange(ctx context.Context, redirectBase, id, code, nonce, c
 		return nil, fmt.Errorf("oidc: nonce mismatch")
 	}
 	var claims struct {
-		Sub               string   `json:"sub"`
-		Email             string   `json:"email"`
-		PreferredUsername string   `json:"preferred_username"`
-		Name              string   `json:"name"`
-		Groups            []string `json:"groups"`
+		Sub               string          `json:"sub"`
+		Email             string          `json:"email"`
+		EmailVerified     json.RawMessage `json:"email_verified"`
+		PreferredUsername string          `json:"preferred_username"`
+		Name              string          `json:"name"`
+		Groups            []string        `json:"groups"`
 	}
 	if err := idToken.Claims(&claims); err != nil {
 		return nil, fmt.Errorf("oidc: parse claims: %w", err)
@@ -330,10 +353,51 @@ func (m *Manager) Exchange(ctx context.Context, redirectBase, id, code, nonce, c
 		Sub:               claims.Sub,
 		Issuer:            idToken.Issuer,
 		Email:             claims.Email,
+		EmailVerified:     parseEmailVerified(claims.EmailVerified),
 		PreferredUsername: claims.PreferredUsername,
 		Name:              claims.Name,
 		Groups:            claims.Groups,
 	}, nil
+}
+
+// parseEmailVerified interprets the `email_verified` claim. The OIDC spec
+// defines it as a boolean, but some IdPs (and JWT libraries) serialise it as
+// the string "true"/"false". Anything that is not an explicit truthy value —
+// including an absent claim — is treated as not verified (fail-closed).
+func parseEmailVerified(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var b bool
+	if err := json.Unmarshal(raw, &b); err == nil {
+		return b
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return strings.EqualFold(strings.TrimSpace(s), "true")
+	}
+	return false
+}
+
+// GroupsAllowed reports whether a login carrying the given group claims is
+// permitted by the provider's AllowedGroups policy. When AllowedGroups is
+// empty the policy is "allow all" and this always returns true. Otherwise the
+// login is permitted only if userGroups intersects AllowedGroups. Matching is
+// exact and case-sensitive — group names from an IdP are opaque identifiers.
+func GroupsAllowed(allowedGroups, userGroups []string) bool {
+	if len(allowedGroups) == 0 {
+		return true
+	}
+	allowed := make(map[string]struct{}, len(allowedGroups))
+	for _, g := range allowedGroups {
+		allowed[g] = struct{}{}
+	}
+	for _, g := range userGroups {
+		if _, ok := allowed[g]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // --- PKCE helpers ------------------------------------------------------------

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -407,3 +407,120 @@ func TestSubCollisionAcrossIssuers(t *testing.T) {
 		t.Fatal("test setup error: issuers should differ")
 	}
 }
+
+// --- AllowedGroups enforcement (issue #709, finding 2) -----------------------
+
+func TestGroupsAllowed(t *testing.T) {
+	tests := []struct {
+		name          string
+		allowedGroups []string
+		userGroups    []string
+		want          bool
+	}{
+		{
+			name:          "empty AllowedGroups allows any login",
+			allowedGroups: nil,
+			userGroups:    []string{"some-random-group"},
+			want:          true,
+		},
+		{
+			name:          "empty AllowedGroups allows a login with no groups",
+			allowedGroups: []string{},
+			userGroups:    nil,
+			want:          true,
+		},
+		{
+			name:          "user in an allowed group is admitted",
+			allowedGroups: []string{"bindery-users", "bindery-admins"},
+			userGroups:    []string{"staff", "bindery-users"},
+			want:          true,
+		},
+		{
+			name:          "user not in any allowed group is rejected",
+			allowedGroups: []string{"bindery-users"},
+			userGroups:    []string{"staff", "everyone"},
+			want:          false,
+		},
+		{
+			name:          "user with no groups is rejected when AllowedGroups is set",
+			allowedGroups: []string{"bindery-users"},
+			userGroups:    nil,
+			want:          false,
+		},
+		{
+			name:          "group matching is case-sensitive",
+			allowedGroups: []string{"Bindery-Users"},
+			userGroups:    []string{"bindery-users"},
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GroupsAllowed(tt.allowedGroups, tt.userGroups); got != tt.want {
+				t.Errorf("GroupsAllowed(%v, %v) = %v, want %v",
+					tt.allowedGroups, tt.userGroups, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- email_verified parsing (issue #709, finding 1) -------------------------
+
+func TestParseEmailVerified(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string // raw JSON value of the email_verified claim
+		want bool
+	}{
+		{name: "absent claim is not verified", raw: ``, want: false},
+		{name: "boolean true", raw: `true`, want: true},
+		{name: "boolean false", raw: `false`, want: false},
+		{name: "string \"true\" (some IdPs serialise it this way)", raw: `"true"`, want: true},
+		{name: "string \"True\" case-insensitive", raw: `"True"`, want: true},
+		{name: "string \"false\"", raw: `"false"`, want: false},
+		{name: "empty string is not verified", raw: `""`, want: false},
+		{name: "null is not verified", raw: `null`, want: false},
+		{name: "numeric 1 is not verified (not a recognised truthy form)", raw: `1`, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw json.RawMessage
+			if tt.raw != "" {
+				raw = json.RawMessage(tt.raw)
+			}
+			if got := parseEmailVerified(raw); got != tt.want {
+				t.Errorf("parseEmailVerified(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestProviderConfig_ExposesAllowedGroups verifies the manager surfaces a
+// loaded provider's config (including AllowedGroups) so the callback handler
+// can enforce the group policy after a token exchange.
+func TestProviderConfig_ExposesAllowedGroups(t *testing.T) {
+	m := NewManager()
+	if _, ok := m.ProviderConfig("missing"); ok {
+		t.Fatal("ProviderConfig should report ok=false for an unknown provider")
+	}
+
+	cfg := ProviderConfig{
+		ID:            "corp",
+		Issuer:        "https://idp.example.com",
+		ClientID:      "cid",
+		AllowedGroups: []string{"bindery-users"},
+	}
+	// Inject a loaded entry directly — discovery is exercised elsewhere and
+	// this test only cares about the config accessor.
+	m.mu.Lock()
+	m.providers["corp"] = &entry{cfg: cfg}
+	m.mu.Unlock()
+
+	got, ok := m.ProviderConfig("corp")
+	if !ok {
+		t.Fatal("ProviderConfig should report ok=true for a loaded provider")
+	}
+	if len(got.AllowedGroups) != 1 || got.AllowedGroups[0] != "bindery-users" {
+		t.Fatalf("AllowedGroups = %v, want [bindery-users]", got.AllowedGroups)
+	}
+}


### PR DESCRIPTION
Implements the two deferred security findings of #709. (Finding 3, the reload-context fix, was already in `main`.)

## Finding 1 — OIDC email-linking trusted an unverified `email` claim (account takeover)

`internal/api/auth_oidc.go` linked an OIDC `(issuer, sub)` identity to an existing Bindery account whenever the `email` claim matched an existing user, with **no `email_verified` check**. An attacker able to set an arbitrary unverified `email` on their account at any trusted IdP could take over a victim's Bindery account — including an admin account.

Fix:
- `internal/auth/oidc/provider.go`: the `email_verified` claim is now parsed into `Claims.EmailVerified`. Parsing tolerates both the OIDC-spec boolean and the string `"true"/"false"` form some IdPs emit (`parseEmailVerified`). Anything not explicitly truthy — including an absent claim — is treated as not verified.
- Email-linking only runs when `claims.EmailVerified` is true. An absent/false claim skips linking and falls through to normal subject-based provisioning (unchanged behaviour for an unlinkable login).

## Finding 2 — `AllowedGroups` was configured but never enforced

`ProviderConfig.AllowedGroups` existed and `Claims.Groups` was parsed, but membership was never checked — an admin restricting access by group got no restriction.

Fix:
- `internal/auth/oidc/provider.go`: new `GroupsAllowed(allowed, user []string)` helper (exact, case-sensitive intersection; empty `allowed` means allow-all) and a `Manager.ProviderConfig(id)` accessor so the callback can read the policy.
- `internal/api/auth_oidc.go`: after a successful `Exchange`, the callback returns `403` when `AllowedGroups` is non-empty and the IdP's `groups` claim does not intersect it. Empty `AllowedGroups` is unchanged (allow all).

## Fail-closed behaviour (intended)

Both changes fail closed. An IdP that does not send `email_verified` will not email-link; a missing or misconfigured `groups` claim will block login. This can lock out a misconfigured setup — that is the point. Rejection messages name the relevant setting and the missing claim so an admin can diagnose it.

## Tests

- `internal/auth/oidc/provider_test.go`: table tests for `GroupsAllowed` (in-group / out-of-group / no-groups / empty / case-sensitivity), `parseEmailVerified` (bool, string, absent, null, numeric), and the `ProviderConfig` accessor.
- `internal/api/auth_oidc_callback_test.go`: a fake RS256-signing IdP (discovery + JWKS + token endpoints) drives the `Callback` handler end to end over a real in-memory DB. Covers verified vs unverified vs absent `email_verified`, and in-group / out-of-group / no-groups-claim / empty `AllowedGroups`. The unverified-email case is an explicit account-takeover regression test.

`gofmt`, `go build ./...`, `go vet`, and `go test ./internal/auth/... ./internal/api/...` all pass.

Scope: `internal/auth/oidc/` and `internal/api/auth_oidc.go` only.

Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)