### PR TITLE
fix(import): canonical dedup key to stop ABS/Calibre duplicate book rows (#940)

### DIFF
--- a/internal/abs/import_cross_source_test.go
+++ b/internal/abs/import_cross_source_test.go
@@ -1,0 +1,118 @@
+package abs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// seedCalibreStyleBook creates a book the way the Calibre importer (or any
+// other create path) would: a plain Create, which now populates dedup_key from
+// the title via indexer.CanonicalDedupKey. Returns the row.
+func seedCalibreStyleBook(t *testing.T, bookRepo *db.BookRepo, authorID int64, fid, title string) *models.Book {
+	t.Helper()
+	b := &models.Book{
+		ForeignID:        fid,
+		AuthorID:         authorID,
+		Title:            title,
+		SortTitle:        title,
+		Status:           models.BookStatusImported,
+		Genres:           []string{},
+		MetadataProvider: "calibre",
+		MediaType:        models.MediaTypeEbook,
+		Monitored:        true,
+	}
+	if err := bookRepo.Create(context.Background(), b); err != nil {
+		t.Fatalf("seed book: %v", err)
+	}
+	return b
+}
+
+func countBooksForAuthor(t *testing.T, bookRepo *db.BookRepo, authorID int64) int {
+	t.Helper()
+	books, err := bookRepo.ListByAuthorIncludingExcluded(context.Background(), authorID)
+	if err != nil {
+		t.Fatalf("list books: %v", err)
+	}
+	return len(books)
+}
+
+// TestImporter_CrossSourceBindsByDedupKey is the #940 importer-level
+// regression. A book already filed by Calibre under one title form must be
+// LINKED (not duplicated) when ABS imports the same work under a differing but
+// canonically-equal title form — for subtitle, case, and umlaut variants.
+func TestImporter_CrossSourceBindsByDedupKey(t *testing.T) {
+	cases := []struct {
+		name         string
+		calibreTitle string
+		absTitle     string
+	}{
+		{"abs drops subtitle calibre keeps it", "Mistborn: The Final Empire", "Mistborn"},
+		{"abs adds bracket qualifier", "The Way of Kings", "The Way of Kings [Unabridged]"},
+		{"case differs", "Elantris", "ELANTRIS"},
+		{"umlaut form differs", "Die Straße", "Die Strasse"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			importer, authorRepo, bookRepo, _, _, _, _, _, _, _ := newABSImporterFixture(t)
+			ctx := context.Background()
+
+			author := &models.Author{ForeignID: "OL-CS", Name: "Brandon Sanderson", SortName: "Sanderson, Brandon", Monitored: true, MetadataProvider: "openlibrary"}
+			if err := authorRepo.Create(ctx, author); err != nil {
+				t.Fatal(err)
+			}
+			seedCalibreStyleBook(t, bookRepo, author.ID, "calibre:book:1", tc.calibreTitle)
+
+			if got := countBooksForAuthor(t, bookRepo, author.ID); got != 1 {
+				t.Fatalf("precondition: expected 1 seeded book, got %d", got)
+			}
+
+			item := sampleABSItem()
+			item.ItemID = "li-cross-source"
+			item.Title = tc.absTitle
+			item.ASIN = ""
+			item.Series = nil
+			item.Authors = []NormalizedAuthor{{ID: "author-cs", Name: "Brandon Sanderson"}}
+			runSingleABSImport(t, importer, item)
+
+			if got := countBooksForAuthor(t, bookRepo, author.ID); got != 1 {
+				t.Fatalf("ABS import duplicated the book: expected 1 row, got %d (calibre=%q abs=%q)", got, tc.calibreTitle, tc.absTitle)
+			}
+		})
+	}
+}
+
+// TestImporter_ABSFirstThenReimportDoesNotDuplicate proves the opposite order
+// and the resurrection case: ABS creates the row, and re-running the same ABS
+// import binds to it instead of creating a second row (#940's "re-running
+// resurrected deleted rows" symptom).
+func TestImporter_ABSFirstThenReimportDoesNotDuplicate(t *testing.T) {
+	importer, authorRepo, bookRepo, _, _, _, _, _, _, _ := newABSImporterFixture(t)
+	ctx := context.Background()
+
+	author := &models.Author{ForeignID: "OL-RE", Name: "Andy Weir", SortName: "Weir, Andy", Monitored: true, MetadataProvider: "openlibrary"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	item := sampleABSItem()
+	item.ItemID = "li-reimport"
+	item.Title = "Artemis: A Novel"
+	item.ASIN = ""
+	item.Series = nil
+	item.Authors = []NormalizedAuthor{{ID: "author-weir", Name: "Andy Weir"}}
+
+	runSingleABSImport(t, importer, item)
+	if got := countBooksForAuthor(t, bookRepo, author.ID); got != 1 {
+		t.Fatalf("first import: expected 1 book, got %d", got)
+	}
+
+	// Re-run with the subtitle-less form a different scan might present.
+	item.Title = "Artemis"
+	runSingleABSImport(t, importer, item)
+	if got := countBooksForAuthor(t, bookRepo, author.ID); got != 1 {
+		t.Fatalf("re-import duplicated: expected 1 book, got %d", got)
+	}
+}

--- a/internal/abs/import_upserts.go
+++ b/internal/abs/import_upserts.go
@@ -781,24 +781,29 @@ func (i *Importer) upsertBookProvenance(ctx context.Context, cfg ImportConfig, r
 	})
 }
 
+// findBookByNormalizedTitle binds an incoming ABS item to an existing local
+// book for the same author using the stored canonical dedup_key (#940). Both
+// the Calibre importer and book-create paths persist the same key via
+// indexer.CanonicalDedupKey, so this now binds across sources regardless of
+// import order instead of re-normalizing raw titles in memory with a scheme
+// that disagreed with Calibre's raw LOWER(title) match.
+//
+// Returns (match, ambiguous, err). ambiguous is true when more than one local
+// row shares the key — the caller routes that to review rather than guessing.
 func (i *Importer) findBookByNormalizedTitle(ctx context.Context, authorID int64, title string) (*models.Book, bool, error) {
-	books, err := i.books.ListByAuthorIncludingExcluded(ctx, authorID)
+	books, err := i.books.FindAllByAuthorAndDedupKey(ctx, authorID, title)
 	if err != nil {
 		return nil, false, err
 	}
-	key := normalizeTitle(title)
-	var match *models.Book
-	for idx := range books {
-		if normalizeTitle(books[idx].Title) != key {
-			continue
-		}
-		if match != nil {
-			return nil, true, nil
-		}
-		copy := books[idx]
-		match = &copy
+	switch len(books) {
+	case 0:
+		return nil, false, nil
+	case 1:
+		match := books[0]
+		return &match, false, nil
+	default:
+		return nil, true, nil
 	}
-	return match, false, nil
 }
 
 func (i *Importer) applyBookFields(ctx context.Context, book *models.Book, authorID int64, item NormalizedLibraryItem) error {

--- a/internal/abs/import_utils.go
+++ b/internal/abs/import_utils.go
@@ -2,7 +2,6 @@ package abs
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -166,34 +165,14 @@ func normalizeAuthorName(name string) string {
 	return textutil.NormalizeAuthorName(name)
 }
 
-// bracketSuffixRe matches one trailing square-bracketed qualifier. ABS titles
-// routinely append format/edition tags this way ("[Unabridged]",
-// "[Dramatized Adaptation]", "[Audiobook]"). indexer.NormalizeTitleForDedup
-// only strips a trailing *parenthesised* qualifier, so without this step
-// "The Eye of the World [Unabridged]" and "The Eye of the World" produce
-// different keys and never match against the metadata provider or a local row.
-var bracketSuffixRe = regexp.MustCompile(`\s*\[[^\[\]]*\]\s*$`)
-
-// stripBracketSuffixes removes any trailing square-bracketed qualifiers,
-// applied repeatedly so "Title [Unabridged] [2021]" is fully cleaned.
-func stripBracketSuffixes(title string) string {
-	for {
-		stripped := bracketSuffixRe.ReplaceAllString(title, "")
-		if stripped == title {
-			return strings.TrimSpace(stripped)
-		}
-		title = stripped
-	}
-}
-
 // normalizeTitle produces the canonical key used to compare an ABS item title
-// against local book rows and metadata-provider works. ABS-specific bracketed
-// edition/format noise is stripped first; the remainder reuses the shared
-// indexer normalization (paren-suffix strip, subtitle strip, case/Unicode
-// folding). The same wrapper is applied to both sides of every comparison, so
-// the dedup key stays symmetric.
+// against local book rows and metadata-provider works. It delegates to the
+// single shared indexer.CanonicalDedupKey so the key matches exactly what is
+// stored in books.dedup_key and what the Calibre importer computes — see #940,
+// where ABS and Calibre previously normalized titles asymmetrically and created
+// duplicate rows for the same work.
 func normalizeTitle(title string) string {
-	return indexer.NormalizeTitleForDedup(stripBracketSuffixes(strings.TrimSpace(title)))
+	return indexer.CanonicalDedupKey(title)
 }
 
 func primaryAuthorName(item NormalizedLibraryItem) string {

--- a/internal/calibre/import_cross_source_test.go
+++ b/internal/calibre/import_cross_source_test.go
@@ -1,0 +1,73 @@
+package calibre
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestImporter_CrossSourceBindsByDedupKey is the #940 regression for the
+// Calibre side (the mirror of the ABS-side test). A book already filed by ABS
+// under one title form must be LINKED via Path 3 (author + canonical dedup_key)
+// when Calibre imports the same work under a differing-but-equivalent title,
+// not duplicated. Pre-fix, Path 3 matched raw LOWER(title) and created a 2nd
+// row for every subtitle/case/umlaut variant.
+func TestImporter_CrossSourceBindsByDedupKey(t *testing.T) {
+	cases := []struct {
+		name         string
+		absTitle     string // title ABS persisted
+		calibreTitle string // title Calibre presents for the same work
+	}{
+		{"calibre drops subtitle abs keeps it", "Mistborn: The Final Empire", "Mistborn"},
+		{"calibre keeps subtitle abs dropped it", "Mistborn", "Mistborn: The Final Empire"},
+		{"case differs", "Elantris", "ELANTRIS"},
+		{"umlaut form differs", "Die Strasse", "Die Straße"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			imp, fr, authorRepo, bookRepo, _, _, _ := newImporterFixture(t)
+			ctx := context.Background()
+
+			// Seed an author + an ABS-style book (plain Create -> dedup_key set).
+			author := &models.Author{ForeignID: "abs:author:1", Name: "Brandon Sanderson", SortName: "Sanderson, Brandon", Monitored: true, MetadataProvider: "audiobookshelf"}
+			if err := authorRepo.Create(ctx, author); err != nil {
+				t.Fatal(err)
+			}
+			absBook := &models.Book{
+				ForeignID: "abs:book:1", AuthorID: author.ID, Title: tc.absTitle, SortTitle: tc.absTitle,
+				Status: models.BookStatusImported, Genres: []string{}, MetadataProvider: "audiobookshelf",
+				MediaType: models.MediaTypeAudiobook, Monitored: true,
+			}
+			if err := bookRepo.Create(ctx, absBook); err != nil {
+				t.Fatal(err)
+			}
+
+			fr.books = []CalibreBook{sampleCalibreBook(1, tc.calibreTitle, "Brandon Sanderson")}
+			stats, err := imp.Run(ctx, "/lib")
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if stats.BooksAdded != 0 {
+				t.Fatalf("Calibre import created a duplicate (BooksAdded=%d) for abs=%q calibre=%q", stats.BooksAdded, tc.absTitle, tc.calibreTitle)
+			}
+
+			books, err := bookRepo.ListByAuthorIncludingExcluded(ctx, author.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(books) != 1 {
+				t.Fatalf("expected 1 book after cross-source bind, got %d", len(books))
+			}
+			// The single surviving row must now carry the Calibre id (Path 3
+			// links by SetCalibreID).
+			linked, err := bookRepo.GetByCalibreID(ctx, 1)
+			if err != nil || linked == nil {
+				t.Fatalf("book not linked to calibre_id: %v / %v", err, linked)
+			}
+			if linked.ID != absBook.ID {
+				t.Fatalf("Calibre linked to a new row (%d) instead of the ABS row (%d)", linked.ID, absBook.ID)
+			}
+		})
+	}
+}

--- a/internal/calibre/importer.go
+++ b/internal/calibre/importer.go
@@ -624,8 +624,13 @@ func (i *Importer) upsertBook(ctx context.Context, runID int64, author *models.A
 		return &bookUpsertResult{row: existing, matchedBy: "foreign_id"}, false, nil
 	}
 
-	// Path 3 — same author + title.
-	if existing, err := i.books.FindByAuthorAndTitle(ctx, author.ID, cb.Title); err != nil {
+	// Path 3 — same author + canonical dedup key. Binds to a book the user (or
+	// a previous ABS/Calibre/CWA ingest) already filed for the same work even
+	// when the stored title differs by subtitle, case, bracketed qualifier, or
+	// umlaut form. Previously this matched on raw
+	// LOWER(title) SQL, which disagreed with the ABS importer's normalized
+	// match and produced duplicate rows (#940).
+	if existing, err := i.books.FindByAuthorAndDedupKey(ctx, author.ID, cb.Title); err != nil {
 		return nil, false, err
 	} else if existing != nil {
 		i.recordBookBeforeSnapshot(ctx, runID, externalID, existing, outcomeLinked, map[string]any{"matchedBy": "title"})

--- a/internal/db/book_dedup_key_test.go
+++ b/internal/db/book_dedup_key_test.go
@@ -1,0 +1,205 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/indexer"
+)
+
+// TestBookRepo_DedupKeyPersistedOnCreate proves Create writes the canonical
+// dedup key derived from the title, so every book-creation path (Calibre, ABS,
+// CWA, manual) is keyed identically (#940).
+func TestBookRepo_DedupKeyPersistedOnCreate(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := mkAuthor(t, authorRepo, ctx, "OL-DK-A")
+
+	b := mkBook(t, bookRepo, ctx, a.ID, "OL-DK-B", "Mistborn: The Final Empire", "wanted")
+	want := indexer.CanonicalDedupKey("Mistborn: The Final Empire")
+	if b.DedupKey != want {
+		t.Fatalf("Create did not set DedupKey: got %q want %q", b.DedupKey, want)
+	}
+
+	got, _ := bookRepo.GetByID(ctx, b.ID)
+	if got.DedupKey != want {
+		t.Fatalf("stored DedupKey: got %q want %q", got.DedupKey, want)
+	}
+}
+
+// TestBookRepo_DedupKeyRecomputedOnUpdate proves a title change refreshes the
+// stored key so it can never go stale and silently break future binds.
+func TestBookRepo_DedupKeyRecomputedOnUpdate(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := mkAuthor(t, authorRepo, ctx, "OL-DK-U")
+
+	b := mkBook(t, bookRepo, ctx, a.ID, "OL-DK-UB", "Old Title", "wanted")
+	b.Title = "New Title: A Subtitle"
+	if err := bookRepo.Update(ctx, b); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	want := indexer.CanonicalDedupKey("New Title: A Subtitle")
+	got, _ := bookRepo.GetByID(ctx, b.ID)
+	if got.DedupKey != want {
+		t.Fatalf("Update did not recompute DedupKey: got %q want %q", got.DedupKey, want)
+	}
+}
+
+// TestBookRepo_FindByAuthorAndDedupKey_Asymmetry is the core #940 regression.
+// A book stored under one source's raw title must be found by the OTHER
+// source's differing-but-equivalent title via the canonical key, in BOTH
+// directions, for titles differing by subtitle, bracket/paren qualifier, case,
+// and umlaut form. The pre-fix FindByAuthorAndTitle (raw LOWER match) failed
+// every one of these.
+func TestBookRepo_FindByAuthorAndDedupKey_Asymmetry(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+
+	cases := []struct {
+		name   string
+		stored string // title as one source persists it
+		lookup string // title the other source presents
+	}{
+		{"subtitle vs none", "Mistborn: The Final Empire", "Mistborn"},
+		{"none vs subtitle", "Mistborn", "Mistborn: The Final Empire"},
+		{"bracket qualifier", "The Eye of the World", "The Eye of the World [Unabridged]"},
+		{"case differs", "DUNE", "dune"},
+		{"umlaut form differs", "Die Straße", "Die Strasse"},
+		{"paren edition", "Dune", "Dune (Unabridged)"},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := mkAuthor(t, authorRepo, ctx, "OL-AS-A"+string(rune('a'+i)))
+			b := mkBook(t, bookRepo, ctx, a.ID, "OL-AS-B"+string(rune('a'+i)), tc.stored, "wanted")
+
+			got, err := bookRepo.FindByAuthorAndDedupKey(ctx, a.ID, tc.lookup)
+			if err != nil {
+				t.Fatalf("FindByAuthorAndDedupKey: %v", err)
+			}
+			if got == nil || got.ID != b.ID {
+				t.Fatalf("stored %q not found via lookup %q (got %+v)", tc.stored, tc.lookup, got)
+			}
+		})
+	}
+}
+
+// TestBookRepo_FindByAuthorAndDedupKey_EmptyKeyAndWrongAuthor guards against
+// the two ways the lookup could over-match: a blank title (which must never
+// collapse untitled rows) and a different author.
+func TestBookRepo_FindByAuthorAndDedupKey_EmptyKeyAndWrongAuthor(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := mkAuthor(t, authorRepo, ctx, "OL-EK-A")
+	_ = mkBook(t, bookRepo, ctx, a.ID, "OL-EK-B", "Some Title", "wanted")
+
+	// Blank lookup title -> empty key -> never match.
+	got, err := bookRepo.FindByAuthorAndDedupKey(ctx, a.ID, "   ")
+	if err != nil {
+		t.Fatalf("blank lookup: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("blank title must not match, got %+v", got)
+	}
+
+	// Right key, wrong author.
+	got, err = bookRepo.FindByAuthorAndDedupKey(ctx, 999, "Some Title")
+	if err != nil {
+		t.Fatalf("wrong author lookup: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("wrong author must not match, got %+v", got)
+	}
+}
+
+// TestBookRepo_FindAllByAuthorAndDedupKey_Ambiguous proves the ABS importer's
+// ambiguity signal: two rows under one author sharing a canonical key are both
+// returned so the caller can route to review instead of guessing.
+func TestBookRepo_FindAllByAuthorAndDedupKey_Ambiguous(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := mkAuthor(t, authorRepo, ctx, "OL-AM-A")
+
+	_ = mkBook(t, bookRepo, ctx, a.ID, "OL-AM-1", "Foundation", "wanted")
+	_ = mkBook(t, bookRepo, ctx, a.ID, "OL-AM-2", "Foundation: The Empire", "wanted")
+
+	all, err := bookRepo.FindAllByAuthorAndDedupKey(ctx, a.ID, "foundation")
+	if err != nil {
+		t.Fatalf("FindAllByAuthorAndDedupKey: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 ambiguous rows, got %d", len(all))
+	}
+}
+
+// TestBackfillBookDedupKeys recomputes the exact key for rows whose stored
+// value is blank or only the coarse SQL approximation. Simulates a legacy row
+// by clearing dedup_key directly, then asserts the startup backfill fixes it.
+func TestBackfillBookDedupKeys(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := mkAuthor(t, authorRepo, ctx, "OL-BF-A")
+	b := mkBook(t, bookRepo, ctx, a.ID, "OL-BF-B", "Die Straße: Ein Roman", "wanted")
+
+	// Simulate a pre-051 / coarse-SQL row: wrong (un-folded) key.
+	if _, err := database.ExecContext(ctx, "UPDATE books SET dedup_key = ? WHERE id = ?", "die straße", b.ID); err != nil {
+		t.Fatalf("seed stale key: %v", err)
+	}
+
+	if err := backfillBookDedupKeys(database); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	want := indexer.CanonicalDedupKey("Die Straße: Ein Roman")
+	got, _ := bookRepo.GetByID(ctx, b.ID)
+	if got.DedupKey != want {
+		t.Fatalf("backfill did not canonicalize: got %q want %q", got.DedupKey, want)
+	}
+	// Now the umlaut-transliterated lookup must bind.
+	found, _ := bookRepo.FindByAuthorAndDedupKey(ctx, a.ID, "Die Strasse")
+	if found == nil || found.ID != b.ID {
+		t.Fatalf("post-backfill umlaut lookup failed: %+v", found)
+	}
+}

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -151,7 +152,7 @@ const bookColumns = `books.id, books.foreign_id, books.author_id, books.title, b
 	books.created_at, books.updated_at,
 	COALESCE(fe.path, COALESCE(books.ebook_file_path, '')),
 	COALESCE(fa.path, COALESCE(books.audiobook_file_path, '')),
-	books.excluded,
+	books.excluded, COALESCE(books.dedup_key, ''),
 	au.id, au.foreign_id, au.name, au.sort_name,
 	COALESCE(books.owner_user_id, 0)`
 
@@ -282,18 +283,24 @@ func (r *BookRepo) Create(ctx context.Context, b *models.Book) error {
 		mediaType = models.MediaTypeEbook
 	}
 
+	// Centralized dedup-key computation (#940): every book-creation path flows
+	// through Create, so deriving dedup_key here from the title with the single
+	// canonical normalizer guarantees Calibre, ABS, CWA and manual creates all
+	// write byte-identical keys for the same work.
+	b.DedupKey = indexer.CanonicalDedupKey(b.Title)
+
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO books (foreign_id, author_id, title, sort_title, original_title, description,
 		                   image_url, release_date, genres, average_rating, ratings_count,
 		                   monitored, status, any_edition_ok, selected_edition_id,
 		                   language, media_type, narrator, duration_seconds, asin,
-		                   metadata_provider, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		                   metadata_provider, dedup_key, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		b.ForeignID, b.AuthorID, b.Title, b.SortTitle, b.OriginalTitle, b.Description,
 		b.ImageURL, timeArg(b.ReleaseDate), string(genresJSON), b.AverageRating, b.RatingsCount,
 		b.Monitored, b.Status, b.AnyEditionOK, b.SelectedEditionID,
 		b.Language, mediaType, b.Narrator, b.DurationSeconds, b.ASIN,
-		b.MetadataProvider, timeValueArg(now), timeValueArg(now))
+		b.MetadataProvider, b.DedupKey, timeValueArg(now), timeValueArg(now))
 	if err != nil {
 		return fmt.Errorf("create book: %w", err)
 	}
@@ -320,19 +327,24 @@ func (r *BookRepo) Update(ctx context.Context, b *models.Book) error {
 		mediaType = models.MediaTypeEbook
 	}
 
+	// Keep dedup_key in lockstep with the title (#940). applyBookFields in both
+	// importers rewrites Title on every update, so recomputing here prevents a
+	// stale key after a title edit/refresh from silently breaking future binds.
+	b.DedupKey = indexer.CanonicalDedupKey(b.Title)
+
 	_, err = r.exec.ExecContext(ctx, `
 		UPDATE books SET foreign_id=?, author_id=?, title=?, sort_title=?, original_title=?, description=?, image_url=?,
 		                 release_date=?, genres=?, average_rating=?, ratings_count=?,
 		                 monitored=?, status=?, any_edition_ok=?, selected_edition_id=?,
 		                 file_path=?, language=?, media_type=?, narrator=?, duration_seconds=?, asin=?,
-		                 metadata_provider=?, last_metadata_refresh_at=?, updated_at=?,
+		                 metadata_provider=?, dedup_key=?, last_metadata_refresh_at=?, updated_at=?,
 		                 ebook_file_path=?, audiobook_file_path=?
 		WHERE id=?`,
 		b.ForeignID, b.AuthorID, b.Title, b.SortTitle, b.OriginalTitle, b.Description, b.ImageURL,
 		timeArg(b.ReleaseDate), string(genresJSON), b.AverageRating, b.RatingsCount,
 		b.Monitored, b.Status, b.AnyEditionOK, b.SelectedEditionID,
 		b.FilePath, b.Language, mediaType, b.Narrator, b.DurationSeconds, b.ASIN,
-		b.MetadataProvider, timeArg(b.LastMetadataRefreshAt), timeValueArg(now),
+		b.MetadataProvider, b.DedupKey, timeArg(b.LastMetadataRefreshAt), timeValueArg(now),
 		b.EbookFilePath, b.AudiobookFilePath, b.ID)
 	if err != nil {
 		return fmt.Errorf("update book %d: %w", b.ID, err)
@@ -498,11 +510,12 @@ func (r *BookRepo) GetByCalibreID(ctx context.Context, calibreID int64) (*models
 }
 
 // FindByAuthorAndTitle locates a book under authorID whose title matches
-// `title` case-insensitively. Used by the Calibre importer as a secondary
-// dedupe path when the existing row has no calibre_id yet but the user
-// (or a previous Bindery ingest) has already filed a book with the same
-// title — re-matching by title links the two rows instead of creating a
-// duplicate.
+// `title` case-insensitively (raw LOWER(title) = LOWER(?)).
+//
+// Deprecated for cross-source dedup: this exact-match-modulo-case lookup is
+// what caused #940 (it disagreed with the ABS importer's normalized match and
+// produced duplicate rows). Importers now use FindByAuthorAndDedupKey. Retained
+// only for callers that genuinely need a raw-title match.
 func (r *BookRepo) FindByAuthorAndTitle(ctx context.Context, authorID int64, title string) (*models.Book, error) {
 	books, err := r.query(ctx,
 		bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE author_id = ? AND LOWER(title) = LOWER(?)",
@@ -514,6 +527,50 @@ func (r *BookRepo) FindByAuthorAndTitle(ctx context.Context, authorID int64, tit
 		return nil, nil
 	}
 	return &books[0], nil
+}
+
+// FindByAuthorAndDedupKey locates a book under authorID whose stored canonical
+// dedup_key equals the key computed for `title` by indexer.CanonicalDedupKey.
+// This is the cross-source bind used by both the Calibre and ABS importers
+// (#940): because both sides compute the key with the same function and the
+// key is persisted at create time, a book imported from one source binds to
+// the existing row from the other regardless of import order, subtitle, case,
+// bracketed qualifier, or umlaut form.
+//
+// An empty computed key (blank/whitespace title) never matches: the early
+// return avoids a query that would otherwise collapse every untitled row under
+// an author into one. A row whose stored dedup_key is still NULL/empty
+// (pre-backfill) likewise cannot match a non-empty computed key, so it is never
+// falsely merged.
+func (r *BookRepo) FindByAuthorAndDedupKey(ctx context.Context, authorID int64, title string) (*models.Book, error) {
+	key := indexer.CanonicalDedupKey(title)
+	if key == "" {
+		return nil, nil
+	}
+	books, err := r.query(ctx,
+		bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE author_id = ? AND books.dedup_key = ?",
+		[]any{authorID, key})
+	if err != nil {
+		return nil, err
+	}
+	if len(books) == 0 {
+		return nil, nil
+	}
+	return &books[0], nil
+}
+
+// FindAllByAuthorAndDedupKey returns every book under authorID matching the
+// canonical key for `title`. The ABS importer uses it to detect the *ambiguous*
+// case (more than one local row shares the key) and route to review instead of
+// guessing which row to bind.
+func (r *BookRepo) FindAllByAuthorAndDedupKey(ctx context.Context, authorID int64, title string) ([]models.Book, error) {
+	key := indexer.CanonicalDedupKey(title)
+	if key == "" {
+		return nil, nil
+	}
+	return r.query(ctx,
+		bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE author_id = ? AND books.dedup_key = ?",
+		[]any{authorID, key})
 }
 
 // SetExcluded toggles the excluded flag on a book.
@@ -569,7 +626,7 @@ func (r *BookRepo) query(ctx context.Context, q string, args []any) ([]models.Bo
 			&b.CalibreID, &b.MetadataProvider, &lastMetadataRefreshAtStr,
 			&createdAtStr, &updatedAtStr,
 			&b.EbookFilePath, &b.AudiobookFilePath,
-			&excluded,
+			&excluded, &b.DedupKey,
 			&authorID, &authorForeignID, &authorName, &authorSortName,
 			&b.OwnerUserID,
 		)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/vavallee/bindery/internal/indexer"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -247,6 +249,82 @@ func migrate(database *sql.DB) error {
 		slog.Info("applied migration", "version", v, "file", entry.Name())
 	}
 
+	// Post-migration Go-side backfill. Migration 051's SQL backfill is a coarse
+	// approximation of indexer.CanonicalDedupKey (SQLite cannot run the Go
+	// normalizer); recompute the exact key for any row whose stored key is
+	// blank or no longer matches the canonical function (#940). Idempotent and
+	// cheap: a no-op once every row already holds the canonical key.
+	if err := backfillBookDedupKeys(database); err != nil {
+		return fmt.Errorf("backfill book dedup keys: %w", err)
+	}
+
+	return nil
+}
+
+// backfillBookDedupKeys recomputes books.dedup_key for every row whose stored
+// value differs from indexer.CanonicalDedupKey(title). It runs on every startup
+// after migrations so that:
+//   - legacy rows created before migration 051 get a correct key (the SQL
+//     backfill only produced a coarse lowercase/subtitle approximation);
+//   - a future change to the canonical normalizer re-canonicalizes existing
+//     rows on the next boot rather than leaving them permanently stale.
+//
+// It deliberately does NOT merge duplicate rows — reconciling existing dupes is
+// risky (file ownership, edition links, provenance) and is left as a follow-up.
+// Writing keys is safe: at worst two pre-existing dupes now share a key, which
+// only makes future imports bind to one of them instead of creating a third.
+func backfillBookDedupKeys(database *sql.DB) error {
+	rows, err := database.Query("SELECT id, title, COALESCE(dedup_key, '') FROM books")
+	if err != nil {
+		return fmt.Errorf("read books for dedup backfill: %w", err)
+	}
+	type pending struct {
+		id  int64
+		key string
+	}
+	var updates []pending
+	for rows.Next() {
+		var id int64
+		var title, stored string
+		if err := rows.Scan(&id, &title, &stored); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan book for dedup backfill: %w", err)
+		}
+		want := indexer.CanonicalDedupKey(title)
+		if want != stored {
+			updates = append(updates, pending{id: id, key: want})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("iterate books for dedup backfill: %w", err)
+	}
+	rows.Close()
+	if len(updates) == 0 {
+		return nil
+	}
+
+	tx, err := database.Begin()
+	if err != nil {
+		return fmt.Errorf("begin dedup backfill tx: %w", err)
+	}
+	stmt, err := tx.Prepare("UPDATE books SET dedup_key = ? WHERE id = ?")
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("prepare dedup backfill: %w", err)
+	}
+	for _, u := range updates {
+		if _, err := stmt.Exec(u.key, u.id); err != nil {
+			_ = stmt.Close()
+			_ = tx.Rollback()
+			return fmt.Errorf("update dedup_key for book %d: %w", u.id, err)
+		}
+	}
+	_ = stmt.Close()
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit dedup backfill: %w", err)
+	}
+	slog.Info("backfilled book dedup keys", "rows", len(updates))
 	return nil
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -274,32 +274,38 @@ func migrate(database *sql.DB) error {
 // Writing keys is safe: at worst two pre-existing dupes now share a key, which
 // only makes future imports bind to one of them instead of creating a third.
 func backfillBookDedupKeys(database *sql.DB) error {
-	rows, err := database.Query("SELECT id, title, COALESCE(dedup_key, '') FROM books")
-	if err != nil {
-		return fmt.Errorf("read books for dedup backfill: %w", err)
-	}
 	type pending struct {
 		id  int64
 		key string
 	}
-	var updates []pending
-	for rows.Next() {
-		var id int64
-		var title, stored string
-		if err := rows.Scan(&id, &title, &stored); err != nil {
-			rows.Close()
-			return fmt.Errorf("scan book for dedup backfill: %w", err)
+	// Read phase in its own scope so rows is closed (via defer) BEFORE we open
+	// the write transaction — holding an open read cursor across Begin() risks
+	// a "database is locked" on SQLite.
+	updates, err := func() ([]pending, error) {
+		rows, err := database.Query("SELECT id, title, COALESCE(dedup_key, '') FROM books")
+		if err != nil {
+			return nil, fmt.Errorf("read books for dedup backfill: %w", err)
 		}
-		want := indexer.CanonicalDedupKey(title)
-		if want != stored {
-			updates = append(updates, pending{id: id, key: want})
+		defer rows.Close()
+		var out []pending
+		for rows.Next() {
+			var id int64
+			var title, stored string
+			if err := rows.Scan(&id, &title, &stored); err != nil {
+				return nil, fmt.Errorf("scan book for dedup backfill: %w", err)
+			}
+			if want := indexer.CanonicalDedupKey(title); want != stored {
+				out = append(out, pending{id: id, key: want})
+			}
 		}
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("iterate books for dedup backfill: %w", err)
+		}
+		return out, nil
+	}()
+	if err != nil {
+		return err
 	}
-	if err := rows.Err(); err != nil {
-		rows.Close()
-		return fmt.Errorf("iterate books for dedup backfill: %w", err)
-	}
-	rows.Close()
 	if len(updates) == 0 {
 		return nil
 	}
@@ -313,14 +319,13 @@ func backfillBookDedupKeys(database *sql.DB) error {
 		_ = tx.Rollback()
 		return fmt.Errorf("prepare dedup backfill: %w", err)
 	}
+	defer stmt.Close()
 	for _, u := range updates {
 		if _, err := stmt.Exec(u.key, u.id); err != nil {
-			_ = stmt.Close()
 			_ = tx.Rollback()
 			return fmt.Errorf("update dedup_key for book %d: %w", u.id, err)
 		}
 	}
-	_ = stmt.Close()
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit dedup backfill: %w", err)
 	}

--- a/internal/db/migration_051_test.go
+++ b/internal/db/migration_051_test.go
@@ -1,0 +1,29 @@
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMigration051AppliesAndIndexExists(t *testing.T) {
+	d, err := OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer d.Close()
+	ctx := context.Background()
+	var name string
+	err = d.QueryRowContext(ctx, "SELECT name FROM pragma_table_info('books') WHERE name='dedup_key'").Scan(&name)
+	if err != nil || name != "dedup_key" {
+		t.Fatalf("dedup_key column missing: %v (%q)", err, name)
+	}
+	var idx string
+	err = d.QueryRowContext(ctx, "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_books_author_dedup_key'").Scan(&idx)
+	if err != nil || idx != "idx_books_author_dedup_key" {
+		t.Fatalf("index missing: %v (%q)", err, idx)
+	}
+	var ver int
+	if err := d.QueryRowContext(ctx, "SELECT version FROM schema_migrations WHERE version=51").Scan(&ver); err != nil {
+		t.Fatalf("migration 51 not recorded: %v", err)
+	}
+}

--- a/internal/db/migrations/051_book_dedup_key.sql
+++ b/internal/db/migrations/051_book_dedup_key.sql
@@ -1,0 +1,47 @@
+-- +migrate Up
+-- Canonical cross-source dedup key on books (#940).
+--
+-- ABS and Calibre imported the same work into two rows, one with files and one
+-- empty. Root cause was asymmetric title normalization at lookup time. The
+-- Calibre importer matched on raw LOWER(title) = LOWER(?) SQL while the ABS
+-- importer matched on an in-memory normalized key (subtitle and bracket
+-- stripped, umlaut-folded). Whichever source imported first won, and
+-- the other created a duplicate. Re-running an import resurrected deleted rows.
+--
+-- Fix. Persist a single canonical dedup key computed by exactly one Go
+-- function (indexer.CanonicalDedupKey) at every book-create path, and switch
+-- both importer lookups to author_id + dedup_key. The column is nullable so
+-- existing rows that have not yet been recomputed are simply skipped by the
+-- equality lookup (NULL never matches), never falsely merged.
+ALTER TABLE books ADD COLUMN dedup_key TEXT;
+
+-- Index the lookup the importers use, "is there already a book for this author
+-- with this canonical key". Partial on non-NULL keeps the index small and
+-- guarantees NULL rows (not yet backfilled) are not lookup-eligible.
+CREATE INDEX IF NOT EXISTS idx_books_author_dedup_key
+    ON books(author_id, dedup_key) WHERE dedup_key IS NOT NULL;
+
+-- Best-effort SQL backfill so the column is non-NULL for the common case even
+-- before the application starts. This is a deliberately COARSE approximation
+-- of indexer.CanonicalDedupKey. It lowercases, collapses a trailing colon-space
+-- subtitle, and trims. It does NOT do bracket or paren-suffix stripping,
+-- Unicode NFC, or umlaut folding because SQLite cannot express those. The
+-- Go-side backfill (db.backfillBookDedupKeys, run on startup)
+-- recomputes the exact key for every row and overwrites these approximations,
+-- so this clause only narrows the window where lookups could miss before the
+-- app boots.
+UPDATE books
+SET dedup_key = TRIM(LOWER(
+        CASE
+            WHEN INSTR(title, ': ') > 0 THEN SUBSTR(title, 1, INSTR(title, ': ') - 1)
+            ELSE title
+        END))
+WHERE dedup_key IS NULL;
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS idx_books_author_dedup_key;
+-- SQLite < 3.35 cannot DROP COLUMN. The forward migration is additive and
+-- defaults to NULL on existing rows, so leaving the column in place is a no-op
+-- for callers that do not read it. A true rollback requires a manual table
+-- rebuild.

--- a/internal/indexer/dedup.go
+++ b/internal/indexer/dedup.go
@@ -1,6 +1,7 @@
 package indexer
 
 import (
+	"regexp"
 	"strings"
 
 	"golang.org/x/text/unicode/norm"
@@ -35,6 +36,42 @@ func NormalizeTitleForDedup(title string) string {
 	title = strings.ToLower(title)
 	title = transliterateUmlauts(title)
 	return title
+}
+
+// bracketSuffixRe matches one trailing square-bracketed qualifier. Provider
+// titles (Audiobookshelf in particular) routinely append format/edition tags
+// this way ("[Unabridged]", "[Dramatized Adaptation]", "[Audiobook]").
+// NormalizeTitleForDedup only strips a trailing *parenthesised* qualifier, so
+// without this step "The Eye of the World [Unabridged]" and "The Eye of the
+// World" produce different keys.
+var bracketSuffixRe = regexp.MustCompile(`\s*\[[^\[\]]*\]\s*$`)
+
+// StripBracketSuffixes removes any trailing square-bracketed qualifiers,
+// applied repeatedly so "Title [Unabridged] [2021]" is fully cleaned.
+func StripBracketSuffixes(title string) string {
+	for {
+		stripped := bracketSuffixRe.ReplaceAllString(title, "")
+		if stripped == title {
+			return strings.TrimSpace(stripped)
+		}
+		title = stripped
+	}
+}
+
+// CanonicalDedupKey is the single, authoritative dedup key used to decide
+// whether two book rows describe the same work across importers (Calibre,
+// Audiobookshelf, CWA, manual). It MUST be the only function any book-creation
+// path uses to populate books.dedup_key and the only function any lookup uses
+// to key by author+title, so the key is computed identically on every side and
+// the previous asymmetry (#940 — Calibre matched on raw LOWER(title) SQL while
+// ABS matched on a normalized in-memory key) cannot recur.
+//
+// It strips trailing bracketed qualifiers first (ABS-style "[Unabridged]"),
+// then applies NormalizeTitleForDedup (paren-suffix strip, subtitle strip,
+// whitespace/Unicode/umlaut folding, lowercasing). The result is
+// case-insensitive and stable, so it is stored verbatim and compared with =.
+func CanonicalDedupKey(title string) string {
+	return NormalizeTitleForDedup(StripBracketSuffixes(strings.TrimSpace(title)))
 }
 
 // stripSubtitle removes a trailing ": subtitle" segment when the colon is

--- a/internal/indexer/dedup_test.go
+++ b/internal/indexer/dedup_test.go
@@ -85,6 +85,47 @@ func TestNormalizeTitleForDedup(t *testing.T) {
 	}
 }
 
+// TestCanonicalDedupKey covers the single cross-source key (#940): it must
+// strip ABS-style bracketed qualifiers on top of all NormalizeTitleForDedup
+// folding, so titles a Calibre ebook and an ABS audiobook present for the same
+// work collapse to one key.
+func TestCanonicalDedupKey(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"The Eye of the World [Unabridged]", "the eye of the world"},
+		{"The Eye of the World", "the eye of the world"},
+		{"Mistborn: The Final Empire", "mistborn"},
+		{"Mistborn", "mistborn"},
+		{"Dune (Unabridged) [Audiobook]", "dune"},
+		{"Die Straße", "die strasse"},
+		{"Die Strasse", "die strasse"},
+		{"  spaced  out [2021] ", "spaced out"},
+	}
+	for _, tc := range cases {
+		if got := CanonicalDedupKey(tc.in); got != tc.want {
+			t.Errorf("CanonicalDedupKey(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestCanonicalDedupKey_Symmetric is the order-independence invariant: any two
+// titles for the same work, in either order, produce the same key.
+func TestCanonicalDedupKey_Symmetric(t *testing.T) {
+	pairs := [][2]string{
+		{"Mistborn: The Final Empire", "Mistborn"},
+		{"The Eye of the World [Unabridged]", "the eye of the world"},
+		{"Dune (Unabridged)", "Dune [Audiobook]"},
+		{"Die Straße: Ein Roman", "Die Strasse"},
+	}
+	for _, p := range pairs {
+		if a, b := CanonicalDedupKey(p[0]), CanonicalDedupKey(p[1]); a != b {
+			t.Errorf("asymmetric: %q->%q vs %q->%q", p[0], a, p[1], b)
+		}
+	}
+}
+
 func TestNormalizeTitleForDedup_Symmetric(t *testing.T) {
 	// Both the raw provider form and the trailing-stripped form must map to
 	// the same key — this is the core dedup invariant.

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -13,32 +13,38 @@ type SeriesRef struct {
 }
 
 type Book struct {
-	ID                    int64      `json:"id"`
-	ForeignID             string     `json:"foreignBookId"`
-	AuthorID              int64      `json:"authorId"`
-	Title                 string     `json:"title"`
-	SortTitle             string     `json:"sortTitle"`
-	OriginalTitle         string     `json:"originalTitle"`
-	Description           string     `json:"description"`
-	ImageURL              string     `json:"imageUrl"`
-	ReleaseDate           *time.Time `json:"releaseDate"`
-	Genres                []string   `json:"genres"`
-	AverageRating         float64    `json:"averageRating"`
-	RatingsCount          int        `json:"ratingsCount"`
-	EditionCount          int        `json:"-"`
-	ISBNs                 []string   `json:"-"`
-	Monitored             bool       `json:"monitored"`
-	Status                string     `json:"status"`
-	AnyEditionOK          bool       `json:"anyEditionOk"`
-	SelectedEditionID     *int64     `json:"selectedEditionId"`
-	FilePath              string     `json:"filePath"`
-	Language              string     `json:"language"`
-	MediaType             string     `json:"mediaType"`
-	Narrator              string     `json:"narrator"`
-	DurationSeconds       int        `json:"durationSeconds"`
-	ASIN                  string     `json:"asin"`
-	CalibreID             *int64     `json:"calibre_id,omitempty"`
-	MetadataProvider      string     `json:"metadataProvider"`
+	ID                int64      `json:"id"`
+	ForeignID         string     `json:"foreignBookId"`
+	AuthorID          int64      `json:"authorId"`
+	Title             string     `json:"title"`
+	SortTitle         string     `json:"sortTitle"`
+	OriginalTitle     string     `json:"originalTitle"`
+	Description       string     `json:"description"`
+	ImageURL          string     `json:"imageUrl"`
+	ReleaseDate       *time.Time `json:"releaseDate"`
+	Genres            []string   `json:"genres"`
+	AverageRating     float64    `json:"averageRating"`
+	RatingsCount      int        `json:"ratingsCount"`
+	EditionCount      int        `json:"-"`
+	ISBNs             []string   `json:"-"`
+	Monitored         bool       `json:"monitored"`
+	Status            string     `json:"status"`
+	AnyEditionOK      bool       `json:"anyEditionOk"`
+	SelectedEditionID *int64     `json:"selectedEditionId"`
+	FilePath          string     `json:"filePath"`
+	Language          string     `json:"language"`
+	MediaType         string     `json:"mediaType"`
+	Narrator          string     `json:"narrator"`
+	DurationSeconds   int        `json:"durationSeconds"`
+	ASIN              string     `json:"asin"`
+	CalibreID         *int64     `json:"calibre_id,omitempty"`
+	MetadataProvider  string     `json:"metadataProvider"`
+	// DedupKey is the canonical cross-source title key (#940), computed by
+	// indexer.CanonicalDedupKey at every book-create path. It is the only
+	// signal used to bind the same work imported from different sources
+	// (Calibre, Audiobookshelf, CWA, manual). Nullable for rows created before
+	// migration 051 that have not yet been recomputed by the startup backfill.
+	DedupKey              string     `json:"-"`
 	HardcoverForeignID    string     `json:"-"`
 	LastMetadataRefreshAt *time.Time `json:"lastMetadataRefreshAt"`
 	CreatedAt             time.Time  `json:"createdAt"`


### PR DESCRIPTION
## Problem

ABS + Calibre import produced **two book rows for the same book** — one with files, one empty (#940, confirmed by a second reporter, Jashun44, "some merge, some don't").

The cross-source merge had exactly one bridge in each importer — the "same author + title" fallback — and the two importers normalized titles **asymmetrically**, so the bind was order-dependent:

- **Calibre** (`internal/calibre/importer.go`, Path 3) matched via `FindByAuthorAndTitle` → SQL `WHERE author_id=? AND LOWER(title)=LOWER(?)`: exact match modulo case, no subtitle/bracket normalization.
- **ABS** (`internal/abs/import_upserts.go`, `findBookByNormalizedTitle`) matched via an in-memory `normalizeTitle` (bracket-strip + `indexer.NormalizeTitleForDedup`: subtitle strip, NFC, umlaut fold, lowercase).

Neither importer persisted the normalized key; both stored the **raw** title and re-normalized at lookup with their own scheme. So e.g. ABS stores `Mistborn: The Final Empire`, Calibre later looks up `Mistborn` → no SQL match → 2nd row; re-running resurrected deleted rows. The opposite import order could bind, and byte-identical titles bound regardless — exactly the "some merge, some don't" report.

## Fix — one canonical, stored dedup key

1. **`indexer.CanonicalDedupKey`** is now the single normalizer: trailing bracket-strip (ABS `[Unabridged]`) + existing `NormalizeTitleForDedup` (paren-suffix strip, subtitle strip, whitespace/Unicode/umlaut fold, lowercase). ABS's `normalizeTitle` delegates to it; the old private `stripBracketSuffixes` is promoted to `indexer.StripBracketSuffixes`.
2. **Migration 051** (`051_book_dedup_key.sql`): `ALTER TABLE books ADD COLUMN dedup_key TEXT` (nullable) + partial index `idx_books_author_dedup_key (author_id, dedup_key) WHERE dedup_key IS NOT NULL`.
3. **Populate at create time, centralized**: `BookRepo.Create` (and `Update`, to track title edits) compute `dedup_key` from the title via `CanonicalDedupKey`. Every book-create path flows through `Create`, so Calibre/ABS/CWA/manual all write byte-identical keys — there is exactly one place that computes it.
4. **Both lookups switched** to `author_id + dedup_key`: new `BookRepo.FindByAuthorAndDedupKey` / `FindAllByAuthorAndDedupKey`. Calibre Path 3 and ABS `findBookByNormalizedTitle` use them. Empty key / NULL stored key never match (no false merges).

## Backfill

- **SQL** (in the migration): coarse best-effort (lowercase + trailing `": "` subtitle strip + trim) so the column is non-NULL before the app boots. SQLite cannot run the Go normalizer, so this is deliberately approximate.
- **Go-side, authoritative** (`db.backfillBookDedupKeys`, run on every startup after migrations): recomputes the exact `CanonicalDedupKey` for every row whose stored key is blank or stale and overwrites the SQL approximation. Idempotent; also re-canonicalizes existing rows if the normalizer ever changes.

## Existing duplicates — deferred (not reconciled)

This PR does **not** merge pre-existing duplicate rows. Reconciling existing dupes is risky (file ownership, edition links, provenance) and is left as a follow-up. Writing keys is safe: at worst two existing dupes now share a key, which only makes *future* imports bind to one of them instead of creating a third. New imports stop creating duplicates immediately.

## Migration number / #887

Next free migration on `main` is **051** (latest is `050_blocklist_created_by_user_id.sql`). The unmerged **PR #887 also adds a migration 051** — main is the source of truth, so this PR uses 051 and **#887 will need to rebase its migration to 052** to avoid the duplicate-version guard (`assertUniqueMigrationVersions`) failing on boot.

## Tests

- `indexer`: `CanonicalDedupKey` + symmetry (subtitle/bracket/paren/case/umlaut).
- `db`: dedup_key persisted on Create, recomputed on Update, `FindByAuthorAndDedupKey` asymmetry matrix (both directions), empty-key/wrong-author guards, ambiguity, backfill, and a migration-applies smoke test.
- `abs` + `calibre`: importer-level cross-source bind to **one** row in ABS-first **and** Calibre-first order across subtitle/case/umlaut/bracket variants; re-running an import does not resurrect/duplicate.

Verified: `go build ./...`, `go vet ./...`, `gofmt -l` clean, full `go test ./...` (53 pkgs) green.

Closes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)