### PR TITLE
feat(indexers): auto-populate per-indexer seed-ratio from Prowlarr seedCriteria

### DIFF
--- a/changelog.d/1065-prowlarr-seed-ratio.md
+++ b/changelog.d/1065-prowlarr-seed-ratio.md
@@ -1,0 +1,3 @@
+### Added
+
+- Indexers synced from Prowlarr now auto-populate their per-indexer seed-ratio override from Prowlarr's `seedCriteria.seedRatio`, unless you've set the ratio yourself (your value always wins).

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -118,6 +118,13 @@ func (h *IndexerHandler) Create(w http.ResponseWriter, r *http.Request) {
 		idx.Categories = []int{7000, 7020, 3030}
 	}
 
+	// A seed-ratio override supplied on a manually-created indexer is a user
+	// choice (#1065). Manual indexers carry no Prowlarr ID so the syncer never
+	// touches them, but recording the provenance keeps the field consistent.
+	if idx.SeedRatio != nil {
+		idx.SeedRatioSource = models.SeedRatioSourceUser
+	}
+
 	// Check for duplicate URL
 	existing, _ := h.indexers.List(r.Context())
 	for _, e := range existing {
@@ -157,6 +164,11 @@ func (h *IndexerHandler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	idx.ID = id
+	// A user editing the indexer takes ownership of the seed-ratio override, so
+	// the Prowlarr syncer (#1065) will not overwrite it on the next sync. This
+	// holds even when the user clears the value to null ("no override") or sets
+	// the -1 unlimited sentinel — the explicit choice sticks.
+	idx.SeedRatioSource = models.SeedRatioSourceUser
 	if err := h.indexers.Update(r.Context(), &idx); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return

--- a/internal/db/extra_repos_test.go
+++ b/internal/db/extra_repos_test.go
@@ -806,6 +806,55 @@ func TestIndexerRepo_SeedRatio(t *testing.T) {
 	}
 }
 
+// TestIndexerRepo_SeedRatioSource round-trips the seed-ratio provenance column
+// (#1065) so the Prowlarr syncer can tell user-owned overrides from
+// auto-populated ones.
+func TestIndexerRepo_SeedRatioSource(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewIndexerRepo(database)
+
+	ratio := 1.5
+	idx := &models.Indexer{
+		Name: "Sourced", Type: "torznab", URL: "https://example.com/api",
+		APIKey: "k", Categories: []int{7020}, Priority: 1, Enabled: true,
+		SeedRatio: &ratio, SeedRatioSource: models.SeedRatioSourceProwlarr,
+	}
+	if err := repo.Create(ctx, idx); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := repo.GetByID(ctx, idx.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.SeedRatioSource != models.SeedRatioSourceProwlarr {
+		t.Errorf("SeedRatioSource after create: want %q, got %q", models.SeedRatioSourceProwlarr, got.SeedRatioSource)
+	}
+
+	got.SeedRatioSource = models.SeedRatioSourceUser
+	if err := repo.Update(ctx, got); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, _ = repo.GetByID(ctx, idx.ID)
+	if got.SeedRatioSource != models.SeedRatioSourceUser {
+		t.Errorf("SeedRatioSource after update: want %q, got %q", models.SeedRatioSourceUser, got.SeedRatioSource)
+	}
+
+	// A freshly created indexer with no source defaults to unset.
+	plain := &models.Indexer{Name: "Plain", Type: "torznab", URL: "https://example.com/p", APIKey: "k", Categories: []int{7020}}
+	if err := repo.Create(ctx, plain); err != nil {
+		t.Fatalf("Create plain: %v", err)
+	}
+	got, _ = repo.GetByID(ctx, plain.ID)
+	if got.SeedRatioSource != models.SeedRatioSourceUnset {
+		t.Errorf("SeedRatioSource default: want unset, got %q", got.SeedRatioSource)
+	}
+}
+
 // TestIndexerRepo_UpdateAPIKeyByProwlarrInstance verifies that rotating the
 // Prowlarr instance's API key via this helper rewrites only the rows belonging
 // to that instance, leaving manual indexers and indexers from a different

--- a/internal/db/indexers.go
+++ b/internal/db/indexers.go
@@ -21,7 +21,7 @@ func NewIndexerRepo(db *sql.DB) *IndexerRepo {
 func (r *IndexerRepo) List(ctx context.Context) ([]models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
-		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, created_at, updated_at
+		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at
 		FROM indexers ORDER BY priority`)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (r *IndexerRepo) List(ctx context.Context) ([]models.Indexer, error) {
 func (r *IndexerRepo) GetByID(ctx context.Context, id int64) (*models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
-		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, created_at, updated_at
+		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at
 		FROM indexers WHERE id=?`, id)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (r *IndexerRepo) GetByID(ctx context.Context, id int64) (*models.Indexer, e
 func (r *IndexerRepo) ListByProwlarrInstance(ctx context.Context, instanceID int64) ([]models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
-		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, created_at, updated_at
+		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at
 		FROM indexers WHERE prowlarr_instance_id=?`, instanceID)
 	if err != nil {
 		return nil, err
@@ -87,11 +87,11 @@ func (r *IndexerRepo) Create(ctx context.Context, idx *models.Indexer) error {
 	}
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO indexers (name, type, url, api_key, categories, priority, enabled, supports_search,
-		                      prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		                      prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		idx.Name, idx.Type, idx.URL, idx.APIKey, string(catsJSON),
 		idx.Priority, idx.Enabled, idx.SupportsSearch,
-		idx.ProwlarrInstanceID, idx.ProwlarrIndexerID, idx.SeedRatio, now, now)
+		idx.ProwlarrInstanceID, idx.ProwlarrIndexerID, idx.SeedRatio, idx.SeedRatioSource, now, now)
 	if err != nil {
 		return fmt.Errorf("create indexer: %w", err)
 	}
@@ -113,10 +113,10 @@ func (r *IndexerRepo) Update(ctx context.Context, idx *models.Indexer) error {
 	}
 	_, err = r.db.ExecContext(ctx, `
 		UPDATE indexers SET name=?, type=?, url=?, api_key=?, categories=?, priority=?,
-		                    enabled=?, supports_search=?, seed_ratio=?, updated_at=?
+		                    enabled=?, supports_search=?, seed_ratio=?, seed_ratio_source=?, updated_at=?
 		WHERE id=?`,
 		idx.Name, idx.Type, idx.URL, idx.APIKey, string(catsJSON),
-		idx.Priority, idx.Enabled, idx.SupportsSearch, idx.SeedRatio, now, idx.ID)
+		idx.Priority, idx.Enabled, idx.SupportsSearch, idx.SeedRatio, idx.SeedRatioSource, now, idx.ID)
 	return err
 }
 
@@ -157,7 +157,7 @@ func scanIndexer(s indexerScanner) (models.Indexer, error) {
 	if err := s.Scan(
 		&idx.ID, &idx.Name, &idx.Type, &idx.URL, &idx.APIKey,
 		&catsJSON, &idx.Priority, &enabled, &supportsSearch,
-		&idx.ProwlarrInstanceID, &idx.ProwlarrIndexerID, &idx.SeedRatio,
+		&idx.ProwlarrInstanceID, &idx.ProwlarrIndexerID, &idx.SeedRatio, &idx.SeedRatioSource,
 		&idx.CreatedAt, &idx.UpdatedAt,
 	); err != nil {
 		return idx, err

--- a/internal/db/migrations/054_indexer_seed_ratio_source.sql
+++ b/internal/db/migrations/054_indexer_seed_ratio_source.sql
@@ -1,0 +1,20 @@
+-- +migrate Up
+-- Track the provenance of an indexer's seed_ratio so the Prowlarr syncer can
+-- auto-populate the value (#1065) without ever clobbering a choice the user made
+-- explicitly. Values:
+--   ''         unset / never touched, so Prowlarr may fill it.
+--   'prowlarr' auto-populated from Prowlarr's seedCriteria.seedRatio, and a
+--              later Prowlarr change may refresh it.
+--   'user'     the user set, cleared, or toggled it via the UI, so Prowlarr must
+--              not touch seed_ratio again (an explicit clear-to-null sticks).
+-- Existing rows predate auto-population. A row with a non-NULL seed_ratio was
+-- necessarily set by the user (Prowlarr did not write it before this feature),
+-- so it is backfilled to 'user' to protect those overrides. NULL rows stay
+-- unset and remain eligible for Prowlarr auto-population.
+ALTER TABLE indexers ADD COLUMN seed_ratio_source TEXT NOT NULL DEFAULT '';
+
+UPDATE indexers SET seed_ratio_source = 'user' WHERE seed_ratio IS NOT NULL;
+
+-- +migrate Down
+
+ALTER TABLE indexers DROP COLUMN seed_ratio_source;

--- a/internal/models/indexer.go
+++ b/internal/models/indexer.go
@@ -19,7 +19,26 @@ type Indexer struct {
 	// keeps its global rule); an explicit -1 is the unlimited sentinel
 	// (Prowlarr/qBittorrent convention). The downloader adapters translate the
 	// value into each client's own API shape.
-	SeedRatio *float64  `json:"seedRatio,omitempty"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	SeedRatio *float64 `json:"seedRatio,omitempty"`
+	// SeedRatioSource records who last wrote SeedRatio, so the Prowlarr syncer
+	// (#1065) can auto-populate the ratio without clobbering an explicit user
+	// choice. See the SeedRatioSource* constants. The empty string means "unset"
+	// and is eligible for Prowlarr auto-population.
+	SeedRatioSource string    `json:"seedRatioSource,omitempty"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
 }
+
+// Provenance values for Indexer.SeedRatioSource.
+const (
+	// SeedRatioSourceUnset means no one has set a seed-ratio override; the
+	// Prowlarr syncer may auto-populate it.
+	SeedRatioSourceUnset = ""
+	// SeedRatioSourceProwlarr means the override was auto-populated from
+	// Prowlarr's per-indexer seedCriteria.seedRatio. A later Prowlarr change may
+	// refresh it.
+	SeedRatioSourceProwlarr = "prowlarr"
+	// SeedRatioSourceUser means the user set, cleared, or toggled the override
+	// via the UI. The Prowlarr syncer must never overwrite a user-owned value.
+	SeedRatioSourceUser = "user"
+)

--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -48,6 +48,41 @@ type remoteIndexer struct {
 	Capabilities   struct {
 		Categories []remoteCategory `json:"categories"`
 	} `json:"capabilities"`
+	// Fields carries the indexer's flattened settings. For torrent indexers
+	// Prowlarr exposes the per-indexer seed criteria here under the
+	// "torrentBaseSettings.seedRatio" key (the camelCased property path of
+	// IndexerTorrentBaseSettings.SeedRatio).
+	Fields []remoteField `json:"fields"`
+}
+
+// prowlarrSeedRatioField is the field name Prowlarr serialises for the
+// per-indexer seed-ratio setting on a torrent indexer. It is the camelCased
+// flattening of ITorrentIndexerSettings.TorrentBaseSettings.SeedRatio.
+const prowlarrSeedRatioField = "torrentBaseSettings.seedRatio"
+
+// seedRatio returns the per-indexer seed ratio Prowlarr has configured for this
+// indexer, or nil when none is set. Prowlarr models the value as a nullable
+// double and its own validator rejects anything <= 0, so a present, positive
+// value is the only "configured ratio" shape; null / missing / non-positive all
+// collapse to "no ratio".
+func (ri remoteIndexer) seedRatio() *float64 {
+	for _, f := range ri.Fields {
+		if f.Name != prowlarrSeedRatioField {
+			continue
+		}
+		if len(f.Value) == 0 || string(f.Value) == "null" {
+			return nil
+		}
+		var v float64
+		if err := json.Unmarshal(f.Value, &v); err != nil {
+			return nil
+		}
+		if v <= 0 {
+			return nil
+		}
+		return &v
+	}
+	return nil
 }
 
 type remoteCategory struct {
@@ -84,6 +119,10 @@ type IndexerInfo struct {
 	APIKey         string
 	SupportsSearch bool
 	Categories     []int
+	// SeedRatio is the per-indexer seed ratio Prowlarr has configured, or nil
+	// when Prowlarr has none. Used to auto-populate Bindery's local seed-ratio
+	// override (#1065) for torrent indexers that lack an explicit override.
+	SeedRatio *float64
 }
 
 // FetchIndexers returns all indexers configured in Prowlarr.
@@ -134,6 +173,7 @@ func (c *Client) FetchIndexers(ctx context.Context) ([]IndexerInfo, error) {
 			APIKey:         c.apiKey,
 			SupportsSearch: ri.SupportsSearch,
 			Categories:     cats,
+			SeedRatio:      ri.seedRatio(),
 		})
 	}
 	return infos, nil

--- a/internal/prowlarr/seed_ratio_test.go
+++ b/internal/prowlarr/seed_ratio_test.go
@@ -1,0 +1,202 @@
+package prowlarr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func float64Ptr(v float64) *float64 { return &v }
+
+// TestFetchIndexers_ParsesSeedRatio covers how a Prowlarr torrent indexer's
+// torrentBaseSettings.seedRatio field maps onto IndexerInfo.SeedRatio.
+func TestFetchIndexers_ParsesSeedRatio(t *testing.T) {
+	body := `[
+		{"id":1,"name":"HasRatio","protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}],
+		 "fields":[{"name":"torrentBaseSettings.seedRatio","value":2.5}]},
+		{"id":2,"name":"NullRatio","protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}],
+		 "fields":[{"name":"torrentBaseSettings.seedRatio","value":null}]},
+		{"id":3,"name":"NoField","protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}],
+		 "fields":[{"name":"torrentBaseSettings.appMinimumSeeders","value":5}]},
+		{"id":4,"name":"ZeroRatio","protocol":"torrent","supportsSearch":true,"categories":[{"id":7020}],
+		 "fields":[{"name":"torrentBaseSettings.seedRatio","value":0}]},
+		{"id":5,"name":"Usenet","protocol":"usenet","supportsSearch":true,"categories":[{"id":7020}]}
+	]`
+	srv := prowlarrStub(t, body)
+	defer srv.Close()
+
+	infos, err := New(srv.URL, "k").FetchIndexers(context.Background())
+	if err != nil {
+		t.Fatalf("FetchIndexers: %v", err)
+	}
+	byName := map[string]*float64{}
+	for _, in := range infos {
+		byName[in.Name] = in.SeedRatio
+	}
+
+	if got := byName["HasRatio"]; got == nil || *got != 2.5 {
+		t.Errorf("HasRatio SeedRatio = %v, want 2.5", got)
+	}
+	for _, name := range []string{"NullRatio", "NoField", "ZeroRatio", "Usenet"} {
+		if got := byName[name]; got != nil {
+			t.Errorf("%s SeedRatio = %v, want nil", name, got)
+		}
+	}
+}
+
+func TestApplyProwlarrSeedRatio(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          models.Indexer
+		prowlarr    *float64
+		wantChanged bool
+		wantRatio   *float64
+		wantSource  string
+	}{
+		{
+			name:        "unset row gets Prowlarr ratio",
+			in:          models.Indexer{},
+			prowlarr:    float64Ptr(1.5),
+			wantChanged: true,
+			wantRatio:   float64Ptr(1.5),
+			wantSource:  models.SeedRatioSourceProwlarr,
+		},
+		{
+			name:        "user override is never clobbered by a Prowlarr value",
+			in:          models.Indexer{SeedRatio: float64Ptr(3), SeedRatioSource: models.SeedRatioSourceUser},
+			prowlarr:    float64Ptr(1.5),
+			wantChanged: false,
+			wantRatio:   float64Ptr(3),
+			wantSource:  models.SeedRatioSourceUser,
+		},
+		{
+			name:        "user unlimited sentinel is never clobbered",
+			in:          models.Indexer{SeedRatio: float64Ptr(-1), SeedRatioSource: models.SeedRatioSourceUser},
+			prowlarr:    float64Ptr(2),
+			wantChanged: false,
+			wantRatio:   float64Ptr(-1),
+			wantSource:  models.SeedRatioSourceUser,
+		},
+		{
+			name:        "user-cleared (null, source=user) is never re-filled",
+			in:          models.Indexer{SeedRatio: nil, SeedRatioSource: models.SeedRatioSourceUser},
+			prowlarr:    float64Ptr(2),
+			wantChanged: false,
+			wantRatio:   nil,
+			wantSource:  models.SeedRatioSourceUser,
+		},
+		{
+			name:        "prowlarr-sourced value refreshes on a later Prowlarr change",
+			in:          models.Indexer{SeedRatio: float64Ptr(1), SeedRatioSource: models.SeedRatioSourceProwlarr},
+			prowlarr:    float64Ptr(2),
+			wantChanged: true,
+			wantRatio:   float64Ptr(2),
+			wantSource:  models.SeedRatioSourceProwlarr,
+		},
+		{
+			name:        "prowlarr-sourced value cleared when Prowlarr drops its ratio",
+			in:          models.Indexer{SeedRatio: float64Ptr(1), SeedRatioSource: models.SeedRatioSourceProwlarr},
+			prowlarr:    nil,
+			wantChanged: true,
+			wantRatio:   nil,
+			wantSource:  models.SeedRatioSourceUnset,
+		},
+		{
+			name:        "no-op when prowlarr-sourced value is unchanged",
+			in:          models.Indexer{SeedRatio: float64Ptr(2), SeedRatioSource: models.SeedRatioSourceProwlarr},
+			prowlarr:    float64Ptr(2),
+			wantChanged: false,
+			wantRatio:   float64Ptr(2),
+			wantSource:  models.SeedRatioSourceProwlarr,
+		},
+		{
+			name:        "unset row with no Prowlarr ratio stays unset (no-op)",
+			in:          models.Indexer{},
+			prowlarr:    nil,
+			wantChanged: false,
+			wantRatio:   nil,
+			wantSource:  models.SeedRatioSourceUnset,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			idx := tc.in
+			changed := applyProwlarrSeedRatio(&idx, tc.prowlarr)
+			if changed != tc.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tc.wantChanged)
+			}
+			if !float64PtrEqual(idx.SeedRatio, tc.wantRatio) {
+				t.Errorf("SeedRatio = %v, want %v", deref(idx.SeedRatio), deref(tc.wantRatio))
+			}
+			if idx.SeedRatioSource != tc.wantSource {
+				t.Errorf("SeedRatioSource = %q, want %q", idx.SeedRatioSource, tc.wantSource)
+			}
+		})
+	}
+}
+
+func deref(p *float64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+// TestSyncer_AutoPopulatesSeedRatio exercises the full sync path: a new indexer
+// is created with the Prowlarr-sourced ratio recorded as provenance "prowlarr".
+func TestSyncer_AutoPopulatesSeedRatio(t *testing.T) {
+	srv := prowlarrStub(t, `[{"id":7,"name":"RatioTracker","enable":true,"protocol":"torrent","supportsSearch":true,
+		"categories":[{"id":7020}],"fields":[{"name":"torrentBaseSettings.seedRatio","value":1.75}]}]`)
+	defer srv.Close()
+
+	store := &fakeIndexerStore{}
+	if _, err := NewSyncer(New(srv.URL, "k"), store, fakeInstanceStore{}).Sync(context.Background(), 1); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(store.created) != 1 {
+		t.Fatalf("created = %d, want 1", len(store.created))
+	}
+	got := store.created[0]
+	if got.SeedRatio == nil || *got.SeedRatio != 1.75 {
+		t.Errorf("SeedRatio = %v, want 1.75", deref(got.SeedRatio))
+	}
+	if got.SeedRatioSource != models.SeedRatioSourceProwlarr {
+		t.Errorf("SeedRatioSource = %q, want %q", got.SeedRatioSource, models.SeedRatioSourceProwlarr)
+	}
+}
+
+// TestSyncer_DoesNotClobberUserSeedRatio confirms an explicit user override on
+// an existing indexer survives a sync that reports a different Prowlarr ratio.
+func TestSyncer_DoesNotClobberUserSeedRatio(t *testing.T) {
+	pID := 7
+	instID := int64(1)
+	existing := []models.Indexer{{
+		ID:                 10,
+		Name:               "RatioTracker",
+		Type:               "torznab",
+		URL:                "", // forces a different field too, but ratio must stay
+		Categories:         []int{7020},
+		SeedRatio:          float64Ptr(4),
+		SeedRatioSource:    models.SeedRatioSourceUser,
+		ProwlarrInstanceID: &instID,
+		ProwlarrIndexerID:  &pID,
+	}}
+	// Build the matching Torznab URL so only the ratio question is under test.
+	srv := prowlarrStub(t, `[{"id":7,"name":"RatioTracker","enable":true,"protocol":"torrent","supportsSearch":true,
+		"categories":[{"id":7020}],"fields":[{"name":"torrentBaseSettings.seedRatio","value":1.0}]}]`)
+	defer srv.Close()
+	existing[0].URL = srv.URL + "/7/api"
+
+	store := &fakeIndexerStore{existing: existing}
+	if _, err := NewSyncer(New(srv.URL, "k"), store, fakeInstanceStore{}).Sync(context.Background(), 1); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	// Nothing else changed, so the row should not be updated at all.
+	for _, u := range store.updated {
+		if u.SeedRatio == nil || *u.SeedRatio != 4 || u.SeedRatioSource != models.SeedRatioSourceUser {
+			t.Errorf("user override was modified: SeedRatio=%v source=%q",
+				deref(u.SeedRatio), u.SeedRatioSource)
+		}
+	}
+}

--- a/internal/prowlarr/syncer.go
+++ b/internal/prowlarr/syncer.go
@@ -99,12 +99,18 @@ func (s *Syncer) Sync(ctx context.Context, instanceID int64) (SyncResult, error)
 		idxType := indexerTypeForProtocol(ri.Protocol)
 
 		if ex, ok := byProwlarrID[ri.ProwlarrID]; ok {
+			// Auto-populate the seed-ratio override from Prowlarr (#1065), but
+			// only on rows the user has not taken ownership of. An explicit
+			// user value/clear (source="user") always wins and is never touched;
+			// an unset or previously Prowlarr-sourced row tracks Prowlarr's
+			// current ratio so a later Prowlarr change refreshes it.
+			ratioChanged := applyProwlarrSeedRatio(ex, ri.SeedRatio)
 			// Update only if something meaningful changed. Type is included so
 			// rows created by older versions (which hardcoded "torznab" for
 			// every indexer, misrouting usenet grabs to torrent clients) are
 			// corrected on the next sync. Categories are included so that
 			// re-syncing propagates removed parent categories (7000, 3000).
-			if ex.Name != ri.Name || ex.URL != ri.TorznabURL || ex.Type != idxType || !intSliceEqual(ex.Categories, cats) {
+			if ratioChanged || ex.Name != ri.Name || ex.URL != ri.TorznabURL || ex.Type != idxType || !intSliceEqual(ex.Categories, cats) {
 				ex.Name = ri.Name
 				ex.URL = ri.TorznabURL
 				ex.Type = idxType
@@ -133,6 +139,7 @@ func (s *Syncer) Sync(ctx context.Context, instanceID int64) (SyncResult, error)
 			ProwlarrInstanceID: &instID,
 			ProwlarrIndexerID:  &pID,
 		}
+		applyProwlarrSeedRatio(idx, ri.SeedRatio)
 		if err := s.indexers.Create(ctx, idx); err != nil {
 			slog.Warn("prowlarr sync: create indexer failed",
 				"name", ri.Name, "error", err)
@@ -215,6 +222,50 @@ func filterCategoriesForMedia(cats []int) []int {
 		out = append(out, 3030)
 	}
 	return out
+}
+
+// applyProwlarrSeedRatio reconciles an indexer's seed-ratio override with the
+// ratio Prowlarr reports, returning whether the row changed.
+//
+// Precedence (#1065): an explicit user override always wins. A row whose
+// SeedRatioSource is "user" is never touched, so a value the user set, cleared
+// to null, or toggled to the -1 unlimited sentinel sticks across syncs.
+//
+// For an unset row, or one previously auto-populated from Prowlarr, the override
+// tracks Prowlarr's current ratio: a later Prowlarr change refreshes the value,
+// and a ratio removed in Prowlarr clears Bindery's auto-populated value. The
+// nullable + -1-unlimited semantics from #1061 are preserved: Prowlarr only ever
+// reports a positive ratio or none, so auto-population sets a concrete value or
+// nil (download client keeps its global rule) — the -1 sentinel is reserved for
+// the user-driven "unlimited" toggle.
+func applyProwlarrSeedRatio(idx *models.Indexer, prowlarrRatio *float64) bool {
+	if idx.SeedRatioSource == models.SeedRatioSourceUser {
+		return false
+	}
+	if float64PtrEqual(idx.SeedRatio, prowlarrRatio) &&
+		idx.SeedRatioSource == sourceForRatio(prowlarrRatio) {
+		return false
+	}
+	idx.SeedRatio = prowlarrRatio
+	idx.SeedRatioSource = sourceForRatio(prowlarrRatio)
+	return true
+}
+
+// sourceForRatio is the provenance to record when auto-populating from Prowlarr:
+// "prowlarr" when a ratio is present, "unset" when Prowlarr has none (so the row
+// stays eligible for future auto-population).
+func sourceForRatio(ratio *float64) string {
+	if ratio == nil {
+		return models.SeedRatioSourceUnset
+	}
+	return models.SeedRatioSourceProwlarr
+}
+
+func float64PtrEqual(a, b *float64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 func intSliceEqual(a, b []int) bool {

--- a/web/src/api/indexers.ts
+++ b/web/src/api/indexers.ts
@@ -14,6 +14,10 @@ export interface Indexer {
   // Per-indexer seed-ratio override (#883). Omitted/null = no override (the
   // download client keeps its global rule); -1 = unlimited (seed forever).
   seedRatio?: number | null
+  // Provenance of seedRatio (#1065): 'prowlarr' = auto-populated from Prowlarr's
+  // seedCriteria.seedRatio (a later Prowlarr change may refresh it); 'user' = the
+  // user set/cleared it (Prowlarr won't touch it); omitted/'' = unset.
+  seedRatioSource?: string
 }
 
 export interface IndexerTestResult {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -395,6 +395,7 @@
         "seedRatio": "Seed ratio",
         "seedRatioPlaceholder": "e.g. 1.0",
         "seedRatioUnlimited": "Unlimited",
+        "seedRatioFromProwlarr": "Auto-filled from Prowlarr. Edit and save to override; Prowlarr won't change it again.",
         "seedRatioHint": "Per-indexer seed-ratio limit applied to torrents grabbed from this indexer (qBittorrent, Transmission, Deluge). Leave blank to use the download client's global rule, or check Unlimited to seed forever. Ignored for Usenet."
       }
     },

--- a/web/src/pages/settings/IndexersTab.tsx
+++ b/web/src/pages/settings/IndexersTab.tsx
@@ -37,7 +37,7 @@ function IndexerTestResultBanner({ r }: { r: IndexerTestResult }) {
 //   - null/undefined → no override (input empty, toggle off)
 //   - >= 0           → that ratio (input shows it, toggle off)
 //   - -1             → unlimited (input disabled/blank, toggle on)
-function SeedRatioField({ value, onChange }: { value: number | null | undefined; onChange: (v: number | null) => void }) {
+function SeedRatioField({ value, onChange, source }: { value: number | null | undefined; onChange: (v: number | null) => void; source?: string }) {
   const { t } = useTranslation()
   const unlimited = value === -1
   // Text mirror of the numeric input so a half-typed "1." doesn't get clobbered.
@@ -81,6 +81,9 @@ function SeedRatioField({ value, onChange }: { value: number | null | undefined;
           {t('settings.indexers.form.seedRatioUnlimited')}
         </label>
       </div>
+      {source === 'prowlarr' && (
+        <p className="text-xs text-amber-600 dark:text-amber-500 mt-1">{t('settings.indexers.form.seedRatioFromProwlarr')}</p>
+      )}
       <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.seedRatioHint')}</p>
     </div>
   )
@@ -386,7 +389,7 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
         <input type="number" value={priority} onChange={e => setPriority(e.target.value)} placeholder="0" className={inputCls} />
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.priorityHint')}</p>
       </div>
-      <SeedRatioField value={seedRatio} onChange={setSeedRatio} />
+      <SeedRatioField value={seedRatio} onChange={setSeedRatio} source={indexer.seedRatioSource} />
       {testResult && <IndexerTestResultBanner r={testResult} />}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">{t('common.cancel')}</button>


### PR DESCRIPTION
## Problem

#1061 shipped the Bindery-local per-indexer seed-ratio override (`models.Indexer.SeedRatio`, applied to qBittorrent/Transmission/Deluge with the `-1` unlimited sentinel and a UI toggle) but deliberately did not read the ratio from Prowlarr. Users running Prowlarr had to re-enter ratios Prowlarr already knows. This is the follow-up (#1065) that sources the override automatically.

## Approach

- **Fetch:** `prowlarr.Client.FetchIndexers` now parses the `torrentBaseSettings.seedRatio` field from `GET /api/v1/indexer` (the camelCased flattening of `ITorrentIndexerSettings.TorrentBaseSettings.SeedRatio`, confirmed against Prowlarr's `SchemaBuilder`/`IndexerTorrentBaseSettings`/`SeedConfigProvider`). Prowlarr models it as a nullable double its own validator keeps `> 0`, so a present positive value is the only "configured ratio" shape — `null` / missing / `<= 0` all collapse to "no ratio". Exposed on `IndexerInfo.SeedRatio`.
- **Precedence + re-sync policy:** a new `seed_ratio_source` provenance column (`''` unset, `'prowlarr'`, `'user'`) decides who owns the value:
  - An explicit user value, clear-to-null, or unlimited-toggle is recorded as `user` and is **never** overwritten by a sync.
  - An unset or previously Prowlarr-sourced row **tracks** Prowlarr: a later Prowlarr change refreshes the auto-populated value, and a ratio removed in Prowlarr clears Bindery's auto-populated value.
  - Migration 054 adds the column and backfills existing non-NULL ratios to `user`, since before this feature only the user could have written them.
- **API:** Create/Update mark a user-supplied ratio as `source='user'` so the syncer leaves it alone thereafter.
- **Semantics preserved:** the nullable + `-1`-unlimited shape from #1061 is intact — Prowlarr only ever yields a positive ratio or nil, so the `-1` sentinel stays reserved for the user-driven "unlimited" toggle.
- **Web:** `seedRatioSource` surfaced on the `Indexer` type; the edit form shows a hint when a ratio was auto-filled from Prowlarr.

Seed *time* remains out of scope per the issue.

## Tests

- `prowlarr`: `FetchIndexers` parses present / null / missing / zero / usenet shapes; `applyProwlarrSeedRatio` table test covers populate, user-override-wins, user-cleared-sticks, prowlarr-refresh, prowlarr-clear, no-op; full `Sync` path covers auto-populate-on-create and don't-clobber-user-override.
- `db`: `seed_ratio_source` round-trips through Create/Update/GetByID and defaults to unset.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `golangci-lint run` on `internal/prowlarr`, `internal/db`, `internal/api`, `internal/models` → 0 issues
- `go test` on those packages → pass
- `cd web && npm ci && npm run typecheck && npm run build && npm run lint && npm test` → typecheck/build clean, lint 0 errors (only pre-existing warnings in untouched files), 324 tests pass

Closes #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)