### PR TITLE
fix(ui): poll the book detail page while a download imports (#1161)

### DIFF
--- a/changelog.d/1161-bookdetail-poll-import.md
+++ b/changelog.d/1161-bookdetail-poll-import.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Book page updates live while a download imports** (#1161) — the book detail page now polls while a book is downloading/importing, so the file and "Imported" status appear on their own instead of requiring a manual page reload.

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -563,3 +563,48 @@ describe('BookDetailPage — danger zone', () => {
     await waitFor(() => expect(api.deleteBook).toHaveBeenCalledWith(42, true))
   })
 })
+
+describe('BookDetailPage — live import polling (#1161)', () => {
+  it('refreshes the book and surfaces the file when an import completes, without a reload', async () => {
+    vi.useFakeTimers()
+    try {
+      const downloading = makeBook({ status: 'downloading', mediaType: 'audiobook', audiobookFilePath: '' })
+      const imported = makeBook({ status: 'imported', mediaType: 'audiobook', audiobookFilePath: '/lib/leviathan.m4b' })
+      vi.mocked(api.getBook).mockResolvedValueOnce(downloading).mockResolvedValue(imported)
+
+      renderBookDetailPage()
+
+      // Initial load: downloading, no file on disk yet.
+      await vi.advanceTimersByTimeAsync(0)
+      expect(screen.queryByText('/lib/leviathan.m4b')).not.toBeInTheDocument()
+      expect(vi.mocked(api.getBook).mock.calls.length).toBe(1)
+
+      // The background import finishes; the 5s poll picks it up live.
+      await vi.advanceTimersByTimeAsync(5000)
+      await vi.advanceTimersByTimeAsync(0) // flush the setBook re-render
+      expect(vi.mocked(api.getBook).mock.calls.length).toBeGreaterThan(1)
+      expect(screen.getByText('/lib/leviathan.m4b')).toBeInTheDocument()
+
+      // Once the book settles (imported), polling stops — no further fetches.
+      const settledCalls = vi.mocked(api.getBook).mock.calls.length
+      await vi.advanceTimersByTimeAsync(15000)
+      expect(vi.mocked(api.getBook).mock.calls.length).toBe(settledCalls)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not poll a settled (wanted) book', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(api.getBook).mockResolvedValue(makeBook({ status: 'wanted' }))
+      renderBookDetailPage()
+      await vi.advanceTimersByTimeAsync(0)
+      const initial = vi.mocked(api.getBook).mock.calls.length
+      await vi.advanceTimersByTimeAsync(15000)
+      expect(vi.mocked(api.getBook).mock.calls.length).toBe(initial)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -187,6 +187,28 @@ export default function BookDetailPage() {
     return () => { cancelled = true }
   }, [bookId, t])
 
+  // While a grab is in flight, the download → import pipeline finishes
+  // asynchronously on the backend. Poll the book + history so the file and
+  // status appear without a manual page reload (#1161). Only polls while the
+  // book is actively downloading/importing; the dependency on book?.status
+  // tears the interval down the moment it settles. Mirrors QueuePage's 5s poll.
+  useEffect(() => {
+    const s = book?.status
+    if (s !== 'downloading' && s !== 'downloaded') return
+    let cancelled = false
+    const interval = setInterval(() => {
+      Promise.all([
+        api.getBook(bookId),
+        api.listHistory({ bookId }),
+      ]).then(([b, h]) => {
+        if (cancelled) return
+        setBook(b)
+        setEvents(h.items)
+      }).catch(() => {})
+    }, 5000)
+    return () => { cancelled = true; clearInterval(interval) }
+  }, [book?.status, bookId])
+
   const saveField = async (patch: Partial<Book>) => {
     if (!book) return
     setSaving(true)


### PR DESCRIPTION
Closes #1161.

## Problem

The book detail page fetched the book once on mount (and once immediately after a grab) but never polled. The download → import pipeline completes asynchronously on the backend, so the file and `Imported` status never appeared until the user manually reloaded. Reproduced live with a *Leviathan Wakes* audiobook.

## Fix

Added a 5s poll (mirroring `QueuePage.tsx:34`) that runs **only** while the book is actively `downloading`/`downloaded` and tears down the moment it settles — the effect depends on `book?.status`, so the interval clears as soon as the status flips to `imported`. No polling on settled (`wanted`/`imported`/`skipped`) books.

## Tests

- import completes → file + status appear without a reload (fake timers)
- polling stops once the book settles (no further fetches)
- a `wanted` book is never polled

Frontend: typecheck ✓, lint ✓ (0 errors), build ✓, 32/32 BookDetailPage tests ✓.

## Note

This same fetch-once-no-poll pattern exists on other pages that show async-mutating book/download status (WantedPage, BooksPage, AuthorDetailPage, SeriesPage). This PR fixes the detail page only — the reported case; the list pages are a separate decision (broader polling has a load cost; a shared live-update mechanism may be the better long-term answer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)