### PR TITLE
fix(auth): invalidate existing sessions on password change (Wave 1 / Bundle C)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -1194,6 +1194,20 @@ func (p *dbAuthProvider) UserRole(ctx context.Context, userID int64) string {
 	}
 	return u.Role
 }
+
+// UserSessionEpoch returns the user's current users.session_epoch, the value
+// the cookie payload must match for the auth middleware to accept it. Bumped
+// inside UpdatePassword so a password change immediately evicts every
+// outstanding cookie for that user (Wave 1 / Bundle C audit finding).
+// Returns 0 on lookup failure or missing user — that fails closed against
+// any cookie minted after the 047 migration (which defaults the column to 1).
+func (p *dbAuthProvider) UserSessionEpoch(ctx context.Context, userID int64) int64 {
+	epoch, err := p.users.GetSessionEpoch(ctx, userID)
+	if err != nil {
+		return 0
+	}
+	return epoch
+}
 func (p *dbAuthProvider) UserProvisioner() auth.UserProvisioner {
 	return &dbUserProvisioner{users: p.users}
 }

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -281,9 +281,24 @@ func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, "hash: "+err.Error())
 		return
 	}
+	// UpdatePassword atomically bumps users.session_epoch, which invalidates
+	// every existing session cookie for this user — including the one the
+	// caller just used to authenticate. Re-issue a fresh cookie carrying the
+	// new epoch so the browser that performed the change is not immediately
+	// bounced to the login screen (Wave 1 / Bundle C audit finding). Other
+	// browsers / devices / stolen cookies still hold the pre-bump epoch and
+	// are correctly evicted.
 	if err := h.users.UpdatePassword(ctx, u.ID, hash); err != nil {
 		writeErr(w, http.StatusInternalServerError, "update: "+err.Error())
 		return
+	}
+	// Re-mint only when the change is happening on behalf of a logged-in
+	// caller. The single-user-fallback path (uid==0) has no cookie to
+	// preserve, so skip cookie issuance there.
+	if uid != 0 {
+		if !h.issueSession(w, r, ctx, u.ID, true) {
+			return
+		}
 	}
 	writeOK(w, map[string]any{"ok": true})
 }
@@ -479,13 +494,28 @@ func (h *AuthHandler) sessionSecrets(ctx context.Context) [][]byte {
 // issueSession signs and sets the session cookie. It returns true on success.
 // On failure it writes a 500 error response and returns false — callers must
 // return immediately without writing any further response.
+//
+// The cookie carries the user's current session_epoch (looked up here). The
+// middleware compares that field against the live column on every request and
+// rejects mismatches, which is how UpdatePassword's epoch bump invalidates
+// every outstanding cookie for that user (Wave 1 / Bundle C audit finding).
+//
+// Order matters at the password-change call site: epoch must be bumped FIRST,
+// the new cookie minted SECOND. issueSession reads the post-bump epoch here,
+// so a caller that mints the cookie before bumping would invalidate it
+// instantly.
 func (h *AuthHandler) issueSession(w http.ResponseWriter, r *http.Request, ctx context.Context, userID int64, rememberMe bool) bool {
 	dur := auth.SessionDurationShort
 	if rememberMe {
 		dur = auth.SessionDuration
 	}
 	exp := time.Now().Add(dur)
-	value, err := auth.SignSession(h.sessionSecret(ctx), userID, exp)
+	epoch, err := h.users.GetSessionEpoch(ctx, userID)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "session epoch lookup: "+err.Error())
+		return false
+	}
+	value, err := auth.SignSessionWithEpoch(h.sessionSecret(ctx), userID, epoch, exp)
 	if err != nil {
 		// Secret is absent or too short — fail closed rather than issue a
 		// forgeable token. This should never happen in practice because

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -4,14 +4,19 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
 )
 
 // newAuthFixture spins up an in-memory DB, the auth repos, a seeded session
@@ -603,4 +608,257 @@ func TestStatus_LocalAuthEnabled_False(t *testing.T) {
 	if resp.LocalAuthEnabled {
 		t.Error("expected localAuthEnabled=false after WithLocalAuthEnabled(false)")
 	}
+}
+
+// --- Wave 1 / Bundle C: session invalidation on password change --------------
+//
+// These tests pin the "log everyone out after a password change" contract
+// (audit finding #893 sibling). The mechanism is the per-user session_epoch
+// column: cookies carry the epoch under which they were minted, the
+// middleware compares against the live column on every request, and
+// UpdatePassword bumps the column. Verifying through the real auth.Middleware
+// chain is the only way to assert the audit-blocker is closed end-to-end —
+// poking ChangePassword in isolation would miss the cookie/epoch comparison.
+
+// epochProvider is a real auth.Provider that defers to a UserRepo for the
+// session_epoch (and role) so the middleware behaves exactly as in prod.
+type epochProvider struct {
+	users  *db.UserRepo
+	secret []byte
+}
+
+func (p *epochProvider) Mode() auth.Mode                       { return auth.ModeEnabled }
+func (p *epochProvider) APIKey() string                        { return "" }
+func (p *epochProvider) SessionSecret() []byte                 { return p.secret }
+func (p *epochProvider) SessionSecrets() [][]byte              { return [][]byte{p.secret} }
+func (p *epochProvider) SetupRequired() bool                   { return false }
+func (p *epochProvider) ProxyAuthHeader() string               { return "" }
+func (p *epochProvider) ProxyAutoProvision() bool              { return false }
+func (p *epochProvider) TrustedProxyCIDRs() []*net.IPNet       { return nil }
+func (p *epochProvider) UserProvisioner() auth.UserProvisioner { return nil }
+func (p *epochProvider) UserRole(ctx context.Context, id int64) string {
+	u, _ := p.users.GetByID(ctx, id)
+	if u == nil {
+		return ""
+	}
+	return u.Role
+}
+func (p *epochProvider) UserSessionEpoch(ctx context.Context, id int64) int64 {
+	e, _ := p.users.GetSessionEpoch(ctx, id)
+	return e
+}
+
+// extractSessionCookie returns the session cookie set on the response, or nil
+// if none. The auth handlers always reset the cookie on Login / password
+// change, so a missing cookie there is a test-relevant failure.
+func extractSessionCookie(resp *http.Response) *http.Cookie {
+	for _, c := range resp.Cookies() {
+		if c.Name == auth.SessionCookieName {
+			return c
+		}
+	}
+	return nil
+}
+
+// loginAndGetCookie issues a Login through the handler and returns the
+// session cookie. Fails the test if login does not succeed or no cookie is
+// set. Tightly bound to TestSession_InvalidatedOn* helpers below.
+func loginAndGetCookie(t *testing.T, h *AuthHandler, username, password string) *http.Cookie {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.Login(rec, httptest.NewRequest(http.MethodPost, "/auth/login",
+		jsonBody(t, loginRequest{Username: username, Password: password, RememberMe: true})))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("login: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	c := extractSessionCookie(rec.Result())
+	if c == nil || c.Value == "" {
+		t.Fatal("login: no session cookie set")
+	}
+	return c
+}
+
+// TestSession_InvalidatedOnPasswordChange is the headline audit-fix test:
+// a user logs in, captures their cookie, changes their own password, then
+// the OLD cookie must no longer authenticate. Without the per-user epoch
+// bump, a stolen pre-change cookie would keep working for the full 30-day
+// TTL — exactly the failure mode this PR closes.
+func TestSession_InvalidatedOnPasswordChange(t *testing.T) {
+	h, users, settings, ctx := newAuthFixture(t)
+	hash, _ := auth.HashPassword("old-password-1234")
+	u, err := users.Create(ctx, "alice", hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldCookie := loginAndGetCookie(t, h, "alice", "old-password-1234")
+
+	// Change the password while authenticated as alice. The handler reads
+	// the uid from context, so drive it the same way the middleware would.
+	cpReq := httptest.NewRequest(http.MethodPost, "/auth/password",
+		jsonBody(t, changePasswordRequest{
+			CurrentPassword: "old-password-1234",
+			NewPassword:     "new-password-9876",
+		}))
+	cpReq = cpReq.WithContext(auth.WithUserID(cpReq.Context(), u.ID))
+	cpRec := httptest.NewRecorder()
+	h.ChangePassword(cpRec, cpReq)
+	if cpRec.Code != http.StatusOK {
+		t.Fatalf("change password: status=%d body=%s", cpRec.Code, cpRec.Body.String())
+	}
+
+	// Build the real middleware chain with a provider that reads the live
+	// epoch — this mirrors production exactly. The handler the chain wraps
+	// records whether the cookie authenticated.
+	provider := &epochProvider{users: users, secret: []byte(must(settings.Get(ctx, SettingAuthSessionSecret)).Value)}
+	var reached bool
+	chain := auth.Middleware(provider)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth.UserIDFromContext(r.Context()) != 0 {
+			reached = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Re-use the OLD cookie on a fresh request — must NOT authenticate.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/author", nil)
+	req.AddCookie(oldCookie)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+	if reached {
+		t.Fatal("pre-password-change cookie still authenticated — the epoch bump did not invalidate it")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status=%d; want 401 for stale cookie", rec.Code)
+	}
+}
+
+// TestSession_InvalidatedOnAdminPasswordReset covers the admin-reset path:
+// userB's own cookie must be rejected after an admin resets B's password.
+// This is the multi-user case the audit specifically flagged — the admin
+// reset is what an operator runs when responding to a suspected compromise.
+func TestSession_InvalidatedOnAdminPasswordReset(t *testing.T) {
+	h, users, settings, ctx := newAuthFixture(t)
+
+	// userA is the admin doing the reset; userB is the target.
+	hashA, _ := auth.HashPassword("admin-password-12")
+	if _, err := users.Create(ctx, "admin", hashA); err != nil {
+		t.Fatal(err)
+	}
+	if err := users.PromoteFirstUser(ctx); err != nil {
+		t.Fatal(err)
+	}
+	hashB, _ := auth.HashPassword("user-b-password-1")
+	userB, err := users.Create(ctx, "bob", hashB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// userB logs in and captures their cookie.
+	bobCookie := loginAndGetCookie(t, h, "bob", "user-b-password-1")
+
+	// Admin resets userB's password via the user-management handler. That
+	// handler calls users.UpdatePassword, which bumps session_epoch in the
+	// same UPDATE — no separate API call needed.
+	umh := NewUserManagementHandler(users)
+	resetReq := httptest.NewRequest(http.MethodPut,
+		"/api/v1/auth/users/"+strconv.FormatInt(userB.ID, 10)+"/reset-password",
+		jsonBody(t, map[string]string{"password": "reset-by-admin99"}))
+	resetReq = withChiURLParam(resetReq, "id", strconv.FormatInt(userB.ID, 10))
+	resetRec := httptest.NewRecorder()
+	umh.ResetPassword(resetRec, resetReq)
+	if resetRec.Code != http.StatusOK {
+		t.Fatalf("admin reset: status=%d body=%s", resetRec.Code, resetRec.Body.String())
+	}
+
+	// Bob's old cookie must now be rejected by the real middleware chain.
+	provider := &epochProvider{users: users, secret: []byte(must(settings.Get(ctx, SettingAuthSessionSecret)).Value)}
+	var reached bool
+	chain := auth.Middleware(provider)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if auth.UserIDFromContext(r.Context()) != 0 {
+			reached = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/author", nil)
+	req.AddCookie(bobCookie)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+	if reached {
+		t.Fatal("bob's pre-reset cookie still authenticated — admin reset must invalidate sessions")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status=%d; want 401", rec.Code)
+	}
+}
+
+// TestSession_NewCookieValidAfterPasswordChange confirms the partner contract:
+// the browser that performed the password change is NOT logged out. The
+// /auth/password response sets a fresh cookie carrying the post-bump epoch,
+// and that cookie must authenticate on the next request. Without this the
+// user who just changed their password would land on the login screen — bad
+// UX and a regression that would silently revert the audit-fix in practice.
+func TestSession_NewCookieValidAfterPasswordChange(t *testing.T) {
+	h, users, settings, ctx := newAuthFixture(t)
+	hash, _ := auth.HashPassword("old-password-1234")
+	u, err := users.Create(ctx, "alice", hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = loginAndGetCookie(t, h, "alice", "old-password-1234")
+
+	// Drive ChangePassword as alice and capture the response's new cookie.
+	cpReq := httptest.NewRequest(http.MethodPost, "/auth/password",
+		jsonBody(t, changePasswordRequest{
+			CurrentPassword: "old-password-1234",
+			NewPassword:     "new-password-9876",
+		}))
+	cpReq = cpReq.WithContext(auth.WithUserID(cpReq.Context(), u.ID))
+	cpRec := httptest.NewRecorder()
+	h.ChangePassword(cpRec, cpReq)
+	if cpRec.Code != http.StatusOK {
+		t.Fatalf("change password: status=%d body=%s", cpRec.Code, cpRec.Body.String())
+	}
+	newCookie := extractSessionCookie(cpRec.Result())
+	if newCookie == nil || newCookie.Value == "" {
+		t.Fatal("password-change response must set a fresh session cookie so the caller stays logged in")
+	}
+
+	// The fresh cookie must authenticate against the real middleware chain.
+	provider := &epochProvider{users: users, secret: []byte(must(settings.Get(ctx, SettingAuthSessionSecret)).Value)}
+	var gotUID int64
+	chain := auth.Middleware(provider)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUID = auth.UserIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/author", nil)
+	req.AddCookie(newCookie)
+	rec := httptest.NewRecorder()
+	chain.ServeHTTP(rec, req)
+	if gotUID != u.ID {
+		t.Errorf("freshly-issued cookie failed to authenticate: gotUID=%d, want %d", gotUID, u.ID)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status=%d; want 200 for valid fresh cookie", rec.Code)
+	}
+}
+
+// must panics if the SettingsRepo lookup returned an error or nil. Keeps the
+// epoch tests above readable without losing the safety net.
+func must(s *models.Setting, err error) *models.Setting {
+	if err != nil {
+		panic(err)
+	}
+	if s == nil {
+		panic("nil setting")
+	}
+	return s
+}
+
+// withChiURLParam attaches a chi URL parameter to the request context. The
+// user-management handlers parse the user id via chi.URLParam, which expects
+// the chi RouteContext to be present even outside a router.
+func withChiURLParam(r *http.Request, key, value string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(key, value)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
 }

--- a/internal/api/opds_auth.go
+++ b/internal/api/opds_auth.go
@@ -42,9 +42,23 @@ func OPDSAuth(p auth.Provider, users *db.UserRepo, limiter *auth.LoginLimiter) f
 				return
 			}
 			if c, err := r.Cookie(auth.SessionCookieName); err == nil {
-				if _, err := auth.VerifySessionMulti(p.SessionSecrets(), c.Value); err == nil {
-					next.ServeHTTP(w, r)
-					return
+				if uid, epoch, err := auth.VerifySessionMultiWithEpoch(p.SessionSecrets(), c.Value); err == nil {
+					// Same epoch check the main auth middleware performs: the
+					// cookie's epoch must match the user's current
+					// users.session_epoch, which UpdatePassword bumps. Without
+					// this, an OPDS reader holding a pre-password-change
+					// cookie would keep working after the user rotated
+					// credentials (Wave 1 / Bundle C audit finding). users may
+					// be nil under test harnesses that don't wire it; in that
+					// case fall back to signature/expiry-only verification.
+					if users == nil {
+						next.ServeHTTP(w, r)
+						return
+					}
+					if liveEpoch, err := users.GetSessionEpoch(r.Context(), uid); err == nil && liveEpoch == epoch {
+						next.ServeHTTP(w, r)
+						return
+					}
 				}
 			}
 			if username, password, ok := r.BasicAuth(); ok && users != nil {

--- a/internal/api/opds_test.go
+++ b/internal/api/opds_test.go
@@ -135,6 +135,12 @@ func (p *testProvider) ProxyAuthHeader() string                    { return "X-F
 func (p *testProvider) ProxyAutoProvision() bool                   { return false }
 func (p *testProvider) TrustedProxyCIDRs() []*net.IPNet            { return nil }
 func (p *testProvider) UserRole(_ context.Context, _ int64) string { return "admin" }
+
+// UserSessionEpoch returns 0 here; the OPDS tests in this file mint session
+// cookies via SignSession (legacy v2/v1 wrapper) which decode as epoch=0, so
+// returning 0 keeps every existing cookie test passing. The dedicated
+// password-change/epoch-bump integration tests live elsewhere.
+func (p *testProvider) UserSessionEpoch(_ context.Context, _ int64) int64 { return 0 }
 func (p *testProvider) UserProvisioner() auth.UserProvisioner {
 	return nil // proxy auth not exercised in these tests
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -242,6 +242,10 @@ type fakeProvider struct {
 	proxyProvision bool
 	proxyCIDRs     []*net.IPNet
 	provisioner    UserProvisioner
+	// wantEpoch is what UserSessionEpoch returns. Defaults to 0, which lets
+	// legacy v1/v2 test cookies (which decode as epoch=0) authenticate
+	// without every test having to mint v3 cookies.
+	wantEpoch int64
 }
 
 func (f *fakeProvider) Mode() Mode            { return f.mode }
@@ -260,6 +264,11 @@ func (f *fakeProvider) ProxyAutoProvision() bool                   { return f.pr
 func (f *fakeProvider) TrustedProxyCIDRs() []*net.IPNet            { return f.proxyCIDRs }
 func (f *fakeProvider) UserRole(_ context.Context, _ int64) string { return "admin" }
 func (f *fakeProvider) UserProvisioner() UserProvisioner           { return f.provisioner }
+
+// UserSessionEpoch defaults to 0 so legacy v1/v2 test cookies (which decode
+// as epoch=0) continue to authenticate. Tests that exercise the password-
+// change epoch-bump path override this via the wantEpoch field below.
+func (f *fakeProvider) UserSessionEpoch(_ context.Context, _ int64) int64 { return f.wantEpoch }
 
 // staticProvisioner always returns the same user ID for any username.
 type staticProvisioner struct{ uid int64 }
@@ -1306,15 +1315,18 @@ func TestIsLocalRequest_DirectLocalPeerNoXFF(t *testing.T) {
 
 // --- Finding 3: session key-id and rotation primitive ------------------------
 
-func TestSession_V2KeyIDRoundTrip(t *testing.T) {
+func TestSession_V3KeyIDRoundTrip(t *testing.T) {
+	// v3 is the current format (key-id + per-user session epoch). The wrapper
+	// SignSession mints epoch=0 by default, which is fine for this round-trip
+	// test — we are checking the framing, not the epoch-bump invariant.
 	secret := testSecret32
 	cookie, err := SignSession(secret, 99, time.Now().Add(time.Hour))
 	if err != nil {
 		t.Fatalf("sign: %v", err)
 	}
 	parts := strings.Split(cookie, ".")
-	if len(parts) != 5 || parts[0] != "v2" {
-		t.Fatalf("cookie = %q; want 5-part v2 format", cookie)
+	if len(parts) != 6 || parts[0] != "v3" {
+		t.Fatalf("cookie = %q; want 6-part v3 format", cookie)
 	}
 	if parts[1] != keyID(secret) {
 		t.Errorf("cookie key-id = %q; want %q", parts[1], keyID(secret))
@@ -1325,6 +1337,29 @@ func TestSession_V2KeyIDRoundTrip(t *testing.T) {
 	}
 	if uid != 99 {
 		t.Errorf("uid = %d; want 99", uid)
+	}
+}
+
+// TestSession_V2LegacyStillVerifies confirms a v2 cookie minted before the
+// epoch field was introduced still decodes — the audit-fix release accepts
+// v2 on the way in (it just decodes as epoch=0, which the middleware's
+// live-epoch comparison then rejects for upgraded installs).
+func TestSession_V2LegacyStillVerifies(t *testing.T) {
+	secret := testSecret32
+	exp := time.Now().Add(time.Hour).Unix()
+	payload := fmt.Sprintf("v2.%s.%d.%d", keyID(secret), int64(77), exp)
+	mac := hmacSum(secret, payload)
+	v2Cookie := payload + "." + base64.RawURLEncoding.EncodeToString(mac)
+
+	uid, epoch, err := VerifySessionWithEpoch(secret, v2Cookie)
+	if err != nil {
+		t.Fatalf("legacy v2 verify: %v", err)
+	}
+	if uid != 77 {
+		t.Errorf("uid = %d; want 77", uid)
+	}
+	if epoch != 0 {
+		t.Errorf("epoch = %d; want 0 for v2 (no epoch field)", epoch)
 	}
 }
 
@@ -1389,8 +1424,8 @@ func TestSession_LegacyV1StillVerifies(t *testing.T) {
 	}
 }
 
-func TestSession_V2WrongKeyIDStillVerifiesWithCorrectSecret(t *testing.T) {
-	// Decode-tolerant: a v2 cookie whose key-id field does not match (e.g.
+func TestSession_V3WrongKeyIDStillVerifiesWithCorrectSecret(t *testing.T) {
+	// Decode-tolerant: a v3 cookie whose key-id field does not match (e.g.
 	// truncated/garbled) must still verify if the signature is genuine — the
 	// HMAC is authoritative, the key-id is only a routing hint.
 	secret := testSecret32
@@ -1401,14 +1436,16 @@ func TestSession_V2WrongKeyIDStillVerifiesWithCorrectSecret(t *testing.T) {
 	parts := strings.Split(cookie, ".")
 	// Re-sign the payload but lie about the key-id field. The HMAC covers the
 	// key-id, so we must recompute it for the doctored payload to be valid.
+	// v3 payload = parts[0..4] (version, key_id, user_id, epoch, exp); the
+	// HMAC sits at parts[5].
 	parts[1] = "deadbeef"
-	doctoredPayload := strings.Join(parts[:4], ".")
-	parts[4] = base64.RawURLEncoding.EncodeToString(hmacSum(secret, doctoredPayload))
+	doctoredPayload := strings.Join(parts[:5], ".")
+	parts[5] = base64.RawURLEncoding.EncodeToString(hmacSum(secret, doctoredPayload))
 	doctored := strings.Join(parts, ".")
 
 	uid, err := VerifySession(secret, doctored)
 	if err != nil {
-		t.Fatalf("v2 with non-matching key-id but valid sig: %v", err)
+		t.Fatalf("v3 with non-matching key-id but valid sig: %v", err)
 	}
 	if uid != 12 {
 		t.Errorf("uid = %d; want 12", uid)

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -76,6 +76,14 @@ func WithUserRole(ctx context.Context, role string) context.Context {
 	return context.WithValue(ctx, userRoleCtxKey, role)
 }
 
+// WithUserID returns a context carrying the given authenticated user id.
+// Exported so tests can construct the same state Middleware sets after
+// resolving a session cookie, without going through the full middleware
+// chain. Production code paths never call this directly.
+func WithUserID(ctx context.Context, userID int64) context.Context {
+	return context.WithValue(ctx, userIDCtxKey, userID)
+}
+
 // RequireAdmin is a middleware that rejects non-admin requests with 403.
 func RequireAdmin(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -129,6 +137,13 @@ type Provider interface {
 	// UserRole returns the role string ("admin" or "user") for the given user
 	// id. Returns "" if the user is not found or an error occurs.
 	UserRole(ctx context.Context, userID int64) string
+	// UserSessionEpoch returns the user's current session epoch, the value
+	// the cookie's epoch field must match for the cookie to authenticate.
+	// Bumped on password change so old cookies stop verifying. Returns 0 if
+	// the user does not exist or the lookup fails — the comparison below then
+	// fails closed for any cookie minted after the 047 migration (which sets
+	// session_epoch to >= 1 by default).
+	UserSessionEpoch(ctx context.Context, userID int64) int64
 }
 
 // AllowUnauthPath returns true for routes the middleware must always let
@@ -176,10 +191,22 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 			ctx := r.Context()
 			cookieValid := false
 			if c, err := r.Cookie(SessionCookieName); err == nil {
-				if uid, err := VerifySessionMulti(p.SessionSecrets(), c.Value); err == nil {
-					ctx = context.WithValue(ctx, userIDCtxKey, uid)
-					ctx = context.WithValue(ctx, userRoleCtxKey, p.UserRole(ctx, uid))
-					cookieValid = true
+				if uid, epoch, err := VerifySessionMultiWithEpoch(p.SessionSecrets(), c.Value); err == nil {
+					// Compare the cookie's epoch field against the user's
+					// current session_epoch (bumped on password change). A
+					// mismatch means the cookie pre-dates the most recent
+					// credential rotation and must be rejected, even though
+					// the signature and expiry are otherwise valid — this is
+					// the "log everyone out after a password change" check
+					// (Wave 1 / Bundle C audit finding). Pre-047-migration
+					// cookies decode as epoch=0; the migration default of 1
+					// makes them all fail here on upgrade, which is the
+					// deliberate forced-logout-on-upgrade behaviour.
+					if p.UserSessionEpoch(ctx, uid) == epoch {
+						ctx = context.WithValue(ctx, userIDCtxKey, uid)
+						ctx = context.WithValue(ctx, userRoleCtxKey, p.UserRole(ctx, uid))
+						cookieValid = true
+					}
 				}
 			}
 

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -14,13 +14,26 @@ import (
 
 // Session cookie format (all dot-separated).
 //
-// Current (v2), carries a key-id so the secret can be rotated with an
-// overlapping window:
+// Current (v3), carries a per-user session epoch so a password change can
+// revoke every outstanding cookie for that user without rotating the
+// server-wide signing secret:
+//
+//	v3.<key_id>.<user_id>.<session_epoch>.<expires_unix>.<hmac(secret, "v3.<key_id>.<user_id>.<session_epoch>.<expires_unix>")>
+//
+// The middleware compares <session_epoch> against the live users.session_epoch
+// column and rejects mismatched cookies. UpdatePassword bumps the column,
+// which is how "log everyone out after a password change" is enforced
+// (Wave 1 / Bundle C audit finding).
+//
+// Previous (v2), no epoch — still ACCEPTED on verification with epoch=0
+// returned, but in production users.session_epoch defaults to 1 after the
+// 047 migration, so every v2 cookie minted before the upgrade fails the
+// epoch check. That is the deliberate forced-logout-on-upgrade behaviour:
 //
 //	v2.<key_id>.<user_id>.<expires_unix>.<hmac(secret, "v2.<key_id>.<user_id>.<expires_unix>")>
 //
-// Legacy (v1), no key-id — still accepted on verification so a deploy that
-// introduces v2 does not invalidate every outstanding cookie at once:
+// Legacy (v1), no key-id and no epoch — same backwards-compat treatment as
+// v2 (returns epoch=0, callers compare and reject):
 //
 //	v1.<user_id>.<expires_unix>.<hmac(secret, "v1.<user_id>.<expires_unix>")>
 //
@@ -36,8 +49,9 @@ const (
 	SessionDuration      = 30 * 24 * time.Hour // when "remember me" is checked
 	SessionDurationShort = 12 * time.Hour      // browser-session equivalent when not
 
-	sessionCookieVersion       = "v2" // current format written by SignSession
-	sessionCookieVersionLegacy = "v1" // older format still accepted by VerifySession
+	sessionCookieVersion       = "v3" // current format written by SignSessionWithEpoch
+	sessionCookieVersionV2     = "v2" // pre-epoch format, accepted on verify
+	sessionCookieVersionLegacy = "v1" // oldest format, accepted on verify
 
 	// keyIDLen is the number of hex chars of the secret fingerprint embedded
 	// in the cookie. 8 hex chars = 32 bits — enough to distinguish a handful of
@@ -70,24 +84,50 @@ func keyID(secret []byte) string {
 	return hex.EncodeToString(mac)[:keyIDLen]
 }
 
-// SignSession returns a signed cookie value (current v2 format, with key-id)
-// for the given user that expires at exp. It returns an error wrapping
-// ErrSessionInvalid if secret is nil or shorter than minSecretLen bytes.
+// SignSession returns a signed cookie value for the given user that expires
+// at exp. It mints a v3 cookie with session_epoch=0 — provided as a
+// convenience wrapper for tests and callers that do not yet plumb an epoch.
+// PRODUCTION callers MUST use SignSessionWithEpoch with the user's current
+// users.session_epoch value; otherwise the resulting cookie will fail the
+// middleware's epoch check (which expects a non-zero default after migration
+// 047). It returns an error wrapping ErrSessionInvalid if secret is nil or
+// shorter than minSecretLen bytes.
 func SignSession(secret []byte, userID int64, exp time.Time) (string, error) {
+	return SignSessionWithEpoch(secret, userID, 0, exp)
+}
+
+// SignSessionWithEpoch returns a signed v3 cookie carrying the user's
+// session epoch. PRODUCTION callers must source epoch from
+// users.session_epoch so the middleware's per-request comparison succeeds.
+// Returns an error wrapping ErrSessionInvalid if secret is nil or shorter
+// than minSecretLen bytes.
+func SignSessionWithEpoch(secret []byte, userID, epoch int64, exp time.Time) (string, error) {
 	if len(secret) < minSecretLen {
 		return "", fmt.Errorf("sign session: %w", ErrSessionInvalid)
 	}
-	payload := fmt.Sprintf("%s.%s.%d.%d", sessionCookieVersion, keyID(secret), userID, exp.Unix())
+	payload := fmt.Sprintf("%s.%s.%d.%d.%d", sessionCookieVersion, keyID(secret), userID, epoch, exp.Unix())
 	mac := hmacSum(secret, payload)
 	return payload + "." + base64.RawURLEncoding.EncodeToString(mac), nil
 }
 
 // VerifySession returns the user id carried by a valid, unexpired signed
-// cookie, or an error on any tamper/expiry/parse failure. It accepts both the
-// current v2 (key-id) format and the legacy v1 format. It returns
-// ErrSessionInvalid (wrapped) when secret is absent/too short.
+// cookie, or an error on any tamper/expiry/parse failure. It accepts v3, v2
+// and legacy v1 formats. The carried epoch (zero for v2/v1) is discarded; use
+// VerifySessionWithEpoch when the caller needs to enforce a session-epoch
+// match (the auth middleware does). Returns ErrSessionInvalid (wrapped) when
+// secret is absent/too short.
 func VerifySession(secret []byte, cookie string) (int64, error) {
-	return VerifySessionMulti([][]byte{secret}, cookie)
+	uid, _, err := VerifySessionMultiWithEpoch([][]byte{secret}, cookie)
+	return uid, err
+}
+
+// VerifySessionWithEpoch is VerifySession that also returns the session_epoch
+// embedded in the cookie. v3 cookies carry an explicit epoch; v2 and v1
+// cookies decode as epoch=0, which lets the middleware reject them after the
+// 047 migration sets every user's live epoch to >= 1 (the forced-logout-on-
+// upgrade behaviour called out in the release notes).
+func VerifySessionWithEpoch(secret []byte, cookie string) (int64, int64, error) {
+	return VerifySessionMultiWithEpoch([][]byte{secret}, cookie)
 }
 
 // VerifySessionMulti is VerifySession against a small ordered set of candidate
@@ -95,15 +135,24 @@ func VerifySession(secret []byte, cookie string) (int64, error) {
 // be handed {current, previous} so cookies signed under either are accepted;
 // the writer (SignSession) always uses the first/current secret.
 //
-// For a v2 cookie the embedded key-id is used to pick the matching candidate
-// directly (constant work, no HMAC against non-matching secrets); if no key-id
-// matches, every candidate is still HMAC-checked so a key-id collision or a
-// secret whose fingerprint is unknown cannot cause a spurious rejection. For a
-// legacy v1 cookie (no key-id) each candidate is tried in turn.
-//
 // Verification is never weakened: a cookie is accepted only if some candidate
 // secret produces an HMAC equal (in constant time) to the cookie's signature.
 func VerifySessionMulti(secrets [][]byte, cookie string) (int64, error) {
+	uid, _, err := VerifySessionMultiWithEpoch(secrets, cookie)
+	return uid, err
+}
+
+// VerifySessionMultiWithEpoch is the full verifier: returns (userID, epoch,
+// err). For a v3 cookie the embedded key-id is used to pick the matching
+// candidate directly (constant work, no HMAC against non-matching secrets);
+// if no key-id matches, every candidate is still HMAC-checked so a key-id
+// collision or a secret whose fingerprint is unknown cannot cause a spurious
+// rejection. For legacy v2/v1 cookies each candidate is tried in turn and
+// epoch=0 is returned.
+//
+// Verification is never weakened: a cookie is accepted only if some candidate
+// secret produces an HMAC equal (in constant time) to the cookie's signature.
+func VerifySessionMultiWithEpoch(secrets [][]byte, cookie string) (int64, int64, error) {
 	// Keep only usable (long-enough) secrets. Fail closed if none remain.
 	var usable [][]byte
 	for _, s := range secrets {
@@ -112,16 +161,22 @@ func VerifySessionMulti(secrets [][]byte, cookie string) (int64, error) {
 		}
 	}
 	if len(usable) == 0 {
-		return 0, fmt.Errorf("verify session: %w", ErrSessionInvalid)
+		return 0, 0, fmt.Errorf("verify session: %w", ErrSessionInvalid)
 	}
 
 	parts := strings.Split(cookie, ".")
 	var sig string
-	var idIdx, expIdx int // indices into parts of user-id and expiry
+	var idIdx, expIdx, epochIdx int // indices into parts; -1 means absent
 	var cookieKeyID string
+	epochIdx = -1
 
 	switch {
-	case len(parts) == 5 && parts[0] == sessionCookieVersion:
+	case len(parts) == 6 && parts[0] == sessionCookieVersion:
+		// v3.<key_id>.<user_id>.<session_epoch>.<expires>.<hmac>
+		cookieKeyID = parts[1]
+		idIdx, epochIdx, expIdx = 2, 3, 4
+		sig = parts[5]
+	case len(parts) == 5 && parts[0] == sessionCookieVersionV2:
 		// v2.<key_id>.<user_id>.<expires>.<hmac>
 		cookieKeyID = parts[1]
 		idIdx, expIdx = 2, 3
@@ -131,26 +186,33 @@ func VerifySessionMulti(secrets [][]byte, cookie string) (int64, error) {
 		idIdx, expIdx = 1, 2
 		sig = parts[3]
 	default:
-		return 0, fmt.Errorf("malformed session: %w", ErrSessionInvalid)
+		return 0, 0, fmt.Errorf("malformed session: %w", ErrSessionInvalid)
 	}
 
 	userID, err := strconv.ParseInt(parts[idIdx], 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("bad user id: %w", ErrSessionInvalid)
+		return 0, 0, fmt.Errorf("bad user id: %w", ErrSessionInvalid)
+	}
+	var epoch int64
+	if epochIdx >= 0 {
+		epoch, err = strconv.ParseInt(parts[epochIdx], 10, 64)
+		if err != nil {
+			return 0, 0, fmt.Errorf("bad session epoch: %w", ErrSessionInvalid)
+		}
 	}
 	expUnix, err := strconv.ParseInt(parts[expIdx], 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("bad expiry: %w", ErrSessionInvalid)
+		return 0, 0, fmt.Errorf("bad expiry: %w", ErrSessionInvalid)
 	}
 	payload := strings.Join(parts[:len(parts)-1], ".")
 	got, err := base64.RawURLEncoding.DecodeString(sig)
 	if err != nil {
-		return 0, fmt.Errorf("bad signature encoding: %w", ErrSessionInvalid)
+		return 0, 0, fmt.Errorf("bad signature encoding: %w", ErrSessionInvalid)
 	}
 
-	// Try the candidate whose key-id matches first (v2 fast path), then fall
-	// back to every candidate. matched stays false until a constant-time HMAC
-	// comparison succeeds.
+	// Try the candidate whose key-id matches first (v3/v2 fast path), then
+	// fall back to every candidate. matched stays false until a constant-time
+	// HMAC comparison succeeds.
 	matched := false
 	for _, secret := range usable {
 		if cookieKeyID != "" && keyID(secret) != cookieKeyID {
@@ -164,9 +226,10 @@ func VerifySessionMulti(secrets [][]byte, cookie string) (int64, error) {
 		}
 	}
 	if !matched && cookieKeyID != "" {
-		// Fallback: a v2 cookie whose key-id matched no candidate (collision,
-		// or a candidate set that does not announce its fingerprints). Verify
-		// against every secret so a correct signature is never rejected.
+		// Fallback: a v3/v2 cookie whose key-id matched no candidate
+		// (collision, or a candidate set that does not announce its
+		// fingerprints). Verify against every secret so a correct signature is
+		// never rejected.
 		for _, secret := range usable {
 			if hmac.Equal(got, hmacSum(secret, payload)) {
 				matched = true
@@ -175,12 +238,12 @@ func VerifySessionMulti(secrets [][]byte, cookie string) (int64, error) {
 		}
 	}
 	if !matched {
-		return 0, fmt.Errorf("bad signature: %w", ErrSessionInvalid)
+		return 0, 0, fmt.Errorf("bad signature: %w", ErrSessionInvalid)
 	}
 	if time.Now().Unix() > expUnix {
-		return 0, fmt.Errorf("cookie expired: %w", ErrSessionExpired)
+		return 0, 0, fmt.Errorf("cookie expired: %w", ErrSessionExpired)
 	}
-	return userID, nil
+	return userID, epoch, nil
 }
 
 func hmacSum(secret []byte, payload string) []byte {

--- a/internal/db/auth.go
+++ b/internal/db/auth.go
@@ -16,6 +16,13 @@ type User struct {
 	Role         string // "admin" or "user"
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
+	// SessionEpoch is bumped every time the user's credentials change
+	// (password self-change, admin password reset). The signed session cookie
+	// carries the epoch under which it was minted; the auth middleware
+	// compares it against this column on every request and rejects mismatched
+	// cookies. That is how "log everyone out after a password change" is
+	// enforced (Wave 1 / Bundle C audit finding).
+	SessionEpoch int64
 	// OIDC fields — nil for local-password users.
 	OIDCSub     *string
 	OIDCIssuer  *string
@@ -39,13 +46,13 @@ func (r *UserRepo) Count(ctx context.Context) (int, error) {
 }
 
 const userSelectCols = `id, username, password_hash, role, created_at, updated_at,
-	oidc_sub, oidc_issuer, email, display_name`
+	oidc_sub, oidc_issuer, email, display_name, session_epoch`
 
 func scanUser(row interface{ Scan(...any) error }) (*User, error) {
 	var u User
 	err := row.Scan(
 		&u.ID, &u.Username, &u.PasswordHash, &u.Role, &u.CreatedAt, &u.UpdatedAt,
-		&u.OIDCSub, &u.OIDCIssuer, &u.Email, &u.DisplayName,
+		&u.OIDCSub, &u.OIDCIssuer, &u.Email, &u.DisplayName, &u.SessionEpoch,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -203,7 +210,11 @@ func (r *UserRepo) Create(ctx context.Context, username, passwordHash string) (*
 	if err != nil {
 		return nil, fmt.Errorf("get user id: %w", err)
 	}
-	return &User{ID: id, Username: username, PasswordHash: passwordHash, Role: "user", CreatedAt: now, UpdatedAt: now}, nil
+	// SessionEpoch matches the column default in migration 047. Returning the
+	// concrete value (rather than the Go zero) keeps the in-memory User
+	// consistent with the row that was just written, so callers comparing
+	// against GetSessionEpoch don't see a phantom mismatch.
+	return &User{ID: id, Username: username, PasswordHash: passwordHash, Role: "user", CreatedAt: now, UpdatedAt: now, SessionEpoch: 1}, nil
 }
 
 // List returns all users ordered by id.
@@ -314,10 +325,49 @@ func (r *UserRepo) PromoteFirstUser(ctx context.Context) error {
 	return err
 }
 
+// UpdatePassword writes a new password hash AND atomically increments the
+// user's session_epoch. The epoch bump is what makes a password change
+// invalidate every existing session cookie for that user: the auth middleware
+// compares the cookie's epoch field against this column on each request and
+// rejects mismatches. Doing both writes in one UPDATE keeps the two states
+// in lockstep — there is no window in which the new password is live but
+// the old cookies are still trusted (Wave 1 / Bundle C audit finding).
 func (r *UserRepo) UpdatePassword(ctx context.Context, id int64, passwordHash string) error {
 	_, err := r.db.ExecContext(ctx,
-		"UPDATE users SET password_hash=?, updated_at=? WHERE id=?",
+		"UPDATE users SET password_hash=?, session_epoch=session_epoch+1, updated_at=? WHERE id=?",
 		passwordHash, time.Now().UTC(), id,
+	)
+	return err
+}
+
+// GetSessionEpoch returns the user's current session_epoch, or (0, nil) when
+// the user does not exist. The auth middleware calls this on every
+// session-cookie-authenticated request to compare against the epoch embedded
+// in the cookie payload — a mismatch means the cookie was minted before the
+// most recent password change and must be rejected.
+func (r *UserRepo) GetSessionEpoch(ctx context.Context, id int64) (int64, error) {
+	var epoch int64
+	err := r.db.QueryRowContext(ctx,
+		"SELECT session_epoch FROM users WHERE id=?", id,
+	).Scan(&epoch)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("get session epoch: %w", err)
+	}
+	return epoch, nil
+}
+
+// BumpSessionEpoch increments the user's session_epoch by one. Intended for
+// callers that need to invalidate every outstanding session for a user
+// without changing the password itself (a hook for future "log out all
+// devices" UI). The password-change paths inline the bump into UpdatePassword
+// so the two cannot drift apart.
+func (r *UserRepo) BumpSessionEpoch(ctx context.Context, id int64) error {
+	_, err := r.db.ExecContext(ctx,
+		"UPDATE users SET session_epoch=session_epoch+1, updated_at=? WHERE id=?",
+		time.Now().UTC(), id,
 	)
 	return err
 }

--- a/internal/db/migrations/047_user_session_epoch.sql
+++ b/internal/db/migrations/047_user_session_epoch.sql
@@ -1,0 +1,24 @@
+-- +migrate Up
+
+-- Per-user session epoch. Bumped on password change (self-serve or admin
+-- reset) to invalidate every outstanding session cookie for that user, the
+-- "logout everywhere" primitive (Wave 1 / Bundle C audit finding).
+--
+-- The cookie payload carries the epoch under which it was minted. The auth
+-- middleware loads users.session_epoch on every request and rejects the
+-- cookie when the two disagree. Bumping the column therefore evicts
+-- stolen-cookie attackers the instant the rightful owner rotates their
+-- password.
+--
+-- Default = 1 (not 0) so pre-migration cookies, which carry no epoch field
+-- and decode as epoch=0, fail the comparison on upgrade. That is the
+-- deliberate forced-logout-on-upgrade behaviour called out as a breaking
+-- change in the release notes. On a 100k-user table this default-fill is a
+-- single cheap UPDATE with no constraint check, safe to run online.
+ALTER TABLE users ADD COLUMN session_epoch INTEGER NOT NULL DEFAULT 1;
+
+-- +migrate Down
+
+-- SQLite does not support DROP COLUMN in older versions, so rely on a
+-- schema rebuild if a downgrade is ever needed. Best-effort for dev
+-- rollbacks only, mirroring the convention used by 025_multiuser.sql.


### PR DESCRIPTION
## Summary

Closes the Wave 1 / Bundle C audit finding: **session invalidation on password change**. Before this PR, a self-serve password change or an admin reset left every existing session cookie for the affected user valid for the full 30-day TTL. A stolen-cookie attacker therefore kept access even after the rightful owner rotated their password, the textbook "logout everywhere" failure mode the audit flagged.

## Design: per-user session epoch

The fix is a per-user `session_epoch` column in the `users` table:

1. **Migration 047** adds `users.session_epoch INTEGER NOT NULL DEFAULT 1`. Safe on a 100k-user table (single default-filled column, no constraint check).
2. **`UserRepo.UpdatePassword`** now bumps `session_epoch` atomically in the same UPDATE. Both the self-serve handler (`POST /auth/password`) and the admin reset handler (`PUT /auth/users/:id/reset-password`) reach this path, so both surfaces are covered without a second code change.
3. **Session cookie format** moves from v2 to v3:
   ```
   v3.<key_id>.<user_id>.<session_epoch>.<expires_unix>.<hmac>
   ```
4. **The auth middleware** decodes the cookie, looks up the user's live `session_epoch`, and rejects mismatched cookies. The OPDS middleware (the second cookie surface, used by KOReader / Moon+ Reader / Aldiko) performs the same comparison via `UserRepo.GetSessionEpoch`.
5. **The password-change response** re-issues a fresh cookie carrying the post-bump epoch, so the browser that performed the change is not bounced to the login screen. Other browsers, other devices, and stolen cookies still hold the pre-bump epoch and are correctly evicted.

**Order matters:** `UpdatePassword` bumps the epoch FIRST, `issueSession` reads the post-bump value SECOND. The single SQL UPDATE keeps them in lockstep, so there is no window in which the new cookie is invalid the moment it is set.

### Why per-user epoch instead of a server-side token table

The codebase has no `sessions` table today, cookies are self-contained signed payloads. Adding a per-user epoch column and embedding it in the cookie keeps that property: no new table, no new index hot path, one extra DB read per authenticated request (acceptable, caching can come later).

### OIDC, API keys, proxy auth

- **OIDC** users go through the same `issueSession` path, so they pick up the epoch transitively. They have no local password to rotate, but the comparison runs uniformly.
- **API keys** (`auth.api_key`) are untouched. They are not user-scoped (they live in `settings`, not `users`), so this fix's scope does not apply. The existing rotation endpoint already covers the equivalent revocation primitive for them.
- **Proxy auth** and **local-only mode** bypass the cookie path entirely.

## BREAKING: forced logout on upgrade

The migration defaults `session_epoch` to `1` (not `0`). Pre-existing v2/v1 cookies carry no epoch field and decode as epoch=0, so every outstanding session cookie fails the live comparison on first boot of this release. Every user will be prompted to log in again once. No data loss, no setting reset, no manual remediation required.

This is the cleaner of the two transition strategies the audit allowed (the alternative being a one-release window that accepts cookies without an epoch field). Calling it out clearly here so the release notes can reproduce it under "Upgrade notes".

## Test plan

Three new tests in `internal/api/auth_test.go`, all driving the real `auth.Middleware` chain end-to-end:

- [x] `TestSession_InvalidatedOnPasswordChange`: login -> change password -> stale cookie returns 401.
- [x] `TestSession_InvalidatedOnAdminPasswordReset`: admin resets userB's password -> userB's pre-reset cookie returns 401.
- [x] `TestSession_NewCookieValidAfterPasswordChange`: the cookie set on the `/auth/password` response works on the next request, so the caller stays logged in in the browser they performed the change from.

Existing session-format tests (round-trip, key-id rotation, signature tamper, secret rotation window) updated for the v3 framing and continue to pass. Full `go test ./...` is green.

Manual repro:
- [ ] Log in to bindery in browser A. Log in to bindery as the same user in browser B.
- [ ] Change the password in browser A.
- [ ] Refresh browser A: the page stays authenticated (response set a fresh cookie carrying the new epoch).
- [ ] Refresh browser B: the user is bounced to `/login` (stale cookie carries the pre-bump epoch).
- [ ] Repeat with admin-reset against a different user from the Users page (`web/src/pages/UsersPage.tsx`).

## Related

- PR #892, PR #893: audit's critical-tier siblings (Wave 1 / Bundles A and B).