### PR TITLE
docs: contributor-experience improvements (make check, changelog fragments, CoC)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,10 +6,13 @@
 
 - [ ] Tests added or updated
 - [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed
-- [ ] `CHANGELOG.md` `[Unreleased]` section updated
+- [ ] Added a changelog fragment under `changelog.d/` (not an edit to `CHANGELOG.md`) — see [changelog.d/README.md](../changelog.d/README.md)
 - [ ] Wiki pages updated if user-facing behaviour changed
 
 ## Test plan
 
-- [ ] `go test ./cmd/... ./internal/...`
-- [ ] `cd web && npm run build`
+- [ ] `make check` (or the individual `go test ./cmd/... ./internal/...` and `cd web && npm run build` steps)
+
+<!-- Only lint, validate (Go), and Security Summary are required to merge.
+     Other security scans are advisory; a red Container Scan is often a base-image
+     CVE unrelated to your change — mention it and a maintainer will confirm. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+This project adopts the **Contributor Covenant, version 2.1** as its code of
+conduct. The full text is published at:
+
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+In short: be respectful and constructive in all project spaces (GitHub issues
+and PRs, the Discord server, and any other community channel). Harassment and
+exclusionary behaviour are not tolerated.
+
+## Reporting
+
+To report unacceptable behaviour, contact a maintainer privately via the
+project Discord (a DM to a moderator/maintainer) rather than in a public thread.
+Reports are handled confidentially. Maintainers are responsible for enforcement
+and may remove, edit, or reject contributions and participants that violate this
+code.
+
+Attribution: Contributor Covenant v2.1,
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,14 @@ A failing check at any step aborts the release — no artifacts are published fr
 
 ### Running the full local check suite
 
-Mirror the CI matrix locally before opening a PR:
+The fastest path is the one-shot target, which runs the same things the gating
+CI checks run:
+
+```bash
+make check
+```
+
+That is equivalent to the commands below; run them individually while iterating:
 
 ```bash
 # Go: format, vet, lint, vuln scan, test
@@ -134,6 +141,40 @@ docker buildx build --platform linux/amd64,linux/arm64 -t bindery:local .
 # Release rehearsal (no publish, no tag)
 goreleaser release --snapshot --clean
 ```
+
+### Which checks actually block a PR
+
+Bindery runs a deliberately heavy security suite (CodeQL, Semgrep, gosec, Grype,
+Checkov, Hadolint, gitleaks, ZAP DAST, SBOM, Scorecard). **Most of those are
+advisory** — they surface findings in the Security tab but do not block merge,
+and some go red for reasons unrelated to your change (e.g. *Container Scan*
+flagging a CVE in the base image). Only **lint**, **validate (Go)**, and
+**Security Summary** are required to merge. If a non-required scan is red,
+mention it in the PR and a maintainer will tell you whether it's pre-existing.
+
+New/changed lines should be ≥70% covered (enforced on the patch via Codecov);
+doc- and config-only PRs have no measured lines and pass automatically.
+
+## Database migrations — numbering convention
+
+Schema changes are additive SQL files in `internal/db/migrations/`, applied
+idempotently at startup, named `NNN_short_description.sql`.
+
+- **Use the next free number** — look at the highest existing file and add one.
+- **The gap at `010` is intentional**; numbering follows the filename prefix, not
+  slice position. Don't fill the gap.
+- Two files sharing a number are rejected at boot (the duplicate-version guard),
+  so if your branch and `main` both added `0NN`, **renumber yours** to the next
+  free slot when you rebase.
+- Migrations are forward-only and must not destructively rewrite existing rows.
+
+## Changelog — add a fragment, don't edit CHANGELOG.md
+
+Editing the single `CHANGELOG.md` in every PR causes constant merge conflicts.
+Instead, drop a small fragment under [`changelog.d/`](changelog.d/) and leave
+`CHANGELOG.md` alone — a maintainer assembles fragments at release time. One
+fragment per PR; format and examples are in
+[`changelog.d/README.md`](changelog.d/README.md). Preview with `make changelog`.
 
 ## Pull request flow
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build dev test lint clean docker-build web-build web-dev help security helm-lint sbom smoke predeploy-smoke abs-contract
+.PHONY: build dev test lint clean docker-build web-build web-dev help security helm-lint sbom smoke predeploy-smoke abs-contract check changelog
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -36,6 +36,19 @@ lint-go: ## Run Go linter only
 
 lint-web: ## Run frontend linter only
 	cd web && npm run lint
+
+check: ## Run everything the gating CI checks run (do this before opening a PR)
+	go build ./...
+	go vet ./...
+	golangci-lint run ./...
+	go test -race ./cmd/... ./internal/...
+	cd web && npm ci && npm run typecheck && npm run lint && npm run build && npm test
+
+changelog: ## Preview the unreleased changelog assembled from changelog.d/*.md
+	@found=0; for f in changelog.d/*.md; do \
+		case "$$f" in changelog.d/README.md) continue ;; esac; \
+		[ -e "$$f" ] || continue; found=1; cat "$$f"; echo; \
+	done; [ "$$found" = 1 ] || echo "(no changelog fragments in changelog.d/)"
 
 docker-build: ## Build Docker image
 	docker build -t ghcr.io/vavallee/bindery:$(VERSION) -t ghcr.io/vavallee/bindery:latest .

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,32 @@
+# Changelog fragments
+
+To avoid every PR editing the same `CHANGELOG.md` (which causes constant merge
+conflicts), each change drops a small **fragment** here instead. A maintainer
+assembles the fragments into `CHANGELOG.md` at release time, then clears this
+directory.
+
+## How to add one
+
+Create a file named `<pr-or-issue-number>-<slug>.md` (or just a short slug if you
+don't have a number yet), e.g. `997-drop-folder.md`:
+
+```markdown
+### Added
+- **Post-import drop folder** (#941) — short, user-facing description of the change.
+```
+
+Rules:
+- Start with the Keep-a-Changelog section the entry belongs to: `### Added`,
+  `### Changed`, `### Fixed`, `### Removed`, `### Security`, or `### Deprecated`.
+- Write it the way it should read in the release notes (user-facing, not "fixed a
+  bug in scanner.go"). Reference the issue/PR number.
+- One fragment per PR. Don't touch `CHANGELOG.md` in your PR.
+
+## Preview / assemble
+
+```bash
+make changelog        # prints every fragment, grouped as you wrote them
+```
+
+At release, the maintainer merges the fragments into the new version section of
+`CHANGELOG.md` and deletes the `*.md` files here (this `README.md` stays).


### PR DESCRIPTION
Lowers the barrier to a first successful contribution. Implements the genuine gaps from the contributor-experience review.

**Reality check first:** a LICENSE (MIT, GitHub-detected), all three issue templates, a PR template, and the `good first issue` / `help wanted` labels **already exist** and `docs/ARCHITECTURE.md` is already current — so this PR does *not* re-add them. It fills only what was actually missing:

### Added / changed
- **`make check`** — one command that runs the gating CI checks locally (build, vet, golangci-lint, `go test -race`, web typecheck/lint/build/test). CONTRIBUTING listed these manually; now there's a single target.
- **`make changelog`** + **`changelog.d/`** — changelog fragments to kill the `CHANGELOG.md` merge-conflict magnet (every PR currently edits one file → constant conflicts, hand-resolved via a union driver). One fragment per PR; maintainer assembles at release. See `changelog.d/README.md`.
- **CONTRIBUTING.md** gains:
  - the **migration-numbering convention** (next free number, the intentional gap at `010`, renumber-on-collision — the trap that left #887 with a `051` clash),
  - **which checks actually gate** a PR (only `lint` / `validate (Go)` / `Security Summary`; the rest of the security suite is advisory and a red Container Scan is usually a base-image CVE),
  - the patch-coverage expectation and the `make check` / changelog-fragment flow.
- **PR template** now points at a `changelog.d/` fragment instead of editing `CHANGELOG.md`, references `make check`, and notes advisory-vs-gating checks.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (by reference).

### Deliberately not done here
- **Release-notes contributor credit** — the release body is intentionally CHANGELOG-driven (GoReleaser `changelog: disable` + `release: mode: append`); adding `.github/release.yml` would be inert without risky release-pipeline edits. Recommend opting into `gh release ... --generate-notes` as a separate, deliberate change.
- **Merge queue** — a live repo-settings change; recommend enabling it (auto-rebase/serialize would have prevented #887 going stale), but not flipping it while PRs are mid-flight.

Docs/config only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)