### PR TITLE
Add copy/hardlink-only multi-disc audiobook flattening

### DIFF
--- a/changelog.d/886-multidisc-flatten.md
+++ b/changelog.d/886-multidisc-flatten.md
@@ -1,0 +1,2 @@
+### Added
+- **Optional multi-disc audiobook flattening** (#886) — when enabled (Settings → General, copy/hardlink mode only), a completed audiobook download split into `Disc 1`/`CD 2`/… folders is imported into one flat folder as `Part 001.ext`, `Part 002.ext`, … so audiobook players sort it correctly; the source is never moved, so torrents keep seeding. Off by default and single-disc imports are unchanged.

--- a/docs/Storage-And-Hardlinks-Wiki.md
+++ b/docs/Storage-And-Hardlinks-Wiki.md
@@ -22,6 +22,18 @@ Set the import mode in **Settings → File Naming**.
 | **copy** | doubled | kept | Use when downloads and library are on different filesystems. Copies into the library and leaves the download in place so it can keep seeding. |
 | **move** | none | **broken** | Moves the file out of the download location, so a torrent can no longer seed it. Only suitable for Usenet, or when you do not seed. |
 
+## Multi-disc audiobook flattening
+
+Some audiobook releases arrive as nested disc folders with repeated track names, for example `Disc 1/Track 01.mp3`, `Disc 1/Track 02.mp3`, `Disc 2/Track 01.mp3`. Audiobook players that sort each disc folder independently (or treat repeated `Track 01` names as duplicates) play these in the wrong order.
+
+Enable **Settings → General → File Naming → Flatten multi-disc audiobooks** to import such a download into a single flat folder, renaming tracks to `Part 001.ext`, `Part 002.ext`, … in disc-then-track order. Disc numbers are detected from folder names like `Disc 1`, `Disk 02`, `CD 3`, `Part 4`; track numbers from file names like `Track 01.mp3`, `Chapter 02.mp3`, or a leading `01 - Title.mp3`. Root-level sidecars (cover art, cue sheets) are carried across.
+
+Guarantees:
+
+- **Off by default.** Single-disc audiobooks and downloads with no disc folders are never altered.
+- **Copy/hardlink only.** Flattening is enforced backend-side to run only when the resolved import mode is `copy` or `hardlink`, because it renames files and must never touch a still-seeding torrent source. In `move` and `external` mode the setting is ignored and the existing whole-folder behaviour applies.
+- **Seeding preserved.** The source download is copied or hardlinked, never moved or renamed, so it keeps seeding.
+
 ## Download folders
 
 | Variable | Purpose |

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -69,6 +69,16 @@ const (
 	SettingImportDropLinkMode = "import.drop_link_mode"
 )
 
+// SettingImportAudiobookFlattenMultiDisc (#886) is "true" to flatten multi-disc
+// audiobook downloads into a single "Part 001.ext", … sequence on import, or
+// unset/"false" (default) to preserve the download's disc-folder layout.
+// Flattening only ever runs in copy/hardlink import mode — the backend enforces
+// that restriction at import time regardless of this flag, because flattening
+// renames files and must never touch a still-seeding source in move mode. The
+// importer reads this key as a string literal to avoid an import cycle; keep
+// the literal in sync with this constant.
+const SettingImportAudiobookFlattenMultiDisc = "import.audiobook.flatten_multi_disc"
+
 type SettingsHandler struct {
 	settings *db.SettingsRepo
 }

--- a/internal/importer/flatten.go
+++ b/internal/importer/flatten.go
@@ -1,0 +1,256 @@
+package importer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// audioFlattenExtensions lists the audio extensions that participate in
+// multi-disc audiobook flattening. It deliberately mirrors the audio set used
+// by detectDownloadFormat so the flattener and the format detector agree on
+// what counts as an audio track.
+var audioFlattenExtensions = map[string]bool{
+	".mp3": true, ".m4b": true, ".m4a": true, ".aac": true,
+	".flac": true, ".ogg": true, ".opus": true,
+}
+
+// discDirPattern matches a directory component that names a disc, e.g.
+// "Disc 1", "Disk 02", "CD 3", "CD3", "Part 4", "Volume 2", "Vol. 3". The
+// number is captured. Matching is anchored loosely: the keyword can carry a
+// trailing label ("Disc 1 - Intro") as long as the number follows the keyword.
+var discDirPattern = regexp.MustCompile(`(?i)\b(?:disc|disk|cd|part|volume|vol)\.?\s*0*([0-9]{1,3})\b`)
+
+// trackNumPattern matches a leading or keyword-introduced track number in a
+// file's base name, e.g. "Track 01.mp3", "Chapter 02.mp3", "01 - Title.mp3",
+// "1-05 - Title.mp3" (disc-track combined). The LAST captured group is the
+// track number; a leading "<n>-" disc prefix is allowed and ignored here
+// because disc ordering is resolved from the directory.
+var trackNumPattern = regexp.MustCompile(`(?i)^(?:track|chapter|chap|part|ch)\.?\s*0*([0-9]{1,4})\b`)
+
+// leadingNumPattern matches a bare leading number, optionally preceded by a
+// "<disc>-" or "<disc>." prefix: "05 - Title.mp3", "1-05 Title.mp3",
+// "1.05 Title.mp3". The final group is the track number.
+var leadingNumPattern = regexp.MustCompile(`^(?:[0-9]{1,2}[-.])?0*([0-9]{1,4})\b`)
+
+// flattenTrack is one audio file selected for flattening, carrying the
+// detected disc/track ordering keys and its source path.
+type flattenTrack struct {
+	src   string // absolute source path
+	rel   string // path relative to the source root (tiebreaker, deterministic)
+	disc  int    // detected disc number; 0 when none detected
+	track int    // detected track number; 0 when none detected
+}
+
+// extractDiscNumber returns the disc number encoded in any component of relDir
+// (the directory path of an audio file relative to the audiobook source root),
+// or 0 when none of the components name a disc. The deepest matching component
+// wins so "CD 1/Disc 2/.." style nesting resolves to the most specific disc.
+func extractDiscNumber(relDir string) int {
+	if relDir == "" || relDir == "." {
+		return 0
+	}
+	disc := 0
+	for _, comp := range strings.Split(relDir, string(filepath.Separator)) {
+		if m := discDirPattern.FindStringSubmatch(comp); m != nil {
+			if n, err := strconv.Atoi(m[1]); err == nil {
+				disc = n
+			}
+		}
+	}
+	return disc
+}
+
+// extractTrackNumber returns the track number encoded in a file's base name
+// (extension stripped by the caller is not required), or 0 when none is found.
+// Keyword forms ("Track 01", "Chapter 2") win over a bare leading number.
+func extractTrackNumber(base string) int {
+	name := strings.TrimSuffix(base, filepath.Ext(base))
+	name = strings.TrimSpace(name)
+	if m := trackNumPattern.FindStringSubmatch(name); m != nil {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	if m := leadingNumPattern.FindStringSubmatch(name); m != nil {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+// collectFlattenTracks walks srcRoot, returning every audio file it finds as a
+// flattenTrack with disc/track ordering keys resolved, sorted deterministically
+// by (disc, track, rel). Symlinks are skipped (never followed). The returned
+// slice is the flat playback order the caller will rename to Part NNN.
+func collectFlattenTracks(srcRoot string) ([]flattenTrack, error) {
+	var tracks []flattenTrack
+	err := filepath.Walk(srcRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		// Skip symlinks: never follow them into or out of the source tree.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if !audioFlattenExtensions[ext] {
+			return nil
+		}
+		rel, relErr := filepath.Rel(srcRoot, path)
+		if relErr != nil {
+			rel = filepath.Base(path)
+		}
+		tracks = append(tracks, flattenTrack{
+			src:   path,
+			rel:   rel,
+			disc:  extractDiscNumber(filepath.Dir(rel)),
+			track: extractTrackNumber(filepath.Base(path)),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(tracks, func(i, j int) bool {
+		a, b := tracks[i], tracks[j]
+		if a.disc != b.disc {
+			return a.disc < b.disc
+		}
+		if a.track != b.track {
+			return a.track < b.track
+		}
+		return a.rel < b.rel
+	})
+	return tracks, nil
+}
+
+// isMultiDiscAudiobook reports whether the audio files under srcRoot span two
+// or more distinct disc directories — the only shape flattening targets. A
+// single disc folder, or a flat folder with no disc directories at all, is left
+// untouched (returns false) so existing single-disc imports are unchanged.
+func isMultiDiscAudiobook(srcRoot string) bool {
+	tracks, err := collectFlattenTracks(srcRoot)
+	if err != nil || len(tracks) < 2 {
+		return false
+	}
+	discs := map[int]struct{}{}
+	for _, tr := range tracks {
+		if tr.disc > 0 {
+			discs[tr.disc] = struct{}{}
+		}
+	}
+	return len(discs) >= 2
+}
+
+// flattenAudiobookDir places every audio track found under srcRoot into destDir
+// as a flat "Part 001.ext", "Part 002.ext", … sequence using copy or hardlink
+// only — the source is never moved, so the download keeps seeding. Non-audio
+// sidecar files (cover art, cue sheets, NFOs) at the source root are carried
+// across verbatim where their names do not collide with a generated Part name.
+//
+// mode must be "copy" or "hardlink"; any other value is rejected so the
+// backend enforces the import-mode restriction even if a stale setting slips
+// through. destDir must not already exist (the caller resolves collisions via
+// UniqueDir) and is created here.
+//
+// The placement honours the same containment guarantee as the rest of the
+// importer: every destination path is a direct child of destDir (Part NNN has
+// no separators), so book-derived strings cannot escape the library.
+func flattenAudiobookDir(ctx context.Context, mode, srcRoot, destDir string) error {
+	if mode != "copy" && mode != "hardlink" {
+		return fmt.Errorf("flatten supports copy/hardlink only, got %q", mode)
+	}
+	tracks, err := collectFlattenTracks(srcRoot)
+	if err != nil {
+		return fmt.Errorf("collect tracks: %w", err)
+	}
+	if len(tracks) == 0 {
+		return fmt.Errorf("no audio tracks found under %q", srcRoot)
+	}
+	if _, statErr := os.Stat(destDir); statErr == nil {
+		return fmt.Errorf("destination already exists: %s", destDir)
+	}
+	if err := os.MkdirAll(destDir, 0o750); err != nil {
+		return fmt.Errorf("create dest dir: %w", err)
+	}
+
+	// reserved tracks every generated Part filename so a sidecar copy can never
+	// clobber one, and so a re-run never silently overwrites.
+	reserved := make(map[string]struct{}, len(tracks))
+	for i, tr := range tracks {
+		if err := ctx.Err(); err != nil {
+			_ = os.RemoveAll(destDir)
+			return err
+		}
+		ext := strings.ToLower(filepath.Ext(tr.src))
+		name := fmt.Sprintf("Part %03d%s", i+1, ext)
+		reserved[name] = struct{}{}
+		dst := filepath.Join(destDir, name)
+		if err := placeFlattened(ctx, mode, tr.src, dst); err != nil {
+			_ = os.RemoveAll(destDir)
+			return fmt.Errorf("place %q: %w", tr.rel, err)
+		}
+	}
+
+	// Carry root-level sidecars (cover.jpg, *.cue, *.nfo) across so players that
+	// rely on embedded art still find it. Only regular files directly at the
+	// source root are considered; nested disc-folder sidecars are skipped to
+	// avoid name collisions and noise. Failures here are non-fatal — the audio
+	// is already placed and a missing cover must not block the import.
+	carryRootSidecars(ctx, mode, srcRoot, destDir, reserved)
+	return nil
+}
+
+// placeFlattened copies or hardlinks a single track to dst.
+func placeFlattened(ctx context.Context, mode, src, dst string) error {
+	switch mode {
+	case "hardlink":
+		return HardlinkFile(src, dst)
+	default: // "copy" — guarded by flattenAudiobookDir
+		return CopyFileCtx(ctx, src, dst)
+	}
+}
+
+// carryRootSidecars copies non-audio regular files that live directly at the
+// source root into destDir, skipping symlinks, directories, audio files
+// (already flattened) and any name already reserved by a generated Part. It is
+// best-effort: individual failures are swallowed so a missing sidecar never
+// fails an otherwise-successful audio import.
+func carryRootSidecars(ctx context.Context, mode, srcRoot, destDir string, reserved map[string]struct{}) {
+	entries, err := os.ReadDir(srcRoot)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() || e.Type()&os.ModeSymlink != 0 || !e.Type().IsRegular() {
+			continue
+		}
+		name := e.Name()
+		if audioFlattenExtensions[strings.ToLower(filepath.Ext(name))] {
+			continue
+		}
+		if _, taken := reserved[name]; taken {
+			continue
+		}
+		dst := filepath.Join(destDir, name)
+		if _, statErr := os.Stat(dst); statErr == nil {
+			continue // never overwrite an existing destination file
+		}
+		src := filepath.Join(srcRoot, name)
+		if mode == "hardlink" {
+			_ = HardlinkFile(src, dst)
+		} else {
+			_ = CopyFileCtx(ctx, src, dst)
+		}
+	}
+}

--- a/internal/importer/flatten_test.go
+++ b/internal/importer/flatten_test.go
@@ -1,0 +1,224 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractDiscNumber(t *testing.T) {
+	cases := []struct {
+		relDir string
+		want   int
+	}{
+		{"Disc 1", 1},
+		{"Disc 01", 1},
+		{"Disk 02", 2},
+		{"CD 3", 3},
+		{"CD3", 3},
+		{"Part 4", 4},
+		{"Volume 2", 2},
+		{"Vol. 3", 3},
+		{"Disc 1 - The Beginning", 1},
+		{filepath.Join("Audiobook", "Disc 2"), 2},
+		{"", 0},
+		{".", 0},
+		{"NotADisc", 0},
+		{"Bonus", 0},
+	}
+	for _, tc := range cases {
+		if got := extractDiscNumber(tc.relDir); got != tc.want {
+			t.Errorf("extractDiscNumber(%q) = %d, want %d", tc.relDir, got, tc.want)
+		}
+	}
+}
+
+func TestExtractTrackNumber(t *testing.T) {
+	cases := []struct {
+		base string
+		want int
+	}{
+		{"Track 01.mp3", 1},
+		{"Track 12.mp3", 12},
+		{"Chapter 02.mp3", 2},
+		{"01 - Title.mp3", 1},
+		{"05 Title.flac", 5},
+		{"1-05 - Title.mp3", 5},
+		{"1.05 Title.m4a", 5},
+		{"cover.jpg", 0},
+		{"book.m4b", 0},
+		{"Title Only.mp3", 0},
+	}
+	for _, tc := range cases {
+		if got := extractTrackNumber(tc.base); got != tc.want {
+			t.Errorf("extractTrackNumber(%q) = %d, want %d", tc.base, got, tc.want)
+		}
+	}
+}
+
+// buildMultiDiscTree creates Disc 1/Disc 2 folders with tracks (in a
+// deliberately non-sorted directory write order) plus a root cover.jpg.
+func buildMultiDiscTree(t *testing.T) (root string) {
+	t.Helper()
+	root = t.TempDir()
+	mk := func(rel, content string) {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk(filepath.Join("Disc 2", "Track 01.mp3"), "d2t1")
+	mk(filepath.Join("Disc 2", "Track 02.mp3"), "d2t2")
+	mk(filepath.Join("Disc 1", "Track 02.mp3"), "d1t2")
+	mk(filepath.Join("Disc 1", "Track 01.mp3"), "d1t1")
+	mk("cover.jpg", "img")
+	return root
+}
+
+func TestIsMultiDiscAudiobook(t *testing.T) {
+	multi := buildMultiDiscTree(t)
+	if !isMultiDiscAudiobook(multi) {
+		t.Error("multi-disc tree not detected as multi-disc")
+	}
+
+	// Single disc folder → not multi-disc.
+	single := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(single, "Disc 1"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	for _, n := range []string{"Track 01.mp3", "Track 02.mp3"} {
+		if err := os.WriteFile(filepath.Join(single, "Disc 1", n), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if isMultiDiscAudiobook(single) {
+		t.Error("single-disc tree wrongly detected as multi-disc")
+	}
+
+	// Flat folder, no disc dirs → not multi-disc.
+	flat := t.TempDir()
+	for _, n := range []string{"01.mp3", "02.mp3"} {
+		if err := os.WriteFile(filepath.Join(flat, n), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if isMultiDiscAudiobook(flat) {
+		t.Error("flat folder wrongly detected as multi-disc")
+	}
+}
+
+func TestCollectFlattenTracksOrdering(t *testing.T) {
+	root := buildMultiDiscTree(t)
+	tracks, err := collectFlattenTracks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRel := []string{
+		filepath.Join("Disc 1", "Track 01.mp3"),
+		filepath.Join("Disc 1", "Track 02.mp3"),
+		filepath.Join("Disc 2", "Track 01.mp3"),
+		filepath.Join("Disc 2", "Track 02.mp3"),
+	}
+	if len(tracks) != len(wantRel) {
+		t.Fatalf("got %d tracks, want %d", len(tracks), len(wantRel))
+	}
+	for i, tr := range tracks {
+		if tr.rel != wantRel[i] {
+			t.Errorf("track[%d] rel = %q, want %q", i, tr.rel, wantRel[i])
+		}
+	}
+}
+
+// assertFlatResult checks that destDir contains exactly the expected flat
+// Part-named files with the expected contents in order, plus the cover sidecar.
+func assertFlatResult(t *testing.T, destDir string) {
+	t.Helper()
+	want := map[string]string{
+		"Part 001.mp3": "d1t1",
+		"Part 002.mp3": "d1t2",
+		"Part 003.mp3": "d2t1",
+		"Part 004.mp3": "d2t2",
+		"cover.jpg":    "img",
+	}
+	for name, content := range want {
+		got, err := os.ReadFile(filepath.Join(destDir, name))
+		if err != nil {
+			t.Errorf("missing %s: %v", name, err)
+			continue
+		}
+		if string(got) != content {
+			t.Errorf("%s content = %q, want %q", name, got, content)
+		}
+	}
+	// No nested disc directories should remain in the flat output.
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			t.Errorf("flat dest contains a subdirectory %q — flattening should produce a flat folder", e.Name())
+		}
+	}
+	if len(entries) != len(want) {
+		t.Errorf("flat dest has %d entries, want %d", len(entries), len(want))
+	}
+}
+
+func TestFlattenAudiobookDir_Copy(t *testing.T) {
+	src := buildMultiDiscTree(t)
+	dst := filepath.Join(t.TempDir(), "Author", "Book (2020)")
+
+	if err := flattenAudiobookDir(context.Background(), "copy", src, dst); err != nil {
+		t.Fatalf("flattenAudiobookDir copy: %v", err)
+	}
+	assertFlatResult(t, dst)
+
+	// Copy must leave the source fully intact (seeding preserved) and produce
+	// an independent inode (not a hard link).
+	srcFile := filepath.Join(src, "Disc 1", "Track 01.mp3")
+	if _, err := os.Stat(srcFile); err != nil {
+		t.Errorf("source track removed after copy: %v", err)
+	}
+	si, _ := os.Stat(srcFile)
+	di, _ := os.Stat(filepath.Join(dst, "Part 001.mp3"))
+	if os.SameFile(si, di) {
+		t.Error("copy mode produced a hardlink (same inode) — expected an independent copy")
+	}
+}
+
+func TestFlattenAudiobookDir_Hardlink(t *testing.T) {
+	src := buildMultiDiscTree(t)
+	dst := filepath.Join(t.TempDir(), "Author", "Book (2020)")
+
+	if err := flattenAudiobookDir(context.Background(), "hardlink", src, dst); err != nil {
+		t.Fatalf("flattenAudiobookDir hardlink: %v", err)
+	}
+	assertFlatResult(t, dst)
+
+	// Hardlink must share inodes with the source and leave the source intact.
+	srcFile := filepath.Join(src, "Disc 1", "Track 01.mp3")
+	si, err := os.Stat(srcFile)
+	if err != nil {
+		t.Fatalf("source track removed after hardlink: %v", err)
+	}
+	di, _ := os.Stat(filepath.Join(dst, "Part 001.mp3"))
+	if !os.SameFile(si, di) {
+		t.Error("hardlink mode did not share an inode with the source")
+	}
+}
+
+func TestFlattenAudiobookDir_RejectsMoveMode(t *testing.T) {
+	src := buildMultiDiscTree(t)
+	dst := filepath.Join(t.TempDir(), "out")
+	if err := flattenAudiobookDir(context.Background(), "move", src, dst); err == nil {
+		t.Error("flattenAudiobookDir must reject move mode")
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Error("rejected mode must not create the destination")
+	}
+}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -915,13 +915,29 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 				return
 			}
 			if srcInfo.IsDir() {
-				switch mode {
-				case "hardlink":
-					dirErr = HardlinkDir(audiobookSource, destDir)
-				case "copy":
-					dirErr = CopyDirCtx(importCtx, audiobookSource, destDir)
-				default:
-					dirErr = MoveDirCtx(importCtx, audiobookSource, destDir)
+				// Multi-disc flattening (#886): when enabled AND the resolved
+				// mode is copy/hardlink (NEVER move — the source must keep
+				// seeding and flattening renames files) AND the source is a
+				// multi-disc audiobook, place every track flat into destDir as
+				// "Part 001.ext", … instead of mirroring the disc-folder tree.
+				// The mode restriction is enforced here in the backend even if a
+				// stale UI setting is enabled, because import mode is resolved at
+				// import time. Falls through to the normal dir placement when the
+				// source is single-disc.
+				if (mode == "copy" || mode == "hardlink") &&
+					s.flattenMultiDiscEnabled(ctx) &&
+					isMultiDiscAudiobook(audiobookSource) {
+					slog.Info("flattening multi-disc audiobook", "src", audiobookSource, "dst", destDir, "mode", mode)
+					dirErr = flattenAudiobookDir(importCtx, mode, audiobookSource, destDir)
+				} else {
+					switch mode {
+					case "hardlink":
+						dirErr = HardlinkDir(audiobookSource, destDir)
+					case "copy":
+						dirErr = CopyDirCtx(importCtx, audiobookSource, destDir)
+					default:
+						dirErr = MoveDirCtx(importCtx, audiobookSource, destDir)
+					}
 				}
 			} else {
 				if err := os.MkdirAll(destDir, 0o750); err != nil {

--- a/internal/importer/scanner_flatten_test.go
+++ b/internal/importer/scanner_flatten_test.go
@@ -1,0 +1,175 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// flattenScannerFixture extends dataLossFixture: it flips the seeded book to an
+// audiobook, sets the import mode, optionally enables flattening, and builds a
+// multi-disc download tree. It returns the Scanner, download, and the download
+// path to import.
+func flattenScannerFixture(t *testing.T, importMode string, flatten bool) (*Scanner, *models.Download, string) {
+	t.Helper()
+	libraryDir := t.TempDir()
+	s, dl, _, bookRepo, ctx := dataLossFixture(t, libraryDir, importMode)
+
+	book, err := bookRepo.GetByID(ctx, *dl.BookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	book.MediaType = models.MediaTypeAudiobook
+	if err := bookRepo.Update(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	if flatten {
+		if err := s.settings.Set(ctx, "import.audiobook.flatten_multi_disc", "true"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	download := buildMultiDiscDownload(t)
+	return s, dl, download
+}
+
+// buildMultiDiscDownload creates a download folder with two disc subfolders and
+// a cover, returning the folder path.
+func buildMultiDiscDownload(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	mk := func(rel, content string) {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk(filepath.Join("Disc 1", "Track 01.mp3"), "d1t1")
+	mk(filepath.Join("Disc 1", "Track 02.mp3"), "d1t2")
+	mk(filepath.Join("Disc 2", "Track 01.mp3"), "d2t1")
+	mk(filepath.Join("Disc 2", "Track 02.mp3"), "d2t2")
+	mk("cover.jpg", "img")
+	return root
+}
+
+// importedAudiobookDir returns the on-disk audiobook destination recorded for
+// the book after an import, or fails the test.
+func importedAudiobookDir(t *testing.T, s *Scanner) string {
+	t.Helper()
+	// effectiveAudiobookDir falls back to libraryDir (set as audiobookDir by
+	// NewScanner) → AudiobookDestDir = libraryDir/Author A/Title T. There is no
+	// year, so the template yields "Title T ()". Resolve via the renamer to stay
+	// in lockstep with production naming.
+	author := &models.Author{Name: "Author A"}
+	book := &models.Book{Title: "Title T"}
+	dest, err := s.renamer.AudiobookDestDir(s.audiobookDir, author, book, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dest
+}
+
+func TestScannerFlatten_CopyMode(t *testing.T) {
+	s, dl, downloadPath := flattenScannerFixture(t, "copy", true)
+	ctx := context.Background()
+
+	s.tryImportInternal(ctx, dl, downloadPath, "", "", "", nil, nil)
+
+	dest := importedAudiobookDir(t, s)
+	assertFlatResult(t, dest)
+
+	// Source must survive (seeding preserved).
+	if _, err := os.Stat(filepath.Join(downloadPath, "Disc 1", "Track 01.mp3")); err != nil {
+		t.Errorf("copy mode removed the source: %v", err)
+	}
+}
+
+func TestScannerFlatten_HardlinkMode(t *testing.T) {
+	s, dl, downloadPath := flattenScannerFixture(t, "hardlink", true)
+	ctx := context.Background()
+
+	s.tryImportInternal(ctx, dl, downloadPath, "", "", "", nil, nil)
+
+	dest := importedAudiobookDir(t, s)
+	assertFlatResult(t, dest)
+
+	si, err := os.Stat(filepath.Join(downloadPath, "Disc 1", "Track 01.mp3"))
+	if err != nil {
+		t.Fatalf("hardlink mode removed the source: %v", err)
+	}
+	di, _ := os.Stat(filepath.Join(dest, "Part 001.mp3"))
+	if !os.SameFile(si, di) {
+		t.Error("hardlink scanner import did not share an inode with the source")
+	}
+}
+
+// TestScannerFlatten_MoveModeNeverFlattens asserts the backend enforces the
+// copy/hardlink restriction: with import mode "move" the multi-disc folder is
+// moved whole (disc subfolders preserved), never flattened, even if the setting
+// is on.
+func TestScannerFlatten_MoveModeNeverFlattens(t *testing.T) {
+	s, dl, downloadPath := flattenScannerFixture(t, "move", true)
+	ctx := context.Background()
+
+	s.tryImportInternal(ctx, dl, downloadPath, "", "", "", nil, nil)
+
+	dest := importedAudiobookDir(t, s)
+	// Disc subfolders must be preserved (no flattening in move mode).
+	if _, err := os.Stat(filepath.Join(dest, "Disc 1", "Track 01.mp3")); err != nil {
+		t.Errorf("move mode must preserve disc-folder layout, missing Disc 1/Track 01.mp3: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "Part 001.mp3")); !os.IsNotExist(err) {
+		t.Error("move mode must NOT produce flattened Part 001.mp3")
+	}
+}
+
+// TestScannerFlatten_SettingOffPreservesLayout asserts that with the setting
+// off, a multi-disc audiobook keeps its disc-folder layout in copy mode (no
+// behaviour change for users who don't opt in).
+func TestScannerFlatten_SettingOffPreservesLayout(t *testing.T) {
+	s, dl, downloadPath := flattenScannerFixture(t, "copy", false)
+	ctx := context.Background()
+
+	s.tryImportInternal(ctx, dl, downloadPath, "", "", "", nil, nil)
+
+	dest := importedAudiobookDir(t, s)
+	if _, err := os.Stat(filepath.Join(dest, "Disc 1", "Track 01.mp3")); err != nil {
+		t.Errorf("setting-off copy must preserve disc-folder layout: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "Part 001.mp3")); !os.IsNotExist(err) {
+		t.Error("setting-off must NOT flatten")
+	}
+}
+
+// TestScannerFlatten_SingleDiscUnchanged asserts a single-disc audiobook is not
+// flattened even when the setting is on (only multi-disc shapes are targeted).
+func TestScannerFlatten_SingleDiscUnchanged(t *testing.T) {
+	s, dl, _ := flattenScannerFixture(t, "copy", true)
+	ctx := context.Background()
+
+	// Replace the download with a single-disc tree.
+	single := t.TempDir()
+	for _, n := range []string{"Track 01.mp3", "Track 02.mp3"} {
+		dir := filepath.Join(single, "Disc 1")
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s.tryImportInternal(ctx, dl, single, "", "", "", nil, nil)
+
+	dest := importedAudiobookDir(t, s)
+	if _, err := os.Stat(filepath.Join(dest, "Disc 1", "Track 01.mp3")); err != nil {
+		t.Errorf("single-disc must preserve layout even with flatten on: %v", err)
+	}
+}

--- a/internal/importer/scanner_handoff.go
+++ b/internal/importer/scanner_handoff.go
@@ -71,6 +71,23 @@ func (s *Scanner) importMode(ctx context.Context, src, dst string) string {
 	return "copy"
 }
 
+// flattenMultiDiscEnabled reads the "import.audiobook.flatten_multi_disc"
+// setting (#886). It returns true only when the value is explicitly "true";
+// the feature is opt-in and OFF by default so existing audiobook imports keep
+// preserving the download's internal layout. The key is read as a string
+// literal to avoid an import cycle with the api package; keep it in sync with
+// api.SettingImportAudiobookFlattenMultiDisc.
+func (s *Scanner) flattenMultiDiscEnabled(ctx context.Context) bool {
+	if s.settings == nil {
+		return false
+	}
+	setting, err := s.settings.Get(ctx, "import.audiobook.flatten_multi_disc")
+	if err != nil || setting == nil {
+		return false
+	}
+	return setting.Value == "true"
+}
+
 // pushToCWA copies the just-imported file into the directory watched by a
 // sibling Calibre-Web-Automated container, when the cwa.ingest_path setting
 // is configured. CWA's auto-ingest deletes whatever lands in that folder

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -544,6 +544,8 @@
       "recommendationsLabel": "Enable book recommendations",
       "recommendationsHint": "Analyse your library to suggest new books on the Discover page. Runs locally every 24 hours — no data leaves your server.",
       "fileNaming": "File Naming",
+      "flattenMultiDisc": "Flatten multi-disc audiobooks",
+      "flattenMultiDiscHint": "When a completed audiobook download has multiple disc folders (Disc 1, CD 2, …), place its tracks into one flat folder named Part 001, Part 002, … so audiobook players sort them correctly. Available only in Copy or Hardlink mode; the source is never moved and torrents keep seeding. Single-disc audiobooks are unaffected.",
       "dropFolder": "Drop folder",
       "dropFolderHint": "Optional. In External mode, Bindery renames each finished download into this folder for a watch-folder tool (Calibre-Web-Automated, Storyteller) to ingest, instead of leaving it in the download dir. The source is never moved, so torrents keep seeding. Bindery still reconciles the managed copy on the next library scan. Leave empty to hand off in place.",
       "dropLayout": "Layout",

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -324,6 +324,30 @@ export default function GeneralTab() {
               ))}
             </div>
           </div>
+          {['copy', 'hardlink'].includes(settings['import.mode'] ?? 'move') && (
+            <div className="border-t border-slate-200 dark:border-zinc-800 pt-3">
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="mt-0.5"
+                  checked={settings['import.audiobook.flatten_multi_disc'] === 'true'}
+                  onChange={async e => {
+                    const v = e.target.checked ? 'true' : 'false'
+                    setSettings(s => ({ ...s, 'import.audiobook.flatten_multi_disc': v }))
+                    await api.setSetting('import.audiobook.flatten_multi_disc', v).catch(console.error)
+                  }}
+                />
+                <span>
+                  <span className="text-xs font-medium text-slate-700 dark:text-zinc-300">
+                    {t('settings.general.flattenMultiDisc', 'Flatten multi-disc audiobooks')}
+                  </span>
+                  <span className="block text-xs text-slate-600 dark:text-zinc-500">
+                    {t('settings.general.flattenMultiDiscHint', 'When a completed audiobook download has multiple disc folders (Disc 1, CD 2, …), place its tracks into one flat folder named Part 001, Part 002, … so audiobook players sort them correctly. Available only in Copy or Hardlink mode; the source is never moved and torrents keep seeding. Single-disc audiobooks are unaffected.')}
+                  </span>
+                </span>
+              </label>
+            </div>
+          )}
           {(settings['import.mode'] ?? 'move') === 'external' && (
             <div className="border-t border-slate-200 dark:border-zinc-800 pt-3 space-y-3">
               <div>


### PR DESCRIPTION
## Problem

Multi-disc audiobook releases land as nested disc folders with repeated track names (`Disc 1/Track 01.mp3`, `Disc 2/Track 01.mp3`, …). Audiobook players that sort disc folders independently, or treat repeated `Track 01` names as duplicates, play them in the wrong order. Bindery previously preserved the download's internal layout verbatim, with no way to normalise it. Closes #886.

## Approach

Opt-in, default-off setting `import.audiobook.flatten_multi_disc`. When enabled **and** the resolved import mode is `copy` or `hardlink`, a completed audiobook whose audio files span two or more disc directories is placed into one flat destination as `Part 001.ext`, `Part 002.ext`, … in disc-then-track order.

- New `internal/importer/flatten.go`: disc detection from directory names (`Disc 1`, `Disk 02`, `CD 3`, `CD3`, `Part 4`, `Vol. 2`), track detection from file names (`Track 01`, `Chapter 02`, leading `01 - Title`, combined `1-05`), deterministic sort by `(disc, track, rel)`, and `flattenAudiobookDir` which copies/hardlinks each track and carries root-level sidecars (cover art, cue sheets) across without overwriting.
- Wired into the audiobook directory branch of `tryImportInternal`; the existing `MoveDir`/`CopyDir`/`HardlinkDir` placement is the fallback for single-disc / setting-off.
- The **copy/hardlink-only restriction is enforced backend-side** at import time (`flattenAudiobookDir` rejects any other mode, and the call site gates on `mode == copy|hardlink`), so a stale UI setting can never flatten in move/external mode. The source is never moved or renamed — seeding is preserved.
- Reuses `CopyFileCtx`/`HardlinkFile`; `Part NNN` names have no separators so containment holds. Symlinks are never followed.
- UI: copy/hardlink-only checkbox in Settings → General → File Naming, with i18n. Setting constant added in `api`. Docs in the Storage & Hardlinks wiki.

The existing `alreadyImportedFormat` idempotency guard runs before the flatten branch, so a crashed/retried import does not produce a duplicate `Title (2)` folder.

## Tests

- Detector unit tests: `extractDiscNumber`, `extractTrackNumber`, `isMultiDiscAudiobook` (multi vs single vs flat), `collectFlattenTracks` ordering.
- `flattenAudiobookDir` for copy (independent inodes, source intact), hardlink (shared inode, source intact), and move-mode rejection (no destination created).
- Scanner integration via `tryImportInternal`: copy and hardlink flatten to `Part NNN` with sidecar carried; move mode never flattens; setting-off preserves disc-folder layout; single-disc preserved even with the setting on.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `golangci-lint run ./internal/importer/ ./internal/api/` → 0 issues
- `go test ./internal/importer/ ./internal/api/` passes
- `tsc --noEmit` and `eslint` on the changed UI clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)