### PR TITLE
fix(oidc): release lock during discovery + race-free failedEntry read (Wave 5 / M)

### DIFF
--- a/internal/auth/oidc/provider.go
+++ b/internal/auth/oidc/provider.go
@@ -165,15 +165,31 @@ func (e *entry) oauth2Config(redirectBase string) oauth2.Config {
 // haven't changed keep their verifier (and therefore JWKS cache). Providers
 // whose discovery fails are recorded in the failed map (instead of silently
 // dropped) so the admin UI can surface them and EnsureLoaded can retry.
+//
+// The discovery roundtrip for each new/changed provider is a network call to
+// the IdP and can take hundreds of milliseconds (more over WAN). To avoid
+// stalling concurrent OIDC operations (login, callback, providers-list) we
+// release the manager lock between snapshotting the current state and doing
+// discovery, and only re-acquire the write lock to install the resolved set.
+// Concurrent Reload calls are last-write-wins; that matches the contract that
+// Reload mirrors the persisted settings, which is itself a serial source.
 func (m *Manager) Reload(ctx context.Context, cfgs []ProviderConfig) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	// Step 1: snapshot the existing loaded providers under RLock so we can
+	// reuse entries whose config is unchanged (preserving the JWKS cache).
+	m.mu.RLock()
+	existing := make(map[string]*entry, len(m.providers))
+	for id, e := range m.providers {
+		existing[id] = e
+	}
+	m.mu.RUnlock()
 
+	// Step 2: resolve the new state without holding the manager lock. This
+	// is the slow path: every cache miss triggers an OIDC discovery HTTP
+	// roundtrip to the IdP.
 	next := make(map[string]*entry, len(cfgs))
 	nextFailed := make(map[string]*failedEntry)
 	for _, cfg := range cfgs {
-		// Re-use the existing entry if config is identical (preserves JWKS cache).
-		if e, ok := m.providers[cfg.ID]; ok && configEqual(e.cfg, cfg) {
+		if e, ok := existing[cfg.ID]; ok && configEqual(e.cfg, cfg) {
 			next[cfg.ID] = e
 			continue
 		}
@@ -185,8 +201,13 @@ func (m *Manager) Reload(ctx context.Context, cfgs []ProviderConfig) {
 		}
 		next[cfg.ID] = e
 	}
+
+	// Step 3: install the resolved state under the write lock. The lock is
+	// only held for the assignment, never across the network roundtrip.
+	m.mu.Lock()
 	m.providers = next
 	m.failed = nextFailed
+	m.mu.Unlock()
 }
 
 func (m *Manager) buildEntry(ctx context.Context, cfg ProviderConfig) (*entry, error) {
@@ -202,6 +223,12 @@ func (m *Manager) buildEntry(ctx context.Context, cfg ProviderConfig) (*entry, e
 // failed map, rate-limited by retryMinInterval to protect the IdP from a
 // hammered login button. No-op if the provider is already loaded or unknown.
 // Errors are recorded on the failed entry; this function never returns one.
+//
+// The pre-check that gates whether we bother taking the write lock reads
+// failedEntry.lastAttempt; that field is mutated under the write lock when an
+// attempt completes, so we snapshot it under the RLock rather than reading it
+// after releasing the lock (which would be a data race the -race detector
+// would flag, and could produce a torn read of time.Time on 32-bit systems).
 func (m *Manager) EnsureLoaded(ctx context.Context, id string) {
 	m.mu.RLock()
 	if _, ok := m.providers[id]; ok {
@@ -209,28 +236,50 @@ func (m *Manager) EnsureLoaded(ctx context.Context, id string) {
 		return
 	}
 	f, isFailed := m.failed[id]
+	var lastAttempt time.Time
+	if isFailed {
+		lastAttempt = f.lastAttempt
+	}
 	m.mu.RUnlock()
 	if !isFailed {
 		return
 	}
-	if time.Since(f.lastAttempt) < retryMinInterval {
+	if time.Since(lastAttempt) < retryMinInterval {
 		return
 	}
 
+	// Claim the retry slot: stamp lastAttempt under the write lock and capture
+	// the cfg to discover. This serialises concurrent retries (only one
+	// goroutine actually fires the network call per interval) without holding
+	// the manager lock across the discovery roundtrip.
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	// Re-check after acquiring the write lock — another goroutine may have
-	// won the race and either loaded the provider or just attempted retry.
 	if _, ok := m.providers[id]; ok {
+		m.mu.Unlock()
 		return
 	}
 	f, isFailed = m.failed[id]
 	if !isFailed || time.Since(f.lastAttempt) < retryMinInterval {
+		m.mu.Unlock()
 		return
 	}
-
 	f.lastAttempt = time.Now()
-	e, err := m.buildEntry(ctx, f.cfg)
+	cfg := f.cfg
+	m.mu.Unlock()
+
+	// Discovery without the lock. Other OIDC operations (login on a healthy
+	// provider, callback, providers-list) are not blocked while we wait on
+	// the IdP roundtrip.
+	e, err := m.buildEntry(ctx, cfg)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// The failed entry may have been displaced by a concurrent Reload while
+	// the lock was released. If it's gone, the new state is authoritative
+	// and we drop our result on the floor.
+	f, stillFailed := m.failed[id]
+	if !stillFailed {
+		return
+	}
 	if err != nil {
 		f.lastErr = err
 		slog.Warn("oidc: on-demand re-discovery failed", "id", id, "error", err)

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -524,5 +525,253 @@ func TestProviderConfig_ExposesAllowedGroups(t *testing.T) {
 	}
 	if len(got.AllowedGroups) != 1 || got.AllowedGroups[0] != "bindery-users" {
 		t.Fatalf("AllowedGroups = %v, want [bindery-users]", got.AllowedGroups)
+	}
+}
+
+// --- Wave 5 / M: concurrency regressions -------------------------------------
+
+// pausingIDP is a fakeIDP that blocks every discovery request on a channel
+// the test controls. It lets us assert Reload releases the manager lock during
+// the IdP roundtrip — concurrent reads must not be stuck behind it.
+type pausingIDP struct {
+	*httptest.Server
+	release chan struct{}
+	hits    atomic.Int32
+}
+
+func newPausingIDP() *pausingIDP {
+	p := &pausingIDP{release: make(chan struct{})}
+	p.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/.well-known/openid-configuration") {
+			http.NotFound(w, r)
+			return
+		}
+		p.hits.Add(1)
+		// Block until the test releases us — simulates a slow IdP.
+		<-p.release
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                p.URL,
+			"authorization_endpoint":                p.URL + "/authorize",
+			"token_endpoint":                        p.URL + "/token",
+			"jwks_uri":                              p.URL + "/jwks",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+			"response_types_supported":              []string{"code"},
+			"subject_types_supported":               []string{"public"},
+		})
+	}))
+	return p
+}
+
+// TestReload_ReleasesLockDuringDiscovery is the regression test for Wave 5
+// finding 17: Manager.Reload used to hold the write lock through the
+// gooidc.NewProvider discovery roundtrip, blocking every concurrent OIDC
+// operation behind it. The fix snapshots state under RLock, does discovery
+// unlocked, and installs the new state under a short Lock.
+//
+// We assert by calling Reload in goroutine A (which stalls in the paused IdP)
+// and then calling List/Status from goroutine B. With the bug, B blocks until
+// the IdP is released. With the fix, B returns promptly.
+func TestReload_ReleasesLockDuringDiscovery(t *testing.T) {
+	idp := newPausingIDP()
+	defer idp.Close()
+
+	mgr := NewManager()
+	cfg := ProviderConfig{ID: "slow", Name: "Slow", Issuer: idp.URL, ClientID: "cid", ClientSecret: "sec"}
+
+	reloadDone := make(chan struct{})
+	go func() {
+		mgr.Reload(context.Background(), []ProviderConfig{cfg})
+		close(reloadDone)
+	}()
+
+	// Wait for the IdP to start serving the request — that's the proof the
+	// goroutine is currently in the middle of discovery.
+	deadline := time.Now().Add(2 * time.Second)
+	for idp.hits.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("Reload goroutine did not reach the IdP within 2s")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Now hammer the read paths. With the old code these would block on the
+	// write lock until the IdP responds. With the fix they return promptly.
+	readDone := make(chan struct{})
+	go func() {
+		_ = mgr.List()
+		_ = mgr.Status("slow")
+		_ = mgr.Get("slow")
+		close(readDone)
+	}()
+
+	select {
+	case <-readDone:
+		// good — the reads did not block behind the network call.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("read paths blocked behind Reload's network roundtrip — the lock is still held during discovery")
+	}
+
+	// Let the IdP finish so the goroutine can exit cleanly.
+	close(idp.release)
+	select {
+	case <-reloadDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reload did not complete after IdP was released")
+	}
+	if mgr.Status("slow").State != "ok" {
+		t.Fatalf("Reload should have loaded the provider, status=%+v", mgr.Status("slow"))
+	}
+}
+
+// TestEnsureLoaded_NoRaceOnLastAttempt is the regression test for Wave 5
+// finding 18: EnsureLoaded used to read failedEntry.lastAttempt outside the
+// lock. Under `go test -race` with concurrent EnsureLoaded calls plus a
+// Reload that mutates the failed map, the detector flagged the read.
+//
+// This test drives many concurrent EnsureLoaded calls against a failed
+// provider, interleaved with a Reload that swaps the failed map. With the
+// fix the race detector reports no findings; pre-fix it reliably triggers.
+func TestEnsureLoaded_NoRaceOnLastAttempt(t *testing.T) {
+	idp := newFakeIDP()
+	defer idp.Close()
+	idp.failing.Store(true)
+
+	prev := retryMinInterval
+	retryMinInterval = 1 * time.Millisecond
+	defer func() { retryMinInterval = prev }()
+
+	mgr := NewManager()
+	cfg := ProviderConfig{ID: "racy", Name: "Racy", Issuer: idp.URL, ClientID: "cid", ClientSecret: "sec"}
+	mgr.Reload(context.Background(), []ProviderConfig{cfg})
+	if mgr.Status("racy").State != "failed" {
+		t.Fatal("setup: provider should start in failed state")
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Fan-out EnsureLoaded calls. Each one races on the lastAttempt read of
+	// the failedEntry pointer in the map.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					mgr.EnsureLoaded(context.Background(), "racy")
+				}
+			}
+		}()
+	}
+
+	// A concurrent Reload swaps the failed-map pointer entirely, exercising
+	// the path where the failedEntry observed by EnsureLoaded's RLock branch
+	// is then re-pointed by a writer.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				mgr.Reload(context.Background(), []ProviderConfig{cfg})
+			}
+		}
+	}()
+
+	// Also pound Status which reads the same field from the read side.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = mgr.Status("racy")
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// TestEnsureLoaded_ReleasesLockDuringRetryDiscovery covers the same lock
+// release pattern for the on-demand retry path. With the old code, a single
+// click on a failed-provider login button held the write lock through the
+// retry's discovery roundtrip and blocked every other OIDC operation.
+func TestEnsureLoaded_ReleasesLockDuringRetryDiscovery(t *testing.T) {
+	// Start with a normal fake IdP so the initial Reload records a failed
+	// entry quickly. Then swap in a pausing IdP for the retry path.
+	failingIDP := newFakeIDP()
+	defer failingIDP.Close()
+	failingIDP.failing.Store(true)
+
+	prev := retryMinInterval
+	retryMinInterval = 1 * time.Millisecond
+	defer func() { retryMinInterval = prev }()
+
+	mgr := NewManager()
+	// Use the pausing IdP as the configured issuer from the start; the first
+	// Reload call below will block in discovery and we'll release it to seed
+	// a failed entry, then verify the retry path doesn't hold the lock.
+	pausingFailing := newPausingIDP()
+	defer pausingFailing.Close()
+
+	cfg := ProviderConfig{ID: "retry", Name: "Retry", Issuer: pausingFailing.URL, ClientID: "cid", ClientSecret: "sec"}
+
+	// Seed: release the IdP with a 503 by closing it mid-flight isn't viable;
+	// instead, drive the initial discovery to failure by cancelling the ctx.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	mgr.Reload(ctx, []ProviderConfig{cfg})
+	cancel()
+	if mgr.Status("retry") == nil || mgr.Status("retry").State != "failed" {
+		t.Fatalf("setup: provider should be in failed state after cancelled discovery, got %+v", mgr.Status("retry"))
+	}
+
+	// Sleep past the retry interval so EnsureLoaded will attempt.
+	time.Sleep(5 * time.Millisecond)
+
+	// Trigger the retry path. It will block in the IdP roundtrip.
+	retryDone := make(chan struct{})
+	go func() {
+		mgr.EnsureLoaded(context.Background(), "retry")
+		close(retryDone)
+	}()
+
+	// Wait until the retry goroutine has reached the IdP.
+	deadline := time.Now().Add(2 * time.Second)
+	for pausingFailing.hits.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("retry goroutine did not reach the IdP within 2s")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Concurrent read must not be blocked behind the retry's roundtrip.
+	readDone := make(chan struct{})
+	go func() {
+		_ = mgr.List()
+		_ = mgr.Status("retry")
+		close(readDone)
+	}()
+	select {
+	case <-readDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("read paths blocked behind EnsureLoaded's retry roundtrip — the lock is still held during discovery")
+	}
+
+	close(pausingFailing.release)
+	select {
+	case <-retryDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("EnsureLoaded did not complete after IdP was released")
 	}
 }


### PR DESCRIPTION
## Summary

Two related concurrency findings in `internal/auth/oidc/provider.go` from the Wave 5 deep audit.

**Finding 17, `Manager.Reload`**: held the manager write lock through the gooidc discovery roundtrip. A boot-time or settings-save reload stalled every concurrent OIDC operation (login, callback, providers-list) behind a network call that takes hundreds of milliseconds, more over WAN. Same bug applied to `EnsureLoaded`'s on-demand retry path.

**Finding 18, `Manager.EnsureLoaded`**: read `failedEntry.lastAttempt` outside the lock at provider.go:216. The same field is mutated under the write lock when an attempt completes. Textbook data race; `go test -race` flags it.

## Fix

Standard snapshot/network/install pattern:

1. `RLock`, copy the data needed for discovery, `RUnlock`.
2. Do the IdP discovery roundtrip without holding the manager lock.
3. `Lock`, install the resolved state, `Unlock`.

Concurrent `Reload` calls are last-write-wins; `Reload` mirrors the persisted settings, which is itself a serial source, so a stale concurrent reload would have been read-after-write anyway.

`EnsureLoaded`'s retry path claims the retry slot by stamping `lastAttempt` under the write lock (so only one goroutine fires the IdP call per interval), then releases the lock before the actual discovery call. Result is folded back in under the lock; the failed entry may have been displaced by a concurrent `Reload` during the roundtrip, in which case the result is dropped (the new state is authoritative).

For Finding 18, `lastAttempt` is snapshotted into a local under the `RLock` before the lock is released. Chose the lock-snapshot route rather than `atomic.Int64`-encoded `UnixNano` since `time.Time` is already there and the lock is held one line earlier anyway.

## Race-detector evidence

Pre-fix run of the new `TestEnsureLoaded_NoRaceOnLastAttempt` against the buggy `provider.go`:

```
WARNING: DATA RACE
Write at 0x00c0001446c0 by goroutine 21:
  github.com/vavallee/bindery/internal/auth/oidc.(*Manager).EnsureLoaded
      internal/auth/oidc/provider.go:232 +0x38e
Previous read at 0x00c0001446c0 by goroutine 20:
  github.com/vavallee/bindery/internal/auth/oidc.(*Manager).EnsureLoaded
      internal/auth/oidc/provider.go:216 +0x16e
...
    testing.go:1617: race detected during execution of test
--- FAIL: TestEnsureLoaded_NoRaceOnLastAttempt (0.10s)
```

Provider.go:216 is exactly the read flagged in Finding 18.

Post-fix:

```
$ go test -race -count=1 ./internal/auth/oidc/...
ok  	github.com/vavallee/bindery/internal/auth/oidc	3.439s
```

Full API package also clean: `go test -race ./internal/api/...` passes (446s).

## Test plan

- [x] `TestReload_ReleasesLockDuringDiscovery`: pause-on-channel IdP; Reload from goroutine A; assert List/Status/Get from goroutine B return within 500ms while A is still blocked in the network call.
- [x] `TestEnsureLoaded_NoRaceOnLastAttempt`: 8 concurrent EnsureLoaded goroutines + a Reload goroutine + a Status reader for 50ms; `-race` reports nothing.
- [x] `TestEnsureLoaded_ReleasesLockDuringRetryDiscovery`: same lock-release assertion for the on-demand retry path (drives initial discovery to failure via ctx cancel, then retries against a paused IdP).
- [x] Existing OIDC suite passes with `-race`.
- [x] `go vet ./internal/auth/oidc/...` and `go build ./...` clean.

## Wave context

Wave 5 followup. Sibling OIDC PRs in earlier waves: #892, #893, #894, #895-#902, #915-#918.

Branch: `agent/1780368076-2`.

Generated with [Claude Code](https://claude.com/claude-code)