### PR TITLE
fix(web): paginate + server-side search authors and books lists (#1010)

### DIFF
--- a/changelog.d/1010-author-book-pagination.md
+++ b/changelog.d/1010-author-book-pagination.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Authors and Books pages now reach past the first 100 entries** (#1010) — the
+  list, search, sort, and filters are applied server-side and paginated, so
+  libraries with more than 100 authors or books are fully browsable. Previously
+  only the first page loaded, author/book name search was limited to that page,
+  and the footer always read "1–100 of 100". Author/book name search is now
+  matched on the server (book search also matches the author's name).

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -187,7 +187,20 @@ func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	userID := auth.UserIDFromContext(ctx)
 	limit, offset := parseLimitOffset(r, authorListDefaultLimit, authorListMaxLimit)
-	authors, total, err := h.authors.ListPage(ctx, userID, limit, offset)
+	filter := db.AuthorListFilter{
+		UserID: userID,
+		Search: strings.TrimSpace(r.URL.Query().Get("search")),
+		Sort:   r.URL.Query().Get("sort"),
+	}
+	switch r.URL.Query().Get("monitored") {
+	case "true":
+		v := true
+		filter.Monitored = &v
+	case "false":
+		v := false
+		filter.Monitored = &v
+	}
+	authors, total, err := h.authors.ListPageFiltered(ctx, filter, limit, offset)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -276,28 +276,30 @@ func (h *BookHandler) List(w http.ResponseWriter, r *http.Request) {
 			books, err = h.books.ListByAuthor(r.Context(), id)
 		}
 		books, total = pageBooks(books, limit, offset)
-	case status != "":
-		// Status-filtered lists (wanted/imported/etc.) can be large on a 50k
-		// library but they back the dashboard widgets, which always fetch the
-		// whole set today. Keep that behaviour for now and slice for the new
-		// envelope; a follow-up can add a SQL-paginated ListByStatusPage if
-		// the audit shows the wanted/imported pages dominate at scale.
-		if includeExcluded {
+	case includeExcluded:
+		// includeExcluded is an admin/maintenance view (Author detail "show
+		// excluded"); keep the whole-set fetch + in-memory slice. Search/sort
+		// filtering is not offered here.
+		if status != "" {
 			books, err = h.books.ListByStatusIncludingExcluded(r.Context(), status)
 		} else {
-			books, err = h.books.ListByStatus(r.Context(), status)
+			books, err = h.books.ListIncludingExcluded(r.Context())
 		}
 		books, total = pageBooks(books, limit, offset)
 	default:
-		if includeExcluded {
-			books, err = h.books.ListIncludingExcluded(r.Context())
-			books, total = pageBooks(books, limit, offset)
-		} else {
-			// Default-path SQL pagination: the books list is the hottest
-			// 50k-row scan in the app, so push LIMIT/OFFSET to SQLite where
-			// idx_books_sort_title (migration 048) keeps the sort cheap.
-			books, total, err = h.books.ListPage(r.Context(), 0, limit, offset)
-		}
+		// Default Books-page path: SQL-paginated with optional search / status
+		// / mediaType / sort applied server-side (issue #1010), so a library
+		// with >100 books is fully reachable instead of capped at the first
+		// page. idx_books_sort_title (migration 048) keeps the sort cheap.
+		// Note: unlike the legacy ListByStatus, status here only forces
+		// monitored=1 for "wanted" — matching what the Books page showed when
+		// it filtered client-side over the full set.
+		books, total, err = h.books.ListPageFiltered(r.Context(), db.BookListFilter{
+			Search:    strings.TrimSpace(r.URL.Query().Get("search")),
+			Status:    status,
+			MediaType: r.URL.Query().Get("mediaType"),
+			Sort:      r.URL.Query().Get("sort"),
+		}, limit, offset)
 	}
 
 	if err != nil {

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -100,14 +100,53 @@ func (r *AuthorRepo) ListByUser(ctx context.Context, userID int64) ([]models.Aut
 	return authors, rows.Err()
 }
 
+// AuthorListFilter narrows ListPageFiltered. The zero value selects every
+// visible author in sort_name order (identical to the old ListPage).
+type AuthorListFilter struct {
+	UserID int64 // 0 = unscoped; otherwise owner_user_id = UserID OR NULL
+	// Search is a case-insensitive substring match on the author name. Empty
+	// disables the filter.
+	Search string
+	// Monitored, when non-nil, restricts to authors with that monitored flag.
+	Monitored *bool
+	// Sort is one of "az" (sort_name asc, default), "za" (sort_name desc), or
+	// "recent" (created_at desc). Unknown values fall back to "az".
+	Sort string
+}
+
+// escapeLike escapes the LIKE metacharacters (%, _, and the \ escape itself)
+// so a user-typed search term matches literally under `LIKE ? ESCAPE '\'`.
+func escapeLike(s string) string {
+	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(s)
+}
+
+// authorSortOrder maps a whitelisted sort key to a fixed ORDER BY clause. The
+// value never contains user input, so it is safe to interpolate.
+func authorSortOrder(sort string) string {
+	switch sort {
+	case "za":
+		return "sort_name DESC"
+	case "recent":
+		return "created_at DESC, id DESC"
+	default:
+		return "sort_name ASC"
+	}
+}
+
 // ListPage returns one page of the authors visible to userID, ordered by
-// sort_name, alongside the total row count that matches the same filter.
-// limit must be positive; offset is clamped at 0. When userID is 0 the query
-// is unscoped (matches List); otherwise it matches ListByUser's predicate
-// (owner_user_id = userID OR owner_user_id IS NULL).
+// sort_name, alongside the total row count. Thin wrapper over ListPageFiltered
+// with no search/monitored/sort filtering — kept for existing callers.
+func (r *AuthorRepo) ListPage(ctx context.Context, userID int64, limit, offset int) ([]models.Author, int, error) {
+	return r.ListPageFiltered(ctx, AuthorListFilter{UserID: userID}, limit, offset)
+}
+
+// ListPageFiltered returns one page of authors matching f, ordered per f.Sort,
+// alongside the total row count that matches the same filter (the count ignores
+// limit/offset so the UI can paginate). limit must be positive; offset is
+// clamped at 0.
 //
 // The sort_name order is backed by idx_authors_sort_name (migration 048).
-func (r *AuthorRepo) ListPage(ctx context.Context, userID int64, limit, offset int) ([]models.Author, int, error) {
+func (r *AuthorRepo) ListPageFiltered(ctx context.Context, f AuthorListFilter, limit, offset int) ([]models.Author, int, error) {
 	if limit <= 0 {
 		limit = 50
 	}
@@ -115,34 +154,38 @@ func (r *AuthorRepo) ListPage(ctx context.Context, userID int64, limit, offset i
 		offset = 0
 	}
 
-	countQuery := "SELECT COUNT(*) FROM authors"
-	listQuery := "SELECT " + authorSelectCols + " FROM authors"
 	var (
-		args     []any
-		pageArgs []any
+		conds []string
+		args  []any
 	)
-	if userID != 0 {
+	if f.UserID != 0 {
 		// Match ListByUser: include NULL-owner rows so pre-multiuser-migration
 		// authors stay visible to every user instead of silently disappearing.
-		countQuery += " WHERE owner_user_id = ? OR owner_user_id IS NULL"
-		listQuery += " WHERE owner_user_id = ? OR owner_user_id IS NULL"
-		args = []any{userID}
-		pageArgs = []any{userID, limit, offset}
-	} else {
-		pageArgs = []any{limit, offset}
+		conds = append(conds, "(owner_user_id = ? OR owner_user_id IS NULL)")
+		args = append(args, f.UserID)
 	}
-	listQuery += " ORDER BY sort_name LIMIT ? OFFSET ?"
+	if s := strings.TrimSpace(f.Search); s != "" {
+		conds = append(conds, "name LIKE ? ESCAPE '\\' COLLATE NOCASE")
+		args = append(args, "%"+escapeLike(s)+"%")
+	}
+	if f.Monitored != nil {
+		conds = append(conds, "monitored = ?")
+		args = append(args, boolToInt(*f.Monitored))
+	}
+	where := ""
+	if len(conds) > 0 {
+		where = " WHERE " + strings.Join(conds, " AND ")
+	}
 
 	var total int
-	var countRow *sql.Row
-	if len(args) > 0 {
-		countRow = r.db.QueryRowContext(ctx, countQuery, args...)
-	} else {
-		countRow = r.db.QueryRowContext(ctx, countQuery)
-	}
-	if err := countRow.Scan(&total); err != nil {
+	if err := r.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM authors"+where, args...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("count authors: %w", err)
 	}
+
+	//nolint:gosec // query is built only from static columns, a parameterised WHERE, and a whitelisted ORDER BY (authorSortOrder); all user values are bound via args
+	listQuery := "SELECT " + authorSelectCols + " FROM authors" + where +
+		" ORDER BY " + authorSortOrder(f.Sort) + " LIMIT ? OFFSET ?"
+	pageArgs := append(append([]any{}, args...), limit, offset)
 
 	rows, err := r.db.QueryContext(ctx, listQuery, pageArgs...)
 	if err != nil {

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -203,6 +203,87 @@ func (r *BookRepo) ListPage(ctx context.Context, userID int64, limit, offset int
 	return books, total, nil
 }
 
+// BookListFilter narrows ListPageFiltered. The zero value (with UserID 0)
+// selects every non-excluded book in sort_title order — identical to ListPage.
+type BookListFilter struct {
+	UserID int64 // 0 = unscoped; otherwise owner_user_id = UserID
+	// Search is a case-insensitive substring match on the book title OR its
+	// author's name. Empty disables the filter.
+	Search string
+	// Status restricts to books with that status. As a special case, "wanted"
+	// additionally requires monitored = 1 (an unmonitored book is not wanted),
+	// matching the old client-side filter. Empty disables the filter.
+	Status string
+	// MediaType is "ebook" (matches ebook/both/unset, mirroring the UI default)
+	// or "audiobook" (matches audiobook/both). Any other value disables it.
+	MediaType string
+	// Sort is one of "title-az" (default), "title-za", "date-new", "date-old".
+	Sort string
+}
+
+// bookSortOrder maps a whitelisted sort key to a fixed ORDER BY clause. Never
+// contains user input, so safe to interpolate. NULL release dates sort last in
+// both date orders (matching the old client-side comparator).
+func bookSortOrder(sort string) string {
+	switch sort {
+	case "title-za":
+		return "sort_title DESC"
+	case "date-new":
+		return "release_date IS NULL, release_date DESC"
+	case "date-old":
+		return "release_date IS NULL, release_date ASC"
+	default:
+		return "sort_title ASC"
+	}
+}
+
+// ListPageFiltered returns one page of non-excluded books matching f, ordered
+// per f.Sort, alongside the total row count for the same filter (count ignores
+// limit/offset so the UI can paginate). limit must be positive; offset clamped
+// at 0. Replaces the per-filter client-side slicing the Books page used to do,
+// so libraries with >100 books are fully reachable (issue #1010).
+func (r *BookRepo) ListPageFiltered(ctx context.Context, f BookListFilter, limit, offset int) ([]models.Book, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	where, args := QueryScopeFor("books.owner_user_id", "WHERE excluded = 0", f.UserID)
+	if s := strings.TrimSpace(f.Search); s != "" {
+		where += " AND (books.title LIKE ? ESCAPE '\\' COLLATE NOCASE OR au.name LIKE ? ESCAPE '\\' COLLATE NOCASE)"
+		like := "%" + escapeLike(s) + "%"
+		args = append(args, like, like)
+	}
+	if f.Status != "" {
+		where += " AND books.status = ?"
+		args = append(args, f.Status)
+		if f.Status == models.BookStatusWanted {
+			where += " AND books.monitored = 1"
+		}
+	}
+	switch f.MediaType {
+	case "ebook":
+		where += " AND (books.media_type IN ('ebook','both') OR books.media_type IS NULL OR books.media_type = '')"
+	case "audiobook":
+		where += " AND books.media_type IN ('audiobook','both')"
+	}
+
+	total, err := r.count(ctx, bookCTE+" SELECT COUNT(*) FROM books "+bookJoins+" "+where, args)
+	if err != nil {
+		return nil, 0, err
+	}
+	q := bookCTE + " SELECT " + bookColumns + " FROM books " + bookJoins + " " + where +
+		" ORDER BY " + bookSortOrder(f.Sort) + " LIMIT ? OFFSET ?"
+	pageArgs := append(append([]any{}, args...), limit, offset)
+	books, err := r.query(ctx, q, pageArgs)
+	if err != nil {
+		return nil, 0, err
+	}
+	return books, total, nil
+}
+
 func (r *BookRepo) count(ctx context.Context, query string, args []any) (int, error) {
 	var total int
 	var row *sql.Row

--- a/internal/db/list_filtered_test.go
+++ b/internal/db/list_filtered_test.go
@@ -1,0 +1,226 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestAuthorRepo_ListPageFiltered_Pagination is the direct regression test for
+// issue #1010 bug 1: a library with more authors than one page must be fully
+// reachable via limit/offset, and total must reflect the whole set (not the
+// page length).
+func TestAuthorRepo_ListPageFiltered_Pagination(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	names := []string{"Acevedo", "Brown", "Clarke", "Dahl", "Eco"}
+	for i, n := range names {
+		if err := repo.Create(ctx, &models.Author{
+			ForeignID: "OL-P" + n, Name: n, SortName: n, Monitored: i%2 == 0,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", n, err)
+		}
+	}
+
+	// Page 2 of size 2 must return the 3rd/4th authors with total=5.
+	got, total, err := repo.ListPageFiltered(ctx, AuthorListFilter{Sort: "az"}, 2, 2)
+	if err != nil {
+		t.Fatalf("ListPageFiltered: %v", err)
+	}
+	if total != 5 {
+		t.Errorf("total = %d, want 5 (the whole set, not the page length)", total)
+	}
+	if len(got) != 2 {
+		t.Fatalf("page len = %d, want 2", len(got))
+	}
+	if got[0].Name != "Clarke" || got[1].Name != "Dahl" {
+		t.Errorf("page 2 = [%s, %s], want [Clarke, Dahl]", got[0].Name, got[1].Name)
+	}
+
+	// The last page (offset 4) must reach the author past the first page —
+	// the row that was unreachable before the fix.
+	last, _, err := repo.ListPageFiltered(ctx, AuthorListFilter{Sort: "az"}, 2, 4)
+	if err != nil {
+		t.Fatalf("ListPageFiltered last: %v", err)
+	}
+	if len(last) != 1 || last[0].Name != "Eco" {
+		t.Errorf("last page = %v, want [Eco]", last)
+	}
+}
+
+func TestAuthorRepo_ListPageFiltered_SearchSortMonitored(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	seed := []struct {
+		name      string
+		monitored bool
+	}{
+		{"Brad Thor", true},
+		{"Douglas Adams", false},
+		{"Thornton Wilder", true},
+		{"Elizabeth Acevedo", false},
+	}
+	for _, s := range seed {
+		if err := repo.Create(ctx, &models.Author{
+			ForeignID: "OL-S" + s.name, Name: s.name, SortName: s.name, Monitored: s.monitored,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", s.name, err)
+		}
+	}
+
+	// Case-insensitive substring search on name (#1010 bug 2).
+	got, total, err := repo.ListPageFiltered(ctx, AuthorListFilter{Search: "thor", Sort: "az"}, 50, 0)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if total != 2 || len(got) != 2 {
+		t.Fatalf("search 'thor' total=%d len=%d, want 2/2 (Brad Thor, Thornton Wilder)", total, len(got))
+	}
+	if got[0].Name != "Brad Thor" || got[1].Name != "Thornton Wilder" {
+		t.Errorf("search 'thor' = [%s, %s], want [Brad Thor, Thornton Wilder]", got[0].Name, got[1].Name)
+	}
+
+	// Monitored filter.
+	mon := true
+	monly, total, err := repo.ListPageFiltered(ctx, AuthorListFilter{Monitored: &mon}, 50, 0)
+	if err != nil {
+		t.Fatalf("monitored filter: %v", err)
+	}
+	if total != 2 || len(monly) != 2 {
+		t.Errorf("monitored=true total=%d len=%d, want 2", total, len(monly))
+	}
+
+	// Descending sort.
+	za, _, err := repo.ListPageFiltered(ctx, AuthorListFilter{Sort: "za"}, 1, 0)
+	if err != nil {
+		t.Fatalf("za: %v", err)
+	}
+	if len(za) != 1 || za[0].Name != "Thornton Wilder" {
+		t.Errorf("za first = %v, want [Thornton Wilder]", za)
+	}
+}
+
+func TestBookRepo_ListPageFiltered(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	ctx := context.Background()
+
+	author := &models.Author{ForeignID: "OL-BA", Name: "Brandon Sanderson", SortName: "Sanderson, Brandon", Monitored: true}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatalf("author: %v", err)
+	}
+
+	books := []struct {
+		title     string
+		status    string
+		monitored bool
+		media     string
+	}{
+		{"Mistborn", models.BookStatusImported, true, models.MediaTypeEbook},
+		{"Elantris", models.BookStatusWanted, true, models.MediaTypeAudiobook},
+		{"Warbreaker", models.BookStatusWanted, false, models.MediaTypeEbook}, // wanted but unmonitored
+		{"The Way of Kings", models.BookStatusImported, true, models.MediaTypeBoth},
+	}
+	for i, b := range books {
+		if err := bookRepo.Create(ctx, &models.Book{
+			ForeignID: "OL-BW" + b.title, AuthorID: author.ID, Title: b.title, SortTitle: b.title,
+			Status: b.status, Monitored: b.monitored, MediaType: b.media,
+		}); err != nil {
+			t.Fatalf("seed book %d: %v", i, err)
+		}
+	}
+
+	// Pagination + total (#1010 bug 1).
+	page, total, err := bookRepo.ListPageFiltered(ctx, BookListFilter{Sort: "title-az"}, 2, 0)
+	if err != nil {
+		t.Fatalf("page: %v", err)
+	}
+	if total != 4 || len(page) != 2 {
+		t.Errorf("page total=%d len=%d, want 4/2", total, len(page))
+	}
+
+	// Search matches title.
+	_, total, err = bookRepo.ListPageFiltered(ctx, BookListFilter{Search: "mistborn"}, 50, 0)
+	if err != nil {
+		t.Fatalf("search title: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("search 'mistborn' total=%d, want 1", total)
+	}
+
+	// Search matches author name (the cross-table case the old client-side
+	// filter could not reach past page 1).
+	_, total, err = bookRepo.ListPageFiltered(ctx, BookListFilter{Search: "sanderson"}, 50, 0)
+	if err != nil {
+		t.Fatalf("search author: %v", err)
+	}
+	if total != 4 {
+		t.Errorf("search 'sanderson' total=%d, want 4 (all books by the author)", total)
+	}
+
+	// Status=wanted must exclude the unmonitored "Warbreaker" (only wanted
+	// requires monitored=1, mirroring the old Books-page behaviour).
+	wanted, total, err := bookRepo.ListPageFiltered(ctx, BookListFilter{Status: models.BookStatusWanted}, 50, 0)
+	if err != nil {
+		t.Fatalf("status wanted: %v", err)
+	}
+	if total != 1 || len(wanted) != 1 || wanted[0].Title != "Elantris" {
+		t.Errorf("status=wanted = %d rows, want 1 (Elantris only)", total)
+	}
+
+	// Status=imported does NOT require monitored, so both imported books show.
+	_, total, err = bookRepo.ListPageFiltered(ctx, BookListFilter{Status: models.BookStatusImported}, 50, 0)
+	if err != nil {
+		t.Fatalf("status imported: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("status=imported total=%d, want 2", total)
+	}
+
+	// mediaType=audiobook is both-aware: Elantris (audiobook) + The Way of
+	// Kings (both).
+	_, total, err = bookRepo.ListPageFiltered(ctx, BookListFilter{MediaType: "audiobook"}, 50, 0)
+	if err != nil {
+		t.Fatalf("media audiobook: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("mediaType=audiobook total=%d, want 2 (audiobook + both)", total)
+	}
+
+	// mediaType=ebook is both-aware: Mistborn + Warbreaker (ebook) + The Way of
+	// Kings (both).
+	_, total, err = bookRepo.ListPageFiltered(ctx, BookListFilter{MediaType: "ebook"}, 50, 0)
+	if err != nil {
+		t.Fatalf("media ebook: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("mediaType=ebook total=%d, want 3 (ebook + both)", total)
+	}
+
+	// Descending title sort.
+	za, _, err := bookRepo.ListPageFiltered(ctx, BookListFilter{Sort: "title-za"}, 1, 0)
+	if err != nil {
+		t.Fatalf("title-za: %v", err)
+	}
+	if len(za) != 1 || za[0].Title != "Warbreaker" {
+		t.Errorf("title-za first = %v, want [Warbreaker]", za)
+	}
+}

--- a/web/src/api/authors.ts
+++ b/web/src/api/authors.ts
@@ -93,12 +93,30 @@ export interface UpdateAuthorRequest {
 
 export const authorsApi = {
   // Authors
-  listAuthors: (params?: { limit?: number; offset?: number }) => {
+  listAuthors: (params?: { limit?: number; offset?: number; search?: string; sort?: string; monitored?: boolean }) => {
     const q = new URLSearchParams()
     if (params?.limit !== undefined) q.set('limit', String(params.limit))
     if (params?.offset !== undefined) q.set('offset', String(params.offset))
+    if (params?.search) q.set('search', params.search)
+    if (params?.sort) q.set('sort', params.sort)
+    if (params?.monitored !== undefined) q.set('monitored', String(params.monitored))
     const qs = q.toString()
     return request<Page<Author>>(`/author${qs ? '?' + qs : ''}`)
+  },
+  // listAllAuthors pages through the server until the full set is collected.
+  // For callers that genuinely need every author (merge picker, series book
+  // picker, relink candidates) rather than one display page.
+  listAllAuthors: async (params?: { search?: string; sort?: string; monitored?: boolean }): Promise<Author[]> => {
+    const pageSize = 500
+    let offset = 0
+    const all: Author[] = []
+    for (;;) {
+      const { items, total } = await authorsApi.listAuthors({ ...params, limit: pageSize, offset })
+      all.push(...items)
+      offset += items.length
+      if (items.length === 0 || all.length >= total) break
+    }
+    return all
   },
   getAuthor: (id: number) => request<Author>(`/author/${id}`),
   addAuthor: (data: AddAuthorRequest) => request<Author>('/author', { method: 'POST', body: JSON.stringify(data) }),

--- a/web/src/api/books.ts
+++ b/web/src/api/books.ts
@@ -115,15 +115,34 @@ export const booksApi = {
     request<Book>('/author/book', { method: 'POST', body: JSON.stringify(data) }),
 
   // Books
-  listBooks: (params?: { authorId?: number; status?: string; includeExcluded?: boolean; limit?: number; offset?: number }) => {
+  listBooks: (params?: { authorId?: number; status?: string; includeExcluded?: boolean; limit?: number; offset?: number; search?: string; mediaType?: string; sort?: string }) => {
     const q = new URLSearchParams()
     if (params?.authorId) q.set('authorId', String(params.authorId))
     if (params?.status) q.set('status', params.status)
     if (params?.includeExcluded) q.set('includeExcluded', 'true')
     if (params?.limit !== undefined) q.set('limit', String(params.limit))
     if (params?.offset !== undefined) q.set('offset', String(params.offset))
+    if (params?.search) q.set('search', params.search)
+    if (params?.mediaType) q.set('mediaType', params.mediaType)
+    if (params?.sort) q.set('sort', params.sort)
     const qs = q.toString()
     return request<Page<Book>>(`/book${qs ? '?' + qs : ''}`)
+  },
+  // listAllBooks pages through the server until the full set is collected. For
+  // callers that need every book (calendar, series book picker) rather than one
+  // display page. Heavy on very large libraries by design — prefer paginated
+  // listBooks for browse views.
+  listAllBooks: async (params?: { search?: string; status?: string; mediaType?: string; sort?: string; includeExcluded?: boolean }): Promise<Book[]> => {
+    const pageSize = 500
+    let offset = 0
+    const all: Book[] = []
+    for (;;) {
+      const { items, total } = await booksApi.listBooks({ ...params, limit: pageSize, offset })
+      all.push(...items)
+      offset += items.length
+      if (items.length === 0 || all.length >= total) break
+    }
+    return all
   },
   getBook: (id: number) => request<Book>(`/book/${id}`),
   updateBook: (id: number, data: Partial<Book>) => request<Book>(`/book/${id}`, { method: 'PUT', body: JSON.stringify(data) }),

--- a/web/src/components/AddSeriesBookModal.tsx
+++ b/web/src/components/AddSeriesBookModal.tsx
@@ -20,11 +20,13 @@ export default function AddSeriesBookModal({ series, onClose, onLinked }: Props)
 
   useEffect(() => {
     let active = true
-    Promise.all([api.listBooks(), api.listAuthors()])
+    // The picker lets the user attach any book/author to the series, so it
+    // needs the full lists rather than one paginated page (#1010).
+    Promise.all([api.listAllBooks(), api.listAllAuthors()])
       .then(([bookList, authorList]) => {
         if (!active) return
-        setBooks(bookList.items)
-        setAuthors(authorList.items)
+        setBooks(bookList)
+        setAuthors(authorList)
       })
       .catch(err => {
         if (active) setError(err instanceof Error ? err.message : 'Failed to load books')

--- a/web/src/components/usePagination.ts
+++ b/web/src/components/usePagination.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 const SHARED_PAGE_SIZE_KEY = 'pageSize:shared'
 
@@ -12,6 +12,56 @@ function readStoredPageSize(storageKey: string | undefined): number | null {
     }
   }
   return null
+}
+
+function persistPageSize(storageKey: string | undefined, size: number) {
+  if (storageKey) localStorage.setItem(`pageSize:${storageKey}`, String(size))
+  localStorage.setItem(SHARED_PAGE_SIZE_KEY, String(size))
+}
+
+/**
+ * useServerPagination: page/pageSize state for lists paginated on the SERVER.
+ *
+ * Unlike usePagination (which slices a fully-loaded client array), this tracks
+ * the current page and size and builds Pagination props from a server-provided
+ * `total`. The caller fetches the page whenever `page`/`pageSize` (or its own
+ * filters) change — typically by listing them in a fetch effect's deps. Page
+ * size is persisted under the same localStorage keys as usePagination, so the
+ * user's preference carries across both kinds of list.
+ */
+export function useServerPagination(total: number, defaultPageSize = 50, storageKey?: string) {
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSizeState] = useState(() => readStoredPageSize(storageKey) ?? defaultPageSize)
+
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+  // If the result set shrank (e.g. a filter was applied) below the current
+  // page, snap back so the user is not stranded on an empty page.
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages)
+  }, [page, totalPages])
+
+  const setPageSize = useCallback((size: number) => {
+    setPageSizeState(size)
+    setPage(1)
+    persistPageSize(storageKey, size)
+  }, [storageKey])
+
+  const reset = useCallback(() => setPage(1), [])
+
+  return {
+    page,
+    pageSize,
+    setPage,
+    reset,
+    paginationProps: {
+      page: Math.min(page, totalPages),
+      totalPages,
+      pageSize,
+      totalItems: total,
+      onPageChange: setPage,
+      onPageSizeChange: setPageSize,
+    },
+  }
 }
 
 /**

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -156,6 +156,7 @@
   },
   "books": {
     "title": "Books",
+    "countLabel": "{{count}} books",
     "searchPlaceholder": "Search books or authors...",
     "sortLabel": "Sort:",
     "typeLabel": "Type:",

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -412,7 +412,7 @@ export default function AuthorDetailPage() {
             </button>
             <button
               onClick={() => {
-                if (allAuthors.length === 0) api.listAuthors().then(({ items }) => setAllAuthors(items)).catch(console.error)
+                if (allAuthors.length === 0) api.listAllAuthors().then(setAllAuthors).catch(console.error)
                 setShowMerge(true)
               }}
               className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium"

--- a/web/src/pages/AuthorsPage.onboarding.test.tsx
+++ b/web/src/pages/AuthorsPage.onboarding.test.tsx
@@ -40,6 +40,13 @@ vi.mock('../components/usePagination', () => ({
     paginationProps: { page: 1, totalPages: 1, pageSize: 50, totalItems: items.length, onPageChange: vi.fn(), onPageSizeChange: vi.fn() },
     reset: vi.fn(),
   }),
+  useServerPagination: (total: number) => ({
+    page: 1,
+    pageSize: 50,
+    setPage: vi.fn(),
+    reset: vi.fn(),
+    paginationProps: { page: 1, totalPages: 1, pageSize: 50, totalItems: total, onPageChange: vi.fn(), onPageSizeChange: vi.fn() },
+  }),
 }))
 
 vi.mock('../components/Pagination', () => ({ default: () => null }))

--- a/web/src/pages/AuthorsPage.test.tsx
+++ b/web/src/pages/AuthorsPage.test.tsx
@@ -69,6 +69,13 @@ vi.mock('../components/usePagination', () => ({
     paginationProps: { page: 1, totalPages: 1, pageSize: 50, totalItems: items.length, onPageChange: vi.fn(), onPageSizeChange: vi.fn() },
     reset: vi.fn(),
   }),
+  useServerPagination: (total: number) => ({
+    page: 1,
+    pageSize: 50,
+    setPage: vi.fn(),
+    reset: vi.fn(),
+    paginationProps: { page: 1, totalPages: 1, pageSize: 50, totalItems: total, onPageChange: vi.fn(), onPageSizeChange: vi.fn() },
+  }),
 }))
 
 vi.mock('../components/Pagination', () => ({ default: () => null }))
@@ -77,6 +84,19 @@ describe('AuthorsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(api.listAuthors).mockResolvedValue({ items: [], total: 0, limit: 100, offset: 0 })
+  })
+
+  it('requests a bounded server page rather than the whole table (issue #1010)', async () => {
+    render(
+      <MemoryRouter>
+        <AuthorsPage />
+      </MemoryRouter>,
+    )
+    // The Authors page must drive server pagination: a finite limit + offset,
+    // not an unbounded fetch that the UI then clamps to the first 100 rows.
+    await waitFor(() => expect(api.listAuthors).toHaveBeenCalled())
+    const arg = vi.mocked(api.listAuthors).mock.calls[0][0]
+    expect(arg).toMatchObject({ limit: 50, offset: 0 })
   })
 
   it('creates a series from the authors toolbar and opens it on the series page', async () => {

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useMemo } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { api, Author, MediaType, AuthorRefreshStatus } from '../api/client'
@@ -8,7 +8,7 @@ import MergeAuthorsModal from '../components/MergeAuthorsModal'
 import SeriesNameModal from '../components/SeriesNameModal'
 import BulkActionBar from '../components/BulkActionBar'
 import Pagination from '../components/Pagination'
-import { usePagination } from '../components/usePagination'
+import { useServerPagination } from '../components/usePagination'
 import ViewToggle from '../components/ViewToggle'
 import { useView } from '../components/useView'
 import GettingStartedGuidance from '../components/GettingStartedGuidance'
@@ -21,12 +21,17 @@ export default function AuthorsPage() {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [authors, setAuthors] = useState<Author[]>([])
+  const [total, setTotal] = useState(0)
+  // Full author list fetched lazily for the merge picker, which needs every
+  // author, not just the current page.
+  const [mergeAuthors, setMergeAuthors] = useState<Author[]>([])
   const [loading, setLoading] = useState(true)
   const [showAdd, setShowAdd] = useState(false)
   const [showAddBook, setShowAddBook] = useState(false)
   const [showAddSeries, setShowAddSeries] = useState(false)
   const [showMerge, setShowMerge] = useState(false)
   const [search, setSearch] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
   const [sort, setSort] = useState<SortMode>('az')
   const [monitoredFilter, setMonitoredFilter] = useState<MonitoredFilter>(() => {
     try {
@@ -46,12 +51,36 @@ export default function AuthorsPage() {
   const [refreshStatus, setRefreshStatus] = useState<AuthorRefreshStatus | null>(null)
   const [refreshing, setRefreshing] = useState(false)
 
-  const load = () => {
-    setLoading(true)
-    api.listAuthors().then(({ items }) => setAuthors(items)).catch(console.error).finally(() => setLoading(false))
-  }
+  const monitoredParam = monitoredFilter === 'monitored' ? true : monitoredFilter === 'unmonitored' ? false : undefined
+  const { page, pageSize, paginationProps, reset } = useServerPagination(total, 50, 'authors')
 
-  useEffect(() => { load() }, [])
+  // Server-side list: page, page size, search, sort, and the monitored filter
+  // are all applied by the API, so libraries with >100 authors are fully
+  // reachable (issue #1010). load() refetches the current page; the mutation
+  // handlers below call it to refresh.
+  const load = useCallback(() => {
+    setLoading(true)
+    api.listAuthors({
+      limit: pageSize,
+      offset: (page - 1) * pageSize,
+      search: debouncedSearch || undefined,
+      sort,
+      monitored: monitoredParam,
+    }).then(({ items, total }) => { setAuthors(items); setTotal(total) })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [page, pageSize, debouncedSearch, sort, monitoredParam])
+
+  useEffect(() => { load() }, [load])
+
+  // Debounce the search box so typing does not fire a request per keystroke.
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedSearch(search.trim()), 300)
+    return () => clearTimeout(id)
+  }, [search])
+
+  // Jump back to page 1 whenever the query changes.
+  useEffect(() => { reset() }, [debouncedSearch, sort, monitoredFilter, pageSize, reset])
 
   // Restore the last-known refresh status on mount so the banner survives a
   // page reload. If a job is still "running", resume polling.
@@ -122,29 +151,10 @@ export default function AuthorsPage() {
     load()
   }
 
-  const filtered = useMemo(() => {
-    let list = authors
-    if (monitoredFilter === 'monitored') list = list.filter(a => a.monitored)
-    else if (monitoredFilter === 'unmonitored') list = list.filter(a => !a.monitored)
-    if (search.trim()) {
-      const q = search.trim().toLowerCase()
-      list = list.filter(a =>
-        a.authorName.toLowerCase().includes(q) ||
-        (a.description && a.description.toLowerCase().includes(q))
-      )
-    }
-    if (sort === 'az') list = [...list].sort((a, b) => a.authorName.localeCompare(b.authorName))
-    else if (sort === 'za') list = [...list].sort((a, b) => b.authorName.localeCompare(a.authorName))
-    return list
-  }, [authors, monitoredFilter, search, sort])
-
-  const { pageItems, paginationProps, reset } = usePagination(filtered, 50, 'authors')
-
-  useEffect(() => { reset() }, [search, sort, monitoredFilter, reset])
-
-  // Keep the select-all checkbox indeterminate state in sync.
-  const allPageSelected = pageItems.length > 0 && pageItems.every(a => selectedIds.has(a.id))
-  const somePageSelected = pageItems.some(a => selectedIds.has(a.id)) && !allPageSelected
+  // Keep the select-all checkbox indeterminate state in sync. "Page" here is
+  // the server-returned page held in `authors`.
+  const allPageSelected = authors.length > 0 && authors.every(a => selectedIds.has(a.id))
+  const somePageSelected = authors.some(a => selectedIds.has(a.id)) && !allPageSelected
   useEffect(() => {
     if (selectAllRef.current) selectAllRef.current.indeterminate = somePageSelected
   }, [somePageSelected])
@@ -163,7 +173,18 @@ export default function AuthorsPage() {
     })
   }
 
-  const selectAllOnPage = () => setSelectedIds(new Set(pageItems.map(a => a.id)))
+  const selectAllOnPage = () => setSelectedIds(new Set(authors.map(a => a.id)))
+
+  // Merge needs the full author list, not just the current page; fetch it
+  // lazily when the modal opens.
+  const openMerge = async () => {
+    try {
+      setMergeAuthors(await api.listAllAuthors())
+    } catch {
+      setMergeAuthors(authors)
+    }
+    setShowMerge(true)
+  }
   const clearSelection = () => setSelectedIds(new Set())
 
   const runBulk = async (action: Parameters<typeof api.bulkActionAuthors>[1]) => {
@@ -218,15 +239,15 @@ export default function AuthorsPage() {
           <ViewToggle view={view} onChange={setView} />
           <button
             onClick={handleRefreshAll}
-            disabled={refreshing || authors.length === 0}
+            disabled={refreshing || total === 0}
             className="px-3 py-2 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-md text-sm font-medium transition-colors"
             title={t('authors.refreshAllTip')}
           >
             {refreshing ? t('authors.refreshAllRunning') : t('authors.refreshAll')}
           </button>
           <button
-            onClick={() => setShowMerge(true)}
-            disabled={authors.length < 2}
+            onClick={openMerge}
+            disabled={total < 2}
             className="px-3 py-2 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-md text-sm font-medium transition-colors"
             title={t('authors.mergeTip')}
           >
@@ -299,13 +320,13 @@ export default function AuthorsPage() {
 
       {loading ? (
         <div className="text-slate-600 dark:text-zinc-500">{t('common.loading')}</div>
-      ) : filtered.length === 0 && authors.length === 0 ? (
+      ) : total === 0 && !debouncedSearch && !monitoredFilter ? (
         <div className="text-center py-16 text-slate-600 dark:text-zinc-500">
           {needsSetup && <GettingStartedGuidance reasonKey="gettingStarted.reasonAuthors" />}
           <p className="text-lg mb-2">{t('authors.empty')}</p>
           <p className="text-sm">{t('authors.emptyHint')}</p>
         </div>
-      ) : filtered.length === 0 ? (
+      ) : total === 0 ? (
         <div className="text-center py-16 text-slate-600 dark:text-zinc-500">
           <p>{t('authors.noMatch', { query: search })}</p>
         </div>
@@ -333,7 +354,7 @@ export default function AuthorsPage() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-200 dark:divide-zinc-800">
-                {pageItems.map(author => (
+                {authors.map(author => (
                   <tr
                     key={author.id}
                     className={`hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 ${selectedIds.has(author.id) ? 'bg-emerald-500/10 dark:bg-emerald-500/10' : 'bg-slate-100/50 dark:bg-zinc-900/50'}`}
@@ -393,7 +414,7 @@ export default function AuthorsPage() {
         </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-          {pageItems.map(author => (
+          {authors.map(author => (
             <div
               key={author.id}
               className={`border rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden hover:border-emerald-500 transition-colors ${selectedIds.has(author.id) ? 'border-emerald-500' : 'border-slate-200 dark:border-zinc-800'}`}
@@ -479,7 +500,7 @@ export default function AuthorsPage() {
       )}
       {showMerge && (
         <MergeAuthorsModal
-          authors={authors}
+          authors={mergeAuthors}
           onClose={() => setShowMerge(false)}
           onMerged={load}
         />

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import ViewToggle from '../components/ViewToggle'
@@ -9,7 +9,7 @@ import { useNeedsSetup } from '../components/useNeedsSetup'
 import { api, BINDERY_BASE, Book } from '../api/client'
 import BulkActionBar from '../components/BulkActionBar'
 import Pagination from '../components/Pagination'
-import { usePagination } from '../components/usePagination'
+import { useServerPagination } from '../components/usePagination'
 
 type SortMode = 'title-az' | 'title-za' | 'date-new' | 'date-old'
 
@@ -26,10 +26,12 @@ const statusLabelKeys: Record<string, string> = {
 export default function BooksPage() {
   const { t } = useTranslation()
   const [books, setBooks] = useState<Book[]>([])
+  const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
   const [statusFilter, setStatusFilter] = useState('')
   const [mediaFilter, setMediaFilter] = useState<'' | 'ebook' | 'audiobook'>('')
   const [search, setSearch] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
   const [sort, setSort] = useState<SortMode>('title-az')
   const [view, setView] = useView('books', 'grid')
   const needsSetup = useNeedsSetup()
@@ -37,56 +39,40 @@ export default function BooksPage() {
   const [bulkBusy, setBulkBusy] = useState(false)
   const selectAllRef = useRef<HTMLInputElement>(null)
 
-  const load = () => {
-    api.listBooks().then(({ items }) => setBooks(items)).catch(console.error).finally(() => setLoading(false))
-  }
+  const { page, pageSize, paginationProps, reset } = useServerPagination(total, 50, 'books')
 
+  // Server-side list: page, page size, search, status, media type, and sort are
+  // all applied by the API so a library with >100 books is fully reachable
+  // (issue #1010). load() refetches the current page after mutations.
+  const load = useCallback(() => {
+    setLoading(true)
+    api.listBooks({
+      limit: pageSize,
+      offset: (page - 1) * pageSize,
+      search: debouncedSearch || undefined,
+      status: statusFilter || undefined,
+      mediaType: mediaFilter || undefined,
+      sort,
+    }).then(({ items, total }) => { setBooks(items); setTotal(total) })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [page, pageSize, debouncedSearch, statusFilter, mediaFilter, sort])
+
+  useEffect(() => { load() }, [load])
+
+  // Debounce the search box so typing does not fire a request per keystroke.
   useEffect(() => {
-    load()
-  }, [])
+    const id = setTimeout(() => setDebouncedSearch(search.trim()), 300)
+    return () => clearTimeout(id)
+  }, [search])
 
-  const filtered = useMemo(() => {
-    let list = books
-    if (statusFilter) list = list.filter(b => b.status === statusFilter && (statusFilter !== 'wanted' || b.monitored))
-    if (mediaFilter) {
-      list = list.filter(b => {
-        const mt = b.mediaType || 'ebook'
-        // 'both' books count as both ebook and audiobook so they show up
-        // under either filter.
-        return mt === mediaFilter || mt === 'both'
-      })
-    }
-    if (search.trim()) {
-      const q = search.trim().toLowerCase()
-      list = list.filter(b =>
-        b.title.toLowerCase().includes(q) ||
-        (b.author?.authorName && b.author.authorName.toLowerCase().includes(q))
-      )
-    }
-    if (sort === 'title-az') list = [...list].sort((a, b) => a.title.localeCompare(b.title))
-    else if (sort === 'title-za') list = [...list].sort((a, b) => b.title.localeCompare(a.title))
-    else if (sort === 'date-new') list = [...list].sort((a, b) => {
-      if (!a.releaseDate && !b.releaseDate) return 0
-      if (!a.releaseDate) return 1
-      if (!b.releaseDate) return -1
-      return new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime()
-    })
-    else if (sort === 'date-old') list = [...list].sort((a, b) => {
-      if (!a.releaseDate && !b.releaseDate) return 0
-      if (!a.releaseDate) return 1
-      if (!b.releaseDate) return -1
-      return new Date(a.releaseDate).getTime() - new Date(b.releaseDate).getTime()
-    })
-    return list
-  }, [books, statusFilter, mediaFilter, search, sort])
+  // Jump back to page 1 whenever the query changes.
+  useEffect(() => { reset() }, [debouncedSearch, statusFilter, mediaFilter, sort, pageSize, reset])
 
-  const { pageItems, paginationProps, reset } = usePagination(filtered, 50, 'books')
-
-  useEffect(() => { reset() }, [statusFilter, mediaFilter, search, sort, reset])
-
-  // Keep the select-all checkbox indeterminate state in sync.
-  const allPageSelected = pageItems.length > 0 && pageItems.every(b => selectedIds.has(b.id))
-  const somePageSelected = pageItems.some(b => selectedIds.has(b.id)) && !allPageSelected
+  // Keep the select-all checkbox indeterminate state in sync. "Page" here is
+  // the server-returned page held in `books`.
+  const allPageSelected = books.length > 0 && books.every(b => selectedIds.has(b.id))
+  const somePageSelected = books.some(b => selectedIds.has(b.id)) && !allPageSelected
   useEffect(() => {
     if (selectAllRef.current) selectAllRef.current.indeterminate = somePageSelected
   }, [somePageSelected])
@@ -105,7 +91,7 @@ export default function BooksPage() {
     })
   }
 
-  const selectAllOnPage = () => setSelectedIds(new Set(pageItems.map(b => b.id)))
+  const selectAllOnPage = () => setSelectedIds(new Set(books.map(b => b.id)))
   const clearSelection = () => setSelectedIds(new Set())
 
   const runBulk = async (action: Parameters<typeof api.bulkActionBooks>[1], mediaType?: 'ebook' | 'audiobook') => {
@@ -134,7 +120,7 @@ export default function BooksPage() {
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-bold">{t('books.title')}</h2>
         <div className="flex items-center gap-3">
-          <span className="text-sm text-slate-600 dark:text-zinc-500">{filtered.length} of {books.length}</span>
+          <span className="text-sm text-slate-600 dark:text-zinc-500">{t('books.countLabel', { count: total, defaultValue: '{{count}} books' })}</span>
           <ViewToggle view={view} onChange={setView} />
         </div>
       </div>
@@ -176,9 +162,9 @@ export default function BooksPage() {
 
       {loading ? (
         <div className="text-slate-600 dark:text-zinc-500">{t('common.loading')}</div>
-      ) : filtered.length === 0 ? (
+      ) : total === 0 ? (
         <div className="text-center py-16 text-slate-600 dark:text-zinc-500">
-          {books.length === 0 ? (
+          {!debouncedSearch && !statusFilter && !mediaFilter ? (
             <>
               {needsSetup && <GettingStartedGuidance reasonKey="gettingStarted.reasonBooks" />}
               <p className="font-medium">{t('books.empty')}</p>
@@ -213,7 +199,7 @@ export default function BooksPage() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-200 dark:divide-zinc-800">
-                {pageItems.map(book => (
+                {books.map(book => (
                   <tr
                     key={book.id}
                     className={`hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 cursor-pointer ${selectedIds.has(book.id) ? 'bg-emerald-500/10 dark:bg-emerald-500/10' : 'bg-slate-100/50 dark:bg-zinc-900/50'}`}
@@ -274,7 +260,7 @@ export default function BooksPage() {
         </div>
         ) : (
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
-          {pageItems.map(book => (
+          {books.map(book => (
             <div
               key={book.id}
               className={`border rounded-lg bg-slate-100 dark:bg-zinc-900 overflow-hidden group text-left transition-colors ${selectedIds.has(book.id) ? 'border-emerald-500' : 'border-slate-200 dark:border-zinc-800 hover:border-emerald-500'}`}

--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -27,7 +27,9 @@ export default function CalendarPage() {
   const [viewMonth, setViewMonth] = useState(today.getMonth())
 
   useEffect(() => {
-    api.listBooks().then(({ items }) => setBooks(items)).catch(console.error).finally(() => setLoading(false))
+    // The calendar plots every upcoming release, so it needs the full set, not
+    // one paginated page (listBooks now caps at 100 by default — #1010).
+    api.listAllBooks().then(setBooks).catch(console.error).finally(() => setLoading(false))
   }, [])
 
   useEffect(() => {

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -14,6 +14,8 @@ vi.mock('../api/client', async importOriginal => {
       status: vi.fn(),
       listBooks: vi.fn(),
       listAuthors: vi.fn(),
+      listAllBooks: vi.fn(),
+      listAllAuthors: vi.fn(),
       listSeries: vi.fn(),
       createSeries: vi.fn(),
       updateSeries: vi.fn(),
@@ -48,6 +50,8 @@ describe('SeriesPage', () => {
     vi.mocked(api.status).mockResolvedValue({ version: 'dev', commit: 'unknown', buildDate: '', enhancedHardcoverApi: true, hardcoverTokenConfigured: true })
     vi.mocked(api.listBooks).mockResolvedValue({ items: [], total: 0, limit: 100, offset: 0 })
     vi.mocked(api.listAuthors).mockResolvedValue({ items: [], total: 0, limit: 100, offset: 0 })
+    vi.mocked(api.listAllBooks).mockResolvedValue([])
+    vi.mocked(api.listAllAuthors).mockResolvedValue([])
     vi.mocked(api.getSeriesHardcoverLink).mockRejectedValue(new Error('not linked'))
     vi.mocked(api.searchHardcoverSeries).mockResolvedValue([])
   })
@@ -487,31 +491,21 @@ describe('SeriesPage', () => {
       ...series,
       books: [...(series.books ?? []), { seriesId: 30, bookId: 102, positionInSeries: '2', primarySeries: true, book: candidate }],
     }
-    vi.mocked(api.listBooks).mockResolvedValue({
-      items: [series.books![0].book!, candidate],
-      total: 2,
-      limit: 100,
-      offset: 0,
-    })
-    vi.mocked(api.listAuthors).mockResolvedValue({
-      items: [
-        {
-          id: 12,
-          foreignAuthorId: 'author-12',
-          authorName: 'Frank Herbert',
-          sortName: 'Herbert, Frank',
-          description: '',
-          imageUrl: '',
-          disambiguation: '',
-          ratingsCount: 0,
-          averageRating: 0,
-          monitored: true,
-        },
-      ],
-      total: 1,
-      limit: 100,
-      offset: 0,
-    })
+    vi.mocked(api.listAllBooks).mockResolvedValue([series.books![0].book!, candidate])
+    vi.mocked(api.listAllAuthors).mockResolvedValue([
+      {
+        id: 12,
+        foreignAuthorId: 'author-12',
+        authorName: 'Frank Herbert',
+        sortName: 'Herbert, Frank',
+        description: '',
+        imageUrl: '',
+        disambiguation: '',
+        ratingsCount: 0,
+        averageRating: 0,
+        monitored: true,
+      },
+    ])
     vi.mocked(api.linkBookToSeries).mockResolvedValue(updated)
 
     renderSeriesPage([series])


### PR DESCRIPTION
Closes #1010.

## The regression
#902 (Wave 2) added server-side `LIMIT`/`OFFSET` to the `/author` and `/book` List endpoints but the frontend was never updated to drive it. The Authors and Books pages fetched a single default page (100 rows), paginated it **in memory**, and computed the footer from `items.length`. Result on any library with >100 authors/books:

- footer always reads "1–100 of 100", Per-page selector does nothing, nothing past row 100 is reachable (Bug 1);
- author/book name search filtered the already-fetched 100 rows client-side, and there was **no server-side name filter at all**, so search could never reach the hidden rows (Bug 2).

Reporter (sman97) nailed the diagnosis: API correct (`total: 276`, `?offset=250` returns the missing rows), UI clamps to 100.

## Fix

**Backend**
- `AuthorRepo.ListPageFiltered` — case-insensitive name search, monitored filter, whitelisted sort (`az`/`za`/`recent`); `ListPage` delegates to it.
- `BookRepo.ListPageFiltered` — search (title **OR author name**), status (`wanted` still requires `monitored=1`, matching the old client rule; other statuses don't), media-type (both-aware), whitelisted sort. The default `/book` path now routes through it so status/search/sort/pagination compose in SQL.
- `/author` and `/book` handlers parse the new params. ORDER BY / WHERE are built only from whitelisted constants; all user values are bound args.

**Frontend**
- `useServerPagination` hook: page/size state (same localStorage keys as before) + `Pagination` props from a server `total`.
- `AuthorsPage` / `BooksPage` are now fully server-driven — search (debounced), sort, and filters round-trip to the API; the footer uses the real total.
- Consumers that genuinely need the whole set (Calendar, series book picker, author merge/relink pickers) use new `listAllAuthors`/`listAllBooks` helpers that page through, instead of being silently capped at 100 (they were also victims of this bug).

Not included: Bug 3 (relative asset paths on deep-route hard loads) — that's the `BINDERY_URL_BASE`/#974 area, separate.

## Verify
- Backend: `go build`, `go vet`, `golangci-lint` (touched pkgs), full `go test ./cmd/... ./internal/...` — all green. New `ListPageFiltered` tests cover pagination/total, search, status, media-type, and sort.
- Frontend: `tsc`, `npm run build`, `npm run lint` (0 errors), `npm test` 274/274. Added an AuthorsPage test asserting the page requests a bounded server page (not an unbounded fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)