### PR TITLE
perf(api): paginate List endpoints + add sort/lookup indexes (Wave 2 / E)

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -140,10 +140,26 @@ func (h *AuthorHandler) hydrateHardcoverEditionsFrom(ctx context.Context, book *
 	})
 }
 
+// authorListResponse is the paginated wrapper returned by List. Replaces the
+// pre-Wave-2 bare `[]models.Author` shape; clients must unwrap `items` to
+// reach the rows. See the Wave 2 / E PR for the breaking-change disclosure.
+type authorListResponse struct {
+	Items  []models.Author `json:"items"`
+	Total  int             `json:"total"`
+	Limit  int             `json:"limit"`
+	Offset int             `json:"offset"`
+}
+
+const (
+	authorListDefaultLimit = 100
+	authorListMaxLimit     = 500
+)
+
 func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	userID := auth.UserIDFromContext(ctx)
-	authors, err := h.authors.ListByUser(ctx, userID)
+	limit, offset := parseLimitOffset(r, authorListDefaultLimit, authorListMaxLimit)
+	authors, total, err := h.authors.ListPage(ctx, userID, limit, offset)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -155,7 +171,12 @@ func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
 		cleanAuthorDescription(&authors[i])
 		proxyAuthorImages(&authors[i])
 	}
-	writeJSON(w, http.StatusOK, authors)
+	writeJSON(w, http.StatusOK, authorListResponse{
+		Items:  authors,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }
 
 func (h *AuthorHandler) Get(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2631,5 +2632,125 @@ func TestDeleteAuthor_PathContainment_RejectsOutsideRoots(t *testing.T) {
 	// Author row gone.
 	if got, _ := authorRepo.GetByID(ctx, author.ID); got != nil {
 		t.Errorf("author row should be deleted, got id=%d", got.ID)
+	}
+}
+
+// authorListFixture spins up the minimum wiring required by AuthorHandler.List:
+// a memory DB, AuthorRepo, and a handler that only needs the repo + profile
+// repo to satisfy the constructor.
+func authorListFixture(t *testing.T) (*AuthorHandler, *db.AuthorRepo, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	profiles := db.NewMetadataProfileRepo(database)
+	h := NewAuthorHandler(authors, nil, books, nil, nil, nil, profiles, nil)
+	return h, authors, context.Background()
+}
+
+// seedAuthorsForPagination seeds n authors with deterministic sort_names
+// "Sort 001", "Sort 002" so the sort_name ORDER BY in ListPage is
+// predictable.
+func seedAuthorsForPagination(t *testing.T, authors *db.AuthorRepo, ctx context.Context, n int) []string {
+	t.Helper()
+	sorts := make([]string, 0, n)
+	for i := 1; i <= n; i++ {
+		s := fmt.Sprintf("Sort %03d", i)
+		a := &models.Author{
+			ForeignID: fmt.Sprintf("OL-PAGE-%03d", i), Name: s, SortName: s,
+			MetadataProvider: "openlibrary", Monitored: true,
+		}
+		if err := authors.Create(ctx, a); err != nil {
+			t.Fatal(err)
+		}
+		sorts = append(sorts, s)
+	}
+	return sorts
+}
+
+func TestAuthorList_Paginates(t *testing.T) {
+	h, authors, ctx := authorListFixture(t)
+	sorts := seedAuthorsForPagination(t, authors, ctx, 10)
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/author?limit=3&offset=0", nil))
+	var first authorListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &first); err != nil {
+		t.Fatalf("decode first: %v", err)
+	}
+	if first.Total != 10 || first.Limit != 3 || first.Offset != 0 || len(first.Items) != 3 {
+		t.Errorf("first page = %+v, want total=10 limit=3 offset=0 len=3", first)
+	}
+	for i, a := range first.Items {
+		if a.SortName != sorts[i] {
+			t.Errorf("first page item %d sort_name = %q, want %q", i, a.SortName, sorts[i])
+		}
+	}
+
+	rec = httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/author?limit=3&offset=9", nil))
+	var tail authorListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &tail); err != nil {
+		t.Fatalf("decode tail: %v", err)
+	}
+	if tail.Total != 10 || len(tail.Items) != 1 || tail.Items[0].SortName != sorts[9] {
+		t.Errorf("tail page = %+v, want one item %q", tail, sorts[9])
+	}
+}
+
+func TestAuthorList_DefaultsAndCaps(t *testing.T) {
+	h, authors, ctx := authorListFixture(t)
+	seedAuthorsForPagination(t, authors, ctx, 3)
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/author", nil))
+	var defaults authorListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &defaults); err != nil {
+		t.Fatalf("decode defaults: %v", err)
+	}
+	if defaults.Limit != authorListDefaultLimit {
+		t.Errorf("expected default limit %d, got %d", authorListDefaultLimit, defaults.Limit)
+	}
+
+	rec = httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/author?limit=10000", nil))
+	var clamped authorListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &clamped); err != nil {
+		t.Fatalf("decode clamped: %v", err)
+	}
+	if clamped.Limit != authorListMaxLimit {
+		t.Errorf("expected clamped limit %d, got %d", authorListMaxLimit, clamped.Limit)
+	}
+}
+
+func TestAuthorList_OrderStable(t *testing.T) {
+	h, authors, ctx := authorListFixture(t)
+	seedAuthorsForPagination(t, authors, ctx, 5)
+	collect := func() []string {
+		rec := httptest.NewRecorder()
+		h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/author?limit=5&offset=0", nil))
+		var page authorListResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		out := make([]string, len(page.Items))
+		for i, a := range page.Items {
+			out[i] = a.SortName
+		}
+		return out
+	}
+	first := collect()
+	second := collect()
+	if len(first) != 5 || len(second) != 5 {
+		t.Fatalf("expected 5+5 items, got %d/%d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Errorf("order changed at %d: %q vs %q", i, first[i], second[i])
+		}
 	}
 }

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -207,33 +207,70 @@ func (h *BookHandler) tryMapAudiobookMetadataByASIN(ctx context.Context, book *m
 	}
 }
 
-func (h *BookHandler) List(w http.ResponseWriter, r *http.Request) {
-	var books []models.Book
-	var err error
+// bookListResponse is the paginated wrapper returned by List. Replaces the
+// pre-Wave-2 bare `[]models.Book` shape; clients must unwrap `items` to get
+// the rows. See PR #E for the breaking-change disclosure.
+type bookListResponse struct {
+	Items  []models.Book `json:"items"`
+	Total  int           `json:"total"`
+	Limit  int           `json:"limit"`
+	Offset int           `json:"offset"`
+}
 
+// bookListDefaultLimit is the default page size for an unparameterised List
+// request; bookListMaxLimit is the hard cap so a client cannot ask for
+// limit=10_000_000 and OOM the server building one big JSON blob.
+const (
+	bookListDefaultLimit = 100
+	bookListMaxLimit     = 500
+)
+
+func (h *BookHandler) List(w http.ResponseWriter, r *http.Request) {
 	authorID := r.URL.Query().Get("authorId")
 	status := r.URL.Query().Get("status")
 	includeExcluded := r.URL.Query().Get("includeExcluded") == "true"
+	limit, offset := parseLimitOffset(r, bookListDefaultLimit, bookListMaxLimit)
+
+	var (
+		books []models.Book
+		total int
+		err   error
+	)
 
 	switch {
 	case authorID != "":
+		// Filtered-by-author lists are bounded (max a few hundred per author)
+		// so we paginate in memory rather than threading LIMIT/OFFSET through
+		// every ListByAuthor* variant. The repo call still pulls one author's
+		// catalogue; the slice is cheap.
 		id, _ := strconv.ParseInt(authorID, 10, 64)
 		if includeExcluded {
 			books, err = h.books.ListByAuthorIncludingExcluded(r.Context(), id)
 		} else {
 			books, err = h.books.ListByAuthor(r.Context(), id)
 		}
+		books, total = pageBooks(books, limit, offset)
 	case status != "":
+		// Status-filtered lists (wanted/imported/etc.) can be large on a 50k
+		// library but they back the dashboard widgets, which always fetch the
+		// whole set today. Keep that behaviour for now and slice for the new
+		// envelope; a follow-up can add a SQL-paginated ListByStatusPage if
+		// the audit shows the wanted/imported pages dominate at scale.
 		if includeExcluded {
 			books, err = h.books.ListByStatusIncludingExcluded(r.Context(), status)
 		} else {
 			books, err = h.books.ListByStatus(r.Context(), status)
 		}
+		books, total = pageBooks(books, limit, offset)
 	default:
 		if includeExcluded {
 			books, err = h.books.ListIncludingExcluded(r.Context())
+			books, total = pageBooks(books, limit, offset)
 		} else {
-			books, err = h.books.List(r.Context())
+			// Default-path SQL pagination: the books list is the hottest
+			// 50k-row scan in the app, so push LIMIT/OFFSET to SQLite where
+			// idx_books_sort_title (migration 047) keeps the sort cheap.
+			books, total, err = h.books.ListPage(r.Context(), 0, limit, offset)
 		}
 	}
 
@@ -248,7 +285,27 @@ func (h *BookHandler) List(w http.ResponseWriter, r *http.Request) {
 		cleanBookDescription(&books[i])
 		proxyBookImages(&books[i])
 	}
-	writeJSON(w, http.StatusOK, books)
+	writeJSON(w, http.StatusOK, bookListResponse{
+		Items:  books,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
+}
+
+// pageBooks slices a fully-loaded book list by (limit, offset) and returns
+// the page along with the unsliced total. Used for the filtered List paths
+// where the underlying repo method does not yet take a page argument.
+func pageBooks(in []models.Book, limit, offset int) ([]models.Book, int) {
+	total := len(in)
+	if offset >= total {
+		return []models.Book{}, total
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	return in[offset:end], total
 }
 
 func (h *BookHandler) Get(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/books_test.go
+++ b/internal/api/books_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -90,8 +91,10 @@ func withURLParam(req *http.Request, key, val string) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
-// TestBookList_Empty returns [] (not null) so the frontend can render without
-// a null-check. A nil body here would break the books grid on first load.
+// TestBookList_Empty returns a wrapped envelope with items=[] (not null) so
+// the frontend can render without a null-check. A nil body here would break
+// the books grid on first load. As of Wave 2 / Bundle E the shape is
+// {items, total, limit, offset}, not a bare array.
 func TestBookList_Empty(t *testing.T) {
 	h, _, _, _, _ := bookFixture(t)
 	rec := httptest.NewRecorder()
@@ -99,8 +102,15 @@ func TestBookList_Empty(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
-	if bytes.TrimSpace(rec.Body.Bytes())[0] != '[' {
-		t.Errorf("expected JSON array, got %s", rec.Body.String())
+	var got bookListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode envelope: %v (body=%s)", err, rec.Body.String())
+	}
+	if got.Items == nil {
+		t.Errorf("expected items=[] (not null) so the frontend can render, got %s", rec.Body.String())
+	}
+	if got.Total != 0 || got.Offset != 0 || got.Limit != bookListDefaultLimit {
+		t.Errorf("expected zero totals + default limit, got %+v", got)
 	}
 }
 
@@ -124,12 +134,130 @@ func TestBookList_FiltersByAuthor(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book?authorId="+strconv.FormatInt(a1.ID, 10), nil))
-	var got []models.Book
+	var got bookListResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 2 {
-		t.Errorf("expected 2 books for author %d, got %d", a1.ID, len(got))
+	if got.Total != 2 || len(got.Items) != 2 {
+		t.Errorf("expected 2 books for author %d, got total=%d items=%d", a1.ID, got.Total, len(got.Items))
+	}
+}
+
+// seedBooksForPagination creates n books under the given author with
+// deterministic sort_titles ("Book 001", "Book 002", ...) so the order is
+// stable and the test can assert which slice of titles came back.
+func seedBooksForPagination(t *testing.T, books *db.BookRepo, ctx context.Context, authorID int64, n int) []string {
+	t.Helper()
+	titles := make([]string, 0, n)
+	for i := 1; i <= n; i++ {
+		title := fmt.Sprintf("Book %03d", i)
+		b := &models.Book{
+			ForeignID: fmt.Sprintf("PAGE-%03d", i), AuthorID: authorID, Title: title, SortTitle: title,
+			Status: "wanted", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+		}
+		if err := books.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+		titles = append(titles, title)
+	}
+	return titles
+}
+
+// TestBookList_Paginates exercises ?limit=N&offset=K with N seeded rows.
+// The first page returns three books and the trailing-edge page returns
+// the leftover one. Total is the unsliced count regardless of page.
+func TestBookList_Paginates(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+	titles := seedBooksForPagination(t, books, ctx, author.ID, 10)
+
+	// limit=3 offset=0 — first three by sort_title.
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book?limit=3&offset=0", nil))
+	var first bookListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &first); err != nil {
+		t.Fatalf("decode first: %v", err)
+	}
+	if first.Total != 10 || first.Limit != 3 || first.Offset != 0 || len(first.Items) != 3 {
+		t.Errorf("first page envelope = %+v, want total=10 limit=3 offset=0 len=3", first)
+	}
+	for i, b := range first.Items {
+		if b.Title != titles[i] {
+			t.Errorf("first page item %d = %q, want %q", i, b.Title, titles[i])
+		}
+	}
+
+	// offset=9 lands on the last book alone.
+	rec = httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book?limit=3&offset=9", nil))
+	var tail bookListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &tail); err != nil {
+		t.Fatalf("decode tail: %v", err)
+	}
+	if tail.Total != 10 || len(tail.Items) != 1 || tail.Items[0].Title != titles[9] {
+		t.Errorf("tail page = %+v, want one item %q", tail, titles[9])
+	}
+}
+
+// TestBookList_DefaultsAndCaps checks the default limit is applied when no
+// query param is set and that an oversized request is clamped at the
+// configured max so a client cannot pull the entire 50k library at once.
+func TestBookList_DefaultsAndCaps(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+	seedBooksForPagination(t, books, ctx, author.ID, 3)
+
+	// No params — default limit applies.
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book", nil))
+	var defaults bookListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &defaults); err != nil {
+		t.Fatalf("decode defaults: %v", err)
+	}
+	if defaults.Limit != bookListDefaultLimit {
+		t.Errorf("expected default limit %d, got %d", bookListDefaultLimit, defaults.Limit)
+	}
+
+	// limit=10000 must be clamped to bookListMaxLimit.
+	rec = httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book?limit=10000", nil))
+	var clamped bookListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &clamped); err != nil {
+		t.Fatalf("decode clamped: %v", err)
+	}
+	if clamped.Limit != bookListMaxLimit {
+		t.Errorf("expected clamped limit %d, got %d", bookListMaxLimit, clamped.Limit)
+	}
+}
+
+// TestBookList_OrderStable confirms the same query returns the same order on
+// repeat calls. Stability is what backs the frontend's "load next page"
+// pattern; if rows could shuffle between requests the user would see
+// duplicates or gaps as they scrolled.
+func TestBookList_OrderStable(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+	seedBooksForPagination(t, books, ctx, author.ID, 5)
+
+	collect := func() []string {
+		rec := httptest.NewRecorder()
+		h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book?limit=5&offset=0", nil))
+		var page bookListResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		out := make([]string, len(page.Items))
+		for i, b := range page.Items {
+			out[i] = b.Title
+		}
+		return out
+	}
+	first := collect()
+	second := collect()
+	if len(first) != 5 || len(second) != 5 {
+		t.Fatalf("expected 5+5 items, got %d/%d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Errorf("order changed between calls at %d: %q vs %q", i, first[i], second[i])
+		}
 	}
 }
 

--- a/internal/api/history.go
+++ b/internal/api/history.go
@@ -21,41 +21,48 @@ func NewHistoryHandler(history *db.HistoryRepo, blocklist *db.BlocklistRepo) *Hi
 	return &HistoryHandler{history: history, blocklist: blocklist}
 }
 
-func (h *HistoryHandler) List(w http.ResponseWriter, r *http.Request) {
-	var events []models.HistoryEvent
-	var err error
+// historyListResponse is the paginated wrapper returned by List. Replaces the
+// pre-Wave-2 bare `[]models.HistoryEvent` shape; clients must unwrap `items`
+// to reach the rows. See the Wave 2 / E PR for the breaking-change disclosure.
+type historyListResponse struct {
+	Items  []models.HistoryEvent `json:"items"`
+	Total  int                   `json:"total"`
+	Limit  int                   `json:"limit"`
+	Offset int                   `json:"offset"`
+}
 
+const (
+	historyListDefaultLimit = 100
+	historyListMaxLimit     = 500
+)
+
+func (h *HistoryHandler) List(w http.ResponseWriter, r *http.Request) {
 	bookIDStr := r.URL.Query().Get("bookId")
 	eventType := r.URL.Query().Get("eventType")
+	limit, offset := parseLimitOffset(r, historyListDefaultLimit, historyListMaxLimit)
 
-	// Per-user scoping (D3): history rows are scoped via JOIN through
-	// books.owner_user_id. When the gate is off, or for admin/API-key
-	// callers, fall through to the unscoped repo methods.
+	opts := db.HistoryListOpts{
+		EventType: eventType,
+		Limit:     limit,
+		Offset:    offset,
+	}
+	if bookIDStr != "" {
+		// Tolerate junk in the query string the same way the pre-Wave-2 code
+		// did (strconv error gives id=0, which then matches no rows).
+		opts.BookID, _ = strconv.ParseInt(bookIDStr, 10, 64)
+	}
+	// Per-user scoping (D3): when EnforceTenancy is on and the caller is a
+	// non-admin user, restrict to events whose book is owned by them. The
+	// JOIN-shape lives inside ListPage so paginated and filtered queries see
+	// the same scoping rule.
 	ctx := r.Context()
-	scope := auth.EnforceTenancy() && auth.UserRoleFromContext(ctx) != "admin"
-	uid := auth.UserIDFromContext(ctx)
-	if !scope || uid == 0 {
-		switch {
-		case bookIDStr != "":
-			id, _ := strconv.ParseInt(bookIDStr, 10, 64)
-			events, err = h.history.ListByBook(ctx, id)
-		case eventType != "":
-			events, err = h.history.ListByType(ctx, eventType)
-		default:
-			events, err = h.history.List(ctx)
-		}
-	} else {
-		switch {
-		case bookIDStr != "":
-			id, _ := strconv.ParseInt(bookIDStr, 10, 64)
-			events, err = h.history.ListByBookAndUser(ctx, id, uid)
-		case eventType != "":
-			events, err = h.history.ListByTypeAndUser(ctx, eventType, uid)
-		default:
-			events, err = h.history.ListForUser(ctx, uid)
+	if auth.EnforceTenancy() && auth.UserRoleFromContext(ctx) != "admin" {
+		if uid := auth.UserIDFromContext(ctx); uid != 0 {
+			opts.UserID = uid
 		}
 	}
 
+	events, total, err := h.history.ListPage(ctx, opts)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -63,7 +70,12 @@ func (h *HistoryHandler) List(w http.ResponseWriter, r *http.Request) {
 	if events == nil {
 		events = []models.HistoryEvent{}
 	}
-	writeJSON(w, http.StatusOK, events)
+	writeJSON(w, http.StatusOK, historyListResponse{
+		Items:  events,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }
 
 func (h *HistoryHandler) Delete(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/history_test.go
+++ b/internal/api/history_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -26,6 +27,9 @@ func historyFixture(t *testing.T) (*HistoryHandler, *db.HistoryRepo, *db.Blockli
 	return NewHistoryHandler(history, blocklist), history, blocklist, context.Background()
 }
 
+// TestHistoryList_EmptyReturnsArray verifies a fresh history table returns
+// the paginated envelope with items=[] (not null) so the frontend can render
+// without a null-check. The shape was a bare array pre-Wave-2.
 func TestHistoryList_EmptyReturnsArray(t *testing.T) {
 	h, _, _, _ := historyFixture(t)
 	rec := httptest.NewRecorder()
@@ -33,9 +37,15 @@ func TestHistoryList_EmptyReturnsArray(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
-	var got []models.HistoryEvent
+	var got historyListResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("expected JSON array, got %s", rec.Body.String())
+		t.Fatalf("decode envelope: %v (body=%s)", err, rec.Body.String())
+	}
+	if got.Items == nil {
+		t.Errorf("expected items=[] (not null), got %s", rec.Body.String())
+	}
+	if got.Total != 0 || got.Limit != historyListDefaultLimit {
+		t.Errorf("expected default-limit zero-total envelope, got %+v", got)
 	}
 }
 
@@ -55,12 +65,121 @@ func TestHistoryList_FiltersByEventType(t *testing.T) {
 	}
 	rec := httptest.NewRecorder()
 	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/history?eventType="+models.HistoryEventGrabbed, nil))
-	var got []models.HistoryEvent
+	var got historyListResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 2 {
-		t.Errorf("expected 2 grabbed events, got %d", len(got))
+	if got.Total != 2 || len(got.Items) != 2 {
+		t.Errorf("expected 2 grabbed events, got total=%d items=%d", got.Total, len(got.Items))
+	}
+}
+
+// seedHistoryEvents seeds n grabbed events. The sequential Create calls
+// give them strictly increasing IDs; the ORDER BY created_at DESC, id DESC
+// in HistoryRepo.ListPage yields the reverse-insertion order on read.
+func seedHistoryEvents(t *testing.T, history *db.HistoryRepo, ctx context.Context, n int) []string {
+	t.Helper()
+	titles := make([]string, 0, n)
+	for i := 1; i <= n; i++ {
+		title := fmt.Sprintf("Event %03d", i)
+		if err := history.Create(ctx, &models.HistoryEvent{
+			EventType: models.HistoryEventGrabbed, SourceTitle: title,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		titles = append(titles, title)
+	}
+	return titles
+}
+
+// TestHistoryList_Paginates seeds 10 events and pages through them.
+func TestHistoryList_Paginates(t *testing.T) {
+	h, history, _, ctx := historyFixture(t)
+	titles := seedHistoryEvents(t, history, ctx, 10)
+	// titles is insertion order (oldest first). The list endpoint returns
+	// newest first, so the expected page 0 is titles[9..7].
+	wantFirst := []string{titles[9], titles[8], titles[7]}
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/history?limit=3&offset=0", nil))
+	var first historyListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &first); err != nil {
+		t.Fatalf("decode first: %v", err)
+	}
+	if first.Total != 10 || first.Limit != 3 || first.Offset != 0 || len(first.Items) != 3 {
+		t.Errorf("first page = %+v, want total=10 limit=3 offset=0 len=3", first)
+	}
+	for i, e := range first.Items {
+		if e.SourceTitle != wantFirst[i] {
+			t.Errorf("first page item %d = %q, want %q", i, e.SourceTitle, wantFirst[i])
+		}
+	}
+
+	rec = httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/history?limit=3&offset=9", nil))
+	var tail historyListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &tail); err != nil {
+		t.Fatalf("decode tail: %v", err)
+	}
+	if tail.Total != 10 || len(tail.Items) != 1 || tail.Items[0].SourceTitle != titles[0] {
+		t.Errorf("tail page = %+v, want one item %q (oldest)", tail, titles[0])
+	}
+}
+
+// TestHistoryList_DefaultsAndCaps confirms default + max limit behaviour.
+func TestHistoryList_DefaultsAndCaps(t *testing.T) {
+	h, history, _, ctx := historyFixture(t)
+	seedHistoryEvents(t, history, ctx, 3)
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/history", nil))
+	var defaults historyListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &defaults); err != nil {
+		t.Fatalf("decode defaults: %v", err)
+	}
+	if defaults.Limit != historyListDefaultLimit {
+		t.Errorf("expected default limit %d, got %d", historyListDefaultLimit, defaults.Limit)
+	}
+
+	rec = httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/history?limit=10000", nil))
+	var clamped historyListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &clamped); err != nil {
+		t.Fatalf("decode clamped: %v", err)
+	}
+	if clamped.Limit != historyListMaxLimit {
+		t.Errorf("expected clamped limit %d, got %d", historyListMaxLimit, clamped.Limit)
+	}
+}
+
+// TestHistoryList_OrderStable — repeated identical requests must return the
+// same rows in the same order. Backed by the (created_at DESC, id DESC) tie
+// breaker in HistoryRepo.ListPage so rows sharing a timestamp don't shuffle.
+func TestHistoryList_OrderStable(t *testing.T) {
+	h, history, _, ctx := historyFixture(t)
+	seedHistoryEvents(t, history, ctx, 5)
+	collect := func() []string {
+		rec := httptest.NewRecorder()
+		h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/history?limit=5", nil))
+		var page historyListResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		titles := make([]string, len(page.Items))
+		for i, e := range page.Items {
+			titles[i] = e.SourceTitle
+		}
+		return titles
+	}
+	first := collect()
+	second := collect()
+	if len(first) != 5 || len(second) != 5 {
+		t.Fatalf("expected 5+5 items, got %d/%d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Errorf("order changed at %d: %q vs %q", i, first[i], second[i])
+		}
 	}
 }
 
@@ -252,12 +371,14 @@ func TestHistoryList_FiltersToCallerWhenGateOn(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status=%d", rec.Code)
 	}
-	var got []models.HistoryEvent
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+	// Wave 2 / E introduced a Page envelope { items, total, limit, offset };
+	// unwrap items here.
+	var resp historyListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 1 || got[0].ID != eB {
-		t.Errorf("bob should see only his event; got %+v", got)
+	if len(resp.Items) != 1 || resp.Items[0].ID != eB {
+		t.Errorf("bob should see only his event; got %+v", resp.Items)
 	}
 }
 

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -73,6 +73,70 @@ func (r *AuthorRepo) ListByUser(ctx context.Context, userID int64) ([]models.Aut
 	return authors, rows.Err()
 }
 
+// ListPage returns one page of the authors visible to userID, ordered by
+// sort_name, alongside the total row count that matches the same filter.
+// limit must be positive; offset is clamped at 0. When userID is 0 the query
+// is unscoped (matches List); otherwise it matches ListByUser's predicate
+// (owner_user_id = userID OR owner_user_id IS NULL).
+//
+// The sort_name order is backed by idx_authors_sort_name (migration 047).
+func (r *AuthorRepo) ListPage(ctx context.Context, userID int64, limit, offset int) ([]models.Author, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	countQuery := "SELECT COUNT(*) FROM authors"
+	listQuery := "SELECT " + authorSelectCols + " FROM authors"
+	var (
+		args     []any
+		pageArgs []any
+	)
+	if userID != 0 {
+		// Match ListByUser: include NULL-owner rows so pre-multiuser-migration
+		// authors stay visible to every user instead of silently disappearing.
+		countQuery += " WHERE owner_user_id = ? OR owner_user_id IS NULL"
+		listQuery += " WHERE owner_user_id = ? OR owner_user_id IS NULL"
+		args = []any{userID}
+		pageArgs = []any{userID, limit, offset}
+	} else {
+		pageArgs = []any{limit, offset}
+	}
+	listQuery += " ORDER BY sort_name LIMIT ? OFFSET ?"
+
+	var total int
+	var countRow *sql.Row
+	if len(args) > 0 {
+		countRow = r.db.QueryRowContext(ctx, countQuery, args...)
+	} else {
+		countRow = r.db.QueryRowContext(ctx, countQuery)
+	}
+	if err := countRow.Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count authors: %w", err)
+	}
+
+	rows, err := r.db.QueryContext(ctx, listQuery, pageArgs...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list authors page: %w", err)
+	}
+	defer rows.Close()
+
+	var authors []models.Author
+	for rows.Next() {
+		a, err := scanAuthor(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		authors = append(authors, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	return authors, total, nil
+}
+
 func (r *AuthorRepo) GetByID(ctx context.Context, id int64) (*models.Author, error) {
 	row := r.exec.QueryRowContext(ctx, `
 		SELECT `+authorSelectCols+`

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -88,6 +88,50 @@ func (r *BookRepo) ListByUser(ctx context.Context, userID int64) ([]models.Book,
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where+" ORDER BY sort_title", args)
 }
 
+// ListPage returns one page of the visible-books list, ordered by sort_title,
+// alongside the total row count that matches the same filter. limit must be
+// positive; offset is clamped at 0. When userID is 0 the query is unscoped
+// (matches List); otherwise it matches ListByUser's scope predicate.
+//
+// The sort_title order is backed by idx_books_sort_title (migration 047) so
+// large libraries no longer pay a full in-memory sort per page request.
+func (r *BookRepo) ListPage(ctx context.Context, userID int64, limit, offset int) ([]models.Book, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	where, args := QueryScopeFor("books.owner_user_id", "WHERE excluded = 0", userID)
+	total, err := r.count(ctx, "SELECT COUNT(*) FROM books "+where, args)
+	if err != nil {
+		return nil, 0, err
+	}
+	q := bookCTE + " SELECT " + bookColumns + " FROM books " + bookJoins + " " + where +
+		" ORDER BY sort_title LIMIT ? OFFSET ?"
+	pageArgs := append([]any{}, args...)
+	pageArgs = append(pageArgs, limit, offset)
+	books, err := r.query(ctx, q, pageArgs)
+	if err != nil {
+		return nil, 0, err
+	}
+	return books, total, nil
+}
+
+func (r *BookRepo) count(ctx context.Context, query string, args []any) (int, error) {
+	var total int
+	var row *sql.Row
+	if args != nil {
+		row = r.exec.QueryRowContext(ctx, query, args...)
+	} else {
+		row = r.exec.QueryRowContext(ctx, query)
+	}
+	if err := row.Scan(&total); err != nil {
+		return 0, fmt.Errorf("count books: %w", err)
+	}
+	return total, nil
+}
+
 // ListIncludingExcluded returns all books regardless of their excluded flag.
 func (r *BookRepo) ListIncludingExcluded(ctx context.Context) ([]models.Book, error) {
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" ORDER BY sort_title", nil)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -188,6 +188,45 @@ func TestMigrate033ABSReviewResolutionIdempotent(t *testing.T) {
 	}
 }
 
+// TestMigrate047ListEndpointIndexes confirms the Wave 2 / E migration lands
+// every index the paginated List endpoints depend on. A missing index here
+// silently regresses the sort cost on the 50k-book hot path to a full table
+// scan (the failure mode is "everything works, just slow"), so the only
+// reliable guard is asserting on sqlite_master.
+func TestMigrate047ListEndpointIndexes(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	defer database.Close()
+
+	want := []string{
+		"idx_books_sort_title",
+		"idx_books_release_date",
+		"idx_books_status_sort_title",
+		"idx_authors_sort_name",
+		"idx_series_books_book",
+		"idx_history_created_at_desc",
+	}
+	for _, name := range want {
+		var got string
+		err := database.QueryRow(
+			`SELECT name FROM sqlite_master WHERE type='index' AND name=?`,
+			name,
+		).Scan(&got)
+		if err != nil {
+			t.Errorf("index %s missing after migration 047: %v", name, err)
+		}
+	}
+
+	// Re-running migrate must not fail. CREATE INDEX IF NOT EXISTS keeps the
+	// migration idempotent even if its schema_migrations marker is dropped
+	// (e.g. a re-applied row from a backup restore).
+	if err := migrate(database); err != nil {
+		t.Fatalf("rerun migrations should be idempotent: %v", err)
+	}
+}
+
 // TestMigrate042AuthorAudiobookRootFolder verifies migration 042 adds the
 // audiobook_root_folder_id column to the authors table (#579) and that the
 // column round-trips a value through CreateForUser / GetByID.

--- a/internal/db/history.go
+++ b/internal/db/history.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -51,6 +52,79 @@ func (r *HistoryRepo) ListByBook(ctx context.Context, bookID int64) ([]models.Hi
 
 func (r *HistoryRepo) ListByType(ctx context.Context, eventType string) ([]models.HistoryEvent, error) {
 	return r.query(ctx, "SELECT "+historyColumns+" FROM history WHERE event_type=? ORDER BY created_at DESC", eventType)
+}
+
+// HistoryListOpts is the filter+page argument for ListPage. Empty fields are
+// treated as "no filter": a zero BookID, empty EventType, and zero UserID
+// return every row that survives the other filters. Limit must be positive;
+// Offset is clamped at 0 by ListPage. UserID > 0 restricts to events whose
+// book is owned by that user (NULL book_id events pass through since they
+// predate a book link and have no owner to scope to), matching ListForUser
+// semantics.
+type HistoryListOpts struct {
+	BookID    int64
+	EventType string
+	UserID    int64
+	Limit     int
+	Offset    int
+}
+
+// ListPage returns one page of history events (newest first) plus the total
+// row count that matches the filter. Backed by idx_history_created_at_desc
+// (migration 048) so the newest-first scan does not pay an OrderBy step on
+// top of a forward-only index walk.
+func (r *HistoryRepo) ListPage(ctx context.Context, opts HistoryListOpts) ([]models.HistoryEvent, int, error) {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	offset := opts.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	clauses := []string{}
+	args := []any{}
+	switch {
+	case opts.BookID != 0:
+		clauses = append(clauses, "book_id = ?")
+		args = append(args, opts.BookID)
+	case opts.EventType != "":
+		clauses = append(clauses, "event_type = ?")
+		args = append(args, opts.EventType)
+	}
+	if opts.UserID > 0 {
+		// Same JOIN-scoped shape as ListForUser: include NULL-book_id rows
+		// regardless (orphan grab/failure records pre-link) and otherwise
+		// restrict by books.owner_user_id.
+		clauses = append(clauses, "(book_id IS NULL OR book_id IN (SELECT id FROM books WHERE owner_user_id = ?))")
+		args = append(args, opts.UserID)
+	}
+	where := ""
+	if len(clauses) > 0 {
+		where = " WHERE " + strings.Join(clauses, " AND ")
+	}
+
+	var total int
+	var countRow *sql.Row
+	if len(args) > 0 {
+		countRow = r.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM history"+where, args...)
+	} else {
+		countRow = r.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM history"+where)
+	}
+	if err := countRow.Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count history events: %w", err)
+	}
+
+	pageArgs := append([]any{}, args...)
+	pageArgs = append(pageArgs, limit, offset)
+	events, err := r.query(ctx,
+		"SELECT "+historyColumns+" FROM history"+where+" ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?",
+		pageArgs...)
+	if err != nil {
+		return nil, 0, err
+	}
+	return events, total, nil
 }
 
 func (r *HistoryRepo) GetByID(ctx context.Context, id int64) (*models.HistoryEvent, error) {

--- a/internal/db/migrations/048_list_endpoint_indexes.sql
+++ b/internal/db/migrations/048_list_endpoint_indexes.sql
@@ -1,0 +1,51 @@
+-- +migrate Up
+-- Wave 2 / Bundle E indexes for the columns that the paginated List
+-- endpoints sort by. Without these the books/authors/history list queries
+-- do a full in-memory sort on every page request, which dominates wall
+-- time on 50k-book Calibre imports.
+--
+-- IF NOT EXISTS on every CREATE so reruns are safe even after an operator
+-- has hand-added one of these on a hot database.
+--
+-- Naming note. An ASCending idx_history_created_at already exists from
+-- migration 001. SQLite cannot use an ASC index for a DESC scan walk in
+-- reverse without an extra OrderBy step, so we add a dedicated DESC-keyed
+-- index (suffix `_desc`) to power the newest-first list query in
+-- HistoryRepo.
+
+-- Books. List sorts by sort_title. Status-filtered list also sorts by
+-- sort_title. ListByAuthor and ListByAuthorAndUser sort by release_date.
+-- release_date is nullable. SQLite default sort order treats NULL as the
+-- smallest value, so an ASC sort puts NULL rows first and a DESC sort
+-- puts them last. The list endpoint is ASC by release_date today.
+-- Callers that need a strict NULLS LAST contract should add
+-- `ORDER BY release_date IS NULL, release_date` in the query (this index
+-- still supports the rewritten form).
+CREATE INDEX IF NOT EXISTS idx_books_sort_title         ON books(sort_title);
+CREATE INDEX IF NOT EXISTS idx_books_release_date       ON books(release_date);
+CREATE INDEX IF NOT EXISTS idx_books_status_sort_title  ON books(status, sort_title);
+
+-- Authors. List sorts by sort_name.
+CREATE INDEX IF NOT EXISTS idx_authors_sort_name        ON authors(sort_name);
+
+-- series_books has a composite PK (series_id, book_id) which only indexes
+-- forward lookups by series_id. Reverse lookups `WHERE book_id = ?` (used
+-- by series.GetSeriesIDsForBook and ListBookSeriesByAuthor) currently
+-- scan the whole join table. A standalone book_id index turns those into
+-- a single index seek.
+CREATE INDEX IF NOT EXISTS idx_series_books_book        ON series_books(book_id);
+
+-- History pagination index. The list query is ORDER BY created_at DESC.
+-- The existing idx_history_created_at (migration 001) is ASC-only and
+-- SQLite still has to walk it backwards plus pay an extra OrderBy when
+-- the result is paginated. A DESC-keyed index removes that overhead.
+CREATE INDEX IF NOT EXISTS idx_history_created_at_desc  ON history(created_at DESC);
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS idx_history_created_at_desc;
+DROP INDEX IF EXISTS idx_series_books_book;
+DROP INDEX IF EXISTS idx_authors_sort_name;
+DROP INDEX IF EXISTS idx_books_status_sort_title;
+DROP INDEX IF EXISTS idx_books_release_date;
+DROP INDEX IF EXISTS idx_books_sort_title;

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -87,19 +87,24 @@ func TestSmoke(t *testing.T) {
 
 	t.Run("authors list empty on fresh install", func(t *testing.T) {
 		body := getJSON(t, base+"/api/v1/author")
-		var arr []map[string]any
-		if err := json.Unmarshal(body, &arr); err != nil {
+		// List endpoints return a Page envelope after Wave 2 / E.
+		var page struct {
+			Items []map[string]any `json:"items"`
+		}
+		if err := json.Unmarshal(body, &page); err != nil {
 			t.Fatalf("decode: %v (body=%s)", err, body)
 		}
-		if len(arr) != 0 {
-			t.Errorf("expected empty authors, got %d", len(arr))
+		if len(page.Items) != 0 {
+			t.Errorf("expected empty authors, got %d", len(page.Items))
 		}
 	})
 
 	t.Run("books list returns an array", func(t *testing.T) {
 		body := getJSON(t, base+"/api/v1/book")
-		var arr []map[string]any
-		if err := json.Unmarshal(body, &arr); err != nil {
+		var page struct {
+			Items []map[string]any `json:"items"`
+		}
+		if err := json.Unmarshal(body, &page); err != nil {
 			t.Fatalf("decode: %v (body=%s)", err, body)
 		}
 	})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -253,7 +253,13 @@ export const api = {
     request<Book>('/author/book', { method: 'POST', body: JSON.stringify(data) }),
 
   // Authors
-  listAuthors: () => request<Author[]>('/author'),
+  listAuthors: (params?: { limit?: number; offset?: number }) => {
+    const q = new URLSearchParams()
+    if (params?.limit !== undefined) q.set('limit', String(params.limit))
+    if (params?.offset !== undefined) q.set('offset', String(params.offset))
+    const qs = q.toString()
+    return request<Page<Author>>(`/author${qs ? '?' + qs : ''}`)
+  },
   getAuthor: (id: number) => request<Author>(`/author/${id}`),
   addAuthor: (data: AddAuthorRequest) => request<Author>('/author', { method: 'POST', body: JSON.stringify(data) }),
   updateAuthor: (id: number, data: UpdateAuthorRequest) => request<Author>(`/author/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
@@ -272,13 +278,15 @@ export const api = {
     }),
 
   // Books
-  listBooks: (params?: { authorId?: number; status?: string; includeExcluded?: boolean }) => {
+  listBooks: (params?: { authorId?: number; status?: string; includeExcluded?: boolean; limit?: number; offset?: number }) => {
     const q = new URLSearchParams()
     if (params?.authorId) q.set('authorId', String(params.authorId))
     if (params?.status) q.set('status', params.status)
     if (params?.includeExcluded) q.set('includeExcluded', 'true')
+    if (params?.limit !== undefined) q.set('limit', String(params.limit))
+    if (params?.offset !== undefined) q.set('offset', String(params.offset))
     const qs = q.toString()
-    return request<Book[]>(`/book${qs ? '?' + qs : ''}`)
+    return request<Page<Book>>(`/book${qs ? '?' + qs : ''}`)
   },
   getBook: (id: number) => request<Book>(`/book/${id}`),
   updateBook: (id: number, data: Partial<Book>) => request<Book>(`/book/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
@@ -362,12 +370,14 @@ export const api = {
   grabPending: (id: number) => request<Download>(`/pending/${id}/grab`, { method: 'POST' }),
 
   // History
-  listHistory: (params?: { bookId?: number; eventType?: string }) => {
+  listHistory: (params?: { bookId?: number; eventType?: string; limit?: number; offset?: number }) => {
     const q = new URLSearchParams()
     if (params?.bookId) q.set('bookId', String(params.bookId))
     if (params?.eventType) q.set('eventType', params.eventType)
+    if (params?.limit !== undefined) q.set('limit', String(params.limit))
+    if (params?.offset !== undefined) q.set('offset', String(params.offset))
     const qs = q.toString()
-    return request<HistoryEvent[]>(`/history${qs ? '?' + qs : ''}`)
+    return request<Page<HistoryEvent>>(`/history${qs ? '?' + qs : ''}`)
   },
   deleteHistory: (id: number) => request<void>(`/history/${id}`, { method: 'DELETE' }),
   blocklistFromHistory: (id: number) => request<BlocklistEntry>(`/history/${id}/blocklist`, { method: 'POST' }),
@@ -952,6 +962,17 @@ export interface ABSReviewItem {
 }
 
 export interface PaginatedResponse<T> {
+  items: T[]
+  total: number
+  limit: number
+  offset: number
+}
+
+// Page<T> is the envelope returned by the paginated List endpoints introduced
+// in PR #902 (GET /book, /author, /history). Shape matches PaginatedResponse
+// above and the two will likely be unified later; kept distinct for now so
+// the diff stays scoped to the three new endpoints.
+export interface Page<T> {
   items: T[]
   total: number
   limit: number

--- a/web/src/components/AddSeriesBookModal.tsx
+++ b/web/src/components/AddSeriesBookModal.tsx
@@ -23,8 +23,8 @@ export default function AddSeriesBookModal({ series, onClose, onLinked }: Props)
     Promise.all([api.listBooks(), api.listAuthors()])
       .then(([bookList, authorList]) => {
         if (!active) return
-        setBooks(bookList)
-        setAuthors(authorList)
+        setBooks(bookList.items)
+        setAuthors(authorList.items)
       })
       .catch(err => {
         if (active) setError(err instanceof Error ? err.message : 'Failed to load books')

--- a/web/src/components/MergeAuthorsModal.tsx
+++ b/web/src/components/MergeAuthorsModal.tsx
@@ -32,7 +32,7 @@ export default function MergeAuthorsModal({ authors, initialTargetId, onClose, o
     if (!sourceId) { setSourceBookCount(null); return }
     let cancelled = false
     api.listBooks({ authorId: Number(sourceId) })
-      .then(bs => { if (!cancelled) setSourceBookCount(bs.length) })
+      .then(page => { if (!cancelled) setSourceBookCount(page.total) })
       .catch(() => { if (!cancelled) setSourceBookCount(null) })
     return () => { cancelled = true }
   }, [sourceId])

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -82,7 +82,7 @@ function installLocalStorageMock() {
 function renderAuthorDetailPage(books: Book[], view: 'grid' | 'table' = 'grid') {
   localStorage.setItem('bindery.view.author-detail', view)
   vi.mocked(api.getAuthor).mockResolvedValue(author)
-  vi.mocked(api.listBooks).mockResolvedValue(books)
+  vi.mocked(api.listBooks).mockResolvedValue({ items: books, total: books.length, limit: 100, offset: 0 })
 
   return render(
     <MemoryRouter initialEntries={['/author/42']}>

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -137,7 +137,7 @@ export default function AuthorDetailPage() {
       api.getAuthor(authorId),
       api.listBooks({ authorId, includeExcluded: showExcluded }),
     ])
-      .then(([a, bs]) => { if (!cancelled) { setAuthor(a); setBooks(bs) } })
+      .then(([a, bs]) => { if (!cancelled) { setAuthor(a); setBooks(bs.items) } })
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load'))
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
@@ -150,7 +150,7 @@ export default function AuthorDetailPage() {
       await api.refreshAuthor(author.id)
       const [a, bs] = await Promise.all([api.getAuthor(authorId), api.listBooks({ authorId, includeExcluded: showExcluded })])
       setAuthor(a)
-      setBooks(bs)
+      setBooks(bs.items)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Refresh failed')
     } finally {
@@ -218,8 +218,8 @@ export default function AuthorDetailPage() {
   // unless showExcluded is on; delete removes them outright).
   const reloadBooks = async () => {
     try {
-      const bs = await api.listBooks({ authorId, includeExcluded: showExcluded })
-      setBooks(bs)
+      const { items } = await api.listBooks({ authorId, includeExcluded: showExcluded })
+      setBooks(items)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Reload failed')
     }
@@ -389,7 +389,7 @@ export default function AuthorDetailPage() {
             </button>
             <button
               onClick={() => {
-                if (allAuthors.length === 0) api.listAuthors().then(setAllAuthors).catch(console.error)
+                if (allAuthors.length === 0) api.listAuthors().then(({ items }) => setAllAuthors(items)).catch(console.error)
                 setShowMerge(true)
               }}
               className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium"
@@ -439,7 +439,7 @@ export default function AuthorDetailPage() {
           onMerged={() => {
             // Reload current author (aliases may have grown) + its books.
             Promise.all([api.getAuthor(authorId), api.listBooks({ authorId })])
-              .then(([a, bs]) => { setAuthor(a); setBooks(bs) })
+              .then(([a, bs]) => { setAuthor(a); setBooks(bs.items) })
               .catch(console.error)
           }}
         />

--- a/web/src/pages/AuthorsPage.test.tsx
+++ b/web/src/pages/AuthorsPage.test.tsx
@@ -65,7 +65,7 @@ vi.mock('../components/Pagination', () => ({ default: () => null }))
 describe('AuthorsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(api.listAuthors).mockResolvedValue([])
+    vi.mocked(api.listAuthors).mockResolvedValue({ items: [], total: 0, limit: 100, offset: 0 })
   })
 
   it('creates a series from the authors toolbar and opens it on the series page', async () => {

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -40,7 +40,7 @@ export default function AuthorsPage() {
 
   const load = () => {
     setLoading(true)
-    api.listAuthors().then(setAuthors).catch(console.error).finally(() => setLoading(false))
+    api.listAuthors().then(({ items }) => setAuthors(items)).catch(console.error).finally(() => setLoading(false))
   }
 
   useEffect(() => { load() }, [])
@@ -53,7 +53,7 @@ export default function AuthorsPage() {
     let withFiles = 0
     let total = 0
     try {
-      const books = await api.listBooks({ authorId: id })
+      const { items: books } = await api.listBooks({ authorId: id })
       total = books.length
       withFiles = books.filter(b => b.filePath).length
     } catch { /* fall through to no-file-sweep default */ }

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -170,7 +170,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   document.title = 'Bindery'
   vi.mocked(api.getBook).mockResolvedValue(makeBook())
-  vi.mocked(api.listHistory).mockResolvedValue([])
+  vi.mocked(api.listHistory).mockResolvedValue({ items: [], total: 0, limit: 100, offset: 0 })
   vi.mocked(api.searchBook).mockResolvedValue({ results: [], debug: null })
   vi.mocked(api.listIndexers).mockResolvedValue([])
   vi.mocked(api.grab).mockResolvedValue(makeDownload())
@@ -275,7 +275,7 @@ describe('SearchResultsSection — single-format book', () => {
 
 describe('BookDetailPage — header & metadata', () => {
   it('loads book details and history', async () => {
-    vi.mocked(api.listHistory).mockResolvedValue([makeHistory()])
+    vi.mocked(api.listHistory).mockResolvedValue({ items: [makeHistory()], total: 1, limit: 100, offset: 0 })
 
     renderBookDetailPage()
 
@@ -382,8 +382,8 @@ describe('BookDetailPage — search', () => {
       .mockResolvedValueOnce(makeBook())
       .mockResolvedValueOnce(makeBook({ status: 'downloading' }))
     vi.mocked(api.listHistory)
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([makeHistory({ sourceTitle: 'Grab refreshed history' })])
+      .mockResolvedValueOnce({ items: [], total: 0, limit: 100, offset: 0 })
+      .mockResolvedValueOnce({ items: [makeHistory({ sourceTitle: 'Grab refreshed history' })], total: 1, limit: 100, offset: 0 })
     vi.mocked(api.listIndexers).mockResolvedValue([makeIndexer()])
     vi.mocked(api.searchBook).mockResolvedValue({
       results: [
@@ -504,9 +504,12 @@ describe('BookDetailPage — dual-format book', () => {
 
 describe('BookDetailPage — history section', () => {
   it('renders the humanised event label', async () => {
-    vi.mocked(api.listHistory).mockResolvedValue([
-      makeHistory({ eventType: 'bookImported', sourceTitle: 'A.Desolation.Called.Peace' }),
-    ])
+    vi.mocked(api.listHistory).mockResolvedValue({
+      items: [makeHistory({ eventType: 'bookImported', sourceTitle: 'A.Desolation.Called.Peace' })],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    })
     renderBookDetailPage()
     expect(await screen.findByText('Book imported')).toBeInTheDocument()
     expect(screen.getByText('A.Desolation.Called.Peace')).toBeInTheDocument()

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -186,7 +186,7 @@ export default function BookDetailPage() {
     setLoading(true)
     Promise.all([
       api.getBook(bookId).then(b => { if (!cancelled) { setBook(b); setAsinDraft(b.asin || '') } }),
-      api.listHistory({ bookId }).then(setEvents).catch(() => {}),
+      api.listHistory({ bookId }).then(({ items }) => setEvents(items)).catch(() => {}),
     ])
       .catch(err => setError(err instanceof Error ? err.message : t('bookDetail.loadFailed')))
       .finally(() => { if (!cancelled) setLoading(false) })
@@ -249,7 +249,7 @@ export default function BookDetailPage() {
         api.listHistory({ bookId: book.id }),
       ])
       setBook(b)
-      setEvents(h)
+      setEvents(h.items)
       setResults(null)
     } catch (e) {
       setError(e instanceof Error ? e.message : t('bookDetail.grabFailed'))
@@ -288,7 +288,7 @@ export default function BookDetailPage() {
       const params = format ? `?format=${format}` : ''
       const updated = await api.deleteBookFile(book.id, params)
       setBook(updated)
-      const h = await api.listHistory({ bookId: book.id }).catch(() => events)
+      const h = await api.listHistory({ bookId: book.id }).then(p => p.items).catch(() => events)
       setEvents(h)
     } catch (e) {
       setError(e instanceof Error ? e.message : t('bookDetail.deleteFailed'))

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -41,7 +41,7 @@ export default function BooksPage() {
   const selectAllRef = useRef<HTMLInputElement>(null)
 
   const load = () => {
-    api.listBooks().then(setBooks).catch(console.error).finally(() => setLoading(false))
+    api.listBooks().then(({ items }) => setBooks(items)).catch(console.error).finally(() => setLoading(false))
   }
 
   useEffect(() => {

--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -27,7 +27,7 @@ export default function CalendarPage() {
   const [viewMonth, setViewMonth] = useState(today.getMonth())
 
   useEffect(() => {
-    api.listBooks().then(setBooks).catch(console.error).finally(() => setLoading(false))
+    api.listBooks().then(({ items }) => setBooks(items)).catch(console.error).finally(() => setLoading(false))
   }, [])
 
   useEffect(() => {

--- a/web/src/pages/HistoryPage.test.tsx
+++ b/web/src/pages/HistoryPage.test.tsx
@@ -104,33 +104,38 @@ function rowFor(text: string) {
 beforeEach(() => {
   vi.clearAllMocks()
   document.title = 'Bindery'
-  vi.mocked(api.listHistory).mockResolvedValue([])
+  vi.mocked(api.listHistory).mockResolvedValue({ items: [], total: 0, limit: 100, offset: 0 })
   vi.mocked(api.deleteHistory).mockResolvedValue(undefined)
   vi.mocked(api.blocklistFromHistory).mockResolvedValue(makeBlocklistEntry())
 })
 
 describe('HistoryPage', () => {
   it('renders history rows with parsed details, media type, and size', async () => {
-    vi.mocked(api.listHistory).mockResolvedValue([
-      makeHistory({
-        id: 1,
-        eventType: 'grabbed',
-        sourceTitle: 'Dune EPUB',
-        data: JSON.stringify({ path: '/library/Dune.epub', size: 1048576 }),
-      }),
-      makeHistory({
-        id: 2,
-        eventType: 'downloadFailed',
-        sourceTitle: 'Dune MP3',
-        data: JSON.stringify({ message: 'Download client rejected release', size: 2147483648 }),
-      }),
-      makeHistory({
-        id: 3,
-        eventType: 'bookImported',
-        sourceTitle: '',
-        data: JSON.stringify({ size: 0 }),
-      }),
-    ])
+    vi.mocked(api.listHistory).mockResolvedValue({
+      items: [
+        makeHistory({
+          id: 1,
+          eventType: 'grabbed',
+          sourceTitle: 'Dune EPUB',
+          data: JSON.stringify({ path: '/library/Dune.epub', size: 1048576 }),
+        }),
+        makeHistory({
+          id: 2,
+          eventType: 'downloadFailed',
+          sourceTitle: 'Dune MP3',
+          data: JSON.stringify({ message: 'Download client rejected release', size: 2147483648 }),
+        }),
+        makeHistory({
+          id: 3,
+          eventType: 'bookImported',
+          sourceTitle: '',
+          data: JSON.stringify({ size: 0 }),
+        }),
+      ],
+      total: 3,
+      limit: 100,
+      offset: 0,
+    })
 
     renderHistoryPage()
 
@@ -155,13 +160,23 @@ describe('HistoryPage', () => {
 
   it('filters history by event type', async () => {
     vi.mocked(api.listHistory)
-      .mockResolvedValueOnce([
-        makeHistory({ id: 1, eventType: 'grabbed', sourceTitle: 'Grabbed Release' }),
-        makeHistory({ id: 2, eventType: 'downloadFailed', sourceTitle: 'Failed Release' }),
-      ])
-      .mockResolvedValueOnce([
-        makeHistory({ id: 2, eventType: 'downloadFailed', sourceTitle: 'Failed Release' }),
-      ])
+      .mockResolvedValueOnce({
+        items: [
+          makeHistory({ id: 1, eventType: 'grabbed', sourceTitle: 'Grabbed Release' }),
+          makeHistory({ id: 2, eventType: 'downloadFailed', sourceTitle: 'Failed Release' }),
+        ],
+        total: 2,
+        limit: 100,
+        offset: 0,
+      })
+      .mockResolvedValueOnce({
+        items: [
+          makeHistory({ id: 2, eventType: 'downloadFailed', sourceTitle: 'Failed Release' }),
+        ],
+        total: 1,
+        limit: 100,
+        offset: 0,
+      })
 
     renderHistoryPage()
 
@@ -176,10 +191,15 @@ describe('HistoryPage', () => {
   })
 
   it('blocklists blocklistable events and removes them from local history', async () => {
-    vi.mocked(api.listHistory).mockResolvedValue([
-      makeHistory({ id: 7, eventType: 'importFailed', sourceTitle: 'Blocklist Me' }),
-      makeHistory({ id: 8, eventType: 'bookImported', sourceTitle: 'Keep Me' }),
-    ])
+    vi.mocked(api.listHistory).mockResolvedValue({
+      items: [
+        makeHistory({ id: 7, eventType: 'importFailed', sourceTitle: 'Blocklist Me' }),
+        makeHistory({ id: 8, eventType: 'bookImported', sourceTitle: 'Keep Me' }),
+      ],
+      total: 2,
+      limit: 100,
+      offset: 0,
+    })
 
     renderHistoryPage()
 
@@ -192,10 +212,15 @@ describe('HistoryPage', () => {
   })
 
   it('deletes history events and removes them from local history', async () => {
-    vi.mocked(api.listHistory).mockResolvedValue([
-      makeHistory({ id: 11, eventType: 'grabbed', sourceTitle: 'Delete Me' }),
-      makeHistory({ id: 12, eventType: 'bookImported', sourceTitle: 'Keep Me' }),
-    ])
+    vi.mocked(api.listHistory).mockResolvedValue({
+      items: [
+        makeHistory({ id: 11, eventType: 'grabbed', sourceTitle: 'Delete Me' }),
+        makeHistory({ id: 12, eventType: 'bookImported', sourceTitle: 'Keep Me' }),
+      ],
+      total: 2,
+      limit: 100,
+      offset: 0,
+    })
 
     renderHistoryPage()
 
@@ -208,10 +233,15 @@ describe('HistoryPage', () => {
   })
 
   it('renders only delete actions for non-blocklistable events', async () => {
-    vi.mocked(api.listHistory).mockResolvedValue([
-      makeHistory({ id: 21, eventType: 'bookImported', sourceTitle: 'Imported Release' }),
-      makeHistory({ id: 22, eventType: 'deleted', sourceTitle: 'Deleted Release' }),
-    ])
+    vi.mocked(api.listHistory).mockResolvedValue({
+      items: [
+        makeHistory({ id: 21, eventType: 'bookImported', sourceTitle: 'Imported Release' }),
+        makeHistory({ id: 22, eventType: 'deleted', sourceTitle: 'Deleted Release' }),
+      ],
+      total: 2,
+      limit: 100,
+      offset: 0,
+    })
 
     renderHistoryPage()
 

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -56,7 +56,7 @@ export default function HistoryPage() {
 
   const load = useCallback((filter?: string) => {
     api.listHistory(filter ? { eventType: filter } : undefined)
-      .then(setEvents)
+      .then(({ items }) => setEvents(items))
       .catch(console.error)
       .finally(() => setLoading(false))
   }, [])

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -46,8 +46,8 @@ describe('SeriesPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(api.status).mockResolvedValue({ version: 'dev', commit: 'unknown', buildDate: '', enhancedHardcoverApi: true, hardcoverTokenConfigured: true })
-    vi.mocked(api.listBooks).mockResolvedValue([])
-    vi.mocked(api.listAuthors).mockResolvedValue([])
+    vi.mocked(api.listBooks).mockResolvedValue({ items: [], total: 0, limit: 100, offset: 0 })
+    vi.mocked(api.listAuthors).mockResolvedValue({ items: [], total: 0, limit: 100, offset: 0 })
     vi.mocked(api.getSeriesHardcoverLink).mockRejectedValue(new Error('not linked'))
     vi.mocked(api.searchHardcoverSeries).mockResolvedValue([])
   })
@@ -487,21 +487,31 @@ describe('SeriesPage', () => {
       ...series,
       books: [...(series.books ?? []), { seriesId: 30, bookId: 102, positionInSeries: '2', primarySeries: true, book: candidate }],
     }
-    vi.mocked(api.listBooks).mockResolvedValue([series.books![0].book!, candidate])
-    vi.mocked(api.listAuthors).mockResolvedValue([
-      {
-        id: 12,
-        foreignAuthorId: 'author-12',
-        authorName: 'Frank Herbert',
-        sortName: 'Herbert, Frank',
-        description: '',
-        imageUrl: '',
-        disambiguation: '',
-        ratingsCount: 0,
-        averageRating: 0,
-        monitored: true,
-      },
-    ])
+    vi.mocked(api.listBooks).mockResolvedValue({
+      items: [series.books![0].book!, candidate],
+      total: 2,
+      limit: 100,
+      offset: 0,
+    })
+    vi.mocked(api.listAuthors).mockResolvedValue({
+      items: [
+        {
+          id: 12,
+          foreignAuthorId: 'author-12',
+          authorName: 'Frank Herbert',
+          sortName: 'Herbert, Frank',
+          description: '',
+          imageUrl: '',
+          disambiguation: '',
+          ratingsCount: 0,
+          averageRating: 0,
+          monitored: true,
+        },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    })
     vi.mocked(api.linkBookToSeries).mockResolvedValue(updated)
 
     renderSeriesPage([series])


### PR DESCRIPTION
## Summary

Backend pagination for the three list endpoints that today serialize an entire table to one JSON blob, plus migration 047 with the indexes the new SQL pagination relies on. Targets the 50k-book Calibre-import pain point.

- `GET /api/v1/book`, `/api/v1/author`, `/api/v1/history` now return `{items, total, limit, offset}` instead of a bare `[...]`.
- Default `limit=100`, max `limit=500` (hard cap so a client cannot OOM the server asking for `limit=10000000`).
- `?limit` and `?offset` are honoured for every filter combination, including `?authorId`, `?status`, `?bookId`, `?eventType`.
- Migration 047 adds the six indexes the audit flagged.

## Breaking change

The response shape changes from `[{...}, ...]` to:

```json
{
  "items": [...],
  "total": 50000,
  "limit": 100,
  "offset": 0
}
```

This is the same envelope `/api/v1/abs/review` and `/api/v1/abs/conflicts` already use, so it matches the existing internal convention rather than inventing a new one.

### Frontend follow-up

A follow-up PR in `web/src/` needs to unwrap `items` before consuming the rows. Files to update:

- `web/src/api/client.ts`: `listAuthors`, `listBooks`, `listHistory` (lines ~256, ~275-281, ~363). Return type changes from `T[]` to `{items: T[], total: number, ...}`.
- `web/src/pages/BooksPage.tsx`
- `web/src/pages/AuthorsPage.tsx`
- `web/src/pages/HistoryPage.tsx`
- `web/src/pages/BookDetailPage.tsx` (history widget)
- `web/src/pages/AuthorDetailPage.tsx` (history widget)

## Migration

- File: `internal/db/migrations/047_list_endpoint_indexes.sql`
- Indexes added:
  - `idx_books_sort_title` (sort_title)
  - `idx_books_release_date` (release_date, nullable; SQLite NULL-first semantics documented in the migration comment, no `ORDER BY` change in this PR)
  - `idx_books_status_sort_title` (status, sort_title) for the wanted-books-by-title pattern
  - `idx_authors_sort_name` (sort_name)
  - `idx_series_books_book` (book_id) — reverse lookup on the composite-PK join table, fixes the audit finding for `internal/db/migrations/001_initial.sql:58`
  - `idx_history_created_at_desc` (created_at DESC). The existing `idx_history_created_at` from migration 001 is ASC-only and SQLite still pays an OrderBy step on a paginated DESC scan; a dedicated DESC-keyed index removes that.
- Idempotent. Every CREATE is `IF NOT EXISTS`.
- No-op Down section.

## Rebase warning

Wave 1 PRs #898 and #899 touch `internal/db/books.go`, `internal/db/authors.go`, and `internal/db/history.go` in overlapping regions (per-user filtering, `ListForUser` helpers). This branch is cut from current `main` and the new `ListPage` methods preserve the existing `ListByUser`/`List` signatures, so the rebase against the Wave 1 merge should be mechanical, but it is expected. Wave 1 PRs to land first (and for context): #892, #893, #894, #895, #896, #897, #898, #899.

## Pagination shape rationale

Searched `internal/api/` for existing pagination conventions: `abs_review.go` and `abs_conflicts.go` already use the same `{items, total, limit, offset}` envelope (parsed via `parseLimitOffset` in `helpers.go`). This PR reuses that helper and matches the field naming so the frontend client can share a single decoder for all four endpoints.

A second convention exists on `/api/v1/queue?type=arr`: a Sonarr-compatible `{records, totalRecords, page, pageSize, ...}` shape. That one is external-tool-facing (Harpoon) and explicitly kept as-is. The new endpoints follow the internal `items/total/limit/offset` shape.

## Skipped endpoints

- `/api/v1/queue` (main UI shape): the list path is `enrichedQueueItems` which threads through live downloader status enrichment; clean pagination would require pushing LIMIT/OFFSET past the enrichment, which is a more involved refactor than this bundle covers.
- `/api/v1/pending` and `/api/v1/blocklist`: small in practice; not the audit pain.
- Status- and author-filtered book lists: paginated at the handler level (slice on the loaded result) because the underlying lists are bounded; the new ListPage SQL path is reserved for the unfiltered hot scan.

## Test plan

- [x] `go test ./...` passes locally
- [x] `internal/db/db_test.go::TestMigrate047ListEndpointIndexes` asserts on `sqlite_master` for every new index
- [x] Per resource: `TestX_List_Paginates`, `TestX_List_DefaultsAndCaps`, `TestX_List_OrderStable` cover the seeded page + cap + stability invariants
- [x] Updated pre-existing tests (`TestBookList_Empty`, `TestBookList_FiltersByAuthor`, `TestHistoryList_EmptyReturnsArray`, `TestHistoryList_FiltersByEventType`) to assert on the new envelope shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)