### PR TITLE
fix(web): toggle-vs-badge affordance, status legend, AA badge fixes

### DIFF
--- a/web/src/components/BookStatusLegend.tsx
+++ b/web/src/components/BookStatusLegend.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from 'react-i18next'
+import { bookStatusBadge } from './bookStatus'
+
+// Collapsible legend for the library status pills. It renders each swatch via
+// bookStatusBadge so the legend always matches the real badges (same labels,
+// same AA-checked colours) instead of being a hand-maintained copy that drifts.
+const ENTRIES: Array<{ status: string; monitored: boolean }> = [
+  { status: 'wanted', monitored: true },
+  { status: 'downloading', monitored: true },
+  { status: 'downloaded', monitored: true },
+  { status: 'imported', monitored: true },
+  { status: 'skipped', monitored: true },
+  { status: 'wanted', monitored: false }, // resolves to "Not monitored"
+]
+
+export default function BookStatusLegend() {
+  const { t } = useTranslation()
+  return (
+    <details className="mb-4 text-xs text-slate-600 dark:text-zinc-400">
+      <summary className="cursor-pointer select-none hover:text-slate-900 dark:hover:text-white">
+        {t('books.legendTitle', 'What do the status labels mean?')}
+      </summary>
+      <ul className="mt-2 flex flex-wrap gap-x-4 gap-y-2">
+        {ENTRIES.map(({ status, monitored }) => {
+          const badge = bookStatusBadge(status, monitored, t)
+          return (
+            <li key={`${status}-${monitored}`}>
+              <span className={`px-2 py-0.5 rounded text-[10px] font-medium ${badge.colorClass}`}>
+                {badge.label}
+              </span>
+            </li>
+          )
+        })}
+      </ul>
+    </details>
+  )
+}

--- a/web/src/components/Switch.tsx
+++ b/web/src/components/Switch.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react'
+
+interface SwitchProps {
+  checked: boolean
+  onChange: () => void
+  /** Accessible name (and tooltip, unless `title` is given). */
+  label: string
+  /** Optional visible text rendered next to the switch. */
+  children?: ReactNode
+  title?: string
+  className?: string
+}
+
+// A toggle switch (sliding knob), used for controls like "Monitored" that the
+// user can flip — distinct from a read-only status badge (see bookStatus). The
+// sliding affordance is the whole point: a badge and a toggle must not look
+// alike, or users can't tell which pills they can click. Track/knob sizing
+// matches the original inline switch on the Series page.
+export default function Switch({ checked, onChange, label, children, title, className = '' }: SwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      title={title ?? label}
+      onClick={onChange}
+      className={`group inline-flex items-center gap-2 focus-visible:outline-none ${className}`}
+    >
+      <span
+        className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 group-focus-visible:ring-2 group-focus-visible:ring-emerald-500 group-focus-visible:ring-offset-1 group-focus-visible:ring-offset-slate-100 dark:group-focus-visible:ring-offset-zinc-900 ${checked ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
+      >
+        <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${checked ? 'translate-x-4' : ''}`} />
+      </span>
+      {children != null && <span className="text-xs font-medium text-slate-700 dark:text-zinc-300">{children}</span>}
+    </button>
+  )
+}

--- a/web/src/components/ViewToggle.tsx
+++ b/web/src/components/ViewToggle.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import type { View } from './useView'
 
 interface Props {
@@ -6,6 +7,7 @@ interface Props {
 }
 
 export default function ViewToggle({ view, onChange }: Props) {
+  const { t } = useTranslation()
   const btn = (v: View) =>
     `px-2 py-1 rounded text-xs font-medium transition-colors ${
       view === v
@@ -14,8 +16,24 @@ export default function ViewToggle({ view, onChange }: Props) {
     }`
   return (
     <div className="inline-flex gap-1 border border-slate-200 dark:border-zinc-800 rounded p-0.5">
-      <button onClick={() => onChange('grid')} className={btn('grid')} title="Grid view">▦</button>
-      <button onClick={() => onChange('table')} className={btn('table')} title="Table view">☰</button>
+      <button
+        onClick={() => onChange('grid')}
+        className={btn('grid')}
+        title={t('common.gridView')}
+        aria-label={t('common.gridView')}
+        aria-pressed={view === 'grid'}
+      >
+        ▦
+      </button>
+      <button
+        onClick={() => onChange('table')}
+        className={btn('table')}
+        title={t('common.tableView')}
+        aria-label={t('common.tableView')}
+        aria-pressed={view === 'table'}
+      >
+        ☰
+      </button>
     </div>
   )
 }

--- a/web/src/components/bookStatus.test.ts
+++ b/web/src/components/bookStatus.test.ts
@@ -37,3 +37,66 @@ describe('bookStatusBadge', () => {
     expect(b.colorClass).toMatch(/slate|zinc/)
   })
 })
+
+// WCAG AA enforcement for the status badges. These pills carry small text
+// (text-[10px]/text-xs), so the 4.5:1 normal-text threshold applies — not the
+// 3:1 large-text one. The test reads the real colorClass so a future shade
+// change re-checks contrast instead of silently regressing.
+describe('bookStatusBadge contrast (WCAG AA)', () => {
+  // Only the shades actually used by the badges.
+  const PALETTE: Record<string, [number, number, number]> = {
+    'amber-500': [0xf5, 0x9e, 0x0b], 'amber-800': [0x92, 0x40, 0x0e], 'amber-400': [0xfb, 0xbf, 0x24],
+    'blue-500': [0x3b, 0x82, 0xf6], 'blue-700': [0x1d, 0x4e, 0xd8], 'blue-400': [0x60, 0xa5, 0xfa],
+    'purple-500': [0xa8, 0x55, 0xf7], 'purple-700': [0x7e, 0x22, 0xce], 'purple-400': [0xc0, 0x84, 0xfc],
+    'emerald-500': [0x10, 0xb9, 0x81], 'emerald-800': [0x06, 0x5f, 0x46], 'emerald-400': [0x34, 0xd3, 0x99],
+    'slate-300': [0xcb, 0xd5, 0xe1], 'slate-600': [0x47, 0x55, 0x69],
+    'zinc-700': [0x3f, 0x3f, 0x46], 'zinc-300': [0xd4, 0xd4, 0xd8],
+  }
+  // Worst-case card surfaces (darkest light card / lightest dark card).
+  const LIGHT_CARD: [number, number, number] = [0xf1, 0xf5, 0xf9]
+  const DARK_CARD: [number, number, number] = [0x18, 0x18, 0x1b]
+
+  type RGB = [number, number, number]
+  const chan = (c: number) => { const s = c / 255; return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4 }
+  const lum = ([r, g, b]: RGB) => 0.2126 * chan(r) + 0.7152 * chan(g) + 0.0722 * chan(b)
+  const ratio = (a: RGB, b: RGB) => { const [L1, L2] = [lum(a), lum(b)].sort((x, y) => y - x); return (L1 + 0.05) / (L2 + 0.05) }
+  const over = (fg: RGB, alpha: number, bg: RGB): RGB => fg.map((f, i) => alpha * f + (1 - alpha) * bg[i]) as RGB
+
+  // Pull a `bg-<color>/<alpha>` and the theme-appropriate text colour out of a
+  // Tailwind class string, then compute the effective foreground/background.
+  function resolve(colorClass: string, dark: boolean): { fg: RGB; bg: RGB } {
+    const tokens = colorClass.split(/\s+/)
+    const pick = (prefix: string) => {
+      const want = dark ? `dark:${prefix}` : prefix
+      // Prefer the dark: variant in dark mode, else the base utility.
+      const t = tokens.find(x => x.startsWith(want)) ?? (dark ? tokens.find(x => x.startsWith(prefix) && !x.startsWith('dark:')) : undefined)
+      return t?.slice(want.length) ?? null
+    }
+    const surface = dark ? DARK_CARD : LIGHT_CARD
+    const bgTok = pick('bg-')
+    let bg = surface
+    if (bgTok) {
+      const [name, alpha] = bgTok.split('/')
+      const c = PALETTE[name]
+      if (c) bg = alpha ? over(c, Number(alpha) / 100, surface) : c
+    }
+    const fgName = pick('text-')!
+    return { fg: PALETTE[fgName], bg }
+  }
+
+  const statuses: Array<[string, boolean]> = [
+    ['wanted', true], ['downloading', true], ['downloaded', true],
+    ['imported', true], ['skipped', true], ['wanted', false], // wanted+unmonitored = muted
+  ]
+
+  for (const [status, monitored] of statuses) {
+    for (const dark of [false, true]) {
+      it(`${status}${monitored ? '' : ' (unmonitored)'} badge passes AA in ${dark ? 'dark' : 'light'}`, () => {
+        const { colorClass } = bookStatusBadge(status, monitored, t)
+        const { fg, bg } = resolve(colorClass, dark)
+        expect(fg, `unknown shade in: ${colorClass}`).toBeDefined()
+        expect(ratio(fg, bg)).toBeGreaterThanOrEqual(4.5)
+      })
+    }
+  }
+})

--- a/web/src/components/bookStatus.ts
+++ b/web/src/components/bookStatus.ts
@@ -7,16 +7,20 @@
 // backlist book (`wanted` + unmonitored) must NOT read "Wanted" on its detail
 // page or in lists — otherwise the pill and the Wanted page disagree (#977).
 
+// Text shades are the AA-safe pair for each tinted background: amber-700 and
+// emerald-700 on their `/20` tints fall just under 4.5:1 on a light card
+// (3.99 and 4.20), so light uses the -800 step; zinc-400 on zinc-700 is 4.07,
+// so dark muted uses zinc-300. See bookStatus.test.ts.
 const statusColors: Record<string, string> = {
-  wanted: 'bg-amber-500/20 text-amber-700 dark:text-amber-400',
+  wanted: 'bg-amber-500/20 text-amber-800 dark:text-amber-400',
   downloading: 'bg-blue-500/20 text-blue-700 dark:text-blue-400',
   downloaded: 'bg-purple-500/20 text-purple-700 dark:text-purple-400',
-  imported: 'bg-emerald-500/20 text-emerald-700 dark:text-emerald-400',
-  skipped: 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400',
+  imported: 'bg-emerald-500/20 text-emerald-800 dark:text-emerald-400',
+  skipped: 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-300',
 }
 
 // Muted slate, used for the not-monitored state and any unknown status.
-const mutedColor = 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'
+const mutedColor = 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-300'
 
 import type { TFunction } from 'i18next'
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1,6 +1,8 @@
 {
   "common": {
     "loading": "Loading...",
+    "gridView": "Grid view",
+    "tableView": "Table view",
     "cancel": "Cancel",
     "delete": "Delete",
     "edit": "Edit",
@@ -137,6 +139,8 @@
     "noDescription": "No description available",
     "monitored": "Monitored",
     "unmonitored": "Unmonitored",
+    "startMonitoring": "Monitor",
+    "stopMonitoring": "Stop monitoring",
     "deleteConfirm": "Delete this author and all their books?",
     "deleteWithFilesConfirm": "Delete this author, {{total}} book(s), AND {{withFiles}} file(s)/folder(s) on disk?\n\nThis cannot be undone.",
     "bulkDeleteConfirm": "Delete {{count}} author(s) and all their books?",
@@ -167,6 +171,7 @@
   "books": {
     "title": "Books",
     "countLabel": "{{count}} books",
+    "legendTitle": "What do the status labels mean?",
     "searchPlaceholder": "Search books or authors...",
     "sortLabel": "Sort:",
     "typeLabel": "Type:",

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -11,6 +11,7 @@ import BulkActionBar from '../components/BulkActionBar'
 import { useView } from '../components/useView'
 import MarkdownDescription from '../components/MarkdownDescription'
 import { btn } from '../components/buttons'
+import Switch from '../components/Switch'
 
 type MediaFilter = '' | 'ebook' | 'audiobook'
 type StatusFilter = '' | 'wanted' | 'downloading' | 'downloaded' | 'imported' | 'skipped'
@@ -398,12 +399,14 @@ export default function AuthorDetailPage() {
             />
           )}
           <div className="flex flex-wrap gap-2 mt-4">
-            <button
-              onClick={handleToggleMonitored}
-              className={`px-3 py-1.5 rounded text-xs font-medium ${author.monitored ? 'bg-emerald-600 text-white hover:bg-emerald-500' : 'bg-slate-200 dark:bg-zinc-800 text-slate-700 dark:text-zinc-300 hover:bg-slate-300 dark:hover:bg-zinc-700'}`}
+            <Switch
+              checked={author.monitored}
+              onChange={handleToggleMonitored}
+              label={author.monitored ? t('authors.stopMonitoring', 'Stop monitoring') : t('authors.startMonitoring', 'Monitor')}
+              className="px-1"
             >
-              {author.monitored ? 'Monitored' : 'Not monitored'}
-            </button>
+              {author.monitored ? t('authors.monitored') : t('authors.unmonitored')}
+            </Switch>
             <button
               onClick={handleRefresh}
               disabled={refreshing}

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -14,6 +14,7 @@ import { useView } from '../components/useView'
 import GettingStartedGuidance from '../components/GettingStartedGuidance'
 import { useNeedsSetup } from '../components/useNeedsSetup'
 import { btn, btnSize } from '../components/buttons'
+import Switch from '../components/Switch'
 
 type SortMode = 'az' | 'za' | 'recent'
 type MonitoredFilter = '' | 'monitored' | 'unmonitored'
@@ -386,12 +387,11 @@ export default function AuthorsPage() {
                       {author.averageRating > 0 ? `★ ${author.averageRating.toFixed(2)}` : '—'}
                     </td>
                     <td className="px-3 py-2 whitespace-nowrap">
-                      <button
-                        onClick={() => handleToggleMonitored(author)}
-                        className={`text-xs px-2 py-0.5 rounded ${author.monitored ? 'bg-emerald-500/20 text-emerald-400' : 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}
-                      >
-                        {author.monitored ? t('common.yes') : t('common.no')}
-                      </button>
+                      <Switch
+                        checked={author.monitored}
+                        onChange={() => handleToggleMonitored(author)}
+                        label={author.monitored ? t('authors.stopMonitoring', 'Stop monitoring') : t('authors.startMonitoring', 'Monitor')}
+                      />
                     </td>
                     <td className="px-3 py-2 text-right whitespace-nowrap">
                       <button
@@ -445,12 +445,13 @@ export default function AuthorsPage() {
                 </Link>
               </div>
               <div className="flex items-center justify-between px-4 py-2 bg-slate-200/50 dark:bg-zinc-800/50 border-t border-slate-200 dark:border-zinc-800">
-                <button
-                  onClick={() => handleToggleMonitored(author)}
-                  className={`text-xs px-2 py-1 rounded ${author.monitored ? 'bg-emerald-500/20 text-emerald-400' : 'bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-zinc-400'}`}
+                <Switch
+                  checked={author.monitored}
+                  onChange={() => handleToggleMonitored(author)}
+                  label={author.monitored ? t('authors.stopMonitoring', 'Stop monitoring') : t('authors.startMonitoring', 'Monitor')}
                 >
                   {author.monitored ? t('authors.monitored') : t('authors.unmonitored')}
-                </button>
+                </Switch>
                 <div className="flex gap-2">
                   <button
                     onClick={() => api.refreshAuthor(author.id).then(load)}

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import ViewToggle from '../components/ViewToggle'
 import { bookStatusBadge } from '../components/bookStatus'
+import BookStatusLegend from '../components/BookStatusLegend'
 import { useView } from '../components/useView'
 import GettingStartedGuidance from '../components/GettingStartedGuidance'
 import { useNeedsSetup } from '../components/useNeedsSetup'
@@ -159,6 +160,8 @@ export default function BooksPage() {
         <button onClick={() => setMediaFilter('ebook')} className={sortBtnCls(mediaFilter === 'ebook')}>📖 {t('common.ebook')}</button>
         <button onClick={() => setMediaFilter('audiobook')} className={sortBtnCls(mediaFilter === 'audiobook')}>🎧 {t('common.audiobook')}</button>
       </div>
+
+      <BookStatusLegend />
 
       {loading ? (
         <div className="text-slate-600 dark:text-zinc-500">{t('common.loading')}</div>

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -5,6 +5,7 @@ import AddSeriesBookModal from '../components/AddSeriesBookModal'
 import HardcoverSeriesLinkModal from '../components/HardcoverSeriesLinkModal'
 import SeriesNameModal from '../components/SeriesNameModal'
 import { btn, btnSize } from '../components/buttons'
+import Switch from '../components/Switch'
 
 export default function SeriesPage() {
   const location = useLocation()
@@ -262,16 +263,13 @@ export default function SeriesPage() {
 
                 {/* Actions row */}
                 <div className="px-4 pb-3 flex items-center gap-3 flex-wrap" onClick={e => e.stopPropagation()}>
-                  <button
-                    onClick={() => toggleMonitor(series)}
-                    className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${series.monitored ? 'bg-emerald-600' : 'bg-slate-300 dark:bg-zinc-700'}`}
-                    title={series.monitored ? 'Stop monitoring' : 'Monitor series'}
+                  <Switch
+                    checked={series.monitored}
+                    onChange={() => toggleMonitor(series)}
+                    label={series.monitored ? 'Stop monitoring' : 'Monitor series'}
                   >
-                    <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full transition-transform ${series.monitored ? 'translate-x-4' : ''}`} />
-                  </button>
-                  <span className="text-xs text-slate-600 dark:text-zinc-400">
                     {series.monitored ? 'Monitored' : 'Not monitored'}
-                  </span>
+                  </Switch>
                   {enhancedHardcoverApi && (
                     <button
                       onClick={() => openHardcoverLink(series)}


### PR DESCRIPTION
## What

P3 affordance fix (2 of 2): make toggles look like toggles, document the status palette, and fix the badge contrast failures that the palette review surfaced.

## Toggle vs badge

"Monitored" controls were emerald/neutral **pills** — visually identical to the read-only `bookStatusBadge` pills, so users couldn't tell which ones are clickable. The Series page already had a proper slide switch; I extracted it into a shared **`<Switch>`** (`role="switch"`, `aria-checked`, `aria-label`, focus ring) and applied it to:
- Authors list (grid + table) Monitored toggle
- Author detail Monitored toggle
- Series monitor toggle (now uses the shared component; dedupe)

A sliding knob reads unambiguously as a control, distinct from a static badge.

## Status legend

New collapsible **`BookStatusLegend`** on the Books page. It renders each swatch through `bookStatusBadge`, so the legend always matches the real badges (labels + colours) instead of being a hand-maintained copy that drifts.

## AA badge fixes (token level)

The palette review found three badge text/bg pairs failing WCAG AA — and badge text is small (`text-[10px]`/`text-xs`), so 4.5:1 applies, not 3:1:

| badge | before | after |
|---|---|---|
| wanted (light) | amber-700 → **3.99** | amber-800 → 5.63 |
| imported (light) | emerald-700 → **4.20** | emerald-800 → 5.89 |
| muted/skipped (dark) | zinc-400 → **4.07** | zinc-300 → 7.07 |

Fixed in `bookStatus.ts`. `bookStatus.test.ts` now parses the real `colorClass` and asserts ≥4.5:1 over the worst-case card surface in **both** themes (12 new assertions), so a future shade change re-checks instead of silently regressing.

## Also

- `aria-label` + `aria-pressed` on the grid/table view toggle (was `title`-only).

## Verify

- Light + dark, narrow widths.
- `npm run typecheck` clean · `npm run lint` (only pre-existing warnings) · `npm test` 298 pass · `npm run build` clean.

## Token note (affects both themes)

Badge colours changed in `bookStatus.ts` for **light and dark**; review alongside #1037 (text tokens) and #1041 (button vocabulary) as the shared theme surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)