### PR TITLE
fix(security): Go 1.26.4 image build + grype severity-cutoff to clear/stop the failing container scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -232,7 +232,10 @@ jobs:
       # Grype is the single image CVE scanner (it pairs with the Syft SBOM
       # below). Trivy was removed: it overlapped Grype ~90% on image-CVE
       # coverage, doubling scan time and Security-tab noise for little marginal
-      # signal. Grype's fail-build gate keeps CRITICAL/HIGH CVEs blocking.
+      # signal. The fail-build gate keeps CRITICAL/HIGH CVEs blocking; medium
+      # and below are still reported to the Security tab via the SARIF upload
+      # but do not fail the run (severity-cutoff defaults to medium, which made
+      # this advisory job go red on routine, often-unfixable base/stdlib CVEs).
       - name: Grype vulnerability scan (SARIF)
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         id: grype
@@ -240,6 +243,7 @@ jobs:
           image: bindery:scan
           output-format: sarif
           output-file: grype.sarif
+          severity-cutoff: high
           fail-build: true
 
       - name: Upload Grype SARIF

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY web/ .
 RUN npm run build
 
 # Stage 2: Build Go binary (native on BUILDPLATFORM, cross-compile to TARGETOS/TARGETARCH)
-FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/changelog.d/container-scan-go-1.26.4.md
+++ b/changelog.d/container-scan-go-1.26.4.md
@@ -1,0 +1,2 @@
+### Security
+- **Bump the release image's Go toolchain to 1.26.4** — the published Docker image was built with Go 1.26.3, which has known standard-library vulnerabilities (incl. the high-severity CVE-2026-42504) that the container scan flagged. The build now uses the patched Go 1.26.4 release. CI's `go.mod`/test matrix already tracked the patched 1.25.11 line; this aligns the shipped binary.


### PR DESCRIPTION
The **Container Scan** (Grype) job has been red on every recent run. Two fixes, both here.

## 1. The actual vulnerability — bump Go 1.26.3 → 1.26.4
Grype flags the **Go stdlib version compiled into the binary**, not README or base packages:

- builder was `golang:1.26.3-alpine` → embedded `go1.26.3` with 1 high (`CVE-2026-42504` / `GO-2026-5038`) + several medium stdlib CVEs.
- CI's `govulncheck` runs on **1.25.11** (latest 1.25 patch, clean), so it never saw them; only the image scan, which inspects the built binary, did. A Go-version skew: `go.mod` + all CI on 1.25.11, but the shipped binary on 1.26.3.

Bump the builder to **`golang:1.26.4-alpine`** (patched, digest-pinned). `go.mod`/CI stay on 1.25.11.

## 2. The gate — grype `severity-cutoff: high`
The step ran `fail-build: true` with **no** `severity-cutoff`, so it defaulted to failing on **medium**, despite its own comment saying it "keeps CRITICAL/HIGH blocking." That turned routine, often-unfixable medium base/stdlib CVEs into a red advisory job. Now pinned to `high`; medium-and-below are still uploaded to the Security tab via SARIF, they just don't fail the run.

## Verify
Patch-level Go bump, no code change. CI's multi-arch image build validates the Dockerfile; the Container Scan should pass (high stdlib CVE fixed upstream, and the gate now matches its documented intent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)