### PR TITLE
fix(qbittorrent): accept category save paths under the download dir

### DIFF
--- a/internal/downloader/health.go
+++ b/internal/downloader/health.go
@@ -143,8 +143,8 @@ func checkQbittorrentCategoryPath(ctx context.Context, client *models.DownloadCl
 	}
 
 	localPath := filepath.Clean(pathmap.Parse(client.PathRemap).Apply(savePath))
-	if localPath != expected {
-		return healthError(fmt.Sprintf("qBittorrent category %q saves to %q, which maps to %q; expected %q", category, savePath, localPath, expected))
+	if !pathIsAtOrUnder(localPath, expected) {
+		return healthError(fmt.Sprintf("qBittorrent category %q saves to %q, which maps to %q; expected a path at or under %q", category, savePath, localPath, expected))
 	}
 
 	return models.DownloadClientHealth{
@@ -155,4 +155,15 @@ func checkQbittorrentCategoryPath(ctx context.Context, client *models.DownloadCl
 
 func healthError(message string) models.DownloadClientHealth {
 	return models.DownloadClientHealth{Status: HealthError, Message: message}
+}
+
+// pathIsAtOrUnder reports whether candidate is equal to base or is a
+// subdirectory of base. Both paths must already be filepath.Clean'd.
+// A trailing separator is added to base before the prefix check so that
+// "/data/downloads-extra" is not mistakenly accepted as "under" "/data/downloads".
+func pathIsAtOrUnder(candidate, base string) bool {
+	if candidate == base {
+		return true
+	}
+	return strings.HasPrefix(candidate, base+string(filepath.Separator))
 }

--- a/internal/downloader/health_test.go
+++ b/internal/downloader/health_test.go
@@ -38,7 +38,18 @@ func TestCheckDownloadClientHealth_QBittorrentCategoryPath(t *testing.T) {
 			name:       "mismatched category path",
 			categories: `{"books":{"name":"books","savePath":"/media/other"}}`,
 			wantStatus: HealthError,
-			wantText:   `expected "/books/downloads"`,
+			wantText:   `expected a path at or under "/books/downloads"`,
+		},
+		{
+			name:       "category path is a subdirectory of download dir",
+			categories: `{"books":{"name":"books","savePath":"/media/downloads/Torrents/books"}}`,
+			wantStatus: HealthOK,
+		},
+		{
+			name:       "category path under sibling dir is still rejected",
+			categories: `{"books":{"name":"books","savePath":"/media/downloads-extra/books"}}`,
+			wantStatus: HealthError,
+			wantText:   `expected a path at or under "/books/downloads"`,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- The category-path health check in `checkQbittorrentCategoryPath` required the category's save path (after any path remap) to equal the configured download directory exactly. This rejected valid setups where a qBittorrent category saves into a subdirectory (e.g. `/data/downloads/Torrents/books`) rather than directly to the download root.
- Replaced the equality check with a new `pathIsAtOrUnder` helper that accepts a category save path that equals or is nested beneath the configured download dir. Paths genuinely outside the download dir still produce a health error.
- Added two regression test cases: one confirming a subdirectory save path passes health, and one confirming a path under a sibling directory (e.g. `/data/downloads-extra/books`) is still rejected.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/downloader/... ./internal/importer/...` exits 0 (all packages ok)
- [x] New test `category path is a subdirectory of download dir` — verifies the fix
- [x] New test `category path under sibling dir is still rejected` — verifies the guard still holds
- [x] Existing `remapped category path matches` test still passes — path-remap behavior unchanged

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)