### PR TITLE
fix(downloader): emit nzbget json-rpc params last so append returns a real id

### DIFF
--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -167,9 +167,7 @@ func (c *Client) Add(ctx context.Context, nzbURL, name, category string, priorit
 		}
 	}
 	encoded := base64.StdEncoding.EncodeToString(content)
-	// append params: name, content, category, priority, dupecheck, dupekey, dupescore,
-	//                ppparameters (array), addtoTop, addpaused, urlpassword, postscript
-	params := []any{name, encoded, category, priority, false, "", 0, []any{}, false, false, "", ""}
+	params := appendParams(name, encoded, category, priority)
 	var resp appendResponse
 	if err := c.call(ctx, "append", params, &resp); err != nil {
 		return 0, fmt.Errorf("add nzb: %w", err)
@@ -183,6 +181,25 @@ func (c *Client) Add(ctx context.Context, nzbURL, name, category string, priorit
 		return 0, fmt.Errorf("NZBGet rejected the download (append returned id 0) — check NZBGet's log for the reason. Common causes: disk full, write-permission on the intermediate or destination directory, NZBGet paused with quota reached, or invalid NZB content")
 	}
 	return resp.Result, nil
+}
+
+// appendParams builds the parameter list for NZBGet's append RPC. It sends the
+// nine parameters that NZBGet has required since v13:
+//
+//	name, content, category, priority, addToTop, addPaused, dupeKey, dupeScore, dupeMode
+//
+// The two parameters NZBGet added later — ppParameters (v16) and autoCategory
+// (v25.3) — are deliberately omitted. Both are optional trailing parameters
+// that every NZBGet version parses with unguarded reads (absent ⇒ default), so
+// omitting them is accepted on all versions and behaves identically to sending
+// their defaults (no post-processing params, autoCategory off). This keeps the
+// call version-agnostic and avoids any per-client version state.
+//
+// dupeMode "FORCE" tells NZBGet to add the download unconditionally rather than
+// silently dropping it as a duplicate of a prior history item. Bindery decides
+// what to grab and does its own deduplication, so NZBGet must honour the grab.
+func appendParams(name, encoded, category string, priority int) []any {
+	return []any{name, encoded, category, priority, false, false, "", 0, "FORCE"}
 }
 
 // containsString returns true when needle appears in haystack. Tiny helper
@@ -323,5 +340,26 @@ func (c *Client) call(ctx context.Context, method string, params []any, target a
 		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
 	}
 
-	return json.NewDecoder(resp.Body).Decode(target)
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	// NZBGet signals a failed call with a JSON-RPC "error" object (and a null
+	// result). Without this check an append fault — "Invalid parameter",
+	// malformed NZB, etc. — silently decodes into result 0 and surfaces as a
+	// useless generic "id 0" message. Surface the real reason instead.
+	var probe struct {
+		Error json.RawMessage `json:"error"`
+	}
+	if json.Unmarshal(raw, &probe) == nil && len(probe.Error) > 0 && string(probe.Error) != "null" {
+		var e struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(probe.Error, &e) == nil && e.Message != "" {
+			return fmt.Errorf("NZBGet %s RPC error %d: %s", method, e.Code, e.Message)
+		}
+		return fmt.Errorf("NZBGet %s RPC error: %s", method, string(probe.Error))
+	}
+	return json.Unmarshal(raw, target)
 }

--- a/internal/downloader/nzbget/client_test.go
+++ b/internal/downloader/nzbget/client_test.go
@@ -842,3 +842,86 @@ func TestCheckCategories_ListFails(t *testing.T) {
 		t.Errorf("expected wrapped list error, got: %q", err.Error())
 	}
 }
+
+// TestRPCRequest_ParamsMarshalledLast guards the NZBGet JSON-RPC quirk that
+// forced this fix: NZBGet's param reader overshoots one byte past the final
+// array element, so anything after the params array (e.g. an "id" field) gets
+// misread as a post-processing parameter and the append is rejected with
+// "Invalid parameter (Parameters)". The envelope must therefore end with the
+// params array immediately before the closing brace.
+func TestRPCRequest_ParamsMarshalledLast(t *testing.T) {
+	buf, err := json.Marshal(rpcRequest{
+		Method: "append",
+		ID:     1,
+		Params: []any{"name", "content", "books", 0, false, false, "", 0, "FORCE"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(buf)
+	if !strings.HasSuffix(body, `]}`) {
+		t.Errorf("request must end with the params array then '}'; got: %s", body)
+	}
+	if strings.Index(body, `"params"`) < strings.Index(body, `"id"`) {
+		t.Errorf(`"params" must be marshalled after "id"; got: %s`, body)
+	}
+}
+
+// TestAppendParams_Shape verifies the append RPC is called with exactly the
+// nine version-agnostic parameters in the order NZBGet expects, with the
+// correct JSON types at each position. This is the regression guard for the
+// original bug, where positions 5–8 carried the wrong types (e.g. addPaused
+// got "" instead of a bool), causing NZBGet to silently reject the download
+// with id 0 on every version.
+func TestAppendParams_Shape(t *testing.T) {
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, testNZBContent)
+	}))
+	defer indexerSrv.Close()
+
+	var gotReq rpcRequest
+	nzbgetSrv := nzbgetTestServer(t, []string{"books"}, func(w http.ResponseWriter, r *http.Request) {
+		gotReq = decodeRequest(t, r)
+		json.NewEncoder(w).Encode(appendResponse{Result: 99})
+	})
+	defer nzbgetSrv.Close()
+
+	host, port := serverHostPort(t, nzbgetSrv.URL)
+	c := New(host, port, "user", "pass", "", false)
+	allowNZBFetch(c)
+
+	_, err := c.Add(context.Background(), indexerSrv.URL+"/file.nzb", "Test Book", "books", 7)
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if len(gotReq.Params) != 9 {
+		t.Fatalf("append expects 9 params, got %d: %v", len(gotReq.Params), gotReq.Params)
+	}
+	// Positions and types per NZBGet's append signature:
+	// [name, content, category, priority, addToTop, addPaused, dupeKey, dupeScore, dupeMode].
+	// JSON numbers decode into float64, so check the numeric positions as such.
+	assertString := func(i int, want string) {
+		if got, ok := gotReq.Params[i].(string); !ok || got != want {
+			t.Errorf("param[%d]: want string %q, got %T %v", i, want, gotReq.Params[i], gotReq.Params[i])
+		}
+	}
+	assertBool := func(i int, want bool) {
+		if got, ok := gotReq.Params[i].(bool); !ok || got != want {
+			t.Errorf("param[%d]: want bool %v, got %T %v", i, want, gotReq.Params[i], gotReq.Params[i])
+		}
+	}
+	assertNumber := func(i int, want float64) {
+		if got, ok := gotReq.Params[i].(float64); !ok || got != want {
+			t.Errorf("param[%d]: want number %v, got %T %v", i, want, gotReq.Params[i], gotReq.Params[i])
+		}
+	}
+	assertString(0, "Test Book") // name
+	// param[1] is base64 content — asserted in TestAdd
+	assertString(2, "books") // category
+	assertNumber(3, 7)       // priority
+	assertBool(4, false)     // addToTop
+	assertBool(5, false)     // addPaused
+	assertString(6, "")      // dupeKey
+	assertNumber(7, 0)       // dupeScore
+	assertString(8, "FORCE") // dupeMode
+}

--- a/internal/downloader/nzbget/types.go
+++ b/internal/downloader/nzbget/types.go
@@ -1,10 +1,21 @@
 package nzbget
 
 // rpcRequest is the JSON-RPC request envelope.
+//
+// Field order matters: "params" MUST be marshalled last. NZBGet's JSON
+// param reader (XmlCommand::NextParamAsStr) advances its cursor one byte past
+// each value's trailing delimiter. For the final array element that pushes the
+// cursor past the closing "]" into whatever follows the params array. On the
+// v13 append path NZBGet then reads that trailing text as post-processing
+// "Parameters": if "id" follows params it misreads it and rejects the call with
+// `Invalid parameter (Parameters)`, silently dropping every download. Keeping
+// params last means the overshoot lands on the closing "}", which the parser
+// treats as end-of-params. encoding/json marshals fields in declaration order,
+// so the order below is the wire order.
 type rpcRequest struct {
 	Method string `json:"method"`
-	Params []any  `json:"params"`
 	ID     int    `json:"id"`
+	Params []any  `json:"params"`
 }
 
 // versionResponse is the result of calling the "version" method.


### PR DESCRIPTION
## Summary

NZBGet rejected **every** download with `append returned id 0`, silently breaking all NZBGet grabs regardless of NZBGet version. The real cause is a cursor-overshoot in NZBGet's JSON-RPC parser combined with the order Bindery serialised the request envelope. This makes append return a real NZBID again. Closes #531. Closes #861.

## Root cause

NZBGet's JSON param reader (`XmlCommand::NextParamAsStr`, `daemon/remote/XmlRpc.cpp`) advances its cursor **one byte past** each value's trailing delimiter. For middle params that harmlessly skips the `,` separator; for the **final** element of the `params` array it pushes the cursor past the closing `]` into whatever follows.

On the append "v13 path" (the one that returns the integer NZBID, which Bindery needs to track the download), NZBGet then reads that trailing text as post-processing `Parameters`. Because Bindery emitted the envelope as `{"method":…,"params":[…],"id":1}`, NZBGet misread the trailing `"id"` field and rejected the call with `Invalid parameter (Parameters)` → result `0`.

This was invisible because Bindery's JSON-RPC client never inspected the response's `error` object — the fault decoded silently to `result: 0` and surfaced as the generic "id 0" message.

## Fix

| Change | Why |
|--------|-----|
| Marshal `params` **last** in `rpcRequest` (`{method, id, params}`) | The cursor overshoot now lands on the closing `}`, which NZBGet treats as end-of-params. `encoding/json` emits fields in declaration order, so field order is wire order. |
| Surface NZBGet's JSON-RPC `error` object in `call()` | A real fault ("Invalid parameter", malformed NZB, …) now produces an actionable error instead of a generic "id 0". |
| Send the clean 9-param v13 append signature with correct types | The previous list had wrong types at several positions (e.g. `AddPaused` got `""`). The two later/optional params (`PPParameters` v16, `AutoCategory` v25.3) are omitted — both are optional trailing params on every version and Bindery only ever sent their defaults. |

Verified end-to-end against a live NZBGet **26.1**: grab now returns HTTP 202 and NZBGet assigns a real NZBID; before the fix the identical grab failed with `Invalid parameter (Parameters)` → id 0.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (downloader-internal change; godoc added on `rpcRequest`; no env/config/Helm/README surface change)
- [x] Wiki pages updated if user-facing behaviour changed (n/a)

## Test plan

- [x] `go test -race ./internal/downloader/nzbget/...`
- [x] `go vet ./... && gofmt -l` clean
- [x] Live grab against NZBGet 26.1 → HTTP 202, real NZBID assigned
