### PR TITLE
fix(openlibrary): edition-sample work language to catch the allowed_languages tail (#891)

### DIFF
--- a/changelog.d/891-ol-language-sampling.md
+++ b/changelog.d/891-ol-language-sampling.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Foreign-language OpenLibrary works are now caught by the language filter** (#891) — OpenLibrary works carry no work-level language, so translations the search index didn't backfill slipped past a metadata profile's `allowed_languages` as "unknown". When the active profile restricts language, Bindery now edition-samples each such work (bounded to 5 editions) to derive its language before filtering.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1351,6 +1351,17 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 	// default) and parse its allowed_languages CSV. Nil means "no filter".
 	allowedLangs, unknownFail := h.resolveAllowedLanguages(ctx, author)
 
+	// OpenLibrary works carry no work-level language; the search enricher only
+	// backfills it for indexed works, so a tail of works (often translations)
+	// reach the filter below with Language="" and slip through the unknown
+	// fallback. When the profile actually restricts language, edition-sample
+	// those works so the OL tail is caught (#891). Gated on allowedLangs being
+	// set so we don't spend the round-trips when the filter is "any".
+	var langSampled int
+	if len(allowedLangs) > 0 {
+		langSampled = h.meta.FillMissingAuthorWorkLanguages(ctx, books)
+	}
+
 	// Track titles we've already added (case-insensitive) to avoid OL duplicates.
 	// The value is a pointer to the existing book so we can enrich calibre-imported
 	// stubs with the OL foreign ID and language when they title-match an OL record.
@@ -1425,7 +1436,7 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 		// unknown_language_behavior (pass by default; see #232).
 		if !models.IsLanguageAllowed(b.Language, allowedLangs, unknownFail) {
 			skippedLang++
-			slog.Debug("skipping non-allowed-language book", "title", b.Title, "language", b.Language, "allowed", allowedLangs)
+			slog.Debug("skipping non-allowed-language book", "title", b.Title, "language", b.Language, "allowed", allowedLangs, "edition_sampled", langSampled)
 			continue
 		}
 		b.Monitored = shouldMonitorBookForAuthor(author, b, latestKeys, today)

--- a/internal/metadata/aggregator_author_works.go
+++ b/internal/metadata/aggregator_author_works.go
@@ -14,6 +14,28 @@ type worksProvider interface {
 	GetAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error)
 }
 
+// workLanguageFiller is the optional capability a provider implements when it
+// can derive a work-level language for books that arrived without one (e.g.
+// OpenLibrary, whose works carry no language and must be edition-sampled; #891).
+type workLanguageFiller interface {
+	FillMissingWorkLanguages(ctx context.Context, books []models.Book) int
+}
+
+// FillMissingAuthorWorkLanguages asks the primary provider to derive a language
+// for any book in books that has Language=="" by edition-sampling, mutating the
+// slice in place. It is a no-op when the primary provider lacks the capability.
+//
+// Callers should gate this on the active metadata profile actually restricting
+// language: the edition sampling is bounded but still costs upstream
+// round-trips, which are wasted when allowed_languages is "any" and every book
+// passes the filter regardless of its language (#891).
+func (a *Aggregator) FillMissingAuthorWorkLanguages(ctx context.Context, books []models.Book) int {
+	if filler, ok := a.primary.(workLanguageFiller); ok {
+		return filler.FillMissingWorkLanguages(ctx, books)
+	}
+	return 0
+}
+
 type authorWorksByNameProvider interface {
 	Name() string
 	GetAuthorWorksByName(ctx context.Context, authorName string) ([]models.Book, error)

--- a/internal/metadata/aggregator_author_works_test.go
+++ b/internal/metadata/aggregator_author_works_test.go
@@ -370,3 +370,63 @@ func TestAggregator_GetAuthorWorksForAuthor_CachesSuccessfulSupplement(t *testin
 		t.Fatalf("expected cached supplemental result, got %+v", got)
 	}
 }
+
+// mockLangFillerProvider is a primary provider that can derive work-level
+// languages by edition-sampling (the OpenLibrary capability behind #891).
+type mockLangFillerProvider struct {
+	mockProvider
+	byForeignID map[string]string // foreignID -> derived language
+	fillCalls   int
+}
+
+func (m *mockLangFillerProvider) FillMissingWorkLanguages(_ context.Context, books []models.Book) int {
+	m.fillCalls++
+	filled := 0
+	for i := range books {
+		if books[i].Language != "" {
+			continue
+		}
+		if lang, ok := m.byForeignID[books[i].ForeignID]; ok && lang != "" {
+			books[i].Language = lang
+			filled++
+		}
+	}
+	return filled
+}
+
+func TestAggregator_FillMissingAuthorWorkLanguages_DelegatesToPrimary(t *testing.T) {
+	primary := &mockLangFillerProvider{
+		mockProvider: mockProvider{name: "ol"},
+		byForeignID:  map[string]string{"OLSPAW": "spa"},
+	}
+	agg := newTestAggregator(primary)
+
+	books := []models.Book{
+		{ForeignID: "OLENGW", Language: "eng"},
+		{ForeignID: "OLSPAW"},
+	}
+	filled := agg.FillMissingAuthorWorkLanguages(context.Background(), books)
+	if filled != 1 {
+		t.Fatalf("expected 1 filled, got %d", filled)
+	}
+	if primary.fillCalls != 1 {
+		t.Errorf("expected primary FillMissingWorkLanguages to be called once, got %d", primary.fillCalls)
+	}
+	if books[1].Language != "spa" {
+		t.Errorf("expected OLSPAW language 'spa', got %q", books[1].Language)
+	}
+}
+
+func TestAggregator_FillMissingAuthorWorkLanguages_NoOpWhenUnsupported(t *testing.T) {
+	// A primary that lacks the capability must be a safe no-op.
+	primary := &mockProvider{name: "plain"}
+	agg := newTestAggregator(primary)
+
+	books := []models.Book{{ForeignID: "OLW"}}
+	if filled := agg.FillMissingAuthorWorkLanguages(context.Background(), books); filled != 0 {
+		t.Errorf("expected 0 filled for provider without capability, got %d", filled)
+	}
+	if books[0].Language != "" {
+		t.Errorf("language should be untouched, got %q", books[0].Language)
+	}
+}

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -32,15 +32,32 @@ const (
 	coverURL = "https://covers.openlibrary.org"
 )
 
+// editionLangSampleCap bounds how many editions we fetch per work when
+// deriving a work-level language from its editions. OpenLibrary works carry no
+// language of their own, so for the foreign-language filter (#891) we sample
+// the editions endpoint. The cap is deliberately small: the first handful of
+// editions is enough to establish the work's dominant language, and the
+// editions endpoint is expensive enough that OL throttles per-UA, so we keep
+// the round-trip cheap (limit=N) rather than paging the full edition list.
+const editionLangSampleCap = 5
+
 // Client implements the metadata.Provider interface for OpenLibrary.
 type Client struct {
 	http *http.Client
+
+	// workLangCache memoizes derived work-level languages keyed on work ID so a
+	// later refresh pass (or a second author sharing the work) doesn't re-hit
+	// the editions endpoint. An entry with value "" records a sample that
+	// yielded no language so we don't retry it within the process lifetime.
+	workLangMu    sync.Mutex
+	workLangCache map[string]string
 }
 
 // New creates a new OpenLibrary client.
 func New() *Client {
 	return &Client{
-		http: &http.Client{Timeout: 15 * time.Second, Transport: httpsec.DefaultProxyTransport()},
+		http:          &http.Client{Timeout: 15 * time.Second, Transport: httpsec.DefaultProxyTransport()},
+		workLangCache: map[string]string{},
 	}
 }
 
@@ -516,6 +533,106 @@ func (c *Client) GetEditions(ctx context.Context, bookForeignID string) ([]model
 		editions = append(editions, ed)
 	}
 	return editions, nil
+}
+
+// FillMissingWorkLanguages derives a language for any book that arrived with an
+// empty Language by sampling its OpenLibrary editions. OL works carry no
+// language at the work level; the /search.json enricher only backfills language
+// for works it indexes, so a tail of works (often translations) reach the
+// allowed_languages filter with Language="" and pass through the
+// unknown-language fallback (#891).
+//
+// For each such book it fetches /works/{id}/editions.json?limit=N (N capped by
+// editionLangSampleCap) and takes the majority edition language. Results are
+// memoized per work ID so refresh passes don't re-fetch. The mutation is done
+// in place. Per-work fetch failures are logged at debug and leave Language=""
+// so the caller's unknown-language behavior still applies.
+//
+// Callers should only invoke this when the active metadata profile actually
+// restricts language (allowed_languages != "any"); there is no point spending
+// the editions round-trips when the filter would pass everything anyway.
+// It returns the number of books whose Language was populated from sampling so
+// callers can surface it in their filter-decision logs.
+func (c *Client) FillMissingWorkLanguages(ctx context.Context, books []models.Book) int {
+	filled := 0
+	for i := range books {
+		if books[i].Language != "" || books[i].ForeignID == "" {
+			continue
+		}
+		if lang := c.sampleWorkLanguage(ctx, books[i].ForeignID); lang != "" {
+			books[i].Language = lang
+			filled++
+		}
+	}
+	return filled
+}
+
+// sampleWorkLanguage returns the dominant edition language for a work, or ""
+// when the editions can't be sampled or carry no language. Results (including
+// the empty result) are cached per work ID.
+func (c *Client) sampleWorkLanguage(ctx context.Context, workID string) string {
+	if lang, ok := c.cachedWorkLang(workID); ok {
+		return lang
+	}
+
+	u := fmt.Sprintf("%s/works/%s/editions.json?limit=%d", baseURL, workID, editionLangSampleCap)
+	var resp editionsResponse
+	if err := c.getJSON(ctx, u, &resp); err != nil {
+		slog.Debug("openlibrary: edition language sampling failed", "work", workID, "error", err)
+		// Cache the miss so we don't retry a flaky/expensive call this run.
+		c.setCachedWorkLang(workID, "")
+		return ""
+	}
+
+	lang := majorityEditionLanguage(resp.Entries)
+	c.setCachedWorkLang(workID, lang)
+	return lang
+}
+
+// majorityEditionLanguage returns the most common language across the sampled
+// editions, preferring "eng" on a tie so an author's English work isn't
+// reclassified by a couple of foreign editions. Empty languages are ignored;
+// "" is returned when no edition carries a language.
+func majorityEditionLanguage(entries []editionEntry) string {
+	counts := map[string]int{}
+	for _, e := range entries {
+		for _, l := range e.Languages {
+			code := strings.TrimPrefix(l.Key, "/languages/")
+			if code != "" {
+				counts[code]++
+			}
+		}
+	}
+	if len(counts) == 0 {
+		return ""
+	}
+	best := ""
+	bestN := 0
+	for code, n := range counts {
+		if n > bestN || (n == bestN && code == "eng") {
+			best, bestN = code, n
+		}
+	}
+	return best
+}
+
+func (c *Client) cachedWorkLang(workID string) (string, bool) {
+	if c.workLangCache == nil {
+		return "", false
+	}
+	c.workLangMu.Lock()
+	defer c.workLangMu.Unlock()
+	lang, ok := c.workLangCache[workID]
+	return lang, ok
+}
+
+func (c *Client) setCachedWorkLang(workID, lang string) {
+	if c.workLangCache == nil {
+		return
+	}
+	c.workLangMu.Lock()
+	defer c.workLangMu.Unlock()
+	c.workLangCache[workID] = lang
 }
 
 // GetSubjectBooks fetches the top books for an OpenLibrary subject.

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/vavallee/bindery/internal/models"
 )
 
 // pathTransport routes HTTP calls by URL path to a handler map.
@@ -935,6 +937,140 @@ func TestGetAuthorWorks_HTTP_NoiseFilterSearchEnrichment(t *testing.T) {
 	}
 	if len(books) != 1 || books[0].Title != "Real Book" {
 		t.Fatalf("expected only 'Real Book' to survive, got %+v", books)
+	}
+}
+
+// --- FillMissingWorkLanguages (edition sampling, #891) ---
+
+func langEntries(codes ...string) []editionEntry {
+	entries := make([]editionEntry, 0, len(codes))
+	for _, code := range codes {
+		e := editionEntry{Key: "/books/OLxM"}
+		if code != "" {
+			e.Languages = []struct {
+				Key string `json:"key"`
+			}{{Key: "/languages/" + code}}
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+// A work that has no work-level language but whose editions are foreign gets
+// the dominant edition language, so the allowed_languages filter can catch it.
+func TestFillMissingWorkLanguages_DerivesFromEditions(t *testing.T) {
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/works/OLSPAW/editions.json": jsonStr(editionsResponse{
+			Entries: langEntries("spa", "spa", "eng"),
+		}),
+	})
+	c.workLangCache = map[string]string{}
+
+	books := []models.Book{{ForeignID: "OLSPAW", Title: "Spanish-only Work"}}
+	filled := c.FillMissingWorkLanguages(context.Background(), books)
+	if filled != 1 {
+		t.Fatalf("expected 1 book filled, got %d", filled)
+	}
+	if books[0].Language != "spa" {
+		t.Errorf("Language: want 'spa' (majority edition language), got %q", books[0].Language)
+	}
+}
+
+// A work with no language anywhere (no work-level, no edition languages) stays
+// empty so the caller's unknown-language behavior still applies (pass).
+func TestFillMissingWorkLanguages_NoLanguageStaysUnknown(t *testing.T) {
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/works/OLNOLANGW/editions.json": jsonStr(editionsResponse{
+			Entries: langEntries("", ""),
+		}),
+	})
+	c.workLangCache = map[string]string{}
+
+	books := []models.Book{{ForeignID: "OLNOLANGW", Title: "No Language Work"}}
+	filled := c.FillMissingWorkLanguages(context.Background(), books)
+	if filled != 0 {
+		t.Fatalf("expected 0 books filled, got %d", filled)
+	}
+	if books[0].Language != "" {
+		t.Errorf("Language: want '' (unknown), got %q", books[0].Language)
+	}
+}
+
+// Books that already have a language are not sampled, and the editions endpoint
+// is only hit once per work (cap respected): the limit query param is bounded
+// and a cached miss is not re-fetched.
+func TestFillMissingWorkLanguages_BoundedAndCached(t *testing.T) {
+	var calls int32
+	var gotURL string
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/works/OLSAMPLEW/editions.json": func(r *http.Request) string {
+			atomic.AddInt32(&calls, 1)
+			gotURL = r.URL.String()
+			return jsonStr(editionsResponse{Entries: langEntries("fre")})
+		},
+		"/works/OLHASLANGW/editions.json": func(r *http.Request) string {
+			t.Error("should not sample a work that already has a language")
+			return "{}"
+		},
+	})
+	c.workLangCache = map[string]string{}
+
+	books := []models.Book{
+		{ForeignID: "OLHASLANGW", Title: "Already English", Language: "eng"},
+		{ForeignID: "OLSAMPLEW", Title: "Needs Sampling"},
+		{ForeignID: "", Title: "No Foreign ID"},
+	}
+
+	// First pass derives the language; second pass must reuse the cache.
+	if filled := c.FillMissingWorkLanguages(context.Background(), books); filled != 1 {
+		t.Fatalf("first pass: expected 1 filled, got %d", filled)
+	}
+	books[1].Language = "" // reset to force a re-derive attempt
+	c.FillMissingWorkLanguages(context.Background(), books)
+
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("editions endpoint should be hit once (cached after), hit %d times", got)
+	}
+	if !strings.Contains(gotURL, "limit=5") {
+		t.Errorf("sampling should bound editions with limit=5, got URL %q", gotURL)
+	}
+	if books[1].Language != "fre" {
+		t.Errorf("Language: want 'fre', got %q", books[1].Language)
+	}
+}
+
+// A failure fetching editions leaves the work unknown (caller's fallback wins)
+// and the miss is cached so a flaky/expensive endpoint isn't retried this run.
+func TestFillMissingWorkLanguages_FetchErrorCachesMiss(t *testing.T) {
+	var calls int32
+	c := newClientWithStatus(t,
+		map[string]interface{}{
+			"/works/OLERRW/editions.json": func(r *http.Request) string {
+				atomic.AddInt32(&calls, 1)
+				return "boom"
+			},
+		},
+		map[string]int{"/works/OLERRW/editions.json": http.StatusInternalServerError},
+	)
+	c.workLangCache = map[string]string{}
+
+	books := []models.Book{{ForeignID: "OLERRW", Title: "Flaky Work"}}
+	c.FillMissingWorkLanguages(context.Background(), books)
+	books[0].Language = ""
+	c.FillMissingWorkLanguages(context.Background(), books)
+
+	if books[0].Language != "" {
+		t.Errorf("Language should stay empty on fetch error, got %q", books[0].Language)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("a failed sample should be cached, not retried; hit %d times", got)
+	}
+}
+
+func TestMajorityEditionLanguage_PrefersEngOnTie(t *testing.T) {
+	got := majorityEditionLanguage(langEntries("eng", "fre"))
+	if got != "eng" {
+		t.Errorf("on a tie 'eng' should win, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

OpenLibrary works carry no language at the work level, and the `/search.json` enricher only backfills `language` for works it indexes. For prolific authors, a tail of works (often translations) arrive at the `allowed_languages` filter with `Language=""` and fall through the default `unknown_language_behavior=pass` branch. This is the OpenLibrary half of #889 (Spanish editions of Connelly/Patterson/Gladwell leaking); the Hardcover half was closed by #890. OL-primary setups (no Hardcover token) kept seeing foreign-language works in author bibliographies even with a language-restricted profile.

## Approach

- New `openlibrary.Client.FillMissingWorkLanguages`: for each work with `Language==""`, sample `/works/{id}/editions.json?limit=5` and take the majority edition language (preferring `eng` on a tie so a couple of foreign editions don't reclassify an English work). Reuses the existing `getJSON` call pattern (SSRF-safe transport, `useragent.Get()`, context).
- Per-work-ID memoization (including empty/failed results) so refresh passes and flaky/expensive calls aren't re-fetched. The cap of 5 keeps the editions call cheap; OL throttles per-UA on the editions endpoint, so the sample is bounded by `limit=5` rather than paging.
- Exposed via the aggregator as an optional `workLanguageFiller` capability (`FillMissingAuthorWorkLanguages`), a no-op for providers that don't implement it.
- Wired into the author-works ingestion path (`internal/api/authors.go`) so it runs only when the active profile actually restricts language (`len(allowedLangs) > 0`); no round-trips are spent when `allowed_languages` is `any`. Preserves "unknown ⇒ pass" when sampling yields nothing.
- The `skipping non-allowed-language book` debug log now carries an `edition_sampled` count so the behavior is observable in production logs.

### Assumptions
- Sampling cap = 5 editions (documented inline). Issue suggested 5.
- The profile-aware gating lives at the API ingestion layer (where the profile/`allowed_languages` is resolved), with the OL client doing the bounded fetch + cache. The issue text said "in `GetAuthorWorks`", but the client has no view of the active profile, so gating there would either always sample or require threading profile state through the provider interface. Doing the gate where the profile is known keeps the round-trips out of the `any` case as the issue's point 3 requires.

## Tests
- `openlibrary`: work with language only on editions → derived (majority); no language anywhere → stays unknown; bounded `limit=5` + per-work caching (no re-fetch, already-known works skipped); fetch error caches the miss; eng-on-tie.
- `metadata`: aggregator delegates to a capability-bearing primary; no-op for a primary without the capability.

## Verification
- `go build ./...` clean
- `go vet ./...` clean
- `golangci-lint run ./internal/metadata/openlibrary/ ./internal/metadata/ ./internal/api/` → 0 issues
- `go test ./internal/metadata/ ./internal/metadata/openlibrary/ ./internal/api/` pass

Closes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)