### PR TITLE
fix(ui): standardize clipboard fallback handling

### DIFF
--- a/web/src/components/ClipboardManualFallback.tsx
+++ b/web/src/components/ClipboardManualFallback.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  text: string
+  className?: string
+}
+
+export default function ClipboardManualFallback({ text, className = '' }: Props) {
+  const { t } = useTranslation()
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    textareaRef.current?.select()
+  }, [text])
+
+  return (
+    <div className={`rounded border border-amber-200 dark:border-amber-900/70 bg-amber-50 dark:bg-amber-950/30 p-3 text-amber-900 dark:text-amber-200 ${className}`}>
+      <p role="status" className="mb-2 text-xs">
+        {t('common.clipboardBlocked', 'Clipboard access is blocked. Copy the selected text below.')}
+      </p>
+      <textarea
+        ref={textareaRef}
+        readOnly
+        aria-label={t('common.clipboardTextLabel', 'Text to copy')}
+        value={text}
+        onFocus={e => e.currentTarget.select()}
+        className="h-32 w-full resize-y rounded border border-amber-200 dark:border-amber-900/70 bg-white dark:bg-zinc-950 p-2 font-mono text-xs text-slate-700 dark:text-zinc-200"
+      />
+    </div>
+  )
+}

--- a/web/src/components/SearchDebugPanel.test.tsx
+++ b/web/src/components/SearchDebugPanel.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import SearchDebugPanel from './SearchDebugPanel'
+import { SearchDebug } from '../api/client'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: unknown) => typeof fallback === 'string' ? fallback : String(_key),
+  }),
+}))
+
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+const originalIsSecureContext = Object.getOwnPropertyDescriptor(window, 'isSecureContext')
+const originalExecCommand = document.execCommand
+
+const debug: SearchDebug = {
+  query: {
+    title: 'Dune',
+    author: 'Frank Herbert',
+    mediaType: 'ebook',
+    year: 1965,
+  },
+  indexers: [
+    {
+      indexerId: 1,
+      indexerName: 'Test Indexer',
+      enabled: true,
+      categories: [7020],
+      resultCount: 1,
+      durationMs: 42,
+    },
+  ],
+  pipeline: {
+    rawCount: 1,
+    afterDedupe: 1,
+    afterUsenetJunk: 1,
+    afterRelevance: 1,
+  },
+  filters: [
+    {
+      title: 'Dune release',
+      indexerName: 'Test Indexer',
+      stage: 'relevance',
+      reason: 'accepted',
+    },
+  ],
+  startedAt: '2026-05-27T10:00:00Z',
+  durationMs: 50,
+}
+
+const expectedDebugJson = JSON.stringify(debug, null, 2)
+
+function setClipboard(writeText?: (text: string) => Promise<void>) {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: writeText ? { writeText } : undefined,
+  })
+}
+
+function setSecureContext(isSecureContext: boolean) {
+  Object.defineProperty(window, 'isSecureContext', {
+    configurable: true,
+    value: isSecureContext,
+  })
+}
+
+function setExecCommand(execCommand?: (commandId: string) => boolean) {
+  Object.defineProperty(document, 'execCommand', {
+    configurable: true,
+    value: execCommand,
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  if (originalClipboard) {
+    Object.defineProperty(navigator, 'clipboard', originalClipboard)
+  } else {
+    Reflect.deleteProperty(navigator, 'clipboard')
+  }
+  if (originalIsSecureContext) {
+    Object.defineProperty(window, 'isSecureContext', originalIsSecureContext)
+  } else {
+    Reflect.deleteProperty(window, 'isSecureContext')
+  }
+  if (originalExecCommand) {
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: originalExecCommand,
+    })
+  } else {
+    Reflect.deleteProperty(document, 'execCommand')
+  }
+})
+
+describe('SearchDebugPanel', () => {
+  it('copies debug JSON to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setSecureContext(true)
+    setClipboard(writeText)
+
+    render(<SearchDebugPanel debug={debug} resultCount={1} defaultOpen />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy debug info (JSON)' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(expectedDebugJson))
+    expect(screen.getByRole('button', { name: 'Copied!' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Text to copy')).toBeNull()
+  })
+
+  it('copies debug JSON with the legacy fallback when the Clipboard API is missing', async () => {
+    const execCommand = vi.fn(() => true)
+    setSecureContext(false)
+    setClipboard()
+    setExecCommand(execCommand)
+
+    render(<SearchDebugPanel debug={debug} resultCount={1} defaultOpen />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy debug info (JSON)' }))
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith('copy'))
+    expect(screen.getByRole('button', { name: 'Copied!' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Text to copy')).toBeNull()
+  })
+
+  it('shows selected JSON when clipboard writes and legacy copy fail', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    const execCommand = vi.fn(() => false)
+    setSecureContext(true)
+    setClipboard(writeText)
+    setExecCommand(execCommand)
+
+    render(<SearchDebugPanel debug={debug} resultCount={1} defaultOpen />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy debug info (JSON)' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(expectedDebugJson))
+    expect(execCommand).toHaveBeenCalledWith('copy')
+    expect(await screen.findByRole('status')).toHaveTextContent('Clipboard access is blocked')
+    const fallback = screen.getByLabelText('Text to copy') as HTMLTextAreaElement
+    expect(fallback).toHaveValue(expectedDebugJson)
+    await waitFor(() => {
+      expect(fallback.selectionStart).toBe(0)
+      expect(fallback.selectionEnd).toBe(expectedDebugJson.length)
+    })
+  })
+})

--- a/web/src/components/SearchDebugPanel.tsx
+++ b/web/src/components/SearchDebugPanel.tsx
@@ -1,28 +1,7 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { SearchDebug } from '../api/client'
-
-// legacyCopyToClipboard implements the document.execCommand('copy') fallback
-// for browsers running in non-secure contexts (plain-HTTP LAN deployments —
-// the common Bindery shape). Returns true on success. The temp textarea is
-// positioned off-screen and removed even when execCommand throws.
-function legacyCopyToClipboard(text: string): boolean {
-  const ta = document.createElement('textarea')
-  ta.value = text
-  ta.setAttribute('readonly', '')
-  ta.style.position = 'fixed'
-  ta.style.top = '-9999px'
-  ta.style.left = '-9999px'
-  document.body.appendChild(ta)
-  ta.focus()
-  ta.select()
-  try {
-    return document.execCommand('copy')
-  } catch {
-    return false
-  } finally {
-    document.body.removeChild(ta)
-  }
-}
+import ClipboardManualFallback from './ClipboardManualFallback'
+import { useClipboardCopy } from './useClipboardCopy'
 
 interface Props {
   debug: SearchDebug
@@ -35,34 +14,11 @@ interface Props {
 // Collapsed by default unless the caller opens it (typically when results=0).
 export default function SearchDebugPanel({ debug, resultCount, defaultOpen }: Props) {
   const [open, setOpen] = useState(!!defaultOpen)
-  const [copied, setCopied] = useState(false)
-  const [copyError, setCopyError] = useState(false)
+  const debugJson = useMemo(() => JSON.stringify(debug, null, 2), [debug])
+  const debugClipboard = useClipboardCopy()
 
   const copy = async () => {
-    const text = JSON.stringify(debug, null, 2)
-    // Modern path requires a secure context (HTTPS or localhost). Most
-    // Bindery installs run over plain HTTP on a LAN at e.g.
-    // http://192.168.x.x:8787, where navigator.clipboard is undefined and
-    // the previous catch-and-do-nothing left the button silently broken
-    // (#850). Try the modern API first, then fall back to the legacy
-    // execCommand-on-temp-textarea trick that works in non-secure contexts.
-    if (window.isSecureContext && navigator.clipboard?.writeText) {
-      try {
-        await navigator.clipboard.writeText(text)
-        setCopied(true)
-        setTimeout(() => setCopied(false), 1500)
-        return
-      } catch {
-        // fall through to legacy fallback
-      }
-    }
-    if (legacyCopyToClipboard(text)) {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-      return
-    }
-    setCopyError(true)
-    setTimeout(() => setCopyError(false), 3000)
+    await debugClipboard.copy(debugJson)
   }
 
   const indexers = debug.indexers ?? []
@@ -102,9 +58,13 @@ export default function SearchDebugPanel({ debug, resultCount, defaultOpen }: Pr
               onClick={copy}
               className="px-2 py-1 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded font-medium"
             >
-              {copyError ? 'Copy failed — select & ⌘C' : copied ? 'Copied!' : 'Copy debug info (JSON)'}
+              {debugClipboard.status === 'copied' ? 'Copied!' : 'Copy debug info (JSON)'}
             </button>
           </div>
+
+          {debugClipboard.status === 'manual' && (
+            <ClipboardManualFallback text={debugClipboard.manualText} />
+          )}
 
           <div>
             <h4 className="font-semibold text-slate-700 dark:text-zinc-300 mb-1">Query</h4>

--- a/web/src/components/useClipboardCopy.test.tsx
+++ b/web/src/components/useClipboardCopy.test.tsx
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import ClipboardManualFallback from './ClipboardManualFallback'
+import { useClipboardCopy } from './useClipboardCopy'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: unknown) => typeof fallback === 'string' ? fallback : String(_key),
+  }),
+}))
+
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard')
+const originalIsSecureContext = Object.getOwnPropertyDescriptor(window, 'isSecureContext')
+const originalExecCommand = document.execCommand
+
+function setClipboard(writeText?: (text: string) => Promise<void>) {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: writeText ? { writeText } : undefined,
+  })
+}
+
+function setSecureContext(isSecureContext: boolean) {
+  Object.defineProperty(window, 'isSecureContext', {
+    configurable: true,
+    value: isSecureContext,
+  })
+}
+
+function setExecCommand(execCommand?: (commandId: string) => boolean) {
+  Object.defineProperty(document, 'execCommand', {
+    configurable: true,
+    value: execCommand,
+  })
+}
+
+function restoreClipboard() {
+  if (originalClipboard) {
+    Object.defineProperty(navigator, 'clipboard', originalClipboard)
+  } else {
+    Reflect.deleteProperty(navigator, 'clipboard')
+  }
+}
+
+function restoreIsSecureContext() {
+  if (originalIsSecureContext) {
+    Object.defineProperty(window, 'isSecureContext', originalIsSecureContext)
+  } else {
+    Reflect.deleteProperty(window, 'isSecureContext')
+  }
+}
+
+function restoreExecCommand() {
+  if (originalExecCommand) {
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: originalExecCommand,
+    })
+  } else {
+    Reflect.deleteProperty(document, 'execCommand')
+  }
+}
+
+function ClipboardHarness({ text = 'copy me' }: { text?: string }) {
+  const clipboard = useClipboardCopy()
+
+  return (
+    <div>
+      <button type="button" onClick={() => clipboard.copy(text)}>
+        Copy
+      </button>
+      <span data-testid="status">{clipboard.status}</span>
+      {clipboard.status === 'manual' && (
+        <ClipboardManualFallback text={clipboard.manualText} />
+      )}
+    </div>
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  restoreClipboard()
+  restoreIsSecureContext()
+  restoreExecCommand()
+})
+
+describe('useClipboardCopy', () => {
+  it('copies text with the Clipboard API', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setSecureContext(true)
+    setClipboard(writeText)
+
+    render(<ClipboardHarness text="clipboard text" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('clipboard text'))
+    expect(screen.getByTestId('status')).toHaveTextContent('copied')
+    expect(screen.queryByLabelText('Text to copy')).toBeNull()
+  })
+
+  it('copies text with the legacy fallback when the Clipboard API is missing', async () => {
+    const execCommand = vi.fn(() => true)
+    setSecureContext(false)
+    setClipboard()
+    setExecCommand(execCommand)
+
+    render(<ClipboardHarness text="legacy text" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+
+    await waitFor(() => expect(execCommand).toHaveBeenCalledWith('copy'))
+    expect(screen.getByTestId('status')).toHaveTextContent('copied')
+    expect(screen.queryByLabelText('Text to copy')).toBeNull()
+  })
+
+  it('shows selected fallback text when clipboard writes and legacy copy fail', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    const execCommand = vi.fn(() => false)
+    setSecureContext(true)
+    setClipboard(writeText)
+    setExecCommand(execCommand)
+
+    render(<ClipboardHarness text="manual text" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('manual text'))
+    expect(execCommand).toHaveBeenCalledWith('copy')
+    expect(await screen.findByRole('status')).toHaveTextContent('Clipboard access is blocked')
+    const fallback = screen.getByLabelText('Text to copy') as HTMLTextAreaElement
+    expect(fallback).toHaveValue('manual text')
+    await waitFor(() => {
+      expect(fallback.selectionStart).toBe(0)
+      expect(fallback.selectionEnd).toBe('manual text'.length)
+    })
+  })
+})

--- a/web/src/components/useClipboardCopy.ts
+++ b/web/src/components/useClipboardCopy.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export type ClipboardCopyStatus = 'idle' | 'copied' | 'manual'
+
+// Keep copy buttons working on plain-HTTP LAN installs where the modern
+// Clipboard API is unavailable, then fall back to a visible textarea.
+function legacyCopyToClipboard(text: string): boolean {
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.top = '-9999px'
+  textarea.style.left = '-9999px'
+  document.body.appendChild(textarea)
+  textarea.focus()
+  textarea.select()
+  try {
+    return document.execCommand('copy')
+  } catch {
+    return false
+  } finally {
+    document.body.removeChild(textarea)
+  }
+}
+
+export function useClipboardCopy(resetDelayMs = 1500) {
+  const [status, setStatus] = useState<ClipboardCopyStatus>('idle')
+  const [manualText, setManualText] = useState('')
+  const resetTimerRef = useRef<number | undefined>(undefined)
+
+  const clearResetTimer = useCallback(() => {
+    if (resetTimerRef.current !== undefined) {
+      window.clearTimeout(resetTimerRef.current)
+      resetTimerRef.current = undefined
+    }
+  }, [])
+
+  useEffect(() => () => {
+    clearResetTimer()
+  }, [clearResetTimer])
+
+  const markCopied = useCallback(() => {
+    setManualText('')
+    setStatus('copied')
+    resetTimerRef.current = window.setTimeout(() => {
+      setStatus('idle')
+      resetTimerRef.current = undefined
+    }, resetDelayMs)
+  }, [resetDelayMs])
+
+  const copy = useCallback(async (text: string) => {
+    clearResetTimer()
+    if (window.isSecureContext && navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text)
+        markCopied()
+        return true
+      } catch {
+        // Try the legacy path before asking the user to copy manually.
+      }
+    }
+    if (legacyCopyToClipboard(text)) {
+      markCopied()
+      return true
+    }
+    setManualText(text)
+    setStatus('manual')
+    return false
+  }, [clearResetTimer, markCopied])
+
+  const reset = useCallback(() => {
+    clearResetTimer()
+    setManualText('')
+    setStatus('idle')
+  }, [clearResetTimer])
+
+  return { status, manualText, copy, reset }
+}

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -31,7 +31,11 @@
     "connOk": "Verbindung erfolgreich!",
     "connFail": "Test fehlgeschlagen: {{error}}",
     "prev": "Prev",
-    "next": "Next"
+    "next": "Next",
+    "copy": "Kopieren",
+    "copied": "Kopiert",
+    "clipboardBlocked": "Der Zugriff auf die Zwischenablage ist blockiert. Kopiere den ausgewählten Text unten.",
+    "clipboardTextLabel": "Zu kopierender Text"
   },
   "nav": {
     "authors": "Autoren",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -32,7 +32,11 @@
     "connOk": "Connection successful!",
     "connFail": "Test failed: {{error}}",
     "prev": "Prev",
-    "next": "Next"
+    "next": "Next",
+    "copy": "Copy",
+    "copied": "Copied",
+    "clipboardBlocked": "Clipboard access is blocked. Copy the selected text below.",
+    "clipboardTextLabel": "Text to copy"
   },
   "monitorMode": {
     "all": "All books",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -32,7 +32,11 @@
     "connOk": "¡Conexión exitosa!",
     "connFail": "Error en la prueba: {{error}}",
     "prev": "Prev",
-    "next": "Next"
+    "next": "Next",
+    "copy": "Copiar",
+    "copied": "Copiado",
+    "clipboardBlocked": "El acceso al portapapeles está bloqueado. Copia el texto seleccionado abajo.",
+    "clipboardTextLabel": "Texto para copiar"
   },
   "nav": {
     "authors": "Autores",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -31,7 +31,11 @@
     "connOk": "Connexion réussie !",
     "connFail": "Test échoué : {{error}}",
     "prev": "Prev",
-    "next": "Next"
+    "next": "Next",
+    "copy": "Copier",
+    "copied": "Copié",
+    "clipboardBlocked": "L’accès au presse-papiers est bloqué. Copiez le texte sélectionné ci-dessous.",
+    "clipboardTextLabel": "Texte à copier"
   },
   "nav": {
     "authors": "Auteurs",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -32,7 +32,11 @@
     "connOk": "Koneksi berhasil!",
     "connFail": "Uji gagal: {{error}}",
     "prev": "Prev",
-    "next": "Next"
+    "next": "Next",
+    "copy": "Salin",
+    "copied": "Disalin",
+    "clipboardBlocked": "Akses clipboard diblokir. Salin teks yang dipilih di bawah ini.",
+    "clipboardTextLabel": "Teks untuk disalin"
   },
   "nav": {
     "authors": "Penulis",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -31,7 +31,11 @@
     "connOk": "Verbinding geslaagd!",
     "connFail": "Test mislukt: {{error}}",
     "prev": "Prev",
-    "next": "Next"
+    "next": "Next",
+    "copy": "Kopiëren",
+    "copied": "Gekopieerd",
+    "clipboardBlocked": "Toegang tot het klembord is geblokkeerd. Kopieer de geselecteerde tekst hieronder.",
+    "clipboardTextLabel": "Te kopiëren tekst"
   },
   "nav": {
     "authors": "Auteurs",

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -32,7 +32,11 @@
     "connOk": "Matagumpay ang koneksyon!",
     "connFail": "Nabigo ang pagsubok: {{error}}",
     "prev": "Prev",
-    "next": "Next"
+    "next": "Next",
+    "copy": "Kopyahin",
+    "copied": "Nakopya",
+    "clipboardBlocked": "Naka-block ang access sa clipboard. Kopyahin ang napiling text sa ibaba.",
+    "clipboardTextLabel": "Text na kokopyahin"
   },
   "nav": {
     "authors": "Mga May-akda",

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -180,7 +180,18 @@ beforeEach(() => {
   vi.mocked(api.toggleExcluded).mockImplementation(async () => makeBook({ excluded: true }))
   vi.mocked(api.enrichAudiobook).mockImplementation(async () => makeBook())
   // jsdom has no clipboard by default.
-  Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } })
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  })
+  Object.defineProperty(window, 'isSecureContext', {
+    value: true,
+    configurable: true,
+  })
+  Object.defineProperty(document, 'execCommand', {
+    value: vi.fn().mockReturnValue(false),
+    configurable: true,
+  })
 })
 
 describe('SearchResultsSection — dual-format book', () => {

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -6,6 +6,8 @@ import SearchDebugPanel from '../components/SearchDebugPanel'
 import MediaBadge from '../components/MediaBadge'
 import RebindModal from '../components/RebindModal'
 import ConfirmDialog from '../components/ConfirmDialog'
+import ClipboardManualFallback from '../components/ClipboardManualFallback'
+import { useClipboardCopy } from '../components/useClipboardCopy'
 
 function formatSize(n: number): string {
   if (!n || n <= 0) return ''
@@ -168,7 +170,7 @@ export default function BookDetailPage() {
   const [togglingExclude, setTogglingExclude] = useState(false)
   const [showRebind, setShowRebind] = useState(false)
   const [showDeleteBook, setShowDeleteBook] = useState(false)
-  const [copied, setCopied] = useState(false)
+  const pathClipboard = useClipboardCopy()
   // For dual-format books, which format the file section is acting on.
   const [activeFormat, setActiveFormat] = useState<'ebook' | 'audiobook'>('ebook')
 
@@ -337,13 +339,7 @@ export default function BookDetailPage() {
   }
 
   const copyPath = async (path: string) => {
-    try {
-      await navigator.clipboard.writeText(path)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    } catch {
-      /* clipboard unavailable */
-    }
+    await pathClipboard.copy(path)
   }
 
   if (loading) return <div className="text-slate-600 dark:text-zinc-500">{t('common.loading')}</div>
@@ -554,13 +550,18 @@ export default function BookDetailPage() {
                     className="shrink-0 text-slate-500 dark:text-zinc-400 hover:text-slate-700 dark:hover:text-zinc-200 text-xs border border-slate-300 dark:border-zinc-700 rounded px-1.5 py-0.5"
                     aria-label={t('bookDetail.copyPath')}
                   >
-                    <span aria-hidden>⧉</span> {copied ? t('bookDetail.copied') : t('bookDetail.copy')}
+                    <span aria-hidden>⧉</span> {pathClipboard.status === 'copied' ? t('bookDetail.copied') : t('bookDetail.copy')}
                   </button>
                 </>
               ) : (
                 <span className="text-xs text-slate-500 dark:text-zinc-500">{t('bookDetail.noFile')}</span>
               )}
             </span>
+            {pathClipboard.status === 'manual' && (
+              <div className="col-start-2">
+                <ClipboardManualFallback text={pathClipboard.manualText} />
+              </div>
+            )}
           </div>
 
           <div className="mt-4 pt-4 border-t border-slate-200 dark:border-zinc-800 flex flex-wrap items-center gap-2">

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -353,6 +353,14 @@ describe('SettingsPage', () => {
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
       configurable: true,
     })
+    Object.defineProperty(window, 'isSecureContext', {
+      value: true,
+      configurable: true,
+    })
+    Object.defineProperty(document, 'execCommand', {
+      value: vi.fn().mockReturnValue(false),
+      configurable: true,
+    })
     seedSettingsMocks()
   })
 
@@ -671,6 +679,28 @@ describe('SettingsPage', () => {
     } finally {
       confirmSpy.mockRestore()
     }
+  })
+
+  it('shows manual copy fallback when security API key clipboard access is blocked', async () => {
+    vi.mocked(api.authConfig).mockResolvedValue({ mode: 'enabled', apiKey: 'api-secret', username: 'admin' })
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+      configurable: true,
+    })
+
+    renderSettings()
+
+    await screen.findByRole('heading', { name: 'Security' })
+    const security = sectionForHeading('Security')
+    expect(security.queryByDisplayValue('api-secret')).not.toBeInTheDocument()
+
+    fireEvent.click(security.getByRole('button', { name: 'Copy' }))
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith('api-secret')
+    })
+
+    expect(await security.findByRole('status')).toHaveTextContent('Clipboard access is blocked')
+    expect(security.getByLabelText('Text to copy')).toHaveValue('api-secret')
   })
 
   it('validates and submits password changes', async () => {

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -4,6 +4,8 @@ import { api, AuthConfig, AuthStatus, AuthorMonitorMode, HardcoverTestResult, Ro
 import AuthSettings from '../../settings/AuthSettings'
 import ThemeToggle from '../../components/ThemeToggle'
 import LanguageSwitcher from '../../components/LanguageSwitcher'
+import ClipboardManualFallback from '../../components/ClipboardManualFallback'
+import { useClipboardCopy } from '../../components/useClipboardCopy'
 import { useAuth } from '../../auth/AuthContext'
 import { inputCls } from './formStyles'
 import Toggle from './Toggle'
@@ -36,6 +38,7 @@ function isAuthorMonitorMode(value: string): value is AuthorMonitorMode {
 export default function GeneralTab() {
   const { t } = useTranslation()
   const { isAdmin } = useAuth()
+  const opdsClipboard = useClipboardCopy()
   const [settings, setSettings] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState<string | null>(null)
@@ -827,12 +830,15 @@ export default function GeneralTab() {
                 {window.location.origin}/opds
               </code>
               <button
-                onClick={() => navigator.clipboard.writeText(window.location.origin + '/opds')}
+                onClick={() => opdsClipboard.copy(window.location.origin + '/opds')}
                 className="px-3 py-1.5 bg-slate-600 hover:bg-slate-500 rounded text-xs font-medium flex-shrink-0"
               >
-                {t('settings.general.copy')}
+                {opdsClipboard.status === 'copied' ? t('common.copied', 'Copied') : t('settings.general.copy')}
               </button>
             </div>
+            {opdsClipboard.status === 'manual' && (
+              <ClipboardManualFallback text={opdsClipboard.manualText} className="mt-2" />
+            )}
             <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1.5">{t('settings.general.opdsHint')}</p>
           </div>
         </div>
@@ -941,13 +947,14 @@ export default function GeneralTab() {
 }
 
 function SecuritySection() {
+  const { t } = useTranslation()
   const { status, refresh, isAdmin } = useAuth()
   const [cfg, setCfg] = useState<AuthConfig | null>(null)
   const [showKey, setShowKey] = useState(false)
   const [regenerating, setRegenerating] = useState(false)
   const [rotatingSecret, setRotatingSecret] = useState(false)
   const [savingMode, setSavingMode] = useState(false)
-  const [copied, setCopied] = useState(false)
+  const apiKeyClipboard = useClipboardCopy()
 
   const loadCfg = () => {
     api.authConfig().then(setCfg).catch(console.error)
@@ -997,11 +1004,7 @@ function SecuritySection() {
 
   const copyKey = async () => {
     if (!cfg?.apiKey) return
-    try {
-      await navigator.clipboard.writeText(cfg.apiKey)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    } catch { /* clipboard blocked */ }
+    await apiKeyClipboard.copy(cfg.apiKey)
   }
 
   if (!cfg) return null
@@ -1041,12 +1044,15 @@ function SecuritySection() {
               {showKey ? 'Hide' : 'Show'}
             </button>
             <button onClick={copyKey} className="px-3 py-2 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium">
-              {copied ? 'Copied' : 'Copy'}
+              {apiKeyClipboard.status === 'copied' ? t('common.copied', 'Copied') : t('common.copy', 'Copy')}
             </button>
             <button onClick={regenerate} disabled={regenerating} className="px-3 py-2 bg-amber-600 hover:bg-amber-500 rounded text-xs font-medium disabled:opacity-50">
               {regenerating ? '...' : 'Regenerate'}
             </button>
           </div>
+          {apiKeyClipboard.status === 'manual' && (
+            <ClipboardManualFallback text={apiKeyClipboard.manualText} className="mt-2" />
+          )}
         </div>
 
         <div className="border-t border-slate-200 dark:border-zinc-800 pt-4">

--- a/web/src/settings/AuthSettings.tsx
+++ b/web/src/settings/AuthSettings.tsx
@@ -1,6 +1,8 @@
 import { FormEvent, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, OidcProvider, OidcProviderConfig } from '../api/client'
+import ClipboardManualFallback from '../components/ClipboardManualFallback'
+import { useClipboardCopy } from '../components/useClipboardCopy'
 
 const inputCls = 'w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600'
 
@@ -152,7 +154,7 @@ function AddProviderForm({
   const [callbackTemplate, setCallbackTemplate] = useState('/api/v1/auth/oidc/{id}/callback')
   // undefined = still loading, true = env var set, false = derived from headers
   const [baseConfigured, setBaseConfigured] = useState<boolean | undefined>(undefined)
-  const [copied, setCopied] = useState(false)
+  const callbackClipboard = useClipboardCopy()
 
   useEffect(() => {
     api.oidcRedirectBase()
@@ -166,27 +168,13 @@ function AddProviderForm({
       .catch(() => {})
   }, [])
 
-  // Reset the "copied" badge after 1.5s. Lives in an effect (rather than a
-  // bare setTimeout in the click handler) so it's cleared if the form
-  // unmounts before the timer fires.
-  useEffect(() => {
-    if (!copied) return
-    const t = setTimeout(() => setCopied(false), 1500)
-    return () => clearTimeout(t)
-  }, [copied])
-
   const trimmedId = id.trim()
   const callbackPreview = trimmedId
     ? redirectBase + callbackTemplate.replace('{id}', encodeURIComponent(trimmedId))
     : ''
   const copyCallback = async () => {
     if (!callbackPreview) return
-    try {
-      await navigator.clipboard.writeText(callbackPreview)
-      setCopied(true)
-    } catch {
-      /* clipboard unavailable */
-    }
+    await callbackClipboard.copy(callbackPreview)
   }
 
   const submit = (e: FormEvent) => {
@@ -235,9 +223,12 @@ function AddProviderForm({
             disabled={!callbackPreview}
             className="px-2 py-1.5 text-xs rounded border border-slate-300 dark:border-zinc-700 hover:bg-slate-100 dark:hover:bg-zinc-800 disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
           >
-            {copied ? t('settings.oidc.callbackUrlCopied') : t('settings.oidc.callbackUrlCopy')}
+            {callbackClipboard.status === 'copied' ? t('settings.oidc.callbackUrlCopied') : t('settings.oidc.callbackUrlCopy')}
           </button>
         </div>
+        {callbackClipboard.status === 'manual' && (
+          <ClipboardManualFallback text={callbackClipboard.manualText} className="mt-2" />
+        )}
         <p className="text-[11px] text-slate-500 dark:text-zinc-500 mt-1">
           {t('settings.oidc.callbackUrlHint')}
         </p>


### PR DESCRIPTION
## Summary

This follows the issue #850 clipboard fix by moving the copy behavior into a shared helper so copy buttons handle secure Clipboard API writes, plain-HTTP LAN fallback copy, and visible manual copy fallback consistently. Refs #850.

- Added `useClipboardCopy` and `ClipboardManualFallback` as shared UI clipboard primitives.
- Reused the helper for search debug JSON, book file paths, OPDS feed URLs, API keys, and OIDC callback URLs.
- Added focused coverage for modern clipboard writes, legacy copy fallback, and manual copy fallback states.

## Checklist

- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed - N/A, no deployment or config changes
- [ ] `CHANGELOG.md` `[Unreleased]` section updated - N/A, release-time only per AGENTS.md
- [ ] Wiki pages updated if user-facing behaviour changed - N/A, no wiki update needed for this follow-up

## Test plan

- [ ] `go test ./cmd/... ./internal/...` - N/A, frontend-only change
- [x] `cd web && npm ci`
- [x] `cd web && npm test -- SearchDebugPanel.test.tsx useClipboardCopy.test.tsx SettingsPage.test.tsx`
- [x] `cd web && npm test -- BookDetailPage.test.tsx`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run typecheck`
- [x] `cd web && npm run build`
- [x] `cd web && npm test`
