### PR TITLE
fix: make BINDERY_URL_BASE subpath deploys fully work (serving, frontend URLs, cover proxy)

### DIFF
--- a/cmd/bindery/index_html_test.go
+++ b/cmd/bindery/index_html_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// fakeIndex mimics the relevant shape of Vite's built index.html: the entry
+// module <script> and the stylesheet <link> live in <head> with relative
+// "./assets/…" URLs. That relative form is exactly what makes the <base> tag's
+// position load-bearing.
+const fakeIndex = `<!doctype html><html lang="en"><head>` +
+	`<meta charset="UTF-8">` +
+	`<script type="module" crossorigin src="./assets/index-abc.js"></script>` +
+	`<link rel="stylesheet" crossorigin href="./assets/index-abc.css">` +
+	`</head><body><div id="root"></div></body></html>`
+
+// TestInjectBaseHTML_BasePrecedesAssets is the regression guard for the
+// white-page-on-reload bug: <base> must be injected BEFORE the first relative
+// "./assets/…" reference. If it lands after them (e.g. before </head>), the
+// browser resolves the bundle against the document path and every non-root SPA
+// route 404s its JS/CSS on a hard reload.
+func TestInjectBaseHTML_BasePrecedesAssets(t *testing.T) {
+	out := injectBaseHTML(fakeIndex, "/bindery")
+
+	baseIdx := strings.Index(out, "<base ")
+	if baseIdx == -1 {
+		t.Fatalf("no <base> tag injected:\n%s", out)
+	}
+	assetIdx := strings.Index(out, "./assets/")
+	if assetIdx == -1 {
+		t.Fatalf("fixture lost its ./assets/ references:\n%s", out)
+	}
+	if baseIdx > assetIdx {
+		t.Fatalf("<base> (at %d) must precede first ./assets/ ref (at %d):\n%s", baseIdx, assetIdx, out)
+	}
+}
+
+func TestInjectBaseHTML_HrefForSubpath(t *testing.T) {
+	out := injectBaseHTML(fakeIndex, "/bindery")
+	if !strings.Contains(out, `<base href="/bindery/">`) {
+		t.Fatalf("expected <base href=\"/bindery/\">, got:\n%s", out)
+	}
+	if !strings.Contains(out, `<script src="/bindery/__bindery_base.js"></script>`) {
+		t.Fatalf("expected bootstrap script with /bindery prefix, got:\n%s", out)
+	}
+}
+
+func TestInjectBaseHTML_HrefForRoot(t *testing.T) {
+	out := injectBaseHTML(fakeIndex, "")
+	if !strings.Contains(out, `<base href="/">`) {
+		t.Fatalf("expected <base href=\"/\"> for empty url base, got:\n%s", out)
+	}
+}

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -593,6 +593,9 @@ func main() {
 		WithAppContext(appCtx)
 	imageProxyHandler := api.NewImageProxyHandler(cfg.DataDir)
 	imageProxyHandler.StartEviction(24 * time.Hour)
+	// Proxied cover URLs must carry the path prefix so they resolve under a
+	// subpath deploy (BINDERY_URL_BASE). No-op when URLBase is empty.
+	api.SetImageProxyBase(cfg.URLBase)
 	migrateHandler := api.NewMigrateHandler(
 		authorRepo, indexerRepo, dlClientRepo, blocklistRepo, bookRepo, metaAgg,
 		// Bulk imports always populate the catalogue but never auto-grab.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -1012,8 +1012,19 @@ func main() {
 	}
 	baseHref := cfg.URLBase + "/"
 	baseJSON, _ := json.Marshal(cfg.URLBase)
-	injection := fmt.Sprintf(`<script>window.__BINDERY_BASE__=%s</script><base href="%s">`, baseJSON, baseHref)
+	// Expose the base via a same-origin EXTERNAL script rather than an inline
+	// <script>. The strict CSP (script-src 'self') blocks inline scripts, which
+	// would silently drop window.__BINDERY_BASE__ — harmless at root (the ""
+	// fallback is correct) but fatal under a path prefix.
+	baseScript := []byte(fmt.Sprintf("window.__BINDERY_BASE__=%s;", baseJSON))
+	injection := fmt.Sprintf(`<script src="%s/__bindery_base.js"></script><base href="%s">`, cfg.URLBase, baseHref)
 	indexHTML := []byte(strings.Replace(string(rawIndex), "</head>", injection+"</head>", 1))
+
+	r.Get("/__bindery_base.js", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		_, _ = w.Write(baseScript)
+	})
 
 	fileServer := http.FileServer(http.FS(distFS))
 	r.Get("/*", func(w http.ResponseWriter, r *http.Request) {
@@ -1043,7 +1054,13 @@ func main() {
 		// Redirect bare prefix (no trailing slash) to prefix/ so the SPA
 		// bootstrap and asset resolution work correctly.
 		outer.Get(cfg.URLBase, http.RedirectHandler(cfg.URLBase+"/", http.StatusMovedPermanently).ServeHTTP)
-		outer.Mount(cfg.URLBase, r)
+		// http.StripPrefix actually rewrites r.URL.Path before dispatch, so the
+		// inner router sees un-prefixed paths. chi.Mount only rewrites the
+		// routing-context path and leaves r.URL.Path prefixed, which breaks the
+		// static file handler and http.FileServer — they read r.URL.Path directly
+		// and would look up "<prefix>/assets/…" in the embedded FS, miss, and fall
+		// back to serving index.html (text/html) for every JS/CSS asset.
+		outer.Handle(cfg.URLBase+"/*", http.StripPrefix(cfg.URLBase, r))
 		handler = outer
 		slog.Info("serving under path prefix", "urlBase", cfg.URLBase)
 	}

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -1001,27 +1001,26 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Build the index.html payload once at startup. The backend injects two
-	// things before </head>:
+	// Build the index.html payload once at startup. injectBaseHTML prepends two
+	// things to <head> (see that function for why position matters):
 	//   1. <base href="<URLBase>/"> so that Vite's relative asset URLs
 	//      (./assets/…) resolve correctly regardless of which SPA route the
 	//      browser navigates to directly.
-	//   2. window.__BINDERY_BASE__ so the frontend can set BrowserRouter
-	//      basename and prefix API calls without a per-deployment build.
+	//   2. window.__BINDERY_BASE__ (via __bindery_base.js) so the frontend can
+	//      set BrowserRouter basename and prefix API calls without a
+	//      per-deployment build.
 	rawIndex, err := fs.ReadFile(distFS, "index.html")
 	if err != nil {
 		slog.Error("failed to read embedded index.html", "error", err)
 		os.Exit(1)
 	}
-	baseHref := cfg.URLBase + "/"
 	baseJSON, _ := json.Marshal(cfg.URLBase)
 	// Expose the base via a same-origin EXTERNAL script rather than an inline
 	// <script>. The strict CSP (script-src 'self') blocks inline scripts, which
 	// would silently drop window.__BINDERY_BASE__ — harmless at root (the ""
 	// fallback is correct) but fatal under a path prefix.
 	baseScript := []byte(fmt.Sprintf("window.__BINDERY_BASE__=%s;", baseJSON))
-	injection := fmt.Sprintf(`<script src="%s/__bindery_base.js"></script><base href="%s">`, cfg.URLBase, baseHref)
-	indexHTML := []byte(strings.Replace(string(rawIndex), "</head>", injection+"</head>", 1))
+	indexHTML := []byte(injectBaseHTML(string(rawIndex), cfg.URLBase))
 
 	r.Get("/__bindery_base.js", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
@@ -1106,6 +1105,26 @@ func main() {
 		}
 		slog.Info("shutdown complete")
 	}
+}
+
+// injectBaseHTML rewrites the embedded index.html so the <base href> and the
+// __bindery_base.js bootstrap script are the FIRST children of <head>, ahead of
+// Vite's relative-path asset tags.
+//
+// Vite (base: './') emits the entry <script type="module"> and the stylesheet
+// <link> into <head> with relative "./assets/…" URLs. Per the HTML spec a <base>
+// element only governs relative URLs that appear AFTER it in document order, so
+// the base tag MUST precede those asset tags. Injecting it before </head> (i.e.
+// last) leaves the assets resolving against the document path: at /<base>/ that
+// coincidentally yields /<base>/assets/…, but a deep route like /<base>/author/10
+// resolves to /<base>/author/assets/… → 404 → the SPA fallback returns index.html
+// (text/html), the module load fails, and the page renders blank on reload.
+//
+// The __bindery_base.js classic script still executes before the deferred entry
+// module, so window.__BINDERY_BASE__ is set in time for the BrowserRouter basename.
+func injectBaseHTML(raw, urlBase string) string {
+	injection := fmt.Sprintf(`<base href="%s/"><script src="%s/__bindery_base.js"></script>`, urlBase, urlBase)
+	return strings.Replace(raw, "<head>", "<head>"+injection, 1)
 }
 
 func googleBooksAPIKey(ctx context.Context, settings *db.SettingsRepo) string {

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -259,14 +259,24 @@ func (h *ImageProxyHandler) CacheSize() (int64, error) {
 	return total, err
 }
 
+// imageProxyBase is the URL path prefix (BINDERY_URL_BASE, e.g. "/bindery")
+// the app is served under. Set once at startup via SetImageProxyBase so proxied
+// cover URLs resolve correctly behind a path-prefix reverse proxy. Empty for
+// root-mounted deploys.
+var imageProxyBase string
+
+// SetImageProxyBase configures the path prefix prepended to proxied image URLs.
+// Call once during startup, before serving requests.
+func SetImageProxyBase(base string) { imageProxyBase = base }
+
 // ProxyImageURL rewrites a raw external image URL into the local proxy path
-// /api/v1/images?url=<encoded>. Returns raw unchanged when it is empty or
+// <base>/api/v1/images?url=<encoded>. Returns raw unchanged when it is empty or
 // already a relative URL (already proxied or intentionally local).
 func ProxyImageURL(raw string) string {
 	if raw == "" || strings.HasPrefix(raw, "/") {
 		return raw
 	}
-	return "/api/v1/images?url=" + url.QueryEscape(raw)
+	return imageProxyBase + "/api/v1/images?url=" + url.QueryEscape(raw)
 }
 
 // proxyAuthorImages rewrites ImageURL on an author and all its embedded books.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,7 +1,7 @@
 // Path prefix injected by the backend at serve time (empty for root-mounted
 // deploys). Read once at module load so all API calls and redirects use a
 // consistent value throughout the session.
-const BINDERY_BASE: string = (window as unknown as { __BINDERY_BASE__?: string }).__BINDERY_BASE__ ?? ''
+export const BINDERY_BASE: string = (window as unknown as { __BINDERY_BASE__?: string }).__BINDERY_BASE__ ?? ''
 const BASE = `${BINDERY_BASE}/api/v1`
 
 // Pages that render before the user is authenticated — reaching /auth/status

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState, ReactNode, useCallback } from 'react'
-import { api, AuthStatus, initCSRF } from '../api/client'
+import { api, BINDERY_BASE, AuthStatus, initCSRF } from '../api/client'
 
 interface AuthContextValue {
   status: AuthStatus | null
@@ -43,7 +43,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const logout = useCallback(async () => {
     try { await api.authLogout() } catch { /* ignore — we're clearing state anyway */ }
     await refresh()
-    window.location.href = '/login'
+    window.location.href = `${BINDERY_BASE}/login`
   }, [refresh])
 
   const isAdmin = status?.role === 'admin'

--- a/web/src/components/RecommendationCard.tsx
+++ b/web/src/components/RecommendationCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Recommendation } from '../api/client'
+import { BINDERY_BASE, Recommendation } from '../api/client'
 
 interface RecommendationCardProps {
   rec: Recommendation
@@ -26,7 +26,7 @@ export default function RecommendationCard({ rec, onDismiss, onAdd, onExcludeAut
   }, [menuOpen])
 
   const imageUrl = rec.imageUrl
-    ? `/api/v1/images?url=${encodeURIComponent(rec.imageUrl)}`
+    ? `${BINDERY_BASE}/api/v1/images?url=${encodeURIComponent(rec.imageUrl)}`
     : ''
 
   const stars = Math.round(rec.rating * 2) / 2

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { api, Author, Book, BookBulkAction } from '../api/client'
+import { api, BINDERY_BASE, Author, Book, BookBulkAction } from '../api/client'
 import ViewToggle from '../components/ViewToggle'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
 import EditAuthorModal from '../components/EditAuthorModal'
@@ -535,7 +535,7 @@ export default function AuthorDetailPage() {
                     <tr
                       key={book.id}
                       className={`${selected.has(book.id) ? 'bg-emerald-500/10 dark:bg-emerald-500/10' : 'bg-slate-100/50 dark:bg-zinc-900/50'} hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 cursor-pointer`}
-                      onClick={() => (window.location.href = `/book/${book.id}`)}
+                      onClick={() => (window.location.href = `${BINDERY_BASE}/book/${book.id}`)}
                     >
                       <td className="px-3 py-2 w-10 align-middle" onClick={e => e.stopPropagation()}>
                         <input

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { api, Book, HistoryEvent, MediaType, SearchResult, SearchDebug } from '../api/client'
+import { api, BINDERY_BASE, Book, HistoryEvent, MediaType, SearchResult, SearchDebug } from '../api/client'
 import SearchDebugPanel from '../components/SearchDebugPanel'
 import MediaBadge from '../components/MediaBadge'
 import RebindModal from '../components/RebindModal'
@@ -370,8 +370,8 @@ export default function BookDetailPage() {
         : t('bookDetail.searchEbookIndexers')
 
   const downloadHref = isDual
-    ? `/api/v1/book/${book.id}/file?format=${fmt}`
-    : `/api/v1/book/${book.id}/file`
+    ? `${BINDERY_BASE}/api/v1/book/${book.id}/file?format=${fmt}`
+    : `${BINDERY_BASE}/api/v1/book/${book.id}/file`
 
   const formatButtonCls = (active: boolean) =>
     `px-3 py-1 text-xs font-medium border ${

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -5,7 +5,7 @@ import ViewToggle from '../components/ViewToggle'
 import { useView } from '../components/useView'
 import GettingStartedGuidance from '../components/GettingStartedGuidance'
 import { useNeedsSetup } from '../components/useNeedsSetup'
-import { api, Book } from '../api/client'
+import { api, BINDERY_BASE, Book } from '../api/client'
 import BulkActionBar from '../components/BulkActionBar'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
@@ -223,7 +223,7 @@ export default function BooksPage() {
                   <tr
                     key={book.id}
                     className={`hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 cursor-pointer ${selectedIds.has(book.id) ? 'bg-emerald-500/10 dark:bg-emerald-500/10' : 'bg-slate-100/50 dark:bg-zinc-900/50'}`}
-                    onClick={() => (window.location.href = `/book/${book.id}`)}
+                    onClick={() => (window.location.href = `${BINDERY_BASE}/book/${book.id}`)}
                   >
                     <td className="px-3 py-2 w-8" onClick={e => e.stopPropagation()}>
                       <input
@@ -329,7 +329,7 @@ export default function BooksPage() {
                   )}
                   {book.filePath && (
                     <a
-                      href={`/api/v1/book/${book.id}/file`}
+                      href={`${BINDERY_BASE}/api/v1/book/${book.id}/file`}
                       onClick={e => e.stopPropagation()}
                       className="text-[10px] text-emerald-400 hover:text-emerald-300"
                       title={t('books.downloadFile')}

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { FormEvent, useEffect, useState } from 'react'
 import { Navigate, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { api, OidcProvider } from '../api/client'
+import { api, BINDERY_BASE, OidcProvider } from '../api/client'
 import { useAuth } from '../auth/AuthContext'
 import Logo from '../components/Logo'
 
@@ -75,7 +75,7 @@ export default function LoginPage() {
           {oidcProviders.map(p => (
             <a
               key={p.id}
-              href={`/api/v1/auth/oidc/${encodeURIComponent(p.id)}/login`}
+              href={`${BINDERY_BASE}/api/v1/auth/oidc/${encodeURIComponent(p.id)}/login`}
               className="flex items-center justify-center w-full border border-slate-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 hover:bg-slate-50 dark:hover:bg-zinc-700 rounded-md py-2 text-sm font-medium transition-colors"
             >
               {t('login.signInWith', { name: p.name })}

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, AuthConfig, AuthStatus, AuthorMonitorMode, HardcoverTestResult, RootFolder, SystemStatus } from '../../api/client'
+import { api, BINDERY_BASE, AuthConfig, AuthStatus, AuthorMonitorMode, HardcoverTestResult, RootFolder, SystemStatus } from '../../api/client'
 import AuthSettings from '../../settings/AuthSettings'
 import ThemeToggle from '../../components/ThemeToggle'
 import LanguageSwitcher from '../../components/LanguageSwitcher'
@@ -859,10 +859,10 @@ export default function GeneralTab() {
             <span className="block text-xs font-medium text-slate-600 dark:text-zinc-400 mb-1">{t('settings.general.opdsFeedUrl')}</span>
             <div className="flex items-center gap-2">
               <code className="flex-1 text-xs bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 px-2 py-1.5 rounded font-mono break-all">
-                {window.location.origin}/opds
+                {window.location.origin}{BINDERY_BASE}/opds
               </code>
               <button
-                onClick={() => opdsClipboard.copy(window.location.origin + '/opds')}
+                onClick={() => opdsClipboard.copy(window.location.origin + BINDERY_BASE + '/opds')}
                 className="px-3 py-1.5 bg-slate-600 hover:bg-slate-500 rounded text-xs font-medium flex-shrink-0"
               >
                 {opdsClipboard.status === 'copied' ? t('common.copied', 'Copied') : t('settings.general.copy')}

--- a/web/src/settings/AuthSettings.tsx
+++ b/web/src/settings/AuthSettings.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, OidcProvider, OidcProviderConfig } from '../api/client'
+import { api, BINDERY_BASE, OidcProvider, OidcProviderConfig } from '../api/client'
 import ClipboardManualFallback from '../components/ClipboardManualFallback'
 import { useClipboardCopy } from '../components/useClipboardCopy'
 
@@ -151,7 +151,7 @@ function AddProviderForm({
   const [redirectBase, setRedirectBase] = useState(() =>
     typeof window !== 'undefined' ? window.location.origin : ''
   )
-  const [callbackTemplate, setCallbackTemplate] = useState('/api/v1/auth/oidc/{id}/callback')
+  const [callbackTemplate, setCallbackTemplate] = useState(`${BINDERY_BASE}/api/v1/auth/oidc/{id}/callback`)
   // undefined = still loading, true = env var set, false = derived from headers
   const [baseConfigured, setBaseConfigured] = useState<boolean | undefined>(undefined)
   const callbackClipboard = useClipboardCopy()


### PR DESCRIPTION
Closes #974

Deploying behind a reverse proxy with `BINDERY_URL_BASE=/bindery` was broken at several layers. This PR fixes all of them; root-mounted deploys (`BINDERY_URL_BASE` unset) are unaffected throughout (every change is a no-op when the base is empty).

Verified end-to-end on a live install behind nginx + Cloudflare at `…/bindery/`: app boots, assets/CSS load, book downloads work, book/author covers load, and the OPDS URL is correct.

## 1. Serving under the prefix — `cmd/bindery/main.go`

- **Assets returned `text/html`.** `chi.Mount` only rewrites the routing-context path, not `r.URL.Path`; the static handler and `http.FileServer` read `r.URL.Path` directly, so under a prefix they looked up `"<prefix>/assets/…"`, missed, and fell through to the SPA shell — every JS/CSS asset came back as `text/html` and the browser rejected the module script. Fixed by mounting with `http.StripPrefix`, which actually strips the prefix so inner handlers see un-prefixed paths.
- **CSP blocked the bootstrap.** The path base was injected as an inline `<script>window.__BINDERY_BASE__=…</script>`, but the app's CSP is `script-src 'self'`, which blocks inline scripts. Silent at root (the `""` fallback is correct), fatal under a prefix. Fixed by serving the base from a same-origin external script (`<prefix>/__bindery_base.js`), which `'self'` allows — no inline exception or per-value hash.

## 2. Frontend-built URLs — `web/src/*`

Several spots built root-absolute URLs directly instead of going through the API client (which already prefixes `BINDERY_BASE`). Root-absolute URLs ignore `<base href>`, so they resolved to the domain root:

- OPDS feed URL shown in Settings
- book download links (BookDetailPage, BooksPage)
- Discover cover images (RecommendationCard, `/api/v1/images` proxy)
- row-click navigation (BooksPage, AuthorDetailPage)
- logout / session-expiry redirect (AuthContext)
- OIDC login link + callback-URL preview (LoginPage, AuthSettings)

Exported `BINDERY_BASE` from the API client and prefixed it in each.

## 3. Server-built cover URLs — `internal/api/imageproxy.go`

`ProxyImageURL` wrapped every external book/author cover into `/api/v1/images?url=…` with no prefix, so all covers returned by the API (`author.imageUrl`, `book.imageUrl`) pointed at the domain root. Added a startup-set package base (`SetImageProxyBase`, wired from `cfg.URLBase` in `main`) and prefixed it.

## How to verify

```bash
BINDERY_URL_BASE=/bindery ./bindery   # behind any reverse proxy that forwards the prefix

curl -sI .../bindery/assets/<hashed>.js     # Content-Type: application/javascript (was text/html)
curl -s  .../bindery/__bindery_base.js      # window.__BINDERY_BASE__="/bindery";
# In the UI: covers load, book downloads work, Settings shows .../bindery/opds
```

## Notes / not in scope
- Reverse proxies must forward the prefix (do not strip `/bindery`); the app handles it internally.
- OIDC under a prefix still needs `BINDERY_OIDC_REDIRECT_BASE_URL`; session/CSRF cookies remain `Path=/`. Both unrelated to this PR.
- OPDS feed *image links* (inside the `/opds` XML) weren't audited here; the feed URL itself is fixed.