### PR TITLE
feat: per-author audiobook root folder (#579)

### DIFF
--- a/internal/abs/import_files.go
+++ b/internal/abs/import_files.go
@@ -165,8 +165,14 @@ func (i *Importer) pathAllowedForBook(ctx context.Context, author *models.Author
 }
 
 func (i *Importer) allowedRootsForBook(ctx context.Context, author *models.Author, format string) []string {
-	roots := make([]string, 0, 3)
+	roots := make([]string, 0, 4)
 	if format == models.MediaTypeAudiobook {
+		// Per-author audiobook root folder (#579), then the global audiobook
+		// dir. Both must be accepted so an audiobook stored under an author's
+		// override is recognised as inside Bindery storage.
+		if root := strings.TrimSpace(i.effectiveAudiobookDir(ctx, author)); root != "" {
+			roots = append(roots, filepath.Clean(root))
+		}
 		if root := strings.TrimSpace(i.audiobookDir); root != "" {
 			roots = append(roots, filepath.Clean(root))
 		}
@@ -180,6 +186,21 @@ func (i *Importer) allowedRootsForBook(ctx context.Context, author *models.Autho
 		}
 	}
 	return dedupeCleanPaths(roots)
+}
+
+// effectiveAudiobookDir returns the audiobook root for the given author:
+// the per-author AudiobookRootFolderID when set (#579), else the global
+// audiobookDir. It deliberately does not consult the ebook RootFolderID so an
+// ebook root folder never widens audiobook acceptance into the ebook tree
+// (#421). author may be nil (e.g. inspectFormatPath has no author context),
+// in which case only the global dir applies.
+func (i *Importer) effectiveAudiobookDir(ctx context.Context, author *models.Author) string {
+	if author != nil && author.AudiobookRootFolderID != nil && i.rootFolders != nil {
+		if root, err := i.rootFolders.GetByID(ctx, *author.AudiobookRootFolderID); err == nil && root != nil {
+			return root.Path
+		}
+	}
+	return i.audiobookDir
 }
 
 func (i *Importer) effectiveLibraryDir(ctx context.Context, author *models.Author) string {

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -111,14 +111,15 @@ func (h *AuthorHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		ForeignID         string `json:"foreignAuthorId"`
-		Name              string `json:"authorName"`
-		QualityProfileID  *int64 `json:"qualityProfileId"`
-		MetadataProfileID *int64 `json:"metadataProfileId"`
-		RootFolderID      *int64 `json:"rootFolderId"`
-		Monitored         bool   `json:"monitored"`
-		SearchOnAdd       bool   `json:"searchOnAdd"`
-		MediaType         string `json:"mediaType"`
+		ForeignID             string `json:"foreignAuthorId"`
+		Name                  string `json:"authorName"`
+		QualityProfileID      *int64 `json:"qualityProfileId"`
+		MetadataProfileID     *int64 `json:"metadataProfileId"`
+		RootFolderID          *int64 `json:"rootFolderId"`
+		AudiobookRootFolderID *int64 `json:"audiobookRootFolderId"`
+		Monitored             bool   `json:"monitored"`
+		SearchOnAdd           bool   `json:"searchOnAdd"`
+		MediaType             string `json:"mediaType"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -158,7 +159,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	} else if canonical != nil {
 		if canRelinkAuthorToUpstream(canonical) {
-			if err := h.relinkExistingAuthorToUpstream(r.Context(), canonical, author, req.Name, req.Monitored, req.QualityProfileID, req.MetadataProfileID, req.RootFolderID); err != nil {
+			if err := h.relinkExistingAuthorToUpstream(r.Context(), canonical, author, req.Name, req.Monitored, req.QualityProfileID, req.MetadataProfileID, req.RootFolderID, req.AudiobookRootFolderID); err != nil {
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 				return
 			}
@@ -174,7 +175,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		h.writeCanonicalAuthorConflict(w, canonical, "author name already resolves to an existing author — confirm merge")
 		return
 	}
-	applyAuthorCreateOptions(author, req.Monitored, req.QualityProfileID, req.MetadataProfileID, req.RootFolderID)
+	applyAuthorCreateOptions(author, req.Monitored, req.QualityProfileID, req.MetadataProfileID, req.RootFolderID, req.AudiobookRootFolderID)
 
 	if err := h.authors.CreateForUser(r.Context(), author, auth.UserIDFromContext(r.Context())); err != nil {
 		slog.Error("create author failed", "foreign_id", req.ForeignID, "error", err)
@@ -259,10 +260,11 @@ func (h *AuthorHandler) fetchAuthorForCreate(ctx context.Context, foreignID, fal
 	return author, nil
 }
 
-func applyAuthorCreateOptions(author *models.Author, monitored bool, qualityProfileID, metadataProfileID, rootFolderID *int64) {
+func applyAuthorCreateOptions(author *models.Author, monitored bool, qualityProfileID, metadataProfileID, rootFolderID, audiobookRootFolderID *int64) {
 	author.Monitored = monitored
 	author.QualityProfileID = qualityProfileID
 	author.RootFolderID = rootFolderID
+	author.AudiobookRootFolderID = audiobookRootFolderID
 	// Default to the seeded "Standard" profile (id=1) so the language filter
 	// has something to consult when the UI didn't send an explicit choice.
 	// The client can opt out by sending a profile whose allowed_languages is
@@ -284,7 +286,7 @@ func canRelinkAuthorToUpstream(author *models.Author) bool {
 	return foreignID == "" || strings.HasPrefix(foreignID, "abs:") || provider == "audiobookshelf"
 }
 
-func (h *AuthorHandler) relinkExistingAuthorToUpstream(ctx context.Context, author, upstream *models.Author, requestedName string, monitored bool, qualityProfileID, metadataProfileID, rootFolderID *int64) error {
+func (h *AuthorHandler) relinkExistingAuthorToUpstream(ctx context.Context, author, upstream *models.Author, requestedName string, monitored bool, qualityProfileID, metadataProfileID, rootFolderID, audiobookRootFolderID *int64) error {
 	if author == nil || upstream == nil {
 		return errors.New("author relink requires local and upstream authors")
 	}
@@ -320,7 +322,7 @@ func (h *AuthorHandler) relinkExistingAuthorToUpstream(ctx context.Context, auth
 	} else {
 		author.MetadataProvider = "openlibrary"
 	}
-	applyAuthorCreateOptions(author, monitored, qualityProfileID, metadataProfileID, rootFolderID)
+	applyAuthorCreateOptions(author, monitored, qualityProfileID, metadataProfileID, rootFolderID, audiobookRootFolderID)
 	now := time.Now().UTC()
 	author.LastMetadataRefreshAt = &now
 	if err := h.authors.Update(ctx, author); err != nil {
@@ -487,10 +489,16 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Monitored         *bool  `json:"monitored"`
-		QualityProfileID  *int64 `json:"qualityProfileId"`
-		MetadataProfileID *int64 `json:"metadataProfileId"`
-		RootFolderID      *int64 `json:"rootFolderId"`
+		Monitored             *bool  `json:"monitored"`
+		QualityProfileID      *int64 `json:"qualityProfileId"`
+		MetadataProfileID     *int64 `json:"metadataProfileId"`
+		RootFolderID          *int64 `json:"rootFolderId"`
+		AudiobookRootFolderID *int64 `json:"audiobookRootFolderId"`
+		// ClearAudiobookRootFolder lets the client explicitly reset the
+		// per-author audiobook root folder to "use the global dir". A nil
+		// AudiobookRootFolderID alone is ambiguous (omitted vs. cleared), so
+		// the UI sends this flag when the user picks the default option.
+		ClearAudiobookRootFolder bool `json:"clearAudiobookRootFolder"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -507,6 +515,11 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.RootFolderID != nil {
 		author.RootFolderID = req.RootFolderID
+	}
+	if req.AudiobookRootFolderID != nil {
+		author.AudiobookRootFolderID = req.AudiobookRootFolderID
+	} else if req.ClearAudiobookRootFolder {
+		author.AudiobookRootFolderID = nil
 	}
 
 	if err := h.authors.Update(r.Context(), author); err != nil {
@@ -576,7 +589,7 @@ func (h *AuthorHandler) RelinkUpstream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.relinkExistingAuthorToUpstream(r.Context(), author, upstream, author.Name, author.Monitored, author.QualityProfileID, author.MetadataProfileID, author.RootFolderID); err != nil {
+	if err := h.relinkExistingAuthorToUpstream(r.Context(), author, upstream, author.Name, author.Monitored, author.QualityProfileID, author.MetadataProfileID, author.RootFolderID, author.AudiobookRootFolderID); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -20,7 +20,7 @@ func NewAuthorRepo(db *sql.DB) *AuthorRepo {
 
 const authorSelectCols = `id, foreign_id, name, sort_name, description, image_url, disambiguation,
 	       ratings_count, average_rating, monitored, quality_profile_id, metadata_profile_id, root_folder_id,
-	       metadata_provider, last_metadata_refresh_at, created_at, updated_at`
+	       audiobook_root_folder_id, metadata_provider, last_metadata_refresh_at, created_at, updated_at`
 
 func (r *AuthorRepo) List(ctx context.Context) ([]models.Author, error) {
 	return r.ListByUser(ctx, 0)
@@ -124,11 +124,11 @@ func (r *AuthorRepo) CreateForUser(ctx context.Context, a *models.Author, ownerU
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO authors (foreign_id, name, sort_name, description, image_url, disambiguation,
 		                     ratings_count, average_rating, monitored, quality_profile_id, metadata_profile_id, root_folder_id,
-		                     metadata_provider, owner_user_id, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		                     audiobook_root_folder_id, metadata_provider, owner_user_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.ForeignID, a.Name, a.SortName, a.Description, a.ImageURL, a.Disambiguation,
 		a.RatingsCount, a.AverageRating, a.Monitored, a.QualityProfileID, a.MetadataProfileID, a.RootFolderID,
-		a.MetadataProvider, ownerArg, now, now)
+		a.AudiobookRootFolderID, a.MetadataProvider, ownerArg, now, now)
 	if err != nil {
 		return fmt.Errorf("create author: %w", err)
 	}
@@ -227,12 +227,12 @@ func (r *AuthorRepo) Update(ctx context.Context, a *models.Author) error {
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE authors SET foreign_id=?, name=?, sort_name=?, description=?, image_url=?, disambiguation=?,
 		                   ratings_count=?, average_rating=?, monitored=?, quality_profile_id=?,
-		                   metadata_profile_id=?, root_folder_id=?, metadata_provider=?,
+		                   metadata_profile_id=?, root_folder_id=?, audiobook_root_folder_id=?, metadata_provider=?,
 		                   last_metadata_refresh_at=?, updated_at=?
 		WHERE id=?`,
 		a.ForeignID, a.Name, a.SortName, a.Description, a.ImageURL, a.Disambiguation,
 		a.RatingsCount, a.AverageRating, a.Monitored, a.QualityProfileID,
-		a.MetadataProfileID, a.RootFolderID, a.MetadataProvider, a.LastMetadataRefreshAt, now, a.ID)
+		a.MetadataProfileID, a.RootFolderID, a.AudiobookRootFolderID, a.MetadataProvider, a.LastMetadataRefreshAt, now, a.ID)
 	if err != nil {
 		return fmt.Errorf("update author %d: %w", a.ID, err)
 	}
@@ -253,7 +253,7 @@ func scanAuthor(rows *sql.Rows) (models.Author, error) {
 	var monitored int
 	err := rows.Scan(&a.ID, &a.ForeignID, &a.Name, &a.SortName, &a.Description, &a.ImageURL,
 		&a.Disambiguation, &a.RatingsCount, &a.AverageRating, &monitored,
-		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.MetadataProvider,
+		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.AudiobookRootFolderID, &a.MetadataProvider,
 		&a.LastMetadataRefreshAt, &a.CreatedAt, &a.UpdatedAt)
 	a.Monitored = monitored == 1
 	return a, err
@@ -264,7 +264,7 @@ func scanAuthorRow(row *sql.Row) (models.Author, error) {
 	var monitored int
 	err := row.Scan(&a.ID, &a.ForeignID, &a.Name, &a.SortName, &a.Description, &a.ImageURL,
 		&a.Disambiguation, &a.RatingsCount, &a.AverageRating, &monitored,
-		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.MetadataProvider,
+		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.AudiobookRootFolderID, &a.MetadataProvider,
 		&a.LastMetadataRefreshAt, &a.CreatedAt, &a.UpdatedAt)
 	a.Monitored = monitored == 1
 	return a, err

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -139,6 +139,71 @@ func TestMigrate033ABSReviewResolutionIdempotent(t *testing.T) {
 	}
 }
 
+// TestMigrate042AuthorAudiobookRootFolder verifies migration 042 adds the
+// audiobook_root_folder_id column to the authors table (#579) and that the
+// column round-trips a value through CreateForUser / GetByID.
+func TestMigrate042AuthorAudiobookRootFolder(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	var name string
+	if err := database.QueryRow(
+		`SELECT name FROM pragma_table_info('authors') WHERE name = 'audiobook_root_folder_id'`,
+	).Scan(&name); err != nil {
+		t.Fatalf("authors.audiobook_root_folder_id column missing after migration: %v", err)
+	}
+
+	// Re-running migrate must not fail — ALTER TABLE ADD COLUMN is not
+	// idempotent in SQLite, so this confirms the schema_migrations marker
+	// guards the re-run.
+	if err := migrate(database); err != nil {
+		t.Fatalf("rerun migrations should be idempotent: %v", err)
+	}
+
+	// Round-trip the new field through the repo.
+	ctx := context.Background()
+	rf := NewRootFolderRepo(database)
+	folder, err := rf.Create(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("create root folder: %v", err)
+	}
+
+	authors := NewAuthorRepo(database)
+	author := &models.Author{
+		ForeignID:             "OL-ab-root-042",
+		Name:                  "Audiobook Author",
+		SortName:              "Author, Audiobook",
+		AudiobookRootFolderID: &folder.ID,
+	}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatalf("create author: %v", err)
+	}
+
+	got, err := authors.GetByID(ctx, author.ID)
+	if err != nil || got == nil {
+		t.Fatalf("get author: %v", err)
+	}
+	if got.AudiobookRootFolderID == nil || *got.AudiobookRootFolderID != folder.ID {
+		t.Fatalf("AudiobookRootFolderID not persisted: want %d, got %v", folder.ID, got.AudiobookRootFolderID)
+	}
+
+	// Updating it to nil must clear it.
+	got.AudiobookRootFolderID = nil
+	if err := authors.Update(ctx, got); err != nil {
+		t.Fatalf("update author: %v", err)
+	}
+	reloaded, err := authors.GetByID(ctx, author.ID)
+	if err != nil || reloaded == nil {
+		t.Fatalf("reload author: %v", err)
+	}
+	if reloaded.AudiobookRootFolderID != nil {
+		t.Fatalf("AudiobookRootFolderID should be nil after clear, got %v", *reloaded.AudiobookRootFolderID)
+	}
+}
+
 func migrationVersionForTest(t *testing.T, filename string) int {
 	t.Helper()
 	v, err := migrationVersion(filename)

--- a/internal/db/migrations/042_author_audiobook_root_folder.sql
+++ b/internal/db/migrations/042_author_audiobook_root_folder.sql
@@ -1,0 +1,6 @@
+-- Per-author audiobook root folder (issue #579). Adds a nullable override
+-- distinct from root_folder_id: root_folder_id only routes ebooks, so an
+-- audiobook-specific column lets an author's audiobooks land in their own
+-- directory without an ebook root folder accidentally redirecting them (#421).
+-- Nullable: when unset, audiobooks fall back to BINDERY_AUDIOBOOK_DIR.
+ALTER TABLE authors ADD COLUMN audiobook_root_folder_id INTEGER;

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -165,6 +165,23 @@ func (s *Scanner) effectiveLibraryDir(ctx context.Context, author *models.Author
 	return s.libraryDir
 }
 
+// effectiveAudiobookDir returns the audiobook root to use for the given author.
+// Priority: (1) author's explicit AudiobookRootFolderID, (2) global
+// audiobookDir from env-var. It deliberately mirrors effectiveLibraryDir but
+// consults a separate per-author field: routing audiobooks through the ebook
+// RootFolderID would send them into the ebook root whenever an author has any
+// custom ebook root folder assigned, silently ignoring BINDERY_AUDIOBOOK_DIR
+// (#421). There is no audiobook equivalent of library.defaultRootFolderId, so
+// the only override is the per-author column.
+func (s *Scanner) effectiveAudiobookDir(ctx context.Context, author *models.Author) string {
+	if author != nil && author.AudiobookRootFolderID != nil && s.rootFolders != nil {
+		if rf, err := s.rootFolders.GetByID(ctx, *author.AudiobookRootFolderID); err == nil && rf != nil {
+			return rf.Path
+		}
+	}
+	return s.audiobookDir
+}
+
 // WithCalibre attaches the Calibre integration. The mode resolver is consulted
 // on every import so the operator can switch modes in the UI without restarting.
 func (s *Scanner) WithCalibre(mode func() calibre.Mode, adder calibreAdder) *Scanner {
@@ -1151,14 +1168,12 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			}
 			return
 		}
-		// audiobookRoot always starts from BINDERY_AUDIOBOOK_DIR (set at
-		// startup). effectiveLibraryDir is format-agnostic — it resolves the
-		// per-author ebook root folder — so applying it here would send
-		// audiobooks into the ebook root whenever the author has any custom
-		// root folder assigned, silently ignoring BINDERY_AUDIOBOOK_DIR
-		// (#421). Until a per-author audiobook root folder field exists we
-		// leave audiobookRoot as-is.
-		audiobookRoot := s.audiobookDir
+		// effectiveAudiobookDir resolves the per-author audiobook root folder
+		// (#579) and falls back to BINDERY_AUDIOBOOK_DIR. It deliberately does
+		// NOT consult the author's ebook RootFolderID: routing audiobooks
+		// through that would send them into the ebook root whenever an author
+		// has any custom ebook root folder assigned (#421).
+		audiobookRoot := s.effectiveAudiobookDir(ctx, author)
 		seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
 		audiobookDest, destErr := s.renamer.AudiobookDestDir(audiobookRoot, author, book, seriesTitle, seriesNum)
 		if destErr != nil {

--- a/internal/importer/scanner_rootfolder_test.go
+++ b/internal/importer/scanner_rootfolder_test.go
@@ -215,6 +215,210 @@ func TestEffectiveLibraryDir_AuthorRootFolderTakesPriorityOverDefault(t *testing
 	}
 }
 
+// scannerWithRootFoldersAndAudiobookDir builds a Scanner wired to a real
+// in-memory DB with a RootFolderRepo, libraryDir and a distinct audiobookDir so
+// effectiveAudiobookDir resolution can be exercised end-to-end (#579).
+func scannerWithRootFoldersAndAudiobookDir(t *testing.T, libraryDir, audiobookDir string) (*Scanner, *db.RootFolderRepo, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	history := db.NewHistoryRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+	rf := db.NewRootFolderRepo(database)
+
+	s := NewScanner(downloads, clients, books, authors, history, libraryDir, audiobookDir, "", "", "")
+	s.WithRootFolders(rf)
+	return s, rf, context.Background()
+}
+
+func TestEffectiveAudiobookDir_NilAuthor(t *testing.T) {
+	s, _, ctx := scannerWithRootFoldersAndAudiobookDir(t, "/default/lib", "/default/audiobooks")
+	got := s.effectiveAudiobookDir(ctx, nil)
+	if got != "/default/audiobooks" {
+		t.Errorf("nil author: want /default/audiobooks, got %q", got)
+	}
+}
+
+func TestEffectiveAudiobookDir_AuthorNoAudiobookRootFolder(t *testing.T) {
+	s, _, ctx := scannerWithRootFoldersAndAudiobookDir(t, "/default/lib", "/default/audiobooks")
+	author := &models.Author{AudiobookRootFolderID: nil}
+	got := s.effectiveAudiobookDir(ctx, author)
+	if got != "/default/audiobooks" {
+		t.Errorf("author with nil AudiobookRootFolderID: want /default/audiobooks, got %q", got)
+	}
+}
+
+func TestEffectiveAudiobookDir_AuthorWithAudiobookRootFolder(t *testing.T) {
+	dir := t.TempDir()
+	s, rf, ctx := scannerWithRootFoldersAndAudiobookDir(t, "/default/lib", "/default/audiobooks")
+
+	created, err := rf.Create(ctx, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{AudiobookRootFolderID: &created.ID}
+	got := s.effectiveAudiobookDir(ctx, author)
+	if got != dir {
+		t.Errorf("author with AudiobookRootFolderID: want %q, got %q", dir, got)
+	}
+}
+
+// TestEffectiveAudiobookDir_IgnoresEbookRootFolder is the #421 guarantee at the
+// resolver level: an author with an ebook RootFolderID but no audiobook
+// override must still resolve to the global audiobook dir.
+func TestEffectiveAudiobookDir_IgnoresEbookRootFolder(t *testing.T) {
+	ebookDir := t.TempDir()
+	s, rf, ctx := scannerWithRootFoldersAndAudiobookDir(t, "/default/lib", "/default/audiobooks")
+
+	ebookRF, err := rf.Create(ctx, ebookDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Ebook root folder set, audiobook root folder NOT set.
+	author := &models.Author{RootFolderID: &ebookRF.ID}
+	got := s.effectiveAudiobookDir(ctx, author)
+	if got != "/default/audiobooks" {
+		t.Errorf("ebook root folder must not redirect audiobooks (#421): want /default/audiobooks, got %q", got)
+	}
+}
+
+func TestEffectiveAudiobookDir_DeletedRootFolderFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	s, rf, ctx := scannerWithRootFoldersAndAudiobookDir(t, "/default/lib", "/default/audiobooks")
+
+	created, err := rf.Create(ctx, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rf.Delete(ctx, created.ID); err != nil {
+		t.Fatal(err)
+	}
+	author := &models.Author{AudiobookRootFolderID: &created.ID}
+	got := s.effectiveAudiobookDir(ctx, author)
+	if got != "/default/audiobooks" {
+		t.Errorf("deleted audiobook root folder: want /default/audiobooks, got %q", got)
+	}
+}
+
+func TestEffectiveAudiobookDir_NoRootFolderRepo(t *testing.T) {
+	// Scanner without WithRootFolders — should always use audiobookDir.
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	history := db.NewHistoryRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+	s := NewScanner(downloads, clients, books, authors, history, "/default/lib", "/default/audiobooks", "", "", "")
+	// No WithRootFolders call — rootFolders field is nil.
+
+	id := int64(42)
+	author := &models.Author{AudiobookRootFolderID: &id}
+	got := s.effectiveAudiobookDir(context.Background(), author)
+	if got != "/default/audiobooks" {
+		t.Errorf("no repo: want /default/audiobooks, got %q", got)
+	}
+}
+
+// TestAudiobookImport_UsesPerAuthorAudiobookRootFolder verifies the end-to-end
+// placement path: when an author has an audiobook root folder set, the imported
+// audiobook lands under it rather than the global BINDERY_AUDIOBOOK_DIR (#579).
+func TestAudiobookImport_UsesPerAuthorAudiobookRootFolder(t *testing.T) {
+	perAuthorAudiobookDir := t.TempDir() // author's audiobook root folder
+	globalAudiobookDir := t.TempDir()    // BINDERY_AUDIOBOOK_DIR
+	libraryDir := t.TempDir()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	history := db.NewHistoryRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+	rf := db.NewRootFolderRepo(database)
+
+	s := NewScanner(downloads, clients, books, authors, history, libraryDir, globalAudiobookDir, "", "", "")
+	s.WithRootFolders(rf)
+
+	ctx := context.Background()
+
+	audiobookRF, err := rf.Create(ctx, perAuthorAudiobookDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{
+		ForeignID:             "OL-ab-rf-author",
+		Name:                  "Test Author",
+		SortName:              "Author, Test",
+		AudiobookRootFolderID: &audiobookRF.ID,
+	}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	book := &models.Book{
+		ForeignID: "OL-ab-rf-book",
+		AuthorID:  author.ID,
+		Title:     "Per-Author Audiobook",
+		Status:    models.BookStatusWanted,
+		MediaType: models.MediaTypeAudiobook,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	dl := &models.Download{
+		GUID:   "guid-ab-per-author-rf",
+		Title:  book.Title,
+		BookID: &book.ID,
+		Status: models.StateCompleted,
+		NZBURL: "fake://url",
+	}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	downloadPath := t.TempDir()
+	m4bFile := filepath.Join(downloadPath, "audiobook.m4b")
+	if err := os.WriteFile(m4bFile, []byte("fake m4b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s.tryImportInternal(ctx, dl, downloadPath, "", "", nil)
+
+	got, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AudiobookFilePath == "" {
+		t.Fatal("AudiobookFilePath is empty — import did not complete")
+	}
+	if !strings.HasPrefix(got.AudiobookFilePath, perAuthorAudiobookDir) {
+		t.Errorf("audiobook landed in %q; want path under per-author audiobook root folder %q",
+			got.AudiobookFilePath, perAuthorAudiobookDir)
+	}
+	if strings.HasPrefix(got.AudiobookFilePath, globalAudiobookDir) {
+		t.Errorf("audiobook landed in global audiobook dir %q — per-author override was ignored (#579)",
+			got.AudiobookFilePath)
+	}
+}
+
 // TestAudiobookImport_UsesAudiobookDirNotEbookRoot is a regression test for
 // issue #421. When an author has a per-author ebook root folder set,
 // audiobooks must still be placed under BINDERY_AUDIOBOOK_DIR (s.audiobookDir)

--- a/internal/models/author.go
+++ b/internal/models/author.go
@@ -5,19 +5,24 @@ package models
 import "time"
 
 type Author struct {
-	ID                    int64      `json:"id"`
-	ForeignID             string     `json:"foreignAuthorId"`
-	Name                  string     `json:"authorName"`
-	SortName              string     `json:"sortName"`
-	Description           string     `json:"description"`
-	ImageURL              string     `json:"imageUrl"`
-	Disambiguation        string     `json:"disambiguation"`
-	RatingsCount          int        `json:"ratingsCount"`
-	AverageRating         float64    `json:"averageRating"`
-	Monitored             bool       `json:"monitored"`
-	QualityProfileID      *int64     `json:"qualityProfileId"`
-	MetadataProfileID     *int64     `json:"metadataProfileId"`
-	RootFolderID          *int64     `json:"rootFolderId"`
+	ID                int64   `json:"id"`
+	ForeignID         string  `json:"foreignAuthorId"`
+	Name              string  `json:"authorName"`
+	SortName          string  `json:"sortName"`
+	Description       string  `json:"description"`
+	ImageURL          string  `json:"imageUrl"`
+	Disambiguation    string  `json:"disambiguation"`
+	RatingsCount      int     `json:"ratingsCount"`
+	AverageRating     float64 `json:"averageRating"`
+	Monitored         bool    `json:"monitored"`
+	QualityProfileID  *int64  `json:"qualityProfileId"`
+	MetadataProfileID *int64  `json:"metadataProfileId"`
+	RootFolderID      *int64  `json:"rootFolderId"`
+	// AudiobookRootFolderID overrides the audiobook destination for this
+	// author. Distinct from RootFolderID, which only routes ebooks: keeping
+	// them separate ensures an ebook root folder never redirects audiobooks
+	// (#421). Nil falls back to the global audiobook library dir.
+	AudiobookRootFolderID *int64     `json:"audiobookRootFolderId"`
 	MetadataProvider      string     `json:"metadataProvider"`
 	LastMetadataRefreshAt *time.Time `json:"lastMetadataRefreshAt"`
 	CreatedAt             time.Time  `json:"createdAt"`

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -256,7 +256,7 @@ export const api = {
   listAuthors: () => request<Author[]>('/author'),
   getAuthor: (id: number) => request<Author>(`/author/${id}`),
   addAuthor: (data: AddAuthorRequest) => request<Author>('/author', { method: 'POST', body: JSON.stringify(data) }),
-  updateAuthor: (id: number, data: Partial<Author>) => request<Author>(`/author/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  updateAuthor: (id: number, data: UpdateAuthorRequest) => request<Author>(`/author/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   deleteAuthor: (id: number, deleteFiles = false) =>
     request<void>(`/author/${id}${deleteFiles ? '?deleteFiles=true' : ''}`, { method: 'DELETE' }),
   refreshAuthor: (id: number) => request<void>(`/author/${id}/refresh`, { method: 'POST' }),
@@ -536,6 +536,7 @@ export interface Author {
   qualityProfileId?: number | null
   metadataProfileId?: number | null
   rootFolderId?: number | null
+  audiobookRootFolderId?: number | null
   books?: Book[]
   statistics?: { bookCount: number; availableBookCount: number; wantedBookCount: number }
   aliases?: AuthorAlias[]
@@ -1057,6 +1058,19 @@ export interface AddAuthorRequest {
   qualityProfileId?: number | null
   rootFolderId?: number | null
   mediaType?: MediaType
+}
+
+// UpdateAuthorRequest is a partial author patch. clearAudiobookRootFolder is a
+// separate flag because a null audiobookRootFolderId is ambiguous over the wire
+// (omitted vs. cleared): the backend only resets the per-author audiobook root
+// folder when this flag is true.
+export interface UpdateAuthorRequest {
+  monitored?: boolean
+  qualityProfileId?: number | null
+  metadataProfileId?: number | null
+  rootFolderId?: number | null
+  audiobookRootFolderId?: number | null
+  clearAudiobookRootFolder?: boolean
 }
 
 export interface GrabRequest {

--- a/web/src/components/EditAuthorModal.test.tsx
+++ b/web/src/components/EditAuthorModal.test.tsx
@@ -67,12 +67,13 @@ describe('EditAuthorModal', () => {
   })
 
   async function getSelects() {
-    // Wait for profiles to load — once they do all three selects render.
+    // Wait for profiles to load — once they do all four selects render
+    // (quality, metadata, ebook root folder, audiobook root folder).
     await screen.findByRole('option', { name: 'Any' })
     const selects = screen.getAllByRole('combobox') as HTMLSelectElement[]
-    expect(selects).toHaveLength(3)
-    const [quality, metadata, root] = selects
-    return { quality, metadata, root }
+    expect(selects).toHaveLength(4)
+    const [quality, metadata, root, audiobookRoot] = selects
+    return { quality, metadata, root, audiobookRoot }
   }
 
   it('opens with the current author values prefilled', async () => {
@@ -98,6 +99,44 @@ describe('EditAuthorModal', () => {
     const callArg = vi.mocked(api.updateAuthor).mock.calls[0][1] as Record<string, unknown>
     expect('metadataProfileId' in callArg).toBe(false)
     expect('rootFolderId' in callArg).toBe(false)
+    expect('audiobookRootFolderId' in callArg).toBe(false)
+    expect('clearAudiobookRootFolder' in callArg).toBe(false)
+  })
+
+  it('prefills the audiobook root folder and sends it when changed', async () => {
+    render(
+      <EditAuthorModal
+        author={{ ...baseAuthor, audiobookRootFolderId: 100 }}
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    )
+
+    const { audiobookRoot } = await getSelects()
+    expect(audiobookRoot.value).toBe('100')
+
+    fireEvent.change(audiobookRoot, { target: { value: '101' } })
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(api.updateAuthor).toHaveBeenCalledTimes(1))
+    expect(api.updateAuthor).toHaveBeenCalledWith(42, { audiobookRootFolderId: 101 })
+  })
+
+  it('sends the clear flag when the audiobook root folder is reset to the global folder', async () => {
+    render(
+      <EditAuthorModal
+        author={{ ...baseAuthor, audiobookRootFolderId: 100 }}
+        onClose={onClose}
+        onSaved={onSaved}
+      />,
+    )
+
+    const { audiobookRoot } = await getSelects()
+    fireEvent.change(audiobookRoot, { target: { value: '' } })
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(api.updateAuthor).toHaveBeenCalledTimes(1))
+    expect(api.updateAuthor).toHaveBeenCalledWith(42, { clearAudiobookRootFolder: true })
   })
 
   it('passes the updated author to onSaved after a successful save', async () => {

--- a/web/src/components/EditAuthorModal.tsx
+++ b/web/src/components/EditAuthorModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, Author, MetadataProfile, QualityProfile, RootFolder } from '../api/client'
+import { api, Author, MetadataProfile, QualityProfile, RootFolder, UpdateAuthorRequest } from '../api/client'
 
 interface Props {
   author: Author
@@ -18,6 +18,7 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
   const [qualityProfileId, setQualityProfileId] = useState<number | null>(author.qualityProfileId ?? null)
   const [metadataProfileId, setMetadataProfileId] = useState<number | null>(author.metadataProfileId ?? null)
   const [rootFolderId, setRootFolderId] = useState<number | null>(author.rootFolderId ?? null)
+  const [audiobookRootFolderId, setAudiobookRootFolderId] = useState<number | null>(author.audiobookRootFolderId ?? null)
 
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -43,7 +44,7 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
   const save = async () => {
     // Build a patch with only the fields that actually changed — sending
     // unchanged values is functionally fine but produces noisy log lines.
-    const patch: Partial<Author> = {}
+    const patch: UpdateAuthorRequest = {}
     if (qualityProfileId !== (author.qualityProfileId ?? null)) {
       patch.qualityProfileId = qualityProfileId
     }
@@ -52,6 +53,16 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
     }
     if (rootFolderId !== (author.rootFolderId ?? null)) {
       patch.rootFolderId = rootFolderId
+    }
+    if (audiobookRootFolderId !== (author.audiobookRootFolderId ?? null)) {
+      // A null audiobookRootFolderId is indistinguishable from "omitted" once
+      // serialised, so resetting to the global dir is signalled by an explicit
+      // flag the backend honours separately.
+      if (audiobookRootFolderId === null) {
+        patch.clearAudiobookRootFolder = true
+      } else {
+        patch.audiobookRootFolderId = audiobookRootFolderId
+      }
     }
 
     if (Object.keys(patch).length === 0) {
@@ -125,6 +136,22 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
                       <option key={rf.id} value={rf.id}>{rf.path}</option>
                     ))}
                   </select>
+                </div>
+              )}
+              {rootFolders.length > 0 && (
+                <div className="mb-3">
+                  <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('editAuthorModal.audiobookRootFolder', 'Audiobook root folder')}</label>
+                  <select
+                    value={audiobookRootFolderId ?? ''}
+                    onChange={e => setAudiobookRootFolderId(e.target.value ? Number(e.target.value) : null)}
+                    className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+                  >
+                    <option value="">{t('editAuthorModal.audiobookRootFolderDefault', 'Use global audiobook folder')}</option>
+                    {rootFolders.map(rf => (
+                      <option key={rf.id} value={rf.id}>{rf.path}</option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('editAuthorModal.audiobookRootFolderHint', "Where this author's audiobooks are stored. Separate from the ebook root folder.")}</p>
                 </div>
               )}
               {error && (

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -151,7 +151,7 @@ export default function AuthorDetailPage() {
   const handleToggleMonitored = async () => {
     if (!author) return
     try {
-      await api.updateAuthor(author.id, { monitored: !author.monitored } as Partial<Author>)
+      await api.updateAuthor(author.id, { monitored: !author.monitored })
       setAuthor({ ...author, monitored: !author.monitored })
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Update failed')

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -66,7 +66,7 @@ export default function AuthorsPage() {
   }
 
   const handleToggleMonitored = async (author: Author) => {
-    await api.updateAuthor(author.id, { monitored: !author.monitored } as Partial<Author>)
+    await api.updateAuthor(author.id, { monitored: !author.monitored })
     load()
   }
 


### PR DESCRIPTION
Closes #579

Credit to @j-tt for the original report and the reference patch (`j-tt/bindery@3ea2bcb`). That patch was ~6 releases stale; this PR re-implements the same design against current `main` (migration renumbered 038 → 042, ABS import path added, frontend rewritten for the current `EditAuthorModal`).

## Problem

All audiobooks route to the single global `BINDERY_AUDIOBOOK_DIR`. `models.Author` has `RootFolderID` for ebooks only — and per #421 it deliberately must NOT redirect audiobooks — so there is no way to send different authors' audiobooks to different directories.

## Change

- **Migration `042_author_audiobook_root_folder.sql`** — adds a nullable `audiobook_root_folder_id` column to `authors`, matching how `root_folder_id` is defined (plain nullable `INTEGER`, no explicit FK, consistent with the existing schema).
- **Model** — `models.Author.AudiobookRootFolderID *int64` (`json:"audiobookRootFolderId"`).
- **DB layer** — `internal/db/authors.go` scans/inserts/updates the new column everywhere `root_folder_id` is handled (select cols, `CreateForUser`, `Update`, both scan helpers).
- **Scanner** — new `effectiveAudiobookDir(ctx, author)`: returns the author's `AudiobookRootFolderID` path when set, else the global audiobook dir. Wired into the audiobook placement path in `tryImportInternal` (replacing the hard-coded `s.audiobookDir`). Ebook routing via `effectiveLibraryDir` is untouched (#421). There is no `library.defaultRootFolderId` equivalent for audiobooks, so the only override is the per-author column.
- **ABS importer** — new `effectiveAudiobookDir(ctx, author)` on `internal/abs.Importer`, wired into `allowedRootsForBook`: audiobook reconciliation now accepts the per-author audiobook root folder (then the global audiobook dir, then library dir) so an audiobook stored under an author's override is recognised as inside Bindery storage rather than rejected as "outside Bindery storage; imported metadata only".
- **API** — author `Create` and `Update` accept `audiobookRootFolderId`. `Update` also accepts a `clearAudiobookRootFolder` flag, because a `null` id is indistinguishable from "omitted" once serialised; the flag is how the UI resets the override back to the global folder.
- **Frontend** — `EditAuthorModal` gains an "Audiobook root folder" selector next to the existing root-folder selector, with a "use global audiobook folder" default option and a hint clarifying it is separate from the ebook root folder.

## Tests

- `effectiveAudiobookDir` resolution: nil author, author without override (fallback), author with override, ebook-root-folder-must-not-redirect (#421 guarantee), deleted root folder fallback, no root-folder repo.
- End-to-end `TestAudiobookImport_UsesPerAuthorAudiobookRootFolder` — imports an audiobook and asserts it lands under the per-author folder, not the global dir.
- `TestMigrate042AuthorAudiobookRootFolder` — verifies the column exists, migration re-run is idempotent, and the value round-trips through the repo including clear-to-nil.
- `EditAuthorModal` tests updated for the 4th select, plus new cases for prefill, change, and the clear flag.

## Verification (all run in the worktree)

- `gofmt -l` on changed Go files — clean.
- `go vet ./...` — clean.
- `go build ./...` — succeeds.
- `go test ./internal/importer/... ./internal/abs/... ./internal/db/... ./internal/api/...` — all pass.
- `cd web && npm run typecheck` — clean.
- `cd web && npm run build` — succeeds.
- `cd web && npm run lint` — 5 warnings, all pre-existing on `main` (AuthContext, HardcoverSeriesLinkModal, UsersPage, WantedPage); none in files touched here.
- `EditAuthorModal` Vitest suite — 8/8 pass. Full `web` Vitest suite has one pre-existing failure in `QueuePage.test.tsx` confirmed to fail identically on a clean `main`; unrelated to this change.

## Notes / deviations

- `EditAuthorModal` strings use `t('editAuthorModal.*', 'fallback')` defaults — the entire component already relies on `t()` fallbacks with no `editAuthorModal` keys in any locale file. New keys follow that existing convention rather than introducing a half-populated locale section.
- `FindExisting` (pre-search dedup) still walks only the global roots; it has no `*models.Author` in scope and extending it is outside this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)