### PR TITLE
fix(qbittorrent): treat 409 duplicate-add as success (#769)

### DIFF
--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -193,6 +193,9 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 
 	var req *http.Request
 	submitted := magnetOrURL
+	// torrentFile holds the raw .torrent bytes when the add is a file upload,
+	// so a 409 duplicate response can still recover the infohash.
+	var torrentFile []byte
 	if strings.HasPrefix(magnetOrURL, "http://") || strings.HasPrefix(magnetOrURL, "https://") {
 		// Fetch the .torrent content in Bindery so qBittorrent never needs to
 		// reach the indexer URL directly (which may be a Docker-only hostname
@@ -219,6 +222,7 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 			}
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		} else {
+			torrentFile = fetched.data
 			var buf bytes.Buffer
 			mw := multipart.NewWriter(&buf)
 			fw, err := mw.CreateFormFile("torrents", "upload.torrent")
@@ -275,6 +279,24 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	text := strings.TrimSpace(string(body))
+
+	// qBittorrent answers POST /torrents/add with 409 Conflict when it already
+	// holds the torrent. The content is effectively available, so recover the
+	// existing torrent's hash and proceed instead of failing the grab.
+	if resp.StatusCode == http.StatusConflict {
+		hash := infoHashFromMagnet(submitted)
+		if hash == "" {
+			hash = infoHashFromTorrentFile(torrentFile)
+		}
+		if hash == "" {
+			return "", fmt.Errorf("add torrent: qBittorrent reports the torrent is already present but its hash could not be determined")
+		}
+		if category != "" {
+			_ = c.setCategory(ctx, hash, category)
+		}
+		slog.Info("add torrent: already present in qBittorrent, reusing existing torrent", "hash", hash)
+		return hash, nil
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("add torrent HTTP %d: %s", resp.StatusCode, text)

--- a/internal/downloader/qbittorrent/infohash.go
+++ b/internal/downloader/qbittorrent/infohash.go
@@ -1,7 +1,7 @@
 package qbittorrent
 
 import (
-	"crypto/sha1" //nolint:gosec // G505: the BitTorrent v1 infohash is defined as SHA-1, not used as a security primitive
+	"crypto/sha1" //nolint:gosec // #nosec G505 -- the BitTorrent v1 infohash is defined as SHA-1, not a security primitive
 	"encoding/hex"
 	"errors"
 	"strconv"
@@ -23,7 +23,7 @@ func infoHashFromTorrentFile(data []byte) string {
 	if !ok {
 		return ""
 	}
-	sum := sha1.Sum(data[start:end]) //nolint:gosec // G401: the BitTorrent v1 infohash is defined as SHA-1, not used as a security primitive
+	sum := sha1.Sum(data[start:end]) //nolint:gosec // #nosec G401 -- the BitTorrent v1 infohash is defined as SHA-1, not a security primitive
 	return hex.EncodeToString(sum[:])
 }
 

--- a/internal/downloader/qbittorrent/infohash.go
+++ b/internal/downloader/qbittorrent/infohash.go
@@ -1,0 +1,120 @@
+package qbittorrent
+
+import (
+	"crypto/sha1" //nolint:gosec // G505: the BitTorrent v1 infohash is defined as SHA-1, not used as a security primitive
+	"encoding/hex"
+	"errors"
+	"strconv"
+)
+
+// errBencode marks malformed bencode input. Callers treat it as "hash not
+// recoverable" rather than a fatal error.
+var errBencode = errors.New("invalid bencode")
+
+// infoHashFromTorrentFile computes a torrent's v1 infohash — the SHA-1 of the
+// bencoded "info" dictionary — from raw .torrent file bytes. It returns "" when
+// data is not a bencoded dictionary containing an "info" key.
+//
+// qBittorrent's 409 "already present" response to POST /torrents/add carries no
+// hash, so when a torrent is submitted as a file upload this lets AddTorrent
+// recover the hash of the torrent qBittorrent already holds.
+func infoHashFromTorrentFile(data []byte) string {
+	start, end, ok := bencodeMemberSpan(data, "info")
+	if !ok {
+		return ""
+	}
+	sum := sha1.Sum(data[start:end]) //nolint:gosec // G401: the BitTorrent v1 infohash is defined as SHA-1, not used as a security primitive
+	return hex.EncodeToString(sum[:])
+}
+
+// bencodeMemberSpan returns the [start,end) byte span of the value mapped to
+// key in the top-level bencoded dictionary in data. The span covers the value's
+// exact bytes, delimiters included, which is what the v1 infohash is taken over.
+func bencodeMemberSpan(data []byte, key string) (start, end int, ok bool) {
+	if len(data) == 0 || data[0] != 'd' {
+		return 0, 0, false
+	}
+	pos := 1
+	for pos < len(data) && data[pos] != 'e' {
+		k, afterKey, err := bencodeReadString(data, pos)
+		if err != nil {
+			return 0, 0, false
+		}
+		valEnd, err := bencodeSkipValue(data, afterKey)
+		if err != nil {
+			return 0, 0, false
+		}
+		if string(k) == key {
+			return afterKey, valEnd, true
+		}
+		pos = valEnd
+	}
+	return 0, 0, false
+}
+
+// bencodeReadString reads a bencoded byte string ("<len>:<bytes>") at pos and
+// returns its bytes and the index immediately after it.
+func bencodeReadString(data []byte, pos int) ([]byte, int, error) {
+	colon := pos
+	for colon < len(data) && data[colon] != ':' {
+		if data[colon] < '0' || data[colon] > '9' {
+			return nil, 0, errBencode
+		}
+		colon++
+	}
+	if colon == pos || colon >= len(data) {
+		return nil, 0, errBencode
+	}
+	n, err := strconv.Atoi(string(data[pos:colon]))
+	if err != nil || n < 0 {
+		return nil, 0, errBencode
+	}
+	start := colon + 1
+	end := start + n
+	if end > len(data) || end < start {
+		return nil, 0, errBencode
+	}
+	return data[start:end], end, nil
+}
+
+// bencodeSkipValue advances past one bencoded value of any type at pos and
+// returns the index immediately after it.
+func bencodeSkipValue(data []byte, pos int) (int, error) {
+	if pos >= len(data) {
+		return 0, errBencode
+	}
+	switch c := data[pos]; {
+	case c == 'i': // integer: i<digits>e
+		end := pos + 1
+		for end < len(data) && data[end] != 'e' {
+			end++
+		}
+		if end >= len(data) {
+			return 0, errBencode
+		}
+		return end + 1, nil
+	case c == 'l' || c == 'd': // list (l...e) or dict (d...e)
+		p := pos + 1
+		for p < len(data) && data[p] != 'e' {
+			var err error
+			if c == 'd' {
+				// Dictionary keys are bencoded byte strings.
+				if _, p, err = bencodeReadString(data, p); err != nil {
+					return 0, err
+				}
+			}
+			if p, err = bencodeSkipValue(data, p); err != nil {
+				return 0, err
+			}
+		}
+		if p >= len(data) {
+			return 0, errBencode
+		}
+		return p + 1, nil
+	case c >= '0' && c <= '9': // byte string: <len>:<bytes>
+		_, end, err := bencodeReadString(data, pos)
+		return end, err
+	default:
+		return 0, errBencode
+	}
+}

--- a/internal/downloader/qbittorrent/infohash.go
+++ b/internal/downloader/qbittorrent/infohash.go
@@ -1,7 +1,8 @@
 package qbittorrent
 
 import (
-	"crypto/sha1" //nolint:gosec // #nosec G505 -- the BitTorrent v1 infohash is defined as SHA-1, not a security primitive
+	//nolint:gosec // G505: protocol-mandated SHA-1 for the BitTorrent v1 infohash, see the #nosec note
+	"crypto/sha1" // #nosec G505 -- the BitTorrent v1 infohash is defined as SHA-1, not a security primitive
 	"encoding/hex"
 	"errors"
 	"strconv"
@@ -23,7 +24,8 @@ func infoHashFromTorrentFile(data []byte) string {
 	if !ok {
 		return ""
 	}
-	sum := sha1.Sum(data[start:end]) //nolint:gosec // #nosec G401 -- the BitTorrent v1 infohash is defined as SHA-1, not a security primitive
+	//nolint:gosec // G401: protocol-mandated SHA-1 for the BitTorrent v1 infohash, see the #nosec note
+	sum := sha1.Sum(data[start:end]) // #nosec G401 -- the BitTorrent v1 infohash is defined as SHA-1, not a security primitive
 	return hex.EncodeToString(sum[:])
 }
 

--- a/internal/downloader/qbittorrent/infohash_test.go
+++ b/internal/downloader/qbittorrent/infohash_test.go
@@ -1,0 +1,155 @@
+package qbittorrent
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// sampleInfoDict is a realistic single-file bencoded "info" dictionary.
+const sampleInfoDict = "d6:lengthi5e4:name8:test.txt12:piece lengthi16384e6:pieces20:" +
+	"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14e"
+
+func sha1Hex(s string) string {
+	sum := sha1.Sum([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+func TestInfoHashFromTorrentFile(t *testing.T) {
+	want := sha1Hex(sampleInfoDict)
+
+	t.Run("info is the first key", func(t *testing.T) {
+		torrent := "d4:info" + sampleInfoDict + "8:announce10:udp://t/ane"
+		if got := infoHashFromTorrentFile([]byte(torrent)); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("info after other keys", func(t *testing.T) {
+		torrent := "d8:announce10:udp://t/an13:creation datei1700000000e4:info" + sampleInfoDict + "e"
+		if got := infoHashFromTorrentFile([]byte(torrent)); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("info followed by another key", func(t *testing.T) {
+		// Verifies the value span stops at the info dict's own closing 'e'
+		// rather than running into the next key.
+		torrent := "d4:info" + sampleInfoDict + "7:comment5:helloe"
+		if got := infoHashFromTorrentFile([]byte(torrent)); got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	negatives := map[string]string{
+		"empty":             "",
+		"not a dictionary":  "i5e",
+		"no info key":       "d8:announce10:udp://t/ane",
+		"truncated":         "d4:info",
+		"bad string length": "d99:infod" + sampleInfoDict,
+	}
+	for name, in := range negatives {
+		t.Run(name, func(t *testing.T) {
+			if got := infoHashFromTorrentFile([]byte(in)); got != "" {
+				t.Fatalf("got %q, want empty string", got)
+			}
+		})
+	}
+}
+
+// TestAddTorrent_Duplicate409_Magnet is a regression test for #769.
+// qBittorrent returns 409 Conflict from POST /torrents/add when it already
+// holds the torrent. That is not a real failure — the content is available —
+// so AddTorrent recovers the existing torrent's hash from the magnet and
+// succeeds instead of reporting "failed to send to downloader".
+func TestAddTorrent_Duplicate409_Magnet(t *testing.T) {
+	const hash = "abcdef0123456789abcdef0123456789abcdef01"
+	magnet := "magnet:?xt=urn:btih:" + hash + "&dn=Book"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte("Conflict"))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	c.loggedIn = true
+
+	got, err := c.AddTorrent(context.Background(), magnet, "", "")
+	if err != nil {
+		t.Fatalf("409 on a torrent qBittorrent already holds must not fail: %v", err)
+	}
+	if got != hash {
+		t.Errorf("recovered hash: want %q, got %q", hash, got)
+	}
+}
+
+// TestAddTorrent_Duplicate409_File covers the #769 duplicate path when the
+// torrent is submitted as a file upload. The 409 body carries no hash, so it
+// is recovered from the .torrent bytes (SHA-1 of the bencoded info dict).
+func TestAddTorrent_Duplicate409_File(t *testing.T) {
+	torrent := "d8:announce11:udp://t/ann4:info" + sampleInfoDict + "e"
+	wantHash := sha1Hex(sampleInfoDict)
+
+	indexer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/torrent" {
+			_, _ = w.Write([]byte(torrent))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer indexer.Close()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			w.WriteHeader(http.StatusConflict)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	allowTorrentFetch(c)
+	c.loggedIn = true
+
+	got, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "", "")
+	if err != nil {
+		t.Fatalf("409 on a file-upload add must not fail: %v", err)
+	}
+	if got != wantHash {
+		t.Errorf("recovered hash: want %q, got %q", wantHash, got)
+	}
+}
+
+// TestAddTorrent_NonConflictErrorStillFails confirms the 409 handling did not
+// soften other non-200 responses — a real failure must still surface.
+func TestAddTorrent_NonConflictErrorStillFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	c.loggedIn = true
+
+	_, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abcdef0123456789abcdef0123456789abcdef01", "", "")
+	if err == nil || !strings.Contains(err.Error(), "500") {
+		t.Fatalf("expected a 500 error to still fail, got %v", err)
+	}
+}

--- a/internal/downloader/qbittorrent/infohash_test.go
+++ b/internal/downloader/qbittorrent/infohash_test.go
@@ -2,37 +2,33 @@ package qbittorrent
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
 
-// sampleInfoDict is a realistic single-file bencoded "info" dictionary.
-const sampleInfoDict = "d6:lengthi5e4:name8:test.txt12:piece lengthi16384e6:pieces20:" +
-	"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14e"
-
-func sha1Hex(s string) string {
-	sum := sha1.Sum([]byte(s))
-	return hex.EncodeToString(sum[:])
-}
+// sampleInfoDict is a realistic single-file bencoded "info" dictionary, and
+// sampleInfoHash is its v1 infohash (SHA-1 of the bytes above) as a golden
+// value — hardcoded so the test does not itself depend on crypto/sha1.
+const (
+	sampleInfoDict = "d6:lengthi5e4:name8:test.txt12:piece lengthi16384e6:pieces20:" +
+		"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14e"
+	sampleInfoHash = "9ca9aea0e4d50429f039ca828f52ec49283f36bb"
+)
 
 func TestInfoHashFromTorrentFile(t *testing.T) {
-	want := sha1Hex(sampleInfoDict)
-
 	t.Run("info is the first key", func(t *testing.T) {
 		torrent := "d4:info" + sampleInfoDict + "8:announce10:udp://t/ane"
-		if got := infoHashFromTorrentFile([]byte(torrent)); got != want {
-			t.Fatalf("got %q, want %q", got, want)
+		if got := infoHashFromTorrentFile([]byte(torrent)); got != sampleInfoHash {
+			t.Fatalf("got %q, want %q", got, sampleInfoHash)
 		}
 	})
 
 	t.Run("info after other keys", func(t *testing.T) {
 		torrent := "d8:announce10:udp://t/an13:creation datei1700000000e4:info" + sampleInfoDict + "e"
-		if got := infoHashFromTorrentFile([]byte(torrent)); got != want {
-			t.Fatalf("got %q, want %q", got, want)
+		if got := infoHashFromTorrentFile([]byte(torrent)); got != sampleInfoHash {
+			t.Fatalf("got %q, want %q", got, sampleInfoHash)
 		}
 	})
 
@@ -40,8 +36,8 @@ func TestInfoHashFromTorrentFile(t *testing.T) {
 		// Verifies the value span stops at the info dict's own closing 'e'
 		// rather than running into the next key.
 		torrent := "d4:info" + sampleInfoDict + "7:comment5:helloe"
-		if got := infoHashFromTorrentFile([]byte(torrent)); got != want {
-			t.Fatalf("got %q, want %q", got, want)
+		if got := infoHashFromTorrentFile([]byte(torrent)); got != sampleInfoHash {
+			t.Fatalf("got %q, want %q", got, sampleInfoHash)
 		}
 	})
 
@@ -98,7 +94,6 @@ func TestAddTorrent_Duplicate409_Magnet(t *testing.T) {
 // is recovered from the .torrent bytes (SHA-1 of the bencoded info dict).
 func TestAddTorrent_Duplicate409_File(t *testing.T) {
 	torrent := "d8:announce11:udp://t/ann4:info" + sampleInfoDict + "e"
-	wantHash := sha1Hex(sampleInfoDict)
 
 	indexer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/torrent" {
@@ -127,8 +122,8 @@ func TestAddTorrent_Duplicate409_File(t *testing.T) {
 	if err != nil {
 		t.Fatalf("409 on a file-upload add must not fail: %v", err)
 	}
-	if got != wantHash {
-		t.Errorf("recovered hash: want %q, got %q", wantHash, got)
+	if got != sampleInfoHash {
+		t.Errorf("recovered hash: want %q, got %q", sampleInfoHash, got)
 	}
 }
 


### PR DESCRIPTION
Closes #769

## Problem

Re-grabbing a book whose torrent qBittorrent **already holds** failed hard:

```
failed to send to downloader: add torrent HTTP 409: Conflict
```

`AddTorrent` checked `resp.StatusCode != http.StatusOK` and treated *any* non-200 — including a 409 duplicate rejection — as a fatal send error. But a 409 means qBittorrent already has the torrent, so the content is effectively available; it's not a real failure.

## Fix

On `409 Conflict`, recover the existing torrent's hash instead of bailing:

- **Magnet adds** → `infoHashFromMagnet` (the hash is in the magnet URI).
- **File-upload adds** → new `infoHashFromTorrentFile`, which computes the v1 infohash (SHA-1 of the bencoded `info` dictionary) from the `.torrent` bytes Bindery already fetched. A minimal bencode span-scanner (`infohash.go`) locates the exact byte range of the `info` value — no third-party dependency.

`AddTorrent` then sets the category on the recovered hash and returns success, so Bindery tracks the already-present torrent and proceeds to import.

Notes:
- The 409 path is **specific to 409** — other non-200 responses still fail exactly as before (covered by a test).
- The before/after hash-set diff *cannot* recover the hash on a 409: nothing is added, so the diff is empty by construction. Direct hash recovery is required — which is why the bencode helper exists.
- If a 409 yields no recoverable hash, `AddTorrent` still errors rather than returning success with an empty hash.

## Tests

- `infoHashFromTorrentFile` — info dict first / mid / followed-by-another-key, plus malformed inputs (empty, non-dict, no `info`, truncated, bad length).
- `AddTorrent` 409 via magnet → recovers the hash.
- `AddTorrent` 409 via file upload → recovers the hash from the `.torrent` bytes.
- `AddTorrent` non-409 error (500) → still fails.

`gofmt` / `go vet` / `golangci-lint` clean; full `internal/downloader/qbittorrent` suite passes.