### PR TITLE
fix(security): replace deprecated chi.middleware.RealIP with TrustedRealIP (#840)

### DIFF
--- a/cmd/bindery/proxy.go
+++ b/cmd/bindery/proxy.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/go-chi/chi/v5/middleware"
-
 	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/httpsec/realip"
 )
 
 // parseTrustedProxyCIDRs parses a comma-separated list of IP/CIDR strings
@@ -32,29 +31,42 @@ var proxyHeaders = []string{
 }
 
 // trustedProxyMiddleware returns a middleware that rewrites RemoteAddr from
-// X-Forwarded-For / X-Real-IP only when the direct peer is a configured
-// trusted proxy. When the peer is not trusted, all forwarded headers are
-// stripped so downstream handlers cannot be spoofed via X-Forwarded-Proto
-// or X-Forwarded-Host.
+// X-Forwarded-For / True-Client-IP / X-Real-IP only when the direct peer is a
+// configured trusted proxy. When the peer is not trusted, all forwarded
+// headers are stripped so downstream handlers cannot be spoofed via
+// X-Forwarded-Proto or X-Forwarded-Host.
 //
 // Configured via BINDERY_TRUSTED_PROXY: a comma-separated list of IPs or
 // CIDRs. Bare IPs are treated as /32 (IPv4) or /128 (IPv6).
+//
+// Previously this delegated RemoteAddr rewriting to chi's middleware.RealIP
+// inside the trusted-peer branch. That middleware was deprecated upstream
+// (SA1019 — GHSA-3fxj-6jh8-hvhx / GHSA-rjr7-jggh-pgcp / GHSA-9g5q-2w5x-hmxf)
+// because it picks the leftmost X-Forwarded-For entry, which a remote client
+// can forge. We now use httpsec/realip.TrustedRealIP, which walks XFF
+// right-to-left to find the first untrusted hop (matches auth.ResolveClientIP).
 func trustedProxyMiddleware() func(http.Handler) http.Handler {
 	trusted := parseTrustedProxyCIDRs(os.Getenv("BINDERY_TRUSTED_PROXY"))
+	realIP := realip.TrustedRealIP(trusted)
 
 	return func(next http.Handler) http.Handler {
+		// realIP itself is a no-op when trusted is empty, so this composes
+		// safely without a mount-time gate.
+		hardened := realIP(next)
+
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Capture the true TCP peer before chi's RealIP overwrites
+			// Capture the true TCP peer before TrustedRealIP overwrites
 			// RemoteAddr. The local-only trust decision needs the genuine peer
-			// to walk X-Forwarded-For right-to-left; RealIP's leftmost pick is
-			// attacker-controlled and must not be used for auth.
+			// to walk X-Forwarded-For right-to-left; without it, downstream
+			// code would have to reverse-engineer "was this rewritten?" from
+			// the post-rewrite value.
 			r = r.WithContext(auth.WithRealPeer(r.Context(), r.RemoteAddr))
 
 			peerHost, _, _ := net.SplitHostPort(r.RemoteAddr)
 			peerIP := net.ParseIP(strings.Trim(peerHost, "[]"))
 			for _, cidr := range trusted {
 				if peerIP != nil && cidr.Contains(peerIP) {
-					middleware.RealIP(next).ServeHTTP(w, r)
+					hardened.ServeHTTP(w, r)
 					return
 				}
 			}

--- a/internal/httpsec/realip/realip.go
+++ b/internal/httpsec/realip/realip.go
@@ -1,0 +1,161 @@
+// Package realip provides a hardened replacement for chi's deprecated
+// middleware.RealIP. The upstream middleware blindly rewrites r.RemoteAddr
+// from the leftmost X-Forwarded-For (or True-Client-IP / X-Real-IP) entry
+// regardless of whether the immediate TCP peer is a trusted proxy, so any
+// client on the open internet can forge an arbitrary RemoteAddr — see
+// GHSA-3fxj-6jh8-hvhx, GHSA-rjr7-jggh-pgcp, GHSA-9g5q-2w5x-hmxf.
+//
+// TrustedRealIP only honours forwarded headers when the immediate peer is in
+// a caller-supplied trusted-proxy CIDR set, and walks X-Forwarded-For
+// right-to-left to find the first untrusted hop (the genuine client) instead
+// of trusting the leftmost (attacker-controlled) entry.
+package realip
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// TrustedRealIP returns a middleware that, when the immediate connection peer
+// falls within trustedCIDRs, rewrites r.RemoteAddr to the rightmost value in
+// X-Forwarded-For that is NOT in trustedCIDRs (the first untrusted hop walking
+// back from the proxy chain). It falls back to True-Client-IP, then X-Real-IP,
+// then leaves r.RemoteAddr alone.
+//
+// When the immediate peer is NOT in trustedCIDRs, forwarded headers are
+// ignored — an open-internet client cannot spoof r.RemoteAddr.
+//
+// When trustedCIDRs is empty the middleware is a no-op. Mount it
+// unconditionally; the caller does not need to gate at mount time.
+//
+// Why rightmost-untrusted instead of leftmost (the deprecated chi behaviour):
+// X-Forwarded-For is appended left-to-right (oldest hop first). A remote
+// client may prepend any value it likes; a trusted proxy at the edge will then
+// append the client's true source IP and pass the whole list through. The
+// leftmost entry is therefore attacker-controlled. Walking right-to-left and
+// peeling off hops that are themselves trusted proxies yields the genuine
+// client — the first hop we cannot vouch for. This matches the algorithm
+// auth.ResolveClientIP uses for the local-only-auth trust decision so both
+// code paths agree on "who is the client".
+func TrustedRealIP(trustedCIDRs []*net.IPNet) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		// No proxies configured: the TCP peer is the client by definition;
+		// forwarded headers are untrusted and must not influence RemoteAddr.
+		if len(trustedCIDRs) == 0 {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			peerHost, peerPort, err := net.SplitHostPort(r.RemoteAddr)
+			if err != nil {
+				// RemoteAddr without a port (httptest sometimes, or a custom
+				// listener). Treat the whole string as the host; preserve
+				// "no port" on rewrite.
+				peerHost = r.RemoteAddr
+				peerPort = ""
+			}
+			peerIP := net.ParseIP(strings.Trim(peerHost, "[]"))
+			if peerIP == nil || !ipInCIDRs(peerIP, trustedCIDRs) {
+				// Peer is on the open internet (or unparseable). Forwarded
+				// headers from it are untrusted: leave RemoteAddr alone.
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if client := clientFromXFF(r.Header.Values("X-Forwarded-For"), trustedCIDRs); client != "" {
+				r.RemoteAddr = joinHostPort(client, peerPort)
+				next.ServeHTTP(w, r)
+				return
+			}
+			if tci := strings.TrimSpace(r.Header.Get("True-Client-IP")); tci != "" {
+				if net.ParseIP(tci) != nil {
+					r.RemoteAddr = joinHostPort(tci, peerPort)
+					next.ServeHTTP(w, r)
+					return
+				}
+				slog.Debug("realip: True-Client-IP unparseable, leaving RemoteAddr alone", "value", tci)
+			}
+			if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" {
+				if net.ParseIP(xri) != nil {
+					r.RemoteAddr = joinHostPort(xri, peerPort)
+					next.ServeHTTP(w, r)
+					return
+				}
+				slog.Debug("realip: X-Real-IP unparseable, leaving RemoteAddr alone", "value", xri)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// clientFromXFF walks the combined X-Forwarded-For chain right-to-left and
+// returns the first hop that is NOT in trustedCIDRs (the genuine client). If
+// every hop is trusted, returns the leftmost hop (the original client per
+// standard XFF semantics). Returns "" when XFF is empty.
+//
+// An unparseable hop breaks the chain of trust: we cannot account for who is
+// upstream of it, so we return that raw value and let the caller use it as
+// the client (fail closed — a garbage entry will not look like a trusted
+// private IP downstream).
+func clientFromXFF(values []string, trustedCIDRs []*net.IPNet) string {
+	hops := parseXFF(values)
+	if len(hops) == 0 {
+		return ""
+	}
+	for i := len(hops) - 1; i >= 0; i-- {
+		ip := net.ParseIP(hops[i])
+		if ip == nil {
+			return hops[i]
+		}
+		if !ipInCIDRs(ip, trustedCIDRs) {
+			return hops[i]
+		}
+	}
+	return hops[0]
+}
+
+// parseXFF flattens repeated X-Forwarded-For values and comma-separated
+// entries into an ordered list of bare host strings (oldest hop first),
+// dropping empty entries and stripping any host:port / [v6] decoration.
+func parseXFF(values []string) []string {
+	var out []string
+	for _, v := range values {
+		for _, part := range strings.Split(v, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			out = append(out, hostOnly(part))
+		}
+	}
+	return out
+}
+
+func hostOnly(addr string) string {
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		addr = h
+	}
+	return strings.Trim(addr, "[]")
+}
+
+func ipInCIDRs(ip net.IP, cidrs []*net.IPNet) bool {
+	for _, n := range cidrs {
+		if n != nil && n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// joinHostPort rebuilds an address string preserving the original peer's
+// port. The deprecated chi RealIP stripped the port; we keep it so downstream
+// callers doing net.SplitHostPort(r.RemoteAddr) continue to work. When the
+// original RemoteAddr had no port (unusual but possible with custom
+// listeners), we emit the bare host to match.
+func joinHostPort(host, port string) string {
+	if port == "" {
+		return host
+	}
+	return net.JoinHostPort(host, port)
+}

--- a/internal/httpsec/realip/realip_test.go
+++ b/internal/httpsec/realip/realip_test.go
@@ -1,0 +1,172 @@
+package realip
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/auth"
+)
+
+// captured records the r.RemoteAddr the wrapped handler observed.
+type captured struct {
+	remote string
+}
+
+func (c *captured) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
+	c.remote = r.RemoteAddr
+}
+
+func mustCIDRs(t *testing.T, raw string) []*net.IPNet {
+	t.Helper()
+	return auth.ParseTrustedProxyCIDRs(raw)
+}
+
+// runReq drives one request through TrustedRealIP and returns whatever
+// RemoteAddr the inner handler saw.
+func runReq(t *testing.T, trusted []*net.IPNet, peer string, headers http.Header) string {
+	t.Helper()
+	sink := &captured{}
+	mw := TrustedRealIP(trusted)(sink)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = peer
+	if headers != nil {
+		req.Header = headers
+	}
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+	return sink.remote
+}
+
+func TestTrustedRealIP_NoHeaders_TrustedPeer_Unchanged(t *testing.T) {
+	got := runReq(t, mustCIDRs(t, "10.0.0.0/8"), "10.0.0.1:55000", nil)
+	if got != "10.0.0.1:55000" {
+		t.Fatalf("RemoteAddr = %q; want unchanged 10.0.0.1:55000", got)
+	}
+}
+
+func TestTrustedRealIP_NoHeaders_UntrustedPeer_Unchanged(t *testing.T) {
+	got := runReq(t, mustCIDRs(t, "10.0.0.0/8"), "8.8.8.8:443", nil)
+	if got != "8.8.8.8:443" {
+		t.Fatalf("RemoteAddr = %q; want unchanged 8.8.8.8:443", got)
+	}
+}
+
+func TestTrustedRealIP_TrustedChain_PicksRealClient(t *testing.T) {
+	// Peer 10.0.0.1 (trusted proxy) presents a chain where 10.0.0.x are all
+	// trusted proxies and 1.2.3.4 is the original (untrusted) client.
+	// Right-to-left walk should peel 10.0.0.2, then return 1.2.3.4.
+	h := http.Header{}
+	h.Set("X-Forwarded-For", "1.2.3.4, 10.0.0.2")
+	got := runReq(t, mustCIDRs(t, "10.0.0.0/8"), "10.0.0.1:55000", h)
+	if got != "1.2.3.4:55000" {
+		t.Fatalf("RemoteAddr = %q; want 1.2.3.4:55000", got)
+	}
+}
+
+func TestTrustedRealIP_UntrustedPeer_SpoofRejected(t *testing.T) {
+	// Open-internet peer 1.2.3.4 forges XFF. RemoteAddr must stay 1.2.3.4.
+	h := http.Header{}
+	h.Set("X-Forwarded-For", "5.6.7.8")
+	h.Set("True-Client-IP", "9.9.9.9")
+	h.Set("X-Real-IP", "10.10.10.10")
+	got := runReq(t, mustCIDRs(t, "10.0.0.0/8"), "1.2.3.4:55000", h)
+	if got != "1.2.3.4:55000" {
+		t.Fatalf("RemoteAddr = %q; want unchanged 1.2.3.4:55000 (spoof rejected)", got)
+	}
+}
+
+func TestTrustedRealIP_AllHopsTrusted_LeftmostWins(t *testing.T) {
+	// Every XFF hop is itself a trusted proxy. Fall back to leftmost
+	// (standard XFF semantics — the outermost is the original client).
+	h := http.Header{}
+	h.Set("X-Forwarded-For", "10.0.0.5, 10.0.0.4, 10.0.0.3")
+	got := runReq(t, mustCIDRs(t, "10.0.0.0/8"), "10.0.0.1:55000", h)
+	if got != "10.0.0.5:55000" {
+		t.Fatalf("RemoteAddr = %q; want 10.0.0.5:55000", got)
+	}
+}
+
+func TestTrustedRealIP_TrueClientIP_TrustedPeer(t *testing.T) {
+	h := http.Header{}
+	h.Set("True-Client-IP", "203.0.113.42")
+	got := runReq(t, mustCIDRs(t, "10.0.0.0/8"), "10.0.0.1:55000", h)
+	if got != "203.0.113.42:55000" {
+		t.Fatalf("RemoteAddr = %q; want 203.0.113.42:55000", got)
+	}
+}
+
+func TestTrustedRealIP_XRealIP_TrustedPeer(t *testing.T) {
+	h := http.Header{}
+	h.Set("X-Real-IP", "203.0.113.99")
+	got := runReq(t, mustCIDRs(t, "10.0.0.0/8"), "10.0.0.1:55000", h)
+	if got != "203.0.113.99:55000" {
+		t.Fatalf("RemoteAddr = %q; want 203.0.113.99:55000", got)
+	}
+}
+
+func TestTrustedRealIP_XFFGarbage_FallsThrough(t *testing.T) {
+	// Unparseable XFF entry: the chain of trust is broken at that hop, so
+	// clientFromXFF returns the raw token. RemoteAddr is rewritten with it
+	// (a downstream IP-parser will then fail closed). We assert that XFF
+	// short-circuits and the True-Client-IP / X-Real-IP fallbacks are NOT
+	// consulted when XFF was present.
+	h := http.Header{}
+	h.Set("X-Forwarded-For", "not-an-ip")
+	h.Set("True-Client-IP", "203.0.113.7")
+	got := runReq(t, mustCIDRs(t, "10.0.0.0/8"), "10.0.0.1:55000", h)
+	if got != "not-an-ip:55000" {
+		t.Fatalf("RemoteAddr = %q; want not-an-ip:55000 (XFF garbage short-circuits)", got)
+	}
+}
+
+func TestTrustedRealIP_GarbageTrueClientIP_LeavesAlone(t *testing.T) {
+	h := http.Header{}
+	h.Set("True-Client-IP", "definitely not an ip")
+	got := runReq(t, mustCIDRs(t, "10.0.0.0/8"), "10.0.0.1:55000", h)
+	if got != "10.0.0.1:55000" {
+		t.Fatalf("RemoteAddr = %q; want unchanged 10.0.0.1:55000", got)
+	}
+}
+
+func TestTrustedRealIP_EmptyTrustedCIDRs_Noop(t *testing.T) {
+	// When trustedCIDRs is empty the middleware MUST be a no-op regardless
+	// of headers or peer — even a peer that *would* be trusted in a different
+	// config must not have its RemoteAddr rewritten.
+	h := http.Header{}
+	h.Set("X-Forwarded-For", "5.6.7.8")
+	h.Set("True-Client-IP", "9.9.9.9")
+	h.Set("X-Real-IP", "10.10.10.10")
+	if got := runReq(t, nil, "10.0.0.1:55000", h); got != "10.0.0.1:55000" {
+		t.Fatalf("RemoteAddr = %q; want unchanged 10.0.0.1:55000 (no trusted proxies)", got)
+	}
+	if got := runReq(t, nil, "1.2.3.4:55000", h); got != "1.2.3.4:55000" {
+		t.Fatalf("RemoteAddr = %q; want unchanged 1.2.3.4:55000 (no trusted proxies)", got)
+	}
+}
+
+func TestTrustedRealIP_PreservesIPv6Port(t *testing.T) {
+	// IPv6 peer with port. Rewritten RemoteAddr must be valid for
+	// net.SplitHostPort, i.e. bracketed.
+	h := http.Header{}
+	h.Set("X-Forwarded-For", "1.2.3.4")
+	trusted := mustCIDRs(t, "fd00::/8")
+	got := runReq(t, trusted, "[fd00::1]:55000", h)
+	if got != "1.2.3.4:55000" {
+		t.Fatalf("RemoteAddr = %q; want 1.2.3.4:55000", got)
+	}
+	if h2, p2, err := net.SplitHostPort(got); err != nil || h2 != "1.2.3.4" || p2 != "55000" {
+		t.Fatalf("rewritten addr not parseable: %v %q %q", err, h2, p2)
+	}
+}
+
+func TestTrustedRealIP_NoPortInPeer_NoPortInRewrite(t *testing.T) {
+	// Unusual: r.RemoteAddr without a port (custom listener). Keep the
+	// rewrite portless rather than inventing a synthetic port.
+	h := http.Header{}
+	h.Set("X-Forwarded-For", "1.2.3.4")
+	got := runReq(t, mustCIDRs(t, "10.0.0.0/8"), "10.0.0.1", h)
+	if got != "1.2.3.4" {
+		t.Fatalf("RemoteAddr = %q; want 1.2.3.4", got)
+	}
+}


### PR DESCRIPTION
## What

Replaces `chi.middleware.RealIP` at `cmd/bindery/proxy.go:57` with a new `internal/httpsec/realip.TrustedRealIP` that only honours forwarded headers when the immediate TCP peer is in the `BINDERY_TRUSTED_PROXY` allowlist, and walks `X-Forwarded-For` right-to-left to find the first untrusted hop instead of trusting the (attacker-controlled) leftmost entry.

## Why

go-chi upstream deprecated `middleware.RealIP` because it rewrites `r.RemoteAddr` from the leftmost `X-Forwarded-For` (or `True-Client-IP`/`X-Real-IP`) value **regardless of whether the immediate peer is a trusted proxy** — see GHSA-3fxj-6jh8-hvhx, GHSA-rjr7-jggh-pgcp, GHSA-9g5q-2w5x-hmxf. Any client on the open internet can send `X-Forwarded-For: 1.2.3.4` and the deprecated middleware will obediently set `r.RemoteAddr = 1.2.3.4`. Bindery's CSRF, login rate-limiter, local-only auth bypass, and trusted-proxy-CIDR checks downstream all rely on `r.RemoteAddr` being correct, so the deprecated middleware is actively dangerous in a homelab deployment behind a reverse proxy that forwards inbound XFF.

This is the SA1019 lint failure currently blocking #816 (dependabot's go-chi bump).

### Why rightmost-untrusted, not leftmost

`X-Forwarded-For` is appended left-to-right (oldest hop first). A remote client may prepend anything it likes; the trusted proxy at the edge then appends the client's real source IP and passes the whole list through. The **leftmost** entry is therefore attacker-controlled — that is the entire CVE class. Walking **right-to-left** and peeling off hops that are themselves trusted proxies yields the first hop we cannot vouch for, which is by definition the genuine client. This matches the algorithm `auth.ResolveClientIP` already uses for the local-only-auth trust decision, so both code paths now agree on "who is the client".

If every XFF hop is itself a trusted proxy, we fall back to the leftmost entry (standard XFF semantics — that is the original client). When the immediate peer is *not* trusted, all forwarded headers are ignored and `RemoteAddr` is left alone, so an open-internet client cannot spoof it.

### Package location: `internal/httpsec/realip`

Chose `internal/httpsec/realip` over `internal/auth/realip`. `httpsec` already exists as the home for HTTP-layer security primitives (the SSRF validator lives there); RemoteAddr-rewriting is a transport-level concern that auth happens to consume, not an auth concept itself. `internal/auth` stays focused on identity/sessions; `httpsec` stays focused on hardening the HTTP layer.

### Port preservation

`chi.middleware.RealIP` stripped the port from `r.RemoteAddr`. `TrustedRealIP` preserves the original peer's port on rewrite (so `net.SplitHostPort(r.RemoteAddr)` continues to work downstream). When the original `RemoteAddr` had no port (unusual but possible with a custom listener), the rewrite is also portless rather than inventing a synthetic value.

## What unblocks

- #816 (dependabot go-chi bump — currently red because the deprecated symbol trips SA1019 under golangci-lint v2.11.4).

## Tests

`internal/httpsec/realip/realip_test.go` covers:
- No headers, trusted peer / untrusted peer (no rewrite).
- Trusted XFF chain — peeled right-to-left to the real client.
- Untrusted source forging XFF / True-Client-IP / X-Real-IP — all rejected, peer unchanged.
- All XFF hops trusted — leftmost (original client) wins.
- True-Client-IP and X-Real-IP fallbacks (trusted peer, no XFF).
- Garbage XFF entry — short-circuits to that raw value (chain of trust broken; fails closed downstream).
- Garbage `True-Client-IP` / `X-Real-IP` — left alone.
- Empty trusted CIDR list — middleware is a true no-op regardless of headers or peer.
- IPv6 peer with port — rewritten address remains `net.SplitHostPort`-parseable.
- Portless peer — rewrite is also portless.

## Verification

- `gofmt -l ./cmd ./internal` clean
- `go vet ./...` clean
- `golangci-lint v2.11.4 run --timeout=5m` — 0 issues (SA1019 RealIP deprecation gone)
- `go test ./...` — full suite green
- `cd web && npm run typecheck && npm run lint && npm run build && npm test` — clean (5 pre-existing react-hooks warnings, no errors; no frontend changes in this PR)

Closes #840
Refs #816

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>