### PR TITLE
fix(logging): surface swallowed errors that hide broken features

### DIFF
--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -900,7 +900,11 @@ func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
 	if h.series != nil {
 		if existingIDs, serErr := h.series.GetSeriesIDsForBook(r.Context(), book.ID); serErr == nil {
 			for _, sid := range existingIDs {
-				_ = h.series.UnlinkBook(r.Context(), sid, book.ID)
+				if err := h.series.UnlinkBook(r.Context(), sid, book.ID); err != nil {
+					// A failed unlink leaves stale series membership on the
+					// rebound book; the link ops below already Warn, so match.
+					slog.Warn("rebind: failed to unlink series", "book", book.Title, "seriesId", sid, "error", err)
+				}
 			}
 		}
 		for _, ref := range upstream.SeriesRefs {

--- a/internal/api/grimmory.go
+++ b/internal/api/grimmory.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -94,7 +95,11 @@ func (h *GrimmoryHandler) SetConfig(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	set := func(key, val string) {
-		_ = h.settings.Set(ctx, key, val)
+		if err := h.settings.Set(ctx, key, val); err != nil {
+			// The handler returns the re-read config either way, so a failed
+			// write is otherwise invisible: the user saves and nothing persists.
+			slog.Warn("grimmory: failed to persist setting", "key", key, "error", err)
+		}
 	}
 
 	if req.Enabled != nil {

--- a/internal/api/pending.go
+++ b/internal/api/pending.go
@@ -161,8 +161,12 @@ func (h *PendingHandler) Grab(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Remove from pending on successful grab.
-	_ = h.pending.DeleteByGUID(r.Context(), pr.GUID)
+	// Remove from pending on successful grab. A surviving entry can be
+	// re-approved and re-grabbed by the scheduler — duplicate downloads with
+	// no visible cause — so a failed delete is worth a warning.
+	if err := h.pending.DeleteByGUID(r.Context(), pr.GUID); err != nil {
+		slog.Warn("failed to remove pending release after grab", "guid", pr.GUID, "book_id", pr.BookID, "error", err)
+	}
 
 	writeJSON(w, http.StatusCreated, dl)
 }

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -331,7 +331,13 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 			return "", fmt.Errorf("add torrent: qBittorrent reports the torrent is already present but its hash could not be determined")
 		}
 		if category != "" {
-			_ = c.setCategory(ctx, hash, category)
+			if err := c.setCategory(ctx, hash, category); err != nil {
+				// Best-effort (the grab still succeeds — the poller's unfiltered
+				// listing recovers category-missed torrents), but this is the root
+				// cause of the #969 cross-seed wedge, so surface it.
+				slog.Warn("add torrent: failed to set category on existing torrent",
+					"hash", hash, "category", category, "error", err)
+			}
 		}
 		slog.Info("add torrent: already present in qBittorrent, reusing existing torrent", "hash", hash)
 		return hash, nil
@@ -394,7 +400,12 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 		if newest != nil {
 			hash := strings.ToLower(newest.Hash)
 			if category != "" {
-				_ = c.setCategory(ctx, hash, category)
+				if err := c.setCategory(ctx, hash, category); err != nil {
+					// Best-effort, but a torrent left outside Bindery's category
+					// is invisible to the category-filtered poll (#969/#939).
+					slog.Warn("add torrent: failed to set category on recovered torrent",
+						"hash", hash, "category", category, "error", err)
+				}
 			}
 			return hash, nil
 		}

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -539,7 +539,7 @@ func (s *Scanner) blockStaleImportFailures(
 ) {
 	allDownloads, err := s.downloads.List(ctx)
 	if err != nil {
-		slog.Debug("blockStaleImportFailures: failed to list downloads", "error", err)
+		slog.Warn("blockStaleImportFailures: failed to list downloads", "error", err)
 		return
 	}
 	for i := range allDownloads {

--- a/internal/importer/scanner_poll.go
+++ b/internal/importer/scanner_poll.go
@@ -25,7 +25,11 @@ func (s *Scanner) checkSABnzbdDownloads(ctx context.Context, client *models.Down
 	// Check history for completed downloads (no category filter — match by NZO ID)
 	history, err := sab.GetHistory(ctx, "", 50)
 	if err != nil {
-		slog.Debug("failed to fetch SABnzbd history", "error", err)
+		// Warn, not Debug: a persistent fetch failure means the import poller is
+		// dead for this client and every download wedges at "downloading" with
+		// no visible cause (the #1019 failure mode).
+		slog.Warn("download poll: failed to fetch SABnzbd history — downloads will not be imported",
+			"client", client.Name, "error", err)
 		return
 	}
 
@@ -91,7 +95,9 @@ func (s *Scanner) checkNZBGetDownloads(ctx context.Context, client *models.Downl
 	// Check history for completed/failed downloads (matched by NZBID stored as sabnzbd_nzo_id).
 	history, err := ng.GetHistory(ctx)
 	if err != nil {
-		slog.Debug("failed to fetch NZBGet history", "error", err)
+		// Warn, not Debug: see checkSABnzbdDownloads (#1019 failure mode).
+		slog.Warn("download poll: failed to fetch NZBGet history — downloads will not be imported",
+			"client", client.Name, "error", err)
 		return
 	}
 
@@ -168,14 +174,16 @@ func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models
 	// Bindery only sees its own torrents on a shared Transmission instance.
 	torrents, err := trans.GetTorrents(ctx, client.Category)
 	if err != nil {
-		slog.Debug("failed to fetch Transmission torrents", "error", err)
+		// Warn, not Debug: see checkSABnzbdDownloads (#1019 failure mode).
+		slog.Warn("download poll: failed to fetch Transmission torrents — downloads will not be imported",
+			"client", client.Name, "error", err)
 		return
 	}
 
 	// Get all active downloads from DB (not yet completed/imported)
 	allDownloads, err := s.downloads.List(ctx)
 	if err != nil {
-		slog.Debug("failed to list downloads", "error", err)
+		slog.Warn("download poll: failed to list downloads", "client", client.Name, "error", err)
 		return
 	}
 	torrentsMap := make(map[string]transmission.Torrent)
@@ -254,7 +262,7 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 
 	allDownloads, err := s.downloads.List(ctx)
 	if err != nil {
-		slog.Debug("failed to list downloads", "error", err)
+		slog.Warn("download poll: failed to list downloads", "client", client.Name, "error", err)
 		return
 	}
 
@@ -268,7 +276,9 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 	for _, cat := range downloader.CategoriesToPoll(client) {
 		torrents, err := qb.GetTorrents(ctx, cat)
 		if err != nil {
-			slog.Debug("failed to fetch qBittorrent torrents", "category", cat, "error", err)
+			// Warn, not Debug: see checkSABnzbdDownloads (#1019 failure mode).
+			slog.Warn("download poll: failed to fetch qBittorrent torrents — downloads will not be imported",
+				"client", client.Name, "category", cat, "error", err)
 			return
 		}
 		for _, t := range torrents {
@@ -298,7 +308,11 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 	if allErr != nil {
 		// Non-fatal: fall back to the category-filtered map only. We still want
 		// to process the torrents we did find rather than abort the whole poll.
-		slog.Debug("qbittorrent: unfiltered torrent listing failed; reconciliation fallback disabled", "error", allErr)
+		// Warn, not Debug: when this fires the category-filtered fetch above
+		// succeeded, so the divergence is real and the #969/#939 category-miss
+		// recovery is silently disabled while it persists.
+		slog.Warn("qbittorrent: unfiltered torrent listing failed; category-mismatch recovery disabled this cycle",
+			"client", client.Name, "error", allErr)
 	}
 	unfilteredByHash := make(map[string]qbittorrent.Torrent, len(allTorrents))
 	for _, t := range allTorrents {
@@ -523,13 +537,16 @@ func (s *Scanner) checkDelugeDownloads(ctx context.Context, client *models.Downl
 	dlc := downloader.DelugeFor(client)
 	torrents, err := dlc.GetTorrents(ctx)
 	if err != nil {
-		slog.Debug("failed to fetch Deluge torrents", "error", err)
+		// Warn, not Debug: see checkSABnzbdDownloads (#1019 failure mode — this
+		// poller exists because exactly this failure was invisible at Debug).
+		slog.Warn("download poll: failed to fetch Deluge torrents — downloads will not be imported",
+			"client", client.Name, "error", err)
 		return
 	}
 
 	allDownloads, err := s.downloads.List(ctx)
 	if err != nil {
-		slog.Debug("failed to list downloads", "error", err)
+		slog.Warn("download poll: failed to list downloads", "client", client.Name, "error", err)
 		return
 	}
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -630,7 +630,12 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	// entries for the book would discard the other format's candidates for a
 	// dual-format ('both') book, forcing an unnecessary re-search (see #707).
 	if s.pending != nil {
-		_ = s.pending.DeleteByBookAndMediaType(ctx, book.ID, mediaType)
+		if err := s.pending.DeleteByBookAndMediaType(ctx, book.ID, mediaType); err != nil {
+			// A surviving pending entry can be re-approved and re-grabbed on a
+			// later cycle, producing duplicate downloads with no visible cause.
+			slog.Warn("failed to clear pending releases after grab",
+				"book_id", book.ID, "media_type", mediaType, "error", err)
+		}
 	}
 }
 
@@ -687,7 +692,12 @@ func (s *Scheduler) checkPendingReleases(ctx context.Context, book models.Book, 
 		rel := decision.ReleaseFromSearchResult(res)
 		decisions := dm.Evaluate([]decision.Release{rel}, book)
 		if len(decisions) > 0 && decisions[0].Approved {
-			_ = s.pending.DeleteByID(ctx, pendingList[i].ID)
+			if err := s.pending.DeleteByID(ctx, pendingList[i].ID); err != nil {
+				// If the entry survives it is re-approved and re-grabbed on the
+				// next cycle — duplicate grabs with no visible cause.
+				slog.Warn("failed to delete pending release after approval",
+					"pending_id", pendingList[i].ID, "book_id", book.ID, "guid", res.GUID, "error", err)
+			}
 			return &res
 		}
 	}
@@ -855,7 +865,10 @@ func (s *Scheduler) checkStalledDownloads(ctx context.Context) {
 
 		stalledIDs, _, err := downloader.GetStalledIDs(ctx, client)
 		if err != nil {
-			slog.Debug("stall check: failed to fetch stalled IDs", "client", client.Name, "error", err)
+			// Warn, not Debug: a persistent failure here silently disables stall
+			// detection for this client (same invisibility class as #1019).
+			slog.Warn("stall check: failed to fetch stalled IDs — stall detection inactive for this client",
+				"client", client.Name, "error", err)
 			continue
 		}
 		if len(stalledIDs) == 0 {


### PR DESCRIPTION
## Swallowed-errors audit

Sweep of `internal/` and `cmd/` for error-swallowing patterns, motivated by #1019 (Deluge poll failures logged at debug left every download wedged at "downloading" invisibly) and the Calibre plugin GUI-refresh bug. Judgment standard: *if this fires on every poll/request for a week, does anything at default log level tell the operator?*

No behavioural changes beyond log levels and added log context. Verified: `go build ./...`, full `go test ./internal/... ./cmd/...` (all pass), `golangci-lint run` on touched packages (0 issues), gofmt clean.

### RISKY — fixed (18)

| Finding (pre-fix location) | Classification | Action |
|---|---|---|
| `internal/importer/scanner_poll.go:28` SABnzbd GetHistory failure logged at Debug | RISKY | Promoted to Warn with client name; this is the literal #1019 failure mode (poller dead, downloads wedge silently) |
| `internal/importer/scanner_poll.go:94` NZBGet GetHistory failure at Debug | RISKY | Promoted to Warn with client name |
| `internal/importer/scanner_poll.go:171` Transmission GetTorrents failure at Debug | RISKY | Promoted to Warn with client name |
| `internal/importer/scanner_poll.go:178` downloads.List failure at Debug (Transmission poll) | RISKY | Promoted to Warn |
| `internal/importer/scanner_poll.go:257` downloads.List failure at Debug (qBittorrent poll) | RISKY | Promoted to Warn |
| `internal/importer/scanner_poll.go:271` qBittorrent GetTorrents (per category) failure at Debug, aborts poll | RISKY | Promoted to Warn with client + category |
| `internal/importer/scanner_poll.go:301` qBittorrent unfiltered listing failure at Debug | RISKY | Promoted to Warn — when it fires the filtered fetch succeeded, so the #969/#939 category-miss recovery is silently disabled |
| `internal/importer/scanner_poll.go:526` Deluge GetTorrents failure at Debug | RISKY | Promoted to Warn — the exact #1019 site class |
| `internal/importer/scanner_poll.go:532` downloads.List failure at Debug (Deluge poll) | RISKY | Promoted to Warn |
| `internal/importer/scanner.go:542` blockStaleImportFailures downloads.List at Debug | RISKY | Promoted to Warn |
| `internal/scheduler/scheduler.go:868` GetStalledIDs failure at Debug | RISKY | Promoted to Warn — persistent failure silently disables stall detection for the client |
| `internal/scheduler/scheduler.go:633` `_ = pending.DeleteByBookAndMediaType` after grab | RISKY | Warn on error — surviving pending entry gets re-approved/re-grabbed later (duplicate downloads, invisible) |
| `internal/scheduler/scheduler.go:690` `_ = pending.DeleteByID` after approval | RISKY | Warn on error — same duplicate-grab loop, fires every search cycle |
| `internal/api/pending.go:165` `_ = pending.DeleteByGUID` after manual grab | RISKY | Warn on error — same class |
| `internal/api/grimmory.go:97` `_ = settings.Set` in SetConfig | RISKY | Warn on error — user saves Grimmory config, nothing persists, no log; sibling handlers return 500 or Warn |
| `internal/api/books.go:903` `_ = series.UnlinkBook` during rebind | RISKY | Warn on error — stale series memberships survive rebind; adjacent CreateOrGet/LinkBook already Warn |
| `internal/downloader/qbittorrent/client.go:334` `_ = setCategory` on 409-reuse path | RISKY | Warn on error — root cause of the #969 cross-seed wedge (torrent invisible to category-filtered poll) |
| `internal/downloader/qbittorrent/client.go:403` `_ = setCategory` on hash-recovery path | RISKY | Warn on error — same #969/#939 class |

### SAFE — left untouched

| Finding | Reason |
|---|---|
| `internal/downloader/deluge/client.go:135` `_ = setLabel` | Label plugin optional by design (commented); poller matches by hash, not label |
| `internal/importer/flatten.go:251,253` `_ = HardlinkFile` / `_ = CopyFileCtx` | Companion-file (cover/cue) copy is best-effort enrichment; book files handled on the logged path |
| `internal/importer/flatten.go:192,200` `_ = os.RemoveAll` | Cleanup on failed staging |
| `internal/importer/lookup.go:116,130` Debug on epub/filename match failure | Tiered matching with fallback; caller surfaces the unmatched download |
| `internal/importer/lookup.go:156-162` DB error returns nil,nil | Same — caller surfaces unmatched; DB failure loud elsewhere |
| `internal/importer/scanner_handoff.go:290` `_ = os.Remove(dst)` | Cleanup of partial copy |
| `internal/importer/scanner_handoff.go:362` adder-nil Debug | Unreachable in production wiring (main.go always calls WithCalibre); add failures already Warn at :379 |
| `internal/importer/scanner_handoff.go:425,448` cover materialization / edition list Debug | Optional metadata enrichment with graceful degradation |
| `internal/importer/renamer.go:180-693` (15 sites), `internal/importer/epubmeta.go:39` | Close/Remove/RemoveAll on error/defer paths; primary error already propagates |
| `internal/scheduler/scheduler.go:608,895,934` `_ = history.Create` | Audit-trail rows, best-effort by design |
| `internal/scheduler/scheduler.go:643` Marshal error return | json.Marshal of own struct, cannot realistically fail |
| `internal/scheduler/scheduler.go:832,852,927` silent err branches | Per-item DB gets; persistent DB failure is loud everywhere else |
| `internal/api/root_folders.go:37,70` `_ = UpdateFreeSpace` | Display-only persistence; value recomputed on every list call |
| `internal/api/abs_review.go:127`, `internal/api/abs_conflicts.go:151` | Compensation writes on an error path already returned to the user; state visible/recoverable in UI |
| `internal/api/recommendations.go:242` `_ = recs.Dismiss` | Rec stays visible and manually dismissable; book add already succeeded |
| `internal/api/books.go:929` `_ = history.Create` | Audit-trail best-effort |
| `internal/api/books.go:719` `_ = os.Remove(parent)` | Empty-dir cleanup, commented |
| `internal/api/history.go:61` ParseInt discard | Query-param default-to-zero by design |
| `internal/api/grimmory.go:140` body Decode discard | Optional request body by design (falls back to stored config) |
| `internal/api/auth.go:264,559-560` | Guarded fallback (nil handled with 401) / commented placeholder helper |
| `internal/api/authors.go:743,757,2276` alias creation Debug | Best-effort alias enrichment |
| `internal/api/authors.go:2015,2069` `author, _ = GetByAnyForeignIDForUser` | UNIQUE-race recovery refetch; original error still propagates if refetch misses |
| `internal/api/authors.go:2046,2253` Debug on provider lookups | Optional provider enrichment with fallback |
| `internal/api/books.go:203` ASIN metadata map Debug | Optional enrichment |
| `internal/api/imageproxy.go:168-265` (8 sites) | Image cache writes/renames/evictions, best-effort by design |
| `internal/api/backup.go:69,121-145`, `internal/api/migrate.go:143-203` | Per-file stat skip + tmp-file cleanup |
| `internal/api/files.go:156,158` | zip writer close/walk errors surface as a truncated download on an already-streaming response |
| `internal/abs/import_upserts.go` (20 sites), `internal/abs/import_hardcover_series.go:281,336,369,463` `_ = recordRunEntity` | Rollback-audit rows, best-effort by design; import outcome itself is logged/returned |
| `internal/abs/importer.go:373,403` `_ = runs.Finish` | On an error path whose error already propagates to the caller/UI |
| `internal/abs/importer.go:726` audnex enrichment Debug | Optional enrichment |
| `internal/abs/import_author_matcher.go:425,442,459` alias Debug | Best-effort alias records |
| `internal/abs/import_snapshots.go:335`, `import_rollback.go:71,80` Unmarshal discards | Defensive decode of self-written JSON columns |
| `internal/calibre/metadata.go:330-344`, `calibre/import_rollback.go:169` | tmp cleanup / tx.Rollback |
| `internal/calibre/importer.go:587` alias Debug | Best-effort alias record |
| `internal/hardcoverlistsyncer/syncer.go:296`, `internal/migrate/goodreads.go:355` | UNIQUE-race recovery refetch; create error still returned if refetch misses |
| `internal/opds/builder.go:300,356,381,439` | Per-item author display enrichment / filter; DB failure loud elsewhere |
| `internal/metadata/aggregator_canonical.go:562,662,734` Debug | Canonical-match fallback, fires per book inside refresh runs (would be noise at Warn); non-canonical path still works |
| `internal/metadata/aggregator_enrichment.go:272`, `aggregator.go:858`, `openlibrary/client.go:582` Debug | Multi-provider fallback / optional enrichment; primary search failures already Warn at `aggregator.go:183` |
| `internal/bookhydrate/hardcover.go:142` Debug | Error also recorded in result.Err for the caller |
| `internal/indexer/newznab/client.go:225` tier fallthrough Debug; `:461` Atoi continue | Query-tier fallback by design (hard errors propagate); caps parse skip with safe default |
| `internal/metadata/audible/client.go:254` Atoi continue | Image-width key parse skip |
| `internal/telemetry/client.go:168` Debug | Telemetry is optional by design |
| `internal/db/*` tx.Rollback / stmt.Close / LastInsertId / RowsAffected / probe cleanup (db.go:120-121,319-508; authors.go; settings.go; recommendations.go; author_aliases.go:204; series.go; import_lists.go; editions.go:124; prowlarr.go:67) | Idiomatic Go database hygiene |
| `internal/db/log_handler.go:72,129` | Intentional: the log sink cannot log its own failure (recursion); recover guard commented |
| `internal/db/books.go:780`, `db/logs.go:128` Unmarshal discards | Defensive decode of self-written JSON columns |
| HTTP error-body reads `body, _ := io.ReadAll(io.LimitReader(...))` (qbittorrent, deluge, transmission, sabnzbd, nzbget, prowlarr, metadata clients) | Best-effort capture of error text for an error that is itself returned |
| `resp.Body.Close()` / `io.Copy(io.Discard, ...)` discards (abs/client.go, notifier, downloader clients, cmd/) | Idiomatic drain/close |
| `internal/auth/csrf.go:73`, `auth/middleware.go:169,357,365` | Response writes / commented probe |
| `internal/config/validate.go:138-142` | Probe-file cleanup + reserved parameters, commented |
| `internal/decision/specs.go:200` `_ = cf` | Dead loop variable, not an error (cosmetic, out of scope) |
| `cmd/bindery`, `cmd/telemetry-server`, `cmd/discord-stats` write/encode discards | HTTP response writes; nothing actionable on failure |
| errors.Is usages (db/*, metadata/*, importer/epubmeta.go) | Standard sql.ErrNoRows / ErrNotFound / io.EOF idioms; unexpected error types propagate |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
