### PR TITLE
fix(scheduler): guard refreshMetadata against (nil, nil) from aggregator

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -766,6 +766,16 @@ func (s *Scheduler) refreshMetadata() {
 			slog.Warn("failed to refresh author", "author", author.Name, "error", err)
 			continue
 		}
+		// Aggregator returns (nil, nil) when no configured provider owns this
+		// foreignID prefix (e.g. a Hardcover-prefixed author after Hardcover
+		// was disabled, or any author whose ForeignID prefix no longer maps to
+		// a provider). Without this guard the deref below panics, which exits
+		// the range loop and kills every subsequent author's refresh that
+		// cycle.
+		if updated == nil {
+			slog.Debug("no metadata provider for author, skipping refresh", "author", author.Name, "foreignID", author.ForeignID)
+			continue
+		}
 
 		// Update changed fields
 		author.Description = updated.Description

--- a/internal/scheduler/scheduler_jobs_test.go
+++ b/internal/scheduler/scheduler_jobs_test.go
@@ -414,3 +414,46 @@ func TestRefreshMetadata_MonitoredAuthor_MetaSuccess(t *testing.T) {
 	// Loop body executes: GetAuthor → success → Update author fields.
 	s.refreshMetadata()
 }
+
+// TestRefreshMetadata_NilAuthor_DoesNotPanic pins down the regression where
+// Aggregator.GetAuthor returns (nil, nil) — which happens when no configured
+// provider owns the foreignID prefix, e.g. a Hardcover-prefixed author after
+// Hardcover is disabled. The pre-fix code did `author.Description =
+// updated.Description` immediately and panicked, killing the refresh loop
+// and every subsequent author's refresh that cycle.
+func TestRefreshMetadata_NilAuthor_DoesNotPanic(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authRepo := db.NewAuthorRepo(database)
+	// Two monitored authors so we can also verify the loop continues past
+	// the nil result instead of aborting after the first one.
+	for _, a := range []*models.Author{
+		{ForeignID: "OL_NIL_1A", Name: "First", SortName: "First", MetadataProvider: "openlibrary", Monitored: true},
+		{ForeignID: "OL_NIL_2A", Name: "Second", SortName: "Second", MetadataProvider: "openlibrary", Monitored: true},
+	} {
+		if err := authRepo.Create(ctx, a); err != nil {
+			t.Fatalf("create author: %v", err)
+		}
+	}
+
+	// author=nil → mockMetaProvider.GetAuthor returns (nil, nil), which the
+	// aggregator passes straight through to the scheduler.
+	mockProvider := &mockMetaProvider{author: nil}
+	s := &Scheduler{
+		authors: authRepo,
+		meta:    metadata.NewAggregator(mockProvider),
+	}
+
+	// Pre-fix: panics on the first author. Post-fix: skips both and returns.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("refreshMetadata panicked on nil author from aggregator: %v", r)
+		}
+	}()
+	s.refreshMetadata()
+}


### PR DESCRIPTION
## Summary

Critical nil-deref crash in `Scheduler.refreshMetadata`:

- `Aggregator.GetAuthor` returns `(*models.Author, error) = (nil, nil)` when no configured provider owns the author's `ForeignID` prefix (`internal/metadata/aggregator.go:67-69`). This happens when an author was added under Hardcover and Hardcover is later disabled, or when the primary provider is swapped — both real configurations.
- `scheduler.go:771` derefs `updated.Description` immediately after a nil-only check on `err`. With `updated == nil`, the goroutine panics.
- The panic exits the `range authors` loop, so every author **after** the offending one is silently skipped for that refresh cycle. If there's no top-level `recover` the process dies; if there is, refresh is half-broken in a way that won't show up in normal logs.

## Fix

- Add the missing `if updated == nil { continue }` after `GetAuthor`, log at debug so it's visible when investigating.
- Pin the regression with `TestRefreshMetadata_NilAuthor_DoesNotPanic` — two monitored authors, mock provider returning `(nil, nil)`, asserts no panic via `recover`.

Confirmed the test fails without the production-code change (verified by stashing the fix and re-running).

## Audit context

Surfaced by the deep audit pass on #890's branch. Other `GetAuthor` call sites in `internal/api/authors.go` (`:1025`, `:1506`, `:1676`) and `internal/abs/import_upserts.go:274` already check `nil`. `internal/abs/import_author_matcher.go:553` passes a nil result back to its caller (which does check) — defensible but worth tightening separately.

## Test plan

- [x] `go test ./internal/scheduler/... -count=1` green
- [x] Test fails on `main` without the production change (panic), passes with it
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)