### PR TITLE
feat(search): link each interactive search result to its indexer detail page (#1122)

### DIFF
--- a/changelog.d/1122-result-detail-link.md
+++ b/changelog.d/1122-result-detail-link.md
@@ -1,0 +1,2 @@
+### Added
+- **Link to the indexer's release page from search results** (#1122) — each interactive search result (book page and Wanted page) now shows a small "↗ indexer" link, opening the indexer's human-readable detail/info page in a new tab so you can inspect a release before grabbing. The link appears only when the indexer supplies a usable URL.

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -151,6 +151,44 @@ func (c *Client) signDownloadURL(raw string) string {
 	return u.String()
 }
 
+// detailURL extracts the indexer's human-readable detail/release page URL for a
+// feed item, if one is present. It prefers, in order: the <comments> element,
+// then a <guid> carrying isPermaLink="true", then the <link> element — using the
+// first that is an absolute http(s) URL distinct from the enclosure download URL.
+//
+// It deliberately never returns the enclosure/download URL: <link> is also used
+// as a download fallback by some indexers, so any candidate matching the
+// enclosure URL is skipped. The result is a user-facing browser target and is
+// not signed with the apikey.
+func detailURL(item rssItem) string {
+	download := item.Enclosure.URL
+
+	candidates := []string{item.Comments}
+	if strings.EqualFold(strings.TrimSpace(item.GUID.IsPermaLink), "true") {
+		candidates = append(candidates, item.GUID.Value)
+	}
+	candidates = append(candidates, item.Link)
+
+	for _, raw := range candidates {
+		raw = strings.TrimSpace(raw)
+		if raw == "" || raw == download {
+			continue
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			continue
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			continue
+		}
+		if u.Host == "" {
+			continue
+		}
+		return raw
+	}
+	return ""
+}
+
 // Caps fetches the indexer capabilities.
 func (c *Client) Caps(ctx context.Context) (*capsResponse, error) {
 	u, err := c.buildURL("caps", map[string]string{})
@@ -507,6 +545,8 @@ func (c *Client) parseResults(items []rssItem) []SearchResult {
 		if r.NZBURL == "" {
 			r.NZBURL = c.signDownloadURL(item.Link)
 		}
+
+		r.InfoURL = detailURL(item)
 
 		results = append(results, r)
 	}

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -531,6 +531,134 @@ func TestParseResults_UsesLinkWhenEnclosureMissing(t *testing.T) {
 	}
 }
 
+// TestDetailURL covers the ordered-fallback extraction of the human-readable
+// indexer detail page from a feed item: prefer <comments>, then a
+// <guid isPermaLink="true">, then <link>, accepting only absolute http(s) URLs
+// and never the enclosure download URL.
+func TestDetailURL(t *testing.T) {
+	tests := []struct {
+		name string
+		item rssItem
+		want string
+	}{
+		{
+			name: "comments preferred over guid and link",
+			item: rssItem{
+				Comments:  "https://indexer.example/details/1",
+				GUID:      rssGUID{IsPermaLink: "true", Value: "https://indexer.example/guid/1"},
+				Link:      "https://indexer.example/page/1",
+				Enclosure: rssEnclosure{URL: "https://indexer.example/getnzb/1.nzb"},
+			},
+			want: "https://indexer.example/details/1",
+		},
+		{
+			name: "guid permalink used when no comments",
+			item: rssItem{
+				GUID:      rssGUID{IsPermaLink: "true", Value: "https://indexer.example/guid/2"},
+				Link:      "https://indexer.example/getnzb/2.nzb",
+				Enclosure: rssEnclosure{URL: "https://indexer.example/getnzb/2.nzb"},
+			},
+			want: "https://indexer.example/guid/2",
+		},
+		{
+			name: "guid ignored when not a permalink",
+			item: rssItem{
+				GUID:      rssGUID{IsPermaLink: "false", Value: "opaque-id-3"},
+				Link:      "https://indexer.example/page/3",
+				Enclosure: rssEnclosure{URL: "https://indexer.example/getnzb/3.nzb"},
+			},
+			want: "https://indexer.example/page/3",
+		},
+		{
+			name: "torznab magnet enclosure with comments page (torrent shape)",
+			item: rssItem{
+				Comments:  "https://tracker.example/torrent/4",
+				GUID:      rssGUID{Value: "magnet:?xt=urn:btih:abcd"},
+				Link:      "https://tracker.example/download/4.torrent",
+				Enclosure: rssEnclosure{URL: "magnet:?xt=urn:btih:abcd", Type: "application/x-bittorrent"},
+			},
+			want: "https://tracker.example/torrent/4",
+		},
+		{
+			name: "no detail URL when only a download URL is present",
+			item: rssItem{
+				GUID:      rssGUID{IsPermaLink: "false", Value: "opaque-id-5"},
+				Link:      "https://indexer.example/getnzb/5.nzb",
+				Enclosure: rssEnclosure{URL: "https://indexer.example/getnzb/5.nzb"},
+			},
+			want: "",
+		},
+		{
+			name: "link equal to enclosure is skipped",
+			item: rssItem{
+				Link:      "https://indexer.example/getnzb/6.nzb",
+				Enclosure: rssEnclosure{URL: "https://indexer.example/getnzb/6.nzb"},
+			},
+			want: "",
+		},
+		{
+			name: "non-http guid permalink rejected, falls through to link",
+			item: rssItem{
+				GUID: rssGUID{IsPermaLink: "true", Value: "ftp://indexer.example/x"},
+				Link: "https://indexer.example/page/7",
+			},
+			want: "https://indexer.example/page/7",
+		},
+		{
+			name: "empty item yields no detail URL",
+			item: rssItem{},
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detailURL(tc.item); got != tc.want {
+				t.Errorf("detailURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseResults_PopulatesInfoURL verifies that parseResults threads the
+// extracted detail URL onto SearchResult.InfoURL (and leaves it empty when the
+// feed provides only a download URL), end-to-end through a canned feed.
+func TestParseResults_PopulatesInfoURL(t *testing.T) {
+	const feed = `<?xml version="1.0"?>
+<rss><channel>
+  <item>
+    <title>With detail page</title>
+    <guid isPermaLink="false">opaque-1</guid>
+    <comments>https://indexer.example/details/1</comments>
+    <enclosure url="https://indexer.example/getnzb/1.nzb" length="1000"/>
+  </item>
+  <item>
+    <title>Download only</title>
+    <guid isPermaLink="false">opaque-2</guid>
+    <enclosure url="https://indexer.example/getnzb/2.nzb" length="2000"/>
+  </item>
+</channel></rss>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		w.Write([]byte(feed))
+	}))
+	defer srv.Close()
+
+	c := testNew(srv.URL, "testkey")
+	results, err := c.Search(context.Background(), "q", nil)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].InfoURL != "https://indexer.example/details/1" {
+		t.Errorf("expected InfoURL on first result, got %q", results[0].InfoURL)
+	}
+	if results[1].InfoURL != "" {
+		t.Errorf("expected empty InfoURL on download-only result, got %q", results[1].InfoURL)
+	}
+}
+
 // TestGetXML_SurfacesNon200 verifies the low-level getXML helper turns
 // HTTP failures into errors that include the status code, rather than
 // attempting to parse the body.

--- a/internal/indexer/newznab/types.go
+++ b/internal/indexer/newznab/types.go
@@ -86,6 +86,7 @@ type rssItem struct {
 	Title     string       `xml:"title"`
 	GUID      rssGUID      `xml:"guid"`
 	Link      string       `xml:"link"`
+	Comments  string       `xml:"comments"`
 	PubDate   string       `xml:"pubDate"`
 	Category  string       `xml:"category"`
 	Enclosure rssEnclosure `xml:"enclosure"`
@@ -143,6 +144,7 @@ type SearchResult struct {
 	Size            int64  `json:"size"`
 	PubDate         string `json:"pubDate"`
 	NZBURL          string `json:"nzbUrl"`
+	InfoURL         string `json:"infoUrl,omitempty"` // human-readable indexer detail/release page (from comments, guid-permalink, or link); never the download URL
 	Category        string `json:"category"`
 	Grabs           int    `json:"grabs"`
 	Author          string `json:"author"`

--- a/web/src/api/books.ts
+++ b/web/src/api/books.ts
@@ -44,6 +44,7 @@ export interface SearchResult {
   title: string
   size: number
   nzbUrl: string
+  infoUrl?: string // human-readable indexer detail/release page (open in new tab); absent when the indexer provides none
   grabs: number
   pubDate: string
   protocol: string   // "usenet" or "torrent"

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -272,6 +272,27 @@ describe('SearchResultsSection — single-format book', () => {
     )
     expect(container.querySelectorAll('button').length).toBe(20)
   })
+
+  it('renders an indexer detail link when infoUrl is present', () => {
+    const results = [
+      makeResult({ guid: 'r1', title: 'Linked', infoUrl: 'https://indexer.example/details/1' }),
+    ]
+    render(
+      <SearchResultsSection results={results} bookMediaType="ebook" grabbing={null} onGrab={noop} />,
+    )
+    const link = screen.getByRole('link', { name: /indexer/ })
+    expect(link).toHaveAttribute('href', 'https://indexer.example/details/1')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders no detail link when infoUrl is absent', () => {
+    const results = [makeResult({ guid: 'r1', title: 'Unlinked' })]
+    render(
+      <SearchResultsSection results={results} bookMediaType="ebook" grabbing={null} onGrab={noop} />,
+    )
+    expect(screen.queryByRole('link', { name: /indexer/ })).toBeNull()
+  })
 })
 
 describe('BookDetailPage — header & metadata', () => {

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -89,6 +89,20 @@ export function SearchResultsSection({
         </div>
         <span className="text-slate-500 dark:text-zinc-500 truncate block">
           {r.indexerName} · {formatSize(r.size)} · {r.grabs} grabs
+          {r.infoUrl && (
+            <>
+              {' · '}
+              <a
+                href={r.infoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={e => e.stopPropagation()}
+                className="text-sky-600 dark:text-sky-400 hover:underline"
+              >
+                ↗ indexer
+              </a>
+            </>
+          )}
           {r.rejection && <span className="ml-2 text-amber-600 dark:text-amber-400">· {r.rejection}</span>}
         </span>
       </div>

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -349,6 +349,19 @@ export default function WantedPage() {
                           <span className="truncate block">{r.title}</span>
                           <span className="text-slate-600 dark:text-zinc-500 truncate block">
                             {r.indexerName} &middot; {formatSize(r.size)} &middot; {r.grabs} grabs
+                            {r.infoUrl && (
+                              <>
+                                {' '}&middot;{' '}
+                                <a
+                                  href={r.infoUrl}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-sky-600 dark:text-sky-400 hover:underline"
+                                >
+                                  ↗ indexer
+                                </a>
+                              </>
+                            )}
                             {r.language && (
                               <span className="ml-1.5 inline-block px-1 py-0 rounded bg-slate-300 dark:bg-zinc-700 text-[9px] font-medium uppercase tracking-wide">{r.language}</span>
                             )}


### PR DESCRIPTION
Closes #1122

## Summary
Interactive search results (book page + Wanted page) now offer a small "↗ indexer" link next to each result, opening the indexer's human-readable detail/release page in a new tab. The link is shown only when the indexer supplies a usable URL. Grab remains the row's primary action; the link is a distinct affordance, not a whole-row navigation.

## Feed fields used (priority order)
Detail URL is extracted from the Newznab/Torznab feed item in this order, taking the first absolute `http(s)` URL that is **not** the enclosure download URL:
1. `<comments>` (newly parsed)
2. `<guid>` when `isPermaLink="true"`
3. `<link>`

`nzbUrl` (the `.nzb`/`.torrent`/magnet download) is never used and the detail URL is never signed with the apikey (it's a user-initiated browser navigation, no server fetch → no SSRF).

## Changes
- Backend: `SearchResult.InfoURL` field; parse `<comments>`; `detailURL()` helper + wiring in `parseResults`. Flows through the API `searchDecision` automatically (it embeds `newznab.SearchResult`), no DTO change needed.
- Frontend: `infoUrl?` on the TS `SearchResult`; conditional `<a target="_blank" rel="noopener noreferrer">` link in `SearchResultsSection` (book page) and the Wanted page inline rows.

## Tests
- Backend: `TestDetailURL` (comments/guid-permalink/link priority, torrent magnet shape, download-only → empty, non-http rejection) + `TestParseResults_PopulatesInfoURL` end-to-end.
- Frontend: link rendered when `infoUrl` present (asserts href/target/rel), absent otherwise.

## Verification
- `go build ./...` ✓ · `go vet ./internal/indexer/... ./internal/api/` ✓ · `go test ./internal/indexer/... ./internal/api/` ✓
- `npm run typecheck` ✓ · `npm run lint` (0 errors, pre-existing warnings only) ✓ · `npm test` (336 passed) ✓ · `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)