### PR TITLE
fix(oidc): SSRF + redirect-revalidation + trusted-proxy scheme guards (Wave 1 / Bundle A)

### DIFF
--- a/internal/api/auth_oidc.go
+++ b/internal/api/auth_oidc.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 
@@ -12,6 +13,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/auth/oidc"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/httpsec"
 )
 
 const (
@@ -459,7 +461,33 @@ func (h *OIDCHandler) TestDiscovery(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, "issuer required")
 		return
 	}
-	doc, err := oidc.Discover(r.Context(), issuer)
+	// SSRF guard: block loopback, link-local, and cloud-metadata destinations
+	// so an admin (or anyone whose session leaks once) cannot use this admin
+	// probe to fingerprint internal services or read AWS/Azure/DO metadata. The
+	// default policy is LAN (RFC1918 still reachable for legitimate on-prem
+	// IdPs); operators with stricter needs can keep the default, and operators
+	// who intentionally point Bindery at a LAN IdP get the default behaviour
+	// without further config. BINDERY_ALLOW_LAN_OIDC=true keeps the historical
+	// behaviour where any URL the admin types is fetched verbatim, including
+	// loopback, for users who run an OIDC provider on the Bindery host itself.
+	var discoverOpts []oidc.DiscoverOption
+	if !oidcAllowLAN() {
+		policy := oidcDiscoveryPolicy()
+		if err := httpsec.ValidateOutboundURL(issuer, policy); err != nil {
+			// Mirror the handler's existing "report inline, don't surface as
+			// HTTP error" contract: any failure that has the user-visible
+			// shape of "we did not fetch the IdP" (unreachable, SSRF refusal,
+			// scheme refusal) goes back as ok=false in the body so the Settings
+			// UI can render the message next to the issuer field. The 400
+			// branch is reserved for malformed input (e.g. empty issuer).
+			writeOK(w, map[string]any{"ok": false, "error": err.Error()})
+			return
+		}
+		// Same policy is re-applied to every redirect hop inside Discover so an
+		// attacker can't bounce the request from a public URL into a private one.
+		discoverOpts = append(discoverOpts, oidc.DiscoverPolicy(policy))
+	}
+	doc, err := oidc.Discover(r.Context(), issuer, discoverOpts...)
 	if err != nil {
 		writeOK(w, map[string]any{"ok": false, "error": err.Error()})
 		return
@@ -603,4 +631,25 @@ func cookieSecure(r *http.Request) bool {
 func sanitizeLog(s string) string {
 	s = strings.ReplaceAll(s, "\r", " ")
 	return strings.ReplaceAll(s, "\n", " ")
+}
+
+// oidcAllowLAN reports whether the operator has opted out of the SSRF guard
+// on the OIDC discovery probe via BINDERY_ALLOW_LAN_OIDC. Setting this to
+// "1" or "true" (case-insensitive) restores the historical behaviour where
+// any URL the admin types is fetched verbatim, including loopback and other
+// destinations a hardened deploy would normally refuse. The escape hatch
+// exists for users who run an OIDC provider on the Bindery host itself.
+func oidcAllowLAN() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("BINDERY_ALLOW_LAN_OIDC")))
+	return v == "1" || v == "true"
+}
+
+// oidcDiscoveryPolicy returns the SSRF policy applied to the OIDC discovery
+// probe and to redirects followed by the discovery client. PolicyLAN is the
+// default: it blocks loopback, link-local, and cloud-metadata, but allows
+// RFC1918 destinations so an on-prem Keycloak/Authentik on a LAN IP keeps
+// working. Stricter setups can run with the LAN-side IdP unreachable from
+// the Bindery host.
+func oidcDiscoveryPolicy() httpsec.Policy {
+	return httpsec.PolicyLAN
 }

--- a/internal/api/auth_oidc_test.go
+++ b/internal/api/auth_oidc_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/vavallee/bindery/internal/auth/oidc"
+	"github.com/vavallee/bindery/internal/httpsec"
 )
 
 // TestGetRedirectBase verifies the endpoint returns the resolved base URL
@@ -95,6 +96,10 @@ func TestGetRedirectBase_ResolverHonorsRequest(t *testing.T) {
 // TestTestDiscovery_Success verifies the handler returns ok=true and the
 // discovered metadata when the IdP serves a valid openid-configuration doc.
 func TestTestDiscovery_Success(t *testing.T) {
+	// httptest.NewServer binds to 127.0.0.1; the SSRF guard would otherwise
+	// reject it. The escape hatch is the same one the rest of the test suite
+	// uses for guarded outbound HTTP.
+	defer httpsec.AllowLoopbackForTests()()
 	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/.well-known/openid-configuration" {
 			http.NotFound(w, r)
@@ -142,6 +147,7 @@ func TestTestDiscovery_Success(t *testing.T) {
 // when the discovered issuer doesn't match the input — the silent killer for
 // Authentik per-provider mode and Keycloak realms.
 func TestTestDiscovery_IssuerMismatch(t *testing.T) {
+	defer httpsec.AllowLoopbackForTests()()
 	idp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -209,6 +215,83 @@ func TestTestDiscovery_RejectsEmptyIssuer(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+}
+
+// TestOIDCTestDiscovery_RejectsInternalIP pins down the SSRF fix on the
+// authenticated /api/v1/auth/oidc/test-discovery endpoint. Without the guard,
+// an admin (or anyone whose session leaks once) can probe the cloud-metadata
+// endpoint 169.254.169.254 or other link-local destinations and have the
+// server fetch them. The fix validates the issuer URL through
+// httpsec.ValidateOutboundURL before any HTTP request is built. The error
+// flows back to the UI through the existing ok=false contract so admins see
+// the reason inline next to the issuer field.
+func TestOIDCTestDiscovery_RejectsInternalIP(t *testing.T) {
+	cases := []struct {
+		name   string
+		issuer string
+	}{
+		{"cloud metadata IPv4 literal", "http://169.254.169.254/.well-known/openid-configuration"},
+		{"link-local IPv4", "http://169.254.10.20/.well-known/openid-configuration"},
+		{"cloud metadata hostname", "http://metadata.google.internal/.well-known/openid-configuration"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mgr := oidc.NewManager()
+			h := NewOIDCHandler(mgr, nil, nil, nil, nil)
+			body := strings.NewReader(`{"issuer":"` + c.issuer + `"}`)
+			rec := httptest.NewRecorder()
+			h.TestDiscovery(rec, httptest.NewRequest(http.MethodPost, "/api/v1/auth/oidc/test-discovery", body))
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("issuer=%q: status=%d, want 200 with ok=false in body; body=%s", c.issuer, rec.Code, rec.Body.String())
+			}
+			var got struct {
+				OK    bool   `json:"ok"`
+				Error string `json:"error"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+				t.Fatalf("issuer=%q: parse body: %v (body=%s)", c.issuer, err, rec.Body.String())
+			}
+			if got.OK {
+				t.Fatalf("issuer=%q: ok=true, want false (SSRF guard should refuse)", c.issuer)
+			}
+			if got.Error == "" {
+				t.Fatalf("issuer=%q: empty error message — UI has nothing to display", c.issuer)
+			}
+		})
+	}
+}
+
+// TestOIDCTestDiscovery_AllowLANEscapeHatch verifies BINDERY_ALLOW_LAN_OIDC
+// disables the SSRF guard so users who run an OIDC provider on the Bindery
+// host itself (or on a loopback overlay) can still hit Test Discovery.
+func TestOIDCTestDiscovery_AllowLANEscapeHatch(t *testing.T) {
+	t.Setenv("BINDERY_ALLOW_LAN_OIDC", "true")
+	// Loopback would still be blocked by ValidateOutboundURL without the
+	// escape hatch; the test confirms the escape hatch skips the check
+	// entirely. We do not need an actual server — the request just has to
+	// progress past the guard and fail on the network (returned as
+	// ok=false in the body, per the handler contract).
+	mgr := oidc.NewManager()
+	h := NewOIDCHandler(mgr, nil, nil, nil, nil)
+	body := strings.NewReader(`{"issuer":"http://127.0.0.1:1"}`)
+	rec := httptest.NewRecorder()
+	h.TestDiscovery(rec, httptest.NewRequest(http.MethodPost, "/api/v1/auth/oidc/test-discovery", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("escape hatch should let the request through (network error returned as ok=false in body); got status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got.OK {
+		t.Fatal("ok=true, want false (port 1 should fail to connect)")
+	}
+	if got.Error == "" {
+		t.Fatal("expected an error message describing the connection failure")
 	}
 }
 

--- a/internal/api/oidc_redirect.go
+++ b/internal/api/oidc_redirect.go
@@ -15,8 +15,14 @@ import (
 //  2. X-Forwarded-Proto + X-Forwarded-Host on the request, if the request is
 //     coming from a trusted proxy peer (BINDERY_TRUSTED_PROXY). Honors the
 //     same trust boundary as proxy-auth mode.
-//  3. r.Host with scheme inferred from r.TLS or X-Forwarded-Proto. Used when
-//     Bindery is reached directly without a proxy.
+//  3. r.Host with scheme inferred from r.TLS. Used when Bindery is reached
+//     directly without a proxy.
+//
+// X-Forwarded-Proto is NEVER honoured outside the trusted-proxy branch — when
+// Bindery is reachable directly, an attacker can set the header from a
+// browser fetch and would otherwise be able to influence the redirect_uri
+// scheme (e.g. forcing an https → http downgrade for the OIDC callback).
+// r.TLS is the only safe signal in that case.
 //
 // Returns the empty string only when the request has no Host header at all
 // (which would already have been rejected upstream). Trailing slashes are
@@ -34,8 +40,13 @@ func ResolveOIDCRedirectBase(r *http.Request, configured string, trusted []*net.
 		}
 	}
 
+	// Direct-reach path: only trust r.TLS for scheme. XFP from an untrusted
+	// peer is attacker-controlled (see CVE-style scheme-downgrade scenario in
+	// the function doc). trustedProxyMiddleware also strips XFP from untrusted
+	// peers when wired in cmd/bindery, but this function is callable in
+	// isolation (and tested in isolation) so it must stay safe on its own.
 	scheme := "http"
-	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
+	if r.TLS != nil {
 		scheme = "https"
 	}
 	if r.Host == "" {

--- a/internal/api/oidc_redirect_test.go
+++ b/internal/api/oidc_redirect_test.go
@@ -49,9 +49,13 @@ func TestResolveOIDCRedirectBase_UntrustedPeerIgnoresForwarded(t *testing.T) {
 	r.Header.Set("X-Forwarded-Host", "evil.example.com")
 	r.RemoteAddr = "203.0.113.7:443"
 
+	// Untrusted peer must not be able to influence host OR scheme. r.TLS is
+	// nil here, so the safe fallback is plain http. Honouring XF-Proto=https
+	// from an untrusted peer would be the scheme-spoofing bug the audit
+	// flagged (Bundle A finding #3).
 	got := ResolveOIDCRedirectBase(r, "", []*net.IPNet{mustCIDR(t, "10.0.0.0/8")})
-	if got != "https://internal.cluster.svc" {
-		t.Fatalf("forwarded headers from untrusted peer must be ignored, got %q", got)
+	if got != "http://internal.cluster.svc" {
+		t.Fatalf("forwarded headers from untrusted peer must be ignored (host AND scheme); got %q, want http://internal.cluster.svc", got)
 	}
 }
 
@@ -81,12 +85,19 @@ func TestResolveOIDCRedirectBase_HTTPSDetection(t *testing.T) {
 			want: "https://bindery.example.com",
 		},
 		{
-			name: "X-Forwarded-Proto=https without trusted proxy",
+			// SECURITY: X-Forwarded-Proto from an untrusted peer is attacker-
+			// controlled (browser fetch / curl can set it). Honouring it here
+			// would let an attacker downgrade the OIDC callback URI from
+			// https to http when Bindery is reached directly. Only r.TLS
+			// is a safe signal in the direct-reach path; this case must
+			// fall back to plain http even with XFP=https set.
+			name: "X-Forwarded-Proto=https from untrusted peer is ignored",
 			set: func(r *http.Request) {
 				r.Host = "bindery.example.com"
 				r.Header.Set("X-Forwarded-Proto", "https")
+				r.RemoteAddr = "203.0.113.7:443"
 			},
-			want: "https://bindery.example.com",
+			want: "http://bindery.example.com",
 		},
 		{
 			name: "plain HTTP",
@@ -103,6 +114,57 @@ func TestResolveOIDCRedirectBase_HTTPSDetection(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestOIDCRedirect_HonorsXForwardedProtoOnlyForTrustedProxies pins down the
+// scheme-downgrade fix: an untrusted peer that sends X-Forwarded-Proto: http
+// must not be able to force the OIDC callback off https, and a trusted peer
+// must still be able to surface the real public scheme. Without the trusted-
+// proxy gate, a developer instance reachable directly would issue a callback
+// like http://bindery.example.com/... after an attacker pings the login URL
+// with the spoofed header, opening a downgrade-and-intercept window on the
+// OIDC code exchange.
+func TestOIDCRedirect_HonorsXForwardedProtoOnlyForTrustedProxies(t *testing.T) {
+	trusted := []*net.IPNet{mustCIDR(t, "10.0.0.0/8")}
+
+	t.Run("untrusted peer cannot downgrade scheme with X-Forwarded-Proto", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/x/login", nil)
+		r.Host = "bindery.example.com"
+		r.TLS = &tls.ConnectionState{} // real connection is TLS
+		r.RemoteAddr = "192.168.1.5:1234"
+		r.Header.Set("X-Forwarded-Proto", "http")
+
+		got := ResolveOIDCRedirectBase(r, "", trusted)
+		if got != "https://bindery.example.com" {
+			t.Fatalf("untrusted XF-Proto=http must not downgrade an https connection; got %q, want https://bindery.example.com", got)
+		}
+	})
+
+	t.Run("untrusted peer cannot upgrade scheme with X-Forwarded-Proto", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/x/login", nil)
+		r.Host = "bindery.example.com"
+		// No r.TLS — plain HTTP connection.
+		r.RemoteAddr = "203.0.113.7:443"
+		r.Header.Set("X-Forwarded-Proto", "https")
+
+		got := ResolveOIDCRedirectBase(r, "", trusted)
+		if got != "http://bindery.example.com" {
+			t.Fatalf("untrusted XF-Proto=https must not pretend a plain http connection is https; got %q, want http://bindery.example.com", got)
+		}
+	})
+
+	t.Run("trusted peer is honoured", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/x/login", nil)
+		r.Host = "internal.cluster.svc"
+		r.RemoteAddr = "10.0.0.5:54321"
+		r.Header.Set("X-Forwarded-Proto", "https")
+		r.Header.Set("X-Forwarded-Host", "bindery.example.com")
+
+		got := ResolveOIDCRedirectBase(r, "", trusted)
+		if got != "https://bindery.example.com" {
+			t.Fatalf("trusted proxy XF headers must be honoured; got %q", got)
+		}
+	})
 }
 
 func TestResolveOIDCRedirectBase_StripsTrailingSlashes(t *testing.T) {

--- a/internal/auth/oidc/discover.go
+++ b/internal/auth/oidc/discover.go
@@ -3,13 +3,48 @@ package oidc
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/vavallee/bindery/internal/httpsec"
 )
+
+// DiscoverOption configures the discovery client. Currently only DiscoverPolicy
+// is exposed; the option pattern keeps Discover's signature stable as more
+// guardrails are layered in.
+type DiscoverOption func(*discoverConfig)
+
+// discoverConfig holds the resolved Discover options. policy is a pointer so
+// the absence of a policy (zero value) is distinct from PolicyLAN (the
+// strictest-by-default policy that still admits RFC1918 IdPs).
+type discoverConfig struct {
+	policy       *httpsec.Policy
+	maxRedirects int
+}
+
+// DiscoverPolicy installs an httpsec.Policy that is re-applied to every
+// redirect hop. Without this option, redirects are followed without
+// per-hop validation — appropriate only when the caller has no SSRF
+// concerns (e.g. an in-process test against httptest.NewServer).
+func DiscoverPolicy(p httpsec.Policy) DiscoverOption {
+	return func(c *discoverConfig) { c.policy = &p }
+}
+
+// DiscoverMaxRedirects overrides the default redirect cap (5). Useful for
+// tests that need to exercise the cap without flooding production with a
+// long-running redirect chain.
+func DiscoverMaxRedirects(n int) DiscoverOption {
+	return func(c *discoverConfig) {
+		if n > 0 {
+			c.maxRedirects = n
+		}
+	}
+}
 
 // DiscoveryDoc is the subset of the OIDC provider metadata document that the
 // Settings UI's "Test discovery" button surfaces. The fields here match the
@@ -35,8 +70,12 @@ type DiscoveryDoc struct {
 //
 // SSRF guardrails: only http and https schemes are accepted; redirects are
 // limited; response body is capped at 256 KB; total operation has its own
-// deadline via the supplied context.
-func Discover(ctx context.Context, issuer string) (*DiscoveryDoc, error) {
+// deadline via the supplied context. When opts contains a DiscoverPolicy,
+// every redirect hop is re-validated against the supplied httpsec.Policy so
+// an attacker cannot bounce the request from a public issuer URL to a
+// private destination (e.g. http://169.254.169.254/) the initial URL guard
+// would otherwise have refused.
+func Discover(ctx context.Context, issuer string, opts ...DiscoverOption) (*DiscoveryDoc, error) {
 	issuer = strings.TrimRight(strings.TrimSpace(issuer), "/")
 	if issuer == "" {
 		return nil, fmt.Errorf("empty issuer")
@@ -59,9 +98,41 @@ func Discover(ctx context.Context, issuer string) (*DiscoveryDoc, error) {
 	}
 	req.Header.Set("Accept", "application/json")
 
-	client := &http.Client{Timeout: 8 * time.Second}
+	cfg := discoverConfig{maxRedirects: 5}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	client := &http.Client{
+		Timeout: 8 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Cap hop count to prevent redirect-loop / blow-up abuse. Default
+			// 5 mirrors Go's stdlib default, but we set it explicitly so the
+			// cap survives any future stdlib change.
+			if len(via) >= cfg.maxRedirects {
+				return fmt.Errorf("stopped after %d redirects", cfg.maxRedirects)
+			}
+			// When the caller installed an SSRF policy, re-validate every hop's
+			// destination. This defeats the redirect-bypass where an attacker
+			// controls a public-looking issuer URL that 302s to
+			// http://169.254.169.254/ (or any internal address the initial-URL
+			// guard refuses), bouncing the request past the perimeter check.
+			if cfg.policy != nil {
+				if err := httpsec.ValidateOutboundURL(req.URL.String(), *cfg.policy); err != nil {
+					return fmt.Errorf("redirect refused: %w", err)
+				}
+			}
+			return nil
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
+		// http.Client.Do wraps the CheckRedirect error in a *url.Error; surface
+		// the underlying redirect-refusal message so callers can log it cleanly.
+		var uerr *url.Error
+		if errors.As(err, &uerr) && uerr.Err != nil {
+			return nil, uerr.Err
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()

--- a/internal/auth/oidc/discover_test.go
+++ b/internal/auth/oidc/discover_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/vavallee/bindery/internal/httpsec"
 )
 
 // TestDiscover_Success verifies the happy path returns parsed metadata when
@@ -139,6 +141,72 @@ func TestDiscover_TrimTrailingSlash(t *testing.T) {
 	_, _ = Discover(context.Background(), srv.URL+"/")
 	if seenPath != "/.well-known/openid-configuration" {
 		t.Errorf("path=%q, want exactly /.well-known/openid-configuration (no double slash)", seenPath)
+	}
+}
+
+// TestDiscover_RedirectToInternalIP_IsBlocked verifies the CheckRedirect hook
+// re-validates every hop against the supplied policy. Without it, an attacker
+// who controls a public-looking issuer URL could 302 the discovery probe to
+// http://10.0.0.1/ (or http://169.254.169.254/) and bypass the initial URL
+// guard at the API handler.
+func TestDiscover_RedirectToInternalIP_IsBlocked(t *testing.T) {
+	// httptest.NewServer binds to 127.0.0.1, which the SSRF guard rejects.
+	// Allow loopback so we can run the public-looking origin server; the
+	// redirect destination (10.0.0.1) is the one that has to be refused.
+	defer httpsec.AllowLoopbackForTests()()
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Redirect to an RFC1918 address — under PolicyStrict this is the
+		// attack we are testing against. We use PolicyStrict in the call
+		// below so the redirect-validation actually fires on 10.0.0.1.
+		http.Redirect(w, r, "http://10.0.0.1/.well-known/openid-configuration", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	_, err := Discover(context.Background(), origin.URL, DiscoverPolicy(httpsec.PolicyStrict))
+	if err == nil {
+		t.Fatal("expected redirect to internal IP to be refused, got nil")
+	}
+	if !strings.Contains(err.Error(), "redirect refused") {
+		t.Errorf("error=%q, want a redirect-refused message so operators can tell it apart from a transport error", err.Error())
+	}
+}
+
+// TestDiscover_RedirectToCloudMetadata_IsBlocked is the same shape but
+// against the cloud-metadata endpoint, which PolicyLAN already refuses (so
+// callers don't need PolicyStrict to get the protection that matters most).
+func TestDiscover_RedirectToCloudMetadata_IsBlocked(t *testing.T) {
+	defer httpsec.AllowLoopbackForTests()()
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://169.254.169.254/latest/meta-data/iam/security-credentials/", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	_, err := Discover(context.Background(), origin.URL, DiscoverPolicy(httpsec.PolicyLAN))
+	if err == nil {
+		t.Fatal("expected redirect to 169.254.169.254 to be refused, got nil")
+	}
+	if !strings.Contains(err.Error(), "redirect refused") {
+		t.Errorf("error=%q, want a redirect-refused message", err.Error())
+	}
+}
+
+// TestDiscover_RedirectCap stops a malicious or misconfigured IdP from
+// chaining endless redirects.
+func TestDiscover_RedirectCap(t *testing.T) {
+	defer httpsec.AllowLoopbackForTests()()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Each hit redirects back to itself, growing via[] without bound.
+		http.Redirect(w, r, srv.URL+"/.well-known/openid-configuration", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := Discover(context.Background(), srv.URL, DiscoverMaxRedirects(3))
+	if err == nil {
+		t.Fatal("expected redirect-cap error, got nil")
+	}
+	if !strings.Contains(err.Error(), "stopped after") {
+		t.Errorf("error=%q, want it to mention the redirect cap", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

Bundle A from the v1.15.3 deep audit. Three related high-severity OIDC findings, fixed together because they all live in the same auth pathway and share a single conceptual root (trusting attacker-influenced inputs to outbound requests / redirect URI construction).

Companion to the two critical findings from the same audit cycle, PR #892 and PR #893.

### Finding 1 (SSRF on /api/v1/auth/oidc/test-discovery)

`internal/api/auth_oidc.go` previously fed the admin-supplied issuer URL straight into `oidc.Discover()` with no destination check. An admin (or anyone whose admin session leaks once) could probe `http://169.254.169.254/...` for cloud-metadata, RFC1918 services, or loopback. Fixed by routing the URL through `httpsec.ValidateOutboundURL(httpsec.PolicyLAN)` before any request is built, matching the pattern in `settings_handler.go` for `SettingCalibrePluginURL`. The error flows back to the UI via the existing `{ok:false, error:...}` body shape so the Settings page renders the reason inline next to the issuer field.

Escape hatch: `BINDERY_ALLOW_LAN_OIDC=true` skips the check entirely. Documented because some users deliberately run their OIDC provider on the Bindery host itself (loopback). PolicyLAN already permits RFC1918, so on-prem IdPs on a LAN IP work out of the box.

### Finding 2 (discovery follows redirects without revalidating)

`internal/auth/oidc/discover.go` used a plain `http.Client{Timeout: 8s}` and followed redirects with no per-hop check. Even with the perimeter guard from finding #1, an attacker-controlled public URL could 302 to `http://169.254.169.254/`. Fixed with a `CheckRedirect` hook that re-runs `httpsec.ValidateOutboundURL` on every destination and caps the chain at 5 hops. The policy is passed in by the caller via a new variadic `DiscoverOption` so the existing happy-path tests remain unchanged and so unit tests can opt into a stricter policy than the caller would in production.

### Finding 3 (X-Forwarded-Proto scheme spoofing)

`internal/api/oidc_redirect.go` line 38 trusted `X-Forwarded-Proto` unconditionally when inferring the callback scheme. On a developer or homelab deploy reachable directly (no proxy), an attacker could send `X-Forwarded-Proto: http` from a browser fetch and get a downgraded redirect_uri vulnerable to interception. Fix: only honour `X-Forwarded-Proto`/`X-Forwarded-Host` inside the existing `BINDERY_TRUSTED_PROXY` allowlist branch; the direct-reach fallback now infers scheme from `r.TLS` only.

The existing `trustedProxyMiddleware` already strips XFP/XFH from untrusted peers when wired in `cmd/bindery`, but `ResolveOIDCRedirectBase` is callable in isolation (and tested in isolation), so the safe-by-default fix lives in the function itself.

## Files changed

* `internal/api/auth_oidc.go` (finding 1) + escape-hatch helpers
* `internal/auth/oidc/discover.go` (finding 2) + `DiscoverOption` pattern
* `internal/api/oidc_redirect.go` (finding 3)
* Tests across all three packages

## Notes on the existing tests

Two existing tests were updated to reflect the safer behaviour:

* `TestResolveOIDCRedirectBase_UntrustedPeerIgnoresForwarded` previously asserted that the scheme survived from XFP when the host was stripped; that was the bug. It now asserts that both host AND scheme are ignored from an untrusted peer.
* The `X-Forwarded-Proto=https without trusted proxy` subtest in `TestResolveOIDCRedirectBase_HTTPSDetection` was renamed and inverted to match the fix.
* `TestTestDiscovery_Success` / `TestTestDiscovery_IssuerMismatch` opt into `httpsec.AllowLoopbackForTests()` because `httptest.NewServer` binds to 127.0.0.1, which the new guard rightly refuses.

## Test plan

Tests added per finding; `go test ./internal/api/... ./internal/auth/... ./internal/httpsec/...` green locally. Full `go test ./...` also green.

- [ ] CI green
- [ ] Manual: confirm `BINDERY_ALLOW_LAN_OIDC=true` still allows pointing Test Discovery at a loopback IdP on a real instance
- [ ] Manual: confirm a deploy with no `BINDERY_TRUSTED_PROXY` set still gets correct https callbacks when behind TLS termination from the platform (k8s ingress with TLS-passthrough, direct r.TLS != nil)