### PR TITLE
fix(importer): recover wedged imports and stop silent retry/re-download loops

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -395,6 +395,13 @@ func main() {
 	telemetryClient := telemetry.New(settingsRepo, version)
 	sched.WithTelemetry(telemetryClient)
 
+	// Recover downloads wedged mid-import by a prior crash or timeout before the
+	// scheduler starts polling. StateImporting / StateImportPending are
+	// non-terminal with no automatic re-entry; this sweeps them to
+	// StateImportFailed so the scanner's retry path picks them up
+	// (issue #706 finding 1).
+	importScanner.RecoverInterruptedImports(ctxBoot)
+
 	sched.Start()
 	defer sched.Stop()
 

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -375,7 +375,8 @@ func queueItemSizeLeft(item enrichedQueueItem) int64 {
 
 	switch item.Download.Status {
 	case models.StateCompleted, models.StateImportPending, models.StateImporting,
-		models.StateImported, models.StateFailed, models.StateImportFailed, models.StateImportBlocked:
+		models.StateImported, models.StateFailed, models.StateImportFailed,
+		models.StateImportBlocked, models.StateImportExternal:
 		return 0
 	default:
 		return item.Download.Size

--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -239,6 +239,61 @@ func (r *DownloadRepo) IncrementImportRetryCount(ctx context.Context, id int64) 
 	return err
 }
 
+// RecoverInterruptedImports moves every download stuck in a non-terminal,
+// non-resumable import state (StateImporting, StateImportPending) to
+// StateImportFailed so the scanner's retry path (which only fires from
+// StateImportFailed) can pick them up. It is called once on startup: a process
+// crash or timeout mid-import leaves the download in StateImporting/Pending
+// with no automatic re-entry, wedging it forever (issue #706 finding 1).
+//
+// StateImportExternal is intentionally NOT swept — it is a legitimate
+// long-lived parked state awaiting reconciliation by ScanLibrary, not a
+// crash artefact.
+//
+// It returns the IDs of the downloads it transitioned so the caller can log /
+// emit history events for them.
+func (r *DownloadRepo) RecoverInterruptedImports(ctx context.Context) ([]int64, error) {
+	rows, err := r.db.QueryContext(ctx,
+		"SELECT id FROM downloads WHERE status IN (?, ?)",
+		models.StateImporting, models.StateImportPending)
+	if err != nil {
+		return nil, fmt.Errorf("list interrupted imports: %w", err)
+	}
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan interrupted import id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("iterate interrupted imports: %w", err)
+	}
+	rows.Close()
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	// Both StateImporting and StateImportPending can legally transition to
+	// StateImportFailed (see validTransitions), so a single guarded UPDATE is
+	// safe. The error_message records why the state moved so the cause is
+	// visible in the Queue/History UI.
+	const msg = "import interrupted (process restart) — re-queued for retry"
+	recovered := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if _, err := r.db.ExecContext(ctx,
+			"UPDATE downloads SET status=?, error_message=? WHERE id=? AND status IN (?, ?)",
+			models.StateImportFailed, msg, id, models.StateImporting, models.StateImportPending); err != nil {
+			return recovered, fmt.Errorf("recover interrupted import %d: %w", id, err)
+		}
+		recovered = append(recovered, id)
+	}
+	return recovered, nil
+}
+
 func (r *DownloadRepo) Delete(ctx context.Context, id int64) error {
 	_, err := r.db.ExecContext(ctx, "DELETE FROM downloads WHERE id=?", id)
 	return err

--- a/internal/db/downloads_coverage_test.go
+++ b/internal/db/downloads_coverage_test.go
@@ -74,6 +74,77 @@ func TestDownloadRepo_GetByNzoIDNotFound(t *testing.T) {
 	}
 }
 
+// TestDownloadRepo_RecoverInterruptedImports verifies the startup sweep
+// (issue #706 finding 1): downloads wedged mid-import in StateImporting /
+// StateImportPending are moved to StateImportFailed so the retry path can pick
+// them up, while terminal and unrelated states are left untouched.
+func TestDownloadRepo_RecoverInterruptedImports(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewDownloadRepo(database)
+
+	mk := func(guid string, status models.DownloadState) *models.Download {
+		d := &models.Download{GUID: guid, Title: guid, NZBURL: "x", Status: status}
+		if err := repo.Create(ctx, d); err != nil {
+			t.Fatalf("create %s: %v", guid, err)
+		}
+		return d
+	}
+
+	importing := mk("wedged-importing", models.StateImporting)
+	pending := mk("wedged-pending", models.StateImportPending)
+	done := mk("terminal-imported", models.StateImported)
+	external := mk("external-handoff", models.StateImportExternal)
+	downloading := mk("still-downloading", models.StateDownloading)
+
+	recovered, err := repo.RecoverInterruptedImports(ctx)
+	if err != nil {
+		t.Fatalf("RecoverInterruptedImports: %v", err)
+	}
+	if len(recovered) != 2 {
+		t.Fatalf("recovered %d downloads, want 2 (importing + pending)", len(recovered))
+	}
+
+	check := func(id int64, want models.DownloadState) {
+		all, err := repo.List(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, d := range all {
+			if d.ID == id {
+				if d.Status != want {
+					t.Errorf("download %d status = %q, want %q", id, d.Status, want)
+				}
+				return
+			}
+		}
+		t.Errorf("download %d not found", id)
+	}
+
+	// The two wedged downloads must now be retryable.
+	check(importing.ID, models.StateImportFailed)
+	check(pending.ID, models.StateImportFailed)
+	// Terminal / parked / in-flight states must be untouched. In particular
+	// StateImportExternal is a legitimate long-lived parked state, NOT a crash
+	// artefact, and must survive the sweep.
+	check(done.ID, models.StateImported)
+	check(external.ID, models.StateImportExternal)
+	check(downloading.ID, models.StateDownloading)
+
+	// Idempotent: a second sweep with nothing wedged recovers nothing.
+	again, err := repo.RecoverInterruptedImports(ctx)
+	if err != nil {
+		t.Fatalf("second RecoverInterruptedImports: %v", err)
+	}
+	if len(again) != 0 {
+		t.Errorf("second sweep recovered %d downloads, want 0", len(again))
+	}
+}
+
 func TestAuthorRepo_GetByForeignIDNotFound(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -435,14 +435,55 @@ func (s *Scanner) CheckDownloads(ctx context.Context) {
 	}
 }
 
-func isTrackedTorrentDownloadForClient(dl models.Download, clientID int64) bool {
-	if dl.DownloadClientID == nil || *dl.DownloadClientID != clientID {
-		return false
+// RecoverInterruptedImports sweeps downloads stuck mid-import back into a
+// retryable state. It must be called once at startup, before the scheduler
+// begins polling.
+//
+// A process crash or the 30-minute per-import timeout can leave a download in
+// StateImporting (or the earlier StateImportPending) — both non-terminal states
+// with no automatic re-entry. CheckDownloads only retries from
+// StateImportFailed, so without this sweep such a download is wedged forever
+// (issue #706 finding 1). Moving it to StateImportFailed lets the existing
+// retry path (CheckDownloads, while the source is still in the client) pick it
+// up; if the source has since vanished, the same path now terminally blocks it
+// (finding 4) rather than leaving it silently stuck.
+func (s *Scanner) RecoverInterruptedImports(ctx context.Context) {
+	if s.downloads == nil {
+		return
 	}
-	if dl.TorrentID == nil {
-		return false
+	recovered, err := s.downloads.RecoverInterruptedImports(ctx)
+	if err != nil {
+		slog.Warn("failed to sweep interrupted imports on startup", "error", err)
+		// Fall through: some downloads may still have been recovered before the
+		// error; emit history for those.
 	}
-	return dl.Status != models.StateImported && dl.Status != models.StateFailed
+	for _, id := range recovered {
+		slog.Info("recovered interrupted import — re-queued for retry", "download_id", id)
+		dl, getErr := s.downloadByID(ctx, id)
+		if getErr != nil || dl == nil {
+			continue
+		}
+		s.createHistoryEvent(ctx, models.HistoryEventImportFailed, dl.Title, dl.BookID, map[string]string{
+			"guid":    dl.GUID,
+			"message": "import interrupted (process restart) — re-queued for retry",
+			"status":  string(models.StateImportFailed),
+		})
+	}
+}
+
+// downloadByID is a small helper used by recovery/diagnostic paths that only
+// have an ID. DownloadRepo has no GetByID, so look the row up via List.
+func (s *Scanner) downloadByID(ctx context.Context, id int64) (*models.Download, error) {
+	all, err := s.downloads.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range all {
+		if all[i].ID == id {
+			return &all[i], nil
+		}
+	}
+	return nil, nil
 }
 
 func (s *Scanner) setDownloadError(ctx context.Context, id int64, message string) {
@@ -495,6 +536,73 @@ func (s *Scanner) markDownloadFailed(ctx context.Context, dl *models.Download, m
 	s.createHistoryEvent(ctx, models.HistoryEventDownloadFailed, dl.Title, dl.BookID, map[string]string{"guid": dl.GUID, "message": message})
 }
 
+// blockStaleImportFailures terminally blocks downloads that are stuck in
+// StateImportFailed with no remaining automatic recovery path (issue #706
+// finding 4).
+//
+// CheckDownloads only retries a StateImportFailed download while its source
+// still appears in the client's torrent list / history. Two cases leave such a
+// download wedged below the retry limit forever, with no terminal state:
+//
+//   - the retry budget is exhausted (ImportRetryCount >= importRetryLimit);
+//   - the source has vanished from the client (the torrent was removed, or the
+//     usenet history entry was cleared), so no future poll will ever revisit it.
+//
+// For both, this transitions the download to terminal StateImportBlocked with
+// an actionable message so the operator sees it needs manual intervention
+// rather than a silent stuck queue entry.
+//
+// seenSourceIDs holds the IDs of every download whose source was observed in
+// this poll cycle — a StateImportFailed download NOT in that set has lost its
+// source. belongsToClient reports whether a download is owned by the polling
+// client (torrent vs. usenet ownership differs, so the caller supplies the
+// predicate).
+//
+// sourceListIsComplete must be true only when seenSourceIDs was built from a
+// complete enumeration of the client's sources. Torrent clients return every
+// torrent, so a missing entry definitively means the source is gone. Usenet
+// history APIs are paginated (SABnzbd is capped at 50 slots here), so a missing
+// entry there could merely be an aged-out-but-healthy download — for those
+// callers this is false and only the retry-exhaustion case blocks, never the
+// vanished-source case.
+//
+// The download list is re-fetched here rather than reusing the caller's
+// snapshot: a retry that ran earlier in the same poll cycle may have changed a
+// download's status / retry count, and acting on the stale snapshot could
+// misjudge the retry budget.
+func (s *Scanner) blockStaleImportFailures(
+	ctx context.Context,
+	seenSourceIDs map[int64]bool,
+	sourceListIsComplete bool,
+	belongsToClient func(models.Download) bool,
+) {
+	allDownloads, err := s.downloads.List(ctx)
+	if err != nil {
+		slog.Debug("blockStaleImportFailures: failed to list downloads", "error", err)
+		return
+	}
+	for i := range allDownloads {
+		dl := allDownloads[i]
+		if dl.Status != models.StateImportFailed {
+			continue
+		}
+		if !belongsToClient(dl) {
+			continue
+		}
+		var reason string
+		switch {
+		case dl.ImportRetryCount >= importRetryLimit:
+			reason = fmt.Sprintf("import retry limit reached (%d attempts) — fix the underlying problem, then retry manually", importRetryLimit)
+		case sourceListIsComplete && !seenSourceIDs[dl.ID]:
+			reason = "download source no longer available in the client — re-download or import the files manually"
+		default:
+			continue
+		}
+		slog.Warn("blocking unrecoverable import failure", "title", dl.Title, "download_id", dl.ID, "reason", reason)
+		s.failImport(ctx, &dl, models.StateImportBlocked, reason)
+	}
+}
+
 // checkSABnzbdDownloads polls SABnzbd for status changes.
 func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.DownloadClient) {
 	sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.URLBase, client.UseSSL)
@@ -506,11 +614,17 @@ func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.Down
 		return
 	}
 
+	// Track which downloads' sources we observed this cycle so stale
+	// StateImportFailed downloads (history entry cleared / aged out) can be
+	// terminally blocked rather than left stuck (issue #706 finding 4).
+	seenSourceIDs := make(map[int64]bool)
+
 	for _, slot := range history.Slots {
 		dl, err := s.downloads.GetByNzoID(ctx, slot.NzoID)
 		if err != nil || dl == nil {
 			continue
 		}
+		seenSourceIDs[dl.ID] = true
 
 		switch slot.Status {
 		case "Completed":
@@ -540,6 +654,15 @@ func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.Down
 			}
 		}
 	}
+
+	// Terminally block StateImportFailed downloads whose retry budget is spent
+	// (issue #706 finding 4). sourceListIsComplete is false: SABnzbd history is
+	// paginated (capped at 50 slots above), so a download missing from this poll
+	// may simply have aged out while still healthy — only retry-exhaustion is a
+	// safe, definitive signal here.
+	s.blockStaleImportFailures(ctx, seenSourceIDs, false, func(d models.Download) bool {
+		return d.DownloadClientID != nil && *d.DownloadClientID == client.ID
+	})
 }
 
 // checkNZBGetDownloads polls NZBGet for status changes using its JSON-RPC API.
@@ -553,12 +676,16 @@ func (s *Scanner) checkNZBGetDownloads(ctx context.Context, client *models.Downl
 		return
 	}
 
+	// Track which downloads' sources we observed this cycle (issue #706 finding 4).
+	seenSourceIDs := make(map[int64]bool)
+
 	for _, item := range history {
 		nzbIDStr := strconv.Itoa(item.NZBID)
 		dl, err := s.downloads.GetByNzoID(ctx, nzbIDStr)
 		if err != nil || dl == nil {
 			continue
 		}
+		seenSourceIDs[dl.ID] = true
 
 		if nzbget.IsSuccess(item.Status) {
 			if dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed {
@@ -588,6 +715,14 @@ func (s *Scanner) checkNZBGetDownloads(ctx context.Context, client *models.Downl
 			}
 		}
 	}
+
+	// Terminally block StateImportFailed downloads whose retry budget is spent
+	// (issue #706 finding 4). sourceListIsComplete is false: the NZBGet history
+	// response is not a guaranteed-complete enumeration of every source we might
+	// still retry, so only retry-exhaustion is acted on here.
+	s.blockStaleImportFailures(ctx, seenSourceIDs, false, func(d models.Download) bool {
+		return d.DownloadClientID != nil && *d.DownloadClientID == client.ID
+	})
 }
 
 // tryImportNZBGet attempts to import a completed NZBGet download into the library.
@@ -622,13 +757,22 @@ func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models
 		torrentsMap[fmt.Sprintf("%d", t.ID)] = t
 	}
 
+	// Track which downloads' sources we observed this cycle so stale
+	// StateImportFailed downloads (torrent removed) can be terminally blocked
+	// rather than left stuck below the retry limit (issue #706 finding 4).
+	seenSourceIDs := make(map[int64]bool)
+
 	for _, dl := range allDownloads {
-		if !isTrackedTorrentDownloadForClient(dl, client.ID) {
+		if dl.DownloadClientID == nil || *dl.DownloadClientID != client.ID || dl.TorrentID == nil {
 			continue
 		}
-
 		torrent, ok := torrentsMap[*dl.TorrentID]
 		if !ok {
+			continue
+		}
+		seenSourceIDs[dl.ID] = true
+
+		if dl.Status == models.StateImported || dl.Status == models.StateFailed {
 			continue
 		}
 
@@ -661,6 +805,14 @@ func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models
 			s.markDownloadFailed(ctx, &dl, stopError)
 		}
 	}
+
+	// Terminally block StateImportFailed downloads whose torrent has been
+	// removed from Transmission, or whose retry budget is spent (issue #706
+	// finding 4). sourceListIsComplete is true: GetTorrents returns every
+	// torrent, so a missing entry definitively means the source is gone.
+	s.blockStaleImportFailures(ctx, seenSourceIDs, true, func(d models.Download) bool {
+		return d.DownloadClientID != nil && *d.DownloadClientID == client.ID
+	})
 }
 
 // checkQbittorrentDownloads polls qBittorrent for status changes.
@@ -683,13 +835,20 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 		torrentsMap[strings.ToLower(t.Hash)] = t
 	}
 
+	// Track which downloads' sources we observed this cycle (issue #706 finding 4).
+	seenSourceIDs := make(map[int64]bool)
+
 	for _, dl := range allDownloads {
-		if !isTrackedTorrentDownloadForClient(dl, client.ID) {
+		if dl.DownloadClientID == nil || *dl.DownloadClientID != client.ID || dl.TorrentID == nil {
 			continue
 		}
-
 		torrent, ok := torrentsMap[strings.ToLower(*dl.TorrentID)]
 		if !ok {
+			continue
+		}
+		seenSourceIDs[dl.ID] = true
+
+		if dl.Status == models.StateImported || dl.Status == models.StateFailed {
 			continue
 		}
 
@@ -741,6 +900,14 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 			s.markDownloadFailed(ctx, &dl, "Torrent failed in qBittorrent")
 		}
 	}
+
+	// Terminally block StateImportFailed downloads whose torrent has been
+	// removed from qBittorrent, or whose retry budget is spent (issue #706
+	// finding 4). sourceListIsComplete is true: GetTorrents returns every
+	// torrent, so a missing entry definitively means the source is gone.
+	s.blockStaleImportFailures(ctx, seenSourceIDs, true, func(d models.Download) bool {
+		return d.DownloadClientID != nil && *d.DownloadClientID == client.ID
+	})
 }
 
 // tryImportSABnzbd attempts to import a completed SABnzbd download into the library.
@@ -794,6 +961,67 @@ func resolveQbitContentPath(t qbittorrent.Torrent) (string, bool) {
 	return "", false
 }
 
+// alreadyImportedFormat reports whether book already has a tracked, on-disk
+// file for the given format. It is the idempotency guard for issue #706
+// finding 2: the book-file write, the download-status write and the history
+// event are three separate non-transactional ops, so a crash between them
+// leaves the file on disk and recorded in book_files while the download stays
+// non-terminal. The startup sweep (finding 1) then re-queues the download and
+// the retry would import the SAME files a second time — and because the
+// audiobook destination is run through UniqueDir, the retry lands a duplicate
+// folder ("Title (2)") that INSERT OR IGNORE cannot dedupe.
+//
+// Checking book_files AND os.Stat (rather than book_files alone) means a
+// recorded-but-since-deleted file does not wrongly suppress a legitimate
+// re-import.
+func (s *Scanner) alreadyImportedFormat(ctx context.Context, book *models.Book, format string) bool {
+	if book == nil {
+		return false
+	}
+	files, err := s.books.ListFiles(ctx, book.ID)
+	if err != nil {
+		slog.Warn("idempotency check: failed to list book files", "bookID", book.ID, "error", err)
+		return false
+	}
+	for _, f := range files {
+		if f.Format != format {
+			continue
+		}
+		if _, statErr := os.Stat(f.Path); statErr == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// alreadyImportedPath reports whether the exact destination path is already
+// tracked in book_files for the book and still exists on disk. This is the
+// per-file idempotency guard for ebook imports, whose destination paths are
+// deterministic (no UniqueDir): a retry recomputes the identical destPath, so
+// a match here means that specific file already landed and must not be
+// re-imported. It is intentionally per-file so a retry of a genuine PARTIAL
+// failure still imports the files that never landed.
+func (s *Scanner) alreadyImportedPath(ctx context.Context, book *models.Book, destPath string) bool {
+	if book == nil {
+		return false
+	}
+	files, err := s.books.ListFiles(ctx, book.ID)
+	if err != nil {
+		slog.Warn("idempotency check: failed to list book files", "bookID", book.ID, "error", err)
+		return false
+	}
+	cleanDest := filepath.Clean(destPath)
+	for _, f := range files {
+		if filepath.Clean(f.Path) != cleanDest {
+			continue
+		}
+		if _, statErr := os.Stat(f.Path); statErr == nil {
+			return true
+		}
+	}
+	return false
+}
+
 // tryImportInternal is the common import logic shared by SABnzbd and Transmission.
 func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, downloadPath, cleanupClientType, cleanupRemoteID string, cleanupFunc func() error) {
 	if s.libraryDir == "" {
@@ -813,21 +1041,22 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// below — no further DB reads of "import.mode" occur for this import.
 	importMode := s.importMode(ctx, downloadPath, s.libraryDir)
 
-	// External mode: skip all file operations and reset the book to wanted so
-	// the library scan can reconcile it after the user's external tool (Calibre,
+	// External mode: skip all file operations and leave the book Wanted so the
+	// library scan can reconcile it after the user's external tool (Calibre,
 	// Grimmory, etc.) processes and places the file in the library directory.
+	//
+	// The download is parked in StateImportExternal — a NON-terminal state
+	// (issue #706 finding 3). Marking it terminal-StateImported here was wrong:
+	// if the external tool never places the file (or places it outside the
+	// library dir, where ScanLibrary's path constraint rejects it), the book
+	// stays Wanted forever and searchWanted re-grabs the same release every
+	// sweep, each prior download reading as a success. StateImportExternal lets
+	// searchWanted skip the book while the hand-off is outstanding, and
+	// ScanLibrary still reconciles the file the moment it lands.
 	if importMode == "external" {
-		if dl.BookID != nil {
-			if b, err := s.books.GetByID(ctx, *dl.BookID); err == nil && b != nil {
-				b.Status = models.BookStatusWanted
-				if err := s.books.Update(ctx, b); err != nil {
-					slog.Warn("external import: failed to reset book status", "bookId", b.ID, "error", err)
-				}
-			}
-		}
-		s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
+		s.updateDownloadStatus(ctx, dl.ID, models.StateImportExternal)
 		slog.Info("external import: download handed off, awaiting library scan", "title", dl.Title)
-		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"mode": "external"})
+		s.createHistoryEvent(ctx, models.HistoryEventDownloadFolderImport, dl.Title, dl.BookID, map[string]string{"mode": "external", "status": string(models.StateImportExternal)})
 		return
 	}
 
@@ -890,6 +1119,22 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// Audiobook path: place the entire download directory as a unit so
 	// multi-part m4b/mp3 files, cover art, and cue sheets stay together.
 	if detectedFormat == models.MediaTypeAudiobook {
+		// Idempotency guard (issue #706 finding 2): if a prior attempt already
+		// placed this audiobook (book_files has an on-disk audiobook entry) but
+		// crashed before writing the terminal status, re-importing here would
+		// run AudiobookDestDir through UniqueDir and land a duplicate
+		// "Title (2)" folder. Short-circuit straight to StateImported instead.
+		if s.alreadyImportedFormat(ctx, book, models.MediaTypeAudiobook) {
+			slog.Info("audiobook already imported — skipping re-import (idempotency guard)",
+				"title", dl.Title, "bookID", book.ID)
+			s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
+			if cleanupFunc != nil {
+				if err := cleanupFunc(); err != nil {
+					slog.Warn("cleanup failed", cleanupWarnAttrs(cleanupClientType, cleanupRemoteID, err)...)
+				}
+			}
+			return
+		}
 		// audiobookRoot always starts from BINDERY_AUDIOBOOK_DIR (set at
 		// startup). effectiveLibraryDir is format-agnostic — it resolves the
 		// per-author ebook root folder — so applying it here would send
@@ -994,6 +1239,22 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			failed++
 			continue
 		}
+
+		// Idempotency guard (issue #706 finding 2): if a prior attempt already
+		// landed this exact destination file and recorded it in book_files but
+		// crashed before writing the terminal status, re-importing would
+		// re-copy the bytes and re-emit the history event. The ebook
+		// destination is deterministic, so a match means the file is already
+		// imported — count it as imported and move on. Per-file (not
+		// per-download) so a retry of a genuine partial failure still imports
+		// the files that never landed.
+		if s.alreadyImportedPath(ctx, book, destPath) {
+			slog.Info("book file already imported — skipping re-import (idempotency guard)",
+				"src", srcFile, "dst", destPath)
+			imported++
+			continue
+		}
+
 		mode := importMode
 		slog.Info("importing book", "src", srcFile, "dst", destPath, "mode", mode)
 

--- a/internal/importer/scanner_recovery_test.go
+++ b/internal/importer/scanner_recovery_test.go
@@ -1,0 +1,305 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestRecoverInterruptedImports_SweepsWedgedImporting is the regression test
+// for issue #706 finding 1: a download wedged in the non-terminal
+// StateImporting (process crashed mid-move) must be swept back to
+// StateImportFailed on startup so the scanner's retry path can pick it up.
+func TestRecoverInterruptedImports_SweepsWedgedImporting(t *testing.T) {
+	t.Parallel()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+
+	dlRepo := db.NewDownloadRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+	s := NewScanner(dlRepo, db.NewDownloadClientRepo(database),
+		db.NewBookRepo(database), db.NewAuthorRepo(database), histRepo,
+		t.TempDir(), "", "", "", "")
+
+	// A download a prior process left mid-import.
+	wedged := &models.Download{GUID: "wedged", Title: "Crashed Mid-Move",
+		NZBURL: "x", Status: models.StateImporting}
+	if err := dlRepo.Create(ctx, wedged); err != nil {
+		t.Fatal(err)
+	}
+	// An untouched terminal download — must not be disturbed.
+	done := &models.Download{GUID: "done", Title: "Already Imported",
+		NZBURL: "x", Status: models.StateImported}
+	if err := dlRepo.Create(ctx, done); err != nil {
+		t.Fatal(err)
+	}
+
+	s.RecoverInterruptedImports(ctx)
+
+	got, err := dlRepo.GetByGUID(ctx, "wedged")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StateImportFailed {
+		t.Errorf("wedged download status = %q, want %q — startup sweep must re-queue it for retry",
+			got.Status, models.StateImportFailed)
+	}
+	if got.ErrorMessage == "" {
+		t.Error("expected an actionable error message on the recovered download")
+	}
+
+	gotDone, err := dlRepo.GetByGUID(ctx, "done")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotDone.Status != models.StateImported {
+		t.Errorf("terminal download status = %q, want %q — sweep must not touch it",
+			gotDone.Status, models.StateImported)
+	}
+
+	// The sweep must emit a history event so the recovery is visible.
+	events, err := histRepo.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, e := range events {
+		if e.EventType == models.HistoryEventImportFailed {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected an importFailed history event for the recovered download")
+	}
+}
+
+// TestTryImportInternal_RetryIsIdempotent is the regression test for issue #706
+// finding 2: re-running an import whose book file already landed on disk and was
+// recorded in book_files — but which crashed before the terminal status was
+// written — must NOT re-import the file or add a duplicate book_files row. The
+// retry must short-circuit straight to StateImported.
+func TestTryImportInternal_RetryIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	downloadPath := t.TempDir()
+	src := filepath.Join(downloadPath, "book.epub")
+	if err := os.WriteFile(src, []byte("epub-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// copy mode: the source survives the import, so a retry walks the same
+	// download folder again — the exact case where a double-add can occur.
+	s, dl, dlRepo, bookRepo, ctx := dataLossFixture(t, libraryDir, "copy")
+
+	// First import: succeeds normally and writes the book_files row.
+	s.tryImportInternal(ctx, dl, downloadPath, "transmission", "tor-1", nil)
+
+	filesAfterFirst, err := bookRepo.ListFiles(ctx, *dl.BookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filesAfterFirst) != 1 {
+		t.Fatalf("after first import: %d book_files rows, want 1", len(filesAfterFirst))
+	}
+	destPath := filesAfterFirst[0].Path
+
+	// Reproduce the post-crash state precisely: the book_files row + the file on
+	// disk survive (the first import wrote them), but the download crashed before
+	// the terminal status was set, so the startup sweep re-queued it to
+	// StateImportFailed. The download record is non-terminal again and a retry is
+	// about to run. (We cannot reuse the StateImported row from above — that
+	// transition is terminal — so build the row directly in the post-sweep state,
+	// matching exactly what RecoverInterruptedImports produces.)
+	retryDL := &models.Download{
+		GUID:   "guid-retry-idem",
+		Title:  dl.Title,
+		BookID: dl.BookID,
+		Status: models.StateImportFailed,
+		NZBURL: "fake://url",
+	}
+	if err := dlRepo.Create(ctx, retryDL); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(destPath); err != nil {
+		t.Fatalf("precondition: imported file should still be on disk: %v", err)
+	}
+
+	s.tryImportInternal(ctx, retryDL, downloadPath, "transmission", "tor-1", nil)
+
+	// The idempotency guard must short-circuit: no second book_files row.
+	filesAfterRetry, err := bookRepo.ListFiles(ctx, *dl.BookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filesAfterRetry) != 1 {
+		t.Errorf("after retry: %d book_files rows, want 1 — the retry double-added the file", len(filesAfterRetry))
+	}
+
+	// And the retry must still drive the download to the terminal imported state.
+	gotRetry, err := dlRepo.GetByGUID(ctx, retryDL.GUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRetry.Status != models.StateImported {
+		t.Errorf("after retry status = %q, want %q — an idempotent retry must still finalise the download",
+			gotRetry.Status, models.StateImported)
+	}
+}
+
+// TestBlockStaleImportFailures_VanishedSourceEndsBlocked is the regression test
+// for issue #706 finding 4: a StateImportFailed download whose source is no
+// longer present in the client's (complete) source list must transition to the
+// terminal StateImportBlocked rather than sitting in StateImportFailed forever
+// below the retry limit.
+func TestBlockStaleImportFailures_VanishedSourceEndsBlocked(t *testing.T) {
+	t.Parallel()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	s := NewScanner(dlRepo, clientRepo,
+		db.NewBookRepo(database), db.NewAuthorRepo(database), db.NewHistoryRepo(database),
+		t.TempDir(), "", "", "", "")
+
+	client := &models.DownloadClient{Name: "qbit", Type: "qbittorrent", Host: "h", Port: 8080}
+	if err := clientRepo.Create(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+	clientID := client.ID
+
+	// A failed import that is still below the retry limit — its only problem is
+	// that the torrent has been removed from the client.
+	vanished := &models.Download{GUID: "vanished", Title: "Torrent Removed",
+		NZBURL: "x", Status: models.StateImportFailed, DownloadClientID: &clientID}
+	if err := dlRepo.Create(ctx, vanished); err != nil {
+		t.Fatal(err)
+	}
+
+	// seenSourceIDs is empty: the torrent did not appear in this poll cycle.
+	// sourceListIsComplete=true because a torrent client enumerates every
+	// torrent, so a missing entry definitively means the source is gone.
+	s.blockStaleImportFailures(ctx, map[int64]bool{}, true, func(d models.Download) bool {
+		return d.DownloadClientID != nil && *d.DownloadClientID == clientID
+	})
+
+	got, err := dlRepo.GetByGUID(ctx, "vanished")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StateImportBlocked {
+		t.Errorf("vanished-source download status = %q, want %q — a download whose source is gone must end terminally blocked, not stuck",
+			got.Status, models.StateImportBlocked)
+	}
+	if got.ErrorMessage == "" {
+		t.Error("expected an actionable error message explaining the source is gone")
+	}
+}
+
+// TestBlockStaleImportFailures_RetryExhaustedEndsBlocked verifies the
+// retry-budget half of issue #706 finding 4: a StateImportFailed download whose
+// source is STILL present but whose retry count is exhausted must be terminally
+// blocked rather than left stuck.
+func TestBlockStaleImportFailures_RetryExhaustedEndsBlocked(t *testing.T) {
+	t.Parallel()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	s := NewScanner(dlRepo, clientRepo,
+		db.NewBookRepo(database), db.NewAuthorRepo(database), db.NewHistoryRepo(database),
+		t.TempDir(), "", "", "", "")
+
+	client := &models.DownloadClient{Name: "qbit", Type: "qbittorrent", Host: "h", Port: 8080}
+	if err := clientRepo.Create(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+	clientID := client.ID
+
+	exhausted := &models.Download{GUID: "exhausted", Title: "Retries Burned",
+		NZBURL: "x", Status: models.StateImportFailed, DownloadClientID: &clientID}
+	if err := dlRepo.Create(ctx, exhausted); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < importRetryLimit; i++ {
+		if err := dlRepo.IncrementImportRetryCount(ctx, exhausted.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The source IS still present (seenSourceIDs contains it) — only the retry
+	// budget is spent. It must still be blocked.
+	s.blockStaleImportFailures(ctx, map[int64]bool{exhausted.ID: true}, true,
+		func(d models.Download) bool {
+			return d.DownloadClientID != nil && *d.DownloadClientID == clientID
+		})
+
+	got, err := dlRepo.GetByGUID(ctx, "exhausted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StateImportBlocked {
+		t.Errorf("retry-exhausted download status = %q, want %q",
+			got.Status, models.StateImportBlocked)
+	}
+}
+
+// TestTryImportInternal_ExternalModeParksNonTerminal is the regression test for
+// issue #706 finding 3: an external-mode hand-off must leave the download in the
+// NON-terminal StateImportExternal (so searchWanted can skip it and ScanLibrary
+// can reconcile the file) rather than jumping to terminal StateImported, which
+// caused a silent re-download loop.
+func TestTryImportInternal_ExternalModeParksNonTerminal(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	downloadPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(downloadPath, "book.epub"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, dl, dlRepo, bookRepo, ctx := dataLossFixture(t, libraryDir, "external")
+
+	s.tryImportInternal(ctx, dl, downloadPath, "transmission", "tor-1", nil)
+
+	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StateImportExternal {
+		t.Errorf("external-mode download status = %q, want %q — must be parked non-terminal, not terminal-imported",
+			got.Status, models.StateImportExternal)
+	}
+
+	// The book must stay Wanted so ScanLibrary can reconcile the file once the
+	// external tool places it (ScanLibrary only reconciles Wanted books).
+	book, err := bookRepo.GetByID(ctx, *dl.BookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if book.Status != models.BookStatusWanted {
+		t.Errorf("book status = %q, want %q — external hand-off must leave the book reconcilable",
+			book.Status, models.BookStatusWanted)
+	}
+}

--- a/internal/models/download_state.go
+++ b/internal/models/download_state.go
@@ -18,6 +18,14 @@ const (
 	StateFailed        DownloadState = "failed"
 	StateImportFailed  DownloadState = "importFailed"
 	StateImportBlocked DownloadState = "importBlocked"
+	// StateImportExternal marks a download handed off to an external import
+	// tool (import.mode=external). It is deliberately NON-terminal: the file
+	// has not yet been reconciled into the library, so the download is not
+	// "imported". The book stays Wanted so ScanLibrary can reconcile the file
+	// once the external tool places it; searchWanted skips books that have a
+	// download in this state so the release is not re-grabbed forever while the
+	// hand-off is outstanding (issue #706 finding 3).
+	StateImportExternal DownloadState = "importExternal"
 )
 
 // validTransitions defines which state transitions are allowed.
@@ -25,12 +33,16 @@ var validTransitions = map[DownloadState][]DownloadState{
 	StateGrabbed:       {StateDownloading, StateFailed},
 	StateDownloading:   {StateCompleted, StateFailed},
 	StateCompleted:     {StateImportPending, StateImportFailed},
-	StateImportPending: {StateImporting, StateImportFailed},
+	StateImportPending: {StateImporting, StateImportFailed, StateImportExternal},
 	StateImporting:     {StateImported, StateImportFailed, StateImportBlocked},
 	StateImported:      {},
 	StateFailed:        {},
 	StateImportFailed:  {StateImportPending, StateImportBlocked, StateImporting},
 	StateImportBlocked: {},
+	// External hand-off is non-terminal. It can only be retired by a manual
+	// retry (which routes through StateImportPending) — there is no automatic
+	// path out, by design: ScanLibrary reconciles the file independently.
+	StateImportExternal: {StateImportPending},
 }
 
 // CanTransitionTo reports whether a transition from s to next is valid.

--- a/internal/models/download_state_test.go
+++ b/internal/models/download_state_test.go
@@ -27,6 +27,14 @@ func TestCanTransitionTo(t *testing.T) {
 		{StateFailed, StateGrabbed, false},
 		{StateImportBlocked, StateImporting, false},
 
+		// External hand-off is non-terminal (issue #706 finding 3)
+		{StateImportPending, StateImportExternal, true},
+		{StateImportExternal, StateImportPending, true},
+		// ...but it does not jump straight to a terminal state
+		{StateImportExternal, StateImported, false},
+		{StateImportExternal, StateImporting, false},
+		{StateImportExternal, StateImportBlocked, false},
+
 		// No backwards transitions
 		{StateImported, StateImportPending, false},
 		{StateImportFailed, StateImported, false},

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -634,9 +634,31 @@ func (s *Scheduler) searchWanted() {
 		return
 	}
 
+	// Books with a download parked in StateImportExternal have been handed off
+	// to an external import tool; the book is deliberately still Wanted so
+	// ScanLibrary can reconcile the file once it lands, but the release must
+	// NOT be re-grabbed in the meantime or the importer re-downloads the same
+	// book every sweep (issue #706 finding 3).
+	externalHandoffBooks := make(map[int64]bool)
+	if s.downloads != nil {
+		if pending, derr := s.downloads.ListByStatus(ctx, models.StateImportExternal); derr != nil {
+			slog.Warn("failed to list external-handoff downloads", "error", derr)
+		} else {
+			for _, d := range pending {
+				if d.BookID != nil {
+					externalHandoffBooks[*d.BookID] = true
+				}
+			}
+		}
+	}
+
 	searchQueue := make([]models.Book, 0, len(wanted))
 	for _, book := range wanted {
 		if book.Excluded {
+			continue
+		}
+		if externalHandoffBooks[book.ID] {
+			slog.Debug("skipping wanted search — external import hand-off outstanding", "book", book.Title)
 			continue
 		}
 		searchQueue = append(searchQueue, book)


### PR DESCRIPTION
Implements the four deferred state-machine / crash-recovery findings of #706. The four #705 move-mode cleanup findings already merged to main and are built on, not redone.

## Finding 1 — crash mid-move wedges the download forever
`StateImporting` / `StateImportPending` are non-terminal with no automatic re-entry; `CheckDownloads` only retries from `StateImportFailed`. Adds `DownloadRepo.RecoverInterruptedImports` and `Scanner.RecoverInterruptedImports`, wired into startup in `cmd/bindery/main.go` before the scheduler starts, which sweeps wedged downloads to `StateImportFailed` so the existing retry path picks them up. `StateImportExternal` is deliberately excluded — it is a legitimate parked state, not a crash artefact.

## Finding 2 — non-transactional book-file write + status + history (conservative partial)
The repos (`DownloadRepo`, `BookRepo`/`BookFileRepo`, `HistoryRepo`) each hold their own `*sql.DB` and share no transaction-capable interface, so a true cross-table transaction would require threading a `*sql.Tx` through all three — invasive. Implemented the **idempotency guard** the issue offers as the lower-risk alternative instead: `alreadyImportedFormat` / `alreadyImportedPath` check whether the destination file is already recorded in `book_files` **and** present on disk, and short-circuit to `StateImported` rather than re-importing. This kills the audiobook `UniqueDir` `" (2)"` double-add and the duplicate `book_files` row on a post-crash retry.

**Conservative-partial note:** a move-mode retry whose source files were already consumed by the original move finds an empty download dir and still routes through `StateImportFailed` → `StateImportBlocked` rather than short-circuiting. This is **no data loss** (the book file is correctly recorded and on disk) — only a cosmetically-blocked download. The full fix (a real transaction) is left out as too invasive per the issue's guidance.

## Finding 3 — `external` import mode silent re-download loop
External mode marked the download terminal-`StateImported` while leaving the book `Wanted`, so `searchWanted` re-grabbed the release every sweep. The issue's suggested conservative fix (don't flip the book to `Wanted`) is **not viable** — `ScanLibrary` reconciliation explicitly requires `book.Status == Wanted`, so a non-Wanted book's file would never be reconciled. Instead adds a distinct non-terminal `StateImportExternal`: the book stays `Wanted` (so `ScanLibrary` reconciles the file once it lands) and `searchWanted` now skips books that have a download parked in `StateImportExternal`. `queue.go` size-left handling updated for the new state.

## Finding 4 — retries impossible once the source disappears
`CheckDownloads` only retries a `StateImportFailed` download while its source is still in the client's torrent list / history. Adds `Scanner.blockStaleImportFailures`, run at the end of every `check*Downloads` cycle, which transitions a `StateImportFailed` download to terminal `StateImportBlocked` with an actionable message when the retry budget is exhausted, or — for torrent clients, whose source list is a complete enumeration — when the source has vanished. The usenet checkers (SABnzbd/NZBGet) act only on retry-exhaustion, never vanished-source, because their history APIs are paginated (SAB is capped at 50 slots) and a missing entry is not a reliable "source gone" signal. The `StateImportFailed → StateImportBlocked` transition itself was already added by #720.

## Tests
- startup sweep moves a wedged `StateImporting` download to `StateImportFailed` and leaves terminal/parked states untouched (`scanner_recovery_test.go`, `downloads_coverage_test.go`)
- a post-crash retry is idempotent — no duplicate `book_files` row, still finalises to `StateImported`
- a vanished-source download and a retry-exhausted download both end terminal-`StateImportBlocked`
- external mode parks the download non-terminal and keeps the book `Wanted`
- `download_state_test.go` covers the new `StateImportExternal` edges

`gofmt` clean, `go build ./...` and `go vet` pass, `go test ./internal/importer/...` passes.

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)