### PR TITLE
fix(downloader): detect case-mismatched qBit path after PathRemap (#800 follow-up)

### DIFF
--- a/internal/downloader/health.go
+++ b/internal/downloader/health.go
@@ -3,6 +3,7 @@ package downloader
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -194,7 +195,68 @@ func validateQbittorrentCategorySavePath(ctx context.Context, qb *qbittorrent.Cl
 		return healthError(fmt.Sprintf("qBittorrent category %q saves to %q, which maps to %q inside Bindery; expected a path at or under %q — %s", category, savePath, localPath, expected, hint))
 	}
 
+	// pathIsAtOrUnder passes — the strings agree. Now verify the resolved
+	// path is actually reachable from Bindery's filesystem, because Linux is
+	// case-sensitive and a user with a Windows/WSL/Docker setup can produce
+	// a textually-correct remap that silently points at nothing (PixieApples,
+	// follow-up to #800). When the path is missing but a case-variant exists,
+	// name the divergent component so the user knows exactly which letter to
+	// fix instead of brute-forcing combinations.
+	if _, err := os.Stat(localPath); os.IsNotExist(err) {
+		if resolved, divergedAt := findCaseInsensitivePath(localPath); resolved != "" {
+			return healthError(fmt.Sprintf("qBittorrent category %q saves to %q, which maps to %q inside Bindery — that exact path does not exist, but %q does. Linux is case-sensitive; update the path remap so it produces %q (the segment %q must match the on-disk case).", category, savePath, localPath, resolved, resolved, filepath.Base(divergedAt)))
+		}
+		return healthError(fmt.Sprintf("qBittorrent category %q saves to %q, which maps to %q inside Bindery — but that path does not exist. Check the path remap and the directory Bindery is mounting.", category, savePath, localPath))
+	}
+
 	return models.DownloadClientHealth{Status: HealthOK}
+}
+
+// findCaseInsensitivePath walks p from root and, if the literal path does not
+// exist but a case-insensitive sibling does at some level, returns the
+// case-corrected path and the first divergent component. Returns ("", "") if
+// the path can't be resolved even case-insensitively. Used by the qBittorrent
+// health-check to give Windows/WSL/Docker users a concrete fix when their
+// PathRemap is textually right but on the wrong-cased mount point.
+func findCaseInsensitivePath(p string) (resolved, divergedAt string) {
+	if !filepath.IsAbs(p) {
+		return "", ""
+	}
+	sep := string(filepath.Separator)
+	parts := strings.Split(strings.TrimPrefix(filepath.Clean(p), sep), sep)
+	cur := sep
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		candidate := filepath.Join(cur, part)
+		if _, err := os.Stat(candidate); err == nil {
+			cur = candidate
+			continue
+		}
+		entries, err := os.ReadDir(cur)
+		if err != nil {
+			return "", ""
+		}
+		var match string
+		for _, entry := range entries {
+			if strings.EqualFold(entry.Name(), part) {
+				match = entry.Name()
+				break
+			}
+		}
+		if match == "" {
+			return "", ""
+		}
+		if divergedAt == "" {
+			divergedAt = filepath.Join(cur, match)
+		}
+		cur = filepath.Join(cur, match)
+	}
+	if divergedAt == "" {
+		return "", ""
+	}
+	return cur, divergedAt
 }
 
 func healthError(message string) models.DownloadClientHealth {

--- a/internal/downloader/health_test.go
+++ b/internal/downloader/health_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,6 +13,18 @@ import (
 )
 
 func TestCheckDownloadClientHealth_QBittorrentCategoryPath(t *testing.T) {
+	// Build real on-disk paths so the post-pathIsAtOrUnder stat() check
+	// passes on the happy paths. Cases that should fail before stat (missing
+	// category, empty save path, pathIsAtOrUnder mismatch) are unaffected.
+	tmp := t.TempDir()
+	expected := filepath.Join(tmp, "books", "downloads")
+	if err := os.MkdirAll(filepath.Join(expected, "books"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(expected, "Torrents", "books"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		name       string
 		categories string
@@ -20,13 +34,14 @@ func TestCheckDownloadClientHealth_QBittorrentCategoryPath(t *testing.T) {
 	}{
 		{
 			name:       "remapped category path matches",
-			categories: `{"books":{"name":"books","savePath":"/media/downloads"}}`,
+			categories: `{"books":{"name":"books","savePath":"/media/downloads/books"}}`,
+			pathRemap:  "/media/downloads:" + expected,
 			wantStatus: HealthOK,
 		},
 		{
 			name:       "qbit v5 boolean download_path still remaps category path",
-			categories: `{"books":{"download_path":false,"name":"books","savePath":"/media/books/downloads"}}`,
-			pathRemap:  "/media/books:/books",
+			categories: `{"books":{"download_path":false,"name":"books","savePath":"/media/books/downloads/books"}}`,
+			pathRemap:  "/media/books/downloads:" + expected,
 			wantStatus: HealthOK,
 		},
 		{
@@ -45,18 +60,20 @@ func TestCheckDownloadClientHealth_QBittorrentCategoryPath(t *testing.T) {
 			name:       "mismatched category path",
 			categories: `{"books":{"name":"books","savePath":"/media/other"}}`,
 			wantStatus: HealthError,
-			wantText:   `expected a path at or under "/books/downloads"`,
+			wantText:   `expected a path at or under`,
 		},
 		{
 			name:       "category path is a subdirectory of download dir",
 			categories: `{"books":{"name":"books","savePath":"/media/downloads/Torrents/books"}}`,
+			pathRemap:  "/media/downloads:" + expected,
 			wantStatus: HealthOK,
 		},
 		{
 			name:       "category path under sibling dir is still rejected",
 			categories: `{"books":{"name":"books","savePath":"/media/downloads-extra/books"}}`,
+			pathRemap:  "/media/downloads:" + expected,
 			wantStatus: HealthError,
-			wantText:   `expected a path at or under "/books/downloads"`,
+			wantText:   `expected a path at or under`,
 		},
 	}
 
@@ -77,10 +94,6 @@ func TestCheckDownloadClientHealth_QBittorrentCategoryPath(t *testing.T) {
 			defer srv.Close()
 
 			host, port := serverHostPort(t, srv.URL)
-			pathRemap := tc.pathRemap
-			if pathRemap == "" {
-				pathRemap = "/media:/books"
-			}
 			client := &models.DownloadClient{
 				Type:      "qbittorrent",
 				Host:      host,
@@ -88,9 +101,9 @@ func TestCheckDownloadClientHealth_QBittorrentCategoryPath(t *testing.T) {
 				Username:  "u",
 				Password:  "p",
 				Category:  "books",
-				PathRemap: pathRemap,
+				PathRemap: tc.pathRemap,
 			}
-			got := CheckDownloadClientHealth(context.Background(), client, "/books/downloads", "")
+			got := CheckDownloadClientHealth(context.Background(), client, expected, "")
 			if got.Status != tc.wantStatus {
 				t.Fatalf("status = %q, want %q; message=%s", got.Status, tc.wantStatus, got.Message)
 			}
@@ -114,8 +127,20 @@ func TestExpectedDownloadDirForClient_AudiobookMediaType(t *testing.T) {
 // TestCheckDownloadClientHealth_QBittorrentAudiobookCategory exercises the
 // per-media-type validation added in #700: when CategoryAudiobook is set, the
 // health check must validate the audiobook category's save path against the
-// audiobook download dir as well, and only return OK when both pass.
+// audiobook download dir as well, and only return OK when both pass. Uses
+// real on-disk t.TempDir paths so the post-pathIsAtOrUnder stat() check
+// (#800 case-mismatch follow-up) doesn't fire on the happy paths.
 func TestCheckDownloadClientHealth_QBittorrentAudiobookCategory(t *testing.T) {
+	tmp := t.TempDir()
+	ebookDir := filepath.Join(tmp, "books", "downloads")
+	audioDir := filepath.Join(tmp, "books", "audio-downloads")
+	if err := os.MkdirAll(filepath.Join(ebookDir, "books"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(audioDir, "audiobooks"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		name       string
 		categories string
@@ -124,21 +149,21 @@ func TestCheckDownloadClientHealth_QBittorrentAudiobookCategory(t *testing.T) {
 	}{
 		{
 			name:       "both categories valid",
-			categories: `{"books":{"name":"books","savePath":"/media/downloads"},"audiobooks":{"name":"audiobooks","savePath":"/media/audio-downloads"}}`,
+			categories: `{"books":{"name":"books","savePath":"/media/downloads/books"},"audiobooks":{"name":"audiobooks","savePath":"/media/audio-downloads/audiobooks"}}`,
 			wantStatus: HealthOK,
 			wantText:   "audiobooks",
 		},
 		{
 			name:       "audiobook category missing",
-			categories: `{"books":{"name":"books","savePath":"/media/downloads"}}`,
+			categories: `{"books":{"name":"books","savePath":"/media/downloads/books"}}`,
 			wantStatus: HealthError,
 			wantText:   `qBittorrent category "audiobooks" was not found`,
 		},
 		{
 			name:       "audiobook category points outside audiobook dir",
-			categories: `{"books":{"name":"books","savePath":"/media/downloads"},"audiobooks":{"name":"audiobooks","savePath":"/media/downloads"}}`,
+			categories: `{"books":{"name":"books","savePath":"/media/downloads/books"},"audiobooks":{"name":"audiobooks","savePath":"/media/downloads/books"}}`,
 			wantStatus: HealthError,
-			wantText:   `expected a path at or under "/books/audio-downloads"`,
+			wantText:   `expected a path at or under`,
 		},
 	}
 
@@ -166,9 +191,9 @@ func TestCheckDownloadClientHealth_QBittorrentAudiobookCategory(t *testing.T) {
 				Password:          "p",
 				Category:          "books",
 				CategoryAudiobook: "audiobooks",
-				PathRemap:         "/media:/books",
+				PathRemap:         "/media/downloads:" + ebookDir + ",/media/audio-downloads:" + audioDir,
 			}
-			got := CheckDownloadClientHealth(context.Background(), client, "/books/downloads", "/books/audio-downloads")
+			got := CheckDownloadClientHealth(context.Background(), client, ebookDir, audioDir)
 			if got.Status != tc.wantStatus {
 				t.Fatalf("status = %q, want %q; message=%s", got.Status, tc.wantStatus, got.Message)
 			}
@@ -176,6 +201,64 @@ func TestCheckDownloadClientHealth_QBittorrentAudiobookCategory(t *testing.T) {
 				t.Fatalf("message %q does not contain %q", got.Message, tc.wantText)
 			}
 		})
+	}
+}
+
+// TestQbittorrentCategoryPath_DetectsCaseMismatch covers the PixieApples
+// follow-up to #800: when the path remap is textually correct (pathIsAtOrUnder
+// passes against BINDERY_DOWNLOAD_DIR) but the resolved path does not exist on
+// Bindery's filesystem because of case differences — common in WSL + Docker on
+// Windows — the health-check must surface the divergent segment by name
+// rather than silently reporting OK while later imports fail to find files.
+func TestQbittorrentCategoryPath_DetectsCaseMismatch(t *testing.T) {
+	tmp := t.TempDir()
+	// Skip on case-insensitive filesystems (macOS default, Windows) since
+	// the detection is a no-op when the OS itself smooths case over.
+	probe := filepath.Join(tmp, "casetest")
+	if err := os.MkdirAll(probe, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "CASETEST")); err == nil {
+		t.Skip("filesystem is case-insensitive; case-mismatch detection is a no-op here")
+	}
+
+	// Real on-disk path uses capital D; the user's configuration in qBit and
+	// BINDERY_DOWNLOAD_DIR both use lowercase d. pathIsAtOrUnder passes
+	// (strings agree), but the path does not exist on disk.
+	realDir := filepath.Join(tmp, "Downloads", "books")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	configuredDir := filepath.Join(tmp, "downloads")       // BINDERY_DOWNLOAD_DIR (wrong case)
+	qbSavePath := filepath.Join(tmp, "downloads", "books") // qBit reports lowercase
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/categories":
+			_, _ = w.Write([]byte(`{"books":{"name":"books","savePath":"` + qbSavePath + `"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Type: "qbittorrent", Host: host, Port: port, Username: "u", Password: "p",
+		Category: "books",
+		// No PathRemap — qbSavePath already sits under configuredDir
+		// textually, so pathIsAtOrUnder passes and the stat check fires.
+	}
+	got := CheckDownloadClientHealth(context.Background(), client, configuredDir, "")
+	if got.Status != HealthError {
+		t.Fatalf("status = %q, want %q; message=%s", got.Status, HealthError, got.Message)
+	}
+	for _, want := range []string{"does not exist", "case-sensitive", realDir, "Downloads"} {
+		if !strings.Contains(got.Message, want) {
+			t.Errorf("message missing %q\nfull: %s", want, got.Message)
+		}
 	}
 }
 


### PR DESCRIPTION
Follow-up to #800 / #803.

## The gap PR #803 missed

The v1.14.2 fix made the qBittorrent category-path error suggest a concrete \`PathRemap\` value. That helped users who needed *some* remap — but it only verified the remapped string was at-or-under \`BINDERY_DOWNLOAD_DIR\`, never that the resolved path actually existed on Bindery's filesystem. Linux is case-sensitive, so a Windows/WSL/Docker user with their drive mounted at \`/N/\` but qBit reporting \`/n/\` gets a *textually*-correct remap suggestion that silently points at nothing.

PixieApples reported brute-forcing \`/n/\`, \`N:/\`, \`/N/\` combinations on Discord before landing the right one — \"I almost fell off my chair.\" That's the gap this PR closes.

## What changed

\`internal/downloader/health.go\`:

- After \`pathIsAtOrUnder\` passes, \`stat()\` the resolved local path.
- If missing, walk from root looking for a case-insensitive match at each level (\`findCaseInsensitivePath\`).
- If a case-variant exists, the error names the corrected path AND the first divergent segment so the user knows exactly which letter to fix:

> qBittorrent category \"books\" saves to \"/tmp/.../downloads/books\", which maps to \"/tmp/.../downloads/books\" inside Bindery — that exact path does not exist, but \"/tmp/.../Downloads/books\" does. Linux is case-sensitive; update the path remap so it produces \"/tmp/.../Downloads/books\" (the segment \"Downloads\" must match the on-disk case).

- If even the case-insensitive walk finds nothing, fall back to a plain \"path does not exist; check the path remap and the directory Bindery is mounting\" error rather than silently reporting OK.

## Tests

- New \`TestQbittorrentCategoryPath_DetectsCaseMismatch\`: builds a real \`tmp/Downloads/books\` dir, configures \`BINDERY_DOWNLOAD_DIR\` and qBit save path as \`tmp/downloads/books\` (wrong case), asserts the error names \"Downloads\" and the corrected path. Skips on case-insensitive filesystems (macOS default) where the OS smooths case over.
- Existing health tests rebuilt to use \`t.TempDir()\` paths that actually exist so the new stat check has something to validate. Error-path tests (missing category, empty save path, true mismatch) are unaffected — they short-circuit before the stat call.

## Test plan

- [x] \`go test ./internal/downloader/...\` — green
- [x] \`go vet ./...\` — clean
- [x] \`gofmt -l\` — clean

## Forward note

Case-mismatch detection only fires on \`pathIsAtOrUnder\` passes. When the user hasn't set a remap at all and the prefix doesn't match, the existing #803 error still wins. The two paths are complementary — they cover different misconfigurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)