### PR TITLE
fix(import): format-aware already-imported decision for dual-format books (#1148)

### DIFF
--- a/changelog.d/1148-format-aware-import-decision.md
+++ b/changelog.d/1148-format-aware-import-decision.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Dual-format books can grab the missing format** (#1148) — for a book monitored as both ebook and audiobook, having one format on disk no longer blocks the other. Interactive search results for the missing format are no longer rejected with "book already imported", changing a book to "both" re-evaluates it back to wanted, and a library scan now attaches an existing file for the missing format even when the other format is already tracked.

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -397,6 +397,7 @@ func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	oldStatus := book.Status
+	oldMediaType := book.MediaType
 
 	// Note: file_path is deliberately NOT accepted here. It's set by the
 	// importer once a grab lands, and letting clients write it arbitrarily
@@ -443,18 +444,27 @@ func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
 		book.Narrator = *req.Narrator
 	}
 
+	// A media-type change shifts the wanted↔imported boundary: switching an
+	// audiobook-only book to 'both' must flip it back to 'wanted' so the missing
+	// ebook is grabbed (#1148). This mirrors the bulk media-type path
+	// (reevaluateBookStatus in bulk.go). Skip it when the caller set status
+	// explicitly in the same request — their choice wins.
+	if req.MediaType != nil && book.MediaType != oldMediaType && req.Status == nil {
+		reevaluateBookStatus(book)
+	}
+
 	if err := h.books.Update(r.Context(), book); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
 
 	// Fire an immediate indexer search when a book transitions into wanted
-	// status (e.g. "Delete file" flips imported → wanted, or a manual status
-	// edit). Gate on searcher to keep tests that don't wire it nil-safe.
-	// Detach the request context so the search outlives the HTTP response
-	// but keeps any request-scoped values.
-	if h.searcher != nil && req.Status != nil &&
-		*req.Status == models.BookStatusWanted && oldStatus != models.BookStatusWanted {
+	// status (e.g. "Delete file" flips imported → wanted, a manual status edit,
+	// or a media-type change that exposes a missing format — #1148). Gate on
+	// searcher to keep tests that don't wire it nil-safe. Detach the request
+	// context so the search outlives the HTTP response but keeps any
+	// request-scoped values.
+	if h.searcher != nil && book.Status == models.BookStatusWanted && oldStatus != models.BookStatusWanted {
 		b := *book
 		bgCtx := h.bgCtx()
 		// Respect the global auto-grab kill-switch.

--- a/internal/api/books_test.go
+++ b/internal/api/books_test.go
@@ -834,6 +834,54 @@ func TestBookUpdate_NoSearchWhenAlreadyWanted(t *testing.T) {
 	searcher.assertNoCall(t, 50*time.Millisecond)
 }
 
+// TestBookUpdate_MediaTypeChangeReevaluatesStatus covers #1148: promoting an
+// imported audiobook-only book to media_type=both must flip it back to wanted
+// (the ebook is now monitored but absent) and fire a search for the missing
+// format — matching the bulk media-type path.
+func TestBookUpdate_MediaTypeChangeReevaluatesStatus(t *testing.T) {
+	searcher := newMockBookSearcher()
+	h, books, author, ctx := bookFixtureWithSearcher(t, searcher)
+
+	book := &models.Book{
+		ForeignID: "B1148", AuthorID: author.ID, Title: "Dual", SortTitle: "dual",
+		Status: models.BookStatusWanted, MediaType: models.MediaTypeAudiobook,
+		Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	// Attach the audiobook so the book is fully imported as audiobook-only.
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, "/audiobooks/dual.m4b"); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := books.GetByID(ctx, book.ID); got == nil || got.Status != models.BookStatusImported {
+		t.Fatalf("precondition: expected imported audiobook, got %+v", got)
+	}
+
+	// Promote to dual-format; status must NOT be sent so the handler re-evaluates.
+	body := bytes.NewBufferString(`{"mediaType":"both"}`)
+	req := withURLParam(httptest.NewRequest(http.MethodPut, "/api/v1/book/"+strconv.FormatInt(book.ID, 10), body), "id", strconv.FormatInt(book.ID, 10))
+	rec := httptest.NewRecorder()
+	h.Update(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got, err := books.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.BookStatusWanted {
+		t.Errorf("status should flip to wanted (ebook missing), got %q", got.Status)
+	}
+	if got.MediaType != models.MediaTypeBoth {
+		t.Errorf("mediaType should be both, got %q", got.MediaType)
+	}
+	if call := searcher.waitForCall(t, time.Second); call.ID != book.ID {
+		t.Errorf("searcher called with wrong book id: got %d, want %d", call.ID, book.ID)
+	}
+}
+
 // staticRootLister is a RootLister stub that returns a fixed set of root
 // folder paths without touching a database. Used by the path-containment
 // tests so they don't have to wire a real RootFolderRepo.

--- a/internal/decision/decision.go
+++ b/internal/decision/decision.go
@@ -26,6 +26,7 @@ type Release struct {
 	Protocol    string // "usenet" | "torrent"
 	Language    string // ISO 639-1 or empty
 	Format      string // epub, pdf, m4b, … (parsed from title)
+	MediaType   string // "ebook" | "audiobook" | "" — set for dual-format book searches
 	CustomScore int    // cumulative custom-format score
 }
 
@@ -99,6 +100,7 @@ func ReleaseFromSearchResult(sr newznab.SearchResult) Release {
 		Protocol:    sr.Protocol,
 		Language:    sr.Language,
 		Format:      indexer.ParseRelease(sr.Title).Format,
+		MediaType:   sr.MediaType,
 	}
 }
 

--- a/internal/decision/decision_test.go
+++ b/internal/decision/decision_test.go
@@ -256,6 +256,58 @@ func TestAlreadyImportedSpec_HasFile(t *testing.T) {
 	}
 }
 
+// withMediaType tags a release with the per-format media type the dual-format
+// search assigns to each result.
+func withMediaType(mt string) func(*decision.Release) {
+	return func(r *decision.Release) { r.MediaType = mt }
+}
+
+// TestAlreadyImportedSpec_DualFormat covers #1148: a media_type=both book with
+// only the audiobook on disk must still allow ebook releases. The check is
+// per-format via the release's MediaType, not the legacy whole-book FilePath.
+func TestAlreadyImportedSpec_DualFormat(t *testing.T) {
+	s := decision.AlreadyImportedSpec{}
+	// Audiobook imported, ebook missing. FilePath is the legacy column the old
+	// code rejected on; it points at the audiobook path here.
+	book := models.Book{
+		MediaType:         models.MediaTypeBoth,
+		AudiobookFilePath: "/audiobooks/test",
+		FilePath:          "/audiobooks/test",
+	}
+
+	if ok, reason := s.IsSatisfiedBy(release(withMediaType(models.MediaTypeEbook)), book); !ok {
+		t.Errorf("ebook release must pass when only the audiobook is imported, got reject: %q", reason)
+	}
+	if ok, _ := s.IsSatisfiedBy(release(withMediaType(models.MediaTypeAudiobook)), book); ok {
+		t.Error("audiobook release must be rejected when the audiobook is already imported")
+	}
+
+	// Mirror case: ebook imported, audiobook missing.
+	book = models.Book{
+		MediaType:     models.MediaTypeBoth,
+		EbookFilePath: "/books/test.epub",
+		FilePath:      "/books/test.epub",
+	}
+	if ok, _ := s.IsSatisfiedBy(release(withMediaType(models.MediaTypeEbook)), book); ok {
+		t.Error("ebook release must be rejected when the ebook is already imported")
+	}
+	if ok, reason := s.IsSatisfiedBy(release(withMediaType(models.MediaTypeAudiobook)), book); !ok {
+		t.Errorf("audiobook release must pass when only the ebook is imported, got reject: %q", reason)
+	}
+}
+
+// TestAlreadyImportedSpec_UntaggedFallsBackToFilePath confirms single-format
+// searches (no MediaType on the result) keep the legacy whole-book behavior.
+func TestAlreadyImportedSpec_UntaggedFallsBackToFilePath(t *testing.T) {
+	s := decision.AlreadyImportedSpec{}
+	if ok, _ := s.IsSatisfiedBy(release(), bookWithFile()); ok {
+		t.Error("untagged release on a book with FilePath must still reject")
+	}
+	if ok, _ := s.IsSatisfiedBy(release(), emptyBook()); !ok {
+		t.Error("untagged release on a book with no file must pass")
+	}
+}
+
 // --- SizeLimitSpec ---
 
 func TestSizeLimitSpec_NoLimits(t *testing.T) {

--- a/internal/decision/specs.go
+++ b/internal/decision/specs.go
@@ -124,16 +124,33 @@ func (s *BlocklistedSpec) IsSatisfiedBy(r Release, _ models.Book) (bool, string)
 
 // --- AlreadyImported ---
 
-// AlreadyImportedSpec rejects releases for books that have already been
-// imported (file exists on disk). A book with a FilePath set is considered
-// imported.
+// AlreadyImportedSpec rejects releases for books whose corresponding format is
+// already on disk. The check is per-format: for a dual-format book
+// (media_type=both) that has only the audiobook imported, ebook releases must
+// stay grabbable and vice versa. The release's MediaType ("ebook"/"audiobook",
+// populated for dual-format searches) selects which path column to consult.
+// When MediaType is empty — single-format book searches don't tag results — it
+// falls back to the legacy whole-book FilePath check.
 type AlreadyImportedSpec struct{}
 
-func (AlreadyImportedSpec) IsSatisfiedBy(_ Release, book models.Book) (bool, string) {
-	if book.FilePath != "" {
-		return false, "book already imported"
+func (AlreadyImportedSpec) IsSatisfiedBy(r Release, book models.Book) (bool, string) {
+	switch r.MediaType {
+	case models.MediaTypeEbook:
+		if book.EbookFilePath != "" {
+			return false, "ebook already imported"
+		}
+		return true, ""
+	case models.MediaTypeAudiobook:
+		if book.AudiobookFilePath != "" {
+			return false, "audiobook already imported"
+		}
+		return true, ""
+	default:
+		if book.FilePath != "" {
+			return false, "book already imported"
+		}
+		return true, ""
 	}
-	return true, ""
 }
 
 // --- SizeLimit ---

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -2049,6 +2049,14 @@ func isReconcileCandidate(b *models.Book) bool {
 	if b.Status != models.BookStatusImported {
 		return false
 	}
+	// A dual-format book still missing a format on disk is a candidate even
+	// though its other format is present, so the scan can attach the missing
+	// edition (#1148). Without this, a 'both' book with the audiobook imported
+	// but the ebook absent would never reconcile the ebook, because the loop
+	// below short-circuits the moment any one path resolves.
+	if b.NeedsEbook() || b.NeedsAudiobook() {
+		return true
+	}
 	// Imported books reconcile only when no path we have on file actually
 	// resolves to a real file. A book row may carry up to three legacy
 	// path columns plus the modern book_files rows; the scanner already

--- a/internal/importer/scanner_extra_test.go
+++ b/internal/importer/scanner_extra_test.go
@@ -264,6 +264,34 @@ func TestIsReconcileCandidate(t *testing.T) {
 			t.Error("Imported with existing FilePath should not be a candidate")
 		}
 	})
+	t.Run("dual-format imported still missing a format is a candidate", func(t *testing.T) {
+		// #1148: a media_type=both book with the audiobook on disk but the ebook
+		// absent must reconcile so the scan can attach the existing ebook, even
+		// though the audiobook path resolves.
+		tmp := t.TempDir()
+		audio := filepath.Join(tmp, "book.m4b")
+		if err := os.WriteFile(audio, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		b := &models.Book{
+			Status:            models.BookStatusImported,
+			MediaType:         models.MediaTypeBoth,
+			AudiobookFilePath: audio,
+			FilePath:          audio,
+		}
+		if !isReconcileCandidate(b) {
+			t.Error("dual-format book missing the ebook should be a candidate")
+		}
+		// Once both formats are present, it is no longer a candidate.
+		ebook := filepath.Join(tmp, "book.epub")
+		if err := os.WriteFile(ebook, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		b.EbookFilePath = ebook
+		if isReconcileCandidate(b) {
+			t.Error("dual-format book with both formats on disk should not be a candidate")
+		}
+	})
 	t.Run("downloading and downloaded are not candidates", func(t *testing.T) {
 		for _, s := range []string{models.BookStatusDownloading, models.BookStatusDownloaded, models.BookStatusSkipped} {
 			if isReconcileCandidate(&models.Book{Status: s}) {


### PR DESCRIPTION
Fixes #1148.

## Problem

A book monitored as `media_type=both` treated "any file on disk" as "fully imported". Once one format landed (e.g. the audiobook), the missing format (the ebook) could never be grabbed. @magrhino diagnosed three independent format-blind code paths; I verified all three against `main`.

## Fixes

**1. Interactive search hid the missing format** — `decision.AlreadyImportedSpec` ignored its `Release` arg and rejected on the legacy whole-book `book.FilePath`, which for a `both` book is synced to whichever format is present. So every ebook release showed "book already imported". The spec is now per-format: it consults `EbookFilePath`/`AudiobookFilePath` keyed by the release's `MediaType` (already tagged on dual-format searches in `indexers.go`), and falls back to the legacy `FilePath` check for untagged single-format searches. Required adding `MediaType` to `decision.Release` and threading `sr.MediaType` through `ReleaseFromSearchResult`.

**2. Media-type change didn't re-evaluate status** — the bulk path calls `reevaluateBookStatus`; the single-book `PUT /book/{id}` handler didn't. Promoting a book to `both` now flips it back to `wanted` for the missing format (and fires a search), matching bulk. Skipped when the caller sets `status` explicitly in the same request.

**3. Library scan wouldn't reconcile the missing format** — `isReconcileCandidate` returned false for any imported book once a single path resolved on disk, so a `both` book with the audiobook present never reconciled an existing ebook. It now stays a candidate while `NeedsEbook()`/`NeedsAudiobook()` holds. The downstream `AddBookFile` is already per-format, so the missing edition attaches without clobbering the other (and `refreshBookStatus` already derives status from the per-format `Needs*` helpers).

The scheduler auto-grab path was already format-aware (`NeedsEbook`/`NeedsAudiobook`), so it's untouched — this brings interactive search, single-book edit, and library scan into line with it.

## Tests

- `decision`: ebook release passes when only the audiobook is imported (and the mirror case); untagged releases keep legacy `FilePath` behavior.
- `api`: promoting an imported audiobook-only book to `both` flips it to `wanted` and fires a search.
- `importer`: a `both` book missing the ebook is a reconcile candidate; not a candidate once both formats are on disk.

`go build/vet/test` green on `decision`/`api`/`importer`; `gofmt` clean; `golangci-lint` 0 issues. No frontend change (it just renders the API's rejection reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)