### PR TITLE
feat(auth): wire session-secret rotation with current+previous keys

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -563,7 +563,7 @@ func main() {
 	r.Route("/api", func(r chi.Router) {
 		r.Use(auth.Middleware(authProvider))
 		r.Use(auth.RequireXRequestedWith)
-		r.Use(auth.RequireCSRFToken(authProvider.SessionSecret))
+		r.Use(auth.RequireCSRFToken(authProvider.SessionSecrets))
 
 		r.Get("/queue", queueHandler.ListArrCompatible)
 	})
@@ -571,7 +571,7 @@ func main() {
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(auth.Middleware(authProvider))
 		r.Use(auth.RequireXRequestedWith)
-		r.Use(auth.RequireCSRFToken(authProvider.SessionSecret))
+		r.Use(auth.RequireCSRFToken(authProvider.SessionSecrets))
 
 		// System
 		r.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
@@ -621,6 +621,7 @@ func main() {
 		r.Group(func(r chi.Router) {
 			r.Use(auth.RequireAdmin)
 			r.Post("/auth/apikey/regenerate", authHandler.RegenerateAPIKey)
+			r.Post("/auth/session-secret/rotate", authHandler.RotateSessionSecret)
 			r.Put("/auth/oidc/providers", oidcHandler.SetProviders)
 			r.Put("/auth/mode", authHandler.SetMode)
 			r.Get("/auth/users", userMgmtHandler.List)
@@ -1103,6 +1104,19 @@ func (p *dbAuthProvider) SessionSecret() []byte {
 		return nil
 	}
 	return []byte(s.Value)
+}
+
+// SessionSecrets returns the ordered verification candidate set
+// {current, previous}. The previous secret is included only when it has been
+// populated by a rotation; until then this is a single-element slice and
+// verification is identical to single-secret behavior. VerifySessionMulti
+// applies the minimum-length fail-closed guard to every entry.
+func (p *dbAuthProvider) SessionSecrets() [][]byte {
+	secrets := [][]byte{p.SessionSecret()}
+	if s, _ := p.settings.Get(context.Background(), api.SettingAuthSessionSecretPrevious); s != nil && s.Value != "" {
+		secrets = append(secrets, []byte(s.Value))
+	}
+	return secrets
 }
 
 func (p *dbAuthProvider) SetupRequired() bool {

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -35,8 +35,14 @@ func CookieSecureMode() string {
 const (
 	SettingAuthAPIKey        = "auth.api_key"        //nolint:gosec // setting key name, not a credential
 	SettingAuthSessionSecret = "auth.session_secret" //nolint:gosec // setting key name, not a credential
-	SettingAuthMode          = "auth.mode"
-	SettingOIDCProviders     = "auth.oidc.providers" //nolint:gosec // setting key name, not a credential
+	// SettingAuthSessionSecretPrevious holds the secret rotated out by the most
+	// recent rotation. It is consulted only for *verification* so a cookie
+	// signed under the just-rotated-out secret still validates during the
+	// rotation window; SignSession never uses it. Absent/empty until the first
+	// rotation, in which case verification is single-secret as before.
+	SettingAuthSessionSecretPrevious = "auth.session_secret_previous" //nolint:gosec // setting key name, not a credential
+	SettingAuthMode                  = "auth.mode"
+	SettingOIDCProviders             = "auth.oidc.providers" //nolint:gosec // setting key name, not a credential
 )
 
 // AuthHandler owns the login / setup / password / mode endpoints.
@@ -314,6 +320,46 @@ func (h *AuthHandler) RegenerateAPIKey(w http.ResponseWriter, r *http.Request) {
 	writeOK(w, map[string]any{"apiKey": key})
 }
 
+// RotateSessionSecret rotates the session signing secret. The current secret is
+// moved into auth.session_secret_previous and a fresh 32-byte secret becomes
+// the new current; both keys are persisted atomically via SettingsRepo.SetMany
+// so a verifier never observes a half-applied rotation.
+//
+// After rotation: new logins (and re-issued CSRF tokens) sign with the new
+// secret, while existing sessions remain valid because VerifySessionMulti is
+// handed {current, previous}. The window closes on the next rotation, which
+// overwrites the previous slot — at which point cookies signed under the
+// twice-rotated-out secret stop verifying and those users must re-login.
+//
+// Admin-only: this route is mounted inside the RequireAdmin group in
+// cmd/bindery/main.go alongside /auth/apikey/regenerate.
+func (h *AuthHandler) RotateSessionSecret(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// The new current secret. RandomBase64(32) yields >= 32 bytes of base64
+	// text, comfortably clearing the minSecretLen fail-closed guard.
+	newSecret, err := auth.RandomBase64(32)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "gen: "+err.Error())
+		return
+	}
+
+	// The current secret becomes the previous one. If it is somehow absent
+	// (should not happen — bootstrapAuth seeds it before serving), we simply
+	// rotate forward without a fallback window rather than fail.
+	cur := h.sessionSecret(ctx)
+
+	if err := h.settings.SetMany(ctx, []db.SettingKV{
+		{Key: SettingAuthSessionSecretPrevious, Value: string(cur)},
+		{Key: SettingAuthSessionSecret, Value: newSecret},
+	}); err != nil {
+		writeErr(w, http.StatusInternalServerError, "save: "+err.Error())
+		return
+	}
+	slog.Info("session signing secret rotated")
+	writeOK(w, map[string]any{"ok": true})
+}
+
 // CSRF issues (or re-issues) a double-submit CSRF token bound to the caller's
 // session cookie. The token is returned as JSON and also set as a readable
 // (non-HttpOnly) cookie so the frontend JS can read it. Unauthenticated
@@ -394,6 +440,20 @@ func (h *AuthHandler) sessionSecret(ctx context.Context) []byte {
 	// Secret is stored as base64; hand back raw bytes. Accept anything on
 	// decode failure (the seed path writes valid base64).
 	return []byte(s.Value)
+}
+
+// sessionSecrets returns the ordered verification candidate set
+// {current, previous}. The previous entry is included only when it is set and
+// non-empty; when absent the result is the single-element {current} slice and
+// verification behaves exactly as it did before rotation existed. The
+// minimum-length fail-closed guard is applied downstream by VerifySessionMulti
+// for every entry, so a short previous secret cannot weaken verification.
+func (h *AuthHandler) sessionSecrets(ctx context.Context) [][]byte {
+	secrets := [][]byte{h.sessionSecret(ctx)}
+	if s, _ := h.settings.Get(ctx, SettingAuthSessionSecretPrevious); s != nil && s.Value != "" {
+		secrets = append(secrets, []byte(s.Value))
+	}
+	return secrets
 }
 
 // issueSession signs and sets the session cookie. It returns true on success.

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -410,6 +410,129 @@ func TestRegenerateAPIKey(t *testing.T) {
 	}
 }
 
+// TestRotateSessionSecret_PersistsBothKeys verifies the rotation action moves
+// the current secret into the previous slot and writes a fresh current secret,
+// persisting both atomically.
+func TestRotateSessionSecret_PersistsBothKeys(t *testing.T) {
+	h, _, settings, ctx := newAuthFixture(t)
+
+	before, _ := settings.Get(ctx, SettingAuthSessionSecret)
+	if before == nil || before.Value == "" {
+		t.Fatal("fixture should have seeded a current session secret")
+	}
+
+	rec := httptest.NewRecorder()
+	h.RotateSessionSecret(rec, httptest.NewRequest(http.MethodPost, "/auth/session-secret/rotate", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	cur, _ := settings.Get(ctx, SettingAuthSessionSecret)
+	prev, _ := settings.Get(ctx, SettingAuthSessionSecretPrevious)
+	if cur == nil || cur.Value == "" {
+		t.Fatal("current secret must be set after rotation")
+	}
+	if prev == nil || prev.Value != before.Value {
+		t.Fatalf("previous secret must equal the pre-rotation current; got %v want %q", prev, before.Value)
+	}
+	if cur.Value == before.Value {
+		t.Fatal("current secret must change on rotation")
+	}
+	// The new current secret must clear the fail-closed minimum-length guard.
+	if len(cur.Value) < 32 {
+		t.Errorf("new current secret too short for minSecretLen: %d bytes", len(cur.Value))
+	}
+}
+
+// TestRotateSessionSecret_OldCookieStillVerifies proves the rotation window:
+// a session cookie signed under the just-rotated-out secret still verifies via
+// the {current, previous} candidate set, while signing always uses the new
+// current secret.
+func TestRotateSessionSecret_OldCookieStillVerifies(t *testing.T) {
+	h, _, _, ctx := newAuthFixture(t)
+
+	oldSecret := h.sessionSecret(ctx)
+	oldCookie, err := auth.SignSession(oldSecret, 7, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign old cookie: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.RotateSessionSecret(rec, httptest.NewRequest(http.MethodPost, "/auth/session-secret/rotate", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("rotate: expected 200, got %d", rec.Code)
+	}
+
+	// Old cookie still verifies during the rotation window.
+	if uid, err := auth.VerifySessionMulti(h.sessionSecrets(ctx), oldCookie); err != nil || uid != 7 {
+		t.Fatalf("rotated-out cookie: uid=%d err=%v; want 7,nil", uid, err)
+	}
+
+	// A cookie freshly signed under the new current secret also verifies.
+	newCookie, err := auth.SignSession(h.sessionSecret(ctx), 8, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign new cookie: %v", err)
+	}
+	if uid, err := auth.VerifySessionMulti(h.sessionSecrets(ctx), newCookie); err != nil || uid != 8 {
+		t.Fatalf("post-rotation cookie: uid=%d err=%v; want 8,nil", uid, err)
+	}
+}
+
+// TestRotateSessionSecret_StaleSecretRejected confirms a cookie signed with a
+// secret that is neither current nor previous — e.g. one rotated out two
+// rotations ago — is rejected. Verification must not be weakened.
+func TestRotateSessionSecret_StaleSecretRejected(t *testing.T) {
+	h, _, _, ctx := newAuthFixture(t)
+
+	// A secret never installed on this server.
+	staleSecret := []byte("stale-secret-never-installed-32b!")
+	staleCookie, err := auth.SignSession(staleSecret, 9, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign stale cookie: %v", err)
+	}
+
+	// One rotation: candidate set is {new, original}. The stale secret is
+	// neither, so its cookie must fail.
+	rec := httptest.NewRecorder()
+	h.RotateSessionSecret(rec, httptest.NewRequest(http.MethodPost, "/auth/session-secret/rotate", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("rotate: expected 200, got %d", rec.Code)
+	}
+	if _, err := auth.VerifySessionMulti(h.sessionSecrets(ctx), staleCookie); err == nil {
+		t.Fatal("cookie signed with a never-installed secret must be rejected")
+	}
+
+	// A second rotation drops the original secret out of the window entirely:
+	// a cookie signed under the original is now also rejected.
+	originalSecret := []byte("test-secret-32-bytes-long-enough") // gitleaks:allow — matches fixture seed
+	originalCookie, err := auth.SignSession(originalSecret, 10, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign original cookie: %v", err)
+	}
+	rec2 := httptest.NewRecorder()
+	h.RotateSessionSecret(rec2, httptest.NewRequest(http.MethodPost, "/auth/session-secret/rotate", nil))
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("second rotate: expected 200, got %d", rec2.Code)
+	}
+	if _, err := auth.VerifySessionMulti(h.sessionSecrets(ctx), originalCookie); err == nil {
+		t.Fatal("cookie signed with the twice-rotated-out secret must be rejected")
+	}
+}
+
+// TestSessionSecrets_SingleSecretWhenNoPrevious confirms that with no previous
+// secret configured the candidate set is exactly {current} — behavior is
+// identical to single-secret verification.
+func TestSessionSecrets_SingleSecretWhenNoPrevious(t *testing.T) {
+	h, _, _, ctx := newAuthFixture(t)
+	got := h.sessionSecrets(ctx)
+	if len(got) != 1 {
+		t.Fatalf("with no previous secret, candidate set must have 1 entry, got %d", len(got))
+	}
+	if string(got[0]) != string(h.sessionSecret(ctx)) {
+		t.Fatal("the single candidate must be the current secret")
+	}
+}
+
 // TestSetup_RejectsEmptyBody just confirms the 400 path for malformed JSON;
 // a silent failure here would let a misbehaving client soft-crash setup.
 func TestSetup_RejectsEmptyBody(t *testing.T) {

--- a/internal/api/opds_auth.go
+++ b/internal/api/opds_auth.go
@@ -42,7 +42,7 @@ func OPDSAuth(p auth.Provider, users *db.UserRepo, limiter *auth.LoginLimiter) f
 				return
 			}
 			if c, err := r.Cookie(auth.SessionCookieName); err == nil {
-				if _, err := auth.VerifySession(p.SessionSecret(), c.Value); err == nil {
+				if _, err := auth.VerifySessionMulti(p.SessionSecrets(), c.Value); err == nil {
 					next.ServeHTTP(w, r)
 					return
 				}

--- a/internal/api/opds_test.go
+++ b/internal/api/opds_test.go
@@ -121,6 +121,13 @@ func (p *testProvider) SessionSecret() []byte {
 	}
 	return []byte(s.Value)
 }
+func (p *testProvider) SessionSecrets() [][]byte {
+	secrets := [][]byte{p.SessionSecret()}
+	if s, _ := p.settings.Get(context.Background(), SettingAuthSessionSecretPrevious); s != nil && s.Value != "" {
+		secrets = append(secrets, []byte(s.Value))
+	}
+	return secrets
+}
 func (p *testProvider) SetupRequired() bool                        { return false }
 func (p *testProvider) ProxyAuthHeader() string                    { return "X-Forwarded-User" }
 func (p *testProvider) ProxyAutoProvision() bool                   { return false }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -236,6 +236,7 @@ type fakeProvider struct {
 	mode           Mode
 	apiKey         string
 	secret         []byte
+	prevSecret     []byte // optional rotated-out secret; nil = single-secret
 	setup          bool
 	proxyHeader    string
 	proxyProvision bool
@@ -243,9 +244,16 @@ type fakeProvider struct {
 	provisioner    UserProvisioner
 }
 
-func (f *fakeProvider) Mode() Mode                                 { return f.mode }
-func (f *fakeProvider) APIKey() string                             { return f.apiKey }
-func (f *fakeProvider) SessionSecret() []byte                      { return f.secret }
+func (f *fakeProvider) Mode() Mode            { return f.mode }
+func (f *fakeProvider) APIKey() string        { return f.apiKey }
+func (f *fakeProvider) SessionSecret() []byte { return f.secret }
+func (f *fakeProvider) SessionSecrets() [][]byte {
+	secrets := [][]byte{f.secret}
+	if len(f.prevSecret) > 0 {
+		secrets = append(secrets, f.prevSecret)
+	}
+	return secrets
+}
 func (f *fakeProvider) SetupRequired() bool                        { return f.setup }
 func (f *fakeProvider) ProxyAuthHeader() string                    { return f.proxyHeader }
 func (f *fakeProvider) ProxyAutoProvision() bool                   { return f.proxyProvision }
@@ -352,6 +360,41 @@ func TestMiddlewareAcceptsValidSessionCookie(t *testing.T) {
 	h.ServeHTTP(nopWriter{}, req)
 	if gotUID != 7 {
 		t.Errorf("uid = %d; want 7", gotUID)
+	}
+}
+
+// TestMiddlewareAcceptsCookieFromPreviousSecret confirms the middleware
+// resolves identity from a cookie signed under the rotated-out secret while the
+// provider's SessionSecrets() set is {current, previous}.
+func TestMiddlewareAcceptsCookieFromPreviousSecret(t *testing.T) {
+	prevSecret := []byte("old-rotation-secret-32-bytes-long")
+	curSecret := []byte("new-rotation-secret-32-bytes-long")
+	p := &fakeProvider{mode: ModeEnabled, secret: curSecret, prevSecret: prevSecret}
+	mw := Middleware(p)
+	var gotUID int64
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotUID = UserIDFromContext(r.Context())
+	}))
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	cookie, err := SignSession(prevSecret, 13, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: cookie})
+	h.ServeHTTP(nopWriter{}, req)
+	if gotUID != 13 {
+		t.Errorf("uid = %d; want 13 (cookie signed under previous secret must resolve)", gotUID)
+	}
+
+	// Once the rotation window closes (previous secret dropped), the same
+	// cookie must no longer resolve an identity.
+	p.prevSecret = nil
+	gotUID = 0
+	req2, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req2.AddCookie(&http.Cookie{Name: SessionCookieName, Value: cookie})
+	h.ServeHTTP(nopWriter{}, req2)
+	if gotUID != 0 {
+		t.Errorf("uid = %d; want 0 (cookie under dropped secret must not resolve)", gotUID)
 	}
 }
 
@@ -485,7 +528,7 @@ func TestMakeCSRFToken_SameInputsSameOutput(t *testing.T) {
 
 func TestRequireCSRFToken_AllowsSafeMethod(t *testing.T) {
 	secret := []byte("s")
-	mw := RequireCSRFToken(func() []byte { return secret })
+	mw := RequireCSRFToken(func() [][]byte { return [][]byte{secret} })
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
 	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
@@ -497,7 +540,7 @@ func TestRequireCSRFToken_AllowsSafeMethod(t *testing.T) {
 
 func TestRequireCSRFToken_AllowsUnauthPath(t *testing.T) {
 	secret := []byte("s")
-	mw := RequireCSRFToken(func() []byte { return secret })
+	mw := RequireCSRFToken(func() [][]byte { return [][]byte{secret} })
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
 	// AllowUnauthPath routes must always pass through, even with a stale session cookie.
@@ -515,7 +558,7 @@ func TestRequireCSRFToken_BlocksMutationWithSessionButNoToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
-	mw := RequireCSRFToken(func() []byte { return secret })
+	mw := RequireCSRFToken(func() [][]byte { return [][]byte{secret} })
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
 	// Session cookie present but no CSRF token — cross-origin attack scenario.
@@ -533,7 +576,7 @@ func TestRequireCSRFToken_BlocksMutationWithSessionButNoToken(t *testing.T) {
 
 func TestRequireCSRFToken_AllowsMutationWithAPIKey(t *testing.T) {
 	secret := []byte("s")
-	mw := RequireCSRFToken(func() []byte { return secret })
+	mw := RequireCSRFToken(func() [][]byte { return [][]byte{secret} })
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
 	req, _ := http.NewRequest("POST", "/api/v1/author", nil)
@@ -558,7 +601,7 @@ func TestRequireCSRFToken_BogusAPIKeyDoesNotBypassCSRF(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
-	mw := RequireCSRFToken(func() []byte { return secret })
+	mw := RequireCSRFToken(func() [][]byte { return [][]byte{secret} })
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
 
@@ -586,7 +629,7 @@ func TestRequireCSRFToken_BogusAPIKeyHeaderDoesNotBypassCSRF(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
-	mw := RequireCSRFToken(func() []byte { return secret })
+	mw := RequireCSRFToken(func() [][]byte { return [][]byte{secret} })
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
 
@@ -611,7 +654,7 @@ func TestRequireCSRFToken_AllowsMutationWithValidToken(t *testing.T) {
 	}
 	token := MakeCSRFToken(secret, sessionVal)
 
-	mw := RequireCSRFToken(func() []byte { return secret })
+	mw := RequireCSRFToken(func() [][]byte { return [][]byte{secret} })
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
 	req, _ := http.NewRequest("DELETE", "/api/v1/author/1", nil)
@@ -630,7 +673,7 @@ func TestRequireCSRFToken_BlocksMutationWithWrongToken(t *testing.T) {
 		t.Fatalf("sign: %v", err)
 	}
 
-	mw := RequireCSRFToken(func() []byte { return secret })
+	mw := RequireCSRFToken(func() [][]byte { return [][]byte{secret} })
 	called := false
 	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
 	req, _ := http.NewRequest("PUT", "/api/v1/author/1", nil)
@@ -640,6 +683,51 @@ func TestRequireCSRFToken_BlocksMutationWithWrongToken(t *testing.T) {
 	h.ServeHTTP(w, req)
 	if called {
 		t.Fatal("PUT with wrong CSRF token must be rejected")
+	}
+	if w.status != http.StatusForbidden {
+		t.Errorf("status = %d; want 403", w.status)
+	}
+}
+
+// TestRequireCSRFToken_AcceptsTokenFromPreviousSecret proves the CSRF rotation
+// window: a token minted under the rotated-out secret still validates while the
+// verifier is handed {current, previous}, so an in-flight mutation does not 403
+// the instant the session secret is rotated.
+func TestRequireCSRFToken_AcceptsTokenFromPreviousSecret(t *testing.T) {
+	prevSecret := []byte("old-rotation-secret-32-bytes-long")
+	curSecret := []byte("new-rotation-secret-32-bytes-long")
+
+	// The session cookie itself was signed under the previous secret and is
+	// still valid in the window — bind the CSRF token to it under prevSecret.
+	sessionVal, err := SignSession(prevSecret, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	tokenUnderPrev := MakeCSRFToken(prevSecret, sessionVal)
+
+	mw := RequireCSRFToken(func() [][]byte { return [][]byte{curSecret, prevSecret} })
+	called := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+	req, _ := http.NewRequest("POST", "/api/v1/author", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessionVal})
+	req.Header.Set("X-CSRF-Token", tokenUnderPrev)
+	h.ServeHTTP(nopWriter{}, req)
+	if !called {
+		t.Fatal("CSRF token minted under the previous secret must validate during the rotation window")
+	}
+
+	// A token minted under a secret that is neither current nor previous must
+	// still be rejected — the window does not weaken verification.
+	staleSecret := []byte("stale-secret-not-in-the-window32")
+	tokenUnderStale := MakeCSRFToken(staleSecret, sessionVal)
+	called = false
+	req2, _ := http.NewRequest("POST", "/api/v1/author", nil)
+	req2.AddCookie(&http.Cookie{Name: SessionCookieName, Value: sessionVal})
+	req2.Header.Set("X-CSRF-Token", tokenUnderStale)
+	w := &captureWriter{}
+	h.ServeHTTP(w, req2)
+	if called {
+		t.Fatal("CSRF token minted under a stale secret must be rejected")
 	}
 	if w.status != http.StatusForbidden {
 		t.Errorf("status = %d; want 403", w.status)
@@ -725,7 +813,7 @@ func TestRequireXRequestedWith_AllowsMutationWithCorrectHeader(t *testing.T) {
 func buildCSRFStack(p Provider, secret []byte, inner http.Handler) http.Handler {
 	return Middleware(p)(
 		RequireXRequestedWith(
-			RequireCSRFToken(func() []byte { return secret })(inner),
+			RequireCSRFToken(func() [][]byte { return [][]byte{secret} })(inner),
 		),
 	)
 }

--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -11,7 +11,9 @@ const CSRFCookieName = "bindery_csrf"
 
 // MakeCSRFToken derives a double-submit CSRF token from the raw session cookie
 // value and the session secret. Binding the token to the session value means
-// it is automatically invalidated when the session rotates.
+// it is automatically invalidated when the session rotates. Tokens are always
+// minted with the current secret; see ValidCSRFToken for the rotation-window
+// acceptance of tokens minted under a just-rotated-out secret.
 func MakeCSRFToken(secret []byte, sessionValue string) string {
 	h := hmac.New(sha256.New, secret)
 	h.Write([]byte("csrf:" + sessionValue))
@@ -19,14 +21,24 @@ func MakeCSRFToken(secret []byte, sessionValue string) string {
 }
 
 // ValidCSRFToken reports whether the supplied token matches what we would
-// derive from the session cookie present on r.
-func ValidCSRFToken(secret []byte, r *http.Request, token string) bool {
+// derive from the session cookie present on r, under any of the candidate
+// secrets. During a session-secret rotation the verifier is handed
+// {current, previous} so a CSRF token minted just before the rotation still
+// validates until the holder's next /auth/csrf refresh re-mints it under the
+// current secret. Verification is never weakened: the token is accepted only
+// if it equals (in constant time) a token derived from some candidate secret.
+func ValidCSRFToken(secrets [][]byte, r *http.Request, token string) bool {
 	c, err := r.Cookie(SessionCookieName)
 	if err != nil || c.Value == "" {
 		return false
 	}
-	want := MakeCSRFToken(secret, c.Value)
-	return hmac.Equal([]byte(token), []byte(want))
+	for _, secret := range secrets {
+		want := MakeCSRFToken(secret, c.Value)
+		if hmac.Equal([]byte(token), []byte(want)) {
+			return true
+		}
+	}
+	return false
 }
 
 // RequireCSRFToken rejects state-mutating requests that lack a valid
@@ -34,13 +46,18 @@ func ValidCSRFToken(secret []byte, r *http.Request, token string) bool {
 // AllowUnauthPath routes (login, logout, setup…), and requests with no session
 // cookie.
 //
+// The secrets func returns an ordered candidate set ({current, previous}
+// during a rotation window). The token is validated against every candidate so
+// a token minted just before a session-secret rotation is still accepted until
+// the next /auth/csrf refresh re-mints it under the current secret.
+//
 // The API-key exemption keys off the AuthedViaAPIKey context flag, which
 // Middleware sets only after subtle.ConstantTimeCompare confirms the key. A
 // request carrying a *bogus* ?apikey= no longer skips the CSRF check: it fails
 // key verification, falls through to cookie auth, and is held to the token
 // requirement like any other session request (#708 finding 3). This depends on
 // auth.Middleware running before this middleware — see cmd/bindery/main.go.
-func RequireCSRFToken(secret func() []byte) func(http.Handler) http.Handler {
+func RequireCSRFToken(secrets func() [][]byte) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.Method {
@@ -50,7 +67,7 @@ func RequireCSRFToken(secret func() []byte) func(http.Handler) http.Handler {
 				if !AuthedViaAPIKey(r.Context()) && !AllowUnauthPath(r.URL.Path) {
 					if c, err := r.Cookie(SessionCookieName); err == nil && c.Value != "" {
 						tok := r.Header.Get("X-CSRF-Token")
-						if !ValidCSRFToken(secret(), r, tok) {
+						if !ValidCSRFToken(secrets(), r, tok) {
 							w.Header().Set("Content-Type", "application/json")
 							w.WriteHeader(http.StatusForbidden)
 							_, _ = w.Write([]byte(`{"error":"invalid or missing CSRF token"}`))

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -102,7 +102,16 @@ type UserProvisioner interface {
 type Provider interface {
 	Mode() Mode
 	APIKey() string
+	// SessionSecret returns the current session signing secret — the secret
+	// SignSession must always use when minting a new cookie.
 	SessionSecret() []byte
+	// SessionSecrets returns the ordered candidate set used for *verification*:
+	// {current, previous}. During a secret rotation a cookie signed under the
+	// just-rotated-out secret still verifies. When no previous secret is
+	// configured this is a one-element slice and behavior matches single-secret
+	// verification. Empty/too-short secrets are filtered downstream by
+	// VerifySessionMulti, which fails closed if none remain.
+	SessionSecrets() [][]byte
 	// SetupRequired reports whether no user exists yet (first-run). When true
 	// and the request is unauthenticated, /setup endpoints are allowed through.
 	SetupRequired() bool
@@ -167,7 +176,7 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 			ctx := r.Context()
 			cookieValid := false
 			if c, err := r.Cookie(SessionCookieName); err == nil {
-				if uid, err := VerifySession(p.SessionSecret(), c.Value); err == nil {
+				if uid, err := VerifySessionMulti(p.SessionSecrets(), c.Value); err == nil {
 					ctx = context.WithValue(ctx, userIDCtxKey, uid)
 					ctx = context.WithValue(ctx, userRoleCtxKey, p.UserRole(ctx, uid))
 					cookieValid = true

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -201,6 +201,8 @@ export const api = {
     }),
   authRegenerateApiKey: () =>
     request<{ apiKey: string }>('/auth/apikey/regenerate', { method: 'POST' }),
+  authRotateSessionSecret: () =>
+    request<{ ok: boolean }>('/auth/session-secret/rotate', { method: 'POST' }),
   authSetMode: (mode: AuthStatus['mode']) =>
     request<{ mode: string }>('/auth/mode', {
       method: 'PUT',

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -4608,6 +4608,7 @@ function SecuritySection() {
   const [cfg, setCfg] = useState<AuthConfig | null>(null)
   const [showKey, setShowKey] = useState(false)
   const [regenerating, setRegenerating] = useState(false)
+  const [rotatingSecret, setRotatingSecret] = useState(false)
   const [savingMode, setSavingMode] = useState(false)
   const [copied, setCopied] = useState(false)
 
@@ -4628,6 +4629,19 @@ function SecuritySection() {
       alert('Regenerate failed: ' + (e instanceof Error ? e.message : 'unknown'))
     } finally {
       setRegenerating(false)
+    }
+  }
+
+  const rotateSessionSecret = async () => {
+    if (!confirm('Rotate the session signing secret? Existing logins keep working during a rotation window via the previous secret; a second rotation closes that window.')) return
+    setRotatingSecret(true)
+    try {
+      await api.authRotateSessionSecret()
+      alert('Session secret rotated. New logins sign with the new secret; existing sessions remain valid until the next rotation.')
+    } catch (e) {
+      alert('Rotate failed: ' + (e instanceof Error ? e.message : 'unknown'))
+    } finally {
+      setRotatingSecret(false)
     }
   }
 
@@ -4698,6 +4712,15 @@ function SecuritySection() {
           </div>
         </div>
 
+        <div className="border-t border-slate-200 dark:border-zinc-800 pt-4">
+          <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Session Secret</label>
+          <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
+            Signs session cookies. Rotating it generates a new secret while keeping the previous one valid for a rotation window, so existing logins are not dropped immediately. Rotate twice to fully invalidate sessions signed with the old secret.
+          </p>
+          <button onClick={rotateSessionSecret} disabled={rotatingSecret} className="px-3 py-2 bg-amber-600 hover:bg-amber-500 rounded text-xs font-medium disabled:opacity-50">
+            {rotatingSecret ? '...' : 'Rotate session secret'}
+          </button>
+        </div>
         </>)}
 
         {status?.authenticated && (


### PR DESCRIPTION
Completes the final open piece of #710. PR #737 shipped the v2 session-cookie format (key-id) and the `VerifySessionMulti(secrets, cookie)` primitive, but nothing sourced current+previous secrets or offered a rotation action — so `VerifySessionMulti` was unused. This wires it end-to-end.

## What changed

**Source current + previous secrets**
- New setting key `auth.session_secret_previous` holds the secret rotated out by the most recent rotation. Consulted only for verification; `SignSession` always uses the current secret.
- New `Provider.SessionSecrets() [][]byte` returns the ordered candidate set `{current, previous}`. `auth.Middleware` and the OPDS guard now verify via `VerifySessionMulti`, so a cookie signed under the just-rotated-out secret still verifies during the rotation window. With no previous secret configured the set is `{current}` and behavior is identical to single-secret verification.

**Rotation action**
- New admin-only `POST /api/v1/auth/session-secret/rotate`, mounted inside the existing `RequireAdmin` route group alongside `/auth/apikey/regenerate`. Rotation moves the current secret into the previous slot, generates a fresh current secret, and persists both atomically via `SettingsRepo.SetMany`.
- Client call `authRotateSessionSecret` plus a minimal confirm-gated "Rotate session secret" control in Settings → Security.

**CSRF rotation window**
- `ValidCSRFToken` / `RequireCSRFToken` now accept the `{current, previous}` candidate set, so a CSRF token minted just before a rotation is not 403'd mid-flight. Tokens are still always minted under the current secret and re-minted on the next `/auth/csrf` refresh.

## Security

Verification is not weakened. The fail-closed minimum-secret-length guard from #726 still applies to every candidate (current and previous) inside `VerifySessionMulti`, which fails closed when no usable secret remains. A cookie or CSRF token signed with a secret that is neither current nor previous is rejected. Tests cover: a cookie signed under the previous secret still verifies after rotation; one signed under a never-installed / twice-rotated-out secret is rejected; rotation persists both keys.

## Verification

- `go build ./...` clean; `go vet` clean; `gofmt` clean.
- `go test ./internal/auth/... ./internal/api/... ./internal/db/...` — all pass.
- `npm run typecheck` + `npm run build` — clean.

Note: `web/src/pages/SettingsPage.tsx` may also be edited by parallel PR #666; this edit is confined to the Security section to minimize conflict — a rebase may be needed at merge time.

Closes #710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)