### PR TITLE
feat(web): Test button in add/edit download-client and indexer forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **Test a download client / indexer before saving** — the Add and Edit forms for download clients and indexers now have an inline **Test** button that probes the unsaved host/port/URL/credentials, so a wrong value can be caught and fixed in place instead of having to save a broken entry, find Test on the saved row, reopen the editor, fix, and re-save. Backed by two new admin-only test-by-config endpoints (`POST /downloadclient/test` and `POST /indexer/test`) that validate and probe a posted config without persisting it; the response shape mirrors the existing test-by-id endpoints so the UI reuses one rendering path.
+
 ## [v1.16.0] — 2026-06-03
 
 Security and hardening release. The bulk of this version is an audit-driven hardening pass (the **D1–D4** access-control findings and the **Wave 2–5** robustness sweep), opt-in per-user data isolation, a batch of performance work, and a long tail of import/scheduler correctness fixes. No breaking config changes, but two behaviour changes worth noting before upgrading: list endpoints are now paginated and request bodies are capped at 1 MiB by default (see **Changed**).

--- a/cmd/bindery/sensitive_routes.go
+++ b/cmd/bindery/sensitive_routes.go
@@ -19,6 +19,7 @@ type indexerRouteHandler interface {
 	Update(http.ResponseWriter, *http.Request)
 	Delete(http.ResponseWriter, *http.Request)
 	Test(http.ResponseWriter, *http.Request)
+	TestConfig(http.ResponseWriter, *http.Request)
 	SearchQuery(http.ResponseWriter, *http.Request)
 	LastSearchDebug(http.ResponseWriter, *http.Request)
 }
@@ -38,6 +39,8 @@ func registerIndexerRoutes(r chi.Router, h indexerRouteHandler) {
 		r.Put("/indexer/{id}", h.Update)
 		r.Delete("/indexer/{id}", h.Delete)
 		r.Post("/indexer/{id}/test", h.Test)
+		// Test an unsaved config posted in the body (inline form Test button).
+		r.Post("/indexer/test", h.TestConfig)
 	})
 }
 
@@ -75,6 +78,7 @@ type downloadClientRouteHandler interface {
 	Update(http.ResponseWriter, *http.Request)
 	Delete(http.ResponseWriter, *http.Request)
 	Test(http.ResponseWriter, *http.Request)
+	TestConfig(http.ResponseWriter, *http.Request)
 }
 
 // registerDownloadClientRoutes mounts /downloadclient/* — entire subtree is
@@ -88,5 +92,7 @@ func registerDownloadClientRoutes(r chi.Router, h downloadClientRouteHandler) {
 		r.Put("/downloadclient/{id}", h.Update)
 		r.Delete("/downloadclient/{id}", h.Delete)
 		r.Post("/downloadclient/{id}/test", h.Test)
+		// Test an unsaved config posted in the body (inline form Test button).
+		r.Post("/downloadclient/test", h.TestConfig)
 	})
 }

--- a/cmd/bindery/sensitive_routes_test.go
+++ b/cmd/bindery/sensitive_routes_test.go
@@ -41,6 +41,9 @@ func (h *stubSensitiveHandler) Delete(w http.ResponseWriter, _ *http.Request) {
 func (h *stubSensitiveHandler) Test(w http.ResponseWriter, _ *http.Request) {
 	h.record("test", w)
 }
+func (h *stubSensitiveHandler) TestConfig(w http.ResponseWriter, _ *http.Request) {
+	h.record("test-config", w)
+}
 func (h *stubSensitiveHandler) Sync(w http.ResponseWriter, _ *http.Request) {
 	h.record("sync", w)
 }
@@ -72,6 +75,7 @@ func TestSensitiveRoutesRequireAdmin(t *testing.T) {
 		{name: "update indexer", method: http.MethodPut, path: "/indexer/1"},
 		{name: "delete indexer", method: http.MethodDelete, path: "/indexer/1"},
 		{name: "test indexer", method: http.MethodPost, path: "/indexer/1/test"},
+		{name: "test indexer config", method: http.MethodPost, path: "/indexer/test"},
 		// Prowlarr — entire subtree.
 		{name: "list prowlarr", method: http.MethodGet, path: "/prowlarr"},
 		{name: "get prowlarr", method: http.MethodGet, path: "/prowlarr/1"},
@@ -87,6 +91,7 @@ func TestSensitiveRoutesRequireAdmin(t *testing.T) {
 		{name: "update download client", method: http.MethodPut, path: "/downloadclient/1"},
 		{name: "delete download client", method: http.MethodDelete, path: "/downloadclient/1"},
 		{name: "test download client", method: http.MethodPost, path: "/downloadclient/1/test"},
+		{name: "test download client config", method: http.MethodPost, path: "/downloadclient/test"},
 	}
 
 	for _, tt := range tests {
@@ -129,6 +134,7 @@ func TestSensitiveRoutesAllowAdmin(t *testing.T) {
 		{name: "update indexer", method: http.MethodPut, path: "/indexer/1", called: "update"},
 		{name: "delete indexer", method: http.MethodDelete, path: "/indexer/1", called: "delete"},
 		{name: "test indexer", method: http.MethodPost, path: "/indexer/1/test", called: "test"},
+		{name: "test indexer config", method: http.MethodPost, path: "/indexer/test", called: "test-config"},
 		{name: "list prowlarr", method: http.MethodGet, path: "/prowlarr", called: "list"},
 		{name: "get prowlarr", method: http.MethodGet, path: "/prowlarr/1", called: "get"},
 		{name: "create prowlarr", method: http.MethodPost, path: "/prowlarr", called: "create"},
@@ -142,6 +148,7 @@ func TestSensitiveRoutesAllowAdmin(t *testing.T) {
 		{name: "update download client", method: http.MethodPut, path: "/downloadclient/1", called: "update"},
 		{name: "delete download client", method: http.MethodDelete, path: "/downloadclient/1", called: "delete"},
 		{name: "test download client", method: http.MethodPost, path: "/downloadclient/1/test", called: "test"},
+		{name: "test download client config", method: http.MethodPost, path: "/downloadclient/test", called: "test-config"},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -220,6 +220,40 @@ func (h *DownloadClientHandler) Test(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// TestConfig probes a download-client configuration supplied in the request
+// body without persisting it. This backs the inline "Test" button on the
+// Add/Edit forms so a user can verify host/port/credentials before saving.
+// The response shape mirrors Test (test-by-id) so the UI reuses one path.
+func (h *DownloadClientHandler) TestConfig(w http.ResponseWriter, r *http.Request) {
+	var c models.DownloadClient
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if c.Host == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "host required"})
+		return
+	}
+	c.Host = sanitizeHost(c.Host)
+	if c.Type == "" {
+		c.Type = "sabnzbd"
+	}
+	if c.Port == 0 {
+		c.Port = 8080
+	}
+	if err := httpsec.ValidateOutboundURL(downloadClientURL(&c), httpsec.PolicyLAN); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := downloader.TestClient(r.Context(), &c); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, struct {
+		Message string `json:"message"`
+	}{Message: "Connection verified"})
+}
+
 func (h *DownloadClientHandler) attachHealth(clients []models.DownloadClient) {
 	for i := range clients {
 		h.attachClientHealth(&clients[i])

--- a/internal/api/download_clients_test.go
+++ b/internal/api/download_clients_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -212,6 +213,87 @@ func TestDownloadClientTest_SuccessMessage(t *testing.T) {
 	}
 	if out.Message != "Connection verified" {
 		t.Errorf("message: want Connection verified, got %q", out.Message)
+	}
+}
+
+func TestDownloadClientTestConfig_MissingHost(t *testing.T) {
+	h, _ := downloadClientFixture(t)
+	rec := httptest.NewRecorder()
+	h.TestConfig(rec, httptest.NewRequest(http.MethodPost, "/downloadclient/test", bytes.NewBufferString(`{"type":"qbittorrent"}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing host, got %d", rec.Code)
+	}
+}
+
+func TestDownloadClientTestConfig_Reachable(t *testing.T) {
+	// httptest binds 127.0.0.1; allow loopback through the SSRF guard.
+	defer httpsec.AllowLoopbackForTests()()
+	// A reachable qBittorrent stub. The posted config is probed but never
+	// persisted — the repo stays empty afterwards.
+	qbit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/app/version":
+			_, _ = w.Write([]byte("5.1.4"))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer qbit.Close()
+	u, _ := url.Parse(qbit.URL)
+	host, portStr, _ := net.SplitHostPort(u.Host)
+	port, _ := strconv.Atoi(portStr)
+
+	h, clients := downloadClientFixture(t)
+	rec := httptest.NewRecorder()
+	body := `{"name":"qBit","type":"qbittorrent","host":"` + host + `","port":` + strconv.Itoa(port) + `,"username":"u","password":"p","enabled":true}`
+	h.TestConfig(rec, httptest.NewRequest(http.MethodPost, "/downloadclient/test", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Message != "Connection verified" {
+		t.Errorf("message: want Connection verified, got %q", out.Message)
+	}
+	list, _ := clients.List(context.Background())
+	if len(list) != 0 {
+		t.Errorf("test-by-config must not persist; repo has %d clients", len(list))
+	}
+}
+
+func TestDownloadClientTestConfig_Unreachable(t *testing.T) {
+	defer httpsec.AllowLoopbackForTests()()
+	// Start a stub server to grab a real local address, then close it so the
+	// connection is refused immediately (fast + deterministic, no 15s timeout).
+	stub := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	u, _ := url.Parse(stub.URL)
+	host, portStr, _ := net.SplitHostPort(u.Host)
+	port, _ := strconv.Atoi(portStr)
+	stub.Close()
+
+	h, _ := downloadClientFixture(t)
+	rec := httptest.NewRecorder()
+	body := `{"name":"qBit","type":"qbittorrent","host":"` + host + `","port":` + strconv.Itoa(port) + `,"username":"u","password":"p","enabled":true}`
+	h.TestConfig(rec, httptest.NewRequest(http.MethodPost, "/downloadclient/test", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unreachable client, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Error == "" {
+		t.Error("expected a non-empty error message")
 	}
 }
 

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -223,6 +223,46 @@ func (h *IndexerHandler) Test(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// TestConfig probes an indexer configuration supplied in the request body
+// without persisting it. This backs the inline "Test" button on the Add/Edit
+// forms so a user can verify the URL/API key before saving. The response
+// shape mirrors Test (test-by-id) so the UI reuses one rendering path. Like
+// Test, a reachable-but-failed probe returns HTTP 200 with the error inline.
+func (h *IndexerHandler) TestConfig(w http.ResponseWriter, r *http.Request) {
+	var idx models.Indexer
+	if err := json.NewDecoder(r.Body).Decode(&idx); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if idx.URL == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "url required"})
+		return
+	}
+	if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLAN); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	client := newznab.New(idx.URL, idx.APIKey)
+	probe := client.Probe(r.Context())
+	resp := IndexerTestResponse{
+		Status:        probe.Status,
+		Categories:    probe.Categories,
+		BookSearch:    probe.BookSearch,
+		LatencyMs:     probe.LatencyMs,
+		SearchResults: probe.SearchResults,
+		SearchError:   probe.SearchError,
+	}
+	if probe.Error != "" {
+		resp.Error = probe.Error
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+	resp.OK = true
+	resp.Message = "ok"
+	writeJSON(w, http.StatusOK, resp)
+}
+
 // SearchBook searches all enabled indexers for a specific book.
 func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 	bookID, ok := parseID(w, r)

--- a/internal/api/indexers_test.go
+++ b/internal/api/indexers_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/indexer/newznab"
 	"github.com/vavallee/bindery/internal/models"
@@ -178,6 +179,68 @@ func TestIndexerTest_NotFound(t *testing.T) {
 	h.Test(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/indexer/999/test", nil), "id", "999"))
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestIndexerTestConfig_MissingURL(t *testing.T) {
+	h := indexerFixture(t)
+	rec := httptest.NewRecorder()
+	h.TestConfig(rec, httptest.NewRequest(http.MethodPost, "/indexer/test", bytes.NewBufferString(`{"apiKey":"k"}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing url, got %d", rec.Code)
+	}
+}
+
+func TestIndexerTestConfig_Reachable(t *testing.T) {
+	// httptest binds 127.0.0.1; allow loopback through the SSRF guard.
+	defer httpsec.AllowLoopbackForTests()()
+	// A reachable newznab-style endpoint returning a caps document. The probe
+	// reports ok=true; the unsaved body is never persisted.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><caps><categories><category id="7020" name="Ebook"/></categories></caps>`))
+	}))
+	defer srv.Close()
+
+	h := indexerFixture(t)
+	rec := httptest.NewRecorder()
+	body := `{"name":"X","type":"newznab","url":"` + srv.URL + `","apiKey":"k"}`
+	h.TestConfig(rec, httptest.NewRequest(http.MethodPost, "/indexer/test", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out IndexerTestResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !out.OK {
+		t.Errorf("expected ok=true for reachable indexer, got error %q", out.Error)
+	}
+}
+
+func TestIndexerTestConfig_Unreachable(t *testing.T) {
+	defer httpsec.AllowLoopbackForTests()()
+	// A reachable-but-failing probe returns HTTP 200 with an inline error so
+	// the UI can render the actionable message instead of a generic toast.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("bad api key"))
+	}))
+	defer srv.Close()
+
+	h := indexerFixture(t)
+	rec := httptest.NewRecorder()
+	body := `{"name":"X","type":"newznab","url":"` + srv.URL + `","apiKey":"wrong"}`
+	h.TestConfig(rec, httptest.NewRequest(http.MethodPost, "/indexer/test", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out IndexerTestResponse
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.OK || out.Error == "" {
+		t.Errorf("expected ok=false with an error, got ok=%v error=%q", out.OK, out.Error)
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -322,6 +322,10 @@ export const api = {
   updateIndexer: (id: number, data: Partial<Indexer>) => request<Indexer>(`/indexer/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   deleteIndexer: (id: number) => request<void>(`/indexer/${id}`, { method: 'DELETE' }),
   testIndexer: (id: number) => request<IndexerTestResult>(`/indexer/${id}/test`, { method: 'POST' }),
+  // Test an unsaved indexer config (Add/Edit form Test button). Same response
+  // shape as testIndexer so the UI reuses one rendering path.
+  testIndexerConfig: (data: Partial<Indexer>) =>
+    request<IndexerTestResult>('/indexer/test', { method: 'POST', body: JSON.stringify(data) }),
 
   // Prowlarr indexer sync
   listProwlarr: () => request<ProwlarrInstance[]>('/prowlarr'),
@@ -338,6 +342,10 @@ export const api = {
   updateDownloadClient: (id: number, data: Partial<DownloadClient>) => request<DownloadClient>(`/downloadclient/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
   deleteDownloadClient: (id: number) => request<void>(`/downloadclient/${id}`, { method: 'DELETE' }),
   testDownloadClient: (id: number) => request<{ message: string; health?: DownloadClientHealth }>(`/downloadclient/${id}/test`, { method: 'POST' }),
+  // Test an unsaved download-client config (Add/Edit form Test button). Does
+  // not persist; mirrors testDownloadClient's response (minus async health).
+  testDownloadClientConfig: (data: Partial<DownloadClient>) =>
+    request<{ message: string }>('/downloadclient/test', { method: 'POST', body: JSON.stringify(data) }),
 
   // Library
   triggerLibraryScan: () => request<{ message: string }>('/library/scan', { method: 'POST' }),

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1190,7 +1190,7 @@ describe('SettingsPage', () => {
     fireEvent.change(screen.getByPlaceholderText('API Key'), { target: { value: 'sab-secret' } })
     fireEvent.change(screen.getByDisplayValue('books'), { target: { value: 'ebooks' } })
     fireEvent.change(screen.getByLabelText('Download client path remap'), { target: { value: ' /media:/books ' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
 
     await waitFor(() => {
       expect(api.addDownloadClient).toHaveBeenCalledWith({
@@ -1258,7 +1258,7 @@ describe('SettingsPage', () => {
     }
     fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: password } })
     fireEvent.change(screen.getByDisplayValue('books'), { target: { value: category } })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
 
     await waitFor(() => {
       expect(api.addDownloadClient).toHaveBeenCalledWith({
@@ -1296,7 +1296,7 @@ describe('SettingsPage', () => {
     fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: 'qbit-pass' } })
     fireEvent.change(screen.getByDisplayValue('books'), { target: { value: 'ebooks' } })
     fireEvent.change(screen.getByLabelText('Download client path remap'), { target: { value: ' /media:/books ' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
 
     await waitFor(() => {
       expect(api.updateDownloadClient).toHaveBeenCalledWith(44, {
@@ -1331,7 +1331,7 @@ describe('SettingsPage', () => {
     fireEvent.change(screen.getByPlaceholderText('API Key'), { target: { value: 'k' } })
     fireEvent.change(screen.getByDisplayValue('books'), { target: { value: 'ebooks' } })
     fireEvent.change(screen.getByPlaceholderText('settings.clients.audiobookCategoryPlaceholder'), { target: { value: ' audiobooks ' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
 
     await waitFor(() => {
       expect(api.addDownloadClient).toHaveBeenCalledWith(expect.objectContaining({
@@ -1386,7 +1386,7 @@ describe('SettingsPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'settings.clients.addButton' }))
     fireEvent.change(screen.getByPlaceholderText('Host'), { target: { value: 'badhost' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
 
     expect(await screen.findByText('Connection refused')).toBeInTheDocument()
     expect(api.addDownloadClient).toHaveBeenCalledOnce()
@@ -1401,7 +1401,7 @@ describe('SettingsPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
     fireEvent.change(screen.getByPlaceholderText('Host'), { target: { value: 'newhost' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
 
     expect(await screen.findByText('Server error')).toBeInTheDocument()
     expect(api.updateDownloadClient).toHaveBeenCalledOnce()

--- a/web/src/pages/settings/ClientsTab.tsx
+++ b/web/src/pages/settings/ClientsTab.tsx
@@ -135,6 +135,8 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [pathRemap, setPathRemap] = useState(client.pathRemap || '')
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const handleTypeChange = (newType: string) => {
@@ -146,10 +148,12 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
   const isPasswordClient = (t: string) => t === 'qbittorrent' || t === 'transmission' || t === 'nzbget' || t === 'deluge'
   const hasUsername = (t: string) => t === 'qbittorrent' || t === 'transmission' || t === 'nzbget'
 
+  const buildData = () => isPasswordClient(type)
+    ? { ...client, name, type, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), useSsl: useSSL, urlBase: urlBase.trim() }
+    : { ...client, name, type, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), useSsl: useSSL, urlBase: urlBase.trim() }
+
   const submit = async () => {
-    const data = isPasswordClient(type)
-      ? { ...client, name, type, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), useSsl: useSSL, urlBase: urlBase.trim() }
-      : { ...client, name, type, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), useSsl: useSSL, urlBase: urlBase.trim() }
+    const data = buildData()
     setSaving(true)
     setSaveError(null)
     try {
@@ -159,6 +163,19 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
       setSaveError(err instanceof Error ? err.message : 'Failed to save')
     } finally {
       setSaving(false)
+    }
+  }
+
+  const handleTest = async () => {
+    setTesting(true)
+    setTestResult(null)
+    try {
+      await api.testDownloadClientConfig(buildData())
+      setTestResult({ ok: true, msg: t('common.connOk') })
+    } catch (err: unknown) {
+      setTestResult({ ok: false, msg: t('common.connFail', { error: err instanceof Error ? err.message : 'Unknown error' }) })
+    } finally {
+      setTesting(false)
     }
   }
 
@@ -235,9 +252,16 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
         help={downloadClientPathRemapHelp(type)}
       />
       {saveError && <p className="text-sm text-red-500">{saveError}</p>}
+      {testResult && (
+        <div role="status" className={`px-3 py-1.5 rounded text-xs flex items-center gap-2 ${testResult.ok ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300' : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'}`}>
+          <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${testResult.ok ? 'bg-emerald-500' : 'bg-red-500'}`} />
+          {testResult.msg}
+        </div>
+      )}
       <div className="flex gap-2 justify-end">
-        <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
-        <button onClick={submit} disabled={saving} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium disabled:opacity-50">Save</button>
+        <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">{t('common.cancel')}</button>
+        <button onClick={handleTest} disabled={testing || !host} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white disabled:opacity-50">{testing ? t('common.testing') : t('common.test')}</button>
+        <button onClick={submit} disabled={saving} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium disabled:opacity-50">{t('common.save')}</button>
       </div>
     </div>
   )
@@ -258,6 +282,8 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [pathRemap, setPathRemap] = useState('')
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const isPasswordClient = (t: string) => t === 'qbittorrent' || t === 'transmission' || t === 'nzbget' || t === 'deluge'
@@ -291,10 +317,12 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
     setPort('8080')
   }
 
+  const buildData = () => isPasswordClient(type)
+    ? { name, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
+    : { name, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
+
   const submit = async () => {
-    const data = isPasswordClient(type)
-      ? { name, host, port: parseInt(port), username: hasUsername(type) ? username : '', password: credential, apiKey: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
-      : { name, host, port: parseInt(port), apiKey: credential, username: '', password: '', category, categoryAudiobook: categoryAudiobook.trim(), pathRemap: pathRemap.trim(), type, enabled: true, useSsl: useSSL, urlBase: urlBase.trim() }
+    const data = buildData()
     setSaving(true)
     setSaveError(null)
     try {
@@ -304,6 +332,19 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
       setSaveError(err instanceof Error ? err.message : 'Failed to save')
     } finally {
       setSaving(false)
+    }
+  }
+
+  const handleTest = async () => {
+    setTesting(true)
+    setTestResult(null)
+    try {
+      await api.testDownloadClientConfig(buildData())
+      setTestResult({ ok: true, msg: t('common.connOk') })
+    } catch (err: unknown) {
+      setTestResult({ ok: false, msg: t('common.connFail', { error: err instanceof Error ? err.message : 'Unknown error' }) })
+    } finally {
+      setTesting(false)
     }
   }
 
@@ -380,9 +421,16 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
         help={downloadClientPathRemapHelp(type)}
       />
       {saveError && <p className="text-sm text-red-500">{saveError}</p>}
+      {testResult && (
+        <div role="status" className={`px-3 py-1.5 rounded text-xs flex items-center gap-2 ${testResult.ok ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300' : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'}`}>
+          <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${testResult.ok ? 'bg-emerald-500' : 'bg-red-500'}`} />
+          {testResult.msg}
+        </div>
+      )}
       <div className="flex gap-2 justify-end">
-        <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">Cancel</button>
-        <button onClick={submit} disabled={saving} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium disabled:opacity-50">Save</button>
+        <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">{t('common.cancel')}</button>
+        <button onClick={handleTest} disabled={testing || !host} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white disabled:opacity-50">{testing ? t('common.testing') : t('common.test')}</button>
+        <button onClick={submit} disabled={saving} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium disabled:opacity-50">{t('common.save')}</button>
       </div>
     </div>
   )

--- a/web/src/pages/settings/IndexersTab.tsx
+++ b/web/src/pages/settings/IndexersTab.tsx
@@ -5,6 +5,31 @@ import { inputCls } from './formStyles'
 import { parseCats } from './helpers'
 import Toggle from './Toggle'
 
+// IndexerTestResultBanner renders a probe result with the same ok/warn/fail
+// semantics as the saved-row Test feedback (ok=true + 0 results → amber warn).
+function IndexerTestResultBanner({ r }: { r: IndexerTestResult }) {
+  const { t } = useTranslation()
+  const warn = r.ok && r.searchResults === 0
+  const colorCls = !r.ok
+    ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+    : warn
+      ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
+      : 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
+  const dotCls = !r.ok ? 'bg-red-500' : warn ? 'bg-amber-500' : 'bg-emerald-500'
+  return (
+    <div role="status" className={`px-3 py-2 rounded text-xs flex items-center gap-2 ${colorCls}`}>
+      <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${dotCls}`} />
+      {!r.ok ? (
+        <span>{t('settings.indexers.testFail', { error: r.error ?? 'Unknown error' })}</span>
+      ) : warn ? (
+        <span>{t('settings.indexers.testWarn', { status: r.status, categories: r.categories, latency: r.latencyMs })}{r.searchError ? ` — ${r.searchError}` : ''}</span>
+      ) : (
+        <span>{t('settings.indexers.testOk', { status: r.status, categories: r.categories, latency: r.latencyMs, results: r.searchResults })}</span>
+      )}
+    </div>
+  )
+}
+
 // indexers/prowlarrInstances are owned by SettingsPage so they can be fetched
 // eagerly on page mount (matching the pre-refactor monolith), not on tab open.
 interface Props {
@@ -247,11 +272,26 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
   const [url, setUrl] = useState(indexer.url)
   const [apiKey, setApiKey] = useState(indexer.apiKey)
   const [categories, setCategories] = useState((indexer.categories ?? [7020]).join(', '))
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState<IndexerTestResult | null>(null)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
     const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey, categories: parseCats(categories) })
     onSaved(updated)
+  }
+
+  const handleTest = async () => {
+    setTesting(true)
+    setTestResult(null)
+    try {
+      const r = await api.testIndexerConfig({ name, type, url, apiKey, categories: parseCats(categories) })
+      setTestResult(r)
+    } catch (err: unknown) {
+      setTestResult({ ok: false, status: 0, categories: 0, bookSearch: false, latencyMs: 0, searchResults: 0, error: err instanceof Error ? err.message : 'Request failed' })
+    } finally {
+      setTesting(false)
+    }
   }
 
   return (
@@ -283,8 +323,10 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
         <input value={categories} onChange={e => setCategories(e.target.value)} placeholder={t('settings.indexers.form.categoriesPlaceholder')} className={inputCls} />
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.categoriesHint')}</p>
       </div>
+      {testResult && <IndexerTestResultBanner r={testResult} />}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">{t('common.cancel')}</button>
+        <button onClick={handleTest} disabled={testing || !url} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white disabled:opacity-50">{testing ? t('common.testing') : t('common.test')}</button>
         <button onClick={submit} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium">{t('common.save')}</button>
       </div>
     </div>
@@ -298,11 +340,26 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
   const [url, setUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [categories, setCategories] = useState('7020')
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState<IndexerTestResult | null>(null)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
     const idx = await api.addIndexer({ name, url, apiKey, type, categories: parseCats(categories), enabled: true })
     onAdded(idx)
+  }
+
+  const handleTest = async () => {
+    setTesting(true)
+    setTestResult(null)
+    try {
+      const r = await api.testIndexerConfig({ name, type, url, apiKey, categories: parseCats(categories) })
+      setTestResult(r)
+    } catch (err: unknown) {
+      setTestResult({ ok: false, status: 0, categories: 0, bookSearch: false, latencyMs: 0, searchResults: 0, error: err instanceof Error ? err.message : 'Request failed' })
+    } finally {
+      setTesting(false)
+    }
   }
 
   return (
@@ -334,8 +391,10 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
         <input value={categories} onChange={e => setCategories(e.target.value)} placeholder={t('settings.indexers.form.categoriesPlaceholder')} className={inputCls} />
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.categoriesHint')}</p>
       </div>
+      {testResult && <IndexerTestResultBanner r={testResult} />}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">{t('common.cancel')}</button>
+        <button onClick={handleTest} disabled={testing || !url} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white disabled:opacity-50">{testing ? t('common.testing') : t('common.test')}</button>
         <button onClick={submit} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium">{t('common.save')}</button>
       </div>
     </div>

--- a/web/src/pages/settings/InlineTestButtons.test.tsx
+++ b/web/src/pages/settings/InlineTestButtons.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+
+// i18n: echo the key (plus interpolated options) so assertions are stable.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (!options) return key
+      let out = key
+      for (const [k, v] of Object.entries(options)) {
+        out += ` ${k}=${String(v)}`
+      }
+      return out
+    },
+  }),
+}))
+
+vi.mock('../../api/client', () => ({
+  api: {
+    testDownloadClientConfig: vi.fn(),
+    addDownloadClient: vi.fn(),
+    updateDownloadClient: vi.fn(),
+    deleteDownloadClient: vi.fn(),
+    testIndexerConfig: vi.fn(),
+    addIndexer: vi.fn(),
+    updateIndexer: vi.fn(),
+    deleteIndexer: vi.fn(),
+  },
+}))
+
+import { api } from '../../api/client'
+import ClientsTab from './ClientsTab'
+import IndexersTab from './IndexersTab'
+
+const testClient = api.testDownloadClientConfig as ReturnType<typeof vi.fn>
+const testIndexer = api.testIndexerConfig as ReturnType<typeof vi.fn>
+
+describe('ClientsTab inline Test button', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('tests the Add form with the current (unsaved) form values and shows success', async () => {
+    testClient.mockResolvedValueOnce({ message: 'Connection verified' })
+    render(<ClientsTab clients={[]} setClients={vi.fn()} />)
+
+    // Open the Add form.
+    fireEvent.click(screen.getByText('settings.clients.addButton'))
+
+    // Type a host so the Test button enables and the value is sent.
+    const host = screen.getByPlaceholderText('Host')
+    fireEvent.change(host, { target: { value: '10.0.0.5' } })
+
+    fireEvent.click(screen.getByText('common.test'))
+
+    await waitFor(() => {
+      expect(testClient).toHaveBeenCalledTimes(1)
+    })
+    // The unsaved host value is forwarded to the test-by-config endpoint.
+    expect(testClient.mock.calls[0][0]).toMatchObject({ host: '10.0.0.5' })
+    // Success feedback is rendered (reuses common.connOk).
+    expect(await screen.findByText('common.connOk')).toBeInTheDocument()
+  })
+
+  it('renders an actionable error when the test fails', async () => {
+    testClient.mockRejectedValueOnce(new Error('connection refused'))
+    render(<ClientsTab clients={[]} setClients={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('settings.clients.addButton'))
+    fireEvent.change(screen.getByPlaceholderText('Host'), { target: { value: '10.0.0.5' } })
+    fireEvent.click(screen.getByText('common.test'))
+
+    await waitFor(() => expect(testClient).toHaveBeenCalledTimes(1))
+    // The backend error string is surfaced via common.connFail.
+    expect(await screen.findByText('common.connFail error=connection refused')).toBeInTheDocument()
+  })
+})
+
+describe('IndexersTab inline Test button', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('tests the Add form with the current (unsaved) form values and shows success', async () => {
+    testIndexer.mockResolvedValueOnce({
+      ok: true, status: 200, categories: 3, bookSearch: true, latencyMs: 42, searchResults: 5,
+    })
+    render(<IndexersTab indexers={[]} setIndexers={vi.fn()} prowlarrInstances={[]} setProwlarrInstances={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('settings.indexers.addButton'))
+
+    const url = screen.getByPlaceholderText('settings.indexers.form.urlPlaceholderExample')
+    fireEvent.change(url, { target: { value: 'https://idx.example/api' } })
+
+    fireEvent.click(screen.getByText('common.test'))
+
+    await waitFor(() => expect(testIndexer).toHaveBeenCalledTimes(1))
+    expect(testIndexer.mock.calls[0][0]).toMatchObject({ url: 'https://idx.example/api' })
+    // Success banner uses the testOk key with interpolated probe values.
+    expect(await screen.findByText(/settings\.indexers\.testOk/)).toBeInTheDocument()
+  })
+
+  it('renders an actionable error when the test fails', async () => {
+    testIndexer.mockRejectedValueOnce(new Error('HTTP 401'))
+    render(<IndexersTab indexers={[]} setIndexers={vi.fn()} prowlarrInstances={[]} setProwlarrInstances={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('settings.indexers.addButton'))
+    fireEvent.change(screen.getByPlaceholderText('settings.indexers.form.urlPlaceholderExample'), { target: { value: 'https://idx.example/api' } })
+    fireEvent.click(screen.getByText('common.test'))
+
+    await waitFor(() => expect(testIndexer).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText('settings.indexers.testFail error=HTTP 401')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What

Adds an inline **Test** button to the Add and Edit forms for download clients and indexers so a user can verify host/port/URL/credentials **before** saving.

### Flow change

Before: Add/Edit forms only had Cancel/Save. A wrong host/port/credential meant you had to save a broken entry, find **Test** on the saved list row, test, reopen the editor, fix, and re-save. The test endpoints only accepted a saved **id**.

After: each Add/Edit form has a Test button that probes the **current unsaved** form values and renders the same success/warn/error feedback the row-level Test already shows (download client: emerald/red connection banner reusing `common.connOk` / `common.connFail`; indexer: emerald/amber/red banner reusing `settings.indexers.testOk` / `testWarn` / `testFail`). No save required.

## Backend endpoint: added (not reused)

The existing test endpoints (`DownloadClientHandler.Test`, `IndexerHandler.Test`) are **test-by-id only** — they load a persisted row and probe it; they do not accept a config body. So two minimal **test-by-config** endpoints were added, each reusing the existing probe logic (`downloader.TestClient`, `newznab.Client.Probe`) and mirroring the existing handler's response shape:

- `POST /downloadclient/test` → `DownloadClientHandler.TestConfig` (internal/api/download_clients.go:223)
- `POST /indexer/test` → `IndexerHandler.TestConfig` (internal/api/indexers.go:226)

Both decode a config from the body, run the SSRF LAN-policy check (`httpsec.ValidateOutboundURL`), probe without persisting, and return the same JSON the test-by-id path returns. Routes are registered behind the **same `RequireAdmin` group** as the rest of the download-client / indexer settings routes (cmd/bindery/sensitive_routes.go) — added to the route-handler interfaces and the admin gating is asserted in the existing route tests.

## Tests

Frontend (`web/src/pages/settings/InlineTestButtons.test.tsx`, vi.mock the api client):
- `ClientsTab inline Test button > tests the Add form with the current (unsaved) form values and shows success`
- `ClientsTab inline Test button > renders an actionable error when the test fails`
- `IndexersTab inline Test button > tests the Add form with the current (unsaved) form values and shows success`
- `IndexersTab inline Test button > renders an actionable error when the test fails`

Backend (handler tests, valid config → ok; unreachable → actionable error; verifies no persistence):
- `TestDownloadClientTestConfig_MissingHost`, `TestDownloadClientTestConfig_Reachable`, `TestDownloadClientTestConfig_Unreachable`
- `TestIndexerTestConfig_MissingURL`, `TestIndexerTestConfig_Reachable`, `TestIndexerTestConfig_Unreachable`
- Route gating: `test indexer config` / `test download client config` rows added to the existing `TestSensitiveRoutes*` (reject-non-admin / allow-admin) tables.

## Verification

- Frontend: `npm ci && npm run typecheck && npm run build && npm run lint` (0 errors; only pre-existing warnings) and `npx vitest run` (247 passed).
- Backend: `go build ./... && go vet ./internal/api/... ./cmd/bindery/... && go test ./internal/api/... ./cmd/bindery/...` green.

## Note on existing tests

Switched the two remaining hardcoded `Save`/`Cancel` labels in ClientsTab to `t('common.save')` / `t('common.cancel')` for i18n consistency (the IndexersTab forms already used t()). The 6 SettingsPage tests that asserted `name: 'Save'` were updated to `name: 'common.save'`, matching how every other assertion in that file already refers to the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)