### PR TITLE
fix(importer): library scan reconciles Imported books missing their file (#875)

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -2118,8 +2118,19 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 	// Precompute per-book reconciliation data once. The title tier previously
 	// called normalizeTitle(book.Title) inside the per-file loop — a pure,
 	// loop-invariant function recomputed files×books times. Hoisting it here
-	// makes it run once per book. Only "wanted" books can reconcile, so the
-	// candidate set is filtered down up front, and ASIN lookups become O(1).
+	// makes it run once per book. The candidate set is filtered down up front
+	// and ASIN lookups become O(1).
+	//
+	// Two book states count as candidates:
+	//   - Wanted: the book has no file yet by definition; this is the main case.
+	//   - Imported with no file actually on disk: covers two situations the
+	//     scanner used to ignore entirely. (a) #875: Calibre import sets
+	//     Status=Imported on every book it creates, but in container setups
+	//     where Calibre's library mount differs from Bindery's view, FilePath
+	//     stays empty and the user's 3700 epubs found 0 reconciliation
+	//     targets. (b) The user moved or renamed their files, leaving Imported
+	//     rows pointing at locations that no longer exist; re-scan now relinks
+	//     them rather than leaving the rows orphaned.
 	wantedBooks := make([]scanBook, 0, len(allBooks))
 	asinIndex := make(map[string][]scanBook)
 	// booksByAuthor maps an author ID to the indices (into wantedBooks, i.e. in
@@ -2129,7 +2140,7 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 	booksByAuthor := make(map[int64][]int)
 	for i := range allBooks {
 		b := &allBooks[i]
-		if b.Status != models.BookStatusWanted {
+		if !isReconcileCandidate(b) {
 			continue
 		}
 		sb := scanBook{book: b, normTitle: normalizeTitle(b.Title)}
@@ -2401,6 +2412,45 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		"reconciled", reconciled, "unmatched", unmatched, "tagReadFailed", tagReadFailed)
 
 	s.writeScanResult(ctx, len(foundFiles), reconciled, unmatched, tagReadFailed, unmatchedFiles)
+}
+
+// isReconcileCandidate reports whether a book should be considered for
+// file-to-book matching during library scan. Returns true for:
+//
+//   - Status=Wanted books (the default case: the book has no file yet).
+//   - Status=Imported books whose recorded file paths either are empty or
+//     point at locations that no longer exist on disk. This covers #875
+//     (Calibre import leaves Status=Imported with FilePath unpopulated when
+//     Calibre's library mount differs from Bindery's view) and the related
+//     case of users moving their library and re-running a scan.
+//
+// Books with a valid on-disk file at any recorded path are skipped — the
+// scanner has no reason to re-reconcile a file that's already where it
+// should be, and re-attaching would churn book_files rows for no benefit.
+func isReconcileCandidate(b *models.Book) bool {
+	if b == nil {
+		return false
+	}
+	if b.Status == models.BookStatusWanted {
+		return true
+	}
+	if b.Status != models.BookStatusImported {
+		return false
+	}
+	// Imported books reconcile only when no path we have on file actually
+	// resolves to a real file. A book row may carry up to three legacy
+	// path columns plus the modern book_files rows; the scanner already
+	// trusts the trackedPaths set for book_files, so here we only need to
+	// gate on the legacy columns.
+	for _, p := range []string{b.FilePath, b.EbookFilePath, b.AudiobookFilePath} {
+		if p == "" {
+			continue
+		}
+		if _, err := os.Stat(p); err == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // unmatchedFile represents a file that could not be reconciled during library scan.

--- a/internal/importer/scanner_extra_test.go
+++ b/internal/importer/scanner_extra_test.go
@@ -113,6 +113,171 @@ func TestScanLibrary_ReconcilesMatchingBook(t *testing.T) {
 	}
 }
 
+// TestScanLibrary_ReconcilesImportedWithEmptyFilePath is the #875 repro:
+// Calibre import creates books with Status=Imported, but in container
+// setups where Calibre's mount differs from Bindery's view the FilePath
+// stays empty. Pre-fix the scanner skipped these entirely (the candidate
+// filter required Status=Wanted), so a 3700-epub library reconciled zero
+// books until each author was metadata-refreshed.
+func TestScanLibrary_ReconcilesImportedWithEmptyFilePath(t *testing.T) {
+	libDir := t.TempDir()
+	epub := filepath.Join(libDir, "Dark Matter.epub")
+	if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, books, authors, ctx := scannerFixture(t, libDir)
+	author := &models.Author{ForeignID: "OL1A", Name: "A", SortName: "A"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "calibre:book:1", AuthorID: author.ID,
+		Title: "Dark Matter", Status: models.BookStatusImported, FilePath: "",
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	got, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FilePath != epub {
+		t.Errorf("expected Imported book with empty FilePath to reconcile to %q, got %q", epub, got.FilePath)
+	}
+}
+
+// TestScanLibrary_ReconcilesImportedWithMissingFile covers the related
+// case where the recorded FilePath points at a location the file no
+// longer exists at (user moved the library, file got renamed, etc.).
+// Pre-fix these orphaned rows stayed orphaned forever.
+func TestScanLibrary_ReconcilesImportedWithMissingFile(t *testing.T) {
+	libDir := t.TempDir()
+	epub := filepath.Join(libDir, "Recursion.epub")
+	if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, books, authors, ctx := scannerFixture(t, libDir)
+	author := &models.Author{ForeignID: "OL2A", Name: "B", SortName: "B"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "calibre:book:2", AuthorID: author.ID,
+		Title: "Recursion", Status: models.BookStatusImported,
+		FilePath: "/this/path/does/not/exist/Recursion.epub",
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	got, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FilePath != epub {
+		t.Errorf("expected Imported book with stale FilePath to reconcile to %q, got %q", epub, got.FilePath)
+	}
+}
+
+// TestScanLibrary_LeavesImportedWithTrackedFile verifies the candidate
+// filter does not double-attach an Imported book whose file is already
+// on disk and recorded in book_files. Pre-fix, an over-broad filter
+// would have re-reconciled the book and the title tier would have
+// rejected the duplicate at AddBookFile time (UNIQUE on path) but the
+// pre-AddBookFile diagnostics would noisily log every attempted match.
+//
+// The book is created via AddBookFile so book_files is correctly
+// populated and the scanner's trackedPaths set picks up the path. The
+// scanner sees a tracked path and skips the file entirely.
+func TestScanLibrary_LeavesImportedWithTrackedFile(t *testing.T) {
+	libDir := t.TempDir()
+	epubA := filepath.Join(libDir, "First.epub")
+	if err := os.WriteFile(epubA, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, books, authors, ctx := scannerFixture(t, libDir)
+	author := &models.Author{ForeignID: "OL3A", Name: "C", SortName: "C"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	bookA := &models.Book{
+		ForeignID: "calibre:book:A", AuthorID: author.ID,
+		Title: "First", Status: models.BookStatusImported,
+	}
+	if err := books.Create(ctx, bookA); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, bookA.ID, "ebook", epubA); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	filesA, err := books.ListFiles(ctx, bookA.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filesA) != 1 || filesA[0].Path != epubA {
+		t.Errorf("bookA must keep exactly one book_files row at %q; got %d entries: %+v", epubA, len(filesA), filesA)
+	}
+}
+
+// TestIsReconcileCandidate covers the candidate-filter helper in
+// isolation so a future refactor that breaks the precedence of these
+// cases shows up here rather than as a scanner-level surprise.
+func TestIsReconcileCandidate(t *testing.T) {
+	t.Run("wanted is always a candidate", func(t *testing.T) {
+		if !isReconcileCandidate(&models.Book{Status: models.BookStatusWanted}) {
+			t.Error("Wanted should be a candidate")
+		}
+		if !isReconcileCandidate(&models.Book{Status: models.BookStatusWanted, FilePath: "/already/has/file"}) {
+			t.Error("Wanted should remain a candidate even with FilePath set")
+		}
+	})
+	t.Run("imported with no recorded paths is a candidate", func(t *testing.T) {
+		if !isReconcileCandidate(&models.Book{Status: models.BookStatusImported}) {
+			t.Error("Imported with empty FilePath should be a candidate")
+		}
+	})
+	t.Run("imported with nonexistent path is a candidate", func(t *testing.T) {
+		b := &models.Book{Status: models.BookStatusImported, FilePath: "/no/such/file"}
+		if !isReconcileCandidate(b) {
+			t.Error("Imported with nonexistent FilePath should be a candidate")
+		}
+	})
+	t.Run("imported with existing path is not a candidate", func(t *testing.T) {
+		tmp := t.TempDir()
+		f := filepath.Join(tmp, "exists.epub")
+		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		b := &models.Book{Status: models.BookStatusImported, FilePath: f}
+		if isReconcileCandidate(b) {
+			t.Error("Imported with existing FilePath should not be a candidate")
+		}
+	})
+	t.Run("downloading and downloaded are not candidates", func(t *testing.T) {
+		for _, s := range []string{models.BookStatusDownloading, models.BookStatusDownloaded, models.BookStatusSkipped} {
+			if isReconcileCandidate(&models.Book{Status: s}) {
+				t.Errorf("status %q should not be a candidate", s)
+			}
+		}
+	})
+	t.Run("nil is not a candidate", func(t *testing.T) {
+		if isReconcileCandidate(nil) {
+			t.Error("nil book should not be a candidate")
+		}
+	})
+}
+
 // TestScanLibrary_NonBookFilesIgnored — extensions not in bookExtensions
 // (jpg, nfo, etc.) should not appear in the walked list.
 func TestScanLibrary_NonBookFilesIgnored(t *testing.T) {


### PR DESCRIPTION
## Summary

- @Jashun44 reported in #875 that Calibre import + library scan reconciled zero of their 3700 epubs until each author was metadata-refreshed.
- Root cause documented in the issue: \`scanner.go:2132\` only considered \`Status=Wanted\` books as reconciliation candidates, but \`calibre/importer.go:575\` always sets \`Status=Imported\` (with FilePath empty when Calibre's mount differs from Bindery's view).
- Fix is to extend the candidate filter to include \`Status=Imported\` books whose recorded paths (\`FilePath\`, \`EbookFilePath\`, \`AudiobookFilePath\`) either are empty or point at locations that no longer exist on disk. Imported books with a valid file at any recorded path stay out of the candidate set (no re-attaching, no churn).

This also fixes a related orphan-row case: a user moving their library and re-running a scan would previously leave Imported rows pointing at stale paths forever. They now relink to the new location.

## Behaviour

- Wanted book → reconciles as before.
- Imported with empty FilePath (Calibre canonical case, #875) → reconciles.
- Imported with FilePath pointing at a path that no longer exists (moved library) → reconciles to wherever the file actually is.
- Imported with FilePath pointing at a valid on-disk file → not in candidate set, scanner leaves it alone.
- Downloading/Downloaded/Skipped → unchanged, not in candidate set.

## Test plan

- [x] \`go test ./internal/importer/...\` green
- [x] \`go test ./...\` clean across the repo
- [x] \`go build ./...\` clean
- [x] New unit tests cover all six \`isReconcileCandidate\` cases (wanted always, imported empty, imported nonexistent, imported existing-file negative, downloading/downloaded/skipped negative, nil negative)
- [x] New integration tests cover: Imported with empty FilePath reconciles to discovered epub; Imported with stale FilePath reconciles to discovered epub at new location; Imported with valid on-disk file at a tracked book_files path is not double-attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)