### PR TITLE
fix(indexer): hyphenated titles split into keywords like NormalizeRelease (#871)

### DIFF
--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -812,6 +812,16 @@ func TestSigWords(t *testing.T) {
 		{"Ender's Game", []string{"enders", "game"}},
 		// German umlaut transliteration
 		{"Märchen", []string{"maerchen"}},
+		// Hyphenated titles split into separate keywords so the title
+		// side matches a NormalizeRelease'd release-side string (#871).
+		// "to" is dropped as a stopword; "five"/"mother" survive.
+		{"Slaughterhouse-Five", []string{"slaughterhouse", "five"}},
+		{"Mother-to-Mother", []string{"mother", "mother"}},
+		// Other NormalizeRelease separators (dot, underscore, parens,
+		// brackets) split the same way.
+		{"K.A.M.I", nil}, // single-character remainders dropped by min length
+		{"snake_case_title", []string{"snake", "case", "title"}},
+		{"Title (Subtitle)", []string{"title", "subtitle"}},
 	}
 	for _, c := range cases {
 		got := SigWords(c.in)

--- a/internal/indexer/newznab/words.go
+++ b/internal/indexer/newznab/words.go
@@ -11,13 +11,31 @@ var stopWords = map[string]bool{
 	"as": true, "on": true, "be": true,
 }
 
+// sigWordSeparators are the same separator characters that NormalizeRelease
+// (internal/indexer/release.go) treats as word boundaries when normalising
+// release names. Splitting here keeps the two sides of the relevance match
+// symmetric: "Slaughterhouse-Five" on the title side becomes the same
+// [slaughterhouse, five] pair that "Slaughterhouse-Five.epub" yields on the
+// release side after NormalizeRelease. Without this split, single-word
+// hyphenated titles produced one literal-hyphen keyword that could never
+// match the de-hyphenated release string (#871).
+var sigWordSeparators = "._-()[]|"
+
 // SigWords returns the meaningful (non-stop, 3+ char) words from s.
 // Apostrophes are stripped so "Ender's" produces the token "enders",
 // matching the apostrophe-free form used in most release names.
+// Hyphens and other NZB separators are split on so a title like
+// "Slaughterhouse-Five" yields [slaughterhouse, five] (#871).
 // German umlauts are transliterated (ä→ae etc.) to match NormalizeRelease.
 func SigWords(s string) []string {
 	var out []string
-	for _, w := range strings.Fields(strings.ToLower(s)) {
+	normalised := strings.Map(func(r rune) rune {
+		if strings.ContainsRune(sigWordSeparators, r) {
+			return ' '
+		}
+		return r
+	}, strings.ToLower(s))
+	for _, w := range strings.Fields(normalised) {
 		w = strings.ReplaceAll(w, "'", "")
 		w = transliterateUmlauts(w)
 		if len(w) >= 3 && !stopWords[w] {

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -219,6 +219,32 @@ func TestFilterRelevantApostrophe(t *testing.T) {
 	}
 }
 
+// TestFilterRelevantHyphenatedTitle is a regression test for #871: titles
+// whose entire significant content is a single hyphenated token (e.g.
+// "Slaughterhouse-Five") were tokenised by SigWords as one literal-hyphen
+// keyword, which never matched the de-hyphenated release-side string. Now
+// that SigWords splits on the same separators as NormalizeRelease, the
+// hyphenated title side and the release side line up.
+func TestFilterRelevantHyphenatedTitle(t *testing.T) {
+	results := toResults(
+		"Slaughterhouse-Five by Kurt Vonnegut EPUB",
+		"Kurt.Vonnegut.Slaughterhouse.Five.RETAIL.epub",
+		"Some.Unrelated.Book.epub",
+	)
+	got := filterRelevant(results, "Slaughterhouse-Five", "Kurt Vonnegut", nil)
+	for _, want := range []string{
+		"Slaughterhouse-Five by Kurt Vonnegut EPUB",
+		"Kurt.Vonnegut.Slaughterhouse.Five.RETAIL.epub",
+	} {
+		if !contains(got, want) {
+			t.Errorf("expected %q in results, got %v", want, resultTitles(got))
+		}
+	}
+	if contains(got, "Some.Unrelated.Book.epub") {
+		t.Error("unrelated release must not pass")
+	}
+}
+
 // TestFilterRelevantEditionQualifier — regression test for issue #283.
 // filterRelevant must accept real NZB releases for a book whose metadata
 // title carries a parenthesised edition qualifier. Before the fix,


### PR DESCRIPTION
## Summary

- @eliseban reported in #871 that any book whose entire significant title is one hyphenated token (e.g. **Slaughterhouse-Five**) had every matching release dropped at the relevance filter.
- Root cause is asymmetric hyphen handling between the two sides of the match. \`NormalizeRelease\` treats \`-\` as a separator and replaces it with a space, but \`SigWords\` only splits on whitespace, so \`Slaughterhouse-Five\` produced a single literal-hyphen keyword that the de-hyphenated release-side string could never match.
- Fix is to pre-convert the same separator set as \`NormalizeRelease\` (\`._-()[]|\`) to spaces in \`SigWords\` before tokenising. Multi-word titles are unchanged (they already went through the multi-keyword \`ContainsPhrase\` path). Single hyphenated titles now produce \`[slaughterhouse, five]\` and join the same path.

Reporter included the root-cause diagnosis and the suggested fix shape; this PR implements suggestion 1.

## Test plan

- [x] \`go test ./internal/indexer/...\` green
- [x] \`go test ./...\` clean across the repo
- [x] New regression tests in \`searcher_test.go\` (\`TestFilterRelevantHyphenatedTitle\`) and \`client_test.go\` (\`TestSigWords\` cases for hyphenated, dotted, underscore, bracketed forms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)