### PR TITLE
feat(telemetry-server): daily aggregates with perpetual retention (Phase 4)

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -132,6 +132,34 @@ var aggregateInterval = 24 * time.Hour
 // approximate counts (installs that pinged then but more recently
 // updated last_seen forward won't be attributed to the older day). Run
 // daily so today's snapshot is captured before the rollover.
+// readVersionCounts returns a map of version → count of installs whose
+// last_seen falls on dayStr. Used by snapshotDay so its INSERT loop runs
+// after the read cursor has been released (defer covers all return paths).
+func readVersionCounts(ctx context.Context, tx *sql.Tx, dayStr string) (map[string]int, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT version, COUNT(*) FROM installs
+		WHERE substr(last_seen, 1, 10) = ?
+		GROUP BY version
+	`, dayStr)
+	if err != nil {
+		return nil, fmt.Errorf("version rows: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]int)
+	for rows.Next() {
+		var v string
+		var n int
+		if err := rows.Scan(&v, &n); err != nil {
+			return nil, fmt.Errorf("version scan: %w", err)
+		}
+		out[v] = n
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("version iter: %w", err)
+	}
+	return out, nil
+}
+
 func (s *server) snapshotDay(ctx context.Context, day time.Time) error {
 	dayStr := day.UTC().Format("2006-01-02")
 
@@ -178,39 +206,16 @@ func (s *server) snapshotDay(ctx context.Context, day time.Time) error {
 	); err != nil {
 		return fmt.Errorf("snapshot %s: clear version: %w", dayStr, err)
 	}
-	rows, err := tx.QueryContext(ctx, `
-		SELECT version, COUNT(*) FROM installs
-		WHERE substr(last_seen, 1, 10) = ?
-		GROUP BY version
-	`, dayStr)
+	// Buffer the version rows fully before issuing any INSERTs so the
+	// scope of the read cursor is bounded by readVersionCounts.
+	versionCounts, err := readVersionCounts(ctx, tx, dayStr)
 	if err != nil {
-		return fmt.Errorf("snapshot %s: version rows: %w", dayStr, err)
+		return fmt.Errorf("snapshot %s: %w", dayStr, err)
 	}
-	// Collect rows fully before issuing any INSERTs so the read cursor is
-	// closed before we touch the transaction again (SQLite's cursor can hold
-	// a snapshot-visibility lock that blocks subsequent writes on the same tx).
-	type versionRow struct {
-		version string
-		count   int
-	}
-	var versionRows []versionRow
-	for rows.Next() {
-		var vr versionRow
-		if err := rows.Scan(&vr.version, &vr.count); err != nil {
-			_ = rows.Close()
-			return fmt.Errorf("snapshot %s: version scan: %w", dayStr, err)
-		}
-		versionRows = append(versionRows, vr)
-	}
-	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return fmt.Errorf("snapshot %s: version rows iter: %w", dayStr, err)
-	}
-	_ = rows.Close()
-	for _, vr := range versionRows {
+	for v, n := range versionCounts {
 		if _, err := tx.ExecContext(ctx,
 			`INSERT INTO daily_version (day, version, active_count) VALUES (?, ?, ?)`,
-			dayStr, vr.version, vr.count); err != nil {
+			dayStr, v, n); err != nil {
 			return fmt.Errorf("snapshot %s: version insert: %w", dayStr, err)
 		}
 	}

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -116,6 +116,179 @@ func (s *server) runRetentionLoop(ctx context.Context) {
 	}
 }
 
+// aggregateInterval is how often runAggregateLoop fires. Same shape as
+// retentionInterval; both run independently so a slow snapshot can't
+// starve the eviction sweep.
+var aggregateInterval = 24 * time.Hour
+
+// snapshotDay writes the daily aggregate rows for `day` from the current
+// installs table state. All three aggregate tables (global, version,
+// features) are upserted in one transaction so a partial failure leaves
+// no orphan rows. day is normalised to UTC YYYY-MM-DD on the way in.
+//
+// The active_day, version split, and feature counts are computed from
+// rows whose last_seen falls on `day`. Because last_seen is the most
+// recent ping per install, snapshotting historical days produces
+// approximate counts (installs that pinged then but more recently
+// updated last_seen forward won't be attributed to the older day). Run
+// daily so today's snapshot is captured before the rollover.
+func (s *server) snapshotDay(ctx context.Context, day time.Time) error {
+	dayStr := day.UTC().Format("2006-01-02")
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("snapshot %s: begin: %w", dayStr, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// daily_global: one row per day with active_day, new_installs, total.
+	var activeDay, newInstalls, total int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM installs WHERE substr(last_seen, 1, 10) = ?`, dayStr,
+	).Scan(&activeDay); err != nil {
+		return fmt.Errorf("snapshot %s: active_day: %w", dayStr, err)
+	}
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM installs WHERE substr(first_seen, 1, 10) = ?`, dayStr,
+	).Scan(&newInstalls); err != nil {
+		return fmt.Errorf("snapshot %s: new_installs: %w", dayStr, err)
+	}
+	if err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM installs`,
+	).Scan(&total); err != nil {
+		return fmt.Errorf("snapshot %s: total: %w", dayStr, err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO daily_global (day, active_day, new_installs, total)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(day) DO UPDATE SET
+			active_day   = excluded.active_day,
+			new_installs = excluded.new_installs,
+			total        = excluded.total
+	`, dayStr, activeDay, newInstalls, total); err != nil {
+		return fmt.Errorf("snapshot %s: upsert global: %w", dayStr, err)
+	}
+
+	// daily_version: one row per (day, version) with the active count on
+	// that day. Replace any prior rows for `day` first so versions that
+	// dropped to zero aren't left stranded (which would happen if we just
+	// upserted: the row from yesterday's snapshot stays at its old count).
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM daily_version WHERE day = ?`, dayStr,
+	); err != nil {
+		return fmt.Errorf("snapshot %s: clear version: %w", dayStr, err)
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT version, COUNT(*) FROM installs
+		WHERE substr(last_seen, 1, 10) = ?
+		GROUP BY version
+	`, dayStr)
+	if err != nil {
+		return fmt.Errorf("snapshot %s: version rows: %w", dayStr, err)
+	}
+	for rows.Next() {
+		var v string
+		var n int
+		if err := rows.Scan(&v, &n); err != nil {
+			rows.Close()
+			return fmt.Errorf("snapshot %s: version scan: %w", dayStr, err)
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO daily_version (day, version, active_count) VALUES (?, ?, ?)`,
+			dayStr, v, n); err != nil {
+			rows.Close()
+			return fmt.Errorf("snapshot %s: version insert: %w", dayStr, err)
+		}
+	}
+	rows.Close()
+
+	// daily_features: one row per (day, field). reporting_count is the
+	// denominator (installs active on day with non-null features) and is
+	// the same for every field. enabled_count is the per-field numerator.
+	var reporting int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM installs
+		WHERE substr(last_seen, 1, 10) = ?
+		  AND features IS NOT NULL
+	`, dayStr).Scan(&reporting); err != nil {
+		return fmt.Errorf("snapshot %s: features reporting: %w", dayStr, err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM daily_features WHERE day = ?`, dayStr,
+	); err != nil {
+		return fmt.Errorf("snapshot %s: clear features: %w", dayStr, err)
+	}
+	if reporting > 0 {
+		for _, f := range featureFields {
+			var enabled int
+			if err := tx.QueryRowContext(ctx, `
+				SELECT COUNT(*) FROM installs
+				WHERE substr(last_seen, 1, 10) = ?
+				  AND features IS NOT NULL
+				  AND json_extract(features, '$.'||?) > 0
+			`, dayStr, f.JSONKey).Scan(&enabled); err != nil {
+				return fmt.Errorf("snapshot %s: feature %s: %w", dayStr, f.JSONKey, err)
+			}
+			if _, err := tx.ExecContext(ctx, `
+				INSERT INTO daily_features (day, field, enabled_count, reporting_count)
+				VALUES (?, ?, ?, ?)
+			`, dayStr, f.JSONKey, enabled, reporting); err != nil {
+				return fmt.Errorf("snapshot %s: feature insert %s: %w", dayStr, f.JSONKey, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("snapshot %s: commit: %w", dayStr, err)
+	}
+	return nil
+}
+
+// backfillNewInstalls populates daily_global.new_installs for every day in
+// the installs table's first_seen range. Only this column is historically
+// recoverable; the others depend on last_seen which has rolled forward.
+// Idempotent: existing rows have new_installs replaced; active_day, total
+// are preserved (only set non-zero when we have current data for the day).
+//
+// Runs once at startup. Cheap: one INSERT ... SELECT against an indexed
+// substring; the installs table holds at most ~5k rows at our scale.
+func (s *server) backfillNewInstalls(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO daily_global (day, active_day, new_installs, total)
+		SELECT substr(first_seen, 1, 10) AS day, 0, COUNT(*), 0
+		  FROM installs
+		 WHERE first_seen IS NOT NULL
+		 GROUP BY day
+		ON CONFLICT(day) DO UPDATE SET
+			new_installs = excluded.new_installs
+	`)
+	return err
+}
+
+// runAggregateLoop drives snapshotDay on the same daily cadence as
+// retention. On each tick it snapshots both today and yesterday: yesterday
+// captures whatever pings landed since the previous tick before any of
+// today's pings have had a chance to roll last_seen forward; today fills
+// in the live "what's happening right now" row that the dashboard reads.
+func (s *server) runAggregateLoop(ctx context.Context) {
+	tick := time.NewTicker(aggregateInterval)
+	defer tick.Stop()
+	for {
+		now := time.Now().UTC()
+		if err := s.snapshotDay(ctx, now); err != nil {
+			slog.Warn("snapshot today failed", "error", err)
+		}
+		if err := s.snapshotDay(ctx, now.AddDate(0, 0, -1)); err != nil {
+			slog.Warn("snapshot yesterday failed", "error", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+		}
+	}
+}
+
 type pingRequest struct {
 	InstallID string           `json:"install_id"`
 	Version   string           `json:"version"`
@@ -233,6 +406,38 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Daily aggregate tables (Phase 4). One row per day for the global
+	// counts, one per (day, version) for the version split, one per
+	// (day, field) for feature adoption. Populated by the nightly snapshot
+	// loop; perpetual retention so charts can extend beyond the 60-day
+	// retention window we keep on raw rows.
+	for _, stmt := range []string{
+		`CREATE TABLE IF NOT EXISTS daily_global (
+			day          TEXT PRIMARY KEY,
+			active_day   INTEGER NOT NULL DEFAULT 0,
+			new_installs INTEGER NOT NULL DEFAULT 0,
+			total        INTEGER NOT NULL DEFAULT 0
+		)`,
+		`CREATE TABLE IF NOT EXISTS daily_version (
+			day          TEXT NOT NULL,
+			version      TEXT NOT NULL,
+			active_count INTEGER NOT NULL,
+			PRIMARY KEY (day, version)
+		)`,
+		`CREATE TABLE IF NOT EXISTS daily_features (
+			day              TEXT NOT NULL,
+			field            TEXT NOT NULL,
+			enabled_count    INTEGER NOT NULL,
+			reporting_count  INTEGER NOT NULL,
+			PRIMARY KEY (day, field)
+		)`,
+	} {
+		if _, err := db.ExecContext(context.Background(), stmt); err != nil {
+			slog.Error("create aggregate table", "error", err)
+			os.Exit(1)
+		}
+	}
+
 	// Boot-time sweep so dashboards on a fresh process are clean immediately;
 	// the nightly cron below keeps them clean from then on.
 	if _, err := sweepStaleAndDev(context.Background(), db); err != nil {
@@ -256,6 +461,22 @@ func main() {
 	// 60-day window matches the active-install definition used downstream
 	// (60-day evict means an install ID is either active or absent).
 	go s.runRetentionLoop(context.Background())
+
+	// Backfill the one historically-recoverable aggregate (new_installs by
+	// day, computed from first_seen which never changes). active_day,
+	// version splits, and feature adoption can't be backfilled because the
+	// installs table holds only the most-recent ping per install; those
+	// metrics begin accumulating from today's snapshot forward. Best-effort:
+	// a failure here does not block startup.
+	if err := s.backfillNewInstalls(context.Background()); err != nil {
+		slog.Warn("aggregate backfill failed", "error", err)
+	}
+
+	// Daily snapshot job for the aggregate tables. Mirrors the retention
+	// loop's lifecycle: fires immediately, then every 24 hours. Each tick
+	// snapshots the current state into today's row (UPSERT), so a process
+	// restart can recover today's partial counts without manual intervention.
+	go s.runAggregateLoop(context.Background())
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", s.handleHome)
@@ -525,7 +746,7 @@ const telemetryFieldsHTML = `<!DOCTYPE html>
 
   <h2>How the data is stored</h2>
 
-  <p>Pings land in a small SQLite database on a single VM in Hetzner Cloud (Falkenstein, Germany). Rows whose <code>last_seen</code> is older than 60 days are deleted nightly. The database itself is backed up daily to an off-site object store; backups follow the same 60-day retention.</p>
+  <p>Pings land in a small SQLite database on a single VM in Hetzner Cloud (Falkenstein, Germany). Per-install rows whose <code>last_seen</code> is older than 60 days are deleted nightly. The dashboard's long-running charts (monthly new installs, version adoption over time) are computed from daily aggregate tables that hold only counts per day: how many new installs, how many were active, how many were on each version, how many had each subsystem enabled. The aggregate rows never contain individual install IDs, so they're kept indefinitely. The database itself is backed up daily to an off-site object store; backups follow the same 60-day retention on per-install rows.</p>
 
   <p>The aggregated dashboard at <a href="/stats">/stats</a> is rendered live from the database with no caching. The full source of both the bindery client and the telemetry server lives at <a href="https://github.com/vavallee/bindery">github.com/vavallee/bindery</a> &mdash; the client at <code>internal/telemetry/client.go</code>, the server at <code>cmd/telemetry-server/main.go</code>.</p>
 
@@ -847,11 +1068,18 @@ func (s *server) computeStats(ctx context.Context) (*statsData, error) {
 		return nil, err
 	}
 
-	// Monthly new installs for the last 12 calendar months.
-	monthlyCutoff := time.Now().UTC().AddDate(0, -12, 0)
-	rowsMon, err := s.db.QueryContext(ctx,
-		`SELECT substr(first_seen, 1, 7) AS month, COUNT(*) FROM installs WHERE first_seen >= ? GROUP BY month ORDER BY month`,
-		monthlyCutoff)
+	// Monthly new installs for the last 12 calendar months. Reads from
+	// daily_global rather than installs so the chart survives the 60-day
+	// retention sweep: once a row's first_seen drops out of installs it's
+	// already accumulated into the daily aggregate for that day.
+	monthlyCutoff := time.Now().UTC().AddDate(0, -12, 0).Format("2006-01-02")
+	rowsMon, err := s.db.QueryContext(ctx, `
+		SELECT substr(day, 1, 7) AS month, SUM(new_installs)
+		  FROM daily_global
+		 WHERE day >= ?
+		 GROUP BY month
+		 ORDER BY month
+	`, monthlyCutoff)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -186,21 +186,34 @@ func (s *server) snapshotDay(ctx context.Context, day time.Time) error {
 	if err != nil {
 		return fmt.Errorf("snapshot %s: version rows: %w", dayStr, err)
 	}
+	// Collect rows fully before issuing any INSERTs so the read cursor is
+	// closed before we touch the transaction again (SQLite's cursor can hold
+	// a snapshot-visibility lock that blocks subsequent writes on the same tx).
+	type versionRow struct {
+		version string
+		count   int
+	}
+	var versionRows []versionRow
 	for rows.Next() {
-		var v string
-		var n int
-		if err := rows.Scan(&v, &n); err != nil {
-			rows.Close()
+		var vr versionRow
+		if err := rows.Scan(&vr.version, &vr.count); err != nil {
+			_ = rows.Close()
 			return fmt.Errorf("snapshot %s: version scan: %w", dayStr, err)
 		}
+		versionRows = append(versionRows, vr)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("snapshot %s: version rows iter: %w", dayStr, err)
+	}
+	_ = rows.Close()
+	for _, vr := range versionRows {
 		if _, err := tx.ExecContext(ctx,
 			`INSERT INTO daily_version (day, version, active_count) VALUES (?, ?, ?)`,
-			dayStr, v, n); err != nil {
-			rows.Close()
+			dayStr, vr.version, vr.count); err != nil {
 			return fmt.Errorf("snapshot %s: version insert: %w", dayStr, err)
 		}
 	}
-	rows.Close()
 
 	// daily_features: one row per (day, field). reporting_count is the
 	// denominator (installs active on day with non-null features) and is

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -736,6 +736,9 @@ func TestSnapshotDay(t *testing.T) {
 		}
 		versionCounts[v] = n
 	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate version rows: %v", err)
+	}
 	if versionCounts["1.15.2"] != 2 || versionCounts["1.15.1"] != 1 {
 		t.Errorf("daily_version[2026-05-27] = %v, want {1.15.2: 2, 1.15.1: 1}", versionCounts)
 	}
@@ -761,6 +764,9 @@ func TestSnapshotDay(t *testing.T) {
 		}
 		enabled[f] = e
 		reporting = r // same for every row
+	}
+	if err := featRows.Err(); err != nil {
+		t.Fatalf("iterate feature rows: %v", err)
 	}
 	if reporting != 2 {
 		t.Errorf("reporting_count = %d, want 2 (two installs reported features)", reporting)

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -123,17 +123,40 @@ func newTestServer(t *testing.T, latest string) *server {
 		t.Fatalf("open db: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
-	if _, err := db.ExecContext(context.Background(), `CREATE TABLE installs (
-		install_id  TEXT PRIMARY KEY,
-		version     TEXT NOT NULL,
-		os          TEXT NOT NULL,
-		arch        TEXT NOT NULL,
-		first_seen  DATETIME NOT NULL,
-		last_seen   DATETIME NOT NULL,
-		deploy      TEXT NOT NULL DEFAULT '',
-		features    TEXT
-	)`); err != nil {
-		t.Fatalf("create table: %v", err)
+	for _, stmt := range []string{
+		`CREATE TABLE installs (
+			install_id  TEXT PRIMARY KEY,
+			version     TEXT NOT NULL,
+			os          TEXT NOT NULL,
+			arch        TEXT NOT NULL,
+			first_seen  DATETIME NOT NULL,
+			last_seen   DATETIME NOT NULL,
+			deploy      TEXT NOT NULL DEFAULT '',
+			features    TEXT
+		)`,
+		`CREATE TABLE daily_global (
+			day          TEXT PRIMARY KEY,
+			active_day   INTEGER NOT NULL DEFAULT 0,
+			new_installs INTEGER NOT NULL DEFAULT 0,
+			total        INTEGER NOT NULL DEFAULT 0
+		)`,
+		`CREATE TABLE daily_version (
+			day          TEXT NOT NULL,
+			version      TEXT NOT NULL,
+			active_count INTEGER NOT NULL,
+			PRIMARY KEY (day, version)
+		)`,
+		`CREATE TABLE daily_features (
+			day              TEXT NOT NULL,
+			field            TEXT NOT NULL,
+			enabled_count    INTEGER NOT NULL,
+			reporting_count  INTEGER NOT NULL,
+			PRIMARY KEY (day, field)
+		)`,
+	} {
+		if _, err := db.ExecContext(context.Background(), stmt); err != nil {
+			t.Fatalf("create table: %v", err)
+		}
 	}
 	return &server{db: db, latestVersion: latest}
 }
@@ -641,5 +664,260 @@ func TestHandleTelemetryFields(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("expected /telemetry-fields to contain %q", want)
 		}
+	}
+}
+
+// TestSnapshotDay verifies that a single call to snapshotDay populates all
+// three aggregate tables correctly for a target day with mixed data:
+// installs pinged on that day, installs that pinged a different day, and
+// installs that reported features payloads.
+func TestSnapshotDay(t *testing.T) {
+	s := newTestServer(t, "v1.15.3")
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	target := time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC) // snapshot yesterday
+
+	// Three installs pinged on 2026-05-27: two v1.15.2, one v1.15.1
+	// (two with features, one of those with calibre on).
+	insertInstallWithFeatures(t, s, uuid('1'), "1.15.2",
+		now.AddDate(0, 0, -10), time.Date(2026, 5, 27, 8, 0, 0, 0, time.UTC),
+		map[string]any{"indexers": 2, "calibre_enabled": true})
+	insertInstallWithFeatures(t, s, uuid('2'), "1.15.2",
+		now.AddDate(0, 0, -8), time.Date(2026, 5, 27, 15, 0, 0, 0, time.UTC),
+		map[string]any{"indexers": 1})
+	insertInstall(t, s, uuid('3'), "1.15.1",
+		now.AddDate(0, 0, -5), time.Date(2026, 5, 27, 20, 0, 0, 0, time.UTC))
+
+	// One install pinged on a different day; must not contribute to the
+	// 2026-05-27 snapshot.
+	insertInstall(t, s, uuid('4'), "1.14.0",
+		now.AddDate(0, 0, -20), time.Date(2026, 5, 25, 10, 0, 0, 0, time.UTC))
+
+	// A fifth install that was first_seen on 2026-05-27 but pinged later;
+	// should show up in new_installs even though it's not in active_day.
+	insertInstall(t, s, uuid('5'), "1.15.3",
+		time.Date(2026, 5, 27, 6, 0, 0, 0, time.UTC), now.Add(-1*time.Hour))
+
+	if err := s.snapshotDay(context.Background(), target); err != nil {
+		t.Fatalf("snapshotDay: %v", err)
+	}
+
+	// daily_global row for 2026-05-27.
+	var activeDay, newInstalls, total int
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT active_day, new_installs, total FROM daily_global WHERE day = ?`,
+		"2026-05-27",
+	).Scan(&activeDay, &newInstalls, &total); err != nil {
+		t.Fatalf("read daily_global: %v", err)
+	}
+	if activeDay != 3 {
+		t.Errorf("active_day = %d, want 3 (two v1.15.2 + one v1.15.1)", activeDay)
+	}
+	if newInstalls != 1 {
+		t.Errorf("new_installs = %d, want 1 (the v1.15.3 install with first_seen=2026-05-27)", newInstalls)
+	}
+	if total != 5 {
+		t.Errorf("total = %d, want 5 (all rows)", total)
+	}
+
+	// daily_version rows for 2026-05-27.
+	rows, err := s.db.QueryContext(context.Background(),
+		`SELECT version, active_count FROM daily_version WHERE day = ? ORDER BY version`,
+		"2026-05-27")
+	if err != nil {
+		t.Fatalf("read daily_version: %v", err)
+	}
+	defer rows.Close()
+	versionCounts := map[string]int{}
+	for rows.Next() {
+		var v string
+		var n int
+		if err := rows.Scan(&v, &n); err != nil {
+			t.Fatalf("scan version row: %v", err)
+		}
+		versionCounts[v] = n
+	}
+	if versionCounts["1.15.2"] != 2 || versionCounts["1.15.1"] != 1 {
+		t.Errorf("daily_version[2026-05-27] = %v, want {1.15.2: 2, 1.15.1: 1}", versionCounts)
+	}
+	if _, present := versionCounts["1.14.0"]; present {
+		t.Errorf("1.14.0 should not appear (last_seen was 2026-05-25)")
+	}
+
+	// daily_features rows for 2026-05-27.
+	featRows, err := s.db.QueryContext(context.Background(),
+		`SELECT field, enabled_count, reporting_count FROM daily_features WHERE day = ?`,
+		"2026-05-27")
+	if err != nil {
+		t.Fatalf("read daily_features: %v", err)
+	}
+	defer featRows.Close()
+	enabled := map[string]int{}
+	var reporting int
+	for featRows.Next() {
+		var f string
+		var e, r int
+		if err := featRows.Scan(&f, &e, &r); err != nil {
+			t.Fatalf("scan feature row: %v", err)
+		}
+		enabled[f] = e
+		reporting = r // same for every row
+	}
+	if reporting != 2 {
+		t.Errorf("reporting_count = %d, want 2 (two installs reported features)", reporting)
+	}
+	if enabled["indexers"] != 2 {
+		t.Errorf("indexers enabled = %d, want 2 (both reporting installs have indexers > 0)", enabled["indexers"])
+	}
+	if enabled["calibre_enabled"] != 1 {
+		t.Errorf("calibre_enabled = %d, want 1 (one install has calibre on)", enabled["calibre_enabled"])
+	}
+}
+
+// TestSnapshotDayReplaceVersionRows verifies that re-snapshotting a day
+// drops version rows whose count went to zero. Without this guard a
+// version that was active on day N but not on day N+1's re-snapshot would
+// be left at its day-N count, exaggerating reach in trend charts.
+func TestSnapshotDayReplaceVersionRows(t *testing.T) {
+	s := newTestServer(t, "v1.15.3")
+	target := time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
+
+	// First snapshot: one install on 1.14.0.
+	insertInstall(t, s, uuid('1'), "1.14.0",
+		target.AddDate(0, 0, -10), time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC))
+	if err := s.snapshotDay(context.Background(), target); err != nil {
+		t.Fatalf("first snapshot: %v", err)
+	}
+
+	// Move the install to 1.15.2; re-snapshot. The 1.14.0 row from the
+	// first snapshot must disappear.
+	if _, err := s.db.ExecContext(context.Background(),
+		`UPDATE installs SET version = '1.15.2' WHERE install_id = ?`, uuid('1'),
+	); err != nil {
+		t.Fatalf("update version: %v", err)
+	}
+	if err := s.snapshotDay(context.Background(), target); err != nil {
+		t.Fatalf("second snapshot: %v", err)
+	}
+
+	var rows int
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM daily_version WHERE day = ? AND version = '1.14.0'`,
+		"2026-05-27",
+	).Scan(&rows); err != nil {
+		t.Fatalf("query 1.14.0 rows: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("expected 1.14.0 row to be cleared on re-snapshot; got %d rows", rows)
+	}
+
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM daily_version WHERE day = ? AND version = '1.15.2'`,
+		"2026-05-27",
+	).Scan(&rows); err != nil {
+		t.Fatalf("query 1.15.2 rows: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("expected 1.15.2 row to exist after re-snapshot; got %d rows", rows)
+	}
+}
+
+// TestBackfillNewInstalls verifies the startup backfill creates
+// daily_global rows for every distinct first_seen day, with the correct
+// counts; idempotent across multiple calls; safe to run alongside an
+// already-populated table (preserves active_day, total).
+func TestBackfillNewInstalls(t *testing.T) {
+	s := newTestServer(t, "v1.15.3")
+	d1 := time.Date(2026, 5, 26, 10, 0, 0, 0, time.UTC)
+	d2 := time.Date(2026, 5, 27, 11, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+
+	insertInstall(t, s, uuid('1'), "1.15.2", d1, now)
+	insertInstall(t, s, uuid('2'), "1.15.2", d1, now)
+	insertInstall(t, s, uuid('3'), "1.15.1", d2, now)
+
+	// Pre-seed daily_global for 2026-05-26 with non-zero active_day; the
+	// backfill must update new_installs without clobbering active_day.
+	if _, err := s.db.ExecContext(context.Background(),
+		`INSERT INTO daily_global (day, active_day, new_installs, total)
+		 VALUES ('2026-05-26', 99, 0, 999)`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := s.backfillNewInstalls(context.Background()); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	var active, newCount, total int
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT active_day, new_installs, total FROM daily_global WHERE day = '2026-05-26'`,
+	).Scan(&active, &newCount, &total); err != nil {
+		t.Fatalf("read 2026-05-26: %v", err)
+	}
+	if newCount != 2 {
+		t.Errorf("new_installs[2026-05-26] = %d, want 2", newCount)
+	}
+	if active != 99 {
+		t.Errorf("active_day must be preserved across backfill; got %d, want 99", active)
+	}
+	if total != 999 {
+		t.Errorf("total must be preserved across backfill; got %d, want 999", total)
+	}
+
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT new_installs FROM daily_global WHERE day = '2026-05-27'`,
+	).Scan(&newCount); err != nil {
+		t.Fatalf("read 2026-05-27: %v", err)
+	}
+	if newCount != 1 {
+		t.Errorf("new_installs[2026-05-27] = %d, want 1", newCount)
+	}
+
+	// Idempotency: second call must leave state identical.
+	if err := s.backfillNewInstalls(context.Background()); err != nil {
+		t.Fatalf("backfill twice: %v", err)
+	}
+	var seen int
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM daily_global`,
+	).Scan(&seen); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if seen != 2 {
+		t.Errorf("daily_global row count after second backfill = %d, want 2", seen)
+	}
+}
+
+// TestComputeStats_MonthlyReadsFromAggregates verifies the monthly new
+// installs chart sources data from daily_global, not from the installs
+// table directly. Once raw rows expire from the 60-day retention window
+// the monthly chart should still show their contribution to history.
+func TestComputeStats_MonthlyReadsFromAggregates(t *testing.T) {
+	s := newTestServer(t, "v1.15.3")
+	now := time.Now().UTC()
+
+	// Seed daily_global with a row that has no corresponding installs row
+	// (simulating data from before the retention window).
+	pastMonth := now.AddDate(0, -3, 0).Format("2006-01-02")
+	if _, err := s.db.ExecContext(context.Background(),
+		`INSERT INTO daily_global (day, active_day, new_installs, total)
+		 VALUES (?, 0, 42, 0)`, pastMonth); err != nil {
+		t.Fatalf("seed past month: %v", err)
+	}
+
+	d, err := s.computeStats(context.Background())
+	if err != nil {
+		t.Fatalf("computeStats: %v", err)
+	}
+
+	monthLabel := now.AddDate(0, -3, 0).Format("Jan '06")
+	var got int
+	for _, b := range d.Monthly {
+		if b.Label == monthLabel {
+			got = b.Count
+			break
+		}
+	}
+	if got != 42 {
+		t.Errorf("Monthly[%s] = %d, want 42 (from daily_global with no raw rows)", monthLabel, got)
 	}
 }


### PR DESCRIPTION
## Why

Phase 1 (#869) made the dashboard trustworthy. Phase 2+3 (#872) added per-subsystem feature counters and the public schema doc. Phase 4 makes the long-running charts survive the 60-day retention sweep that Phase 1 introduced.

Without aggregates, the "Monthly new installs (last 12 months)" chart silently truncates as rows age out of raw retention. The "version adoption stacked bar" and any future cohort view have the same issue.

## What ships

Three new aggregate tables, created idempotently at startup:

- `daily_global` (one row per day): `active_day`, `new_installs`, `total`
- `daily_version` (one row per day-version pair): `active_count`
- `daily_features` (one row per day-feature pair): `enabled_count`, `reporting_count`

Nightly snapshot loop fires at startup then every 24h. Each tick snapshots both today (live, evolving) and yesterday (settled before new pings roll `last_seen` forward). Snapshots are upserts so a restart near midnight doesn't double-count. The version-split table clears its day's rows before re-inserting so a version that dropped to zero doesn't linger.

Startup runs `backfillNewInstalls()` once: scans `installs.first_seen` across all rows and seeds `daily_global.new_installs`. This is the only historically-recoverable metric because `first_seen` never changes after row creation. `active_day`, version splits, and feature adoption only start accumulating from today forward.

Dashboard migration: the monthly new-installs chart now reads from `daily_global` aggregated by month instead of `installs` directly. Other charts (daily activity, version trend) stay on raw rows since their 30-day windows fit inside retention.

## Compatibility

Server-internal change only. No client-side or wire impact. Older bindery clients keep posting whatever they post; the server's new tables fill from whatever's in `installs` at snapshot time.

## Test plan

- [x] `go test ./...` green across the whole repo
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] New tests cover: snapshotDay populates all three tables with correct counts for a target day, ignoring installs that pinged a different day; re-snapshot clears stale version rows so a version that dropped to zero disappears; backfillNewInstalls produces correct counts and is idempotent + preserves any pre-existing active_day/total; the monthly chart reads from daily_global rather than installs (verified by seeding aggregates with no corresponding raw rows)

## After merge

The `.github/workflows/ping-server.yml` workflow auto-builds + pushes the GHCR image. Per the rollout plan, this means a single `kubectl set image deployment/bindery-ping bindery-ping=ghcr.io/...:sha-<this-commit>` lands Phase 1+2+3+4 on hetz1 all at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)