### PR TITLE
feat(hardcover): populate series refs during list sync (#805)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -391,6 +391,7 @@ func main() {
 
 	// Register the Hardcover list syncer (24-hour job).
 	hcSyncer := hardcoverlistsyncer.New(importListRepo, authorRepo, bookRepo).
+		WithSeriesRepo(seriesRepo).
 		WithTokenSource(func(ctx context.Context) string {
 			return api.GetHardcoverAPIToken(ctx, settingsRepo)
 		})

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -19,6 +19,7 @@ type ListSyncer struct {
 	importLists     *db.ImportListRepo
 	authors         *db.AuthorRepo
 	books           *db.BookRepo
+	series          seriesLinker
 	tokenSource     func(context.Context) string
 	hardcoverClient func(token string) hardcoverListClient
 }
@@ -26,6 +27,14 @@ type ListSyncer struct {
 type hardcoverListClient interface {
 	GetUserLists(ctx context.Context) ([]hardcover.HCList, error)
 	GetListBooks(ctx context.Context, listID int) ([]models.Book, error)
+}
+
+// seriesLinker is the slice of *db.SeriesRepo the syncer needs to persist
+// the primary-series association attached to imported books. Declared as an
+// interface so tests can stub it without standing up the full SQL schema.
+type seriesLinker interface {
+	CreateOrGet(ctx context.Context, s *models.Series) error
+	LinkBook(ctx context.Context, seriesID, bookID int64, position string, primary bool) error
 }
 
 // New creates a new ListSyncer.
@@ -38,6 +47,18 @@ func New(importLists *db.ImportListRepo, authors *db.AuthorRepo, books *db.BookR
 			return hardcover.NewAuthenticated(token)
 		},
 	}
+}
+
+// WithSeriesRepo wires the series persistence layer so that books imported
+// from Hardcover lists carry forward their primary-series association.
+// Without it, SeriesRefs on imported books are silently dropped.
+func (s *ListSyncer) WithSeriesRepo(repo *db.SeriesRepo) *ListSyncer {
+	if repo == nil {
+		s.series = nil
+		return s
+	}
+	s.series = repo
+	return s
 }
 
 // WithTokenSource configures the fallback Hardcover API token used when an
@@ -175,9 +196,30 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 			continue
 		}
 		slog.Info("imported book from hardcover list", "title", book.Title, "author_id", authorID)
+
+		s.linkSeriesRefs(ctx, &book)
 	}
 
 	return nil
+}
+
+// linkSeriesRefs persists each Hardcover SeriesRef into the series table and
+// links it to the freshly imported book. Best-effort: a failed link must not
+// roll back or block the book import — log and move on.
+func (s *ListSyncer) linkSeriesRefs(ctx context.Context, book *models.Book) {
+	if s.series == nil || len(book.SeriesRefs) == 0 || book.ID == 0 {
+		return
+	}
+	for _, ref := range book.SeriesRefs {
+		ser := &models.Series{ForeignID: ref.ForeignID, Title: ref.Title}
+		if err := s.series.CreateOrGet(ctx, ser); err != nil {
+			slog.Warn("hardcover list sync: upsert series failed", "series", ref.Title, "book", book.Title, "error", err)
+			continue
+		}
+		if err := s.series.LinkBook(ctx, ser.ID, book.ID, ref.Position, ref.Primary); err != nil {
+			slog.Warn("hardcover list sync: link book to series failed", "series", ref.Title, "book", book.Title, "error", err)
+		}
+	}
 }
 
 func (s *ListSyncer) tokenForList(ctx context.Context, il models.ImportList) string {

--- a/internal/hardcoverlistsyncer/syncer_test.go
+++ b/internal/hardcoverlistsyncer/syncer_test.go
@@ -244,3 +244,179 @@ func (f fakeHardcoverListClient) GetUserLists(context.Context) ([]hardcover.HCLi
 func (f fakeHardcoverListClient) GetListBooks(context.Context, int) ([]models.Book, error) {
 	return f.books, nil
 }
+
+// newTestSyncerWithSeries returns a syncer wired against a real in-memory DB
+// and gives the test direct access to the SeriesRepo so it can verify links
+// were actually persisted.
+func newTestSyncerWithSeries(t *testing.T) (*ListSyncer, *db.ImportListRepo, *db.SeriesRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	importLists := db.NewImportListRepo(database)
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	series := db.NewSeriesRepo(database)
+	s := New(importLists, authors, books).WithSeriesRepo(series)
+	return s, importLists, series
+}
+
+func bookWithSeriesRef(foreignID, title string, refs []models.SeriesRef) models.Book {
+	return models.Book{
+		ForeignID:        foreignID,
+		Title:            title,
+		SortTitle:        title,
+		MetadataProvider: "hardcover",
+		Author: &models.Author{
+			ForeignID:        "hc:author-x",
+			Name:             "Author X",
+			SortName:         "X, Author",
+			MetadataProvider: "hardcover",
+		},
+		SeriesRefs: refs,
+	}
+}
+
+// TestSyncOne_LinksSeriesRefsAfterBookImport is the issue #805 happy path:
+// books that arrive with a populated SeriesRefs slice must be linked through
+// the SeriesRepo so the import doesn't quietly lose series membership.
+func TestSyncOne_LinksSeriesRefsAfterBookImport(t *testing.T) {
+	s, repo, series := newTestSyncerWithSeries(t)
+	ctx := context.Background()
+
+	il := testImportList("With Series", "hardcover", true)
+	if err := repo.Create(ctx, &il); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	book := bookWithSeriesRef("hc:dune", "Dune", []models.SeriesRef{{
+		ForeignID: "hc-series:17",
+		Title:     "Dune Chronicles",
+		Position:  "1",
+		Primary:   true,
+	}})
+	s.hardcoverClient = func(string) hardcoverListClient {
+		return fakeHardcoverListClient{
+			lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{book},
+		}
+	}
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne: %v", err)
+	}
+
+	persisted, err := series.GetByForeignID(ctx, "hc-series:17")
+	if err != nil {
+		t.Fatalf("GetByForeignID: %v", err)
+	}
+	if persisted == nil {
+		t.Fatal("series was not created during sync")
+	}
+	booksInSeries, err := series.ListBooksInSeries(ctx, persisted.ID)
+	if err != nil {
+		t.Fatalf("ListBooksInSeries: %v", err)
+	}
+	if len(booksInSeries) != 1 || booksInSeries[0].ForeignID != "hc:dune" {
+		t.Fatalf("series should contain the imported book, got %+v", booksInSeries)
+	}
+}
+
+// TestSyncOne_SeriesLinkErrorDoesNotBlockImport guarantees the best-effort
+// contract: when the SeriesRepo errors out, the book is still imported and
+// the sync does not fail the whole list. Regression guard for the warning
+// path.
+func TestSyncOne_SeriesLinkErrorDoesNotBlockImport(t *testing.T) {
+	s, repo, _ := newTestSyncerWithSeries(t)
+	ctx := context.Background()
+
+	stub := &erroringSeriesRepo{}
+	s.series = stub
+
+	il := testImportList("Series Error", "hardcover", true)
+	if err := repo.Create(ctx, &il); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	book := bookWithSeriesRef("hc:dune", "Dune", []models.SeriesRef{{
+		ForeignID: "hc-series:17",
+		Title:     "Dune Chronicles",
+		Position:  "1",
+		Primary:   true,
+	}})
+	s.hardcoverClient = func(string) hardcoverListClient {
+		return fakeHardcoverListClient{
+			lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{book},
+		}
+	}
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne should succeed even when series linking errors: %v", err)
+	}
+	if stub.upsertCalls == 0 {
+		t.Errorf("expected CreateOrGet to be attempted, got 0 calls")
+	}
+
+	imported, err := s.books.GetByForeignID(ctx, "hc:dune")
+	if err != nil || imported == nil {
+		t.Fatalf("book should still be imported despite series link failure: %v, %v", imported, err)
+	}
+}
+
+// erroringSeriesRepo always fails CreateOrGet so we can prove the syncer
+// swallows the error.
+type erroringSeriesRepo struct {
+	upsertCalls int
+	linkCalls   int
+}
+
+func (e *erroringSeriesRepo) CreateOrGet(context.Context, *models.Series) error {
+	e.upsertCalls++
+	return errors.New("simulated upsert failure")
+}
+
+func (e *erroringSeriesRepo) LinkBook(context.Context, int64, int64, string, bool) error {
+	e.linkCalls++
+	return errors.New("should not be called when upsert fails")
+}
+
+// TestSyncOne_NoSeriesRepo_NoSeriesLinkAttempted protects the optional
+// nature of the repo: the syncer must remain functional when WithSeriesRepo
+// was never called (e.g. older deployments wired before #805 landed).
+func TestSyncOne_NoSeriesRepo_NoSeriesLinkAttempted(t *testing.T) {
+	s, _ := newTestSyncer(t)
+	if s.series != nil {
+		t.Fatalf("default syncer should have no series repo, got %T", s.series)
+	}
+
+	il := testImportList("No Series Repo", "hardcover", true)
+	importLists := s.importLists
+	ctx := context.Background()
+	if err := importLists.Create(ctx, &il); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	book := bookWithSeriesRef("hc:dune", "Dune", []models.SeriesRef{{
+		ForeignID: "hc-series:17",
+		Title:     "Dune Chronicles",
+		Position:  "1",
+		Primary:   true,
+	}})
+	s.hardcoverClient = func(string) hardcoverListClient {
+		return fakeHardcoverListClient{
+			lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{book},
+		}
+	}
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne: %v", err)
+	}
+	imported, err := s.books.GetByForeignID(ctx, "hc:dune")
+	if err != nil || imported == nil {
+		t.Fatalf("book should be imported: %v, %v", imported, err)
+	}
+}

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -564,26 +564,38 @@ type hcContribution struct {
 }
 
 type hcBook struct {
-	ID                    int              `json:"id"`
-	Title                 string           `json:"title"`
-	Subtitle              string           `json:"subtitle"`
-	Slug                  string           `json:"slug"`
-	Description           string           `json:"description"`
-	Image                 *hcImage         `json:"image"`
-	ReleaseYear           *int             `json:"release_year"`
-	RatingsCount          int              `json:"ratings_count"`
-	Rating                float64          `json:"rating"`
-	UsersCount            int              `json:"users_count"`
-	Genres                []string         `json:"genres"`
-	ISBNs                 []string         `json:"isbns"`
-	HasAudiobook          bool             `json:"has_audiobook"`
-	HasEbook              bool             `json:"has_ebook"`
-	AudioSeconds          *int             `json:"audio_seconds"`
-	DefaultAudioEditionID *int             `json:"default_audio_edition_id"`
-	DefaultEbookEditionID *int             `json:"default_ebook_edition_id"`
-	Contributions         []hcContribution `json:"contributions"`
-	AuthorNames           []string         `json:"author_names"`
-	SeriesRefs            []models.SeriesRef
+	ID                     int                `json:"id"`
+	Title                  string             `json:"title"`
+	Subtitle               string             `json:"subtitle"`
+	Slug                   string             `json:"slug"`
+	Description            string             `json:"description"`
+	Image                  *hcImage           `json:"image"`
+	ReleaseYear            *int               `json:"release_year"`
+	RatingsCount           int                `json:"ratings_count"`
+	Rating                 float64            `json:"rating"`
+	UsersCount             int                `json:"users_count"`
+	Genres                 []string           `json:"genres"`
+	ISBNs                  []string           `json:"isbns"`
+	HasAudiobook           bool               `json:"has_audiobook"`
+	HasEbook               bool               `json:"has_ebook"`
+	AudioSeconds           *int               `json:"audio_seconds"`
+	DefaultAudioEditionID  *int               `json:"default_audio_edition_id"`
+	DefaultEbookEditionID  *int               `json:"default_ebook_edition_id"`
+	Contributions          []hcContribution   `json:"contributions"`
+	AuthorNames            []string           `json:"author_names"`
+	FeaturedSeries         *hcFeaturedSeries  `json:"featured_series"`
+	FeaturedSeriesID       *int               `json:"featured_series_id"`
+	FeaturedSeriesPosition any                `json:"featured_series_position"`
+	SeriesRefs             []models.SeriesRef `json:"-"`
+}
+
+// hcFeaturedSeries captures the Hardcover GraphQL `featured_series` relation
+// on a book — the primary series the book belongs to. Used to hydrate
+// SeriesRefs for list/shelf books, which would otherwise lose their series
+// association at import time.
+type hcFeaturedSeries struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
 }
 
 type hcEdition struct {
@@ -963,6 +975,34 @@ func searchBool(value any) bool {
 	}
 }
 
+// featuredSeriesRefs builds SeriesRefs from the GraphQL featured_series fields
+// on a book. Mirrors searchSeriesRefs (Typesense) so list/shelf imports get
+// the same primary-series linking the search path already provides.
+func featuredSeriesRefs(series *hcFeaturedSeries, idValue *int, positionValue any) []models.SeriesRef {
+	var (
+		title string
+		id    string
+	)
+	if series != nil {
+		title = strings.TrimSpace(series.Name)
+		if series.ID > 0 {
+			id = strconv.Itoa(series.ID)
+		}
+	}
+	if id == "" && idValue != nil && *idValue > 0 {
+		id = strconv.Itoa(*idValue)
+	}
+	if title == "" || id == "" {
+		return nil
+	}
+	return []models.SeriesRef{{
+		ForeignID: seriesIDPrefix + id,
+		Title:     title,
+		Position:  formatSeriesPosition(positionValue),
+		Primary:   true,
+	}}
+}
+
 func searchSeriesRefs(seriesValue, idValue, positionValue any) []models.SeriesRef {
 	title, id := searchFeaturedSeries(seriesValue)
 	if id == "" {
@@ -1066,6 +1106,10 @@ func (c *Client) toBook(b hcBook) models.Book {
 	if slug == "" {
 		slug = fmt.Sprintf("%d", b.ID)
 	}
+	seriesRefs := b.SeriesRefs
+	if len(seriesRefs) == 0 {
+		seriesRefs = featuredSeriesRefs(b.FeaturedSeries, b.FeaturedSeriesID, b.FeaturedSeriesPosition)
+	}
 	bk := models.Book{
 		ForeignID:        idPrefix + slug,
 		Title:            b.Title,
@@ -1078,7 +1122,7 @@ func (c *Client) toBook(b hcBook) models.Book {
 		Status:           models.BookStatusWanted,
 		Genres:           []string{},
 		ISBNs:            b.ISBNs,
-		SeriesRefs:       b.SeriesRefs,
+		SeriesRefs:       seriesRefs,
 	}
 	if len(b.Genres) > 0 {
 		bk.Genres = b.Genres

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -2041,6 +2041,105 @@ func TestGetListBooks_PositiveIDPaginates(t *testing.T) {
 	}
 }
 
+// TestGetListBooks_PositiveIDPopulatesSeriesRefs covers issue #805: the
+// list_books GraphQL query now asks for featured_series and the parsed book
+// carries those forward as SeriesRefs so the list syncer can persist them.
+func TestGetListBooks_PositiveIDPopulatesSeriesRefs(t *testing.T) {
+	var gotQuery string
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		var req gqlRequest
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		gotQuery = req.Query
+		resp := `{"data":{"list_books":[{"book":{"id":99,"title":"Dune","slug":"dune","featured_series":{"id":17,"name":"Dune Chronicles"},"featured_series_id":17,"featured_series_position":1,"contributions":[{"author":{"id":1,"name":"Frank Herbert","slug":"frank-herbert"}}]}}]}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(resp)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	c = c.WithToken("hc-token")
+
+	books, err := c.GetListBooks(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("GetListBooks: %v", err)
+	}
+	if !strings.Contains(gotQuery, "featured_series { id name }") {
+		t.Errorf("query missing featured_series selection: %q", gotQuery)
+	}
+	if !strings.Contains(gotQuery, "featured_series_position") {
+		t.Errorf("query missing featured_series_position: %q", gotQuery)
+	}
+	if len(books) != 1 {
+		t.Fatalf("books len = %d, want 1", len(books))
+	}
+	if len(books[0].SeriesRefs) != 1 {
+		t.Fatalf("SeriesRefs len = %d, want 1: %+v", len(books[0].SeriesRefs), books[0].SeriesRefs)
+	}
+	ref := books[0].SeriesRefs[0]
+	if ref.ForeignID != "hc-series:17" || ref.Title != "Dune Chronicles" || ref.Position != "1" || !ref.Primary {
+		t.Errorf("SeriesRef = %+v, want hc-series:17/Dune Chronicles/1/primary", ref)
+	}
+}
+
+// TestGetListBooks_BuiltinShelfPopulatesSeriesRefs mirrors the above for the
+// shelf code path (negative listIDs use the me.user_books query).
+func TestGetListBooks_BuiltinShelfPopulatesSeriesRefs(t *testing.T) {
+	var gotQuery string
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		var req gqlRequest
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		gotQuery = req.Query
+		resp := `{"data":{"me":[{"user_books":[{"book":{"id":99,"title":"The Way of Kings","slug":"the-way-of-kings","featured_series":{"id":103,"name":"The Stormlight Archive"},"featured_series_id":103,"featured_series_position":1,"contributions":[{"author":{"id":2,"name":"Brandon Sanderson","slug":"brandon-sanderson"}}]}}]}]}}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(resp)),
+			Header:     make(http.Header),
+		}, nil
+	})
+	c = c.WithToken("hc-token")
+
+	books, err := c.GetListBooks(context.Background(), -1)
+	if err != nil {
+		t.Fatalf("GetListBooks shelf: %v", err)
+	}
+	if !strings.Contains(gotQuery, "featured_series { id name }") {
+		t.Errorf("shelf query missing featured_series selection: %q", gotQuery)
+	}
+	if len(books) != 1 || len(books[0].SeriesRefs) != 1 {
+		t.Fatalf("books = %+v", books)
+	}
+	ref := books[0].SeriesRefs[0]
+	if ref.ForeignID != "hc-series:103" || ref.Title != "The Stormlight Archive" || ref.Position != "1" || !ref.Primary {
+		t.Errorf("shelf SeriesRef = %+v", ref)
+	}
+}
+
+// TestFeaturedSeriesRefs_FallbackAndEdgeCases exercises featuredSeriesRefs
+// directly so the conversion rules don't drift silently.
+func TestFeaturedSeriesRefs_FallbackAndEdgeCases(t *testing.T) {
+	// Title from relation, id falls back to scalar featured_series_id.
+	scalarID := 55
+	refs := featuredSeriesRefs(&hcFeaturedSeries{ID: 0, Name: "Foundation"}, &scalarID, 2)
+	if len(refs) != 1 || refs[0].ForeignID != "hc-series:55" || refs[0].Title != "Foundation" || refs[0].Position != "2" {
+		t.Errorf("scalar id fallback: %+v", refs)
+	}
+
+	// Missing id everywhere → drop the ref (we cannot link without a stable
+	// foreign id).
+	if got := featuredSeriesRefs(&hcFeaturedSeries{Name: "Anon"}, nil, nil); got != nil {
+		t.Errorf("missing id should drop ref, got %+v", got)
+	}
+
+	// Nil relation, but scalar id alone (no title) → drop: a series with no
+	// name is unusable upstream.
+	zero := 0
+	if got := featuredSeriesRefs(nil, &zero, nil); got != nil {
+		t.Errorf("zero id should drop ref, got %+v", got)
+	}
+}
+
 func TestHcShelfStatusID(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/metadata/hardcover/lists.go
+++ b/internal/metadata/hardcover/lists.go
@@ -239,6 +239,9 @@ func (c *Client) GetListBooks(ctx context.Context, listID int) ([]models.Book, e
 				rating
 				default_audio_edition_id
 				default_ebook_edition_id
+				featured_series { id name }
+				featured_series_id
+				featured_series_position
 				contributions {
 					author { id name slug }
 				}
@@ -292,6 +295,9 @@ func (c *Client) getShelfBooks(ctx context.Context, statusID int) ([]models.Book
 					rating
 					default_audio_edition_id
 					default_ebook_edition_id
+					featured_series { id name }
+					featured_series_id
+					featured_series_position
 					contributions {
 						author { id name slug }
 					}


### PR DESCRIPTION
## Summary

Hardcover list sync was throwing away series associations at exactly the point Bindery had a confident match. `GetListBooks` and `getShelfBooks` asked for everything except the primary series, `SeriesRefs` landed empty, and the syncer's only series-linking code path was never reached — so books showed up unlinked even when Hardcover knew the series.

## Changes

- **GraphQL queries** (`internal/metadata/hardcover/lists.go`): both `list_books` and `me.user_books` now request `featured_series { id name }`, `featured_series_id`, and `featured_series_position`. Same fields the search path has been using.
- **Book parsing** (`internal/metadata/hardcover/client.go`): added `hcFeaturedSeries` + `featuredSeriesRefs()` helper. `toBook` uses it only when the search path hasn't already populated `SeriesRefs`, so the two paths don't fight.
- **Syncer wiring** (`internal/hardcoverlistsyncer/syncer.go`): new `WithSeriesRepo` option + a small `seriesLinker` interface (`CreateOrGet`, `LinkBook`) so tests don't have to stand up the full repo. `linkSeriesRefs` runs after each book create — best-effort, errors are logged and the book import keeps moving. Matches the pattern used in `handleNewWantedBook` and `cmd/bindery/reconcile.go`.
- **main.go**: pass the existing `seriesRepo` into `hardcoverlistsyncer.New`.

## Tests

- `TestGetListBooks_PositiveIDPopulatesSeriesRefs` / `TestGetListBooks_BuiltinShelfPopulatesSeriesRefs`: assert the new GraphQL fields are in the outbound query and that `book.SeriesRefs` comes back populated for both code paths.
- `TestFeaturedSeriesRefs_FallbackAndEdgeCases`: covers the relation-or-scalar-id fallback and the drop-on-missing-id rule.
- `TestSyncOne_LinksSeriesRefsAfterBookImport`: end-to-end against an in-memory DB — book gets imported, series gets created, link exists.
- `TestSyncOne_SeriesLinkErrorDoesNotBlockImport`: stub repo that always errors; book still lands.
- `TestSyncOne_NoSeriesRepo_NoSeriesLinkAttempted`: regression guard for the nil-repo case (default constructor).

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] `go test ./cmd/... ./internal/...` all green
- [ ] No frontend changes — skipping web build

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)