### PR TITLE
fix(useragent): include project URL so OpenLibrary stops returning 403 (#834)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenLibrary name/title searches no longer fail with HTTP 403** (#834) — OpenLibrary's API now blocks requests whose `User-Agent` does not include a contact pointer (email or URL), and Bindery's previous `bindery/<version> (<os>)` UA matched that block. Name/title book additions failed immediately against OpenLibrary while ISBN lookups (which fall through to Hardcover enrichment) still worked, so the breakage was easy to miss in smoke checks. The User-Agent now appends the project URL — `bindery/<version> (<os>; https://github.com/vavallee/bindery)` — which satisfies OpenLibrary's policy and unlocks its higher rate limit. Thanks to @thetic for the precise repro and root-cause analysis.
+
 ## [v1.14.2] — 2026-05-24
 
 ### Fixed

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -1,11 +1,13 @@
 // Package useragent produces the canonical User-Agent string Bindery sends
 // on every outbound HTTP request.
 //
-// The format follows the convention used by Sonarr/Radarr/Lidarr/Prowlarr:
+// The format follows the convention used by Sonarr/Radarr/Lidarr/Prowlarr,
+// extended with the project URL as the contact pointer required by
+// OpenLibrary's API policy (https://openlibrary.org/developers/api):
 //
-//	bindery/<version> (<os>)
+//	bindery/<version> (<os>; https://github.com/vavallee/bindery)
 //
-// e.g. "bindery/1.11.1 (linux)" or "bindery/dev (darwin)".
+// e.g. "bindery/1.14.2 (linux; https://github.com/vavallee/bindery)".
 //
 // Lowercase "bindery" is deliberate. At least one indexer (nzbfinder.ws)
 // runs a Cloudflare WAF rule that case-sensitively rejects any User-Agent
@@ -13,6 +15,11 @@
 // lowercase identity across every external client means all of Bindery's
 // outbound traffic shares one reputation signal — easy to whitelist and
 // easy to debug.
+//
+// The trailing URL is OpenLibrary-mandated (#834): without it, OpenLibrary
+// returns 403 on every search request, breaking name/title book additions
+// for any user running with OpenLibrary as the primary metadata provider.
+// OpenLibrary also grants a higher rate limit when the contact is present.
 package useragent
 
 import (
@@ -42,6 +49,11 @@ func Get() string {
 	return *current.Load()
 }
 
+// ContactURL is the contact pointer Bindery advertises in its User-Agent so
+// OpenLibrary (and any other provider that requires it) can reach the
+// project. Exported so tests can assert it is present in the UA.
+const ContactURL = "https://github.com/vavallee/bindery"
+
 // Build constructs the canonical User-Agent without touching the singleton.
 // Useful for clients that already accept a version parameter (e.g. abs,
 // grimmory) and want to compute their UA up-front.
@@ -51,5 +63,5 @@ func Build(version string) string {
 		v = "dev"
 	}
 	v = strings.TrimPrefix(v, "v")
-	return "bindery/" + v + " (" + runtime.GOOS + ")"
+	return "bindery/" + v + " (" + runtime.GOOS + "; " + ContactURL + ")"
 }

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -7,17 +7,18 @@ import (
 )
 
 func TestBuildFormats(t *testing.T) {
+	suffix := " (" + runtime.GOOS + "; " + ContactURL + ")"
 	tests := []struct {
 		name    string
 		version string
 		want    string
 	}{
-		{"semver", "1.11.1", "bindery/1.11.1 (" + runtime.GOOS + ")"},
-		{"v-prefix stripped", "v1.11.1", "bindery/1.11.1 (" + runtime.GOOS + ")"},
-		{"whitespace trimmed", "  1.11.1  ", "bindery/1.11.1 (" + runtime.GOOS + ")"},
-		{"empty falls back to dev", "", "bindery/dev (" + runtime.GOOS + ")"},
-		{"only spaces falls back to dev", "   ", "bindery/dev (" + runtime.GOOS + ")"},
-		{"dev passes through", "dev", "bindery/dev (" + runtime.GOOS + ")"},
+		{"semver", "1.11.1", "bindery/1.11.1" + suffix},
+		{"v-prefix stripped", "v1.11.1", "bindery/1.11.1" + suffix},
+		{"whitespace trimmed", "  1.11.1  ", "bindery/1.11.1" + suffix},
+		{"empty falls back to dev", "", "bindery/dev" + suffix},
+		{"only spaces falls back to dev", "   ", "bindery/dev" + suffix},
+		{"dev passes through", "dev", "bindery/dev" + suffix},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -32,11 +33,13 @@ func TestSetGet(t *testing.T) {
 	original := Get()
 	t.Cleanup(func() {
 		// Restore — other parallel tests may observe Get().
-		Set(strings.TrimPrefix(strings.TrimSuffix(strings.TrimPrefix(original, "bindery/"), " ("+runtime.GOOS+")"), "v"))
+		suffix := " (" + runtime.GOOS + "; " + ContactURL + ")"
+		v := strings.TrimSuffix(strings.TrimPrefix(original, "bindery/"), suffix)
+		Set(strings.TrimPrefix(v, "v"))
 	})
 
 	Set("9.9.9")
-	if got, want := Get(), "bindery/9.9.9 ("+runtime.GOOS+")"; got != want {
+	if got, want := Get(), "bindery/9.9.9 ("+runtime.GOOS+"; "+ContactURL+")"; got != want {
 		t.Fatalf("Get() = %q, want %q", got, want)
 	}
 }
@@ -46,5 +49,19 @@ func TestUALowercaseB(t *testing.T) {
 	// "Bindery". The whole point of this package is to keep us lowercase.
 	if ua := Get(); strings.Contains(ua, "Bindery") {
 		t.Fatalf("User-Agent must not contain capital-B 'Bindery'; got %q", ua)
+	}
+}
+
+// TestUAContainsContactPointer is the #834 regression guard: OpenLibrary
+// returns 403 on every search when the User-Agent has no contact pointer
+// (email or URL). Asserting a URL or email is present in the built UA
+// stops a future refactor from silently re-breaking name/title searches.
+func TestUAContainsContactPointer(t *testing.T) {
+	ua := Build("1.0.0")
+	if !strings.Contains(ua, ContactURL) {
+		t.Fatalf("User-Agent must contain the configured contact pointer %q; got %q", ContactURL, ua)
+	}
+	if !strings.Contains(ua, "github.com") && !strings.Contains(ua, "@") {
+		t.Fatalf("User-Agent must contain a URL or email contact; got %q", ua)
 	}
 }


### PR DESCRIPTION
Closes #834.

## The break

OpenLibrary's [API policy](https://openlibrary.org/developers/api) now enforces a contact pointer (email or URL) in the \`User-Agent\` of every request, returning HTTP 403 when missing. Bindery's previous UA was \`bindery/<version> (<os>)\` — no contact — so every name/title book add against OpenLibrary failed immediately with:

\`\`\`
metadata provider unavailable: search books: HTTP 403: 403 Forbidden
\`\`\`

ISBN lookups kept working because they fall through to the Hardcover enrichment path, which is why this didn't surface in smoke checks. Reporter @thetic verified the cause externally by hitting \`openlibrary.org/search.json\` with default vs Bindery UAs from inside the container — 200 vs 403.

This is the default install hitting the default metadata provider, so the blast radius is "every user who hasn't switched to a non-OpenLibrary primary."

## The fix

\`internal/useragent/useragent.go\`: append the project URL inside the parens after a semicolon, matching the Sonarr-family convention the package header already documents:

\`\`\`
bindery/<version> (<os>; https://github.com/vavallee/bindery)
\`\`\`

Lowercase \`bindery\` is preserved so the existing nzbfinder.ws WAF case-sensitivity guard still triggers a clean rejection signature. Bonus: OpenLibrary grants a 3× higher rate limit when the UA carries contact info.

## Regression guard

New unit test \`TestUAContainsContactPointer\` asserts:
1. The UA contains the configured \`ContactURL\` constant.
2. A looser fallback: the UA contains either \`github.com\` or \`@\`, so swapping the URL for a contact email later still passes the spirit of the check.

If a future refactor strips contact info from the UA, the test fires before CI hits the live OpenLibrary endpoint.

## Cross-cutting impact

The UA is shared across every outbound HTTP client (ABS, Hardcover, indexers, etc.) per the package's deliberate one-UA-everywhere design. The only other test in the repo that introspects the UA is \`internal/abs/client_test.go\` using a prefix check (\`bindery/dev (\`) — still matches.

## Test plan

- [x] \`go test ./internal/useragent/... -v\` — including new regression
- [x] \`go test ./...\` — full suite, no regressions
- [x] \`gofmt -l\` clean
- [x] \`go vet ./...\` clean

CHANGELOG entry under \`[Unreleased]\` credits @thetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)