### PR TITLE
fix(api): refresh-all status returns 200 idle instead of 404

### DIFF
--- a/internal/api/author_refresh.go
+++ b/internal/api/author_refresh.go
@@ -175,15 +175,17 @@ func (h *AuthorRefreshHandler) persist(ctx context.Context, status authorRefresh
 	}
 }
 
-// RefreshAllStatus serves the last refresh-all progress as JSON, or 404 if no
-// job has ever run. If the stored status says "running" but no job is actually
-// running in this process (e.g. the server restarted mid-job), it is reported
-// as "failed" with an "interrupted by restart" message so the UI banner does
-// not hang forever. The reconciled value is written back once so subsequent
-// reads are consistent.
+// RefreshAllStatus serves the last refresh-all progress as JSON, or a 200
+// {"status":"idle"} when no job has ever run. (It previously 404'd for "no job
+// run", which the Authors page polls on every load — surfacing a 404 per page
+// view and conflating "no job" with a real error; idle is the honest signal.)
+// If the stored status says "running" but no job is actually running in this
+// process (e.g. the server restarted mid-job), it is reported as "failed" with
+// an "interrupted by restart" message so the UI banner does not hang forever.
+// The reconciled value is written back once so subsequent reads are consistent.
 func (h *AuthorRefreshHandler) RefreshAllStatus(w http.ResponseWriter, r *http.Request) {
 	if h.settings == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no refresh result available"})
+		writeJSON(w, http.StatusOK, map[string]string{"status": "idle"})
 		return
 	}
 	setting, err := h.settings.Get(r.Context(), SettingAuthorBulkRefresh)
@@ -192,7 +194,7 @@ func (h *AuthorRefreshHandler) RefreshAllStatus(w http.ResponseWriter, r *http.R
 		return
 	}
 	if setting == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no refresh result available"})
+		writeJSON(w, http.StatusOK, map[string]string{"status": "idle"})
 		return
 	}
 

--- a/internal/api/author_refresh_test.go
+++ b/internal/api/author_refresh_test.go
@@ -167,12 +167,21 @@ func TestAuthorRefresh_ConcurrentReturns409(t *testing.T) {
 	close(release)
 }
 
-func TestAuthorRefresh_StatusNotFoundBeforeRun(t *testing.T) {
+func TestAuthorRefresh_StatusIdleBeforeRun(t *testing.T) {
 	h, _ := refreshTestFixture(t, &stubAuthorLister{}, func(_ *models.Author) {})
 	w := httptest.NewRecorder()
 	h.RefreshAllStatus(w, httptest.NewRequest(http.MethodGet, "/authors/refresh-all/status", nil))
-	if w.Code != http.StatusNotFound {
-		t.Fatalf("status = %d, want 404", w.Code)
+	// Before any job has run, status is a 200 idle state (not a 404) so the
+	// Authors page poll doesn't surface a 404 on every load.
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["status"] != "idle" {
+		t.Fatalf("status field = %q, want %q", got["status"], "idle")
 	}
 }
 

--- a/web/src/api/authors.ts
+++ b/web/src/api/authors.ts
@@ -147,9 +147,10 @@ export const authorsApi = {
   // per-selection bulkActionAuthors('refresh'): this enumerates every author and
   // refreshes sequentially with progress that survives a page reload.
   refreshAllAuthors: () => request<{ message: string }>('/authors/refresh-all', { method: 'POST' }),
-  // Returns null when no refresh has ever run (the backend serves 404). A
-  // stored "running" status is reconciled to "failed" server-side after a
-  // restart so the UI banner never hangs.
+  // The backend returns a 200 {status:"idle"} when no refresh has ever run. The
+  // 404 fallback is kept for back-compat with older servers that 404'd that
+  // case. A stored "running" status is reconciled to "failed" server-side after
+  // a restart so the UI banner never hangs.
   refreshAllAuthorsStatus: () =>
     request<AuthorRefreshStatus>('/authors/refresh-all/status').catch((err) => {
       if (err instanceof ApiError && err.status === 404) return null
@@ -161,7 +162,7 @@ export const authorsApi = {
 // "running" while the job iterates authors, "completed" when done, or "failed"
 // (e.g. the author list could not be loaded, or the server restarted mid-job).
 export interface AuthorRefreshStatus {
-  status: 'running' | 'completed' | 'failed'
+  status: 'idle' | 'running' | 'completed' | 'failed'
   total: number
   done: number
   failed: number


### PR DESCRIPTION
P2 from the UI bug sweep.

## Finding
The Authors page polls `GET /authors/refresh-all/status` on every load. The route is correctly registered (not a mispath), but it **404'd by design** when no refresh job had ever run, and the client treated that 404 as "idle". So every Authors visit logged a 404, and a real error was indistinguishable from "no job".

(The report also mentioned a "singular variant" and Books polling it — neither is the case: only the Authors page calls the plural path.)

## Fix
Return `200 {"status":"idle"}` for the no-job case instead of 404. Frontend `AuthorRefreshStatus.status` gains `'idle'` (renders no banner, same as before). The client keeps its 404 fallback so it still works against older servers.

## Tests
`TestAuthorRefresh_StatusIdleBeforeRun` (was `…NotFoundBeforeRun`) now asserts 200 + `status:"idle"`. Go + frontend typecheck/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)