### PR TITLE
feat(blocklist): add created_by_user_id audit column (D4b, audit follow-up)

### DIFF
--- a/internal/api/history.go
+++ b/internal/api/history.go
@@ -167,7 +167,18 @@ func (h *HistoryHandler) Blocklist(w http.ResponseWriter, r *http.Request) {
 		Title:  event.SourceTitle,
 		Reason: event.EventType,
 	}
-	if err := h.blocklist.Create(r.Context(), entry); err != nil {
+	// D4b audit: this is a user-driven write (someone pressed "Blocklist" in
+	// the history UI), so tag the row with their id. The list/IsBlocked
+	// queries are global and don't read this column; it's surfaced through
+	// the API for admin views only. UserIDFromContext returns 0 for
+	// unauthenticated requests, in which case fall back to the system-write
+	// path so we don't insert a fake user id.
+	if uid := auth.UserIDFromContext(r.Context()); uid != 0 {
+		err = h.blocklist.CreateByUser(r.Context(), entry, uid)
+	} else {
+		err = h.blocklist.Create(r.Context(), entry)
+	}
+	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}

--- a/internal/api/history_test.go
+++ b/internal/api/history_test.go
@@ -267,6 +267,91 @@ func TestHistoryBlocklist_NotFound(t *testing.T) {
 	}
 }
 
+// TestBlocklistHandler_HistoryBlocklistRecordsCaller covers the D4b audit
+// contract end-to-end: when an authenticated user promotes a history event
+// to the blocklist, the persisted row carries their uid in
+// created_by_user_id. The handler decides this from the request context, so
+// the test drives it with an auth-tagged ctx and asserts the row in the
+// repo.
+func TestBlocklistHandler_HistoryBlocklistRecordsCaller(t *testing.T) {
+	// Use OpenMemory directly so we can seed a real user before the
+	// handler writes the audit row. The blocklist.created_by_user_id FK
+	// to users(id) means a synthetic uid would trip the constraint.
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	ctx := context.Background()
+	users := db.NewUserRepo(database)
+	u, err := users.Create(ctx, "audit-alice", "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	history := db.NewHistoryRepo(database)
+	blocklist := db.NewBlocklistRepo(database)
+	h := NewHistoryHandler(history, blocklist)
+
+	data, _ := json.Marshal(map[string]any{"guid": "nzb-guid-d4b"})
+	e := &models.HistoryEvent{
+		EventType: models.HistoryEventGrabbed, SourceTitle: "Tagged Release",
+		Data: string(data),
+	}
+	if err := history.Create(ctx, e); err != nil {
+		t.Fatal(err)
+	}
+	req := withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/history/"+strconv.FormatInt(e.ID, 10)+"/blocklist", nil), "id", strconv.FormatInt(e.ID, 10))
+	// Tag the request ctx with a user id so the handler routes through
+	// CreateByUser. Role is irrelevant here; the audit write happens
+	// regardless of role.
+	reqCtx := auth.WithUserID(req.Context(), u.ID)
+	rec := httptest.NewRecorder()
+	h.Blocklist(rec, req.WithContext(reqCtx))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	entries, err := blocklist.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 blocklist row, got %d", len(entries))
+	}
+	if entries[0].CreatedByUserID == nil || *entries[0].CreatedByUserID != u.ID {
+		t.Errorf("expected CreatedByUserID=%d, got %v", u.ID, entries[0].CreatedByUserID)
+	}
+}
+
+// TestBlocklistHandler_HistoryBlocklistAnonymousFallsBackToSystem asserts
+// the handler does not invent a fake uid when the request context has no
+// authenticated user (UserIDFromContext returns 0). The row is still
+// created (preserving the legacy unauth-friendly behavior), but the audit
+// column stays NULL like a system-write.
+func TestBlocklistHandler_HistoryBlocklistAnonymousFallsBackToSystem(t *testing.T) {
+	h, history, blocklist, ctx := historyFixture(t)
+	data, _ := json.Marshal(map[string]any{"guid": "nzb-guid-anon"})
+	e := &models.HistoryEvent{
+		EventType: models.HistoryEventGrabbed, SourceTitle: "Anon Release",
+		Data: string(data),
+	}
+	if err := history.Create(ctx, e); err != nil {
+		t.Fatal(err)
+	}
+	req := withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/history/"+strconv.FormatInt(e.ID, 10)+"/blocklist", nil), "id", strconv.FormatInt(e.ID, 10))
+	rec := httptest.NewRecorder()
+	h.Blocklist(rec, req) // no ctx auth tagging
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	entries, _ := blocklist.List(ctx)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 blocklist row, got %d", len(entries))
+	}
+	if entries[0].CreatedByUserID != nil {
+		t.Errorf("expected CreatedByUserID=nil for anonymous caller, got %v", *entries[0].CreatedByUserID)
+	}
+}
+
 // --- D3 per-user scoping ---------------------------------------------------
 
 // seedTwoUserHistory creates two users, an owned book each, and one history

--- a/internal/db/blocklist.go
+++ b/internal/db/blocklist.go
@@ -9,6 +9,11 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
+// blocklistColumns is the canonical column list shared between the writer and
+// the reader paths. Keep it aligned with the Scan order in query() and with
+// the INSERT shape in create().
+const blocklistColumns = "id, book_id, guid, title, indexer_id, reason, created_at, created_by_user_id"
+
 type BlocklistRepo struct {
 	db *sql.DB
 }
@@ -17,12 +22,31 @@ func NewBlocklistRepo(db *sql.DB) *BlocklistRepo {
 	return &BlocklistRepo{db: db}
 }
 
+// Create inserts a system-attributed blocklist row. The audit column
+// created_by_user_id is left NULL. Use this path from non-user-driven
+// writers (scheduler stall-detection, readarr import migration) where no
+// caller user identity exists. For user-driven writes (e.g. the history
+// handler's "blocklist this release" action) use CreateByUser so the audit
+// column records who pressed the button.
 func (r *BlocklistRepo) Create(ctx context.Context, e *models.BlocklistEntry) error {
+	return r.create(ctx, e, nil)
+}
+
+// CreateByUser inserts a blocklist row tagged with the supplied user id. The
+// row is otherwise identical to one written by Create: the BlocklistedSpec
+// decision matcher and IsBlocked / List queries are global on purpose, so
+// the audit column is metadata only. See migration 049 for the rationale.
+func (r *BlocklistRepo) CreateByUser(ctx context.Context, e *models.BlocklistEntry, userID int64) error {
+	uid := userID
+	return r.create(ctx, e, &uid)
+}
+
+func (r *BlocklistRepo) create(ctx context.Context, e *models.BlocklistEntry, userID *int64) error {
 	now := time.Now().UTC()
 	result, err := r.db.ExecContext(ctx, `
-		INSERT INTO blocklist (book_id, guid, title, indexer_id, reason, created_at)
-		VALUES (?, ?, ?, ?, ?, ?)`,
-		e.BookID, e.GUID, e.Title, e.IndexerID, e.Reason, now)
+		INSERT INTO blocklist (book_id, guid, title, indexer_id, reason, created_at, created_by_user_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		e.BookID, e.GUID, e.Title, e.IndexerID, e.Reason, now, userID)
 	if err != nil {
 		return fmt.Errorf("create blocklist entry: %w", err)
 	}
@@ -32,11 +56,12 @@ func (r *BlocklistRepo) Create(ctx context.Context, e *models.BlocklistEntry) er
 	}
 	e.ID = id
 	e.CreatedAt = now
+	e.CreatedByUserID = userID
 	return nil
 }
 
 func (r *BlocklistRepo) List(ctx context.Context) ([]models.BlocklistEntry, error) {
-	return r.query(ctx, "SELECT id, book_id, guid, title, indexer_id, reason, created_at FROM blocklist ORDER BY created_at DESC")
+	return r.query(ctx, "SELECT "+blocklistColumns+" FROM blocklist ORDER BY created_at DESC")
 }
 
 func (r *BlocklistRepo) IsBlocked(ctx context.Context, guid string) (bool, error) {
@@ -69,7 +94,7 @@ func (r *BlocklistRepo) query(ctx context.Context, q string, args ...interface{}
 	for rows.Next() {
 		var e models.BlocklistEntry
 		if err := rows.Scan(
-			&e.ID, &e.BookID, &e.GUID, &e.Title, &e.IndexerID, &e.Reason, &e.CreatedAt,
+			&e.ID, &e.BookID, &e.GUID, &e.Title, &e.IndexerID, &e.Reason, &e.CreatedAt, &e.CreatedByUserID,
 		); err != nil {
 			return nil, fmt.Errorf("scan blocklist entry: %w", err)
 		}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1443,6 +1443,115 @@ func TestBlocklistRepoCRUD(t *testing.T) {
 	}
 }
 
+// seedUser inserts a row in users and returns its id, so D4b audit tests
+// can pass the FK constraint on created_by_user_id.
+func seedUser(t *testing.T, ctx context.Context, database *sql.DB, username string) int64 {
+	t.Helper()
+	u, err := NewUserRepo(database).Create(ctx, username, "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u.ID
+}
+
+// TestBlocklist_CreateByUser_PopulatesAudit asserts the D4b audit column is
+// set to the caller's user id when a row is written via CreateByUser. This
+// is the user-driven write path (e.g. history -> blocklist promote).
+func TestBlocklist_CreateByUser_PopulatesAudit(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	uid := seedUser(t, ctx, database, "alice")
+	repo := NewBlocklistRepo(database)
+
+	entry := &models.BlocklistEntry{GUID: "g-user", Title: "by-user"}
+	if err := repo.CreateByUser(ctx, entry, uid); err != nil {
+		t.Fatalf("CreateByUser: %v", err)
+	}
+	if entry.CreatedByUserID == nil || *entry.CreatedByUserID != uid {
+		t.Errorf("in-memory entry: expected CreatedByUserID=%d, got %v", uid, entry.CreatedByUserID)
+	}
+	// Round-trip: List must hydrate the audit column too.
+	list, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(list))
+	}
+	if list[0].CreatedByUserID == nil || *list[0].CreatedByUserID != uid {
+		t.Errorf("listed entry: expected CreatedByUserID=%d, got %v", uid, list[0].CreatedByUserID)
+	}
+}
+
+// TestBlocklist_Create_LeavesAuditNull asserts the system-write path (used
+// by scheduler stall-detection and the readarr import migration) does not
+// fabricate an owner. NULL is the honest "unknown origin" answer.
+func TestBlocklist_Create_LeavesAuditNull(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewBlocklistRepo(database)
+
+	entry := &models.BlocklistEntry{GUID: "g-system", Title: "system"}
+	if err := repo.Create(ctx, entry); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if entry.CreatedByUserID != nil {
+		t.Errorf("in-memory entry: expected CreatedByUserID=nil, got %v", *entry.CreatedByUserID)
+	}
+	list, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(list))
+	}
+	if list[0].CreatedByUserID != nil {
+		t.Errorf("listed entry: expected CreatedByUserID=nil, got %v", *list[0].CreatedByUserID)
+	}
+}
+
+// TestBlocklist_IsBlocked_RemainsGlobal is the regression guard against
+// anyone "fixing" the audit column into per-user scoping. The decision spec
+// (internal/decision/specs.go) matches on GUID alone because a broken
+// release is broken for every user. A row written by user 1 must block
+// user 2's grab too. If this test ever needs to be relaxed, the deep audit
+// rationale in PR D4b should be revisited first.
+func TestBlocklist_IsBlocked_RemainsGlobal(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	uid := seedUser(t, ctx, database, "alice")
+	repo := NewBlocklistRepo(database)
+
+	entry := &models.BlocklistEntry{GUID: "g-shared", Title: "shared"}
+	if err := repo.CreateByUser(ctx, entry, uid); err != nil {
+		t.Fatalf("CreateByUser uid=%d: %v", uid, err)
+	}
+	// IsBlocked accepts only the GUID; it has no user-id parameter. Calling
+	// it after a write by user 1 must return true regardless of who's
+	// asking. The signature itself is the contract; this assertion guards
+	// the underlying COUNT(*) query against being narrowed by a future
+	// edit.
+	blocked, err := repo.IsBlocked(ctx, "g-shared")
+	if err != nil {
+		t.Fatalf("IsBlocked: %v", err)
+	}
+	if !blocked {
+		t.Error("expected IsBlocked(g-shared) to be true regardless of caller; got false")
+	}
+}
+
 func TestHistoryRepoCRUD(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {

--- a/internal/db/migrations/050_blocklist_created_by_user_id.sql
+++ b/internal/db/migrations/050_blocklist_created_by_user_id.sql
@@ -1,0 +1,28 @@
+-- +migrate Up
+-- D4b (deep audit follow-up). Adds an audit column recording which user
+-- promoted a row into the blocklist. Audit only. The decision spec
+-- (internal/decision/specs.go BlocklistedSpec) matches on GUID alone, so
+-- blocklist semantics stay global on purpose. A failed release (broken
+-- .nzb, virus, stalled grab) is broken for every user, and per-user
+-- blocklist would force user 2 to re-pay the cost of user 1's failed grab.
+--
+-- IsBlocked, List, BlocklistedSpec, DeleteByID and DeleteByBookID are NOT
+-- changed by this migration. The column is read by an admin view that
+-- displays "blocklisted by X" without altering query semantics.
+--
+-- No backfill. Existing rows predate the audit column and have no honest
+-- owner. Readarr-imported rows have book_id IS NULL and were never tied
+-- to a real user, and backfilling them to user 1 would lie about
+-- provenance. NULL means "unknown origin", which is the correct answer
+-- for legacy rows and for system-write paths (scheduler stall-detection,
+-- readarr import migration) that intentionally leave the field empty.
+ALTER TABLE blocklist ADD COLUMN created_by_user_id INTEGER REFERENCES users(id);
+CREATE INDEX IF NOT EXISTS idx_blocklist_created_by ON blocklist(created_by_user_id);
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS idx_blocklist_created_by;
+-- SQLite < 3.35 cannot DROP COLUMN. The forward migration is additive and
+-- defaults to NULL on existing rows so a rollback that leaves the column
+-- in place is a no-op for callers. If a true rollback is required, the
+-- operator must rebuild the table manually.

--- a/internal/models/blocklist.go
+++ b/internal/models/blocklist.go
@@ -10,4 +10,11 @@ type BlocklistEntry struct {
 	IndexerID *int64    `json:"indexerId"`
 	Reason    string    `json:"reason"`
 	CreatedAt time.Time `json:"createdAt"`
+	// CreatedByUserID records which user promoted this row into the blocklist.
+	// NULL for system-write paths (scheduler stall-detection, readarr import
+	// migration) and for legacy rows that predate migration 049. The field is
+	// audit-only: IsBlocked / List / BlocklistedSpec do not filter on it, and
+	// the blocklist remains global by design. See migration 049 for the
+	// rationale.
+	CreatedByUserID *int64 `json:"createdByUserId,omitempty"`
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1225,6 +1225,12 @@ export interface BlocklistEntry {
   indexerId?: number
   reason: string
   createdAt: string
+  // D4b audit. Surfaces who promoted this row into the blocklist. NULL
+  // for system-written rows (scheduler stall-detection, readarr migration)
+  // and for legacy rows that predate migration 049. Audit only; the list
+  // semantics remain global. The admin "blocklisted by X" UI consuming
+  // this field is a future task.
+  createdByUserId?: number | null
 }
 
 export interface NotificationConfig {


### PR DESCRIPTION
## Audit, not isolation

D4b is the audit follow-up to the deep-audit blocklist finding. The original D4 plan (per-user blocklist scoping) was rejected during the deep analysis pass because the blocklist is global *by design*, not by accident:

- The decision matcher in `internal/decision/specs.go` (`BlocklistedSpec`) keys on GUID alone. A broken release (corrupt `.nzb`, virus, stalled grab) is broken for every user. Per-user scoping would force user 2 to re-pay the cost of user 1's failed grab.
- `Scheduler.SearchAndGrabBook(ctx, book)` has no user identity threaded through it. The `models.Book` struct has no `OwnerUserID` field even though the column exists in the DB schema. Threading user identity into the spec would be a multi-PR refactor the maintainer hasn't asked for.
- Readarr-imported rows have `book_id IS NULL` and no real user attached. Backfilling them to user 1 would lie about provenance.

The right fix is to record *who* promoted a row into the blocklist, without changing *how* the queries work. That's what this PR does.

## Schema delta (migration 049)

```sql
ALTER TABLE blocklist ADD COLUMN created_by_user_id INTEGER REFERENCES users(id);
CREATE INDEX IF NOT EXISTS idx_blocklist_created_by ON blocklist(created_by_user_id);
```

Existing rows are **NOT** backfilled. NULL is the honest "unknown origin" answer for legacy rows and for system-write paths. The migration's `-- ` comment header documents the choice.

`IsBlocked`, `List`, `BlocklistedSpec`, `DeleteByID` and `DeleteByBookID` are unchanged.

## Two write paths

`BlocklistRepo` now exposes two writers, chosen by intent at the call site:

| Method | Audit | Used by |
| --- | --- | --- |
| `Create(ctx, entry)` | leaves `created_by_user_id` NULL | `scheduler.go` stall-detection, `migrate/readarr.go` import migration |
| `CreateByUser(ctx, entry, uid)` | tags row with `uid` | `api/history.go::Blocklist` (the user clicked "Blocklist" on a history event) |

The history handler resolves `auth.UserIDFromContext(ctx)` and routes to `CreateByUser` when the request is authenticated, falling back to `Create` for the legacy anonymous path so no fake uid is invented.

## Frontend

`web/src/api/client.ts` adds `createdByUserId?: number | null` to the `BlocklistEntry` interface so an admin view can display "blocklisted by X" later. **The admin UI itself is out of scope** and is the natural follow-up.

## Test plan

- [x] `TestBlocklist_CreateByUser_PopulatesAudit` (`internal/db`) — uid round-trips into the row.
- [x] `TestBlocklist_Create_LeavesAuditNull` (`internal/db`) — system write keeps audit NULL.
- [x] `TestBlocklist_IsBlocked_RemainsGlobal` (`internal/db`) — **regression guard.** Pins the global semantics so a future "fix" cannot quietly narrow `IsBlocked` into per-user scoping. If this test ever needs to be relaxed, the D4 deep-audit rationale must be revisited first.
- [x] `TestBlocklistHandler_HistoryBlocklistRecordsCaller` (`internal/api`) — end-to-end: authed history -> blocklist promote persists the caller's uid.
- [x] `TestBlocklistHandler_HistoryBlocklistAnonymousFallsBackToSystem` (`internal/api`) — no auth in ctx still succeeds, but the row's audit field stays NULL (no synthetic uid).
- [x] `go test ./...` clean.
- [x] `go vet ./...` clean.
- [x] `npm run typecheck` clean.

## Follow-ups

- Admin UI consuming `createdByUserId` ("blocklisted by X" column in the blocklist table).