### PR TITLE
chore(security): extend nosec to cover G703 on book-file delete paths

### DIFF
--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -521,13 +521,13 @@ func removeBookPathScoped(p, format string) error {
 			if !strings.EqualFold(s, stem) {
 				continue
 			}
-			if rmErr := os.Remove(filepath.Join(parent, n)); rmErr != nil && !os.IsNotExist(rmErr) { //nosec G304 G703 -- parent + stem both from importer-sanitized DB row; #865 plans defense-in-depth root-check
+			if rmErr := os.Remove(filepath.Join(parent, n)); rmErr != nil && !os.IsNotExist(rmErr) { // #nosec G304 G703 -- parent + stem both from importer-sanitized DB row; #865 plans defense-in-depth root-check
 				slog.Warn("book delete: failed to remove sibling file", "path", filepath.Join(parent, n), "error", rmErr)
 			}
 		}
 	} else {
 		// ReadDir failed — fall back to deleting only the target file.
-		if err := os.Remove(p); err != nil { //nosec G304 G703 -- p is from book_files row written by importer's sanitizePath; #865 plans defense-in-depth root-check
+		if err := os.Remove(p); err != nil { // #nosec G304 G703 -- p is from book_files row written by importer's sanitizePath; #865 plans defense-in-depth root-check
 			return err
 		}
 	}
@@ -535,7 +535,7 @@ func removeBookPathScoped(p, format string) error {
 	// Clean up parent directory if it is now empty.
 	remaining, err := os.ReadDir(parent)
 	if err == nil && len(remaining) == 0 {
-		_ = os.Remove(parent) //nosec G304 G703 -- parent = filepath.Dir of importer-sanitized DB row; #865 plans defense-in-depth root-check
+		_ = os.Remove(parent) // #nosec G304 G703 -- parent = filepath.Dir of importer-sanitized DB row; #865 plans defense-in-depth root-check
 	}
 	return nil
 }

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -521,13 +521,13 @@ func removeBookPathScoped(p, format string) error {
 			if !strings.EqualFold(s, stem) {
 				continue
 			}
-			if rmErr := os.Remove(filepath.Join(parent, n)); rmErr != nil && !os.IsNotExist(rmErr) { //nosec G304 -- derived from DB-stored path
+			if rmErr := os.Remove(filepath.Join(parent, n)); rmErr != nil && !os.IsNotExist(rmErr) { //nosec G304 G703 -- parent + stem both from importer-sanitized DB row; #865 plans defense-in-depth root-check
 				slog.Warn("book delete: failed to remove sibling file", "path", filepath.Join(parent, n), "error", rmErr)
 			}
 		}
 	} else {
 		// ReadDir failed — fall back to deleting only the target file.
-		if err := os.Remove(p); err != nil { //nosec G304 -- p is a DB-stored path written by the import pipeline, not user input
+		if err := os.Remove(p); err != nil { //nosec G304 G703 -- p is from book_files row written by importer's sanitizePath; #865 plans defense-in-depth root-check
 			return err
 		}
 	}
@@ -535,7 +535,7 @@ func removeBookPathScoped(p, format string) error {
 	// Clean up parent directory if it is now empty.
 	remaining, err := os.ReadDir(parent)
 	if err == nil && len(remaining) == 0 {
-		_ = os.Remove(parent) //nosec G304 -- derived from DB-stored path, not user input
+		_ = os.Remove(parent) //nosec G304 G703 -- parent = filepath.Dir of importer-sanitized DB row; #865 plans defense-in-depth root-check
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- gosec G703 (path-traversal via taint analysis) was flagging the three \`os.Remove\` call sites in \`removeBookPathScoped\` at \`internal/api/books.go:524,530,538\`.
- The existing \`//nosec G304\` comments only suppress G304 — extends them to \`G304 G703\` and references #865 (defense-in-depth root-folder containment check) as the real fix.
- No behavioural change. The paths reaching these calls are already sanitized by \`importer.sanitizePath\` (strips \`..\`, \`/\`, \`\\\`, \`:\`, etc.), so the alert is a false positive in current code, but the suppression should be explicit.

## Test plan

- [x] \`go build ./...\` clean
- N/A — comment-only change