### PR TITLE
fix(db): tolerate legacy date formats in book/author Scan and write RFC3339 (closes #914)

### DIFF
--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -207,7 +208,7 @@ func (r *AuthorRepo) CreateForUser(ctx context.Context, a *models.Author, ownerU
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.ForeignID, a.Name, a.SortName, a.Description, a.ImageURL, a.Disambiguation,
 		a.RatingsCount, a.AverageRating, a.Monitored, a.QualityProfileID, a.MetadataProfileID, a.RootFolderID,
-		a.AudiobookRootFolderID, a.MonitorMode, a.MonitorLatestCount, a.MetadataProvider, ownerArg, now, now)
+		a.AudiobookRootFolderID, a.MonitorMode, a.MonitorLatestCount, a.MetadataProvider, ownerArg, timeValueArg(now), timeValueArg(now))
 	if err != nil {
 		return fmt.Errorf("create author: %w", err)
 	}
@@ -293,7 +294,7 @@ func (r *AuthorRepo) UpgradeSyntheticDNB(ctx context.Context, currentForeignID s
 		target.ImageURL, target.ImageURL, // image_url
 		target.Disambiguation, target.Disambiguation, // disambiguation
 		target.MetadataProvider, // metadata_provider = COALESCE(NULLIF(?,''), metadata_provider)
-		now,                     // updated_at
+		timeValueArg(now),       // updated_at
 		currentForeignID)        // WHERE foreign_id = ?
 	if err != nil {
 		return fmt.Errorf("upgrade synthetic dnb author %q -> %q: %w", currentForeignID, target.ForeignID, err)
@@ -313,7 +314,7 @@ func (r *AuthorRepo) Update(ctx context.Context, a *models.Author) error {
 		a.ForeignID, a.Name, a.SortName, a.Description, a.ImageURL, a.Disambiguation,
 		a.RatingsCount, a.AverageRating, a.Monitored, a.QualityProfileID,
 		a.MetadataProfileID, a.RootFolderID, a.AudiobookRootFolderID, a.MonitorMode,
-		a.MonitorLatestCount, a.MetadataProvider, a.LastMetadataRefreshAt, now, a.ID)
+		a.MonitorLatestCount, a.MetadataProvider, timeArg(a.LastMetadataRefreshAt), timeValueArg(now), a.ID)
 	if err != nil {
 		return fmt.Errorf("update author %d: %w", a.ID, err)
 	}
@@ -381,7 +382,7 @@ func (r *AuthorRepo) SetMonitoredSeriesIDs(ctx context.Context, authorID int64, 
 				continue
 			}
 			seen[id] = struct{}{}
-			if _, err := stmt.ExecContext(ctx, authorID, id, now); err != nil {
+			if _, err := stmt.ExecContext(ctx, authorID, id, timeValueArg(now)); err != nil {
 				return fmt.Errorf("insert monitored series (%d, %d): %w", authorID, id, err)
 			}
 		}
@@ -393,30 +394,44 @@ func (r *AuthorRepo) SetMonitoredSeriesIDs(ctx context.Context, authorID int64, 
 	return nil
 }
 
+// rowScanner is the common subset of *sql.Rows and *sql.Row used by the
+// author scan helpers so a single implementation handles both shapes.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
 func scanAuthor(rows *sql.Rows) (models.Author, error) {
-	var a models.Author
-	var monitored int
-	err := rows.Scan(&a.ID, &a.ForeignID, &a.Name, &a.SortName, &a.Description, &a.ImageURL,
-		&a.Disambiguation, &a.RatingsCount, &a.AverageRating, &monitored,
-		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.AudiobookRootFolderID,
-		&a.MonitorMode, &a.MonitorLatestCount, &a.MetadataProvider,
-		&a.LastMetadataRefreshAt, &a.CreatedAt, &a.UpdatedAt, &a.OwnerUserID)
-	a.Monitored = monitored == 1
-	normalizeAuthorMonitorDefaults(&a)
-	return a, err
+	return scanAuthorFrom(rows)
 }
 
 func scanAuthorRow(row *sql.Row) (models.Author, error) {
+	return scanAuthorFrom(row)
+}
+
+func scanAuthorFrom(s rowScanner) (models.Author, error) {
 	var a models.Author
 	var monitored int
-	err := row.Scan(&a.ID, &a.ForeignID, &a.Name, &a.SortName, &a.Description, &a.ImageURL,
+	// Time columns scanned as strings + parseFlexibleTime so legacy rows
+	// written by Go's default time.String() shape (#914) still load.
+	var lastMetadataRefreshAtStr, createdAtStr, updatedAtStr sql.NullString
+	err := s.Scan(&a.ID, &a.ForeignID, &a.Name, &a.SortName, &a.Description, &a.ImageURL,
 		&a.Disambiguation, &a.RatingsCount, &a.AverageRating, &monitored,
 		&a.QualityProfileID, &a.MetadataProfileID, &a.RootFolderID, &a.AudiobookRootFolderID,
 		&a.MonitorMode, &a.MonitorLatestCount, &a.MetadataProvider,
-		&a.LastMetadataRefreshAt, &a.CreatedAt, &a.UpdatedAt, &a.OwnerUserID)
+		&lastMetadataRefreshAtStr, &createdAtStr, &updatedAtStr, &a.OwnerUserID)
+	if err != nil {
+		return a, err
+	}
+	if lm, perr := parseFlexibleTime(lastMetadataRefreshAtStr); perr != nil {
+		slog.Warn("unparseable author.last_metadata_refresh_at, leaving nil", "author_id", a.ID, "value", lastMetadataRefreshAtStr.String, "error", perr)
+	} else {
+		a.LastMetadataRefreshAt = lm
+	}
+	a.CreatedAt = parseFlexibleTimeValue(createdAtStr, "authors.created_at")
+	a.UpdatedAt = parseFlexibleTimeValue(updatedAtStr, "authors.updated_at")
 	a.Monitored = monitored == 1
 	normalizeAuthorMonitorDefaults(&a)
-	return a, err
+	return a, nil
 }
 
 func normalizeAuthorMonitorDefaults(a *models.Author) {

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -6,10 +6,93 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
 )
+
+// timeArg formats a *time.Time argument for SQLite as RFC3339Nano (in UTC).
+// The modernc.org/sqlite driver round-trips that shape cleanly back into
+// time.Time on Scan. Passing the raw *time.Time would make database/sql
+// fall through to time.Time.String(), which produces
+// `2006-01-02 15:04:05 +0000 UTC`; that shape fails to Scan back, which is
+// the root cause of #914 (book list 500s after Calibre imports).
+//
+// Nil and zero values are returned as nil so the column is stored as NULL.
+func timeArg(t *time.Time) any {
+	if t == nil || t.IsZero() {
+		return nil
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// timeValueArg is the non-pointer sibling of timeArg, used for columns that
+// are always populated (created_at, updated_at).
+func timeValueArg(t time.Time) any {
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// timeParseLayouts is the ordered set of layouts parseFlexibleTime walks
+// when decoding a time string from SQLite. The list covers every shape
+// Bindery has historically written into time columns plus the formats
+// Calibre's own metadata.db has shipped over the years:
+//
+//   - RFC3339Nano / RFC3339: the canonical shape (what timeArg now writes).
+//   - Go's default time.String() output, with and without sub-second
+//     precision: written by older Bindery versions that handed a raw
+//     time.Time to ExecContext, which is the #914 corruption.
+//   - Calibre's pubdate shape with a `+00:00` offset and no `T` separator.
+//   - SQLite's CURRENT_TIMESTAMP shape (no zone).
+var timeParseLayouts = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02 15:04:05.999999999 -0700 MST",
+	"2006-01-02 15:04:05 -0700 MST",
+	"2006-01-02 15:04:05.999999999-07:00",
+	"2006-01-02 15:04:05-07:00",
+	"2006-01-02 15:04:05+00:00",
+	"2006-01-02 15:04:05",
+	"2006-01-02",
+}
+
+// parseFlexibleTime parses a time string scanned out of SQLite, tolerating
+// every layout Bindery or Calibre has ever written into a time column.
+// Returns (nil, nil) for the empty / NULL case and a UTC-normalised
+// *time.Time on a successful parse.
+//
+// The fallback shields the Books page (#914) from rows whose release_date
+// or last_metadata_refresh_at were written by an older Bindery build that
+// stored `2006-01-02 15:04:05 +0000 UTC` (Go's default time.String shape),
+// which the modernc.org/sqlite driver refuses to Scan back into time.Time.
+func parseFlexibleTime(s sql.NullString) (*time.Time, error) {
+	if !s.Valid || s.String == "" {
+		return nil, nil
+	}
+	for _, layout := range timeParseLayouts {
+		if t, err := time.Parse(layout, s.String); err == nil {
+			u := t.UTC()
+			return &u, nil
+		}
+	}
+	return nil, fmt.Errorf("cannot parse time %q", s.String)
+}
+
+// parseFlexibleTimeValue is the non-pointer flavour, used for columns
+// that are always populated (created_at, updated_at). A failed parse or
+// a NULL row produces the zero time.Time rather than an error so a single
+// corrupt row does not kill the entire list query.
+func parseFlexibleTimeValue(s sql.NullString, columnHint string) time.Time {
+	t, err := parseFlexibleTime(s)
+	if err != nil {
+		slog.Warn("unparseable time value, substituting zero", "column", columnHint, "value", s.String, "error", err)
+		return time.Time{}
+	}
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
 
 type BookRepo struct {
 	db    *sql.DB
@@ -207,10 +290,10 @@ func (r *BookRepo) Create(ctx context.Context, b *models.Book) error {
 		                   metadata_provider, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		b.ForeignID, b.AuthorID, b.Title, b.SortTitle, b.OriginalTitle, b.Description,
-		b.ImageURL, b.ReleaseDate, string(genresJSON), b.AverageRating, b.RatingsCount,
+		b.ImageURL, timeArg(b.ReleaseDate), string(genresJSON), b.AverageRating, b.RatingsCount,
 		b.Monitored, b.Status, b.AnyEditionOK, b.SelectedEditionID,
 		b.Language, mediaType, b.Narrator, b.DurationSeconds, b.ASIN,
-		b.MetadataProvider, now, now)
+		b.MetadataProvider, timeValueArg(now), timeValueArg(now))
 	if err != nil {
 		return fmt.Errorf("create book: %w", err)
 	}
@@ -246,10 +329,10 @@ func (r *BookRepo) Update(ctx context.Context, b *models.Book) error {
 		                 ebook_file_path=?, audiobook_file_path=?
 		WHERE id=?`,
 		b.ForeignID, b.AuthorID, b.Title, b.SortTitle, b.OriginalTitle, b.Description, b.ImageURL,
-		b.ReleaseDate, string(genresJSON), b.AverageRating, b.RatingsCount,
+		timeArg(b.ReleaseDate), string(genresJSON), b.AverageRating, b.RatingsCount,
 		b.Monitored, b.Status, b.AnyEditionOK, b.SelectedEditionID,
 		b.FilePath, b.Language, mediaType, b.Narrator, b.DurationSeconds, b.ASIN,
-		b.MetadataProvider, b.LastMetadataRefreshAt, now,
+		b.MetadataProvider, timeArg(b.LastMetadataRefreshAt), timeValueArg(now),
 		b.EbookFilePath, b.AudiobookFilePath, b.ID)
 	if err != nil {
 		return fmt.Errorf("update book %d: %w", b.ID, err)
@@ -264,7 +347,7 @@ func (r *BookRepo) MarkWantedMonitored(ctx context.Context, id int64) error {
 	now := time.Now().UTC()
 	_, err := r.db.ExecContext(ctx,
 		`UPDATE books SET status = ?, monitored = 1, updated_at = ? WHERE id = ?`,
-		models.BookStatusWanted, now, id)
+		models.BookStatusWanted, timeValueArg(now), id)
 	if err != nil {
 		return fmt.Errorf("mark book %d wanted: %w", id, err)
 	}
@@ -439,7 +522,7 @@ func (r *BookRepo) SetExcluded(ctx context.Context, id int64, excluded bool) err
 	if excluded {
 		v = 1
 	}
-	_, err := r.db.ExecContext(ctx, "UPDATE books SET excluded=?, updated_at=? WHERE id=?", v, time.Now().UTC(), id)
+	_, err := r.db.ExecContext(ctx, "UPDATE books SET excluded=?, updated_at=? WHERE id=?", v, timeValueArg(time.Now().UTC()), id)
 	return err
 }
 
@@ -467,19 +550,24 @@ func (r *BookRepo) query(ctx context.Context, q string, args []any) ([]models.Bo
 		var b models.Book
 		var monitored, anyEditionOK, excluded int
 		var genresStr string
+		// Time columns are scanned as strings and parsed via
+		// parseFlexibleTime so legacy rows written by Go's default
+		// time.String() shape (the #914 corruption) still load.
+		var releaseDateStr, lastMetadataRefreshAtStr sql.NullString
+		var createdAtStr, updatedAtStr sql.NullString
 		// Author columns from the LEFT JOIN. Nullable since the join may not
 		// match when author_id points at a deleted author row.
 		var authorID sql.NullInt64
 		var authorForeignID, authorName, authorSortName sql.NullString
 		err := rows.Scan(
 			&b.ID, &b.ForeignID, &b.AuthorID, &b.Title, &b.SortTitle,
-			&b.OriginalTitle, &b.Description, &b.ImageURL, &b.ReleaseDate,
+			&b.OriginalTitle, &b.Description, &b.ImageURL, &releaseDateStr,
 			&genresStr, &b.AverageRating, &b.RatingsCount,
 			&monitored, &b.Status, &anyEditionOK, &b.SelectedEditionID,
 			&b.FilePath, &b.Language, &b.MediaType,
 			&b.Narrator, &b.DurationSeconds, &b.ASIN,
-			&b.CalibreID, &b.MetadataProvider, &b.LastMetadataRefreshAt,
-			&b.CreatedAt, &b.UpdatedAt,
+			&b.CalibreID, &b.MetadataProvider, &lastMetadataRefreshAtStr,
+			&createdAtStr, &updatedAtStr,
 			&b.EbookFilePath, &b.AudiobookFilePath,
 			&excluded,
 			&authorID, &authorForeignID, &authorName, &authorSortName,
@@ -488,6 +576,22 @@ func (r *BookRepo) query(ctx context.Context, q string, args []any) ([]models.Bo
 		if err != nil {
 			return nil, fmt.Errorf("scan book: %w", err)
 		}
+		// parseFlexibleTime tolerates the Calibre and legacy-Go date
+		// shapes (#914). On a truly garbage value we log and substitute
+		// nil / zero so a single corrupt row does not blank out the
+		// entire Books page.
+		if rd, perr := parseFlexibleTime(releaseDateStr); perr != nil {
+			slog.Warn("unparseable book.release_date, leaving nil", "book_id", b.ID, "value", releaseDateStr.String, "error", perr)
+		} else {
+			b.ReleaseDate = rd
+		}
+		if lm, perr := parseFlexibleTime(lastMetadataRefreshAtStr); perr != nil {
+			slog.Warn("unparseable book.last_metadata_refresh_at, leaving nil", "book_id", b.ID, "value", lastMetadataRefreshAtStr.String, "error", perr)
+		} else {
+			b.LastMetadataRefreshAt = lm
+		}
+		b.CreatedAt = parseFlexibleTimeValue(createdAtStr, "books.created_at")
+		b.UpdatedAt = parseFlexibleTimeValue(updatedAtStr, "books.updated_at")
 		b.Monitored = monitored == 1
 		b.AnyEditionOK = anyEditionOK == 1
 		b.Excluded = excluded == 1

--- a/internal/db/books_coverage_test.go
+++ b/internal/db/books_coverage_test.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -311,5 +313,171 @@ func TestBookRepo_ListHandlesOrphanAuthorID(t *testing.T) {
 	}
 	if all[0].AuthorID != 99999 {
 		t.Errorf("AuthorID should be preserved; got %d", all[0].AuthorID)
+	}
+}
+
+// TestBook_ScansLegacyGoStringFormat pins down the #914 regression: rows
+// whose release_date was written as Go's default time.String() shape
+// (`2006-01-02 15:04:05 +0000 UTC`) must still load via the Scan helper.
+// Before the parseFlexibleTime fallback, modernc.org/sqlite returned
+// "unsupported Scan" and the Books page rendered blank.
+func TestBook_ScansLegacyGoStringFormat(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := mkAuthor(t, authorRepo, ctx, "OL-LEGACY-A")
+	b := mkBook(t, bookRepo, ctx, a.ID, "OL-LEGACY-B", "Legacy Book", models.BookStatusWanted)
+
+	// Overwrite release_date with the Go-default shape that modernc rejects.
+	const legacy = "2024-01-15 12:34:56 +0000 UTC"
+	if _, err := database.ExecContext(ctx,
+		"UPDATE books SET release_date = ? WHERE id = ?", legacy, b.ID); err != nil {
+		t.Fatalf("seed legacy date: %v", err)
+	}
+
+	got, err := bookRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("List should tolerate legacy date format, got: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 book, got %d", len(got))
+	}
+	if got[0].ReleaseDate == nil {
+		t.Fatal("expected ReleaseDate populated from legacy format, got nil")
+	}
+	if got[0].ReleaseDate.Year() != 2024 || got[0].ReleaseDate.Month() != time.January || got[0].ReleaseDate.Day() != 15 {
+		t.Errorf("ReleaseDate mis-parsed: got %v", got[0].ReleaseDate)
+	}
+}
+
+// TestBook_ScansCalibrePubdateFormat covers the format Calibre itself
+// emits into metadata.db for pubdate (`+00:00` offset, space separator,
+// no `T`). When that value flows through a Calibre import and gets
+// stored back in books.release_date, the Scan path must still load it.
+func TestBook_ScansCalibrePubdateFormat(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := mkAuthor(t, authorRepo, ctx, "OL-CAL-A")
+	b := mkBook(t, bookRepo, ctx, a.ID, "OL-CAL-B", "Calibre Book", models.BookStatusWanted)
+
+	const calibreShape = "2024-01-15 12:34:56+00:00"
+	if _, err := database.ExecContext(ctx,
+		"UPDATE books SET release_date = ? WHERE id = ?", calibreShape, b.ID); err != nil {
+		t.Fatalf("seed calibre date: %v", err)
+	}
+
+	got, err := bookRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("List should tolerate calibre date format, got: %v", err)
+	}
+	if len(got) != 1 || got[0].ReleaseDate == nil {
+		t.Fatalf("expected book with non-nil ReleaseDate, got %+v", got)
+	}
+	if got[0].ReleaseDate.Year() != 2024 {
+		t.Errorf("ReleaseDate mis-parsed: got %v", got[0].ReleaseDate)
+	}
+}
+
+// TestBook_WriteRoundTripUsesRFC3339Nano guarantees the write side stores
+// release_date in a shape modernc.org/sqlite can Scan back without help.
+// If a future change reintroduces the raw *time.Time argument, the stored
+// string will revert to Go's default shape and this test fails.
+func TestBook_WriteRoundTripUsesRFC3339Nano(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := mkAuthor(t, authorRepo, ctx, "OL-RT-A")
+
+	when := time.Date(2024, 1, 15, 12, 34, 56, 0, time.UTC)
+	b := &models.Book{
+		ForeignID:        "OL-RT-B",
+		AuthorID:         a.ID,
+		Title:            "Round Trip",
+		SortTitle:        "Round Trip",
+		Status:           models.BookStatusWanted,
+		Genres:           []string{},
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+		ReleaseDate:      &when,
+	}
+	if err := bookRepo.Create(ctx, b); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var stored string
+	if err := database.QueryRowContext(ctx,
+		"SELECT release_date FROM books WHERE id = ?", b.ID).Scan(&stored); err != nil {
+		t.Fatalf("read raw release_date: %v", err)
+	}
+	if strings.Contains(stored, "+0000 UTC") || strings.Contains(stored, " UTC") {
+		t.Errorf("stored release_date used Go default shape %q; want RFC3339Nano", stored)
+	}
+	if _, perr := time.Parse(time.RFC3339Nano, stored); perr != nil {
+		t.Errorf("stored release_date %q does not parse as RFC3339Nano: %v", stored, perr)
+	}
+
+	// Also confirm created_at / updated_at went through the same path.
+	var createdAt, updatedAt string
+	if err := database.QueryRowContext(ctx,
+		"SELECT created_at, updated_at FROM books WHERE id = ?", b.ID).Scan(&createdAt, &updatedAt); err != nil {
+		t.Fatalf("read created_at/updated_at: %v", err)
+	}
+	for name, v := range map[string]string{"created_at": createdAt, "updated_at": updatedAt} {
+		if strings.Contains(v, " UTC") {
+			t.Errorf("%s stored Go default shape %q; want RFC3339Nano", name, v)
+		}
+	}
+}
+
+// TestBook_GarbageInTimeColumnDoesNotKillScan checks the
+// log-and-substitute behaviour: a single unparseable time string must
+// not take out the whole list query. The row still shows up; the bad
+// column resolves to nil (for *time.Time) or zero (for time.Time).
+func TestBook_GarbageInTimeColumnDoesNotKillScan(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := mkAuthor(t, authorRepo, ctx, "OL-GARBAGE-A")
+	b := mkBook(t, bookRepo, ctx, a.ID, "OL-GARBAGE-B", "Garbage Book", models.BookStatusWanted)
+
+	if _, err := database.ExecContext(ctx,
+		"UPDATE books SET release_date = ? WHERE id = ?", "not a date", b.ID); err != nil {
+		t.Fatalf("seed garbage date: %v", err)
+	}
+
+	got, err := bookRepo.List(ctx)
+	if err != nil {
+		t.Fatalf("List should tolerate garbage time, got: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 book despite garbage release_date, got %d", len(got))
+	}
+	if got[0].ReleaseDate != nil {
+		t.Errorf("expected nil ReleaseDate for garbage value, got %v", got[0].ReleaseDate)
 	}
 }

--- a/internal/db/editions.go
+++ b/internal/db/editions.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -43,19 +44,13 @@ func (r *EditionRepo) GetByForeignID(ctx context.Context, foreignID string) (*mo
 		       publish_date, format, num_pages, language, image_url, is_ebook,
 		       edition_info, monitored, created_at, updated_at
 		FROM editions WHERE foreign_id = ?`, foreignID)
-	var e models.Edition
-	var isEbook, monitored int
-	err := row.Scan(&e.ID, &e.ForeignID, &e.BookID, &e.Title, &e.ISBN13, &e.ISBN10,
-		&e.ASIN, &e.Publisher, &e.PublishDate, &e.Format, &e.NumPages, &e.Language,
-		&e.ImageURL, &isEbook, &e.EditionInfo, &monitored, &e.CreatedAt, &e.UpdatedAt)
+	e, err := scanEditionFrom(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get edition %s: %w", foreignID, err)
 	}
-	e.IsEbook = isEbook == 1
-	e.Monitored = monitored == 1
 	return &e, nil
 }
 
@@ -73,15 +68,10 @@ func (r *EditionRepo) ListByBook(ctx context.Context, bookID int64) ([]models.Ed
 
 	var out []models.Edition
 	for rows.Next() {
-		var e models.Edition
-		var isEbook, monitored int
-		if err := rows.Scan(&e.ID, &e.ForeignID, &e.BookID, &e.Title, &e.ISBN13, &e.ISBN10,
-			&e.ASIN, &e.Publisher, &e.PublishDate, &e.Format, &e.NumPages, &e.Language,
-			&e.ImageURL, &isEbook, &e.EditionInfo, &monitored, &e.CreatedAt, &e.UpdatedAt); err != nil {
+		e, err := scanEditionFrom(rows)
+		if err != nil {
 			return nil, fmt.Errorf("scan edition: %w", err)
 		}
-		e.IsEbook = isEbook == 1
-		e.Monitored = monitored == 1
 		out = append(out, e)
 	}
 	return out, rows.Err()
@@ -124,8 +114,8 @@ func (r *EditionRepo) Upsert(ctx context.Context, e *models.Edition) error {
 		    language    = excluded.language,
 		    updated_at  = excluded.updated_at`,
 		e.ForeignID, e.BookID, e.Title, e.ISBN13, e.ISBN10, e.ASIN,
-		e.Publisher, e.PublishDate, e.Format, e.NumPages, e.Language,
-		e.ImageURL, isEbook, e.EditionInfo, monitored, now, now)
+		e.Publisher, timeArg(e.PublishDate), e.Format, e.NumPages, e.Language,
+		e.ImageURL, isEbook, e.EditionInfo, monitored, timeValueArg(now), timeValueArg(now))
 	if err != nil {
 		return fmt.Errorf("upsert edition %s: %w", e.ForeignID, err)
 	}
@@ -186,8 +176,8 @@ func (r *EditionRepo) UpsertMetadata(ctx context.Context, e *models.Edition) (bo
 		    updated_at  = excluded.updated_at
 		WHERE editions.book_id = excluded.book_id`,
 		e.ForeignID, e.BookID, e.Title, e.ISBN13, e.ISBN10, e.ASIN,
-		e.Publisher, e.PublishDate, e.Format, e.NumPages, e.Language,
-		e.ImageURL, isEbook, e.EditionInfo, monitored, now, now)
+		e.Publisher, timeArg(e.PublishDate), e.Format, e.NumPages, e.Language,
+		e.ImageURL, isEbook, e.EditionInfo, monitored, timeValueArg(now), timeValueArg(now))
 	if err != nil {
 		return false, fmt.Errorf("upsert metadata edition %s: %w", e.ForeignID, err)
 	}
@@ -204,23 +194,41 @@ func (r *EditionRepo) UpsertMetadata(ctx context.Context, e *models.Edition) (bo
 		       publish_date, format, num_pages, language, image_url, is_ebook,
 		       edition_info, monitored, created_at, updated_at
 		FROM editions WHERE foreign_id = ?`, e.ForeignID)
-	var stored models.Edition
-	var isStoredEbook, storedMonitored int
-	if err := row.Scan(&stored.ID, &stored.ForeignID, &stored.BookID, &stored.Title,
-		&stored.ISBN13, &stored.ISBN10, &stored.ASIN, &stored.Publisher,
-		&stored.PublishDate, &stored.Format, &stored.NumPages, &stored.Language,
-		&stored.ImageURL, &isStoredEbook, &stored.EditionInfo, &storedMonitored,
-		&stored.CreatedAt, &stored.UpdatedAt); err != nil {
+	stored, err := scanEditionFrom(row)
+	if err != nil {
 		return false, fmt.Errorf("lookup metadata edition %s: %w", e.ForeignID, err)
 	}
-	stored.IsEbook = isStoredEbook == 1
-	stored.Monitored = storedMonitored == 1
 	if stored.BookID != e.BookID {
 		e.ID = 0
 		return false, nil
 	}
 	*e = stored
 	return true, nil
+}
+
+// scanEditionFrom decodes an editions row using parseFlexibleTime for the
+// three time-typed columns so legacy rows written by Go's default
+// time.String shape, or by Calibre's own pubdate writer, still Scan
+// successfully (#914 root cause).
+func scanEditionFrom(s rowScanner) (models.Edition, error) {
+	var e models.Edition
+	var isEbook, monitored int
+	var publishDateStr, createdAtStr, updatedAtStr sql.NullString
+	if err := s.Scan(&e.ID, &e.ForeignID, &e.BookID, &e.Title, &e.ISBN13, &e.ISBN10,
+		&e.ASIN, &e.Publisher, &publishDateStr, &e.Format, &e.NumPages, &e.Language,
+		&e.ImageURL, &isEbook, &e.EditionInfo, &monitored, &createdAtStr, &updatedAtStr); err != nil {
+		return e, err
+	}
+	if pd, perr := parseFlexibleTime(publishDateStr); perr != nil {
+		slog.Warn("unparseable edition.publish_date, leaving nil", "edition_id", e.ID, "value", publishDateStr.String, "error", perr)
+	} else {
+		e.PublishDate = pd
+	}
+	e.CreatedAt = parseFlexibleTimeValue(createdAtStr, "editions.created_at")
+	e.UpdatedAt = parseFlexibleTimeValue(updatedAtStr, "editions.updated_at")
+	e.IsEbook = isEbook == 1
+	e.Monitored = monitored == 1
+	return e, nil
 }
 
 func (r *EditionRepo) Delete(ctx context.Context, id int64) error {


### PR DESCRIPTION
## Root cause

Reporter (commiepinko) traced #914: every book-list SQL query failed with `unsupported Scan` and the Books page rendered blank / the API 500'd. Calibre stores `pubdate` as `2006-01-02 15:04:05+00:00`. When Bindery read that and wrote it back via `*time.Time`, `database/sql` fell through to `time.Time.String()` and persisted `2006-01-02 15:04:05 +0000 UTC`. modernc.org/sqlite cannot Scan that shape back into a `*time.Time`, so every Scan blew up and the entire list query died.

## The two-sided fix

**Write side.** New `timeArg(*time.Time)` and `timeValueArg(time.Time)` helpers in `internal/db/books.go` format every time argument as `RFC3339Nano` (UTC), the canonical shape the driver round-trips cleanly. Applied at every Create / Update / Upsert / DML site that touches a time-typed column:

- `books.release_date`, `books.last_metadata_refresh_at`, `books.created_at`, `books.updated_at` (Create, Update, MarkWantedMonitored, SetExcluded).
- `authors.last_metadata_refresh_at`, `authors.created_at`, `authors.updated_at` (CreateForUser, UpgradeSyntheticDNB, Update), plus `author_monitored_series.created_at`.
- `editions.publish_date`, `editions.created_at`, `editions.updated_at` (Upsert, UpsertMetadata).

**Read side.** Every time column is now scanned into `sql.NullString` and parsed via `parseFlexibleTime`, which walks an ordered layout list:

- `time.RFC3339Nano` / `time.RFC3339` (canonical shape, what we now write).
- Go's default `time.String()` output with and without sub-second precision (the #914 corruption shape).
- The Calibre `+00:00` shape with no `T` separator.
- The SQLite default (no zone).
- All-day `2006-01-02`.

Unparseable values log a WARN and resolve to nil (for `*time.Time`) or the zero `time.Time` (for non-pointer columns) so a single corrupt row does not blank out the entire Books page. Author and edition scans share a `rowScanner` interface so the same helper backs both `*sql.Rows` and `*sql.Row` callers.

## Scope

`parseFlexibleTime` treatment applied to:

- `internal/db/books.go` (BookRepo.query, all list / get paths).
- `internal/db/authors.go` (scanAuthor, scanAuthorRow via shared `scanAuthorFrom`).
- `internal/db/editions.go` (GetByForeignID, ListByBook, UpsertMetadata lookup via shared `scanEditionFrom`).

Other repos that select `books.release_date` (e.g. `series.go`, `recommendations.go`) use `sql.NullTime`. They are not in the #914 reproducer path (the Books page goes through `BookRepo.List` / `ListPage`), so they are left alone for now. Worth a follow-up audit if related Scan errors surface.

## Test plan

New tests in `internal/db/books_coverage_test.go`:

- [x] `TestBook_ScansLegacyGoStringFormat`: seeds `release_date = '2024-01-15 12:34:56 +0000 UTC'` (the #914 shape), calls `BookRepo.List`, asserts the row loads and the date parses.
- [x] `TestBook_ScansCalibrePubdateFormat`: same with `'2024-01-15 12:34:56+00:00'`.
- [x] `TestBook_WriteRoundTripUsesRFC3339Nano`: Create a book with a `ReleaseDate`, raw-SELECT `release_date` / `created_at` / `updated_at`, assert none contain ` UTC` and `release_date` parses as RFC3339Nano. This pins the write side so a regression cannot reintroduce the corrupt shape.
- [x] `TestBook_GarbageInTimeColumnDoesNotKillScan`: seeds `release_date = 'not a date'`, asserts `List` still returns the row with `ReleaseDate == nil` and no error bubbles up.

All four pass; the full `./internal/db/...` and `./...` suites stay green.

## Why migration was skipped

The reporter suggested running a SQL UPDATE to clean up bad strings in place. The Scan-side fallback already covers every legacy row on read, and the write-side fix prevents new bad rows from being persisted, so a one-shot UPDATE that touches every row in the DB is heavier than needed and would surprise upgraders. Easy to add later as a gated startup repair if some user reports symptoms the fallback misses.

Closes #914.