### PR TITLE
fix: code-sweep correctness findings (cache clone, DNS-rebind, float-eq, JW runes, syncer race, pw min) (#948)

### DIFF
--- a/internal/api/auth_users.go
+++ b/internal/api/auth_users.go
@@ -21,6 +21,20 @@ type UserManagementHandler struct {
 	localAuthEnabled bool
 }
 
+// minPasswordLength is the minimum length enforced for locally-managed
+// passwords (admin Create and ResetPassword), matching the login/registration
+// flows in auth.go.
+const minPasswordLength = 8
+
+// validatePassword returns a user-facing error message when pw is too short,
+// or "" when it is acceptable.
+func validatePassword(pw string) string {
+	if len(pw) < minPasswordLength {
+		return "password must be at least 8 characters"
+	}
+	return ""
+}
+
 func NewUserManagementHandler(users *db.UserRepo) *UserManagementHandler {
 	return &UserManagementHandler{users: users, localAuthEnabled: true}
 }
@@ -85,6 +99,10 @@ func (h *UserManagementHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.Username == "" || body.Password == "" {
 		writeErr(w, http.StatusBadRequest, "username and password required")
+		return
+	}
+	if msg := validatePassword(body.Password); msg != "" {
+		writeErr(w, http.StatusBadRequest, msg)
 		return
 	}
 	hash, err := auth.HashPassword(body.Password)
@@ -160,8 +178,8 @@ func (h *UserManagementHandler) ResetPassword(w http.ResponseWriter, r *http.Req
 		writeErr(w, http.StatusBadRequest, "invalid body")
 		return
 	}
-	if len(body.Password) < 8 {
-		writeErr(w, http.StatusBadRequest, "password must be at least 8 characters")
+	if msg := validatePassword(body.Password); msg != "" {
+		writeErr(w, http.StatusBadRequest, msg)
 		return
 	}
 	hash, err := auth.HashPassword(body.Password)

--- a/internal/api/auth_users_handler_test.go
+++ b/internal/api/auth_users_handler_test.go
@@ -162,6 +162,30 @@ func TestUserMgmt_Create_MissingPassword(t *testing.T) {
 	}
 }
 
+// TestUserMgmt_Create_ShortPassword asserts Create enforces the same 8-char
+// minimum as ResetPassword. A 7-char password must be rejected and no row
+// created; an 8-char one must succeed.
+func TestUserMgmt_Create_ShortPassword(t *testing.T) {
+	h, users := newUserMgmtFixture(t)
+
+	rec := httptest.NewRecorder()
+	h.Create(rec, jsonReq(http.MethodPost, "/api/v1/auth/users",
+		`{"username":"shorty","password":"1234567"}`, nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("7-char password status=%d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if u, _ := users.GetByUsername(context.Background(), "shorty"); u != nil {
+		t.Error("user created despite too-short password")
+	}
+
+	rec = httptest.NewRecorder()
+	h.Create(rec, jsonReq(http.MethodPost, "/api/v1/auth/users",
+		`{"username":"justok","password":"12345678"}`, nil))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("8-char password status=%d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestUserMgmt_Create_InvalidJSON(t *testing.T) {
 	h, _ := newUserMgmtFixture(t)
 	rec := httptest.NewRecorder()

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -43,7 +43,7 @@ func NewImageProxyHandler(dataDir string) *ImageProxyHandler {
 		cacheDir: filepath.Join(dataDir, "image-cache"),
 		client: &http.Client{
 			Timeout:   15 * time.Second,
-			Transport: httpsec.DefaultProxyTransport(),
+			Transport: imageProxyTransport(),
 			// Re-validate redirect targets — a permissive upstream could otherwise
 			// redirect from a public host into the LAN (cloud metadata, internal
 			// services) and leak the body back through the cache.
@@ -61,6 +61,31 @@ func NewImageProxyHandler(dataDir string) *ImageProxyHandler {
 	}
 	go h.migrateFlatCache()
 	return h
+}
+
+// imageProxyTransport returns the RoundTripper for the image-proxy client with a
+// per-request SSRF-revalidating DialContext installed, closing the DNS-rebind
+// TOCTOU window between the up-front URL validation and the actual dial.
+//
+// It starts from httpsec.DefaultProxyTransport() (preserving outbound-proxy
+// support added in #987) and clones it so installing DialContext does not mutate
+// the shared transport. Caveat: when an outbound proxy IS configured the
+// connection is dialled to the proxy address, so the dial-time re-check sees the
+// proxy rather than the upstream host (the same documented limitation as the
+// newznab client); for the default no-proxy case this fully closes the rebind
+// window. If the underlying transport is not an *http.Transport we fall back to
+// a fresh transport carrying the proxy resolver plus DialContext.
+func imageProxyTransport() http.RoundTripper {
+	base := httpsec.DefaultProxyTransport()
+	if t, ok := base.(*http.Transport); ok {
+		c := t.Clone()
+		c.DialContext = httpsec.NewDialContext(httpsec.PolicyStrict)
+		return c
+	}
+	return &http.Transport{
+		Proxy:       httpsec.ProxyFunc(),
+		DialContext: httpsec.NewDialContext(httpsec.PolicyStrict),
+	}
 }
 
 // Serve handles GET /api/v1/images?url=<encoded-external-url>.

--- a/internal/calibre/syncer.go
+++ b/internal/calibre/syncer.go
@@ -255,11 +255,14 @@ func (s *Syncer) run(ctx context.Context, cfg Config) {
 	s.setProgress(func(p *SyncProgress) {
 		p.Message = "done"
 	})
+	// Snapshot under lock — setProgress writes s.progress concurrently with the
+	// HTTP poller reading it, so read the stats through the locked getter.
+	final := s.Progress()
 	slog.Info("calibre sync complete",
 		"total", len(eligible),
-		"pushed", s.progress.Stats.Pushed,
-		"alreadyInCalibre", s.progress.Stats.AlreadyInCalibre,
-		"failed", s.progress.Stats.Failed)
+		"pushed", final.Stats.Pushed,
+		"alreadyInCalibre", final.Stats.AlreadyInCalibre,
+		"failed", final.Stats.Failed)
 }
 
 // pushPath returns the on-disk path to send to Calibre for the given

--- a/internal/metadata/aggregator_author_works.go
+++ b/internal/metadata/aggregator_author_works.go
@@ -26,7 +26,7 @@ type authorWorksByNameProvider interface {
 func (a *Aggregator) GetAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error) {
 	key := "authorworks:" + authorForeignID
 	if cached, ok := a.cache.get(key); ok {
-		return cached.([]models.Book), nil
+		return cloneBooks(cached.([]models.Book)), nil
 	}
 
 	books, err := a.rawPrimaryAuthorWorks(ctx, authorForeignID)
@@ -34,7 +34,7 @@ func (a *Aggregator) GetAuthorWorks(ctx context.Context, authorForeignID string)
 		return nil, err
 	}
 	a.enrichMissingAuthorWorkCovers(ctx, books)
-	a.cache.set(key, books)
+	a.cache.set(key, cloneBooks(books))
 	return books, nil
 }
 
@@ -44,7 +44,7 @@ func (a *Aggregator) GetAuthorWorks(ctx context.Context, authorForeignID string)
 func (a *Aggregator) GetAuthorWorksForAuthor(ctx context.Context, author models.Author) ([]models.Book, error) {
 	key := "authorworks-author:" + author.ForeignID + ":" + strings.ToLower(strings.TrimSpace(author.Name))
 	if cached, ok := a.cache.get(key); ok {
-		return cached.([]models.Book), nil
+		return cloneBooks(cached.([]models.Book)), nil
 	}
 
 	books, err := a.rawPrimaryAuthorWorks(ctx, author.ForeignID)
@@ -74,7 +74,7 @@ func (a *Aggregator) GetAuthorWorksForAuthor(ctx context.Context, author models.
 
 	a.enrichMissingAuthorWorkCovers(ctx, books)
 	if supplementsComplete {
-		a.cache.set(key, books)
+		a.cache.set(key, cloneBooks(books))
 	}
 	return books, nil
 }

--- a/internal/metadata/aggregator_author_works_test.go
+++ b/internal/metadata/aggregator_author_works_test.go
@@ -31,6 +31,36 @@ func TestAggregator_GetAuthorWorks_WorksProvider(t *testing.T) {
 	}
 }
 
+// TestAggregator_GetAuthorWorks_CallerCannotPoisonCache verifies that a caller
+// mutating the returned slice cannot corrupt the shared cache: both the cache
+// set and the cache hit must clone, matching rawPrimaryAuthorWorks.
+func TestAggregator_GetAuthorWorks_CallerCannotPoisonCache(t *testing.T) {
+	books := []models.Book{{Title: "Dune"}, {Title: "Dune Messiah"}}
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: books},
+	}
+	agg := &Aggregator{
+		primary: primary,
+		cache:   newTTLCache(time.Minute),
+	}
+
+	first, err := agg.GetAuthorWorks(context.Background(), "OL777A")
+	if err != nil {
+		t.Fatalf("GetAuthorWorks: %v", err)
+	}
+	// Poison the returned slice — must not bleed into the cached copy.
+	first[0].Title = "POISONED"
+
+	primary.authorWorks = nil // force the next call to come from cache
+	second, err := agg.GetAuthorWorks(context.Background(), "OL777A")
+	if err != nil {
+		t.Fatalf("GetAuthorWorks (cache): %v", err)
+	}
+	if second[0].Title != "Dune" {
+		t.Errorf("cache poisoned by caller mutation: got %q, want %q", second[0].Title, "Dune")
+	}
+}
+
 func TestAggregator_GetAuthorWorks_Fallback(t *testing.T) {
 	// Primary does not implement worksProvider → falls back to SearchBooks.
 	books := []models.Book{{Title: "Foundation"}, {Title: "Foundation and Empire"}}

--- a/internal/recommender/candidates.go
+++ b/internal/recommender/candidates.go
@@ -44,7 +44,7 @@ func GenerateSeries(
 		nextPos := state.MaxPosition + 1
 		for _, sb := range full.Books {
 			pos := parsePosition(sb.PositionInSeries)
-			if pos != nextPos || sb.Book == nil {
+			if !floatEqual(pos, nextPos) || sb.Book == nil {
 				continue
 			}
 			if profile.OwnedForeignIDs[sb.Book.ForeignID] {
@@ -64,7 +64,7 @@ func GenerateSeries(
 		for _, missingPos := range state.MissingPositions {
 			for _, sb := range full.Books {
 				pos := parsePosition(sb.PositionInSeries)
-				if pos != missingPos || sb.Book == nil {
+				if !floatEqual(pos, missingPos) || sb.Book == nil {
 					continue
 				}
 				if profile.OwnedForeignIDs[sb.Book.ForeignID] {

--- a/internal/recommender/profile.go
+++ b/internal/recommender/profile.go
@@ -183,6 +183,16 @@ func medianReleaseYear(books []models.Book) int {
 
 // parsePosition converts a series position string like "1", "2.5" to float64.
 // Returns 0 for empty or unparseable values.
+// positionEpsilon is the tolerance for comparing parsed series positions.
+// Positions are small integers or short decimals (e.g. "2.5"), so any pair
+// closer than this is treated as equal — avoiding exact float64 == pitfalls.
+const positionEpsilon = 1e-9
+
+// floatEqual reports whether a and b are within positionEpsilon of each other.
+func floatEqual(a, b float64) bool {
+	return math.Abs(a-b) < positionEpsilon
+}
+
 func parsePosition(s string) float64 {
 	s = strings.TrimSpace(s)
 	if s == "" {

--- a/internal/recommender/scorer.go
+++ b/internal/recommender/scorer.go
@@ -122,13 +122,13 @@ func seriesScore(c models.RecommendationCandidate, p *UserProfile) float64 {
 	}
 
 	// Next-in-sequence: one position after the user's max.
-	if pos == state.MaxPosition+1 {
+	if floatEqual(pos, state.MaxPosition+1) {
 		return 1.0
 	}
 
 	// Fills a gap in the user's collection.
 	for _, missing := range state.MissingPositions {
-		if pos == missing {
+		if floatEqual(pos, missing) {
 			return 0.5
 		}
 	}

--- a/internal/recommender/scorer_test.go
+++ b/internal/recommender/scorer_test.go
@@ -179,6 +179,37 @@ func TestSeriesScore(t *testing.T) {
 	}
 }
 
+func TestFloatEqual(t *testing.T) {
+	// 0.1+0.2 != 0.3 under exact float64 ==, but should compare equal here.
+	if !floatEqual(0.1+0.2, 0.3) {
+		t.Errorf("floatEqual(0.1+0.2, 0.3) should be true (epsilon compare)")
+	}
+	if floatEqual(2.5, 3.0) {
+		t.Errorf("floatEqual(2.5, 3.0) should be false")
+	}
+	if !floatEqual(4, 4) {
+		t.Errorf("floatEqual(4, 4) should be true")
+	}
+}
+
+func TestSeriesScore_FractionalPositions(t *testing.T) {
+	sid := int64(7)
+	// MaxPosition 2.5 -> next-in-sequence is 3.5; a fractional missing entry at
+	// 1.5 should also be detected. Exact float == on parsed positions is
+	// brittle; the epsilon compare must still match.
+	profile := &UserProfile{
+		SeriesState: map[int64]SeriesState{
+			7: {SeriesID: 7, MaxPosition: 2.5, MissingPositions: []float64{1.5}},
+		},
+	}
+	if got := seriesScore(models.RecommendationCandidate{SeriesID: &sid, SeriesPos: "3.5"}, profile); got != 1.0 {
+		t.Errorf("fractional next-in-sequence: got %v, want 1.0", got)
+	}
+	if got := seriesScore(models.RecommendationCandidate{SeriesID: &sid, SeriesPos: "1.5"}, profile); got != 0.5 {
+		t.Errorf("fractional gap fill: got %v, want 0.5", got)
+	}
+}
+
 func TestCommunityScore(t *testing.T) {
 	// No ratings: should be 0
 	c := models.RecommendationCandidate{Rating: 0, RatingsCount: 0}

--- a/internal/textutil/jarowinkler.go
+++ b/internal/textutil/jarowinkler.go
@@ -7,7 +7,10 @@ func JaroWinkler(s, t string) float64 {
 	if s == t {
 		return 1
 	}
-	sl, tl := len(s), len(t)
+	// Index over runes, not bytes: multibyte UTF-8 (CJK, accented Latin) must
+	// be compared codepoint-by-codepoint or the scores are meaningless.
+	sr, tr := []rune(s), []rune(t)
+	sl, tl := len(sr), len(tr)
 	if sl == 0 || tl == 0 {
 		return 0
 	}
@@ -37,7 +40,7 @@ func JaroWinkler(s, t string) float64 {
 		lo := max(0, i-matchWindow)
 		hi := min(tl, i+matchWindow+1)
 		for j := lo; j < hi; j++ {
-			if tMatch[j] || s[i] != t[j] {
+			if tMatch[j] || sr[i] != tr[j] {
 				continue
 			}
 			sMatch[i] = true
@@ -50,7 +53,7 @@ func JaroWinkler(s, t string) float64 {
 		return 0
 	}
 
-	tr := 0
+	transpositions := 0
 	k := 0
 	for i := 0; i < sl; i++ {
 		if !sMatch[i] {
@@ -59,17 +62,17 @@ func JaroWinkler(s, t string) float64 {
 		for !tMatch[k] {
 			k++
 		}
-		if s[i] != t[k] {
-			tr++
+		if sr[i] != tr[k] {
+			transpositions++
 		}
 		k++
 	}
 
-	jaro := (float64(m)/float64(sl) + float64(m)/float64(tl) + float64(m-tr/2)/float64(m)) / 3
+	jaro := (float64(m)/float64(sl) + float64(m)/float64(tl) + float64(m-transpositions/2)/float64(m)) / 3
 
 	prefix := 0
 	for i := 0; i < 4 && i < sl && i < tl; i++ {
-		if s[i] != t[i] {
+		if sr[i] != tr[i] {
 			break
 		}
 		prefix++

--- a/internal/textutil/jarowinkler_test.go
+++ b/internal/textutil/jarowinkler_test.go
@@ -40,3 +40,41 @@ func TestJaroWinklerSymmetric(t *testing.T) {
 		t.Fatalf("JaroWinkler should be symmetric for %q and %q", a, b)
 	}
 }
+
+// TestJaroWinklerUnicode verifies rune-based (not byte-based) comparison:
+// multibyte UTF-8 must score sensibly. Byte-indexing produced meaningless
+// scores for CJK and accented Latin.
+func TestJaroWinklerUnicode(t *testing.T) {
+	cases := []struct {
+		name      string
+		s         string
+		t         string
+		want      float64
+		delta     float64
+		wantAbove float64 // when >0, assert score strictly exceeds this instead of want±delta
+	}{
+		// Identical multibyte strings must score exactly 1.0.
+		{name: "cjk_identical", s: "村上春樹", t: "村上春樹", want: 1, delta: 0},
+		{name: "accented_identical", s: "gabriel garcía márquez", t: "gabriel garcía márquez", want: 1, delta: 0},
+		// Near-identical accented names must score high (single accent change).
+		{name: "accented_near", s: "garcía", t: "garcia", wantAbove: 0.9},
+		// Near-identical CJK (one differing trailing character) must score high.
+		{name: "cjk_near", s: "村上春樹", t: "村上春木", wantAbove: 0.8},
+		// A multibyte string with a single accent swap scores high, not 0.
+		{name: "accented_swap", s: "café", t: "cafë", wantAbove: 0.8},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := JaroWinkler(tc.s, tc.t)
+			if tc.wantAbove > 0 {
+				if got <= tc.wantAbove {
+					t.Fatalf("JaroWinkler(%q,%q) = %.4f, want > %.4f", tc.s, tc.t, got, tc.wantAbove)
+				}
+				return
+			}
+			if math.Abs(got-tc.want) > tc.delta {
+				t.Fatalf("JaroWinkler(%q,%q) = %.4f, want %.4f ±%.4f", tc.s, tc.t, got, tc.want, tc.delta)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Code sweep of 6 independently-verified medium/low correctness findings from #948. Each verified against current code and fixed.

1. **Cache aliasing** — `internal/metadata/aggregator_author_works.go`: `GetAuthorWorks` / `GetAuthorWorksForAuthor` returned and cached the live `[]models.Book` slice. Now clone on both set and hit (reusing the existing `cloneBooks` helper), matching `rawPrimaryAuthorWorks` so a caller mutating the result can't poison the shared cache.

2. **DNS-rebind TOCTOU** — `internal/api/imageproxy.go`: the image-proxy client validated the URL up front and re-validated redirects but had no SSRF-revalidating dialer. New `imageProxyTransport()` starts from `httpsec.DefaultProxyTransport()`, clones it (so the shared transport is not mutated, preserving #987 outbound-proxy support), and sets `DialContext = httpsec.NewDialContext(httpsec.PolicyStrict)`.
   **Caveat:** when an outbound proxy IS configured, the connection is dialled to the proxy address, so the dial-time re-check sees the proxy rather than the upstream host (the same documented limitation as the newznab client). For the default no-proxy case this fully closes the rebind window.

3. **Float equality** — `internal/recommender/scorer.go` and `internal/recommender/candidates.go`: exact `float64 ==` on parsed series positions missed fractional entries (e.g. "2.5"). Added `positionEpsilon` (1e-9) and a `floatEqual(a,b)` helper in `profile.go`, applied at all four comparison sites.

4. **Jaro-Winkler over bytes** — `internal/textutil/jarowinkler.go`: all indexing was byte-based, producing meaningless scores for multibyte UTF-8 (CJK, accented Latin). Converted both inputs to `[]rune` once at the top and index over runes throughout (match window, transpositions, common prefix); algorithm otherwise unchanged.

5. **Data race** — `internal/calibre/syncer.go`: the final `slog.Info(...)` in `run()` read `s.progress` without the lock while `setProgress` writes under lock and the HTTP poll reads under lock. Now snapshots via the locked `Progress()` getter before logging. Verified with `go test -race ./internal/calibre/`.

6. **Password-length inconsistency** — `internal/api/auth_users.go`: admin `Create` enforced only non-empty; `ResetPassword` enforced an 8-char minimum. Extracted `minPasswordLength`/`validatePassword` and applied it in both handlers (no duplicated literal).

Tests added/extended for findings 1, 3, 4, and 6.

### Verification
- `go build ./...`, `go vet`, `gofmt -l` clean on all changed files
- `go test` green on metadata, api, recommender, textutil; `go test -race` green on calibre
- `golangci-lint run` on the 5 changed packages: 0 issues

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)