### PR TITLE
fix(api): enforce per-user ownership on bulk endpoints (#947)

### DIFF
--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -6,9 +6,23 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/concurrency"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
+)
+
+// errBulkNotOwned is the sentinel returned by the per-ID bulk helpers when the
+// caller does not own the targeted resource under BINDERY_ENFORCE_TENANCY. It
+// is surfaced in the per-ID result map with the same opaque "not found" message
+// the single-resource handlers use (404 on mismatch), so a non-owner cannot
+// distinguish "exists but yours" from "does not exist" and cannot probe for the
+// existence of another user's authors/books (#947). When tenancy is off
+// auth.CheckOwnership is a no-op, so this is never returned and behaviour is
+// unchanged.
+var (
+	errBulkAuthorNotOwned = fmt.Errorf("author not found")
+	errBulkBookNotOwned   = fmt.Errorf("book not found")
 )
 
 // bulkSearchConcurrency caps how many indexer searches a single bulk
@@ -173,13 +187,34 @@ func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 		case "delete":
+			// Ownership-gate the delete: load the author first so we can verify
+			// the caller owns it before mutating (the repo deletes purely by id).
+			author, err := h.authors.GetByID(r.Context(), id)
+			if err != nil {
+				resp.Results[key] = bulkItemResult{Error: err.Error()}
+				continue
+			}
+			if author == nil || !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
+				resp.Results[key] = bulkItemResult{Error: errBulkAuthorNotOwned.Error()}
+				continue
+			}
 			if err := h.authors.Delete(r.Context(), id); err != nil {
 				resp.Results[key] = bulkItemResult{Error: err.Error()}
 				continue
 			}
 		case "search":
-			// Fetch wanted books while the request context is still alive,
-			// then collect them for the bounded post-response fan-out.
+			// Verify ownership before fanning out searches for another user's
+			// catalogue. Load the author to read OwnerUserID, then collect its
+			// wanted books while the request context is still alive.
+			author, err := h.authors.GetByID(r.Context(), id)
+			if err != nil {
+				resp.Results[key] = bulkItemResult{Error: err.Error()}
+				continue
+			}
+			if author == nil || !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
+				resp.Results[key] = bulkItemResult{Error: errBulkAuthorNotOwned.Error()}
+				continue
+			}
 			books, err := h.books.ListByAuthor(r.Context(), id)
 			if err != nil {
 				resp.Results[key] = bulkItemResult{Error: err.Error()}
@@ -200,8 +235,8 @@ func (h *BulkHandler) AuthorsBulk(w http.ResponseWriter, r *http.Request) {
 				resp.Results[key] = bulkItemResult{Error: err.Error()}
 				continue
 			}
-			if author == nil {
-				resp.Results[key] = bulkItemResult{Error: "author not found"}
+			if author == nil || !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
+				resp.Results[key] = bulkItemResult{Error: errBulkAuthorNotOwned.Error()}
 				continue
 			}
 			refreshTargets = append(refreshTargets, author)
@@ -308,8 +343,8 @@ func (h *BulkHandler) BooksBulk(w http.ResponseWriter, r *http.Request) {
 			opErr = h.books.Delete(r.Context(), id)
 		case "search":
 			book, err := h.books.GetByID(r.Context(), id)
-			if err != nil || book == nil {
-				resp.Results[key] = bulkItemResult{Error: "book not found"}
+			if err != nil || book == nil || !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
+				resp.Results[key] = bulkItemResult{Error: errBulkBookNotOwned.Error()}
 				continue
 			}
 			if h.searcher != nil {
@@ -370,8 +405,8 @@ func (h *BulkHandler) WantedBulk(w http.ResponseWriter, r *http.Request) {
 		switch req.Action {
 		case "search":
 			book, err := h.books.GetByID(r.Context(), id)
-			if err != nil || book == nil {
-				resp.Results[key] = bulkItemResult{Error: "book not found"}
+			if err != nil || book == nil || !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
+				resp.Results[key] = bulkItemResult{Error: errBulkBookNotOwned.Error()}
 				continue
 			}
 			if h.searcher != nil {
@@ -403,8 +438,8 @@ func (h *BulkHandler) setAuthorMonitored(ctx context.Context, id int64, monitore
 	if err != nil {
 		return err
 	}
-	if author == nil {
-		return fmt.Errorf("author not found")
+	if author == nil || !auth.CheckOwnership(ctx, author.OwnerUserID) {
+		return errBulkAuthorNotOwned
 	}
 	author.Monitored = monitored
 	return h.authors.Update(ctx, author)
@@ -415,8 +450,8 @@ func (h *BulkHandler) setBookMonitored(ctx context.Context, id int64, monitored 
 	if err != nil {
 		return err
 	}
-	if book == nil {
-		return fmt.Errorf("book not found")
+	if book == nil || !auth.CheckOwnership(ctx, book.OwnerUserID) {
+		return errBulkBookNotOwned
 	}
 	book.Monitored = monitored
 	return h.books.Update(ctx, book)
@@ -431,8 +466,8 @@ func (h *BulkHandler) setBookExcluded(ctx context.Context, id int64, excluded bo
 	if err != nil {
 		return err
 	}
-	if book == nil {
-		return fmt.Errorf("book not found")
+	if book == nil || !auth.CheckOwnership(ctx, book.OwnerUserID) {
+		return errBulkBookNotOwned
 	}
 	return h.books.SetExcluded(ctx, id, excluded)
 }
@@ -442,8 +477,8 @@ func (h *BulkHandler) setBookMediaType(ctx context.Context, id int64, mediaType 
 	if err != nil {
 		return err
 	}
-	if book == nil {
-		return fmt.Errorf("book not found")
+	if book == nil || !auth.CheckOwnership(ctx, book.OwnerUserID) {
+		return errBulkBookNotOwned
 	}
 	book.MediaType = mediaType
 	reevaluateBookStatus(book)
@@ -484,8 +519,8 @@ func (h *BulkHandler) setAuthorBooksMediaType(ctx context.Context, authorID int6
 	if err != nil {
 		return err
 	}
-	if author == nil {
-		return fmt.Errorf("author not found")
+	if author == nil || !auth.CheckOwnership(ctx, author.OwnerUserID) {
+		return errBulkAuthorNotOwned
 	}
 	books, err := h.books.ListByAuthor(ctx, authorID)
 	if err != nil {
@@ -513,8 +548,8 @@ func (h *BulkHandler) skipBook(ctx context.Context, id int64) error {
 	if err != nil {
 		return err
 	}
-	if book == nil {
-		return fmt.Errorf("book not found")
+	if book == nil || !auth.CheckOwnership(ctx, book.OwnerUserID) {
+		return errBulkBookNotOwned
 	}
 	book.Monitored = false
 	book.Status = models.BookStatusSkipped

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -1000,5 +1002,288 @@ func TestBulkHandler_GoroutineCancelsOnLifetimeCtxCancel(t *testing.T) {
 		// good
 	case <-time.After(2 * time.Second):
 		t.Fatal("spawned goroutine did not observe lifetime ctx cancellation")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-user ownership / IDOR regression suite (#947)
+//
+// Bulk endpoints are registered at the authenticated user level (not admin),
+// so a non-admin can legitimately bulk-act on their OWN resources. The bug:
+// the handlers mutated purely by id, so under BINDERY_ENFORCE_TENANCY a
+// non-admin could pass another user's ids and delete/unmonitor/exclude/skip
+// them. These tests assert the durable invariant (the victim row is untouched)
+// rather than just the per-id error string. Mirrors the gate/admin/gate-off
+// matrix in authorization_test.go.
+// ---------------------------------------------------------------------------
+
+type bulkAuthzFixture struct {
+	database *sql.DB
+	h        *BulkHandler
+	authors  *db.AuthorRepo
+	books    *db.BookRepo
+	u1, u2   int64
+	// Alice's (u1) resources.
+	a1 *models.Author
+	b1 *models.Book
+	// Bob's (u2) resources.
+	a2 *models.Author
+	b2 *models.Book
+}
+
+// seedTwoUserBulk builds two users, each owning one author and one book. Book
+// ownership is stamped by hand because BookRepo.Create does not yet write
+// owner_user_id (same approach authorization_test.go's setOwner uses).
+func seedTwoUserBulk(t *testing.T) bulkAuthzFixture {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	users := db.NewUserRepo(database)
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	blocklist := db.NewBlocklistRepo(database)
+
+	ctx := context.Background()
+	u1, err := users.Create(ctx, "alice", "hash1")
+	if err != nil {
+		t.Fatalf("create alice: %v", err)
+	}
+	u2, err := users.Create(ctx, "bob", "hash2")
+	if err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+
+	a1 := &models.Author{ForeignID: "OL-BA1", Name: "Alice Author", SortName: "Author, Alice", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authors.CreateForUser(ctx, a1, u1.ID); err != nil {
+		t.Fatalf("create alice author: %v", err)
+	}
+	a2 := &models.Author{ForeignID: "OL-BA2", Name: "Bob Author", SortName: "Author, Bob", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authors.CreateForUser(ctx, a2, u2.ID); err != nil {
+		t.Fatalf("create bob author: %v", err)
+	}
+
+	b1 := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "OL-BB1", AuthorID: a1.ID, Title: "Alice Book", SortTitle: "alice book",
+		Status: models.BookStatusWanted, MediaType: models.MediaTypeEbook,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+	b2 := mustCreateBook(t, books, ctx, &models.Book{
+		ForeignID: "OL-BB2", AuthorID: a2.ID, Title: "Bob Book", SortTitle: "bob book",
+		Status: models.BookStatusWanted, MediaType: models.MediaTypeEbook,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	})
+	setOwner(t, database, "books", b1.ID, u1.ID)
+	setOwner(t, database, "books", b2.ID, u2.ID)
+
+	// Re-read so the owner column lands on the structs the handler reads.
+	a1, _ = authors.GetByID(ctx, a1.ID)
+	a2, _ = authors.GetByID(ctx, a2.ID)
+	b1, _ = books.GetByID(ctx, b1.ID)
+	b2, _ = books.GetByID(ctx, b2.ID)
+
+	h := NewBulkHandler(authors, books, blocklist, nil).WithRefreshFunc(func(*models.Author) {})
+
+	return bulkAuthzFixture{
+		database: database, h: h, authors: authors, books: books,
+		u1: u1.ID, u2: u2.ID, a1: a1, b1: b1, a2: a2, b2: b2,
+	}
+}
+
+// postBulkAs posts a bulk request whose context carries the given identity.
+func postBulkAs(t *testing.T, handler http.HandlerFunc, body string, userID int64, role string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(body))
+	req = req.WithContext(withAuthCtx(req.Context(), userID, role))
+	handler(rec, req)
+	return rec
+}
+
+// resultOK reports the ok flag for a single id in a bulk response.
+func resultOK(t *testing.T, rec *httptest.ResponseRecorder, id int64) bool {
+	t.Helper()
+	var resp bulkResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode bulk response: %v (body=%s)", err, rec.Body.String())
+	}
+	return resp.Results[fmt.Sprintf("%d", id)].OK
+}
+
+// TestBulk_Author_OwnershipMatrix exercises AuthorsBulk delete across the
+// gate-on/non-owner, gate-on/owner, gate-on/admin, and gate-off axes. The
+// durable invariant is whether the targeted author still exists afterwards.
+func TestBulk_Author_OwnershipMatrix(t *testing.T) {
+	cases := []struct {
+		name        string
+		gateOn      bool
+		callerIsBob bool // false => Alice (the owner)
+		admin       bool
+		wantDeleted bool // did the victim author get deleted?
+		wantOK      bool // per-id ok flag
+	}{
+		{"gate on, cross-user blocked", true, true, false, false, false},
+		{"gate on, owner allowed", true, false, false, true, true},
+		{"gate on, admin allowed", true, true, true, true, true},
+		{"gate off, cross-user allowed", false, true, false, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth.SetEnforceTenancyForTests(t, tc.gateOn)
+			f := seedTwoUserBulk(t)
+
+			caller := f.u1
+			role := "user"
+			if tc.callerIsBob {
+				caller = f.u2
+			}
+			if tc.admin {
+				caller = 99
+				role = "admin"
+			}
+
+			// Always target Alice's author (a1).
+			body := fmt.Sprintf(`{"ids":[%d],"action":"delete"}`, f.a1.ID)
+			rec := postBulkAs(t, f.h.AuthorsBulk, body, caller, role)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if got := resultOK(t, rec, f.a1.ID); got != tc.wantOK {
+				t.Errorf("per-id ok=%v, want %v", got, tc.wantOK)
+			}
+			got, _ := f.authors.GetByID(context.Background(), f.a1.ID)
+			deleted := got == nil
+			if deleted != tc.wantDeleted {
+				t.Errorf("author deleted=%v, want %v (durable invariant)", deleted, tc.wantDeleted)
+			}
+		})
+	}
+}
+
+// TestBulk_Book_OwnershipMatrix exercises BooksBulk unmonitor across the same
+// axes. The durable invariant is whether Alice's book stays monitored.
+func TestBulk_Book_OwnershipMatrix(t *testing.T) {
+	cases := []struct {
+		name          string
+		gateOn        bool
+		callerIsBob   bool
+		admin         bool
+		wantUnmonitor bool
+		wantOK        bool
+	}{
+		{"gate on, cross-user blocked", true, true, false, false, false},
+		{"gate on, owner allowed", true, false, false, true, true},
+		{"gate on, admin allowed", true, true, true, true, true},
+		{"gate off, cross-user allowed", false, true, false, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth.SetEnforceTenancyForTests(t, tc.gateOn)
+			f := seedTwoUserBulk(t)
+
+			caller := f.u1
+			role := "user"
+			if tc.callerIsBob {
+				caller = f.u2
+			}
+			if tc.admin {
+				caller = 99
+				role = "admin"
+			}
+
+			body := fmt.Sprintf(`{"ids":[%d],"action":"unmonitor"}`, f.b1.ID)
+			rec := postBulkAs(t, f.h.BooksBulk, body, caller, role)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if got := resultOK(t, rec, f.b1.ID); got != tc.wantOK {
+				t.Errorf("per-id ok=%v, want %v", got, tc.wantOK)
+			}
+			got, _ := f.books.GetByID(context.Background(), f.b1.ID)
+			unmonitored := !got.Monitored
+			if unmonitored != tc.wantUnmonitor {
+				t.Errorf("book unmonitored=%v, want %v (durable invariant)", unmonitored, tc.wantUnmonitor)
+			}
+		})
+	}
+}
+
+// TestBulk_Wanted_OwnershipMatrix exercises WantedBulk blocklist across the
+// same axes. The durable invariant is whether Alice's book got skipped.
+func TestBulk_Wanted_OwnershipMatrix(t *testing.T) {
+	cases := []struct {
+		name        string
+		gateOn      bool
+		callerIsBob bool
+		admin       bool
+		wantSkipped bool
+		wantOK      bool
+	}{
+		{"gate on, cross-user blocked", true, true, false, false, false},
+		{"gate on, owner allowed", true, false, false, true, true},
+		{"gate on, admin allowed", true, true, true, true, true},
+		{"gate off, cross-user allowed", false, true, false, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth.SetEnforceTenancyForTests(t, tc.gateOn)
+			f := seedTwoUserBulk(t)
+
+			caller := f.u1
+			role := "user"
+			if tc.callerIsBob {
+				caller = f.u2
+			}
+			if tc.admin {
+				caller = 99
+				role = "admin"
+			}
+
+			body := fmt.Sprintf(`{"ids":[%d],"action":"blocklist"}`, f.b1.ID)
+			rec := postBulkAs(t, f.h.WantedBulk, body, caller, role)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if got := resultOK(t, rec, f.b1.ID); got != tc.wantOK {
+				t.Errorf("per-id ok=%v, want %v", got, tc.wantOK)
+			}
+			got, _ := f.books.GetByID(context.Background(), f.b1.ID)
+			skipped := got.Status == models.BookStatusSkipped
+			if skipped != tc.wantSkipped {
+				t.Errorf("book skipped=%v, want %v (durable invariant)", skipped, tc.wantSkipped)
+			}
+		})
+	}
+}
+
+// TestBulk_MixedOwnership_PartialEnforcement proves a single bulk call mixing
+// the caller's own id with a victim's id mutates only the owned row: Alice
+// bulk-deletes [a1 (hers), a2 (Bob's)] under the gate; a1 must be deleted, a2
+// must survive, and a2's per-id result must be an error.
+func TestBulk_MixedOwnership_PartialEnforcement(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := seedTwoUserBulk(t)
+
+	body := fmt.Sprintf(`{"ids":[%d,%d],"action":"delete"}`, f.a1.ID, f.a2.ID)
+	rec := postBulkAs(t, f.h.AuthorsBulk, body, f.u1, "user")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if ok := resultOK(t, rec, f.a1.ID); !ok {
+		t.Error("Alice's own author should be deleted (ok:true)")
+	}
+	if ok := resultOK(t, rec, f.a2.ID); ok {
+		t.Error("Bob's author must be rejected (ok:false) for Alice")
+	}
+
+	ctx := context.Background()
+	if got, _ := f.authors.GetByID(ctx, f.a1.ID); got != nil {
+		t.Error("Alice's author should be gone")
+	}
+	if got, _ := f.authors.GetByID(ctx, f.a2.ID); got == nil {
+		t.Error("Bob's author must be untouched (durable invariant)")
 	}
 }


### PR DESCRIPTION
## The IDOR

The bulk endpoints `POST /author/bulk`, `/book/bulk`, `/wanted/bulk` are registered at the authenticated **user** level (correct — bulk-acting on one's own resources is a legitimate user action), but the handlers in `internal/api/bulk.go` mutated resources **purely by id** (`WHERE id=?`). The single-resource handlers in `books.go` (8 call sites) and `authors.go` (6) all gate mutations with `auth.CheckOwnership`; the bulk handlers had **zero**.

Under `BINDERY_ENFORCE_TENANCY=true` a non-admin could therefore pass another user's ids to a bulk request and delete / unmonitor / exclude / skip / retarget / fire searches against resources they don't own.

## The fix

Apply the existing ownership model per id. Every bulk helper and inline path already loads the full object (which carries `OwnerUserID`), so the check reuses that load — **no redundant queries added**.

- When tenancy is enforced and the caller is not admin, ids the caller does not own are rejected in the per-id result map with the same opaque `"... not found"` message the single-resource path returns (404 semantics — a non-owner cannot distinguish "yours" from "doesn't exist", preventing existence probing).
- Admins keep full access.
- When tenancy is **off**, `auth.CheckOwnership` is a no-op, so the default single-user path is byte-for-byte unchanged.

Covers all actions across the three handlers: author monitor/unmonitor/delete/search/refresh/set_media_type, book monitor/unmonitor/delete/search/set_media_type/exclude, wanted search/unmonitor/blocklist.

## Test coverage

Table-driven ownership matrix for all three bulk handlers, each over four axes:
- gate on + cross-user → rejected, **row untouched**
- gate on + owner → succeeds
- gate on + admin → succeeds (any owner)
- gate off → cross-user succeeds (default behaviour preserved)

Assertions check the **durable invariant** (the victim author/book row is actually untouched in the DB), not just the status code. Plus `TestBulk_MixedOwnership_PartialEnforcement`: a single batch mixing the caller's own id with a victim's id mutates only the owned row.

`go build ./...`, `go vet ./internal/api/`, `go test ./internal/api/`, `gofmt`, and `golangci-lint run ./internal/api/` (0 issues) all pass.

Closes #947