### PR TITLE
fix(api): allow setting the Calibre plugin API key (#1036)

### DIFF
--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -122,8 +122,15 @@ func isSecretSetting(key string) bool {
 	return false
 }
 
+// isWritableSecretSetting reports whether a secret key may still be written
+// through the generic settings endpoint (it stays hidden from reads/list — it's
+// write-only, not exposed). These are integration credentials the user sets in
+// the settings UI and that have no dedicated handler of their own. The ABS and
+// Grimmory keys are absent here on purpose: they're persisted by their own
+// connection-test handlers, not the generic PUT.
 func isWritableSecretSetting(key string) bool {
-	return key == SettingHardcoverAPIToken
+	return key == SettingHardcoverAPIToken ||
+		key == SettingCalibrePluginAPIKey
 }
 
 func (h *SettingsHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -162,7 +169,7 @@ func (h *SettingsHandler) Get(w http.ResponseWriter, r *http.Request) {
 func (h *SettingsHandler) Set(w http.ResponseWriter, r *http.Request) {
 	key := chi.URLParam(r, "key")
 	if isSecretSetting(key) && !isWritableSecretSetting(key) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "use /auth/* endpoints for auth settings"})
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "this secret setting cannot be set through the generic settings API; use its dedicated settings screen"})
 		return
 	}
 	var req struct {
@@ -450,7 +457,7 @@ func validateSettingValue(key, value string) error {
 func (h *SettingsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	key := chi.URLParam(r, "key")
 	if isSecretSetting(key) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "use /auth/* endpoints for auth settings"})
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "this secret setting cannot be deleted through the generic settings API"})
 		return
 	}
 	if err := h.settings.Delete(r.Context(), key); err != nil {

--- a/internal/api/settings_handler_test.go
+++ b/internal/api/settings_handler_test.go
@@ -334,6 +334,35 @@ func TestSettings_SetHardcoverTokenIsWriteOnly(t *testing.T) {
 	}
 }
 
+// TestSettings_SetCalibrePluginKeyIsWriteOnly is the regression for #1036:
+// the Calibre Bridge plugin API key is a secret, but it's set through the
+// generic settings endpoint (no dedicated handler), so it must be writable
+// there while staying hidden from reads. Before the fix, Set returned 403
+// "use /auth/* endpoints for auth settings" and the key was unsettable.
+func TestSettings_SetCalibrePluginKeyIsWriteOnly(t *testing.T) {
+	h, repo, ctx := settingsFixture(t)
+	req := withKey(httptest.NewRequest(http.MethodPut, "/api/v1/settings/"+SettingCalibrePluginAPIKey, bytes.NewBufferString(`{"value":"plugin-secret"}`)), SettingCalibrePluginAPIKey)
+	rec := httptest.NewRecorder()
+	h.Set(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte("plugin-secret")) {
+		t.Fatalf("plugin key leaked through Set response: %s", rec.Body.String())
+	}
+	got, _ := repo.Get(ctx, SettingCalibrePluginAPIKey)
+	if got == nil || got.Value != "plugin-secret" {
+		t.Fatalf("expected plugin key persisted, got %+v", got)
+	}
+	// Still hidden from reads.
+	getReq := withKey(httptest.NewRequest(http.MethodGet, "/api/v1/settings/"+SettingCalibrePluginAPIKey, nil), SettingCalibrePluginAPIKey)
+	getRec := httptest.NewRecorder()
+	h.Get(getRec, getReq)
+	if getRec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for plugin key Get, got %d", getRec.Code)
+	}
+}
+
 func TestGetHardcoverAPITokenNormalizesLegacyStoredValue(t *testing.T) {
 	_, repo, ctx := settingsFixture(t)
 	if err := repo.Set(ctx, SettingHardcoverAPIToken, "Authorization: Bearer hc-secret"); err != nil {


### PR DESCRIPTION
Fixes #1036.

## Bug

Setting the Calibre Bridge plugin API key (Settings → Calibre → plugin → Save) returned **403 `use /auth/* endpoints for auth settings`**. The frontend PUTs `/api/v1/setting/calibre.plugin_api_key`, but `calibre.plugin_api_key` is a *secret* key that was not on the writable-secret allowlist, so `Set` rejected it. There is no `/auth/*` endpoint for it either, so the key was **impossible to set** from the UI or API.

## Fix

Add `SettingCalibrePluginAPIKey` to `isWritableSecretSetting`, next to `hardcover.api_token`. It stays **write-only**: settable through the settings endpoint, still hidden from GET/list.

## Audit (per request: checked all code for the same trap)

Cross-checked every frontend `setSetting(...)` key against `isSecretSetting`:
- `calibre.plugin_api_key` — the only secret written generically without being writable → **this fix**.
- `hardcover.api_token` — already writable.
- ABS (`abs.api_key`) and Grimmory (`grimmory.api_key`) — persisted by their own connection-test handlers, not the generic PUT, so unaffected.
- `login.password` / `setup.password` — auth-form fields, not settings writes.

No other instances.

## Also

Reworded the `Set`/`Delete` 403 messages. The old "use /auth/* endpoints" text is wrong for non-auth secrets (ABS, Grimmory, Calibre) and is exactly what sent the reporter hunting for a nonexistent endpoint.

## Tests

- New `TestSettings_SetCalibrePluginKeyIsWriteOnly`: Set returns 200, value persists, response doesn't echo it, and GET still 404s.
- `go build ./...`, `go vet`, `go test ./internal/api/` all pass.

Clean candidate for **1.17.1** (small, well-scoped bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)