### PR TITLE
fix(scanner): surface every walked root in library-scan completion log (#905 second symptom)

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -2785,7 +2785,16 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		}
 	}
 
-	slog.Info("library scan complete", "path", s.libraryDir, "bookFiles", len(foundFiles),
+	// Surface every walked root in the completion log. The scan can union
+	// the audiobook root with the library root (see ScanLibrary), and the
+	// pre-fix log only showed s.libraryDir, which let users with separate
+	// roots interpret the file count as coming from the wrong directory
+	// (issue #905, second symptom).
+	scanRoots := []string{s.libraryDir}
+	if s.audiobookDir != "" && s.audiobookDir != s.libraryDir {
+		scanRoots = append(scanRoots, s.audiobookDir)
+	}
+	slog.Info("library scan complete", "paths", scanRoots, "bookFiles", len(foundFiles),
 		"reconciled", reconciled, "unmatched", unmatched, "tagReadFailed", tagReadFailed)
 
 	s.writeScanResult(ctx, len(foundFiles), reconciled, unmatched, tagReadFailed, unmatchedFiles)


### PR DESCRIPTION
## Summary

Second symptom of #905. The library scan unions \`BINDERY_LIBRARY_DIR\` with \`BINDERY_AUDIOBOOK_DIR\` (when set and different) and walks both. The pre-fix completion log emitted only \`s.libraryDir\` under the \`path\` field, so reporter ovizii saw 512 files attributed to \`/books\` even though \`/books\` was empty. The files were actually in \`/audiobooks\`, the union root, which the log never named.

## Fix

Change \`\"path\"\` (singular) to \`\"paths\"\` (slice) at \`internal/importer/scanner.go:2788\`. Same data the discovery-time log at \`:2450\` already emits at the top of \`ScanLibrary\`; this aligns the completion line so observers do not have to correlate two log entries to figure out what was walked.

## Out of scope

The user's broader workflow (separate Calibre auto-ingest root \`/books\` plus a curated library at \`/calibre-library\` plus an audiobook library at \`/audiobooks\`) involves Bindery walking what is, from the user's perspective, the wrong directory. Whether the library scan should follow the curated library instead of the ingest root is a configuration design decision and warrants its own thread. This PR fixes only the log-confusion symptom that made debugging the situation harder than necessary.

The series-import half of #905 is PR #936.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/importer/ -run Scan\` green (no scanner test asserted the singular \`path\` field; nothing breaks)
- [ ] Manual: run a library scan with separate \`BINDERY_LIBRARY_DIR\` and \`BINDERY_AUDIOBOOK_DIR\`, confirm the completion log lists both