### PR TITLE
fix(migrate): join AuthorMetadata to read author Name from Readarr

### DIFF
--- a/internal/migrate/readarr.go
+++ b/internal/migrate/readarr.go
@@ -77,10 +77,17 @@ func ImportReadarr(
 	return res, nil
 }
 
-// importReadarrAuthors pulls Authors.Name+Monitored from Readarr and
-// re-resolves each one against OpenLibrary. No Goodreads IDs are trusted.
+// importReadarrAuthors pulls each author's Name (from AuthorMetadata) and
+// Monitored flag from Readarr and re-resolves them against OpenLibrary. No
+// Goodreads IDs are trusted. Authors.Name does not exist in the Readarr
+// schema — the human-readable name lives in AuthorMetadata joined via
+// Authors.AuthorMetadataId.
 func importReadarrAuthors(ctx context.Context, src *sql.DB, repo *db.AuthorRepo, agg *metadata.Aggregator, onSearchOnAdd func(*models.Author), res *Result) error {
-	rows, err := src.QueryContext(ctx, `SELECT Name, Monitored FROM Authors`)
+	rows, err := src.QueryContext(ctx, `
+		SELECT am.Name, a.Monitored
+		FROM Authors a
+		JOIN AuthorMetadata am ON am.Id = a.AuthorMetadataId
+	`)
 	if err != nil {
 		return fmt.Errorf("query Authors: %w", err)
 	}

--- a/internal/migrate/readarr_test.go
+++ b/internal/migrate/readarr_test.go
@@ -26,10 +26,16 @@ func newReadarrDB(t *testing.T) string {
 	t.Cleanup(func() { src.Close() })
 
 	stmts := []string{
+		// Real Readarr schema: Authors holds Monitored + a FK to AuthorMetadata,
+		// where the human-readable Name actually lives.
+		`CREATE TABLE AuthorMetadata (
+			Id INTEGER PRIMARY KEY,
+			Name TEXT NOT NULL
+		)`,
 		`CREATE TABLE Authors (
 			Id INTEGER PRIMARY KEY,
-			Name TEXT NOT NULL,
-			Monitored INTEGER NOT NULL DEFAULT 1
+			Monitored INTEGER NOT NULL DEFAULT 1,
+			AuthorMetadataId INTEGER NOT NULL
 		)`,
 		`CREATE TABLE Indexers (
 			Id INTEGER PRIMARY KEY,
@@ -83,11 +89,19 @@ func TestImportReadarr_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = src.Exec(`INSERT INTO Authors (Name, Monitored) VALUES
-		('Andy Weir', 1),
-		('', 1),
-		('Duplicate Author', 1),
-		('Isaac Asimov', 0)`)
+	_, err = src.Exec(`INSERT INTO AuthorMetadata (Id, Name) VALUES
+		(1, 'Andy Weir'),
+		(2, ''),
+		(3, 'Duplicate Author'),
+		(4, 'Isaac Asimov')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = src.Exec(`INSERT INTO Authors (Monitored, AuthorMetadataId) VALUES
+		(1, 1),
+		(1, 2),
+		(1, 3),
+		(0, 4)`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +271,8 @@ func TestImportReadarr_BlacklistFallback(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, stmt := range []string{
-		`CREATE TABLE Authors (Id INTEGER PRIMARY KEY, Name TEXT, Monitored INTEGER)`,
+		`CREATE TABLE AuthorMetadata (Id INTEGER PRIMARY KEY, Name TEXT)`,
+		`CREATE TABLE Authors (Id INTEGER PRIMARY KEY, Monitored INTEGER, AuthorMetadataId INTEGER)`,
 		`CREATE TABLE Indexers (Id INTEGER PRIMARY KEY, Name TEXT, Implementation TEXT, Settings TEXT, EnableRss INTEGER)`,
 		`CREATE TABLE DownloadClients (Id INTEGER PRIMARY KEY, Name TEXT, Implementation TEXT, Settings TEXT, Enable INTEGER)`,
 		`CREATE TABLE Blacklist (Id INTEGER PRIMARY KEY, SourceTitle TEXT, Message TEXT)`,


### PR DESCRIPTION
## Bug

`importReadarrAuthors` runs `SELECT Name, Monitored FROM Authors`, but `Authors.Name` does not exist in any stock Readarr SQLite schema. The human-readable name lives in `AuthorMetadata.Name`, joined from `Authors` via `Authors.AuthorMetadataId`.

The result is that every real Readarr import logs:

```
WARN  readarr import: authors failed  error="query Authors: SQL logic error: no such column: Name (1)"
INFO  readarr import: complete  authors_added=0 indexers_added=N clients_added=N blocklist_added=N
```

Indexers, download clients, and blocklist all carry over, but zero authors do — which makes the import look superficially successful in the UI until the user notices the empty author list.

## Why tests didn't catch it

The existing test fixture in `newReadarrDB` (and the `Blacklist`-fallback test) seeds a simplified `Authors` table with `Name` as a top-level column rather than the real Readarr two-table layout. Both pre-existing tests passed against this fake schema even though no real Readarr DB would ever satisfy the query.

## Reproduction

1. Take any stock Readarr `readarr.db` (the fork `ghcr.io/pennydreadful/bookshelf:softcover` reproduces too — it keeps the upstream schema).
2. Confirm `.schema Authors` shows no `Name` column, only `CleanName` + `AuthorMetadataId`. The `Name` is in `AuthorMetadata`.
3. Settings → Import → upload the db. Logs show the SQL error above, `authors_added=0`.

## Fix

Query joins `AuthorMetadata` so we read the real name and pair it with the per-author `Monitored` flag:

```go
SELECT am.Name, a.Monitored
FROM Authors a
JOIN AuthorMetadata am ON am.Id = a.AuthorMetadataId
```

The rest of the function is unchanged — it still ignores Readarr's foreign IDs and re-resolves authors against OpenLibrary as before.

## Test updates

- `newReadarrDB` now creates both `AuthorMetadata` and `Authors` tables matching the real Readarr schema (`Authors.AuthorMetadataId` FK).
- `TestImportReadarr_HappyPath` seed inserts split across both tables, preserving the four test cases (added / blank / pre-seeded duplicate / OpenLibrary-miss).
- `TestImportReadarr_BlacklistFallback` schema updated to match.

## Verification

Locally, against a real Readarr DB with 93 authors:
- Pre-fix: 0 authors imported (SQL error).
- Post-fix: 87 authors imported. The remaining 6 hit the existing `res.fail("no OpenLibrary match")` path, which is expected behavior unrelated to this change.

Unit tests pass:

```
$ go test ./internal/migrate/...
ok  github.com/vavallee/bindery/internal/migrate    3.773s
```

## Alternative considered

Could query `CleanName` directly from `Authors` (no JOIN). Rejected — `CleanName` is a normalized sort key, not the display name. `AuthorMetadata.Name` is the right field semantically and the JOIN is one extra line.