### PR TITLE
ci(notify): @mention the maintainer on external-PR Discord pings

### DIFF
--- a/.github/workflows/notify-external-pr-backstop.yml
+++ b/.github/workflows/notify-external-pr-backstop.yml
@@ -42,6 +42,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          MAINTAINER_ID: ${{ vars.DISCORD_MAINTAINER_ID }}
           REPO: ${{ github.repository }}
           REPO_OWNER: ${{ github.repository_owner }}
           LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '7' }}
@@ -90,12 +91,18 @@ jobs:
             if [[ "$labels" == *"bindery-notified"* ]]; then continue; fi
 
             echo "Backstop posting for PR #${num} by ${author}"
+            MENTION=""
+            if [ -n "${MAINTAINER_ID:-}" ]; then
+              MENTION="<@${MAINTAINER_ID}> "
+            fi
             PAYLOAD=$(jq -nc \
               --arg title "$title" \
               --arg url "$url" \
               --arg author "$author" \
               --arg num "$num" \
-              '{content: "📥 New PR #\($num) by **\($author)** (cron-caught): \($title)\n\($url)"}')
+              --arg mention "$MENTION" \
+              '{content: "\($mention)📥 New PR #\($num) by **\($author)** (cron-caught): \($title)\n\($url)",
+                allowed_mentions: {parse: ["users"]}}')
             HTTP=$(curl -sS -o /dev/null -w "%{http_code}" \
               -X POST -H "Content-Type: application/json" \
               -d "$PAYLOAD" "$WEBHOOK") || HTTP=000

--- a/.github/workflows/notify-external-pr.yml
+++ b/.github/workflows/notify-external-pr.yml
@@ -44,6 +44,11 @@ jobs:
         id: post
         env:
           WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          # Optional: a Discord user ID to @mention so the maintainer gets a real
+          # ping (a plain channel post is easy to miss). Stored as a repo variable
+          # rather than hardcoded so the ID isn't baked into this public file and
+          # is easy to change. Empty → no mention.
+          MAINTAINER_ID: ${{ vars.DISCORD_MAINTAINER_ID }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -59,13 +64,19 @@ jobs:
           if [ "$PR_DRAFT" = "true" ]; then
             DRAFT_TAG=" (draft)"
           fi
+          MENTION=""
+          if [ -n "$MAINTAINER_ID" ]; then
+            MENTION="<@${MAINTAINER_ID}> "
+          fi
           PAYLOAD=$(jq -nc \
             --arg title "$PR_TITLE" \
             --arg url "$PR_URL" \
             --arg author "$PR_AUTHOR" \
             --arg num "$PR_NUMBER" \
             --arg draft "$DRAFT_TAG" \
-            '{content: "📥 New PR #\($num) by **\($author)**\($draft): \($title)\n\($url)"}')
+            --arg mention "$MENTION" \
+            '{content: "\($mention)📥 New PR #\($num) by **\($author)**\($draft): \($title)\n\($url)",
+              allowed_mentions: {parse: ["users"]}}')
           HTTP=$(curl -sS -o /dev/null -w "%{http_code}" \
             -X POST -H "Content-Type: application/json" \
             -d "$PAYLOAD" "$WEBHOOK")


### PR DESCRIPTION
## What
You already have external-PR → Discord notifications (`notify-external-pr.yml` on `pull_request_target` + a cron backstop, posting via `DISCORD_RELEASE_WEBHOOK`, skipping your own PRs and bots). They just posted to the channel **without pinging anyone**, so "notify me" wasn't really happening.

This prepends a configurable `<@id>` **mention** to both the event-driven and cron-backstop messages and sets `allowed_mentions: {parse: ["users"]}` so Discord delivers the ping.

## How
- Mention ID comes from a new repo **variable** `DISCORD_MAINTAINER_ID` (already set to your Discord user ID) — kept out of this public file and easy to change. Empty → no mention (clean degradation).
- No secret/channel change: still posts via `DISCORD_RELEASE_WEBHOOK`.

## Notes
- The notification covers `opened` and `ready_for_review` (draft→ready), external authors only, bots excluded. The cron backstop catches the documented `pull_request_target` gaps (#626/#616) and dedupes via the `bindery-notified` label.
- The webhook posts to whatever channel `DISCORD_RELEASE_WEBHOOK` targets (currently the release channel). If you'd rather these land in a separate dev/PR channel, create another webhook and I'll switch the workflows to a `DISCORD_PR_WEBHOOK` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)