### PR TITLE
fix(api): direct-insert requested book when adding a new author (#804)

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1193,6 +1193,14 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	// issue #667 bug 3.
 	bookCreated := false
 
+	// authorWasJustCreated tracks whether this request inserted the author
+	// row (vs. found it already present). Used by both the orphan-cleanup
+	// defer and the direct-insert block below — when the author was just
+	// created the async catalogue sync may take longer than the 15s poll
+	// budget for prolific authors, so we synchronously persist the requested
+	// book to guarantee it exists before the cleanup defer runs (#804).
+	authorWasJustCreated := false
+
 	if req.ForeignAuthorID == "" {
 		resolved, err := h.resolveAuthorForBook(ctx, req.ForeignBookID)
 		if err != nil {
@@ -1258,13 +1266,11 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// authorWasJustCreated tracks whether this request's CreateForUser
-		// succeeded (vs. the UNIQUE-race fallback at line 1247). When the
-		// poll loop below times out without seeing the requested book, we
-		// roll back this insert iff the author currently has zero books —
-		// otherwise the user is left with a permanent orphan author (the
-		// failure mode reported in issue #667).
-		authorWasJustCreated := false
+		// CreateForUser may collide with a concurrent request inserting the
+		// same author; the UNIQUE-constraint branch below recovers by
+		// re-fetching the row. authorWasJustCreated stays false on the race
+		// path so the orphan-cleanup defer never rolls back somebody else's
+		// author row (issue #667).
 		if author == nil {
 			if err := h.authors.CreateForUser(ctx, fetched, auth.UserIDFromContext(ctx)); err != nil {
 				if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
@@ -1290,18 +1296,28 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 1b. Direct insert for providers without a queryable author-works
-	// endpoint. DNB's public SRU has no author→works relationship, so the
-	// async FetchAuthorBooks goroutine returns zero books for synthetic
-	// dnb:gnd:* / dnb:author:* IDs — the poll loop below would time out
-	// every time. Fetch the single requested record now and persist it
-	// so the poll finds it on its first iteration. UNIQUE-constraint
-	// races against a concurrent FetchAuthorBooks insert are tolerated.
-	if strings.HasPrefix(req.ForeignBookID, "dnb:") {
+	// 1b. Direct insert for the requested book.
+	//
+	// Originally added (#667) for DNB synthetic IDs, whose async sync returns
+	// zero books because DNB's public SRU has no author→works relationship.
+	// #804 widened this: for any author the request just created, the async
+	// catalogue sync can take longer than the 15 s poll budget (OpenLibrary
+	// took >32 s for a 175-work author in the bug report). When the poll
+	// times out, the orphan-cleanup defer deletes the author row — and the
+	// still-running goroutine then logs a FK-constraint failure for every
+	// book it tries to insert against the now-deleted author_id.
+	//
+	// Synchronously fetching and persisting the single requested record
+	// guarantees the poll succeeds on its first iteration AND that the
+	// cleanup defer sees a non-empty book list (so it keeps the author).
+	// The async sync still runs as a backfill for the rest of the catalogue;
+	// any UNIQUE collision against this row is silently tolerated.
+	directInsertNeeded := authorWasJustCreated || strings.HasPrefix(req.ForeignBookID, "dnb:")
+	if directInsertNeeded {
 		if existing, _ := h.books.GetByForeignID(ctx, req.ForeignBookID); existing == nil {
 			primary, err := h.meta.GetBook(ctx, req.ForeignBookID)
 			if err != nil {
-				slog.Warn("AddBook: DNB direct fetch failed",
+				slog.Warn("AddBook: direct fetch failed",
 					"foreignBookId", req.ForeignBookID, "error", err)
 			} else if primary != nil {
 				primary.AuthorID = author.ID
@@ -1311,7 +1327,7 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 				}
 				if err := h.books.Create(ctx, primary); err != nil &&
 					!strings.Contains(err.Error(), "UNIQUE constraint failed") {
-					slog.Warn("AddBook: DNB direct insert failed",
+					slog.Warn("AddBook: direct insert failed",
 						"foreignBookId", req.ForeignBookID, "error", err)
 				}
 			}

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -1466,6 +1466,93 @@ func TestAddBook_DNBDirectInsertSucceeds(t *testing.T) {
 	}
 }
 
+// TestAddBook_DirectInsertCoversSlowAsyncSync is the #804 regression test.
+//
+// Scenario from the bug report: a user adds a single book by a prolific
+// author (Stephenie Meyer, 175 works). OpenLibrary's GetAuthorWorks takes
+// longer than the 15s poll budget. The poll loop times out → 404 → the
+// orphan-cleanup defer deletes the just-created author row → the still-
+// running async goroutine then logs a FK-constraint failure for every
+// book it tries to insert against the now-deleted author_id.
+//
+// The fix lifts the existing DNB direct-insert path so it also fires when
+// the author was just created, regardless of provider. We simulate the
+// slow OL by having GetAuthorWorks block past the test's wall-clock
+// budget; the test asserts that AddBook still returns 201 because the
+// direct-insert ran synchronously before the poll loop.
+func TestAddBook_DirectInsertCoversSlowAsyncSync(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	// Mirrors OpenLibrary's response for the user's requested book.
+	primary := &models.Book{
+		ForeignID:        "OL12345W",
+		Title:            "Twilight",
+		SortTitle:        "Twilight",
+		Language:         "eng",
+		Status:           models.BookStatusWanted,
+		Genres:           []string{},
+		MetadataProvider: "openlibrary",
+	}
+	// works empty: simulates an OL author whose works list is still being
+	// fetched when the poll loop starts. Without the direct-insert path the
+	// poll would time out (no books appear) and the cleanup defer would
+	// delete the just-created author.
+	stub := &stubMetaProvider{
+		name:  "openlibrary",
+		works: nil,
+		getBookByID: map[string]*models.Book{
+			"OL12345W": primary,
+		},
+	}
+	agg := metadata.NewAggregator(stub)
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, nil)
+
+	body, _ := json.Marshal(map[string]any{
+		"foreignBookId":   "OL12345W",
+		"foreignAuthorId": "OL1391085A",
+		"authorName":      "Stephenie Meyer",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/author/book", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.AddBook(rec, req)
+
+	// 201 (not 404) proves the direct-insert ran before the poll loop —
+	// without the fix, this fails with "book not found after author sync".
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got, err := bookRepo.GetByForeignID(context.Background(), "OL12345W")
+	if err != nil || got == nil {
+		t.Fatalf("book not persisted: err=%v got=%v", err, got)
+	}
+	if !got.Monitored {
+		t.Errorf("book should be Monitored=true after AddBook success")
+	}
+	if got.AuthorID == 0 {
+		t.Errorf("book AuthorID should be linked to the author row")
+	}
+
+	// Author kept (not orphan-cleaned): the direct-insert persisted a book
+	// against author.ID, so cleanupOrphanIfNoBooks sees len(books)>0 and
+	// skips deletion. Before the fix, the goroutine's inserts all FK-failed
+	// because the author row had already been removed.
+	auth, err := authorRepo.GetByForeignID(context.Background(), "OL1391085A")
+	if err != nil || auth == nil {
+		t.Fatalf("author was orphan-cleaned despite direct-insert: err=%v auth=%v", err, auth)
+	}
+}
+
 // TestCanUpgradeToBoth validates the helper that decides whether two
 // complementary media types should be merged into a dual-format row.
 func TestCanUpgradeToBoth(t *testing.T) {


### PR DESCRIPTION
## Summary

Reporter at #804 traced this themselves and got it exactly right. \`AddBook\` inserts an unmonitored author row, kicks off an async catalogue sync, then polls 15 s for the requested book. For prolific authors whose OL works fetch takes longer than the poll budget (Stephenie Meyer, 175 works in the bug report), the sequence is:

1. \`CreateForUser(author)\` — id 48 inserted
2. \`fetchAuthorBooksAsync(snapshot{ID:48})\` — goroutine launched with a value-copy of the author
3. 15 s poll times out → 404 \`book not found after author sync\`
4. \`defer cleanupOrphanIfNoBooks\` → author 48 deleted (zero books at that moment)
5. goroutine, still running, calls \`Create(book)\` with \`AuthorID=48\` → SQLite FK rejects every one of 175 books

User sees the add fail silently; logs fill with cascading FK warnings; nothing persists.

## Fix

Widen the existing DNB-only direct-insert path (#667) so it also fires when the request just created the author, regardless of provider. Synchronously fetching and persisting the single requested book makes two things true before the cleanup defer can run:

- the poll loop succeeds on its first iteration (no 15 s wait)
- \`len(books) > 0\` → \`cleanupOrphanIfNoBooks\` keeps the author

The async sync still runs as a backfill for the rest of the catalogue. Any UNIQUE collision against the directly-inserted row is silently tolerated — same as the original DNB path.

\`authorWasJustCreated\` is hoisted from inside \`if author == nil\` to function scope so the direct-insert block can read it. Same flag is still used by the orphan-cleanup defer; existing-author flows are unchanged.

## Why not just extend the timeout

It only kicks the problem down the road for the next prolific author. The async sync's work is being thrown away on every retry; better to bypass dependence on it for the single-book add and let it run as a true background backfill.

## Test plan

- [x] \`go test ./internal/api/... -count=1\` — green
- New \`TestAddBook_DirectInsertCoversSlowAsyncSync\` simulates the OL slow case with an empty \`GetAuthorWorks\` response and asserts:
  - response is 201 (not 404)
  - book is persisted with \`Monitored=true\` and an \`AuthorID\` linkage
  - author row was kept (not orphan-cleaned)
- [x] Existing \`TestAddBook_OrphanAuthorDeletedOnTimeout\` still passes — when GetBook also returns nil the direct-insert falls through to the poll, which times out, and cleanup fires as before.
- [x] Existing \`TestAddBook_DNBDirectInsertSucceeds\` still passes — DNB path unchanged.

## Closes

Closes #804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)