### PR TITLE
feat(authors): add configurable monitor defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 ## Features
 
 **Library management**
-- Author monitoring via OpenLibrary's author-works endpoint, with per-book monitor toggles and a `wanted → downloading → downloaded → imported` workflow.
+- Author monitoring via OpenLibrary's author-works endpoint, configurable author monitor modes for all/future/latest/none defaults, per-book monitor toggles, and a `wanted → downloading → downloaded → imported` workflow.
 - Dual-format books — each title holds an ebook *and* an audiobook in independent slots, with separate search, grab, and import pipelines, and the audiobook side moves multi-part `.m4b` / `.mp3` folders as one unit.
 - Series support with position tracking, edition tracking (format / ISBN / publisher / page count), Calendar view of upcoming releases, and multiple library roots.
 - Library scan with four-tier matching: ASIN → title + author → series name + position → fuzzy title. Honours librarian sort-suffix form (`Title, The`) and series-annotated filenames (`[Mistborn, Book 1]`).

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -111,15 +112,17 @@ func (h *AuthorHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		ForeignID             string `json:"foreignAuthorId"`
-		Name                  string `json:"authorName"`
-		QualityProfileID      *int64 `json:"qualityProfileId"`
-		MetadataProfileID     *int64 `json:"metadataProfileId"`
-		RootFolderID          *int64 `json:"rootFolderId"`
-		AudiobookRootFolderID *int64 `json:"audiobookRootFolderId"`
-		Monitored             bool   `json:"monitored"`
-		SearchOnAdd           bool   `json:"searchOnAdd"`
-		MediaType             string `json:"mediaType"`
+		ForeignID             string  `json:"foreignAuthorId"`
+		Name                  string  `json:"authorName"`
+		QualityProfileID      *int64  `json:"qualityProfileId"`
+		MetadataProfileID     *int64  `json:"metadataProfileId"`
+		RootFolderID          *int64  `json:"rootFolderId"`
+		AudiobookRootFolderID *int64  `json:"audiobookRootFolderId"`
+		Monitored             bool    `json:"monitored"`
+		MonitorMode           *string `json:"monitorMode"`
+		MonitorLatestCount    *int    `json:"monitorLatestCount"`
+		SearchOnAdd           bool    `json:"searchOnAdd"`
+		MediaType             string  `json:"mediaType"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -127,6 +130,11 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.ForeignID == "" || req.Name == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "foreignAuthorId and authorName required"})
+		return
+	}
+	monitorMode, monitorLatestCount, err := h.resolveCreateMonitorOptions(r.Context(), req.MonitorMode, req.MonitorLatestCount)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
 
@@ -159,7 +167,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	} else if canonical != nil {
 		if canRelinkAuthorToUpstream(canonical) {
-			if err := h.relinkExistingAuthorToUpstream(r.Context(), canonical, author, req.Name, req.Monitored, req.QualityProfileID, req.MetadataProfileID, req.RootFolderID, req.AudiobookRootFolderID); err != nil {
+			if err := h.relinkExistingAuthorToUpstream(r.Context(), canonical, author, req.Name, req.Monitored, monitorMode, monitorLatestCount, req.QualityProfileID, req.MetadataProfileID, req.RootFolderID, req.AudiobookRootFolderID); err != nil {
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 				return
 			}
@@ -175,7 +183,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		h.writeCanonicalAuthorConflict(w, canonical, "author name already resolves to an existing author — confirm merge")
 		return
 	}
-	applyAuthorCreateOptions(author, req.Monitored, req.QualityProfileID, req.MetadataProfileID, req.RootFolderID, req.AudiobookRootFolderID)
+	applyAuthorCreateOptions(author, req.Monitored, monitorMode, monitorLatestCount, req.QualityProfileID, req.MetadataProfileID, req.RootFolderID, req.AudiobookRootFolderID)
 
 	if err := h.authors.CreateForUser(r.Context(), author, auth.UserIDFromContext(r.Context())); err != nil {
 		slog.Error("create author failed", "foreign_id", req.ForeignID, "error", err)
@@ -260,8 +268,10 @@ func (h *AuthorHandler) fetchAuthorForCreate(ctx context.Context, foreignID, fal
 	return author, nil
 }
 
-func applyAuthorCreateOptions(author *models.Author, monitored bool, qualityProfileID, metadataProfileID, rootFolderID, audiobookRootFolderID *int64) {
+func applyAuthorCreateOptions(author *models.Author, monitored bool, monitorMode string, monitorLatestCount int, qualityProfileID, metadataProfileID, rootFolderID, audiobookRootFolderID *int64) {
 	author.Monitored = monitored
+	author.MonitorMode = monitorMode
+	author.MonitorLatestCount = monitorLatestCount
 	author.QualityProfileID = qualityProfileID
 	author.RootFolderID = rootFolderID
 	author.AudiobookRootFolderID = audiobookRootFolderID
@@ -277,6 +287,51 @@ func applyAuthorCreateOptions(author *models.Author, monitored bool, qualityProf
 	}
 }
 
+func (h *AuthorHandler) resolveCreateMonitorOptions(ctx context.Context, requestedMode *string, requestedLatestCount *int) (string, int, error) {
+	mode := h.resolveDefaultAuthorMonitorMode(ctx)
+	if requestedMode != nil {
+		mode = strings.TrimSpace(*requestedMode)
+	}
+	if !models.IsAuthorMonitorModeValid(mode) {
+		return "", 0, fmt.Errorf("monitorMode must be one of: all, future, latest, none")
+	}
+
+	latestCount := h.resolveDefaultAuthorMonitorLatestCount(ctx)
+	if requestedLatestCount != nil {
+		latestCount = *requestedLatestCount
+	}
+	if latestCount <= 0 {
+		return "", 0, fmt.Errorf("monitorLatestCount must be a positive integer")
+	}
+	return mode, latestCount, nil
+}
+
+func (h *AuthorHandler) resolveDefaultAuthorMonitorMode(ctx context.Context) string {
+	if h.settings == nil {
+		return models.DefaultAuthorMonitorMode
+	}
+	s, _ := h.settings.Get(ctx, SettingAuthorDefaultMonitorMode)
+	if s == nil || s.Value == "" || !models.IsAuthorMonitorModeValid(s.Value) {
+		return models.DefaultAuthorMonitorMode
+	}
+	return s.Value
+}
+
+func (h *AuthorHandler) resolveDefaultAuthorMonitorLatestCount(ctx context.Context) int {
+	if h.settings == nil {
+		return models.DefaultAuthorMonitorLatestCount
+	}
+	s, _ := h.settings.Get(ctx, SettingAuthorDefaultMonitorLatestCount)
+	if s == nil || s.Value == "" {
+		return models.DefaultAuthorMonitorLatestCount
+	}
+	n, err := strconv.Atoi(s.Value)
+	if err != nil || n <= 0 {
+		return models.DefaultAuthorMonitorLatestCount
+	}
+	return n
+}
+
 func canRelinkAuthorToUpstream(author *models.Author) bool {
 	if author == nil {
 		return false
@@ -286,7 +341,7 @@ func canRelinkAuthorToUpstream(author *models.Author) bool {
 	return foreignID == "" || strings.HasPrefix(foreignID, "abs:") || provider == "audiobookshelf"
 }
 
-func (h *AuthorHandler) relinkExistingAuthorToUpstream(ctx context.Context, author, upstream *models.Author, requestedName string, monitored bool, qualityProfileID, metadataProfileID, rootFolderID, audiobookRootFolderID *int64) error {
+func (h *AuthorHandler) relinkExistingAuthorToUpstream(ctx context.Context, author, upstream *models.Author, requestedName string, monitored bool, monitorMode string, monitorLatestCount int, qualityProfileID, metadataProfileID, rootFolderID, audiobookRootFolderID *int64) error {
 	if author == nil || upstream == nil {
 		return errors.New("author relink requires local and upstream authors")
 	}
@@ -322,7 +377,7 @@ func (h *AuthorHandler) relinkExistingAuthorToUpstream(ctx context.Context, auth
 	} else {
 		author.MetadataProvider = "openlibrary"
 	}
-	applyAuthorCreateOptions(author, monitored, qualityProfileID, metadataProfileID, rootFolderID, audiobookRootFolderID)
+	applyAuthorCreateOptions(author, monitored, monitorMode, monitorLatestCount, qualityProfileID, metadataProfileID, rootFolderID, audiobookRootFolderID)
 	now := time.Now().UTC()
 	author.LastMetadataRefreshAt = &now
 	if err := h.authors.Update(ctx, author); err != nil {
@@ -489,16 +544,19 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Monitored             *bool  `json:"monitored"`
-		QualityProfileID      *int64 `json:"qualityProfileId"`
-		MetadataProfileID     *int64 `json:"metadataProfileId"`
-		RootFolderID          *int64 `json:"rootFolderId"`
-		AudiobookRootFolderID *int64 `json:"audiobookRootFolderId"`
+		Monitored             *bool   `json:"monitored"`
+		MonitorMode           *string `json:"monitorMode"`
+		MonitorLatestCount    *int    `json:"monitorLatestCount"`
+		QualityProfileID      *int64  `json:"qualityProfileId"`
+		MetadataProfileID     *int64  `json:"metadataProfileId"`
+		RootFolderID          *int64  `json:"rootFolderId"`
+		AudiobookRootFolderID *int64  `json:"audiobookRootFolderId"`
 		// ClearAudiobookRootFolder lets the client explicitly reset the
 		// per-author audiobook root folder to "use the global dir". A nil
 		// AudiobookRootFolderID alone is ambiguous (omitted vs. cleared), so
 		// the UI sends this flag when the user picks the default option.
-		ClearAudiobookRootFolder bool `json:"clearAudiobookRootFolder"`
+		ClearAudiobookRootFolder   bool `json:"clearAudiobookRootFolder"`
+		ApplyMonitorModeToExisting bool `json:"applyMonitorModeToExisting"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -506,6 +564,21 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Monitored != nil {
 		author.Monitored = *req.Monitored
+	}
+	if req.MonitorMode != nil {
+		mode := strings.TrimSpace(*req.MonitorMode)
+		if !models.IsAuthorMonitorModeValid(mode) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "monitorMode must be one of: all, future, latest, none"})
+			return
+		}
+		author.MonitorMode = mode
+	}
+	if req.MonitorLatestCount != nil {
+		if *req.MonitorLatestCount <= 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "monitorLatestCount must be a positive integer"})
+			return
+		}
+		author.MonitorLatestCount = *req.MonitorLatestCount
 	}
 	if req.QualityProfileID != nil {
 		author.QualityProfileID = req.QualityProfileID
@@ -526,7 +599,38 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	if req.ApplyMonitorModeToExisting {
+		if err := h.applyMonitorModeToExistingBooks(r.Context(), author); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+	}
 	writeJSON(w, http.StatusOK, author)
+}
+
+func (h *AuthorHandler) applyMonitorModeToExistingBooks(ctx context.Context, author *models.Author) error {
+	books, err := h.books.ListByAuthorIncludingExcluded(ctx, author.ID)
+	if err != nil {
+		return fmt.Errorf("list author books: %w", err)
+	}
+	latestKeys := latestBookMonitorKeys(books, author.MonitorLatestCount, func(b models.Book) bool {
+		return !b.Excluded
+	})
+	today := dateOnly(time.Now().UTC())
+	for i := range books {
+		next := shouldMonitorBookForAuthor(author, books[i], latestKeys, today)
+		if books[i].Excluded {
+			next = false
+		}
+		if books[i].Monitored == next {
+			continue
+		}
+		books[i].Monitored = next
+		if err := h.books.Update(ctx, &books[i]); err != nil {
+			return fmt.Errorf("update book %d monitor state: %w", books[i].ID, err)
+		}
+	}
+	return nil
 }
 
 func (h *AuthorHandler) RelinkUpstream(w http.ResponseWriter, r *http.Request) {
@@ -589,7 +693,7 @@ func (h *AuthorHandler) RelinkUpstream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.relinkExistingAuthorToUpstream(r.Context(), author, upstream, author.Name, author.Monitored, author.QualityProfileID, author.MetadataProfileID, author.RootFolderID, author.AudiobookRootFolderID); err != nil {
+	if err := h.relinkExistingAuthorToUpstream(r.Context(), author, upstream, author.Name, author.Monitored, author.MonitorMode, author.MonitorLatestCount, author.QualityProfileID, author.MetadataProfileID, author.RootFolderID, author.AudiobookRootFolderID); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
@@ -824,6 +928,10 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 	}
 
 	normalizedAuthor := strings.ToLower(strings.TrimSpace(author.Name))
+	latestKeys := latestBookMonitorKeys(books, author.MonitorLatestCount, func(book models.Book) bool {
+		return isAuthorWorkMonitorCandidate(book, normalizedAuthor, allowedLangs, unknownFail)
+	})
+	today := dateOnly(time.Now().UTC())
 
 	searchQueue := make([]models.Book, 0)
 	autoSearchEnabled := autoSearch && h.searcher != nil && author.Monitored && h.isAutoGrabEnabled(ctx)
@@ -831,7 +939,6 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 	var added, skippedLang, skippedJunk int
 	for _, b := range books {
 		b.AuthorID = author.ID
-		b.Monitored = author.Monitored
 		// Apply the caller-provided default media type when the provider
 		// didn't set one. Never overwrite an explicit value — the audiobook
 		// enrichment flow relies on provider-supplied audiobook rows coming
@@ -860,6 +967,7 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 			slog.Debug("skipping non-allowed-language book", "title", b.Title, "language", b.Language, "allowed", allowedLangs)
 			continue
 		}
+		b.Monitored = shouldMonitorBookForAuthor(author, b, latestKeys, today)
 
 		// Update ratings on existing books so the recommender has data to work with,
 		// then skip further processing (we don't want to overwrite user state like status).
@@ -947,7 +1055,7 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 
 		// Auto-search the freshly-added wanted book only when the per-add
 		// flag AND the global auto-grab kill-switch both say yes.
-		if autoSearchEnabled {
+		if autoSearchEnabled && b.Monitored {
 			searchQueue = append(searchQueue, b)
 		}
 	}
@@ -1017,6 +1125,93 @@ func runBookSearches(ctx context.Context, searcher BookSearcher, books []models.
 		}()
 	}
 	wg.Wait()
+}
+
+func shouldMonitorBookForAuthor(author *models.Author, book models.Book, latestKeys map[string]struct{}, today time.Time) bool {
+	if author == nil || !author.Monitored {
+		return false
+	}
+	switch author.MonitorMode {
+	case models.AuthorMonitorModeFuture:
+		if book.ReleaseDate == nil {
+			return false
+		}
+		return dateOnly(book.ReleaseDate.UTC()).After(today)
+	case models.AuthorMonitorModeLatest:
+		_, ok := latestKeys[indexer.NormalizeTitleForDedup(book.Title)]
+		return ok
+	case models.AuthorMonitorModeNone:
+		return false
+	case models.AuthorMonitorModeAll, "":
+		return true
+	default:
+		return true
+	}
+}
+
+type latestMonitorCandidate struct {
+	key         string
+	title       string
+	releaseDate time.Time
+}
+
+func latestBookMonitorKeys(books []models.Book, count int, include func(models.Book) bool) map[string]struct{} {
+	if count <= 0 {
+		count = models.DefaultAuthorMonitorLatestCount
+	}
+	byKey := make(map[string]latestMonitorCandidate)
+	for _, book := range books {
+		if book.ReleaseDate == nil {
+			continue
+		}
+		if include != nil && !include(book) {
+			continue
+		}
+		key := indexer.NormalizeTitleForDedup(book.Title)
+		if key == "" {
+			continue
+		}
+		candidate := latestMonitorCandidate{
+			key:         key,
+			title:       book.Title,
+			releaseDate: dateOnly(book.ReleaseDate.UTC()),
+		}
+		if existing, ok := byKey[key]; ok && !candidate.releaseDate.After(existing.releaseDate) {
+			continue
+		}
+		byKey[key] = candidate
+	}
+	candidates := make([]latestMonitorCandidate, 0, len(byKey))
+	for _, candidate := range byKey {
+		candidates = append(candidates, candidate)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if !candidates[i].releaseDate.Equal(candidates[j].releaseDate) {
+			return candidates[i].releaseDate.After(candidates[j].releaseDate)
+		}
+		return strings.ToLower(candidates[i].title) < strings.ToLower(candidates[j].title)
+	})
+	if len(candidates) > count {
+		candidates = candidates[:count]
+	}
+	keys := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		keys[candidate.key] = struct{}{}
+	}
+	return keys
+}
+
+func isAuthorWorkMonitorCandidate(book models.Book, normalizedAuthor string, allowedLangs []string, unknownFail bool) bool {
+	normalizedTitle := strings.ToLower(strings.TrimSpace(book.Title))
+	if normalizedTitle == "" || normalizedTitle == normalizedAuthor {
+		return false
+	}
+	return models.IsLanguageAllowed(book.Language, allowedLangs, unknownFail)
+}
+
+func dateOnly(t time.Time) time.Time {
+	y, m, d := t.UTC().Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
 }
 
 func (h *AuthorHandler) lookupUpstreamAuthorByName(ctx context.Context, name string) (*models.Author, error) {

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -480,6 +480,132 @@ func TestFetchAuthorBooks_SkipsSearchWhenNotMonitored(t *testing.T) {
 	}
 }
 
+func TestFetchAuthorBooks_AppliesAuthorMonitorModes(t *testing.T) {
+	now := time.Now().UTC()
+	oldDate := now.AddDate(0, 0, -30)
+	middleDate := now.AddDate(0, 0, -7)
+	futureDate := now.AddDate(0, 0, 7)
+
+	testCases := []struct {
+		name        string
+		mode        string
+		latestCount int
+		want        map[string]bool
+	}{
+		{
+			name:        "all",
+			mode:        models.AuthorMonitorModeAll,
+			latestCount: 1,
+			want: map[string]bool{
+				"Old Book":     true,
+				"Middle Book":  true,
+				"Future Book":  true,
+				"Unknown Book": true,
+			},
+		},
+		{
+			name:        "future",
+			mode:        models.AuthorMonitorModeFuture,
+			latestCount: 1,
+			want: map[string]bool{
+				"Old Book":     false,
+				"Middle Book":  false,
+				"Future Book":  true,
+				"Unknown Book": false,
+			},
+		},
+		{
+			name:        "latest",
+			mode:        models.AuthorMonitorModeLatest,
+			latestCount: 2,
+			want: map[string]bool{
+				"Old Book":     false,
+				"Middle Book":  true,
+				"Future Book":  true,
+				"Unknown Book": false,
+			},
+		},
+		{
+			name:        "none",
+			mode:        models.AuthorMonitorModeNone,
+			latestCount: 1,
+			want: map[string]bool{
+				"Old Book":     false,
+				"Middle Book":  false,
+				"Future Book":  false,
+				"Unknown Book": false,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			database, err := db.OpenMemory()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer database.Close()
+
+			authorRepo := db.NewAuthorRepo(database)
+			bookRepo := db.NewBookRepo(database)
+			profileRepo := db.NewMetadataProfileRepo(database)
+			ctx := context.Background()
+
+			author := &models.Author{
+				ForeignID:          "OL-MODE-" + tc.name,
+				Name:               "Mode Author",
+				SortName:           "Author, Mode",
+				MetadataProvider:   "openlibrary",
+				Monitored:          true,
+				MonitorMode:        tc.mode,
+				MonitorLatestCount: tc.latestCount,
+			}
+			if err := authorRepo.Create(ctx, author); err != nil {
+				t.Fatal(err)
+			}
+
+			stub := &stubMetaProvider{
+				works: []models.Book{
+					{ForeignID: "OL-MODE-OLD-" + tc.name, Title: "Old Book", SortTitle: "old book", ReleaseDate: &oldDate, Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+					{ForeignID: "OL-MODE-MID-" + tc.name, Title: "Middle Book", SortTitle: "middle book", ReleaseDate: &middleDate, Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+					{ForeignID: "OL-MODE-FUT-" + tc.name, Title: "Future Book", SortTitle: "future book", ReleaseDate: &futureDate, Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+					{ForeignID: "OL-MODE-UNK-" + tc.name, Title: "Unknown Book", SortTitle: "unknown book", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+				},
+			}
+			spy := &searcherSpy{}
+			h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(stub), nil, profileRepo, spy)
+			h.FetchAuthorBooks(author, true, "")
+
+			books, err := bookRepo.ListByAuthor(ctx, author.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(books) != len(tc.want) {
+				t.Fatalf("books = %d, want %d", len(books), len(tc.want))
+			}
+			for _, book := range books {
+				want, ok := tc.want[book.Title]
+				if !ok {
+					t.Fatalf("unexpected book %q", book.Title)
+				}
+				if book.Monitored != want {
+					t.Errorf("%s monitored = %v, want %v", book.Title, book.Monitored, want)
+				}
+			}
+
+			seenSearches := map[string]bool{}
+			for _, title := range spy.titles() {
+				seenSearches[title] = true
+			}
+			for title, wantMonitored := range tc.want {
+				if seenSearches[title] != wantMonitored {
+					t.Errorf("search for %q = %v, want %v", title, seenSearches[title], wantMonitored)
+				}
+			}
+		})
+	}
+}
+
 // TestFetchAuthorBooks_DedupsEditionSuffix is a regression test for issue #283.
 // When two provider results for the same work differ only in a trailing
 // parenthesised edition qualifier (e.g. "Dune" vs "Dune (German Edition)"),
@@ -793,6 +919,136 @@ func TestCreateAuthor_UsesCanonicalMetadataAndRecordsAlias(t *testing.T) {
 	}
 	if len(aliases) != 1 || aliases[0].Name != "J.K. Rowling" {
 		t.Fatalf("aliases = %+v, want J.K. Rowling alias", aliases)
+	}
+}
+
+func TestCreateAuthor_UsesGlobalMonitorDefaultsWhenOmitted(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+
+	if err := settingsRepo.Set(ctx, SettingAuthorDefaultMonitorMode, models.AuthorMonitorModeFuture); err != nil {
+		t.Fatal(err)
+	}
+	if err := settingsRepo.Set(ctx, SettingAuthorDefaultMonitorLatestCount, "4"); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &fixedAuthorProvider{
+		result: &models.Author{
+			ForeignID:        "OL-GLOBAL-A",
+			Name:             "Global Defaults",
+			SortName:         "Defaults, Global",
+			MetadataProvider: "openlibrary",
+		},
+	}
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(provider), settingsRepo, profileRepo, nil)
+	body, _ := json.Marshal(map[string]any{
+		"foreignAuthorId": "OL-GLOBAL-A",
+		"authorName":      "Global Defaults",
+		"monitored":       true,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/author", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	h.Create(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, err := authorRepo.GetByForeignID(ctx, "OL-GLOBAL-A")
+	if err != nil || got == nil {
+		t.Fatalf("fetch author: %v, got=%+v", err, got)
+	}
+	if got.MonitorMode != models.AuthorMonitorModeFuture || got.MonitorLatestCount != 4 {
+		t.Fatalf("monitor defaults = %q/%d, want future/4", got.MonitorMode, got.MonitorLatestCount)
+	}
+}
+
+func TestUpdateAuthor_ApplyMonitorModeToExistingBooks(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+
+	author := &models.Author{
+		ForeignID:        "OL-APPLY-A",
+		Name:             "Apply Author",
+		SortName:         "Author, Apply",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+		MonitorMode:      models.AuthorMonitorModeAll,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	oldDate := time.Now().UTC().AddDate(0, 0, -3)
+	futureDate := time.Now().UTC().AddDate(0, 0, 3)
+	books := []*models.Book{
+		{ForeignID: "OL-APPLY-OLD", AuthorID: author.ID, Title: "Old Book", SortTitle: "old book", ReleaseDate: &oldDate, Status: models.BookStatusWanted, Monitored: true, Genres: []string{}, MetadataProvider: "openlibrary"},
+		{ForeignID: "OL-APPLY-FUTURE", AuthorID: author.ID, Title: "Future Book", SortTitle: "future book", ReleaseDate: &futureDate, Status: models.BookStatusWanted, Monitored: true, Genres: []string{}, MetadataProvider: "openlibrary"},
+		{ForeignID: "OL-APPLY-UNKNOWN", AuthorID: author.ID, Title: "Unknown Book", SortTitle: "unknown book", Status: models.BookStatusWanted, Monitored: true, Genres: []string{}, MetadataProvider: "openlibrary"},
+		{ForeignID: "OL-APPLY-EXCLUDED", AuthorID: author.ID, Title: "Excluded Book", SortTitle: "excluded book", ReleaseDate: &futureDate, Status: models.BookStatusWanted, Monitored: true, Genres: []string{}, MetadataProvider: "openlibrary"},
+	}
+	for _, book := range books {
+		if err := bookRepo.Create(ctx, book); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := bookRepo.SetExcluded(ctx, books[3].ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, nil, nil, profileRepo, nil)
+	body, _ := json.Marshal(map[string]any{
+		"monitorMode":                models.AuthorMonitorModeFuture,
+		"applyMonitorModeToExisting": true,
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/author/"+strconv.FormatInt(author.ID, 10), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(author.ID, 10))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	h.Update(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	gotBooks, err := bookRepo.ListByAuthorIncludingExcluded(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, book := range gotBooks {
+		got[book.Title] = book.Monitored
+	}
+	want := map[string]bool{
+		"Old Book":      false,
+		"Future Book":   true,
+		"Unknown Book":  false,
+		"Excluded Book": false,
+	}
+	for title, wantMonitored := range want {
+		if got[title] != wantMonitored {
+			t.Errorf("%s monitored = %v, want %v", title, got[title], wantMonitored)
+		}
 	}
 }
 

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -25,6 +25,14 @@ import (
 // unset falls back to ebook for backwards compatibility.
 const SettingDefaultMediaType = "default.media_type"
 
+// SettingAuthorDefaultMonitorMode controls which newly discovered books are
+// monitored for authors created without an explicit monitorMode.
+const SettingAuthorDefaultMonitorMode = "author.default_monitor_mode"
+
+// SettingAuthorDefaultMonitorLatestCount stores the N for monitor_mode=latest
+// when authors are created without an explicit monitorLatestCount.
+const SettingAuthorDefaultMonitorLatestCount = "author.default_monitor_latest_count"
+
 // SettingDefaultLibraryRootFolderID is the KV key that stores the ID of the
 // root folder used as the fallback library path when an author has no
 // per-author RootFolderID. Value is a decimal integer (the root_folder.id);
@@ -276,6 +284,21 @@ func validateSettingValue(key, value string) error {
 			return nil
 		default:
 			return fmt.Errorf("default.media_type %q is not one of: ebook, audiobook, both", value)
+		}
+	case SettingAuthorDefaultMonitorMode:
+		if value == "" {
+			return nil
+		}
+		if !models.IsAuthorMonitorModeValid(value) {
+			return fmt.Errorf("author.default_monitor_mode %q is not one of: all, future, latest, none", value)
+		}
+	case SettingAuthorDefaultMonitorLatestCount:
+		if value == "" {
+			return nil
+		}
+		n, err := strconv.Atoi(value)
+		if err != nil || n <= 0 {
+			return fmt.Errorf("author.default_monitor_latest_count %q must be a positive integer", value)
 		}
 	case SettingDefaultLibraryRootFolderID:
 		// Empty = unset (fall back to env-var default); non-empty must be a

--- a/internal/api/settings_handler_test.go
+++ b/internal/api/settings_handler_test.go
@@ -182,6 +182,46 @@ func TestSettings_SetBadBody(t *testing.T) {
 	}
 }
 
+func TestSettings_AuthorMonitorDefaultsValidation(t *testing.T) {
+	h, repo, ctx := settingsFixture(t)
+
+	validReq := withKey(httptest.NewRequest(http.MethodPut, "/api/v1/settings/"+SettingAuthorDefaultMonitorMode, bytes.NewBufferString(`{"value":"future"}`)), SettingAuthorDefaultMonitorMode)
+	validRec := httptest.NewRecorder()
+	h.Set(validRec, validReq)
+	if validRec.Code != http.StatusOK {
+		t.Fatalf("expected valid mode 200, got %d: %s", validRec.Code, validRec.Body.String())
+	}
+	got, _ := repo.Get(ctx, SettingAuthorDefaultMonitorMode)
+	if got == nil || got.Value != models.AuthorMonitorModeFuture {
+		t.Fatalf("expected future setting persisted, got %+v", got)
+	}
+
+	badModeReq := withKey(httptest.NewRequest(http.MethodPut, "/api/v1/settings/"+SettingAuthorDefaultMonitorMode, bytes.NewBufferString(`{"value":"yesterday"}`)), SettingAuthorDefaultMonitorMode)
+	badModeRec := httptest.NewRecorder()
+	h.Set(badModeRec, badModeReq)
+	if badModeRec.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid mode 400, got %d", badModeRec.Code)
+	}
+
+	validCountReq := withKey(httptest.NewRequest(http.MethodPut, "/api/v1/settings/"+SettingAuthorDefaultMonitorLatestCount, bytes.NewBufferString(`{"value":"5"}`)), SettingAuthorDefaultMonitorLatestCount)
+	validCountRec := httptest.NewRecorder()
+	h.Set(validCountRec, validCountReq)
+	if validCountRec.Code != http.StatusOK {
+		t.Fatalf("expected valid count 200, got %d: %s", validCountRec.Code, validCountRec.Body.String())
+	}
+	got, _ = repo.Get(ctx, SettingAuthorDefaultMonitorLatestCount)
+	if got == nil || got.Value != "5" {
+		t.Fatalf("expected latest count persisted, got %+v", got)
+	}
+
+	badCountReq := withKey(httptest.NewRequest(http.MethodPut, "/api/v1/settings/"+SettingAuthorDefaultMonitorLatestCount, bytes.NewBufferString(`{"value":"0"}`)), SettingAuthorDefaultMonitorLatestCount)
+	badCountRec := httptest.NewRecorder()
+	h.Set(badCountRec, badCountReq)
+	if badCountRec.Code != http.StatusBadRequest {
+		t.Fatalf("expected invalid count 400, got %d", badCountRec.Code)
+	}
+}
+
 func TestSettings_GetABSSecretReturns404(t *testing.T) {
 	h, repo, ctx := settingsFixture(t)
 	if err := repo.Set(ctx, SettingABSAPIKey, "supersecret"); err != nil {

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -20,7 +20,8 @@ func NewAuthorRepo(db *sql.DB) *AuthorRepo {
 
 const authorSelectCols = `id, foreign_id, name, sort_name, description, image_url, disambiguation,
 	       ratings_count, average_rating, monitored, quality_profile_id, metadata_profile_id, root_folder_id,
-	       audiobook_root_folder_id, metadata_provider, last_metadata_refresh_at, created_at, updated_at`
+	       audiobook_root_folder_id, monitor_mode, monitor_latest_count, metadata_provider, last_metadata_refresh_at,
+	       created_at, updated_at`
 
 func (r *AuthorRepo) List(ctx context.Context) ([]models.Author, error) {
 	return r.ListByUser(ctx, 0)
@@ -117,6 +118,7 @@ func (r *AuthorRepo) Create(ctx context.Context, a *models.Author) error {
 
 func (r *AuthorRepo) CreateForUser(ctx context.Context, a *models.Author, ownerUserID int64) error {
 	now := time.Now().UTC()
+	normalizeAuthorMonitorDefaults(a)
 	var ownerArg any
 	if ownerUserID != 0 {
 		ownerArg = ownerUserID
@@ -124,11 +126,12 @@ func (r *AuthorRepo) CreateForUser(ctx context.Context, a *models.Author, ownerU
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO authors (foreign_id, name, sort_name, description, image_url, disambiguation,
 		                     ratings_count, average_rating, monitored, quality_profile_id, metadata_profile_id, root_folder_id,
-		                     audiobook_root_folder_id, metadata_provider, owner_user_id, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		                     audiobook_root_folder_id, monitor_mode, monitor_latest_count, metadata_provider, owner_user_id,
+		                     created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.ForeignID, a.Name, a.SortName, a.Description, a.ImageURL, a.Disambiguation,
 		a.RatingsCount, a.AverageRating, a.Monitored, a.QualityProfileID, a.MetadataProfileID, a.RootFolderID,
-		a.AudiobookRootFolderID, a.MetadataProvider, ownerArg, now, now)
+		a.AudiobookRootFolderID, a.MonitorMode, a.MonitorLatestCount, a.MetadataProvider, ownerArg, now, now)
 	if err != nil {
 		return fmt.Errorf("create author: %w", err)
 	}
@@ -224,15 +227,17 @@ func (r *AuthorRepo) UpgradeSyntheticDNB(ctx context.Context, currentForeignID s
 
 func (r *AuthorRepo) Update(ctx context.Context, a *models.Author) error {
 	now := time.Now().UTC()
+	normalizeAuthorMonitorDefaults(a)
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE authors SET foreign_id=?, name=?, sort_name=?, description=?, image_url=?, disambiguation=?,
 		                   ratings_count=?, average_rating=?, monitored=?, quality_profile_id=?,
-		                   metadata_profile_id=?, root_folder_id=?, audiobook_root_folder_id=?, metadata_provider=?,
-		                   last_metadata_refresh_at=?, updated_at=?
+		                   metadata_profile_id=?, root_folder_id=?, audiobook_root_folder_id=?, monitor_mode=?,
+		                   monitor_latest_count=?, metadata_provider=?, last_metadata_refresh_at=?, updated_at=?
 		WHERE id=?`,
 		a.ForeignID, a.Name, a.SortName, a.Description, a.ImageURL, a.Disambiguation,
 		a.RatingsCount, a.AverageRating, a.Monitored, a.QualityProfileID,
-		a.MetadataProfileID, a.RootFolderID, a.AudiobookRootFolderID, a.MetadataProvider, a.LastMetadataRefreshAt, now, a.ID)
+		a.MetadataProfileID, a.RootFolderID, a.AudiobookRootFolderID, a.MonitorMode,
+		a.MonitorLatestCount, a.MetadataProvider, a.LastMetadataRefreshAt, now, a.ID)
 	if err != nil {
 		return fmt.Errorf("update author %d: %w", a.ID, err)
 	}
@@ -253,9 +258,11 @@ func scanAuthor(rows *sql.Rows) (models.Author, error) {
 	var monitored int
 	err := rows.Scan(&a.ID, &a.ForeignID, &a.Name, &a.SortName, &a.Description, &a.ImageURL,
 		&a.Disambiguation, &a.RatingsCount, &a.AverageRating, &monitored,
-		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.AudiobookRootFolderID, &a.MetadataProvider,
+		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.AudiobookRootFolderID,
+		&a.MonitorMode, &a.MonitorLatestCount, &a.MetadataProvider,
 		&a.LastMetadataRefreshAt, &a.CreatedAt, &a.UpdatedAt)
 	a.Monitored = monitored == 1
+	normalizeAuthorMonitorDefaults(&a)
 	return a, err
 }
 
@@ -264,8 +271,22 @@ func scanAuthorRow(row *sql.Row) (models.Author, error) {
 	var monitored int
 	err := row.Scan(&a.ID, &a.ForeignID, &a.Name, &a.SortName, &a.Description, &a.ImageURL,
 		&a.Disambiguation, &a.RatingsCount, &a.AverageRating, &monitored,
-		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.AudiobookRootFolderID, &a.MetadataProvider,
+		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.AudiobookRootFolderID,
+		&a.MonitorMode, &a.MonitorLatestCount, &a.MetadataProvider,
 		&a.LastMetadataRefreshAt, &a.CreatedAt, &a.UpdatedAt)
 	a.Monitored = monitored == 1
+	normalizeAuthorMonitorDefaults(&a)
 	return a, err
+}
+
+func normalizeAuthorMonitorDefaults(a *models.Author) {
+	if a == nil {
+		return
+	}
+	if !models.IsAuthorMonitorModeValid(a.MonitorMode) {
+		a.MonitorMode = models.DefaultAuthorMonitorMode
+	}
+	if a.MonitorLatestCount <= 0 {
+		a.MonitorLatestCount = models.DefaultAuthorMonitorLatestCount
+	}
 }

--- a/internal/db/authors_test.go
+++ b/internal/db/authors_test.go
@@ -38,6 +38,58 @@ func TestAuthorRepo_GetByDNBSyntheticName_NoMatch(t *testing.T) {
 	}
 }
 
+func TestAuthorRepo_MonitorDefaultsRoundTrip(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	author := &models.Author{
+		ForeignID:        "OL-MON-A",
+		Name:             "Monitor Author",
+		SortName:         "Author, Monitor",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := repo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	if author.MonitorMode != models.AuthorMonitorModeAll {
+		t.Fatalf("create default monitor mode = %q, want %q", author.MonitorMode, models.AuthorMonitorModeAll)
+	}
+	if author.MonitorLatestCount != models.DefaultAuthorMonitorLatestCount {
+		t.Fatalf("create default latest count = %d, want %d", author.MonitorLatestCount, models.DefaultAuthorMonitorLatestCount)
+	}
+
+	got, err := repo.GetByID(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("author not found")
+	}
+	if got.MonitorMode != models.AuthorMonitorModeAll || got.MonitorLatestCount != models.DefaultAuthorMonitorLatestCount {
+		t.Fatalf("defaults did not round trip: %+v", got)
+	}
+
+	got.MonitorMode = models.AuthorMonitorModeLatest
+	got.MonitorLatestCount = 3
+	if err := repo.Update(ctx, got); err != nil {
+		t.Fatal(err)
+	}
+	got, err = repo.GetByID(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.MonitorMode != models.AuthorMonitorModeLatest || got.MonitorLatestCount != 3 {
+		t.Fatalf("updated monitor defaults did not round trip: %+v", got)
+	}
+}
+
 // TestAuthorRepo_GetByDNBSyntheticName_MatchesSyntheticOnly verifies the
 // foreign_id LIKE 'dnb:author:%' guard: rows with dnb:gnd: or other prefixes
 // are not considered synthetic, only dnb:author:<slug> rows are eligible for

--- a/internal/db/migrations/043_author_monitor_mode.sql
+++ b/internal/db/migrations/043_author_monitor_mode.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+-- Per-author monitor defaults control which newly discovered books start as
+-- monitored. Existing authors keep the historical "all books" behaviour.
+ALTER TABLE authors ADD COLUMN monitor_mode TEXT NOT NULL DEFAULT 'all';
+ALTER TABLE authors ADD COLUMN monitor_latest_count INTEGER NOT NULL DEFAULT 1;

--- a/internal/models/author.go
+++ b/internal/models/author.go
@@ -5,19 +5,21 @@ package models
 import "time"
 
 type Author struct {
-	ID                int64   `json:"id"`
-	ForeignID         string  `json:"foreignAuthorId"`
-	Name              string  `json:"authorName"`
-	SortName          string  `json:"sortName"`
-	Description       string  `json:"description"`
-	ImageURL          string  `json:"imageUrl"`
-	Disambiguation    string  `json:"disambiguation"`
-	RatingsCount      int     `json:"ratingsCount"`
-	AverageRating     float64 `json:"averageRating"`
-	Monitored         bool    `json:"monitored"`
-	QualityProfileID  *int64  `json:"qualityProfileId"`
-	MetadataProfileID *int64  `json:"metadataProfileId"`
-	RootFolderID      *int64  `json:"rootFolderId"`
+	ID                 int64   `json:"id"`
+	ForeignID          string  `json:"foreignAuthorId"`
+	Name               string  `json:"authorName"`
+	SortName           string  `json:"sortName"`
+	Description        string  `json:"description"`
+	ImageURL           string  `json:"imageUrl"`
+	Disambiguation     string  `json:"disambiguation"`
+	RatingsCount       int     `json:"ratingsCount"`
+	AverageRating      float64 `json:"averageRating"`
+	Monitored          bool    `json:"monitored"`
+	MonitorMode        string  `json:"monitorMode"`
+	MonitorLatestCount int     `json:"monitorLatestCount"`
+	QualityProfileID   *int64  `json:"qualityProfileId"`
+	MetadataProfileID  *int64  `json:"metadataProfileId"`
+	RootFolderID       *int64  `json:"rootFolderId"`
 	// AudiobookRootFolderID overrides the audiobook destination for this
 	// author. Distinct from RootFolderID, which only routes ebooks: keeping
 	// them separate ensures an ebook root folder never redirects audiobooks
@@ -36,6 +38,25 @@ type Author struct {
 	// Transient: populated from the metadata provider during add/refresh; not stored in DB.
 	// Used to seed author_aliases so non-latin primary names get latin-script alternates.
 	AlternateNames []string `json:"-"`
+}
+
+const (
+	AuthorMonitorModeAll    = "all"
+	AuthorMonitorModeFuture = "future"
+	AuthorMonitorModeLatest = "latest"
+	AuthorMonitorModeNone   = "none"
+
+	DefaultAuthorMonitorMode        = AuthorMonitorModeAll
+	DefaultAuthorMonitorLatestCount = 1
+)
+
+func IsAuthorMonitorModeValid(mode string) bool {
+	switch mode {
+	case AuthorMonitorModeAll, AuthorMonitorModeFuture, AuthorMonitorModeLatest, AuthorMonitorModeNone:
+		return true
+	default:
+		return false
+	}
 }
 
 type AuthorStats struct {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -543,6 +543,8 @@ export interface Author {
   ratingsCount: number
   averageRating: number
   monitored: boolean
+  monitorMode?: AuthorMonitorMode
+  monitorLatestCount?: number
   qualityProfileId?: number | null
   metadataProfileId?: number | null
   rootFolderId?: number | null
@@ -568,6 +570,7 @@ export interface MergeAuthorsResult {
 }
 
 export type MediaType = 'ebook' | 'audiobook' | 'both'
+export type AuthorMonitorMode = 'all' | 'future' | 'latest' | 'none'
 
 export interface BookFile {
   id: number
@@ -1063,6 +1066,8 @@ export interface AddAuthorRequest {
   foreignAuthorId: string
   authorName: string
   monitored: boolean
+  monitorMode?: AuthorMonitorMode
+  monitorLatestCount?: number
   searchOnAdd: boolean
   metadataProfileId?: number | null
   qualityProfileId?: number | null
@@ -1076,11 +1081,14 @@ export interface AddAuthorRequest {
 // folder when this flag is true.
 export interface UpdateAuthorRequest {
   monitored?: boolean
+  monitorMode?: AuthorMonitorMode
+  monitorLatestCount?: number
   qualityProfileId?: number | null
   metadataProfileId?: number | null
   rootFolderId?: number | null
   audiobookRootFolderId?: number | null
   clearAudiobookRootFolder?: boolean
+  applyMonitorModeToExisting?: boolean
 }
 
 export interface GrabRequest {

--- a/web/src/components/AddAuthorModal.test.tsx
+++ b/web/src/components/AddAuthorModal.test.tsx
@@ -218,7 +218,7 @@ describe('AddAuthorModal — search error handling', () => {
     }))
   })
 
-  it('loads global monitor defaults and sends them when adding an author', async () => {
+  it('loads global monitor defaults and lets the backend apply them when unchanged', async () => {
     vi.mocked(api.getSetting).mockImplementation(async (key: string) => {
       if (key === 'default.media_type') return { key, value: 'ebook' }
       if (key === 'author.default_monitor_mode') return { key, value: 'latest' }
@@ -260,8 +260,48 @@ describe('AddAuthorModal — search error handling', () => {
     expect(api.addAuthor).toHaveBeenCalledWith(expect.objectContaining({
       foreignAuthorId: 'OL26320A',
       authorName: 'J.R.R. Tolkien',
+    }))
+    const callArg = vi.mocked(api.addAuthor).mock.calls[0][0]
+    expect('monitorMode' in callArg).toBe(false)
+    expect('monitorLatestCount' in callArg).toBe(false)
+  })
+
+  it('sends monitor overrides when the controls are changed', async () => {
+    vi.mocked(api.searchAuthors).mockResolvedValue([
+      {
+        id: 0,
+        foreignAuthorId: 'OL26320A',
+        authorName: 'J.R.R. Tolkien',
+        sortName: 'Tolkien, J.R.R.',
+        description: '',
+        imageUrl: '',
+        disambiguation: '',
+        ratingsCount: 0,
+        averageRating: 0,
+        monitored: true,
+      },
+    ])
+
+    render(<AddAuthorModal onClose={onClose} onAdded={onAdded} />)
+
+    const monitorMode = screen.getAllByRole('combobox')[1]
+    fireEvent.change(monitorMode, { target: { value: 'latest' } })
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '3' } })
+
+    fireEvent.change(screen.getByPlaceholderText('Search by author name...'), {
+      target: { value: 'tolkien' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+    await waitFor(() => expect(screen.getByText('J.R.R. Tolkien')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    await waitFor(() => expect(api.addAuthor).toHaveBeenCalledTimes(1))
+    expect(api.addAuthor).toHaveBeenCalledWith(expect.objectContaining({
+      foreignAuthorId: 'OL26320A',
+      authorName: 'J.R.R. Tolkien',
       monitorMode: 'latest',
-      monitorLatestCount: 5,
+      monitorLatestCount: 3,
     }))
   })
 

--- a/web/src/components/AddAuthorModal.test.tsx
+++ b/web/src/components/AddAuthorModal.test.tsx
@@ -218,6 +218,53 @@ describe('AddAuthorModal — search error handling', () => {
     }))
   })
 
+  it('loads global monitor defaults and sends them when adding an author', async () => {
+    vi.mocked(api.getSetting).mockImplementation(async (key: string) => {
+      if (key === 'default.media_type') return { key, value: 'ebook' }
+      if (key === 'author.default_monitor_mode') return { key, value: 'latest' }
+      if (key === 'author.default_monitor_latest_count') return { key, value: '5' }
+      throw new Error('setting not found')
+    })
+    vi.mocked(api.searchAuthors).mockResolvedValue([
+      {
+        id: 0,
+        foreignAuthorId: 'OL26320A',
+        authorName: 'J.R.R. Tolkien',
+        sortName: 'Tolkien, J.R.R.',
+        description: '',
+        imageUrl: '',
+        disambiguation: '',
+        ratingsCount: 0,
+        averageRating: 0,
+        monitored: true,
+      },
+    ])
+
+    render(<AddAuthorModal onClose={onClose} onAdded={onAdded} />)
+
+    await waitFor(() => {
+      const selects = screen.getAllByRole('combobox') as HTMLSelectElement[]
+      expect(selects[1].value).toBe('latest')
+    })
+    expect(screen.getByRole('spinbutton')).toHaveValue(5)
+
+    fireEvent.change(screen.getByPlaceholderText('Search by author name...'), {
+      target: { value: 'tolkien' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+    await waitFor(() => expect(screen.getByText('J.R.R. Tolkien')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+
+    await waitFor(() => expect(api.addAuthor).toHaveBeenCalledTimes(1))
+    expect(api.addAuthor).toHaveBeenCalledWith(expect.objectContaining({
+      foreignAuthorId: 'OL26320A',
+      authorName: 'J.R.R. Tolkien',
+      monitorMode: 'latest',
+      monitorLatestCount: 5,
+    }))
+  })
+
   it('hides likely book-title results by default and reveals them on request', async () => {
     const hiddenAuthor = author({
       foreignAuthorId: 'OL_BAD_TITLE_A',

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, Author, MediaType, MetadataProfile, RootFolder } from '../api/client'
+import { api, Author, AuthorMonitorMode, MediaType, MetadataProfile, RootFolder } from '../api/client'
 import { splitAuthorSearchResults } from './addAuthorTitleGuard'
 
 interface Props {
@@ -9,6 +9,12 @@ interface Props {
 }
 
 const AUTO_GRAB_STORAGE_KEY = 'addAuthor.autoGrab'
+const DEFAULT_MONITOR_MODE: AuthorMonitorMode = 'all'
+const DEFAULT_MONITOR_LATEST_COUNT = 1
+
+function isAuthorMonitorMode(value: string): value is AuthorMonitorMode {
+  return value === 'all' || value === 'future' || value === 'latest' || value === 'none'
+}
 
 function loadAutoGrabDefault(): boolean {
   try {
@@ -35,6 +41,8 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const [rootFolderId, setRootFolderId] = useState<number | null>(null)
   const [searchOnAdd, setSearchOnAdd] = useState(loadAutoGrabDefault)
   const [mediaType, setMediaType] = useState<MediaType>('ebook')
+  const [monitorMode, setMonitorMode] = useState<AuthorMonitorMode>(DEFAULT_MONITOR_MODE)
+  const [monitorLatestCount, setMonitorLatestCount] = useState(DEFAULT_MONITOR_LATEST_COUNT)
 
   useEffect(() => {
     api.listMetadataProfiles().then(ps => {
@@ -57,6 +65,17 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
         }
       })
       .catch(() => { /* 404 = unset; keep ebook default */ })
+    api.getSetting('author.default_monitor_mode')
+      .then(s => {
+        if (isAuthorMonitorMode(s.value)) setMonitorMode(s.value)
+      })
+      .catch(() => { /* unset; keep all-books default */ })
+    api.getSetting('author.default_monitor_latest_count')
+      .then(s => {
+        const n = Number(s.value)
+        if (Number.isInteger(n) && n > 0) setMonitorLatestCount(n)
+      })
+      .catch(() => { /* unset; keep latest count default */ })
   }, [])
 
   const search = async () => {
@@ -89,6 +108,8 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
         foreignAuthorId: author.foreignAuthorId,
         authorName: author.authorName,
         monitored: true,
+        monitorMode,
+        monitorLatestCount,
         searchOnAdd,
         metadataProfileId: profileId,
         rootFolderId: rootFolderId,
@@ -158,6 +179,35 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
               <option value="both">{t('mediaType.both', 'Both')}</option>
             </select>
           </div>
+          <div className="mb-3">
+            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">
+              {t('addAuthorModal.monitorMode', 'Monitor mode')}
+            </label>
+            <select
+              value={monitorMode}
+              onChange={e => setMonitorMode(e.target.value as AuthorMonitorMode)}
+              className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+            >
+              <option value="all">{t('monitorMode.all', 'All books')}</option>
+              <option value="future">{t('monitorMode.future', 'Future books only')}</option>
+              <option value="latest">{t('monitorMode.latest', 'Latest only')}</option>
+              <option value="none">{t('monitorMode.none', 'None')}</option>
+            </select>
+          </div>
+          {monitorMode === 'latest' && (
+            <div className="mb-3">
+              <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">
+                {t('addAuthorModal.monitorLatestCount', 'Latest book count')}
+              </label>
+              <input
+                type="number"
+                min={1}
+                value={monitorLatestCount}
+                onChange={e => setMonitorLatestCount(Math.max(1, Number(e.target.value) || 1))}
+                className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+              />
+            </div>
+          )}
           <label className="flex items-start gap-2 text-sm mb-3 cursor-pointer select-none">
             <input
               type="checkbox"

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, Author, AuthorMonitorMode, MediaType, MetadataProfile, RootFolder } from '../api/client'
+import { api, AddAuthorRequest, Author, AuthorMonitorMode, MediaType, MetadataProfile, RootFolder } from '../api/client'
 import { splitAuthorSearchResults } from './addAuthorTitleGuard'
 
 interface Props {
@@ -43,6 +43,7 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const [mediaType, setMediaType] = useState<MediaType>('ebook')
   const [monitorMode, setMonitorMode] = useState<AuthorMonitorMode>(DEFAULT_MONITOR_MODE)
   const [monitorLatestCount, setMonitorLatestCount] = useState(DEFAULT_MONITOR_LATEST_COUNT)
+  const [monitorOptionsChanged, setMonitorOptionsChanged] = useState(false)
 
   useEffect(() => {
     api.listMetadataProfiles().then(ps => {
@@ -104,17 +105,20 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const addAuthor = async (author: Author) => {
     setAdding(author.foreignAuthorId)
     try {
-      await api.addAuthor({
+      const request: AddAuthorRequest = {
         foreignAuthorId: author.foreignAuthorId,
         authorName: author.authorName,
         monitored: true,
-        monitorMode,
-        monitorLatestCount,
         searchOnAdd,
         metadataProfileId: profileId,
         rootFolderId: rootFolderId,
         mediaType,
-      })
+      }
+      if (monitorOptionsChanged) {
+        request.monitorMode = monitorMode
+        request.monitorLatestCount = monitorLatestCount
+      }
+      await api.addAuthor(request)
       try {
         localStorage.setItem(AUTO_GRAB_STORAGE_KEY, String(searchOnAdd))
       } catch {
@@ -185,7 +189,10 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
             </label>
             <select
               value={monitorMode}
-              onChange={e => setMonitorMode(e.target.value as AuthorMonitorMode)}
+              onChange={e => {
+                setMonitorMode(e.target.value as AuthorMonitorMode)
+                setMonitorOptionsChanged(true)
+              }}
               className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
             >
               <option value="all">{t('monitorMode.all', 'All books')}</option>
@@ -203,7 +210,10 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
                 type="number"
                 min={1}
                 value={monitorLatestCount}
-                onChange={e => setMonitorLatestCount(Math.max(1, Number(e.target.value) || 1))}
+                onChange={e => {
+                  setMonitorLatestCount(Math.max(1, Number(e.target.value) || 1))
+                  setMonitorOptionsChanged(true)
+                }}
                 className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
               />
             </div>

--- a/web/src/components/EditAuthorModal.test.tsx
+++ b/web/src/components/EditAuthorModal.test.tsx
@@ -67,13 +67,13 @@ describe('EditAuthorModal', () => {
   })
 
   async function getSelects() {
-    // Wait for profiles to load — once they do all four selects render
-    // (quality, metadata, ebook root folder, audiobook root folder).
+    // Wait for profiles to load — once they do all five selects render
+    // (quality, metadata, ebook root folder, audiobook root folder, monitor mode).
     await screen.findByRole('option', { name: 'Any' })
     const selects = screen.getAllByRole('combobox') as HTMLSelectElement[]
-    expect(selects).toHaveLength(4)
-    const [quality, metadata, root, audiobookRoot] = selects
-    return { quality, metadata, root, audiobookRoot }
+    expect(selects).toHaveLength(5)
+    const [quality, metadata, root, audiobookRoot, monitorMode] = selects
+    return { quality, metadata, root, audiobookRoot, monitorMode }
   }
 
   it('opens with the current author values prefilled', async () => {
@@ -101,6 +101,25 @@ describe('EditAuthorModal', () => {
     expect('rootFolderId' in callArg).toBe(false)
     expect('audiobookRootFolderId' in callArg).toBe(false)
     expect('clearAudiobookRootFolder' in callArg).toBe(false)
+    expect('monitorMode' in callArg).toBe(false)
+    expect('applyMonitorModeToExisting' in callArg).toBe(false)
+  })
+
+  it('sends monitor mode fields and the apply flag when selected', async () => {
+    render(<EditAuthorModal author={baseAuthor} onClose={onClose} onSaved={onSaved} />)
+
+    const { monitorMode } = await getSelects()
+    fireEvent.change(monitorMode, { target: { value: 'latest' } })
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '3' } })
+    fireEvent.click(screen.getByRole('checkbox', { name: /apply monitor mode to existing books/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(api.updateAuthor).toHaveBeenCalledTimes(1))
+    expect(api.updateAuthor).toHaveBeenCalledWith(42, {
+      monitorMode: 'latest',
+      monitorLatestCount: 3,
+      applyMonitorModeToExisting: true,
+    })
   })
 
   it('prefills the audiobook root folder and sends it when changed', async () => {

--- a/web/src/components/EditAuthorModal.tsx
+++ b/web/src/components/EditAuthorModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, Author, MetadataProfile, QualityProfile, RootFolder, UpdateAuthorRequest } from '../api/client'
+import { api, Author, AuthorMonitorMode, MetadataProfile, QualityProfile, RootFolder, UpdateAuthorRequest } from '../api/client'
 
 interface Props {
   author: Author
@@ -19,6 +19,9 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
   const [metadataProfileId, setMetadataProfileId] = useState<number | null>(author.metadataProfileId ?? null)
   const [rootFolderId, setRootFolderId] = useState<number | null>(author.rootFolderId ?? null)
   const [audiobookRootFolderId, setAudiobookRootFolderId] = useState<number | null>(author.audiobookRootFolderId ?? null)
+  const [monitorMode, setMonitorMode] = useState<AuthorMonitorMode>(author.monitorMode ?? 'all')
+  const [monitorLatestCount, setMonitorLatestCount] = useState(author.monitorLatestCount ?? 1)
+  const [applyMonitorModeToExisting, setApplyMonitorModeToExisting] = useState(false)
 
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -63,6 +66,15 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
       } else {
         patch.audiobookRootFolderId = audiobookRootFolderId
       }
+    }
+    if (monitorMode !== (author.monitorMode ?? 'all')) {
+      patch.monitorMode = monitorMode
+    }
+    if (monitorLatestCount !== (author.monitorLatestCount ?? 1)) {
+      patch.monitorLatestCount = monitorLatestCount
+    }
+    if (applyMonitorModeToExisting) {
+      patch.applyMonitorModeToExisting = true
     }
 
     if (Object.keys(patch).length === 0) {
@@ -154,6 +166,43 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
                   <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('editAuthorModal.audiobookRootFolderHint', "Where this author's audiobooks are stored. Separate from the ebook root folder.")}</p>
                 </div>
               )}
+              <div className="mb-3">
+                <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('editAuthorModal.monitorMode', 'Monitor mode')}</label>
+                <select
+                  value={monitorMode}
+                  onChange={e => setMonitorMode(e.target.value as AuthorMonitorMode)}
+                  className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+                >
+                  <option value="all">{t('monitorMode.all', 'All books')}</option>
+                  <option value="future">{t('monitorMode.future', 'Future books only')}</option>
+                  <option value="latest">{t('monitorMode.latest', 'Latest only')}</option>
+                  <option value="none">{t('monitorMode.none', 'None')}</option>
+                </select>
+              </div>
+              {monitorMode === 'latest' && (
+                <div className="mb-3">
+                  <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('editAuthorModal.monitorLatestCount', 'Latest book count')}</label>
+                  <input
+                    type="number"
+                    min={1}
+                    value={monitorLatestCount}
+                    onChange={e => setMonitorLatestCount(Math.max(1, Number(e.target.value) || 1))}
+                    className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+                  />
+                </div>
+              )}
+              <label className="flex items-start gap-2 text-sm mb-3 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={applyMonitorModeToExisting}
+                  onChange={e => setApplyMonitorModeToExisting(e.target.checked)}
+                  className="accent-emerald-500 mt-0.5 flex-shrink-0"
+                />
+                <span>
+                  <span className="font-medium">{t('editAuthorModal.applyMonitorModeToExisting', 'Apply monitor mode to existing books')}</span>
+                  <span className="block text-xs text-slate-600 dark:text-zinc-400 mt-0.5">{t('editAuthorModal.applyMonitorModeToExistingHint', 'Otherwise this only affects books discovered in future refreshes.')}</span>
+                </span>
+              </label>
               {error && (
                 <p className="text-sm text-red-600 dark:text-red-400 mt-2">{error}</p>
               )}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -33,6 +33,12 @@
     "prev": "Prev",
     "next": "Next"
   },
+  "monitorMode": {
+    "all": "All books",
+    "future": "Future books only",
+    "latest": "Latest only",
+    "none": "None"
+  },
   "nav": {
     "authors": "Authors",
     "books": "Books",
@@ -481,6 +487,8 @@
     "title": "Add Author",
     "metadataProfile": "Metadata profile",
     "rootFolder": "Root folder",
+    "monitorMode": "Monitor mode",
+    "monitorLatestCount": "Latest book count",
     "autoGrabLabel": "Auto-grab books on add",
     "autoGrabHint": "Bindery will always fetch the book catalogue. Enable this to also queue downloads immediately.",
     "searchPlaceholder": "Search by author name...",

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -449,9 +449,18 @@ describe('SettingsPage', () => {
     expect(defaultLocation.getByRole('combobox')).toHaveValue('8')
 
     const authorDefaults = sectionForHeading('Author defaults')
-    fireEvent.change(authorDefaults.getByRole('combobox'), { target: { value: 'audiobook' } })
+    const authorDefaultSelects = authorDefaults.getAllByRole('combobox')
+    fireEvent.change(authorDefaultSelects[0], { target: { value: 'audiobook' } })
     await waitFor(() => {
       expect(api.setSetting).toHaveBeenCalledWith('default.media_type', 'audiobook')
+    })
+    fireEvent.change(authorDefaultSelects[1], { target: { value: 'latest' } })
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('author.default_monitor_mode', 'latest')
+    })
+    fireEvent.change(authorDefaults.getByRole('spinbutton'), { target: { value: '3' } })
+    await waitFor(() => {
+      expect(api.setSetting).toHaveBeenCalledWith('author.default_monitor_latest_count', '3')
     })
   })
 

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, AuthConfig, AuthStatus, HardcoverTestResult, RootFolder, SystemStatus } from '../../api/client'
+import { api, AuthConfig, AuthStatus, AuthorMonitorMode, HardcoverTestResult, RootFolder, SystemStatus } from '../../api/client'
 import AuthSettings from '../../settings/AuthSettings'
 import ThemeToggle from '../../components/ThemeToggle'
 import LanguageSwitcher from '../../components/LanguageSwitcher'
@@ -27,6 +27,10 @@ function formatRelativeTime(iso: string): string {
   if (Math.abs(hrs) < 24) return hrs >= 0 ? `${hrs}h ago` : `in ${-hrs}h`
   const days = Math.round(diffSec / 86400)
   return days >= 0 ? `${days}d ago` : `in ${-days}d`
+}
+
+function isAuthorMonitorMode(value: string): value is AuthorMonitorMode {
+  return value === 'all' || value === 'future' || value === 'latest' || value === 'none'
 }
 
 export default function GeneralTab() {
@@ -583,26 +587,70 @@ export default function GeneralTab() {
       {/* Author defaults */}
       <section>
         <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.authorDefaults', 'Author defaults')}</h3>
-        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
-          <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200 mb-1">
-            {t('settings.general.defaultMediaTypeLabel', 'Default media type')}
-          </label>
-          <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
-            {t('settings.general.defaultMediaTypeHint', 'Applied to new authors when no explicit choice is made. Existing authors are unaffected — use the Authors page bulk action to migrate them.')}
-          </p>
-          <select
-            value={settings['default.media_type'] ?? 'ebook'}
-            onChange={async e => {
-              const next = e.target.value
-              setSettings(s => ({ ...s, 'default.media_type': next }))
-              await api.setSetting('default.media_type', next).catch(console.error)
-            }}
-            className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
-          >
-            <option value="ebook">{t('mediaType.ebook', 'Ebook')}</option>
-            <option value="audiobook">{t('mediaType.audiobook', 'Audiobook')}</option>
-            <option value="both">{t('mediaType.both', 'Both')}</option>
-          </select>
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200 mb-1">
+              {t('settings.general.defaultMediaTypeLabel', 'Default media type')}
+            </label>
+            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
+              {t('settings.general.defaultMediaTypeHint', 'Applied to new authors when no explicit choice is made. Existing authors are unaffected — use the Authors page bulk action to migrate them.')}
+            </p>
+            <select
+              value={settings['default.media_type'] ?? 'ebook'}
+              onChange={async e => {
+                const next = e.target.value
+                setSettings(s => ({ ...s, 'default.media_type': next }))
+                await api.setSetting('default.media_type', next).catch(console.error)
+              }}
+              className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+            >
+              <option value="ebook">{t('mediaType.ebook', 'Ebook')}</option>
+              <option value="audiobook">{t('mediaType.audiobook', 'Audiobook')}</option>
+              <option value="both">{t('mediaType.both', 'Both')}</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200 mb-1">
+              {t('settings.general.defaultMonitorModeLabel', 'Default monitor mode')}
+            </label>
+            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
+              {t('settings.general.defaultMonitorModeHint', 'Applied to newly added authors. Existing authors keep their current mode unless edited.')}
+            </p>
+            <select
+              value={isAuthorMonitorMode(settings['author.default_monitor_mode'] ?? '') ? settings['author.default_monitor_mode'] : 'all'}
+              onChange={async e => {
+                const next = e.target.value as AuthorMonitorMode
+                setSettings(s => ({ ...s, 'author.default_monitor_mode': next }))
+                await api.setSetting('author.default_monitor_mode', next).catch(console.error)
+              }}
+              className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+            >
+              <option value="all">{t('monitorMode.all', 'All books')}</option>
+              <option value="future">{t('monitorMode.future', 'Future books only')}</option>
+              <option value="latest">{t('monitorMode.latest', 'Latest only')}</option>
+              <option value="none">{t('monitorMode.none', 'None')}</option>
+            </select>
+          </div>
+          {(settings['author.default_monitor_mode'] ?? 'all') === 'latest' && (
+            <div>
+              <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200 mb-1">
+                {t('settings.general.defaultMonitorLatestCountLabel', 'Latest book count')}
+              </label>
+              <input
+                type="number"
+                min={1}
+                value={settings['author.default_monitor_latest_count'] ?? '1'}
+                onChange={async e => {
+                  const next = e.target.value
+                  setSettings(s => ({ ...s, 'author.default_monitor_latest_count': next }))
+                  if (/^[1-9]\d*$/.test(next)) {
+                    await api.setSetting('author.default_monitor_latest_count', next).catch(console.error)
+                  }
+                }}
+                className="w-28 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+              />
+            </div>
+          )}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Adds configurable author monitor modes so users can add or edit authors without automatically monitoring every back-catalogue title. This closes the primary author-level workflow requested in #792 while leaving per-series monitoring as a separate follow-up request. Closes #792.

- Adds per-author monitor mode fields for all books, future books only, latest N books, and none, including migration defaults that preserve existing behaviour.
- Applies monitor modes when author works are fetched, avoids auto-searching books that the selected mode leaves unmonitored, and supports applying an edited mode to existing books.
- Adds settings/API validation for global author monitor defaults and wires the add/edit author UI to those defaults.
- Documents the feature in `README.md`.

## Follow-ups (not in this PR)

Per-series monitor selection is intentionally deferred and should be tracked in a separate feature request.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed - N/A, no deployment/config/upgrade change
- [ ] `CHANGELOG.md` `[Unreleased]` section updated - N/A, release-time only per `AGENTS.md`
- [x] Wiki pages updated if user-facing behaviour changed - README feature surface updated and no author-monitor wiki page exists

## Test plan

- [x] `gofmt -l internal/api/authors.go internal/api/authors_test.go internal/api/settings_handler.go internal/api/settings_handler_test.go internal/db/authors.go internal/db/authors_test.go internal/models/author.go`
- [x] `go vet ./...`
- [x] `golangci-lint run --timeout=5m` with repo-pinned v2.11.4
- [x] `govulncheck ./...`
- [x] `go test ./cmd/... ./internal/...`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run typecheck`
- [x] `cd web && npm run build`
- [x] `cd web && npm test`
