### PR TITLE
fix(web): make the book status pill monitored-aware (#977)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Backlist books no longer show a misleading "Wanted" pill** (#977) — `status` and `monitored` are orthogonal (every book starts `status=wanted`; backlist siblings are added unmonitored), but the status pill rendered `status` alone, so an unmonitored backlist book read "Wanted" while correctly never appearing on the Wanted page (which lists `status=wanted AND monitored`). A shared `bookStatusBadge` helper now makes the pill monitored-aware across the book detail page, book lists, and author rows: `wanted` + monitored → "Wanted"; `wanted` + unmonitored → "Not monitored" (muted). No status/model/DB change.
+
 ## [v1.16.1] — 2026-06-03
 
 A getting-started / onboarding friction pass plus a batch of fixes from user reports. No breaking changes.

--- a/web/src/components/bookStatus.test.ts
+++ b/web/src/components/bookStatus.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { bookStatusBadge } from './bookStatus'
+
+// Stub t: return the key so we can assert which label path was taken without
+// depending on the loaded i18n resources.
+const t = ((key: string) => key) as unknown as Parameters<typeof bookStatusBadge>[2]
+
+describe('bookStatusBadge', () => {
+  it('labels a wanted+monitored book "Wanted" with the amber colour', () => {
+    const b = bookStatusBadge('wanted', true, t)
+    expect(b.label).toBe('bookStatus.wanted')
+    expect(b.colorClass).toContain('amber')
+  })
+
+  it('labels a wanted+UNmonitored book "Not monitored" with a muted colour, not Wanted (#977)', () => {
+    const b = bookStatusBadge('wanted', false, t)
+    expect(b.label).toBe('bookStatus.notMonitored')
+    expect(b.label).not.toBe('bookStatus.wanted')
+    expect(b.colorClass).toMatch(/slate|zinc/)
+    expect(b.colorClass).not.toContain('amber')
+  })
+
+  it('leaves non-wanted statuses unaffected by monitored', () => {
+    for (const monitored of [true, false]) {
+      const imp = bookStatusBadge('imported', monitored, t)
+      expect(imp.label).toBe('bookStatus.imported')
+      expect(imp.colorClass).toContain('emerald')
+
+      const dl = bookStatusBadge('downloading', monitored, t)
+      expect(dl.label).toBe('bookStatus.downloading')
+      expect(dl.colorClass).toContain('blue')
+    }
+  })
+
+  it('falls back to a muted badge for an unknown status', () => {
+    const b = bookStatusBadge('weird', true, t)
+    expect(b.colorClass).toMatch(/slate|zinc/)
+  })
+})

--- a/web/src/components/bookStatus.ts
+++ b/web/src/components/bookStatus.ts
@@ -1,0 +1,35 @@
+// Shared status-badge logic for library books, used by the book detail page and
+// the book/author list views so every surface agrees with the Wanted page.
+//
+// `status` and `monitored` are orthogonal: `status` is the acquisition
+// lifecycle (every book starts `wanted`), while `monitored` is whether Bindery
+// actively pursues it. The Wanted page lists `status=wanted AND monitored`, so a
+// backlist book (`wanted` + unmonitored) must NOT read "Wanted" on its detail
+// page or in lists — otherwise the pill and the Wanted page disagree (#977).
+
+const statusColors: Record<string, string> = {
+  wanted: 'bg-amber-500/20 text-amber-700 dark:text-amber-400',
+  downloading: 'bg-blue-500/20 text-blue-700 dark:text-blue-400',
+  downloaded: 'bg-purple-500/20 text-purple-700 dark:text-purple-400',
+  imported: 'bg-emerald-500/20 text-emerald-700 dark:text-emerald-400',
+  skipped: 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400',
+}
+
+// Muted slate, used for the not-monitored state and any unknown status.
+const mutedColor = 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'
+
+import type { TFunction } from 'i18next'
+
+// bookStatusBadge returns the label and colour classes for a book's status
+// pill, made monitored-aware. Pass i18next's `t`. Callers supply their own
+// sizing/layout classes and append `colorClass`.
+export function bookStatusBadge(
+  status: string,
+  monitored: boolean,
+  t: TFunction,
+): { label: string; colorClass: string } {
+  if (status === 'wanted' && !monitored) {
+    return { label: t('bookStatus.notMonitored', { defaultValue: 'Not monitored' }), colorClass: mutedColor }
+  }
+  return { label: t(`bookStatus.${status}`, { defaultValue: status }), colorClass: statusColors[status] ?? mutedColor }
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -731,6 +731,14 @@
     "roleFail": "Failed to change role",
     "createFail": "Failed to create user"
   },
+  "bookStatus": {
+    "wanted": "Wanted",
+    "downloading": "Downloading",
+    "downloaded": "Downloaded",
+    "imported": "Imported",
+    "skipped": "Skipped",
+    "notMonitored": "Not monitored"
+  },
   "bookDetail": {
     "back": "← Books",
     "notFound": "Book not found",

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -198,13 +198,13 @@ describe('AuthorDetailPage', () => {
     expect(snapshotCells[4]).toHaveTextContent('Downloaded')
 
     const dualFormatCells = within(rowForTitle('Dual Format')).getAllByRole('cell')
-    expect(dualFormatCells[1]).toHaveTextContent('In Library')
+    expect(dualFormatCells[1]).toHaveTextContent('Imported')
     expect(dualFormatCells[1]).toHaveTextContent('📖🎧 Both')
     expect(dualFormatCells[1]).toHaveTextContent('2022')
     expect(dualFormatCells[1]).toHaveTextContent('Excluded')
     expect(dualFormatCells[2]).toHaveTextContent('2022')
     expect(dualFormatCells[3]).toHaveTextContent('📖🎧 Both')
-    expect(dualFormatCells[4]).toHaveTextContent('In Library')
+    expect(dualFormatCells[4]).toHaveTextContent('Imported')
     expect(dualFormatCells[4]).toHaveTextContent('Excluded')
   })
 

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -3,28 +3,11 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { api, BINDERY_BASE, Author, Book, BookBulkAction } from '../api/client'
 import ViewToggle from '../components/ViewToggle'
+import { bookStatusBadge } from '../components/bookStatus'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
 import EditAuthorModal from '../components/EditAuthorModal'
 import BulkActionBar from '../components/BulkActionBar'
 import { useView } from '../components/useView'
-
-const statusColors: Record<string, string> = {
-  wanted: 'bg-amber-500/20 text-amber-700 dark:text-amber-400',
-  downloading: 'bg-blue-500/20 text-blue-700 dark:text-blue-400',
-  downloaded: 'bg-purple-500/20 text-purple-700 dark:text-purple-400',
-  imported: 'bg-emerald-500/20 text-emerald-700 dark:text-emerald-400',
-  skipped: 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400',
-}
-
-const fallbackStatusColor = 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'
-
-const statusLabel: Record<string, string> = {
-  wanted: 'Wanted',
-  downloading: 'Downloading',
-  downloaded: 'Downloaded',
-  imported: 'In Library',
-  skipped: 'Skipped',
-}
 
 type MediaFilter = '' | 'ebook' | 'audiobook'
 type StatusFilter = '' | 'wanted' | 'downloading' | 'downloaded' | 'imported' | 'skipped'
@@ -38,9 +21,6 @@ function fmtPublishedYear(d?: string): string {
   return d.slice(0, 4)
 }
 
-function statusBadgeClass(status: string, base = 'inline-block px-2 py-0.5 rounded text-[10px] font-medium'): string {
-  return `${base} ${statusColors[status] || fallbackStatusColor}`
-}
 
 function mediaLabel(mediaType?: Book['mediaType']): string {
   if (mediaType === 'audiobook') return '🎧 Audiobook'
@@ -556,9 +536,14 @@ export default function AuthorDetailPage() {
                           <span className="min-w-0 flex-1">
                             <span className="block text-slate-800 dark:text-zinc-200 truncate">{book.title}</span>
                             <span className="mt-1 flex flex-wrap items-center gap-1 sm:hidden">
-                              <span className={statusBadgeClass(book.status, 'inline-block px-1.5 py-0.5 rounded text-[10px] font-medium')}>
-                                {statusLabel[book.status] ?? book.status}
-                              </span>
+                              {(() => {
+                                const badge = bookStatusBadge(book.status, book.monitored, t)
+                                return (
+                                  <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${badge.colorClass}`}>
+                                    {badge.label}
+                                  </span>
+                                )
+                              })()}
                               <span className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400">
                                 {mediaLabel(book.mediaType)}
                               </span>
@@ -579,9 +564,14 @@ export default function AuthorDetailPage() {
                         {mediaLabel(book.mediaType)}
                       </td>
                       <td className="hidden sm:table-cell px-3 py-2 whitespace-nowrap align-middle">
-                        <span className={statusBadgeClass(book.status)}>
-                          {statusLabel[book.status] ?? book.status}
-                        </span>
+                        {(() => {
+                          const badge = bookStatusBadge(book.status, book.monitored, t)
+                          return (
+                            <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-medium ${badge.colorClass}`}>
+                              {badge.label}
+                            </span>
+                          )
+                        })()}
                         {book.excluded && (
                           <span className="inline-block ml-1 px-2 py-0.5 rounded text-[10px] font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">
                             Excluded
@@ -622,9 +612,14 @@ export default function AuthorDetailPage() {
                   <div className="p-2">
                     <h4 className="text-xs font-medium truncate" title={book.title}>{book.title}</h4>
                     <div className="flex items-center gap-1 mt-1 flex-wrap">
-                      <span className={statusBadgeClass(book.status, 'px-1.5 py-0.5 rounded text-[10px] font-medium')}>
-                        {statusLabel[book.status] ?? book.status}
-                      </span>
+                      {(() => {
+                        const badge = bookStatusBadge(book.status, book.monitored, t)
+                        return (
+                          <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${badge.colorClass}`}>
+                            {badge.label}
+                          </span>
+                        )
+                      })()}
                       {book.mediaType === 'audiobook' && (
                         <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300">🎧 Audio</span>
                       )}

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { api, BINDERY_BASE, Book, HistoryEvent, MediaType, SearchResult, SearchDebug } from '../api/client'
 import SearchDebugPanel from '../components/SearchDebugPanel'
 import MediaBadge from '../components/MediaBadge'
+import { bookStatusBadge } from '../components/bookStatus'
 import RebindModal from '../components/RebindModal'
 import ConfirmDialog from '../components/ConfirmDialog'
 import ClipboardManualFallback from '../components/ClipboardManualFallback'
@@ -47,13 +48,6 @@ function languageName(code?: string): string | null {
   return LANGUAGE_NAMES[code.toLowerCase()] ?? code
 }
 
-const statusColors: Record<string, string> = {
-  wanted: 'bg-amber-500/20 text-amber-700 dark:text-amber-400',
-  downloading: 'bg-blue-500/20 text-blue-700 dark:text-blue-400',
-  downloaded: 'bg-purple-500/20 text-purple-700 dark:text-purple-400',
-  imported: 'bg-emerald-500/20 text-emerald-700 dark:text-emerald-400',
-  skipped: 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400',
-}
 
 // Small coloured dot for a history row, by event type.
 const eventDotColors: Record<string, string> = {
@@ -414,9 +408,14 @@ export default function BookDetailPage() {
           )}
 
           <div className="flex flex-wrap items-center gap-2 mt-3 text-xs">
-            <span className={`inline-flex items-center px-2 py-0.5 rounded font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
-              {t(`bookDetail.status.${book.status}`, book.status)}
-            </span>
+            {(() => {
+              const badge = bookStatusBadge(book.status, book.monitored, t)
+              return (
+                <span className={`inline-flex items-center px-2 py-0.5 rounded font-medium ${badge.colorClass}`}>
+                  {badge.label}
+                </span>
+              )
+            })()}
             {book.excluded && (
               <span className="inline-flex items-center px-2 py-0.5 rounded font-medium bg-amber-500/20 text-amber-700 dark:text-amber-400">
                 {t('bookDetail.excludedBadge')}

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import ViewToggle from '../components/ViewToggle'
+import { bookStatusBadge } from '../components/bookStatus'
 import { useView } from '../components/useView'
 import GettingStartedGuidance from '../components/GettingStartedGuidance'
 import { useNeedsSetup } from '../components/useNeedsSetup'
@@ -12,13 +13,6 @@ import { usePagination } from '../components/usePagination'
 
 type SortMode = 'title-az' | 'title-za' | 'date-new' | 'date-old'
 
-const statusColors: Record<string, string> = {
-  wanted: 'bg-amber-500/20 text-amber-400',
-  downloading: 'bg-blue-500/20 text-blue-400',
-  downloaded: 'bg-cyan-500/20 text-cyan-400',
-  imported: 'bg-emerald-500/20 text-emerald-400',
-  skipped: 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400',
-}
 
 // statusLabel is populated at render time from t() — see BooksPage
 const statusLabelKeys: Record<string, string> = {
@@ -263,9 +257,14 @@ export default function BooksPage() {
                           : `📖 ${t('common.ebook')}`}
                     </td>
                     <td className="px-3 py-2 whitespace-nowrap">
-                      <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
-                        {statusLabelKeys[book.status] ? t(statusLabelKeys[book.status]) : book.status}
-                      </span>
+                      {(() => {
+                        const badge = bookStatusBadge(book.status, book.monitored, t)
+                        return (
+                          <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-medium ${badge.colorClass}`}>
+                            {badge.label}
+                          </span>
+                        )
+                      })()}
                     </td>
                   </tr>
                 ))}
@@ -305,9 +304,14 @@ export default function BooksPage() {
                   <p className="text-[10px] text-slate-500 dark:text-zinc-500 truncate mt-0.5">{book.author.authorName}</p>
                 )}
                 <div className="flex items-center gap-1 mt-1 flex-wrap">
-                  <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${statusColors[book.status] || 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
-                    {statusLabelKeys[book.status] ? t(statusLabelKeys[book.status]) : book.status}
-                  </span>
+                  {(() => {
+                    const badge = bookStatusBadge(book.status, book.monitored, t)
+                    return (
+                      <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${badge.colorClass}`}>
+                        {badge.label}
+                      </span>
+                    )
+                  })()}
                   {(book.mediaType === 'audiobook' || book.mediaType === 'both') && (
                     <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300">{t('books.audioLabel')}</span>
                   )}


### PR DESCRIPTION
## What

Fixes #977. Backlist books showed a **"Wanted"** pill on their detail page (and in lists) but never appeared on the Wanted page.

## Root cause

`status` and `monitored` are orthogonal. Every book starts `status=wanted`; backlist siblings are added **unmonitored**. The Wanted page filters `status=wanted AND monitored=1`, but the status pill rendered `status` alone, so an unmonitored backlist book read "Wanted" while being (correctly) absent from the Wanted page. The data was right; the label lied.

## Fix (display-only)

New shared `bookStatusBadge(status, monitored, t)` helper:
- `wanted` + monitored → **Wanted** (amber)
- `wanted` + unmonitored → **Not monitored** (muted)
- other statuses → unchanged

Applied to the book detail page, both book-list views, and the author detail rows, replacing three divergent local status maps. (AuthorDetailPage's one-off "In Library" label becomes the consistent "Imported".) No status enum, model, or DB change.

The "make the monitored toggle visible on the book page" idea from the issue is deliberately **not** included here — that's a feature add; this PR is the display-correctness fix. Worth a follow-up.

## Verify

- `bookStatus.test.ts` covers the monitored-aware branching.
- typecheck / build / lint clean; full web suite 263 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)