### PR TITLE
fix(db): populate book.Author in List and Get responses (closes #882)

### DIFF
--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -83,7 +83,7 @@ func (r *BookRepo) List(ctx context.Context) ([]models.Book, error) {
 }
 
 func (r *BookRepo) ListByUser(ctx context.Context, userID int64) ([]models.Book, error) {
-	where, args := QueryScopeFor("books.owner_user_id","WHERE excluded = 0", userID)
+	where, args := QueryScopeFor("books.owner_user_id", "WHERE excluded = 0", userID)
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where+" ORDER BY sort_title", args)
 }
 
@@ -97,7 +97,7 @@ func (r *BookRepo) ListByAuthor(ctx context.Context, authorID int64) ([]models.B
 }
 
 func (r *BookRepo) ListByAuthorAndUser(ctx context.Context, authorID, userID int64) ([]models.Book, error) {
-	where, args := QueryScopeFor("books.owner_user_id","WHERE author_id = ? AND excluded = 0", userID, authorID)
+	where, args := QueryScopeFor("books.owner_user_id", "WHERE author_id = ? AND excluded = 0", userID, authorID)
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where+" ORDER BY release_date", args)
 }
 
@@ -111,7 +111,7 @@ func (r *BookRepo) ListByStatus(ctx context.Context, status string) ([]models.Bo
 }
 
 func (r *BookRepo) ListByStatusAndUser(ctx context.Context, status string, userID int64) ([]models.Book, error) {
-	where, args := QueryScopeFor("books.owner_user_id","WHERE status = ? AND books.monitored = 1 AND excluded = 0", userID, status)
+	where, args := QueryScopeFor("books.owner_user_id", "WHERE status = ? AND books.monitored = 1 AND excluded = 0", userID, status)
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where+" ORDER BY sort_title", args)
 }
 

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -52,25 +52,38 @@ first_audiobook AS (
 // (so multi-file books see the first registered path), with the legacy column
 // as a fallback for rows that pre-date the migration and have not yet been
 // re-imported via AddBookFile.
-const bookColumns = `books.id, foreign_id, author_id, title, sort_title, original_title, description,
-	image_url, release_date, genres, average_rating, ratings_count, monitored, status,
-	any_edition_ok, selected_edition_id, file_path, language, media_type, narrator, duration_seconds, asin,
-	calibre_id, metadata_provider, last_metadata_refresh_at, created_at, updated_at,
+//
+// The trailing author columns hydrate book.Author for List/Get responses
+// (#882): the frontend's Books page and Book detail page read
+// book.author.authorName and were rendering empty for every row when the
+// join was missing. LEFT JOIN so an orphan author_id (author row deleted
+// but book still references it) returns NULL columns rather than dropping
+// the book from the result; the scan loop handles the NULLs.
+const bookColumns = `books.id, books.foreign_id, books.author_id, books.title, books.sort_title,
+	books.original_title, books.description, books.image_url, books.release_date,
+	books.genres, books.average_rating, books.ratings_count, books.monitored, books.status,
+	books.any_edition_ok, books.selected_edition_id, books.file_path, books.language,
+	books.media_type, books.narrator, books.duration_seconds, books.asin,
+	books.calibre_id, books.metadata_provider, books.last_metadata_refresh_at,
+	books.created_at, books.updated_at,
 	COALESCE(fe.path, COALESCE(books.ebook_file_path, '')),
 	COALESCE(fa.path, COALESCE(books.audiobook_file_path, '')),
-	excluded`
+	books.excluded,
+	au.id, au.foreign_id, au.name, au.sort_name`
 
 // bookJoins are the LEFT JOINs that attach the first_ebook and first_audiobook
-// CTE results to the books table. Must follow the FROM books clause.
+// CTE results plus the author row to the books table. Must follow the FROM
+// books clause.
 const bookJoins = `LEFT JOIN first_ebook    fe ON fe.book_id = books.id
-LEFT JOIN first_audiobook fa ON fa.book_id = books.id`
+LEFT JOIN first_audiobook fa ON fa.book_id = books.id
+LEFT JOIN authors         au ON au.id = books.author_id`
 
 func (r *BookRepo) List(ctx context.Context) ([]models.Book, error) {
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE excluded = 0 ORDER BY sort_title", nil)
 }
 
 func (r *BookRepo) ListByUser(ctx context.Context, userID int64) ([]models.Book, error) {
-	where, args := QueryScope("WHERE excluded = 0", userID)
+	where, args := QueryScopeFor("books.owner_user_id","WHERE excluded = 0", userID)
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where+" ORDER BY sort_title", args)
 }
 
@@ -84,7 +97,7 @@ func (r *BookRepo) ListByAuthor(ctx context.Context, authorID int64) ([]models.B
 }
 
 func (r *BookRepo) ListByAuthorAndUser(ctx context.Context, authorID, userID int64) ([]models.Book, error) {
-	where, args := QueryScope("WHERE author_id = ? AND excluded = 0", userID, authorID)
+	where, args := QueryScopeFor("books.owner_user_id","WHERE author_id = ? AND excluded = 0", userID, authorID)
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where+" ORDER BY release_date", args)
 }
 
@@ -94,17 +107,17 @@ func (r *BookRepo) ListByAuthorIncludingExcluded(ctx context.Context, authorID i
 }
 
 func (r *BookRepo) ListByStatus(ctx context.Context, status string) ([]models.Book, error) {
-	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE status = ? AND monitored = 1 AND excluded = 0 ORDER BY sort_title", []any{status})
+	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE status = ? AND books.monitored = 1 AND excluded = 0 ORDER BY sort_title", []any{status})
 }
 
 func (r *BookRepo) ListByStatusAndUser(ctx context.Context, status string, userID int64) ([]models.Book, error) {
-	where, args := QueryScope("WHERE status = ? AND monitored = 1 AND excluded = 0", userID, status)
+	where, args := QueryScopeFor("books.owner_user_id","WHERE status = ? AND books.monitored = 1 AND excluded = 0", userID, status)
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where+" ORDER BY sort_title", args)
 }
 
 // ListByStatusIncludingExcluded returns books with the given status regardless of excluded flag.
 func (r *BookRepo) ListByStatusIncludingExcluded(ctx context.Context, status string) ([]models.Book, error) {
-	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE status = ? AND monitored = 1 ORDER BY sort_title", []any{status})
+	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE status = ? AND books.monitored = 1 ORDER BY sort_title", []any{status})
 }
 
 func (r *BookRepo) GetByID(ctx context.Context, id int64) (*models.Book, error) {
@@ -119,7 +132,7 @@ func (r *BookRepo) GetByID(ctx context.Context, id int64) (*models.Book, error) 
 }
 
 func (r *BookRepo) GetByForeignID(ctx context.Context, foreignID string) (*models.Book, error) {
-	books, err := r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE foreign_id = ?", []any{foreignID})
+	books, err := r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE books.foreign_id = ?", []any{foreignID})
 	if err != nil {
 		return nil, err
 	}
@@ -409,6 +422,10 @@ func (r *BookRepo) query(ctx context.Context, q string, args []any) ([]models.Bo
 		var b models.Book
 		var monitored, anyEditionOK, excluded int
 		var genresStr string
+		// Author columns from the LEFT JOIN. Nullable since the join may not
+		// match when author_id points at a deleted author row.
+		var authorID sql.NullInt64
+		var authorForeignID, authorName, authorSortName sql.NullString
 		err := rows.Scan(
 			&b.ID, &b.ForeignID, &b.AuthorID, &b.Title, &b.SortTitle,
 			&b.OriginalTitle, &b.Description, &b.ImageURL, &b.ReleaseDate,
@@ -420,6 +437,7 @@ func (r *BookRepo) query(ctx context.Context, q string, args []any) ([]models.Bo
 			&b.CreatedAt, &b.UpdatedAt,
 			&b.EbookFilePath, &b.AudiobookFilePath,
 			&excluded,
+			&authorID, &authorForeignID, &authorName, &authorSortName,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan book: %w", err)
@@ -430,6 +448,20 @@ func (r *BookRepo) query(ctx context.Context, q string, args []any) ([]models.Bo
 		_ = json.Unmarshal([]byte(genresStr), &b.Genres)
 		if b.Genres == nil {
 			b.Genres = []string{}
+		}
+		// Populate the joined-author projection (ID + foreign ID + name +
+		// sort name) when the LEFT JOIN found a row. Other Author fields
+		// stay zero; the frontend reads authorName and the URL builder
+		// uses book.authorId, so a minimal projection is enough. Callers
+		// that need the full Author (description, image, ratings, etc.)
+		// should still go through AuthorRepo.GetByID.
+		if authorID.Valid {
+			b.Author = &models.Author{
+				ID:        authorID.Int64,
+				ForeignID: authorForeignID.String,
+				Name:      authorName.String,
+				SortName:  authorSortName.String,
+			}
 		}
 		books = append(books, b)
 	}

--- a/internal/db/books_coverage_test.go
+++ b/internal/db/books_coverage_test.go
@@ -193,3 +193,123 @@ func TestBookRepo_FindByAuthorAndTitleCaseInsensitive(t *testing.T) {
 		t.Error("expected nil for unrelated title")
 	}
 }
+
+// TestBookRepo_ListPopulatesAuthor is the regression test for #882. The
+// Books page and book detail page in the frontend both read
+// book.author.authorName; before the LEFT JOIN to authors was added, that
+// field was nil on every row and the UI rendered empty author columns.
+func TestBookRepo_ListPopulatesAuthor(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	bookRepo := NewBookRepo(database)
+	authorRepo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	a := mkAuthor(t, authorRepo, ctx, "OL-LIST-AUTHOR")
+	b := mkBook(t, bookRepo, ctx, a.ID, "OL-LIST-BOOK", "The Book", models.BookStatusWanted)
+
+	// List
+	all, err := bookRepo.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(all))
+	}
+	if all[0].Author == nil {
+		t.Fatal("List: book.Author is nil; expected joined author projection")
+	}
+	if all[0].Author.ID != a.ID {
+		t.Errorf("List: Author.ID = %d, want %d", all[0].Author.ID, a.ID)
+	}
+	if all[0].Author.Name != a.Name {
+		t.Errorf("List: Author.Name = %q, want %q", all[0].Author.Name, a.Name)
+	}
+	if all[0].Author.ForeignID != a.ForeignID {
+		t.Errorf("List: Author.ForeignID = %q, want %q", all[0].Author.ForeignID, a.ForeignID)
+	}
+
+	// GetByID
+	gotByID, err := bookRepo.GetByID(ctx, b.ID)
+	if err != nil || gotByID == nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if gotByID.Author == nil || gotByID.Author.Name != a.Name {
+		t.Errorf("GetByID: expected Author.Name = %q; got %+v", a.Name, gotByID.Author)
+	}
+
+	// GetByForeignID
+	gotByFID, err := bookRepo.GetByForeignID(ctx, b.ForeignID)
+	if err != nil || gotByFID == nil {
+		t.Fatalf("GetByForeignID: %v", err)
+	}
+	if gotByFID.Author == nil || gotByFID.Author.Name != a.Name {
+		t.Errorf("GetByForeignID: expected Author.Name = %q; got %+v", a.Name, gotByFID.Author)
+	}
+
+	// ListByAuthor
+	byAuthor, err := bookRepo.ListByAuthor(ctx, a.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(byAuthor) != 1 || byAuthor[0].Author == nil {
+		t.Errorf("ListByAuthor: expected 1 book with Author populated; got %+v", byAuthor)
+	}
+
+	// ListByStatus
+	byStatus, err := bookRepo.ListByStatus(ctx, models.BookStatusWanted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(byStatus) != 1 || byStatus[0].Author == nil {
+		t.Errorf("ListByStatus: expected 1 book with Author populated; got %+v", byStatus)
+	}
+}
+
+// TestBookRepo_ListHandlesOrphanAuthorID pins down the LEFT JOIN choice
+// against an orphan author_id. Production has FOREIGN KEY=ON so this
+// shouldn't happen naturally, but the defensive code path matters if FKs
+// ever get bypassed during migration. We disable the FK constraint for
+// the duration of this test to set up the impossible-in-prod state.
+func TestBookRepo_ListHandlesOrphanAuthorID(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	bookRepo := NewBookRepo(database)
+	authorRepo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	a := mkAuthor(t, authorRepo, ctx, "OL-ORPHAN-A")
+	b := mkBook(t, bookRepo, ctx, a.ID, "OL-ORPHAN-B", "Orphan Book", models.BookStatusWanted)
+
+	// Bypass the FK constraint just long enough to set up the orphan row.
+	if _, err := database.ExecContext(ctx, "PRAGMA foreign_keys=OFF"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx, "UPDATE books SET author_id = 99999 WHERE id = ?", b.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx, "PRAGMA foreign_keys=ON"); err != nil {
+		t.Fatal(err)
+	}
+	_ = a
+
+	all, err := bookRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected book to still appear despite orphan author_id; got %d rows", len(all))
+	}
+	if all[0].Author != nil {
+		t.Errorf("expected Author == nil for orphan author_id; got %+v", all[0].Author)
+	}
+	if all[0].AuthorID != 99999 {
+		t.Errorf("AuthorID should be preserved; got %d", all[0].AuthorID)
+	}
+}

--- a/internal/db/scope.go
+++ b/internal/db/scope.go
@@ -10,11 +10,19 @@ package db
 //	where, args := db.QueryScope("WHERE excluded = 0", userID, existingArgs...)
 //	rows, err := r.db.QueryContext(ctx, "SELECT ... FROM books "+where, args...)
 func QueryScope(where string, userID int64, args ...any) (string, []any) {
+	return QueryScopeFor("owner_user_id", where, userID, args...)
+}
+
+// QueryScopeFor is QueryScope but lets the caller name a qualified column.
+// Used when the query joins multiple tables that each have an owner_user_id
+// column (e.g. books JOIN authors, post-#882), where the bare reference
+// would be ambiguous. Pass e.g. "books.owner_user_id".
+func QueryScopeFor(column, where string, userID int64, args ...any) (string, []any) {
 	if userID == 0 {
 		return where, args
 	}
 	if where == "" {
-		return "WHERE owner_user_id = ?", append([]any{userID}, args...)
+		return "WHERE " + column + " = ?", append([]any{userID}, args...)
 	}
-	return where + " AND owner_user_id = ?", append(args, userID)
+	return where + " AND " + column + " = ?", append(args, userID)
 }


### PR DESCRIPTION
## Summary

- ThatGuyHere reported in #882 that the Books page and book detail page show empty author columns for every book.
- Root cause: \`BookRepo.query\` joined \`first_ebook\` / \`first_audiobook\` for file paths but never joined \`authors\`, so \`models.Book.Author\` was nil on every row. Frontend reads \`book.author.authorName\` and rendered empty for the entire install.
- Fix: \`LEFT JOIN authors\` plus a minimal projection (id, foreign_id, name, sort_name) into \`bookColumns\`. Scan reads them as \`sql.Null*\` and populates \`b.Author\` when the join matched.
- LEFT JOIN (not INNER) so books with a stale author_id (theoretically possible if FK enforcement were ever bypassed) still surface with \`Author == nil\`.

## Side-effect: QueryScope qualified-column variant

The new join makes the bare \`owner_user_id = ?\` predicate ambiguous because authors also has that column. Added \`QueryScopeFor(column, ...)\` so books-side multi-user queries pass \`"books.owner_user_id"\`. \`QueryScope\` keeps its old shape for other repos that don't join, so no other callers need updating.

## Test plan

- [x] \`go test ./...\` green across the repo
- [x] \`go build ./...\` clean
- [x] New \`TestBookRepo_ListPopulatesAuthor\` verifies List, GetByID, GetByForeignID, ListByAuthor, ListByStatus all return populated \`Author\`
- [x] New \`TestBookRepo_ListHandlesOrphanAuthorID\` pins down the LEFT JOIN choice (orphan author_id stays in the result set with Author == nil)

🤖 Generated with [Claude Code](https://claude.com/claude-code)