### PR TITLE
fix(importer): mark re-grabbed already-imported torrent as StateImported (#769)

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -892,6 +892,22 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 		if isComplete && (dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed) {
 			rawPath, ok := resolveQbitContentPath(torrent)
 			if !ok {
+				// content_path is absent or points to a path that no longer exists.
+				// This can happen when files were moved to the library by a prior
+				// Bindery import (move mode) and the torrent is re-grabbed via a
+				// 409 duplicate-add (#769). If the book is already in the library,
+				// close out this download immediately rather than looping forever.
+				if s.isBookAlreadyImported(ctx, &dl) {
+					slog.Info("qbittorrent: content path gone but book already in library — marking as imported",
+						"title", dl.Title)
+					// Walk the state machine: grabbed/downloading → completed →
+					// importPending → importing → imported.
+					s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
+					s.updateDownloadStatus(ctx, dl.ID, models.StateImportPending)
+					s.updateDownloadStatus(ctx, dl.ID, models.StateImporting)
+					s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
+					continue
+				}
 				// Path doesn't exist on disk yet (qBittorrent may sanitise characters
 				// in the torrent name that differ from what the API reports, e.g. ':'→'_').
 				// Do NOT fall back to torrent.SavePath — for multi-file torrents that is
@@ -914,6 +930,16 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 			// files — retry the import rather than leaving it stuck permanently.
 			rawPath, ok := resolveQbitContentPath(torrent)
 			if !ok {
+				// Same guard as the StateGrabbed branch: if the book is already in
+				// the library (files moved by a prior import), close out cleanly.
+				if s.isBookAlreadyImported(ctx, &dl) {
+					slog.Info("qbittorrent: content path gone but book already in library — marking as imported",
+						"title", dl.Title)
+					s.updateDownloadStatus(ctx, dl.ID, models.StateImportPending)
+					s.updateDownloadStatus(ctx, dl.ID, models.StateImporting)
+					s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
+					continue
+				}
 				slog.Warn("qbittorrent: content path not found during import retry, will retry next cycle",
 					"title", dl.Title,
 					"save_path", torrent.SavePath,
@@ -1027,6 +1053,27 @@ func (s *Scanner) alreadyImportedFormat(ctx context.Context, book *models.Book, 
 	return false
 }
 
+// isBookAlreadyImported reports whether any on-disk file is tracked in
+// book_files for the book linked to dl, in either ebook or audiobook format.
+//
+// It is used as a guard for duplicate-add re-grabs (#769): when a torrent is
+// re-grabbed after qBittorrent already holds it (409 response), the original
+// download files may have been moved to the library by a prior Bindery import
+// (move mode), leaving the download path empty. Rather than failing with "no
+// book files found" and burning through the retry budget, the caller can check
+// this and mark the Download StateImported directly.
+func (s *Scanner) isBookAlreadyImported(ctx context.Context, dl *models.Download) bool {
+	if dl.BookID == nil {
+		return false
+	}
+	book, err := s.books.GetByID(ctx, *dl.BookID)
+	if err != nil || book == nil {
+		return false
+	}
+	return s.alreadyImportedFormat(ctx, book, models.MediaTypeAudiobook) ||
+		s.alreadyImportedFormat(ctx, book, models.MediaTypeEbook)
+}
+
 // alreadyImportedPath reports whether the exact destination path is already
 // tracked in book_files for the book and still exists on disk. This is the
 // per-file idempotency guard for ebook imports, whose destination paths are
@@ -1108,6 +1155,20 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	}
 
 	if len(bookFiles) == 0 {
+		// Before failing, check whether the book is already in the library. This
+		// covers the case where a torrent was re-grabbed after its files were moved
+		// to the library by a prior Bindery import (move mode): the download path is
+		// empty but the book is already on disk. Marking it StateImported avoids
+		// spurious failure noise and retry churn (#769).
+		if s.isBookAlreadyImported(ctx, dl) {
+			slog.Info("no book files at download path but book already in library — marking as imported",
+				"title", dl.Title, "path", downloadPath)
+			// Currently at StateImportPending (set at the top of this function).
+			// Walk: importPending → importing → imported.
+			s.updateDownloadStatus(ctx, dl.ID, models.StateImporting)
+			s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
+			return
+		}
 		slog.Warn("no book files found in download", "path", downloadPath)
 		// No files — retryable if the downloader hasn't flushed them yet.
 		s.failImport(ctx, dl, models.StateImportFailed, fmt.Sprintf("no book files found in %q", downloadPath))

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1053,8 +1053,9 @@ func (s *Scanner) alreadyImportedFormat(ctx context.Context, book *models.Book, 
 	return false
 }
 
-// isBookAlreadyImported reports whether any on-disk file is tracked in
-// book_files for the book linked to dl, in either ebook or audiobook format.
+// isBookAlreadyImported reports whether the book linked to dl already has an
+// on-disk file tracked in book_files, scoped to the format(s) the book is
+// monitored for.
 //
 // It is used as a guard for duplicate-add re-grabs (#769): when a torrent is
 // re-grabbed after qBittorrent already holds it (409 response), the original
@@ -1062,6 +1063,14 @@ func (s *Scanner) alreadyImportedFormat(ctx context.Context, book *models.Book, 
 // (move mode), leaving the download path empty. Rather than failing with "no
 // book files found" and burning through the retry budget, the caller can check
 // this and mark the Download StateImported directly.
+//
+// Scoping: the check is limited to the format(s) the book is configured for
+// (book.MediaType). For single-format books (ebook or audiobook) this avoids
+// falsely marking a fresh download as imported when only the other format
+// already exists. For dual-format books (MediaTypeBoth) the Download record
+// does not carry which format this particular grab targets, so both formats
+// are checked; a re-grab of one format where only the other is on disk is
+// an accepted narrow false-positive in that case.
 func (s *Scanner) isBookAlreadyImported(ctx context.Context, dl *models.Download) bool {
 	if dl.BookID == nil {
 		return false
@@ -1070,8 +1079,15 @@ func (s *Scanner) isBookAlreadyImported(ctx context.Context, dl *models.Download
 	if err != nil || book == nil {
 		return false
 	}
-	return s.alreadyImportedFormat(ctx, book, models.MediaTypeAudiobook) ||
-		s.alreadyImportedFormat(ctx, book, models.MediaTypeEbook)
+	switch book.MediaType {
+	case models.MediaTypeEbook:
+		return s.alreadyImportedFormat(ctx, book, models.MediaTypeEbook)
+	case models.MediaTypeAudiobook:
+		return s.alreadyImportedFormat(ctx, book, models.MediaTypeAudiobook)
+	default: // MediaTypeBoth or unknown
+		return s.alreadyImportedFormat(ctx, book, models.MediaTypeAudiobook) ||
+			s.alreadyImportedFormat(ctx, book, models.MediaTypeEbook)
+	}
 }
 
 // alreadyImportedPath reports whether the exact destination path is already

--- a/internal/importer/scanner_qbittorrent_test.go
+++ b/internal/importer/scanner_qbittorrent_test.go
@@ -397,7 +397,7 @@ func TestCheckQbittorrentDownloads_ContentPathGoneAlreadyImported(t *testing.T) 
 	if err := authorRepo.Create(ctx, author); err != nil {
 		t.Fatal(err)
 	}
-	book := &models.Book{AuthorID: author.ID, Title: "My Book", ForeignID: "b-769", Status: "wanted"}
+	book := &models.Book{AuthorID: author.ID, Title: "My Book", ForeignID: "b-769", Status: "wanted", MediaType: models.MediaTypeEbook}
 	if err := bookRepo.Create(ctx, book); err != nil {
 		t.Fatal(err)
 	}
@@ -448,13 +448,15 @@ func TestCheckQbittorrentDownloads_ContentPathGoneAlreadyImported(t *testing.T) 
 // book files (e.g. files were moved to the library by a prior import). The
 // book is already tracked in book_files with an on-disk file. The scanner must
 // mark the Download StateImported rather than StateImportFailed.
+// Uses MediaTypeAudiobook to exercise that switch arm of isBookAlreadyImported.
 func TestTryImportInternal_EmptyPathAlreadyImported(t *testing.T) {
 	libraryDir := t.TempDir()
+	audiobookDir := t.TempDir()
 	emptyDownloadDir := t.TempDir() // no book files
 
-	// Simulate a book file already in the library.
-	libEpub := filepath.Join(libraryDir, "book.epub")
-	if err := os.WriteFile(libEpub, []byte("epub-in-library"), 0o644); err != nil {
+	// Simulate an audiobook already in the library.
+	libM4b := filepath.Join(audiobookDir, "book.m4b")
+	if err := os.WriteFile(libM4b, []byte("m4b-in-library"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -471,17 +473,17 @@ func TestTryImportInternal_EmptyPathAlreadyImported(t *testing.T) {
 	authorRepo := db.NewAuthorRepo(database)
 	histRepo := db.NewHistoryRepo(database)
 
-	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, "", "", "", "")
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, audiobookDir, "", "", "")
 
 	author := &models.Author{Name: "Test Author", ForeignID: "a-769b", SortName: "Author, Test"}
 	if err := authorRepo.Create(ctx, author); err != nil {
 		t.Fatal(err)
 	}
-	book := &models.Book{AuthorID: author.ID, Title: "My Book", ForeignID: "b-769b", Status: "wanted"}
+	book := &models.Book{AuthorID: author.ID, Title: "My Book", ForeignID: "b-769b", Status: "wanted", MediaType: models.MediaTypeAudiobook}
 	if err := bookRepo.Create(ctx, book); err != nil {
 		t.Fatal(err)
 	}
-	if err := bookRepo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, libEpub); err != nil {
+	if err := bookRepo.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, libM4b); err != nil {
 		t.Fatal(err)
 	}
 
@@ -505,5 +507,118 @@ func TestTryImportInternal_EmptyPathAlreadyImported(t *testing.T) {
 		t.Errorf("#769 regression: expected status %q (book already in library), got %q — "+
 			"re-grab of already-imported book must not fail with 'no book files found'",
 			models.StateImported, got.Status)
+	}
+}
+
+// TestCheckQbittorrentDownloads_ImportFailedContentPathGoneAlreadyImported
+// covers the StateImportFailed retry branch of checkQbittorrentDownloads when
+// content_path is absent and the book is already in the library (#769).
+//
+// Scenario: a prior import attempt left the download in StateImportFailed
+// (e.g. the path was temporarily missing). The book is now confirmed on disk.
+// On the next retry cycle the scanner must mark it StateImported rather than
+// incrementing the retry counter and looping again.
+func TestCheckQbittorrentDownloads_ImportFailedContentPathGoneAlreadyImported(t *testing.T) {
+	saveRoot := t.TempDir()
+	libraryDir := t.TempDir()
+
+	libEpub := filepath.Join(libraryDir, "book.epub")
+	if err := os.WriteFile(libEpub, []byte("epub-in-library"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const torrentHash = "cafe1234567890cafe1234567890cafe12345678"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			torrents := []map[string]any{{
+				"hash":         torrentHash,
+				"name":         "My Book",
+				"state":        "missingFiles",
+				"progress":     1.0,
+				"save_path":    saveRoot,
+				"content_path": "",
+			}}
+			_ = json.NewEncoder(w).Encode(torrents)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, "", "", "", "")
+
+	author := &models.Author{Name: "Test Author", ForeignID: "a-769c", SortName: "Author, Test"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{AuthorID: author.ID, Title: "My Book", ForeignID: "b-769c", Status: "wanted", MediaType: models.MediaTypeEbook}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, libEpub); err != nil {
+		t.Fatal(err)
+	}
+
+	host, port := scannerTestHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name: "qbit-769c", Type: "qbittorrent",
+		Host: host, Port: port, Enabled: true,
+	}
+	if err := clientRepo.Create(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+
+	hash := torrentHash
+	dl := &models.Download{
+		GUID:             "guid-769-importfailed",
+		Title:            "My Book",
+		Status:           models.StateImportFailed,
+		Protocol:         "torrent",
+		TorrentID:        &hash,
+		BookID:           &book.ID,
+		DownloadClientID: &client.ID,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	s.checkQbittorrentDownloads(ctx, client)
+
+	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.Status != models.StateImported {
+		t.Errorf("#769 regression (StateImportFailed branch): expected status %q (book already in library), got %q",
+			models.StateImported, got.Status)
+	}
+	if got.ImportRetryCount != 0 {
+		t.Errorf("expected ImportRetryCount=0 (no retry when already imported), got %d", got.ImportRetryCount)
+	}
+}
+
+// TestIsBookAlreadyImported_NilBookID verifies the nil-BookID guard returns false.
+func TestIsBookAlreadyImported_NilBookID(t *testing.T) {
+	s, _, _, ctx := scannerFixture(t, t.TempDir())
+	dl := &models.Download{GUID: "no-book", Status: models.StateGrabbed} // BookID is nil
+	if s.isBookAlreadyImported(ctx, dl) {
+		t.Error("expected false for download with no BookID, got true")
 	}
 }

--- a/internal/importer/scanner_qbittorrent_test.go
+++ b/internal/importer/scanner_qbittorrent_test.go
@@ -622,3 +622,65 @@ func TestIsBookAlreadyImported_NilBookID(t *testing.T) {
 		t.Error("expected false for download with no BookID, got true")
 	}
 }
+
+// TestIsBookAlreadyImported_BookNotFound verifies that a non-nil BookID that
+// resolves to no book (GetByID returns nil, nil) causes isBookAlreadyImported
+// to return false rather than panic or return true.
+func TestIsBookAlreadyImported_BookNotFound(t *testing.T) {
+	s, _, _, ctx := scannerFixture(t, t.TempDir())
+	// Use a BookID that was never inserted — GetByID returns nil, nil.
+	missingID := int64(99999)
+	dl := &models.Download{
+		GUID:   "orphan-book",
+		Status: models.StateGrabbed,
+		BookID: &missingID,
+	}
+	if s.isBookAlreadyImported(ctx, dl) {
+		t.Error("expected false for download whose book does not exist, got true")
+	}
+}
+
+// TestIsBookAlreadyImported_MediaTypeBoth exercises the default branch of
+// isBookAlreadyImported for a MediaTypeBoth book where the ebook is already on
+// disk but no audiobook file exists. The audiobook check returns false (so both
+// sides of the || are evaluated) and the ebook check returns true, so the
+// function must return true.
+func TestIsBookAlreadyImported_MediaTypeBoth(t *testing.T) {
+	libraryDir := t.TempDir()
+	s, bookRepo, authorRepo, ctx := scannerFixture(t, libraryDir)
+
+	// Put an ebook in the library.
+	libEpub := filepath.Join(libraryDir, "book.epub")
+	if err := os.WriteFile(libEpub, []byte("epub-content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{Name: "Both Author", ForeignID: "a-both", SortName: "Author, Both"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		AuthorID:  author.ID,
+		Title:     "Dual Format Book",
+		ForeignID: "b-both",
+		Status:    "wanted",
+		MediaType: models.MediaTypeBoth,
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	// Track only the ebook — no audiobook file — so the audiobook arm of the
+	// default case returns false before the ebook arm returns true.
+	if err := bookRepo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, libEpub); err != nil {
+		t.Fatal(err)
+	}
+
+	dl := &models.Download{
+		GUID:   "guid-both",
+		Status: models.StateGrabbed,
+		BookID: &book.ID,
+	}
+	if !s.isBookAlreadyImported(ctx, dl) {
+		t.Error("expected true for MediaTypeBoth book with ebook already on disk, got false")
+	}
+}

--- a/internal/importer/scanner_qbittorrent_test.go
+++ b/internal/importer/scanner_qbittorrent_test.go
@@ -333,3 +333,177 @@ func TestCheckQbittorrentDownloads_MissingContentPathDoesNotFallBackToSaveRoot(t
 			models.StateDownloading, got.Status)
 	}
 }
+
+// TestCheckQbittorrentDownloads_ContentPathGoneAlreadyImported is the
+// regression test for #769 (part 1 — content_path missing path).
+//
+// Scenario: a book was previously downloaded, imported with move mode (files
+// now live in the library), then re-grabbed. qBittorrent already holds the
+// torrent (409) so the hash is recovered and a new Download record is created
+// in StateGrabbed. By the next poll cycle the torrent is seeding but
+// content_path is absent AND Join(SavePath, Name) doesn't exist on disk (files
+// were moved to the library). The scanner must detect that the book is already
+// in the library and mark the Download StateImported rather than looping
+// forever in StateGrabbed.
+func TestCheckQbittorrentDownloads_ContentPathGoneAlreadyImported(t *testing.T) {
+	saveRoot := t.TempDir()
+	libraryDir := t.TempDir()
+
+	// Simulate a book file already in the library (placed there by a prior import).
+	libEpub := filepath.Join(libraryDir, "book.epub")
+	if err := os.WriteFile(libEpub, []byte("epub-in-library"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const torrentHash = "feed1234567890feed1234567890feed12345678"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			torrents := []map[string]any{{
+				"hash":         torrentHash,
+				"name":         "My Book",
+				"state":        "missingFiles",
+				"progress":     1.0,
+				"save_path":    saveRoot,
+				"content_path": "", // absent — files were moved to the library
+			}}
+			_ = json.NewEncoder(w).Encode(torrents)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, "", "", "", "")
+
+	// Seed author and book records.
+	author := &models.Author{Name: "Test Author", ForeignID: "a-769", SortName: "Author, Test"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{AuthorID: author.ID, Title: "My Book", ForeignID: "b-769", Status: "wanted"}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	// Record the library file in book_files to simulate a prior successful import.
+	if err := bookRepo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, libEpub); err != nil {
+		t.Fatal(err)
+	}
+
+	host, port := scannerTestHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name: "qbit-769", Type: "qbittorrent",
+		Host: host, Port: port, Enabled: true,
+	}
+	if err := clientRepo.Create(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+
+	hash := torrentHash
+	dl := &models.Download{
+		GUID:             "guid-769-qbit",
+		Title:            "My Book",
+		Status:           models.StateGrabbed,
+		Protocol:         "torrent",
+		TorrentID:        &hash,
+		BookID:           &book.ID,
+		DownloadClientID: &client.ID,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	s.checkQbittorrentDownloads(ctx, client)
+
+	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.Status != models.StateImported {
+		t.Errorf("#769 regression: expected status %q (book already in library), got %q",
+			models.StateImported, got.Status)
+	}
+}
+
+// TestTryImportInternal_EmptyPathAlreadyImported is the regression test for
+// #769 (part 2 — empty download path, all clients).
+//
+// Scenario: tryImportInternal is called with a download path that contains no
+// book files (e.g. files were moved to the library by a prior import). The
+// book is already tracked in book_files with an on-disk file. The scanner must
+// mark the Download StateImported rather than StateImportFailed.
+func TestTryImportInternal_EmptyPathAlreadyImported(t *testing.T) {
+	libraryDir := t.TempDir()
+	emptyDownloadDir := t.TempDir() // no book files
+
+	// Simulate a book file already in the library.
+	libEpub := filepath.Join(libraryDir, "book.epub")
+	if err := os.WriteFile(libEpub, []byte("epub-in-library"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, "", "", "", "")
+
+	author := &models.Author{Name: "Test Author", ForeignID: "a-769b", SortName: "Author, Test"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{AuthorID: author.ID, Title: "My Book", ForeignID: "b-769b", Status: "wanted"}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, libEpub); err != nil {
+		t.Fatal(err)
+	}
+
+	dl := &models.Download{
+		GUID:   "guid-769-internal",
+		Title:  "My Book",
+		Status: models.StateCompleted,
+		BookID: &book.ID,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	s.tryImportInternal(ctx, dl, emptyDownloadDir, "", "", nil)
+
+	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.Status != models.StateImported {
+		t.Errorf("#769 regression: expected status %q (book already in library), got %q — "+
+			"re-grab of already-imported book must not fail with 'no book files found'",
+			models.StateImported, got.Status)
+	}
+}

--- a/internal/models/download_state.go
+++ b/internal/models/download_state.go
@@ -30,7 +30,10 @@ const (
 
 // validTransitions defines which state transitions are allowed.
 var validTransitions = map[DownloadState][]DownloadState{
-	StateGrabbed:       {StateDownloading, StateFailed},
+	// StateCompleted is included for the duplicate-add (409) case: when a
+	// torrent is re-grabbed and qBittorrent already holds it at 100%, Bindery
+	// should proceed straight to import without a downloading phase (#769).
+	StateGrabbed: {StateDownloading, StateCompleted, StateFailed},
 	StateDownloading:   {StateCompleted, StateFailed},
 	StateCompleted:     {StateImportPending, StateImportFailed},
 	StateImportPending: {StateImporting, StateImportFailed, StateImportExternal},

--- a/internal/models/download_state.go
+++ b/internal/models/download_state.go
@@ -29,11 +29,11 @@ const (
 )
 
 // validTransitions defines which state transitions are allowed.
+// StateGrabbed includes StateCompleted for the 409 duplicate-add case: when a
+// torrent is re-grabbed and qBittorrent already holds it at 100%, Bindery
+// skips the downloading phase and goes straight to import (#769).
 var validTransitions = map[DownloadState][]DownloadState{
-	// StateCompleted is included for the duplicate-add (409) case: when a
-	// torrent is re-grabbed and qBittorrent already holds it at 100%, Bindery
-	// should proceed straight to import without a downloading phase (#769).
-	StateGrabbed: {StateDownloading, StateCompleted, StateFailed},
+	StateGrabbed:       {StateDownloading, StateCompleted, StateFailed},
 	StateDownloading:   {StateCompleted, StateFailed},
 	StateCompleted:     {StateImportPending, StateImportFailed},
 	StateImportPending: {StateImporting, StateImportFailed, StateImportExternal},


### PR DESCRIPTION
## Problem

When a torrent is re-grabbed and qBittorrent already holds it (409 duplicate-add), PR #783 correctly recovers the hash and creates a `Download` record in `StateGrabbed`. Two gaps remained that prevented the import from completing:

**Gap 1 — `content_path` absent, files already in library (move mode)**

`checkQbittorrentDownloads` calls `resolveQbitContentPath` which returns `false` when the download files were moved to the library by a prior import. The download loops in `StateGrabbed` forever — `os.Stat` never finds the path and there's no exit condition.

**Gap 2 — Empty download directory (move mode), all clients**

`tryImportInternal` walks the download path, finds no book files, and emits `StateImportFailed`. After three retries `blockStaleImportFailures` transitions it to `StateImportBlocked` — even though the book is already in the library.

**Gap 3 — `grabbed → completed` transition missing from state machine**

`checkQbittorrentDownloads` calls `updateDownloadStatus(StateCompleted)` before `tryImportInternal`, but `grabbed → completed` was not in `validTransitions`. The transition was silently rejected, leaving the `Download` record in `StateGrabbed` even after a successful file copy — for any torrent that was already at 100% when first grabbed.

## Fix

- **`isBookAlreadyImported(ctx, dl)`** — new helper that checks `book_files` + `os.Stat` for both ebook and audiobook formats. Returns `true` only when the file is actually on disk in the library.

- **`checkQbittorrentDownloads`** — when `resolveQbitContentPath` returns `false` and the book is confirmed in the library, walk the state machine (`grabbed/downloading → completed → importPending → importing → imported`) instead of retrying indefinitely. Applied to both the fresh-grab branch and the `StateImportFailed` retry branch.

- **`tryImportInternal`** — when `bookFiles` is empty and the book is already in the library, walk `importPending → importing → imported` instead of emitting `StateImportFailed`. Covers all download clients.

- **`download_state.go`** — add `grabbed → completed` as a valid transition.

## Tests

Two new regression tests in `scanner_qbittorrent_test.go`:
- `TestCheckQbittorrentDownloads_ContentPathGoneAlreadyImported` — torrent seeding with `content_path` absent, book already in library → `StateImported`
- `TestTryImportInternal_EmptyPathAlreadyImported` — empty download directory, book already in library → `StateImported` (not `StateImportFailed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)