### PR TITLE
feat(metadata): derive audiobook metadata from Hardcover editions; prefer stronger Hardcover ratings

### DIFF
--- a/changelog.d/806-807-hardcover-metadata.md
+++ b/changelog.d/806-807-hardcover-metadata.md
@@ -1,0 +1,3 @@
+### Changed
+- **Audiobook metadata is now derived from Hardcover editions before Audnex enrichment** (#806) — when a confident Hardcover match is hydrated, the chosen audio edition's language and cover (and audiobook media type) are filled from Hardcover first, leaving Audnex to supply only what Hardcover lacks (narrator, refined duration, summary). Known fields are never overwritten.
+- **Metadata enrichment now prefers stronger Hardcover rating signals** (#807) — when Hardcover carries a materially better-supported rating (at least 2× the current `ratings_count`, above a small floor), Bindery adopts its `average_rating` and `ratings_count` instead of keeping a sparse first-seen value; weaker or empty incoming ratings still never replace a known one.

--- a/internal/bookhydrate/hardcover.go
+++ b/internal/bookhydrate/hardcover.go
@@ -45,6 +45,7 @@ type Result struct {
 	Fetched           int
 	Upserted          int
 	ASINPromoted      bool
+	MetadataDerived   bool
 	AudiobookEnriched bool
 	BookUpdated       bool
 	Err               error
@@ -117,8 +118,22 @@ func HydrateHardcoverEditions(ctx context.Context, opts Options) Result {
 		}
 	}
 
+	// #806: derive audiobook metadata from the chosen Hardcover edition BEFORE
+	// running Audnex, so Hardcover's deterministic edition data fills the book
+	// and Audnex is left to cover only the gaps (narrator, refined duration,
+	// summary, cover-if-missing). preferredAudioEdition picks the same edition
+	// maybePromoteASIN promotes the ASIN from, keeping the two derivations
+	// consistent.
+	if edition, ok := preferredAudioEdition(acceptedAudioEditions); ok {
+		if deriveAudiobookMetadataFromEdition(book, edition) {
+			result.MetadataDerived = true
+		}
+	}
+
 	if maybePromoteASIN(book, acceptedAudioEditions) {
 		result.ASINPromoted = true
+		// Audnex enrichment runs AFTER Hardcover-edition derivation (above) so
+		// it only fills what Hardcover lacked (#806).
 		if opts.Enricher != nil {
 			if err := opts.Enricher.EnrichAudiobook(ctx, book); err != nil {
 				if result.Err == nil {
@@ -129,19 +144,85 @@ func HydrateHardcoverEditions(ctx context.Context, opts Options) Result {
 				result.AudiobookEnriched = true
 			}
 		}
-		if opts.Books != nil {
-			if err := opts.Books.Update(ctx, book); err != nil {
-				if result.Err == nil {
-					result.Err = err
-				}
-				slog.Warn("hardcover ASIN promotion persist failed", "bookID", book.ID, "asin", book.ASIN, "error", err)
-			} else {
-				result.BookUpdated = true
+	}
+
+	// Persist when Hardcover-edition derivation or ASIN promotion changed the
+	// book. Derivation alone (e.g. ASIN already set) is enough to warrant a
+	// write so the language/cover/duration we pulled isn't lost.
+	if (result.ASINPromoted || result.MetadataDerived) && opts.Books != nil {
+		if err := opts.Books.Update(ctx, book); err != nil {
+			if result.Err == nil {
+				result.Err = err
 			}
+			slog.Warn("hardcover book hydration persist failed", "bookID", book.ID, "asin", book.ASIN, "error", err)
+		} else {
+			result.BookUpdated = true
 		}
 	}
 
 	return result
+}
+
+// preferredAudioEdition returns the audio-looking edition the hydrator should
+// derive book metadata from — the same edition maybePromoteASIN promotes the
+// ASIN from (highest audioEditionScore, first on ties). Returns ok=false when
+// there is no audio edition to derive from.
+func preferredAudioEdition(editions []models.Edition) (models.Edition, bool) {
+	best := -1
+	bestScore := -1
+	for i := range editions {
+		score := audioEditionScore(editions[i])
+		if best == -1 || score > bestScore {
+			best = i
+			bestScore = score
+		}
+	}
+	if best == -1 {
+		return models.Edition{}, false
+	}
+	return editions[best], true
+}
+
+// deriveAudiobookMetadataFromEdition fills book-level audiobook fields from a
+// Hardcover edition, preferring Hardcover's deterministic edition data before
+// Audnex runs (#806). It only ever fills unknown fields — known values are
+// never overwritten ("unknown ⇒ don't clobber known"). It also makes sure an
+// audio-bearing book carries an audiobook MediaType so the Audnex path is
+// eligible. Returns whether it changed anything.
+func deriveAudiobookMetadataFromEdition(book *models.Book, edition models.Edition) bool {
+	if book == nil {
+		return false
+	}
+	changed := false
+
+	if !bookAcceptsAudiobookASIN(book) {
+		// The chosen edition is audio-looking but the book wasn't flagged as
+		// audio yet; promote it so downstream audio enrichment is eligible.
+		switch book.MediaType {
+		case "":
+			book.MediaType = models.MediaTypeAudiobook
+			changed = true
+		case models.MediaTypeEbook:
+			book.MediaType = models.MediaTypeBoth
+			changed = true
+		}
+	}
+
+	if book.Language == "" {
+		if lang := strings.TrimSpace(edition.Language); lang != "" {
+			book.Language = lang
+			changed = true
+		}
+	}
+
+	if book.ImageURL == "" {
+		if cover := strings.TrimSpace(edition.ImageURL); cover != "" {
+			book.ImageURL = cover
+			changed = true
+		}
+	}
+
+	return changed
 }
 
 func maybePromoteASIN(book *models.Book, editions []models.Edition) bool {

--- a/internal/bookhydrate/hardcover_test.go
+++ b/internal/bookhydrate/hardcover_test.go
@@ -109,6 +109,156 @@ func TestHydrateHardcoverEditionsAssignsBookAndPromotesAudioASIN(t *testing.T) {
 	}
 }
 
+// TestHydrateHardcoverEditionsDerivesAudiobookMetadataBeforeAudnex covers
+// issue #806: book-level audiobook fields (language, cover) are derived from
+// the chosen Hardcover audio edition first, and Audnex is left to fill only
+// the gap it owns (narrator).
+func TestHydrateHardcoverEditionsDerivesAudiobookMetadataBeforeAudnex(t *testing.T) {
+	books, editions, book, ctx := newHydrateBook(t, "hc:hydrated-book", "hardcover", models.MediaTypeAudiobook)
+	audioASIN := "b222222222"
+	editionLang := "ger"
+	editionCover := "https://img.example/hc-audio.jpg"
+	enricher := &fakeAudiobookEnricher{}
+
+	result := HydrateHardcoverEditions(ctx, Options{
+		Book:     book,
+		Provider: "hardcover",
+		Editions: editions,
+		Books:    books,
+		FetchEditions: func(context.Context, string) ([]models.Edition, error) {
+			return []models.Edition{{
+				ForeignID: "hc:audio",
+				Title:     "Audio",
+				ASIN:      &audioASIN,
+				Format:    "Audiobook",
+				Language:  editionLang,
+				ImageURL:  editionCover,
+				Monitored: true,
+			}}, nil
+		},
+		Enricher: enricher,
+	})
+	if result.Err != nil {
+		t.Fatalf("hydrate err = %v", result.Err)
+	}
+	if !result.MetadataDerived {
+		t.Fatalf("expected MetadataDerived, got result=%+v", result)
+	}
+	if !result.ASINPromoted || !result.AudiobookEnriched || !result.BookUpdated {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	// Hardcover edition supplied language + cover...
+	if book.Language != editionLang {
+		t.Fatalf("language not derived from Hardcover edition: %q", book.Language)
+	}
+	if book.ImageURL != editionCover {
+		t.Fatalf("cover not derived from Hardcover edition: %q", book.ImageURL)
+	}
+	// ...and Audnex filled the gap it owns.
+	if book.Narrator != "Kate Reading" {
+		t.Fatalf("Audnex did not fill narrator gap: %q", book.Narrator)
+	}
+	stored, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Language != editionLang || stored.ImageURL != editionCover || stored.Narrator != "Kate Reading" {
+		t.Fatalf("derived audiobook metadata not persisted: %+v", stored)
+	}
+}
+
+// TestHydrateHardcoverEditionsDoesNotClobberKnownAudiobookFields guards the
+// "unknown ⇒ don't overwrite known" invariant: Hardcover edition data must not
+// replace language/cover the book already carries.
+func TestHydrateHardcoverEditionsDoesNotClobberKnownAudiobookFields(t *testing.T) {
+	books, editions, book, ctx := newHydrateBook(t, "hc:hydrated-book", "hardcover", models.MediaTypeAudiobook)
+	book.Language = "eng"
+	book.ImageURL = "https://existing.example/cover.jpg"
+	if err := books.Update(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	audioASIN := "b222222222"
+
+	result := HydrateHardcoverEditions(ctx, Options{
+		Book:     book,
+		Provider: "hardcover",
+		Editions: editions,
+		Books:    books,
+		FetchEditions: func(context.Context, string) ([]models.Edition, error) {
+			return []models.Edition{{
+				ForeignID: "hc:audio",
+				Title:     "Audio",
+				ASIN:      &audioASIN,
+				Format:    "Audiobook",
+				Language:  "ger",
+				ImageURL:  "https://img.example/hc-audio.jpg",
+				Monitored: true,
+			}}, nil
+		},
+		Enricher: &fakeAudiobookEnricher{},
+	})
+	if result.Err != nil {
+		t.Fatalf("hydrate err = %v", result.Err)
+	}
+	if book.Language != "eng" {
+		t.Fatalf("known language was clobbered: %q", book.Language)
+	}
+	if book.ImageURL != "https://existing.example/cover.jpg" {
+		t.Fatalf("known cover was clobbered: %q", book.ImageURL)
+	}
+}
+
+// TestHydrateHardcoverEditionsDerivesMetadataWithoutASINPromotion covers the
+// case where the book already has an ASIN (so no promotion happens) but the
+// Hardcover edition still has language/cover to contribute — the derivation
+// must run and persist on its own (#806).
+func TestHydrateHardcoverEditionsDerivesMetadataWithoutASINPromotion(t *testing.T) {
+	books, editions, book, ctx := newHydrateBook(t, "hc:hydrated-book", "hardcover", models.MediaTypeAudiobook)
+	book.ASIN = "B000PREEXIST"
+	if err := books.Update(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	editionASIN := "b222222222"
+
+	result := HydrateHardcoverEditions(ctx, Options{
+		Book:     book,
+		Provider: "hardcover",
+		Editions: editions,
+		Books:    books,
+		FetchEditions: func(context.Context, string) ([]models.Edition, error) {
+			return []models.Edition{{
+				ForeignID: "hc:audio",
+				Title:     "Audio",
+				ASIN:      &editionASIN,
+				Format:    "Audiobook",
+				Language:  "ger",
+				ImageURL:  "https://img.example/hc-audio.jpg",
+				Monitored: true,
+			}}, nil
+		},
+		Enricher: &fakeAudiobookEnricher{},
+	})
+	if result.Err != nil {
+		t.Fatalf("hydrate err = %v", result.Err)
+	}
+	if result.ASINPromoted {
+		t.Fatalf("ASIN should not be promoted over an existing one: %+v", result)
+	}
+	if !result.MetadataDerived || !result.BookUpdated {
+		t.Fatalf("derivation should run and persist without ASIN promotion: %+v", result)
+	}
+	if book.ASIN != "B000PREEXIST" {
+		t.Fatalf("existing ASIN changed: %q", book.ASIN)
+	}
+	stored, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Language != "ger" || stored.ImageURL != "https://img.example/hc-audio.jpg" {
+		t.Fatalf("derived metadata not persisted without ASIN promotion: %+v", stored)
+	}
+}
+
 func TestHydrateHardcoverEditionsDoesNotPromoteSkippedEditionASIN(t *testing.T) {
 	books, editions, book, ctx := newHydrateBook(t, "hc:hydrated-book", "hardcover", models.MediaTypeAudiobook)
 	other := &models.Book{

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -802,7 +802,7 @@ func (a *Aggregator) cacheISBNBook(ctx context.Context, key string, book *models
 					if book.ImageURL == "" && full.ImageURL != "" {
 						book.ImageURL = full.ImageURL
 					}
-					if book.AverageRating == 0 && full.AverageRating > 0 {
+					if preferStrongerRating(book.AverageRating, book.RatingsCount, full.AverageRating, full.RatingsCount) {
 						book.AverageRating = full.AverageRating
 						book.RatingsCount = full.RatingsCount
 					}

--- a/internal/metadata/aggregator_author_works.go
+++ b/internal/metadata/aggregator_author_works.go
@@ -204,10 +204,12 @@ func mergeAuthorWorkMetadata(dst *models.Book, src models.Book) {
 	if dst.Description == "" {
 		dst.Description = src.Description
 	}
-	if dst.AverageRating == 0 {
+	// #807: keep the (average, count) pair together and prefer the source with
+	// the materially stronger ratings_count rather than filling each field
+	// independently (which could pair an average from one source with a count
+	// from another).
+	if preferStrongerRating(dst.AverageRating, dst.RatingsCount, src.AverageRating, src.RatingsCount) {
 		dst.AverageRating = src.AverageRating
-	}
-	if dst.RatingsCount == 0 {
 		dst.RatingsCount = src.RatingsCount
 	}
 	if dst.ReleaseDate == nil {

--- a/internal/metadata/aggregator_enrichment.go
+++ b/internal/metadata/aggregator_enrichment.go
@@ -285,7 +285,12 @@ func (a *Aggregator) enrichBook(ctx context.Context, book *models.Book) {
 			book.Description = e.Description
 			slog.Debug("enriched description", "provider", enricher.Name(), "book", book.Title)
 		}
-		if book.AverageRating == 0 && e.AverageRating > 0 {
+		// #807: take the incoming rating when we have none yet, or when the
+		// incoming source carries a materially stronger ratings_count than the
+		// value we're holding (e.g. Hardcover's community signal vs. sparse
+		// OpenLibrary data). preferStrongerRating keeps the "unknown ⇒ don't
+		// overwrite a known value" invariant.
+		if preferStrongerRating(book.AverageRating, book.RatingsCount, e.AverageRating, e.RatingsCount) {
 			book.AverageRating = e.AverageRating
 			book.RatingsCount = e.RatingsCount
 		}
@@ -328,10 +333,42 @@ func applyEnrichmentSnapshot(book *models.Book, snap enrichmentSnapshot) {
 	if book.ImageURL == "" && snap.imageURL != "" {
 		book.ImageURL = snap.imageURL
 	}
-	if book.AverageRating == 0 && snap.averageRating > 0 {
+	if preferStrongerRating(book.AverageRating, book.RatingsCount, snap.averageRating, snap.ratingsCount) {
 		book.AverageRating = snap.averageRating
 		book.RatingsCount = snap.ratingsCount
 	}
+}
+
+// ratingStrengthFactor is how many times larger an incoming ratings_count
+// must be before it displaces a rating we already hold. A 2x threshold means
+// we only swap when the new source is clearly better supported, not when two
+// sources are within noise of each other.
+const ratingStrengthFactor = 2
+
+// ratingStrengthFloor is the minimum ratings_count an incoming rating must
+// carry to ever displace an existing one. It guards against a handful of
+// ratings (statistically meaningless) overwriting an established value just
+// because the existing source happens to report even fewer.
+const ratingStrengthFloor = 10
+
+// preferStrongerRating reports whether an incoming (average, count) rating
+// should replace the current one. Issue #807's rule:
+//   - never overwrite with an empty incoming rating (incoming average <= 0 ⇒
+//     keep current);
+//   - take the incoming rating when we currently hold none (current average
+//     <= 0) — any rating beats no rating, even a count-less one;
+//   - otherwise (both sides have a rating) replace only when the incoming
+//     ratings_count clears the floor AND is at least ratingStrengthFactor× the
+//     current count — a materially stronger community signal — so weaker or
+//     count-less data never clobbers an established value.
+func preferStrongerRating(curAvg float64, curCount int, inAvg float64, inCount int) bool {
+	if inAvg <= 0 {
+		return false
+	}
+	if curAvg <= 0 {
+		return true
+	}
+	return inCount >= ratingStrengthFloor && inCount >= curCount*ratingStrengthFactor
 }
 
 // pickEnrichmentMatch returns the first candidate that plausibly matches

--- a/internal/metadata/aggregator_enrichment_test.go
+++ b/internal/metadata/aggregator_enrichment_test.go
@@ -441,6 +441,93 @@ func TestAggregator_enrichBook_CoverProviderSkippedWhenAlreadyHaveCover(t *testi
 	}
 }
 
+// TestPreferStrongerRating_Rule exercises issue #807's field-level merge rule
+// directly: empty incoming never wins, an incoming rating always fills an empty
+// current, and between two populated sources only a materially stronger
+// ratings_count (≥ floor AND ≥ 2× current) displaces the existing value.
+func TestPreferStrongerRating_Rule(t *testing.T) {
+	cases := []struct {
+		name     string
+		curAvg   float64
+		curCount int
+		inAvg    float64
+		inCount  int
+		want     bool
+	}{
+		{"empty incoming keeps current", 4.0, 100, 0, 0, false},
+		{"incoming count-less but current empty fills", 0, 0, 4.5, 0, true},
+		{"incoming fills empty current", 0, 0, 4.2, 5, true},
+		{"stronger incoming displaces", 4.0, 50, 3.9, 500, true},
+		{"weaker incoming kept out", 4.0, 500, 4.8, 50, false},
+		{"slightly higher but below 2x kept out", 4.0, 100, 4.1, 150, false},
+		{"above floor and 2x wins", 4.0, 100, 4.1, 200, true},
+		{"meets 2x but below floor kept out", 4.0, 3, 4.9, 6, false},
+		{"equal counts kept out", 4.0, 100, 4.9, 100, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := preferStrongerRating(tc.curAvg, tc.curCount, tc.inAvg, tc.inCount)
+			if got != tc.want {
+				t.Fatalf("preferStrongerRating(%v,%d,%v,%d) = %v, want %v",
+					tc.curAvg, tc.curCount, tc.inAvg, tc.inCount, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAggregator_enrichBook_PrefersStrongerRatingSignal verifies the rule wires
+// through enrichBook: a Hardcover enricher with a materially stronger
+// ratings_count replaces the sparse rating the book already carries (#807).
+func TestAggregator_enrichBook_PrefersStrongerRatingSignal(t *testing.T) {
+	enricher := &mockProvider{
+		name: "hardcover",
+		searchBooks: []models.Book{{
+			Title:         "Dune",
+			Author:        &models.Author{Name: "Frank Herbert"},
+			AverageRating: 4.3,
+			RatingsCount:  9000,
+		}},
+	}
+	agg := &Aggregator{enrichers: []Provider{enricher}, cache: newTTLCache(time.Minute)}
+
+	book := &models.Book{
+		Title:         "Dune",
+		Author:        &models.Author{Name: "Frank Herbert"},
+		AverageRating: 3.9,
+		RatingsCount:  20,
+	}
+	agg.enrichBook(context.Background(), book)
+	if book.AverageRating != 4.3 || book.RatingsCount != 9000 {
+		t.Fatalf("stronger Hardcover rating not adopted: avg=%v count=%d", book.AverageRating, book.RatingsCount)
+	}
+}
+
+// TestAggregator_enrichBook_KeepsStrongerExistingRating is the inverse guard:
+// a weaker incoming rating must not clobber a better-supported existing one.
+func TestAggregator_enrichBook_KeepsStrongerExistingRating(t *testing.T) {
+	enricher := &mockProvider{
+		name: "hardcover",
+		searchBooks: []models.Book{{
+			Title:         "Dune",
+			Author:        &models.Author{Name: "Frank Herbert"},
+			AverageRating: 4.9,
+			RatingsCount:  12,
+		}},
+	}
+	agg := &Aggregator{enrichers: []Provider{enricher}, cache: newTTLCache(time.Minute)}
+
+	book := &models.Book{
+		Title:         "Dune",
+		Author:        &models.Author{Name: "Frank Herbert"},
+		AverageRating: 4.1,
+		RatingsCount:  8000,
+	}
+	agg.enrichBook(context.Background(), book)
+	if book.AverageRating != 4.1 || book.RatingsCount != 8000 {
+		t.Fatalf("weaker incoming rating clobbered stronger existing: avg=%v count=%d", book.AverageRating, book.RatingsCount)
+	}
+}
+
 func TestAggregator_GetBook_NoCover_EnrichedFromProvider(t *testing.T) {
 	// Book has a long description so the old trigger wouldn't fire — but
 	// ImageURL is empty so enrichment must still run.


### PR DESCRIPTION
## Problem

Two related gaps in the Hardcover metadata-enrichment path:

- **#806** — When Bindery has a confident Hardcover match, audiobook fields (language, cover, media type) were not derived from Hardcover's edition data; the pipeline jumped straight to promoting an ASIN and calling Audnex. Hardcover edition data is deterministic and should fill those fields first.
- **#807** — Rating merges were first-non-zero-wins, so a book could keep sparse OpenLibrary rating data even when Hardcover had a materially stronger community signal for the same work.

## Approach

Two clearly-separated concerns shipped together because both touch the Hardcover enrichment path.

**#806 (`internal/bookhydrate/hardcover.go`)** — After upserting Hardcover editions and selecting the preferred audio edition (the same one the ASIN is promoted from), derive book-level audiobook metadata from that edition *before* Audnex runs:
- audiobook `MediaType` (promote empty→audiobook, ebook→both when an audio edition is present)
- `Language` and cover `ImageURL` from the edition, **only when the book's value is unknown**

Audnex then runs and fills only what Hardcover lacked (narrator, refined duration, summary, cover-if-missing). Derivation persists even when no ASIN is promoted (e.g. the book already had one). Per-edition duration is not carried by `models.Edition`; Hardcover book-level `audio_seconds` already maps to `DurationSeconds` via the client, and Audnex refines it — so no schema change was needed.

**#807 (`internal/metadata/`)** — New `preferStrongerRating(curAvg, curCount, inAvg, inCount)` rule:
- empty incoming (`avg <= 0`) never wins;
- incoming fills an empty current (`curAvg <= 0`) — any rating beats none;
- between two populated sources, replace only when incoming `ratings_count` is ≥ a small floor (10) **and** ≥ 2× the current count.

Applied in `enrichBook` (+ its snapshot-cache apply), ISBN hydration (`cacheISBNBook`), and the author-work merge path (`mergeAuthorWorkMetadata`). The "unknown ⇒ don't overwrite a known value" invariant is preserved everywhere.

## Tests

- `internal/bookhydrate`: derivation pulls language/cover from the Hardcover audio edition before Audnex (and Audnex fills the narrator gap); known fields are not clobbered; derivation runs and persists without ASIN promotion. Existing ASIN-promotion tests still pass.
- `internal/metadata`: table-driven `preferStrongerRating` rule; `enrichBook` adopts a stronger Hardcover rating; weaker incoming rating does not clobber a stronger existing one. Ebook path and existing "don't clobber" cover/rating invariants preserved.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `golangci-lint run ./internal/metadata/ ./internal/metadata/hardcover/ ./internal/metadata/audnex/ ./internal/bookhydrate/` → 0 issues
- `go test ./internal/metadata/... ./internal/bookhydrate/... ./internal/hardcoverlistsyncer/... ./internal/abs/... ./internal/api/...` → pass

Closes #806
Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)