### PR TITLE
fix(importer): drop dangling leading separator when a leading naming token is empty

### DIFF
--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -6,11 +6,15 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/vavallee/bindery/internal/models"
 )
+
+// templateTokenRe matches a "{Token}" placeholder in a naming template.
+var templateTokenRe = regexp.MustCompile(`\{(\w+)\}`)
 
 const defaultNamingTemplate = "{Author}/{Title} ({Year})/{Title} - {Author}.{ext}"
 const defaultAudiobookTemplate = "{Author}/{Title} ({Year})"
@@ -95,16 +99,88 @@ func (r *Renamer) apply(template string, author *models.Author, book *models.Boo
 	if author != nil {
 		authorName = author.Name
 	}
-	result := template
-	result = strings.ReplaceAll(result, "{Author}", sanitizePath(authorName))
-	result = strings.ReplaceAll(result, "{SortAuthor}", sanitizePath(authorSortName(authorName)))
-	result = strings.ReplaceAll(result, "{Title}", sanitizePath(book.Title))
-	result = strings.ReplaceAll(result, "{Year}", year)
-	result = strings.ReplaceAll(result, "{ASIN}", sanitizePath(book.ASIN))
-	result = strings.ReplaceAll(result, "{Series}", sanitizePath(series))
-	result = strings.ReplaceAll(result, "{SeriesNumber}", sanitizePath(seriesNumber))
-	result = strings.ReplaceAll(result, "{ext}", ext)
-	return result
+	values := map[string]string{
+		"Author":       sanitizePath(authorName),
+		"SortAuthor":   sanitizePath(authorSortName(authorName)),
+		"Title":        sanitizePath(book.Title),
+		"Year":         year,
+		"ASIN":         sanitizePath(book.ASIN),
+		"Series":       sanitizePath(series),
+		"SeriesNumber": sanitizePath(seriesNumber),
+		"ext":          ext,
+	}
+
+	// Render per path segment. A segment that renders empty (e.g. an empty
+	// "{Series}" component) is dropped so the path doesn't gain an empty
+	// directory level.
+	segments := strings.Split(template, "/")
+	kept := segments[:0]
+	for _, seg := range segments {
+		rendered := renderSegment(seg, values)
+		if rendered != "" {
+			kept = append(kept, rendered)
+		}
+	}
+	return strings.Join(kept, "/")
+}
+
+// renderSegment substitutes "{Token}" placeholders in a single path segment.
+// When the leading token(s) of a segment resolve to empty, the separator glue
+// that would dangle in front of the first real value is dropped, so a template
+// like "{SeriesNumber} - {Title}" with no series number yields "Title" rather
+// than " - Title" (issue: Discord report, Jonathan Stroud "The Hollow Boy").
+//
+// Only leading glue is collapsed. Interior and trailing glue is left intact so
+// the established behaviour of "{Title} ({Year})" → "Title ()" and
+// "{Title}.{ext}" → "Title." (audiobook folders) is preserved — those are
+// pinned by the preview drift guard and mirrored client-side.
+//
+// Unknown tokens are left verbatim (e.g. a "{Titel}" typo stays "{Titel}"),
+// matching the previous literal-passthrough behaviour.
+func renderSegment(seg string, values map[string]string) string {
+	locs := templateTokenRe.FindAllStringSubmatchIndex(seg, -1)
+	if len(locs) == 0 {
+		return strings.TrimSpace(seg)
+	}
+
+	// Split the segment into literals (len n+1) interleaved with token values
+	// (len n): lits[0] vals[0] lits[1] vals[1] ... vals[n-1] lits[n].
+	lits := make([]string, 0, len(locs)+1)
+	vals := make([]string, 0, len(locs))
+	prev := 0
+	for _, m := range locs {
+		start, end := m[0], m[1]
+		name := seg[m[2]:m[3]]
+		lits = append(lits, seg[prev:start])
+		v, ok := values[name]
+		if !ok {
+			v = seg[start:end] // unknown token: keep "{Token}" verbatim
+		}
+		vals = append(vals, v)
+		prev = end
+	}
+	lits = append(lits, seg[prev:])
+
+	// Walk the leading run of empty tokens, dropping the separator that follows
+	// each. Stop at the first non-empty value, or at a leading literal that is
+	// real text rather than just glue (so "Vol {SeriesNumber}" keeps "Vol ").
+	for i := range vals {
+		if vals[i] != "" {
+			break
+		}
+		if strings.TrimSpace(lits[i]) != "" {
+			break
+		}
+		lits[i+1] = ""
+	}
+
+	var b strings.Builder
+	for i, v := range vals {
+		b.WriteString(lits[i])
+		b.WriteString(v)
+	}
+	b.WriteString(lits[len(lits)-1])
+	return strings.TrimSpace(b.String())
 }
 
 // MoveFile atomically copies a file to the destination and then removes the source.

--- a/internal/importer/renamer_test.go
+++ b/internal/importer/renamer_test.go
@@ -128,18 +128,45 @@ func TestRenamerSeriesTokens(t *testing.T) {
 }
 
 func TestRenamerSeriesTokensEmpty(t *testing.T) {
-	// No series — {Series} and {SeriesNumber} produce empty segments, stripped by sanitizePath
-	r := NewRenamer("{Author}/{Series}/{Title}.{ext}")
 	author := &models.Author{Name: "Author"}
 	book := &models.Book{Title: "Standalone"}
 
-	got, err := r.DestPath("/books", author, book, "", "", "book.epub")
-	if err != nil {
-		t.Fatalf("DestPath: %v", err)
+	cases := []struct {
+		name     string
+		template string
+		want     string
+	}{
+		{
+			name:     "series segment dropped",
+			template: "{Author}/{Series}/{Title}.{ext}",
+			want:     filepath.Join("/books", "Author", "Standalone.epub"),
+		},
+		{
+			// Discord report (Jonathan Stroud "The Hollow Boy"): empty
+			// {SeriesNumber} leaves " - " dangling before the title.
+			name:     "leading seriesNumber separator stripped",
+			template: "{Author}/{Series}/{SeriesNumber} - {Title}.{ext}",
+			want:     filepath.Join("/books", "Author", "Standalone.epub"),
+		},
+		{
+			// Both leading series tokens empty: the whole "{Series}" segment
+			// drops and the "{SeriesNumber} - " prefix collapses.
+			name:     "consecutive leading tokens stripped",
+			template: "{Author}/{Series} - {SeriesNumber} - {Title}.{ext}",
+			want:     filepath.Join("/books", "Author", "Standalone.epub"),
+		},
 	}
-	want := filepath.Join("/books", "Author", "Standalone.epub")
-	if got != want {
-		t.Errorf("got  %q\nwant %q", got, want)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRenamer(tc.template)
+			got, err := r.DestPath("/books", author, book, "", "", "book.epub")
+			if err != nil {
+				t.Fatalf("DestPath: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got  %q\nwant %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/web/src/pages/settings/NamingTemplateField.test.tsx
+++ b/web/src/pages/settings/NamingTemplateField.test.tsx
@@ -59,6 +59,22 @@ describe('namingTemplate renderer (renamer.go mirror)', () => {
     // ":" and "/" -> "-", "?<>" stripped; result is one segment
     expect(out).toBe('A- B - C D')
   })
+
+  it('drops dangling leading separators when a leading token is empty', () => {
+    const noSeries = { ...SAMPLE_BOOK, series: '', seriesNumber: '' }
+    // Discord report: "{SeriesNumber} - {Title}" with no number must not yield " - Title".
+    expect(
+      renderTemplate('{Author}/{Series}/{SeriesNumber} - {Title}.{ext}', 'book', noSeries),
+    ).toBe('Jane Doe/Sample Book.epub')
+    // Consecutive empty leading tokens collapse.
+    expect(
+      renderTemplate('{Author}/{Series} - {SeriesNumber} - {Title}.{ext}', 'book', noSeries),
+    ).toBe('Jane Doe/Sample Book.epub')
+    // Interior/trailing glue is preserved (empty {Year} still yields "()").
+    expect(
+      renderTemplate('{Title} ({Year})', 'book', { ...SAMPLE_BOOK, year: '' }),
+    ).toBe('Sample Book ()')
+  })
 })
 
 describe('validateTemplate', () => {

--- a/web/src/pages/settings/namingTemplate.ts
+++ b/web/src/pages/settings/namingTemplate.ts
@@ -97,29 +97,69 @@ export function sanitizePath(s: string): string {
   return kept.join(SEP)
 }
 
-// render mirrors Renamer.apply: substitute each token (sanitized where the Go
-// code sanitizes) for the given sample. For the audiobook kind, {ext} renders
-// empty, matching AudiobookDestDir which passes ext="".
+// render mirrors Renamer.apply: render each "/"-separated path segment with its
+// tokens substituted (sanitized where the Go code sanitizes), dropping empty
+// segments. For the audiobook kind, {ext} renders empty, matching
+// AudiobookDestDir which passes ext="".
 export function renderTemplate(
   template: string,
   kind: TemplateKind,
   sample: SampleBook = SAMPLE_BOOK,
 ): string {
   const ext = kind === 'audiobook' ? '' : sample.ext
-  let result = template
-  result = replaceAll(result, '{Author}', sanitizePath(sample.author))
-  result = replaceAll(result, '{SortAuthor}', sanitizePath(sample.sortAuthor))
-  result = replaceAll(result, '{Title}', sanitizePath(sample.title))
-  result = replaceAll(result, '{Year}', sample.year)
-  result = replaceAll(result, '{ASIN}', sanitizePath(sample.asin))
-  result = replaceAll(result, '{Series}', sanitizePath(sample.series))
-  result = replaceAll(result, '{SeriesNumber}', sanitizePath(sample.seriesNumber))
-  result = replaceAll(result, '{ext}', ext)
-  return result
+  const values: Record<string, string> = {
+    Author: sanitizePath(sample.author),
+    SortAuthor: sanitizePath(sample.sortAuthor),
+    Title: sanitizePath(sample.title),
+    Year: sample.year,
+    ASIN: sanitizePath(sample.asin),
+    Series: sanitizePath(sample.series),
+    SeriesNumber: sanitizePath(sample.seriesNumber),
+    ext,
+  }
+  return template
+    .split(SEP)
+    .map(seg => renderSegment(seg, values))
+    .filter(seg => seg !== '')
+    .join(SEP)
 }
 
-function replaceAll(s: string, from: string, to: string): string {
-  return s.split(from).join(to)
+const SEGMENT_TOKEN_RE = /\{(\w+)\}/g
+
+// renderSegment mirrors renamer.go renderSegment: substitute "{Token}"
+// placeholders in a single path segment and, when the leading token(s) render
+// empty, drop the separator glue that would otherwise dangle before the first
+// real value ("{SeriesNumber} - {Title}" with no series number → "Title", not
+// " - Title"). Only leading glue is collapsed; interior/trailing glue stays so
+// "{Title} ({Year})" → "Title ()" and "{Title}.{ext}" → "Title." are preserved.
+// Unknown tokens are kept verbatim.
+function renderSegment(seg: string, values: Record<string, string>): string {
+  const lits: string[] = []
+  const vals: string[] = []
+  let prev = 0
+  SEGMENT_TOKEN_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = SEGMENT_TOKEN_RE.exec(seg)) !== null) {
+    lits.push(seg.slice(prev, m.index))
+    const v = values[m[1]]
+    vals.push(v !== undefined ? v : m[0]) // unknown token: keep "{Token}" verbatim
+    prev = m.index + m[0].length
+  }
+  if (vals.length === 0) return seg.trim()
+  lits.push(seg.slice(prev))
+
+  // Drop the separator following each leading empty token. Stop at the first
+  // non-empty value, or at a leading literal that is real text, not just glue.
+  for (let i = 0; i < vals.length; i++) {
+    if (vals[i] !== '') break
+    if (lits[i].trim() !== '') break
+    lits[i + 1] = ''
+  }
+
+  let out = ''
+  for (let i = 0; i < vals.length; i++) out += lits[i] + vals[i]
+  out += lits[lits.length - 1]
+  return out.trim()
 }
 
 export interface ValidationResult {


### PR DESCRIPTION
## Problem

Reported in Discord (Ben): with a naming template like `{Author}/{Series}/{SeriesNumber} - {Title} {Year}`, grabbing a book that has no series info yields a folder named ` - The Hollow Boy 2015` — a dangling ` - ` because the empty `{SeriesNumber}` token left its separator behind. (Series metadata often isn't populated at grab time even with Hardcover enrichment enabled.)

Root cause: `Renamer.apply` substituted tokens with naive `strings.ReplaceAll`, so an empty token's surrounding literal glue stayed in the output.

## Fix

`apply()` now renders per `/`-separated path segment via a new `renderSegment` helper. For the **leading** run of empty tokens in each segment, it drops the separator that would otherwise dangle in front of the first real value. It does *not* enumerate separator strings — it drops the literal structurally bound to the empty leading token, so it works for any glue (` - `, `: `, ` (`, etc.).

Interior and trailing glue is deliberately left untouched, preserving established (drift-guard-pinned) behaviour:
- `{Title} ({Year})` with no year → `Title ()`
- `{Title}.{ext}` (audiobook folder) → `Title.`

## Cross-stack

The File Naming settings live-preview has a TypeScript mirror (`web/src/pages/settings/namingTemplate.ts`) pinned to the Go engine by `renamer_preview_test.go`. It had the **identical bug** and is fixed in lockstep, so the preview matches what the importer actually writes.

## Scope note

Only the **leading** separator case (the actual report) is fixed. The symmetric **trailing** case (`{Title} - {SeriesNumber}` → `Title - `) is intentionally left alone because collapsing it would conflict with the pinned `{Title}.{ext}` → `Title.` behaviour and is a separate behaviour decision. Happy to follow up if wanted.

## Tests
- [x] `go test ./internal/importer/` (added leading + consecutive-leading cases; existing `{Title} ({Year})`/`{Title}.{ext}` cases still green)
- [x] `vitest` `NamingTemplateField.test.tsx` (mirror cases + interior-glue-preserved assertion)
- [x] `tsc --noEmit` + `eslint` clean
- [x] `go vet` + `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)