### PR TITLE
fix(api): admin-gate shared deployment-config routes (D2)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -818,40 +818,48 @@ func main() {
 		r.Post("/tag", tagHandler.Create)
 		r.Delete("/tag/{id}", tagHandler.Delete)
 
-		// Import lists
-		r.Get("/importlist", importListHandler.List)
-		r.Post("/importlist", importListHandler.Create)
-		r.Get("/importlist/hardcover/lists", importListHandler.HardcoverLists)
-		r.Get("/importlist/{id}", importListHandler.Get)
-		r.Put("/importlist/{id}", importListHandler.Update)
-		r.Delete("/importlist/{id}", importListHandler.Delete)
-		r.Post("/importlist/{id}/sync", importListHandler.Sync)
+		// Import lists, delay profiles, custom formats: shared deployment
+		// config, not per-user content. Reads and writes are admin-only so
+		// non-admin sessions can't enumerate which import lists feed the
+		// library or which delay profiles gate downloads. Previously every
+		// authenticated user could list/read these, which leaked operational
+		// detail (which TRaSH custom-format rules are active, which
+		// HC-list/RSS feeds are wired up, what the delay-profile policy is).
+		r.Group(func(r chi.Router) {
+			r.Use(auth.RequireAdmin)
+			r.Get("/importlist", importListHandler.List)
+			r.Post("/importlist", importListHandler.Create)
+			r.Get("/importlist/hardcover/lists", importListHandler.HardcoverLists)
+			r.Get("/importlist/{id}", importListHandler.Get)
+			r.Put("/importlist/{id}", importListHandler.Update)
+			r.Delete("/importlist/{id}", importListHandler.Delete)
+			r.Post("/importlist/{id}/sync", importListHandler.Sync)
 
-		// Import list exclusions
-		r.Get("/importlistexclusion", importListHandler.ListExclusions)
-		r.Post("/importlistexclusion", importListHandler.CreateExclusion)
-		r.Delete("/importlistexclusion/{id}", importListHandler.DeleteExclusion)
+			r.Get("/importlistexclusion", importListHandler.ListExclusions)
+			r.Post("/importlistexclusion", importListHandler.CreateExclusion)
+			r.Delete("/importlistexclusion/{id}", importListHandler.DeleteExclusion)
 
-		// Metadata profiles
+			r.Get("/delayprofile", delayProfileHandler.List)
+			r.Post("/delayprofile", delayProfileHandler.Create)
+			r.Get("/delayprofile/{id}", delayProfileHandler.Get)
+			r.Put("/delayprofile/{id}", delayProfileHandler.Update)
+			r.Delete("/delayprofile/{id}", delayProfileHandler.Delete)
+
+			r.Get("/customformat", customFormatHandler.List)
+			r.Post("/customformat", customFormatHandler.Create)
+			r.Get("/customformat/{id}", customFormatHandler.Get)
+			r.Put("/customformat/{id}", customFormatHandler.Update)
+			r.Delete("/customformat/{id}", customFormatHandler.Delete)
+		})
+
+		// Metadata profiles — per-user (owner_user_id from migration 025).
+		// Reads stay available to all authenticated users; the cross-user
+		// Get/Update/Delete IDOR is closed by D1's env-gated handler check.
 		r.Get("/metadataprofile", metadataProfileHandler.List)
 		r.Post("/metadataprofile", metadataProfileHandler.Create)
 		r.Get("/metadataprofile/{id}", metadataProfileHandler.Get)
 		r.Put("/metadataprofile/{id}", metadataProfileHandler.Update)
 		r.Delete("/metadataprofile/{id}", metadataProfileHandler.Delete)
-
-		// Delay profiles
-		r.Get("/delayprofile", delayProfileHandler.List)
-		r.Post("/delayprofile", delayProfileHandler.Create)
-		r.Get("/delayprofile/{id}", delayProfileHandler.Get)
-		r.Put("/delayprofile/{id}", delayProfileHandler.Update)
-		r.Delete("/delayprofile/{id}", delayProfileHandler.Delete)
-
-		// Custom formats
-		r.Get("/customformat", customFormatHandler.List)
-		r.Post("/customformat", customFormatHandler.Create)
-		r.Get("/customformat/{id}", customFormatHandler.Get)
-		r.Put("/customformat/{id}", customFormatHandler.Update)
-		r.Delete("/customformat/{id}", customFormatHandler.Delete)
 
 		// Backups — Restore overwrites the live database, Delete removes
 		// stored backups, and List leaks filenames containing timestamps that


### PR DESCRIPTION
## Summary

Wave 1 Bundle D2 of the deep audit followups. Sibling PRs: #892 (scheduler nil-deref), #893 (settings secret leak), #894 (OIDC SSRF), #895 (path containment), #896 (session epoch).

The audit caught that several routes serving shared deployment config were readable + mutable by any authenticated user even though their content is operationally sensitive:

| Route | Why it should be admin-only |
|---|---|
| `/importlist/*` | Which TRaSH / Hardcover / RSS feeds populate the library |
| `/importlistexclusion/*` | Which authors are blocked from import-list pickup |
| `/delayprofile/*` | Per-protocol delay rules gating downloads |
| `/customformat/*` | TRaSH-style scoring rules |

None of these have a per-user concept in the schema. They're install-wide deployment configuration.

## Fix

Wrap the affected routes in a `RequireAdmin` chi group. No handler changes, no schema changes. Single-file diff.

Metadata profiles are intentionally **not** in this PR: they have an `owner_user_id` (from migration 025), so they're per-user and the IDOR fix belongs in D1 alongside authors/books/etc. The route stays open at the router level; D1 adds the `CheckOwnership` check at the handler level.

## Out of scope

- Per-user `tags` and `blocklist` (D4): require a schema migration to add `owner_user_id` and merit their own deep-analysis pass before shipping.
- Tier-1 IDOR (D1): authors, books, recommendations, root folders, quality profiles, metadata profiles.
- Tier-2 view scoping (D3): queue, history, pending releases, OPDS.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./cmd/bindery/... ./internal/api/...` green
- [ ] Manual: with a non-admin session, `GET /api/v1/importlist` returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)