### PR TITLE
chore: bump CI Go toolchain to 1.25.11 (govulncheck stdlib fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           cache: true
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
@@ -56,7 +56,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -84,7 +84,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
@@ -112,7 +112,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           cache: true
       - run: go test -race -timeout=15m ./cmd/... ./internal/...
 
@@ -152,7 +152,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
@@ -185,7 +185,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           cache: true
       - run: go test -race -timeout=15m ./cmd/... ./internal/...
 
@@ -362,7 +362,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -436,7 +436,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           cache: true
       - name: Run ABS contract suite
         env:
@@ -464,7 +464,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           cache: true
       - name: Wait for ArgoCD dev to sync
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           cache: true
 
       - name: gosec (SARIF)
@@ -324,7 +324,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.10"
+          go-version: "1.25.11"
           cache: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vavallee/bindery
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/coreos/go-oidc/v3 v3.18.0


### PR DESCRIPTION
## Why

`govulncheck` (run in the required **lint** check) started failing repo-wide once two Go **standard library** vulns were disclosed:

- `GO-2026-5039` — net/textproto
- `GO-2026-5037` — crypto/x509

Both are fixed in **go1.25.11**. CI was pinned to 1.25.10, so every open PR's `lint` check is now red through no fault of its own.

## What

- `go.mod`: `go 1.25.10` → `1.25.11`
- `.github/workflows/ci.yml` + `security.yml`: all `go-version` pins → `1.25.11` (11 lines)

The runtime image (`Dockerfile`, `golang:1.26.3`) was never affected — this is purely the CI toolchain pin.

## Verification

```
$ go build ./...        # clean under 1.25.11
$ govulncheck ./...     # No vulnerabilities found.
```

Unblocks the `lint` check for #944, #795, #887 and the rest of the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)