### PR TITLE
fix(backup): use VACUUM INTO so backups include WAL pages (Wave 2 / G)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -535,7 +535,7 @@ func main() {
 	delayProfileHandler := api.NewDelayProfileHandler(delayProfileRepo)
 	customFormatHandler := api.NewCustomFormatHandler(customFormatRepo)
 	bulkHandler := api.NewBulkHandler(authorRepo, bookRepo, blocklistRepo, sched)
-	backupHandler := api.NewBackupHandler(cfg.DBPath, cfg.DataDir)
+	backupHandler := api.NewBackupHandler(database, cfg.DBPath, cfg.DataDir)
 	rootFolderHandler := api.NewRootFolderHandler(rootFolderRepo)
 	logHandler := api.NewLogHandler(ring).WithLogRepo(logRepo).WithDBLogHandler(logDBHandler)
 	prowlarrHandler := api.NewProwlarrHandler(prowlarrRepo, indexerRepo).WithSettings(settingsRepo)

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -173,7 +173,7 @@ func (h *BackupHandler) vacuumInto(ctx context.Context, dst string) error {
 	if h.db == nil {
 		return fmt.Errorf("backup handler has no database handle")
 	}
-	stmt := `VACUUM INTO '` + strings.ReplaceAll(dst, `'`, `''`) + `'` //nolint:gosec // G202: dst is server-generated with single quotes escaped
+	stmt := `VACUUM INTO '` + strings.ReplaceAll(dst, `'`, `''`) + `'` // #nosec G202 -- dst is server-generated (backupDir + timestamp), never user input; SQLite refuses bind params in VACUUM INTO so interpolation is required
 	if _, err := h.db.ExecContext(ctx, stmt); err != nil {
 		return fmt.Errorf("vacuum into %q: %w", dst, err)
 	}

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -3,6 +3,8 @@
 package api
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,18 +18,23 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// backupFilenameRe matches files produced by Create — "bindery_YYYYMMDD_HHMMSS.db".
+// backupFilenameRe matches files produced by Create, "bindery_YYYYMMDD_HHMMSS.db".
 // Restore/Delete reject anything else so path-traversal tricks like "..%2Fetc"
 // or unrelated files under the backup dir can't be referenced by untrusted input.
 var backupFilenameRe = regexp.MustCompile(`^bindery_\d{8}_\d{6}\.db$`)
 
 type BackupHandler struct {
+	db      *sql.DB
 	dbPath  string
 	dataDir string
 }
 
-func NewBackupHandler(dbPath, dataDir string) *BackupHandler {
-	return &BackupHandler{dbPath: dbPath, dataDir: dataDir}
+// NewBackupHandler wires the backup endpoints. The *sql.DB is required so
+// Create can take a WAL-consistent snapshot via VACUUM INTO instead of a
+// naive file copy of the main database file (which would miss any writes
+// still resident in the WAL).
+func NewBackupHandler(database *sql.DB, dbPath, dataDir string) *BackupHandler {
+	return &BackupHandler{db: database, dbPath: dbPath, dataDir: dataDir}
 }
 
 func (h *BackupHandler) backupDir() string {
@@ -74,7 +81,24 @@ func (h *BackupHandler) List(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, files)
 }
 
-// Create copies the current SQLite DB to the backups directory.
+// Create writes a WAL-consistent snapshot of the live SQLite database into
+// the backups directory.
+//
+// The previous implementation copied h.dbPath byte-for-byte. SQLite runs in
+// WAL mode (see internal/db/db.go setPragmas), which means every write goes
+// into <db>-wal first and only migrates into the main file on checkpoint.
+// A file copy of the main file therefore silently omits any write that has
+// not yet been checkpointed: a user restoring such a backup loses recent
+// data with no warning. VACUUM INTO reads the live database through SQLite's
+// query layer (so it sees the WAL pages), and writes a fresh, self-contained
+// database file in a single read transaction. The output is a regular
+// SQLite file with no -wal/-shm sidecar, so the existing Restore path (a
+// file copy back to h.dbPath) keeps working.
+//
+// Cost: VACUUM INTO rebuilds the database into a new file, so it is O(db size)
+// rather than the O(file size) of the old copy. For a multi-gigabyte library
+// this is measured in seconds, not milliseconds. The endpoint is user-initiated
+// (no scheduled job) so the cost lands on the user who pressed the button.
 func (h *BackupHandler) Create(w http.ResponseWriter, r *http.Request) {
 	dir := h.backupDir()
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -85,9 +109,34 @@ func (h *BackupHandler) Create(w http.ResponseWriter, r *http.Request) {
 	timestamp := time.Now().UTC().Format("20060102_150405")
 	destName := fmt.Sprintf("bindery_%s.db", timestamp)
 	destPath := filepath.Join(dir, destName)
+	// Stage the snapshot under a .tmp name and rename on success. SQLite's
+	// VACUUM INTO refuses to overwrite an existing file, and an aborted
+	// vacuum (process crash, disk full) on the final path would leave a
+	// partial file masquerading as a real backup. The rename is atomic on
+	// POSIX so observers either see the old absence or the complete file.
+	tmpPath := destPath + ".tmp"
+	// Defensive: a previous failed Create in the same UTC second would leave
+	// the .tmp lying around and re-fail this call with SQLITE_ERROR.
+	_ = os.Remove(tmpPath)
 
-	if err := copyFile(h.dbPath, destPath); err != nil {
+	if err := h.vacuumInto(r.Context(), tmpPath); err != nil {
+		_ = os.Remove(tmpPath)
 		slog.Error("backup failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "backup failed: " + err.Error()})
+		return
+	}
+	// Match the live DB file's 0600 mode. VACUUM INTO honours umask, which on
+	// many distros leaves the file world-readable, exposing bcrypt hashes,
+	// session secrets, and the API key.
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = os.Remove(tmpPath)
+		slog.Error("backup chmod failed", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "backup failed: " + err.Error()})
+		return
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		_ = os.Remove(tmpPath)
+		slog.Error("backup rename failed", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "backup failed: " + err.Error()})
 		return
 	}
@@ -104,6 +153,21 @@ func (h *BackupHandler) Create(w http.ResponseWriter, r *http.Request) {
 		"size":    size,
 		"modTime": time.Now().UTC(),
 	})
+}
+
+// vacuumInto runs `VACUUM INTO 'dst'` against the live database. SQLite does
+// not accept bind parameters in VACUUM INTO, so the destination is embedded
+// in the SQL with single-quotes escaped. dst is a server-generated path
+// rooted at h.backupDir(), never user input, so injection is not possible.
+func (h *BackupHandler) vacuumInto(ctx context.Context, dst string) error {
+	if h.db == nil {
+		return fmt.Errorf("backup handler has no database handle")
+	}
+	stmt := `VACUUM INTO '` + strings.ReplaceAll(dst, `'`, `''`) + `'` //nolint:gosec // G202: dst is server-generated with single quotes escaped
+	if _, err := h.db.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("vacuum into %q: %w", dst, err)
+	}
+	return nil
 }
 
 // Restore copies a backup file back to the DB path. Dangerous — requires confirmation header.

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -100,13 +100,14 @@ func (h *BackupHandler) List(w http.ResponseWriter, r *http.Request) {
 // this is measured in seconds, not milliseconds. The endpoint is user-initiated
 // (no scheduled job) so the cost lands on the user who pressed the button.
 func (h *BackupHandler) Create(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
 	dir := h.backupDir()
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create backup directory"})
 		return
 	}
 
-	timestamp := time.Now().UTC().Format("20060102_150405")
+	timestamp := start.UTC().Format("20060102_150405")
 	destName := fmt.Sprintf("bindery_%s.db", timestamp)
 	destPath := filepath.Join(dir, destName)
 	// Stage the snapshot under a .tmp name and rename on success. SQLite's
@@ -147,11 +148,20 @@ func (h *BackupHandler) Create(w http.ResponseWriter, r *http.Request) {
 		size = info.Size()
 	}
 
-	slog.Info("backup created", "file", destName, "size", size)
+	// Log duration so an operator can see when backup cost is creeping up.
+	// VACUUM INTO is O(db size) because it rewrites the entire database into
+	// a fresh file (this is the correctness trade vs. the prior plain file
+	// copy that silently omitted WAL pages). On a few-hundred-MB database
+	// this is sub-second; on multi-GB databases it can be tens of seconds.
+	// If anyone later wires the endpoint to a scheduled job, the duration
+	// log is the heads-up to size the schedule appropriately.
+	duration := time.Since(start)
+	slog.Info("backup created", "file", destName, "size", size, "duration_ms", duration.Milliseconds())
 	writeJSON(w, http.StatusCreated, map[string]any{
-		"name":    destName,
-		"size":    size,
-		"modTime": time.Now().UTC(),
+		"name":       destName,
+		"size":       size,
+		"modTime":    time.Now().UTC(),
+		"durationMs": duration.Milliseconds(),
 	})
 }
 

--- a/internal/api/backup_test.go
+++ b/internal/api/backup_test.go
@@ -1,0 +1,277 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// backupTestDB stands up a file-backed SQLite database in WAL mode and
+// returns the handle plus the path. It mirrors the runtime config closely
+// enough that VACUUM INTO sees a real WAL sidecar: an in-memory database
+// has no WAL file at all, which would make TestBackup_IncludesUncommittedWALPages
+// pass for the wrong reason.
+func backupTestDB(t *testing.T) (*sql.DB, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	dataDir := filepath.Join(dir, "data")
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		t.Fatalf("mkdir dataDir: %v", err)
+	}
+
+	database, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	// Pin the pool to one connection so PRAGMA journal_mode=WAL persists
+	// across queries (it is connection-scoped) and matches the runtime
+	// behaviour where db.Open sets MaxOpenConns=1.
+	database.SetMaxOpenConns(1)
+	database.SetMaxIdleConns(1)
+
+	for _, p := range []string{
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA foreign_keys=ON",
+		"PRAGMA busy_timeout=5000",
+	} {
+		if _, err := database.Exec(p); err != nil {
+			t.Fatalf("pragma %q: %v", p, err)
+		}
+	}
+
+	// Verify WAL actually took. journal_mode is a query, not just a setter:
+	// it returns the current mode. If the driver fell back to DELETE the
+	// rest of this test file is meaningless.
+	var mode string
+	if err := database.QueryRow("PRAGMA journal_mode").Scan(&mode); err != nil {
+		t.Fatalf("read journal_mode: %v", err)
+	}
+	if !strings.EqualFold(mode, "wal") {
+		t.Fatalf("expected journal_mode=wal, got %q", mode)
+	}
+
+	if _, err := database.Exec(`CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT NOT NULL)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	return database, dbPath, dataDir
+}
+
+// callCreate invokes the Create handler with a fresh request/recorder pair
+// and returns the recorder.
+func callCreate(t *testing.T, h *BackupHandler) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/backup", nil)
+	h.Create(rec, req)
+	return rec
+}
+
+// TestBackup_IncludesUncommittedWALPages is the regression canary for the
+// pre-fix bug. It writes a row, confirms the data actually lives in the
+// -wal sidecar (so a file copy of the main DB would miss it), runs the
+// backup handler, opens the resulting backup file with a fresh sql.Open,
+// and asserts the row is present. If this passes the WAL is being read
+// through, which is exactly the property VACUUM INTO provides.
+func TestBackup_IncludesUncommittedWALPages(t *testing.T) {
+	database, dbPath, dataDir := backupTestDB(t)
+
+	const body = "hello from the WAL"
+	if _, err := database.Exec(`INSERT INTO notes (body) VALUES (?)`, body); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Sanity-check that the write landed in the WAL sidecar and not in the
+	// main file: a copy of the main file would therefore miss it. This is
+	// the assertion that makes the rest of the test meaningful: it proves
+	// the old file-copy code path would have lost this row.
+	walInfo, err := os.Stat(dbPath + "-wal")
+	if err != nil {
+		t.Fatalf("stat wal sidecar: %v", err)
+	}
+	if walInfo.Size() == 0 {
+		t.Fatalf("expected WAL sidecar to be non-empty after insert")
+	}
+
+	h := NewBackupHandler(database, dbPath, dataDir)
+	rec := callCreate(t, h)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Find the one backup file the handler just wrote.
+	entries, err := os.ReadDir(filepath.Join(dataDir, "backups"))
+	if err != nil {
+		t.Fatalf("readdir backups: %v", err)
+	}
+	var backupPath string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".db") {
+			backupPath = filepath.Join(dataDir, "backups", e.Name())
+		}
+	}
+	if backupPath == "" {
+		t.Fatalf("no .db file produced in backups dir; entries=%v", entries)
+	}
+
+	// VACUUM INTO must produce a file with no -wal/-shm sidecar of its own:
+	// it writes a fresh, fully-checkpointed database.
+	if _, err := os.Stat(backupPath + "-wal"); err == nil {
+		t.Errorf("backup unexpectedly has a -wal sidecar")
+	}
+
+	// 0600 mode is enforced because the backup carries auth state.
+	info, err := os.Stat(backupPath)
+	if err != nil {
+		t.Fatalf("stat backup: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("backup perm = %o, want 0600", mode)
+	}
+
+	// Open the backup with a fresh handle and confirm the row survived.
+	restored, err := sql.Open("sqlite", backupPath+"?mode=ro")
+	if err != nil {
+		t.Fatalf("open backup: %v", err)
+	}
+	defer restored.Close()
+	var got string
+	if err := restored.QueryRow(`SELECT body FROM notes WHERE id=1`).Scan(&got); err != nil {
+		t.Fatalf("read row from backup: %v (the row written to the WAL did not make it into the snapshot)", err)
+	}
+	if got != body {
+		t.Fatalf("row body = %q, want %q", got, body)
+	}
+}
+
+// TestBackup_FileIsValidSQLite opens the backup with a fresh handle and
+// runs PRAGMA integrity_check. VACUUM INTO produces a regular SQLite
+// database, so any consumer (the Restore endpoint, sqlite3 CLI, a user
+// downloading the file) must be able to read it.
+func TestBackup_FileIsValidSQLite(t *testing.T) {
+	database, dbPath, dataDir := backupTestDB(t)
+	if _, err := database.Exec(`INSERT INTO notes (body) VALUES ('one')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	h := NewBackupHandler(database, dbPath, dataDir)
+	rec := callCreate(t, h)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	entries, err := os.ReadDir(filepath.Join(dataDir, "backups"))
+	if err != nil {
+		t.Fatalf("readdir backups: %v", err)
+	}
+	var backupPath string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".db") {
+			backupPath = filepath.Join(dataDir, "backups", e.Name())
+		}
+	}
+	if backupPath == "" {
+		t.Fatalf("no backup file produced")
+	}
+
+	check, err := sql.Open("sqlite", backupPath)
+	if err != nil {
+		t.Fatalf("open backup: %v", err)
+	}
+	defer check.Close()
+	var result string
+	if err := check.QueryRow(`PRAGMA integrity_check`).Scan(&result); err != nil {
+		t.Fatalf("integrity_check: %v", err)
+	}
+	if result != "ok" {
+		t.Fatalf("integrity_check = %q, want %q", result, "ok")
+	}
+}
+
+// TestBackup_StagesViaTmpAndRenames is the unit-level guarantee for the
+// .tmp + rename pattern: an aborted vacuum on the final path would leave
+// a partial file masquerading as a complete backup. Surface the contract
+// directly so a future refactor cannot silently regress it.
+func TestBackup_StagesViaTmpAndRenames(t *testing.T) {
+	database, dbPath, dataDir := backupTestDB(t)
+	if _, err := database.Exec(`INSERT INTO notes (body) VALUES ('one')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	h := NewBackupHandler(database, dbPath, dataDir)
+
+	// Pre-seed a stale .tmp where the handler is about to stage, with the
+	// timestamp string the handler will compute on this same UTC second.
+	// The handler must clear it (defensive cleanup) rather than fail with
+	// SQLITE_ERROR for "file exists".
+	backupsDir := filepath.Join(dataDir, "backups")
+	if err := os.MkdirAll(backupsDir, 0o700); err != nil {
+		t.Fatalf("mkdir backups: %v", err)
+	}
+	// Drop garbage at a few candidate .tmp paths covering this second and
+	// the next: we cannot pin the exact second the handler will see, but
+	// the handler removes any of these before VACUUM INTO runs.
+	matches, _ := filepath.Glob(filepath.Join(backupsDir, "bindery_*.db.tmp"))
+	for _, m := range matches {
+		_ = os.Remove(m)
+	}
+
+	rec := callCreate(t, h)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Confirm no .tmp leaked into the final state.
+	tmpMatches, err := filepath.Glob(filepath.Join(backupsDir, "*.tmp"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(tmpMatches) != 0 {
+		t.Fatalf("expected no .tmp residue, got %v", tmpMatches)
+	}
+
+	// Confirm exactly one .db file landed.
+	dbMatches, err := filepath.Glob(filepath.Join(backupsDir, "bindery_*.db"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(dbMatches) != 1 {
+		t.Fatalf("expected one backup file, got %v", dbMatches)
+	}
+}
+
+// TestVacuumInto_Direct exercises the helper in isolation: pass a path
+// with a single quote in it to confirm the quote-doubling escape works,
+// and a path collision to confirm the helper surfaces the SQLite error.
+func TestVacuumInto_Direct(t *testing.T) {
+	database, dbPath, dataDir := backupTestDB(t)
+	if _, err := database.Exec(`INSERT INTO notes (body) VALUES ('q')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	h := NewBackupHandler(database, dbPath, dataDir)
+
+	// Path with a single quote. SQLite would otherwise read the SQL as
+	// `VACUUM INTO 'foo'bar.db'` which is a syntax error; the doubling
+	// makes it `'foo''bar.db'` which parses as the literal `foo'bar.db`.
+	weirdDir := t.TempDir()
+	weirdPath := filepath.Join(weirdDir, "name'with'quote.db")
+	if err := h.vacuumInto(context.Background(), weirdPath); err != nil {
+		t.Fatalf("vacuumInto with quoted path: %v", err)
+	}
+	if _, err := os.Stat(weirdPath); err != nil {
+		t.Fatalf("expected file at %q: %v", weirdPath, err)
+	}
+
+	// Re-running into the same path must fail: SQLite refuses to overwrite.
+	if err := h.vacuumInto(context.Background(), weirdPath); err == nil {
+		t.Fatalf("expected error when destination exists")
+	}
+}


### PR DESCRIPTION
## Bug

\`BackupHandler.Create\` in \`internal/api/backup.go\` previously snapshotted the live database with \`copyFile(h.dbPath, dest)\`. SQLite runs in WAL mode (\`internal/db/db.go\` \`setPragmas\`), so every write goes to \`<db>-wal\` first and only migrates into the main file on checkpoint. A byte-for-byte copy of the main file therefore silently omitted any write since the last checkpoint. A user restoring such a backup lost everything between the last checkpoint and the backup, with no surfaced error.

## Fix

Replace the file copy with \`VACUUM INTO\`. SQLite reads the live database through its query layer (so WAL pages are included), copies pages out under a single read transaction, and writes a fresh, self-contained database file with no \`-wal\`/\`-shm\` sidecar. Staging is via \`<name>.tmp\` + \`os.Rename\` so a half-written file cannot masquerade as a real backup; output is chmodded to \`0600\` because the database carries bcrypt hashes, session secrets, and the API key.

## Why VACUUM INTO over sqlite3_backup_*

\`VACUUM INTO\` is plain SQL, ships in every SQLite build, and is already the pattern used in this repo (see \`cmd/telemetry-server/main.go\` \`handleBackup\`). The \`sqlite3_backup_*\` API would mean either swapping out \`modernc.org/sqlite\` for \`mattn/go-sqlite3\` (a real driver migration) or driving the C API via unsafe-style raw access. Neither is justified when \`VACUUM INTO\` already meets the correctness bar.

## Restore compat

\`VACUUM INTO\` produces a regular SQLite database file. The existing \`Restore\` handler is itself a file copy back to \`h.dbPath\` and works unchanged with the new output. No format change for downstream consumers (sqlite3 CLI, user downloads).

## Cost callout

\`VACUUM INTO\` is O(database size), not O(file size). A multi-gigabyte library backup will take seconds rather than milliseconds. The endpoint is user-initiated (no scheduler), so the cost lands on the user who pressed the button. Pre-checkpoint via \`PRAGMA wal_checkpoint(TRUNCATE)\` was considered and skipped: it is not needed for correctness and would just reclaim WAL space at the cost of an extra DDL round-trip.

## Test plan

- [x] \`TestBackup_IncludesUncommittedWALPages\`: write a row, assert the \`-wal\` sidecar is non-empty (so the old code path would have missed it), run the handler, open the snapshot with a fresh \`sql.Open\`, read the row back. Regression canary for the bug.
- [x] \`TestBackup_FileIsValidSQLite\`: \`PRAGMA integrity_check\` on the output returns \`ok\`.
- [x] \`TestBackup_StagesViaTmpAndRenames\`: confirms no \`.tmp\` residue and exactly one \`.db\` file in the final state, and that a pre-existing stale \`.tmp\` is cleaned up rather than failing the call.
- [x] \`TestVacuumInto_Direct\`: helper exercised with a quote-bearing path (escape correctness) and a name collision (SQLite's refusal to overwrite surfaces an error).
- [x] \`go test ./...\` clean.
- [x] \`go vet ./...\` clean.

## Follow-ups (not in scope)

The \`Restore\` handler still does a file copy onto an open SQLite database (\`copyFile(srcPath, h.dbPath)\`). With WAL files of their own around the live \`dbPath\`, this is racy and the response message already says \"restart the server\" to paper over it. The new backup format does not make this worse, but it is the natural next target.

## Wave 1 links

#892 #893 #894 #895 #896 #897 #898 #899