### PR TITLE
Fix/naming template validation on load

### DIFF
--- a/changelog.d/naming-template-touched-validation.md
+++ b/changelog.d/naming-template-touched-validation.md
@@ -1,0 +1,2 @@
+### Fixed
+- **File Naming settings** — "Template cannot be empty" validation error no longer appears on page load when no template has been saved yet (the server uses a built-in default for empty templates, so the error was a false alarm until the field is actually edited).

--- a/web/src/pages/settings/NamingTemplateField.test.tsx
+++ b/web/src/pages/settings/NamingTemplateField.test.tsx
@@ -143,6 +143,8 @@ describe('NamingTemplateField component', () => {
 
   it('warns on an unknown token and disables save', () => {
     render(<Harness initial="{Bogus}/{Title}" />)
+    const input = screen.getByPlaceholderText('placeholder')
+    fireEvent.blur(input)
     expect(screen.getByText(/errorUnknownTokens.*\{Bogus\}/)).toBeTruthy()
     const save = screen.getByRole('button', { name: 'common.save' }) as HTMLButtonElement
     expect(save.disabled).toBe(true)
@@ -150,7 +152,17 @@ describe('NamingTemplateField component', () => {
 
   it('blocks save on an empty template', () => {
     render(<Harness initial="" />)
+    const input = screen.getByPlaceholderText('placeholder')
+    fireEvent.blur(input)
     expect(screen.getByText('settings.general.naming.errorEmpty')).toBeTruthy()
+    const save = screen.getByRole('button', { name: 'common.save' }) as HTMLButtonElement
+    expect(save.disabled).toBe(true)
+  })
+
+  it('does not show validation errors on initial load with an empty (default) value', () => {
+    render(<Harness initial="" />)
+    expect(screen.queryByText('settings.general.naming.errorEmpty')).toBeNull()
+    // Save is still disabled even without the error message visible.
     const save = screen.getByRole('button', { name: 'common.save' }) as HTMLButtonElement
     expect(save.disabled).toBe(true)
   })

--- a/web/src/pages/settings/NamingTemplateField.tsx
+++ b/web/src/pages/settings/NamingTemplateField.tsx
@@ -6,7 +6,7 @@
 // which mirrors the Go renamer (internal/importer/renamer.go) so the preview
 // matches what the importer actually writes.
 
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { inputCls, labelCls } from './formStyles'
 import {
@@ -39,6 +39,7 @@ export default function NamingTemplateField({
 }: NamingTemplateFieldProps) {
   const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement>(null)
+  const [touched, setTouched] = useState(false)
 
   const validation = validateTemplate(value)
   const preview = renderTemplate(value, kind)
@@ -78,7 +79,7 @@ export default function NamingTemplateField({
             <button
               key={tok.token}
               type="button"
-              onClick={() => !greyed && insertToken(tok.token)}
+              onClick={() => { if (!greyed) { setTouched(true); insertToken(tok.token) } }}
               disabled={greyed}
               title={
                 greyed
@@ -101,9 +102,10 @@ export default function NamingTemplateField({
         <input
           ref={inputRef}
           value={value}
-          onChange={e => onChange(e.target.value)}
+          onChange={e => { setTouched(true); onChange(e.target.value) }}
+          onBlur={() => setTouched(true)}
           placeholder={placeholder}
-          aria-invalid={hasErrors}
+          aria-invalid={touched && hasErrors}
           className={inputCls + ' flex-1 font-mono'}
         />
         <button
@@ -131,18 +133,18 @@ export default function NamingTemplateField({
         </p>
       )}
 
-      {/* Validation feedback */}
-      {validation.empty && (
+      {/* Validation feedback — only after user interaction */}
+      {touched && validation.empty && (
         <p className="text-xs text-red-600 dark:text-red-400 mt-1.5" role="alert">
           {t('settings.general.naming.errorEmpty')}
         </p>
       )}
-      {validation.traversal && (
+      {touched && validation.traversal && (
         <p className="text-xs text-red-600 dark:text-red-400 mt-1.5" role="alert">
           {t('settings.general.naming.errorTraversal')}
         </p>
       )}
-      {validation.unknownTokens.length > 0 && (
+      {touched && validation.unknownTokens.length > 0 && (
         <p className="text-xs text-amber-600 dark:text-amber-400 mt-1.5" role="alert">
           {t('settings.general.naming.errorUnknownTokens', {
             tokens: validation.unknownTokens.join(', '),


### PR DESCRIPTION
## Summary

The server returns an empty string for naming.bookTemplate / naming_template_audiobook when they've never been explicitly set (the renamer falls back to compiled-in defaults at import time). This caused "Template cannot be empty" to appear immediately on the File Naming settings page even without user interaction.

<img width="973" height="561" alt="image" src="https://github.com/user-attachments/assets/eefc34aa-96eb-4c8d-91c5-6e73472dc110" />

Fix: gate all validation feedback behind a `touched` state that is set on first onChange or onBlur. The Save button remains disabled for invalid templates regardless of touched state, so the constraint is still enforced.


## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed
- [x] Added a changelog fragment under `changelog.d/` (not an edit to `CHANGELOG.md`) — see [changelog.d/README.md](../changelog.d/README.md)
- [x] Wiki pages updated if user-facing behaviour changed

## Test plan

- [x] `make check` (or the individual `go test ./cmd/... ./internal/...` and `cd web && npm run build` steps)

<!-- Only lint, validate (Go), and Security Summary are required to merge.
     Other security scans are advisory; a red Container Scan is often a base-image
     CVE unrelated to your change — mention it and a maintainer will confirm. -->
