### PR TITLE
fix(web): set Search page document title

### DIFF
--- a/web/src/pages/SearchPage.tsx
+++ b/web/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { api, isNoDownloadClientError, SearchResult } from '../api/client'
@@ -24,6 +24,11 @@ export default function SearchPage() {
   // empty, which the first-run guidance (#960) didn't cover (#968).
   const [needsClient, setNeedsClient] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    document.title = 'Search · Bindery'
+    return () => { document.title = 'Bindery' }
+  }, [])
 
   const search = async () => {
     const q = query.trim()


### PR DESCRIPTION
P3 from the UI bug sweep. The Search Indexers page (`/search`) never set `document.title`, so it stayed "Bindery" while every other route sets "X · Bindery". Added the standard per-page title effect ("Search · Bindery"). Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)