### PR TITLE
fix(web): semantic AA text-color tokens (contrast)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -147,7 +147,7 @@ function Shell() {
                     href={`https://github.com/vavallee/bindery/releases/tag/v${version}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="hidden lg:block text-xs text-slate-500 dark:text-zinc-600 hover:underline whitespace-nowrap"
+                    className="hidden lg:block text-xs text-fg-muted hover:underline whitespace-nowrap"
                   >
                     {`v${version}`}
                   </a>
@@ -156,14 +156,14 @@ function Shell() {
                     href="https://github.com/vavallee/bindery/releases"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="hidden lg:block text-xs text-slate-500 dark:text-zinc-600 hover:underline whitespace-nowrap"
+                    className="hidden lg:block text-xs text-fg-muted hover:underline whitespace-nowrap"
                   >{version}</a>
                 )
               )}
               {status?.authenticated && status.mode !== 'disabled' && (
                 <button
                   onClick={logout}
-                  className="hidden lg:block text-xs text-slate-500 dark:text-zinc-500 hover:text-slate-900 dark:hover:text-white transition-colors"
+                  className="hidden lg:block text-xs text-fg-muted hover:text-slate-900 dark:hover:text-white transition-colors"
                   title={status.username ? `${t('login.signedInAs')} ${status.username}` : t('login.signOut')}
                 >
                   {t('login.signOut')}
@@ -249,7 +249,7 @@ function Shell() {
               {status?.authenticated && status.mode !== 'disabled' && (
                 <button
                   onClick={logout}
-                  className="text-xs text-slate-500 dark:text-zinc-500 hover:text-slate-900 dark:hover:text-white transition-colors"
+                  className="text-xs text-fg-muted hover:text-slate-900 dark:hover:text-white transition-colors"
                 >
                   {t('login.signOut')}
                 </button>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,7 +1,30 @@
 @import "tailwindcss";
 @config "../tailwind.config.js";
 
+/* Semantic text-color tokens (WCAG AA). The app otherwise uses raw slate/zinc
+   utilities; several muted pairings fail contrast (secondary text on zinc-500,
+   the faint version/placeholder zinc-600, and green text links on light). These
+   tokens are CSS vars that flip with the .dark class and are exposed to Tailwind
+   via @theme inline, generating `text-fg-muted` / `text-accent-text` utilities
+   that resolve to an AA-passing shade in each theme. Values verified in
+   src/theme/contrast.test.ts.
+     - fg-muted:    secondary text — slate-600 (light) / zinc-400 (dark)
+     - accent-text: green text/links on a surface — emerald-700 (light) /
+       emerald-400 (dark); the bare emerald-400 was ~1.76:1 on light. */
 @layer base {
+  :root {
+    --fg-muted: #475569;     /* slate-600 */
+    --accent-text: #047857;  /* emerald-700 */
+  }
+  html.dark {
+    --fg-muted: #a1a1aa;     /* zinc-400 */
+    --accent-text: #34d399;  /* emerald-400 */
+  }
   html { background-color: rgb(248 250 252); } /* slate-50 */
   html.dark { background-color: rgb(9 9 11); } /* zinc-950 */
+}
+
+@theme inline {
+  --color-fg-muted: var(--fg-muted);
+  --color-accent-text: var(--accent-text);
 }

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -120,7 +120,7 @@ export default function BooksPage() {
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-2xl font-bold">{t('books.title')}</h2>
         <div className="flex items-center gap-3">
-          <span className="text-sm text-slate-600 dark:text-zinc-500">{t('books.countLabel', { count: total, defaultValue: '{{count}} books' })}</span>
+          <span className="text-sm text-fg-muted">{t('books.countLabel', { count: total, defaultValue: '{{count}} books' })}</span>
           <ViewToggle view={view} onChange={setView} />
         </div>
       </div>
@@ -321,7 +321,7 @@ export default function BooksPage() {
                     <a
                       href={`${BINDERY_BASE}/api/v1/book/${book.id}/file`}
                       onClick={e => e.stopPropagation()}
-                      className="text-[10px] text-emerald-400 hover:text-emerald-300"
+                      className="text-[10px] text-accent-text hover:underline"
                       title={t('books.downloadFile')}
                     >
                       {t('books.download')}

--- a/web/src/theme/contrast.test.ts
+++ b/web/src/theme/contrast.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+
+// WCAG 2.1 relative-luminance + contrast ratio for sRGB hex colors.
+function srgbToLinear(c: number): number {
+  const cs = c / 255
+  return cs <= 0.03928 ? cs / 12.92 : Math.pow((cs + 0.055) / 1.055, 2.4)
+}
+function luminance(hex: string): number {
+  const h = hex.replace('#', '')
+  const r = parseInt(h.slice(0, 2), 16)
+  const g = parseInt(h.slice(2, 4), 16)
+  const b = parseInt(h.slice(4, 6), 16)
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b)
+}
+function contrast(a: string, b: string): number {
+  const la = luminance(a)
+  const lb = luminance(b)
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05)
+}
+
+// Surfaces the tokens render on. Light: slate-50 page / slate-100 cards.
+// Dark: zinc-950 page / zinc-900 cards.
+const SURFACES = {
+  lightPage: '#f8fafc',
+  lightCard: '#f1f5f9',
+  darkPage: '#09090b',
+  darkCard: '#18181b',
+}
+
+// The semantic tokens defined in index.css (kept in sync by hand — this test
+// is the guard that they stay AA).
+const TOKENS = {
+  fgMuted: { light: '#475569', dark: '#a1a1aa' }, // slate-600 / zinc-400
+  accentText: { light: '#047857', dark: '#34d399' }, // emerald-700 / emerald-400
+}
+
+const AA_NORMAL = 4.5
+
+describe('theme text tokens meet WCAG AA on app surfaces', () => {
+  const cases: Array<[string, string, string]> = [
+    ['fg-muted light on slate-50', TOKENS.fgMuted.light, SURFACES.lightPage],
+    ['fg-muted light on slate-100', TOKENS.fgMuted.light, SURFACES.lightCard],
+    ['fg-muted dark on zinc-950', TOKENS.fgMuted.dark, SURFACES.darkPage],
+    ['fg-muted dark on zinc-900', TOKENS.fgMuted.dark, SURFACES.darkCard],
+    ['accent-text light on slate-50', TOKENS.accentText.light, SURFACES.lightPage],
+    ['accent-text light on slate-100', TOKENS.accentText.light, SURFACES.lightCard],
+    ['accent-text dark on zinc-950', TOKENS.accentText.dark, SURFACES.darkPage],
+    ['accent-text dark on zinc-900', TOKENS.accentText.dark, SURFACES.darkCard],
+  ]
+  for (const [name, fg, bg] of cases) {
+    it(`${name} >= ${AA_NORMAL}:1`, () => {
+      expect(contrast(fg, bg)).toBeGreaterThanOrEqual(AA_NORMAL)
+    })
+  }
+
+  it('regression: the old bare emerald-400 fails on light (why accent-text exists)', () => {
+    expect(contrast('#34d399', SURFACES.lightCard)).toBeLessThan(AA_NORMAL)
+  })
+})


### PR DESCRIPTION
P1 from the UX/contrast review.

## Premise correction
The report assumed an oklch token config to bump. This codebase has **none** — `index.css` was just `@import "tailwindcss"` + class dark mode, and all colors are raw slate/zinc utilities. So I added the token layer the report wanted.

## What
Tailwind v4 `@theme inline` semantic tokens backed by CSS vars that flip with `.dark`:
- **`text-fg-muted`** — secondary text: slate-600 (light) / zinc-400 (dark)
- **`text-accent-text`** — green text/links on a surface: emerald-700 (light) / emerald-400 (dark)

Both clear **4.5:1** on the app surfaces (slate-50/slate-100, zinc-950/zinc-900) in both themes.

Migrated the cited failures to the tokens:
- Books **"Download"** link (`text-emerald-400`, ~1.76:1 on light) → `text-accent-text` + underline
- Books count ("N books"), navbar **version** label, **Sign out** (faint zinc-500/600) → `text-fg-muted`

## Acceptance
`src/theme/contrast.test.ts` computes WCAG ratios for every token×surface pair and asserts AA, plus a regression assert that the old bare emerald-400 *failed* on light. 9/9 pass; build confirms the `@theme` utilities generate.

## Scope note
This lands the token layer + the worst offenders. Remaining muted-text utilities across other pages can adopt `text-fg-muted` incrementally (didn't blanket-migrate ~30 files in one PR). **Token change affects both themes — review the two values together.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)