### PR TITLE
fix(notifications): surface save errors instead of silent failure (#799)

### DIFF
--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -237,7 +237,8 @@
       "onUpgrade": "Beim Upgrade",
       "onFailure": "Bei Fehler",
       "onHealth": "Bei Gesundheitsstatus",
-      "testSent": "Testbenachrichtigung gesendet!"
+      "testSent": "Testbenachrichtigung gesendet!",
+      "saveFailed": "Benachrichtigung konnte nicht gespeichert werden: {{error}}"
     },
     "quality": {
       "heading": "Qualitätsprofile",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -271,7 +271,8 @@
       "onUpgrade": "On Upgrade",
       "onFailure": "On Failure",
       "onHealth": "On Health",
-      "testSent": "Test notification sent!"
+      "testSent": "Test notification sent!",
+      "saveFailed": "Couldn't save notification: {{error}}"
     },
     "quality": {
       "heading": "Quality Profiles",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -259,7 +259,8 @@
       "onUpgrade": "Al actualizar",
       "onFailure": "Al fallar",
       "onHealth": "En estado de salud",
-      "testSent": "¡Notificación de prueba enviada!"
+      "testSent": "¡Notificación de prueba enviada!",
+      "saveFailed": "No se pudo guardar la notificación: {{error}}"
     },
     "quality": {
       "heading": "Perfiles de calidad",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -237,7 +237,8 @@
       "onUpgrade": "À la mise à niveau",
       "onFailure": "En cas d'échec",
       "onHealth": "À l'état de santé",
-      "testSent": "Notification de test envoyée !"
+      "testSent": "Notification de test envoyée !",
+      "saveFailed": "Impossible d'enregistrer la notification : {{error}}"
     },
     "quality": {
       "heading": "Profils de qualité",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -259,7 +259,8 @@
       "onUpgrade": "Saat Ditingkatkan",
       "onFailure": "Saat Gagal",
       "onHealth": "Saat Kesehatan",
-      "testSent": "Notifikasi uji terkirim!"
+      "testSent": "Notifikasi uji terkirim!",
+      "saveFailed": "Tidak dapat menyimpan notifikasi: {{error}}"
     },
     "quality": {
       "heading": "Profil Kualitas",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -237,7 +237,8 @@
       "onUpgrade": "Bij upgrade",
       "onFailure": "Bij fout",
       "onHealth": "Bij gezondheidsstatus",
-      "testSent": "Testmelding verzonden!"
+      "testSent": "Testmelding verzonden!",
+      "saveFailed": "Kan melding niet opslaan: {{error}}"
     },
     "quality": {
       "heading": "Kwaliteitsprofielen",

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -259,7 +259,8 @@
       "onUpgrade": "Kapag Na-upgrade",
       "onFailure": "Kapag Nabigo",
       "onHealth": "Sa Kalusugan",
-      "testSent": "Naipadala ang test notification!"
+      "testSent": "Naipadala ang test notification!",
+      "saveFailed": "Hindi ma-save ang notification: {{error}}"
     },
     "quality": {
       "heading": "Mga Quality Profile",

--- a/web/src/pages/settings/NotificationsTab.tsx
+++ b/web/src/pages/settings/NotificationsTab.tsx
@@ -117,6 +117,7 @@ export default function NotificationsTab() {
 }
 
 function EditNotificationForm({ notification, onClose, onSaved }: { notification: NotificationConfig; onClose: () => void; onSaved: (n: NotificationConfig) => void }) {
+  const { t } = useTranslation()
   const [name, setName] = useState(notification.name)
   const [url, setUrl] = useState(notification.url)
   const [method, setMethod] = useState(notification.method || 'POST')
@@ -125,10 +126,20 @@ function EditNotificationForm({ notification, onClose, onSaved }: { notification
   const [onFailure, setOnFailure] = useState(notification.onFailure)
   const [onUpgrade, setOnUpgrade] = useState(notification.onUpgrade)
   const [onHealth, setOnHealth] = useState(notification.onHealth)
+  const [saveError, setSaveError] = useState('')
+  const [saving, setSaving] = useState(false)
 
   const submit = async () => {
-    const updated = await api.updateNotification(notification.id, { ...notification, name, url, method, onGrab, onImport, onFailure, onUpgrade, onHealth })
-    onSaved(updated)
+    setSaveError('')
+    setSaving(true)
+    try {
+      const updated = await api.updateNotification(notification.id, { ...notification, name, url, method, onGrab, onImport, onFailure, onUpgrade, onHealth })
+      onSaved(updated)
+    } catch (err: unknown) {
+      setSaveError(t('settings.notifications.saveFailed', { error: err instanceof Error ? err.message : 'Unknown error' }))
+    } finally {
+      setSaving(false)
+    }
   }
 
   const toggleCls = (active: boolean) =>
@@ -159,15 +170,21 @@ function EditNotificationForm({ notification, onClose, onSaved }: { notification
           <button type="button" onClick={() => setOnHealth(!onHealth)} className={toggleCls(onHealth)}>Health</button>
         </div>
       </div>
+      {saveError && (
+        <div role="alert" className="px-3 py-1.5 rounded text-xs bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300">
+          {saveError}
+        </div>
+      )}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
-        <button onClick={submit} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium">Save</button>
+        <button onClick={submit} disabled={saving} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-60 disabled:cursor-not-allowed rounded text-sm font-medium">Save</button>
       </div>
     </div>
   )
 }
 
 function AddNotificationForm({ onClose, onAdded }: { onClose: () => void; onAdded: (n: NotificationConfig) => void }) {
+  const { t } = useTranslation()
   const [name, setName] = useState('')
   const [url, setUrl] = useState('')
   const [method, setMethod] = useState('POST')
@@ -176,15 +193,25 @@ function AddNotificationForm({ onClose, onAdded }: { onClose: () => void; onAdde
   const [onFailure, setOnFailure] = useState(true)
   const [onUpgrade, setOnUpgrade] = useState(false)
   const [onHealth, setOnHealth] = useState(false)
+  const [saveError, setSaveError] = useState('')
+  const [saving, setSaving] = useState(false)
 
   const submit = async () => {
-    const n = await api.addNotification({
-      name, url, method, type: 'webhook',
-      headers: '{}',
-      onGrab, onImport, onFailure, onUpgrade, onHealth,
-      enabled: true,
-    })
-    onAdded(n)
+    setSaveError('')
+    setSaving(true)
+    try {
+      const n = await api.addNotification({
+        name, url, method, type: 'webhook',
+        headers: '{}',
+        onGrab, onImport, onFailure, onUpgrade, onHealth,
+        enabled: true,
+      })
+      onAdded(n)
+    } catch (err: unknown) {
+      setSaveError(t('settings.notifications.saveFailed', { error: err instanceof Error ? err.message : 'Unknown error' }))
+    } finally {
+      setSaving(false)
+    }
   }
 
   const toggleCls = (active: boolean) =>
@@ -215,9 +242,14 @@ function AddNotificationForm({ onClose, onAdded }: { onClose: () => void; onAdde
           <button type="button" onClick={() => setOnHealth(!onHealth)} className={toggleCls(onHealth)}>Health</button>
         </div>
       </div>
+      {saveError && (
+        <div role="alert" className="px-3 py-1.5 rounded text-xs bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300">
+          {saveError}
+        </div>
+      )}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
-        <button onClick={submit} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium">Save</button>
+        <button onClick={submit} disabled={saving} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-60 disabled:cursor-not-allowed rounded text-sm font-medium">Save</button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Reporter at #799 entered a webhook URL, clicked Save, and \"nothing happens.\" Nothing in the logs either.

The cause: \`AddNotificationForm.submit()\` and \`EditNotificationForm.submit()\` (NotificationsTab.tsx) awaited the API call and called the success callback. If the call *rejected* — most plausibly because the user's URL failed \`httpsec.ValidateOutboundURL\` under \`PolicyStrict\`, or any other 4xx/5xx — the rejected promise was swallowed by React's event handler. No toast, no banner, no rethrow. From the user's seat: nothing happens.

This PR wraps both submit handlers, surfaces the backend error message in a \`role=\"alert\"\` banner under the form, and disables the Save button while the request is in flight. Same pattern as the existing test-notification result banner directly above.

## Why this matters

Silent UI failures train users to believe the product is broken when it's actually politely telling them their input is invalid. The fix is mechanical but the user impact is real: anyone whose webhook host violates the outbound-URL policy currently has no path to discover that.

#799 also has a separate backend bug (local-only mode not granting admin role); that ships in #801.

## Test plan

- [x] \`cd web && npm run typecheck\` — clean
- [x] \`cd web && npm run build\` — green
- [x] \`cd web && npm run lint\` — no new warnings
- [ ] Manual: configure a webhook with a private URL while \`BINDERY_NOTIFICATIONS_ALLOW_PRIVATE\` is unset → red error banner appears with the backend's actual reason
- [ ] Manual: same flow with a valid webhook URL → notification saves, form closes

## i18n

Added \`settings.notifications.saveFailed\` to all seven locale files (en/de/es/fr/id/nl/tl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)