### PR TITLE
fix(web): shared button vocabulary + AA-safe destructive buttons

### DIFF
--- a/web/src/components/buttons.ts
+++ b/web/src/components/buttons.ts
@@ -1,0 +1,44 @@
+// Shared button vocabulary. Call sites used to invent their own class strings
+// per button, which drifted in two ways: emphasis was inconsistent, and most
+// destructive actions were a bare `text-red-400 hover:text-red-300` with no
+// light-mode pairing — red-400 on a light surface fails WCAG AA. These variants
+// carry their own slate(light)/zinc(dark) pairing so danger is AA-safe in both
+// themes and primary/secondary/tertiary emphasis is consistent everywhere.
+//
+// Colour semantics (see ui-design): emerald = primary, red = destructive,
+// slate/zinc = neutral.
+//
+// Variants are colour/emphasis only — compose a size from `btnSize` so call
+// sites that need a larger touch target don't end up with two conflicting
+// padding utilities on one element: `className={`${btn.danger} ${btnSize.sm}`}`.
+
+const base =
+  'inline-flex items-center justify-center gap-1.5 rounded-md font-medium transition-colors ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1 ' +
+  'focus-visible:ring-offset-slate-100 dark:focus-visible:ring-offset-zinc-900 ' +
+  'disabled:opacity-50 disabled:cursor-not-allowed'
+
+export const btn = {
+  // Primary action (grab, save, add an entity).
+  primary: `${base} bg-emerald-600 hover:bg-emerald-500 text-white focus-visible:ring-emerald-500`,
+  // Secondary action (filled neutral, lower weight than primary).
+  secondary: `${base} bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 text-slate-800 dark:text-zinc-200 focus-visible:ring-slate-400`,
+  // Tertiary action (ghost, lowest emphasis — e.g. row "Refresh").
+  ghost: `${base} text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200/60 dark:hover:bg-zinc-800/60 focus-visible:ring-slate-400`,
+  // Destructive action: ghost-danger button (outlined + tinted hover). AA-safe
+  // in both themes. Pair with a confirmation at the call site — this is styling,
+  // not a guard.
+  danger: `${base} border border-red-300 dark:border-red-900/70 text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-950/40 focus-visible:ring-red-500`,
+} as const
+
+export const btnSize = {
+  sm: 'px-2.5 py-1 text-xs',
+  md: 'px-3 py-1.5 text-sm',
+  lg: 'px-3 py-2 text-xs', // larger touch target (queue row actions)
+} as const
+
+// Inline destructive link, for dense list rows where a bordered button would be
+// too heavy. Properly paired for light + dark — use this instead of a bare
+// `text-red-400`, which is invisible-to-low-contrast on light surfaces.
+export const dangerLink =
+  'text-red-700 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 transition-colors'

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -10,6 +10,7 @@ import AuthorMetadataLinkModal from '../components/AuthorMetadataLinkModal'
 import BulkActionBar from '../components/BulkActionBar'
 import { useView } from '../components/useView'
 import MarkdownDescription from '../components/MarkdownDescription'
+import { btn } from '../components/buttons'
 
 type MediaFilter = '' | 'ebook' | 'audiobook'
 type StatusFilter = '' | 'wanted' | 'downloading' | 'downloaded' | 'imported' | 'skipped'
@@ -413,7 +414,7 @@ export default function AuthorDetailPage() {
             {showMetadataLinkAction && (
               <button
                 onClick={() => setShowMetadataLink(true)}
-                className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium"
+                className={`${btn.secondary} px-3 py-1.5 text-xs`}
               >
                 {metadataLinkLabel}
               </button>
@@ -428,7 +429,7 @@ export default function AuthorDetailPage() {
             </button>
             <button
               onClick={() => setShowEdit(true)}
-              className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium"
+              className={`${btn.secondary} px-3 py-1.5 text-xs`}
               title="Edit quality, metadata, and root folder"
             >
               Edit
@@ -438,14 +439,14 @@ export default function AuthorDetailPage() {
                 if (allAuthors.length === 0) api.listAllAuthors().then(setAllAuthors).catch(console.error)
                 setShowMerge(true)
               }}
-              className="px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium"
+              className={`${btn.secondary} px-3 py-1.5 text-xs`}
               title="Merge another author into this one"
             >
               Merge…
             </button>
             <button
               onClick={handleDelete}
-              className="px-3 py-1.5 text-red-600 dark:text-red-400 hover:text-red-500 text-xs font-medium"
+              className={`${btn.danger} px-3 py-1.5 text-xs`}
             >
               Delete
             </button>

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -13,6 +13,7 @@ import ViewToggle from '../components/ViewToggle'
 import { useView } from '../components/useView'
 import GettingStartedGuidance from '../components/GettingStartedGuidance'
 import { useNeedsSetup } from '../components/useNeedsSetup'
+import { btn, btnSize } from '../components/buttons'
 
 type SortMode = 'az' | 'za' | 'recent'
 type MonitoredFilter = '' | 'monitored' | 'unmonitored'
@@ -395,13 +396,13 @@ export default function AuthorsPage() {
                     <td className="px-3 py-2 text-right whitespace-nowrap">
                       <button
                         onClick={() => api.refreshAuthor(author.id).then(load)}
-                        className="text-xs text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white mr-3"
+                        className={`${btn.ghost} ${btnSize.sm} mr-3`}
                       >
                         {t('common.refresh')}
                       </button>
                       <button
                         onClick={() => handleDelete(author.id)}
-                        className="text-xs text-red-400 hover:text-red-300"
+                        className={`${btn.danger} ${btnSize.sm}`}
                       >
                         {t('common.delete')}
                       </button>
@@ -453,14 +454,14 @@ export default function AuthorsPage() {
                 <div className="flex gap-2">
                   <button
                     onClick={() => api.refreshAuthor(author.id).then(load)}
-                    className="text-xs text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white"
+                    className={`${btn.ghost} ${btnSize.sm}`}
                     title="Refresh metadata"
                   >
                     {t('common.refresh')}
                   </button>
                   <button
                     onClick={() => handleDelete(author.id)}
-                    className="text-xs text-red-400 hover:text-red-300"
+                    className={`${btn.danger} ${btnSize.sm}`}
                   >
                     {t('common.delete')}
                   </button>

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -4,6 +4,7 @@ import { api, HistoryEvent } from '../api/client'
 import BookAuthorLink from '../components/BookAuthorLink'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
+import { dangerLink } from '../components/buttons'
 
 const EVENT_TYPE_COLORS: Record<string, string> = {
   grabbed: 'bg-blue-500/20 text-blue-400',
@@ -196,7 +197,7 @@ export default function HistoryPage() {
                           )}
                           <button
                             onClick={() => handleDelete(event.id)}
-                            className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                            className={`text-xs ${dangerLink}`}
                           >
                             {t('history.delete')}
                           </button>
@@ -256,7 +257,7 @@ export default function HistoryPage() {
                     )}
                     <button
                       onClick={() => handleDelete(event.id)}
-                      className="text-xs text-red-400 hover:text-red-300 transition-colors py-1"
+                      className={`text-xs py-1 ${dangerLink}`}
                     >
                       {t('history.delete')}
                     </button>

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -5,6 +5,7 @@ import BookAuthorLink from '../components/BookAuthorLink'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
 import { summarizeError, ERROR_SUMMARY_LEN } from './queueError'
+import { btn, btnSize } from '../components/buttons'
 
 export default function QueuePage() {
   const { t } = useTranslation()
@@ -278,7 +279,7 @@ export default function QueuePage() {
                     )}
                     <button
                       onClick={() => openDeleteDialog(item)}
-                      className="px-3 py-2 text-xs text-red-400 hover:text-red-300 touch-manipulation"
+                      className={`${btn.danger} ${btnSize.lg} touch-manipulation`}
                     >
                       {t('queue.remove')}
                     </button>

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -4,6 +4,7 @@ import { api, Series, SeriesFillBookRequest, SeriesHardcoverDiff, SeriesHardcove
 import AddSeriesBookModal from '../components/AddSeriesBookModal'
 import HardcoverSeriesLinkModal from '../components/HardcoverSeriesLinkModal'
 import SeriesNameModal from '../components/SeriesNameModal'
+import { btn, btnSize } from '../components/buttons'
 
 export default function SeriesPage() {
   const location = useLocation()
@@ -301,7 +302,7 @@ export default function SeriesPage() {
                   )}
                   <button
                     onClick={() => deleteSeries(series)}
-                    className="text-xs px-2.5 py-1 rounded font-medium text-red-500 hover:text-red-400 hover:bg-red-500/10"
+                    className={`${btn.danger} ${btnSize.sm}`}
                   >
                     Delete
                   </button>

--- a/web/src/pages/settings/BlocklistTab.tsx
+++ b/web/src/pages/settings/BlocklistTab.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { api, BlocklistEntry } from '../../api/client'
 import Pagination from '../../components/Pagination'
 import { usePagination } from '../../components/usePagination'
+import { dangerLink } from '../../components/buttons'
 
 function formatBlocklistDate(s: string) {
   return new Date(s).toLocaleString(undefined, {
@@ -142,7 +143,7 @@ export default function BlocklistTab() {
                       <td className="px-4 py-3 text-right">
                         <button
                           onClick={() => handleDelete(entry.id)}
-                          className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                          className={`text-xs ${dangerLink}`}
                         >
                           {t('common.delete')}
                         </button>
@@ -191,7 +192,7 @@ export default function BlocklistTab() {
                   </div>
                   <button
                     onClick={() => handleDelete(entry.id)}
-                    className="text-xs text-red-400 hover:text-red-300 transition-colors flex-shrink-0 py-1 px-2"
+                    className={`text-xs flex-shrink-0 py-1 px-2 ${dangerLink}`}
                   >
                     {t('common.delete')}
                   </button>

--- a/web/src/pages/settings/ClientsTab.tsx
+++ b/web/src/pages/settings/ClientsTab.tsx
@@ -5,6 +5,7 @@ import { inputCls } from './formStyles'
 import Toggle from './Toggle'
 import PathRemapField from './PathRemapField'
 import { downloadClientPathRemapHelp } from './helpers'
+import { dangerLink } from '../../components/buttons'
 
 // clients is owned by SettingsPage so it can be fetched eagerly on page mount
 // (matching the pre-refactor monolith), not on tab open.
@@ -76,12 +77,12 @@ export default function ClientsTab({ clients, setClients }: Props) {
                           setClients(clients.filter(x => x.id !== c.id))
                           setConfirmDeleteClient(null)
                         }}
-                        className="text-xs text-red-500 font-medium hover:text-red-400"
+                        className={`text-xs font-medium ${dangerLink}`}
                       >{t('common.yes')}</button>
                       <button onClick={() => setConfirmDeleteClient(null)} className="text-xs text-slate-500 dark:text-zinc-500 hover:text-slate-700 dark:hover:text-zinc-300">{t('common.no')}</button>
                     </span>
                   ) : (
-                    <button onClick={() => setConfirmDeleteClient(c.id)} className="text-xs text-red-400 hover:text-red-300">
+                    <button onClick={() => setConfirmDeleteClient(c.id)} className={`text-xs ${dangerLink}`}>
                       {t('common.delete')}
                     </button>
                   )}

--- a/web/src/pages/settings/IndexersTab.tsx
+++ b/web/src/pages/settings/IndexersTab.tsx
@@ -4,6 +4,7 @@ import { api, Indexer, IndexerTestResult, ProwlarrInstance } from '../../api/cli
 import { inputCls } from './formStyles'
 import { parseCats, parsePriority } from './helpers'
 import Toggle from './Toggle'
+import { dangerLink } from '../../components/buttons'
 
 // IndexerTestResultBanner renders a probe result with the same ok/warn/fail
 // semantics as the saved-row Test feedback (ok=true + 0 results → amber warn).
@@ -105,12 +106,12 @@ export default function IndexersTab({ indexers, setIndexers, prowlarrInstances, 
                           setIndexers(indexers.filter(i => i.id !== idx.id))
                           setConfirmDeleteIndexer(null)
                         }}
-                        className="text-xs text-red-500 font-medium hover:text-red-400"
+                        className={`text-xs font-medium ${dangerLink}`}
                       >{t('common.yes')}</button>
                       <button onClick={() => setConfirmDeleteIndexer(null)} className="text-xs text-slate-500 dark:text-zinc-500 hover:text-slate-700 dark:hover:text-zinc-300">{t('common.no')}</button>
                     </span>
                   ) : (
-                    <button onClick={() => setConfirmDeleteIndexer(idx.id)} className="text-xs text-red-400 hover:text-red-300">
+                    <button onClick={() => setConfirmDeleteIndexer(idx.id)} className={`text-xs ${dangerLink}`}>
                       {t('common.delete')}
                     </button>
                   )}
@@ -230,7 +231,7 @@ export default function IndexersTab({ indexers, setIndexers, prowlarrInstances, 
                       setProwlarrInstances(prev => prev.filter(i => i.id !== p.id))
                       api.listIndexers().then(setIndexers).catch(console.error)
                     }}
-                    className="text-xs text-red-400 hover:text-red-300"
+                    className={`text-xs ${dangerLink}`}
                   >
                     {t('settings.prowlarr.delete')}
                   </button>

--- a/web/src/pages/settings/MetadataTab.tsx
+++ b/web/src/pages/settings/MetadataTab.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, MetadataProfile } from '../../api/client'
 import { inputCls } from './formStyles'
+import { dangerLink } from '../../components/buttons'
 
 // KNOWN_LANGUAGES are the ISO 639-2/B codes exposed in the profile editor.
 // We keep the list short rather than dumping the full ISO catalogue because
@@ -94,7 +95,7 @@ export default function MetadataTab() {
                         await api.deleteMetadataProfile(p.id)
                         reload()
                       }}
-                      className="text-xs text-red-400 hover:text-red-300"
+                      className={`text-xs ${dangerLink}`}
                     >
                       {t('common.delete')}
                     </button>

--- a/web/src/pages/settings/NotificationsTab.tsx
+++ b/web/src/pages/settings/NotificationsTab.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { api, NotificationConfig } from '../../api/client'
 import { inputCls } from './formStyles'
 import Toggle from './Toggle'
+import { dangerLink } from '../../components/buttons'
 
 export default function NotificationsTab() {
   const { t } = useTranslation()
@@ -77,12 +78,12 @@ export default function NotificationsTab() {
                             setNotifications(notifications.filter(x => x.id !== n.id))
                             setConfirmDeleteNotification(null)
                           }}
-                          className="text-xs text-red-500 font-medium hover:text-red-400"
+                          className={`text-xs font-medium ${dangerLink}`}
                         >{t('common.yes')}</button>
                         <button onClick={() => setConfirmDeleteNotification(null)} className="text-xs text-slate-500 dark:text-zinc-500 hover:text-slate-700 dark:hover:text-zinc-300">{t('common.no')}</button>
                       </span>
                     ) : (
-                      <button onClick={() => setConfirmDeleteNotification(n.id)} className="text-xs text-red-400 hover:text-red-300">
+                      <button onClick={() => setConfirmDeleteNotification(n.id)} className={`text-xs ${dangerLink}`}>
                         {t('common.delete')}
                       </button>
                     )}

--- a/web/src/pages/settings/QualityTab.tsx
+++ b/web/src/pages/settings/QualityTab.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, QualityProfile } from '../../api/client'
 import { inputCls, labelCls } from './formStyles'
+import { dangerLink } from '../../components/buttons'
 
 // EBOOK_FORMATS and AUDIOBOOK_FORMATS are the format keys the rest of the
 // backend (decision.QualityRank, QualityFromFilename) already understands.
@@ -159,7 +160,7 @@ function ProfileRow({
             type="button"
             onClick={handleDelete}
             disabled={deleting}
-            className="text-xs text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 disabled:opacity-50"
+            className={`text-xs disabled:opacity-50 ${dangerLink}`}
           >
             {deleting ? t('common.deleting') : t('common.delete')}
           </button>
@@ -347,7 +348,7 @@ function QualityProfileForm({
                 type="button"
                 onClick={() => removeItem(item.quality)}
                 aria-label={t('common.remove')}
-                className="text-xs px-1.5 py-0.5 text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300"
+                className={`text-xs px-1.5 py-0.5 ${dangerLink}`}
               >
                 {'×'}
               </button>


### PR DESCRIPTION
## What

P3 affordance fix (1 of 2): establishes a consistent **button vocabulary** and fixes a latent light-mode contrast bug.

New `web/src/components/buttons.ts`:
- `btn.primary` (emerald) / `btn.secondary` (filled neutral) / `btn.ghost` (tertiary) / `btn.danger` (outlined ghost-danger)
- `btnSize.sm|md|lg` size tokens (kept separate from variants so call sites needing a bigger touch target don't stack two conflicting paddings)
- `dangerLink` inline destructive link for dense list rows

## Why

Most destructive actions were `text-red-400 hover:text-red-300` with **no `dark:` pairing**. `red-400` (#f87171) on a light surface is ~3.7:1 — fails WCAG AA for normal text. The vocabulary bakes in the slate(light)/zinc(dark) + red-700/red-300 pairing, so this migration is also a contrast fix.

## Changed

- **Prominent destructive → `btn.danger`** (outlined): Authors delete (grid+table), Queue remove, Author-detail delete, Series delete.
- **Neutral → `btn.ghost`/`btn.secondary`**: Authors "Refresh", Author-detail "Edit"/"Merge…" (demonstrates the full vocabulary).
- **Inline list-row delete links → `dangerLink`** (AA-safe): History (×2), and settings tabs Blocklist, Metadata, Notifications, Clients, Indexers, Quality.

Confirmation dialogs are unchanged — this is styling only.

## Before / after

- Before: `text-red-400 hover:text-red-300` (invisible-ish on light, no border, inconsistent per call site).
- After: outlined ghost-danger button (prominent) or paired red-700/red-400 link (inline), focus-ring included, AA in both themes.

## Verify

- Light + dark, narrow widths.
- `npm run typecheck` clean · `npm run lint` (only pre-existing warnings) · `npm test` 286 pass · `npm run build` clean.

## Token note (affects both themes)

`buttons.ts` is the single source of truth for button colour/emphasis; `btn.danger`/`dangerLink` define the destructive palette for light **and** dark. Review alongside #1037 (text-colour tokens) since both touch the shared theme surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)