### PR TITLE
notifier: emit Apprise-compatible body/title in webhook payload

### DIFF
--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -122,7 +122,30 @@ func (n *Notifier) send(ctx context.Context, notif *models.Notification, payload
 		}
 	}
 
-	body, err := json.Marshal(payload)
+	// Apprise's REST API (apprise-api) requires a "body" field and rejects any
+	// payload without one ("Payload lacks minimum requirements"). Enrich a copy
+	// of the payload with Apprise-friendly "body"/"title" fields so those
+	// endpoints work out of the box. This is purely additive: the original keys
+	// (title, message, and event-specific fields) are preserved, so existing
+	// ntfy / Home Assistant / Discord-proxy consumers are unaffected. We copy
+	// rather than mutate because Send reuses one payload map across every
+	// configured notification.
+	out := make(map[string]interface{}, len(payload)+2)
+	for k, v := range payload {
+		out[k] = v
+	}
+	if _, ok := out["body"]; !ok {
+		if msg, _ := out["message"].(string); msg != "" {
+			out["body"] = msg
+		} else if title, _ := out["title"].(string); title != "" {
+			out["body"] = title
+		}
+	}
+	if title, _ := out["title"].(string); title == "" {
+		out["title"] = "Bindery"
+	}
+
+	body, err := json.Marshal(out)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -183,6 +184,71 @@ func TestSend_InvalidHeaders(t *testing.T) {
 	// Should not error — invalid headers are silently ignored.
 	if err := n.send(context.Background(), notif, map[string]interface{}{}); err != nil {
 		t.Fatalf("send with invalid headers JSON: %v", err)
+	}
+}
+
+// TestSend_AppriseFields verifies the payload sent over the wire carries a
+// "body" (and a "title") so Apprise's REST API accepts it, while leaving the
+// caller's original fields untouched for other webhook consumers.
+func TestSend_AppriseFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   map[string]interface{}
+		wantBody  string
+		wantTitle string
+	}{
+		{
+			name:      "title only (grab/import) → body falls back to title",
+			payload:   map[string]interface{}{"title": "Dune", "author": "Herbert"},
+			wantBody:  "Dune",
+			wantTitle: "Dune",
+		},
+		{
+			name:      "message only (test/health) → body from message, default title",
+			payload:   map[string]interface{}{"eventType": "test", "message": "hello"},
+			wantBody:  "hello",
+			wantTitle: "Bindery",
+		},
+		{
+			name:      "explicit body is preserved",
+			payload:   map[string]interface{}{"body": "explicit", "message": "ignored"},
+			wantBody:  "explicit",
+			wantTitle: "Bindery",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotBody, _ = io.ReadAll(r.Body)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			n := testNotifier(&http.Client{})
+			notif := &models.Notification{URL: srv.URL, Method: "POST"}
+			if err := n.send(context.Background(), notif, tt.payload); err != nil {
+				t.Fatalf("send: %v", err)
+			}
+
+			var got map[string]interface{}
+			if err := json.Unmarshal(gotBody, &got); err != nil {
+				t.Fatalf("unmarshal sent body: %v (%s)", err, gotBody)
+			}
+			if got["body"] != tt.wantBody {
+				t.Errorf("body = %v, want %q", got["body"], tt.wantBody)
+			}
+			if got["title"] != tt.wantTitle {
+				t.Errorf("title = %v, want %q", got["title"], tt.wantTitle)
+			}
+			// Caller's original keys must survive untouched.
+			for k, v := range tt.payload {
+				if got[k] != v {
+					t.Errorf("original key %q = %v, want %v", k, got[k], v)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Webhook notifications can't reach an [Apprise](https://github.com/caronc/apprise-api) instance. Apprise's REST API requires a `body` field and rejects any payload without one:

```
HTTP 400 {"error": "Payload lacks minimum requirements"}
```

Bindery's payloads only carry event-specific keys (`title`, `message`, `size`, …) and never a `body`, so every POST to an Apprise `/notify/<key>` endpoint fails — even with `BINDERY_NOTIFICATIONS_ALLOW_PRIVATE=1` set (this is separate from #870; the request does reach Apprise, it's just rejected on shape).

### Reproduce
```bash
# Bindery's test payload → rejected
curl -X POST -H 'Content-Type: application/json' \
  -d '{"eventType":"test","message":"Bindery notification test"}' \
  http://apprise:8000/notify/<key>
# → HTTP 400 {"error": "Payload lacks minimum requirements"}

# Same payload + a "body" → accepted, notification delivered
curl -X POST -H 'Content-Type: application/json' \
  -d '{"eventType":"test","message":"Bindery notification test","title":"Bindery","body":"Bindery notification test"}' \
  http://apprise:8000/notify/<key>
# → HTTP 200
```
Apprise ignores the extra `eventType`/`message` keys, confirming the fix can be purely additive.

## Change

In `notifier.send()`, enrich a **copy** of the payload before marshaling:
- add `body` when absent — from `message`, falling back to `title` (covers grab/import which carry `title`, and test/health/failure which carry `message`);
- default `title` to `"Bindery"` when absent.

This is additive — the original keys are preserved, so ntfy / Home Assistant / Discord-proxy consumers are unaffected. A copy is used because `Send` reuses one payload map across every configured notification.

## Tests
`TestSend_AppriseFields` covers the three cases (title-only, message-only, explicit-body-preserved) and asserts the caller's original keys survive untouched. Existing notifier tests still pass.

If you'd prefer to gate this on a notification "type" (e.g. `type == "apprise"`) rather than always emitting `body`/`title`, happy to adjust.