### PR TITLE
feat(telemetry): per-subsystem feature counters and public schema doc (Phase 2+3)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -423,7 +423,10 @@ func main() {
 	sched.WithLogRepo(logRepo, cfg.LogRetentionDays)
 
 	// Anonymous install ping (opt-out via telemetry.enabled=false in settings).
-	telemetryClient := telemetry.New(settingsRepo, version)
+	// The gatherer captures repo handles by closure and runs at ping time. It
+	// must not block on network IO; all queries are local SQLite reads.
+	telemetryClient := telemetry.New(settingsRepo, version).
+		WithGatherer(buildTelemetryGatherer(indexerRepo, dlClientRepo, notificationRepo, userRepo, settingsRepo))
 	sched.WithTelemetry(telemetryClient)
 
 	// Recover downloads wedged mid-import by a prior crash or timeout before the
@@ -1222,4 +1225,96 @@ func routeTemplate(r *http.Request) string {
 		}
 	}
 	return r.URL.Path
+}
+
+// buildTelemetryGatherer returns a telemetry.Gatherer closure that reads the
+// current per-subsystem configuration counts directly from SQLite. Every
+// query is best-effort: a failure on any one subsystem leaves that field at
+// its zero value (which the Features struct omits from the wire), rather
+// than skipping the entire ping. Costs at most a handful of small SELECTs
+// per call; safe to invoke from the daily ping goroutine.
+//
+// Published schema: getbindery.dev/telemetry-fields. Adding a new field
+// here means updating that page so opt-in users know what they're sending.
+func buildTelemetryGatherer(
+	indexers *db.IndexerRepo,
+	clients *db.DownloadClientRepo,
+	notifications *db.NotificationRepo,
+	users *db.UserRepo,
+	settings *db.SettingsRepo,
+) telemetry.Gatherer {
+	return func(ctx context.Context) telemetry.Features {
+		f := telemetry.Features{}
+
+		// Count enabled indexers / download clients / notifications. These
+		// repos don't have a Count() variant so we List() and filter in
+		// memory; the sets are small (under 100 per install in practice).
+		if list, err := indexers.List(ctx); err == nil {
+			for _, ix := range list {
+				if ix.Enabled {
+					f.Indexers++
+				}
+			}
+		}
+		if list, err := clients.List(ctx); err == nil {
+			for _, c := range list {
+				if c.Enabled {
+					f.DownloadClients++
+				}
+			}
+		}
+		if list, err := notifications.List(ctx); err == nil {
+			for _, n := range list {
+				if n.Enabled {
+					f.Notifications++
+				}
+			}
+		}
+		if n, err := users.Count(ctx); err == nil {
+			f.Users = n
+			if n > 1 {
+				f.MultiUser = true
+			}
+		}
+
+		// Per-subsystem enabled flags. "Enabled" is what the user actually
+		// flipped on (not "configured but disabled"), matching the way the
+		// dashboard groups by intent rather than state.
+		f.CalibreEnabled = settingTruthy(ctx, settings, api.SettingCalibreEnabled)
+		f.ABSEnabled = settingTruthy(ctx, settings, api.SettingABSEnabled)
+		f.GrimmoryEnabled = settingTruthy(ctx, settings, api.SettingGrimmoryEnabled)
+
+		// HardcoverToken is "is there a token saved" (presence, not value).
+		// Bindery's enhanced Hardcover mode is gated on having one, so this
+		// closely tracks whether the install uses Hardcover features.
+		if v, err := settings.Get(ctx, api.SettingHardcoverAPIToken); err == nil && v != nil && v.Value != "" {
+			f.HardcoverToken = true
+		}
+
+		// OIDC enabled if the providers list is non-empty (the same gate
+		// the API uses to decide whether to render OIDC login buttons).
+		if v, err := settings.Get(ctx, api.SettingOIDCProviders); err == nil && v != nil {
+			trimmed := strings.TrimSpace(v.Value)
+			if trimmed != "" && trimmed != "[]" && trimmed != "null" {
+				f.OIDCEnabled = true
+			}
+		}
+
+		return f
+	}
+}
+
+// settingTruthy reads a setting key and returns true when the stored value
+// represents "on" ("true" / "1" / "yes"). Missing keys and errors return
+// false; the gatherer treats both as "not enabled."
+func settingTruthy(ctx context.Context, settings *db.SettingsRepo, key string) bool {
+	v, err := settings.Get(ctx, key)
+	if err != nil || v == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(v.Value)) {
+	case "true", "1", "yes", "on":
+		return true
+	}
+	return false
 }

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -117,11 +117,32 @@ func (s *server) runRetentionLoop(ctx context.Context) {
 }
 
 type pingRequest struct {
-	InstallID string `json:"install_id"`
-	Version   string `json:"version"`
-	OS        string `json:"os"`
-	Arch      string `json:"arch"`
-	Deploy    string `json:"deploy"`
+	InstallID string           `json:"install_id"`
+	Version   string           `json:"version"`
+	OS        string           `json:"os"`
+	Arch      string           `json:"arch"`
+	Deploy    string           `json:"deploy"`
+	Features  *featuresPayload `json:"features,omitempty"`
+}
+
+// featuresPayload mirrors the bindery client's telemetry.Features struct.
+// Pointer-on-the-request so older clients (no features field) decode cleanly
+// to Features == nil. Count fields use *int instead of int so we can tell
+// "client reported 0 indexers" from "client didn't report this field"
+// during the rollout window with mixed-version traffic; both render as
+// "not reported" / "0" downstream but the distinction is preserved on the
+// wire in case a future query wants it.
+type featuresPayload struct {
+	Indexers        *int  `json:"indexers,omitempty"`
+	DownloadClients *int  `json:"download_clients,omitempty"`
+	Notifications   *int  `json:"notifications,omitempty"`
+	Users           *int  `json:"users,omitempty"`
+	CalibreEnabled  *bool `json:"calibre_enabled,omitempty"`
+	ABSEnabled      *bool `json:"abs_enabled,omitempty"`
+	GrimmoryEnabled *bool `json:"grimmory_enabled,omitempty"`
+	HardcoverToken  *bool `json:"hardcover_token,omitempty"`
+	OIDCEnabled     *bool `json:"oidc_enabled,omitempty"`
+	MultiUser       *bool `json:"multi_user,omitempty"`
 }
 
 // validDeploys constrains the set of deploy strings we accept on /api/ping.
@@ -200,6 +221,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Add the features JSON column for per-subsystem adoption snapshots
+	// (indexer count, ABS enabled, etc.). Stored as a JSON blob so the
+	// schema can grow without further ALTERs; aggregate queries use
+	// SQLite's json_extract. Older clients send no features field and the
+	// row stores NULL, which surfaces as "not reported" on the dashboard.
+	if _, err := db.ExecContext(context.Background(),
+		`ALTER TABLE installs ADD COLUMN features TEXT`,
+	); err != nil && !strings.Contains(err.Error(), "duplicate column") {
+		slog.Error("add features column", "error", err)
+		os.Exit(1)
+	}
+
 	// Boot-time sweep so dashboards on a fresh process are clean immediately;
 	// the nightly cron below keeps them clean from then on.
 	if _, err := sweepStaleAndDev(context.Background(), db); err != nil {
@@ -229,6 +262,7 @@ func main() {
 	mux.HandleFunc("GET /stats", s.handleStatsPage)
 	mux.HandleFunc("GET /stats.json", s.handleStatsJSON)
 	mux.HandleFunc("GET /stats/preview", s.handlePreviewPage)
+	mux.HandleFunc("GET /telemetry-fields", s.handleTelemetryFields)
 	mux.HandleFunc("POST /api/ping", s.handlePing)
 	mux.HandleFunc("GET /api/stats", s.handleStats)
 	mux.HandleFunc("GET /api/backup", s.handleBackup)
@@ -372,6 +406,136 @@ func (s *server) handleHome(w http.ResponseWriter, _ *http.Request) {
 </html>`))
 }
 
+// handleTelemetryFields renders the public schema doc: every field a
+// Bindery install can send, with a one-line explanation of why we ask.
+// This is the trust artifact users link to when deciding whether to leave
+// telemetry on. The page lists fields by category (core, features, future)
+// and includes the opt-out instructions in one place.
+func (s *server) handleTelemetryFields(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = w.Write([]byte(telemetryFieldsHTML))
+}
+
+// telemetryFieldsHTML is the static HTML for /telemetry-fields. Inline so
+// the binary has no asset dependencies; the page is small and updates
+// infrequently (only when ping schema gains a field).
+const telemetryFieldsHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Bindery telemetry: what we send</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { min-height: 100svh; background: #0f1117; color: #e2e8f0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; padding: 3rem 1.5rem; }
+  .container { max-width: 760px; margin: 0 auto; }
+  a.back { color: #94a3b8; font-size: .85rem; text-decoration: none; }
+  a.back:hover { color: #e2e8f0; }
+  h1 { font-size: 2rem; font-weight: 700; letter-spacing: -0.02em; margin: .75rem 0 .5rem; }
+  h2 { font-size: 1.1rem; font-weight: 600; color: #cbd5e1; margin: 2rem 0 .75rem; }
+  p, li { line-height: 1.6; color: #cbd5e1; }
+  p { margin-bottom: 1rem; }
+  ul { padding-left: 1.5rem; margin-bottom: 1rem; }
+  li { margin-bottom: .5rem; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #1e293b; padding: .15rem .4rem; border-radius: 3px; font-size: .9em; color: #f1f5f9; }
+  .field { margin-bottom: 1rem; padding: .85rem 1rem; background: #1e293b; border: 1px solid #334155; border-radius: 8px; }
+  .field code { background: #0f1117; }
+  .field .why { color: #94a3b8; font-size: .9rem; margin-top: .35rem; }
+  footer { margin-top: 3rem; color: #64748b; font-size: .75rem; text-align: center; }
+  .opt-out { background: #1e293b; border-left: 3px solid #10b981; padding: 1rem 1.25rem; border-radius: 4px; margin: 1.5rem 0; }
+  .opt-out code { background: #0f1117; display: inline-block; margin: .25rem 0; }
+</style>
+</head>
+<body>
+<div class="container">
+  <p><a class="back" href="/">&larr; Bindery</a></p>
+  <h1>Telemetry: what we send</h1>
+
+  <p>Every Bindery install sends one anonymous ping per day to <code>api.getbindery.dev/api/ping</code>. The full schema is below. Nothing else leaves your install via telemetry: no library contents, no book titles, no author names, no IPs, no hostnames, no usernames.</p>
+
+  <p>This page is the source of truth. If a future release adds a field, it appears here first.</p>
+
+  <h2>Core fields (always sent)</h2>
+
+  <div class="field">
+    <code>install_id</code>
+    <div class="why">Random UUID generated on first run and stored in your Bindery database. Lets us count distinct installs without tracking who you are. Resetting Bindery's DB resets the UUID; we have no other way to link two installs together.</div>
+  </div>
+
+  <div class="field">
+    <code>version</code>
+    <div class="why">The Bindery binary's release tag (e.g. <code>1.15.2</code>). Lets us see which versions are actually deployed so we know when an old release can be deprecated. Non-release builds (dev / sha-XXXXX / commits past a tag) are dropped client-side and never sent.</div>
+  </div>
+
+  <div class="field">
+    <code>os</code> / <code>arch</code>
+    <div class="why">Output of Go's <code>runtime.GOOS</code> and <code>runtime.GOARCH</code> (e.g. <code>linux</code> / <code>amd64</code>). Lets us prioritise fixes for the OS/arch combos that are actually in use.</div>
+  </div>
+
+  <div class="field">
+    <code>deploy</code>
+    <div class="why">How Bindery is being run: <code>kubernetes</code> (inside a pod), <code>docker</code> (inside any other container), <code>binary</code> (bare metal), <code>helm</code> (Helm chart, when the chart sets <code>BINDERY_DEPLOY_METHOD=helm</code>). Detected from <code>KUBERNETES_SERVICE_HOST</code> and the presence of <code>/.dockerenv</code>. Helps us know which deployment paths are worth supporting.</div>
+  </div>
+
+  <h2>Features (sent starting v1.15.3+, optional)</h2>
+
+  <p>Counts and booleans summarising which subsystems are configured. No names, IDs, URLs, or values are ever sent &mdash; just numbers and on/off flags. Tells the maintainer which features users actually use so support time goes to the parts of Bindery people rely on.</p>
+
+  <div class="field">
+    <code>features.indexers</code> / <code>features.download_clients</code> / <code>features.notifications</code> / <code>features.users</code>
+    <div class="why">Integer count of enabled configuration rows. The user count tells us whether multi-user is in real use; the others tell us how many integrations a typical install has.</div>
+  </div>
+
+  <div class="field">
+    <code>features.calibre_enabled</code> / <code>features.abs_enabled</code> / <code>features.grimmory_enabled</code>
+    <div class="why">Boolean: whether the Calibre, Audiobookshelf, or Grimmory integration is turned on. No URLs, paths, or credentials.</div>
+  </div>
+
+  <div class="field">
+    <code>features.hardcover_token</code>
+    <div class="why">Boolean: whether a Hardcover API token is configured (presence, not the value).</div>
+  </div>
+
+  <div class="field">
+    <code>features.oidc_enabled</code> / <code>features.multi_user</code>
+    <div class="why">Booleans: whether OIDC sign-in is configured, and whether there is more than one user account in the local DB.</div>
+  </div>
+
+  <h2>What we don't collect</h2>
+
+  <ul>
+    <li>Your IP address (the server rate-limits by IP but never stores it).</li>
+    <li>Your hostname, server name, domain, or any DNS-resolvable identifier.</li>
+    <li>Anything about your library: book titles, author names, ISBNs, ratings, file paths.</li>
+    <li>Anything about your network: indexer URLs, download client URLs, notification webhook URLs.</li>
+    <li>Anything about your users: usernames, email addresses, OIDC subject IDs.</li>
+    <li>API keys, tokens, passwords, session secrets.</li>
+    <li>Request logs, error traces, or stack traces.</li>
+  </ul>
+
+  <h2>How to opt out</h2>
+
+  <div class="opt-out">
+    <p>Two ways to disable telemetry entirely. Either is sufficient; the env var wins if both are set.</p>
+    <p><strong>Env var (recommended for fresh installs):</strong><br>
+    <code>BINDERY_TELEMETRY_DISABLED=true</code></p>
+    <p><strong>Settings DB (for running installs):</strong><br>
+    Set the <code>telemetry.enabled</code> setting to <code>false</code>. Survives restarts; takes effect on the next scheduled ping (within 24 hours).</p>
+  </div>
+
+  <h2>How the data is stored</h2>
+
+  <p>Pings land in a small SQLite database on a single VM in Hetzner Cloud (Falkenstein, Germany). Rows whose <code>last_seen</code> is older than 60 days are deleted nightly. The database itself is backed up daily to an off-site object store; backups follow the same 60-day retention.</p>
+
+  <p>The aggregated dashboard at <a href="/stats">/stats</a> is rendered live from the database with no caching. The full source of both the bindery client and the telemetry server lives at <a href="https://github.com/vavallee/bindery">github.com/vavallee/bindery</a> &mdash; the client at <code>internal/telemetry/client.go</code>, the server at <code>cmd/telemetry-server/main.go</code>.</p>
+
+  <footer>
+    Last updated 2026-05-29. If a future release changes any of this, the change lands on this page before it ships.
+  </footer>
+</div>
+</body>
+</html>`
+
 func (s *server) handlePing(w http.ResponseWriter, r *http.Request) {
 	ip := realIP(r)
 	if !s.limiter.allow(ip) {
@@ -409,24 +573,39 @@ func (s *server) handlePing(w http.ResponseWriter, r *http.Request) {
 		req.Deploy = ""
 	}
 
+	// features is stored as JSON or NULL when the client didn't send any.
+	// Re-marshal here instead of forwarding the original JSON bytes so the
+	// stored payload is normalised (whitespace-stripped, key order stable)
+	// regardless of what the client serialised. Any marshal error keeps the
+	// column NULL so a bad features field never blocks a valid ping.
+	var featuresJSON sql.NullString
+	if req.Features != nil {
+		if buf, err := json.Marshal(req.Features); err == nil {
+			featuresJSON = sql.NullString{String: string(buf), Valid: true}
+		} else {
+			slog.Warn("marshal features", "id", req.InstallID[:min(8, len(req.InstallID))], "error", err)
+		}
+	}
+
 	now := time.Now().UTC()
 	_, err := s.db.ExecContext(r.Context(), `
-		INSERT INTO installs (install_id, version, os, arch, deploy, first_seen, last_seen)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO installs (install_id, version, os, arch, deploy, features, first_seen, last_seen)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(install_id) DO UPDATE SET
 			version   = excluded.version,
 			os        = excluded.os,
 			arch      = excluded.arch,
 			deploy    = excluded.deploy,
+			features  = excluded.features,
 			last_seen = excluded.last_seen
-	`, req.InstallID, req.Version, req.OS, req.Arch, req.Deploy, now, now)
+	`, req.InstallID, req.Version, req.OS, req.Arch, req.Deploy, featuresJSON, now, now)
 	if err != nil {
 		slog.Warn("upsert install", "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
-	slog.Info("ping", "id", req.InstallID[:min(8, len(req.InstallID))], "version", req.Version, "os", req.OS, "arch", req.Arch)
+	slog.Info("ping", "id", req.InstallID[:min(8, len(req.InstallID))], "version", req.Version, "os", req.OS, "arch", req.Arch, "features", featuresJSON.Valid)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(pingResponse{LatestVersion: s.latestVersion})
@@ -475,6 +654,14 @@ type statsData struct {
 	Monthly          []statsBucket     // new installs per calendar month, last 12 mo
 	VersionTrend     []versionTrendDay // per-day per-version active counts, 30 days
 	TopVersions      []string          // top-N versions for VersionTrend legend
+
+	// Features (last 7d): per-subsystem adoption counts among installs that
+	// have reported a features payload in the last 7 days. FeaturesReporting
+	// is the denominator; each bucket count is the numerator. Older clients
+	// without the features field don't contribute to either, so the
+	// percentage is "of the installs we have data for."
+	FeaturesReporting int
+	Features          []statsBucket
 }
 
 // computeStats runs every dashboard query and returns one assembled snapshot.
@@ -652,6 +839,14 @@ func (s *server) computeStats(ctx context.Context) (*statsData, error) {
 		}
 	}
 
+	// Features adoption among 7d-active installs that reported a payload.
+	// Older clients send features = NULL and don't appear in either the
+	// numerator or the denominator, which gives an accurate "% of installs
+	// we have data for" rather than a misleading "% of all installs."
+	if err := s.computeFeatureAdoption(ctx, cutoff7d, d); err != nil {
+		return nil, err
+	}
+
 	// Monthly new installs for the last 12 calendar months.
 	monthlyCutoff := time.Now().UTC().AddDate(0, -12, 0)
 	rowsMon, err := s.db.QueryContext(ctx,
@@ -750,6 +945,67 @@ func (s *server) handleStats(w http.ResponseWriter, r *http.Request) {
 		Total:     d.Total,
 		Versions:  versions,
 	})
+}
+
+// featureField describes one row in the Features section: the JSON key
+// inside the stored features blob, the kind of bucket (count vs boolean),
+// and the human label rendered on the dashboard. Count fields are summed
+// across reporting installs (e.g. "12 indexers per install on average")
+// and would render differently; today we just count installs with a
+// non-zero value, matching the booleans, because adoption is more
+// actionable than mean configuration size at this scale.
+type featureField struct {
+	JSONKey string
+	Label   string
+}
+
+var featureFields = []featureField{
+	{"indexers", "Indexers configured"},
+	{"download_clients", "Download clients configured"},
+	{"notifications", "Notifications configured"},
+	{"calibre_enabled", "Calibre integration"},
+	{"abs_enabled", "Audiobookshelf integration"},
+	{"grimmory_enabled", "Grimmory integration"},
+	{"hardcover_token", "Hardcover enhanced"},
+	{"oidc_enabled", "OIDC auth"},
+	{"multi_user", "Multi-user"},
+}
+
+// computeFeatureAdoption fills d.FeaturesReporting and d.Features from
+// installs that pinged in the last 7 days and include a non-null features
+// payload. Uses SQLite's JSON1 extension (modernc.org/sqlite ships with
+// it). Booleans count any truthy JSON value; counts count any non-zero
+// numeric value. Both reduce to "this install has the subsystem in use,"
+// which is the question the dashboard answers.
+func (s *server) computeFeatureAdoption(ctx context.Context, since time.Time, d *statsData) error {
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM installs WHERE last_seen >= ? AND features IS NOT NULL`,
+		since,
+	).Scan(&d.FeaturesReporting); err != nil {
+		return err
+	}
+	if d.FeaturesReporting == 0 {
+		return nil
+	}
+	for _, f := range featureFields {
+		var n int
+		// json_extract returns NULL when the key is missing; the count
+		// then excludes the row. For booleans, true → 1, false → 0; the
+		// > 0 filter catches both true booleans and non-zero counts.
+		if err := s.db.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			  FROM installs
+			 WHERE last_seen >= ?
+			   AND features IS NOT NULL
+			   AND json_extract(features, '$.'||?) > 0
+		`, since, f.JSONKey).Scan(&n); err != nil {
+			// Best-effort; a single bad field shouldn't sink the page.
+			slog.Warn("feature adoption query", "field", f.JSONKey, "error", err)
+			continue
+		}
+		d.Features = append(d.Features, statsBucket{Label: f.Label, Count: n})
+	}
+	return nil
 }
 
 // handleStatsJSON returns a small public JSON payload with active install
@@ -1037,6 +1293,37 @@ func renderLongevity(buckets []statsBucket, youngDB bool) string {
 		`(every install's age is bounded by the data span).</p>`
 }
 
+// renderFeatures renders the per-subsystem adoption table. Bar widths and
+// the count column are denominated in installs (out of reporting); the
+// header notes the denominator so a reader can convert to percent. When no
+// 7d-active install has reported a features payload yet (older clients
+// only), the section renders an explanatory message instead of an empty
+// chart with confusing zero counts.
+func renderFeatures(buckets []statsBucket, reporting int) string {
+	if reporting == 0 {
+		return `<div class="chart"><p class="empty">No features data yet. ` +
+			`Older clients (pre-v1.15.3) don't include a features payload; ` +
+			`this section populates as installs upgrade.</p></div>`
+	}
+	header := fmt.Sprintf(
+		`<p class="empty" style="margin:0 0 .5rem 0">Out of %d install%s reporting features in the last 7 days.</p>`,
+		reporting,
+		pluralS(reporting),
+	)
+	// reuse renderBarChart for the bar/count rows; bar widths scale to
+	// the largest reported count so the row with the highest adoption
+	// pegs at 100 percent and the rest scale down.
+	return header + renderBarChart(buckets, 0, "")
+}
+
+// pluralS returns "" or "s" for English plural agreement based on count.
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
 // renderSparkline returns inline SVG for a 30-day daily-activity bar chart.
 func renderSparkline(daily []dailyBucket) string {
 	if len(daily) == 0 {
@@ -1276,7 +1563,7 @@ func (s *server) handleStatsPage(w http.ResponseWriter, r *http.Request) {
   <header>
     <a class="back" href="/">← Bindery</a>
     <h1>Telemetry</h1>
-    <p>Anonymous install counts from instances that opted in to update checks. No identifying information is collected, only an opaque install UUID, the version, and the OS/arch reported by Go's runtime. "Active 7d" is the count of installs that pinged in the last seven days (the closest proxy we have for "running right now"); "Active 30d" is the wider 30-day window and includes dormant installs that have not pinged in a while.</p>
+    <p>Anonymous install counts from instances that opted in to update checks. No identifying information is collected, only an opaque install UUID, the version, the OS/arch reported by Go's runtime, and (on v1.15.3+) per-subsystem adoption counts. "Active 7d" is the count of installs that pinged in the last seven days (the closest proxy we have for "running right now"); "Active 30d" is the wider 30-day window and includes dormant installs that have not pinged in a while. Full schema and opt-out instructions: <a href="/telemetry-fields" style="color:#10b981">/telemetry-fields</a>.</p>
   </header>
 
   <div class="summary">
@@ -1326,6 +1613,11 @@ func (s *server) handleStatsPage(w http.ResponseWriter, r *http.Request) {
   </section>
 
   <section>
+    <h2>Feature adoption (last 7 days)</h2>
+    %s
+  </section>
+
+  <section>
     <h2>Version mix (last 30 days)</h2>
     <div class="chart">%s</div>
   </section>
@@ -1345,6 +1637,7 @@ func (s *server) handleStatsPage(w http.ResponseWriter, r *http.Request) {
 		renderSparkline(d.DailyNew),
 		renderMonthlyChart(d.Monthly),
 		renderLongevity(d.Longevity, d.LongevityYoungDB),
+		renderFeatures(d.Features, d.FeaturesReporting),
 		renderVersionTrend(d.VersionTrend, d.TopVersions),
 		time.Now().UTC().Format("2006-01-02 15:04 MST"),
 	); err != nil {

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -130,7 +130,8 @@ func newTestServer(t *testing.T, latest string) *server {
 		arch        TEXT NOT NULL,
 		first_seen  DATETIME NOT NULL,
 		last_seen   DATETIME NOT NULL,
-		deploy      TEXT NOT NULL DEFAULT ''
+		deploy      TEXT NOT NULL DEFAULT '',
+		features    TEXT
 	)`); err != nil {
 		t.Fatalf("create table: %v", err)
 	}
@@ -441,6 +442,204 @@ func TestRenderLongevityFootnote(t *testing.T) {
 	for _, html := range []string{withFootnote, withoutFootnote} {
 		if !strings.Contains(html, "&lt; 1 week") {
 			t.Errorf("expected bucket label in output; got: %s", html)
+		}
+	}
+}
+
+// insertInstallWithFeatures inserts a row with a serialized features JSON
+// payload. The features arg is marshalled here so callers can pass a literal
+// struct without dealing with json.Marshal.
+func insertInstallWithFeatures(t *testing.T, s *server, id, version string, firstSeen, lastSeen time.Time, features any) {
+	t.Helper()
+	var featuresJSON sql.NullString
+	if features != nil {
+		buf, err := json.Marshal(features)
+		if err != nil {
+			t.Fatalf("marshal features: %v", err)
+		}
+		featuresJSON = sql.NullString{String: string(buf), Valid: true}
+	}
+	if _, err := s.db.ExecContext(context.Background(),
+		`INSERT INTO installs (install_id, version, os, arch, first_seen, last_seen, deploy, features)
+		 VALUES (?, ?, 'linux', 'amd64', ?, ?, 'docker', ?)`,
+		id, version, firstSeen, lastSeen, featuresJSON); err != nil {
+		t.Fatalf("insert install %s: %v", id, err)
+	}
+}
+
+// TestHandlePing_StoresFeatures verifies a ping with a features payload
+// persists it as JSON in the installs.features column, and that a ping
+// without features stores NULL.
+func TestHandlePing_StoresFeatures(t *testing.T) {
+	s := newTestServer(t, "v1.15.3")
+	s.limiter = newRateLimiter(time.Hour, time.Minute)
+
+	t.Run("with features", func(t *testing.T) {
+		body := pingRequest{
+			InstallID: "11111111-1111-1111-1111-111111111111",
+			Version:   "1.15.3",
+			OS:        "linux",
+			Arch:      "amd64",
+			Deploy:    "docker",
+			Features: &featuresPayload{
+				Indexers:       ptr(2),
+				CalibreEnabled: ptr(true),
+			},
+		}
+		buf, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/api/ping", bytes.NewReader(buf))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "192.0.2.1:1234" // bypasses rate limit (unique IP)
+		rec := httptest.NewRecorder()
+		s.handlePing(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+		}
+
+		var stored sql.NullString
+		if err := s.db.QueryRowContext(context.Background(),
+			`SELECT features FROM installs WHERE install_id = ?`, body.InstallID,
+		).Scan(&stored); err != nil {
+			t.Fatalf("read back features: %v", err)
+		}
+		if !stored.Valid {
+			t.Fatal("features column is NULL; expected JSON payload")
+		}
+		if !strings.Contains(stored.String, `"indexers":2`) {
+			t.Errorf("stored features missing indexers:2; got: %s", stored.String)
+		}
+		if !strings.Contains(stored.String, `"calibre_enabled":true`) {
+			t.Errorf("stored features missing calibre_enabled:true; got: %s", stored.String)
+		}
+	})
+
+	t.Run("without features", func(t *testing.T) {
+		body := pingRequest{
+			InstallID: "22222222-2222-2222-2222-222222222222",
+			Version:   "1.15.2",
+			OS:        "linux",
+			Arch:      "amd64",
+			Deploy:    "docker",
+		}
+		buf, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/api/ping", bytes.NewReader(buf))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "192.0.2.2:1234"
+		rec := httptest.NewRecorder()
+		s.handlePing(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+		}
+
+		var stored sql.NullString
+		if err := s.db.QueryRowContext(context.Background(),
+			`SELECT features FROM installs WHERE install_id = ?`, body.InstallID,
+		).Scan(&stored); err != nil {
+			t.Fatalf("read back features: %v", err)
+		}
+		if stored.Valid {
+			t.Errorf("features column should be NULL for legacy payload; got: %s", stored.String)
+		}
+	})
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// TestComputeFeatureAdoption verifies the aggregated counts: denominator is
+// the count of 7d-active installs with non-NULL features, numerator per
+// field is the count of installs whose features payload contains a truthy
+// (non-zero / true) value for that field. Older-client rows (NULL features)
+// don't contribute to either side.
+func TestComputeFeatureAdoption(t *testing.T) {
+	s := newTestServer(t, "v1.15.3")
+	now := time.Now().UTC()
+
+	// Three reporting installs, two with calibre on, one without.
+	insertInstallWithFeatures(t, s, uuid('1'), "1.15.3", now.Add(-1*time.Hour), now.Add(-1*time.Hour),
+		map[string]any{"indexers": 2, "calibre_enabled": true})
+	insertInstallWithFeatures(t, s, uuid('2'), "1.15.3", now.Add(-2*time.Hour), now.Add(-2*time.Hour),
+		map[string]any{"indexers": 1, "calibre_enabled": true, "multi_user": true})
+	insertInstallWithFeatures(t, s, uuid('3'), "1.15.3", now.Add(-3*time.Hour), now.Add(-3*time.Hour),
+		map[string]any{"indexers": 0}) // explicit zero should not count
+
+	// One older client with no features payload at all.
+	insertInstall(t, s, uuid('4'), "1.15.2", now.Add(-4*time.Hour), now.Add(-4*time.Hour))
+
+	// One install that pinged outside the 7d window; ignored entirely.
+	insertInstallWithFeatures(t, s, uuid('5'), "1.15.3", now.Add(-20*24*time.Hour), now.Add(-10*24*time.Hour),
+		map[string]any{"calibre_enabled": true})
+
+	d, err := s.computeStats(context.Background())
+	if err != nil {
+		t.Fatalf("computeStats: %v", err)
+	}
+	if d.FeaturesReporting != 3 {
+		t.Errorf("FeaturesReporting = %d, want 3 (three 7d-active installs with features)", d.FeaturesReporting)
+	}
+
+	got := bucketMap(d.Features)
+	if got["Indexers configured"] != 2 {
+		t.Errorf("Indexers configured = %d, want 2", got["Indexers configured"])
+	}
+	if got["Calibre integration"] != 2 {
+		t.Errorf("Calibre integration = %d, want 2", got["Calibre integration"])
+	}
+	if got["Multi-user"] != 1 {
+		t.Errorf("Multi-user = %d, want 1", got["Multi-user"])
+	}
+	if got["Audiobookshelf integration"] != 0 {
+		t.Errorf("Audiobookshelf integration = %d, want 0 (no install has abs_enabled)", got["Audiobookshelf integration"])
+	}
+}
+
+// TestRenderFeatures_NoData verifies the empty-state message renders when
+// no install has reported features yet (typical immediately after the
+// telemetry-server upgrade but before any v1.15.3+ client has pinged).
+func TestRenderFeatures_NoData(t *testing.T) {
+	html := renderFeatures(nil, 0)
+	if !strings.Contains(html, "No features data yet") {
+		t.Errorf("expected empty-state message; got: %s", html)
+	}
+}
+
+// TestRenderFeatures_WithData verifies the header includes the install
+// count and the bar chart appears.
+func TestRenderFeatures_WithData(t *testing.T) {
+	html := renderFeatures([]statsBucket{
+		{"Indexers configured", 14},
+		{"Calibre integration", 6},
+	}, 20)
+	for _, want := range []string{"Out of 20 installs reporting", "Indexers configured", "Calibre integration", ">14<", ">6<"} {
+		if !strings.Contains(html, want) {
+			t.Errorf("expected output to contain %q; got: %s", want, html)
+		}
+	}
+	// Singular "install" agreement when reporting=1.
+	if !strings.Contains(renderFeatures([]statsBucket{{"X", 1}}, 1), "Out of 1 install reporting") {
+		t.Errorf("expected singular form when reporting=1")
+	}
+}
+
+// TestHandleTelemetryFields verifies the public schema doc renders and
+// includes the core wire fields a privacy-conscious user would want to
+// audit (install_id, version, deploy) plus the opt-out instructions.
+func TestHandleTelemetryFields(t *testing.T) {
+	s := newTestServer(t, "v1.15.3")
+	req := httptest.NewRequest(http.MethodGet, "/telemetry-fields", nil)
+	rec := httptest.NewRecorder()
+	s.handleTelemetryFields(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"install_id", "version", "deploy", "features",
+		"BINDERY_TELEMETRY_DISABLED",
+		"telemetry.enabled",
+		"What we don't collect",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected /telemetry-fields to contain %q", want)
 		}
 	}
 }

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -1,13 +1,17 @@
 // Package telemetry sends an anonymous once-daily ping to api.getbindery.dev so
 // the project maintainer can count active installs. The ping carries:
 //
-//   - install_id  — random UUID generated on first run, stored in the DB
-//   - version     — the running binary's version string
-//   - os / arch   — runtime.GOOS / runtime.GOARCH
-//   - deploy      — kubernetes / docker / binary (best-effort runtime detect)
+//   - install_id: random UUID generated on first run, stored in the DB
+//   - version: the running binary's version string
+//   - os / arch: runtime.GOOS / runtime.GOARCH
+//   - deploy: kubernetes / docker / binary (best-effort runtime detect)
+//   - features: counts and booleans summarising which subsystems are
+//     configured. Strictly numeric/boolean, never names or values. Sent
+//     only when a Gatherer is wired via WithGatherer; absent otherwise.
 //
-// No personal data, no hostnames, no library contents. The setting
-// "telemetry.enabled" (default "true") can be set to "false" to opt out.
+// No personal data, no hostnames, no library contents, no titles, no IDs.
+// The setting "telemetry.enabled" (default "true") can be set to "false" to
+// opt out. The published schema lives at getbindery.dev/telemetry-fields.
 package telemetry
 
 import (
@@ -34,6 +38,18 @@ const (
 	timeout          = 10 * time.Second
 )
 
+// pingPayload is the JSON body sent on each ping. Features is a pointer so it
+// is omitted entirely when no Gatherer is configured (the previous payload
+// shape), preserving wire compatibility with older telemetry-server versions.
+type pingPayload struct {
+	InstallID string    `json:"install_id"`
+	Version   string    `json:"version"`
+	OS        string    `json:"os"`
+	Arch      string    `json:"arch"`
+	Deploy    string    `json:"deploy"`
+	Features  *Features `json:"features,omitempty"`
+}
+
 // releaseVersionPattern matches semver-shaped release tags ("1.7.0", "v1.7.0").
 // CI builds inject non-matching strings — the literal "dev" when the binary
 // has no -ldflags, "sha-abc1234" / "dev-abc1234" for non-release branches,
@@ -55,16 +71,59 @@ func isReleaseVersion(v string) bool {
 	return releaseVersionPattern.MatchString(v)
 }
 
+// Features is the per-install feature-adoption snapshot sent with each ping.
+// Every field is a count or boolean; never a name, ID, URL, or value. Fields
+// are added as new subsystems land. The struct is JSON-omit-empty so an
+// install that has nothing configured doesn't emit a wall of zeroes.
+//
+// Add new fields with care: anything here is documented at
+// getbindery.dev/telemetry-fields and committed to the public schema.
+type Features struct {
+	// Counts of enabled configuration rows. Tells the maintainer which
+	// subsystems users actually configure (vs the long tail of "installed
+	// and never touched").
+	Indexers        int `json:"indexers,omitempty"`
+	DownloadClients int `json:"download_clients,omitempty"`
+	Notifications   int `json:"notifications,omitempty"`
+	Users           int `json:"users,omitempty"`
+
+	// Booleans for "is this subsystem turned on at all" where a count would
+	// be misleading (these are 0-or-1 settings, not lists).
+	CalibreEnabled  bool `json:"calibre_enabled,omitempty"`
+	ABSEnabled      bool `json:"abs_enabled,omitempty"`
+	GrimmoryEnabled bool `json:"grimmory_enabled,omitempty"`
+	HardcoverToken  bool `json:"hardcover_token,omitempty"`
+	OIDCEnabled     bool `json:"oidc_enabled,omitempty"`
+	MultiUser       bool `json:"multi_user,omitempty"`
+}
+
+// Gatherer returns the current Features snapshot. Called inline from Ping,
+// so it should be cheap (a handful of small SQL reads, no network). Errors
+// from individual subqueries should be swallowed by the implementation; a
+// missing field is preferable to skipping the whole ping. Nil Gatherer is
+// fine and means the ping carries no features payload (backwards-compatible
+// with older telemetry-server versions).
+type Gatherer func(ctx context.Context) Features
+
 // Client sends anonymous usage pings and surfaces the latest published version.
 type Client struct {
 	settings      *db.SettingsRepo
 	version       string
 	latestVersion string
+	gatherer      Gatherer
 }
 
 // New creates a telemetry client. version is the running binary's version string.
 func New(settings *db.SettingsRepo, version string) *Client {
 	return &Client{settings: settings, version: version}
+}
+
+// WithGatherer wires in a feature-snapshot gatherer. Calling without this
+// keeps the legacy payload shape (no features field). Returns the receiver
+// to support fluent construction (telemetry.New(...).WithGatherer(...)).
+func (c *Client) WithGatherer(g Gatherer) *Client {
+	c.gatherer = g
+	return c
 }
 
 // LatestVersion returns the most recently received latest-version string from
@@ -105,13 +164,18 @@ func (c *Client) Ping(ctx context.Context) {
 		return
 	}
 
-	payload, _ := json.Marshal(map[string]string{
-		"install_id": id,
-		"version":    c.version,
-		"os":         runtime.GOOS,
-		"arch":       runtime.GOARCH,
-		"deploy":     detectDeploy(),
-	})
+	body := pingPayload{
+		InstallID: id,
+		Version:   c.version,
+		OS:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+		Deploy:    detectDeploy(),
+	}
+	if c.gatherer != nil {
+		f := c.gatherer(ctx)
+		body.Features = &f
+	}
+	payload, _ := json.Marshal(body)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, pingURL, bytes.NewReader(payload))
 	if err != nil {
@@ -132,12 +196,12 @@ func (c *Client) Ping(ctx context.Context) {
 		return
 	}
 
-	var body struct {
+	var reply struct {
 		LatestVersion string `json:"latest_version"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err == nil && body.LatestVersion != "" {
-		c.latestVersion = body.LatestVersion
-		slog.Debug("telemetry: ping ok", "latest", body.LatestVersion)
+	if err := json.NewDecoder(resp.Body).Decode(&reply); err == nil && reply.LatestVersion != "" {
+		c.latestVersion = reply.LatestVersion
+		slog.Debug("telemetry: ping ok", "latest", reply.LatestVersion)
 	}
 }
 

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1,6 +1,10 @@
 package telemetry
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
 
 func TestIsReleaseVersion(t *testing.T) {
 	cases := []struct {
@@ -31,5 +35,95 @@ func TestIsReleaseVersion(t *testing.T) {
 		if got := isReleaseVersion(tc.version); got != tc.want {
 			t.Errorf("isReleaseVersion(%q) = %v, want %v", tc.version, got, tc.want)
 		}
+	}
+}
+
+// TestPingPayloadWireShape verifies the JSON shape of a ping payload both
+// with and without a features section. Two cohorts care about the shape:
+// older telemetry-server versions that don't know about features (must
+// accept the message without the field), and the current server which
+// expects the nested features object verbatim.
+func TestPingPayloadWireShape(t *testing.T) {
+	t.Run("no features field when gatherer is nil", func(t *testing.T) {
+		body := pingPayload{
+			InstallID: "11111111-1111-1111-1111-111111111111",
+			Version:   "1.15.2",
+			OS:        "linux",
+			Arch:      "amd64",
+			Deploy:    "docker",
+		}
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if _, present := decoded["features"]; present {
+			t.Errorf("features field must be omitted when nil; got: %s", raw)
+		}
+	})
+
+	t.Run("features field embeds when gatherer is set", func(t *testing.T) {
+		f := Features{
+			Indexers:        2,
+			DownloadClients: 1,
+			Notifications:   3,
+			CalibreEnabled:  true,
+			MultiUser:       true,
+		}
+		body := pingPayload{
+			InstallID: "22222222-2222-2222-2222-222222222222",
+			Version:   "1.15.3",
+			OS:        "linux",
+			Arch:      "amd64",
+			Deploy:    "docker",
+			Features:  &f,
+		}
+		raw, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var decoded struct {
+			Features map[string]any `json:"features"`
+		}
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got := decoded.Features["indexers"]; got != float64(2) {
+			t.Errorf("features.indexers = %v, want 2", got)
+		}
+		if got := decoded.Features["calibre_enabled"]; got != true {
+			t.Errorf("features.calibre_enabled = %v, want true", got)
+		}
+		// Zero-valued fields must be omitted, otherwise the payload bloats
+		// for installs that have nothing configured.
+		if _, present := decoded.Features["abs_enabled"]; present {
+			t.Errorf("features.abs_enabled must be omitted when false; got: %v", decoded.Features)
+		}
+		if _, present := decoded.Features["users"]; present {
+			t.Errorf("features.users must be omitted when zero; got: %v", decoded.Features)
+		}
+	})
+}
+
+// TestWithGathererIsOptional verifies that calling WithGatherer is optional
+// and that omitting it leaves the gatherer nil so Ping falls back to the
+// legacy payload shape (covered above by the no-features-field test).
+func TestWithGathererIsOptional(t *testing.T) {
+	c := &Client{}
+	if c.gatherer != nil {
+		t.Error("zero-value Client should have nil gatherer")
+	}
+	c2 := (&Client{}).WithGatherer(func(context.Context) Features {
+		return Features{Indexers: 1}
+	})
+	if c2.gatherer == nil {
+		t.Error("WithGatherer should set the gatherer")
+	}
+	got := c2.gatherer(context.Background())
+	if got.Indexers != 1 {
+		t.Errorf("gatherer returned %+v, want Indexers=1", got)
 	}
 }


### PR DESCRIPTION
## Why

Phase 1 (#869) made the dashboard honest about which versions are actually running. This phase answers the question that today has zero data: "is feature X actually used enough that I should keep maintaining it?"

Today the maintainer guesses from Discord vibes. After this, the dashboard says e.g. "out of 50 installs reporting, 14 have ntfy configured, 6 use Hardcover enhanced, 1 uses multi-user."

## What ships

**Client side (`internal/telemetry`):**
- `Features` struct: counts of enabled indexers / download_clients / notifications / users, plus booleans for calibre / abs / grimmory / hardcover_token / oidc_enabled / multi_user
- `Gatherer` is a `func(ctx) Features` the caller wires via `WithGatherer`
- Bindery's `cmd/bindery/main.go` provides the gatherer as a closure over existing repos; every subquery is best-effort
- Strictly numeric or boolean. No names, IDs, URLs, paths, or values ever leave the install via this payload

**Server side (`cmd/telemetry-server`):**
- Idempotent `ALTER TABLE installs ADD COLUMN features TEXT` (JSON blob)
- `handlePing` decodes optional `features`, re-marshals to normalise, persists
- `computeFeatureAdoption` uses SQLite's `json_extract` to count installs with each subsystem enabled among 7d-active reporting installs (denominator = installs with non-NULL features)
- New "Feature adoption (last 7 days)" section on `/stats` with the denominator in the section header so the percentages are honest
- New `/telemetry-fields` page documenting every field that ever leaves a Bindery install plus opt-out instructions. Inspired by Sourcegraph's pings doc, which the OSS-telemetry survey flagged as the highest-leverage privacy-trust artifact available

## Wire compatibility matrix

| Client | Server | Result |
|---|---|---|
| Old | Old | Works (no features at all) |
| Old | New | Works (features = NULL, install not counted in adoption denominator) |
| New | Old | Works (server ignores the unknown field, payload still accepted) |
| New | New | Full adoption telemetry |

So neither component has to ship in lockstep. Recommendation: deploy the telemetry-server first (no behavioural change for older clients), then ship the new Bindery client whenever the next release cuts.

## Test plan

- [x] `go test ./...` green across the whole repo
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] New tests cover: payload omits features when nil; payload embeds when set; zero-valued fields omit (preserves wire economy); handlePing stores JSON correctly; handlePing accepts legacy no-features payloads; computeFeatureAdoption counts correctly and ignores out-of-window/old-client rows; renderFeatures empty state + denominator header; /telemetry-fields renders with expected fields

## What's NOT in this PR

Phase 4 (daily aggregates rollover with 60d raw-row eviction) defers a couple of weeks to let real feature data accumulate first. The current setup is fine at 566 installs; rollover matters more at 5k+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)