### PR TITLE
fix(test): add explicit returns after t.Fatal nil-checks for staticcheck

### DIFF
--- a/internal/abs/client_test.go
+++ b/internal/abs/client_test.go
@@ -136,6 +136,7 @@ func TestClientRejectsAPIKeyControlCharacters(t *testing.T) {
 			_, err := NewClient("https://abs.example.com", key)
 			if err == nil {
 				t.Fatal("expected error")
+				return
 			}
 			if strings.Contains(err.Error(), key) {
 				t.Fatalf("error leaked api key: %q", err.Error())

--- a/internal/abs/enumerator_test.go
+++ b/internal/abs/enumerator_test.go
@@ -248,6 +248,7 @@ func TestEnumerator_ResumeFromCheckpoint(t *testing.T) {
 	}
 	if setting == nil {
 		t.Fatal("expected checkpoint to be stored")
+		return
 	}
 	var checkpoint ImportCheckpoint
 	if err := json.Unmarshal([]byte(setting.Value), &checkpoint); err != nil {

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -2735,6 +2735,7 @@ func TestImporter_RepeatedABSSeriesRollbackUnlinksAllRunMemberships(t *testing.T
 	}
 	if series == nil {
 		t.Fatal("expected imported series")
+		return
 	}
 	hydrated, err := seriesRepo.GetByID(ctx, series.ID)
 	if err != nil {
@@ -2824,6 +2825,7 @@ func TestImporter_ABSSeriesRerunRollbackPreservesOriginalMembership(t *testing.T
 	}
 	if series == nil {
 		t.Fatal("series after second rollback = nil, want original series preserved")
+		return
 	}
 	hydrated, err := seriesRepo.GetByID(ctx, series.ID)
 	if err != nil {

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -214,6 +214,7 @@ func TestImporter_ProgressResultsKeepsLatestHundredItems(t *testing.T) {
 	}
 	if progress.Stats == nil {
 		t.Fatal("progress stats = nil, want final stats")
+		return
 	}
 	if progress.Stats.ItemsSeen != itemCount || progress.Stats.BooksCreated != itemCount {
 		t.Fatalf("progress stats = %+v, want full-run counts", progress.Stats)
@@ -3106,6 +3107,7 @@ func TestImporter_HardcoverSeriesLinksExistingCatalogBookWithRollback(t *testing
 	}
 	if remainingBook == nil {
 		t.Fatal("existing catalog book was deleted by rollback")
+		return
 	}
 	series, err = seriesRepo.GetByForeignID(ctx, catalog.ForeignID)
 	if err != nil {
@@ -3187,6 +3189,7 @@ func TestImporter_HardcoverSeriesMatchPromotesExactABSSeries(t *testing.T) {
 	}
 	if series == nil {
 		t.Fatal("expected promoted Hardcover series")
+		return
 	}
 	all, err := seriesRepo.List(context.Background())
 	if err != nil {
@@ -3616,6 +3619,7 @@ func TestImporter_RollbackKeepsRunCreatedSeriesWithUserMembership(t *testing.T) 
 	}
 	if surviving == nil {
 		t.Fatal("series after rollback = nil, want kept because user membership remains")
+		return
 	}
 	if len(surviving.Books) != 1 || surviving.Books[0].BookID != userBook.ID {
 		t.Fatalf("series books after rollback = %+v, want only user-added membership", surviving.Books)
@@ -3916,6 +3920,7 @@ func TestImporter_RollbackFirstLibraryPreservesSecondLibrarySharedBook(t *testin
 	}
 	if series == nil {
 		t.Fatal("series after rollback = nil, want shared local series retained")
+		return
 	}
 	if len(series.Books) != 1 || series.Books[0].BookID != bookID {
 		t.Fatalf("series books after rollback = %+v, want shared local book retained", series.Books)

--- a/internal/abs/importer_test.go
+++ b/internal/abs/importer_test.go
@@ -2938,6 +2938,7 @@ func TestImporter_HardcoverSeriesMatchLinksItemWithoutABSSeries(t *testing.T) {
 	}
 	if series == nil {
 		t.Fatal("expected Hardcover series")
+		return
 	}
 	link, err := seriesRepo.GetHardcoverLink(context.Background(), series.ID)
 	if err != nil {
@@ -3064,6 +3065,7 @@ func TestImporter_HardcoverSeriesLinksExistingCatalogBookWithRollback(t *testing
 	}
 	if series == nil {
 		t.Fatal("expected Hardcover series")
+		return
 	}
 	hydrated, err := seriesRepo.GetByID(ctx, series.ID)
 	if err != nil {
@@ -3574,6 +3576,7 @@ func TestImporter_RollbackKeepsRunCreatedSeriesWithUserMembership(t *testing.T) 
 	}
 	if series == nil {
 		t.Fatal("expected imported series before rollback")
+		return
 	}
 	authors, err := authorRepo.List(ctx)
 	if err != nil {

--- a/internal/api/auth_oidc_callback_test.go
+++ b/internal/api/auth_oidc_callback_test.go
@@ -343,6 +343,7 @@ func TestCallback_EmailLink_UnverifiedEmail(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected a new account to be provisioned for the attacker's subject")
+		return
 	}
 	if got.ID == victim.ID {
 		t.Fatal("SECURITY: unverified email claim was linked to the victim's account — account takeover")

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -176,6 +176,7 @@ func TestLogin_CookieMaxAge_Short(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected session cookie")
+		return
 	}
 	want := int(auth.SessionDurationShort.Seconds())
 	if got.MaxAge != want {
@@ -207,6 +208,7 @@ func TestLogin_CookieMaxAge_RememberMe(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected session cookie")
+		return
 	}
 	want := int(auth.SessionDuration.Seconds())
 	if got.MaxAge != want {

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -494,6 +494,7 @@ func TestBooksBulk_Exclude(t *testing.T) {
 	}
 	if found == nil {
 		t.Fatalf("book %d missing from ListByAuthorIncludingExcluded", book.ID)
+		return
 	}
 	if !found.Excluded {
 		t.Errorf("book.Excluded: want true after bulk exclude, got false")

--- a/internal/api/download_clients_test.go
+++ b/internal/api/download_clients_test.go
@@ -95,6 +95,7 @@ func TestDownloadClientCRUD(t *testing.T) {
 	got, _ := clients.GetByID(ctx, created.ID)
 	if got == nil {
 		t.Fatal("expected client still exists after update")
+		return
 	}
 	if got.PathRemap != "/remote2:/local2" {
 		t.Errorf("updated pathRemap = %q", got.PathRemap)

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -1308,6 +1308,7 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 	}
 	if created == nil {
 		t.Fatal("expected Hardcover book to be created")
+		return
 	}
 	if created.MetadataProvider != "hardcover" {
 		t.Fatalf("expected metadata provider to be preserved, got %q", created.MetadataProvider)

--- a/internal/auth/oidc/discover_test.go
+++ b/internal/auth/oidc/discover_test.go
@@ -82,6 +82,7 @@ func TestDiscover_NonOK(t *testing.T) {
 	_, err := Discover(context.Background(), srv.URL)
 	if err == nil {
 		t.Fatal("expected error for 404 response")
+		return
 	}
 	if !strings.Contains(err.Error(), "404") {
 		t.Errorf("error=%q, want it to mention 404 status", err.Error())

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -197,6 +197,7 @@ func TestReload_FailedProviderRecorded(t *testing.T) {
 	st := mgr.Status("x")
 	if st == nil {
 		t.Fatal("status should exist for a configured-but-failed provider")
+		return
 	}
 	if st.State != "failed" {
 		t.Fatalf("want state=failed, got %q", st.State)
@@ -326,6 +327,7 @@ func TestAuthURL_StillFailsWhenIdPDown(t *testing.T) {
 	_, err := mgr.AuthURL(context.Background(), "https://bindery.example.com", "q", "state", "nonce", verifier)
 	if err == nil {
 		t.Fatal("AuthURL should fail when IdP is still down after retry attempt")
+		return
 	}
 	if !strings.Contains(err.Error(), "unknown oidc provider") {
 		t.Fatalf("expected unknown-provider error, got: %v", err)

--- a/internal/calibre/client_test.go
+++ b/internal/calibre/client_test.go
@@ -240,6 +240,7 @@ func TestAdd_WrapsRunnerError(t *testing.T) {
 	_, err := c.Add(context.Background(), "/x.epub", Metadata{})
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	// Both the runner error and the stderr payload must appear in the
 	// wrapped message — operators rely on stderr to diagnose permission

--- a/internal/calibre/import_rollback_test.go
+++ b/internal/calibre/import_rollback_test.go
@@ -158,10 +158,12 @@ func TestImporter_ExecuteRollback_DeletesEntitiesAndMarksRun(t *testing.T) {
 	book, _ := bookRepo.GetByCalibreID(context.Background(), 20)
 	if book == nil {
 		t.Fatal("book missing before rollback")
+		return
 	}
 	author, _ := authorRepo.GetByID(context.Background(), book.AuthorID)
 	if author == nil {
 		t.Fatal("author missing before rollback")
+		return
 	}
 	eds, _ := editionRepo.ListByBook(context.Background(), book.ID)
 	if len(eds) != 1 {
@@ -272,6 +274,7 @@ func TestImporter_Rollback_FileRowsNotTouchedOnDisk(t *testing.T) {
 	book, _ := bookRepo.GetByCalibreID(context.Background(), 40)
 	if book == nil {
 		t.Fatal("book missing")
+		return
 	}
 	if book.FilePath == "" {
 		book.FilePath = fakePath

--- a/internal/calibre/plugin_client_test.go
+++ b/internal/calibre/plugin_client_test.go
@@ -163,6 +163,7 @@ func TestPluginClient_Add401ReturnsDescriptiveError(t *testing.T) {
 	_, err := c.Add(context.Background(), "/a.epub", Metadata{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "authentication failed") {
 		t.Errorf("error = %v, want it to mention authentication failure", err)

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -78,6 +78,7 @@ func TestValidate_OIDCRedirectBaseURL_Invalid(t *testing.T) {
 			err := cfg.Validate(discardLogger())
 			if err == nil {
 				t.Fatalf("expected error for invalid URL %q, got nil", tc.url)
+				return
 			}
 			if !strings.Contains(err.Error(), tc.wantErr) {
 				t.Errorf("error %q does not mention %q", err.Error(), tc.wantErr)

--- a/internal/db/abs_imports_test.go
+++ b/internal/db/abs_imports_test.go
@@ -45,6 +45,7 @@ func TestABSImportRunRepoFinishRetainsCheckpointOnFailure(t *testing.T) {
 	}
 	if stored == nil {
 		t.Fatal("expected stored run")
+		return
 	}
 	if stored.CheckpointJSON == "" || stored.CheckpointJSON == "{}" {
 		t.Fatalf("checkpoint_json = %q, want persisted checkpoint", stored.CheckpointJSON)

--- a/internal/db/auth_test.go
+++ b/internal/db/auth_test.go
@@ -26,6 +26,7 @@ func TestGetByEmail_Found(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected user, got nil")
+		return
 	}
 	if got.Username != "alice" {
 		t.Errorf("Username=%q, want alice", got.Username)
@@ -89,6 +90,7 @@ func TestDeleteLastAdmin(t *testing.T) {
 	err = repo.Delete(ctx, admin.ID)
 	if err == nil {
 		t.Fatal("expected error when deleting last admin, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "last admin") {
 		t.Errorf("unexpected error: %v", err)
@@ -146,6 +148,7 @@ func TestSetRoleLastAdmin(t *testing.T) {
 	err = repo.SetRole(ctx, admin.ID, "user")
 	if err == nil {
 		t.Fatal("expected error when demoting last admin, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "last admin") {
 		t.Errorf("unexpected error: %v", err)
@@ -218,6 +221,7 @@ func TestLinkOIDCSubject(t *testing.T) {
 	}
 	if after == nil {
 		t.Fatal("expected user after link, got nil")
+		return
 	}
 	if after.ID != u.ID {
 		t.Errorf("user ID after link: got %d, want %d", after.ID, u.ID)

--- a/internal/db/author_aliases_test.go
+++ b/internal/db/author_aliases_test.go
@@ -91,6 +91,7 @@ func TestAliasCreate_RejectsReassignment(t *testing.T) {
 	err = aliasRepo.Create(ctx, &models.AuthorAlias{AuthorID: b.ID, Name: "shared name"})
 	if err == nil {
 		t.Fatal("expected error when reassigning alias to different author")
+		return
 	}
 	if !strings.Contains(err.Error(), "already points") {
 		t.Errorf("expected 'already points' error, got: %v", err)

--- a/internal/db/author_monitored_series_test.go
+++ b/internal/db/author_monitored_series_test.go
@@ -43,6 +43,7 @@ func TestAuthorMonitoredSeriesRoundTrip(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatalf("expected non-nil empty slice")
+		return
 	}
 	if len(got) != 0 {
 		t.Fatalf("expected 0 ids, got %v", got)

--- a/internal/db/authors_test.go
+++ b/internal/db/authors_test.go
@@ -71,6 +71,7 @@ func TestAuthorRepo_MonitorDefaultsRoundTrip(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("author not found")
+		return
 	}
 	if got.MonitorMode != models.AuthorMonitorModeAll || got.MonitorLatestCount != models.DefaultAuthorMonitorLatestCount {
 		t.Fatalf("defaults did not round trip: %+v", got)
@@ -224,6 +225,7 @@ func TestAuthorRepo_UpgradeSyntheticDNB_RowUpdatedInPlace(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected row with canonical foreign_id to exist after upgrade")
+		return
 	}
 	if got.ID != originalID {
 		t.Errorf("primary key changed: want %d, got %d (in-place update broken)", originalID, got.ID)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -40,6 +40,7 @@ func TestPreflightReadOnlyParent(t *testing.T) {
 	err := preflight(filepath.Join(parent, "bindery.db"))
 	if err == nil {
 		t.Fatal("expected preflight to fail on read-only parent")
+		return
 	}
 	// The message must name the path and mention writability; that's the
 	// whole point of the check.
@@ -376,6 +377,7 @@ func TestAuthorCRUD(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected author by foreign id")
+		return
 	}
 
 	// List
@@ -690,6 +692,7 @@ func TestPickClientForMediaType(t *testing.T) {
 			}
 			if got == nil {
 				t.Fatal("expected a client, got nil")
+				return
 			}
 			if got.ID != tt.wantID {
 				t.Errorf("expected client ID %d, got %d (%s)", tt.wantID, got.ID, got.Name)

--- a/internal/db/download_clients_test.go
+++ b/internal/db/download_clients_test.go
@@ -38,6 +38,7 @@ func TestDownloadClientRepoHydratesLegacyCredentialStorage(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatal("expected download client")
+		return
 	}
 	if client.Username != "old-user" || client.Password != "old-pass" {
 		t.Fatalf("credentials = %q/%q, want legacy values", client.Username, client.Password)
@@ -75,6 +76,7 @@ func TestDownloadClientRepoPreservesRealURLBase(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected download client")
+		return
 	}
 	if got.URLBase != "/qbit" {
 		t.Fatalf("urlBase = %q, want /qbit", got.URLBase)
@@ -109,6 +111,7 @@ func TestDownloadClientRepoPreservesBareURLBaseMatchingUsername(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected download client")
+		return
 	}
 	if got.URLBase != "transmission" {
 		t.Fatalf("urlBase = %q, want bare reverse-proxy path preserved", got.URLBase)
@@ -149,6 +152,7 @@ func TestDownloadClientRepoRoundTripsCategoryAudiobook(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected download client")
+		return
 	}
 	if got.Category != "books" || got.CategoryAudiobook != "audiobooks" {
 		t.Fatalf("categories = %q/%q, want books/audiobooks", got.Category, got.CategoryAudiobook)
@@ -201,6 +205,7 @@ func TestDownloadClientRepoDefaultsCategoryAudiobookEmpty(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected download client")
+		return
 	}
 	if got.CategoryAudiobook != "" {
 		t.Fatalf("CategoryAudiobook = %q, want empty fallback", got.CategoryAudiobook)
@@ -237,6 +242,7 @@ func TestDownloadClientRepoPreservesNewBareURLBaseWithoutLegacyAPIKey(t *testing
 	}
 	if client == nil {
 		t.Fatal("expected download client")
+		return
 	}
 	if client.URLBase != "transmission" {
 		t.Fatalf("urlBase = %q, want bare reverse-proxy path preserved", client.URLBase)

--- a/internal/db/editions_test.go
+++ b/internal/db/editions_test.go
@@ -57,6 +57,7 @@ func TestEditionRepo_UpsertInsertAndUpdate(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected edition, got nil")
+		return
 	}
 	if got.Title != "First Edition" || !got.IsEbook || !got.Monitored {
 		t.Errorf("unexpected round-trip: %+v", got)

--- a/internal/db/extra_repos_test.go
+++ b/internal/db/extra_repos_test.go
@@ -220,6 +220,7 @@ func TestDelayProfileRepoCRUD(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected non-nil delay profile")
+		return
 	}
 	if got.UsenetDelay != 60 {
 		t.Errorf("UsenetDelay: want 60, got %d", got.UsenetDelay)

--- a/internal/db/metadata_profiles_test.go
+++ b/internal/db/metadata_profiles_test.go
@@ -49,6 +49,7 @@ func TestMetadataProfileRepo_CRUD(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected profile")
+		return
 	}
 	if got.Name != "Strict" || got.MinPopularity != 100 || got.MinPages != 50 {
 		t.Errorf("scalar fields mismatch: %+v", got)

--- a/internal/db/recommendations_test.go
+++ b/internal/db/recommendations_test.go
@@ -83,6 +83,7 @@ func TestRecommendationRepoReadsLegacyNullGenresAsEmptyArray(t *testing.T) {
 	}
 	if rec == nil {
 		t.Fatal("get recommendation returned nil")
+		return
 	}
 	if rec.Genres == nil {
 		t.Fatal("loaded legacy genres is nil, want empty slice")

--- a/internal/db/series_test.go
+++ b/internal/db/series_test.go
@@ -98,6 +98,7 @@ func TestSeriesLinkBook(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected series, got nil")
+		return
 	}
 	if got.Title != "Dune Chronicles" {
 		t.Errorf("title: want %q, got %q", "Dune Chronicles", got.Title)

--- a/internal/downloader/deluge/client_test.go
+++ b/internal/downloader/deluge/client_test.go
@@ -324,6 +324,7 @@ func TestAddTorrent_URL_HashLookupTimeout(t *testing.T) {
 	_, err := c.AddTorrent(context.Background(), "http://example.com/book.torrent", "scifi")
 	if err == nil {
 		t.Fatal("expected error on timeout, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "hash could not be determined") {
 		t.Errorf("unexpected error: %v", err)
@@ -369,6 +370,7 @@ func TestTest_DNSNotFound(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "same Docker network") {
 		t.Errorf("expected Docker network hint, got: %q", err.Error())
@@ -385,6 +387,7 @@ func TestTest_ConnectionRefused(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "host firewall is rejecting") {
 		t.Errorf("expected port hint, got: %q", err.Error())
@@ -401,6 +404,7 @@ func TestTest_Timeout(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "firewall or proxy") {
 		t.Errorf("expected firewall hint, got: %q", err.Error())
@@ -418,6 +422,7 @@ func TestTest_ServerError_NoHint(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	msg := err.Error()
 	for _, hint := range []string{"Docker network", "host firewall is rejecting", "firewall or proxy"} {

--- a/internal/downloader/nzbget/client_test.go
+++ b/internal/downloader/nzbget/client_test.go
@@ -196,6 +196,7 @@ func TestAdd_FetchFailure(t *testing.T) {
 	_, err := c.Add(context.Background(), indexerSrv.URL+"/file.nzb", "Book", "books", 0)
 	if err == nil {
 		t.Fatal("expected error on fetch failure")
+		return
 	}
 	if !strings.Contains(err.Error(), "401") {
 		t.Errorf("expected HTTP 401 in error, got: %v", err)
@@ -217,6 +218,7 @@ func TestAdd_SSRFBlocked(t *testing.T) {
 	_, err := c.Add(context.Background(), "http://127.0.0.1:9999/file.nzb", "Book", "books", 0)
 	if err == nil {
 		t.Fatal("expected SSRF guard to block loopback URL")
+		return
 	}
 	if !strings.Contains(err.Error(), "url not allowed") {
 		t.Errorf("expected 'url not allowed' in error, got: %v", err)
@@ -456,6 +458,7 @@ func TestTest_DNSNotFound(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "same Docker network") {
 		t.Errorf("expected Docker network hint, got: %q", err.Error())
@@ -474,6 +477,7 @@ func TestTest_ConnectionRefused(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "host firewall is rejecting") {
 		t.Errorf("expected port hint, got: %q", err.Error())
@@ -492,6 +496,7 @@ func TestTest_Timeout(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "firewall or proxy") {
 		t.Errorf("expected firewall hint, got: %q", err.Error())
@@ -512,6 +517,7 @@ func TestTest_ServerError_NoHint(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	msg := err.Error()
 	for _, hint := range []string{"Docker network", "host firewall is rejecting", "firewall or proxy"} {

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -348,6 +348,7 @@ func TestLogin_AuthError_BadCreds(t *testing.T) {
 	err := c.Login(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	var authErr *AuthError
 	if !errors.As(err, &authErr) {
@@ -374,6 +375,7 @@ func TestLogin_AuthError_BanEmpty403(t *testing.T) {
 	err := c.Login(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	var authErr *AuthError
 	if !errors.As(err, &authErr) {
@@ -404,6 +406,7 @@ func TestTest_AuthErrorDoesNotMisdirect(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	msg := err.Error()
 	if strings.Contains(msg, "could not reach") {
@@ -716,6 +719,7 @@ func TestAddTorrent_TorrentURL_FetchFailure(t *testing.T) {
 	_, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "", "")
 	if err == nil {
 		t.Fatal("expected error when indexer returns 401")
+		return
 	}
 	if !strings.Contains(err.Error(), "401") {
 		t.Errorf("error should mention 401, got: %v", err)
@@ -792,6 +796,7 @@ func TestAddTorrent_TorrentURL_OversizedResponseDoesNotCallQbitAdd(t *testing.T)
 	_, err := c.AddTorrent(context.Background(), indexer.URL+"/too-large.torrent", "", "")
 	if err == nil {
 		t.Fatal("expected oversized response error")
+		return
 	}
 	if !strings.Contains(err.Error(), "exceeds") {
 		t.Errorf("expected oversized error, got: %v", err)
@@ -827,6 +832,7 @@ func TestAddTorrent_TorrentURL_DefaultValidationRejectsLoopbackBeforeFetch(t *te
 	_, err := c.AddTorrent(context.Background(), indexer.URL+"/blocked.torrent", "", "")
 	if err == nil {
 		t.Fatal("expected loopback URL validation failure")
+		return
 	}
 	if !strings.Contains(err.Error(), "url not allowed") {
 		t.Errorf("expected URL validation error, got: %v", err)
@@ -1258,6 +1264,7 @@ func TestAddTorrent_HashLookupTimeout(t *testing.T) {
 	_, err := c.AddTorrent(context.Background(), indexer.URL+"/torrent", "books", "")
 	if err == nil {
 		t.Fatal("expected error on timeout, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "hash could not be determined") {
 		t.Errorf("unexpected error: %v", err)
@@ -1309,6 +1316,7 @@ func TestTest_DNSNotFound(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	msg := err.Error()
 	if strings.Contains(msg, "connected to qBittorrent") {
@@ -1328,6 +1336,7 @@ func TestTest_ConnectionRefused(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "host firewall is rejecting") {
 		t.Errorf("expected port hint, got: %q", err.Error())
@@ -1343,6 +1352,7 @@ func TestTest_Timeout_QBit(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "firewall or proxy") {
 		t.Errorf("expected firewall hint, got: %q", err.Error())
@@ -1366,6 +1376,7 @@ func TestTest_ServerError_NoHint_QBit(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	msg := err.Error()
 	for _, hint := range []string{"Docker network", "host firewall is rejecting", "firewall or proxy"} {

--- a/internal/downloader/sabnzbd/client_test.go
+++ b/internal/downloader/sabnzbd/client_test.go
@@ -207,6 +207,7 @@ func TestTest_DNSNotFound(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	msg := err.Error()
 	if !strings.Contains(msg, "same Docker network") {
@@ -226,6 +227,7 @@ func TestTest_ConnectionRefused(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	msg := err.Error()
 	if !strings.Contains(msg, "host firewall is rejecting") {
@@ -245,6 +247,7 @@ func TestTest_Timeout(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	msg := err.Error()
 	if !strings.Contains(msg, "firewall or proxy") {
@@ -265,6 +268,7 @@ func TestTest_ServerError(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	msg := err.Error()
 	for _, hint := range []string{"Docker network", "host firewall is rejecting", "firewall or proxy"} {

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -405,6 +405,7 @@ func TestTest_DNSNotFound(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "same Docker network") {
 		t.Errorf("expected Docker network hint, got: %q", err.Error())
@@ -420,6 +421,7 @@ func TestTest_ConnectionRefused(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "host firewall is rejecting") {
 		t.Errorf("expected port hint, got: %q", err.Error())
@@ -435,6 +437,7 @@ func TestTest_Timeout(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "firewall or proxy") {
 		t.Errorf("expected firewall hint, got: %q", err.Error())
@@ -454,6 +457,7 @@ func TestTest_ServerError_NoHint(t *testing.T) {
 	err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	msg := err.Error()
 	for _, hint := range []string{"Docker network", "host firewall is rejecting", "firewall or proxy"} {

--- a/internal/hardcoverlistsyncer/syncer_test.go
+++ b/internal/hardcoverlistsyncer/syncer_test.go
@@ -34,6 +34,7 @@ func TestNew_WiresRepos(t *testing.T) {
 	s, _ := newTestSyncer(t)
 	if s == nil {
 		t.Fatal("New returned nil")
+		return
 	}
 	if s.importLists == nil || s.authors == nil || s.books == nil {
 		t.Errorf("expected all repo fields to be set, got %+v", s)
@@ -314,6 +315,7 @@ func TestSyncOne_LinksSeriesRefsAfterBookImport(t *testing.T) {
 	}
 	if persisted == nil {
 		t.Fatal("series was not created during sync")
+		return
 	}
 	booksInSeries, err := series.ListBooksInSeries(ctx, persisted.ID)
 	if err != nil {

--- a/internal/httpsec/ssrf_test.go
+++ b/internal/httpsec/ssrf_test.go
@@ -316,6 +316,7 @@ func TestNewDialContext_BlocksLoopback(t *testing.T) {
 	_, err := client.Get(srv.URL) //nolint:bodyclose
 	if err == nil {
 		t.Fatal("expected dial to be rejected for loopback address, got nil error")
+		return
 	}
 	if !strings.Contains(err.Error(), "loopback") {
 		t.Errorf("expected 'loopback' in error, got: %v", err)
@@ -350,6 +351,7 @@ func TestNewDialContext_BlocksRFC1918UnderStrict(t *testing.T) {
 	_, err := dialCtx(ctx, "tcp", "192.168.1.1:80")
 	if err == nil {
 		t.Fatal("expected dial to RFC1918 to be rejected under PolicyStrict")
+		return
 	}
 	if !strings.Contains(err.Error(), "private network") {
 		t.Errorf("expected 'private network' in error, got: %v", err)

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -545,6 +545,7 @@ func TestGetXML_SurfacesNon200(t *testing.T) {
 	_, err := c.Search(context.Background(), "anything", nil)
 	if err == nil {
 		t.Fatalf("expected error on 503, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "503") {
 		t.Errorf("expected error to mention 503, got %v", err)
@@ -579,6 +580,7 @@ func TestParseNewznabError(t *testing.T) {
 			}
 			if err == nil {
 				t.Fatalf("expected error containing %q, got nil", tc.want)
+				return
 			}
 			if !strings.Contains(err.Error(), tc.want) {
 				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
@@ -601,6 +603,7 @@ func TestSearch_SurfacesNewznabError(t *testing.T) {
 	_, err := c.Search(context.Background(), "anything", nil)
 	if err == nil {
 		t.Fatal("expected error on <error> response, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "500") || !strings.Contains(err.Error(), "Request limit reached") {
 		t.Errorf("expected error with indexer code and description, got %v", err)
@@ -952,6 +955,7 @@ func TestNew_HardenedDialerBlocksLoopback(t *testing.T) {
 	_, err := c.Caps(context.Background())
 	if err == nil {
 		t.Fatal("expected connection to loopback to be rejected by the SSRF dialer, got nil error")
+		return
 	}
 	if !strings.Contains(err.Error(), "loopback") {
 		t.Errorf("expected 'loopback' in SSRF dial error, got: %v", err)

--- a/internal/metadata/aggregator_canonical_live_test.go
+++ b/internal/metadata/aggregator_canonical_live_test.go
@@ -68,6 +68,7 @@ func TestLiveAggregatorCanonicalPrimaryBookTortureCorpus(t *testing.T) {
 					}
 					if canonical == nil {
 						t.Fatalf("canonicalPrimaryBook(%q source=%s) = nil, want OpenLibrary work %s", isbnInput, describeCanonicalLiveBook(source), tc.expectedOpenLibraryWork)
+						return
 					}
 					if canonical.ForeignID != tc.expectedOpenLibraryWork {
 						t.Fatalf("canonical.ForeignID = %q, want %q (isbn=%q source=%s)", canonical.ForeignID, tc.expectedOpenLibraryWork, isbnInput, describeCanonicalLiveBook(source))
@@ -104,6 +105,7 @@ func TestLiveAggregatorCanonicalPrimaryBookTortureCorpus(t *testing.T) {
 					}
 					if canonical == nil {
 						t.Fatalf("canonicalPrimaryBook(%q, %q) = nil, want OpenLibrary work %s", titleInput, authorInput, tc.expectedOpenLibraryWork)
+						return
 					}
 					if canonical.ForeignID != tc.expectedOpenLibraryWork {
 						t.Fatalf("canonical.ForeignID = %q, want %q (title=%q author=%q)", canonical.ForeignID, tc.expectedOpenLibraryWork, titleInput, authorInput)
@@ -133,6 +135,7 @@ func assertCanonicalProviderSource(t *testing.T, source *models.Book, tc canonic
 	t.Helper()
 	if source == nil {
 		t.Fatalf("%s source = nil, want provider result", tc.provider)
+		return
 	}
 	if source.MetadataProvider != tc.expectedSourceProvider {
 		t.Fatalf("source provider = %q, want %q (source=%s)", source.MetadataProvider, tc.expectedSourceProvider, describeCanonicalLiveBook(source))

--- a/internal/metadata/aggregator_isbn_test.go
+++ b/internal/metadata/aggregator_isbn_test.go
@@ -52,6 +52,7 @@ func TestAggregator_GetBookByISBN_SearchesRegisteredEnrichers(t *testing.T) {
 			}
 			if got == nil {
 				t.Fatal("expected secondary provider result")
+				return
 			}
 			if got.MetadataProvider != tt.provider {
 				t.Fatalf("MetadataProvider = %q, want %q", got.MetadataProvider, tt.provider)
@@ -488,6 +489,7 @@ func TestAggregator_GetBookByISBN_EnrichesShortDescription(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected book")
+		return
 	}
 	if got.Description == "Short." {
 		t.Fatalf("expected enriched description, got %q", got.Description)

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -306,6 +306,7 @@ func TestAggregator_ResolveBookByISBN_AcceptsDNBWithSyntheticAuthorID(t *testing
 	}
 	if got == nil {
 		t.Fatal("expected DNB result with synthetic author ForeignID to be accepted, got nil")
+		return
 	}
 	if got.Author == nil || got.Author.ForeignID != "dnb:gnd:118585665" {
 		t.Errorf("unexpected resolved author: %+v", got.Author)

--- a/internal/metadata/audnex/client_test.go
+++ b/internal/metadata/audnex/client_test.go
@@ -36,6 +36,7 @@ func TestGetBook(t *testing.T) {
 	}
 	if b == nil {
 		t.Fatal("expected book, got nil")
+		return
 	}
 	if b.NarratorList() != "Scott Brick, Simon Vance" {
 		t.Errorf("NarratorList = %q", b.NarratorList())

--- a/internal/metadata/dnb/client_test.go
+++ b/internal/metadata/dnb/client_test.go
@@ -236,6 +236,7 @@ func TestGetBook_Success(t *testing.T) {
 	}
 	if book == nil {
 		t.Fatal("expected non-nil book")
+		return
 	}
 	if book.ForeignID != "dnb:1234567890" {
 		t.Errorf("ForeignID = %q, want dnb:1234567890", book.ForeignID)
@@ -848,6 +849,7 @@ func TestRecordToBook_TitleHasNoNonSortingBrackets(t *testing.T) {
 	}
 	if book == nil {
 		t.Fatal("GetBookByISBN returned nil book")
+		return
 	}
 	if strings.ContainsRune(book.Title, '\u0098') || strings.ContainsRune(book.Title, '\u009c') {
 		t.Fatalf("Title %q still contains MARC NSB/NSE control characters", book.Title)
@@ -890,6 +892,7 @@ func TestRecordToBook_FallsBackTo700AUT(t *testing.T) {
 	}
 	if book == nil {
 		t.Fatal("nil book returned")
+		return
 	}
 	if book.Author == nil {
 		t.Fatal("Author is nil — 700 fallback did not fire")
@@ -1030,6 +1033,7 @@ func TestRecordToBook_NoAuthorWhenNo100NoAny700(t *testing.T) {
 	}
 	if book == nil {
 		t.Fatal("nil book")
+		return
 	}
 	if book.Author != nil {
 		t.Fatalf("Author should be nil (no 100, no 700); got %+v", book.Author)

--- a/internal/metadata/dnb/live_test.go
+++ b/internal/metadata/dnb/live_test.go
@@ -117,6 +117,7 @@ func TestLive_DNB_AllZippokingISBNs(t *testing.T) {
 			if book == nil {
 				failures = append(failures, tc.isbn)
 				t.Fatalf("[%s] no DNB record for ISBN", tc.source)
+				return
 			}
 			if book.Title == "" {
 				failures = append(failures, tc.isbn)

--- a/internal/metadata/googlebooks/client_test.go
+++ b/internal/metadata/googlebooks/client_test.go
@@ -271,6 +271,7 @@ func TestGetBookByISBN_Found(t *testing.T) {
 	}
 	if book == nil {
 		t.Fatal("expected non-nil book")
+		return
 	}
 	if book.Title != "ISBN Book" {
 		t.Errorf("Title: want 'ISBN Book', got %q", book.Title)

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -161,6 +161,7 @@ func TestQuery_GraphQLErrorsReturnError(t *testing.T) {
 	_, err := c.SearchAuthors(context.Background(), "Sanderson")
 	if err == nil {
 		t.Fatal("expected GraphQL error")
+		return
 	}
 	if !strings.Contains(err.Error(), "Malformed Authorization header") || !strings.Contains(err.Error(), "invalid-headers") {
 		t.Fatalf("unexpected error: %v", err)
@@ -735,6 +736,7 @@ func TestGetAuthor_Found(t *testing.T) {
 	}
 	if author == nil {
 		t.Fatal("expected non-nil author")
+		return
 	}
 	if author.Name != "Neil Gaiman" {
 		t.Errorf("Name: want 'Neil Gaiman', got %q", author.Name)
@@ -832,6 +834,7 @@ func TestGetBook_Found(t *testing.T) {
 	}
 	if book == nil {
 		t.Fatal("expected non-nil book")
+		return
 	}
 	if book.Title != "American Gods" {
 		t.Errorf("Title: want 'American Gods', got %q", book.Title)
@@ -1131,6 +1134,7 @@ func TestGetEditions_GraphQLError(t *testing.T) {
 	_, err := c.GetEditions(context.Background(), "hc:dune")
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "hardcover get editions") {
 		t.Fatalf("error = %v, want hardcover get editions wrapper", err)
@@ -1149,6 +1153,7 @@ func TestGetEditions_HTTPError(t *testing.T) {
 	_, err := c.GetEditions(context.Background(), "hc:dune")
 	if err == nil {
 		t.Fatal("expected error")
+		return
 	}
 	if !strings.Contains(err.Error(), "hardcover get editions") {
 		t.Fatalf("error = %v, want hardcover get editions wrapper", err)
@@ -1177,6 +1182,7 @@ func TestGetBookByISBN_Found(t *testing.T) {
 	}
 	if book == nil {
 		t.Fatal("expected non-nil book")
+		return
 	}
 	if book.Title != "The Name of the Wind" {
 		t.Errorf("Title: want 'The Name of the Wind', got %q", book.Title)
@@ -1213,6 +1219,7 @@ func TestGetBookByISBN_WithLanguage(t *testing.T) {
 	}
 	if book == nil {
 		t.Fatal("expected non-nil book")
+		return
 	}
 	if strings.Contains(gotQuery, "iso_639_1") {
 		t.Fatalf("GetBookByISBN query uses unsupported language field: %s", gotQuery)
@@ -1248,6 +1255,7 @@ func TestGetBookByISBN_NoLanguage(t *testing.T) {
 	}
 	if book == nil {
 		t.Fatal("expected non-nil book")
+		return
 	}
 	if book.Language != "" {
 		t.Errorf("Language: want empty, got %q", book.Language)
@@ -1349,6 +1357,7 @@ func TestSearchSeries_ErrorsWhenMatchesCannotBeMapped(t *testing.T) {
 	_, err := c.SearchSeries(context.Background(), "Dune", 5)
 	if err == nil {
 		t.Fatal("expected unmappable search response error")
+		return
 	}
 	if !strings.Contains(err.Error(), "no mappable series documents") {
 		t.Fatalf("unexpected error: %v", err)
@@ -1433,6 +1442,7 @@ func TestGetSeriesCatalog_ParsesAndDedupesBooks(t *testing.T) {
 	}
 	if catalog == nil {
 		t.Fatal("expected catalog")
+		return
 	}
 	if catalog.ForeignID != "hc-series:123" || catalog.Title != "Foundation" || catalog.AuthorName != "Isaac Asimov" {
 		t.Fatalf("unexpected catalog: %+v", catalog)

--- a/internal/metadata/isbn_provider_live_test.go
+++ b/internal/metadata/isbn_provider_live_test.go
@@ -61,6 +61,7 @@ func TestLiveISBNProviderFallbackTortureCorpus(t *testing.T) {
 					}
 					if got == nil {
 						t.Fatalf("GetBookByISBN(%q) = nil, want OpenLibrary work %s", isbnInput, tc.expectedOpenLibraryWork)
+						return
 					}
 					if got.MetadataProvider != "openlibrary" || got.ForeignID != tc.expectedOpenLibraryWork {
 						t.Fatalf("GetBookByISBN(%q) = %s, want provider=%q foreignID=%q", isbnInput, describeLiveISBNBook(got), "openlibrary", tc.expectedOpenLibraryWork)

--- a/internal/metadata/live_provider_test.go
+++ b/internal/metadata/live_provider_test.go
@@ -337,6 +337,7 @@ func assertLiveBook(t *testing.T, book *models.Book, provider string, want liveB
 	t.Helper()
 	if book == nil {
 		t.Fatal("book = nil, want live provider result")
+		return
 	}
 	if book.ForeignID == "" {
 		t.Fatal("ForeignID is empty")

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -422,6 +422,7 @@ func TestGetBookByISBN_HTTP_WithWorkRef(t *testing.T) {
 	}
 	if book == nil {
 		t.Fatal("expected non-nil book")
+		return
 	}
 	// Should resolve the work, not the edition stub
 	if book.Title != "Dune" {

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -225,6 +225,7 @@ func TestNew_DefaultValidator(t *testing.T) {
 	n := New(nil)
 	if n == nil {
 		t.Fatal("New returned nil")
+		return
 	}
 	if n.validate == nil {
 		t.Fatal("New did not install a validator")

--- a/internal/opds/builder_test.go
+++ b/internal/opds/builder_test.go
@@ -248,6 +248,7 @@ func TestBuildAuthor_Acquisition(t *testing.T) {
 	acq := findLink(entry.Links, RelAcquisition)
 	if acq == nil {
 		t.Fatal("acquisition link missing")
+		return
 	}
 	if acq.Href != "http://host:8787/opds/book/10/file" {
 		t.Errorf("acq href = %q", acq.Href)
@@ -421,6 +422,7 @@ func mustHaveRel(t *testing.T, links []Link, rel, href string) {
 	l := findLink(links, rel)
 	if l == nil {
 		t.Fatalf("missing rel=%s", rel)
+		return
 	}
 	if l.Href != href {
 		t.Errorf("rel=%s href = %q, want %q", rel, l.Href, href)

--- a/internal/prowlarr/client_test.go
+++ b/internal/prowlarr/client_test.go
@@ -397,6 +397,7 @@ func TestFetchIndexers_ReturnsApplicationScopeError(t *testing.T) {
 	_, err := New(srv.URL, "key").FetchIndexers(context.Background())
 	if err == nil {
 		t.Fatal("expected application scope error, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "fetch prowlarr applications") {
 		t.Fatalf("error = %v, want fetch prowlarr applications", err)
@@ -460,6 +461,7 @@ func TestFetchIndexers_Unauthorized(t *testing.T) {
 	_, err := c.FetchIndexers(context.Background())
 	if err == nil {
 		t.Fatal("expected error on 401, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "invalid Prowlarr API key") {
 		t.Errorf("unexpected error %v", err)
@@ -477,6 +479,7 @@ func TestFetchIndexers_Non200(t *testing.T) {
 	_, err := c.FetchIndexers(context.Background())
 	if err == nil {
 		t.Fatal("expected error on 500, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "500") {
 		t.Errorf("expected 500 in error, got %v", err)
@@ -494,6 +497,7 @@ func TestFetchIndexers_BadJSON(t *testing.T) {
 	_, err := c.FetchIndexers(context.Background())
 	if err == nil {
 		t.Fatal("expected error on bad JSON, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "decode prowlarr indexers") {
 		t.Errorf("expected decode error, got %v", err)
@@ -547,6 +551,7 @@ func TestTest_NetworkError(t *testing.T) {
 	_, err := c.Test(context.Background())
 	if err == nil {
 		t.Fatal("expected error on connection refused, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "could not reach Prowlarr") {
 		t.Errorf("expected 'could not reach Prowlarr' in error, got %v", err)

--- a/internal/scheduler/scheduler_jobs_test.go
+++ b/internal/scheduler/scheduler_jobs_test.go
@@ -66,6 +66,7 @@ func TestNew_Construction(t *testing.T) {
 	s := New(context.Background(), nil, nil, nil, authors, books, indexers, downloads, clients, settings, blocklist)
 	if s == nil {
 		t.Fatal("New returned nil")
+		return
 	}
 	if s.cron == nil {
 		t.Fatal("cron field not initialized")

--- a/tests/security/ssrf_test.go
+++ b/tests/security/ssrf_test.go
@@ -112,6 +112,7 @@ func TestSSRF_ErrorMessages(t *testing.T) {
 	err := httpsec.ValidateOutboundURL("http://127.0.0.1/", httpsec.PolicyStrict)
 	if err == nil {
 		t.Fatal("expected error for loopback")
+		return
 	}
 	msg := strings.ToLower(err.Error())
 	allowed := []string{"loopback", "private", "disallowed", "blocked", "not allowed"}


### PR DESCRIPTION
CI's golangci-lint (v2.11.4) reports SA5011 (\"possible nil pointer dereference\") on three sites in \`internal/abs\` test files. The pattern is:

\`\`\`go
if x == nil { t.Fatal(\"...\") }
y := x.Field   // SA5011 fires here
\`\`\`

\`staticcheck\` doesn't see \`t.Fatal\` as terminating, so the follow-up field access counts as a possible nil deref. Adding an explicit \`return\` after each terminal \`t.Fatal\` quiets the analyzer without changing runtime behaviour (`t.Fatal` already ends the test via `runtime.Goexit`).

These failures didn't trigger pre-release because the previous golangci-lint pass apparently used a different staticcheck version. They started biting #838's CI today.

## Why now

Blocks #838 (i18n migration). Fixed test files as defensive belt-and-braces so the analyzer can't false-positive again on this pattern.

## Test plan

- [x] \`gofmt -l internal/abs\` clean
- [x] \`go vet ./internal/abs/...\` clean
- [x] \`go test ./internal/abs/... -count=1\` green
- Local lint is silent on this (different staticcheck resolution); CI will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)