### PR TITLE
fix(security): hardening sweep — 5 P1+P2 findings from the v1.15.0 review

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -178,6 +178,21 @@ func main() {
 	// and the proxy-auth identity check).
 	trustedCIDRs := parseTrustedProxyCIDRs(os.Getenv("BINDERY_TRUSTED_PROXY"))
 
+	// Warn loudly when the trusted-proxy allowlist effectively trusts every
+	// possible peer (0.0.0.0/0 or ::/0). In that shape every client's
+	// X-Forwarded-For header is honoured, defeating the login rate-limiter
+	// (which keys off the post-RealIP `RemoteAddr`) and any other per-IP
+	// decision in the stack. Operators sometimes do this in Helm charts to
+	// silence the proxy-mode safety gate without thinking through the
+	// implication; surfacing it at boot makes the misconfiguration obvious.
+	for _, c := range trustedCIDRs {
+		ones, bits := c.Mask.Size()
+		if ones == 0 && bits > 0 {
+			slog.Warn("BINDERY_TRUSTED_PROXY entry trusts every peer — login rate-limiter and per-IP decisions are effectively disabled",
+				"cidr", c.String())
+		}
+	}
+
 	// Safety gate: proxy auth mode requires at least one trusted proxy CIDR so
 	// that the identity header cannot be forged by arbitrary LAN hosts.
 	if s, _ := settingsRepo.Get(ctxBoot, api.SettingAuthMode); s != nil && s.Value == string(auth.ModeProxy) {
@@ -836,11 +851,17 @@ func main() {
 		r.Put("/customformat/{id}", customFormatHandler.Update)
 		r.Delete("/customformat/{id}", customFormatHandler.Delete)
 
-		// Backups
-		r.Get("/backup", backupHandler.List)
-		r.Post("/backup", backupHandler.Create)
-		r.Post("/backup/{filename}/restore", backupHandler.Restore)
-		r.Delete("/backup/{filename}", backupHandler.Delete)
+		// Backups — Restore overwrites the live database, Delete removes
+		// stored backups, and List leaks filenames containing timestamps that
+		// help an attacker target Restore. Admin-only across the whole
+		// surface.
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireAdmin)
+			r.Get("/backup", backupHandler.List)
+			r.Post("/backup", backupHandler.Create)
+			r.Post("/backup/{filename}/restore", backupHandler.Restore)
+			r.Delete("/backup/{filename}", backupHandler.Delete)
+		})
 
 		// System logs
 		r.Get("/system/logs", logHandler.List)

--- a/internal/abs/client.go
+++ b/internal/abs/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/useragent"
 )
 
@@ -56,6 +57,23 @@ func NormalizeBaseURL(raw string) (string, error) {
 		u.Path = ""
 	}
 	return u.String(), nil
+}
+
+// ValidateBaseURLSecure layers an SSRF policy check on top of NormalizeBaseURL.
+// Use this at the admin-input boundary (settings save) to refuse base URLs
+// that point at link-local or cloud-metadata endpoints. Loopback and RFC1918
+// are still allowed via PolicyLAN for typical homelab deployments. NewClient
+// callers should keep using NormalizeBaseURL directly so test fixtures with
+// httptest (loopback) still work.
+func ValidateBaseURLSecure(raw string) (string, error) {
+	u, err := NormalizeBaseURL(raw)
+	if err != nil {
+		return "", err
+	}
+	if err := httpsec.ValidateOutboundURL(u, httpsec.PolicyLAN); err != nil {
+		return "", fmt.Errorf("base_url %q: %w", raw, err)
+	}
+	return u, nil
 }
 
 func NormalizeAPIKey(raw string) (string, error) {

--- a/internal/api/auth_oidc.go
+++ b/internal/api/auth_oidc.go
@@ -336,6 +336,10 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		}
 		// Decide the provisioning role (issue #688). Start from the configured
 		// default; the promote-first-OIDC-user fallback may upgrade it to admin.
+		// The fallback is gated by SettingsRepo.SetIfAbsent on the
+		// FirstAdminPromoted guard — only one concurrent first-time login can
+		// win the race and become admin; any other simultaneous logins fall
+		// back to the default role even when they all observed admins == 0.
 		provisionRole := h.resolveProvisionRole(ctx)
 		user, err = h.users.GetOrCreateByOIDC(ctx,
 			claims.Issuer, claims.Sub,
@@ -346,13 +350,6 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			slog.Error("oidc: user provisioning failed", "error", err)
 			writeErr(w, http.StatusInternalServerError, "user provisioning failed")
 			return
-		}
-		// If the fallback fired, record the one-shot guard so deleting all
-		// admins later cannot silently re-promote a future first OIDC user.
-		if provisionRole == "admin" && user.Role == "admin" {
-			if err := h.settings.Set(ctx, SettingOIDCFirstAdminPromoted, "true"); err != nil {
-				slog.Warn("oidc: failed to persist first-admin-promoted flag", "error", err)
-			}
 		}
 	}
 
@@ -413,22 +410,29 @@ func (h *OIDCHandler) resolveProvisionRole(ctx context.Context) string {
 	if h.localAuthEnabled {
 		return role // local auth still offers a recovery path
 	}
-	if s, err := h.settings.Get(ctx, SettingOIDCFirstAdminPromoted); err != nil {
-		slog.Warn("oidc: cannot read first-admin-promoted guard; skipping promote-first fallback", "error", err)
-		return role
-	} else if s != nil && s.Value == "true" {
-		return role // fallback already used once
-	}
 	admins, err := h.users.CountAdmins(ctx)
 	if err != nil {
 		slog.Warn("oidc: cannot count admins; skipping promote-first fallback", "error", err)
 		return role
 	}
-	if admins == 0 {
-		slog.Warn("oidc: promoting first OIDC user to admin — local auth disabled and no admin exists")
-		return "admin"
+	if admins != 0 {
+		return role
 	}
-	return role
+	// Atomically claim the promote-first slot. SetIfAbsent is an INSERT ON
+	// CONFLICT DO NOTHING — exactly one concurrent first-time login wins; any
+	// other simultaneous login that also saw admins == 0 loses here and falls
+	// back to the default role. Without this, a TOCTOU race between the count
+	// and the legacy Get+Set guard could promote two users to admin.
+	won, err := h.settings.SetIfAbsent(ctx, SettingOIDCFirstAdminPromoted, "true")
+	if err != nil {
+		slog.Warn("oidc: cannot claim first-admin guard; skipping promote-first fallback", "error", err)
+		return role
+	}
+	if !won {
+		return role // another concurrent first-time login already claimed it
+	}
+	slog.Warn("oidc: promoting first OIDC user to admin — local auth disabled and no admin exists")
+	return "admin"
 }
 
 // TestDiscovery probes <issuer>/.well-known/openid-configuration and returns

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -116,13 +116,13 @@ func asciiFallback(name string) string {
 
 // isAllowedPath reports whether p falls under one of the configured library
 // roots. Paths are compared after filepath.Clean so trailing slashes and
-// `..` traversal don't bypass the check. If no roots are configured the
-// handler falls back to allowing any path — this preserves behaviour for
-// installs that haven't set BINDERY_LIBRARY_DIR and for tests that wire
-// the handler without roots.
+// `..` traversal don't bypass the check. Fails CLOSED when no roots are
+// configured — a production install missing BINDERY_LIBRARY_DIR should not
+// silently degrade to "serve any path on disk". Tests that need an unscoped
+// handler must seed allowedRoots explicitly (e.g. t.TempDir()).
 func (h *FileHandler) isAllowedPath(p string) bool {
 	if len(h.allowedRoots) == 0 {
-		return true
+		return false
 	}
 	p = filepath.Clean(p)
 	for _, root := range h.allowedRoots {

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
-func fileFixture(t *testing.T) (*FileHandler, *db.BookRepo, *models.Author, context.Context) {
+func fileFixture(t *testing.T) (*FileHandler, *db.BookRepo, *models.Author, context.Context, string) {
 	t.Helper()
 	database, err := db.OpenMemory()
 	if err != nil {
@@ -31,11 +31,15 @@ func fileFixture(t *testing.T) (*FileHandler, *db.BookRepo, *models.Author, cont
 	if err := authors.Create(ctx, author); err != nil {
 		t.Fatal(err)
 	}
-	return NewFileHandler(books), books, author, ctx
+	// isAllowedPath fails closed when no roots are configured (security
+	// hardening sweep); fixture returns its TempDir as the configured root
+	// and the test stores book file paths under it.
+	root := t.TempDir()
+	return NewFileHandler(books, root), books, author, ctx, root
 }
 
 func TestFileDownload_BadID(t *testing.T) {
-	h, _, _, _ := fileFixture(t)
+	h, _, _, _, _ := fileFixture(t)
 	rec := httptest.NewRecorder()
 	h.Download(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/file/abc/download", nil), "id", "abc"))
 	if rec.Code != http.StatusBadRequest {
@@ -44,7 +48,7 @@ func TestFileDownload_BadID(t *testing.T) {
 }
 
 func TestFileDownload_NotFound(t *testing.T) {
-	h, _, _, _ := fileFixture(t)
+	h, _, _, _, _ := fileFixture(t)
 	rec := httptest.NewRecorder()
 	h.Download(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/file/999/download", nil), "id", "999"))
 	if rec.Code != http.StatusNotFound {
@@ -53,7 +57,7 @@ func TestFileDownload_NotFound(t *testing.T) {
 }
 
 func TestFileDownload_NoFilePath(t *testing.T) {
-	h, books, author, ctx := fileFixture(t)
+	h, books, author, ctx, _ := fileFixture(t)
 	book := &models.Book{ForeignID: "OL1B", AuthorID: author.ID, Title: "T"}
 	if err := books.Create(ctx, book); err != nil {
 		t.Fatal(err)
@@ -66,13 +70,14 @@ func TestFileDownload_NoFilePath(t *testing.T) {
 }
 
 func TestFileDownload_FileMissingOnDisk(t *testing.T) {
-	h, books, author, ctx := fileFixture(t)
+	h, books, author, ctx, tmp := fileFixture(t)
 	book := &models.Book{ForeignID: "OL1B", AuthorID: author.ID, Title: "T"}
 	if err := books.Create(ctx, book); err != nil {
 		t.Fatal(err)
 	}
-	// FilePath set to a non-existent path.
-	if err := books.SetFilePath(ctx, book.ID, "/nope/not-a-real-path.epub"); err != nil {
+	// FilePath set to a path under the allowed root but the file doesn't
+	// exist — isAllowedPath passes, os.Stat fails → 404.
+	if err := books.SetFilePath(ctx, book.ID, filepath.Join(tmp, "missing.epub")); err != nil {
 		t.Fatal(err)
 	}
 	rec := httptest.NewRecorder()
@@ -82,9 +87,27 @@ func TestFileDownload_FileMissingOnDisk(t *testing.T) {
 	}
 }
 
+func TestFileDownload_PathOutsideAllowedRoots(t *testing.T) {
+	h, books, author, ctx, _ := fileFixture(t)
+	book := &models.Book{ForeignID: "OL1C", AuthorID: author.ID, Title: "T"}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	// Path is outside the configured allowedRoots — isAllowedPath fails
+	// closed → 403, defending against tampered DB rows or importer bugs
+	// that point at /etc/passwd or anywhere else off the library tree.
+	if err := books.SetFilePath(ctx, book.ID, "/etc/passwd"); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	h.Download(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/file/1/download", nil), "id", "1"))
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("out-of-root path: expected 403, got %d", rec.Code)
+	}
+}
+
 func TestFileDownload_EbookFile(t *testing.T) {
-	h, books, author, ctx := fileFixture(t)
-	tmp := t.TempDir()
+	h, books, author, ctx, tmp := fileFixture(t)
 	path := filepath.Join(tmp, "book.epub")
 	if err := os.WriteFile(path, []byte("epub bytes"), 0o644); err != nil {
 		t.Fatal(err)
@@ -111,8 +134,7 @@ func TestFileDownload_EbookFile(t *testing.T) {
 }
 
 func TestFileDownload_NonASCIIFilename(t *testing.T) {
-	h, books, author, ctx := fileFixture(t)
-	tmp := t.TempDir()
+	h, books, author, ctx, tmp := fileFixture(t)
 	name := "日本語.epub"
 	path := filepath.Join(tmp, name)
 	if err := os.WriteFile(path, []byte("epub bytes"), 0o644); err != nil {
@@ -150,8 +172,7 @@ func TestFileDownload_NonASCIIFilename(t *testing.T) {
 }
 
 func TestFileDownload_AudiobookDirStreamsZip(t *testing.T) {
-	h, books, author, ctx := fileFixture(t)
-	tmp := t.TempDir()
+	h, books, author, ctx, tmp := fileFixture(t)
 	dir := filepath.Join(tmp, "Title (2020)")
 	if err := os.MkdirAll(filepath.Join(dir, "nested"), 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/api/grimmory.go
+++ b/internal/api/grimmory.go
@@ -105,7 +105,7 @@ func (h *GrimmoryHandler) SetConfig(w http.ResponseWriter, r *http.Request) {
 		set(SettingGrimmoryEnabled, val)
 	}
 	if req.BaseURL != nil {
-		u, err := grimmory.NormalizeBaseURL(*req.BaseURL)
+		u, err := grimmory.ValidateBaseURLSecure(*req.BaseURL)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return

--- a/internal/api/opds_test.go
+++ b/internal/api/opds_test.go
@@ -75,7 +75,9 @@ func opdsFixture(t *testing.T) (*chi.Mux, *db.UserRepo, *db.SettingsRepo, string
 	}
 
 	builder := opds.NewBuilder(opds.Config{PageSize: 50}, books, authors, series)
-	fh := NewFileHandler(books)
+	// FileHandler fails closed without allowedRoots — seed it with the
+	// fixture's tmp dir so the OPDS download path resolves through it.
+	fh := NewFileHandler(books, tmp)
 	h := NewOPDSHandler(builder, books, fh)
 	p := &testProvider{settings: settings}
 

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vavallee/bindery/internal/abs"
 	"github.com/vavallee/bindery/internal/calibre"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/metadata/hardcover"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -338,11 +339,17 @@ func validateSettingValue(key, value string) error {
 		if u.Host == "" {
 			return fmt.Errorf("plugin_url %q is missing a host", value)
 		}
+		// Block link-local and cloud-metadata so the Calibre plugin URL can't
+		// be used as an admin-only SSRF foot-gun (mirrors ABS / Grimmory /
+		// indexer / prowlarr / downloadclient validation).
+		if err := httpsec.ValidateOutboundURL(value, httpsec.PolicyLAN); err != nil {
+			return fmt.Errorf("plugin_url %q: %w", value, err)
+		}
 	case SettingABSBaseURL:
 		if value == "" {
 			return nil
 		}
-		if _, err := abs.NormalizeBaseURL(value); err != nil {
+		if _, err := abs.ValidateBaseURLSecure(value); err != nil {
 			return err
 		}
 	case SettingABSEnabled:

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -196,6 +196,16 @@ func migrate(database *sql.DB) error {
 		return entries[i].Name() < entries[j].Name()
 	})
 
+	// Refuse to start if two migration files share a numeric prefix. The apply
+	// loop keys on version number (SELECT COUNT(*) FROM schema_migrations WHERE
+	// version = ?) so a second NNN_*.sql file is silently skipped on any DB
+	// that already applied the first — the schema change in the skipped file
+	// is lost. This bit the 043 collision incident on 2026-05-26; the fail-
+	// loud guard prevents recurrence.
+	if err := assertUniqueMigrationVersions(entries); err != nil {
+		return err
+	}
+
 	// Older Bindery builds recorded schema_migrations.version as the 0-based
 	// slice index + 1 instead of the filename number. Reconcile any such DB to
 	// filename-based versions exactly once, before the apply loop, so neither
@@ -256,6 +266,25 @@ func migrate(database *sql.DB) error {
 //     no longer fires.
 //
 // A fresh database has no schema_migrations rows and is left untouched.
+// assertUniqueMigrationVersions returns an error when two migration files share
+// the same numeric prefix. Without this guard the apply loop silently skips
+// the second file on any DB that already recorded that version, losing its
+// schema change. See the 043 collision incident on 2026-05-26.
+func assertUniqueMigrationVersions(entries []os.DirEntry) error {
+	byVersion := make(map[int]string, len(entries))
+	for _, entry := range entries {
+		v, err := migrationVersion(entry.Name())
+		if err != nil {
+			return err
+		}
+		if existing, ok := byVersion[v]; ok {
+			return fmt.Errorf("duplicate migration version %d: %q and %q share the same numeric prefix; rename one before booting", v, existing, entry.Name())
+		}
+		byVersion[v] = entry.Name()
+	}
+	return nil
+}
+
 func reconcileMigrationVersions(database *sql.DB, entries []os.DirEntry) error {
 	// Build the set of valid filename-based versions, and the index->filename
 	// mapping (1-based index, matching the legacy +1 numbering).

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -69,6 +69,54 @@ func TestOpenMemory(t *testing.T) {
 	}
 }
 
+// TestAssertUniqueMigrationVersions covers the duplicate-prefix guard added
+// after the 043 collision incident (2026-05-26): two unrelated PRs both
+// shipped a migration numbered 043, the apply loop silently skipped the
+// second on installs that had already applied the first, and the lost
+// schema change wasn't noticed until prod broke.
+func TestAssertUniqueMigrationVersions(t *testing.T) {
+	t.Run("unique versions pass", func(t *testing.T) {
+		entries := []os.DirEntry{
+			fakeDirEntry{name: "001_a.sql"},
+			fakeDirEntry{name: "002_b.sql"},
+			fakeDirEntry{name: "003_c.sql"},
+		}
+		if err := assertUniqueMigrationVersions(entries); err != nil {
+			t.Errorf("unique versions should not error: %v", err)
+		}
+	})
+	t.Run("duplicate prefix errors", func(t *testing.T) {
+		entries := []os.DirEntry{
+			fakeDirEntry{name: "043_author_monitor_mode.sql"},
+			fakeDirEntry{name: "043_download_client_category_audiobook.sql"},
+		}
+		err := assertUniqueMigrationVersions(entries)
+		if err == nil {
+			t.Fatal("expected duplicate-version error")
+		}
+		if !strings.Contains(err.Error(), "duplicate migration version 43") {
+			t.Errorf("error should name the duplicate version: %v", err)
+		}
+		if !strings.Contains(err.Error(), "043_author_monitor_mode.sql") ||
+			!strings.Contains(err.Error(), "043_download_client_category_audiobook.sql") {
+			t.Errorf("error should name both files: %v", err)
+		}
+	})
+	t.Run("non-numeric prefix bubbles up", func(t *testing.T) {
+		entries := []os.DirEntry{fakeDirEntry{name: "bogus_no_prefix.sql"}}
+		if err := assertUniqueMigrationVersions(entries); err == nil {
+			t.Fatal("expected non-numeric prefix to error")
+		}
+	})
+}
+
+type fakeDirEntry struct{ name string }
+
+func (e fakeDirEntry) Name() string               { return e.name }
+func (e fakeDirEntry) IsDir() bool                { return false }
+func (e fakeDirEntry) Type() os.FileMode          { return 0 }
+func (e fakeDirEntry) Info() (os.FileInfo, error) { return nil, nil }
+
 func TestMigrateIdempotent(t *testing.T) {
 	db, err := OpenMemory()
 	if err != nil {

--- a/internal/db/settings.go
+++ b/internal/db/settings.go
@@ -40,6 +40,28 @@ func (r *SettingsRepo) Set(ctx context.Context, key, value string) error {
 	return err
 }
 
+// SetIfAbsent atomically inserts a settings row only when the key does not
+// already exist, and reports whether the insert won (true) or lost the race
+// (false). Used as a one-shot lock for irreversible decisions like the OIDC
+// promote-first-admin guard: two concurrent first-time logins both see no
+// admins, both want to claim admin, but only one wins SetIfAbsent and the
+// other falls back to the default role.
+func (r *SettingsRepo) SetIfAbsent(ctx context.Context, key, value string) (bool, error) {
+	now := time.Now().UTC()
+	res, err := r.db.ExecContext(ctx, `
+		INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+		ON CONFLICT(key) DO NOTHING`,
+		key, value, now)
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows == 1, nil
+}
+
 // SettingKV is a single key/value pair for SetMany.
 type SettingKV struct {
 	Key   string

--- a/internal/grimmory/client.go
+++ b/internal/grimmory/client.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/useragent"
 )
 
@@ -64,6 +65,23 @@ func NormalizeBaseURL(raw string) (string, error) {
 		u.Path = strings.TrimRight(u.Path, "/")
 	}
 	return u.String(), nil
+}
+
+// ValidateBaseURLSecure layers an SSRF policy check on top of NormalizeBaseURL.
+// Use this at the admin-input boundary (settings save) to refuse base URLs
+// that point at link-local or cloud-metadata endpoints. Loopback and RFC1918
+// are still allowed via PolicyLAN for homelab deployments. NewClient callers
+// should keep using NormalizeBaseURL directly so test fixtures with httptest
+// (loopback) still work.
+func ValidateBaseURLSecure(raw string) (string, error) {
+	u, err := NormalizeBaseURL(raw)
+	if err != nil {
+		return "", err
+	}
+	if err := httpsec.ValidateOutboundURL(u, httpsec.PolicyLAN); err != nil {
+		return "", fmt.Errorf("base_url %q: %w", raw, err)
+	}
+	return u, nil
 }
 
 // NormalizeAPIKey strips whitespace and rejects control characters.


### PR DESCRIPTION
Bundles five independent findings from the v1.15.0 security review into one PR. Each is small and unrelated to the others; one CI cycle, one release entry.

## P1 — backup endpoints behind RequireAdmin

\`cmd/bindery/main.go:840-843\` — backup List / Create / Restore / Delete were outside any admin group. Restore overwrites the live SQLite from any timestamped backup; any authenticated user could roll back the instance. Wrapped in a RequireAdmin group.

## P1 — OIDC promote-first-admin TOCTOU race

\`internal/api/auth_oidc.go\` — the guard read + admin count + guard set was not atomic. Two concurrent first-time logins on an admin-less instance could both pass the check and both get \`role=admin\`. New \`SettingsRepo.SetIfAbsent\` (\`INSERT ON CONFLICT DO NOTHING\`) is used as a row-level lock acquire: exactly one concurrent first-time login wins and gets admin; any other simultaneous login that also observed \`admins == 0\` loses there and falls back to the default role. Old Get-then-Set guard removed.

## P1 — migration runner duplicate-version detector

\`internal/db/db.go\` — the 043 collision on 2026-05-26 bit because two PRs both shipped a migration numbered 043 and the apply loop silently skipped the second on installs that had already applied the first. \`assertUniqueMigrationVersions\` fails-loud at boot when two files share a numeric prefix. Test covers unique pass, duplicate fail with both filenames in the error, and non-numeric prefix bubbling up.

## P2 — SSRF check on ABS / Grimmory / Calibre plugin base URLs

ABS / Grimmory clients now expose a \`ValidateBaseURLSecure\` that layers \`httpsec.ValidateOutboundURL(PolicyLAN)\` on top of the existing format-only \`NormalizeBaseURL\`. \`NormalizeBaseURL\` itself stays format-only so test fixtures using httptest (loopback) still construct clients. Save-config paths (settings\\_handler / grimmory.SetConfig) now use the secure variant; \`SettingCalibrePluginURL\` validation gains the same check. Blocks link-local (169.254/16, AWS IMDSv4) and cloud-metadata endpoints.

## P2 — FileHandler.isAllowedPath fails closed

\`internal/api/files.go\` previously allowed any path when no roots were configured ("preserves behaviour for installs missing BINDERY\\_LIBRARY\\_DIR"). That's a silent defense degradation. Now returns false when \`allowedRoots\` is empty; test fixture seeds a TempDir root and new \`TestFileDownload\\_PathOutsideAllowedRoots\` covers the 403 behavior.

## P2 — trusted-proxy 0.0.0.0/0 boot warning

\`cmd/bindery/main.go\` — when \`BINDERY_TRUSTED_PROXY\` parses to \`/0\`, every client's X-Forwarded-For is honoured, defeating the login rate-limiter and any per-IP decision in the stack. Operators sometimes set this in Helm charts to silence the proxy-mode safety gate without thinking through the implication. The boot warning makes the misconfiguration visible in logs.

## Not in this PR

- P1 #1 (credential redaction for indexer/prowlarr/downloadclient) — PR #844 (separate, simultaneous).
- P1 #3 (Calibre rollback transactional) — separate PR in flight.
- P2 #7 (contextBackground app-lifetime ctx) — deferred, larger refactor.

## Verification

- [x] \`gofmt -l\` clean
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint v2.11.4\` — 0 issues
- [x] \`go test ./...\` — full suite green incl. 4 new tests:
  - \`TestAssertUniqueMigrationVersions\` (3 sub-tests)
  - \`TestFileDownload_PathOutsideAllowedRoots\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)