### PR TITLE
chore: declare MIT license in image OCI labels and web manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,13 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
 
 # Stage 3: Minimal runtime
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639
+# OCI image metadata so registries and `docker inspect` surface the MIT license
+# and source, matching the repo's LICENSE.
+LABEL org.opencontainers.image.title="Bindery" \
+      org.opencontainers.image.description="Automated book download manager for Usenet & Torrents" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.source="https://github.com/vavallee/bindery" \
+      org.opencontainers.image.url="https://github.com/vavallee/bindery"
 COPY --from=builder /bindery /bindery
 USER nonroot
 EXPOSE 8787

--- a/changelog.d/oci-license-metadata.md
+++ b/changelog.d/oci-license-metadata.md
@@ -1,0 +1,2 @@
+### Changed
+- **Docker image now carries OCI metadata** — the published image declares its license (`org.opencontainers.image.licenses=MIT`), source, title, and description, so registries and `docker inspect` surface them. The web package manifest also declares `MIT`, matching the repo's `LICENSE`.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "bindery-web",
       "version": "1.17.0",
+      "license": "MIT",
       "dependencies": {
         "i18next": "^26.3.1",
         "i18next-browser-languagedetector": "^8.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "bindery-web",
   "private": true,
   "version": "1.17.0",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Problem

The repo's `LICENSE` is MIT and the README says so, but a license audit found the license wasn't surfaced where tooling looks for it:
- the Docker image carried **no OCI metadata**, so registries and `docker inspect` showed no license;
- `web/package.json` had **no `license` field**.

No file claimed a non-MIT license; these were gaps, not contradictions.

## Change

- `Dockerfile`: add OCI image labels to the runtime stage — `org.opencontainers.image.licenses=MIT` plus `title` / `description` (the README tagline) / `source` / `url`.
- `web/package.json`: add `"license": "MIT"`, and sync the lockfile root entry so `npm ci` stays in sync.

## Verification

- `web/package.json` and `web/package-lock.json` are valid JSON; `npm ci` passes with the synced lockfile.
- Dockerfile label syntax is standard `LABEL key=value` (hadolint runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)