### PR TITLE
fix(api): library-root containment on book/author file deletion (Wave 1 / Bundle B)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -472,17 +472,25 @@ func main() {
 	userMgmtHandler := api.NewUserManagementHandler(userRepo).
 		WithLocalAuthEnabled(cfg.LocalAuthEnabled)
 	searchHandler := api.NewSearchHandler(metaAgg)
+	// Library-root containment checker (Wave 1 / Bundle B): used by the book
+	// and author delete handlers to refuse on-disk removal of any path that
+	// isn't inside a configured root. Defaults to the legacy single-root env
+	// vars so installs that never created a root_folders row still get the
+	// check.
+	libraryRoots := api.NewLibraryRoots(rootFolderRepo, cfg.LibraryDir, cfg.AudiobookDir)
 	authorHandler := api.NewAuthorHandler(authorRepo, authorAliasRepo, bookRepo, seriesRepo, metaAgg, settingsRepo, metadataProfileRepo, sched).
 		WithFinder(importScanner).
 		WithHardcoverFeatureSettings(settingsRepo, cfg.EnhancedHardcoverAPI).
-		WithEditionHydration(editionRepo)
+		WithEditionHydration(editionRepo).
+		WithRoots(libraryRoots)
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
 	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).
 		WithSettings(settingsRepo).
 		WithDownloads(downloadRepo).
 		WithAuthors(authorRepo).
 		WithSeries(seriesRepo).
-		WithEditionHydration(editionRepo)
+		WithEditionHydration(editionRepo).
+		WithRoots(libraryRoots)
 	indexerHandler := api.NewIndexerHandler(indexerRepo, bookRepo, authorRepo, metadataProfileRepo, idxSearcher, settingsRepo, blocklistRepo).WithAliases(authorAliasRepo)
 	downloadHealth := downloader.NewHealthStore().WithNotifier(notif)
 	if clients, err := dlClientRepo.List(ctxBoot); err == nil {

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -44,6 +44,7 @@ type AuthorHandler struct {
 	searcher                    BookSearcher
 	finder                      LibraryFinder
 	editions                    *db.EditionRepo
+	roots                       *LibraryRoots // optional: library-root containment for delete
 	enhancedHardcoverEnvEnabled bool
 
 	editionFetcher bookhydrate.EditionFetcher
@@ -65,6 +66,14 @@ func (h *AuthorHandler) WithFinder(f LibraryFinder) *AuthorHandler {
 // books created while syncing author catalogues.
 func (h *AuthorHandler) WithEditionHydration(editions *db.EditionRepo) *AuthorHandler {
 	h.editions = editions
+	return h
+}
+
+// WithRoots wires the library-root containment checker used by Delete to
+// refuse on-disk removal of paths outside the configured library. A nil
+// value disables the check.
+func (h *AuthorHandler) WithRoots(r *LibraryRoots) *AuthorHandler {
+	h.roots = r
 	return h
 }
 
@@ -908,6 +917,12 @@ func (h *AuthorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// us nothing to walk. Per-path errors are logged but don't abort the
 	// response: the author is already gone, and a partial sweep is better
 	// than rolling the whole thing back.
+	//
+	// Each path is run through the library-root containment check (Wave 1 /
+	// Bundle B): if a `file_path` is outside any configured library root —
+	// whether through a tampered import, a buggy migration, or a hostile
+	// metadata payload — the on-disk delete is skipped with a WARN log
+	// rather than walking outside the library.
 	var pathsToRemove []string
 	if r.URL.Query().Get("deleteFiles") == "true" {
 		books, err := h.books.ListByAuthor(r.Context(), id)
@@ -927,7 +942,7 @@ func (h *AuthorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, p := range pathsToRemove {
-		if err := removeBookPath(p); err != nil {
+		if _, err := safeRemoveBookPath(r.Context(), h.roots, p, "", "author_id", id); err != nil {
 			slog.Warn("delete author: failed to remove file", "author_id", id, "path", p, "error", err)
 		}
 	}

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -2556,3 +2556,80 @@ func TestCanUpgradeToBoth(t *testing.T) {
 		}
 	}
 }
+
+// TestDeleteAuthor_PathContainment_RejectsOutsideRoots is the author-side
+// Wave 1 / Bundle B guard. When the delete-files sweep walks a book whose
+// file_path is outside every configured root, the on-disk file is left
+// alone but the author + book rows are still removed via the FK cascade.
+func TestDeleteAuthor_PathContainment_RejectsOutsideRoots(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL920A", Name: "Outside Author", SortName: "Author, Outside",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	libA := t.TempDir()
+	// Outside-roots file: this must survive the delete.
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "outside.epub")
+	if err := os.WriteFile(outsidePath, []byte("untouchable"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Inside-roots file: this should still be deleted.
+	insidePath := filepath.Join(libA, "inside.epub")
+	if err := os.WriteFile(insidePath, []byte("legit"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, b := range []*models.Book{
+		{ForeignID: "OL920W1", AuthorID: author.ID, Title: "Outside", SortTitle: "outside", FilePath: outsidePath, Status: "imported", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true},
+		{ForeignID: "OL920W2", AuthorID: author.ID, Title: "Inside", SortTitle: "inside", FilePath: insidePath, Status: "imported", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true},
+	} {
+		if err := bookRepo.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+		if err := bookRepo.SetFilePath(ctx, b.ID, b.FilePath); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, nil, nil, profileRepo, nil).
+		WithRoots(NewLibraryRoots(staticRootLister{paths: []string{libA}}))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/author/"+strconv.FormatInt(author.ID, 10)+"?deleteFiles=true", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(author.ID, 10))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Outside-roots file: must survive.
+	if _, err := os.Stat(outsidePath); err != nil {
+		t.Errorf("file outside library roots must NOT be deleted: stat err=%v", err)
+	}
+	// Inside-roots file: removed normally.
+	if _, err := os.Stat(insidePath); !os.IsNotExist(err) {
+		t.Errorf("file inside library root SHOULD be deleted, stat err=%v", err)
+	}
+	// Author row gone.
+	if got, _ := authorRepo.GetByID(ctx, author.ID); got != nil {
+		t.Errorf("author row should be deleted, got id=%d", got.ID)
+	}
+}

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -32,6 +32,7 @@ type BookHandler struct {
 	authors   *db.AuthorRepo
 	series    *db.SeriesRepo
 	editions  *db.EditionRepo
+	roots     *LibraryRoots // optional: library-root containment for delete
 
 	editionFetcher bookhydrate.EditionFetcher
 }
@@ -81,6 +82,14 @@ func (h *BookHandler) WithSeries(s *db.SeriesRepo) *BookHandler {
 // metadata identities.
 func (h *BookHandler) WithEditionHydration(editions *db.EditionRepo) *BookHandler {
 	h.editions = editions
+	return h
+}
+
+// WithRoots wires the library-root containment checker used by the delete
+// handlers to refuse on-disk removal of paths outside the configured library.
+// A nil value disables the check (the default; preserves legacy test wiring).
+func (h *BookHandler) WithRoots(r *LibraryRoots) *BookHandler {
+	h.roots = r
 	return h
 }
 
@@ -367,11 +376,16 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Opt-in `?deleteFiles=true` also removes every on-disk file tracked in
-	// book_files before dropping the record.
+	// book_files before dropping the record. Each path is first run through
+	// the library-root containment check (Wave 1 / Bundle B) so a tampered
+	// or mis-imported `file_path` outside any configured root cannot redirect
+	// the on-disk delete. Skipped paths are WARN-logged; the DB delete below
+	// still proceeds — the row is going away regardless, and a loud refusal
+	// is better than silently walking outside the library.
 	if r.URL.Query().Get("deleteFiles") == "true" {
 		files, _ := h.books.ListFiles(r.Context(), id)
 		for _, f := range files {
-			if err := removeBookPath(f.Path); err != nil {
+			if _, err := safeRemoveBookPath(r.Context(), h.roots, f.Path, "", "id", id); err != nil {
 				slog.Warn("book delete: failed to remove file", "id", id, "path", f.Path, "error", err)
 			}
 		}
@@ -380,7 +394,7 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			if book, _ := h.books.GetByID(r.Context(), id); book != nil {
 				for _, p := range []string{book.EbookFilePath, book.AudiobookFilePath, book.FilePath} {
 					if p != "" {
-						if err := removeBookPath(p); err != nil {
+						if _, err := safeRemoveBookPath(r.Context(), h.roots, p, "", "id", id); err != nil {
 							slog.Warn("book delete: failed to remove legacy file", "id", id, "path", p, "error", err)
 						}
 					}
@@ -464,14 +478,21 @@ func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 	// Remove files from disk and from book_files. When a format filter is
 	// supplied, the stem-sibling sweep is scoped to that format so deleting
 	// the ebook does not also destroy the audiobook sibling (and vice versa).
+	// Paths failing the library-root containment check are skipped (with a
+	// WARN log); the book_files row is still deregistered so the orphaned
+	// path stops surfacing in subsequent reads. Returning 500 instead would
+	// strand the row permanently behind a path the user cannot delete.
 	var deletedPaths []string
 	for _, p := range toDelete {
-		if err := removeBookPathScoped(p, format); err != nil {
+		skipped, err := safeRemoveBookPath(r.Context(), h.roots, p, format, "id", id)
+		if err != nil {
 			slog.Error("failed to remove book file", "id", id, "path", p, "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
 		}
-		deletedPaths = append(deletedPaths, p)
+		if !skipped {
+			deletedPaths = append(deletedPaths, p)
+		}
 		if _, err := h.books.RemoveBookFile(r.Context(), p); err != nil {
 			slog.Warn("failed to deregister book file", "id", id, "path", p, "error", err)
 		}
@@ -501,12 +522,6 @@ func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, book)
-}
-
-// removeBookPath deletes a file or directory at p with an unscoped stem
-// sweep — see removeBookPathScoped. Used when no format filter is supplied.
-func removeBookPath(p string) error {
-	return removeBookPathScoped(p, "")
 }
 
 // removeBookPathScoped deletes a file or directory at p. Audiobooks are stored

--- a/internal/api/books_test.go
+++ b/internal/api/books_test.go
@@ -705,3 +705,176 @@ func TestBookUpdate_NoSearchWhenAlreadyWanted(t *testing.T) {
 
 	searcher.assertNoCall(t, 50*time.Millisecond)
 }
+
+// staticRootLister is a RootLister stub that returns a fixed set of root
+// folder paths without touching a database. Used by the path-containment
+// tests so they don't have to wire a real RootFolderRepo.
+type staticRootLister struct {
+	paths []string
+}
+
+func (s staticRootLister) List(_ context.Context) ([]models.RootFolder, error) {
+	out := make([]models.RootFolder, 0, len(s.paths))
+	for i, p := range s.paths {
+		out = append(out, models.RootFolder{ID: int64(i + 1), Path: p})
+	}
+	return out, nil
+}
+
+// TestBookDelete_PathContainment_RejectsOutsideRoots is the Wave 1 / Bundle B
+// defence-in-depth guard: even with ?deleteFiles=true, a DB row whose
+// file_path points outside every configured library root must not be
+// followed onto disk. The DB row still goes away (the file is already
+// orphaned from Bindery's perspective; preserving the row would just leave
+// it permanently un-deletable through the UI) but the on-disk file is
+// untouched.
+func TestBookDelete_PathContainment_RejectsOutsideRoots(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+	libA := t.TempDir()
+	libB := t.TempDir()
+	// Wire the handler with two library roots that do NOT contain the
+	// book's file_path.
+	h.WithRoots(NewLibraryRoots(staticRootLister{paths: []string{libA, libB}}))
+
+	// Fixture file outside both roots. We use t.TempDir() so the test
+	// cleanup deletes it if the production code regresses and removes it
+	// here — better an orphan in the temp dir than a real /etc/passwd
+	// touch in CI.
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "definitely-not-mine.epub")
+	if err := os.WriteFile(outsidePath, []byte("untouchable"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	book := &models.Book{
+		ForeignID: "B-OUT", AuthorID: author.ID, Title: "Outside", SortTitle: "outside",
+		Status: models.BookStatusImported, Genres: []string{},
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.SetFilePath(ctx, book.ID, outsidePath); err != nil {
+		t.Fatal(err)
+	}
+
+	req := withURLParam(
+		httptest.NewRequest(http.MethodDelete, "/api/v1/book/"+strconv.FormatInt(book.ID, 10)+"?deleteFiles=true", nil),
+		"id", strconv.FormatInt(book.ID, 10))
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// The on-disk file must survive.
+	if _, err := os.Stat(outsidePath); err != nil {
+		t.Errorf("file outside library roots must NOT be deleted: stat err=%v", err)
+	}
+	// The DB row must be gone.
+	if got, _ := books.GetByID(ctx, book.ID); got != nil {
+		t.Errorf("book row should be deleted even when on-disk delete is refused, got id=%d", got.ID)
+	}
+}
+
+// TestBookDelete_PathContainment_AllowsInsideRoots confirms the positive
+// case: when the file_path IS inside a configured root, the on-disk file
+// is removed and the DB row goes away — the containment check must not
+// regress the existing legitimate-delete path.
+func TestBookDelete_PathContainment_AllowsInsideRoots(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+	libA := t.TempDir()
+	libB := t.TempDir()
+	h.WithRoots(NewLibraryRoots(staticRootLister{paths: []string{libA, libB}}))
+
+	// File legitimately under libA, mirroring the importer's
+	// "<root>/<Author>/<Title>.epub" layout.
+	authorDir := filepath.Join(libA, "Test Author")
+	if err := os.MkdirAll(authorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	insidePath := filepath.Join(authorDir, "book.epub")
+	if err := os.WriteFile(insidePath, []byte("legit"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	book := &models.Book{
+		ForeignID: "B-IN", AuthorID: author.ID, Title: "Inside", SortTitle: "inside",
+		Status: models.BookStatusImported, Genres: []string{},
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.SetFilePath(ctx, book.ID, insidePath); err != nil {
+		t.Fatal(err)
+	}
+
+	req := withURLParam(
+		httptest.NewRequest(http.MethodDelete, "/api/v1/book/"+strconv.FormatInt(book.ID, 10)+"?deleteFiles=true", nil),
+		"id", strconv.FormatInt(book.ID, 10))
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if _, err := os.Stat(insidePath); !os.IsNotExist(err) {
+		t.Errorf("file inside library root SHOULD be deleted, stat err=%v", err)
+	}
+	if got, _ := books.GetByID(ctx, book.ID); got != nil {
+		t.Errorf("book row should be deleted, got id=%d", got.ID)
+	}
+}
+
+// TestBookDeleteFile_PathContainment_RejectsOutsideRoots covers the
+// "scrub-and-keep" flow (DeleteFile, not Delete): an outside-roots
+// file_path must not get unlinked, but the book row must keep moving
+// through its state transition (book_files row dropped, status flipped
+// back to wanted) so the orphan path doesn't get stuck in the UI.
+func TestBookDeleteFile_PathContainment_RejectsOutsideRoots(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+	libA := t.TempDir()
+	h.WithRoots(NewLibraryRoots(staticRootLister{paths: []string{libA}}))
+
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "outside.epub")
+	if err := os.WriteFile(outsidePath, []byte("untouchable"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	book := &models.Book{
+		ForeignID: "B-DF-OUT", AuthorID: author.ID, Title: "DF Outside", SortTitle: "df out",
+		Status: models.BookStatusImported, Genres: []string{},
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.SetFilePath(ctx, book.ID, outsidePath); err != nil {
+		t.Fatal(err)
+	}
+
+	req := withURLParam(
+		httptest.NewRequest(http.MethodDelete, "/api/v1/book/"+strconv.FormatInt(book.ID, 10)+"/file", nil),
+		"id", strconv.FormatInt(book.ID, 10))
+	rec := httptest.NewRecorder()
+	h.DeleteFile(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// File survives.
+	if _, err := os.Stat(outsidePath); err != nil {
+		t.Errorf("file outside library roots must NOT be deleted: stat err=%v", err)
+	}
+	// Status flips, file_path is cleared — the orphan no longer shows up as
+	// an imported file.
+	got, _ := books.GetByID(ctx, book.ID)
+	if got == nil {
+		t.Fatal("book row should remain after DeleteFile")
+	}
+	if got.FilePath != "" {
+		t.Errorf("file_path should be cleared after refused delete, got %q", got.FilePath)
+	}
+}

--- a/internal/api/path_safety.go
+++ b/internal/api/path_safety.go
@@ -1,0 +1,192 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// RootLister is the minimal surface LibraryRoots needs from the root-folders
+// repo. Declared here (rather than depending on *db.RootFolderRepo directly)
+// so tests can plug in a static list without spinning up a database.
+type RootLister interface {
+	List(ctx context.Context) ([]models.RootFolder, error)
+}
+
+// LibraryRoots resolves the set of on-disk paths that the user has declared
+// "Bindery may write to and delete from". It backs the defence-in-depth
+// containment check used by the delete handlers (Wave 1 / Bundle B): even if
+// a DB row ever ends up with a `file_path` outside any configured library
+// (via a future bug, a tampered import, or a hostile metadata payload), the
+// delete handler refuses to walk outside the configured roots.
+//
+// Roots come from two places:
+//
+//   - The `root_folders` table, populated by the user from the UI. This is the
+//     dynamic, primary source of truth.
+//   - A static `defaults` slice carried by the process — typically the
+//     BINDERY_LIBRARY_DIR / BINDERY_AUDIOBOOK_DIR env vars. These cover the
+//     legacy single-root setup where the user never created a root_folders
+//     row but the importer still writes under one of those dirs.
+//
+// Both are merged into a deduplicated, filepath.Cleaned set per call. The
+// lookup is small (typically <5 roots) so we don't bother caching.
+//
+// A nil *LibraryRoots is a deliberate signal: "no containment check
+// available". Callers treat nil as "allow", preserving backwards behaviour
+// for tests and any code path that hasn't been wired yet. The production
+// wiring in cmd/bindery/main.go always supplies a non-nil instance.
+type LibraryRoots struct {
+	lister   RootLister
+	defaults []string
+}
+
+// NewLibraryRoots builds a LibraryRoots backed by the given lister and any
+// static fallback paths (typically BINDERY_LIBRARY_DIR and
+// BINDERY_AUDIOBOOK_DIR). nil or empty default entries are dropped silently.
+func NewLibraryRoots(lister RootLister, defaults ...string) *LibraryRoots {
+	clean := make([]string, 0, len(defaults))
+	for _, d := range defaults {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		clean = append(clean, filepath.Clean(d))
+	}
+	return &LibraryRoots{lister: lister, defaults: clean}
+}
+
+// resolveRoots returns the merged + cleaned set of root paths for this call.
+// Errors from the DB lister are logged and treated as "no DB roots" so a
+// transient DB hiccup does not turn the containment check into a deny-all
+// (which would block legitimate file deletions). The static defaults still
+// apply.
+func (r *LibraryRoots) resolveRoots(ctx context.Context) []string {
+	seen := make(map[string]struct{}, len(r.defaults)+4)
+	out := make([]string, 0, len(r.defaults)+4)
+	add := func(p string) {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			return
+		}
+		p = filepath.Clean(p)
+		if _, ok := seen[p]; ok {
+			return
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	for _, d := range r.defaults {
+		add(d)
+	}
+	if r.lister != nil {
+		folders, err := r.lister.List(ctx)
+		if err != nil {
+			slog.Warn("path containment: failed to list root folders, falling back to static defaults", "error", err)
+		} else {
+			for _, f := range folders {
+				add(f.Path)
+			}
+		}
+	}
+	return out
+}
+
+// Contains reports whether p is inside at least one configured library root.
+// The check is deliberately strict:
+//
+//   - Empty or relative inputs are rejected. The importer always writes
+//     absolute paths; a relative path in a `file_path` column is a bug or a
+//     hostile payload, and there is no safe way to anchor it.
+//   - p and each root are filepath.Cleaned before comparison so trailing
+//     slashes and `..` segments don't bypass the prefix check.
+//   - Symlinks inside p are resolved via filepath.EvalSymlinks when possible.
+//     If the path no longer exists, EvalSymlinks fails — we fall back to the
+//     lexical Clean+Rel check rather than refusing the delete (the file is
+//     already gone or the symlink target moved; either way refusing here
+//     would just orphan the DB row indefinitely).
+//   - Containment is established via filepath.Rel: the relative path from
+//     the root to p must not start with ".." and must not be "." (a root
+//     pointed at itself is not a valid book file).
+//
+// Returns true iff at least one root contains p. A nil receiver returns
+// true — the caller has opted out of the check.
+func (r *LibraryRoots) Contains(ctx context.Context, p string) bool {
+	if r == nil {
+		return true
+	}
+	p = strings.TrimSpace(p)
+	if p == "" || !filepath.IsAbs(p) {
+		return false
+	}
+	cleaned := filepath.Clean(p)
+	// Best-effort symlink resolution. A failure here (file deleted, broken
+	// link, permission denied) just falls back to the lexical check below.
+	resolved := cleaned
+	if real, err := filepath.EvalSymlinks(cleaned); err == nil {
+		resolved = real
+	}
+	roots := r.resolveRoots(ctx)
+	if len(roots) == 0 {
+		// No roots configured at all (no DB rows AND no static defaults).
+		// We can't tell what's "inside"; allow to preserve legacy behaviour
+		// for single-tenant installs that never wired roots. Production
+		// wiring always seeds at least one default.
+		return true
+	}
+	for _, root := range roots {
+		if containsUnderRoot(resolved, root) {
+			return true
+		}
+		// Also try the un-resolved form: symlinks pointing into the library
+		// from outside should still pass when the lexical path is inside.
+		if resolved != cleaned && containsUnderRoot(cleaned, root) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsUnderRoot is the lexical containment primitive shared by Contains.
+// Returns true iff p is the same as root or strictly nested under it.
+func containsUnderRoot(p, root string) bool {
+	if root == "" || root == "." {
+		return false
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		// p == root. A library root itself is not a deletable book path.
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
+// safeRemoveBookPath is the containment-gated wrapper around
+// removeBookPathScoped used by the book/author delete handlers. If roots is
+// non-nil and p is not contained, the deletion is skipped with a WARN log
+// and (skipped=true, nil) is returned: skipped=true signals "we
+// intentionally did not touch disk".
+//
+// Calibre-imported paths get the same containment check. Letting calibre
+// rows allow-list themselves around the gate would re-introduce the exact
+// failure mode the audit flagged: a hostile or buggy import (e.g. a
+// metadata.opf with `<path>/etc/passwd</path>`) could redirect a delete
+// outside any library. The Calibre integration writes into a configured
+// library dir anyway, so legitimate Calibre books still pass the check.
+func safeRemoveBookPath(ctx context.Context, roots *LibraryRoots, p, format string, logFields ...any) (skipped bool, err error) {
+	if !roots.Contains(ctx, p) {
+		fields := append([]any{"path", p, "operation", "book_file_delete"}, logFields...)
+		slog.Warn("path containment: refusing to delete file outside configured library roots", fields...)
+		return true, nil
+	}
+	return false, removeBookPathScoped(p, format)
+}

--- a/internal/api/path_safety_test.go
+++ b/internal/api/path_safety_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// TestLibraryRoots_Contains exercises the containment primitive directly so a
+// regression in the rules (clean, rel, abs, "." sentinel) shows up here
+// before any handler-level test even has to construct fixture files.
+func TestLibraryRoots_Contains(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir()
+	roots := NewLibraryRoots(staticRootLister{paths: []string{root}})
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"nested file under root", filepath.Join(root, "Author", "book.epub"), true},
+		{"nested deeper", filepath.Join(root, "a", "b", "c", "d.epub"), true},
+		{"root itself is not a deletable path", root, false},
+		{"sibling temp dir outside root", filepath.Join(other, "x.epub"), false},
+		{"absolute /etc/passwd", "/etc/passwd", false},
+		{"relative path rejected outright", "Author/book.epub", false},
+		{"empty path rejected", "", false},
+		{"traversal attempt with ..", filepath.Join(root, "..", filepath.Base(other), "x.epub"), false},
+		{"trailing slash on input still inside", filepath.Join(root, "Author") + string(filepath.Separator), true},
+	}
+	ctx := context.Background()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := roots.Contains(ctx, c.path)
+			if got != c.want {
+				t.Errorf("Contains(%q) = %v, want %v", c.path, got, c.want)
+			}
+		})
+	}
+}
+
+// TestLibraryRoots_NilReceiverAllows confirms the nil-receiver shortcut: a
+// handler that hasn't been wired with WithRoots keeps the legacy behaviour
+// (no containment check). Critical so the existing test fixtures that don't
+// configure roots don't suddenly start rejecting all delete operations.
+func TestLibraryRoots_NilReceiverAllows(t *testing.T) {
+	var r *LibraryRoots
+	if !r.Contains(context.Background(), "/anything") {
+		t.Error("nil *LibraryRoots must report Contains = true")
+	}
+}
+
+// TestLibraryRoots_DefaultsOnlyContains verifies the static-defaults path
+// (the BINDERY_LIBRARY_DIR / BINDERY_AUDIOBOOK_DIR cover for installs that
+// never created a root_folders row). No DB lister at all, just defaults.
+func TestLibraryRoots_DefaultsOnlyContains(t *testing.T) {
+	libraryDir := t.TempDir()
+	audiobookDir := t.TempDir()
+	roots := NewLibraryRoots(nil, libraryDir, audiobookDir, "")
+
+	ctx := context.Background()
+	if !roots.Contains(ctx, filepath.Join(libraryDir, "x.epub")) {
+		t.Errorf("path under libraryDir default must be contained")
+	}
+	if !roots.Contains(ctx, filepath.Join(audiobookDir, "y.m4b")) {
+		t.Errorf("path under audiobookDir default must be contained")
+	}
+	if roots.Contains(ctx, "/etc/passwd") {
+		t.Errorf("/etc/passwd must not be contained")
+	}
+}
+
+// TestLibraryRoots_NoConfigurationFallsOpen documents the deliberate
+// fail-open when neither a DB lister nor static defaults are supplied.
+// The production wiring always supplies at least one default, but legacy
+// tests that construct handlers without WithRoots rely on this branch.
+func TestLibraryRoots_NoConfigurationFallsOpen(t *testing.T) {
+	roots := NewLibraryRoots(nil)
+	if !roots.Contains(context.Background(), "/tmp/whatever.epub") {
+		t.Error("no roots configured: Contains must fall open to preserve legacy behaviour")
+	}
+}


### PR DESCRIPTION
## Summary

Defence-in-depth fix for the Wave 1 / Bundle B audit finding `library-root path containment on delete`. The book and author delete handlers walked DB-stored `file_path` columns straight into `os.Remove` / `os.RemoveAll` without any check that the path sat under a configured library root. A `file_path` mis-set by a future bug (SSTI in the metadata renderer, a hostile ABS import payload, a tampered Calibre `.opf`, or a bad migration) could redirect the on-disk delete anywhere the bindery process can write — turning a normal "Delete book (files)" click into "Bindery just deleted `/etc/passwd`".

## Threat model

- **Not a known active exploit.** No current code path lets an attacker write an arbitrary value into `books.file_path`; the importer sanitises everything it writes. The audit flagged this as defence-in-depth because the failure mode (Bindery silently walking outside the library) is asymmetric: catastrophic on the wrong day, near-free to gate.
- **Failure surface today.** Every place that ever writes to `books.file_path`, `book_files.path`, `books.ebook_file_path`, or `books.audiobook_file_path`. That includes the importer, the ABS import flow (which already does its own sandboxing but trusts the configured root list), the Calibre import flow, and any future write path (#864 / #889 / #893 are all candidates).
- **Fix shape.** A small `LibraryRoots` helper (DB-backed root_folders list, merged with the `BINDERY_LIBRARY_DIR` / `BINDERY_AUDIOBOOK_DIR` env-var defaults) plus a `safeRemoveBookPath` wrapper around the existing `removeBookPathScoped`. The wrapper refuses to call `os.Remove` / `os.RemoveAll` on any out-of-roots path, WARN-logs the rejection with the offending path + the operation, and lets the delete handler keep going so the DB row still goes away (the orphan is already orphaned from Bindery's perspective; leaving the row behind would just mean the user can never delete the book through the UI).

## Design choices worth flagging

- **Calibre paths get the same gate.** I considered allow-listing `MetadataProvider == "calibre"` rows out of the check, but that re-introduces the exact failure mode the audit flagged: a hostile or buggy Calibre import (e.g. a metadata.opf with `<path>/etc/passwd</path>`) would silently bypass the gate. The Calibre integration writes into a configured library dir anyway, so legitimate Calibre books still pass containment. The comment in `safeRemoveBookPath` documents this.
- **Fail-open when no roots are configured at all.** A handler constructed without `WithRoots()` (existing tests) and a process with neither root_folders rows nor `BINDERY_LIBRARY_DIR`/`BINDERY_AUDIOBOOK_DIR` configured both fall through to the old behaviour. The first preserves legacy test fixtures; the second is unreachable in production (`cmd/bindery/main.go` always passes the env-var defaults). A future PR could harden this to fail-closed once we're confident every install has configured at least one root.
- **Symlink resolution is best-effort.** `filepath.EvalSymlinks` runs when the path still exists; on failure we fall back to the lexical Clean+Rel check rather than refusing the delete. A delete handler that refuses every dead-symlink path would leave orphaned DB rows forever.
- **DeleteFile keeps deregistering book_files even when the on-disk delete is skipped.** Returning 500 here would strand the row permanently behind a path the user cannot delete through the UI. The orphan path stops showing up in reads; the file on disk is intact and WARN-logged for the admin to investigate.

## Call sites covered

- `BookHandler.Delete` (`?deleteFiles=true`): every `book_files.path` + legacy `EbookFilePath`/`AudiobookFilePath`/`FilePath` fallback.
- `BookHandler.DeleteFile` (the `/file` endpoint, plus `?format=ebook`/`audiobook` scoped variants).
- `AuthorHandler.Delete` (`?deleteFiles=true`): every book row owned by the author.

## Call sites NOT covered (need a follow-up decision)

- **Downloader / importer cleanup paths.** `internal/downloader/*` and `internal/importer/*` do their own `os.Remove` on staged downloads and post-import cleanup. Those are gated by the configured download/library dirs at startup and have never been audited as an arbitrary-path-delete risk, but they bypass this new check. Out of scope for Wave 1 / Bundle B; ping back if you want them in.
- **`/api/v1/book/{id}/file` from the OPDS/queue side.** These do not call the delete handlers — they only read. Confirmed safe today.

## Test plan

Added:

- `TestLibraryRoots_Contains` (and friends in `path_safety_test.go`) covering the containment primitive: clean, rel, abs-vs-relative, traversal attempts, trailing slash, the "root itself" sentinel, nil-receiver and no-config fall-open branches.
- `TestBookDelete_PathContainment_RejectsOutsideRoots` — fixture file outside both roots; assert the file survives, the DB row is gone, and the handler returns 204.
- `TestBookDelete_PathContainment_AllowsInsideRoots` — fixture file under a configured root; assert the file IS deleted and the row IS gone (positive case; guards against the gate over-blocking legitimate deletes).
- `TestBookDeleteFile_PathContainment_RejectsOutsideRoots` — the scrub-and-keep flow; outside-roots file survives, but `file_path` is cleared and the row stays so the orphan does not stick in the UI.
- `TestDeleteAuthor_PathContainment_RejectsOutsideRoots` — author with two books, one inside roots and one outside; assert only the inside-roots file is deleted.

Manual:

- [x] `go build ./...` clean
- [x] `golangci-lint run ./internal/api/ ./cmd/...` clean
- [x] `go test ./internal/api/` clean
- [x] `go test -race ./internal/api/ -run "TestBookDelete|TestAuthor|TestBookDeleteFile|TestLibraryRoots|TestDeleteAuthor|TestBookList|TestBookUpdate"` clean

## Related audit work

- PR #892 / PR #893: Wave 1 critical-tier fixes. This PR is the Wave 1 / Bundle B defence-in-depth follow-up. Update these references if the numbers landed differently.