### PR TITLE
feat(series): link un-added series rows to their existing library book (#1123)

### DIFF
--- a/changelog.d/1123-series-missing-row-link.md
+++ b/changelog.d/1123-series-missing-row-link.md
@@ -1,0 +1,2 @@
+### Added
+- **Clickable un-added series rows** (#1123) — on the series page, an un-added Hardcover book that already exists in your library now links straight to its book page, matching the added rows. Rows with no library match keep the "add" button.

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -586,4 +586,110 @@ describe('SeriesPage', () => {
       position: '2',
     }))
   })
+
+  it('links a Hardcover missing row that maps to an existing library book', async () => {
+    const hardcoverLink = {
+      id: 1,
+      seriesId: 41,
+      hardcoverSeriesId: 'hc-series:42',
+      hardcoverProviderId: '42',
+      hardcoverTitle: 'The Stormlight Archive',
+      hardcoverAuthorName: 'Brandon Sanderson',
+      hardcoverBookCount: 2,
+      confidence: 1,
+      linkedBy: 'manual',
+      linkedAt: '2026-01-01T00:00:00Z',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    }
+    const series: Series = {
+      id: 41,
+      foreignSeriesId: 'series-41',
+      title: 'The Stormlight Archive',
+      description: '',
+      monitored: true,
+      books: [],
+      hardcoverLink,
+    }
+    vi.mocked(api.getSeriesHardcoverDiff).mockResolvedValue({
+      seriesId: 41,
+      link: hardcoverLink,
+      present: [],
+      missing: [
+        {
+          foreignBookId: 'hc:words-of-radiance',
+          providerId: '102',
+          title: 'Words of Radiance',
+          position: '2',
+          authorName: 'Brandon Sanderson',
+          localBookId: 555,
+        },
+      ],
+      localOnly: [],
+      uncertain: [],
+      presentCount: 0,
+      missingCount: 1,
+    })
+
+    renderSeriesPage([series])
+
+    fireEvent.click(await screen.findByRole('heading', { name: 'The Stormlight Archive' }))
+
+    const bookLink = await screen.findByRole('link', { name: /Words of Radiance/ })
+    expect(bookLink).toHaveAttribute('href', '/book/555')
+    const row = within(bookLink).queryByRole('button', { name: 'add' })
+    expect(row).not.toBeInTheDocument()
+  })
+
+  it('keeps a Hardcover missing row without a library match non-clickable', async () => {
+    const hardcoverLink = {
+      id: 1,
+      seriesId: 42,
+      hardcoverSeriesId: 'hc-series:42',
+      hardcoverProviderId: '42',
+      hardcoverTitle: 'The Stormlight Archive',
+      hardcoverAuthorName: 'Brandon Sanderson',
+      hardcoverBookCount: 2,
+      confidence: 1,
+      linkedBy: 'manual',
+      linkedAt: '2026-01-01T00:00:00Z',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    }
+    const series: Series = {
+      id: 42,
+      foreignSeriesId: 'series-42',
+      title: 'The Stormlight Archive',
+      description: '',
+      monitored: true,
+      books: [],
+      hardcoverLink,
+    }
+    vi.mocked(api.getSeriesHardcoverDiff).mockResolvedValue({
+      seriesId: 42,
+      link: hardcoverLink,
+      present: [],
+      missing: [
+        {
+          foreignBookId: 'hc:rhythm-of-war',
+          providerId: '103',
+          title: 'Rhythm of War',
+          position: '4',
+          authorName: 'Brandon Sanderson',
+        },
+      ],
+      localOnly: [],
+      uncertain: [],
+      presentCount: 0,
+      missingCount: 1,
+    })
+
+    renderSeriesPage([series])
+
+    fireEvent.click(await screen.findByRole('heading', { name: 'The Stormlight Archive' }))
+
+    expect(await screen.findByText('Rhythm of War')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /Rhythm of War/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'add' })).toBeInTheDocument()
+  })
 })

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -400,30 +400,51 @@ export default function SeriesPage() {
                     )}
                     {diff && diff.missing.length > 0 && (
                       <div className="px-4 pb-4 space-y-2">
-                        {diff.missing.slice(0, 8).map(book => (
-                          <div key={`${book.foreignBookId}-${book.position}`} className="flex items-center gap-3 p-3 rounded-md bg-slate-200/50 dark:bg-zinc-800/50">
-                            <span className="text-xs text-slate-600 dark:text-zinc-500 w-10 flex-shrink-0 font-mono">
-                              #{book.position || '?'}
-                            </span>
-                            {book.imageUrl ? (
-                              <img src={book.imageUrl} alt={book.title} className="w-8 h-10 object-cover rounded flex-shrink-0" />
-                            ) : (
-                              <div className="w-8 h-10 bg-slate-200 dark:bg-zinc-800 rounded flex-shrink-0" />
-                            )}
-                            <div className="min-w-0">
-                              <p className="text-sm font-medium truncate">{book.title}</p>
-                              {book.authorName && <p className="text-xs text-slate-600 dark:text-zinc-500 truncate">{book.authorName}</p>}
+                        {diff.missing.slice(0, 8).map(book => {
+                          const rowClass = 'flex items-center gap-3 p-3 rounded-md bg-slate-200/50 dark:bg-zinc-800/50'
+                          const rowInner = (
+                            <>
+                              <span className="text-xs text-slate-600 dark:text-zinc-500 w-10 flex-shrink-0 font-mono">
+                                #{book.position || '?'}
+                              </span>
+                              {book.imageUrl ? (
+                                <img src={book.imageUrl} alt={book.title} className="w-8 h-10 object-cover rounded flex-shrink-0" />
+                              ) : (
+                                <div className="w-8 h-10 bg-slate-200 dark:bg-zinc-800 rounded flex-shrink-0" />
+                              )}
+                              <div className="min-w-0">
+                                <p className="text-sm font-medium truncate">{book.title}</p>
+                                {book.authorName && <p className="text-xs text-slate-600 dark:text-zinc-500 truncate">{book.authorName}</p>}
+                              </div>
+                            </>
+                          )
+                          // When the missing catalog book maps to an existing library book,
+                          // link the row to that book page instead of showing the "add" button.
+                          if (book.localBookId != null) {
+                            return (
+                              <Link
+                                key={`${book.foreignBookId}-${book.position}`}
+                                to={`/book/${book.localBookId}`}
+                                className={`${rowClass} hover:bg-slate-300/50 dark:hover:bg-zinc-700/50 transition-colors`}
+                              >
+                                {rowInner}
+                              </Link>
+                            )
+                          }
+                          return (
+                            <div key={`${book.foreignBookId}-${book.position}`} className={rowClass}>
+                              {rowInner}
+                              <button
+                                onClick={() => fillGaps(series, book)}
+                                disabled={filling === series.id}
+                                className="ml-auto text-xs px-2.5 py-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded font-medium flex-shrink-0"
+                                title="Add this missing Hardcover book and search indexers"
+                              >
+                                {filling === series.id ? '...' : 'add'}
+                              </button>
                             </div>
-                            <button
-                              onClick={() => fillGaps(series, book)}
-                              disabled={filling === series.id}
-                              className="ml-auto text-xs px-2.5 py-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded font-medium flex-shrink-0"
-                              title="Add this missing Hardcover book and search indexers"
-                            >
-                              {filling === series.id ? '...' : 'add'}
-                            </button>
-                          </div>
-                        ))}
+                          )
+                        })}
                         {diff.missing.length > 8 && (
                           <p className="text-xs text-slate-600 dark:text-zinc-500 px-1">{diff.missing.length - 8} more missing books</p>
                         )}


### PR DESCRIPTION
Closes #1123

## Summary

On the series page, books already in the library render as clickable `<Link to=/book/:id>`, but un-added rows from the Hardcover diff rendered as plain non-clickable `<div>`s. The diff DTO `seriesHardcoverDiffBook` already carries `LocalBookID *int64` (serialized as `localBookId`), non-nil when the catalog book maps to an existing library row.

This change: when a missing-row's `localBookId` is non-nil, render it as a `<Link to=/book/${localBookId}>` matching the added-book row styling, and drop the redundant "add" button (the book is already in the library). Rows with no library match (`localBookId` nil) keep the existing non-clickable display plus the "add" button.

Scope: frontend only (`web/src/pages/SeriesPage.tsx`). No backend change — the TS type and Go DTO already expose the field.

## Tests

Added two tests to `SeriesPage.test.tsx`:
- missing row WITH `localBookId` renders a link to `/book/:id` and shows no "add" button
- missing row WITHOUT `localBookId` stays non-clickable and keeps the "add" button

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass (0 errors; only pre-existing warnings in unrelated files)
- `npm test` — pass (336/336)
- `npm run build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)