### PR TITLE
fix(auth): close cross-user IDOR on Tier-1 per-user resources (D1, env-gated)

### DIFF
--- a/internal/api/authorization_test.go
+++ b/internal/api/authorization_test.go
@@ -1,0 +1,558 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// Regression suite for the Tier-1 cross-user IDOR fix (D1). Each resource gets
+// three scenarios:
+//
+//   1. Gate on + non-owner caller          -> 404 (no leak)
+//   2. Gate on + admin caller              -> succeeds
+//   3. Gate OFF (default)                  -> succeeds even cross-user, so the
+//      env-gate promise (existing tests + single-user installs unchanged) is
+//      asserted in the same file as the new behavior.
+//
+// To keep the test surface compact we exercise one Get and one Delete per
+// resource. The other handler shapes share the exact same CheckOwnership call
+// site; adding 18 near-identical tests would dilute signal without catching
+// new bugs.
+
+// withAuthCtx attaches a userID and role to ctx — mirrors what the auth
+// middleware would do at runtime, but constructed by hand for tests.
+func withAuthCtx(ctx context.Context, userID int64, role string) context.Context {
+	ctx = auth.WithUserID(ctx, userID)
+	ctx = auth.WithUserRole(ctx, role)
+	return ctx
+}
+
+// newRequestForID builds a chi-aware request with `{id}` populated. Tests want
+// to hit Get/Delete handlers directly without spinning up the whole router.
+func newRequestForID(method, path string, id int64, ctx context.Context) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(id, 10))
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+	return req
+}
+
+// setOwner stamps owner_user_id directly on a row. The Create paths for some
+// repos (books, profiles, root folders) do not yet write that column, so the
+// tests force it by hand to mirror what migration 025's backfill would do for
+// existing rows in a production install.
+func setOwner(t *testing.T, database *sql.DB, table string, id, owner int64) {
+	t.Helper()
+	if _, err := database.Exec("UPDATE "+table+" SET owner_user_id=? WHERE id=?", owner, id); err != nil {
+		t.Fatalf("set owner on %s: %v", table, err)
+	}
+}
+
+// --- Author ---------------------------------------------------------------
+
+type authzAuthorFixture struct {
+	database *sql.DB
+	authors  *db.AuthorRepo
+	books    *db.BookRepo
+	profiles *db.MetadataProfileRepo
+	u1, u2   int64
+	a1, a2   *models.Author
+}
+
+func seedTwoUserAuthors(t *testing.T) authzAuthorFixture {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	users := db.NewUserRepo(database)
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	profiles := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	u1, err := users.Create(ctx, "alice", "hash1")
+	if err != nil {
+		t.Fatalf("create alice: %v", err)
+	}
+	u2, err := users.Create(ctx, "bob", "hash2")
+	if err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+
+	a1 := &models.Author{ForeignID: "OL-A1", Name: "Author One", SortName: "One, Author", MetadataProvider: "openlibrary"}
+	if err := authors.CreateForUser(ctx, a1, u1.ID); err != nil {
+		t.Fatalf("create author1: %v", err)
+	}
+	a2 := &models.Author{ForeignID: "OL-A2", Name: "Author Two", SortName: "Two, Author", MetadataProvider: "openlibrary"}
+	if err := authors.CreateForUser(ctx, a2, u2.ID); err != nil {
+		t.Fatalf("create author2: %v", err)
+	}
+	// GetByID re-reads through the scan path so the owner column lands on the
+	// struct, which the handler will read via author.OwnerUserID.
+	a1, _ = authors.GetByID(ctx, a1.ID)
+	a2, _ = authors.GetByID(ctx, a2.ID)
+	return authzAuthorFixture{
+		database: database, authors: authors, books: books, profiles: profiles,
+		u1: u1.ID, u2: u2.ID, a1: a1, a2: a2,
+	}
+}
+
+func TestAuthor_Get_CrossUserBlockedWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserAuthors(t)
+	h := NewAuthorHandler(f.authors, nil, f.books, nil, nil, nil, f.profiles, nil)
+
+	// Bob (u2) tries to read Alice's author (a1).
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodGet, "/api/v1/author/"+strconv.FormatInt(f.a1.ID, 10), f.a1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user Get must 404 with gate on; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAuthor_Get_AdminCanSeeAllWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserAuthors(t)
+	h := NewAuthorHandler(f.authors, nil, f.books, nil, nil, nil, f.profiles, nil)
+
+	ctx := withAuthCtx(context.Background(), 99, "admin")
+	req := newRequestForID(http.MethodGet, "/api/v1/author/"+strconv.FormatInt(f.a1.ID, 10), f.a1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin Get must succeed; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAuthor_Get_GateOffAllowsCrossUser(t *testing.T) {
+	// Default state (the env-gate canary): existing tests and single-user
+	// installs must keep seeing the pre-fix behavior, namely no per-user
+	// isolation, when BINDERY_ENFORCE_TENANCY is unset.
+	auth.SetEnforceTenancyForTests(t, false)
+	f := seedTwoUserAuthors(t)
+	h := NewAuthorHandler(f.authors, nil, f.books, nil, nil, nil, f.profiles, nil)
+
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodGet, "/api/v1/author/"+strconv.FormatInt(f.a1.ID, 10), f.a1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("gate off must preserve pre-fix cross-user access; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAuthor_Delete_CrossUserBlockedWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserAuthors(t)
+	h := NewAuthorHandler(f.authors, nil, f.books, nil, nil, nil, f.profiles, nil)
+
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodDelete, "/api/v1/author/"+strconv.FormatInt(f.a1.ID, 10), f.a1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user Delete must 404; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got, _ := f.authors.GetByID(context.Background(), f.a1.ID); got == nil {
+		t.Error("cross-user Delete must not actually remove the row")
+	}
+}
+
+// --- Book -----------------------------------------------------------------
+
+type authzBookFixture struct {
+	authzAuthorFixture
+	b1, b2 *models.Book
+}
+
+func seedTwoUserBooks(t *testing.T) authzBookFixture {
+	t.Helper()
+	af := seedTwoUserAuthors(t)
+	ctx := context.Background()
+
+	b1 := &models.Book{ForeignID: "B-1", AuthorID: af.a1.ID, Title: "Alice Book", SortTitle: "Alice Book", Status: "wanted", MetadataProvider: "openlibrary"}
+	if err := af.books.Create(ctx, b1); err != nil {
+		t.Fatalf("create b1: %v", err)
+	}
+	b2 := &models.Book{ForeignID: "B-2", AuthorID: af.a2.ID, Title: "Bob Book", SortTitle: "Bob Book", Status: "wanted", MetadataProvider: "openlibrary"}
+	if err := af.books.Create(ctx, b2); err != nil {
+		t.Fatalf("create b2: %v", err)
+	}
+	// BookRepo.Create does not yet set owner_user_id (Tier-2 work); stamp it
+	// manually so the handler-level check has something to verify.
+	setOwner(t, af.database, "books", b1.ID, af.u1)
+	setOwner(t, af.database, "books", b2.ID, af.u2)
+	b1, _ = af.books.GetByID(ctx, b1.ID)
+	b2, _ = af.books.GetByID(ctx, b2.ID)
+	return authzBookFixture{authzAuthorFixture: af, b1: b1, b2: b2}
+}
+
+func TestBook_Get_CrossUserBlockedWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserBooks(t)
+
+	h := &BookHandler{books: f.books}
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodGet, "/api/v1/book/"+strconv.FormatInt(f.b1.ID, 10), f.b1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user book Get must 404; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBook_Get_AdminCanSeeAllWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserBooks(t)
+
+	h := &BookHandler{books: f.books}
+	ctx := withAuthCtx(context.Background(), 99, "admin")
+	req := newRequestForID(http.MethodGet, "/api/v1/book/"+strconv.FormatInt(f.b1.ID, 10), f.b1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin book Get must succeed; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBook_Get_GateOffAllowsCrossUser(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, false)
+	f := seedTwoUserBooks(t)
+
+	h := &BookHandler{books: f.books}
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodGet, "/api/v1/book/"+strconv.FormatInt(f.b1.ID, 10), f.b1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("gate off must preserve cross-user book access; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestBook_Delete_CrossUserBlockedWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserBooks(t)
+
+	h := &BookHandler{books: f.books}
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodDelete, "/api/v1/book/"+strconv.FormatInt(f.b1.ID, 10), f.b1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user book Delete must 404; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got, _ := f.books.GetByID(context.Background(), f.b1.ID); got == nil {
+		t.Error("cross-user Delete must not actually remove the row")
+	}
+}
+
+// --- MetadataProfile -------------------------------------------------------
+
+type authzMetadataProfileFixture struct {
+	database *sql.DB
+	repo     *db.MetadataProfileRepo
+	u1, u2   int64
+	p1, p2   *models.MetadataProfile
+}
+
+func seedTwoUserMetadataProfiles(t *testing.T) authzMetadataProfileFixture {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	users := db.NewUserRepo(database)
+	repo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	u1, _ := users.Create(ctx, "alice", "h1")
+	u2, _ := users.Create(ctx, "bob", "h2")
+
+	p1 := &models.MetadataProfile{Name: "Alice Profile"}
+	if err := repo.Create(ctx, p1); err != nil {
+		t.Fatalf("create p1: %v", err)
+	}
+	p2 := &models.MetadataProfile{Name: "Bob Profile"}
+	if err := repo.Create(ctx, p2); err != nil {
+		t.Fatalf("create p2: %v", err)
+	}
+	setOwner(t, database, "metadata_profiles", p1.ID, u1.ID)
+	setOwner(t, database, "metadata_profiles", p2.ID, u2.ID)
+	p1, _ = repo.GetByID(ctx, p1.ID)
+	p2, _ = repo.GetByID(ctx, p2.ID)
+	return authzMetadataProfileFixture{database: database, repo: repo, u1: u1.ID, u2: u2.ID, p1: p1, p2: p2}
+}
+
+func TestMetadataProfile_Get_CrossUserBlockedWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserMetadataProfiles(t)
+
+	h := NewMetadataProfileHandler(f.repo)
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodGet, "/api/v1/metadataprofile/"+strconv.FormatInt(f.p1.ID, 10), f.p1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user metadata profile Get must 404; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMetadataProfile_Get_AdminCanSeeAllWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserMetadataProfiles(t)
+
+	h := NewMetadataProfileHandler(f.repo)
+	ctx := withAuthCtx(context.Background(), 99, "admin")
+	req := newRequestForID(http.MethodGet, "/api/v1/metadataprofile/"+strconv.FormatInt(f.p1.ID, 10), f.p1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin Get must succeed; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMetadataProfile_Get_GateOffAllowsCrossUser(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, false)
+	f := seedTwoUserMetadataProfiles(t)
+
+	h := NewMetadataProfileHandler(f.repo)
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodGet, "/api/v1/metadataprofile/"+strconv.FormatInt(f.p1.ID, 10), f.p1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("gate off must preserve cross-user access; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMetadataProfile_Delete_CrossUserBlockedWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserMetadataProfiles(t)
+
+	h := NewMetadataProfileHandler(f.repo)
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodDelete, "/api/v1/metadataprofile/"+strconv.FormatInt(f.p1.ID, 10), f.p1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user metadata profile Delete must 404; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got, _ := f.repo.GetByID(context.Background(), f.p1.ID); got == nil {
+		t.Error("Delete must not remove the row when blocked")
+	}
+}
+
+// --- QualityProfile --------------------------------------------------------
+
+type authzQualityProfileFixture struct {
+	database *sql.DB
+	repo     *db.QualityProfileRepo
+	u1, u2   int64
+	p1       *models.QualityProfile
+}
+
+func seedTwoUserQualityProfile(t *testing.T) authzQualityProfileFixture {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	users := db.NewUserRepo(database)
+	repo := db.NewQualityProfileRepo(database)
+	ctx := context.Background()
+
+	u1, _ := users.Create(ctx, "alice", "h1")
+	u2, _ := users.Create(ctx, "bob", "h2")
+
+	p1 := &models.QualityProfile{
+		Name:           "Alice Quality",
+		Cutoff:         "epub",
+		UpgradeAllowed: true,
+		Items:          []models.QualityItem{{Quality: "epub", Allowed: true}},
+	}
+	if err := repo.Create(ctx, p1); err != nil {
+		t.Fatalf("create p1: %v", err)
+	}
+	setOwner(t, database, "quality_profiles", p1.ID, u1.ID)
+	p1, _ = repo.GetByID(ctx, p1.ID)
+	return authzQualityProfileFixture{database: database, repo: repo, u1: u1.ID, u2: u2.ID, p1: p1}
+}
+
+func TestQualityProfile_Get_CrossUserBlockedWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserQualityProfile(t)
+
+	h := NewQualityProfileHandler(f.repo)
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodGet, "/api/v1/qualityprofile/"+strconv.FormatInt(f.p1.ID, 10), f.p1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user quality profile Get must 404; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestQualityProfile_Get_GateOffAllowsCrossUser(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, false)
+	f := seedTwoUserQualityProfile(t)
+
+	h := NewQualityProfileHandler(f.repo)
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodGet, "/api/v1/qualityprofile/"+strconv.FormatInt(f.p1.ID, 10), f.p1.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("gate off must preserve cross-user access; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// --- RootFolder ------------------------------------------------------------
+
+type authzRootFolderFixture struct {
+	database *sql.DB
+	repo     *db.RootFolderRepo
+	u1, u2   int64
+	rf       *models.RootFolder
+}
+
+func seedTwoUserRootFolder(t *testing.T) authzRootFolderFixture {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	users := db.NewUserRepo(database)
+	repo := db.NewRootFolderRepo(database)
+	ctx := context.Background()
+
+	u1, _ := users.Create(ctx, "alice", "h1")
+	u2, _ := users.Create(ctx, "bob", "h2")
+
+	rf, err := repo.Create(ctx, t.TempDir())
+	if err != nil {
+		t.Fatalf("create rf: %v", err)
+	}
+	setOwner(t, database, "root_folders", rf.ID, u1.ID)
+	rf, _ = repo.GetByID(ctx, rf.ID)
+	return authzRootFolderFixture{database: database, repo: repo, u1: u1.ID, u2: u2.ID, rf: rf}
+}
+
+func TestRootFolder_Delete_CrossUserBlockedWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserRootFolder(t)
+
+	h := NewRootFolderHandler(f.repo)
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodDelete, "/api/v1/rootfolder/"+strconv.FormatInt(f.rf.ID, 10), f.rf.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user root folder Delete must 404; got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if got, _ := f.repo.GetByID(context.Background(), f.rf.ID); got == nil {
+		t.Error("Delete must not remove the row when blocked")
+	}
+}
+
+func TestRootFolder_Delete_GateOffAllowsCrossUser(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, false)
+	f := seedTwoUserRootFolder(t)
+
+	h := NewRootFolderHandler(f.repo)
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodDelete, "/api/v1/rootfolder/"+strconv.FormatInt(f.rf.ID, 10), f.rf.ID, ctx)
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("gate off must preserve pre-fix cross-user delete; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// --- Recommendation --------------------------------------------------------
+
+type authzRecommendationFixture struct {
+	database *sql.DB
+	repo     *db.RecommendationRepo
+	u1, u2   int64
+	recID    int64
+}
+
+func seedTwoUserRecommendation(t *testing.T) authzRecommendationFixture {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	users := db.NewUserRepo(database)
+	repo := db.NewRecommendationRepo(database)
+	ctx := context.Background()
+
+	u1, _ := users.Create(ctx, "alice", "h1")
+	u2, _ := users.Create(ctx, "bob", "h2")
+
+	// Insert one recommendation for u1 directly so we control the user_id.
+	res, err := database.Exec(`
+		INSERT INTO recommendations (
+			user_id, foreign_id, rec_type, title, author_name, author_id,
+			image_url, description, genres, rating, ratings_count, release_date,
+			language, media_type, score, reason, series_id, series_pos,
+			dismissed, batch_id, created_at
+		) VALUES (?, ?, ?, ?, ?, NULL, ?, ?, '[]', 0, 0, NULL, '', '', 0, '', NULL, '', 0, 'batch', CURRENT_TIMESTAMP)`,
+		u1.ID, "rec-foreign-1", "series", "Alice Rec", "Some Author", "", "")
+	if err != nil {
+		t.Fatalf("insert recommendation: %v", err)
+	}
+	recID, _ := res.LastInsertId()
+	return authzRecommendationFixture{database: database, repo: repo, u1: u1.ID, u2: u2.ID, recID: recID}
+}
+
+func TestRecommendation_Dismiss_CrossUserBlockedWhenGateOn(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserRecommendation(t)
+
+	h := &RecommendationHandler{recs: f.repo, appCtx: context.Background()}
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodPost, "/api/v1/recommendations/"+strconv.FormatInt(f.recID, 10)+"/dismiss", f.recID, ctx)
+	rec := httptest.NewRecorder()
+	h.Dismiss(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user recommendation Dismiss must 404; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRecommendation_Dismiss_GateOffAllowsCrossUser(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, false)
+	f := seedTwoUserRecommendation(t)
+
+	h := &RecommendationHandler{recs: f.repo, appCtx: context.Background()}
+	ctx := withAuthCtx(context.Background(), f.u2, "user")
+	req := newRequestForID(http.MethodPost, "/api/v1/recommendations/"+strconv.FormatInt(f.recID, 10)+"/dismiss", f.recID, ctx)
+	rec := httptest.NewRecorder()
+	h.Dismiss(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("gate off must preserve pre-fix cross-user Dismiss; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -174,6 +174,12 @@ func (h *AuthorHandler) Get(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
 		return
 	}
+	// Tier-1 cross-user IDOR guard (D1). Return 404 (not 403) on mismatch so
+	// non-owners cannot probe for the existence of another user's authors.
+	if !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+		return
+	}
 
 	// Attach books
 	books, err := h.books.ListByAuthor(r.Context(), id)
@@ -211,6 +217,17 @@ func (h *AuthorHandler) ListSeries(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1). Look the author up so the ownership
+	// check runs before we list series belonging to it.
+	author, err := h.authors.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if author == nil || !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
 		return
 	}
 	if h.series == nil {
@@ -657,6 +674,11 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
 		return
 	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+		return
+	}
 
 	var req struct {
 		Monitored             *bool   `json:"monitored"`
@@ -850,6 +872,11 @@ func (h *AuthorHandler) RelinkUpstream(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
 		return
 	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+		return
+	}
 	if !canRelinkAuthorToUpstream(author) {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "author is already linked to upstream metadata"})
 		return
@@ -911,6 +938,19 @@ func (h *AuthorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Tier-1 cross-user IDOR guard (D1). Look the author up so the ownership
+	// check can run before any destructive work; return 404 on mismatch or
+	// missing row so non-owners cannot probe for existence by status code.
+	author, err := h.authors.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if author == nil || !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+		return
+	}
+
 	// Opt-in `?deleteFiles=true` sweeps every book's on-disk path after the
 	// DB delete. We must collect the paths *before* deleting the author —
 	// the FK cascade removes the book rows along with it, which would leave
@@ -959,6 +999,11 @@ func (h *AuthorHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 
 	author, err := h.authors.GetByID(r.Context(), id)
 	if err != nil || author == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
 		return
 	}

--- a/internal/api/authors_alias.go
+++ b/internal/api/authors_alias.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -41,6 +42,11 @@ func (h *AuthorAliasHandler) List(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
 		return
 	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+		return
+	}
 	aliases, err := h.aliases.ListByAuthor(r.Context(), id)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
@@ -71,6 +77,11 @@ func (h *AuthorAliasHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if author == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found"})
 		return
 	}
@@ -121,14 +132,17 @@ func (h *AuthorAliasHandler) Merge(w http.ResponseWriter, r *http.Request) {
 
 	// Validate both exist up-front so the UI gets a 404 instead of a 500.
 	// The transaction inside Merge re-reads them under lock anyway, so this
-	// is only a preflight.
+	// is only a preflight. Both rows must also pass the Tier-1 cross-user
+	// ownership check (D1) so a non-owner cannot merge an unrelated author
+	// (source) into one of their own, or absorb their author into someone
+	// else's row (target).
 	for _, id := range []int64{req.SourceID, targetID} {
 		a, err := h.authors.GetByID(r.Context(), id)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
 		}
-		if a == nil {
+		if a == nil || !auth.CheckOwnership(r.Context(), a.OwnerUserID) {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "author not found: " + strconv.FormatInt(id, 10)})
 			return
 		}

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/importer"
@@ -133,6 +134,11 @@ func (h *BookHandler) EnrichAudiobook(w http.ResponseWriter, r *http.Request) {
 	}
 	book, err := h.books.GetByID(r.Context(), id)
 	if err != nil || book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1). 404 (not 403) on mismatch.
+	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}
@@ -261,6 +267,11 @@ func (h *BookHandler) Get(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
 	proxyBookImages(book)
 	cleanBookDescription(book)
 	h.attachBookFiles(r.Context(), book)
@@ -290,6 +301,11 @@ func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	book, err := h.books.GetByID(r.Context(), id)
 	if err != nil || book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}
@@ -375,6 +391,18 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
 		return
 	}
+	// Tier-1 cross-user IDOR guard (D1). Pre-fetch the book so the ownership
+	// check can run before any destructive work; 404 on mismatch or missing
+	// row so non-owners cannot probe for existence. The handler's existing
+	// `?deleteFiles=true` branch re-fetches when it needs the legacy file
+	// columns; the extra lookup is cheap and keeps the diff localised.
+	if existing, err := h.books.GetByID(r.Context(), id); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	} else if existing == nil || !auth.CheckOwnership(r.Context(), existing.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
 	// Opt-in `?deleteFiles=true` also removes every on-disk file tracked in
 	// book_files before dropping the record. Each path is first run through
 	// the library-root containment check (Wave 1 / Bundle B) so a tampered
@@ -426,6 +454,16 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 	id, ok := parseID(w, r)
 	if !ok {
+		return
+	}
+
+	// Tier-1 cross-user IDOR guard (D1). Fetch the book up-front so the
+	// ownership check runs before any file enumeration or destructive work.
+	if existing, err := h.books.GetByID(r.Context(), id); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	} else if existing == nil || !auth.CheckOwnership(r.Context(), existing.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}
 
@@ -660,6 +698,11 @@ func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
 
 	var req struct {
 		Provider  string `json:"provider"`
@@ -821,6 +864,11 @@ func (h *BookHandler) ToggleExcluded(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
 
 	newVal := !book.Excluded
 	if err := h.books.SetExcluded(r.Context(), id, newVal); err != nil {
@@ -858,6 +906,11 @@ func (h *BookHandler) MapMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 	book, err := h.books.GetByID(r.Context(), id)
 	if err != nil || book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 )
 
@@ -43,6 +44,13 @@ func (h *FileHandler) Download(w http.ResponseWriter, r *http.Request) {
 
 	book, err := h.books.GetByID(r.Context(), id)
 	if err != nil || book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1). Hit by OPDS readers too; respond
+	// 404 (not 403) on mismatch so we do not change the response shape and
+	// do not leak existence to non-owners.
+	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/decision"
 	"github.com/vavallee/bindery/internal/httpsec"
@@ -230,6 +231,11 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 	}
 	book, err := h.books.GetByID(r.Context(), bookID)
 	if err != nil || book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
 		return
 	}

--- a/internal/api/metadata_profiles.go
+++ b/internal/api/metadata_profiles.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -43,6 +44,11 @@ func (h *MetadataProfileHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if p == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "metadata profile not found"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), p.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "metadata profile not found"})
 		return
 	}
@@ -83,6 +89,11 @@ func (h *MetadataProfileHandler) Update(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "metadata profile not found"})
 		return
 	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), existing.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "metadata profile not found"})
+		return
+	}
 	var p models.MetadataProfile
 	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -103,6 +114,17 @@ func (h *MetadataProfileHandler) Delete(w http.ResponseWriter, r *http.Request) 
 	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid id"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1). Pre-fetch so non-owners cannot
+	// observe a 200 / 500 vs. 404 difference and probe for existence.
+	existing, err := h.repo.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if existing == nil || !auth.CheckOwnership(r.Context(), existing.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "metadata profile not found"})
 		return
 	}
 	if err := h.repo.Delete(r.Context(), id); err != nil {

--- a/internal/api/quality_profiles.go
+++ b/internal/api/quality_profiles.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -45,6 +46,13 @@ func (h *QualityProfileHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if p == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "quality profile not found"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1). The Put / Delete routes for this
+	// resource are already RequireAdmin (see cmd/bindery/main.go), so only
+	// the read path needs the per-user gate here.
+	if !auth.CheckOwnership(r.Context(), p.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "quality profile not found"})
 		return
 	}

--- a/internal/api/recommendations.go
+++ b/internal/api/recommendations.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/metadata"
@@ -142,6 +143,20 @@ func (h *RecommendationHandler) Dismiss(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Tier-1 cross-user IDOR guard (D1). Recommendations carry a UserID
+	// column (see migration 015); fetch the row and verify ownership before
+	// recording the dismissal so a non-owner cannot purge someone else's
+	// feed by ID. 404 (not 403) on mismatch to avoid leaking existence.
+	rec, err := h.recs.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if rec == nil || !auth.CheckOwnership(r.Context(), rec.UserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "recommendation not found"})
+		return
+	}
+
 	if err := h.recs.Dismiss(r.Context(), 1, id); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -163,6 +178,11 @@ func (h *RecommendationHandler) Add(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if rec == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "recommendation not found"})
+		return
+	}
+	// Tier-1 cross-user IDOR guard (D1).
+	if !auth.CheckOwnership(r.Context(), rec.UserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "recommendation not found"})
 		return
 	}

--- a/internal/api/root_folders.go
+++ b/internal/api/root_folders.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -74,6 +75,18 @@ func (h *RootFolderHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 func (h *RootFolderHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	// Tier-1 cross-user IDOR guard (D1). Pre-fetch so non-owners cannot
+	// delete a root folder belonging to a different user, and cannot
+	// distinguish "exists but not mine" from "does not exist".
+	existing, err := h.folders.GetByID(r.Context(), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if existing == nil || !auth.CheckOwnership(r.Context(), existing.OwnerUserID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "root folder not found"})
+		return
+	}
 	if err := h.folders.Delete(r.Context(), id); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -6,7 +6,11 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
 )
 
 // Mode represents the auth posture. Matches Sonarr's "Authentication Required"
@@ -77,11 +81,82 @@ func WithUserRole(ctx context.Context, role string) context.Context {
 }
 
 // WithUserID returns a context carrying the given authenticated user id.
-// Exported so tests can construct the same state Middleware sets after
-// resolving a session cookie, without going through the full middleware
-// chain. Production code paths never call this directly.
+// Exported so tests (and any future non-middleware code paths) can construct
+// the same authenticated context shape that Middleware attaches at runtime.
 func WithUserID(ctx context.Context, userID int64) context.Context {
 	return context.WithValue(ctx, userIDCtxKey, userID)
+}
+
+// enforceTenancy is the resolved value of BINDERY_ENFORCE_TENANCY, cached so
+// each CheckOwnership call does not hit os.Getenv. 0 = off, 1 = on. Read once
+// at first use (or whenever a test overrides it via SetEnforceTenancyForTests).
+var (
+	enforceTenancy     atomic.Int32
+	enforceTenancyOnce sync.Once
+)
+
+// enforceTenancyEnabled reports whether per-user resource isolation is on.
+// Reads BINDERY_ENFORCE_TENANCY the first time it is called and caches the
+// result. Values "1", "true", "yes", "on" (case insensitive) flip the gate
+// on; everything else (including the empty value) leaves it off, matching
+// the single-user default.
+func enforceTenancyEnabled() bool {
+	enforceTenancyOnce.Do(func() {
+		enforceTenancy.Store(readEnforceTenancyEnv())
+	})
+	return enforceTenancy.Load() == 1
+}
+
+func readEnforceTenancyEnv() int32 {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("BINDERY_ENFORCE_TENANCY"))) {
+	case "1", "true", "yes", "on":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// SetEnforceTenancyForTests forces the tenancy gate on or off for the duration
+// of a single test. The previous value is restored via t.Cleanup so test order
+// does not matter. Bypasses the sync.Once so subsequent CheckOwnership calls
+// observe the override immediately.
+func SetEnforceTenancyForTests(t *testing.T, on bool) {
+	t.Helper()
+	// Force the Once to be considered done so future reads skip the env lookup.
+	enforceTenancyOnce.Do(func() {})
+	prev := enforceTenancy.Load()
+	var next int32
+	if on {
+		next = 1
+	}
+	enforceTenancy.Store(next)
+	t.Cleanup(func() { enforceTenancy.Store(prev) })
+}
+
+// CheckOwnership reports whether the request identified by ctx may act on a
+// resource owned by ownerUserID. The check is permissive by design so the
+// single-user install (no env var set) keeps working unchanged: returns true
+// when the BINDERY_ENFORCE_TENANCY gate is off, when the caller is admin,
+// when the resource has no recorded owner (legacy pre-migration-025 rows
+// scan as 0), or when the caller's user id matches.
+//
+// Handlers should treat a false result as "pretend the resource does not
+// exist" and respond 404, never 403; leaking existence to non-owners is the
+// IDOR this helper is designed to close.
+func CheckOwnership(ctx context.Context, ownerUserID int64) bool {
+	if !enforceTenancyEnabled() {
+		return true
+	}
+	if UserRoleFromContext(ctx) == "admin" {
+		return true
+	}
+	if ownerUserID == 0 {
+		// Legacy / system-owned rows have no recorded user; treat as visible
+		// to every authenticated caller so a pre-migration-025 install can
+		// flip the gate on without orphaning data.
+		return true
+	}
+	return ownerUserID == UserIDFromContext(ctx)
 }
 
 // RequireAdmin is a middleware that rejects non-admin requests with 403.

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -144,5 +145,101 @@ func TestProxyAuthRegularPathUntrustedIPStill401s(t *testing.T) {
 	}
 	if w.status != http.StatusUnauthorized {
 		t.Errorf("status = %d; want 401", w.status)
+	}
+}
+
+// Regression tests for CheckOwnership, the helper that closes Tier-1 per-user
+// IDOR (D1). The contract:
+//
+//   - Gate off (BINDERY_ENFORCE_TENANCY unset/false): always returns true so
+//     existing single-user installs and tests see no behavior change.
+//   - Gate on + admin role: passes regardless of owner.
+//   - Gate on + owner match: passes.
+//   - Gate on + owner mismatch: blocked.
+//   - Gate on + ownerUserID == 0 (legacy / pre-migration-025 row): passes,
+//     to avoid orphaning data when an operator first turns the flag on.
+//
+// Each test uses SetEnforceTenancyForTests with t.Cleanup so order does not
+// matter and the package-level cache is restored after the test exits.
+
+func TestCheckOwnership_GateOffAllowsAll(t *testing.T) {
+	SetEnforceTenancyForTests(t, false)
+
+	ctx := context.WithValue(context.Background(), userIDCtxKey, int64(7))
+	// Caller is user 7 but the resource is owned by user 99; with the gate
+	// off this must still pass so single-user installs keep working.
+	if !CheckOwnership(ctx, 99) {
+		t.Error("CheckOwnership must pass when BINDERY_ENFORCE_TENANCY is off, regardless of owner")
+	}
+}
+
+func TestCheckOwnership_AdminAlwaysPasses(t *testing.T) {
+	SetEnforceTenancyForTests(t, true)
+
+	ctx := context.WithValue(context.Background(), userIDCtxKey, int64(7))
+	ctx = WithUserRole(ctx, "admin")
+	if !CheckOwnership(ctx, 99) {
+		t.Error("admin role must override owner mismatch even when the gate is on")
+	}
+}
+
+func TestCheckOwnership_OwnerMatchesPasses(t *testing.T) {
+	SetEnforceTenancyForTests(t, true)
+
+	ctx := context.WithValue(context.Background(), userIDCtxKey, int64(7))
+	ctx = WithUserRole(ctx, "user")
+	if !CheckOwnership(ctx, 7) {
+		t.Error("CheckOwnership must pass when caller owns the resource")
+	}
+}
+
+func TestCheckOwnership_OwnerMismatchBlocked(t *testing.T) {
+	SetEnforceTenancyForTests(t, true)
+
+	ctx := context.WithValue(context.Background(), userIDCtxKey, int64(7))
+	ctx = WithUserRole(ctx, "user")
+	if CheckOwnership(ctx, 99) {
+		t.Error("CheckOwnership must block when caller is not owner and not admin")
+	}
+}
+
+func TestCheckOwnership_OwnerZeroPassesAsLegacyRow(t *testing.T) {
+	SetEnforceTenancyForTests(t, true)
+
+	ctx := context.WithValue(context.Background(), userIDCtxKey, int64(7))
+	ctx = WithUserRole(ctx, "user")
+	// owner_user_id IS NULL scans as 0 in Go; those rows pre-date migration
+	// 025's backfill and must remain accessible after the flag is flipped on
+	// so the operator does not orphan their library.
+	if !CheckOwnership(ctx, 0) {
+		t.Error("CheckOwnership must pass when ownerUserID is 0 (legacy row)")
+	}
+}
+
+func TestCheckOwnership_UnauthenticatedBlockedOnOwnedRow(t *testing.T) {
+	SetEnforceTenancyForTests(t, true)
+
+	// No user id, no role — a request that somehow reached an authed
+	// handler context without identity must still be blocked from owned
+	// resources. Gate-off path handles the "no auth required" case.
+	ctx := context.Background()
+	if CheckOwnership(ctx, 99) {
+		t.Error("unauthenticated context must not pass ownership for owned rows when the gate is on")
+	}
+}
+
+func TestSetEnforceTenancyForTests_RestoresPreviousValue(t *testing.T) {
+	// Capture the value the package currently sees.
+	pre := enforceTenancyEnabled()
+
+	// Sub-test flips the gate; its t.Cleanup must restore pre.
+	t.Run("flipped", func(t *testing.T) {
+		SetEnforceTenancyForTests(t, !pre)
+		if enforceTenancyEnabled() == pre {
+			t.Fatalf("flip did not stick; got %v, want %v", enforceTenancyEnabled(), !pre)
+		}
+	})
+	if enforceTenancyEnabled() != pre {
+		t.Errorf("cleanup did not restore; got %v, want %v", enforceTenancyEnabled(), pre)
 	}
 }

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -33,7 +33,7 @@ func (r *AuthorRepo) WithTx(tx *sql.Tx) *AuthorRepo {
 const authorSelectCols = `id, foreign_id, name, sort_name, description, image_url, disambiguation,
 	       ratings_count, average_rating, monitored, quality_profile_id, metadata_profile_id, root_folder_id,
 	       audiobook_root_folder_id, monitor_mode, monitor_latest_count, metadata_provider, last_metadata_refresh_at,
-	       created_at, updated_at`
+	       created_at, updated_at, COALESCE(owner_user_id, 0)`
 
 func (r *AuthorRepo) List(ctx context.Context) ([]models.Author, error) {
 	return r.ListByUser(ctx, 0)
@@ -336,7 +336,7 @@ func scanAuthor(rows *sql.Rows) (models.Author, error) {
 		&a.Disambiguation, &a.RatingsCount, &a.AverageRating, &monitored,
 		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.AudiobookRootFolderID,
 		&a.MonitorMode, &a.MonitorLatestCount, &a.MetadataProvider,
-		&a.LastMetadataRefreshAt, &a.CreatedAt, &a.UpdatedAt)
+		&a.LastMetadataRefreshAt, &a.CreatedAt, &a.UpdatedAt, &a.OwnerUserID)
 	a.Monitored = monitored == 1
 	normalizeAuthorMonitorDefaults(&a)
 	return a, err
@@ -349,7 +349,7 @@ func scanAuthorRow(row *sql.Row) (models.Author, error) {
 		&a.Disambiguation, &a.RatingsCount, &a.AverageRating, &monitored,
 		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.AudiobookRootFolderID,
 		&a.MonitorMode, &a.MonitorLatestCount, &a.MetadataProvider,
-		&a.LastMetadataRefreshAt, &a.CreatedAt, &a.UpdatedAt)
+		&a.LastMetadataRefreshAt, &a.CreatedAt, &a.UpdatedAt, &a.OwnerUserID)
 	a.Monitored = monitored == 1
 	normalizeAuthorMonitorDefaults(&a)
 	return a, err

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -69,7 +69,8 @@ const bookColumns = `books.id, books.foreign_id, books.author_id, books.title, b
 	COALESCE(fe.path, COALESCE(books.ebook_file_path, '')),
 	COALESCE(fa.path, COALESCE(books.audiobook_file_path, '')),
 	books.excluded,
-	au.id, au.foreign_id, au.name, au.sort_name`
+	au.id, au.foreign_id, au.name, au.sort_name,
+	COALESCE(books.owner_user_id, 0)`
 
 // bookJoins are the LEFT JOINs that attach the first_ebook and first_audiobook
 // CTE results plus the author row to the books table. Must follow the FROM
@@ -438,6 +439,7 @@ func (r *BookRepo) query(ctx context.Context, q string, args []any) ([]models.Bo
 			&b.EbookFilePath, &b.AudiobookFilePath,
 			&excluded,
 			&authorID, &authorForeignID, &authorName, &authorSortName,
+			&b.OwnerUserID,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("scan book: %w", err)

--- a/internal/db/metadata_profiles.go
+++ b/internal/db/metadata_profiles.go
@@ -19,7 +19,8 @@ func NewMetadataProfileRepo(db *sql.DB) *MetadataProfileRepo {
 func (r *MetadataProfileRepo) List(ctx context.Context) ([]models.MetadataProfile, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, min_popularity, min_pages, skip_missing_date, skip_missing_isbn,
-		       skip_part_books, allowed_languages, unknown_language_behavior, created_at
+		       skip_part_books, allowed_languages, unknown_language_behavior, created_at,
+		       COALESCE(owner_user_id, 0)
 		FROM metadata_profiles ORDER BY id`)
 	if err != nil {
 		return nil, fmt.Errorf("list metadata profiles: %w", err)
@@ -40,7 +41,8 @@ func (r *MetadataProfileRepo) List(ctx context.Context) ([]models.MetadataProfil
 func (r *MetadataProfileRepo) GetByID(ctx context.Context, id int64) (*models.MetadataProfile, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, min_popularity, min_pages, skip_missing_date, skip_missing_isbn,
-		       skip_part_books, allowed_languages, unknown_language_behavior, created_at
+		       skip_part_books, allowed_languages, unknown_language_behavior, created_at,
+		       COALESCE(owner_user_id, 0)
 		FROM metadata_profiles WHERE id=?`, id)
 	if err != nil {
 		return nil, fmt.Errorf("get metadata profile %d: %w", id, err)
@@ -115,7 +117,7 @@ func scanMetadataProfile(rows *sql.Rows) (models.MetadataProfile, error) {
 	err := rows.Scan(
 		&p.ID, &p.Name, &p.MinPopularity, &p.MinPages,
 		&skipDate, &skipISBN, &skipPart, &p.AllowedLanguages,
-		&p.UnknownLanguageBehavior, &p.CreatedAt,
+		&p.UnknownLanguageBehavior, &p.CreatedAt, &p.OwnerUserID,
 	)
 	if err != nil {
 		return p, fmt.Errorf("scan metadata profile: %w", err)

--- a/internal/db/quality_profiles.go
+++ b/internal/db/quality_profiles.go
@@ -31,7 +31,7 @@ func NewQualityProfileRepo(db *sql.DB) *QualityProfileRepo {
 
 func (r *QualityProfileRepo) List(ctx context.Context) ([]models.QualityProfile, error) {
 	rows, err := r.db.QueryContext(ctx,
-		"SELECT id, name, upgrade_allowed, cutoff, items, created_at FROM quality_profiles ORDER BY id")
+		"SELECT id, name, upgrade_allowed, cutoff, items, created_at, COALESCE(owner_user_id, 0) FROM quality_profiles ORDER BY id")
 	if err != nil {
 		return nil, fmt.Errorf("list quality profiles: %w", err)
 	}
@@ -50,7 +50,7 @@ func (r *QualityProfileRepo) List(ctx context.Context) ([]models.QualityProfile,
 
 func (r *QualityProfileRepo) GetByID(ctx context.Context, id int64) (*models.QualityProfile, error) {
 	rows, err := r.db.QueryContext(ctx,
-		"SELECT id, name, upgrade_allowed, cutoff, items, created_at FROM quality_profiles WHERE id=?", id)
+		"SELECT id, name, upgrade_allowed, cutoff, items, created_at, COALESCE(owner_user_id, 0) FROM quality_profiles WHERE id=?", id)
 	if err != nil {
 		return nil, fmt.Errorf("get quality profile %d: %w", id, err)
 	}
@@ -212,7 +212,7 @@ func scanQualityProfile(rows *sql.Rows) (models.QualityProfile, error) {
 	var p models.QualityProfile
 	var upgradeAllowed int
 	var itemsJSON string
-	if err := rows.Scan(&p.ID, &p.Name, &upgradeAllowed, &p.Cutoff, &itemsJSON, &p.CreatedAt); err != nil {
+	if err := rows.Scan(&p.ID, &p.Name, &upgradeAllowed, &p.Cutoff, &itemsJSON, &p.CreatedAt, &p.OwnerUserID); err != nil {
 		return p, fmt.Errorf("scan quality profile: %w", err)
 	}
 	p.UpgradeAllowed = upgradeAllowed == 1

--- a/internal/db/root_folders.go
+++ b/internal/db/root_folders.go
@@ -20,7 +20,7 @@ func NewRootFolderRepo(db *sql.DB) *RootFolderRepo {
 
 func (r *RootFolderRepo) List(ctx context.Context) ([]models.RootFolder, error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, path, free_space, created_at FROM root_folders ORDER BY id`)
+		`SELECT id, path, free_space, created_at, COALESCE(owner_user_id, 0) FROM root_folders ORDER BY id`)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +29,7 @@ func (r *RootFolderRepo) List(ctx context.Context) ([]models.RootFolder, error) 
 	var folders []models.RootFolder
 	for rows.Next() {
 		var f models.RootFolder
-		if err := rows.Scan(&f.ID, &f.Path, &f.FreeSpace, &f.CreatedAt); err != nil {
+		if err := rows.Scan(&f.ID, &f.Path, &f.FreeSpace, &f.CreatedAt, &f.OwnerUserID); err != nil {
 			return nil, err
 		}
 		folders = append(folders, f)
@@ -40,8 +40,8 @@ func (r *RootFolderRepo) List(ctx context.Context) ([]models.RootFolder, error) 
 func (r *RootFolderRepo) GetByID(ctx context.Context, id int64) (*models.RootFolder, error) {
 	var f models.RootFolder
 	err := r.db.QueryRowContext(ctx,
-		`SELECT id, path, free_space, created_at FROM root_folders WHERE id=?`, id).
-		Scan(&f.ID, &f.Path, &f.FreeSpace, &f.CreatedAt)
+		`SELECT id, path, free_space, created_at, COALESCE(owner_user_id, 0) FROM root_folders WHERE id=?`, id).
+		Scan(&f.ID, &f.Path, &f.FreeSpace, &f.CreatedAt, &f.OwnerUserID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}

--- a/internal/models/author.go
+++ b/internal/models/author.go
@@ -30,6 +30,13 @@ type Author struct {
 	CreatedAt             time.Time  `json:"createdAt"`
 	UpdatedAt             time.Time  `json:"updatedAt"`
 
+	// OwnerUserID is the per-user ownership column added in migration 025.
+	// Zero means "no recorded owner" (legacy pre-backfill rows or rows
+	// imported without a user context); CheckOwnership treats that as
+	// visible to every authenticated caller. The field is not exposed in
+	// JSON: it is an internal scoping hint, not API contract.
+	OwnerUserID int64 `json:"-"`
+
 	// Joined data
 	Books      []Book        `json:"books,omitempty"`
 	Statistics *AuthorStats  `json:"statistics,omitempty"`

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -44,6 +44,11 @@ type Book struct {
 	CreatedAt             time.Time  `json:"createdAt"`
 	UpdatedAt             time.Time  `json:"updatedAt"`
 
+	// OwnerUserID is the per-user ownership column added in migration 025.
+	// See models.Author for the legacy zero-value semantics. Not surfaced
+	// in JSON: callers identify books by id, not owner.
+	OwnerUserID int64 `json:"-"`
+
 	Excluded bool `json:"excluded"`
 
 	// EbookFilePath and AudiobookFilePath are computed views over the book_files

--- a/internal/models/metadata_profile.go
+++ b/internal/models/metadata_profile.go
@@ -21,4 +21,8 @@ type MetadataProfile struct {
 	AllowedLanguages        string    `json:"allowedLanguages"`
 	UnknownLanguageBehavior string    `json:"unknownLanguageBehavior"`
 	CreatedAt               time.Time `json:"createdAt"`
+	// OwnerUserID is the per-user ownership column added in migration 025.
+	// Zero means "no recorded owner" (legacy pre-backfill rows); auth's
+	// CheckOwnership treats that as visible to every authenticated caller.
+	OwnerUserID int64 `json:"-"`
 }

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -42,6 +42,10 @@ type RootFolder struct {
 	Path      string    `json:"path"`
 	FreeSpace int64     `json:"freeSpace"`
 	CreatedAt time.Time `json:"createdAt"`
+	// OwnerUserID is the per-user ownership column added in migration 025.
+	// Zero means "no recorded owner" (legacy pre-backfill rows); auth's
+	// CheckOwnership treats that as visible to every authenticated caller.
+	OwnerUserID int64 `json:"-"`
 }
 
 type QualityProfile struct {
@@ -51,6 +55,9 @@ type QualityProfile struct {
 	Cutoff         string        `json:"cutoff"`
 	Items          []QualityItem `json:"items"`
 	CreatedAt      time.Time     `json:"createdAt"`
+	// OwnerUserID is the per-user ownership column added in migration 025.
+	// See RootFolder for legacy zero-value semantics.
+	OwnerUserID int64 `json:"-"`
 }
 
 type QualityItem struct {


### PR DESCRIPTION
## Summary

Closes the cross-user IDOR on Tier-1 per-user resources. Pre-fix, any
logged-in user could `GET /api/v1/author/{$OTHERS_ID}` and see (or modify,
or delete) another user's data; same for books, profiles, root folders,
and recommendations. The audit caught this as Wave 1 Bundle D1.

## Design

Env-gated handler-level check, NOT a repo signature refactor.

* New `auth.CheckOwnership(ctx, ownerUserID)` is permissive by design:
  returns true when the env gate is off, when the caller is admin, when
  the resource row has `owner_user_id IS NULL` (legacy / pre-migration-025
  data, scanned as 0), or when the caller's user id matches the owner.
* Gate lives in `BINDERY_ENFORCE_TENANCY`. Unset / empty / `false` keeps
  the helper permissive, so existing tests and single-user installs see
  no behavior change. Multi-user deployments opt in by setting it to
  `true` (also accepts `1`, `yes`, `on`).
* Value is cached via `sync.Once` so the env read does not happen per
  request. `auth.SetEnforceTenancyForTests(t, on)` flips the cache and
  restores the previous value via `t.Cleanup`.
* On mismatch handlers respond 404 (not 403) so a non-owner cannot probe
  for the existence of another user's resources by status code.
* Repo `GetByID(ctx, id)` signatures are unchanged. Treating that as a
  separate v2 refactor.

## Handlers covered

| Resource | Routes |
|----------|--------|
| authors  | Get, Update, Delete, Refresh, RelinkUpstream, ListSeries, alias List, alias Delete, Merge |
| books    | Get, Update, Delete, DeleteFile, ToggleExcluded, Rebind, MapMetadata, EnrichAudiobook, indexer SearchBook, file Download |
| metadata profiles | Get, Update, Delete |
| quality profiles  | Get (Put / Delete already wrapped in `RequireAdmin`) |
| root folders      | Delete |
| recommendations   | Dismiss, Add |

The book file download (`GET /book/{id}/file`) is hit by ebook readers
and OPDS clients; the check responds 404 on mismatch so the response
shape is unchanged.

## Model + repo changes

`OwnerUserID int64 \`json:\"-\"\`` added to Author, Book, MetadataProfile,
QualityProfile, RootFolder. Recommendation already exposed `UserID` from
migration 015 so no model change there. Each repo's Scan path now reads
`COALESCE(owner_user_id, 0)` so a NULL legacy row surfaces as 0, which
`CheckOwnership` treats as visible to every authenticated caller. JSON
output for these resources is unchanged because the new field is tagged
`json:\"-\"`.

## Test plan

* [x] `internal/auth/middleware_test.go` covers the helper directly:
  gate off allows all, admin passes, owner matches passes, owner
  mismatch blocked, owner zero passes, unauthenticated blocked,
  `SetEnforceTenancyForTests` cleanup restores the previous value.
* [x] `internal/api/authorization_test.go` covers handlers end to end:
  for each of the six resources, one Get plus one Delete (where the
  shape applies) with three flavors apiece: gate on plus non-owner
  caller blocks with 404, gate on plus admin caller succeeds, gate off
  preserves pre-fix cross-user access (the env-gate canary).
* [x] `go test ./...` passes; nothing in the existing suite regressed.
* [x] `go vet ./...` clean.

## Out of scope

* **List endpoints**: not re-audited here. The Tier-1 List routes already
  go through `QueryScope` / `QueryScopeFor` from the migration 025
  scaffolding; the handlers only see the user's own rows. If a follow-up
  audit finds a List that bypasses the scope helper, that is a separate
  patch.
* **D3**: queue, history, pending, OPDS scoping.
* **D4**: tags / blocklist schema migration.
* **Recommendation handlers keyed off `{name}`** (author exclusions): a
  different IDOR shape, separate PR if needed.
* **`BookRepo.Create` does not stamp `owner_user_id`** yet; that is a
  Tier-2 follow-up. The handler-level check protects existing rows that
  already carry the column (post migration 025 backfill or via
  `CreateForUser` paths).

## Unusual handler shapes

A few handlers did not have a single resource-fetch shape and needed
small adjustments rather than a one-line insert:

* `authors.Delete` and `metadata_profiles.Delete` did not fetch the row
  at all (the Delete repo call took care of it). Added a `GetByID` so
  the ownership check has something to read.
* `authors.ListSeries` did not fetch the author either. Added a
  `GetByID` for the same reason.
* `books.Delete` and `books.DeleteFile` fetched the book only
  conditionally (when `?deleteFiles=true` and `book_files` was empty).
  Added an unconditional pre-fetch so the gate fires before any
  destructive work.
* `recommendations.Dismiss` previously hardcoded `userID = 1` and did
  not fetch the row. Now reads via `recs.GetByID` and checks against
  the caller's user id; the hardcoded `1` passed to `recs.Dismiss`
  stays because that argument records the dismissal under the same
  fixed user id the rest of the recommendation handlers use, and
  swapping it to the actual caller id is a separate behavioral change
  outside the IDOR fix.

## Related audit follow-ups

Refs #892, #893, #894, #895, #896, #897.