### PR TITLE
feat(scheduler): configurable wanted-search interval

### DIFF
--- a/changelog.d/1097-configurable-search-interval.md
+++ b/changelog.d/1097-configurable-search-interval.md
@@ -1,0 +1,2 @@
+### Added
+- **Configurable wanted-search interval** ([#1097](https://github.com/vavallee/bindery/issues/1097)) — the automatic wanted-books search interval is now a setting (Settings → General) instead of a fixed schedule. Lengthen it to ease load on your indexers / stay under daily API caps for large libraries, or shorten it to find releases sooner. Defaults to the previous behaviour; takes effect after the next Bindery restart.

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -69,6 +69,11 @@ const (
 	SettingImportDropLinkMode = "import.drop_link_mode"
 )
 
+// SettingSearchInterval is the KV key for the wanted-book search cadence.
+// Value is a Go duration string (e.g. "12h", "24h"). Empty or unset falls
+// back to the scheduler's defaultSearchInterval (12h). Takes effect on restart.
+const SettingSearchInterval = "search.interval"
+
 // SettingImportAudiobookFlattenMultiDisc (#886) is "true" to flatten multi-disc
 // audiobook downloads into a single "Part 001.ext", … sequence on import, or
 // unset/"false" (default) to preserve the download's disc-folder layout.
@@ -459,6 +464,21 @@ func validateSettingValue(key, value string) error {
 		}
 		if !strings.EqualFold(value, "true") && !strings.EqualFold(value, "false") {
 			return fmt.Errorf("abs.enabled %q is not one of: true, false", value)
+		}
+	case SettingSearchInterval:
+		// Empty = unset (scheduler falls back to its built-in default).
+		if value == "" {
+			return nil
+		}
+		d, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("search.interval %q is not a valid duration (e.g. 12h, 24h, 48h)", value)
+		}
+		if d < time.Hour {
+			return fmt.Errorf("search.interval %q is too short — minimum is 1h to avoid hammering indexers", value)
+		}
+		if d > 168*time.Hour {
+			return fmt.Errorf("search.interval %q exceeds the maximum of 168h (7 days)", value)
 		}
 	}
 	return nil

--- a/internal/api/settings_handler_test.go
+++ b/internal/api/settings_handler_test.go
@@ -531,6 +531,37 @@ func TestSettings_ImportDropValidation(t *testing.T) {
 	}
 }
 
+// TestValidateSettingValue_SearchInterval exercises the search.interval bounds
+// the validator enforces: empty is allowed (scheduler falls back to default),
+// any duration in [1h, 168h] is accepted, and values below 1h, above 168h, or
+// that don't parse as a Go duration are rejected. These bounds are mirrored in
+// the scheduler (resolveSearchInterval) so an out-of-band DB value can't slip
+// through; keep the two in sync.
+func TestValidateSettingValue_SearchInterval(t *testing.T) {
+	// Empty = unset, accepted.
+	if err := validateSettingValue(SettingSearchInterval, ""); err != nil {
+		t.Errorf("empty should be accepted: %v", err)
+	}
+	// Valid in-range values, including the inclusive bounds.
+	for _, v := range []string{"1h", "12h", "24h", "168h"} {
+		if err := validateSettingValue(SettingSearchInterval, v); err != nil {
+			t.Errorf("%q should be accepted: %v", v, err)
+		}
+	}
+	// Below the 1h minimum: rejected.
+	if err := validateSettingValue(SettingSearchInterval, "30m"); err == nil {
+		t.Error("30m should be rejected (below 1h minimum)")
+	}
+	// Above the 168h maximum: rejected.
+	if err := validateSettingValue(SettingSearchInterval, "200h"); err == nil {
+		t.Error("200h should be rejected (above 168h maximum)")
+	}
+	// Unparseable duration string: rejected.
+	if err := validateSettingValue(SettingSearchInterval, "soon"); err == nil {
+		t.Error("'soon' should be rejected (not a valid duration)")
+	}
+}
+
 func mustJSON(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,6 +6,7 @@ package scheduler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -71,6 +72,10 @@ type eventNotifier interface {
 const (
 	notifierEventGrabbed = "grabbed"
 )
+
+// defaultSearchInterval is the fallback wanted-book search cadence used when
+// the "search.interval" DB setting is absent or invalid.
+const defaultSearchInterval = "12h"
 
 // Scheduler runs background jobs on configurable intervals.
 type Scheduler struct {
@@ -281,8 +286,20 @@ func (s *Scheduler) Start() {
 		s.checkStalledDownloads(s.ctx())
 	}))
 
-	// Search for wanted books every 12 hours
-	s.cron.AddFunc("@every 12h", runJob("search-wanted", func() {
+	// Search for wanted books on a configurable interval (default 12h).
+	// Read the setting once at Start() — a restart is required to apply changes.
+	searchInterval := defaultSearchInterval
+	if s.settings != nil {
+		if v, _ := s.settings.Get(s.ctx(), "search.interval"); v != nil && v.Value != "" {
+			searchInterval = v.Value
+		}
+	}
+	searchDuration, err := time.ParseDuration(searchInterval)
+	if err != nil || searchDuration < time.Hour {
+		slog.Warn("scheduler: invalid search.interval, falling back to default", "value", searchInterval, "default", defaultSearchInterval)
+		searchDuration = 12 * time.Hour
+	}
+	s.cron.AddFunc(fmt.Sprintf("@every %s", searchDuration), runJob("search-wanted", func() {
 		slog.Info("job: search wanted books")
 		s.searchWanted()
 	}))

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -74,8 +74,42 @@ const (
 )
 
 // defaultSearchInterval is the fallback wanted-book search cadence used when
-// the "search.interval" DB setting is absent or invalid.
-const defaultSearchInterval = "12h"
+// the "search.interval" DB setting is absent or invalid. Typed as a
+// time.Duration (not a string) so the unset-path default and the
+// invalid-value fallback can never diverge — both derive from this constant.
+const defaultSearchInterval = 12 * time.Hour
+
+// minSearchInterval and maxSearchInterval mirror the bounds the API validator
+// enforces for the "search.interval" setting (see
+// internal/api/settings_handler.go::validateSettingValue, SettingSearchInterval
+// case). A value can still reach the DB out-of-band (e.g. direct DB edit) past
+// the API, so the scheduler re-checks the same bounds and falls back to the
+// default rather than honouring an absurd cadence.
+const (
+	minSearchInterval = time.Hour
+	maxSearchInterval = 168 * time.Hour
+)
+
+// resolveSearchInterval reads the "search.interval" DB setting and returns the
+// wanted-book search cadence. It falls back to defaultSearchInterval (logging a
+// WARN) when the setting is unset/empty, unparseable, or outside the
+// [minSearchInterval, maxSearchInterval] bounds enforced by the API validator.
+func (s *Scheduler) resolveSearchInterval() time.Duration {
+	if s.settings == nil {
+		return defaultSearchInterval
+	}
+	v, _ := s.settings.Get(s.ctx(), "search.interval")
+	if v == nil || v.Value == "" {
+		return defaultSearchInterval
+	}
+	d, err := time.ParseDuration(v.Value)
+	if err != nil || d < minSearchInterval || d > maxSearchInterval {
+		slog.Warn("scheduler: invalid search.interval, falling back to default",
+			"value", v.Value, "default", defaultSearchInterval)
+		return defaultSearchInterval
+	}
+	return d
+}
 
 // Scheduler runs background jobs on configurable intervals.
 type Scheduler struct {
@@ -288,17 +322,9 @@ func (s *Scheduler) Start() {
 
 	// Search for wanted books on a configurable interval (default 12h).
 	// Read the setting once at Start() — a restart is required to apply changes.
-	searchInterval := defaultSearchInterval
-	if s.settings != nil {
-		if v, _ := s.settings.Get(s.ctx(), "search.interval"); v != nil && v.Value != "" {
-			searchInterval = v.Value
-		}
-	}
-	searchDuration, err := time.ParseDuration(searchInterval)
-	if err != nil || searchDuration < time.Hour {
-		slog.Warn("scheduler: invalid search.interval, falling back to default", "value", searchInterval, "default", defaultSearchInterval)
-		searchDuration = 12 * time.Hour
-	}
+	// resolveSearchInterval clamps to the same [1h, 168h] bounds the API
+	// validator enforces, falling back to the default for out-of-range values.
+	searchDuration := s.resolveSearchInterval()
 	s.cron.AddFunc(fmt.Sprintf("@every %s", searchDuration), runJob("search-wanted", func() {
 		slog.Info("job: search wanted books")
 		s.searchWanted()

--- a/internal/scheduler/scheduler_jobs_test.go
+++ b/internal/scheduler/scheduler_jobs_test.go
@@ -104,6 +104,114 @@ func TestStart_RegistersBaseJobs(t *testing.T) {
 	}
 }
 
+// hasEntryWithDelay reports whether any cron entry runs on a
+// ConstantDelaySchedule (@every) with exactly the given delay. Used to assert
+// the search-wanted job is registered at the resolved interval.
+func hasEntryWithDelay(entries []cron.Entry, d time.Duration) bool {
+	for _, e := range entries {
+		if cds, ok := e.Schedule.(cron.ConstantDelaySchedule); ok && cds.Delay == d {
+			return true
+		}
+	}
+	return false
+}
+
+// schedulerWithSearchInterval builds a Scheduler backed by an in-memory DB and
+// seeds (or omits) the search.interval setting. value=="" leaves the setting
+// unset. A nil settings repo is requested with seedSettings=false.
+func schedulerWithSearchInterval(t *testing.T, seedSettings bool, value string) *Scheduler {
+	t.Helper()
+	s := &Scheduler{cron: cron.New(cron.WithSeconds())}
+	if seedSettings {
+		database, err := db.OpenMemory()
+		if err != nil {
+			t.Fatalf("OpenMemory: %v", err)
+		}
+		t.Cleanup(func() { database.Close() })
+		repo := db.NewSettingsRepo(database)
+		if value != "" {
+			if err := repo.Set(context.Background(), "search.interval", value); err != nil {
+				t.Fatalf("seed search.interval: %v", err)
+			}
+		}
+		s.settings = repo
+	}
+	return s
+}
+
+// TestStart_SearchWantedUsesConfiguredInterval verifies the search-wanted cron
+// entry honours a valid configured search.interval rather than the default.
+func TestStart_SearchWantedUsesConfiguredInterval(t *testing.T) {
+	s := schedulerWithSearchInterval(t, true, "48h")
+	s.Start()
+	entries := s.cron.Entries()
+	s.Stop()
+
+	if !hasEntryWithDelay(entries, 48*time.Hour) {
+		t.Error("expected a cron entry at the configured 48h interval, found none")
+	}
+}
+
+// TestStart_SearchWantedFallsBackToDefault verifies the search-wanted entry
+// uses defaultSearchInterval when settings is nil and when the setting is unset.
+func TestStart_SearchWantedFallsBackToDefault(t *testing.T) {
+	cases := []struct {
+		name  string
+		seed  bool
+		value string
+	}{
+		{"nil settings repo", false, ""},
+		{"empty/unset setting", true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := schedulerWithSearchInterval(t, tc.seed, tc.value)
+			s.Start()
+			entries := s.cron.Entries()
+			s.Stop()
+			if !hasEntryWithDelay(entries, defaultSearchInterval) {
+				t.Errorf("expected search-wanted entry at default %s, found none", defaultSearchInterval)
+			}
+		})
+	}
+}
+
+// TestStart_SearchWantedRejectsOutOfBounds verifies garbage and out-of-range
+// search.interval values fall back to the default (mirroring the API bounds).
+func TestStart_SearchWantedRejectsOutOfBounds(t *testing.T) {
+	for _, value := range []string{"not-a-duration", "30m", "200h"} {
+		t.Run(value, func(t *testing.T) {
+			s := schedulerWithSearchInterval(t, true, value)
+			s.Start()
+			entries := s.cron.Entries()
+			s.Stop()
+			if !hasEntryWithDelay(entries, defaultSearchInterval) {
+				t.Errorf("value %q should fall back to default %s", value, defaultSearchInterval)
+			}
+		})
+	}
+}
+
+// TestResolveSearchInterval covers the helper directly: unset/nil falls back,
+// valid in-range values pass through, and out-of-bounds/unparseable values fall
+// back to the default.
+func TestResolveSearchInterval(t *testing.T) {
+	if got := schedulerWithSearchInterval(t, false, "").resolveSearchInterval(); got != defaultSearchInterval {
+		t.Errorf("nil settings: got %s, want %s", got, defaultSearchInterval)
+	}
+	if got := schedulerWithSearchInterval(t, true, "").resolveSearchInterval(); got != defaultSearchInterval {
+		t.Errorf("unset setting: got %s, want %s", got, defaultSearchInterval)
+	}
+	if got := schedulerWithSearchInterval(t, true, "6h").resolveSearchInterval(); got != 6*time.Hour {
+		t.Errorf("valid 6h: got %s, want 6h", got)
+	}
+	for _, bad := range []string{"30m", "200h", "garbage"} {
+		if got := schedulerWithSearchInterval(t, true, bad).resolveSearchInterval(); got != defaultSearchInterval {
+			t.Errorf("invalid %q: got %s, want default %s", bad, got, defaultSearchInterval)
+		}
+	}
+}
+
 // TestStop_IdempotentAfterStart confirms that calling Stop right after Start
 // does not hang or panic.
 func TestStop_IdempotentAfterStart(t *testing.T) {

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -393,7 +393,11 @@
       "defaultLibraryLocationLink": "In Stammordner verwalten →",
       "naming": {
         "hintEmpty": "Erforderlich – mindestens ein Token oder Pfadsegment eingeben."
-      }
+      },
+      "search": "Search",
+      "searchIntervalLabel": "Wanted search interval",
+      "searchIntervalHint": "How often Bindery searches all wanted books against your indexers. Reduce if you have a large library and are hitting indexer API rate limits.",
+      "searchIntervalRestart": "Takes effect after the next Bindery restart."
     },
     "import": {
       "csvHeading": "CSV mit Autorennamen",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -635,7 +635,11 @@
       "metadataProviderDnb": "DNB — Deutsche Nationalbibliothek (German/DACH)",
       "defaultLibraryLocation": "Default library location",
       "defaultLibraryLocationHint": "Manage root folders and the default library location in the Root Folders tab.",
-      "defaultLibraryLocationLink": "Manage in Root Folders →"
+      "defaultLibraryLocationLink": "Manage in Root Folders →",
+      "search": "Search",
+      "searchIntervalLabel": "Wanted search interval",
+      "searchIntervalHint": "How often Bindery searches all wanted books against your indexers. Reduce if you have a large library and are hitting indexer API rate limits.",
+      "searchIntervalRestart": "Takes effect after the next Bindery restart."
     },
     "import": {
       "csvHeading": "CSV of author names",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -422,7 +422,11 @@
       "defaultLibraryLocationLink": "Gestionar en Carpetas raíz →",
       "naming": {
         "hintEmpty": "Obligatorio: introduce al menos un token o segmento de ruta."
-      }
+      },
+      "search": "Search",
+      "searchIntervalLabel": "Wanted search interval",
+      "searchIntervalHint": "How often Bindery searches all wanted books against your indexers. Reduce if you have a large library and are hitting indexer API rate limits.",
+      "searchIntervalRestart": "Takes effect after the next Bindery restart."
     },
     "import": {
       "csvHeading": "CSV de nombres de autores",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -393,7 +393,11 @@
       "defaultLibraryLocationLink": "Gérer dans Dossiers racines →",
       "naming": {
         "hintEmpty": "Requis – saisissez au moins un jeton ou segment de chemin."
-      }
+      },
+      "search": "Search",
+      "searchIntervalLabel": "Wanted search interval",
+      "searchIntervalHint": "How often Bindery searches all wanted books against your indexers. Reduce if you have a large library and are hitting indexer API rate limits.",
+      "searchIntervalRestart": "Takes effect after the next Bindery restart."
     },
     "import": {
       "csvHeading": "CSV de noms d'auteurs",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -422,7 +422,11 @@
       "defaultLibraryLocationLink": "Kelola di Folder Utama →",
       "naming": {
         "hintEmpty": "Wajib — masukkan setidaknya satu token atau segmen jalur."
-      }
+      },
+      "search": "Search",
+      "searchIntervalLabel": "Wanted search interval",
+      "searchIntervalHint": "How often Bindery searches all wanted books against your indexers. Reduce if you have a large library and are hitting indexer API rate limits.",
+      "searchIntervalRestart": "Takes effect after the next Bindery restart."
     },
     "import": {
       "csvHeading": "CSV nama penulis",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -393,7 +393,11 @@
       "defaultLibraryLocationLink": "Beheren in Hoofdmappen →",
       "naming": {
         "hintEmpty": "Vereist — voer minstens één token of padsegment in."
-      }
+      },
+      "search": "Search",
+      "searchIntervalLabel": "Wanted search interval",
+      "searchIntervalHint": "How often Bindery searches all wanted books against your indexers. Reduce if you have a large library and are hitting indexer API rate limits.",
+      "searchIntervalRestart": "Takes effect after the next Bindery restart."
     },
     "import": {
       "csvHeading": "CSV van auteursnamen",

--- a/web/src/i18n/locales/tl.json
+++ b/web/src/i18n/locales/tl.json
@@ -422,7 +422,11 @@
       "defaultLibraryLocationLink": "Pamahalaan sa Mga Root Folder →",
       "naming": {
         "hintEmpty": "Kailangan — maglagay ng kahit isang token o path segment."
-      }
+      },
+      "search": "Search",
+      "searchIntervalLabel": "Wanted search interval",
+      "searchIntervalHint": "How often Bindery searches all wanted books against your indexers. Reduce if you have a large library and are hitting indexer API rate limits.",
+      "searchIntervalRestart": "Takes effect after the next Bindery restart."
     },
     "import": {
       "csvHeading": "CSV ng mga pangalan ng may-akda",

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -489,6 +489,40 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
         </div>
       </section>
 
+      {/* Wanted search interval */}
+      <section>
+        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.search')}</h3>
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+          <div>
+            <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200 mb-1">
+              {t('settings.general.searchIntervalLabel')}
+            </label>
+            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
+              {t('settings.general.searchIntervalHint')}
+            </p>
+            <select
+              value={settings['search.interval'] ?? '12h'}
+              onChange={async e => {
+                const next = e.target.value
+                setSettings(s => ({ ...s, 'search.interval': next }))
+                await api.setSetting('search.interval', next).catch(console.error)
+              }}
+              className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+            >
+              <option value="6h">6 hours</option>
+              <option value="12h">12 hours (default)</option>
+              <option value="24h">24 hours</option>
+              <option value="48h">48 hours</option>
+              <option value="72h">72 hours</option>
+              <option value="168h">7 days</option>
+            </select>
+            <p className="text-xs text-slate-500 dark:text-zinc-600 mt-1">
+              {t('settings.general.searchIntervalRestart')}
+            </p>
+          </div>
+        </div>
+      </section>
+
       {/* Default library location */}
       <section>
         <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.defaultLibraryLocation')}</h3>


### PR DESCRIPTION
## Problem

The wanted-book search job runs on a hardcoded `@every 12h` schedule. Libraries with 5 000+ monitored books hit indexer daily API caps or get temporary bans because every search cycle fires hundreds of queries in a short window. There is no knob to dial this back short of patching the binary.

Closes #1097 (item 1 only — per-indexer rate limiting and batch cooldowns are tracked as separate follow-ups in that issue).

## Solution

Expose the interval as a DB setting (`search.interval`, a Go duration string). The scheduler reads it once at `Start()` time; a restart is required to apply a change, which the UI makes clear.

### Backend

- `internal/scheduler/scheduler.go`: reads `search.interval` from the settings repo at `Start()`. Falls back to `12h` (new `defaultSearchInterval` constant) if the key is absent, blank, unparseable, or below 1 h. Logs a warning on fallback.
- `internal/api/settings_handler.go`: adds `SettingSearchInterval = "search.interval"` constant and a `validateSettingValue` case that rejects durations outside `[1h, 168h]`.

### Frontend

Settings → General gains a **Search** section with a `<select>` offering six preset intervals (6 h / 12 h default / 24 h / 48 h / 72 h / 7 d). The setting is written via the existing `api.setSetting` call on change. A note below the dropdown explains that a restart is needed for the change to take effect.

### i18n

Three keys added under `settings.general` in all 7 locale files (`en`, `de`, `es`, `fr`, `id`, `nl`, `tl`). Non-English files carry the English strings as fallback; translators can update at their leisure.

## What this is NOT

This PR does **not** implement per-indexer rate limiting or inter-search batch cooldowns. Those are harder problems tracked separately under #1097 items 2–3.

## Checklist

- [x] `go build ./... && go vet ./...` pass
- [x] `npm run typecheck` passes
- [x] Setting read at startup only; no runtime reload complexity
- [x] Validation rejects values outside `[1h, 168h]` with a clear error message
- [x] UI shows restart-required notice
- [x] CHANGELOG.md `[Unreleased]` updated