### PR TITLE
fix: plumb app-lifetime context to bulk/author/calibre goroutines (closes #846)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -174,6 +174,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Process-lifecycle context. Unlike a per-request context this is not tied
+	// to any single HTTP request; it is cancelled when the process receives
+	// SIGINT/SIGTERM (graceful shutdown). Long-lived background goroutines —
+	// the scheduler's cron jobs, the recommendations refresh, and the bulk
+	// search fan-out — derive from this so they observe shutdown instead of
+	// running against a context that never cancels. See #550 and #846.
+	//
+	// Declared before any scheduler closure that needs to capture it (the
+	// Calibre mode resolver below) and threaded into NewBulkHandler/
+	// NewAuthorHandler/NewCalibreHandler/NewRecommendationHandler via the
+	// WithLifetimeCtx / WithAppContext builders.
+	appCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	// Parse trusted-proxy CIDRs once at startup (shared by trustedProxyMiddleware
 	// and the proxy-auth identity check).
 	trustedCIDRs := parseTrustedProxyCIDRs(os.Getenv("BINDERY_TRUSTED_PROXY"))
@@ -302,9 +316,14 @@ func main() {
 		},
 	)
 
-	modeResolver := func() calibre.Mode { return api.LoadCalibreMode(settingsRepo) }
-	calibreCfg := api.LoadCalibreConfig(settingsRepo)
-	currentMode := api.LoadCalibreMode(settingsRepo)
+	// The mode resolver is called from the importer on every scan; it must
+	// observe shutdown when the scheduler is mid-tick, so it captures appCtx
+	// (declared below) by closure rather than running on context.Background().
+	// The boot-time reads on the next two lines use ctxBoot because appCtx
+	// isn't constructed yet.
+	modeResolver := func() calibre.Mode { return api.LoadCalibreMode(appCtx, settingsRepo) }
+	calibreCfg := api.LoadCalibreConfig(ctxBoot, settingsRepo)
+	currentMode := api.LoadCalibreMode(ctxBoot, settingsRepo)
 	if currentMode == calibre.ModePlugin {
 		pluginClient := calibre.NewPluginClient(calibreCfg.PluginURL, calibreCfg.PluginAPIKey)
 		importScanner.WithCalibre(modeResolver, pluginClient)
@@ -348,11 +367,11 @@ func main() {
 		slog.Info("abs interrupted import resumed from checkpoint")
 	}
 	if syncOnStartup(settingsRepo) {
-		cfg := api.LoadCalibreConfig(settingsRepo)
+		cfg := api.LoadCalibreConfig(ctxBoot, settingsRepo)
 		if cfg.Enabled && cfg.LibraryPath != "" {
 			slog.Info("calibre sync_on_startup enabled — kicking off library import")
 			go func() {
-				if _, err := calibreImporter.Run(context.Background(), cfg.LibraryPath); err != nil {
+				if _, err := calibreImporter.Run(appCtx, cfg.LibraryPath); err != nil {
 					slog.Warn("calibre startup import failed", "error", err)
 				}
 			}()
@@ -380,17 +399,6 @@ func main() {
 			}()
 		}
 	}
-
-	// Process-lifecycle context. Unlike a per-request context this is not tied
-	// to any single HTTP request; it is cancelled when the process receives
-	// SIGINT/SIGTERM (graceful shutdown). Long-lived background goroutines —
-	// the scheduler's cron jobs and the recommendations goroutine — should
-	// derive from this so they observe shutdown instead of running against a
-	// context that never cancels. This commit only threads appCtx into the
-	// scheduler and the recommendation handler; converting the existing
-	// context.Background() call sites to use it is the job of #707 and #550.
-	appCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	// Scheduler
 	sched := scheduler.New(appCtx, importScanner, idxSearcher, metaAgg,
@@ -482,7 +490,8 @@ func main() {
 		WithFinder(importScanner).
 		WithHardcoverFeatureSettings(settingsRepo, cfg.EnhancedHardcoverAPI).
 		WithEditionHydration(editionRepo).
-		WithRoots(libraryRoots)
+		WithRoots(libraryRoots).
+		WithLifetimeCtx(appCtx)
 	authorAliasHandler := api.NewAuthorAliasHandler(authorRepo, authorAliasRepo)
 	bookHandler := api.NewBookHandler(bookRepo, metaAgg, historyRepo, sched).
 		WithSettings(settingsRepo).
@@ -542,12 +551,14 @@ func main() {
 	metadataProfileHandler := api.NewMetadataProfileHandler(metadataProfileRepo)
 	delayProfileHandler := api.NewDelayProfileHandler(delayProfileRepo)
 	customFormatHandler := api.NewCustomFormatHandler(customFormatRepo)
-	bulkHandler := api.NewBulkHandler(authorRepo, bookRepo, blocklistRepo, sched)
+	bulkHandler := api.NewBulkHandler(authorRepo, bookRepo, blocklistRepo, sched).
+		WithLifetimeCtx(appCtx)
 	backupHandler := api.NewBackupHandler(database, cfg.DBPath, cfg.DataDir)
 	rootFolderHandler := api.NewRootFolderHandler(rootFolderRepo)
 	logHandler := api.NewLogHandler(ring).WithLogRepo(logRepo).WithDBLogHandler(logDBHandler)
 	prowlarrHandler := api.NewProwlarrHandler(prowlarrRepo, indexerRepo).WithSettings(settingsRepo)
-	calibreHandler := api.NewCalibreHandler(settingsRepo)
+	calibreHandler := api.NewCalibreHandler(settingsRepo).
+		WithLifetimeCtx(appCtx)
 	grimmoryHandler := api.NewGrimmoryHandler(settingsRepo).WithVersion(version)
 	absHandler := api.NewABSHandler(settingsRepo).WithVersion(version)
 	absConflictHandler := api.NewABSConflictHandler(absConflictRepo, authorRepo, bookRepo)
@@ -558,14 +569,14 @@ func main() {
 		return api.LoadABSConfig(ctx, settingsRepo)
 	})
 	calibreImportHandler := api.NewCalibreImportHandler(calibreImporter, func() calibre.Config {
-		return api.LoadCalibreConfig(settingsRepo)
+		return api.LoadCalibreConfig(appCtx, settingsRepo)
 	})
 	calibreRunsHandler := api.NewCalibreRunsHandler(calibreImporter)
 	calibreSyncer := calibre.NewSyncer(bookRepo).WithMetadata(authorRepo, editionRepo)
 	calibreSyncHandler := api.NewCalibreSyncHandler(
 		calibreSyncer,
-		func() calibre.Config { return api.LoadCalibreConfig(settingsRepo) },
-		func() calibre.Mode { return api.LoadCalibreMode(settingsRepo) },
+		func() calibre.Config { return api.LoadCalibreConfig(appCtx, settingsRepo) },
+		func() calibre.Mode { return api.LoadCalibreMode(appCtx, settingsRepo) },
 	)
 	recHandler := api.NewRecommendationHandler(recRepo, recEngine, authorRepo, bookRepo, sched).
 		WithFinder(seriesRepo, importScanner).

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -48,6 +48,12 @@ type AuthorHandler struct {
 	enhancedHardcoverEnvEnabled bool
 
 	editionFetcher bookhydrate.EditionFetcher
+
+	// lifetimeCtx is the process-lifecycle context, cancelled on server
+	// shutdown so the FetchAuthorBooks / orphan-cleanup / SearchOnAdd
+	// goroutines do not outlive the process. Falls back to
+	// context.Background() when not set; see #846 and recommendations.go.
+	lifetimeCtx context.Context
 }
 
 func NewAuthorHandler(authors *db.AuthorRepo, aliases *db.AuthorAliasRepo, books *db.BookRepo, series *db.SeriesRepo, meta *metadata.Aggregator, settings *db.SettingsRepo, profiles *db.MetadataProfileRepo, searcher BookSearcher) *AuthorHandler {
@@ -89,6 +95,27 @@ func (h *AuthorHandler) WithHardcoverFeatureSettings(settings *db.SettingsRepo, 
 	h.settings = settings
 	h.enhancedHardcoverEnvEnabled = envEnabled
 	return h
+}
+
+// WithLifetimeCtx attaches the process-lifecycle context so background work
+// started from a request handler (FetchAuthorBooks, AddBook's SearchOnAdd
+// goroutine, orphan-cleanup) is cancelled on shutdown rather than running
+// against context.Background(). A nil ctx is tolerated and ignored. See #846.
+func (h *AuthorHandler) WithLifetimeCtx(ctx context.Context) *AuthorHandler {
+	if ctx != nil {
+		h.lifetimeCtx = ctx
+	}
+	return h
+}
+
+// bgCtx returns the lifetime context if set, otherwise context.Background().
+// Used by every spawn site so tests that construct a handler without
+// WithLifetimeCtx keep their previous semantics.
+func (h *AuthorHandler) bgCtx() context.Context {
+	if h.lifetimeCtx != nil {
+		return h.lifetimeCtx
+	}
+	return context.Background()
 }
 
 func (h *AuthorHandler) enhancedHardcoverEnabled(ctx context.Context) bool {
@@ -1143,7 +1170,7 @@ func (h *AuthorHandler) relinkCalibreAuthor(ctx context.Context, author *models.
 // mediaType is applied to each newly-created book when the provider didn't
 // return one; pass an empty string to accept whatever the provider set.
 func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool, mediaType string) {
-	ctx := contextBackground()
+	ctx := h.bgCtx()
 	slog.Info("fetching books for author", "author", author.Name, "foreignId", author.ForeignID)
 
 	// Calibre-imported authors carry a synthetic "calibre:author:N" foreign ID
@@ -1893,9 +1920,11 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 4. Optionally trigger an indexer search.
+	// 4. Optionally trigger an indexer search. Use the process-lifecycle
+	// context so the search goroutine is cancelled on shutdown rather than
+	// running against context.Background(). See #846.
 	if req.SearchOnAdd && h.searcher != nil {
-		go h.searcher.SearchAndGrabBook(contextBackground(), *book)
+		go h.searcher.SearchAndGrabBook(h.bgCtx(), *book) // #nosec G118 -- intentional: search must outlive the request
 	}
 
 	writeJSON(w, http.StatusCreated, book)
@@ -1920,7 +1949,7 @@ func (h *AuthorHandler) cleanupOrphanIfNoBooks(author *models.Author, bookCreate
 	if author == nil || author.ID == 0 {
 		return
 	}
-	ctx := contextBackground()
+	ctx := h.bgCtx()
 	books, err := h.books.ListByAuthor(ctx, author.ID)
 	if err != nil {
 		slog.Warn("AddBook: orphan-cleanup ListByAuthor failed",

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -2754,3 +2754,47 @@ func TestAuthorList_OrderStable(t *testing.T) {
 		}
 	}
 }
+
+// TestAuthorHandler_GoroutineCancelsOnLifetimeCtxCancel is the #846 guard
+// for AuthorHandler: the FetchAuthorBooks / orphan-cleanup / SearchOnAdd
+// goroutines must derive from the process-lifecycle ctx, not
+// context.Background(). The simplest expression of that contract is that
+// bgCtx() returns the configured lifetime ctx and observes its cancellation
+// from a spawned goroutine. AddBook's full plumbing is exercised elsewhere;
+// this test isolates the ctx wiring without dragging in the metadata
+// aggregator. The fallback case (no WithLifetimeCtx) is also asserted so
+// the legacy tests' construction sites keep their previous semantics.
+func TestAuthorHandler_GoroutineCancelsOnLifetimeCtxCancel(t *testing.T) {
+	// Default: no lifetime ctx wired → bgCtx must be Background() and
+	// never cancel.
+	h := &AuthorHandler{}
+	bg := h.bgCtx()
+	if bg == nil {
+		t.Fatal("bgCtx returned nil")
+	}
+	select {
+	case <-bg.Done():
+		t.Fatal("default bgCtx must not be cancelled")
+	default:
+	}
+
+	// With WithLifetimeCtx wired, the goroutine started below must
+	// observe the cancellation.
+	lifetimeCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h = (&AuthorHandler{}).WithLifetimeCtx(lifetimeCtx)
+
+	observed := make(chan struct{})
+	go func() {
+		<-h.bgCtx().Done()
+		close(observed)
+	}()
+
+	cancel()
+	select {
+	case <-observed:
+		// good
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not observe lifetime ctx cancellation")
+	}
+}

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -30,10 +30,38 @@ type BulkHandler struct {
 	books     *db.BookRepo
 	blocklist *db.BlocklistRepo
 	searcher  BookSearcher
+
+	// lifetimeCtx is the process-lifecycle context; cancelled on server
+	// shutdown so a bulk-action POST that fans out indexer searches does
+	// not leak goroutines (or worse, grab a torrent mid-shutdown) past
+	// Server.Shutdown. Falls back to context.Background() when not set;
+	// see #846 and the mirroring pattern in recommendations.go.
+	lifetimeCtx context.Context
 }
 
 func NewBulkHandler(authors *db.AuthorRepo, books *db.BookRepo, blocklist *db.BlocklistRepo, searcher BookSearcher) *BulkHandler {
 	return &BulkHandler{authors: authors, books: books, blocklist: blocklist, searcher: searcher}
+}
+
+// WithLifetimeCtx attaches the process-lifecycle context so the bulk-search
+// fan-out goroutine is cancelled on shutdown rather than running against
+// context.Background(). A nil ctx is tolerated and ignored (the handler then
+// falls back to context.Background() at fan-out time). See #846.
+func (h *BulkHandler) WithLifetimeCtx(ctx context.Context) *BulkHandler {
+	if ctx != nil {
+		h.lifetimeCtx = ctx
+	}
+	return h
+}
+
+// bgCtx returns the lifetime context if set, otherwise context.Background().
+// Centralised so every spawn site uses the same fallback rule and tests that
+// construct a handler without WithLifetimeCtx behave as they did before.
+func (h *BulkHandler) bgCtx() context.Context {
+	if h.lifetimeCtx != nil {
+		return h.lifetimeCtx
+	}
+	return context.Background()
 }
 
 // bulkItemResult is the per-ID result entry in a bulk response.
@@ -147,14 +175,16 @@ func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
 
 // fanOutSearches dispatches per-book indexer searches under a bounded pool
 // so a single bulk action can't spawn one goroutine per book. The pool
-// itself runs on a detached background context so the HTTP response is
-// not blocked on indexer round-trips; the bulk endpoint is fire-and-forget
-// for searches by design (results show up in History).
+// runs on the process-lifecycle context (see WithLifetimeCtx, falling back
+// to context.Background()), so the HTTP response is not blocked on
+// indexer round-trips and a server shutdown cancels in-flight searches
+// rather than letting them grab torrents mid-shutdown. The bulk endpoint
+// is fire-and-forget for searches by design (results show up in History).
 func (h *BulkHandler) fanOutSearches(books []models.Book) {
 	if h.searcher == nil || len(books) == 0 {
 		return
 	}
-	bgCtx := contextBackground()
+	bgCtx := h.bgCtx()
 	go concurrency.RunBounded(bgCtx, books, bulkSearchConcurrency, func(ctx context.Context, b models.Book) {
 		h.searcher.SearchAndGrabBook(ctx, b)
 	})

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -841,3 +841,78 @@ func TestAuthorsBulk_Search_BoundsConcurrency(t *testing.T) {
 		t.Fatalf("call count = %d, want %d", got, total)
 	}
 }
+
+// ctxCapturingSearcher records the per-call context the bulk fan-out passes
+// in so #846 regression tests can assert the lifetime ctx is propagated.
+// The first call publishes its ctx and signals seen; later calls overwrite
+// the field but never re-close the channel (close-once via sync.Once).
+type ctxCapturingSearcher struct {
+	mu      sync.Mutex
+	gotCtx  context.Context
+	seen    chan struct{}
+	seenOne sync.Once
+}
+
+func newCtxCapturingSearcher() *ctxCapturingSearcher {
+	return &ctxCapturingSearcher{seen: make(chan struct{})}
+}
+
+func (s *ctxCapturingSearcher) SearchAndGrabBook(ctx context.Context, _ models.Book) {
+	s.mu.Lock()
+	s.gotCtx = ctx
+	s.mu.Unlock()
+	s.seenOne.Do(func() { close(s.seen) })
+	// Block until the test cancels the lifetime ctx so the goroutine is
+	// observably alive when the assertion runs. A bare receive on ctx.Done
+	// is the production contract we are guarding: the searcher must observe
+	// cancellation rather than running on context.Background().
+	<-ctx.Done()
+}
+
+// TestBulkHandler_GoroutineCancelsOnLifetimeCtxCancel is the #846 regression
+// guard for BulkHandler. The bulk-action search fan-out must derive from the
+// process-lifecycle ctx passed via WithLifetimeCtx; cancelling that ctx must
+// be observed inside the spawned goroutine. Without the fix the goroutine
+// would run on context.Background() and never see Done.
+func TestBulkHandler_GoroutineCancelsOnLifetimeCtxCancel(t *testing.T) {
+	searcher := newCtxCapturingSearcher()
+	h, _, books, author, ctx := bulkFixtureWithSearcher(t, searcher)
+
+	lifetimeCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h.WithLifetimeCtx(lifetimeCtx)
+
+	book := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "BLK_LIFE", AuthorID: author.ID, Title: "Lifetime Ctx",
+		SortTitle: "lifetime ctx", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+
+	body := fmt.Sprintf(`{"ids":[%d],"action":"search"}`, book.ID)
+	rec := postBulk(t, h.BooksBulk, body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	// Wait until the searcher actually starts (so we know fan-out spawned).
+	select {
+	case <-searcher.seen:
+	case <-time.After(2 * time.Second):
+		t.Fatal("searcher was not invoked within 2s")
+	}
+
+	// Cancel the lifetime ctx; the goroutine, parked on ctx.Done, must
+	// unblock. If the bulk handler had used context.Background() the
+	// receive below would never complete.
+	cancel()
+
+	searcher.mu.Lock()
+	gotCtx := searcher.gotCtx
+	searcher.mu.Unlock()
+	select {
+	case <-gotCtx.Done():
+		// good
+	case <-time.After(2 * time.Second):
+		t.Fatal("spawned goroutine did not observe lifetime ctx cancellation")
+	}
+}

--- a/internal/api/calibre.go
+++ b/internal/api/calibre.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -35,17 +36,43 @@ const SettingCWAIngestPath = "cwa.ingest_path"
 // this handler just validates and probes.
 type CalibreHandler struct {
 	settings *db.SettingsRepo
+
+	// lifetimeCtx is the process-lifecycle context. The settings reads in
+	// LoadCalibreConfig/LoadCalibreMode are short-lived but must observe
+	// shutdown when called from scheduler closures so a server-stop does
+	// not block on SQLite. Falls back to context.Background() when not
+	// set; see #846 and recommendations.go.
+	lifetimeCtx context.Context
 }
 
 func NewCalibreHandler(settings *db.SettingsRepo) *CalibreHandler {
 	return &CalibreHandler{settings: settings}
 }
 
+// WithLifetimeCtx attaches the process-lifecycle context. A nil ctx is
+// tolerated and ignored. See #846.
+func (h *CalibreHandler) WithLifetimeCtx(ctx context.Context) *CalibreHandler {
+	if ctx != nil {
+		h.lifetimeCtx = ctx
+	}
+	return h
+}
+
+// bgCtx returns the lifetime context if set, otherwise context.Background().
+func (h *CalibreHandler) bgCtx() context.Context {
+	if h.lifetimeCtx != nil {
+		return h.lifetimeCtx
+	}
+	return context.Background()
+}
+
 // LoadCalibreConfig materialises a calibre.Config from the settings table.
 // Exported so main.go can build the importer's Calibre client at boot and
-// refresh it on each scheduler tick.
-func LoadCalibreConfig(settings *db.SettingsRepo) calibre.Config {
-	ctx := contextBackground()
+// refresh it on each scheduler tick. ctx is the read-lifetime: pass
+// the process-lifecycle context from scheduler closures so a shutdown
+// cancels in-flight reads; pass r.Context() from handlers; pass
+// context.Background() at boot when no other context exists. See #846.
+func LoadCalibreConfig(ctx context.Context, settings *db.SettingsRepo) calibre.Config {
 	get := func(key string) string {
 		s, _ := settings.Get(ctx, key)
 		if s == nil {
@@ -53,7 +80,7 @@ func LoadCalibreConfig(settings *db.SettingsRepo) calibre.Config {
 		}
 		return s.Value
 	}
-	mode := LoadCalibreMode(settings)
+	mode := LoadCalibreMode(ctx, settings)
 	enabled := mode == calibre.ModeCalibredb || mode == calibre.ModePlugin
 	// Back-compat: if the operator still has the v0.8.0 `calibre.enabled`
 	// boolean set to true but the migration hasn't run yet (e.g. someone
@@ -74,9 +101,10 @@ func LoadCalibreConfig(settings *db.SettingsRepo) calibre.Config {
 
 // LoadCalibreMode returns the currently-configured integration mode. The
 // scanner calls this on every import so toggling the radio in Settings
-// takes effect without a restart.
-func LoadCalibreMode(settings *db.SettingsRepo) calibre.Mode {
-	s, _ := settings.Get(contextBackground(), SettingCalibreMode)
+// takes effect without a restart. ctx scopes the underlying settings read;
+// see LoadCalibreConfig for the call-site policy.
+func LoadCalibreMode(ctx context.Context, settings *db.SettingsRepo) calibre.Mode {
+	s, _ := settings.Get(ctx, SettingCalibreMode)
 	if s == nil {
 		return calibre.ModeOff
 	}
@@ -121,14 +149,14 @@ func validateCalibreConfig(cfg calibre.Config) error {
 // success so the UI can display "calibredb v7.3.0 — OK" and confirms the
 // library path at the same time.
 func (h *CalibreHandler) Test(w http.ResponseWriter, r *http.Request) {
-	cfg := LoadCalibreConfig(h.settings)
+	cfg := LoadCalibreConfig(r.Context(), h.settings)
 	// Force-enable for the duration of this probe. The Test button on the
 	// settings page is explicitly "does this work?", and requiring the user
 	// to save calibre.enabled=true before clicking Test would be a
 	// surprising extra step.
 	cfg.Enabled = true
 
-	if LoadCalibreMode(h.settings) == calibre.ModePlugin {
+	if LoadCalibreMode(r.Context(), h.settings) == calibre.ModePlugin {
 		if cfg.PluginURL == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "plugin_url is not configured"})
 			return

--- a/internal/api/calibre_test.go
+++ b/internal/api/calibre_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/vavallee/bindery/internal/db"
 )
@@ -77,7 +78,7 @@ func TestLoadCalibreConfig_ParsesFromSettings(t *testing.T) {
 	if err := repo.Set(ctx, SettingCalibreLibraryPath, tmp); err != nil {
 		t.Fatal(err)
 	}
-	cfg := LoadCalibreConfig(repo)
+	cfg := LoadCalibreConfig(ctx, repo)
 	if !cfg.Enabled {
 		t.Error("Enabled should be true")
 	}
@@ -98,14 +99,14 @@ func TestLoadCalibreConfig_EnabledCaseInsensitive(t *testing.T) {
 		if err := repo.Set(ctx, SettingCalibreEnabled, v); err != nil {
 			t.Fatal(err)
 		}
-		if !LoadCalibreConfig(repo).Enabled {
+		if !LoadCalibreConfig(ctx, repo).Enabled {
 			t.Errorf("Enabled = false for value %q", v)
 		}
 	}
 	if err := repo.Set(ctx, SettingCalibreEnabled, "false"); err != nil {
 		t.Fatal(err)
 	}
-	if LoadCalibreConfig(repo).Enabled {
+	if LoadCalibreConfig(ctx, repo).Enabled {
 		t.Error("Enabled should be false for 'false'")
 	}
 }
@@ -188,8 +189,8 @@ func TestSettings_SetRejectsInvalidCalibrePath(t *testing.T) {
 // report mode=off so the scanner doesn't attempt either integration before
 // the operator opts in.
 func TestLoadCalibreMode_DefaultsToOff(t *testing.T) {
-	_, repo, _ := calibreFixture(t)
-	if got := LoadCalibreMode(repo); got != "off" {
+	_, repo, ctx := calibreFixture(t)
+	if got := LoadCalibreMode(ctx, repo); got != "off" {
 		t.Errorf("LoadCalibreMode default = %q, want off", got)
 	}
 }
@@ -207,7 +208,7 @@ func TestLoadCalibreMode_ParsesKnownValues(t *testing.T) {
 		if err := repo.Set(ctx, SettingCalibreMode, tc.in); err != nil {
 			t.Fatal(err)
 		}
-		if got := string(LoadCalibreMode(repo)); got != tc.want {
+		if got := string(LoadCalibreMode(ctx, repo)); got != tc.want {
 			t.Errorf("LoadCalibreMode for %q = %q, want %q", tc.in, got, tc.want)
 		}
 	}
@@ -228,7 +229,7 @@ func TestLoadCalibreConfig_ModeDrivesEnabled(t *testing.T) {
 		if err := repo.Set(ctx, SettingCalibreMode, tc.mode); err != nil {
 			t.Fatal(err)
 		}
-		if got := LoadCalibreConfig(repo).Enabled; got != tc.want {
+		if got := LoadCalibreConfig(ctx, repo).Enabled; got != tc.want {
 			t.Errorf("mode=%s Enabled=%v, want %v", tc.mode, got, tc.want)
 		}
 	}
@@ -258,7 +259,44 @@ func TestLoadCalibreConfig_LegacyEnabledHonored(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Mode left unset (empty → off).
-	if got := LoadCalibreConfig(repo).Enabled; !got {
+	if got := LoadCalibreConfig(ctx, repo).Enabled; !got {
 		t.Error("legacy calibre.enabled=true must keep Enabled=true")
+	}
+}
+
+// TestCalibreHandler_GoroutineCancelsOnLifetimeCtxCancel is the #846 guard
+// for CalibreHandler: when WithLifetimeCtx is wired, bgCtx must return that
+// ctx (and observe its cancellation from a spawned goroutine). When not
+// wired, bgCtx must fall back to a never-cancelled Background() so the
+// existing tests that build a handler without WithLifetimeCtx keep working.
+func TestCalibreHandler_GoroutineCancelsOnLifetimeCtxCancel(t *testing.T) {
+	// Default fallback: must be Background() and never cancel.
+	h := &CalibreHandler{}
+	bg := h.bgCtx()
+	if bg == nil {
+		t.Fatal("bgCtx returned nil")
+	}
+	select {
+	case <-bg.Done():
+		t.Fatal("default bgCtx must not be cancelled")
+	default:
+	}
+
+	lifetimeCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	h = (&CalibreHandler{}).WithLifetimeCtx(lifetimeCtx)
+
+	observed := make(chan struct{})
+	go func() {
+		<-h.bgCtx().Done()
+		close(observed)
+	}()
+
+	cancel()
+	select {
+	case <-observed:
+		// good
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not observe lifetime ctx cancellation")
 	}
 }

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -33,10 +33,6 @@ type LibraryFinder interface {
 	FindExisting(ctx context.Context, title, authorName, mediaType string) string
 }
 
-func contextBackground() context.Context {
-	return context.Background()
-}
-
 // parseID extracts the `{id}` URL parameter as an int64. If the value is
 // missing or non-numeric it writes HTTP 400 and returns (0, false). Callers
 // should check ok and bail out on false.

--- a/internal/api/notifications_test.go
+++ b/internal/api/notifications_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -183,7 +184,7 @@ func TestNotificationTest_Webhook(t *testing.T) {
 		URL:     srv.URL,
 		Enabled: true,
 	}
-	if err := repo.Create(contextBackground(), n); err != nil {
+	if err := repo.Create(context.Background(), n); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -171,7 +171,7 @@ func TestSeriesGet_NotFound(t *testing.T) {
 // covered.
 func TestSeriesListAndGet_WithData(t *testing.T) {
 	h, seriesRepo, authorRepo, bookRepo := seriesFixture(t)
-	ctx := contextBackground()
+	ctx := context.Background()
 
 	author := &models.Author{ForeignID: "OL1A", Name: "A", SortName: "A"}
 	if err := authorRepo.Create(ctx, author); err != nil {
@@ -220,7 +220,7 @@ func TestSeriesListAndGet_WithData(t *testing.T) {
 
 func TestSeriesCreateUpdateDeleteAndLink(t *testing.T) {
 	h, seriesRepo, authorRepo, bookRepo := seriesFixture(t)
-	ctx := contextBackground()
+	ctx := context.Background()
 
 	createBody := bytes.NewBufferString(`{"title":"  Dune Chronicles  "}`)
 	rec := httptest.NewRecorder()
@@ -302,7 +302,7 @@ func TestSeriesCreateUpdateDeleteAndLink(t *testing.T) {
 
 func TestSeriesManagementInvalidInput(t *testing.T) {
 	h, seriesRepo, _, _ := seriesFixture(t)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "ol-series:dune", Title: "Dune Chronicles"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -363,7 +363,7 @@ func TestSeriesManagementInvalidInput(t *testing.T) {
 
 func TestSeriesManagementRejectsOverlongTitle(t *testing.T) {
 	h, seriesRepo, _, _ := seriesFixture(t)
-	ctx := contextBackground()
+	ctx := context.Background()
 	tooLongTitle := strings.Repeat("a", seriesTitleMaxLength+1)
 
 	rec := httptest.NewRecorder()
@@ -400,7 +400,7 @@ func TestSeriesManagementRejectsOverlongTitle(t *testing.T) {
 
 func TestSeriesMonitorEndpoint(t *testing.T) {
 	h, seriesRepo, _, _ := seriesFixture(t)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "manual:stormlight", Title: "Stormlight Archive"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -581,7 +581,7 @@ func TestSeriesAutoLinkHardcoverPersistsTopCandidate(t *testing.T) {
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}
 	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, provider, nil)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -650,7 +650,7 @@ func TestSeriesAutoLinkHardcoverRejectsExactTitleWrongAuthorWithoutOverlap(t *te
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}
 	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, provider, nil)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "ol-series:shared", Title: "Shared Series Title"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -733,7 +733,7 @@ func TestSeriesAutoLinkHardcoverAmbiguousNoop(t *testing.T) {
 	}
 	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, provider, nil)
 	series := &models.Series{ForeignID: "ol-series:rhythm", Title: "Rhythm of War"}
-	if err := seriesRepo.Create(contextBackground(), series); err != nil {
+	if err := seriesRepo.Create(context.Background(), series); err != nil {
 		t.Fatal(err)
 	}
 
@@ -749,7 +749,7 @@ func TestSeriesAutoLinkHardcoverAmbiguousNoop(t *testing.T) {
 	if response.Linked {
 		t.Fatalf("ambiguous result should not persist, got %+v", response)
 	}
-	link, err := seriesRepo.GetHardcoverLink(contextBackground(), series.ID)
+	link, err := seriesRepo.GetHardcoverLink(context.Background(), series.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -764,7 +764,7 @@ func TestSeriesPutHardcoverLinkPersistsManualLink(t *testing.T) {
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}
 	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, provider, nil)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -800,7 +800,7 @@ func TestSeriesPutHardcoverLinkInvalidRequests(t *testing.T) {
 	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}, nil)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -833,7 +833,7 @@ func TestSeriesPutHardcoverLinkProviderFailure(t *testing.T) {
 		catalogs:   map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 		catalogErr: errors.New("hardcover unavailable"),
 	}, nil)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -858,7 +858,7 @@ func TestSeriesGetHardcoverLinkEndpoint(t *testing.T) {
 	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}, nil)
-	ctx := contextBackground()
+	ctx := context.Background()
 	linked := &models.Series{ForeignID: "manual:series:linked", Title: "Linked"}
 	if err := seriesRepo.Create(ctx, linked); err != nil {
 		t.Fatal(err)
@@ -928,7 +928,7 @@ func TestSeriesDeleteHardcoverLinkRemovesStoredLink(t *testing.T) {
 	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}, nil)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -990,7 +990,7 @@ func TestSeriesHardcoverDiffEndpoint(t *testing.T) {
 	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}, nil)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -1066,7 +1066,7 @@ func TestSeriesHardcoverDiffEndpointErrors(t *testing.T) {
 		catalogs:   map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 		catalogErr: errors.New("hardcover unavailable"),
 	}, nil)
-	ctx := contextBackground()
+	ctx := context.Background()
 	linked := &models.Series{ForeignID: "manual:series:linked", Title: "Linked"}
 	if err := seriesRepo.Create(ctx, linked); err != nil {
 		t.Fatal(err)
@@ -1144,7 +1144,7 @@ func TestSeriesFillEndpointErrors(t *testing.T) {
 		h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{
 			catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 		}, nil)
-		ctx := contextBackground()
+		ctx := context.Background()
 		series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
 		if err := seriesRepo.Create(ctx, series); err != nil {
 			t.Fatal(err)
@@ -1170,7 +1170,7 @@ func TestSeriesFillEndpointErrors(t *testing.T) {
 	t.Run("missing link", func(t *testing.T) {
 		h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{}, nil)
 		series := &models.Series{ForeignID: "manual:series:unlinked", Title: "Unlinked"}
-		if err := seriesRepo.Create(contextBackground(), series); err != nil {
+		if err := seriesRepo.Create(context.Background(), series); err != nil {
 			t.Fatal(err)
 		}
 		rec := httptest.NewRecorder()
@@ -1186,7 +1186,7 @@ func TestSeriesFillEndpointErrors(t *testing.T) {
 			catalogs:   map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 			catalogErr: errors.New("hardcover unavailable"),
 		}, nil)
-		ctx := contextBackground()
+		ctx := context.Background()
 		series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
 		if err := seriesRepo.Create(ctx, series); err != nil {
 			t.Fatal(err)
@@ -1217,7 +1217,7 @@ func TestSeriesFillSkipsHardcoverCatalogWhenFeatureDisabled(t *testing.T) {
 	}
 	searcher := newMockBookSearcher()
 	h, seriesRepo, authorRepo, bookRepo, settingsRepo := seriesFixtureWithProviderAndSettings(t, provider, searcher, false)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -1288,7 +1288,7 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}, searcher)
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
-	if err := seriesRepo.Create(contextBackground(), series); err != nil {
+	if err := seriesRepo.Create(context.Background(), series); err != nil {
 		t.Fatal(err)
 	}
 	link := &models.SeriesHardcoverLink{
@@ -1301,7 +1301,7 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 		Confidence:          1,
 		LinkedBy:            "manual",
 	}
-	if err := seriesRepo.UpsertHardcoverLink(contextBackground(), link); err != nil {
+	if err := seriesRepo.UpsertHardcoverLink(context.Background(), link); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1321,7 +1321,7 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 	if queued.Title != "The Way of Kings" {
 		t.Fatalf("unexpected queued book: %+v", queued)
 	}
-	created, err := bookRepo.GetByForeignID(contextBackground(), "hc:the-way-of-kings")
+	created, err := bookRepo.GetByForeignID(context.Background(), "hc:the-way-of-kings")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1335,7 +1335,7 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 	if !created.AnyEditionOK {
 		t.Fatal("expected anyEditionOk to be preserved")
 	}
-	books, err := seriesRepo.ListBooksInSeries(contextBackground(), series.ID)
+	books, err := seriesRepo.ListBooksInSeries(context.Background(), series.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1362,10 +1362,10 @@ func TestSeriesFillHydratesHardcoverEditionsBeforeQueue(t *testing.T) {
 		}}, nil
 	})
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
-	if err := seriesRepo.Create(contextBackground(), series); err != nil {
+	if err := seriesRepo.Create(context.Background(), series); err != nil {
 		t.Fatal(err)
 	}
-	if err := seriesRepo.UpsertHardcoverLink(contextBackground(), &models.SeriesHardcoverLink{
+	if err := seriesRepo.UpsertHardcoverLink(context.Background(), &models.SeriesHardcoverLink{
 		SeriesID:            series.ID,
 		HardcoverSeriesID:   catalog.ForeignID,
 		HardcoverProviderID: catalog.ProviderID,
@@ -1387,14 +1387,14 @@ func TestSeriesFillHydratesHardcoverEditionsBeforeQueue(t *testing.T) {
 	if queued.ASIN != audioASIN {
 		t.Fatalf("queued book ASIN = %q, want %q", queued.ASIN, audioASIN)
 	}
-	created, err := bookRepo.GetByForeignID(contextBackground(), "hc:the-way-of-kings")
+	created, err := bookRepo.GetByForeignID(context.Background(), "hc:the-way-of-kings")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if created == nil || created.ASIN != audioASIN {
 		t.Fatalf("created book ASIN not persisted: %+v", created)
 	}
-	editions, err := editionRepo.ListByBook(contextBackground(), created.ID)
+	editions, err := editionRepo.ListByBook(context.Background(), created.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1409,7 +1409,7 @@ func TestSeriesFillReusesCrossProviderAuthorAndExistingBook(t *testing.T) {
 	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}, searcher)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -1506,7 +1506,7 @@ func TestSeriesFillSkipsExcludedHardcoverForeignIDMatch(t *testing.T) {
 	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}, searcher)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -1580,7 +1580,7 @@ func TestSeriesFillSkipsExcludedHardcoverTitleMatch(t *testing.T) {
 	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}, searcher)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -1661,7 +1661,7 @@ func TestSeriesFillSkipsExcludedCrossProviderTitleMatch(t *testing.T) {
 	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}, searcher)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -1752,7 +1752,7 @@ func TestSeriesFillSkipsAmbiguousCrossProviderAuthorMatch(t *testing.T) {
 	h, seriesRepo, authorRepo, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}, searcher)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)
@@ -1831,7 +1831,7 @@ func TestSeriesFillCreatesOnlyRequestedHardcoverBook(t *testing.T) {
 		catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 	}, searcher)
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
-	if err := seriesRepo.Create(contextBackground(), series); err != nil {
+	if err := seriesRepo.Create(context.Background(), series); err != nil {
 		t.Fatal(err)
 	}
 	link := &models.SeriesHardcoverLink{
@@ -1844,7 +1844,7 @@ func TestSeriesFillCreatesOnlyRequestedHardcoverBook(t *testing.T) {
 		Confidence:          1,
 		LinkedBy:            "manual",
 	}
-	if err := seriesRepo.UpsertHardcoverLink(contextBackground(), link); err != nil {
+	if err := seriesRepo.UpsertHardcoverLink(context.Background(), link); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1866,21 +1866,21 @@ func TestSeriesFillCreatesOnlyRequestedHardcoverBook(t *testing.T) {
 		t.Fatalf("unexpected queued book: %+v", queued)
 	}
 	searcher.assertNoCall(t, 50*time.Millisecond)
-	created, err := bookRepo.GetByForeignID(contextBackground(), "hc:words-of-radiance")
+	created, err := bookRepo.GetByForeignID(context.Background(), "hc:words-of-radiance")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if created == nil {
 		t.Fatal("expected requested Hardcover book to be created")
 	}
-	notCreated, err := bookRepo.GetByForeignID(contextBackground(), "hc:the-way-of-kings")
+	notCreated, err := bookRepo.GetByForeignID(context.Background(), "hc:the-way-of-kings")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if notCreated != nil {
 		t.Fatalf("expected unrequested Hardcover book to remain missing, got %+v", notCreated)
 	}
-	books, err := seriesRepo.ListBooksInSeries(contextBackground(), series.ID)
+	books, err := seriesRepo.ListBooksInSeries(context.Background(), series.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1896,7 +1896,7 @@ func TestSeriesFillQueuesLocalBooksWhenHardcoverCatalogFails(t *testing.T) {
 		catalogs:   map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
 		catalogErr: errors.New("hardcover unavailable"),
 	}, searcher)
-	ctx := contextBackground()
+	ctx := context.Background()
 	series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
 	if err := seriesRepo.Create(ctx, series); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Closes #846 (P2 from the v1.15.0 security review).

> `internal/api/helpers.go:36` defines `contextBackground()` which returns `context.Background()`. Callers in `internal/api/bulk.go:110,185,242`, `internal/api/authors.go:990,1730,1755`, and `internal/api/calibre.go:48` fire background goroutines (search, grab, etc.) using this context. Those goroutines do not get cancelled when the originating HTTP request context times out or the server shuts down via `Server.Shutdown(ctx)`. On a busy shutdown an indexer-search goroutine fired by a bulk-action POST will keep running until its own internal timeout. That's a goroutine leak with side effects (the search may grab a torrent into a download client mid-shutdown).

## Approach

Mirror the pattern `internal/api/recommendations.go` introduced in #550:

- A process-lifecycle context (the existing `appCtx`, declared via `signal.NotifyContext` in `cmd/bindery/main.go`) is threaded into each handler via a builder. `recommendations.go` named it `WithAppContext`; the new handlers use the issue's preferred name `WithLifetimeCtx` and a private `bgCtx()` accessor that falls back to `context.Background()` when not set. That fallback is what keeps the existing tests (which construct handlers without `WithLifetimeCtx`) green without rewiring every fixture.
- `appCtx` was moved up in `main.go` to sit next to `ctxBoot` so the Calibre mode-resolver closure (declared earlier in `main` than the prior `appCtx` line) can capture it.

## Call sites moved off `contextBackground`

| File | Was | Now |
| --- | --- | --- |
| `internal/api/bulk.go` (`fanOutSearches`) | `bgCtx := contextBackground()` | `bgCtx := h.bgCtx()` |
| `internal/api/authors.go` (`FetchAuthorBooks`) | `ctx := contextBackground()` | `ctx := h.bgCtx()` |
| `internal/api/authors.go` (`AddBook` SearchOnAdd) | `go h.searcher.SearchAndGrabBook(contextBackground(), *book)` | `go h.searcher.SearchAndGrabBook(h.bgCtx(), *book)` |
| `internal/api/authors.go` (`cleanupOrphanIfNoBooks`) | `ctx := contextBackground()` | `ctx := h.bgCtx()` |
| `internal/api/calibre.go` (`LoadCalibreConfig`) | `ctx := contextBackground()` | `func LoadCalibreConfig(ctx context.Context, ...)` |
| `internal/api/calibre.go` (`LoadCalibreMode`) | `contextBackground()` | `func LoadCalibreMode(ctx context.Context, ...)` |

`LoadCalibreConfig`/`LoadCalibreMode` are package-level helpers (not handler methods), so the cleanest fix was to take `ctx context.Context` as a parameter. All callers updated:
- `cmd/bindery/main.go` boot path uses `ctxBoot`.
- `cmd/bindery/main.go` scheduler/import closures capture `appCtx`.
- `CalibreHandler.Test` uses `r.Context()`.

`internal/api/helpers.go:contextBackground` is **deleted**. `internal/api/series_test.go` and `internal/api/notifications_test.go` were updated to call `context.Background()` directly (those were the only test files still referencing the helper).

## Lifetime ctx initialization

In `cmd/bindery/main.go`:

```go
appCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
defer stop()
```

The constructor chains now include `WithLifetimeCtx(appCtx)`:

```go
authorHandler := api.NewAuthorHandler(...).
    WithFinder(importScanner).
    WithHardcoverFeatureSettings(...).
    WithEditionHydration(editionRepo).
    WithRoots(libraryRoots).
    WithLifetimeCtx(appCtx)

bulkHandler := api.NewBulkHandler(...).
    WithLifetimeCtx(appCtx)

calibreHandler := api.NewCalibreHandler(settingsRepo).
    WithLifetimeCtx(appCtx)
```

## Test plan

- [x] `TestBulkHandler_GoroutineCancelsOnLifetimeCtxCancel` (end-to-end). Posts `/book/bulk action=search`, the mock searcher captures the per-call ctx and parks on `<-ctx.Done()`; cancelling the lifetime ctx must unblock it.
- [x] `TestAuthorHandler_GoroutineCancelsOnLifetimeCtxCancel`. Asserts (a) the zero-value handler's `bgCtx()` returns a never-cancelled `Background()` (the legacy-fixture compat contract), and (b) a goroutine started off `WithLifetimeCtx(lifetimeCtx).bgCtx()` observes cancellation.
- [x] `TestCalibreHandler_GoroutineCancelsOnLifetimeCtxCancel`. Same shape as the author test.
- [x] `go test ./...` clean (no existing tests regressed).
- [x] `go vet ./...` clean.

## Out of scope (audit findings, follow-up candidates)

While auditing for additional offenders I found four more goroutines that won't observe shutdown for the same root reason. They use `context.WithoutCancel` or a fresh `context.Background()` with a timeout rather than `contextBackground`, so they were outside the literal #846 grep:

- `internal/api/books.go:438` (`go h.searcher.SearchAndGrabBook(bgCtx, b)` where `bgCtx := context.WithoutCancel(r.Context())`).
- `internal/api/series.go:467` (`go concurrency.RunBounded(bgCtx, ...)` where `bgCtx := context.WithoutCancel(ctx)`).
- `internal/api/download_clients.go:223` (`go func() { ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second); ...}`).
- `internal/api/auth_oidc.go:608` (`reloadCtx := context.WithoutCancel(r.Context())`).

Same defect class, different mechanism. Punting to a follow-up issue so this PR stays the scoped refactor #846 asked for.