### PR TITLE
feat(web): expose per-indexer priority in the Indexers settings form

### DIFF
--- a/web/src/api/indexers.ts
+++ b/web/src/api/indexers.ts
@@ -8,6 +8,7 @@ export interface Indexer {
   url: string
   apiKey: string
   categories: number[]
+  priority: number
   enabled: boolean
   prowlarrInstanceId?: number
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -355,7 +355,9 @@
         "apiKey": "API Key",
         "categories": "Categories",
         "categoriesPlaceholder": "Categories (e.g. 7020, 7120, 3030)",
-        "categoriesHint": "Comma-separated Newznab category IDs. 7020 = eBooks, 3030 = Audiobooks. Add custom IDs for indexers with non-standard categories (e.g. 7120 for German books)."
+        "categoriesHint": "Comma-separated Newznab category IDs. 7020 = eBooks, 3030 = Audiobooks. Add custom IDs for indexers with non-standard categories (e.g. 7120 for German books).",
+        "priority": "Priority",
+        "priorityHint": "Higher wins ties when the same release is found on multiple indexers. Use it to prefer one indexer — e.g. set Usenet indexers above torrent ones. Default 0."
       }
     },
     "prowlarr": {

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -133,6 +133,7 @@ function makeIndexer(overrides: Partial<Indexer> = {}): Indexer {
     url: 'https://indexer.example.com',
     apiKey: 'test-key',
     categories: [7020],
+    priority: 0,
     enabled: true,
     ...overrides,
   }

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -104,6 +104,7 @@ function makeIndexer(overrides: Partial<Indexer> = {}): Indexer {
     url: 'https://nzbgeek.example.com',
     apiKey: 'indexer-key',
     categories: [7020],
+    priority: 0,
     enabled: true,
     ...overrides,
   }
@@ -1068,6 +1069,7 @@ describe('SettingsPage', () => {
         apiKey: 'scene-key',
         type: 'torznab',
         categories: [7020, 7120, 3030],
+        priority: 0,
         enabled: true,
       })
     })

--- a/web/src/pages/settings/IndexersTab.tsx
+++ b/web/src/pages/settings/IndexersTab.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, Indexer, IndexerTestResult, ProwlarrInstance } from '../../api/client'
 import { inputCls } from './formStyles'
-import { parseCats } from './helpers'
+import { parseCats, parsePriority } from './helpers'
 import Toggle from './Toggle'
 
 // IndexerTestResultBanner renders a probe result with the same ok/warn/fail
@@ -272,12 +272,13 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
   const [url, setUrl] = useState(indexer.url)
   const [apiKey, setApiKey] = useState(indexer.apiKey)
   const [categories, setCategories] = useState((indexer.categories ?? [7020]).join(', '))
+  const [priority, setPriority] = useState(String(indexer.priority ?? 0))
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<IndexerTestResult | null>(null)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
-    const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey, categories: parseCats(categories) })
+    const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey, categories: parseCats(categories), priority: parsePriority(priority) })
     onSaved(updated)
   }
 
@@ -323,6 +324,11 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
         <input value={categories} onChange={e => setCategories(e.target.value)} placeholder={t('settings.indexers.form.categoriesPlaceholder')} className={inputCls} />
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.categoriesHint')}</p>
       </div>
+      <div>
+        <label className={labelCls}>{t('settings.indexers.form.priority')}</label>
+        <input type="number" value={priority} onChange={e => setPriority(e.target.value)} placeholder="0" className={inputCls} />
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.priorityHint')}</p>
+      </div>
       {testResult && <IndexerTestResultBanner r={testResult} />}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">{t('common.cancel')}</button>
@@ -340,12 +346,13 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
   const [url, setUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [categories, setCategories] = useState('7020')
+  const [priority, setPriority] = useState('0')
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<IndexerTestResult | null>(null)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
-    const idx = await api.addIndexer({ name, url, apiKey, type, categories: parseCats(categories), enabled: true })
+    const idx = await api.addIndexer({ name, url, apiKey, type, categories: parseCats(categories), priority: parsePriority(priority), enabled: true })
     onAdded(idx)
   }
 
@@ -390,6 +397,11 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
         <label className={labelCls}>{t('settings.indexers.form.categories')}</label>
         <input value={categories} onChange={e => setCategories(e.target.value)} placeholder={t('settings.indexers.form.categoriesPlaceholder')} className={inputCls} />
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.categoriesHint')}</p>
+      </div>
+      <div>
+        <label className={labelCls}>{t('settings.indexers.form.priority')}</label>
+        <input type="number" value={priority} onChange={e => setPriority(e.target.value)} placeholder="0" className={inputCls} />
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.priorityHint')}</p>
       </div>
       {testResult && <IndexerTestResultBanner r={testResult} />}
       <div className="flex gap-2 justify-end">

--- a/web/src/pages/settings/helpers.ts
+++ b/web/src/pages/settings/helpers.ts
@@ -6,6 +6,13 @@ export function parseCats(s: string): number[] {
   return s.split(',').map(t => parseInt(t.trim(), 10)).filter(n => !isNaN(n))
 }
 
+// parsePriority parses an indexer priority (any integer; higher wins ties in
+// release ranking). Blank or non-numeric falls back to 0.
+export function parsePriority(s: string): number {
+  const n = parseInt(s.trim(), 10)
+  return isNaN(n) ? 0 : n
+}
+
 // downloadClientPathRemapHelp returns the help text for the path-remap field
 // of a given download-client type.
 export function downloadClientPathRemapHelp(type: string) {


### PR DESCRIPTION
Part of the LazyLibrarian feature comparison ("provider priority" — prefer one source over another).

## Finding
The capability already exists end-to-end: `models.Indexer.Priority` is persisted by the DB repo and create/update API, and the ranker factors it into release scoring (`internal/indexer/searcher.go` — a higher-priority indexer wins ties and can outweigh small quality gaps). Protocol preference also already exists via **delay profiles** (`preferred_protocol`). The only gap was the **UI**: the Indexers settings form had no priority field, so manually-added indexers were stuck at priority 0 (only Prowlarr-synced ones ever got a priority).

## Change (frontend only)
- Add a **Priority** number input to the add and edit indexer forms, wired into the existing `addIndexer`/`updateIndexer` payloads.
- Add `priority` to the web `Indexer` type and a `parsePriority` helper.
- i18n keys + hint ("higher wins ties; e.g. set Usenet indexers above torrent ones").
- Default 0 → behaviour unchanged for anyone who doesn't set it.

No backend change needed.

## Verify
`tsc` clean, `npm run build` clean, `npm run lint` no new warnings, `npm test` 273/273 (updated two indexer mocks + the add-indexer payload assertion for the new field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)