### PR TITLE
fix(web): render inline [text](url) links in author descriptions

### DIFF
--- a/web/src/components/MarkdownDescription.tsx
+++ b/web/src/components/MarkdownDescription.tsx
@@ -11,7 +11,16 @@ interface MarkdownDescriptionProps {
 
 const referenceDefinitionRE = /^\s*\[[^\]]+\]:\s+\S+/
 const sourcesLineRE = /^\s*\(Sources?:\s*.*\)\s*$/i
-const inlineTokenRE = /\[([^\]]+)\]\[[^\]]+\]|\*\*([^*\n]+?)\*\*|\*([^*\n]+?)\*/g
+// Inline tokens, in priority order: [text](url) inline link, [text][ref]
+// reference link (rendered as plain text — the [ref]: defs are stripped),
+// **bold**, *italic*.
+const inlineTokenRE = /\[([^\]]+)\]\(([^)\s]+)\)|\[([^\]]+)\]\[[^\]]+\]|\*\*([^*\n]+?)\*\*|\*([^*\n]+?)\*/g
+
+// safeHref returns url only when it is an http(s) URL, so a description from an
+// upstream metadata provider can't inject javascript:/data: links.
+function safeHref(url: string): string {
+  return /^https?:\/\//i.test(url) ? url : ''
+}
 
 function cleanMarkdownDescription(text: string): string {
   return text
@@ -43,15 +52,35 @@ function parseInlineMarkdown(text: string, keyPrefix: string): ReactNode[] {
     }
 
     if (match[1] !== undefined) {
+      // [text](url) inline link. Render an anchor only for safe http(s) URLs;
+      // otherwise fall back to the link text so nothing dangerous is emitted.
+      const href = safeHref(match[2])
+      const inner = parseInlineMarkdown(match[1], `${keyPrefix}-link-${index}`)
+      nodes.push(
+        href ? (
+          <a
+            key={`${keyPrefix}-link-${index}`}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+            className="text-emerald-600 dark:text-emerald-400 underline hover:no-underline"
+          >
+            {inner}
+          </a>
+        ) : (
+          <span key={`${keyPrefix}-link-${index}`}>{inner}</span>
+        ),
+      )
+    } else if (match[3] !== undefined) {
       nodes.push(
         <span key={`${keyPrefix}-ref-${index}`}>
-          {parseInlineMarkdown(match[1], `${keyPrefix}-ref-${index}`)}
+          {parseInlineMarkdown(match[3], `${keyPrefix}-ref-${index}`)}
         </span>,
       )
-    } else if (match[2] !== undefined) {
-      nodes.push(<strong key={`${keyPrefix}-strong-${index}`}>{match[2]}</strong>)
-    } else if (match[3] !== undefined) {
-      nodes.push(<em key={`${keyPrefix}-em-${index}`}>{match[3]}</em>)
+    } else if (match[4] !== undefined) {
+      nodes.push(<strong key={`${keyPrefix}-strong-${index}`}>{match[4]}</strong>)
+    } else if (match[5] !== undefined) {
+      nodes.push(<em key={`${keyPrefix}-em-${index}`}>{match[5]}</em>)
     }
 
     lastIndex = index + match[0].length

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -157,6 +157,22 @@ describe('AuthorDetailPage', () => {
     expect(screen.queryByRole('link', { name: /Mistborn: The Final Empire/ })).not.toBeInTheDocument()
   })
 
+  it('renders inline [text](url) links as safe anchors', async () => {
+    renderAuthorDetailPage([], 'grid', {
+      description: 'See [Wikipedia (EN)](https://en.wikipedia.org/wiki/Brandon_Sanderson) for more. Also [bad](javascript:alert(1)) here.',
+    })
+
+    const link = await screen.findByRole('link', { name: 'Wikipedia (EN)' })
+    expect(link).toHaveAttribute('href', 'https://en.wikipedia.org/wiki/Brandon_Sanderson')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    expect(link).toHaveAttribute('target', '_blank')
+    // The raw markdown syntax must not leak through.
+    expect(screen.queryByText(/\]\(https/)).not.toBeInTheDocument()
+    // A non-http(s) URL must NOT become a link (no javascript: anchor).
+    expect(screen.queryByRole('link', { name: 'bad' })).not.toBeInTheDocument()
+    expect(screen.getByText('bad')).toBeInTheDocument()
+  })
+
   it('toggles long author descriptions', async () => {
     const restoreOverflow = mockElementOverflow(true)
     try {


### PR DESCRIPTION
Part of the UI bug sweep (P1 — author description rendering).

## Scope note
Most of the original P1 report (raw markdown, no bold, no show-more, "(Sources:)" shown) reflected **v1.17.0 / the stale dev env** — those were already fixed on `main` by #1018's `MarkdownDescription`. The one real gap remaining on current `main`: its inline tokenizer matched reference-style `[text][ref]` but **not** inline `[text](url)` links, which rendered literally.

## Fix
Extend the existing (dependency-free) renderer to handle inline `[text](url)`:
- Emits an `<a target="_blank" rel="noopener noreferrer nofollow">` **only** for `http(s)` URLs.
- Any other scheme (`javascript:`, `data:`, …) falls back to rendering the link text — no unsafe anchor.
- Reference-style links and the "(Sources:)" strip are unchanged.

I deliberately did **not** swap in react-markdown/remark-gfm — #1018 chose a hand-rolled, no-dependency renderer specifically to avoid enabling arbitrary external links / the sanitize burden, and this keeps that posture while rendering the links you want.

## Repro
Author with an OpenLibrary bio containing `[Wikipedia (EN)](https://…)` → previously showed the raw `[Wikipedia (EN)](https://…)`; now a clickable link.

## Tests
`AuthorDetailPage.test.tsx`: added a case asserting an inline link renders as an anchor with the right href/rel/target, the raw syntax doesn't leak, and a `javascript:` URL does **not** become a link. 16/16 pass, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)