### PR TITLE
fix(db): check Close() error returns in SetMany and RecoverInterruptedImports

### DIFF
--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -263,16 +263,16 @@ func (r *DownloadRepo) RecoverInterruptedImports(ctx context.Context) ([]int64, 
 	for rows.Next() {
 		var id int64
 		if err := rows.Scan(&id); err != nil {
-			rows.Close()
+			_ = rows.Close()
 			return nil, fmt.Errorf("scan interrupted import id: %w", err)
 		}
 		ids = append(ids, id)
 	}
 	if err := rows.Err(); err != nil {
-		rows.Close()
+		_ = rows.Close()
 		return nil, fmt.Errorf("iterate interrupted imports: %w", err)
 	}
-	rows.Close()
+	_ = rows.Close()
 	if len(ids) == 0 {
 		return nil, nil
 	}

--- a/internal/db/settings.go
+++ b/internal/db/settings.go
@@ -66,7 +66,7 @@ func (r *SettingsRepo) SetMany(ctx context.Context, kvs []SettingKV) error {
 	if err != nil {
 		return err
 	}
-	defer stmt.Close()
+	defer func() { _ = stmt.Close() }()
 
 	for _, kv := range kvs {
 		if _, err := stmt.ExecContext(ctx, kv.Key, kv.Value, now); err != nil {


### PR DESCRIPTION
Two pre-existing lint violations on `main` (unchecked `Close()` returns flagged by errcheck/gosec) in code added by #741/#742. Discards the error returns explicitly — no behaviour change. Unblocks the `lint` job for any PR that touches Go code.