### PR TITLE
fix(scheduler): record HistoryEventGrabbed on auto-grab (Discord report)

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -574,6 +574,28 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		slog.Warn("failed to update download status", "download_id", dl.ID, "status", models.StateDownloading, "error", err)
 	}
 	slog.Info("sent to downloader", "client", client.Type, "title", best.Title)
+	// Record history for the auto-grab. Without this the History tab is
+	// empty for every scheduler-initiated grab (manual grabs via the queue
+	// handler already record themselves at queue.go::recordHistory), which
+	// the user-visible audit trail makes very confusing: search-and-grab is
+	// the only path that produces zero history rows. Surfaced via a user
+	// report from ThatGuyHere in Discord, 2026-05-30.
+	if s.history != nil {
+		data, _ := json.Marshal(map[string]any{
+			"guid":      best.GUID,
+			"author":    authorName,
+			"indexer":   best.IndexerName,
+			"protocol":  best.Protocol,
+			"size":      best.Size,
+			"mediaType": mediaType,
+		})
+		_ = s.history.Create(ctx, &models.HistoryEvent{
+			BookID:      &book.ID,
+			EventType:   models.HistoryEventGrabbed,
+			SourceTitle: best.Title,
+			Data:        string(data),
+		})
+	}
 	// Publish EventGrabbed so user-configured notification webhooks fire for
 	// auto-grabs as well as the queue-page manual grabs (issue #849). Payload
 	// shape mirrors the queue.go manual-grab Send so existing webhook


### PR DESCRIPTION
## Summary

The scheduler's \`searchAndGrabFormat\` (the auto-grab path driven by the scheduled wanted-search and status-flip triggers) persists the download row, fires the external notifier, and clears pending releases, but **never writes a HistoryEvent**. The \`QueueHandler\`'s manual-grab path at \`queue.go:744\` records \`HistoryEventGrabbed\`; the scheduler path did not.

## Impact

Any user whose grabs come exclusively from auto-grab (which is most installs once wanted-search is enabled) sees an empty History tab. Reported in Discord on 2026-05-30 by ThatGuyHere: \"history tab has no entries at all despite all of the other previous actions.\"

## Fix

Add the history write at the same point we fire the notify, with a payload that includes \`guid\` + \`indexer\` + \`protocol\` + \`mediaType\` so the History UI and any post-hoc audit can correlate the row back to the indexer that served it.

Mirrors the queue-handler \`recordHistory\` pattern; both surfaces now produce the same row shape for the same event type.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/scheduler/ -count=1\` green
- [ ] Manual: trigger an auto-grab (wanted search), confirm a row appears in History with \`eventType=grabbed\` and the indexer name in \`data.indexer\`

## Note on testing

The existing scheduler tests exercise \`SearchAndGrabBook\` only through the \"no indexers → return early\" path; driving the full grab-path requires a stub searcher returning valid results plus a stub download client plus stub indexer + download-client repos. That's significant plumbing for one assertion. The change here is mechanical and mirrors the already-tested \`s.notify\` emission immediately above it (see \`TestNotify_DispatchesEventGrabbed\` in \`scheduler_jobs_test.go\` for the wiring proof). If you want a follow-up test of the full happy path, it's worth doing as a single test that asserts both the notify + history fire together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)