### PR TITLE
perf(abs): debounce enumerator checkpoint writes (Wave 3 / K)

### DIFF
--- a/internal/abs/enumerator.go
+++ b/internal/abs/enumerator.go
@@ -15,6 +15,23 @@ import (
 
 const SettingABSImportCheckpoint = "abs.import_checkpoint"
 
+// Default debounce thresholds for the checkpointer. The enumerator writes a
+// per-item checkpoint into the singleton settings row so an interrupted import
+// can resume near where it stopped. Writing on every item turned a 10k-book
+// library into 10k fsync+WAL appends against one row (finding 13); debouncing
+// to "every N items or every K seconds, whichever comes first" cuts that to a
+// few hundred writes while keeping the resume window bounded.
+//
+// After a crash, the import may re-process up to checkpointMinItems items or
+// checkpointMinInterval of work that the user already saw progress for. ABS
+// imports are idempotent (upsertBook / resolveAuthor key off ForeignID via
+// GetByForeignID and either Update or Create, never insert-only audit rows
+// keyed by run), so replaying a handful of items is harmless.
+const (
+	checkpointMinItems    = 100
+	checkpointMinInterval = 5 * time.Second
+)
+
 type enumerationClient interface {
 	ListLibraryItems(ctx context.Context, libraryID string, page, limit int) (*LibraryItemsPage, error)
 	GetLibraryItem(ctx context.Context, itemID string) (*LibraryItem, error)
@@ -41,6 +58,9 @@ type Enumerator struct {
 	pageSize      int
 	checkpointKey string
 	onCheckpoint  func(ImportCheckpoint)
+	minItems      int
+	minInterval   time.Duration
+	now           func() time.Time
 }
 
 func NewEnumerator(client enumerationClient, settings *db.SettingsRepo, pageSize int) *Enumerator {
@@ -52,12 +72,93 @@ func NewEnumerator(client enumerationClient, settings *db.SettingsRepo, pageSize
 		settings:      settings,
 		pageSize:      pageSize,
 		checkpointKey: SettingABSImportCheckpoint,
+		minItems:      checkpointMinItems,
+		minInterval:   checkpointMinInterval,
+		now:           time.Now,
 	}
 }
 
 func (e *Enumerator) WithCheckpointObserver(fn func(ImportCheckpoint)) *Enumerator {
 	e.onCheckpoint = fn
 	return e
+}
+
+// WithCheckpointDebounce overrides the default debounce thresholds. A
+// non-positive minItems or minInterval falls back to the package default.
+// Intended for tests; production code should rely on the defaults.
+func (e *Enumerator) WithCheckpointDebounce(minItems int, minInterval time.Duration) *Enumerator {
+	if minItems > 0 {
+		e.minItems = minItems
+	}
+	if minInterval > 0 {
+		e.minInterval = minInterval
+	}
+	return e
+}
+
+// WithClock injects a clock for tests. Production callers should not use this.
+func (e *Enumerator) WithClock(now func() time.Time) *Enumerator {
+	if now != nil {
+		e.now = now
+	}
+	return e
+}
+
+// checkpointer debounces calls to writeFn: it writes when at least minItems
+// candidates have been offered since the last write OR at least minInterval
+// has elapsed, whichever fires first. flush() forces the most recent pending
+// candidate to disk regardless of either threshold. A nil pending candidate
+// means nothing has been offered since the last write, so flush is a no-op.
+type checkpointer struct {
+	now             func() time.Time
+	minInterval     time.Duration
+	minItems        int
+	writeFn         func(context.Context, ImportCheckpoint) error
+	pending         *ImportCheckpoint
+	itemsSinceWrite int
+	lastWriteAt     time.Time
+}
+
+func newCheckpointer(minItems int, minInterval time.Duration, now func() time.Time, writeFn func(context.Context, ImportCheckpoint) error) *checkpointer {
+	if now == nil {
+		now = time.Now
+	}
+	return &checkpointer{
+		now:         now,
+		minInterval: minInterval,
+		minItems:    minItems,
+		writeFn:     writeFn,
+		lastWriteAt: now(),
+	}
+}
+
+// offer records a new candidate checkpoint and writes it if either threshold
+// is met. It is safe to call once per processed item.
+func (c *checkpointer) offer(ctx context.Context, cp ImportCheckpoint) error {
+	c.pending = &cp
+	c.itemsSinceWrite++
+	if c.itemsSinceWrite < c.minItems && c.now().Sub(c.lastWriteAt) < c.minInterval {
+		return nil
+	}
+	return c.flush(ctx)
+}
+
+// flush writes the pending candidate (if any) regardless of thresholds and
+// resets the counters. Callers MUST call flush when the enumeration ends
+// (whether on success or on an error returned by the per-item callback) so the
+// final position is durable.
+func (c *checkpointer) flush(ctx context.Context) error {
+	if c.pending == nil {
+		return nil
+	}
+	cp := *c.pending
+	if err := c.writeFn(ctx, cp); err != nil {
+		return err
+	}
+	c.pending = nil
+	c.itemsSinceWrite = 0
+	c.lastWriteAt = c.now()
+	return nil
 }
 
 func (e *Enumerator) Enumerate(ctx context.Context, libraryID string, fn func(context.Context, NormalizedLibraryItem) error) (EnumerationStats, error) {
@@ -78,16 +179,30 @@ func (e *Enumerator) Enumerate(ctx context.Context, libraryID string, fn func(co
 		skipUntilID = checkpoint.LastItemID
 	}
 
+	cp := newCheckpointer(e.minItems, e.minInterval, e.now, e.saveCheckpoint)
+	// Always flush the most recent pending checkpoint on return so resume from
+	// a crash, a context cancel, or a callback error lands at the last
+	// successfully processed item rather than discarding the partial progress
+	// captured since the last debounced write.
+	flushOnReturn := func() {
+		if flushErr := cp.flush(ctx); flushErr != nil {
+			slog.Warn("abs enumerate: flush checkpoint failed", "libraryID", libraryID, "error", flushErr)
+		}
+	}
+
 	for {
 		if err := ctx.Err(); err != nil {
+			flushOnReturn()
 			return stats, err
 		}
 
 		resp, err := e.client.ListLibraryItems(ctx, libraryID, page, e.pageSize)
 		if err != nil {
+			flushOnReturn()
 			return stats, err
 		}
 		if err := validateBookLibraryPage(libraryID, resp); err != nil {
+			flushOnReturn()
 			return stats, err
 		}
 		stats.PagesScanned++
@@ -132,6 +247,7 @@ func (e *Enumerator) Enumerate(ctx context.Context, libraryID string, fn func(co
 					"reasons", reasons)
 				detail, err := e.client.GetLibraryItem(ctx, item.ID)
 				if err != nil {
+					flushOnReturn()
 					return stats, err
 				}
 				item = MergeLibraryItem(item, *detail)
@@ -140,26 +256,31 @@ func (e *Enumerator) Enumerate(ctx context.Context, libraryID string, fn func(co
 
 			normalized := NormalizeLibraryItem(item, detailFetched)
 			if err := fn(ctx, normalized); err != nil {
+				flushOnReturn()
 				return stats, err
 			}
 			stats.ItemsNormalized++
-			if err := e.saveCheckpoint(ctx, ImportCheckpoint{
+			if err := cp.offer(ctx, ImportCheckpoint{
 				LibraryID:  libraryID,
 				Page:       page,
 				LastItemID: item.ID,
 				PageSize:   e.pageSize,
-				UpdatedAt:  time.Now().UTC(),
+				UpdatedAt:  e.now().UTC(),
 			}); err != nil {
 				return stats, err
 			}
 		}
 
 		page++
-		if err := e.saveCheckpoint(ctx, ImportCheckpoint{
+		// Page boundary: offer a checkpoint that records the next page with no
+		// LastItemID so resume picks up at the top of the new page. The
+		// debounce still applies here. Final correctness is guaranteed by the
+		// flushOnReturn at the end of the function.
+		if err := cp.offer(ctx, ImportCheckpoint{
 			LibraryID: libraryID,
 			Page:      page,
 			PageSize:  e.pageSize,
-			UpdatedAt: time.Now().UTC(),
+			UpdatedAt: e.now().UTC(),
 		}); err != nil {
 			return stats, err
 		}
@@ -174,8 +295,12 @@ func (e *Enumerator) Enumerate(ctx context.Context, libraryID string, fn func(co
 	}
 
 	if err := e.clearCheckpoint(ctx); err != nil {
+		flushOnReturn()
 		return stats, err
 	}
+	// Successful completion: drop the pending checkpoint without writing,
+	// since clearCheckpoint already wiped the stored value.
+	cp.pending = nil
 	slog.Info("abs enumerate complete",
 		"libraryID", libraryID,
 		"pagesScanned", stats.PagesScanned,

--- a/internal/abs/enumerator_test.go
+++ b/internal/abs/enumerator_test.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/vavallee/bindery/internal/db"
 )
@@ -278,5 +282,318 @@ func TestEnumerator_ResumeFromCheckpoint(t *testing.T) {
 	}
 	if setting != nil {
 		t.Fatalf("checkpoint should be cleared, got %+v", setting)
+	}
+}
+
+func TestCheckpointer_WritesEveryN(t *testing.T) {
+	t.Parallel()
+
+	var writes int
+	clock := time.Unix(0, 0)
+	cp := newCheckpointer(100, time.Hour, func() time.Time { return clock }, func(_ context.Context, _ ImportCheckpoint) error {
+		writes++
+		return nil
+	})
+
+	for i := 0; i < 99; i++ {
+		if err := cp.offer(context.Background(), ImportCheckpoint{LastItemID: strconv.Itoa(i)}); err != nil {
+			t.Fatalf("offer %d: %v", i, err)
+		}
+	}
+	if writes != 0 {
+		t.Fatalf("writes after 99 offers = %d, want 0", writes)
+	}
+	if err := cp.offer(context.Background(), ImportCheckpoint{LastItemID: "99"}); err != nil {
+		t.Fatalf("offer 100: %v", err)
+	}
+	if writes != 1 {
+		t.Fatalf("writes after 100 offers = %d, want 1", writes)
+	}
+
+	for i := 100; i < 199; i++ {
+		if err := cp.offer(context.Background(), ImportCheckpoint{LastItemID: strconv.Itoa(i)}); err != nil {
+			t.Fatalf("offer %d: %v", i, err)
+		}
+	}
+	if writes != 1 {
+		t.Fatalf("writes after 199 offers = %d, want 1", writes)
+	}
+	if err := cp.offer(context.Background(), ImportCheckpoint{LastItemID: "199"}); err != nil {
+		t.Fatalf("offer 200: %v", err)
+	}
+	if writes != 2 {
+		t.Fatalf("writes after 200 offers = %d, want 2", writes)
+	}
+}
+
+func TestCheckpointer_WritesOnTimeElapsed(t *testing.T) {
+	t.Parallel()
+
+	var writes int
+	var lastWritten ImportCheckpoint
+	clock := time.Unix(0, 0)
+	cp := newCheckpointer(1_000_000, 5*time.Second, func() time.Time { return clock }, func(_ context.Context, c ImportCheckpoint) error {
+		writes++
+		lastWritten = c
+		return nil
+	})
+
+	if err := cp.offer(context.Background(), ImportCheckpoint{LastItemID: "a"}); err != nil {
+		t.Fatal(err)
+	}
+	if writes != 0 {
+		t.Fatalf("writes after first offer = %d, want 0", writes)
+	}
+	clock = clock.Add(4 * time.Second)
+	if err := cp.offer(context.Background(), ImportCheckpoint{LastItemID: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	if writes != 0 {
+		t.Fatalf("writes after offer at +4s = %d, want 0", writes)
+	}
+	clock = clock.Add(2 * time.Second)
+	if err := cp.offer(context.Background(), ImportCheckpoint{LastItemID: "c"}); err != nil {
+		t.Fatal(err)
+	}
+	if writes != 1 {
+		t.Fatalf("writes after offer at +6s = %d, want 1", writes)
+	}
+	if lastWritten.LastItemID != "c" {
+		t.Fatalf("lastWritten = %q, want %q", lastWritten.LastItemID, "c")
+	}
+}
+
+func TestCheckpointer_FlushAlwaysWrites(t *testing.T) {
+	t.Parallel()
+
+	var writes int
+	var lastWritten ImportCheckpoint
+	clock := time.Unix(0, 0)
+	cp := newCheckpointer(1_000_000, time.Hour, func() time.Time { return clock }, func(_ context.Context, c ImportCheckpoint) error {
+		writes++
+		lastWritten = c
+		return nil
+	})
+
+	if err := cp.offer(context.Background(), ImportCheckpoint{LastItemID: "pending"}); err != nil {
+		t.Fatal(err)
+	}
+	if writes != 0 {
+		t.Fatalf("writes pre-flush = %d, want 0", writes)
+	}
+	if err := cp.flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if writes != 1 || lastWritten.LastItemID != "pending" {
+		t.Fatalf("flush: writes=%d lastWritten=%q", writes, lastWritten.LastItemID)
+	}
+
+	// Second flush with nothing pending is a no-op.
+	if err := cp.flush(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if writes != 1 {
+		t.Fatalf("idle flush wrote: writes = %d, want 1", writes)
+	}
+}
+
+func TestCheckpointer_FlushPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("settings write failed")
+	cp := newCheckpointer(1, time.Hour, time.Now, func(_ context.Context, _ ImportCheckpoint) error {
+		return wantErr
+	})
+	if err := cp.offer(context.Background(), ImportCheckpoint{LastItemID: "x"}); !errors.Is(err, wantErr) {
+		t.Fatalf("offer err = %v, want %v", err, wantErr)
+	}
+}
+
+// fakeEnumerationServer serves a synthetic ABS library of size totalItems split
+// into pages of pageSize. Used for the debounce integration test below.
+func fakeEnumerationServer(t *testing.T, libraryID string, totalItems, pageSize int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/libraries/"+libraryID+"/items" {
+			http.NotFound(w, r)
+			return
+		}
+		q := r.URL.Query()
+		page, err := strconv.Atoi(q.Get("page"))
+		if err != nil {
+			page = 0
+		}
+		limit := pageSize
+		if l := q.Get("limit"); l != "" {
+			if v, err := strconv.Atoi(l); err == nil && v > 0 {
+				limit = v
+			}
+		}
+		start := page * limit
+		end := start + limit
+		if end > totalItems {
+			end = totalItems
+		}
+		results := make([]map[string]any, 0, end-start)
+		for i := start; i < end; i++ {
+			id := fmt.Sprintf("li_%04d", i)
+			results = append(results, map[string]any{
+				"id":        id,
+				"libraryId": libraryID,
+				"path":      "/audiobooks/Author/" + id + ".m4b",
+				"relPath":   "Author/" + id + ".m4b",
+				"isFile":    true,
+				"mediaType": "book",
+				"media": map[string]any{
+					"libraryItemId": id,
+					"metadata": map[string]any{
+						"title": "Title " + id,
+						"authors": []map[string]any{
+							{"id": "au_1", "name": "Author"},
+						},
+					},
+					"duration": 100,
+					"size":     1000,
+					"audioFiles": []map[string]any{
+						{
+							"ino":   "ino_" + id,
+							"index": 1,
+							"path":  "/audiobooks/Author/" + id + ".m4b",
+						},
+					},
+				},
+			})
+		}
+		payload := map[string]any{
+			"results":   results,
+			"total":     totalItems,
+			"limit":     limit,
+			"page":      page,
+			"mediaType": "book",
+			"minified":  true,
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+}
+
+func TestEnumerator_DebouncesSettingsWritesOnLargeLibrary(t *testing.T) {
+	t.Parallel()
+
+	const (
+		total    = 250
+		pageSize = 50
+	)
+	srv := fakeEnumerationServer(t, "lib-books", total, pageSize)
+	defer srv.Close()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	settings := db.NewSettingsRepo(database)
+	client, err := NewClient(srv.URL, "fixture-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var observerCalls int64
+	enumerator := NewEnumerator(client, settings, pageSize).
+		WithCheckpointObserver(func(ImportCheckpoint) {
+			atomic.AddInt64(&observerCalls, 1)
+		})
+
+	var processed int
+	stats, err := enumerator.Enumerate(context.Background(), "lib-books", func(context.Context, NormalizedLibraryItem) error {
+		processed++
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if processed != total {
+		t.Fatalf("processed = %d, want %d", processed, total)
+	}
+	if stats.ItemsNormalized != total {
+		t.Fatalf("ItemsNormalized = %d, want %d", stats.ItemsNormalized, total)
+	}
+
+	// Each observer call corresponds to one underlying settings.Set. With the
+	// default debounce thresholds of 100 items / 5s, a 250-item synchronous
+	// import should write roughly 2-3 times (at item 100, item 200, and
+	// possibly one page-boundary write). Without debouncing it would be 250+.
+	writes := atomic.LoadInt64(&observerCalls)
+	if writes < 1 || writes > 10 {
+		t.Fatalf("checkpoint writes = %d for %d items, want between 1 and 10", writes, total)
+	}
+
+	// On successful completion the checkpoint row is cleared.
+	setting, err := settings.Get(context.Background(), SettingABSImportCheckpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if setting != nil {
+		t.Fatalf("checkpoint should be cleared on success, got %+v", setting)
+	}
+}
+
+func TestEnumerator_FlushesPendingCheckpointOnCallbackError(t *testing.T) {
+	t.Parallel()
+
+	const (
+		total    = 50
+		pageSize = 50
+	)
+	srv := fakeEnumerationServer(t, "lib-books", total, pageSize)
+	defer srv.Close()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	settings := db.NewSettingsRepo(database)
+	client, err := NewClient(srv.URL, "fixture-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// minItems=1_000_000 + minInterval=1h means the debounce will never fire
+	// from offer() alone; only the flush-on-return path should write.
+	enumerator := NewEnumerator(client, settings, pageSize).
+		WithCheckpointDebounce(1_000_000, time.Hour)
+
+	stopErr := errors.New("stop after item 5")
+	var seen []string
+	_, err = enumerator.Enumerate(context.Background(), "lib-books", func(_ context.Context, item NormalizedLibraryItem) error {
+		seen = append(seen, item.ItemID)
+		if len(seen) == 6 {
+			return stopErr
+		}
+		return nil
+	})
+	if !errors.Is(err, stopErr) {
+		t.Fatalf("err = %v, want stopErr", err)
+	}
+
+	setting, err := settings.Get(context.Background(), SettingABSImportCheckpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if setting == nil {
+		t.Fatal("expected pending checkpoint to be flushed on callback error")
+		return
+	}
+	var checkpoint ImportCheckpoint
+	if err := json.Unmarshal([]byte(setting.Value), &checkpoint); err != nil {
+		t.Fatal(err)
+	}
+	// fn returned stopErr on the 6th item (index 5). The last successfully
+	// processed item was index 4 (li_0004), which is what should be durable.
+	if checkpoint.LastItemID != "li_0004" {
+		t.Fatalf("checkpoint.LastItemID = %q, want li_0004", checkpoint.LastItemID)
 	}
 }


### PR DESCRIPTION
## Finding & impact

Audit finding 13 (`internal/abs/enumerator.go:146`): the ABS enumerator wrote `ImportCheckpoint` into the singleton settings row after every processed item. For a 10k-book Audiobookshelf library that was 10k `SettingsRepo.Set` calls, each triggering a SQLite fsync + WAL append against one row. Large imports slowed to a crawl. The audit's recommended fix was to debounce.

## Strategy

Count + time, whichever fires first. A `checkpointer` is offered a candidate after each successful per-item callback; it writes only when EITHER:

* 100 items have been offered since the last write, OR
* 5 seconds have elapsed since the last write.

On return from `Enumerate` the most recent pending candidate is flushed to disk so the durable state always reflects the last successfully processed item, regardless of whether the enumeration stopped on success, context cancel, page-fetch error, or callback error. On successful completion `clearCheckpoint` still wipes the row.

The clock and the two thresholds are injectable (`WithCheckpointDebounce`, `WithClock`) so tests can drive deterministic behaviour without `time.Sleep`. Production uses the constants.

## Crash-recovery semantics

After a crash the import may re-process up to 100 items or 5 seconds of work that the user already saw progress for. Documented inline at the top of `enumerator.go`.

## Idempotency confirmation

Verified the upsert path tolerates re-processing. `Importer.upsertBook` (`internal/abs/import_upserts.go`) looks the book up by `ForeignID` via `i.books.GetByForeignID` and either calls `Update` on the existing row or `Create` for a new one. `resolveAuthor` follows the same `GetByForeignID -> Update | Create` shape. Provenance writes go through `provenance.Upsert`. No code path inserts an append-only audit row keyed by run + item that would duplicate on replay, so re-processing the last few items is harmless.

## Test plan

* `TestCheckpointer_WritesEveryN` asserts exactly 1 write after 100 offers and exactly 2 after 200.
* `TestCheckpointer_WritesOnTimeElapsed` uses an injected clock to advance virtual time past 5s and asserts the next offer writes.
* `TestCheckpointer_FlushAlwaysWrites` asserts `flush` writes regardless of count or elapsed time, and that a second flush with no pending candidate is a no-op.
* `TestCheckpointer_FlushPropagatesError` asserts a `writeFn` error surfaces from `offer`.
* `TestEnumerator_DebouncesSettingsWritesOnLargeLibrary` runs the enumerator over a synthetic 250-item library and asserts the underlying `SettingsRepo.Set` is called between 1 and 10 times (real run: a small handful), not 250.
* `TestEnumerator_FlushesPendingCheckpointOnCallbackError` sets thresholds so the debounce never fires from `offer` alone, stops the callback on item 6, and asserts the row durably reflects `li_0004` (the last successfully processed item).
* The pre-existing `TestEnumerator_ResumeFromCheckpoint` still passes unchanged: the `flushOnReturn` writes `li_resume_1` when the callback stops at item 2, and the resume run picks up at `li_resume_2`.

All `internal/abs/` tests and the full `go test ./...` suite pass.

## Wave links

Continues the deep-audit Wave 3 series. Prior waves: #892 - #902.