### PR TITLE
fix(importer): poll both qBittorrent categories in the main import poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Audiobook downloads could hang in "downloading" forever (qBittorrent)** — the main import poll (`checkQbittorrentDownloads`) queried only the client's ebook `Category`, so torrents grabbed under `CategoryAudiobook` were never returned and their downloads never matched (logged as `download not found in torrent list`), leaving them stuck. The #700 fix that polls both categories had only been applied to the stall/health adapters, not this poll. It now polls every category the client may have grabbed under via `CategoriesToPoll`. Transmission and Deluge are unaffected (Transmission does not split audiobooks by category/dir; Deluge polls all torrents).
+
 ## [v1.16.0] — 2026-06-03
 
 Security and hardening release. The bulk of this version is an audit-driven hardening pass (the **D1–D4** access-control findings and the **Wave 2–5** robustness sweep), opt-in per-user data isolation, a batch of performance work, and a long tail of import/scheduler correctness fixes. No breaking config changes, but two behaviour changes worth noting before upgrading: list endpoints are now paginated and request bodies are capped at 1 MiB by default (see **Changed**).

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -236,7 +236,7 @@ func GetStalledIDs(ctx context.Context, client *models.DownloadClient) (map[stri
 		// returns both Category and CategoryAudiobook when the latter is set
 		// (closes #700).
 		out := make(map[string]bool)
-		for _, cat := range categoriesToPoll(client) {
+		for _, cat := range CategoriesToPoll(client) {
 			torrents, err := qb.GetTorrents(ctx, cat)
 			if err != nil {
 				return nil, true, err
@@ -392,7 +392,7 @@ func getTorrentLiveStatuses(ctx context.Context, client *models.DownloadClient) 
 	// returns both Category and CategoryAudiobook when the latter is set
 	// (closes #700).
 	out := make(map[string]LiveStatus)
-	for _, cat := range categoriesToPoll(client) {
+	for _, cat := range CategoriesToPoll(client) {
 		torrents, err := qb.GetTorrents(ctx, cat)
 		if err != nil {
 			return nil, err

--- a/internal/downloader/category.go
+++ b/internal/downloader/category.go
@@ -16,16 +16,17 @@ func ResolveCategory(client *models.DownloadClient, mediaType string) string {
 	return client.Category
 }
 
-// categoriesToPoll returns the set of category strings GetTorrents/GetStalledIDs
+// CategoriesToPoll returns the set of category strings GetTorrents/GetStalledIDs
 // callers must poll to cover both ebook and audiobook downloads on the same
 // client. When CategoryAudiobook is unset, the slice contains only Category
 // (which may itself be empty — qBittorrent treats that as "all torrents").
 //
-// We poll by category at grab time is not persisted on the Download row; the
+// The category used at grab time is not persisted on the Download row; the
 // alternative — storing the category-used on Download and looking it up per
 // poll — would touch the Download schema and every grab call-site. Polling
-// both categories is the smaller blast radius (closes #700).
-func categoriesToPoll(client *models.DownloadClient) []string {
+// both categories is the smaller blast radius (closes #700). Exported so the
+// importer's main poll (package importer) can reuse it.
+func CategoriesToPoll(client *models.DownloadClient) []string {
 	if client == nil {
 		return nil
 	}

--- a/internal/downloader/category_test.go
+++ b/internal/downloader/category_test.go
@@ -93,7 +93,7 @@ func TestCategoriesToPoll(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := categoriesToPoll(tc.client)
+			got := CategoriesToPoll(tc.client)
 			if len(got) != len(tc.want) {
 				t.Fatalf("len(got)=%d, want %d (got=%v)", len(got), len(tc.want), got)
 			}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1022,23 +1022,31 @@ func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models
 func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.DownloadClient) {
 	qb := downloader.QbittorrentFor(client)
 
-	torrents, err := qb.GetTorrents(ctx, client.Category)
-	if err != nil {
-		slog.Debug("failed to fetch qBittorrent torrents", "error", err)
-		return
-	}
-
 	allDownloads, err := s.downloads.List(ctx)
 	if err != nil {
 		slog.Debug("failed to list downloads", "error", err)
 		return
 	}
+
+	// Poll every category this client may have grabbed under. Audiobook grabs
+	// use CategoryAudiobook (e.g. "audiobooks") while ebook grabs use Category
+	// (e.g. "ebook"); querying only Category leaves audiobook torrents out of
+	// the result, so their downloads never match here and hang in "downloading"
+	// forever. CategoriesToPoll returns both. The stall/health adapters were
+	// already fixed for #700; this is the main import poll that was missed.
 	torrentsMap := make(map[string]qbittorrent.Torrent)
-	for _, t := range torrents {
-		torrentsMap[strings.ToLower(t.Hash)] = t
+	for _, cat := range downloader.CategoriesToPoll(client) {
+		torrents, err := qb.GetTorrents(ctx, cat)
+		if err != nil {
+			slog.Debug("failed to fetch qBittorrent torrents", "category", cat, "error", err)
+			return
+		}
+		for _, t := range torrents {
+			torrentsMap[strings.ToLower(t.Hash)] = t
+		}
 	}
 
-	slog.Debug("qbittorrent poll", "torrents", len(torrents), "downloads", len(allDownloads), "category", client.Category)
+	slog.Debug("qbittorrent poll", "torrents", len(torrentsMap), "downloads", len(allDownloads), "categories", downloader.CategoriesToPoll(client))
 
 	// Track which downloads' sources we observed this cycle (issue #706 finding 4).
 	seenSourceIDs := make(map[int64]bool)

--- a/internal/importer/scanner_qbittorrent_audiocat_test.go
+++ b/internal/importer/scanner_qbittorrent_audiocat_test.go
@@ -1,0 +1,137 @@
+package importer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestCheckQbittorrentDownloads_PollsAudiobookCategory is the regression test
+// for the audiobook-category poll gap.
+//
+// Scenario: a client is configured with Category="ebook" and
+// CategoryAudiobook="audiobooks". An audiobook was grabbed under the
+// "audiobooks" category (as the grab path does via ResolveCategory). The import
+// poll previously queried only Category ("ebook"), so qBittorrent never returned
+// the audiobook torrent, the download's hash never matched any torrent, and it
+// hung in its current state forever ("download not found in torrent list").
+//
+// The mock server returns the torrent ONLY when queried with category
+// "audiobooks" and an empty list for "ebook". Reaching StateImported therefore
+// proves the poll queried the audiobook category — with the old single-category
+// behaviour the torrent is invisible and the download stays StateGrabbed.
+func TestCheckQbittorrentDownloads_PollsAudiobookCategory(t *testing.T) {
+	saveRoot := t.TempDir()
+	libraryDir := t.TempDir()
+	audiobookDir := t.TempDir()
+
+	// The audiobook is already on disk in the library (placed by a prior import),
+	// so the content-path-gone shortcut deterministically marks it imported once
+	// the torrent is actually found.
+	libM4b := filepath.Join(audiobookDir, "book.m4b")
+	if err := os.WriteFile(libM4b, []byte("m4b-in-library"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const torrentHash = "audi0b00k1234567890audi0b00k1234567890ab"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			// Honour the category filter the way qBittorrent does: the torrent
+			// lives under "audiobooks" and must be absent from any other query.
+			if r.URL.Query().Get("category") != "audiobooks" {
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+				return
+			}
+			torrents := []map[string]any{{
+				"hash":         torrentHash,
+				"name":         "My Audiobook",
+				"state":        "missingFiles",
+				"progress":     1.0,
+				"save_path":    saveRoot,
+				"content_path": "", // files were moved to the library on a prior import
+			}}
+			_ = json.NewEncoder(w).Encode(torrents)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, audiobookDir, "", "", "")
+
+	author := &models.Author{Name: "Audio Author", ForeignID: "a-audiocat", SortName: "Author, Audio"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{AuthorID: author.ID, Title: "My Audiobook", ForeignID: "b-audiocat", Status: "wanted", MediaType: models.MediaTypeAudiobook}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, libM4b); err != nil {
+		t.Fatal(err)
+	}
+
+	host, port := scannerTestHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name:              "qbit-audiocat",
+		Type:              "qbittorrent",
+		Host:              host,
+		Port:              port,
+		Enabled:           true,
+		Category:          "ebook",
+		CategoryAudiobook: "audiobooks",
+	}
+	if err := clientRepo.Create(ctx, client); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	hash := torrentHash
+	dl := &models.Download{
+		GUID:             "guid-audiocat",
+		Title:            "My Audiobook",
+		Status:           models.StateGrabbed,
+		Protocol:         "torrent",
+		TorrentID:        &hash,
+		BookID:           &book.ID,
+		DownloadClientID: &client.ID,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	s.checkQbittorrentDownloads(ctx, client)
+
+	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.Status != models.StateImported {
+		t.Errorf("audiobook-category regression: expected status %q (torrent found under the audiobook "+
+			"category and recognised as already imported), got %q — the poll did not query CategoryAudiobook",
+			models.StateImported, got.Status)
+	}
+}


### PR DESCRIPTION
## What

A Discord user (ThatGuyHere) reported an audiobook stuck in `downloading` forever. His logs showed the poll running with `category:ebook` while the torrent was grabbed under the `audiobooks` category, producing `download not found in torrent list` every cycle.

## Root cause

`checkQbittorrentDownloads` (`scanner.go`), the **primary import poll** called from the scan loop, queried only `client.Category`:

```go
torrents, err := qb.GetTorrents(ctx, client.Category) // "ebook" only
```

Audiobook grabs use `CategoryAudiobook` (via `ResolveCategory`), so qBittorrent never returned the audiobook torrent. Its hash matched nothing in the result map → `download not found in torrent list` → the record was never advanced or imported.

`#700` already introduced `categoriesToPoll` (returns both `Category` and `CategoryAudiobook`) — but it was only wired into the **stall/health adapters** (`GetStalledIDs`, `GetLiveStatuses` in `adapter.go`). The main import poll was missed.

## Fix

- Export the helper as `downloader.CategoriesToPoll` (the scanner is in package `importer`); update the two internal callers.
- `checkQbittorrentDownloads` now loops `CategoriesToPoll(client)` and merges torrents by hash.

## Scope (audited per request)

- **Transmission** — *not affected*. Its grab reuses `Category` as an optional download-dir override and never touches `CategoryAudiobook`, so audiobooks and ebooks land in the same place; the poll's single-category use is consistent with the grab. (Noted separately: a bare-label `Category` makes grab pass `""` but the poll filters on that label as an exact `DownloadDir` — a pre-existing inconsistency unrelated to this bug, left alone.)
- **Deluge** — *not affected*. `GetTorrents` takes no category and returns all torrents.

## Test

`TestCheckQbittorrentDownloads_PollsAudiobookCategory`: mock qBit returns the torrent **only** for `category=audiobooks` and an empty list otherwise; reaching `StateImported` proves the audiobook category was polled. **Verified it fails** (`got "grabbed"`) when reverted to the single-category fetch.

## Verification

- `go build ./...`, `go vet ./internal/...` clean
- `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)