### PR TITLE
feat(telemetry): access-log middleware on the telemetry-server

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -173,7 +173,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:         addr,
-		Handler:      secureHeaders(canonicalHost, mux),
+		Handler:      logRequests(secureHeaders(canonicalHost, mux)),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  120 * time.Second,
@@ -183,6 +183,42 @@ func main() {
 		slog.Error("listen", "error", err)
 		os.Exit(1)
 	}
+}
+
+// statusRecorder wraps http.ResponseWriter to capture the response status code
+// for the access log. Defaults to 200 — a handler that only calls Write (never
+// WriteHeader) still sends 200 implicitly.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+// logRequests is an access-log middleware: one slog line per request, carrying
+// the real client IP via realIP (X-Real-Ip / X-Forwarded-For aware), so the log
+// shows the external address rather than Traefik's pod IP. The /health
+// readiness probe is skipped so it doesn't flood the log every few seconds.
+func logRequests(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+		slog.Info("request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", rec.status,
+			"ip", realIP(r),
+			"dur", time.Since(start).Round(time.Millisecond).String(),
+		)
+	})
 }
 
 // secureHeaders adds security response headers and rejects non-HTTPS requests

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -182,3 +182,23 @@ func TestHandleStatsJSON(t *testing.T) {
 		t.Errorf("Latest = %q, want v1.9.5", got.Latest)
 	}
 }
+
+func TestLogRequestsPassesThrough(t *testing.T) {
+	h := logRequests(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	// Both a normal path and /health (the skipped path) must pass the
+	// downstream handler's status and body through unchanged.
+	for _, path := range []string{"/api/ping", "/health"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusTeapot {
+			t.Errorf("%s: status = %d, want %d", path, rec.Code, http.StatusTeapot)
+		}
+		if rec.Body.String() != "ok" {
+			t.Errorf("%s: body = %q, want \"ok\"", path, rec.Body.String())
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The telemetry-server only logged pings (and errors) — there was no per-request access log, and no client IP in the logs at all. Adds a `logRequests` middleware: one `slog` line per request with method, path, status, the **real client IP**, and duration.

## Implementation notes

- `logRequests` wraps the chain outermost — `logRequests(secureHeaders(canonicalHost, mux))` — so even requests `secureHeaders` rejects are logged.
- Client IP via the existing `realIP` helper (`X-Real-Ip` / `X-Forwarded-For` aware) — shows the external address, not Traefik's pod IP.
- `/health` is skipped so the 10s readiness probe doesn't flood the log.
- `statusRecorder` captures the response status (defaults to 200).

## Checklist

- [x] Tests added or updated — `TestLogRequestsPassesThrough`
- [x] Doc-update gate cleared — no env vars / flags / auth / config surface changed
- [x] Wiki — n/a, internal

## Test plan

- [x] `go test -race ./cmd/telemetry-server/`
- [x] `go vet` + `go build` + `gofmt -l ./cmd/telemetry-server/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
