### PR TITLE
fix(nethint): name the Docker-host firewall case in the ECONNREFUSED hint

### DIFF
--- a/internal/downloader/deluge/client_test.go
+++ b/internal/downloader/deluge/client_test.go
@@ -386,7 +386,7 @@ func TestTest_ConnectionRefused(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "service may not be running") {
+	if !strings.Contains(err.Error(), "host firewall is rejecting") {
 		t.Errorf("expected port hint, got: %q", err.Error())
 	}
 }
@@ -420,7 +420,7 @@ func TestTest_ServerError_NoHint(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	msg := err.Error()
-	for _, hint := range []string{"Docker network", "service may not be running", "firewall or proxy"} {
+	for _, hint := range []string{"Docker network", "host firewall is rejecting", "firewall or proxy"} {
 		if strings.Contains(msg, hint) {
 			t.Errorf("server-side error must not produce hint %q; got: %q", hint, msg)
 		}

--- a/internal/downloader/nethint/nethint.go
+++ b/internal/downloader/nethint/nethint.go
@@ -29,9 +29,16 @@ func ForErr(err error) string {
 		return " (if using a container name, ensure both services are on the same Docker network)"
 	}
 
-	// 2. Connection refused — service is not listening on that port.
+	// 2. Connection refused — TCP got rejected. Two common causes:
+	//    a) Service genuinely isn't listening on that port.
+	//    b) Bindery runs in Docker, the target is on the bare-metal host (or
+	//       a different subnet), and a host firewall is REJECTing traffic
+	//       from the Docker bridge subnet (REJECT sends RST → ECONNREFUSED,
+	//       while DROP would surface as a timeout instead).
+	//    Naming both cases stops users from chasing the wrong layer when
+	//    the service is actually running and a firewall is the blocker.
 	if errors.Is(err, syscall.ECONNREFUSED) {
-		return " (service may not be running on that port)"
+		return " (connection refused — service may not be listening on that port, or a host firewall is rejecting traffic from the Docker subnet)"
 	}
 
 	// 3. Timeout — host is reachable but not responding (firewall, proxy, etc.).

--- a/internal/downloader/nethint/nethint_test.go
+++ b/internal/downloader/nethint/nethint_test.go
@@ -42,7 +42,7 @@ func TestForErr_DNSTemporary(t *testing.T) {
 func TestForErr_ConnectionRefused(t *testing.T) {
 	err := fmt.Errorf("dial tcp: %w", syscall.ECONNREFUSED)
 	got := nethint.ForErr(err)
-	want := " (service may not be running on that port)"
+	want := " (connection refused — service may not be listening on that port, or a host firewall is rejecting traffic from the Docker subnet)"
 	if got != want {
 		t.Errorf("ForErr(ECONNREFUSED) = %q, want %q", got, want)
 	}

--- a/internal/downloader/nzbget/client_test.go
+++ b/internal/downloader/nzbget/client_test.go
@@ -475,7 +475,7 @@ func TestTest_ConnectionRefused(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "service may not be running") {
+	if !strings.Contains(err.Error(), "host firewall is rejecting") {
 		t.Errorf("expected port hint, got: %q", err.Error())
 	}
 }
@@ -514,7 +514,7 @@ func TestTest_ServerError_NoHint(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	msg := err.Error()
-	for _, hint := range []string{"Docker network", "service may not be running", "firewall or proxy"} {
+	for _, hint := range []string{"Docker network", "host firewall is rejecting", "firewall or proxy"} {
 		if strings.Contains(msg, hint) {
 			t.Errorf("clean server error must not produce hint %q; got: %q", hint, msg)
 		}

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -1258,7 +1258,7 @@ func TestTest_ConnectionRefused(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "service may not be running") {
+	if !strings.Contains(err.Error(), "host firewall is rejecting") {
 		t.Errorf("expected port hint, got: %q", err.Error())
 	}
 }
@@ -1297,7 +1297,7 @@ func TestTest_ServerError_NoHint_QBit(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	msg := err.Error()
-	for _, hint := range []string{"Docker network", "service may not be running", "firewall or proxy"} {
+	for _, hint := range []string{"Docker network", "host firewall is rejecting", "firewall or proxy"} {
 		if strings.Contains(msg, hint) {
 			t.Errorf("server error must not produce hint %q; got: %q", hint, msg)
 		}

--- a/internal/downloader/sabnzbd/client_test.go
+++ b/internal/downloader/sabnzbd/client_test.go
@@ -228,7 +228,7 @@ func TestTest_ConnectionRefused(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	msg := err.Error()
-	if !strings.Contains(msg, "service may not be running") {
+	if !strings.Contains(msg, "host firewall is rejecting") {
 		t.Errorf("expected port hint, got: %q", msg)
 	}
 }
@@ -267,7 +267,7 @@ func TestTest_ServerError(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	msg := err.Error()
-	for _, hint := range []string{"Docker network", "service may not be running", "firewall or proxy"} {
+	for _, hint := range []string{"Docker network", "host firewall is rejecting", "firewall or proxy"} {
 		if strings.Contains(msg, hint) {
 			t.Errorf("clean server error must not produce hint %q; got: %q", hint, msg)
 		}

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -421,7 +421,7 @@ func TestTest_ConnectionRefused(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "service may not be running") {
+	if !strings.Contains(err.Error(), "host firewall is rejecting") {
 		t.Errorf("expected port hint, got: %q", err.Error())
 	}
 }
@@ -456,7 +456,7 @@ func TestTest_ServerError_NoHint(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	msg := err.Error()
-	for _, hint := range []string{"Docker network", "service may not be running", "firewall or proxy"} {
+	for _, hint := range []string{"Docker network", "host firewall is rejecting", "firewall or proxy"} {
 		if strings.Contains(msg, hint) {
 			t.Errorf("clean server error must not produce hint %q; got: %q", hint, msg)
 		}


### PR DESCRIPTION
Follow-up from a Discord support thread (Daize, 2026-05-24): Bindery in Docker, SABnzbd on bare-metal yunohost. \`Test connection\` returned:

\`\`\`
could not reach SABnzbd at http://192.168.x.xx:50155/ — dial tcp 192.168.x.xx:50155: connect: connection refused (service may not be running on that port)
\`\`\`

The service WAS running — yunohost's iptables firewall was REJECTing traffic from the Docker bridge subnet. Our hint sent the reporter chasing the wrong layer; the hint also misled #800's reporter and at least one other Discord user this week.

## Why ECONNREFUSED is ambiguous

ECONNREFUSED on the client side fires when the kernel receives a TCP RST in response to SYN. Two distinct causes:

1. Nothing is listening on that port.
2. A host firewall REJECTed the connection (sends RST). A DROP-rule firewall would surface as a connection timeout instead, which already has its own hint.

The previous wording claimed only (1). Users running Bindery in Docker against any bare-metal service whose host firewall doesn't allowlist the Docker bridge subnet hit (2), and the message lied to them.

## The fix

\`internal/downloader/nethint/nethint.go\`: rewrite the ECONNREFUSED hint to name both causes.

Before:
> \`(service may not be running on that port)\`

After:
> \`(connection refused — service may not be listening on that port, or a host firewall is rejecting traffic from the Docker subnet)\`

Slightly longer but actionable. The Docker-subnet phrasing also gives the user the right search term.

## Test changes

5 downstream client test files (\`sabnzbd\`, \`nzbget\`, \`qbittorrent\`, \`transmission\`, \`deluge\`) had substring asserts keyed off the old wording \`\"service may not be running\"\`. Switched to \`\"host firewall is rejecting\"\` — the new actionable bit. The direct \`nethint_test.go\` ECONNREFUSED assertion is updated to the full new string.

## Test plan

- [x] \`go test ./internal/downloader/...\` — all clients green, nethint green
- [x] \`go test ./...\` — full suite, no regressions
- [x] \`gofmt -l\` clean
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)