### PR TITLE
fix(downloader): send project User-Agent on indexer fetch (#1053)

### DIFF
--- a/changelog.d/1053-nzb-fetch-useragent.md
+++ b/changelog.d/1053-nzb-fetch-useragent.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Grabbing from indexers that fingerprint the User-Agent now works** (#1053) — fetching the NZB/torrent file from an indexer (e.g. nzbfinder.ws) failed with `indexer returned HTTP 403` and an anti-bot HTML interstitial, even though search worked. The download-client fetch paths sent Go's default `User-Agent` instead of the project UA the search client already uses, so the indexer served a block page. All indexer-fetch paths (SABnzbd, NZBGet, Transmission, qBittorrent) now send `bindery/<version>`. Direct-magnet grabs were never affected.

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 	"github.com/vavallee/bindery/internal/httpsec"
+	"github.com/vavallee/bindery/internal/useragent"
 )
 
 // categoryNameKey matches the NZBGet config keys that carry a category's
@@ -228,6 +229,10 @@ func (c *Client) fetchNZBContent(ctx context.Context, nzbURL string) ([]byte, er
 	if err != nil {
 		return nil, fmt.Errorf("fetch nzb: %w", err)
 	}
+	// Some indexers (e.g. nzbfinder.ws, #1053) fingerprint the User-Agent and
+	// serve an anti-bot 403 to Go's default UA, so use the project UA the
+	// search path already relies on.
+	req.Header.Set("User-Agent", useragent.Get())
 	resp, err := c.fetchHTTP.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch nzb from indexer: %w", err)

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 	"github.com/vavallee/bindery/internal/httpsec"
+	"github.com/vavallee/bindery/internal/useragent"
 )
 
 // AuthError signals that qBittorrent responded but rejected the login.
@@ -426,6 +427,9 @@ func (c *Client) fetchTorrentContent(ctx context.Context, rawURL string) (*fetch
 			return nil, fmt.Errorf("build torrent fetch request: %w", err)
 		}
 		req.Header.Set("Accept", "application/x-bittorrent")
+		// Some indexers fingerprint the User-Agent and serve an anti-bot 403
+		// to Go's default UA (#1053); use the project UA like the search path.
+		req.Header.Set("User-Agent", useragent.Get())
 
 		resp, err := fetchClient.Do(req)
 		if err != nil {

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 	"github.com/vavallee/bindery/internal/httpsec"
+	"github.com/vavallee/bindery/internal/useragent"
 )
 
 // Client interacts with the SABnzbd API.
@@ -204,6 +205,10 @@ func (c *Client) fetchNZBContent(ctx context.Context, nzbURL string) ([]byte, er
 	if err != nil {
 		return nil, fmt.Errorf("fetch nzb: %w", err)
 	}
+	// Some indexers (e.g. nzbfinder.ws, #1053) fingerprint the User-Agent and
+	// serve an anti-bot 403 to Go's default UA, so use the project UA the
+	// search path already relies on.
+	req.Header.Set("User-Agent", useragent.Get())
 	resp, err := c.fetchHTTP.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch nzb from indexer: %w", err)

--- a/internal/downloader/sabnzbd/client_test.go
+++ b/internal/downloader/sabnzbd/client_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/vavallee/bindery/internal/useragent"
 )
 
 const testNZBContent = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE nzb PUBLIC "-//newzBin//DTD NZB 1.1//EN" "http://www.newzbin.com/DTD/nzb/nzb-1.1.dtd"><nzb></nzb>`
@@ -113,6 +115,39 @@ func TestAddURL(t *testing.T) {
 	}
 	if string(gotPayload) != testNZBContent {
 		t.Errorf("uploaded payload mismatch:\n want: %q\n got:  %q", testNZBContent, string(gotPayload))
+	}
+}
+
+// TestAddURL_SetsUserAgentOnIndexerFetch guards #1053: the NZB fetch must
+// carry the project User-Agent, not Go's default, or indexers like
+// nzbfinder.ws serve an anti-bot 403.
+func TestAddURL_SetsUserAgentOnIndexerFetch(t *testing.T) {
+	var gotUA string
+	indexerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/x-nzb")
+		fmt.Fprint(w, testNZBContent)
+	}))
+	defer indexerSrv.Close()
+
+	sabSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		readMultipartFile(t, r)
+		json.NewEncoder(w).Encode(AddURLResponse{Status: true, NzoIDs: []string{"x"}})
+	}))
+	defer sabSrv.Close()
+
+	c := New("127.0.0.1", 0, "testkey", "", false)
+	c.baseURL = sabSrv.URL
+	allowNZBFetch(c)
+
+	if _, err := c.AddURL(context.Background(), indexerSrv.URL+"/file.nzb", "Test Book", "books", 0); err != nil {
+		t.Fatalf("add url: %v", err)
+	}
+	if want := useragent.Get(); gotUA != want {
+		t.Errorf("indexer fetch User-Agent = %q, want %q", gotUA, want)
+	}
+	if strings.HasPrefix(gotUA, "Go-http-client") {
+		t.Errorf("indexer fetch used Go default User-Agent %q", gotUA)
 	}
 }
 

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/vavallee/bindery/internal/downloader/nethint"
 	"github.com/vavallee/bindery/internal/downloader/urlbase"
 	"github.com/vavallee/bindery/internal/httpsec"
+	"github.com/vavallee/bindery/internal/useragent"
 )
 
 // Client interacts with the Transmission RPC API.
@@ -315,6 +316,9 @@ func (c *Client) fetchTorrentContent(ctx context.Context, torrentURL string) (*f
 			return nil, fmt.Errorf("fetch torrent: %w", err)
 		}
 		req.Header.Set("Accept", "application/x-bittorrent")
+		// Some indexers fingerprint the User-Agent and serve an anti-bot 403
+		// to Go's default UA (#1053); use the project UA like the search path.
+		req.Header.Set("User-Agent", useragent.Get())
 
 		resp, err := fetchClient.Do(req)
 		if err != nil {


### PR DESCRIPTION
Closes #1053.

## Problem

Grabbing a release whose enclosure resolves to an indexer that fingerprints the User-Agent (e.g. **nzbfinder.ws**) fails at the NZB/torrent-fetch step with `indexer returned HTTP 403` and an anti-bot HTML interstitial (`no-js ie6 oldie`). Search works; only the download fetch fails.

`useragent` documents that nzbfinder.ws (and OpenLibrary, #835) block on User-Agent, and the search path already sends the project `bindery/<version>` UA. But the download-client fetch-from-indexer paths built their GET request without any UA, so the request went out as `Go-http-client/...` and got blocked.

## Fix

Set `req.Header.Set("User-Agent", useragent.Get())` on every indexer-fetch path:

- `sabnzbd.fetchNZBContent`
- `nzbget.fetchNZBContent`
- `transmission.fetchTorrentContent`
- `qbittorrent.fetchTorrentContent`

The issue only named SABnzbd, but NZBGet/Transmission/qBittorrent have the identical flaw on their fetch-from-indexer paths, so all four are fixed. The SAB/NZBGet `apiCall`/`apiUpload` paths talk to the user's own daemon (not an anti-bot surface) and are deliberately left unchanged. Deluge passes the URL to its daemon and has no Bindery-side fetch. Direct-magnet grabs were never affected.

## Test

New `TestAddURL_SetsUserAgentOnIndexerFetch` asserts the indexer fetch carries `useragent.Get()` and not Go's default.

## Verification

- `go build ./...`, `go vet ./internal/downloader/...` clean
- `golangci-lint run` on all four packages: 0 issues
- `go test ./internal/downloader/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)