### PR TITLE
fix(downloader): fetch torrents through Bindery, submit via metainfo (#873)

### DIFF
--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
+	"github.com/vavallee/bindery/internal/httpsec"
 )
 
 // Client interacts with the Transmission RPC API.
@@ -29,9 +30,12 @@ type Client struct {
 	initErr   error
 	username  string
 	password  string
-	http      *http.Client
+	http      *http.Client // Transmission RPC transport (validated target)
+	fetchHTTP *http.Client // used to fetch .torrent content from indexers before submission
 	sessionID string
 	mu        sync.Mutex
+	// validateTorrentURL is injectable for tests; nil uses httpsec.ValidateOutboundURL.
+	validateTorrentURL func(string) error
 }
 
 // New creates a Transmission client.
@@ -45,9 +49,13 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 	}
 
 	client := &Client{
-		username: username,
-		password: password,
-		http:     &http.Client{Timeout: 15 * time.Second},
+		username:  username,
+		password:  password,
+		http:      &http.Client{Timeout: 15 * time.Second},
+		fetchHTTP: &http.Client{Timeout: 60 * time.Second},
+		validateTorrentURL: func(raw string) error {
+			return httpsec.ValidateOutboundURL(raw, httpsec.PolicyLAN)
+		},
 	}
 
 	rpcURL, err := buildRPCURL(scheme, host, port, urlBase)
@@ -78,13 +86,30 @@ func (c *Client) Test(ctx context.Context) error {
 	return nil
 }
 
-// AddTorrent submits a magnet link or torrent URL to Transmission for download.
+// AddTorrent submits a magnet link or torrent URL to Transmission for
+// download. For magnet links the URL is passed through to Transmission's
+// filename arg unchanged (the daemon dials the DHT/trackers itself, no HTTP
+// fetch involved). For http(s) URLs Bindery fetches the .torrent file
+// itself and submits the bytes via metainfo, base64-encoded. This is the
+// same shape SAB (#864) and NZBGet (#837) use: in containerised setups
+// where the download client is on a different network than the indexer
+// (e.g. transmission behind a VPN container), the daemon can't fetch the
+// URL, so it sits in retry until Bindery's request deadline expires.
+// Reported by @Bclark117 in #873.
 func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, downloadDir string) (int64, error) {
-	args := map[string]interface{}{
-		"filename": magnetOrURL,
-	}
+	args := map[string]interface{}{}
 	if downloadDir != "" {
 		args["download-dir"] = downloadDir
+	}
+
+	if isMagnetLink(magnetOrURL) {
+		args["filename"] = magnetOrURL
+	} else {
+		content, err := c.fetchTorrentContent(ctx, magnetOrURL)
+		if err != nil {
+			return 0, err
+		}
+		args["metainfo"] = base64.StdEncoding.EncodeToString(content)
 	}
 
 	req, err := c.buildRequest(ctx, "torrent-add", args)
@@ -173,6 +198,48 @@ func (c *Client) RemoveTorrent(ctx context.Context, torrentID int64, deleteFiles
 	}
 	_, err = c.doRequest(req)
 	return err
+}
+
+// isMagnetLink reports whether magnetOrURL is a magnet: scheme URL. Magnet
+// links carry trackers and infohash inline, so Transmission can resolve
+// them via DHT/trackers without needing to make an outbound HTTP fetch.
+// HTTP(S) URLs to .torrent files are the case Bindery now fetches itself.
+func isMagnetLink(magnetOrURL string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(magnetOrURL)), "magnet:")
+}
+
+// validateTorrentFetchURL applies the same SSRF policy SAB/NZBGet use
+// before reaching out for the .torrent content. Loopback and link-local
+// addresses are blocked; private RFC1918 ranges are permitted under
+// PolicyLAN (typical homelab indexer setup).
+func (c *Client) validateTorrentFetchURL(raw string) error {
+	if c.validateTorrentURL == nil {
+		return httpsec.ValidateOutboundURL(raw, httpsec.PolicyLAN)
+	}
+	return c.validateTorrentURL(raw)
+}
+
+// fetchTorrentContent downloads the .torrent file Bindery would otherwise
+// have asked Transmission to fetch. 50 MB cap matches the NZB fetch cap on
+// SAB/NZBGet so an indexer returning HTML by mistake can't OOM the process.
+func (c *Client) fetchTorrentContent(ctx context.Context, torrentURL string) ([]byte, error) {
+	if err := c.validateTorrentFetchURL(torrentURL); err != nil {
+		return nil, fmt.Errorf("fetch torrent: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, torrentURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetch torrent: %w", err)
+	}
+	resp, err := c.fetchHTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch torrent from indexer: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 256))
+		return nil, fmt.Errorf("fetch torrent: indexer returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 50<<20)) // 50 MB cap
 }
 
 // buildRequest constructs a Transmission RPC request.

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -2,7 +2,10 @@ package transmission
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +14,13 @@ import (
 	"syscall"
 	"testing"
 )
+
+// newJSONDecoder is a wrapper so tests don't import encoding/json
+// alongside the helpers; keeps the helper section narrow.
+func newJSONDecoder(r io.Reader) *json.Decoder { return json.NewDecoder(r) }
+
+// decodeBase64 is a wrapper around base64.StdEncoding.DecodeString.
+func decodeBase64(s string) ([]byte, error) { return base64.StdEncoding.DecodeString(s) }
 
 // newTestClient creates a Client pointing at the given test server URL.
 func newTestClient(serverURL, username, password string) *Client {
@@ -463,6 +473,188 @@ func TestTest_ServerError_NoHint(t *testing.T) {
 	for _, hint := range []string{"Docker network", "host firewall is rejecting", "firewall or proxy"} {
 		if strings.Contains(msg, hint) {
 			t.Errorf("clean server error must not produce hint %q; got: %q", hint, msg)
+		}
+	}
+}
+
+const testTorrentContent = "d8:announce32:http://tracker.example.com/announce4:infod6:lengthi32e4:name8:test.txt12:piece lengthi32e6:pieces20:" +
+	"01234567890123456789ee"
+
+// allowTorrentFetch bypasses the SSRF guard so a test can point at a
+// loopback httptest server. Mirrors allowNZBFetch in the sabnzbd tests.
+func allowTorrentFetch(c *Client) {
+	c.validateTorrentURL = func(string) error { return nil }
+}
+
+// readRPCArgs decodes the JSON-RPC request body and returns the arguments
+// map. Used to assert against the metainfo/filename keys Transmission sees.
+func readRPCArgs(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	body := struct {
+		Method    string         `json:"method"`
+		Arguments map[string]any `json:"arguments"`
+	}{}
+	if err := decodeJSONBody(r, &body); err != nil {
+		t.Fatalf("decode rpc body: %v", err)
+	}
+	return body.Arguments
+}
+
+func decodeJSONBody(r *http.Request, dst any) error {
+	defer r.Body.Close()
+	dec := newJSONDecoder(r.Body)
+	return dec.Decode(dst)
+}
+
+// TestAddTorrent_HTTPURLFetchesContent verifies that an http(s) URL is
+// fetched by Bindery (not Transmission) and submitted as metainfo. This
+// is the fix path for the VPN-isolated-transmission case in #873.
+func TestAddTorrent_HTTPURLFetchesContent(t *testing.T) {
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-bittorrent")
+		_, _ = w.Write([]byte(testTorrentContent))
+	}))
+	defer indexerSrv.Close()
+
+	var gotArgs map[string]any
+	transSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotArgs = readRPCArgs(t, r)
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{"torrent-added":{"id":42,"name":"x"}}}`))
+	}))
+	defer transSrv.Close()
+
+	c := newTestClient(transSrv.URL, "", "")
+	allowTorrentFetch(c)
+
+	id, err := c.AddTorrent(context.Background(), indexerSrv.URL+"/file.torrent", "")
+	if err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if id != 42 {
+		t.Errorf("id = %d, want 42", id)
+	}
+	if gotArgs["filename"] != nil {
+		t.Errorf("filename arg must not be set when content is sent via metainfo; got: %v", gotArgs["filename"])
+	}
+	meta, ok := gotArgs["metainfo"].(string)
+	if !ok || meta == "" {
+		t.Fatalf("metainfo arg missing or non-string; got: %v", gotArgs["metainfo"])
+	}
+	decoded, err := decodeBase64(meta)
+	if err != nil {
+		t.Fatalf("metainfo not base64: %v", err)
+	}
+	if string(decoded) != testTorrentContent {
+		t.Errorf("metainfo payload mismatch:\n want %q\n got  %q", testTorrentContent, string(decoded))
+	}
+}
+
+// TestAddTorrent_MagnetLinkSkipsFetch verifies the magnet-link
+// pass-through preserves the old behaviour: no HTTP fetch, magnet URL
+// goes directly into Transmission's filename arg.
+func TestAddTorrent_MagnetLinkSkipsFetch(t *testing.T) {
+	fetchCalled := false
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCalled = true
+	}))
+	defer indexerSrv.Close()
+
+	var gotArgs map[string]any
+	transSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotArgs = readRPCArgs(t, r)
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{"torrent-added":{"id":7,"name":"m"}}}`))
+	}))
+	defer transSrv.Close()
+
+	c := newTestClient(transSrv.URL, "", "")
+	allowTorrentFetch(c)
+
+	magnet := "magnet:?xt=urn:btih:abc123&tr=" + url.QueryEscape(indexerSrv.URL)
+	id, err := c.AddTorrent(context.Background(), magnet, "")
+	if err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if id != 7 {
+		t.Errorf("id = %d, want 7", id)
+	}
+	if fetchCalled {
+		t.Error("magnet link path must not fetch the URL through Bindery")
+	}
+	if gotArgs["metainfo"] != nil {
+		t.Errorf("magnet path must not set metainfo; got: %v", gotArgs["metainfo"])
+	}
+	if gotArgs["filename"] != magnet {
+		t.Errorf("magnet path filename mismatch; got: %v", gotArgs["filename"])
+	}
+}
+
+// TestAddTorrent_HTTPURLFetchFailure verifies that when the indexer
+// returns an error, AddTorrent fails at the fetch step and never reaches
+// Transmission. This is the diagnostic path: a clear "indexer returned
+// HTTP X" beats Transmission timing out 15 seconds later.
+func TestAddTorrent_HTTPURLFetchFailure(t *testing.T) {
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+	}))
+	defer indexerSrv.Close()
+
+	transSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("Transmission must not be called when torrent fetch fails")
+	}))
+	defer transSrv.Close()
+
+	c := newTestClient(transSrv.URL, "", "")
+	allowTorrentFetch(c)
+
+	_, err := c.AddTorrent(context.Background(), indexerSrv.URL+"/file.torrent", "")
+	if err == nil {
+		t.Fatal("expected error on indexer 401")
+		return
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected HTTP 401 in error; got: %v", err)
+	}
+}
+
+// TestAddTorrent_HTTPURLSSRFBlocked verifies the validateTorrentURL guard
+// rejects loopback URLs in production (when the test bypass is not
+// applied). Symmetric with the SAB and NZBGet SSRF tests.
+func TestAddTorrent_HTTPURLSSRFBlocked(t *testing.T) {
+	transSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("Transmission must not be called when SSRF guard blocks the indexer URL")
+	}))
+	defer transSrv.Close()
+
+	c := newTestClient(transSrv.URL, "", "")
+	// Do NOT call allowTorrentFetch; the guard must be active.
+
+	_, err := c.AddTorrent(context.Background(), "http://127.0.0.1:9999/file.torrent", "")
+	if err == nil {
+		t.Fatal("expected SSRF guard to block loopback URL")
+		return
+	}
+	if !strings.Contains(err.Error(), "url not allowed") {
+		t.Errorf("expected 'url not allowed' in error; got: %v", err)
+	}
+}
+
+// TestIsMagnetLink verifies the scheme detection that switches between
+// pass-through and fetch-then-submit. Tested independently so a future
+// refactor that breaks the detection (e.g. case-sensitivity) shows up
+// here rather than as a Transmission-side failure.
+func TestIsMagnetLink(t *testing.T) {
+	cases := map[string]bool{
+		"magnet:?xt=urn:btih:abc":  true,
+		"MAGNET:?xt=urn:btih:abc":  true,
+		"  magnet:?xt=urn:btih:a ": true,
+		"http://x/file.torrent":    false,
+		"https://x/file.torrent":   false,
+		"":                         false,
+		"magneturl":                false,
+	}
+	for in, want := range cases {
+		if got := isMagnetLink(in); got != want {
+			t.Errorf("isMagnetLink(%q) = %v, want %v", in, got, want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- @Bclark117 reported in #873 that Transmission times out on every grab when run inside \`haugene/transmission-openvpn\` (Transmission's outbound traffic routes through a VPN container) even though Test-Connection passes and the network is otherwise fine.
- Same root cause as #864 (SAB) and #837 (NZBGet): Bindery was passing the indexer URL via Transmission's \`filename\` arg, which makes the daemon fetch the URL itself. When the daemon can't reach the indexer the call sits in retry until Bindery's 15s deadline trips.
- Fix mirrors the established pattern: for http(s) URLs Bindery fetches the .torrent file through its own HTTP client (which has the indexer credentials and network path) and submits the content to Transmission as base64 via \`metainfo\`. Magnet links stay on the filename pass-through (Transmission resolves them via DHT/trackers without an outbound HTTP fetch).

Same \`httpsec.PolicyLAN\` SSRF guard and 50 MB cap as the other clients.

## Behaviour

- Magnet URL → same as before, no Bindery fetch, magnet handed to Transmission via \`filename\`. Verified by \`TestAddTorrent_MagnetLinkSkipsFetch\`.
- HTTP(S) URL → Bindery fetches, base64-encodes, submits via \`metainfo\`. Verified by \`TestAddTorrent_HTTPURLFetchesContent\`.
- HTTP(S) URL with failing indexer → AddTorrent fails at the fetch step, Transmission is never called, error names the HTTP status. Verified by \`TestAddTorrent_HTTPURLFetchFailure\`.
- HTTP(S) loopback URL with the guard active → blocked by \`httpsec\`, Transmission never called. Verified by \`TestAddTorrent_HTTPURLSSRFBlocked\`.

## Test plan

- [x] \`go test ./internal/downloader/...\` green
- [x] \`go test ./...\` clean across the repo
- [x] \`go build ./...\` clean
- [x] All existing magnet-link tests keep passing (\`TestAddTorrent_NewTorrent\`, \`TestAddTorrent_DuplicateTorrent\`, \`TestAddTorrent_WithDownloadDir\`, etc.) since they go through the pass-through path

🤖 Generated with [Claude Code](https://claude.com/claude-code)