### PR TITLE
fix(web): show selection checkmark over white covers in light mode

### DIFF
--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -606,7 +606,7 @@ export default function AuthorDetailPage() {
                   checked={selected.has(book.id)}
                   onChange={() => toggleSelect(book.id)}
                   onClick={e => e.stopPropagation()}
-                  className="absolute top-2 left-2 z-10 rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 bg-white/80 dark:bg-zinc-900/80"
+                  className={`absolute top-2 left-2 z-10 rounded border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 ${selected.has(book.id) ? '' : 'bg-white/80 dark:bg-zinc-900/80'}`}
                   aria-label={`Select ${book.title}`}
                 />
                 <Link to={`/book/${book.id}`} className="block">

--- a/web/src/pages/AuthorsPage.test.tsx
+++ b/web/src/pages/AuthorsPage.test.tsx
@@ -144,4 +144,50 @@ describe('AuthorsPage', () => {
       expect(api.bulkActionAuthors).toHaveBeenCalledWith([7], 'refresh'),
     )
   })
+
+  // Regression for the "invisible checkmark in light mode" bug: the grid-card
+  // overlay checkbox uses a translucent white backdrop so the empty box is
+  // visible over cover art. But @tailwindcss/forms paints the *checked* state
+  // with a white checkmark on a `currentColor` (emerald) fill — and under
+  // Tailwind v4's cascade layers the `bg-white/80` utility (utilities layer)
+  // overrides that fill (base layer), leaving a white check on white. So the
+  // opaque backdrop must NOT be present once the box is checked.
+  it('drops the opaque white backdrop on a selected grid card so the checkmark shows', async () => {
+    vi.mocked(api.listAuthors).mockResolvedValue({
+      items: [
+        {
+          id: 7,
+          foreignAuthorId: 'OL7',
+          authorName: 'Andy Weir',
+          sortName: 'Weir, Andy',
+          description: '',
+          imageUrl: '',
+          disambiguation: '',
+          ratingsCount: 0,
+          averageRating: 0,
+          monitored: true,
+        },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    })
+
+    render(
+      <MemoryRouter>
+        <AuthorsPage />
+      </MemoryRouter>,
+    )
+
+    const checkbox = await screen.findByTitle('Select Andy Weir')
+    // Unchecked: the translucent backdrop keeps the empty box visible over art.
+    expect(checkbox.className).toContain('bg-white/80')
+
+    fireEvent.click(checkbox)
+
+    // Checked: the white backdrop must be gone so the emerald fill + white
+    // checkmark is visible instead of white-on-white.
+    expect(checkbox).toBeChecked()
+    expect(checkbox.className).not.toContain('bg-white/80')
+  })
 })

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -326,7 +326,7 @@ export default function AuthorsPage() {
                   type="checkbox"
                   checked={selectedIds.has(author.id)}
                   onChange={() => toggleSelect(author.id)}
-                  className="absolute top-2 left-2 z-10 rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 bg-white/80 dark:bg-zinc-900/80"
+                  className={`absolute top-2 left-2 z-10 rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 ${selectedIds.has(author.id) ? '' : 'bg-white/80 dark:bg-zinc-900/80'}`}
                   title={`Select ${author.authorName}`}
                 />
                 <Link to={`/author/${author.id}`} className="flex gap-3 p-4 hover:bg-slate-200/40 dark:hover:bg-zinc-800/40 transition-colors">

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -285,7 +285,7 @@ export default function BooksPage() {
                   type="checkbox"
                   checked={selectedIds.has(book.id)}
                   onChange={() => toggleSelect(book.id)}
-                  className="absolute top-2 left-2 z-10 rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 bg-white/80 dark:bg-zinc-900/80"
+                  className={`absolute top-2 left-2 z-10 rounded-full border-slate-400 dark:border-zinc-600 text-emerald-500 focus:ring-emerald-500 focus:ring-offset-0 ${selectedIds.has(book.id) ? '' : 'bg-white/80 dark:bg-zinc-900/80'}`}
                   title={`Select ${book.title}`}
                   onClick={e => e.stopPropagation()}
                 />


### PR DESCRIPTION
Closes #978

## Problem

Selecting a card in a grid view (Authors, Books, an author's books) shows **no checkmark in light mode** — the border turns emerald and the selection registers, but the box looks empty. It's worst over white cover art, where the box vanishes. Dark mode is fine.

## Root cause

The grid-card boxes are native checkboxes styled by `@tailwindcss/forms`, which paints a **white checkmark on a `currentColor` (emerald) fill** when checked. The overlay boxes also carry `bg-white/80 dark:bg-zinc-900/80` so the *empty* box stays visible over cover art.

Under **Tailwind v4's cascade layers**, the `bg-white/80` utility (utilities layer) overrides the plugin's checked fill (base layer) regardless of specificity. So a checked box keeps the translucent backdrop:

- light mode → white check on `white/80` → invisible
- dark mode → white check on `zinc-900/80` → visible (why it's light-mode-only)

The table and select-all checkboxes have no `bg-white/80`, so they already render correctly.

## Fix

Apply the translucent backdrop **only while unselected**. Once checked, it drops away and the emerald fill + white check shows through — in both themes, consistent with every other checkbox in the app.

```diff
- className="… bg-white/80 dark:bg-zinc-900/80"
+ className={`… ${selected ? '' : 'bg-white/80 dark:bg-zinc-900/80'}`}
```

Applied to all three grid-overlay checkboxes:
- `web/src/pages/AuthorsPage.tsx`
- `web/src/pages/BooksPage.tsx`
- `web/src/pages/AuthorDetailPage.tsx`

## Tests

- Added a regression test in `AuthorsPage.test.tsx`: a selected grid card must not keep the opaque backdrop (otherwise white-on-white).
- Full suite green (259 tests), `tsc --noEmit` clean, `eslint` clean.
