### PR TITLE
feat(deploy-dev): enable log-rate alerting on bindery-dev

### DIFF
--- a/charts/bindery/values-dev.yaml
+++ b/charts/bindery/values-dev.yaml
@@ -1,2 +1,16 @@
 image:
   tag: "1.2.0"
+
+# Log-rate alerting (#1085): page Discord when bindery-dev accumulates
+# WARN/ERROR log entries, so the dev instance acts as a live canary instead
+# of failures sitting unseen in its logs. Secrets come from the
+# "bindery-secrets" ExternalSecret in the bindery-dev namespace, which syncs
+# Vault's secret/cluster/bindery (keys: dev-api-key, webhook-url).
+logAlert:
+  enabled: true
+  apiKeySecret:
+    name: bindery-secrets
+    key: dev-api-key
+  webhookSecret:
+    name: bindery-secrets
+    key: webhook-url


### PR DESCRIPTION
## Problem

The dev instance's logs are unwatched — the "author works supplement failed" class of persistent failure sat invisible until a user report. #1085 added the alerting CronJob to the chart but nothing enables it.

## Approach

Enable `logAlert` in `values-dev.yaml` (defaults: hourly, 60m lookback, ERROR>=1 / WARN>=20). Secrets reference the `bindery-secrets` ExternalSecret already applied in the `bindery-dev` namespace, synced by ESO from Vault `secret/cluster/bindery` (`dev-api-key`, `webhook-url`). The CI deploy-dev job only rewrites the `image.tag` line, so this block survives tag bumps; the development-branch force-sync carries it to the deployed values.

## Verification

- `helm lint` clean; `helm template -f values-dev.yaml` renders the `bindery-log-alert` CronJob with the right secret refs.
- ExternalSecret confirmed synced in-cluster (4 keys present).