### PR TITLE
fix(web): calendar fetches only the visible month

### DIFF
--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -295,10 +295,12 @@ func (h *BookHandler) List(w http.ResponseWriter, r *http.Request) {
 		// monitored=1 for "wanted" — matching what the Books page showed when
 		// it filtered client-side over the full set.
 		books, total, err = h.books.ListPageFiltered(r.Context(), db.BookListFilter{
-			Search:    strings.TrimSpace(r.URL.Query().Get("search")),
-			Status:    status,
-			MediaType: r.URL.Query().Get("mediaType"),
-			Sort:      r.URL.Query().Get("sort"),
+			Search:        strings.TrimSpace(r.URL.Query().Get("search")),
+			Status:        status,
+			MediaType:     r.URL.Query().Get("mediaType"),
+			Sort:          r.URL.Query().Get("sort"),
+			ReleaseFrom:   strings.TrimSpace(r.URL.Query().Get("releaseFrom")),
+			ReleaseBefore: strings.TrimSpace(r.URL.Query().Get("releaseBefore")),
 		}, limit, offset)
 	}
 

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -219,6 +219,13 @@ type BookListFilter struct {
 	MediaType string
 	// Sort is one of "title-az" (default), "title-za", "date-new", "date-old".
 	Sort string
+	// ReleaseFrom / ReleaseBefore bound release_date to [ReleaseFrom, ReleaseBefore)
+	// (ISO date strings; lexical compare works for ISO-8601). Used by the
+	// calendar to fetch a single month instead of the whole library. Empty
+	// disables each bound; rows with a NULL release_date are excluded when either
+	// bound is set.
+	ReleaseFrom   string
+	ReleaseBefore string
 }
 
 // bookSortOrder maps a whitelisted sort key to a fixed ORDER BY clause. Never
@@ -268,6 +275,14 @@ func (r *BookRepo) ListPageFiltered(ctx context.Context, f BookListFilter, limit
 		where += " AND (books.media_type IN ('ebook','both') OR books.media_type IS NULL OR books.media_type = '')"
 	case "audiobook":
 		where += " AND books.media_type IN ('audiobook','both')"
+	}
+	if rf := strings.TrimSpace(f.ReleaseFrom); rf != "" {
+		where += " AND books.release_date >= ?"
+		args = append(args, rf)
+	}
+	if rb := strings.TrimSpace(f.ReleaseBefore); rb != "" {
+		where += " AND books.release_date < ?"
+		args = append(args, rb)
 	}
 
 	total, err := r.count(ctx, bookCTE+" SELECT COUNT(*) FROM books "+bookJoins+" "+where, args)

--- a/internal/db/list_filtered_test.go
+++ b/internal/db/list_filtered_test.go
@@ -3,9 +3,60 @@ package db
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/vavallee/bindery/internal/models"
 )
+
+// TestBookRepo_ListPageFiltered_ReleaseRange covers the calendar's date-range
+// query: [ReleaseFrom, ReleaseBefore) on release_date, excluding NULL dates.
+func TestBookRepo_ListPageFiltered_ReleaseRange(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	ctx := context.Background()
+
+	author := &models.Author{ForeignID: "OL-RA", Name: "Range Author", SortName: "Author, Range", Monitored: true}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	mk := func(title, date string) {
+		b := &models.Book{ForeignID: "OL-R" + title, AuthorID: author.ID, Title: title, SortTitle: title, MediaType: models.MediaTypeEbook}
+		if date != "" {
+			d, perr := time.Parse("2006-01-02", date)
+			if perr != nil {
+				t.Fatal(perr)
+			}
+			b.ReleaseDate = &d
+		}
+		if err := bookRepo.Create(ctx, b); err != nil {
+			t.Fatalf("seed %s: %v", title, err)
+		}
+	}
+	mk("May", "2026-05-20")
+	mk("JuneEarly", "2026-06-02")
+	mk("JuneLate", "2026-06-29")
+	mk("July", "2026-07-03")
+	mk("NoDate", "")
+
+	// June only: [2026-06-01, 2026-07-01)
+	got, total, err := bookRepo.ListPageFiltered(ctx, BookListFilter{
+		ReleaseFrom: "2026-06-01", ReleaseBefore: "2026-07-01", Sort: "date-old",
+	}, 50, 0)
+	if err != nil {
+		t.Fatalf("range: %v", err)
+	}
+	if total != 2 || len(got) != 2 {
+		t.Fatalf("June range total=%d len=%d, want 2 (JuneEarly, JuneLate)", total, len(got))
+	}
+	if got[0].Title != "JuneEarly" || got[1].Title != "JuneLate" {
+		t.Errorf("June range = [%s, %s], want [JuneEarly, JuneLate]", got[0].Title, got[1].Title)
+	}
+}
 
 // TestAuthorRepo_ListPageFiltered_Pagination is the direct regression test for
 // issue #1010 bug 1: a library with more authors than one page must be fully

--- a/web/src/api/books.ts
+++ b/web/src/api/books.ts
@@ -115,7 +115,7 @@ export const booksApi = {
     request<Book>('/author/book', { method: 'POST', body: JSON.stringify(data) }),
 
   // Books
-  listBooks: (params?: { authorId?: number; status?: string; includeExcluded?: boolean; limit?: number; offset?: number; search?: string; mediaType?: string; sort?: string }) => {
+  listBooks: (params?: { authorId?: number; status?: string; includeExcluded?: boolean; limit?: number; offset?: number; search?: string; mediaType?: string; sort?: string; releaseFrom?: string; releaseBefore?: string }) => {
     const q = new URLSearchParams()
     if (params?.authorId) q.set('authorId', String(params.authorId))
     if (params?.status) q.set('status', params.status)
@@ -125,6 +125,8 @@ export const booksApi = {
     if (params?.search) q.set('search', params.search)
     if (params?.mediaType) q.set('mediaType', params.mediaType)
     if (params?.sort) q.set('sort', params.sort)
+    if (params?.releaseFrom) q.set('releaseFrom', params.releaseFrom)
+    if (params?.releaseBefore) q.set('releaseBefore', params.releaseBefore)
     const qs = q.toString()
     return request<Page<Book>>(`/book${qs ? '?' + qs : ''}`)
   },

--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -26,11 +26,22 @@ export default function CalendarPage() {
   const [viewYear, setViewYear] = useState(today.getFullYear())
   const [viewMonth, setViewMonth] = useState(today.getMonth())
 
+  // Fetch only the visible month's releases (a scoped server query) rather than
+  // pulling the whole library and filtering client-side. Re-fetches when the
+  // month changes. releaseFrom is inclusive, releaseBefore exclusive (the 1st of
+  // the next month), so the query is exactly [month-start, next-month-start).
   useEffect(() => {
-    // The calendar plots every upcoming release, so it needs the full set, not
-    // one paginated page (listBooks now caps at 100 by default — #1010).
-    api.listAllBooks().then(setBooks).catch(console.error).finally(() => setLoading(false))
-  }, [])
+    const pad = (n: number) => String(n).padStart(2, '0')
+    const from = `${viewYear}-${pad(viewMonth + 1)}-01`
+    const beforeYear = viewMonth === 11 ? viewYear + 1 : viewYear
+    const beforeMonth = viewMonth === 11 ? 0 : viewMonth + 1
+    const before = `${beforeYear}-${pad(beforeMonth + 1)}-01`
+    setLoading(true)
+    api.listBooks({ releaseFrom: from, releaseBefore: before, limit: 500 })
+      .then(({ items }) => setBooks(items))
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [viewYear, viewMonth])
 
   useEffect(() => {
     document.title = 'Calendar · Bindery'


### PR DESCRIPTION
P2 from the UI bug sweep.

## Symptom
`/calendar` issued sequential `GET /book?limit=500&offset=…` calls covering the **whole library** (≈9 calls for ~4,185 books) just to compute one month's grid.

## Fix
Add a date-range filter to the book list query and have the calendar request only the visible month.

- **Backend:** `BookListFilter.ReleaseFrom` (inclusive) / `ReleaseBefore` (exclusive) → `release_date >= ? AND release_date < ?` in `ListPageFiltered`; the `/book` handler parses `releaseFrom` / `releaseBefore`. ISO-date lexical compare, NULL release dates excluded.
- **Frontend:** `listBooks` gains the two params; `CalendarPage` fetches `[month-start, next-month-start)` with `limit=500` and re-fetches on month navigation, instead of `listAllBooks`.

## Tests
`TestBookRepo_ListPageFiltered_ReleaseRange` (June-only window excludes May/July/NULL). Go + full web suite green, golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)