### PR TITLE
fix(web): surface re-bind author-mismatch override (preserve API error status/body)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Re-bind metadata "Re-bind anyway" override was unreachable** — when re-binding a book to a provider whose record belongs to a different author, the API returns a `409` carrying `force_required` so the UI can offer an override. The web API client discarded the HTTP status and JSON body on error, so `RebindModal` never saw the flag and rendered the raw `author mismatch` text with no way forward. The client now throws a structured `ApiError` (status + body); the amber "Re-bind anyway" confirmation works as intended. Note: forcing past the mismatch re-points the book's metadata to the new record but keeps it filed under its current author.
+
 ## [v1.16.0] — 2026-06-03
 
 Security and hardening release. The bulk of this version is an audit-driven hardening pass (the **D1–D4** access-control findings and the **Wave 2–5** robustness sweep), opt-in per-user data isolation, a batch of performance work, and a long tail of import/scheduler correctness fixes. No breaking config changes, but two behaviour changes worth noting before upgrading: list endpoints are now paginated and request bodies are capped at 1 MiB by default (see **Changed**).

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -35,6 +35,23 @@ export async function initCSRF(): Promise<void> {
 
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
 
+// Error thrown for any non-OK API response. Carries the HTTP status and the
+// parsed JSON body so callers can branch on structured fields (e.g. a 409
+// rebind conflict exposing `force_required`). Stays an `Error` subclass with a
+// human-readable `.message`, so callers that only read `.message` are
+// unaffected.
+export class ApiError extends Error {
+  status: number
+  body: { error?: string; [key: string]: unknown }
+
+  constructor(status: number, body: { error?: string; [key: string]: unknown }, fallback: string) {
+    super(body.error || fallback)
+    this.name = 'ApiError'
+    this.status = status
+    this.body = body
+  }
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   // Merge caller-supplied headers on top of the defaults so we can't lose
   // the CSRF header if a caller passes their own `headers`.
@@ -62,7 +79,7 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   }
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }))
-    throw new Error(err.error || res.statusText)
+    throw new ApiError(res.status, err, res.statusText)
   }
   if (res.status === 204) return undefined as unknown as T
   return res.json()
@@ -89,7 +106,7 @@ async function uploadFile<T>(path: string, body: FormData): Promise<T> {
   }
   if (!res.ok) {
     const data = await res.json().catch(() => ({ error: res.statusText }))
-    throw new Error(data.error || `HTTP ${res.status}`)
+    throw new ApiError(res.status, data, `HTTP ${res.status}`)
   }
   return res.json() as Promise<T>
 }

--- a/web/src/components/RebindModal.test.tsx
+++ b/web/src/components/RebindModal.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import RebindModal from './RebindModal'
+
+// Keep the real ApiError so `instanceof ApiError` works inside the component;
+// mock only the `api` surface so no real HTTP is made.
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return {
+    ...actual,
+    api: { rebindBook: vi.fn() },
+  }
+})
+
+import { api, ApiError } from '../api/client'
+import type { Book } from '../api/client'
+
+function book(overrides: Partial<Book> = {}): Book {
+  return { id: 7, title: 'State of the Union', ...overrides } as Book
+}
+
+const rebindBook = vi.mocked(api.rebindBook)
+
+beforeEach(() => {
+  rebindBook.mockReset()
+})
+
+describe('RebindModal', () => {
+  it('surfaces the force-override panel on a 409 author mismatch instead of a dead-end error', async () => {
+    // First submit (force=false) → backend 409 with force_required.
+    rebindBook.mockRejectedValueOnce(
+      new ApiError(
+        409,
+        {
+          error: 'author mismatch: upstream record belongs to a different author',
+          force_required: true,
+          current_author: 'Old Author',
+          upstream_author: 'New Author',
+        },
+        'Conflict',
+      ),
+    )
+
+    render(<RebindModal book={book()} onClose={() => {}} onSuccess={() => {}} />)
+
+    fireEvent.change(screen.getByPlaceholderText(/OL12345W/), { target: { value: 'OL999W' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Re-bind' }))
+
+    // The amber override panel must appear — not the raw red error text.
+    await waitFor(() => {
+      expect(screen.getByText('Author mismatch')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/New Author/)).toBeInTheDocument()
+    expect(screen.getByText(/Old Author/)).toBeInTheDocument()
+    const again = screen.getByRole('button', { name: 'Re-bind anyway' })
+    expect(again).toBeInTheDocument()
+
+    // Confirming retries with force=true.
+    rebindBook.mockResolvedValueOnce(book({ title: 'State of the Union (corrected)' }))
+    fireEvent.click(again)
+    await waitFor(() => {
+      expect(rebindBook).toHaveBeenLastCalledWith(7, 'openlibrary', 'OL999W', true)
+    })
+  })
+
+  it('calls onSuccess with force=true after confirming the override', async () => {
+    rebindBook
+      .mockRejectedValueOnce(
+        new ApiError(409, { error: 'author mismatch', force_required: true, current_author: 'A', upstream_author: 'B' }, 'Conflict'),
+      )
+    const updated = book({ title: 'fixed' })
+    rebindBook.mockResolvedValueOnce(updated)
+
+    const onSuccess = vi.fn()
+    render(<RebindModal book={book()} onClose={() => {}} onSuccess={onSuccess} />)
+
+    fireEvent.change(screen.getByPlaceholderText(/OL12345W/), { target: { value: 'OL999W' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Re-bind' }))
+    const again = await screen.findByRole('button', { name: 'Re-bind anyway' })
+    fireEvent.click(again)
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith(updated))
+    expect(rebindBook).toHaveBeenLastCalledWith(7, 'openlibrary', 'OL999W', true)
+  })
+
+  it('shows a plain error for a non-409 failure', async () => {
+    rebindBook.mockRejectedValueOnce(new ApiError(502, { error: 'upstream unavailable' }, 'Bad Gateway'))
+
+    render(<RebindModal book={book()} onClose={() => {}} onSuccess={() => {}} />)
+    fireEvent.change(screen.getByPlaceholderText(/OL12345W/), { target: { value: 'OL999W' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Re-bind' }))
+
+    await waitFor(() => expect(screen.getByText('upstream unavailable')).toBeInTheDocument())
+    expect(screen.queryByText('Author mismatch')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/RebindModal.tsx
+++ b/web/src/components/RebindModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { api, Book } from '../api/client'
+import { api, ApiError, Book } from '../api/client'
 
 interface AuthorMismatch {
   currentAuthor: string
@@ -32,17 +32,17 @@ export default function RebindModal({ book, onClose, onSuccess }: Props) {
       const updated = await api.rebindBook(book.id, provider, trimmed, force)
       onSuccess(updated)
     } catch (err: unknown) {
-      if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 409) {
-        const body = err as { body?: { force_required?: boolean; current_author?: string; upstream_author?: string; error?: string } }
-        if (body.body?.force_required) {
+      if (err instanceof ApiError && err.status === 409) {
+        const body = err.body as { force_required?: boolean; current_author?: string; upstream_author?: string; error?: string }
+        if (body.force_required) {
           setMismatch({
-            currentAuthor: body.body.current_author ?? '',
-            upstreamAuthor: body.body.upstream_author ?? '',
+            currentAuthor: body.current_author ?? '',
+            upstreamAuthor: body.upstream_author ?? '',
           })
           setSubmitting(false)
           return
         }
-        setError(body.body?.error ?? 'Conflict')
+        setError(body.error ?? 'Conflict')
       } else {
         setError(err instanceof Error ? err.message : 'Re-bind failed')
       }


### PR DESCRIPTION
## What

A Discord user (IndianaJoe) hit `author mismatch: upstream record belongs to a different author` when re-binding a book to a Hardcover record, with no way to proceed. Diagnosed as a frontend bug, not user error.

## Root cause

The Rebind handler returns a `409` carrying `force_required: true` (plus `current_author` / `upstream_author`) precisely so the UI can offer an override. `RebindModal` gates that override panel on `err.status === 409` and `err.body.force_required`.

But the web API client's `request()` / `uploadFile()` threw a bare `new Error(message)` on any non-OK response, **discarding the HTTP status and the parsed JSON body**. So `RebindModal` never saw `status`/`body`, fell through to `setError(err.message)`, and rendered the raw `author mismatch` string as a dead end. The amber **"Re-bind anyway"** confirmation button was unreachable in production.

`RebindModal` is the only consumer of `err.status` / `err.body` in the codebase, so this latent defect only surfaced here. The rebind 409→force path had **zero frontend test coverage**, which is why it shipped.

## Fix

- `client.ts`: throw a structured `ApiError extends Error { status; body }` from both `request()` and `uploadFile()`. It remains an `Error` with `.message`, so every other caller (all of which only read `.message`) is unaffected.
- `RebindModal.tsx`: tighten the duck-typed check to `instanceof ApiError`. No behaviour change beyond now actually receiving the status/body.
- New `RebindModal.test.tsx`: covers the 409→override panel, success-after-force (asserts `force=true` on retry), and a non-409 plain-error path.

## Note on semantics

Forcing past the mismatch re-points the **book's** metadata to the new provider record but keeps the book filed under its **current author** (the handler does not mutate `book.AuthorID`). The mismatch check is a typo guard, not a hard block. Documented in the user reply.

## Verification

- `npm run typecheck` clean
- `npm run lint` no new warnings (5 pre-existing, none in touched files)
- `npm run build` succeeds
- `npx vitest run` — 246 passed (28 files), including the 3 new cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)