### PR TITLE
perf(importer): cut library-scan reconciliation from O(n^2) to O(n)

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1718,6 +1719,68 @@ func pathUnderDir(path, dir string) bool {
 	return err == nil && !strings.HasPrefix(rel, "..")
 }
 
+// scanBook is the precomputed per-book data the library-scan reconciliation
+// loop needs. Hoisting normalizeTitle into this struct makes it run once per
+// book instead of once per (file, book) pair — see ScanLibrary.
+type scanBook struct {
+	book      *models.Book
+	normTitle string
+	normLen   int
+}
+
+// wordRunsInto appends every maximal [0-9A-Za-z_] run of s, lowercased, to dst
+// and returns the result. These are the runs a `\b…\b` regex (authorTokenRegex,
+// used by authorMatch) treats as words, so an index of them is an exact
+// super-set key for authorMatch candidates. dst is reused to avoid allocations.
+func wordRunsInto(dst []string, s string) []string {
+	start := -1
+	for i := range len(s) {
+		c := s[i]
+		isWord := c == '_' || (c >= '0' && c <= '9') ||
+			(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+		if isWord {
+			if start < 0 {
+				start = i
+			}
+			continue
+		}
+		if start >= 0 {
+			dst = append(dst, strings.ToLower(s[start:i]))
+			start = -1
+		}
+	}
+	if start >= 0 {
+		dst = append(dst, strings.ToLower(s[start:]))
+	}
+	return dst
+}
+
+// firstWordRun returns the first maximal [0-9A-Za-z_] run of tok, lowercased,
+// or "" if tok has no word characters. Whenever authorMatch's `\btok\b` test
+// matches an author name, firstWordRun(tok) is one of that name's word runs —
+// which is what makes authorWordIndex a guaranteed super-set (see ScanLibrary).
+func firstWordRun(tok string) string {
+	start := -1
+	for i := range len(tok) {
+		c := tok[i]
+		isWord := c == '_' || (c >= '0' && c <= '9') ||
+			(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+		if isWord {
+			if start < 0 {
+				start = i
+			}
+			continue
+		}
+		if start >= 0 {
+			return strings.ToLower(tok[start:i])
+		}
+	}
+	if start >= 0 {
+		return strings.ToLower(tok[start:])
+	}
+	return ""
+}
+
 // ScanLibrary walks the library directory (and the separate audiobook directory
 // when configured) for book files not yet tracked in the database and reconciles
 // found files with existing "wanted" book records.
@@ -1797,8 +1860,147 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 	// the correct earlier assignment.
 	reconciledBooks := make(map[int64]bool)
 
+	// Precompute per-book reconciliation data once. The title tier previously
+	// called normalizeTitle(book.Title) inside the per-file loop — a pure,
+	// loop-invariant function recomputed files×books times. Hoisting it here
+	// makes it run once per book. Only "wanted" books can reconcile, so the
+	// candidate set is filtered down up front, and ASIN lookups become O(1).
+	wantedBooks := make([]scanBook, 0, len(allBooks))
+	asinIndex := make(map[string][]scanBook)
+	// booksByAuthor maps an author ID to the indices (into wantedBooks, i.e. in
+	// library order) of that author's wanted books, so the title tier can build
+	// its candidate list from just the matching authors instead of walking
+	// every book in the library.
+	booksByAuthor := make(map[int64][]int)
+	for i := range allBooks {
+		b := &allBooks[i]
+		if b.Status != models.BookStatusWanted {
+			continue
+		}
+		sb := scanBook{book: b, normTitle: normalizeTitle(b.Title)}
+		sb.normLen = len(sb.normTitle)
+		idx := len(wantedBooks)
+		wantedBooks = append(wantedBooks, sb)
+		booksByAuthor[b.AuthorID] = append(booksByAuthor[b.AuthorID], idx)
+		if b.ASIN != "" {
+			asinIndex[b.ASIN] = append(asinIndex[b.ASIN], sb)
+		}
+	}
+
+	// authorWordIndex maps each author-name word run to the authors containing
+	// it. The title tier only matches a book when authorMatch(authorName,
+	// parsed.Author) holds, so resolving the matching authors up front lets the
+	// title comparison skip every other author's books — turning the tier from
+	// O(files × books) into roughly O(files × books-per-author).
+	authorWordIndex := make(map[string][]int64)
+	{
+		var runs []string
+		for id, name := range authorNames {
+			runs = wordRunsInto(runs[:0], name)
+			for _, w := range runs {
+				authorWordIndex[w] = append(authorWordIndex[w], id)
+			}
+		}
+	}
+
+	// matchingAuthors returns the set of author IDs satisfying authorMatch for
+	// parsedAuthor. A nil result means "every author" — authorMatch's contract
+	// for an empty or initials-only parsed author. Candidates come from the
+	// rarest token's word-run bucket (a guaranteed super-set of authorMatch
+	// matches) and are then verified with the exact authorMatch, so the result
+	// is identical to scanning every author. Memoised: a {Author}/{Title}/file
+	// library yields the same parsed author for all of that author's files.
+	authorMatchCache := make(map[string]map[int64]bool)
+	matchingAuthors := func(parsedAuthor string) map[int64]bool {
+		if parsedAuthor == "" {
+			return nil
+		}
+		if set, ok := authorMatchCache[parsedAuthor]; ok {
+			return set
+		}
+		tokens := significantAuthorTokens(parsedAuthor)
+		if len(tokens) == 0 {
+			authorMatchCache[parsedAuthor] = nil
+			return nil
+		}
+		var candidates []int64
+		haveBucket := false
+		for _, tok := range tokens {
+			run := firstWordRun(tok)
+			if run == "" {
+				continue
+			}
+			if bucket := authorWordIndex[run]; !haveBucket || len(bucket) < len(candidates) {
+				candidates, haveBucket = bucket, true
+			}
+		}
+		set := make(map[int64]bool)
+		if !haveBucket {
+			// No indexable token — fall back to scanning every author.
+			for id, name := range authorNames {
+				if authorMatch(name, parsedAuthor) {
+					set[id] = true
+				}
+			}
+		} else {
+			for _, id := range candidates {
+				if !set[id] && authorMatch(authorNames[id], parsedAuthor) {
+					set[id] = true
+				}
+			}
+		}
+		authorMatchCache[parsedAuthor] = set
+		return set
+	}
+
 	var unmatchedFiles []unmatchedFile
 	var reconciled, unmatched, tagReadFailed int
+
+	// tryReconcileTitle attempts to reconcile path to the given wanted book via
+	// the fuzzy title tier, returning true once a book is claimed. The
+	// candidate's author is already known to satisfy authorMatch — see the
+	// title tier in the file loop below.
+	var titleCand []int // reused candidate-index scratch
+	tryReconcileTitle := func(sb *scanBook, path, cleanPath, normParsed, detectedFmt string) bool {
+		b := sb.book
+		if reconciledBooks[b.ID] {
+			return false
+		}
+		// Length gate: Jaro-Winkler is bounded above by 0.8 + 0.2·(minLen/
+		// maxLen), so a score >= 0.85 is impossible once the shorter normalised
+		// title drops below a quarter of the longer. Cheap, never skips a match.
+		lo, hi := sb.normLen, len(normParsed)
+		if lo > hi {
+			lo, hi = hi, lo
+		}
+		if lo == 0 || lo*4 < hi {
+			return false
+		}
+		// Require Jaro-Winkler >= 0.85 to prevent low-confidence matches from
+		// reconciling the wrong book after a delete+rescan (#343).
+		jwScore := textutil.JaroWinkler(sb.normTitle, normParsed)
+		if jwScore < 0.85 {
+			return false
+		}
+		// File must live under the candidate book's effective library root to
+		// prevent cross-author mismapping after delete+rescan (#343).
+		effDir := s.effectiveLibraryDir(ctx, authorMap[b.AuthorID])
+		if !pathUnderDir(path, effDir) {
+			slog.Debug("library scan: title+author match rejected (outside library root)",
+				"title", b.Title, "path", path, "root", effDir)
+			return false
+		}
+		if err := s.books.AddBookFile(ctx, b.ID, detectedFmt, path); err != nil {
+			slog.Error("library scan: failed to update book", "id", b.ID, "error", err)
+			return false
+		}
+		slog.Info("library scan: reconciled book", "title", b.Title, "path", path, "jw", jwScore)
+		trackedPaths[cleanPath] = true
+		reconciledBooks[b.ID] = true
+		reconciled++
+		return true
+	}
+
 	for _, path := range foundFiles {
 		// Skip files already tracked, or files inside a tracked directory
 		// (individual tracks inside an already-imported audiobook folder).
@@ -1855,11 +2057,9 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		matched := false
 		detectedFmt := detectDownloadFormat([]string{path})
 		if parsed.ASIN != "" {
-			for _, b := range allBooks {
+			for _, sb := range asinIndex[parsed.ASIN] {
+				b := sb.book
 				if reconciledBooks[b.ID] {
-					continue
-				}
-				if b.Status != models.BookStatusWanted || b.ASIN != parsed.ASIN {
 					continue
 				}
 				// File must live under the candidate book's effective library root.
@@ -1882,39 +2082,34 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 			}
 		}
 		if !matched && parsed.Title != "" {
-			for _, b := range allBooks {
-				if reconciledBooks[b.ID] {
-					continue
+			// normalizeTitle strips leading articles and inverts comma-suffix
+			// sort form ("Title, A" → "title") so librarian-sorted folders
+			// reconcile correctly (#513). Hoisted: computed once per file.
+			normParsed := normalizeTitle(parsed.Title)
+			// authorMatch is part of the title-tier predicate. Resolving the
+			// matching authors first lets the candidate list be built from just
+			// their books (booksByAuthor), iterated in library order. A nil set
+			// means the parsed author is empty/initials-only — authorMatch then
+			// accepts any author, so every wanted book is a candidate.
+			if authorSet := matchingAuthors(parsed.Author); authorSet == nil {
+				for i := range wantedBooks {
+					if tryReconcileTitle(&wantedBooks[i], path, cleanPath, normParsed, detectedFmt) {
+						matched = true
+						break
+					}
 				}
-				// Require Jaro-Winkler >= 0.85 on normalised titles to prevent
-				// low-confidence matches from reconciling the wrong book after a
-				// delete+rescan cycle (#343). normalizeTitle strips leading articles
-				// and inverts comma-suffix sort form ("Title, A" → "title") so that
-				// librarian-sorted folders reconcile correctly (#513).
-				jwScore := textutil.JaroWinkler(normalizeTitle(b.Title), normalizeTitle(parsed.Title))
-				if b.Status != models.BookStatusWanted ||
-					jwScore < 0.85 ||
-					!authorMatch(authorNames[b.AuthorID], parsed.Author) {
-					continue
+			} else {
+				titleCand = titleCand[:0]
+				for id := range authorSet {
+					titleCand = append(titleCand, booksByAuthor[id]...)
 				}
-				// File must live under the candidate book's effective library root
-				// to prevent cross-author mismapping after delete+rescan (#343).
-				effDir := s.effectiveLibraryDir(ctx, authorMap[b.AuthorID])
-				if !pathUnderDir(path, effDir) {
-					slog.Debug("library scan: title+author match rejected (outside library root)",
-						"title", b.Title, "path", path, "root", effDir)
-					continue
+				slices.Sort(titleCand) // restore library order across authors
+				for _, idx := range titleCand {
+					if tryReconcileTitle(&wantedBooks[idx], path, cleanPath, normParsed, detectedFmt) {
+						matched = true
+						break
+					}
 				}
-				if err := s.books.AddBookFile(ctx, b.ID, detectedFmt, path); err != nil {
-					slog.Error("library scan: failed to update book", "id", b.ID, "error", err)
-					continue
-				}
-				slog.Info("library scan: reconciled book", "title", b.Title, "path", path, "jw", jwScore)
-				trackedPaths[cleanPath] = true
-				reconciledBooks[b.ID] = true
-				reconciled++
-				matched = true
-				break
 			}
 		}
 

--- a/internal/importer/scanner_authorscope_test.go
+++ b/internal/importer/scanner_authorscope_test.go
@@ -1,0 +1,89 @@
+package importer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestScanLibrary_HyphenatedAuthorReconciles guards the author-scoping word-run
+// index: a hyphenated author name must still resolve. "Mary-Kate" splits into
+// the runs "mary" and "kate", and the parsed token "mary-kate" indexes on its
+// first run "mary" — the index must still be a super-set of authorMatch.
+func TestScanLibrary_HyphenatedAuthorReconciles(t *testing.T) {
+	libDir := t.TempDir()
+	bookDir := filepath.Join(libDir, "Mary-Kate Olsen", "Influence")
+	if err := os.MkdirAll(bookDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	epub := filepath.Join(bookDir, "Influence.epub")
+	if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, books, authors, ctx := scannerFixture(t, libDir)
+	author := &models.Author{ForeignID: "OL-hy", Name: "Mary-Kate Olsen", SortName: "Olsen, Mary-Kate"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{ForeignID: "OL-hy-b", AuthorID: author.ID, Title: "Influence", Status: models.BookStatusWanted}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	got, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FilePath != epub {
+		t.Errorf("hyphenated author: want FilePath=%q, got %q", epub, got.FilePath)
+	}
+}
+
+// TestScanLibrary_SharedFirstNameScopedToRightAuthor — two authors share the
+// first name "John" and own an identically titled book. The file under
+// "John Smith/" must reconcile Smith's book and leave Carter's untouched: the
+// word-run index may bucket both authors under "john", but the exact
+// authorMatch verification must reject the cross-author candidate.
+func TestScanLibrary_SharedFirstNameScopedToRightAuthor(t *testing.T) {
+	libDir := t.TempDir()
+	bookDir := filepath.Join(libDir, "John Smith", "Quantum Gardens")
+	if err := os.MkdirAll(bookDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	epub := filepath.Join(bookDir, "Quantum Gardens.epub")
+	if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, books, authors, ctx := scannerFixture(t, libDir)
+	smith := &models.Author{ForeignID: "OL-js", Name: "John Smith", SortName: "Smith, John"}
+	carter := &models.Author{ForeignID: "OL-jc", Name: "John Carter", SortName: "Carter, John"}
+	for _, a := range []*models.Author{smith, carter} {
+		if err := authors.Create(ctx, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+	smithBook := &models.Book{ForeignID: "OL-js-b", AuthorID: smith.ID, Title: "Quantum Gardens", Status: models.BookStatusWanted}
+	carterBook := &models.Book{ForeignID: "OL-jc-b", AuthorID: carter.ID, Title: "Quantum Gardens", Status: models.BookStatusWanted}
+	for _, bk := range []*models.Book{smithBook, carterBook} {
+		if err := books.Create(ctx, bk); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s.ScanLibrary(ctx)
+
+	gotSmith, _ := books.GetByID(ctx, smithBook.ID)
+	if gotSmith.FilePath != epub {
+		t.Errorf("Smith book: want FilePath=%q, got %q", epub, gotSmith.FilePath)
+	}
+	gotCarter, _ := books.GetByID(ctx, carterBook.ID)
+	if gotCarter.FilePath != "" {
+		t.Errorf("Carter book must stay unreconciled, got FilePath=%q", gotCarter.FilePath)
+	}
+}

--- a/internal/importer/scanner_bench_test.go
+++ b/internal/importer/scanner_bench_test.go
@@ -1,0 +1,158 @@
+package importer
+
+// Benchmarks for the library-scan hot path.
+//
+// ScanLibrary reconciles every untracked file on disk against the "wanted"
+// books in the database. These benchmarks measure that scaling for two
+// library layouts and isolate the per-comparison primitives.
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/textutil"
+)
+
+// silenceSlog discards log output for the duration of a benchmark — ScanLibrary
+// logs two lines per call and bindery routes slog to stdout, which otherwise
+// drowns the benchmark results. Restored on cleanup.
+func silenceSlog(tb testing.TB) {
+	tb.Helper()
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	tb.Cleanup(func() { slog.SetDefault(prev) })
+}
+
+// benchScannerFixture mirrors scannerFixture (scanner_extra_test.go) but accepts
+// testing.TB so benchmarks can share it.
+func benchScannerFixture(tb testing.TB, libraryDir string) (*Scanner, *db.BookRepo, *db.AuthorRepo, context.Context) {
+	tb.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { _ = database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	history := db.NewHistoryRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+
+	s := NewScanner(downloads, clients, books, authors, history, libraryDir, "", "", "", "")
+	return s, books, authors, context.Background()
+}
+
+// seedLibrary creates totalBooks untracked .epub files on disk plus totalBooks
+// matching "wanted" book rows. File titles and book titles use disjoint
+// vocabularies so Jaro-Winkler stays below the 0.85 reconcile threshold — the
+// scan does its full matching work every iteration with no reconcile side
+// effects, keeping iterations identical.
+//
+// nested=true uses the realistic {Author}/{Title}/file.epub layout with 4
+// books per author, so ParseFilename recovers an author and the title tier can
+// scope comparison to that author. nested=false dumps every file flat in the
+// library root under one author — the worst case, no author scoping possible.
+func seedLibrary(tb testing.TB, libDir string, books *db.BookRepo, authors *db.AuthorRepo, totalBooks int, nested bool) {
+	tb.Helper()
+	ctx := context.Background()
+	const booksPerAuthor = 4
+	var author *models.Author
+	for i := range totalBooks {
+		if author == nil || (nested && i%booksPerAuthor == 0) {
+			author = &models.Author{
+				ForeignID: fmt.Sprintf("OL-A-%06d", i),
+				Name:      fmt.Sprintf("Firstname%06d Lastname%06d", i, i),
+				SortName:  fmt.Sprintf("Lastname%06d, Firstname%06d", i, i),
+			}
+			if err := authors.Create(ctx, author); err != nil {
+				tb.Fatal(err)
+			}
+		}
+		title := fmt.Sprintf("Catalogue Record Distinct Entry %06d", i)
+		var fp string
+		if nested {
+			dir := filepath.Join(libDir, author.Name, title)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				tb.Fatal(err)
+			}
+			fp = filepath.Join(dir, fmt.Sprintf("Untracked Manuscript Number %06d.epub", i))
+		} else {
+			fp = filepath.Join(libDir, fmt.Sprintf("Untracked Manuscript Number %06d.epub", i))
+		}
+		if err := os.WriteFile(fp, []byte("x"), 0o644); err != nil {
+			tb.Fatal(err)
+		}
+		bk := &models.Book{
+			ForeignID: fmt.Sprintf("OL-B-%06d", i),
+			AuthorID:  author.ID,
+			Title:     title,
+			Status:    models.BookStatusWanted,
+		}
+		if err := books.Create(ctx, bk); err != nil {
+			tb.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScanLibrary measures a full ScanLibrary pass. "nested" is the
+// realistic per-author layout; "flat" is the worst case with no author hints.
+func BenchmarkScanLibrary(b *testing.B) {
+	for _, layout := range []struct {
+		name   string
+		nested bool
+	}{{"nested", true}, {"flat", false}} {
+		for _, n := range []int{500, 2000, 8000} {
+			b.Run(fmt.Sprintf("%s-%d", layout.name, n), func(b *testing.B) {
+				silenceSlog(b)
+				libDir := b.TempDir()
+				s, books, authors, ctx := benchScannerFixture(b, libDir)
+				seedLibrary(b, libDir, books, authors, n, layout.nested)
+				b.ReportAllocs()
+				for b.Loop() {
+					s.ScanLibrary(ctx)
+				}
+			})
+		}
+	}
+}
+
+// Package-level sinks defeat dead-code elimination in the micro-benchmarks.
+var (
+	sinkString string
+	sinkFloat  float64
+)
+
+// BenchmarkNormalizeTitle isolates the per-call cost of normalizeTitle.
+func BenchmarkNormalizeTitle(b *testing.B) {
+	titles := []string{
+		"The Fragile Threads of Power",
+		"Fragile Threads of Power, The",
+		"A Darker Shade of Magic",
+		"Catalogue Record Distinct Entry 01234",
+	}
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		sinkString = normalizeTitle(titles[i%len(titles)])
+		i++
+	}
+}
+
+// BenchmarkJaroWinkler isolates the per-call cost of the fuzzy title-distance
+// function the title tier runs per candidate pair.
+func BenchmarkJaroWinkler(b *testing.B) {
+	left := normalizeTitle("Untracked Manuscript Number 01234")
+	right := normalizeTitle("Catalogue Record Distinct Entry 01234")
+	b.ReportAllocs()
+	for b.Loop() {
+		sinkFloat = textutil.JaroWinkler(left, right)
+	}
+}

--- a/internal/textutil/jarowinkler.go
+++ b/internal/textutil/jarowinkler.go
@@ -17,8 +17,21 @@ func JaroWinkler(s, t string) float64 {
 		matchWindow = 0
 	}
 
-	sMatch := make([]bool, sl)
-	tMatch := make([]bool, tl)
+	// Stack-allocated scratch for the common case (titles, author names);
+	// avoids two heap allocations per call on the library-scan hot path.
+	// Inputs longer than the buffer fall back to heap allocation.
+	var sBuf, tBuf [256]bool
+	var sMatch, tMatch []bool
+	if sl <= len(sBuf) {
+		sMatch = sBuf[:sl]
+	} else {
+		sMatch = make([]bool, sl)
+	}
+	if tl <= len(tBuf) {
+		tMatch = tBuf[:tl]
+	} else {
+		tMatch = make([]bool, tl)
+	}
 	m := 0
 	for i := 0; i < sl; i++ {
 		lo := max(0, i-matchWindow)


### PR DESCRIPTION
## Summary

`ScanLibrary` reconciled every untracked file against every wanted book — running Jaro-Winkler and `normalizeTitle` once per *(file, book)* pair, i.e. O(files × books). This scopes the fuzzy title match to the file's author and hoists loop-invariant work out of the inner loop, making a realistic per-author library scan **linear** in library size. Closes #756.

## Implementation notes

- **Hoist `normalizeTitle(book.Title)`** into a per-book precompute — a pure, loop-invariant function previously recomputed files × books times.
- **Index wanted books** by ASIN (O(1) lookup) and by author.
- **Resolve matching authors** via an inverted index of author-name word runs — a *provable super-set* of `authorMatch` candidates — then verify each with the exact `authorMatch`, memoised per parsed author. The result is identical to scanning every author.
- **Iterate only the matching authors' books**, sorted to preserve the library-order "first match wins" tiebreak.
- Provably-safe Jaro-Winkler **length gate** (`JW ≥ 0.85 ⇒ minLen/maxLen ≥ 0.25`).
- **Stack-allocate `JaroWinkler`'s match scratch arrays** — 0 allocations, ~30% faster — benefits every caller.

## Why minimal / scope decisions

Match results and the first-match tiebreak are unchanged — this is a performance change, not a behaviour change. A flat library with no `{Author}/` directories has no author hint to scope on and stays O(n²); the allocation reductions still apply there. No public API, config, or behaviour change, so no doc updates (per the `commits` skill doc-gate).

## Results

`benchstat`, baseline vs fixed (AMD Ryzen 7 5700X3D, `-count=6`, all `p=0.002`):

| Benchmark | Before | After | Δ |
|-----------|--------|-------|---|
| `ScanLibrary/nested-2000` — time | 3.63 s | 0.080 s | **−97.8%** |
| `ScanLibrary/nested-2000` — mem | 749 MiB | 12.3 MiB | −98.4% |
| `ScanLibrary/nested-2000` — allocs | 16.2 M | 163 k | −99.0% |
| `ScanLibrary/flat-2000` — time | 3.60 s | 1.83 s | −49.2% |
| `JaroWinkler` | 547 ns / 2 allocs | 385 ns / 0 allocs | −30% / −100% |

The `nested` (per-author) layout now scales **linearly**: 500 / 2000 / 8000 books run in 19.7 ms / 79.6 ms / 323 ms — 4× books → ~4× time, versus ~15× before.

## Checklist

- [x] Tests added or updated — new `scanner_authorscope_test.go` (hyphenated + shared-name authors); all 11 existing `ScanLibrary` tests pass
- [x] Doc-update gate cleared — pure performance change, no `docs/` / `README` / godoc / Helm impact
- [x] Wiki pages updated if user-facing behaviour changed — N/A, no user-facing change

## Test plan

- [x] `make test` — `go test -race -coverprofile -covermode=atomic ./cmd/... ./internal/...` — 46 packages, pass
- [x] `make lint-go` — `golangci-lint run ./...` — 0 issues
- [x] `go test -bench=BenchmarkScanLibrary -benchmem -count=6 ./internal/importer/` — see Results
- [ ] `cd web && npm run build` — N/A, Go-only change, no `web/` files touched
