### PR TITLE
fix(qbittorrent): normalize Windows backslashes in paths reported by qBit API

### DIFF
--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -506,6 +506,14 @@ func (c *Client) GetTorrents(ctx context.Context, category string) ([]Torrent, e
 	if err := json.Unmarshal(data, &torrents); err != nil {
 		return nil, fmt.Errorf("decode torrents: %w", err)
 	}
+	// Windows-qBit reports paths with backslashes; downstream Linux path code
+	// (filepath.Walk, PathRemap.Apply, pathIsAtOrUnder) can't process them.
+	// Normalize at the API boundary so every consumer sees forward-slash form.
+	for i := range torrents {
+		torrents[i].SavePath = normalizePath(torrents[i].SavePath)
+		torrents[i].ContentPath = normalizePath(torrents[i].ContentPath)
+		torrents[i].Name = normalizePath(torrents[i].Name)
+	}
 	return torrents, nil
 }
 

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -913,6 +913,77 @@ func TestGetTorrents_InvalidJSON(t *testing.T) {
 	}
 }
 
+// TestGetTorrents_NormalizesWindowsPaths is the PixieApples follow-up to
+// #800: a qBittorrent instance running on Windows reports SavePath /
+// ContentPath / Name with backslash separators, which downstream Linux
+// path code in Bindery (filepath.Walk, PathRemap.Apply, pathIsAtOrUnder)
+// cannot process. The normalization must happen at the API boundary so
+// every consumer sees forward-slash paths regardless of qBit's host OS.
+func TestGetTorrents_NormalizesWindowsPaths(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			// Backslashes in JSON strings are escaped as \\; the resulting
+			// Go string contains single backslashes.
+			_, _ = w.Write([]byte(`[{
+				"hash":"abc",
+				"name":"Book Title",
+				"state":"pausedUP",
+				"progress":1.0,
+				"save_path":"N:\\Torrents\\complete",
+				"content_path":"N:\\Torrents\\complete\\library\\book"
+			}]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	torrents, err := c.GetTorrents(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetTorrents: %v", err)
+	}
+	if len(torrents) != 1 {
+		t.Fatalf("expected 1 torrent, got %d", len(torrents))
+	}
+	if got, want := torrents[0].SavePath, "N:/Torrents/complete"; got != want {
+		t.Errorf("SavePath = %q, want %q (backslashes should be normalized)", got, want)
+	}
+	if got, want := torrents[0].ContentPath, "N:/Torrents/complete/library/book"; got != want {
+		t.Errorf("ContentPath = %q, want %q (backslashes should be normalized)", got, want)
+	}
+}
+
+// TestGetCategories_NormalizesWindowsSavePath asserts the same normalization
+// applies to Category.SavePath returned by GET /torrents/categories, so the
+// qBit health-check (which uses category save paths) doesn't fail on a
+// Windows-qBit deployment.
+func TestGetCategories_NormalizesWindowsSavePath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/categories":
+			_, _ = w.Write([]byte(`{"library":{"name":"library","savePath":"N:\\Torrents\\complete\\library"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	cats, err := c.GetCategories(context.Background())
+	if err != nil {
+		t.Fatalf("GetCategories: %v", err)
+	}
+	if got, want := cats["library"].SavePath, "N:/Torrents/complete/library"; got != want {
+		t.Errorf("SavePath = %q, want %q (backslashes should be normalized)", got, want)
+	}
+}
+
 func TestDeleteTorrent_Success(t *testing.T) {
 	var gotHash, gotDeleteFiles string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/downloader/qbittorrent/types.go
+++ b/internal/downloader/qbittorrent/types.go
@@ -1,6 +1,9 @@
 package qbittorrent
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // Torrent represents a single torrent as returned by the qBittorrent WebUI API.
 type Torrent struct {
@@ -16,6 +19,20 @@ type Torrent struct {
 	ETA         int     `json:"eta"`
 	AddedOn     int64   `json:"added_on"`
 	DLSpeed     int64   `json:"dlspeed"`
+}
+
+// normalizePath rewrites Windows-style backslashes to forward slashes so
+// downstream Linux path code (filepath.Walk, pathmap.Apply, pathIsAtOrUnder)
+// can process paths reported by a qBittorrent instance running on Windows.
+// A path with no backslashes is returned unchanged. The only false positive
+// would be a literal "\" in a Linux save path or torrent name — qBittorrent
+// running on Linux does not produce such paths (it uses forward slashes), so
+// the conversion is unambiguous in practice.
+func normalizePath(p string) string {
+	if !strings.Contains(p, `\`) {
+		return p
+	}
+	return strings.ReplaceAll(p, `\`, "/")
 }
 
 // Category represents a qBittorrent category. Different qBittorrent versions
@@ -44,6 +61,11 @@ func (c *Category) UnmarshalJSON(data []byte) error {
 	if c.SavePath == "" {
 		c.SavePath = categoryPathString(raw.DownloadPath)
 	}
+	// Windows-qBit reports save paths with backslashes; downstream Linux path
+	// code can't process those. Convert at the boundary so consumers see only
+	// forward-slash paths (PixieApples #800 follow-up: import-side failures
+	// after the health check passed).
+	c.SavePath = normalizePath(c.SavePath)
 	return nil
 }
 


### PR DESCRIPTION
Follow-up to #800. PixieApples reported on Discord:

> bindery can see my contents of N:/ in /n/ but it just failed out on the qbittorrent location reporting
>
> no book files found in \`\"N:\\Torrents\\complete\\library\\..\"\` in the event history

She'd gotten the health check passing using the v1.14.2 hint, but the import-side path code couldn't process the backslash-separated paths qBittorrent reports when running on Windows.

## The actual bug

When qBit runs on Windows, every path it returns uses backslash separators:

\`\`\`
SavePath:    N:\Torrents\complete
ContentPath: N:\Torrents\complete\library\book
Category SavePath: N:\Torrents\complete\library
\`\`\`

Bindery's downstream Linux path code can't process those:

- \`filepath.Walk(\"N:\\\\Torrents\\\\complete\\\\library\\\\book\")\` walks nothing — Linux doesn't see \`\\\` as a separator, treats the whole thing as one bizarre filename, and finds no such directory.
- \`pathmap.Apply\` does prefix string matching — a user's remap like \`N:\\Torrents:/N/Torrents\` and the literal \`N:\\Torrents\\complete\\...\` rawpath produce a weird mixed-separator output that \`pathIsAtOrUnder\` then can't validate properly.
- The category health-check has the same problem on the SavePath returned by GET /torrents/categories.

The user's PathRemap configuration cannot fix this on its own because the corrupted separator is downstream of the remap.

## The fix

Normalize at the qBittorrent API boundary. \`internal/downloader/qbittorrent/types.go\` gains a private \`normalizePath\` helper:

\`\`\`go
func normalizePath(p string) string {
    if !strings.Contains(p, \`\\\\\`) {
        return p
    }
    return strings.ReplaceAll(p, \`\\\\\`, \"/\")
}
\`\`\`

Applied in two places:

- \`Client.GetTorrents\` — normalizes every \`SavePath\`, \`ContentPath\`, and \`Name\` after JSON unmarshal.
- \`Category.UnmarshalJSON\` — normalizes \`SavePath\` after picking the right key.

Downstream code (scanner.go, health.go, PathRemap, filepath.Walk) sees only forward-slash paths regardless of which OS qBit runs on.

## Why this is safe

A qBittorrent instance running on Linux cannot have a literal backslash in a save path or torrent name — qBit uses the host OS's native separator, and on Linux that's forward slash. So the conversion is unambiguous in practice: any path containing a backslash came from a Windows-qBit and the backslashes are path separators by definition.

## Test coverage

- \`TestGetTorrents_NormalizesWindowsPaths\` — JSON fixture with \`N:\\Torrents\\complete\` reported by a stub server; asserts the returned \`Torrent\` carries forward-slash paths.
- \`TestGetCategories_NormalizesWindowsSavePath\` — same shape for the category endpoint.
- All existing tests still pass; existing fixtures only use forward-slash paths so they're untouched.

## Test plan

- [x] \`go test ./internal/downloader/qbittorrent/... -count=1\` — green, including the two new tests
- [x] \`go test ./...\` — full suite, no regressions
- [x] \`gofmt -l\` clean
- [x] \`go vet ./...\` clean

## What PixieApples will need to do after this lands

With backslashes normalized to forward slashes at the API boundary, her PathRemap configuration should be writable as a Linux-Linux remap. For her setup (qBit reports \`N:\\Torrents\\...\` → normalized to \`N:/Torrents/...\`, and Bindery mounts the same storage at \`/N/Torrents/\`), the PathRemap is:

\`\`\`
N:/Torrents:/N/Torrents
\`\`\`

Documented this in the Discord reply alongside the PR notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)