### PR TITLE
fix(prowlarr): sync book indexers without an application scope

### DIFF
--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -114,6 +114,16 @@ func (c *Client) FetchIndexers(ctx context.Context) ([]IndexerInfo, error) {
 		if len(cats) == 0 {
 			cats = categoriesFromApplicationScopes(ri, scopes)
 		}
+		// Issue #763: when Prowlarr has no book-scoped application registered
+		// there is no app signal to scope capability categories against. Most
+		// Bindery users run Prowlarr standalone (or alongside only Sonarr/
+		// Radarr), so without this fallback every indexer is rejected as
+		// having "no book/audiobook categories" and the syncer wipes the lot.
+		// Trust the indexer's own capability categories, narrowed to the
+		// book/audiobook Newznab ranges.
+		if len(cats) == 0 && len(scopes) == 0 {
+			cats = bookCapabilityCategories(ri)
+		}
 
 		infos = append(infos, IndexerInfo{
 			ProwlarrID:     ri.ID,
@@ -177,13 +187,34 @@ func (a remoteApplication) syncCategories() []int {
 	return nil
 }
 
+// isBookOrAudiobookCategory reports whether a Newznab category ID falls in the
+// book (7000-7999) or audiobook (3000-3999) ranges.
+func isBookOrAudiobookCategory(category int) bool {
+	return (category >= 7000 && category < 8000) || (category >= 3000 && category < 4000)
+}
+
 func hasBookOrAudiobookCategory(categories []int) bool {
 	for _, cat := range categories {
-		if (cat >= 7000 && cat < 8000) || (cat >= 3000 && cat < 4000) {
+		if isBookOrAudiobookCategory(cat) {
 			return true
 		}
 	}
 	return false
+}
+
+// bookCapabilityCategories returns an indexer's advertised capability
+// categories restricted to the book and audiobook ranges. It is the
+// standalone-Prowlarr fallback for FetchIndexers (issue #763): with no
+// application scope to consult, the indexer's own capabilities are the only
+// signal for whether it can serve books.
+func bookCapabilityCategories(indexer remoteIndexer) []int {
+	var out []int
+	for _, id := range categoryIDs(indexer.Capabilities.Categories) {
+		if isBookOrAudiobookCategory(id) {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 func categoryIDs(categories []remoteCategory) []int {

--- a/internal/prowlarr/client_test.go
+++ b/internal/prowlarr/client_test.go
@@ -235,7 +235,10 @@ func TestFetchIndexers_RequiresApplicationTagMatchForCapabilityCategories(t *tes
 	}
 }
 
-func TestFetchIndexers_SkipsCapabilityCategoriesWithOnlyNonBookApplicationScope(t *testing.T) {
+func TestFetchIndexers_FallsBackToCapabilitiesWithOnlyNonBookApplicationScope(t *testing.T) {
+	// Issue #763: the only registered application is non-book (e.g. Radarr),
+	// so there is no book-scoped application to consult. The indexer's own
+	// book capabilities must still be used rather than dropped.
 	indexerBody := `[
 		{
 			"id":3,
@@ -258,6 +261,70 @@ func TestFetchIndexers_SkipsCapabilityCategoriesWithOnlyNonBookApplicationScope(
 		}
 	]`
 	srv := prowlarrClientStub(t, indexerBody, applicationsBody)
+	defer srv.Close()
+
+	infos, err := New(srv.URL, "key").FetchIndexers(context.Background())
+	if err != nil {
+		t.Fatalf("FetchIndexers: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 info, got %d", len(infos))
+	}
+	assertCategoryIDs(t, infos[0].Categories, []int{7000, 7020})
+}
+
+func TestFetchIndexers_FallsBackToCapabilitiesWhenNoApplications(t *testing.T) {
+	// Issue #763: standalone Prowlarr with no applications registered. The
+	// indexer's book/audiobook capabilities are the only signal and must be
+	// used; non-book capabilities (movies) are dropped.
+	indexerBody := `[
+		{
+			"id":3,
+			"name":"MyAnonamouse",
+			"protocol":"torrent",
+			"supportsSearch":true,
+			"categories":[],
+			"capabilities":{
+				"categories":[
+					{"id":2000,"name":"Movies","subCategories":[{"id":2010,"name":"Movies/HD"}]},
+					{"id":3000,"name":"Audio","subCategories":[{"id":3030,"name":"Audio/Audiobook"}]},
+					{"id":7000,"name":"Books","subCategories":[{"id":7020,"name":"Books/EBook"}]}
+				]
+			}
+		}
+	]`
+	srv := prowlarrClientStub(t, indexerBody, `[]`)
+	defer srv.Close()
+
+	infos, err := New(srv.URL, "key").FetchIndexers(context.Background())
+	if err != nil {
+		t.Fatalf("FetchIndexers: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 info, got %d", len(infos))
+	}
+	assertCategoryIDs(t, infos[0].Categories, []int{3000, 3030, 7000, 7020})
+}
+
+func TestFetchIndexers_NonBookIndexerStaysEmptyWithoutApplications(t *testing.T) {
+	// A movie/TV-only indexer has no book or audiobook capabilities, so the
+	// standalone fallback leaves it with no categories (the syncer drops it).
+	indexerBody := `[
+		{
+			"id":4,
+			"name":"MovieTracker",
+			"protocol":"torrent",
+			"supportsSearch":true,
+			"categories":[],
+			"capabilities":{
+				"categories":[
+					{"id":2000,"name":"Movies","subCategories":[{"id":2010,"name":"Movies/HD"}]},
+					{"id":5000,"name":"TV","subCategories":[{"id":5040,"name":"TV/HD"}]}
+				]
+			}
+		}
+	]`
+	srv := prowlarrClientStub(t, indexerBody, `[]`)
 	defer srv.Close()
 
 	infos, err := New(srv.URL, "key").FetchIndexers(context.Background())

--- a/internal/prowlarr/syncer.go
+++ b/internal/prowlarr/syncer.go
@@ -141,16 +141,26 @@ func (s *Syncer) Sync(ctx context.Context, instanceID int64) (SyncResult, error)
 		}
 	}
 
-	// Remove indexers that disappeared from Prowlarr.
-	for prowlarrID, ex := range byProwlarrID {
-		if _, ok := seen[prowlarrID]; ok {
-			continue
-		}
-		if err := s.indexers.Delete(ctx, ex.ID); err != nil {
-			slog.Warn("prowlarr sync: delete stale indexer failed",
-				"id", ex.ID, "name", ex.Name, "error", err)
-		} else {
-			result.Removed++
+	// Remove indexers that disappeared from Prowlarr — but never when a sync
+	// matched nothing at all. Issue #763: a category-filter regression filtered
+	// out every indexer, turning each sync into a full wipe of the user's
+	// indexer config (priorities, enable state). Zero matches against a
+	// non-empty existing set is treated as a failed sync, not an instruction to
+	// delete everything; a genuinely stale indexer can still be removed by hand.
+	if len(seen) == 0 && len(byProwlarrID) > 0 {
+		slog.Warn("prowlarr sync: zero indexers matched an existing set; skipping removals to protect indexer config",
+			"instance_id", instanceID, "existing", len(byProwlarrID))
+	} else {
+		for prowlarrID, ex := range byProwlarrID {
+			if _, ok := seen[prowlarrID]; ok {
+				continue
+			}
+			if err := s.indexers.Delete(ctx, ex.ID); err != nil {
+				slog.Warn("prowlarr sync: delete stale indexer failed",
+					"id", ex.ID, "name", ex.Name, "error", err)
+			} else {
+				result.Removed++
+			}
 		}
 	}
 

--- a/internal/prowlarr/syncer_test.go
+++ b/internal/prowlarr/syncer_test.go
@@ -272,3 +272,67 @@ func TestSyncer_NoUpdateWhenNothingChanged(t *testing.T) {
 		t.Errorf("expected no updates, got %+v", store.updated)
 	}
 }
+
+func TestSyncer_KeepsExistingIndexersWhenSyncMatchesNothing(t *testing.T) {
+	// Issue #763: a sync that matches zero indexers (a category-filter
+	// regression, a partial Prowlarr response) must not delete the user's
+	// existing synced indexers.
+	pID := 7
+	instID := int64(1)
+	existing := []models.Indexer{{
+		ID:                 11,
+		Name:               "TrackerX",
+		Type:               "torznab",
+		Categories:         []int{7020},
+		ProwlarrInstanceID: &instID,
+		ProwlarrIndexerID:  &pID,
+	}}
+	// Prowlarr returns an indexer the filter rejects (no categories, no
+	// capabilities, no applications) — nothing matches.
+	srv := prowlarrStub(t, `[{"id":99,"name":"Torrenting","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[]}]`)
+	defer srv.Close()
+
+	store := &fakeIndexerStore{existing: existing}
+	syncer := NewSyncer(New(srv.URL, "k"), store, fakeInstanceStore{})
+
+	res, err := syncer.Sync(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(store.deleted) != 0 {
+		t.Errorf("deleted = %v, want none (a zero-match sync must not wipe indexers)", store.deleted)
+	}
+	if res.Removed != 0 {
+		t.Errorf("Removed = %d, want 0", res.Removed)
+	}
+}
+
+func TestSyncer_RemovesStaleIndexerWhenOthersStillMatch(t *testing.T) {
+	// The zero-match guard must not block legitimate removals: when at least
+	// one indexer still matches, indexers gone from Prowlarr are deleted.
+	matchID, staleID := 7, 8
+	instID := int64(1)
+	existing := []models.Indexer{
+		{ID: 11, Name: "Keep", Type: "torznab", Categories: []int{7020},
+			ProwlarrInstanceID: &instID, ProwlarrIndexerID: &matchID},
+		{ID: 12, Name: "Gone", Type: "torznab", Categories: []int{7020},
+			ProwlarrInstanceID: &instID, ProwlarrIndexerID: &staleID},
+	}
+	srv := prowlarrStub(t, `[{"id":7,"name":"Keep","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}]}]`)
+	defer srv.Close()
+	existing[0].URL = srv.URL + "/7/api"
+
+	store := &fakeIndexerStore{existing: existing}
+	syncer := NewSyncer(New(srv.URL, "k"), store, fakeInstanceStore{})
+
+	res, err := syncer.Sync(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(store.deleted) != 1 || store.deleted[0] != 12 {
+		t.Errorf("deleted = %v, want [12]", store.deleted)
+	}
+	if res.Removed != 1 {
+		t.Errorf("Removed = %d, want 1", res.Removed)
+	}
+}


### PR DESCRIPTION
## Summary

Completes the #763 fix. #788 began parsing `capabilities.categories` but only trusts them when a book-scoped Prowlarr **application** (Readarr/LazyLibrarian) is registered to scope them against. Users running Prowlarr standalone — or with only Sonarr/Radarr registered — have no such application, so for them every indexer was still dropped and the syncer kept wiping their existing indexer config (`removed=26` in one report).

- **`FetchIndexers`** — when no book-scoped application scope is available (`len(scopes) == 0`), fall back to the indexer's own `capabilities.categories`, narrowed to the book (7000-7999) and audiobook (3000-3999) Newznab ranges. A pure book tracker (MyAnonamouse) syncs; a movie/TV-only tracker still does not. Where a book-scoped application *does* exist, #788's precise app-scoped path is unchanged.
- **`Syncer`** — never delete indexers when a sync matches nothing at all. A zero-match run against a non-empty existing set is treated as a failed sync, not an instruction to wipe the user's indexer config. This bounds the blast radius of any future filter regression — the original #763 data loss could not happen again even if the category logic broke.

One #788 test (`...SkipsCapabilityCategoriesWithOnlyNonBookApplicationScope`) asserted the old drop-everything behaviour for the only-non-book-app case; it is renamed and updated to assert the fallback, which is the correct outcome for #763.

Closes #763.

## Checklist

- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated — N/A, no env vars, config, or upgrade path changed
- [ ] `CHANGELOG.md` `[Unreleased]` updated — N/A, release-time only per `AGENTS.md`
- [ ] Wiki pages updated — N/A, restores intended behaviour

## Test plan

- [x] `gofmt -l internal/prowlarr/`
- [x] `go vet ./internal/prowlarr/...`
- [x] `golangci-lint run ./internal/prowlarr/... --timeout=3m` (v2.11.4, 0 issues)
- [x] `go build ./...`
- [x] `go test ./cmd/... ./internal/...` (46 packages, all pass)