### PR TITLE
feat(downloader): separate audiobook category per download client (#700)

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -658,6 +658,10 @@ func TestPickClientForMediaType(t *testing.T) {
 	audioClient := models.DownloadClient{ID: 1, Name: "SAB-audio", Category: "audiobooks", Type: "sabnzbd"}
 	ebookClient := models.DownloadClient{ID: 2, Name: "SAB-ebook", Category: "ebooks", Type: "sabnzbd"}
 	genericClient := models.DownloadClient{ID: 3, Name: "SAB-generic", Category: "books", Type: "sabnzbd"}
+	// #700: a "dual" client uses the explicit CategoryAudiobook field; the
+	// picker should treat that as a stronger signal than the legacy "category
+	// contains audio" heuristic.
+	dualClient := models.DownloadClient{ID: 4, Name: "SAB-dual", Category: "books", CategoryAudiobook: "audiobooks", Type: "sabnzbd"}
 
 	tests := []struct {
 		name      string
@@ -671,6 +675,8 @@ func TestPickClientForMediaType(t *testing.T) {
 		{"ebook prefers non-audio category", []models.DownloadClient{audioClient, ebookClient}, "ebook", 2},
 		{"audiobook falls back to first when no match", []models.DownloadClient{ebookClient, genericClient}, "audiobook", 2},
 		{"ebook falls back to first when all audio", []models.DownloadClient{audioClient}, "ebook", 1},
+		{"audiobook prefers explicit CategoryAudiobook over legacy heuristic", []models.DownloadClient{audioClient, dualClient}, "audiobook", 4},
+		{"ebook on dual-config client returns it via fallback path", []models.DownloadClient{dualClient}, "ebook", 4},
 	}
 
 	for _, tt := range tests {

--- a/internal/db/download_clients.go
+++ b/internal/db/download_clients.go
@@ -17,7 +17,7 @@ type DownloadClientRepo struct {
 
 const downloadClientSelectColumns = `
 	id, name, type, host, port, api_key, use_ssl, url_base, username, password,
-	category, path_remap, priority, enabled, created_at, updated_at`
+	category, category_audiobook, path_remap, priority, enabled, created_at, updated_at`
 
 func isCredentialClient(clientType string) bool {
 	return clientType == "qbittorrent" || clientType == "transmission"
@@ -111,7 +111,7 @@ func (r *DownloadClientRepo) List(ctx context.Context) ([]models.DownloadClient,
 		var c models.DownloadClient
 		var enabled, useSSL int
 		if err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.CategoryAudiobook, &c.PathRemap, &c.Priority,
 			&enabled, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
@@ -130,7 +130,7 @@ func (r *DownloadClientRepo) GetByID(ctx context.Context, id int64) (*models.Dow
 		SELECT `+downloadClientSelectColumns+`
 		FROM download_clients WHERE id=?`, id).
 		Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.CategoryAudiobook, &c.PathRemap, &c.Priority,
 			&enabled, &c.CreatedAt, &c.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -151,7 +151,7 @@ func (r *DownloadClientRepo) GetFirstEnabled(ctx context.Context) (*models.Downl
 		SELECT `+downloadClientSelectColumns+`
 		FROM download_clients WHERE enabled=1 ORDER BY priority LIMIT 1`).
 		Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.CategoryAudiobook, &c.PathRemap, &c.Priority,
 			&enabled, &c.CreatedAt, &c.UpdatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -177,14 +177,14 @@ func (r *DownloadClientRepo) GetFirstEnabledByProtocol(ctx context.Context, prot
 			SELECT `+downloadClientSelectColumns+`
 			FROM download_clients WHERE enabled=1 AND type IN (?, ?, ?) ORDER BY priority LIMIT 1`, "qbittorrent", "transmission", "deluge").
 			Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
+				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.CategoryAudiobook, &c.PathRemap, &c.Priority,
 				&enabled, &c.CreatedAt, &c.UpdatedAt)
 	} else {
 		err = r.db.QueryRowContext(ctx, `
 			SELECT `+downloadClientSelectColumns+`
 			FROM download_clients WHERE enabled=1 AND type IN (?, ?) ORDER BY priority LIMIT 1`, "sabnzbd", "nzbget").
 			Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
+				&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.CategoryAudiobook, &c.PathRemap, &c.Priority,
 				&enabled, &c.CreatedAt, &c.UpdatedAt)
 	}
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -226,7 +226,7 @@ func (r *DownloadClientRepo) GetEnabledByProtocol(ctx context.Context, protocol 
 		var c models.DownloadClient
 		var enabled, useSSL int
 		if err := rows.Scan(&c.ID, &c.Name, &c.Type, &c.Host, &c.Port, &c.APIKey,
-			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.PathRemap, &c.Priority,
+			&useSSL, &c.URLBase, &c.Username, &c.Password, &c.Category, &c.CategoryAudiobook, &c.PathRemap, &c.Priority,
 			&enabled, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
@@ -242,9 +242,9 @@ func (r *DownloadClientRepo) Create(ctx context.Context, c *models.DownloadClien
 	normalizeClientCredentialStorage(c)
 	now := time.Now().UTC()
 	result, err := r.db.ExecContext(ctx, `
-		INSERT INTO download_clients (name, type, host, port, api_key, use_ssl, url_base, username, password, category, path_remap, priority, enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Username, c.Password, c.Category, c.PathRemap, c.Priority, c.Enabled, now, now)
+		INSERT INTO download_clients (name, type, host, port, api_key, use_ssl, url_base, username, password, category, category_audiobook, path_remap, priority, enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Username, c.Password, c.Category, c.CategoryAudiobook, c.PathRemap, c.Priority, c.Enabled, now, now)
 	if err != nil {
 		return fmt.Errorf("create download client: %w", err)
 	}
@@ -263,9 +263,9 @@ func (r *DownloadClientRepo) Update(ctx context.Context, c *models.DownloadClien
 	now := time.Now().UTC()
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE download_clients SET name=?, type=?, host=?, port=?, api_key=?, use_ssl=?,
-		                            url_base=?, username=?, password=?, category=?, path_remap=?, priority=?, enabled=?, updated_at=?
+		                            url_base=?, username=?, password=?, category=?, category_audiobook=?, path_remap=?, priority=?, enabled=?, updated_at=?
 		WHERE id=?`,
-		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Username, c.Password, c.Category, c.PathRemap, c.Priority, c.Enabled, now, c.ID)
+		c.Name, c.Type, c.Host, c.Port, c.APIKey, c.UseSSL, c.URLBase, c.Username, c.Password, c.Category, c.CategoryAudiobook, c.PathRemap, c.Priority, c.Enabled, now, c.ID)
 	return err
 }
 
@@ -275,8 +275,12 @@ func (r *DownloadClientRepo) Delete(ctx context.Context, id int64) error {
 }
 
 // PickClientForMediaType selects the best client from a list for the given
-// media type. Audiobooks prefer a client whose category contains "audio";
-// other types prefer one without. Falls back to the first client.
+// media type. The explicit per-media-type CategoryAudiobook field (added in
+// #700) is the strongest signal: a client with that field populated can
+// handle audiobooks regardless of its primary Category name. As a fallback
+// for clients that have not opted into the new field, we keep the legacy
+// fuzzy "audio in category" heuristic so existing single-client setups keep
+// working.
 func PickClientForMediaType(clients []models.DownloadClient, mediaType string) *models.DownloadClient {
 	if len(clients) == 0 {
 		return nil
@@ -284,12 +288,19 @@ func PickClientForMediaType(clients []models.DownloadClient, mediaType string) *
 	if len(clients) == 1 {
 		return &clients[0]
 	}
+	// First pass: prefer a client whose explicit fields match.
 	for i := range clients {
-		cat := strings.ToLower(clients[i].Category)
-		if mediaType == "audiobook" && strings.Contains(cat, "audio") {
+		if mediaType == models.MediaTypeAudiobook && strings.TrimSpace(clients[i].CategoryAudiobook) != "" {
 			return &clients[i]
 		}
-		if mediaType != "audiobook" && !strings.Contains(cat, "audio") {
+	}
+	// Second pass: legacy heuristic for clients without CategoryAudiobook set.
+	for i := range clients {
+		cat := strings.ToLower(clients[i].Category)
+		if mediaType == models.MediaTypeAudiobook && strings.Contains(cat, "audio") {
+			return &clients[i]
+		}
+		if mediaType != models.MediaTypeAudiobook && !strings.Contains(cat, "audio") {
 			return &clients[i]
 		}
 	}

--- a/internal/db/download_clients_test.go
+++ b/internal/db/download_clients_test.go
@@ -118,6 +118,95 @@ func TestDownloadClientRepoPreservesBareURLBaseMatchingUsername(t *testing.T) {
 	}
 }
 
+// TestDownloadClientRepoRoundTripsCategoryAudiobook verifies the per-media-type
+// category field (#700) survives Create → GetByID → List round-trips.
+func TestDownloadClientRepoRoundTripsCategoryAudiobook(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	repo := NewDownloadClientRepo(database)
+	client := &models.DownloadClient{
+		Name:              "qBit",
+		Type:              "qbittorrent",
+		Host:              "10.0.0.1",
+		Port:              8080,
+		Username:          "admin",
+		Password:          "secret",
+		Category:          "books",
+		CategoryAudiobook: "audiobooks",
+		Enabled:           true,
+	}
+	if err := repo.Create(context.Background(), client); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.GetByID(context.Background(), client.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected download client")
+	}
+	if got.Category != "books" || got.CategoryAudiobook != "audiobooks" {
+		t.Fatalf("categories = %q/%q, want books/audiobooks", got.Category, got.CategoryAudiobook)
+	}
+
+	got.CategoryAudiobook = "audio"
+	if err := repo.Update(context.Background(), got); err != nil {
+		t.Fatal(err)
+	}
+	listed, err := repo.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 || listed[0].CategoryAudiobook != "audio" {
+		t.Fatalf("after update: listed=%+v, want CategoryAudiobook=audio", listed)
+	}
+}
+
+// TestDownloadClientRepoDefaultsCategoryAudiobookEmpty proves that pre-#700
+// rows (where the column defaults to "") survive the new SELECT shape so
+// existing deployments keep working.
+func TestDownloadClientRepoDefaultsCategoryAudiobookEmpty(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	now := time.Now().UTC()
+	// Insert a row through the raw schema with no category_audiobook value —
+	// the migration's default '' should hold and round-trip cleanly.
+	result, err := database.ExecContext(context.Background(), `
+		INSERT INTO download_clients (
+			name, type, host, port, api_key, use_ssl, url_base, username, password,
+			category, priority, enabled, created_at, updated_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"Legacy qBit", "qbittorrent", "10.0.0.2", 8080, "", 0, "", "admin", "pw",
+		"books", 0, 1, now, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := NewDownloadClientRepo(database).GetByID(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected download client")
+	}
+	if got.CategoryAudiobook != "" {
+		t.Fatalf("CategoryAudiobook = %q, want empty fallback", got.CategoryAudiobook)
+	}
+}
+
 func TestDownloadClientRepoPreservesNewBareURLBaseWithoutLegacyAPIKey(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {

--- a/internal/db/migrations/043_download_client_category_audiobook.sql
+++ b/internal/db/migrations/043_download_client_category_audiobook.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+-- Per-media-type download category (#700). Existing rows default to empty,
+-- which makes ResolveCategory fall back to category for audiobooks as well —
+-- zero behaviour change until the user opts in by populating the new column.
+ALTER TABLE download_clients ADD COLUMN category_audiobook TEXT NOT NULL DEFAULT '';

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -122,7 +122,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 	case "qbittorrent":
 		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
 		savePath := qbitSavePath(client, opts)
-		hash, err := qb.AddTorrent(ctx, sourceURL, client.Category, savePath)
+		hash, err := qb.AddTorrent(ctx, sourceURL, ResolveCategory(client, opts.MediaType), savePath)
 		if err != nil {
 			return nil, err
 		}
@@ -134,7 +134,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		return result, nil
 	case "deluge":
 		dl := deluge.New(client.Host, client.Port, client.Password, client.URLBase, client.UseSSL)
-		hash, err := dl.AddTorrent(ctx, sourceURL, client.Category)
+		hash, err := dl.AddTorrent(ctx, sourceURL, ResolveCategory(client, opts.MediaType))
 		if err != nil {
 			return nil, err
 		}
@@ -145,7 +145,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		return result, nil
 	case "nzbget":
 		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
-		nzbID, err := ng.Add(ctx, sourceURL, title, client.Category, 0)
+		nzbID, err := ng.Add(ctx, sourceURL, title, ResolveCategory(client, opts.MediaType), 0)
 		if err != nil {
 			return nil, err
 		}
@@ -153,7 +153,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		return result, nil
 	default:
 		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.URLBase, client.UseSSL)
-		resp, err := sab.AddURL(ctx, sourceURL, title, client.Category, 0)
+		resp, err := sab.AddURL(ctx, sourceURL, title, ResolveCategory(client, opts.MediaType), 0)
 		if err != nil {
 			return nil, err
 		}
@@ -229,15 +229,20 @@ func GetStalledIDs(ctx context.Context, client *models.DownloadClient) (map[stri
 	switch client.Type {
 	case "qbittorrent":
 		qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
-		torrents, err := qb.GetTorrents(ctx, client.Category)
-		if err != nil {
-			return nil, true, err
-		}
-		out := make(map[string]bool, len(torrents))
-		for _, t := range torrents {
-			state := strings.ToLower(t.State)
-			if state == "stalleddl" {
-				out[strings.ToLower(t.Hash)] = true
+		// Poll every category this client may have grabbed under; categoriesToPoll
+		// returns both Category and CategoryAudiobook when the latter is set
+		// (closes #700).
+		out := make(map[string]bool)
+		for _, cat := range categoriesToPoll(client) {
+			torrents, err := qb.GetTorrents(ctx, cat)
+			if err != nil {
+				return nil, true, err
+			}
+			for _, t := range torrents {
+				state := strings.ToLower(t.State)
+				if state == "stalleddl" {
+					out[strings.ToLower(t.Hash)] = true
+				}
 			}
 		}
 		return out, true, nil
@@ -380,20 +385,24 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 	}
 
 	qb := qbittorrent.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
-	torrents, err := qb.GetTorrents(ctx, client.Category)
-	if err != nil {
-		return nil, err
-	}
-
-	out := make(map[string]LiveStatus, len(torrents))
-	for _, t := range torrents {
-		out[strings.ToLower(t.Hash)] = LiveStatus{
-			Percentage: fmt.Sprintf("%.1f", t.Progress*100),
-			TimeLeft:   etaToTimeLeft(int64(t.ETA)),
-			Speed:      bytesPerSecondToString(t.DLSpeed),
-			Size:       t.Size,
-			SizeLeft:   t.AmountLeft,
-			Status:     t.State,
+	// Poll every category this client may have grabbed under; categoriesToPoll
+	// returns both Category and CategoryAudiobook when the latter is set
+	// (closes #700).
+	out := make(map[string]LiveStatus)
+	for _, cat := range categoriesToPoll(client) {
+		torrents, err := qb.GetTorrents(ctx, cat)
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range torrents {
+			out[strings.ToLower(t.Hash)] = LiveStatus{
+				Percentage: fmt.Sprintf("%.1f", t.Progress*100),
+				TimeLeft:   etaToTimeLeft(int64(t.ETA)),
+				Speed:      bytesPerSecondToString(t.DLSpeed),
+				Size:       t.Size,
+				SizeLeft:   t.AmountLeft,
+				Status:     t.State,
+			}
 		}
 	}
 	return out, nil

--- a/internal/downloader/adapter_test.go
+++ b/internal/downloader/adapter_test.go
@@ -640,6 +640,116 @@ func TestSendDownload_QbittorrentAudiobookSavePath(t *testing.T) {
 	}
 }
 
+// TestSendDownload_QbittorrentAudiobookCategory verifies that when a client has
+// CategoryAudiobook set and the send is for an audiobook, the qBittorrent
+// `category` form field reflects the audiobook category — not the ebook one
+// (#700). The savepath is also validated to round-trip the audiobook dir.
+func TestSendDownload_QbittorrentAudiobookCategory(t *testing.T) {
+	var gotCategory, gotSavePath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			_ = r.ParseForm()
+			gotCategory = r.FormValue("category")
+			gotSavePath = r.FormValue("savepath")
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte("[]"))
+		}
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Type:              "qbittorrent",
+		Host:              host,
+		Port:              port,
+		Username:          "u",
+		Password:          "p",
+		PathRemap:         "/media:/books",
+		Category:          "books",
+		CategoryAudiobook: "audiobooks",
+	}
+	_, err := SendDownload(context.Background(), client, "magnet:?xt=urn:btih:ABCDEF123&dn=Book", "", SendOptions{
+		MediaType:            models.MediaTypeAudiobook,
+		DownloadDir:          "/books/downloads",
+		AudiobookDownloadDir: "/books/audio-downloads",
+	})
+	if err != nil {
+		t.Fatalf("SendDownload: %v", err)
+	}
+	if gotCategory != "audiobooks" {
+		t.Errorf("category: want %q, got %q", "audiobooks", gotCategory)
+	}
+	if gotSavePath != "/media/audio-downloads" {
+		t.Errorf("savepath: want %q, got %q", "/media/audio-downloads", gotSavePath)
+	}
+}
+
+// TestSendDownload_QbittorrentEbookCategoryUnchanged confirms that grabs for
+// non-audiobook media types continue to use the existing Category even when
+// CategoryAudiobook is configured — backwards-compat guard for #700.
+func TestSendDownload_QbittorrentEbookCategoryUnchanged(t *testing.T) {
+	var gotCategory string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			_ = r.ParseForm()
+			gotCategory = r.FormValue("category")
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte("[]"))
+		}
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Type:              "qbittorrent",
+		Host:              host,
+		Port:              port,
+		Username:          "u",
+		Password:          "p",
+		Category:          "books",
+		CategoryAudiobook: "audiobooks",
+	}
+	if _, err := SendDownload(context.Background(), client, "magnet:?xt=urn:btih:ABCDEF123&dn=Book", "", SendOptions{MediaType: models.MediaTypeEbook}); err != nil {
+		t.Fatalf("SendDownload: %v", err)
+	}
+	if gotCategory != "books" {
+		t.Errorf("ebook send used category %q, want %q", gotCategory, "books")
+	}
+}
+
+// TestSendDownload_SABnzbdAudiobookCategory verifies the audiobook category
+// flows through SABnzbd's send path as well — the non-torrent branch of #700.
+func TestSendDownload_SABnzbdAudiobookCategory(t *testing.T) {
+	var gotCategory string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotCategory = r.FormValue("cat")
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": true, "nzo_ids": []string{"nzoAUDIO"}})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Type:              "sabnzbd",
+		Host:              host,
+		Port:              port,
+		APIKey:            "k",
+		Category:          "books",
+		CategoryAudiobook: "audiobooks",
+	}
+	if _, err := SendDownload(context.Background(), client, "https://example.com/file.nzb", "My Book", SendOptions{MediaType: models.MediaTypeAudiobook}); err != nil {
+		t.Fatalf("SendDownload: %v", err)
+	}
+	if gotCategory != "audiobooks" {
+		t.Errorf("cat: want %q, got %q", "audiobooks", gotCategory)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // RemoveDownload
 // ---------------------------------------------------------------------------

--- a/internal/downloader/category.go
+++ b/internal/downloader/category.go
@@ -1,0 +1,37 @@
+package downloader
+
+import "github.com/vavallee/bindery/internal/models"
+
+// ResolveCategory picks the correct download-client category/label for a given
+// media type. Audiobook downloads use CategoryAudiobook when it is non-empty;
+// every other case (ebook, MediaTypeBoth, unset) falls back to Category, which
+// preserves the pre-#700 behaviour for clients that have not opted in.
+func ResolveCategory(client *models.DownloadClient, mediaType string) string {
+	if client == nil {
+		return ""
+	}
+	if mediaType == models.MediaTypeAudiobook && client.CategoryAudiobook != "" {
+		return client.CategoryAudiobook
+	}
+	return client.Category
+}
+
+// categoriesToPoll returns the set of category strings GetTorrents/GetStalledIDs
+// callers must poll to cover both ebook and audiobook downloads on the same
+// client. When CategoryAudiobook is unset, the slice contains only Category
+// (which may itself be empty — qBittorrent treats that as "all torrents").
+//
+// We poll by category at grab time is not persisted on the Download row; the
+// alternative — storing the category-used on Download and looking it up per
+// poll — would touch the Download schema and every grab call-site. Polling
+// both categories is the smaller blast radius (closes #700).
+func categoriesToPoll(client *models.DownloadClient) []string {
+	if client == nil {
+		return nil
+	}
+	cats := []string{client.Category}
+	if client.CategoryAudiobook != "" && client.CategoryAudiobook != client.Category {
+		cats = append(cats, client.CategoryAudiobook)
+	}
+	return cats
+}

--- a/internal/downloader/category_test.go
+++ b/internal/downloader/category_test.go
@@ -1,0 +1,107 @@
+package downloader
+
+import (
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestResolveCategory(t *testing.T) {
+	tests := []struct {
+		name      string
+		client    *models.DownloadClient
+		mediaType string
+		want      string
+	}{
+		{
+			name:      "nil client returns empty",
+			client:    nil,
+			mediaType: models.MediaTypeEbook,
+			want:      "",
+		},
+		{
+			name:      "ebook mediaType returns Category",
+			client:    &models.DownloadClient{Category: "books", CategoryAudiobook: "audiobooks"},
+			mediaType: models.MediaTypeEbook,
+			want:      "books",
+		},
+		{
+			name:      "audiobook mediaType returns CategoryAudiobook when set",
+			client:    &models.DownloadClient{Category: "books", CategoryAudiobook: "audiobooks"},
+			mediaType: models.MediaTypeAudiobook,
+			want:      "audiobooks",
+		},
+		{
+			name:      "audiobook mediaType falls back to Category when CategoryAudiobook empty",
+			client:    &models.DownloadClient{Category: "books"},
+			mediaType: models.MediaTypeAudiobook,
+			want:      "books",
+		},
+		{
+			name:      "both mediaType returns Category (not the audiobook one)",
+			client:    &models.DownloadClient{Category: "books", CategoryAudiobook: "audiobooks"},
+			mediaType: models.MediaTypeBoth,
+			want:      "books",
+		},
+		{
+			name:      "empty mediaType returns Category",
+			client:    &models.DownloadClient{Category: "books", CategoryAudiobook: "audiobooks"},
+			mediaType: "",
+			want:      "books",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveCategory(tc.client, tc.mediaType); got != tc.want {
+				t.Fatalf("ResolveCategory = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCategoriesToPoll(t *testing.T) {
+	tests := []struct {
+		name   string
+		client *models.DownloadClient
+		want   []string
+	}{
+		{
+			name:   "nil client",
+			client: nil,
+			want:   nil,
+		},
+		{
+			name:   "category only",
+			client: &models.DownloadClient{Category: "books"},
+			want:   []string{"books"},
+		},
+		{
+			name:   "category and audiobook category",
+			client: &models.DownloadClient{Category: "books", CategoryAudiobook: "audiobooks"},
+			want:   []string{"books", "audiobooks"},
+		},
+		{
+			name:   "duplicate values are not polled twice",
+			client: &models.DownloadClient{Category: "books", CategoryAudiobook: "books"},
+			want:   []string{"books"},
+		},
+		{
+			name:   "empty category still produces one entry (qbit treats as all)",
+			client: &models.DownloadClient{Category: ""},
+			want:   []string{""},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := categoriesToPoll(tc.client)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len(got)=%d, want %d (got=%v)", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got[%d]=%q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/downloader/health.go
+++ b/internal/downloader/health.go
@@ -96,11 +96,16 @@ func CheckDownloadClientHealth(ctx context.Context, client *models.DownloadClien
 	return checkQbittorrentCategoryPath(ctx, client, downloadDir, audiobookDownloadDir)
 }
 
-func ExpectedDownloadDirForClient(client *models.DownloadClient, downloadDir, audiobookDownloadDir string) string {
+// ExpectedDownloadDirForClient returns the local download directory Bindery
+// expects the given client's category to map to for the supplied media type.
+// Before #700 this used a fuzzy strings.Contains(category, "audio") heuristic
+// because the client had no explicit media-type binding; now the caller
+// passes the media type explicitly and we honour that without guessing.
+func ExpectedDownloadDirForClient(client *models.DownloadClient, mediaType, downloadDir, audiobookDownloadDir string) string {
 	if client == nil {
 		return strings.TrimSpace(downloadDir)
 	}
-	if strings.Contains(strings.ToLower(client.Category), "audio") && strings.TrimSpace(audiobookDownloadDir) != "" {
+	if mediaType == models.MediaTypeAudiobook && strings.TrimSpace(audiobookDownloadDir) != "" {
 		return strings.TrimSpace(audiobookDownloadDir)
 	}
 	return strings.TrimSpace(downloadDir)
@@ -118,7 +123,7 @@ func checkQbittorrentCategoryPath(ctx context.Context, client *models.DownloadCl
 	if category == "" {
 		return healthError("qBittorrent category is empty; configure a category with a save path")
 	}
-	expected := filepath.Clean(ExpectedDownloadDirForClient(client, downloadDir, audiobookDownloadDir))
+	expected := filepath.Clean(ExpectedDownloadDirForClient(client, models.MediaTypeEbook, downloadDir, audiobookDownloadDir))
 	if expected == "." || expected == "" {
 		return healthError("Bindery download directory is empty; check BINDERY_DOWNLOAD_DIR")
 	}
@@ -128,6 +133,40 @@ func checkQbittorrentCategoryPath(ctx context.Context, client *models.DownloadCl
 	if err != nil {
 		return healthError(fmt.Sprintf("qBittorrent category path check failed: %v", err))
 	}
+
+	// Validate the ebook category first; if it fails, return immediately.
+	// When CategoryAudiobook is set, validate it against audiobookDownloadDir
+	// as well — both must be healthy for the client to be healthy (#700).
+	if h := validateQbittorrentCategorySavePath(ctx, qb, client, category, expected, categories); h.Status != HealthOK {
+		return h
+	}
+
+	audioCategory := strings.TrimSpace(client.CategoryAudiobook)
+	if audioCategory != "" && audioCategory != category {
+		expectedAudio := filepath.Clean(ExpectedDownloadDirForClient(client, models.MediaTypeAudiobook, downloadDir, audiobookDownloadDir))
+		if expectedAudio == "." || expectedAudio == "" {
+			return healthError("Bindery audiobook download directory is empty; check BINDERY_AUDIOBOOK_DOWNLOAD_DIR")
+		}
+		if h := validateQbittorrentCategorySavePath(ctx, qb, client, audioCategory, expectedAudio, categories); h.Status != HealthOK {
+			return h
+		}
+	}
+
+	if audioCategory != "" && audioCategory != category {
+		return models.DownloadClientHealth{
+			Status:  HealthOK,
+			Message: fmt.Sprintf("qBittorrent categories %q and %q (audiobook) both validated", category, audioCategory),
+		}
+	}
+	return models.DownloadClientHealth{
+		Status:  HealthOK,
+		Message: fmt.Sprintf("qBittorrent category %q saves under %q", category, expected),
+	}
+}
+
+// validateQbittorrentCategorySavePath checks that a single qBittorrent category
+// exists and that its (path-remapped) save path falls at or under expected.
+func validateQbittorrentCategorySavePath(ctx context.Context, qb *qbittorrent.Client, client *models.DownloadClient, category, expected string, categories map[string]qbittorrent.Category) models.DownloadClientHealth {
 	qbCategory, ok := categories[category]
 	if !ok {
 		return healthError(fmt.Sprintf("qBittorrent category %q was not found; create it with save path %q", category, expected))
@@ -155,10 +194,7 @@ func checkQbittorrentCategoryPath(ctx context.Context, client *models.DownloadCl
 		return healthError(fmt.Sprintf("qBittorrent category %q saves to %q, which maps to %q inside Bindery; expected a path at or under %q — %s", category, savePath, localPath, expected, hint))
 	}
 
-	return models.DownloadClientHealth{
-		Status:  HealthOK,
-		Message: fmt.Sprintf("qBittorrent category %q saves to %q", category, savePath),
-	}
+	return models.DownloadClientHealth{Status: HealthOK}
 }
 
 func healthError(message string) models.DownloadClientHealth {

--- a/internal/downloader/health_test.go
+++ b/internal/downloader/health_test.go
@@ -101,10 +101,81 @@ func TestCheckDownloadClientHealth_QBittorrentCategoryPath(t *testing.T) {
 	}
 }
 
-func TestExpectedDownloadDirForClient_AudiobookCategory(t *testing.T) {
-	client := &models.DownloadClient{Category: "audiobooks"}
-	if got := ExpectedDownloadDirForClient(client, "/books/downloads", "/books/audio-downloads"); got != "/books/audio-downloads" {
-		t.Fatalf("expected audiobook download dir, got %q", got)
+func TestExpectedDownloadDirForClient_AudiobookMediaType(t *testing.T) {
+	client := &models.DownloadClient{Category: "books", CategoryAudiobook: "audiobooks"}
+	if got := ExpectedDownloadDirForClient(client, models.MediaTypeAudiobook, "/books/downloads", "/books/audio-downloads"); got != "/books/audio-downloads" {
+		t.Fatalf("audiobook mediaType: expected audiobook download dir, got %q", got)
+	}
+	if got := ExpectedDownloadDirForClient(client, models.MediaTypeEbook, "/books/downloads", "/books/audio-downloads"); got != "/books/downloads" {
+		t.Fatalf("ebook mediaType: expected ebook download dir, got %q", got)
+	}
+}
+
+// TestCheckDownloadClientHealth_QBittorrentAudiobookCategory exercises the
+// per-media-type validation added in #700: when CategoryAudiobook is set, the
+// health check must validate the audiobook category's save path against the
+// audiobook download dir as well, and only return OK when both pass.
+func TestCheckDownloadClientHealth_QBittorrentAudiobookCategory(t *testing.T) {
+	tests := []struct {
+		name       string
+		categories string
+		wantStatus string
+		wantText   string
+	}{
+		{
+			name:       "both categories valid",
+			categories: `{"books":{"name":"books","savePath":"/media/downloads"},"audiobooks":{"name":"audiobooks","savePath":"/media/audio-downloads"}}`,
+			wantStatus: HealthOK,
+			wantText:   "audiobooks",
+		},
+		{
+			name:       "audiobook category missing",
+			categories: `{"books":{"name":"books","savePath":"/media/downloads"}}`,
+			wantStatus: HealthError,
+			wantText:   `qBittorrent category "audiobooks" was not found`,
+		},
+		{
+			name:       "audiobook category points outside audiobook dir",
+			categories: `{"books":{"name":"books","savePath":"/media/downloads"},"audiobooks":{"name":"audiobooks","savePath":"/media/downloads"}}`,
+			wantStatus: HealthError,
+			wantText:   `expected a path at or under "/books/audio-downloads"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v2/auth/login":
+					_, _ = w.Write([]byte("Ok."))
+				case "/api/v2/torrents/categories":
+					_, _ = w.Write([]byte(tc.categories))
+				case "/api/v2/app/defaultSavePath":
+					_, _ = w.Write([]byte("/media/default"))
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer srv.Close()
+			host, port := serverHostPort(t, srv.URL)
+			client := &models.DownloadClient{
+				Type:              "qbittorrent",
+				Host:              host,
+				Port:              port,
+				Username:          "u",
+				Password:          "p",
+				Category:          "books",
+				CategoryAudiobook: "audiobooks",
+				PathRemap:         "/media:/books",
+			}
+			got := CheckDownloadClientHealth(context.Background(), client, "/books/downloads", "/books/audio-downloads")
+			if got.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q; message=%s", got.Status, tc.wantStatus, got.Message)
+			}
+			if tc.wantText != "" && !strings.Contains(got.Message, tc.wantText) {
+				t.Fatalf("message %q does not contain %q", got.Message, tc.wantText)
+			}
+		})
 	}
 }
 

--- a/internal/models/download.go
+++ b/internal/models/download.go
@@ -3,21 +3,26 @@ package models
 import "time"
 
 type DownloadClient struct {
-	ID        int64                 `json:"id"`
-	Name      string                `json:"name"`
-	Type      string                `json:"type"`
-	Host      string                `json:"host"`
-	Port      int                   `json:"port"`
-	APIKey    string                `json:"apiKey"`
-	UseSSL    bool                  `json:"useSsl"`
-	URLBase   string                `json:"urlBase"`
-	Category  string                `json:"category"`
-	PathRemap string                `json:"pathRemap"`
-	Priority  int                   `json:"priority"`
-	Enabled   bool                  `json:"enabled"`
-	CreatedAt time.Time             `json:"createdAt"`
-	UpdatedAt time.Time             `json:"updatedAt"`
-	Health    *DownloadClientHealth `json:"health,omitempty"`
+	ID       int64  `json:"id"`
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	APIKey   string `json:"apiKey"`
+	UseSSL   bool   `json:"useSsl"`
+	URLBase  string `json:"urlBase"`
+	Category string `json:"category"`
+	// CategoryAudiobook is the category/label/tag used when sending an
+	// audiobook download. When empty, audiobooks fall back to Category, which
+	// preserves pre-#700 behaviour for clients that have not opted in to the
+	// per-media-type split.
+	CategoryAudiobook string                `json:"categoryAudiobook"`
+	PathRemap         string                `json:"pathRemap"`
+	Priority          int                   `json:"priority"`
+	Enabled           bool                  `json:"enabled"`
+	CreatedAt         time.Time             `json:"createdAt"`
+	UpdatedAt         time.Time             `json:"updatedAt"`
+	Health            *DownloadClientHealth `json:"health,omitempty"`
 
 	// Username and Password are used by download clients that authenticate with
 	// credentials rather than an API key (e.g. qBittorrent, Transmission).

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -966,6 +966,10 @@ export interface DownloadClient {
   useSsl: boolean
   urlBase: string
   category: string
+  // categoryAudiobook overrides category for audiobook grabs only.
+  // Optional; when empty (the default for pre-#700 rows) audiobook grabs
+  // fall back to `category`.
+  categoryAudiobook?: string
   pathRemap?: string
   enabled: boolean
   health?: DownloadClientHealth

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -282,7 +282,10 @@
     "clients": {
       "heading": "Download Clients",
       "addButton": "+ Add Client",
-      "empty": "No download clients configured. Add SABnzbd to enable downloads."
+      "empty": "No download clients configured. Add SABnzbd to enable downloads.",
+      "audiobookCategoryLabel": "Audiobook Category / Label",
+      "audiobookCategoryPlaceholder": "audiobooks",
+      "audiobookCategoryHelp": "Optional. When set, audiobook grabs use this category instead of the one above. Leave blank to use the same category as ebooks."
     },
     "notifications": {
       "heading": "Webhook Notifications",

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1162,6 +1162,7 @@ describe('SettingsPage', () => {
         username: '',
         password: '',
         category: 'ebooks',
+        categoryAudiobook: '',
         pathRemap: '/media:/books',
         type: 'sabnzbd',
         enabled: true,
@@ -1229,6 +1230,7 @@ describe('SettingsPage', () => {
         password,
         apiKey: '',
         category,
+        categoryAudiobook: '',
         pathRemap: '',
         type,
         enabled: true,
@@ -1268,12 +1270,36 @@ describe('SettingsPage', () => {
         password: 'qbit-pass',
         apiKey: '',
         category: 'ebooks',
+        categoryAudiobook: '',
         pathRemap: '/media:/books',
         useSsl: true,
         urlBase: '/qbittorrent',
       })
     })
     expect(await screen.findByText('qBit Books')).toBeInTheDocument()
+  })
+
+  // #700: per-media-type categories. Verifies the audiobook category field
+  // round-trips through the add form. The transmission case is excluded — its
+  // "Category" field is repurposed as a download-directory override; an audiobook
+  // category for it would need a separate path UI (left to a follow-up).
+  it('adds a download client with a separate audiobook category', async () => {
+    renderSettings()
+    await openClientsTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.clients.addButton' }))
+    fireEvent.change(screen.getByPlaceholderText('Host'), { target: { value: 'sabnzbd' } })
+    fireEvent.change(screen.getByPlaceholderText('API Key'), { target: { value: 'k' } })
+    fireEvent.change(screen.getByDisplayValue('books'), { target: { value: 'ebooks' } })
+    fireEvent.change(screen.getByPlaceholderText('settings.clients.audiobookCategoryPlaceholder'), { target: { value: ' audiobooks ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => {
+      expect(api.addDownloadClient).toHaveBeenCalledWith(expect.objectContaining({
+        category: 'ebooks',
+        categoryAudiobook: 'audiobooks',
+      }))
+    })
   })
 
   it('shows qBittorrent path health errors under the client', async () => {

--- a/web/src/pages/settings/ClientsTab.tsx
+++ b/web/src/pages/settings/ClientsTab.tsx
@@ -120,6 +120,7 @@ export default function ClientsTab({ clients, setClients }: Props) {
 }
 
 function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; onClose: () => void; onSaved: (c: DownloadClient) => void }) {
+  const { t } = useTranslation()
   const [name, setName] = useState(client.name)
   const [type, setType] = useState(client.type || 'sabnzbd')
   const [host, setHost] = useState(client.host)
@@ -130,6 +131,7 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
   const [useSSL, setUseSSL] = useState(client.useSsl || false)
   const [urlBase, setUrlBase] = useState(client.urlBase || '')
   const [category, setCategory] = useState(client.category)
+  const [categoryAudiobook, setCategoryAudiobook] = useState(client.categoryAudiobook || '')
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [pathRemap, setPathRemap] = useState(client.pathRemap || '')
@@ -146,8 +148,8 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
 
   const submit = async () => {
     const data = isPasswordClient(type)
-      ? { ...client, name, type, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, pathRemap: pathRemap.trim(), useSsl: useSSL, urlBase: urlBase.trim() }
-      : { ...client, name, type, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, pathRemap: pathRemap.trim(), useSsl: useSSL, urlBase: urlBase.trim() }
+      ? { ...client, name, type, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), useSsl: useSSL, urlBase: urlBase.trim() }
+      : { ...client, name, type, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), useSsl: useSSL, urlBase: urlBase.trim() }
     setSaving(true)
     setSaveError(null)
     try {
@@ -217,6 +219,13 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
         {type === 'transmission' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Optional absolute path override. Leave blank to use Transmission's configured default download directory.</p>}
         {type === 'deluge' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Applied via the Deluge label plugin. Leave blank if the plugin is not installed.</p>}
       </div>
+      {type !== 'transmission' && (
+        <div>
+          <label className={labelCls}>{t('settings.clients.audiobookCategoryLabel')}</label>
+          <input value={categoryAudiobook} onChange={e => setCategoryAudiobook(e.target.value)} placeholder={t('settings.clients.audiobookCategoryPlaceholder')} className={inputCls} />
+          <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.clients.audiobookCategoryHelp')}</p>
+        </div>
+      )}
       <PathRemapField
         id={`edit-client-path-remap-${client.id}`}
         label="Download client path remap"
@@ -235,6 +244,7 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
 }
 
 function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c: DownloadClient) => void }) {
+  const { t } = useTranslation()
   const [name, setName] = useState('SABnzbd')
   const [type, setType] = useState<'sabnzbd' | 'nzbget' | 'qbittorrent' | 'transmission' | 'deluge'>('sabnzbd')
   const [host, setHost] = useState('')
@@ -244,6 +254,7 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
   const [useSSL, setUseSSL] = useState(false)
   const [urlBase, setUrlBase] = useState('')
   const [category, setCategory] = useState('books')
+  const [categoryAudiobook, setCategoryAudiobook] = useState('')
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [pathRemap, setPathRemap] = useState('')
@@ -282,8 +293,8 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
 
   const submit = async () => {
     const data = isPasswordClient(type)
-      ? { name, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, pathRemap: pathRemap.trim(), type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
-      : { name, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, pathRemap: pathRemap.trim(), type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
+      ? { name, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
+      : { name, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
     setSaving(true)
     setSaveError(null)
     try {
@@ -353,6 +364,13 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
         {type === 'transmission' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Optional absolute path override. Leave blank to use Transmission's configured default download directory.</p>}
         {type === 'deluge' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Applied via the Deluge label plugin. Leave blank if the plugin is not installed.</p>}
       </div>
+      {type !== 'transmission' && (
+        <div>
+          <label className={labelCls}>{t('settings.clients.audiobookCategoryLabel')}</label>
+          <input value={categoryAudiobook} onChange={e => setCategoryAudiobook(e.target.value)} placeholder={t('settings.clients.audiobookCategoryPlaceholder')} className={inputCls} />
+          <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.clients.audiobookCategoryHelp')}</p>
+        </div>
+      )}
       <PathRemapField
         id="add-client-path-remap"
         label="Download client path remap"


### PR DESCRIPTION
## Summary

Today a `DownloadClient` has one `Category` and every grab — ebook or audiobook — gets routed through it. #700 (strenkml) asks for separate tags so audiobook downloads can land in their own qBit category / SAB tag / NZBGet category / Deluge label.

This adds a `CategoryAudiobook` field. Empty = current behaviour (fall back to `Category`). Existing rows get the empty default from the migration, so deployments that do not opt in see zero behaviour change.

## Implementation

- **Model + migration** — `CategoryAudiobook string \`json:\"categoryAudiobook\"\`` on `models.DownloadClient`; migration 043 adds `category_audiobook TEXT NOT NULL DEFAULT ''`. Repo SELECT/INSERT/UPDATE all carry the new column.
- **Send path** — `ResolveCategory(client, mediaType)` is the single lookup. `SendOptions.MediaType` was already plumbed through to every send call, so the switch was mechanical: qBittorrent, Deluge, NZBGet, SABnzbd all now pass `ResolveCategory(client, opts.MediaType)`.
- **Transmission is left alone.** Its `Category` field is repurposed as a download-directory override, not a tag — wiring an audiobook category for it would need a parallel audiobook-path UI. Out of scope here; punt to a follow-up.
- **GetTorrents callers** — `GetStalledIDs` and `getTorrentLiveStatuses` on qBittorrent now poll both `Category` and `CategoryAudiobook` (via `categoriesToPoll`). Chose this over storing the grab-time category on `Download` because the latter touches the schema and every grab call-site for marginal benefit.
- **Health check** — `ExpectedDownloadDirForClient` now takes `mediaType` instead of guessing from `strings.Contains(category, \"audio\")`. `checkQbittorrentCategoryPath` validates both categories' save paths when `CategoryAudiobook` is set; both must be healthy for the client to be healthy. Error messages name the failing category.
- **PickClientForMediaType** — for users with multiple clients, an explicit `CategoryAudiobook != \"\"` now beats the legacy fuzzy heuristic when picking for an audiobook grab.
- **Frontend** — optional \"Audiobook Category / Label\" field next to the existing one on every client type except Transmission. `en.json` keys added; fallback handles other locales.

## Tests

- `ResolveCategory` / `categoriesToPoll` unit tests cover all branches
- `TestSendDownload_QbittorrentAudiobookCategory` and `…_EbookCategoryUnchanged` assert the right category lands in the qBit `add` form-field
- `TestSendDownload_SABnzbdAudiobookCategory` covers the non-torrent path
- `TestCheckDownloadClientHealth_QBittorrentAudiobookCategory` covers both-valid, audiobook-category-missing, and audiobook-save-path-mismatch
- DB round-trip tests for the new column (`Create→GetByID→List→Update`) plus a default-empty test for pre-#700 rows
- Frontend test: add-client form round-trips `categoryAudiobook` through `api.addDownloadClient`

## Backwards compatibility

Existing rows have empty `category_audiobook`. `ResolveCategory` returns `Category` in that case for every media type. Health check skips the audiobook validation. The frontend field starts empty and is optional.

## Verification

- `gofmt -l .` clean
- `go vet ./...` clean
- `golangci-lint run --timeout=5m` → 0 issues
- `go test ./cmd/... ./internal/...` → all green
- `cd web && npm run typecheck && npm run lint && npm run build && npm test` → 229/229 tests pass

Closes #700

## Test plan

- [ ] Manual: create a qBit client with `Category=books`, `CategoryAudiobook=audiobooks`; grab an ebook, confirm it lands in `books`; grab an audiobook, confirm it lands in `audiobooks`
- [ ] Manual: same client with `CategoryAudiobook` blank — audiobook grab should still land in `books` (no regression)
- [ ] Manual: misconfigure `audiobooks` save path in qBit, confirm health surfaces \"qBittorrent category \\\"audiobooks\\\" saves to …\" error
- [ ] Migration: upgrade a v1.14.2 SQLite DB, confirm migration 043 applies cleanly and existing clients still load