### PR TITLE
feat(authors): bulk multi-select monitor/exclude/delete on Author detail (#791)

### DIFF
--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -129,8 +129,13 @@ func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
 
 // BooksBulk handles POST /api/v1/book/bulk.
 //
-// Supported actions: "monitor", "unmonitor", "delete", "search", "set_media_type".
+// Supported actions: "monitor", "unmonitor", "delete", "search", "set_media_type", "exclude".
 // For "set_media_type" the body must also include "mediaType": "ebook"|"audiobook".
+// "exclude" sets the book's excluded flag to true so it disappears from author
+// lists and is blocked from re-import on the next OL sync — mirrors the
+// single-book PUT /book/:id/exclude path but skips the toggle semantics
+// (bulk callers always want exclude=true; un-excluding remains a per-book
+// affordance).
 func (h *BulkHandler) BooksBulk(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		IDs       []int64 `json:"ids"`
@@ -147,7 +152,7 @@ func (h *BulkHandler) BooksBulk(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch req.Action {
-	case "monitor", "unmonitor", "delete", "search", "set_media_type":
+	case "monitor", "unmonitor", "delete", "search", "set_media_type", "exclude":
 	default:
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown action: " + req.Action})
 		return
@@ -181,6 +186,8 @@ func (h *BulkHandler) BooksBulk(w http.ResponseWriter, r *http.Request) {
 			}
 		case "set_media_type":
 			opErr = h.setBookMediaType(r.Context(), id, req.MediaType)
+		case "exclude":
+			opErr = h.setBookExcluded(r.Context(), id, true)
 		}
 		if opErr != nil {
 			resp.Results[key] = bulkItemResult{Error: opErr.Error()}
@@ -273,6 +280,21 @@ func (h *BulkHandler) setBookMonitored(ctx context.Context, id int64, monitored 
 	}
 	book.Monitored = monitored
 	return h.books.Update(ctx, book)
+}
+
+// setBookExcluded flags a book as excluded so it is hidden from author/book
+// lists and skipped on subsequent OL refreshes. Unlike the toggle endpoint
+// at PUT /book/:id/exclude, this is a one-way set used by bulk callers; the
+// repo handles the timestamp update.
+func (h *BulkHandler) setBookExcluded(ctx context.Context, id int64, excluded bool) error {
+	book, err := h.books.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if book == nil {
+		return fmt.Errorf("book not found")
+	}
+	return h.books.SetExcluded(ctx, id, excluded)
 }
 
 func (h *BulkHandler) setBookMediaType(ctx context.Context, id int64, mediaType string) error {

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -452,6 +452,54 @@ func TestBooksBulk_Delete(t *testing.T) {
 	}
 }
 
+// TestBooksBulk_Exclude covers the bulk "exclude" action added for #791:
+// the Author detail page lets users mass-exclude unwanted OL imports without
+// clicking through each book's exclude toggle.
+func TestBooksBulk_Exclude(t *testing.T) {
+	h, _, books, author, ctx := bulkFixture(t)
+
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "B_EXC", AuthorID: author.ID, Title: "Exclude Me",
+		SortTitle: "exclude me", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"exclude"}`, book.ID)
+	rec := postBulk(t, h.BooksBulk, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp bulkResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	key := fmt.Sprintf("%d", book.ID)
+	if r := resp.Results[key]; !r.OK {
+		t.Errorf("expected ok for book %d, got %+v", book.ID, r)
+	}
+
+	// SetExcluded hides the row from default List queries; use the
+	// IncludingExcluded variant to confirm the flag round-trips.
+	all, err := books.ListByAuthorIncludingExcluded(ctx, author.ID)
+	if err != nil {
+		t.Fatalf("ListByAuthorIncludingExcluded: %v", err)
+	}
+	var found *models.Book
+	for i := range all {
+		if all[i].ID == book.ID {
+			found = &all[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("book %d missing from ListByAuthorIncludingExcluded", book.ID)
+	}
+	if !found.Excluded {
+		t.Errorf("book.Excluded: want true after bulk exclude, got false")
+	}
+}
+
 func TestBooksBulk_SetMediaType_Ebook(t *testing.T) {
 	h, _, books, author, ctx := bulkFixture(t)
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1384,7 +1384,7 @@ export interface Recommendation {
 }
 
 export type AuthorBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search' | 'set_media_type'
-export type BookBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search' | 'set_media_type'
+export type BookBulkAction = 'monitor' | 'unmonitor' | 'delete' | 'search' | 'set_media_type' | 'exclude'
 export type WantedBulkAction = 'search' | 'blocklist' | 'unmonitor'
 
 export interface BulkResult {

--- a/web/src/components/BulkActionBar.tsx
+++ b/web/src/components/BulkActionBar.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 export interface BulkAction {
   label: string
   onClick: () => void
-  variant?: 'default' | 'danger'
+  variant?: 'default' | 'caution' | 'danger'
 }
 
 interface BulkActionBarProps {
@@ -35,7 +35,9 @@ export default function BulkActionBar({ count, actions, onClear, busy = false }:
             className={`px-3 py-1.5 rounded text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
               action.variant === 'danger'
                 ? 'bg-red-600 hover:bg-red-500 text-white'
-                : 'bg-slate-600 hover:bg-slate-500 dark:bg-zinc-700 dark:hover:bg-zinc-600 text-white'
+                : action.variant === 'caution'
+                  ? 'bg-amber-600 hover:bg-amber-500 text-white'
+                  : 'bg-slate-600 hover:bg-slate-500 dark:bg-zinc-700 dark:hover:bg-zinc-600 text-white'
             }`}
           >
             {action.label}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -115,6 +115,19 @@
     "deleteWithFilesConfirm": "Delete this author, {{total}} book(s), AND {{withFiles}} file(s)/folder(s) on disk?\n\nThis cannot be undone.",
     "bulkDeleteConfirm": "Delete {{count}} author(s) and all their books?"
   },
+  "authorDetail": {
+    "bulk": {
+      "monitor": "Monitor",
+      "unmonitor": "Unmonitor",
+      "exclude": "Exclude",
+      "delete": "Delete",
+      "excludeConfirm": "Exclude {{count}} book(s)? Excluded books are hidden and blocked from re-import on the next metadata refresh.",
+      "deleteConfirm": "Delete {{count}} book(s)? Files on disk are not removed.",
+      "success": "{{action}} applied to {{count}} book(s).",
+      "partial": "{{action}}: {{ok}} of {{total}} succeeded. First error: {{error}}",
+      "failed": "Bulk {{action}} failed: {{error}}"
+    }
+  },
   "books": {
     "title": "Books",
     "searchPlaceholder": "Search books or authors...",

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import AuthorDetailPage from './AuthorDetailPage'
 import { api } from '../api/client'
 import type { Author, Book } from '../api/client'
+import '../i18n'
 
 vi.mock('../api/client', async importOriginal => {
   const actual = await importOriginal<typeof import('../api/client')>()
@@ -18,6 +19,7 @@ vi.mock('../api/client', async importOriginal => {
       updateAuthor: vi.fn(),
       deleteAuthor: vi.fn(),
       searchAuthorWanted: vi.fn(),
+      bulkActionBooks: vi.fn(),
     },
   }
 })
@@ -172,33 +174,90 @@ describe('AuthorDetailPage', () => {
     expect(within(table).getByRole('columnheader', { name: 'Type' })).toBeInTheDocument()
     expect(within(table).getByRole('columnheader', { name: 'Status' })).toBeInTheDocument()
 
+    // Cells: [0]=row checkbox (bulk select), [1]=title+inline metadata,
+    // [2]=published year, [3]=type, [4]=status. Checkbox column was added
+    // for #791 bulk multi-select.
     const firefightCells = within(rowForTitle('Firefight')).getAllByRole('cell')
-    expect(firefightCells).toHaveLength(4)
-    expect(firefightCells[0]).toHaveTextContent('Wanted')
-    expect(firefightCells[0]).toHaveTextContent('📖 Ebook')
-    expect(firefightCells[0]).toHaveTextContent('2008')
-    expect(firefightCells[0]).not.toHaveTextContent('2008-01-01')
+    expect(firefightCells).toHaveLength(5)
+    expect(within(firefightCells[0]).getByRole('checkbox')).toBeInTheDocument()
+    expect(firefightCells[1]).toHaveTextContent('Wanted')
+    expect(firefightCells[1]).toHaveTextContent('📖 Ebook')
     expect(firefightCells[1]).toHaveTextContent('2008')
     expect(firefightCells[1]).not.toHaveTextContent('2008-01-01')
-    expect(firefightCells[2]).toHaveTextContent('📖 Ebook')
-    expect(firefightCells[3]).toHaveTextContent('Wanted')
+    expect(firefightCells[2]).toHaveTextContent('2008')
+    expect(firefightCells[2]).not.toHaveTextContent('2008-01-01')
+    expect(firefightCells[3]).toHaveTextContent('📖 Ebook')
+    expect(firefightCells[4]).toHaveTextContent('Wanted')
 
     const snapshotCells = within(rowForTitle('Snapshot')).getAllByRole('cell')
-    expect(snapshotCells[0]).toHaveTextContent('Downloaded')
-    expect(snapshotCells[0]).toHaveTextContent('🎧 Audiobook')
-    expect(snapshotCells[0]).toHaveTextContent('2023')
+    expect(snapshotCells[1]).toHaveTextContent('Downloaded')
+    expect(snapshotCells[1]).toHaveTextContent('🎧 Audiobook')
     expect(snapshotCells[1]).toHaveTextContent('2023')
-    expect(snapshotCells[2]).toHaveTextContent('🎧 Audiobook')
-    expect(snapshotCells[3]).toHaveTextContent('Downloaded')
+    expect(snapshotCells[2]).toHaveTextContent('2023')
+    expect(snapshotCells[3]).toHaveTextContent('🎧 Audiobook')
+    expect(snapshotCells[4]).toHaveTextContent('Downloaded')
 
     const dualFormatCells = within(rowForTitle('Dual Format')).getAllByRole('cell')
-    expect(dualFormatCells[0]).toHaveTextContent('In Library')
-    expect(dualFormatCells[0]).toHaveTextContent('📖🎧 Both')
-    expect(dualFormatCells[0]).toHaveTextContent('2022')
-    expect(dualFormatCells[0]).toHaveTextContent('Excluded')
+    expect(dualFormatCells[1]).toHaveTextContent('In Library')
+    expect(dualFormatCells[1]).toHaveTextContent('📖🎧 Both')
     expect(dualFormatCells[1]).toHaveTextContent('2022')
-    expect(dualFormatCells[2]).toHaveTextContent('📖🎧 Both')
-    expect(dualFormatCells[3]).toHaveTextContent('In Library')
-    expect(dualFormatCells[3]).toHaveTextContent('Excluded')
+    expect(dualFormatCells[1]).toHaveTextContent('Excluded')
+    expect(dualFormatCells[2]).toHaveTextContent('2022')
+    expect(dualFormatCells[3]).toHaveTextContent('📖🎧 Both')
+    expect(dualFormatCells[4]).toHaveTextContent('In Library')
+    expect(dualFormatCells[4]).toHaveTextContent('Excluded')
+  })
+
+  it('bulk-excludes selected books via /book/bulk', async () => {
+    vi.mocked(api.bulkActionBooks).mockResolvedValue({
+      results: { '101': { ok: true }, '102': { ok: true } },
+    })
+    renderAuthorDetailPage(
+      [
+        makeBook({ id: 101, title: 'Drop One', status: 'wanted' }),
+        makeBook({ id: 102, title: 'Drop Two', status: 'wanted' }),
+        makeBook({ id: 103, title: 'Keep', status: 'wanted' }),
+      ],
+      'table',
+    )
+
+    await screen.findByText('Drop One')
+    const row1 = rowForTitle('Drop One')
+    const row2 = rowForTitle('Drop Two')
+    fireEvent.click(within(row1).getByRole('checkbox'))
+    fireEvent.click(within(row2).getByRole('checkbox'))
+
+    // Confirm dialog for exclude — auto-accept.
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const excludeBtn = await screen.findByRole('button', { name: 'Exclude' })
+    fireEvent.click(excludeBtn)
+
+    await waitFor(() => {
+      expect(api.bulkActionBooks).toHaveBeenCalledWith([101, 102], 'exclude')
+    })
+    confirmSpy.mockRestore()
+  })
+
+  it('surfaces partial-failure summary when some bulk actions fail', async () => {
+    vi.mocked(api.bulkActionBooks).mockResolvedValue({
+      results: { '201': { ok: true }, '202': { ok: false, error: 'gone' } },
+    })
+    renderAuthorDetailPage(
+      [
+        makeBook({ id: 201, title: 'Mon One', status: 'wanted', monitored: false }),
+        makeBook({ id: 202, title: 'Mon Two', status: 'wanted', monitored: false }),
+      ],
+      'table',
+    )
+
+    await screen.findByText('Mon One')
+    fireEvent.click(within(rowForTitle('Mon One')).getByRole('checkbox'))
+    fireEvent.click(within(rowForTitle('Mon Two')).getByRole('checkbox'))
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Monitor' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Monitor: 1 of 2 succeeded\. First error: gone/)).toBeInTheDocument()
+    })
   })
 })

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { api, Author, Book } from '../api/client'
+import { useTranslation } from 'react-i18next'
+import { api, Author, Book, BookBulkAction } from '../api/client'
 import ViewToggle from '../components/ViewToggle'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
 import EditAuthorModal from '../components/EditAuthorModal'
+import BulkActionBar from '../components/BulkActionBar'
 import { useView } from '../components/useView'
 
 const statusColors: Record<string, string> = {
@@ -49,6 +51,7 @@ function mediaLabel(mediaType?: Book['mediaType']): string {
 export default function AuthorDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const { t } = useTranslation()
   const authorId = Number(id)
 
   const [author, setAuthor] = useState<Author | null>(null)
@@ -61,6 +64,13 @@ export default function AuthorDetailPage() {
   const [showEdit, setShowEdit] = useState(false)
   const [showExcluded, setShowExcluded] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // Bulk multi-select state (#791). Selection is keyed by book.id and
+  // intentionally scoped to the filtered view: hidden books can't be
+  // accidentally swept up by select-all.
+  const [selected, setSelected] = useState<Set<number>>(new Set())
+  const [bulkBusy, setBulkBusy] = useState(false)
+  const selectAllRef = useRef<HTMLInputElement>(null)
 
   const [view, setView] = useView('author-detail', 'grid')
 
@@ -192,6 +202,71 @@ export default function AuthorDetailPage() {
     }
   }
 
+  const toggleSelect = (bookId: number) => {
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(bookId)) next.delete(bookId)
+      else next.add(bookId)
+      return next
+    })
+  }
+
+  const clearSelection = () => setSelected(new Set())
+
+  // reloadBooks refetches the author's books without clobbering loading state —
+  // used after a bulk action to reflect changes (e.g. exclude hides rows
+  // unless showExcluded is on; delete removes them outright).
+  const reloadBooks = async () => {
+    try {
+      const bs = await api.listBooks({ authorId, includeExcluded: showExcluded })
+      setBooks(bs)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Reload failed')
+    }
+  }
+
+  // runBulk routes a multi-select action through the existing /book/bulk
+  // endpoint. The handler returns 200 with per-id outcomes even when some
+  // rows fail (stale IDs, missing books) — surface the first error inline
+  // so the user knows partial success happened without burying it.
+  const runBulk = async (action: BookBulkAction, actionLabel: string, confirmMsg?: string) => {
+    if (selected.size === 0) return
+    if (confirmMsg && !confirm(confirmMsg)) return
+    setBulkBusy(true)
+    setError(null)
+    try {
+      const ids = Array.from(selected)
+      const res = await api.bulkActionBooks(ids, action)
+      let okCount = 0
+      let firstError = ''
+      for (const id of ids) {
+        const r = res.results[String(id)]
+        if (r?.ok) {
+          okCount++
+        } else if (!firstError) {
+          firstError = r?.error || 'unknown error'
+        }
+      }
+      if (okCount < ids.length) {
+        setError(t('authorDetail.bulk.partial', {
+          action: actionLabel,
+          ok: okCount,
+          total: ids.length,
+          error: firstError,
+        }))
+      }
+      clearSelection()
+      await reloadBooks()
+    } catch (e) {
+      setError(t('authorDetail.bulk.failed', {
+        action: actionLabel,
+        error: e instanceof Error ? e.message : String(e),
+      }))
+    } finally {
+      setBulkBusy(false)
+    }
+  }
+
   const filteredBooks = useMemo(() => {
     let list = books
     if (typeFilter) list = list.filter(b => (b.mediaType || 'ebook') === typeFilter)
@@ -210,6 +285,29 @@ export default function AuthorDetailPage() {
     }
     return list
   }, [books, typeFilter, statusFilter, publishedFilter, dateSort])
+
+  // Drop any selected IDs that are no longer in the filtered view so the
+  // bulk bar count never lies about what's about to be acted on.
+  const visibleIds = useMemo(() => new Set(filteredBooks.map(b => b.id)), [filteredBooks])
+  useEffect(() => {
+    setSelected(prev => {
+      let changed = false
+      const next = new Set<number>()
+      for (const id of prev) {
+        if (visibleIds.has(id)) next.add(id)
+        else changed = true
+      }
+      return changed ? next : prev
+    })
+  }, [visibleIds])
+
+  const allVisibleSelected = filteredBooks.length > 0 && filteredBooks.every(b => selected.has(b.id))
+  const someVisibleSelected = filteredBooks.some(b => selected.has(b.id)) && !allVisibleSelected
+  useEffect(() => {
+    if (selectAllRef.current) selectAllRef.current.indeterminate = someVisibleSelected
+  }, [someVisibleSelected])
+
+  const selectAllVisible = () => setSelected(new Set(filteredBooks.map(b => b.id)))
 
   if (loading) return <div className="text-slate-600 dark:text-zinc-500">Loading…</div>
   if (!author) return <div className="text-slate-600 dark:text-zinc-500">Author not found</div>
@@ -231,7 +329,7 @@ export default function AuthorDetailPage() {
   const dateSortIcon = dateSort === 'asc' ? ' ↑' : dateSort === 'desc' ? ' ↓' : ''
 
   return (
-    <div className="max-w-5xl">
+    <div className={`max-w-5xl${selected.size > 0 ? ' pb-20' : ''}`}>
       <div className="mb-4 flex items-center gap-3 text-sm">
         <button onClick={() => navigate(-1)} className="text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white">← Back</button>
       </div>
@@ -409,6 +507,17 @@ export default function AuthorDetailPage() {
               <table className="w-full table-fixed text-sm">
                 <thead>
                   <tr className="bg-slate-100 dark:bg-zinc-900 border-b border-slate-200 dark:border-zinc-800">
+                    <th className="w-10 px-3 py-2">
+                      <input
+                        ref={selectAllRef}
+                        type="checkbox"
+                        checked={allVisibleSelected}
+                        onChange={e => e.target.checked ? selectAllVisible() : clearSelection()}
+                        className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+                        title={t('common.selectAllPage')}
+                        aria-label={t('common.selectAllPage')}
+                      />
+                    </th>
                     <th className="w-full sm:w-[46%] text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase">Title</th>
                     <th
                       className="hidden sm:table-cell sm:w-28 text-left px-3 py-2 text-xs font-medium text-slate-600 dark:text-zinc-400 uppercase cursor-pointer select-none hover:text-slate-900 dark:hover:text-white whitespace-nowrap"
@@ -425,9 +534,18 @@ export default function AuthorDetailPage() {
                   {filteredBooks.map(book => (
                     <tr
                       key={book.id}
-                      className="bg-slate-100/50 dark:bg-zinc-900/50 hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 cursor-pointer"
+                      className={`${selected.has(book.id) ? 'bg-emerald-500/10 dark:bg-emerald-500/10' : 'bg-slate-100/50 dark:bg-zinc-900/50'} hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 cursor-pointer`}
                       onClick={() => (window.location.href = `/book/${book.id}`)}
                     >
+                      <td className="px-3 py-2 w-10 align-middle" onClick={e => e.stopPropagation()}>
+                        <input
+                          type="checkbox"
+                          checked={selected.has(book.id)}
+                          onChange={() => toggleSelect(book.id)}
+                          className="rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0"
+                          aria-label={`Select ${book.title}`}
+                        />
+                      </td>
                       <td className="px-3 py-2 align-middle">
                         <Link to={`/book/${book.id}`} className="flex items-center gap-2 min-w-0" onClick={e => e.stopPropagation()}>
                           {book.imageUrl ? (
@@ -479,42 +597,71 @@ export default function AuthorDetailPage() {
         ) : (
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
             {filteredBooks.map(book => (
-              <Link
+              <div
                 key={book.id}
-                to={`/book/${book.id}`}
-                className="border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden group hover:border-emerald-500 transition-colors"
+                className={`relative border rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden group transition-colors ${selected.has(book.id) ? 'border-emerald-500' : 'border-slate-200 dark:border-zinc-800 hover:border-emerald-500'}`}
               >
-                <div className="aspect-[2/3] bg-slate-200 dark:bg-zinc-800 relative">
-                  {book.imageUrl ? (
-                    <img src={book.imageUrl} alt={book.title} className="w-full h-full object-cover" />
-                  ) : (
-                    <div className="w-full h-full flex items-center justify-center p-3 text-center">
-                      <span className="text-sm text-slate-500 dark:text-zinc-600">{book.title}</span>
-                    </div>
-                  )}
-                </div>
-                <div className="p-2">
-                  <h4 className="text-xs font-medium truncate" title={book.title}>{book.title}</h4>
-                  <div className="flex items-center gap-1 mt-1 flex-wrap">
-                    <span className={statusBadgeClass(book.status, 'px-1.5 py-0.5 rounded text-[10px] font-medium')}>
-                      {statusLabel[book.status] ?? book.status}
-                    </span>
-                    {book.mediaType === 'audiobook' && (
-                      <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300">🎧 Audio</span>
-                    )}
-                    {book.excluded && (
-                      <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">Excluded</span>
+                <input
+                  type="checkbox"
+                  checked={selected.has(book.id)}
+                  onChange={() => toggleSelect(book.id)}
+                  onClick={e => e.stopPropagation()}
+                  className="absolute top-2 left-2 z-10 rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 bg-white/80 dark:bg-zinc-900/80"
+                  aria-label={`Select ${book.title}`}
+                />
+                <Link to={`/book/${book.id}`} className="block">
+                  <div className="aspect-[2/3] bg-slate-200 dark:bg-zinc-800 relative">
+                    {book.imageUrl ? (
+                      <img src={book.imageUrl} alt={book.title} className="w-full h-full object-cover" />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center p-3 text-center">
+                        <span className="text-sm text-slate-500 dark:text-zinc-600">{book.title}</span>
+                      </div>
                     )}
                   </div>
-                  {book.releaseDate && (
-                    <p className="text-[10px] text-slate-600 dark:text-zinc-500 mt-0.5">{fmtPublishedYear(book.releaseDate)}</p>
-                  )}
-                </div>
-              </Link>
+                  <div className="p-2">
+                    <h4 className="text-xs font-medium truncate" title={book.title}>{book.title}</h4>
+                    <div className="flex items-center gap-1 mt-1 flex-wrap">
+                      <span className={statusBadgeClass(book.status, 'px-1.5 py-0.5 rounded text-[10px] font-medium')}>
+                        {statusLabel[book.status] ?? book.status}
+                      </span>
+                      {book.mediaType === 'audiobook' && (
+                        <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300">🎧 Audio</span>
+                      )}
+                      {book.excluded && (
+                        <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">Excluded</span>
+                      )}
+                    </div>
+                    {book.releaseDate && (
+                      <p className="text-[10px] text-slate-600 dark:text-zinc-500 mt-0.5">{fmtPublishedYear(book.releaseDate)}</p>
+                    )}
+                  </div>
+                </Link>
+              </div>
             ))}
           </div>
         )}
       </section>
+
+      <BulkActionBar
+        count={selected.size}
+        onClear={clearSelection}
+        busy={bulkBusy}
+        actions={[
+          { label: t('authorDetail.bulk.monitor'), onClick: () => runBulk('monitor', t('authorDetail.bulk.monitor')) },
+          { label: t('authorDetail.bulk.unmonitor'), onClick: () => runBulk('unmonitor', t('authorDetail.bulk.unmonitor')) },
+          {
+            label: t('authorDetail.bulk.exclude'),
+            variant: 'caution',
+            onClick: () => runBulk('exclude', t('authorDetail.bulk.exclude'), t('authorDetail.bulk.excludeConfirm', { count: selected.size })),
+          },
+          {
+            label: t('authorDetail.bulk.delete'),
+            variant: 'danger',
+            onClick: () => runBulk('delete', t('authorDetail.bulk.delete'), t('authorDetail.bulk.deleteConfirm', { count: selected.size })),
+          },
+        ]}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## What changed

Author detail page now supports multi-select for bulk monitor, unmonitor, exclude, and delete. Reporter scenario in #791: Alexander Freed import drops 51 OL works as Wanted, user wants only 3-4 Star Wars titles — previously meant clicking through every row.

### Frontend (`web/src/pages/AuthorDetailPage.tsx`)
- Per-row checkbox in both table and grid views. Table gets a select-all column in the header with indeterminate state when only some visible rows are selected.
- Selection is scoped to the **filtered** view (not the entire fetch), so toggling `Show excluded` or a status chip doesn't sweep hidden rows into a bulk action. IDs that drop out of the visible set are pruned from the selection automatically.
- Sticky `BulkActionBar` at the bottom: Monitor, Unmonitor, Exclude (amber/caution), Delete (red/danger). `clearSelection` + `reloadBooks` on success.
- Partial failures (per-ID `error` from the existing per-ID bulk envelope) are surfaced inline in the existing error banner: `Monitor: 3 of 5 succeeded. First error: book not found`. Hard failures (network, 4xx) use the same banner.
- All copy under `authorDetail.bulk.*` in `web/src/i18n/locales/en.json`; non-en locales fall back via `fallbackLng`.

### Backend (`internal/api/bulk.go`)
- Added `"exclude"` action to `BooksBulk`. Implementation mirrors the single-book `PUT /book/:id/exclude` path (calls `books.SetExcluded(ctx, id, true)`). One-way set rather than a toggle — bulk callers always want to hide, and un-excluding stays a per-book affordance.
- `BookBulkAction` TS union updated to match.
- New `TestBooksBulk_Exclude` confirms the flag round-trips via `ListByAuthorIncludingExcluded`.

### Component
- `BulkActionBar` gained a `caution` variant (amber) for Exclude, alongside the existing `default` and `danger`, per the ui-design colour map (amber = disruptive-but-recoverable).

## Decisions worth flagging

- **No toast system.** The task brief mentioned toasts, but the project has none — every page uses inline `setError` banners + `alert()` for confirms. Followed the existing convention rather than inventing infrastructure.
- **No `unexclude` bulk action.** Out of scope per the issue; an excluded book hidden by default is hard to bulk-select anyway. If demand surfaces, it's a one-liner addition.
- **Confirm dialogs.** Exclude and Delete use `confirm()` (matches `BooksPage` behaviour); Monitor/Unmonitor are immediate (low-risk, reversible).
- **Existing table-cell test updated** for the new checkbox column (4 cells → 5). No behavioural assertions lost.

## Pairs with

#792 (per-author monitor modes — anthonysnyder's other ask in the same area). Independent; no shared code path.

Closes #791