### PR TITLE
feat(web): redesign the Wanted page

### DIFF
--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -152,7 +152,15 @@
     "ebookDone": "📖 ✓",
     "audiobookDone": "🎧 ✓",
     "selectBook": "{{title}} auswählen",
-    "unmonitorHint": "Überwachung dieses Buches beenden"
+    "unmonitorHint": "Überwachung dieses Buches beenden",
+    "showExcluded": "Ausgeschlossene anzeigen",
+    "excluded": "Ausgeschlossen",
+    "colTitleAuthor": "Titel & Autor",
+    "colFormat": "Format",
+    "colActions": "Aktionen",
+    "noCover": "Kein Cover",
+    "authorUnknown": "Autor unbekannt",
+    "changeFormat": "Format für {{title}} ändern"
   },
   "history": {
     "title": "Verlauf",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -173,7 +173,13 @@
     "selectBook": "Select {{title}}",
     "unmonitorHint": "Stop monitoring this book",
     "showExcluded": "Show excluded",
-    "excluded": "Excluded"
+    "excluded": "Excluded",
+    "colTitleAuthor": "Title & author",
+    "colFormat": "Format",
+    "colActions": "Actions",
+    "noCover": "No cover",
+    "authorUnknown": "Author unknown",
+    "changeFormat": "Change format for {{title}}"
   },
   "history": {
     "title": "History",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -171,7 +171,13 @@
     "selectBook": "Seleccionar {{title}}",
     "unmonitorHint": "Dejar de monitorizar este libro",
     "showExcluded": "Mostrar excluidos",
-    "excluded": "Excluido"
+    "excluded": "Excluido",
+    "colTitleAuthor": "Título y autor",
+    "colFormat": "Formato",
+    "colActions": "Acciones",
+    "noCover": "Sin portada",
+    "authorUnknown": "Autor desconocido",
+    "changeFormat": "Cambiar formato de {{title}}"
   },
   "history": {
     "title": "Historial",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -152,7 +152,15 @@
     "ebookDone": "📖 ✓",
     "audiobookDone": "🎧 ✓",
     "selectBook": "Sélectionner {{title}}",
-    "unmonitorHint": "Arrêter la surveillance de ce livre"
+    "unmonitorHint": "Arrêter la surveillance de ce livre",
+    "showExcluded": "Afficher les exclus",
+    "excluded": "Exclu",
+    "colTitleAuthor": "Titre et auteur",
+    "colFormat": "Format",
+    "colActions": "Actions",
+    "noCover": "Aucune couverture",
+    "authorUnknown": "Auteur inconnu",
+    "changeFormat": "Changer le format de {{title}}"
   },
   "history": {
     "title": "Historique",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -171,7 +171,13 @@
     "selectBook": "Pilih {{title}}",
     "unmonitorHint": "Berhenti memantau buku ini",
     "showExcluded": "Tampilkan yang dikecualikan",
-    "excluded": "Dikecualikan"
+    "excluded": "Dikecualikan",
+    "colTitleAuthor": "Judul & penulis",
+    "colFormat": "Format",
+    "colActions": "Tindakan",
+    "noCover": "Tanpa sampul",
+    "authorUnknown": "Penulis tidak diketahui",
+    "changeFormat": "Ubah format untuk {{title}}"
   },
   "history": {
     "title": "Riwayat",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -152,7 +152,15 @@
     "ebookDone": "📖 ✓",
     "audiobookDone": "🎧 ✓",
     "selectBook": "{{title}} selecteren",
-    "unmonitorHint": "Stop met bewaken van dit boek"
+    "unmonitorHint": "Stop met bewaken van dit boek",
+    "showExcluded": "Uitgesloten tonen",
+    "excluded": "Uitgesloten",
+    "colTitleAuthor": "Titel & auteur",
+    "colFormat": "Formaat",
+    "colActions": "Acties",
+    "noCover": "Geen omslag",
+    "authorUnknown": "Auteur onbekend",
+    "changeFormat": "Formaat wijzigen voor {{title}}"
   },
   "history": {
     "title": "Geschiedenis",

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -171,7 +171,13 @@
     "selectBook": "Piliin ang {{title}}",
     "unmonitorHint": "Itigil ang pagbabantay sa librong ito",
     "showExcluded": "Ipakita ang mga ibinukod",
-    "excluded": "Ibinukod"
+    "excluded": "Ibinukod",
+    "colTitleAuthor": "Pamagat at may-akda",
+    "colFormat": "Format",
+    "colActions": "Mga aksyon",
+    "noCover": "Walang pabalat",
+    "authorUnknown": "Hindi alam ang may-akda",
+    "changeFormat": "Baguhin ang format para sa {{title}}"
   },
   "history": {
     "title": "Kasaysayan",

--- a/web/src/pages/WantedPage.test.tsx
+++ b/web/src/pages/WantedPage.test.tsx
@@ -25,6 +25,7 @@ vi.mock('react-i18next', () => ({
     t: (key: string, options?: Record<string, unknown>) => {
       if (key === 'wanted.countLabel') return `${String(options?.filtered)} of ${String(options?.total)}`
       if (key === 'wanted.selectBook') return `Select ${String(options?.title)}`
+      if (key === 'wanted.changeFormat') return `Change format for ${String(options?.title)}`
       if (key === 'bulkActionBar.selected') return `${String(options?.count)} selected`
 
       const labels: Record<string, string> = {
@@ -53,6 +54,11 @@ vi.mock('react-i18next', () => ({
         'books.mediaAudiobook': '🎧 Audiobook',
         'books.mediaBoth': '📖🎧 Both',
         'bulkActionBar.clear': 'Clear',
+        'wanted.colTitleAuthor': 'Title & author',
+        'wanted.colFormat': 'Format',
+        'wanted.colActions': 'Actions',
+        'wanted.noCover': 'No cover',
+        'wanted.authorUnknown': 'Author unknown',
       }
       return labels[key] ?? key
     },
@@ -169,6 +175,97 @@ describe('WantedPage', () => {
     expect(await screen.findByText('No wanted books. Add an author to start tracking.')).toBeInTheDocument()
     expect(screen.getByText('0 of 0')).toBeInTheDocument()
     expect(api.listWanted).toHaveBeenCalledWith({ includeExcluded: false })
+  })
+
+  it('renders a row with the book title and its author', async () => {
+    const tolkien: Author = { ...author, id: 99, authorName: 'J.R.R. Tolkien' }
+    vi.mocked(api.listWanted).mockResolvedValue([
+      makeBook({ id: 1, title: 'The Hobbit', authorId: 99, author: tolkien, releaseDate: '1937-09-21' }),
+    ])
+
+    renderWantedPage()
+
+    expect(await screen.findByRole('link', { name: 'The Hobbit' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'J.R.R. Tolkien' })).toBeInTheDocument()
+    // author line also carries the release year
+    expect(screen.getByText(/1937/)).toBeInTheDocument()
+  })
+
+  it('renders gracefully and shows a fallback when a book has no author', async () => {
+    vi.mocked(api.listWanted).mockResolvedValue([
+      makeBook({ id: 1, title: 'Orphan Book', author: undefined }),
+    ])
+
+    renderWantedPage()
+
+    expect(await screen.findByRole('link', { name: 'Orphan Book' })).toBeInTheDocument()
+    expect(screen.getByText('Author unknown')).toBeInTheDocument()
+  })
+
+  it('renders the column header row with a select-all checkbox', async () => {
+    vi.mocked(api.listWanted).mockResolvedValue([makeBook({ id: 1, title: 'Dune' })])
+
+    renderWantedPage()
+
+    await screen.findByRole('link', { name: 'Dune' })
+    expect(screen.getByText('Title & author')).toBeInTheDocument()
+    expect(screen.getByText('Format')).toBeInTheDocument()
+    expect(screen.getByText('Actions')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Select all on this page' })).toBeInTheDocument()
+  })
+
+  it('filters the list with the search box', async () => {
+    vi.mocked(api.listWanted).mockResolvedValue([
+      makeBook({ id: 1, title: 'Dune' }),
+      makeBook({ id: 2, title: 'Hyperion' }),
+    ])
+
+    renderWantedPage()
+
+    await screen.findByRole('link', { name: 'Dune' })
+    fireEvent.change(screen.getByPlaceholderText('Search by title or author...'), {
+      target: { value: 'hyper' },
+    })
+
+    expect(screen.queryByRole('link', { name: 'Dune' })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Hyperion' })).toBeInTheDocument()
+  })
+
+  it('changes a book format with the per-row format control', async () => {
+    vi.mocked(api.listWanted).mockResolvedValue([makeBook({ id: 1, title: 'Dune' })])
+
+    renderWantedPage()
+
+    await screen.findByRole('link', { name: 'Dune' })
+    const formatSelect = screen.getByRole('combobox', { name: 'Change format for Dune' })
+    expect(formatSelect).toHaveValue('ebook')
+    fireEvent.change(formatSelect, { target: { value: 'audiobook' } })
+
+    await waitFor(() => expect(api.updateBook).toHaveBeenCalledWith(1, { mediaType: 'audiobook' }))
+  })
+
+  it('selecting a row drives the bulk action bar and select-all toggles every row', async () => {
+    vi.mocked(api.listWanted).mockResolvedValue([
+      makeBook({ id: 1, title: 'Dune' }),
+      makeBook({ id: 2, title: 'Hyperion' }),
+    ])
+
+    renderWantedPage()
+
+    await screen.findByRole('link', { name: 'Dune' })
+    expect(screen.queryByText('1 selected')).not.toBeInTheDocument()
+
+    // per-row selection
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Dune' }))
+    expect(screen.getByText('1 selected')).toBeInTheDocument()
+
+    // select-all picks up every row
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select all on this page' }))
+    expect(screen.getByText('2 selected')).toBeInTheDocument()
+
+    // select-all again clears
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select all on this page' }))
+    expect(screen.queryByText(/selected/)).not.toBeInTheDocument()
   })
 
   it('searches a wanted book and renders result metadata', async () => {

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -6,6 +6,10 @@ import BulkActionBar from '../components/BulkActionBar'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
 
+// Shared grid template so the header row and every list row line up exactly.
+// columns: checkbox · cover · title+author · format · actions
+const ROW_GRID = 'grid grid-cols-[1.5rem_2rem_1fr_6rem_8.5rem] items-center gap-3'
+
 export default function WantedPage() {
   const { t } = useTranslation()
 
@@ -158,6 +162,8 @@ export default function WantedPage() {
     return (bytes / 1024).toFixed(0) + ' KB'
   }
 
+  const checkboxCls = 'rounded border-slate-400 dark:border-zinc-600 text-emerald-600 focus:ring-emerald-500 focus:ring-offset-0'
+
   return (
     <div className={selectedIds.size > 0 ? 'pb-16' : ''}>
       {toast && (
@@ -165,20 +171,22 @@ export default function WantedPage() {
           {toast}
         </div>
       )}
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-2xl font-bold">{t('wanted.title')}</h2>
-        <div className="flex items-center gap-4">
-          <label className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-zinc-400 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={showExcluded}
-              onChange={e => setShowExcluded(e.target.checked)}
-              className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
-            />
-            {t('wanted.showExcluded')}
-          </label>
-          <span className="text-sm text-slate-600 dark:text-zinc-500">{t('wanted.countLabel', { filtered: filtered.length, total: books.length })}</span>
-        </div>
+
+      {/* Page header: title · count · show-excluded */}
+      <div className="flex items-center gap-3 mb-3">
+        <h2 className="text-xl font-semibold text-slate-800 dark:text-zinc-200">{t('wanted.title')}</h2>
+        <span className="text-xs text-slate-500 dark:text-zinc-500">
+          {t('wanted.countLabel', { filtered: filtered.length, total: books.length })}
+        </span>
+        <label className="ml-auto flex items-center gap-1.5 text-xs text-slate-600 dark:text-zinc-400 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={showExcluded}
+            onChange={e => setShowExcluded(e.target.checked)}
+            className={checkboxCls}
+          />
+          {t('wanted.showExcluded')}
+        </label>
       </div>
 
       <input
@@ -186,7 +194,7 @@ export default function WantedPage() {
         value={search}
         onChange={e => setSearch(e.target.value)}
         placeholder={t('wanted.searchPlaceholder')}
-        className="w-full mb-4 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600 placeholder-slate-400 dark:placeholder-zinc-600"
+        className="w-full mb-3 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-1.5 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600 placeholder-slate-400 dark:placeholder-zinc-600"
       />
 
       {loading ? (
@@ -200,89 +208,127 @@ export default function WantedPage() {
           <p>{t('wanted.noMatch')}</p>
         </div>
       ) : (
-        <>
-          {/* Select-all row */}
-          <div className="flex items-center gap-2 mb-2 px-1">
+        <div className="border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden">
+          {/* Column-header row with select-all checkbox */}
+          <div className={`${ROW_GRID} px-3 py-2 border-b border-slate-200 dark:border-zinc-800 bg-slate-200/60 dark:bg-zinc-800/60 text-[11px] font-medium uppercase tracking-wide text-slate-500 dark:text-zinc-500`}>
             <input
               ref={selectAllRef}
               type="checkbox"
               checked={allPageSelected}
               onChange={e => e.target.checked ? selectAllOnPage() : clearSelection()}
-              className="rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
-              title="Select all on this page"
+              className={checkboxCls}
+              aria-label={t('common.selectAllPage')}
+              title={t('common.selectAllPage')}
             />
-            <span className="text-xs text-slate-500 dark:text-zinc-500">{t('common.selectAllPage')}</span>
+            <span aria-hidden />
+            <span>{t('wanted.colTitleAuthor')}</span>
+            <span>{t('wanted.colFormat')}</span>
+            <span className="text-right">{t('wanted.colActions')}</span>
           </div>
 
-          <div className="space-y-2">
-            {pageItems.map(book => (
-              <div key={book.id}>
-                <div className={`flex items-center justify-between p-3 border rounded-lg transition-colors ${selectedIds.has(book.id) ? 'border-emerald-500 bg-emerald-500/5 dark:bg-emerald-500/5' : 'border-slate-200 dark:border-zinc-800 bg-slate-100 dark:bg-zinc-900'}`}>
-                  <div className="flex items-center gap-3 min-w-0">
-                    <input
-                      type="checkbox"
-                      checked={selectedIds.has(book.id)}
-                      onChange={() => toggleSelect(book.id)}
-                      className="rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 flex-shrink-0"
-                      title={t('wanted.selectBook', { title: book.title })}
+          {pageItems.map((book, i) => {
+            const isSelected = selectedIds.has(book.id)
+            const year = book.releaseDate ? new Date(book.releaseDate).getFullYear() : null
+            const authorName = book.author?.authorName
+            return (
+              <div key={book.id} className={i < pageItems.length - 1 ? 'border-b border-slate-200 dark:border-zinc-800' : ''}>
+                <div className={`${ROW_GRID} px-3 py-1.5 transition-colors ${
+                  isSelected
+                    ? 'bg-emerald-500/10 dark:bg-emerald-500/10'
+                    : 'hover:bg-slate-200/50 dark:hover:bg-zinc-800/50'
+                }`}>
+                  {/* selection */}
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggleSelect(book.id)}
+                    className={checkboxCls}
+                    aria-label={t('wanted.selectBook', { title: book.title })}
+                    title={t('wanted.selectBook', { title: book.title })}
+                  />
+
+                  {/* uniform cover slot */}
+                  {book.imageUrl ? (
+                    <img
+                      src={book.imageUrl}
+                      alt=""
+                      className="w-8 h-11 object-cover rounded bg-slate-200 dark:bg-zinc-800"
                     />
-                    {book.imageUrl && (
-                      <img src={book.imageUrl} alt="" className="w-10 h-14 object-cover rounded flex-shrink-0" />
-                    )}
-                    <div className="min-w-0">
-                      <Link to={`/book/${book.id}`} className="font-medium text-sm truncate block hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors">
-                        {book.title}
-                      </Link>
-                      {book.author && (
+                  ) : (
+                    <div
+                      className="w-8 h-11 rounded bg-slate-200 dark:bg-zinc-800 grid place-items-center text-[8px] text-slate-400 dark:text-zinc-600 text-center leading-tight"
+                      aria-hidden
+                    >
+                      {t('wanted.noCover')}
+                    </div>
+                  )}
+
+                  {/* title + author · year */}
+                  <div className="min-w-0">
+                    <Link
+                      to={`/book/${book.id}`}
+                      className="block truncate text-sm font-medium text-slate-800 dark:text-zinc-200 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+                    >
+                      {book.title}
+                    </Link>
+                    <div className="truncate text-xs text-slate-500 dark:text-zinc-500">
+                      {authorName ? (
                         <Link
                           to={`/author/${book.authorId}`}
-                          className="text-[11px] text-slate-500 dark:text-zinc-500 hover:text-emerald-500 dark:hover:text-emerald-400 transition-colors truncate block"
+                          className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
                         >
-                          {book.author.authorName}
+                          {authorName}
                         </Link>
+                      ) : (
+                        <span>{t('wanted.authorUnknown')}</span>
                       )}
-                      <div className="flex items-center gap-2 mt-0.5 flex-wrap">
-                        <select
-                          value={book.mediaType || 'ebook'}
-                          onChange={e => changeMediaType(book, e.target.value as 'ebook' | 'audiobook' | 'both')}
-                          className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded text-[11px] px-1.5 py-0.5 focus:outline-none"
-                          title="Change media type"
-                        >
-                          <option value="ebook">{t('books.mediaEbook')}</option>
-                          <option value="audiobook">{t('books.mediaAudiobook')}</option>
-                          <option value="both">{t('books.mediaBoth')}</option>
-                        </select>
-                        {book.mediaType === 'both' && (
-                          <span className="text-[10px] text-slate-500 dark:text-zinc-500">
-                            {book.ebookFilePath ? t('wanted.ebookDone') : t('wanted.ebookNeeded')}
-                            {' · '}
-                            {book.audiobookFilePath ? t('wanted.audiobookDone') : t('wanted.audiobookNeeded')}
-                          </span>
-                        )}
-                      </div>
-                      {book.releaseDate && (
-                        <p className="text-xs text-slate-600 dark:text-zinc-500">{new Date(book.releaseDate).getFullYear()}</p>
-                      )}
+                      {year != null && <span> · {year}</span>}
                     </div>
                   </div>
-                  <div className="flex items-center gap-2 flex-shrink-0">
+
+                  {/* format control — compact select, still changes the value */}
+                  <div className="min-w-0">
+                    <select
+                      value={book.mediaType || 'ebook'}
+                      onChange={e => changeMediaType(book, e.target.value as 'ebook' | 'audiobook' | 'both')}
+                      className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded text-[11px] px-1.5 py-0.5 focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+                      aria-label={t('wanted.changeFormat', { title: book.title })}
+                      title={t('wanted.changeFormat', { title: book.title })}
+                    >
+                      <option value="ebook">{t('books.mediaEbook')}</option>
+                      <option value="audiobook">{t('books.mediaAudiobook')}</option>
+                      <option value="both">{t('books.mediaBoth')}</option>
+                    </select>
+                    {book.mediaType === 'both' && (
+                      <div className="mt-0.5 text-[10px] text-slate-500 dark:text-zinc-500 truncate">
+                        {book.ebookFilePath ? t('wanted.ebookDone') : t('wanted.ebookNeeded')}
+                        {' · '}
+                        {book.audiobookFilePath ? t('wanted.audiobookDone') : t('wanted.audiobookNeeded')}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* actions */}
+                  <div className="flex items-center justify-end gap-1.5">
                     {book.excluded && (
-                      <span className="px-2 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">
+                      <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">
                         {t('wanted.excluded')}
                       </span>
                     )}
                     <button
+                      type="button"
                       onClick={() => unmonitor(book)}
                       disabled={unmonitoringId === book.id}
-                      className="px-2 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-amber-100 dark:hover:bg-amber-900/30 hover:text-amber-700 dark:hover:text-amber-400 rounded text-xs font-medium disabled:opacity-50 transition-colors"
+                      className="px-2 py-1 rounded text-xs font-medium bg-slate-200 dark:bg-zinc-800 hover:bg-amber-100 dark:hover:bg-amber-900/30 hover:text-amber-700 dark:hover:text-amber-400 text-slate-700 dark:text-zinc-300 disabled:opacity-50 transition-colors"
                       title={t('wanted.unmonitorHint')}
                     >
                       {unmonitoringId === book.id ? '…' : t('common.unmonitor')}
                     </button>
                     <button
+                      type="button"
                       onClick={() => searchBook(book)}
                       disabled={searchingId === book.id}
-                      className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium disabled:opacity-50"
+                      className="px-2 py-1 rounded text-xs font-medium bg-emerald-600 hover:bg-emerald-500 text-white disabled:opacity-50 transition-colors"
                     >
                       {searchingId === book.id ? t('wanted.searching') : t('common.search')}
                     </button>
@@ -290,13 +336,13 @@ export default function WantedPage() {
                 </div>
 
                 {showResults === book.id && results.length === 0 && (
-                  <div className="mt-1 mb-3 px-3 py-2 bg-slate-200/50 dark:bg-zinc-800/50 rounded text-xs text-slate-600 dark:text-zinc-500">
+                  <div className="px-3 pb-2 text-xs text-slate-600 dark:text-zinc-500">
                     {t('wanted.noIndexerResults')}
                   </div>
                 )}
 
                 {showResults === book.id && results.length > 0 && (
-                  <div className="mt-1 mb-3 space-y-1">
+                  <div className="px-3 pb-2 space-y-1">
                     {results.slice(0, 10).map(r => (
                       <div key={r.guid} className="flex items-center justify-between p-2 bg-slate-200/50 dark:bg-zinc-800/50 rounded text-xs">
                         <div className="min-w-0 mr-3">
@@ -309,6 +355,7 @@ export default function WantedPage() {
                           </span>
                         </div>
                         <button
+                          type="button"
                           onClick={() => grab(r, book)}
                           disabled={grabbingGuid === r.guid || grabbedGuid === r.guid}
                           className={`px-2 py-2 rounded text-[10px] font-medium flex-shrink-0 touch-manipulation transition-colors disabled:cursor-default ${
@@ -326,10 +373,11 @@ export default function WantedPage() {
                   </div>
                 )}
               </div>
-            ))}
-          </div>
-        </>
+            )
+          })}
+        </div>
       )}
+
       <Pagination {...paginationProps} />
 
       <BulkActionBar


### PR DESCRIPTION
## Summary

Redesigns the Wanted page from tall card rows into a compact, aligned list, matching the approved mockup. This is a restyle + restructure — **no feature change**.

## What changed

- **Compact divided list.** One bordered container with thin dividers replaces the separate fat cards; roughly 2.5x the previous row density.
- **Fixed CSS grid rows** (`checkbox · cover · title+author · format · actions`) so columns line up between rows, with a column-header row (`Title & author / Format / Actions`) carrying the select-all checkbox.
- **Square selection checkboxes** for both per-row and select-all — the previous round/radio styling was wrong for multi-select.
- **Author is now shown.** Each row has the title plus a muted `Author · Year` second line. The author *is* available in the wanted-list payload (`book.author?.authorName`) — no backend change needed. A graceful `Author unknown` fallback renders when a book genuinely has no author.
- **Uniform 32x44 cover slot** with a neutral placeholder so every row's left edge aligns.
- **Tightened spacing** on the page header (title / count / Show excluded) and the search box.

## Behaviour preserved

Every prior capability still works and is covered by tests:

- Search box (title/author filter)
- Show excluded toggle + result count
- Per-row and select-all selection driving the `BulkActionBar`
- Per-row Unmonitor and Search actions (with optimistic-unmonitor toast/revert)
- Per-row **format control** — still a functional `<select>` that changes the book's media type, including the dual-format needed/done indicator
- Pagination, the indexer-results panel, and the grab flow

No handler, API call, piece of state, or prop was dropped.

## i18n

New keys (`colTitleAuthor`, `colFormat`, `colActions`, `noCover`, `authorUnknown`, `changeFormat`) added to all seven locales. The previously-missing `showExcluded`/`excluded` keys were also backfilled into `de`/`fr`/`nl`, which lacked them.

## Tests

`WantedPage.test.tsx` updated for the new structure and extended: row title+author rendering, the no-author fallback, the column header, search-box filtering, the format control changing the value, and per-row selection plus select-all driving the bulk action bar.

## Verification

- `npm run typecheck` — clean (exit 0)
- `npm run build` — succeeds (exit 0)
- `npm run lint` — exit 0, no new warnings (the one `WantedPage` `useEffect`/`load` warning is pre-existing, unchanged from the original file)
- `npm test -- WantedPage` — 14/14 green (exit 0)

## Scope notes

Only `WantedPage.tsx`, its test, and `web/src/i18n/locales/*` were touched. `BulkActionBar` and `Pagination` were **not** modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)