### PR TITLE
ci: add fuzz targets, enforce coverage, dedupe security scanners

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,13 +2,17 @@ coverage:
   status:
     project:
       default:
+        # Block when overall coverage drops more than 1% vs the base — catches
+        # silent erosion. (Was informational, so it never enforced anything.)
         target: auto
         threshold: 1%
-        informational: true
+        informational: false
     patch:
       default:
-        target: auto
-        informational: true
+        # New/changed lines must be >=70% covered. Patch only measures the diff,
+        # so doc-/config-only PRs (no measurable lines) pass automatically.
+        target: 70%
+        informational: false
 
 comment:
   layout: "reach, diff, flags, files"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,40 +36,12 @@ concurrency:
 
 jobs:
   # ── Go SAST: gosec only — golangci-lint and govulncheck run in ci.yml lint ──
-  sast-go:
-    name: SAST – Go
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
-        with:
-          go-version: "1.25.11"
-          cache: true
-
-      - name: gosec (SARIF)
-        uses: securego/gosec@5f4eec95fa28ce5dc6cf555de8c242cb57545f01 # master
-        with:
-          # G402 (TLS/cookie insecure) excluded: cookie Secure flag is dynamic (auto-detected
-          # from r.TLS and X-Forwarded-Proto, overridable via BINDERY_COOKIE_SECURE) and gosec
-          # only accepts literal `true`. Safety is enforced by cookie config logic + docs.
-          args: '-no-fail -fmt sarif -out gosec.sarif -exclude=G101,G402 ./...'
-
-      - name: Upload gosec SARIF
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
-        if: always()
-        with:
-          sarif_file: gosec.sarif
-          category: gosec
+  # gosec runs as part of golangci-lint in ci.yml (blocking, on every push/PR),
+  # so a second standalone gosec here was redundant — and worse, it was
+  # advisory-only (-no-fail) with a *different* exclude set (G101,G402) that
+  # suppressed hardcoded-credential and TLS checks the golangci run enforces.
+  # Removed; golangci's gosec is the single, stricter source of truth. CodeQL
+  # (codeql.yml) still feeds the Security tab and covers Scorecard's SAST signal.
 
   # ── Frontend SAST: Semgrep + npm audit + ESLint security ───────────────────
   sast-frontend:
@@ -230,7 +202,7 @@ jobs:
           sarif_file: checkov.sarif
           category: checkov
 
-  # ── Container scan: Trivy + Grype + Syft SBOM ────────────────────────────
+  # ── Container scan: Grype + Syft SBOM ────────────────────────────────────
   container-scan:
     name: Container Scan
     runs-on: ubuntu-latest
@@ -257,22 +229,10 @@ jobs:
             -t bindery:scan \
             .
 
-      - name: Trivy vulnerability scan (SARIF)
-        uses: aquasecurity/trivy-action@1994662b5555670344cd84d29ed3cad4bd26f31c # master
-        with:
-          image-ref: bindery:scan
-          format: sarif
-          output: trivy.sarif
-          severity: CRITICAL,HIGH
-          exit-code: '1'
-
-      - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
-        if: always()
-        with:
-          sarif_file: trivy.sarif
-          category: trivy
-
+      # Grype is the single image CVE scanner (it pairs with the Syft SBOM
+      # below). Trivy was removed: it overlapped Grype ~90% on image-CVE
+      # coverage, doubling scan time and Security-tab noise for little marginal
+      # signal. Grype's fail-build gate keeps CRITICAL/HIGH CVEs blocking.
       - name: Grype vulnerability scan (SARIF)
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         id: grype
@@ -399,7 +359,6 @@ jobs:
     name: Security Summary
     runs-on: ubuntu-latest
     needs:
-      - sast-go
       - sast-frontend
       - secrets-scan
       - iac-scan
@@ -420,11 +379,10 @@ jobs:
 
           | Job | Status |
           |-----|--------|
-          | SAST – Go (gosec) | ${{ needs.sast-go.result }} |
           | SAST – Frontend (Semgrep, npm audit, ESLint) | ${{ needs.sast-frontend.result }} |
           | Secrets Scan (Gitleaks) | ${{ needs.secrets-scan.result }} |
           | IaC Scan (Hadolint, Helm lint, Checkov) | ${{ needs.iac-scan.result }} |
-          | Container Scan (Trivy, Grype, Syft SBOM) | ${{ needs.container-scan.result }} |
+          | Container Scan (Grype, Syft SBOM) | ${{ needs.container-scan.result }} |
           | DAST – ZAP Baseline | ${{ needs.dast-api.result }} |
           | Helm Policy Tests | ${{ needs.policy-test.result }} |
 

--- a/internal/api/path_safety_fuzz_test.go
+++ b/internal/api/path_safety_fuzz_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FuzzContainsUnderRoot exercises the lexical containment primitive that backs
+// the delete- and import-path safety checks. It must never panic, and it must
+// never report containment for a path that actually escapes the root (a false
+// "contained" would let a delete/import operate outside the library). The
+// function is pure (no filesystem access), so fuzzing it is hermetic.
+func FuzzContainsUnderRoot(f *testing.F) {
+	seeds := [][2]string{
+		{"/lib/Author/book.epub", "/lib"},
+		{"/lib", "/lib"},
+		{"/etc/passwd", "/lib"},
+		{"/lib/../etc/passwd", "/lib"},
+		{"Author/book.epub", "/lib"},
+		{"", ""},
+		{"/lib/a/b/c", "/lib/a"},
+		{"/libother/x", "/lib"},
+		{"/lib/", "/lib"},
+		{"\x00", "/lib"},
+	}
+	for _, s := range seeds {
+		f.Add(s[0], s[1])
+	}
+
+	f.Fuzz(func(t *testing.T, p, root string) {
+		got := containsUnderRoot(p, root) // must not panic
+
+		// Invariant: if it claims containment, filepath.Rel(root, p) must not
+		// climb out of root (no ".." prefix) — otherwise the "containment"
+		// control is unsound.
+		if got {
+			rel, err := filepath.Rel(root, p)
+			if err != nil {
+				t.Fatalf("containsUnderRoot(%q,%q)=true but filepath.Rel errored: %v", p, root, err)
+			}
+			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				t.Fatalf("containsUnderRoot(%q,%q)=true but rel %q escapes root", p, root, rel)
+			}
+		}
+	})
+}

--- a/internal/httpsec/ssrf_fuzz_test.go
+++ b/internal/httpsec/ssrf_fuzz_test.go
@@ -1,0 +1,58 @@
+package httpsec
+
+import (
+	"net"
+	"testing"
+)
+
+// fuzzResolver is a hermetic stub so the fuzzer never touches DNS. It returns a
+// mix of address families per call so the IP-range checks (loopback, RFC1918,
+// link-local, cloud-metadata, ULA) are all exercised regardless of the hostname.
+type fuzzResolver struct{}
+
+func (fuzzResolver) LookupIP(host string) ([]net.IP, error) {
+	return []net.IP{
+		net.ParseIP("127.0.0.1"),
+		net.ParseIP("10.0.0.1"),
+		net.ParseIP("169.254.169.254"),
+		net.ParseIP("::1"),
+		net.ParseIP("8.8.8.8"),
+	}, nil
+}
+
+// FuzzValidateOutboundURL exercises the SSRF guard with arbitrary URL strings
+// across every policy. ValidateOutboundURL runs on operator- and (for some
+// callers) attacker-influenced URLs, so a panic in it is a denial-of-service on
+// the request path. It must reject or accept, never crash. A hermetic resolver
+// keeps the fuzzer off the network. Doubles as an OpenSSF Scorecard fuzz target.
+func FuzzValidateOutboundURL(f *testing.F) {
+	seeds := []string{
+		"",
+		"http://127.0.0.1:50155",
+		"https://example.com/path?q=1",
+		"http://[::1]:8080",
+		"http://169.254.169.254/latest/meta-data/",
+		"ftp://example.com",
+		"http://10.0.0.1",
+		"http://user:pass@host:99999",
+		"http://%zz",
+		"http://example.com:not-a-port",
+		"https://[fe80::1]/x",
+		"http://localhost",
+		"\x00\x01\x02",
+		"http://" + string(rune(0)) + ".com",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	policies := []Policy{PolicyStrict, PolicyLAN, PolicyLANLoopback}
+	r := fuzzResolver{}
+	f.Fuzz(func(t *testing.T, raw string) {
+		for _, p := range policies {
+			// Must never panic. The boolean result is irrelevant to the
+			// invariant — we only assert it returns.
+			_ = validateWithResolver(raw, p, r)
+		}
+	})
+}

--- a/internal/indexer/newznab/parser_fuzz_test.go
+++ b/internal/indexer/newznab/parser_fuzz_test.go
@@ -1,0 +1,43 @@
+package newznab
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+// FuzzParseResults runs the untrusted-indexer-response path over arbitrary
+// bytes: the Newznab/Torznab error sniffer and the RSS→SearchResult decoder.
+// Indexer responses are remote and attacker-influenceable (a hostile or buggy
+// indexer), so neither parser may panic on any input. New() does not dial and
+// signDownloadURL only builds strings, so the target is hermetic.
+func FuzzParseResults(f *testing.F) {
+	seeds := []string{
+		"",
+		`<?xml version="1.0"?><error code="100" description="Incorrect user credentials"/>`,
+		`<rss><channel><item><title>A Book</title><enclosure url="http://x/y.nzb" length="123"/>` +
+			`<newznab:attr name="size" value="999"/></item></channel></rss>`,
+		`<rss><channel></channel></rss>`,
+		`not xml at all`,
+		`<rss><channel><item><enclosure length="notanumber"/></item></channel></rss>`,
+		`<error`,
+		"\x00\x01\x02",
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	c := New("http://indexer.invalid", "apikey")
+	f.Fuzz(func(t *testing.T, body []byte) {
+		// 1) Error sniffer must never panic.
+		_ = parseNewznabError(body)
+
+		// 2) RSS decode + result mapping must never panic. A decode error is a
+		// legitimate, handled outcome (non-RSS body); only the mapping of a
+		// successfully-decoded feed is under test.
+		var resp rssResponse
+		if err := xml.Unmarshal(body, &resp); err != nil {
+			return
+		}
+		_ = c.parseResults(resp.Channel.Items)
+	})
+}

--- a/internal/migrate/csv_fuzz_test.go
+++ b/internal/migrate/csv_fuzz_test.go
@@ -1,0 +1,41 @@
+package migrate
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzParseCSVRows runs the CSV importer's row parser over arbitrary input.
+// CSV uploads are user-supplied and parsed before any validation, so the parser
+// must never panic and must never return more rows than the input could contain.
+// rowFromFields is exercised through the same path.
+func FuzzParseCSVRows(f *testing.F) {
+	seeds := []string{
+		"",
+		"name\nBrandon Sanderson\n",
+		"name,foreign_id,searchOnAdd\nAuthor,OL123A,true\n",
+		"Andy Weir,,\n",
+		"a,b,c,d,e,f,g\n",
+		"\"unterminated quote\nNextLine,x",
+		"name\n\"\"\"\"\"\"\n",
+		strings.Repeat("a,b,c\n", 200),
+		"\x00\x01,\x02\n",
+		"héllo,wörld\n",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, data string) {
+		rows, err := parseCSVRows(strings.NewReader(data)) // must not panic
+		if err != nil {
+			return // malformed CSV is a legitimate, handled outcome
+		}
+		// A parsed row count can't exceed the number of newlines + 1; anything
+		// more signals a construction bug.
+		maxRows := strings.Count(data, "\n") + 1
+		if len(rows) > maxRows {
+			t.Fatalf("parsed %d rows from input with at most %d lines", len(rows), maxRows)
+		}
+	})
+}


### PR DESCRIPTION
Three CI/testing-hardening changes from the CI review (items a/b/c).

## (a) Fuzz the untrusted-input & security surface
Native Go fuzz targets, each **hermetic** (no network/filesystem) so they run as seed-tests in the normal `test` job and double as OpenSSF Scorecard Fuzzing signals (complements #885):
- `httpsec.FuzzValidateOutboundURL` — the SSRF guard, via the injectable resolver stub (no DNS), across all three policies.
- `api.FuzzContainsUnderRoot` — the path-traversal containment primitive (pure); asserts a "contained" verdict never corresponds to a `..`-escaping `filepath.Rel`.
- `migrate.FuzzParseCSVRows` — the CSV importer parser.
- `newznab.FuzzParseResults` — the indexer error sniffer + RSS→`SearchResult` decode (attacker-influenceable indexer responses).

3-second live `-fuzz` bursts on the SSRF + path targets (236k + 51k execs) found no crashes.

## (b) Make Codecov actually enforce
`.codecov.yml` had **every** status `informational: true`, so coverage could silently erode. Flipped to blocking: project blocks on a >1% drop vs base; patch requires new/changed lines ≥70% covered (doc-/config-only PRs have no measured lines and pass).

## (c) Remove redundant scanners
- **Standalone gosec dropped** from `security.yml`. It was advisory (`-no-fail`) *and* used a different, weaker exclude set (`G101,G402` — suppressing hardcoded-credential and TLS checks) than golangci-lint's gosec. golangci's gosec (in `ci.yml`, **blocking**, every push/PR) is the stricter single source of truth; CodeQL still populates the Security tab and covers Scorecard's SAST signal.
- **Trivy dropped** from `container-scan` — ~90% overlap with Grype on image CVEs, doubling scan time/noise. Grype (with `fail-build` gating CRITICAL/HIGH) + Syft SBOM remain. Summary `needs` + table updated.

## Verify
YAML parses; build/vet/gofmt/lint clean on all touched Go packages; `go test` green on httpsec/api/migrate/newznab. No dangling `sast-go`/Trivy references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)