### PR TITLE
fix(web): deep-link Settings sub-tabs (/blocklist -> Blocklist tab)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -274,7 +274,7 @@ function Shell() {
             <Route path="/calendar" element={<CalendarPage />} />
             <Route path="/discover" element={<DiscoverPage />} />
             <Route path="/search" element={<SearchPage />} />
-            <Route path="/blocklist" element={<Navigate to="/settings" replace />} />
+            <Route path="/blocklist" element={<Navigate to="/settings?tab=blocklist" replace />} />
             <Route path="/settings" element={<SettingsPage />} />
             {isAdmin && <Route path="/users" element={<UsersPage />} />}
           </Routes>

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../api/client', async importOriginal => {
     ...actual,
     api: {
       ...actual.api,
+      listBlocklist: vi.fn(),
       listIndexers: vi.fn(),
       addIndexer: vi.fn(),
       updateIndexer: vi.fn(),
@@ -341,6 +342,11 @@ function sectionForHeading(name: string) {
 describe('SettingsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // SettingsPage syncs the active tab into ?tab= via replaceState; reset it
+    // between tests so a tab selected in one test doesn't leak into the next
+    // test's initial tab (jsdom shares one location across the file).
+    window.history.replaceState(null, '', '/settings')
+    vi.mocked(api.listBlocklist).mockResolvedValue([])
     mockAuthContext.status = {
       authenticated: true,
       setupRequired: false,
@@ -363,6 +369,14 @@ describe('SettingsPage', () => {
       configurable: true,
     })
     seedSettingsMocks()
+  })
+
+  it('deep-links to the blocklist tab via ?tab=blocklist', async () => {
+    window.history.replaceState(null, '', '/settings?tab=blocklist')
+    renderSettings()
+    // BlocklistTab renders its title; the General tab would not. (The t() mock
+    // returns the key, so we assert on the key the blocklist tab emits.)
+    expect(await screen.findByText('blocklist.title')).toBeInTheDocument()
   })
 
   it('adds a write-only Hardcover token field with API link', async () => {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, DownloadClient, Indexer, ProwlarrInstance } from '../api/client'
 import { useAuth } from '../auth/AuthContext'
@@ -64,7 +64,21 @@ function SettingsNavLink({ tab, active, onSelect, label }: { tab: Tab; active: T
 export default function SettingsPage() {
   const { t } = useTranslation()
   const { isAdmin } = useAuth()
-  const [tab, setTab] = useState<Tab>(initialTabFromUrl)
+  const [tab, setTabState] = useState<Tab>(initialTabFromUrl)
+
+  // Keep the active tab in the URL (?tab=…) so every Settings sub-tab is
+  // deep-linkable and survives a refresh/back. replaceState (not a router
+  // navigate) avoids piling a history entry per tab click while still letting
+  // initialTabFromUrl pick the tab on a fresh load (e.g. /blocklist redirects
+  // to /settings?tab=blocklist).
+  const setTab = useCallback((next: Tab) => {
+    setTabState(next)
+    try {
+      const url = new URL(window.location.href)
+      url.searchParams.set('tab', next)
+      window.history.replaceState(window.history.state, '', url)
+    } catch { /* ignore — tab state still updates */ }
+  }, [])
 
   // Eagerly fetched on page mount (cross-tab — see file header note).
   const [indexers, setIndexers] = useState<Indexer[]>([])
@@ -106,7 +120,7 @@ export default function SettingsPage() {
     if (!isAdmin && ADMIN_TABS.includes(tab)) {
       setTab('general')
     }
-  }, [isAdmin, tab])
+  }, [isAdmin, tab, setTab])
 
   return (
     <div>


### PR DESCRIPTION
P2 from the UI bug sweep.

## Symptom
Hard-navigating to `/blocklist` rewrote the URL to `/settings` and showed the **General** tab, not the Blocklist view.

## Cause
`/blocklist` was `<Navigate to="/settings">` (no tab), and although `SettingsPage` already reads `?tab=` on first load, the redirect dropped it and tab clicks never wrote the tab back to the URL — so no Settings sub-tab was deep-linkable.

## Fix
- `/blocklist` → `/settings?tab=blocklist`.
- `SettingsPage` syncs the active tab into `?tab=` via `replaceState` on every selection, so all sub-tabs are deep-linkable and survive refresh/back (no extra history entry per click).

## Tests
Added a test that `?tab=blocklist` renders the Blocklist tab; reset the URL in `beforeEach` so the new replaceState doesn't leak `?tab` across tests. 45/45 pass, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)