### PR TITLE
fix(downloader): name the fix in qBit category-path mismatch error (#800)

### DIFF
--- a/internal/downloader/health.go
+++ b/internal/downloader/health.go
@@ -144,7 +144,15 @@ func checkQbittorrentCategoryPath(ctx context.Context, client *models.DownloadCl
 
 	localPath := filepath.Clean(pathmap.Parse(client.PathRemap).Apply(savePath))
 	if !pathIsAtOrUnder(localPath, expected) {
-		return healthError(fmt.Sprintf("qBittorrent category %q saves to %q, which maps to %q; expected a path at or under %q", category, savePath, localPath, expected))
+		// #800: the error message above told the user where the paths
+		// disagreed but never named the fix. Most users hit this when
+		// qBittorrent and Bindery mount the same storage at different paths
+		// (e.g. /torrents in qBit, /downloads in Bindery). Spell out the
+		// path-remap recipe and reference the two settings that need to
+		// match so the user has a concrete next step rather than just a
+		// validation refusal.
+		hint := fmt.Sprintf("set this client's path remap to translate the qBittorrent prefix to Bindery's (e.g. %q), or mount the same directory at %q inside Bindery and set BINDERY_DOWNLOAD_DIR to match", remapHint(savePath, expected), localPath)
+		return healthError(fmt.Sprintf("qBittorrent category %q saves to %q, which maps to %q inside Bindery; expected a path at or under %q — %s", category, savePath, localPath, expected, hint))
 	}
 
 	return models.DownloadClientHealth{
@@ -155,6 +163,25 @@ func checkQbittorrentCategoryPath(ctx context.Context, client *models.DownloadCl
 
 func healthError(message string) models.DownloadClientHealth {
 	return models.DownloadClientHealth{Status: HealthError, Message: message}
+}
+
+// remapHint derives a "src:dst" PathRemap suggestion from the qBittorrent
+// save path and Bindery's expected download dir. It strips one path segment
+// from each so the suggestion translates the shared parent rather than the
+// fully-qualified leaf path: a user with qBit at "/torrents/complete/library"
+// and Bindery at "/downloads" gets "/torrents/complete:/downloads", which
+// also covers any sibling category save paths under the same root. When
+// either path is "/" the hint falls back to the full strings.
+func remapHint(savePath, expected string) string {
+	src := strings.TrimRight(filepath.Dir(filepath.Clean(savePath)), string(filepath.Separator))
+	dst := strings.TrimRight(filepath.Clean(expected), string(filepath.Separator))
+	if src == "" || src == "." {
+		src = filepath.Clean(savePath)
+	}
+	if dst == "" {
+		dst = "/"
+	}
+	return src + ":" + dst
 }
 
 // pathIsAtOrUnder reports whether candidate is equal to base or is a

--- a/internal/downloader/health_test.go
+++ b/internal/downloader/health_test.go
@@ -107,3 +107,49 @@ func TestExpectedDownloadDirForClient_AudiobookCategory(t *testing.T) {
 		t.Fatalf("expected audiobook download dir, got %q", got)
 	}
 }
+
+// TestQbittorrentCategoryPath_MismatchMessageGuidesUserToPathRemap is the #800
+// regression: when the category save path doesn't fall under Bindery's
+// download dir, the error message must name the fix (PathRemap) and include a
+// concrete src:dst suggestion the user can copy. The previous wording said
+// what was wrong but not how to fix it; reporter at #800 and #704 both bounced
+// off it.
+func TestQbittorrentCategoryPath_MismatchMessageGuidesUserToPathRemap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/categories":
+			_, _ = w.Write([]byte(`{"library":{"name":"library","savePath":"/torrents/complete/library"}}`))
+		case "/api/v2/app/defaultSavePath":
+			_, _ = w.Write([]byte("/torrents"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Type:     "qbittorrent",
+		Host:     host,
+		Port:     port,
+		Username: "u",
+		Password: "p",
+		Category: "library",
+	}
+	got := CheckDownloadClientHealth(context.Background(), client, "/downloads", "")
+	if got.Status != HealthError {
+		t.Fatalf("status = %q, want %q; message=%s", got.Status, HealthError, got.Message)
+	}
+	wants := []string{
+		`expected a path at or under "/downloads"`,
+		"path remap",
+		`"/torrents/complete:/downloads"`,
+	}
+	for _, w := range wants {
+		if !strings.Contains(got.Message, w) {
+			t.Errorf("message missing %q\nfull: %s", w, got.Message)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two reports — #800 (open) and #704 (closed prematurely) — both bounce off the same wall: qBittorrent's category save path doesn't fall under \`BINDERY_DOWNLOAD_DIR\`, the health check correctly refuses, and the error message names the problem but never the fix.

Reporter at #800:
> qBittorrent category \"library\" saves to \"torrents/complete/library\", which maps to \"/torrents/complete/library\"; expected a path at or under \"/downloads\"

Their next move was to assume Bindery should override its env var with the path qBit reports — which is wrong (Bindery still needs to see the files), but is the most reasonable conclusion you can draw from that error message. The settings that actually fix this (\`PathRemap\` on the download client, or matching volume mounts + \`BINDERY_DOWNLOAD_DIR\`) are never named.

## Change

Append a concrete recipe to the error that:

1. **Names \`path remap\` as the setting to change.**
2. **Includes a derived \`src:dst\` suggestion** built from the qBit save path and Bindery's download dir. One segment is stripped off the qBit side (\`/torrents/complete/library\` → \`/torrents/complete\`) so the remap covers sibling category save paths under the same root, not just the leaf.
3. **Mentions the volume-mount alternative** for users who'd rather fix this at the container layer.

Resulting message for the #800 reporter:

> qBittorrent category \"library\" saves to \"/torrents/complete/library\", which maps to \"/torrents/complete/library\" inside Bindery; expected a path at or under \"/downloads\" — set this client's path remap to translate the qBittorrent prefix to Bindery's (e.g. \"/torrents/complete:/downloads\"), or mount the same directory at \"/torrents/complete/library\" inside Bindery and set BINDERY_DOWNLOAD_DIR to match

## Test plan

- [x] \`go test ./internal/downloader/...\` — green
- New \`TestQbittorrentCategoryPath_MismatchMessageGuidesUserToPathRemap\` asserts:
  - status is HealthError
  - message contains \"expected a path at or under …\" (existing prefix preserved)
  - message contains \"path remap\"
  - message contains the derived suggestion \`\"/torrents/complete:/downloads\"\`
- Existing assertions on \"expected a path at or under\" still pass — the new wording extends the message, doesn't replace the prefix.

## Closes / relates

Closes #800. Supersedes the prematurely-closed #704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)