### PR TITLE
fix(auth): resolve client IP right-to-left for local-only; add session key-id

### DIFF
--- a/cmd/bindery/proxy.go
+++ b/cmd/bindery/proxy.go
@@ -1,43 +1,23 @@
 package main
 
 import (
-	"log/slog"
 	"net"
 	"net/http"
 	"os"
 	"strings"
 
 	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/vavallee/bindery/internal/auth"
 )
 
 // parseTrustedProxyCIDRs parses a comma-separated list of IP/CIDR strings
 // (from BINDERY_TRUSTED_PROXY) into []*net.IPNet. Bare IPs are treated as
-// /32 (IPv4) or /128 (IPv6). Invalid entries are logged and skipped.
+// /32 (IPv4) or /128 (IPv6). Invalid entries are skipped. It delegates to
+// auth.ParseTrustedProxyCIDRs so the proxy middleware and the local-only
+// trust decision parse the env var identically.
 func parseTrustedProxyCIDRs(raw string) []*net.IPNet {
-	if raw == "" {
-		return nil
-	}
-	var trusted []*net.IPNet
-	for _, s := range strings.Split(raw, ",") {
-		s = strings.TrimSpace(s)
-		if s == "" {
-			continue
-		}
-		if !strings.Contains(s, "/") {
-			if strings.Contains(s, ":") {
-				s += "/128"
-			} else {
-				s += "/32"
-			}
-		}
-		_, cidr, err := net.ParseCIDR(s)
-		if err != nil {
-			slog.Warn("BINDERY_TRUSTED_PROXY: invalid entry, skipping", "entry", s, "err", err)
-			continue
-		}
-		trusted = append(trusted, cidr)
-	}
-	return trusted
+	return auth.ParseTrustedProxyCIDRs(raw)
 }
 
 // proxyHeaders is the set of forwarded headers that only a trusted proxy
@@ -64,6 +44,12 @@ func trustedProxyMiddleware() func(http.Handler) http.Handler {
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Capture the true TCP peer before chi's RealIP overwrites
+			// RemoteAddr. The local-only trust decision needs the genuine peer
+			// to walk X-Forwarded-For right-to-left; RealIP's leftmost pick is
+			// attacker-controlled and must not be used for auth.
+			r = r.WithContext(auth.WithRealPeer(r.Context(), r.RemoteAddr))
+
 			peerHost, _, _ := net.SplitHostPort(r.RemoteAddr)
 			peerIP := net.ParseIP(strings.Trim(peerHost, "[]"))
 			for _, cidr := range trusted {

--- a/internal/api/opds_auth.go
+++ b/internal/api/opds_auth.go
@@ -33,7 +33,7 @@ func OPDSAuth(p auth.Provider, users *db.UserRepo, limiter *auth.LoginLimiter) f
 				next.ServeHTTP(w, r)
 				return
 			}
-			if mode == auth.ModeLocalOnly && auth.IsLocalRequest(r) {
+			if mode == auth.ModeLocalOnly && auth.IsLocalRequestTrusted(r, p.TrustedProxyCIDRs()) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -2,9 +2,12 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -1029,5 +1032,258 @@ func TestMiddleware_SessionAuthDoesNotSetAPIKeyFlag(t *testing.T) {
 	h.ServeHTTP(nopWriter{}, req)
 	if viaKey {
 		t.Fatal("session-cookie request must NOT set the AuthedViaAPIKey flag")
+	}
+}
+
+// --- Finding 1: X-Forwarded-For spoofing of local-only mode -------------------
+
+// mkReq builds a request whose true TCP peer is peer and which carries the
+// given X-Forwarded-For header value (empty = no header). The true peer is
+// stashed in context exactly as trustedProxyMiddleware does in production.
+func mkReq(peer, xff string) *http.Request {
+	r := &http.Request{RemoteAddr: peer, Header: http.Header{}}
+	if xff != "" {
+		r.Header.Set("X-Forwarded-For", xff)
+	}
+	r = r.WithContext(WithRealPeer(r.Context(), peer))
+	return r
+}
+
+func cidrs(t *testing.T, raw string) []*net.IPNet {
+	t.Helper()
+	return ParseTrustedProxyCIDRs(raw)
+}
+
+func TestResolveClientIP_NoTrustedProxy_IgnoresXFF(t *testing.T) {
+	// No trusted proxy: the TCP peer is the client; a forged XFF must be
+	// ignored entirely. A remote client claiming a private IP stays remote.
+	r := mkReq("8.8.8.8:443", "10.0.0.5")
+	if got := ResolveClientIP(r, nil); got != "8.8.8.8" {
+		t.Fatalf("ResolveClientIP = %q; want 8.8.8.8 (XFF must be ignored)", got)
+	}
+	if IsLocalRequestTrusted(r, nil) {
+		t.Fatal("local-only must NOT be bypassed: forged XFF, no trusted proxy")
+	}
+}
+
+func TestResolveClientIP_SpoofedLeftmostXFF_Rejected(t *testing.T) {
+	// The core CVE: a remote client prepends a forged private IP, the trusted
+	// proxy appends its own hop. chi RealIP would pick the leftmost (forged)
+	// 10.0.0.5 — we must instead resolve to the real remote client.
+	trusted := cidrs(t, "203.0.113.7") // the proxy
+	r := mkReq("203.0.113.7:55000", "10.0.0.5, 8.8.8.8")
+	if got := ResolveClientIP(r, trusted); got != "8.8.8.8" {
+		t.Fatalf("ResolveClientIP = %q; want 8.8.8.8 (real client, not forged 10.0.0.5)", got)
+	}
+	if IsLocalRequestTrusted(r, trusted) {
+		t.Fatal("local-only MUST NOT be bypassed by a forged leftmost XFF entry")
+	}
+}
+
+func TestResolveClientIP_GenuineLocalClientViaProxy(t *testing.T) {
+	// A genuine LAN client behind the trusted proxy: XFF has exactly one hop,
+	// the real private client IP. local-only should allow it.
+	trusted := cidrs(t, "203.0.113.7")
+	r := mkReq("203.0.113.7:55000", "192.168.1.50")
+	if got := ResolveClientIP(r, trusted); got != "192.168.1.50" {
+		t.Fatalf("ResolveClientIP = %q; want 192.168.1.50", got)
+	}
+	if !IsLocalRequestTrusted(r, trusted) {
+		t.Fatal("genuine LAN client behind trusted proxy should be local")
+	}
+}
+
+func TestResolveClientIP_MultipleTrustedHopsPeeled(t *testing.T) {
+	// Two chained trusted proxies. XFF: <client>, <proxyA>; TCP peer = proxyB.
+	// Both proxies are trusted and must be peeled, leaving the client.
+	trusted := cidrs(t, "203.0.113.7,203.0.113.8")
+	r := mkReq("203.0.113.8:40000", "8.8.4.4, 203.0.113.7")
+	if got := ResolveClientIP(r, trusted); got != "8.8.4.4" {
+		t.Fatalf("ResolveClientIP = %q; want 8.8.4.4", got)
+	}
+	if IsLocalRequestTrusted(r, trusted) {
+		t.Fatal("remote client behind two trusted proxies must not be local")
+	}
+}
+
+func TestResolveClientIP_UntrustedPeerXFFIgnored(t *testing.T) {
+	// The TCP peer is NOT a configured proxy: it talks to us directly, so it
+	// is the client and any XFF it sends is untrusted.
+	trusted := cidrs(t, "203.0.113.7")
+	r := mkReq("8.8.8.8:1234", "10.0.0.9")
+	if got := ResolveClientIP(r, trusted); got != "8.8.8.8" {
+		t.Fatalf("ResolveClientIP = %q; want 8.8.8.8 (untrusted peer's XFF ignored)", got)
+	}
+	if IsLocalRequestTrusted(r, trusted) {
+		t.Fatal("untrusted direct peer must not gain local via its own XFF")
+	}
+}
+
+func TestResolveClientIP_IPv6TrustedProxyAndClient(t *testing.T) {
+	// IPv6: trusted proxy is a /48; the real client is a public v6 address
+	// prepended with a forged ULA. The forged fd00:: must not win.
+	trusted := cidrs(t, "2001:db8:aaaa::/48")
+	r := mkReq("[2001:db8:aaaa::1]:9000", "fd00::1, 2606:4700:4700::1111")
+	if got := ResolveClientIP(r, trusted); got != "2606:4700:4700::1111" {
+		t.Fatalf("ResolveClientIP = %q; want 2606:4700:4700::1111 (real v6 client)", got)
+	}
+	if IsLocalRequestTrusted(r, trusted) {
+		t.Fatal("forged IPv6 ULA in XFF must not make the request local")
+	}
+
+	// Genuine IPv6 loopback client behind the trusted v6 proxy.
+	r2 := mkReq("[2001:db8:aaaa::1]:9000", "::1")
+	if !IsLocalRequestTrusted(r2, trusted) {
+		t.Fatal("genuine ::1 client behind trusted v6 proxy should be local")
+	}
+}
+
+func TestResolveClientIP_AllHopsTrusted(t *testing.T) {
+	// Every XFF hop is itself a trusted proxy (degenerate config). The
+	// outermost entry is taken as the best-effort client.
+	trusted := cidrs(t, "203.0.113.0/24")
+	r := mkReq("203.0.113.8:40000", "203.0.113.1, 203.0.113.2")
+	if got := ResolveClientIP(r, trusted); got != "203.0.113.1" {
+		t.Fatalf("ResolveClientIP = %q; want 203.0.113.1 (outermost)", got)
+	}
+}
+
+func TestResolveClientIP_GarbageHopFailsClosed(t *testing.T) {
+	// An unparseable XFF entry breaks the chain of trust; we must not keep
+	// peeling past it (that could expose a forged private IP to its left).
+	trusted := cidrs(t, "203.0.113.7")
+	r := mkReq("203.0.113.7:55000", "10.0.0.5, garbage")
+	got := ResolveClientIP(r, trusted)
+	if got != "garbage" {
+		t.Fatalf("ResolveClientIP = %q; want \"garbage\" (chain breaks, fail closed)", got)
+	}
+	if IsLocalRequestTrusted(r, trusted) {
+		t.Fatal("garbage hop must not resolve to a local address")
+	}
+}
+
+func TestIsLocalRequest_DirectLocalPeerNoXFF(t *testing.T) {
+	// Direct LAN client, no proxy, no XFF — the common local-only case.
+	r := mkReq("192.168.1.10:54321", "")
+	if !IsLocalRequestTrusted(r, nil) {
+		t.Fatal("direct LAN peer should be local")
+	}
+}
+
+// --- Finding 3: session key-id and rotation primitive ------------------------
+
+func TestSession_V2KeyIDRoundTrip(t *testing.T) {
+	secret := testSecret32
+	cookie, err := SignSession(secret, 99, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	parts := strings.Split(cookie, ".")
+	if len(parts) != 5 || parts[0] != "v2" {
+		t.Fatalf("cookie = %q; want 5-part v2 format", cookie)
+	}
+	if parts[1] != keyID(secret) {
+		t.Errorf("cookie key-id = %q; want %q", parts[1], keyID(secret))
+	}
+	uid, err := VerifySession(secret, cookie)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if uid != 99 {
+		t.Errorf("uid = %d; want 99", uid)
+	}
+}
+
+func TestSession_KeyIDChangesWithSecret(t *testing.T) {
+	a := []byte("secret-A-for-keyid-test-32bytes!!")
+	b := []byte("secret-B-for-keyid-test-32bytes!!")
+	if keyID(a) == keyID(b) {
+		t.Fatal("different secrets must produce different key-ids")
+	}
+}
+
+func TestSession_VerifyMultiAcceptsOldAndNew(t *testing.T) {
+	// Rotation window: cookies signed under the previous secret must still
+	// verify when the verifier is handed {new, old}.
+	oldSecret := []byte("old-rotation-secret-32-bytes-long")
+	newSecret := []byte("new-rotation-secret-32-bytes-long")
+
+	oldCookie, err := SignSession(oldSecret, 7, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign old: %v", err)
+	}
+	newCookie, err := SignSession(newSecret, 8, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign new: %v", err)
+	}
+
+	set := [][]byte{newSecret, oldSecret}
+	if uid, err := VerifySessionMulti(set, oldCookie); err != nil || uid != 7 {
+		t.Fatalf("old cookie under rotation set: uid=%d err=%v; want 7,nil", uid, err)
+	}
+	if uid, err := VerifySessionMulti(set, newCookie); err != nil || uid != 8 {
+		t.Fatalf("new cookie under rotation set: uid=%d err=%v; want 8,nil", uid, err)
+	}
+	// After the window closes (only the new secret), the old cookie must fail.
+	if _, err := VerifySessionMulti([][]byte{newSecret}, oldCookie); !errors.Is(err, ErrSessionInvalid) {
+		t.Fatalf("old cookie post-rotation: want ErrSessionInvalid, got %v", err)
+	}
+}
+
+func TestSession_LegacyV1StillVerifies(t *testing.T) {
+	// A v1 cookie minted the old way must still verify so a deploy that adds
+	// v2 does not invalidate every outstanding session at once.
+	secret := testSecret32
+	exp := time.Now().Add(time.Hour).Unix()
+	payload := fmt.Sprintf("v1.%d.%d", int64(55), exp)
+	mac := hmacSum(secret, payload)
+	v1Cookie := payload + "." + base64.RawURLEncoding.EncodeToString(mac)
+
+	uid, err := VerifySession(secret, v1Cookie)
+	if err != nil {
+		t.Fatalf("legacy v1 verify: %v", err)
+	}
+	if uid != 55 {
+		t.Errorf("uid = %d; want 55", uid)
+	}
+
+	// A tampered v1 cookie must still be rejected.
+	tampered := fmt.Sprintf("v1.%d.%d.", int64(9999), exp) +
+		base64.RawURLEncoding.EncodeToString(mac)
+	if _, err := VerifySession(secret, tampered); !errors.Is(err, ErrSessionInvalid) {
+		t.Fatalf("tampered v1 cookie: want ErrSessionInvalid, got %v", err)
+	}
+}
+
+func TestSession_V2WrongKeyIDStillVerifiesWithCorrectSecret(t *testing.T) {
+	// Decode-tolerant: a v2 cookie whose key-id field does not match (e.g.
+	// truncated/garbled) must still verify if the signature is genuine — the
+	// HMAC is authoritative, the key-id is only a routing hint.
+	secret := testSecret32
+	cookie, err := SignSession(secret, 12, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	parts := strings.Split(cookie, ".")
+	// Re-sign the payload but lie about the key-id field. The HMAC covers the
+	// key-id, so we must recompute it for the doctored payload to be valid.
+	parts[1] = "deadbeef"
+	doctoredPayload := strings.Join(parts[:4], ".")
+	parts[4] = base64.RawURLEncoding.EncodeToString(hmacSum(secret, doctoredPayload))
+	doctored := strings.Join(parts, ".")
+
+	uid, err := VerifySession(secret, doctored)
+	if err != nil {
+		t.Fatalf("v2 with non-matching key-id but valid sig: %v", err)
+	}
+	if uid != 12 {
+		t.Errorf("uid = %d; want 12", uid)
+	}
+}
+
+func TestSession_VerifyMultiRejectsWhenNoSecretUsable(t *testing.T) {
+	cookie, _ := SignSession(testSecret32, 1, time.Now().Add(time.Hour))
+	if _, err := VerifySessionMulti([][]byte{[]byte("short"), nil}, cookie); !errors.Is(err, ErrSessionInvalid) {
+		t.Fatal("VerifySessionMulti must fail closed when no secret meets minSecretLen")
 	}
 }

--- a/internal/auth/localip.go
+++ b/internal/auth/localip.go
@@ -1,9 +1,12 @@
 package auth
 
 import (
+	"context"
 	"net"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
 )
 
 // privateCIDRs: RFC1918 + loopback + link-local + IPv6 unique-local + IPv6 loopback.
@@ -29,10 +32,148 @@ var privateCIDRs = func() []*net.IPNet {
 	return out
 }()
 
-// IsLocalRequest returns true when the request's client IP falls in a private
-// range. Respects a cleaned RemoteAddr set by chi's RealIP middleware upstream.
+// realPeerCtxKey carries the connection's true peer address (host:port or bare
+// host) as observed before any X-Forwarded-* rewriting (chi's RealIP) ran.
+// trustedProxyMiddleware stashes it so the local-only trust decision can start
+// its right-to-left X-Forwarded-For walk from the actual TCP peer rather than
+// from a value an attacker may control.
+type realPeerCtxKeyT struct{}
+
+var realPeerCtxKey = realPeerCtxKeyT{}
+
+// WithRealPeer returns a context carrying the request's true peer address.
+// Call this from the proxy middleware *before* chi's RealIP overwrites
+// r.RemoteAddr, passing the original r.RemoteAddr.
+func WithRealPeer(ctx context.Context, remoteAddr string) context.Context {
+	return context.WithValue(ctx, realPeerCtxKey, remoteAddr)
+}
+
+// realPeerHost returns the bare host of the request's true TCP peer. It
+// prefers the value stashed by WithRealPeer (the address before RealIP
+// rewriting); if that is absent it falls back to r.RemoteAddr. The fallback is
+// only safe when no proxy rewriting happened — see ResolveClientIP.
+func realPeerHost(r *http.Request) string {
+	addr := r.RemoteAddr
+	if v, ok := r.Context().Value(realPeerCtxKey).(string); ok && v != "" {
+		addr = v
+	}
+	return hostOnly(addr)
+}
+
+// hostOnly strips an optional :port and surrounding brackets from an address.
+func hostOnly(addr string) string {
+	host := addr
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return strings.Trim(host, "[]")
+}
+
+// IsLocalRequest reports whether the request's *real* client IP is in a
+// private/loopback range, for the local-only auth bypass. It resolves the
+// client IP from the true TCP peer and X-Forwarded-For, trusting only the
+// proxies configured via BINDERY_TRUSTED_PROXY. It never trusts a
+// client-supplied leftmost X-Forwarded-For entry (chi RealIP's pick), so a
+// remote client cannot spoof a private IP to bypass local-only auth.
 func IsLocalRequest(r *http.Request) bool {
-	return IsLocalIP(clientIP(r))
+	return IsLocalRequestTrusted(r, envTrustedProxyCIDRs())
+}
+
+// IsLocalRequestTrusted is IsLocalRequest with an explicit trusted-proxy CIDR
+// set. Callers that already hold the parsed CIDR list (e.g. the auth Provider)
+// should use this to avoid re-parsing the environment.
+func IsLocalRequestTrusted(r *http.Request, trusted []*net.IPNet) bool {
+	return IsLocalIP(ResolveClientIP(r, trusted))
+}
+
+// ResolveClientIP returns the request's real client IP for trust decisions.
+//
+// It deliberately does NOT use chi RealIP's leftmost X-Forwarded-For pick,
+// which is attacker-controlled: a remote client can prepend a forged private
+// IP and any proxy that does not strip inbound XFF will pass it through as the
+// leftmost entry.
+//
+// Algorithm:
+//   - The chain considered is [realPeer] + X-Forwarded-For entries, ordered
+//     closest-to-server last. realPeer is the actual TCP peer (captured before
+//     RealIP rewrote RemoteAddr).
+//   - If no trusted proxy is configured, the peer is the client and XFF is
+//     ignored entirely.
+//   - If the peer itself is not a trusted proxy, the peer is the client and
+//     its XFF header is not trusted.
+//   - Otherwise walk the chain right-to-left, peeling off every hop that is a
+//     trusted proxy; the first non-trusted address encountered is the real
+//     client. If every hop is trusted, the left-most (outermost) hop is used.
+//
+// The returned string is a bare IP, or "" if no usable address is found.
+func ResolveClientIP(r *http.Request, trusted []*net.IPNet) string {
+	peer := realPeerHost(r)
+
+	// No trusted proxy configured: the TCP peer is the client, full stop.
+	// Any X-Forwarded-For header is untrusted and ignored.
+	if len(trusted) == 0 {
+		return peer
+	}
+
+	peerIP := net.ParseIP(peer)
+	// The peer is not one of our proxies: it is talking to us directly, so it
+	// is the client. Do not trust an XFF header it supplied.
+	if peerIP == nil || !ipInCIDRs(peerIP, trusted) {
+		return peer
+	}
+
+	// Peer is a trusted proxy. Reconstruct the forwarding chain. X-Forwarded-For
+	// is appended left-to-right (oldest first), so the rightmost entries are the
+	// closest hops. The TCP peer sits one hop further in than the rightmost XFF
+	// entry. Walk right-to-left, discarding trusted-proxy hops; the first
+	// non-trusted hop is the genuine client.
+	xff := parseXFF(r.Header.Values("X-Forwarded-For"))
+	for i := len(xff) - 1; i >= 0; i-- {
+		ip := net.ParseIP(xff[i])
+		if ip == nil {
+			// An unparseable hop breaks the chain of trust: we can no longer
+			// account for who is upstream of it. Treat it as the client so the
+			// decision fails closed (a garbage entry will not be "local").
+			return xff[i]
+		}
+		if !ipInCIDRs(ip, trusted) {
+			return xff[i]
+		}
+	}
+
+	// Every XFF hop was a trusted proxy (or XFF was empty). The client is the
+	// outermost entry if present, otherwise the trusted peer itself.
+	if len(xff) > 0 {
+		return xff[0]
+	}
+	return peer
+}
+
+// parseXFF flattens one or more X-Forwarded-For header values into an ordered
+// list of trimmed host strings (oldest hop first), dropping empty entries.
+func parseXFF(values []string) []string {
+	var out []string
+	for _, v := range values {
+		for _, part := range strings.Split(v, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			// XFF may carry "host:port" (rare) or bracketed IPv6 — normalise.
+			out = append(out, hostOnly(part))
+		}
+	}
+	return out
+}
+
+// ipInCIDRs reports whether ip falls within any of the given CIDRs.
+func ipInCIDRs(ip net.IP, cidrs []*net.IPNet) bool {
+	for _, n := range cidrs {
+		if n != nil && n.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // IsLocalIP returns true for RFC1918, loopback, and link-local addresses.
@@ -49,13 +190,36 @@ func IsLocalIP(ip string) bool {
 	return false
 }
 
-func clientIP(r *http.Request) string {
-	// chi's middleware.RealIP (applied in main.go) normalises RemoteAddr based on
-	// X-Forwarded-For / X-Real-IP. Accept RemoteAddr as host:port or bare host.
-	host := r.RemoteAddr
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		host = h
+// envTrustedProxyCIDRs parses BINDERY_TRUSTED_PROXY once. It mirrors
+// cmd/bindery.parseTrustedProxyCIDRs; that one cannot be imported (main
+// package), and the env var is the single source of truth for both.
+var envTrustedProxyCIDRs = sync.OnceValue(func() []*net.IPNet {
+	return ParseTrustedProxyCIDRs(os.Getenv("BINDERY_TRUSTED_PROXY"))
+})
+
+// ParseTrustedProxyCIDRs parses a comma-separated list of IP/CIDR strings into
+// []*net.IPNet. Bare IPs become /32 (IPv4) or /128 (IPv6). Invalid entries are
+// skipped silently. Exported so callers (and tests) share one parser.
+func ParseTrustedProxyCIDRs(raw string) []*net.IPNet {
+	if strings.TrimSpace(raw) == "" {
+		return nil
 	}
-	host = strings.Trim(host, "[]")
-	return host
+	var out []*net.IPNet
+	for _, s := range strings.Split(raw, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if !strings.Contains(s, "/") {
+			if strings.Contains(s, ":") {
+				s += "/128"
+			} else {
+				s += "/32"
+			}
+		}
+		if _, cidr, err := net.ParseCIDR(s); err == nil {
+			out = append(out, cidr)
+		}
+	}
+	return out
 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -200,7 +200,7 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
-			if mode == ModeLocalOnly && IsLocalRequest(r) {
+			if mode == ModeLocalOnly && IsLocalRequestTrusted(r, p.TrustedProxyCIDRs()) {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strconv"
@@ -11,17 +12,37 @@ import (
 	"time"
 )
 
-// Session cookie format (all base64-url-nopad, dot-separated):
+// Session cookie format (all dot-separated).
 //
-//	v1.<user_id>.<expires_unix>.<hmac(secret, "v1."+user_id+"."+expires)>
+// Current (v2), carries a key-id so the secret can be rotated with an
+// overlapping window:
 //
-// Self-contained: no server-side session table. Rotating auth.session_secret
-// invalidates every outstanding cookie.
+//	v2.<key_id>.<user_id>.<expires_unix>.<hmac(secret, "v2.<key_id>.<user_id>.<expires_unix>")>
+//
+// Legacy (v1), no key-id — still accepted on verification so a deploy that
+// introduces v2 does not invalidate every outstanding cookie at once:
+//
+//	v1.<user_id>.<expires_unix>.<hmac(secret, "v1.<user_id>.<expires_unix>")>
+//
+// <key_id> is a short, deterministic fingerprint of the signing secret (see
+// keyID). Because it is derived from the secret itself there is nothing extra
+// to store: rotating the secret changes the key-id automatically, and a
+// verifier handed several candidate secrets can match the cookie's key-id to
+// pick the right one (or fall back to trying each).
+//
+// Self-contained: no server-side session table.
 const (
 	SessionCookieName    = "bindery_session"
 	SessionDuration      = 30 * 24 * time.Hour // when "remember me" is checked
 	SessionDurationShort = 12 * time.Hour      // browser-session equivalent when not
-	sessionCookieVersion = "v1"
+
+	sessionCookieVersion       = "v2" // current format written by SignSession
+	sessionCookieVersionLegacy = "v1" // older format still accepted by VerifySession
+
+	// keyIDLen is the number of hex chars of the secret fingerprint embedded
+	// in the cookie. 8 hex chars = 32 bits — enough to distinguish a handful of
+	// rotation-window secrets; it is not security-relevant (the HMAC is).
+	keyIDLen = 8
 
 	// minSecretLen is the minimum length (in bytes) required for a session
 	// signing secret. Shorter secrets are rejected fail-closed.
@@ -39,43 +60,121 @@ var (
 	ErrSessionInvalid = errors.New("session invalid")
 )
 
-// SignSession returns a signed cookie value for the given user that expires at exp.
-// It returns an error if secret is nil or shorter than minSecretLen bytes.
+// keyID returns a short, deterministic, non-secret fingerprint of secret,
+// used as the cookie's key-id. It is HMAC-SHA256 keyed by the secret over a
+// fixed domain-separation label, truncated to keyIDLen hex chars. Using an
+// HMAC (rather than a bare hash of the secret) avoids publishing a plain
+// digest of the signing key in every cookie.
+func keyID(secret []byte) string {
+	mac := hmacSum(secret, "bindery-session-key-id")
+	return hex.EncodeToString(mac)[:keyIDLen]
+}
+
+// SignSession returns a signed cookie value (current v2 format, with key-id)
+// for the given user that expires at exp. It returns an error wrapping
+// ErrSessionInvalid if secret is nil or shorter than minSecretLen bytes.
 func SignSession(secret []byte, userID int64, exp time.Time) (string, error) {
 	if len(secret) < minSecretLen {
 		return "", fmt.Errorf("sign session: %w", ErrSessionInvalid)
 	}
-	payload := fmt.Sprintf("%s.%d.%d", sessionCookieVersion, userID, exp.Unix())
+	payload := fmt.Sprintf("%s.%s.%d.%d", sessionCookieVersion, keyID(secret), userID, exp.Unix())
 	mac := hmacSum(secret, payload)
 	return payload + "." + base64.RawURLEncoding.EncodeToString(mac), nil
 }
 
-// VerifySession returns the user id carried by a valid, unexpired signed cookie,
-// or an error on any tamper/expiry/parse failure.
-// It returns ErrSessionInvalid (wrapped) when secret is absent/too short.
+// VerifySession returns the user id carried by a valid, unexpired signed
+// cookie, or an error on any tamper/expiry/parse failure. It accepts both the
+// current v2 (key-id) format and the legacy v1 format. It returns
+// ErrSessionInvalid (wrapped) when secret is absent/too short.
 func VerifySession(secret []byte, cookie string) (int64, error) {
-	if len(secret) < minSecretLen {
+	return VerifySessionMulti([][]byte{secret}, cookie)
+}
+
+// VerifySessionMulti is VerifySession against a small ordered set of candidate
+// secrets — the rotation primitive. During a secret rotation the verifier can
+// be handed {current, previous} so cookies signed under either are accepted;
+// the writer (SignSession) always uses the first/current secret.
+//
+// For a v2 cookie the embedded key-id is used to pick the matching candidate
+// directly (constant work, no HMAC against non-matching secrets); if no key-id
+// matches, every candidate is still HMAC-checked so a key-id collision or a
+// secret whose fingerprint is unknown cannot cause a spurious rejection. For a
+// legacy v1 cookie (no key-id) each candidate is tried in turn.
+//
+// Verification is never weakened: a cookie is accepted only if some candidate
+// secret produces an HMAC equal (in constant time) to the cookie's signature.
+func VerifySessionMulti(secrets [][]byte, cookie string) (int64, error) {
+	// Keep only usable (long-enough) secrets. Fail closed if none remain.
+	var usable [][]byte
+	for _, s := range secrets {
+		if len(s) >= minSecretLen {
+			usable = append(usable, s)
+		}
+	}
+	if len(usable) == 0 {
 		return 0, fmt.Errorf("verify session: %w", ErrSessionInvalid)
 	}
+
 	parts := strings.Split(cookie, ".")
-	if len(parts) != 4 || parts[0] != sessionCookieVersion {
+	var sig string
+	var idIdx, expIdx int // indices into parts of user-id and expiry
+	var cookieKeyID string
+
+	switch {
+	case len(parts) == 5 && parts[0] == sessionCookieVersion:
+		// v2.<key_id>.<user_id>.<expires>.<hmac>
+		cookieKeyID = parts[1]
+		idIdx, expIdx = 2, 3
+		sig = parts[4]
+	case len(parts) == 4 && parts[0] == sessionCookieVersionLegacy:
+		// v1.<user_id>.<expires>.<hmac>
+		idIdx, expIdx = 1, 2
+		sig = parts[3]
+	default:
 		return 0, fmt.Errorf("malformed session: %w", ErrSessionInvalid)
 	}
-	userID, err := strconv.ParseInt(parts[1], 10, 64)
+
+	userID, err := strconv.ParseInt(parts[idIdx], 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("bad user id: %w", ErrSessionInvalid)
 	}
-	expUnix, err := strconv.ParseInt(parts[2], 10, 64)
+	expUnix, err := strconv.ParseInt(parts[expIdx], 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("bad expiry: %w", ErrSessionInvalid)
 	}
-	payload := strings.Join(parts[:3], ".")
-	want := hmacSum(secret, payload)
-	got, err := base64.RawURLEncoding.DecodeString(parts[3])
+	payload := strings.Join(parts[:len(parts)-1], ".")
+	got, err := base64.RawURLEncoding.DecodeString(sig)
 	if err != nil {
 		return 0, fmt.Errorf("bad signature encoding: %w", ErrSessionInvalid)
 	}
-	if !hmac.Equal(got, want) {
+
+	// Try the candidate whose key-id matches first (v2 fast path), then fall
+	// back to every candidate. matched stays false until a constant-time HMAC
+	// comparison succeeds.
+	matched := false
+	for _, secret := range usable {
+		if cookieKeyID != "" && keyID(secret) != cookieKeyID {
+			// key-id mismatch — still checked in the fallback pass below, but
+			// skipped here to keep the common case cheap.
+			continue
+		}
+		if hmac.Equal(got, hmacSum(secret, payload)) {
+			matched = true
+			break
+		}
+	}
+	if !matched && cookieKeyID != "" {
+		// Fallback: a v2 cookie whose key-id matched no candidate (collision,
+		// or a candidate set that does not announce its fingerprints). Verify
+		// against every secret so a correct signature is never rejected.
+		for _, secret := range usable {
+			if hmac.Equal(got, hmacSum(secret, payload)) {
+				matched = true
+				break
+			}
+		}
+	}
+	if !matched {
 		return 0, fmt.Errorf("bad signature: %w", ErrSessionInvalid)
 	}
 	if time.Now().Unix() > expUnix {


### PR DESCRIPTION
Implements the **deferred** findings 1 and 3 of #710. Findings 2 (session-secret fail-closed) and 4 (VerifySession sentinels) already landed.

## Finding 1 — `local-only` mode spoofable via `X-Forwarded-For`

chi's `RealIP` rewrites `RemoteAddr` to the **leftmost** XFF entry. A remote client behind a trusted proxy that does not strip inbound XFF could prepend `X-Forwarded-For: 10.0.0.5`, the proxy appends its own hop, and `IsLocalRequest` returned true — bypassing `local-only` auth.

- `trustedProxyMiddleware` now stashes the true TCP peer in the request context (`auth.WithRealPeer`) **before** chi `RealIP` overwrites `RemoteAddr`.
- New `auth.ResolveClientIP` walks `[realPeer] + X-Forwarded-For` **right-to-left**, peeling hops inside the configured `BINDERY_TRUSTED_PROXY` CIDRs; the first non-trusted address is the real client. RealIP's attacker-controlled leftmost pick is never used for the trust decision.
- No trusted proxy configured → direct `RemoteAddr` is the client, XFF ignored entirely. Untrusted direct peer's XFF is also ignored. An unparseable hop breaks the chain and fails closed.
- IPv6 handled throughout. CIDR parsing shared via `auth.ParseTrustedProxyCIDRs` (`cmd/bindery/proxy.go` now delegates to it).
- `local-only` callers (`auth.Middleware`, `OPDSAuth`) pass the Provider's trusted-proxy CIDR set via `IsLocalRequestTrusted`; `AuthHandler.Status` uses the env-derived default.

## Finding 3 — session secret rotation has no key-id

The cookie carried only a `v1` tag; rotating `auth.session_secret` invalidated every session at once.

- New **v2** cookie format embeds a `key-id`: a short, deterministic, non-secret HMAC fingerprint of the signing secret. Rotating the secret changes the key-id automatically — nothing extra to store.
- `VerifySession` accepts **both** v2 and legacy v1 cookies, so introducing v2 does not invalidate outstanding sessions on deploy. v2 verification is decode-tolerant (a non-matching key-id still verifies if the HMAC is genuine — the HMAC is authoritative).
- New `VerifySessionMulti(secrets, cookie)` is the rotation primitive: given `{current, previous}` it accepts cookies signed under either, routing by key-id with a fallback that HMAC-checks every candidate so a correct signature is never rejected. **Verification is never weakened.**

### Deferred on finding 3

Wiring `VerifySessionMulti` to actually source current+previous secrets from settings is **deferred** — it needs a second settings key (or a list), a `SettingsRepo`/schema change, and an admin rotation flow, which would balloon this diff. The cookie format and the multi-secret verification primitive are fully implemented and tested; only the settings plumbing to feed two live secrets remains.

## Tests

`go build ./...` OK, `go vet` clean, `go test ./internal/auth/... ./internal/api/...` all pass. New tests: XFF right-to-left with trusted/untrusted/multiple/IPv6 hops; spoofed leftmost IP rejected; garbage hop fails closed; v2 key-id round-trip; rotation-window accept old+new; legacy v1 still verifies.

Refs #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)