### PR TITLE
feat: {Genre} naming token sourced from Hardcover, with {Token:default} fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **`{Genre}` file-naming token** — organise your library into top-level genre folders (e.g. `{Genre}/{Author}/{Title}`). Genres are sourced from Hardcover's curated taxonomy when Hardcover is enabled; without it the token falls back to OpenLibrary's noisier subject data. New books pick up genres immediately; **refresh an author** to backfill genres onto books imported before this release.
+- **`{Token:default}` fallback syntax in naming templates** — any token can specify a fallback used when it renders empty, mirroring Calibre's `ifempty(...)`. For example `{Genre:Unsorted}/{Author}/{Title}` routes un-tagged books to an `Unsorted/` folder instead of dropping the folder level.
+
+### Changed
+
+- **Genres now prefer Hardcover's taxonomy over OpenLibrary subjects** — when a Hardcover match is available, its curated genres (`Fantasy`, `Science Fiction`) replace OpenLibrary's raw subject bag (`Fiction`, `American literature`, `Large type books`) for display and for the new `{Genre}` token. Non-Hardcover enrichers (e.g. Google Books BISAC categories) no longer overwrite genres.
+
+### Notes
+
+- `{Genre}` uses the first genre Hardcover lists. If Hardcover later re-categorises a book, new grabs follow the new genre, but already-imported files are not relocated.
+- Per-book genre editing (your own vocabulary, like a Calibre custom column) is not yet supported; this release sources clean genres automatically but does not let you override them per book.
+
 ## [v1.18.0] — 2026-06-11
 
 ### Added

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1452,13 +1453,27 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 			}
 		}
 
-		// Update ratings on existing books so the recommender has data to work with,
-		// then skip further processing (we don't want to overwrite user state like status).
+		// Update ratings + genres on existing books, then skip further
+		// processing (we don't want to overwrite user state like status).
 		existing, _ := h.books.GetByForeignID(ctx, b.ForeignID)
 		if existing != nil {
+			changed := false
 			if b.RatingsCount > 0 && (existing.RatingsCount == 0 || b.RatingsCount > existing.RatingsCount) {
 				existing.RatingsCount = b.RatingsCount
 				existing.AverageRating = b.AverageRating
+				changed = true
+			}
+			// Backfill Hardcover genres onto rows imported before genre
+			// sourcing existed. Gated to Hardcover provenance (a HardcoverForeignID
+			// means HC matched this work this fetch) so a refresh while HC is
+			// unavailable never downgrades clean genres back to OL subjects.
+			// NOTE: once a per-book genre override lands (follow-up), this must
+			// be guarded to not clobber a user-edited value.
+			if b.HardcoverForeignID != "" && len(b.Genres) > 0 && !slices.Equal(existing.Genres, b.Genres) {
+				existing.Genres = b.Genres
+				changed = true
+			}
+			if changed {
 				if err := h.books.Update(ctx, existing); err != nil {
 					slog.Warn("authors: update during dedup", "error", err, "book_id", existing.ID)
 				}

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"sync"
 	"testing"
@@ -402,6 +403,62 @@ func (f *stubLibraryFinder) FindExisting(_ context.Context, title, _, _ string) 
 // LibraryFinder reports a book is already on disk, FetchAuthorBooks sets the
 // file path on the book row and does NOT call SearchAndGrabBook for it. Books
 // NOT found on disk should still be searched normally.
+// TestFetchAuthorBooks_BackfillsHardcoverGenres verifies that refreshing an
+// author updates an existing book's genres when the incoming work carries
+// Hardcover provenance, so libraries imported before genre sourcing get cleaned.
+func TestFetchAuthorBooks_BackfillsHardcoverGenres(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	author := &models.Author{
+		ForeignID: "OL800A", Name: "Backfill Author", SortName: "Author, Backfill",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-existing row with noisy OpenLibrary subjects and no Hardcover link.
+	existing := &models.Book{
+		ForeignID: "OL801W", AuthorID: author.ID, Title: "Old Book", SortTitle: "old book",
+		Language: "eng", Status: models.BookStatusWanted, MetadataProvider: "openlibrary",
+		Genres: []string{"Fiction", "American literature"},
+	}
+	if err := bookRepo.Create(ctx, existing); err != nil {
+		t.Fatal(err)
+	}
+
+	// Refresh returns the same work, now Hardcover-matched with clean genres.
+	stub := &stubMetaProvider{
+		works: []models.Book{
+			{
+				ForeignID: "OL801W", Title: "Old Book", SortTitle: "old book", Language: "eng",
+				Status: models.BookStatusWanted, MetadataProvider: "openlibrary",
+				HardcoverForeignID: "hc:old-book", Genres: []string{"Fantasy"},
+			},
+		},
+	}
+	agg := metadata.NewAggregator(stub)
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, &searcherSpy{})
+	h.FetchAuthorBooks(author, false, "")
+
+	got, err := bookRepo.GetByForeignID(ctx, "OL801W")
+	if err != nil || got == nil {
+		t.Fatalf("reload book: %v", err)
+	}
+	if want := []string{"Fantasy"}; !slices.Equal(got.Genres, want) {
+		t.Errorf("genres should be backfilled from hardcover: want %v, got %v", want, got.Genres)
+	}
+}
+
 func TestFetchAuthorBooks_SkipsSearchForOwnedBooks(t *testing.T) {
 	database, err := db.OpenMemory()
 	if err != nil {

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -13,8 +13,13 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
-// templateTokenRe matches a "{Token}" placeholder in a naming template.
-var templateTokenRe = regexp.MustCompile(`\{(\w+)\}`)
+// templateTokenRe matches a "{Token}" placeholder, optionally with a default
+// value after a colon ("{Genre:Unsorted}"). The default is substituted when the
+// token renders empty, mirroring Calibre's ifempty(...) so a top-level taxonomy
+// folder (e.g. genre) can route un-tagged books to a fixed folder instead of
+// collapsing the path segment. Group 1 is the token name; group 2 (optional) is
+// the default text.
+var templateTokenRe = regexp.MustCompile(`\{(\w+)(?::([^}]*))?\}`)
 
 const defaultNamingTemplate = "{Author}/{Title} ({Year})/{Title} - {Author}.{ext}"
 const defaultAudiobookTemplate = "{Author}/{Title} ({Year})"
@@ -107,6 +112,7 @@ func (r *Renamer) apply(template string, author *models.Author, book *models.Boo
 		"ASIN":         sanitizePath(book.ASIN),
 		"Series":       sanitizePath(series),
 		"SeriesNumber": sanitizePath(seriesNumber),
+		"Genre":        sanitizePath(firstGenre(book.Genres)),
 		"ext":          ext,
 	}
 
@@ -153,8 +159,11 @@ func renderSegment(seg string, values map[string]string) string {
 		name := seg[m[2]:m[3]]
 		lits = append(lits, seg[prev:start])
 		v, ok := values[name]
-		if !ok {
-			v = seg[start:end] // unknown token: keep "{Token}" verbatim
+		switch {
+		case !ok:
+			v = seg[start:end] // unknown token: keep "{Token}" (or "{Token:def}") verbatim
+		case v == "" && m[4] >= 0:
+			v = sanitizePath(seg[m[4]:m[5]]) // empty known token with a default
 		}
 		vals = append(vals, v)
 		prev = end
@@ -181,6 +190,19 @@ func renderSegment(seg string, values map[string]string) string {
 	}
 	b.WriteString(lits[len(lits)-1])
 	return strings.TrimSpace(b.String())
+}
+
+// firstGenre returns the primary genre for the {Genre} token: the first entry
+// of the book's genre list, or "" when there are none. The list is populated
+// from Hardcover's curated taxonomy when available (see aggregator enrichment);
+// the choice of index 0 is deterministic for a given fetch, but note that
+// upstream re-categorisation can change it and Bindery does not relocate
+// already-imported files when it does.
+func firstGenre(genres []string) string {
+	if len(genres) == 0 {
+		return ""
+	}
+	return genres[0]
 }
 
 // MoveFile atomically copies a file to the destination and then removes the source.

--- a/internal/importer/renamer_preview_test.go
+++ b/internal/importer/renamer_preview_test.go
@@ -18,13 +18,14 @@ import (
 func TestRenamerPreviewSampleDriftGuard(t *testing.T) {
 	// Mirrors SAMPLE_BOOK: author "Jane Doe" (sort "Doe, Jane"),
 	// title "Sample Book", year 2024, ASIN "B01ABCDEFG",
-	// series "Demo Series", series number "2", ext "epub".
+	// series "Demo Series", series number "2", genre "Fantasy", ext "epub".
 	releaseDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	author := &models.Author{Name: "Jane Doe"}
 	book := &models.Book{
 		Title:       "Sample Book",
 		ASIN:        "B01ABCDEFG",
 		ReleaseDate: &releaseDate,
+		Genres:      []string{"Fantasy"},
 	}
 	const series = "Demo Series"
 	const seriesNumber = "2"
@@ -39,9 +40,9 @@ func TestRenamerPreviewSampleDriftGuard(t *testing.T) {
 	}{
 		{
 			name:     "all tokens (ebook)",
-			template: "{Author}|{SortAuthor}|{Title}|{Year}|{ASIN}|{Series}|{SeriesNumber}|{ext}",
+			template: "{Author}|{SortAuthor}|{Title}|{Year}|{ASIN}|{Series}|{SeriesNumber}|{Genre}|{ext}",
 			ext:      "epub",
-			want:     "Jane Doe|Doe, Jane|Sample Book|2024|B01ABCDEFG|Demo Series|2|epub",
+			want:     "Jane Doe|Doe, Jane|Sample Book|2024|B01ABCDEFG|Demo Series|2|Fantasy|epub",
 		},
 		{
 			name:     "default ebook template",

--- a/internal/importer/renamer_test.go
+++ b/internal/importer/renamer_test.go
@@ -170,6 +170,56 @@ func TestRenamerSeriesTokensEmpty(t *testing.T) {
 	}
 }
 
+func TestRenamerGenreToken(t *testing.T) {
+	author := &models.Author{Name: "Frank Herbert"}
+
+	cases := []struct {
+		name     string
+		template string
+		genres   []string
+		want     string
+	}{
+		{
+			name:     "genre folder from first genre",
+			template: "{Genre}/{Author}/{Title}.{ext}",
+			genres:   []string{"Science Fiction", "Fantasy"},
+			want:     filepath.Join("/books", "Science Fiction", "Frank Herbert", "Dune.epub"),
+		},
+		{
+			name:     "empty genre drops the segment",
+			template: "{Genre}/{Author}/{Title}.{ext}",
+			genres:   nil,
+			want:     filepath.Join("/books", "Frank Herbert", "Dune.epub"),
+		},
+		{
+			// VENGEANCE's Calibre {#genre:ifempty(Unsorted)} workflow.
+			name:     "empty genre uses default",
+			template: "{Genre:Unsorted}/{Author}/{Title}.{ext}",
+			genres:   nil,
+			want:     filepath.Join("/books", "Unsorted", "Frank Herbert", "Dune.epub"),
+		},
+		{
+			name:     "default ignored when genre present",
+			template: "{Genre:Unsorted}/{Author}/{Title}.{ext}",
+			genres:   []string{"Fantasy"},
+			want:     filepath.Join("/books", "Fantasy", "Frank Herbert", "Dune.epub"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewRenamer(tc.template)
+			book := &models.Book{Title: "Dune", Genres: tc.genres}
+			got, err := r.DestPath("/books", author, book, "", "", "book.epub")
+			if err != nil {
+				t.Fatalf("DestPath: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got  %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRenamerAudiobookSeriesTokens(t *testing.T) {
 	r := NewRenamerWithAudiobook("", "{Author}/{Series}/{SeriesNumber} - {Title}")
 	author := &models.Author{Name: "Brandon Sanderson"}

--- a/internal/metadata/aggregator_author_works.go
+++ b/internal/metadata/aggregator_author_works.go
@@ -253,7 +253,13 @@ func mergeAuthorWorkMetadata(dst *models.Book, src models.Book) {
 	if dst.ReleaseDate == nil {
 		dst.ReleaseDate = src.ReleaseDate
 	}
-	if len(dst.Genres) == 0 {
+	// Genres: a Hardcover supplement replaces OpenLibrary's noisy "subjects"
+	// bag with its curated taxonomy. Gated to Hardcover provenance so other
+	// enrichers (e.g. Google Books BISAC categories) don't overwrite with
+	// slash-delimited strings. Non-Hardcover sources keep the fill-empty rule.
+	if src.MetadataProvider == "hardcover" && len(src.Genres) > 0 {
+		dst.Genres = src.Genres
+	} else if len(dst.Genres) == 0 {
 		dst.Genres = src.Genres
 	}
 	if dst.DurationSeconds == 0 {

--- a/internal/metadata/aggregator_author_works_test.go
+++ b/internal/metadata/aggregator_author_works_test.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -152,6 +153,32 @@ func TestAggregator_GetAuthorWorksForAuthor_MergesSupplementalByTitle(t *testing
 	}
 	if got[1].HardcoverForeignID != "" {
 		t.Fatalf("unmatched supplemental book should not carry matched hardcover identity: %+v", got[1])
+	}
+}
+
+func TestMergeAuthorWorkMetadata_GenrePreferHardcover(t *testing.T) {
+	// Hardcover supplement replaces OL subjects with its taxonomy.
+	dst := models.Book{Genres: []string{"Fiction", "American literature"}}
+	src := models.Book{MetadataProvider: "hardcover", Genres: []string{"Fantasy"}}
+	mergeAuthorWorkMetadata(&dst, src)
+	if want := []string{"Fantasy"}; !slices.Equal(dst.Genres, want) {
+		t.Errorf("hardcover genres should replace: want %v, got %v", want, dst.Genres)
+	}
+
+	// Non-Hardcover supplement does not overwrite a non-empty genre list.
+	dst2 := models.Book{Genres: []string{"Fiction"}}
+	src2 := models.Book{MetadataProvider: "googlebooks", Genres: []string{"Fiction / Science Fiction / General"}}
+	mergeAuthorWorkMetadata(&dst2, src2)
+	if want := []string{"Fiction"}; !slices.Equal(dst2.Genres, want) {
+		t.Errorf("non-hardcover must not overwrite: want %v, got %v", want, dst2.Genres)
+	}
+
+	// Non-Hardcover still fills an empty genre list (existing behaviour).
+	dst3 := models.Book{}
+	src3 := models.Book{MetadataProvider: "googlebooks", Genres: []string{"Biography"}}
+	mergeAuthorWorkMetadata(&dst3, src3)
+	if want := []string{"Biography"}; !slices.Equal(dst3.Genres, want) {
+		t.Errorf("fill-empty should still apply: want %v, got %v", want, dst3.Genres)
 	}
 }
 

--- a/internal/metadata/aggregator_enrichment.go
+++ b/internal/metadata/aggregator_enrichment.go
@@ -227,6 +227,11 @@ type enrichmentSnapshot struct {
 	imageURL      string
 	averageRating float64
 	ratingsCount  int
+	// genres holds the Hardcover genre taxonomy when a Hardcover match
+	// supplied one. We snapshot it so the {Genre} naming token and the genre
+	// display read a curated source instead of OpenLibrary's noisy "subjects"
+	// bag. Empty when no Hardcover match contributed genres.
+	genres []string
 }
 
 // enrichBookCacheKey is keyed on (MetadataProvider, ForeignID) because that
@@ -298,6 +303,17 @@ func (a *Aggregator) enrichBook(ctx context.Context, book *models.Book) {
 			book.ImageURL = e.ImageURL
 			slog.Debug("enriched cover", "provider", enricher.Name(), "book", book.Title)
 		}
+		// Genres: prefer Hardcover's curated taxonomy ("Fantasy", "Science
+		// Fiction") over OpenLibrary's raw subject bag. Gated to Hardcover
+		// specifically — Google Books ships slash-delimited BISAC strings
+		// ("Fiction / Science Fiction / General") that would pollute folder
+		// names. Replace rather than fill-empty, since OL almost always
+		// supplies *some* subject so fill-empty would never fire. Never blank
+		// existing genres with an empty Hardcover result.
+		if enricher.Name() == "hardcover" && len(e.Genres) > 0 {
+			book.Genres = e.Genres
+			slog.Debug("enriched genres", "provider", enricher.Name(), "book", book.Title)
+		}
 	}
 
 	// Cover-only fallback: any provider implementing CoverProvider gets
@@ -315,6 +331,7 @@ func (a *Aggregator) enrichBook(ctx context.Context, book *models.Book) {
 			imageURL:      book.ImageURL,
 			averageRating: book.AverageRating,
 			ratingsCount:  book.RatingsCount,
+			genres:        book.Genres,
 		})
 	}
 }
@@ -336,6 +353,14 @@ func applyEnrichmentSnapshot(book *models.Book, snap enrichmentSnapshot) {
 	if preferStrongerRating(book.AverageRating, book.RatingsCount, snap.averageRating, snap.ratingsCount) {
 		book.AverageRating = snap.averageRating
 		book.RatingsCount = snap.ratingsCount
+	}
+	// Mirror the live genre rule: the snapshot holds the post-enrichment
+	// genres (Hardcover's when a match supplied them). The cache key is
+	// (provider, foreignID), so a hit reuses the same book identity and the
+	// same source genres; replacing is correct and a no-op when no Hardcover
+	// match ever contributed.
+	if len(snap.genres) > 0 {
+		book.Genres = snap.genres
 	}
 }
 

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -498,6 +499,71 @@ func TestAggregator_GetBook_Enrichment_RatingFilled(t *testing.T) {
 	}
 	if got.RatingsCount != 100 {
 		t.Errorf("ratingsCount: want 100, got %d", got.RatingsCount)
+	}
+}
+
+func TestAggregator_GetBook_Enrichment_GenresFromHardcover(t *testing.T) {
+	// Hardcover's curated taxonomy replaces OpenLibrary's noisy subjects.
+	primary := &mockProvider{
+		name:    "ol",
+		getBook: &models.Book{Title: "Mistborn", Description: "x", Genres: []string{"Fiction", "American literature", "Large type books"}},
+	}
+	hc := &mockProvider{
+		name:        "hardcover",
+		searchBooks: []models.Book{{Title: "Mistborn", Description: "Some desc", Genres: []string{"Fantasy", "Epic Fantasy"}}},
+	}
+	agg := &Aggregator{primary: primary, enrichers: []Provider{hc}, cache: newTTLCache(time.Minute)}
+
+	got, err := agg.GetBook(context.Background(), "OL100W")
+	if err != nil {
+		t.Fatalf("GetBook: %v", err)
+	}
+	if want := []string{"Fantasy", "Epic Fantasy"}; !slices.Equal(got.Genres, want) {
+		t.Errorf("genres: want %v, got %v", want, got.Genres)
+	}
+}
+
+func TestAggregator_GetBook_Enrichment_NonHardcoverGenresIgnored(t *testing.T) {
+	// Google Books ships slash-delimited BISAC strings; they must not replace
+	// the existing genres (gated to Hardcover provenance).
+	olGenres := []string{"Fiction"}
+	primary := &mockProvider{
+		name:    "ol",
+		getBook: &models.Book{Title: "Dune", Description: "x", Genres: olGenres},
+	}
+	gb := &mockProvider{
+		name:        "googlebooks",
+		searchBooks: []models.Book{{Title: "Dune", Description: "Some desc", Genres: []string{"Fiction / Science Fiction / General"}}},
+	}
+	agg := &Aggregator{primary: primary, enrichers: []Provider{gb}, cache: newTTLCache(time.Minute)}
+
+	got, err := agg.GetBook(context.Background(), "OL200W")
+	if err != nil {
+		t.Fatalf("GetBook: %v", err)
+	}
+	if !slices.Equal(got.Genres, olGenres) {
+		t.Errorf("genres should be untouched by non-Hardcover enricher: want %v, got %v", olGenres, got.Genres)
+	}
+}
+
+func TestAggregator_GetBook_Enrichment_EmptyHardcoverGenresDoNotBlank(t *testing.T) {
+	olGenres := []string{"Fiction"}
+	primary := &mockProvider{
+		name:    "ol",
+		getBook: &models.Book{Title: "Dune", Description: "x", Genres: olGenres},
+	}
+	hc := &mockProvider{
+		name:        "hardcover",
+		searchBooks: []models.Book{{Title: "Dune", Description: "Some desc"}}, // no genres
+	}
+	agg := &Aggregator{primary: primary, enrichers: []Provider{hc}, cache: newTTLCache(time.Minute)}
+
+	got, err := agg.GetBook(context.Background(), "OL300W")
+	if err != nil {
+		t.Fatalf("GetBook: %v", err)
+	}
+	if !slices.Equal(got.Genres, olGenres) {
+		t.Errorf("existing genres must survive an empty Hardcover result: want %v, got %v", olGenres, got.Genres)
 	}
 }
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -568,6 +568,7 @@
         "tokenAsin": "{ASIN} — Audible ASIN (blank if none)",
         "tokenSeries": "{Series} — series title (blank for standalone)",
         "tokenSeriesNumber": "{SeriesNumber} — position in series",
+        "tokenGenre": "{Genre} — primary genre, best with Hardcover enabled. Use {Genre:Unsorted} to set a fallback folder.",
         "tokenExt": "{ext} — file extension, no leading dot (ebook only)",
         "tokenIgnoredAudiobook": "{{token}} is ignored for the audiobook folder template",
         "errorEmpty": "Template cannot be empty.",

--- a/web/src/pages/settings/NamingTemplateField.test.tsx
+++ b/web/src/pages/settings/NamingTemplateField.test.tsx
@@ -43,10 +43,10 @@ describe('namingTemplate renderer (renamer.go mirror)', () => {
   })
 
   it('renders all tokens', () => {
-    const out = renderTemplate('{Author}|{SortAuthor}|{Title}|{Year}|{ASIN}|{Series}|{SeriesNumber}|{ext}', 'book')
+    const out = renderTemplate('{Author}|{SortAuthor}|{Title}|{Year}|{ASIN}|{Series}|{SeriesNumber}|{Genre}|{ext}', 'book')
     // "|" is stripped by sanitize only inside a substituted field, not in the
     // literal template, so the separators survive between tokens.
-    expect(out).toBe('Jane Doe|Doe, Jane|Sample Book|2024|B01ABCDEFG|Demo Series|2|epub')
+    expect(out).toBe('Jane Doe|Doe, Jane|Sample Book|2024|B01ABCDEFG|Demo Series|2|Fantasy|epub')
   })
 
   it('renders {ext} as empty for the audiobook (folder) kind', () => {
@@ -74,6 +74,22 @@ describe('namingTemplate renderer (renamer.go mirror)', () => {
     expect(
       renderTemplate('{Title} ({Year})', 'book', { ...SAMPLE_BOOK, year: '' }),
     ).toBe('Sample Book ()')
+  })
+
+  it('renders the {Genre} token and {Token:default} fallback', () => {
+    expect(renderTemplate('{Genre}/{Title}.{ext}', 'book')).toBe('Fantasy/Sample Book.epub')
+    const noGenre = { ...SAMPLE_BOOK, genre: '' }
+    // Empty genre drops the segment...
+    expect(renderTemplate('{Genre}/{Title}.{ext}', 'book', noGenre)).toBe('Sample Book.epub')
+    // ...unless a default is given (mirrors Calibre's ifempty(Unsorted)).
+    expect(renderTemplate('{Genre:Unsorted}/{Title}.{ext}', 'book', noGenre)).toBe('Unsorted/Sample Book.epub')
+    // Default is ignored when the token has a value.
+    expect(renderTemplate('{Genre:Unsorted}/{Title}.{ext}', 'book')).toBe('Fantasy/Sample Book.epub')
+  })
+
+  it('treats {Genre:Unsorted} as a known token in validation', () => {
+    expect(validateTemplate('{Genre:Unsorted}/{Author}/{Title}.{ext}').unknownTokens).toEqual([])
+    expect(validateTemplate('{Bogus:x}').unknownTokens).toEqual(['{Bogus:x}'])
   })
 })
 

--- a/web/src/pages/settings/namingTemplate.ts
+++ b/web/src/pages/settings/namingTemplate.ts
@@ -27,6 +27,7 @@ export const NAMING_TOKENS: readonly NamingToken[] = [
   { token: '{ASIN}', descKey: 'tokenAsin' },
   { token: '{Series}', descKey: 'tokenSeries' },
   { token: '{SeriesNumber}', descKey: 'tokenSeriesNumber' },
+  { token: '{Genre}', descKey: 'tokenGenre' },
   { token: '{ext}', descKey: 'tokenExt', ebookOnly: true },
 ] as const
 
@@ -44,6 +45,7 @@ export interface SampleBook {
   asin: string
   series: string
   seriesNumber: string
+  genre: string
   ext: string
 }
 
@@ -56,6 +58,7 @@ export const SAMPLE_BOOK: SampleBook = {
   asin: 'B01ABCDEFG',
   series: 'Demo Series',
   seriesNumber: '2',
+  genre: 'Fantasy',
   ext: 'epub',
 }
 
@@ -115,6 +118,7 @@ export function renderTemplate(
     ASIN: sanitizePath(sample.asin),
     Series: sanitizePath(sample.series),
     SeriesNumber: sanitizePath(sample.seriesNumber),
+    Genre: sanitizePath(sample.genre),
     ext,
   }
   return template
@@ -124,7 +128,9 @@ export function renderTemplate(
     .join(SEP)
 }
 
-const SEGMENT_TOKEN_RE = /\{(\w+)\}/g
+// Group 1: token name. Group 2 (optional): default after a colon, used when the
+// token renders empty ("{Genre:Unsorted}"). Mirrors templateTokenRe in renamer.go.
+const SEGMENT_TOKEN_RE = /\{(\w+)(?::([^}]*))?\}/g
 
 // renderSegment mirrors renamer.go renderSegment: substitute "{Token}"
 // placeholders in a single path segment and, when the leading token(s) render
@@ -132,7 +138,8 @@ const SEGMENT_TOKEN_RE = /\{(\w+)\}/g
 // real value ("{SeriesNumber} - {Title}" with no series number → "Title", not
 // " - Title"). Only leading glue is collapsed; interior/trailing glue stays so
 // "{Title} ({Year})" → "Title ()" and "{Title}.{ext}" → "Title." are preserved.
-// Unknown tokens are kept verbatim.
+// A "{Token:default}" empty token renders its default instead. Unknown tokens
+// are kept verbatim.
 function renderSegment(seg: string, values: Record<string, string>): string {
   const lits: string[] = []
   const vals: string[] = []
@@ -142,7 +149,13 @@ function renderSegment(seg: string, values: Record<string, string>): string {
   while ((m = SEGMENT_TOKEN_RE.exec(seg)) !== null) {
     lits.push(seg.slice(prev, m.index))
     const v = values[m[1]]
-    vals.push(v !== undefined ? v : m[0]) // unknown token: keep "{Token}" verbatim
+    if (v === undefined) {
+      vals.push(m[0]) // unknown token: keep "{Token}" (or "{Token:def}") verbatim
+    } else if (v === '' && m[2] !== undefined) {
+      vals.push(sanitizePath(m[2])) // empty known token with a default
+    } else {
+      vals.push(v)
+    }
     prev = m.index + m[0].length
   }
   if (vals.length === 0) return seg.trim()
@@ -181,7 +194,10 @@ export function validateTemplate(template: string): ValidationResult {
   const matches = template.match(TOKEN_RE) ?? []
   const unknown: string[] = []
   for (const m of matches) {
-    if (!SUPPORTED.has(m) && !unknown.includes(m)) unknown.push(m)
+    // Strip an optional ":default" ("{Genre:Unsorted}" → "{Genre}") before the
+    // supported-token check; report the original token text if still unknown.
+    const norm = m.replace(/^(\{\w+):[^}]*\}$/, '$1}')
+    if (!SUPPORTED.has(norm) && !unknown.includes(m)) unknown.push(m)
   }
   return {
     unknownTokens: unknown,


### PR DESCRIPTION
## Summary

Adds a `{Genre}` file-naming token so users can organise libraries into top-level genre folders (e.g. `{Genre}/{Author}/{Title}`), requested in Discord. The token is only as good as the genre data, so the bulk of this PR is the data-hygiene fix underneath it.

### Part 1: genres sourced from Hardcover, not OpenLibrary subjects
OpenLibrary stuffs its raw "subjects" bag into `Genres` (`Fiction`, `American literature`, `Large type books`); Hardcover's curated taxonomy (`Fantasy`, `Science Fiction`) was fetched and thrown away. Now:
- `enrichBook` (GetBook path) replaces genres when the matched enricher is **Hardcover specifically** and supplies them. Gated to Hardcover provenance so Google Books BISAC strings (`Fiction / Science Fiction / General`) can't pollute the field. Snapshot + cache-apply mirror the rule.
- `mergeAuthorWorkMetadata` (catalogue path): Hardcover `src` replaces; other providers keep fill-empty.
- `FetchAuthorBooks` existing-row branch backfills genres onto rows imported before this change, gated to Hardcover provenance so a refresh while Hardcover is unavailable never downgrades clean genres back to OL subjects.

### Part 2: `{Genre}` token + `{Token:default}` fallback
- `{Genre}` renders the first genre (Hardcover's primary).
- `{Token:default}` lets any token specify a fallback when empty, mirroring the requester's Calibre `ifempty(Unsorted)`: `{Genre:Unsorted}/{Author}/{Title}` routes un-tagged books to `Unsorted/` instead of dropping the segment.
- TS preview mirror (`namingTemplate.ts`) updated in lockstep, including `validateTemplate` stripping `:default` before the supported-token check. Drift guard `SAMPLE_BOOK` gains a `genre` field and `{Genre}` is added to the all-tokens pinned string on both stacks.

## Review findings folded in
This was scoped against a detailed review:
1. **Backfill** existing rows, not just newly-discovered books (the existing-row branch now updates genres like it updates ratings).
2. **HC-gated** replacement, so Google Books BISAC categories never land as folder names.
3. **Empty fallback** via `{Token:default}` rather than relying on segment-drop, since a top-level taxonomy folder shouldn't silently collapse to a mixed-depth tree.
4. **Deterministic pick** (`Genres[0]`), documented that upstream re-categorisation does not relocate already-imported files.
5. **Per-book editable genre is explicitly deferred** — this delivers clean genre folders, not the user's own hand-curated vocabulary. Named as the follow-up below.

## Known gap / follow-up
Per-book genre override (a `genre` field on `BookHandler.Update` + a book-detail editor + a "don't clobber on refresh" guard in the Part 1 backfill). That is what delivers a user's own vocabulary like a Calibre custom column.

## Caveats (documented in CHANGELOG + in-app token description)
- Clean genres require Hardcover enabled; without it the token falls back to OL subjects.
- Existing libraries need an author refresh to backfill.
- Genre changes after import do not relocate files.

## Test plan
- [x] `go test ./internal/metadata/ ./internal/importer/ ./internal/api/`
- [x] `vitest` settings suite (29 tests); `tsc --noEmit`; `eslint`
- [x] `go vet` + `gofmt` clean
- [x] enrichBook HC-replace / non-HC-ignored / empty-no-blank; merge gating; FetchAuthorBooks backfill; `{Genre}` + `{Genre:Unsorted}` render + validation; drift guard updated both stacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)