### PR TITLE
chore(security): raise OpenSSF Scorecard (Token-Permissions, Fuzzing)

### DIFF
--- a/.github/workflows/discord-stats.yml
+++ b/.github/workflows/discord-stats.yml
@@ -10,11 +10,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push the image to GHCR
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/ping-server.yml
+++ b/.github/workflows/ping-server.yml
@@ -10,11 +10,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # push the image to GHCR
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/internal/importer/parser_fuzz_test.go
+++ b/internal/importer/parser_fuzz_test.go
@@ -1,0 +1,53 @@
+package importer
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzParseFilename exercises the release-name/filename parser with arbitrary
+// input. ParseFilename runs on untrusted strings (torrent/NZB titles, on-disk
+// names) throughout the import path, so it must never panic and must return
+// sane, bounded output regardless of input. This is also Bindery's OpenSSF
+// Scorecard "Fuzzing" signal (a Go native fuzz target).
+func FuzzParseFilename(f *testing.F) {
+	seeds := []string{
+		"",
+		"Andy Weir - Project Hail Mary (2021) [B08GB58KD5].epub",
+		"The Way of Kings by Brandon Sanderson [Stormlight Archive #1].m4b",
+		"01 - The Fellowship of the Ring.mobi",
+		"978-0-13-468599-1 Some Title.pdf",
+		"....___...",
+		"[[[(((]]]))) #### 9780134685991",
+		"Title – Author With En Dash.azw3",
+		strings.Repeat("a ", 500) + "#12",
+		"日本語のタイトル by 村上春樹.epub",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, path string) {
+		got := ParseFilename(path) // must not panic on any input
+
+		// FilePath echoes the input verbatim.
+		if got.FilePath != path {
+			t.Fatalf("FilePath mutated: got %q want %q", got.FilePath, path)
+		}
+		// No extracted field may be longer than the input — the parser only
+		// slices substrings out, so anything longer signals a construction bug.
+		// (Encoding is intentionally not asserted: ParseFilename passes bytes
+		// through and does not promise to sanitise invalid UTF-8 from a hostile
+		// filename; downstream JSON/DB layers handle that. It must not panic,
+		// which is the property this fuzz target guards.)
+		for name, v := range map[string]string{
+			"Title": got.Title, "Author": got.Author, "Series": got.Series,
+			"SeriesNumber": got.SeriesNumber, "ISBN": got.ISBN, "ASIN": got.ASIN,
+			"Year": got.Year, "Format": got.Format,
+		} {
+			if len(v) > len(path) {
+				t.Fatalf("%s longer than input (%d > %d) for %q: %q", name, len(v), len(path), path, v)
+			}
+		}
+	})
+}

--- a/internal/importer/testdata/fuzz/FuzzParseFilename/c59cf72be34148ed
+++ b/internal/importer/testdata/fuzz/FuzzParseFilename/c59cf72be34148ed
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\xa1")


### PR DESCRIPTION
## Context

Current Scorecard aggregate is **5.6/10** (measured with the scorecard CLI against the repo). This PR fixes the two biggest **code-level** gaps; both verified locally with `scorecard --local` moving **0/10 → 10/10**.

## Changes

**Token-Permissions: 0 → 10.** `discord-stats.yml` and `ping-server.yml` declared `packages: write` at the *workflow top level* — Scorecard flags top-level write as excessive. Moved it to the single `build` job that actually pushes to GHCR; top level is now `contents: read`. With those two the only offenders, the whole repo now follows least privilege.

**Fuzzing: 0 → 10.** Added `FuzzParseFilename`, a Go native fuzz target for the release-name/filename parser, which runs on untrusted torrent/NZB titles and on-disk names. It asserts no-panic and bounded output and survives ~870k execs. (The fuzzer surfaced that the parser passes invalid-UTF-8 bytes through to `Title` — not a defect: the input is itself invalid, it doesn't panic, and JSON/DB layers handle it; the invariant was relaxed rather than asserting a contract the parser never had. A `"\xa1"` regression seed is included.)

## Scorecard breakdown (for reference) and what's left

| Check | Score | Fixable here? |
|---|---|---|
| Token-Permissions | 0 → **10** | ✅ this PR |
| Fuzzing | 0 → **10** | ✅ this PR |
| Pinned-Dependencies | 9 | npm/pip commands not hash-pinned; brittle for +1, skipped |
| Branch-Protection | 3 | **repo settings** (maintainer) — require reviews/status checks on main + release branches |
| Code-Review | 0 | **process** — changes need approving reviews before merge (solo admin-merges score 0) |
| Signed-Releases | 0 | release pipeline — add cosign/SLSA signing to GoReleaser (separate, sensitive) |
| CII-Best-Practices | 0 | **external** — register for the OpenSSF Best Practices badge |
| Maintained | 0 | **time** — repo is <90 days old; auto-resolves |
| Contributors | 0 | organic (contributor org affiliations) |

Already 10/10: Binary-Artifacts, Dangerous-Workflow, Dependency-Update-Tool, License, Packaging, SAST, Security-Policy, Vulnerabilities; CI-Tests 9.

## Verify

- `go test ./internal/importer/ -run FuzzParseFilename` green; `-fuzz` 30s clean (~870k execs).
- `scorecard --local` → Token-Permissions 10/10, Fuzzing 10/10.
- Both workflow YAMLs parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)