### PR TITLE
chore(changelog): backfill missing 1.18.0 fragments

### DIFF
--- a/changelog.d/1037-1042-ui-accessibility-polish.md
+++ b/changelog.d/1037-1042-ui-accessibility-polish.md
@@ -1,0 +1,2 @@
+### Changed
+- **UI accessibility and visual polish across the app** (#1037, #1038, #1039, #1040, #1041, #1042) — a coordinated pass on contrast and affordance: WCAG AA-compliant text-color tokens and badge colors in both themes; a redesigned queue with status chips, quieter error rows, and bulk actions; a shared button vocabulary with AA-safe destructive buttons; clickable toggles that no longer look like static badges (plus a status legend); blank book covers replaced by an accessible placeholder with a readable title; and author bios constrained to a readable line length.

--- a/changelog.d/1063-scattered-keyword-author-match.md
+++ b/changelog.d/1063-scattered-keyword-author-match.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Releases whose title words match out of order are no longer grabbed** (#1063) — the weakest release-matching fallback accepted any release containing all the title's keywords in any order, so e.g. searching "Secrets of the Human Body" could grab "Body of Secrets". That fallback now requires either the author's name in the release or the title words appearing in order.

--- a/changelog.d/1064-cross-provider-search.md
+++ b/changelog.d/1064-cross-provider-search.md
@@ -1,0 +1,2 @@
+### Added
+- **Book and author search now queries every configured metadata provider** (#1064) — searches fan out in parallel to OpenLibrary, Hardcover, Google Books, and DNB (each with its own timeout), then results are de-duplicated and ranked by relevance with primary-provider hits first. Books and authors that OpenLibrary lacks — recent releases, niche or foreign-language titles — now show up in search instead of coming back empty.

--- a/changelog.d/1069-name-only-author-add.md
+++ b/changelog.d/1069-name-only-author-add.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Search results without an author ID can now be added** (#1069) — results carrying only an author *name* (typical for Google Books hits, which have no author ID and no ISBN to resolve one from) were findable in search yet rejected on add. Bindery now resolves the author by name — reusing a matching library author (including inverted "Last, First" forms) before adopting OpenLibrary's canonical record — so the add completes without duplicating authors or flooding Wanted.


### PR DESCRIPTION
## Problem

Release-prep audit for 1.18.0: nine merged commits in `v1.17.1..main` have no `changelog.d/` fragment, so `make changelog` would assemble release notes that omit them — including #1064 (cross-provider search), one of the release's headline features.

## Approach

Four new fragments, wording verified against the actual commit messages:

- `1064-cross-provider-search.md` (Added) — search fans out to all providers, dedup + relevance ranking.
- `1063-scattered-keyword-author-match.md` (Fixed) — out-of-order keyword matches now require author or in-order title.
- `1069-name-only-author-add.md` (Fixed) — name-only (Google Books) results addable.
- `1037-1042-ui-accessibility-polish.md` (Changed) — the six-PR AA/UX stack, grouped as one user-facing entry.

Docs-only; no code.