### PR TITLE
feat(settings): inline save feedback, Grimmory preview badge, Hardcover token link

### DIFF
--- a/internal/api/import_lists.go
+++ b/internal/api/import_lists.go
@@ -151,7 +151,7 @@ func (h *ImportListHandler) HardcoverLists(w http.ResponseWriter, r *http.Reques
 		}
 		token = GetHardcoverAPIToken(r.Context(), h.settings)
 		if token == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "hardcover API token is not configured"})
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Hardcover API token is not configured"})
 			return
 		}
 	}

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -233,7 +233,7 @@ func (h *SettingsHandler) TestHardcover(w http.ResponseWriter, r *http.Request) 
 	token := GetHardcoverAPIToken(r.Context(), h.settings)
 	result := HardcoverTestResponse{TokenConfigured: token != ""}
 	if token == "" {
-		result.Error = "hardcover API token is not configured"
+		result.Error = "Hardcover API token is not configured"
 		writeJSON(w, http.StatusOK, result)
 		return
 	}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bindery-web",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bindery-web",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "license": "MIT",
       "dependencies": {
         "i18next": "^26.3.1",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -212,7 +212,7 @@
       "notifications": "Benachrichtigungen",
       "quality": "Qualitätsprofile",
       "metadata": "Metadatenprofile",
-      "import": "Import / Migrate",
+      "import": "Import / Migration",
       "rootfolders": "Stammordner",
       "logs": "Protokolle",
       "general": "Allgemein",
@@ -382,7 +382,10 @@
       "logRetention": "Log Retention",
       "logRetentionLabel": "Keep log entries for",
       "logRetentionHint": "Log entries older than this are deleted by the daily trim job.",
-      "days": "days"
+      "days": "days",
+      "naming": {
+        "hintEmpty": "Erforderlich – mindestens ein Token oder Pfadsegment eingeben."
+      }
     },
     "import": {
       "csvHeading": "CSV mit Autorennamen",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -212,7 +212,7 @@
       "notifications": "Benachrichtigungen",
       "quality": "Qualitätsprofile",
       "metadata": "Metadatenprofile",
-      "import": "Import",
+      "import": "Import / Migrate",
       "rootfolders": "Stammordner",
       "logs": "Protokolle",
       "general": "Allgemein",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -311,7 +311,7 @@
       "notifications": "Notifications",
       "quality": "Quality Profiles",
       "metadata": "Metadata Profiles",
-      "import": "Import",
+      "import": "Import / Migrate",
       "rootfolders": "Root Folders",
       "logs": "Logs",
       "general": "General",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -572,7 +572,8 @@
         "tokenIgnoredAudiobook": "{{token}} is ignored for the audiobook folder template",
         "errorEmpty": "Template cannot be empty.",
         "errorTraversal": "Template must not contain \".\" or \"..\" path segments.",
-        "errorUnknownTokens": "Unknown token(s): {{tokens}}. These are case-sensitive and will be written literally."
+        "errorUnknownTokens": "Unknown token(s): {{tokens}}. These are case-sensitive and will be written literally.",
+        "hintEmpty": "Required — enter at least one token or path segment."
       },
       "apiKeys": "External API Keys",
       "googleBooksKey": "Google Books API Key",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -231,7 +231,7 @@
       "notifications": "Notificaciones",
       "quality": "Perfiles de calidad",
       "metadata": "Perfiles de metadatos",
-      "import": "Importar",
+      "import": "Import / Migrate",
       "rootfolders": "Carpetas raíz",
       "logs": "Registros",
       "general": "General",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -231,7 +231,7 @@
       "notifications": "Notificaciones",
       "quality": "Perfiles de calidad",
       "metadata": "Perfiles de metadatos",
-      "import": "Import / Migrate",
+      "import": "Importar / Migrar",
       "rootfolders": "Carpetas raíz",
       "logs": "Registros",
       "general": "General",
@@ -411,7 +411,10 @@
       "logRetention": "Log Retention",
       "logRetentionLabel": "Keep log entries for",
       "logRetentionHint": "Log entries older than this are deleted by the daily trim job.",
-      "days": "days"
+      "days": "days",
+      "naming": {
+        "hintEmpty": "Obligatorio: introduce al menos un token o segmento de ruta."
+      }
     },
     "import": {
       "csvHeading": "CSV de nombres de autores",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -212,7 +212,7 @@
       "notifications": "Notifications",
       "quality": "Profils de qualité",
       "metadata": "Profils de métadonnées",
-      "import": "Importation",
+      "import": "Import / Migrate",
       "rootfolders": "Dossiers racines",
       "logs": "Journaux",
       "general": "Général",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -212,7 +212,7 @@
       "notifications": "Notifications",
       "quality": "Profils de qualité",
       "metadata": "Profils de métadonnées",
-      "import": "Import / Migrate",
+      "import": "Importer / Migrer",
       "rootfolders": "Dossiers racines",
       "logs": "Journaux",
       "general": "Général",
@@ -382,7 +382,10 @@
       "logRetention": "Log Retention",
       "logRetentionLabel": "Keep log entries for",
       "logRetentionHint": "Log entries older than this are deleted by the daily trim job.",
-      "days": "days"
+      "days": "days",
+      "naming": {
+        "hintEmpty": "Obligatoire — saisissez au moins un jeton ou segment de chemin."
+      }
     },
     "import": {
       "csvHeading": "CSV de noms d'auteurs",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -231,7 +231,7 @@
       "notifications": "Notifikasi",
       "quality": "Profil Kualitas",
       "metadata": "Profil Metadata",
-      "import": "Impor",
+      "import": "Import / Migrate",
       "rootfolders": "Folder Utama",
       "logs": "Log",
       "general": "Umum",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -231,7 +231,7 @@
       "notifications": "Notifikasi",
       "quality": "Profil Kualitas",
       "metadata": "Profil Metadata",
-      "import": "Import / Migrate",
+      "import": "Impor / Migrasi",
       "rootfolders": "Folder Utama",
       "logs": "Log",
       "general": "Umum",
@@ -411,7 +411,10 @@
       "logRetention": "Log Retention",
       "logRetentionLabel": "Keep log entries for",
       "logRetentionHint": "Log entries older than this are deleted by the daily trim job.",
-      "days": "days"
+      "days": "days",
+      "naming": {
+        "hintEmpty": "Wajib — masukkan setidaknya satu token atau segmen path."
+      }
     },
     "import": {
       "csvHeading": "CSV nama penulis",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -212,7 +212,7 @@
       "notifications": "Meldingen",
       "quality": "Kwaliteitsprofielen",
       "metadata": "Metadataprofielen",
-      "import": "Import / Migrate",
+      "import": "Importeren / Migreren",
       "rootfolders": "Hoofdmappen",
       "logs": "Logboeken",
       "general": "Algemeen",
@@ -382,7 +382,10 @@
       "logRetention": "Log Retention",
       "logRetentionLabel": "Keep log entries for",
       "logRetentionHint": "Log entries older than this are deleted by the daily trim job.",
-      "days": "days"
+      "days": "days",
+      "naming": {
+        "hintEmpty": "Verplicht — voer minstens één token of padsegment in."
+      }
     },
     "import": {
       "csvHeading": "CSV van auteursnamen",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -212,7 +212,7 @@
       "notifications": "Meldingen",
       "quality": "Kwaliteitsprofielen",
       "metadata": "Metadataprofielen",
-      "import": "Importeren",
+      "import": "Import / Migrate",
       "rootfolders": "Hoofdmappen",
       "logs": "Logboeken",
       "general": "Algemeen",

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -231,7 +231,7 @@
       "notifications": "Mga Notification",
       "quality": "Mga Quality Profile",
       "metadata": "Mga Metadata Profile",
-      "import": "Import / Migrate",
+      "import": "Mag-import / Maglipat",
       "rootfolders": "Mga Root Folder",
       "logs": "Mga Log",
       "general": "Pangkalahatan",
@@ -411,7 +411,10 @@
       "logRetention": "Log Retention",
       "logRetentionLabel": "Keep log entries for",
       "logRetentionHint": "Log entries older than this are deleted by the daily trim job.",
-      "days": "days"
+      "days": "days",
+      "naming": {
+        "hintEmpty": "Kinakailangan — maglagay ng kahit isang token o path segment."
+      }
     },
     "import": {
       "csvHeading": "CSV ng mga pangalan ng may-akda",

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -231,7 +231,7 @@
       "notifications": "Mga Notification",
       "quality": "Mga Quality Profile",
       "metadata": "Mga Metadata Profile",
-      "import": "Mag-import",
+      "import": "Import / Migrate",
       "rootfolders": "Mga Root Folder",
       "logs": "Mga Log",
       "general": "Pangkalahatan",

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -623,38 +623,40 @@ describe('SettingsPage', () => {
     expect(screen.queryByText('settings.general.scanNoFilesWarning')).not.toBeInTheDocument()
   })
 
-  it('persists default root folder and media type choices', async () => {
-    const existing = makeRootFolder({ id: 7, path: '/mnt/books' })
-    const added = makeRootFolder({ id: 8, path: '/mnt/audiobooks' })
-
+  it('soft-navigates to Root Folders from the Default library location link', async () => {
+    // #1108 removed the duplicate root-folder selector from General; the
+    // "Default library location" section is now an informational pointer to the
+    // Root Folders tab. The link must switch tabs in place (soft nav) rather
+    // than full-page-reload.
     renderSettings({
-      rootFolders: [existing],
+      rootFolders: [makeRootFolder({ id: 7, path: '/mnt/books' })],
       settings: [
-        { key: 'library.defaultRootFolderId', value: '' },
         { key: 'default.media_type', value: 'ebook' },
         { key: 'hardcover.enhanced_series_enabled', value: 'false' },
       ],
     })
-    vi.mocked(api.addRootFolder).mockResolvedValue(added)
 
     await screen.findByRole('heading', { name: 'Default library location' })
     const defaultLocation = sectionForHeading('Default library location')
+    // No functional root-folder selector lives here anymore.
+    expect(defaultLocation.queryByRole('combobox')).not.toBeInTheDocument()
 
-    fireEvent.change(defaultLocation.getByRole('combobox'), { target: { value: '7' } })
-    await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('library.defaultRootFolderId', '7')
+    fireEvent.click(defaultLocation.getByRole('button', { name: 'Manage in Root Folders →' }))
+    // Soft nav: the Root Folders tab content renders without a page reload.
+    expect(await screen.findByRole('heading', { name: 'settings.rootfolders.heading' })).toBeInTheDocument()
+    expect(new URLSearchParams(window.location.search).get('tab')).toBe('rootfolders')
+  })
+
+  it('persists media type and monitor mode author defaults', async () => {
+    renderSettings({
+      rootFolders: [makeRootFolder({ id: 7, path: '/mnt/books' })],
+      settings: [
+        { key: 'default.media_type', value: 'ebook' },
+        { key: 'hardcover.enhanced_series_enabled', value: 'false' },
+      ],
     })
 
-    fireEvent.click(defaultLocation.getByRole('button', { name: '+ Add root folder' }))
-    fireEvent.change(defaultLocation.getByPlaceholderText('/mnt/books'), { target: { value: ' /mnt/audiobooks ' } })
-    fireEvent.click(defaultLocation.getByRole('button', { name: 'Add' }))
-
-    await waitFor(() => expect(api.addRootFolder).toHaveBeenCalledWith('/mnt/audiobooks'))
-    await waitFor(() => {
-      expect(api.setSetting).toHaveBeenCalledWith('library.defaultRootFolderId', '8')
-    })
-    expect(defaultLocation.getByRole('combobox')).toHaveValue('8')
-
+    await screen.findByRole('heading', { name: 'Author defaults' })
     const authorDefaults = sectionForHeading('Author defaults')
     const authorDefaultSelects = authorDefaults.getAllByRole('combobox')
     fireEvent.change(authorDefaultSelects[0], { target: { value: 'audiobook' } })

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -170,7 +170,19 @@ export default function SettingsPage() {
                 <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-zinc-600 px-3 mb-1">Integrations</p>
                 <SettingsNavLink tab="calibre" active={tab} onSelect={setTab} label={t('settings.tabs.calibre')} />
                 <SettingsNavLink tab="abs" active={tab} onSelect={setTab} label={t('settings.tabs.abs')} />
-                <SettingsNavLink tab="grimmory" active={tab} onSelect={setTab} label={t('settings.tabs.grimmory')} />
+                <button
+                  onClick={() => setTab('grimmory')}
+                  className={`w-full text-left px-3 py-1.5 rounded-md text-sm transition-colors flex items-center gap-2 ${
+                    tab === 'grimmory'
+                      ? 'bg-slate-200 dark:bg-zinc-800 text-slate-900 dark:text-white font-medium'
+                      : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-zinc-800/50'
+                  }`}
+                >
+                  <span>{t('settings.tabs.grimmory')}</span>
+                  <span className="text-[9px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400 font-medium leading-none">
+                    Preview
+                  </span>
+                </button>
               </div>
 
               <div className="pt-3 pb-0.5">

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -99,6 +99,15 @@ export default function SettingsPage() {
     } catch { /* ignore — tab state still updates */ }
   }, [])
 
+  // Soft cross-tab navigation passed to tabs (e.g. General's "Manage in Root
+  // Folders →", Import's "Configure … in General settings →") so those links
+  // switch tabs in place via setTab instead of window.location.assign, which
+  // would full-page-reload the SPA. Validates the incoming tab id against
+  // ALL_TABS so a bad caller can't desync the UI.
+  const navigateToTab = useCallback((next: string) => {
+    if ((ALL_TABS as string[]).includes(next)) setTab(next as Tab)
+  }, [setTab])
+
   // Eagerly fetched on page mount (cross-tab — see file header note).
   const [indexers, setIndexers] = useState<Indexer[]>([])
   const [clients, setClients] = useState<DownloadClient[]>([])
@@ -117,7 +126,7 @@ export default function SettingsPage() {
 
   const renderTab = () => {
     switch (tab) {
-      case 'general': return <GeneralTab />
+      case 'general': return <GeneralTab onNavigate={navigateToTab} />
       case 'indexers': return <IndexersTab indexers={indexers} setIndexers={setIndexers} prowlarrInstances={prowlarrInstances} setProwlarrInstances={setProwlarrInstances} />
       case 'clients': return <ClientsTab clients={clients} setClients={setClients} />
       case 'notifications': return <NotificationsTab />
@@ -127,7 +136,7 @@ export default function SettingsPage() {
       case 'calibre': return <CalibreTab />
       case 'abs': return <ABSTab />
       case 'grimmory': return <GrimmoryTab />
-      case 'import': return <ImportTab />
+      case 'import': return <ImportTab onNavigate={navigateToTab} />
       case 'blocklist': return <BlocklistTab />
       case 'logs': return <LogsTab />
     }

--- a/web/src/pages/settings/CalibreTab.tsx
+++ b/web/src/pages/settings/CalibreTab.tsx
@@ -8,6 +8,7 @@ import {
   CalibreSyncProgress,
 } from '../../api/client'
 import Toggle from './Toggle'
+import { useSaveResult } from './useSaveResult'
 
 export default function CalibreTab() {
   const [settings, setSettings] = useState<Record<string, string>>({})
@@ -62,6 +63,11 @@ function CalibreSection({
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<{ ok: boolean; msg: string } | null>(null)
   const [saveError, setSaveError] = useState<{ key: string; msg: string } | null>(null)
+  const [libraryPathSaveResult, libraryPathSave] = useSaveResult()
+  const [binaryPathSaveResult, binaryPathSave] = useSaveResult()
+  const [pluginUrlSaveResult, pluginUrlSave] = useSaveResult()
+  const [pluginKeySaveResult, pluginKeySave] = useSaveResult()
+  const [cwaPathSaveResult, cwaPathSave] = useSaveResult()
   const [importProgress, setImportProgress] = useState<CalibreImportProgress | null>(null)
   const [importError, setImportError] = useState<string | null>(null)
   const [syncProgress, setSyncProgress] = useState<CalibreSyncProgress | null>(null)
@@ -72,11 +78,14 @@ function CalibreSection({
   const [runs, setRuns] = useState<CalibreImportRun[]>([])
   const [rollbackRun, setRollbackRun] = useState<CalibreImportRun | null>(null)
 
-  const saveSettingWithError = async (key: string) => {
+  const saveSettingWithErrorThrowing = async (key: string) => {
     setSaveError(null)
     setTestResult(null)
     const err = await saveSetting(key)
-    if (err) setSaveError({ key, msg: err })
+    if (err) {
+      setSaveError({ key, msg: err })
+      throw new Error(err)
+    }
   }
 
   // Legacy fallback: a pre-migration DB with `calibre.enabled=true` but no
@@ -224,11 +233,11 @@ function CalibreSection({
               className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
             />
             <button
-              onClick={() => saveSettingWithError('calibre.library_path')}
+              onClick={() => libraryPathSave(() => saveSettingWithErrorThrowing('calibre.library_path'))}
               disabled={saving === 'calibre.library_path'}
-              className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+              className={`px-3 py-2 rounded text-xs font-medium disabled:opacity-50 ${libraryPathSaveResult === 'saved' ? 'bg-emerald-500' : libraryPathSaveResult === 'error' ? 'bg-red-600' : 'bg-emerald-600 hover:bg-emerald-500'}`}
             >
-              {saving === 'calibre.library_path' ? 'Saving...' : 'Save'}
+              {libraryPathSaveResult === 'saved' ? 'Saved ✓' : libraryPathSaveResult === 'error' ? 'Error' : saving === 'calibre.library_path' ? 'Saving...' : 'Save'}
             </button>
           </div>
           {saveError?.key === 'calibre.library_path' && (
@@ -274,11 +283,11 @@ function CalibreSection({
                 className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
               />
               <button
-                onClick={() => saveSettingWithError('calibre.binary_path')}
+                onClick={() => binaryPathSave(() => saveSettingWithErrorThrowing('calibre.binary_path'))}
                 disabled={saving === 'calibre.binary_path'}
-                className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+                className={`px-3 py-2 rounded text-xs font-medium disabled:opacity-50 ${binaryPathSaveResult === 'saved' ? 'bg-emerald-500' : binaryPathSaveResult === 'error' ? 'bg-red-600' : 'bg-emerald-600 hover:bg-emerald-500'}`}
               >
-                {saving === 'calibre.binary_path' ? 'Saving...' : 'Save'}
+                {binaryPathSaveResult === 'saved' ? 'Saved ✓' : binaryPathSaveResult === 'error' ? 'Error' : saving === 'calibre.binary_path' ? 'Saving...' : 'Save'}
               </button>
             </div>
             {saveError?.key === 'calibre.binary_path' && (
@@ -301,11 +310,11 @@ function CalibreSection({
                 className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
               />
               <button
-                onClick={() => saveSettingWithError('calibre.plugin_url')}
+                onClick={() => pluginUrlSave(() => saveSettingWithErrorThrowing('calibre.plugin_url'))}
                 disabled={saving === 'calibre.plugin_url'}
-                className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+                className={`px-3 py-2 rounded text-xs font-medium disabled:opacity-50 ${pluginUrlSaveResult === 'saved' ? 'bg-emerald-500' : pluginUrlSaveResult === 'error' ? 'bg-red-600' : 'bg-emerald-600 hover:bg-emerald-500'}`}
               >
-                {saving === 'calibre.plugin_url' ? 'Saving...' : 'Save'}
+                {pluginUrlSaveResult === 'saved' ? 'Saved ✓' : pluginUrlSaveResult === 'error' ? 'Error' : saving === 'calibre.plugin_url' ? 'Saving...' : 'Save'}
               </button>
             </div>
             {saveError?.key === 'calibre.plugin_url' && (
@@ -329,11 +338,11 @@ function CalibreSection({
                 className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
               />
               <button
-                onClick={() => saveSettingWithError('calibre.plugin_api_key')}
+                onClick={() => pluginKeySave(() => saveSettingWithErrorThrowing('calibre.plugin_api_key'))}
                 disabled={saving === 'calibre.plugin_api_key'}
-                className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+                className={`px-3 py-2 rounded text-xs font-medium disabled:opacity-50 ${pluginKeySaveResult === 'saved' ? 'bg-emerald-500' : pluginKeySaveResult === 'error' ? 'bg-red-600' : 'bg-emerald-600 hover:bg-emerald-500'}`}
               >
-                {saving === 'calibre.plugin_api_key' ? 'Saving...' : 'Save'}
+                {pluginKeySaveResult === 'saved' ? 'Saved ✓' : pluginKeySaveResult === 'error' ? 'Error' : saving === 'calibre.plugin_api_key' ? 'Saving...' : 'Save'}
               </button>
             </div>
             {saveError?.key === 'calibre.plugin_api_key' && (
@@ -511,11 +520,11 @@ function CalibreSection({
               className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
             />
             <button
-              onClick={() => saveSettingWithError('cwa.ingest_path')}
+              onClick={() => cwaPathSave(() => saveSettingWithErrorThrowing('cwa.ingest_path'))}
               disabled={saving === 'cwa.ingest_path'}
-              className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+              className={`px-3 py-2 rounded text-xs font-medium disabled:opacity-50 ${cwaPathSaveResult === 'saved' ? 'bg-emerald-500' : cwaPathSaveResult === 'error' ? 'bg-red-600' : 'bg-emerald-600 hover:bg-emerald-500'}`}
             >
-              {saving === 'cwa.ingest_path' ? 'Saving...' : 'Save'}
+              {cwaPathSaveResult === 'saved' ? 'Saved ✓' : cwaPathSaveResult === 'error' ? 'Error' : saving === 'cwa.ingest_path' ? 'Saving...' : 'Save'}
             </button>
           </div>
           {saveError?.key === 'cwa.ingest_path' && (

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -37,7 +37,14 @@ function isAuthorMonitorMode(value: string): value is AuthorMonitorMode {
   return value === 'all' || value === 'future' || value === 'latest' || value === 'none'
 }
 
-export default function GeneralTab() {
+// Tab identifiers used by onNavigate for soft (no-reload) cross-tab links.
+// Kept loose (string) so GeneralTab doesn't need to import SettingsPage's Tab
+// union; SettingsPage validates the value.
+export interface GeneralTabProps {
+  onNavigate?: (tab: string) => void
+}
+
+export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
   const { t } = useTranslation()
   const { isAdmin } = useAuth()
   const opdsClipboard = useClipboardCopy()
@@ -45,6 +52,8 @@ export default function GeneralTab() {
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState<string | null>(null)
   const [dropErr, setDropErr] = useState<string | null>(null)
+  const [langErr, setLangErr] = useState<string | null>(null)
+  const [logRetentionErr, setLogRetentionErr] = useState<string | null>(null)
   const [backups, setBackups] = useState<Array<{ name: string; size: number; modTime: string }>>([])
   const [creatingBackup, setCreatingBackup] = useState(false)
   const [deletingBackup, setDeletingBackup] = useState<string | null>(null)
@@ -117,6 +126,39 @@ export default function GeneralTab() {
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Save failed'
       setDropErr(msg)
+      throw err
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  // savePreferredLanguage / saveLogRetention mirror saveDropFolder: they set
+  // and clear `saving` (so the disabled guard fires and "Saving…" shows) and
+  // throw on failure so useSaveResult flips to 'error' AND a visible message is
+  // surfaced inline — instead of routing api.setSetting straight into
+  // useSaveResult, which set neither `saving` nor any error text.
+  const savePreferredLanguage = async () => {
+    setSaving('search.preferredLanguage')
+    setLangErr(null)
+    try {
+      await api.setSetting('search.preferredLanguage', settings['search.preferredLanguage'] ?? '')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Save failed'
+      setLangErr(msg)
+      throw err
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  const saveLogRetention = async () => {
+    setSaving('log.retention_days')
+    setLogRetentionErr(null)
+    try {
+      await api.setSetting('log.retention_days', settings['log.retention_days'] ?? '')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Save failed'
+      setLogRetentionErr(msg)
       throw err
     } finally {
       setSaving(null)
@@ -446,13 +488,14 @@ export default function GeneralTab() {
                 <option value="en">{t('settings.general.preferredLanguageEn')}</option>
               </select>
               <button
-                onClick={() => langSave(() => api.setSetting('search.preferredLanguage', settings['search.preferredLanguage'] ?? ''))}
+                onClick={() => langSave(savePreferredLanguage)}
                 disabled={saving === 'search.preferredLanguage'}
                 className={`px-3 py-2 rounded text-xs font-medium disabled:opacity-50 ${langSaveResult === 'saved' ? 'bg-emerald-500' : langSaveResult === 'error' ? 'bg-red-600' : 'bg-emerald-600 hover:bg-emerald-500'}`}
               >
                 {langSaveResult === 'saved' ? 'Saved ✓' : langSaveResult === 'error' ? 'Error' : saving === 'search.preferredLanguage' ? t('common.saving') : t('common.save')}
               </button>
             </div>
+            {langErr && <p className="text-xs text-red-600 dark:text-red-400 mt-1">{langErr}</p>}
           </div>
         </div>
       </section>
@@ -616,7 +659,7 @@ export default function GeneralTab() {
             Manage root folders and the default library location in the Root Folders tab.
           </p>
           <button
-            onClick={() => window.location.assign('/settings?tab=rootfolders')}
+            onClick={() => onNavigate ? onNavigate('rootfolders') : window.location.assign('/settings?tab=rootfolders')}
             className="text-sm text-emerald-600 dark:text-emerald-400 hover:underline"
           >
             Manage in Root Folders →
@@ -926,7 +969,7 @@ export default function GeneralTab() {
               />
               <span className="text-sm text-slate-600 dark:text-zinc-400">{t('settings.general.days')}</span>
               <button
-                onClick={() => logRetentionSave(() => api.setSetting('log.retention_days', settings['log.retention_days'] ?? ''))}
+                onClick={() => logRetentionSave(saveLogRetention)}
                 disabled={saving === 'log.retention_days'}
                 className={`px-3 py-1.5 rounded text-sm font-medium disabled:opacity-50 ${logRetentionSaveResult === 'saved' ? 'bg-emerald-500' : logRetentionSaveResult === 'error' ? 'bg-red-600' : 'bg-emerald-600 hover:bg-emerald-500'}`}
               >
@@ -934,6 +977,7 @@ export default function GeneralTab() {
               </button>
             </div>
           </div>
+          {logRetentionErr && <p className="text-xs text-red-600 dark:text-red-400 mt-2">{logRetentionErr}</p>}
         </div>
       </section>
 

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '../../auth/AuthContext'
 import { inputCls } from './formStyles'
 import Toggle from './Toggle'
 import NamingTemplateField from './NamingTemplateField'
+import { useSaveResult } from './useSaveResult'
 
 function formatBackupSize(bytes: number): string {
   if (!bytes || bytes <= 0) return '0 B'
@@ -67,6 +68,10 @@ export default function GeneralTab() {
   const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null)
   const [hardcoverToken, setHardcoverToken] = useState('')
   const [hardcoverTestResult, setHardcoverTestResult] = useState<(HardcoverTestResult & { testing?: boolean }) | null>(null)
+  const [langSaveResult, langSave] = useSaveResult()
+  const [logRetentionSaveResult, logRetentionSave] = useSaveResult()
+  const [dropSaveResult, dropSave] = useSaveResult()
+
   useEffect(() => {
     api.listSettings()
       .then(list => {
@@ -110,7 +115,9 @@ export default function GeneralTab() {
     try {
       await api.setSetting('import.drop_folder', settings['import.drop_folder'] ?? '')
     } catch (err) {
-      setDropErr(err instanceof Error ? err.message : 'Save failed')
+      const msg = err instanceof Error ? err.message : 'Save failed'
+      setDropErr(msg)
+      throw err
     } finally {
       setSaving(null)
     }
@@ -357,11 +364,11 @@ export default function GeneralTab() {
                     className={inputCls + ' flex-1'}
                   />
                   <button
-                    onClick={saveDropFolder}
+                    onClick={() => dropSave(saveDropFolder)}
                     disabled={saving === 'import.drop_folder'}
-                    className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+                    className={`px-3 py-2 rounded text-xs font-medium disabled:opacity-50 ${dropSaveResult === 'saved' ? 'bg-emerald-500' : dropSaveResult === 'error' ? 'bg-red-600' : 'bg-emerald-600 hover:bg-emerald-500'}`}
                   >
-                    {saving === 'import.drop_folder' ? t('common.saving') : t('common.save')}
+                    {dropSaveResult === 'saved' ? 'Saved ✓' : dropSaveResult === 'error' ? 'Error' : saving === 'import.drop_folder' ? t('common.saving') : t('common.save')}
                   </button>
                 </div>
                 {dropErr && <p className="text-xs text-red-600 dark:text-red-400 mt-1">{dropErr}</p>}
@@ -439,11 +446,11 @@ export default function GeneralTab() {
                 <option value="en">{t('settings.general.preferredLanguageEn')}</option>
               </select>
               <button
-                onClick={() => saveSetting('search.preferredLanguage')}
+                onClick={() => langSave(() => api.setSetting('search.preferredLanguage', settings['search.preferredLanguage'] ?? ''))}
                 disabled={saving === 'search.preferredLanguage'}
-                className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium disabled:opacity-50"
+                className={`px-3 py-2 rounded text-xs font-medium disabled:opacity-50 ${langSaveResult === 'saved' ? 'bg-emerald-500' : langSaveResult === 'error' ? 'bg-red-600' : 'bg-emerald-600 hover:bg-emerald-500'}`}
               >
-                {saving === 'search.preferredLanguage' ? t('common.saving') : t('common.save')}
+                {langSaveResult === 'saved' ? 'Saved ✓' : langSaveResult === 'error' ? 'Error' : saving === 'search.preferredLanguage' ? t('common.saving') : t('common.save')}
               </button>
             </div>
           </div>
@@ -919,11 +926,11 @@ export default function GeneralTab() {
               />
               <span className="text-sm text-slate-600 dark:text-zinc-400">{t('settings.general.days')}</span>
               <button
-                onClick={() => saveSetting('log.retention_days')}
+                onClick={() => logRetentionSave(() => api.setSetting('log.retention_days', settings['log.retention_days'] ?? ''))}
                 disabled={saving === 'log.retention_days'}
-                className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium disabled:opacity-50"
+                className={`px-3 py-1.5 rounded text-sm font-medium disabled:opacity-50 ${logRetentionSaveResult === 'saved' ? 'bg-emerald-500' : logRetentionSaveResult === 'error' ? 'bg-red-600' : 'bg-emerald-600 hover:bg-emerald-500'}`}
               >
-                {saving === 'log.retention_days' ? t('common.saving') : t('common.save')}
+                {logRetentionSaveResult === 'saved' ? 'Saved ✓' : logRetentionSaveResult === 'error' ? 'Error' : saving === 'log.retention_days' ? t('common.saving') : t('common.save')}
               </button>
             </div>
           </div>

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -1134,9 +1134,6 @@ function SecuritySection() {
         {isAdmin && (<>
         <div>
           <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Authentication Mode</label>
-          <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
-            <strong>Enabled</strong>: always require login. <strong>Local only</strong>: skip login for requests from private IPs (home network). <strong>Disabled</strong>: no authentication — only safe behind a trusted reverse proxy.
-          </p>
           <select
             value={cfg.mode}
             onChange={e => setMode(e.target.value as AuthStatus['mode'])}
@@ -1147,6 +1144,9 @@ function SecuritySection() {
             <option value="local-only">Local only (bypass for private IPs)</option>
             <option value="disabled">Disabled (no auth)</option>
           </select>
+          {cfg.mode === 'enabled' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Always requires login, regardless of network origin.</p>}
+          {cfg.mode === 'local-only' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Login is bypassed for requests from private / LAN IP ranges. Still requires login from the internet.</p>}
+          {cfg.mode === 'disabled' && <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">No authentication — only safe when Bindery is behind a trusted reverse proxy that enforces access control.</p>}
         </div>
 
         <div className="border-t border-slate-200 dark:border-zinc-800 pt-4">
@@ -1170,6 +1170,11 @@ function SecuritySection() {
           </div>
           {apiKeyClipboard.status === 'manual' && (
             <ClipboardManualFallback text={apiKeyClipboard.manualText} className="mt-2" />
+          )}
+          {!showKey && (
+            <p className="text-[11px] text-slate-500 dark:text-zinc-500 mt-1">
+              Regenerating invalidates the current key — update all external integrations afterward.
+            </p>
           )}
         </div>
 

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, BINDERY_BASE, AuthConfig, AuthStatus, AuthorMonitorMode, HardcoverTestResult, RootFolder, SystemStatus } from '../../api/client'
+import { api, BINDERY_BASE, AuthConfig, AuthStatus, AuthorMonitorMode, HardcoverTestResult, SystemStatus } from '../../api/client'
 import AuthSettings from '../../settings/AuthSettings'
 import ThemeToggle from '../../components/ThemeToggle'
 import LanguageSwitcher from '../../components/LanguageSwitcher'
@@ -67,11 +67,6 @@ export default function GeneralTab() {
   const [systemStatus, setSystemStatus] = useState<SystemStatus | null>(null)
   const [hardcoverToken, setHardcoverToken] = useState('')
   const [hardcoverTestResult, setHardcoverTestResult] = useState<(HardcoverTestResult & { testing?: boolean }) | null>(null)
-  const [rootFolders, setRootFolders] = useState<RootFolder[]>([])
-  const [newDefaultFolderPath, setNewDefaultFolderPath] = useState('')
-  const [newDefaultFolderError, setNewDefaultFolderError] = useState('')
-  const [addingDefaultFolder, setAddingDefaultFolder] = useState(false)
-
   useEffect(() => {
     api.listSettings()
       .then(list => {
@@ -85,7 +80,6 @@ export default function GeneralTab() {
     api.libraryScanStatus().then(setLastScan).catch(() => {/* no prior scan — ignore 404 */})
     api.getStorage().then(setStorage).catch(console.error)
     api.status().then(setSystemStatus).catch(console.error)
-    api.listRootFolders().then(setRootFolders).catch(console.error)
   }, [])
 
   const refreshSystemStatus = async () => {
@@ -610,73 +604,16 @@ export default function GeneralTab() {
       {/* Default library location */}
       <section>
         <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">Default library location</h3>
-        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900 space-y-3">
-          <div>
-            <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200 mb-1">Default root folder</label>
-            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
-              When an author has no per-author root folder set, Bindery uses this location. Leave unset to fall back to <code className="font-mono bg-slate-200 dark:bg-zinc-800 px-1 rounded">BINDERY_LIBRARY_DIR</code>.
-            </p>
-            <select
-              value={settings['library.defaultRootFolderId'] ?? ''}
-              onChange={async e => {
-                const next = e.target.value
-                setSettings(s => ({ ...s, 'library.defaultRootFolderId': next }))
-                await api.setSetting('library.defaultRootFolderId', next).catch(console.error)
-              }}
-              className="w-full bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
-            >
-              <option value="">— Unset (use BINDERY_LIBRARY_DIR) —</option>
-              {rootFolders.map(rf => (
-                <option key={rf.id} value={String(rf.id)}>{rf.path}</option>
-              ))}
-            </select>
-          </div>
-          {!addingDefaultFolder ? (
-            <button
-              onClick={() => { setAddingDefaultFolder(true); setNewDefaultFolderError('') }}
-              className="text-xs text-emerald-600 dark:text-emerald-400 hover:underline"
-            >
-              + Add root folder
-            </button>
-          ) : (
-            <div className="space-y-2">
-              <label className="block text-xs text-slate-600 dark:text-zinc-400">New root folder path</label>
-              <div className="flex gap-2">
-                <input
-                  value={newDefaultFolderPath}
-                  onChange={e => setNewDefaultFolderPath(e.target.value)}
-                  placeholder="/mnt/books"
-                  className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-emerald-500 font-mono"
-                />
-                <button
-                  onClick={async () => {
-                    if (!newDefaultFolderPath.trim()) return
-                    setNewDefaultFolderError('')
-                    try {
-                      const created = await api.addRootFolder(newDefaultFolderPath.trim())
-                      setRootFolders(prev => [...prev, created])
-                      setSettings(s => ({ ...s, 'library.defaultRootFolderId': String(created.id) }))
-                      await api.setSetting('library.defaultRootFolderId', String(created.id)).catch(console.error)
-                      setNewDefaultFolderPath('')
-                      setAddingDefaultFolder(false)
-                    } catch (err) {
-                      setNewDefaultFolderError(err instanceof Error ? err.message : 'Failed to add folder')
-                    }
-                  }}
-                  className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium"
-                >
-                  Add
-                </button>
-                <button
-                  onClick={() => { setAddingDefaultFolder(false); setNewDefaultFolderPath(''); setNewDefaultFolderError('') }}
-                  className="px-3 py-2 bg-slate-300 dark:bg-zinc-700 hover:bg-slate-400 dark:hover:bg-zinc-600 rounded text-xs font-medium"
-                >
-                  Cancel
-                </button>
-              </div>
-              {newDefaultFolderError && <p className="text-xs text-red-500">{newDefaultFolderError}</p>}
-            </div>
-          )}
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+          <p className="text-xs text-slate-600 dark:text-zinc-500 mb-3">
+            Manage root folders and the default library location in the Root Folders tab.
+          </p>
+          <button
+            onClick={() => window.location.assign('/settings?tab=rootfolders')}
+            className="text-sm text-emerald-600 dark:text-emerald-400 hover:underline"
+          >
+            Manage in Root Folders →
+          </button>
         </div>
       </section>
 

--- a/web/src/pages/settings/ImportTab.tsx
+++ b/web/src/pages/settings/ImportTab.tsx
@@ -553,7 +553,21 @@ function HardcoverListsSection() {
         })}
       </div>
 
-      {error && <p className="mt-2 text-xs text-red-600 dark:text-red-400">{error}</p>}
+      {error && (
+        <div className="mt-2 text-sm text-rose-600 dark:text-rose-400">
+          {error}
+          {(error.toLowerCase().includes('token') || error.toLowerCase().includes('not configured')) && (
+            <span className="block mt-1 text-xs">
+              <button
+                onClick={() => window.location.assign('/settings?tab=general')}
+                className="text-emerald-600 dark:text-emerald-400 hover:underline"
+              >
+                Configure the Hardcover API token in General settings →
+              </button>
+            </span>
+          )}
+        </div>
+      )}
     </section>
   )
 }

--- a/web/src/pages/settings/ImportTab.tsx
+++ b/web/src/pages/settings/ImportTab.tsx
@@ -20,7 +20,13 @@ interface ReadarrResult {
   blocklist?: MigrateResult
 }
 
-export default function ImportTab() {
+// onNavigate threads SettingsPage's soft (no-reload) tab switch into the
+// "Configure … in General settings →" link so it doesn't full-page-reload.
+export interface ImportTabProps {
+  onNavigate?: (tab: string) => void
+}
+
+export default function ImportTab({ onNavigate }: ImportTabProps = {}) {
   const { t } = useTranslation()
   const [csvResult, setCsvResult] = useState<MigrateResult | null>(null)
   const [readarrResult, setReadarrResult] = useState<ReadarrResult | null>(null)
@@ -113,7 +119,7 @@ export default function ImportTab() {
       </section>
       <ManualImportSection />
       <GoodreadsImportSection />
-      <HardcoverListsSection />
+      <HardcoverListsSection onNavigate={onNavigate} />
 
       {err && (
         <div className="px-3 py-2 bg-red-100 dark:bg-red-950/30 border border-red-300 dark:border-red-900 rounded text-sm text-red-800 dark:text-red-300">
@@ -269,7 +275,7 @@ interface HardcoverImportListRow {
   stale: boolean
 }
 
-function HardcoverListsSection() {
+function HardcoverListsSection({ onNavigate }: { onNavigate?: (tab: string) => void }) {
   const { t } = useTranslation()
   const [lists, setLists] = useState<ImportList[]>([])
   const [hcLists, setHcLists] = useState<HardcoverList[]>([])
@@ -559,7 +565,7 @@ function HardcoverListsSection() {
           {(error.toLowerCase().includes('token') || error.toLowerCase().includes('not configured')) && (
             <span className="block mt-1 text-xs">
               <button
-                onClick={() => window.location.assign('/settings?tab=general')}
+                onClick={() => onNavigate ? onNavigate('general') : window.location.assign('/settings?tab=general')}
                 className="text-emerald-600 dark:text-emerald-400 hover:underline"
               >
                 Configure the Hardcover API token in General settings →

--- a/web/src/pages/settings/LogsTab.tsx
+++ b/web/src/pages/settings/LogsTab.tsx
@@ -51,6 +51,7 @@ export default function LogsTab() {
 
         {/* Level filter pills */}
         <div className="flex items-center gap-1.5 text-xs">
+          <span className="text-[10px] font-medium uppercase text-slate-400 dark:text-zinc-600 mr-1">View</span>
           {(['all', 'debug', 'info', 'warn', 'error'] as const).map(f => (
             <button
               key={f}
@@ -68,7 +69,7 @@ export default function LogsTab() {
 
         {/* Runtime log level */}
         <div className="flex items-center gap-2 text-xs">
-          <span className="text-slate-500 dark:text-zinc-500">{t('settings.logs.level')}</span>
+          <span className="text-slate-500 dark:text-zinc-500 font-medium">Runtime level</span>
           <select
             value={logLevel}
             onChange={async e => {
@@ -76,6 +77,7 @@ export default function LogsTab() {
               await api.setLogLevel(l).catch(console.error)
               setLogLevel(l)
             }}
+            title="Controls which log levels are written to the database"
             className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-2 py-1 text-xs"
           >
             {['debug', 'info', 'warn', 'error'].map(l => (

--- a/web/src/pages/settings/MetadataTab.tsx
+++ b/web/src/pages/settings/MetadataTab.tsx
@@ -77,8 +77,8 @@ export default function MetadataTab() {
                   <div className="min-w-0">
                     <h4 className="font-medium text-sm">{p.name}</h4>
                     <div className="flex flex-wrap gap-3 mt-2 text-xs text-slate-600 dark:text-zinc-400">
-                      <span>{t('settings.metadata.minPopularity')} <span className="text-slate-800 dark:text-zinc-200">{p.minPopularity}</span></span>
-                      <span>{t('settings.metadata.minPages')} <span className="text-slate-800 dark:text-zinc-200">{p.minPages}</span></span>
+                      <span>{t('settings.metadata.minPopularity')} <span className="text-slate-800 dark:text-zinc-200">{p.minPopularity === 0 ? 'none' : p.minPopularity}</span></span>
+                      <span>{t('settings.metadata.minPages')} <span className="text-slate-800 dark:text-zinc-200">{p.minPages === 0 ? 'none' : p.minPages}</span></span>
                       <span>{t('settings.metadata.languages')} <span className="text-slate-800 dark:text-zinc-200">{formatLanguageList(p.allowedLanguages)}</span></span>
                     </div>
                     <div className="flex flex-wrap gap-1.5 mt-2">

--- a/web/src/pages/settings/NamingTemplateField.test.tsx
+++ b/web/src/pages/settings/NamingTemplateField.test.tsx
@@ -116,9 +116,12 @@ describe('NamingTemplateField component', () => {
     expect(save.disabled).toBe(true)
   })
 
-  it('blocks save on an empty template', () => {
+  it('blocks save on an empty template and announces it', () => {
     render(<Harness initial="" />)
-    expect(screen.getByText('settings.general.naming.errorEmpty')).toBeTruthy()
+    // The empty-template message is announced (role="alert") while Save stays
+    // blocked, so screen-reader users hear why the button is disabled.
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('settings.general.naming.hintEmpty')
     const save = screen.getByRole('button', { name: 'common.save' }) as HTMLButtonElement
     expect(save.disabled).toBe(true)
   })

--- a/web/src/pages/settings/NamingTemplateField.tsx
+++ b/web/src/pages/settings/NamingTemplateField.tsx
@@ -133,8 +133,8 @@ export default function NamingTemplateField({
 
       {/* Validation feedback */}
       {validation.empty && (
-        <p className="text-xs text-red-600 dark:text-red-400 mt-1.5" role="alert">
-          {t('settings.general.naming.errorEmpty')}
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1.5">
+          {t('settings.general.naming.hintEmpty', 'Required — enter at least one token or path segment.')}
         </p>
       )}
       {validation.traversal && (

--- a/web/src/pages/settings/NamingTemplateField.tsx
+++ b/web/src/pages/settings/NamingTemplateField.tsx
@@ -133,7 +133,10 @@ export default function NamingTemplateField({
 
       {/* Validation feedback */}
       {validation.empty && (
-        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1.5">
+        // role="alert" so screen readers announce the still-blocking empty
+        // state (Save stays disabled). Kept visually muted — it's a "required"
+        // prompt, not a hard error like traversal — but still announced.
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1.5" role="alert">
           {t('settings.general.naming.hintEmpty', 'Required — enter at least one token or path segment.')}
         </p>
       )}

--- a/web/src/pages/settings/QualityTab.test.tsx
+++ b/web/src/pages/settings/QualityTab.test.tsx
@@ -64,11 +64,13 @@ describe('QualityTab', () => {
     await waitFor(() => {
       expect(screen.getByText('Ebook Preferred')).toBeInTheDocument()
     })
-    // Each item is rendered as a chip; "epub" appears both as a chip and as
-    // the cutoff value, so prefer getAllByText for that one.
-    expect(screen.getByText('pdf')).toBeInTheDocument()
-    expect(screen.getByText('mobi')).toBeInTheDocument()
-    expect(screen.getAllByText('epub').length).toBeGreaterThan(0)
+    // Each item is rendered as a numbered chip ("1. pdf", "2. mobi", …) so the
+    // preference order is visible. "epub" also appears as the cutoff value, so
+    // prefer getAllByText for that one.
+    expect(screen.getByText('1. pdf')).toBeInTheDocument()
+    expect(screen.getByText('2. mobi')).toBeInTheDocument()
+    expect(screen.getByText('3. epub')).toBeInTheDocument()
+    expect(screen.getAllByText('epub', { exact: false }).length).toBeGreaterThan(0)
     // Cutoff label rendered.
     expect(screen.getByText('settings.quality.cutoff', { exact: false })).toBeInTheDocument()
   })

--- a/web/src/pages/settings/QualityTab.tsx
+++ b/web/src/pages/settings/QualityTab.tsx
@@ -134,17 +134,20 @@ function ProfileRow({
             )}
           </div>
           {profile.items && profile.items.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mt-2">
-              {profile.items.map((item, i) => (
-                <span
-                  key={`${item.quality}-${i}`}
-                  className={`text-[10px] px-2 py-0.5 rounded ${item.allowed
-                    ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300'
-                    : 'bg-slate-200 dark:bg-zinc-800 text-slate-500 dark:text-zinc-500'}`}
-                >
-                  {item.quality}
-                </span>
-              ))}
+            <div className="mt-2">
+              <p className="text-[10px] text-slate-500 dark:text-zinc-600 mb-1">Worst → best</p>
+              <div className="flex flex-wrap gap-1.5">
+                {profile.items.map((item, i) => (
+                  <span
+                    key={`${item.quality}-${i}`}
+                    className={`text-[10px] px-2 py-0.5 rounded ${item.allowed
+                      ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300'
+                      : 'bg-slate-200 dark:bg-zinc-800 text-slate-500 dark:text-zinc-500'}`}
+                  >
+                    {i + 1}. {item.quality}
+                  </span>
+                ))}
+              </div>
             </div>
           )}
         </div>

--- a/web/src/pages/settings/useSaveResult.test.tsx
+++ b/web/src/pages/settings/useSaveResult.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSaveResult } from './useSaveResult'
+
+describe('useSaveResult', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('transitions idle → saved → idle on success', async () => {
+    const { result } = renderHook(() => useSaveResult())
+    expect(result.current[0]).toBe('idle')
+
+    await act(async () => {
+      await result.current[1](() => Promise.resolve())
+    })
+    expect(result.current[0]).toBe('saved')
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current[0]).toBe('idle')
+  })
+
+  it('transitions idle → error → idle on failure', async () => {
+    const { result } = renderHook(() => useSaveResult())
+
+    await act(async () => {
+      await result.current[1](() => Promise.reject(new Error('boom')))
+    })
+    expect(result.current[0]).toBe('error')
+
+    // Error stays visible for 3s, not 2s.
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current[0]).toBe('error')
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current[0]).toBe('idle')
+  })
+
+  it('cancels a previously scheduled idle reset when save() is re-invoked', async () => {
+    const { result } = renderHook(() => useSaveResult())
+
+    await act(async () => {
+      await result.current[1](() => Promise.resolve())
+    })
+    expect(result.current[0]).toBe('saved')
+
+    // Re-save before the first 2s reset fires; the old timer must be cancelled
+    // so it can't clobber the new 'saved' state.
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    await act(async () => {
+      await result.current[1](() => Promise.resolve())
+    })
+    expect(result.current[0]).toBe('saved')
+
+    // The original timer (scheduled 1s ago) would have fired here if it were
+    // still pending; it must not, so we remain 'saved'.
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current[0]).toBe('saved')
+
+    // The new timer fires at its own 2s mark.
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current[0]).toBe('idle')
+  })
+
+  it('clears pending timers on unmount (no setState after unmount)', async () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const { result, unmount } = renderHook(() => useSaveResult())
+
+    await act(async () => {
+      await result.current[1](() => Promise.resolve())
+    })
+    expect(result.current[0]).toBe('saved')
+
+    // Unmount with a pending reset timer; cleanup must clear it.
+    unmount()
+    expect(clearSpy).toHaveBeenCalled()
+
+    // Advancing past the reset window must not throw or warn (timer gone).
+    expect(() => {
+      vi.advanceTimersByTime(3000)
+    }).not.toThrow()
+
+    clearSpy.mockRestore()
+  })
+})

--- a/web/src/pages/settings/useSaveResult.ts
+++ b/web/src/pages/settings/useSaveResult.ts
@@ -1,0 +1,21 @@
+import { useState, useCallback } from 'react'
+
+type SaveResult = 'idle' | 'saved' | 'error'
+
+export function useSaveResult(): [SaveResult, (fn: () => Promise<unknown>) => Promise<void>] {
+  const [result, setResult] = useState<SaveResult>('idle')
+
+  const save = useCallback(async (fn: () => Promise<unknown>) => {
+    setResult('idle')
+    try {
+      await fn()
+      setResult('saved')
+      setTimeout(() => setResult('idle'), 2000)
+    } catch {
+      setResult('error')
+      setTimeout(() => setResult('idle'), 3000)
+    }
+  }, [])
+
+  return [result, save]
+}

--- a/web/src/pages/settings/useSaveResult.ts
+++ b/web/src/pages/settings/useSaveResult.ts
@@ -1,21 +1,36 @@
-import { useState, useCallback } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 type SaveResult = 'idle' | 'saved' | 'error'
 
 export function useSaveResult(): [SaveResult, (fn: () => Promise<unknown>) => Promise<void>] {
   const [result, setResult] = useState<SaveResult>('idle')
+  // Holds the pending "reset to idle" timer so we can cancel a previously
+  // scheduled reset when save() is re-invoked (rapid re-clicks) and clear it
+  // on unmount — otherwise stacked timers fire setState after the component is
+  // gone (React warns) and an old reset can clobber a newer saved/error state.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = () => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }
 
   const save = useCallback(async (fn: () => Promise<unknown>) => {
+    clearTimer()
     setResult('idle')
     try {
       await fn()
       setResult('saved')
-      setTimeout(() => setResult('idle'), 2000)
+      timerRef.current = setTimeout(() => setResult('idle'), 2000)
     } catch {
       setResult('error')
-      setTimeout(() => setResult('idle'), 3000)
+      timerRef.current = setTimeout(() => setResult('idle'), 3000)
     }
   }, [])
+
+  useEffect(() => clearTimer, [])
 
   return [result, save]
 }


### PR DESCRIPTION
## Summary
- Shared useSaveResult hook gives Save buttons transient Saved ✓ / Error feedback
- Applied to Preferred Language, Log Retention, Drop Folder, and Calibre Save buttons
- Grimmory sidebar link now shows a small "Preview" badge (config-only, tracking #826)
- Import tab Hardcover lists shows a link to General settings when token is not configured

## Test plan
- [ ] Click Save on Preferred Language — button briefly shows "Saved ✓" green state
- [ ] On save failure, button briefly shows "Error" red state
- [ ] Grimmory shows "Preview" badge in sidebar (light + dark themes)
- [ ] Import tab shows link to General when Hardcover token not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)