### PR TITLE
fix(api): skip strict dial re-check for image fetches via outbound proxy

### DIFF
--- a/changelog.d/1177-cover-proxy-dial.md
+++ b/changelog.d/1177-cover-proxy-dial.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Cover images load again when `BINDERY_OUTBOUND_PROXY` is set** (#1177) — the cover-image proxy no longer applies its strict per-dial SSRF re-check to the outbound proxy itself, which had rejected a LAN/loopback proxy address and returned `502` for every cover (silently breaking the on-disk image cache). The DNS-rebind guard still applies on the direct, no-proxy path.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -301,7 +301,7 @@ Outbound URLs are validated against an SSRF policy. Two trust levels apply:
 
 If a same-host service still isn't reachable, the usual cause is that the service is bound to an interface your URL doesn't match (for example SABnzbd listening only on `127.0.0.1` while you used the LAN IP, or vice versa). Either point Bindery at the interface the service actually listens on, or set the service to listen on `0.0.0.0`.
 
-**Outbound proxy interaction.** When `BINDERY_OUTBOUND_PROXY` is set, in-scope requests are dialled to the proxy and the proxy resolves the destination — so the destination-URL SSRF validation still runs, but the per-connection dial re-check sees the proxy's address rather than the target's. Local destinations skip the proxy entirely per `BINDERY_OUTBOUND_PROXY_BYPASS_LOCAL` (see [Environment variables](#environment-variables)), which is also what keeps a LAN indexer manager (Jackett/Prowlarr) reachable.
+**Outbound proxy interaction.** When `BINDERY_OUTBOUND_PROXY` is set, in-scope requests are dialled to the proxy and the proxy resolves the destination, so the destination-URL SSRF validation still runs up front. The per-connection dial re-check (the DNS-rebind guard) can then only see the proxy's own address, not the target's — so for the strict-policy cover-image proxy that re-check is skipped whenever a proxy is configured; otherwise it would reject a LAN/loopback proxy and block every cover fetch. Local destinations skip the proxy entirely per `BINDERY_OUTBOUND_PROXY_BYPASS_LOCAL` (see [Environment variables](#environment-variables)), which is also what keeps a LAN indexer manager (Jackett/Prowlarr) reachable.
 
 ## First-run setup
 

--- a/internal/api/imageproxy.go
+++ b/internal/api/imageproxy.go
@@ -63,27 +63,34 @@ func NewImageProxyHandler(dataDir string) *ImageProxyHandler {
 	return h
 }
 
-// imageProxyTransport returns the RoundTripper for the image-proxy client with a
-// per-request SSRF-revalidating DialContext installed, closing the DNS-rebind
-// TOCTOU window between the up-front URL validation and the actual dial.
+// imageProxyTransport returns the RoundTripper for the image-proxy client.
 //
-// It starts from httpsec.DefaultProxyTransport() (preserving outbound-proxy
-// support added in #987) and clones it so installing DialContext does not mutate
-// the shared transport. Caveat: when an outbound proxy IS configured the
-// connection is dialled to the proxy address, so the dial-time re-check sees the
-// proxy rather than the upstream host (the same documented limitation as the
-// newznab client); for the default no-proxy case this fully closes the rebind
-// window. If the underlying transport is not an *http.Transport we fall back to
-// a fresh transport carrying the proxy resolver plus DialContext.
+// On the direct (no outbound proxy) path it installs a per-request
+// SSRF-revalidating DialContext, closing the DNS-rebind TOCTOU window between
+// the up-front URL validation and the actual dial. It starts from
+// httpsec.DefaultProxyTransport() and clones it so installing DialContext does
+// not mutate the shared transport.
+//
+// When an outbound proxy IS configured (#987) the transport dials the *proxy*,
+// not the upstream host, so a PolicyStrict DialContext would re-validate the
+// proxy's own address and reject a LAN/loopback proxy — breaking every cover
+// fetch. In that case we return the shared proxy transport unchanged and rely on
+// the up-front h.validateURL plus the CheckRedirect hook for upstream SSRF: the
+// proxy is operator-configured and trusted, and the rebind re-check cannot see
+// past it anyway (the dial only reaches the proxy address). The strict per-dial
+// re-check therefore applies only to the direct path, where it is both meaningful
+// and the place a rebind would actually land.
 func imageProxyTransport() http.RoundTripper {
 	base := httpsec.DefaultProxyTransport()
+	if httpsec.ProxyFunc() != nil {
+		return base
+	}
 	if t, ok := base.(*http.Transport); ok {
 		c := t.Clone()
 		c.DialContext = httpsec.NewDialContext(httpsec.PolicyStrict)
 		return c
 	}
 	return &http.Transport{
-		Proxy:       httpsec.ProxyFunc(),
 		DialContext: httpsec.NewDialContext(httpsec.PolicyStrict),
 	}
 }

--- a/internal/api/imageproxy_test.go
+++ b/internal/api/imageproxy_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -266,6 +267,47 @@ func TestProxyBookImages(t *testing.T) {
 				t.Errorf("in=%q: want %q, got %q", tc.in, tc.want, b.ImageURL)
 			}
 		}
+	}
+}
+
+// TestImageProxyTransport_NoStrictDialWhenProxied is the regression guard for
+// the cover-proxy 502 bug: when BINDERY_OUTBOUND_PROXY is configured the image
+// transport dials the proxy, not the upstream host, so installing a PolicyStrict
+// per-dial re-check would reject a LAN/loopback proxy and break every fetch.
+// In the proxy case the handler must return the shared proxy transport unchanged.
+func TestImageProxyTransport_NoStrictDialWhenProxied(t *testing.T) {
+	t.Cleanup(func() { _, _ = httpsec.ConfigureOutboundProxy("", "", true) })
+
+	// A loopback proxy is exactly the case PolicyStrict would have rejected.
+	if _, err := httpsec.ConfigureOutboundProxy("http://127.0.0.1:0", "", true); err != nil {
+		t.Fatalf("ConfigureOutboundProxy: %v", err)
+	}
+
+	got := imageProxyTransport()
+	if got != httpsec.DefaultProxyTransport() {
+		t.Errorf("with a proxy configured, imageProxyTransport() must return the shared proxy transport unchanged; got a different transport (%T)", got)
+	}
+}
+
+// TestImageProxyTransport_StrictDialWhenDirect verifies the direct (no-proxy)
+// path still installs the rebind-closing DialContext on a clone of the default
+// transport, so SSRF protection is preserved where a rebind would actually land.
+func TestImageProxyTransport_StrictDialWhenDirect(t *testing.T) {
+	t.Cleanup(func() { _, _ = httpsec.ConfigureOutboundProxy("", "", true) })
+	if _, err := httpsec.ConfigureOutboundProxy("", "", true); err != nil {
+		t.Fatalf("ConfigureOutboundProxy reset: %v", err)
+	}
+
+	got := imageProxyTransport()
+	tr, ok := got.(*http.Transport)
+	if !ok {
+		t.Fatalf("imageProxyTransport() = %T, want *http.Transport on the direct path", got)
+	}
+	if tr.DialContext == nil {
+		t.Error("direct-path transport must install a DialContext (the rebind re-check)")
+	}
+	if got == httpsec.DefaultProxyTransport() {
+		t.Error("direct-path transport must be a clone, not the shared default transport")
 	}
 }
 


### PR DESCRIPTION
## Summary

When `BINDERY_OUTBOUND_PROXY` is configured to a proxy on a LAN/loopback
address, every book/author cover returns `502` and the on-disk image cache
silently stops populating (already-cached covers then age out over the 30-day
TTL, so it presents as "the image cache stopped working").

The cover-fetch client installs a per-dial `PolicyStrict` SSRF re-check
(`NewDialContext`, added to close a DNS-rebind window). But when an outbound
proxy is set, `http.Transport` dials the **proxy**, so the re-check validates
the proxy's own RFC1918/loopback address and rejects it. This skips the per-dial
re-check whenever a proxy is configured — upstream SSRF is already enforced by
the up-front `h.validateURL` and the `CheckRedirect` hook, and the re-check
can't see past the proxy anyway. The direct (no-proxy) path keeps the rebind
guard, where it's both meaningful and where a rebind would actually land.

Closes #1177.

## What changed

| File | Change |
|------|--------|
| `internal/api/imageproxy.go` | `imageProxyTransport()` returns the shared proxy transport unchanged when `httpsec.ProxyFunc() != nil`; the strict `DialContext` is installed only on the direct path. |
| `internal/api/imageproxy_test.go` | Regression tests: no strict dial when proxied; strict dial retained when direct. |
| `docs/DEPLOYMENT.md` | Corrected the "Outbound proxy interaction" note (strict-policy cover proxy skips the re-check under a proxy). |
| `changelog.d/1177-cover-proxy-dial.md` | Changelog fragment. |

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated (proxy/SSRF interaction note)
- [x] Added a changelog fragment under `changelog.d/`
- [ ] Wiki pages updated if user-facing behaviour changed — n/a (restores documented behaviour)

## Test plan

- [ ] `make check` — not run locally (no Go toolchain on this dev machine; relying on PR CI)
- [x] Compiles in CI (`go build` + `tsc`) via a fork image build of this exact commit
- [x] Verified on a live Docker deployment: a cover that returned `502` with `BINDERY_OUTBOUND_PROXY` pointed at a LAN proxy now returns `200`, and the on-disk image cache repopulates. Direct (no-proxy) cover fetches still work and still reject SSRF targets.
