### PR TITLE
ci: nightly live-provider canaries for metadata APIs

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,59 @@
+# Nightly live-provider canaries.
+#
+# Runs the build-tagged tests in tests/canary/ against the REAL OpenLibrary,
+# Hardcover, and Google Books APIs through bindery's actual client code, so
+# upstream API drift (the class of bug behind #1048's Hardcover schema
+# rejection and #1053's indexer UA 403) is caught the night it ships instead
+# of via user reports. On failure it pings Discord with the run URL.
+#
+# Hardcover and Google Books legs skip cleanly when their secrets are absent;
+# the OpenLibrary leg always runs (no auth required).
+name: Provider canaries
+
+on:
+  schedule:
+    # 04:43 UTC: off-peak for the providers and for this repo's runner queue,
+    # off the :00 boundary to dodge the GitHub scheduled-job thundering herd.
+    - cron: '43 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          # Audit, not block: this job's entire purpose is calling third-party APIs.
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.25.11"
+
+      - name: Run live-provider canaries
+        env:
+          HARDCOVER_API_TOKEN: ${{ secrets.HARDCOVER_API_TOKEN }}
+          GOOGLE_BOOKS_API_KEY: ${{ secrets.GOOGLE_BOOKS_API_KEY }}
+        run: go test -tags canary -count=1 -v -timeout=5m ./tests/canary/
+
+      - name: Notify Discord on failure
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_RELEASE_WEBHOOK is not set; skipping Discord notification."
+            exit 0
+          fi
+          payload=$(printf '{"content":"**Provider canary failed** — possible third-party API drift (OpenLibrary / Hardcover / Google Books). Run: %s"}' "$RUN_URL")
+          curl -fsS -X POST -H 'Content-Type: application/json' -d "$payload" "$DISCORD_WEBHOOK"

--- a/tests/canary/canary_test.go
+++ b/tests/canary/canary_test.go
@@ -1,0 +1,38 @@
+//go:build canary
+
+// Package canary_test exercises bindery's real metadata clients against the
+// LIVE third-party provider APIs (OpenLibrary, Hardcover, Google Books). It
+// exists to catch upstream API drift — schema changes, new auth/UA
+// requirements, endpoint deprecations — the day it happens instead of via
+// user bug reports (the class of failure behind #1048, where Hardcover
+// started rejecting the author-works query, and #1053, where an indexer
+// began 403-ing our User-Agent).
+//
+// Design rules:
+//   - Build-tagged `canary` so it never runs in normal CI or `go test ./...`.
+//     Run it explicitly: go test -tags canary -count=1 -v ./tests/canary/
+//   - Assertions are drift-tolerant: "no error, non-empty, core fields
+//     parse". Providers reorder and rescore results constantly, so nothing
+//     here asserts exact content or ordering.
+//   - Rate-limit friendly: a handful of requests per provider per run, once
+//     nightly (.github/workflows/canary.yml). The clients under test already
+//     send the project User-Agent via internal/useragent.
+//   - Authenticated providers skip (not fail) when their credential env var
+//     is absent, so the canary degrades gracefully on forks and local runs.
+package canary_test
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// testCtx returns a context bounded well under the suite's -timeout so a
+// hung provider fails the individual test with a deadline error instead of
+// panicking the whole run.
+func testCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}

--- a/tests/canary/googlebooks_test.go
+++ b/tests/canary/googlebooks_test.go
@@ -1,0 +1,32 @@
+//go:build canary
+
+package canary_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/metadata/googlebooks"
+)
+
+// TestGoogleBooksSearchBooks verifies the volumes search endpoint still
+// responds with our key and that volumes parse into books. The client works
+// keyless against the shared quota pool, but the canary skips without a key
+// so a quota-exhausted shared pool can't produce false alarms.
+func TestGoogleBooksSearchBooks(t *testing.T) {
+	key := os.Getenv("GOOGLE_BOOKS_API_KEY")
+	if key == "" {
+		t.Skip("GOOGLE_BOOKS_API_KEY is not set; skipping Google Books canary (add the repo secret to enable)")
+	}
+
+	books, err := googlebooks.New(key).SearchBooks(testCtx(t), "Dune")
+	if err != nil {
+		t.Fatalf("SearchBooks(%q): %v", "Dune", err)
+	}
+	if len(books) == 0 {
+		t.Fatalf("SearchBooks(%q) returned no results; expected at least one", "Dune")
+	}
+	if b := books[0]; b.Title == "" {
+		t.Errorf("first book is missing core fields: ForeignID=%q Title=%q", b.ForeignID, b.Title)
+	}
+}

--- a/tests/canary/hardcover_test.go
+++ b/tests/canary/hardcover_test.go
@@ -1,0 +1,78 @@
+//go:build canary
+
+package canary_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/metadata/hardcover"
+)
+
+// hardcoverClient returns a client authenticated from HARDCOVER_API_TOKEN,
+// or skips the test when the token is absent (every Hardcover GraphQL query
+// requires auth, so there is nothing useful to canary without it).
+func hardcoverClient(t *testing.T) *hardcover.Client {
+	t.Helper()
+	token := os.Getenv("HARDCOVER_API_TOKEN")
+	if token == "" {
+		t.Skip("HARDCOVER_API_TOKEN is not set; skipping Hardcover canary (add the repo secret to enable)")
+	}
+	return hardcover.New().WithToken(token)
+}
+
+// TestHardcoverSearchBooksAndGetBook verifies the Typesense-backed search
+// query still parses, then feeds the first result's foreign ID straight into
+// GetBook to verify the books-by-slug/id GraphQL query as well. Chaining
+// from the live search result (rather than hardcoding a slug) keeps the
+// GetBook leg valid by construction even if Hardcover renames slugs, while
+// still exercising the exact client code and response shapes.
+func TestHardcoverSearchBooksAndGetBook(t *testing.T) {
+	c := hardcoverClient(t)
+	ctx := testCtx(t)
+
+	books, err := c.SearchBooks(ctx, "Dune")
+	if err != nil {
+		t.Fatalf("SearchBooks(%q): %v", "Dune", err)
+	}
+	if len(books) == 0 {
+		t.Fatalf("SearchBooks(%q) returned no results; expected at least one", "Dune")
+	}
+	first := books[0]
+	if first.ForeignID == "" || first.Title == "" {
+		t.Fatalf("first search result is missing core fields: ForeignID=%q Title=%q", first.ForeignID, first.Title)
+	}
+
+	got, err := c.GetBook(ctx, first.ForeignID)
+	if err != nil {
+		t.Fatalf("GetBook(%q): %v", first.ForeignID, err)
+	}
+	if got == nil {
+		t.Fatalf("GetBook(%q) returned nil for an ID Hardcover search just produced", first.ForeignID)
+	}
+	if got.Title == "" {
+		t.Errorf("GetBook(%q) parsed a book with no title", first.ForeignID)
+	}
+}
+
+// TestHardcoverGetAuthorWorksByName is the regression canary for #1048: the
+// author-works query once selected an edition-only field (`language`) on the
+// `books` type and Hardcover rejected the entire query with a GraphQL
+// validation error, silently breaking the author-works supplement for every
+// author. Any schema drift in this query surfaces here as a returned error
+// (the client folds GraphQL `errors` payloads into err), so the only
+// assertions needed are "no error" and "non-empty".
+func TestHardcoverGetAuthorWorksByName(t *testing.T) {
+	c := hardcoverClient(t)
+
+	books, err := c.GetAuthorWorksByName(testCtx(t), "Frank Herbert")
+	if err != nil {
+		t.Fatalf("GetAuthorWorksByName(%q): %v (a GraphQL validation error here means the Hardcover schema drifted under our query, as in #1048)", "Frank Herbert", err)
+	}
+	if len(books) == 0 {
+		t.Fatalf("GetAuthorWorksByName(%q) returned no works; Frank Herbert has dozens on Hardcover", "Frank Herbert")
+	}
+	if b := books[0]; b.ForeignID == "" || b.Title == "" {
+		t.Errorf("first work is missing core fields: ForeignID=%q Title=%q", b.ForeignID, b.Title)
+	}
+}

--- a/tests/canary/openlibrary_test.go
+++ b/tests/canary/openlibrary_test.go
@@ -1,0 +1,62 @@
+//go:build canary
+
+package canary_test
+
+import (
+	"testing"
+
+	"github.com/vavallee/bindery/internal/metadata/openlibrary"
+)
+
+// frankHerbertOLID is the OpenLibrary author ID for Frank Herbert
+// (https://openlibrary.org/authors/OL79034A). OL author IDs are permanent
+// identifiers, so this is safe to hardcode.
+const frankHerbertOLID = "OL79034A"
+
+// TestOpenLibrarySearchAuthors verifies the author search endpoint still
+// responds and that the documents parse into authors with their core
+// identity fields populated.
+func TestOpenLibrarySearchAuthors(t *testing.T) {
+	authors, err := openlibrary.New().SearchAuthors(testCtx(t), "Frank Herbert")
+	if err != nil {
+		t.Fatalf("SearchAuthors(%q): %v", "Frank Herbert", err)
+	}
+	if len(authors) == 0 {
+		t.Fatalf("SearchAuthors(%q) returned no results; expected at least one", "Frank Herbert")
+	}
+	if a := authors[0]; a.ForeignID == "" || a.Name == "" {
+		t.Errorf("first author is missing core fields: ForeignID=%q Name=%q", a.ForeignID, a.Name)
+	}
+}
+
+// TestOpenLibrarySearchBooks verifies /search.json still responds (OL has
+// deprecated search endpoints under us before, see issue #462) and that the
+// documents parse into books with identity fields populated.
+func TestOpenLibrarySearchBooks(t *testing.T) {
+	books, err := openlibrary.New().SearchBooks(testCtx(t), "Dune")
+	if err != nil {
+		t.Fatalf("SearchBooks(%q): %v", "Dune", err)
+	}
+	if len(books) == 0 {
+		t.Fatalf("SearchBooks(%q) returned no results; expected at least one", "Dune")
+	}
+	if b := books[0]; b.ForeignID == "" || b.Title == "" {
+		t.Errorf("first book is missing core fields: ForeignID=%q Title=%q", b.ForeignID, b.Title)
+	}
+}
+
+// TestOpenLibraryGetAuthorWorks verifies the author-works path (the
+// /authors/{id}/works.json backfill plus the search-index enrichment) still
+// parses for a stable, prolific author.
+func TestOpenLibraryGetAuthorWorks(t *testing.T) {
+	books, err := openlibrary.New().GetAuthorWorks(testCtx(t), frankHerbertOLID)
+	if err != nil {
+		t.Fatalf("GetAuthorWorks(%q): %v", frankHerbertOLID, err)
+	}
+	if len(books) == 0 {
+		t.Fatalf("GetAuthorWorks(%q) returned no works; Frank Herbert has hundreds", frankHerbertOLID)
+	}
+	if b := books[0]; b.ForeignID == "" || b.Title == "" {
+		t.Errorf("first work is missing core fields: ForeignID=%q Title=%q", b.ForeignID, b.Title)
+	}
+}


### PR DESCRIPTION
## Problem

Third-party API drift only surfaces when a user trips over it. #1048 (Hardcover started rejecting the author-works query with a GraphQL validation error, silently breaking the author-works supplement for every author) and #1053 (an indexer began 403-ing our User-Agent) both shipped upstream silently and were found via user reports. Nothing in CI talks to the real providers, so nothing can catch this class of failure proactively.

## Approach

**`tests/canary/`** — a `//go:build canary`-tagged package that exercises the LIVE provider APIs through bindery's actual clients (`internal/metadata/{openlibrary,hardcover,googlebooks}`), so a drift that breaks production code breaks the canary the same night. Assertions are deliberately drift-tolerant (no error, non-empty, core fields parse — never exact content or ordering) and the call count is small (~9 requests total per nightly run):

- **OpenLibrary** (no auth, always runs): `SearchAuthors("Frank Herbert")` non-empty; `SearchBooks("Dune")` non-empty; `GetAuthorWorks("OL79034A")` (Frank Herbert, permanent OL ID) parses and is non-empty.
- **Hardcover** (skips with a clear message unless `HARDCOVER_API_TOKEN` is set): `SearchBooks("Dune")` non-empty, then `GetBook` on the first result's foreign ID (chained from live search rather than a hardcoded slug, so the ID is valid by construction while still exercising the books-by-slug/id query); `GetAuthorWorksByName("Frank Herbert")` — the exact query that broke in #1048 — asserts no error (the client folds GraphQL validation errors into `err`) and non-empty.
- **Google Books** (skips unless `GOOGLE_BOOKS_API_KEY` is set): `SearchBooks("Dune")` non-empty.

**`.github/workflows/canary.yml`** — nightly `schedule` (04:43 UTC, off-peak and off the :00 thundering-herd boundary) plus `workflow_dispatch`; Go 1.25.11 (matches `go.mod`/CI); runs `go test -tags canary -count=1 -v -timeout=5m ./tests/canary/` with both secrets in env. On failure, a `curl` POST sends the run URL to Discord via `DISCORD_RELEASE_WEBHOOK`, guarded by `if: failure()` and skipped when the secret is empty; the webhook value is never echoed. Action pins and harden-runner match existing workflows.

The build tag keeps the package out of every normal path: `go build ./...`, `go vet ./...`, and `go test ./...`-style invocations all skip it, and CI's test jobs only target `./cmd/... ./internal/...` anyway.

### Secrets to add for full coverage

| Secret | Enables |
|---|---|
| `HARDCOVER_API_TOKEN` | both Hardcover canaries, incl. the #1048 regression query |
| `GOOGLE_BOOKS_API_KEY` | Google Books search canary |

Without them the OpenLibrary canaries still run and the rest skip (visible as SKIP in the log, not failures). `DISCORD_RELEASE_WEBHOOK` already exists.

## Verification

- `gofmt -l tests/canary/` clean; `go vet -tags canary ./tests/canary/` clean
- `go build ./...` and `go vet ./...` pass and skip the canary package (constraint-excluded)
- `go test -run xxx ./tests/...` does not list `tests/canary` (excluded from untagged runs)
- Compile check without network: `go test -tags canary -run xxx -count=1 ./tests/canary/` → ok
- Live run: `go test -tags canary -count=1 -v ./tests/canary/` → 3 OpenLibrary tests PASS against the real API, Hardcover/Google Books SKIP with the expected messages
- Workflow YAML parses; `OL79034A` verified live as Frank Herbert

No changelog.d fragment (CI-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)