### PR TITLE
fix(api): cap request body size to 1 MiB by default (Wave 2 / F)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -584,6 +584,16 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Compress(5))
 	r.Use(api.SecurityHeaders)
+	// Cap JSON / form request bodies at 1 MiB by default so an authenticated
+	// client cannot pin the process by streaming a multi-gigabyte body into
+	// json.Decode. Routes that legitimately accept larger payloads opt in via
+	// api.WithMaxBody on the chi sub-route (see /migrate/* below).
+	// PreserveRawBody must run first so the per-route override can re-wrap
+	// the raw body with a higher cap; without it the override would chain a
+	// larger MaxBytesReader on top of the smaller default and the inner cap
+	// would silently win.
+	r.Use(api.PreserveRawBody)
+	r.Use(api.MaxRequestBody)
 	r.Use(metrics.HTTPMiddleware(routeTemplate))
 
 	// Prometheus exposition. Mounted at the router root (no auth, no
@@ -912,14 +922,20 @@ func main() {
 		// Migration imports (CSV of author names, or Readarr SQLite DB).
 		// The Readarr import is async — POST returns 202 immediately and the
 		// UI polls GET /migrate/readarr/status to track completion.
-		r.Post("/migrate/csv", migrateHandler.ImportCSV)
-		r.Post("/migrate/readarr", migrateHandler.ImportReadarr)
+		//
+		// Per-route body caps override the 1 MiB default for routes that
+		// accept multipart file uploads. The handler-side acceptUpload still
+		// applies the authoritative per-route cap via http.MaxBytesReader;
+		// these overrides just raise the outer router-level ceiling so the
+		// inner wrap is the one that decides.
+		r.With(api.WithMaxBody(6<<20)).Post("/migrate/csv", migrateHandler.ImportCSV)         // CSV under 5 MiB
+		r.With(api.WithMaxBody(2<<30)).Post("/migrate/readarr", migrateHandler.ImportReadarr) // readarr.db can be hundreds of MiB
 		r.Get("/migrate/readarr/status", migrateHandler.ImportReadarrStatus)
 
 		// Goodreads library CSV import — a two-step migration aid: POST the
 		// export to /goodreads/preview for a dry-run, then POST the returned
 		// token to /goodreads/commit to add the resolved books.
-		r.Post("/migrate/goodreads/preview", migrateHandler.ImportGoodreadsPreview)
+		r.With(api.WithMaxBody(24<<20)).Post("/migrate/goodreads/preview", migrateHandler.ImportGoodreadsPreview) // Goodreads export under 20 MiB
 		r.Post("/migrate/goodreads/commit", migrateHandler.ImportGoodreadsCommit)
 
 		// Image proxy — caches external cover images locally so the browser

--- a/internal/api/maxbody.go
+++ b/internal/api/maxbody.go
@@ -3,8 +3,19 @@ package api
 import (
 	"context"
 	"io"
+	"log/slog"
 	"net/http"
+	"sync"
 )
+
+// Wiring contract: when this package's middleware is mounted, PreserveRawBody
+// MUST run before MaxRequestBody at the router root, and both must run before
+// any per-route WithMaxBody override. Skipping PreserveRawBody silently clamps
+// per-route overrides to DefaultMaxRequestBody (because chi runs Use before
+// With and MaxBytesReader cannot be unwrapped). The fallback path in
+// WithMaxBody logs a one-shot warning when this invariant is broken so the
+// misconfiguration shows up in dev / staging logs rather than only as a 400
+// on the first oversized upload.
 
 // DefaultMaxRequestBody is the per-request body cap applied by MaxRequestBody
 // when no per-route override is in effect. It is intentionally small:
@@ -78,12 +89,19 @@ func WithMaxBody(n int64) func(http.Handler) http.Handler {
 			}
 			raw, ok := r.Context().Value(origBodyCtxKey{}).(io.ReadCloser)
 			if !ok {
-				// PreserveRawBody was not in the chain (test fixtures, future
-				// embedders). Fall back to wrapping whatever is on r.Body.
-				// When the chain does not include the default cap this is
-				// the correct outcome; when it does, the smaller inner cap
-				// will still win but the developer is no worse off than
-				// without WithMaxBody.
+				// PreserveRawBody was not in the chain. In test fixtures
+				// constructing handlers directly this is fine. In production
+				// it means a per-route override is being silently clamped to
+				// the default cap (because MaxBytesReader cannot be
+				// unwrapped). Warn once so the misconfiguration is
+				// observable; further requests stay quiet to avoid log
+				// spam.
+				warnMissingPreserveRawBody.Do(func() {
+					slog.Warn("WithMaxBody installed without PreserveRawBody upstream; per-route override may be silently capped at DefaultMaxRequestBody",
+						"defaultLimit", DefaultMaxRequestBody,
+						"overrideLimit", n,
+					)
+				})
 				raw = r.Body
 			}
 			r.Body = http.MaxBytesReader(w, raw, n)
@@ -91,6 +109,12 @@ func WithMaxBody(n int64) func(http.Handler) http.Handler {
 		})
 	}
 }
+
+// warnMissingPreserveRawBody guards the slog.Warn fired the first time
+// WithMaxBody runs without PreserveRawBody upstream. The sync.Once keeps it
+// to one warning per process lifetime; logging on every request would flood
+// at the same rate as the offending route's traffic without adding info.
+var warnMissingPreserveRawBody sync.Once
 
 // hasRequestBody reports whether the HTTP method routinely carries a request
 // body. GET, HEAD, DELETE, and OPTIONS do not in any handler Bindery

--- a/internal/api/maxbody.go
+++ b/internal/api/maxbody.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"context"
+	"io"
+	"net/http"
+)
+
+// DefaultMaxRequestBody is the per-request body cap applied by MaxRequestBody
+// when no per-route override is in effect. It is intentionally small:
+// Bindery's JSON payloads are single records (an author, a book, a settings
+// blob, a small ID list) so 1 MiB is generous in practice. Routes that
+// legitimately accept larger payloads (file uploads, database dumps) opt in
+// to a larger cap via WithMaxBody on the chi route.
+const DefaultMaxRequestBody int64 = 1 << 20 // 1 MiB
+
+// origBodyCtxKey carries the raw, un-wrapped request body so WithMaxBody
+// can install a fresh MaxBytesReader against it. Without the original
+// reference a per-route override would chain a larger MaxBytesReader on top
+// of the default one and still clamp reads at the inner (lower) cap.
+type origBodyCtxKey struct{}
+
+// PreserveRawBody snapshots r.Body before any later middleware wraps it.
+// Wired at the router root, before MaxRequestBody, so that WithMaxBody can
+// retrieve the unwrapped reader and re-wrap with a higher per-route limit.
+//
+// The snapshot is only taken for methods that carry a body (POST, PUT,
+// PATCH); other methods pass through without touching the context.
+func PreserveRawBody(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hasRequestBody(r.Method) && r.Body != nil {
+			ctx := context.WithValue(r.Context(), origBodyCtxKey{}, r.Body)
+			r = r.WithContext(ctx)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// MaxRequestBody wraps r.Body in http.MaxBytesReader so any downstream
+// json.Decode, io.ReadAll, or ParseForm call stops cleanly at the byte cap.
+// Without this an authenticated client can POST a 10 GB body and pin the
+// process inside json.Decode while Go grows its decode buffers.
+//
+// Only methods that carry a body (POST, PUT, PATCH) are wrapped. GET, HEAD,
+// DELETE, and OPTIONS pass through untouched so the wrapper does not allocate
+// for the read-mostly traffic that dominates the request mix.
+//
+// Per-route overrides use WithMaxBody. Because chi runs r.With middleware
+// after r.Use middleware in the same chain, WithMaxBody cannot pre-empt the
+// default by setting context; instead it grabs the original body that
+// PreserveRawBody snapshotted at the router root and installs a fresh
+// MaxBytesReader with the higher limit, replacing the default wrap entirely.
+func MaxRequestBody(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hasRequestBody(r.Method) && r.Body != nil {
+			r.Body = http.MaxBytesReader(w, r.Body, DefaultMaxRequestBody)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// WithMaxBody returns a middleware that raises the per-request body cap to n
+// bytes for a single route. Use it via chi's r.With for routes that
+// legitimately accept larger payloads:
+//
+//	r.With(api.WithMaxBody(50 << 20)).Post("/migrate/readarr", h.ImportReadarr)
+//
+// The implementation discards the default wrap installed by MaxRequestBody
+// and re-wraps the raw body (snapshotted by PreserveRawBody at the router
+// root) with the higher limit. Without the discard a 1 MiB inner cap would
+// silently clamp reads regardless of the outer limit.
+func WithMaxBody(n int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !hasRequestBody(r.Method) || r.Body == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+			raw, ok := r.Context().Value(origBodyCtxKey{}).(io.ReadCloser)
+			if !ok {
+				// PreserveRawBody was not in the chain (test fixtures, future
+				// embedders). Fall back to wrapping whatever is on r.Body.
+				// When the chain does not include the default cap this is
+				// the correct outcome; when it does, the smaller inner cap
+				// will still win but the developer is no worse off than
+				// without WithMaxBody.
+				raw = r.Body
+			}
+			r.Body = http.MaxBytesReader(w, raw, n)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// hasRequestBody reports whether the HTTP method routinely carries a request
+// body. GET, HEAD, DELETE, and OPTIONS do not in any handler Bindery
+// registers, so wrapping their body would only cost an allocation.
+func hasRequestBody(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/api/maxbody_test.go
+++ b/internal/api/maxbody_test.go
@@ -1,0 +1,275 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// readAllHandler is a tiny sink that drains r.Body so the MaxBytesReader cap
+// is actually consulted on the read path. Real handlers do the equivalent
+// via json.Decode or io.ReadAll; we model the read side directly to keep the
+// middleware tests independent of any specific decoder.
+func readAllHandler(t *testing.T, gotErr *error, gotBytes *int) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		*gotErr = err
+		*gotBytes = len(buf)
+		if err != nil {
+			// Mirror what real handlers do: turn the cap error into a 4xx
+			// so the test can assert the status code in the integration test.
+			var mbe *http.MaxBytesError
+			if errors.As(err, &mbe) {
+				http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestMaxBody_AllowsUnderLimit(t *testing.T) {
+	var readErr error
+	var readN int
+	h := PreserveRawBody(MaxRequestBody(readAllHandler(t, &readErr, &readN)))
+
+	// 500 KiB, well under the 1 MiB default cap.
+	body := bytes.Repeat([]byte("a"), 500<<10)
+	req := httptest.NewRequest(http.MethodPost, "/x", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if readErr != nil {
+		t.Fatalf("expected handler to read body cleanly, got error: %v", readErr)
+	}
+	if readN != len(body) {
+		t.Errorf("read %d bytes, want %d", readN, len(body))
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestMaxBody_BlocksOverLimit(t *testing.T) {
+	var readErr error
+	var readN int
+	h := PreserveRawBody(MaxRequestBody(readAllHandler(t, &readErr, &readN)))
+
+	// 2 MiB, over the 1 MiB default cap; the read must error out.
+	body := bytes.Repeat([]byte("b"), 2<<20)
+	req := httptest.NewRequest(http.MethodPost, "/x", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if readErr == nil {
+		t.Fatal("expected read error from MaxBytesReader, got nil")
+	}
+	var mbe *http.MaxBytesError
+	if !errors.As(readErr, &mbe) {
+		t.Fatalf("expected *http.MaxBytesError, got %T: %v", readErr, readErr)
+	}
+	if mbe.Limit != DefaultMaxRequestBody {
+		t.Errorf("MaxBytesError.Limit = %d, want %d", mbe.Limit, DefaultMaxRequestBody)
+	}
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", rr.Code)
+	}
+}
+
+func TestMaxBody_PerRouteOverride(t *testing.T) {
+	// A request that would be blocked by the default (2 MiB body, 1 MiB cap)
+	// must pass when the route opts in to a higher cap via WithMaxBody. The
+	// fixture chains the same middleware stack the real router uses:
+	// PreserveRawBody at the top, MaxRequestBody on the route group, then
+	// WithMaxBody on the specific route.
+	var readErr error
+	var readN int
+	final := readAllHandler(t, &readErr, &readN)
+
+	r := chi.NewRouter()
+	r.Use(PreserveRawBody)
+	r.Use(MaxRequestBody)
+	r.With(WithMaxBody(10<<20)).Post("/big", final.ServeHTTP)
+
+	body := bytes.Repeat([]byte("c"), 2<<20)
+	req := httptest.NewRequest(http.MethodPost, "/big", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if readErr != nil {
+		t.Fatalf("override should accept 2 MiB body, got error: %v", readErr)
+	}
+	if readN != len(body) {
+		t.Errorf("read %d bytes, want %d", readN, len(body))
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestMaxBody_PerRouteOverrideStillEnforcesItsCap(t *testing.T) {
+	// Sanity check that the override is itself a real cap, not "unlimited".
+	// A 12 MiB body with a 10 MiB override must still fail.
+	var readErr error
+	var readN int
+	final := readAllHandler(t, &readErr, &readN)
+
+	r := chi.NewRouter()
+	r.Use(PreserveRawBody)
+	r.Use(MaxRequestBody)
+	r.With(WithMaxBody(10<<20)).Post("/big", final.ServeHTTP)
+
+	body := bytes.Repeat([]byte("d"), 12<<20)
+	req := httptest.NewRequest(http.MethodPost, "/big", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if readErr == nil {
+		t.Fatal("expected read error when body exceeds the override cap")
+	}
+	var mbe *http.MaxBytesError
+	if !errors.As(readErr, &mbe) {
+		t.Fatalf("expected *http.MaxBytesError, got %T: %v", readErr, readErr)
+	}
+	if mbe.Limit != 10<<20 {
+		t.Errorf("MaxBytesError.Limit = %d, want %d", mbe.Limit, 10<<20)
+	}
+}
+
+func TestMaxBody_GetIsExempt(t *testing.T) {
+	// GET has no body to read; the middleware must not allocate a wrapper
+	// or otherwise interfere with the request. We can't easily assert "no
+	// wrapper installed" so we just confirm a downstream Read returns 0
+	// bytes with EOF (the default Body for a body-less request).
+	var readErr error
+	var readN int
+	h := PreserveRawBody(MaxRequestBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		readErr = err
+		readN = len(buf)
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	req := httptest.NewRequest(http.MethodGet, "/y", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if readErr != nil {
+		t.Errorf("GET body read returned error: %v", readErr)
+	}
+	if readN != 0 {
+		t.Errorf("GET body read %d bytes, want 0", readN)
+	}
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestMaxBody_DeleteIsExempt(t *testing.T) {
+	// DELETE bodies are unusual in REST; Bindery never reads them. Confirm
+	// the middleware does not wrap them so a hypothetical larger body would
+	// pass through. Reading 2 MiB on DELETE must not produce a MaxBytesError.
+	var readErr error
+	var readN int
+	h := PreserveRawBody(MaxRequestBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		readErr = err
+		readN = len(buf)
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	body := bytes.Repeat([]byte("e"), 2<<20)
+	req := httptest.NewRequest(http.MethodDelete, "/z", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if readErr != nil {
+		t.Fatalf("DELETE read returned error: %v", readErr)
+	}
+	if readN != len(body) {
+		t.Errorf("DELETE read %d bytes, want %d (must pass through)", readN, len(body))
+	}
+}
+
+func TestMaxBody_PutCapped(t *testing.T) {
+	// PUT carries bodies (settings updates, OIDC providers). Confirm the cap
+	// applies symmetrically with POST.
+	var readErr error
+	var readN int
+	h := PreserveRawBody(MaxRequestBody(readAllHandler(t, &readErr, &readN)))
+
+	body := bytes.Repeat([]byte("f"), 2<<20)
+	req := httptest.NewRequest(http.MethodPut, "/w", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if readErr == nil {
+		t.Fatal("expected PUT body to be capped")
+	}
+	var mbe *http.MaxBytesError
+	if !errors.As(readErr, &mbe) {
+		t.Fatalf("expected *http.MaxBytesError, got %T", readErr)
+	}
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413", rr.Code)
+	}
+}
+
+func TestMaxBody_DefaultIsOneMiB(t *testing.T) {
+	// Pin the documented default. A regression here would silently raise or
+	// lower the cap for every JSON endpoint.
+	if DefaultMaxRequestBody != 1<<20 {
+		t.Errorf("DefaultMaxRequestBody = %d, want %d (1 MiB)", DefaultMaxRequestBody, 1<<20)
+	}
+}
+
+// TestMaxBody_OversizedJSONReturns4xx is an end-to-end check on a real chi
+// route that decodes JSON via json.NewDecoder(r.Body).Decode, the exact
+// pattern audited in internal/api/bulk.go:57. The handler is a stand-in
+// because spinning up the full BulkHandler would drag in db fixtures; the
+// behavior the middleware guarantees is identical: an oversized body causes
+// json.Decode to surface a *http.MaxBytesError before any allocations
+// proportional to the body size happen.
+func TestMaxBody_OversizedJSONReturns4xx(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(PreserveRawBody)
+	r.Use(MaxRequestBody)
+	r.Post("/api/v1/bulk", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			IDs []int64 `json:"ids"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			var mbe *http.MaxBytesError
+			if errors.As(err, &mbe) {
+				http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// 2 MiB of JSON noise wrapped as a string field. The decoder will start
+	// reading and trip the cap inside json.Decode.
+	pad := strings.Repeat("a", 2<<20)
+	body := `{"ids":[1],"pad":"` + pad + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/bulk", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 413; body = %q", rr.Code, rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Wave 2 Bundle F of the deep-audit followups. Centralizes a request-body
size cap in chi middleware so every POST/PUT/PATCH handler inherits
protection by default. Closes the audit finding at
`internal/api/bulk.go:57` (and 60+ similar `json.NewDecoder(r.Body).Decode`
call sites) where an authenticated client could POST a 10 GiB body and
pin the process inside `json.Decode`.

## Default cap

**1 MiB** (`1 << 20`). Bindery's JSON payloads are single records
(an author, a book, a bulk ID list, the OIDC providers blob, a settings
write). The OIDC providers PUT is the largest realistic JSON write and
fits in single-digit KiB even with a dozen providers. 1 MiB is generous.

## Per-route overrides

The multipart upload routes already wrap `r.Body` with their own
`http.MaxBytesReader` inside `acceptUpload`. To stop the default 1 MiB
cap from clamping reads before the handler-level cap can take effect,
those routes opt in to a larger outer ceiling via `api.WithMaxBody`:

| Route | Outer cap | Inner cap (acceptUpload) |
|---|---|---|
| `POST /api/v1/migrate/csv` | 6 MiB | 5 MiB |
| `POST /api/v1/migrate/readarr` | 2 GiB | 1 GiB |
| `POST /api/v1/migrate/goodreads/preview` | 24 MiB | 20 MiB |

Backup restore (`POST /api/v1/backup/{filename}/restore`) reads the
backup from disk by filename, not from the request body, so the default
1 MiB cap is fine there. No image upload routes exist (the only image
endpoint is a GET proxy).

## Design

Two middlewares wired at the router root:

  - `PreserveRawBody` snapshots `r.Body` in context before any wrap.
  - `MaxRequestBody` wraps `r.Body` in `http.MaxBytesReader` at 1 MiB.

`WithMaxBody(n)` is a per-route helper that retrieves the raw body
from context and rewraps with the larger cap, fully replacing the
default wrap rather than chaining a higher limit on top of a lower one
(which would silently keep clamping reads at the inner cap, defeating
the override).

Only POST, PUT, and PATCH are wrapped. GET, HEAD, DELETE, and OPTIONS
pass through untouched.

## Test plan

- [x] `TestMaxBody_AllowsUnderLimit` 500 KiB POST passes
- [x] `TestMaxBody_BlocksOverLimit` 2 MiB POST returns `*http.MaxBytesError`
- [x] `TestMaxBody_PerRouteOverride` 2 MiB POST passes through `WithMaxBody(10 MiB)`
- [x] `TestMaxBody_PerRouteOverrideStillEnforcesItsCap` 12 MiB POST fails against `WithMaxBody(10 MiB)`
- [x] `TestMaxBody_GetIsExempt` GET passes through with no cap
- [x] `TestMaxBody_DeleteIsExempt` DELETE passes through with no cap
- [x] `TestMaxBody_PutCapped` PUT receives the same cap as POST
- [x] `TestMaxBody_DefaultIsOneMiB` pins the documented constant
- [x] `TestMaxBody_OversizedJSONReturns4xx` end-to-end check that `json.NewDecoder(r.Body).Decode` surfaces the cap as a 413, exercising the exact pattern from the audit reference
- [x] Full `go test ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt` clean

## Wave 1 PRs

#892, #893, #894, #895, #896, #897, #898, #899