### PR TITLE
test(api): cover auth user-management + OIDC SetProviders handlers

### DIFF
--- a/internal/api/auth_oidc_setproviders_test.go
+++ b/internal/api/auth_oidc_setproviders_test.go
@@ -1,0 +1,244 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/auth/oidc"
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// These tests cover OIDCHandler.SetProviders (PUT /auth/oidc/providers), which
+// was at 0% handler coverage. SetProviders does a full-array replace of the
+// configured provider set and persists it via SettingsRepo, preserving secrets
+// that the client omits.
+//
+// AUTHORIZATION NOTE: like the user-management mutations, the admin gate for
+// SetProviders is the router's RequireAdmin middleware
+// (cmd/bindery/main.go:704), not anything inside the handler. The handler reads
+// no user/role from the request context at all. TestSetProviders_NonAdmin
+// Forbidden mounts the handler behind RequireAdmin to assert the authorization
+// contract holds at the wiring level.
+
+func newOIDCSetProvidersFixture(t *testing.T) (*OIDCHandler, *db.SettingsRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	settings := db.NewSettingsRepo(database)
+	mgr := oidc.NewManager()
+	h := NewOIDCHandler(mgr, nil, settings, nil, func(_ *http.Request) string {
+		return "https://bindery.example.com"
+	})
+	return h, settings
+}
+
+// storedProviders parses the raw persisted SettingOIDCProviders value back into
+// configs so tests can assert what actually landed in the DB.
+func storedProviders(t *testing.T, settings *db.SettingsRepo) []oidc.ProviderConfig {
+	t.Helper()
+	s, err := settings.Get(context.Background(), SettingOIDCProviders)
+	if err != nil {
+		t.Fatalf("read setting: %v", err)
+	}
+	if s == nil || s.Value == "" {
+		return nil
+	}
+	ps, err := oidc.ParseProviders(s.Value)
+	if err != nil {
+		t.Fatalf("parse stored providers: %v", err)
+	}
+	return ps
+}
+
+func TestSetProviders_ValidReplacesSet(t *testing.T) {
+	h, settings := newOIDCSetProvidersFixture(t)
+
+	body := `[
+		{"id":"keycloak","name":"Keycloak","issuer":"https://kc.example.com","client_id":"abc","client_secret":"s3cr3t","scopes":["openid"]},
+		{"id":"authentik","name":"Authentik","issuer":"https://ak.example.com","client_id":"def","client_secret":"t0ps3cr3t","scopes":["openid"]}
+	]`
+	rec := httptest.NewRecorder()
+	h.SetProviders(rec, jsonReq(http.MethodPut, "/api/v1/auth/oidc/providers", body, context.Background()))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("SetProviders status=%d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		OK    bool `json:"ok"`
+		Count int  `json:"count"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse body: %v (body=%s)", err, rec.Body.String())
+	}
+	if !got.OK || got.Count != 2 {
+		t.Fatalf("ok=%v count=%d, want ok=true count=2", got.OK, got.Count)
+	}
+	ps := storedProviders(t, settings)
+	if len(ps) != 2 {
+		t.Fatalf("stored %d providers, want 2", len(ps))
+	}
+	if ps[0].ID != "keycloak" || ps[1].ID != "authentik" {
+		t.Errorf("stored ids = %q,%q; want keycloak,authentik", ps[0].ID, ps[1].ID)
+	}
+}
+
+// TestSetProviders_FullArrayReplace verifies the second PUT fully replaces the
+// first set rather than merging by id — submitting a single provider drops the
+// others.
+func TestSetProviders_FullArrayReplace(t *testing.T) {
+	h, settings := newOIDCSetProvidersFixture(t)
+	ctx := context.Background()
+
+	first := `[
+		{"id":"a","name":"A","issuer":"https://a.example.com","client_id":"a","client_secret":"sa","scopes":["openid"]},
+		{"id":"b","name":"B","issuer":"https://b.example.com","client_id":"b","client_secret":"sb","scopes":["openid"]}
+	]`
+	rec := httptest.NewRecorder()
+	h.SetProviders(rec, jsonReq(http.MethodPut, "/api/v1/auth/oidc/providers", first, ctx))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first SetProviders status=%d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Now replace with just "a". "b" must be gone.
+	second := `[{"id":"a","name":"A2","issuer":"https://a.example.com","client_id":"a","client_secret":"sa2","scopes":["openid"]}]`
+	rec = httptest.NewRecorder()
+	h.SetProviders(rec, jsonReq(http.MethodPut, "/api/v1/auth/oidc/providers", second, ctx))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second SetProviders status=%d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	ps := storedProviders(t, settings)
+	if len(ps) != 1 || ps[0].ID != "a" {
+		t.Fatalf("after replace got %d providers (%+v), want exactly [a]", len(ps), ps)
+	}
+	if ps[0].Name != "A2" {
+		t.Errorf("name=%q, want A2 (replacement should overwrite fields)", ps[0].Name)
+	}
+}
+
+// TestSetProviders_PreservesOmittedSecret verifies the secret-preservation
+// merge: when an existing provider is re-submitted with an empty client_secret,
+// the previously stored secret is retained (the UI never re-sends secrets).
+func TestSetProviders_PreservesOmittedSecret(t *testing.T) {
+	h, settings := newOIDCSetProvidersFixture(t)
+	ctx := context.Background()
+
+	first := `[{"id":"kc","name":"KC","issuer":"https://kc.example.com","client_id":"cid","client_secret":"original-secret","scopes":["openid"]}]`
+	rec := httptest.NewRecorder()
+	h.SetProviders(rec, jsonReq(http.MethodPut, "/api/v1/auth/oidc/providers", first, ctx))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first SetProviders status=%d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Re-submit the same provider with the secret omitted (empty).
+	second := `[{"id":"kc","name":"KC renamed","issuer":"https://kc.example.com","client_id":"cid","client_secret":"","scopes":["openid"]}]`
+	rec = httptest.NewRecorder()
+	h.SetProviders(rec, jsonReq(http.MethodPut, "/api/v1/auth/oidc/providers", second, ctx))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second SetProviders status=%d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	ps := storedProviders(t, settings)
+	if len(ps) != 1 {
+		t.Fatalf("stored %d providers, want 1", len(ps))
+	}
+	if ps[0].ClientSecret != "original-secret" {
+		t.Errorf("client_secret=%q, want it preserved as original-secret", ps[0].ClientSecret)
+	}
+	if ps[0].Name != "KC renamed" {
+		t.Errorf("name=%q, want KC renamed (non-secret fields still update)", ps[0].Name)
+	}
+}
+
+// TestSetProviders_NewProviderRequiresSecret verifies that a brand-new provider
+// submitted without a client_secret is rejected with 400 — there's no prior
+// secret to preserve.
+func TestSetProviders_NewProviderRequiresSecret(t *testing.T) {
+	h, settings := newOIDCSetProvidersFixture(t)
+
+	body := `[{"id":"brandnew","name":"New","issuer":"https://new.example.com","client_id":"cid","client_secret":"","scopes":["openid"]}]`
+	rec := httptest.NewRecorder()
+	h.SetProviders(rec, jsonReq(http.MethodPut, "/api/v1/auth/oidc/providers", body, context.Background()))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("new provider without secret status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	// Nothing should have been persisted.
+	if ps := storedProviders(t, settings); len(ps) != 0 {
+		t.Errorf("expected nothing persisted on validation failure, got %+v", ps)
+	}
+}
+
+func TestSetProviders_InvalidJSON(t *testing.T) {
+	h, _ := newOIDCSetProvidersFixture(t)
+	rec := httptest.NewRecorder()
+	h.SetProviders(rec, jsonReq(http.MethodPut, "/api/v1/auth/oidc/providers", `{not an array`, context.Background()))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("malformed body status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestSetProviders_EmptyArrayClears verifies an empty array is a valid input
+// that clears the provider set (count=0).
+func TestSetProviders_EmptyArrayClears(t *testing.T) {
+	h, settings := newOIDCSetProvidersFixture(t)
+	ctx := context.Background()
+
+	first := `[{"id":"a","name":"A","issuer":"https://a.example.com","client_id":"a","client_secret":"sa","scopes":["openid"]}]`
+	rec := httptest.NewRecorder()
+	h.SetProviders(rec, jsonReq(http.MethodPut, "/api/v1/auth/oidc/providers", first, ctx))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("seed SetProviders status=%d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	h.SetProviders(rec, jsonReq(http.MethodPut, "/api/v1/auth/oidc/providers", `[]`, ctx))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty-array SetProviders status=%d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Count int `json:"count"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got.Count != 0 {
+		t.Errorf("count=%d, want 0", got.Count)
+	}
+	if ps := storedProviders(t, settings); len(ps) != 0 {
+		t.Errorf("provider set not cleared, got %+v", ps)
+	}
+}
+
+// TestSetProviders_NonAdminForbidden asserts the AUTHORIZATION requirement for
+// PUT /auth/oidc/providers. The handler itself has no role check; the gate is
+// the RequireAdmin middleware the router wraps it with. Mounting the handler the
+// same way main.go does and driving it with a non-admin context proves the
+// request is rejected with 403 before SetProviders runs (so nothing is
+// persisted).
+func TestSetProviders_NonAdminForbidden(t *testing.T) {
+	h, settings := newOIDCSetProvidersFixture(t)
+
+	r := chi.NewRouter()
+	r.With(auth.RequireAdmin).Put("/auth/oidc/providers", h.SetProviders)
+
+	ctx := withAuthCtx(context.Background(), 42, "user")
+	body := `[{"id":"evil","name":"Evil","issuer":"https://evil.example.com","client_id":"x","client_secret":"x","scopes":["openid"]}]`
+	req := jsonReq(http.MethodPut, "/auth/oidc/providers", body, ctx)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-admin SetProviders status=%d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	if ps := storedProviders(t, settings); len(ps) != 0 {
+		t.Errorf("non-admin caller mutated the provider set despite 403: %+v", ps)
+	}
+}

--- a/internal/api/auth_users_handler_test.go
+++ b/internal/api/auth_users_handler_test.go
@@ -1,0 +1,365 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// These tests cover the admin-only user-management mutations in auth_users.go
+// (Create, Delete, SetRole), which were at 0% handler coverage. They exercise
+// the handlers directly through httptest, mirroring the construction pattern in
+// authorization_test.go.
+//
+// AUTHORIZATION NOTE: the admin gate for these endpoints lives in the router
+// (cmd/bindery/main.go:701, `r.Use(auth.RequireAdmin)`), NOT inside the handler
+// methods. Calling the handler method directly therefore bypasses the gate by
+// construction. To still assert the authorization contract, TestUserMgmt_Create
+// _NonAdminForbidden mounts the handler behind auth.RequireAdmin and proves a
+// non-admin caller is rejected with 403 before the handler ever runs.
+
+func newUserMgmtFixture(t *testing.T) (*UserManagementHandler, *db.UserRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	users := db.NewUserRepo(database)
+	return NewUserManagementHandler(users), users
+}
+
+// jsonReq builds a request with a JSON body and the supplied context.
+func jsonReq(method, path, body string, ctx context.Context) *http.Request {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
+	return req
+}
+
+// jsonReqWithID is jsonReq plus a chi {id} URL param.
+func jsonReqWithID(method, path, body string, id int64, ctx context.Context) *http.Request {
+	req := jsonReq(method, path, body, ctx)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(id, 10))
+	base := req.Context()
+	req = req.WithContext(context.WithValue(base, chi.RouteCtxKey, rctx))
+	return req
+}
+
+// --- Create ---------------------------------------------------------------
+
+func TestUserMgmt_Create_Success(t *testing.T) {
+	h, users := newUserMgmtFixture(t)
+
+	rec := httptest.NewRecorder()
+	h.Create(rec, jsonReq(http.MethodPost, "/api/v1/auth/users",
+		`{"username":"newuser","password":"hunter2pass"}`, nil))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Create status=%d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	var got userResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parse body: %v (body=%s)", err, rec.Body.String())
+	}
+	if got.Username != "newuser" {
+		t.Errorf("username=%q, want newuser", got.Username)
+	}
+	if got.Role != "user" {
+		t.Errorf("role=%q, want user (default)", got.Role)
+	}
+	if got.ID == 0 {
+		t.Error("expected a non-zero id for the created user")
+	}
+	// Verify the row actually persisted.
+	if u, err := users.GetByUsername(context.Background(), "newuser"); err != nil || u == nil {
+		t.Fatalf("created user not found in db: %v", err)
+	}
+}
+
+func TestUserMgmt_Create_AdminRole(t *testing.T) {
+	h, users := newUserMgmtFixture(t)
+
+	rec := httptest.NewRecorder()
+	h.Create(rec, jsonReq(http.MethodPost, "/api/v1/auth/users",
+		`{"username":"adminuser","password":"hunter2pass","role":"admin"}`, nil))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("Create status=%d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	var got userResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got.Role != "admin" {
+		t.Errorf("role=%q, want admin", got.Role)
+	}
+	u, _ := users.GetByUsername(context.Background(), "adminuser")
+	if u == nil || u.Role != "admin" {
+		t.Fatalf("admin role not persisted, got %+v", u)
+	}
+}
+
+// TestUserMgmt_Create_DuplicateUsername asserts the durable invariant: a
+// duplicate username is rejected with an error status and the original row is
+// untouched. It deliberately does NOT pin the exact code — the handler currently
+// surfaces the repo's UNIQUE-constraint error as 500, whereas 409 would be more
+// correct (flagged as a follow-up). Accepting either keeps this test correct
+// both today and after that fix, rather than enshrining the wart.
+func TestUserMgmt_Create_DuplicateUsername(t *testing.T) {
+	h, users := newUserMgmtFixture(t)
+	seed, err := users.Create(context.Background(), "dupe", "hash")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Create(rec, jsonReq(http.MethodPost, "/api/v1/auth/users",
+		`{"username":"dupe","password":"hunter2pass"}`, nil))
+
+	// Must be rejected. 409 is the target status; 500 is current behaviour.
+	if rec.Code != http.StatusConflict && rec.Code != http.StatusInternalServerError {
+		t.Fatalf("duplicate username status=%d, want 409 (preferred) or 500 (current); body=%s", rec.Code, rec.Body.String())
+	}
+
+	// The original row must be untouched (no overwrite, still the seeded user).
+	got, err := users.GetByUsername(context.Background(), "dupe")
+	if err != nil || got == nil {
+		t.Fatalf("seeded user missing after duplicate create: %v", err)
+	}
+	if got.ID != seed.ID {
+		t.Fatalf("duplicate create altered the existing row: id %d -> %d", seed.ID, got.ID)
+	}
+}
+
+func TestUserMgmt_Create_MissingUsername(t *testing.T) {
+	h, _ := newUserMgmtFixture(t)
+	rec := httptest.NewRecorder()
+	h.Create(rec, jsonReq(http.MethodPost, "/api/v1/auth/users",
+		`{"username":"","password":"hunter2pass"}`, nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty username status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUserMgmt_Create_MissingPassword(t *testing.T) {
+	h, _ := newUserMgmtFixture(t)
+	rec := httptest.NewRecorder()
+	h.Create(rec, jsonReq(http.MethodPost, "/api/v1/auth/users",
+		`{"username":"someone","password":""}`, nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty password status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUserMgmt_Create_InvalidJSON(t *testing.T) {
+	h, _ := newUserMgmtFixture(t)
+	rec := httptest.NewRecorder()
+	h.Create(rec, jsonReq(http.MethodPost, "/api/v1/auth/users", `{not json`, nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("malformed body status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUserMgmt_Create_LocalAuthDisabled(t *testing.T) {
+	h, _ := newUserMgmtFixture(t)
+	h = h.WithLocalAuthEnabled(false)
+	rec := httptest.NewRecorder()
+	h.Create(rec, jsonReq(http.MethodPost, "/api/v1/auth/users",
+		`{"username":"someone","password":"hunter2pass"}`, nil))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("local-auth-disabled status=%d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestUserMgmt_Create_NonAdminForbidden asserts the AUTHORIZATION contract: the
+// endpoint must reject non-admin callers. The gate is the router's RequireAdmin
+// middleware, so we mount the handler behind it (as cmd/bindery/main.go does)
+// and confirm a "user"-role caller never reaches the handler.
+func TestUserMgmt_Create_NonAdminForbidden(t *testing.T) {
+	h, users := newUserMgmtFixture(t)
+
+	r := chi.NewRouter()
+	r.With(auth.RequireAdmin).Post("/auth/users", h.Create)
+
+	ctx := withAuthCtx(context.Background(), 7, "user")
+	req := jsonReq(http.MethodPost, "/auth/users",
+		`{"username":"sneaky","password":"hunter2pass"}`, ctx)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("non-admin Create status=%d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+	// And the user must NOT have been created.
+	if u, _ := users.GetByUsername(context.Background(), "sneaky"); u != nil {
+		t.Error("non-admin caller managed to create a user despite 403")
+	}
+}
+
+// --- Delete ---------------------------------------------------------------
+
+func TestUserMgmt_Delete_Success(t *testing.T) {
+	h, users := newUserMgmtFixture(t)
+	ctx := context.Background()
+	// Seed an admin (so deleting the target is not a last-admin situation) and
+	// a plain user to delete.
+	admin, _ := users.Create(ctx, "admin", "h")
+	_ = users.SetRole(ctx, admin.ID, "admin")
+	victim, _ := users.Create(ctx, "victim", "h")
+
+	rec := httptest.NewRecorder()
+	h.Delete(rec, jsonReqWithID(http.MethodDelete, "/api/v1/auth/users/x", "", victim.ID, ctx))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Delete status=%d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if u, _ := users.GetByID(ctx, victim.ID); u != nil {
+		t.Error("user still present after Delete")
+	}
+}
+
+// TestUserMgmt_Delete_NotFound documents that deleting a non-existent id is a
+// no-op success (the repo returns nil for ErrNoRows), so the handler returns
+// 200. This pins the current "already gone" semantics.
+func TestUserMgmt_Delete_NotFound(t *testing.T) {
+	h, _ := newUserMgmtFixture(t)
+	rec := httptest.NewRecorder()
+	h.Delete(rec, jsonReqWithID(http.MethodDelete, "/api/v1/auth/users/x", "", 999999, context.Background()))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Delete missing id status=%d, want 200 (no-op); body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUserMgmt_Delete_InvalidID(t *testing.T) {
+	h, _ := newUserMgmtFixture(t)
+	req := jsonReq(http.MethodDelete, "/api/v1/auth/users/abc", "", context.Background())
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "abc")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("non-numeric id status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestUserMgmt_Delete_LastAdmin asserts the last-admin guard: the sole admin
+// cannot be deleted (repo returns an error, handler maps it to 400).
+func TestUserMgmt_Delete_LastAdmin(t *testing.T) {
+	h, users := newUserMgmtFixture(t)
+	ctx := context.Background()
+	admin, _ := users.Create(ctx, "onlyadmin", "h")
+	_ = users.SetRole(ctx, admin.ID, "admin")
+
+	rec := httptest.NewRecorder()
+	h.Delete(rec, jsonReqWithID(http.MethodDelete, "/api/v1/auth/users/x", "", admin.ID, ctx))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("delete-last-admin status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if u, _ := users.GetByID(ctx, admin.ID); u == nil {
+		t.Error("last admin was deleted despite the guard")
+	}
+}
+
+// --- SetRole --------------------------------------------------------------
+
+func TestUserMgmt_SetRole_Promote(t *testing.T) {
+	h, users := newUserMgmtFixture(t)
+	ctx := context.Background()
+	u, _ := users.Create(ctx, "promoteme", "h")
+
+	rec := httptest.NewRecorder()
+	h.SetRole(rec, jsonReqWithID(http.MethodPut, "/api/v1/auth/users/x/role", `{"role":"admin"}`, u.ID, ctx))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("SetRole status=%d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	got, _ := users.GetByID(ctx, u.ID)
+	if got == nil || got.Role != "admin" {
+		t.Fatalf("role not updated to admin, got %+v", got)
+	}
+}
+
+func TestUserMgmt_SetRole_Demote(t *testing.T) {
+	h, users := newUserMgmtFixture(t)
+	ctx := context.Background()
+	// Two admins so demoting one is allowed.
+	a1, _ := users.Create(ctx, "admin1", "h")
+	_ = users.SetRole(ctx, a1.ID, "admin")
+	a2, _ := users.Create(ctx, "admin2", "h")
+	_ = users.SetRole(ctx, a2.ID, "admin")
+
+	rec := httptest.NewRecorder()
+	h.SetRole(rec, jsonReqWithID(http.MethodPut, "/api/v1/auth/users/x/role", `{"role":"user"}`, a2.ID, ctx))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("demote status=%d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	got, _ := users.GetByID(ctx, a2.ID)
+	if got == nil || got.Role != "user" {
+		t.Fatalf("role not demoted, got %+v", got)
+	}
+}
+
+func TestUserMgmt_SetRole_InvalidRole(t *testing.T) {
+	h, users := newUserMgmtFixture(t)
+	ctx := context.Background()
+	u, _ := users.Create(ctx, "u", "h")
+
+	rec := httptest.NewRecorder()
+	h.SetRole(rec, jsonReqWithID(http.MethodPut, "/api/v1/auth/users/x/role", `{"role":"superadmin"}`, u.ID, ctx))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid role status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUserMgmt_SetRole_InvalidJSON(t *testing.T) {
+	h, _ := newUserMgmtFixture(t)
+	rec := httptest.NewRecorder()
+	h.SetRole(rec, jsonReqWithID(http.MethodPut, "/api/v1/auth/users/x/role", `{bad`, 1, context.Background()))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("malformed body status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestUserMgmt_SetRole_InvalidID(t *testing.T) {
+	h, _ := newUserMgmtFixture(t)
+	req := jsonReq(http.MethodPut, "/api/v1/auth/users/abc/role", `{"role":"admin"}`, context.Background())
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "abc")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.SetRole(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("non-numeric id status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestUserMgmt_SetRole_DemoteLastAdmin asserts the last-admin demotion guard.
+func TestUserMgmt_SetRole_DemoteLastAdmin(t *testing.T) {
+	h, users := newUserMgmtFixture(t)
+	ctx := context.Background()
+	admin, _ := users.Create(ctx, "onlyadmin", "h")
+	_ = users.SetRole(ctx, admin.ID, "admin")
+
+	rec := httptest.NewRecorder()
+	h.SetRole(rec, jsonReqWithID(http.MethodPut, "/api/v1/auth/users/x/role", `{"role":"user"}`, admin.ID, ctx))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("demote-last-admin status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	got, _ := users.GetByID(ctx, admin.ID)
+	if got == nil || got.Role != "admin" {
+		t.Fatalf("last admin was demoted despite the guard, got %+v", got)
+	}
+}


### PR DESCRIPTION
## What

Adds handler-level test coverage for four mutating, security-relevant auth handlers that were previously at **0%** coverage:

- `internal/api/auth_users.go` — `Create`, `Delete`, `SetRole`
- `internal/api/auth_oidc.go` — `SetProviders`

Test-only change. No production `.go` files were modified.

## Coverage delta (target functions)

| Handler | Before | After |
|---|---|---|
| `auth_users.Create` | 0% | 84.0% |
| `auth_users.Delete` | 0% | 100% |
| `auth_users.SetRole` | 0% | 100% |
| `auth_oidc.SetProviders` | 0% | 85.3% |

Residual gaps in Create/SetProviders are unreachable internal-error branches (password-hash failure, JSON marshal failure, `settings.Set` DB error) that an in-memory DB cannot trigger.

## Scenarios

**Create:** success (returns created user, persisted), admin-role creation, duplicate username, empty username, empty password, malformed JSON, local-auth-disabled (403), non-admin rejected (403).
**Delete:** success, not-found no-op (200), non-numeric id (400), last-admin guard (400, row preserved).
**SetRole:** promote, demote (two-admin), invalid role (400), malformed JSON, non-numeric id, last-admin demotion guard (400, role preserved).
**SetProviders:** valid array replace, full-array-replace semantics (drops omitted ids), omitted-secret preservation merge, new-provider-without-secret rejection (400, nothing persisted), malformed JSON, empty-array clears, non-admin rejected (403, nothing persisted).

## Authorization findings

The admin gate for all four endpoints is the router-level `auth.RequireAdmin` middleware (`cmd/bindery/main.go:701-711`), **not** any check inside the handler bodies. The handlers read no role from the request context. This is the existing architecture and it is correct: the `_NonAdminForbidden` tests mount each handler behind `RequireAdmin` exactly as `main.go` does and confirm a non-admin caller is rejected with 403 before the handler runs and nothing is mutated.

**No authz/security gap found in these handlers.** Note: issue #947 (bulk IDOR under `BINDERY_ENFORCE_TENANCY`) concerns `bulk.go` (`AuthorsBulk`/`BooksBulk`/`WantedBulk`), which are mounted at the authenticated-**user** level without ownership checks — a different surface from the admin-gated handlers covered here. The OIDC provider API has no per-provider ownership model (it's a single global settings array gated by `RequireAdmin`), so the #947 class does not apply to it.

## Documented current (non-ideal) behavior

`Create` with a duplicate username returns **500**, not 409 — the repo's UNIQUE-constraint error is surfaced verbatim. The test pins this as current behavior; 409 would be the more correct status. Flagged here rather than silently enshrined.

## Verify

- `go test ./internal/api/...` passes (no skips added by this PR).
- `go vet ./internal/api/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)