### PR TITLE
chore(deploy): promote bindery to 1.13.0

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/vavallee/bindery
-  tag: "1.12.3"
+  tag: "1.13.0"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
Manual recovery for the failing `Deploy to prod` CI job (known deploy-prod race). The v1.13.0 image was built by goreleaser; this bumps `charts/bindery/values.yaml` to 1.13.0 so ArgoCD self-syncs prod.