### PR TITLE
ci: raise -race test timeout 15m -> 25m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           go-version: "1.25.11"
           cache: true
-      - run: go test -race -timeout=15m ./cmd/... ./internal/...
+      - run: go test -race -timeout=25m ./cmd/... ./internal/...
 
   validate-frontend:
     name: validate (frontend)
@@ -187,7 +187,7 @@ jobs:
         with:
           go-version: "1.25.11"
           cache: true
-      - run: go test -race -timeout=15m ./cmd/... ./internal/...
+      - run: go test -race -timeout=25m ./cmd/... ./internal/...
 
   # ── Docker image — runs after test passes ──────────────────────────────────
   image:


### PR DESCRIPTION
## What

The `validate (Go race)` job is failing on main with `panic: test timed out after 15m0s` in `internal/api` (900s).

## It's a timeout, not a data race

- CI reported a **timeout panic**, not `DATA RACE detected`.
- The non-race suite (`go test ./...`) is fully green.
- The race job was already ~15m53s wall on earlier PRs; the auth/queue/bulk/test-config tests added in the 1.16.1 batch tipped the race-instrumented `internal/api` suite past the 15m Go test timeout.

`validate (Go race)` is **not** a required check (required: `lint`, `validate (Go)`, `Security Summary`), so this wasn't blocking merges — but it's a real red on main.

## Fix

Raise `-timeout=15m` → `25m` in both race invocations in `ci.yml` (the PR-only job and the main/tag job).

## Follow-up (not in this PR)

`internal/api` spins up an httptest server + a fresh in-memory DB per test, which is what makes it slow under `-race`. Parallelising or sharing fixtures would cut the runtime rather than just raising the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)