### PR TITLE
fix(hardcover): query book_series, not featured_series, on the books type

### DIFF
--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -566,39 +566,40 @@ type hcContribution struct {
 }
 
 type hcBook struct {
-	ID                     int                `json:"id"`
-	Title                  string             `json:"title"`
-	Subtitle               string             `json:"subtitle"`
-	Slug                   string             `json:"slug"`
-	Description            string             `json:"description"`
-	Image                  *hcImage           `json:"image"`
-	ReleaseYear            *int               `json:"release_year"`
-	RatingsCount           int                `json:"ratings_count"`
-	Rating                 float64            `json:"rating"`
-	UsersCount             int                `json:"users_count"`
-	Genres                 []string           `json:"genres"`
-	ISBNs                  []string           `json:"isbns"`
-	HasAudiobook           bool               `json:"has_audiobook"`
-	HasEbook               bool               `json:"has_ebook"`
-	AudioSeconds           *int               `json:"audio_seconds"`
-	DefaultAudioEditionID  *int               `json:"default_audio_edition_id"`
-	DefaultEbookEditionID  *int               `json:"default_ebook_edition_id"`
-	Language               *hcLanguage        `json:"language"`
-	Contributions          []hcContribution   `json:"contributions"`
-	AuthorNames            []string           `json:"author_names"`
-	FeaturedSeries         *hcFeaturedSeries  `json:"featured_series"`
-	FeaturedSeriesID       *int               `json:"featured_series_id"`
-	FeaturedSeriesPosition any                `json:"featured_series_position"`
-	SeriesRefs             []models.SeriesRef `json:"-"`
+	ID                    int                `json:"id"`
+	Title                 string             `json:"title"`
+	Subtitle              string             `json:"subtitle"`
+	Slug                  string             `json:"slug"`
+	Description           string             `json:"description"`
+	Image                 *hcImage           `json:"image"`
+	ReleaseYear           *int               `json:"release_year"`
+	RatingsCount          int                `json:"ratings_count"`
+	Rating                float64            `json:"rating"`
+	UsersCount            int                `json:"users_count"`
+	Genres                []string           `json:"genres"`
+	ISBNs                 []string           `json:"isbns"`
+	HasAudiobook          bool               `json:"has_audiobook"`
+	HasEbook              bool               `json:"has_ebook"`
+	AudioSeconds          *int               `json:"audio_seconds"`
+	DefaultAudioEditionID *int               `json:"default_audio_edition_id"`
+	DefaultEbookEditionID *int               `json:"default_ebook_edition_id"`
+	Language              *hcLanguage        `json:"language"`
+	Contributions         []hcContribution   `json:"contributions"`
+	AuthorNames           []string           `json:"author_names"`
+	BookSeries            []hcBookSeries     `json:"book_series"`
+	SeriesRefs            []models.SeriesRef `json:"-"`
 }
 
-// hcFeaturedSeries captures the Hardcover GraphQL `featured_series` relation
-// on a book — the primary series the book belongs to. Used to hydrate
-// SeriesRefs for list/shelf books, which would otherwise lose their series
-// association at import time.
-type hcFeaturedSeries struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+// hcBookSeries captures the Hardcover GraphQL `book_series` relation on a
+// book — the series it belongs to and its position. Used to hydrate
+// SeriesRefs for list/shelf books (the `books` type has no `featured_series`
+// field; that exists only on Typesense search documents).
+type hcBookSeries struct {
+	Position any `json:"position"`
+	Series   struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	} `json:"series"`
 }
 
 type hcEdition struct {
@@ -978,32 +979,24 @@ func searchBool(value any) bool {
 	}
 }
 
-// featuredSeriesRefs builds SeriesRefs from the GraphQL featured_series fields
-// on a book. Mirrors searchSeriesRefs (Typesense) so list/shelf imports get
-// the same primary-series linking the search path already provides.
-func featuredSeriesRefs(series *hcFeaturedSeries, idValue *int, positionValue any) []models.SeriesRef {
-	var (
-		title string
-		id    string
-	)
-	if series != nil {
-		title = strings.TrimSpace(series.Name)
-		if series.ID > 0 {
-			id = strconv.Itoa(series.ID)
+// bookSeriesRefs builds SeriesRefs from the GraphQL book_series relation on a
+// book. Mirrors searchSeriesRefs (Typesense) so list/shelf imports get the
+// same series linking the search path provides. book_series is ordered by
+// position asc, so the first valid entry is the primary series.
+func bookSeriesRefs(bs []hcBookSeries) []models.SeriesRef {
+	for _, s := range bs {
+		title := strings.TrimSpace(s.Series.Name)
+		if title == "" || s.Series.ID <= 0 {
+			continue
 		}
+		return []models.SeriesRef{{
+			ForeignID: seriesIDPrefix + strconv.Itoa(s.Series.ID),
+			Title:     title,
+			Position:  formatSeriesPosition(s.Position),
+			Primary:   true,
+		}}
 	}
-	if id == "" && idValue != nil && *idValue > 0 {
-		id = strconv.Itoa(*idValue)
-	}
-	if title == "" || id == "" {
-		return nil
-	}
-	return []models.SeriesRef{{
-		ForeignID: seriesIDPrefix + id,
-		Title:     title,
-		Position:  formatSeriesPosition(positionValue),
-		Primary:   true,
-	}}
+	return nil
 }
 
 func searchSeriesRefs(seriesValue, idValue, positionValue any) []models.SeriesRef {
@@ -1111,7 +1104,7 @@ func (c *Client) toBook(b hcBook) models.Book {
 	}
 	seriesRefs := b.SeriesRefs
 	if len(seriesRefs) == 0 {
-		seriesRefs = featuredSeriesRefs(b.FeaturedSeries, b.FeaturedSeriesID, b.FeaturedSeriesPosition)
+		seriesRefs = bookSeriesRefs(b.BookSeries)
 	}
 	bk := models.Book{
 		ForeignID:        idPrefix + slug,

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -2076,7 +2076,7 @@ func TestGetListBooks_PositiveIDPaginates(t *testing.T) {
 }
 
 // TestGetListBooks_PositiveIDPopulatesSeriesRefs covers issue #805: the
-// list_books GraphQL query now asks for featured_series and the parsed book
+// list_books GraphQL query asks for book_series and the parsed book
 // carries those forward as SeriesRefs so the list syncer can persist them.
 func TestGetListBooks_PositiveIDPopulatesSeriesRefs(t *testing.T) {
 	var gotQuery string
@@ -2085,7 +2085,7 @@ func TestGetListBooks_PositiveIDPopulatesSeriesRefs(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(body, &req)
 		gotQuery = req.Query
-		resp := `{"data":{"list_books":[{"book":{"id":99,"title":"Dune","slug":"dune","featured_series":{"id":17,"name":"Dune Chronicles"},"featured_series_id":17,"featured_series_position":1,"contributions":[{"author":{"id":1,"name":"Frank Herbert","slug":"frank-herbert"}}]}}]}}`
+		resp := `{"data":{"list_books":[{"book":{"id":99,"title":"Dune","slug":"dune","book_series":[{"position":1,"series":{"id":17,"name":"Dune Chronicles"}}],"contributions":[{"author":{"id":1,"name":"Frank Herbert","slug":"frank-herbert"}}]}}]}}`
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(resp)),
@@ -2098,11 +2098,8 @@ func TestGetListBooks_PositiveIDPopulatesSeriesRefs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetListBooks: %v", err)
 	}
-	if !strings.Contains(gotQuery, "featured_series { id name }") {
-		t.Errorf("query missing featured_series selection: %q", gotQuery)
-	}
-	if !strings.Contains(gotQuery, "featured_series_position") {
-		t.Errorf("query missing featured_series_position: %q", gotQuery)
+	if !strings.Contains(gotQuery, "book_series(order_by: { position: asc })") {
+		t.Errorf("query missing book_series selection: %q", gotQuery)
 	}
 	if len(books) != 1 {
 		t.Fatalf("books len = %d, want 1", len(books))
@@ -2125,7 +2122,7 @@ func TestGetListBooks_BuiltinShelfPopulatesSeriesRefs(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(body, &req)
 		gotQuery = req.Query
-		resp := `{"data":{"me":[{"user_books":[{"book":{"id":99,"title":"The Way of Kings","slug":"the-way-of-kings","featured_series":{"id":103,"name":"The Stormlight Archive"},"featured_series_id":103,"featured_series_position":1,"contributions":[{"author":{"id":2,"name":"Brandon Sanderson","slug":"brandon-sanderson"}}]}}]}]}}`
+		resp := `{"data":{"me":[{"user_books":[{"book":{"id":99,"title":"The Way of Kings","slug":"the-way-of-kings","book_series":[{"position":1,"series":{"id":103,"name":"The Stormlight Archive"}}],"contributions":[{"author":{"id":2,"name":"Brandon Sanderson","slug":"brandon-sanderson"}}]}}]}]}}`
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader(resp)),
@@ -2138,8 +2135,8 @@ func TestGetListBooks_BuiltinShelfPopulatesSeriesRefs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetListBooks shelf: %v", err)
 	}
-	if !strings.Contains(gotQuery, "featured_series { id name }") {
-		t.Errorf("shelf query missing featured_series selection: %q", gotQuery)
+	if !strings.Contains(gotQuery, "book_series(order_by: { position: asc })") {
+		t.Errorf("shelf query missing book_series selection: %q", gotQuery)
 	}
 	if len(books) != 1 || len(books[0].SeriesRefs) != 1 {
 		t.Fatalf("books = %+v", books)
@@ -2150,27 +2147,52 @@ func TestGetListBooks_BuiltinShelfPopulatesSeriesRefs(t *testing.T) {
 	}
 }
 
-// TestFeaturedSeriesRefs_FallbackAndEdgeCases exercises featuredSeriesRefs
-// directly so the conversion rules don't drift silently.
-func TestFeaturedSeriesRefs_FallbackAndEdgeCases(t *testing.T) {
-	// Title from relation, id falls back to scalar featured_series_id.
-	scalarID := 55
-	refs := featuredSeriesRefs(&hcFeaturedSeries{ID: 0, Name: "Foundation"}, &scalarID, 2)
-	if len(refs) != 1 || refs[0].ForeignID != "hc-series:55" || refs[0].Title != "Foundation" || refs[0].Position != "2" {
-		t.Errorf("scalar id fallback: %+v", refs)
+// TestBookSeriesRefs_EdgeCases exercises bookSeriesRefs directly so the
+// conversion rules don't drift silently.
+func TestBookSeriesRefs_EdgeCases(t *testing.T) {
+	// Valid entry -> a primary SeriesRef with prefixed foreign id.
+	refs := bookSeriesRefs([]hcBookSeries{{Position: 2, Series: struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}{ID: 55, Name: "Foundation"}}})
+	if len(refs) != 1 || refs[0].ForeignID != "hc-series:55" || refs[0].Title != "Foundation" || refs[0].Position != "2" || !refs[0].Primary {
+		t.Errorf("valid entry: %+v", refs)
 	}
 
-	// Missing id everywhere → drop the ref (we cannot link without a stable
-	// foreign id).
-	if got := featuredSeriesRefs(&hcFeaturedSeries{Name: "Anon"}, nil, nil); got != nil {
+	// First valid entry wins (book_series is ordered by position asc).
+	multi := bookSeriesRefs([]hcBookSeries{
+		{Position: 1, Series: struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		}{ID: 7, Name: "Primary"}},
+		{Position: 3, Series: struct {
+			ID   int    `json:"id"`
+			Name string `json:"name"`
+		}{ID: 9, Name: "Secondary"}},
+	})
+	if len(multi) != 1 || multi[0].ForeignID != "hc-series:7" || !multi[0].Primary {
+		t.Errorf("first entry should win: %+v", multi)
+	}
+
+	// Missing id -> drop (cannot link without a stable foreign id).
+	if got := bookSeriesRefs([]hcBookSeries{{Series: struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}{ID: 0, Name: "Anon"}}}); got != nil {
 		t.Errorf("missing id should drop ref, got %+v", got)
 	}
 
-	// Nil relation, but scalar id alone (no title) → drop: a series with no
-	// name is unusable upstream.
-	zero := 0
-	if got := featuredSeriesRefs(nil, &zero, nil); got != nil {
-		t.Errorf("zero id should drop ref, got %+v", got)
+	// Missing name -> drop (unusable upstream).
+	if got := bookSeriesRefs([]hcBookSeries{{Series: struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}{ID: 12, Name: ""}}}); got != nil {
+		t.Errorf("missing name should drop ref, got %+v", got)
+	}
+
+	// Empty -> nil.
+	if got := bookSeriesRefs(nil); got != nil {
+		t.Errorf("empty should be nil, got %+v", got)
 	}
 }
 

--- a/internal/metadata/hardcover/lists.go
+++ b/internal/metadata/hardcover/lists.go
@@ -239,9 +239,10 @@ func (c *Client) GetListBooks(ctx context.Context, listID int) ([]models.Book, e
 				rating
 				default_audio_edition_id
 				default_ebook_edition_id
-				featured_series { id name }
-				featured_series_id
-				featured_series_position
+				book_series(order_by: { position: asc }) {
+					position
+					series { id name }
+				}
 				contributions {
 					author { id name slug }
 				}
@@ -295,9 +296,10 @@ func (c *Client) getShelfBooks(ctx context.Context, statusID int) ([]models.Book
 					rating
 					default_audio_edition_id
 					default_ebook_edition_id
-					featured_series { id name }
-					featured_series_id
-					featured_series_position
+					book_series(order_by: { position: asc }) {
+						position
+						series { id name }
+					}
 					contributions {
 						author { id name slug }
 					}


### PR DESCRIPTION
Hey team,

Just installed Bindery and really enjoy it! I found a glitch around Hardcover where importing a list (my "Want to read") failed immediately with:

```
{"error":"get list books: hardcover get shelf books: GraphQL: field 'featured_series' not found in type: 'books' (validation-failed)"}
```

`featured_series` is a real Hardcover field it's but only on search result docs returned by the `search` query — a different schema from the `books` table type. The search path in this repo is correct and unchanged; only the list/shelf path was selecting a search-document field on the table type.

## Verification (live API, `api.hardcover.app/v1/graphql`)

- On the `books` type, `featured_series` → `field 'featured_series' not found in type: 'books'`.
- `book_series { position series { id name } }` on the `books` type → resolves (`[]` when a book has no series).
- Introspection of the `books` type: `featured_series` absent, `book_series` present.

Full disclosure, I used AI to spin-up this PR. However, I was able to verify locally and it's all correctly working now, I was able to import my "to read" Hardcover list.
