### PR TITLE
fix(openlibrary): pass ISBNs through SearchBooks and searchAuthorWorks

### DIFF
--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -111,6 +111,7 @@ func (c *Client) SearchBooks(ctx context.Context, query string) ([]models.Book, 
 			SortTitle:        doc.Title,
 			Genres:           truncateSlice(doc.Subject, 10),
 			RatingsCount:     doc.RatingsCount,
+			ISBNs:            doc.ISBN,
 			MetadataProvider: "openlibrary",
 			Monitored:        true,
 			Status:           models.BookStatusWanted,
@@ -351,7 +352,7 @@ func (c *Client) GetAuthorWorks(ctx context.Context, authorForeignID string) ([]
 // HTML web-UI path still served by Solr, which returns HTTP 500
 // "DEPRECATED ENDPOINT ACCESSED" for API consumers (issue #462).
 func (c *Client) searchAuthorWorks(ctx context.Context, authorForeignID string) ([]models.Book, error) {
-	u := fmt.Sprintf("%s/search.json?author_key=%s&fields=key,title,language,edition_count,first_publish_year,cover_i,subject,ratings_count,ratings_average&limit=200",
+	u := fmt.Sprintf("%s/search.json?author_key=%s&fields=key,title,language,edition_count,first_publish_year,cover_i,isbn,subject,ratings_count,ratings_average&limit=200",
 		baseURL, authorForeignID)
 	var resp struct {
 		Docs []struct {
@@ -361,6 +362,7 @@ func (c *Client) searchAuthorWorks(ctx context.Context, authorForeignID string) 
 			EditionCount     int      `json:"edition_count"`
 			FirstPublishYear int      `json:"first_publish_year"`
 			CoverI           *int     `json:"cover_i"`
+			ISBN             []string `json:"isbn"`
 			Subject          []string `json:"subject"`
 			RatingsCount     int      `json:"ratings_count"`
 			RatingsAverage   float64  `json:"ratings_average"`
@@ -383,6 +385,7 @@ func (c *Client) searchAuthorWorks(ctx context.Context, authorForeignID string) 
 			Language:         pickPreferredLanguage(doc.Language),
 			RatingsCount:     doc.RatingsCount,
 			AverageRating:    doc.RatingsAverage,
+			ISBNs:            doc.ISBN,
 			MetadataProvider: "openlibrary",
 			Monitored:        true,
 			Status:           models.BookStatusWanted,


### PR DESCRIPTION
## Summary

Both OL search paths already requested `isbn` from `/search.json` but discarded the values — `SearchBooks` fetched it via the fields list and ignored it; `searchAuthorWorks` didn't even include it in the fields list.

- `SearchBooks`: assign `doc.ISBN` → `Book.ISBNs`
- `searchAuthorWorks`: add `isbn` to the fields query param, add the struct field, assign it

The aggregator's existing ISBN-first dedup (`aggregator.go:549`) can now collapse OL results against Hardcover results when a shared ISBN is present. No behaviour change when ISBNs are absent.

## Test plan

- [x] `go test ./internal/metadata/openlibrary/ ./internal/metadata/` passes
- [x] No new logic — just wiring up data that was already fetched

🤖 Generated with [Claude Code](https://claude.com/claude-code)