### PR TITLE
fix(importer): import only torrent file list, not whole download dir (closes #903)

### DIFF
--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -238,6 +238,32 @@ func (c *Client) GetTorrents(ctx context.Context) (map[string]TorrentStatus, err
 	return out, nil
 }
 
+// Files returns the per-torrent file list for hash. Names are paths
+// relative to the torrent's save_path / download_location; for a
+// single-file torrent dropped directly at the save root the entry's Name
+// is just the file's basename.
+//
+// This is the authoritative list of files that belong to this torrent, used
+// by the importer (issue #903) to avoid walking the shared download root
+// and picking up unrelated siblings.
+//
+// A torrent that the Deluge daemon does not know about surfaces as an RPC
+// error from core.get_torrent_status (KeyError on the hash).
+func (c *Client) Files(ctx context.Context, hash string) ([]File, error) {
+	var status torrentFilesStatus
+	if err := c.call(ctx, true, "core.get_torrent_status", []any{hash, []string{"files"}}, &status); err != nil {
+		return nil, fmt.Errorf("get torrent files: %w", err)
+	}
+	out := make([]File, 0, len(status.Files))
+	for _, f := range status.Files {
+		if f.Path == "" {
+			continue
+		}
+		out = append(out, File{Name: f.Path, Size: f.Size})
+	}
+	return out, nil
+}
+
 // RemoveTorrent removes a torrent by hash, optionally deleting its data files.
 func (c *Client) RemoveTorrent(ctx context.Context, hash string, deleteFiles bool) error {
 	if err := c.ensureLoggedIn(ctx); err != nil {

--- a/internal/downloader/deluge/client_test.go
+++ b/internal/downloader/deluge/client_test.go
@@ -44,11 +44,18 @@ type delugeServer struct {
 	t        *testing.T
 	password string
 	torrents map[string]deluge.TorrentStatus // keyed by lower-cased hash
+	// files maps torrent hash to the per-file list returned by
+	// core.get_torrent_status with keys=["files"]. Tests that don't care
+	// about Files() can leave this nil.
+	files map[string][]map[string]any
 
 	// optional overrides
 	loginErr     bool
 	addMagnetErr bool
 	removeFail   bool
+	// statusErr forces core.get_torrent_status to return an RPC error,
+	// exercising the Files() error path.
+	statusErr bool
 }
 
 func (s *delugeServer) handler() http.HandlerFunc {
@@ -126,6 +133,22 @@ func (s *delugeServer) handler() http.HandlerFunc {
 		case "core.get_torrents_status":
 			write(s.torrents)
 
+		case "core.get_torrent_status":
+			if s.statusErr {
+				writeErr("status error")
+				return
+			}
+			var hash string
+			json.Unmarshal(req.Params[0], &hash)
+			hash = strings.ToLower(hash)
+			files, ok := s.files[hash]
+			if !ok {
+				// Unknown hash: Deluge surfaces this as a KeyError RPC.
+				writeErr("torrent not found")
+				return
+			}
+			write(map[string]any{"files": files})
+
 		case "core.remove_torrent":
 			var hash string
 			json.Unmarshal(req.Params[0], &hash)
@@ -148,6 +171,7 @@ func newTestServer(t *testing.T, password string) (*httptest.Server, *delugeServ
 		t:        t,
 		password: password,
 		torrents: make(map[string]deluge.TorrentStatus),
+		files:    make(map[string][]map[string]any),
 	}
 	srv := httptest.NewServer(ds.handler())
 	t.Cleanup(srv.Close)
@@ -429,5 +453,80 @@ func TestTest_ServerError_NoHint(t *testing.T) {
 		if strings.Contains(msg, hint) {
 			t.Errorf("server-side error must not produce hint %q; got: %q", hint, msg)
 		}
+	}
+}
+
+// TestClient_Files_ReturnsRelativeNames verifies that Files() decodes the
+// core.get_torrent_status "files" entries into the importer's []File shape
+// with paths left relative to the torrent's save_path. Issue #903 regression
+// guard.
+func TestClient_Files_ReturnsRelativeNames(t *testing.T) {
+	srv, ds := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+
+	const hash = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	ds.files[hash] = []map[string]any{
+		{"index": 0, "offset": 0, "path": "MyBook/disc01.m4b", "size": 1024},
+		{"index": 1, "offset": 1024, "path": "MyBook/disc02.m4b", "size": 2048},
+		{"index": 2, "offset": 3072, "path": "MyBook/cover.jpg", "size": 128},
+	}
+
+	files, err := c.Files(context.Background(), hash)
+	if err != nil {
+		t.Fatalf("Files: %v", err)
+	}
+	if len(files) != 3 {
+		t.Fatalf("want 3 files, got %d", len(files))
+	}
+	if files[0].Name != "MyBook/disc01.m4b" || files[0].Size != 1024 {
+		t.Errorf("file 0 mismatch: %+v", files[0])
+	}
+	if files[2].Name != "MyBook/cover.jpg" {
+		t.Errorf("file 2 mismatch: %+v", files[2])
+	}
+}
+
+// TestClient_Files_SingleFileTorrent — the issue #903 shape: a single
+// loose file at the save root. The path entry is just the basename.
+func TestClient_Files_SingleFileTorrent(t *testing.T) {
+	srv, ds := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+
+	const hash = "11111111111111111111111111111111aaaabbbb"
+	ds.files[hash] = []map[string]any{
+		{"index": 0, "offset": 0, "path": "standalone-book.m4b", "size": 50000},
+	}
+
+	files, err := c.Files(context.Background(), hash)
+	if err != nil {
+		t.Fatalf("Files: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "standalone-book.m4b" {
+		t.Errorf("expected single basename-only file, got %+v", files)
+	}
+}
+
+// TestClient_Files_TorrentMissing — Deluge surfaces an unknown hash as a
+// KeyError RPC fault. Files() returns an error so the importer can fall
+// back to the directory walk with a WARN log.
+func TestClient_Files_TorrentMissing(t *testing.T) {
+	srv, _ := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+
+	if _, err := c.Files(context.Background(), "nonexistent-hash"); err == nil {
+		t.Fatal("expected error for unknown torrent hash")
+	}
+}
+
+// TestClient_Files_StatusErrorReturnsError — when core.get_torrent_status
+// itself errors (e.g. transient daemon issue) Files() must surface the
+// error rather than silently returning empty.
+func TestClient_Files_StatusErrorReturnsError(t *testing.T) {
+	srv, ds := newTestServer(t, "pw")
+	ds.statusErr = true
+	c := clientFromServer(srv, "pw")
+
+	if _, err := c.Files(context.Background(), "any-hash"); err == nil {
+		t.Fatal("expected error when status RPC fails")
 	}
 }

--- a/internal/downloader/deluge/types.go
+++ b/internal/downloader/deluge/types.go
@@ -11,3 +11,25 @@ type TorrentStatus struct {
 	TotalSize    int64   `json:"total_size"`
 	TotalDone    int64   `json:"total_done"`
 }
+
+// File is a single file belonging to a torrent, as returned by
+// core.get_torrent_status with keys=["files"]. Path is the file path
+// relative to the torrent's save path; for a single-file torrent it is
+// just the file's basename.
+type File struct {
+	Name string
+	Size int64
+}
+
+// rpcFile mirrors the Deluge core.get_torrent_status "files" entry shape:
+// {index, offset, path, size}. Only path + size are kept.
+type rpcFile struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+// torrentFilesStatus holds the keys we request from core.get_torrent_status
+// when only the file list is needed.
+type torrentFilesStatus struct {
+	Files []rpcFile `json:"files"`
+}

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -545,6 +545,39 @@ func (c *Client) GetDefaultSavePath(ctx context.Context) (string, error) {
 	return strings.TrimSpace(string(data)), nil
 }
 
+// Files returns the per-torrent file list for hash. Names are paths
+// relative to the torrent's save path (forward-slash normalised even when
+// qBittorrent runs on Windows); for a single-file torrent dropped directly
+// at the save root the entry's Name is just the file's basename.
+//
+// This is the authoritative list of files that belong to this torrent, used
+// by the importer (issue #903) to avoid walking the shared download root
+// and picking up unrelated siblings.
+//
+// An empty list with a nil error means qBittorrent reported no files for
+// the torrent (typical for a torrent still resolving metadata). An unknown
+// hash returns HTTP 404 from the API, which is surfaced as an error.
+func (c *Client) Files(ctx context.Context, hash string) ([]File, error) {
+	endpoint := "/api/v2/torrents/files?hash=" + url.QueryEscape(hash)
+	data, err := c.get(ctx, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	var files []rpcFile
+	if err := json.Unmarshal(data, &files); err != nil {
+		return nil, fmt.Errorf("decode torrent files: %w", err)
+	}
+	out := make([]File, 0, len(files))
+	for _, f := range files {
+		name := normalizePath(f.Name)
+		if name == "" {
+			continue
+		}
+		out = append(out, File{Name: name, Size: f.Size})
+	}
+	return out, nil
+}
+
 // DeleteTorrent removes a torrent by hash, optionally deleting its files.
 func (c *Client) DeleteTorrent(ctx context.Context, hash string, deleteFiles bool) error {
 	deleteFilesStr := "false"

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -1776,3 +1776,121 @@ func TestTest_V4AndV5_VersionString(t *testing.T) {
 		})
 	}
 }
+
+// TestClient_Files_ReturnsRelativeNames verifies that Files() decodes the
+// /api/v2/torrents/files response into the importer's []File shape with
+// names left relative to the torrent's save path. Issue #903 regression
+// guard: the importer joins these names with save_path to identify the
+// exact files of THIS torrent, avoiding a walk of the shared download
+// root.
+func TestClient_Files_ReturnsRelativeNames(t *testing.T) {
+	const hash = "deadbeef1234567890deadbeef1234567890dead"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/files":
+			if got := r.URL.Query().Get("hash"); got != hash {
+				t.Errorf("Files: missing or wrong hash query, got %q", got)
+			}
+			_, _ = w.Write([]byte(`[
+				{"name":"MyBook/disc01.m4b","size":1024,"progress":1,"priority":1},
+				{"name":"MyBook/disc02.m4b","size":2048,"progress":1,"priority":1},
+				{"name":"MyBook/cover.jpg","size":128,"progress":1,"priority":1}
+			]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	files, err := c.Files(context.Background(), hash)
+	if err != nil {
+		t.Fatalf("Files: %v", err)
+	}
+	if len(files) != 3 {
+		t.Fatalf("want 3 files, got %d", len(files))
+	}
+	if files[0].Name != "MyBook/disc01.m4b" || files[0].Size != 1024 {
+		t.Errorf("file 0 mismatch: %+v", files[0])
+	}
+	if files[2].Name != "MyBook/cover.jpg" {
+		t.Errorf("file 2 mismatch: %+v", files[2])
+	}
+}
+
+// TestClient_Files_SingleFileTorrent — the issue #903 shape: a torrent
+// containing a single loose file at the save root. Name is just the
+// basename so the importer can resolve it directly via SavePath join.
+func TestClient_Files_SingleFileTorrent(t *testing.T) {
+	const hash = "1111111111111111111111111111111111111111"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/files":
+			_, _ = w.Write([]byte(`[{"name":"standalone-book.m4b","size":50000,"progress":1}]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	files, err := c.Files(context.Background(), hash)
+	if err != nil {
+		t.Fatalf("Files: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "standalone-book.m4b" {
+		t.Errorf("expected single basename-only file, got %+v", files)
+	}
+}
+
+// TestClient_Files_TorrentMissing — qBittorrent returns 404 for an unknown
+// hash. Files() surfaces this as an error so the importer can decide to
+// fall back to the directory walk (with a WARN) rather than swallowing the
+// signal.
+func TestClient_Files_TorrentMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/files":
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	if _, err := c.Files(context.Background(), "nonexistent-hash"); err == nil {
+		t.Fatal("expected error for unknown torrent hash")
+	}
+}
+
+// TestClient_Files_WindowsBackslashesNormalized — a Windows qBittorrent
+// instance reports nested file names with backslashes. The importer
+// downstream uses forward-slash path operations, so Files() must normalize
+// at the API boundary.
+func TestClient_Files_WindowsBackslashesNormalized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/files":
+			_, _ = w.Write([]byte(`[{"name":"MyBook\\disc01.m4b","size":1024}]`))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	files, err := c.Files(context.Background(), "h")
+	if err != nil {
+		t.Fatalf("Files: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "MyBook/disc01.m4b" {
+		t.Errorf("backslash not normalized: %+v", files)
+	}
+}

--- a/internal/downloader/qbittorrent/types.go
+++ b/internal/downloader/qbittorrent/types.go
@@ -69,6 +69,23 @@ func (c *Category) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// File is a single file belonging to a torrent, as returned by
+// /api/v2/torrents/files?hash=<hash>. Name is the path relative to the
+// torrent's save path (forward-slash normalised); for a single-file
+// torrent it is just the file's basename.
+type File struct {
+	Name string
+	Size int64
+}
+
+// rpcFile mirrors the qBittorrent v2 API shape for a torrent file entry.
+// Only name + size are needed by the importer; progress, priority, and the
+// rest are intentionally discarded.
+type rpcFile struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
 func categoryPathString(raw json.RawMessage) string {
 	if len(raw) == 0 || string(raw) == "null" {
 		return ""

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -183,6 +183,56 @@ func (c *Client) GetTorrents(ctx context.Context, downloadDir string) ([]Torrent
 	return resp.Arguments.Torrents, nil
 }
 
+// Files returns the per-torrent file list for torrentID. Names are paths
+// relative to the torrent's downloadDir; for a single-file torrent dropped
+// directly at the root the entry's Name is just the file's basename.
+//
+// This is the authoritative list of files that belong to this torrent, used
+// by the importer (issue #903) to avoid walking the shared download root and
+// picking up unrelated siblings.
+//
+// An empty list with a nil error means Transmission reported no files for
+// the torrent (typical for a torrent still resolving metadata at 0%). An
+// unknown torrent ID returns ("", error) so the caller can distinguish
+// "metadata not yet available" from "torrent gone".
+func (c *Client) Files(ctx context.Context, torrentID int64) ([]File, error) {
+	args := map[string]interface{}{
+		"ids":    []int64{torrentID},
+		"fields": []string{"id", "files"},
+	}
+
+	req, err := c.buildRequest(ctx, "torrent-get", args)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := c.doRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp torrentFilesResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("decode torrent-get files response: %w", err)
+	}
+	if resp.Result != "success" {
+		return nil, fmt.Errorf("torrent-get files failed: %s", resp.Result)
+	}
+	if len(resp.Arguments.Torrents) == 0 {
+		// No torrent matched the supplied id. Surface a distinct error so the
+		// importer can decide to retry vs. terminally fail. Empty Files on a
+		// matched torrent (metadata still resolving) is the nil/empty return.
+		return nil, fmt.Errorf("torrent %d not found", torrentID)
+	}
+	out := make([]File, 0, len(resp.Arguments.Torrents[0].Files))
+	for _, f := range resp.Arguments.Torrents[0].Files {
+		if f.Name == "" {
+			continue
+		}
+		out = append(out, File{Name: f.Name, Size: f.Length})
+	}
+	return out, nil
+}
+
 // RemoveTorrent removes a torrent by ID.
 func (c *Client) RemoveTorrent(ctx context.Context, torrentID int64, deleteFiles bool) error {
 	args := map[string]interface{}{

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -260,6 +260,123 @@ func TestGetTorrents_InvalidJSON(t *testing.T) {
 	}
 }
 
+// TestClient_Files_ReturnsRelativeNames verifies that Files() decodes the
+// torrent-get RPC "files" entries into the importer's []File shape with
+// names left in the form Transmission reported them (relative to the
+// torrent's downloadDir). Issue #903 regression guard: the importer relies
+// on these names being the authoritative file list of the torrent so it
+// can avoid walking the shared download root.
+func TestClient_Files_ReturnsRelativeNames(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"result":"success",
+			"arguments":{
+				"torrents":[{
+					"id":42,
+					"files":[
+						{"name":"MyBook/disc01.m4b","length":1024,"bytesCompleted":1024},
+						{"name":"MyBook/disc02.m4b","length":2048,"bytesCompleted":2048},
+						{"name":"MyBook/cover.jpg","length":128,"bytesCompleted":128}
+					]
+				}]
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	files, err := c.Files(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("Files: %v", err)
+	}
+	if len(files) != 3 {
+		t.Fatalf("want 3 files, got %d", len(files))
+	}
+	if files[0].Name != "MyBook/disc01.m4b" || files[0].Size != 1024 {
+		t.Errorf("file 0 mismatch: %+v", files[0])
+	}
+	if files[2].Name != "MyBook/cover.jpg" || files[2].Size != 128 {
+		t.Errorf("file 2 mismatch: %+v", files[2])
+	}
+}
+
+// TestClient_Files_SingleFileTorrent — issue #903 specific shape: a torrent
+// containing a single loose file with no subfolder. The Name is just the
+// basename; joining it with downloadDir yields the file's on-disk path.
+func TestClient_Files_SingleFileTorrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"result":"success",
+			"arguments":{
+				"torrents":[{
+					"id":7,
+					"files":[
+						{"name":"standalone-book.m4b","length":50000,"bytesCompleted":50000}
+					]
+				}]
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	files, err := c.Files(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("Files: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("want 1 file, got %d", len(files))
+	}
+	if files[0].Name != "standalone-book.m4b" {
+		t.Errorf("expected basename-only Name, got %q", files[0].Name)
+	}
+}
+
+// TestClient_Files_TorrentMissing — when torrent-get returns an empty torrents
+// array Transmission has no record of the supplied id (already removed, or
+// the supplied id was wrong). The caller needs a distinct signal so the
+// importer can decide whether to retry the next cycle or terminally fail.
+func TestClient_Files_TorrentMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{"torrents":[]}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	_, err := c.Files(context.Background(), 999)
+	if err == nil {
+		t.Fatal("expected error for unknown torrent id")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+// TestClient_Files_NoFilesYet — a torrent that is still resolving metadata
+// (e.g. magnet at 0%) appears in torrent-get but with an empty files array.
+// Files() returns an empty slice with no error so the importer can retry
+// next cycle once the metadata flushes.
+func TestClient_Files_NoFilesYet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"result":"success",
+			"arguments":{
+				"torrents":[{"id":1,"files":[]}]
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	files, err := c.Files(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Files: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("want empty file list, got %d entries", len(files))
+	}
+}
+
 func TestRemoveTorrent_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`{"result":"success","arguments":{}}`))

--- a/internal/downloader/transmission/types.go
+++ b/internal/downloader/transmission/types.go
@@ -39,3 +39,34 @@ type TorrentGetResponse struct {
 type SimpleResponse struct {
 	Result string `json:"result"`
 }
+
+// File is a single file belonging to a torrent, as reported by torrent-get
+// with fields=["files"]. Name is the path relative to the torrent's
+// downloadDir; for a single-file torrent it is just the file's basename.
+type File struct {
+	Name string
+	Size int64
+}
+
+// rpcFile mirrors the Transmission RPC shape: each entry under arguments
+// .torrents[].files is {bytesCompleted, length, name}. Bindery only needs
+// name + length to drive the importer; bytesCompleted is intentionally
+// dropped (the per-torrent percentDone already gates whether files are
+// flushed to disk).
+type rpcFile struct {
+	Name           string `json:"name"`
+	Length         int64  `json:"length"`
+	BytesCompleted int64  `json:"bytesCompleted"`
+}
+
+// torrentFilesResponse decodes the torrent-get response when only the
+// files field is requested.
+type torrentFilesResponse struct {
+	Arguments struct {
+		Torrents []struct {
+			ID    int64     `json:"id"`
+			Files []rpcFile `json:"files"`
+		} `json:"torrents"`
+	} `json:"arguments"`
+	Result string `json:"result"`
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -920,11 +920,14 @@ func (s *Scanner) checkNZBGetDownloads(ctx context.Context, client *models.Downl
 
 // tryImportNZBGet attempts to import a completed NZBGet download into the library.
 // ng is used to clean up the NZBGet history entry once bindery has taken ownership.
+//
+// NZBGet always lands a job inside a per-job DestDir, so walking that path is
+// safe; the issue #903 file-list API addition does not apply here.
 func (s *Scanner) tryImportNZBGet(ctx context.Context, ng *nzbget.Client, dl *models.Download, nzbID int, downloadPath string) {
 	nzbIDStr := strconv.Itoa(nzbID)
 	s.tryImportInternal(ctx, dl, downloadPath, "nzbget", nzbIDStr, func() error {
 		return ng.RemoveHistory(ctx, nzbID)
-	})
+	}, nil)
 }
 
 // checkTransmissionDownloads polls Transmission for status changes.
@@ -977,18 +980,25 @@ func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models
 		if isComplete && (dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed) {
 			// Download is complete
 			downloadPath := s.remapDownloadClientPath(client, torrent.DownloadDir)
-			slog.Info("download completed", "title", dl.Title, "path", downloadPath)
+			// Issue #903: ask Transmission for the authoritative file list so
+			// the importer only touches files belonging to THIS torrent rather
+			// than walking the shared download root. A nil return signals
+			// transmissionFilesFor to fall back to the legacy dir walk (a WARN
+			// is already emitted inside the helper).
+			bookFiles := s.transmissionFilesFor(ctx, trans, client, torrent)
+			slog.Info("download completed", "title", dl.Title, "path", downloadPath, "files", len(bookFiles))
 			s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
-			s.tryImportTransmission(ctx, &dl, downloadPath)
+			s.tryImportTransmission(ctx, &dl, downloadPath, bookFiles)
 		} else if isComplete && dl.Status == models.StateImportFailed && dl.ImportRetryCount < importRetryLimit {
 			// Bug #7: retry a previously failed import.
 			downloadPath := s.remapDownloadClientPath(client, torrent.DownloadDir)
+			bookFiles := s.transmissionFilesFor(ctx, trans, client, torrent)
 			slog.Info("retrying failed import", "title", dl.Title, "path", downloadPath,
-				"attempt", dl.ImportRetryCount+1, "limit", importRetryLimit)
+				"attempt", dl.ImportRetryCount+1, "limit", importRetryLimit, "files", len(bookFiles))
 			if err := s.downloads.IncrementImportRetryCount(ctx, dl.ID); err != nil {
 				slog.Warn("failed to increment import retry count", "download_id", dl.ID, "error", err)
 			}
-			s.tryImportTransmission(ctx, &dl, downloadPath)
+			s.tryImportTransmission(ctx, &dl, downloadPath, bookFiles)
 		} else if isStopped && !isComplete && dl.Status != models.StateFailed {
 			if stopError == "" {
 				// Transmission also reports user-paused torrents as stopped.
@@ -1096,9 +1106,15 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 			}
 			downloadPath := s.remapDownloadClientPath(client, rawPath)
 
-			slog.Info("download completed", "title", dl.Title, "path", downloadPath, "raw_path", rawPath)
+			// Issue #903: ask qBittorrent for the authoritative file list so
+			// the importer only touches files belonging to THIS torrent.
+			// qbittorrentFilesFor returns nil and logs a WARN on RPC error
+			// or empty-file response; tryImportInternal then falls back to
+			// the legacy filepath.Walk(downloadPath).
+			bookFiles := s.qbittorrentFilesFor(ctx, qb, client, torrent)
+			slog.Info("download completed", "title", dl.Title, "path", downloadPath, "raw_path", rawPath, "files", len(bookFiles))
 			s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
-			s.tryImportQbittorrent(ctx, &dl, downloadPath)
+			s.tryImportQbittorrent(ctx, &dl, downloadPath, bookFiles)
 		} else if isComplete && dl.Status == models.StateImportFailed && dl.ImportRetryCount < importRetryLimit {
 			// Bug #7: a previous import attempt failed (e.g. transient filesystem
 			// error, path mismatch). The torrent is still seeding so we have the
@@ -1123,12 +1139,13 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 				continue
 			}
 			downloadPath := s.remapDownloadClientPath(client, rawPath)
+			bookFiles := s.qbittorrentFilesFor(ctx, qb, client, torrent)
 			slog.Info("retrying failed import", "title", dl.Title, "path", downloadPath,
-				"attempt", dl.ImportRetryCount+1, "limit", importRetryLimit)
+				"attempt", dl.ImportRetryCount+1, "limit", importRetryLimit, "files", len(bookFiles))
 			if err := s.downloads.IncrementImportRetryCount(ctx, dl.ID); err != nil {
 				slog.Warn("failed to increment import retry count", "download_id", dl.ID, "error", err)
 			}
-			s.tryImportQbittorrent(ctx, &dl, downloadPath)
+			s.tryImportQbittorrent(ctx, &dl, downloadPath, bookFiles)
 		} else if isFailed && dl.Status != models.StateFailed {
 			slog.Warn("download failed", "title", dl.Title, "state", torrent.State)
 			s.markDownloadFailed(ctx, &dl, "Torrent failed in qBittorrent")
@@ -1147,20 +1164,214 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 // tryImportSABnzbd attempts to import a completed SABnzbd download into the library.
 // sab is used to clear the SABnzbd history entry once bindery has taken
 // ownership of the files; nzoID is the history slot's NZO identifier.
+//
+// SAB always lands a job inside a per-job completed-folder (`storage` in the
+// history slot), so walking that path is safe; the issue #903 file-list
+// API addition does not apply here.
 func (s *Scanner) tryImportSABnzbd(ctx context.Context, sab *sabnzbd.Client, dl *models.Download, nzoID, downloadPath string) {
 	s.tryImportInternal(ctx, dl, downloadPath, "sabnzbd", nzoID, func() error {
 		// Clean up SABnzbd history
 		return sab.DeleteHistory(ctx, nzoID, false)
-	})
+	}, nil)
 }
 
 // tryImportTransmission attempts to import a completed Transmission download into the library.
-func (s *Scanner) tryImportTransmission(ctx context.Context, dl *models.Download, downloadPath string) {
-	s.tryImportInternal(ctx, dl, downloadPath, "transmission", safeRemoteID(dl.TorrentID), nil)
+//
+// explicitFiles, when non-nil and non-empty, is the absolute Bindery-side
+// path of every file that belongs to this specific torrent (built from the
+// Transmission torrent-get "files" RPC and run through PathRemap). Passing
+// it avoids the legacy filepath.Walk(downloadPath) and the issue #903 class
+// of bug where a single-file torrent at a shared download root would cause
+// every unrelated sibling to be imported. Pass nil to fall back to the
+// directory walk.
+func (s *Scanner) tryImportTransmission(ctx context.Context, dl *models.Download, downloadPath string, explicitFiles []string) {
+	s.tryImportInternal(ctx, dl, downloadPath, "transmission", safeRemoteID(dl.TorrentID), nil, explicitFiles)
 }
 
-func (s *Scanner) tryImportQbittorrent(ctx context.Context, dl *models.Download, downloadPath string) {
-	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", safeRemoteID(dl.TorrentID), nil)
+// tryImportQbittorrent attempts to import a completed qBittorrent download. See
+// tryImportTransmission for the semantics of explicitFiles.
+func (s *Scanner) tryImportQbittorrent(ctx context.Context, dl *models.Download, downloadPath string, explicitFiles []string) {
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", safeRemoteID(dl.TorrentID), nil, explicitFiles)
+}
+
+// torrentFile is the minimal shape resolveTorrentFiles consumes; it matches
+// transmission.File / qbittorrent.File / deluge.File without taking a
+// dependency on any of them. Each downloader's File type is converted to
+// []torrentFile at the call site.
+type torrentFile struct {
+	Name string
+	Size int64
+}
+
+// resolveTorrentFiles maps a downloader's per-torrent file list onto absolute
+// Bindery-side book-file paths. For each file:
+//
+//  1. Join the client's save path with the file's relative name, producing
+//     the path the download client sees on its filesystem.
+//  2. Apply the download-client's PathRemap (and the global scanner remapper
+//     when no client-level rule matches) so Bindery sees the file at its
+//     local mount point. This is the same helper checkXxxDownloads already
+//     uses for the per-torrent downloadPath, so a single shared rule covers
+//     both the parent dir and the files inside it.
+//  3. Filter to book files via IsBookFile to match what the legacy
+//     filepath.Walk path produced.
+//
+// Files with empty or path-traversing names ("..", absolute paths) are
+// rejected and logged at WARN; they shouldn't reach here from a sane client
+// response and treating them as legitimate could resolve outside the
+// download root.
+//
+// The Bindery-side absolute path is returned with filepath.Clean applied so
+// downstream code (cleanupMovedSources, alreadyImportedPath) compares clean
+// forms consistently.
+func (s *Scanner) resolveTorrentFiles(client *models.DownloadClient, clientSavePath string, files []torrentFile) []string {
+	if len(files) == 0 || strings.TrimSpace(clientSavePath) == "" {
+		return nil
+	}
+	out := make([]string, 0, len(files))
+	for _, f := range files {
+		name := strings.TrimSpace(f.Name)
+		if name == "" {
+			continue
+		}
+		// Reject absolute paths and any ".." path segment: both can resolve
+		// outside the torrent's save path; a sane client never produces them
+		// in the files-list response, so treat them as malformed and skip
+		// rather than silently quoting an attacker-controlled name through
+		// Join. Splitting and matching per-segment avoids false positives on
+		// legitimate names like "My..Book.epub" while still catching
+		// "MyBook/../escape.epub".
+		if filepath.IsAbs(name) || hasDotDotSegment(name) {
+			slog.Warn("import: rejecting malformed file name from download client",
+				"client", client.Name, "name", name)
+			continue
+		}
+		clientPath := filepath.Join(clientSavePath, name)
+		binderyPath := filepath.Clean(s.remapDownloadClientPath(client, clientPath))
+		if !IsBookFile(binderyPath) {
+			continue
+		}
+		out = append(out, binderyPath)
+	}
+	return out
+}
+
+// hasDotDotSegment reports whether p contains a ".." path segment under
+// either forward-slash or platform separators. The downloader Files() APIs
+// normalise to forward slash already, but checking both is defensive — a
+// rogue Windows-format response then can't smuggle a "..\\" past the
+// guard.
+func hasDotDotSegment(p string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(p), "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveAudiobookSource decides what to move/copy/hardlink for an audiobook
+// import when the caller supplied an explicit per-torrent file list. The
+// audiobook flow normally moves the whole download folder so cover art,
+// cue sheets and other non-book companions land together, which is wrong
+// for a single-file torrent whose downloadPath is a shared download root
+// (issue #903).
+//
+// Returns either (path, false) when a safe source path is found:
+//
+//   - For a single book file the file's path itself (the existing
+//     not-a-directory branch then places it inside destDir).
+//   - For multiple book files sharing a common directory strictly under
+//     downloadPath, that common directory (so companion files within the
+//     torrent's folder ride along).
+//
+// Returns ("", true) when no safe directory exists, signalling the caller
+// to fall back to per-file placement. This covers the shape where bookFiles
+// share no parent below the (shared) downloadPath, i.e. exactly the
+// dangerous case the issue describes.
+func (s *Scanner) resolveAudiobookSource(downloadPath string, bookFiles []string) (string, bool) {
+	if len(bookFiles) == 0 {
+		return downloadPath, false
+	}
+	if len(bookFiles) == 1 {
+		return bookFiles[0], false
+	}
+	common := filepath.Clean(filepath.Dir(bookFiles[0]))
+	for _, f := range bookFiles[1:] {
+		fDir := filepath.Clean(filepath.Dir(f))
+		// Walk common upward until it sits at or above fDir.
+		for common != fDir && !pathUnderDir(fDir, common) {
+			parent := filepath.Dir(common)
+			if parent == common {
+				break
+			}
+			common = parent
+		}
+	}
+	cleanDownload := filepath.Clean(downloadPath)
+	// Only accept a common directory that is strictly under downloadPath.
+	// Equal-to-downloadPath means the bookFiles sit at the shared download
+	// root (the issue #903 shape) and moving downloadPath would catch
+	// unrelated siblings. Outside-downloadPath should never happen if the
+	// remap is consistent; treat the same way.
+	if common == cleanDownload || !pathUnderDir(common, cleanDownload) {
+		return "", true
+	}
+	return common, false
+}
+
+// transmissionFilesFor calls Transmission's torrent-get "files" RPC for the
+// supplied torrent and returns the absolute Bindery-side book-file paths,
+// or nil when the call fails or the torrent reported no files yet. A nil
+// return signals tryImportInternal to fall back to filepath.Walk; the
+// caller is responsible for emitting the WARN log that records the
+// fallback so an operator can spot a misconfigured / unreachable client.
+func (s *Scanner) transmissionFilesFor(ctx context.Context, trans *transmission.Client, client *models.DownloadClient, torrent transmission.Torrent) []string {
+	files, err := trans.Files(ctx, torrent.ID)
+	if err != nil {
+		slog.Warn("import: Transmission Files RPC failed, falling back to directory walk (issue #903 fallback)",
+			"title", torrent.Name, "id", torrent.ID, "error", err)
+		return nil
+	}
+	if len(files) == 0 {
+		slog.Warn("import: Transmission reported no files for torrent yet, falling back to directory walk",
+			"title", torrent.Name, "id", torrent.ID)
+		return nil
+	}
+	conv := make([]torrentFile, 0, len(files))
+	for _, f := range files {
+		conv = append(conv, torrentFile{Name: f.Name, Size: f.Size})
+	}
+	return s.resolveTorrentFiles(client, torrent.DownloadDir, conv)
+}
+
+// qbittorrentFilesFor calls qBittorrent's /torrents/files API for the
+// supplied torrent and returns the absolute Bindery-side book-file paths,
+// or nil when the call fails or qBittorrent reported no files yet.
+//
+// SavePath, not ContentPath, is the join base: qBittorrent's files API
+// returns names that include the torrent's display folder (e.g.
+// "MyBook/file.epub") when the torrent has one, and just the basename for
+// single-file torrents. Joining against SavePath reproduces what's on disk
+// in both cases. ContentPath is the wrong base for multi-file torrents
+// because the file names already include the folder.
+func (s *Scanner) qbittorrentFilesFor(ctx context.Context, qb *qbittorrent.Client, client *models.DownloadClient, torrent qbittorrent.Torrent) []string {
+	files, err := qb.Files(ctx, torrent.Hash)
+	if err != nil {
+		slog.Warn("import: qBittorrent Files API failed, falling back to directory walk (issue #903 fallback)",
+			"title", torrent.Name, "hash", torrent.Hash, "error", err)
+		return nil
+	}
+	if len(files) == 0 {
+		slog.Warn("import: qBittorrent reported no files for torrent yet, falling back to directory walk",
+			"title", torrent.Name, "hash", torrent.Hash)
+		return nil
+	}
+	conv := make([]torrentFile, 0, len(files))
+	for _, f := range files {
+		conv = append(conv, torrentFile{Name: f.Name, Size: f.Size})
+	}
+	return s.resolveTorrentFiles(client, torrent.SavePath, conv)
 }
 
 func (s *Scanner) remapDownloadClientPath(client *models.DownloadClient, rawPath string) string {
@@ -1293,8 +1504,19 @@ func (s *Scanner) alreadyImportedPath(ctx context.Context, book *models.Book, de
 	return false
 }
 
-// tryImportInternal is the common import logic shared by SABnzbd and Transmission.
-func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, downloadPath, cleanupClientType, cleanupRemoteID string, cleanupFunc func() error) {
+// tryImportInternal is the common import logic shared by SABnzbd, NZBGet,
+// Transmission and qBittorrent.
+//
+// explicitFiles, when non-nil and non-empty, is the authoritative list of
+// absolute Bindery-side file paths that belong to the download. Passing it
+// short-circuits the legacy filepath.Walk(downloadPath) discovery and is
+// the issue #903 fix: with a shared download root (Transmission's default)
+// a single-file torrent's downloadPath is the entire shared root and a
+// directory walk would import every unrelated sibling. The list is built
+// from the per-client Files() RPC by the caller; pass nil when no such
+// list is available (older client API, RPC error) and the legacy walk
+// runs as the fallback.
+func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, downloadPath, cleanupClientType, cleanupRemoteID string, cleanupFunc func() error, explicitFiles []string) {
 	if s.libraryDir == "" {
 		slog.Warn("no library directory configured, skipping import")
 		// Not writable/configured — needs user action before import can proceed.
@@ -1331,18 +1553,29 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		return
 	}
 
-	// Find book files in the download path
+	// Find book files. When the caller supplied an explicit per-torrent file
+	// list (issue #903: built from the client's authoritative Files() RPC),
+	// use that directly; it is strictly more precise than filepath.Walk and
+	// avoids importing unrelated siblings when downloadPath is a shared
+	// download root. Falling through to the walk preserves behaviour for
+	// callers that can't (or don't yet) supply a file list (SABnzbd/NZBGet
+	// per-job destDir, plus the RPC-failure fallback path for torrent
+	// clients).
 	var bookFiles []string
-	if err := filepath.Walk(downloadPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
+	if len(explicitFiles) > 0 {
+		bookFiles = explicitFiles
+	} else {
+		if err := filepath.Walk(downloadPath, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return nil
+			}
+			if IsBookFile(path) {
+				bookFiles = append(bookFiles, path)
+			}
 			return nil
+		}); err != nil {
+			slog.Warn("failed to walk download path", "path", downloadPath, "error", err)
 		}
-		if IsBookFile(path) {
-			bookFiles = append(bookFiles, path)
-		}
-		return nil
-	}); err != nil {
-		slog.Warn("failed to walk download path", "path", downloadPath, "error", err)
 	}
 
 	if len(bookFiles) == 0 {
@@ -1445,43 +1678,88 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		}
 		destDir := UniqueDir(audiobookDest)
 		mode := importMode
-		slog.Info("importing audiobook folder", "src", downloadPath, "dst", destDir, "mode", mode)
+		// audiobookSource is the path the move/copy/hardlink will operate on.
+		// When the caller supplied an explicit per-torrent file list (issue
+		// #903), prefer that to downloadPath: downloadPath can be a shared
+		// download root for single-file torrents and moving the whole root
+		// would drag in unrelated sibling files. resolveAudiobookSource
+		// inspects bookFiles and returns either the lone file (single-file
+		// torrent), the torrent's strict subdir (multi-file torrent unpacked
+		// into its own folder), or "" with usePerFile=true to fall through to
+		// per-file placement.
+		audiobookSource := downloadPath
+		usePerFile := false
+		if len(explicitFiles) > 0 {
+			src, perFile := s.resolveAudiobookSource(downloadPath, bookFiles)
+			usePerFile = perFile
+			if !perFile {
+				audiobookSource = src
+			}
+		}
+		slog.Info("importing audiobook folder", "src", audiobookSource, "dst", destDir, "mode", mode, "perFile", usePerFile)
 		// Single-file audiobook releases (e.g. a lone .m4b from a torrent) give
 		// us a file path rather than a folder. MoveDir/CopyDir/HardlinkDir all
 		// reject non-directory sources, so place the file inside destDir.
-		srcInfo, statErr := os.Stat(downloadPath)
-		if statErr != nil {
-			slog.Error("failed to stat audiobook source", "src", downloadPath, "error", statErr)
-			s.failImport(ctx, dl, models.StateImportBlocked, fmt.Sprintf("audiobook source unavailable: %v", statErr))
-			return
-		}
 		var dirErr error
-		if srcInfo.IsDir() {
-			switch mode {
-			case "hardlink":
-				dirErr = HardlinkDir(downloadPath, destDir)
-			case "copy":
-				dirErr = CopyDirCtx(importCtx, downloadPath, destDir)
-			default:
-				dirErr = MoveDirCtx(importCtx, downloadPath, destDir)
-			}
-		} else {
+		if usePerFile {
+			// Files don't share a strict subdir under downloadPath; copy each
+			// known file into destDir individually. This loses cover art and
+			// cue sheets that the dir walk would have grabbed, but is safer
+			// than moving the shared download root.
 			if err := os.MkdirAll(destDir, 0o750); err != nil {
 				dirErr = fmt.Errorf("create audiobook dest dir: %w", err)
 			} else {
-				dstFile := filepath.Join(destDir, filepath.Base(downloadPath))
+				for _, srcFile := range bookFiles {
+					dstFile := filepath.Join(destDir, filepath.Base(srcFile))
+					var fileErr error
+					switch mode {
+					case "hardlink":
+						fileErr = HardlinkFile(srcFile, dstFile)
+					case "copy":
+						fileErr = CopyFileCtx(importCtx, srcFile, dstFile)
+					default:
+						fileErr = MoveFileCtx(importCtx, srcFile, dstFile)
+					}
+					if fileErr != nil {
+						dirErr = fileErr
+						break
+					}
+				}
+			}
+		} else {
+			srcInfo, statErr := os.Stat(audiobookSource)
+			if statErr != nil {
+				slog.Error("failed to stat audiobook source", "src", audiobookSource, "error", statErr)
+				s.failImport(ctx, dl, models.StateImportBlocked, fmt.Sprintf("audiobook source unavailable: %v", statErr))
+				return
+			}
+			if srcInfo.IsDir() {
 				switch mode {
 				case "hardlink":
-					dirErr = HardlinkFile(downloadPath, dstFile)
+					dirErr = HardlinkDir(audiobookSource, destDir)
 				case "copy":
-					dirErr = CopyFileCtx(importCtx, downloadPath, dstFile)
+					dirErr = CopyDirCtx(importCtx, audiobookSource, destDir)
 				default:
-					dirErr = MoveFileCtx(importCtx, downloadPath, dstFile)
+					dirErr = MoveDirCtx(importCtx, audiobookSource, destDir)
+				}
+			} else {
+				if err := os.MkdirAll(destDir, 0o750); err != nil {
+					dirErr = fmt.Errorf("create audiobook dest dir: %w", err)
+				} else {
+					dstFile := filepath.Join(destDir, filepath.Base(audiobookSource))
+					switch mode {
+					case "hardlink":
+						dirErr = HardlinkFile(audiobookSource, dstFile)
+					case "copy":
+						dirErr = CopyFileCtx(importCtx, audiobookSource, dstFile)
+					default:
+						dirErr = MoveFileCtx(importCtx, audiobookSource, dstFile)
+					}
 				}
 			}
 		}
 		if dirErr != nil {
-			slog.Error("failed to import audiobook folder", "src", downloadPath, "mode", mode, "error", dirErr)
+			slog.Error("failed to import audiobook folder", "src", audiobookSource, "mode", mode, "error", dirErr)
 			s.failImport(ctx, dl, models.StateImportBlocked, fmt.Sprintf("audiobook %s failed: %v", mode, dirErr))
 			return
 		}

--- a/internal/importer/scanner_abs_test.go
+++ b/internal/importer/scanner_abs_test.go
@@ -94,7 +94,7 @@ func TestTryImportInternal_NotifiesABSAfterAudiobookImport(t *testing.T) {
 	const wantLibraryID = "lib-audiobooks-123"
 	s.WithABSNotifier(notifier, func() []string { return []string{wantLibraryID} })
 
-	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil)
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil, nil)
 
 	if len(notifier.scanCalls) != 1 {
 		t.Fatalf("expected 1 ScanLibrary call after audiobook import, got %d", len(notifier.scanCalls))
@@ -118,7 +118,7 @@ func TestTryImportInternal_NotifiesAllConfiguredABSLibraries(t *testing.T) {
 	notifier := &fakeABSNotifier{}
 	s.WithABSNotifier(notifier, func() []string { return []string{"lib-books", "lib-audio", "lib-books", ""} })
 
-	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil)
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil, nil)
 
 	if got, want := len(notifier.scanCalls), 2; got != want {
 		t.Fatalf("ScanLibrary calls = %d, want %d: %v", got, want, notifier.scanCalls)
@@ -166,7 +166,7 @@ func TestTryImportInternal_DoesNotNotifyABSForEbookImport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil)
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil, nil)
 
 	if len(notifier.scanCalls) != 0 {
 		t.Fatalf("expected 0 ScanLibrary calls for ebook import, got %d: %v", len(notifier.scanCalls), notifier.scanCalls)
@@ -191,7 +191,7 @@ func TestTryImportInternal_ABSNotifySkippedWhenNoLibraryID(t *testing.T) {
 	// Library ID resolver returns "" — ABS not configured.
 	s.WithABSNotifier(notifier, func() []string { return nil })
 
-	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil)
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", nil, nil)
 
 	if len(notifier.scanCalls) != 0 {
 		t.Fatalf("expected 0 ScanLibrary calls when libraryID is empty, got %d", len(notifier.scanCalls))

--- a/internal/importer/scanner_dataloss_test.go
+++ b/internal/importer/scanner_dataloss_test.go
@@ -111,7 +111,7 @@ func TestTryImportInternal_PartialFailureDoesNotDeleteUnlandedSource(t *testing.
 		t.Fatal(err)
 	}
 
-	s.tryImportInternal(ctx, dl, downloadPath, "transmission", "tor-1", nil)
+	s.tryImportInternal(ctx, dl, downloadPath, "transmission", "tor-1", nil, nil)
 
 	// The download must NOT be terminal-imported: one file failed.
 	got, err := dlRepo.GetByGUID(ctx, dl.GUID)

--- a/internal/importer/scanner_diagnostics_test.go
+++ b/internal/importer/scanner_diagnostics_test.go
@@ -45,7 +45,7 @@ func TestTryImportInternal_PathNotFound(t *testing.T) {
 	// a temp dir that was never created.
 	nonexistent := filepath.Join(t.TempDir(), "qbit-container-path", "book.epub")
 
-	s.tryImportInternal(ctx, dl, nonexistent, "", "", nil)
+	s.tryImportInternal(ctx, dl, nonexistent, "", "", nil, nil)
 
 	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
 	if err != nil {
@@ -72,7 +72,7 @@ func TestTryImportInternal_PathExistsNoBooks(t *testing.T) {
 	// An existing but empty directory — os.Stat succeeds, IsNotExist is false.
 	emptyDir := t.TempDir()
 
-	s.tryImportInternal(ctx, dl, emptyDir, "", "", nil)
+	s.tryImportInternal(ctx, dl, emptyDir, "", "", nil, nil)
 
 	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
 	if err != nil {

--- a/internal/importer/scanner_filelist_test.go
+++ b/internal/importer/scanner_filelist_test.go
@@ -1,0 +1,358 @@
+package importer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestImport_SingleFileTorrentSkipsSiblingFiles is the end-to-end regression
+// test for issue #903.
+//
+// Scenario: Transmission reports a completed torrent whose single file (an
+// .m4b audiobook) sits directly inside the shared download root. The same
+// shared root holds unrelated sibling files (other books seeded by the
+// user). Before the fix, Bindery walked downloadDir and imported every
+// recognised book file there, dragging the unrelated siblings into the
+// library. With the file-list API the importer asks Transmission which
+// files belong to THIS torrent and only stages those.
+func TestImport_SingleFileTorrentSkipsSiblingFiles(t *testing.T) {
+	// One shared download root with three book files: the torrent's own
+	// file plus two unrelated siblings that must NOT be imported.
+	sharedDownloadDir := t.TempDir()
+	ownFile := filepath.Join(sharedDownloadDir, "the-book.m4b")
+	siblingA := filepath.Join(sharedDownloadDir, "other-book-a.m4b")
+	siblingB := filepath.Join(sharedDownloadDir, "unrelated-ebook.epub")
+	for _, p := range []string{ownFile, siblingA, siblingB} {
+		if err := os.WriteFile(p, []byte("data"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	libraryDir := t.TempDir()
+	audiobookDir := t.TempDir()
+
+	// Transmission stub. torrent-get for fields=[id, files] returns ONLY
+	// "the-book.m4b" so the importer must not pick up the siblings.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Method    string         `json:"method"`
+			Arguments map[string]any `json:"arguments"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Method != "torrent-get" {
+			_, _ = w.Write([]byte(`{"result":"success","arguments":{}}`))
+			return
+		}
+		fields, _ := body.Arguments["fields"].([]any)
+		hasFiles := false
+		for _, f := range fields {
+			if f == "files" {
+				hasFiles = true
+				break
+			}
+		}
+		if hasFiles {
+			_, _ = w.Write([]byte(`{
+				"result":"success",
+				"arguments":{
+					"torrents":[{
+						"id":42,
+						"files":[{"name":"the-book.m4b","length":4,"bytesCompleted":4}]
+					}]
+				}
+			}`))
+			return
+		}
+		// listing call (the one driven by GetTorrents)
+		torrents := []map[string]any{{
+			"id":          42,
+			"hashString":  "h",
+			"name":        "the-book",
+			"percentDone": 1.0,
+			"status":      3,
+			"downloadDir": sharedDownloadDir,
+		}}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result":    "success",
+			"arguments": map[string]any{"torrents": torrents},
+		})
+	}))
+	defer srv.Close()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, audiobookDir, "", "", "")
+
+	author := &models.Author{Name: "Test Author", ForeignID: "a-903", SortName: "Author, Test"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{AuthorID: author.ID, Title: "The Book", ForeignID: "b-903", Status: "wanted", MediaType: models.MediaTypeAudiobook}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	host, port := scannerTestHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name: "transmission-903", Type: "transmission",
+		Host: host, Port: port, Enabled: true,
+	}
+	if err := clientRepo.Create(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+
+	torrentID := "42"
+	dl := &models.Download{
+		GUID:             "guid-903",
+		Title:            "The Book",
+		Status:           models.StateDownloading,
+		Protocol:         "torrent",
+		TorrentID:        &torrentID,
+		BookID:           &book.ID,
+		DownloadClientID: &client.ID,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	s.checkTransmissionDownloads(ctx, client)
+
+	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.Status != models.StateImported {
+		t.Fatalf("issue #903: expected StateImported, got %q; the file-list path may not have been taken", got.Status)
+	}
+
+	// The book's audiobook file must point inside the library, not somewhere
+	// derived from the shared download root.
+	files, err := bookRepo.ListFiles(ctx, book.ID)
+	if err != nil {
+		t.Fatalf("list book files: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("expected a book file entry after a successful import")
+	}
+	// Walk the audiobook output dir and assert ONLY the torrent's own file
+	// landed there. The two sibling files must not appear in the library.
+	var landed []string
+	if err := filepath.Walk(audiobookDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		landed = append(landed, filepath.Base(path))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range landed {
+		if name != "the-book.m4b" {
+			t.Errorf("issue #903 regression: sibling file %q landed in the audiobook library; expected only the-book.m4b", name)
+		}
+	}
+	if len(landed) == 0 {
+		t.Error("expected the-book.m4b to land in the audiobook library; nothing did")
+	}
+
+	// The siblings must remain untouched in the shared download dir,
+	// confirming the importer never reached for them.
+	for _, sibling := range []string{siblingA, siblingB} {
+		if _, statErr := os.Stat(sibling); statErr != nil {
+			t.Errorf("issue #903 regression: sibling %q was disturbed by the import: %v", sibling, statErr)
+		}
+	}
+}
+
+// TestImport_FallsBackToDirWalkWhenFilesUnavailable verifies the fallback
+// behaviour: when the per-client Files() RPC returns an error the importer
+// must emit a WARN log and fall back to walking the download path, rather
+// than failing the import. This preserves behaviour for older client
+// protocol versions and transient RPC failures.
+//
+// The test exercises tryImportInternal directly with explicitFiles=nil
+// (the way the call site behaves after a failed Files() lookup) and asserts
+// that the directory walk picks up the book file. A separate test
+// (TestImport_SingleFileTorrentSkipsSiblingFiles) covers the
+// happy-path file-list shape end-to-end through checkTransmissionDownloads.
+func TestImport_FallsBackToDirWalkWhenFilesUnavailable(t *testing.T) {
+	downloadDir := t.TempDir()
+	libraryDir := t.TempDir()
+
+	bookFile := filepath.Join(downloadDir, "fallback-book.epub")
+	if err := os.WriteFile(bookFile, []byte("epub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, "", "", "", "")
+
+	author := &models.Author{Name: "Fallback Author", ForeignID: "a-fb", SortName: "Author, Fallback"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{AuthorID: author.ID, Title: "Fallback Book", ForeignID: "b-fb", Status: "wanted", MediaType: models.MediaTypeEbook}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	dl := &models.Download{
+		GUID:   "guid-fallback",
+		Title:  "Fallback Book",
+		Status: models.StateCompleted,
+		BookID: &book.ID,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	// explicitFiles=nil: the caller couldn't get a file list (e.g. RPC
+	// error), so tryImportInternal must walk downloadDir itself. With a
+	// valid book file present the import should succeed.
+	s.tryImportInternal(ctx, dl, downloadDir, "transmission", "42", nil, nil)
+
+	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.Status != models.StateImported {
+		t.Fatalf("fallback path: expected StateImported, got %q", got.Status)
+	}
+	files, err := bookRepo.ListFiles(ctx, book.ID)
+	if err != nil || len(files) == 0 {
+		t.Fatalf("expected book file recorded after fallback walk; files=%v err=%v", files, err)
+	}
+}
+
+// TestResolveTorrentFiles_BuildsAbsoluteBinderyPaths verifies the helper
+// that maps the downloader's per-torrent file list onto absolute Bindery-
+// side paths. The path-remap rule rewrites the client view to Bindery's
+// mount point; IsBookFile drops non-book entries; malformed names with
+// ".." or absolute paths are skipped.
+func TestResolveTorrentFiles_BuildsAbsoluteBinderyPaths(t *testing.T) {
+	s, _, _, _ := scannerFixture(t, t.TempDir())
+	client := &models.DownloadClient{
+		Name:      "trans",
+		Type:      "transmission",
+		PathRemap: "/data/downloads:/local/downloads",
+	}
+	files := []torrentFile{
+		{Name: "MyBook/disc01.m4b", Size: 1024},
+		{Name: "MyBook/cover.jpg", Size: 128}, // dropped by IsBookFile
+		{Name: "MyBook/disc02.m4b", Size: 2048},
+	}
+	got := s.resolveTorrentFiles(client, "/data/downloads", files)
+	want := []string{
+		"/local/downloads/MyBook/disc01.m4b",
+		"/local/downloads/MyBook/disc02.m4b",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: want %d, got %d (%v)", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] want %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+// TestResolveTorrentFiles_RejectsMalformedNames covers the safety guard.
+// A file-list response containing an absolute path or a ".." traversal
+// must be silently skipped rather than producing a path that could
+// resolve outside the torrent's save path.
+func TestResolveTorrentFiles_RejectsMalformedNames(t *testing.T) {
+	s, _, _, _ := scannerFixture(t, t.TempDir())
+	client := &models.DownloadClient{Name: "trans", Type: "transmission"}
+	files := []torrentFile{
+		{Name: "/etc/passwd"},                 // absolute — rejected
+		{Name: "../escape.epub"},              // dotdot — rejected
+		{Name: "MyBook/../outside.epub"},      // hidden dotdot — rejected
+		{Name: "good.epub", Size: 1},          // accepted
+	}
+	got := s.resolveTorrentFiles(client, "/downloads", files)
+	if len(got) != 1 {
+		t.Fatalf("want 1 accepted file, got %d: %v", len(got), got)
+	}
+	if !strings.HasSuffix(got[0], "good.epub") {
+		t.Errorf("expected only good.epub to pass, got %q", got[0])
+	}
+}
+
+// TestResolveAudiobookSource_SingleFileReturnsFileItself — single-file
+// torrent: source is the file itself so the not-a-directory branch of the
+// audiobook flow places it inside destDir. Critically the shared download
+// root is NOT used.
+func TestResolveAudiobookSource_SingleFileReturnsFileItself(t *testing.T) {
+	s, _, _, _ := scannerFixture(t, t.TempDir())
+	got, perFile := s.resolveAudiobookSource("/data/downloads", []string{"/data/downloads/lone.m4b"})
+	if perFile {
+		t.Fatal("single file: expected dir-based placement (perFile=false)")
+	}
+	if got != "/data/downloads/lone.m4b" {
+		t.Errorf("single file: expected file itself, got %q", got)
+	}
+}
+
+// TestResolveAudiobookSource_CommonSubdirAcceptedAsSource — multi-file
+// torrent whose files share a strict subdir of the download root: the
+// helper returns that subdir so MoveDir handles the whole folder.
+func TestResolveAudiobookSource_CommonSubdirAcceptedAsSource(t *testing.T) {
+	s, _, _, _ := scannerFixture(t, t.TempDir())
+	got, perFile := s.resolveAudiobookSource("/data/downloads", []string{
+		"/data/downloads/MyBook/01.m4b",
+		"/data/downloads/MyBook/02.m4b",
+	})
+	if perFile {
+		t.Fatal("common subdir: expected dir-based placement (perFile=false)")
+	}
+	if got != "/data/downloads/MyBook" {
+		t.Errorf("expected common subdir, got %q", got)
+	}
+}
+
+// TestResolveAudiobookSource_SharedRootFallsBackToPerFile — multi-file
+// torrent whose files sit DIRECTLY at the shared download root (no
+// containing subfolder). Moving downloadPath would catch unrelated
+// siblings; the helper must signal per-file placement instead.
+func TestResolveAudiobookSource_SharedRootFallsBackToPerFile(t *testing.T) {
+	s, _, _, _ := scannerFixture(t, t.TempDir())
+	_, perFile := s.resolveAudiobookSource("/data/downloads", []string{
+		"/data/downloads/disc01.m4b",
+		"/data/downloads/disc02.m4b",
+	})
+	if !perFile {
+		t.Fatal("issue #903: files at the shared root must fall back to per-file placement")
+	}
+}

--- a/internal/importer/scanner_filelist_test.go
+++ b/internal/importer/scanner_filelist_test.go
@@ -296,10 +296,10 @@ func TestResolveTorrentFiles_RejectsMalformedNames(t *testing.T) {
 	s, _, _, _ := scannerFixture(t, t.TempDir())
 	client := &models.DownloadClient{Name: "trans", Type: "transmission"}
 	files := []torrentFile{
-		{Name: "/etc/passwd"},                 // absolute — rejected
-		{Name: "../escape.epub"},              // dotdot — rejected
-		{Name: "MyBook/../outside.epub"},      // hidden dotdot — rejected
-		{Name: "good.epub", Size: 1},          // accepted
+		{Name: "/etc/passwd"},            // absolute — rejected
+		{Name: "../escape.epub"},         // dotdot — rejected
+		{Name: "MyBook/../outside.epub"}, // hidden dotdot — rejected
+		{Name: "good.epub", Size: 1},     // accepted
 	}
 	got := s.resolveTorrentFiles(client, "/downloads", files)
 	if len(got) != 1 {

--- a/internal/importer/scanner_qbittorrent_test.go
+++ b/internal/importer/scanner_qbittorrent_test.go
@@ -497,7 +497,7 @@ func TestTryImportInternal_EmptyPathAlreadyImported(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.tryImportInternal(ctx, dl, emptyDownloadDir, "", "", nil)
+	s.tryImportInternal(ctx, dl, emptyDownloadDir, "", "", nil, nil)
 
 	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
 	if err != nil {

--- a/internal/importer/scanner_recovery_test.go
+++ b/internal/importer/scanner_recovery_test.go
@@ -102,7 +102,7 @@ func TestTryImportInternal_RetryIsIdempotent(t *testing.T) {
 	s, dl, dlRepo, bookRepo, ctx := dataLossFixture(t, libraryDir, "copy")
 
 	// First import: succeeds normally and writes the book_files row.
-	s.tryImportInternal(ctx, dl, downloadPath, "transmission", "tor-1", nil)
+	s.tryImportInternal(ctx, dl, downloadPath, "transmission", "tor-1", nil, nil)
 
 	filesAfterFirst, err := bookRepo.ListFiles(ctx, *dl.BookID)
 	if err != nil {
@@ -134,7 +134,7 @@ func TestTryImportInternal_RetryIsIdempotent(t *testing.T) {
 		t.Fatalf("precondition: imported file should still be on disk: %v", err)
 	}
 
-	s.tryImportInternal(ctx, retryDL, downloadPath, "transmission", "tor-1", nil)
+	s.tryImportInternal(ctx, retryDL, downloadPath, "transmission", "tor-1", nil, nil)
 
 	// The idempotency guard must short-circuit: no second book_files row.
 	filesAfterRetry, err := bookRepo.ListFiles(ctx, *dl.BookID)
@@ -281,7 +281,7 @@ func TestTryImportInternal_ExternalModeParksNonTerminal(t *testing.T) {
 
 	s, dl, dlRepo, bookRepo, ctx := dataLossFixture(t, libraryDir, "external")
 
-	s.tryImportInternal(ctx, dl, downloadPath, "transmission", "tor-1", nil)
+	s.tryImportInternal(ctx, dl, downloadPath, "transmission", "tor-1", nil, nil)
 
 	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
 	if err != nil {

--- a/internal/importer/scanner_rootfolder_test.go
+++ b/internal/importer/scanner_rootfolder_test.go
@@ -400,7 +400,7 @@ func TestAudiobookImport_UsesPerAuthorAudiobookRootFolder(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.tryImportInternal(ctx, dl, downloadPath, "", "", nil)
+	s.tryImportInternal(ctx, dl, downloadPath, "", "", nil, nil)
 
 	got, err := books.GetByID(ctx, book.ID)
 	if err != nil {
@@ -498,7 +498,7 @@ func TestAudiobookImport_UsesAudiobookDirNotEbookRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s.tryImportInternal(ctx, dl, downloadPath, "", "", nil)
+	s.tryImportInternal(ctx, dl, downloadPath, "", "", nil, nil)
 
 	// The book's audiobook file path must live under audiobookDir, not under
 	// the per-author ebook root (ebookRoot).

--- a/internal/importer/scanner_test.go
+++ b/internal/importer/scanner_test.go
@@ -457,7 +457,7 @@ func TestImportInternal_ThreeFileBundle_TracksAllInBookFiles(t *testing.T) {
 	}
 
 	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, db.NewHistoryRepo(database), libDir, "", "", "", "")
-	s.tryImportInternal(ctx, dl, dlDir, "", "", nil)
+	s.tryImportInternal(ctx, dl, dlDir, "", "", nil, nil)
 
 	files, err := bookRepo.ListFiles(ctx, book.ID)
 	if err != nil {
@@ -520,7 +520,7 @@ func TestTryImportInternal_HistoryEventIncludesFormat(t *testing.T) {
 	}
 
 	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, historyRepo, libDir, "", "", "", "")
-	s.tryImportInternal(ctx, dl, dlDir, "", "", nil)
+	s.tryImportInternal(ctx, dl, dlDir, "", "", nil, nil)
 
 	events, err := historyRepo.ListByType(ctx, models.HistoryEventBookImported)
 	if err != nil {
@@ -616,7 +616,7 @@ func TestImportSuccess_FiresBookImported(t *testing.T) {
 	spy := &spyNotifier{}
 	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, db.NewHistoryRepo(database), libDir, "", "", "", "").
 		WithNotifier(spy)
-	s.tryImportInternal(ctx, dl, dlDir, "", "", nil)
+	s.tryImportInternal(ctx, dl, dlDir, "", "", nil, nil)
 
 	call := spy.lookup(notifierEventBookImported)
 	if call == nil {


### PR DESCRIPTION
Closes #903.

## Reporter's repro (Bclark117)

- Transmission with a shared download directory (e.g. `/data/downloads`); PathRemap configured per client (`/data:/downloads`).
- The user seeds several books in that one directory; each is a single loose `.m4b` file with no containing subfolder.
- A new completed download lands; Bindery's importer walks `downloadDir` and copies every recognised book file there into the audiobook library, dragging the unrelated siblings in.

Root cause: with Transmission a single-file torrent's `downloadDir` is the shared root itself, not a per-torrent subdirectory. `filepath.Walk(downloadDir)` then enumerates every sibling, and the importer treats them all as part of this torrent. qBittorrent and Deluge share the same shape when the user disables the default per-torrent subfolder option.

## What changed

### Per-client `Files(ctx, downloadID)` API

| Client | Backing API | Returns |
|---|---|---|
| Transmission | `torrent-get` RPC with `fields=["id", "files"]` | `[]File{Name, Size}` where `Name` is relative to `downloadDir` |
| qBittorrent  | `GET /api/v2/torrents/files?hash=<hash>` | `[]File{Name, Size}` where `Name` is relative to `save_path` (Windows backslashes normalised) |
| Deluge       | `core.get_torrent_status` with `keys=["files"]` | `[]File{Name, Size}` where `Name` is relative to the torrent's save path |

A new `File{Name, Size}` type lives in each downloader package, matching the existing per-package types pattern.

SABnzbd and NZBGet are intentionally not modified; both always land jobs inside a per-job destination folder (`storage` / `DestDir`), so a directory walk there cannot pick up sibling jobs. Documented in code comments and skipped in the test plan.

### Threading through the importer

In `internal/importer/scanner.go`:

- `tryImportInternal` accepts a new `explicitFiles []string` parameter. When non-nil and non-empty, the importer uses it directly instead of `filepath.Walk(downloadPath)`.
- `tryImportTransmission` / `tryImportQbittorrent` accept the file list and forward it.
- `checkTransmissionDownloads` / `checkQbittorrentDownloads` call the new `transmissionFilesFor` / `qbittorrentFilesFor` helpers right after deciding to import, then pass the result through.
- A new `resolveTorrentFiles(client, savePath, []torrentFile)` does the mapping from client-relative names to absolute Bindery-side paths, joining with `savePath` and running through `remapDownloadClientPath` so the existing per-client and global remap rules still apply uniformly.

### Path-remap interaction

The new code reuses `remapDownloadClientPath` (the same helper that already rewrites `torrent.DownloadDir` for the parent dir). The flow per file is:

1. `clientPath = filepath.Join(clientSavePath, file.Name)` — the path the download client sees.
2. `binderyPath = remapDownloadClientPath(client, clientPath)` — the same per-client PathRemap rule that was already applied to the parent dir now rewrites the full file path consistently.
3. `IsBookFile(binderyPath)` filter, matching the legacy walk.

No new remap logic is introduced; the rules an operator sets in the UI keep working unchanged.

### Fallback behaviour

When `Files()` returns an error or an empty list:

- `transmissionFilesFor` / `qbittorrentFilesFor` log a WARN (so an operator can see the fallback firing) and return `nil`.
- `tryImportInternal` falls back to the legacy `filepath.Walk(downloadPath)` discovery.

This preserves behaviour for older client protocol versions, transient RPC issues, and torrents that have not yet flushed metadata to disk (Transmission at 0% returns an empty files array).

### Audiobook flow

The audiobook branch previously moved the entire `downloadPath`, which is the dangerous behaviour for #903's shape. With the file list:

- Single-file torrent: source is the file itself, placed inside `destDir` via the existing not-a-directory branch.
- Multi-file torrent whose files share a strict subdirectory under `downloadPath`: source is that subdirectory (so cover art and cue sheets within the torrent's folder still ride along).
- Multi-file torrent whose files sit at the shared root: falls back to per-file placement into `destDir`. Cover art outside the file list is left behind (the safer tradeoff vs. catching unrelated siblings).

### Safety guards

File names containing an absolute path or any `..` path segment are rejected with a WARN. Windows backslashes are normalised at the qBit API boundary so the segment check works uniformly.

## Test plan

### Unit tests for the downloader `Files()` APIs

- `TestClient_Files_ReturnsRelativeNames` (Transmission / qBittorrent / Deluge): canned RPC response → asserts `[]File` shape matches.
- `TestClient_Files_SingleFileTorrent` (Transmission / qBittorrent / Deluge): the #903 shape, basename-only `Name`.
- `TestClient_Files_TorrentMissing` (Transmission / qBittorrent / Deluge): unknown id surfaces an error so the importer can fall back.
- `TestClient_Files_NoFilesYet` (Transmission): empty array, nil error (metadata still resolving).
- `TestClient_Files_WindowsBackslashesNormalized` (qBittorrent): backslashes from a Windows qBit instance rewritten to forward slashes.
- `TestClient_Files_StatusErrorReturnsError` (Deluge): RPC-level fault surfaces as an error.

### Importer-side tests

- `TestImport_SingleFileTorrentSkipsSiblingFiles` (end-to-end through `checkTransmissionDownloads`): shared download dir with the torrent's own `.m4b` plus two unrelated siblings; Transmission stub reports `Files=[the-book.m4b]`; asserts only `the-book.m4b` lands in the audiobook library and both siblings remain untouched.
- `TestImport_FallsBackToDirWalkWhenFilesUnavailable`: `tryImportInternal` with `explicitFiles=nil` (the post-RPC-failure shape) → asserts the dir walk runs and the book is imported.
- `TestResolveTorrentFiles_BuildsAbsoluteBinderyPaths`: covers PathRemap interaction and `IsBookFile` filtering.
- `TestResolveTorrentFiles_RejectsMalformedNames`: absolute paths and `..` segments are dropped.
- `TestResolveAudiobookSource_*`: covers the single-file, common-subdir-accepted, and shared-root-falls-back-to-per-file branches.

### Regression coverage

- Full `go test ./...` passes.
- `go vet ./...` clean.
- Existing Transmission and qBittorrent scanner tests pass unchanged; they now pass `nil` for `explicitFiles` and exercise the fallback walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)