### PR TITLE
fix(qbittorrent): ignore boolean download_path flags

### DIFF
--- a/internal/downloader/health_test.go
+++ b/internal/downloader/health_test.go
@@ -14,12 +14,19 @@ func TestCheckDownloadClientHealth_QBittorrentCategoryPath(t *testing.T) {
 	tests := []struct {
 		name       string
 		categories string
+		pathRemap  string
 		wantStatus string
 		wantText   string
 	}{
 		{
 			name:       "remapped category path matches",
 			categories: `{"books":{"name":"books","savePath":"/media/downloads"}}`,
+			wantStatus: HealthOK,
+		},
+		{
+			name:       "qbit v5 boolean download_path still remaps category path",
+			categories: `{"books":{"download_path":false,"name":"books","savePath":"/media/books/downloads"}}`,
+			pathRemap:  "/media/books:/books",
 			wantStatus: HealthOK,
 		},
 		{
@@ -70,6 +77,10 @@ func TestCheckDownloadClientHealth_QBittorrentCategoryPath(t *testing.T) {
 			defer srv.Close()
 
 			host, port := serverHostPort(t, srv.URL)
+			pathRemap := tc.pathRemap
+			if pathRemap == "" {
+				pathRemap = "/media:/books"
+			}
 			client := &models.DownloadClient{
 				Type:      "qbittorrent",
 				Host:      host,
@@ -77,7 +88,7 @@ func TestCheckDownloadClientHealth_QBittorrentCategoryPath(t *testing.T) {
 				Username:  "u",
 				Password:  "p",
 				Category:  "books",
-				PathRemap: "/media:/books",
+				PathRemap: pathRemap,
 			}
 			got := CheckDownloadClientHealth(context.Background(), client, "/books/downloads", "")
 			if got.Status != tc.wantStatus {

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -1501,8 +1501,10 @@ func TestGetTorrents_V4AndV5_StateValues(t *testing.T) {
 // parses both the v4 and v5 JSON object shapes. The endpoint has always
 // returned a name->object map; the variation across versions is the per-entry
 // save-path key (`savePath`, `save_path`, `download_path`), which
-// Category.UnmarshalJSON normalizes. This fixture exercises every observed
-// key and confirms a missing-name entry is backfilled from its map key.
+// Category.UnmarshalJSON normalizes. qBittorrent v5.1.4 can also include a
+// boolean `download_path` flag alongside `savePath`; that alias must be ignored
+// instead of failing the whole categories response. This fixture exercises every
+// observed key and confirms a missing-name entry is backfilled from its map key.
 func TestGetCategories_V4AndV5_ResponseShapes(t *testing.T) {
 	fixtures := []struct {
 		name string
@@ -1519,6 +1521,10 @@ func TestGetCategories_V4AndV5_ResponseShapes(t *testing.T) {
 		{
 			name: "mixed_with_download_path_and_missing_name",
 			body: `{"Video":{"savePath":"/dl/video"},"eBooks":{"name":"eBooks","download_path":"/dl/ebooks"}}`,
+		},
+		{
+			name: "v5_1_4_boolean_download_path_flag",
+			body: `{"Video":{"name":"Video","download_path":false,"savePath":"/dl/video"},"eBooks":{"name":"eBooks","download_path":false,"savePath":"/dl/ebooks"}}`,
 		},
 	}
 	for _, f := range fixtures {

--- a/internal/downloader/qbittorrent/types.go
+++ b/internal/downloader/qbittorrent/types.go
@@ -28,21 +28,32 @@ type Category struct {
 
 func (c *Category) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		Name          string `json:"name"`
-		SavePath      string `json:"savePath"`
-		SavePathSnake string `json:"save_path"`
-		DownloadPath  string `json:"download_path"`
+		Name          string          `json:"name"`
+		SavePath      json.RawMessage `json:"savePath"`
+		SavePathSnake json.RawMessage `json:"save_path"`
+		DownloadPath  json.RawMessage `json:"download_path"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 	c.Name = raw.Name
-	c.SavePath = raw.SavePath
+	c.SavePath = categoryPathString(raw.SavePath)
 	if c.SavePath == "" {
-		c.SavePath = raw.SavePathSnake
+		c.SavePath = categoryPathString(raw.SavePathSnake)
 	}
 	if c.SavePath == "" {
-		c.SavePath = raw.DownloadPath
+		c.SavePath = categoryPathString(raw.DownloadPath)
 	}
 	return nil
+}
+
+func categoryPathString(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return ""
+	}
+	return value
 }


### PR DESCRIPTION
## Summary

qBittorrent 5.1.4 can return a boolean `download_path` flag in category payloads alongside `savePath`, which made Bindery fail category health checks with `cannot unmarshal bool into Go struct field`. This PR ignores non-string category path aliases while preserving the string save path used for qBittorrent category validation.

- Decode category path aliases through `json.RawMessage` so non-string `download_path` flags do not fail the categories response.
- Add qBittorrent and downloader health fixtures covering the 5.1.4 boolean `download_path` category shape.

## Checklist

- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed - N/A, backend qBittorrent response compatibility only
- [ ] `CHANGELOG.md` `[Unreleased]` section updated - N/A, release-time only per `AGENTS.md`
- [ ] Wiki pages updated if user-facing behaviour changed - N/A, no wiki update needed for this compatibility fix

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [ ] `cd web && npm run build` - N/A, backend-only diff
- [x] `go test ./internal/downloader/...`
- [x] `gofmt -l internal/downloader/health_test.go internal/downloader/qbittorrent/client_test.go internal/downloader/qbittorrent/types.go`
- [x] `go vet ./...`
- [x] `golangci-lint run --timeout=5m` with repo-pinned v2.11.4
- [x] `govulncheck ./...`
