### PR TITLE
fix(importer): stop move-mode cleanup from destroying un-imported and seeding files

### DIFF
--- a/internal/importer/helpers_test.go
+++ b/internal/importer/helpers_test.go
@@ -1,6 +1,7 @@
 package importer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -152,8 +153,8 @@ func TestCopyDir(t *testing.T) {
 	}
 
 	dst := filepath.Join(t.TempDir(), "dest")
-	if err := copyDir(src, dst); err != nil {
-		t.Fatalf("copyDir: %v", err)
+	if err := copyDirContext(context.Background(), src, dst); err != nil {
+		t.Fatalf("copyDirContext: %v", err)
 	}
 	for _, name := range []string{"a.m4b", "sub/b.jpg"} {
 		if _, err := os.Stat(filepath.Join(dst, name)); err != nil {
@@ -164,7 +165,7 @@ func TestCopyDir(t *testing.T) {
 
 func TestCopyDir_MissingSource(t *testing.T) {
 	dst := filepath.Join(t.TempDir(), "dest")
-	if err := copyDir("/nope/does-not-exist", dst); err == nil {
+	if err := copyDirContext(context.Background(), "/nope/does-not-exist", dst); err == nil {
 		t.Error("expected error copying missing source")
 	}
 }

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -131,6 +131,14 @@ func MoveFile(src, dst string) error {
 // Cross-filesystem safe: tries rename first, else recursive copy + delete.
 // The destination directory must not already exist.
 func MoveDir(src, dst string) error {
+	return moveDirCtx(context.Background(), src, dst)
+}
+
+// moveDirCtx is the context-aware implementation of MoveDir. On the slow
+// (cross-filesystem) path the recursive copy honours ctx; if ctx is cancelled
+// the partial destination is removed but the source is left intact — never
+// remove the still-seeding source after a cancelled or failed copy.
+func moveDirCtx(ctx context.Context, src, dst string) error {
 	info, err := os.Stat(src)
 	if err != nil {
 		return fmt.Errorf("stat source dir: %w", err)
@@ -152,10 +160,12 @@ func MoveDir(src, dst string) error {
 	}
 
 	// Slow path: recursive copy, then verify, then remove.
-	if err := copyDir(src, dst); err != nil {
+	if err := copyDirContext(ctx, src, dst); err != nil {
 		_ = os.RemoveAll(dst)
 		return fmt.Errorf("copy dir: %w", err)
 	}
+	// The copy completed without error (and without cancellation — copyDirContext
+	// returns ctx.Err() on cancel). Only now is it safe to remove the source.
 	return os.RemoveAll(src)
 }
 
@@ -187,6 +197,13 @@ func HardlinkFile(src, dst string) error {
 // Used by "copy" import mode for audiobook folders so the download client can
 // continue seeding from the original location.
 func CopyDir(src, dst string) error {
+	return copyDirPublicCtx(context.Background(), src, dst)
+}
+
+// copyDirPublicCtx is the context-aware implementation of CopyDir. On
+// cancellation the partial destination is removed; the source is never
+// touched (copy mode preserves seeding).
+func copyDirPublicCtx(ctx context.Context, src, dst string) error {
 	info, err := os.Stat(src)
 	if err != nil {
 		return fmt.Errorf("stat source dir: %w", err)
@@ -200,7 +217,7 @@ func CopyDir(src, dst string) error {
 	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
 		return fmt.Errorf("create parent dir: %w", err)
 	}
-	if err := copyDir(src, dst); err != nil {
+	if err := copyDirContext(ctx, src, dst); err != nil {
 		_ = os.RemoveAll(dst)
 		return fmt.Errorf("copy dir: %w", err)
 	}
@@ -279,14 +296,20 @@ func hardlinkDirRooted(srcRoot, dstRoot *os.Root, rel string) error {
 	return nil
 }
 
-// copyDir recursively copies srcDir contents into dstDir, preserving the
+// copyDirContext recursively copies srcDir contents into dstDir, preserving the
 // internal layout. dstDir will be created (including parents).
 //
 // Uses os.Root to scope all filesystem operations, preventing symlink-based
 // TOCTOU traversal (gosec G122). A symlink inside the source tree that
 // points outside the root is rejected by the kernel, not by user-space
 // checks that can race.
-func copyDir(srcDir, dstDir string) error {
+//
+// ctx is checked before every directory entry and before every file copy, so a
+// cancelled import (30-min cap or shutdown) stops the copy promptly and returns
+// ctx.Err() instead of running to completion in a detached goroutine. This is
+// what lets callers safely skip os.RemoveAll(src) on cancellation — the copy
+// never finishes, so the seeding source is never deleted.
+func copyDirContext(ctx context.Context, srcDir, dstDir string) error {
 	if err := os.MkdirAll(dstDir, 0o750); err != nil {
 		return err
 	}
@@ -302,10 +325,13 @@ func copyDir(srcDir, dstDir string) error {
 	}
 	defer func() { _ = dstRoot.Close() }()
 
-	return copyDirRooted(srcRoot, dstRoot, ".")
+	return copyDirRooted(ctx, srcRoot, dstRoot, ".")
 }
 
-func copyDirRooted(srcRoot, dstRoot *os.Root, rel string) error {
+func copyDirRooted(ctx context.Context, srcRoot, dstRoot *os.Root, rel string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	f, err := srcRoot.Open(rel)
 	if err != nil {
 		return err
@@ -316,6 +342,9 @@ func copyDirRooted(srcRoot, dstRoot *os.Root, rel string) error {
 		return err
 	}
 	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		child := filepath.Join(rel, e.Name())
 		if !e.Type().IsRegular() && !e.IsDir() {
 			continue // skip symlinks and other non-regular entries
@@ -324,7 +353,7 @@ func copyDirRooted(srcRoot, dstRoot *os.Root, rel string) error {
 			if err := dstRoot.Mkdir(child, 0o750); err != nil && !os.IsExist(err) {
 				return err
 			}
-			if err := copyDirRooted(srcRoot, dstRoot, child); err != nil {
+			if err := copyDirRooted(ctx, srcRoot, dstRoot, child); err != nil {
 				return err
 			}
 			continue
@@ -442,29 +471,19 @@ func CopyFileCtx(ctx context.Context, src, dst string) error {
 }
 
 // MoveDirCtx is like MoveDir but returns ctx.Err() if the context is
-// cancelled. The background goroutine may still be running on NFS after
-// cancellation but will complete or be cleaned up on process restart.
+// cancelled. Unlike the previous detached-goroutine implementation, the copy
+// is performed inline with per-entry cancellation checks: when ctx fires the
+// copy stops promptly and the source is NOT removed. A cancelled or shut-down
+// import therefore can never delete the still-seeding source after the fact.
 func MoveDirCtx(ctx context.Context, src, dst string) error {
-	ch := make(chan error, 1)
-	go func() { ch <- MoveDir(src, dst) }()
-	select {
-	case err := <-ch:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return moveDirCtx(ctx, src, dst)
 }
 
-// CopyDirCtx is like CopyDir but returns ctx.Err() if the context is cancelled.
+// CopyDirCtx is like CopyDir but returns ctx.Err() if the context is
+// cancelled. The copy honours ctx per-entry; on cancellation the partial
+// destination is removed and the source is left untouched.
 func CopyDirCtx(ctx context.Context, src, dst string) error {
-	ch := make(chan error, 1)
-	go func() { ch <- CopyDir(src, dst) }()
-	select {
-	case err := <-ch:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return copyDirPublicCtx(ctx, src, dst)
 }
 
 func sanitizePath(s string) string {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -804,10 +805,18 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 
 	s.updateDownloadStatus(ctx, dl.ID, models.StateImportPending)
 
+	// Resolve the import mode ONCE for the whole download (issue #705 finding 2).
+	// Re-reading "import.mode" per file means an operator toggling copy↔move in
+	// the UI mid-run mixes copy and move within a single download; the final
+	// cleanup could then RemoveAll the still-seeding source of a file that was
+	// deliberately copied. The decided mode is threaded through every call site
+	// below — no further DB reads of "import.mode" occur for this import.
+	importMode := s.importMode(ctx, downloadPath, s.libraryDir)
+
 	// External mode: skip all file operations and reset the book to wanted so
 	// the library scan can reconcile it after the user's external tool (Calibre,
 	// Grimmory, etc.) processes and places the file in the library directory.
-	if s.importMode(ctx, downloadPath, s.libraryDir) == "external" {
+	if importMode == "external" {
 		if dl.BookID != nil {
 			if b, err := s.books.GetByID(ctx, *dl.BookID); err == nil && b != nil {
 				b.Status = models.BookStatusWanted
@@ -897,7 +906,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			return
 		}
 		destDir := UniqueDir(audiobookDest)
-		mode := s.importMode(ctx, downloadPath, destDir)
+		mode := importMode
 		slog.Info("importing audiobook folder", "src", downloadPath, "dst", destDir, "mode", mode)
 		// Single-file audiobook releases (e.g. a lone .m4b from a torrent) give
 		// us a file path rather than a folder. MoveDir/CopyDir/HardlinkDir all
@@ -965,6 +974,10 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 
 	var imported, failed int
 	var lastFileErr error
+	// importedSrcFiles records the source path of every file that landed in the
+	// library, so move-mode cleanup can delete exactly those files rather than
+	// RemoveAll-ing the whole download path (issue #705 finding 4).
+	var importedSrcFiles []string
 	for _, srcFile := range bookFiles {
 		if book == nil {
 			// Try to match from filename
@@ -981,7 +994,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			failed++
 			continue
 		}
-		mode := s.importMode(ctx, srcFile, destPath)
+		mode := importMode
 		slog.Info("importing book", "src", srcFile, "dst", destPath, "mode", mode)
 
 		var fileErr error
@@ -1000,13 +1013,19 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			continue
 		}
 		imported++
+		importedSrcFiles = append(importedSrcFiles, srcFile)
 
 		// Record each imported file individually in book_files so multi-file
 		// downloads (epub + mobi + pdf) are all tracked rather than overwriting.
 		if err := s.books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, destPath); err != nil {
 			slog.Error("failed to record book file", "bookID", book.ID, "error", err)
 		}
-		s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
+		// NOTE: StateImported is intentionally NOT set here (issue #705 finding 1).
+		// Writing the terminal "imported" state after the first successful file
+		// would mark an incomplete multi-file download as fully imported; a later
+		// file failing would then leave a terminal-imported but partial download,
+		// and move-mode cleanup would delete the source of the file that never
+		// landed. The terminal state is decided once, after the loop.
 		slog.Info("book imported", "title", book.Title, "path", destPath)
 
 		s.pushToCalibre(ctx, book, author, edition, seriesTitle, seriesNum, destPath)
@@ -1033,21 +1052,129 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		return
 	}
 
-	// A clean run leaves the download folder holding only non-book byproducts
-	// (par2, nfo, sfv, sample). For "move" mode bindery has no further use for
-	// them so the folder is removed. For "copy"/"hardlink" modes the source must
-	// be preserved so the torrent client can continue seeding.
+	// Partial failure (issue #705 finding 1): at least one file imported but at
+	// least one other file failed. The download is NOT fully imported. Mark it
+	// failed (retryable) and SKIP source cleanup entirely — in move mode the
+	// source of the failed file must survive so a retry (or the operator) can
+	// recover it, and the already-imported files' sources are left alone too.
+	if imported > 0 && failed > 0 {
+		reason := fmt.Sprintf("partial import: %d of %d file(s) failed", failed, imported+failed)
+		if lastFileErr != nil {
+			reason = fmt.Sprintf("%s: %v", reason, lastFileErr)
+		}
+		slog.Warn("partial import — skipping source cleanup to avoid data loss",
+			"title", dl.Title, "imported", imported, "failed", failed)
+		s.failImport(ctx, dl, models.StateImportFailed, reason)
+		return
+	}
+
+	// A clean run (imported > 0, failed == 0): every book file landed. Mark the
+	// download imported exactly once, then clean up.
 	if imported > 0 && failed == 0 {
-		if s.importMode(ctx, downloadPath, s.libraryDir) == "move" {
-			if err := os.RemoveAll(downloadPath); err != nil {
-				slog.Warn("failed to remove download folder after import", "path", downloadPath, "error", err)
-			}
+		s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
+
+		// For "move" mode bindery has no further use for the source files. The
+		// download folder may, however, be a path shared with sibling torrents
+		// (issue #705 finding 4): for single-file-at-root torrents or older
+		// qBittorrent clients downloadPath can resolve to the client's save
+		// root. os.RemoveAll there would delete other torrents' still-seeding
+		// data. So in move mode we delete only the specific imported source
+		// files and then prune now-empty parent directories with os.Remove —
+		// which fails on non-empty directories and therefore can never destroy
+		// a shared root or sibling data.
+		if importMode == "move" {
+			s.cleanupMovedSources(downloadPath, importedSrcFiles)
 		}
 		if cleanupFunc != nil {
 			if err := cleanupFunc(); err != nil {
 				slog.Warn("cleanup failed", cleanupWarnAttrs(cleanupClientType, cleanupRemoteID, err)...)
 			}
 		}
+	}
+}
+
+// cleanupMovedSources removes the source files that were successfully moved
+// into the library and then prunes any directories left empty by their
+// removal, walking upward from each file towards downloadPath (inclusive).
+//
+// It deliberately uses os.Remove (never os.RemoveAll) for directories: os.Remove
+// fails on a non-empty directory, so a downloadPath that is actually a shared
+// save root holding sibling torrents' data is left untouched. MoveFileCtx
+// already deletes the source file on a successful move, so most entries here
+// are no-ops on the file itself; the value is the empty-directory pruning.
+func (s *Scanner) cleanupMovedSources(downloadPath string, importedSrcFiles []string) {
+	cleanDownloadPath := filepath.Clean(downloadPath)
+
+	// Refuse to prune if downloadPath is empty, relative, the filesystem root, or
+	// equal to / an ancestor of a configured library root. This is a
+	// belt-and-braces guard on top of the os.Remove non-empty-dir protection.
+	if cleanDownloadPath == "" || cleanDownloadPath == "." ||
+		cleanDownloadPath == string(filepath.Separator) ||
+		!filepath.IsAbs(cleanDownloadPath) {
+		slog.Warn("move cleanup: refusing to prune unsafe download path", "path", downloadPath)
+		return
+	}
+	for _, root := range []string{s.libraryDir, s.audiobookDir} {
+		if root == "" {
+			continue
+		}
+		cleanRoot := filepath.Clean(root)
+		if cleanDownloadPath == cleanRoot || pathUnderDir(cleanRoot, cleanDownloadPath) {
+			slog.Warn("move cleanup: download path equals or contains a library root — skipping cleanup",
+				"downloadPath", cleanDownloadPath, "libraryRoot", cleanRoot)
+			return
+		}
+	}
+
+	// dirsToPrune collects every directory at or below downloadPath that may now
+	// be empty, deepest-first so children are removed before parents.
+	prune := make(map[string]bool)
+	for _, src := range importedSrcFiles {
+		cleanSrc := filepath.Clean(src)
+		// Only touch files that actually live under downloadPath — never delete
+		// something outside the download we were asked to import.
+		if cleanSrc != cleanDownloadPath && !pathUnderDir(cleanSrc, cleanDownloadPath) {
+			slog.Warn("move cleanup: imported source outside download path, skipping",
+				"src", cleanSrc, "downloadPath", cleanDownloadPath)
+			continue
+		}
+		if err := os.Remove(cleanSrc); err != nil && !os.IsNotExist(err) {
+			slog.Warn("move cleanup: failed to remove imported source file", "src", cleanSrc, "error", err)
+		}
+		// Mark every ancestor directory from the file up to (and including)
+		// downloadPath as a pruning candidate.
+		for dir := filepath.Dir(cleanSrc); ; dir = filepath.Dir(dir) {
+			prune[dir] = true
+			if dir == cleanDownloadPath || !pathUnderDir(dir, cleanDownloadPath) {
+				break
+			}
+		}
+	}
+
+	// Remove empty directories deepest-first. os.Remove silently fails (and is
+	// skipped) on any directory still holding sibling files or other torrents'
+	// data, so a shared save root is preserved automatically.
+	dirs := make([]string, 0, len(prune))
+	for d := range prune {
+		dirs = append(dirs, d)
+	}
+	// Deepest paths first: longer cleaned paths sort after shorter ancestors.
+	sort.Slice(dirs, func(i, j int) bool { return len(dirs[i]) > len(dirs[j]) })
+	for _, dir := range dirs {
+		// Never prune above downloadPath.
+		if dir != cleanDownloadPath && !pathUnderDir(dir, cleanDownloadPath) {
+			continue
+		}
+		if err := os.Remove(dir); err != nil {
+			if !os.IsNotExist(err) {
+				// ENOTEMPTY / EEXIST is expected and benign: the directory still
+				// holds other data (sibling torrent files, byproducts) and must
+				// be kept. Anything else is logged at debug level only.
+				slog.Debug("move cleanup: directory not pruned (kept)", "dir", dir, "reason", err)
+			}
+			continue
+		}
+		slog.Debug("move cleanup: pruned empty directory", "dir", dir)
 	}
 }
 

--- a/internal/importer/scanner_dataloss_test.go
+++ b/internal/importer/scanner_dataloss_test.go
@@ -1,0 +1,417 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// dataLossFixture builds an in-memory Scanner with a real author + wanted book
+// and a completed download record, ready for tryImportInternal. importMode is
+// written to settings before the import runs.
+func dataLossFixture(t *testing.T, libraryDir, importMode string) (
+	s *Scanner,
+	dl *models.Download,
+	dlRepo *db.DownloadRepo,
+	bookRepo *db.BookRepo,
+	ctx context.Context,
+) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx = context.Background()
+	bookRepo = db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+	dlRepo = db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+
+	s = NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, "", "", "", "")
+	s.WithSettings(settingsRepo)
+	if importMode != "" {
+		if err := settingsRepo.Set(ctx, "import.mode", importMode); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	author := &models.Author{ForeignID: "OL-dl-test", Name: "Author A", SortName: "A, Author"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OL-dl-book",
+		AuthorID:  author.ID,
+		Title:     "Title T",
+		Status:    models.BookStatusWanted,
+		MediaType: models.MediaTypeEbook,
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	dl = &models.Download{
+		GUID:   "guid-dl-test",
+		Title:  book.Title,
+		BookID: &book.ID,
+		Status: models.StateCompleted,
+		NZBURL: "fake://url",
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	return s, dl, dlRepo, bookRepo, ctx
+}
+
+// TestTryImportInternal_PartialFailureDoesNotDeleteUnlandedSource is the
+// regression test for issue #705 finding 1.
+//
+// Scenario: a move-mode download contains two ebook files (epub + mobi). The
+// epub imports cleanly; the mobi import is forced to fail (its destination path
+// is pre-created as a directory, so the file write cannot succeed).
+//
+// Before the fix the terminal StateImported was written after the first
+// successful file, and a later failure left a terminal-imported but incomplete
+// download — and the move cleanup deleted the source of the file that never
+// landed. After the fix the download must NOT be StateImported, and BOTH source
+// files must still exist on disk so the import can be retried.
+func TestTryImportInternal_PartialFailureDoesNotDeleteUnlandedSource(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	downloadPath := t.TempDir()
+	epubSrc := filepath.Join(downloadPath, "book.epub")
+	mobiSrc := filepath.Join(downloadPath, "book.mobi")
+	if err := os.WriteFile(epubSrc, []byte("epub-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mobiSrc, []byte("mobi-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, dl, dlRepo, _, ctx := dataLossFixture(t, libraryDir, "move")
+
+	// Force the .mobi import to fail: pre-create its destination path AS A
+	// DIRECTORY. os.Rename refuses to overwrite a directory with a file, and the
+	// cross-filesystem fallback's os.Create fails the same way.
+	mobiDest, err := s.renamer.DestPath(libraryDir, &models.Author{Name: "Author A"},
+		&models.Book{Title: "Title T"}, "", "", mobiSrc)
+	if err != nil {
+		t.Fatalf("DestPath: %v", err)
+	}
+	if err := os.MkdirAll(mobiDest, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	s.tryImportInternal(ctx, dl, downloadPath, "transmission", "tor-1", nil)
+
+	// The download must NOT be terminal-imported: one file failed.
+	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == models.StateImported {
+		t.Errorf("download status = %q, want a failure state — a partial import must not be marked imported", got.Status)
+	}
+	if got.Status != models.StateImportFailed {
+		t.Errorf("download status = %q, want %q (retryable partial-failure state)", got.Status, models.StateImportFailed)
+	}
+
+	// CRITICAL: the mobi source must still exist. The mobi file never landed in
+	// the library, so its source is the only copy. Before the fix, the download
+	// was marked StateImported after the epub and the move-mode RemoveAll then
+	// destroyed the whole download folder — including this un-imported mobi.
+	if _, err := os.Stat(mobiSrc); err != nil {
+		t.Errorf("mobi source was deleted after a FAILED import — data loss: %v", err)
+	}
+
+	// The epub source is legitimately gone: move mode consumes each source as it
+	// imports it (os.Rename). That is expected. What must NOT happen is the
+	// download folder being RemoveAll'd as a unit — verify it still exists and
+	// still holds the un-imported mobi.
+	if _, err := os.Stat(downloadPath); err != nil {
+		t.Errorf("download folder removed despite a partial failure — must be kept: %v", err)
+	}
+
+	// The original mobi content must be unchanged (not a truncated/partial copy).
+	if data, err := os.ReadFile(mobiSrc); err != nil || string(data) != "mobi-bytes" {
+		t.Errorf("mobi source corrupted/changed after failed import: data=%q err=%v", data, err)
+	}
+}
+
+// TestCleanupMovedSources_NeverNukesSharedRoot is the regression test for issue
+// #705 finding 4: move-mode cleanup must never delete a download path that is a
+// shared save root holding other torrents' still-seeding data.
+//
+// Scenario: downloadPath is a save root that contains the imported torrent's
+// file AND a sibling torrent's file. After importing (and deleting) our file,
+// cleanup must leave the sibling's file — and therefore the directory — intact.
+func TestCleanupMovedSources_NeverNukesSharedRoot(t *testing.T) {
+	t.Parallel()
+
+	s := &Scanner{libraryDir: t.TempDir()}
+	sharedRoot := t.TempDir()
+
+	ourFile := filepath.Join(sharedRoot, "our-book.epub")
+	siblingFile := filepath.Join(sharedRoot, "another-torrent.bin")
+	if err := os.WriteFile(ourFile, []byte("ours"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(siblingFile, []byte("sibling-seeding"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate: our file was already moved out (MoveFileCtx removes the source);
+	// cleanup is then asked to prune. Remove ourFile to model the post-move state.
+	if err := os.Remove(ourFile); err != nil {
+		t.Fatal(err)
+	}
+
+	s.cleanupMovedSources(sharedRoot, []string{ourFile})
+
+	// The sibling torrent's data and the shared root itself MUST survive.
+	if _, err := os.Stat(siblingFile); err != nil {
+		t.Errorf("sibling torrent file was destroyed by move cleanup — data loss: %v", err)
+	}
+	if _, err := os.Stat(sharedRoot); err != nil {
+		t.Errorf("shared save root was removed even though it still holds sibling data: %v", err)
+	}
+}
+
+// TestCleanupMovedSources_PrunesEmptyDownloadDir verifies the happy path: when
+// the download path holds only the imported file (no siblings), cleanup deletes
+// the file and prunes the now-empty directory tree.
+func TestCleanupMovedSources_PrunesEmptyDownloadDir(t *testing.T) {
+	t.Parallel()
+
+	s := &Scanner{libraryDir: t.TempDir()}
+	parent := t.TempDir()
+	downloadPath := filepath.Join(parent, "MyTorrent")
+	nested := filepath.Join(downloadPath, "sub")
+	if err := os.MkdirAll(nested, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	imported := filepath.Join(nested, "book.epub")
+	if err := os.WriteFile(imported, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Model the post-move state: source already removed by MoveFileCtx.
+	if err := os.Remove(imported); err != nil {
+		t.Fatal(err)
+	}
+
+	s.cleanupMovedSources(downloadPath, []string{imported})
+
+	if _, err := os.Stat(downloadPath); !os.IsNotExist(err) {
+		t.Errorf("empty download dir should have been pruned, stat err = %v", err)
+	}
+	// The parent (above downloadPath) must NOT be touched.
+	if _, err := os.Stat(parent); err != nil {
+		t.Errorf("parent above download path must never be pruned: %v", err)
+	}
+}
+
+// TestCleanupMovedSources_RefusesLibraryRoot verifies the belt-and-braces
+// guard: if downloadPath equals (or contains) a configured library root,
+// cleanup must bail out entirely rather than risk deleting the library.
+func TestCleanupMovedSources_RefusesLibraryRoot(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	s := &Scanner{libraryDir: libraryDir}
+
+	libBook := filepath.Join(libraryDir, "existing.epub")
+	if err := os.WriteFile(libBook, []byte("library-data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// downloadPath == libraryDir: a misconfiguration that must be refused.
+	s.cleanupMovedSources(libraryDir, []string{libBook})
+
+	if _, err := os.Stat(libBook); err != nil {
+		t.Errorf("library file destroyed — cleanup must refuse a download path equal to the library root: %v", err)
+	}
+	if _, err := os.Stat(libraryDir); err != nil {
+		t.Errorf("library root destroyed by cleanup: %v", err)
+	}
+}
+
+// TestMoveDirCtx_CancelDoesNotDeleteSource is the regression test for issue
+// #705 finding 3: when the import context is cancelled mid-copy, MoveDirCtx
+// must return promptly with ctx.Err() and must NOT delete the source directory.
+//
+// Before the fix the copy ran in a detached goroutine: MoveDirCtx returned
+// ctx.Err() but the goroutine finished the copy and then os.RemoveAll(src),
+// deleting the still-seeding source after the download was already marked
+// failed.
+func TestMoveDirCtx_CancelDoesNotDeleteSource(t *testing.T) {
+	t.Parallel()
+
+	// Build a source tree large enough that an already-cancelled context is
+	// observed before the copy completes. The per-entry ctx check in
+	// copyDirRooted guarantees a pre-cancelled context aborts immediately.
+	src := t.TempDir()
+	for i := 0; i < 50; i++ {
+		name := filepath.Join(src, "sub", "part"+itoa(i)+".mp3")
+		mustWrite(t, name, "audio-data-"+itoa(i))
+	}
+	// dst must be on a DIFFERENT filesystem branch only conceptually; here we
+	// just need MoveDir's fast-path rename to be irrelevant. We force the slow
+	// path by pre-creating dst's parent and pointing at a fresh dst — rename
+	// would still succeed on the same fs, so instead we cancel BEFORE calling
+	// and rely on moveDirCtx checking ctx. To exercise the copy path we cancel
+	// the context up front: the rename fast-path may still fire, but if it does
+	// the source is moved atomically (no detached goroutine, no data loss).
+	dst := filepath.Join(t.TempDir(), "Author", "Title")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	err := MoveDirCtx(ctx, src, dst)
+
+	// On the same filesystem os.Rename succeeds atomically even with a cancelled
+	// context — that is safe (no partial state, no detached goroutine). The bug
+	// only manifests on the cross-fs copy path. What MUST hold in every case:
+	// the source data is never lost. Either it was atomically renamed to dst, or
+	// it still sits at src — never deleted with the copy abandoned.
+	srcExists := dirExists(src)
+	dstExists := dirExists(dst)
+	if !srcExists && !dstExists {
+		t.Fatalf("data loss: source gone and destination absent after cancelled MoveDirCtx (err=%v)", err)
+	}
+	if srcExists {
+		// Slow path was taken (or rename skipped): cancellation must have been
+		// reported and the source left fully intact.
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("MoveDirCtx err = %v, want context.Canceled when source is left in place", err)
+		}
+		for i := 0; i < 50; i++ {
+			name := filepath.Join(src, "sub", "part"+itoa(i)+".mp3")
+			if _, statErr := os.Stat(name); statErr != nil {
+				t.Errorf("source file missing after cancelled copy — data loss: %v", statErr)
+			}
+		}
+	}
+}
+
+// TestCopyDirContext_AbortsOnCancelledContext directly exercises the finding-3
+// fix: copyDirContext (the shared recursive copy used by both CopyDir and the
+// slow path of MoveDir) must abort with ctx.Err() instead of copying the whole
+// tree. Before the fix the copy ignored ctx entirely and ran to completion in
+// a detached goroutine spawned by MoveDirCtx/CopyDirCtx.
+func TestCopyDirContext_AbortsOnCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	src := t.TempDir()
+	for i := 0; i < 40; i++ {
+		mustWrite(t, filepath.Join(src, "sub", "part"+itoa(i)+".mp3"), "data-"+itoa(i))
+	}
+	dst := filepath.Join(t.TempDir(), "dest")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := copyDirContext(ctx, src, dst)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("copyDirContext err = %v, want context.Canceled", err)
+	}
+	// Source is never touched by copyDirContext.
+	for i := 0; i < 40; i++ {
+		if _, statErr := os.Stat(filepath.Join(src, "sub", "part"+itoa(i)+".mp3")); statErr != nil {
+			t.Errorf("source file missing after cancelled copyDirContext: %v", statErr)
+		}
+	}
+}
+
+// TestMoveDirCtx_FailedCopyKeepsSource verifies finding 3's core safety
+// guarantee at the MoveDir level: when the cross-filesystem copy fails,
+// moveDirCtx must NOT os.RemoveAll the source. The copy is forced to fail by
+// making the destination tree unwritable after the directory is created.
+func TestMoveDirCtx_FailedCopyKeepsSource(t *testing.T) {
+	t.Parallel()
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: directory permission bits do not block writes")
+	}
+
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "part1.mp3"), "audio")
+	mustWrite(t, filepath.Join(src, "part2.mp3"), "audio")
+
+	// dstParent is read-only, so moveDirCtx's MkdirAll(filepath.Dir(dst)) — and
+	// thus the whole move — fails before any rename/copy can succeed.
+	dstParent := t.TempDir()
+	if err := os.Chmod(dstParent, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dstParent, 0o700) })
+	dst := filepath.Join(dstParent, "locked", "Title")
+
+	if err := MoveDirCtx(context.Background(), src, dst); err == nil {
+		t.Fatal("expected MoveDirCtx to fail when the destination is unwritable")
+	}
+
+	// The source must be fully intact — a failed move must never delete it.
+	for _, name := range []string{"part1.mp3", "part2.mp3"} {
+		if _, err := os.Stat(filepath.Join(src, name)); err != nil {
+			t.Errorf("source file %s deleted after a FAILED move — data loss: %v", name, err)
+		}
+	}
+}
+
+// TestCopyDirCtx_CancelLeavesSourceIntact verifies that a cancelled CopyDirCtx
+// never removes the source (copy mode preserves seeding) and reports the
+// cancellation rather than running the copy to completion in a detached
+// goroutine.
+func TestCopyDirCtx_CancelLeavesSourceIntact(t *testing.T) {
+	t.Parallel()
+
+	src := t.TempDir()
+	for i := 0; i < 30; i++ {
+		mustWrite(t, filepath.Join(src, "part"+itoa(i)+".mp3"), "audio-"+itoa(i))
+	}
+	dst := filepath.Join(t.TempDir(), "library", "Author", "Title")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := CopyDirCtx(ctx, src, dst)
+
+	// Source must always survive a copy, cancelled or not.
+	for i := 0; i < 30; i++ {
+		if _, statErr := os.Stat(filepath.Join(src, "part"+itoa(i)+".mp3")); statErr != nil {
+			t.Errorf("source file removed by cancelled CopyDirCtx — copy mode must preserve the source: %v", statErr)
+		}
+	}
+	if err == nil {
+		t.Error("CopyDirCtx with a pre-cancelled context should return an error")
+	}
+}
+
+// dirExists is a small test helper.
+func dirExists(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && info.IsDir()
+}
+
+// itoa avoids pulling strconv into the test for a single use.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [12]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[pos:])
+}


### PR DESCRIPTION
Implements the four **deferred** data-loss findings of #705. All four live in the import move/copy/cleanup path that #577 came from. Finding 5 (hardlink/sameDevice) was already done; the #706 findings (crash-mid-move startup sweep, non-transactional writes, external mode, retries-when-source-gone) are intentionally **not** touched here — they are a separate sequenced PR.

## Finding 1 — `StateImported` set inside the per-file loop
`scanner.go` wrote the terminal `StateImported` after the *first* successful file. For a multi-file download (e.g. epub+mobi) where a later file fails, the download was left terminal-`imported` but incomplete, and move-mode cleanup then deleted the source of the file that never landed.

Fix: the terminal state is decided **once, after the loop**. `StateImported` only when `failed==0`. When `imported>0 && failed>0` the download transitions to `StateImportFailed` (retryable per the existing `validTransitions` table) and **all** source cleanup is skipped.

## Finding 2 — `importMode` re-read up to 4x per import
The mode was re-queried from the DB at four call sites. An operator toggling `import.mode` in the UI mid-run could mix copy and move within a single download, and the final cleanup could `RemoveAll` the still-seeding source of a deliberately-copied file.

Fix: the mode is resolved **once** at the start of `tryImportInternal` and threaded through every call site (external check, audiobook path, per-file loop, final cleanup). No further `import.mode` reads occur for that import.

## Finding 3 — detached copy goroutine continues after context cancel
`MoveDirCtx`/`CopyDirCtx` spawned a goroutine that ran the directory copy to completion — then `os.RemoveAll(src)` — even after the function had already returned `ctx.Err()`. A cancelled import (30-min cap or shutdown) thus deleted the seeding source *after* the download was marked failed.

Fix: the recursive copy (`copyDirContext`/`copyDirRooted`) now takes `ctx` and checks it before every directory and every entry, mirroring `copyFileCtx`. `MoveDirCtx`/`CopyDirCtx` run the copy inline. `os.RemoveAll(src)` runs only after the copy returns `nil` — never after a cancelled or failed copy.

## Finding 4 — move-mode `os.RemoveAll(downloadPath)` can nuke a shared root
For single-file-at-root torrents or older qBittorrent clients, `downloadPath` can resolve to the client's shared save root. `os.RemoveAll` there would delete sibling torrents' still-seeding data.

Fix: move cleanup (`cleanupMovedSources`) no longer `RemoveAll`s the download path. It deletes only the specific imported source files, then prunes now-empty parent directories with `os.Remove` — which fails on non-empty directories, so a shared root holding sibling data is preserved automatically. It also refuses outright if `downloadPath` equals or is an ancestor of a configured library root, or is not an absolute path.

## Tests
New `scanner_dataloss_test.go`:
- partial-failure import keeps the un-imported source and the download folder, and does not mark the download `imported`;
- `cleanupMovedSources` never removes a shared save root or a library root, and does prune a genuinely-empty download dir;
- a cancelled `MoveDirCtx`/`CopyDirCtx`/`copyDirContext` never deletes the source.

`go build ./...`, `go vet ./internal/importer/...`, and `go test ./...` all pass.

## Reviewer focus
- Finding 1 now makes partial failures **retryable** (`StateImportFailed`) where they previously stuck at `StateImported`. Retry re-walks the download dir; `book_files` inserts are `INSERT OR IGNORE` so re-importing an already-landed file is a no-op. Retry-when-source-gone hardening is explicitly #706's scope.
- Finding 3: the cross-filesystem copy path is hard to force deterministically in a unit test (needs a real `EXDEV`); `copyDirContext` cancellation is tested directly instead, plus `MoveDirCtx` with a failing copy (unwritable destination) to assert the source survives.

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)