### PR TITLE
chore(release): bindery v1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.13.2] — 2026-05-20
+
+### Changed
+
+- **The library scan is now linear in library size instead of quadratic** (#757) — reconciling on-disk files against the database ran a Jaro-Winkler title comparison for every *(file, book)* pair, an O(files × books) cost that made the first scan of a large migrated library take minutes and allocate gigabytes of memory. The title comparison is now scoped to the file's author and the loop-invariant title normalisation is hoisted out of the inner loop, so a realistic per-author library scans in time proportional to its size — a 2,000-book library drops from ~3.6 s to ~0.08 s, allocating 98% less memory.
+
+### Fixed
+
+- **The library scan no longer transposes author and title for Readarr- and Calibre-organised libraries** (#754) — the scan inferred author and title by splitting the filename on `" - "`, assuming a `Title - Author` order, but Readarr's default naming and Calibre both write `Author - Title`, so every migrated book scanned in with the two swapped and downstream metadata matching failed. The scan now derives author and title from the `{Author}/{Book}/` folder hierarchy — unambiguous and dash-safe — and falls back to filename parsing only when no such hierarchy is present.
+
+### Docs
+
+- **Added wiki pages for troubleshooting, storage and hardlinking, and migrating from Readarr** (#755) — new guides under `docs/` covering common setup problems, how Bindery's storage layout and hardlinking behave, and the path for bringing an existing Readarr library across.
+
 ## [v1.13.1] — 2026-05-20
 
 ### Changed

--- a/charts/bindery/Chart.yaml
+++ b/charts/bindery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bindery
 description: Automated book download manager for Usenet and Torrents
 type: application
-version: 0.7.5
-appVersion: "1.13.1"
+version: 0.7.6
+appVersion: "1.13.2"
 home: https://github.com/vavallee/bindery
 sources:
   - https://github.com/vavallee/bindery

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindery-web",
   "private": true,
-  "version": "1.13.1",
+  "version": "1.13.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Patch release bundling everything merged since `v1.13.1`:

| PR | Change |
|----|--------|
| #757 | `perf(importer)` — library scan reconciliation O(n²) → O(n) |
| #754 / #758 | `fix(importer)` — scan no longer transposes author/title on Readarr/Calibre-organised libraries |
| #755 | `docs` — troubleshooting, storage/hardlinking, and Readarr-migration wiki pages |

Bumps `appVersion` 1.13.1 → 1.13.2, Helm chart `version` 0.7.5 → 0.7.6, and `web/package.json` to 1.13.2; adds the `## [v1.13.2]` CHANGELOG section.

## Checklist

- [x] CHANGELOG `## [v1.13.2]` section drafted — Changed / Fixed / Docs, every PR since `v1.13.1` represented
- [x] Version bumped — Chart `version` + `appVersion`, `web/package.json`
- [x] Patch bump is correct per SemVer — perf, bug fix, and docs only; no new features or breaking changes
- [x] No `charts/bindery/values.yaml` digest edit — owned by the deploy bot

## Test plan

- [x] Each bundled PR passed full CI and `make test` before merge
- [ ] Release CI on this PR
