### PR TITLE
chore(telemetry): harden telemetry-server Dockerfile (distroless)

### DIFF
--- a/cmd/telemetry-server/Dockerfile
+++ b/cmd/telemetry-server/Dockerfile
@@ -5,9 +5,14 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /telemetry-server ./cmd/telemetry-server
 
-FROM alpine:3.22@sha256:310c62b5e7ca5b08167e4384c68db0fd2905dd9c7493756d356e893909057601
-RUN apk add --no-cache sqlite && adduser -D -u 1000 app
-USER app
+# Distroless runtime — parity with the main Dockerfile. The binary is a static
+# CGO-free build (modernc.org/sqlite is pure Go), so distroless/static is
+# sufficient: no runtime sqlite package, no shell, minimal attack surface.
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
 COPY --from=builder /telemetry-server /telemetry-server
+# Numeric non-root UID, matching runAsUser in deploy/telemetry-server.yaml.
+USER 1000:1000
 EXPOSE 8080
+# No HEALTHCHECK: distroless has no shell/curl, and deploy/telemetry-server.yaml
+# already defines a readinessProbe on /health.
 ENTRYPOINT ["/telemetry-server"]


### PR DESCRIPTION
Closes #553

`cmd/telemetry-server/Dockerfile` had an alpine runtime while the main `Dockerfile` uses distroless. telemetry-server is internet-exposed via `api.getbindery.dev`, so it's exactly the surface that benefits from a minimal runtime.

## Changes (Dockerfile only)

- **alpine → distroless.** Runtime stage is now `gcr.io/distroless/static-debian12:nonroot`, pinned to the **same digest as the main Dockerfile**. No shell, no package manager, minimal attack surface.
- **Dropped `apk add --no-cache sqlite`.** The binary uses `modernc.org/sqlite` (pure Go, built `CGO_ENABLED=0`), and the backup endpoint runs `VACUUM INTO` *through the driver* — nothing shells out to the `sqlite3` CLI. The runtime package was dead weight; removing it is what makes the distroless/static base sufficient.
- **`USER 1000:1000`**, matching `runAsUser: 1000` in `deploy/telemetry-server.yaml`.
- **No `HEALTHCHECK`** — distroless has no shell/curl, and the deployment already defines a `readinessProbe` on `/health`.

## The issue's comparison table is partly stale

The pod-level hardening #553 asks for is **already present** in `deploy/telemetry-server.yaml`: `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`, `runAsNonRoot: true`, `seccompProfile: RuntimeDefault`, and a writable `/data` PVC. So only the Dockerfile actually needed changing.

## Verification

CI's image build (`ping-server.yml`) only runs on push to `main`, not on PRs — so this was validated locally:
- `docker build` of the new Dockerfile — succeeds
- Container runs in distroless — `telemetry-server starting addr=:8080` logged, `GET /health` → **HTTP 200**, SQLite writes work
- `go build ./cmd/telemetry-server` — clean

## Operational note

Distroless removes the debug shell. First-time troubleshooting now needs `kubectl debug -it <pod> --image=busybox --target=ping` rather than `kubectl exec ... sh`.