### PR TITLE
feat(authors): per-series monitor mode (#810)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -658,6 +658,7 @@ func main() {
 		r.Delete("/author/{id}", authorHandler.Delete)
 		r.Post("/author/{id}/refresh", authorHandler.Refresh)
 		r.Post("/author/{id}/relink-upstream", authorHandler.RelinkUpstream)
+		r.Get("/author/{id}/series", authorHandler.ListSeries)
 		r.Get("/author/{id}/aliases", authorAliasHandler.List)
 		r.Delete("/author/{id}/aliases/{aliasID}", authorAliasHandler.Delete)
 		r.Post("/author/{id}/merge", authorAliasHandler.Merge)

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -105,9 +105,40 @@ func (h *AuthorHandler) Get(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Attach the per-author monitored-series pin set when applicable. The
+	// field is omitempty so non-series modes don't bloat the payload, but the
+	// edit modal still needs the existing selection to preselect chips.
+	if author.MonitorMode == models.AuthorMonitorModeSeries {
+		if ids, err := h.authors.ListMonitoredSeriesIDs(r.Context(), id); err == nil {
+			author.MonitoredSeriesIDs = ids
+		}
+	}
+
 	proxyAuthorImages(author)
 	cleanAuthorDescription(author)
 	writeJSON(w, http.StatusOK, author)
+}
+
+// ListSeries returns the series belonging to the author — i.e. the series
+// that any of the author's books are linked to. Backs the monitor-by-series
+// picker (#810) so the edit modal can render a checkbox list scoped to this
+// author rather than the global /series collection.
+func (h *AuthorHandler) ListSeries(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		return
+	}
+	if h.series == nil {
+		writeJSON(w, http.StatusOK, []models.Series{})
+		return
+	}
+	series, err := h.series.ListByAuthor(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, series)
 }
 
 func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
@@ -557,6 +588,11 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 		// the UI sends this flag when the user picks the default option.
 		ClearAudiobookRootFolder   bool `json:"clearAudiobookRootFolder"`
 		ApplyMonitorModeToExisting bool `json:"applyMonitorModeToExisting"`
+		// MonitoredSeriesIDs is the per-author series pin set (#810). Only
+		// meaningful when MonitorMode == "series". A nil pointer means "do
+		// not touch the existing selection" — an explicit empty array clears
+		// it. Validated against the author's own series before persistence.
+		MonitoredSeriesIDs *[]int64 `json:"monitoredSeriesIds"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -568,7 +604,7 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.MonitorMode != nil {
 		mode := strings.TrimSpace(*req.MonitorMode)
 		if !models.IsAuthorMonitorModeValid(mode) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "monitorMode must be one of: all, future, latest, none"})
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "monitorMode must be one of: all, future, latest, none, series"})
 			return
 		}
 		author.MonitorMode = mode
@@ -599,6 +635,42 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+
+	// Persist the per-author series pin set before applying so the apply pass
+	// reads the freshly-written rows. Validate every ID belongs to this
+	// author's series — accepting arbitrary series IDs would let one author's
+	// monitor selection silently reference an unrelated catalog row.
+	if req.MonitoredSeriesIDs != nil {
+		if len(*req.MonitoredSeriesIDs) > 0 {
+			ownSeries, err := h.series.ListByAuthor(r.Context(), author.ID)
+			if err != nil {
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				return
+			}
+			owned := make(map[int64]struct{}, len(ownSeries))
+			for _, s := range ownSeries {
+				owned[s.ID] = struct{}{}
+			}
+			for _, id := range *req.MonitoredSeriesIDs {
+				if _, ok := owned[id]; !ok {
+					writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("series %d does not belong to author %d", id, author.ID)})
+					return
+				}
+			}
+		}
+		if err := h.authors.SetMonitoredSeriesIDs(r.Context(), author.ID, *req.MonitoredSeriesIDs); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		author.MonitoredSeriesIDs = append([]int64(nil), (*req.MonitoredSeriesIDs)...)
+	} else if author.MonitorMode == models.AuthorMonitorModeSeries {
+		// Mode unchanged or set without overriding the pin set: surface the
+		// current selection so the client can render chips without a refetch.
+		if ids, err := h.authors.ListMonitoredSeriesIDs(r.Context(), author.ID); err == nil {
+			author.MonitoredSeriesIDs = ids
+		}
+	}
+
 	if req.ApplyMonitorModeToExisting {
 		if err := h.applyMonitorModeToExistingBooks(r.Context(), author); err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -616,9 +688,38 @@ func (h *AuthorHandler) applyMonitorModeToExistingBooks(ctx context.Context, aut
 	latestKeys := latestBookMonitorKeys(books, author.MonitorLatestCount, func(b models.Book) bool {
 		return !b.Excluded
 	})
+
+	// For series mode the decision needs book→series membership. Bulk-load
+	// once to avoid an N+1 over GetSeriesIDsForBook in the loop below.
+	var (
+		monitoredSet map[int64]struct{}
+		bookSeries   map[int64][]int64
+	)
+	if author.MonitorMode == models.AuthorMonitorModeSeries {
+		ids, err := h.authors.ListMonitoredSeriesIDs(ctx, author.ID)
+		if err != nil {
+			return fmt.Errorf("list monitored series ids: %w", err)
+		}
+		monitoredSet = make(map[int64]struct{}, len(ids))
+		for _, id := range ids {
+			monitoredSet[id] = struct{}{}
+		}
+		if h.series != nil {
+			bookSeries, err = h.series.ListBookSeriesByAuthor(ctx, author.ID)
+			if err != nil {
+				return fmt.Errorf("list book→series for author: %w", err)
+			}
+		}
+	}
+
 	today := dateOnly(time.Now().UTC())
 	for i := range books {
 		next := shouldMonitorBookForAuthor(author, books[i], latestKeys, today)
+		if author.MonitorMode == models.AuthorMonitorModeSeries {
+			next = bookInMonitoredSeries(books[i].ID, bookSeries, monitoredSet)
+		}
+		// Excluded wins over every mode — a user-excluded book must never
+		// flip back to monitored regardless of series membership.
 		if books[i].Excluded {
 			next = false
 		}
@@ -631,6 +732,22 @@ func (h *AuthorHandler) applyMonitorModeToExistingBooks(ctx context.Context, aut
 		}
 	}
 	return nil
+}
+
+// bookInMonitoredSeries reports whether the book belongs to at least one
+// series in the author's monitored set. An empty monitored set means "monitor
+// nothing" — which is the right default when the user picks series mode
+// without selecting any series yet.
+func bookInMonitoredSeries(bookID int64, bookSeries map[int64][]int64, monitoredSet map[int64]struct{}) bool {
+	if len(monitoredSet) == 0 {
+		return false
+	}
+	for _, sid := range bookSeries[bookID] {
+		if _, ok := monitoredSet[sid]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *AuthorHandler) RelinkUpstream(w http.ResponseWriter, r *http.Request) {
@@ -933,6 +1050,34 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 	})
 	today := dateOnly(time.Now().UTC())
 
+	// Build a foreign-id index of the author's monitored series so that, in
+	// series mode, freshly-discovered books can be flipped to monitored at
+	// creation time if their provider-supplied SeriesRefs already match one
+	// of the pinned series. Without this lookup the user would have to wait
+	// for a subsequent apply pass to flip them on.
+	monitoredSeriesForeignIDs := map[string]struct{}{}
+	if author.MonitorMode == models.AuthorMonitorModeSeries && h.series != nil {
+		pinIDs, err := h.authors.ListMonitoredSeriesIDs(ctx, author.ID)
+		if err != nil {
+			slog.Warn("failed to load monitored series ids for author works fetch", "author", author.Name, "error", err)
+		} else if len(pinIDs) > 0 {
+			ownSeries, err := h.series.ListByAuthor(ctx, author.ID)
+			if err != nil {
+				slog.Warn("failed to load author series for series-mode fetch", "author", author.Name, "error", err)
+			} else {
+				pinSet := make(map[int64]struct{}, len(pinIDs))
+				for _, id := range pinIDs {
+					pinSet[id] = struct{}{}
+				}
+				for _, s := range ownSeries {
+					if _, ok := pinSet[s.ID]; ok && s.ForeignID != "" {
+						monitoredSeriesForeignIDs[s.ForeignID] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+
 	searchQueue := make([]models.Book, 0)
 	autoSearchEnabled := autoSearch && h.searcher != nil && author.Monitored && h.isAutoGrabEnabled(ctx)
 
@@ -968,6 +1113,17 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 			continue
 		}
 		b.Monitored = shouldMonitorBookForAuthor(author, b, latestKeys, today)
+		// Series mode short-circuit: if the upstream provider already says
+		// this book is in one of the user's pinned series, monitor it on
+		// first discovery instead of waiting for the apply pass.
+		if author.MonitorMode == models.AuthorMonitorModeSeries && author.Monitored && len(monitoredSeriesForeignIDs) > 0 {
+			for _, ref := range b.SeriesRefs {
+				if _, ok := monitoredSeriesForeignIDs[ref.ForeignID]; ok {
+					b.Monitored = true
+					break
+				}
+			}
+		}
 
 		// Update ratings on existing books so the recommender has data to work with,
 		// then skip further processing (we don't want to overwrite user state like status).
@@ -1141,6 +1297,13 @@ func shouldMonitorBookForAuthor(author *models.Author, book models.Book, latestK
 		_, ok := latestKeys[indexer.NormalizeTitleForDedup(book.Title)]
 		return ok
 	case models.AuthorMonitorModeNone:
+		return false
+	case models.AuthorMonitorModeSeries:
+		// Newly-discovered books default to unmonitored under series mode:
+		// the series-membership join is established by the series sync
+		// later, so we don't yet know which series this book belongs to.
+		// A subsequent ApplyMonitorModeToExisting (manual or scheduled
+		// refresh) flips the flag on once the join row exists.
 		return false
 	case models.AuthorMonitorModeAll, "":
 		return true

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -1052,6 +1052,246 @@ func TestUpdateAuthor_ApplyMonitorModeToExistingBooks(t *testing.T) {
 	}
 }
 
+// TestUpdateAuthor_ApplyMonitorModeSeries covers the per-series monitor mode
+// (#810): selected series → monitored, others → unmonitored, excluded books
+// stay unmonitored regardless of series membership.
+func TestUpdateAuthor_ApplyMonitorModeSeries(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	seriesRepo := db.NewSeriesRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+
+	author := &models.Author{
+		ForeignID: "OL-S-A", Name: "Series Author", SortName: "Author, Series",
+		MetadataProvider: "openlibrary", Monitored: true, MonitorMode: models.AuthorMonitorModeAll,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	// 5 books: 3 in series A, 1 in series B, 1 standalone.
+	mk := func(fid, title string) *models.Book {
+		return &models.Book{
+			ForeignID: fid, AuthorID: author.ID, Title: title, SortTitle: title,
+			Status: models.BookStatusWanted, Monitored: true, Genres: []string{}, MetadataProvider: "openlibrary",
+		}
+	}
+	a1, a2, a3 := mk("OL-A1", "A1"), mk("OL-A2", "A2"), mk("OL-A3", "A3")
+	b1 := mk("OL-B1", "B1")
+	solo := mk("OL-SOLO", "Solo")
+	for _, b := range []*models.Book{a1, a2, a3, b1, solo} {
+		if err := bookRepo.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Exclude one of the A-series books — it must stay unmonitored even
+	// though the user picks series A.
+	if err := bookRepo.SetExcluded(ctx, a3.ID, true); err != nil {
+		t.Fatal(err)
+	}
+
+	sA := &models.Series{ForeignID: "ol-series:A", Title: "A"}
+	sB := &models.Series{ForeignID: "ol-series:B", Title: "B"}
+	if err := seriesRepo.CreateOrGet(ctx, sA); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.CreateOrGet(ctx, sB); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []int64{a1.ID, a2.ID, a3.ID} {
+		if err := seriesRepo.LinkBook(ctx, sA.ID, id, "", true); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := seriesRepo.LinkBook(ctx, sB.ID, b1.ID, "", true); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, seriesRepo, nil, nil, profileRepo, nil)
+	body, _ := json.Marshal(map[string]any{
+		"monitorMode":                models.AuthorMonitorModeSeries,
+		"monitoredSeriesIds":         []int64{sA.ID},
+		"applyMonitorModeToExisting": true,
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/author/"+strconv.FormatInt(author.ID, 10), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(author.ID, 10))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	h.Update(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got, err := bookRepo.ListByAuthorIncludingExcluded(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byTitle := map[string]bool{}
+	for _, b := range got {
+		byTitle[b.Title] = b.Monitored
+	}
+	want := map[string]bool{
+		"A1":   true,  // in selected series
+		"A2":   true,  // in selected series
+		"A3":   false, // excluded — wins over series membership
+		"B1":   false, // series B not selected
+		"Solo": false, // no series at all
+	}
+	for title, wantMon := range want {
+		if byTitle[title] != wantMon {
+			t.Errorf("%s monitored = %v, want %v", title, byTitle[title], wantMon)
+		}
+	}
+
+	// Verify the response carries the pinned series IDs back.
+	var respAuthor models.Author
+	if err := json.Unmarshal(rec.Body.Bytes(), &respAuthor); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(respAuthor.MonitoredSeriesIDs) != 1 || respAuthor.MonitoredSeriesIDs[0] != sA.ID {
+		t.Errorf("response MonitoredSeriesIDs = %v, want [%d]", respAuthor.MonitoredSeriesIDs, sA.ID)
+	}
+}
+
+// TestUpdateAuthor_RejectsForeignSeriesID covers the validation that a
+// monitored series id must belong to the author. Accepting any id would let
+// one author's pin set reference an unrelated catalog row.
+func TestUpdateAuthor_RejectsForeignSeriesID(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	seriesRepo := db.NewSeriesRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+
+	owner := &models.Author{ForeignID: "OL-OWN", Name: "Owner", SortName: "Owner", MetadataProvider: "openlibrary", Monitored: true}
+	other := &models.Author{ForeignID: "OL-OTH", Name: "Other", SortName: "Other", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authorRepo.Create(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+	if err := authorRepo.Create(ctx, other); err != nil {
+		t.Fatal(err)
+	}
+
+	ownerBook := &models.Book{ForeignID: "OL-OB", AuthorID: owner.ID, Title: "OB", SortTitle: "ob", Status: models.BookStatusWanted, Monitored: true, Genres: []string{}, MetadataProvider: "openlibrary"}
+	otherBook := &models.Book{ForeignID: "OL-XB", AuthorID: other.ID, Title: "XB", SortTitle: "xb", Status: models.BookStatusWanted, Monitored: true, Genres: []string{}, MetadataProvider: "openlibrary"}
+	if err := bookRepo.Create(ctx, ownerBook); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.Create(ctx, otherBook); err != nil {
+		t.Fatal(err)
+	}
+
+	ownerSeries := &models.Series{ForeignID: "ol-series:own", Title: "Own"}
+	foreignSeries := &models.Series{ForeignID: "ol-series:foreign", Title: "Foreign"}
+	if err := seriesRepo.CreateOrGet(ctx, ownerSeries); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.CreateOrGet(ctx, foreignSeries); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, ownerSeries.ID, ownerBook.ID, "", true); err != nil {
+		t.Fatal(err)
+	}
+	// foreignSeries is linked only to other author's book.
+	if err := seriesRepo.LinkBook(ctx, foreignSeries.ID, otherBook.ID, "", true); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, seriesRepo, nil, nil, profileRepo, nil)
+	body, _ := json.Marshal(map[string]any{
+		"monitorMode":        models.AuthorMonitorModeSeries,
+		"monitoredSeriesIds": []int64{foreignSeries.ID},
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/author/"+strconv.FormatInt(owner.ID, 10), bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(owner.ID, 10))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	h.Update(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for foreign series id, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Nothing should have been persisted.
+	got, _ := authorRepo.ListMonitoredSeriesIDs(ctx, owner.ID)
+	if len(got) != 0 {
+		t.Errorf("expected empty pin set after rejection, got %v", got)
+	}
+}
+
+// TestListAuthorSeries returns only series the author actually has books in.
+func TestListAuthorSeries(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	seriesRepo := db.NewSeriesRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+
+	a := &models.Author{ForeignID: "OL-LS", Name: "LS", SortName: "LS", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authorRepo.Create(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{ForeignID: "OL-LS-B", AuthorID: a.ID, Title: "T", SortTitle: "t", Status: models.BookStatusWanted, Monitored: true, Genres: []string{}, MetadataProvider: "openlibrary"}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	s := &models.Series{ForeignID: "ol-series:t", Title: "T-Series"}
+	if err := seriesRepo.CreateOrGet(ctx, s); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, s.ID, book.ID, "", true); err != nil {
+		t.Fatal(err)
+	}
+	// A second unlinked series exists globally — must not appear in the
+	// per-author response.
+	noise := &models.Series{ForeignID: "ol-series:noise", Title: "Noise"}
+	if err := seriesRepo.CreateOrGet(ctx, noise); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, seriesRepo, nil, nil, profileRepo, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/author/"+strconv.FormatInt(a.ID, 10)+"/series", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(a.ID, 10))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+
+	h.ListSeries(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	var got []models.Series
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != s.ID {
+		t.Fatalf("got %d series, want only the linked one (id %d): %+v", len(got), s.ID, got)
+	}
+}
+
 func TestCreateAuthor_RelinksExistingABSAuthor(t *testing.T) {
 	database, err := db.OpenMemory()
 	if err != nil {

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -289,8 +289,11 @@ func validateSettingValue(key, value string) error {
 		if value == "" {
 			return nil
 		}
-		if !models.IsAuthorMonitorModeValid(value) {
-			return fmt.Errorf("author.default_monitor_mode %q is not one of: all, future, latest, none", value)
+		// "series" is per-author by definition (#810) — there is no
+		// install-wide series selection that would make sense, so reject it
+		// here even though IsAuthorMonitorModeValid accepts it.
+		if !models.IsAuthorMonitorModeValidAsGlobalDefault(value) {
+			return fmt.Errorf("author.default_monitor_mode %q is not one of: all, future, latest, none (series is per-author only)", value)
 		}
 	case SettingAuthorDefaultMonitorLatestCount:
 		if value == "" {

--- a/internal/api/settings_handler_test.go
+++ b/internal/api/settings_handler_test.go
@@ -220,6 +220,16 @@ func TestSettings_AuthorMonitorDefaultsValidation(t *testing.T) {
 	if badCountRec.Code != http.StatusBadRequest {
 		t.Fatalf("expected invalid count 400, got %d", badCountRec.Code)
 	}
+
+	// "series" is a per-author mode only — rejecting it as a global default
+	// prevents an install from booting every new author into a mode that has
+	// no global selection (#810).
+	seriesReq := withKey(httptest.NewRequest(http.MethodPut, "/api/v1/settings/"+SettingAuthorDefaultMonitorMode, bytes.NewBufferString(`{"value":"series"}`)), SettingAuthorDefaultMonitorMode)
+	seriesRec := httptest.NewRecorder()
+	h.Set(seriesRec, seriesReq)
+	if seriesRec.Code != http.StatusBadRequest {
+		t.Fatalf("expected series-as-default 400, got %d: %s", seriesRec.Code, seriesRec.Body.String())
+	}
 }
 
 func TestSettings_GetABSSecretReturns404(t *testing.T) {

--- a/internal/db/author_monitored_series_test.go
+++ b/internal/db/author_monitored_series_test.go
@@ -1,0 +1,265 @@
+package db
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestAuthorMonitoredSeriesRoundTrip(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OL-A1", Name: "Frank Herbert", SortName: "Herbert, Frank",
+		MetadataProvider: "openlibrary", Monitored: true, MonitorMode: models.AuthorMonitorModeSeries,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatalf("create author: %v", err)
+	}
+
+	s1 := &models.Series{ForeignID: "ol-series:dune", Title: "Dune"}
+	s2 := &models.Series{ForeignID: "ol-series:dosadi", Title: "ConSentiency"}
+	if err := seriesRepo.CreateOrGet(ctx, s1); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.CreateOrGet(ctx, s2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty by default — returns [] not nil.
+	got, err := authorRepo.ListMonitoredSeriesIDs(ctx, author.ID)
+	if err != nil {
+		t.Fatalf("list empty: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected non-nil empty slice")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 ids, got %v", got)
+	}
+
+	// Set two.
+	if err := authorRepo.SetMonitoredSeriesIDs(ctx, author.ID, []int64{s1.ID, s2.ID}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, _ = authorRepo.ListMonitoredSeriesIDs(ctx, author.ID)
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+	want := []int64{s1.ID, s2.ID}
+	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("after set: got %v want %v", got, want)
+	}
+
+	// Replace selection — old rows must be gone.
+	if err := authorRepo.SetMonitoredSeriesIDs(ctx, author.ID, []int64{s1.ID}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	got, _ = authorRepo.ListMonitoredSeriesIDs(ctx, author.ID)
+	if len(got) != 1 || got[0] != s1.ID {
+		t.Fatalf("after replace: got %v want [%d]", got, s1.ID)
+	}
+
+	// Duplicates in input are deduped.
+	if err := authorRepo.SetMonitoredSeriesIDs(ctx, author.ID, []int64{s2.ID, s2.ID, s2.ID}); err != nil {
+		t.Fatalf("dup: %v", err)
+	}
+	got, _ = authorRepo.ListMonitoredSeriesIDs(ctx, author.ID)
+	if len(got) != 1 || got[0] != s2.ID {
+		t.Fatalf("after dedup: got %v want [%d]", got, s2.ID)
+	}
+
+	// Clear.
+	if err := authorRepo.SetMonitoredSeriesIDs(ctx, author.ID, nil); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	got, _ = authorRepo.ListMonitoredSeriesIDs(ctx, author.ID)
+	if len(got) != 0 {
+		t.Fatalf("after clear: got %v", got)
+	}
+}
+
+func TestAuthorMonitoredSeriesCascadesOnDelete(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	author := &models.Author{ForeignID: "OL-A2", Name: "A", SortName: "A", MetadataProvider: "openlibrary"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	s := &models.Series{ForeignID: "ol-series:x", Title: "X"}
+	if err := seriesRepo.CreateOrGet(ctx, s); err != nil {
+		t.Fatal(err)
+	}
+	if err := authorRepo.SetMonitoredSeriesIDs(ctx, author.ID, []int64{s.ID}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Deleting the series should drop the join row via FK CASCADE — and
+	// listing for the author should now be empty without erroring.
+	if err := seriesRepo.Delete(ctx, s.ID); err != nil {
+		t.Fatalf("delete series: %v", err)
+	}
+	got, err := authorRepo.ListMonitoredSeriesIDs(ctx, author.ID)
+	if err != nil {
+		t.Fatalf("list after series delete: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected cascade to clear join row, got %v", got)
+	}
+
+	// Re-seed and verify the author-side cascade too.
+	if err := seriesRepo.CreateOrGet(ctx, s); err != nil {
+		t.Fatal(err)
+	}
+	if err := authorRepo.SetMonitoredSeriesIDs(ctx, author.ID, []int64{s.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := authorRepo.Delete(ctx, author.ID); err != nil {
+		t.Fatalf("delete author: %v", err)
+	}
+	// The join row should be gone. Easiest cross-check: re-creating the
+	// author and listing returns nothing.
+	author2 := &models.Author{ForeignID: "OL-A2", Name: "A", SortName: "A", MetadataProvider: "openlibrary"}
+	if err := authorRepo.Create(ctx, author2); err != nil {
+		t.Fatal(err)
+	}
+	got2, _ := authorRepo.ListMonitoredSeriesIDs(ctx, author2.ID)
+	if len(got2) != 0 {
+		t.Fatalf("expected empty after author delete cascade, got %v", got2)
+	}
+}
+
+func TestListBookSeriesByAuthor(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	author := &models.Author{ForeignID: "OL-AX", Name: "X", SortName: "X", MetadataProvider: "openlibrary"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	b1 := &models.Book{ForeignID: "OL-W1", AuthorID: author.ID, Title: "B1", SortTitle: "B1", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"}
+	b2 := &models.Book{ForeignID: "OL-W2", AuthorID: author.ID, Title: "B2", SortTitle: "B2", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"}
+	b3 := &models.Book{ForeignID: "OL-W3", AuthorID: author.ID, Title: "B3", SortTitle: "B3", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"}
+	for _, b := range []*models.Book{b1, b2, b3} {
+		if err := bookRepo.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sA := &models.Series{ForeignID: "ol-series:A", Title: "A"}
+	sB := &models.Series{ForeignID: "ol-series:B", Title: "B"}
+	if err := seriesRepo.CreateOrGet(ctx, sA); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.CreateOrGet(ctx, sB); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, sA.ID, b1.ID, "1", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, sA.ID, b2.ID, "2", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.LinkBook(ctx, sB.ID, b2.ID, "1", false); err != nil {
+		t.Fatal(err)
+	}
+	// b3 is standalone.
+
+	got, err := seriesRepo.ListBookSeriesByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got[b1.ID]) != 1 || got[b1.ID][0] != sA.ID {
+		t.Errorf("b1: want [sA], got %v", got[b1.ID])
+	}
+	if len(got[b2.ID]) != 2 {
+		t.Errorf("b2: want 2 series, got %v", got[b2.ID])
+	}
+	if len(got[b3.ID]) != 0 {
+		t.Errorf("b3 should not be in map, got %v", got[b3.ID])
+	}
+}
+
+func TestSeriesListByAuthor(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	seriesRepo := NewSeriesRepo(database)
+
+	a1 := &models.Author{ForeignID: "OL-1", Name: "Author One", SortName: "One, Author", MetadataProvider: "openlibrary"}
+	a2 := &models.Author{ForeignID: "OL-2", Name: "Author Two", SortName: "Two, Author", MetadataProvider: "openlibrary"}
+	if err := authorRepo.Create(ctx, a1); err != nil {
+		t.Fatal(err)
+	}
+	if err := authorRepo.Create(ctx, a2); err != nil {
+		t.Fatal(err)
+	}
+
+	b1 := &models.Book{ForeignID: "OL-B1", AuthorID: a1.ID, Title: "X", SortTitle: "X", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"}
+	b2 := &models.Book{ForeignID: "OL-B2", AuthorID: a2.ID, Title: "Y", SortTitle: "Y", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"}
+	if err := bookRepo.Create(ctx, b1); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.Create(ctx, b2); err != nil {
+		t.Fatal(err)
+	}
+
+	sA := &models.Series{ForeignID: "ol-series:a1", Title: "A1"}
+	sB := &models.Series{ForeignID: "ol-series:a2", Title: "A2"}
+	if err := seriesRepo.CreateOrGet(ctx, sA); err != nil {
+		t.Fatal(err)
+	}
+	if err := seriesRepo.CreateOrGet(ctx, sB); err != nil {
+		t.Fatal(err)
+	}
+	_ = seriesRepo.LinkBook(ctx, sA.ID, b1.ID, "1", true)
+	_ = seriesRepo.LinkBook(ctx, sB.ID, b2.ID, "1", true)
+
+	got, err := seriesRepo.ListByAuthor(ctx, a1.ID)
+	if err != nil {
+		t.Fatalf("list by author: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != sA.ID {
+		t.Fatalf("a1: want [sA], got %v", got)
+	}
+
+	got2, err := seriesRepo.ListByAuthor(ctx, a2.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got2) != 1 || got2[0].ID != sB.ID {
+		t.Fatalf("a2: want [sB], got %v", got2)
+	}
+}

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -253,6 +253,70 @@ func (r *AuthorRepo) Delete(ctx context.Context, id int64) error {
 	return nil
 }
 
+// ListMonitoredSeriesIDs returns the series IDs the author is pinned to when
+// MonitorMode == AuthorMonitorModeSeries. Returns an empty slice (not nil)
+// when nothing is pinned so the JSON encoder produces `[]` rather than null,
+// which keeps the UI's chip list happy.
+func (r *AuthorRepo) ListMonitoredSeriesIDs(ctx context.Context, authorID int64) ([]int64, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT series_id FROM author_monitored_series WHERE author_id = ? ORDER BY series_id`, authorID)
+	if err != nil {
+		return nil, fmt.Errorf("list monitored series ids for author %d: %w", authorID, err)
+	}
+	defer rows.Close()
+	ids := make([]int64, 0)
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan monitored series id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// SetMonitoredSeriesIDs replaces the author's monitored-series selection
+// atomically. Passing an empty slice clears the selection. Callers must
+// validate that every ID belongs to a series the author actually has books in
+// before calling — this repo trusts its inputs.
+func (r *AuthorRepo) SetMonitoredSeriesIDs(ctx context.Context, authorID int64, seriesIDs []int64) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin set monitored series tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM author_monitored_series WHERE author_id = ?`, authorID); err != nil {
+		return fmt.Errorf("clear monitored series for author %d: %w", authorID, err)
+	}
+
+	if len(seriesIDs) > 0 {
+		now := time.Now().UTC()
+		stmt, err := tx.PrepareContext(ctx,
+			`INSERT INTO author_monitored_series (author_id, series_id, created_at) VALUES (?, ?, ?)`)
+		if err != nil {
+			return fmt.Errorf("prepare insert monitored series: %w", err)
+		}
+		defer func() { _ = stmt.Close() }()
+		// Dedupe input — callers may pass duplicates and we want a clean PK insert.
+		seen := make(map[int64]struct{}, len(seriesIDs))
+		for _, id := range seriesIDs {
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			if _, err := stmt.ExecContext(ctx, authorID, id, now); err != nil {
+				return fmt.Errorf("insert monitored series (%d, %d): %w", authorID, id, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit set monitored series: %w", err)
+	}
+	return nil
+}
+
 func scanAuthor(rows *sql.Rows) (models.Author, error) {
 	var a models.Author
 	var monitored int

--- a/internal/db/migrations/046_author_monitored_series.sql
+++ b/internal/db/migrations/046_author_monitored_series.sql
@@ -1,0 +1,18 @@
+-- +migrate Up
+-- Per-author monitored-series join (#810). Holds the subset of series the
+-- author is pinned to when authors.monitor_mode = 'series'. Kept separate
+-- from series.monitored (a global watchlist flag) so the per-author selection
+-- never silently flips series-wide state for other authors that share a
+-- series. ON DELETE CASCADE on both sides drops the row when either parent
+-- vanishes — there is no business reason to retain a dangling pin.
+CREATE TABLE author_monitored_series (
+    author_id  INTEGER NOT NULL,
+    series_id  INTEGER NOT NULL,
+    created_at DATETIME NOT NULL,
+    PRIMARY KEY (author_id, series_id),
+    FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE CASCADE,
+    FOREIGN KEY (series_id) REFERENCES series(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_author_monitored_series_author ON author_monitored_series(author_id);
+CREATE INDEX idx_author_monitored_series_series ON author_monitored_series(series_id);

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -519,6 +519,65 @@ func (r *SeriesRepo) UnlinkBook(ctx context.Context, seriesID, bookID int64) err
 	return nil
 }
 
+// ListByAuthor returns the distinct series that any of the author's books are
+// linked to. Used by the per-author monitor-by-series picker (#810) and the
+// API endpoint that backs it. Returns an empty slice (not nil) when the
+// author has no series-linked books.
+func (r *SeriesRepo) ListByAuthor(ctx context.Context, authorID int64) ([]models.Series, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT DISTINCT s.id, s.foreign_id, s.title, s.description, s.monitored, s.created_at
+		FROM series s
+		JOIN series_books sb ON sb.series_id = s.id
+		JOIN books b ON b.id = sb.book_id
+		WHERE b.author_id = ?
+		ORDER BY s.title`, authorID)
+	if err != nil {
+		return nil, fmt.Errorf("list series by author %d: %w", authorID, err)
+	}
+	defer rows.Close()
+	series := make([]models.Series, 0)
+	for rows.Next() {
+		var s models.Series
+		var monitored int
+		if err := rows.Scan(&s.ID, &s.ForeignID, &s.Title, &s.Description, &monitored, &s.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan series by author: %w", err)
+		}
+		s.Monitored = monitored == 1
+		series = append(series, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := r.hydrateHardcoverLinks(ctx, series); err != nil {
+		return nil, err
+	}
+	return series, nil
+}
+
+// ListBookSeriesByAuthor returns a map of book_id → list of series IDs the
+// book belongs to, scoped to a single author. Used by apply-monitor-mode when
+// mode=series to avoid an N+1 over GetSeriesIDsForBook (one query per book).
+func (r *SeriesRepo) ListBookSeriesByAuthor(ctx context.Context, authorID int64) (map[int64][]int64, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT b.id, sb.series_id
+		FROM books b
+		JOIN series_books sb ON sb.book_id = b.id
+		WHERE b.author_id = ?`, authorID)
+	if err != nil {
+		return nil, fmt.Errorf("list book→series for author %d: %w", authorID, err)
+	}
+	defer rows.Close()
+	out := make(map[int64][]int64)
+	for rows.Next() {
+		var bookID, seriesID int64
+		if err := rows.Scan(&bookID, &seriesID); err != nil {
+			return nil, fmt.Errorf("scan book→series: %w", err)
+		}
+		out[bookID] = append(out[bookID], seriesID)
+	}
+	return out, rows.Err()
+}
+
 // GetSeriesIDsForBook returns the IDs of every series the book currently belongs to.
 func (r *SeriesRepo) GetSeriesIDsForBook(ctx context.Context, bookID int64) ([]int64, error) {
 	rows, err := r.db.QueryContext(ctx, `SELECT series_id FROM series_books WHERE book_id = ?`, bookID)

--- a/internal/models/author.go
+++ b/internal/models/author.go
@@ -34,6 +34,10 @@ type Author struct {
 	Books      []Book        `json:"books,omitempty"`
 	Statistics *AuthorStats  `json:"statistics,omitempty"`
 	Aliases    []AuthorAlias `json:"aliases,omitempty"`
+	// MonitoredSeriesIDs is the user-selected subset of series the author is
+	// pinned to when MonitorMode == AuthorMonitorModeSeries (#810). Populated
+	// by the author Get handler so the edit modal can preselect chips.
+	MonitoredSeriesIDs []int64 `json:"monitoredSeriesIds,omitempty"`
 
 	// Transient: populated from the metadata provider during add/refresh; not stored in DB.
 	// Used to seed author_aliases so non-latin primary names get latin-script alternates.
@@ -45,6 +49,11 @@ const (
 	AuthorMonitorModeFuture = "future"
 	AuthorMonitorModeLatest = "latest"
 	AuthorMonitorModeNone   = "none"
+	// AuthorMonitorModeSeries restricts monitoring to books belonging to a
+	// user-selected subset of the author's series (#810). The selection lives
+	// in the author_monitored_series join table rather than overloading
+	// series.monitored, which is a separate global-watchlist flag.
+	AuthorMonitorModeSeries = "series"
 
 	DefaultAuthorMonitorMode        = AuthorMonitorModeAll
 	DefaultAuthorMonitorLatestCount = 1
@@ -52,11 +61,18 @@ const (
 
 func IsAuthorMonitorModeValid(mode string) bool {
 	switch mode {
-	case AuthorMonitorModeAll, AuthorMonitorModeFuture, AuthorMonitorModeLatest, AuthorMonitorModeNone:
+	case AuthorMonitorModeAll, AuthorMonitorModeFuture, AuthorMonitorModeLatest, AuthorMonitorModeNone, AuthorMonitorModeSeries:
 		return true
 	default:
 		return false
 	}
+}
+
+// IsAuthorMonitorModeValidAsGlobalDefault returns true when mode is acceptable
+// as the install-wide default. Series mode is excluded because a per-author
+// series selection has no sensible global value.
+func IsAuthorMonitorModeValidAsGlobalDefault(mode string) bool {
+	return IsAuthorMonitorModeValid(mode) && mode != AuthorMonitorModeSeries
 }
 
 type AuthorStats struct {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -262,6 +262,9 @@ export const api = {
   refreshAuthor: (id: number) => request<void>(`/author/${id}/refresh`, { method: 'POST' }),
   relinkAuthorUpstream: (id: number) => request<Author>(`/author/${id}/relink-upstream`, { method: 'POST' }),
   listAuthorAliases: (id: number) => request<AuthorAlias[]>(`/author/${id}/aliases`),
+  // listAuthorSeries returns the series the author has books in. Backs the
+  // per-author monitor-by-series picker in EditAuthorModal (#810).
+  listAuthorSeries: (id: number) => request<Series[]>(`/author/${id}/series`),
   mergeAuthors: (targetId: number, sourceId: number, overwriteDefaults = true) =>
     request<MergeAuthorsResult>(`/author/${targetId}/merge`, {
       method: 'POST',
@@ -559,6 +562,9 @@ export interface Author {
   books?: Book[]
   statistics?: { bookCount: number; availableBookCount: number; wantedBookCount: number }
   aliases?: AuthorAlias[]
+  // Populated by the author Get response when monitorMode === 'series' (#810).
+  // The Update endpoint accepts an updated array via UpdateAuthorRequest.
+  monitoredSeriesIds?: number[]
 }
 
 export interface AuthorAlias {
@@ -577,7 +583,7 @@ export interface MergeAuthorsResult {
 }
 
 export type MediaType = 'ebook' | 'audiobook' | 'both'
-export type AuthorMonitorMode = 'all' | 'future' | 'latest' | 'none'
+export type AuthorMonitorMode = 'all' | 'future' | 'latest' | 'none' | 'series'
 
 export interface BookFile {
   id: number
@@ -1145,6 +1151,10 @@ export interface UpdateAuthorRequest {
   audiobookRootFolderId?: number | null
   clearAudiobookRootFolder?: boolean
   applyMonitorModeToExisting?: boolean
+  // monitoredSeriesIds is the per-author series pin set (#810). Only valid
+  // when monitorMode === 'series'. Backend rejects ids that don't belong to
+  // this author.
+  monitoredSeriesIds?: number[]
 }
 
 export interface GrabRequest {

--- a/web/src/components/EditAuthorModal.test.tsx
+++ b/web/src/components/EditAuthorModal.test.tsx
@@ -198,8 +198,8 @@ describe('EditAuthorModal', () => {
 
   it('lazy-loads the author series picker when monitor mode is set to series', async () => {
     const series: Series[] = [
-      { id: 1, foreignSeriesId: 'ol-s:1', title: 'Stormlight Archive', description: '', monitored: false, createdAt: '', hardcoverLink: { id: 1, seriesId: 1, hardcoverSeriesId: 'hc:1', hardcoverProviderId: 'p', hardcoverTitle: 'Stormlight Archive', hardcoverAuthorName: 'Brandon Sanderson', hardcoverBookCount: 10, confidence: 1, linkedBy: 'user', linkedAt: '', createdAt: '', updatedAt: '' } },
-      { id: 2, foreignSeriesId: 'ol-s:2', title: 'Mistborn', description: '', monitored: false, createdAt: '' },
+      { id: 1, foreignSeriesId: 'ol-s:1', title: 'Stormlight Archive', description: '', monitored: false, hardcoverLink: { id: 1, seriesId: 1, hardcoverSeriesId: 'hc:1', hardcoverProviderId: 'p', hardcoverTitle: 'Stormlight Archive', hardcoverAuthorName: 'Brandon Sanderson', hardcoverBookCount: 10, confidence: 1, linkedBy: 'user', linkedAt: '', createdAt: '', updatedAt: '' } },
+      { id: 2, foreignSeriesId: 'ol-s:2', title: 'Mistborn', description: '', monitored: false },
     ]
     vi.mocked(api.listAuthorSeries).mockResolvedValue(series)
 

--- a/web/src/components/EditAuthorModal.test.tsx
+++ b/web/src/components/EditAuthorModal.test.tsx
@@ -13,12 +13,13 @@ vi.mock('../api/client', () => ({
     listQualityProfiles: vi.fn(),
     listMetadataProfiles: vi.fn(),
     listRootFolders: vi.fn(),
+    listAuthorSeries: vi.fn(),
     updateAuthor: vi.fn(),
   },
 }))
 
 import { api } from '../api/client'
-import type { Author, MetadataProfile, QualityProfile, RootFolder } from '../api/client'
+import type { Author, MetadataProfile, QualityProfile, RootFolder, Series } from '../api/client'
 
 const baseAuthor: Author = {
   id: 42,
@@ -60,6 +61,7 @@ describe('EditAuthorModal', () => {
     vi.mocked(api.listQualityProfiles).mockResolvedValue(qualityProfiles)
     vi.mocked(api.listMetadataProfiles).mockResolvedValue(metadataProfiles)
     vi.mocked(api.listRootFolders).mockResolvedValue(rootFolders)
+    vi.mocked(api.listAuthorSeries).mockResolvedValue([])
     vi.mocked(api.updateAuthor).mockImplementation(async (_id, patch) => ({
       ...baseAuthor,
       ...patch,
@@ -192,6 +194,44 @@ describe('EditAuthorModal', () => {
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
     expect(api.updateAuthor).not.toHaveBeenCalled()
     expect(onSaved).not.toHaveBeenCalled()
+  })
+
+  it('lazy-loads the author series picker when monitor mode is set to series', async () => {
+    const series: Series[] = [
+      { id: 1, foreignSeriesId: 'ol-s:1', title: 'Stormlight Archive', description: '', monitored: false, createdAt: '', hardcoverLink: { id: 1, seriesId: 1, hardcoverSeriesId: 'hc:1', hardcoverProviderId: 'p', hardcoverTitle: 'Stormlight Archive', hardcoverAuthorName: 'Brandon Sanderson', hardcoverBookCount: 10, confidence: 1, linkedBy: 'user', linkedAt: '', createdAt: '', updatedAt: '' } },
+      { id: 2, foreignSeriesId: 'ol-s:2', title: 'Mistborn', description: '', monitored: false, createdAt: '' },
+    ]
+    vi.mocked(api.listAuthorSeries).mockResolvedValue(series)
+
+    render(<EditAuthorModal author={baseAuthor} onClose={onClose} onSaved={onSaved} />)
+
+    const { monitorMode } = await getSelects()
+    // Picker should not be fetched until series mode is picked.
+    expect(api.listAuthorSeries).not.toHaveBeenCalled()
+    fireEvent.change(monitorMode, { target: { value: 'series' } })
+
+    await waitFor(() => expect(api.listAuthorSeries).toHaveBeenCalledWith(42))
+    // Both series titles render; the one without a hardcover link is flagged.
+    await screen.findByText('Stormlight Archive')
+    await screen.findByText('Mistborn')
+    expect(screen.getByText(/no Hardcover link/i)).toBeInTheDocument()
+
+    // Pick Mistborn — selecting an unlinked series surfaces the warning chip.
+    const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
+    // The first checkbox is the "Apply monitor mode to existing books" toggle;
+    // the next two are the series. Click the Mistborn (second series) one.
+    const mistbornCheckbox = checkboxes.find(cb => cb.parentElement?.textContent?.includes('Mistborn'))
+    expect(mistbornCheckbox).toBeTruthy()
+    fireEvent.click(mistbornCheckbox!)
+    expect(screen.getByText(/no Hardcover link.*will not be auto-filled/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() => expect(api.updateAuthor).toHaveBeenCalledTimes(1))
+    expect(api.updateAuthor).toHaveBeenCalledWith(42, {
+      monitorMode: 'series',
+      monitoredSeriesIds: [2],
+    })
   })
 
   it('shows an error message when save fails', async () => {

--- a/web/src/components/EditAuthorModal.tsx
+++ b/web/src/components/EditAuthorModal.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, Author, AuthorMonitorMode, MetadataProfile, QualityProfile, RootFolder, UpdateAuthorRequest } from '../api/client'
+import { api, Author, AuthorMonitorMode, MetadataProfile, QualityProfile, RootFolder, Series, UpdateAuthorRequest } from '../api/client'
 
 interface Props {
   author: Author
@@ -14,6 +14,8 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
   const [qualityProfiles, setQualityProfiles] = useState<QualityProfile[]>([])
   const [metadataProfiles, setMetadataProfiles] = useState<MetadataProfile[]>([])
   const [rootFolders, setRootFolders] = useState<RootFolder[]>([])
+  const [authorSeries, setAuthorSeries] = useState<Series[]>([])
+  const [seriesLoaded, setSeriesLoaded] = useState(false)
 
   const [qualityProfileId, setQualityProfileId] = useState<number | null>(author.qualityProfileId ?? null)
   const [metadataProfileId, setMetadataProfileId] = useState<number | null>(author.metadataProfileId ?? null)
@@ -22,6 +24,7 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
   const [monitorMode, setMonitorMode] = useState<AuthorMonitorMode>(author.monitorMode ?? 'all')
   const [monitorLatestCount, setMonitorLatestCount] = useState(author.monitorLatestCount ?? 1)
   const [applyMonitorModeToExisting, setApplyMonitorModeToExisting] = useState(false)
+  const [monitoredSeriesIds, setMonitoredSeriesIds] = useState<number[]>(author.monitoredSeriesIds ?? [])
 
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -43,6 +46,32 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
   }, [])
+
+  // Lazy-load the author's series only when the user actually picks series
+  // mode. The list can be hundreds of rows for prolific authors and most
+  // edits never touch it.
+  useEffect(() => {
+    if (monitorMode !== 'series' || seriesLoaded) return
+    let cancelled = false
+    api.listAuthorSeries(author.id)
+      .then(list => { if (!cancelled) { setAuthorSeries(list); setSeriesLoaded(true) } })
+      .catch(() => { if (!cancelled) { setAuthorSeries([]); setSeriesLoaded(true) } })
+    return () => { cancelled = true }
+  }, [monitorMode, seriesLoaded, author.id])
+
+  const selectedSet = useMemo(() => new Set(monitoredSeriesIds), [monitoredSeriesIds])
+
+  const toggleSeries = (id: number) => {
+    setMonitoredSeriesIds(prev => prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id])
+  }
+
+  // The Hardcover-fill behaviour relies on the selected series having a
+  // catalog link; surface a warning when any selection is missing one so the
+  // user knows the apply pass will only act on locally-known books for those.
+  const selectedWithoutHardcover = useMemo(
+    () => authorSeries.filter(s => selectedSet.has(s.id) && !s.hardcoverLink),
+    [authorSeries, selectedSet],
+  )
 
   const save = async () => {
     // Build a patch with only the fields that actually changed — sending
@@ -75,6 +104,17 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
     }
     if (applyMonitorModeToExisting) {
       patch.applyMonitorModeToExisting = true
+    }
+    // Only include the series selection on the wire when the user is in
+    // series mode and the set actually differs from what came back from the
+    // Get. An undefined field leaves the existing selection untouched.
+    if (monitorMode === 'series') {
+      const original = (author.monitoredSeriesIds ?? []).slice().sort()
+      const current = monitoredSeriesIds.slice().sort()
+      const changed = original.length !== current.length || original.some((id, i) => id !== current[i])
+      if (changed || monitorMode !== (author.monitorMode ?? 'all')) {
+        patch.monitoredSeriesIds = monitoredSeriesIds
+      }
     }
 
     if (Object.keys(patch).length === 0) {
@@ -177,8 +217,47 @@ export default function EditAuthorModal({ author, onClose, onSaved }: Props) {
                   <option value="future">{t('monitorMode.future', 'Future books only')}</option>
                   <option value="latest">{t('monitorMode.latest', 'Latest only')}</option>
                   <option value="none">{t('monitorMode.none', 'None')}</option>
+                  <option value="series">{t('monitorMode.series', 'By series')}</option>
                 </select>
               </div>
+              {monitorMode === 'series' && (
+                <div className="mb-3">
+                  <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('editAuthorModal.monitoredSeries', 'Monitored series')}</label>
+                  {!seriesLoaded ? (
+                    <p className="text-xs text-slate-500 dark:text-zinc-500">{t('common.loading', 'Loading...')}</p>
+                  ) : authorSeries.length === 0 ? (
+                    <p className="text-xs text-slate-500 dark:text-zinc-500">
+                      {t('editAuthorModal.monitoredSeriesEmpty', 'No series found for this author yet. Refresh the author to pull series data first.')}
+                    </p>
+                  ) : (
+                    <div className="max-h-48 overflow-y-auto border border-slate-300 dark:border-zinc-700 rounded-md p-2 bg-slate-50 dark:bg-zinc-950">
+                      {authorSeries.map(s => (
+                        <label key={s.id} className="flex items-start gap-2 text-sm py-1 cursor-pointer select-none">
+                          <input
+                            type="checkbox"
+                            checked={selectedSet.has(s.id)}
+                            onChange={() => toggleSeries(s.id)}
+                            className="accent-emerald-500 mt-0.5 flex-shrink-0"
+                          />
+                          <span className="flex-1">
+                            <span className="font-medium">{s.title}</span>
+                            {!s.hardcoverLink && (
+                              <span className="ml-2 text-xs text-amber-700 dark:text-amber-400">
+                                {t('editAuthorModal.seriesNoHardcoverLink', '(no Hardcover link)')}
+                              </span>
+                            )}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                  {selectedWithoutHardcover.length > 0 && (
+                    <p className="text-xs text-amber-700 dark:text-amber-400 mt-2">
+                      {t('editAuthorModal.seriesNoHardcoverWarning', 'Some selected series have no Hardcover link. Only books Bindery already knows about will be monitored — missing entries will not be auto-filled.')}
+                    </p>
+                  )}
+                </div>
+              )}
               {monitorMode === 'latest' && (
                 <div className="mb-3">
                   <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('editAuthorModal.monitorLatestCount', 'Latest book count')}</label>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -37,7 +37,8 @@
     "all": "All books",
     "future": "Future books only",
     "latest": "Latest only",
-    "none": "None"
+    "none": "None",
+    "series": "By series"
   },
   "nav": {
     "authors": "Authors",


### PR DESCRIPTION
## Summary

Adds a fifth author `MonitorMode` value, `series`, that pins monitoring to a user-selected subset of the author's series. Extends — does not replace — the `all` / `future` / `latest` / `none` plumbing that landed in #809.

## How it builds on #809

#809 made the monitor decision per-author and added an apply-to-existing pass. This PR slots `series` into the same code paths:

- `IsAuthorMonitorModeValid` accepts the new value; the dropdown gets a fifth option.
- `applyMonitorModeToExistingBooks` branches on series mode and consults the per-author pin set instead of the date / latest-count logic.
- The newly-discovered loop in `FetchAuthorBooks` short-circuits to monitored when the provider's `SeriesRefs` already match a pinned series at ingestion time, so the user doesn't have to re-run apply after every refresh.

## Schema

New migration `046_author_monitored_series.sql` adds a join table:

```sql
author_monitored_series(author_id, series_id, created_at, PK(author_id, series_id))
```

with FK CASCADE on both sides. Did **not** overload `series.monitored` per the issue's explicit guidance — that flag is the global watchlist marker and flipping it to express a per-author pin would silently change state for every other author that shares a series. The migration is `046` (`045` was renamed from `043` in the #832 hotfix; verified before naming).

## Apply logic

- For each book of the author, look up its series IDs from a single bulk `ListBookSeriesByAuthor` query (no N+1).
- Monitored if any of those IDs is in the author's pinned set; unmonitored otherwise.
- Excluded books always stay unmonitored — excluded wins over series membership.

Tested with the 5-book / 2-series / 1-standalone / 1-excluded fixture from the issue.

## API

- `GET /author/{id}` populates `monitoredSeriesIds` when `monitorMode == "series"`.
- `PUT /author/{id}` accepts `monitoredSeriesIds: number[]` and validates that every id belongs to a series this author has books in. Unknown / foreign ids → 400.
- New `GET /author/{id}/series` returns the distinct series the author has books in. Backs the picker.
- Global `author.default_monitor_mode` setting now rejects `series` with a clear error — per-author by definition, no install-wide default makes sense.

## Frontend

`EditAuthorModal` gets a new option in the existing mode dropdown. When `series` is picked, the modal lazy-loads `/author/{id}/series` and renders a checkbox list. A warning chip flags individual series that lack a Hardcover link, and a summary warning explains the apply pass will only act on locally-known books for those. Strings through `t()` with English fallbacks; `en.json` gains `monitorMode.series`.

## Deferred follow-up

The issue's user story #4 (auto-trigger the existing Hardcover series-fill from the apply pass when a pinned series has a Hardcover link) is **not** in this PR. The fill helpers (`createMissingHardcoverBooks`, `queueSeriesBook`) live on `SeriesHandler` and reusing them from `AuthorHandler` would require pulling them into a shared service. Users can still hit "Fill" on each series page in the meantime. Tracked as a follow-up.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run --timeout=5m` (v2.11.4) — 0 issues
- [x] `go test ./cmd/... ./internal/...` — all pass
- [x] `cd web && npm run typecheck && npm run lint && npm run build && npm test` — 233/233 pass (+1 new)
- [ ] Manual: edit an author, switch to series mode, pick 1–2 series, hit apply — verify books in/out of the pinned set flip correctly and excluded ones stay unmonitored.

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)