### PR TITLE
fix(web): paginate the queue and summarize raw error bodies

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -245,6 +245,7 @@
   "queue": {
     "title": "Queue",
     "empty": "Queue is empty",
+    "errorDetails": "Show full error",
     "remaining": "{{time}} remaining",
     "retryImport": "Retry import",
     "retryingImport": "Retrying…",

--- a/web/src/pages/QueuePage.test.tsx
+++ b/web/src/pages/QueuePage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import QueuePage from './QueuePage'
+import { summarizeError, ERROR_SUMMARY_LEN } from './queueError'
 import { api } from '../api/client'
 import type { Download, PendingRelease, QueueItem } from '../api/client'
 
@@ -34,6 +35,7 @@ vi.mock('react-i18next', () => ({
         'queue.retryingImport': 'Retrying…',
         'queue.retryImportHint': 'After fixing the path remap or moving the completed files in the download client, retry import to reuse the existing download.',
         'queue.retryImportError': `Retry failed: ${String(options?.error)}`,
+        'queue.errorDetails': 'Show full error',
       }
       return labels[key] ?? key
     },
@@ -119,6 +121,20 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
+describe('summarizeError', () => {
+  it('returns short plain messages unchanged', () => {
+    expect(summarizeError('Missing target folder')).toBe('Missing target folder')
+  })
+  it('strips HTML tags and collapses whitespace', () => {
+    expect(summarizeError('HTTP 403: <h1>Forbidden</h1>\n\n  <p>nope</p>')).toBe('HTTP 403: Forbidden nope')
+  })
+  it('truncates over the limit with an ellipsis', () => {
+    const out = summarizeError('x'.repeat(ERROR_SUMMARY_LEN + 50))
+    expect(out.length).toBe(ERROR_SUMMARY_LEN + 1) // limit chars + the ellipsis
+    expect(out.endsWith('…')).toBe(true)
+  })
+})
+
 describe('QueuePage', () => {
   it('renders loading and then the empty queue state', async () => {
     const queueLoad = deferred<QueueItem[]>()
@@ -193,6 +209,19 @@ describe('QueuePage', () => {
     expect(screen.getByText('Client rejected download')).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: 'Retry import' })).toHaveLength(1)
     expect(container.querySelector('[style="width: 45%;"]')).toBeInTheDocument()
+  })
+
+  it('shows a "full error" expander for a long raw-HTML error body', async () => {
+    const htmlBody = 'fetch nzb: indexer returned HTTP 403: <!DOCTYPE html><html><head><title>Forbidden</title></head><body>' +
+      '<h1>403 Forbidden</h1>'.repeat(40) + '</body></html>'
+    vi.mocked(api.listQueue).mockResolvedValue([
+      makeQueueItem({ id: 9, title: 'Huge Error', status: 'failed', errorMessage: htmlBody }),
+    ])
+
+    renderQueuePage()
+    await screen.findByText('Huge Error')
+    // A long error gets a collapsed details expander rather than dumping inline.
+    expect(screen.getByText('Show full error')).toBeInTheDocument()
   })
 
   it('retries an import-failed queue item and reloads the queue', async () => {

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -2,6 +2,9 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, PendingRelease, QueueItem } from '../api/client'
 import BookAuthorLink from '../components/BookAuthorLink'
+import Pagination from '../components/Pagination'
+import { usePagination } from '../components/usePagination'
+import { summarizeError, ERROR_SUMMARY_LEN } from './queueError'
 
 export default function QueuePage() {
   const { t } = useTranslation()
@@ -35,6 +38,10 @@ export default function QueuePage() {
     document.title = 'Queue · Bindery'
     return () => { document.title = 'Bindery' }
   }, [])
+
+  // Paginate the queue client-side so a large queue (hundreds/thousands of
+  // items) doesn't render every row at once and blow up the DOM.
+  const { pageItems: queuePage, paginationProps: queuePaginationProps } = usePagination(queue, 50, 'queue')
 
   // Open the remove dialog. The file-deletion choice always starts unchecked
   // so the default action keeps downloaded data (and torrent seeds) on disk.
@@ -184,7 +191,7 @@ export default function QueuePage() {
         <div className="space-y-6">
           {queue.length > 0 && (
             <div className="space-y-2">
-              {queue.map(item => (
+              {queuePage.map(item => (
                 <div key={item.id} className="flex items-center justify-between p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
                   <div className="min-w-0 flex-1">
                     <h3 className="font-medium text-sm truncate">{item.title}</h3>
@@ -226,7 +233,17 @@ export default function QueuePage() {
                             ? 'Import blocked: '
                             : 'Error: '}
                         </span>
-                        {item.errorMessage}
+                        {summarizeError(item.errorMessage)}
+                        {item.errorMessage.length > ERROR_SUMMARY_LEN && (
+                          <details className="mt-1">
+                            <summary className="cursor-pointer text-red-300 hover:text-red-200">
+                              {t('queue.errorDetails', 'Show full error')}
+                            </summary>
+                            <pre className="mt-1 max-h-48 overflow-auto whitespace-pre-wrap text-[10px] text-red-300">
+                              {item.errorMessage.slice(0, 4000)}
+                            </pre>
+                          </details>
+                        )}
                       </div>
                     )}
                     {item.status === 'importFailed' && (
@@ -268,6 +285,7 @@ export default function QueuePage() {
                   </div>
                 </div>
               ))}
+              <Pagination {...queuePaginationProps} />
             </div>
           )}
 

--- a/web/src/pages/queueError.ts
+++ b/web/src/pages/queueError.ts
@@ -1,0 +1,11 @@
+// Queue error messages can be raw upstream bodies (e.g. an indexer 403 that
+// returns a full HTML page). summarizeError strips tags, collapses whitespace,
+// and truncates so the queue cell shows a readable one-liner instead of dumping
+// thousands of characters of markup; the full text stays available behind the
+// details expander in QueuePage.
+export const ERROR_SUMMARY_LEN = 200
+
+export function summarizeError(msg: string): string {
+  const stripped = msg.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim()
+  return stripped.length > ERROR_SUMMARY_LEN ? stripped.slice(0, ERROR_SUMMARY_LEN) + '…' : stripped
+}


### PR DESCRIPTION
P1 from the UI bug sweep.

## Symptoms
- `/queue` rendered **every** item at once (no pagination) — a large queue (~1,200 items observed) produced ~17k DOM nodes.
- Failed items printed the full raw upstream error verbatim, e.g. `Error: fetch nzb: indexer returned HTTP 403: <!DOCTYPE html> …` — thousands of characters of HTML in the cell.

## Fix (frontend-only)
- **Pagination:** queue list now uses `usePagination` (50/page) + the shared `Pagination` control, consistent with Books/Authors. Bounds the DOM regardless of queue size.
- **Error summary:** `summarizeError()` (new `queueError.ts`) strips HTML tags, collapses whitespace, and truncates to 200 chars for the inline cell. The full body (capped at 4k) is available behind a collapsed **Show full error** `<details>` expander. (React already escapes text, so there was no XSS — the issue was raw size/readability.)

## Tests
Unit tests for `summarizeError` (passthrough / tag-strip / truncate) + a render test that a long error gets the expander. 13/13 pass; typecheck + lint clean.

Note: this bounds the *DOM*. The `/queue` API still returns the whole list; a server-paginated queue endpoint is a sensible follow-up if queues routinely run into the thousands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)