### PR TITLE
fix(settings): copy and clarity nits — auth mode, API key confirm, log levels, quality order, naming hint

### DIFF
--- a/internal/api/import_lists.go
+++ b/internal/api/import_lists.go
@@ -151,7 +151,7 @@ func (h *ImportListHandler) HardcoverLists(w http.ResponseWriter, r *http.Reques
 		}
 		token = GetHardcoverAPIToken(r.Context(), h.settings)
 		if token == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "hardcover API token is not configured"})
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Hardcover API token is not configured"})
 			return
 		}
 	}

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -233,7 +233,7 @@ func (h *SettingsHandler) TestHardcover(w http.ResponseWriter, r *http.Request) 
 	token := GetHardcoverAPIToken(r.Context(), h.settings)
 	result := HardcoverTestResponse{TokenConfigured: token != ""}
 	if token == "" {
-		result.Error = "hardcover API token is not configured"
+		result.Error = "Hardcover API token is not configured"
 		writeJSON(w, http.StatusOK, result)
 		return
 	}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -572,7 +572,8 @@
         "tokenIgnoredAudiobook": "{{token}} is ignored for the audiobook folder template",
         "errorEmpty": "Template cannot be empty.",
         "errorTraversal": "Template must not contain \".\" or \"..\" path segments.",
-        "errorUnknownTokens": "Unknown token(s): {{tokens}}. These are case-sensitive and will be written literally."
+        "errorUnknownTokens": "Unknown token(s): {{tokens}}. These are case-sensitive and will be written literally.",
+        "hintEmpty": "Required — enter at least one token or path segment."
       },
       "apiKeys": "External API Keys",
       "googleBooksKey": "Google Books API Key",

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -1134,9 +1134,6 @@ function SecuritySection() {
         {isAdmin && (<>
         <div>
           <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Authentication Mode</label>
-          <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
-            <strong>Enabled</strong>: always require login. <strong>Local only</strong>: skip login for requests from private IPs (home network). <strong>Disabled</strong>: no authentication — only safe behind a trusted reverse proxy.
-          </p>
           <select
             value={cfg.mode}
             onChange={e => setMode(e.target.value as AuthStatus['mode'])}
@@ -1147,6 +1144,9 @@ function SecuritySection() {
             <option value="local-only">Local only (bypass for private IPs)</option>
             <option value="disabled">Disabled (no auth)</option>
           </select>
+          {cfg.mode === 'enabled' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Always requires login, regardless of network origin.</p>}
+          {cfg.mode === 'local-only' && <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">Login is bypassed for requests from private / LAN IP ranges. Still requires login from the internet.</p>}
+          {cfg.mode === 'disabled' && <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">No authentication — only safe when Bindery is behind a trusted reverse proxy that enforces access control.</p>}
         </div>
 
         <div className="border-t border-slate-200 dark:border-zinc-800 pt-4">
@@ -1170,6 +1170,11 @@ function SecuritySection() {
           </div>
           {apiKeyClipboard.status === 'manual' && (
             <ClipboardManualFallback text={apiKeyClipboard.manualText} className="mt-2" />
+          )}
+          {!showKey && (
+            <p className="text-[11px] text-slate-500 dark:text-zinc-500 mt-1">
+              Regenerating invalidates the current key — update all external integrations afterward.
+            </p>
           )}
         </div>
 

--- a/web/src/pages/settings/LogsTab.tsx
+++ b/web/src/pages/settings/LogsTab.tsx
@@ -51,6 +51,7 @@ export default function LogsTab() {
 
         {/* Level filter pills */}
         <div className="flex items-center gap-1.5 text-xs">
+          <span className="text-[10px] font-medium uppercase text-slate-400 dark:text-zinc-600 mr-1">View</span>
           {(['all', 'debug', 'info', 'warn', 'error'] as const).map(f => (
             <button
               key={f}
@@ -68,7 +69,7 @@ export default function LogsTab() {
 
         {/* Runtime log level */}
         <div className="flex items-center gap-2 text-xs">
-          <span className="text-slate-500 dark:text-zinc-500">{t('settings.logs.level')}</span>
+          <span className="text-slate-500 dark:text-zinc-500 font-medium">Runtime level</span>
           <select
             value={logLevel}
             onChange={async e => {
@@ -76,6 +77,7 @@ export default function LogsTab() {
               await api.setLogLevel(l).catch(console.error)
               setLogLevel(l)
             }}
+            title="Controls which log levels are written to the database"
             className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-2 py-1 text-xs"
           >
             {['debug', 'info', 'warn', 'error'].map(l => (

--- a/web/src/pages/settings/MetadataTab.tsx
+++ b/web/src/pages/settings/MetadataTab.tsx
@@ -77,8 +77,8 @@ export default function MetadataTab() {
                   <div className="min-w-0">
                     <h4 className="font-medium text-sm">{p.name}</h4>
                     <div className="flex flex-wrap gap-3 mt-2 text-xs text-slate-600 dark:text-zinc-400">
-                      <span>{t('settings.metadata.minPopularity')} <span className="text-slate-800 dark:text-zinc-200">{p.minPopularity}</span></span>
-                      <span>{t('settings.metadata.minPages')} <span className="text-slate-800 dark:text-zinc-200">{p.minPages}</span></span>
+                      <span>{t('settings.metadata.minPopularity')} <span className="text-slate-800 dark:text-zinc-200">{p.minPopularity === 0 ? 'none' : p.minPopularity}</span></span>
+                      <span>{t('settings.metadata.minPages')} <span className="text-slate-800 dark:text-zinc-200">{p.minPages === 0 ? 'none' : p.minPages}</span></span>
                       <span>{t('settings.metadata.languages')} <span className="text-slate-800 dark:text-zinc-200">{formatLanguageList(p.allowedLanguages)}</span></span>
                     </div>
                     <div className="flex flex-wrap gap-1.5 mt-2">

--- a/web/src/pages/settings/NamingTemplateField.tsx
+++ b/web/src/pages/settings/NamingTemplateField.tsx
@@ -133,8 +133,8 @@ export default function NamingTemplateField({
 
       {/* Validation feedback */}
       {validation.empty && (
-        <p className="text-xs text-red-600 dark:text-red-400 mt-1.5" role="alert">
-          {t('settings.general.naming.errorEmpty')}
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1.5">
+          {t('settings.general.naming.hintEmpty', 'Required — enter at least one token or path segment.')}
         </p>
       )}
       {validation.traversal && (

--- a/web/src/pages/settings/QualityTab.tsx
+++ b/web/src/pages/settings/QualityTab.tsx
@@ -134,17 +134,20 @@ function ProfileRow({
             )}
           </div>
           {profile.items && profile.items.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mt-2">
-              {profile.items.map((item, i) => (
-                <span
-                  key={`${item.quality}-${i}`}
-                  className={`text-[10px] px-2 py-0.5 rounded ${item.allowed
-                    ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300'
-                    : 'bg-slate-200 dark:bg-zinc-800 text-slate-500 dark:text-zinc-500'}`}
-                >
-                  {item.quality}
-                </span>
-              ))}
+            <div className="mt-2">
+              <p className="text-[10px] text-slate-500 dark:text-zinc-600 mb-1">Worst → best</p>
+              <div className="flex flex-wrap gap-1.5">
+                {profile.items.map((item, i) => (
+                  <span
+                    key={`${item.quality}-${i}`}
+                    className={`text-[10px] px-2 py-0.5 rounded ${item.allowed
+                      ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300'
+                      : 'bg-slate-200 dark:bg-zinc-800 text-slate-500 dark:text-zinc-500'}`}
+                  >
+                    {i + 1}. {item.quality}
+                  </span>
+                ))}
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Auth Mode: static description replaced with per-mode contextual hint below the dropdown
- API Key: helper line about updating integrations after Regenerate (shown when key is hidden)
- OIDC password form: labeling deferred — AuthConfig has no OIDC user indicator (only `mode`, `apiKey`, `username` fields)
- Logs: "View" label on filter pills, "Runtime level" label on the level dropdown to disambiguate them
- Quality Profiles: ProfileRow now shows "1. epub, 2. pdf…" order with "Worst → best" hint
- Metadata Profiles: renders minPopularity=0 / minPages=0 as "none"
- Naming templates: empty-field message changed from red alert to muted hint; `hintEmpty` key added to en.json
- Backend: capitalize "Hardcover" in API token error strings in settings_handler.go and import_lists.go

## Test plan
- [ ] Auth Mode dropdown: change modes, verify contextual description updates below the select
- [ ] API Key section: with key hidden (default), helper line about integrations is visible
- [ ] Quality profile list shows numbered formats + "Worst → best" order label
- [ ] Metadata profile list shows "none" instead of 0 for minPopularity/minPages
- [ ] Naming template field: empty state shows muted grey hint, not red error
- [ ] Logs toolbar: "View" label before filter pills, "Runtime level" label before level select
- [ ] go build passes, tsc --noEmit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)