### PR TITLE
test: bounded Go fuzzing for rollback metadata and fetch-URL SSRF guards

### DIFF
--- a/changelog.d/885-fuzz.md
+++ b/changelog.d/885-fuzz.md
@@ -1,0 +1,2 @@
+### Security
+- **Hardened parsers against malformed input with Go fuzz tests** (#885) — added bounded native fuzz targets for the Calibre rollback-metadata decoder and the NZB/torrent indexer fetch-URL SSRF guards, asserting they never panic and never let a loopback, link-local, cloud-metadata, or non-http(s) target through.

--- a/internal/calibre/import_snapshots_fuzz_test.go
+++ b/internal/calibre/import_snapshots_fuzz_test.go
@@ -1,0 +1,71 @@
+package calibre
+
+import (
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// FuzzRollbackMetadataDecode exercises the serialized rollback-metadata decode
+// path with arbitrary strings. The metadata is JSON stored in
+// calibre_entity_snapshots.metadata_json; a corrupt or attacker-tampered row
+// must never panic the rollback worker — it must decode cleanly or report
+// "not usable" (ok=false). We additionally feed any decoded snapshot straight
+// into the restore functions so a malformed-but-parseable envelope can't crash
+// the field-restore step either. Runs only the seed corpus under `go test`
+// (bounded); doubles as an OpenSSF Scorecard fuzz target.
+func FuzzRollbackMetadataDecode(f *testing.F) {
+	seeds := []string{
+		"",
+		"   ",
+		"null",
+		"{}",
+		"[]",
+		"not json",
+		`{"kind":"calibre_run_entity_metadata","version":1}`,
+		`{"kind":"calibre_run_entity_metadata","version":1,"data":{"x":1}}`,
+		`{"kind":"wrong","version":1}`,
+		`{"kind":"calibre_run_entity_metadata","version":2}`,
+		`{"kind":"calibre_run_entity_metadata","version":1,"snapshot":{"entityType":"book","before":{"title":"a"},"after":{"title":"b"}}}`,
+		`{"kind":"calibre_run_entity_metadata","version":1,"snapshot":{"entityType":"author","before":{"name":"a"},"after":{"name":"b"}}}`,
+		// Snapshot present but before/after empty (must yield ok=false).
+		`{"kind":"calibre_run_entity_metadata","version":1,"snapshot":{"entityType":"book"}}`,
+		// Mismatched entity type for each decoder.
+		`{"kind":"calibre_run_entity_metadata","version":1,"snapshot":{"entityType":"edition","before":{},"after":{}}}`,
+		// Type-confused inner payloads: before/after that won't unmarshal into the snapshot struct.
+		`{"kind":"calibre_run_entity_metadata","version":1,"snapshot":{"entityType":"book","before":"oops","after":42}}`,
+		`{"kind":"calibre_run_entity_metadata","version":1,"snapshot":{"entityType":"author","before":[1,2,3],"after":{}}}`,
+		// Deeply nested / oversized-ish field values.
+		`{"kind":"calibre_run_entity_metadata","version":1,"snapshot":{"entityType":"book","before":{"releaseDate":"not-a-time"},"after":{"calibreId":"x"}}}`,
+		"\x00\x01\x02",
+		`{"kind":"calibre_run_entity_metadata","version":1` + string(rune(0)),
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		// Must never panic on any input. Results are intentionally ignored
+		// except to thread decoded snapshots through the restore step below.
+		bBefore, bAfter, bOK := bookRollbackSnapshotFromMetadata(raw)
+		aBefore, aAfter, aOK := authorRollbackSnapshotFromMetadata(raw)
+		_, _ = parseRunEntityMetadata(raw)
+
+		// A decode that reports usable (ok=true) must return non-nil snapshots,
+		// otherwise the rollback worker would dereference nil. Guard the
+		// invariant rather than assume it.
+		if bOK {
+			if bBefore == nil || bAfter == nil {
+				t.Fatalf("book decode ok=true but nil snapshot(s): before=%v after=%v", bBefore, bAfter)
+			}
+			// Restoring with a decoded snapshot must not panic either.
+			restoreBookFromSnapshot(&models.Book{}, bBefore, bAfter)
+		}
+		if aOK {
+			if aBefore == nil || aAfter == nil {
+				t.Fatalf("author decode ok=true but nil snapshot(s): before=%v after=%v", aBefore, aAfter)
+			}
+			restoreAuthorFromSnapshot(&models.Author{}, aBefore, aAfter)
+		}
+	})
+}

--- a/internal/downloader/nzbget/client_fuzz_test.go
+++ b/internal/downloader/nzbget/client_fuzz_test.go
@@ -1,0 +1,95 @@
+package nzbget
+
+import (
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// FuzzValidateNZBFetchURL fuzzes the NZB fetch-URL guard that runs on every
+// indexer-supplied download URL before Bindery fetches it. A panic here is a
+// DoS on the grab path; worse, a private/loopback/non-http(s) target slipping
+// through is an SSRF. The default client validator delegates to
+// httpsec.ValidateOutboundURL(PolicyLAN), which under PolicyLAN blocks
+// loopback, link-local, and cloud-metadata while permitting RFC1918 LAN hosts.
+//
+// To stay hermetic and bounded (no DNS, no network) we only invoke the real
+// validator when the host is empty or an IP literal — hostname resolution is
+// out of scope for a fuzz target and would hang. Runs only the seed corpus
+// under `go test`; doubles as an OpenSSF Scorecard fuzz target.
+func FuzzValidateNZBFetchURL(f *testing.F) {
+	seeds := []string{
+		"",
+		"http://10.0.0.5:8080/get.nzb",      // RFC1918: allowed under LAN
+		"http://127.0.0.1/get.nzb",          // loopback: must reject
+		"http://[::1]:6789/x",               // loopback v6: must reject
+		"http://169.254.169.254/latest",     // cloud metadata: must reject
+		"http://[fe80::1]/x",                // link-local: must reject
+		"ftp://10.0.0.5/x",                  // non-http(s): must reject
+		"file:///etc/passwd",                // non-http(s): must reject
+		"http://192.168.1.10:6789/get.nzb",  // RFC1918: allowed
+		"https://[2001:db8::1]/x",           // documentation range: allowed
+		"http://user:pass@127.0.0.1:99999/", // loopback w/ creds + bad port
+		"http://%zz",
+		"\x00\x01\x02",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	c := New("nzbget.invalid", 6789, "", "", "", false)
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		host := hostnameOf(raw)
+		// Skip non-IP hostnames so we never trigger DNS in CI/fuzzing.
+		if host != "" && net.ParseIP(host) == nil {
+			return
+		}
+
+		err := c.validateNZBFetchURL(raw) // must never panic
+
+		// SSRF invariant: a dangerous IP-literal target must be rejected.
+		if ip := net.ParseIP(host); ip != nil && dangerousUnderLAN(ip) && err == nil {
+			t.Fatalf("validateNZBFetchURL(%q) accepted dangerous target %s", raw, ip)
+		}
+		// Non-http(s) schemes must always be rejected.
+		if sch := schemeOf(raw); sch != "" && sch != "http" && sch != "https" && err == nil {
+			t.Fatalf("validateNZBFetchURL(%q) accepted non-http(s) scheme %q", raw, sch)
+		}
+	})
+}
+
+// hostnameOf returns the URL hostname, or "" if raw is unparseable.
+func hostnameOf(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}
+
+// schemeOf returns the lowercased URL scheme, or "" if raw is unparseable.
+func schemeOf(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Scheme)
+}
+
+// dangerousUnderLAN reports whether ip must be rejected under PolicyLAN:
+// loopback, link-local, or the AWS/Azure/DO cloud-metadata address. RFC1918 is
+// deliberately allowed under LAN policy so it is NOT dangerous here.
+func dangerousUnderLAN(ip net.IP) bool {
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+		return true
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4[0] == 169 && v4[1] == 254 && v4[2] == 169 && v4[3] == 254
+	}
+	return false
+}

--- a/internal/downloader/qbittorrent/client_fuzz_test.go
+++ b/internal/downloader/qbittorrent/client_fuzz_test.go
@@ -1,0 +1,92 @@
+package qbittorrent
+
+import (
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// FuzzValidateTorrentFetchURL fuzzes the torrent fetch-URL guard that runs on
+// every indexer-supplied .torrent URL before Bindery downloads it. A panic
+// here is a DoS on the grab path; a private/loopback/non-http(s) target
+// slipping through is an SSRF. The default client validator delegates to
+// httpsec.ValidateOutboundURL(PolicyLAN), which blocks loopback, link-local,
+// and cloud-metadata while permitting RFC1918 LAN hosts.
+//
+// To stay hermetic and bounded (no DNS, no network) we only invoke the real
+// validator when the host is empty or an IP literal. Runs only the seed corpus
+// under `go test`; doubles as an OpenSSF Scorecard fuzz target.
+func FuzzValidateTorrentFetchURL(f *testing.F) {
+	seeds := []string{
+		"",
+		"http://10.0.0.5:8080/x.torrent",   // RFC1918: allowed under LAN
+		"http://127.0.0.1/x.torrent",       // loopback: must reject
+		"http://[::1]:6881/x",              // loopback v6: must reject
+		"http://169.254.169.254/latest",    // cloud metadata: must reject
+		"http://[fe80::1]/x",               // link-local: must reject
+		"magnet:?xt=urn:btih:deadbeef",     // non-http(s): must reject
+		"ftp://10.0.0.5/x",                 // non-http(s): must reject
+		"http://192.168.1.10:8080/x",       // RFC1918: allowed
+		"https://[2001:db8::1]/x",          // documentation range: allowed
+		"http://user:pass@127.0.0.1:99999", // loopback w/ creds + bad port
+		"http://%zz",
+		"\x00\x01\x02",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	c := New("qbit.invalid", 8080, "", "", "", false)
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		host := hostnameOf(raw)
+		// Skip non-IP hostnames so we never trigger DNS in CI/fuzzing.
+		if host != "" && net.ParseIP(host) == nil {
+			return
+		}
+
+		err := c.validateTorrentFetchURL(raw) // must never panic
+
+		if ip := net.ParseIP(host); ip != nil && dangerousUnderLAN(ip) && err == nil {
+			t.Fatalf("validateTorrentFetchURL(%q) accepted dangerous target %s", raw, ip)
+		}
+		if sch := schemeOf(raw); sch != "" && sch != "http" && sch != "https" && err == nil {
+			t.Fatalf("validateTorrentFetchURL(%q) accepted non-http(s) scheme %q", raw, sch)
+		}
+	})
+}
+
+// hostnameOf returns the URL hostname, or "" if raw is unparseable.
+func hostnameOf(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}
+
+// schemeOf returns the lowercased URL scheme, or "" if raw is unparseable.
+func schemeOf(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Scheme)
+}
+
+// dangerousUnderLAN reports whether ip must be rejected under PolicyLAN:
+// loopback, link-local, or the cloud-metadata address. RFC1918 is allowed
+// under LAN policy so it is NOT dangerous here.
+func dangerousUnderLAN(ip net.IP) bool {
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+		return true
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4[0] == 169 && v4[1] == 254 && v4[2] == 169 && v4[3] == 254
+	}
+	return false
+}


### PR DESCRIPTION
## Problem
The Calibre rollback-metadata decoder reads JSON straight from
`calibre_entity_snapshots.metadata_json`, and the NZB/torrent fetch-URL guards
validate indexer-supplied download URLs before Bindery fetches them. Both run
on data that can be malformed or attacker-influenced. A panic in either is a
DoS on the rollback/grab path; a private/loopback/non-http(s) target slipping
past the fetch-URL guards is an SSRF. Neither parser/validator had fuzz
coverage (the SSRF core in `internal/httpsec` already did).

## Approach
Added native Go fuzz targets (`func FuzzXxx(f *testing.F)`) next to the code
they exercise, each with a representative seed corpus. They are bounded: under
ordinary `go test` only the seed corpus runs (no fuzzing loop), and they stay
hermetic (no DNS, no network).

- `internal/calibre/import_snapshots_fuzz_test.go` — `FuzzRollbackMetadataDecode`
  drives `parseRunEntityMetadata`, `bookRollbackSnapshotFromMetadata`, and
  `authorRollbackSnapshotFromMetadata`, then threads any decoded snapshot
  through `restoreBookFromSnapshot`/`restoreAuthorFromSnapshot`. Asserts no
  panic and that an `ok=true` decode never yields nil snapshots.
- `internal/downloader/nzbget/client_fuzz_test.go` and
  `internal/downloader/qbittorrent/client_fuzz_test.go` — fuzz
  `validateNZBFetchURL` / `validateTorrentFetchURL` through the real default
  `httpsec.ValidateOutboundURL(PolicyLAN)` validator. To stay hermetic the
  validator is only invoked for empty/IP-literal hosts (hostnames are skipped
  so no DNS). Asserts no panic, and that loopback, link-local, cloud-metadata,
  and non-http(s) targets are never accepted (RFC1918 stays allowed under LAN
  policy, by design).

## Tests
- `go test -run=Fuzz` runs all three new fuzz targets over their seed corpora
  (and the existing `FuzzValidateOutboundURL`) — all pass.
- Active `go test -fuzz=... -fuzztime=5s` on each target found no crash
  (calibre ~150k execs, nzbget ~270k, qbittorrent ~170k).

## Verification
- `go build ./...` — pass
- `go vet ./...` — pass
- `golangci-lint run ./internal/httpsec/ ./internal/downloader/... ./internal/calibre/` — 0 issues
- `go test ./internal/calibre/ ./internal/downloader/nzbget/ ./internal/downloader/qbittorrent/` — pass

Closes #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)