### PR TITLE
fix(web): constrain author bio to a readable measure

### DIFF
--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -393,7 +393,7 @@ export default function AuthorDetailPage() {
               text={author.description}
               showMoreLabel={t('authorDetail.description.showMore', 'Show more')}
               showLessLabel={t('authorDetail.description.showLess', 'Show less')}
-              className="mt-3"
+              className="mt-3 max-w-prose"
             />
           )}
           <div className="flex flex-wrap gap-2 mt-4">


### PR DESCRIPTION
P2 from the UX review. The author detail description spanned the full ~1,150px content width (130+ char lines). Wrapped it in `max-w-prose` (~65ch) so long-form text reads comfortably; grids/other layout untouched. Typecheck + AuthorDetailPage tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)