### PR TITLE
fix(indexer): require author match on scattered-keyword release matches

### DIFF
--- a/internal/indexer/inorder.go
+++ b/internal/indexer/inorder.go
@@ -1,0 +1,25 @@
+package indexer
+
+import (
+	"regexp"
+	"strings"
+)
+
+// containsInOrder reports whether every word in seq appears in haystack in the
+// given order, allowing arbitrary intervening text. Unlike ContainsPhrase
+// (which requires the words contiguous) it tolerates gaps; unlike a plain
+// all-present check it rejects REORDERED matches — so "Secrets of the Human
+// Body" does not satisfy the ["body","secrets"] sequence, but "The Lord of the
+// Rings" does satisfy ["lord","rings"].
+func containsInOrder(haystack string, seq []string) bool {
+	if len(seq) == 0 {
+		return true
+	}
+	parts := make([]string, len(seq))
+	for i, w := range seq {
+		parts[i] = umlautFlexRegex(regexp.QuoteMeta(strings.ToLower(w)))
+	}
+	pattern := `(?i)\b` + strings.Join(parts, `\b.*\b`) + `\b`
+	re, _ := regexCache.LoadOrStore(pattern, regexp.MustCompile(pattern))
+	return re.(*regexp.Regexp).MatchString(haystack)
+}

--- a/internal/indexer/inorder_test.go
+++ b/internal/indexer/inorder_test.go
@@ -1,0 +1,36 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/vavallee/bindery/internal/indexer/newznab"
+)
+
+// Regression for the relevance fuzzy-match collisions observed in production:
+// the keyword fallback accepted releases that merely contained every title word
+// in any order, with no author check, pulling in wrong books.
+func TestFilterRelevantReorderedKeywordCollisions(t *testing.T) {
+	cases := []struct {
+		title   string
+		author  string
+		release string
+		want    bool // true = kept (relevant), false = dropped
+	}{
+		// Junk: title words present but REORDERED, wrong author -> drop.
+		{"Locked Doors", "Blake Crouch", "Becki Willis - Keep Your Doors Locked (epub)", false},
+		{"Body of Secrets", "James Bamford", "Chris.van.Tulleken-Secrets.of.the.Human.Body.epub", false},
+		{"Flash Boys", "Michael Lewis", "Ted Neill - Zombies, Frat Boys, Monster Flash Mobs.epub", false},
+		{"Summer Frost", "Blake Crouch", "Hailey Frost - Summer Haze and Tokyo Craze.epub", false},
+		// Legit: in-order stop-word title (no author), author-named, surname-only -> keep.
+		{"The Lord of the Rings", "J.R.R. Tolkien", "The.Lord.of.the.Rings.Fellowship.epub", true},
+		{"Body of Secrets", "James Bamford", "James.Bamford.-.Body.of.Secrets.epub", true},
+		{"Locked Doors", "Blake Crouch", "Blake.Crouch.-.Locked.Doors.epub", true},
+	}
+	for _, c := range cases {
+		got := filterRelevant([]newznab.SearchResult{{Title: c.release}}, c.title, c.author, nil)
+		pass := len(got) == 1
+		if pass != c.want {
+			t.Errorf("filterRelevant(%q | title=%q author=%q): kept=%v, want %v", c.release, c.title, c.author, pass, c.want)
+		}
+	}
+}

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -376,7 +376,16 @@ func titleMatchesResult(normResult string, titleKws []string, authorToks []strin
 				return false
 			}
 		}
-		return true
+		// All title words are present but not contiguous. Weak evidence: a
+		// different work can contain the same words REORDERED ("Keep Your Doors
+		// Locked" vs "Locked Doors"; "Secrets of the Human Body" vs "Body of
+		// Secrets"). Accept only if the author anchors it, or the words appear in
+		// title order (legit stop-word-separated titles like "The Lord of the
+		// Rings").
+		if len(authorToks) > 0 && authorMatchesRelease(normResult, authorToks) {
+			return true
+		}
+		return containsInOrder(normResult, titleKws)
 	}
 }
 


### PR DESCRIPTION
## Summary

The relevance filter's multi-word-title keyword fallback accepted any release that merely contained all the title words in *any* order, with no author check. So bulk/automatic searches grabbed wrong books:

| Wanted title | Grabbed release (different book/author) |
|---|---|
| Locked Doors | Keep Your Doors Locked |
| Body of Secrets | Secrets of the Human Body |
| Flash Boys | ...Frat Boys Monster Flash Mobs |

This tightens that one fallback to require an author match or the title words appearing in title order.

## Implementation notes

`titleMatchesResult`'s keyword fallback fires when the title words aren't a contiguous phrase (common once stopwords drop out of `SigWords`). It previously returned true if all title words appeared anywhere in the release name. Now it accepts only when `authorMatchesRelease` is true **or** the title words appear in title order (new `containsInOrder` helper — an ordered-subsequence `\bw1\b.*\bw2\b` match).

In-order matching preserves legitimate stop-word-separated titles ("The Lord of the Rings" -> lord...rings) and surname-only / author-less releases, while rejecting reordered collisions. The contiguous-phrase path is unchanged.

## Why minimal / scope

Same-order coincidences (query and release share the words in the same order, e.g. "Body of Secrets" vs "...Body...Secrets") still pass the contiguous path; only the author disambiguates those, and requiring it would drop legitimate author-less releases. That residue is documented in the code and left out of scope — this PR closes the reordered-keyword false positive.

## Checklist

- [x] Tests added or updated — `inorder_test.go` covers the real production false-match cases
- [x] Doc-update gate cleared — nothing in `docs/`/`README` describes relevance-matching internals
- [ ] Wiki pages updated if user-facing behaviour changed — n/a

## Test plan

- [x] `go test ./internal/indexer/...`
- [x] `go build ./...`
- [ ] full `go test ./cmd/... ./internal/...` + lint — left to CI
