### PR TITLE
fix(indexer): treat all punctuation as word boundaries in title relevance matching

### DIFF
--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -822,6 +822,19 @@ func TestSigWords(t *testing.T) {
 		{"K.A.M.I", nil}, // single-character remainders dropped by min length
 		{"snake_case_title", []string{"snake", "case", "title"}},
 		{"Title (Subtitle)", []string{"title", "subtitle"}},
+		// Every run of non-alphanumeric characters is a word boundary, so any
+		// punctuation a title carries but a release name omits is stripped
+		// rather than glued to a keyword that no release could match.
+		// Trailing "!" stripped.
+		{"Eat That Frog!", []string{"eat", "that", "frog"}},
+		// "?" stripped; 2-char "my" below min length.
+		{"Who Moved My Cheese?", []string{"who", "moved", "cheese"}},
+		// "," stripped; lone "&" below min length.
+		{"Eats, Shoots & Leaves", []string{"eats", "shoots", "leaves"}},
+		// Leading "#" stripped.
+		{"#Girlboss", []string{"girlboss"}},
+		// Hyphen split; "22" below min length.
+		{"Catch-22", []string{"catch"}},
 	}
 	for _, c := range cases {
 		got := SigWords(c.in)

--- a/internal/indexer/newznab/words.go
+++ b/internal/indexer/newznab/words.go
@@ -1,6 +1,9 @@
 package newznab
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
 // stopWords are common English words excluded from keyword significance checks.
 // Must stay in sync with the set used by filterRelevant in the indexer package.
@@ -11,32 +14,34 @@ var stopWords = map[string]bool{
 	"as": true, "on": true, "be": true,
 }
 
-// sigWordSeparators are the same separator characters that NormalizeRelease
-// (internal/indexer/release.go) treats as word boundaries when normalising
-// release names. Splitting here keeps the two sides of the relevance match
-// symmetric: "Slaughterhouse-Five" on the title side becomes the same
-// [slaughterhouse, five] pair that "Slaughterhouse-Five.epub" yields on the
-// release side after NormalizeRelease. Without this split, single-word
-// hyphenated titles produced one literal-hyphen keyword that could never
-// match the de-hyphenated release string (#871).
-var sigWordSeparators = "._-()[]|"
-
 // SigWords returns the meaningful (non-stop, 3+ char) words from s.
-// Apostrophes are stripped so "Ender's" produces the token "enders",
-// matching the apostrophe-free form used in most release names.
-// Hyphens and other NZB separators are split on so a title like
-// "Slaughterhouse-Five" yields [slaughterhouse, five] (#871).
-// German umlauts are transliterated (ä→ae etc.) to match NormalizeRelease.
+//
+// Tokenisation is kept symmetric with NormalizeRelease
+// (internal/indexer/release.go): both strip apostrophes, transliterate German
+// umlauts, and treat every run of non-alphanumeric characters as a word
+// boundary. Keeping the two alphabets identical is what lets a title keyword
+// line up with the release-side string. Any punctuation the metadata title
+// carries but a release name omits — a trailing "!"/"?", a stray ","/":", a
+// "%"/"#"/"$" glued to a word — would otherwise survive as a keyword that no
+// release could ever contain: e.g. "Eat That Frog!" yielding "frog!" against a
+// release named "Eat That Frog" (the hyphen variant of this was #871).
+//
+// Apostrophes (both ASCII ' and the Unicode ’) are stripped rather than split
+// so "Ender's" produces the token "enders", matching the apostrophe-free form
+// used in most release names. Unicode letters (CJK, accented Latin) count as
+// word characters so non-Latin titles still tokenise.
 func SigWords(s string) []string {
 	var out []string
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, "'", "")
+	s = strings.ReplaceAll(s, "’", "")
 	normalised := strings.Map(func(r rune) rune {
-		if strings.ContainsRune(sigWordSeparators, r) {
-			return ' '
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			return r
 		}
-		return r
-	}, strings.ToLower(s))
+		return ' '
+	}, s)
 	for _, w := range strings.Fields(normalised) {
-		w = strings.ReplaceAll(w, "'", "")
 		w = transliterateUmlauts(w)
 		if len(w) >= 3 && !stopWords[w] {
 			out = append(out, w)

--- a/internal/indexer/release.go
+++ b/internal/indexer/release.go
@@ -21,7 +21,7 @@ type ParsedRelease struct {
 }
 
 var (
-	separatorRe  = regexp.MustCompile(`[._\-()\[\]|]+`)
+	separatorRe  = regexp.MustCompile(`[^\p{L}\p{N}]+`)
 	multiSpaceRe = regexp.MustCompile(`\s{2,}`)
 	articleRe    = regexp.MustCompile(`\b(a|an|the|and|or|of)\b`)
 
@@ -50,15 +50,22 @@ func transliterateUmlauts(s string) string {
 	return s
 }
 
-// NormalizeRelease lowercases s and replaces NZB separators with single spaces.
-// Parentheses, brackets, pipes and repeated separators are all collapsed.
-// Apostrophes are stripped so possessive forms in book titles ("Ender's") match
-// the corresponding release names which typically omit them ("Enders").
-// German umlauts are transliterated to their ASCII equivalents (ä→ae etc.) to
-// match the convention used by German-language NZB indexers like Scenenzbs.
+// NormalizeRelease lowercases s and replaces every run of non-alphanumeric
+// characters with a single space, so all punctuation (dots, dashes, brackets,
+// pipes, and symbols like %, !, ?, #, $) collapses to word boundaries. This
+// keeps the release side symmetric with SigWords (internal/indexer/newznab):
+// whatever punctuation a metadata title carries, both sides reduce it to the
+// same alphanumeric tokens. Unicode letters (\p{L}) and numbers (\p{N}) are
+// preserved so CJK and accented-Latin release names survive.
+// Apostrophes (both ASCII ' and the Unicode ’) are stripped first so possessive
+// forms in book titles ("Ender's") match the corresponding release names which
+// typically omit them ("Enders"). German umlauts are transliterated to their
+// ASCII equivalents (ä→ae etc.) to match the convention used by German-language
+// NZB indexers like Scenenzbs.
 func NormalizeRelease(s string) string {
 	s = strings.ToLower(s)
 	s = strings.ReplaceAll(s, "'", "") // "ender's" → "enders", "hitchhiker's" → "hitchhikers"
+	s = strings.ReplaceAll(s, "’", "") // Unicode right single quote, same intent
 	s = transliterateUmlauts(s)
 	s = separatorRe.ReplaceAllString(s, " ")
 	s = multiSpaceRe.ReplaceAllString(s, " ")

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -245,6 +245,35 @@ func TestFilterRelevantHyphenatedTitle(t *testing.T) {
 	}
 }
 
+// TestFilterRelevantPunctuationInTitle — regression test for the general
+// punctuation-asymmetry bug. A symbol the metadata title carries but the
+// release name drops (here the trailing "!") used to glue onto a keyword:
+// SigWords("Eat That Frog!") produced "frog!", which can never appear in a
+// release written as "Eat That Frog". Every correctly-named release was dropped
+// at the relevance stage. Now that both SigWords and NormalizeRelease treat any
+// run of non-alphanumeric characters as a word boundary, the title reduces to
+// ["eat", "that", "frog"] and the releases match. The same class previously bit
+// "%", "?", ",", "#", "$", etc.
+func TestFilterRelevantPunctuationInTitle(t *testing.T) {
+	results := toResults(
+		"Brian Tracy - Eat That Frog (Unabridged) (AUDIOBOOK)",
+		"Brian.Tracy.Eat.That.Frog.m4b",
+		"Some.Unrelated.Audiobook.m4b",
+	)
+	got := filterRelevant(results, "Eat That Frog!", "Brian Tracy", nil)
+	for _, want := range []string{
+		"Brian Tracy - Eat That Frog (Unabridged) (AUDIOBOOK)",
+		"Brian.Tracy.Eat.That.Frog.m4b",
+	} {
+		if !contains(got, want) {
+			t.Errorf("expected %q in results, got %v", want, resultTitles(got))
+		}
+	}
+	if contains(got, "Some.Unrelated.Audiobook.m4b") {
+		t.Error("unrelated release must not pass")
+	}
+}
+
 // TestFilterRelevantEditionQualifier — regression test for issue #283.
 // filterRelevant must accept real NZB releases for a book whose metadata
 // title carries a parenthesised edition qualifier. Before the fix,


### PR DESCRIPTION
## Summary

The search relevance filter dropped correctly-named releases whenever a work's title carried punctuation that the release name omits. `SigWords` (title side) and `NormalizeRelease` (release side) shared a fixed separator list (`. _ - ( ) [ ] |`), so any other punctuation stayed glued to the adjacent word and became a keyword no release could contain — e.g. `Eat That Frog!` → keyword `frog!`, which never matches a release named `Eat That Frog`. Both sides now treat **every run of non-alphanumeric characters** as a word boundary, generalising the hyphen fix (#871) and the possessive-apostrophe fix (#409). Closes #1179.

## Root cause

`SigWords("Eat That Frog!")` produced `["eat", "that", "frog!"]`. The keyword `frog!` is matched against the `NormalizeRelease`'d release string (`brian tracy eat that frog ...`), which has no `!`, so neither the phrase match nor the word-boundary fallback can hit — the release is dropped at the `relevance` stage with `title/author keywords did not match release name`.

The two sides were meant to share one alphabet; the separator set was just incomplete.

| Character (glued to a word) | Example title | Old keyword | Release writes | Dropped? |
|---|---|---|---|---|
| `!` | Eat That Frog! | `frog!` | `frog` | yes |
| `?` | Who Moved My Cheese? | `cheese?` | `cheese` | yes |
| `,` | Eats, Shoots & Leaves | `eats,` | `eats` | yes |
| `%` | (numeric-prefixed titles) | `NN%` | `NN` | yes |
| `#` `$` | #-/$-prefixed titles | `#word` / `$NN` | `word` / `NN` | yes |

Spaced punctuation (`Pride & Prejudice`) was already fine — the lone symbol is below the 3-char keyword minimum.

## Implementation notes

- `SigWords` (`internal/indexer/newznab/words.go`): replaced the fixed `sigWordSeparators` list with "any rune that is not a Unicode letter or number is a word boundary". Apostrophes (ASCII `'` and Unicode `’`) are stripped first so possessives still collapse (`Ender's` → `enders`).
- `NormalizeRelease` (`internal/indexer/release.go`): `separatorRe` is now `[^\p{L}\p{N}]+`, and the Unicode apostrophe is stripped alongside the ASCII one to keep the two sides symmetric.
- `\p{L}` / `\p{N}` are preserved, so CJK and accented-Latin titles/releases still tokenise (no regression to #380's non-Latin author handling). German umlaut transliteration is unchanged.

## Scope decisions

- Generalised rather than adding each new symbol to the old list — the bug is the asymmetry, and a "non-alphanumeric = boundary" rule closes the whole class instead of inviting the next exotic character.
- `+` is deliberately covered by the same rule; cases like `C++` continue to match because both sides reduce identically and the release is anchored by the remaining words + author.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — internal matching logic only; godoc on `SigWords` / `NormalizeRelease` updated; no `docs/`, README, or Helm changes apply
- [x] Wiki pages updated if user-facing behaviour changed — N/A (no user-facing surface change)

## Test plan

- [x] `go test ./cmd/... ./internal/...`  *(green in CI — `validate (Go)` + `validate (Go race)`)*
- [x] `cd web && npm run build`  *(green in CI — `validate (frontend)`)*

New / updated tests:
- `TestSigWords` — added `!`, `?`, `,`/`&`, leading `#`, and `Catch-22` cases.
- `TestFilterRelevantPunctuationInTitle` — end-to-end: `Eat That Frog!` releases survive, unrelated release is rejected.
- Existing apostrophe (`TestFilterRelevantApostrophe`), umlaut, hyphen (#871), and `NormalizeRelease` / `FuzzParseRelease` invariants still hold.
