### PR TITLE
fix(web): friendly labels for history event types

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -233,6 +233,18 @@
   "history": {
     "title": "History",
     "allEventTypes": "All event types",
+    "events": {
+      "grabbed": "Grabbed",
+      "downloadFailed": "Download Failed",
+      "downloadStalled": "Download Stalled",
+      "downloadRequeued": "Download Requeued",
+      "downloadFolderImported": "Folder Imported",
+      "importFailed": "Import Failed",
+      "bookImported": "Book Imported",
+      "bookFileDeleted": "File Deleted",
+      "bookRenamed": "File Renamed",
+      "bookRebound": "Rebound"
+    },
     "empty": "No history events found",
     "colEvent": "Event",
     "colSourceTitle": "Source Title",

--- a/web/src/pages/HistoryPage.test.tsx
+++ b/web/src/pages/HistoryPage.test.tsx
@@ -20,9 +20,12 @@ vi.mock('../api/client', async importOriginal => {
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => {
+    t: (key: string, opts?: { defaultValue?: string }) => {
       const labels: Record<string, string> = {
         'common.loading': 'Loading...',
+        'history.events.grabbed': 'Grabbed',
+        'history.events.downloadFailed': 'Download Failed',
+        'history.events.importFailed': 'Import Failed',
         'history.title': 'History',
         'history.allEventTypes': 'All event types',
         'history.empty': 'No history events found',
@@ -34,7 +37,7 @@ vi.mock('react-i18next', () => ({
         'history.blocklist': 'Blocklist',
         'history.delete': 'Delete',
       }
-      return labels[key] ?? key
+      return labels[key] ?? opts?.defaultValue ?? key
     },
   }),
 }))
@@ -143,18 +146,18 @@ describe('HistoryPage', () => {
     expect(await within(table).findByText('Dune EPUB')).toBeInTheDocument()
 
     const ebookRow = rowFor('Dune EPUB')
-    expect(within(ebookRow).getByText('grabbed')).toBeInTheDocument()
+    expect(within(ebookRow).getByText('Grabbed')).toBeInTheDocument()
     expect(within(ebookRow).getByText('/library/Dune.epub')).toBeInTheDocument()
     expect(within(ebookRow).getByText('📖 Ebook')).toBeInTheDocument()
     expect(within(ebookRow).getByText('1 MB')).toBeInTheDocument()
 
     const audioRow = rowFor('Dune MP3')
-    expect(within(audioRow).getByText('downloadFailed')).toBeInTheDocument()
+    expect(within(audioRow).getByText('Download Failed')).toBeInTheDocument()
     expect(within(audioRow).getByText('Download client rejected release')).toBeInTheDocument()
     expect(within(audioRow).getByText('🎧 Audiobook')).toBeInTheDocument()
     expect(within(audioRow).getByText('2.0 GB')).toBeInTheDocument()
 
-    const importedRow = rowFor('bookImported')
+    const importedRow = rowFor('Book Imported')
     expect(within(importedRow).getAllByText('—').length).toBeGreaterThan(0)
   })
 

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -17,6 +17,14 @@ const EVENT_TYPE_COLORS: Record<string, string> = {
   bookFileRenamed: 'bg-purple-500/20 text-purple-400',
 }
 
+// humanizeEventType turns a camelCase event enum into a Title Case fallback
+// ("downloadFailed" -> "Download Failed") for any type without a curated i18n
+// label, so a newly-added event type never renders as a raw identifier.
+function humanizeEventType(type: string): string {
+  const spaced = type.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
 function formatDate(s: string) {
   return new Date(s).toLocaleString(undefined, {
     year: 'numeric', month: 'short', day: 'numeric',
@@ -54,6 +62,13 @@ export default function HistoryPage() {
   const [events, setEvents] = useState<HistoryEvent[]>([])
   const [loading, setLoading] = useState(true)
   const [typeFilter, setTypeFilter] = useState('')
+
+  // Friendly label for an event-type enum: curated i18n where available, else a
+  // humanized camelCase fallback. Keeps the enum as the filter <option> value.
+  const eventLabel = useCallback(
+    (type: string) => t(`history.events.${type}`, { defaultValue: humanizeEventType(type) }),
+    [t],
+  )
 
   const load = useCallback((filter?: string) => {
     api.listHistory(filter ? { eventType: filter } : undefined)
@@ -101,8 +116,8 @@ export default function HistoryPage() {
           className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-1.5 text-sm text-slate-800 dark:text-zinc-200 focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
         >
           <option value="">{t('history.allEventTypes')}</option>
-          {eventTypes.map(t => (
-            <option key={t} value={t}>{t}</option>
+          {eventTypes.map(et => (
+            <option key={et} value={et}>{eventLabel(et)}</option>
           ))}
         </select>
       </div>
@@ -140,7 +155,7 @@ export default function HistoryPage() {
                       <tr key={event.id} className="bg-slate-100/50 dark:bg-zinc-900/50 hover:bg-slate-200/50 dark:hover:bg-zinc-800/50 transition-colors">
                         <td className="px-4 py-3 align-top">
                           <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${EVENT_TYPE_COLORS[event.eventType] ?? 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
-                            {event.eventType}
+                            {eventLabel(event.eventType)}
                           </span>
                         </td>
                         <td className="px-4 py-3 text-slate-800 dark:text-zinc-200 max-w-md">
@@ -207,7 +222,7 @@ export default function HistoryPage() {
                   <div className="flex items-start justify-between gap-2 mb-2">
                     <div className="flex flex-wrap items-center gap-1.5">
                       <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium flex-shrink-0 ${EVENT_TYPE_COLORS[event.eventType] ?? 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}>
-                        {event.eventType}
+                        {eventLabel(event.eventType)}
                       </span>
                       {mt === 'audiobook' && (
                         <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300 text-[10px] font-medium">🎧</span>


### PR DESCRIPTION
P3 from the UI bug sweep. The History event-type filter and Type column showed raw enums (`downloadFailed`, `grabbed`, `importFailed`). Now mapped to friendly labels via i18n `history.events.*` with a camelCase-humanizing fallback (so a new event type degrades to "Title Case" rather than a raw id). The filter `<option>` value stays the enum, so filtering behaviour is unchanged. Tests updated; 6/6 pass, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)