### PR TITLE
feat(authors): resolve name-only search results so they can be added

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1907,6 +1907,28 @@ func dedupeAuthorQueries(values []string) []string {
 // to the resolved provider's IDs so the rest of the existing flow works as
 // before. When it fails, the request is rejected with a friendly hint about
 // adding the author manually first.
+// findLibraryAuthorByName returns an author already in the user's library whose
+// name canonically matches the given name (treating "Last, First" == "First
+// Last"), or nil. Lets a name-only search result (e.g. Google Books, which has
+// no author ID) attach to the user's existing author instead of duplicating it.
+// Identity uses the same key as ResolveCanonicalAuthor so the two agree.
+func (h *AuthorHandler) findLibraryAuthorByName(ctx context.Context, name string) *models.Author {
+	want := metadata.CanonicalAuthorKey(name)
+	if want == "" {
+		return nil
+	}
+	authors, err := h.authors.ListByUser(ctx, auth.UserIDFromContext(ctx))
+	if err != nil {
+		return nil
+	}
+	for i := range authors {
+		if metadata.CanonicalAuthorKey(authors[i].Name) == want {
+			return &authors[i]
+		}
+	}
+	return nil
+}
+
 func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ForeignBookID   string `json:"foreignBookId"`
@@ -1940,26 +1962,48 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	// book to guarantee it exists before the cleanup defer runs (#804).
 	authorWasJustCreated := false
 
+	// resolvedByName is set when the author was resolved from the result's NAME
+	// (not an ISBN/provider ID) — the case for Google Books results, which carry
+	// an author name but no author ID and no ISBN editions. It forces a direct
+	// insert of the chosen edition (the author's catalogue fetch won't contain a
+	// cross-provider book) and suppresses the speculative catalogue fetch.
+	resolvedByName := false
+
 	if req.ForeignAuthorID == "" {
 		resolved, err := h.resolveAuthorForBook(ctx, req.ForeignBookID)
 		if err != nil {
 			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
 			return
 		}
-		if resolved == nil {
+		if resolved != nil {
+			// Rewrite the request so the existing fetch+poll flow targets the
+			// canonical provider's IDs. The user sees the canonical record (e.g.
+			// the OpenLibrary version) in their library; the original DNB record
+			// is dropped because bindery's author/book identity is single-source.
+			req.ForeignBookID = resolved.ForeignID
+			req.ForeignAuthorID = resolved.Author.ForeignID
+			if req.AuthorName == "" {
+				req.AuthorName = resolved.Author.Name
+			}
+		} else if req.AuthorName != "" {
+			// ISBN-based resolution failed (e.g. Google Books: author name, no
+			// author ID, no ISBN). Resolve the author by NAME — prefer one already
+			// in the library so we reuse the user's existing author instead of
+			// duplicating it; otherwise adopt OpenLibrary's canonical record. Keep
+			// the chosen edition (req.ForeignBookID) — the other providers don't
+			// have this book.
+			if existing := h.findLibraryAuthorByName(ctx, req.AuthorName); existing != nil {
+				req.ForeignAuthorID = existing.ForeignID
+			} else if canonical, cErr := h.meta.ResolveCanonicalAuthor(ctx, req.AuthorName); cErr == nil && canonical != nil {
+				req.ForeignAuthorID = canonical.ForeignID
+			}
+			resolvedByName = req.ForeignAuthorID != ""
+		}
+		if req.ForeignAuthorID == "" {
 			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
 				"error": "Author metadata unavailable for this result. Add the author manually first (Authors → Add Author by name), then try again.",
 			})
 			return
-		}
-		// Rewrite the request so the existing fetch+poll flow targets the
-		// canonical provider's IDs. The user sees the canonical record (e.g.
-		// the OpenLibrary version) in their library; the original DNB record
-		// is dropped because bindery's author/book identity is single-source.
-		req.ForeignBookID = resolved.ForeignID
-		req.ForeignAuthorID = resolved.Author.ForeignID
-		if req.AuthorName == "" {
-			req.AuthorName = resolved.Author.Name
 		}
 	}
 
@@ -2030,7 +2074,14 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 			} else {
 				author = fetched
 				authorWasJustCreated = true
-				h.fetchAuthorBooksAsync(author, false, h.resolveDefaultMediaType(ctx))
+				// A name-resolved add (e.g. a Google Books pick) means the user
+				// chose ONE book; don't speculatively fetch this newly-adopted
+				// author's whole catalogue and flood Wanted. The synchronous
+				// direct-insert below still creates the picked book and keeps the
+				// author non-orphan.
+				if !resolvedByName {
+					h.fetchAuthorBooksAsync(author, false, h.resolveDefaultMediaType(ctx))
+				}
 			}
 		}
 		// Defer the orphan cleanup so cancellation paths inside the poll
@@ -2060,7 +2111,7 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	// cleanup defer sees a non-empty book list (so it keeps the author).
 	// The async sync still runs as a backfill for the rest of the catalogue;
 	// any UNIQUE collision against this row is silently tolerated.
-	directInsertNeeded := authorWasJustCreated || authorMatchedByAlternateID || strings.HasPrefix(req.ForeignBookID, "dnb:")
+	directInsertNeeded := authorWasJustCreated || authorMatchedByAlternateID || strings.HasPrefix(req.ForeignBookID, "dnb:") || resolvedByName
 	if directInsertNeeded {
 		if existing, _ := h.books.GetByForeignID(ctx, req.ForeignBookID); existing == nil {
 			primary, err := h.meta.GetBook(ctx, req.ForeignBookID)
@@ -2072,6 +2123,12 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 				primary.Monitored = author.Monitored
 				if primary.Status == "" {
 					primary.Status = models.BookStatusWanted
+				}
+				// Some providers (notably Google Books) don't set a media type;
+				// fall back to the global default so the row isn't created with an
+				// empty format (which would mis-route its indexer search).
+				if primary.MediaType == "" {
+					primary.MediaType = h.resolveDefaultMediaType(ctx)
 				}
 				if err := h.books.Create(ctx, primary); err != nil {
 					if !strings.Contains(err.Error(), "UNIQUE constraint failed") {

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -3528,6 +3528,80 @@ func TestAddBook_DNBDirectInsertSucceeds(t *testing.T) {
 	}
 }
 
+// TestAddBook_NameOnlyResolvesToExistingLibraryAuthor covers the Google-Books
+// add path: a result carrying an author NAME but no author ID and no ISBN (so
+// resolveAuthorForBook returns nil) must still be addable. It resolves by name
+// onto the user's existing author (no duplicate), direct-inserts the chosen
+// edition, and stamps a media type (GB leaves it empty, which would otherwise
+// mis-route the indexer search).
+func TestAddBook_NameOnlyResolvesToExistingLibraryAuthor(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	// Existing library author, stored INVERTED to prove inversion-aware matching.
+	existing := &models.Author{
+		ForeignID: "OL564887A", Name: "Brooks, Arthur C.", SortName: "Brooks, Arthur C.",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, existing); err != nil {
+		t.Fatal(err)
+	}
+
+	// A Google Books result: author name, no author ID, no ISBN editions, and no
+	// media type set.
+	gbBook := &models.Book{
+		ForeignID: "gb:cMGGEQAAQBAJ", Title: "The Meaning of Your Life",
+		SortTitle: "meaning of your life", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "googlebooks",
+	}
+	stub := &stubMetaProvider{
+		name:        "googlebooks", // aggregator routes "gb:" to this provider
+		getBookByID: map[string]*models.Book{"gb:cMGGEQAAQBAJ": gbBook},
+	}
+	agg := metadata.NewAggregator(stub)
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, nil)
+
+	body, _ := json.Marshal(map[string]any{
+		"foreignBookId": "gb:cMGGEQAAQBAJ",
+		"authorName":    "Arthur C. Brooks", // natural form; matches the inverted record
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/author/book", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.AddBook(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got, err := bookRepo.GetByForeignID(ctx, "gb:cMGGEQAAQBAJ")
+	if err != nil || got == nil {
+		t.Fatalf("book not persisted: err=%v got=%v", err, got)
+	}
+	if got.AuthorID != existing.ID {
+		t.Errorf("book should link to the existing author %d, got %d", existing.ID, got.AuthorID)
+	}
+	if got.MediaType == "" {
+		t.Error("media type should be stamped (not empty) so the indexer search routes correctly")
+	}
+	authors, err := authorRepo.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(authors) != 1 {
+		t.Errorf("expected no duplicate author (1 total), got %d", len(authors))
+	}
+}
+
 // TestAddBook_DirectInsertCoversSlowAsyncSync is the #804 regression test.
 //
 // Scenario from the bug report: a user adds a single book by a prolific

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -81,6 +81,76 @@ func (a *Aggregator) SearchAuthors(ctx context.Context, query string) ([]models.
 	return merged, nil
 }
 
+// ResolveCanonicalAuthor finds the richest OpenLibrary record for an author name
+// — the canonical (inversion-aware) name match with the largest catalogue — and
+// returns its full profile (bio/image from GetAuthor; ratings/disambiguation
+// from the search record). It queries OpenLibrary directly, NOT the merged/
+// deduped author search, so the OL record can't be collapsed away by another
+// provider. Returns nil when no confident OL record (BookCount > 0) exists. Used
+// to resolve the author of a name-only result (e.g. Google Books) when adding it.
+func (a *Aggregator) ResolveCanonicalAuthor(ctx context.Context, name string) (*models.Author, error) {
+	var ol Provider
+	for _, p := range a.providers() {
+		if p != nil && normalizedProviderName(p.Name()) == "openlibrary" {
+			ol = p
+			break
+		}
+	}
+	if ol == nil {
+		return nil, nil
+	}
+	results, err := ol.SearchAuthors(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	want := canonicalAuthorKey(name)
+	var best *models.Author
+	for i := range results {
+		r := &results[i]
+		if canonicalAuthorKey(r.Name) != want || authorBookCount(*r) <= 0 {
+			continue
+		}
+		if best == nil || authorBookCount(*r) > authorBookCount(*best) {
+			best = r
+		}
+	}
+	if best == nil {
+		return nil, nil
+	}
+
+	full, err := a.GetAuthor(ctx, best.ForeignID)
+	if err != nil {
+		return nil, err
+	}
+	// Start from the search record (ratings, work count, disambiguation), then
+	// overlay GetAuthor's richer profile (bio, image). Copy into a fresh value so
+	// we never mutate GetAuthor's cached object.
+	out := *best
+	if full != nil {
+		out.ForeignID = full.ForeignID
+		out.Name = full.Name
+		if full.Description != "" {
+			out.Description = full.Description
+		}
+		if full.ImageURL != "" {
+			out.ImageURL = full.ImageURL
+		}
+		if full.SortName != "" {
+			out.SortName = full.SortName
+		}
+		if full.Disambiguation != "" {
+			out.Disambiguation = full.Disambiguation
+		}
+		if full.RatingsCount > 0 {
+			out.RatingsCount = full.RatingsCount
+		}
+		if full.AverageRating > 0 {
+			out.AverageRating = full.AverageRating
+		}
+	}
+	return &out, nil
+}
+
 // searchFanOut runs fn against the primary and every enricher in parallel (with
 // a per-provider timeout), returning each provider's results in provider order
 // (primary first), whether any provider returned without error, and the first
@@ -128,6 +198,13 @@ func searchFanOut[T any](ctx context.Context, providers []Provider, fn func(cont
 // forms collapse together.
 func canonicalAuthorKey(name string) string {
 	return normalizeForDedup(uninvertAuthorName(name))
+}
+
+// CanonicalAuthorKey is the exported form of canonicalAuthorKey, so callers
+// (e.g. the API layer matching a search result's author name against the
+// library) identify authors the same way ResolveCanonicalAuthor does.
+func CanonicalAuthorKey(name string) string {
+	return canonicalAuthorKey(name)
 }
 
 // uninvertAuthorName converts "Last, First" to "First Last"; other forms are


### PR DESCRIPTION
## Summary

`AddBook` rejected any result whose `foreignAuthorId` was empty and whose foreign book had no ISBN edition to resolve an author from — the case for Google Books results, which carry an author name but no author ID and no ISBN. Such results became findable in search (#1064) but were still unaddable ("Author metadata unavailable for this result"). This adds a name-based author fallback so they can be added.

## Implementation notes

When ISBN-based resolution (`resolveAuthorForBook`) returns nil but the result carries an author name:

- prefer an author already in the user's library whose name canonically matches (`findLibraryAuthorByName`, inversion-aware so "Last, First" == "First Last") — the add reuses the existing author instead of creating a duplicate;
- otherwise adopt OpenLibrary's canonical record (`ResolveCanonicalAuthor`, which queries OL directly so the record can't be collapsed away by another provider).

A name-resolved add keeps the chosen edition (the adopted author's catalogue won't contain a cross-provider book), so it:

- direct-inserts that edition (same path used for DNB / just-created authors);
- suppresses the speculative catalogue fetch, so Wanted isn't flooded with the adopted author's whole backlist;
- stamps the default media type when the provider left it empty (Google Books does) — otherwise the row's empty format mis-routes its indexer search.

Builds on the multi-provider search merge (#1064).

## Checklist

- [x] Tests added or updated — `TestAddBook_NameOnlyResolvesToExistingLibraryAuthor` (name reuse, no duplicate author, media type stamped)
- [x] Doc-update gate cleared — no user-facing doc describes AddBook resolution internals
- [ ] Wiki pages updated if user-facing behaviour changed — n/a

## Test plan

- [x] `go test ./internal/api/... ./internal/metadata/...`
- [x] `go build ./...`
