### PR TITLE
fix(hardcover): propagate canonical-book language to plug author-works filter leak (#889)

### DIFF
--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -199,6 +199,7 @@ func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([
 			audio_seconds
 			default_audio_edition_id
 			default_ebook_edition_id
+			language { language }
 			contributions {
 				author { id name slug }
 			}
@@ -581,6 +582,7 @@ type hcBook struct {
 	AudioSeconds           *int               `json:"audio_seconds"`
 	DefaultAudioEditionID  *int               `json:"default_audio_edition_id"`
 	DefaultEbookEditionID  *int               `json:"default_ebook_edition_id"`
+	Language               *hcLanguage        `json:"language"`
 	Contributions          []hcContribution   `json:"contributions"`
 	AuthorNames            []string           `json:"author_names"`
 	FeaturedSeries         *hcFeaturedSeries  `json:"featured_series"`
@@ -1123,6 +1125,7 @@ func (c *Client) toBook(b hcBook) models.Book {
 		Genres:           []string{},
 		ISBNs:            b.ISBNs,
 		SeriesRefs:       seriesRefs,
+		Language:         hardcoverLanguageName(b.Language),
 	}
 	if len(b.Genres) > 0 {
 		bk.Genres = b.Genres

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -645,7 +645,7 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 				t.Fatalf("query requested search-only Hardcover field %q: %s", field, req.Query)
 			}
 		}
-		for _, field := range []string{"default_audio_edition_id", "default_ebook_edition_id"} {
+		for _, field := range []string{"default_audio_edition_id", "default_ebook_edition_id", "language"} {
 			if !strings.Contains(req.Query, field) {
 				t.Fatalf("query did not request Hardcover format field %q: %s", field, req.Query)
 			}
@@ -664,6 +664,20 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 					"rating":        4.5,
 					"users_count":   2000,
 					"audio_seconds": 7200,
+					"language":      map[string]interface{}{"language": "en"},
+					"contributions": []map[string]interface{}{
+						{"author": map[string]interface{}{"id": 1, "name": "Frank Herbert", "slug": "frank-herbert"}},
+					},
+				},
+				{
+					"id":            11,
+					"title":         "Dune (Spanish edition)",
+					"slug":          "dune-es",
+					"release_year":  1965,
+					"ratings_count": 50,
+					"rating":        4.2,
+					"users_count":   100,
+					"language":      map[string]interface{}{"language": "es"},
 					"contributions": []map[string]interface{}{
 						{"author": map[string]interface{}{"id": 1, "name": "Frank Herbert", "slug": "frank-herbert"}},
 					},
@@ -683,8 +697,8 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 	if gotVars["author"] != "Frank Herbert" {
 		t.Fatalf("author variable = %v", gotVars["author"])
 	}
-	if len(books) != 1 {
-		t.Fatalf("books len = %d, want 1", len(books))
+	if len(books) != 2 {
+		t.Fatalf("books len = %d, want 2", len(books))
 	}
 	book := books[0]
 	if book.ForeignID != "hc:dune" || book.Title != "Dune" || book.ImageURL == "" {
@@ -698,6 +712,16 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 	}
 	if book.MediaType != "" {
 		t.Fatalf("MediaType = %q, want empty author import default", book.MediaType)
+	}
+	// #889: Language must be propagated so the aggregator can drop foreign
+	// editions via the metadata profile's allowed_languages filter. Before
+	// this fix every Hardcover-sourced supplemental book arrived with
+	// Language="" and slipped past the filter as "unknown language: pass".
+	if book.Language != "eng" {
+		t.Errorf("English book Language = %q, want %q (normalized to ISO 639-2)", book.Language, "eng")
+	}
+	if books[1].Language != "spa" {
+		t.Errorf("Spanish book Language = %q, want %q (normalized to ISO 639-2)", books[1].Language, "spa")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `GetAuthorWorksByName` never queried `language { language }`, so every Hardcover-sourced supplemental book arrived with `Language=""` and slipped past the metadata profile's `allowed_languages` filter via the default "unknown language → pass" branch.
- Same gap as #224 / #232; #889 was the user-reported recurrence (Spanish editions of Michael Connelly, James Patterson, etc. leaking into English-only author bibliographies).
- Add the projection, plumb the field through `hcBook` + `toBook`, and assert both the query shape and the `en`/`es` → `eng`/`spa` mapping in the existing `TestGetAuthorWorksByName_WithToken`.

OpenLibrary's work-level tail (works not indexed by `/search.json`) is the other half of the historical gap and is left for a follow-up — that needs edition sampling and is a bigger change.

Closes #889.

## Test plan

- [x] `go test ./internal/metadata/hardcover/... -count=1` — `TestGetAuthorWorksByName_WithToken` now asserts the new `language` projection in the query and the `en→eng` / `es→spa` propagation.
- [x] `go test ./internal/metadata/... ./internal/api/... -count=1` — green, no regressions.
- [ ] Manual: add Michael Connelly with the Standard profile post-merge and confirm Spanish editions no longer appear in the books list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)