### PR TITLE
chore(release): cut v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.20.0] — 2026-06-16
+
+### Added
+
+- **Korean (한국어) translation** ([#1138](https://github.com/vavallee/bindery/pull/1138)) — full Korean locale for the web UI, selectable from the language switcher.
+- **Inline save feedback across Settings** ([#1107](https://github.com/vavallee/bindery/pull/1107)) — settings controls now show saving → saved status inline, plus an experimental Grimmory preview badge and a direct link to the Hardcover token field from the import flow.
+
+### Changed
+
+- **Settings General tab decluttered** ([#1109](https://github.com/vavallee/bindery/pull/1109)) — the overloaded General tab's sections (API keys, metadata, logs) moved into their own domain tabs, and the Root Folders tab gained a default-root-folder selector.
+
 ## [v1.19.1] — 2026-06-15
 
 ### Fixed

--- a/changelog.d/korean-translation.md
+++ b/changelog.d/korean-translation.md
@@ -1,2 +1,0 @@
-### Added
-- **Korean (한국어) translation** — full Korean locale for the web UI, selectable from the language switcher.

--- a/charts/bindery/Chart.yaml
+++ b/charts/bindery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bindery
 description: Automated book download manager for Usenet and Torrents
 type: application
-version: 0.9.6
-appVersion: "1.19.1"
+version: 0.9.7
+appVersion: "1.20.0"
 home: https://github.com/vavallee/bindery
 sources:
   - https://github.com/vavallee/bindery

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bindery-web",
   "private": true,
-  "version": "1.19.1",
+  "version": "1.20.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Minor release from `main`. Contents:

### Added
- Korean (한국어) translation (#1138)
- Inline save feedback across Settings + Grimmory preview badge + Hardcover token link (#1107)

### Changed
- Settings General tab decluttered into domain tabs; default-root-folder selector on Root Folders (#1109)

Bumps Chart `0.9.6 → 0.9.7`, appVersion + `web/package.json` to `1.20.0`, consolidates the Korean changelog fragment, and hand-writes notes for #1107/#1109 (which shipped no fragments). The #1139/#1150 fixes already released in v1.19.1 are intentionally not re-listed.

After merge, tag `v1.20.0` on the merge commit to trigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)