### PR TITLE
fix(security): re-validate resolved IPs per connection to block DNS rebinding

### DIFF
--- a/internal/httpsec/ssrf.go
+++ b/internal/httpsec/ssrf.go
@@ -186,6 +186,68 @@ func isIPv6ULA(ip net.IP) bool {
 	return ip16[0]&0xfe == 0xfc
 }
 
+// ValidateIP returns an error if ip is forbidden under policy. It applies the
+// same rules as ValidateOutboundURL's per-IP checks (loopback, link-local,
+// cloud-metadata, and RFC1918/ULA depending on policy). Callers that have
+// already resolved a hostname to a net.IP — for example, a custom DialContext
+// that intercepts the resolved address — can use this to enforce the policy at
+// connection time without re-parsing a URL.
+func ValidateIP(ip net.IP, policy Policy) error {
+	return checkIP(ip, policy)
+}
+
+// NewDialContext returns a DialContext function that wraps net.Dialer and
+// re-validates every resolved IP against policy before completing the TCP
+// connection. This prevents DNS-rebinding attacks where a hostname initially
+// resolves to a public IP (passing ValidateOutboundURL at config time) but
+// later flips to a private address after the DNS TTL expires.
+//
+// The returned function preserves the caller's context and is safe for
+// concurrent use. Pass it to http.Transport.DialContext.
+func NewDialContext(policy Policy) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		// addr is "host:port" as provided by the HTTP transport.
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("dial: invalid address %q: %w", addr, err)
+		}
+
+		// If host is already an IP literal, validate it directly and dial.
+		if ip := net.ParseIP(host); ip != nil {
+			if err := checkIP(ip, policy); err != nil {
+				return nil, fmt.Errorf("dial %s: %w", addr, err)
+			}
+			return dialer.DialContext(ctx, network, addr)
+		}
+
+		// Resolve the hostname so we can validate each returned IP before
+		// handing control to the kernel's connect(2). This is the per-request
+		// re-validation that defeats DNS rebinding: the OS may have cached an
+		// old (allowed) IP while DNS now points at a private address.
+		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("dial: dns lookup %q: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("dial: no addresses for %q", host)
+		}
+
+		// Validate every resolved address. Fail-closed: if any IP is forbidden
+		// we refuse the entire dial rather than trying only the allowed ones,
+		// because an attacker might arrange for one A record to be public and
+		// another to be the target address.
+		for _, ia := range ips {
+			if err := checkIP(ia.IP, policy); err != nil {
+				return nil, fmt.Errorf("dial %s: resolved %s: %w", host, ia.IP, err)
+			}
+		}
+
+		// All resolved IPs passed; dial using the first one (standard behaviour).
+		return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+	}
+}
+
 // PolicyFromEnv returns override if the given env variable is set to "1" or
 // "true" (case-insensitive), otherwise returns def. This lets callers flip
 // the strict default to LAN policy for users with on-LAN services.

--- a/internal/httpsec/ssrf_test.go
+++ b/internal/httpsec/ssrf_test.go
@@ -1,8 +1,12 @@
 package httpsec
 
 import (
+	"context"
 	"errors"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -263,5 +267,91 @@ func TestPolicyFromEnv(t *testing.T) {
 	t.Setenv(key, "maybe")
 	if got := PolicyFromEnv(PolicyStrict, key); got != PolicyStrict {
 		t.Errorf("'maybe': want PolicyStrict, got %v", got)
+	}
+}
+
+// TestValidateIP exercises the exported thin wrapper around checkIP.
+func TestValidateIP(t *testing.T) {
+	// Public IP: always allowed.
+	if err := ValidateIP(mustIP("93.184.216.34"), PolicyStrict); err != nil {
+		t.Errorf("public IP blocked unexpectedly: %v", err)
+	}
+	// Loopback: always blocked.
+	if err := ValidateIP(mustIP("127.0.0.1"), PolicyStrict); err == nil {
+		t.Error("expected loopback to be blocked")
+	}
+	if err := ValidateIP(mustIP("127.0.0.1"), PolicyLAN); err == nil {
+		t.Error("expected loopback to be blocked under LAN policy")
+	}
+	// Cloud metadata: always blocked.
+	if err := ValidateIP(mustIP("169.254.169.254"), PolicyLAN); err == nil {
+		t.Error("expected cloud-metadata IP to be blocked under LAN policy")
+	}
+	// RFC1918: blocked under Strict, allowed under LAN.
+	if err := ValidateIP(mustIP("192.168.1.1"), PolicyStrict); err == nil {
+		t.Error("expected RFC1918 to be blocked under Strict")
+	}
+	if err := ValidateIP(mustIP("192.168.1.1"), PolicyLAN); err != nil {
+		t.Errorf("expected RFC1918 to be allowed under LAN, got: %v", err)
+	}
+}
+
+// TestNewDialContext_BlocksLoopback verifies the custom dialer rejects a
+// connection whose target resolves to loopback under all policies.
+func TestNewDialContext_BlocksLoopback(t *testing.T) {
+	// Start a real server on loopback so we have a valid port to dial.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Build an http.Client that uses the hardened dialer.
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: NewDialContext(PolicyStrict),
+		},
+	}
+
+	// srv.URL is "http://127.0.0.1:<port>" — loopback, always blocked.
+	_, err := client.Get(srv.URL) //nolint:bodyclose
+	if err == nil {
+		t.Fatal("expected dial to be rejected for loopback address, got nil error")
+	}
+	if !strings.Contains(err.Error(), "loopback") {
+		t.Errorf("expected 'loopback' in error, got: %v", err)
+	}
+}
+
+// TestNewDialContext_AllowsPublicHosts verifies the custom dialer does not
+// inject a policy error for a public IP literal. We use an immediately-expired
+// context so the TCP connect never blocks; the important assertion is that the
+// error is a context error, not a policy rejection.
+func TestNewDialContext_AllowsPublicHosts(t *testing.T) {
+	dialCtx := NewDialContext(PolicyLAN)
+	// Cancel the context immediately so the TCP handshake never blocks, but the
+	// policy check (which runs before the dial) has already completed.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := dialCtx(ctx, "tcp", "93.184.216.34:80")
+	// A policy rejection would contain "url not allowed"; a context/network
+	// error is acceptable and expected here.
+	if err != nil && strings.Contains(err.Error(), "url not allowed") {
+		t.Errorf("public IP should not be rejected by policy, got: %v", err)
+	}
+}
+
+// TestNewDialContext_BlocksRFC1918UnderStrict verifies a dial to an RFC1918
+// address is blocked by PolicyStrict but would be allowed by PolicyLAN (the
+// block is verified; the allow is not dialed since we have no LAN server).
+func TestNewDialContext_BlocksRFC1918UnderStrict(t *testing.T) {
+	dialCtx := NewDialContext(PolicyStrict)
+	ctx := context.Background()
+	_, err := dialCtx(ctx, "tcp", "192.168.1.1:80")
+	if err == nil {
+		t.Fatal("expected dial to RFC1918 to be rejected under PolicyStrict")
+	}
+	if !strings.Contains(err.Error(), "private network") {
+		t.Errorf("expected 'private network' in error, got: %v", err)
 	}
 }

--- a/internal/indexer/debug.go
+++ b/internal/indexer/debug.go
@@ -114,7 +114,7 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 			defer wg.Done()
 			start := time.Now()
 
-			client := newznab.New(idx.URL, idx.APIKey)
+			client := s.makeClient(idx.URL, idx.APIKey)
 			cats := filterCategoriesForMedia(idx.Categories, c.MediaType)
 			entry.Categories = cats
 

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/useragent"
 )
 
@@ -50,7 +51,37 @@ func New(baseURL, apiKey string) *Client {
 		baseURL:  parsedURL,
 		baseHost: baseHost,
 		apiKey:   resolvedAPIKey,
-		http:     &http.Client{Timeout: 30 * time.Second},
+		http:     newHTTPClient(),
+	}
+}
+
+// SetHTTPClient replaces the client's internal http.Client. Intended for tests
+// that need to reach httptest servers on loopback without triggering the SSRF
+// dialer that newHTTPClient installs by default.
+func (c *Client) SetHTTPClient(h *http.Client) {
+	c.http = h
+}
+
+// newHTTPClient returns an *http.Client whose transport re-validates the
+// resolved IP address on every new TCP connection. This prevents DNS-rebinding
+// attacks: ValidateOutboundURL runs at indexer create/update time, but an
+// attacker who controls the indexer hostname can flip its DNS record to
+// 169.254.169.254 (cloud metadata) or an RFC1918 address after the initial
+// check passes. The custom DialContext re-runs the IP validation per
+// connection, so a post-TTL rebind is caught before the kernel's connect(2)
+// is invoked. PolicyLAN is used because indexers legitimately run on LAN
+// addresses; loopback, link-local, and cloud-metadata remain blocked under
+// all policies.
+func newHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			DialContext:           httpsec.NewDialContext(httpsec.PolicyLAN),
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
 	}
 }
 

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -9,7 +9,18 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
+
+// testNew creates a newznab Client for use with httptest servers. It replaces
+// the hardened http.Client (whose DialContext blocks loopback) with a plain
+// one so tests can reach 127.0.0.1 without triggering the SSRF policy. Only
+// use this in tests that are not specifically testing the SSRF dialer.
+func testNew(baseURL, apiKey string) *Client {
+	c := New(baseURL, apiKey)
+	c.http = &http.Client{Timeout: 30 * time.Second}
+	return c
+}
 
 const testRSS = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
@@ -62,7 +73,7 @@ func TestParseSearchResults(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	results, err := c.Search(context.Background(), "dark matter", []int{7000, 7020})
 	if err != nil {
 		t.Fatalf("search: %v", err)
@@ -100,7 +111,7 @@ func TestParseCaps(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	caps, err := c.Caps(context.Background())
 	if err != nil {
 		t.Fatalf("caps: %v", err)
@@ -127,7 +138,7 @@ func TestTest(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	err := c.Test(context.Background())
 	if err != nil {
 		t.Errorf("test should pass: %v", err)
@@ -177,7 +188,7 @@ func TestCapsWithFullTorznabEndpointURL(t *testing.T) {
 	defer srv.Close()
 
 	endpoint := srv.URL + "/1/api?apikey=from-url"
-	c := New(endpoint, "")
+	c := testNew(endpoint, "")
 	if _, err := c.Caps(context.Background()); err != nil {
 		t.Fatalf("caps: %v", err)
 	}
@@ -204,7 +215,7 @@ func TestCapsWithEndpointAndExplicitAPIKeyOverridesURL(t *testing.T) {
 	defer srv.Close()
 
 	endpoint := srv.URL + "/1/api?apikey=from-url"
-	c := New(endpoint, "from-field")
+	c := testNew(endpoint, "from-field")
 	if _, err := c.Caps(context.Background()); err != nil {
 		t.Fatalf("caps: %v", err)
 	}
@@ -287,7 +298,7 @@ func TestBookSearch_Tier1StructuredBook(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	results, err := c.BookSearch(context.Background(), "Dark Matter: A Novel", "Blake Crouch", []int{7020})
 	if err != nil {
 		t.Fatalf("BookSearch: %v", err)
@@ -330,7 +341,7 @@ func TestBookSearch_FallsBackToSurnameTier(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	results, err := c.BookSearch(context.Background(), "Dark Matter", "Blake Crouch", []int{7020})
 	if err != nil {
 		t.Fatalf("BookSearch: %v", err)
@@ -361,7 +372,7 @@ func TestBookSearch_FinalFallbackTitleOnly(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	// No author supplied: tiers 1-3 should be skipped and tier 4 taken.
 	results, err := c.BookSearch(context.Background(), "Dune", "", []int{7020})
 	if err != nil {
@@ -385,7 +396,7 @@ func TestProbe_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	result := c.Probe(context.Background())
 	if result.Error != "" {
 		t.Fatalf("unexpected error: %s", result.Error)
@@ -417,7 +428,7 @@ func TestProbe_HTTPErrorStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "wrong")
+	c := testNew(srv.URL, "wrong")
 	result := c.Probe(context.Background())
 	if result.Status != http.StatusUnauthorized {
 		t.Errorf("expected status 401, got %d", result.Status)
@@ -439,7 +450,7 @@ func TestProbe_InvalidXML(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	result := c.Probe(context.Background())
 	if result.Status != http.StatusOK {
 		t.Errorf("expected status 200 even with bad body, got %d", result.Status)
@@ -456,7 +467,7 @@ func TestProbe_NetworkError(t *testing.T) {
 	// Close immediately so Do() returns a dial error.
 	srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	result := c.Probe(context.Background())
 	if result.Status != 0 {
 		t.Errorf("expected zero status on dial failure, got %d", result.Status)
@@ -502,7 +513,7 @@ func TestParseResults_UsesLinkWhenEnclosureMissing(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	results, err := c.Search(context.Background(), "q", nil)
 	if err != nil {
 		t.Fatalf("search: %v", err)
@@ -530,7 +541,7 @@ func TestGetXML_SurfacesNon200(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	_, err := c.Search(context.Background(), "anything", nil)
 	if err == nil {
 		t.Fatalf("expected error on 503, got nil")
@@ -586,7 +597,7 @@ func TestSearch_SurfacesNewznabError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	_, err := c.Search(context.Background(), "anything", nil)
 	if err == nil {
 		t.Fatal("expected error on <error> response, got nil")
@@ -718,7 +729,7 @@ func TestParseResults_AppendsApikeyToEnclosure(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL+"/1/api", "the-key")
+	c := testNew(srv.URL+"/1/api", "the-key")
 	results, err := c.Search(context.Background(), "anything", nil)
 	if err != nil {
 		t.Fatalf("search: %v", err)
@@ -904,7 +915,7 @@ func TestBookSearch_Tier1FallsBackOnCannedFeed(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "testkey")
+	c := testNew(srv.URL, "testkey")
 	results, err := c.BookSearch(context.Background(), "Life Ascending", "Nick Lane", []int{7020})
 	if err != nil {
 		t.Fatalf("BookSearch: %v", err)
@@ -921,5 +932,28 @@ func TestBookSearch_Tier1FallsBackOnCannedFeed(t *testing.T) {
 	}
 	if queries[0].Get("t") != "book" {
 		t.Errorf("expected first request to be t=book, got t=%s", queries[0].Get("t"))
+	}
+}
+
+// TestNew_HardenedDialerBlocksLoopback verifies that the http.Client returned
+// by New() uses the httpsec-hardened DialContext that blocks loopback addresses,
+// preventing DNS-rebinding attacks where a hostname resolves to 127.0.0.1 after
+// the initial ValidateOutboundURL check passes. This is the Finding 1 fix from
+// issue #711: re-validation happens per connection, not only at config time.
+func TestNew_HardenedDialerBlocksLoopback(t *testing.T) {
+	// Start a local server — its address will be on 127.0.0.1 (loopback).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Use New() (hardened client), NOT testNew() — the dialer must be active.
+	c := New(srv.URL, "testkey")
+	_, err := c.Caps(context.Background())
+	if err == nil {
+		t.Fatal("expected connection to loopback to be rejected by the SSRF dialer, got nil error")
+	}
+	if !strings.Contains(err.Error(), "loopback") {
+		t.Errorf("expected 'loopback' in SSRF dial error, got: %v", err)
 	}
 }

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -17,7 +17,13 @@ import (
 )
 
 // Searcher coordinates searches across multiple Newznab indexers.
-type Searcher struct{}
+type Searcher struct {
+	// newClient is the factory used to create per-indexer newznab clients.
+	// nil uses newznab.New, which builds a client with the SSRF-hardened
+	// transport. Tests that run against httptest servers can inject a factory
+	// that bypasses the dialer.
+	newClient func(baseURL, apiKey string) *newznab.Client
+}
 
 // NewSearcher creates a new multi-indexer searcher.
 func NewSearcher() *Searcher {
@@ -42,6 +48,15 @@ type MatchCriteria struct {
 	MediaType        string   // models.MediaTypeEbook or models.MediaTypeAudiobook
 	AllowedLanguages []string // from author's MetadataProfile; empty = no filter
 	AuthorAliases    []string // alternate names (e.g. latin-script romanisations for non-latin authors)
+}
+
+// makeClient creates a newznab client using the injected factory, falling
+// back to newznab.New (with its SSRF-hardened transport) when none is set.
+func (s *Searcher) makeClient(baseURL, apiKey string) *newznab.Client {
+	if s.newClient != nil {
+		return s.newClient(baseURL, apiKey)
+	}
+	return newznab.New(baseURL, apiKey)
 }
 
 // filterCategoriesForMedia returns the subset of configured indexer
@@ -103,7 +118,7 @@ func (s *Searcher) SearchBook(ctx context.Context, indexers []models.Indexer, c 
 		go func(idx models.Indexer) {
 			defer wg.Done()
 
-			client := newznab.New(idx.URL, idx.APIKey)
+			client := s.makeClient(idx.URL, idx.APIKey)
 			cats := filterCategoriesForMedia(idx.Categories, c.MediaType)
 			hits, err := client.BookSearch(ctx, c.Title, c.Author, cats)
 			if err != nil {
@@ -152,7 +167,7 @@ func (s *Searcher) SearchQuery(ctx context.Context, indexers []models.Indexer, q
 		go func(idx models.Indexer) {
 			defer wg.Done()
 
-			client := newznab.New(idx.URL, idx.APIKey)
+			client := s.makeClient(idx.URL, idx.APIKey)
 			hits, err := client.Search(ctx, query, idx.Categories)
 			if err != nil {
 				slog.Warn("indexer search failed", "indexer", idx.Name, "error", err)

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -6,10 +6,23 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/vavallee/bindery/internal/indexer/newznab"
 	"github.com/vavallee/bindery/internal/models"
 )
+
+// newTestSearcher returns a Searcher whose client factory bypasses the
+// SSRF-hardened DialContext so tests can target httptest servers on loopback.
+func newTestSearcher() *Searcher {
+	return &Searcher{
+		newClient: func(baseURL, apiKey string) *newznab.Client {
+			c := newznab.New(baseURL, apiKey)
+			c.SetHTTPClient(&http.Client{Timeout: 30 * time.Second})
+			return c
+		},
+	}
+}
 
 func resultTitles(rs []newznab.SearchResult) []string {
 	out := make([]string, len(rs))
@@ -996,7 +1009,7 @@ func TestSearchBookWithDebug_PerResultLogging(t *testing.T) {
 	t.Cleanup(func() { slog.SetDefault(orig) })
 
 	idxs := []models.Indexer{{ID: 1, Name: "test", URL: srv.URL, Enabled: true, Categories: []int{7020}}}
-	results, dbg := NewSearcher().SearchBookWithDebug(context.Background(), idxs, MatchCriteria{
+	results, dbg := newTestSearcher().SearchBookWithDebug(context.Background(), idxs, MatchCriteria{
 		Title:  "Life Ascending",
 		Author: "Nick Lane",
 	})


### PR DESCRIPTION
## Summary

- Adds `httpsec.NewDialContext(policy)` — a `DialContext` func that wraps `net.Dialer` and re-validates every resolved `net.IP` against the httpsec policy before invoking `connect(2)`. Also exports `httpsec.ValidateIP` for callers that already hold a `net.IP`.
- Wires the hardened transport into `newznab.New` via `newHTTPClient()` using `PolicyLAN` (RFC1918 allowed; loopback, link-local, and cloud-metadata always blocked).
- Adds an injectable `newClient` factory to `Searcher` (used by `SearchBook`, `SearchQuery`, and `SearchBookWithDebug`) so existing tests that target httptest servers on loopback continue to work without disabling the security dialer globally.
- Adds `newznab.Client.SetHTTPClient` to allow tests in external packages to substitute the transport.

**Why per-connection re-validation matters:** `ValidateOutboundURL` runs once at indexer create/update time. An attacker who controls the indexer's DNS zone can serve a public IP during validation, wait for the TTL to expire, then flip the record to `169.254.169.254` (cloud metadata) or an RFC1918 service. `NewDialContext` runs the same IP-level checks on every new TCP connection, catching post-TTL rebinds before the kernel touches the wire.

## Test plan

- [ ] `go test ./internal/httpsec/...` — new tests: `TestValidateIP`, `TestNewDialContext_BlocksLoopback`, `TestNewDialContext_AllowsPublicHosts`, `TestNewDialContext_BlocksRFC1918UnderStrict`
- [ ] `go test ./internal/indexer/...` — new test `TestNew_HardenedDialerBlocksLoopback` confirms `New()` rejects loopback at dial time; all pre-existing tests pass via `testNew`/`newTestSearcher` helpers that substitute the plain transport
- [ ] `go test ./internal/downloader/...` — all pass; no changes to downloader package behavior
- [ ] `go build ./...` — clean

**Downloader follow-up:** `qbittorrent.fetchTorrentContent` and `nzbget.fetchNZBContent` each guard outbound fetches with `ValidateOutboundURL` at request time, which is stronger than config-time-only. Adding per-dial hardening there is lower priority but worth a follow-up.

Refs #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)