### PR TITLE
fix(importer): derive library-scan author/title from the folder layout (#754)

### DIFF
--- a/docs/Migrating-From-Readarr-Wiki.md
+++ b/docs/Migrating-From-Readarr-Wiki.md
@@ -23,4 +23,4 @@ Bindery is a single instance. One author record covers ebook, audiobook, or both
 
 ## Bringing in books already on disk
 
-For files already on disk, use **Library Scan**. Parsing of existing filenames is still being improved — if authors and titles come in wrong, check the open issues or ask in support before bulk-renaming.
+For files already on disk, use **Library Scan**. It takes the author and title from your folder layout: a file under `{Author}/{Book}/` — Readarr's and Calibre's default structure — is matched on the folder names, so the filename convention (`Author - Title` vs `Title - Author`) does not matter. Loose files with no author/book folders fall back to filename parsing, which can still be ambiguous, so keep an organised folder structure for the most reliable scan.

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1781,6 +1781,41 @@ func firstWordRun(tok string) string {
 	return ""
 }
 
+// cleanLayoutTitle strips bracket/paren annotations from a book-folder name —
+// Calibre's " (id)", Readarr's " (year)" — so it matches the stored title.
+func cleanLayoutTitle(dir string) string {
+	s := cleanRe.ReplaceAllString(dir, "")
+	s = multiSp.ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+// authorTitleFromLayout derives author and title from a library file's folder
+// hierarchy. A file under <root>/<Author>/<Book>/<file> names both
+// unambiguously and is dash-safe, unlike splitting an "Author - Title" or
+// "Title - Author" filename (#754). title is "" when only the author folder is
+// present; ok is false when the file is not nested under any root.
+func authorTitleFromLayout(path string, roots ...string) (author, title string, ok bool) {
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		switch parts := strings.Split(rel, string(filepath.Separator)); {
+		case len(parts) >= 3:
+			// <root>/<Author>/…/<Book>/<file>: first dir is the author,
+			// the file's immediate parent dir is the book title.
+			return strings.TrimSpace(parts[0]), cleanLayoutTitle(parts[len(parts)-2]), true
+		case len(parts) == 2:
+			// <root>/<Author>/<file>: only the author is unambiguous.
+			return strings.TrimSpace(parts[0]), "", true
+		}
+	}
+	return "", "", false
+}
+
 // ScanLibrary walks the library directory (and the separate audiobook directory
 // when configured) for book files not yet tracked in the database and reconciles
 // found files with existing "wanted" book records.
@@ -2009,17 +2044,25 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 			continue
 		}
 
-		// Parse the filename for title/author hints. If the filename alone
-		// doesn't yield an author (e.g. the file is named just "book.epub"),
-		// fall back to the first directory component relative to whichever
-		// library root contains the file — most layouts are
-		// {Author}/{Title}/filename.ext.
+		// Parse the filename for title/author hints, then let the folder
+		// hierarchy correct them. A file under <root>/<Author>/<Book>/<file>
+		// names author and title unambiguously and dash-safe, unlike splitting
+		// an "Author - Title" / "Title - Author" filename — the scan must not
+		// assume a single filename order (#754).
 		parsed := ParseFilename(path)
+		if a, t, ok := authorTitleFromLayout(path, s.libraryDir, s.audiobookDir); ok {
+			if a != "" {
+				parsed.Author = a
+			}
+			if t != "" {
+				parsed.Title = t
+			}
+		}
 
-		// Prefer embedded audio tags over filename parsing for audiobook
-		// files. Well-tagged M4B/MP3 releases carry the author, title and
-		// often an ASIN in their ID3/iTunes atoms; using them avoids the
-		// fuzzy-match noise seen on users' organised libraries (#303).
+		// Prefer embedded audio tags over filename and folder parsing for
+		// audiobook files. Well-tagged M4B/MP3 releases carry the author,
+		// title and often an ASIN in their ID3/iTunes atoms; using them avoids
+		// the fuzzy-match noise seen on users' organised libraries (#303).
 		if IsAudioTagFile(path) {
 			if tags, err := ReadAudioTags(path); err != nil {
 				slog.Warn("library scan: tag read failed, falling back to filename",
@@ -2034,21 +2077,6 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 				}
 				if tags.ASIN != "" {
 					parsed.ASIN = tags.ASIN
-				}
-			}
-		}
-
-		if parsed.Author == "" {
-			for _, root := range []string{s.libraryDir, s.audiobookDir} {
-				if root == "" {
-					continue
-				}
-				if rel, err := filepath.Rel(root, path); err == nil && !strings.HasPrefix(rel, "..") {
-					parts := strings.SplitN(rel, string(filepath.Separator), 2)
-					if len(parts) >= 2 {
-						parsed.Author = parts[0]
-						break
-					}
 				}
 			}
 		}

--- a/internal/importer/scanner_bench_test.go
+++ b/internal/importer/scanner_bench_test.go
@@ -51,15 +51,17 @@ func benchScannerFixture(tb testing.TB, libraryDir string) (*Scanner, *db.BookRe
 }
 
 // seedLibrary creates totalBooks untracked .epub files on disk plus totalBooks
-// matching "wanted" book rows. File titles and book titles use disjoint
-// vocabularies so Jaro-Winkler stays below the 0.85 reconcile threshold — the
-// scan does its full matching work every iteration with no reconcile side
-// effects, keeping iterations identical.
+// matching "wanted" book rows. The names the scan reads (folder names when
+// nested, filename when flat) use a vocabulary disjoint from the book titles,
+// so Jaro-Winkler stays below the 0.85 reconcile threshold — the scan does its
+// full matching work every iteration with no reconcile side effects, keeping
+// iterations identical.
 //
-// nested=true uses the realistic {Author}/{Title}/file.epub layout with 4
-// books per author, so ParseFilename recovers an author and the title tier can
-// scope comparison to that author. nested=false dumps every file flat in the
-// library root under one author — the worst case, no author scoping possible.
+// nested=true uses the realistic {Author}/{Book}/file.epub layout with 4 books
+// per author, so the scan recovers the author from the folder hierarchy and
+// the title tier can scope comparison to that author. nested=false dumps every
+// file flat in the library root under one author — the worst case, no author
+// scoping possible.
 func seedLibrary(tb testing.TB, libDir string, books *db.BookRepo, authors *db.AuthorRepo, totalBooks int, nested bool) {
 	tb.Helper()
 	ctx := context.Background()
@@ -76,16 +78,20 @@ func seedLibrary(tb testing.TB, libDir string, books *db.BookRepo, authors *db.A
 				tb.Fatal(err)
 			}
 		}
-		title := fmt.Sprintf("Catalogue Record Distinct Entry %06d", i)
+		dbTitle := fmt.Sprintf("Catalogue Record Distinct Entry %06d", i)
+		fileBase := fmt.Sprintf("Untracked Manuscript Number %06d.epub", i)
 		var fp string
 		if nested {
-			dir := filepath.Join(libDir, author.Name, title)
+			// The book-folder name is deliberately disjoint from dbTitle: the
+			// scan derives the title from this folder (#754), so a matching
+			// name here would reconcile the file and skew later iterations.
+			dir := filepath.Join(libDir, author.Name, fmt.Sprintf("Unmatched Folder Volume %06d", i))
 			if err := os.MkdirAll(dir, 0o755); err != nil {
 				tb.Fatal(err)
 			}
-			fp = filepath.Join(dir, fmt.Sprintf("Untracked Manuscript Number %06d.epub", i))
+			fp = filepath.Join(dir, fileBase)
 		} else {
-			fp = filepath.Join(libDir, fmt.Sprintf("Untracked Manuscript Number %06d.epub", i))
+			fp = filepath.Join(libDir, fileBase)
 		}
 		if err := os.WriteFile(fp, []byte("x"), 0o644); err != nil {
 			tb.Fatal(err)
@@ -93,7 +99,7 @@ func seedLibrary(tb testing.TB, libDir string, books *db.BookRepo, authors *db.A
 		bk := &models.Book{
 			ForeignID: fmt.Sprintf("OL-B-%06d", i),
 			AuthorID:  author.ID,
-			Title:     title,
+			Title:     dbTitle,
 			Status:    models.BookStatusWanted,
 		}
 		if err := books.Create(ctx, bk); err != nil {

--- a/internal/importer/scanner_layout_test.go
+++ b/internal/importer/scanner_layout_test.go
@@ -1,0 +1,95 @@
+package importer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestAuthorTitleFromLayout unit-tests the folder-hierarchy resolver: author is
+// the first directory under the root, title is the file's immediate parent
+// directory with bracket/paren annotations stripped (#754).
+func TestAuthorTitleFromLayout(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct {
+		name         string
+		path         string
+		wantA, wantT string
+		wantOK       bool
+	}{
+		{
+			name:  "author/book/file",
+			path:  filepath.Join(root, "Cal Newport", "Deep Work", "Cal Newport - Deep Work.epub"),
+			wantA: "Cal Newport", wantT: "Deep Work", wantOK: true,
+		},
+		{
+			name:  "calibre id stripped from book folder",
+			path:  filepath.Join(root, "Andy Weir", "Project Hail Mary (4242)", "x.epub"),
+			wantA: "Andy Weir", wantT: "Project Hail Mary", wantOK: true,
+		},
+		{
+			name:  "author/series/book/file uses first and immediate-parent dirs",
+			path:  filepath.Join(root, "Brandon Sanderson", "Mistborn", "The Final Empire", "x.epub"),
+			wantA: "Brandon Sanderson", wantT: "The Final Empire", wantOK: true,
+		},
+		{
+			name:  "author folder only",
+			path:  filepath.Join(root, "Isaac Asimov", "foundation.epub"),
+			wantA: "Isaac Asimov", wantT: "", wantOK: true,
+		},
+		{
+			name:  "file directly in root has no hierarchy",
+			path:  filepath.Join(root, "loose.epub"),
+			wantA: "", wantT: "", wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a, tl, ok := authorTitleFromLayout(c.path, root)
+			if a != c.wantA || tl != c.wantT || ok != c.wantOK {
+				t.Errorf("authorTitleFromLayout(%q) = (%q, %q, %v); want (%q, %q, %v)",
+					c.path, a, tl, ok, c.wantA, c.wantT, c.wantOK)
+			}
+		})
+	}
+}
+
+// TestScanLibrary_ReadarrFolderLayoutFixesSwappedFilename is the #754
+// regression test: a Readarr-style "{Author} - {Title}.epub" file in an
+// <Author>/<Book>/ hierarchy. ParseFilename alone reads the filename as
+// "Title - Author" and transposes the two; the scan must instead take author
+// and title from the unambiguous folder names and reconcile correctly.
+func TestScanLibrary_ReadarrFolderLayoutFixesSwappedFilename(t *testing.T) {
+	libDir := t.TempDir()
+	bookDir := filepath.Join(libDir, "Cal Newport", "Deep Work")
+	if err := os.MkdirAll(bookDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Readarr's default "{Author Name} - {Book Title}" filename.
+	epub := filepath.Join(bookDir, "Cal Newport - Deep Work.epub")
+	if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, books, authors, ctx := scannerFixture(t, libDir)
+	author := &models.Author{ForeignID: "OL-cn", Name: "Cal Newport", SortName: "Newport, Cal"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{ForeignID: "OL-dw", AuthorID: author.ID, Title: "Deep Work", Status: models.BookStatusWanted}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	got, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FilePath != epub {
+		t.Errorf("Readarr-layout file must reconcile via the folder names, want FilePath=%q, got %q", epub, got.FilePath)
+	}
+}


### PR DESCRIPTION
## Summary

The library scan read author and title **transposed** for essentially every migrated library. `ParseFilename` assumes filenames are `Title - Author`, but Readarr's default format and Calibre both write `Author - Title` — so `Cal Newport - Deep Work.epub` scanned in as a book titled "Cal Newport" by an author "Deep Work", and downstream metadata matching failed. Closes #754.

## Implementation notes

The folder hierarchy states author and title unambiguously and is dash-safe, unlike splitting a filename. `ScanLibrary` now derives them from it:

- A file under `<root>/<Author>/<Book>/<file>` takes its **author** from the first directory and its **title** from the file's immediate parent directory (`authorTitleFromLayout`).
- Calibre/Readarr ` (id)` / ` (year)` book-folder annotations are stripped (`cleanLayoutTitle`).
- Precedence is **embedded audio tags > folder hierarchy > filename parse** — well-tagged audiobooks still win (#303); the filename parse is used only when no folder hierarchy is present.
- This replaces the old author-only directory inference, which fired only when the filename produced *no* author — useless against this bug, where the filename produces the *wrong* author.

## Why minimal / scope decisions

- `ParseFilename` itself is unchanged: a bare filename genuinely cannot disambiguate `Author - Title` from `Title - Author` without context, so the fix lives at the scan layer, where the folder context exists.
- Loose files with no `{Author}/{Book}/` folders still fall back to filename parsing — documented as a known limitation in the migration wiki.
- `findExistingInDir` (a separate pre-search code path) shares the same latent filename assumption; out of scope here, noted as a follow-up.

## Tests

| Test | Covers |
|------|--------|
| `TestAuthorTitleFromLayout` | resolver unit test — Author/Book, Calibre `(id)` stripping, Author/Series/Book, author-only, no-hierarchy |
| `TestScanLibrary_ReadarrFolderLayoutFixesSwappedFilename` | end-to-end #754 regression — a `{Author} - {Title}.epub` in an `<Author>/<Book>/` tree must reconcile via the folder names (fails on old code, passes now) |

All existing `ScanLibrary` tests still pass; the scan benchmark's seed layout was updated so folder names stay disjoint from book titles.

## Checklist

- [x] Tests added or updated — new `scanner_layout_test.go`; full importer suite passes
- [x] Doc-update gate cleared — `docs/Migrating-From-Readarr-Wiki.md` updated (it previously documented this bug as a known limitation)
- [x] Wiki pages updated if user-facing behaviour changed — migration wiki updated

## Test plan

- [x] `go test ./internal/importer/ ./internal/textutil/` + `go build ./internal/... ./cmd/...` — pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -bench=BenchmarkScanLibrary -benchmem ./internal/importer/` — scan stays linear (~100 ms / 2000 books), no reconcile side effects
- [x] full `make test` (`-race`, all packages) — run locally; also gated by CI `validate (Go)`
- [ ] `cd web && npm run build` — N/A, no `web/` files touched
