### PR TITLE
feat(calibre): rollback for Calibre imports (#643)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -142,6 +142,9 @@ func main() {
 	absProvenanceRepo := db.NewABSProvenanceRepo(database)
 	absConflictRepo := db.NewABSMetadataConflictRepo(database)
 	absReviewRepo := db.NewABSReviewItemRepo(database)
+	calibreImportRunRepo := db.NewCalibreImportRunRepo(database)
+	calibreSnapshotRepo := db.NewCalibreEntitySnapshotRepo(database)
+	calibreProvenanceRepo := db.NewCalibreProvenanceRepo(database)
 	indexerRepo := db.NewIndexerRepo(database)
 	dlClientRepo := db.NewDownloadClientRepo(database)
 	downloadRepo := db.NewDownloadRepo(database)
@@ -296,7 +299,8 @@ func main() {
 	// runs. A single instance is shared between the API handler and the
 	// startup-sync branch below — both paths share the "only one import
 	// at a time" guard.
-	calibreImporter := calibre.NewImporter(authorRepo, authorAliasRepo, bookRepo, editionRepo, settingsRepo)
+	calibreImporter := calibre.NewImporter(authorRepo, authorAliasRepo, bookRepo, editionRepo, settingsRepo).
+		WithRunTracking(calibreImportRunRepo, calibreSnapshotRepo, calibreProvenanceRepo)
 	absImporter := abs.NewImporter(authorRepo, authorAliasRepo, bookRepo, editionRepo, seriesRepo, settingsRepo, absImportRunRepo, absImportRunEntityRepo, absProvenanceRepo, absReviewRepo, absConflictRepo).
 		WithVersion(version).
 		WithStoragePaths(cfg.LibraryDir, cfg.AudiobookDir, rootFolderRepo).
@@ -513,6 +517,7 @@ func main() {
 	calibreImportHandler := api.NewCalibreImportHandler(calibreImporter, func() calibre.Config {
 		return api.LoadCalibreConfig(settingsRepo)
 	})
+	calibreRunsHandler := api.NewCalibreRunsHandler(calibreImporter)
 	calibreSyncer := calibre.NewSyncer(bookRepo).WithMetadata(authorRepo, editionRepo)
 	calibreSyncHandler := api.NewCalibreSyncHandler(
 		calibreSyncer,
@@ -861,6 +866,17 @@ func main() {
 		// idempotent. Single-job policy — second call returns 409.
 		r.Post("/calibre/sync", calibreSyncHandler.Start)
 		r.Get("/calibre/sync/status", calibreSyncHandler.Status)
+
+		// Calibre import run history + rollback (#643). Admin-only — a bad
+		// rollback can delete authors/books wholesale, so the destructive
+		// path is gated by RequireAdmin and the read-only list is grouped
+		// here for consistency.
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireAdmin)
+			r.Get("/calibre/runs", calibreRunsHandler.List)
+			r.Get("/calibre/runs/{runID}/rollback/preview", calibreRunsHandler.RollbackPreview)
+			r.Post("/calibre/runs/{runID}/rollback", calibreRunsHandler.Rollback)
+		})
 
 		// Migration imports (CSV of author names, or Readarr SQLite DB).
 		// The Readarr import is async — POST returns 202 immediately and the

--- a/internal/api/calibre_runs.go
+++ b/internal/api/calibre_runs.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/vavallee/bindery/internal/calibre"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// calibreRunsAPI is the subset of *calibre.Importer this handler depends
+// on, narrowed for testability.
+type calibreRunsAPI interface {
+	RecentRuns(ctx context.Context, limit int) ([]models.CalibreImportRun, error)
+	PreviewRollback(ctx context.Context, runID int64) (*calibre.RollbackResult, error)
+	Rollback(ctx context.Context, runID int64) (*calibre.RollbackResult, error)
+}
+
+// CalibreRunsHandler serves the run-listing + rollback endpoints introduced
+// in #643. Sits alongside CalibreImportHandler / CalibreSyncHandler rather
+// than folding into them so each handler maps cleanly to one URL prefix.
+type CalibreRunsHandler struct {
+	importer calibreRunsAPI
+}
+
+func NewCalibreRunsHandler(importer calibreRunsAPI) *CalibreRunsHandler {
+	return &CalibreRunsHandler{importer: importer}
+}
+
+// List returns the most recent Calibre import runs. Pagination is via
+// ?limit (default 20, max 100).
+func (h *CalibreRunsHandler) List(w http.ResponseWriter, r *http.Request) {
+	limit, _ := parseLimitOffset(r, 20, 100)
+	if limit <= 0 {
+		limit = 20
+	}
+	runs, err := h.importer.RecentRuns(r.Context(), limit)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if runs == nil {
+		runs = []models.CalibreImportRun{}
+	}
+	writeJSON(w, http.StatusOK, runs)
+}
+
+func (h *CalibreRunsHandler) RollbackPreview(w http.ResponseWriter, r *http.Request) {
+	runID, err := calibreRunID(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	result, err := h.importer.PreviewRollback(r.Context(), runID)
+	switch {
+	case errors.Is(err, calibre.ErrRunNotFound):
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	case errors.Is(err, calibre.ErrRollbackUnavailable):
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	case err != nil:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (h *CalibreRunsHandler) Rollback(w http.ResponseWriter, r *http.Request) {
+	runID, err := calibreRunID(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	result, err := h.importer.Rollback(r.Context(), runID)
+	switch {
+	case errors.Is(err, calibre.ErrRunNotFound):
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	case errors.Is(err, calibre.ErrAlreadyRolledBack):
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	case errors.Is(err, calibre.ErrRollbackUnavailable):
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	case err != nil:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func calibreRunID(r *http.Request) (int64, error) {
+	raw := strings.TrimSpace(chi.URLParam(r, "runID"))
+	if raw == "" {
+		return 0, errors.New("run id is required")
+	}
+	runID, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || runID <= 0 {
+		return 0, errors.New("invalid run id")
+	}
+	return runID, nil
+}

--- a/internal/api/calibre_runs_test.go
+++ b/internal/api/calibre_runs_test.go
@@ -1,0 +1,198 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/vavallee/bindery/internal/calibre"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+type stubCalibreRuns struct {
+	runs          []models.CalibreImportRun
+	preview       *calibre.RollbackResult
+	previewErr    error
+	rollback      *calibre.RollbackResult
+	rollbackErr   error
+	lastPreviewID int64
+	lastApplyID   int64
+}
+
+func (s *stubCalibreRuns) RecentRuns(_ context.Context, _ int) ([]models.CalibreImportRun, error) {
+	return s.runs, nil
+}
+
+func (s *stubCalibreRuns) PreviewRollback(_ context.Context, runID int64) (*calibre.RollbackResult, error) {
+	s.lastPreviewID = runID
+	if s.previewErr != nil {
+		return nil, s.previewErr
+	}
+	if s.preview == nil {
+		return &calibre.RollbackResult{RunID: runID, Preview: true}, nil
+	}
+	return s.preview, nil
+}
+
+func (s *stubCalibreRuns) Rollback(_ context.Context, runID int64) (*calibre.RollbackResult, error) {
+	s.lastApplyID = runID
+	if s.rollbackErr != nil {
+		return nil, s.rollbackErr
+	}
+	if s.rollback == nil {
+		return &calibre.RollbackResult{RunID: runID, Applied: true, Status: "rolled_back"}, nil
+	}
+	return s.rollback, nil
+}
+
+func newCalibreRunsRouter(stub *stubCalibreRuns) http.Handler {
+	r := chi.NewRouter()
+	h := NewCalibreRunsHandler(stub)
+	r.Get("/calibre/runs", h.List)
+	r.Get("/calibre/runs/{runID}/rollback/preview", h.RollbackPreview)
+	r.Post("/calibre/runs/{runID}/rollback", h.Rollback)
+	return r
+}
+
+func TestCalibreRunsHandler_List(t *testing.T) {
+	t.Parallel()
+	stub := &stubCalibreRuns{
+		runs: []models.CalibreImportRun{{
+			ID:          7,
+			SourceID:    "default",
+			LibraryPath: "/lib",
+			Status:      "completed",
+			StartedAt:   time.Now().UTC(),
+		}},
+	}
+	srv := newCalibreRunsRouter(stub)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/calibre/runs?limit=5", nil)
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var got []models.CalibreImportRun
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != 7 {
+		t.Errorf("unexpected response: %+v", got)
+	}
+}
+
+func TestCalibreRunsHandler_ListEmpty(t *testing.T) {
+	t.Parallel()
+	stub := &stubCalibreRuns{}
+	srv := newCalibreRunsRouter(stub)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/calibre/runs", nil)
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got == "null\n" || got == "null" {
+		t.Errorf("empty list serialized as null; want []. got=%q", got)
+	}
+}
+
+func TestCalibreRunsHandler_RollbackPreview(t *testing.T) {
+	t.Parallel()
+	stub := &stubCalibreRuns{
+		preview: &calibre.RollbackResult{RunID: 42, Preview: true, Stats: calibre.RollbackStats{ActionsPlanned: 3}},
+	}
+	srv := newCalibreRunsRouter(stub)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/calibre/runs/42/rollback/preview", nil)
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if stub.lastPreviewID != 42 {
+		t.Errorf("preview run id forwarded = %d, want 42", stub.lastPreviewID)
+	}
+	var got calibre.RollbackResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Stats.ActionsPlanned != 3 {
+		t.Errorf("actionsPlanned = %d, want 3", got.Stats.ActionsPlanned)
+	}
+}
+
+func TestCalibreRunsHandler_RollbackPreviewRunNotFound(t *testing.T) {
+	t.Parallel()
+	stub := &stubCalibreRuns{previewErr: calibre.ErrRunNotFound}
+	srv := newCalibreRunsRouter(stub)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/calibre/runs/999/rollback/preview", nil)
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCalibreRunsHandler_RollbackApply(t *testing.T) {
+	t.Parallel()
+	stub := &stubCalibreRuns{
+		rollback: &calibre.RollbackResult{RunID: 8, Applied: true, Status: "rolled_back"},
+	}
+	srv := newCalibreRunsRouter(stub)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/calibre/runs/8/rollback", nil)
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if stub.lastApplyID != 8 {
+		t.Errorf("apply run id forwarded = %d, want 8", stub.lastApplyID)
+	}
+}
+
+func TestCalibreRunsHandler_RollbackApplyAlreadyRolledBack(t *testing.T) {
+	t.Parallel()
+	stub := &stubCalibreRuns{rollbackErr: calibre.ErrAlreadyRolledBack}
+	srv := newCalibreRunsRouter(stub)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/calibre/runs/8/rollback", nil)
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+}
+
+func TestCalibreRunsHandler_RollbackApplyUnavailable(t *testing.T) {
+	t.Parallel()
+	stub := &stubCalibreRuns{rollbackErr: calibre.ErrRollbackUnavailable}
+	srv := newCalibreRunsRouter(stub)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/calibre/runs/8/rollback", nil)
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestCalibreRunsHandler_InvalidRunID(t *testing.T) {
+	t.Parallel()
+	stub := &stubCalibreRuns{}
+	srv := newCalibreRunsRouter(stub)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/calibre/runs/abc/rollback/preview", nil)
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}

--- a/internal/calibre/import_rollback.go
+++ b/internal/calibre/import_rollback.go
@@ -1,0 +1,687 @@
+package calibre
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// RollbackStats is the per-run roll-up returned by Preview / Execute. Mirror
+// of the ABS shape, minus ABS-only counts.
+type RollbackStats struct {
+	ActionsPlanned     int `json:"actionsPlanned"`
+	EntitiesDeleted    int `json:"entitiesDeleted"`
+	ProvenanceUnlinked int `json:"provenanceUnlinked"`
+	FilesAffected      int `json:"filesAffected"`
+	Skipped            int `json:"skipped"`
+	Failed             int `json:"failed"`
+}
+
+// RollbackAction describes a single planned (or applied) entity action.
+// Action ∈ {restore_book, delete_book, restore_author, delete_author,
+// delete_edition, unlink_provenance, skip}.
+type RollbackAction struct {
+	EntityType  string `json:"entityType"`
+	ExternalID  string `json:"externalId"`
+	LocalID     int64  `json:"localId"`
+	DisplayName string `json:"displayName,omitempty"`
+	Outcome     string `json:"outcome"`
+	Action      string `json:"action"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+// RollbackResult is the JSON payload returned by both Preview and Execute.
+// Preview=true means nothing was applied; Preview=false + Applied=true means
+// every planned action ran. FilesOnDiskWarning is set when the run touched
+// rows that point at on-disk files — rollback is metadata-only, the files
+// themselves stay put on disk.
+type RollbackResult struct {
+	RunID              int64            `json:"runId"`
+	Preview            bool             `json:"preview"`
+	Applied            bool             `json:"applied"`
+	DryRun             bool             `json:"dryRun"`
+	Status             string           `json:"status"`
+	Stats              RollbackStats    `json:"stats"`
+	Actions            []RollbackAction `json:"actions"`
+	FilesOnDiskWarning string           `json:"filesOnDiskWarning,omitempty"`
+	Finished           time.Time        `json:"finishedAt"`
+}
+
+// ErrRunNotFound and ErrAlreadyRolledBack get mapped to 404 / 409 at the API
+// layer so the UI can show distinct messages.
+var (
+	ErrRunNotFound         = errors.New("calibre import run not found")
+	ErrAlreadyRolledBack   = errors.New("calibre import run has already been rolled back")
+	ErrRollbackUnavailable = errors.New("calibre rollback is unavailable: run tracking not configured")
+)
+
+// RecentRuns lists the most recent N Calibre import runs (DESC by start
+// time). Returns nil if the importer was constructed without a run repo
+// (legacy/test wiring).
+func (i *Importer) RecentRuns(ctx context.Context, limit int) ([]models.CalibreImportRun, error) {
+	if i.runs == nil {
+		return nil, nil
+	}
+	return i.runs.ListRecent(ctx, limit)
+}
+
+// GetRun returns one persisted run or nil if it doesn't exist.
+func (i *Importer) GetRun(ctx context.Context, runID int64) (*models.CalibreImportRun, error) {
+	if i.runs == nil {
+		return nil, nil
+	}
+	return i.runs.GetByID(ctx, runID)
+}
+
+// PreviewRollback computes the action list without mutating anything. Safe
+// to call repeatedly.
+func (i *Importer) PreviewRollback(ctx context.Context, runID int64) (*RollbackResult, error) {
+	return i.rollback(ctx, runID, true)
+}
+
+// Rollback executes the rollback and marks the run rolled_back. Refuses to
+// run on a run already in rolled_back state (returns ErrAlreadyRolledBack).
+func (i *Importer) Rollback(ctx context.Context, runID int64) (*RollbackResult, error) {
+	return i.rollback(ctx, runID, false)
+}
+
+func (i *Importer) rollback(ctx context.Context, runID int64, preview bool) (*RollbackResult, error) {
+	if i.runs == nil || i.snapshots == nil || i.provenance == nil {
+		return nil, ErrRollbackUnavailable
+	}
+	// Nil-guards for the repos this code actually touches: a silent
+	// nil-deref would leave the run half-rolled which is worse than refusing
+	// to start.
+	if i.books == nil || i.authors == nil || i.editions == nil {
+		return nil, ErrRollbackUnavailable
+	}
+	run, err := i.runs.GetByID(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if run == nil {
+		return nil, ErrRunNotFound
+	}
+	if !preview && run.Status == runStatusRolledBack {
+		return nil, ErrAlreadyRolledBack
+	}
+	result := &RollbackResult{
+		RunID:    runID,
+		Preview:  preview,
+		DryRun:   run.DryRun,
+		Status:   run.Status,
+		Finished: time.Now().UTC(),
+	}
+	if run.DryRun {
+		// A dry-run import never mutated anything, so rollback is a no-op.
+		// Returning early avoids surfacing confusing "would delete" actions
+		// for entities the run never actually touched.
+		return result, nil
+	}
+
+	entities, err := i.snapshots.ListByRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	// Editions before books before authors. Without this, deleting a book
+	// while its edition still references it would either fail (FK) or
+	// orphan the edition row.
+	sort.SliceStable(entities, func(a, b int) bool {
+		return rollbackEntityRank(entities[a]) < rollbackEntityRank(entities[b])
+	})
+
+	deletedBooks := map[int64]struct{}{}
+	filesTouched := 0
+
+	for _, entity := range entities {
+		current, perr := i.provenance.GetByExternal(ctx, entity.SourceID, entity.EntityType, entity.ExternalID)
+		if perr != nil {
+			result.Stats.Failed++
+			result.Actions = append(result.Actions, RollbackAction{
+				EntityType:  entity.EntityType,
+				ExternalID:  entity.ExternalID,
+				LocalID:     entity.LocalID,
+				DisplayName: i.rollbackDisplayName(ctx, entity),
+				Outcome:     entity.Outcome,
+				Action:      "inspect",
+				Reason:      perr.Error(),
+			})
+			continue
+		}
+		if current == nil {
+			result.Stats.Skipped++
+			result.Actions = append(result.Actions, RollbackAction{
+				EntityType:  entity.EntityType,
+				ExternalID:  entity.ExternalID,
+				LocalID:     entity.LocalID,
+				DisplayName: i.rollbackDisplayName(ctx, entity),
+				Outcome:     entity.Outcome,
+				Action:      "skip",
+				Reason:      "already rolled back",
+			})
+			continue
+		}
+		currentMatches := current.LocalID == entity.LocalID
+		ownedByRun := currentMatches && current.ImportRunID != nil && *current.ImportRunID == runID
+		if !currentMatches {
+			result.Stats.Skipped++
+			result.Actions = append(result.Actions, RollbackAction{
+				EntityType:  entity.EntityType,
+				ExternalID:  entity.ExternalID,
+				LocalID:     entity.LocalID,
+				DisplayName: i.rollbackDisplayName(ctx, entity),
+				Outcome:     entity.Outcome,
+				Action:      "skip",
+				Reason:      "provenance now points to a different local entity",
+			})
+			continue
+		}
+
+		action := RollbackAction{
+			EntityType:  entity.EntityType,
+			ExternalID:  entity.ExternalID,
+			LocalID:     entity.LocalID,
+			DisplayName: i.rollbackDisplayName(ctx, entity),
+			Outcome:     entity.Outcome,
+		}
+
+		switch {
+		case entity.EntityType == entityTypeEdition:
+			// Editions are append-only during Calibre import: when outcome
+			// is "created" we delete the row; otherwise (no other path
+			// today) skip — there's no field-level edition restore.
+			if entity.Outcome != outcomeCreated || !ownedByRun {
+				action.Action = "skip"
+				if !ownedByRun {
+					action.Reason = "run is no longer the current provenance owner for this edition"
+				} else {
+					action.Reason = "edition was not created by this run"
+				}
+				result.Stats.Skipped++
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			action.Action = "delete_edition"
+			result.Stats.ActionsPlanned++
+			if !preview {
+				if err := i.editions.Delete(ctx, entity.LocalID); err != nil {
+					action.Action = "skip"
+					action.Reason = err.Error()
+					result.Stats.Failed++
+					result.Actions = append(result.Actions, action)
+					continue
+				}
+				unlinked, err := i.provenance.DeleteByLocal(ctx, entity.EntityType, entity.LocalID)
+				if err != nil {
+					action.Action = "skip"
+					action.Reason = err.Error()
+					result.Stats.Failed++
+					result.Actions = append(result.Actions, action)
+					continue
+				}
+				result.Stats.EntitiesDeleted++
+				result.Stats.ProvenanceUnlinked += int(unlinked)
+			}
+
+		case entity.EntityType == entityTypeBook && entity.Outcome == outcomeCreated:
+			if !ownedByRun {
+				action.Action = "skip"
+				action.Reason = "run is no longer the current provenance owner for this book"
+				result.Stats.Skipped++
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			retain, err := i.hasProvenanceOutsideRun(ctx, entity.EntityType, entity.LocalID, runID)
+			if err != nil {
+				action.Action = "skip"
+				action.Reason = err.Error()
+				result.Stats.Failed++
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			if retain {
+				action.Action = "unlink_provenance"
+				action.Reason = "local book retained because another Calibre import link references it"
+				result.Stats.ActionsPlanned++
+				if !preview {
+					if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.EntityType, entity.ExternalID); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					result.Stats.ProvenanceUnlinked++
+				}
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			// Books that point at on-disk files: count the file path so the
+			// API response can warn the caller that on-disk files are NOT
+			// removed by rollback. Metadata-only rollback is deliberate —
+			// see PR description.
+			if book, lookupErr := i.books.GetByID(ctx, entity.LocalID); lookupErr == nil && book != nil {
+				if strings.TrimSpace(book.FilePath) != "" || strings.TrimSpace(book.EbookFilePath) != "" || strings.TrimSpace(book.AudiobookFilePath) != "" {
+					filesTouched++
+				}
+			}
+			action.Action = "delete_book"
+			result.Stats.ActionsPlanned++
+			// Mark as deleted for downstream author-pruning accounting in
+			// both preview and execute modes — otherwise the author check
+			// sees still-attached books and downgrades delete_author to
+			// unlink_provenance only in preview, producing a misleading
+			// diff against execute.
+			deletedBooks[entity.LocalID] = struct{}{}
+			if !preview {
+				if err := i.books.Delete(ctx, entity.LocalID); err != nil {
+					action.Action = "skip"
+					action.Reason = err.Error()
+					result.Stats.Failed++
+					result.Actions = append(result.Actions, action)
+					continue
+				}
+				unlinked, err := i.provenance.DeleteByLocal(ctx, entity.EntityType, entity.LocalID)
+				if err != nil {
+					action.Action = "skip"
+					action.Reason = err.Error()
+					result.Stats.Failed++
+					result.Actions = append(result.Actions, action)
+					continue
+				}
+				result.Stats.EntitiesDeleted++
+				result.Stats.ProvenanceUnlinked += int(unlinked)
+			}
+
+		case entity.EntityType == entityTypeBook:
+			// Updated-in-place book: field-level restore (safe even if the
+			// run no longer owns the row because restoreBookFromSnapshot
+			// only reverts a field when current == after).
+			before, after, ok := bookRollbackSnapshotFromMetadata(entity.MetadataJSON)
+			if !ok {
+				action.Action = "skip"
+				action.Reason = "no usable snapshot for this entity"
+				result.Stats.Skipped++
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			action.Action = "restore_book"
+			result.Stats.ActionsPlanned++
+			if !preview {
+				book, err := i.books.GetByID(ctx, entity.LocalID)
+				if err != nil {
+					action.Action = "skip"
+					action.Reason = err.Error()
+					result.Stats.Failed++
+					result.Actions = append(result.Actions, action)
+					continue
+				}
+				if book == nil {
+					action.Action = "skip"
+					action.Reason = "book no longer exists"
+					result.Stats.Skipped++
+					result.Actions = append(result.Actions, action)
+					continue
+				}
+				if restoreBookFromSnapshot(book, before, after) {
+					if err := i.books.Update(ctx, book); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+				}
+				if ownedByRun {
+					if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.EntityType, entity.ExternalID); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					result.Stats.ProvenanceUnlinked++
+				}
+			}
+
+		case entity.EntityType == entityTypeAuthor && entity.Outcome == outcomeCreated:
+			if !ownedByRun {
+				action.Action = "skip"
+				action.Reason = "run is no longer the current provenance owner for this author"
+				result.Stats.Skipped++
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			// Check books still attached to this author that weren't
+			// themselves deleted above; if any remain, retain the author.
+			books, err := i.books.ListByAuthorIncludingExcluded(ctx, entity.LocalID)
+			if err != nil {
+				action.Action = "skip"
+				action.Reason = err.Error()
+				result.Stats.Failed++
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			remaining := 0
+			for _, book := range books {
+				if _, ok := deletedBooks[book.ID]; ok {
+					continue
+				}
+				remaining++
+			}
+			if remaining > 0 {
+				action.Action = "unlink_provenance"
+				action.Reason = "local author retained because it still has linked books"
+				result.Stats.ActionsPlanned++
+				if !preview {
+					if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.EntityType, entity.ExternalID); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					result.Stats.ProvenanceUnlinked++
+				}
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			retain, err := i.hasProvenanceOutsideRun(ctx, entity.EntityType, entity.LocalID, runID)
+			if err != nil {
+				action.Action = "skip"
+				action.Reason = err.Error()
+				result.Stats.Failed++
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			if retain {
+				action.Action = "unlink_provenance"
+				action.Reason = "local author retained because another Calibre import link references it"
+				result.Stats.ActionsPlanned++
+				if !preview {
+					if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.EntityType, entity.ExternalID); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					result.Stats.ProvenanceUnlinked++
+				}
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			action.Action = "delete_author"
+			result.Stats.ActionsPlanned++
+			if !preview {
+				if err := i.authors.Delete(ctx, entity.LocalID); err != nil {
+					action.Action = "skip"
+					action.Reason = err.Error()
+					result.Stats.Failed++
+					result.Actions = append(result.Actions, action)
+					continue
+				}
+				unlinked, err := i.provenance.DeleteByLocal(ctx, entity.EntityType, entity.LocalID)
+				if err != nil {
+					action.Action = "skip"
+					action.Reason = err.Error()
+					result.Stats.Failed++
+					result.Actions = append(result.Actions, action)
+					continue
+				}
+				result.Stats.EntitiesDeleted++
+				result.Stats.ProvenanceUnlinked += int(unlinked)
+			}
+
+		case entity.EntityType == entityTypeAuthor:
+			before, after, ok := authorRollbackSnapshotFromMetadata(entity.MetadataJSON)
+			if !ok {
+				action.Action = "skip"
+				action.Reason = "no usable snapshot for this entity"
+				result.Stats.Skipped++
+				result.Actions = append(result.Actions, action)
+				continue
+			}
+			action.Action = "restore_author"
+			result.Stats.ActionsPlanned++
+			if !preview {
+				author, err := i.authors.GetByID(ctx, entity.LocalID)
+				if err != nil {
+					action.Action = "skip"
+					action.Reason = err.Error()
+					result.Stats.Failed++
+					result.Actions = append(result.Actions, action)
+					continue
+				}
+				if author == nil {
+					action.Action = "skip"
+					action.Reason = "author no longer exists"
+					result.Stats.Skipped++
+					result.Actions = append(result.Actions, action)
+					continue
+				}
+				if restoreAuthorFromSnapshot(author, before, after) {
+					if err := i.authors.Update(ctx, author); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+				}
+				if ownedByRun {
+					if err := i.provenance.DeleteByExternal(ctx, entity.SourceID, entity.EntityType, entity.ExternalID); err != nil {
+						action.Action = "skip"
+						action.Reason = err.Error()
+						result.Stats.Failed++
+						result.Actions = append(result.Actions, action)
+						continue
+					}
+					result.Stats.ProvenanceUnlinked++
+				}
+			}
+
+		default:
+			action.Action = "skip"
+			action.Reason = "unsupported entity type"
+			result.Stats.Skipped++
+		}
+
+		result.Actions = append(result.Actions, action)
+	}
+
+	result.Stats.FilesAffected = filesTouched
+	if filesTouched > 0 {
+		result.FilesOnDiskWarning = fmt.Sprintf("%d book row(s) referenced on-disk files; rollback removes the metadata row only, the files on disk are untouched.", filesTouched)
+	}
+
+	if !preview && result.Stats.Failed == 0 {
+		if err := i.runs.UpdateStatus(ctx, runID, runStatusRolledBack); err != nil {
+			return nil, err
+		}
+		result.Status = runStatusRolledBack
+		result.Applied = true
+	}
+	return result, nil
+}
+
+func (i *Importer) hasProvenanceOutsideRun(ctx context.Context, entityType string, localID, runID int64) (bool, error) {
+	if i.provenance == nil || localID == 0 {
+		return false, nil
+	}
+	links, err := i.provenance.ListByLocal(ctx, entityType, localID)
+	if err != nil {
+		return false, err
+	}
+	for _, link := range links {
+		if link.ImportRunID == nil || *link.ImportRunID != runID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (i *Importer) rollbackDisplayName(ctx context.Context, entity models.CalibreEntitySnapshot) string {
+	if entity.LocalID == 0 {
+		return ""
+	}
+	switch entity.EntityType {
+	case entityTypeBook:
+		if i.books == nil {
+			return ""
+		}
+		b, err := i.books.GetByID(ctx, entity.LocalID)
+		if err != nil || b == nil {
+			return ""
+		}
+		return strings.TrimSpace(b.Title)
+	case entityTypeAuthor:
+		if i.authors == nil {
+			return ""
+		}
+		a, err := i.authors.GetByID(ctx, entity.LocalID)
+		if err != nil || a == nil {
+			return ""
+		}
+		return strings.TrimSpace(a.Name)
+	case entityTypeEdition:
+		if i.editions == nil {
+			return ""
+		}
+		eds, err := i.editions.ListByBook(ctx, 0)
+		if err != nil {
+			return ""
+		}
+		for _, e := range eds {
+			if e.ID == entity.LocalID {
+				return strings.TrimSpace(e.Title)
+			}
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+// rollbackEntityRank orders entities for rollback so children (editions) go
+// before parents (books, authors). This avoids leaving a dangling
+// edition→book FK while a book is being deleted/restored.
+func rollbackEntityRank(entity models.CalibreEntitySnapshot) int {
+	switch entity.EntityType {
+	case entityTypeEdition:
+		return 0
+	case entityTypeBook:
+		return 1
+	case entityTypeAuthor:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// restoreBookFromSnapshot reverts each book field where the current value
+// still equals the post-import snapshot. Returns true iff any field
+// changed. Designed so a post-import user edit ("After" no longer matches
+// current) is preserved untouched.
+func restoreBookFromSnapshot(book *models.Book, before, after *bookRollbackSnapshot) bool {
+	if book == nil || before == nil || after == nil {
+		return false
+	}
+	changed := false
+	restoreString(&book.ForeignID, before.ForeignID, after.ForeignID, &changed)
+	restoreInt64(&book.AuthorID, before.AuthorID, after.AuthorID, &changed)
+	restoreString(&book.Title, before.Title, after.Title, &changed)
+	restoreString(&book.SortTitle, before.SortTitle, after.SortTitle, &changed)
+	restoreTimePtr(&book.ReleaseDate, before.ReleaseDate, after.ReleaseDate, &changed)
+	restoreString(&book.Language, before.Language, after.Language, &changed)
+	restoreString(&book.Status, before.Status, after.Status, &changed)
+	restoreString(&book.FilePath, before.FilePath, after.FilePath, &changed)
+	restoreString(&book.MetadataProvider, before.MetadataProvider, after.MetadataProvider, &changed)
+	restoreInt64Ptr(&book.CalibreID, before.CalibreID, after.CalibreID, &changed)
+	restoreString(&book.MediaType, before.MediaType, after.MediaType, &changed)
+	restoreBool(&book.AnyEditionOK, before.AnyEditionOK, after.AnyEditionOK, &changed)
+	restoreBool(&book.Monitored, before.Monitored, after.Monitored, &changed)
+	return changed
+}
+
+func restoreAuthorFromSnapshot(author *models.Author, before, after *authorRollbackSnapshot) bool {
+	if author == nil || before == nil || after == nil {
+		return false
+	}
+	changed := false
+	restoreString(&author.ForeignID, before.ForeignID, after.ForeignID, &changed)
+	restoreString(&author.Name, before.Name, after.Name, &changed)
+	restoreString(&author.SortName, before.SortName, after.SortName, &changed)
+	restoreString(&author.MetadataProvider, before.MetadataProvider, after.MetadataProvider, &changed)
+	restoreBool(&author.Monitored, before.Monitored, after.Monitored, &changed)
+	return changed
+}
+
+func restoreString(target *string, before, after string, changed *bool) {
+	if *target != after {
+		return
+	}
+	if *target != before {
+		*changed = true
+	}
+	*target = before
+}
+
+func restoreInt64(target *int64, before, after int64, changed *bool) {
+	if *target != after {
+		return
+	}
+	if *target != before {
+		*changed = true
+	}
+	*target = before
+}
+
+func restoreBool(target *bool, before, after bool, changed *bool) {
+	if *target != after {
+		return
+	}
+	if *target != before {
+		*changed = true
+	}
+	*target = before
+}
+
+func restoreInt64Ptr(target **int64, before, after *int64, changed *bool) {
+	if !equalInt64Ptr(*target, after) {
+		return
+	}
+	if !equalInt64Ptr(*target, before) {
+		*changed = true
+	}
+	*target = cloneInt64Ptr(before)
+}
+
+func restoreTimePtr(target **time.Time, before, after *time.Time, changed *bool) {
+	if !equalTimePtr(*target, after) {
+		return
+	}
+	if !equalTimePtr(*target, before) {
+		*changed = true
+	}
+	*target = cloneTimePtr(before)
+}
+
+func equalInt64Ptr(a, b *int64) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func equalTimePtr(a, b *time.Time) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Equal(*b)
+}

--- a/internal/calibre/import_rollback_helpers_test.go
+++ b/internal/calibre/import_rollback_helpers_test.go
@@ -1,0 +1,12 @@
+package calibre
+
+import "os"
+
+func writeRollbackTestFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o600)
+}
+
+func rollbackTestFileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/calibre/import_rollback_test.go
+++ b/internal/calibre/import_rollback_test.go
@@ -1,0 +1,289 @@
+package calibre
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// newRollbackFixture wires an Importer that has run-tracking repos attached,
+// so importing produces snapshots and rollback can be exercised end-to-end.
+func newRollbackFixture(t *testing.T) (*Importer, *fakeReader, *db.AuthorRepo, *db.BookRepo, *db.EditionRepo, *db.CalibreImportRunRepo, *db.CalibreEntitySnapshotRepo, *db.CalibreProvenanceRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	editionRepo := db.NewEditionRepo(database)
+	aliasRepo := db.NewAuthorAliasRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+	runsRepo := db.NewCalibreImportRunRepo(database)
+	snapshotRepo := db.NewCalibreEntitySnapshotRepo(database)
+	provRepo := db.NewCalibreProvenanceRepo(database)
+
+	fr := &fakeReader{}
+	imp := NewImporter(authorRepo, aliasRepo, bookRepo, editionRepo, settingsRepo).
+		WithRunTracking(runsRepo, snapshotRepo, provRepo)
+	imp.openReader = func(string) (readerIface, error) { return fr, nil }
+
+	return imp, fr, authorRepo, bookRepo, editionRepo, runsRepo, snapshotRepo, provRepo
+}
+
+func TestImporter_RunTracking_RecordsSnapshotsAndProvenance(t *testing.T) {
+	imp, fr, _, _, _, runsRepo, snapshotRepo, provRepo := newRollbackFixture(t)
+	fr.books = []CalibreBook{
+		sampleCalibreBook(1, "Book One", "Alice Author"),
+		sampleCalibreBook(2, "Book Two", "Alice Author"),
+	}
+
+	if _, err := imp.Run(context.Background(), "/lib"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	runs, err := runsRepo.ListRecent(context.Background(), 10)
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d (%v)", len(runs), err)
+	}
+	run := runs[0]
+	if run.Status != runStatusCompleted {
+		t.Errorf("run status = %q, want %q", run.Status, runStatusCompleted)
+	}
+	if run.LibraryPath != "/lib" {
+		t.Errorf("run library_path = %q, want /lib", run.LibraryPath)
+	}
+
+	snaps, err := snapshotRepo.ListByRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("ListByRun: %v", err)
+	}
+	// Two books + one author + two editions = 5 snapshots minimum.
+	if len(snaps) < 5 {
+		t.Errorf("expected >=5 snapshots, got %d", len(snaps))
+	}
+	// Every snapshot must be tagged with the run id and outcome.
+	for _, s := range snaps {
+		if s.RunID != run.ID {
+			t.Errorf("snapshot %d run_id = %d, want %d", s.ID, s.RunID, run.ID)
+		}
+		if s.Outcome == "" {
+			t.Errorf("snapshot %d has empty outcome", s.ID)
+		}
+		// Created rows must specifically carry outcome=created so rollback
+		// knows to delete (not field-restore) them.
+		if (s.EntityType == entityTypeBook || s.EntityType == entityTypeAuthor || s.EntityType == entityTypeEdition) && s.Outcome != outcomeCreated && s.Outcome != outcomeUpdated && s.Outcome != outcomeLinked {
+			t.Errorf("snapshot %d unexpected outcome %q", s.ID, s.Outcome)
+		}
+	}
+
+	// Provenance rows must exist for every Calibre entity touched.
+	authorProv, err := provRepo.GetByExternal(context.Background(), defaultSourceID, entityTypeAuthor, "author:1")
+	if err != nil || authorProv == nil {
+		t.Fatalf("author provenance: %v / %v", err, authorProv)
+	}
+	if authorProv.ImportRunID == nil || *authorProv.ImportRunID != run.ID {
+		t.Errorf("author provenance run id = %v, want %d", authorProv.ImportRunID, run.ID)
+	}
+	for _, externalID := range []string{"book:1", "book:2"} {
+		bookProv, err := provRepo.GetByExternal(context.Background(), defaultSourceID, entityTypeBook, externalID)
+		if err != nil || bookProv == nil {
+			t.Fatalf("book provenance %s: %v / %v", externalID, err, bookProv)
+		}
+	}
+}
+
+func TestImporter_PreviewRollback_ReturnsExpectedActions(t *testing.T) {
+	imp, fr, _, _, _, runsRepo, _, _ := newRollbackFixture(t)
+	fr.books = []CalibreBook{
+		sampleCalibreBook(10, "Book Ten", "Alice"),
+		sampleCalibreBook(11, "Book Eleven", "Alice"),
+	}
+	if _, err := imp.Run(context.Background(), "/lib"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	runs, _ := runsRepo.ListRecent(context.Background(), 5)
+	if len(runs) == 0 {
+		t.Fatal("no runs recorded")
+	}
+	run := runs[0]
+
+	preview, err := imp.PreviewRollback(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("PreviewRollback: %v", err)
+	}
+	if !preview.Preview {
+		t.Error("preview.Preview = false, want true")
+	}
+	if preview.Applied {
+		t.Error("preview.Applied = true; preview must not apply anything")
+	}
+	if preview.Stats.ActionsPlanned == 0 {
+		t.Errorf("expected actions planned > 0, got 0; actions=%+v", preview.Actions)
+	}
+	// Preview must touch deletes for created authors/books/editions.
+	var sawAuthorDelete, sawBookDelete, sawEditionDelete bool
+	for _, a := range preview.Actions {
+		switch {
+		case a.Action == "delete_author" && a.EntityType == entityTypeAuthor:
+			sawAuthorDelete = true
+		case a.Action == "delete_book" && a.EntityType == entityTypeBook:
+			sawBookDelete = true
+		case a.Action == "delete_edition" && a.EntityType == entityTypeEdition:
+			sawEditionDelete = true
+		}
+	}
+	if !sawAuthorDelete || !sawBookDelete || !sawEditionDelete {
+		t.Errorf("missing planned actions: author=%v book=%v edition=%v", sawAuthorDelete, sawBookDelete, sawEditionDelete)
+	}
+}
+
+func TestImporter_ExecuteRollback_DeletesEntitiesAndMarksRun(t *testing.T) {
+	imp, fr, authorRepo, bookRepo, editionRepo, runsRepo, _, provRepo := newRollbackFixture(t)
+	fr.books = []CalibreBook{
+		sampleCalibreBook(20, "Rollback Me", "Zola Zola"),
+	}
+	if _, err := imp.Run(context.Background(), "/lib"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	runs, _ := runsRepo.ListRecent(context.Background(), 5)
+	run := runs[0]
+
+	// Sanity: entities exist before rollback.
+	book, _ := bookRepo.GetByCalibreID(context.Background(), 20)
+	if book == nil {
+		t.Fatal("book missing before rollback")
+	}
+	author, _ := authorRepo.GetByID(context.Background(), book.AuthorID)
+	if author == nil {
+		t.Fatal("author missing before rollback")
+	}
+	eds, _ := editionRepo.ListByBook(context.Background(), book.ID)
+	if len(eds) != 1 {
+		t.Fatalf("editions before rollback = %d, want 1", len(eds))
+	}
+
+	// Drop an on-disk file marker into FilePath so the rollback warning
+	// path is exercised.
+	if book.FilePath == "" {
+		book.FilePath = filepath.Join("/lib", "Rollback Me.epub")
+		if err := bookRepo.Update(context.Background(), book); err != nil {
+			t.Fatalf("update book FilePath: %v", err)
+		}
+	}
+
+	result, err := imp.Rollback(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if result.Preview {
+		t.Error("Rollback result.Preview = true, want false")
+	}
+	if !result.Applied {
+		t.Error("Rollback result.Applied = false, want true")
+	}
+	if result.Status != runStatusRolledBack {
+		t.Errorf("result.Status = %q, want %q", result.Status, runStatusRolledBack)
+	}
+	if result.FilesOnDiskWarning == "" {
+		t.Error("expected FilesOnDiskWarning for a book with FilePath set; got empty")
+	}
+
+	// Run record must now be rolled_back.
+	reloaded, _ := runsRepo.GetByID(context.Background(), run.ID)
+	if reloaded == nil || reloaded.Status != runStatusRolledBack {
+		t.Errorf("run status after rollback = %+v", reloaded)
+	}
+
+	// Book/author/edition rows must be gone.
+	if got, _ := bookRepo.GetByCalibreID(context.Background(), 20); got != nil {
+		t.Error("book still present after rollback")
+	}
+	if got, _ := authorRepo.GetByID(context.Background(), author.ID); got != nil {
+		t.Error("author still present after rollback")
+	}
+	if eds, _ := editionRepo.ListByBook(context.Background(), book.ID); len(eds) != 0 {
+		t.Errorf("editions still present after rollback: %d", len(eds))
+	}
+	// Provenance must be cleared.
+	if got, _ := provRepo.GetByExternal(context.Background(), defaultSourceID, entityTypeBook, "book:20"); got != nil {
+		t.Error("book provenance still present after rollback")
+	}
+}
+
+func TestImporter_RolledBackRun_RefusesSecondRollback(t *testing.T) {
+	imp, fr, _, _, _, runsRepo, _, _ := newRollbackFixture(t)
+	fr.books = []CalibreBook{
+		sampleCalibreBook(30, "Once-Only", "Once"),
+	}
+	if _, err := imp.Run(context.Background(), "/lib"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	runs, _ := runsRepo.ListRecent(context.Background(), 5)
+	run := runs[0]
+
+	if _, err := imp.Rollback(context.Background(), run.ID); err != nil {
+		t.Fatalf("first rollback: %v", err)
+	}
+	_, err := imp.Rollback(context.Background(), run.ID)
+	if err == nil {
+		t.Fatal("expected ErrAlreadyRolledBack on second rollback, got nil")
+	}
+	if !errors.Is(err, ErrAlreadyRolledBack) {
+		t.Errorf("err = %v, want ErrAlreadyRolledBack", err)
+	}
+}
+
+func TestImporter_Rollback_RunNotFound(t *testing.T) {
+	imp, _, _, _, _, _, _, _ := newRollbackFixture(t)
+	if _, err := imp.PreviewRollback(context.Background(), 9999); !errors.Is(err, ErrRunNotFound) {
+		t.Errorf("PreviewRollback unknown run = %v, want ErrRunNotFound", err)
+	}
+	if _, err := imp.Rollback(context.Background(), 9999); !errors.Is(err, ErrRunNotFound) {
+		t.Errorf("Rollback unknown run = %v, want ErrRunNotFound", err)
+	}
+}
+
+func TestImporter_Rollback_FileRowsNotTouchedOnDisk(t *testing.T) {
+	// Metadata-only rollback: even when the book row had a FilePath, we
+	// remove only the row. The file system is untouched. This test
+	// constructs an actual file on disk and asserts it's still there after
+	// rollback.
+	imp, fr, _, bookRepo, _, runsRepo, _, _ := newRollbackFixture(t)
+
+	tmp := t.TempDir()
+	fakePath := filepath.Join(tmp, "should-survive.epub")
+	if err := writeRollbackTestFile(fakePath, "fake epub bytes"); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	cb := sampleCalibreBook(40, "On-Disk", "On-Disk Author")
+	cb.Formats[0].AbsolutePath = fakePath
+	fr.books = []CalibreBook{cb}
+
+	if _, err := imp.Run(context.Background(), "/lib"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	book, _ := bookRepo.GetByCalibreID(context.Background(), 40)
+	if book == nil {
+		t.Fatal("book missing")
+	}
+	if book.FilePath == "" {
+		book.FilePath = fakePath
+		_ = bookRepo.Update(context.Background(), book)
+	}
+
+	runs, _ := runsRepo.ListRecent(context.Background(), 5)
+	if _, err := imp.Rollback(context.Background(), runs[0].ID); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+
+	if !rollbackTestFileExists(fakePath) {
+		t.Errorf("on-disk file %q removed by rollback; rollback must be metadata-only", fakePath)
+	}
+}

--- a/internal/calibre/import_snapshots.go
+++ b/internal/calibre/import_snapshots.go
@@ -1,0 +1,350 @@
+package calibre
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// runEntityMetadataEnvelope is the JSON shape stored in
+// calibre_entity_snapshots.metadata_json. Kind+Version are stamped on every
+// record so future migrations can detect old envelopes; Data holds free-form
+// per-outcome breadcrumbs; Snapshot carries the typed before/after payload
+// rollback restores from.
+type runEntityMetadataEnvelope struct {
+	Kind     string                     `json:"kind"`
+	Version  int                        `json:"version"`
+	Data     map[string]any             `json:"data,omitempty"`
+	Snapshot *runEntitySnapshotEnvelope `json:"snapshot,omitempty"`
+}
+
+type runEntitySnapshotEnvelope struct {
+	EntityType string          `json:"entityType"`
+	Before     json.RawMessage `json:"before,omitempty"`
+	After      json.RawMessage `json:"after,omitempty"`
+}
+
+// bookRollbackSnapshot captures the subset of book fields the Calibre
+// importer mutates (see applyBookFields + upsertBook). Fields outside this
+// list are not touched by the import path so they don't need to be
+// snapshotted or restored.
+type bookRollbackSnapshot struct {
+	ForeignID        string     `json:"foreignId"`
+	AuthorID         int64      `json:"authorId"`
+	Title            string     `json:"title"`
+	SortTitle        string     `json:"sortTitle"`
+	ReleaseDate      *time.Time `json:"releaseDate,omitempty"`
+	Language         string     `json:"language"`
+	Status           string     `json:"status"`
+	FilePath         string     `json:"filePath"`
+	MetadataProvider string     `json:"metadataProvider"`
+	CalibreID        *int64     `json:"calibreId,omitempty"`
+	MediaType        string     `json:"mediaType"`
+	AnyEditionOK     bool       `json:"anyEditionOk"`
+	Monitored        bool       `json:"monitored"`
+}
+
+// authorRollbackSnapshot mirrors bookRollbackSnapshot for the Calibre
+// importer's author path (resolveAuthor — only sets Name, SortName,
+// ForeignID, MetadataProvider, Monitored when creating fresh).
+type authorRollbackSnapshot struct {
+	ForeignID        string `json:"foreignId"`
+	Name             string `json:"name"`
+	SortName         string `json:"sortName"`
+	MetadataProvider string `json:"metadataProvider"`
+	Monitored        bool   `json:"monitored"`
+}
+
+// editionRollbackSnapshot captures the subset of edition fields touched by
+// upsertEdition. Editions are append-only during Calibre import (Upsert
+// either creates fresh or updates everything), so the snapshot mostly
+// matters to identify rows to delete on rollback.
+type editionRollbackSnapshot struct {
+	ForeignID   string     `json:"foreignId"`
+	BookID      int64      `json:"bookId"`
+	Title       string     `json:"title"`
+	ISBN13      *string    `json:"isbn13,omitempty"`
+	PublishDate *time.Time `json:"publishDate,omitempty"`
+	Format      string     `json:"format"`
+	Language    string     `json:"language"`
+	ImageURL    string     `json:"imageUrl"`
+	IsEbook     bool       `json:"isEbook"`
+	Monitored   bool       `json:"monitored"`
+}
+
+func bookSnapshot(b *models.Book) *bookRollbackSnapshot {
+	if b == nil {
+		return nil
+	}
+	return &bookRollbackSnapshot{
+		ForeignID:        b.ForeignID,
+		AuthorID:         b.AuthorID,
+		Title:            b.Title,
+		SortTitle:        b.SortTitle,
+		ReleaseDate:      cloneTimePtr(b.ReleaseDate),
+		Language:         b.Language,
+		Status:           b.Status,
+		FilePath:         b.FilePath,
+		MetadataProvider: b.MetadataProvider,
+		CalibreID:        cloneInt64Ptr(b.CalibreID),
+		MediaType:        b.MediaType,
+		AnyEditionOK:     b.AnyEditionOK,
+		Monitored:        b.Monitored,
+	}
+}
+
+func editionSnapshot(e *models.Edition) *editionRollbackSnapshot {
+	if e == nil {
+		return nil
+	}
+	return &editionRollbackSnapshot{
+		ForeignID:   e.ForeignID,
+		BookID:      e.BookID,
+		Title:       e.Title,
+		ISBN13:      cloneStringPtr(e.ISBN13),
+		PublishDate: cloneTimePtr(e.PublishDate),
+		Format:      e.Format,
+		Language:    e.Language,
+		ImageURL:    e.ImageURL,
+		IsEbook:     e.IsEbook,
+		Monitored:   e.Monitored,
+	}
+}
+
+func bookSnapshotMetadata(data map[string]any, before, after *bookRollbackSnapshot) (runEntityMetadataEnvelope, error) {
+	beforePayload, err := marshalSnapshotPayload(before)
+	if err != nil {
+		return runEntityMetadataEnvelope{}, err
+	}
+	afterPayload, err := marshalSnapshotPayload(after)
+	if err != nil {
+		return runEntityMetadataEnvelope{}, err
+	}
+	return runEntityMetadataEnvelope{
+		Kind:    runEntityMetadataKind,
+		Version: runEntityMetadataVersion,
+		Data:    data,
+		Snapshot: &runEntitySnapshotEnvelope{
+			EntityType: entityTypeBook,
+			Before:     beforePayload,
+			After:      afterPayload,
+		},
+	}, nil
+}
+
+func editionSnapshotMetadata(data map[string]any, before, after *editionRollbackSnapshot) (runEntityMetadataEnvelope, error) {
+	beforePayload, err := marshalSnapshotPayload(before)
+	if err != nil {
+		return runEntityMetadataEnvelope{}, err
+	}
+	afterPayload, err := marshalSnapshotPayload(after)
+	if err != nil {
+		return runEntityMetadataEnvelope{}, err
+	}
+	return runEntityMetadataEnvelope{
+		Kind:    runEntityMetadataKind,
+		Version: runEntityMetadataVersion,
+		Data:    data,
+		Snapshot: &runEntitySnapshotEnvelope{
+			EntityType: entityTypeEdition,
+			Before:     beforePayload,
+			After:      afterPayload,
+		},
+	}, nil
+}
+
+func marshalSnapshotPayload(v any) (json.RawMessage, error) {
+	if v == nil {
+		return nil, nil
+	}
+	// Guard against typed-nil pointers: json.Marshal on a (*T)(nil) encodes
+	// "null", which is indistinguishable from an absent snapshot and would
+	// defeat before/after gating in the restorers.
+	switch t := v.(type) {
+	case *bookRollbackSnapshot:
+		if t == nil {
+			return nil, nil
+		}
+	case *authorRollbackSnapshot:
+		if t == nil {
+			return nil, nil
+		}
+	case *editionRollbackSnapshot:
+		if t == nil {
+			return nil, nil
+		}
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("encode calibre rollback snapshot: %w", err)
+	}
+	return data, nil
+}
+
+// recordBookBeforeSnapshot persists the pre-mutation book snapshot. Called
+// once per (runID, externalID) — snapshot-before-mutation is non-obvious:
+// if we waited until after applyBookFields, the "before" snapshot would be
+// the post-import state and rollback would be a no-op.
+func (i *Importer) recordBookBeforeSnapshot(ctx context.Context, runID int64, externalID string, b *models.Book, outcome string, data map[string]any) {
+	if runID == 0 || i.snapshots == nil || b == nil {
+		return
+	}
+	envelope, err := bookSnapshotMetadata(data, bookSnapshot(b), nil)
+	if err != nil {
+		slog.Warn("calibre import: encode book before snapshot", "runID", runID, "bookID", b.ID, "error", err)
+		return
+	}
+	i.recordSnapshot(ctx, runID, externalID, entityTypeBook, b.ID, outcome, envelope)
+}
+
+func (i *Importer) recordBookAfterSnapshot(ctx context.Context, runID int64, externalID string, bookID int64, outcome string, data map[string]any) {
+	if runID == 0 || i.snapshots == nil || bookID == 0 || i.books == nil {
+		return
+	}
+	b, err := i.books.GetByID(ctx, bookID)
+	if err != nil || b == nil {
+		return
+	}
+	envelope, err := bookSnapshotMetadata(data, nil, bookSnapshot(b))
+	if err != nil {
+		slog.Warn("calibre import: encode book after snapshot", "runID", runID, "bookID", bookID, "error", err)
+		return
+	}
+	i.recordSnapshot(ctx, runID, externalID, entityTypeBook, bookID, outcome, envelope)
+}
+
+func (i *Importer) recordEditionBeforeSnapshot(ctx context.Context, runID int64, externalID string, e *models.Edition, outcome string, data map[string]any) {
+	if runID == 0 || i.snapshots == nil || e == nil {
+		return
+	}
+	envelope, err := editionSnapshotMetadata(data, editionSnapshot(e), nil)
+	if err != nil {
+		slog.Warn("calibre import: encode edition before snapshot", "runID", runID, "editionID", e.ID, "error", err)
+		return
+	}
+	i.recordSnapshot(ctx, runID, externalID, entityTypeEdition, e.ID, outcome, envelope)
+}
+
+func (i *Importer) recordSnapshot(ctx context.Context, runID int64, externalID, entityType string, localID int64, outcome string, envelope runEntityMetadataEnvelope) {
+	if i.snapshots == nil {
+		return
+	}
+	payload, err := json.Marshal(envelope)
+	if err != nil {
+		slog.Warn("calibre import: encode snapshot envelope", "runID", runID, "entityType", entityType, "externalID", externalID, "error", err)
+		return
+	}
+	if err := i.snapshots.Record(ctx, &models.CalibreEntitySnapshot{
+		RunID:        runID,
+		SourceID:     defaultSourceID,
+		EntityType:   entityType,
+		ExternalID:   externalID,
+		LocalID:      localID,
+		Outcome:      outcome,
+		MetadataJSON: string(payload),
+	}); err != nil {
+		slog.Warn("calibre import: persist snapshot",
+			"runID", runID, "entityType", entityType, "externalID", externalID, "localID", localID, "error", err)
+	}
+}
+
+// upsertProvenance records (or refreshes) the calibre_provenance row for a
+// touched entity so rollback can verify the run is still the current owner.
+func (i *Importer) upsertProvenance(ctx context.Context, runID int64, entityType, externalID string, localID int64) {
+	if runID == 0 || i.provenance == nil || localID == 0 || externalID == "" {
+		return
+	}
+	rid := runID
+	if err := i.provenance.Upsert(ctx, &models.CalibreProvenance{
+		SourceID:    defaultSourceID,
+		EntityType:  entityType,
+		ExternalID:  externalID,
+		LocalID:     localID,
+		ImportRunID: &rid,
+	}); err != nil {
+		slog.Warn("calibre import: persist provenance",
+			"runID", runID, "entityType", entityType, "externalID", externalID, "localID", localID, "error", err)
+	}
+}
+
+func bookRollbackSnapshotFromMetadata(raw string) (*bookRollbackSnapshot, *bookRollbackSnapshot, bool) {
+	envelope, ok := parseRunEntityMetadata(raw)
+	if !ok || envelope.Snapshot == nil || envelope.Snapshot.EntityType != entityTypeBook {
+		return nil, nil, false
+	}
+	if len(envelope.Snapshot.Before) == 0 || len(envelope.Snapshot.After) == 0 {
+		return nil, nil, false
+	}
+	var before, after bookRollbackSnapshot
+	if err := json.Unmarshal(envelope.Snapshot.Before, &before); err != nil {
+		return nil, nil, false
+	}
+	if err := json.Unmarshal(envelope.Snapshot.After, &after); err != nil {
+		return nil, nil, false
+	}
+	return &before, &after, true
+}
+
+func authorRollbackSnapshotFromMetadata(raw string) (*authorRollbackSnapshot, *authorRollbackSnapshot, bool) {
+	envelope, ok := parseRunEntityMetadata(raw)
+	if !ok || envelope.Snapshot == nil || envelope.Snapshot.EntityType != entityTypeAuthor {
+		return nil, nil, false
+	}
+	if len(envelope.Snapshot.Before) == 0 || len(envelope.Snapshot.After) == 0 {
+		return nil, nil, false
+	}
+	var before, after authorRollbackSnapshot
+	if err := json.Unmarshal(envelope.Snapshot.Before, &before); err != nil {
+		return nil, nil, false
+	}
+	if err := json.Unmarshal(envelope.Snapshot.After, &after); err != nil {
+		return nil, nil, false
+	}
+	return &before, &after, true
+}
+
+func parseRunEntityMetadata(raw string) (runEntityMetadataEnvelope, bool) {
+	var envelope runEntityMetadataEnvelope
+	if strings.TrimSpace(raw) == "" {
+		return envelope, false
+	}
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		return envelope, false
+	}
+	if envelope.Kind != runEntityMetadataKind || envelope.Version != runEntityMetadataVersion {
+		return envelope, false
+	}
+	if envelope.Data == nil {
+		envelope.Data = map[string]any{}
+	}
+	return envelope, true
+}
+
+func cloneInt64Ptr(v *int64) *int64 {
+	if v == nil {
+		return nil
+	}
+	out := *v
+	return &out
+}
+
+func cloneStringPtr(v *string) *string {
+	if v == nil {
+		return nil
+	}
+	out := *v
+	return &out
+}
+
+func cloneTimePtr(v *time.Time) *time.Time {
+	if v == nil {
+		return nil
+	}
+	out := *v
+	return &out
+}

--- a/internal/calibre/import_types.go
+++ b/internal/calibre/import_types.go
@@ -1,0 +1,21 @@
+package calibre
+
+// Constants for the Calibre run-tracking + rollback layer. Kept in a small
+// dedicated file (rather than importer.go) so the rollback code can depend
+// on them without dragging in the rest of the importer package surface.
+
+const (
+	defaultSourceID          = "default"
+	runEntityMetadataKind    = "calibre_run_entity_metadata"
+	runEntityMetadataVersion = 1
+	entityTypeAuthor         = "author"
+	entityTypeBook           = "book"
+	entityTypeEdition        = "edition"
+	runStatusRunning         = "running"
+	runStatusCompleted       = "completed"
+	runStatusFailed          = "failed"
+	runStatusRolledBack      = "rolled_back"
+	outcomeCreated           = "created"
+	outcomeUpdated           = "updated"
+	outcomeLinked            = "linked"
+)

--- a/internal/calibre/importer.go
+++ b/internal/calibre/importer.go
@@ -53,6 +53,13 @@ type Importer struct {
 	editions *db.EditionRepo
 	settings *db.SettingsRepo
 
+	// Run-tracking + rollback (issue #643). Optional — when any of these is
+	// nil the importer behaves as before with no run record and no
+	// snapshots, so test wiring that only needs the import path still works.
+	runs       *db.CalibreImportRunRepo
+	snapshots  *db.CalibreEntitySnapshotRepo
+	provenance *db.CalibreProvenanceRepo
+
 	openReader func(libraryPath string) (readerIface, error)
 
 	mu       sync.Mutex
@@ -91,6 +98,16 @@ func NewImporter(
 			return r, nil
 		},
 	}
+}
+
+// WithRunTracking attaches the run/provenance/snapshot repos required for
+// rollback (#643). Optional — without it the importer records nothing and
+// rollback APIs return ErrRollbackUnavailable.
+func (i *Importer) WithRunTracking(runs *db.CalibreImportRunRepo, snapshots *db.CalibreEntitySnapshotRepo, provenance *db.CalibreProvenanceRepo) *Importer {
+	i.runs = runs
+	i.snapshots = snapshots
+	i.provenance = provenance
+	return i
 }
 
 // Progress returns a snapshot of the current (or most recent) import.
@@ -165,6 +182,26 @@ func (i *Importer) Run(ctx context.Context, libraryPath string) (*ImportStats, e
 
 func (i *Importer) run(ctx context.Context, libraryPath string) *ImportStats {
 	stats := &ImportStats{}
+	var runID int64
+	// Run record: only created on a real (non-dry-run) import. A dry run
+	// today doesn't exist at the API surface, but the run field is here so
+	// adding one later is a one-line change.
+	if i.runs != nil {
+		run := &models.CalibreImportRun{
+			SourceID:         defaultSourceID,
+			LibraryPath:      libraryPath,
+			Status:           runStatusRunning,
+			DryRun:           false,
+			SourceConfigJSON: encodeSourceConfig(libraryPath),
+			SummaryJSON:      "{}",
+		}
+		if err := i.runs.Create(ctx, run); err != nil {
+			slog.Warn("calibre import: create run record failed", "error", err)
+		} else {
+			runID = run.ID
+		}
+	}
+	failed := false
 	defer func() {
 		now := time.Now().UTC()
 		i.mu.Lock()
@@ -173,10 +210,22 @@ func (i *Importer) run(ctx context.Context, libraryPath string) *ImportStats {
 		i.progress.Stats = stats
 		i.running = false
 		i.mu.Unlock()
+		if runID != 0 && i.runs != nil {
+			status := runStatusCompleted
+			if failed {
+				status = runStatusFailed
+			}
+			// Use Background so we still close out the run even if the
+			// calling ctx was cancelled mid-import.
+			if err := i.runs.Finish(context.Background(), runID, status, stats); err != nil {
+				slog.Warn("calibre import: finish run record failed", "runID", runID, "error", err)
+			}
+		}
 	}()
 
 	reader, err := i.openReader(libraryPath)
 	if err != nil {
+		failed = true
 		i.fail(err)
 		return stats
 	}
@@ -188,6 +237,7 @@ func (i *Importer) run(ctx context.Context, libraryPath string) *ImportStats {
 
 	total, err := reader.Count(ctx)
 	if err != nil {
+		failed = true
 		i.fail(err)
 		return stats
 	}
@@ -200,11 +250,12 @@ func (i *Importer) run(ctx context.Context, libraryPath string) *ImportStats {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		i.importOne(ctx, cb, stats)
+		i.importOne(ctx, runID, cb, stats)
 		i.setProgress(func(p *ImportProgress) { p.Processed++ })
 		return nil
 	})
 	if err != nil {
+		failed = true
 		i.fail(err)
 		return stats
 	}
@@ -213,6 +264,7 @@ func (i *Importer) run(ctx context.Context, libraryPath string) *ImportStats {
 		slog.Warn("calibre import: persist last_import_at failed", "error", err)
 	}
 	slog.Info("calibre import complete",
+		"runID", runID,
 		"authorsAdded", stats.AuthorsAdded, "authorsLinked", stats.AuthorsLinked,
 		"booksAdded", stats.BooksAdded, "booksUpdated", stats.BooksUpdated,
 		"editionsAdded", stats.EditionsAdded, "duplicatesMerged", stats.DuplicatesMerged,
@@ -227,14 +279,14 @@ func (i *Importer) run(ctx context.Context, libraryPath string) *ImportStats {
 // create or update the Bindery book row, then upsert one edition per
 // format. Errors on any step are logged + counted as skipped so one bad
 // record doesn't abort the whole library.
-func (i *Importer) importOne(ctx context.Context, cb CalibreBook, stats *ImportStats) {
+func (i *Importer) importOne(ctx context.Context, runID int64, cb CalibreBook, stats *ImportStats) {
 	if len(cb.Authors) == 0 {
 		slog.Warn("calibre import: book has no authors", "calibre_id", cb.CalibreID, "title", cb.Title)
 		stats.Skipped++
 		return
 	}
 
-	author, created, err := i.resolveAuthor(ctx, cb.Authors[0])
+	author, created, err := i.resolveAuthor(ctx, runID, cb.Authors[0])
 	if err != nil {
 		slog.Warn("calibre import: author resolve failed", "calibre_id", cb.CalibreID, "error", err)
 		stats.Skipped++
@@ -247,7 +299,7 @@ func (i *Importer) importOne(ctx context.Context, cb CalibreBook, stats *ImportS
 	}
 	i.recordSecondaryAuthors(ctx, author.ID, cb.Authors[1:], stats)
 
-	book, newBook, err := i.upsertBook(ctx, author, cb)
+	book, newBook, err := i.upsertBook(ctx, runID, author, cb)
 	if err != nil {
 		slog.Warn("calibre import: book upsert failed", "calibre_id", cb.CalibreID, "error", err)
 		stats.Skipped++
@@ -266,9 +318,28 @@ func (i *Importer) importOne(ctx context.Context, cb CalibreBook, stats *ImportS
 			stats.DuplicatesMerged++
 		}
 	}
+	// Record provenance + after-snapshot for the book regardless of new/old
+	// outcome. The before-snapshot was captured inside upsertBook on the
+	// path that mutates an existing row.
+	bookExternalID := calibreBookExternalID(cb.CalibreID)
+	bookOutcome := outcomeUpdated
+	if newBook {
+		bookOutcome = outcomeCreated
+	} else if book.mergedByTitle {
+		bookOutcome = outcomeLinked
+	}
+	i.upsertProvenance(ctx, runID, entityTypeBook, bookExternalID, book.row.ID)
+	if !newBook {
+		i.recordBookAfterSnapshot(ctx, runID, bookExternalID, book.row.ID, bookOutcome, map[string]any{"matchedBy": book.matchedBy})
+	} else {
+		// For freshly-created books no before-snapshot exists; record an
+		// empty-payload snapshot so the rollback list sees the entity and
+		// knows to delete it.
+		i.recordCreateSnapshot(ctx, runID, entityTypeBook, bookExternalID, book.row.ID)
+	}
 
 	for _, f := range cb.Formats {
-		added, err := i.upsertEdition(ctx, book.row, cb, f)
+		added, edition, err := i.upsertEdition(ctx, runID, book.row, cb, f)
 		if err != nil {
 			slog.Warn("calibre import: edition upsert failed",
 				"calibre_id", cb.CalibreID, "format", f.Format, "error", err)
@@ -277,7 +348,50 @@ func (i *Importer) importOne(ctx context.Context, cb CalibreBook, stats *ImportS
 		if added {
 			stats.EditionsAdded++
 		}
+		if edition != nil {
+			editionExternalID := calibreEditionExternalID(cb.CalibreID, f.Format)
+			i.upsertProvenance(ctx, runID, entityTypeEdition, editionExternalID, edition.ID)
+			if added {
+				i.recordCreateSnapshot(ctx, runID, entityTypeEdition, editionExternalID, edition.ID)
+			}
+		}
 	}
+}
+
+// recordCreateSnapshot records a marker row for an entity that was newly
+// created during this run. Rollback treats outcome=="created" as a hard
+// delete signal regardless of whether a before-snapshot exists.
+func (i *Importer) recordCreateSnapshot(ctx context.Context, runID int64, entityType, externalID string, localID int64) {
+	if runID == 0 || i.snapshots == nil {
+		return
+	}
+	// A minimal envelope: no before/after payload, just kind+version so the
+	// rollback decoder doesn't choke. The "created" outcome is what
+	// rollback keys off; snapshot payload is irrelevant for delete cases.
+	envelope := runEntityMetadataEnvelope{
+		Kind:    runEntityMetadataKind,
+		Version: runEntityMetadataVersion,
+	}
+	i.recordSnapshot(ctx, runID, externalID, entityType, localID, outcomeCreated, envelope)
+}
+
+func calibreBookExternalID(calibreID int64) string {
+	return fmt.Sprintf("book:%d", calibreID)
+}
+
+func calibreAuthorExternalID(calibreID int64) string {
+	return fmt.Sprintf("author:%d", calibreID)
+}
+
+func calibreEditionExternalID(calibreID int64, format string) string {
+	return fmt.Sprintf("edition:%d:%s", calibreID, strings.ToUpper(format))
+}
+
+func encodeSourceConfig(libraryPath string) string {
+	// Tiny payload; written via fmt.Sprintf rather than json.Marshal to
+	// avoid pulling in encoding/json for one field. Path itself is escaped
+	// via %q.
+	return fmt.Sprintf(`{"libraryPath":%q}`, libraryPath)
 }
 
 // resolveAuthor returns the canonical Bindery author for the given Calibre
@@ -289,15 +403,18 @@ func (i *Importer) importOne(ctx context.Context, cb CalibreBook, stats *ImportS
 // `created` is true only for case 3. Calibre's author names are already
 // one-per-row in its metadata.db, so we trust them verbatim rather than
 // re-splitting on commas/separators.
-func (i *Importer) resolveAuthor(ctx context.Context, ca CalibreAuthor) (*models.Author, bool, error) {
+func (i *Importer) resolveAuthor(ctx context.Context, runID int64, ca CalibreAuthor) (*models.Author, bool, error) {
 	name := strings.TrimSpace(ca.Name)
 	if name == "" {
 		return nil, false, errors.New("empty author name")
 	}
 
+	externalID := calibreAuthorExternalID(ca.CalibreID)
+
 	if existing, err := i.findAuthorByName(ctx, name); err != nil {
 		return nil, false, err
 	} else if existing != nil {
+		i.upsertProvenance(ctx, runID, entityTypeAuthor, externalID, existing.ID)
 		return existing, false, nil
 	}
 
@@ -309,6 +426,7 @@ func (i *Importer) resolveAuthor(ctx context.Context, ca CalibreAuthor) (*models
 			return nil, false, err
 		}
 		if existing != nil {
+			i.upsertProvenance(ctx, runID, entityTypeAuthor, externalID, existing.ID)
 			return existing, false, nil
 		}
 	}
@@ -323,6 +441,10 @@ func (i *Importer) resolveAuthor(ctx context.Context, ca CalibreAuthor) (*models
 	if err := i.authors.Create(ctx, author); err != nil {
 		return nil, false, err
 	}
+	// Provenance + creation marker so rollback can delete this author back
+	// out. No before-snapshot — author did not exist prior to this run.
+	i.upsertProvenance(ctx, runID, entityTypeAuthor, externalID, author.ID)
+	i.recordCreateSnapshot(ctx, runID, entityTypeAuthor, externalID, author.ID)
 	return author, true, nil
 }
 
@@ -367,9 +489,12 @@ func (i *Importer) recordSecondaryAuthors(ctx context.Context, canonicalID int64
 
 // bookUpsertResult carries whether a book row was newly created and
 // whether it was discovered via title-match (as opposed to calibre_id).
+// matchedBy is breadcrumbed into the snapshot envelope so rollback previews
+// can report how the original match happened.
 type bookUpsertResult struct {
 	row           *models.Book
 	mergedByTitle bool
+	matchedBy     string
 }
 
 // upsertBook ensures a Bindery books row exists for the given Calibre
@@ -382,17 +507,23 @@ type bookUpsertResult struct {
 //  4. Create a fresh row with the Calibre id set.
 //
 // Returns (result, created). result.mergedByTitle is true only for path 3.
-func (i *Importer) upsertBook(ctx context.Context, author *models.Author, cb CalibreBook) (*bookUpsertResult, bool, error) {
+func (i *Importer) upsertBook(ctx context.Context, runID int64, author *models.Author, cb CalibreBook) (*bookUpsertResult, bool, error) {
+	externalID := calibreBookExternalID(cb.CalibreID)
+
 	// Path 1 — exact calibre_id match.
 	existing, err := i.books.GetByCalibreID(ctx, cb.CalibreID)
 	if err != nil {
 		return nil, false, err
 	}
 	if existing != nil {
+		// Snapshot-before-mutation: must run before applyBookFields, not
+		// after, or rollback gets the post-import state as the "before" and
+		// becomes a no-op.
+		i.recordBookBeforeSnapshot(ctx, runID, externalID, existing, outcomeUpdated, map[string]any{"matchedBy": "calibre_id"})
 		if err := i.applyBookFields(ctx, existing, cb); err != nil {
 			return nil, false, err
 		}
-		return &bookUpsertResult{row: existing}, false, nil
+		return &bookUpsertResult{row: existing, matchedBy: "calibre_id"}, false, nil
 	}
 
 	// Path 2 — foreign_id match: book was created in a previous run but
@@ -401,6 +532,7 @@ func (i *Importer) upsertBook(ctx context.Context, author *models.Author, cb Cal
 	if existing, err := i.books.GetByForeignID(ctx, fid); err != nil {
 		return nil, false, err
 	} else if existing != nil {
+		i.recordBookBeforeSnapshot(ctx, runID, externalID, existing, outcomeUpdated, map[string]any{"matchedBy": "foreign_id"})
 		if existing.CalibreID == nil {
 			if err := i.books.SetCalibreID(ctx, existing.ID, cb.CalibreID); err != nil {
 				return nil, false, err
@@ -411,13 +543,14 @@ func (i *Importer) upsertBook(ctx context.Context, author *models.Author, cb Cal
 		if err := i.applyBookFields(ctx, existing, cb); err != nil {
 			return nil, false, err
 		}
-		return &bookUpsertResult{row: existing}, false, nil
+		return &bookUpsertResult{row: existing, matchedBy: "foreign_id"}, false, nil
 	}
 
 	// Path 3 — same author + title.
 	if existing, err := i.books.FindByAuthorAndTitle(ctx, author.ID, cb.Title); err != nil {
 		return nil, false, err
 	} else if existing != nil {
+		i.recordBookBeforeSnapshot(ctx, runID, externalID, existing, outcomeLinked, map[string]any{"matchedBy": "title"})
 		if err := i.books.SetCalibreID(ctx, existing.ID, cb.CalibreID); err != nil {
 			return nil, false, err
 		}
@@ -426,7 +559,7 @@ func (i *Importer) upsertBook(ctx context.Context, author *models.Author, cb Cal
 		if err := i.applyBookFields(ctx, existing, cb); err != nil {
 			return nil, false, err
 		}
-		return &bookUpsertResult{row: existing, mergedByTitle: true}, false, nil
+		return &bookUpsertResult{row: existing, mergedByTitle: true, matchedBy: "title"}, false, nil
 	}
 
 	// Path 4 — create fresh.
@@ -452,7 +585,7 @@ func (i *Importer) upsertBook(ctx context.Context, author *models.Author, cb Cal
 	if err := i.books.SetCalibreID(ctx, book.ID, cb.CalibreID); err != nil {
 		return nil, false, err
 	}
-	return &bookUpsertResult{row: book}, true, nil
+	return &bookUpsertResult{row: book, matchedBy: "created"}, true, nil
 }
 
 // applyBookFields updates a pre-existing book row with fresh data from
@@ -480,16 +613,24 @@ func (i *Importer) applyBookFields(ctx context.Context, book *models.Book, cb Ca
 }
 
 // upsertEdition upserts one Bindery edition for a single Calibre format.
-// Returns (added, err) where added is true only when a brand-new row was
-// created.
-func (i *Importer) upsertEdition(ctx context.Context, book *models.Book, cb CalibreBook, f CalibreFormat) (bool, error) {
+// Returns (added, edition, err) where added is true only when a brand-new
+// row was created; the returned edition is the resulting row so caller can
+// snapshot it.
+func (i *Importer) upsertEdition(ctx context.Context, runID int64, book *models.Book, cb CalibreBook, f CalibreFormat) (bool, *models.Edition, error) {
 	if f.Format == "" {
-		return false, nil
+		return false, nil, nil
 	}
 	foreignID := fmt.Sprintf("calibre:edition:%d:%s", cb.CalibreID, strings.ToUpper(f.Format))
 	prior, err := i.editions.GetByForeignID(ctx, foreignID)
 	if err != nil {
-		return false, err
+		return false, nil, err
+	}
+	if prior != nil {
+		// Before-snapshot for an updated edition: rollback will skip these
+		// (no field-level edition restore today) but we still want a row in
+		// snapshots so list-by-run reports the touch.
+		externalID := calibreEditionExternalID(cb.CalibreID, f.Format)
+		i.recordEditionBeforeSnapshot(ctx, runID, externalID, prior, outcomeUpdated, nil)
 	}
 
 	isbn13 := ptrStringIfNonEmpty(cb.ISBN)
@@ -511,9 +652,14 @@ func (i *Importer) upsertEdition(ctx context.Context, book *models.Book, cb Cali
 		Monitored:   true,
 	}
 	if err := i.editions.Upsert(ctx, e); err != nil {
-		return false, err
+		return false, nil, err
 	}
-	return prior == nil, nil
+	// Re-fetch to get the assigned ID (Upsert may have created or updated).
+	stored, lookupErr := i.editions.GetByForeignID(ctx, foreignID)
+	if lookupErr != nil {
+		return prior == nil, nil, lookupErr
+	}
+	return prior == nil, stored, nil
 }
 
 // RunSync implements scheduler.CalibreSyncer. It reads the library path from

--- a/internal/db/calibre_imports.go
+++ b/internal/db/calibre_imports.go
@@ -1,0 +1,416 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// CalibreImportRunRepo manages the calibre_import_runs table. Mirrors
+// ABSImportRunRepo line-for-line modulo the dropped checkpoint column
+// (Calibre imports have no mid-run resumable state).
+type CalibreImportRunRepo struct {
+	db *sql.DB
+}
+
+func NewCalibreImportRunRepo(db *sql.DB) *CalibreImportRunRepo {
+	return &CalibreImportRunRepo{db: db}
+}
+
+func (r *CalibreImportRunRepo) Create(ctx context.Context, run *models.CalibreImportRun) error {
+	now := time.Now().UTC()
+	if run.SourceID == "" {
+		run.SourceID = "default"
+	}
+	sourceConfigJSON := run.SourceConfigJSON
+	if sourceConfigJSON == "" {
+		sourceConfigJSON = "{}"
+	}
+	summaryJSON := run.SummaryJSON
+	if summaryJSON == "" {
+		summaryJSON = "{}"
+	}
+	result, err := r.db.ExecContext(ctx, `
+		INSERT INTO calibre_import_runs (source_id, library_path, status, dry_run, source_config_json, summary_json, started_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		run.SourceID, run.LibraryPath, run.Status, boolToInt(run.DryRun), sourceConfigJSON, summaryJSON, now)
+	if err != nil {
+		return fmt.Errorf("create calibre import run: %w", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("calibre import run last insert id: %w", err)
+	}
+	run.ID = id
+	run.StartedAt = now
+	run.SourceConfigJSON = sourceConfigJSON
+	run.SummaryJSON = summaryJSON
+	return nil
+}
+
+func (r *CalibreImportRunRepo) Finish(ctx context.Context, id int64, status string, summary any) error {
+	if id == 0 {
+		return nil
+	}
+	now := time.Now().UTC()
+	payload := "{}"
+	if summary != nil {
+		data, err := json.Marshal(summary)
+		if err != nil {
+			return fmt.Errorf("encode calibre import summary: %w", err)
+		}
+		payload = string(data)
+	}
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE calibre_import_runs
+		SET status = ?, summary_json = ?, finished_at = ?
+		WHERE id = ?`,
+		status, payload, now, id)
+	if err != nil {
+		return fmt.Errorf("finish calibre import run %d: %w", id, err)
+	}
+	return nil
+}
+
+func (r *CalibreImportRunRepo) UpdateStatus(ctx context.Context, id int64, status string) error {
+	if id == 0 {
+		return nil
+	}
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE calibre_import_runs
+		SET status = ?
+		WHERE id = ?`,
+		status, id)
+	if err != nil {
+		return fmt.Errorf("update calibre import run status %d: %w", id, err)
+	}
+	return nil
+}
+
+func (r *CalibreImportRunRepo) GetByID(ctx context.Context, id int64) (*models.CalibreImportRun, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, source_id, library_path, status, dry_run, source_config_json, summary_json, started_at, finished_at
+		FROM calibre_import_runs
+		WHERE id = ?`, id)
+	var run models.CalibreImportRun
+	var dryRun int
+	if err := row.Scan(&run.ID, &run.SourceID, &run.LibraryPath, &run.Status, &dryRun, &run.SourceConfigJSON, &run.SummaryJSON, &run.StartedAt, &run.FinishedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get calibre import run %d: %w", id, err)
+	}
+	run.DryRun = dryRun == 1
+	return &run, nil
+}
+
+func (r *CalibreImportRunRepo) ListRecent(ctx context.Context, limit int) ([]models.CalibreImportRun, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, source_id, library_path, status, dry_run, source_config_json, summary_json, started_at, finished_at
+		FROM calibre_import_runs
+		ORDER BY started_at DESC, id DESC
+		LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list recent calibre import runs: %w", err)
+	}
+	defer rows.Close()
+
+	var out []models.CalibreImportRun
+	for rows.Next() {
+		var run models.CalibreImportRun
+		var dryRun int
+		if err := rows.Scan(&run.ID, &run.SourceID, &run.LibraryPath, &run.Status, &dryRun, &run.SourceConfigJSON, &run.SummaryJSON, &run.StartedAt, &run.FinishedAt); err != nil {
+			return nil, fmt.Errorf("scan calibre import run: %w", err)
+		}
+		run.DryRun = dryRun == 1
+		out = append(out, run)
+	}
+	return out, rows.Err()
+}
+
+// CalibreProvenanceRepo manages the calibre_provenance table — the
+// (entity_type, external_id) → local_id mapping rollback uses to prove a
+// run still owns the row it's about to delete.
+type CalibreProvenanceRepo struct {
+	db *sql.DB
+}
+
+func NewCalibreProvenanceRepo(db *sql.DB) *CalibreProvenanceRepo {
+	return &CalibreProvenanceRepo{db: db}
+}
+
+func (r *CalibreProvenanceRepo) GetByExternal(ctx context.Context, sourceID, entityType, externalID string) (*models.CalibreProvenance, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, source_id, entity_type, external_id, local_id, import_run_id, created_at, updated_at
+		FROM calibre_provenance
+		WHERE source_id = ? AND entity_type = ? AND external_id = ?`,
+		sourceID, entityType, externalID)
+	return scanCalibreProvenance(row, "get calibre provenance")
+}
+
+func (r *CalibreProvenanceRepo) ListByLocal(ctx context.Context, entityType string, localID int64) ([]models.CalibreProvenance, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, source_id, entity_type, external_id, local_id, import_run_id, created_at, updated_at
+		FROM calibre_provenance
+		WHERE entity_type = ? AND local_id = ?
+		ORDER BY id`, entityType, localID)
+	if err != nil {
+		return nil, fmt.Errorf("list calibre provenance for %s %d: %w", entityType, localID, err)
+	}
+	defer rows.Close()
+
+	var out []models.CalibreProvenance
+	for rows.Next() {
+		item, err := scanCalibreProvenanceRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+func (r *CalibreProvenanceRepo) Upsert(ctx context.Context, p *models.CalibreProvenance) error {
+	now := time.Now().UTC()
+	if p.SourceID == "" {
+		p.SourceID = "default"
+	}
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO calibre_provenance (source_id, entity_type, external_id, local_id, import_run_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(source_id, entity_type, external_id) DO UPDATE SET
+			local_id      = excluded.local_id,
+			import_run_id = excluded.import_run_id,
+			updated_at    = excluded.updated_at`,
+		p.SourceID, p.EntityType, p.ExternalID, p.LocalID, p.ImportRunID, now, now)
+	if err != nil {
+		return fmt.Errorf("upsert calibre provenance %s/%s: %w", p.EntityType, p.ExternalID, err)
+	}
+	row := r.db.QueryRowContext(ctx, `
+		SELECT id, created_at, updated_at
+		FROM calibre_provenance
+		WHERE source_id = ? AND entity_type = ? AND external_id = ?`,
+		p.SourceID, p.EntityType, p.ExternalID)
+	if err := row.Scan(&p.ID, &p.CreatedAt, &p.UpdatedAt); err != nil {
+		return fmt.Errorf("reload calibre provenance %s/%s: %w", p.EntityType, p.ExternalID, err)
+	}
+	return nil
+}
+
+func (r *CalibreProvenanceRepo) DeleteByExternal(ctx context.Context, sourceID, entityType, externalID string) error {
+	_, err := r.db.ExecContext(ctx, `
+		DELETE FROM calibre_provenance
+		WHERE source_id = ? AND entity_type = ? AND external_id = ?`,
+		sourceID, entityType, externalID)
+	if err != nil {
+		return fmt.Errorf("delete calibre provenance %s/%s: %w", entityType, externalID, err)
+	}
+	return nil
+}
+
+func (r *CalibreProvenanceRepo) DeleteByLocal(ctx context.Context, entityType string, localID int64) (int64, error) {
+	if localID == 0 {
+		return 0, nil
+	}
+	result, err := r.db.ExecContext(ctx, `
+		DELETE FROM calibre_provenance
+		WHERE entity_type = ? AND local_id = ?`,
+		entityType, localID)
+	if err != nil {
+		return 0, fmt.Errorf("delete calibre provenance for %s %d: %w", entityType, localID, err)
+	}
+	count, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count deleted calibre provenance for %s %d: %w", entityType, localID, err)
+	}
+	return count, nil
+}
+
+// CalibreEntitySnapshotRepo manages calibre_entity_snapshots. Each row holds
+// one before/after snapshot of a single (book/author/edition) the importer
+// mutated during a run. Rollback reads these in reverse to restore state.
+type CalibreEntitySnapshotRepo struct {
+	db *sql.DB
+}
+
+func NewCalibreEntitySnapshotRepo(db *sql.DB) *CalibreEntitySnapshotRepo {
+	return &CalibreEntitySnapshotRepo{db: db}
+}
+
+func (r *CalibreEntitySnapshotRepo) Record(ctx context.Context, entity *models.CalibreEntitySnapshot) error {
+	if entity == nil || entity.RunID == 0 {
+		return nil
+	}
+	sourceID := entity.SourceID
+	if sourceID == "" {
+		sourceID = "default"
+	}
+	metadataJSON := entity.MetadataJSON
+	if metadataJSON == "" {
+		metadataJSON = "{}"
+	}
+	// Snapshot-before-mutation must win: on conflict we keep the first
+	// "before" we ever saw for this entity in this run but always overwrite
+	// "after" (and outcome) with the latest. Without this, a second
+	// applyBookFields() call inside the same run would clobber the original
+	// pre-import state and break rollback.
+	var existingMetadata string
+	var existingOutcome string
+	if err := r.db.QueryRowContext(ctx, `
+		SELECT metadata_json, outcome
+		FROM calibre_entity_snapshots
+		WHERE run_id = ? AND entity_type = ? AND external_id = ? AND local_id = ?`,
+		entity.RunID, entity.EntityType, entity.ExternalID, entity.LocalID).Scan(&existingMetadata, &existingOutcome); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("inspect calibre snapshot %d/%s/%s: %w", entity.RunID, entity.EntityType, entity.ExternalID, err)
+	}
+	outcome := mergeCalibreSnapshotOutcome(existingOutcome, entity.Outcome)
+	mergedJSON := mergeCalibreSnapshotMetadata(existingMetadata, metadataJSON)
+
+	result, err := r.db.ExecContext(ctx, `
+		INSERT INTO calibre_entity_snapshots (run_id, source_id, entity_type, external_id, local_id, outcome, metadata_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(run_id, entity_type, external_id, local_id) DO UPDATE SET
+			outcome       = excluded.outcome,
+			metadata_json = excluded.metadata_json`,
+		entity.RunID, sourceID, entity.EntityType, entity.ExternalID, entity.LocalID, outcome, mergedJSON)
+	if err != nil {
+		return fmt.Errorf("record calibre snapshot %d/%s/%s: %w", entity.RunID, entity.EntityType, entity.ExternalID, err)
+	}
+	if entity.ID == 0 {
+		if id, err := result.LastInsertId(); err == nil && id > 0 {
+			entity.ID = id
+		}
+	}
+	entity.SourceID = sourceID
+	entity.Outcome = outcome
+	entity.MetadataJSON = mergedJSON
+	return nil
+}
+
+func (r *CalibreEntitySnapshotRepo) ListByRun(ctx context.Context, runID int64) ([]models.CalibreEntitySnapshot, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, run_id, source_id, entity_type, external_id, local_id, outcome, metadata_json, created_at
+		FROM calibre_entity_snapshots
+		WHERE run_id = ?
+		ORDER BY id`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("list calibre snapshots %d: %w", runID, err)
+	}
+	defer rows.Close()
+
+	var out []models.CalibreEntitySnapshot
+	for rows.Next() {
+		var entity models.CalibreEntitySnapshot
+		if err := rows.Scan(&entity.ID, &entity.RunID, &entity.SourceID, &entity.EntityType, &entity.ExternalID, &entity.LocalID, &entity.Outcome, &entity.MetadataJSON, &entity.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan calibre snapshot: %w", err)
+		}
+		out = append(out, entity)
+	}
+	return out, rows.Err()
+}
+
+func mergeCalibreSnapshotOutcome(existing, incoming string) string {
+	if existing == "" {
+		return incoming
+	}
+	if incoming == "" {
+		return existing
+	}
+	// Once an entity is recorded as "created" within a run, no later
+	// "updated" should overwrite that — the rollback path uses outcome to
+	// decide between delete-row and restore-fields, and a created row must
+	// always be deleted on rollback.
+	if existing == "created" || incoming == "created" {
+		return "created"
+	}
+	return incoming
+}
+
+// mergeCalibreSnapshotMetadata merges two run_entity_metadata envelopes,
+// keeping the earliest "before" snapshot (snapshot-before-mutation) and
+// overwriting the "after" snapshot + Data with the latest. Anything not
+// matching the envelope shape falls back to a JSON-object merge.
+func mergeCalibreSnapshotMetadata(existingJSON, incomingJSON string) string {
+	existing := decodeJSONMap(existingJSON)
+	incoming := decodeJSONMap(incomingJSON)
+	if len(existing) == 0 {
+		if len(incoming) == 0 {
+			return "{}"
+		}
+		return encodeJSONMap(incoming)
+	}
+	if len(incoming) == 0 {
+		return encodeJSONMap(existing)
+	}
+	merged := make(map[string]any, len(existing)+len(incoming))
+	for k, v := range existing {
+		merged[k] = v
+	}
+	for k, v := range incoming {
+		switch k {
+		case "data":
+			merged[k] = mergeJSONObjects(asJSONMap(merged[k]), asJSONMap(v))
+		case "snapshot":
+			merged[k] = mergeCalibreSnapshotPart(asJSONMap(merged[k]), asJSONMap(v))
+		default:
+			merged[k] = v
+		}
+	}
+	return encodeJSONMap(merged)
+}
+
+func mergeCalibreSnapshotPart(existing, incoming map[string]any) map[string]any {
+	if len(existing) == 0 {
+		return incoming
+	}
+	if len(incoming) == 0 {
+		return existing
+	}
+	merged := make(map[string]any, len(existing)+len(incoming))
+	for k, v := range existing {
+		merged[k] = v
+	}
+	for k, v := range incoming {
+		if k == "before" {
+			if _, ok := merged[k]; ok {
+				continue
+			}
+		}
+		merged[k] = v
+	}
+	return merged
+}
+
+type calibreProvenanceScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanCalibreProvenance(scanner calibreProvenanceScanner, context string) (*models.CalibreProvenance, error) {
+	var item models.CalibreProvenance
+	if err := scanner.Scan(&item.ID, &item.SourceID, &item.EntityType, &item.ExternalID, &item.LocalID, &item.ImportRunID, &item.CreatedAt, &item.UpdatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%s: %w", context, err)
+	}
+	return &item, nil
+}
+
+func scanCalibreProvenanceRows(rows *sql.Rows) (models.CalibreProvenance, error) {
+	item, err := scanCalibreProvenance(rows, "scan calibre provenance")
+	if err != nil {
+		return models.CalibreProvenance{}, err
+	}
+	if item == nil {
+		return models.CalibreProvenance{}, sql.ErrNoRows
+	}
+	return *item, nil
+}

--- a/internal/db/calibre_imports_test.go
+++ b/internal/db/calibre_imports_test.go
@@ -1,0 +1,265 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestCalibreImportRunRepo_CreateFinishGet(t *testing.T) {
+	t.Parallel()
+
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	repo := NewCalibreImportRunRepo(database)
+	run := &models.CalibreImportRun{
+		LibraryPath: "/lib",
+		Status:      "running",
+	}
+	if err := repo.Create(context.Background(), run); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if run.ID == 0 {
+		t.Fatal("Create did not assign id")
+	}
+	if run.SourceID != "default" {
+		t.Errorf("SourceID = %q, want default", run.SourceID)
+	}
+
+	if err := repo.Finish(context.Background(), run.ID, "completed", map[string]any{"booksAdded": 5}); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	stored, err := repo.GetByID(context.Background(), run.ID)
+	if err != nil || stored == nil {
+		t.Fatalf("GetByID: %v / %v", err, stored)
+	}
+	if stored.Status != "completed" {
+		t.Errorf("status = %q, want completed", stored.Status)
+	}
+	if stored.FinishedAt == nil {
+		t.Error("FinishedAt nil after Finish")
+	}
+	if stored.SummaryJSON == "" || stored.SummaryJSON == "{}" {
+		t.Errorf("summary_json = %q, want non-empty", stored.SummaryJSON)
+	}
+}
+
+func TestCalibreImportRunRepo_UpdateStatus(t *testing.T) {
+	t.Parallel()
+
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	repo := NewCalibreImportRunRepo(database)
+	run := &models.CalibreImportRun{LibraryPath: "/lib", Status: "running"}
+	if err := repo.Create(context.Background(), run); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := repo.UpdateStatus(context.Background(), run.ID, "rolled_back"); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+	stored, _ := repo.GetByID(context.Background(), run.ID)
+	if stored == nil || stored.Status != "rolled_back" {
+		t.Errorf("status = %+v, want rolled_back", stored)
+	}
+}
+
+func TestCalibreImportRunRepo_ListRecent_OrderedDesc(t *testing.T) {
+	t.Parallel()
+
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	repo := NewCalibreImportRunRepo(database)
+	for i := 0; i < 3; i++ {
+		if err := repo.Create(context.Background(), &models.CalibreImportRun{
+			LibraryPath: "/lib",
+			Status:      "running",
+		}); err != nil {
+			t.Fatalf("Create %d: %v", i, err)
+		}
+	}
+	runs, err := repo.ListRecent(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("ListRecent: %v", err)
+	}
+	if len(runs) != 3 {
+		t.Fatalf("len(runs) = %d, want 3", len(runs))
+	}
+	if runs[0].ID < runs[1].ID || runs[1].ID < runs[2].ID {
+		t.Errorf("expected DESC id ordering, got %d,%d,%d", runs[0].ID, runs[1].ID, runs[2].ID)
+	}
+}
+
+func TestCalibreProvenanceRepo_UpsertGetDelete(t *testing.T) {
+	t.Parallel()
+
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	runs := NewCalibreImportRunRepo(database)
+	parent := &models.CalibreImportRun{LibraryPath: "/lib", Status: "running"}
+	if err := runs.Create(context.Background(), parent); err != nil {
+		t.Fatalf("create parent run: %v", err)
+	}
+
+	repo := NewCalibreProvenanceRepo(database)
+	runID := parent.ID
+	p := &models.CalibreProvenance{
+		EntityType:  "book",
+		ExternalID:  "book:1",
+		LocalID:     42,
+		ImportRunID: &runID,
+	}
+	if err := repo.Upsert(context.Background(), p); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	got, err := repo.GetByExternal(context.Background(), "default", "book", "book:1")
+	if err != nil || got == nil {
+		t.Fatalf("GetByExternal: %v / %v", err, got)
+	}
+	if got.LocalID != 42 {
+		t.Errorf("local_id = %d, want 42", got.LocalID)
+	}
+
+	// Re-upsert with a different local_id; the conflict clause should overwrite.
+	p.LocalID = 99
+	if err := repo.Upsert(context.Background(), p); err != nil {
+		t.Fatalf("Upsert overwrite: %v", err)
+	}
+	got, _ = repo.GetByExternal(context.Background(), "default", "book", "book:1")
+	if got == nil || got.LocalID != 99 {
+		t.Errorf("after overwrite local_id = %+v, want 99", got)
+	}
+
+	// Delete via local; provenance row should be gone.
+	n, err := repo.DeleteByLocal(context.Background(), "book", 99)
+	if err != nil || n != 1 {
+		t.Fatalf("DeleteByLocal: n=%d err=%v", n, err)
+	}
+	if got, _ := repo.GetByExternal(context.Background(), "default", "book", "book:1"); got != nil {
+		t.Errorf("provenance still present after delete: %+v", got)
+	}
+}
+
+func TestCalibreEntitySnapshotRepo_RecordRetainsFirstBefore(t *testing.T) {
+	t.Parallel()
+
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	runs := NewCalibreImportRunRepo(database)
+	snapshots := NewCalibreEntitySnapshotRepo(database)
+	run := &models.CalibreImportRun{LibraryPath: "/lib", Status: "running"}
+	if err := runs.Create(context.Background(), run); err != nil {
+		t.Fatalf("Create run: %v", err)
+	}
+
+	// First snapshot includes a "before" payload.
+	first := &models.CalibreEntitySnapshot{
+		RunID:        run.ID,
+		EntityType:   "book",
+		ExternalID:   "book:1",
+		LocalID:      5,
+		Outcome:      "updated",
+		MetadataJSON: `{"kind":"calibre_run_entity_metadata","version":1,"snapshot":{"entityType":"book","before":{"title":"original"},"after":{"title":"first-mutation"}}}`,
+	}
+	if err := snapshots.Record(context.Background(), first); err != nil {
+		t.Fatalf("Record first: %v", err)
+	}
+
+	// Second snapshot for the same entity changes "after" and tries to
+	// overwrite "before" — the repo must keep the original "before".
+	second := &models.CalibreEntitySnapshot{
+		RunID:        run.ID,
+		EntityType:   "book",
+		ExternalID:   "book:1",
+		LocalID:      5,
+		Outcome:      "updated",
+		MetadataJSON: `{"kind":"calibre_run_entity_metadata","version":1,"snapshot":{"entityType":"book","before":{"title":"wrong"},"after":{"title":"second-mutation"}}}`,
+	}
+	if err := snapshots.Record(context.Background(), second); err != nil {
+		t.Fatalf("Record second: %v", err)
+	}
+
+	rows, err := snapshots.ListByRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("ListByRun: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected exactly 1 row after upsert, got %d", len(rows))
+	}
+	merged := rows[0].MetadataJSON
+	if !contains(merged, `"original"`) {
+		t.Errorf("merged metadata lost the original 'before': %s", merged)
+	}
+	if !contains(merged, `"second-mutation"`) {
+		t.Errorf("merged metadata missing the latest 'after': %s", merged)
+	}
+}
+
+// CreatedOutcomeWins exercises the outcome-merge rule: a later "updated" must
+// not downgrade a prior "created" because rollback uses outcome to decide
+// delete-vs-restore.
+func TestCalibreEntitySnapshotRepo_CreatedOutcomeWins(t *testing.T) {
+	t.Parallel()
+
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	runs := NewCalibreImportRunRepo(database)
+	snapshots := NewCalibreEntitySnapshotRepo(database)
+	run := &models.CalibreImportRun{LibraryPath: "/lib", Status: "running"}
+	if err := runs.Create(context.Background(), run); err != nil {
+		t.Fatalf("Create run: %v", err)
+	}
+
+	if err := snapshots.Record(context.Background(), &models.CalibreEntitySnapshot{
+		RunID: run.ID, EntityType: "book", ExternalID: "book:1", LocalID: 1, Outcome: "created",
+	}); err != nil {
+		t.Fatalf("Record created: %v", err)
+	}
+	if err := snapshots.Record(context.Background(), &models.CalibreEntitySnapshot{
+		RunID: run.ID, EntityType: "book", ExternalID: "book:1", LocalID: 1, Outcome: "updated",
+	}); err != nil {
+		t.Fatalf("Record updated: %v", err)
+	}
+	rows, _ := snapshots.ListByRun(context.Background(), run.ID)
+	if len(rows) != 1 || rows[0].Outcome != "created" {
+		t.Errorf("outcome = %+v, want created (created must not be downgraded by updated)", rows)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return indexOf(haystack, needle) >= 0
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/db/migrations/044_calibre_import_rollback.sql
+++ b/internal/db/migrations/044_calibre_import_rollback.sql
@@ -1,0 +1,57 @@
+-- +migrate Up
+-- Calibre import/sync rollback (#643). Reporter hit metadata damage from a
+-- bad Calibre import and had to ZFS-restore the whole catalogue.
+-- This mirrors the ABS run-tracking, provenance, and snapshot shape so a
+-- single bad library import can be unwound from the UI instead of backups.
+
+CREATE TABLE calibre_import_runs (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id          TEXT     NOT NULL DEFAULT 'default',
+    library_path       TEXT     NOT NULL DEFAULT '',
+    status             TEXT     NOT NULL DEFAULT 'running',
+    dry_run            INTEGER  NOT NULL DEFAULT 0,
+    source_config_json TEXT     NOT NULL DEFAULT '{}',
+    summary_json       TEXT     NOT NULL DEFAULT '{}',
+    started_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    finished_at        DATETIME
+);
+
+CREATE INDEX idx_calibre_import_runs_started ON calibre_import_runs(started_at DESC);
+
+CREATE TABLE calibre_provenance (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id     TEXT     NOT NULL DEFAULT 'default',
+    entity_type   TEXT     NOT NULL CHECK(entity_type IN ('author', 'book', 'edition')),
+    external_id   TEXT     NOT NULL,
+    local_id      INTEGER  NOT NULL,
+    import_run_id INTEGER  REFERENCES calibre_import_runs(id) ON DELETE SET NULL,
+    created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (source_id, entity_type, external_id)
+);
+
+CREATE INDEX idx_calibre_provenance_local ON calibre_provenance(entity_type, local_id);
+
+CREATE TABLE calibre_entity_snapshots (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id        INTEGER  NOT NULL REFERENCES calibre_import_runs(id) ON DELETE CASCADE,
+    source_id     TEXT     NOT NULL DEFAULT 'default',
+    entity_type   TEXT     NOT NULL CHECK(entity_type IN ('author', 'book', 'edition')),
+    external_id   TEXT     NOT NULL,
+    local_id      INTEGER  NOT NULL DEFAULT 0,
+    outcome       TEXT     NOT NULL DEFAULT '',
+    metadata_json TEXT     NOT NULL DEFAULT '{}',
+    created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (run_id, entity_type, external_id, local_id)
+);
+
+CREATE INDEX idx_calibre_entity_snapshots_run ON calibre_entity_snapshots(run_id, entity_type, local_id);
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS idx_calibre_entity_snapshots_run;
+DROP TABLE IF EXISTS calibre_entity_snapshots;
+DROP INDEX IF EXISTS idx_calibre_provenance_local;
+DROP TABLE IF EXISTS calibre_provenance;
+DROP INDEX IF EXISTS idx_calibre_import_runs_started;
+DROP TABLE IF EXISTS calibre_import_runs;

--- a/internal/models/calibre_import.go
+++ b/internal/models/calibre_import.go
@@ -1,0 +1,49 @@
+package models
+
+import "time"
+
+// CalibreImportRun is the persistent record of one Calibre library import.
+// Mirrors ABSImportRun but drops checkpoint_json — Calibre imports are
+// in-process scans of a local metadata.db with no mid-run pagination state
+// to resume from.
+type CalibreImportRun struct {
+	ID               int64      `json:"id"`
+	SourceID         string     `json:"sourceId"`
+	LibraryPath      string     `json:"libraryPath"`
+	Status           string     `json:"status"`
+	DryRun           bool       `json:"dryRun"`
+	SourceConfigJSON string     `json:"sourceConfigJson"`
+	SummaryJSON      string     `json:"summaryJson"`
+	StartedAt        time.Time  `json:"startedAt"`
+	FinishedAt       *time.Time `json:"finishedAt,omitempty"`
+}
+
+// CalibreEntitySnapshot records the pre-mutation state of a single Bindery
+// entity touched by a Calibre import run. The before/after JSON lives in
+// MetadataJSON (decoded by the rollback layer); Outcome is the importer-side
+// outcome ("created" / "updated") used to decide whether rollback deletes
+// the row or restores its fields.
+type CalibreEntitySnapshot struct {
+	ID           int64     `json:"id"`
+	RunID        int64     `json:"runId"`
+	SourceID     string    `json:"sourceId"`
+	EntityType   string    `json:"entityType"`
+	ExternalID   string    `json:"externalId"`
+	LocalID      int64     `json:"localId"`
+	Outcome      string    `json:"outcome"`
+	MetadataJSON string    `json:"metadataJson"`
+	CreatedAt    time.Time `json:"createdAt"`
+}
+
+// CalibreProvenance links a Bindery local entity to the Calibre book/author
+// id that produced it, so rollback can prove ownership before deleting.
+type CalibreProvenance struct {
+	ID          int64     `json:"id"`
+	SourceID    string    `json:"sourceId"`
+	EntityType  string    `json:"entityType"`
+	ExternalID  string    `json:"externalId"`
+	LocalID     int64     `json:"localId"`
+	ImportRunID *int64    `json:"importRunId,omitempty"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -426,6 +426,11 @@ export const api = {
   calibreImportStatus: () => request<CalibreImportProgress>('/calibre/import/status'),
   calibreSyncStart: () => request<CalibreSyncProgress>('/calibre/sync', { method: 'POST' }),
   calibreSyncStatus: () => request<CalibreSyncProgress>('/calibre/sync/status'),
+  calibreRuns: (limit = 10) => request<CalibreImportRun[]>(`/calibre/runs?limit=${limit}`),
+  calibreRunRollbackPreview: (runId: number) =>
+    request<CalibreRollbackResult>(`/calibre/runs/${runId}/rollback/preview`),
+  calibreRunRollback: (runId: number) =>
+    request<CalibreRollbackResult>(`/calibre/runs/${runId}/rollback`, { method: 'POST' }),
 
   // Grimmory
   grimmoryConfig: () => request<GrimmoryConfig>('/grimmory/config'),
@@ -679,6 +684,51 @@ export interface CalibreSyncProgress {
   error?: string
   stats: CalibreSyncStats
   errors: CalibreSyncError[]
+}
+
+// CalibreImportRun is one persisted Calibre import run (issue #643). Used
+// by the "Recent imports" list in the Calibre settings tab.
+export interface CalibreImportRun {
+  id: number
+  sourceId: string
+  libraryPath: string
+  status: string
+  dryRun: boolean
+  sourceConfigJson?: string
+  summaryJson?: string
+  startedAt: string
+  finishedAt?: string
+}
+
+export interface CalibreRollbackStats {
+  actionsPlanned: number
+  entitiesDeleted: number
+  provenanceUnlinked: number
+  filesAffected: number
+  skipped: number
+  failed: number
+}
+
+export interface CalibreRollbackAction {
+  entityType: string
+  externalId: string
+  localId: number
+  displayName?: string
+  outcome: string
+  action: string
+  reason?: string
+}
+
+export interface CalibreRollbackResult {
+  runId: number
+  preview: boolean
+  applied: boolean
+  dryRun: boolean
+  status: string
+  stats: CalibreRollbackStats
+  actions: CalibreRollbackAction[]
+  filesOnDiskWarning?: string
+  finishedAt: string
 }
 
 export interface GrimmoryConfig {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -269,6 +269,40 @@
         "dismissRunConfirm": "Dismiss {{count}} review items from run #{{runId}}? This cannot be undone."
       }
     },
+    "calibre": {
+      "runs": {
+        "heading": "Recent imports",
+        "description": "Bindery tracks every live import so you can preview and undo it. Files on disk are never touched — only the metadata rows Bindery created or modified.",
+        "refresh": "Refresh",
+        "empty": "No Calibre imports recorded yet.",
+        "runLabel": "Run #{{runId}} · {{status}}",
+        "startedAt": "Started {{startedAt}}",
+        "statusRunning": "Running",
+        "statusCompleted": "Completed",
+        "statusFailed": "Failed",
+        "statusRolledBack": "Rolled back",
+        "preview": "Preview rollback",
+        "previewing": "Previewing…",
+        "rollback": "Roll back…",
+        "rolledBack": "Rolled back",
+        "rollingBack": "Rolling back…",
+        "modalTitle": "Roll back Calibre import #{{runId}}",
+        "modalIntro": "Bindery will revert metadata changes made by this import. Files on disk are never deleted.",
+        "actionsPlanned": "{{count}} action(s) planned",
+        "entitiesDeleted": "{{count}} entities will be deleted",
+        "provenanceUnlinked": "{{count}} link(s) will be removed",
+        "filesAffected": "{{count}} book row(s) referenced files on disk",
+        "filesOnDiskWarning": "Files on disk are NOT removed by rollback. Delete them manually if you need to.",
+        "skipped": "{{count}} entries will be skipped (already rolled back or out of scope)",
+        "actionsHeading": "Planned actions",
+        "noActions": "Nothing to do.",
+        "applyRollback": "Apply rollback",
+        "applying": "Applying…",
+        "cancel": "Cancel",
+        "error": "Rollback failed: {{error}}",
+        "appliedSummary": "Rollback complete — {{deleted}} deleted, {{unlinked}} link(s) removed, {{skipped}} skipped, {{failed}} failures."
+      }
+    },
     "indexers": {
       "heading": "Indexers",
       "addButton": "+ Add Indexer",

--- a/web/src/pages/settings/CalibreTab.tsx
+++ b/web/src/pages/settings/CalibreTab.tsx
@@ -1,5 +1,12 @@
-import { useEffect, useState } from 'react'
-import { api, CalibreImportProgress, CalibreSyncProgress } from '../../api/client'
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  api,
+  CalibreImportProgress,
+  CalibreImportRun,
+  CalibreRollbackResult,
+  CalibreSyncProgress,
+} from '../../api/client'
 import Toggle from './Toggle'
 
 export default function CalibreTab() {
@@ -61,6 +68,9 @@ function CalibreSection({
   const [syncError, setSyncError] = useState<string | null>(null)
   const [syncModalOpen, setSyncModalOpen] = useState(false)
   const [bridgeReachable, setBridgeReachable] = useState<boolean | null>(null)
+  // Recent imports + rollback (issue #643).
+  const [runs, setRuns] = useState<CalibreImportRun[]>([])
+  const [rollbackRun, setRollbackRun] = useState<CalibreImportRun | null>(null)
 
   const saveSettingWithError = async (key: string) => {
     setSaveError(null)
@@ -86,6 +96,10 @@ function CalibreSection({
 
   // Hydrate progress on mount so navigating back mid-import still shows
   // the live bar instead of a dead "Import library" button.
+  const refreshRuns = useCallback(() => {
+    api.calibreRuns(10).then(setRuns).catch(() => {})
+  }, [])
+
   useEffect(() => {
     api.calibreImportStatus().then(setImportProgress).catch(() => {})
     api.calibreSyncStatus().then(p => {
@@ -95,7 +109,16 @@ function CalibreSection({
       // the disabled button is doing.
       if (p.running) setSyncModalOpen(true)
     }).catch(() => {})
-  }, [])
+    refreshRuns()
+  }, [refreshRuns])
+
+  // Refresh runs after an import finishes so the new run shows up without
+  // requiring a manual click.
+  useEffect(() => {
+    if (!importProgress) return
+    if (importProgress.running) return
+    refreshRuns()
+  }, [importProgress, refreshRuns])
 
   // Silently probe plugin reachability so the "Push all to Calibre"
   // button can enable/disable without the user having to click Test
@@ -459,6 +482,12 @@ function CalibreSection({
                   )}
                 </div>
               )}
+
+              <CalibreRunsList
+                runs={runs}
+                onRefresh={refreshRuns}
+                onRollback={setRollbackRun}
+              />
             </>
           )}
         </div>
@@ -502,7 +531,281 @@ function CalibreSection({
           onClose={() => setSyncModalOpen(false)}
         />
       )}
+
+      {rollbackRun && (
+        <CalibreRollbackModal
+          run={rollbackRun}
+          onClose={() => setRollbackRun(null)}
+          onApplied={() => {
+            refreshRuns()
+          }}
+        />
+      )}
     </section>
+  )
+}
+
+// CalibreRunsList renders the "Recent imports" panel inside the Library
+// import block. Each run gets a per-row Rollback button that pops the
+// CalibreRollbackModal.
+function CalibreRunsList({
+  runs,
+  onRefresh,
+  onRollback,
+}: {
+  runs: CalibreImportRun[]
+  onRefresh: () => void
+  onRollback: (run: CalibreImportRun) => void
+}) {
+  const { t } = useTranslation()
+
+  const statusLabel = (status: string) => {
+    switch (status) {
+      case 'running':
+        return t('settings.calibre.runs.statusRunning')
+      case 'completed':
+        return t('settings.calibre.runs.statusCompleted')
+      case 'failed':
+        return t('settings.calibre.runs.statusFailed')
+      case 'rolled_back':
+        return t('settings.calibre.runs.statusRolledBack')
+      default:
+        return status
+    }
+  }
+
+  return (
+    <div className="rounded border border-slate-200 dark:border-zinc-800 bg-slate-50 dark:bg-zinc-950 px-3 py-3 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-medium text-slate-800 dark:text-zinc-200">
+            {t('settings.calibre.runs.heading')}
+          </p>
+          <p className="text-xs text-slate-600 dark:text-zinc-500">
+            {t('settings.calibre.runs.description')}
+          </p>
+        </div>
+        <button
+          onClick={onRefresh}
+          className="px-3 py-2 bg-slate-700 hover:bg-slate-600 rounded text-sm font-medium text-white"
+        >
+          {t('settings.calibre.runs.refresh')}
+        </button>
+      </div>
+
+      {runs.length === 0 && (
+        <p className="text-sm text-slate-500 dark:text-zinc-500">
+          {t('settings.calibre.runs.empty')}
+        </p>
+      )}
+
+      {runs.slice(0, 10).map(run => {
+        const rolledBack = run.status === 'rolled_back'
+        const running = run.status === 'running'
+        return (
+          <div
+            key={run.id}
+            className={`rounded border px-3 py-2 ${
+              rolledBack
+                ? 'border-slate-200 dark:border-zinc-800 bg-slate-100/70 dark:bg-zinc-900/50 opacity-75'
+                : 'border-slate-200 dark:border-zinc-800 bg-white/70 dark:bg-zinc-950/40'
+            }`}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-slate-800 dark:text-zinc-200 truncate">
+                  {t('settings.calibre.runs.runLabel', { runId: run.id, status: statusLabel(run.status) })}
+                </p>
+                <p className="text-[11px] text-slate-500 dark:text-zinc-500">
+                  {t('settings.calibre.runs.startedAt', {
+                    startedAt: new Date(run.startedAt).toLocaleString(),
+                  })}
+                  {run.libraryPath ? ` · ${run.libraryPath}` : ''}
+                </p>
+              </div>
+              <button
+                onClick={() => onRollback(run)}
+                disabled={rolledBack || running}
+                className={`px-3 py-1.5 rounded text-xs font-medium text-white disabled:opacity-50 ${
+                  rolledBack ? 'bg-slate-500 cursor-not-allowed' : 'bg-amber-600 hover:bg-amber-500'
+                }`}
+                title={rolledBack ? t('settings.calibre.runs.rolledBack') : ''}
+              >
+                {rolledBack ? t('settings.calibre.runs.rolledBack') : t('settings.calibre.runs.rollback')}
+              </button>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// CalibreRollbackModal shows the rollback preview, lets the admin confirm,
+// and surfaces the resulting per-action list. Apply uses amber styling
+// rather than red because rollback restores Bindery state — it does not
+// delete on-disk files.
+function CalibreRollbackModal({
+  run,
+  onClose,
+  onApplied,
+}: {
+  run: CalibreImportRun
+  onClose: () => void
+  onApplied: () => void
+}) {
+  const { t } = useTranslation()
+  const [preview, setPreview] = useState<CalibreRollbackResult | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(true)
+  const [applied, setApplied] = useState<CalibreRollbackResult | null>(null)
+  const [applying, setApplying] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setPreviewLoading(true)
+    setError(null)
+    api.calibreRunRollbackPreview(run.id)
+      .then(setPreview)
+      .catch(err => setError(err instanceof Error ? err.message : String(err)))
+      .finally(() => setPreviewLoading(false))
+  }, [run.id])
+
+  const apply = async () => {
+    setApplying(true)
+    setError(null)
+    try {
+      const result = await api.calibreRunRollback(run.id)
+      setApplied(result)
+      onApplied()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  const display = applied ?? preview
+  const closable = !applying
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true">
+      <div className="w-full max-w-2xl rounded-lg bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 shadow-xl">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200 dark:border-zinc-800">
+          <h3 className="text-base font-semibold text-slate-800 dark:text-zinc-100">
+            {t('settings.calibre.runs.modalTitle', { runId: run.id })}
+          </h3>
+          <button
+            onClick={closable ? onClose : undefined}
+            disabled={!closable}
+            className="text-slate-500 hover:text-slate-700 dark:text-zinc-400 dark:hover:text-zinc-200 disabled:opacity-40"
+            title={closable ? '' : t('settings.calibre.runs.applying')}
+          >
+            ✕
+          </button>
+        </div>
+        <div className="p-4 space-y-3">
+          <p className="text-xs text-slate-600 dark:text-zinc-400">{t('settings.calibre.runs.modalIntro')}</p>
+
+          {previewLoading && (
+            <p className="text-sm text-slate-500 dark:text-zinc-500">{t('settings.calibre.runs.previewing')}</p>
+          )}
+
+          {error && (
+            <p className="text-sm text-red-600 dark:text-red-400">
+              {t('settings.calibre.runs.error', { error })}
+            </p>
+          )}
+
+          {display && (
+            <>
+              <div className="grid grid-cols-2 gap-2 text-xs">
+                <div className="rounded border border-slate-200 dark:border-zinc-800 px-2 py-1.5">
+                  <div className="text-slate-600 dark:text-zinc-500">{t('settings.calibre.runs.actionsPlanned', { count: display.stats.actionsPlanned })}</div>
+                </div>
+                <div className="rounded border border-slate-200 dark:border-zinc-800 px-2 py-1.5">
+                  <div className="text-slate-600 dark:text-zinc-500">{t('settings.calibre.runs.entitiesDeleted', { count: display.stats.entitiesDeleted })}</div>
+                </div>
+                <div className="rounded border border-slate-200 dark:border-zinc-800 px-2 py-1.5">
+                  <div className="text-slate-600 dark:text-zinc-500">{t('settings.calibre.runs.provenanceUnlinked', { count: display.stats.provenanceUnlinked })}</div>
+                </div>
+                <div className="rounded border border-slate-200 dark:border-zinc-800 px-2 py-1.5">
+                  <div className="text-slate-600 dark:text-zinc-500">{t('settings.calibre.runs.skipped', { count: display.stats.skipped })}</div>
+                </div>
+              </div>
+
+              {display.stats.filesAffected > 0 && (
+                <div className="rounded border border-amber-300 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/20 px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
+                  <p className="font-medium">{t('settings.calibre.runs.filesAffected', { count: display.stats.filesAffected })}</p>
+                  <p>{display.filesOnDiskWarning || t('settings.calibre.runs.filesOnDiskWarning')}</p>
+                </div>
+              )}
+
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-700 dark:text-zinc-300 mb-1">
+                  {t('settings.calibre.runs.actionsHeading')}
+                </p>
+                {display.actions.length === 0 ? (
+                  <p className="text-xs text-slate-500 dark:text-zinc-500">{t('settings.calibre.runs.noActions')}</p>
+                ) : (
+                  <div className="max-h-64 overflow-y-auto rounded border border-slate-200 dark:border-zinc-800">
+                    <table className="w-full text-xs">
+                      <tbody>
+                        {display.actions.map(action => (
+                          <tr
+                            key={`${action.entityType}-${action.externalId}-${action.localId}-${action.action}`}
+                            className="border-t border-slate-200 dark:border-zinc-800"
+                          >
+                            <td className="px-2 py-1 text-slate-800 dark:text-zinc-200 font-medium">
+                              {action.action}
+                            </td>
+                            <td className="px-2 py-1 text-slate-600 dark:text-zinc-400">{action.entityType}</td>
+                            <td className="px-2 py-1 text-slate-600 dark:text-zinc-400 truncate">
+                              {action.displayName || action.externalId}
+                            </td>
+                            <td className="px-2 py-1 text-slate-500 dark:text-zinc-500 truncate">
+                              {action.reason || ''}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+
+              {applied && (
+                <p className="text-xs text-emerald-700 dark:text-emerald-400">
+                  {t('settings.calibre.runs.appliedSummary', {
+                    deleted: applied.stats.entitiesDeleted,
+                    unlinked: applied.stats.provenanceUnlinked,
+                    skipped: applied.stats.skipped,
+                    failed: applied.stats.failed,
+                  })}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+        <div className="px-4 py-3 border-t border-slate-200 dark:border-zinc-800 flex justify-end gap-2">
+          <button
+            onClick={closable ? onClose : undefined}
+            disabled={!closable}
+            className="px-3 py-1.5 bg-slate-600 hover:bg-slate-500 rounded text-sm font-medium text-white disabled:opacity-50"
+          >
+            {t('settings.calibre.runs.cancel')}
+          </button>
+          {!applied && (
+            <button
+              onClick={apply}
+              disabled={applying || previewLoading || !!error}
+              className="px-3 py-1.5 bg-amber-600 hover:bg-amber-500 rounded text-sm font-medium text-white disabled:opacity-50"
+            >
+              {applying ? t('settings.calibre.runs.applying') : t('settings.calibre.runs.applyRollback')}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Why

Reporter (magrhino, #643) hit metadata damage from a bad Calibre import and had to ZFS-restore the catalogue. The ABS importer already shipped run tracking + entity snapshots + rollback preview/execute. This PR ports the same shape to the Calibre side so a bad library import can be unwound from the UI instead of from backups.

## What ships

- New migration `044_calibre_import_rollback.sql`: `calibre_import_runs`, `calibre_provenance`, `calibre_entity_snapshots`. Layout mirrors the ABS tables in a separate namespace.
- `CalibreImportRunRepo` / `CalibreProvenanceRepo` / `CalibreEntitySnapshotRepo` (`internal/db/calibre_imports.go`) — line-for-line ABS mirror modulo the dropped checkpoint column (Calibre imports have no mid-run resumable state).
- `internal/calibre/import_snapshots.go`: before/after snapshot envelopes for book + author + edition.
- `internal/calibre/import_rollback.go`: `PreviewRollback` / `Rollback` with the same action vocabulary as ABS (`delete_book`, `restore_book`, `delete_author`, `unlink_provenance`, `delete_edition`, `skip`).
- Importer wired to:
  - Create a run record on every live import
  - Snapshot a book BEFORE the first `applyBookFields` call in that run (snapshot-before-mutation is the non-obvious bit)
  - Record provenance + a creation marker for every freshly-created book/author/edition
  - Finish the run as `completed` / `failed` depending on outcome
- Three new admin-only endpoints (mirroring ABS shape):
  - `GET  /api/v1/calibre/runs` — recent runs, paginated (default 20, max 100)
  - `GET  /api/v1/calibre/runs/{id}/rollback/preview` — `RollbackResult` JSON
  - `POST /api/v1/calibre/runs/{id}/rollback` — applies; 409 on already `rolled_back`, 404 on unknown run, 503 if run-tracking wasn't wired (defensive)
- Settings → General → Calibre gains a "Recent imports" panel + per-row Rollback button → modal with the preview + Apply. Amber styling (destructive flavour, not actual destruction); strings via `t()` + `en.json` only.

## Scope of rollback

**Metadata-only.** Rollback removes / restores Bindery rows the run created or updated. Files on disk are never touched. The response payload carries a `filesOnDiskWarning` and `stats.filesAffected` when the run referenced files so the admin can clean them up manually if they want.

## Idempotency / state machine

- A run finishes in `completed` / `failed` (run reporter set on cleanup, even if the calling ctx was cancelled mid-import).
- Rollback flips status to `rolled_back`.
- A second rollback against a `rolled_back` run returns `ErrAlreadyRolledBack` → 409.
- A preview against any state is non-mutating and idempotent.

## Migration number

`044_calibre_import_rollback.sql` (043 was the most recent migration on `main`).

## Deliberately out of scope

- **Sync (push to Calibre) rollback.** Sync only writes `calibre_id` on Bindery books — not data damage in the reporter's sense — and tracking it would need sync-side run records with no precedent in the codebase.
- **ABS code.** Read-only reference; no ABS file touched.
- **Refactoring the Calibre importer/syncer.** Only the minimum wiring to attach run tracking + snapshots.

## Tests added

- `internal/db/calibre_imports_test.go` — repo CRUD, ordering, snapshot upsert merges before/after correctly, `created` outcome cannot be downgraded to `updated`.
- `internal/calibre/import_rollback_test.go`:
  - Importer records snapshots + provenance per touched entity
  - Preview returns expected delete actions for authors/books/editions
  - Execute deletes entities, clears provenance, flips run to `rolled_back`
  - Second rollback returns `ErrAlreadyRolledBack`
  - Unknown run returns `ErrRunNotFound`
  - On-disk file referenced by a rolled-back book row is NOT touched
- `internal/api/calibre_runs_test.go` — HTTP handlers: 200 list, empty `[]` not `null`, 200 preview/apply, 404 unknown run, 409 already rolled back, 503 unavailable, 400 invalid id.

## Verification

- `gofmt -l` clean
- `go vet ./...` clean
- `golangci-lint run --timeout=5m` 0 issues
- `go test ./cmd/... ./internal/...` all green
- `cd web && npm run typecheck && npm run lint && npm run build && npm test` all green

Closes #643