### PR TITLE
fix: remove dead inline theme script blocked by CSP

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,16 +5,6 @@
     <link rel="icon" type="image/png" href="favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bindery</title>
-    <script>
-      (function () {
-        try {
-          var saved = localStorage.getItem('bindery.theme');
-          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-          var dark = saved === 'dark' || (!saved && prefersDark);
-          if (dark) document.documentElement.classList.add('dark');
-        } catch (e) {}
-      })();
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/theme.ts
+++ b/web/src/theme.ts
@@ -19,8 +19,8 @@ function apply(theme: Theme) {
 /**
  * useTheme — returns the current theme and a setter. Persists to
  * localStorage and toggles the `dark` class on <html>. The initial
- * state is read synchronously so SSR/pre-paint matches the rendered
- * markup (see the bootstrap script in index.html).
+ * state is read synchronously so the app's first render already
+ * reflects the persisted/system theme.
  */
 export function useTheme() {
   const [theme, setThemeState] = useState<Theme>(readInitial)


### PR DESCRIPTION
## Problem

`web/index.html` ships an inline `<script>` that sets the `dark` class before paint to avoid a theme flash. But the app's own CSP — `script-src 'self'` in `internal/api/securityheaders.go` — blocks all inline scripts, so this one **never executes**. It only produces a console error on every page load:

> Executing inline script violates the following Content Security Policy directive `script-src 'self'`. ... The action has been blocked.

So it's effectively dead code.

## Why removing it is safe

`useTheme` in `web/src/theme.ts` already reads the same preference (`localStorage['bindery.theme']`, falling back to `prefers-color-scheme`) synchronously and toggles the `dark` class on mount. The theme is applied by the app at runtime regardless of the inline script — confirmed in practice (dark mode works today even though the inline script is already blocked by CSP).

Removing the script:
- clears the recurring CSP console error,
- deletes genuinely dead code,
- changes no user-visible behavior.

Also updates the now-stale `theme.ts` JSDoc that referenced the removed bootstrap script.

## Follow-up (optional)

The only thing lost is *pre-hydration* flash prevention, which has been non-functional under the current CSP anyway. If desired it can be reintroduced CSP-compliantly as an **external same-origin** script (`<script src="…">`) — left out here to keep this change minimal.

Closes #980
