### PR TITLE
fix(db): add 010_noop.sql to permanently close the legacy-index gap

### DIFF
--- a/changelog.d/migration-010-gap.md
+++ b/changelog.d/migration-010-gap.md
@@ -1,0 +1,2 @@
+### Fixed
+- **bindery-dev (and any install that received a legacy-index binary on a fresh DB) no longer crashloops** — a no-op migration `010_noop.sql` fills the gap in the sequence, so the row legacy runners wrote as version 10 is now a valid filename-based version and the migration guard accepts it without treating the table as corrupt.

--- a/internal/db/migrations/010_noop.sql
+++ b/internal/db/migrations/010_noop.sql
@@ -1,0 +1,10 @@
+-- This file exists solely to fill the gap at position 010 in the migration
+-- sequence. The original migration set skipped this number, so the legacy
+-- index-based runner (which stored consecutive integers starting at 1) would
+-- write version=10 into schema_migrations when it applied what is now
+-- 011_calibre_mode.sql. Without a file here, version 10 is not a valid
+-- filename-based version number, causing reconcileMigrationVersions to treat
+-- any DB that carries that row as corrupt and refuse to start.
+--
+-- Adding this no-op makes version 10 a valid filename number so the guard
+-- passes whether the row arrived from a legacy run or a fresh install.


### PR DESCRIPTION
## Summary

- bindery-dev has crashlooped twice with \`schema_migrations contains version 10 that is neither a valid migration filename number nor a valid legacy index\`. Root cause: the migration sequence has a gap at 010 (no file exists), so the legacy index-based runner's row for position 10 is not a valid filename-based version. \`reconcileMigrationVersions\` treats it as corrupt and refuses to open the DB.
- Fix: \`010_noop.sql\` is a comment-only migration — no schema change, just enough to make version 10 a valid filename number. The runner handles an empty statement list correctly; it still commits and inserts the version row.
- This closes the loop permanently: no future restart (even with an old image) can produce a version=10 that the current guard rejects.

## Test plan

- [x] All \`TestReconcile*\` tests pass — migration 10 appears in the apply log as \`version=10 file=010_noop.sql\`
- [x] \`TestMigration051AppliesAndIndexExists\` passes (full 54-migration chain runs cleanly)
- [x] bindery-dev is healthy after manual row deletion + restart before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)