### PR TITLE
fix(importer): guard nil book in audiobook import branch (panic on unmatched audiobook)

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1647,6 +1647,18 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// Audiobook path: place the entire download directory as a unit so
 	// multi-part m4b/mp3 files, cover art, and cue sheets stay together.
 	if detectedFormat == models.MediaTypeAudiobook {
+		// Unmatched audiobook: with no book row we cannot compute a
+		// destination (AudiobookDestDir -> renamer.apply dereferences
+		// book.ReleaseDate/Title), so this branch would panic the scan
+		// goroutine. The ebook branch below treats book == nil as
+		// "unmatched, fail with an actionable status"; do the same here
+		// rather than crash. book can be nil when the download has no
+		// BookID, the lookup errored, or the book row was deleted between
+		// grab and import.
+		if book == nil {
+			s.failImport(ctx, dl, models.StateImportFailed, "could not match any book to this download — check the release title")
+			return
+		}
 		// Idempotency guard (issue #706 finding 2): if a prior attempt already
 		// placed this audiobook (book_files has an on-disk audiobook entry) but
 		// crashed before writing the terminal status, re-importing here would

--- a/internal/importer/scanner_audiobook_nilbook_test.go
+++ b/internal/importer/scanner_audiobook_nilbook_test.go
@@ -1,0 +1,54 @@
+package importer
+
+// Regression test for a nil-pointer panic in the audiobook import branch of
+// tryImportInternal. When a completed download is detected as an audiobook
+// (any file has an audio extension) but no book row resolves — the download
+// has no BookID, the lookup errored, or the row was deleted between grab and
+// import — the branch computed AudiobookDestDir, which dereferences
+// book.ReleaseDate/Title in renamer.apply and panicked the scan goroutine.
+//
+// The ebook branch already treats book == nil as "unmatched, fail with an
+// actionable status"; the audiobook branch must do the same rather than crash.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestTryImportInternal_UnmatchedAudiobookDoesNotPanic(t *testing.T) {
+	libraryDir := t.TempDir()
+	s, _, dlRepo, _, ctx := dataLossFixture(t, libraryDir, "")
+
+	// A download directory containing a lone .m4b so detectDownloadFormat
+	// returns audiobook and the path exists (we get past the stat / file-walk).
+	downloadDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(downloadDir, "book.m4b"), []byte("audio"), 0o600); err != nil {
+		t.Fatalf("write m4b: %v", err)
+	}
+
+	// A completed download with NO BookID — book resolves to nil.
+	dl := &models.Download{
+		GUID:   "guid-unmatched-audiobook",
+		Title:  "Some Unmatched Audiobook",
+		Status: models.StateCompleted,
+		NZBURL: "fake://url",
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatalf("create download: %v", err)
+	}
+
+	// Before the fix this panicked on the nil book deref inside
+	// AudiobookDestDir -> renamer.apply. It must now return cleanly.
+	s.tryImportInternal(ctx, dl, downloadDir, "", "", nil, nil)
+
+	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("GetByGUID: %v", err)
+	}
+	if got.Status != models.StateImportFailed {
+		t.Errorf("unmatched audiobook must end in StateImportFailed (mirroring the ebook branch), got %q", got.Status)
+	}
+}


### PR DESCRIPTION
## Bug

`tryImportInternal` panics the library-scan goroutine when a completed download is detected as an **audiobook** but no book row resolves.

`book` is nil whenever the download has no `BookID`, the book lookup errors, or the row was deleted between grab and import. In that state the audiobook branch still calls `AudiobookDestDir(...)` → `renamer.apply(...)`, which dereferences `book.ReleaseDate` and `book.Title` → **nil-pointer panic**.

The branch is nil-aware everywhere else — `SetFormatFilePath` and the title log both guard `if book != nil` — only the destination computation missed it. The **ebook** branch handles the identical condition gracefully by failing the download with an actionable status (`could not match any book to this download`).

## Fix

Add the symmetric `book == nil` guard at the top of the audiobook branch, failing the download with `StateImportFailed` and the same message as the ebook path, instead of crashing.

## Test

`TestTryImportInternal_UnmatchedAudiobookDoesNotPanic` reproduces it: a completed download with no BookID and a lone `.m4b`. **Panics without the fix, passes with it** (verified by reverting the guard). Full `internal/importer` package green.

Found during a code sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)