### PR TITLE
fix(abs): reconcile stale review items and add per-run bulk dismiss (#767)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -506,7 +506,7 @@ func main() {
 	absImportHandler := api.NewABSImportHandler(absImporter, func(ctx context.Context) api.ABSStoredConfig {
 		return api.LoadABSConfig(ctx, settingsRepo)
 	})
-	absReviewHandler := api.NewABSReviewHandler(absReviewRepo, absImporter, func(ctx context.Context) api.ABSStoredConfig {
+	absReviewHandler := api.NewABSReviewHandler(absReviewRepo, absImportRunRepo, absImporter, func(ctx context.Context) api.ABSStoredConfig {
 		return api.LoadABSConfig(ctx, settingsRepo)
 	})
 	calibreImportHandler := api.NewCalibreImportHandler(calibreImporter, func() calibre.Config {
@@ -764,6 +764,7 @@ func main() {
 			r.Post("/abs/review/{id}/resolve-author", absReviewHandler.ResolveAuthor)
 			r.Post("/abs/review/{id}/resolve-book", absReviewHandler.ResolveBook)
 			r.Post("/abs/review/{id}/dismiss", absReviewHandler.Dismiss)
+			r.Post("/abs/review/dismiss-run/{runID}", absReviewHandler.DismissRun)
 			r.Get("/abs/conflicts", absConflictHandler.List)
 			r.Post("/abs/conflicts/{id}/resolve", absConflictHandler.Resolve)
 		})

--- a/internal/abs/importer.go
+++ b/internal/abs/importer.go
@@ -375,6 +375,7 @@ func (i *Importer) runLibrary(ctx context.Context, cfg ImportConfig, authorMatch
 		return diffImportStats(before, totalStats), err
 	}
 
+	var matchedItemIDs []string
 	enumStats, err := enumFn(ctx, cfg.LibraryID, func(ctx context.Context, item NormalizedLibraryItem) error {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -383,6 +384,9 @@ func (i *Importer) runLibrary(ctx context.Context, cfg ImportConfig, authorMatch
 			p.Message = importItemMessage(cfg.DryRun, firstNonEmpty(item.Title, item.ItemID))
 		})
 		result := i.importOne(ctx, cfg, run.ID, item, totalStats, allowImmediateImport(item), authorMatcher)
+		if isMatchedOutcome(result.Outcome) {
+			matchedItemIDs = append(matchedItemIDs, item.ItemID)
+		}
 		i.setProgress(func(p *ImportProgress) {
 			p.Processed++
 			p.Results = appendImportProgressResult(p.Results, result)
@@ -410,6 +414,18 @@ func (i *Importer) runLibrary(ctx context.Context, cfg ImportConfig, authorMatch
 	summary.Checkpoint = nil
 	libStats := diffImportStats(before, totalStats)
 	summary.Stats = *libStats
+	if !cfg.DryRun && i.reviews != nil && len(matchedItemIDs) > 0 {
+		// A book that previously fell into the no-match review queue can be
+		// matched on a later rescan once the user fixes its ABS metadata
+		// (e.g. adds an ISBN). Without this reconcile the old pending row
+		// lingers forever alongside genuine no-matches — see issue #767.
+		resolved, err := i.reviews.MarkResolvedByItemIDs(ctx, cfg.SourceID, cfg.LibraryID, matchedItemIDs)
+		if err != nil {
+			slog.Warn("abs import: auto-reconcile review items failed", "runID", run.ID, "libraryID", cfg.LibraryID, "error", err)
+		} else if resolved > 0 {
+			slog.Info("abs import: auto-reconciled stale review items", "runID", run.ID, "libraryID", cfg.LibraryID, "resolved", resolved)
+		}
+	}
 	if run.ID != 0 && i.runs != nil {
 		if err := i.runs.Finish(ctx, run.ID, runStatusCompleted, summary); err != nil {
 			slog.Warn("abs import: finish run failed", "runID", run.ID, "error", err)
@@ -430,6 +446,15 @@ func (i *Importer) runLibrary(ctx context.Context, cfg ImportConfig, authorMatch
 		"skipped", libStats.Skipped,
 		"failed", libStats.Failed)
 	return libStats, nil
+}
+
+func isMatchedOutcome(outcome string) bool {
+	switch outcome {
+	case itemOutcomeCreated, itemOutcomeLinked, itemOutcomeUpdated:
+		return true
+	default:
+		return false
+	}
 }
 
 func libraryStartIndex(libraryIDs []string, current string) int {

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -4475,6 +4475,104 @@ func TestImporter_RollbackSkipsSnapshotWhenProvenanceLocalChanged(t *testing.T) 
 	}
 }
 
+// TestImporter_AutoReconcilesStaleReviewItemsOnRescan covers issue #767: a
+// previously-no-match book that becomes matchable on a later rescan must have
+// its old pending review row reconciled, not left to rot in the queue next to
+// genuine no-matches.
+func TestImporter_AutoReconcilesStaleReviewItemsOnRescan(t *testing.T) {
+	t.Parallel()
+
+	importer, _, _, _, _, _, _, _, reviewRepo, _ := newABSImporterFixture(t)
+	ctx := context.Background()
+	const libraryID = "lib-books"
+	const itemID = "li-stale-review"
+
+	// Seed a pre-existing pending review item (no match on the first run) so
+	// we can prove the reconcile flips it back out of the queue on rescan.
+	stale := int64(0)
+	if err := reviewRepo.UpsertPending(ctx, &models.ABSReviewItem{
+		SourceID:      DefaultSourceID,
+		LibraryID:     libraryID,
+		ItemID:        itemID,
+		Title:         "Stale",
+		PrimaryAuthor: "Author",
+		MediaType:     models.MediaTypeAudiobook,
+		ReviewReason:  reviewReasonUnmatchedBook,
+		PayloadJSON:   `{}`,
+		Status:        "pending",
+		LatestRunID:   &stale,
+	}); err != nil {
+		t.Fatalf("seed UpsertPending: %v", err)
+	}
+	// Untouched-by-this-run row stays pending — proves we scope by item id.
+	if err := reviewRepo.UpsertPending(ctx, &models.ABSReviewItem{
+		SourceID:      DefaultSourceID,
+		LibraryID:     libraryID,
+		ItemID:        "li-other",
+		Title:         "Other",
+		PrimaryAuthor: "Author",
+		MediaType:     models.MediaTypeAudiobook,
+		ReviewReason:  reviewReasonUnmatchedBook,
+		PayloadJSON:   `{}`,
+		Status:        "pending",
+	}); err != nil {
+		t.Fatalf("seed unrelated UpsertPending: %v", err)
+	}
+	// User-dismissed row must not be re-touched.
+	if err := reviewRepo.UpsertPending(ctx, &models.ABSReviewItem{
+		SourceID:      DefaultSourceID,
+		LibraryID:     libraryID,
+		ItemID:        "li-user-dismissed",
+		Title:         "Dismissed",
+		PrimaryAuthor: "Author",
+		MediaType:     models.MediaTypeAudiobook,
+		ReviewReason:  reviewReasonUnmatchedBook,
+		PayloadJSON:   `{}`,
+		Status:        "pending",
+	}); err != nil {
+		t.Fatalf("seed dismissed UpsertPending: %v", err)
+	}
+	dismissedItems, err := reviewRepo.ListByStatus(ctx, "pending")
+	if err != nil {
+		t.Fatalf("ListByStatus: %v", err)
+	}
+	var dismissedID int64
+	for _, item := range dismissedItems {
+		if item.ItemID == "li-user-dismissed" {
+			dismissedID = item.ID
+			break
+		}
+	}
+	if dismissedID == 0 {
+		t.Fatal("could not find seeded dismissed-target row")
+	}
+	if err := reviewRepo.UpdateStatus(ctx, dismissedID, "dismissed"); err != nil {
+		t.Fatalf("UpdateStatus dismissed: %v", err)
+	}
+
+	// Now rescan with a matchable normalized item — the same ItemID the
+	// pending review row references — and confirm it gets reconciled.
+	item := sampleABSItem()
+	item.LibraryID = libraryID
+	item.ItemID = itemID
+	runSingleABSImport(t, importer, item)
+
+	pending, err := reviewRepo.ListByStatus(ctx, "pending")
+	if err != nil {
+		t.Fatalf("ListByStatus pending: %v", err)
+	}
+	if len(pending) != 1 || pending[0].ItemID != "li-other" {
+		t.Fatalf("pending after rescan = %+v, want only li-other left", pending)
+	}
+	dismissed, err := reviewRepo.ListByStatus(ctx, "dismissed")
+	if err != nil {
+		t.Fatalf("ListByStatus dismissed: %v", err)
+	}
+	if len(dismissed) != 2 {
+		t.Fatalf("dismissed after rescan = %d, want auto-reconciled + manual dismiss totalling 2", len(dismissed))
+	}
+}
+
 func TestImporter_Rollback_NilReposAreSafe(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/abs_review.go
+++ b/internal/api/abs_review.go
@@ -21,6 +21,7 @@ type absReviewImporter interface {
 
 type ABSReviewHandler struct {
 	reviews  *db.ABSReviewItemRepo
+	runs     *db.ABSImportRunRepo
 	importer absReviewImporter
 	loadCfg  func(context.Context) ABSStoredConfig
 }
@@ -32,8 +33,8 @@ type absReviewListResponse struct {
 	Offset int                    `json:"offset"`
 }
 
-func NewABSReviewHandler(reviews *db.ABSReviewItemRepo, importer absReviewImporter, loadCfg func(context.Context) ABSStoredConfig) *ABSReviewHandler {
-	return &ABSReviewHandler{reviews: reviews, importer: importer, loadCfg: loadCfg}
+func NewABSReviewHandler(reviews *db.ABSReviewItemRepo, runs *db.ABSImportRunRepo, importer absReviewImporter, loadCfg func(context.Context) ABSStoredConfig) *ABSReviewHandler {
+	return &ABSReviewHandler{reviews: reviews, runs: runs, importer: importer, loadCfg: loadCfg}
 }
 
 func (h *ABSReviewHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -217,6 +218,36 @@ func (h *ABSReviewHandler) Dismiss(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, updated)
+}
+
+func (h *ABSReviewHandler) DismissRun(w http.ResponseWriter, r *http.Request) {
+	raw := strings.TrimSpace(chi.URLParam(r, "runID"))
+	if raw == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "run id is required"})
+		return
+	}
+	runID, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || runID <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid run id"})
+		return
+	}
+	if h.runs != nil {
+		run, err := h.runs.GetByID(r.Context(), runID)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		if run == nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "import run not found"})
+			return
+		}
+	}
+	dismissed, err := h.reviews.DismissByRunID(r.Context(), runID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]int64{"dismissed": dismissed})
 }
 
 func (h *ABSReviewHandler) reviewItemFromRequest(r *http.Request) (*models.ABSReviewItem, error) {

--- a/internal/api/abs_review_test.go
+++ b/internal/api/abs_review_test.go
@@ -43,7 +43,7 @@ func absReviewFixture(t *testing.T) (*sql.DB, *ABSReviewHandler, *db.ABSReviewIt
 	t.Cleanup(func() { _ = database.Close() })
 	database.SetMaxOpenConns(1)
 	reviews := db.NewABSReviewItemRepo(database)
-	h := NewABSReviewHandler(reviews, &stubABSReviewImporter{}, func(context.Context) ABSStoredConfig { return ABSStoredConfig{} })
+	h := NewABSReviewHandler(reviews, db.NewABSImportRunRepo(database), &stubABSReviewImporter{}, func(context.Context) ABSStoredConfig { return ABSStoredConfig{} })
 	return database, h, reviews
 }
 
@@ -184,7 +184,7 @@ func TestABSReviewHandler_Approve(t *testing.T) {
 	importer := &stubABSReviewImporter{}
 	type ctxKey struct{}
 	key := ctxKey{}
-	h := NewABSReviewHandler(reviews, importer, func(ctx context.Context) ABSStoredConfig {
+	h := NewABSReviewHandler(reviews, db.NewABSImportRunRepo(database), importer, func(ctx context.Context) ABSStoredConfig {
 		if ctx.Value(key) != "request" {
 			t.Fatalf("load config context value = %v, want request", ctx.Value(key))
 		}
@@ -241,7 +241,7 @@ func TestABSReviewHandler_ResolveAuthorGroupsByPrimaryAuthor(t *testing.T) {
 		}
 	}
 
-	h := NewABSReviewHandler(reviews, &stubABSReviewImporter{}, func(context.Context) ABSStoredConfig { return ABSStoredConfig{} })
+	h := NewABSReviewHandler(reviews, db.NewABSImportRunRepo(database), &stubABSReviewImporter{}, func(context.Context) ABSStoredConfig { return ABSStoredConfig{} })
 	body := bytes.NewBufferString(`{"foreignAuthorId":"OL123A","authorName":"Brandon Sanderson","applyTo":"same_author"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/abs/review/1/resolve-author", body)
 	rctx := chi.NewRouteContext()
@@ -299,7 +299,7 @@ func TestABSReviewHandler_ResolveBookStoresEditedTitle(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	h := NewABSReviewHandler(reviews, &stubABSReviewImporter{}, func(context.Context) ABSStoredConfig { return ABSStoredConfig{} })
+	h := NewABSReviewHandler(reviews, db.NewABSImportRunRepo(database), &stubABSReviewImporter{}, func(context.Context) ABSStoredConfig { return ABSStoredConfig{} })
 	body := bytes.NewBufferString(`{"foreignBookId":"OL456W","title":"The Bands of Mourning","editedTitle":"The Bands of Mourning"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/abs/review/1/resolve-book", body)
 	rctx := chi.NewRouteContext()
@@ -344,7 +344,7 @@ func TestABSReviewHandler_Dismiss(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := NewABSReviewHandler(reviews, &stubABSReviewImporter{}, func(context.Context) ABSStoredConfig { return ABSStoredConfig{} })
+	h := NewABSReviewHandler(reviews, db.NewABSImportRunRepo(database), &stubABSReviewImporter{}, func(context.Context) ABSStoredConfig { return ABSStoredConfig{} })
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/abs/review/1/dismiss", bytes.NewReader(nil))
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("id", "1")
@@ -362,5 +362,124 @@ func TestABSReviewHandler_Dismiss(t *testing.T) {
 	}
 	if updated == nil || updated.Status != "dismissed" {
 		t.Fatalf("updated review = %+v, want dismissed", updated)
+	}
+}
+
+func TestABSReviewHandler_DismissRunHappyPath(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	runs := db.NewABSImportRunRepo(database)
+	run := &models.ABSImportRun{SourceID: abs.DefaultSourceID, Status: "completed"}
+	if err := runs.Create(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	otherRun := &models.ABSImportRun{SourceID: abs.DefaultSourceID, Status: "completed"}
+	if err := runs.Create(context.Background(), otherRun); err != nil {
+		t.Fatal(err)
+	}
+
+	reviews := db.NewABSReviewItemRepo(database)
+	for i, runID := range []int64{run.ID, run.ID, otherRun.ID} {
+		item := &models.ABSReviewItem{
+			SourceID:      abs.DefaultSourceID,
+			LibraryID:     "lib-books",
+			ItemID:        "item-" + strconv.Itoa(i+1),
+			Title:         "Title",
+			PrimaryAuthor: "Author",
+			MediaType:     models.MediaTypeAudiobook,
+			ReviewReason:  "unmatched_book",
+			PayloadJSON:   `{}`,
+			Status:        "pending",
+			LatestRunID:   &runID,
+		}
+		if err := reviews.UpsertPending(context.Background(), item); err != nil {
+			t.Fatal(err)
+		}
+		// UpsertPending only honours LatestRunID via INSERT, so reapply it
+		// for the second-and-later rows that conflict.
+		if _, err := database.ExecContext(context.Background(),
+			`UPDATE abs_review_queue SET latest_run_id = ? WHERE item_id = ?`, runID, item.ItemID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	h := NewABSReviewHandler(reviews, runs, &stubABSReviewImporter{}, func(context.Context) ABSStoredConfig { return ABSStoredConfig{} })
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/abs/review/dismiss-run/"+strconv.FormatInt(run.ID, 10), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("runID", strconv.FormatInt(run.ID, 10))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	h.DismissRun(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]int64
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["dismissed"] != 2 {
+		t.Fatalf("dismissed = %d, want 2", body["dismissed"])
+	}
+	pending, err := reviews.ListByStatus(context.Background(), "pending")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0].ItemID != "item-3" {
+		t.Fatalf("pending = %+v, want only item-3 (other run) left pending", pending)
+	}
+}
+
+func TestABSReviewHandler_DismissRunUnknownRun404(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	reviews := db.NewABSReviewItemRepo(database)
+	runs := db.NewABSImportRunRepo(database)
+	h := NewABSReviewHandler(reviews, runs, &stubABSReviewImporter{}, func(context.Context) ABSStoredConfig { return ABSStoredConfig{} })
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/abs/review/dismiss-run/9999", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("runID", "9999")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	h.DismissRun(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestABSReviewHandler_DismissRunInvalidID(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	reviews := db.NewABSReviewItemRepo(database)
+	runs := db.NewABSImportRunRepo(database)
+	h := NewABSReviewHandler(reviews, runs, &stubABSReviewImporter{}, func(context.Context) ABSStoredConfig { return ABSStoredConfig{} })
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/abs/review/dismiss-run/abc", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("runID", "abc")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	h.DismissRun(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
 }

--- a/internal/db/abs_imports.go
+++ b/internal/db/abs_imports.go
@@ -694,6 +694,76 @@ func (r *ABSReviewItemRepo) UpdateStatus(ctx context.Context, id int64, status s
 	return nil
 }
 
+// MarkResolvedByItemIDs flips pending review items for the given
+// (sourceID, libraryID, itemID) tuples to dismissed. Items that have already
+// left pending state (approved, dismissed) are left untouched so a previous
+// user decision is never overwritten by a later auto-reconcile pass.
+func (r *ABSReviewItemRepo) MarkResolvedByItemIDs(ctx context.Context, sourceID, libraryID string, itemIDs []string) (int64, error) {
+	if len(itemIDs) == 0 {
+		return 0, nil
+	}
+	sourceID = strings.TrimSpace(sourceID)
+	libraryID = strings.TrimSpace(libraryID)
+	if sourceID == "" || libraryID == "" {
+		return 0, nil
+	}
+	placeholders := make([]string, 0, len(itemIDs))
+	args := make([]any, 0, len(itemIDs)+3)
+	now := time.Now().UTC()
+	args = append(args, now, sourceID, libraryID)
+	for _, id := range itemIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		placeholders = append(placeholders, "?")
+		args = append(args, id)
+	}
+	if len(placeholders) == 0 {
+		return 0, nil
+	}
+	//nolint:gosec // placeholders are a fixed-length list of "?" controlled here, real values bound via args
+	query := fmt.Sprintf(`
+		UPDATE abs_review_queue
+		SET status = 'dismissed', updated_at = ?
+		WHERE status = 'pending'
+		  AND source_id = ?
+		  AND library_id = ?
+		  AND item_id IN (%s)`, strings.Join(placeholders, ","))
+	result, err := r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("auto-resolve abs review items: %w", err)
+	}
+	count, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count auto-resolved abs review items: %w", err)
+	}
+	return count, nil
+}
+
+// DismissByRunID flips every pending review item whose latest_run_id matches
+// runID to dismissed in a single statement. Returns the number of rows
+// affected so the caller can report it to the user.
+func (r *ABSReviewItemRepo) DismissByRunID(ctx context.Context, runID int64) (int64, error) {
+	if runID <= 0 {
+		return 0, nil
+	}
+	now := time.Now().UTC()
+	result, err := r.db.ExecContext(ctx, `
+		UPDATE abs_review_queue
+		SET status = 'dismissed', updated_at = ?
+		WHERE status = 'pending'
+		  AND latest_run_id = ?`, now, runID)
+	if err != nil {
+		return 0, fmt.Errorf("dismiss abs review items for run %d: %w", runID, err)
+	}
+	count, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count dismissed abs review items for run %d: %w", runID, err)
+	}
+	return count, nil
+}
+
 type absReviewItemRowScanner interface {
 	Scan(dest ...any) error
 }

--- a/internal/db/abs_imports.go
+++ b/internal/db/abs_imports.go
@@ -722,7 +722,7 @@ func (r *ABSReviewItemRepo) MarkResolvedByItemIDs(ctx context.Context, sourceID,
 	if len(placeholders) == 0 {
 		return 0, nil
 	}
-	//nolint:gosec // placeholders are a fixed-length list of "?" controlled here, real values bound via args
+	// #nosec G201 -- placeholders is a fixed-length slice of "?" controlled here; real values are bound via args.
 	query := fmt.Sprintf(`
 		UPDATE abs_review_queue
 		SET status = 'dismissed', updated_at = ?

--- a/internal/db/abs_imports_test.go
+++ b/internal/db/abs_imports_test.go
@@ -264,3 +264,109 @@ func TestABSImportRunRepoLatestRunningWithCheckpoint(t *testing.T) {
 		t.Fatalf("checkpoint_json = %q, want page 2", got.CheckpointJSON)
 	}
 }
+
+func TestABSReviewItemRepoMarkResolvedByItemIDs(t *testing.T) {
+	t.Parallel()
+
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	repo := NewABSReviewItemRepo(database)
+
+	for _, item := range []models.ABSReviewItem{
+		{SourceID: "default", LibraryID: "lib-books", ItemID: "it-1", Title: "A", PrimaryAuthor: "X", PayloadJSON: "{}", ReviewReason: "unmatched_book"},
+		{SourceID: "default", LibraryID: "lib-books", ItemID: "it-2", Title: "B", PrimaryAuthor: "X", PayloadJSON: "{}", ReviewReason: "unmatched_book"},
+		{SourceID: "default", LibraryID: "lib-books", ItemID: "it-3", Title: "C", PrimaryAuthor: "X", PayloadJSON: "{}", ReviewReason: "unmatched_book"},
+		{SourceID: "default", LibraryID: "lib-other", ItemID: "it-1", Title: "D", PrimaryAuthor: "X", PayloadJSON: "{}", ReviewReason: "unmatched_book"},
+	} {
+		item := item
+		if err := repo.UpsertPending(ctx, &item); err != nil {
+			t.Fatalf("UpsertPending: %v", err)
+		}
+	}
+
+	// Manually dismiss it-2 to confirm we never touch non-pending rows.
+	if _, err := database.ExecContext(ctx, `UPDATE abs_review_queue SET status = 'dismissed' WHERE item_id = 'it-2' AND library_id = 'lib-books'`); err != nil {
+		t.Fatalf("manual dismiss: %v", err)
+	}
+
+	count, err := repo.MarkResolvedByItemIDs(ctx, "default", "lib-books", []string{"it-1", "it-2", "it-3", ""})
+	if err != nil {
+		t.Fatalf("MarkResolvedByItemIDs: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("count = %d, want 2 (it-1 and it-3 in lib-books only; it-2 already dismissed)", count)
+	}
+
+	// Empty ID slice is a no-op, no error.
+	count, err = repo.MarkResolvedByItemIDs(ctx, "default", "lib-books", nil)
+	if err != nil {
+		t.Fatalf("empty MarkResolvedByItemIDs: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("empty count = %d, want 0", count)
+	}
+
+	// Other library kept untouched.
+	pending, err := repo.ListByStatus(ctx, "pending")
+	if err != nil {
+		t.Fatalf("ListByStatus: %v", err)
+	}
+	if len(pending) != 1 || pending[0].LibraryID != "lib-other" {
+		t.Fatalf("pending = %+v, want only lib-other untouched", pending)
+	}
+}
+
+func TestABSReviewItemRepoDismissByRunID(t *testing.T) {
+	t.Parallel()
+
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	repo := NewABSReviewItemRepo(database)
+
+	for i, runID := range []int64{1, 1, 2, 0} {
+		item := &models.ABSReviewItem{
+			SourceID:      "default",
+			LibraryID:     "lib-books",
+			ItemID:        "it-" + string(rune('a'+i)),
+			PayloadJSON:   "{}",
+			ReviewReason:  "unmatched_book",
+			PrimaryAuthor: "X",
+		}
+		if runID != 0 {
+			rid := runID
+			item.LatestRunID = &rid
+		}
+		if err := repo.UpsertPending(ctx, item); err != nil {
+			t.Fatalf("UpsertPending: %v", err)
+		}
+		if runID != 0 {
+			if _, err := database.ExecContext(ctx, `UPDATE abs_review_queue SET latest_run_id = ? WHERE id = ?`, runID, item.ID); err != nil {
+				t.Fatalf("set latest_run_id: %v", err)
+			}
+		}
+	}
+
+	count, err := repo.DismissByRunID(ctx, 1)
+	if err != nil {
+		t.Fatalf("DismissByRunID: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("count = %d, want 2", count)
+	}
+	count, err = repo.DismissByRunID(ctx, 0)
+	if err != nil || count != 0 {
+		t.Fatalf("DismissByRunID(0) = %d err=%v, want 0/nil", count, err)
+	}
+	count, err = repo.DismissByRunID(ctx, 999)
+	if err != nil || count != 0 {
+		t.Fatalf("DismissByRunID(unknown) = %d err=%v, want 0/nil", count, err)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -460,6 +460,8 @@ export const api = {
   resolveAbsReviewBook: (id: number, data: { foreignBookId: string; title: string; editedTitle?: string }) =>
     request<ABSReviewItem>(`/abs/review/${id}/resolve-book`, { method: 'POST', body: JSON.stringify(data) }),
   dismissAbsReviewItem: (id: number) => request<ABSReviewItem>(`/abs/review/${id}/dismiss`, { method: 'POST' }),
+  dismissAbsReviewRun: (runId: number) =>
+    request<{ dismissed: number }>(`/abs/review/dismiss-run/${runId}`, { method: 'POST' }),
   absConflicts: (params?: { limit?: number; offset?: number }) => {
     const q = new URLSearchParams()
     if (params?.limit) q.set('limit', String(params.limit))

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -216,6 +216,15 @@
       "grimmory": "Grimmory",
       "blocklist": "Blockliste"
     },
+    "abs": {
+      "review": {
+        "runHeading": "Lauf #{{runId}} · {{count}} Einträge",
+        "unknownRunHeading": "Ältere Einträge · {{count}}",
+        "dismissRun": "Alle aus diesem Lauf verwerfen",
+        "dismissingRun": "Wird verworfen…",
+        "dismissRunConfirm": "{{count}} Prüfeinträge aus Lauf #{{runId}} verwerfen? Das kann nicht rückgängig gemacht werden."
+      }
+    },
     "indexers": {
       "heading": "Indexer",
       "addButton": "+ Indexer hinzufügen",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -247,6 +247,15 @@
       "grimmory": "Grimmory",
       "blocklist": "Blocklist"
     },
+    "abs": {
+      "review": {
+        "runHeading": "Run #{{runId}} · {{count}} items",
+        "unknownRunHeading": "Older items · {{count}}",
+        "dismissRun": "Dismiss all from this run",
+        "dismissingRun": "Dismissing…",
+        "dismissRunConfirm": "Dismiss {{count}} review items from run #{{runId}}? This cannot be undone."
+      }
+    },
     "indexers": {
       "heading": "Indexers",
       "addButton": "+ Add Indexer",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -235,6 +235,15 @@
       "grimmory": "Grimmory",
       "blocklist": "Lista de bloqueo"
     },
+    "abs": {
+      "review": {
+        "runHeading": "Ejecución n.º {{runId}} · {{count}} elementos",
+        "unknownRunHeading": "Elementos anteriores · {{count}}",
+        "dismissRun": "Descartar todos los de esta ejecución",
+        "dismissingRun": "Descartando…",
+        "dismissRunConfirm": "¿Descartar {{count}} elementos de revisión de la ejecución n.º {{runId}}? Esto no se puede deshacer."
+      }
+    },
     "indexers": {
       "heading": "Indexadores",
       "addButton": "+ Añadir indexador",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -216,6 +216,15 @@
       "grimmory": "Grimmory",
       "blocklist": "Liste de blocage"
     },
+    "abs": {
+      "review": {
+        "runHeading": "Exécution n°{{runId}} · {{count}} éléments",
+        "unknownRunHeading": "Anciens éléments · {{count}}",
+        "dismissRun": "Ignorer tous les éléments de cette exécution",
+        "dismissingRun": "Suppression…",
+        "dismissRunConfirm": "Ignorer {{count}} éléments de revue de l'exécution n°{{runId}} ? Cette action est irréversible."
+      }
+    },
     "indexers": {
       "heading": "Indexeurs",
       "addButton": "+ Ajouter un indexeur",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -235,6 +235,15 @@
       "grimmory": "Grimmory",
       "blocklist": "Daftar blokir"
     },
+    "abs": {
+      "review": {
+        "runHeading": "Jalankan #{{runId}} · {{count}} item",
+        "unknownRunHeading": "Item lama · {{count}}",
+        "dismissRun": "Tolak semua dari jalankan ini",
+        "dismissingRun": "Menolak…",
+        "dismissRunConfirm": "Tolak {{count}} item tinjauan dari jalankan #{{runId}}? Tindakan ini tidak dapat dibatalkan."
+      }
+    },
     "indexers": {
       "heading": "Indexer",
       "addButton": "+ Tambah Indexer",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -216,6 +216,15 @@
       "grimmory": "Grimmory",
       "blocklist": "Blokkeerlijst"
     },
+    "abs": {
+      "review": {
+        "runHeading": "Run #{{runId}} · {{count}} items",
+        "unknownRunHeading": "Oudere items · {{count}}",
+        "dismissRun": "Alles uit deze run negeren",
+        "dismissingRun": "Negeren…",
+        "dismissRunConfirm": "{{count}} reviewitems uit run #{{runId}} negeren? Dit kan niet ongedaan worden gemaakt."
+      }
+    },
     "indexers": {
       "heading": "Indexers",
       "addButton": "+ Indexer toevoegen",

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -235,6 +235,15 @@
       "grimmory": "Grimmory",
       "blocklist": "Blocklist"
     },
+    "abs": {
+      "review": {
+        "runHeading": "Run #{{runId}} · {{count}} items",
+        "unknownRunHeading": "Mga lumang item · {{count}}",
+        "dismissRun": "I-dismiss lahat sa run na ito",
+        "dismissingRun": "Ini-dismiss…",
+        "dismissRunConfirm": "I-dismiss ang {{count}} review item mula sa run #{{runId}}? Hindi ito mababawi."
+      }
+    },
     "indexers": {
       "heading": "Mga Indexer",
       "addButton": "+ Magdagdag ng Indexer",

--- a/web/src/pages/SettingsPage.absReview.test.tsx
+++ b/web/src/pages/SettingsPage.absReview.test.tsx
@@ -12,7 +12,26 @@ vi.mock('../auth/AuthContext', () => ({
 }))
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (_key: string, fallback?: string) => fallback ?? _key,
+    t: (key: string, fallbackOrOpts?: unknown, maybeOpts?: unknown) => {
+      let template: string | undefined
+      let opts: Record<string, unknown> | undefined
+      if (typeof fallbackOrOpts === 'string') {
+        template = fallbackOrOpts
+        opts = (maybeOpts as Record<string, unknown> | undefined) ?? undefined
+      } else if (fallbackOrOpts && typeof fallbackOrOpts === 'object') {
+        opts = fallbackOrOpts as Record<string, unknown>
+        const dv = opts.defaultValue
+        if (typeof dv === 'string') template = dv
+      }
+      let out = template ?? key
+      if (opts) {
+        for (const [k, v] of Object.entries(opts)) {
+          if (k === 'defaultValue') continue
+          out = out.replace(new RegExp(`\\{\\{${k}\\}\\}`, 'g'), String(v))
+        }
+      }
+      return out
+    },
     i18n: { changeLanguage: vi.fn() },
   }),
 }))
@@ -35,6 +54,7 @@ vi.mock('../api/client', async importOriginal => {
       absConflicts: vi.fn(),
       resolveAbsReviewAuthor: vi.fn(),
       resolveAbsReviewBook: vi.fn(),
+      dismissAbsReviewRun: vi.fn(),
       searchAuthors: vi.fn(),
       searchBooks: vi.fn(),
       listSettings: vi.fn(),
@@ -266,5 +286,44 @@ describe('SettingsPage ABS review search', () => {
       expect(api.resolveAbsReviewBook).toHaveBeenCalled()
     })
     expect(api.resolveAbsReviewAuthor).not.toHaveBeenCalled()
+  })
+
+  it('dismisses all review items from a run when the per-run button is confirmed', async () => {
+    const itemA = makeReviewItem({ id: 1, itemId: 'item-1', latestRunId: 42 })
+    const itemB = makeReviewItem({ id: 2, itemId: 'item-2', latestRunId: 42 })
+    const itemC = makeReviewItem({ id: 3, itemId: 'item-3', latestRunId: 99 })
+    vi.mocked(api.dismissAbsReviewRun).mockResolvedValue({ dismissed: 2 })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    try {
+      await renderABSReview([itemA, itemB, itemC])
+
+      const button = await screen.findAllByRole('button', { name: /Dismiss all from this run/ })
+      // Two groups (run 42 and run 99). Most-recent (99) renders first, so
+      // index 1 is the 42-group click target.
+      expect(button.length).toBe(2)
+
+      fireEvent.click(button[1])
+
+      await waitFor(() => {
+        expect(api.dismissAbsReviewRun).toHaveBeenCalledWith(42)
+      })
+      expect(confirmSpy).toHaveBeenCalled()
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+
+  it('does nothing when the per-run dismiss confirmation is cancelled', async () => {
+    const itemA = makeReviewItem({ id: 1, itemId: 'item-1', latestRunId: 42 })
+    vi.mocked(api.dismissAbsReviewRun).mockResolvedValue({ dismissed: 1 })
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    try {
+      await renderABSReview([itemA])
+      const buttons = await screen.findAllByRole('button', { name: /Dismiss all from this run/ })
+      fireEvent.click(buttons[0])
+      expect(api.dismissAbsReviewRun).not.toHaveBeenCalled()
+    } finally {
+      confirmSpy.mockRestore()
+    }
   })
 })

--- a/web/src/pages/settings/ABSTab.tsx
+++ b/web/src/pages/settings/ABSTab.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { api, ABSConfig, ABSImportProgress, ABSImportRun, ABSLibrary, ABSMetadataConflict, ABSReviewItem, ABSRollbackAction, ABSRollbackResult, ABSTestResult, Author, Book } from '../../api/client'
 import ABSConflictPanel from '../../components/ABSAuthorConflictsPanel'
 import { inputCls } from './formStyles'
@@ -36,6 +37,7 @@ export default function ABSTab() {
 }
 
 function AudiobookshelfSection() {
+  const { t } = useTranslation()
   const [config, setConfig] = useState<ABSConfig | null>(null)
   const [draft, setDraft] = useState({ baseUrl: '', apiKey: '', label: 'Audiobookshelf', enabled: false, libraryIds: [] as string[], pathRemap: '' })
   const [libraries, setLibraries] = useState<ABSLibrary[]>([])
@@ -62,6 +64,7 @@ function AudiobookshelfSection() {
   const [reviewItems, setReviewItems] = useState<ABSReviewItem[]>([])
   const [reviewError, setReviewError] = useState<string | null>(null)
   const [reviewActionId, setReviewActionId] = useState<number | null>(null)
+  const [dismissingRunId, setDismissingRunId] = useState<number | null>(null)
   const [authorQueries, setAuthorQueries] = useState<Record<number, string>>({})
   const [authorResults, setAuthorResults] = useState<Record<number, Author[]>>({})
   const [authorSearchId, setAuthorSearchId] = useState<number | null>(null)
@@ -327,6 +330,20 @@ function AudiobookshelfSection() {
     }
   }
 
+  const dismissReviewRun = async (runId: number, count: number) => {
+    if (!confirm(t('settings.abs.review.dismissRunConfirm', { count, runId, defaultValue: 'Dismiss {{count}} review items from run #{{runId}}? This cannot be undone.' }))) return
+    setDismissingRunId(runId)
+    setReviewError(null)
+    try {
+      await api.dismissAbsReviewRun(runId)
+      await refreshReviewItems()
+    } catch (err: unknown) {
+      setReviewError(err instanceof Error ? err.message : 'Failed to dismiss review run')
+    } finally {
+      setDismissingRunId(null)
+    }
+  }
+
   const searchReviewAuthors = async (item: ABSReviewItem) => {
     const query = (authorQueries[item.id] ?? item.primaryAuthor).trim()
     if (!query) return
@@ -374,6 +391,27 @@ function AudiobookshelfSection() {
       setBookSearchId(null)
     }
   }
+
+  const groupedReviewItems = useMemo(() => {
+    type Group = { runId: number | null; items: ABSReviewItem[] }
+    const order: (number | null)[] = []
+    const map = new Map<number | null, ABSReviewItem[]>()
+    for (const item of reviewItems) {
+      const key = typeof item.latestRunId === 'number' && item.latestRunId > 0 ? item.latestRunId : null
+      const bucket = map.get(key)
+      if (bucket) {
+        bucket.push(item)
+      } else {
+        map.set(key, [item])
+        order.push(key)
+      }
+    }
+    // Most recent run first (numerically highest id), unknown last.
+    const numeric = order.filter((k): k is number => k !== null).sort((a, b) => b - a)
+    const hasUnknown = order.includes(null)
+    const sortedKeys: (number | null)[] = hasUnknown ? [...numeric, null] : numeric
+    return sortedKeys.map<Group>(runId => ({ runId, items: map.get(runId) ?? [] }))
+  }, [reviewItems])
 
   const resolveReviewBook = async (item: ABSReviewItem, book: Book) => {
     setReviewActionId(item.id)
@@ -962,7 +1000,28 @@ function AudiobookshelfSection() {
                 <p className="text-sm text-slate-500 dark:text-zinc-500">No queued ABS review items.</p>
               )}
 
-              {reviewItems.map(item => (
+              {groupedReviewItems.map(group => (
+                <div key={group.runId ?? 'unknown'} className="space-y-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2 px-1">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-zinc-400">
+                      {group.runId !== null
+                        ? t('settings.abs.review.runHeading', { runId: group.runId, count: group.items.length, defaultValue: 'Run #{{runId}} · {{count}} items' })
+                        : t('settings.abs.review.unknownRunHeading', { count: group.items.length, defaultValue: 'Older items · {{count}}' })}
+                    </p>
+                    {group.runId !== null && group.items.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={() => dismissReviewRun(group.runId as number, group.items.length)}
+                        disabled={dismissingRunId === group.runId || reviewActionId !== null}
+                        className="px-2 py-1 bg-amber-600 hover:bg-amber-500 rounded text-[11px] font-medium disabled:opacity-50"
+                      >
+                        {dismissingRunId === group.runId
+                          ? t('settings.abs.review.dismissingRun', { defaultValue: 'Dismissing…' })
+                          : t('settings.abs.review.dismissRun', { defaultValue: 'Dismiss all from this run' })}
+                      </button>
+                    )}
+                  </div>
+                  {group.items.map(item => (
                 <div key={item.id} className="rounded border border-slate-200 dark:border-zinc-800 bg-slate-50 dark:bg-zinc-950 px-3 py-3 space-y-2">
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
@@ -1075,6 +1134,8 @@ function AudiobookshelfSection() {
                       Dismiss
                     </button>
                   </div>
+                </div>
+                  ))}
                 </div>
               ))}
             </>


### PR DESCRIPTION
## Why

Two Discord users (last confirmed 2026-05-22) reported the same workflow gap:

1. ABS imports a book it cannot match; a no-match row lands in the review queue.
2. User fixes the metadata in ABS (typically adds the missing ISBN/ASIN) and re-runs the import.
3. The book now imports fine — but the **old pending review row is never touched**. It sits there forever, indistinguishable from genuine current no-matches.

The second reporter (epiphanyplx) specifically asked for *per-run* bulk dismiss, not "clear the whole queue" — the import run is the natural unit of trust. This PR addresses both halves: auto-reconcile so the common case stops piling junk into the queue, plus an explicit bulk action for the residual cases that auto-reconcile cannot reason about.

## What ships

**Auto-reconcile (silent, every rescan).** During `runLibrary` the importer now tracks every ItemID that hits a successful outcome (`created`, `linked`, `updated`). At end of library, before `Finish`, it calls `ABSReviewItemRepo.MarkResolvedByItemIDs(...)` which flips matching `status='pending'` rows to `dismissed` in one statement. Items that are already `approved` or `dismissed` are never re-touched — a previous user decision stands.

The dismissed status was chosen over inventing a new terminal status. Spec said don't invent unless the model needs it; it doesn't.

**Per-run bulk dismiss endpoint.** `POST /api/v1/abs/review/dismiss-run/{runID}` validates the run via `ABSImportRunRepo.GetByID` (404 if unknown, 400 if malformed), then issues a single UPDATE filtered on `status='pending' AND latest_run_id = ?`. Returns `{ dismissed: N }`. The route shape mirrors the existing per-item dismiss (`/abs/review/{id}/dismiss`) so the chi router stays consistent.

**Frontend.** Review items now group by `latestRunId` (sorted most-recent-first, with an "Older items" trailing bucket for any nulls). Each known-run header carries a small amber "Dismiss all from this run" button gated by `window.confirm`, matching the codebase's other dismiss UX. i18n keys added to all 7 locales (`settings.abs.review.*`); the existing inline-strings in ABSTab were left alone (separate debt).

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run --timeout=5m` clean
- [x] `go test ./cmd/... ./internal/...` green
- [x] `cd web && npm run typecheck && npm run lint && npm run build` clean
- [x] `cd web && npm test` — 222 passing including new smoke tests for the dismiss-run button (confirm-accepted and confirm-cancelled)
- [x] Repo: `MarkResolvedByItemIDs` happy path, ignores already-dismissed rows, empty-IDs no-op, library scoping
- [x] Repo: `DismissByRunID` happy path, runID=0 and unknown-runID no-ops
- [x] Handler: `DismissRun` happy path, unknown-runID 404, malformed-runID 400
- [x] Importer: `TestImporter_AutoReconcilesStaleReviewItemsOnRescan` proves a stale pending row gets dismissed on rescan while an unrelated pending row stays and a user-dismissed row is not re-touched

## Out of scope

- No "clear entire queue" button. The reporter explicitly wanted per-run scope so import-run trust is the dismiss boundary; opening a "nuke it all" lever would defeat the point.

Closes #767