### PR TITLE
perf(web): lazy-load Settings tabs (React.lazy + Suspense)

### DIFF
--- a/changelog.d/773-lazy-settings.md
+++ b/changelog.d/773-lazy-settings.md
@@ -1,0 +1,2 @@
+### Changed
+- **Settings tabs now load on demand** (#773) — each Settings tab is code-split and fetched the first time it's opened, shrinking the initial app bundle.

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -304,6 +304,7 @@
   },
   "settings": {
     "title": "Settings",
+    "loadingTab": "Loading…",
     "tabs": {
       "indexers": "Indexers",
       "clients": "Download Clients",

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -322,14 +322,19 @@ function renderSettings(options?: Parameters<typeof seedSettingsMocks>[0]) {
 
 async function openIndexersTab() {
   fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.indexers' }))
+  // The tab is React.lazy/Suspense code-split (#773); await its content so the
+  // chunk has resolved before synchronous queries on the tab body run.
+  await screen.findByRole('button', { name: 'settings.indexers.addButton' })
 }
 
 async function openClientsTab() {
   fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.clients' }))
+  await screen.findByRole('button', { name: 'settings.clients.addButton' })
 }
 
 async function openImportTab() {
   fireEvent.click(await screen.findByRole('button', { name: 'settings.tabs.import' }))
+  await screen.findByText('settings.import.csvHeading')
 }
 
 function sectionForHeading(name: string) {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,32 +1,36 @@
-import { useCallback, useEffect, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, DownloadClient, Indexer, ProwlarrInstance } from '../api/client'
 import { useAuth } from '../auth/AuthContext'
-import GeneralTab from './settings/GeneralTab'
-import IndexersTab from './settings/IndexersTab'
-import ClientsTab from './settings/ClientsTab'
-import NotificationsTab from './settings/NotificationsTab'
-import QualityTab from './settings/QualityTab'
-import MetadataTab from './settings/MetadataTab'
-import RootFoldersTab from './settings/RootFoldersTab'
-import CalibreTab from './settings/CalibreTab'
-import ABSTab from './settings/ABSTab'
-import GrimmoryTab from './settings/GrimmoryTab'
-import ImportTab from './settings/ImportTab'
-import BlocklistTab from './settings/BlocklistTab'
-import LogsTab from './settings/LogsTab'
 
 // Decomposed from the former ~5100-line SettingsPage monolith (#547): each tab
-// now lives in its own file under ./settings/. Tabs are eager-imported rather
-// than React.lazy code-split — the existing SettingsPage tests open a tab and
-// query its content synchronously, which a Suspense boundary breaks. Eager
-// imports keep behaviour identical to the pre-refactor monolith.
+// now lives in its own file under ./settings/. Tabs are React.lazy code-split
+// (#773) so each tab's JS only downloads when the tab is first opened, keeping
+// it out of the initial app bundle. The single <Suspense> boundary around the
+// active tab shows a lightweight loading fallback while the chunk fetches.
+// (The SettingsPage tests already await tab content via findBy* queries, so the
+// async resolution is transparent to them.)
 //
 // Cross-tab state: the monolith fetched indexers, download clients, and
 // Prowlarr instances eagerly on page mount (not on tab select). That fetch
 // timing is preserved by owning those three lists here and passing them to the
 // Indexers and Clients tabs. Everything else is genuinely tab-local and lives
 // inside its own tab component.
+
+// Each tab is a default export, so lazy(() => import(...)) resolves directly.
+const GeneralTab = lazy(() => import('./settings/GeneralTab'))
+const IndexersTab = lazy(() => import('./settings/IndexersTab'))
+const ClientsTab = lazy(() => import('./settings/ClientsTab'))
+const NotificationsTab = lazy(() => import('./settings/NotificationsTab'))
+const QualityTab = lazy(() => import('./settings/QualityTab'))
+const MetadataTab = lazy(() => import('./settings/MetadataTab'))
+const RootFoldersTab = lazy(() => import('./settings/RootFoldersTab'))
+const CalibreTab = lazy(() => import('./settings/CalibreTab'))
+const ABSTab = lazy(() => import('./settings/ABSTab'))
+const GrimmoryTab = lazy(() => import('./settings/GrimmoryTab'))
+const ImportTab = lazy(() => import('./settings/ImportTab'))
+const BlocklistTab = lazy(() => import('./settings/BlocklistTab'))
+const LogsTab = lazy(() => import('./settings/LogsTab'))
 
 type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import' | 'rootfolders' | 'logs' | 'blocklist' | 'calibre' | 'abs' | 'grimmory'
 
@@ -58,6 +62,21 @@ function SettingsNavLink({ tab, active, onSelect, label }: { tab: Tab; active: T
     >
       {label}
     </button>
+  )
+}
+
+// Suspense fallback shown while a lazily-loaded tab chunk downloads. Mirrors the
+// app's existing inline loading style (animated spinner + muted text in a
+// dark:-aware palette).
+function TabFallback({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 py-8 text-sm text-slate-600 dark:text-zinc-500">
+      <span
+        className="h-4 w-4 animate-spin rounded-full border-2 border-slate-300 border-t-slate-600 dark:border-zinc-700 dark:border-t-zinc-400"
+        aria-hidden="true"
+      />
+      <span>{label}</span>
+    </div>
   )
 }
 
@@ -166,7 +185,9 @@ export default function SettingsPage() {
 
         {/* Tab content */}
         <div className="flex-1 min-w-0">
-          {renderTab()}
+          <Suspense fallback={<TabFallback label={t('settings.loadingTab')} />}>
+            {renderTab()}
+          </Suspense>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problem
All Settings tab components were eager-imported into `SettingsPage`, so every tab's code shipped in the initial bundle even though a user only ever views one tab at a time.

## Approach
- Converted the 13 Settings tab imports in `web/src/pages/SettingsPage.tsx` to `React.lazy(() => import('./settings/...'))`. All tabs are default exports, so no export remapping was needed.
- Wrapped the active tab render in a single `<Suspense fallback={...}>` boundary. The fallback is a small inline spinner (`animate-spin`, dark:-aware palette matching the app's existing loading style) plus a translated label.
- Added `settings.loadingTab` to `web/src/i18n/locales/en.json`.
- Kept tab switching, `?tab=` deep-linking, the eager cross-tab fetches, and all tab props intact. No tab-body files were edited (to avoid conflicts with the concurrent GeneralTab/IndexersTab UX PR).
- Updated the shared `open*Tab` test helpers to await the lazily-loaded tab's content so the async chunk resolution is transparent to the existing synchronous assertions.

## Tests
`cd web && npm ci && npm run typecheck && npm run build && npm run lint && npm test` — all pass (308/308 tests, 0 lint errors).

## Verification
Build output confirms each Settings tab is split into its own chunk, separate from the `SettingsPage` chunk:
```
dist/assets/SettingsPage-*.js        6.74 kB
dist/assets/RootFoldersTab-*.js      2.46 kB
dist/assets/GrimmoryTab-*.js         4.53 kB
dist/assets/BlocklistTab-*.js        5.93 kB
dist/assets/LogsTab-*.js             6.99 kB
dist/assets/MetadataTab-*.js         8.28 kB
dist/assets/QualityTab-*.js          9.09 kB
dist/assets/NotificationsTab-*.js   11.64 kB
dist/assets/ClientsTab-*.js         19.28 kB
dist/assets/ImportTab-*.js          20.96 kB
dist/assets/IndexersTab-*.js        21.17 kB
dist/assets/CalibreTab-*.js         27.79 kB
dist/assets/ABSTab-*.js             40.43 kB
dist/assets/GeneralTab-*.js         59.22 kB
```
Previously these were folded into the `SettingsPage`/main bundle.

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)