### PR TITLE
docs(deploy): document single-mount layout for hardlinks (#1170)

### DIFF
--- a/changelog.d/1170-single-mount-hardlinks-docs.md
+++ b/changelog.d/1170-single-mount-hardlinks-docs.md
@@ -1,0 +1,2 @@
+### Changed
+- **Document the single-mount (hardlink) storage layout** (#1170) — `docs/DEPLOYMENT.md` now explains the TRaSH-style single-mount layout required for hardlink imports/seeding, and the Helm `values.yaml` flags that the stock `BINDERY_*_DIR` defaults are placeholders that must point inside a real mounted volume.

--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -40,6 +40,13 @@ persistence:
     size: 4Gi
     mountPath: /config
 
+# Optional single NFS mount for media storage. For HARDLINK support (instant
+# imports, no extra disk, torrents keep seeding) the download dir and the
+# library dir must be subpaths of ONE mount on the same filesystem. Separate
+# mounts get different device IDs inside the container, so hardlinks across
+# them fail and Bindery falls back to copy. Recommended: mountPath: /data and
+# point the BINDERY_*_DIR values below at subpaths of it (the TRaSH layout).
+# See docs/DEPLOYMENT.md → "Storage layout and hardlinks (single mount)".
 nfs:
   enabled: false
   server: ""
@@ -51,6 +58,15 @@ env:
   BINDERY_DB_PATH: /config/bindery.db
   BINDERY_DATA_DIR: /config
   BINDERY_LOG_LEVEL: info
+  # IMPORTANT: these defaults are placeholders, NOT a working layout — they are
+  # two different paths and neither is backed by a mounted volume out of the
+  # box. A dir that isn't inside a mounted volume writes to ephemeral container
+  # storage and is lost on restart. Override them to subpaths of your real
+  # mount. For hardlinks, download + library must share one mount, e.g.:
+  #   nfs.mountPath: /data
+  #   BINDERY_DOWNLOAD_DIR: /data/downloads/complete
+  #   BINDERY_LIBRARY_DIR:  /data/books
+  #   BINDERY_AUDIOBOOK_DIR: /data/audiobooks
   BINDERY_DOWNLOAD_DIR: /downloads
   BINDERY_LIBRARY_DIR: /books
   # Separate destination for audiobook imports. Leave unset to fall back

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -186,6 +186,52 @@ spec:
 
 `BINDERY_PUID` / `BINDERY_PGID` are **sanity checks, not user switchers.** If you set them but forget the `--user` / `runAsUser` side, Bindery fails fast at startup with a log line that shows exactly what flag was missing — replacing the usual silent `permission denied` on `/config` or the library mount. Leaving both unset skips the check entirely (Bindery runs as the default non-root UID `65532` from the distroless base).
 
+## Storage layout and hardlinks (single mount)
+
+Bindery imports with **`hardlink`** mode by default when the completed download and the library destination are on the **same filesystem**. A hardlink is instant, uses no extra disk, and lets a torrent keep seeding from the original path. This is the recommended layout.
+
+The catch: "same filesystem" is decided by the OS device ID *inside the container*. Two separate bind mounts get different device IDs even when they point at the same host filesystem, so a hardlink across them fails and Bindery falls back to **`copy`** (which doubles disk usage and logs a warning). To get hardlinks, the download directory and the library directory must live under **one mount**, as subpaths of it.
+
+This is the [TRaSH-Guides](https://trash-guides.info/Hardlinks/Hardlinks-and-Instant-Moves/) layout the rest of the \*arr stack uses: mount a single volume (e.g. `/data`) and point everything at subpaths of it. The download client mounts the **same** volume at the **same** path, so no path remap is needed either.
+
+### Docker Compose
+
+```yaml
+services:
+  bindery:
+    image: ghcr.io/vavallee/bindery:latest
+    volumes:
+      - /mnt/storage:/data          # ONE mount for downloads + library
+    environment:
+      - BINDERY_DOWNLOAD_DIR=/data/downloads/complete
+      - BINDERY_LIBRARY_DIR=/data/books
+      - BINDERY_AUDIOBOOK_DIR=/data/audiobooks
+
+  sabnzbd:
+    image: lscr.io/linuxserver/sabnzbd:latest
+    volumes:
+      - /mnt/storage:/data          # SAME volume at the SAME path
+    # SABnzbd's complete dir -> /data/downloads/complete
+```
+
+### Kubernetes (Helm `values.yaml`)
+
+```yaml
+nfs:
+  enabled: true
+  server: 192.168.1.4
+  path: /volume1/MEDIA
+  mountPath: /data
+env:
+  BINDERY_DOWNLOAD_DIR: /data/downloads/complete
+  BINDERY_LIBRARY_DIR: /data/books
+  BINDERY_AUDIOBOOK_DIR: /data/audiobooks
+```
+
+> **Don't point a library/download dir at an unmounted path.** `BINDERY_LIBRARY_DIR` / `BINDERY_DOWNLOAD_DIR` / `BINDERY_AUDIOBOOK_DIR` must resolve *inside* a mounted volume. A dir that isn't backed by a volume writes to ephemeral container storage and is lost on restart. The chart's stock defaults (`/downloads`, `/books`) are placeholders — override them to subpaths of your real mount.
+
+If you genuinely can't use a single mount (the download client mounts the share at a different path than Bindery), keep them separate and use [path remapping](#path-remapping-multi-container--multi-pod-setups) below — but note imports will then **`copy`**, not hardlink.
+
 ## Path remapping (multi-container / multi-pod setups)
 
 When Bindery and your download client run in **separate containers**, they typically mount the same storage volume at different paths. Bindery needs to read the files the download client just completed, but the path the client reports (e.g. `/downloads/complete/My.Book`) doesn't exist inside Bindery's container.


### PR DESCRIPTION
Addresses #1170.

## Context

#1170 asks for a single-mount layout so hardlinks work for seeding. This is **already supported** — all three dirs (`BINDERY_DOWNLOAD_DIR`, `BINDERY_LIBRARY_DIR`, `BINDERY_AUDIOBOOK_DIR`) are configurable and the chart mounts a single NFS volume, so pointing them at subpaths of one mount makes `sameDevice` (`internal/importer/samedevice_unix.go`) return true and hardlinks engage automatically. The gap was **documentation + misleading chart defaults**, not a missing feature.

## Changes

- **`docs/DEPLOYMENT.md`** — new "Storage layout and hardlinks (single mount)" section: explains why separate bind mounts break hardlinks (different device IDs in-container → copy fallback), gives the TRaSH `/data` single-mount layout for both Docker Compose and Helm, warns against pointing a dir at an unmounted (ephemeral) path, and cross-links the path-remapping section as the separate-mounts alternative.
- **`charts/bindery/values.yaml`** — comment the `nfs`/`env` block: the stock `BINDERY_*_DIR` defaults (`/downloads`, `/books`) are placeholders, not a working layout, and must be overridden to subpaths of a real mount. Includes the single-mount example inline.

## Deliberately not done

I did **not** change the default values (`/downloads`, `/books`, `mountPath: /media`). Changing them to a coherent `/data` layout would regress existing installs that rely on the current defaults with a volume mounted at those paths. Flagging it as a follow-up decision instead.

`helm lint` passes; `helm template` renders correctly with the single-mount example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)