### PR TITLE
fix(telemetry): stage DB backup next to the DB, not /tmp

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -50,6 +50,7 @@ func isReleaseVersion(v string) bool {
 
 type server struct {
 	db            *sql.DB
+	dbDir         string // directory holding the DB — the writable data volume
 	latestVersion string
 	statsToken    string
 	limiter       *rateLimiter
@@ -153,6 +154,7 @@ func main() {
 
 	s := &server{
 		db:            db,
+		dbDir:         filepath.Dir(dbPath),
 		latestVersion: latestVersion,
 		statsToken:    statsToken,
 		// Each IP may ping at most once per hour.
@@ -695,7 +697,11 @@ func (s *server) handleBackup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dir, err := os.MkdirTemp("", "bindery-backup-*")
+	// Stage the snapshot in the DB's own directory, not os.MkdirTemp's
+	// default of /tmp: the container runs with readOnlyRootFilesystem, so
+	// /tmp is not writable and MkdirTemp there fails every call. The DB
+	// directory is the data volume and is writable by definition.
+	dir, err := os.MkdirTemp(s.dbDir, "bindery-backup-*")
 	if err != nil {
 		slog.Error("backup: mkdir", "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -181,4 +182,44 @@ func TestHandleStatsJSON(t *testing.T) {
 	if got.Latest != "v1.9.5" {
 		t.Errorf("Latest = %q, want v1.9.5", got.Latest)
 	}
+}
+
+func TestHandleBackup(t *testing.T) {
+	s := newTestServer(t, "v1.9.5")
+	s.statsToken = "secret"
+	s.dbDir = t.TempDir() // stand-in for the writable data volume
+	if _, err := s.db.ExecContext(context.Background(),
+		`INSERT INTO installs (install_id, version, os, arch, first_seen, last_seen, deploy)
+		 VALUES ('11111111-1111-1111-1111-111111111111', '1.9.5', 'linux', 'amd64', ?, ?, 'docker')`,
+		time.Now().UTC(), time.Now().UTC()); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/backup", nil)
+		req.Header.Set("Authorization", "Bearer secret")
+		rec := httptest.NewRecorder()
+		s.handleBackup(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+		}
+		// A valid SQLite file begins with the literal header "SQLite format 3\0".
+		if !bytes.HasPrefix(rec.Body.Bytes(), []byte("SQLite format 3\x00")) {
+			t.Errorf("response body is not a SQLite database")
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/vnd.sqlite3" {
+			t.Errorf("Content-Type = %q, want application/vnd.sqlite3", ct)
+		}
+	})
+
+	t.Run("wrong token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/backup", nil)
+		req.Header.Set("Authorization", "Bearer nope")
+		rec := httptest.NewRecorder()
+		s.handleBackup(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", rec.Code)
+		}
+	})
 }

--- a/deploy/telemetry-server.yaml
+++ b/deploy/telemetry-server.yaml
@@ -76,10 +76,19 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            # Writable scratch. The container runs readOnlyRootFilesystem;
+            # the server stages its /api/backup VACUUM INTO copy next to the
+            # DB now, but keeping /tmp writable is cheap insurance for any
+            # stdlib path that falls back to it.
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: bindery-ping-data
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

`handleBackup` created its `VACUUM INTO` staging directory with `os.MkdirTemp("")`, which resolves to `/tmp`. The telemetry-server runs with `readOnlyRootFilesystem: true`, so `/tmp` is not writable — every `/api/backup` call returned HTTP 500 (`mkdir /tmp/bindery-backup-...: read-only file system`), and the scheduled `telemetry-backup` workflow had been failing **7 days straight** (last green run 2026-05-14).

Two commits:
1. **`fix(telemetry)`** — the real fix: stage the snapshot in the DB's own directory (`DB_PATH`'s parent, the writable data volume) so the server no longer depends on `/tmp`.
2. **`fix(deploy)`** — belt-and-suspenders: an `emptyDir` at `/tmp` on the telemetry-server, so the currently-running image keeps working until the fixed image ships, and the manifest matches the running getbindery.dev deployment.

## Implementation notes

- `server` gains a `dbDir` field, set in `main()` to `filepath.Dir(dbPath)`.
- `handleBackup` uses `os.MkdirTemp(s.dbDir, …)` instead of `os.MkdirTemp("", …)`. The data volume is writable by definition (the DB lives there).
- `deploy/telemetry-server.yaml` gains a `tmp` `emptyDir` (64Mi) mounted at `/tmp`.
- Adds `TestHandleBackup` (happy path + auth rejection). `handleBackup` had no test — part of why this shipped unnoticed.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — no env vars / flags / auth / config surface changed
- [x] Wiki pages updated if user-facing behaviour changed — n/a, internal

## Test plan

- [x] `go test -race ./cmd/telemetry-server/`
- [x] `go vet` + `go build` + `gofmt -l` on `./cmd/telemetry-server/` — clean
- [x] `deploy/telemetry-server.yaml` — YAML parse-checked
- [ ] Full `go test ./cmd/... ./internal/...` — not run; change is isolated to `cmd/telemetry-server`
- [x] Verified live against getbindery.dev: `/api/backup` → HTTP 200 + valid SQLite; `telemetry-backup` workflow re-run → success (451 rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
