### PR TITLE
feat(series): choose ebook/audiobook/both when adding from the series page (#1124)

### DIFF
--- a/changelog.d/1124-series-add-format.md
+++ b/changelog.d/1124-series-add-format.md
@@ -1,0 +1,2 @@
+### Added
+- **Choose format when adding from a series** (#1124) — the series page "add" and "add all" actions now have an ebook / audiobook / both selector, so missing books are created (and searched) as the chosen format instead of always defaulting to ebook.

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -350,12 +350,34 @@ type seriesFillRequest struct {
 	ForeignBookID string `json:"foreignBookId"`
 	ProviderID    string `json:"providerId"`
 	Position      string `json:"position"`
+	MediaType     string `json:"mediaType"`
 }
 
 func (r *seriesFillRequest) normalize() {
 	r.ForeignBookID = strings.TrimSpace(r.ForeignBookID)
 	r.ProviderID = strings.TrimSpace(r.ProviderID)
 	r.Position = strings.TrimSpace(r.Position)
+	r.MediaType = strings.TrimSpace(r.MediaType)
+}
+
+// mediaType resolves the requested media type, defaulting to ebook to preserve
+// the historical behaviour when the caller omits it.
+func (r seriesFillRequest) mediaType() string {
+	if r.MediaType == "" {
+		return models.MediaTypeEbook
+	}
+	return r.MediaType
+}
+
+// validMediaType reports whether the requested media type is one of the
+// accepted values. Mirrors the PUT book handler validation in books.go.
+func (r seriesFillRequest) validMediaType() bool {
+	switch r.mediaType() {
+	case models.MediaTypeEbook, models.MediaTypeAudiobook, models.MediaTypeBoth:
+		return true
+	default:
+		return false
+	}
 }
 
 func (r seriesFillRequest) hasBookSelector() bool {
@@ -402,6 +424,11 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 	}
 	body.normalize()
 
+	if !body.validMediaType() {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "mediaType must be 'ebook', 'audiobook', or 'both'"})
+		return
+	}
+
 	if body.hasBookSelector() {
 		if !h.requireEnhancedHardcoverAPI(w, r) {
 			return
@@ -441,7 +468,7 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if h.enhancedHardcoverEnabled(r.Context()) {
-		if err := h.createMissingHardcoverBooks(r.Context(), id); err != nil {
+		if err := h.createMissingHardcoverBooks(r.Context(), id, body.mediaType()); err != nil {
 			if !errors.Is(err, errSeriesMetadataProvider) {
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 				return
@@ -1135,7 +1162,7 @@ func localDiffBook(local models.SeriesBook) seriesHardcoverDiffBook {
 	return item
 }
 
-func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesID int64) error {
+func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesID int64, mediaType string) error {
 	if !h.enhancedHardcoverEnabled(ctx) {
 		return nil
 	}
@@ -1162,7 +1189,7 @@ func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesI
 		if !ok {
 			continue
 		}
-		if _, err := h.ensureHardcoverCatalogBook(ctx, series, catalog.AuthorName, catalogBook); err != nil {
+		if _, err := h.ensureHardcoverCatalogBook(ctx, series, catalog.AuthorName, catalogBook, mediaType); err != nil {
 			return err
 		}
 	}
@@ -1202,7 +1229,7 @@ func (h *SeriesHandler) createMissingHardcoverBook(ctx context.Context, seriesID
 		if !ok {
 			return nil, errSeriesCatalogBookNotFound
 		}
-		return h.ensureHardcoverCatalogBook(ctx, series, catalog.AuthorName, catalogBook)
+		return h.ensureHardcoverCatalogBook(ctx, series, catalog.AuthorName, catalogBook, selector.mediaType())
 	}
 	return nil, errSeriesCatalogBookNotFound
 }
@@ -1219,7 +1246,7 @@ func findCatalogBook(books []metadata.SeriesCatalogBook, foreignID, position str
 	return metadata.SeriesCatalogBook{}, false
 }
 
-func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *models.Series, fallbackAuthor string, catalogBook metadata.SeriesCatalogBook) (*models.Book, error) {
+func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *models.Series, fallbackAuthor string, catalogBook metadata.SeriesCatalogBook, mediaType string) (*models.Book, error) {
 	if series == nil {
 		return nil, errSeriesNotFound
 	}
@@ -1302,7 +1329,9 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *
 	book.Status = models.BookStatusWanted
 	book.Monitored = true
 	book.AnyEditionOK = true
-	book.MediaType = firstNonEmpty(book.MediaType, models.MediaTypeEbook)
+	// The caller's requested media type wins over the catalog default; it has
+	// already been validated and defaults to ebook when omitted.
+	book.MediaType = firstNonEmpty(mediaType, models.MediaTypeEbook)
 	book.Language = firstNonEmpty(book.Language, "eng")
 	book.MetadataProvider = firstNonEmpty(book.MetadataProvider, "hardcover")
 	if book.Genres == nil {

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -1126,6 +1126,15 @@ func TestSeriesFillEndpointErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("invalid media type", func(t *testing.T) {
+		h, _, _, _ := seriesFixture(t)
+		rec := httptest.NewRecorder()
+		h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", bytes.NewBufferString(`{"mediaType":"hologram"}`)), "id", "1"))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
 	t.Run("selector feature disabled", func(t *testing.T) {
 		provider := &stubSeriesProvider{}
 		h, _, _, _, _ := seriesFixtureWithProviderAndSettings(t, provider, nil, false)
@@ -1341,6 +1350,63 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 	}
 	if len(books) != 1 || books[0].ForeignID != "hc:the-way-of-kings" {
 		t.Fatalf("expected created book linked to series, got %+v", books)
+	}
+}
+
+// TestSeriesFillHonoursRequestedMediaType covers #1124: the per-book "add"
+// selector must create the missing Hardcover book with the chosen media type
+// rather than always defaulting to ebook.
+func TestSeriesFillHonoursRequestedMediaType(t *testing.T) {
+	cases := []struct {
+		name      string
+		mediaType string
+	}{
+		{name: "audiobook", mediaType: models.MediaTypeAudiobook},
+		{name: "both", mediaType: models.MediaTypeBoth},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			catalog := stormlightCatalog()
+			searcher := newMockBookSearcher()
+			h, seriesRepo, _, bookRepo := seriesFixtureWithProvider(t, &stubSeriesProvider{
+				catalogs: map[string]*metadata.SeriesCatalog{catalog.ForeignID: catalog},
+			}, searcher)
+			series := &models.Series{ForeignID: "ol-series:stormlight", Title: "The Stormlight Archive"}
+			if err := seriesRepo.Create(context.Background(), series); err != nil {
+				t.Fatal(err)
+			}
+			if err := seriesRepo.UpsertHardcoverLink(context.Background(), &models.SeriesHardcoverLink{
+				SeriesID:            series.ID,
+				HardcoverSeriesID:   catalog.ForeignID,
+				HardcoverProviderID: catalog.ProviderID,
+				HardcoverTitle:      catalog.Title,
+				HardcoverAuthorName: catalog.AuthorName,
+				HardcoverBookCount:  catalog.BookCount,
+				Confidence:          1,
+				LinkedBy:            "manual",
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			rec := httptest.NewRecorder()
+			body := bytes.NewBufferString(`{"foreignBookId":"hc:the-way-of-kings","mediaType":"` + tc.mediaType + `"}`)
+			h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", body), "id", strconv.FormatInt(series.ID, 10)))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			searcher.waitForCall(t, time.Second)
+			created, err := bookRepo.GetByForeignID(context.Background(), "hc:the-way-of-kings")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if created == nil {
+				t.Fatal("expected Hardcover book to be created")
+				return
+			}
+			if created.MediaType != tc.mediaType {
+				t.Fatalf("created book mediaType = %q, want %q", created.MediaType, tc.mediaType)
+			}
+		})
 	}
 }
 

--- a/web/src/api/series.ts
+++ b/web/src/api/series.ts
@@ -1,5 +1,6 @@
 import { request } from './core'
 import type { Book } from './books'
+import type { MediaType } from './authors'
 
 export interface SeriesHardcoverLink {
   id: number
@@ -38,6 +39,7 @@ export interface SeriesFillBookRequest {
   foreignBookId?: string
   providerId?: string
   position?: string
+  mediaType?: MediaType
 }
 
 export interface SeriesHardcoverDiffBook {
@@ -97,6 +99,14 @@ export const seriesApi = {
     request<{ queued: number }>(`/series/${id}/fill`, {
       method: 'POST',
       ...(book ? { body: JSON.stringify(book) } : {}),
+    }),
+  // Fill every missing book at once, optionally targeting a media type. Unlike
+  // fillSeries(book), this carries no book selector — the backend expands the
+  // whole Hardcover catalog — so the media type travels in its own body.
+  fillSeriesAll: (id: number, mediaType?: MediaType) =>
+    request<{ queued: number }>(`/series/${id}/fill`, {
+      method: 'POST',
+      ...(mediaType ? { body: JSON.stringify({ mediaType }) } : {}),
     }),
   searchHardcoverSeries: (term: string, limit = 10) =>
     request<SeriesHardcoverSearchResult[]>(`/series/hardcover/search?term=${encodeURIComponent(term)}&limit=${limit}`),

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -24,6 +24,7 @@ vi.mock('../api/client', async importOriginal => {
       monitorSeries: vi.fn(),
       linkBookToSeries: vi.fn(),
       fillSeries: vi.fn(),
+      fillSeriesAll: vi.fn(),
       autoLinkSeriesHardcover: vi.fn(),
       getSeriesHardcoverLink: vi.fn(),
       searchHardcoverSeries: vi.fn(),
@@ -584,7 +585,80 @@ describe('SeriesPage', () => {
       foreignBookId: 'hc:words-of-radiance',
       providerId: '102',
       position: '2',
+      mediaType: 'ebook',
     }))
+  })
+
+  it('sends the chosen media type when adding a missing Hardcover book (#1124)', async () => {
+    const hardcoverLink = {
+      id: 1,
+      seriesId: 40,
+      hardcoverSeriesId: 'hc-series:42',
+      hardcoverProviderId: '42',
+      hardcoverTitle: 'The Stormlight Archive',
+      hardcoverAuthorName: 'Brandon Sanderson',
+      hardcoverBookCount: 2,
+      confidence: 1,
+      linkedBy: 'manual',
+      linkedAt: '2026-01-01T00:00:00Z',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    }
+    const series: Series = {
+      id: 40,
+      foreignSeriesId: 'series-40',
+      title: 'The Stormlight Archive',
+      description: '',
+      monitored: true,
+      books: [],
+      hardcoverLink,
+    }
+    vi.mocked(api.getSeriesHardcoverDiff).mockResolvedValue({
+      seriesId: 40,
+      link: hardcoverLink,
+      present: [],
+      missing: [
+        {
+          foreignBookId: 'hc:words-of-radiance',
+          providerId: '102',
+          title: 'Words of Radiance',
+          position: '2',
+          authorName: 'Brandon Sanderson',
+        },
+      ],
+      localOnly: [],
+      uncertain: [],
+      presentCount: 0,
+      missingCount: 1,
+    })
+    vi.mocked(api.fillSeries).mockResolvedValue({ queued: 1 })
+    vi.mocked(api.fillSeriesAll).mockResolvedValue({ queued: 1 })
+
+    renderSeriesPage([series])
+
+    fireEvent.click(await screen.findByRole('heading', { name: 'The Stormlight Archive' }))
+
+    expect(await screen.findByRole('button', { name: 'add all' })).toBeInTheDocument()
+
+    // Pick "audiobook" in the format selector, then add the single missing book.
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Format to add' }), {
+      target: { value: 'audiobook' },
+    })
+    const rowTitle = await screen.findByText('Words of Radiance')
+    const row = rowTitle.parentElement?.parentElement
+    if (!row) throw new Error('expected Hardcover missing book row')
+    fireEvent.click(within(row).getByRole('button', { name: 'add' }))
+
+    await waitFor(() => expect(api.fillSeries).toHaveBeenCalledWith(40, {
+      foreignBookId: 'hc:words-of-radiance',
+      providerId: '102',
+      position: '2',
+      mediaType: 'audiobook',
+    }))
+
+    // "add all" carries the same chosen format through the catalog-expansion path.
+    fireEvent.click(screen.getByRole('button', { name: 'add all' }))
+    await waitFor(() => expect(api.fillSeriesAll).toHaveBeenCalledWith(40, 'audiobook'))
   })
 
   it('links a Hardcover missing row that maps to an existing library book', async () => {

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { api, Series, SeriesFillBookRequest, SeriesHardcoverDiff, SeriesHardcoverDiffBook, SeriesHardcoverLink, SeriesHardcoverSearchResult, SystemStatus } from '../api/client'
+import { api, MediaType, Series, SeriesHardcoverDiff, SeriesHardcoverDiffBook, SeriesHardcoverLink, SeriesHardcoverSearchResult, SystemStatus } from '../api/client'
 import AddSeriesBookModal from '../components/AddSeriesBookModal'
 import HardcoverSeriesLinkModal from '../components/HardcoverSeriesLinkModal'
 import SeriesNameModal from '../components/SeriesNameModal'
@@ -14,6 +14,9 @@ export default function SeriesPage() {
   const [expanded, setExpanded] = useState<number | null>(null)
   const [filling, setFilling] = useState<number | null>(null)
   const [fillResult, setFillResult] = useState<Record<number, string>>({})
+  // Format to target when adding missing Hardcover books, keyed by series id.
+  // Defaults to ebook to preserve the previous add behaviour.
+  const [fillMediaType, setFillMediaType] = useState<Record<number, MediaType>>({})
   const [linking, setLinking] = useState<number | null>(null)
   const [linkResult, setLinkResult] = useState<Record<number, string>>({})
   const [linkModalSeries, setLinkModalSeries] = useState<Series | null>(null)
@@ -122,15 +125,17 @@ export default function SeriesPage() {
     setSeriesList(prev => prev.map(s => s.id === series.id ? { ...s, monitored: next } : s))
   }
 
-  const fillGaps = async (series: Series, book?: SeriesHardcoverDiffBook) => {
+  const fillGaps = async (series: Series, book?: SeriesHardcoverDiffBook, mediaType?: MediaType) => {
     setFilling(series.id)
     try {
-      const request: SeriesFillBookRequest | undefined = book ? {
-        foreignBookId: book.foreignBookId,
-        providerId: book.providerId,
-        position: book.position,
-      } : undefined
-      const r = await api.fillSeries(series.id, request)
+      const r = book
+        ? await api.fillSeries(series.id, {
+            foreignBookId: book.foreignBookId,
+            providerId: book.providerId,
+            position: book.position,
+            ...(mediaType ? { mediaType } : {}),
+          })
+        : await api.fillSeriesAll(series.id, mediaType)
       setFillResult(prev => ({ ...prev, [series.id]: r.queued === 0 ? 'Nothing to fill' : `${r.queued} book${r.queued === 1 ? '' : 's'} queued` }))
       const list = await refreshSeriesList()
       const updated = list.find(s => s.id === series.id)
@@ -383,13 +388,27 @@ export default function SeriesPage() {
                         </p>
                       </div>
                       {(diff?.missingCount ?? 0) > 0 && (
-                        <button
-                          onClick={() => fillGaps(series)}
-                          disabled={filling === series.id}
-                          className="text-xs px-2.5 py-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded font-medium flex-shrink-0"
-                        >
-                          {filling === series.id ? 'Queuing...' : 'add all'}
-                        </button>
+                        <div className="flex items-center gap-2 flex-shrink-0">
+                          <select
+                            aria-label="Format to add"
+                            value={fillMediaType[series.id] ?? 'ebook'}
+                            onChange={e => setFillMediaType(prev => ({ ...prev, [series.id]: e.target.value as MediaType }))}
+                            disabled={filling === series.id}
+                            className="text-xs bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-2 py-1 focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600 disabled:opacity-50"
+                            title="Choose which format to add"
+                          >
+                            <option value="ebook">📖 Ebook</option>
+                            <option value="audiobook">🎧 Audiobook</option>
+                            <option value="both">📖🎧 Both</option>
+                          </select>
+                          <button
+                            onClick={() => fillGaps(series, undefined, fillMediaType[series.id] ?? 'ebook')}
+                            disabled={filling === series.id}
+                            className="text-xs px-2.5 py-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded font-medium"
+                          >
+                            {filling === series.id ? 'Queuing...' : 'add all'}
+                          </button>
+                        </div>
                       )}
                     </div>
                     {diffLoading[series.id] && (
@@ -435,7 +454,7 @@ export default function SeriesPage() {
                             <div key={`${book.foreignBookId}-${book.position}`} className={rowClass}>
                               {rowInner}
                               <button
-                                onClick={() => fillGaps(series, book)}
+                                onClick={() => fillGaps(series, book, fillMediaType[series.id] ?? 'ebook')}
                                 disabled={filling === series.id}
                                 className="ml-auto text-xs px-2.5 py-1 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded font-medium flex-shrink-0"
                                 title="Add this missing Hardcover book and search indexers"


### PR DESCRIPTION
Closes #1124

## Summary

Adding a missing book from the series page always created it as an **ebook**, so users who wanted the audiobook (or both) had to add it and then change its media type on the book page. This adds an ebook / audiobook / both selector to the series add actions and honours it end-to-end.

### Backend
- `seriesFillRequest` gains a `mediaType` field, validated against `ebook|audiobook|both` (defaults to ebook when omitted, preserving prior behaviour). Bogus values return 400, mirroring the PUT book handler.
- Threaded through `createMissingHardcoverBook`, `createMissingHardcoverBooks`, and `ensureHardcoverCatalogBook` so the created book's `MediaType` reflects the choice instead of hardcoding ebook.

### Frontend
- `SeriesPage` shows an ebook/audiobook/both `<select>` in the Hardcover section. Per-book "add" and header "add all" send the chosen format.
- New `api.fillSeriesAll(id, mediaType)` carries the media type on the no-book-selector ("add all") path.

## Tests
- Backend: `TestSeriesFillHonoursRequestedMediaType` (audiobook + both create the right `MediaType`); bogus value rejected via a new subtest in `TestSeriesFillEndpointErrors`.
- Frontend: `SeriesPage` test verifies the selected format is sent for both "add" and "add all"; existing per-book test updated for the default `ebook`.

## Verification
- `go build ./...` ✓
- `go vet ./internal/api/` ✓
- `go test ./internal/api/` ✓
- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errors; only pre-existing warnings)
- `npm test` ✓ (335 passed)
- `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)