### PR TITLE
fix(web): route-scoped error boundary so a page crash doesn't blank the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Changed
+
+- **A page crash no longer blanks the whole app** — page render errors are now caught by a route-scoped error boundary that shows the error inline while keeping the nav/header usable, and clears itself when you navigate to another page (no reload needed). Previously the only boundary was the root one, whose full-screen dark-mode fallback took over the entire viewport and required a manual reload to recover.
+
 ## [v1.16.0] — 2026-06-03
 
 Security and hardening release. The bulk of this version is an audit-driven hardening pass (the **D1–D4** access-control findings and the **Wave 2–5** robustness sweep), opt-in per-user data isolation, a batch of performance work, and a long tail of import/scheduler correctness fixes. No breaking config changes, but two behaviour changes worth noting before upgrading: list endpoints are now paginated and request bodies are capped at 1 MiB by default (see **Changed**).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,12 +1,26 @@
-import { BrowserRouter, Routes, Route, NavLink, Link, Navigate } from 'react-router-dom'
-import { lazy, Suspense, useEffect, useState } from 'react'
+import { BrowserRouter, Routes, Route, NavLink, Link, Navigate, useLocation } from 'react-router-dom'
+import { lazy, Suspense, useEffect, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api } from './api/client'
 import { AuthProvider, useAuth } from './auth/AuthContext'
 import AuthGuard from './auth/AuthGuard'
 import PublicOnlyRoute from './auth/PublicOnlyRoute'
+import ErrorBoundary from './components/ErrorBoundary'
 import Logo from './components/Logo'
 import { useTheme } from './theme'
+
+// Route-scoped error boundary: a render crash in one page shows an inline error
+// inside the content area (the nav/header stay usable) instead of bubbling to
+// the root boundary, which would blank the whole app. Keyed on the path so
+// navigating to another page clears the error without a reload.
+function RoutedErrorBoundary({ children }: { children: ReactNode }) {
+  const location = useLocation()
+  return (
+    <ErrorBoundary inline resetKey={location.pathname}>
+      {children}
+    </ErrorBoundary>
+  )
+}
 
 const LoginPage = lazy(() => import('./pages/LoginPage'))
 const SetupPage = lazy(() => import('./pages/SetupPage'))
@@ -247,6 +261,7 @@ function Shell() {
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         <Suspense fallback={<PageLoadingFallback />}>
+          <RoutedErrorBoundary>
           <Routes>
             <Route path="/" element={<AuthorsPage />} />
             <Route path="/author/:id" element={<AuthorDetailPage />} />
@@ -263,6 +278,7 @@ function Shell() {
             <Route path="/settings" element={<SettingsPage />} />
             {isAdmin && <Route path="/users" element={<UsersPage />} />}
           </Routes>
+          </RoutedErrorBoundary>
         </Suspense>
       </main>
 

--- a/web/src/components/ErrorBoundary.test.tsx
+++ b/web/src/components/ErrorBoundary.test.tsx
@@ -70,4 +70,39 @@ describe('ErrorBoundary', () => {
     fireEvent.click(btn)
     expect(screen.getByRole('button', { name: 'Hide details' })).toBeInTheDocument()
   })
+
+  it('clears the error and re-renders children when resetKey changes', () => {
+    // Mirrors navigation: a page crashes, then resetKey (the route path) changes
+    // and the boundary recovers without a reload.
+    const { rerender } = render(
+      <ErrorBoundary resetKey="/settings">
+        <Boom shouldThrow />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+
+    rerender(
+      <ErrorBoundary resetKey="/authors">
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>,
+    )
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(screen.getByTestId('ok')).toBeInTheDocument()
+  })
+
+  it('stays in the error state when resetKey is unchanged', () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKey="/settings">
+        <Boom shouldThrow />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    // Same key, child would now render fine — but the boundary must NOT auto-clear.
+    rerender(
+      <ErrorBoundary resetKey="/settings">
+        <Boom shouldThrow={false} />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
 })

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,6 +1,16 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 
-type Props = { children: ReactNode }
+type Props = {
+  children: ReactNode
+  // When provided, the boundary clears its error state whenever this value
+  // changes. Wiring it to the current route path means navigating away from a
+  // crashed page recovers without a full reload.
+  resetKey?: string | number
+  // Inline boundaries render within the existing layout (keeping the nav/header)
+  // instead of taking over the whole viewport. The default (false) preserves the
+  // original full-screen fallback used by the root boundary.
+  inline?: boolean
+}
 type State = { hasError: boolean; error: Error | null; errorInfo: ErrorInfo | null; showDetails: boolean }
 
 export default class ErrorBoundary extends Component<Props, State> {
@@ -13,6 +23,14 @@ export default class ErrorBoundary extends Component<Props, State> {
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('ui crash', error, errorInfo.componentStack)
     this.setState({ errorInfo })
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    // Reset on navigation so a crashed page doesn't stay crashed after the user
+    // clicks elsewhere in the nav.
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false, error: null, errorInfo: null, showDetails: false })
+    }
   }
 
   private handleReload = () => {
@@ -30,8 +48,11 @@ export default class ErrorBoundary extends Component<Props, State> {
   render() {
     if (!this.state.hasError) return this.props.children
     const { error, errorInfo, showDetails } = this.state
+    const outerClass = this.props.inline
+      ? 'flex justify-center py-6'
+      : 'min-h-screen bg-slate-50 dark:bg-zinc-950 text-slate-900 dark:text-zinc-100 flex items-center justify-center p-4'
     return (
-      <div className="min-h-screen bg-slate-50 dark:bg-zinc-950 text-slate-900 dark:text-zinc-100 flex items-center justify-center p-4">
+      <div className={outerClass}>
         <div role="alert" className="max-w-xl w-full p-6 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-4">
           <h1 className="text-lg font-bold tracking-tight">Something went wrong</h1>
           <p className="text-sm text-slate-600 dark:text-zinc-400">


### PR DESCRIPTION
## What

A Discord user (DiRTYBURGER11) reported the Settings page renders for ~half a second then goes to a dark screen requiring a full reload. Console showed **React error #31** (`Objects are not valid as a React child`) with `args[]=object with keys {name, size, modTime}`.

## Two findings

**1. Blast radius (fixed here).** The only error boundary was the **root** one (`main.tsx`), added in v1.8.0. Its fallback is `min-h-screen bg-zinc-950` — in dark mode a near-black full-viewport takeover that hides the nav and only recovers on reload. That *is* the "dark screen" the user described.

This PR adds an **inline, route-scoped** boundary around the page `<Routes>` inside the app shell:
- A page crash renders the error **within the content area**; the header/nav stay usable.
- The boundary is keyed on `location.pathname`, so **navigating to another page clears it** — no reload.
- The root boundary remains as the last-resort catch.

`ErrorBoundary` gains two optional props: `inline` and `resetKey`. Root behaviour is unchanged when neither is passed.

**2. The underlying #31 (NOT in this PR — see below).** `{name, size, modTime}` is, across the entire codebase, *only* the backup-file shape (`internal/api/backup.go` → `GeneralTab.tsx`). The backup list has rendered its **fields** (not the raw object) in every version since before 1.14, so mainline can't produce this #31 — the reporter is almost certainly running a **stale cached JS bundle** (their bundle hash predates the fix), triggered once they had a backup on disk (the "setting change" they half-remember was clicking *Create Backup*). The actionable user-side fix is a hard refresh / cache clear; this PR ensures that even if a page *does* throw, it no longer blanks the app and the real error is visible inline.

## Tests
`ErrorBoundary.test.tsx`: resetKey clears the error and re-renders children when it changes, and does not auto-clear when unchanged. Full web suite green (245).

## Verify
- `npm run typecheck`, `npm run build`, `npm run lint` clean
- `npx vitest run` — 245 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)