### PR TITLE
fix(ui): poll the Wanted page so background grabs appear without a reload (#1161)

### DIFF
--- a/changelog.d/1161-wanted-page-poll.md
+++ b/changelog.d/1161-wanted-page-poll.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Wanted page updates live** (#1161) — the Wanted list now refreshes on its own, so books grabbed in the background (auto-search) drop off without a manual reload. Polling pauses while you have a results panel open or a grab in progress so the list doesn't shift under you.

--- a/web/src/pages/WantedPage.test.tsx
+++ b/web/src/pages/WantedPage.test.tsx
@@ -424,3 +424,24 @@ describe('WantedPage', () => {
     expect(screen.queryByRole('link', { name: 'Hyperion' })).not.toBeInTheDocument()
   })
 })
+
+describe('WantedPage — live polling (#1161)', () => {
+  it('polls the wanted list so background changes appear without a reload', async () => {
+    vi.useFakeTimers()
+    vi.mocked(api.listWanted)
+      .mockResolvedValueOnce([makeBook({ id: 1, title: 'Stays Wanted' }), makeBook({ id: 2, title: 'Grabbed Away' })])
+      .mockResolvedValue([makeBook({ id: 1, title: 'Stays Wanted' })])
+
+    renderWantedPage()
+    await act(async () => { await vi.advanceTimersByTimeAsync(0) }) // initial load
+    expect(screen.getByText('Grabbed Away')).toBeInTheDocument()
+    expect(vi.mocked(api.listWanted).mock.calls.length).toBe(1)
+
+    // A background auto-grab removes book 2 from the wanted set; the 5s poll
+    // reflects it without a manual reload.
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000) })
+    expect(vi.mocked(api.listWanted).mock.calls.length).toBeGreaterThan(1)
+    expect(screen.queryByText('Grabbed Away')).not.toBeInTheDocument()
+    expect(screen.getByText('Stays Wanted')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -36,6 +36,18 @@ export default function WantedPage() {
     load()
   }, [showExcluded])
 
+  // Poll the wanted list so background auto-grabs (and books leaving as they
+  // import) show up without a manual reload (#1161). Mirrors QueuePage's 5s
+  // poll. Pauses while the user is mid-interaction — a results panel is open or
+  // a grab/search is running — so the list doesn't reshuffle under them.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (showResults !== null || grabbingGuid !== null || searchingId !== null) return
+      api.listWanted({ includeExcluded: showExcluded }).then(setBooks).catch(() => {})
+    }, 5000)
+    return () => clearInterval(interval)
+  }, [showExcluded, showResults, grabbingGuid, searchingId])
+
   useEffect(() => {
     if (!toast) return
     const timer = setTimeout(() => setToast(null), 2500)


### PR DESCRIPTION
Follow-up to #1162 (book detail page polling), part of the same fetch-once-no-poll bug class from #1161.

## Problem

The Wanted list fetched once on mount and only refetched after a *manual* grab. A scheduler auto-grab moves a book out of the wanted set in the background, but the page didn't reflect it until a manual reload.

## Fix

A 5s poll mirroring `QueuePage.tsx`. Unlike the detail page (which gates on a single book's status), Wanted items are all `wanted` by definition, so it polls the list while mounted — but **pauses while the user is mid-interaction** (a results panel is open, or a grab/search is running) so the list doesn't reshuffle under them.

## Tests

- background change (a book leaving the wanted set) appears after the 5s poll without a reload
- existing 14 WantedPage tests still pass

typecheck ✓, lint ✓ (0 errors), build ✓, 15/15 WantedPage tests ✓.

## Related

The broader structural fix (replace per-page polling with an SSE push channel) is tracked in #1163. This and #1162 are the targeted stop-gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)