### PR TITLE
fix(api): plug settings-endpoint secret leak (auth.oidc.providers and others)

### DIFF
--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -55,11 +55,45 @@ func NewSettingsHandler(settings *db.SettingsRepo) *SettingsHandler {
 }
 
 // isSecretSetting reports whether a settings key holds sensitive material
-// that must not leak through the generic settings endpoints. The auth.*
-// values are surfaced through the dedicated /auth/* endpoints instead.
+// that must not leak through the generic settings endpoints. Reads on
+// /api/v1/setting and /api/v1/setting/{key} are available to every
+// authenticated user (the dedicated /auth/* endpoints handle admin-only
+// secret config), so any new sensitive key must either be added to the
+// explicit list below or match one of the suffix/prefix patterns.
+//
+// Design choice: hybrid allowlist-by-pattern + explicit denylist for one-offs.
+// A pure enumerated denylist drifts — every new `*.api_key`, `*.api_token`,
+// `auth.session_secret_previous`, `auth.oidc.*` added in a future release
+// would have to remember to update this function or it leaks silently. The
+// pattern check fails closed for the common cases; the explicit list catches
+// the misnamed ones (auth.oidc.providers in particular: the JSON blob
+// embeds client_secret values per provider but the key itself doesn't
+// match a `*_secret` suffix).
 func isSecretSetting(key string) bool {
+	// 1. Explicit one-offs that don't match the patterns below.
 	switch key {
-	case "auth.api_key", "auth.session_secret", "auth.mode", SettingABSAPIKey, SettingHardcoverAPIToken:
+	case SettingAuthAPIKey,
+		SettingAuthSessionSecret,
+		SettingAuthSessionSecretPrevious,
+		SettingAuthMode,
+		SettingOIDCProviders,
+		SettingABSAPIKey,
+		SettingHardcoverAPIToken,
+		SettingCalibrePluginAPIKey,
+		SettingGrimmoryAPIKey:
+		return true
+	}
+	// 2. Defensive suffix/prefix patterns for keys that follow the bindery
+	//    convention. Anything new that follows the convention is denied by
+	//    default; anything that doesn't has to be added to the explicit list.
+	if strings.HasSuffix(key, ".api_key") ||
+		strings.HasSuffix(key, ".api_token") ||
+		strings.HasSuffix(key, "_secret") ||
+		strings.Contains(key, "_secret_") || // covers session_secret_previous-style variants
+		strings.HasSuffix(key, ".password") ||
+		strings.HasSuffix(key, "_password") ||
+		strings.HasSuffix(key, ".client_secret") ||
+		strings.HasPrefix(key, "auth.oidc.") {
 		return true
 	}
 	return false

--- a/internal/api/settings_handler_test.go
+++ b/internal/api/settings_handler_test.go
@@ -232,6 +232,69 @@ func TestSettings_AuthorMonitorDefaultsValidation(t *testing.T) {
 	}
 }
 
+// TestSettings_SecretLeakRegression pins down the keys that the deep-audit
+// pass discovered were missing from isSecretSetting. Any of them surfacing
+// through the generic settings endpoint leaks credentials to every
+// authenticated user.
+//
+// `auth.oidc.providers` is the worst of these: the value is a JSON blob with
+// one entry per configured IdP, each containing the `client_secret`. Leaking
+// it lets any logged-in user mint tokens against the IdP from outside Bindery.
+func TestSettings_SecretLeakRegression(t *testing.T) {
+	h, repo, ctx := settingsFixture(t)
+	leaky := map[string]string{
+		SettingOIDCProviders:             `[{"id":"okta","clientSecret":"S3CRET"}]`,
+		SettingAuthSessionSecretPrevious: "previous-hmac-key",
+		SettingGrimmoryAPIKey:            "grimmory-api-key",
+		SettingCalibrePluginAPIKey:       "calibre-plugin-key",
+		// Generic pattern coverage: keys that aren't enumerated but follow
+		// the suffix/prefix conventions must still be filtered.
+		"some_new_provider.api_key":   "secret-by-pattern",
+		"some_new_provider.api_token": "secret-by-pattern-token",
+		"some_section.client_secret":  "secret-by-suffix",
+		"foo.bar_secret":              "secret-by-suffix",
+		"db.password":                 "secret-by-password-suffix",
+		"auth.oidc.future_field":      "secret-by-oidc-prefix",
+	}
+	for k, v := range leaky {
+		if err := repo.Set(ctx, k, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// And a key that LOOKS adjacent but is safe — must still be readable.
+	if err := repo.Set(ctx, "grimmory.enabled", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/setting", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("List status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for k, v := range leaky {
+		if bytes.Contains([]byte(body), []byte(v)) {
+			t.Errorf("List leaked secret value for %q: %q present in response", k, v)
+		}
+		if bytes.Contains([]byte(body), []byte(`"key":"`+k+`"`)) {
+			t.Errorf("List leaked secret key %q via key field", k)
+		}
+	}
+	if !bytes.Contains([]byte(body), []byte("grimmory.enabled")) {
+		t.Errorf("non-secret grimmory.enabled missing from List output: %s", body)
+	}
+
+	// Direct GET on each leaky key must 404.
+	for k := range leaky {
+		req := withKey(httptest.NewRequest(http.MethodGet, "/api/v1/setting/"+k, nil), k)
+		rec := httptest.NewRecorder()
+		h.Get(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("Get %q expected 404 (secret), got %d body=%s", k, rec.Code, rec.Body.String())
+		}
+	}
+}
+
 func TestSettings_GetABSSecretReturns404(t *testing.T) {
 	h, repo, ctx := settingsFixture(t)
 	if err := repo.Set(ctx, SettingABSAPIKey, "supersecret"); err != nil {


### PR DESCRIPTION
## Summary

**Critical** disclosure: `GET /api/v1/setting` and `GET /api/v1/setting/{key}` are available to every authenticated user. Secret-redaction lives in `isSecretSetting` (`internal/api/settings_handler.go:60`), which was an enumerated denylist of five keys. The deep audit caught that several sensitive keys were absent:

- **`auth.oidc.providers`** — JSON blob with one entry per IdP, each carrying `client_secret`. Leaking this lets any logged-in user mint tokens against the configured IdP from outside Bindery.
- **`auth.session_secret_previous`** — the previous HMAC key, used during rotation. Usable for cookie forgery during the rotation window.
- **`grimmory.api_key`**, **`calibre.plugin_api_key`** — third-party credentials.

## Fix

1. Add the missing keys to the explicit list.
2. Add suffix/prefix pattern guards (`*.api_key`, `*.api_token`, `*_secret`, `*_password`, `*.client_secret`, `auth.oidc.*`) so future credential settings that follow bindery's naming convention fail closed by default. Anything new that does *not* follow the convention still needs an explicit entry, and the docstring calls that out.
3. `TestSettings_SecretLeakRegression` covers each newly blocked key plus several pattern-only synthetic keys, asserts both List and direct-Get paths.

Verified the new test fails on `main` (10 distinct leak failures) and passes after the fix.

## Audit context

Surfaced by the deep audit. The other critical it surfaced (scheduler nil-deref) is PR #892. The HIGH list is being staged separately.

## Test plan

- [x] `go test ./internal/api/... -count=1` green
- [x] Test fails on `main` without the production change, passes with it
- [x] `go build ./...` clean
- [ ] Manual: log in as non-admin, `GET /api/v1/setting/auth.oidc.providers` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)