### PR TITLE
fix(indexer): pass foreign-language categories through the search filter (#851)

### DIFF
--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -82,10 +82,27 @@ func (s *Searcher) makeClient(baseURL, apiKey string) *newznab.Client {
 // indexers returns unrelated results because the standard IDs do not cover
 // the indexer's extended subcategory tree.
 func filterCategoriesForMedia(cats []int, mediaType string) []int {
-	wantTens := 702
+	// Newznab category convention: 7xxx is the Books parent (7020 ebook,
+	// 7030 magazines), 3xxx is Audio (3030 audiobook). The bare parents
+	// (7000 / 3000) are deliberately dropped: Prowlarr reports them for
+	// generic book trackers and sending them as-is returns the entire
+	// books or audio surface, which is noise.
+	//
+	// Beyond that, every non-parent subcategory in the matching bucket is
+	// trusted: the user explicitly added it to the indexer's category list
+	// in Settings → Indexers. Previously the filter narrowly matched
+	// 702x / 303x and silently dropped foreign-language IDs like 7120
+	// (German ebooks), 7150, 7180, and any 31xx audiobook variants (#851),
+	// leaving non-English users searching only the English bucket. Now any
+	// 7xxx (except 7000) flows through for ebook search, and any 3xxx
+	// (except 3000) flows through for audiobook search. Standard 7020 /
+	// 3030 remain the fallback for empty input or zero matches.
+	wantThousand := 7
+	parent := 7000
 	fallback := []int{7020}
 	if mediaType == "audiobook" {
-		wantTens = 303
+		wantThousand = 3
+		parent = 3000
 		fallback = []int{3030}
 	}
 	if len(cats) == 0 {
@@ -94,7 +111,7 @@ func filterCategoriesForMedia(cats []int, mediaType string) []int {
 	var out []int
 	hasNonStandard := false
 	for _, c := range cats {
-		if c/10 == wantTens {
+		if c/1000 == wantThousand && c != parent {
 			out = append(out, c)
 		}
 		if c > 9999 {

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -315,7 +315,10 @@ func TestFilterByLanguageAny(t *testing.T) {
 func TestFilterCategoriesForMedia(t *testing.T) {
 	all := []int{7000, 7020, 3030}
 	ebook := filterCategoriesForMedia(all, "ebook")
-	if len(ebook) != 1 || ebook[0] != 7020 {
+	// 7000 (books parent) is dropped — sending the broad parent to indexers
+	// returns noise. 7020 is the canonical ebook subcategory. 3030 is audio
+	// so excluded from ebook search.
+	if !equalIntSlice(ebook, []int{7020}) {
 		t.Errorf("ebook filter = %v, want [7020]", ebook)
 	}
 	audio := filterCategoriesForMedia(all, "audiobook")
@@ -591,18 +594,52 @@ func TestFilterRelevantStopWordsBetweenKeywords(t *testing.T) {
 
 // Only standard Newznab ebook (702x) and audiobook (303x) subcategories pass.
 // Site-specific extensions like 7120 or 3130 are outside those ranges.
+// TestFilterCategoriesCustomIDs covers #851: foreign-language ebook/audiobook
+// IDs like 7120/7150/7180 (German) or 3130/3150 (Spanish-audio) must pass
+// through the filter alongside the standard 7020/3030. The previous narrow
+// 702x/303x check silently dropped them, leaving non-English users with
+// search hitting only the English category.
 func TestFilterCategoriesCustomIDs(t *testing.T) {
 	cats := []int{7020, 7120, 3030, 3130}
 
 	ebook := filterCategoriesForMedia(cats, "ebook")
-	if len(ebook) != 1 || ebook[0] != 7020 {
-		t.Errorf("ebook cats = %v, want [7020]", ebook)
+	if !equalIntSlice(ebook, []int{7020, 7120}) {
+		t.Errorf("ebook cats = %v, want [7020, 7120]", ebook)
 	}
 
 	audio := filterCategoriesForMedia(cats, "audiobook")
-	if len(audio) != 1 || audio[0] != 3030 {
+	if !equalIntSlice(audio, []int{3030, 3130}) {
+		t.Errorf("audio cats = %v, want [3030, 3130]", audio)
+	}
+}
+
+// TestFilterCategoriesGermanEbooks is the #851 reporter's exact configuration:
+// the user set 7020 + 7120 + 7150 + 7180 (English + multiple German ebook
+// subcategories) and ALSO had 3030 for audio. Ebook search must pass all four
+// 7xxx categories; audiobook search must keep 3030.
+func TestFilterCategoriesGermanEbooks(t *testing.T) {
+	cats := []int{7020, 7120, 7150, 7180, 3030}
+
+	ebook := filterCategoriesForMedia(cats, "ebook")
+	if !equalIntSlice(ebook, []int{7020, 7120, 7150, 7180}) {
+		t.Errorf("ebook cats = %v, want all four 7xxx categories", ebook)
+	}
+	audio := filterCategoriesForMedia(cats, "audiobook")
+	if !equalIntSlice(audio, []int{3030}) {
 		t.Errorf("audio cats = %v, want [3030]", audio)
 	}
+}
+
+func equalIntSlice(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // TestFilterCategoriesMaM covers indexers like MyAnonamouse whose entire
@@ -656,7 +693,11 @@ func TestFilterCategoriesParentDrop(t *testing.T) {
 		{[]int{7000}, "ebook", []int{7020}},
 		{[]int{3000}, "audiobook", []int{3030}},
 		{[]int{7000, 7020}, "ebook", []int{7020}},
-		{[]int{7000, 7020, 7030}, "ebook", []int{7020}},
+		// Post-#851: a user who configures 7030 alongside 7020 in their ebook
+		// indexer list gets both passed through — we trust the explicit
+		// configuration over the previous narrow 702x-only filter. Only the
+		// bare parent 7000 is dropped.
+		{[]int{7000, 7020, 7030}, "ebook", []int{7020, 7030}},
 		{[]int{3000, 3030}, "audiobook", []int{3030}},
 		{nil, "ebook", []int{7020}},
 		{[]int{7020, 7021, 7022}, "ebook", []int{7020, 7021, 7022}},


### PR DESCRIPTION
Closes #851.

## The bug

\`filterCategoriesForMedia\` narrowly matched \`702x / 303x\` only, silently dropping any other category from the user's explicit configuration. @zippoking on v1.15.0 configured \`7020, 7120, 7150, 7180, 3030\` for German books on a Newznab indexer that exposes those subcategories — the search-debug panel showed only \`7020\` was actually being queried. Same shape for any 31xx audiobook variants.

## The fix

\`internal/indexer/searcher.go:filterCategoriesForMedia\`:

- **Drop the bare parents** \`7000\` and \`3000\` only — Prowlarr reports them for generic book trackers and sending the broad parent to an indexer returns the entire books/audio surface (noise). The historical drop-bare-parent regression test stays intact.
- **Trust everything else** in the matching bucket. Any \`7xxx\` (except 7000) passes for ebook search; any \`3xxx\` (except 3000) passes for audiobook search. The user explicitly listed these categories in Settings → Indexers — second-guessing them was wrong.

The MaM-style \`100xxx\` pass-through path is unchanged. Standard \`7020 / 3030\` remain the empty-input fallback.

## Test coverage

- \`TestFilterCategoriesGermanEbooks\` — the reporter's exact config (\`7020, 7120, 7150, 7180, 3030\`). Ebook search must pass all four 7xxx; audiobook keeps 3030.
- \`TestFilterCategoriesCustomIDs\` updated to expect \`[7020, 7120]\` for ebook and \`[3030, 3130]\` for audio (was previously \`[7020]\` / \`[3030]\`).
- \`TestFilterCategoriesParentDrop\` updated for \`[7000, 7020, 7030]\` ebook to now expect \`[7020, 7030]\` rather than \`[7020]\` — magazines (7030) that the user explicitly listed now pass through.

## Verification

- [x] \`go test ./internal/indexer/... -count=1\` — green incl. new test
- [x] \`go test ./...\` — full suite green
- [x] \`gofmt -l\` clean
- [x] \`golangci-lint v2.11.4\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)