### PR TITLE
Fix: CSRF failing for Readarr import

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -68,6 +68,32 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   return res.json()
 }
 
+// Upload a file (multipart/form-data). Omits Content-Type so the browser
+// sets the boundary automatically, but still injects the CSRF token.
+async function uploadFile<T>(path: string, body: FormData): Promise<T> {
+  const headers = new Headers({
+    'X-Requested-With': 'bindery-ui',
+  })
+  if (csrfToken) {
+    headers.set('X-CSRF-Token', csrfToken)
+  }
+  const res = await fetch(`${BASE}${path}`, {
+    method: 'POST',
+    credentials: 'include',
+    headers,
+    body,
+  })
+  if (res.status === 401 && !PUBLIC_PATHS.has(window.location.pathname)) {
+    window.location.href = `${BINDERY_BASE}/login`
+    return Promise.reject(new Error('unauthenticated'))
+  }
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({ error: res.statusText }))
+    throw new Error(data.error || `HTTP ${res.status}`)
+  }
+  return res.json() as Promise<T>
+}
+
 export interface AuthStatus {
   authenticated: boolean
   setupRequired: boolean
@@ -453,6 +479,8 @@ export const api = {
     request<HardcoverList[]>('/importlist/hardcover/lists', {
       headers: { Authorization: `Bearer ${token}` },
     }),
+  uploadMigrate: <T>(endpoint: 'csv' | 'readarr', body: FormData) =>
+    uploadFile<T>(`/migrate/${endpoint}`, body),
 
   // Metadata Profiles
   listMetadataProfiles: () => request<MetadataProfile[]>('/metadataprofile'),

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1200,14 +1200,9 @@ function ImportTab() {
     try {
       const fd = new FormData()
       fd.append('file', file)
-      const res = await fetch(`/api/v1/migrate/${endpoint}`, { method: 'POST', body: fd })
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({ error: res.statusText }))
-        throw new Error(body.error || `HTTP ${res.status}`)
-      }
-      const data = await res.json()
-      if (endpoint === 'csv') setCsvResult(data)
-      else setReadarrResult(data)
+      const data = await api.uploadMigrate<MigrateResult | ReadarrResult>(endpoint, fd)
+      if (endpoint === 'csv') setCsvResult(data as MigrateResult)
+      else setReadarrResult(data as ReadarrResult)
     } catch (e) {
       setErr(e instanceof Error ? e.message : 'Upload failed')
     } finally {


### PR DESCRIPTION
## Summary

The Readarr import flow fails due to missing X-CSRF-Token header. 

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed
- [x] `CHANGELOG.md` `[Unreleased]` section updated
- [x] Wiki pages updated if user-facing behaviour changed

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [x] `cd web && npm run build`
