### PR TITLE
fix(prowlarr): sync app-scoped categories from capabilities

### DIFF
--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -38,14 +38,39 @@ func NewWithTimeout(baseURL, apiKey string, timeout time.Duration) *Client {
 
 // remoteIndexer is the shape of each element in GET /api/v1/indexer.
 type remoteIndexer struct {
-	ID             int    `json:"id"`
-	Name           string `json:"name"`
-	Enable         bool   `json:"enable"`   // Prowlarr's per-indexer enabled flag
-	Protocol       string `json:"protocol"` // "usenet" or "torrent"
-	SupportsSearch bool   `json:"supportsSearch"`
-	Categories     []struct {
-		ID int `json:"id"`
-	} `json:"categories"`
+	ID             int              `json:"id"`
+	Name           string           `json:"name"`
+	Enable         bool             `json:"enable"`   // Prowlarr's per-indexer enabled flag
+	Protocol       string           `json:"protocol"` // "usenet" or "torrent"
+	SupportsSearch bool             `json:"supportsSearch"`
+	Tags           []int            `json:"tags"`
+	Categories     []remoteCategory `json:"categories"`
+	Capabilities   struct {
+		Categories []remoteCategory `json:"categories"`
+	} `json:"capabilities"`
+}
+
+type remoteCategory struct {
+	ID            int              `json:"id"`
+	Name          string           `json:"name"`
+	SubCategories []remoteCategory `json:"subCategories"`
+}
+
+type remoteApplication struct {
+	Enable    bool          `json:"enable"`
+	SyncLevel string        `json:"syncLevel"`
+	Tags      []int         `json:"tags"`
+	Fields    []remoteField `json:"fields"`
+}
+
+type remoteField struct {
+	Name  string          `json:"name"`
+	Value json.RawMessage `json:"value"`
+}
+
+type applicationCategoryScope struct {
+	categories []int
+	tags       []int
 }
 
 // IndexerInfo holds the information needed to create a Bindery indexer from a
@@ -72,15 +97,22 @@ func (c *Client) FetchIndexers(ctx context.Context) ([]IndexerInfo, error) {
 	if err := json.Unmarshal(data, &remotes); err != nil {
 		return nil, fmt.Errorf("decode prowlarr indexers: %w", err)
 	}
+	var scopes []applicationCategoryScope
+	if needsApplicationCategoryScopes(remotes) {
+		scopes, err = c.fetchApplicationCategoryScopes(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("fetch prowlarr applications: %w", err)
+		}
+	}
 
 	infos := make([]IndexerInfo, 0, len(remotes))
 	for _, ri := range remotes {
 		// Build the Torznab/Newznab URL: {base}/{id}/api
 		torznabURL := fmt.Sprintf("%s/%d/api", c.baseURL, ri.ID)
 
-		cats := make([]int, 0, len(ri.Categories))
-		for _, cat := range ri.Categories {
-			cats = append(cats, cat.ID)
+		cats := categoryIDs(ri.Categories)
+		if len(cats) == 0 {
+			cats = categoriesFromApplicationScopes(ri, scopes)
 		}
 
 		infos = append(infos, IndexerInfo{
@@ -95,6 +127,133 @@ func (c *Client) FetchIndexers(ctx context.Context) ([]IndexerInfo, error) {
 		})
 	}
 	return infos, nil
+}
+
+func needsApplicationCategoryScopes(remotes []remoteIndexer) bool {
+	for _, remote := range remotes {
+		if len(remote.Categories) == 0 && len(remote.Capabilities.Categories) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Client) fetchApplicationCategoryScopes(ctx context.Context) ([]applicationCategoryScope, error) {
+	data, err := c.get(ctx, "/api/v1/applications")
+	if err != nil {
+		return nil, err
+	}
+	var apps []remoteApplication
+	if err := json.Unmarshal(data, &apps); err != nil {
+		return nil, fmt.Errorf("decode prowlarr applications: %w", err)
+	}
+	scopes := make([]applicationCategoryScope, 0, len(apps))
+	for _, app := range apps {
+		if !app.Enable || strings.EqualFold(app.SyncLevel, "disabled") {
+			continue
+		}
+		cats := app.syncCategories()
+		if !hasBookOrAudiobookCategory(cats) {
+			continue
+		}
+		scopes = append(scopes, applicationCategoryScope{
+			categories: cats,
+			tags:       app.Tags,
+		})
+	}
+	return scopes, nil
+}
+
+func (a remoteApplication) syncCategories() []int {
+	for _, field := range a.Fields {
+		if field.Name != "syncCategories" {
+			continue
+		}
+		var cats []int
+		if err := json.Unmarshal(field.Value, &cats); err == nil {
+			return cats
+		}
+	}
+	return nil
+}
+
+func hasBookOrAudiobookCategory(categories []int) bool {
+	for _, cat := range categories {
+		if (cat >= 7000 && cat < 8000) || (cat >= 3000 && cat < 4000) {
+			return true
+		}
+	}
+	return false
+}
+
+func categoryIDs(categories []remoteCategory) []int {
+	var ids []int
+	seen := map[int]struct{}{}
+	for _, cat := range categories {
+		collectCategoryIDs(cat, &ids, seen)
+	}
+	return ids
+}
+
+func collectCategoryIDs(cat remoteCategory, ids *[]int, seen map[int]struct{}) {
+	if cat.ID != 0 {
+		if _, ok := seen[cat.ID]; !ok {
+			seen[cat.ID] = struct{}{}
+			*ids = append(*ids, cat.ID)
+		}
+	}
+	for _, sub := range cat.SubCategories {
+		collectCategoryIDs(sub, ids, seen)
+	}
+}
+
+func categoriesFromApplicationScopes(indexer remoteIndexer, scopes []applicationCategoryScope) []int {
+	if len(scopes) == 0 {
+		return nil
+	}
+	supported := intSet(categoryIDs(indexer.Capabilities.Categories))
+	if len(supported) == 0 {
+		return nil
+	}
+	var out []int
+	seen := map[int]struct{}{}
+	for _, scope := range scopes {
+		if !tagsMatch(indexer.Tags, scope.tags) {
+			continue
+		}
+		for _, cat := range scope.categories {
+			if _, ok := supported[cat]; !ok {
+				continue
+			}
+			if _, ok := seen[cat]; ok {
+				continue
+			}
+			seen[cat] = struct{}{}
+			out = append(out, cat)
+		}
+	}
+	return out
+}
+
+func tagsMatch(indexerTags, scopeTags []int) bool {
+	if len(scopeTags) == 0 {
+		return true
+	}
+	indexerSet := intSet(indexerTags)
+	for _, tag := range scopeTags {
+		if _, ok := indexerSet[tag]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func intSet(values []int) map[int]struct{} {
+	set := make(map[int]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return set
 }
 
 // Test verifies connectivity by fetching the Prowlarr system status.

--- a/internal/prowlarr/client_test.go
+++ b/internal/prowlarr/client_test.go
@@ -89,6 +89,283 @@ func TestFetchIndexers_HappyPath(t *testing.T) {
 	}
 }
 
+func TestFetchIndexers_AppliesApplicationCategoryScopes(t *testing.T) {
+	indexerBody := `[
+		{
+			"id":3,
+			"name":"ScopedBookTracker",
+			"protocol":"torrent",
+			"supportsSearch":true,
+			"tags":[3],
+			"categories":[],
+			"capabilities":{
+				"categories":[
+					{"id":2000,"name":"Movies","subCategories":[{"id":2010,"name":"Movies/HD"}]},
+					{"id":3000,"name":"Audio","subCategories":[{"id":3030,"name":"Audio/Audiobook"}]},
+					{"id":7000,"name":"Books","subCategories":[{"id":7020,"name":"Books/EBook"}]},
+					{"id":7010,"name":"Books/Mags"},
+					{"id":7030,"name":"Books/Comics"},
+					{"id":100060,"name":"Ebooks - General Fiction"}
+				]
+			}
+		}
+	]`
+	applicationsBody := `[
+		{
+			"enable":true,
+			"syncLevel":"fullSync",
+			"tags":[3],
+			"fields":[{"name":"syncCategories","value":[3030,7000,7010,7020,7030,7040]}]
+		},
+		{
+			"enable":true,
+			"syncLevel":"fullSync",
+			"fields":[{"name":"syncCategories","value":[2000,2010]}]
+		}
+	]`
+	srv := prowlarrClientStub(t, indexerBody, applicationsBody)
+	defer srv.Close()
+
+	infos, err := New(srv.URL, "key").FetchIndexers(context.Background())
+	if err != nil {
+		t.Fatalf("FetchIndexers: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 info, got %d", len(infos))
+	}
+	assertCategoryIDs(t, infos[0].Categories, []int{3030, 7000, 7010, 7020, 7030})
+}
+
+func TestFetchIndexers_AppliesApplicationChildOnlyCategoryScopes(t *testing.T) {
+	indexerBody := `[
+		{
+			"id":3,
+			"name":"ChildOnlyBookTracker",
+			"protocol":"torrent",
+			"supportsSearch":true,
+			"tags":[3],
+			"categories":[],
+			"capabilities":{
+				"categories":[
+					{"id":7010,"name":"Books/Mags"},
+					{"id":7030,"name":"Books/Comics"},
+					{"id":7040,"name":"Books/Technical"}
+				]
+			}
+		},
+		{
+			"id":4,
+			"name":"ChildOnlyAudioTracker",
+			"protocol":"torrent",
+			"supportsSearch":true,
+			"tags":[4],
+			"categories":[],
+			"capabilities":{
+				"categories":[
+					{"id":3010,"name":"Audio/MP3"},
+					{"id":3030,"name":"Audio/Audiobook"}
+				]
+			}
+		}
+	]`
+	applicationsBody := `[
+		{
+			"enable":true,
+			"syncLevel":"fullSync",
+			"tags":[3],
+			"fields":[{"name":"syncCategories","value":[7010,7030,7040]}]
+		},
+		{
+			"enable":true,
+			"syncLevel":"fullSync",
+			"tags":[4],
+			"fields":[{"name":"syncCategories","value":[3010,3030]}]
+		}
+	]`
+	srv := prowlarrClientStub(t, indexerBody, applicationsBody)
+	defer srv.Close()
+
+	infos, err := New(srv.URL, "key").FetchIndexers(context.Background())
+	if err != nil {
+		t.Fatalf("FetchIndexers: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 infos, got %d", len(infos))
+	}
+	assertCategoryIDs(t, infos[0].Categories, []int{7010, 7030, 7040})
+	assertCategoryIDs(t, infos[1].Categories, []int{3010, 3030})
+}
+
+func TestFetchIndexers_RequiresApplicationTagMatchForCapabilityCategories(t *testing.T) {
+	indexerBody := `[
+		{
+			"id":3,
+			"name":"UntaggedBookTracker",
+			"protocol":"torrent",
+			"supportsSearch":true,
+			"tags":[5],
+			"categories":[],
+			"capabilities":{
+				"categories":[
+					{"id":7000,"name":"Books","subCategories":[{"id":7020,"name":"Books/EBook"}]}
+				]
+			}
+		}
+	]`
+	applicationsBody := `[
+		{
+			"enable":true,
+			"syncLevel":"fullSync",
+			"tags":[3],
+			"fields":[{"name":"syncCategories","value":[7000,7020]}]
+		}
+	]`
+	srv := prowlarrClientStub(t, indexerBody, applicationsBody)
+	defer srv.Close()
+
+	infos, err := New(srv.URL, "key").FetchIndexers(context.Background())
+	if err != nil {
+		t.Fatalf("FetchIndexers: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 info, got %d", len(infos))
+	}
+	if len(infos[0].Categories) != 0 {
+		t.Fatalf("categories = %v, want []", infos[0].Categories)
+	}
+}
+
+func TestFetchIndexers_SkipsCapabilityCategoriesWithOnlyNonBookApplicationScope(t *testing.T) {
+	indexerBody := `[
+		{
+			"id":3,
+			"name":"BookTracker",
+			"protocol":"torrent",
+			"supportsSearch":true,
+			"categories":[],
+			"capabilities":{
+				"categories":[
+					{"id":7000,"name":"Books","subCategories":[{"id":7020,"name":"Books/EBook"}]}
+				]
+			}
+		}
+	]`
+	applicationsBody := `[
+		{
+			"enable":true,
+			"syncLevel":"fullSync",
+			"fields":[{"name":"syncCategories","value":[2000,2010]}]
+		}
+	]`
+	srv := prowlarrClientStub(t, indexerBody, applicationsBody)
+	defer srv.Close()
+
+	infos, err := New(srv.URL, "key").FetchIndexers(context.Background())
+	if err != nil {
+		t.Fatalf("FetchIndexers: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 info, got %d", len(infos))
+	}
+	if len(infos[0].Categories) != 0 {
+		t.Fatalf("categories = %v, want []", infos[0].Categories)
+	}
+}
+
+func TestFetchIndexers_AppliesApplicationScopeWithAnyMatchingTag(t *testing.T) {
+	indexerBody := `[
+		{
+			"id":3,
+			"name":"PartiallyTaggedBookTracker",
+			"protocol":"torrent",
+			"supportsSearch":true,
+			"tags":[3],
+			"categories":[],
+			"capabilities":{
+				"categories":[
+					{"id":7000,"name":"Books","subCategories":[{"id":7020,"name":"Books/EBook"}]}
+				]
+			}
+		}
+	]`
+	applicationsBody := `[
+		{
+			"enable":true,
+			"syncLevel":"fullSync",
+			"tags":[3,4],
+			"fields":[{"name":"syncCategories","value":[7000,7020]}]
+		}
+	]`
+	srv := prowlarrClientStub(t, indexerBody, applicationsBody)
+	defer srv.Close()
+
+	infos, err := New(srv.URL, "key").FetchIndexers(context.Background())
+	if err != nil {
+		t.Fatalf("FetchIndexers: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 info, got %d", len(infos))
+	}
+	assertCategoryIDs(t, infos[0].Categories, []int{7000, 7020})
+}
+
+func TestFetchIndexers_ReturnsApplicationScopeError(t *testing.T) {
+	indexerBody := `[
+		{
+			"id":3,
+			"name":"ScopedBookTracker",
+			"protocol":"torrent",
+			"supportsSearch":true,
+			"categories":[],
+			"capabilities":{
+				"categories":[
+					{"id":7000,"name":"Books","subCategories":[{"id":7020,"name":"Books/EBook"}]}
+				]
+			}
+		}
+	]`
+	srv := prowlarrClientStub(t, indexerBody, `not json`)
+	defer srv.Close()
+
+	_, err := New(srv.URL, "key").FetchIndexers(context.Background())
+	if err == nil {
+		t.Fatal("expected application scope error, got nil")
+	}
+	if !strings.Contains(err.Error(), "fetch prowlarr applications") {
+		t.Fatalf("error = %v, want fetch prowlarr applications", err)
+	}
+}
+
+func TestFetchIndexers_TopLevelCategoriesTakePrecedence(t *testing.T) {
+	body := `[
+		{
+			"id":4,
+			"name":"ConfiguredTracker",
+			"protocol":"torrent",
+			"supportsSearch":true,
+			"categories":[{"id":7020}],
+			"capabilities":{
+				"categories":[
+					{"id":3000,"name":"Audio","subCategories":[{"id":3030,"name":"Audio/Audiobook"}]},
+					{"id":7000,"name":"Books","subCategories":[{"id":7020,"name":"Books/EBook"}]},
+					{"id":100060,"name":"Ebooks - General Fiction"}
+				]
+			}
+		}
+	]`
+	srv := prowlarrStub(t, body)
+	defer srv.Close()
+
+	infos, err := New(srv.URL, "key").FetchIndexers(context.Background())
+	if err != nil {
+		t.Fatalf("FetchIndexers: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 info, got %d", len(infos))
+	}
+	assertCategoryIDs(t, infos[0].Categories, []int{7020})
+}
+
 func TestFetchIndexers_Empty(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -206,5 +483,32 @@ func TestTest_NetworkError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "could not reach Prowlarr") {
 		t.Errorf("expected 'could not reach Prowlarr' in error, got %v", err)
+	}
+}
+
+func prowlarrClientStub(t *testing.T, indexerBody, applicationsBody string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/indexer":
+			_, _ = w.Write([]byte(indexerBody))
+		case "/api/v1/applications":
+			_, _ = w.Write([]byte(applicationsBody))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func assertCategoryIDs(t *testing.T, got, want []int) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("categories = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("categories = %v, want %v", got, want)
+		}
 	}
 }

--- a/internal/prowlarr/syncer_extra_test.go
+++ b/internal/prowlarr/syncer_extra_test.go
@@ -59,6 +59,118 @@ func TestSyncer_SkipsIndexerWithNoBookCategories(t *testing.T) {
 	}
 }
 
+func TestSyncer_CreatesIndexerFromApplicationScopedCapabilities(t *testing.T) {
+	indexerBody := `[{
+		"id":5,
+		"name":"BookTracker",
+		"enable":true,
+		"protocol":"torrent",
+		"supportsSearch":true,
+		"tags":[3],
+		"categories":[],
+		"capabilities":{
+			"categories":[
+				{"id":7000,"name":"Books","subCategories":[{"id":7020,"name":"Books/EBook"}]},
+				{"id":7010,"name":"Books/Mags"},
+				{"id":7030,"name":"Books/Comics"},
+				{"id":7040,"name":"Books/Technical"}
+			]
+		}
+	}]`
+	applicationsBody := `[{
+		"enable":true,
+		"syncLevel":"fullSync",
+		"tags":[3],
+		"fields":[{"name":"syncCategories","value":[3030,7000,7010,7020,7030,7040,7050]}]
+	}]`
+	srv := prowlarrStubWithApplications(t, indexerBody, applicationsBody)
+	defer srv.Close()
+
+	store := &fakeIndexerStore{}
+	syncer := NewSyncer(New(srv.URL, "k"), store, fakeInstanceStore{})
+
+	if _, err := syncer.Sync(context.Background(), 1); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(store.created) != 1 {
+		t.Fatalf("created = %d, want 1", len(store.created))
+	}
+	assertCategoryIDs(t, store.created[0].Categories, []int{7010, 7020, 7030, 7040})
+}
+
+func TestSyncer_CreatesIndexerFromChildOnlyApplicationScope(t *testing.T) {
+	indexerBody := `[{
+		"id":5,
+		"name":"ChildOnlyBookTracker",
+		"enable":true,
+		"protocol":"torrent",
+		"supportsSearch":true,
+		"tags":[3],
+		"categories":[],
+		"capabilities":{
+			"categories":[
+				{"id":7010,"name":"Books/Mags"},
+				{"id":7030,"name":"Books/Comics"},
+				{"id":7040,"name":"Books/Technical"}
+			]
+		}
+	}]`
+	applicationsBody := `[{
+		"enable":true,
+		"syncLevel":"fullSync",
+		"tags":[3],
+		"fields":[{"name":"syncCategories","value":[7010,7030,7040]}]
+	}]`
+	srv := prowlarrStubWithApplications(t, indexerBody, applicationsBody)
+	defer srv.Close()
+
+	store := &fakeIndexerStore{}
+	syncer := NewSyncer(New(srv.URL, "k"), store, fakeInstanceStore{})
+
+	if _, err := syncer.Sync(context.Background(), 1); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(store.created) != 1 {
+		t.Fatalf("created = %d, want 1", len(store.created))
+	}
+	assertCategoryIDs(t, store.created[0].Categories, []int{7010, 7030, 7040})
+}
+
+func TestSyncer_SkipsCapabilityCategoriesWithoutApplicationScope(t *testing.T) {
+	indexerBody := `[{
+		"id":5,
+		"name":"BookTracker",
+		"enable":true,
+		"protocol":"torrent",
+		"supportsSearch":true,
+		"tags":[5],
+		"categories":[],
+		"capabilities":{
+			"categories":[
+				{"id":7000,"name":"Books","subCategories":[{"id":7020,"name":"Books/EBook"}]}
+			]
+		}
+	}]`
+	applicationsBody := `[{
+		"enable":true,
+		"syncLevel":"fullSync",
+		"tags":[3],
+		"fields":[{"name":"syncCategories","value":[7000,7020]}]
+	}]`
+	srv := prowlarrStubWithApplications(t, indexerBody, applicationsBody)
+	defer srv.Close()
+
+	store := &fakeIndexerStore{}
+	syncer := NewSyncer(New(srv.URL, "k"), store, fakeInstanceStore{})
+
+	if _, err := syncer.Sync(context.Background(), 1); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(store.created) != 0 {
+		t.Errorf("expected 0 created (no book/audiobook categories), got %d", len(store.created))
+	}
+}
+
 func TestSyncer_SkipsDisabledIndexer(t *testing.T) {
 	// Issue #675: an indexer disabled in Prowlarr must not be added to Bindery.
 	srv := prowlarrStub(t, `[{"id":6,"name":"DisabledIdx","enable":false,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`)

--- a/internal/prowlarr/syncer_test.go
+++ b/internal/prowlarr/syncer_test.go
@@ -71,6 +71,21 @@ func prowlarrStub(t *testing.T, body string) *httptest.Server {
 	}))
 }
 
+func prowlarrStubWithApplications(t *testing.T, indexerBody, applicationsBody string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/indexer":
+			_, _ = w.Write([]byte(indexerBody))
+		case "/api/v1/applications":
+			_, _ = w.Write([]byte(applicationsBody))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
 func TestFilterCategoriesForMedia(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

Some Prowlarr indexers can expose book-capable categories through `capabilities.categories` while leaving the top-level indexer category list empty, which caused Bindery to reject them as non-book indexers. This PR infers the relevant book/audiobook scope from enabled Prowlarr applications only when top-level categories are absent, preserving non-book filtering while allowing supported book-focused indexers to sync.

- Flatten direct and nested capability categories from Prowlarr indexers.
- Fetch enabled Prowlarr application category scopes only when an indexer needs the fallback.
- Intersect application `syncCategories` with indexer capabilities and matching tags before creating Bindery indexers.
- Add client and syncer coverage for app-scoped categories, child-only categories, tag mismatches, non-book scopes, and top-level category precedence.

## Checklist

- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed - N/A, no env vars, config, or upgrade path changed
- [ ] `CHANGELOG.md` `[Unreleased]` section updated - N/A, release-time only per `AGENTS.md`
- [ ] Wiki pages updated if user-facing behaviour changed - N/A, scoped Prowlarr sync fix only

## Test plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `golangci-lint v2.11.4 run --timeout=5m`
- [x] `govulncheck ./...`
- [x] `go test ./internal/prowlarr`
- [x] `go test ./cmd/... ./internal/...`
- [x] `make test`
- [ ] `cd web && npm run build` - N/A, `web/` untouched
