### PR TITLE
fix(importer): reconcile qBittorrent downloads complete at grab time (#969, #939)

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1046,23 +1046,100 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 		}
 	}
 
-	slog.Debug("qbittorrent poll", "torrents", len(torrentsMap), "downloads", len(allDownloads), "categories", downloader.CategoriesToPoll(client))
+	// Build an UNFILTERED index of every torrent qBittorrent holds, keyed by
+	// hash. This is the reconciliation fallback for two stuck-in-"downloading"
+	// bugs whose common root is that the category-filtered poll above can miss a
+	// torrent that genuinely belongs to a tracked download:
+	//
+	//   - #969 (cross-seed / complete-at-grab): when Bindery grabs a release the
+	//     client already holds complete+seeding, AddTorrent recovers the existing
+	//     hash via the 409 path but its setCategory call is best-effort (the
+	//     error is ignored, and some qBittorrent versions refuse to recategorise
+	//     an actively-seeding torrent). The torrent then stays under the
+	//     cross-seed's original category, so CategoriesToPoll never returns it and
+	//     the import never fires — the queue item is wedged at downloading/100%.
+	//
+	//   - #939 (category-filter miss): same mechanism for any torrent qBittorrent
+	//     placed outside Bindery's configured categories.
+	//
+	// GetTorrents("") returns every torrent regardless of category, so a
+	// hash/name match here recovers torrents the category filter dropped.
+	allTorrents, allErr := qb.GetTorrents(ctx, "")
+	if allErr != nil {
+		// Non-fatal: fall back to the category-filtered map only. We still want
+		// to process the torrents we did find rather than abort the whole poll.
+		slog.Debug("qbittorrent: unfiltered torrent listing failed; reconciliation fallback disabled", "error", allErr)
+	}
+	unfilteredByHash := make(map[string]qbittorrent.Torrent, len(allTorrents))
+	for _, t := range allTorrents {
+		unfilteredByHash[strings.ToLower(t.Hash)] = t
+	}
+
+	slog.Debug("qbittorrent poll", "torrents", len(torrentsMap), "all_torrents", len(unfilteredByHash), "downloads", len(allDownloads), "categories", downloader.CategoriesToPoll(client))
 
 	// Track which downloads' sources we observed this cycle (issue #706 finding 4).
 	seenSourceIDs := make(map[int64]bool)
 
 	for _, dl := range allDownloads {
-		if dl.DownloadClientID == nil || *dl.DownloadClientID != client.ID || dl.TorrentID == nil {
+		if dl.DownloadClientID == nil || *dl.DownloadClientID != client.ID {
 			continue
 		}
-		torrent, ok := torrentsMap[strings.ToLower(*dl.TorrentID)]
+
+		var torrent qbittorrent.Torrent
+		var ok bool
+		if dl.TorrentID != nil {
+			torrent, ok = torrentsMap[strings.ToLower(*dl.TorrentID)]
+			if !ok {
+				// Not in the category-filtered map. Fall back to the unfiltered
+				// listing before giving up — this is the #969/#939 category-miss
+				// recovery (a cross-seeded torrent qBittorrent kept under a
+				// different category is still found here by hash).
+				torrent, ok = unfilteredByHash[strings.ToLower(*dl.TorrentID)]
+				if ok {
+					slog.Info("qbittorrent: download found only via unfiltered listing (category mismatch)",
+						"title", dl.Title, "hash", *dl.TorrentID, "category", torrent.Category, "dl_status", dl.Status)
+				}
+			}
+		} else {
+			// #939: a download with the client set but no torrent hash. The hash
+			// is only persisted when SendDownload returned a RemoteID; if that
+			// step failed (or the record predates the fix) the row was skipped
+			// FOREVER, leaving the queue item stuck. Recover by matching the
+			// torrent in the unfiltered listing by name (and save-path/category
+			// when available), then BACKFILL the hash so all subsequent polls,
+			// retries and removals work normally.
+			if dl.Status == models.StateImported || dl.Status == models.StateFailed {
+				continue
+			}
+			match, found := matchTorrentForDownload(client, &dl, allTorrents)
+			if !found {
+				slog.Debug("qbittorrent: download has no torrent hash and no listing match yet",
+					"title", dl.Title, "dl_status", dl.Status)
+				continue
+			}
+			torrent = match
+			ok = true
+			slog.Info("qbittorrent: backfilling missing torrent hash from listing match",
+				"title", dl.Title, "hash", torrent.Hash, "category", torrent.Category)
+			if err := s.downloads.SetTorrentID(ctx, dl.ID, torrent.Hash); err != nil {
+				slog.Warn("qbittorrent: failed to backfill torrent hash", "download_id", dl.ID, "error", err)
+			} else {
+				h := strings.ToLower(torrent.Hash)
+				dl.TorrentID = &h
+			}
+		}
+
 		if !ok {
-			// The torrent is not in qBittorrent's list. Common causes: category
-			// filter mismatch, the torrent was manually removed, or the hash stored
-			// in Bindery doesn't match what qBittorrent returned. This is
-			// blockStaleImportFailures territory; only log at Debug to avoid noise.
+			// The torrent is not in qBittorrent's list at all (not under any
+			// category). Common causes: the torrent was manually removed, or the
+			// hash stored in Bindery doesn't match what qBittorrent returned. This
+			// is blockStaleImportFailures territory; only log at Debug to avoid noise.
+			hash := ""
+			if dl.TorrentID != nil {
+				hash = *dl.TorrentID
+			}
 			slog.Debug("qbittorrent: download not found in torrent list",
-				"title", dl.Title, "hash", *dl.TorrentID, "dl_status", dl.Status)
+				"title", dl.Title, "hash", hash, "dl_status", dl.Status)
 			continue
 		}
 		seenSourceIDs[dl.ID] = true
@@ -1072,7 +1149,16 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 		}
 
 		state := strings.ToLower(torrent.State)
-		isComplete := torrent.Progress >= 1.0 || strings.Contains(state, "upload") || strings.Contains(state, "stalledup") || strings.Contains(state, "checkingup")
+		// #969: qBittorrent reports a fully-downloaded torrent as
+		// {progress:1, amount_left:0, state:"stalledUP"|"uploading"|"pausedUP"|...}.
+		// Treat any of those signals as complete. amount_left==0 (with a known
+		// non-zero size) is the most reliable "all bytes present" indicator and
+		// catches states the substring checks miss (e.g. "queuedUP", "forcedUP").
+		isComplete := torrent.Progress >= 1.0 ||
+			(torrent.Size > 0 && torrent.AmountLeft == 0) ||
+			strings.Contains(state, "upload") ||
+			strings.Contains(state, "stalledup") ||
+			strings.Contains(state, "checkingup")
 		isFailed := strings.Contains(state, "error")
 
 		slog.Debug("qbittorrent: torrent status",
@@ -1082,7 +1168,23 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 			"dl_status", dl.Status,
 			"is_complete", isComplete)
 
-		if isComplete && (dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed) {
+		// #969: import whenever the client reports the torrent complete and the
+		// download has not yet reached a terminal/in-flight import state —
+		// regardless of whether Bindery ever observed a "downloading" phase. The
+		// cross-seed / complete-at-grab case lands the record at StateDownloading
+		// (set right after the grab) or StateGrabbed and the torrent is already
+		// seeding, so the old "must be downloading/grabbed" gate fired but the
+		// torrent was invisible due to the category filter (now fixed above by the
+		// unfiltered fallback). StateCompleted/StateImportPending are included so a
+		// record wedged mid-transition (e.g. a crash between the status write and
+		// the import call, or a stuck StateCompleted row encountered between boot
+		// reconciliation sweeps) is also reconciled rather than stuck forever. The
+		// importer's own idempotency guards (isBookAlreadyImported / alreadyImported*
+		// — issue #706) prevent a double-import.
+		importable := dl.Status == models.StateDownloading ||
+			dl.Status == models.StateGrabbed ||
+			dl.Status == models.StateCompleted
+		if isComplete && importable {
 			rawPath, ok := resolveQbitContentPath(torrent)
 			if !ok {
 				// content_path is absent or points to a path that no longer exists.
@@ -1093,10 +1195,15 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 				if s.isBookAlreadyImported(ctx, &dl) {
 					slog.Info("qbittorrent: content path gone but book already in library — marking as imported",
 						"title", dl.Title)
-					// Walk the state machine: grabbed/downloading → completed →
-					// importPending → importing → imported.
-					s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
-					s.updateDownloadStatus(ctx, dl.ID, models.StateImportPending)
+					// Walk the state machine from wherever we are to imported,
+					// skipping any state we have already passed (a self-transition
+					// is rejected by validTransitions).
+					if dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed {
+						s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
+					}
+					if dl.Status != models.StateImportPending {
+						s.updateDownloadStatus(ctx, dl.ID, models.StateImportPending)
+					}
 					s.updateDownloadStatus(ctx, dl.ID, models.StateImporting)
 					s.updateDownloadStatus(ctx, dl.ID, models.StateImported)
 					continue
@@ -1120,8 +1227,14 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 			// or empty-file response; tryImportInternal then falls back to
 			// the legacy filepath.Walk(downloadPath).
 			bookFiles := s.qbittorrentFilesFor(ctx, qb, client, torrent)
-			slog.Info("download completed", "title", dl.Title, "path", downloadPath, "raw_path", rawPath, "files", len(bookFiles))
-			s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
+			slog.Info("download completed", "title", dl.Title, "path", downloadPath, "raw_path", rawPath, "files", len(bookFiles), "dl_status", dl.Status)
+			// Advance to StateCompleted only from a pre-completion state;
+			// tryImportQbittorrent moves on to importPending → importing →
+			// imported. A record already at StateCompleted/StateImportPending
+			// skips straight to the import (a self-transition would be rejected).
+			if dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed {
+				s.updateDownloadStatus(ctx, dl.ID, models.StateCompleted)
+			}
 			s.tryImportQbittorrent(ctx, &dl, downloadPath, bookFiles)
 		} else if isComplete && dl.Status == models.StateImportFailed && dl.ImportRetryCount < importRetryLimit {
 			// Bug #7: a previous import attempt failed (e.g. transient filesystem
@@ -1412,6 +1525,62 @@ func resolveQbitContentPath(t qbittorrent.Torrent) (string, bool) {
 		return candidate, true
 	}
 	return "", false
+}
+
+// matchTorrentForDownload finds the torrent in candidates that corresponds to a
+// download whose torrent hash was never persisted (#939). The hash is only
+// stored when SendDownload returned a RemoteID; if that step failed, or the row
+// predates the hash-setting fix, dl.TorrentID is nil and the poll loop would
+// otherwise skip the record forever, leaving the queue item stuck.
+//
+// Matching is by torrent name against the download title. qBittorrent reports
+// the torrent's display name, which for a Bindery grab is the release title we
+// stored in dl.Title — so an exact (case-insensitive) name match is the primary
+// signal. When the download client declares a category, a candidate whose
+// category matches is preferred to disambiguate two same-named torrents.
+//
+// The match is intentionally conservative: an exact name match only. A fuzzy
+// match risks backfilling the WRONG hash onto a download, which would then
+// import the wrong torrent's files. When no confident match exists the caller
+// leaves the record untouched (logged at Debug) and tries again next cycle.
+func matchTorrentForDownload(client *models.DownloadClient, dl *models.Download, candidates []qbittorrent.Torrent) (qbittorrent.Torrent, bool) {
+	if dl == nil || strings.TrimSpace(dl.Title) == "" {
+		return qbittorrent.Torrent{}, false
+	}
+	wantName := strings.ToLower(strings.TrimSpace(dl.Title))
+
+	var nameMatches []qbittorrent.Torrent
+	for _, t := range candidates {
+		if strings.ToLower(strings.TrimSpace(t.Name)) == wantName {
+			nameMatches = append(nameMatches, t)
+		}
+	}
+	switch len(nameMatches) {
+	case 0:
+		return qbittorrent.Torrent{}, false
+	case 1:
+		return nameMatches[0], true
+	}
+
+	// Multiple torrents share this name. Prefer one whose category matches a
+	// category this client grabs under; if exactly one qualifies, take it.
+	wantCats := map[string]struct{}{}
+	for _, c := range downloader.CategoriesToPoll(client) {
+		if c != "" {
+			wantCats[strings.ToLower(c)] = struct{}{}
+		}
+	}
+	var catMatches []qbittorrent.Torrent
+	for _, t := range nameMatches {
+		if _, ok := wantCats[strings.ToLower(t.Category)]; ok {
+			catMatches = append(catMatches, t)
+		}
+	}
+	if len(catMatches) == 1 {
+		return catMatches[0], true
+	}
+	// Ambiguous — refuse to guess.
+	return qbittorrent.Torrent{}, false
 }
 
 // alreadyImportedFormat reports whether book already has a tracked, on-disk

--- a/internal/importer/scanner_qbittorrent_reconcile_test.go
+++ b/internal/importer/scanner_qbittorrent_reconcile_test.go
@@ -1,0 +1,362 @@
+package importer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/downloader/qbittorrent"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// qbitReconcileFixture wires up an in-memory DB, a book already present in the
+// library (so the content-path-gone shortcut deterministically marks the
+// download imported once the torrent is found), and a download client. The
+// caller supplies the HTTP handler so each test controls the qBittorrent API
+// shape (category filtering, torrent state, etc.).
+type qbitReconcileFixture struct {
+	scanner *Scanner
+	client  *models.DownloadClient
+	dlRepo  *db.DownloadRepo
+	book    *models.Book
+}
+
+func newQbitReconcileFixture(t *testing.T, handler http.HandlerFunc, category, audioCategory string) *qbitReconcileFixture {
+	t.Helper()
+
+	libraryDir := t.TempDir()
+	libEpub := filepath.Join(libraryDir, "book.epub")
+	if err := os.WriteFile(libEpub, []byte("epub-in-library"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, "", "", "", "")
+
+	author := &models.Author{Name: "Recon Author", ForeignID: "a-recon", SortName: "Author, Recon"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{AuthorID: author.ID, Title: "Recon Book", ForeignID: "b-recon", Status: "wanted", MediaType: models.MediaTypeEbook}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.AddBookFile(ctx, book.ID, models.MediaTypeEbook, libEpub); err != nil {
+		t.Fatal(err)
+	}
+
+	host, port := scannerTestHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name:              "qbit-recon",
+		Type:              "qbittorrent",
+		Host:              host,
+		Port:              port,
+		Enabled:           true,
+		Category:          category,
+		CategoryAudiobook: audioCategory,
+	}
+	if err := clientRepo.Create(ctx, client); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	return &qbitReconcileFixture{scanner: s, client: client, dlRepo: dlRepo, book: book}
+}
+
+// TestCheckQbittorrentDownloads_CompleteAtGrab_CategoryMiss is the core #969
+// regression test.
+//
+// Scenario: Bindery grabs a release whose torrent the client ALREADY holds
+// complete + seeding (cross-seed). The AddTorrent 409 path recovers the hash but
+// its setCategory call is best-effort, so the torrent stays under the
+// cross-seed's ORIGINAL category ("crossseed") rather than Bindery's configured
+// "ebook". The download record sits at StateDownloading with the correct hash.
+//
+// The mock returns the torrent ONLY for an unfiltered (no category) query and an
+// empty list for category="ebook". With the old behaviour the category-filtered
+// poll never sees the torrent and the download is wedged at downloading forever.
+// The unfiltered-listing fallback must find it by hash and drive it to imported.
+func TestCheckQbittorrentDownloads_CompleteAtGrab_CategoryMiss(t *testing.T) {
+	const torrentHash = "cr0ssseed1234567890cr0ssseed1234567890ab"
+	saveRoot := t.TempDir()
+
+	fx := newQbitReconcileFixture(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			cat := r.URL.Query().Get("category")
+			// The torrent lives under a foreign category; only the unfiltered
+			// (cat=="") query returns it. Bindery's "ebook" query is empty.
+			if cat == "" {
+				_ = json.NewEncoder(w).Encode([]map[string]any{{
+					"hash":         torrentHash,
+					"name":         "Recon Book",
+					"state":        "stalledUP",
+					"progress":     1.0,
+					"amount_left":  0,
+					"category":     "crossseed",
+					"save_path":    saveRoot,
+					"content_path": "", // files live at the cross-seed location → "already imported" shortcut
+				}})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}, "ebook", "")
+
+	ctx := context.Background()
+	hash := torrentHash
+	dl := &models.Download{
+		GUID:             "guid-crossseed",
+		Title:            "Recon Book",
+		Status:           models.StateDownloading,
+		Protocol:         "torrent",
+		TorrentID:        &hash,
+		BookID:           &fx.book.ID,
+		DownloadClientID: &fx.client.ID,
+	}
+	if err := fx.dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	fx.scanner.checkQbittorrentDownloads(ctx, fx.client)
+
+	got, err := fx.dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.Status != models.StateImported {
+		t.Fatalf("#969 regression: complete-at-grab cross-seed torrent under a foreign "+
+			"category must be reconciled to imported via the unfiltered listing; got %q", got.Status)
+	}
+}
+
+// TestCheckQbittorrentDownloads_NilHash_Backfill is the #939 regression test.
+//
+// Scenario: a download has its DownloadClientID set but TorrentID nil (the hash
+// was never persisted because SendDownload failed to return a RemoteID, or the
+// row predates the fix). The old poll skipped any nil-hash record forever, so
+// the queue item stayed stuck.
+//
+// The reconciliation matches the torrent by name in the unfiltered listing,
+// backfills the hash, and imports. The test asserts BOTH the hash was persisted
+// and the download reached imported.
+func TestCheckQbittorrentDownloads_NilHash_Backfill(t *testing.T) {
+	const torrentHash = "nilhash01234567890nilhash01234567890abcd"
+	saveRoot := t.TempDir()
+
+	fx := newQbitReconcileFixture(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"hash":         torrentHash,
+				"name":         "Recon Book",
+				"state":        "stalledUP",
+				"progress":     1.0,
+				"amount_left":  0,
+				"category":     "ebook",
+				"save_path":    saveRoot,
+				"content_path": "",
+			}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}, "ebook", "")
+
+	ctx := context.Background()
+	dl := &models.Download{
+		GUID:             "guid-nilhash",
+		Title:            "Recon Book",
+		Status:           models.StateDownloading,
+		Protocol:         "torrent",
+		TorrentID:        nil, // the bug: no hash was ever stored
+		BookID:           &fx.book.ID,
+		DownloadClientID: &fx.client.ID,
+	}
+	if err := fx.dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	fx.scanner.checkQbittorrentDownloads(ctx, fx.client)
+
+	got, err := fx.dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.TorrentID == nil || *got.TorrentID != torrentHash {
+		t.Errorf("#939 regression: nil-hash download must have its torrent hash backfilled "+
+			"from the listing match; got TorrentID=%v want %q", got.TorrentID, torrentHash)
+	}
+	if got.Status != models.StateImported {
+		t.Errorf("#939 regression: nil-hash download must be reconciled to imported, got %q", got.Status)
+	}
+}
+
+// TestCheckQbittorrentDownloads_NormalDownloadingToComplete guards against a
+// regression in the ordinary happy path: a torrent under Bindery's configured
+// category that completes normally must still drive the download to imported.
+func TestCheckQbittorrentDownloads_NormalDownloadingToComplete(t *testing.T) {
+	const torrentHash = "normalpath1234567890normalpath1234567890"
+	saveRoot := t.TempDir()
+
+	fx := newQbitReconcileFixture(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			// Present under the configured category, as a normal grab would be.
+			cat := r.URL.Query().Get("category")
+			if cat != "" && cat != "ebook" {
+				_ = json.NewEncoder(w).Encode([]map[string]any{})
+				return
+			}
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"hash":         torrentHash,
+				"name":         "Recon Book",
+				"state":        "uploading",
+				"progress":     1.0,
+				"amount_left":  0,
+				"category":     "ebook",
+				"save_path":    saveRoot,
+				"content_path": "",
+			}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}, "ebook", "")
+
+	ctx := context.Background()
+	hash := torrentHash
+	dl := &models.Download{
+		GUID:             "guid-normal",
+		Title:            "Recon Book",
+		Status:           models.StateDownloading,
+		Protocol:         "torrent",
+		TorrentID:        &hash,
+		BookID:           &fx.book.ID,
+		DownloadClientID: &fx.client.ID,
+	}
+	if err := fx.dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	fx.scanner.checkQbittorrentDownloads(ctx, fx.client)
+
+	got, err := fx.dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.Status != models.StateImported {
+		t.Fatalf("normal downloading→complete path regressed: expected imported, got %q", got.Status)
+	}
+}
+
+// TestCheckQbittorrentDownloads_NoDoubleImport asserts that an already-imported
+// download (importedAt set, terminal StateImported) is left untouched even while
+// the torrent is still seeding and reported complete — the importer must not
+// re-run on a finished record (idempotency, ref #706).
+func TestCheckQbittorrentDownloads_NoDoubleImport(t *testing.T) {
+	const torrentHash = "alreadydone1234567890alreadydone12345678"
+	saveRoot := t.TempDir()
+
+	var importCalls int
+	fx := newQbitReconcileFixture(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_ = json.NewEncoder(w).Encode([]map[string]any{{
+				"hash":         torrentHash,
+				"name":         "Recon Book",
+				"state":        "stalledUP",
+				"progress":     1.0,
+				"amount_left":  0,
+				"category":     "ebook",
+				"save_path":    saveRoot,
+				"content_path": "",
+			}})
+		case "/api/v2/torrents/files":
+			// If the importer were (wrongly) re-entered for the imported record it
+			// would ask for the file list here. Count the calls to prove it doesn't.
+			importCalls++
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}, "ebook", "")
+
+	ctx := context.Background()
+	hash := torrentHash
+	dl := &models.Download{
+		GUID:             "guid-done",
+		Title:            "Recon Book",
+		Status:           models.StateImported,
+		Protocol:         "torrent",
+		TorrentID:        &hash,
+		BookID:           &fx.book.ID,
+		DownloadClientID: &fx.client.ID,
+	}
+	if err := fx.dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	fx.scanner.checkQbittorrentDownloads(ctx, fx.client)
+
+	got, err := fx.dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatalf("get download: %v", err)
+	}
+	if got.Status != models.StateImported {
+		t.Errorf("imported download must stay imported, got %q", got.Status)
+	}
+	if importCalls != 0 {
+		t.Errorf("no-double-import: importer was re-entered for an already-imported download (%d file-list calls)", importCalls)
+	}
+}
+
+// TestMatchTorrentForDownload_AmbiguousNameRefuses verifies the conservative
+// nil-hash matcher: two torrents share the download's name and neither (or both)
+// match the client category, so the matcher must refuse rather than backfill a
+// guessed — possibly wrong — hash.
+func TestMatchTorrentForDownload_AmbiguousNameRefuses(t *testing.T) {
+	client := &models.DownloadClient{Category: "ebook"}
+	dl := &models.Download{Title: "Dune"}
+	candidates := []qbittorrent.Torrent{
+		{Hash: "aaaa", Name: "Dune", Category: "movies"},
+		{Hash: "bbbb", Name: "Dune", Category: "music"},
+	}
+	if _, ok := matchTorrentForDownload(client, dl, candidates); ok {
+		t.Fatal("ambiguous name match must refuse, but a candidate was returned")
+	}
+
+	// One of them under the client's category → unambiguous, take it.
+	candidates[1].Category = "ebook"
+	got, ok := matchTorrentForDownload(client, dl, candidates)
+	if !ok || got.Hash != "bbbb" {
+		t.Fatalf("category tie-break failed: ok=%v hash=%q", ok, got.Hash)
+	}
+}


### PR DESCRIPTION
## Problem

Two reports of a queue item stuck permanently in **downloading** in the qBittorrent import poller share one root cause: `checkQbittorrentDownloads` only inspected torrents found under Bindery's *configured* categories and only matched downloads that already had a torrent hash. Both assumptions break for real-world torrents.

### #969 — cross-seed / complete-at-grab
When Bindery grabs a release whose torrent the client **already holds complete + seeding**, `AddTorrent` recovers the existing hash via the 409 "already present" path, but its `setCategory` call is best-effort (error ignored, and some qBittorrent versions refuse to recategorise an actively-seeding torrent). The torrent stays under the cross-seed's **original** category, so `CategoriesToPoll` never returns it, the import branch never fires, and the queue item is wedged at `downloading` / 100% / `timeLeft="2400h"`. `POST /queue/{id}/retry-import` 409s because the record is not in `importFailed` state. This is the "already complete AT grab" variant of #381/#384, which only covered "completes AFTER grab".

### #939 — nil hash + category miss
A download with `DownloadClientID` set but `TorrentID == nil` (the hash is only persisted when `SendDownload` returns a `RemoteID`; if that step failed, or the row predates the fix, the hash is never stored) was hit by the `dl.TorrentID == nil { continue }` guard and **skipped forever**. The same category-filter miss as #969 also drops correctly-hashed torrents that qBittorrent placed outside Bindery's categories.

## Fix (`internal/importer/scanner.go`)

- **Unfiltered fallback:** build a full `GetTorrents("")` index. When the category-filtered map misses a tracked hash, look it up here — recovering cross-seeded torrents under foreign categories (#969 + #939 category-miss).
- **Nil-hash backfill:** match the torrent by name (with a client-category tie-break) via the new `matchTorrentForDownload`, then `SetTorrentID` to **backfill** the hash so all subsequent polls, retries and removals work. The matcher is deliberately exact-name-only and refuses on ambiguity, so it never attaches the wrong torrent.
- **Complete-at-any-state import:** import whenever the client reports the torrent complete and the record is non-terminal (`downloading` / `grabbed` / `completed`), regardless of the prior observed phase, and strengthen the complete check with `amount_left == 0`. State transitions are guarded so self-transitions aren't attempted; the importer's existing idempotency guards (`isBookAlreadyImported` / `alreadyImported*`, #706) prevent a double-import. `imported`/`failed` records are skipped untouched.

### Decision: nil-hash handling
Backfill by name-match rather than surfacing an error. The hash is the join key for every downstream op (poll, retry, remove); recovering it fixes the record permanently instead of merely flagging it. The match is exact-only to avoid attaching the wrong torrent's files — on ambiguity it leaves the record for the next cycle.

## Tests (`scanner_qbittorrent_reconcile_test.go`)
- complete-at-grab torrent under a foreign category → imported via unfiltered fallback
- nil-hash record → hash backfilled + imported
- normal `downloading → complete` still imports (no regression)
- `StateImported` record → not re-entered (no double-import; asserts zero file-list calls)
- ambiguous name match → matcher refuses; category tie-break resolves a single candidate

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/importer/ ./internal/scheduler/ ./internal/downloader/...` all pass.

Closes #969
Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)