### PR TITLE
fix(downloader): preflight nzbget categories so id-0 rejections name the cause (#861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **NZBGet rejections now name the actual problem** (#861) — when NZBGet's `append` JSON-RPC returns id 0 (rejection), Bindery's error was `NZBGet rejected download (returned id 0)` with nothing more, which gave users no path forward. The most common cause is that the category configured in Bindery's download-client (e.g. `Audiobooks`) isn't defined in NZBGet's own Settings → Categories — NZBGet silently rejects in that case. Bindery now preflights the category list via NZBGet's `config` RPC before submitting; on mismatch the error names both the missing category and what NZBGet actually has configured. The same check runs at Test-Connection time so the misconfig surfaces when saving the client, not on the first grab. If preflight passes but append still returns 0 (disk full, write-permission on intermediate dir, NZBGet paused with quota reached, invalid NZB content), the fallback error now enumerates those causes and points the user at NZBGet's own log. Thanks to @BraynArts for the report.
+
 ## [v1.15.1] — 2026-05-27
 
 Patch release. Five security/correctness fixes from a post-v1.15.0 review pass plus two user-visible bug fixes that affect every install (OpenLibrary author-search 403, notifications silently inert for everything but manual grabs).

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -82,7 +82,14 @@ func TestClient(ctx context.Context, client *models.DownloadClient) error {
 		return dl.Test(ctx)
 	case "nzbget":
 		ng := nzbget.New(client.Host, client.Port, client.Username, client.Password, client.URLBase, client.UseSSL)
-		return ng.Test(ctx)
+		if err := ng.Test(ctx); err != nil {
+			return err
+		}
+		// Catch the most common misconfig (category in Bindery doesn't exist
+		// in NZBGet) at save time rather than on the first grab. Surfaces
+		// both list-RPC errors and mismatch errors; if version succeeded but
+		// config doesn't, that's a real configuration question worth showing.
+		return ng.CheckCategories(ctx, client.Category, client.CategoryAudiobook)
 	default:
 		sab := sabnzbd.New(client.Host, client.Port, client.APIKey, client.URLBase, client.UseSSL)
 		return sab.Test(ctx)

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -18,6 +19,11 @@ import (
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 	"github.com/vavallee/bindery/internal/httpsec"
 )
+
+// categoryNameKey matches the NZBGet config keys that carry a category's
+// display name (Category1.Name, Category2.Name, …). NZBGet config also has
+// CategoryN.DestDir/Unpack/PostScript/Aliases — those are filtered out here.
+var categoryNameKey = regexp.MustCompile(`^Category\d+\.Name$`)
 
 // Client interacts with the NZBGet JSON-RPC API.
 type Client struct {
@@ -62,6 +68,79 @@ func (c *Client) Test(ctx context.Context) error {
 	return nil
 }
 
+// ListCategories returns the category display names defined in NZBGet's
+// nzbget.conf. NZBGet's append RPC silently rejects a download (returning id
+// 0) when the submitted category isn't one of these, so Bindery uses this to
+// preflight-validate before submitting.
+func (c *Client) ListCategories(ctx context.Context) ([]string, error) {
+	var resp configResponse
+	if err := c.call(ctx, "config", nil, &resp); err != nil {
+		return nil, fmt.Errorf("list nzbget categories: %w", err)
+	}
+	cats := make([]string, 0, 8)
+	for _, e := range resp.Result {
+		if categoryNameKey.MatchString(e.Name) && e.Value != "" {
+			cats = append(cats, e.Value)
+		}
+	}
+	return cats, nil
+}
+
+// CheckCategories reports an error when any of wanted is not present in
+// NZBGet's configured category list. Empty entries in wanted are skipped —
+// NZBGet treats an empty category as "use the default destination". When all
+// wanted entries are empty the call short-circuits and never hits the RPC.
+func (c *Client) CheckCategories(ctx context.Context, wanted ...string) error {
+	var nonEmpty []string
+	for _, w := range wanted {
+		if w != "" {
+			nonEmpty = append(nonEmpty, w)
+		}
+	}
+	if len(nonEmpty) == 0 {
+		return nil
+	}
+	have, err := c.ListCategories(ctx)
+	if err != nil {
+		return err
+	}
+	haveSet := make(map[string]struct{}, len(have))
+	for _, h := range have {
+		haveSet[h] = struct{}{}
+	}
+	var missing []string
+	for _, w := range nonEmpty {
+		if _, ok := haveSet[w]; !ok {
+			missing = append(missing, w)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return categoryMismatchError(missing, have)
+}
+
+// categoryMismatchError formats the actionable error returned when one or
+// more Bindery-configured categories aren't defined in NZBGet. We surface
+// both sides so the user can see what to rename on which side.
+func categoryMismatchError(missing, have []string) error {
+	quote := func(in []string) string {
+		out := make([]string, len(in))
+		for i, s := range in {
+			out[i] = strconv.Quote(s)
+		}
+		return strings.Join(out, ", ")
+	}
+	haveStr := "none defined"
+	if len(have) > 0 {
+		haveStr = quote(have)
+	}
+	if len(missing) == 1 {
+		return fmt.Errorf("NZBGet has no category %s configured (existing categories: %s). Add it in NZBGet's Settings → Categories, or change the category in Bindery's download-client config to match", strconv.Quote(missing[0]), haveStr)
+	}
+	return fmt.Errorf("NZBGet has no categories %s configured (existing categories: %s). Add them in NZBGet's Settings → Categories, or change the categories in Bindery's download-client config to match", quote(missing), haveStr)
+}
+
 // Add fetches the NZB file from nzbURL (using Bindery's own HTTP client, which
 // holds the indexer credentials and network path) then submits the content to
 // NZBGet as base64. Sending content rather than a URL means NZBGet never needs
@@ -75,6 +154,18 @@ func (c *Client) Add(ctx context.Context, nzbURL, name, category string, priorit
 	if err != nil {
 		return 0, err
 	}
+	// Best-effort preflight: if the category isn't defined in NZBGet, append
+	// will silently return id 0 with no other context. Surface a clear error
+	// here instead. If we can't reach the config RPC for any reason (older
+	// NZBGet, restricted ControlIP, transient failure) the mismatch error
+	// would be misleading — fall through and let append's response stand.
+	if category != "" {
+		if have, listErr := c.ListCategories(ctx); listErr == nil {
+			if !containsString(have, category) {
+				return 0, categoryMismatchError([]string{category}, have)
+			}
+		}
+	}
 	encoded := base64.StdEncoding.EncodeToString(content)
 	// append params: name, content, category, priority, dupecheck, dupekey, dupescore,
 	//                ppparameters (array), addtoTop, addpaused, urlpassword, postscript
@@ -84,9 +175,25 @@ func (c *Client) Add(ctx context.Context, nzbURL, name, category string, priorit
 		return 0, fmt.Errorf("add nzb: %w", err)
 	}
 	if resp.Result <= 0 {
-		return 0, fmt.Errorf("NZBGet rejected download (returned id %d)", resp.Result)
+		// Preflight already validated the category exists (or skipped because
+		// it's empty / the config call failed), so this branch is for the
+		// other classes of rejection: disk full, write-permission on
+		// NZBGet's intermediate dir, NZBGet paused with quota exhausted,
+		// invalid NZB content. NZBGet's own log carries the actual reason.
+		return 0, fmt.Errorf("NZBGet rejected the download (append returned id 0) — check NZBGet's log for the reason. Common causes: disk full, write-permission on the intermediate or destination directory, NZBGet paused with quota reached, or invalid NZB content")
 	}
 	return resp.Result, nil
+}
+
+// containsString returns true when needle appears in haystack. Tiny helper
+// kept local to avoid a slices import for the one site that needs it.
+func containsString(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) validateNZBFetchURL(raw string) error {

--- a/internal/downloader/nzbget/client_test.go
+++ b/internal/downloader/nzbget/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -99,6 +100,47 @@ func allowNZBFetch(c *Client) {
 	c.validateNZBURL = func(string) error { return nil }
 }
 
+// configWithCategories returns a configResponse JSON payload exposing the
+// given category names as Category1.Name, Category2.Name, … entries. Used to
+// satisfy the preflight call Add() makes before append.
+func configWithCategories(names ...string) configResponse {
+	entries := make([]configEntry, 0, len(names))
+	for i, n := range names {
+		entries = append(entries, configEntry{
+			Name:  fmt.Sprintf("Category%d.Name", i+1),
+			Value: n,
+		})
+	}
+	return configResponse{Result: entries}
+}
+
+// nzbgetTestServer returns a server that routes by JSON-RPC method:
+// "config" responds with configWithCategories(cats...), "append" calls the
+// supplied handler, and anything else 500s.
+func nzbgetTestServer(t *testing.T, cats []string, append http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var probe rpcRequest
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(body, &probe); err != nil {
+			t.Fatalf("decode probe: %v", err)
+		}
+		switch probe.Method {
+		case "config":
+			json.NewEncoder(w).Encode(configWithCategories(cats...))
+		case "append":
+			// rewind the body so append handler can decode it itself
+			r.Body = io.NopCloser(strings.NewReader(string(body)))
+			append(w, r)
+		default:
+			http.Error(w, "unexpected method "+probe.Method, http.StatusInternalServerError)
+		}
+	}))
+}
+
 // TestAdd verifies that Add fetches NZB content from the indexer and submits it
 // as base64 to NZBGet's append RPC (rather than sending a URL for NZBGet to
 // fetch itself, which fails when NZBGet can't reach the indexer).
@@ -111,10 +153,10 @@ func TestAdd(t *testing.T) {
 	defer indexerSrv.Close()
 
 	var gotReq rpcRequest
-	nzbgetSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	nzbgetSrv := nzbgetTestServer(t, []string{"books"}, func(w http.ResponseWriter, r *http.Request) {
 		gotReq = decodeRequest(t, r)
 		json.NewEncoder(w).Encode(appendResponse{Result: 42})
-	}))
+	})
 	defer nzbgetSrv.Close()
 
 	host, port := serverHostPort(t, nzbgetSrv.URL)
@@ -151,16 +193,18 @@ func TestAdd(t *testing.T) {
 	}
 }
 
-// TestAdd_Rejected verifies that Add returns an error when NZBGet rejects the download.
+// TestAdd_Rejected verifies that when append still returns id 0 after the
+// preflight has cleared the category, Add surfaces an actionable error that
+// points the user at NZBGet's log and enumerates the likely causes.
 func TestAdd_Rejected(t *testing.T) {
 	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, testNZBContent)
 	}))
 	defer indexerSrv.Close()
 
-	nzbgetSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	nzbgetSrv := nzbgetTestServer(t, []string{"books"}, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(appendResponse{Result: 0})
-	}))
+	})
 	defer nzbgetSrv.Close()
 
 	host, port := serverHostPort(t, nzbgetSrv.URL)
@@ -170,6 +214,112 @@ func TestAdd_Rejected(t *testing.T) {
 	_, err := c.Add(context.Background(), indexerSrv.URL+"/bad.nzb", "Bad NZB", "books", 0)
 	if err == nil {
 		t.Fatal("expected error when NZBGet rejects download")
+		return
+	}
+	for _, want := range []string{"append returned id 0", "NZBGet's log", "disk full"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error to contain %q, got: %q", want, err.Error())
+		}
+	}
+}
+
+// TestAdd_UnknownCategory verifies that the preflight rejects a category that
+// isn't defined in NZBGet, listing both the missing and the existing names so
+// the user can fix either side. append must not be called in this path.
+func TestAdd_UnknownCategory(t *testing.T) {
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, testNZBContent)
+	}))
+	defer indexerSrv.Close()
+
+	nzbgetSrv := nzbgetTestServer(t, []string{"books", "movies"}, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("append must not be called when preflight rejects the category")
+		json.NewEncoder(w).Encode(appendResponse{Result: 1})
+	})
+	defer nzbgetSrv.Close()
+
+	host, port := serverHostPort(t, nzbgetSrv.URL)
+	c := New(host, port, "", "", "", false)
+	allowNZBFetch(c)
+
+	_, err := c.Add(context.Background(), indexerSrv.URL+"/file.nzb", "Book", "audiobooks", 0)
+	if err == nil {
+		t.Fatal("expected error when category isn't configured in NZBGet")
+		return
+	}
+	for _, want := range []string{`"audiobooks"`, `"books"`, `"movies"`, "Settings → Categories"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error to contain %q, got: %q", want, err.Error())
+		}
+	}
+}
+
+// TestAdd_EmptyCategory verifies that when no category is set, the preflight
+// is skipped entirely (no config RPC) and append proceeds with category="".
+// NZBGet treats an empty category as "use the default destination".
+func TestAdd_EmptyCategory(t *testing.T) {
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, testNZBContent)
+	}))
+	defer indexerSrv.Close()
+
+	var methods []string
+	nzbgetSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRequest(t, r)
+		methods = append(methods, req.Method)
+		json.NewEncoder(w).Encode(appendResponse{Result: 7})
+	}))
+	defer nzbgetSrv.Close()
+
+	host, port := serverHostPort(t, nzbgetSrv.URL)
+	c := New(host, port, "", "", "", false)
+	allowNZBFetch(c)
+
+	id, err := c.Add(context.Background(), indexerSrv.URL+"/file.nzb", "Book", "", 0)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if id != 7 {
+		t.Errorf("expected id=7, got %d", id)
+	}
+	if len(methods) != 1 || methods[0] != "append" {
+		t.Errorf("expected exactly one append call, got %v", methods)
+	}
+}
+
+// TestAdd_PreflightUnreachable verifies that when the config RPC fails (e.g.
+// older NZBGet, ControlIP restriction), Add doesn't pretend the category is
+// wrong — it falls through to append and lets that response stand. The
+// existing rejection-message path covers the case where append also fails.
+func TestAdd_PreflightUnreachable(t *testing.T) {
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, testNZBContent)
+	}))
+	defer indexerSrv.Close()
+
+	nzbgetSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRequest(t, r)
+		switch req.Method {
+		case "config":
+			http.Error(w, "method not found", http.StatusNotFound)
+		case "append":
+			json.NewEncoder(w).Encode(appendResponse{Result: 99})
+		default:
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		}
+	}))
+	defer nzbgetSrv.Close()
+
+	host, port := serverHostPort(t, nzbgetSrv.URL)
+	c := New(host, port, "", "", "", false)
+	allowNZBFetch(c)
+
+	id, err := c.Add(context.Background(), indexerSrv.URL+"/file.nzb", "Book", "anything", 0)
+	if err != nil {
+		t.Fatalf("Add should fall through to append when preflight fails: %v", err)
+	}
+	if id != 99 {
+		t.Errorf("expected id=99, got %d", id)
 	}
 }
 
@@ -524,5 +674,171 @@ func TestTest_ServerError_NoHint(t *testing.T) {
 		if strings.Contains(msg, hint) {
 			t.Errorf("clean server error must not produce hint %q; got: %q", hint, msg)
 		}
+	}
+}
+
+// TestListCategories_Parses verifies CategoryN.Name entries are extracted in
+// order and that non-Name entries (DestDir/Unpack/PostScript) and empty
+// Values are filtered out.
+func TestListCategories_Parses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req := decodeRequest(t, r)
+		if req.Method != "config" {
+			t.Errorf("expected method=config, got %q", req.Method)
+		}
+		json.NewEncoder(w).Encode(configResponse{
+			Result: []configEntry{
+				{Name: "MainDir", Value: "/downloads"},
+				{Name: "Category1.Name", Value: "Books"},
+				{Name: "Category1.DestDir", Value: "/downloads/books"},
+				{Name: "Category1.Unpack", Value: "yes"},
+				{Name: "Category2.Name", Value: "Audiobooks"},
+				{Name: "Category2.Aliases", Value: ""},
+				{Name: "Category3.Name", Value: ""}, // empty — filtered
+				{Name: "Category10.Name", Value: "Movies"},
+				{Name: "DupeCheck", Value: "yes"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", "", false)
+
+	cats, err := c.ListCategories(context.Background())
+	if err != nil {
+		t.Fatalf("ListCategories: %v", err)
+	}
+	want := []string{"Books", "Audiobooks", "Movies"}
+	if len(cats) != len(want) {
+		t.Fatalf("expected %d categories, got %d (%v)", len(want), len(cats), cats)
+	}
+	for i, w := range want {
+		if cats[i] != w {
+			t.Errorf("cats[%d]: want %q, got %q", i, w, cats[i])
+		}
+	}
+}
+
+// TestCheckCategories_Match verifies the common case: every wanted category
+// is present, no error returned.
+func TestCheckCategories_Match(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(configWithCategories("Books", "Audiobooks"))
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", "", false)
+
+	if err := c.CheckCategories(context.Background(), "Books", "Audiobooks"); err != nil {
+		t.Errorf("expected nil error, got: %v", err)
+	}
+}
+
+// TestCheckCategories_EmptySkipped verifies that all-empty wanted entries
+// short-circuit and don't hit the RPC at all (important: an unconfigured
+// Bindery client shouldn't gratuitously fail Test against a working NZBGet).
+func TestCheckCategories_EmptySkipped(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", "", false)
+
+	if err := c.CheckCategories(context.Background(), "", ""); err != nil {
+		t.Errorf("expected nil error for all-empty wanted, got: %v", err)
+	}
+	if called {
+		t.Error("CheckCategories must not call config RPC when all wanted are empty")
+	}
+}
+
+// TestCheckCategories_OneMissing verifies the single-missing case produces a
+// singular "no category" message that names both sides.
+func TestCheckCategories_OneMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(configWithCategories("Books"))
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", "", false)
+
+	err := c.CheckCategories(context.Background(), "Books", "Audiobooks")
+	if err == nil {
+		t.Fatal("expected error when one category is missing")
+		return
+	}
+	for _, want := range []string{`no category "Audiobooks"`, `"Books"`, "Settings → Categories"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error to contain %q, got: %q", want, err.Error())
+		}
+	}
+}
+
+// TestCheckCategories_MultipleMissing verifies the plural variant fires when
+// both wanted categories are absent.
+func TestCheckCategories_MultipleMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(configWithCategories("Movies"))
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", "", false)
+
+	err := c.CheckCategories(context.Background(), "Books", "Audiobooks")
+	if err == nil {
+		t.Fatal("expected error when both categories are missing")
+		return
+	}
+	for _, want := range []string{"no categories", `"Books"`, `"Audiobooks"`, `"Movies"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error to contain %q, got: %q", want, err.Error())
+		}
+	}
+}
+
+// TestCheckCategories_NoneDefined verifies that when NZBGet has zero
+// categories configured, the error message says "none defined" rather than
+// listing an empty set.
+func TestCheckCategories_NoneDefined(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(configResponse{Result: []configEntry{
+			{Name: "MainDir", Value: "/downloads"},
+		}})
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", "", false)
+
+	err := c.CheckCategories(context.Background(), "Books")
+	if err == nil {
+		t.Fatal("expected error")
+		return
+	}
+	if !strings.Contains(err.Error(), "none defined") {
+		t.Errorf("expected 'none defined' in error, got: %q", err.Error())
+	}
+}
+
+// TestCheckCategories_ListFails verifies the list-RPC error is surfaced
+// directly (so the adapter's Test path can show it to the user).
+func TestCheckCategories_ListFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", "", false)
+
+	err := c.CheckCategories(context.Background(), "Books")
+	if err == nil {
+		t.Fatal("expected error from list-RPC failure")
+		return
+	}
+	if !strings.Contains(err.Error(), "list nzbget categories") {
+		t.Errorf("expected wrapped list error, got: %q", err.Error())
 	}
 }

--- a/internal/downloader/nzbget/types.go
+++ b/internal/downloader/nzbget/types.go
@@ -56,3 +56,17 @@ type HistoryItem struct {
 type historyResponse struct {
 	Result []HistoryItem `json:"result"`
 }
+
+// configEntry is a single name/value pair from NZBGet's "config" RPC. Both
+// fields come through as strings regardless of the underlying option type.
+type configEntry struct {
+	Name  string `json:"Name"`
+	Value string `json:"Value"`
+}
+
+// configResponse is the result of calling "config", a flat list of name/value
+// pairs covering every option in NZBGet's nzbget.conf. Categories show up as
+// CategoryN.Name=Books, CategoryN.DestDir=…, CategoryN.Unpack=yes, etc.
+type configResponse struct {
+	Result []configEntry `json:"result"`
+}


### PR DESCRIPTION
## Summary

- @BraynArts reported in #861 that grabbing a book produced `NZBGet rejected download (returned id 0)` with no further context, leaving them stuck.
- NZBGet's `append` JSON-RPC silently returns id 0 when the submitted category isn't defined in NZBGet's own `Settings → Categories`. The Bindery audiobook-category field is the usual offender — easy to set in Bindery, easy to forget on the NZBGet side.
- Preflights the category list via NZBGet's `config` RPC and on mismatch surfaces a clear error naming both the missing category and what NZBGet has configured. Same check runs at Test-Connection time so the misconfig is caught at save, not on the first grab. When preflight passes but append still returns 0 (disk full, write-permission, paused with quota reached, invalid NZB), the fallback error now enumerates those causes and points the user at NZBGet's own log.

## Behaviour

Before:
```
failed to send to downloader: NZBGet rejected download (returned id 0)
```

After (preflight catches it):
```
failed to send to downloader: NZBGet has no category "Audiobooks" configured (existing categories: "Books", "Movies"). Add it in NZBGet's Settings → Categories, or change the category in Bindery's download-client config to match
```

After (something else rejected, preflight passed):
```
failed to send to downloader: NZBGet rejected the download (append returned id 0) — check NZBGet's log for the reason. Common causes: disk full, write-permission on the intermediate or destination directory, NZBGet paused with quota reached, or invalid NZB content
```

If preflight RPC itself fails (older NZBGet, restricted ControlIP), `Add()` falls through to `append` so a real download isn't blocked by a bad mismatch error.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green (full repo sweep)
- [x] New tests cover: `ListCategories` parsing (filters non-Name keys + empty values), all 4 `CheckCategories` paths (match / one missing / multiple missing / none defined / list-RPC fails / all-empty skipped), `Add` preflight rejection with helpful error, `Add` proceeds when category matches, `Add` proceeds when category empty (no RPC), `Add` proceeds when preflight RPC fails
- [x] Existing `TestAdd_Rejected` updated to assert the new wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)