### PR TITLE
feat(web): nudge to configure a download client when search has none (#968)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -52,6 +52,18 @@ export class ApiError extends Error {
   }
 }
 
+// True when an error is the backend's "no enabled download client configured"
+// failure from a grab attempt (#959 / internal/api/queue.go). Detected by the
+// same substring pair the backend uses to classify it as a 400, so a missing
+// download client surfaces a contextual setup nudge instead of a raw error —
+// independent of whether the library is empty (#968). Tolerant of the protocol
+// variants noProtocolClientError produces ("no enabled usenet download client
+// configured …", etc).
+export function isNoDownloadClientError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : ''
+  return msg.includes('no enabled') && msg.includes('download client configured')
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   // Merge caller-supplied headers on top of the defaults so we can't lose
   // the CSRF header if a caller passes their own `headers`.

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -68,7 +68,11 @@
     "resultCount": "{{count}} results",
     "grab": "Grab",
     "grabbing": "Grabbing…",
-    "grabbed": "Grabbed"
+    "grabbed": "Grabbed",
+    "noClient": {
+      "body": "Nothing was grabbed — no enabled download client can handle this release. Add or enable a download client to start downloads.",
+      "action": "Set up Download Clients"
+    }
   },
   "login": {
     "title": "Sign in",

--- a/web/src/pages/SearchPage.test.tsx
+++ b/web/src/pages/SearchPage.test.tsx
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import SearchPage from './SearchPage'
+import { ApiError, api } from '../api/client'
+import type { Download, SearchResult } from '../api/client'
+import en from '../i18n/locales/en.json'
+
+// Resolve a dotted i18n key against the real English locale so the test asserts
+// against the strings the page actually renders.
+function resolveKey(key: string): string | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let node: any = en
+  for (const part of key.split('.')) {
+    if (node && typeof node === 'object' && part in node) node = node[part]
+    else return undefined
+  }
+  return typeof node === 'string' ? node : undefined
+}
+
+function translate(key: string, arg?: unknown): string {
+  const resolved = resolveKey(key)
+  const fallback = typeof arg === 'string' ? arg : key
+  let str = resolved ?? fallback
+  if (arg && typeof arg === 'object') {
+    for (const [k, v] of Object.entries(arg as Record<string, unknown>)) {
+      str = str.replace(new RegExp(`{{\\s*${k}\\s*}}`, 'g'), String(v))
+    }
+  }
+  return str
+}
+
+const translation = { t: translate }
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => translation,
+}))
+
+vi.mock('../api/client', async importOriginal => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      searchIndexers: vi.fn(),
+      grab: vi.fn(),
+    },
+  }
+})
+
+function makeResult(overrides: Partial<SearchResult> & { guid: string; title: string }): SearchResult {
+  return {
+    indexerName: 'Test Indexer',
+    size: 1572864,
+    nzbUrl: 'https://indexer.example.com/release.nzb',
+    grabs: 5,
+    pubDate: '2026-05-01',
+    protocol: 'usenet',
+    ...overrides,
+  }
+}
+
+function makeDownload(overrides: Partial<Download> = {}): Download {
+  return {
+    id: 1,
+    guid: 'dl-guid',
+    title: 'Queued release',
+    status: 'queued',
+    size: 1572864,
+    protocol: 'usenet',
+    errorMessage: '',
+    addedAt: '2026-05-01T12:00:00Z',
+    ...overrides,
+  }
+}
+
+function renderSearchPage() {
+  return render(
+    <MemoryRouter>
+      <SearchPage />
+    </MemoryRouter>,
+  )
+}
+
+const noClientBody = en.search.noClient.body
+const noClientAction = en.search.noClient.action
+
+async function searchAndGetGrabButton() {
+  vi.mocked(api.searchIndexers).mockResolvedValue([
+    makeResult({ guid: 'g1', title: 'Some Book EPUB' }),
+  ])
+  renderSearchPage()
+  fireEvent.change(screen.getByPlaceholderText(en.search.placeholder), {
+    target: { value: 'some book' },
+  })
+  fireEvent.submit(screen.getByPlaceholderText(en.search.placeholder).closest('form')!)
+  return screen.findByRole('button', { name: en.search.grab })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('SearchPage no-download-client nudge', () => {
+  it('shows the contextual setup nudge when a grab fails with the no-client error', async () => {
+    const grabButton = await searchAndGetGrabButton()
+    vi.mocked(api.grab).mockRejectedValue(
+      new ApiError(400, { error: 'no enabled usenet download client configured — add a download client' }, 'Bad Request'),
+    )
+
+    fireEvent.click(grabButton)
+
+    expect(await screen.findByText(noClientBody)).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: noClientAction })
+    expect(link).toHaveAttribute('href', '/settings?tab=clients')
+  })
+
+  it('does not show the nudge on a successful grab', async () => {
+    const grabButton = await searchAndGetGrabButton()
+    vi.mocked(api.grab).mockResolvedValue(makeDownload({ guid: 'g1' }))
+
+    fireEvent.click(grabButton)
+
+    await waitFor(() => expect(screen.getByText(en.search.grabbed)).toBeInTheDocument())
+    expect(screen.queryByText(noClientBody)).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: noClientAction })).not.toBeInTheDocument()
+  })
+
+  it('shows the raw error (not the nudge) for an unrelated grab failure', async () => {
+    const grabButton = await searchAndGetGrabButton()
+    vi.mocked(api.grab).mockRejectedValue(
+      new ApiError(502, { error: 'indexer unreachable' }, 'Bad Gateway'),
+    )
+
+    fireEvent.click(grabButton)
+
+    expect(await screen.findByText('indexer unreachable')).toBeInTheDocument()
+    expect(screen.queryByText(noClientBody)).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/SearchPage.tsx
+++ b/web/src/pages/SearchPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from 'react'
+import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { api, SearchResult } from '../api/client'
+import { api, isNoDownloadClientError, SearchResult } from '../api/client'
 
 function formatSize(n: number): string {
   if (!n || n <= 0) return ''
@@ -17,6 +18,11 @@ export default function SearchPage() {
   const [grabbing, setGrabbing] = useState<string | null>(null)
   const [grabbed, setGrabbed] = useState<Set<string>>(new Set())
   const [error, setError] = useState<string | null>(null)
+  // When a grab fails because no download client of the needed protocol is
+  // enabled (#959 backend error), we swap the raw error for a contextual nudge
+  // linking to the client settings — shown regardless of whether the library is
+  // empty, which the first-run guidance (#960) didn't cover (#968).
+  const [needsClient, setNeedsClient] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
   const search = async () => {
@@ -24,6 +30,7 @@ export default function SearchPage() {
     if (!q) return
     setSearching(true)
     setError(null)
+    setNeedsClient(false)
     setResults(null)
     try {
       const r = await api.searchIndexers(q)
@@ -38,6 +45,7 @@ export default function SearchPage() {
   const grab = async (r: SearchResult) => {
     setGrabbing(r.guid)
     setError(null)
+    setNeedsClient(false)
     try {
       await api.grab({
         guid: r.guid,
@@ -48,7 +56,11 @@ export default function SearchPage() {
       })
       setGrabbed(prev => new Set(prev).add(r.guid))
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Grab failed')
+      if (isNoDownloadClientError(e)) {
+        setNeedsClient(true)
+      } else {
+        setError(e instanceof Error ? e.message : 'Grab failed')
+      }
     } finally {
       setGrabbing(null)
     }
@@ -82,6 +94,18 @@ export default function SearchPage() {
       {error && (
         <div className="mb-4 px-3 py-2 bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300 rounded text-sm">
           {error}
+        </div>
+      )}
+
+      {needsClient && (
+        <div className="mb-4 px-4 py-3 bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200 border border-amber-200 dark:border-amber-900/50 rounded-lg text-sm">
+          <p className="mb-2">{t('search.noClient.body')}</p>
+          <Link
+            to="/settings?tab=clients"
+            className="inline-block px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 text-white rounded-md text-sm font-medium transition-colors"
+          >
+            {t('search.noClient.action')}
+          </Link>
         </div>
       )}
 


### PR DESCRIPTION
## The gap

The first-run guidance added in #960 only shows when the instance has **no authors AND no indexers AND no clients** (`useNeedsSetup`). A user who has a populated library but no enabled download client (deleted them, or never configured one) gets a silent no-op on grab with no nudge — exactly the case in #968.

## The fix

On the Search page, when a grab fails because there's no enabled download client of the needed protocol, swap the raw error message for a lighter contextual banner that links straight to the download-client settings tab. Shown **regardless of whether the library is empty**, so it complements rather than duplicates the empty-state guidance.

## How the no-client case is detected

**Error-driven**, off the specific backend error from #959 (`internal/api/queue.go`, `noProtocolClientError`). New helper `isNoDownloadClientError` in `web/src/api/client.ts` matches the same substring pair (`no enabled` + `download client configured`) the backend itself uses at the grab handler to classify the failure as a 400. That covers all the protocol-mismatch variants the backend emits ("no enabled usenet download client configured …", the plain "add a download client" fallback, etc.) without re-deriving client state on the frontend.

## Where the hint triggers

`SearchPage` grab handler: on a no-client failure it sets `needsClient` and renders an amber banner (caution semantics) with an emerald primary link to `/settings?tab=clients`. Any other grab error still shows the existing red error banner unchanged.

## Files changed

- `web/src/api/client.ts` — `isNoDownloadClientError` helper.
- `web/src/pages/SearchPage.tsx` — detect the error, render the nudge banner.
- `web/src/i18n/locales/en.json` — `search.noClient.body` / `search.noClient.action` (other locales fall back to en).
- `web/src/pages/SearchPage.test.tsx` — new vitest coverage: nudge shows on the no-client error, not on success, and an unrelated error still shows the raw message.

## Verification

`npm run typecheck`, `npm run build`, `npm run lint` (no new warnings — the 5 remaining are pre-existing and in other files), and `npm test` (266 passed) all clean. Dark-mode pairs present on every new colour utility (slate/zinc + amber/emerald with `dark:` counterparts).

Closes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)