### PR TITLE
fix(web): add missing common.actionFailed i18n key

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -31,6 +31,7 @@
     "disable": "Disable",
     "connOk": "Connection successful!",
     "connFail": "Test failed: {{error}}",
+    "actionFailed": "Action failed",
     "prev": "Prev",
     "next": "Next",
     "copy": "Copy",


### PR DESCRIPTION
`GoodreadsImportSection.tsx:102` uses `t('common.actionFailed')` as the fallback error message for a non-`Error` throw, but that key was never added to `en.json`. So on that error path the UI would render the literal string `common.actionFailed` instead of a readable message. Adds the key.

Found while probing the UI for bugs (cross-checking every literal `t('...')` key against `en.json`). That audit otherwise came back clean — no other missing keys, no `dangerouslySetInnerHTML`, no stray `console.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)