### PR TITLE
chore: sync main to v1.19.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.19.1] — 2026-06-15
+
+### Fixed
+
+- **OIDC provider config via API key** ([#1139](https://github.com/vavallee/bindery/pull/1139)) — `PUT /api/v1/auth/oidc/providers` returned `403 {"error":"admin role required"}` even with a valid `X-Api-Key` header, because the auth allowlist matched on path only and skipped the key check entirely. `GET` is intentionally public (login page needs the provider list); `PUT` now goes through normal auth so API-key-authenticated requests are correctly granted admin access.
+- **Dual-format books can grab the missing format** ([#1150](https://github.com/vavallee/bindery/pull/1150), [#1148](https://github.com/vavallee/bindery/issues/1148)) — for a book monitored as both ebook and audiobook, having one format on disk no longer blocks the other. Interactive search results for the missing format are no longer rejected with "book already imported", changing a book to "both" re-evaluates it back to wanted, and a library scan now attaches an existing file for the missing format even when the other format is already tracked.
+
 ## [v1.19.0] — 2026-06-13
 
 ### Added

--- a/changelog.d/1148-format-aware-import-decision.md
+++ b/changelog.d/1148-format-aware-import-decision.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Dual-format books can grab the missing format** (#1148) — for a book monitored as both ebook and audiobook, having one format on disk no longer blocks the other. Interactive search results for the missing format are no longer rejected with "book already imported", changing a book to "both" re-evaluates it back to wanted, and a library scan now attaches an existing file for the missing format even when the other format is already tracked.

--- a/changelog.d/oidc-providers-put-auth.md
+++ b/changelog.d/oidc-providers-put-auth.md
@@ -1,2 +1,0 @@
-### Fixed
-- **OIDC provider config via API key** — `PUT /api/v1/auth/oidc/providers` returned `403 {"error":"admin role required"}` even with a valid `X-Api-Key` header, because the auth allowlist matched on path only and skipped the key check entirely. `GET` is intentionally public (login page needs the provider list); `PUT` now goes through normal auth so API-key-authenticated requests are correctly granted admin access.

--- a/charts/bindery/Chart.yaml
+++ b/charts/bindery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bindery
 description: Automated book download manager for Usenet and Torrents
 type: application
-version: 0.9.5
-appVersion: "1.19.0"
+version: 0.9.6
+appVersion: "1.19.1"
 home: https://github.com/vavallee/bindery
 sources:
   - https://github.com/vavallee/bindery

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindery-web",
   "private": true,
-  "version": "1.19.0",
+  "version": "1.19.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bookkeeping forward-port. **v1.19.1** was cut as a true patch off the `v1.19.0` tag, cherry-picking only the two fixes (#1139 + #1150) and deliberately excluding the unreleased settings work (#1107, #1109) that sits on `main`.

This PR forward-ports the release bookkeeping to `main` so the next release cuts from a correct base:

- Add the `## [v1.19.1]` section to `CHANGELOG.md`.
- Remove the two `changelog.d` fragments consumed by 1.19.1 (otherwise they'd re-appear in the next release notes).
- Bump `charts/bindery/Chart.yaml` version `0.9.5 → 0.9.6`, appVersion `1.19.0 → 1.19.1`, and `web/package.json` to `1.19.1`.

**No code changes** — the two fixes are already on `main` (`0c3c0ee`, `5ed47f7`). The prod image tag in `values.yaml` is handled separately by the deploy bot's `auto/prod-deploy-1.19.1` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)