### PR TITLE
test(web): fix stale QueuePage removal test for confirmation modal

### DIFF
--- a/web/src/pages/QueuePage.test.tsx
+++ b/web/src/pages/QueuePage.test.tsx
@@ -285,7 +285,7 @@ describe('QueuePage', () => {
     expect(await screen.findByText('Queue is empty')).toBeInTheDocument()
   })
 
-  it('deletes a queue item and reloads the queue', async () => {
+  it('deletes a queue item via the confirmation modal and reloads the queue', async () => {
     vi.mocked(api.listQueue)
       .mockResolvedValueOnce([makeQueueItem({ id: 7, title: 'Remove Me' })])
       .mockResolvedValueOnce([])
@@ -296,9 +296,31 @@ describe('QueuePage', () => {
     const card = item.closest('div')!.parentElement!
     fireEvent.click(within(card).getByRole('button', { name: 'Remove' }))
 
-    await waitFor(() => expect(api.deleteFromQueue).toHaveBeenCalledWith(7))
+    // The card's Remove button opens a confirmation modal; the actual delete
+    // only fires on the modal's confirm button. Its label is the untranslated
+    // i18n key here because the test's t() mock only maps a curated subset.
+    fireEvent.click(await screen.findByRole('button', { name: 'queue.removeConfirm' }))
+
+    await waitFor(() => expect(api.deleteFromQueue).toHaveBeenCalledWith(7, false))
     await waitFor(() => expect(api.listQueue).toHaveBeenCalledTimes(2))
     expect(await screen.findByText('Queue is empty')).toBeInTheDocument()
+  })
+
+  it('passes deleteFiles=true when the modal "delete files" checkbox is ticked', async () => {
+    vi.mocked(api.listQueue)
+      .mockResolvedValueOnce([makeQueueItem({ id: 7, title: 'Remove Me' })])
+      .mockResolvedValueOnce([])
+
+    renderQueuePage()
+
+    const item = await screen.findByText('Remove Me')
+    const card = item.closest('div')!.parentElement!
+    fireEvent.click(within(card).getByRole('button', { name: 'Remove' }))
+
+    fireEvent.click(await screen.findByRole('checkbox'))
+    fireEvent.click(screen.getByRole('button', { name: 'queue.removeConfirm' }))
+
+    await waitFor(() => expect(api.deleteFromQueue).toHaveBeenCalledWith(7, true))
   })
 
   it('polls the queue every five seconds and clears the interval on unmount', async () => {


### PR DESCRIPTION
## Problem

`web/src/pages/QueuePage.test.tsx` had a failing test on `main` (`deletes a queue item and reloads the queue`). It was flagged independently by three separate agents during recent work — a genuine pre-existing breakage, unrelated to any feature.

## Cause

`QueuePage` gained a **removal confirmation modal** with an optional "delete files" checkbox, and `api.deleteFromQueue` now takes a second `deleteFiles` argument. The test still:
- clicked the card's **Remove** button and expected an immediate `deleteFromQueue(7)` — but Remove now only *opens* the modal, so the delete never fired and the test timed out at `waitFor`;
- asserted `toHaveBeenCalledWith(7)` — the component now calls `deleteFromQueue(id, deleteFiles)`.

The component itself is correct (all `queue.remove*` i18n keys exist in `en.json`) — this is a **test-only** fix.

## Change

- Update the test to click the modal's confirm button, and assert `deleteFromQueue(7, false)`.
- Add a test covering the "delete files" checkbox path — `deleteFromQueue(7, true)` — which previously had no coverage.

## Verification

- `QueuePage.test.tsx` — 9/9 pass
- Full `web` suite — **220 passing, 24 files** (was 1 failing)
- `npm run typecheck` clean; `npm run lint` — no new warnings