### PR TITLE
ci: backstop Discord external-PR notifications with a cron poll (closes #626)

### DIFF
--- a/.github/workflows/notify-external-pr-backstop.yml
+++ b/.github/workflows/notify-external-pr-backstop.yml
@@ -1,0 +1,111 @@
+name: Notify Discord on external PR (backstop)
+
+# Cron-driven backstop for notify-external-pr.yml. The event-driven workflow
+# has documented gaps (pull_request_target propagation lag for newly-merged
+# workflow files, fork-PR delivery inconsistencies, and the original miss in
+# #626/#616). This poll runs every 15 minutes, finds open external-contributor
+# PRs from the last 7 days that lack the bindery-notified label, and posts a
+# Discord message + applies the label so we don't double-notify.
+#
+# Worst case: a real-time event arrives mid-poll. The label is added by
+# whichever workflow finishes first; the other observes the label and exits
+# without re-posting. Discord ratelimits are far above this volume so even a
+# brief race would not produce duplicate visible messages of consequence,
+# but the label ensures deduplication for the catalog of past PRs.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      lookback_days:
+        description: 'Days of PR history to scan (default 7)'
+        required: false
+        default: '7'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  backstop:
+    name: Catch missed external PRs
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Notify and label any missed external PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '7' }}
+        run: |
+          set -euo pipefail
+          if [ -z "$WEBHOOK" ]; then
+            echo "::warning::DISCORD_RELEASE_WEBHOOK not set; nothing to do"
+            exit 0
+          fi
+
+          # PRs opened within LOOKBACK_DAYS; cap at 50 to bound runtime.
+          # gh outputs newest first; we walk all matches.
+          mapfile -t PRS < <(gh pr list \
+            --repo "$REPO" \
+            --state open \
+            --search "is:pr is:open created:>=$(date -u -d "-${LOOKBACK_DAYS} days" +%Y-%m-%d)" \
+            --limit 50 \
+            --json number,title,url,author,isDraft,labels,createdAt \
+            --jq '.[] | @json')
+
+          if [ "${#PRS[@]}" -eq 0 ]; then
+            echo "No open PRs in lookback window"
+            exit 0
+          fi
+
+          POSTED=0
+          for pr_json in "${PRS[@]}"; do
+            num=$(echo "$pr_json" | jq -r '.number')
+            title=$(echo "$pr_json" | jq -r '.title')
+            url=$(echo "$pr_json" | jq -r '.url')
+            author=$(echo "$pr_json" | jq -r '.author.login')
+            draft=$(echo "$pr_json" | jq -r '.isDraft')
+            labels=$(echo "$pr_json" | jq -r '.labels[].name' | tr '\n' ' ')
+
+            # Skip the maintainer's own PRs and bot accounts.
+            if [ "$author" = "$REPO_OWNER" ]; then continue; fi
+            if [[ "$author" == *"[bot]"* ]]; then continue; fi
+            if [[ "$author" == "dependabot" || "$author" == "github-actions" || "$author" == "step-security-bot" ]]; then continue; fi
+
+            # Skip drafts; the event-driven workflow's ready_for_review type
+            # picks them up when the author flips them. We don't want to
+            # silently advertise a draft.
+            if [ "$draft" = "true" ]; then continue; fi
+
+            # Skip if already notified.
+            if [[ "$labels" == *"bindery-notified"* ]]; then continue; fi
+
+            echo "Backstop posting for PR #${num} by ${author}"
+            PAYLOAD=$(jq -nc \
+              --arg title "$title" \
+              --arg url "$url" \
+              --arg author "$author" \
+              --arg num "$num" \
+              '{content: "📥 New PR #\($num) by **\($author)** (cron-caught): \($title)\n\($url)"}')
+            HTTP=$(curl -sS -o /dev/null -w "%{http_code}" \
+              -X POST -H "Content-Type: application/json" \
+              -d "$PAYLOAD" "$WEBHOOK") || HTTP=000
+            if [ "$HTTP" = "204" ]; then
+              gh pr edit "$num" --repo "$REPO" --add-label bindery-notified || \
+                echo "::warning::failed to add label to #${num}; will retry on next tick"
+              POSTED=$((POSTED+1))
+            else
+              echo "::warning::Discord returned HTTP ${HTTP} for PR #${num}; will retry on next tick"
+            fi
+          done
+
+          echo "Posted ${POSTED} backstop notifications"

--- a/.github/workflows/notify-external-pr.yml
+++ b/.github/workflows/notify-external-pr.yml
@@ -3,12 +3,18 @@ name: Notify Discord on external PR
 # Fires a Discord ping whenever a non-owner, non-bot PR is opened or moved
 # from draft to ready-for-review. Triage on contributor PRs in this repo
 # has historically been slow (e.g. #515 sat 5 days while #590 superseded
-# it locally) — this gives a real-time signal so the queue stays legible.
+# it locally), so this gives a real-time signal so the queue stays legible.
 #
 # pull_request_target runs in the BASE repo's context with secret access,
 # which is what we need for the webhook. We deliberately do NOT check out
-# the PR's code — only read metadata fields — so there's no code-execution
+# the PR's code (only read metadata fields), so there's no code-execution
 # risk from forks.
+#
+# Backstop: pull_request_target has documented gaps for fork PRs and for
+# workflow files freshly merged to main (see #626 / #616 for the canonical
+# miss). A scheduled poll in notify-external-pr-backstop.yml catches those
+# gaps; both workflows use the bindery-notified label to dedupe so a
+# successful event-driven post prevents a redundant cron post and vice versa.
 
 on:
   pull_request_target:
@@ -16,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write   # required for adding the dedupe label after a successful post
 
 jobs:
   notify:
@@ -34,6 +41,7 @@ jobs:
           egress-policy: audit
 
       - name: Post to Discord
+        id: post
         env:
           WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -44,6 +52,7 @@ jobs:
         run: |
           if [ -z "$WEBHOOK" ]; then
             echo "::warning::DISCORD_RELEASE_WEBHOOK not set; skipping"
+            echo "posted=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           DRAFT_TAG=""
@@ -62,7 +71,23 @@ jobs:
             -d "$PAYLOAD" "$WEBHOOK")
           if [ "$HTTP" = "204" ]; then
             echo "Discord notified for PR #${PR_NUMBER}"
+            echo "posted=true" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::Discord returned HTTP ${HTTP}"
+            echo "posted=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
+
+      - name: Mark PR as notified
+        # Only label on a successful post so failed runs are retried by the
+        # cron backstop. The label prevents that backstop from re-posting.
+        if: steps.post.outputs.posted == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Best-effort: a missing label permission must not fail the job
+          # (the backstop will see no label and try again, which is fine
+          # because Discord requests at this volume are essentially free).
+          gh pr edit "$PR_NUMBER" --add-label bindery-notified --repo "${{ github.repository }}" || \
+            echo "::warning::failed to add bindery-notified label (the cron backstop will retry)"


### PR DESCRIPTION
## Summary

The \`pull_request_target\` trigger in \`notify-external-pr.yml\` has documented gaps for fork PRs and for workflow files freshly merged to main: #616 opened ~2 hours after #613 added the workflow, and no run was ever recorded. statte's qBit v5 fix was discovered only after #618 shipped a parallel weaker one, the exact scenario #613 was built to prevent.

## Two changes

### 1. \`notify-external-pr.yml\` (existing event-driven workflow)

- Adds \`permissions.pull-requests: write\` so the job can write a label.
- New \"Mark PR as notified\" step runs after a successful Discord post and adds the \`bindery-notified\` label via \`gh pr edit\`. continue-on-error semantics preserved so a missing label permission does not fail the job (the backstop retries).

### 2. \`notify-external-pr-backstop.yml\` (new)

- \`schedule: '*/15 * * * *'\` poll plus \`workflow_dispatch\` for manual reruns.
- Walks open external PRs created in the last 7 days (configurable via dispatch input, cap 50).
- For each PR without the \`bindery-notified\` label: posts a Discord message (marked \"cron-caught\" so the audience can tell at a glance) and applies the label.
- Skips bots (\`*[bot]*\`, dependabot, github-actions, step-security-bot), drafts, and the maintainer's own PRs.

## Worst-case behavior

Event-driven and cron racing on the same PR: whichever adds the label first wins; the other observes the label and skips. Visible-duplicate risk is bounded by the 15-minute tick. Discord ratelimits are far above this volume, so even a brief race produces at most one extra message.

## Label

\`bindery-notified\` is created on first use by \`gh pr edit --add-label\`. No pre-create step required, no repo settings change required.

## Audit context

This was item #626 in the long-tail audit triage following the campaign that merged 31 PRs across the security/correctness audit (#892 through #934).

## Test plan

- [x] YAML lints clean (jq + curl + gh, all standard runner tooling)
- [ ] Manual smoke: trigger \`workflow_dispatch\` after merge and confirm a Discord ping for any currently-open external PR (e.g. #887 if still open)
- [ ] Wait for next external PR; verify the event-driven workflow fires and labels, then the cron pass on the next tick sees the label and exits without re-posting

🤖 Generated with [Claude Code](https://claude.com/claude-code)