### PR TITLE
fix(security): gate indexer/prowlarr/downloadclient list/get behind RequireAdmin

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -681,43 +681,19 @@ func main() {
 		r.Get("/wanted/missing", bookHandler.ListWanted)
 		r.Post("/wanted/bulk", bulkHandler.WantedBulk)
 
-		// Indexers — reads available to all; mutations admin-only.
-		r.Get("/indexer", indexerHandler.List)
-		r.Get("/indexer/{id}", indexerHandler.Get)
-		r.Get("/indexer/search", indexerHandler.SearchQuery)
-		r.Get("/search/last-debug", indexerHandler.LastSearchDebug)
-		r.Group(func(r chi.Router) {
-			r.Use(auth.RequireAdmin)
-			r.Post("/indexer", indexerHandler.Create)
-			r.Put("/indexer/{id}", indexerHandler.Update)
-			r.Delete("/indexer/{id}", indexerHandler.Delete)
-			r.Post("/indexer/{id}/test", indexerHandler.Test)
-		})
-
-		// Prowlarr indexer sync
-		r.Get("/prowlarr", prowlarrHandler.List)
-		r.Post("/prowlarr", prowlarrHandler.Create)
-		r.Get("/prowlarr/{id}", prowlarrHandler.Get)
-		r.Put("/prowlarr/{id}", prowlarrHandler.Update)
-		r.Delete("/prowlarr/{id}", prowlarrHandler.Delete)
-		r.Post("/prowlarr/{id}/test", prowlarrHandler.Test)
-		r.Post("/prowlarr/{id}/sync", prowlarrHandler.Sync)
+		// Indexers, Prowlarr, and Download clients all return responses that
+		// embed third-party credentials (APIKey, Password). Their routes are
+		// registered via dedicated helpers so the admin-gate boundary is
+		// enforced by a single, testable shape — see cmd/bindery/sensitive_routes.go.
+		registerIndexerRoutes(r, indexerHandler)
+		registerProwlarrRoutes(r, prowlarrHandler)
 
 		// Root folders
 		r.Get("/rootfolder", rootFolderHandler.List)
 		r.Post("/rootfolder", rootFolderHandler.Create)
 		r.Delete("/rootfolder/{id}", rootFolderHandler.Delete)
 
-		// Download clients — reads available to all; mutations admin-only.
-		r.Get("/downloadclient", dlClientHandler.List)
-		r.Get("/downloadclient/{id}", dlClientHandler.Get)
-		r.Group(func(r chi.Router) {
-			r.Use(auth.RequireAdmin)
-			r.Post("/downloadclient", dlClientHandler.Create)
-			r.Put("/downloadclient/{id}", dlClientHandler.Update)
-			r.Delete("/downloadclient/{id}", dlClientHandler.Delete)
-			r.Post("/downloadclient/{id}/test", dlClientHandler.Test)
-		})
+		registerDownloadClientRoutes(r, dlClientHandler)
 
 		// Queue
 		r.Get("/queue", queueHandler.List)

--- a/cmd/bindery/sensitive_routes.go
+++ b/cmd/bindery/sensitive_routes.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+)
+
+// indexerRouteHandler is the surface registerIndexerRoutes needs. The full
+// IndexerHandler exposes more methods (SearchBook, LastSearchDebug,
+// resolveAllowedLanguages); only the routes mounted under /indexer are listed
+// here so tests can supply a stub.
+type indexerRouteHandler interface {
+	List(http.ResponseWriter, *http.Request)
+	Get(http.ResponseWriter, *http.Request)
+	Create(http.ResponseWriter, *http.Request)
+	Update(http.ResponseWriter, *http.Request)
+	Delete(http.ResponseWriter, *http.Request)
+	Test(http.ResponseWriter, *http.Request)
+	SearchQuery(http.ResponseWriter, *http.Request)
+	LastSearchDebug(http.ResponseWriter, *http.Request)
+}
+
+// registerIndexerRoutes mounts the /indexer and /search/last-debug routes.
+// List/Get are admin-only because the response includes Indexer.APIKey.
+// SearchQuery and LastSearchDebug return only release metadata, so they stay
+// open to authenticated non-admin users.
+func registerIndexerRoutes(r chi.Router, h indexerRouteHandler) {
+	r.Get("/indexer/search", h.SearchQuery)
+	r.Get("/search/last-debug", h.LastSearchDebug)
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAdmin)
+		r.Get("/indexer", h.List)
+		r.Get("/indexer/{id}", h.Get)
+		r.Post("/indexer", h.Create)
+		r.Put("/indexer/{id}", h.Update)
+		r.Delete("/indexer/{id}", h.Delete)
+		r.Post("/indexer/{id}/test", h.Test)
+	})
+}
+
+// prowlarrRouteHandler is the surface registerProwlarrRoutes needs.
+type prowlarrRouteHandler interface {
+	List(http.ResponseWriter, *http.Request)
+	Get(http.ResponseWriter, *http.Request)
+	Create(http.ResponseWriter, *http.Request)
+	Update(http.ResponseWriter, *http.Request)
+	Delete(http.ResponseWriter, *http.Request)
+	Test(http.ResponseWriter, *http.Request)
+	Sync(http.ResponseWriter, *http.Request)
+}
+
+// registerProwlarrRoutes mounts /prowlarr/* — the entire subtree is admin-only
+// because List/Get return ProwlarrInstance.APIKey and the mutations always were.
+func registerProwlarrRoutes(r chi.Router, h prowlarrRouteHandler) {
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAdmin)
+		r.Get("/prowlarr", h.List)
+		r.Post("/prowlarr", h.Create)
+		r.Get("/prowlarr/{id}", h.Get)
+		r.Put("/prowlarr/{id}", h.Update)
+		r.Delete("/prowlarr/{id}", h.Delete)
+		r.Post("/prowlarr/{id}/test", h.Test)
+		r.Post("/prowlarr/{id}/sync", h.Sync)
+	})
+}
+
+// downloadClientRouteHandler is the surface registerDownloadClientRoutes needs.
+type downloadClientRouteHandler interface {
+	List(http.ResponseWriter, *http.Request)
+	Get(http.ResponseWriter, *http.Request)
+	Create(http.ResponseWriter, *http.Request)
+	Update(http.ResponseWriter, *http.Request)
+	Delete(http.ResponseWriter, *http.Request)
+	Test(http.ResponseWriter, *http.Request)
+}
+
+// registerDownloadClientRoutes mounts /downloadclient/* — entire subtree is
+// admin-only because List/Get return DownloadClient.Username, Password, APIKey.
+func registerDownloadClientRoutes(r chi.Router, h downloadClientRouteHandler) {
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAdmin)
+		r.Get("/downloadclient", h.List)
+		r.Get("/downloadclient/{id}", h.Get)
+		r.Post("/downloadclient", h.Create)
+		r.Put("/downloadclient/{id}", h.Update)
+		r.Delete("/downloadclient/{id}", h.Delete)
+		r.Post("/downloadclient/{id}/test", h.Test)
+	})
+}

--- a/cmd/bindery/sensitive_routes_test.go
+++ b/cmd/bindery/sensitive_routes_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+)
+
+// stubSensitiveHandler stands in for the indexer, prowlarr, and download
+// client handlers in route-auth tests. Every method records its name and
+// writes 204; if RequireAdmin rejects the request the handler never runs,
+// so an empty `called` slice with status 403 is the regression-free path.
+type stubSensitiveHandler struct {
+	called []string
+}
+
+func (h *stubSensitiveHandler) record(name string, w http.ResponseWriter) {
+	h.called = append(h.called, name)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *stubSensitiveHandler) List(w http.ResponseWriter, _ *http.Request) {
+	h.record("list", w)
+}
+func (h *stubSensitiveHandler) Get(w http.ResponseWriter, _ *http.Request) {
+	h.record("get", w)
+}
+func (h *stubSensitiveHandler) Create(w http.ResponseWriter, _ *http.Request) {
+	h.record("create", w)
+}
+func (h *stubSensitiveHandler) Update(w http.ResponseWriter, _ *http.Request) {
+	h.record("update", w)
+}
+func (h *stubSensitiveHandler) Delete(w http.ResponseWriter, _ *http.Request) {
+	h.record("delete", w)
+}
+func (h *stubSensitiveHandler) Test(w http.ResponseWriter, _ *http.Request) {
+	h.record("test", w)
+}
+func (h *stubSensitiveHandler) Sync(w http.ResponseWriter, _ *http.Request) {
+	h.record("sync", w)
+}
+func (h *stubSensitiveHandler) SearchQuery(w http.ResponseWriter, _ *http.Request) {
+	h.record("search-query", w)
+}
+func (h *stubSensitiveHandler) LastSearchDebug(w http.ResponseWriter, _ *http.Request) {
+	h.record("last-search-debug", w)
+}
+
+// TestSensitiveRoutesRequireAdmin nails down the security finding from the
+// v1.15.0 review: List/Get/Create/Update/Delete on the indexer, prowlarr, and
+// download-client subtrees must all reject a non-admin caller. The full
+// failure mode was that role=user could `GET /indexer` and read every
+// Indexer.APIKey out of the response — same for ProwlarrInstance.APIKey and
+// DownloadClient.{Username,Password,APIKey}. A future addition that forgets
+// to put a new route inside the admin Group will trip this test.
+func TestSensitiveRoutesRequireAdmin(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		// Indexer — both reads and mutations are admin-only because the
+		// response struct carries APIKey.
+		{name: "list indexers", method: http.MethodGet, path: "/indexer"},
+		{name: "get indexer", method: http.MethodGet, path: "/indexer/1"},
+		{name: "create indexer", method: http.MethodPost, path: "/indexer"},
+		{name: "update indexer", method: http.MethodPut, path: "/indexer/1"},
+		{name: "delete indexer", method: http.MethodDelete, path: "/indexer/1"},
+		{name: "test indexer", method: http.MethodPost, path: "/indexer/1/test"},
+		// Prowlarr — entire subtree.
+		{name: "list prowlarr", method: http.MethodGet, path: "/prowlarr"},
+		{name: "get prowlarr", method: http.MethodGet, path: "/prowlarr/1"},
+		{name: "create prowlarr", method: http.MethodPost, path: "/prowlarr"},
+		{name: "update prowlarr", method: http.MethodPut, path: "/prowlarr/1"},
+		{name: "delete prowlarr", method: http.MethodDelete, path: "/prowlarr/1"},
+		{name: "test prowlarr", method: http.MethodPost, path: "/prowlarr/1/test"},
+		{name: "sync prowlarr", method: http.MethodPost, path: "/prowlarr/1/sync"},
+		// Download clients — both reads and mutations.
+		{name: "list download clients", method: http.MethodGet, path: "/downloadclient"},
+		{name: "get download client", method: http.MethodGet, path: "/downloadclient/1"},
+		{name: "create download client", method: http.MethodPost, path: "/downloadclient"},
+		{name: "update download client", method: http.MethodPut, path: "/downloadclient/1"},
+		{name: "delete download client", method: http.MethodDelete, path: "/downloadclient/1"},
+		{name: "test download client", method: http.MethodPost, path: "/downloadclient/1/test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &stubSensitiveHandler{}
+			router := chi.NewRouter()
+			registerIndexerRoutes(router, h)
+			registerProwlarrRoutes(router, h)
+			registerDownloadClientRoutes(router, h)
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req = req.WithContext(auth.WithUserRole(req.Context(), "user"))
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d; want %d (RequireAdmin should reject role=user)", rec.Code, http.StatusForbidden)
+			}
+			if len(h.called) != 0 {
+				t.Fatalf("handler invoked for non-admin request: %v", h.called)
+			}
+		})
+	}
+}
+
+// TestSensitiveRoutesAllowAdmin is the symmetry case: an admin caller must
+// reach every handler the previous test asserts is gated. Without this we'd
+// risk over-tightening the gate (e.g. accidentally mounting routes outside
+// the Group so they 404 instead of dispatching) and not noticing.
+func TestSensitiveRoutesAllowAdmin(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		called string
+	}{
+		{name: "list indexers", method: http.MethodGet, path: "/indexer", called: "list"},
+		{name: "get indexer", method: http.MethodGet, path: "/indexer/1", called: "get"},
+		{name: "create indexer", method: http.MethodPost, path: "/indexer", called: "create"},
+		{name: "update indexer", method: http.MethodPut, path: "/indexer/1", called: "update"},
+		{name: "delete indexer", method: http.MethodDelete, path: "/indexer/1", called: "delete"},
+		{name: "test indexer", method: http.MethodPost, path: "/indexer/1/test", called: "test"},
+		{name: "list prowlarr", method: http.MethodGet, path: "/prowlarr", called: "list"},
+		{name: "get prowlarr", method: http.MethodGet, path: "/prowlarr/1", called: "get"},
+		{name: "create prowlarr", method: http.MethodPost, path: "/prowlarr", called: "create"},
+		{name: "update prowlarr", method: http.MethodPut, path: "/prowlarr/1", called: "update"},
+		{name: "delete prowlarr", method: http.MethodDelete, path: "/prowlarr/1", called: "delete"},
+		{name: "test prowlarr", method: http.MethodPost, path: "/prowlarr/1/test", called: "test"},
+		{name: "sync prowlarr", method: http.MethodPost, path: "/prowlarr/1/sync", called: "sync"},
+		{name: "list download clients", method: http.MethodGet, path: "/downloadclient", called: "list"},
+		{name: "get download client", method: http.MethodGet, path: "/downloadclient/1", called: "get"},
+		{name: "create download client", method: http.MethodPost, path: "/downloadclient", called: "create"},
+		{name: "update download client", method: http.MethodPut, path: "/downloadclient/1", called: "update"},
+		{name: "delete download client", method: http.MethodDelete, path: "/downloadclient/1", called: "delete"},
+		{name: "test download client", method: http.MethodPost, path: "/downloadclient/1/test", called: "test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &stubSensitiveHandler{}
+			router := chi.NewRouter()
+			registerIndexerRoutes(router, h)
+			registerProwlarrRoutes(router, h)
+			registerDownloadClientRoutes(router, h)
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req = req.WithContext(auth.WithUserRole(req.Context(), "admin"))
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d; want %d", rec.Code, http.StatusNoContent)
+			}
+			if len(h.called) != 1 || h.called[0] != tt.called {
+				t.Fatalf("called = %v; want [%s]", h.called, tt.called)
+			}
+		})
+	}
+}
+
+// TestIndexerPublicReadsAllowNonAdmin keeps a guard on the routes we explicitly
+// chose *not* to gate: /indexer/search returns release metadata only (no
+// credentials) and /search/last-debug returns the most recent search audit
+// trail. If a future refactor mistakenly drops them inside the admin Group,
+// non-admin users would lose freeform search.
+func TestIndexerPublicReadsAllowNonAdmin(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		called string
+	}{
+		{name: "indexer search", path: "/indexer/search", called: "search-query"},
+		{name: "last search debug", path: "/search/last-debug", called: "last-search-debug"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &stubSensitiveHandler{}
+			router := chi.NewRouter()
+			registerIndexerRoutes(router, h)
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req = req.WithContext(auth.WithUserRole(req.Context(), "user"))
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d; want %d (non-admin must reach public reads)", rec.Code, http.StatusNoContent)
+			}
+			if len(h.called) != 1 || h.called[0] != tt.called {
+				t.Fatalf("called = %v; want [%s]", h.called, tt.called)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What was broken

`GET /indexer`, `GET /indexer/{id}`, the entire `/prowlarr/*` subtree, and `GET /downloadclient`, `GET /downloadclient/{id}` were mounted outside the `RequireAdmin` group. Any authenticated user — `role=user` included — could:

- read `models.Indexer.APIKey` in full (`apiKey` json tag, no redaction);
- read `models.ProwlarrInstance.APIKey` in full;
- read `models.DownloadClient.Username`, `Password`, and `APIKey` in full (qBittorrent / SABnzbd credentials).

The Prowlarr mutations (`Create`, `Update`, `Delete`, `Test`, `Sync`) were also ungated, so any non-admin could point a Prowlarr instance at an attacker-controlled URL and trigger a sync against it.

This is the obvious bug. There is no redemption arc for it — `RequireAdmin` exists exactly so this can't happen, and somebody just forgot to use it.

## What shipped

- Move `List`/`Get`/`Create`/`Update`/`Delete`/`Test` for indexer and downloadclient, and the whole prowlarr subtree, into the `RequireAdmin` group.
- Extract the three route subtrees into `registerIndexerRoutes`, `registerProwlarrRoutes`, `registerDownloadClientRoutes` in `cmd/bindery/sensitive_routes.go` — matching the pre-existing `registerSeriesRoutes` shape in `cmd/bindery/series_routes.go`. Collapses the admin-gate boundary to a single, testable shape per resource and stops `main.go` from drifting back into the per-route style that hid the original bug.
- `GET /indexer/search` and `GET /search/last-debug` stay open. Verified the response types: `SearchQuery` returns `[]newznab.SearchResult` (release metadata, no credentials) and `LastSearchDebug` returns `SearchDebug` (per-indexer audit trail, also no credentials). Non-admin freeform search continues to work.

## Regression test

`cmd/bindery/sensitive_routes_test.go` adds three table-driven tests:

- `TestSensitiveRoutesRequireAdmin` — every read and mutation on the three subtrees must 403 for `role=user`. The brief listed seven routes; the test covers all 19 routes across the three subtrees, so any future addition that mounts outside the admin group trips it.
- `TestSensitiveRoutesAllowAdmin` — same matrix, admin role, must dispatch.
- `TestIndexerPublicReadsAllowNonAdmin` — `indexer/search` and `search/last-debug` stay reachable from non-admin sessions; if a future refactor drops them inside the admin group, this fails first.

The original gap would have been caught by `TestSensitiveRoutesRequireAdmin`. The series routes already had `TestSeriesMutationRoutesRequireAdmin` — same idea, just nobody applied it to the credentialed resources.

## Out of scope

- Backup routes (`/backup` Create/Restore/Delete) — separate PR pending from maintainer.
- `models.Notification.Headers` carries arbitrary HTTP headers, including authorization tokens, and `GET /notification` returns them ungated. Same shape as this bug. Not touched here because it wasn't in the brief; flagging it because it's the next domino. Anyone who can read indexer keys can also read notification webhook tokens via that route.
- `models.ImportList.APIKey` is already redacted at the response layer via `importListResponse` — not vulnerable, despite carrying an `apiKey` json tag.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint v2.11.4` clean (0 issues)
- [x] `go test ./cmd/... ./internal/...` green, including new tests
- [x] `cd web && npm run typecheck && npm run lint && npm run build && npm test` clean