### PR TITLE
ci(fuzz): nightly long-budget fuzzing with corpus persistence

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,149 @@
+# Nightly long-budget fuzzing. CI runs the fuzz targets' seed corpora as plain
+# unit tests on every PR; this workflow is the real engine time — each native
+# Go fuzz target gets a multi-minute budget, and the mutated corpus persists
+# across nights via actions/cache on Go's fuzz cache dir, so coverage compounds
+# instead of restarting from the seeds every run.
+#
+# Go allows a single -fuzz pattern per `go test` invocation, so each shard
+# loops its targets sequentially. Two shards keep nightly wall-clock at
+# ~5×8m ≈ 40m each instead of ~80m serial.
+name: Fuzz
+
+on:
+  schedule:
+    # 02:23 UTC nightly — offset from telemetry-backup (03:17) and the weekly
+    # 00:00/06:00/07:00 jobs, off-minute to dodge runner contention.
+    - cron: "23 2 * * *"
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: "Per-target fuzz budget (Go duration, e.g. 30s, 8m)"
+        required: false
+        default: "8m"
+
+permissions:
+  contents: read
+
+# Never let two nightly runs overlap (a late manual dispatch + the schedule);
+# queue instead of cancelling so a corpus-saving run always finishes.
+concurrency:
+  group: fuzz-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  fuzz:
+    name: fuzz (${{ matrix.shard }})
+    timeout-minutes: 75
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # name:package pairs, one `go test -fuzz` invocation each.
+          - shard: net
+            targets: >-
+              FuzzValidateOutboundURL:./internal/httpsec
+              FuzzValidateTorrentFetchURL:./internal/downloader/qbittorrent
+              FuzzValidateNZBFetchURL:./internal/downloader/nzbget
+              FuzzContainsUnderRoot:./internal/api
+              FuzzParseResults:./internal/indexer/newznab
+          - shard: parse
+            targets: >-
+              FuzzParseFilename:./internal/importer
+              FuzzReadEpubMetadata:./internal/importer
+              FuzzParseRelease:./internal/indexer
+              FuzzParseCSVRows:./internal/migrate
+              FuzzRollbackMetadataDecode:./internal/calibre
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.25.11"
+          cache: true
+
+      - name: Locate Go fuzz corpus cache
+        id: fuzz-cache
+        run: echo "dir=$(go env GOCACHE)/fuzz" >> "$GITHUB_OUTPUT"
+
+      # The key includes run_id so every run saves a fresh (immutable) cache
+      # entry with the night's new corpus; restore-keys falls back to the most
+      # recent previous night's entry for this shard.
+      - name: Restore fuzz corpus
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.fuzz-cache.outputs.dir }}
+          key: go-fuzz-corpus-${{ matrix.shard }}-${{ github.run_id }}
+          restore-keys: |
+            go-fuzz-corpus-${{ matrix.shard }}-
+
+      - name: Fuzz targets sequentially
+        env:
+          # Empty on schedule events; default to the full nightly budget.
+          FUZZTIME: ${{ inputs.fuzztime || '8m' }}
+          TARGETS: ${{ matrix.targets }}
+        run: |
+          set -u
+          fail=0
+          for entry in $TARGETS; do
+            name="${entry%%:*}"
+            pkg="${entry#*:}"
+            echo "::group::${name} (${pkg}, fuzztime ${FUZZTIME})"
+            if ! go test -run='^$' -fuzz="^${name}\$" -fuzztime="${FUZZTIME}" "${pkg}"; then
+              echo "::error::fuzz target ${name} (${pkg}) failed"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+          exit "$fail"
+
+      # When a target fails, Go writes the crasher input to the package's
+      # testdata/fuzz/<FuzzName>/ in the source tree. Collect only the
+      # untracked files so checked-in seed corpora don't pollute the artifact.
+      - name: Collect new crasher inputs
+        if: failure()
+        run: |
+          mkdir -p /tmp/fuzz-crashers
+          git ls-files --others --exclude-standard -z -- '*testdata/fuzz*' |
+            while IFS= read -r -d '' f; do
+              mkdir -p "/tmp/fuzz-crashers/$(dirname "$f")"
+              cp "$f" "/tmp/fuzz-crashers/$f"
+            done
+          echo "New crasher inputs:"
+          find /tmp/fuzz-crashers -type f -print || true
+      - name: Upload crasher artifact
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fuzz-crashers-${{ matrix.shard }}-${{ github.run_id }}
+          path: /tmp/fuzz-crashers/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Notify Discord
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHARD: ${{ matrix.shard }}
+        run: |
+          if [ -z "${DISCORD_WEBHOOK:-}" ]; then
+            echo "DISCORD_RELEASE_WEBHOOK not configured — skipping notification"
+            exit 0
+          fi
+          PAYLOAD=$(printf '{"content":"Nightly fuzz failure (shard `%s`) — crasher inputs attached to the run.\\n<%s>"}' "$SHARD" "$RUN_URL")
+          HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            -H "Content-Type: application/json" \
+            --data-binary "$PAYLOAD" \
+            "$DISCORD_WEBHOOK")
+          if [ "$HTTP" = "204" ]; then
+            echo "Discord notified"
+          else
+            echo "::warning::Discord webhook returned HTTP ${HTTP} — check DISCORD_RELEASE_WEBHOOK secret"
+          fi

--- a/changelog.d/nightly-fuzz-isbn.md
+++ b/changelog.d/nightly-fuzz-isbn.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Release-title ISBNs with exotic separators now normalise correctly** — the ISBN extractor in `ParseRelease` accepted any whitespace separator (tab, CR, …) but only stripped hyphens and spaces, so a title like `978<TAB>0449912553` produced an ISBN with an embedded control character that silently failed downstream exact-match comparisons. Found by the new `FuzzParseRelease` target on its first 5-second run.

--- a/internal/importer/epubmeta_fuzz_test.go
+++ b/internal/importer/epubmeta_fuzz_test.go
@@ -1,0 +1,141 @@
+package importer
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// maxEpubFuzzInput caps fuzz inputs at 1 MiB. ReadEpubMetadata opens a zip and
+// parses two XML members; the cap keeps each iteration cheap and stops the
+// mutator from wandering into multi-megabyte archives that only test the
+// allocator.
+const maxEpubFuzzInput = 1 << 20
+
+// fuzzEpubZip builds an in-memory zip from name→body pairs (ordered slice so
+// seeds are deterministic).
+func fuzzEpubZip(f *testing.F, entries [][2]string) []byte {
+	f.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, e := range entries {
+		w, err := zw.Create(e[0])
+		if err != nil {
+			f.Fatal(err)
+		}
+		if _, err := w.Write([]byte(e[1])); err != nil {
+			f.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		f.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// FuzzReadEpubMetadata exercises the EPUB embedded-metadata reader (the #1014
+// import-matching path) with arbitrary bytes written to a temp .epub. The
+// reader runs on downloaded, untrusted archives, so it must never panic and
+// must stay fast on any input: a hostile zip/OPF must come back as an error
+// (and the caller falls back to filename parsing), never a crash or a hang.
+func FuzzReadEpubMetadata(f *testing.F) {
+	container := `<?xml version="1.0"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles><rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/></rootfiles>
+</container>`
+	opf := `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+  <metadata>
+    <dc:title>Project Hail Mary</dc:title>
+    <dc:creator opf:role="aut">Andy Weir</dc:creator>
+    <dc:identifier>urn:isbn:9780593135204</dc:identifier>
+  </metadata>
+</package>`
+
+	seeds := [][]byte{
+		nil,
+		[]byte("not a zip at all"),
+		[]byte("PK\x03\x04"), // zip magic, truncated
+		// Fully valid minimal EPUB.
+		fuzzEpubZip(f, [][2]string{
+			{"mimetype", "application/epub+zip"},
+			{"META-INF/container.xml", container},
+			{"OEBPS/content.opf", opf},
+		}),
+		// Valid zip, no container.xml.
+		fuzzEpubZip(f, [][2]string{{"mimetype", "application/epub+zip"}}),
+		// container.xml points at a missing OPF.
+		fuzzEpubZip(f, [][2]string{{"META-INF/container.xml", container}}),
+		// Malformed container XML.
+		fuzzEpubZip(f, [][2]string{{"META-INF/container.xml", "<container><rootfiles>"}}),
+		// Rootfile with an absolute / dot-laced path that needs cleaning.
+		fuzzEpubZip(f, [][2]string{
+			{"META-INF/container.xml", `<container><rootfiles><rootfile full-path="/./OEBPS/../OEBPS/content.opf"/></rootfiles></container>`},
+			{"OEBPS/content.opf", opf},
+		}),
+		// Malformed OPF XML mid-element.
+		fuzzEpubZip(f, [][2]string{
+			{"META-INF/container.xml", container},
+			{"OEBPS/content.opf", "<package><metadata><dc:title>unterminated"},
+		}),
+		// OPF with an ISBN-10 identifier and no role on the creator.
+		fuzzEpubZip(f, [][2]string{
+			{"META-INF/container.xml", container},
+			{"OEBPS/content.opf", `<package><metadata><dc:creator>Someone</dc:creator><dc:identifier>isbn:034547219X</dc:identifier></metadata></package>`},
+		}),
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	// One temp file per worker process, overwritten each iteration —
+	// t.TempDir() inside the fuzz function costs a mkdir+rm per exec and
+	// throttles throughput to a crawl.
+	p := filepath.Join(f.TempDir(), "in.epub")
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > maxEpubFuzzInput {
+			t.Skip("input over size cap")
+		}
+		if err := os.WriteFile(p, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		start := time.Now()
+		meta, err := ReadEpubMetadata(p) // must not panic on any input
+		// Generous wall-clock bound: a ≤1 MiB archive that takes this long
+		// (e.g. a decompression bomb in container.xml/OPF) is a real DoS
+		// finding on the import path, not fuzzer noise.
+		if elapsed := time.Since(start); elapsed > 20*time.Second {
+			t.Fatalf("ReadEpubMetadata took %v on a %d-byte input", elapsed, len(data))
+		}
+		if err != nil {
+			// Error path is the fallback-to-filename-parsing contract: it must
+			// hand back a zero value, not partially-populated metadata.
+			if meta != (EpubMetadata{}) {
+				t.Fatalf("non-zero metadata %+v alongside error %v", meta, err)
+			}
+			return
+		}
+		// ISBN, when present, is normalised: ISBN-13 (digits, 978/979) or
+		// ISBN-10 (digits with optional X check digit).
+		switch len(meta.ISBN) {
+		case 0:
+		case 13:
+			if strings.Trim(meta.ISBN, "0123456789") != "" ||
+				(!strings.HasPrefix(meta.ISBN, "978") && !strings.HasPrefix(meta.ISBN, "979")) {
+				t.Fatalf("malformed ISBN-13 %q", meta.ISBN)
+			}
+		case 10:
+			if strings.Trim(meta.ISBN, "0123456789X") != "" {
+				t.Fatalf("malformed ISBN-10 %q", meta.ISBN)
+			}
+		default:
+			t.Fatalf("ISBN with impossible length: %q", meta.ISBN)
+		}
+	})
+}

--- a/internal/indexer/release.go
+++ b/internal/indexer/release.go
@@ -133,9 +133,18 @@ func ParseRelease(title string) ParsedRelease {
 		}
 	}
 
-	// ISBN: normalize to digits-only
+	// ISBN: normalize to digits-only. The regex accepts any \s separator
+	// (tab, CR, NBSP, …), so strip every non-digit rather than just "-" and
+	// " " — otherwise an exotic separator survives into p.ISBN and breaks
+	// downstream exact-match comparisons. Found by FuzzParseRelease.
 	if isbn := releaseIsbnRe.FindString(title); isbn != "" {
-		p.ISBN = strings.NewReplacer("-", "", " ", "").Replace(isbn)
+		var b strings.Builder
+		for _, r := range isbn {
+			if r >= '0' && r <= '9' {
+				b.WriteByte(byte(r))
+			}
+		}
+		p.ISBN = b.String()
 	}
 
 	// ASIN (Audible identifier). Uppercase BXXXXXXXXX pattern, 10 chars.

--- a/internal/indexer/release_fuzz_test.go
+++ b/internal/indexer/release_fuzz_test.go
@@ -1,0 +1,91 @@
+package indexer
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzParseRelease exercises the release-title parser with arbitrary input.
+// ParseRelease runs on untrusted indexer result titles throughout the search,
+// decision, queue, and scheduler paths (it is distinct from the importer's
+// ParseFilename, which handles on-disk names), so it must never panic and must
+// return structurally sane output regardless of input. All regexes involved
+// are package-level precompiled; nothing attacker-controlled is compiled.
+func FuzzParseRelease(f *testing.F) {
+	seeds := []string{
+		"",
+		"Mary.Doria.Russell.-.The.Sparrow.(1996).RETAIL.EPUB-GROUP",
+		"Dune.Messiah.UNABRIDGED.2020.m4b",
+		"The.Sparrow.ABRIDGED.mp3",
+		"The.Sparrow.9780449912553.epub",
+		"978-0 449 91255 3 The Sparrow",
+		"Dune.Herbert.[B0036S4B2G].m4b",
+		"Der.Schwarm.Frank.Schaetzing.Hoerbuch.2004.MP3-GRP",
+		"Ender's Game – Orson Scott Card | RETAIL (1985) azw3",
+		"....___...|||[[[]]]()()-",
+		strings.Repeat("a.", 400) + "-LONGTAIL",
+		"日本語のタイトル 2021 epub",
+		"UNABRIDGEDABRIDGED retail 1899 2100",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, title string) {
+		p := ParseRelease(title) // must not panic on any input
+
+		// Normalized is trimmed with collapsed single-space separators.
+		if p.Normalized != strings.TrimSpace(p.Normalized) {
+			t.Fatalf("Normalized not trimmed: %q", p.Normalized)
+		}
+		if strings.Contains(p.Normalized, "  ") {
+			t.Fatalf("Normalized contains a double space: %q", p.Normalized)
+		}
+
+		// Year comes from a \b(19|20)\d{2}\b match.
+		if p.Year != 0 && (p.Year < 1900 || p.Year > 2099) {
+			t.Fatalf("Year out of range: %d for %q", p.Year, title)
+		}
+
+		// ISBN is normalised to digits only, 13 long, 978/979 prefixed.
+		if p.ISBN != "" {
+			if len(p.ISBN) != 13 || strings.Trim(p.ISBN, "0123456789") != "" ||
+				(!strings.HasPrefix(p.ISBN, "978") && !strings.HasPrefix(p.ISBN, "979")) {
+				t.Fatalf("malformed ISBN %q for %q", p.ISBN, title)
+			}
+		}
+
+		// ASIN is a 10-char B-prefixed uppercase alphanumeric token.
+		if p.ASIN != "" {
+			if len(p.ASIN) != 10 || p.ASIN[0] != 'B' ||
+				strings.Trim(p.ASIN[1:], "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ") != "" {
+				t.Fatalf("malformed ASIN %q for %q", p.ASIN, title)
+			}
+		}
+
+		// Format is one of the recognised tokens or empty.
+		if p.Format != "" {
+			ok := false
+			for _, ft := range formatTokens {
+				if p.Format == ft {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				t.Fatalf("unknown Format %q for %q", p.Format, title)
+			}
+		}
+
+		// Abridged is defined as "ABRIDGED present and not UNABRIDGED".
+		if p.Abridged && p.Unabridged {
+			t.Fatalf("Abridged and Unabridged both set for %q", title)
+		}
+
+		// ReleaseGroup is the trailing -GROUP alphanumeric capture.
+		if p.ReleaseGroup != "" && strings.Trim(p.ReleaseGroup,
+			"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") != "" {
+			t.Fatalf("non-alphanumeric ReleaseGroup %q for %q", p.ReleaseGroup, title)
+		}
+	})
+}

--- a/internal/indexer/testdata/fuzz/FuzzParseRelease/4714294d3cfba59b
+++ b/internal/indexer/testdata/fuzz/FuzzParseRelease/4714294d3cfba59b
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("978000000000\r0")


### PR DESCRIPTION
## Problem

The #885 fuzz targets (and the ones added since) only ever run their seed corpora as unit tests in CI. The fuzz engine never gets real time, so it never mutates beyond the seeds, and there is no corpus persistence — every run starts from zero. The repo had 8 native fuzz targets and no scheduled runner.

## Approach

**New workflow `.github/workflows/fuzz.yml`**
- Nightly at 02:23 UTC (offset from telemetry-backup's 03:17 and the weekly 00:00/06:00/07:00 jobs), plus `workflow_dispatch` with an optional `fuzztime` input (default `8m`).
- Go allows one `-fuzz` pattern per invocation, so each shard loops its targets sequentially: `go test -run='^$' -fuzz='^Name$' -fuzztime=8m ./pkg`. Two matrix shards (`net` / `parse`, 5 targets each) keep wall clock at ~40m per shard instead of ~80m serial.
- Corpus persists via `actions/cache` on `$(go env GOCACHE)/fuzz`, keyed `go-fuzz-corpus-<shard>-<run_id>` with a prefix `restore-keys` fallback, so each night saves a fresh immutable entry and restores the latest previous one.
- On failure: untracked `testdata/fuzz` crasher inputs upload as an artifact (checked-in regression seeds are excluded), and Discord is notified via `DISCORD_RELEASE_WEBHOOK` (`if: failure()`, skipped when the secret is unset, never echoed).
- Actions pinned by SHA per house style; harden-runner, `persist-credentials: false`, Go 1.25.11 matching ci.yml.

**Target list (10):**

| shard | targets |
|---|---|
| net | FuzzValidateOutboundURL (httpsec), FuzzValidateTorrentFetchURL (qbittorrent), FuzzValidateNZBFetchURL (nzbget), FuzzContainsUnderRoot (api), FuzzParseResults (newznab) |
| parse | FuzzParseFilename (importer), FuzzReadEpubMetadata (importer, new), FuzzParseRelease (indexer, new), FuzzParseCSVRows (migrate), FuzzRollbackMetadataDecode (calibre) |

**Two new targets (coverage gaps):**
- `FuzzParseRelease` — `internal/indexer.ParseRelease` (release-title parser used by searcher/decision/queue/scheduler) was unfuzzed; `FuzzParseFilename` covers the importer's *separate* filename parser. Asserts no panic plus structural invariants (ISBN/ASIN/format/year shape, trimmed normalization, abridged⊕unabridged).
- `FuzzReadEpubMetadata` — the #1014 zip+OPF embedded-metadata reader runs on downloaded, untrusted archives. Caps input at 1 MiB, asserts no panic, bounded wall time, zero-value-on-error contract, normalised ISBN shape. Single temp file per worker (a per-iteration `t.TempDir()` throttled throughput from ~6,600 to ~9 execs/sec).

**Bug found and fixed:** `FuzzParseRelease` failed within 5 seconds of its first run. `releaseIsbnRe` accepts any `\s` separator (tab, CR, NBSP) but `ParseRelease` only stripped `-` and space, so `"978000000000\r0"` produced `p.ISBN = "978000000000\r0"` — an embedded control character that silently breaks downstream exact-match ISBN comparisons. Fixed by stripping all non-digits; the crasher is kept as a checked-in regression seed and a changelog fragment is included (this made the PR no longer test-only).

## Verification

- `go build ./...` clean
- `go test ./internal/indexer/... ./internal/importer/...` pass (new targets run as seed-corpus unit tests; regression crasher now passes)
- Real fuzz sanity: `FuzzParseRelease` 10s (104k execs, post-fix pass), `FuzzReadEpubMetadata` 15s (27.5k execs, pass)
- Workflow loop logic exercised locally verbatim against two targets at `-fuzztime=3s`
- `golangci-lint run` on touched packages: 0 issues; `gofmt -l` clean; YAML parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)