### PR TITLE
fix(dnb): strip promotional text and genre suffixes from MARC title fields

### DIFF
--- a/internal/metadata/dnb/client.go
+++ b/internal/metadata/dnb/client.go
@@ -237,12 +237,9 @@ func recordToBook(rec marcRecord) *models.Book {
 		return nil
 	}
 
-	title := marcClean(rec.subfield("245", "a"))
+	title := cleanDNBTitle(rec.subfield("245", "a"), rec.subfield("245", "b"))
 	if title == "" {
 		return nil
-	}
-	if sub := marcClean(rec.subfield("245", "b")); sub != "" {
-		title = title + ": " + sub
 	}
 
 	b := &models.Book{
@@ -437,6 +434,131 @@ func recordToAuthor(rec marcRecord) *models.Author {
 }
 
 // --- String helpers ---
+
+// cleanDNBTitle normalises a MARC 245 title for DNB records. DNB embeds
+// promotional blurb chains, author attributions, and genre markers in the
+// 245 $a/$b fields; none of these belong in the stored title. The function:
+//
+//   - Strips ` | ` and everything after (promotional text chains in $a/$b).
+//   - Strips ` / ` and everything after (MARC statement-of-responsibility).
+//   - Skips appending $b when it is a genre marker, edition marker, promotional
+//     phrase, or starts with a known intro phrase ("Ein", "Eine", "Deutsche Ausgabe").
+//   - Strips trailing `: <genre>` suffixes from the assembled title.
+//
+// Parenthesised series identifiers like "(Die Geheimnisse von Engeløya 1)" are
+// left intact — they are legitimate cataloguing data.
+func cleanDNBTitle(rawA, rawB string) string {
+	// Clean $a and strip trailing promotional / responsibility fragments.
+	a := marcClean(rawA)
+	if idx := strings.Index(a, " | "); idx != -1 {
+		a = strings.TrimRight(strings.TrimSpace(a[:idx]), " /,.:;=")
+	}
+	if idx := strings.Index(a, " / "); idx != -1 {
+		a = strings.TrimRight(strings.TrimSpace(a[:idx]), " /,.:;=")
+	}
+	a = strings.TrimSpace(a)
+
+	// Clean $b and decide whether to include it.
+	b := marcClean(rawB)
+	if idx := strings.Index(b, " | "); idx != -1 {
+		b = strings.TrimRight(strings.TrimSpace(b[:idx]), " /,.:;=")
+	}
+	if idx := strings.Index(b, " / "); idx != -1 {
+		b = strings.TrimRight(strings.TrimSpace(b[:idx]), " /,.:;=")
+	}
+	b = strings.TrimSpace(b)
+
+	title := a
+	if b != "" && len(b) < 80 && !isDNBJunkSubtitle(b) {
+		title = title + ": " + b
+	}
+
+	// Strip trailing genre/format suffixes added as the last colon segment.
+	title = stripTrailingGenreSuffix(title)
+
+	return title
+}
+
+// dnbGenreKeywords are single-word or compound genre/edition/promotional terms
+// that, when present in a MARC 245 $b, indicate the subtitle is not a real
+// literary subtitle but a cataloguing artifact.
+var dnbGenreKeywords = []string{
+	"roman",
+	"thriller",
+	"krimi",
+	"lesung",
+	"hörbuch",
+	"hoerbuch",
+	"sachbuch",
+	"biografie",
+	"biographie",
+	"erfolg",
+	"bestseller",
+	"bestsellerautor",
+	"bestsellerautorin",
+	"preisgekrönt",
+	"preisgekront",
+	"gewinner",
+	"ausgabe",   // covers "Jubiläumsausgabe", "Sonderausgabe", "Deutsche Ausgabe"
+	"ungekürzt", // "ungekürzte Lesung"
+	"ungekurzt",
+}
+
+// dnbIntroPhrasePrefixes are lowercased prefixes that indicate $b is an
+// introductory phrase rather than a true subtitle.
+var dnbIntroPhrasePrefixes = []string{
+	"deutsche ausgabe",
+	"ein ",
+	"eine ",
+}
+
+// isDNBJunkSubtitle reports whether a cleaned MARC 245 $b value should be
+// dropped rather than appended to the title. Returns true for genre markers,
+// edition labels, promotional phrases, and intro phrases.
+func isDNBJunkSubtitle(b string) bool {
+	lower := strings.ToLower(b)
+	// Check intro-phrase prefixes.
+	for _, pfx := range dnbIntroPhrasePrefixes {
+		if strings.HasPrefix(lower, pfx) {
+			return true
+		}
+	}
+	// Check genre/promotional keyword containment.
+	for _, kw := range dnbGenreKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// dnbTrailingGenreSuffixes are the lowercased genre labels that DNB appends
+// as the final colon-delimited segment of the assembled title. Strip them so
+// stored titles match what indexers index.
+var dnbTrailingGenreSuffixes = []string{
+	": roman",
+	": thriller",
+	": krimi",
+	": lesung",
+	": hörbuch",
+	": hoerbuch",
+	": sachbuch",
+	": biografie",
+	": biographie",
+}
+
+// stripTrailingGenreSuffix removes a terminal `: <genre>` segment from title
+// (case-insensitive). Only the last segment is stripped; the rest is preserved.
+func stripTrailingGenreSuffix(title string) string {
+	lower := strings.ToLower(title)
+	for _, suffix := range dnbTrailingGenreSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			title = strings.TrimSpace(title[:len(title)-len(suffix)])
+			break
+		}
+	}
+	return title
+}
 
 // marcClean strips MARC non-sorting bracket control characters (U+0098 NSB
 // and U+009C NSE, per LoC https://www.loc.gov/marc/nonsorting.html — DNB

--- a/internal/metadata/dnb/client_test.go
+++ b/internal/metadata/dnb/client_test.go
@@ -123,8 +123,9 @@ func TestSearchBooks_Success(t *testing.T) {
 	if b.ForeignID != "dnb:1234567890" {
 		t.Errorf("ForeignID = %q, want dnb:1234567890", b.ForeignID)
 	}
-	if b.Title != "Der Wüstenplanet: Roman" {
-		t.Errorf("Title = %q, want 'Der Wüstenplanet: Roman'", b.Title)
+	// "Roman" is a genre marker in MARC 245 $b; cleanDNBTitle strips it.
+	if b.Title != "Der Wüstenplanet" {
+		t.Errorf("Title = %q, want 'Der Wüstenplanet'", b.Title)
 	}
 	if b.Language != "ger" {
 		t.Errorf("Language = %q, want ger", b.Language)

--- a/internal/metadata/dnb/title_test.go
+++ b/internal/metadata/dnb/title_test.go
@@ -1,0 +1,112 @@
+package dnb
+
+import "testing"
+
+// TestCleanDNBTitle exercises the cleanDNBTitle helper against the real-world
+// DNB MARC 245 bloat patterns reported in issue #1114. DNB routinely embeds
+// promotional blurb chains (pipe-separated), MARC statement-of-responsibility
+// attribution (slash-separated), genre markers, and edition labels in the
+// title fields that should never reach the stored title.
+func TestCleanDNBTitle(t *testing.T) {
+	cases := []struct {
+		name    string
+		rawA    string
+		rawB    string
+		want    string
+	}{
+		{
+			name: "promotional pipe chain in $a stripped",
+			rawA: "Die Nacht der Bärin : Roman | SPIEGEL-Bestsellerautorin Kira Mohn von einer neuen Seite | Aufarbeitung der Vergangenheit und Trauma | Opfer häuslicher Gewalt | Mutter-Tochter-Beziehungen /",
+			rawB: "",
+			want: "Die Nacht der Bärin",
+		},
+		{
+			name: "genre word in $b stripped (ungekürzte Lesung)",
+			rawA: "Der Bademeister ohne Himmel",
+			rawB: "ungekürzte Lesung",
+			want: "Der Bademeister ohne Himmel",
+		},
+		{
+			name: "promotional $b stripped (Erfolg aus Skandinavien), series parens preserved",
+			rawA: "Die Tochter des Doktors (Die Geheimnisse von Engeløya 1)",
+			rawB: "Der große Erfolg aus Skandinavien",
+			want: "Die Tochter des Doktors (Die Geheimnisse von Engeløya 1)",
+		},
+		{
+			name: "intro phrase Ein in $b stripped",
+			rawA: "Das Lied der Dunkelheit",
+			rawB: "Ein Roman aus dem Mittelalter",
+			want: "Das Lied der Dunkelheit",
+		},
+		{
+			name: "promotional $b with Bestseller reference stripped",
+			rawA: "Die Tribute von Panem L. Der Tag bricht an",
+			rawB: "Deutsche Ausgabe von Sunrise on the Reaping, dem neuen Band der dystopischen Bestseller-Reihe",
+			want: "Die Tribute von Panem L. Der Tag bricht an",
+		},
+		{
+			name: "genre/edition label Jubiläumsausgabe in $b stripped",
+			rawA: "Harry Potter und der Stein der Weisen",
+			rawB: "Jubiläumsausgabe",
+			want: "Harry Potter und der Stein der Weisen",
+		},
+		{
+			name: "trailing : Roman genre suffix stripped",
+			rawA: "Ein einfaches Buch : Roman",
+			rawB: "",
+			want: "Ein einfaches Buch",
+		},
+		{
+			name: "trailing : Thriller genre suffix stripped",
+			rawA: "Der dunkle Wald : Thriller",
+			rawB: "",
+			want: "Der dunkle Wald",
+		},
+		{
+			name: "short non-promotional $b kept",
+			rawA: "Der Fänger im Roggen",
+			rawB: "Roman für Erwachsene",
+			// "Roman" keyword present — stripped
+			want: "Der Fänger im Roggen",
+		},
+		{
+			name: "statement of responsibility in $a stripped",
+			rawA: "Gedichte / Rainer Maria Rilke",
+			rawB: "",
+			want: "Gedichte",
+		},
+		{
+			name: "empty $b — title from $a only",
+			rawA: "Stiller",
+			rawB: "",
+			want: "Stiller",
+		},
+		{
+			name: "both $a and $b clean — real subtitle preserved",
+			rawA: "Die Verwandlung",
+			rawB: "und andere Erzählungen",
+			want: "Die Verwandlung: und andere Erzählungen",
+		},
+		{
+			name: "series in parens not stripped from $a",
+			rawA: "Die Tochter des Doktors (Die Geheimnisse von Engeløya 1)",
+			rawB: "",
+			want: "Die Tochter des Doktors (Die Geheimnisse von Engeløya 1)",
+		},
+		{
+			name: "pipe in $b stripped before promotional check",
+			rawA: "Das Buch",
+			rawB: "Guter Untertitel | Bestsellertext",
+			want: "Das Buch: Guter Untertitel",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cleanDNBTitle(tc.rawA, tc.rawB)
+			if got != tc.want {
+				t.Errorf("cleanDNBTitle(%q, %q)\n  got  %q\n  want %q", tc.rawA, tc.rawB, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/metadata/dnb/title_test.go
+++ b/internal/metadata/dnb/title_test.go
@@ -9,10 +9,10 @@ import "testing"
 // title fields that should never reach the stored title.
 func TestCleanDNBTitle(t *testing.T) {
 	cases := []struct {
-		name    string
-		rawA    string
-		rawB    string
-		want    string
+		name string
+		rawA string
+		rawB string
+		want string
 	}{
 		{
 			name: "promotional pipe chain in $a stripped",


### PR DESCRIPTION
## Summary

Fixes #1114.

DNB (Deutsche Nationalbibliothek) MARC 245 title fields regularly carry far more than just the title. DNB cataloguers embed:

- **Promotional blurb chains** separated by ` | ` — e.g. `"... | SPIEGEL-Bestsellerautorin Kira Mohn von einer neuen Seite | Aufarbeitung der Vergangenheit und Trauma | ..."` 
- **MARC statement-of-responsibility** separated by ` / ` — e.g. `"... / Kira Mohn"`
- **Genre labels** in $b — `"Roman"`, `"ungekürzte Lesung"`, `"Hörbuch"`, etc.
- **Edition markers** in $b — `"Jubiläumsausgabe"`, `"Deutsche Ausgabe von ..."`, etc.

Bindery was storing these verbatim, producing titles like:
```
Die Nacht der Bärin : Roman | SPIEGEL-Bestsellerautorin Kira Mohn von einer neuen Seite | Aufarbeitung der Vergangenheit und Trauma | Opfer häuslicher Gewalt | Mutter-Tochter-Beziehungen / Kira Mohn
```
...when the correct title is simply `"Die Nacht der Bärin"`. The garbled string never matches what the indexer indexes, breaking book lookups for German-language titles.

## What changed

- **`internal/metadata/dnb/client.go`** — new `cleanDNBTitle(rawA, rawB string) string` helper replaces the inline title-assembly in `recordToBook`. The helper:
  1. Strips ` | ` and everything after from both $a and $b.
  2. Strips ` / ` and everything after from both.
  3. Drops $b entirely when it is a genre marker (`roman`, `lesung`, `hörbuch`, `krimi`, `sachbuch`, `biografie`), edition label (`ausgabe`, `ungekürzt`), promotional phrase (`bestseller`, `erfolg`, `preisgekrönt`, `gewinner`), or starts with `"Ein "`, `"Eine "`, `"Deutsche Ausgabe"`.
  4. Strips trailing `: <genre>` suffix (`: Roman`, `: Thriller`, etc.) from the assembled title.
  5. Preserves parenthesised series identifiers such as `(Die Geheimnisse von Engeløya 1)`.

- **`internal/metadata/dnb/client_test.go`** — updated `TestSearchBooks_Success` expected title from `"Der Wüstenplanet: Roman"` to `"Der Wüstenplanet"` (the $b `"Roman"` is now correctly stripped as a genre marker).

- **`internal/metadata/dnb/title_test.go`** — 14 direct unit tests for `cleanDNBTitle` covering all issue #1114 examples:

| Input ($a, $b) | Expected title |
|---|---|
| `"Die Nacht der Bärin : Roman \| SPIEGEL-Bestsellerautorin..."`, `""` | `"Die Nacht der Bärin"` |
| `"Der Bademeister ohne Himmel"`, `"ungekürzte Lesung"` | `"Der Bademeister ohne Himmel"` |
| `"Die Tochter des Doktors (Die Geheimnisse von Engeløya 1)"`, `"Der große Erfolg aus Skandinavien"` | `"Die Tochter des Doktors (Die Geheimnisse von Engeløya 1)"` |
| `"Das Lied der Dunkelheit"`, `"Ein Roman aus dem Mittelalter"` | `"Das Lied der Dunkelheit"` |
| `"Die Tribute von Panem L. Der Tag bricht an"`, `"Deutsche Ausgabe von Sunrise on the Reaping..."` | `"Die Tribute von Panem L. Der Tag bricht an"` |
| `"Harry Potter und der Stein der Weisen"`, `"Jubiläumsausgabe"` | `"Harry Potter und der Stein der Weisen"` |
| `"Die Verwandlung"`, `"und andere Erzählungen"` | `"Die Verwandlung: und andere Erzählungen"` (real subtitle kept) |

## Test plan

- [x] `go test ./internal/metadata/dnb/...` — all tests pass (including 14 new `TestCleanDNBTitle` sub-tests)
- [x] `marcClean` is unchanged; `cleanDNBTitle` calls it internally
- [x] No other metadata providers touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)