### PR TITLE
fix(notifier): wire EventGrabbed/Import/DownloadFailed/Health into real events (#849)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -264,6 +264,13 @@ func main() {
 		return
 	}
 
+	// Notifier — constructed early so it can be passed into the import scanner,
+	// scheduler, and download-client health store before they start firing
+	// events. Before issue #849 was fixed, this was constructed only after
+	// scheduler.Start() and only injected into QueueHandler, which is why
+	// auto-grab / import / download-failure events never reached webhooks.
+	notif := notifier.New(notificationRepo)
+
 	// Indexer searcher
 	idxSearcher := indexer.NewSearcher()
 
@@ -275,6 +282,7 @@ func main() {
 		cfg.LibraryDir, cfg.AudiobookDir, namingTemplate, audiobookTemplate,
 		cfg.DownloadPathRemap,
 	)
+	importScanner.WithNotifier(notif)
 	if cfg.AudiobookDownloadDir != "" {
 		importScanner.WithAudiobookDownloadDir(cfg.AudiobookDownloadDir)
 		slog.Info("audiobook download dir configured", "path", cfg.AudiobookDownloadDir)
@@ -392,6 +400,7 @@ func main() {
 	sched.WithDelayProfiles(delayProfileRepo)
 	sched.WithPendingReleases(pendingReleaseRepo)
 	sched.WithStoragePaths(cfg.DownloadDir, cfg.AudiobookDownloadDir)
+	sched.WithNotifier(notif)
 	// Register the Calibre importer as the 24-hour sync job. The scheduler
 	// only fires the job when the syncer is non-nil, so no guard needed here.
 	sched.WithCalibreSyncer(calibreImporter)
@@ -426,9 +435,6 @@ func main() {
 
 	sched.Start()
 	defer sched.Stop()
-
-	// Notifier
-	notif := notifier.New(notificationRepo)
 
 	// OIDC manager — loaded from settings, reload on config change. The
 	// redirect base URL is resolved per-request from the Login/Callback
@@ -466,7 +472,7 @@ func main() {
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
 	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).WithSettings(settingsRepo).WithDownloads(downloadRepo).WithAuthors(authorRepo).WithSeries(seriesRepo)
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, metadataProfileRepo, idxSearcher, settingsRepo, blocklistRepo).WithAliases(authorAliasRepo)
-	downloadHealth := downloader.NewHealthStore()
+	downloadHealth := downloader.NewHealthStore().WithNotifier(notif)
 	if clients, err := dlClientRepo.List(ctxBoot); err == nil {
 		downloader.RefreshDownloadClientHealthAsync(context.Background(), downloadHealth, clients, cfg.DownloadDir, cfg.AudiobookDownloadDir)
 	} else {

--- a/internal/downloader/health.go
+++ b/internal/downloader/health.go
@@ -20,14 +20,38 @@ const (
 	HealthError    = "error"
 )
 
+// eventNotifier publishes a webhook event for a downstream notification
+// target. Narrow shape of *notifier.Notifier so the HealthStore can be tested
+// without an HTTP fixture (issue #849).
+type eventNotifier interface {
+	Send(ctx context.Context, eventType string, payload map[string]interface{})
+}
+
+const notifierEventHealth = "health"
+
 // HealthStore keeps non-persistent download-client health diagnostics.
 type HealthStore struct {
-	mu   sync.RWMutex
-	byID map[int64]models.DownloadClientHealth
+	mu    sync.RWMutex
+	byID  map[int64]models.DownloadClientHealth
+	notif eventNotifier
 }
 
 func NewHealthStore() *HealthStore {
 	return &HealthStore{byID: make(map[int64]models.DownloadClientHealth)}
+}
+
+// WithNotifier attaches a webhook event notifier so transitions into
+// HealthError publish EventHealth (issue #849). Transitions out of error and
+// transitions within error (message changes) are deliberately silent — they
+// would either spam the channel or under-report the actionable signal.
+func (s *HealthStore) WithNotifier(n eventNotifier) *HealthStore {
+	if s == nil {
+		return s
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.notif = n
+	return s
 }
 
 func (s *HealthStore) Set(id int64, health models.DownloadClientHealth) {
@@ -35,8 +59,33 @@ func (s *HealthStore) Set(id int64, health models.DownloadClientHealth) {
 		return
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	prev, hadPrev := s.byID[id]
 	s.byID[id] = health
+	notif := s.notif
+	s.mu.Unlock()
+
+	// Edge-trigger on entry into the error state. "Entry" means the previous
+	// status was anything-but-error AND wasn't the transient "checking"
+	// placeholder — RefreshDownloadClientHealthAsync writes Checking before
+	// every refresh, so without the checking exclusion a persistently-broken
+	// client would webhook on every poll cycle (error → checking → error).
+	// Repeating error → error stays silent for the same anti-spam reason;
+	// out-of-error transitions don't fire because there is no
+	// EventHealthRecovered enum today (issue #849, deferred follow-up).
+	if notif == nil || health.Status != HealthError {
+		return
+	}
+	if hadPrev && (prev.Status == HealthError || prev.Status == HealthChecking) {
+		return
+	}
+	// Background context: this is a fire-and-forget side effect of a state
+	// transition; it must not block Set or be cancelled by the caller's
+	// request context tearing down.
+	notif.Send(context.Background(), notifierEventHealth, map[string]interface{}{
+		"clientId": id,
+		"status":   health.Status,
+		"message":  health.Message,
+	})
 }
 
 func (s *HealthStore) Delete(id int64) {

--- a/internal/downloader/health_test.go
+++ b/internal/downloader/health_test.go
@@ -307,3 +307,69 @@ func TestQbittorrentCategoryPath_MismatchMessageGuidesUserToPathRemap(t *testing
 		}
 	}
 }
+
+// healthSpy records Send calls so HealthStore notification tests can assert.
+type healthSpy struct {
+	calls []struct {
+		eventType string
+		payload   map[string]interface{}
+	}
+}
+
+func (h *healthSpy) Send(_ context.Context, eventType string, payload map[string]interface{}) {
+	h.calls = append(h.calls, struct {
+		eventType string
+		payload   map[string]interface{}
+	}{eventType, payload})
+}
+
+// TestHealthStore_Set_FiresEventHealthOnEntryToError verifies that a
+// healthy→error (and absent→error) transition publishes EventHealth, but
+// repeated error→error transitions do not. This is the wiring for issue #849
+// so user-configured webhooks see download-client breakage.
+func TestHealthStore_Set_FiresEventHealthOnEntryToError(t *testing.T) {
+	spy := &healthSpy{}
+	s := NewHealthStore().WithNotifier(spy)
+
+	// Absent → error: must fire (covers a freshly-added client coming up bad).
+	s.Set(1, models.DownloadClientHealth{Status: HealthError, Message: "save path missing"})
+	if len(spy.calls) != 1 {
+		t.Fatalf("absent->error: want 1 Send, got %d (%+v)", len(spy.calls), spy.calls)
+	}
+	if got, want := spy.calls[0].eventType, notifierEventHealth; got != want {
+		t.Errorf("eventType = %q, want %q", got, want)
+	}
+	if got, want := spy.calls[0].payload["status"], HealthError; got != want {
+		t.Errorf("payload status = %v, want %q", got, want)
+	}
+
+	// error → error (different message): NOT a new failure; must be silent
+	// to avoid spamming the webhook on every poll.
+	s.Set(1, models.DownloadClientHealth{Status: HealthError, Message: "still broken"})
+	if len(spy.calls) != 1 {
+		t.Fatalf("error->error: want 1 Send total, got %d", len(spy.calls))
+	}
+
+	// Recover then re-fail: ok->error must fire again.
+	s.Set(1, models.DownloadClientHealth{Status: HealthOK, Message: "fixed"})
+	s.Set(1, models.DownloadClientHealth{Status: HealthError, Message: "broke again"})
+	if len(spy.calls) != 2 {
+		t.Fatalf("ok->error after recovery: want 2 Sends total, got %d", len(spy.calls))
+	}
+
+	// checking → error: must NOT fire — RefreshDownloadClientHealthAsync
+	// writes Checking before every refresh, so without the suppression a
+	// persistently-broken client would webhook on every poll cycle.
+	s.Set(1, models.DownloadClientHealth{Status: HealthChecking, Message: "polling"})
+	s.Set(1, models.DownloadClientHealth{Status: HealthError, Message: "still broken"})
+	if len(spy.calls) != 2 {
+		t.Fatalf("checking->error: want 2 Sends total (no new fire), got %d", len(spy.calls))
+	}
+}
+
+// TestHealthStore_Set_NilNotifierDoesNotPanic guards optional wiring: a store
+// built without WithNotifier must still work.
+func TestHealthStore_Set_NilNotifierDoesNotPanic(t *testing.T) {
+	s := NewHealthStore()
+	s.Set(1, models.DownloadClientHealth{Status: HealthError, Message: "broken"})
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -43,6 +43,24 @@ type absNotifier interface {
 	ScanLibrary(ctx context.Context, libraryID string) error
 }
 
+// eventNotifier publishes a webhook event for a downstream notification target
+// (Discord/ntfy/etc.). It is the narrow shape the scanner needs from
+// *notifier.Notifier — declared locally so tests can spy on Send without
+// pulling the whole notifier package and its HTTP/SSRF machinery into the
+// fixture (issue #849).
+type eventNotifier interface {
+	Send(ctx context.Context, eventType string, payload map[string]interface{})
+}
+
+// Event-type strings. Duplicated from internal/notifier to avoid an import
+// cycle risk and keep this package free of notifier internals. Must stay in
+// sync with notifier.Event* constants (covered by their respective tests).
+const (
+	notifierEventGrabbed        = "grabbed"
+	notifierEventBookImported   = "bookImported"
+	notifierEventDownloadFailed = "downloadFailed"
+)
+
 // Scanner checks for completed downloads and imports them into the library.
 type Scanner struct {
 	downloads            *db.DownloadRepo
@@ -64,6 +82,7 @@ type Scanner struct {
 	audiobookDownloadDir string
 	absLib               absNotifier
 	absLibraryIDsFn      func() []string
+	notif                eventNotifier
 }
 
 // NewScanner creates an import scanner. downloadPathRemap is an optional
@@ -204,6 +223,47 @@ func (s *Scanner) WithABSNotifier(n absNotifier, libraryIDsFn func() []string) *
 	s.absLib = n
 	s.absLibraryIDsFn = libraryIDsFn
 	return s
+}
+
+// WithNotifier attaches a webhook event notifier so import-success and
+// download-failure transitions publish to user-configured ntfy/Discord/etc.
+// endpoints. Before this wiring (issue #849) only manual grabs from the queue
+// page emitted events — every other site that wrote a history row was silent.
+func (s *Scanner) WithNotifier(n eventNotifier) *Scanner {
+	s.notif = n
+	return s
+}
+
+// notify is a nil-safe Send wrapper. Keeps every call site a one-liner without
+// repeating the guard, and lets tests construct a Scanner without a notifier.
+func (s *Scanner) notify(ctx context.Context, eventType string, payload map[string]interface{}) {
+	if s.notif == nil {
+		return
+	}
+	s.notif.Send(ctx, eventType, payload)
+}
+
+// importedPayload builds the EventBookImported webhook payload. The book may
+// be nil in the unmatched-import edge case; in that case fall back to the
+// download title so the webhook still carries a meaningful "title". Path is
+// optional ("" omits it from the payload) — the ebook path varies per file in
+// a multi-format bundle so emitting one of them would be misleading.
+func importedPayload(book *models.Book, dl *models.Download, format, path string) map[string]interface{} {
+	title := ""
+	if book != nil {
+		title = book.Title
+	}
+	if title == "" && dl != nil {
+		title = dl.Title
+	}
+	p := map[string]interface{}{
+		"title":  title,
+		"format": format,
+	}
+	if path != "" {
+		p["path"] = path
+	}
+	return p
 }
 
 // pushToABS triggers an ABS library scan after a successful audiobook import.
@@ -501,6 +561,10 @@ func (s *Scanner) RecoverInterruptedImports(ctx context.Context) {
 			"message": "import interrupted (process restart) — re-queued for retry",
 			"status":  string(models.StateImportFailed),
 		})
+		// Intentionally NOT firing EventDownloadFailed here: this is a benign
+		// startup-recovery transition that re-queues the import for retry, not a
+		// terminal failure. Webhooking every interrupted import on every restart
+		// would be noise for the user (issue #849).
 	}
 }
 
@@ -533,7 +597,10 @@ func (s *Scanner) updateDownloadStatus(ctx context.Context, id int64, status mod
 
 // failImport records an import failure with a user-facing reason. It persists
 // the status + message and emits an importFailed history event so the cause
-// is visible in the Queue/History UI.
+// is visible in the Queue/History UI. Also publishes EventDownloadFailed so
+// user-configured webhooks see the failure (issue #849) — there is no separate
+// "import failed" event in the notifier enum, so importFailed and
+// downloadFailed share the channel.
 func (s *Scanner) failImport(ctx context.Context, dl *models.Download, status models.DownloadState, reason string) {
 	if err := s.downloads.SetErrorWithStatus(ctx, dl.ID, status, reason); err != nil {
 		slog.Warn("failed to persist import error", "download_id", dl.ID, "status", status, "error", err)
@@ -542,6 +609,10 @@ func (s *Scanner) failImport(ctx context.Context, dl *models.Download, status mo
 		"guid":    dl.GUID,
 		"message": reason,
 		"status":  string(status),
+	})
+	s.notify(ctx, notifierEventDownloadFailed, map[string]interface{}{
+		"title":   dl.Title,
+		"message": reason,
 	})
 }
 
@@ -567,6 +638,10 @@ func (s *Scanner) createHistoryEvent(ctx context.Context, eventType string, sour
 func (s *Scanner) markDownloadFailed(ctx context.Context, dl *models.Download, message string) {
 	s.setDownloadError(ctx, dl.ID, message)
 	s.createHistoryEvent(ctx, models.HistoryEventDownloadFailed, dl.Title, dl.BookID, map[string]string{"guid": dl.GUID, "message": message})
+	s.notify(ctx, notifierEventDownloadFailed, map[string]interface{}{
+		"title":   dl.Title,
+		"message": message,
+	})
 }
 
 // blockStaleImportFailures terminally blocks downloads that are stuck in
@@ -684,6 +759,10 @@ func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.Down
 				slog.Warn("download failed", "title", dl.Title, "message", slot.FailMessage)
 				s.setDownloadError(ctx, dl.ID, slot.FailMessage)
 				s.createHistoryEvent(ctx, models.HistoryEventDownloadFailed, dl.Title, dl.BookID, map[string]string{"guid": dl.GUID, "message": slot.FailMessage})
+				s.notify(ctx, notifierEventDownloadFailed, map[string]interface{}{
+					"title":   dl.Title,
+					"message": slot.FailMessage,
+				})
 			}
 		}
 	}
@@ -745,6 +824,10 @@ func (s *Scanner) checkNZBGetDownloads(ctx context.Context, client *models.Downl
 				slog.Warn("download failed", "title", dl.Title, "status", item.Status)
 				s.setDownloadError(ctx, dl.ID, msg)
 				s.createHistoryEvent(ctx, models.HistoryEventDownloadFailed, dl.Title, dl.BookID, map[string]string{"guid": dl.GUID, "message": msg})
+				s.notify(ctx, notifierEventDownloadFailed, map[string]interface{}{
+					"title":   dl.Title,
+					"message": msg,
+				})
 			}
 		}
 	}
@@ -1342,6 +1425,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		s.pushToABS(ctx)
 
 		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destDir, "format": models.MediaTypeAudiobook})
+		s.notify(ctx, notifierEventBookImported, importedPayload(book, dl, models.MediaTypeAudiobook, destDir))
 		if cleanupFunc != nil {
 			if err := cleanupFunc(); err != nil {
 				slog.Warn("cleanup failed", cleanupWarnAttrs(cleanupClientType, cleanupRemoteID, err)...)
@@ -1466,6 +1550,10 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// download imported exactly once, then clean up.
 	if imported > 0 && failed == 0 {
 		s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
+		// One bookImported notification per download (not per file): a
+		// multi-format ebook bundle (epub + mobi + pdf) is conceptually one
+		// import event from the user's perspective.
+		s.notify(ctx, notifierEventBookImported, importedPayload(book, dl, models.MediaTypeEbook, ""))
 
 		// For "move" mode bindery has no further use for the source files. The
 		// download folder may, however, be a path shared with sibling torrents

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -621,6 +621,7 @@ func TestImportSuccess_FiresBookImported(t *testing.T) {
 	call := spy.lookup(notifierEventBookImported)
 	if call == nil {
 		t.Fatalf("expected EventBookImported to fire; got calls: %+v", spy.calls)
+		return
 	}
 	if got, want := call.payload["title"], book.Title; got != want {
 		t.Errorf("payload title = %q, want %q", got, want)
@@ -657,6 +658,7 @@ func TestFailImport_FiresDownloadFailed(t *testing.T) {
 	call := spy.lookup(notifierEventDownloadFailed)
 	if call == nil {
 		t.Fatalf("expected EventDownloadFailed to fire; got calls: %+v", spy.calls)
+		return
 	}
 	if got, want := call.payload["title"], dl.Title; got != want {
 		t.Errorf("payload title = %q, want %q", got, want)
@@ -690,6 +692,7 @@ func TestMarkDownloadFailed_FiresDownloadFailed(t *testing.T) {
 	call := spy.lookup(notifierEventDownloadFailed)
 	if call == nil {
 		t.Fatalf("expected EventDownloadFailed; got calls: %+v", spy.calls)
+		return
 	}
 	if got := call.payload["message"]; got != "torrent errored" {
 		t.Errorf("payload message = %v, want %q", got, "torrent errored")

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -536,4 +537,168 @@ func TestTryImportInternal_HistoryEventIncludesFormat(t *testing.T) {
 	if got := data["format"]; got != models.MediaTypeEbook {
 		t.Errorf("Bug #13: history event missing format field: got %q, want %q — user cannot tell ebook vs audiobook was imported", got, models.MediaTypeEbook)
 	}
+}
+
+// spyNotifier records every Send so emit-site tests can assert the
+// notification was published with the expected event type and payload.
+type spyNotifier struct {
+	mu    sync.Mutex
+	calls []spyCall
+}
+
+type spyCall struct {
+	eventType string
+	payload   map[string]interface{}
+}
+
+func (n *spyNotifier) Send(_ context.Context, eventType string, payload map[string]interface{}) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.calls = append(n.calls, spyCall{eventType: eventType, payload: payload})
+}
+
+func (n *spyNotifier) lookup(eventType string) *spyCall {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for i := range n.calls {
+		if n.calls[i].eventType == eventType {
+			return &n.calls[i]
+		}
+	}
+	return nil
+}
+
+// TestImportSuccess_FiresBookImported is the regression test for issue #849:
+// before this fix, only manual grabs from the queue page fired notifications.
+// A successful import wrote a HistoryEventBookImported row but never published
+// to the user-configured webhooks. After the fix, every clean import must
+// emit EventBookImported with the book title and format.
+func TestImportSuccess_FiresBookImported(t *testing.T) {
+	libDir := t.TempDir()
+	dlDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dlDir, "book.epub"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+
+	author := &models.Author{ForeignID: "OLA-849", Name: "Notif Author", SortName: "Author, Notif", Monitored: true, MetadataProvider: "openlibrary"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OLB-849", AuthorID: author.ID, Title: "Issue 849",
+		SortTitle: "Issue 849", Status: models.BookStatusWanted,
+		Monitored: true, AnyEditionOK: true, MetadataProvider: "openlibrary",
+	}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	dl := &models.Download{
+		GUID: "849-guid", Title: "Issue 849", BookID: &book.ID,
+		Status: models.StateCompleted,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	spy := &spyNotifier{}
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, db.NewHistoryRepo(database), libDir, "", "", "", "").
+		WithNotifier(spy)
+	s.tryImportInternal(ctx, dl, dlDir, "", "", nil)
+
+	call := spy.lookup(notifierEventBookImported)
+	if call == nil {
+		t.Fatalf("expected EventBookImported to fire; got calls: %+v", spy.calls)
+	}
+	if got, want := call.payload["title"], book.Title; got != want {
+		t.Errorf("payload title = %q, want %q", got, want)
+	}
+	if got, want := call.payload["format"], models.MediaTypeEbook; got != want {
+		t.Errorf("payload format = %q, want %q", got, want)
+	}
+}
+
+// TestFailImport_FiresDownloadFailed asserts that failImport — the helper
+// called for unwritable destinations, partial imports, unmatched downloads,
+// etc. — publishes EventDownloadFailed (issue #849). The notifier has no
+// dedicated EventImportFailed; downloadFailed is the channel for both.
+func TestFailImport_FiresDownloadFailed(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	dlRepo := db.NewDownloadRepo(database)
+
+	dl := &models.Download{GUID: "fail-guid", Title: "Broken Book", Status: models.StateImporting}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	spy := &spyNotifier{}
+	s := &Scanner{downloads: dlRepo, history: db.NewHistoryRepo(database), notif: spy}
+
+	s.failImport(ctx, dl, models.StateImportFailed, "destination unwritable")
+
+	call := spy.lookup(notifierEventDownloadFailed)
+	if call == nil {
+		t.Fatalf("expected EventDownloadFailed to fire; got calls: %+v", spy.calls)
+	}
+	if got, want := call.payload["title"], dl.Title; got != want {
+		t.Errorf("payload title = %q, want %q", got, want)
+	}
+	if got, want := call.payload["message"], "destination unwritable"; got != want {
+		t.Errorf("payload message = %q, want %q", got, want)
+	}
+}
+
+// TestMarkDownloadFailed_FiresDownloadFailed asserts that the inline download-
+// failure helper (used by Transmission/qBittorrent error paths) also fires
+// EventDownloadFailed (issue #849).
+func TestMarkDownloadFailed_FiresDownloadFailed(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	dlRepo := db.NewDownloadRepo(database)
+	dl := &models.Download{GUID: "stall-guid", Title: "Stalled Book", Status: models.StateDownloading}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	spy := &spyNotifier{}
+	s := &Scanner{downloads: dlRepo, history: db.NewHistoryRepo(database), notif: spy}
+	s.markDownloadFailed(ctx, dl, "torrent errored")
+
+	call := spy.lookup(notifierEventDownloadFailed)
+	if call == nil {
+		t.Fatalf("expected EventDownloadFailed; got calls: %+v", spy.calls)
+	}
+	if got := call.payload["message"]; got != "torrent errored" {
+		t.Errorf("payload message = %v, want %q", got, "torrent errored")
+	}
+}
+
+// TestNotify_NilNotifierDoesNotPanic guards the optional-injection contract:
+// a Scanner with no notifier set must silently skip emission, not crash.
+func TestNotify_NilNotifierDoesNotPanic(t *testing.T) {
+	s := &Scanner{}
+	s.notify(context.Background(), notifierEventGrabbed, map[string]interface{}{"title": "x"})
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -57,6 +57,20 @@ type TelemetryPinger interface {
 	Ping(ctx context.Context)
 }
 
+// eventNotifier publishes a webhook event for a downstream notification
+// target (Discord/ntfy/etc.). Narrow shape of *notifier.Notifier so tests can
+// spy on auto-grab Send calls without standing up an HTTP fixture (issue #849).
+type eventNotifier interface {
+	Send(ctx context.Context, eventType string, payload map[string]interface{})
+}
+
+// Event-type strings. Kept in sync with internal/notifier.Event* — declared
+// here to avoid having the scheduler import notifier just for two string
+// constants (and to keep the eventNotifier interface untied to the real type).
+const (
+	notifierEventGrabbed = "grabbed"
+)
+
 // Scheduler runs background jobs on configurable intervals.
 type Scheduler struct {
 	// appCtx is the process-lifecycle context: it is not tied to any single
@@ -92,6 +106,7 @@ type Scheduler struct {
 	hcSyncer             HCListSyncer         // optional; syncs Hardcover import lists
 	telemetry            TelemetryPinger      // optional; sends daily anonymous install ping
 	logs                 *db.LogRepo          // optional; enables periodic log retention trim
+	notif                eventNotifier        // optional; fires EventGrabbed on auto-grab success (#849)
 	logRetainDays        int                  // 0 = use default (14)
 	downloadDir          string
 	audiobookDownloadDir string
@@ -199,6 +214,22 @@ func (s *Scheduler) WithTelemetry(p TelemetryPinger) {
 func (s *Scheduler) WithLogRepo(logs *db.LogRepo, retainDays int) {
 	s.logs = logs
 	s.logRetainDays = retainDays
+}
+
+// WithNotifier attaches a webhook event notifier so auto-grab successes
+// publish EventGrabbed (issue #849). Manual grabs from the queue page already
+// fire via QueueHandler; without this wiring the auto-grab path (wanted-scan,
+// on-add hook, bulk grab, recommendation grab, series grab) was silent.
+func (s *Scheduler) WithNotifier(n eventNotifier) {
+	s.notif = n
+}
+
+// notify is a nil-safe Send wrapper so the auto-grab path stays a one-liner.
+func (s *Scheduler) notify(ctx context.Context, eventType string, payload map[string]interface{}) {
+	if s.notif == nil {
+		return
+	}
+	s.notif.Send(ctx, eventType, payload)
 }
 
 // ctx returns the process-lifecycle context, falling back to
@@ -542,6 +573,20 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.StateDownloading, "error", err)
 	}
 	slog.Info("sent to downloader", "client", client.Type, "title", best.Title)
+	// Publish EventGrabbed so user-configured notification webhooks fire for
+	// auto-grabs as well as the queue-page manual grabs (issue #849). Payload
+	// shape mirrors the queue.go manual-grab Send so existing webhook
+	// templates keep working without modification; "author" is added because
+	// we have it here and it costs nothing.
+	//
+	// TODO(#849): when an upgrade-grab code path exists (the quality cutoff
+	// is currently used only to reject, not to trigger an upgrade re-grab),
+	// emit EventUpgrade here instead of EventGrabbed for upgrade grabs.
+	s.notify(ctx, notifierEventGrabbed, map[string]interface{}{
+		"title":  best.Title,
+		"size":   best.Size,
+		"author": authorName,
+	})
 	// Scope the deletion to the format just grabbed. Deleting all pending
 	// entries for the book would discard the other format's candidates for a
 	// dual-format ('both') book, forcing an unnecessary re-search (see #707).

--- a/internal/scheduler/scheduler_jobs_test.go
+++ b/internal/scheduler/scheduler_jobs_test.go
@@ -364,6 +364,7 @@ func TestNotify_DispatchesEventGrabbed(t *testing.T) {
 	call := spy.lookup(notifierEventGrabbed)
 	if call == nil {
 		t.Fatalf("expected EventGrabbed call; got %+v", spy.calls)
+		return
 	}
 	if got, want := call.payload["title"], "Dune"; got != want {
 		t.Errorf("payload title = %v, want %q", got, want)

--- a/internal/scheduler/scheduler_jobs_test.go
+++ b/internal/scheduler/scheduler_jobs_test.go
@@ -309,6 +309,73 @@ func TestSearchAndGrabBook_WithLanguageSetting(t *testing.T) {
 	s.SearchAndGrabBook(ctx, models.Book{Title: "Le Petit Prince"})
 }
 
+// spyNotifier records Send calls so emit-site tests can assert the
+// notification was published with the expected event type and payload.
+type spyNotifier struct {
+	mu    sync.Mutex
+	calls []spyCall
+}
+
+type spyCall struct {
+	eventType string
+	payload   map[string]interface{}
+}
+
+func (n *spyNotifier) Send(_ context.Context, eventType string, payload map[string]interface{}) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.calls = append(n.calls, spyCall{eventType: eventType, payload: payload})
+}
+
+func (n *spyNotifier) lookup(eventType string) *spyCall {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for i := range n.calls {
+		if n.calls[i].eventType == eventType {
+			return &n.calls[i]
+		}
+	}
+	return nil
+}
+
+// TestNotify_NilNotifierIsSafe guards the optional-injection contract:
+// auto-grab paths run on schedulers built without notifier wiring (legacy
+// tests, embedded use) and must not crash when notify() is called.
+func TestNotify_NilNotifierIsSafe(t *testing.T) {
+	s := &Scheduler{}
+	s.notify(context.Background(), notifierEventGrabbed, map[string]interface{}{"title": "x"})
+}
+
+// TestNotify_DispatchesEventGrabbed verifies that WithNotifier actually wires
+// the field so the Send call lands on the spy. This is the unit-level
+// guarantee that auto-grab successes will publish; the searchAndGrabFormat
+// integration is verified by reading the code (issue #849).
+func TestNotify_DispatchesEventGrabbed(t *testing.T) {
+	spy := &spyNotifier{}
+	s := &Scheduler{}
+	s.WithNotifier(spy)
+
+	s.notify(context.Background(), notifierEventGrabbed, map[string]interface{}{
+		"title":  "Dune",
+		"size":   int64(1024),
+		"author": "Frank Herbert",
+	})
+
+	call := spy.lookup(notifierEventGrabbed)
+	if call == nil {
+		t.Fatalf("expected EventGrabbed call; got %+v", spy.calls)
+	}
+	if got, want := call.payload["title"], "Dune"; got != want {
+		t.Errorf("payload title = %v, want %q", got, want)
+	}
+	if got, want := call.payload["author"], "Frank Herbert"; got != want {
+		t.Errorf("payload author = %v, want %q", got, want)
+	}
+	if got, want := call.payload["size"], int64(1024); got != want {
+		t.Errorf("payload size = %v, want %d", got, want)
+	}
+}
+
 // TestRefreshMetadata_MonitoredAuthor_MetaError exercises the error-continue
 // branch of the refreshMetadata loop by using a metadata provider that always
 // returns a valid author. This pushes coverage into the loop update path.


### PR DESCRIPTION
## The bug

The notifier package defined five events (Grabbed, BookImported, Upgrade, DownloadFailed, Health), the UI let users configure ntfy/Discord/etc. rows that hit Test successfully, and `notif.Send` was called from exactly two places — both behind the queue page's manual-grab button. Every other site that wrote a history row stayed silent. Users configure a webhook, see Test work, then never receive a single real event.

## What changed

| Event | Was wired | Now fires from |
|---|---|---|
| EventGrabbed | manual grab only | manual grab + every auto-grab (wanted-scan, on-add hook, bulk grab, series grab, recommendation grab — they all flow through `Scheduler.searchAndGrabFormat`) |
| EventBookImported | nowhere | `importer.Scanner` clean-import success, both ebook bundle and audiobook folder paths |
| EventDownloadFailed | manual grab only | `failImport`, `markDownloadFailed`, and the inline SAB/NZBGet failure handlers |
| EventHealth | nowhere | `HealthStore.Set` edge-triggered on entry to `HealthError` |

The notifier itself wasn't touched — only the publish layer. Each consumer (`Scheduler`, `Scanner`, `HealthStore`) gets a `WithNotifier(n)` builder mirroring `QueueHandler.WithNotifier` and declares a local narrow `eventNotifier` interface so tests can spy on `Send` without standing up an HTTP fixture.

`cmd/bindery/main.go` reorders the `notifier.New` call so it exists before `importScanner` / `scheduler` / `downloadHealth` are constructed; that was the immediate reason the wiring slot didn't exist before.

## Payload-shape compatibility

| Event | Existing keys (queue.go) | New keys (here) |
|---|---|---|
| EventGrabbed | `title`, `size` | `title`, `size`, `author` |
| EventDownloadFailed | `title`, `message` | `title`, `message` |

`author` is purely additive — existing webhook templates that read `title`/`size` keep working unchanged. The new events use the same shape conventions: `title` + a small set of context fields, no nesting, no nil-able primitives.

`EventBookImported` payload is `{title, format, path?}` — `path` is omitted for multi-file ebook bundles because any single one is misleading; audiobook imports include it because the directory is the authoritative on-disk destination.

`EventHealth` payload is `{clientId, status, message}`.

## Anti-spam on EventHealth

`Set` is called every poll cycle, often with a `HealthChecking` placeholder right before the real result. Naively edge-triggering on `→ HealthError` would webhook on every poll of a persistently-broken client (error → checking → error). The transition guard suppresses both `error → error` and `checking → error`, so the user gets one notification when a client breaks and silence until it recovers and breaks again.

Recovery (`error → ok`) is silent because the notifier enum has no `EventHealthRecovered`. Adding one is out of scope for this PR.

## What's deferred

- **EventUpgrade** has no live publisher. Quality profiles do have `upgrade_allowed` and `QualityCutoff`, but the spec is currently used to **reject** re-grabs, not to fire an upgrade re-grab. There's no distinct "this was an upgrade" code path to hook into yet. A TODO is left at the `EventGrabbed` emit site so the next person to add the upgrade-grab code path sees it.
- **Indexer health** isn't covered — there's no periodic indexer health-check job in the codebase today. When one's added it should follow the same edge-triggered pattern.
- **Recovery events** (health going `error → ok`) — would require a new enum value. The prompt explicitly said don't add new event types.

## Test plan

- [x] `gofmt -l` clean on edited files
- [x] `go vet ./...` clean
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] `go test ./...` — full suite green
- [x] New unit tests cover: `EventBookImported` fires on clean import, `EventDownloadFailed` fires from both `failImport` and `markDownloadFailed`, nil notifier is safe in both consumers, `EventGrabbed` payload shape is what queue.go expects + the new `author` field, `EventHealth` edge-triggers and suppresses both the error→error and checking→error cases
- [ ] Manual verification: configure an ntfy/Discord notification with all five event boxes ticked, then (a) wait for the wanted-scan to auto-grab a book → expect Grabbed webhook, (b) let an import complete → expect BookImported webhook, (c) break a download client config (wrong save path) → expect Health webhook once
- No frontend changes; web verification skipped

Closes #849
Refs #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)