### PR TITLE
fix(abs): import unmatched non-ASIN items instead of queuing for review

### DIFF
--- a/internal/abs/import_upserts.go
+++ b/internal/abs/import_upserts.go
@@ -132,9 +132,15 @@ func (i *Importer) resolveAuthor(ctx context.Context, cfg ImportConfig, runID in
 		return nil, false, "", metadataMergeResult{}, reviewRequiredError{Reason: reviewReasonAmbiguousAuthor}
 	}
 
-	if !allowCreate {
-		return nil, false, "", metadataMergeResult{}, reviewRequiredError{Reason: reviewReasonUnmatchedAuthor}
-	}
+	// No local author matched. Previously a non-ASIN item (allowCreate=false)
+	// was parked in the review queue here, which sent the great majority of a
+	// folder-backed ABS library to review even for unambiguous, well-known
+	// authors (#762). An unmatched author is not an uncertain match: the local
+	// matcher found nothing close, so the correct outcome is to create the
+	// author. enrichAuthor (below) still performs a confidence-gated upstream
+	// lookup and relinks the new row to the metadata provider when it finds a
+	// confident match, so import quality is preserved. Only an *ambiguous*
+	// author (handled above) still requires human review.
 
 	if cfg.DryRun {
 		_ = i.recordRunEntity(ctx, runID, cfg, item.LibraryID, item.ItemID, entityTypeAuthor, externalID, 0, itemOutcomeCreated, nil)
@@ -607,9 +613,11 @@ func (i *Importer) upsertBook(ctx context.Context, cfg ImportConfig, runID int64
 		metaResult, err := i.enrichBook(ctx, cfg, item, author, match)
 		return &bookUpsertResult{row: match, matchedBy: "author+normalized_title"}, false, true, metaResult, err
 	}
-	if !allowCreate {
-		return nil, false, false, metadataMergeResult{}, reviewRequiredError{Reason: reviewReasonUnmatchedBook}
-	}
+	// No local book matched for this author. As with the author path above,
+	// an unmatched book is not an uncertain match and no longer parks the item
+	// in the review queue for non-ASIN items (#762): the book is created and
+	// enrichBook performs a confidence-gated upstream lookup. Only an
+	// *ambiguous* book (handled above) still requires human review.
 
 	if cfg.DryRun {
 		_ = i.recordRunEntity(ctx, runID, cfg, item.LibraryID, item.ItemID, entityTypeBook, externalID, 0, itemOutcomeCreated, nil)

--- a/internal/abs/import_utils.go
+++ b/internal/abs/import_utils.go
@@ -2,6 +2,7 @@ package abs
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -165,8 +166,34 @@ func normalizeAuthorName(name string) string {
 	return textutil.NormalizeAuthorName(name)
 }
 
+// bracketSuffixRe matches one trailing square-bracketed qualifier. ABS titles
+// routinely append format/edition tags this way ("[Unabridged]",
+// "[Dramatized Adaptation]", "[Audiobook]"). indexer.NormalizeTitleForDedup
+// only strips a trailing *parenthesised* qualifier, so without this step
+// "The Eye of the World [Unabridged]" and "The Eye of the World" produce
+// different keys and never match against the metadata provider or a local row.
+var bracketSuffixRe = regexp.MustCompile(`\s*\[[^\[\]]*\]\s*$`)
+
+// stripBracketSuffixes removes any trailing square-bracketed qualifiers,
+// applied repeatedly so "Title [Unabridged] [2021]" is fully cleaned.
+func stripBracketSuffixes(title string) string {
+	for {
+		stripped := bracketSuffixRe.ReplaceAllString(title, "")
+		if stripped == title {
+			return strings.TrimSpace(stripped)
+		}
+		title = stripped
+	}
+}
+
+// normalizeTitle produces the canonical key used to compare an ABS item title
+// against local book rows and metadata-provider works. ABS-specific bracketed
+// edition/format noise is stripped first; the remainder reuses the shared
+// indexer normalization (paren-suffix strip, subtitle strip, case/Unicode
+// folding). The same wrapper is applied to both sides of every comparison, so
+// the dedup key stays symmetric.
 func normalizeTitle(title string) string {
-	return indexer.NormalizeTitleForDedup(strings.TrimSpace(title))
+	return indexer.NormalizeTitleForDedup(stripBracketSuffixes(strings.TrimSpace(title)))
 }
 
 func primaryAuthorName(item NormalizedLibraryItem) string {

--- a/internal/abs/import_utils_test.go
+++ b/internal/abs/import_utils_test.go
@@ -13,3 +13,76 @@ func TestNormalizeLibraryIDsPrependsLegacyPrimary(t *testing.T) {
 		t.Fatalf("library ids = %q, want %q", got, want)
 	}
 }
+
+// TestNormalizeTitle_StripsABSEditionNoise verifies that the ABS title
+// normalization collapses the bracket/paren/series/edition noise that ABS
+// titles routinely carry, so an item title and the corresponding clean
+// metadata-provider work title produce the same dedup key (#762).
+func TestNormalizeTitle_StripsABSEditionNoise(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain title unchanged", "Leviathan Wakes", "leviathan wakes"},
+		{"trailing series parenthetical", "The Eye of the World (The Wheel of Time, Book 1)", "the eye of the world"},
+		{"trailing hash series parenthetical", "Leviathan Wakes (The Expanse #1)", "leviathan wakes"},
+		{"square-bracket unabridged tag", "The Eye of the World [Unabridged]", "the eye of the world"},
+		{"square-bracket dramatized tag", "The Way of Kings [Dramatized Adaptation]", "the way of kings"},
+		{"colon novel subtitle and bracket tag", "Pandora's Star: A Novel [Unabridged]", "pandora's star"},
+		{"stacked bracket tags", "Dune [Unabridged] [2021]", "dune"},
+		{"paren edition then bracket tag", "Mistborn (Unabridged) [Audiobook]", "mistborn"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeTitle(tc.in); got != tc.want {
+				t.Fatalf("normalizeTitle(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeTitle_MatchesNoisyABSTitleToCleanProviderTitle is the core
+// matching invariant: a noisy ABS item title and the clean provider work
+// title for the same book must produce the same key, so lookupUpstreamBook
+// and findBookByNormalizedTitle link them instead of queuing for review.
+func TestNormalizeTitle_MatchesNoisyABSTitleToCleanProviderTitle(t *testing.T) {
+	t.Parallel()
+
+	pairs := [][2]string{
+		{"The Eye of the World (The Wheel of Time, Book 1)", "The Eye of the World"},
+		{"Pandora's Star: A Novel [Unabridged]", "Pandora's Star"},
+		{"Leviathan Wakes (The Expanse #1)", "Leviathan Wakes"},
+		{"The Way of Kings [Unabridged]", "The Way of Kings"},
+		{"Project Hail Mary [Unabridged]", "Project Hail Mary"},
+	}
+	for _, pair := range pairs {
+		absKey := normalizeTitle(pair[0])
+		providerKey := normalizeTitle(pair[1])
+		if absKey != providerKey {
+			t.Errorf("titles must share a dedup key:\n  ABS      %q -> %q\n  provider %q -> %q",
+				pair[0], absKey, pair[1], providerKey)
+		}
+	}
+}
+
+// TestNormalizeTitle_DistinctBooksStayDistinct guards against the bracket
+// stripping over-collapsing genuinely different books to the same key, which
+// would create false ambiguity and send correct items to review.
+func TestNormalizeTitle_DistinctBooksStayDistinct(t *testing.T) {
+	t.Parallel()
+
+	distinct := [][2]string{
+		{"Leviathan Wakes (The Expanse #1)", "Caliban's War (The Expanse #2)"},
+		{"The Eye of the World [Unabridged]", "The Great Hunt [Unabridged]"},
+		{"Pandora's Star [Unabridged]", "Judas Unchained [Unabridged]"},
+	}
+	for _, pair := range distinct {
+		if a, b := normalizeTitle(pair[0]), normalizeTitle(pair[1]); a == b {
+			t.Errorf("distinct books collapsed to same key %q:\n  %q\n  %q", a, pair[0], pair[1])
+		}
+	}
+}

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -1513,7 +1513,12 @@ func TestImporter_CleansABSDescriptionBeforeStoring(t *testing.T) {
 	}
 }
 
-func TestImporter_UnmatchedBookQueuesReview(t *testing.T) {
+// TestImporter_UnmatchedBookImportsWithoutASIN verifies that a non-ASIN item
+// whose author is already known locally but whose title matches no existing
+// book is imported (the book is created) rather than parked in the review
+// queue. Before the #762 fix, the absence of an ASIN forced every such item to
+// review even though an unmatched book is an unambiguous "this is new" signal.
+func TestImporter_UnmatchedBookImportsWithoutASIN(t *testing.T) {
 	t.Parallel()
 
 	importer, authorRepo, bookRepo, _, _, _, _, _, reviewRepo, _ := newABSImporterFixture(t)
@@ -1554,29 +1559,34 @@ func TestImporter_UnmatchedBookQueuesReview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if stats.ReviewQueued != 1 || stats.BooksCreated != 0 {
-		t.Fatalf("stats = %+v, want queued review without creating book", stats)
+	if stats.ReviewQueued != 0 || stats.BooksCreated != 1 {
+		t.Fatalf("stats = %+v, want book created without review", stats)
 	}
 	books, err := bookRepo.ListIncludingExcluded(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(books) != 0 {
-		t.Fatalf("books = %d, want 0", len(books))
+	if len(books) != 1 || books[0].Title != "Completely Unmatched Title" {
+		t.Fatalf("books = %+v, want one created book", books)
 	}
 	reviews, err := reviewRepo.ListByStatus(context.Background(), "pending")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(reviews) != 1 || reviews[0].ReviewReason != reviewReasonUnmatchedBook {
-		t.Fatalf("reviews = %+v, want unmatched_book review", reviews)
+	if len(reviews) != 0 {
+		t.Fatalf("reviews = %+v, want no review items", reviews)
 	}
 }
 
-func TestImporter_UnmatchedAuthorReviewMessageReportsAuthor(t *testing.T) {
+// TestImporter_UnmatchedAuthorImportsWithoutASIN verifies that a well-known
+// author absent from the local database is created (not queued for review)
+// when the item carries no ASIN. This is the headline #762 regression: real
+// authors like Robert Jordan were sent to review purely because their ABS
+// item lacked an embedded ASIN.
+func TestImporter_UnmatchedAuthorImportsWithoutASIN(t *testing.T) {
 	t.Parallel()
 
-	importer, _, _, _, _, _, _, _, _, _ := newABSImporterFixture(t)
+	importer, authorRepo, bookRepo, _, _, _, _, _, reviewRepo, _ := newABSImporterFixture(t)
 	item := sampleABSItem()
 	item.ItemID = "li-onyx-storm"
 	item.Title = "Onyx Storm"
@@ -1602,12 +1612,100 @@ func TestImporter_UnmatchedAuthorReviewMessageReportsAuthor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if stats.ReviewQueued != 1 {
-		t.Fatalf("stats = %+v, want one review item", stats)
+	if stats.ReviewQueued != 0 || stats.AuthorsCreated != 1 || stats.BooksCreated != 1 {
+		t.Fatalf("stats = %+v, want author and book created without review", stats)
 	}
-	progress := importer.Progress()
-	if len(progress.Results) != 1 || !strings.Contains(progress.Results[0].Message, "Rebecca Yarros") {
-		t.Fatalf("result message = %+v, want author name reported", progress.Results)
+	authors, err := authorRepo.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(authors) != 1 || authors[0].Name != "Rebecca Yarros" {
+		t.Fatalf("authors = %+v, want one created author", authors)
+	}
+	books, err := bookRepo.ListIncludingExcluded(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("books = %d, want 1", len(books))
+	}
+	reviews, err := reviewRepo.ListByStatus(context.Background(), "pending")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reviews) != 0 {
+		t.Fatalf("reviews = %+v, want no review items", reviews)
+	}
+}
+
+// TestImporter_AmbiguousBookStillQueuesReview confirms the #762 fix is
+// targeted: an *ambiguous* book match (two local books for the same author
+// normalize to the incoming title) still requires human review even without
+// an ASIN. Only unmatched — not ambiguous — items are auto-created.
+func TestImporter_AmbiguousBookStillQueuesReview(t *testing.T) {
+	t.Parallel()
+
+	importer, authorRepo, bookRepo, _, _, _, _, _, reviewRepo, _ := newABSImporterFixture(t)
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID:        "OL23919A",
+		Name:             "Andy Weir",
+		SortName:         "Weir, Andy",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	for _, dup := range []string{"Artemis", "Artemis (Unabridged)"} {
+		if err := bookRepo.Create(ctx, &models.Book{
+			AuthorID:         author.ID,
+			Title:            dup,
+			SortTitle:        dup,
+			MediaType:        models.MediaTypeAudiobook,
+			Status:           models.BookStatusWanted,
+			MetadataProvider: "openlibrary",
+			ForeignID:        "OL-" + dup,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	item := sampleABSItem()
+	item.ItemID = "li-artemis"
+	item.Title = "Artemis"
+	item.Authors = []NormalizedAuthor{{ID: "author-andy-weir", Name: "Andy Weir"}}
+	item.ASIN = ""
+	item.AudioFiles = nil
+	item.EbookPath = "/abs/artemis.epub"
+	item.EbookINO = "ebook-artemis"
+	importer.enumerateFn = func(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
+		if err := fn(ctx, item); err != nil {
+			return EnumerationStats{}, err
+		}
+		return EnumerationStats{PagesScanned: 1, ItemsSeen: 1, ItemsNormalized: 1}, nil
+	}
+
+	stats, err := importer.Run(ctx, ImportConfig{
+		SourceID:  DefaultSourceID,
+		BaseURL:   "https://abs.example.com",
+		APIKey:    "secret",
+		LibraryID: item.LibraryID,
+		Label:     "Shelf",
+		Enabled:   true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.ReviewQueued != 1 || stats.BooksCreated != 0 {
+		t.Fatalf("stats = %+v, want ambiguous book queued for review", stats)
+	}
+	reviews, err := reviewRepo.ListByStatus(ctx, "pending")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reviews) != 1 || reviews[0].ReviewReason != reviewReasonAmbiguousBook {
+		t.Fatalf("reviews = %+v, want ambiguous_book review", reviews)
 	}
 }
 

--- a/tests/abscontract/contract_test.go
+++ b/tests/abscontract/contract_test.go
@@ -184,8 +184,11 @@ func TestContractHarness_ImporterDryRunAndIdempotentRerun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dry-run Run: %v", err)
 	}
-	if dryRunStats.BooksCreated != 4 || dryRunStats.AuthorsCreated != 4 || dryRunStats.SeriesCreated != 2 || dryRunStats.SeriesLinked != 1 || dryRunStats.ReviewQueued != 2 {
-		t.Fatalf("dry-run stats = %+v, want 4 books/authors, 2 created series, 1 linked series membership, and 2 queued reviews", dryRunStats)
+	// After the #762 fix, the two non-ASIN fixture items (missing-stats and
+	// ebook-only) are imported rather than parked in the review queue: all six
+	// items become books/authors and no item is queued for review.
+	if dryRunStats.BooksCreated != 6 || dryRunStats.AuthorsCreated != 6 || dryRunStats.SeriesCreated != 2 || dryRunStats.SeriesLinked != 1 || dryRunStats.ReviewQueued != 0 {
+		t.Fatalf("dry-run stats = %+v, want 6 books/authors, 2 created series, 1 linked series membership, and no queued reviews", dryRunStats)
 	}
 
 	authors, err := authorRepo.List(context.Background())
@@ -214,15 +217,15 @@ func TestContractHarness_ImporterDryRunAndIdempotentRerun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("commit Run: %v", err)
 	}
-	if commitStats.BooksCreated != 4 || commitStats.SeriesCreated != 2 || commitStats.SeriesLinked != 1 || commitStats.ReviewQueued != 2 {
-		t.Fatalf("commit stats = %+v, want 4 books, repeated series ownership, and 2 queued reviews", commitStats)
+	if commitStats.BooksCreated != 6 || commitStats.SeriesCreated != 2 || commitStats.SeriesLinked != 1 || commitStats.ReviewQueued != 0 {
+		t.Fatalf("commit stats = %+v, want 6 books, repeated series ownership, and no queued reviews", commitStats)
 	}
 	books, err = bookRepo.ListIncludingExcluded(context.Background())
 	if err != nil {
 		t.Fatalf("List books after commit: %v", err)
 	}
-	if len(books) != 4 {
-		t.Fatalf("books = %d, want 4 after commit", len(books))
+	if len(books) != 6 {
+		t.Fatalf("books = %d, want 6 after commit", len(books))
 	}
 	series, err := seriesRepo.ListWithBooks(context.Background())
 	if err != nil {
@@ -254,8 +257,8 @@ func TestContractHarness_ImporterDryRunAndIdempotentRerun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List books after rerun: %v", err)
 	}
-	if len(books) != 4 {
-		t.Fatalf("books after rerun = %d, want 4", len(books))
+	if len(books) != 6 {
+		t.Fatalf("books after rerun = %d, want 6", len(books))
 	}
 	series, err = seriesRepo.ListWithBooks(context.Background())
 	if err != nil {
@@ -271,7 +274,7 @@ func TestContractHarness_ImporterDryRunAndIdempotentRerun(t *testing.T) {
 		t.Fatalf("runs = %d, want 3", len(runs))
 	}
 	latestDryRun := abs.HydrateRun(runs[2])
-	if !latestDryRun.Summary.DryRun || latestDryRun.Summary.Stats.BooksCreated != 4 || latestDryRun.Summary.Stats.SeriesCreated != 2 || latestDryRun.Summary.Stats.SeriesLinked != 1 || latestDryRun.Summary.Stats.ReviewQueued != 2 {
+	if !latestDryRun.Summary.DryRun || latestDryRun.Summary.Stats.BooksCreated != 6 || latestDryRun.Summary.Stats.SeriesCreated != 2 || latestDryRun.Summary.Stats.SeriesLinked != 1 || latestDryRun.Summary.Stats.ReviewQueued != 0 {
 		t.Fatalf("dry-run summary = %+v", latestDryRun.Summary)
 	}
 	if rollback, err := importer.Rollback(context.Background(), runToRollback); err != nil {
@@ -366,16 +369,18 @@ func TestContractHarness_ImporterResumeFromFailedCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resume Run: %v", err)
 	}
-	if resumeStats.BooksCreated != 2 || resumeStats.ReviewQueued != 2 {
-		t.Fatalf("resume stats = %+v, want 2 newly created books and 2 queued reviews after resuming", resumeStats)
+	// After the #762 fix the resumed pages import their non-ASIN items instead
+	// of queuing them for review: four books created on resume, none queued.
+	if resumeStats.BooksCreated != 4 || resumeStats.ReviewQueued != 0 {
+		t.Fatalf("resume stats = %+v, want 4 newly created books and no queued reviews after resuming", resumeStats)
 	}
 
 	books, err := bookRepo.ListIncludingExcluded(context.Background())
 	if err != nil {
 		t.Fatalf("List books after resume: %v", err)
 	}
-	if len(books) != 4 {
-		t.Fatalf("books after resume = %d, want 4", len(books))
+	if len(books) != 6 {
+		t.Fatalf("books after resume = %d, want 6", len(books))
 	}
 
 	runs, err := runRepo.ListRecent(context.Background(), 2)


### PR DESCRIPTION
Closes #762

## Diagnosis

ABS import sent ~90% of large libraries to "queued for review". Two reporters: Merijeek (441/480 reviewed) and hucknz (1540/2000 reviewed). The match rate each saw (~23% imported) tracks the fraction of items carrying an embedded ASIN — that is the tell.

There are two independent root causes. Notably the dominant one is **not** poor provider-search confidence — the resolution path never queries the provider for matching at all.

### 1. The review gate (dominant cause)

`importOne` (`internal/abs/importer.go:385`) computes `allowCreate` from `allowImmediateImport(item)`, which is true **only when the ABS item carries an embedded ASIN**. With `allowCreate=false`:

- `resolveAuthor` matches the ABS author name against the **local** author table only; nothing matched -> `reviewReasonUnmatchedAuthor`.
- `upsertBook` matches the ABS title against the importing author's **local** books only; nothing matched -> `reviewReasonUnmatchedBook`.

Neither path consults the metadata provider for *matching* — the provider is used only for *enrichment* after a local match. So on a fresh import of a folder-backed ABS library (which commonly has no embedded ASINs), the local tables are near-empty, almost every item is "unmatched", and almost every item is reviewed — including unambiguous, well-known authors like Robert Jordan and Peter F. Hamilton. Only the minority of items that happen to carry an ASIN are auto-imported.

An *unmatched* result is not an *uncertain* one. The local matcher (exact + Jaro-Winkler with margins) found nothing close, so the correct outcome is to create the entity. The unmatched branches now create regardless of ASIN. The freshly created row still passes through `enrichAuthor`/`enrichBook`, which run a confidence-gated upstream lookup (`lookupUpstreamAuthor`/`lookupUpstreamBook`) and relink it to the metadata provider when a confident match exists — so import quality is preserved.

**Ambiguous matches still go to review** — that gate (`ambiguous && !allowCreate`) is untouched.

### 2. Title normalization (secondary cause)

`normalizeTitle` (used to compare ABS titles against both local rows and provider works) delegates to `indexer.NormalizeTitleForDedup`, which strips a trailing *parenthesised* qualifier but **not a square-bracketed one**. ABS titles routinely append `[Unabridged]`, `[Dramatized Adaptation]`, etc., so `"The Eye of the World [Unabridged]"` never matched the clean title and produced false misses/ambiguity. `normalizeTitle` now strips trailing bracket qualifiers first.

## Why this is safe (no wrong-match risk)

- **No matcher thresholds were changed.** `AuthorMatchAutoThreshold`, `AuthorMatchAmbiguousMinimum`, and the fuzzy tie margins are all untouched.
- The gate change only converts "park for review" into "create". A created row for a genuinely **unmatched** author/book is a faithful import of the user's own ABS data, not a bad match — there is no pairing being asserted. Near-miss authors still land in the *ambiguous* band and still go to review.
- The bracket strip is applied **symmetrically** to both sides of every comparison, so the dedup key stays consistent. A test asserts genuinely distinct books (e.g. different Expanse volumes) still produce distinct keys, guarding against over-collapsing.
- `stripSubtitle` in the shared indexer normalizer was deliberately **left alone** — it strips at the first `": "`, which is load-bearing for existing dedup symmetry tests; changing it was out of scope and risky.

## Files changed

- `internal/abs/import_upserts.go` — unmatched author/book branches create instead of queuing review; ambiguous branches unchanged.
- `internal/abs/import_utils.go` — `normalizeTitle` strips trailing `[...]` edition/format tags before shared normalization.
- `internal/abs/import_utils_test.go` — normalization tests with realistic ABS titles (Wheel of Time / Expanse / Pandora's Star); asserts noisy ABS titles share a dedup key with clean provider titles and that distinct books stay distinct.
- `internal/abs/importer_test.go` — replaces the two tests that asserted the buggy behavior; new tests confirm non-ASIN unmatched authors/books import and ambiguous books still queue for review.
- `tests/abscontract/contract_test.go` — updated expectations: the harness's two non-ASIN fixtures now import (6 books/authors, 0 reviews).

## Verification

- `gofmt -l` on changed files: clean
- `go vet ./...`: clean
- `go build ./...`: ok
- `go test ./...`: all 50 packages pass (incl. `internal/abs`, `internal/textutil`, `internal/indexer`, `tests/abscontract`)

## Still uncertain / follow-ups

- This drains the review queue for the common case but a non-ASIN item whose author the metadata provider cannot confidently identify is created as a bare `audiobookshelf`-sourced author rather than a provider-linked one. That is strictly better than an unmanageable 1500-item review queue, but a future improvement could attempt upstream resolution *during* resolution (not just enrichment) so even those rows link cleanly. That is a larger change to critical import code and was intentionally left out of this conservative fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)