### PR TITLE
feat(auth): OIDC role mapping — default role + group claim + lockout-trap fix (#688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **OIDC role mapping** (#688) — three new opt-in, backward-compatible env vars remove the manual-promotion friction (and lockout trap) of SSO-only deployments. `BINDERY_OIDC_DEFAULT_ROLE` (`user`/`admin`, default `user`) sets the role assigned at OIDC auto-provision time. `BINDERY_OIDC_ADMIN_GROUP` makes the IdP authoritative for the admin role: when set, every login promotes the user to `admin` if the configured group claim contains that group and demotes to `user` if absent — overriding the manual role-promotion API for OIDC users. `BINDERY_OIDC_GROUP_CLAIM` (default `groups`) selects the claim path and tolerates both shapes IdPs emit (a JSON array of strings, or a single space/comma-delimited string). Finally, when local auth is disabled and Bindery has zero admins at OIDC-provision time, the first provisioned OIDC user is auto-promoted to admin — guarded by a one-shot settings flag so deleting all admins later cannot silently re-promote.
+
 ## [v1.13.2] — 2026-05-20
 
 ### Changed

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -433,7 +433,11 @@ func main() {
 	oidcHandler := api.NewOIDCHandler(oidcMgr, userRepo, settingsRepo, authHandler, oidcResolveBase).
 		WithBaseConfigured(cfg.OIDCRedirectBaseURL != "").
 		WithOIDCAutoProvision(cfg.OIDCAutoProvision).
-		WithOIDCEmailLink(cfg.OIDCEmailLink)
+		WithOIDCEmailLink(cfg.OIDCEmailLink).
+		WithLocalAuthEnabled(cfg.LocalAuthEnabled).
+		WithOIDCDefaultRole(cfg.OIDCDefaultRole).
+		WithOIDCAdminGroup(cfg.OIDCAdminGroup).
+		WithOIDCGroupClaim(cfg.OIDCGroupClaim)
 	userMgmtHandler := api.NewUserManagementHandler(userRepo).
 		WithLocalAuthEnabled(cfg.LocalAuthEnabled)
 	searchHandler := api.NewSearchHandler(metaAgg)

--- a/docs/auth-oidc.md
+++ b/docs/auth-oidc.md
@@ -22,6 +22,9 @@ Sessions are issued using the same HMAC-signed cookie as password login. OIDC si
 | `BINDERY_LOCAL_AUTH_ENABLED` | `true` | Set to `false` to disable password-based login entirely. `POST /auth/login` returns 403 and the admin user-create API is also blocked. Use when all users must authenticate via OIDC. |
 | `BINDERY_OIDC_AUTO_PROVISION` | `true` | Set to `false` to require that OIDC users already exist in Bindery's database. First-time OIDC logins from unknown `(issuer, sub)` pairs return 403 instead of creating an account. |
 | `BINDERY_OIDC_EMAIL_LINK` | `false` | Set to `true` to link an unknown OIDC identity to an existing Bindery account if the email address matches. Runs before the auto-provision check. Useful for migrating from local accounts to OIDC without losing history. |
+| `BINDERY_OIDC_DEFAULT_ROLE` | `user` | Role assigned to a freshly auto-provisioned OIDC user. Valid values: `user`, `admin`. Any other value falls back to `user`. Set to `admin` for single-admin homelab deployments to skip the manual promotion step. |
+| `BINDERY_OIDC_ADMIN_GROUP` | _(unset)_ | When set, makes the IdP authoritative for the admin role. On **every** login, the user is promoted to `admin` if this group is present in the group claim and demoted to `user` if absent. See [Group-based role mapping](#group-based-role-mapping). |
+| `BINDERY_OIDC_GROUP_CLAIM` | `groups` | ID-token claim path Bindery reads the user's groups from for `BINDERY_OIDC_ADMIN_GROUP`. Override for IdPs that put groups under a non-standard claim. |
 
 ## Redirect URL construction
 
@@ -111,6 +114,49 @@ When `BINDERY_OIDC_EMAIL_LINK=true`, Bindery tries to match an unrecognised OIDC
 This is a one-time migration path: once linked, the `(issuer, sub)` pair is stored and subsequent logins bypass the email check. If the email doesn't match any account, the normal auto-provision / deny logic continues.
 
 **Security note:** email linking trusts that the IdP has verified the email address. Only enable this with IdPs that verify email — don't use it with IdPs that allow users to self-assign arbitrary email claims.
+
+### OIDC role mapping
+
+By default every auto-provisioned OIDC user gets the `user` role and must be promoted to `admin` manually (via a local admin session or `PUT /api/v1/auth/users/{id}/role`). Three opt-in env vars remove that friction.
+
+#### Default role for new OIDC users
+
+```
+BINDERY_OIDC_DEFAULT_ROLE=admin
+```
+
+Sets the role assigned at auto-provision time. Valid values are `user` (default) and `admin`; any other value silently falls back to `user` (a startup warning is logged). Use `admin` for single-admin homelab deployments so the first — and only — operator is an admin immediately.
+
+This only affects **new** accounts at creation time. It does not change the role of users who already exist.
+
+#### Group-based role mapping
+
+```
+BINDERY_OIDC_ADMIN_GROUP=bindery-admin
+BINDERY_OIDC_GROUP_CLAIM=groups
+```
+
+When `BINDERY_OIDC_ADMIN_GROUP` is set, the **IdP becomes authoritative for the admin role**. On every login Bindery reads the configured group claim from the ID token and:
+
+- promotes the user to `admin` if the group is present, or
+- demotes the user to `user` if the group is absent.
+
+`BINDERY_OIDC_GROUP_CLAIM` (default `groups`) selects the claim path; override it for IdPs that emit groups under a different name.
+
+The group claim's value shape varies between IdPs — Bindery handles both forms:
+
+- a **JSON array of strings** (`["bindery-admin","staff"]`) — Authentik, Keycloak with a groups mapper;
+- a **single string** with several groups separated by spaces and/or commas (`"bindery-admin staff"` or `"bindery-admin,staff"`) — some Keycloak/Authelia role-string configs.
+
+Group name matching is exact and case-sensitive.
+
+> **Important:** while `BINDERY_OIDC_ADMIN_GROUP` is set it **overrides** any role set manually via `PUT /api/v1/auth/users/{id}/role` for OIDC users. A manual promotion or demotion is reverted on the user's next login to whatever the IdP group membership dictates. This is intentional — manage roles in the IdP, not in Bindery, when group mapping is enabled. The last-admin demotion guard is also bypassed for this IdP-driven sync, so removing a user from the admin group always takes effect.
+
+#### Avoiding the SSO-only lockout trap
+
+If `BINDERY_LOCAL_AUTH_ENABLED=false` and Bindery has **zero admin users** at the time an OIDC user is being provisioned, that user is automatically promoted to `admin`. This mirrors the local-auth `PromoteFirstUser` behaviour and removes the trap where disabling local auth before promoting any admin leaves the instance with no way in.
+
+The fallback is guarded by a one-shot flag (`auth.oidc.first_admin_promoted` in the settings table): once it fires, deleting every admin later will **not** silently re-promote the next OIDC login. The fallback also does nothing when local auth is still enabled (you have a recovery path) or when `BINDERY_OIDC_DEFAULT_ROLE=admin` (every new user is already an admin).
 
 ### Scenario: fully managed SSO deployment
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -43,6 +43,11 @@ const (
 	SettingAuthSessionSecretPrevious = "auth.session_secret_previous" //nolint:gosec // setting key name, not a credential
 	SettingAuthMode                  = "auth.mode"
 	SettingOIDCProviders             = "auth.oidc.providers" //nolint:gosec // setting key name, not a credential
+	// SettingOIDCFirstAdminPromoted is a one-shot guard for the
+	// promote-first-OIDC-user fallback (issue #688). Once an OIDC user has been
+	// auto-promoted to admin because the system had zero admins, this flag is
+	// set so deleting every admin later cannot silently re-trigger promotion.
+	SettingOIDCFirstAdminPromoted = "auth.oidc.first_admin_promoted" //nolint:gosec // setting key name, not a credential
 )
 
 // AuthHandler owns the login / setup / password / mode endpoints.

--- a/internal/api/auth_oidc.go
+++ b/internal/api/auth_oidc.go
@@ -41,6 +41,17 @@ type OIDCHandler struct {
 	baseConfigured    bool
 	oidcAutoProvision bool
 	oidcEmailLink     bool
+	// localAuthEnabled mirrors BINDERY_LOCAL_AUTH_ENABLED. When false, the
+	// promote-first-OIDC-user fallback (issue #688) is armed.
+	localAuthEnabled bool
+	// oidcDefaultRole is the role assigned to a freshly auto-provisioned OIDC
+	// user (issue #688). "admin" or "user"; coerced to "user" if invalid.
+	oidcDefaultRole string
+	// oidcAdminGroup, when non-empty, makes the IdP authoritative for the admin
+	// role: every login promotes/demotes the user based on group membership.
+	oidcAdminGroup string
+	// oidcGroupClaim is the ID-token claim path holding the user's groups.
+	oidcGroupClaim string
 }
 
 func NewOIDCHandler(mgr *oidc.Manager, users *db.UserRepo, settings *db.SettingsRepo, auth *AuthHandler, resolveBase func(*http.Request) string) *OIDCHandler {
@@ -52,6 +63,9 @@ func NewOIDCHandler(mgr *oidc.Manager, users *db.UserRepo, settings *db.Settings
 		resolveBase:       resolveBase,
 		oidcAutoProvision: true,
 		oidcEmailLink:     false,
+		localAuthEnabled:  true,
+		oidcDefaultRole:   "user",
+		oidcGroupClaim:    "groups",
 	}
 }
 
@@ -79,6 +93,44 @@ func (h *OIDCHandler) WithOIDCAutoProvision(v bool) *OIDCHandler {
 // creating a new one or returning 403.
 func (h *OIDCHandler) WithOIDCEmailLink(v bool) *OIDCHandler {
 	h.oidcEmailLink = v
+	return h
+}
+
+// WithLocalAuthEnabled mirrors BINDERY_LOCAL_AUTH_ENABLED into the OIDC handler.
+// When false, the promote-first-OIDC-user fallback is armed: an OIDC login that
+// finds zero admins in the DB promotes the user being provisioned to admin
+// (issue #688). Default true.
+func (h *OIDCHandler) WithLocalAuthEnabled(v bool) *OIDCHandler {
+	h.localAuthEnabled = v
+	return h
+}
+
+// WithOIDCDefaultRole sets the role assigned at OIDC auto-provision time
+// (issue #688). Valid values are "admin" and "user"; any other value falls
+// back to "user".
+func (h *OIDCHandler) WithOIDCDefaultRole(role string) *OIDCHandler {
+	if role != "admin" && role != "user" {
+		role = "user"
+	}
+	h.oidcDefaultRole = role
+	return h
+}
+
+// WithOIDCAdminGroup sets the IdP group whose presence in the configured group
+// claim grants the admin role (issue #688). When non-empty, the IdP becomes
+// authoritative: every login promotes the user to admin if the group is present
+// and demotes to user if it is absent. Empty disables group-based role mapping.
+func (h *OIDCHandler) WithOIDCAdminGroup(group string) *OIDCHandler {
+	h.oidcAdminGroup = strings.TrimSpace(group)
+	return h
+}
+
+// WithOIDCGroupClaim sets the ID-token claim path Bindery reads the user's
+// groups from (issue #688). Default "groups".
+func (h *OIDCHandler) WithOIDCGroupClaim(claim string) *OIDCHandler {
+	if c := strings.TrimSpace(claim); c != "" {
+		h.oidcGroupClaim = c
+	}
 	return h
 }
 
@@ -282,14 +334,48 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			writeErr(w, http.StatusForbidden, "access denied: account not provisioned")
 			return
 		}
+		// Decide the provisioning role (issue #688). Start from the configured
+		// default; the promote-first-OIDC-user fallback may upgrade it to admin.
+		provisionRole := h.resolveProvisionRole(ctx)
 		user, err = h.users.GetOrCreateByOIDC(ctx,
 			claims.Issuer, claims.Sub,
 			claims.PreferredUsername, claims.Email, claims.Name,
+			provisionRole,
 		)
 		if err != nil {
 			slog.Error("oidc: user provisioning failed", "error", err)
 			writeErr(w, http.StatusInternalServerError, "user provisioning failed")
 			return
+		}
+		// If the fallback fired, record the one-shot guard so deleting all
+		// admins later cannot silently re-promote a future first OIDC user.
+		if provisionRole == "admin" && user.Role == "admin" {
+			if err := h.settings.Set(ctx, SettingOIDCFirstAdminPromoted, "true"); err != nil {
+				slog.Warn("oidc: failed to persist first-admin-promoted flag", "error", err)
+			}
+		}
+	}
+
+	// 4. Group-claim role sync (issue #688). When BINDERY_OIDC_ADMIN_GROUP is
+	// configured, the IdP is authoritative for the admin role on every login:
+	// promote when the group is present, demote when absent. This intentionally
+	// overrides any role set via PUT /api/v1/auth/users/{id}/role for OIDC users.
+	if h.oidcAdminGroup != "" {
+		groups := oidc.GroupClaimValues(claims.Raw, h.oidcGroupClaim)
+		want := "user"
+		if oidc.ContainsGroup(groups, h.oidcAdminGroup) {
+			want = "admin"
+		}
+		if user.Role != want {
+			if err := h.users.SetRoleUnguarded(ctx, user.ID, want); err != nil {
+				slog.Error("oidc: group-claim role sync failed", "error", err, "user_id", user.ID)
+				writeErr(w, http.StatusInternalServerError, "role sync failed")
+				return
+			}
+			slog.Info("oidc: synced role from group claim",
+				"username", user.Username, "from", user.Role, "to", want,
+				"admin_group", h.oidcAdminGroup, "group_claim", h.oidcGroupClaim)
+			user.Role = want
 		}
 	}
 
@@ -300,6 +386,49 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	// Redirect to the UI root.
 	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+// resolveProvisionRole decides the role for a brand-new OIDC user (issue #688).
+//
+// It starts from the configured BINDERY_OIDC_DEFAULT_ROLE. The
+// promote-first-OIDC-user fallback then upgrades the result to "admin" when ALL
+// of the following hold:
+//
+//   - local auth is disabled (BINDERY_LOCAL_AUTH_ENABLED=false) — without it
+//     there is no other path back into an admin-less instance;
+//   - the DB currently has zero admin users — the lockout trap;
+//   - the one-shot SettingOIDCFirstAdminPromoted guard has never been set —
+//     so deleting every admin later does not silently re-promote.
+//
+// Any error reading the guard or counting admins is treated conservatively:
+// the fallback does not fire and the configured default role is used.
+func (h *OIDCHandler) resolveProvisionRole(ctx context.Context) string {
+	role := h.oidcDefaultRole
+	if role != "admin" && role != "user" {
+		role = "user"
+	}
+	if role == "admin" {
+		return role // already admin; fallback would be a no-op
+	}
+	if h.localAuthEnabled {
+		return role // local auth still offers a recovery path
+	}
+	if s, err := h.settings.Get(ctx, SettingOIDCFirstAdminPromoted); err != nil {
+		slog.Warn("oidc: cannot read first-admin-promoted guard; skipping promote-first fallback", "error", err)
+		return role
+	} else if s != nil && s.Value == "true" {
+		return role // fallback already used once
+	}
+	admins, err := h.users.CountAdmins(ctx)
+	if err != nil {
+		slog.Warn("oidc: cannot count admins; skipping promote-first fallback", "error", err)
+		return role
+	}
+	if admins == 0 {
+		slog.Warn("oidc: promoting first OIDC user to admin — local auth disabled and no admin exists")
+		return "admin"
+	}
+	return role
 }
 
 // TestDiscovery probes <issuer>/.well-known/openid-configuration and returns

--- a/internal/api/auth_oidc_callback_test.go
+++ b/internal/api/auth_oidc_callback_test.go
@@ -291,7 +291,7 @@ func TestCallback_EmailLink_VerifiedEmail(t *testing.T) {
 	// Pre-create the account that owns victim@example.com via a *different*
 	// OIDC issuer/sub so GetByOIDC for the callback's (issuer,sub) returns nil.
 	existing, err := users.GetOrCreateByOIDC(ctx, "https://other-issuer.example", "other-sub",
-		"victim", "victim@example.com", "Victim")
+		"victim", "victim@example.com", "Victim", "user")
 	if err != nil {
 		t.Fatalf("seed existing user: %v", err)
 	}
@@ -326,7 +326,7 @@ func TestCallback_EmailLink_UnverifiedEmail(t *testing.T) {
 	h, users, ctx := newCallbackTestHandler(t, idp, nil, true)
 
 	victim, err := users.GetOrCreateByOIDC(ctx, "https://other-issuer.example", "victim-sub",
-		"victim", "victim@example.com", "Victim")
+		"victim", "victim@example.com", "Victim", "user")
 	if err != nil {
 		t.Fatalf("seed victim: %v", err)
 	}
@@ -363,7 +363,7 @@ func TestCallback_EmailLink_MissingEmailVerifiedClaim(t *testing.T) {
 	h, users, ctx := newCallbackTestHandler(t, idp, nil, true)
 
 	victim, err := users.GetOrCreateByOIDC(ctx, "https://other-issuer.example", "victim-sub-2",
-		"victim2", "victim@example.com", "Victim")
+		"victim2", "victim@example.com", "Victim", "user")
 	if err != nil {
 		t.Fatalf("seed victim: %v", err)
 	}

--- a/internal/api/auth_oidc_rolemap_test.go
+++ b/internal/api/auth_oidc_rolemap_test.go
@@ -1,0 +1,351 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+// This file covers OIDC role mapping (issue #688): the BINDERY_OIDC_DEFAULT_ROLE
+// provisioning role, the BINDERY_OIDC_ADMIN_GROUP group-claim promotion/demotion
+// (both claim shapes), and the promote-first-OIDC-user lockout-trap fallback.
+//
+// It reuses the fakeIDP / newCallbackTestHandler / doCallback harness from
+// auth_oidc_callback_test.go.
+
+// --- Part 1: BINDERY_OIDC_DEFAULT_ROLE -------------------------------------
+
+// TestCallback_DefaultRole_User confirms the historical default: a provisioned
+// OIDC user gets role "user".
+func TestCallback_DefaultRole_User(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "u-default", "nonce": "test-nonce",
+		"preferred_username": "alice",
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	// default role is "user" out of the box
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByOIDC(ctx, idp.server.URL, "u-default")
+	if err != nil || u == nil {
+		t.Fatalf("provisioned user lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user", u.Role)
+	}
+}
+
+// TestCallback_DefaultRole_Admin confirms BINDERY_OIDC_DEFAULT_ROLE=admin
+// provisions the new user as admin.
+func TestCallback_DefaultRole_Admin(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "u-admin", "nonce": "test-nonce",
+		"preferred_username": "admin1",
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithOIDCDefaultRole("admin")
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByOIDC(ctx, idp.server.URL, "u-admin")
+	if err != nil || u == nil {
+		t.Fatalf("provisioned user lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "admin" {
+		t.Errorf("Role=%q, want admin", u.Role)
+	}
+}
+
+// TestCallback_DefaultRole_InvalidCoerced confirms an invalid configured role
+// is coerced to "user".
+func TestCallback_DefaultRole_InvalidCoerced(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "u-bad", "nonce": "test-nonce", "preferred_username": "bad",
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithOIDCDefaultRole("superuser")
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByOIDC(ctx, idp.server.URL, "u-bad")
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user (invalid configured role must coerce)", u.Role)
+	}
+}
+
+// --- Part 2: BINDERY_OIDC_ADMIN_GROUP group-claim sync ----------------------
+
+// TestCallback_GroupClaim_PromoteArrayShape verifies promotion to admin when the
+// admin group is present and the group claim is a JSON array of strings.
+func TestCallback_GroupClaim_PromoteArrayShape(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "g-array", "nonce": "test-nonce", "preferred_username": "ga",
+		"groups": []string{"staff", "bindery-admin"},
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithOIDCAdminGroup("bindery-admin")
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByOIDC(ctx, idp.server.URL, "g-array")
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "admin" {
+		t.Errorf("Role=%q, want admin (in admin group, array shape)", u.Role)
+	}
+}
+
+// TestCallback_GroupClaim_PromoteStringShape verifies promotion when the group
+// claim is a single space/comma-delimited string rather than an array.
+func TestCallback_GroupClaim_PromoteStringShape(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "g-string", "nonce": "test-nonce", "preferred_username": "gs",
+		"groups": "staff bindery-admin,readers",
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithOIDCAdminGroup("bindery-admin")
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByOIDC(ctx, idp.server.URL, "g-string")
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "admin" {
+		t.Errorf("Role=%q, want admin (in admin group, delimited-string shape)", u.Role)
+	}
+}
+
+// TestCallback_GroupClaim_DemoteOnAbsence verifies that an existing admin OIDC
+// user is demoted to "user" when the admin group is absent from the claim — the
+// IdP is authoritative.
+func TestCallback_GroupClaim_DemoteOnAbsence(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "g-demote", "nonce": "test-nonce", "preferred_username": "gd",
+		"groups": []string{"staff", "readers"}, // no bindery-admin
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithOIDCAdminGroup("bindery-admin")
+
+	// Pre-seed the OIDC user as admin (e.g. promoted earlier or default-role).
+	seeded, err := users.GetOrCreateByOIDC(ctx, idp.server.URL, "g-demote", "gd", "", "", "admin")
+	if err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+	if seeded.Role != "admin" {
+		t.Fatalf("setup: seeded role=%q, want admin", seeded.Role)
+	}
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByID(ctx, seeded.ID)
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user (admin group absent → demote)", u.Role)
+	}
+}
+
+// TestCallback_GroupClaim_DemoteWhenClaimMissingEntirely verifies that when the
+// group claim is absent altogether, an existing admin is demoted (fail-safe:
+// absence of the group, not presence of a deny signal).
+func TestCallback_GroupClaim_DemoteWhenClaimMissingEntirely(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "g-noclaim", "nonce": "test-nonce", "preferred_username": "gn",
+		// no "groups" claim at all
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithOIDCAdminGroup("bindery-admin")
+
+	seeded, err := users.GetOrCreateByOIDC(ctx, idp.server.URL, "g-noclaim", "gn", "", "", "admin")
+	if err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByID(ctx, seeded.ID)
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user (no group claim → demote)", u.Role)
+	}
+}
+
+// TestCallback_GroupClaim_CustomClaimName verifies BINDERY_OIDC_GROUP_CLAIM
+// selects a non-standard claim path.
+func TestCallback_GroupClaim_CustomClaimName(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "g-custom", "nonce": "test-nonce", "preferred_username": "gc",
+		"groups":         []string{"ignored"}, // wrong claim — must be ignored
+		"bindery_groups": []string{"bindery-admin"},
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithOIDCAdminGroup("bindery-admin").WithOIDCGroupClaim("bindery_groups")
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByOIDC(ctx, idp.server.URL, "g-custom")
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "admin" {
+		t.Errorf("Role=%q, want admin (custom group claim path)", u.Role)
+	}
+}
+
+// TestCallback_GroupClaim_Disabled verifies that with no admin group configured
+// the group claim does not affect roles — a default-role user stays "user".
+func TestCallback_GroupClaim_Disabled(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "g-off", "nonce": "test-nonce", "preferred_username": "go",
+		"groups": []string{"bindery-admin"},
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	// no WithOIDCAdminGroup → group mapping disabled
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByOIDC(ctx, idp.server.URL, "g-off")
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user (group mapping disabled)", u.Role)
+	}
+}
+
+// --- Part 3: promote-first-OIDC-user fallback ------------------------------
+
+// TestCallback_PromoteFirstOIDC_LocalAuthDisabled verifies the lockout-trap fix:
+// with local auth disabled and zero admins, the first provisioned OIDC user is
+// promoted to admin and the one-shot guard flag is set.
+func TestCallback_PromoteFirstOIDC_LocalAuthDisabled(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "first-oidc", "nonce": "test-nonce", "preferred_username": "first",
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithLocalAuthEnabled(false)
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByOIDC(ctx, idp.server.URL, "first-oidc")
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "admin" {
+		t.Errorf("Role=%q, want admin (first OIDC user, no admins, local auth off)", u.Role)
+	}
+	// The one-shot guard must now be set.
+	s, err := h.settings.Get(ctx, SettingOIDCFirstAdminPromoted)
+	if err != nil {
+		t.Fatalf("read guard: %v", err)
+	}
+	if s == nil || s.Value != "true" {
+		t.Errorf("first-admin-promoted guard = %v, want set to true", s)
+	}
+}
+
+// TestCallback_PromoteFirstOIDC_GuardPreventsRepromotion verifies that once the
+// guard is set, a later OIDC login does NOT get auto-promoted even if every
+// admin was deleted in the meantime.
+func TestCallback_PromoteFirstOIDC_GuardPreventsRepromotion(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "second-oidc", "nonce": "test-nonce", "preferred_username": "second",
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithLocalAuthEnabled(false)
+
+	// Simulate: the fallback already fired once.
+	if err := h.settings.Set(ctx, SettingOIDCFirstAdminPromoted, "true"); err != nil {
+		t.Fatalf("seed guard: %v", err)
+	}
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByOIDC(ctx, idp.server.URL, "second-oidc")
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user (guard set → no re-promotion)", u.Role)
+	}
+}
+
+// TestCallback_PromoteFirstOIDC_SkippedWhenLocalAuthEnabled verifies the
+// fallback does not fire while local auth is enabled (a recovery path exists).
+func TestCallback_PromoteFirstOIDC_SkippedWhenLocalAuthEnabled(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "la-on", "nonce": "test-nonce", "preferred_username": "laon",
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	// localAuthEnabled defaults to true
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByOIDC(ctx, idp.server.URL, "la-on")
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user (local auth on → no fallback)", u.Role)
+	}
+}
+
+// TestCallback_PromoteFirstOIDC_SkippedWhenAdminExists verifies the fallback
+// does not fire when at least one admin already exists.
+func TestCallback_PromoteFirstOIDC_SkippedWhenAdminExists(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub": "has-admin", "nonce": "test-nonce", "preferred_username": "hasadmin",
+	}
+	h, users, ctx := newCallbackTestHandler(t, idp, nil, false)
+	h.WithLocalAuthEnabled(false)
+
+	// Pre-existing admin via a different identity.
+	if _, err := users.GetOrCreateByOIDC(ctx, "https://other.example", "existing-admin",
+		"existingadmin", "", "", "admin"); err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+
+	if rec := doCallback(t, h); rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302; body=%s", rec.Code, rec.Body.String())
+	}
+	u, err := users.GetByOIDC(ctx, idp.server.URL, "has-admin")
+	if err != nil || u == nil {
+		t.Fatalf("lookup: u=%v err=%v", u, err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user (admin already exists → no fallback)", u.Role)
+	}
+}

--- a/internal/auth/oidc/groupclaim_test.go
+++ b/internal/auth/oidc/groupclaim_test.go
@@ -1,0 +1,139 @@
+package oidc
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestGroupClaimValues_Shapes exercises the group-claim shape variance handled
+// for OIDC role mapping (issue #688): a JSON array of strings, a single
+// space/comma-delimited string, and the degenerate / absent cases.
+func TestGroupClaimValues_Shapes(t *testing.T) {
+	tests := []struct {
+		name      string
+		claimJSON string // the value stored under the "groups" key, as raw JSON
+		want      []string
+	}{
+		{
+			name:      "json array of strings",
+			claimJSON: `["bindery-admin","staff"]`,
+			want:      []string{"bindery-admin", "staff"},
+		},
+		{
+			name:      "single bare string",
+			claimJSON: `"bindery-admin"`,
+			want:      []string{"bindery-admin"},
+		},
+		{
+			name:      "space-delimited string",
+			claimJSON: `"bindery-admin staff readers"`,
+			want:      []string{"bindery-admin", "staff", "readers"},
+		},
+		{
+			name:      "comma-delimited string",
+			claimJSON: `"bindery-admin,staff,readers"`,
+			want:      []string{"bindery-admin", "staff", "readers"},
+		},
+		{
+			name:      "comma-and-space-delimited string",
+			claimJSON: `"bindery-admin, staff , readers"`,
+			want:      []string{"bindery-admin", "staff", "readers"},
+		},
+		{
+			name:      "empty array",
+			claimJSON: `[]`,
+			want:      nil,
+		},
+		{
+			name:      "empty string",
+			claimJSON: `""`,
+			want:      nil,
+		},
+		{
+			name:      "json null",
+			claimJSON: `null`,
+			want:      nil,
+		},
+		{
+			name:      "array with empty and whitespace entries",
+			claimJSON: `["bindery-admin","","  ","staff"]`,
+			want:      []string{"bindery-admin", "staff"},
+		},
+		{
+			name:      "unsupported type (number)",
+			claimJSON: `42`,
+			want:      nil,
+		},
+		{
+			name:      "mixed-type array keeps only strings",
+			claimJSON: `["bindery-admin",1,true,"staff"]`,
+			want:      []string{"bindery-admin", "staff"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := map[string]any{}
+			if err := json.Unmarshal([]byte(`{"groups":`+tc.claimJSON+`}`), &raw); err != nil {
+				t.Fatalf("unmarshal test fixture: %v", err)
+			}
+			got := GroupClaimValues(raw, "groups")
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("GroupClaimValues = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGroupClaimValues_CustomClaimName verifies the configurable claim path.
+func TestGroupClaimValues_CustomClaimName(t *testing.T) {
+	raw := map[string]any{
+		"groups":        []any{"ignored"},
+		"roles/bindery": []any{"bindery-admin"},
+	}
+	got := GroupClaimValues(raw, "roles/bindery")
+	if !reflect.DeepEqual(got, []string{"bindery-admin"}) {
+		t.Errorf("GroupClaimValues custom claim = %#v, want [bindery-admin]", got)
+	}
+}
+
+// TestGroupClaimValues_MissingClaimOrNilMap verifies the absent-claim and
+// nil-map paths return nil rather than panicking.
+func TestGroupClaimValues_MissingClaimOrNilMap(t *testing.T) {
+	if got := GroupClaimValues(nil, "groups"); got != nil {
+		t.Errorf("nil map: got %#v, want nil", got)
+	}
+	if got := GroupClaimValues(map[string]any{}, ""); got != nil {
+		t.Errorf("empty claim name: got %#v, want nil", got)
+	}
+	if got := GroupClaimValues(map[string]any{"other": "x"}, "groups"); got != nil {
+		t.Errorf("missing claim: got %#v, want nil", got)
+	}
+}
+
+// TestGroupClaimValues_StringSliceShape covers the []string concrete type,
+// which the json decoder will not produce but a direct caller might pass.
+func TestGroupClaimValues_StringSliceShape(t *testing.T) {
+	raw := map[string]any{"groups": []string{"bindery-admin", " staff "}}
+	got := GroupClaimValues(raw, "groups")
+	if !reflect.DeepEqual(got, []string{"bindery-admin", "staff"}) {
+		t.Errorf("GroupClaimValues = %#v, want [bindery-admin staff]", got)
+	}
+}
+
+func TestContainsGroup(t *testing.T) {
+	groups := []string{"staff", "bindery-admin"}
+	if !ContainsGroup(groups, "bindery-admin") {
+		t.Error("ContainsGroup: want true for present group")
+	}
+	if ContainsGroup(groups, "Bindery-Admin") {
+		t.Error("ContainsGroup: matching must be case-sensitive")
+	}
+	if ContainsGroup(groups, "missing") {
+		t.Error("ContainsGroup: want false for absent group")
+	}
+	if ContainsGroup(nil, "anything") {
+		t.Error("ContainsGroup: want false for nil slice")
+	}
+}

--- a/internal/auth/oidc/provider.go
+++ b/internal/auth/oidc/provider.go
@@ -90,6 +90,10 @@ type Claims struct {
 	PreferredUsername string
 	Name              string
 	Groups            []string
+	// Raw is the full decoded ID-token claim set. It lets callers read
+	// non-standard claims (e.g. a group claim under a configurable path) that
+	// are not modelled as typed fields above. nil if decoding the raw map fails.
+	Raw map[string]any
 }
 
 // Status is the runtime state of a configured provider as far as the manager
@@ -338,16 +342,27 @@ func (m *Manager) Exchange(ctx context.Context, redirectBase, id, code, nonce, c
 	if idToken.Nonce != nonce {
 		return nil, fmt.Errorf("oidc: nonce mismatch")
 	}
+	// `groups` is decoded as json.RawMessage rather than []string: IdPs vary in
+	// shape (array vs delimited string) and a strict []string field makes the
+	// whole token-exchange fail for a string-shaped claim. GroupClaimValues
+	// normalises the shape after the fact.
 	var claims struct {
 		Sub               string          `json:"sub"`
 		Email             string          `json:"email"`
 		EmailVerified     json.RawMessage `json:"email_verified"`
 		PreferredUsername string          `json:"preferred_username"`
 		Name              string          `json:"name"`
-		Groups            []string        `json:"groups"`
 	}
 	if err := idToken.Claims(&claims); err != nil {
 		return nil, fmt.Errorf("oidc: parse claims: %w", err)
+	}
+	// Also decode the full claim set as a generic map so callers can read
+	// non-standard claims (e.g. a configurable group-claim path) and so the
+	// `groups` claim can be normalised tolerantly. A failure here is non-fatal
+	// — the typed fields above are still usable.
+	var raw map[string]any
+	if err := idToken.Claims(&raw); err != nil {
+		raw = nil
 	}
 	return &Claims{
 		Sub:               claims.Sub,
@@ -356,8 +371,74 @@ func (m *Manager) Exchange(ctx context.Context, redirectBase, id, code, nonce, c
 		EmailVerified:     parseEmailVerified(claims.EmailVerified),
 		PreferredUsername: claims.PreferredUsername,
 		Name:              claims.Name,
-		Groups:            claims.Groups,
+		Groups:            GroupClaimValues(raw, "groups"),
+		Raw:               raw,
 	}, nil
+}
+
+// GroupClaimValues extracts a group list from the named claim in a decoded
+// ID-token claim set, normalising the well-known shape variance between IdPs.
+// The claim value may be:
+//
+//   - a JSON array of strings (Authentik, Keycloak with a groups mapper)  →
+//     used as-is;
+//   - a single string holding several groups separated by spaces and/or
+//     commas (some Keycloak/Authelia role-string configs)  → split;
+//   - a single bare string (one group)  → one-element list.
+//
+// Returns nil when the claim is absent, empty, or of an unsupported type.
+func GroupClaimValues(raw map[string]any, claimName string) []string {
+	if raw == nil || claimName == "" {
+		return nil
+	}
+	v, ok := raw[claimName]
+	if !ok || v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case []string:
+		return trimNonEmpty(val)
+	case []any:
+		out := make([]string, 0, len(val))
+		for _, item := range val {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return trimNonEmpty(out)
+	case string:
+		// Space- and/or comma-delimited single string.
+		fields := strings.FieldsFunc(val, func(r rune) bool {
+			return r == ',' || r == ' ' || r == '\t' || r == '\n' || r == '\r'
+		})
+		return trimNonEmpty(fields)
+	default:
+		return nil
+	}
+}
+
+// trimNonEmpty trims whitespace from each element and drops empties.
+func trimNonEmpty(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if t := strings.TrimSpace(s); t != "" {
+			out = append(out, t)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// ContainsGroup reports whether group is present in groups (exact, case-sensitive).
+func ContainsGroup(groups []string, group string) bool {
+	for _, g := range groups {
+		if g == group {
+			return true
+		}
+	}
+	return false
 }
 
 // parseEmailVerified interprets the `email_verified` claim. The OIDC spec

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,16 @@ type Config struct {
 	LocalAuthEnabled  bool // BINDERY_LOCAL_AUTH_ENABLED (default true)
 	OIDCAutoProvision bool // BINDERY_OIDC_AUTO_PROVISION (default true)
 	OIDCEmailLink     bool // BINDERY_OIDC_EMAIL_LINK (default false)
+	// OIDC role mapping (issue #688).
+	// OIDCDefaultRole is the role assigned to a freshly auto-provisioned OIDC
+	// user. Valid values: "user", "admin"; anything else falls back to "user".
+	OIDCDefaultRole string // BINDERY_OIDC_DEFAULT_ROLE (default "user")
+	// OIDCAdminGroup, when non-empty, makes the IdP authoritative for the admin
+	// role: on every OIDC login the user is promoted to admin if this group is
+	// present in the group claim, and demoted to user if absent.
+	OIDCAdminGroup string // BINDERY_OIDC_ADMIN_GROUP (default "")
+	// OIDCGroupClaim is the ID-token claim path holding the user's groups.
+	OIDCGroupClaim string // BINDERY_OIDC_GROUP_CLAIM (default "groups")
 	// Log retention in days (BINDERY_LOG_RETENTION_DAYS, default 14).
 	LogRetentionDays int
 	// Login rate limit (per-IP sliding window).
@@ -78,6 +88,9 @@ func Load() *Config {
 		LocalAuthEnabled:       envBool("BINDERY_LOCAL_AUTH_ENABLED", true),
 		OIDCAutoProvision:      envBool("BINDERY_OIDC_AUTO_PROVISION", true),
 		OIDCEmailLink:          envBool("BINDERY_OIDC_EMAIL_LINK", false),
+		OIDCDefaultRole:        normalizeOIDCRole(envOr("BINDERY_OIDC_DEFAULT_ROLE", "user")),
+		OIDCAdminGroup:         strings.TrimSpace(envOr("BINDERY_OIDC_ADMIN_GROUP", "")),
+		OIDCGroupClaim:         envOr("BINDERY_OIDC_GROUP_CLAIM", "groups"),
 		LogRetentionDays:       envInt("BINDERY_LOG_RETENTION_DAYS", 14),
 		RateLimitMaxFailures:   envInt("BINDERY_RATE_LIMIT_MAX_FAILURES", 5),
 		RateLimitWindowMinutes: envInt("BINDERY_RATE_LIMIT_WINDOW_MINUTES", 15),
@@ -137,6 +150,19 @@ func defaultDataDir(goos string, userConfigDir func() (string, error)) string {
 		}
 	}
 	return "/config"
+}
+
+// normalizeOIDCRole validates the BINDERY_OIDC_DEFAULT_ROLE value. Only
+// "user" and "admin" are accepted (case-insensitive); anything else — typos,
+// empty, "Admin ", "moderator" — falls back to "user" so a misconfigured env
+// var can never silently grant unintended privileges.
+func normalizeOIDCRole(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "admin":
+		return "admin"
+	default:
+		return "user"
+	}
 }
 
 func envOr(key, fallback string) string {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -86,6 +86,14 @@ func (c *Config) Validate(logger *slog.Logger) error {
 		}
 	}
 
+	// BINDERY_OIDC_DEFAULT_ROLE is silently coerced to "user" on any invalid
+	// value by normalizeOIDCRole; warn so a typo (e.g. "Administrator") does not
+	// quietly produce non-admin users when the operator expected admins.
+	if raw := strings.TrimSpace(os.Getenv("BINDERY_OIDC_DEFAULT_ROLE")); raw != "" && c.OIDCDefaultRole != strings.ToLower(raw) {
+		logger.Warn("config: BINDERY_OIDC_DEFAULT_ROLE has an invalid value — falling back to \"user\"",
+			"provided", raw, "effective", c.OIDCDefaultRole)
+	}
+
 	// BINDERY_URL_BASE must be a clean path prefix after normalisation.
 	if c.URLBase != "" {
 		if strings.Contains(c.URLBase, "://") {

--- a/internal/db/auth.go
+++ b/internal/db/auth.go
@@ -111,14 +111,19 @@ func (r *UserRepo) LinkOIDCSubject(ctx context.Context, userID int64, issuer, su
 
 // GetOrCreateByOIDC resolves or creates a user identified by (issuer, sub).
 // On creation, username is derived from preferredUsername (falling back to sub),
-// email and displayName are stored as provided.
-func (r *UserRepo) GetOrCreateByOIDC(ctx context.Context, issuer, sub, preferredUsername, email, displayName string) (*User, error) {
+// email and displayName are stored as provided, and the user is assigned the
+// given role. role must be "admin" or "user"; any other value is coerced to
+// "user" so a bad caller can never silently grant admin.
+func (r *UserRepo) GetOrCreateByOIDC(ctx context.Context, issuer, sub, preferredUsername, email, displayName, role string) (*User, error) {
 	u, err := r.GetByOIDC(ctx, issuer, sub)
 	if err != nil {
 		return nil, err
 	}
 	if u != nil {
 		return u, nil
+	}
+	if role != "admin" && role != "user" {
+		role = "user"
 	}
 	username := preferredUsername
 	if username == "" {
@@ -139,8 +144,8 @@ func (r *UserRepo) GetOrCreateByOIDC(ctx context.Context, issuer, sub, preferred
 	now := time.Now().UTC()
 	res, err := r.db.ExecContext(ctx,
 		`INSERT INTO users (username, password_hash, role, created_at, updated_at, oidc_sub, oidc_issuer, email, display_name)
-		 VALUES (?, '', 'user', ?, ?, ?, ?, ?, ?)`,
-		username, now, now, sub, issuer, nullableStr(email), nullableStr(displayName),
+		 VALUES (?, '', ?, ?, ?, ?, ?, ?, ?)`,
+		username, role, now, now, sub, issuer, nullableStr(email), nullableStr(displayName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create oidc user: %w", err)
@@ -149,8 +154,31 @@ func (r *UserRepo) GetOrCreateByOIDC(ctx context.Context, issuer, sub, preferred
 	if err != nil {
 		return nil, fmt.Errorf("get oidc user id: %w", err)
 	}
-	slog.Info("oidc: auto-provisioned user", "username", username, "issuer", issuer)
+	slog.Info("oidc: auto-provisioned user", "username", username, "issuer", issuer, "role", role)
 	return r.GetByID(ctx, id)
+}
+
+// CountAdmins returns the number of users with role "admin". Used by the OIDC
+// callback to detect the lockout trap (zero admins) at provision time.
+func (r *UserRepo) CountAdmins(ctx context.Context) (int, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM users WHERE role='admin'").Scan(&n)
+	return n, err
+}
+
+// SetRoleUnguarded sets a user's role without the last-admin demotion guard.
+// It is used by the OIDC group-claim sync path, where the IdP is authoritative:
+// demoting an OIDC user because they lost the admin group must not be blocked
+// by the "cannot demote the last admin" rule (that rule protects against
+// accidental lockout via the manual API, not against deliberate IdP-driven
+// role changes). role must be "admin" or "user".
+func (r *UserRepo) SetRoleUnguarded(ctx context.Context, id int64, role string) error {
+	if role != "admin" && role != "user" {
+		return fmt.Errorf("invalid role %q: must be admin or user", role)
+	}
+	_, err := r.db.ExecContext(ctx,
+		"UPDATE users SET role=?, updated_at=? WHERE id=?", role, time.Now().UTC(), id)
+	return err
 }
 
 func nullableStr(s string) any {

--- a/internal/db/auth_test.go
+++ b/internal/db/auth_test.go
@@ -16,7 +16,7 @@ func TestGetByEmail_Found(t *testing.T) {
 	repo := NewUserRepo(database)
 
 	// Create a user with an email by using the OIDC path (which stores email).
-	if _, err := repo.GetOrCreateByOIDC(ctx, "https://idp.example", "sub-abc", "alice", "alice@example.com", "Alice"); err != nil {
+	if _, err := repo.GetOrCreateByOIDC(ctx, "https://idp.example", "sub-abc", "alice", "alice@example.com", "Alice", "user"); err != nil {
 		t.Fatalf("GetOrCreateByOIDC: %v", err)
 	}
 
@@ -224,5 +224,177 @@ func TestLinkOIDCSubject(t *testing.T) {
 	}
 	if after.Username != "bob" {
 		t.Errorf("Username after link: got %q, want bob", after.Username)
+	}
+}
+
+// --- issue #688: OIDC role mapping -----------------------------------------
+
+// TestGetOrCreateByOIDC_DefaultRoleUser verifies the historical behaviour: an
+// OIDC user provisioned with role "user" gets role "user".
+func TestGetOrCreateByOIDC_DefaultRoleUser(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewUserRepo(database)
+
+	u, err := repo.GetOrCreateByOIDC(ctx, "https://idp.example", "sub-u", "alice", "", "", "user")
+	if err != nil {
+		t.Fatalf("GetOrCreateByOIDC: %v", err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user", u.Role)
+	}
+}
+
+// TestGetOrCreateByOIDC_DefaultRoleAdmin verifies that BINDERY_OIDC_DEFAULT_ROLE
+// = admin provisions the new user as admin.
+func TestGetOrCreateByOIDC_DefaultRoleAdmin(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewUserRepo(database)
+
+	u, err := repo.GetOrCreateByOIDC(ctx, "https://idp.example", "sub-a", "admin1", "", "", "admin")
+	if err != nil {
+		t.Fatalf("GetOrCreateByOIDC: %v", err)
+	}
+	if u.Role != "admin" {
+		t.Errorf("Role=%q, want admin", u.Role)
+	}
+	if !u.IsAdmin() {
+		t.Error("IsAdmin()=false, want true")
+	}
+}
+
+// TestGetOrCreateByOIDC_InvalidRoleCoerced verifies that a bad role string is
+// coerced to "user" — the DB layer never silently grants an unintended role.
+func TestGetOrCreateByOIDC_InvalidRoleCoerced(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewUserRepo(database)
+
+	u, err := repo.GetOrCreateByOIDC(ctx, "https://idp.example", "sub-x", "x", "", "", "superadmin")
+	if err != nil {
+		t.Fatalf("GetOrCreateByOIDC: %v", err)
+	}
+	if u.Role != "user" {
+		t.Errorf("Role=%q, want user (invalid role must be coerced)", u.Role)
+	}
+}
+
+// TestGetOrCreateByOIDC_ExistingUserRoleUnchanged verifies that re-resolving an
+// already-provisioned OIDC user does NOT change its role, regardless of the role
+// argument — GetOrCreateByOIDC only applies the role on creation.
+func TestGetOrCreateByOIDC_ExistingUserRoleUnchanged(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewUserRepo(database)
+
+	first, err := repo.GetOrCreateByOIDC(ctx, "https://idp.example", "sub-e", "e", "", "", "admin")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if first.Role != "admin" {
+		t.Fatalf("setup: Role=%q, want admin", first.Role)
+	}
+	again, err := repo.GetOrCreateByOIDC(ctx, "https://idp.example", "sub-e", "e", "", "", "user")
+	if err != nil {
+		t.Fatalf("resolve again: %v", err)
+	}
+	if again.Role != "admin" {
+		t.Errorf("Role=%q, want admin (existing user role must not change)", again.Role)
+	}
+}
+
+// TestCountAdmins verifies CountAdmins reflects only admin-role users.
+func TestCountAdmins(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewUserRepo(database)
+
+	if n, err := repo.CountAdmins(ctx); err != nil || n != 0 {
+		t.Fatalf("CountAdmins on empty DB: n=%d err=%v, want 0,nil", n, err)
+	}
+	if _, err := repo.GetOrCreateByOIDC(ctx, "https://idp.example", "s1", "u1", "", "", "user"); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := repo.CountAdmins(ctx); err != nil || n != 0 {
+		t.Fatalf("CountAdmins with one user: n=%d err=%v, want 0,nil", n, err)
+	}
+	if _, err := repo.GetOrCreateByOIDC(ctx, "https://idp.example", "s2", "u2", "", "", "admin"); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := repo.CountAdmins(ctx); err != nil || n != 1 {
+		t.Fatalf("CountAdmins with one admin: n=%d err=%v, want 1,nil", n, err)
+	}
+}
+
+// TestSetRoleUnguarded_DemotesLastAdmin verifies that SetRoleUnguarded bypasses
+// the last-admin demotion guard — the IdP-driven group-claim sync must be able
+// to demote even the sole admin.
+func TestSetRoleUnguarded_DemotesLastAdmin(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewUserRepo(database)
+
+	admin, err := repo.GetOrCreateByOIDC(ctx, "https://idp.example", "s", "root", "", "", "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Guarded SetRole must refuse this.
+	if err := repo.SetRole(ctx, admin.ID, "user"); err == nil {
+		t.Fatal("SetRole demoting last admin should fail, got nil")
+	}
+	// Unguarded must succeed.
+	if err := repo.SetRoleUnguarded(ctx, admin.ID, "user"); err != nil {
+		t.Fatalf("SetRoleUnguarded: %v", err)
+	}
+	got, err := repo.GetByID(ctx, admin.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Role != "user" {
+		t.Errorf("Role=%q, want user", got.Role)
+	}
+}
+
+// TestSetRoleUnguarded_InvalidRole verifies SetRoleUnguarded rejects bad roles.
+func TestSetRoleUnguarded_InvalidRole(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewUserRepo(database)
+
+	u, err := repo.GetOrCreateByOIDC(ctx, "https://idp.example", "s", "u", "", "", "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SetRoleUnguarded(ctx, u.ID, "root"); err == nil {
+		t.Error("SetRoleUnguarded with invalid role should fail, got nil")
 	}
 }


### PR DESCRIPTION
Closes #688

Implements OIDC role mapping in three opt-in, backward-compatible parts. Default behaviour is unchanged: with none of the new env vars set, OIDC users are still provisioned as `role='user'`.

## New environment variables

| Variable | Default | Effect |
|----------|---------|--------|
| `BINDERY_OIDC_DEFAULT_ROLE` | `user` | Role assigned at OIDC auto-provision time. Valid values `user`/`admin`; anything else falls back to `user` (a startup warning is logged). |
| `BINDERY_OIDC_ADMIN_GROUP` | _(unset)_ | When set, the IdP becomes authoritative for the admin role — see below. |
| `BINDERY_OIDC_GROUP_CLAIM` | `groups` | ID-token claim path Bindery reads the user's groups from. |

## Part 1 — default role

`internal/db/auth.go:GetOrCreateByOIDC` no longer hardcodes the `'user'` SQL literal; it takes a `role` argument. The configured value is validated in `config.normalizeOIDCRole` (coerced to `user` on anything invalid) and again in the DB layer as defence-in-depth.

## Part 2 — group-claim role sync

When `BINDERY_OIDC_ADMIN_GROUP` is set, **every login** reads the configured group claim from the ID token and promotes the user to `admin` if the group is present, demotes to `user` if absent.

**Group-claim shape variance** — IdPs disagree on the claim's shape, so `oidc.GroupClaimValues` normalises both:
- a **JSON array of strings** (`["bindery-admin","staff"]`) — Authentik, Keycloak with a groups mapper;
- a **single space/comma-delimited string** (`"bindery-admin staff"` / `"bindery-admin,staff"`) — some Keycloak/Authelia role-string configs.

Empty/whitespace entries are dropped; matching is exact and case-sensitive.

**Demote-on-absence** is intentional and symmetric with promotion: if the admin group is absent from the claim — including when the claim is missing entirely — an OIDC user currently holding `admin` is demoted to `user`. The sync uses a new `SetRoleUnguarded` that bypasses the last-admin demotion guard, because IdP-driven demotion must always take effect (the guard protects against accidental lockout via the manual API, not against deliberate IdP role changes).

**This overrides the manual `PUT /api/v1/auth/users/{id}/role` endpoint for OIDC users** — a manual change is reverted on the user's next login to whatever IdP group membership dictates. This is intended (manage roles in the IdP when group mapping is on) and is documented in `docs/auth-oidc.md`.

While fixing this I found and fixed a latent bug: the ID-token `groups` claim was previously decoded into a strict `[]string`, which made the **entire token exchange fail** for any IdP emitting groups as a delimited string. It is now decoded tolerantly.

## Part 3 — promote-first-OIDC-user fallback

If `BINDERY_LOCAL_AUTH_ENABLED=false` and there are zero admin users at OIDC-provision time, the user being provisioned is promoted to `admin` — mirroring `PromoteFirstUser`. Guarded by a one-shot flag (`auth.oidc.first_admin_promoted`) in the existing settings key-value store, so deleting every admin later cannot silently re-promote the next OIDC login. No DB migration. The fallback is skipped when local auth is enabled (a recovery path exists) or when `BINDERY_OIDC_DEFAULT_ROLE=admin`.

## Verification

All passing:
- `gofmt -l` — clean on all changed Go files
- `go vet ./...` — clean
- `go build ./...` — OK
- `go test ./internal/db/... ./internal/api/... ./internal/auth/oidc/... ./internal/config/...` — all `ok`

New tests cover: default-role provisioning (user/admin/invalid-coerced), group-claim promotion and demotion in both claim shapes (array + delimited string), custom claim path, demote-on-absence and demote-when-claim-missing, the promote-first-OIDC-user path, the one-shot guard preventing re-promotion, and the skip conditions. `GroupClaimValues` has a dedicated shape-variance table test.

No `web/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)