### PR TITLE
feat(web): link book and author from Queue, Pending, and History rows

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -540,7 +540,7 @@ func main() {
 
 	libraryHandler := api.NewLibraryHandler(importScanner).WithSettings(settingsRepo)
 	fileHandler := api.NewFileHandler(bookRepo, cfg.LibraryDir, cfg.AudiobookDir)
-	historyHandler := api.NewHistoryHandler(historyRepo, blocklistRepo)
+	historyHandler := api.NewHistoryHandler(historyRepo, blocklistRepo, bookRepo)
 	blocklistHandler := api.NewBlocklistHandler(blocklistRepo)
 	notificationHandler := api.NewNotificationHandler(notificationRepo, notif)
 	qualityProfileHandler := api.NewQualityProfileHandler(qualityProfileRepo)

--- a/internal/api/bookref.go
+++ b/internal/api/bookref.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"context"
+
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// bookRef is the minimal book + author projection attached to queue, pending,
+// and history items so the web UI can render the book title and author name as
+// links to /book/:id and /author/:id. Kept deliberately small — the rows these
+// hang off are hot (the queue polls every 5s), and the frontend only needs the
+// ids and display names.
+type bookRef struct {
+	ID         int64  `json:"id"`
+	Title      string `json:"title"`
+	AuthorID   int64  `json:"authorId"`
+	AuthorName string `json:"authorName"`
+}
+
+// loadBookRefs dedupes and drops zero/negative ids, batch-loads the matching
+// books (each with its Author projection via BookRepo.GetByIDs), and returns a
+// lookup of book id -> bookRef. Books that no longer exist (deleted) are simply
+// absent from the map. Best-effort by contract: on a query error it returns an
+// empty map plus the error so callers can still render rows without links.
+func loadBookRefs(ctx context.Context, books *db.BookRepo, ids []int64) (map[int64]*bookRef, error) {
+	uniq := make([]int64, 0, len(ids))
+	seen := make(map[int64]struct{}, len(ids))
+	for _, id := range ids {
+		if id <= 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		uniq = append(uniq, id)
+	}
+	refs := make(map[int64]*bookRef, len(uniq))
+	if len(uniq) == 0 {
+		return refs, nil
+	}
+	loaded, err := books.GetByIDs(ctx, uniq)
+	if err != nil {
+		return refs, err
+	}
+	for id, b := range loaded {
+		ref := &bookRef{ID: b.ID, Title: b.Title, AuthorID: b.AuthorID}
+		if b.Author != nil {
+			ref.AuthorName = b.Author.Name
+		}
+		refs[id] = ref
+	}
+	return refs, nil
+}

--- a/internal/api/history.go
+++ b/internal/api/history.go
@@ -15,20 +15,29 @@ import (
 type HistoryHandler struct {
 	history   *db.HistoryRepo
 	blocklist *db.BlocklistRepo
+	books     *db.BookRepo
 }
 
-func NewHistoryHandler(history *db.HistoryRepo, blocklist *db.BlocklistRepo) *HistoryHandler {
-	return &HistoryHandler{history: history, blocklist: blocklist}
+func NewHistoryHandler(history *db.HistoryRepo, blocklist *db.BlocklistRepo, books *db.BookRepo) *HistoryHandler {
+	return &HistoryHandler{history: history, blocklist: blocklist, books: books}
+}
+
+// historyItem wraps a history event with a linkable book + author projection so
+// the UI can deep-link each row to /book/:id and /author/:id. The embedded
+// HistoryEvent keeps the row shape unchanged; `book` is added alongside.
+type historyItem struct {
+	models.HistoryEvent
+	Book *bookRef `json:"book,omitempty"`
 }
 
 // historyListResponse is the paginated wrapper returned by List. Replaces the
 // pre-Wave-2 bare `[]models.HistoryEvent` shape; clients must unwrap `items`
 // to reach the rows. See the Wave 2 / E PR for the breaking-change disclosure.
 type historyListResponse struct {
-	Items  []models.HistoryEvent `json:"items"`
-	Total  int                   `json:"total"`
-	Limit  int                   `json:"limit"`
-	Offset int                   `json:"offset"`
+	Items  []historyItem `json:"items"`
+	Total  int           `json:"total"`
+	Limit  int           `json:"limit"`
+	Offset int           `json:"offset"`
 }
 
 const (
@@ -67,11 +76,26 @@ func (h *HistoryHandler) List(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
-	if events == nil {
-		events = []models.HistoryEvent{}
+	items := make([]historyItem, len(events))
+	bookIDs := make([]int64, 0, len(events))
+	for i, e := range events {
+		items[i] = historyItem{HistoryEvent: e}
+		if e.BookID != nil {
+			bookIDs = append(bookIDs, *e.BookID)
+		}
+	}
+	// Best-effort enrichment: a book lookup failure still serves the page.
+	if refs, err := loadBookRefs(ctx, h.books, bookIDs); err != nil {
+		slog.Warn("history: failed to load book refs", "error", err)
+	} else {
+		for i := range items {
+			if items[i].BookID != nil {
+				items[i].Book = refs[*items[i].BookID]
+			}
+		}
 	}
 	writeJSON(w, http.StatusOK, historyListResponse{
-		Items:  events,
+		Items:  items,
 		Total:  total,
 		Limit:  limit,
 		Offset: offset,

--- a/internal/api/history_test.go
+++ b/internal/api/history_test.go
@@ -24,7 +24,8 @@ func historyFixture(t *testing.T) (*HistoryHandler, *db.HistoryRepo, *db.Blockli
 	t.Cleanup(func() { database.Close() })
 	history := db.NewHistoryRepo(database)
 	blocklist := db.NewBlocklistRepo(database)
-	return NewHistoryHandler(history, blocklist), history, blocklist, context.Background()
+	books := db.NewBookRepo(database)
+	return NewHistoryHandler(history, blocklist, books), history, blocklist, context.Background()
 }
 
 // TestHistoryList_EmptyReturnsArray verifies a fresh history table returns
@@ -290,7 +291,8 @@ func TestBlocklistHandler_HistoryBlocklistRecordsCaller(t *testing.T) {
 	}
 	history := db.NewHistoryRepo(database)
 	blocklist := db.NewBlocklistRepo(database)
-	h := NewHistoryHandler(history, blocklist)
+	books := db.NewBookRepo(database)
+	h := NewHistoryHandler(history, blocklist, books)
 
 	data, _ := json.Marshal(map[string]any{"guid": "nzb-guid-d4b"})
 	e := &models.HistoryEvent{
@@ -410,7 +412,39 @@ func seedTwoUserHistory(t *testing.T) (*HistoryHandler, *sql.DB, int64, int64, i
 	if err := hist.Create(ctx, eB); err != nil {
 		t.Fatal(err)
 	}
-	return NewHistoryHandler(hist, blk), database, uA.ID, uB.ID, eA.ID, eB.ID
+	return NewHistoryHandler(hist, blk, books), database, uA.ID, uB.ID, eA.ID, eB.ID
+}
+
+// TestHistoryList_EnrichesBookAndAuthor verifies the history list attaches a
+// linkable book + author projection to events tied to a book (gate off → all
+// events visible).
+func TestHistoryList_EnrichesBookAndAuthor(t *testing.T) {
+	h, _, _, _, eA, _ := seedTwoUserHistory(t)
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/history", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var got historyListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	var alice *historyItem
+	for i := range got.Items {
+		if got.Items[i].ID == eA {
+			alice = &got.Items[i]
+		}
+	}
+	if alice == nil {
+		t.Fatalf("alice's history event missing: %+v", got.Items)
+	}
+	if alice.Book == nil {
+		t.Fatal("expected history event to carry a book ref, got nil")
+	}
+	if alice.Book.Title != "Alice Book" || alice.Book.AuthorID == 0 || alice.Book.AuthorName != "Aa" {
+		t.Errorf("unexpected book ref: %+v", alice.Book)
+	}
 }
 
 func TestHistoryDelete_CrossUserBlockedWhenGateOn(t *testing.T) {

--- a/internal/api/pending.go
+++ b/internal/api/pending.go
@@ -3,12 +3,22 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
 )
+
+// pendingItem wraps a pending release with a linkable book + author projection
+// so the UI can deep-link each row to /book/:id and /author/:id. The embedded
+// PendingRelease keeps the response a flat array (backward compatible); `book`
+// is added alongside.
+type pendingItem struct {
+	models.PendingRelease
+	Book *bookRef `json:"book,omitempty"`
+}
 
 // PendingHandler serves the pending releases API.
 type PendingHandler struct {
@@ -33,10 +43,26 @@ func (h *PendingHandler) List(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
-	if items == nil {
-		items = []models.PendingRelease{}
+
+	out := make([]pendingItem, len(items))
+	bookIDs := make([]int64, 0, len(items))
+	for i, it := range items {
+		out[i] = pendingItem{PendingRelease: it}
+		if it.BookID != 0 {
+			bookIDs = append(bookIDs, it.BookID)
+		}
 	}
-	writeJSON(w, http.StatusOK, items)
+	// Best-effort enrichment: a book lookup failure still serves the list.
+	if refs, err := loadBookRefs(r.Context(), h.books, bookIDs); err != nil {
+		slog.Warn("pending: failed to load book refs", "error", err)
+	} else {
+		for i := range out {
+			if out[i].BookID != 0 {
+				out[i].Book = refs[out[i].BookID]
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, out)
 }
 
 func (h *PendingHandler) listForCaller(r *http.Request) ([]models.PendingRelease, error) {

--- a/internal/api/pending_test.go
+++ b/internal/api/pending_test.go
@@ -132,6 +132,37 @@ func TestPendingList_FiltersToCallerWhenGateOn(t *testing.T) {
 	}
 }
 
+// TestPendingList_EnrichesBookAndAuthor verifies the pending list attaches a
+// linkable book + author projection to each release (gate off → all releases).
+func TestPendingList_EnrichesBookAndAuthor(t *testing.T) {
+	h, _, _, _, idA, _ := seedTwoUserPending(t)
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/pending", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var got []pendingItem
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	var alice *pendingItem
+	for i := range got {
+		if got[i].ID == idA {
+			alice = &got[i]
+		}
+	}
+	if alice == nil {
+		t.Fatalf("alice's pending release missing: %+v", got)
+	}
+	if alice.Book == nil {
+		t.Fatal("expected pending release to carry a book ref, got nil")
+	}
+	if alice.Book.Title != "Alice Book" || alice.Book.AuthorID == 0 || alice.Book.AuthorName != "Aa" {
+		t.Errorf("unexpected book ref: %+v", alice.Book)
+	}
+}
+
 func TestPendingDelete_GateOffPreservesLegacyBehavior(t *testing.T) {
 	h, _, _, uBob, idA, _ := seedTwoUserPending(t)
 

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -68,9 +68,10 @@ func (h *QueueHandler) WithStoragePaths(downloadDir, audiobookDownloadDir string
 // QueueItem combines local download record with live downloader status.
 type QueueItem struct {
 	models.Download
-	Percentage string `json:"percentage,omitempty"`
-	TimeLeft   string `json:"timeLeft,omitempty"`
-	Speed      string `json:"speed,omitempty"`
+	Percentage string   `json:"percentage,omitempty"`
+	TimeLeft   string   `json:"timeLeft,omitempty"`
+	Speed      string   `json:"speed,omitempty"`
+	Book       *bookRef `json:"book,omitempty"`
 }
 
 type enrichedQueueItem struct {
@@ -277,12 +278,29 @@ func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	items := make([]QueueItem, len(enriched))
+	bookIDs := make([]int64, 0, len(enriched))
 	for i, item := range enriched {
 		items[i] = QueueItem{Download: item.Download}
 		if item.HasLive {
 			items[i].Percentage = item.Live.Percentage
 			items[i].TimeLeft = item.Live.TimeLeft
 			items[i].Speed = item.Live.Speed
+		}
+		if item.Download.BookID != nil {
+			bookIDs = append(bookIDs, *item.Download.BookID)
+		}
+	}
+
+	// Attach a linkable book + author projection so the UI can deep-link each
+	// row to /book/:id and /author/:id. Best-effort: this endpoint is hot
+	// (polled every 5s) and a book lookup failure must not blank the queue.
+	if refs, err := loadBookRefs(r.Context(), h.books, bookIDs); err != nil {
+		slog.Warn("queue: failed to load book refs", "error", err)
+	} else {
+		for i := range items {
+			if items[i].BookID != nil {
+				items[i].Book = refs[*items[i].BookID]
+			}
 		}
 	}
 

--- a/internal/api/queue_test.go
+++ b/internal/api/queue_test.go
@@ -463,6 +463,75 @@ func TestQueueDelete_FlipsBookToWanted(t *testing.T) {
 	}
 }
 
+// TestQueueList_EnrichesBookAndAuthor verifies the queue list attaches a
+// linkable book + author projection to downloads tied to a book, and leaves
+// manual (book-less) downloads without one.
+func TestQueueList_EnrichesBookAndAuthor(t *testing.T) {
+	h, database, downloads, _, books, ctx := queueFixture(t)
+	a := &models.Author{
+		ForeignID: "OL-LEGUIN", Name: "Ursula K. Le Guin", SortName: "Le Guin, Ursula",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := db.NewAuthorRepo(database).Create(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	b := &models.Book{
+		ForeignID: "OL-EARTHSEA", AuthorID: a.ID, Title: "A Wizard of Earthsea", SortTitle: "wizard of earthsea",
+		Status: models.BookStatusDownloading, Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+	if err := downloads.Create(ctx, &models.Download{
+		GUID: "g-linked", BookID: &b.ID, Title: "Ursula K. Le Guin - A Wizard of Earthsea [EPUB]",
+		Status: models.DownloadStatusDownloading, Protocol: "usenet",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := downloads.Create(ctx, &models.Download{
+		GUID: "g-unlinked", Title: "Some Manual Release",
+		Status: models.DownloadStatusDownloading, Protocol: "usenet",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/queue", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp queueListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, rec.Body.String())
+	}
+	byGUID := map[string]QueueItem{}
+	for _, it := range resp.Items {
+		byGUID[it.GUID] = it
+	}
+
+	linked, ok := byGUID["g-linked"]
+	if !ok {
+		t.Fatalf("linked download missing from queue: %+v", resp.Items)
+	}
+	if linked.Book == nil {
+		t.Fatal("expected linked download to carry a book ref, got nil")
+	}
+	if linked.Book.ID != b.ID || linked.Book.Title != "A Wizard of Earthsea" {
+		t.Errorf("unexpected book ref: %+v", linked.Book)
+	}
+	if linked.Book.AuthorID != a.ID || linked.Book.AuthorName != "Ursula K. Le Guin" {
+		t.Errorf("unexpected author on book ref: %+v", linked.Book)
+	}
+
+	unlinked, ok := byGUID["g-unlinked"]
+	if !ok {
+		t.Fatal("unlinked download missing from queue")
+	}
+	if unlinked.Book != nil {
+		t.Errorf("expected no book ref on manual download, got %+v", unlinked.Book)
+	}
+}
+
 // queueDeleteFilesProbe spins up a qBittorrent stub and runs Queue.Delete for
 // a torrent download, returning the deleteFiles form value the client sent.
 func queueDeleteFilesProbe(t *testing.T, urlSuffix string) string {

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -257,6 +258,34 @@ func (r *BookRepo) GetByID(ctx context.Context, id int64) (*models.Book, error) 
 		return nil, nil
 	}
 	return &books[0], nil
+}
+
+// GetByIDs loads multiple books in a single query, each with its minimal
+// Author projection populated the same way GetByID does (id, foreignId, name,
+// sortName — see the scan loop). Returns a map keyed by book id; ids with no
+// matching row are simply absent and order is not significant. Used to enrich
+// queue/pending/history items with linkable book + author info without an
+// N+1 of GetByID.
+func (r *BookRepo) GetByIDs(ctx context.Context, ids []int64) (map[int64]*models.Book, error) {
+	if len(ids) == 0 {
+		return map[int64]*models.Book{}, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	books, err := r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+
+		" WHERE books.id IN ("+strings.Join(placeholders, ",")+")", args)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[int64]*models.Book, len(books))
+	for i := range books {
+		out[books[i].ID] = &books[i]
+	}
+	return out, nil
 }
 
 func (r *BookRepo) GetByForeignID(ctx context.Context, foreignID string) (*models.Book, error) {

--- a/internal/db/books_getbyids_test.go
+++ b/internal/db/books_getbyids_test.go
@@ -1,0 +1,79 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestBookRepo_GetByIDs verifies the batch loader returns each requested book
+// keyed by id with its Author projection populated (the same LEFT JOIN GetByID
+// uses), tolerates duplicate and missing ids, and short-circuits empty input.
+func TestBookRepo_GetByIDs(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+
+	authors := NewAuthorRepo(database)
+	books := NewBookRepo(database)
+
+	a := &models.Author{
+		ForeignID: "OL-LEGUIN", Name: "Ursula K. Le Guin", SortName: "Le Guin, Ursula",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authors.Create(ctx, a); err != nil {
+		t.Fatalf("create author: %v", err)
+	}
+	b1 := &models.Book{
+		ForeignID: "OL-EARTHSEA", AuthorID: a.ID, Title: "A Wizard of Earthsea",
+		SortTitle: "wizard of earthsea", Genres: []string{},
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, b1); err != nil {
+		t.Fatalf("create b1: %v", err)
+	}
+	b2 := &models.Book{
+		ForeignID: "OL-DISPOSSESSED", AuthorID: a.ID, Title: "The Dispossessed",
+		SortTitle: "dispossessed", Genres: []string{},
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, b2); err != nil {
+		t.Fatalf("create b2: %v", err)
+	}
+
+	// Duplicate id and a non-existent id are both tolerated: two real books
+	// back, the missing id simply absent.
+	got, err := books.GetByIDs(ctx, []int64{b1.ID, b2.ID, b1.ID, 999999})
+	if err != nil {
+		t.Fatalf("GetByIDs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 books, got %d", len(got))
+	}
+	if got[b1.ID] == nil || got[b1.ID].Title != "A Wizard of Earthsea" {
+		t.Errorf("b1 missing or wrong: %+v", got[b1.ID])
+	}
+	if got[b2.ID] == nil || got[b2.ID].Title != "The Dispossessed" {
+		t.Errorf("b2 missing or wrong: %+v", got[b2.ID])
+	}
+	// Author projection populated via the LEFT JOIN.
+	if got[b1.ID].Author == nil || got[b1.ID].Author.ID != a.ID || got[b1.ID].Author.Name != "Ursula K. Le Guin" {
+		t.Errorf("expected author populated on b1, got %+v", got[b1.ID].Author)
+	}
+	if _, ok := got[999999]; ok {
+		t.Error("did not expect a row for the missing id")
+	}
+
+	// Empty input → empty map, no query, no error.
+	empty, err := books.GetByIDs(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetByIDs(nil): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("expected empty map for nil ids, got %d", len(empty))
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1049,6 +1049,17 @@ export interface IndexerTestResult {
   error?: string
 }
 
+// BookRef is the minimal book + author projection the backend attaches to
+// queue, pending, and history items so the UI can link the book title and
+// author name to /book/:id and /author/:id. Absent when the row has no
+// associated book (manual downloads, orphan history events).
+export interface BookRef {
+  id: number
+  title: string
+  authorId: number
+  authorName: string
+}
+
 export interface PendingRelease {
   id: number
   bookId: number
@@ -1063,6 +1074,7 @@ export interface PendingRelease {
   reason: string
   firstSeen: string
   releaseJson: string
+  book?: BookRef
 }
 
 export interface ProwlarrInstance {
@@ -1113,6 +1125,7 @@ export interface Download {
   grabbedAt?: string
   completedAt?: string
   importedAt?: string
+  book?: BookRef
 }
 
 export interface QueueItem extends Download {
@@ -1247,6 +1260,7 @@ export interface HistoryEvent {
   sourceTitle: string
   data: string
   createdAt: string
+  book?: BookRef
 }
 
 export interface BlocklistEntry {

--- a/web/src/components/BookAuthorLink.tsx
+++ b/web/src/components/BookAuthorLink.tsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom'
+import { BookRef } from '../api/client'
+
+// BookAuthorLink renders a compact secondary line — linked book title · linked
+// author name — for rows that reference a book (queue, pending, history). It
+// returns null when the row has no associated book, so callers can drop it in
+// unconditionally. The router basename already prefixes the configured subpath
+// (BINDERY_URL_BASE), so the to= paths stay root-relative.
+export default function BookAuthorLink({ book, className }: { book?: BookRef; className?: string }) {
+  if (!book) return null
+  return (
+    <p className={`text-xs text-slate-600 dark:text-zinc-400 truncate ${className ?? ''}`}>
+      <Link
+        to={`/book/${book.id}`}
+        className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+      >
+        {book.title}
+      </Link>
+      {book.authorId > 0 && book.authorName && (
+        <>
+          {' · '}
+          <Link
+            to={`/author/${book.authorId}`}
+            className="hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+          >
+            {book.authorName}
+          </Link>
+        </>
+      )}
+    </p>
+  )
+}

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, HistoryEvent } from '../api/client'
+import BookAuthorLink from '../components/BookAuthorLink'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
 
@@ -146,6 +147,7 @@ export default function HistoryPage() {
                           <div className="truncate" title={event.sourceTitle}>
                             {event.sourceTitle || <span className="text-slate-500 dark:text-zinc-600">—</span>}
                           </div>
+                          <BookAuthorLink book={event.book} />
                           {detail && (
                             <div className={`mt-1 text-xs break-words ${isError ? 'text-red-400' : 'text-slate-600 dark:text-zinc-500'}`}>
                               {detail}
@@ -222,6 +224,7 @@ export default function HistoryPage() {
                   <p className="text-sm text-slate-800 dark:text-zinc-200 break-words mb-1">
                     {event.sourceTitle || <span className="text-slate-500 dark:text-zinc-600">—</span>}
                   </p>
+                  <BookAuthorLink book={event.book} />
                   {detail && (
                     <p className={`text-xs break-words mb-2 ${isError ? 'text-red-400' : 'text-slate-600 dark:text-zinc-500'}`}>
                       {detail}

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, PendingRelease, QueueItem } from '../api/client'
+import BookAuthorLink from '../components/BookAuthorLink'
 
 export default function QueuePage() {
   const { t } = useTranslation()
@@ -187,6 +188,7 @@ export default function QueuePage() {
                 <div key={item.id} className="flex items-center justify-between p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
                   <div className="min-w-0 flex-1">
                     <h3 className="font-medium text-sm truncate">{item.title}</h3>
+                    <BookAuthorLink book={item.book} />
                     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-xs">
                       <span className={statusColors[item.status] || 'text-slate-600 dark:text-zinc-400'}>
                         {statusLabels[item.status] ?? item.status}
@@ -280,6 +282,7 @@ export default function QueuePage() {
                   <div key={item.id} className="flex items-center justify-between p-4 border border-amber-200 dark:border-amber-900/40 rounded-lg bg-amber-50 dark:bg-amber-950/20">
                     <div className="min-w-0 flex-1">
                       <h3 className="font-medium text-sm truncate">{item.title}</h3>
+                      <BookAuthorLink book={item.book} />
                       <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1 text-xs">
                         <span className="text-amber-600 dark:text-amber-400">{item.reason}</span>
                         {item.size > 0 && (


### PR DESCRIPTION
## Summary
Each **Queue**, **Pending Releases**, and **History** row now renders a secondary line beneath the release title — linked **book title** · linked **author name** — that deep-links to `/book/:id` and `/author/:id`. Rows without an associated book (manual downloads, orphan history events) render unchanged.

The release title is just a download-name string and the author/author-id weren't present in these API responses, so this adds a small backend enrichment rather than a pure frontend change.

## Changes
**Backend**
- `db`: `BookRepo.GetByIDs` batch-loads books (each with its `Author` projection) in one query — no N+1.
- `api`: shared `bookRef` projection + `loadBookRefs` helper; the queue, pending, and history `List` handlers attach a `book` object best-effort (a lookup failure logs and still serves the rows — the queue endpoint is polled every 5s). `HistoryHandler` gains a `books` dependency, wired through `main.go`.
- The pending response stays a flat array and the history `items` shape is unchanged apart from the additive `book` field — backward compatible.

**Frontend**
- `BookRef` type + optional `book` on `Download` / `PendingRelease` / `HistoryEvent`.
- Reusable `BookAuthorLink` component (renders nothing when there's no book), dropped into the Queue page (queue + pending rows) and the History page (desktop table + mobile card). Uses react-router `<Link>`, so the router basename handles `BINDERY_URL_BASE` subpath deploys.

## Tests
- `BookRepo.GetByIDs` (duplicate / missing ids, author projection, empty input).
- `book` enrichment assertions added to the queue, pending, and history handler tests.

Closes #988