### PR TITLE
fix(httpsec): allow loopback for admin-configured service URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Changed
+
+- **Loopback URLs are now allowed for admin-configured service endpoints** — download clients, indexers, Prowlarr, the Audiobookshelf base URL, and the Calibre plugin URL now accept `http://127.0.0.1:…` / `localhost` (new `PolicyLANLoopback` SSRF tier). Previously the SSRF guard blocked all loopback with no escape hatch, which made a legitimate, common topology impossible: a companion service bound to `127.0.0.1`, or both containers on `network_mode: host`, could not be reached (e.g. SABnzbd on `127.0.0.1:50155` was rejected with "url not allowed: points to loopback address"). These endpoints are admin-only and CSRF-gated, so the loopback block bought ~no security. **Untrusted paths are unchanged**: proxied cover images and outbound webhooks still block loopback, and link-local + cloud-metadata (e.g. `169.254.169.254`) remain blocked everywhere. The release/torrent download URLs returned by indexers also still block loopback (a malicious indexer must not be able to point Bindery at internal services).
+
 ### Fixed
 
 - **Backlist books no longer show a misleading "Wanted" pill** (#977) — `status` and `monitored` are orthogonal (every book starts `status=wanted`; backlist siblings are added unmonitored), but the status pill rendered `status` alone, so an unmonitored backlist book read "Wanted" while correctly never appearing on the Wanted page (which lists `status=wanted AND monitored`). A shared `bookStatusBadge` helper now makes the pill monitored-aware across the book detail page, book lists, and author rows: `wanted` + monitored → "Wanted"; `wanted` + unmonitored → "Not monitored" (muted). No status/model/DB change.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -270,17 +270,15 @@ After fixing a path or category mismatch, use **Queue → Retry import** on an `
 | `BINDERY_TRUSTED_PROXY` | _(empty)_ | Comma-separated IP/CIDR list of reverse proxies trusted to set `X-Forwarded-*`. Bindery resolves the real client IP (for local-only auth and the per-IP login rate-limiter) by walking the `X-Forwarded-For` chain and only trusting hops in this list; it never trusts a client-supplied leftmost entry. An entry like `0.0.0.0/0` trusts every peer and effectively disables per-IP decisions. **Required** when proxy auth mode is active — Bindery refuses to start without it. |
 | `BINDERY_TELEMETRY_DISABLED` | _(unset)_ | Set to `true` to opt out of the daily anonymous telemetry ping before any DB setting exists (e.g. on first boot). Equivalent to `telemetry.enabled: false` in **Settings → General**, but takes effect before the first ping fires. |
 
-## Indexer / Prowlarr URLs
+## Service URLs and the SSRF policy
 
-URLs entered for **Settings → Indexers** and **Settings → Indexers → Add Prowlarr** are validated against an SSRF policy that **blocks loopback** (`127.0.0.0/8`, `::1`), link-local (`169.254/16`, `fe80::/10`), and cloud-metadata endpoints (e.g. `169.254.169.254`). RFC1918 ranges (`10/8`, `172.16/12`, `192.168/16`) are allowed.
+Outbound URLs are validated against an SSRF policy. Two trust levels apply:
 
-This means `http://localhost:9696` and `http://127.0.0.1:9696` are **rejected** even when Prowlarr runs on the same host. Use one of the following instead:
+- **Admin-typed service URLs** — download clients (qBittorrent/Transmission/Deluge/SABnzbd/NZBGet), indexers, Prowlarr, the Audiobookshelf base URL, and the Calibre plugin URL. These **allow loopback** (`127.0.0.1`, `::1`) and RFC1918 LAN ranges (`10/8`, `172.16/12`, `192.168/16`). So `http://127.0.0.1:9696` or `http://localhost:50155` work when the service runs on the same host (including `network_mode: host`, or a companion bound only to loopback). Link-local (`169.254/16`, `fe80::/10`) and cloud-metadata endpoints (e.g. `169.254.169.254`) are always blocked. These endpoints are admin-only and CSRF-gated, so loopback is the operator's call.
 
-- **Same Docker network** — use the service name: `http://prowlarr:9696`.
-- **Same host, different containers** — use the host's LAN IP: `http://192.168.x.y:9696`.
-- **Bare-metal both processes** — use the host's LAN IP, or have Prowlarr listen on a non-loopback interface.
+- **Untrusted / outbound URLs** — proxied cover images (URLs that come from metadata providers and book data) and outbound notification webhooks. These keep blocking loopback, link-local, and cloud-metadata. Webhooks additionally block RFC1918 unless `BINDERY_NOTIFICATIONS_ALLOW_PRIVATE=true`.
 
-The rejection is intentional: a confused-deputy request from Bindery to a loopback URL would let any logged-in user probe services running locally on the Bindery host. There is no env-var escape hatch — if you need it for a controlled test environment, [open an issue](https://github.com/vavallee/bindery/issues/new) describing the use case.
+If a same-host service still isn't reachable, the usual cause is that the service is bound to an interface your URL doesn't match (for example SABnzbd listening only on `127.0.0.1` while you used the LAN IP, or vice versa). Either point Bindery at the interface the service actually listens on, or set the service to listen on `0.0.0.0`.
 
 ## First-run setup
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -64,21 +64,13 @@ point Bindery at a Prowlarr instance.
 (e.g. `http://prowlarr:9696`) and API key, then **Sync now** to pull its
 configured indexers in.
 
-> **Gotcha — `localhost` / `127.0.0.1` indexer URLs are rejected.**
-> Indexer and Prowlarr URLs are validated against an SSRF policy that **blocks
-> loopback** (`127.0.0.0/8`, `::1`), link-local (`169.254.0.0/16`), and
-> cloud-metadata endpoints. This is intentional: a confused-deputy request to
-> a loopback URL would let any logged-in user probe services running locally
-> on the Bindery host, and there is **no env-var escape hatch**. RFC1918
-> ranges (`10/8`, `172.16/12`, `192.168/16`) are allowed, so use:
->
-> - **Same Docker network** → the service name: `http://prowlarr:9696`.
-> - **Same host, different containers** → the host's LAN IP:
->   `http://192.168.x.y:9696`.
-> - **Bare-metal** → the host's LAN IP, or have the indexer listen on a
->   non-loopback interface.
->
-> Full detail: [DEPLOYMENT.md → Indexer / Prowlarr URLs](DEPLOYMENT.md#indexer--prowlarr-urls).
+> **Same-host indexers:** loopback (`http://127.0.0.1:9696`, `localhost`) and
+> LAN IPs are allowed for indexer / Prowlarr URLs, so a same-host indexer works.
+> The catch is networking-mode, not the SSRF policy: if Bindery runs in its own
+> bridge-network container, `127.0.0.1` resolves to *Bindery's* container, not
+> the host — use the service name (`http://prowlarr:9696`), the host LAN IP, or
+> `network_mode: host`. Link-local and cloud-metadata endpoints stay blocked.
+> Full detail: [DEPLOYMENT.md → Service URLs and the SSRF policy](DEPLOYMENT.md#service-urls-and-the-ssrf-policy).
 
 Use the **Test** button on the saved indexer to confirm it connects and
 returns categories.
@@ -109,10 +101,15 @@ username/password for the others), and the **Category / Label** (default
 
 Use **Test** to confirm the connection.
 
-> **Same-host clients:** the loopback rule in step 3 is an *indexer-URL*
-> validation, not a download-client one. But if Bindery runs in a separate
-> container, a download-client host of `127.0.0.1` still points at Bindery's
-> own container, not the client. Use the service name or LAN IP here too.
+> **Same-host clients:** loopback and LAN hosts are allowed for download-client
+> URLs too, so `http://127.0.0.1:50155` works for a same-host SABnzbd (e.g. under
+> `network_mode: host`, or a client bound only to `127.0.0.1`). The same
+> networking-mode caveat applies: if Bindery is in its own bridge-network
+> container, `127.0.0.1` points at *Bindery's* container, not the client — use
+> the service name or LAN IP there. If a same-host client is refused at the
+> connection (not by validation), the service is bound to an interface your URL
+> doesn't match (e.g. it listens only on `127.0.0.1` but you used the LAN IP);
+> point at the right interface or set the service to listen on `0.0.0.0`.
 > When Bindery and the client mount the same storage at different paths, set a
 > [download-client path remap](DEPLOYMENT.md#path-remapping-multi-container--multi-pod-setups).
 

--- a/internal/abs/client.go
+++ b/internal/abs/client.go
@@ -70,7 +70,7 @@ func ValidateBaseURLSecure(raw string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := httpsec.ValidateOutboundURL(u, httpsec.PolicyLAN); err != nil {
+	if err := httpsec.ValidateOutboundURL(u, httpsec.PolicyLANLoopback); err != nil {
 		return "", fmt.Errorf("base_url %q: %w", raw, err)
 	}
 	return u, nil

--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -132,7 +132,7 @@ func (h *DownloadClientHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if c.Category == "" {
 		c.Category = "books"
 	}
-	if err := httpsec.ValidateOutboundURL(downloadClientURL(&c), httpsec.PolicyLAN); err != nil {
+	if err := httpsec.ValidateOutboundURL(downloadClientURL(&c), httpsec.PolicyLANLoopback); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
@@ -161,7 +161,7 @@ func (h *DownloadClientHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	if c.Host != "" {
 		c.Host = sanitizeHost(c.Host)
-		if err := httpsec.ValidateOutboundURL(downloadClientURL(&c), httpsec.PolicyLAN); err != nil {
+		if err := httpsec.ValidateOutboundURL(downloadClientURL(&c), httpsec.PolicyLANLoopback); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -205,7 +205,7 @@ func (h *DownloadClientHandler) Test(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "download client not found"})
 		return
 	}
-	if err := httpsec.ValidateOutboundURL(downloadClientURL(client), httpsec.PolicyLAN); err != nil {
+	if err := httpsec.ValidateOutboundURL(downloadClientURL(client), httpsec.PolicyLANLoopback); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
@@ -245,7 +245,7 @@ func (h *DownloadClientHandler) TestConfig(w http.ResponseWriter, r *http.Reques
 	if c.Port == 0 {
 		c.Port = 8080
 	}
-	if err := httpsec.ValidateOutboundURL(downloadClientURL(&c), httpsec.PolicyLAN); err != nil {
+	if err := httpsec.ValidateOutboundURL(downloadClientURL(&c), httpsec.PolicyLANLoopback); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -105,7 +105,7 @@ func (h *IndexerHandler) Create(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and url required"})
 		return
 	}
-	if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLAN); err != nil {
+	if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLANLoopback); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
@@ -151,7 +151,7 @@ func (h *IndexerHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if idx.URL != "" {
-		if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLAN); err != nil {
+		if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLANLoopback); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -203,7 +203,7 @@ func (h *IndexerHandler) Test(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if idx.URL != "" {
-		if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLAN); err != nil {
+		if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLANLoopback); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
@@ -244,7 +244,7 @@ func (h *IndexerHandler) TestConfig(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "url required"})
 		return
 	}
-	if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLAN); err != nil {
+	if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLANLoopback); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}

--- a/internal/api/prowlarr.go
+++ b/internal/api/prowlarr.go
@@ -106,7 +106,7 @@ func (h *ProwlarrHandler) Create(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "url is required"})
 		return
 	}
-	if err := httpsec.ValidateOutboundURL(p.URL, httpsec.PolicyLAN); err != nil {
+	if err := httpsec.ValidateOutboundURL(p.URL, httpsec.PolicyLANLoopback); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid indexer URL: " + err.Error()})
 		return
 	}
@@ -141,7 +141,7 @@ func (h *ProwlarrHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	existing.ID = id
-	if err := httpsec.ValidateOutboundURL(existing.URL, httpsec.PolicyLAN); err != nil {
+	if err := httpsec.ValidateOutboundURL(existing.URL, httpsec.PolicyLANLoopback); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid indexer URL: " + err.Error()})
 		return
 	}

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -376,7 +376,7 @@ func validateSettingValue(key, value string) error {
 		// Block link-local and cloud-metadata so the Calibre plugin URL can't
 		// be used as an admin-only SSRF foot-gun (mirrors ABS / Grimmory /
 		// indexer / prowlarr / downloadclient validation).
-		if err := httpsec.ValidateOutboundURL(value, httpsec.PolicyLAN); err != nil {
+		if err := httpsec.ValidateOutboundURL(value, httpsec.PolicyLANLoopback); err != nil {
 			return fmt.Errorf("plugin_url %q: %w", value, err)
 		}
 	case SettingABSBaseURL:

--- a/internal/grimmory/client.go
+++ b/internal/grimmory/client.go
@@ -78,7 +78,7 @@ func ValidateBaseURLSecure(raw string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := httpsec.ValidateOutboundURL(u, httpsec.PolicyLAN); err != nil {
+	if err := httpsec.ValidateOutboundURL(u, httpsec.PolicyLANLoopback); err != nil {
 		return "", fmt.Errorf("base_url %q: %w", raw, err)
 	}
 	return u, nil

--- a/internal/httpsec/ssrf.go
+++ b/internal/httpsec/ssrf.go
@@ -24,6 +24,18 @@ const (
 	// RFC1918 addresses are allowed so homelabs can target LAN services
 	// (indexers, download clients, ntfy).
 	PolicyLAN
+
+	// PolicyLANLoopback is PolicyLAN plus loopback (127.0.0.0/8, ::1). It is the
+	// least restrictive policy and still blocks link-local and cloud metadata.
+	// Use it ONLY for admin-configured infrastructure URLs the operator types
+	// themselves (download clients, indexers, Prowlarr, the Calibre plugin / ABS
+	// base URLs). Reaching a co-located service over loopback is the normal case
+	// under `network_mode: host` or when the companion binds to 127.0.0.1, and
+	// these endpoints are admin-only + CSRF-gated, so the loopback block bought
+	// ~no security while breaking a legitimate topology. Never use this for URLs
+	// influenced by untrusted input (cover/image proxy, webhooks) — those keep
+	// PolicyStrict / PolicyLAN.
+	PolicyLANLoopback
 )
 
 // Resolver abstracts net.LookupIP so tests can inject a fake resolver without
@@ -137,9 +149,11 @@ func checkIP(ip net.IP, policy Policy) error {
 		ip = v4
 	}
 
-	// Always blocked: loopback (unless explicitly allowed for tests via
-	// AllowLoopbackForTests — never opt in from production code).
-	if ip.IsLoopback() && !testAllowLoopback {
+	// Loopback is blocked except under PolicyLANLoopback (admin-configured
+	// infrastructure URLs, where reaching a co-located service over 127.0.0.1 is
+	// the intended, normal case) or when explicitly allowed for tests via
+	// AllowLoopbackForTests (never opt in from production code).
+	if ip.IsLoopback() && policy != PolicyLANLoopback && !testAllowLoopback {
 		return errors.New("url not allowed: points to loopback address")
 	}
 

--- a/internal/httpsec/ssrf_test.go
+++ b/internal/httpsec/ssrf_test.go
@@ -71,6 +71,40 @@ func TestValidateOutboundURL_Loopback(t *testing.T) {
 		if err := validate(u, PolicyLAN, r); err == nil {
 			t.Errorf("expected block for loopback %q (LAN policy)", u)
 		}
+		// PolicyLANLoopback is the admin-infra policy and must ALLOW loopback.
+		if err := validate(u, PolicyLANLoopback, r); err != nil {
+			t.Errorf("LANLoopback: unexpected block for loopback %q: %v", u, err)
+		}
+	}
+}
+
+// TestValidateOutboundURL_LANLoopbackPolicy pins the admin-infra policy: it adds
+// loopback to PolicyLAN (loopback + RFC1918 allowed) but must still block
+// link-local and cloud metadata.
+func TestValidateOutboundURL_LANLoopbackPolicy(t *testing.T) {
+	r := fakeResolver{m: map[string][]net.IP{}}
+
+	allowed := []string{
+		"http://127.0.0.1:50155/api", // SAB on loopback (issue this fixes)
+		"http://[::1]:9117/",
+		"http://192.168.1.10:8080/", // RFC1918 still fine
+		"http://10.0.0.5/",
+	}
+	for _, u := range allowed {
+		if err := validate(u, PolicyLANLoopback, r); err != nil {
+			t.Errorf("LANLoopback: expected allow for %q, got: %v", u, err)
+		}
+	}
+
+	blocked := []string{
+		"http://169.254.0.1/",            // link-local
+		"http://[fe80::1]/",              // link-local v6
+		"http://169.254.169.254/latest/", // cloud metadata
+	}
+	for _, u := range blocked {
+		if err := validate(u, PolicyLANLoopback, r); err == nil {
+			t.Errorf("LANLoopback: expected block for %q", u)
+		}
 	}
 }
 

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -95,7 +95,7 @@ func sharedTransportInstance() *http.Transport {
 	sharedTransportOnce.Do(func() {
 		transportBuildCount.Add(1)
 		sharedTransport = &http.Transport{
-			DialContext:           httpsec.NewDialContext(httpsec.PolicyLAN),
+			DialContext:           httpsec.NewDialContext(httpsec.PolicyLANLoopback),
 			MaxIdleConns:          100,
 			MaxIdleConnsPerHost:   8,
 			IdleConnTimeout:       90 * time.Second,

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -948,12 +948,15 @@ func TestBookSearch_Tier1FallsBackOnCannedFeed(t *testing.T) {
 	}
 }
 
-// TestNew_HardenedDialerBlocksLoopback verifies that the http.Client returned
-// by New() uses the httpsec-hardened DialContext that blocks loopback addresses,
-// preventing DNS-rebinding attacks where a hostname resolves to 127.0.0.1 after
-// the initial ValidateOutboundURL check passes. This is the Finding 1 fix from
-// issue #711: re-validation happens per connection, not only at config time.
-func TestNew_HardenedDialerBlocksLoopback(t *testing.T) {
+// TestNew_HardenedDialerAllowsLoopback verifies that the http.Client returned by
+// New() uses the httpsec-hardened DialContext under PolicyLANLoopback, which
+// PERMITS loopback. Indexer URLs are admin-typed infrastructure, and running an
+// indexer (Jackett/Prowlarr) on 127.0.0.1 is normal under `network_mode: host`;
+// blocking it was a foot-gun with no real security benefit on an admin-only,
+// CSRF-gated path. The dialer still re-validates per connection (the #711
+// DNS-rebinding fix) and still blocks link-local / cloud-metadata — see the
+// httpsec ssrf tests.
+func TestNew_HardenedDialerAllowsLoopback(t *testing.T) {
 	// Start a local server — its address will be on 127.0.0.1 (loopback).
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -963,12 +966,11 @@ func TestNew_HardenedDialerBlocksLoopback(t *testing.T) {
 	// Use New() (hardened client), NOT testNew() — the dialer must be active.
 	c := New(srv.URL, "testkey")
 	_, err := c.Caps(context.Background())
-	if err == nil {
-		t.Fatal("expected connection to loopback to be rejected by the SSRF dialer, got nil error")
-		return
-	}
-	if !strings.Contains(err.Error(), "loopback") {
-		t.Errorf("expected 'loopback' in SSRF dial error, got: %v", err)
+	// The empty 200 body makes Caps fail to parse, but that proves the
+	// connection went THROUGH the dialer rather than being SSRF-blocked, which
+	// is what we assert: the error must not be a loopback/SSRF rejection.
+	if err != nil && (strings.Contains(err.Error(), "loopback") || strings.Contains(err.Error(), "url not allowed")) {
+		t.Errorf("loopback indexer should be reachable through the hardened dialer, got SSRF rejection: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Why

A user (Daize, via Discord) ran SABnzbd on `127.0.0.1:50155` under `network_mode: host`. Pointing Bindery's SAB URL at `http://127.0.0.1:50155` was rejected: **`url not allowed: points to loopback address`**. There was no production escape hatch — `internal/httpsec/ssrf.go` blocked loopback under every policy, and `PolicyFromEnv` only ever upgrades Strict→LAN (which also blocks loopback). So a companion bound to loopback, or host-networked containers, simply could not be reached. Loopback is a fundamental, correct way to reach a co-located service; steering users away from it is treating the symptom.

## What

New least-restrictive policy **`PolicyLANLoopback`** (LAN + loopback; still blocks link-local + cloud-metadata), applied to the **admin-typed service URLs** only:

- download-client base URLs (the `download_clients.go` Create/Update/Test/TestConfig handler validation)
- indexers, Prowlarr
- Audiobookshelf base URL (`abs` + `grimmory`)
- Calibre plugin URL
- the **newznab indexer dialer** (`NewDialContext`) so a loopback indexer actually connects, not just validates

These endpoints are admin-only and CSRF-gated, so the loopback block bought ~no security while breaking a legit topology.

## Trust boundary kept intact (deliberately NOT changed)

- **Proxied cover images** (`imageproxy`) and **Calibre cover fetch** stay `PolicyStrict` — URLs come from metadata/book data (untrusted).
- **Outbound webhooks** stay `PolicyStrict` (+`BINDERY_NOTIFICATIONS_ALLOW_PRIVATE`).
- **NZB/torrent download URLs returned by indexers** (sab/qbit/transmission/nzbget `AddURL`/`AddTorrent`) stay `PolicyLAN` — a malicious indexer must not be able to point Bindery at internal loopback services.
- **OIDC issuer** left at `PolicyLAN` (separate auth semantics).
- **Link-local + cloud-metadata** (e.g. `169.254.169.254`) remain blocked everywhere.

## Tests / docs

- `ssrf_test.go`: loopback allowed under `PolicyLANLoopback`; link-local + cloud-metadata still blocked; LAN/Strict still block loopback.
- newznab hardened-dialer test now asserts loopback is permitted (re-validation + link-local/metadata blocking unchanged).
- `go test ./...` green.
- DEPLOYMENT.md and QUICKSTART.md rewritten to drop the "avoid 127.0.0.1" guidance and document the trust split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)