### PR TITLE
perf(metadata): cap TTL cache + cache enrichBook results (Wave 3 / J)

### DIFF
--- a/internal/metadata/aggregator_enrichment.go
+++ b/internal/metadata/aggregator_enrichment.go
@@ -215,14 +215,64 @@ func (a *Aggregator) GetAuthorAudiobooks(ctx context.Context, authorName string)
 	return books, nil
 }
 
+// enrichmentSnapshot captures the subset of fields enrichBook may write
+// into a *models.Book. We cache snapshots, not the *models.Book itself,
+// because callers retain the pointer and can mutate the book after we
+// hand it back; aliasing a *models.Book into the cache would let those
+// mutations leak into the next cache hit (e.g. a downstream call could
+// blank out ImageURL on the cached book and poison every subsequent
+// hit). A value type is impossible to alias.
+type enrichmentSnapshot struct {
+	description   string
+	imageURL      string
+	averageRating float64
+	ratingsCount  int
+}
+
+// enrichBookCacheKey is keyed on (MetadataProvider, ForeignID) because that
+// pair uniquely identifies the book across our provider universe and is
+// what callers route by. When ForeignID is empty (e.g. an audnex-sourced
+// canonical lookup), we fall back to (Title, Author.Name) which is the
+// other natural identity used by pickEnrichmentMatch's match logic. An
+// empty fallback key skips caching entirely; better to refetch than to
+// alias unrelated books under "".
+func enrichBookCacheKey(book *models.Book) string {
+	if book == nil {
+		return ""
+	}
+	fid := strings.TrimSpace(book.ForeignID)
+	if fid != "" {
+		provider := strings.TrimSpace(strings.ToLower(book.MetadataProvider))
+		return "enrich:" + provider + ":" + fid
+	}
+	title := strings.TrimSpace(strings.ToLower(book.Title))
+	author := ""
+	if book.Author != nil {
+		author = strings.TrimSpace(strings.ToLower(book.Author.Name))
+	}
+	if title == "" {
+		return ""
+	}
+	return "enrich-title:" + title + "|" + author
+}
+
 func (a *Aggregator) enrichBook(ctx context.Context, book *models.Book) {
+	cacheKey := enrichBookCacheKey(book)
+	if cacheKey != "" {
+		if cached, ok := a.cache.get(cacheKey); ok {
+			snap := cached.(enrichmentSnapshot)
+			applyEnrichmentSnapshot(book, snap)
+			return
+		}
+	}
+
 	for _, enricher := range a.enrichers {
 		enriched, err := enricher.SearchBooks(ctx, book.Title)
 		if err != nil {
 			slog.Debug("enrichment failed", "provider", enricher.Name(), "error", err)
 			continue
 		}
-		// Pick the first result that plausibly matches our book — same
+		// Pick the first result that plausibly matches our book, same
 		// title AND (if we have one) same author. Without the author
 		// guard a German title like "Die Verwandlung" could pull the
 		// wrong author's record off OL; refusing to enrich is safer
@@ -252,6 +302,35 @@ func (a *Aggregator) enrichBook(ctx context.Context, book *models.Book) {
 	// Skipped entirely when ImageURL is already set.
 	if book.ImageURL == "" {
 		a.fillCoverFromCoverProviders(ctx, book)
+	}
+
+	if cacheKey != "" {
+		a.cache.set(cacheKey, enrichmentSnapshot{
+			description:   book.Description,
+			imageURL:      book.ImageURL,
+			averageRating: book.AverageRating,
+			ratingsCount:  book.RatingsCount,
+		})
+	}
+}
+
+// applyEnrichmentSnapshot mirrors the per-field merge rules used by
+// enrichBook's live path: replace Description only when the cached one is
+// longer, only fill empty cover/rating fields. Same semantics, different
+// source, so a cache hit produces the same book state a cache miss would
+// have produced. Crucially, we copy primitive values out of the snapshot;
+// nothing in the cache is reachable through the input book pointer after
+// this call.
+func applyEnrichmentSnapshot(book *models.Book, snap enrichmentSnapshot) {
+	if len(snap.description) > len(book.Description) {
+		book.Description = snap.description
+	}
+	if book.ImageURL == "" && snap.imageURL != "" {
+		book.ImageURL = snap.imageURL
+	}
+	if book.AverageRating == 0 && snap.averageRating > 0 {
+		book.AverageRating = snap.averageRating
+		book.RatingsCount = snap.ratingsCount
 	}
 }
 

--- a/internal/metadata/aggregator_enrichment_test.go
+++ b/internal/metadata/aggregator_enrichment_test.go
@@ -299,6 +299,123 @@ func TestAggregator_enrichBook_FillsCoverFromCoverProvider(t *testing.T) {
 	}
 }
 
+// TestEnrichBook_CachesAcrossCalls covers finding 12: enrichBook used to
+// make a fresh SearchBooks call per book per refresh, even when the same
+// (provider, foreignID) had just been enriched. With the snapshot cache
+// in place, the second call must reuse the cached fields without
+// re-hitting the enricher.
+func TestEnrichBook_CachesAcrossCalls(t *testing.T) {
+	enricher := &mockProvider{
+		name: "gb",
+		searchBooks: []models.Book{{
+			Title:    "Sapiens",
+			ImageURL: "https://books.google.com/sapiens.jpg",
+		}},
+	}
+	agg := &Aggregator{enrichers: []Provider{enricher}, cache: newTTLCache(time.Minute)}
+
+	first := &models.Book{
+		ForeignID:        "OLW-123",
+		MetadataProvider: "openlibrary",
+		Title:            "Sapiens",
+	}
+	agg.enrichBook(context.Background(), first)
+	if first.ImageURL != "https://books.google.com/sapiens.jpg" {
+		t.Fatalf("first call: cover not enriched, got %q", first.ImageURL)
+	}
+	if len(enricher.searchBookQueries) != 1 {
+		t.Fatalf("first call: SearchBooks called %d times, want 1", len(enricher.searchBookQueries))
+	}
+
+	// Second call: identical foreign ID and provider, fresh book pointer.
+	// Must hit the cache and skip the enricher entirely.
+	second := &models.Book{
+		ForeignID:        "OLW-123",
+		MetadataProvider: "openlibrary",
+		Title:            "Sapiens",
+	}
+	agg.enrichBook(context.Background(), second)
+	if second.ImageURL != "https://books.google.com/sapiens.jpg" {
+		t.Errorf("second call: expected cached cover, got %q", second.ImageURL)
+	}
+	if len(enricher.searchBookQueries) != 1 {
+		t.Errorf("second call: SearchBooks called %d times, want 1 (cache miss)", len(enricher.searchBookQueries))
+	}
+}
+
+// TestEnrichBook_DifferentBooksGetSeparateCacheEntries guards against the
+// keying regression where two distinct books share a cache slot (e.g. a
+// key that only used Title would alias every "Dune" reissue together).
+func TestEnrichBook_DifferentBooksGetSeparateCacheEntries(t *testing.T) {
+	enricher := &mockProvider{
+		name: "gb",
+		searchBooksByQuery: map[string][]models.Book{
+			"Sapiens":   {{Title: "Sapiens", ImageURL: "https://books.google.com/sapiens.jpg"}},
+			"Homo Deus": {{Title: "Homo Deus", ImageURL: "https://books.google.com/homo-deus.jpg"}},
+		},
+	}
+	agg := &Aggregator{enrichers: []Provider{enricher}, cache: newTTLCache(time.Minute)}
+
+	a := &models.Book{ForeignID: "OLW-A", MetadataProvider: "openlibrary", Title: "Sapiens"}
+	b := &models.Book{ForeignID: "OLW-B", MetadataProvider: "openlibrary", Title: "Homo Deus"}
+	agg.enrichBook(context.Background(), a)
+	agg.enrichBook(context.Background(), b)
+
+	if a.ImageURL != "https://books.google.com/sapiens.jpg" {
+		t.Errorf("Sapiens: got %q, want sapiens cover", a.ImageURL)
+	}
+	if b.ImageURL != "https://books.google.com/homo-deus.jpg" {
+		t.Errorf("Homo Deus: got %q, want homo-deus cover", b.ImageURL)
+	}
+	if len(enricher.searchBookQueries) != 2 {
+		t.Errorf("expected 2 distinct SearchBooks calls, got %d (cache aliasing)", len(enricher.searchBookQueries))
+	}
+
+	// Re-enriching either of them must hit the cache, not the network.
+	again := &models.Book{ForeignID: "OLW-A", MetadataProvider: "openlibrary", Title: "Sapiens"}
+	agg.enrichBook(context.Background(), again)
+	if again.ImageURL != "https://books.google.com/sapiens.jpg" {
+		t.Errorf("Sapiens re-enrich: got %q, want cached cover", again.ImageURL)
+	}
+	if len(enricher.searchBookQueries) != 2 {
+		t.Errorf("Sapiens re-enrich went to the network: query count = %d", len(enricher.searchBookQueries))
+	}
+}
+
+// TestEnrichBook_CacheDoesNotAliasBookPointer is the pitfall guard for the
+// snapshot design. If we cached *models.Book by reference, a later
+// mutation by a downstream caller would leak into subsequent cache hits.
+// The snapshot is a value type so mutating the input book after enrichment
+// must not affect the next enrichment of the same key.
+func TestEnrichBook_CacheDoesNotAliasBookPointer(t *testing.T) {
+	enricher := &mockProvider{
+		name:        "gb",
+		searchBooks: []models.Book{{Title: "Dune", ImageURL: "https://books.google.com/dune.jpg"}},
+	}
+	agg := &Aggregator{enrichers: []Provider{enricher}, cache: newTTLCache(time.Minute)}
+
+	first := &models.Book{ForeignID: "OLW-DUNE", MetadataProvider: "openlibrary", Title: "Dune"}
+	agg.enrichBook(context.Background(), first)
+	if first.ImageURL != "https://books.google.com/dune.jpg" {
+		t.Fatalf("first call: cover not enriched, got %q", first.ImageURL)
+	}
+
+	// Mutate the just-enriched book as if a downstream caller did.
+	first.ImageURL = ""
+	first.Description = "downstream-mangled"
+
+	// A new enrichment of the same key must still see the original cover,
+	// not the downstream mutation.
+	second := &models.Book{ForeignID: "OLW-DUNE", MetadataProvider: "openlibrary", Title: "Dune"}
+	agg.enrichBook(context.Background(), second)
+	if second.ImageURL != "https://books.google.com/dune.jpg" {
+		t.Errorf("cache pointer-aliased to the first book: got %q", second.ImageURL)
+	}
+	if second.Description == "downstream-mangled" {
+		t.Errorf("cache leaked downstream mutation into Description: %q", second.Description)
+	}
+}
+
 // TestAggregator_enrichBook_CoverProviderSkippedWhenAlreadyHaveCover
 // guards against the fallback wasting a HEAD request (and overwriting
 // an already-good cover) when an enricher succeeded.

--- a/internal/metadata/ttl_cache.go
+++ b/internal/metadata/ttl_cache.go
@@ -6,9 +6,21 @@ import (
 	"time"
 )
 
-// ttlCache is a goroutine-safe key/value cache with per-entry expiry. A
-// background janitor sweeps expired items hourly so the map doesn't grow
-// without bound when keys are written but never re-read.
+// ttlCache is a goroutine-safe key/value cache with per-entry expiry and a
+// hard cap on entry count. A background janitor sweeps expired items hourly
+// so the map doesn't grow without bound when keys are written but never
+// re-read; the count cap is the backstop for the in-between window where a
+// hot ingestion path can fill the cache faster than the hourly sweep evicts.
+//
+// Eviction policy: when set() would push the entry count past maxEntries,
+// the cache evicts the entry with the earliest expiresAt. That's the entry
+// that would have been dropped soonest anyway, so it's the cheapest correct
+// policy. It's an O(n) scan on every overflow set, which is fine at the
+// default cap of 10000 entries and the access frequency this cache sees
+// (metadata fan-out, not a request-path cache). Switch to container/list
+// LRU if the cap ever needs to climb past ~100k. We deliberately avoid
+// pulling in a third-party LRU package; this cache is internal and the
+// no-deps policy keeps the package vendorable.
 //
 // The janitor's lifetime is tied to the cache value via runtime.AddCleanup:
 // when the cache becomes unreachable, the cleanup fires and the janitor
@@ -29,8 +41,9 @@ type ttlCache struct {
 }
 
 type ttlState struct {
-	mu    sync.RWMutex
-	items map[string]cacheItem
+	mu         sync.RWMutex
+	items      map[string]cacheItem
+	maxEntries int
 }
 
 type cacheItem struct {
@@ -38,8 +51,27 @@ type cacheItem struct {
 	expiresAt time.Time
 }
 
+// defaultMaxEntries caps every aggregator-scoped ttlCache. 10k entries at
+// the heaviest realistic value size (~50KB per cached []models.Book on a
+// prolific-author fan-out) bounds the cache at roughly 500MB worst-case,
+// which is the rough ceiling we want for a single aggregator instance.
+const defaultMaxEntries = 10000
+
 func newTTLCache(ttl time.Duration) *ttlCache {
-	state := &ttlState{items: make(map[string]cacheItem)}
+	return newTTLCacheWithCap(ttl, defaultMaxEntries)
+}
+
+// newTTLCacheWithCap is the explicit-cap constructor used by tests that need
+// to exercise the eviction policy without filling 10k entries. Production
+// callers go through newTTLCache.
+func newTTLCacheWithCap(ttl time.Duration, maxEntries int) *ttlCache {
+	if maxEntries <= 0 {
+		maxEntries = defaultMaxEntries
+	}
+	state := &ttlState{
+		items:      make(map[string]cacheItem),
+		maxEntries: maxEntries,
+	}
 	done := make(chan struct{})
 
 	go runJanitor(state, done)
@@ -88,6 +120,37 @@ func (c *ttlCache) set(key string, value interface{}) {
 	c.state.items[key] = cacheItem{
 		value:     value,
 		expiresAt: time.Now().Add(c.ttl),
+	}
+	// Evict only when the cap is exceeded. Overwriting an existing key
+	// doesn't grow the map, so this branch is a no-op in the steady state.
+	if c.state.maxEntries > 0 && len(c.state.items) > c.state.maxEntries {
+		c.state.evictEarliestLocked(key)
+	}
+}
+
+// evictEarliestLocked removes the entry with the smallest expiresAt and is
+// invoked with state.mu held in write mode. It refuses to evict the key
+// just inserted by the caller so a single set() can never delete its own
+// write (matters when every existing entry happens to share an expiresAt
+// that compares strictly less than the just-written one only by chance).
+func (s *ttlState) evictEarliestLocked(justInserted string) {
+	var (
+		victim       string
+		victimExpiry time.Time
+		found        bool
+	)
+	for k, v := range s.items {
+		if k == justInserted {
+			continue
+		}
+		if !found || v.expiresAt.Before(victimExpiry) {
+			victim = k
+			victimExpiry = v.expiresAt
+			found = true
+		}
+	}
+	if found {
+		delete(s.items, victim)
 	}
 }
 

--- a/internal/metadata/ttl_cache_test.go
+++ b/internal/metadata/ttl_cache_test.go
@@ -2,6 +2,8 @@ package metadata
 
 import (
 	"runtime"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 )
@@ -48,6 +50,104 @@ func TestTTLCache_Cleanup(t *testing.T) {
 	c.state.mu.RUnlock()
 	if n != 0 {
 		t.Errorf("expected 0 items after cleanup, got %d", n)
+	}
+}
+
+// TestTTLCache_EvictsByCount fills the cache past its cap and asserts the
+// entry count never exceeds the cap. Backstops finding 11: between the
+// hourly janitor sweeps a hot fan-out could grow the items map without
+// bound.
+func TestTTLCache_EvictsByCount(t *testing.T) {
+	const cap = 4
+	c := newTTLCacheWithCap(time.Hour, cap)
+	for i := 0; i < cap*3; i++ {
+		c.set(strconv.Itoa(i), i)
+	}
+	c.state.mu.RLock()
+	n := len(c.state.items)
+	c.state.mu.RUnlock()
+	if n > cap {
+		t.Errorf("len(items) = %d, want <= %d", n, cap)
+	}
+}
+
+// TestTTLCache_EvictionPolicyPicksEarliestExpiry stages entries with
+// staggered TTLs, fills to cap with a brand-new entry, and asserts the
+// overflow eviction targets the entry that would have expired soonest,
+// not the most-recently-added.
+func TestTTLCache_EvictionPolicyPicksEarliestExpiry(t *testing.T) {
+	c := newTTLCacheWithCap(time.Hour, 3)
+	// Manually plant entries with controlled expiresAt values so the
+	// test doesn't race the wall clock.
+	now := time.Now()
+	c.state.mu.Lock()
+	c.state.items["soonest"] = cacheItem{value: "s", expiresAt: now.Add(10 * time.Millisecond)}
+	c.state.items["middle"] = cacheItem{value: "m", expiresAt: now.Add(1 * time.Hour)}
+	c.state.items["latest"] = cacheItem{value: "l", expiresAt: now.Add(2 * time.Hour)}
+	c.state.mu.Unlock()
+
+	// This set overflows the cap. The earliest-expiry entry should go.
+	c.set("fresh", "f")
+
+	c.state.mu.RLock()
+	_, soonestPresent := c.state.items["soonest"]
+	_, middlePresent := c.state.items["middle"]
+	_, latestPresent := c.state.items["latest"]
+	_, freshPresent := c.state.items["fresh"]
+	c.state.mu.RUnlock()
+
+	if soonestPresent {
+		t.Error("expected earliest-expiring entry 'soonest' to be evicted")
+	}
+	if !middlePresent {
+		t.Error("expected 'middle' to survive eviction")
+	}
+	if !latestPresent {
+		t.Error("expected 'latest' to survive eviction")
+	}
+	if !freshPresent {
+		t.Error("expected just-inserted 'fresh' to survive eviction")
+	}
+}
+
+// TestTTLCache_TTLStillEvicts pins the original TTL semantics: even with
+// the cap policy added, a past-TTL get is still a miss. Catches the
+// regression of skipping the time.After check after a successful map
+// lookup.
+func TestTTLCache_TTLStillEvicts(t *testing.T) {
+	c := newTTLCacheWithCap(time.Nanosecond, 100)
+	c.set("k", "v")
+	time.Sleep(2 * time.Millisecond)
+	if _, ok := c.get("k"); ok {
+		t.Error("expected cache miss after TTL expiry under capped cache")
+	}
+}
+
+// TestTTLCache_EvictionRaceSafe pounds the cache from multiple goroutines
+// at saturation so go test -race can flag any read-write overlap on the
+// eviction path. evictEarliestLocked iterates the map while holding the
+// write lock, but a regression that downgraded the lock or reordered the
+// branch would surface here.
+func TestTTLCache_EvictionRaceSafe(t *testing.T) {
+	c := newTTLCacheWithCap(time.Minute, 8)
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				key := "w" + strconv.Itoa(worker) + "-" + strconv.Itoa(i)
+				c.set(key, i)
+				_, _ = c.get(key)
+			}
+		}(w)
+	}
+	wg.Wait()
+	c.state.mu.RLock()
+	n := len(c.state.items)
+	c.state.mu.RUnlock()
+	if n > 8 {
+		t.Errorf("len(items) = %d after concurrent writes, want <= 8", n)
 	}
 }
 


### PR DESCRIPTION
## Findings addressed

**Finding 11** (`internal/metadata/ttl_cache.go`): the TTL cache had per-entry expiry but no count cap. The hourly janitor was the only thing keeping the items map bounded, and a hot author-works fan-out can fill it faster than the sweep evicts. Per-entry values are tens of KB (`[]models.Book`), so unbounded growth between sweeps is real memory pressure.

**Finding 12** (`internal/metadata/aggregator_author_works.go:132`): `enrichMissingAuthorWorkCovers` calls `enrichBook` per book, and `enrichBook` made synchronous HTTP requests to every enricher every call. No cache at all; every author refresh refetched every book's enrichment.

## Cap value + eviction policy

- Default `maxEntries = 10000`. At a ~50KB upper bound per `[]Book` cache entry that is roughly 500MB worst case per aggregator, which is the rough ceiling we want.
- Eviction policy: earliest `expiresAt`. On overflow, scan the items map and delete the entry that would have been swept next anyway. O(n) per overflow `set`, which is fine at this cap and access frequency. The just-inserted key is excluded from victim selection so a single `set` cannot delete its own write.
- No third-party LRU dependency. The package's no-deps posture is preserved; container/list + map LRU is a paste-in upgrade if the cap ever climbs past ~100k.

## enrichBook cache key + invalidation

- Key: `enrich:<provider>:<foreignID>`. Provider + foreign ID uniquely identifies a book across our provider universe and is the natural identity callers route by.
- Fallback key when `ForeignID == ""` (e.g. audnex-sourced canonical lookup): `enrich-title:<lowercased title>|<lowercased author>`. Empty fallback skips caching entirely; better to refetch than alias unrelated books under `""`.
- Invalidation: TTL only. The aggregator constructor uses 24h; nothing else flushes the cache. That matches the lifetime of the rest of the aggregator's cache entries.

## Pointer-aliasing pitfall + mitigation

`enrichBook` mutates a `*models.Book`. Caching the pointer would let any downstream caller's mutation leak into the next cache hit (e.g. a downstream call could blank out `ImageURL` on the cached book and poison every subsequent reader). The fix: cache an `enrichmentSnapshot` value type carrying only the four fields enrichBook may write (`Description`, `ImageURL`, `AverageRating`, `RatingsCount`), and apply them on hit through `applyEnrichmentSnapshot` using the same merge rules as the live path (replace `Description` only when the cached one is longer, only fill empty cover/rating fields). Value types are impossible to alias. Covered by `TestEnrichBook_CacheDoesNotAliasBookPointer`.

## Test plan

- [x] `TestTTLCache_EvictsByCount`: fill the cache to N*3, assert `len(items) <= N`.
- [x] `TestTTLCache_EvictionPolicyPicksEarliestExpiry`: stage entries with controlled `expiresAt`, fill to cap, assert the earliest-expiry entry is evicted and not the just-inserted one.
- [x] `TestTTLCache_TTLStillEvicts`: past-TTL `get` still misses after the cap policy is added.
- [x] `TestTTLCache_EvictionRaceSafe`: -race coverage with concurrent saturation writes.
- [x] `TestEnrichBook_CachesAcrossCalls`: two identical inputs, one `SearchBooks` call.
- [x] `TestEnrichBook_DifferentBooksGetSeparateCacheEntries`: keying isolates distinct foreign IDs.
- [x] `TestEnrichBook_CacheDoesNotAliasBookPointer`: mutating an enriched book does not contaminate the next cache hit.
- [x] Full `internal/metadata` suite passes under `-race`.
- [x] `go vet ./...` clean, `go build ./...` clean.

## Wave context

Bundle J of Wave 3, building on the Wave 1 + 2 PRs (#892 through #902).