### PR TITLE
fix(auth): PUT /auth/oidc/providers bypassed API-key auth due to method-blind allowlist

### DIFF
--- a/changelog.d/oidc-providers-put-auth.md
+++ b/changelog.d/oidc-providers-put-auth.md
@@ -1,0 +1,2 @@
+### Fixed
+- **OIDC provider config via API key** — `PUT /api/v1/auth/oidc/providers` returned `403 {"error":"admin role required"}` even with a valid `X-Api-Key` header, because the auth allowlist matched on path only and skipped the key check entirely. `GET` is intentionally public (login page needs the provider list); `PUT` now goes through normal auth so API-key-authenticated requests are correctly granted admin access.

--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -64,7 +64,7 @@ func RequireCSRFToken(secrets func() [][]byte) func(http.Handler) http.Handler {
 			case http.MethodGet, http.MethodHead, http.MethodOptions:
 				// safe methods — no mutation risk
 			default:
-				if !AuthedViaAPIKey(r.Context()) && !AllowUnauthPath(r.URL.Path) {
+				if !AuthedViaAPIKey(r.Context()) && !AllowUnauthPath(r.Method, r.URL.Path) {
 					if c, err := r.Cookie(SessionCookieName); err == nil && c.Value != "" {
 						tok := r.Header.Get("X-CSRF-Token")
 						if !ValidCSRFToken(secrets(), r, tok) {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -222,18 +222,23 @@ type Provider interface {
 	UserSessionEpoch(ctx context.Context, userID int64) int64
 }
 
-// AllowUnauthPath returns true for routes the middleware must always let
-// through, regardless of auth state (health probes, auth endpoints themselves).
-func AllowUnauthPath(path string) bool {
+// AllowUnauthPath reports whether the given method+path combination must always
+// be let through regardless of auth state (health probes, auth endpoints).
+// The method parameter matters: GET /auth/oidc/providers is intentionally
+// public so the login page can discover providers, but PUT on the same path
+// is an admin mutation that must go through normal auth.
+func AllowUnauthPath(method, path string) bool {
 	switch path {
 	case "/api/v1/health",
 		"/api/v1/auth/status",
 		"/api/v1/auth/login",
 		"/api/v1/auth/logout",
 		"/api/v1/auth/setup",
-		"/api/v1/auth/csrf",
-		"/api/v1/auth/oidc/providers":
+		"/api/v1/auth/csrf":
 		return true
+	case "/api/v1/auth/oidc/providers":
+		// Only the read path is public; mutations are admin-only.
+		return method == http.MethodGet || method == http.MethodHead
 	}
 	// OIDC login + callback paths are public — the IdP redirect happens before
 	// the user holds a Bindery session.
@@ -304,7 +309,7 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 			}
 			r = r.WithContext(ctx)
 
-			if AllowUnauthPath(r.URL.Path) {
+			if AllowUnauthPath(r.Method, r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -448,7 +453,7 @@ func RequireXRequestedWith(next http.Handler) http.Handler {
 			// session cookie to protect against CSRF at those points, so
 			// requiring the header is pure friction for non-browser clients.
 			// This mirrors the identical exemption in RequireCSRFToken.
-			if !AuthedViaAPIKey(r.Context()) && !AllowUnauthPath(r.URL.Path) && r.Header.Get("X-Requested-With") != "bindery-ui" {
+			if !AuthedViaAPIKey(r.Context()) && !AllowUnauthPath(r.Method, r.URL.Path) && r.Header.Get("X-Requested-With") != "bindery-ui" {
 				w.Header().Set("Content-Type", "application/json")
 				http.Error(w, `{"error":"forbidden"}`, http.StatusForbidden)
 				return

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -148,6 +148,62 @@ func TestProxyAuthRegularPathUntrustedIPStill401s(t *testing.T) {
 	}
 }
 
+// TestOIDCProvidersGETIsPublicPUTIsNot confirms that AllowUnauthPath is
+// method-aware for /auth/oidc/providers. GET must pass unauthenticated (login
+// page needs to discover providers), but PUT must go through normal auth so a
+// valid X-Api-Key header is required and grants admin access.
+func TestOIDCProvidersGETIsPublicPUTIsNot(t *testing.T) {
+	const apiKey = "test-api-key-for-oidc-test"
+	p := &fakeProvider{mode: ModeEnabled, apiKey: apiKey}
+	mw := Middleware(p)
+
+	// GET must be let through without any credentials.
+	t.Run("GET_public", func(t *testing.T) {
+		called := false
+		h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+		req, _ := http.NewRequest("GET", "/api/v1/auth/oidc/providers", nil)
+		h.ServeHTTP(nopWriter{}, req)
+		if !called {
+			t.Fatal("GET /auth/oidc/providers must be public (login page needs provider list)")
+		}
+	})
+
+	// PUT without credentials must be rejected as 401, not silently let through
+	// with no role (which would cause RequireAdmin to return a confusing 403).
+	t.Run("PUT_requires_auth", func(t *testing.T) {
+		called := false
+		h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }))
+		req, _ := http.NewRequest("PUT", "/api/v1/auth/oidc/providers", nil)
+		w := &captureWriter{}
+		h.ServeHTTP(w, req)
+		if called {
+			t.Fatal("PUT /auth/oidc/providers without credentials must not reach handler")
+		}
+		if w.status != http.StatusUnauthorized {
+			t.Errorf("status = %d; want 401", w.status)
+		}
+	})
+
+	// PUT with a valid API key must pass and set admin role.
+	t.Run("PUT_valid_api_key_is_admin", func(t *testing.T) {
+		var gotRole string
+		called := false
+		h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			called = true
+			gotRole = UserRoleFromContext(r.Context())
+		}))
+		req, _ := http.NewRequest("PUT", "/api/v1/auth/oidc/providers", nil)
+		req.Header.Set("X-Api-Key", apiKey)
+		h.ServeHTTP(nopWriter{}, req)
+		if !called {
+			t.Fatal("PUT with valid API key must reach handler")
+		}
+		if gotRole != "admin" {
+			t.Errorf("role = %q; want \"admin\"", gotRole)
+		}
+	})
+}
+
 // Regression tests for CheckOwnership, the helper that closes Tier-1 per-user
 // IDOR (D1). The contract:
 //


### PR DESCRIPTION
## Summary

AllowUnauthPath matched on path only, so PUT /api/v1/auth/oidc/providers was let through auth.Middleware unauthenticated (the GET is intentionally public for the login page). The request then hit RequireAdmin with no role and returned 403 "admin role required" instead of checking the X-Api-Key header at all.

Fix: make AllowUnauthPath take both method and path. The providers GET remains public; PUT now goes through normal auth so a valid X-Api-Key sets admin role and RequireAdmin passes.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed
- [x] Added a changelog fragment under `changelog.d/` (not an edit to `CHANGELOG.md`) — see [changelog.d/README.md](../changelog.d/README.md)
- [x] Wiki pages updated if user-facing behaviour changed (N/A)

## Test plan

- [x] `make check` (or the individual `go test ./cmd/... ./internal/...` and `cd web && npm run build` steps)

<!-- Only lint, validate (Go), and Security Summary are required to merge.
     Other security scans are advisory; a red Container Scan is often a base-image
     CVE unrelated to your change — mention it and a maintainer will confirm. -->
