### PR TITLE
feat(chart): opt-in log-rate Discord alert CronJob

### DIFF
--- a/changelog.d/1085-log-alert-cronjob.md
+++ b/changelog.d/1085-log-alert-cronjob.md
@@ -1,0 +1,2 @@
+### Added
+- **Log-rate Discord alerting (Helm)** (#1085) — new opt-in `logAlert` CronJob in the chart polls `/api/v1/system/logs` and pings a Discord webhook when WARN/ERROR counts in the lookback window cross configurable thresholds, so persistent log noise pages someone instead of sitting unseen.

--- a/charts/bindery/templates/log-alert-cronjob.yaml
+++ b/charts/bindery/templates/log-alert-cronjob.yaml
@@ -1,0 +1,133 @@
+{{- if .Values.logAlert.enabled -}}
+{{- $apiSecret := .Values.logAlert.apiKeySecret -}}
+{{- $webhookSecret := .Values.logAlert.webhookSecret -}}
+{{- $_ := required "logAlert.apiKeySecret.name is required when logAlert.enabled=true" $apiSecret.name -}}
+{{- $_ = required "logAlert.webhookSecret.name is required when logAlert.enabled=true" $webhookSecret.name -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "bindery.fullname" . }}-log-alert
+  labels:
+    {{- include "bindery.labels" . | nindent 4 }}
+    app.kubernetes.io/component: log-alert
+spec:
+  schedule: {{ .Values.logAlert.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  # If the controller misses a window (cluster down, etc), still start the job
+  # up to 5 minutes late rather than skipping the whole interval.
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 300
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            # Deliberately NOT bindery.selectorLabels — the Service selects on
+            # name+instance and must not pick up this pod as an endpoint.
+            app.kubernetes.io/name: {{ include "bindery.name" . }}-log-alert
+            app.kubernetes.io/instance: {{ .Release.Name }}
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: log-alert
+              image: {{ .Values.logAlert.image | quote }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+              env:
+                - name: BINDERY_URL
+                  value: "http://{{ include "bindery.fullname" . }}:{{ .Values.service.port }}"
+                - name: INSTANCE
+                  value: {{ printf "%s/%s" .Release.Namespace (include "bindery.fullname" .) | quote }}
+                - name: LOOKBACK_MINUTES
+                  value: {{ int .Values.logAlert.lookbackMinutes | quote }}
+                - name: ERROR_THRESHOLD
+                  value: {{ int .Values.logAlert.errorThreshold | quote }}
+                - name: WARN_THRESHOLD
+                  value: {{ int .Values.logAlert.warnThreshold | quote }}
+                - name: BINDERY_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $apiSecret.name | quote }}
+                      key: {{ $apiSecret.key | quote }}
+                - name: DISCORD_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $webhookSecret.name | quote }}
+                      key: {{ $webhookSecret.key | quote }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              command:
+                - sh
+                - -c
+                # NOTE: secrets (BINDERY_API_KEY, DISCORD_WEBHOOK_URL) are only
+                # ever passed as curl header/target — never echoed or logged.
+                - |
+                  set -eu
+                  FROM=$(jq -rn "now - (${LOOKBACK_MINUTES} * 60) | todate")
+                  RESP=/tmp/logs.json
+                  # level=warn is a minimum-level filter: returns WARN + ERROR.
+                  CODE=$(curl -sS -o "$RESP" -w '%{http_code}' --max-time 30 \
+                    -H "X-Api-Key: ${BINDERY_API_KEY}" \
+                    "${BINDERY_URL}/api/v1/system/logs?level=warn&from=${FROM}&limit=1000")
+                  if [ "$CODE" != "200" ]; then
+                    echo "log fetch failed: HTTP $CODE"
+                    exit 1
+                  fi
+                  ERRORS=$(jq '[.[] | select(.level == "ERROR")] | length' "$RESP")
+                  WARNS=$(jq '[.[] | select(.level == "WARN")] | length' "$RESP")
+                  TOTAL=$(jq 'length' "$RESP")
+                  echo "lookback=${LOOKBACK_MINUTES}m errors=$ERRORS warns=$WARNS (fetched $TOTAL, cap 1000)"
+                  ALERT=0
+                  [ "$ERROR_THRESHOLD" -gt 0 ] && [ "$ERRORS" -ge "$ERROR_THRESHOLD" ] && ALERT=1
+                  [ "$WARN_THRESHOLD" -gt 0 ] && [ "$WARNS" -ge "$WARN_THRESHOLD" ] && ALERT=1
+                  if [ "$ALERT" -ne 1 ]; then
+                    echo "below thresholds, no alert"
+                    exit 0
+                  fi
+                  TOP=$(jq -r 'group_by(.level + "|" + .message)
+                    | sort_by(-length) | .[:3]
+                    | map("- \(length)x [\(.[0].level)] \(.[0].message[0:140])")
+                    | join("\n")' "$RESP")
+                  PAYLOAD=$(jq -n \
+                    --arg instance "$INSTANCE" \
+                    --arg errors "$ERRORS" \
+                    --arg warns "$WARNS" \
+                    --arg lookback "$LOOKBACK_MINUTES" \
+                    --arg top "$TOP" \
+                    '{content: ("**Bindery log alert** (" + $instance + "): "
+                      + $errors + " ERROR / " + $warns + " WARN in the last "
+                      + $lookback + " min\n" + $top)[0:1900]}')
+                  CODE=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 \
+                    -H "Content-Type: application/json" \
+                    -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL")
+                  case "$CODE" in
+                    2*) echo "alert sent (HTTP $CODE)" ;;
+                    *)  echo "discord post failed: HTTP $CODE"; exit 1 ;;
+                  esac
+          volumes:
+            - name: tmp
+              emptyDir: {}
+{{- end }}

--- a/charts/bindery/tests/logalert_test.yaml
+++ b/charts/bindery/tests/logalert_test.yaml
@@ -1,0 +1,128 @@
+suite: log alert cronjob
+templates:
+  - log-alert-cronjob.yaml
+
+tests:
+  - it: renders nothing when logAlert is disabled (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails template rendering when enabled without an apiKeySecret name
+    set:
+      logAlert.enabled: true
+      logAlert.webhookSecret.name: discord-webhook
+    asserts:
+      - failedTemplate:
+          errorPattern: logAlert.apiKeySecret.name is required
+
+  - it: fails template rendering when enabled without a webhookSecret name
+    set:
+      logAlert.enabled: true
+      logAlert.apiKeySecret.name: bindery-auth
+    asserts:
+      - failedTemplate:
+          errorPattern: logAlert.webhookSecret.name is required
+
+  - it: renders a CronJob with the default hourly schedule when enabled
+    set:
+      logAlert.enabled: true
+      logAlert.apiKeySecret.name: bindery-auth
+      logAlert.webhookSecret.name: discord-webhook
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CronJob
+      - equal:
+          path: spec.schedule
+          value: "0 * * * *"
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+
+  - it: honours a custom schedule and thresholds
+    set:
+      logAlert.enabled: true
+      logAlert.schedule: "*/15 * * * *"
+      logAlert.lookbackMinutes: 15
+      logAlert.errorThreshold: 5
+      logAlert.warnThreshold: 0
+      logAlert.apiKeySecret.name: bindery-auth
+      logAlert.webhookSecret.name: discord-webhook
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "*/15 * * * *"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: LOOKBACK_MINUTES
+            value: "15"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: ERROR_THRESHOLD
+            value: "5"
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: WARN_THRESHOLD
+            value: "0"
+
+  - it: sources both credentials from Secrets, never inline values
+    set:
+      logAlert.enabled: true
+      logAlert.apiKeySecret.name: bindery-auth
+      logAlert.apiKeySecret.key: api-key
+      logAlert.webhookSecret.name: discord-webhook
+      logAlert.webhookSecret.key: url
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: BINDERY_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: bindery-auth
+                key: api-key
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].env
+          content:
+            name: DISCORD_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                name: discord-webhook
+                key: url
+
+  - it: keeps the hardened security posture and no service account token
+    set:
+      logAlert.enabled: true
+      logAlert.apiKeySecret.name: bindery-auth
+      logAlert.webhookSecret.name: discord-webhook
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext.runAsUser
+          value: 65532
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: does not label the pod so the bindery Service would select it
+    set:
+      logAlert.enabled: true
+      logAlert.apiKeySecret.name: bindery-auth
+      logAlert.webhookSecret.name: discord-webhook
+    asserts:
+      - notEqual:
+          path: spec.jobTemplate.spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: bindery

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -131,3 +131,35 @@ hooks:
     # Image used by the smoke-test container. Kept intentionally minimal
     # (busybox gives us wget + sh). Pin a digest in strict environments.
     image: busybox:1.37
+
+logAlert:
+  # Opt-in CronJob that polls GET /api/v1/system/logs (X-Api-Key auth) and
+  # posts a short Discord message when the number of WARN/ERROR entries in
+  # the lookback window crosses the thresholds below. Catches persistent
+  # warnings that would otherwise sit unseen in the logs.
+  enabled: false
+  # Kubernetes five-field cron schedule. Default: top of every hour.
+  schedule: "0 * * * *"
+  # How far back to count, in minutes. Keep >= the schedule interval so
+  # consecutive runs don't leave gaps (the API caps a single fetch at 1000
+  # entries, so counts saturate there).
+  lookbackMinutes: 60
+  # Alert when ERROR entries in the window >= this value. 0 disables the
+  # ERROR check.
+  errorThreshold: 1
+  # Alert when WARN entries in the window >= this value. 0 disables the
+  # WARN check.
+  warnThreshold: 20
+  # Secret holding the Bindery API key (sent as the X-Api-Key header).
+  # Point this at the same Secret the auth block uses (auth.existingSecret
+  # or the chart-managed "bindery-auth"); key defaults to match.
+  apiKeySecret:
+    name: ""
+    key: api-key
+  # Secret holding the full Discord webhook URL.
+  webhookSecret:
+    name: ""
+    key: url
+  # Image for the alert script — needs sh + curl + jq. alpine/k8s ships all
+  # three and is actively maintained. Pin a digest in strict environments.
+  image: alpine/k8s:1.33.12


### PR DESCRIPTION
## Problem

Persistent WARN/ERROR conditions on a running instance sit unseen in the logs — the "author works supplement failed" warning sat there for weeks before anyone noticed. Nothing pages Discord when log noise crosses a sane threshold.

## Approach

New opt-in Helm CronJob (`templates/log-alert-cronjob.yaml`, gated on `logAlert.enabled`, default **false** — no behaviour change for existing installs):

- Hourly by default, it GETs `/api/v1/system/logs?level=warn&from=<now-lookback>&limit=1000` with the `X-Api-Key` header. The handler already supports min-level + RFC3339 time-window filtering, so **no Go changes were needed**.
- Counts `ERROR` and `WARN` entries; if `errors >= logAlert.errorThreshold` (default 1) or `warns >= logAlert.warnThreshold` (default 20, `0` disables either check), it POSTs a short Discord message: instance, counts, top 3 repeated messages.
- Both credentials come from existing Secrets via `secretKeyRef` (`logAlert.apiKeySecret{name,key}`, `logAlert.webhookSecret{name,key}`); the script never echoes them. `required` fails the render with a clear message if either Secret name is missing while enabled.
- Image: `alpine/k8s:1.33.12` (maintained, ships sh+curl+jq, digest-pinnable). Hardened pod: runAsNonRoot 65532, read-only rootfs (+`emptyDir` /tmp), drop ALL, RuntimeDefault seccomp, no SA token. Pod labels deliberately avoid the chart selectorLabels so the Service never picks the job pod up as an endpoint.
- The app image tag and all other chart values are untouched.

Minimal enable:

```yaml
logAlert:
  enabled: true
  apiKeySecret: { name: bindery-auth }            # key defaults to api-key
  webhookSecret: { name: discord-bindery-webhook } # key defaults to url
```

## Verification

- `helm lint charts/bindery` — pass.
- `helm template` disabled (default): no CronJob rendered; enabled: renders cleanly (output reviewed).
- Helm Policy Tests as CI runs them (`docker run helmunittest/helm-unittest charts/bindery`): all 8 new tests in `tests/logalert_test.yaml` pass (render-off-by-default, required-secret failures, schedule/threshold overrides, secretKeyRef wiring, security posture, label isolation). The one failing test (`security_test.yaml` / BINDERY_API_KEY env) also fails on pristine main — pre-existing, and the CI job is `continue-on-error`.
- jq pipeline (counts, top-message grouping, payload build, 1900-char truncation) exercised against sample log JSON matching `db.LogEntry`.
- No Go code touched.

Caveats: counts saturate at the API's 1000-entry fetch cap (fine for thresholds of this size); `level=warn` is the handler's min-level filter, so one request covers both levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)