### PR TITLE
fix(web): restore author detail alias controls

### DIFF
--- a/changelog.d/author-detail-alias-description.md
+++ b/changelog.d/author-detail-alias-description.md
@@ -1,2 +1,0 @@
-### Changed
-- Author detail pages now restore alias removal controls and render limited inline markdown in descriptions without enabling external links.

--- a/changelog.d/author-detail-alias-description.md
+++ b/changelog.d/author-detail-alias-description.md
@@ -1,0 +1,2 @@
+### Changed
+- Author detail pages now restore alias removal controls and render limited inline markdown in descriptions without enabling external links.

--- a/web/src/api/authors.ts
+++ b/web/src/api/authors.ts
@@ -132,6 +132,8 @@ export const authorsApi = {
       body: candidate ? JSON.stringify(candidate) : undefined,
     }),
   listAuthorAliases: (id: number) => request<AuthorAlias[]>(`/author/${id}/aliases`),
+  deleteAuthorAlias: (authorId: number, aliasId: number) =>
+    request<void>(`/author/${authorId}/aliases/${aliasId}`, { method: 'DELETE' }),
   // listAuthorSeries returns the series the author has books in. Backs the
   // per-author monitor-by-series picker in EditAuthorModal (#810).
   listAuthorSeries: (id: number) => request<Series[]>(`/author/${id}/series`),

--- a/web/src/components/MarkdownDescription.tsx
+++ b/web/src/components/MarkdownDescription.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+
+interface MarkdownDescriptionProps {
+  text: string
+  showMoreLabel: string
+  showLessLabel: string
+  className?: string
+  collapsedLines?: number
+}
+
+const referenceDefinitionRE = /^\s*\[[^\]]+\]:\s+\S+/
+const sourcesLineRE = /^\s*\(Sources?:\s*.*\)\s*$/i
+const inlineTokenRE = /\[([^\]]+)\]\[[^\]]+\]|\*\*([^*\n]+?)\*\*|\*([^*\n]+?)\*/g
+
+function cleanMarkdownDescription(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .split('\n')
+    .filter(line => !referenceDefinitionRE.test(line) && !sourcesLineRE.test(line))
+    .join('\n')
+    .trim()
+}
+
+function descriptionParagraphs(text: string): string[] {
+  const cleaned = cleanMarkdownDescription(text)
+  if (!cleaned) return []
+  return cleaned
+    .split(/\n\s*\n/)
+    .map(paragraph => paragraph.split('\n').map(line => line.trim()).filter(Boolean).join(' '))
+    .filter(Boolean)
+}
+
+function parseInlineMarkdown(text: string, keyPrefix: string): ReactNode[] {
+  const nodes: ReactNode[] = []
+  let lastIndex = 0
+
+  for (const match of text.matchAll(inlineTokenRE)) {
+    const index = match.index ?? 0
+    if (index > lastIndex) {
+      nodes.push(text.slice(lastIndex, index))
+    }
+
+    if (match[1] !== undefined) {
+      nodes.push(
+        <span key={`${keyPrefix}-ref-${index}`}>
+          {parseInlineMarkdown(match[1], `${keyPrefix}-ref-${index}`)}
+        </span>,
+      )
+    } else if (match[2] !== undefined) {
+      nodes.push(<strong key={`${keyPrefix}-strong-${index}`}>{match[2]}</strong>)
+    } else if (match[3] !== undefined) {
+      nodes.push(<em key={`${keyPrefix}-em-${index}`}>{match[3]}</em>)
+    }
+
+    lastIndex = index + match[0].length
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex))
+  }
+
+  return nodes.length > 0 ? nodes : [text]
+}
+
+export default function MarkdownDescription({
+  text,
+  showMoreLabel,
+  showLessLabel,
+  className = '',
+  collapsedLines = 6,
+}: MarkdownDescriptionProps) {
+  const contentId = useId()
+  const contentRef = useRef<HTMLDivElement>(null)
+  const paragraphs = useMemo(() => descriptionParagraphs(text), [text])
+  const [expanded, setExpanded] = useState(false)
+  const [canExpand, setCanExpand] = useState(false)
+  const collapsedStyle: CSSProperties | undefined = expanded
+    ? undefined
+    : {
+        display: '-webkit-box',
+        WebkitLineClamp: collapsedLines,
+        WebkitBoxOrient: 'vertical',
+        overflow: 'hidden',
+      }
+
+  useEffect(() => {
+    setExpanded(false)
+    setCanExpand(false)
+  }, [text])
+
+  useEffect(() => {
+    if (expanded) return
+
+    const measure = () => {
+      const el = contentRef.current
+      if (!el) return
+      setCanExpand(el.scrollHeight > el.clientHeight + 1)
+    }
+
+    measure()
+    const frame = window.requestAnimationFrame(measure)
+    const observer = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measure) : null
+    if (contentRef.current) observer?.observe(contentRef.current)
+    window.addEventListener('resize', measure)
+
+    return () => {
+      window.cancelAnimationFrame(frame)
+      observer?.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [expanded, paragraphs])
+
+  if (paragraphs.length === 0) return null
+
+  return (
+    <div className={className}>
+      <div
+        id={contentId}
+        ref={contentRef}
+        style={collapsedStyle}
+        className="text-sm text-slate-700 dark:text-zinc-300 leading-relaxed"
+      >
+        {paragraphs.map((paragraph, index) => (
+          <span key={index}>
+            {index > 0 && (
+              <>
+                <br />
+                <br />
+              </>
+            )}
+            {parseInlineMarkdown(paragraph, `paragraph-${index}`)}
+          </span>
+        ))}
+      </div>
+      {canExpand && (
+        <button
+          type="button"
+          aria-controls={contentId}
+          aria-expanded={expanded}
+          onClick={() => setExpanded(value => !value)}
+          className="mt-1 text-xs font-medium text-slate-600 hover:text-slate-900 dark:text-zinc-400 dark:hover:text-white"
+        >
+          {expanded ? showLessLabel : showMoreLabel}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -142,6 +142,10 @@
     "bulkRefreshMetadata": "Refresh metadata"
   },
   "authorDetail": {
+    "description": {
+      "showMore": "Show more",
+      "showLess": "Show less"
+    },
     "aliases": {
       "removeConfirm": "Remove alias \"{{name}}\" from {{author}}?",
       "removeLabel": "Remove alias {{name}}",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -142,6 +142,11 @@
     "bulkRefreshMetadata": "Refresh metadata"
   },
   "authorDetail": {
+    "aliases": {
+      "removeConfirm": "Remove alias \"{{name}}\" from {{author}}?",
+      "removeLabel": "Remove alias {{name}}",
+      "removeFailed": "Remove alias failed: {{error}}"
+    },
     "bulk": {
       "monitor": "Monitor",
       "unmonitor": "Unmonitor",

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -21,6 +21,7 @@ vi.mock('../api/client', async importOriginal => {
       relinkAuthorUpstream: vi.fn(),
       updateAuthor: vi.fn(),
       deleteAuthor: vi.fn(),
+      deleteAuthorAlias: vi.fn(),
       searchAuthorWanted: vi.fn(),
       bulkActionBooks: vi.fn(),
     },
@@ -264,6 +265,40 @@ describe('AuthorDetailPage', () => {
     }))
     await waitFor(() => expect(api.getAuthor).toHaveBeenCalledTimes(2))
     expect(screen.queryByRole('heading', { name: 'Link metadata' })).not.toBeInTheDocument()
+  })
+
+  it('removes an author alias after confirmation', async () => {
+    vi.mocked(api.deleteAuthorAlias).mockResolvedValue()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    renderAuthorDetailPage([], 'grid', {
+      aliases: [{ id: 7, authorId: 42, name: 'Robert Jordan', createdAt: '2026-01-01T00:00:00Z' }],
+    })
+
+    await screen.findByText('Robert Jordan')
+    fireEvent.click(screen.getByRole('button', { name: 'Remove alias Robert Jordan' }))
+
+    await waitFor(() => {
+      expect(api.deleteAuthorAlias).toHaveBeenCalledWith(42, 7)
+    })
+    await waitFor(() => {
+      expect(screen.queryByText('Robert Jordan')).not.toBeInTheDocument()
+    })
+    expect(confirmSpy).toHaveBeenCalledWith('Remove alias "Robert Jordan" from Brandon Sanderson?')
+    confirmSpy.mockRestore()
+  })
+
+  it('keeps an author alias when removal is cancelled', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    renderAuthorDetailPage([], 'grid', {
+      aliases: [{ id: 8, authorId: 42, name: 'Pen Name', createdAt: '2026-01-01T00:00:00Z' }],
+    })
+
+    await screen.findByText('Pen Name')
+    fireEvent.click(screen.getByRole('button', { name: 'Remove alias Pen Name' }))
+
+    expect(api.deleteAuthorAlias).not.toHaveBeenCalled()
+    expect(screen.getByText('Pen Name')).toBeInTheDocument()
+    confirmSpy.mockRestore()
   })
 
   it('keeps table metadata visible and repeats it in compact title rows', async () => {

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -113,6 +113,15 @@ function rowForTitle(title: string): HTMLElement {
   return row
 }
 
+function mockElementOverflow(overflows: boolean): () => void {
+  const scrollHeight = vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(overflows ? 120 : 60)
+  const clientHeight = vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(60)
+  return () => {
+    scrollHeight.mockRestore()
+    clientHeight.mockRestore()
+  }
+}
+
 describe('AuthorDetailPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -122,6 +131,63 @@ describe('AuthorDetailPage', () => {
     })
     vi.mocked(api.searchAuthorLinkCandidates).mockResolvedValue([])
     vi.mocked(api.relinkAuthorUpstream).mockResolvedValue(author)
+  })
+
+  it('renders author description markdown without citation noise', async () => {
+    renderAuthorDetailPage([], 'grid', {
+      description: [
+        'Known for the *Mistborn* series and [*Mistborn: The Final Empire*][3].',
+        '',
+        'A **prolific** fantasy author.',
+        '',
+        '(Sources: [1][1],[2][2])',
+        '',
+        '[1]: https://example.com/source',
+        '[3]: https://example.com/mistborn',
+      ].join('\n'),
+    })
+
+    expect(await screen.findByText('Mistborn', { selector: 'em' })).toBeInTheDocument()
+    expect(screen.getByText('Mistborn: The Final Empire', { selector: 'em' })).toBeInTheDocument()
+    expect(screen.getByText('prolific', { selector: 'strong' })).toBeInTheDocument()
+    expect(screen.queryByText(/\*Mistborn\*/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/\[3\]/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Sources:/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/https:\/\/example\.com/)).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /Mistborn: The Final Empire/ })).not.toBeInTheDocument()
+  })
+
+  it('toggles long author descriptions', async () => {
+    const restoreOverflow = mockElementOverflow(true)
+    try {
+      renderAuthorDetailPage([], 'grid', {
+        description: 'Line one.\n\nLine two.\n\nLine three.\n\nLine four.\n\nLine five.\n\nLine six.\n\nLine seven.',
+      })
+
+      const showMore = await screen.findByRole('button', { name: 'Show more' })
+      expect(showMore).toHaveAttribute('aria-expanded', 'false')
+
+      fireEvent.click(showMore)
+
+      const showLess = screen.getByRole('button', { name: 'Show less' })
+      expect(showLess).toHaveAttribute('aria-expanded', 'true')
+    } finally {
+      restoreOverflow()
+    }
+  })
+
+  it('does not show a toggle for short author descriptions', async () => {
+    const restoreOverflow = mockElementOverflow(false)
+    try {
+      renderAuthorDetailPage([], 'grid', {
+        description: 'A short description.',
+      })
+
+      await screen.findByText('A short description.')
+      expect(screen.queryByRole('button', { name: 'Show more' })).not.toBeInTheDocument()
+    } finally {
+      restoreOverflow()
+    }
   })
 
   it('searches all wanted books for the current author', async () => {

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { api, BINDERY_BASE, Author, Book, BookBulkAction } from '../api/client'
+import { api, BINDERY_BASE, Author, AuthorAlias, Book, BookBulkAction } from '../api/client'
 import ViewToggle from '../components/ViewToggle'
 import { bookStatusBadge } from '../components/bookStatus'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
@@ -210,6 +210,23 @@ export default function AuthorDetailPage() {
       navigate('/')
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Delete failed')
+    }
+  }
+
+  const handleDeleteAlias = async (alias: AuthorAlias) => {
+    if (!author) return
+    if (!confirm(t('authorDetail.aliases.removeConfirm', { name: alias.name, author: author.authorName }))) return
+    setError(null)
+    try {
+      await api.deleteAuthorAlias(author.id, alias.id)
+      setAuthor(current => current ? {
+        ...current,
+        aliases: (current.aliases ?? []).filter(a => a.id !== alias.id),
+      } : current)
+    } catch (e) {
+      setError(t('authorDetail.aliases.removeFailed', {
+        error: e instanceof Error ? e.message : String(e),
+      }))
     }
   }
 
@@ -434,10 +451,19 @@ export default function AuthorDetailPage() {
                 {author.aliases.map(a => (
                   <span
                     key={a.id}
-                    className="px-2 py-0.5 rounded bg-slate-200 dark:bg-zinc-800 text-slate-700 dark:text-zinc-300"
+                    className="group/alias inline-flex items-center gap-1 px-2 py-0.5 rounded bg-slate-200 dark:bg-zinc-800 text-slate-700 dark:text-zinc-300"
                     title={a.sourceOlId ? `From ${a.sourceOlId}` : undefined}
                   >
-                    {a.name}
+                    <span>{a.name}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteAlias(a)}
+                      className="ml-0.5 leading-none text-slate-500 hover:text-red-600 focus:text-red-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-red-500 dark:text-zinc-500 dark:hover:text-red-400 dark:focus:text-red-400 opacity-100 transition-opacity [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover/alias:opacity-100 [@media(hover:hover)]:focus:opacity-100 [@media(hover:hover)]:focus-visible:opacity-100"
+                      aria-label={t('authorDetail.aliases.removeLabel', { name: a.name })}
+                      title={t('authorDetail.aliases.removeLabel', { name: a.name })}
+                    >
+                      ×
+                    </button>
                   </span>
                 ))}
               </div>

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -9,6 +9,7 @@ import EditAuthorModal from '../components/EditAuthorModal'
 import AuthorMetadataLinkModal from '../components/AuthorMetadataLinkModal'
 import BulkActionBar from '../components/BulkActionBar'
 import { useView } from '../components/useView'
+import MarkdownDescription from '../components/MarkdownDescription'
 
 type MediaFilter = '' | 'ebook' | 'audiobook'
 type StatusFilter = '' | 'wanted' | 'downloading' | 'downloaded' | 'imported' | 'skipped'
@@ -388,7 +389,12 @@ export default function AuthorDetailPage() {
             )}
           </div>
           {author.description && (
-            <p className="mt-3 text-sm text-slate-700 dark:text-zinc-300 leading-relaxed line-clamp-6">{author.description}</p>
+            <MarkdownDescription
+              text={author.description}
+              showMoreLabel={t('authorDetail.description.showMore', 'Show more')}
+              showLessLabel={t('authorDetail.description.showLess', 'Show less')}
+              className="mt-3"
+            />
           )}
           <div className="flex flex-wrap gap-2 mt-4">
             <button


### PR DESCRIPTION
## Summary

Restores the frontend affordance for scoped author alias deletion backed by the existing `DELETE /author/{id}/aliases/{aliasID}` API introduced in 056f2f7c2fcd00ed05bcc69abe5c9a1731c92221, so aliases can again be removed from the author detail page after confirmation. This also adds a small no-dependency author description renderer that supports limited inline markdown without enabling external links.

- Add the author alias delete API client call, hover/focus remove controls on alias chips, confirmation handling, local state removal after success, and regression coverage for confirm/cancel flows.
- Render author descriptions through a constrained markdown component that strips citation/link reference noise, supports inline emphasis/reference text, and provides show more/show less behavior for long descriptions.
- Cover author description markdown rendering and expansion behavior in `AuthorDetailPage` tests.

## Alternatives considered

A full markdown dependency was considered, but this use case only needs a narrow subset for author descriptions. Avoiding a dependency also avoids enabling external links, where validating link safety would add security work that is unnecessary for this purpose.

## Follow-ups (not in this PR)

- Add the same limited markdown treatment to book descriptions.

## Checklist

- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (N/A - no deployment/config changes)
- [ ] Wiki pages updated if user-facing behaviour changed (N/A - no wiki update for this narrow author detail restoration)

## Test plan

- [x] `npm --prefix web test -- AuthorDetailPage.test.tsx`
- [x] `npm --prefix web run lint` (passed with warnings only)
- [x] `npm --prefix web run typecheck`
- [x] `npm --prefix web run build`
- [x] `make test-web`
- [ ] `make check` (not run; frontend-only change validated with targeted web checks)
