### PR TITLE
fix(auth): grant admin role to local-only trusted bypass (#799)

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -938,6 +938,52 @@ func TestAPIKeyAuthRoleVisibleInContext(t *testing.T) {
 	}
 }
 
+// TestLocalOnlyBypassGrantsAdminRole is the #799 regression test for the
+// local-only bypass branch in Middleware: a trusted-local request to a
+// RequireAdmin-protected endpoint must reach the handler. The whole point of
+// local-only mode is frictionless access from a trusted private network, so
+// returning "admin role required" 403 to a LAN client (as Middleware did
+// before this fix) was a regression of the API-key fix (Bug 11) into a
+// different code path.
+func TestLocalOnlyBypassGrantsAdminRole(t *testing.T) {
+	p := &fakeProvider{mode: ModeLocalOnly}
+
+	called := false
+	stack := Middleware(p)(
+		RequireAdmin(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		})),
+	)
+
+	req, _ := http.NewRequest("POST", "/api/v1/settings/auth/mode", nil)
+	req.RemoteAddr = "192.168.1.5:12345"
+	rw := &captureWriter{}
+	stack.ServeHTTP(rw, req)
+	if !called {
+		t.Fatalf("local-only LAN POST to admin-protected endpoint must reach the handler; got status %d", rw.status)
+	}
+}
+
+// TestLocalOnlyBypassRoleVisibleInContext verifies that the admin role is
+// present in the request context for a local-only bypassed request, so
+// handlers that inspect the role see "admin" rather than "".
+func TestLocalOnlyBypassRoleVisibleInContext(t *testing.T) {
+	p := &fakeProvider{mode: ModeLocalOnly}
+
+	var gotRole string
+	stack := Middleware(p)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotRole = UserRoleFromContext(r.Context())
+	}))
+
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.RemoteAddr = "192.168.1.5:12345"
+	stack.ServeHTTP(nopWriter{}, req)
+	if gotRole != "admin" {
+		t.Errorf("role in context = %q; want \"admin\"", gotRole)
+	}
+}
+
 func TestCSRFStack_BrowserSessionWithoutCSRFTokenIsRejected(t *testing.T) {
 	secret := stackSecret32
 	p := &fakeProvider{mode: ModeEnabled, apiKey: "harpoon-key", secret: secret}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -210,6 +210,14 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 				return
 			}
 			if mode == ModeLocalOnly && IsLocalRequestTrusted(r, p.TrustedProxyCIDRs()) {
+				// Local-only bypass is always treated as admin, mirroring the
+				// API-key branch below. Without this, RequireAdmin-protected
+				// endpoints (auth mode change, user CRUD, settings writes)
+				// return "admin role required" 403 to trusted-local requests
+				// even though the whole point of local-only mode is to grant
+				// frictionless access from a trusted private network (#799).
+				ctx := context.WithValue(r.Context(), userRoleCtxKey, "admin")
+				r = r.WithContext(ctx)
 				next.ServeHTTP(w, r)
 				return
 			}


### PR DESCRIPTION
## Summary

In `local-only` auth mode, requests from trusted private IPs were being short-circuited through the middleware without a role attached to the context. `RequireAdmin`-protected endpoints (auth mode change, user CRUD, settings writes, etc.) then returned \`{\"error\":\"admin role required\"}\` 403 — even though local-only mode's entire purpose is frictionless admin access from a trusted private network.

The API-key branch immediately below this code already sets \`role=admin\` for the same reason (the original Bug 11 fix). Local-only was missed. Apply the same treatment.

## Why this matters

Reporter at #799 hit this while trying to change the auth mode. Symptom from their reply:

> I can't change the Authentication Mode, or create users. I get the same \"Mode change failed: admin role required\" each time.

That's the user-facing symptom of a server that *intends* to fully trust them on the LAN refusing to let them touch any admin setting.

## Test plan

- [x] \`go test ./internal/auth/...\` — green
- New regression tests:
  - \`TestLocalOnlyBypassGrantsAdminRole\` — trusted-local POST to a RequireAdmin handler reaches it
  - \`TestLocalOnlyBypassRoleVisibleInContext\` — handlers see \`UserRoleFromContext == \"admin\"\` for bypassed requests
- [ ] Manual: deploy to dev, set auth mode = local-only, access from a private IP, change the auth mode → should succeed (not 403)

Note: #799 has a second, independent frontend bug (silent failure when notification save fails). That ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)