### PR TITLE
feat(metadata): hydrate hardcover editions from known hardcover ids

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -418,7 +418,8 @@ func main() {
 		WithSeriesRepo(seriesRepo).
 		WithTokenSource(func(ctx context.Context) string {
 			return api.GetHardcoverAPIToken(ctx, settingsRepo)
-		})
+		}).
+		WithEditionHydration(editionRepo, metaAgg)
 	sched.WithHardcoverSyncer(hcSyncer)
 	sched.WithLogRepo(logRepo, cfg.LogRetentionDays)
 
@@ -468,9 +469,16 @@ func main() {
 	userMgmtHandler := api.NewUserManagementHandler(userRepo).
 		WithLocalAuthEnabled(cfg.LocalAuthEnabled)
 	searchHandler := api.NewSearchHandler(metaAgg)
-	authorHandler := api.NewAuthorHandler(authorRepo, authorAliasRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched).WithFinder(importScanner)
+	authorHandler := api.NewAuthorHandler(authorRepo, authorAliasRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched).
+		WithFinder(importScanner).
+		WithEditionHydration(editionRepo)
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
-	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).WithSettings(settingsRepo).WithDownloads(downloadRepo).WithAuthors(authorRepo).WithSeries(seriesRepo)
+	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).
+		WithSettings(settingsRepo).
+		WithDownloads(downloadRepo).
+		WithAuthors(authorRepo).
+		WithSeries(seriesRepo).
+		WithEditionHydration(editionRepo)
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, metadataProfileRepo, idxSearcher, settingsRepo, blocklistRepo).WithAliases(authorAliasRepo)
 	downloadHealth := downloader.NewHealthStore().WithNotifier(notif)
 	if clients, err := dlClientRepo.List(ctxBoot); err == nil {
@@ -515,7 +523,8 @@ func main() {
 	settingsHandler := api.NewSettingsHandler(settingsRepo)
 	seriesHandler := api.NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metaAgg, sched).
 		WithHardcoverFeatureSettings(settingsRepo, cfg.EnhancedHardcoverAPI).
-		WithFinder(importScanner)
+		WithFinder(importScanner).
+		WithEditionHydration(editionRepo)
 	tagHandler := api.NewTagHandler(tagRepo)
 	importListHandler := api.NewImportListHandler(importListRepo, settingsRepo, hcSyncer)
 	metadataProfileHandler := api.NewMetadataProfileHandler(metadataProfileRepo)
@@ -548,6 +557,7 @@ func main() {
 	)
 	recHandler := api.NewRecommendationHandler(recRepo, recEngine, authorRepo, bookRepo, sched).
 		WithFinder(seriesRepo, importScanner).
+		WithEditionHydration(editionRepo, metaAgg).
 		WithAppContext(appCtx)
 	imageProxyHandler := api.NewImageProxyHandler(cfg.DataDir)
 	imageProxyHandler.StartEviction(24 * time.Hour)

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -471,6 +471,7 @@ func main() {
 	searchHandler := api.NewSearchHandler(metaAgg)
 	authorHandler := api.NewAuthorHandler(authorRepo, authorAliasRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched).
 		WithFinder(importScanner).
+		WithHardcoverFeatureSettings(settingsRepo, cfg.EnhancedHardcoverAPI).
 		WithEditionHydration(editionRepo)
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
 	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/metadata"
@@ -42,6 +43,9 @@ type AuthorHandler struct {
 	profiles *db.MetadataProfileRepo
 	searcher BookSearcher
 	finder   LibraryFinder
+	editions *db.EditionRepo
+
+	editionFetcher bookhydrate.EditionFetcher
 }
 
 func NewAuthorHandler(authors *db.AuthorRepo, aliases *db.AuthorAliasRepo, books *db.BookRepo, series *db.SeriesRepo, meta *metadata.Aggregator, settings *db.SettingsRepo, profiles *db.MetadataProfileRepo, searcher BookSearcher) *AuthorHandler {
@@ -54,6 +58,37 @@ func NewAuthorHandler(authors *db.AuthorRepo, aliases *db.AuthorAliasRepo, books
 func (h *AuthorHandler) WithFinder(f LibraryFinder) *AuthorHandler {
 	h.finder = f
 	return h
+}
+
+// WithEditionHydration wires edition persistence for supplemental Hardcover
+// books created while syncing author catalogues.
+func (h *AuthorHandler) WithEditionHydration(editions *db.EditionRepo) *AuthorHandler {
+	h.editions = editions
+	return h
+}
+
+// WithEditionFetcher overrides the edition fetcher used by tests.
+func (h *AuthorHandler) WithEditionFetcher(fetcher bookhydrate.EditionFetcher) *AuthorHandler {
+	h.editionFetcher = fetcher
+	return h
+}
+
+func (h *AuthorHandler) hydrateHardcoverEditions(ctx context.Context, book *models.Book) {
+	if book == nil || h.editions == nil {
+		return
+	}
+	fetcher := h.editionFetcher
+	if fetcher == nil && h.meta != nil {
+		fetcher = h.meta.GetEditions
+	}
+	bookhydrate.HydrateHardcoverEditions(ctx, bookhydrate.Options{
+		Book:          book,
+		Provider:      book.MetadataProvider,
+		Editions:      h.editions,
+		Books:         h.books,
+		FetchEditions: fetcher,
+		Enricher:      h.meta,
+	})
 }
 
 func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -1203,6 +1238,7 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 			slog.Warn("failed to create book", "title", b.Title, "error", err)
 			continue
 		}
+		h.hydrateHardcoverEditions(ctx, &b)
 		added++
 
 		if fileFound := handleNewWantedBook(ctx, h.books, h.series, h.finder, b, author.Name); fileFound {

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1767,10 +1767,13 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 				if primary.Status == "" {
 					primary.Status = models.BookStatusWanted
 				}
-				if err := h.books.Create(ctx, primary); err != nil &&
-					!strings.Contains(err.Error(), "UNIQUE constraint failed") {
-					slog.Warn("AddBook: direct insert failed",
-						"foreignBookId", req.ForeignBookID, "error", err)
+				if err := h.books.Create(ctx, primary); err != nil {
+					if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
+						slog.Warn("AddBook: direct insert failed",
+							"foreignBookId", req.ForeignBookID, "error", err)
+					}
+				} else {
+					h.hydrateHardcoverEditions(ctx, primary)
 				}
 			}
 		}

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -34,16 +34,17 @@ var (
 const authorAutoSearchConcurrency = 4
 
 type AuthorHandler struct {
-	authors  *db.AuthorRepo
-	aliases  *db.AuthorAliasRepo
-	books    *db.BookRepo
-	series   *db.SeriesRepo
-	meta     *metadata.Aggregator
-	settings *db.SettingsRepo
-	profiles *db.MetadataProfileRepo
-	searcher BookSearcher
-	finder   LibraryFinder
-	editions *db.EditionRepo
+	authors                     *db.AuthorRepo
+	aliases                     *db.AuthorAliasRepo
+	books                       *db.BookRepo
+	series                      *db.SeriesRepo
+	meta                        *metadata.Aggregator
+	settings                    *db.SettingsRepo
+	profiles                    *db.MetadataProfileRepo
+	searcher                    BookSearcher
+	finder                      LibraryFinder
+	editions                    *db.EditionRepo
+	enhancedHardcoverEnvEnabled bool
 
 	editionFetcher bookhydrate.EditionFetcher
 }
@@ -73,21 +74,60 @@ func (h *AuthorHandler) WithEditionFetcher(fetcher bookhydrate.EditionFetcher) *
 	return h
 }
 
+// WithHardcoverFeatureSettings wires the enhanced Hardcover feature gate used
+// when a primary-provider book has only a supplemental Hardcover match.
+func (h *AuthorHandler) WithHardcoverFeatureSettings(settings *db.SettingsRepo, envEnabled bool) *AuthorHandler {
+	h.settings = settings
+	h.enhancedHardcoverEnvEnabled = envEnabled
+	return h
+}
+
+func (h *AuthorHandler) enhancedHardcoverEnabled(ctx context.Context) bool {
+	if h.settings == nil {
+		return h.enhancedHardcoverEnvEnabled
+	}
+	return HardcoverFeatureStateFor(ctx, h.settings, h.enhancedHardcoverEnvEnabled).EnhancedHardcoverAPI
+}
+
 func (h *AuthorHandler) hydrateHardcoverEditions(ctx context.Context, book *models.Book) {
+	h.hydrateHardcoverEditionsFrom(ctx, book, "")
+}
+
+func (h *AuthorHandler) hydrateMatchedHardcoverEditions(ctx context.Context, book *models.Book, hardcoverForeignID string) {
+	h.hydrateHardcoverEditionsFrom(ctx, book, hardcoverForeignID)
+}
+
+func (h *AuthorHandler) hydrateHardcoverEditionsFrom(ctx context.Context, book *models.Book, hardcoverForeignID string) {
 	if book == nil || h.editions == nil {
 		return
 	}
+	hardcoverForeignID = strings.TrimSpace(hardcoverForeignID)
+	if hardcoverForeignID == "" && !bookhydrate.IsHardcoverBook(book, book.MetadataProvider) {
+		hardcoverForeignID = strings.TrimSpace(book.HardcoverForeignID)
+	}
+	if hardcoverForeignID != "" {
+		if !strings.HasPrefix(hardcoverForeignID, "hc:") || !h.enhancedHardcoverEnabled(ctx) {
+			return
+		}
+	}
 	fetcher := h.editionFetcher
 	if fetcher == nil && h.meta != nil {
-		fetcher = h.meta.GetEditions
+		if hardcoverForeignID != "" {
+			fetcher = func(ctx context.Context, foreignID string) ([]models.Edition, error) {
+				return h.meta.GetEditionsFromProvider(ctx, "hardcover", foreignID)
+			}
+		} else {
+			fetcher = h.meta.GetEditions
+		}
 	}
 	bookhydrate.HydrateHardcoverEditions(ctx, bookhydrate.Options{
-		Book:          book,
-		Provider:      book.MetadataProvider,
-		Editions:      h.editions,
-		Books:         h.books,
-		FetchEditions: fetcher,
-		Enricher:      h.meta,
+		Book:              book,
+		Provider:          book.MetadataProvider,
+		ProviderForeignID: hardcoverForeignID,
+		Editions:          h.editions,
+		Books:             h.books,
+		FetchEditions:     fetcher,
+		Enricher:          h.meta,
 	})
 }
 
@@ -1188,6 +1228,7 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 		//     truly redundant and is silently skipped (no format gain).
 		dedupKey := indexer.NormalizeTitleForDedup(b.Title)
 		if existing := seenTitles[dedupKey]; existing != nil {
+			hydrateExistingFromMatchedHardcover := false
 			switch {
 			case strings.HasPrefix(existing.ForeignID, "calibre:"):
 				// Upgrade calibre stub to real OL foreign_id.
@@ -1201,6 +1242,8 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 				}
 				if err := h.books.Update(ctx, existing); err != nil {
 					slog.Warn("authors: update during dedup", "error", err, "book_id", existing.ID)
+				} else if existing.WantsAudiobook() {
+					hydrateExistingFromMatchedHardcover = true
 				}
 			case canUpgradeToBoth(existing.MediaType, b.MediaType):
 				// One Work is ebook, the other is audiobook — merge into a single
@@ -1214,6 +1257,7 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 					slog.Warn("failed to upgrade book to dual-format", "title", existing.Title, "error", err)
 				} else {
 					slog.Debug("upgraded book to dual-format", "title", existing.Title, "foreignId", b.ForeignID)
+					hydrateExistingFromMatchedHardcover = true
 				}
 			default:
 				// Same media type duplicate — just refresh ratings if we have better data.
@@ -1224,6 +1268,10 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 						slog.Warn("authors: update during dedup", "error", err, "book_id", existing.ID)
 					}
 				}
+				hydrateExistingFromMatchedHardcover = existing.WantsAudiobook()
+			}
+			if hydrateExistingFromMatchedHardcover {
+				h.hydrateMatchedHardcoverEditions(ctx, existing, b.HardcoverForeignID)
 			}
 			continue
 		}

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -133,6 +133,16 @@ func (p *stubMetaProvider) GetAuthorWorksByName(_ context.Context, _ string) ([]
 	return p.authorWorksByName, nil
 }
 
+func enableHardcoverFeatureForTest(t *testing.T, ctx context.Context, settings *db.SettingsRepo) {
+	t.Helper()
+	if err := settings.Set(ctx, SettingHardcoverAPIToken, "hc-test-token"); err != nil {
+		t.Fatal(err)
+	}
+	if err := settings.Set(ctx, SettingHardcoverEnhancedSeriesEnabled, "true"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestDeleteAuthor_WithDeleteFiles verifies the ?deleteFiles=true branch
 // sweeps every book's on-disk path. The invariant under test is ordering:
 // paths must be collected from `books ListByAuthor` *before* the cascade
@@ -710,6 +720,285 @@ func TestFetchAuthorBooksHydratesOnlySupplementalHardcoverBooks(t *testing.T) {
 	}
 	if len(editions) != 1 || editions[0].ForeignID != "hc:audio-book-edition" {
 		t.Fatalf("expected hydrated edition, got %+v", editions)
+	}
+}
+
+func TestFetchAuthorBooksHydratesMatchedOpenLibraryHardcoverEditions(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	editionRepo := db.NewEditionRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+	enableHardcoverFeatureForTest(t, ctx, settingsRepo)
+	author := &models.Author{
+		ForeignID:        "OL-MATCH-A",
+		Name:             "Author",
+		SortName:         "Author",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	primary := &stubMetaProvider{
+		name: "openlibrary",
+		works: []models.Book{{
+			ForeignID:        "OL-MATCH-W",
+			Title:            "Matched Book",
+			SortTitle:        "Matched Book",
+			Status:           models.BookStatusWanted,
+			Genres:           []string{},
+			MetadataProvider: "openlibrary",
+		}},
+	}
+	audioASIN := "B000MATCH"
+	hardcover := &stubMetaProvider{
+		name: "hardcover",
+		authorWorksByName: []models.Book{{
+			ForeignID:        "hc:matched-book",
+			Title:            "Matched Book",
+			SortTitle:        "Matched Book",
+			Status:           models.BookStatusWanted,
+			Genres:           []string{},
+			MetadataProvider: "hardcover",
+			MediaType:        models.MediaTypeAudiobook,
+		}},
+		editionsByBook: map[string][]models.Edition{
+			"hc:matched-book": {{
+				ForeignID: "hc:matched-book-audio",
+				Title:     "Matched Book",
+				ASIN:      &audioASIN,
+				Format:    "Audiobook",
+				Monitored: true,
+			}},
+		},
+	}
+	agg := metadata.NewAggregator(primary, hardcover).WithAudnexClient(nil)
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil).
+		WithHardcoverFeatureSettings(settingsRepo, true).
+		WithEditionHydration(editionRepo)
+	h.FetchAuthorBooks(author, false, "")
+
+	book, err := bookRepo.GetByForeignID(ctx, "OL-MATCH-W")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if book == nil {
+		t.Fatal("expected OpenLibrary book")
+	}
+	if book.ForeignID != "OL-MATCH-W" || book.MetadataProvider != "openlibrary" {
+		t.Fatalf("book identity was rebound unexpectedly: %+v", book)
+	}
+	if book.MediaType != models.MediaTypeAudiobook || book.ASIN != audioASIN {
+		t.Fatalf("matched book was not hydrated: %+v", book)
+	}
+	if len(primary.editionCalls) != 0 {
+		t.Fatalf("primary provider edition calls = %+v", primary.editionCalls)
+	}
+	if len(hardcover.editionCalls) != 1 || hardcover.editionCalls[0] != "hc:matched-book" {
+		t.Fatalf("hardcover edition calls = %+v", hardcover.editionCalls)
+	}
+	editions, err := editionRepo.ListByBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(editions) != 1 || editions[0].ForeignID != "hc:matched-book-audio" {
+		t.Fatalf("expected matched edition, got %+v", editions)
+	}
+}
+
+func TestFetchAuthorBooksDoesNotHydrateMatchedHardcoverWhenEnhancedDisabled(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	editionRepo := db.NewEditionRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID:        "OL-MATCH-DISABLED-A",
+		Name:             "Author",
+		SortName:         "Author",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	primary := &stubMetaProvider{
+		name: "openlibrary",
+		works: []models.Book{{
+			ForeignID:        "OL-MATCH-DISABLED-W",
+			Title:            "Matched Disabled Book",
+			SortTitle:        "Matched Disabled Book",
+			Status:           models.BookStatusWanted,
+			Genres:           []string{},
+			MetadataProvider: "openlibrary",
+		}},
+	}
+	audioASIN := "B000DISABL"
+	hardcover := &stubMetaProvider{
+		name: "hardcover",
+		authorWorksByName: []models.Book{{
+			ForeignID:        "hc:matched-disabled-book",
+			Title:            "Matched Disabled Book",
+			SortTitle:        "Matched Disabled Book",
+			Status:           models.BookStatusWanted,
+			Genres:           []string{},
+			MetadataProvider: "hardcover",
+			MediaType:        models.MediaTypeAudiobook,
+		}},
+		editionsByBook: map[string][]models.Edition{
+			"hc:matched-disabled-book": {{
+				ForeignID: "hc:matched-disabled-book-audio",
+				Title:     "Matched Disabled Book",
+				ASIN:      &audioASIN,
+				Format:    "Audiobook",
+				Monitored: true,
+			}},
+		},
+	}
+	agg := metadata.NewAggregator(primary, hardcover).WithAudnexClient(nil)
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil).
+		WithHardcoverFeatureSettings(settingsRepo, true).
+		WithEditionHydration(editionRepo)
+	h.FetchAuthorBooks(author, false, "")
+
+	book, err := bookRepo.GetByForeignID(ctx, "OL-MATCH-DISABLED-W")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if book == nil {
+		t.Fatal("expected OpenLibrary book")
+	}
+	if book.ASIN != "" {
+		t.Fatalf("matched book was hydrated while enhanced Hardcover was disabled: %+v", book)
+	}
+	if len(hardcover.editionCalls) != 0 {
+		t.Fatalf("hardcover edition calls = %+v, want none", hardcover.editionCalls)
+	}
+	editions, err := editionRepo.ListByBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(editions) != 0 {
+		t.Fatalf("editions were persisted while enhanced Hardcover was disabled: %+v", editions)
+	}
+}
+
+func TestFetchAuthorBooksHydratesMatchedHardcoverTitleDedupUpgrade(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	editionRepo := db.NewEditionRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+	enableHardcoverFeatureForTest(t, ctx, settingsRepo)
+	author := &models.Author{
+		ForeignID:        "OL-DEDUP-HYDRATE-A",
+		Name:             "Author",
+		SortName:         "Author",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	existing := &models.Book{
+		ForeignID:        "OL-DEDUP-EXISTING-W",
+		AuthorID:         author.ID,
+		Title:            "Shared Book",
+		SortTitle:        "Shared Book",
+		Status:           models.BookStatusWanted,
+		Genres:           []string{},
+		MetadataProvider: "openlibrary",
+		MediaType:        models.MediaTypeEbook,
+		Monitored:        true,
+	}
+	if err := bookRepo.Create(ctx, existing); err != nil {
+		t.Fatal(err)
+	}
+
+	primary := &stubMetaProvider{
+		name: "openlibrary",
+		works: []models.Book{{
+			ForeignID:        "OL-DEDUP-NEW-W",
+			Title:            "Shared Book",
+			SortTitle:        "Shared Book",
+			Status:           models.BookStatusWanted,
+			Genres:           []string{},
+			MetadataProvider: "openlibrary",
+		}},
+	}
+	audioASIN := "B000DEDUP"
+	hardcover := &stubMetaProvider{
+		name: "hardcover",
+		authorWorksByName: []models.Book{{
+			ForeignID:        "hc:dedup-book",
+			Title:            "Shared Book",
+			SortTitle:        "Shared Book",
+			Status:           models.BookStatusWanted,
+			Genres:           []string{},
+			MetadataProvider: "hardcover",
+			MediaType:        models.MediaTypeAudiobook,
+		}},
+		editionsByBook: map[string][]models.Edition{
+			"hc:dedup-book": {{
+				ForeignID: "hc:dedup-book-audio",
+				Title:     "Shared Book",
+				ASIN:      &audioASIN,
+				Format:    "Audiobook",
+				Monitored: true,
+			}},
+		},
+	}
+	agg := metadata.NewAggregator(primary, hardcover).WithAudnexClient(nil)
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil).
+		WithHardcoverFeatureSettings(settingsRepo, true).
+		WithEditionHydration(editionRepo)
+	h.FetchAuthorBooks(author, false, "")
+
+	updated, err := bookRepo.GetByID(ctx, existing.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.MediaType != models.MediaTypeBoth || updated.ASIN != audioASIN {
+		t.Fatalf("existing book was not upgraded and hydrated: %+v", updated)
+	}
+	if created, err := bookRepo.GetByForeignID(ctx, "OL-DEDUP-NEW-W"); err != nil {
+		t.Fatal(err)
+	} else if created != nil {
+		t.Fatalf("dedup path created a second book: %+v", created)
+	}
+	if len(hardcover.editionCalls) != 1 || hardcover.editionCalls[0] != "hc:dedup-book" {
+		t.Fatalf("hardcover edition calls = %+v", hardcover.editionCalls)
+	}
+	editions, err := editionRepo.ListByBook(ctx, existing.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(editions) != 1 || editions[0].ForeignID != "hc:dedup-book-audio" {
+		t.Fatalf("expected dedup hydrated edition, got %+v", editions)
 	}
 }
 

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -2445,6 +2445,90 @@ func TestAddBook_DirectInsertCoversSlowAsyncSync(t *testing.T) {
 	}
 }
 
+func TestAddBook_DirectInsertHydratesMatchedHardcoverEditions(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	editionRepo := db.NewEditionRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+	enableHardcoverFeatureForTest(t, ctx, settingsRepo)
+
+	primaryBook := &models.Book{
+		ForeignID:          "OL-TWILIGHT-W",
+		Title:              "Twilight",
+		SortTitle:          "Twilight",
+		Language:           "eng",
+		Status:             models.BookStatusWanted,
+		Genres:             []string{},
+		MetadataProvider:   "openlibrary",
+		MediaType:          models.MediaTypeAudiobook,
+		HardcoverForeignID: "hc:twilight",
+	}
+	primary := &stubMetaProvider{
+		name:  "openlibrary",
+		works: nil,
+		getBookByID: map[string]*models.Book{
+			"OL-TWILIGHT-W": primaryBook,
+		},
+	}
+	audioASIN := "B000TWILIT"
+	hardcover := &stubMetaProvider{
+		name: "hardcover",
+		editionsByBook: map[string][]models.Edition{
+			"hc:twilight": {{
+				ForeignID: "hc:twilight-audio",
+				Title:     "Twilight",
+				ASIN:      &audioASIN,
+				Format:    "Audiobook",
+				Monitored: true,
+			}},
+		},
+	}
+	agg := metadata.NewAggregator(primary, hardcover).WithAudnexClient(nil)
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil).
+		WithHardcoverFeatureSettings(settingsRepo, true).
+		WithEditionHydration(editionRepo)
+
+	body, _ := json.Marshal(map[string]any{
+		"foreignBookId":   "OL-TWILIGHT-W",
+		"foreignAuthorId": "OL1391085A",
+		"authorName":      "Stephenie Meyer",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/author/book", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.AddBook(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(hardcover.editionCalls) != 1 || hardcover.editionCalls[0] != "hc:twilight" {
+		t.Fatalf("hardcover edition calls = %+v, want [hc:twilight]", hardcover.editionCalls)
+	}
+	got, err := bookRepo.GetByForeignID(ctx, "OL-TWILIGHT-W")
+	if err != nil || got == nil {
+		t.Fatalf("book not persisted: err=%v got=%v", err, got)
+	}
+	if got.ASIN != audioASIN {
+		t.Fatalf("book ASIN = %q, want %q", got.ASIN, audioASIN)
+	}
+	editions, err := editionRepo.ListByBook(ctx, got.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(editions) != 1 || editions[0].ForeignID != "hc:twilight-audio" {
+		t.Fatalf("expected hydrated edition, got %+v", editions)
+	}
+}
+
 // TestCanUpgradeToBoth validates the helper that decides whether two
 // complementary media types should be merged into a dual-format row.
 func TestCanUpgradeToBoth(t *testing.T) {

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -697,6 +697,7 @@ func TestFetchAuthorBooksHydratesOnlySupplementalHardcoverBooks(t *testing.T) {
 	}
 	if primaryBook == nil {
 		t.Fatal("expected primary book")
+		return
 	}
 	if primaryBook.ASIN != "" {
 		t.Fatalf("primary OpenLibrary book was unexpectedly hydrated: %+v", primaryBook)
@@ -793,6 +794,7 @@ func TestFetchAuthorBooksHydratesMatchedOpenLibraryHardcoverEditions(t *testing.
 	}
 	if book == nil {
 		t.Fatal("expected OpenLibrary book")
+		return
 	}
 	if book.ForeignID != "OL-MATCH-W" || book.MetadataProvider != "openlibrary" {
 		t.Fatalf("book identity was rebound unexpectedly: %+v", book)
@@ -884,6 +886,7 @@ func TestFetchAuthorBooksDoesNotHydrateMatchedHardcoverWhenEnhancedDisabled(t *t
 	}
 	if book == nil {
 		t.Fatal("expected OpenLibrary book")
+		return
 	}
 	if book.ASIN != "" {
 		t.Fatalf("matched book was hydrated while enhanced Hardcover was disabled: %+v", book)

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -82,6 +82,12 @@ type stubMetaProvider struct {
 	// returned by Name() — required when a test exercises a code path
 	// that routes by prefix via the aggregator (e.g. "dnb" for DNB IDs).
 	name string
+	// editionsByBook lets tests exercise metadata edition hydration.
+	editionsByBook map[string][]models.Edition
+	editionCalls   []string
+	// authorWorksByName lets tests act as an author-scoped supplemental
+	// provider such as Hardcover.
+	authorWorksByName []models.Book
 }
 
 func (p *stubMetaProvider) Name() string {
@@ -107,7 +113,11 @@ func (p *stubMetaProvider) GetBook(_ context.Context, fid string) (*models.Book,
 	}
 	return nil, nil
 }
-func (p *stubMetaProvider) GetEditions(_ context.Context, _ string) ([]models.Edition, error) {
+func (p *stubMetaProvider) GetEditions(_ context.Context, fid string) ([]models.Edition, error) {
+	p.editionCalls = append(p.editionCalls, fid)
+	if p.editionsByBook != nil {
+		return p.editionsByBook[fid], nil
+	}
 	return nil, nil
 }
 func (p *stubMetaProvider) GetBookByISBN(_ context.Context, _ string) (*models.Book, error) {
@@ -117,6 +127,10 @@ func (p *stubMetaProvider) GetBookByISBN(_ context.Context, _ string) (*models.B
 // GetAuthorWorks satisfies the worksProvider sub-interface used by Aggregator.
 func (p *stubMetaProvider) GetAuthorWorks(_ context.Context, _ string) ([]models.Book, error) {
 	return p.works, nil
+}
+
+func (p *stubMetaProvider) GetAuthorWorksByName(_ context.Context, _ string) ([]models.Book, error) {
+	return p.authorWorksByName, nil
 }
 
 // TestDeleteAuthor_WithDeleteFiles verifies the ?deleteFiles=true branch
@@ -603,6 +617,99 @@ func TestFetchAuthorBooks_AppliesAuthorMonitorModes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFetchAuthorBooksHydratesOnlySupplementalHardcoverBooks(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	editionRepo := db.NewEditionRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID:        "OL-HYDRATE-A",
+		Name:             "Author",
+		SortName:         "Author",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	primary := &stubMetaProvider{
+		name: "openlibrary",
+		works: []models.Book{{
+			ForeignID:        "OL-HYDRATE-W",
+			Title:            "Primary Book",
+			SortTitle:        "Primary Book",
+			Status:           models.BookStatusWanted,
+			Genres:           []string{},
+			MetadataProvider: "openlibrary",
+		}},
+	}
+	audioASIN := "B000AUTHOR"
+	hardcover := &stubMetaProvider{
+		name: "hardcover",
+		authorWorksByName: []models.Book{{
+			ForeignID:        "hc:audio-book",
+			Title:            "Audio Book",
+			SortTitle:        "Audio Book",
+			Status:           models.BookStatusWanted,
+			Genres:           []string{},
+			MetadataProvider: "hardcover",
+			MediaType:        models.MediaTypeAudiobook,
+		}},
+		editionsByBook: map[string][]models.Edition{
+			"hc:audio-book": {{
+				ForeignID: "hc:audio-book-edition",
+				Title:     "Audio Book",
+				ASIN:      &audioASIN,
+				Format:    "Audiobook",
+				Monitored: true,
+			}},
+		},
+	}
+	agg := metadata.NewAggregator(primary, hardcover).WithAudnexClient(nil)
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, nil).
+		WithEditionHydration(editionRepo)
+	h.FetchAuthorBooks(author, false, "")
+
+	primaryBook, err := bookRepo.GetByForeignID(ctx, "OL-HYDRATE-W")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if primaryBook == nil {
+		t.Fatal("expected primary book")
+	}
+	if primaryBook.ASIN != "" {
+		t.Fatalf("primary OpenLibrary book was unexpectedly hydrated: %+v", primaryBook)
+	}
+	hardcoverBook, err := bookRepo.GetByForeignID(ctx, "hc:audio-book")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hardcoverBook == nil || hardcoverBook.ASIN != audioASIN {
+		t.Fatalf("hardcover book was not hydrated: %+v", hardcoverBook)
+	}
+	if len(primary.editionCalls) != 0 {
+		t.Fatalf("primary provider edition calls = %+v", primary.editionCalls)
+	}
+	if len(hardcover.editionCalls) != 1 || hardcover.editionCalls[0] != "hc:audio-book" {
+		t.Fatalf("hardcover edition calls = %+v", hardcover.editionCalls)
+	}
+	editions, err := editionRepo.ListByBook(ctx, hardcoverBook.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(editions) != 1 || editions[0].ForeignID != "hc:audio-book-edition" {
+		t.Fatalf("expected hydrated edition, got %+v", editions)
 	}
 }
 

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/metadata"
@@ -30,6 +31,9 @@ type BookHandler struct {
 	downloads *db.DownloadRepo
 	authors   *db.AuthorRepo
 	series    *db.SeriesRepo
+	editions  *db.EditionRepo
+
+	editionFetcher bookhydrate.EditionFetcher
 }
 
 func NewBookHandler(books *db.BookRepo, meta *metadata.Aggregator, history *db.HistoryRepo, searcher BookSearcher) *BookHandler {
@@ -71,6 +75,43 @@ func (h *BookHandler) WithAuthors(a *db.AuthorRepo) *BookHandler {
 func (h *BookHandler) WithSeries(s *db.SeriesRepo) *BookHandler {
 	h.series = s
 	return h
+}
+
+// WithEditionHydration wires edition persistence for confident Hardcover
+// metadata identities.
+func (h *BookHandler) WithEditionHydration(editions *db.EditionRepo) *BookHandler {
+	h.editions = editions
+	return h
+}
+
+// WithEditionFetcher overrides the edition fetcher used by tests.
+func (h *BookHandler) WithEditionFetcher(fetcher bookhydrate.EditionFetcher) *BookHandler {
+	h.editionFetcher = fetcher
+	return h
+}
+
+func (h *BookHandler) hydrateHardcoverEditions(ctx context.Context, book *models.Book, provider string) {
+	if book == nil || h.editions == nil {
+		return
+	}
+	providerName := firstNonEmpty(provider, book.MetadataProvider)
+	fetcher := h.editionFetcher
+	if fetcher == nil && h.meta != nil {
+		fetcher = func(ctx context.Context, foreignID string) ([]models.Edition, error) {
+			if strings.EqualFold(strings.TrimSpace(providerName), "hardcover") {
+				return h.meta.GetEditionsFromProvider(ctx, "hardcover", foreignID)
+			}
+			return h.meta.GetEditions(ctx, foreignID)
+		}
+	}
+	bookhydrate.HydrateHardcoverEditions(ctx, bookhydrate.Options{
+		Book:          book,
+		Provider:      providerName,
+		Editions:      h.editions,
+		Books:         h.books,
+		FetchEditions: fetcher,
+		Enricher:      h.meta,
+	})
 }
 
 // EnrichAudiobook fetches audnex data for the book's ASIN and updates
@@ -707,6 +748,7 @@ func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	h.hydrateHardcoverEditions(r.Context(), book, req.Provider)
 
 	// Re-link series membership: remove all existing links for this book, then
 	// attach whatever the upstream record declares.
@@ -831,6 +873,7 @@ func (h *BookHandler) MapMetadata(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	h.hydrateHardcoverEditions(r.Context(), book, book.MetadataProvider)
 	updated, err := h.books.GetByID(r.Context(), book.ID)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})

--- a/internal/api/rebind_test.go
+++ b/internal/api/rebind_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -39,6 +40,7 @@ func rebindFixture(t *testing.T) (*BookHandler, *db.BookRepo, *db.AuthorRepo, *d
 	authors := db.NewAuthorRepo(database)
 	series := db.NewSeriesRepo(database)
 	history := db.NewHistoryRepo(database)
+	editions := db.NewEditionRepo(database)
 
 	author := &models.Author{
 		ForeignID: "OL1A", Name: "Test Author", SortName: "Author, Test",
@@ -57,7 +59,7 @@ func rebindFixture(t *testing.T) (*BookHandler, *db.BookRepo, *db.AuthorRepo, *d
 		t.Fatal(err)
 	}
 
-	h := NewBookHandler(books, nil, history, nil).WithAuthors(authors).WithSeries(series)
+	h := NewBookHandler(books, nil, history, nil).WithAuthors(authors).WithSeries(series).WithEditionHydration(editions)
 	return h, books, authors, series, author, book, ctx
 }
 
@@ -89,6 +91,102 @@ func TestRebind_HappyPath(t *testing.T) {
 	}
 	if updated.Title != "Correct Book" {
 		t.Errorf("title not updated: got %q", updated.Title)
+	}
+}
+
+func TestRebind_HydratesHardcoverEditions(t *testing.T) {
+	h, books, _, _, author, book, ctx := rebindFixture(t)
+	book.MediaType = models.MediaTypeAudiobook
+	if err := books.Update(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	audioASIN := "B123456789"
+	h.WithMetaLookup(&stubLookup{book: &models.Book{
+		Title:  "Correct Book",
+		Author: &models.Author{ForeignID: author.ForeignID, Name: author.Name},
+	}})
+	h.WithEditionFetcher(func(context.Context, string) ([]models.Edition, error) {
+		return []models.Edition{{
+			ForeignID: "hc:correct-audio",
+			Title:     "Correct Book",
+			ASIN:      &audioASIN,
+			Format:    "Audiobook",
+			Monitored: true,
+		}}, nil
+	})
+
+	rec := httptest.NewRecorder()
+	h.Rebind(rec, rebindRequest(book.ID, map[string]any{
+		"provider": "hardcover", "foreign_id": "123",
+	}))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	updated, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.ASIN != audioASIN {
+		t.Fatalf("ASIN = %q, want %q", updated.ASIN, audioASIN)
+	}
+	editions, err := h.editions.ListByBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(editions) != 1 || editions[0].ForeignID != "hc:correct-audio" {
+		t.Fatalf("expected hydrated edition, got %+v", editions)
+	}
+}
+
+func TestMapMetadata_HydratesHardcoverEditions(t *testing.T) {
+	h, books, _, _, author, book, ctx := rebindFixture(t)
+	book.MediaType = models.MediaTypeAudiobook
+	if err := books.Update(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	audioASIN := "B987654321"
+	provider := &stubMetaProvider{
+		name: "hardcover",
+		getBookByID: map[string]*models.Book{
+			"hc:mapped": {
+				ForeignID:        "hc:mapped",
+				Title:            "Mapped Book",
+				SortTitle:        "Mapped Book",
+				MetadataProvider: "hardcover",
+				Author:           &models.Author{ForeignID: author.ForeignID, Name: author.Name},
+			},
+		},
+		editionsByBook: map[string][]models.Edition{
+			"hc:mapped": {{
+				ForeignID: "hc:mapped-audio",
+				Title:     "Mapped Book",
+				ASIN:      &audioASIN,
+				Format:    "Audiobook",
+				Monitored: true,
+			}},
+		},
+	}
+	h.meta = metadata.NewAggregator(provider).WithAudnexClient(nil)
+
+	body := bytes.NewBufferString(`{"foreignBookId":"hc:mapped"}`)
+	rec := httptest.NewRecorder()
+	h.MapMetadata(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/book/1/map-metadata", body), "id", strconv.FormatInt(book.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	updated, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.ASIN != audioASIN {
+		t.Fatalf("ASIN = %q, want %q", updated.ASIN, audioASIN)
+	}
+	editions, err := h.editions.ListByBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(editions) != 1 || editions[0].ForeignID != "hc:mapped-audio" {
+		t.Fatalf("expected hydrated edition, got %+v", editions)
 	}
 }
 

--- a/internal/api/recommendations.go
+++ b/internal/api/recommendations.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -27,6 +29,10 @@ type RecommendationHandler struct {
 	series   *db.SeriesRepo
 	searcher BookSearcher
 	finder   LibraryFinder
+	editions *db.EditionRepo
+	meta     *metadata.Aggregator
+
+	editionFetcher bookhydrate.EditionFetcher
 
 	// appCtx is the process-lifecycle context: not tied to any single HTTP
 	// request but cancelled when the process shuts down. Background work
@@ -41,6 +47,40 @@ func (h *RecommendationHandler) WithFinder(series *db.SeriesRepo, finder Library
 	h.series = series
 	h.finder = finder
 	return h
+}
+
+// WithEditionHydration wires edition persistence for Hardcover
+// recommendations accepted into the wanted list.
+func (h *RecommendationHandler) WithEditionHydration(editions *db.EditionRepo, meta *metadata.Aggregator) *RecommendationHandler {
+	h.editions = editions
+	h.meta = meta
+	return h
+}
+
+// WithEditionFetcher overrides the edition fetcher used by tests.
+func (h *RecommendationHandler) WithEditionFetcher(fetcher bookhydrate.EditionFetcher) *RecommendationHandler {
+	h.editionFetcher = fetcher
+	return h
+}
+
+func (h *RecommendationHandler) hydrateHardcoverEditions(ctx context.Context, book *models.Book) {
+	if book == nil || h.editions == nil {
+		return
+	}
+	fetcher := h.editionFetcher
+	if fetcher == nil && h.meta != nil {
+		fetcher = func(ctx context.Context, foreignID string) ([]models.Edition, error) {
+			return h.meta.GetEditionsFromProvider(ctx, "hardcover", foreignID)
+		}
+	}
+	bookhydrate.HydrateHardcoverEditions(ctx, bookhydrate.Options{
+		Book:          book,
+		Provider:      book.MetadataProvider,
+		Editions:      h.editions,
+		Books:         h.books,
+		FetchEditions: fetcher,
+		Enricher:      h.meta,
+	})
 }
 
 // WithAppContext attaches the process-lifecycle context so that background
@@ -155,24 +195,26 @@ func (h *RecommendationHandler) Add(w http.ResponseWriter, r *http.Request) {
 	}
 
 	book := &models.Book{
-		ForeignID:     rec.ForeignID,
-		AuthorID:      authorID,
-		Title:         rec.Title,
-		Description:   rec.Description,
-		ImageURL:      rec.ImageURL,
-		AverageRating: rec.Rating,
-		RatingsCount:  rec.RatingsCount,
-		ReleaseDate:   rec.ReleaseDate,
-		Language:      rec.Language,
-		MediaType:     rec.MediaType,
-		Status:        models.BookStatusWanted,
-		Monitored:     true,
+		ForeignID:        rec.ForeignID,
+		AuthorID:         authorID,
+		Title:            rec.Title,
+		Description:      rec.Description,
+		ImageURL:         rec.ImageURL,
+		AverageRating:    rec.Rating,
+		RatingsCount:     rec.RatingsCount,
+		ReleaseDate:      rec.ReleaseDate,
+		Language:         rec.Language,
+		MediaType:        rec.MediaType,
+		Status:           models.BookStatusWanted,
+		Monitored:        true,
+		MetadataProvider: metadataProviderFromForeignID(rec.ForeignID),
 	}
 
 	if err := h.books.Create(r.Context(), book); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	h.hydrateHardcoverEditions(r.Context(), book)
 
 	fileFound := handleNewWantedBook(r.Context(), h.books, h.series, h.finder, *book, rec.AuthorName)
 

--- a/internal/api/recommendations_test.go
+++ b/internal/api/recommendations_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+type fakeRecommendationEngine struct{}
+
+func (fakeRecommendationEngine) Run(context.Context, int64) error { return nil }
+
+func TestRecommendationAddHydratesHardcoverEditions(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	recRepo := db.NewRecommendationRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	seriesRepo := db.NewSeriesRepo(database)
+	editionRepo := db.NewEditionRepo(database)
+
+	author := &models.Author{
+		ForeignID:        "hc:rec-author",
+		Name:             "Rec Author",
+		SortName:         "Author, Rec",
+		MetadataProvider: "hardcover",
+		Monitored:        true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	if err := recRepo.ReplaceBatch(ctx, 1, []models.RecommendationCandidate{{
+		ForeignID:  "hc:rec-book",
+		RecType:    models.RecTypeListCross,
+		Title:      "Recommended Book",
+		AuthorName: author.Name,
+		AuthorID:   &author.ID,
+		MediaType:  models.MediaTypeAudiobook,
+		Genres:     []string{},
+		Score:      1,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	audioASIN := "B123REC000"
+	provider := &stubMetaProvider{
+		name: "hardcover",
+		editionsByBook: map[string][]models.Edition{
+			"hc:rec-book": {{
+				ForeignID: "hc:rec-book-audio",
+				Title:     "Recommended Book",
+				ASIN:      &audioASIN,
+				Format:    "Audiobook",
+				Monitored: true,
+			}},
+		},
+	}
+	searcher := newMockBookSearcher()
+	handler := NewRecommendationHandler(recRepo, fakeRecommendationEngine{}, authorRepo, bookRepo, searcher).
+		WithFinder(seriesRepo, nil).
+		WithEditionHydration(editionRepo, metadata.NewAggregator(provider).WithAudnexClient(nil)).
+		WithAppContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.Add(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/recommendations/1/add", nil), "id", "1"))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	queued := searcher.waitForCall(t, time.Second)
+	if queued.ASIN != audioASIN {
+		t.Fatalf("queued ASIN = %q, want %q", queued.ASIN, audioASIN)
+	}
+	book, err := bookRepo.GetByForeignID(ctx, "hc:rec-book")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if book == nil || book.ASIN != audioASIN {
+		t.Fatalf("book was not hydrated: %+v", book)
+	}
+	editions, err := editionRepo.ListByBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(editions) != 1 || editions[0].ForeignID != "hc:rec-book-audio" {
+		t.Fatalf("expected hydrated edition, got %+v", editions)
+	}
+}

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
@@ -31,6 +32,9 @@ type SeriesHandler struct {
 	settings                    *db.SettingsRepo
 	finder                      LibraryFinder
 	enhancedHardcoverEnvEnabled bool
+	editions                    *db.EditionRepo
+
+	editionFetcher bookhydrate.EditionFetcher
 }
 
 const (
@@ -54,6 +58,38 @@ func (h *SeriesHandler) WithHardcoverFeatureSettings(settings *db.SettingsRepo, 
 func (h *SeriesHandler) WithFinder(f LibraryFinder) *SeriesHandler {
 	h.finder = f
 	return h
+}
+
+// WithEditionHydration wires edition persistence for Hardcover catalog books.
+func (h *SeriesHandler) WithEditionHydration(editions *db.EditionRepo) *SeriesHandler {
+	h.editions = editions
+	return h
+}
+
+// WithEditionFetcher overrides the edition fetcher used by tests.
+func (h *SeriesHandler) WithEditionFetcher(fetcher bookhydrate.EditionFetcher) *SeriesHandler {
+	h.editionFetcher = fetcher
+	return h
+}
+
+func (h *SeriesHandler) hydrateHardcoverEditions(ctx context.Context, book *models.Book) {
+	if book == nil || h.editions == nil {
+		return
+	}
+	fetcher := h.editionFetcher
+	if fetcher == nil && h.meta != nil {
+		fetcher = func(ctx context.Context, foreignID string) ([]models.Edition, error) {
+			return h.meta.GetEditionsFromProvider(ctx, "hardcover", foreignID)
+		}
+	}
+	bookhydrate.HydrateHardcoverEditions(ctx, bookhydrate.Options{
+		Book:          book,
+		Provider:      "hardcover",
+		Editions:      h.editions,
+		Books:         h.books,
+		FetchEditions: fetcher,
+		Enricher:      h.meta,
+	})
 }
 
 func (h *SeriesHandler) hardcoverFeatureState(ctx context.Context) HardcoverFeatureState {
@@ -413,6 +449,11 @@ func (h *SeriesHandler) queueSeriesBook(ctx context.Context, b models.Book) (boo
 	}
 	if err := h.books.MarkWantedMonitored(ctx, b.ID); err != nil {
 		return false, err
+	}
+	if full, err := h.books.GetByID(ctx, b.ID); err != nil {
+		slog.Warn("series fill: failed to reload queued book metadata", "bookID", b.ID, "error", err)
+	} else if full != nil {
+		b = *full
 	}
 	b.Status = models.BookStatusWanted
 	b.Monitored = true
@@ -1209,6 +1250,7 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *
 	if err := h.books.Create(ctx, &book); err != nil {
 		return nil, err
 	}
+	h.hydrateHardcoverEditions(ctx, &book)
 	if _, err := h.series.LinkBookIfMissing(ctx, series.ID, book.ID, catalogBook.Position, true); err != nil {
 		return nil, err
 	}

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -95,7 +95,7 @@ func seriesFixtureWithProvider(t *testing.T, provider *stubSeriesProvider, searc
 	if searcher == nil {
 		searcher = &mockBookSearcher{}
 	}
-	return NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metadata.NewAggregator(provider), searcher), seriesRepo, authorRepo, bookRepo
+	return NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metadata.NewAggregator(provider).WithAudnexClient(nil), searcher), seriesRepo, authorRepo, bookRepo
 }
 
 func seriesFixtureWithProviderAndSettings(t *testing.T, provider *stubSeriesProvider, searcher BookSearcher, envEnabled bool) (*SeriesHandler, *db.SeriesRepo, *db.AuthorRepo, *db.BookRepo, *db.SettingsRepo) {
@@ -112,9 +112,28 @@ func seriesFixtureWithProviderAndSettings(t *testing.T, provider *stubSeriesProv
 	if searcher == nil {
 		searcher = &mockBookSearcher{}
 	}
-	handler := NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metadata.NewAggregator(provider), searcher).
+	handler := NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metadata.NewAggregator(provider).WithAudnexClient(nil), searcher).
 		WithHardcoverFeatureSettings(settingsRepo, envEnabled)
 	return handler, seriesRepo, authorRepo, bookRepo, settingsRepo
+}
+
+func seriesFixtureWithProviderAndEditions(t *testing.T, provider *stubSeriesProvider, searcher BookSearcher) (*SeriesHandler, *db.SeriesRepo, *db.AuthorRepo, *db.BookRepo, *db.EditionRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	seriesRepo := db.NewSeriesRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	editionRepo := db.NewEditionRepo(database)
+	if searcher == nil {
+		searcher = &mockBookSearcher{}
+	}
+	handler := NewSeriesHandler(seriesRepo, bookRepo, authorRepo, metadata.NewAggregator(provider).WithAudnexClient(nil), searcher).
+		WithEditionHydration(editionRepo)
+	return handler, seriesRepo, authorRepo, bookRepo, editionRepo
 }
 
 func TestSeriesList_Empty(t *testing.T) {
@@ -1322,6 +1341,65 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 	}
 	if len(books) != 1 || books[0].ForeignID != "hc:the-way-of-kings" {
 		t.Fatalf("expected created book linked to series, got %+v", books)
+	}
+}
+
+func TestSeriesFillHydratesHardcoverEditionsBeforeQueue(t *testing.T) {
+	catalog := stormlightCatalog()
+	catalog.Books[0].Book.MediaType = models.MediaTypeAudiobook
+	searcher := newMockBookSearcher()
+	h, seriesRepo, _, bookRepo, editionRepo := seriesFixtureWithProviderAndEditions(t, &stubSeriesProvider{
+		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+	}, searcher)
+	audioASIN := "B000STORML"
+	h.WithEditionFetcher(func(context.Context, string) ([]models.Edition, error) {
+		return []models.Edition{{
+			ForeignID: "hc:stormlight-audio",
+			Title:     "The Way of Kings",
+			ASIN:      &audioASIN,
+			Format:    "Audiobook",
+			Monitored: true,
+		}}, nil
+	})
+	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+	if err := seriesRepo.Create(contextBackground(), series); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.UpsertHardcoverLink(contextBackground(), &models.SeriesHardcoverLink{
+		SeriesID:            series.ID,
+		HardcoverSeriesID:   catalog.ForeignID,
+		HardcoverProviderID: catalog.ProviderID,
+		HardcoverTitle:      catalog.Title,
+		HardcoverAuthorName: catalog.AuthorName,
+		HardcoverBookCount:  catalog.BookCount,
+		Confidence:          1,
+		LinkedBy:            "manual",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", nil), "id", strconv.FormatInt(series.ID, 10)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	queued := searcher.waitForCall(t, time.Second)
+	if queued.ASIN != audioASIN {
+		t.Fatalf("queued book ASIN = %q, want %q", queued.ASIN, audioASIN)
+	}
+	created, err := bookRepo.GetByForeignID(contextBackground(), "hc:the-way-of-kings")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created == nil || created.ASIN != audioASIN {
+		t.Fatalf("created book ASIN not persisted: %+v", created)
+	}
+	editions, err := editionRepo.ListByBook(contextBackground(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(editions) != 1 || editions[0].ForeignID != "hc:stormlight-audio" {
+		t.Fatalf("expected hydrated edition, got %+v", editions)
 	}
 }
 

--- a/internal/bookhydrate/hardcover.go
+++ b/internal/bookhydrate/hardcover.go
@@ -1,0 +1,189 @@
+// Package bookhydrate persists metadata-provider edition details for newly
+// created or rebound books.
+package bookhydrate
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// EditionFetcher fetches provider editions for the given book foreign ID.
+type EditionFetcher func(context.Context, string) ([]models.Edition, error)
+
+// EditionUpserter stores metadata editions without overwriting existing
+// non-empty imported or curated fields.
+type EditionUpserter interface {
+	UpsertMetadata(context.Context, *models.Edition) (bool, error)
+}
+
+// BookUpdater persists book-level fields promoted during hydration.
+type BookUpdater interface {
+	Update(context.Context, *models.Book) error
+}
+
+// AudiobookEnricher fills audiobook metadata once an ASIN is known.
+type AudiobookEnricher interface {
+	EnrichAudiobook(context.Context, *models.Book) error
+}
+
+// Options describes a single Hardcover edition hydration attempt.
+type Options struct {
+	Book          *models.Book
+	Provider      string
+	Editions      EditionUpserter
+	Books         BookUpdater
+	FetchEditions EditionFetcher
+	Enricher      AudiobookEnricher
+}
+
+// Result summarizes a best-effort hydration attempt.
+type Result struct {
+	Fetched           int
+	Upserted          int
+	ASINPromoted      bool
+	AudiobookEnriched bool
+	BookUpdated       bool
+	Err               error
+}
+
+// IsHardcoverBook reports whether a book has a confident Hardcover identity.
+func IsHardcoverBook(book *models.Book, provider string) bool {
+	if strings.EqualFold(strings.TrimSpace(provider), "hardcover") {
+		return true
+	}
+	if book == nil {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(book.MetadataProvider), "hardcover") {
+		return true
+	}
+	return strings.HasPrefix(strings.TrimSpace(book.ForeignID), "hc:")
+}
+
+// HydrateHardcoverEditions fetches and persists Hardcover editions for a
+// confident Hardcover book. All failures are logged and reflected in Result.Err
+// but are non-fatal to callers.
+func HydrateHardcoverEditions(ctx context.Context, opts Options) Result {
+	var result Result
+	book := opts.Book
+	if book == nil || book.ID == 0 {
+		return result
+	}
+	if !IsHardcoverBook(book, opts.Provider) {
+		return result
+	}
+	if opts.Editions == nil || opts.FetchEditions == nil {
+		return result
+	}
+
+	editions, err := opts.FetchEditions(ctx, book.ForeignID)
+	if err != nil {
+		result.Err = err
+		slog.Warn("hardcover edition hydration failed", "bookID", book.ID, "foreignID", book.ForeignID, "error", err)
+		return result
+	}
+	result.Fetched = len(editions)
+
+	for i := range editions {
+		editions[i].BookID = book.ID
+		if strings.TrimSpace(editions[i].Title) == "" {
+			editions[i].Title = book.Title
+		}
+		ok, err := opts.Editions.UpsertMetadata(ctx, &editions[i])
+		if err != nil {
+			if result.Err == nil {
+				result.Err = err
+			}
+			slog.Warn("hardcover edition upsert failed", "bookID", book.ID, "foreignID", book.ForeignID, "editionID", editions[i].ForeignID, "error", err)
+			continue
+		}
+		if !ok {
+			slog.Debug("hardcover edition skipped because it belongs to another book", "bookID", book.ID, "foreignID", book.ForeignID, "editionID", editions[i].ForeignID)
+			continue
+		}
+		result.Upserted++
+	}
+
+	if maybePromoteASIN(book, editions) {
+		result.ASINPromoted = true
+		if opts.Enricher != nil {
+			if err := opts.Enricher.EnrichAudiobook(ctx, book); err != nil {
+				if result.Err == nil {
+					result.Err = err
+				}
+				slog.Debug("hardcover ASIN audiobook enrichment skipped", "bookID", book.ID, "asin", book.ASIN, "error", err)
+			} else {
+				result.AudiobookEnriched = true
+			}
+		}
+		if opts.Books != nil {
+			if err := opts.Books.Update(ctx, book); err != nil {
+				if result.Err == nil {
+					result.Err = err
+				}
+				slog.Warn("hardcover ASIN promotion persist failed", "bookID", book.ID, "asin", book.ASIN, "error", err)
+			} else {
+				result.BookUpdated = true
+			}
+		}
+	}
+
+	return result
+}
+
+func maybePromoteASIN(book *models.Book, editions []models.Edition) bool {
+	if book == nil || strings.TrimSpace(book.ASIN) != "" || !bookAcceptsAudiobookASIN(book) {
+		return false
+	}
+	asin := preferredEditionASIN(editions)
+	if asin == "" {
+		return false
+	}
+	book.ASIN = asin
+	return true
+}
+
+func bookAcceptsAudiobookASIN(book *models.Book) bool {
+	return book.MediaType == models.MediaTypeAudiobook || book.MediaType == models.MediaTypeBoth
+}
+
+func preferredEditionASIN(editions []models.Edition) string {
+	bestASIN := ""
+	bestScore := -1
+	for _, edition := range editions {
+		if edition.ASIN == nil {
+			continue
+		}
+		asin := strings.ToUpper(strings.TrimSpace(*edition.ASIN))
+		if asin == "" {
+			continue
+		}
+		score := audioEditionScore(edition)
+		if bestASIN == "" || score > bestScore {
+			bestASIN = asin
+			bestScore = score
+		}
+	}
+	return bestASIN
+}
+
+func audioEditionScore(edition models.Edition) int {
+	text := strings.ToLower(strings.Join([]string{
+		edition.Format,
+		edition.EditionInfo,
+	}, " "))
+	score := 0
+	for _, marker := range []string{"audio", "audible", "mp3", "cd", "cassette"} {
+		if strings.Contains(text, marker) {
+			score += 10
+			break
+		}
+	}
+	if !edition.IsEbook {
+		score++
+	}
+	return score
+}

--- a/internal/bookhydrate/hardcover.go
+++ b/internal/bookhydrate/hardcover.go
@@ -31,12 +31,13 @@ type AudiobookEnricher interface {
 
 // Options describes a single Hardcover edition hydration attempt.
 type Options struct {
-	Book          *models.Book
-	Provider      string
-	Editions      EditionUpserter
-	Books         BookUpdater
-	FetchEditions EditionFetcher
-	Enricher      AudiobookEnricher
+	Book              *models.Book
+	Provider          string
+	ProviderForeignID string
+	Editions          EditionUpserter
+	Books             BookUpdater
+	FetchEditions     EditionFetcher
+	Enricher          AudiobookEnricher
 }
 
 // Result summarizes a best-effort hydration attempt.
@@ -72,17 +73,21 @@ func HydrateHardcoverEditions(ctx context.Context, opts Options) Result {
 	if book == nil || book.ID == 0 {
 		return result
 	}
-	if !IsHardcoverBook(book, opts.Provider) {
+	editionForeignID := strings.TrimSpace(opts.ProviderForeignID)
+	if editionForeignID == "" {
+		editionForeignID = book.ForeignID
+	}
+	if !IsHardcoverBook(book, opts.Provider) && !strings.HasPrefix(editionForeignID, "hc:") {
 		return result
 	}
 	if opts.Editions == nil || opts.FetchEditions == nil {
 		return result
 	}
 
-	editions, err := opts.FetchEditions(ctx, book.ForeignID)
+	editions, err := opts.FetchEditions(ctx, editionForeignID)
 	if err != nil {
 		result.Err = err
-		slog.Warn("hardcover edition hydration failed", "bookID", book.ID, "foreignID", book.ForeignID, "error", err)
+		slog.Warn("hardcover edition hydration failed", "bookID", book.ID, "foreignID", editionForeignID, "bookForeignID", book.ForeignID, "error", err)
 		return result
 	}
 	result.Fetched = len(editions)
@@ -99,11 +104,11 @@ func HydrateHardcoverEditions(ctx context.Context, opts Options) Result {
 			if result.Err == nil {
 				result.Err = err
 			}
-			slog.Warn("hardcover edition upsert failed", "bookID", book.ID, "foreignID", book.ForeignID, "editionID", edition.ForeignID, "error", err)
+			slog.Warn("hardcover edition upsert failed", "bookID", book.ID, "foreignID", editionForeignID, "bookForeignID", book.ForeignID, "editionID", edition.ForeignID, "error", err)
 			continue
 		}
 		if !ok {
-			slog.Debug("hardcover edition skipped because it belongs to another book", "bookID", book.ID, "foreignID", book.ForeignID, "editionID", edition.ForeignID)
+			slog.Debug("hardcover edition skipped because it belongs to another book", "bookID", book.ID, "foreignID", editionForeignID, "bookForeignID", book.ForeignID, "editionID", edition.ForeignID)
 			continue
 		}
 		result.Upserted++

--- a/internal/bookhydrate/hardcover.go
+++ b/internal/bookhydrate/hardcover.go
@@ -89,25 +89,26 @@ func HydrateHardcoverEditions(ctx context.Context, opts Options) Result {
 
 	acceptedAudioEditions := make([]models.Edition, 0, len(editions))
 	for i := range editions {
-		editions[i].BookID = book.ID
-		if strings.TrimSpace(editions[i].Title) == "" {
-			editions[i].Title = book.Title
+		edition := editions[i]
+		edition.BookID = book.ID
+		if strings.TrimSpace(edition.Title) == "" {
+			edition.Title = book.Title
 		}
-		ok, err := opts.Editions.UpsertMetadata(ctx, &editions[i])
+		ok, err := opts.Editions.UpsertMetadata(ctx, &edition)
 		if err != nil {
 			if result.Err == nil {
 				result.Err = err
 			}
-			slog.Warn("hardcover edition upsert failed", "bookID", book.ID, "foreignID", book.ForeignID, "editionID", editions[i].ForeignID, "error", err)
+			slog.Warn("hardcover edition upsert failed", "bookID", book.ID, "foreignID", book.ForeignID, "editionID", edition.ForeignID, "error", err)
 			continue
 		}
 		if !ok {
-			slog.Debug("hardcover edition skipped because it belongs to another book", "bookID", book.ID, "foreignID", book.ForeignID, "editionID", editions[i].ForeignID)
+			slog.Debug("hardcover edition skipped because it belongs to another book", "bookID", book.ID, "foreignID", book.ForeignID, "editionID", edition.ForeignID)
 			continue
 		}
 		result.Upserted++
-		if isLikelyAudioEdition(editions[i]) {
-			acceptedAudioEditions = append(acceptedAudioEditions, editions[i])
+		if isLikelyAudioEdition(edition) {
+			acceptedAudioEditions = append(acceptedAudioEditions, edition)
 		}
 	}
 

--- a/internal/bookhydrate/hardcover.go
+++ b/internal/bookhydrate/hardcover.go
@@ -87,6 +87,7 @@ func HydrateHardcoverEditions(ctx context.Context, opts Options) Result {
 	}
 	result.Fetched = len(editions)
 
+	acceptedAudioEditions := make([]models.Edition, 0, len(editions))
 	for i := range editions {
 		editions[i].BookID = book.ID
 		if strings.TrimSpace(editions[i].Title) == "" {
@@ -105,9 +106,12 @@ func HydrateHardcoverEditions(ctx context.Context, opts Options) Result {
 			continue
 		}
 		result.Upserted++
+		if isLikelyAudioEdition(editions[i]) {
+			acceptedAudioEditions = append(acceptedAudioEditions, editions[i])
+		}
 	}
 
-	if maybePromoteASIN(book, editions) {
+	if maybePromoteASIN(book, acceptedAudioEditions) {
 		result.ASINPromoted = true
 		if opts.Enricher != nil {
 			if err := opts.Enricher.EnrichAudiobook(ctx, book); err != nil {
@@ -176,14 +180,28 @@ func audioEditionScore(edition models.Edition) int {
 		edition.EditionInfo,
 	}, " "))
 	score := 0
-	for _, marker := range []string{"audio", "audible", "mp3", "cd", "cassette"} {
-		if strings.Contains(text, marker) {
-			score += 10
-			break
-		}
+	if editionHasAudioMarker(text) {
+		score += 10
 	}
 	if !edition.IsEbook {
 		score++
 	}
 	return score
+}
+
+func isLikelyAudioEdition(edition models.Edition) bool {
+	text := strings.ToLower(strings.Join([]string{
+		edition.Format,
+		edition.EditionInfo,
+	}, " "))
+	return editionHasAudioMarker(text)
+}
+
+func editionHasAudioMarker(text string) bool {
+	for _, marker := range []string{"audio", "audible", "mp3", "cd", "cassette"} {
+		if strings.Contains(text, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/bookhydrate/hardcover_test.go
+++ b/internal/bookhydrate/hardcover_test.go
@@ -1,0 +1,145 @@
+package bookhydrate
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+type fakeAudiobookEnricher struct {
+	calls int
+	err   error
+}
+
+func (f *fakeAudiobookEnricher) EnrichAudiobook(_ context.Context, book *models.Book) error {
+	f.calls++
+	if f.err != nil {
+		return f.err
+	}
+	book.Narrator = "Kate Reading"
+	return nil
+}
+
+func newHydrateBook(t *testing.T, foreignID, provider, mediaType string) (*db.BookRepo, *db.EditionRepo, *models.Book, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	editions := db.NewEditionRepo(database)
+	author := &models.Author{ForeignID: "OL-HYDRATE-A", Name: "Author", SortName: "Author", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID:        foreignID,
+		AuthorID:         author.ID,
+		Title:            "Hydrated Book",
+		SortTitle:        "Hydrated Book",
+		Status:           models.BookStatusWanted,
+		Genres:           []string{},
+		MetadataProvider: provider,
+		MediaType:        mediaType,
+		Monitored:        true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	return books, editions, book, ctx
+}
+
+func TestHydrateHardcoverEditionsAssignsBookAndPromotesAudioASIN(t *testing.T) {
+	books, editions, book, ctx := newHydrateBook(t, "hc:hydrated-book", "hardcover", models.MediaTypeAudiobook)
+	kindleASIN := "B111111111"
+	audioASIN := "b222222222"
+	enricher := &fakeAudiobookEnricher{}
+
+	result := HydrateHardcoverEditions(ctx, Options{
+		Book:     book,
+		Provider: "hardcover",
+		Editions: editions,
+		Books:    books,
+		FetchEditions: func(context.Context, string) ([]models.Edition, error) {
+			return []models.Edition{
+				{ForeignID: "hc:kindle", Title: "Kindle", ASIN: &kindleASIN, Format: "Kindle", IsEbook: true},
+				{ForeignID: "hc:audio", Title: "Audio", ASIN: &audioASIN, Format: "Audiobook"},
+			}, nil
+		},
+		Enricher: enricher,
+	})
+	if result.Err != nil {
+		t.Fatalf("hydrate err = %v", result.Err)
+	}
+	if result.Fetched != 2 || result.Upserted != 2 || !result.ASINPromoted || !result.AudiobookEnriched || !result.BookUpdated {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if book.ASIN != "B222222222" {
+		t.Fatalf("promoted ASIN = %q", book.ASIN)
+	}
+	if enricher.calls != 1 {
+		t.Fatalf("enricher calls = %d", enricher.calls)
+	}
+
+	stored, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.ASIN != "B222222222" || stored.Narrator != "Kate Reading" {
+		t.Fatalf("book update not persisted: %+v", stored)
+	}
+	list, err := editions.ListByBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("editions persisted = %d", len(list))
+	}
+	for _, edition := range list {
+		if edition.BookID != book.ID {
+			t.Fatalf("edition book id = %d, want %d", edition.BookID, book.ID)
+		}
+	}
+}
+
+func TestHydrateHardcoverEditionsSkipsNonHardcoverBook(t *testing.T) {
+	books, editions, book, ctx := newHydrateBook(t, "OL123W", "openlibrary", models.MediaTypeAudiobook)
+	calls := 0
+	result := HydrateHardcoverEditions(ctx, Options{
+		Book:     book,
+		Editions: editions,
+		Books:    books,
+		FetchEditions: func(context.Context, string) ([]models.Edition, error) {
+			calls++
+			return nil, nil
+		},
+	})
+	if result.Fetched != 0 || calls != 0 {
+		t.Fatalf("non-Hardcover hydration should be no-op, result=%+v calls=%d", result, calls)
+	}
+}
+
+func TestHydrateHardcoverEditionsReturnsFetchErrorAsBestEffort(t *testing.T) {
+	books, editions, book, ctx := newHydrateBook(t, "hc:hydrated-book", "hardcover", models.MediaTypeAudiobook)
+	fetchErr := errors.New("hardcover unavailable")
+	result := HydrateHardcoverEditions(ctx, Options{
+		Book:          book,
+		Provider:      "hardcover",
+		Editions:      editions,
+		Books:         books,
+		FetchEditions: func(context.Context, string) ([]models.Edition, error) { return nil, fetchErr },
+	})
+	if !errors.Is(result.Err, fetchErr) {
+		t.Fatalf("result err = %v, want %v", result.Err, fetchErr)
+	}
+	if result.Upserted != 0 || book.ASIN != "" {
+		t.Fatalf("unexpected mutation after fetch failure: result=%+v book=%+v", result, book)
+	}
+}

--- a/internal/bookhydrate/hardcover_test.go
+++ b/internal/bookhydrate/hardcover_test.go
@@ -286,6 +286,39 @@ func TestHydrateHardcoverEditionsDoesNotPromoteNonAudioASIN(t *testing.T) {
 	}
 }
 
+func TestHydrateHardcoverEditionsDoesNotMutateFetchedEditions(t *testing.T) {
+	books, editions, book, ctx := newHydrateBook(t, "hc:hydrated-book", "hardcover", models.MediaTypeAudiobook)
+	audioASIN := "B111111111"
+	fetched := []models.Edition{{
+		ForeignID: "hc:audio",
+		ASIN:      &audioASIN,
+		Format:    "Audiobook",
+		Monitored: true,
+	}}
+
+	result := HydrateHardcoverEditions(ctx, Options{
+		Book:     book,
+		Provider: "hardcover",
+		Editions: editions,
+		Books:    books,
+		FetchEditions: func(context.Context, string) ([]models.Edition, error) {
+			return fetched, nil
+		},
+	})
+	if result.Err != nil {
+		t.Fatalf("hydrate err = %v", result.Err)
+	}
+	if result.Upserted != 1 || !result.ASINPromoted {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if fetched[0].BookID != 0 {
+		t.Fatalf("fetched edition BookID mutated to %d", fetched[0].BookID)
+	}
+	if fetched[0].Title != "" {
+		t.Fatalf("fetched edition Title mutated to %q", fetched[0].Title)
+	}
+}
+
 func TestHydrateHardcoverEditionsSkipsNonHardcoverBook(t *testing.T) {
 	books, editions, book, ctx := newHydrateBook(t, "OL123W", "openlibrary", models.MediaTypeAudiobook)
 	calls := 0

--- a/internal/bookhydrate/hardcover_test.go
+++ b/internal/bookhydrate/hardcover_test.go
@@ -183,6 +183,62 @@ func TestHydrateHardcoverEditionsDoesNotPromoteSkippedEditionASIN(t *testing.T) 
 	}
 }
 
+func TestHydrateHardcoverEditionsPromotesStoredEditionASIN(t *testing.T) {
+	books, editions, book, ctx := newHydrateBook(t, "hc:hydrated-book", "hardcover", models.MediaTypeAudiobook)
+	storedASIN := "B111STORED"
+	if ok, err := editions.UpsertMetadata(ctx, &models.Edition{
+		ForeignID: "hc:audio",
+		BookID:    book.ID,
+		Title:     "Stored Audio",
+		ASIN:      &storedASIN,
+		Format:    "Audiobook",
+		Monitored: true,
+	}); err != nil || !ok {
+		t.Fatalf("seed edition ok=%v err=%v", ok, err)
+	}
+	replacementASIN := "B999FETCHD"
+
+	result := HydrateHardcoverEditions(ctx, Options{
+		Book:     book,
+		Provider: "hardcover",
+		Editions: editions,
+		Books:    books,
+		FetchEditions: func(context.Context, string) ([]models.Edition, error) {
+			return []models.Edition{{
+				ForeignID: "hc:audio",
+				Title:     "Fetched Audio",
+				ASIN:      &replacementASIN,
+				Format:    "Audiobook",
+				Monitored: true,
+			}}, nil
+		},
+		Enricher: &fakeAudiobookEnricher{},
+	})
+	if result.Err != nil {
+		t.Fatalf("hydrate err = %v", result.Err)
+	}
+	if !result.ASINPromoted || !result.BookUpdated {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if book.ASIN != storedASIN {
+		t.Fatalf("promoted ASIN = %q, want stored %q", book.ASIN, storedASIN)
+	}
+	stored, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.ASIN != storedASIN {
+		t.Fatalf("stored book ASIN = %q, want %q", stored.ASIN, storedASIN)
+	}
+	edition, err := editions.GetByForeignID(ctx, "hc:audio")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edition.ASIN == nil || *edition.ASIN != storedASIN {
+		t.Fatalf("edition ASIN was overwritten: %+v", edition)
+	}
+}
+
 func TestHydrateHardcoverEditionsDoesNotPromoteNonAudioASIN(t *testing.T) {
 	books, editions, book, ctx := newHydrateBook(t, "hc:hydrated-book", "hardcover", models.MediaTypeAudiobook)
 	kindleASIN := "B111111111"

--- a/internal/bookhydrate/hardcover_test.go
+++ b/internal/bookhydrate/hardcover_test.go
@@ -109,6 +109,127 @@ func TestHydrateHardcoverEditionsAssignsBookAndPromotesAudioASIN(t *testing.T) {
 	}
 }
 
+func TestHydrateHardcoverEditionsDoesNotPromoteSkippedEditionASIN(t *testing.T) {
+	books, editions, book, ctx := newHydrateBook(t, "hc:hydrated-book", "hardcover", models.MediaTypeAudiobook)
+	other := &models.Book{
+		ForeignID:        "hc:other-book",
+		AuthorID:         book.AuthorID,
+		Title:            "Other Book",
+		SortTitle:        "Other Book",
+		Status:           models.BookStatusWanted,
+		Genres:           []string{},
+		MetadataProvider: "hardcover",
+		MediaType:        models.MediaTypeAudiobook,
+		Monitored:        true,
+	}
+	if err := books.Create(ctx, other); err != nil {
+		t.Fatal(err)
+	}
+
+	skippedASIN := "B000SKIPP0"
+	if ok, err := editions.UpsertMetadata(ctx, &models.Edition{
+		ForeignID: "hc:shared-audio",
+		BookID:    other.ID,
+		Title:     "Other Audio",
+		ASIN:      &skippedASIN,
+		Format:    "Audiobook",
+		Monitored: true,
+	}); err != nil || !ok {
+		t.Fatalf("seed edition ok=%v err=%v", ok, err)
+	}
+	enricher := &fakeAudiobookEnricher{}
+
+	result := HydrateHardcoverEditions(ctx, Options{
+		Book:     book,
+		Provider: "hardcover",
+		Editions: editions,
+		Books:    books,
+		FetchEditions: func(context.Context, string) ([]models.Edition, error) {
+			return []models.Edition{{
+				ForeignID: "hc:shared-audio",
+				Title:     "Skipped Audio",
+				ASIN:      &skippedASIN,
+				Format:    "Audiobook",
+				Monitored: true,
+			}}, nil
+		},
+		Enricher: enricher,
+	})
+	if result.Err != nil {
+		t.Fatalf("hydrate err = %v", result.Err)
+	}
+	if result.Fetched != 1 || result.Upserted != 0 || result.ASINPromoted || result.BookUpdated {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if book.ASIN != "" {
+		t.Fatalf("skipped edition ASIN was promoted: %q", book.ASIN)
+	}
+	if enricher.calls != 0 {
+		t.Fatalf("enricher calls = %d, want 0", enricher.calls)
+	}
+	stored, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.ASIN != "" {
+		t.Fatalf("stored ASIN = %q, want empty", stored.ASIN)
+	}
+	list, err := editions.ListByBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("skipped edition was linked to target book: %+v", list)
+	}
+}
+
+func TestHydrateHardcoverEditionsDoesNotPromoteNonAudioASIN(t *testing.T) {
+	books, editions, book, ctx := newHydrateBook(t, "hc:hydrated-book", "hardcover", models.MediaTypeAudiobook)
+	kindleASIN := "B111111111"
+	hardcoverASIN := "B333333333"
+	enricher := &fakeAudiobookEnricher{}
+
+	result := HydrateHardcoverEditions(ctx, Options{
+		Book:     book,
+		Provider: "hardcover",
+		Editions: editions,
+		Books:    books,
+		FetchEditions: func(context.Context, string) ([]models.Edition, error) {
+			return []models.Edition{
+				{ForeignID: "hc:kindle", Title: "Kindle", ASIN: &kindleASIN, Format: "Kindle", IsEbook: true},
+				{ForeignID: "hc:hardcover", Title: "Hardcover", ASIN: &hardcoverASIN, Format: "Hardcover", EditionInfo: "First edition"},
+			}, nil
+		},
+		Enricher: enricher,
+	})
+	if result.Err != nil {
+		t.Fatalf("hydrate err = %v", result.Err)
+	}
+	if result.Fetched != 2 || result.Upserted != 2 || result.ASINPromoted || result.BookUpdated {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if book.ASIN != "" {
+		t.Fatalf("non-audio ASIN was promoted: %q", book.ASIN)
+	}
+	if enricher.calls != 0 {
+		t.Fatalf("enricher calls = %d, want 0", enricher.calls)
+	}
+	stored, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.ASIN != "" {
+		t.Fatalf("stored ASIN = %q, want empty", stored.ASIN)
+	}
+	list, err := editions.ListByBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("editions persisted = %d, want 2", len(list))
+	}
+}
+
 func TestHydrateHardcoverEditionsSkipsNonHardcoverBook(t *testing.T) {
 	books, editions, book, ctx := newHydrateBook(t, "OL123W", "openlibrary", models.MediaTypeAudiobook)
 	calls := 0

--- a/internal/bookhydrate/hardcover_test.go
+++ b/internal/bookhydrate/hardcover_test.go
@@ -319,6 +319,48 @@ func TestHydrateHardcoverEditionsDoesNotMutateFetchedEditions(t *testing.T) {
 	}
 }
 
+func TestHydrateHardcoverEditionsUsesProviderForeignID(t *testing.T) {
+	books, editions, book, ctx := newHydrateBook(t, "OL123W", "openlibrary", models.MediaTypeAudiobook)
+	audioASIN := "B222222222"
+	var gotForeignID string
+
+	result := HydrateHardcoverEditions(ctx, Options{
+		Book:              book,
+		Provider:          "openlibrary",
+		ProviderForeignID: "hc:matched-book",
+		Editions:          editions,
+		Books:             books,
+		FetchEditions: func(_ context.Context, foreignID string) ([]models.Edition, error) {
+			gotForeignID = foreignID
+			return []models.Edition{{
+				ForeignID: "hc:matched-audio",
+				ASIN:      &audioASIN,
+				Format:    "Audiobook",
+				Monitored: true,
+			}}, nil
+		},
+	})
+	if result.Err != nil {
+		t.Fatalf("hydrate err = %v", result.Err)
+	}
+	if gotForeignID != "hc:matched-book" {
+		t.Fatalf("fetch foreign ID = %q, want hc:matched-book", gotForeignID)
+	}
+	if !result.ASINPromoted || !result.BookUpdated {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if book.ForeignID != "OL123W" || book.ASIN != audioASIN {
+		t.Fatalf("book identity or ASIN changed unexpectedly: %+v", book)
+	}
+	list, err := editions.ListByBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 || list[0].ForeignID != "hc:matched-audio" {
+		t.Fatalf("expected matched edition, got %+v", list)
+	}
+}
+
 func TestHydrateHardcoverEditionsSkipsNonHardcoverBook(t *testing.T) {
 	books, editions, book, ctx := newHydrateBook(t, "OL123W", "openlibrary", models.MediaTypeAudiobook)
 	calls := 0

--- a/internal/db/editions.go
+++ b/internal/db/editions.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -140,6 +141,73 @@ func (r *EditionRepo) Upsert(ctx context.Context, e *models.Edition) error {
 	}
 	e.UpdatedAt = now
 	return nil
+}
+
+// UpsertMetadata inserts an edition discovered from an external metadata
+// provider, or fills empty fields on the existing row for the same book. It
+// deliberately refuses to re-parent a foreign edition ID that already belongs
+// to another book; callers can treat ok=false as a benign skipped conflict.
+func (r *EditionRepo) UpsertMetadata(ctx context.Context, e *models.Edition) (bool, error) {
+	if e == nil || strings.TrimSpace(e.ForeignID) == "" || e.BookID == 0 {
+		return false, nil
+	}
+	if strings.TrimSpace(e.Title) == "" {
+		e.Title = "Unknown Edition"
+	}
+
+	now := time.Now().UTC()
+	isEbook := 0
+	if e.IsEbook {
+		isEbook = 1
+	}
+	monitored := 1
+
+	res, err := r.db.ExecContext(ctx, `
+		INSERT INTO editions (foreign_id, book_id, title, isbn_13, isbn_10, asin,
+		                      publisher, publish_date, format, num_pages, language,
+		                      image_url, is_ebook, edition_info, monitored,
+		                      created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(foreign_id) DO UPDATE SET
+		    title       = COALESCE(NULLIF(editions.title, ''), excluded.title),
+		    isbn_13     = COALESCE(NULLIF(editions.isbn_13, ''), excluded.isbn_13),
+		    isbn_10     = COALESCE(NULLIF(editions.isbn_10, ''), excluded.isbn_10),
+		    asin        = COALESCE(NULLIF(editions.asin, ''), excluded.asin),
+		    publisher   = COALESCE(NULLIF(editions.publisher, ''), excluded.publisher),
+		    publish_date= COALESCE(editions.publish_date, excluded.publish_date),
+		    format      = COALESCE(NULLIF(editions.format, ''), excluded.format),
+		    num_pages   = COALESCE(editions.num_pages, excluded.num_pages),
+		    language    = COALESCE(NULLIF(editions.language, ''), excluded.language),
+		    image_url   = COALESCE(NULLIF(editions.image_url, ''), excluded.image_url),
+		    is_ebook    = CASE WHEN editions.is_ebook = 1 THEN 1 ELSE excluded.is_ebook END,
+		    edition_info= COALESCE(NULLIF(editions.edition_info, ''), excluded.edition_info),
+		    updated_at  = excluded.updated_at
+		WHERE editions.book_id = excluded.book_id`,
+		e.ForeignID, e.BookID, e.Title, e.ISBN13, e.ISBN10, e.ASIN,
+		e.Publisher, e.PublishDate, e.Format, e.NumPages, e.Language,
+		e.ImageURL, isEbook, e.EditionInfo, monitored, now, now)
+	if err != nil {
+		return false, fmt.Errorf("upsert metadata edition %s: %w", e.ForeignID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("metadata edition rows affected %s: %w", e.ForeignID, err)
+	}
+	if affected == 0 {
+		return false, nil
+	}
+
+	var bookID int64
+	row := r.db.QueryRowContext(ctx, "SELECT id, book_id FROM editions WHERE foreign_id = ?", e.ForeignID)
+	if err := row.Scan(&e.ID, &bookID); err != nil {
+		return false, fmt.Errorf("lookup metadata edition %s: %w", e.ForeignID, err)
+	}
+	if bookID != e.BookID {
+		e.ID = 0
+		return false, nil
+	}
+	e.UpdatedAt = now
+	return true, nil
 }
 
 func (r *EditionRepo) Delete(ctx context.Context, id int64) error {

--- a/internal/db/editions.go
+++ b/internal/db/editions.go
@@ -144,9 +144,11 @@ func (r *EditionRepo) Upsert(ctx context.Context, e *models.Edition) error {
 }
 
 // UpsertMetadata inserts an edition discovered from an external metadata
-// provider, or fills empty fields on the existing row for the same book. It
-// deliberately refuses to re-parent a foreign edition ID that already belongs
-// to another book; callers can treat ok=false as a benign skipped conflict.
+// provider, or fills empty fields on the existing row for the same book. On a
+// successful insert or update, e is hydrated with the stored row so callers
+// that promote edition fields use the persisted values. It deliberately refuses
+// to re-parent a foreign edition ID that already belongs to another book;
+// callers can treat ok=false as a benign skipped conflict.
 func (r *EditionRepo) UpsertMetadata(ctx context.Context, e *models.Edition) (bool, error) {
 	if e == nil || strings.TrimSpace(e.ForeignID) == "" || e.BookID == 0 {
 		return false, nil
@@ -197,16 +199,27 @@ func (r *EditionRepo) UpsertMetadata(ctx context.Context, e *models.Edition) (bo
 		return false, nil
 	}
 
-	var bookID int64
-	row := r.db.QueryRowContext(ctx, "SELECT id, book_id FROM editions WHERE foreign_id = ?", e.ForeignID)
-	if err := row.Scan(&e.ID, &bookID); err != nil {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, foreign_id, book_id, title, isbn_13, isbn_10, asin, publisher,
+		       publish_date, format, num_pages, language, image_url, is_ebook,
+		       edition_info, monitored, created_at, updated_at
+		FROM editions WHERE foreign_id = ?`, e.ForeignID)
+	var stored models.Edition
+	var isStoredEbook, storedMonitored int
+	if err := row.Scan(&stored.ID, &stored.ForeignID, &stored.BookID, &stored.Title,
+		&stored.ISBN13, &stored.ISBN10, &stored.ASIN, &stored.Publisher,
+		&stored.PublishDate, &stored.Format, &stored.NumPages, &stored.Language,
+		&stored.ImageURL, &isStoredEbook, &stored.EditionInfo, &storedMonitored,
+		&stored.CreatedAt, &stored.UpdatedAt); err != nil {
 		return false, fmt.Errorf("lookup metadata edition %s: %w", e.ForeignID, err)
 	}
-	if bookID != e.BookID {
+	stored.IsEbook = isStoredEbook == 1
+	stored.Monitored = storedMonitored == 1
+	if stored.BookID != e.BookID {
 		e.ID = 0
 		return false, nil
 	}
-	e.UpdatedAt = now
+	*e = stored
 	return true, nil
 }
 

--- a/internal/db/editions_test.go
+++ b/internal/db/editions_test.go
@@ -157,7 +157,7 @@ func TestEditionRepo_UpsertMetadataFillsMissingFields(t *testing.T) {
 
 	isbn13 := "9780000000001"
 	replacementASIN := "B999999999"
-	ok, err = repo.UpsertMetadata(ctx, &models.Edition{
+	incoming := &models.Edition{
 		ForeignID: "hc:ed1",
 		BookID:    b.ID,
 		Title:     "Updated Title",
@@ -168,12 +168,19 @@ func TestEditionRepo_UpsertMetadataFillsMissingFields(t *testing.T) {
 		Language:  "ger",
 		ImageURL:  "https://img/new.jpg",
 		Monitored: true,
-	})
+	}
+	ok, err = repo.UpsertMetadata(ctx, incoming)
 	if err != nil {
 		t.Fatalf("metadata conflict upsert: %v", err)
 	}
 	if !ok {
 		t.Fatal("metadata conflict upsert skipped unexpectedly")
+	}
+	if incoming.ISBN13 == nil || *incoming.ISBN13 != isbn13 {
+		t.Fatalf("incoming edition was not hydrated with filled ISBN13: %+v", incoming)
+	}
+	if incoming.ASIN == nil || *incoming.ASIN != asin || incoming.Format != "Audiobook" || incoming.ImageURL != "https://img/ed1.jpg" {
+		t.Fatalf("incoming edition was not hydrated with preserved stored fields: %+v", incoming)
 	}
 	got, err = repo.GetByForeignID(ctx, "hc:ed1")
 	if err != nil {

--- a/internal/db/editions_test.go
+++ b/internal/db/editions_test.go
@@ -150,6 +150,7 @@ func TestEditionRepo_UpsertMetadataFillsMissingFields(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected edition")
+		return
 	}
 	if got.ASIN == nil || *got.ASIN != asin || got.Publisher != "Tor" || got.NumPages == nil || *got.NumPages != pages || got.ImageURL == "" {
 		t.Fatalf("metadata fields were not inserted: %+v", got)

--- a/internal/db/editions_test.go
+++ b/internal/db/editions_test.go
@@ -100,6 +100,136 @@ func TestEditionRepo_UpsertInsertAndUpdate(t *testing.T) {
 	}
 }
 
+func TestEditionRepo_UpsertMetadataFillsMissingFields(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := &models.Author{ForeignID: "OL-META-A", Name: "A", SortName: "A", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authorRepo.Create(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	b := &models.Book{
+		ForeignID: "hc:meta-book", AuthorID: a.ID, Title: "Book", SortTitle: "Book",
+		Status: "wanted", Genres: []string{}, MetadataProvider: "hardcover", Monitored: true,
+	}
+	if err := bookRepo.Create(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewEditionRepo(database)
+	asin := "B000000001"
+	pages := 400
+	ok, err := repo.UpsertMetadata(ctx, &models.Edition{
+		ForeignID: "hc:ed1",
+		BookID:    b.ID,
+		Title:     "Hardcover Edition",
+		ASIN:      &asin,
+		Publisher: "Tor",
+		Format:    "Audiobook",
+		NumPages:  &pages,
+		Language:  "eng",
+		ImageURL:  "https://img/ed1.jpg",
+		Monitored: true,
+	})
+	if err != nil {
+		t.Fatalf("metadata upsert: %v", err)
+	}
+	if !ok {
+		t.Fatal("metadata upsert skipped unexpectedly")
+	}
+
+	got, err := repo.GetByForeignID(ctx, "hc:ed1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected edition")
+	}
+	if got.ASIN == nil || *got.ASIN != asin || got.Publisher != "Tor" || got.NumPages == nil || *got.NumPages != pages || got.ImageURL == "" {
+		t.Fatalf("metadata fields were not inserted: %+v", got)
+	}
+
+	isbn13 := "9780000000001"
+	replacementASIN := "B999999999"
+	ok, err = repo.UpsertMetadata(ctx, &models.Edition{
+		ForeignID: "hc:ed1",
+		BookID:    b.ID,
+		Title:     "Updated Title",
+		ISBN13:    &isbn13,
+		ASIN:      &replacementASIN,
+		Publisher: "Should Not Replace",
+		Format:    "Kindle",
+		Language:  "ger",
+		ImageURL:  "https://img/new.jpg",
+		Monitored: true,
+	})
+	if err != nil {
+		t.Fatalf("metadata conflict upsert: %v", err)
+	}
+	if !ok {
+		t.Fatal("metadata conflict upsert skipped unexpectedly")
+	}
+	got, err = repo.GetByForeignID(ctx, "hc:ed1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ISBN13 == nil || *got.ISBN13 != isbn13 {
+		t.Fatalf("missing ISBN13 was not filled: %+v", got)
+	}
+	if got.Title != "Hardcover Edition" || got.ASIN == nil || *got.ASIN != asin || got.Publisher != "Tor" || got.Format != "Audiobook" || got.Language != "eng" || got.ImageURL != "https://img/ed1.jpg" {
+		t.Fatalf("existing non-empty metadata was overwritten: %+v", got)
+	}
+}
+
+func TestEditionRepo_UpsertMetadataSkipsDifferentBook(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := &models.Author{ForeignID: "OL-META-SKIP-A", Name: "A", SortName: "A", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authorRepo.Create(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	first := &models.Book{ForeignID: "hc:first", AuthorID: a.ID, Title: "First", SortTitle: "First", Status: "wanted", Genres: []string{}, MetadataProvider: "hardcover", Monitored: true}
+	second := &models.Book{ForeignID: "hc:second", AuthorID: a.ID, Title: "Second", SortTitle: "Second", Status: "wanted", Genres: []string{}, MetadataProvider: "hardcover", Monitored: true}
+	if err := bookRepo.Create(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.Create(ctx, second); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewEditionRepo(database)
+	if ok, err := repo.UpsertMetadata(ctx, &models.Edition{ForeignID: "hc:shared-ed", BookID: first.ID, Title: "First Edition"}); err != nil || !ok {
+		t.Fatalf("seed metadata edition ok=%v err=%v", ok, err)
+	}
+	ok, err := repo.UpsertMetadata(ctx, &models.Edition{ForeignID: "hc:shared-ed", BookID: second.ID, Title: "Second Edition"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("expected conflicting edition to be skipped")
+	}
+	got, err := repo.GetByForeignID(ctx, "hc:shared-ed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.BookID != first.ID || got.Title != "First Edition" {
+		t.Fatalf("edition moved or changed unexpectedly: %+v", got)
+	}
+}
+
 func TestEditionRepo_GetByForeignIDNotFound(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/metadata/hardcover"
 	"github.com/vavallee/bindery/internal/models"
@@ -16,17 +17,21 @@ import (
 
 // ListSyncer syncs enabled Hardcover import lists into Bindery's book catalogue.
 type ListSyncer struct {
-	importLists     *db.ImportListRepo
-	authors         *db.AuthorRepo
-	books           *db.BookRepo
-	series          seriesLinker
-	tokenSource     func(context.Context) string
-	hardcoverClient func(token string) hardcoverListClient
+	importLists *db.ImportListRepo
+	authors     *db.AuthorRepo
+	books       *db.BookRepo
+	series      seriesLinker
+	editions    *db.EditionRepo
+
+	tokenSource   func(context.Context) string
+	clientFactory hardcoverClientFactory
+	enricher      bookhydrate.AudiobookEnricher
 }
 
-type hardcoverListClient interface {
-	GetUserLists(ctx context.Context) ([]hardcover.HCList, error)
-	GetListBooks(ctx context.Context, listID int) ([]models.Book, error)
+type hardcoverClient interface {
+	GetUserLists(context.Context) ([]hardcover.HCList, error)
+	GetListBooks(context.Context, int) ([]models.Book, error)
+	GetEditions(context.Context, string) ([]models.Edition, error)
 }
 
 // seriesLinker is the slice of *db.SeriesRepo the syncer needs to persist
@@ -37,15 +42,15 @@ type seriesLinker interface {
 	LinkBook(ctx context.Context, seriesID, bookID int64, position string, primary bool) error
 }
 
+type hardcoverClientFactory func(string) hardcoverClient
+
 // New creates a new ListSyncer.
 func New(importLists *db.ImportListRepo, authors *db.AuthorRepo, books *db.BookRepo) *ListSyncer {
 	return &ListSyncer{
-		importLists: importLists,
-		authors:     authors,
-		books:       books,
-		hardcoverClient: func(token string) hardcoverListClient {
-			return hardcover.NewAuthenticated(token)
-		},
+		importLists:   importLists,
+		authors:       authors,
+		books:         books,
+		clientFactory: func(apiKey string) hardcoverClient { return hardcover.NewAuthenticated(apiKey) },
 	}
 }
 
@@ -58,6 +63,21 @@ func (s *ListSyncer) WithSeriesRepo(repo *db.SeriesRepo) *ListSyncer {
 		return s
 	}
 	s.series = repo
+	return s
+}
+
+// WithEditionHydration wires edition persistence for Hardcover list imports.
+func (s *ListSyncer) WithEditionHydration(editions *db.EditionRepo, enricher bookhydrate.AudiobookEnricher) *ListSyncer {
+	s.editions = editions
+	s.enricher = enricher
+	return s
+}
+
+// WithClientFactory overrides the Hardcover client factory used by tests.
+func (s *ListSyncer) WithClientFactory(factory hardcoverClientFactory) *ListSyncer {
+	if factory != nil {
+		s.clientFactory = factory
+	}
 	return s
 }
 
@@ -135,7 +155,7 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 	if token == "" {
 		return ErrMissingToken
 	}
-	client := s.hardcoverClient(token)
+	client := s.clientFactory(token)
 
 	// Resolve the list by slug
 	userLists, err := client.GetUserLists(ctx)
@@ -195,6 +215,7 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 			slog.Warn("failed to create book", "title", book.Title, "error", err)
 			continue
 		}
+		s.hydrateHardcoverEditions(ctx, &book, client)
 		slog.Info("imported book from hardcover list", "title", book.Title, "author_id", authorID)
 
 		s.linkSeriesRefs(ctx, &book)
@@ -230,6 +251,20 @@ func (s *ListSyncer) tokenForList(ctx context.Context, il models.ImportList) str
 		return ""
 	}
 	return hardcover.NormalizeAPIToken(s.tokenSource(ctx))
+}
+
+func (s *ListSyncer) hydrateHardcoverEditions(ctx context.Context, book *models.Book, client hardcoverClient) {
+	if book == nil || client == nil || s.editions == nil {
+		return
+	}
+	bookhydrate.HydrateHardcoverEditions(ctx, bookhydrate.Options{
+		Book:          book,
+		Provider:      "hardcover",
+		Editions:      s.editions,
+		Books:         s.books,
+		FetchEditions: client.GetEditions,
+		Enricher:      s.enricher,
+	})
 }
 
 // ensureAuthor looks up the author by foreign ID, creating a minimal record if

--- a/internal/hardcoverlistsyncer/syncer_test.go
+++ b/internal/hardcoverlistsyncer/syncer_test.go
@@ -180,10 +180,10 @@ func TestSyncOne_UsesGlobalTokenWhenListHasNoOverride(t *testing.T) {
 	}
 	s.WithTokenSource(func(context.Context) string { return "global-token" })
 	var gotToken string
-	s.hardcoverClient = func(token string) hardcoverListClient {
+	s.WithClientFactory(func(token string) hardcoverClient {
 		gotToken = token
-		return fakeHardcoverListClient{lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}}}
-	}
+		return &fakeHardcoverClient{lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}}}
+	})
 
 	if err := s.SyncOne(ctx, il.ID); err != nil {
 		t.Fatalf("SyncOne: %v", err)
@@ -204,10 +204,10 @@ func TestSyncOne_PerListTokenOverridesGlobalToken(t *testing.T) {
 	}
 	s.WithTokenSource(func(context.Context) string { return "global-token" })
 	var gotToken string
-	s.hardcoverClient = func(token string) hardcoverListClient {
+	s.WithClientFactory(func(token string) hardcoverClient {
 		gotToken = token
-		return fakeHardcoverListClient{lists: []hardcover.HCList{{ID: 24, Slug: il.URL, Name: il.Name}}}
-	}
+		return &fakeHardcoverClient{lists: []hardcover.HCList{{ID: 24, Slug: il.URL, Name: il.Name}}}
+	})
 
 	if err := s.SyncOne(ctx, il.ID); err != nil {
 		t.Fatalf("SyncOne: %v", err)
@@ -233,17 +233,22 @@ func TestSyncOne_ErrMissingToken(t *testing.T) {
 	}
 }
 
-type fakeHardcoverListClient struct {
-	lists []hardcover.HCList
-	books []models.Book
+type fakeHardcoverClient struct {
+	lists    []hardcover.HCList
+	books    []models.Book
+	editions []models.Edition
 }
 
-func (f fakeHardcoverListClient) GetUserLists(context.Context) ([]hardcover.HCList, error) {
+func (f *fakeHardcoverClient) GetUserLists(context.Context) ([]hardcover.HCList, error) {
 	return f.lists, nil
 }
 
-func (f fakeHardcoverListClient) GetListBooks(context.Context, int) ([]models.Book, error) {
+func (f *fakeHardcoverClient) GetListBooks(context.Context, int) ([]models.Book, error) {
 	return f.books, nil
+}
+
+func (f *fakeHardcoverClient) GetEditions(context.Context, string) ([]models.Edition, error) {
+	return f.editions, nil
 }
 
 // newTestSyncerWithSeries returns a syncer wired against a real in-memory DB
@@ -298,12 +303,12 @@ func TestSyncOne_LinksSeriesRefsAfterBookImport(t *testing.T) {
 		Position:  "1",
 		Primary:   true,
 	}})
-	s.hardcoverClient = func(string) hardcoverListClient {
-		return fakeHardcoverListClient{
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
 			lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}},
 			books: []models.Book{book},
 		}
-	}
+	})
 
 	if err := s.SyncOne(ctx, il.ID); err != nil {
 		t.Fatalf("SyncOne: %v", err)
@@ -348,12 +353,12 @@ func TestSyncOne_SeriesLinkErrorDoesNotBlockImport(t *testing.T) {
 		Position:  "1",
 		Primary:   true,
 	}})
-	s.hardcoverClient = func(string) hardcoverListClient {
-		return fakeHardcoverListClient{
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
 			lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}},
 			books: []models.Book{book},
 		}
-	}
+	})
 
 	if err := s.SyncOne(ctx, il.ID); err != nil {
 		t.Fatalf("SyncOne should succeed even when series linking errors: %v", err)
@@ -407,12 +412,12 @@ func TestSyncOne_NoSeriesRepo_NoSeriesLinkAttempted(t *testing.T) {
 		Position:  "1",
 		Primary:   true,
 	}})
-	s.hardcoverClient = func(string) hardcoverListClient {
-		return fakeHardcoverListClient{
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
 			lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}},
 			books: []models.Book{book},
 		}
-	}
+	})
 
 	if err := s.SyncOne(ctx, il.ID); err != nil {
 		t.Fatalf("SyncOne: %v", err)
@@ -420,5 +425,70 @@ func TestSyncOne_NoSeriesRepo_NoSeriesLinkAttempted(t *testing.T) {
 	imported, err := s.books.GetByForeignID(ctx, "hc:dune")
 	if err != nil || imported == nil {
 		t.Fatalf("book should be imported: %v, %v", imported, err)
+	}
+}
+
+func TestSync_HydratesHardcoverEditions(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	importLists := db.NewImportListRepo(database)
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	editions := db.NewEditionRepo(database)
+
+	audioASIN := "B123LISTEN"
+	client := &fakeHardcoverClient{
+		lists: []hardcover.HCList{{ID: 10, Slug: "want-to-read", Name: "Want to Read"}},
+		books: []models.Book{{
+			ForeignID:        "hc:list-book",
+			Title:            "List Book",
+			SortTitle:        "List Book",
+			MetadataProvider: "hardcover",
+			MediaType:        models.MediaTypeAudiobook,
+			Genres:           []string{},
+			Author: &models.Author{
+				ForeignID:        "hc:list-author",
+				Name:             "List Author",
+				SortName:         "Author, List",
+				MetadataProvider: "hardcover",
+			},
+		}},
+		editions: []models.Edition{{
+			ForeignID: "hc:list-book-audio",
+			Title:     "List Book",
+			ASIN:      &audioASIN,
+			Format:    "Audiobook",
+			Monitored: true,
+		}},
+	}
+	syncer := New(importLists, authors, books).
+		WithEditionHydration(editions, nil).
+		WithClientFactory(func(string) hardcoverClient { return client })
+	il := testImportList("Want", "hardcover", true)
+	il.URL = "want-to-read"
+	if err := importLists.Create(ctx, &il); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := syncer.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	book, err := books.GetByForeignID(ctx, "hc:list-book")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if book == nil || book.ASIN != audioASIN {
+		t.Fatalf("book was not hydrated: %+v", book)
+	}
+	got, err := editions.ListByBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ForeignID != "hc:list-book-audio" {
+		t.Fatalf("expected hydrated edition, got %+v", got)
 	}
 }

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -122,6 +122,34 @@ func (a *Aggregator) GetEditions(ctx context.Context, bookForeignID string) ([]m
 	return editions, nil
 }
 
+// GetEditionsFromProvider fetches editions from a named provider, bypassing
+// prefix-based routing. This is used when callers know the provider from UI
+// state but the stored foreign ID is an unprefixed provider-native value.
+func (a *Aggregator) GetEditionsFromProvider(ctx context.Context, providerName, bookForeignID string) ([]models.Edition, error) {
+	providerName = strings.TrimSpace(strings.ToLower(providerName))
+	bookForeignID = strings.TrimSpace(bookForeignID)
+	if providerName == "" || bookForeignID == "" {
+		return nil, nil
+	}
+	key := "editions-provider:" + providerName + ":" + bookForeignID
+	if cached, ok := a.cache.get(key); ok {
+		return cached.([]models.Edition), nil
+	}
+
+	for _, provider := range a.providers() {
+		if provider == nil || normalizedProviderName(provider.Name()) != normalizedProviderName(providerName) {
+			continue
+		}
+		editions, err := provider.GetEditions(ctx, bookForeignID)
+		if err != nil {
+			return nil, err
+		}
+		a.cache.set(key, editions)
+		return editions, nil
+	}
+	return nil, ErrProviderNotConfigured
+}
+
 func (a *Aggregator) GetBookByISBN(ctx context.Context, isbn string) (*models.Book, error) {
 	isbn = isbnutil.Normalize(isbn)
 	key := "isbn:" + isbn

--- a/internal/metadata/aggregator_author_works.go
+++ b/internal/metadata/aggregator_author_works.go
@@ -173,6 +173,9 @@ func authorWorkMergeKey(title string) string {
 }
 
 func mergeAuthorWorkMetadata(dst *models.Book, src models.Book) {
+	if dst.HardcoverForeignID == "" {
+		dst.HardcoverForeignID = hardcoverForeignIDForAuthorWork(src)
+	}
 	if dst.ImageURL == "" {
 		dst.ImageURL = src.ImageURL
 	}
@@ -200,4 +203,14 @@ func mergeAuthorWorkMetadata(dst *models.Book, src models.Book) {
 	if dst.MediaType == "" {
 		dst.MediaType = src.MediaType
 	}
+}
+
+func hardcoverForeignIDForAuthorWork(book models.Book) string {
+	if id := strings.TrimSpace(book.HardcoverForeignID); strings.HasPrefix(id, "hc:") {
+		return id
+	}
+	if id := strings.TrimSpace(book.ForeignID); strings.HasPrefix(id, "hc:") && normalizedProviderName(book.MetadataProvider) == "hardcover" {
+		return id
+	}
+	return ""
 }

--- a/internal/metadata/aggregator_author_works_test.go
+++ b/internal/metadata/aggregator_author_works_test.go
@@ -111,11 +111,17 @@ func TestAggregator_GetAuthorWorksForAuthor_MergesSupplementalByTitle(t *testing
 	if got[0].ForeignID != "OL1W" || got[0].MetadataProvider != "openlibrary" {
 		t.Fatalf("primary identity should win duplicate title: %+v", got[0])
 	}
+	if got[0].HardcoverForeignID != "hc:dune" {
+		t.Fatalf("matched hardcover identity = %q, want hc:dune", got[0].HardcoverForeignID)
+	}
 	if got[0].ImageURL != "https://img/dune.jpg" || got[0].AverageRating != 4.5 || got[0].Description == "" {
 		t.Fatalf("supplemental metadata was not merged: %+v", got[0])
 	}
 	if got[1].ForeignID != "hc:children-of-dune" {
 		t.Fatalf("supplemental-only book missing: %+v", got[1])
+	}
+	if got[1].HardcoverForeignID != "" {
+		t.Fatalf("unmatched supplemental book should not carry matched hardcover identity: %+v", got[1])
 	}
 }
 

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -281,6 +281,20 @@ func TestAggregator_GetEditions_Cached(t *testing.T) {
 	}
 }
 
+func TestAggregator_GetEditionsFromProvider_RoutesUnprefixedID(t *testing.T) {
+	primary := &mockProvider{name: "ol"}
+	hardcover := &mockProvider{name: "hardcover", getEditions: []models.Edition{{Title: "Audio"}}}
+	agg := newTestAggregator(primary, hardcover)
+
+	got, err := agg.GetEditionsFromProvider(context.Background(), "hardcover", "123")
+	if err != nil {
+		t.Fatalf("GetEditionsFromProvider: %v", err)
+	}
+	if len(got) != 1 || got[0].Title != "Audio" {
+		t.Fatalf("unexpected editions: %+v", got)
+	}
+}
+
 // TestAggregator_ResolveBookByISBN_AcceptsDNBWithSyntheticAuthorID is the
 // regression test for #608: prior to the DNB-author-foreign-id fix, the
 // aggregator silently dropped DNB-only ISBN hits because Author.ForeignID

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -39,6 +39,7 @@ type Book struct {
 	ASIN                  string     `json:"asin"`
 	CalibreID             *int64     `json:"calibre_id,omitempty"`
 	MetadataProvider      string     `json:"metadataProvider"`
+	HardcoverForeignID    string     `json:"-"`
 	LastMetadataRefreshAt *time.Time `json:"lastMetadataRefreshAt"`
 	CreatedAt             time.Time  `json:"createdAt"`
 	UpdatedAt             time.Time  `json:"updatedAt"`


### PR DESCRIPTION
## Summary

Hardcover metadata now exposes useful edition fields, but Bindery was not persisting them when an existing workflow already had a confident Hardcover book identity. This PR hydrates edition rows and promotes audiobook ASINs only from known Hardcover IDs already present during create, rebind, sync, series, and recommendation flows; it does not add matching logic, backfill existing books, or change best-effort add-book matches that lack a `HardcoverForeignID`.

- Adds a shared `bookhydrate` helper that fetches Hardcover editions, upserts edition metadata without overwriting existing non-empty fields, skips edition IDs already attached to another book, and promotes accepted audiobook ASINs before optional Audnex enrichment.
- Adds provider-explicit edition fetching so matched Hardcover IDs can hydrate even when the stored primary book identity belongs to another provider.
- Wires best-effort hydration into rebind/map-metadata, author sync, Hardcover list sync, series fill/catalog creation, recommendations, and direct add-book when the created book already carries a Hardcover identity.
- Adds focused coverage for the hydration helper, metadata edition upserts, matched author sync, direct add, rebind/map-metadata, recommendations, series fill, and Hardcover list sync.

## Checklist

- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed - N/A, no env, config, deployment, or upgrade-path change
- [ ] `CHANGELOG.md` `[Unreleased]` section updated - N/A, release-time only per `AGENTS.md`
- [ ] Wiki pages updated if user-facing behaviour changed - N/A, no wiki source is available in this checkout; scope and limitations are documented above

## Test plan

- [x] `go test ./internal/bookhydrate ./internal/db ./internal/metadata ./internal/hardcoverlistsyncer ./internal/api`
- [x] `gofmt -l cmd internal`
- [x] `go vet ./...`
- [x] `go test ./cmd/... ./internal/...`
- [x] `cd web && npm run build`
