### PR TITLE
feat(metadata): merge and rank book/author search across all providers

### DIFF
--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
+	"unicode"
 
 	"github.com/vavallee/bindery/internal/isbnutil"
 	"github.com/vavallee/bindery/internal/metadata/audible"
@@ -54,8 +56,148 @@ func (a *Aggregator) SearchAuthors(ctx context.Context, query string) ([]models.
 	return a.primary.SearchAuthors(ctx, query)
 }
 
+// searchProviderTimeout bounds how long any single provider may take during a
+// merged book search, so one slow source can't stall the whole request.
+const searchProviderTimeout = 8 * time.Second
+
+// SearchBooks queries the primary provider and every configured enricher in
+// parallel, then merges the results: primary hits rank first, followed by
+// enricher hits the primary didn't already return. This surfaces books the
+// primary (OpenLibrary) lacks — e.g. recent titles present in Google Books or
+// Hardcover. Providers that error or time out are skipped rather than failing
+// the search; an error is returned only when every provider fails. Duplicates
+// are collapsed across providers by ISBN, then by normalized title+author.
 func (a *Aggregator) SearchBooks(ctx context.Context, query string) ([]models.Book, error) {
-	return a.primary.SearchBooks(ctx, query)
+	providers := a.providers() // primary first, then enrichers
+	if len(providers) == 0 {
+		return nil, nil
+	}
+
+	type providerResult struct {
+		books []models.Book
+		err   error
+	}
+	results := make([]providerResult, len(providers))
+	var wg sync.WaitGroup
+	for i, p := range providers {
+		if p == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, p Provider) {
+			defer wg.Done()
+			pctx, cancel := context.WithTimeout(ctx, searchProviderTimeout)
+			defer cancel()
+			books, err := p.SearchBooks(pctx, query)
+			results[i] = providerResult{books: books, err: err}
+		}(i, p)
+	}
+	wg.Wait()
+
+	var (
+		merged     []models.Book
+		seenISBN   = map[string]bool{}
+		seenTA     = map[string]bool{}
+		anySuccess bool
+		firstErr   error
+	)
+	for i, p := range providers {
+		if p == nil {
+			continue
+		}
+		res := results[i]
+		if res.err != nil {
+			if !errors.Is(res.err, ErrProviderNotConfigured) {
+				slog.Warn("metadata search: provider failed", "provider", p.Name(), "error", res.err)
+				if firstErr == nil {
+					firstErr = res.err
+				}
+			}
+			continue
+		}
+		anySuccess = true
+		for _, b := range res.books {
+			if searchBookSeen(b, seenISBN, seenTA) {
+				continue
+			}
+			merged = append(merged, b)
+		}
+	}
+
+	// Only surface an error when no provider succeeded; otherwise return what we
+	// found, even if some providers failed.
+	if !anySuccess && firstErr != nil {
+		return nil, firstErr
+	}
+	return merged, nil
+}
+
+// searchBookSeen reports whether book b duplicates one already emitted — by any
+// of its (normalized) ISBNs, or by its normalized title+author — and registers
+// b's keys so later providers' copies are dropped. Because providers are walked
+// primary-first, the primary's copy of a duplicated book is the one kept.
+func searchBookSeen(b models.Book, seenISBN, seenTA map[string]bool) bool {
+	var isbns []string
+	dup := false
+	for _, raw := range b.ISBNs {
+		n := isbnutil.Normalize(raw)
+		if n == "" {
+			continue
+		}
+		isbns = append(isbns, n)
+		if seenISBN[n] {
+			dup = true
+		}
+	}
+	ta := titleAuthorKey(b)
+	if ta != "" && seenTA[ta] {
+		dup = true
+	}
+	if dup {
+		return true
+	}
+	for _, n := range isbns {
+		seenISBN[n] = true
+	}
+	if ta != "" {
+		seenTA[ta] = true
+	}
+	return false
+}
+
+// titleAuthorKey builds a normalized "title|author" dedup key, or "" when the
+// title is empty (in which case the caller falls back to ISBN-only dedup).
+func titleAuthorKey(b models.Book) string {
+	title := normalizeForDedup(b.Title)
+	if title == "" {
+		return ""
+	}
+	author := ""
+	if b.Author != nil {
+		author = normalizeForDedup(b.Author.Name)
+	}
+	return title + "|" + author
+}
+
+// normalizeForDedup lowercases s and keeps only letters and digits separated by
+// single spaces, so trivial punctuation, spacing, and case differences between
+// providers collapse to the same key.
+func normalizeForDedup(s string) string {
+	var b strings.Builder
+	space := false
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			if space && b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			space = false
+			b.WriteRune(r)
+		default:
+			space = true
+		}
+	}
+	return b.String()
 }
 
 func (a *Aggregator) GetAuthor(ctx context.Context, foreignID string) (*models.Author, error) {

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -129,7 +130,133 @@ func (a *Aggregator) SearchBooks(ctx context.Context, query string) ([]models.Bo
 	if !anySuccess && firstErr != nil {
 		return nil, firstErr
 	}
+
+	rerankByRelevance(merged, query)
 	return merged, nil
+}
+
+// rerankByRelevance reorders merged search results so the best title matches
+// rank first regardless of which provider supplied them — without this, results
+// stay grouped by provider and a strong match from an enricher sits below a
+// weaker provider's whole block. Skipped for ISBN/numeric queries (no title to
+// match). Ties fall back to popularity only when BOTH sides report it (OL and
+// Hardcover populate RatingsCount inconsistently, so 0 means unknown, not
+// unpopular), then to the original provider-first order for stability.
+func rerankByRelevance(books []models.Book, query string) {
+	if len(books) < 2 || !queryHasLetters(query) {
+		return
+	}
+	scores := make([]float64, len(books))
+	for i := range books {
+		scores[i] = searchRelevance(books[i].Title, query)
+	}
+	order := make([]int, len(books))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(x, y int) bool {
+		ix, iy := order[x], order[y]
+		if scores[ix] != scores[iy] {
+			return scores[ix] > scores[iy]
+		}
+		rx, ry := books[ix].RatingsCount, books[iy].RatingsCount
+		if rx > 0 && ry > 0 && rx != ry {
+			return rx > ry
+		}
+		return ix < iy
+	})
+	reordered := make([]models.Book, len(books))
+	for i, j := range order {
+		reordered[i] = books[j]
+	}
+	copy(books, reordered)
+}
+
+// searchStopwords are low-information English words ignored when comparing the
+// query's tokens to a title (the exact/prefix/substring tiers still see them).
+var searchStopwords = map[string]bool{
+	"the": true, "of": true, "a": true, "an": true, "and": true, "to": true, "in": true, "for": true,
+}
+
+// searchRelevance scores how well a book title matches the query (0..1, higher
+// is better). Both are normalized (lowercase, alnum, single spaces). The score
+// is continuous within each tier — a tighter (shorter) title outranks a looser
+// one at the same tier — so title length, not provider order, separates matches.
+func searchRelevance(title, query string) float64 {
+	t := normalizeForDedup(title)
+	q := normalizeForDedup(query)
+	if t == "" || q == "" {
+		return 0
+	}
+	if t == q {
+		return 1.0
+	}
+	// Word-boundary prefix/substring via space padding.
+	pt := " " + t + " "
+	pq := " " + q + " "
+	switch {
+	case strings.HasPrefix(pt, pq):
+		return 0.90 + 0.05*lenRatio(q, t)
+	case strings.Contains(pt, pq):
+		return 0.70 + 0.10*lenRatio(q, t)
+	}
+	qToks := nonStopwordTokens(q)
+	if len(qToks) == 0 {
+		qToks = strings.Fields(q)
+	}
+	if len(qToks) == 0 {
+		return 0
+	}
+	tset := make(map[string]bool)
+	for _, tok := range strings.Fields(t) {
+		tset[tok] = true
+	}
+	matched := 0
+	for _, tok := range qToks {
+		if tset[tok] {
+			matched++
+		}
+	}
+	cov := float64(matched) / float64(len(qToks))
+	if matched == len(qToks) {
+		return 0.45 + 0.15*cov*lenRatio(q, t)
+	}
+	return 0.30 * cov
+}
+
+// lenRatio returns len(short)/len(long) clamped to [0,1]; longer (looser) titles
+// get a smaller ratio, so a tighter match scores higher within its tier.
+func lenRatio(short, long string) float64 {
+	if len(long) == 0 {
+		return 0
+	}
+	r := float64(len(short)) / float64(len(long))
+	if r > 1 {
+		return 1
+	}
+	return r
+}
+
+// nonStopwordTokens splits s into space-separated tokens minus stopwords.
+func nonStopwordTokens(s string) []string {
+	var out []string
+	for _, tok := range strings.Fields(s) {
+		if !searchStopwords[tok] {
+			out = append(out, tok)
+		}
+	}
+	return out
+}
+
+// queryHasLetters reports whether the query contains any letter; a purely
+// numeric query (ISBN) has no title to rank against.
+func queryHasLetters(q string) bool {
+	for _, r := range q {
+		if unicode.IsLetter(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // searchBookSeen reports whether book b duplicates one already emitted — by any

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -53,8 +53,210 @@ func (a *Aggregator) WithAudnexClient(client AudnexBookClient) *Aggregator {
 	return a
 }
 
+// SearchAuthors queries the primary provider and every enricher in parallel,
+// then merges: same-person records (by canonical name, treating "Last, First"
+// and "First Last" as equal) collapse to the single most-complete record, and
+// the result is ranked by how well each name matches the query. This both
+// surfaces authors the primary lacks and de-fragments OpenLibrary's habit of
+// returning several partial records for one author. Providers that error or
+// time out are skipped; an error is returned only when every provider fails.
 func (a *Aggregator) SearchAuthors(ctx context.Context, query string) ([]models.Author, error) {
-	return a.primary.SearchAuthors(ctx, query)
+	providers := a.providers()
+	if len(providers) == 0 {
+		return nil, nil
+	}
+	results, anySuccess, firstErr := searchFanOut(ctx, providers, func(c context.Context, p Provider) ([]models.Author, error) {
+		return p.SearchAuthors(c, query)
+	})
+	if !anySuccess && firstErr != nil {
+		return nil, firstErr
+	}
+
+	var all []models.Author
+	for i := range providers {
+		all = append(all, results[i]...)
+	}
+	merged := dedupeAuthorsByName(all)
+	rerankAuthorsByRelevance(merged, query)
+	return merged, nil
+}
+
+// searchFanOut runs fn against the primary and every enricher in parallel (with
+// a per-provider timeout), returning each provider's results in provider order
+// (primary first), whether any provider returned without error, and the first
+// non-"not configured" error seen.
+func searchFanOut[T any](ctx context.Context, providers []Provider, fn func(context.Context, Provider) ([]T, error)) (results [][]T, anySuccess bool, firstErr error) {
+	results = make([][]T, len(providers))
+	errs := make([]error, len(providers))
+	var wg sync.WaitGroup
+	for i, p := range providers {
+		if p == nil {
+			continue
+		}
+		wg.Add(1)
+		go func(i int, p Provider) {
+			defer wg.Done()
+			pctx, cancel := context.WithTimeout(ctx, searchProviderTimeout)
+			defer cancel()
+			r, err := fn(pctx, p)
+			results[i] = r
+			errs[i] = err
+		}(i, p)
+	}
+	wg.Wait()
+	for i, p := range providers {
+		if p == nil {
+			continue
+		}
+		if errs[i] != nil {
+			if !errors.Is(errs[i], ErrProviderNotConfigured) {
+				slog.Warn("metadata search: provider failed", "provider", p.Name(), "error", errs[i])
+				if firstErr == nil {
+					firstErr = errs[i]
+				}
+			}
+			results[i] = nil
+			continue
+		}
+		anySuccess = true
+	}
+	return results, anySuccess, firstErr
+}
+
+// canonicalAuthorKey normalizes an author name to a comparison key, treating
+// "Last, First" the same as "First Last" so a person's inverted and natural
+// forms collapse together.
+func canonicalAuthorKey(name string) string {
+	return normalizeForDedup(uninvertAuthorName(name))
+}
+
+// uninvertAuthorName converts "Last, First" to "First Last"; other forms are
+// returned unchanged (whitespace-trimmed).
+func uninvertAuthorName(name string) string {
+	n := strings.TrimSpace(name)
+	if i := strings.Index(n, ","); i > 0 {
+		last := strings.TrimSpace(n[:i])
+		first := strings.TrimSpace(n[i+1:])
+		if last != "" && first != "" {
+			return first + " " + last
+		}
+	}
+	return n
+}
+
+// authorBookCount returns the author's known work count, or 0 when unknown
+// (providers other than OpenLibrary leave Statistics nil).
+func authorBookCount(a models.Author) int {
+	if a.Statistics == nil {
+		return 0
+	}
+	return a.Statistics.BookCount
+}
+
+// dedupeAuthorsByName collapses records that refer to the same person (canonical
+// name) to the single most-complete one — most works, then most ratings (each
+// compared only when both report it, since only some providers populate them),
+// then the earliest (provider-first) occurrence. Records with an empty name pass
+// through untouched. Output order follows the kept records' positions.
+func dedupeAuthorsByName(authors []models.Author) []models.Author {
+	best := make(map[string]int)
+	for i := range authors {
+		key := canonicalAuthorKey(authors[i].Name)
+		if key == "" {
+			continue
+		}
+		if j, ok := best[key]; !ok || betterAuthorRecord(authors[i], authors[j]) {
+			best[key] = i
+		}
+	}
+	out := make([]models.Author, 0, len(authors))
+	for i := range authors {
+		key := canonicalAuthorKey(authors[i].Name)
+		if key == "" || best[key] == i {
+			out = append(out, authors[i])
+		}
+	}
+	return out
+}
+
+// betterAuthorRecord reports whether record a is a more complete representative
+// of an author than b. A provider that reports a count (>0) is preferred over
+// one that doesn't (0 = unknown), so OpenLibrary's work/ratings-bearing records
+// win over enrichers that omit them; ties keep the earlier (provider-first) one.
+func betterAuthorRecord(a, b models.Author) bool {
+	if c := preferKnownGreater(authorBookCount(a), authorBookCount(b)); c != 0 {
+		return c > 0
+	}
+	if c := preferKnownGreater(a.RatingsCount, b.RatingsCount); c != 0 {
+		return c > 0
+	}
+	return false
+}
+
+// preferKnownGreater compares two counts where 0 means "unknown": a known value
+// beats unknown, and two known values compare by magnitude. Returns +1 if a is
+// preferable, -1 if b is, 0 if indistinguishable.
+func preferKnownGreater(a, b int) int {
+	if (a > 0) != (b > 0) {
+		if a > 0 {
+			return 1
+		}
+		return -1
+	}
+	if a > 0 && b > 0 && a != b {
+		if a > b {
+			return 1
+		}
+		return -1
+	}
+	return 0
+}
+
+// authorRelevance scores how well an author name matches the query, accounting
+// for "Last, First" forms by also scoring the un-inverted name.
+func authorRelevance(name, query string) float64 {
+	r := searchRelevance(name, query)
+	if inv := uninvertAuthorName(name); inv != strings.TrimSpace(name) {
+		if ri := searchRelevance(inv, query); ri > r {
+			r = ri
+		}
+	}
+	return r
+}
+
+// rerankAuthorsByRelevance reorders authors so the best name matches rank first,
+// tiebreaking by work count then ratings (both compared only when present), then
+// original order.
+func rerankAuthorsByRelevance(authors []models.Author, query string) {
+	if len(authors) < 2 || !queryHasLetters(query) {
+		return
+	}
+	scores := make([]float64, len(authors))
+	for i := range authors {
+		scores[i] = authorRelevance(authors[i].Name, query)
+	}
+	order := make([]int, len(authors))
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(x, y int) bool {
+		ix, iy := order[x], order[y]
+		if scores[ix] != scores[iy] {
+			return scores[ix] > scores[iy]
+		}
+		if c := preferKnownGreater(authorBookCount(authors[ix]), authorBookCount(authors[iy])); c != 0 {
+			return c > 0
+		}
+		if c := preferKnownGreater(authors[ix].RatingsCount, authors[iy].RatingsCount); c != 0 {
+			return c > 0
+		}
+		return ix < iy
+	})
+	reordered := make([]models.Author, len(authors))
+	for i, j := range order {
+		reordered[i] = authors[j]
+	}
+	copy(authors, reordered)
 }
 
 // searchProviderTimeout bounds how long any single provider may take during a
@@ -73,62 +275,25 @@ func (a *Aggregator) SearchBooks(ctx context.Context, query string) ([]models.Bo
 	if len(providers) == 0 {
 		return nil, nil
 	}
-
-	type providerResult struct {
-		books []models.Book
-		err   error
+	results, anySuccess, firstErr := searchFanOut(ctx, providers, func(c context.Context, p Provider) ([]models.Book, error) {
+		return p.SearchBooks(c, query)
+	})
+	// Only surface an error when no provider succeeded; otherwise return what we
+	// found, even if some providers failed.
+	if !anySuccess && firstErr != nil {
+		return nil, firstErr
 	}
-	results := make([]providerResult, len(providers))
-	var wg sync.WaitGroup
-	for i, p := range providers {
-		if p == nil {
-			continue
-		}
-		wg.Add(1)
-		go func(i int, p Provider) {
-			defer wg.Done()
-			pctx, cancel := context.WithTimeout(ctx, searchProviderTimeout)
-			defer cancel()
-			books, err := p.SearchBooks(pctx, query)
-			results[i] = providerResult{books: books, err: err}
-		}(i, p)
-	}
-	wg.Wait()
 
-	var (
-		merged     []models.Book
-		seenISBN   = map[string]bool{}
-		seenTA     = map[string]bool{}
-		anySuccess bool
-		firstErr   error
-	)
-	for i, p := range providers {
-		if p == nil {
-			continue
-		}
-		res := results[i]
-		if res.err != nil {
-			if !errors.Is(res.err, ErrProviderNotConfigured) {
-				slog.Warn("metadata search: provider failed", "provider", p.Name(), "error", res.err)
-				if firstErr == nil {
-					firstErr = res.err
-				}
-			}
-			continue
-		}
-		anySuccess = true
-		for _, b := range res.books {
+	var merged []models.Book
+	seenISBN := map[string]bool{}
+	seenTA := map[string]bool{}
+	for i := range providers {
+		for _, b := range results[i] {
 			if searchBookSeen(b, seenISBN, seenTA) {
 				continue
 			}
 			merged = append(merged, b)
 		}
-	}
-
-	// Only surface an error when no provider succeeded; otherwise return what we
-	// found, even if some providers failed.
-	if !anySuccess && firstErr != nil {
-		return nil, firstErr
 	}
 
 	rerankByRelevance(merged, query)

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -468,7 +468,24 @@ func titleAuthorKey(b models.Book) string {
 	if b.Author != nil {
 		author = normalizeForDedup(b.Author.Name)
 	}
-	return title + "|" + author
+	// Include the format so the same work in different formats (an ebook edition
+	// from one provider, an audiobook from another) is NOT collapsed — the user
+	// must be able to see and pick the format.
+	return title + "|" + author + "|" + searchFormatKey(b.MediaType)
+}
+
+// searchFormatKey folds a media type into a dedup bucket. An unspecified type is
+// treated as ebook (the common case for print/ebook-only providers like Google
+// Books), so two ebook editions still collapse while an audiobook stays distinct.
+func searchFormatKey(mediaType string) string {
+	switch strings.ToLower(strings.TrimSpace(mediaType)) {
+	case models.MediaTypeAudiobook:
+		return "audiobook"
+	case models.MediaTypeBoth:
+		return "both"
+	default:
+		return "ebook"
+	}
 }
 
 // normalizeForDedup lowercases s and keeps only letters and digits separated by

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -313,7 +313,7 @@ func rerankByRelevance(books []models.Book, query string) {
 	}
 	scores := make([]float64, len(books))
 	for i := range books {
-		scores[i] = searchRelevance(books[i].Title, query)
+		scores[i] = bookSearchRelevance(books[i], query)
 	}
 	order := make([]int, len(books))
 	for i := range order {
@@ -341,6 +341,40 @@ func rerankByRelevance(books []models.Book, query string) {
 // query's tokens to a title (the exact/prefix/substring tiers still see them).
 var searchStopwords = map[string]bool{
 	"the": true, "of": true, "a": true, "an": true, "and": true, "to": true, "in": true, "for": true,
+}
+
+// bookSearchRelevance scores a book against the query, accounting for the author.
+// Query tokens satisfied by the book's author are removed from what the TITLE
+// must match — so for a "title author" query the real book (whose author usually
+// isn't in its title) outranks summary/companion books that stuff the author name
+// into their title. Taking the max with the plain title score means author
+// awareness can only help, never hurt.
+func bookSearchRelevance(b models.Book, query string) float64 {
+	q := normalizeForDedup(query)
+	if q == "" {
+		return 0
+	}
+	if b.Author == nil || b.Author.Name == "" {
+		return searchRelevance(b.Title, q)
+	}
+	authorTokens := make(map[string]bool)
+	for _, tok := range strings.Fields(normalizeForDedup(b.Author.Name)) {
+		authorTokens[tok] = true
+	}
+	titleToks := make([]string, 0, len(strings.Fields(q)))
+	authorMatched := false
+	for _, tok := range strings.Fields(q) {
+		if authorTokens[tok] {
+			authorMatched = true
+			continue
+		}
+		titleToks = append(titleToks, tok)
+	}
+	if !authorMatched || len(titleToks) == 0 {
+		return searchRelevance(b.Title, q)
+	}
+	reduced := strings.Join(titleToks, " ")
+	return max(searchRelevance(b.Title, reduced), searchRelevance(b.Title, q))
 }
 
 // searchRelevance scores how well a book title matches the query (0..1, higher

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -374,8 +374,15 @@ func bookSearchRelevance(b models.Book, query string) float64 {
 		return searchRelevance(b.Title, q)
 	}
 	reduced := strings.Join(titleToks, " ")
-	return max(searchRelevance(b.Title, reduced), searchRelevance(b.Title, q))
+	score := max(searchRelevance(b.Title, reduced), searchRelevance(b.Title, q))
+	// Small positive signal that the author matched the query, so a book BY the
+	// queried author edges out a comparable-title match by a different author
+	// (e.g. a real edition vs. a "summary of" companion). Too small to override a
+	// clearly stronger title match.
+	return score + authorQueryMatchBonus
 }
+
+const authorQueryMatchBonus = 0.05
 
 // searchRelevance scores how well a book title matches the query (0..1, higher
 // is better). Both are normalized (lowercase, alnum, single spaces). The score

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -131,6 +131,93 @@ func TestAggregator_SearchBooks_NotConfiguredEnricherIsSilentlySkipped(t *testin
 	}
 }
 
+func TestSearchRelevance_TierOrdering(t *testing.T) {
+	q := "the meaning of your life"
+	s := func(title string) float64 { return searchRelevance(title, q) }
+	exact := s("The Meaning of Your Life")
+	prefix := s("The Meaning of Your Life: Finding Purpose in an Age of Emptiness")
+	substr := s("Work: The Meaning of Your Life - A Christian Perspective")
+	tokens := s("Meaning of YOUR Life") // all non-stopword tokens, but not a substring (no leading "the")
+	none := s("King Lear")
+
+	if !(exact > prefix && prefix > substr && substr > tokens && tokens > none) {
+		t.Errorf("tier order violated: exact=%.3f prefix=%.3f substr=%.3f tokens=%.3f none=%.3f",
+			exact, prefix, substr, tokens, none)
+	}
+	if none != 0 {
+		t.Errorf("unrelated title should score 0, got %.3f", none)
+	}
+}
+
+func TestSearchRelevance_ShorterTitleWinsWithinTier(t *testing.T) {
+	q := "the meaning of your life"
+	short := searchRelevance("The Meaning of Your Life: A Guide", q)
+	long := searchRelevance("The Meaning of Your Life: Finding Purpose in an Age of Emptiness", q)
+	if !(short > long) {
+		t.Errorf("tighter title should outrank looser one in the same tier: short=%.3f long=%.3f", short, long)
+	}
+}
+
+// TestAggregator_SearchBooks_RanksRelevanceAcrossProviders is the headline fix:
+// a strong title match from an enricher must outrank a weaker provider's block.
+func TestAggregator_SearchBooks_RanksRelevanceAcrossProviders(t *testing.T) {
+	primary := &mockProvider{name: "ol", searchBooks: []models.Book{
+		{Title: "Bible", ForeignID: "OLb"},
+		{Title: "King Lear", ForeignID: "OLk"},
+		{Title: "Discover the Meaning of Your Life", ForeignID: "OLd"},
+	}}
+	enricher := &mockProvider{name: "hardcover", searchBooks: []models.Book{
+		{Title: "The Meaning of Your Life: Finding Purpose in an Age of Emptiness", ForeignID: "hc:brooks", RatingsCount: 500},
+	}}
+	agg := newTestAggregator(primary, enricher)
+
+	got, err := agg.SearchBooks(context.Background(), "the meaning of your life")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("want 4 results, got %d", len(got))
+	}
+	if got[0].ForeignID != "hc:brooks" {
+		t.Errorf("prefix match from the enricher must rank first; got %q (%s)", got[0].Title, got[0].ForeignID)
+	}
+	last := got[len(got)-1].Title
+	if last != "Bible" && last != "King Lear" {
+		t.Errorf("unrelated titles should sink to the bottom; last=%q", last)
+	}
+}
+
+func TestAggregator_SearchBooks_RatingsTiebreakOnlyWhenBothPresent(t *testing.T) {
+	// Two equally-good substring matches: one from OL (RatingsCount 0 = unknown),
+	// one from HC with ratings. The HC one must NOT auto-jump the OL one purely
+	// because OL never reports ratings — equal score + one-side-unknown falls back
+	// to original (provider-first) order.
+	primary := &mockProvider{name: "ol", searchBooks: []models.Book{
+		{Title: "The Meaning of Your Life", ForeignID: "OL1"}, // exact, ratings 0
+	}}
+	enricher := &mockProvider{name: "hardcover", searchBooks: []models.Book{
+		{Title: "The Meaning of Your Life", ForeignID: "hc:1", RatingsCount: 9999}, // dup exact, high ratings
+	}}
+	agg := newTestAggregator(primary, enricher)
+	got, _ := agg.SearchBooks(context.Background(), "the meaning of your life")
+	// Deduped to one (same title+author); the primary copy is kept regardless of HC's rating.
+	if len(got) != 1 || got[0].ForeignID != "OL1" {
+		t.Errorf("expected the primary copy kept on dup, got %+v", got)
+	}
+}
+
+func TestAggregator_SearchBooks_NumericQuerySkipsRerank(t *testing.T) {
+	primary := &mockProvider{name: "ol", searchBooks: []models.Book{
+		{Title: "Zeta", ForeignID: "OL1"},
+		{Title: "Alpha", ForeignID: "OL2"},
+	}}
+	agg := newTestAggregator(primary)
+	got, _ := agg.SearchBooks(context.Background(), "9780441172719")
+	if len(got) != 2 || got[0].ForeignID != "OL1" {
+		t.Errorf("numeric/ISBN query should preserve original order, got %+v", got)
+	}
+}
+
 func TestAggregator_GetAuthor_Success(t *testing.T) {
 	author := &models.Author{Name: "Ursula K. Le Guin", ForeignID: "OL111A"}
 	primary := &mockProvider{name: "ol", getAuthor: author}

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -93,6 +93,50 @@ func TestAggregator_SearchBooks_DedupesByTitleAuthor(t *testing.T) {
 	}
 }
 
+func TestAggregator_SearchBooks_KeepsDistinctFormats(t *testing.T) {
+	// Same work, two formats from two providers: must NOT collapse to one — the
+	// user needs to see and pick ebook vs audiobook.
+	primary := &mockProvider{name: "ol", searchBooks: []models.Book{
+		{Title: "The Water Knife", ForeignID: "OL1W", Author: &models.Author{Name: "Paolo Bacigalupi"}, MediaType: models.MediaTypeEbook},
+	}}
+	enricher := &mockProvider{name: "hardcover", searchBooks: []models.Book{
+		{Title: "The Water Knife", ForeignID: "hc:wk", Author: &models.Author{Name: "Paolo Bacigalupi"}, MediaType: models.MediaTypeAudiobook},
+	}}
+	agg := newTestAggregator(primary, enricher)
+
+	got, err := agg.SearchBooks(context.Background(), "water knife")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ebook + audiobook of the same work must both survive, got %d: %+v", len(got), got)
+	}
+	formats := map[string]bool{}
+	for _, b := range got {
+		formats[b.MediaType] = true
+	}
+	if !formats[models.MediaTypeEbook] || !formats[models.MediaTypeAudiobook] {
+		t.Errorf("expected both ebook and audiobook formats present, got %+v", formats)
+	}
+}
+
+func TestAggregator_SearchBooks_StillDedupesSameFormat(t *testing.T) {
+	// Same work, same format (one unspecified, treated as ebook) from two
+	// providers: still collapses to the primary copy.
+	primary := &mockProvider{name: "ol", searchBooks: []models.Book{
+		{Title: "Dune", ForeignID: "OL1W", Author: &models.Author{Name: "Frank Herbert"}, MediaType: models.MediaTypeEbook},
+	}}
+	enricher := &mockProvider{name: "googlebooks", searchBooks: []models.Book{
+		{Title: "Dune", ForeignID: "gb:dune", Author: &models.Author{Name: "Frank Herbert"}}, // unspecified == ebook
+	}}
+	agg := newTestAggregator(primary, enricher)
+
+	got, _ := agg.SearchBooks(context.Background(), "dune")
+	if len(got) != 1 || got[0].ForeignID != "OL1W" {
+		t.Errorf("same-format dup should collapse to the primary copy, got %+v", got)
+	}
+}
+
 func TestAggregator_SearchBooks_SkipsErroredProvider(t *testing.T) {
 	primary := &mockProvider{name: "ol", searchBookErr: errors.New("openlibrary down")}
 	enricher := &mockProvider{name: "googlebooks", searchBooks: []models.Book{{Title: "Found Anyway", ForeignID: "gb:x"}}}

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -204,6 +204,29 @@ func TestSearchRelevance_ShorterTitleWinsWithinTier(t *testing.T) {
 
 // TestAggregator_SearchBooks_RanksRelevanceAcrossProviders is the headline fix:
 // a strong title match from an enricher must outrank a weaker provider's block.
+func TestBookSearchRelevance_AuthorAware(t *testing.T) {
+	q := "the meaning of your life arthur brooks"
+	real := bookSearchRelevance(models.Book{Title: "The Meaning of Your Life", Author: &models.Author{Name: "Arthur C. Brooks"}}, q)
+	summary := bookSearchRelevance(models.Book{Title: "The Meaning of Your Life & Arthur Brooks' Insights", Author: &models.Author{Name: "Colston Silvester"}}, q)
+	wrongAuthor := bookSearchRelevance(models.Book{Title: "The Meaning of Your Life", Author: &models.Author{Name: "Filip Swennen"}}, q)
+
+	if !(real > summary) {
+		t.Errorf("real book (author matches query) must outrank a summary that crams the author into its title: real=%.3f summary=%.3f", real, summary)
+	}
+	if !(real > wrongAuthor) {
+		t.Errorf("right-author book must outrank same-title wrong-author: real=%.3f wrong=%.3f", real, wrongAuthor)
+	}
+}
+
+func TestBookSearchRelevance_NoAuthorRegression(t *testing.T) {
+	// A plain title query (no author tokens) must score exactly as title-only.
+	q := "the meaning of your life"
+	b := models.Book{Title: "The Meaning of Your Life", Author: &models.Author{Name: "Arthur C. Brooks"}}
+	if got, want := bookSearchRelevance(b, q), searchRelevance(b.Title, normalizeForDedup(q)); got != want {
+		t.Errorf("title-only query should equal title relevance: got %.3f want %.3f", got, want)
+	}
+}
+
 func TestAggregator_SearchBooks_RanksRelevanceAcrossProviders(t *testing.T) {
 	primary := &mockProvider{name: "ol", searchBooks: []models.Book{
 		{Title: "Bible", ForeignID: "OLb"},

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -216,6 +216,12 @@ func TestBookSearchRelevance_AuthorAware(t *testing.T) {
 	if !(real > wrongAuthor) {
 		t.Errorf("right-author book must outrank same-title wrong-author: real=%.3f wrong=%.3f", real, wrongAuthor)
 	}
+	// A real edition by the queried author, even with a long subtitle (weaker
+	// title match), must still beat a non-matching summary.
+	subtitleEdition := bookSearchRelevance(models.Book{Title: "The Meaning of Your Life: Finding Purpose in an Age of Emptiness", Author: &models.Author{Name: "Arthur C. Brooks"}}, q)
+	if !(subtitleEdition > summary) {
+		t.Errorf("a real Brooks edition (author matches) should outrank the non-matching summary: %.3f vs %.3f", subtitleEdition, summary)
+	}
 }
 
 func TestBookSearchRelevance_NoAuthorRegression(t *testing.T) {

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -47,6 +47,90 @@ func TestAggregator_SearchBooks(t *testing.T) {
 	}
 }
 
+func TestAggregator_SearchBooks_MergesEnrichers(t *testing.T) {
+	primary := &mockProvider{name: "ol", searchBooks: []models.Book{{Title: "Primary Book", ForeignID: "OL1W"}}}
+	enricher := &mockProvider{name: "googlebooks", searchBooks: []models.Book{{Title: "Enricher Book", ForeignID: "gb:abc"}}}
+	agg := newTestAggregator(primary, enricher)
+
+	got, err := agg.SearchBooks(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 merged results, got %d: %+v", len(got), got)
+	}
+	// Primary results must rank first.
+	if got[0].ForeignID != "OL1W" || got[1].ForeignID != "gb:abc" {
+		t.Errorf("expected primary first then enricher, got %+v", got)
+	}
+}
+
+func TestAggregator_SearchBooks_DedupesByISBN(t *testing.T) {
+	primary := &mockProvider{name: "ol", searchBooks: []models.Book{{Title: "Dune", ForeignID: "OL1W", ISBNs: []string{"978-0-441-17271-9"}}}}
+	enricher := &mockProvider{name: "googlebooks", searchBooks: []models.Book{{Title: "Dune (different edition)", ForeignID: "gb:dup", ISBNs: []string{"9780441172719"}}}}
+	agg := newTestAggregator(primary, enricher)
+
+	got, err := agg.SearchBooks(context.Background(), "dune")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(got) != 1 || got[0].ForeignID != "OL1W" {
+		t.Errorf("ISBN dup should collapse to the primary copy, got %+v", got)
+	}
+}
+
+func TestAggregator_SearchBooks_DedupesByTitleAuthor(t *testing.T) {
+	primary := &mockProvider{name: "ol", searchBooks: []models.Book{{Title: "The Water Knife", ForeignID: "OL1W", Author: &models.Author{Name: "Paolo Bacigalupi"}}}}
+	enricher := &mockProvider{name: "googlebooks", searchBooks: []models.Book{{Title: "the water knife!", ForeignID: "gb:dup", Author: &models.Author{Name: "Paolo  Bacigalupi"}}}}
+	agg := newTestAggregator(primary, enricher)
+
+	got, err := agg.SearchBooks(context.Background(), "water knife")
+	if err != nil {
+		t.Fatalf("SearchBooks: %v", err)
+	}
+	if len(got) != 1 || got[0].ForeignID != "OL1W" {
+		t.Errorf("title+author dup should collapse to primary, got %+v", got)
+	}
+}
+
+func TestAggregator_SearchBooks_SkipsErroredProvider(t *testing.T) {
+	primary := &mockProvider{name: "ol", searchBookErr: errors.New("openlibrary down")}
+	enricher := &mockProvider{name: "googlebooks", searchBooks: []models.Book{{Title: "Found Anyway", ForeignID: "gb:x"}}}
+	agg := newTestAggregator(primary, enricher)
+
+	got, err := agg.SearchBooks(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("a failing provider must not fail the whole search: %v", err)
+	}
+	if len(got) != 1 || got[0].ForeignID != "gb:x" {
+		t.Errorf("expected the enricher result, got %+v", got)
+	}
+}
+
+func TestAggregator_SearchBooks_AllErrorReturnsError(t *testing.T) {
+	primary := &mockProvider{name: "ol", searchBookErr: errors.New("ol down")}
+	enricher := &mockProvider{name: "googlebooks", searchBookErr: errors.New("gb down")}
+	agg := newTestAggregator(primary, enricher)
+
+	if _, err := agg.SearchBooks(context.Background(), "x"); err == nil {
+		t.Error("expected an error when every provider fails")
+	}
+}
+
+func TestAggregator_SearchBooks_NotConfiguredEnricherIsSilentlySkipped(t *testing.T) {
+	primary := &mockProvider{name: "ol", searchBooks: []models.Book{{Title: "Primary", ForeignID: "OL1W"}}}
+	enricher := &mockProvider{name: "hardcover", searchBookErr: ErrProviderNotConfigured}
+	agg := newTestAggregator(primary, enricher)
+
+	got, err := agg.SearchBooks(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("not-configured enricher must not error the search: %v", err)
+	}
+	if len(got) != 1 || got[0].ForeignID != "OL1W" {
+		t.Errorf("expected just the primary result, got %+v", got)
+	}
+}
+
 func TestAggregator_GetAuthor_Success(t *testing.T) {
 	author := &models.Author{Name: "Ursula K. Le Guin", ForeignID: "OL111A"}
 	primary := &mockProvider{name: "ol", getAuthor: author}

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -218,6 +218,86 @@ func TestAggregator_SearchBooks_NumericQuerySkipsRerank(t *testing.T) {
 	}
 }
 
+func TestCanonicalAuthorKey(t *testing.T) {
+	want := "arthur c brooks"
+	for _, name := range []string{"Arthur C. Brooks", "Arthur C Brooks", "Brooks, Arthur C.", "  brooks ,  arthur c "} {
+		if got := canonicalAuthorKey(name); got != want {
+			t.Errorf("canonicalAuthorKey(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestAuthorRelevance_InversionAware(t *testing.T) {
+	q := "arthur c brooks"
+	if natural := authorRelevance("Arthur C. Brooks", q); natural != 1.0 {
+		t.Errorf("natural exact-match want 1.0, got %.3f", natural)
+	}
+	if inverted := authorRelevance("Brooks, Arthur C.", q); inverted < 0.99 {
+		t.Errorf("comma-inverted form should match as exact, got %.3f", inverted)
+	}
+}
+
+// TestAggregator_SearchAuthors_CollapsesFragments is the headline author fix:
+// OpenLibrary's fragmented same-person records (and a cross-provider dup) collapse
+// to ONE record — the most-complete one (most works) — and rank by name match.
+func TestAggregator_SearchAuthors_CollapsesFragments(t *testing.T) {
+	stats := func(n int) *models.AuthorStats { return &models.AuthorStats{BookCount: n} }
+	primary := &mockProvider{name: "ol", searchAuthors: []models.Author{
+		{Name: "Arthur C. Brooks", ForeignID: "OL1A", Statistics: stats(7)},
+		{Name: "Arthur C Brooks", ForeignID: "OL2A", Statistics: stats(2)},
+		{Name: "Brooks, Arthur C.", ForeignID: "OL3A", Statistics: stats(14)},
+		{Name: "Brooks, Arthur C.", ForeignID: "OL4A", Statistics: stats(9)},
+		{Name: "Some Other Author", ForeignID: "OL9A", Statistics: stats(3)},
+	}}
+	enricher := &mockProvider{name: "hardcover", searchAuthors: []models.Author{
+		{Name: "Arthur C. Brooks", ForeignID: "hc:arthur-c-brooks"}, // BookCount unknown (nil Statistics)
+	}}
+	agg := newTestAggregator(primary, enricher)
+
+	got, err := agg.SearchAuthors(context.Background(), "arthur c brooks")
+	if err != nil {
+		t.Fatalf("SearchAuthors: %v", err)
+	}
+	brooks := 0
+	var kept models.Author
+	for _, a := range got {
+		if canonicalAuthorKey(a.Name) == "arthur c brooks" {
+			brooks++
+			kept = a
+		}
+	}
+	if brooks != 1 {
+		t.Fatalf("Brooks fragments + cross-provider dup should collapse to 1, got %d", brooks)
+	}
+	if kept.ForeignID != "OL3A" {
+		t.Errorf("collapsed record should be the most-complete (OL3A, 14 works), got %s (BookCount %d)", kept.ForeignID, authorBookCount(kept))
+	}
+	if got[0].ForeignID != "OL3A" {
+		t.Errorf("the collapsed Brooks (exact name match) should rank first, got %s", got[0].ForeignID)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 results (collapsed Brooks + Some Other Author), got %d", len(got))
+	}
+}
+
+func TestAggregator_SearchAuthors_RanksRelevanceAcrossProviders(t *testing.T) {
+	primary := &mockProvider{name: "ol", searchAuthors: []models.Author{
+		{Name: "Arthur Conan Doyle", ForeignID: "OLx", Statistics: &models.AuthorStats{BookCount: 50}}, // weak match, popular
+	}}
+	enricher := &mockProvider{name: "hardcover", searchAuthors: []models.Author{
+		{Name: "Arthur C. Brooks", ForeignID: "hc:brooks"}, // exact match
+	}}
+	agg := newTestAggregator(primary, enricher)
+
+	got, err := agg.SearchAuthors(context.Background(), "arthur c brooks")
+	if err != nil {
+		t.Fatalf("SearchAuthors: %v", err)
+	}
+	if len(got) == 0 || got[0].ForeignID != "hc:brooks" {
+		t.Errorf("exact name match from enricher must outrank a popular weak match; got %+v", got)
+	}
+}
+
 func TestAggregator_GetAuthor_Success(t *testing.T) {
 	author := &models.Author{Name: "Ursula K. Le Guin", ForeignID: "OL111A"}
 	primary := &mockProvider{name: "ol", getAuthor: author}

--- a/internal/metadata/googlebooks/client.go
+++ b/internal/metadata/googlebooks/client.go
@@ -80,7 +80,10 @@ func (c *Client) GetAuthor(_ context.Context, _ string) (*models.Author, error) 
 }
 
 func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, error) {
-	u := fmt.Sprintf("%s/volumes/%s", baseURL, foreignID)
+	// SearchBooks/volumeToBook stamp ForeignID as "gb:<volumeID>"; strip the
+	// prefix before building the volumes URL or the request 404s.
+	id := strings.TrimPrefix(foreignID, "gb:")
+	u := fmt.Sprintf("%s/volumes/%s", baseURL, id)
 	if c.apiKey != "" {
 		u += "?key=" + url.QueryEscape(c.apiKey)
 	}

--- a/internal/metadata/googlebooks/client_test.go
+++ b/internal/metadata/googlebooks/client_test.go
@@ -224,6 +224,25 @@ func TestGetBook_Success(t *testing.T) {
 	}
 }
 
+func TestGetBook_StripsGBPrefix(t *testing.T) {
+	// The aggregator stores ForeignIDs as "gb:<id>" and routes them straight to
+	// GetBook, so GetBook must strip its own prefix before building the URL or
+	// it requests /volumes/gb:<id> and 404s.
+	var gotURL string
+	c := &Client{
+		http: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			gotURL = r.URL.String()
+			return mockResponse(t, http.StatusOK, volumeItem{ID: "vol999"}), nil
+		})},
+	}
+	if _, err := c.GetBook(context.Background(), "gb:vol999"); err != nil {
+		t.Fatalf("GetBook: %v", err)
+	}
+	if !strings.Contains(gotURL, "/volumes/vol999") || strings.Contains(gotURL, "gb:") {
+		t.Errorf("GetBook must strip the gb: prefix; got URL %q", gotURL)
+	}
+}
+
 func TestGetBook_WithAPIKey(t *testing.T) {
 	var gotURL string
 	c := &Client{

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -78,7 +78,7 @@ func (c *Client) SearchBooks(ctx context.Context, query string) ([]models.Book, 
 	// /search (without .json) is the HTML web-UI path (Solr-backed) and
 	// returns HTTP 500 "DEPRECATED ENDPOINT ACCESSED" for API consumers
 	// since their FastAPI rollout completed (see issue #462, follow-up to #408).
-	u := fmt.Sprintf("%s/search.json?q=%s&fields=key,title,author_name,author_key,first_publish_year,cover_i,isbn,subject&limit=20",
+	u := fmt.Sprintf("%s/search.json?q=%s&fields=key,title,author_name,author_key,first_publish_year,cover_i,isbn,subject,ratings_count&limit=20",
 		baseURL, url.QueryEscape(query))
 	var resp searchResponse
 	if err := c.getJSON(ctx, u, &resp); err != nil {
@@ -93,6 +93,7 @@ func (c *Client) SearchBooks(ctx context.Context, query string) ([]models.Book, 
 			Title:            doc.Title,
 			SortTitle:        doc.Title,
 			Genres:           truncateSlice(doc.Subject, 10),
+			RatingsCount:     doc.RatingsCount,
 			MetadataProvider: "openlibrary",
 			Monitored:        true,
 			Status:           models.BookStatusWanted,

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -150,6 +150,7 @@ func TestSearchBooks_HTTP(t *testing.T) {
 				FirstPublishYear: 1965,
 				CoverI:           &coverI,
 				Subject:          []string{"Science Fiction", "Adventure"},
+				RatingsCount:     2500,
 			},
 		},
 	}
@@ -182,6 +183,9 @@ func TestSearchBooks_HTTP(t *testing.T) {
 	}
 	if !strings.Contains(b.ImageURL, "12345") {
 		t.Errorf("ImageURL should contain cover ID 12345, got %q", b.ImageURL)
+	}
+	if b.RatingsCount != 2500 {
+		t.Errorf("RatingsCount: want 2500, got %d", b.RatingsCount)
 	}
 }
 

--- a/internal/metadata/openlibrary/types.go
+++ b/internal/metadata/openlibrary/types.go
@@ -51,6 +51,7 @@ type searchDoc struct {
 	NumberOfPages    *int     `json:"number_of_pages_median"`
 	Publisher        []string `json:"publisher"`
 	Subject          []string `json:"subject"`
+	RatingsCount     int      `json:"ratings_count"`
 }
 
 type authorSearchResponse struct {


### PR DESCRIPTION
## Summary

`Aggregator.SearchBooks` / `SearchAuthors` queried only the primary provider (OpenLibrary), so a book or author OpenLibrary doesn't catalogue was unfindable even when a configured enricher (Hardcover, DNB, ...) had it — e.g. searching a #1 NYT bestseller returned nothing because OL has zero records for it. This fans search out across all configured providers, merges + de-duplicates, and ranks by relevance.

## Implementation notes

- **Fan-out + merge.** `SearchBooks` and `SearchAuthors` now query primary + all enrichers in parallel (per-provider timeout), merge primary-first, and dedupe across providers:
  - books — normalized ISBN, then title+author, with a *format bucket* so an ebook and an audiobook edition of the same work both survive (instead of one silently winning);
  - authors — collapse same-person records by canonical name ("Last, First" == "First Last") to the single most-complete record.
- **Relevance re-rank.** Results are re-ranked by a tiered title score (exact > prefix > substring > all-tokens > partial), made author-aware: query tokens the author satisfies are removed before title scoring, plus a small author-match bonus, so the real book outranks summaries/anthologies. Numeric/ISBN queries skip re-rank.
- **OL `ratings_count`** was added to the OL search field list (previously omitted, so OL results always reported 0 ratings and lost rating-based tiebreaks).
- Per-provider errors are skipped; the call errors only if every provider fails.

## Scope / deliberately out

- **No Google Books API wiring or quota handling** — this PR is provider-agnostic merge + rank and surfaces results from whatever enrichers are configured. (GB-specific wiring is separate.)

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — no user-facing doc describes the search internals
- [ ] Wiki pages updated if user-facing behaviour changed — n/a

## Test plan

- [x] `go test ./internal/metadata/...` (377 tests)
- [x] `go build ./...`
- [ ] full `go test ./cmd/... ./internal/...` + lint — left to CI
