### PR TITLE
feat(indexers): honor per-indexer seed-ratio override on torrent grabs

### DIFF
--- a/changelog.d/883-seed-ratio.md
+++ b/changelog.d/883-seed-ratio.md
@@ -1,0 +1,2 @@
+### Added
+- **Per-indexer seed-ratio override** (#883) — set a seed ratio (or "unlimited") on each indexer and Bindery applies it to torrents grabbed from it on qBittorrent, Transmission, and Deluge; leave it blank to keep the download client's global rule.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -528,7 +528,8 @@ func main() {
 		WithLifetimeCtx(appCtx)
 	queueHandler := api.NewQueueHandler(downloadRepo, dlClientRepo, bookRepo, historyRepo).
 		WithNotifier(notif).
-		WithStoragePaths(cfg.DownloadDir, cfg.AudiobookDownloadDir)
+		WithStoragePaths(cfg.DownloadDir, cfg.AudiobookDownloadDir).
+		WithIndexers(indexerRepo)
 	manualImportHandler := api.NewManualImportHandler(importScanner, downloadRepo, bookRepo).
 		WithRoots(libraryRoots)
 	pendingHandler := api.NewPendingHandler(pendingReleaseRepo, queueHandler, downloadRepo, bookRepo)

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -42,6 +42,7 @@ type QueueHandler struct {
 	clients              *db.DownloadClientRepo
 	books                *db.BookRepo
 	history              *db.HistoryRepo
+	indexers             *db.IndexerRepo
 	notif                *notifier.Notifier
 	downloadDir          string
 	audiobookDownloadDir string
@@ -55,6 +56,28 @@ func NewQueueHandler(downloads *db.DownloadRepo, clients *db.DownloadClientRepo,
 func (h *QueueHandler) WithNotifier(n *notifier.Notifier) *QueueHandler {
 	h.notif = n
 	return h
+}
+
+// WithIndexers attaches the indexer repo used to resolve the per-indexer
+// seed-ratio override (#883) when sending a torrent. Optional: when unset the
+// grab proceeds without an override.
+func (h *QueueHandler) WithIndexers(indexers *db.IndexerRepo) *QueueHandler {
+	h.indexers = indexers
+	return h
+}
+
+// resolveSeedRatio returns the seed-ratio override for the given indexer, or
+// nil when there is no indexer repo, no indexer id, the lookup fails, or the
+// indexer has no override. nil keeps the download client's global ratio rule.
+func (h *QueueHandler) resolveSeedRatio(ctx context.Context, indexerID *int64) *float64 {
+	if h.indexers == nil || indexerID == nil || *indexerID == 0 {
+		return nil
+	}
+	idx, err := h.indexers.GetByID(ctx, *indexerID)
+	if err != nil || idx == nil {
+		return nil
+	}
+	return idx.SeedRatio
 }
 
 // WithStoragePaths attaches the process-level download roots used when sending
@@ -788,6 +811,7 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 		MediaType:            req.MediaType,
 		DownloadDir:          h.downloadDir,
 		AudiobookDownloadDir: h.audiobookDownloadDir,
+		SeedRatio:            h.resolveSeedRatio(ctx, indexerID),
 	})
 	if err != nil {
 		slog.Error("failed to send download", "client_type", client.Type, "error", err, "title", req.Title)

--- a/internal/db/extra_repos_test.go
+++ b/internal/db/extra_repos_test.go
@@ -748,6 +748,64 @@ func TestIndexerRepo_Update(t *testing.T) {
 	}
 }
 
+// TestIndexerRepo_SeedRatio round-trips the per-indexer seed-ratio override
+// (#883) through Create/Update/GetByID for the three meaningful shapes: unset
+// (nil = no override), a positive value, and the -1 unlimited sentinel.
+func TestIndexerRepo_SeedRatio(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewIndexerRepo(database)
+
+	idx := &models.Indexer{
+		Name: "Ratio Indexer", Type: "torznab", URL: "https://example.com/api",
+		APIKey: "k", Categories: []int{7020}, Priority: 1, Enabled: true,
+	}
+	if err := repo.Create(ctx, idx); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := repo.GetByID(ctx, idx.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.SeedRatio != nil {
+		t.Errorf("SeedRatio: want nil (no override), got %v", *got.SeedRatio)
+	}
+
+	ratio := 2.5
+	got.SeedRatio = &ratio
+	if err := repo.Update(ctx, got); err != nil {
+		t.Fatalf("Update positive: %v", err)
+	}
+	got, _ = repo.GetByID(ctx, idx.ID)
+	if got.SeedRatio == nil || *got.SeedRatio != 2.5 {
+		t.Errorf("SeedRatio after update: want 2.5, got %v", got.SeedRatio)
+	}
+
+	unlimited := -1.0
+	got.SeedRatio = &unlimited
+	if err := repo.Update(ctx, got); err != nil {
+		t.Fatalf("Update sentinel: %v", err)
+	}
+	got, _ = repo.GetByID(ctx, idx.ID)
+	if got.SeedRatio == nil || *got.SeedRatio != -1 {
+		t.Errorf("SeedRatio sentinel: want -1, got %v", got.SeedRatio)
+	}
+
+	// Clearing the override back to nil must persist as NULL.
+	got.SeedRatio = nil
+	if err := repo.Update(ctx, got); err != nil {
+		t.Fatalf("Update clear: %v", err)
+	}
+	got, _ = repo.GetByID(ctx, idx.ID)
+	if got.SeedRatio != nil {
+		t.Errorf("SeedRatio after clear: want nil, got %v", *got.SeedRatio)
+	}
+}
+
 // TestIndexerRepo_UpdateAPIKeyByProwlarrInstance verifies that rotating the
 // Prowlarr instance's API key via this helper rewrites only the rows belonging
 // to that instance, leaving manual indexers and indexers from a different

--- a/internal/db/indexers.go
+++ b/internal/db/indexers.go
@@ -21,7 +21,7 @@ func NewIndexerRepo(db *sql.DB) *IndexerRepo {
 func (r *IndexerRepo) List(ctx context.Context) ([]models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
-		       prowlarr_instance_id, prowlarr_indexer_id, created_at, updated_at
+		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, created_at, updated_at
 		FROM indexers ORDER BY priority`)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (r *IndexerRepo) List(ctx context.Context) ([]models.Indexer, error) {
 func (r *IndexerRepo) GetByID(ctx context.Context, id int64) (*models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
-		       prowlarr_instance_id, prowlarr_indexer_id, created_at, updated_at
+		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, created_at, updated_at
 		FROM indexers WHERE id=?`, id)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (r *IndexerRepo) GetByID(ctx context.Context, id int64) (*models.Indexer, e
 func (r *IndexerRepo) ListByProwlarrInstance(ctx context.Context, instanceID int64) ([]models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
-		       prowlarr_instance_id, prowlarr_indexer_id, created_at, updated_at
+		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, created_at, updated_at
 		FROM indexers WHERE prowlarr_instance_id=?`, instanceID)
 	if err != nil {
 		return nil, err
@@ -87,11 +87,11 @@ func (r *IndexerRepo) Create(ctx context.Context, idx *models.Indexer) error {
 	}
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO indexers (name, type, url, api_key, categories, priority, enabled, supports_search,
-		                      prowlarr_instance_id, prowlarr_indexer_id, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		                      prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		idx.Name, idx.Type, idx.URL, idx.APIKey, string(catsJSON),
 		idx.Priority, idx.Enabled, idx.SupportsSearch,
-		idx.ProwlarrInstanceID, idx.ProwlarrIndexerID, now, now)
+		idx.ProwlarrInstanceID, idx.ProwlarrIndexerID, idx.SeedRatio, now, now)
 	if err != nil {
 		return fmt.Errorf("create indexer: %w", err)
 	}
@@ -113,10 +113,10 @@ func (r *IndexerRepo) Update(ctx context.Context, idx *models.Indexer) error {
 	}
 	_, err = r.db.ExecContext(ctx, `
 		UPDATE indexers SET name=?, type=?, url=?, api_key=?, categories=?, priority=?,
-		                    enabled=?, supports_search=?, updated_at=?
+		                    enabled=?, supports_search=?, seed_ratio=?, updated_at=?
 		WHERE id=?`,
 		idx.Name, idx.Type, idx.URL, idx.APIKey, string(catsJSON),
-		idx.Priority, idx.Enabled, idx.SupportsSearch, now, idx.ID)
+		idx.Priority, idx.Enabled, idx.SupportsSearch, idx.SeedRatio, now, idx.ID)
 	return err
 }
 
@@ -157,7 +157,7 @@ func scanIndexer(s indexerScanner) (models.Indexer, error) {
 	if err := s.Scan(
 		&idx.ID, &idx.Name, &idx.Type, &idx.URL, &idx.APIKey,
 		&catsJSON, &idx.Priority, &enabled, &supportsSearch,
-		&idx.ProwlarrInstanceID, &idx.ProwlarrIndexerID,
+		&idx.ProwlarrInstanceID, &idx.ProwlarrIndexerID, &idx.SeedRatio,
 		&idx.CreatedAt, &idx.UpdatedAt,
 	); err != nil {
 		return idx, err

--- a/internal/db/migrations/053_indexer_seed_ratio.sql
+++ b/internal/db/migrations/053_indexer_seed_ratio.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+-- Per-indexer seed-ratio override (#883). Nullable: NULL means "no override"
+-- so the torrent inherits the download client's global ratio rule. A stored
+-- value of -1 is the unlimited sentinel (Prowlarr/qBittorrent convention),
+-- carried verbatim through to the client adapters which translate it per their
+-- own API mechanics.
+ALTER TABLE indexers ADD COLUMN seed_ratio REAL;
+
+-- +migrate Down
+
+ALTER TABLE indexers DROP COLUMN seed_ratio;

--- a/internal/downloader/adapter.go
+++ b/internal/downloader/adapter.go
@@ -5,6 +5,7 @@ package downloader
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"math"
 	"strconv"
 	"strings"
@@ -47,6 +48,11 @@ type SendOptions struct {
 	MediaType            string
 	DownloadDir          string
 	AudiobookDownloadDir string
+	// SeedRatio is the per-indexer seed-ratio override (#883) resolved from the
+	// grabbed release's indexer. nil means "no override" (keep the client's
+	// global rule); -1 is the unlimited sentinel. Only honored by torrent
+	// clients; SAB/NZBGet ignore it (ratio is a torrent concept).
+	SeedRatio *float64
 }
 
 func IsTorrentClient(clientType string) bool {
@@ -117,7 +123,7 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		if !strings.HasPrefix(transDL, "/") {
 			transDL = ""
 		}
-		torrentID, err := trans.AddTorrent(ctx, sourceURL, transDL)
+		torrentID, err := trans.AddTorrent(ctx, sourceURL, transDL, opts.SeedRatio)
 		if err != nil {
 			return nil, err
 		}
@@ -137,11 +143,21 @@ func SendDownload(ctx context.Context, client *models.DownloadClient, sourceURL,
 		if hash == "" {
 			return nil, fmt.Errorf("downloader accepted request but did not return a trackable torrent ID")
 		}
+		// Apply the per-indexer seed-ratio override (#883). qBittorrent has no
+		// ratioLimit param on /torrents/add, so it is a separate setShareLimits
+		// call once the hash is known. nil = no override; -1/-2 are valid
+		// sentinels qBit recognizes. A failure here must not fail the grab — the
+		// torrent is already added — so the error is logged, not returned.
+		if opts.SeedRatio != nil {
+			if err := qb.SetShareLimits(ctx, hash, *opts.SeedRatio); err != nil {
+				slog.Warn("qbittorrent: failed to set seed-ratio limit", "hash", hash, "ratio", *opts.SeedRatio, "error", err)
+			}
+		}
 		result.RemoteID = hash
 		return result, nil
 	case "deluge":
 		dl := DelugeFor(client)
-		hash, err := dl.AddTorrent(ctx, sourceURL, ResolveCategory(client, opts.MediaType))
+		hash, err := dl.AddTorrent(ctx, sourceURL, ResolveCategory(client, opts.MediaType), opts.SeedRatio)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -98,7 +98,14 @@ func (c *Client) Test(ctx context.Context) error {
 }
 
 // AddTorrent submits a magnet link or torrent URL and returns the torrent hash.
-func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, label string) (string, error) {
+//
+// seedRatio carries the per-indexer override (#883): a non-negative value is
+// applied via core.set_torrent_stop_ratio after the hash resolves. Deluge's
+// RPC accepts only non-negative floats here, so the -1 unlimited sentinel (and
+// a nil pointer) skips the call entirely, leaving Deluge's global default in
+// place. Ratio-limit errors are non-fatal: the torrent is already added, so a
+// failure to tighten the ratio must not fail the grab.
+func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, label string, seedRatio *float64) (string, error) {
 	if err := c.ensureLoggedIn(ctx); err != nil {
 		return "", err
 	}
@@ -128,7 +135,31 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, label string) (str
 		_ = c.setLabel(ctx, hash, label)
 	}
 
+	// Apply the per-indexer seed-ratio override. Skipped for nil (no override)
+	// and the -1 unlimited sentinel, which Deluge cannot express via
+	// set_torrent_stop_ratio (it rejects negatives) — leave the global default.
+	if seedRatio != nil && *seedRatio >= 0 {
+		if err := c.setStopRatio(ctx, hash, *seedRatio); err != nil {
+			slog.Warn("deluge: failed to set seed-ratio limit", "hash", hash, "ratio", *seedRatio, "error", err)
+		}
+	}
+
 	return hash, nil
+}
+
+// setStopRatio sets the per-torrent stop seed ratio via
+// core.set_torrent_stop_ratio and enables ratio-based stopping via
+// core.set_torrent_stop_at_ratio so the limit is actually honored rather than
+// silently stored. Both accept (hash, value) and only non-negative ratios.
+func (c *Client) setStopRatio(ctx context.Context, hash string, ratio float64) error {
+	var result any
+	if err := c.call(ctx, true, "core.set_torrent_stop_ratio", []any{hash, ratio}, &result); err != nil {
+		return fmt.Errorf("set torrent stop ratio: %w", err)
+	}
+	if err := c.call(ctx, true, "core.set_torrent_stop_at_ratio", []any{hash, true}, &result); err != nil {
+		return fmt.Errorf("set torrent stop at ratio: %w", err)
+	}
+	return nil
 }
 
 // addMagnet calls core.add_torrent_magnet which returns the hash directly.

--- a/internal/downloader/deluge/client_test.go
+++ b/internal/downloader/deluge/client_test.go
@@ -56,6 +56,13 @@ type delugeServer struct {
 	// statusErr forces core.get_torrent_status to return an RPC error,
 	// exercising the Files() error path.
 	statusErr bool
+
+	// stopRatio records the ratio passed to core.set_torrent_stop_ratio per
+	// hash; stopAtRatio records whether core.set_torrent_stop_at_ratio(true)
+	// fired. Both stay zero/false when AddTorrent skips the seed-ratio step.
+	stopRatio    map[string]float64
+	stopAtRatio  map[string]bool
+	stopRatioErr bool
 }
 
 func (s *delugeServer) handler() http.HandlerFunc {
@@ -128,6 +135,32 @@ func (s *delugeServer) handler() http.HandlerFunc {
 			write([]bool{true})
 
 		case "label.set_torrent":
+			write(nil)
+
+		case "core.set_torrent_stop_ratio":
+			if s.stopRatioErr {
+				writeErr("set stop ratio error")
+				return
+			}
+			var hash string
+			var ratio float64
+			json.Unmarshal(req.Params[0], &hash)
+			json.Unmarshal(req.Params[1], &ratio)
+			if s.stopRatio == nil {
+				s.stopRatio = make(map[string]float64)
+			}
+			s.stopRatio[strings.ToLower(hash)] = ratio
+			write(nil)
+
+		case "core.set_torrent_stop_at_ratio":
+			var hash string
+			var enabled bool
+			json.Unmarshal(req.Params[0], &hash)
+			json.Unmarshal(req.Params[1], &enabled)
+			if s.stopAtRatio == nil {
+				s.stopAtRatio = make(map[string]bool)
+			}
+			s.stopAtRatio[strings.ToLower(hash)] = enabled
 			write(nil)
 
 		case "core.get_torrents_status":
@@ -223,7 +256,7 @@ func TestAddTorrent_Magnet(t *testing.T) {
 	c := clientFromServer(srv, "pw")
 
 	magnet := "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd&dn=Test+Book"
-	hash, err := c.AddTorrent(context.Background(), magnet, "books")
+	hash, err := c.AddTorrent(context.Background(), magnet, "books", nil)
 	if err != nil {
 		t.Fatalf("AddTorrent magnet: %v", err)
 	}
@@ -235,11 +268,76 @@ func TestAddTorrent_Magnet(t *testing.T) {
 	}
 }
 
+func ratioPtr(f float64) *float64 { return &f }
+
+// TestAddTorrent_SeedRatio_Positive: a non-negative override is applied via
+// core.set_torrent_stop_ratio and ratio-stopping is enabled.
+func TestAddTorrent_SeedRatio_Positive(t *testing.T) {
+	srv, ds := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+
+	magnet := "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd"
+	hash, err := c.AddTorrent(context.Background(), magnet, "", ratioPtr(2))
+	if err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if got, ok := ds.stopRatio[hash]; !ok || got != 2 {
+		t.Errorf("stopRatio[%s] = %v (set=%v), want 2", hash, got, ok)
+	}
+	if !ds.stopAtRatio[hash] {
+		t.Error("set_torrent_stop_at_ratio(true) should have fired for a positive override")
+	}
+}
+
+// TestAddTorrent_SeedRatio_Unlimited: the -1 sentinel must NOT call
+// set_torrent_stop_ratio (Deluge rejects negatives) — the global default stays.
+func TestAddTorrent_SeedRatio_Unlimited(t *testing.T) {
+	srv, ds := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+
+	magnet := "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd"
+	hash, err := c.AddTorrent(context.Background(), magnet, "", ratioPtr(-1))
+	if err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if _, ok := ds.stopRatio[hash]; ok {
+		t.Error("stopRatio must not be set for the unlimited sentinel")
+	}
+}
+
+// TestAddTorrent_SeedRatio_Unset: a nil override skips the ratio call entirely.
+func TestAddTorrent_SeedRatio_Unset(t *testing.T) {
+	srv, ds := newTestServer(t, "pw")
+	c := clientFromServer(srv, "pw")
+
+	magnet := "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd"
+	hash, err := c.AddTorrent(context.Background(), magnet, "", nil)
+	if err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if _, ok := ds.stopRatio[hash]; ok {
+		t.Error("stopRatio must not be set when no override is provided")
+	}
+}
+
+// TestAddTorrent_SeedRatio_ErrorNonFatal: a failure setting the ratio must not
+// fail the grab — the torrent is already added.
+func TestAddTorrent_SeedRatio_ErrorNonFatal(t *testing.T) {
+	srv, ds := newTestServer(t, "pw")
+	ds.stopRatioErr = true
+	c := clientFromServer(srv, "pw")
+
+	magnet := "magnet:?xt=urn:btih:aabbccddeeff00112233445566778899aabbccdd"
+	if _, err := c.AddTorrent(context.Background(), magnet, "", ratioPtr(2)); err != nil {
+		t.Fatalf("AddTorrent must succeed despite a ratio-set failure: %v", err)
+	}
+}
+
 func TestAddTorrent_URL(t *testing.T) {
 	srv, _ := newTestServer(t, "pw")
 	c := clientFromServer(srv, "pw")
 
-	hash, err := c.AddTorrent(context.Background(), "http://indexer.example/torrent.torrent", "")
+	hash, err := c.AddTorrent(context.Background(), "http://indexer.example/torrent.torrent", "", nil)
 	if err != nil {
 		t.Fatalf("AddTorrent URL: %v", err)
 	}
@@ -345,7 +443,7 @@ func TestAddTorrent_URL_HashLookupTimeout(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	c := clientFromServer(srv, "pw")
-	_, err := c.AddTorrent(context.Background(), "http://example.com/book.torrent", "scifi")
+	_, err := c.AddTorrent(context.Background(), "http://example.com/book.torrent", "scifi", nil)
 	if err == nil {
 		t.Fatal("expected error on timeout, got nil")
 		return

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -158,6 +159,43 @@ func (c *Client) Test(ctx context.Context) error {
 			return fmt.Errorf("connected to qBittorrent at %s but %w", c.baseURL, err)
 		}
 		return fmt.Errorf("could not reach qBittorrent at %s — %w%s", c.baseURL, err, nethint.ForErr(err))
+	}
+	return nil
+}
+
+// SetShareLimits applies a per-torrent seed-ratio limit via
+// POST /api/v2/torrents/setShareLimits. ratioLimit follows qBittorrent's own
+// convention: a positive float is the target ratio, -1 means "no limit"
+// (seed forever) and -2 means "use the global limit". seedingTimeLimit and
+// inactiveSeedingTimeLimit are left at -2 (use global) so this call only ever
+// touches the ratio rule. Callers resolve the value from the indexer's
+// SeedRatio override (#883); a nil override skips this call entirely so the
+// torrent keeps the client's global rule.
+func (c *Client) SetShareLimits(ctx context.Context, hash string, ratioLimit float64) error {
+	if err := c.ensureLoggedIn(ctx); err != nil {
+		return err
+	}
+	form := url.Values{
+		"hashes":                   {hash},
+		"ratioLimit":               {strconv.FormatFloat(ratioLimit, 'f', -1, 64)},
+		"seedingTimeLimit":         {"-2"},
+		"inactiveSeedingTimeLimit": {"-2"},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/api/v2/torrents/setShareLimits",
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("build setShareLimits request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("setShareLimits: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("setShareLimits HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return nil
 }

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"syscall"
@@ -1892,5 +1893,87 @@ func TestClient_Files_WindowsBackslashesNormalized(t *testing.T) {
 	}
 	if len(files) != 1 || files[0].Name != "MyBook/disc01.m4b" {
 		t.Errorf("backslash not normalized: %+v", files)
+	}
+}
+
+// TestSetShareLimits_Positive asserts a positive override posts the ratioLimit
+// verbatim to /api/v2/torrents/setShareLimits, with seedingTime fields left at
+// -2 (use global) so only the ratio rule is touched.
+func TestSetShareLimits_Positive(t *testing.T) {
+	var gotForm url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/setShareLimits":
+			_ = r.ParseForm()
+			gotForm = r.PostForm
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "u", "p")
+	c.loggedIn = true
+	if err := c.SetShareLimits(context.Background(), "abc", 1.5); err != nil {
+		t.Fatalf("SetShareLimits: %v", err)
+	}
+	if got := gotForm.Get("hashes"); got != "abc" {
+		t.Errorf("hashes = %q, want abc", got)
+	}
+	if got := gotForm.Get("ratioLimit"); got != "1.5" {
+		t.Errorf("ratioLimit = %q, want 1.5", got)
+	}
+	if got := gotForm.Get("seedingTimeLimit"); got != "-2" {
+		t.Errorf("seedingTimeLimit = %q, want -2 (use global)", got)
+	}
+}
+
+// TestSetShareLimits_Unlimited asserts the -1 sentinel passes straight through;
+// qBittorrent recognizes -1 as "no limit".
+func TestSetShareLimits_Unlimited(t *testing.T) {
+	var gotRatio string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/setShareLimits":
+			_ = r.ParseForm()
+			gotRatio = r.PostForm.Get("ratioLimit")
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "u", "p")
+	c.loggedIn = true
+	if err := c.SetShareLimits(context.Background(), "abc", -1); err != nil {
+		t.Fatalf("SetShareLimits: %v", err)
+	}
+	if gotRatio != "-1" {
+		t.Errorf("ratioLimit = %q, want -1", gotRatio)
+	}
+}
+
+// TestSetShareLimits_HTTPError surfaces a non-200 as an error so the caller can
+// log it (the grab itself is not failed by the caller, but the method reports).
+func TestSetShareLimits_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/auth/login" {
+			_, _ = w.Write([]byte("Ok."))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "u", "p")
+	c.loggedIn = true
+	if err := c.SetShareLimits(context.Background(), "abc", 2); err == nil {
+		t.Fatal("expected error on HTTP 500")
 	}
 }

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -97,11 +97,18 @@ func (c *Client) Test(ctx context.Context) error {
 // (e.g. transmission behind a VPN container), the daemon can't fetch the
 // URL, so it sits in retry until Bindery's request deadline expires.
 // Reported by @Bclark117 in #873.
-func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, downloadDir string) (int64, error) {
+//
+// seedRatio carries the per-indexer override (#883): a positive value sets a
+// per-torrent ratio with seedRatioMode=1 (single, ignore the global rule); the
+// -1 unlimited sentinel maps to seedRatioMode=2 (no ratio limit) because the
+// Transmission RPC rejects a negative seedRatioLimit float. A nil pointer
+// leaves both fields unset so the torrent keeps Transmission's global rule.
+func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, downloadDir string, seedRatio *float64) (int64, error) {
 	args := map[string]interface{}{}
 	if downloadDir != "" {
 		args["download-dir"] = downloadDir
 	}
+	applySeedRatioArgs(args, seedRatio)
 
 	if isMagnetLink(magnetOrURL) {
 		args["filename"] = magnetOrURL
@@ -150,6 +157,31 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, downloadDir string
 	}
 
 	return 0, fmt.Errorf("no torrent ID returned")
+}
+
+// Transmission seedRatioMode values (RPC spec): 0 = use global limit,
+// 1 = use the per-torrent seedRatioLimit, 2 = no ratio limit (seed forever).
+const (
+	seedRatioModeSingle    = 1
+	seedRatioModeUnlimited = 2
+)
+
+// applySeedRatioArgs writes the seedRatioLimit/seedRatioMode pair into a
+// torrent-add (or torrent-set) argument map for the given override. nil leaves
+// the map untouched (keep the global rule). A non-negative value sets a single
+// per-torrent ratio; the -1 unlimited sentinel becomes seedRatioMode=2 since
+// the RPC rejects a negative seedRatioLimit. Other negatives are treated as
+// unlimited too (defensive: the only negative Bindery stores is -1).
+func applySeedRatioArgs(args map[string]interface{}, seedRatio *float64) {
+	if seedRatio == nil {
+		return
+	}
+	if *seedRatio < 0 {
+		args["seedRatioMode"] = seedRatioModeUnlimited
+		return
+	}
+	args["seedRatioLimit"] = *seedRatio
+	args["seedRatioMode"] = seedRatioModeSingle
 }
 
 // GetTorrents returns torrents in the given download directory (empty = all).

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -94,7 +94,7 @@ func TestAddTorrent_NewTorrent(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "user", "pass")
-	id, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc123", "")
+	id, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc123", "", nil)
 	if err != nil {
 		t.Fatalf("AddTorrent: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestAddTorrent_HTTPRedirectToMagnet(t *testing.T) {
 	c := newTestClient(rpc.URL, "user", "pass")
 	c.validateTorrentURL = func(string) error { return nil } // allow the loopback test server
 
-	id, err := c.AddTorrent(context.Background(), indexer.URL+"/download/123", "")
+	id, err := c.AddTorrent(context.Background(), indexer.URL+"/download/123", "", nil)
 	if err != nil {
 		t.Fatalf("AddTorrent: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestAddTorrent_DuplicateTorrent(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "user", "pass")
-	id, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "")
+	id, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", nil)
 	if err != nil {
 		t.Fatalf("AddTorrent: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestAddTorrent_NoID(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "user", "pass")
-	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", ""); err == nil {
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", nil); err == nil {
 		t.Fatal("expected error when no torrent ID returned")
 	}
 }
@@ -185,7 +185,7 @@ func TestAddTorrent_FailResult(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "user", "pass")
-	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", ""); err == nil {
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", nil); err == nil {
 		t.Fatal("expected error on non-success result")
 	}
 }
@@ -198,7 +198,7 @@ func TestAddTorrent_HTTPError(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "user", "pass")
-	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", ""); err == nil {
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", nil); err == nil {
 		t.Fatal("expected error on 403")
 	}
 }
@@ -216,7 +216,7 @@ func TestAddTorrent_WithDownloadDir(t *testing.T) {
 	defer srv.Close()
 
 	c := newTestClient(srv.URL, "user", "pass")
-	id, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "/custom/dir")
+	id, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "/custom/dir", nil)
 	if err != nil {
 		t.Fatalf("AddTorrent: %v", err)
 	}
@@ -690,7 +690,7 @@ func TestAddTorrent_HTTPURLFetchesContent(t *testing.T) {
 	c := newTestClient(transSrv.URL, "", "")
 	allowTorrentFetch(c)
 
-	id, err := c.AddTorrent(context.Background(), indexerSrv.URL+"/file.torrent", "")
+	id, err := c.AddTorrent(context.Background(), indexerSrv.URL+"/file.torrent", "", nil)
 	if err != nil {
 		t.Fatalf("AddTorrent: %v", err)
 	}
@@ -734,7 +734,7 @@ func TestAddTorrent_MagnetLinkSkipsFetch(t *testing.T) {
 	allowTorrentFetch(c)
 
 	magnet := "magnet:?xt=urn:btih:abc123&tr=" + url.QueryEscape(indexerSrv.URL)
-	id, err := c.AddTorrent(context.Background(), magnet, "")
+	id, err := c.AddTorrent(context.Background(), magnet, "", nil)
 	if err != nil {
 		t.Fatalf("AddTorrent: %v", err)
 	}
@@ -770,7 +770,7 @@ func TestAddTorrent_HTTPURLFetchFailure(t *testing.T) {
 	c := newTestClient(transSrv.URL, "", "")
 	allowTorrentFetch(c)
 
-	_, err := c.AddTorrent(context.Background(), indexerSrv.URL+"/file.torrent", "")
+	_, err := c.AddTorrent(context.Background(), indexerSrv.URL+"/file.torrent", "", nil)
 	if err == nil {
 		t.Fatal("expected error on indexer 401")
 		return
@@ -792,7 +792,7 @@ func TestAddTorrent_HTTPURLSSRFBlocked(t *testing.T) {
 	c := newTestClient(transSrv.URL, "", "")
 	// Do NOT call allowTorrentFetch; the guard must be active.
 
-	_, err := c.AddTorrent(context.Background(), "http://127.0.0.1:9999/file.torrent", "")
+	_, err := c.AddTorrent(context.Background(), "http://127.0.0.1:9999/file.torrent", "", nil)
 	if err == nil {
 		t.Fatal("expected SSRF guard to block loopback URL")
 		return
@@ -820,5 +820,72 @@ func TestIsMagnetLink(t *testing.T) {
 		if got := isMagnetLink(in); got != want {
 			t.Errorf("isMagnetLink(%q) = %v, want %v", in, got, want)
 		}
+	}
+}
+
+// floatPtr is a test helper for the *float64 seed-ratio override.
+func floatPtr(f float64) *float64 { return &f }
+
+// captureAddArgs spins up an RPC stub that records the torrent-add arguments
+// and returns a captured map plus the client, so each seed-ratio case can
+// assert on the exact seedRatioLimit/seedRatioMode the daemon would receive.
+func captureAddArgs(t *testing.T) (*Client, *map[string]any) {
+	t.Helper()
+	captured := map[string]any{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Arguments map[string]any `json:"arguments"`
+		}
+		_ = newJSONDecoder(r.Body).Decode(&req)
+		captured = req.Arguments
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{"torrent-added":{"id":1,"name":"B"}}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return newTestClient(srv.URL, "u", "p"), &captured
+}
+
+// TestAddTorrent_SeedRatio_Positive: a positive override sets a per-torrent
+// ratio with seedRatioMode=1 (single, ignore the global rule).
+func TestAddTorrent_SeedRatio_Positive(t *testing.T) {
+	c, captured := captureAddArgs(t)
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", floatPtr(2.5)); err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if got := (*captured)["seedRatioLimit"]; got != 2.5 {
+		t.Errorf("seedRatioLimit = %v, want 2.5", got)
+	}
+	// JSON numbers decode to float64.
+	if got := (*captured)["seedRatioMode"]; got != float64(seedRatioModeSingle) {
+		t.Errorf("seedRatioMode = %v, want %d", got, seedRatioModeSingle)
+	}
+}
+
+// TestAddTorrent_SeedRatio_Unlimited: the -1 sentinel must not be sent as a
+// negative seedRatioLimit (the RPC rejects it); it becomes seedRatioMode=2.
+func TestAddTorrent_SeedRatio_Unlimited(t *testing.T) {
+	c, captured := captureAddArgs(t)
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", floatPtr(-1)); err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if _, ok := (*captured)["seedRatioLimit"]; ok {
+		t.Errorf("seedRatioLimit must be omitted for the unlimited sentinel, got %v", (*captured)["seedRatioLimit"])
+	}
+	if got := (*captured)["seedRatioMode"]; got != float64(seedRatioModeUnlimited) {
+		t.Errorf("seedRatioMode = %v, want %d", got, seedRatioModeUnlimited)
+	}
+}
+
+// TestAddTorrent_SeedRatio_Unset: a nil override leaves both fields off so the
+// torrent keeps Transmission's global ratio rule.
+func TestAddTorrent_SeedRatio_Unset(t *testing.T) {
+	c, captured := captureAddArgs(t)
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", nil); err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if _, ok := (*captured)["seedRatioLimit"]; ok {
+		t.Error("seedRatioLimit must be omitted when no override is set")
+	}
+	if _, ok := (*captured)["seedRatioMode"]; ok {
+		t.Error("seedRatioMode must be omitted when no override is set")
 	}
 }

--- a/internal/models/indexer.go
+++ b/internal/models/indexer.go
@@ -3,17 +3,23 @@ package models
 import "time"
 
 type Indexer struct {
-	ID                 int64     `json:"id"`
-	Name               string    `json:"name"`
-	Type               string    `json:"type"`
-	URL                string    `json:"url"`
-	APIKey             string    `json:"apiKey"`
-	Categories         []int     `json:"categories"`
-	Priority           int       `json:"priority"`
-	Enabled            bool      `json:"enabled"`
-	SupportsSearch     bool      `json:"supportsSearch"`
-	ProwlarrInstanceID *int64    `json:"prowlarrInstanceId,omitempty"`
-	ProwlarrIndexerID  *int      `json:"prowlarrIndexerId,omitempty"`
-	CreatedAt          time.Time `json:"createdAt"`
-	UpdatedAt          time.Time `json:"updatedAt"`
+	ID                 int64  `json:"id"`
+	Name               string `json:"name"`
+	Type               string `json:"type"`
+	URL                string `json:"url"`
+	APIKey             string `json:"apiKey"`
+	Categories         []int  `json:"categories"`
+	Priority           int    `json:"priority"`
+	Enabled            bool   `json:"enabled"`
+	SupportsSearch     bool   `json:"supportsSearch"`
+	ProwlarrInstanceID *int64 `json:"prowlarrInstanceId,omitempty"`
+	ProwlarrIndexerID  *int   `json:"prowlarrIndexerId,omitempty"`
+	// SeedRatio is the per-indexer seed-ratio override applied to torrents
+	// grabbed from this indexer. nil means "no override" (the download client
+	// keeps its global rule); an explicit -1 is the unlimited sentinel
+	// (Prowlarr/qBittorrent convention). The downloader adapters translate the
+	// value into each client's own API shape.
+	SeedRatio *float64  `json:"seedRatio,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -400,6 +400,21 @@ func (s *Scheduler) SearchAndGrabBook(ctx context.Context, book models.Book) {
 	}
 }
 
+// resolveSeedRatio looks up the per-indexer seed-ratio override (#883) for the
+// indexer a release was grabbed from. Returns nil (no override) when the
+// indexer repo is unset, the id is zero, the lookup fails, or the indexer has
+// no override stored, so the download client keeps its global ratio rule.
+func (s *Scheduler) resolveSeedRatio(ctx context.Context, indexerID int64) *float64 {
+	if s.indexers == nil || indexerID == 0 {
+		return nil
+	}
+	idx, err := s.indexers.GetByID(ctx, indexerID)
+	if err != nil || idx == nil {
+		return nil
+	}
+	return idx.SeedRatio
+}
+
 // searchAndGrabFormat searches for and grabs a specific format of a book.
 // mediaType must be MediaTypeEbook or MediaTypeAudiobook.
 func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, mediaType string) {
@@ -550,6 +565,7 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		MediaType:            mediaType,
 		DownloadDir:          s.downloadDir,
 		AudiobookDownloadDir: s.audiobookDownloadDir,
+		SeedRatio:            s.resolveSeedRatio(ctx, best.IndexerID),
 	})
 	if err != nil {
 		slog.Error("SearchAndGrabBook: failed to send to downloader", "client", client.Type, "title", best.Title, "error", err)

--- a/web/src/api/indexers.ts
+++ b/web/src/api/indexers.ts
@@ -11,6 +11,9 @@ export interface Indexer {
   priority: number
   enabled: boolean
   prowlarrInstanceId?: number
+  // Per-indexer seed-ratio override (#883). Omitted/null = no override (the
+  // download client keeps its global rule); -1 = unlimited (seed forever).
+  seedRatio?: number | null
 }
 
 export interface IndexerTestResult {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -390,7 +390,11 @@
         "categoriesPlaceholder": "Categories (e.g. 7020, 7120, 3030)",
         "categoriesHint": "Comma-separated Newznab category IDs. 7020 = eBooks, 3030 = Audiobooks. Add custom IDs for indexers with non-standard categories (e.g. 7120 for German books).",
         "priority": "Priority",
-        "priorityHint": "Higher wins ties when the same release is found on multiple indexers. Use it to prefer one indexer — e.g. set Usenet indexers above torrent ones. Default 0."
+        "priorityHint": "Higher wins ties when the same release is found on multiple indexers. Use it to prefer one indexer — e.g. set Usenet indexers above torrent ones. Default 0.",
+        "seedRatio": "Seed ratio",
+        "seedRatioPlaceholder": "e.g. 1.0",
+        "seedRatioUnlimited": "Unlimited",
+        "seedRatioHint": "Per-indexer seed-ratio limit applied to torrents grabbed from this indexer (qBittorrent, Transmission, Deluge). Leave blank to use the download client's global rule, or check Unlimited to seed forever. Ignored for Usenet."
       }
     },
     "prowlarr": {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1085,6 +1085,7 @@ describe('SettingsPage', () => {
         categories: [7020, 7120, 3030],
         priority: 0,
         enabled: true,
+        seedRatio: null,
       })
     })
     expect(await screen.findByText('SceneNZBs')).toBeInTheDocument()
@@ -1112,9 +1113,47 @@ describe('SettingsPage', () => {
         url: 'https://slug.example.com/api',
         apiKey: 'slug-key',
         categories: [7020, 3030],
+        seedRatio: null,
       })
     })
     expect(await screen.findByText('DrunkenSlug')).toBeInTheDocument()
+  })
+
+  it('saves a numeric per-indexer seed ratio', async () => {
+    const indexer = makeIndexer({ id: 11, name: 'RatioIdx' })
+    renderSettings({ indexers: [indexer] })
+    await openIndexersTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+    fireEvent.change(screen.getByPlaceholderText('settings.indexers.form.seedRatioPlaceholder'), { target: { value: '1.5' } })
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => {
+      expect(api.updateIndexer).toHaveBeenCalledWith(11, expect.objectContaining({ seedRatio: 1.5 }))
+    })
+  })
+
+  it('saves the unlimited seed-ratio sentinel via the toggle', async () => {
+    const indexer = makeIndexer({ id: 12, name: 'UnlimitedIdx' })
+    renderSettings({ indexers: [indexer] })
+    await openIndexersTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+    fireEvent.click(screen.getByLabelText('settings.indexers.form.seedRatioUnlimited'))
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => {
+      expect(api.updateIndexer).toHaveBeenCalledWith(12, expect.objectContaining({ seedRatio: -1 }))
+    })
+  })
+
+  it('round-trips an existing -1 seed ratio as the unlimited toggle', async () => {
+    const indexer = makeIndexer({ id: 13, name: 'PreUnlimited', seedRatio: -1 })
+    renderSettings({ indexers: [indexer] })
+    await openIndexersTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+    expect(screen.getByLabelText('settings.indexers.form.seedRatioUnlimited')).toBeChecked()
   })
 
   it('toggles and deletes an indexer', async () => {

--- a/web/src/pages/settings/IndexersTab.tsx
+++ b/web/src/pages/settings/IndexersTab.tsx
@@ -31,6 +31,61 @@ function IndexerTestResultBanner({ r }: { r: IndexerTestResult }) {
   )
 }
 
+// SeedRatioField renders the per-indexer seed-ratio override (#883) as a
+// numeric input plus an "unlimited" toggle, so users never have to learn the
+// -1 sentinel. It round-trips three shapes:
+//   - null/undefined → no override (input empty, toggle off)
+//   - >= 0           → that ratio (input shows it, toggle off)
+//   - -1             → unlimited (input disabled/blank, toggle on)
+function SeedRatioField({ value, onChange }: { value: number | null | undefined; onChange: (v: number | null) => void }) {
+  const { t } = useTranslation()
+  const unlimited = value === -1
+  // Text mirror of the numeric input so a half-typed "1." doesn't get clobbered.
+  const [text, setText] = useState(value != null && value >= 0 ? String(value) : '')
+
+  const handleText = (raw: string) => {
+    setText(raw)
+    if (raw.trim() === '') {
+      onChange(null)
+      return
+    }
+    const n = Number(raw)
+    if (!Number.isNaN(n) && n >= 0) onChange(n)
+  }
+
+  const toggleUnlimited = () => {
+    if (unlimited) {
+      onChange(null)
+      setText('')
+    } else {
+      onChange(-1)
+    }
+  }
+
+  return (
+    <div>
+      <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('settings.indexers.form.seedRatio')}</label>
+      <div className="flex items-center gap-3">
+        <input
+          type="number"
+          min="0"
+          step="0.1"
+          value={unlimited ? '' : text}
+          disabled={unlimited}
+          onChange={e => handleText(e.target.value)}
+          placeholder={t('settings.indexers.form.seedRatioPlaceholder')}
+          className={`${inputCls} flex-1 disabled:opacity-50`}
+        />
+        <label className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-zinc-400 whitespace-nowrap">
+          <input type="checkbox" checked={unlimited} onChange={toggleUnlimited} className="accent-emerald-600 dark:accent-emerald-500" />
+          {t('settings.indexers.form.seedRatioUnlimited')}
+        </label>
+      </div>
+      <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.seedRatioHint')}</p>
+    </div>
+  )
+}
+
 // indexers/prowlarrInstances are owned by SettingsPage so they can be fetched
 // eagerly on page mount (matching the pre-refactor monolith), not on tab open.
 interface Props {
@@ -274,12 +329,13 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
   const [apiKey, setApiKey] = useState(indexer.apiKey)
   const [categories, setCategories] = useState((indexer.categories ?? [7020]).join(', '))
   const [priority, setPriority] = useState(String(indexer.priority ?? 0))
+  const [seedRatio, setSeedRatio] = useState<number | null>(indexer.seedRatio ?? null)
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<IndexerTestResult | null>(null)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
-    const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey, categories: parseCats(categories), priority: parsePriority(priority) })
+    const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey, categories: parseCats(categories), priority: parsePriority(priority), seedRatio })
     onSaved(updated)
   }
 
@@ -330,6 +386,7 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
         <input type="number" value={priority} onChange={e => setPriority(e.target.value)} placeholder="0" className={inputCls} />
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.priorityHint')}</p>
       </div>
+      <SeedRatioField value={seedRatio} onChange={setSeedRatio} />
       {testResult && <IndexerTestResultBanner r={testResult} />}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">{t('common.cancel')}</button>
@@ -348,12 +405,13 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
   const [apiKey, setApiKey] = useState('')
   const [categories, setCategories] = useState('7020')
   const [priority, setPriority] = useState('0')
+  const [seedRatio, setSeedRatio] = useState<number | null>(null)
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<IndexerTestResult | null>(null)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
-    const idx = await api.addIndexer({ name, url, apiKey, type, categories: parseCats(categories), priority: parsePriority(priority), enabled: true })
+    const idx = await api.addIndexer({ name, url, apiKey, type, categories: parseCats(categories), priority: parsePriority(priority), enabled: true, seedRatio })
     onAdded(idx)
   }
 
@@ -404,6 +462,7 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
         <input type="number" value={priority} onChange={e => setPriority(e.target.value)} placeholder="0" className={inputCls} />
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.priorityHint')}</p>
       </div>
+      <SeedRatioField value={seedRatio} onChange={setSeedRatio} />
       {testResult && <IndexerTestResultBanner r={testResult} />}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">{t('common.cancel')}</button>


### PR DESCRIPTION
## Problem
Prowlarr/Readarr let you set a seed-ratio rule per indexer (private trackers commonly require ratio >= N). Bindery dropped this on the floor: torrents inherited whatever default the download client applied, with no way to express a per-indexer requirement short of one dedicated category per indexer (#883).

## Approach
Adds a nullable `models.Indexer.SeedRatio *float64` plumbed end-to-end:
- **Storage**: migration `053_indexer_seed_ratio.sql` adds a nullable `seed_ratio REAL`. `nil` = no override (keep the client's global rule); `-1` = unlimited sentinel (Prowlarr/qBittorrent convention).
- **Resolution**: both grab paths (scheduler auto-grab, manual queue grab) look up the override from the release's indexer and pass it via `downloader.SendOptions.SeedRatio`.
- **qBittorrent**: `POST /api/v2/torrents/setShareLimits` with `ratioLimit` once the hash resolves (`-1`/`-2` recognized).
- **Transmission**: `seedRatioLimit` + `seedRatioMode=1` on `torrent-add` for `>0`; `-1` maps to `seedRatioMode=2` (no limit) because the RPC rejects a negative `seedRatioLimit`.
- **Deluge**: `core.set_torrent_stop_ratio` (+ `set_torrent_stop_at_ratio`) for `>=0`; `-1`/`nil` skip the call so Deluge keeps its global default. Ratio-set failures are non-fatal (the torrent is already added).
- **UI**: a numeric input plus an "unlimited" toggle in the indexer Add/Edit forms, so users never see the `-1` sentinel; round-trips null/value/-1 through the API.

Sourcing the ratio from Prowlarr's `seedCriteria.seedRatio` during sync is left as a follow-up; this ships the Bindery-local per-indexer override per the spec's `models.Indexer.SeedRatio`.

## Tests
- Go httptest-server unit tests per client asserting the exact params/mode for value>0, -1 (unlimited), and unset (no call) — qBittorrent `setShareLimits`, Transmission `torrent-add` args, Deluge `set_torrent_stop_ratio` (incl. non-fatal-error case).
- DB round-trip test for nil/positive/-1/clear-to-null persistence.
- Frontend tests: numeric save, unlimited-toggle save (-1), and round-tripping a stored -1 back to the toggle; updated two existing payload assertions.

## Verification
- `go build ./...`, `go vet ./...` clean.
- `golangci-lint run` on every touched Go package: 0 issues.
- `go test` on touched Go packages: pass.
- `cd web && npm ci && npm run typecheck && npm run build && npm run lint && npm test`: typecheck/build clean, lint 0 errors (6 pre-existing warnings in unrelated files), 311 tests pass.

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)