### PR TITLE
fix(api): apply SSRF guard to test-by-id handlers

### DIFF
--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -205,6 +205,10 @@ func (h *DownloadClientHandler) Test(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "download client not found"})
 		return
 	}
+	if err := httpsec.ValidateOutboundURL(downloadClientURL(client), httpsec.PolicyLAN); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
 	if err := downloader.TestClient(r.Context(), client); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return

--- a/internal/api/download_clients_test.go
+++ b/internal/api/download_clients_test.go
@@ -159,6 +159,7 @@ func TestDownloadClientTest_NotFound(t *testing.T) {
 }
 
 func TestDownloadClientTest_SuccessMessage(t *testing.T) {
+	defer httpsec.AllowLoopbackForTests()()
 	qbit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v2/auth/login":

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -202,6 +202,12 @@ func (h *IndexerHandler) Test(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "indexer not found"})
 		return
 	}
+	if idx.URL != "" {
+		if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLAN); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+	}
 
 	client := newznab.New(idx.URL, idx.APIKey)
 	probe := client.Probe(r.Context())


### PR DESCRIPTION
## Summary
- `Test` (test-by-id) handlers for indexers and download clients now call `httpsec.ValidateOutboundURL(url, httpsec.PolicyLAN)` on the persisted URL, mirroring what `TestConfig` already does.
- The `TestDownloadClientTest_SuccessMessage` handler test now opts into `httpsec.AllowLoopbackForTests()` via the documented `defer` idiom, so the global flag is restored before the next test runs.

## Background
The `internal/httpsec` package is the codebase's single SSRF guard. `TestConfig` (the inline body variant of the test endpoint) called it; `Test` (the test-by-id variant) did not. A persisted URL that pointed at loopback, link-local, or the cloud-metadata IP would have flowed through the test-by-id endpoint unchallenged, defeating the policy applied at the create/update boundary. The drift was caught by the issue #967 audit sweep.

## Testing
- `go build ./...` — clean.
- `go test ./internal/api/... ./internal/httpsec/... -p 1` — passes.
- The new SSRF guard calls are inside the existing handler-test suite; `TestDownloadClientTest_SuccessMessage` continues to pass and exercises the new loopback-allow path.
- `golangci-lint` was not run in this environment (the project's pinned version is `v2.11.4` and the local Go install does not have it installed). The change is in two six-line `if` blocks; no new linter suppressions are needed.

## Notes
- No new dependencies. No schema or DB changes. The handler error responses use the same `BadRequest` body shape as the existing `TestConfig` rejection path, so the UI error rendering is unchanged.
- The change is additive: a previously-allowed URL still works; previously-not-validated URLs are now subject to the same policy as `TestConfig`.
