### PR TITLE
fix(grimmory): document that v3.x has no API keys and omit empty Authorization (#818)

### DIFF
--- a/internal/grimmory/client.go
+++ b/internal/grimmory/client.go
@@ -135,7 +135,13 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader, ou
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	// Grimmory v3.x does not have API keys; the maintainer confirmed this on
+	// grimmory-tools/grimmory#1487 (#818). Send the Authorization header only
+	// when the user actually configured one — sending "Bearer " with an empty
+	// token is a no-op against current Grimmory and just noise on the wire.
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
 	req.Header.Set("User-Agent", c.userAgent)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")

--- a/internal/grimmory/client_test.go
+++ b/internal/grimmory/client_test.go
@@ -333,6 +333,29 @@ func TestDo_SetsAuthHeader(t *testing.T) {
 	}
 }
 
+// TestDo_OmitsAuthHeaderWhenKeyEmpty covers #818: Grimmory v3.x has no API
+// keys, so the client must not send "Authorization: Bearer " with an empty
+// token when the user leaves the field blank. Sending the header with a
+// trailing space is meaningless and just clutters the request.
+func TestDo_OmitsAuthHeaderWhenKeyEmpty(t *testing.T) {
+	var sawAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawAuth = r.Header["Authorization"]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(srv.URL, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	_, _ = c.Ping(context.Background())
+
+	if sawAuth {
+		t.Error("Authorization header was set with empty api key; expected omission")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // APIError.Error()
 // ---------------------------------------------------------------------------

--- a/web/src/pages/settings/GrimmoryTab.tsx
+++ b/web/src/pages/settings/GrimmoryTab.tsx
@@ -67,8 +67,13 @@ export default function GrimmoryTab() {
         <p className="text-xs text-slate-600 dark:text-zinc-500 mb-4">
           Push newly imported books to a{' '}
           <a href="https://grimmory.org" target="_blank" rel="noopener noreferrer" className="underline">Grimmory</a>{' '}
-          self-hosted library. Enable the Grimmory REST API (<code>API_DOCS_ENABLED=true</code>) and provide
-          your server URL and API token.
+          self-hosted library. Enable the Grimmory REST API on your Grimmory server with{' '}
+          <code>API_DOCS_ENABLED=true</code> and enter its URL below.
+        </p>
+        <p className="text-xs text-amber-700 dark:text-amber-400 mb-4">
+          Grimmory v3.x does not have API keys
+          (<a href="https://github.com/orgs/grimmory-tools/discussions/1487" target="_blank" rel="noopener noreferrer" className="underline">grimmory-tools/grimmory#1487</a>)
+          — leave the field blank unless a future Grimmory release adds token auth.
         </p>
       </div>
 
@@ -95,13 +100,16 @@ export default function GrimmoryTab() {
         </div>
         <div>
           <label className="block text-xs font-medium mb-1">
-            API Key{config?.apiKeyConfigured && !draft.apiKey ? ' (configured — leave blank to keep)' : ''}
+            API Key
+            <span className="ml-1 text-slate-500 dark:text-zinc-500 font-normal">
+              {config?.apiKeyConfigured && !draft.apiKey ? '(configured — leave blank to keep)' : '(optional, see above)'}
+            </span>
           </label>
           <input
             type="password"
             value={draft.apiKey}
             onChange={e => setDraft(prev => ({ ...prev, apiKey: e.target.value }))}
-            placeholder={config?.apiKeyConfigured ? '••••••••' : 'Paste API token here'}
+            placeholder={config?.apiKeyConfigured ? '••••••••' : 'Leave blank for current Grimmory'}
             className={inputCls}
           />
         </div>

--- a/web/src/pages/settings/GrimmoryTab.tsx
+++ b/web/src/pages/settings/GrimmoryTab.tsx
@@ -64,6 +64,11 @@ export default function GrimmoryTab() {
     <div className="space-y-6 max-w-lg">
       <div>
         <h3 className="text-lg font-semibold mb-1">Grimmory</h3>
+        <div role="alert" className="mb-4 px-3 py-2 rounded border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-900/20 text-xs text-amber-800 dark:text-amber-300">
+          <strong>Configuration only.</strong> Bindery does not yet push imported books to Grimmory — the
+          settings here are persisted and the connection can be tested, but no books will be sent.{' '}
+          <a href="https://github.com/vavallee/bindery/issues/826" target="_blank" rel="noopener noreferrer" className="underline">Tracking issue #826</a>.
+        </div>
         <p className="text-xs text-slate-600 dark:text-zinc-500 mb-4">
           Push newly imported books to a{' '}
           <a href="https://grimmory.org" target="_blank" rel="noopener noreferrer" className="underline">Grimmory</a>{' '}


### PR DESCRIPTION
Closes #818. Honesty pass on the Grimmory integration.

## Two changes

**1. Document the API-key reality (#818)**
The Grimmory maintainer confirmed in [grimmory-tools/grimmory#1487](https://github.com/orgs/grimmory-tools/discussions/1487): *"There are no API keys at this time."* Our Settings UI implied a token was required, so the reporter who couldn't find one assumed the integration was broken.

- **GrimmoryTab.tsx**: description explicitly states Grimmory v3.x has no API keys, links the upstream discussion, marks the field optional. Placeholder reads "Leave blank for current Grimmory".
- **internal/grimmory/client.go**: `Client.do()` now omits the `Authorization` header when `apiKey` is empty. Sending `Bearer ` (trailing space, nothing else) was a no-op against today's Grimmory and just noise.
- New regression test `TestDo_OmitsAuthHeaderWhenKeyEmpty`.

**2. Mark the tab configuration-only (banner pointing to #826)**
Audit found the broader integration is essentially cosmetic — the client exposes only `Ping()`, the importer never pushes books to Grimmory after import, and the "Enable Grimmory integration" toggle is dead. PR #825 doesn't fix that gap, but it stops the UI from misleading the user about it.

- **GrimmoryTab.tsx**: amber alert banner at the top of the tab: *"Configuration only. Bindery does not yet push imported books to Grimmory — the settings here are persisted and the connection can be tested, but no books will be sent. Tracking issue #826."*

The actual push pipeline (client write methods, importer hook, bulk sync, idempotency, etc.) is tracked separately in #826.

## Forward compat

If Grimmory eventually ships token auth, paste it into the same field — the existing code path still works. Nothing was removed.

## Test plan

- [x] `go test ./internal/grimmory/...` — green, including new `TestDo_OmitsAuthHeaderWhenKeyEmpty`
- [x] `gofmt -l`, `go vet ./...` — clean
- [x] `npm run typecheck`, `npm run lint`, `npm run build` — clean
- [x] `npm test` — 226/226 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)