### PR TITLE
docs: troubleshooting + storage + Readarr-migration wiki pages

### DIFF
--- a/docs/Migrating-From-Readarr-Wiki.md
+++ b/docs/Migrating-From-Readarr-Wiki.md
@@ -1,0 +1,26 @@
+# Migrating from Readarr
+
+## Importing a readarr.db
+
+In **Settings → Import**, upload your `readarr.db`. The import brings in:
+
+- **Authors**, with their monitored state
+- **Indexers**
+- **Download clients**
+- **Blocklist**
+
+Each imported author's catalogue is populated from metadata. Nothing is auto-grabbed — grab from the **Wanted** page when you are ready.
+
+The import dedupes by metadata id, so re-running it is safe: authors that already exist are skipped.
+
+## Two Readarr instances (separate ebook / audiobook)
+
+Bindery is a single instance. One author record covers ebook, audiobook, or both, set per author or per book.
+
+- **Run the import once per `readarr.db`.** The second run skips authors already imported and adds any new ones.
+- **If your two instances are kept in sync** via Import Lists and hold the same authors, importing one database is enough — the other would be all-skipped.
+- **Media type is not carried over.** The import does not know which database is "audiobooks"; every author arrives as a standard record. After importing, set ebook / audiobook / both per author or book where you want audiobooks.
+
+## Bringing in books already on disk
+
+For files already on disk, use **Library Scan**. Parsing of existing filenames is still being improved — if authors and titles come in wrong, check the open issues or ask in support before bulk-renaming.

--- a/docs/Storage-And-Hardlinks-Wiki.md
+++ b/docs/Storage-And-Hardlinks-Wiki.md
@@ -1,0 +1,38 @@
+# Storage layout and hardlinking
+
+## Recommended layout: a single /data mount
+
+Mount one volume so downloads and the library sit on the **same filesystem**:
+
+```
+/data
+  /downloads    completed downloads (your download clients write here)
+  /media        your library (Bindery writes here)
+```
+
+This is the standard *arr layout. It matters because **hardlinks only work within a single filesystem** — if downloads and library are separate mounts, Bindery cannot hardlink between them.
+
+## Import modes
+
+Set the import mode in **Settings → File Naming**.
+
+| Mode | Extra disk | Seeding | Notes |
+|---|---|---|---|
+| **hardlink** | none | kept | Recommended for torrents. The completed file is linked into the library instantly; the download client keeps seeding the same data on disk. Requires downloads and library on one filesystem. |
+| **copy** | doubled | kept | Use when downloads and library are on different filesystems. Copies into the library and leaves the download in place so it can keep seeding. |
+| **move** | none | **broken** | Moves the file out of the download location, so a torrent can no longer seed it. Only suitable for Usenet, or when you do not seed. |
+
+## Download folders
+
+| Variable | Purpose |
+|---|---|
+| `BINDERY_DOWNLOAD_DIR` | Where completed downloads land. Default `/downloads`. |
+| `BINDERY_AUDIOBOOK_DOWNLOAD_DIR` | Optional separate folder for audiobook downloads. Falls back to `BINDERY_DOWNLOAD_DIR`. |
+| `BINDERY_LIBRARY_DIR` | Ebook library destination. |
+| `BINDERY_AUDIOBOOK_DIR` | Audiobook library destination. |
+
+## Torrent vs Usenet folders
+
+There is **no per-protocol download folder setting**, and you do not need one. Each download client (qBittorrent, SABnzbd, NZBGet) decides where it places completed files in its own configuration, so they are already separate.
+
+Point them at subfolders of a common root — for example `/data/downloads/torrents` and `/data/downloads/usenet` — set `BINDERY_DOWNLOAD_DIR` to that root, and Bindery reads each completed download from the path the client reports. Bindery accepts completed downloads anywhere at or under `BINDERY_DOWNLOAD_DIR`, so there is no need to consolidate them into one folder.

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -1,0 +1,40 @@
+# Troubleshooting
+
+Solutions to recurring problems, organised by symptom. Add new entries here as patterns come up in support.
+
+## A grabbed book never imports
+
+The book shows **grabbed** in History and reaches 100% in your download client, but Bindery never imports it. Usually one of two causes.
+
+### qBittorrent 5.x with an old Bindery
+
+qBittorrent 5.x changed the reply it sends when a torrent is added: 4.x answered with the plain text `Ok.`, 5.x answers with a JSON object. Bindery **before 1.12.1** only understood `Ok.`, so it treats every add to a qBittorrent 5.x client as failed even though the torrent was accepted and downloads fine.
+
+You may see `add torrent failed: {"added_torrent_ids":...}` or `failed to send to downloader`. Because Bindery believes the hand-off failed, it never records the download, so it is never imported and no `importFailed` event appears.
+
+**Fix:** upgrade to Bindery **1.12.1 or later** (the current release is recommended). Bindery 1.11.0 and earlier cannot complete torrent grabs against qBittorrent 5.x at all — it is a hard incompatibility. After upgrading, re-grab anything that was stuck.
+
+### Bindery cannot read the completed files
+
+If Bindery and the download client see the storage at different paths (different container mounts), Bindery cannot find the finished download. This usually surfaces as `importFailed` in the Queue.
+
+**Fix:** set a download-client path remap in **Settings → Download clients**, then use **Queue → Retry import**. See [Path remapping](./DEPLOYMENT.md#path-remapping-multi-container--multi-pod-setups) in `DEPLOYMENT.md`.
+
+## "Could not reach the metadata provider" / OpenLibrary timeout
+
+```
+metadata provider unavailable: search authors: Get "https://openlibrary.org/..."
+context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+```
+
+Bindery waited 15 seconds for OpenLibrary (run by the Internet Archive) and got nothing back. Common causes:
+
+- **VPN or datacenter IP** — the Internet Archive throttles or blocks many shared VPN and hosting IP ranges.
+- **OpenLibrary outage** — the Internet Archive has intermittent downtime.
+
+Bindery's primary metadata provider is OpenLibrary or DNB (the German national library). There is currently no English alternative as the primary provider, so the fix is to make OpenLibrary reachable rather than to switch provider.
+
+**Fixes:**
+
+- Behind a VPN: split-tunnel `openlibrary.org` out of the VPN. Metadata lookups do not need VPN protection — only torrent traffic does — so a paid dedicated IP is not required. Switching to a different VPN exit location also often helps, since some exit IPs are blocked and others are not.
+- Not on a VPN: retry later, and check the status of `openlibrary.org` / `archive.org`.


### PR DESCRIPTION
Three wiki pages capturing recurring support patterns. `Closes #627`.

- **`docs/Troubleshooting-Wiki.md`** — the troubleshooting page #627 asked for: "a grabbed book never imports" (qBittorrent 5.x against pre-1.12.1 Bindery; path-remap mismatch) and "Could not reach the metadata provider" (OpenLibrary timeout / VPN-IP throttling). Structured so new entries can be appended.
- **`docs/Storage-And-Hardlinks-Wiki.md`** — the single `/data` mount, copy vs hardlink vs move (and what each does to seeding), the download-folder env vars, and why there is no torrent/usenet folder split.
- **`docs/Migrating-From-Readarr-Wiki.md`** — what the `readarr.db` import does, dedup behaviour, running it once per instance, and the media-type-not-carried caveat.

Docs-only. Drawn from real Discord support threads.