### PR TITLE
feat(metadata): hide compilations from author works via Hardcover

### DIFF
--- a/changelog.d/author-works-hide-compilations.md
+++ b/changelog.d/author-works-hide-compilations.md
@@ -1,0 +1,2 @@
+### Changed
+- **Author refresh no longer clutters the works list with omnibuses/box sets** — when a Hardcover API token is configured, works Hardcover classifies as compilations (omnibuses, box sets, "complete" bundles) are pruned from an author's book list, so the same content stops appearing in several places. OpenLibrary itself carries no such signal, so Hardcover's classification is what drives the cleanup; genuine books, and installs without a Hardcover token, are unaffected.

--- a/internal/metadata/aggregator_author_works.go
+++ b/internal/metadata/aggregator_author_works.go
@@ -76,6 +76,7 @@ func (a *Aggregator) GetAuthorWorksForAuthor(ctx context.Context, author models.
 
 	authorName := strings.TrimSpace(author.Name)
 	supplementsComplete := true
+	compilationTitles := map[string]struct{}{}
 	if authorName != "" {
 		for _, provider := range a.authorWorksByNameProviders() {
 			supplemental, err := provider.GetAuthorWorksByName(ctx, authorName)
@@ -90,9 +91,26 @@ func (a *Aggregator) GetAuthorWorksForAuthor(ctx context.Context, author models.
 			if len(supplemental) == 0 {
 				continue
 			}
-			books = mergeAuthorWorks(books, supplemental)
+			// Enrichers like Hardcover classify which of an author's works are
+			// compilations / omnibuses / box sets. Record those titles so the
+			// matching primary-provider (e.g. OpenLibrary) works can be pruned
+			// below, and drop the compilation entries themselves instead of
+			// merging them — otherwise the same content surfaces as several
+			// "bundle" rows, the clutter users see on author refresh.
+			kept := supplemental[:0]
+			for _, b := range supplemental {
+				if b.IsCompilation {
+					if k := authorWorkMergeKey(b.Title); k != "" {
+						compilationTitles[k] = struct{}{}
+					}
+					continue
+				}
+				kept = append(kept, b)
+			}
+			books = mergeAuthorWorks(books, kept)
 		}
 	}
+	books = pruneAuthorWorkCompilations(books, compilationTitles)
 
 	a.enrichMissingAuthorWorkCovers(ctx, books)
 	if supplementsComplete {
@@ -140,6 +158,26 @@ func (a *Aggregator) authorWorksByNameProviders() []authorWorksByNameProvider {
 		}
 	}
 	return providers
+}
+
+// pruneAuthorWorkCompilations drops works whose normalized title matches one an
+// enricher flagged as a compilation/omnibus, plus any book still carrying the
+// compilation flag directly. Primary-provider works (OpenLibrary) carry no
+// compilation signal of their own, so the enricher's classification is the only
+// way to know an inflated "bundle" came through the primary list. The filter is
+// in place and order-preserving.
+func pruneAuthorWorkCompilations(books []models.Book, compilationTitles map[string]struct{}) []models.Book {
+	filtered := books[:0]
+	for _, b := range books {
+		if b.IsCompilation {
+			continue
+		}
+		if _, ok := compilationTitles[authorWorkMergeKey(b.Title)]; ok {
+			continue
+		}
+		filtered = append(filtered, b)
+	}
+	return filtered
 }
 
 func cloneBooks(books []models.Book) []models.Book {

--- a/internal/metadata/aggregator_author_works_test.go
+++ b/internal/metadata/aggregator_author_works_test.go
@@ -155,6 +155,53 @@ func TestAggregator_GetAuthorWorksForAuthor_MergesSupplementalByTitle(t *testing
 	}
 }
 
+// TestAggregator_GetAuthorWorksForAuthor_PrunesCompilations verifies that works
+// an enricher (Hardcover) flags as compilations are removed: the matching
+// primary (OpenLibrary) "bundle" work is dropped, the compilation entry itself
+// is never added, and genuine books are untouched.
+func TestAggregator_GetAuthorWorksForAuthor_PrunesCompilations(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{
+			{ForeignID: "OL1W", Title: "Dune", MetadataProvider: "openlibrary"},
+			{ForeignID: "OL2W", Title: "The Ultimate Dune Omnibus", MetadataProvider: "openlibrary"},
+			{ForeignID: "OL3W", Title: "Children of Dune", MetadataProvider: "openlibrary"},
+		}},
+	}
+	hardcover := &mockAuthorWorksByNameProvider{
+		mockProvider: mockProvider{name: "hardcover"},
+		authorWorksByName: []models.Book{
+			{ForeignID: "hc:dune", Title: "Dune", ImageURL: "https://img/dune.jpg", MetadataProvider: "hardcover"},
+			{ForeignID: "hc:ultimate-dune", Title: "The Ultimate Dune Omnibus", MetadataProvider: "hardcover", IsCompilation: true},
+			{ForeignID: "hc:dune-messiah", Title: "Dune Messiah", MetadataProvider: "hardcover"},
+		},
+	}
+	agg := &Aggregator{
+		primary:   primary,
+		enrichers: []Provider{hardcover},
+		cache:     newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL123A", Name: "Frank Herbert"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor: %v", err)
+	}
+	titles := map[string]bool{}
+	for _, b := range got {
+		titles[b.Title] = true
+	}
+	if titles["The Ultimate Dune Omnibus"] {
+		t.Errorf("compilation should have been pruned, got: %v", got)
+	}
+	for _, want := range []string{"Dune", "Children of Dune", "Dune Messiah"} {
+		if !titles[want] {
+			t.Errorf("expected %q to remain, got: %v", want, titles)
+		}
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 works after pruning the omnibus, got %d: %+v", len(got), got)
+	}
+}
+
 func TestAggregator_GetAuthorWorksForAuthor_MergesSupplementalIntoFirstDuplicateTitle(t *testing.T) {
 	primary := &mockWorksProvider{
 		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -203,6 +203,7 @@ func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([
 			ratings_count
 			rating
 			users_count
+			compilation
 			audio_seconds
 			default_audio_edition_id
 			default_ebook_edition_id
@@ -585,6 +586,7 @@ type hcBook struct {
 	ISBNs                 []string           `json:"isbns"`
 	HasAudiobook          bool               `json:"has_audiobook"`
 	HasEbook              bool               `json:"has_ebook"`
+	Compilation           bool               `json:"compilation"`
 	AudioSeconds          *int               `json:"audio_seconds"`
 	DefaultAudioEditionID *int               `json:"default_audio_edition_id"`
 	DefaultEbookEditionID *int               `json:"default_ebook_edition_id"`
@@ -1125,6 +1127,7 @@ func (c *Client) toBook(b hcBook) models.Book {
 		ISBNs:            b.ISBNs,
 		SeriesRefs:       seriesRefs,
 		Language:         hardcoverLanguageName(b.Language),
+		IsCompilation:    b.Compilation,
 	}
 	if len(b.Genres) > 0 {
 		bk.Genres = b.Genres

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -645,9 +645,9 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 				t.Fatalf("query requested search-only Hardcover field %q: %s", field, req.Query)
 			}
 		}
-		for _, field := range []string{"default_audio_edition_id", "default_ebook_edition_id"} {
+		for _, field := range []string{"default_audio_edition_id", "default_ebook_edition_id", "compilation"} {
 			if !strings.Contains(req.Query, field) {
-				t.Fatalf("query did not request Hardcover format field %q: %s", field, req.Query)
+				t.Fatalf("query did not request Hardcover field %q: %s", field, req.Query)
 			}
 		}
 		// Regression: `language` is an edition field, not a `books` field.
@@ -676,12 +676,13 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 				},
 				{
 					"id":            11,
-					"title":         "Dune (Spanish edition)",
-					"slug":          "dune-es",
+					"title":         "The Great Dune Omnibus",
+					"slug":          "dune-omnibus",
 					"release_year":  1965,
 					"ratings_count": 50,
 					"rating":        4.2,
 					"users_count":   100,
+					"compilation":   true,
 					"contributions": []map[string]interface{}{
 						{"author": map[string]interface{}{"id": 1, "name": "Frank Herbert", "slug": "frank-herbert"}},
 					},
@@ -707,6 +708,12 @@ func TestGetAuthorWorksByName_WithToken(t *testing.T) {
 	book := books[0]
 	if book.ForeignID != "hc:dune" || book.Title != "Dune" || book.ImageURL == "" {
 		t.Fatalf("unexpected book: %+v", book)
+	}
+	if book.IsCompilation {
+		t.Errorf("Dune should not be flagged as a compilation: %+v", book)
+	}
+	if !books[1].IsCompilation {
+		t.Errorf("The Great Dune Omnibus should be flagged as a compilation: %+v", books[1])
 	}
 	if book.DurationSeconds != 7200 {
 		t.Fatalf("DurationSeconds = %d, want 7200", book.DurationSeconds)

--- a/internal/models/book.go
+++ b/internal/models/book.go
@@ -44,8 +44,14 @@ type Book struct {
 	// signal used to bind the same work imported from different sources
 	// (Calibre, Audiobookshelf, CWA, manual). Nullable for rows created before
 	// migration 051 that have not yet been recomputed by the startup backfill.
-	DedupKey              string     `json:"-"`
-	HardcoverForeignID    string     `json:"-"`
+	DedupKey           string `json:"-"`
+	HardcoverForeignID string `json:"-"`
+	// IsCompilation marks a book Hardcover classifies as a compilation /
+	// omnibus / box set (`books.compilation`). Transient: never persisted, only
+	// used to prune "bundle" entries from an author's works list so the same
+	// content doesn't appear in many places (the author-refresh fluff). Defaults
+	// false for sources that don't report it.
+	IsCompilation         bool       `json:"-"`
 	LastMetadataRefreshAt *time.Time `json:"lastMetadataRefreshAt"`
 	CreatedAt             time.Time  `json:"createdAt"`
 	UpdatedAt             time.Time  `json:"updatedAt"`


### PR DESCRIPTION
## Problem

Refreshing an author surfaces a cluttered list: OpenLibrary returns every omnibus, box set, and "complete" bundle as a separate work, so the same content shows up in many places. (Reported in [discussion #1062-adjacent](https://github.com/vavallee/bindery/discussions) Discord; the same complaint that makes users prefer Hardcover's curated author page.)

OpenLibrary exposes **no** signal to tell a real book from a bundle, and a title keyword filter ("Complete", "Trilogy", "Omnibus") is unsafe — it would hide genuine single titles like *The Complete Poems*.

## Approach

Hardcover **does** classify this: `books.compilation` (Boolean) on its GraphQL `books` type. When a Hardcover token is configured, the author-works supplement now:

1. Selects `compilation` on the author-works query and carries it through a new transient `models.Book.IsCompilation` (never persisted).
2. Records the titles Hardcover flags as compilations, **drops** those supplemental entries instead of merging them, and **prunes** any primary-provider (OpenLibrary) work whose normalized title matches.

This:
- Keeps OpenLibrary as the identity/primary — no foreign-id migration, unlike making Hardcover the primary source.
- Only removes what Hardcover *positively* classifies as a compilation (low false-positive risk).
- Is a complete no-op without a Hardcover token (no regression for those installs).

Scope note: this is the safe, surgical realization of "use Hardcover's curation." Full Hardcover-as-primary (author-works-by-ID, settings, wiring, migration tail) remains a separate, larger piece.

## Tests

- `metadata`: `TestAggregator_GetAuthorWorksForAuthor_PrunesCompilations` — an OL work matching a Hardcover compilation is dropped, the compilation entry itself is never added, genuine books remain.
- `hardcover`: extended `TestGetAuthorWorksByName_WithToken` to assert the query requests `compilation` and maps it to `IsCompilation`.

## Verification

- `go build ./...`, `go vet`, `gofmt`, `golangci-lint` — clean.
- `go test ./internal/metadata/... ./internal/api/ ./internal/abs/ ./internal/models/` — pass.