### PR TITLE
chore(release): bindery v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.13.1] — 2026-05-20
+
+### Changed
+
+- **The book detail page has been redesigned** (#751) — the scattered action links are now consistent buttons, the file path and per-format on-disk status are surfaced clearly, history entries are humanised, and deleting a book and its files moved to a dedicated "Danger zone" that requires an explicit checkbox confirmation. The media-type control sits with the indexer-search action it scopes.
+
 ## [v1.13.0] — 2026-05-20
 
 ### Added

--- a/charts/bindery/Chart.yaml
+++ b/charts/bindery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bindery
 description: Automated book download manager for Usenet and Torrents
 type: application
-version: 0.7.4
-appVersion: "1.13.0"
+version: 0.7.5
+appVersion: "1.13.1"
 home: https://github.com/vavallee/bindery
 sources:
   - https://github.com/vavallee/bindery

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindery-web",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Patch release **v1.13.1** — the book detail page redesign (#751).

- `[Unreleased]` → `[v1.13.1] — 2026-05-20`
- `charts/bindery/Chart.yaml`: version 0.7.4 → 0.7.5, appVersion 1.13.0 → 1.13.1
- `web/package.json`: 1.13.0 → 1.13.1