### PR TITLE
fix(hardcover): stop selecting invalid books.language in author works

### DIFF
--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -177,6 +177,12 @@ func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([
 		return nil, metadata.ErrProviderNotConfigured
 	}
 
+	// NB: do NOT select `language` here. It is an *edition* field; the `books`
+	// type has no `language`, so requesting it makes Hardcover reject the whole
+	// query ("field 'language' not found in type: 'books'", validation-failed)
+	// and the entire author-works supplement fails (#1036-adjacent report). A
+	// book's language can only be derived by traversing to a default edition;
+	// until that's added, supplemental books carry no language.
 	gql := `query GetAuthorWorksByName($author: String!, $limit: Int!, $offset: Int!) {
 		books(
 			where: {
@@ -200,7 +206,6 @@ func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([
 			audio_seconds
 			default_audio_edition_id
 			default_ebook_edition_id
-			language { language }
 			contributions {
 				author { id name slug }
 			}

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -645,10 +645,16 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 				t.Fatalf("query requested search-only Hardcover field %q: %s", field, req.Query)
 			}
 		}
-		for _, field := range []string{"default_audio_edition_id", "default_ebook_edition_id", "language"} {
+		for _, field := range []string{"default_audio_edition_id", "default_ebook_edition_id"} {
 			if !strings.Contains(req.Query, field) {
 				t.Fatalf("query did not request Hardcover format field %q: %s", field, req.Query)
 			}
+		}
+		// Regression: `language` is an edition field, not a `books` field.
+		// Requesting it makes Hardcover reject the whole query
+		// (validation-failed) and the author-works supplement fails entirely.
+		if strings.Contains(req.Query, "language") {
+			t.Fatalf("author-works query must not request the invalid books.language field: %s", req.Query)
 		}
 		gotVars = req.Variables
 		data := map[string]interface{}{
@@ -664,7 +670,6 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 					"rating":        4.5,
 					"users_count":   2000,
 					"audio_seconds": 7200,
-					"language":      map[string]interface{}{"language": "en"},
 					"contributions": []map[string]interface{}{
 						{"author": map[string]interface{}{"id": 1, "name": "Frank Herbert", "slug": "frank-herbert"}},
 					},
@@ -677,7 +682,6 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 					"ratings_count": 50,
 					"rating":        4.2,
 					"users_count":   100,
-					"language":      map[string]interface{}{"language": "es"},
 					"contributions": []map[string]interface{}{
 						{"author": map[string]interface{}{"id": 1, "name": "Frank Herbert", "slug": "frank-herbert"}},
 					},
@@ -713,15 +717,16 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 	if book.MediaType != "" {
 		t.Fatalf("MediaType = %q, want empty author import default", book.MediaType)
 	}
-	// #889: Language must be propagated so the aggregator can drop foreign
-	// editions via the metadata profile's allowed_languages filter. Before
-	// this fix every Hardcover-sourced supplemental book arrived with
-	// Language="" and slipped past the filter as "unknown language: pass".
-	if book.Language != "eng" {
-		t.Errorf("English book Language = %q, want %q (normalized to ISO 639-2)", book.Language, "eng")
+	// #889 originally selected books.language to drive the allowed_languages
+	// filter, but that field doesn't exist on Hardcover's `books` type and made
+	// the whole query fail. With it removed, supplemental books carry no
+	// language until it's derived from a default edition (follow-up); the filter
+	// treats them as "unknown language: pass", which is the pre-#889 behaviour.
+	if book.Language != "" {
+		t.Errorf("author-works book Language = %q, want empty (not fetched at books level)", book.Language)
 	}
-	if books[1].Language != "spa" {
-		t.Errorf("Spanish book Language = %q, want %q (normalized to ISO 639-2)", books[1].Language, "spa")
+	if books[1].Language != "" {
+		t.Errorf("author-works book[1] Language = %q, want empty", books[1].Language)
 	}
 }
 


### PR DESCRIPTION
## Bug (reported in Discord)

Logs show repeated:
```
WARN author works supplement failed  author="James Binney" error="hardcover get author works: GraphQL: field 'language' not found in type: 'books' (validation-failed)" provider=hardcover
```

`GetAuthorWorksByName` selected `language { language }` on the `books` type. `language` is an **edition** field; Hardcover's `books` type has no `language`, so the real API rejects the entire query as `validation-failed`. The whole Hardcover author-works supplement fails, so Hardcover author metadata refresh is effectively broken.

## Why it slipped through

The field was added for #889 (propagate language to the `allowed_languages` filter), but it never worked against the real schema — the test mock returned `books.language`, hiding the mismatch. The codebase only ever gets language via `editions`; there is no working books-level language.

## Fix

Remove `language { language }` from the author-works `books` query, restoring the supplement. Per-book language for author works now requires traversing to a default edition (follow-up); until then supplemental books carry no language, which is the pre-#889 behaviour (the filter treats them as "unknown: pass").

## Tests

- Flip the assertion: the query must **not** request `books.language` (regression guard), and drop the mock field that masked the schema mismatch.
- `go build`, `go vet`, `go test ./internal/metadata/...` pass.

Clean **1.17.1** candidate (restores a broken integration; low risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)