### PR TITLE
feat(ui): surface Manual Import from empty Queue/Wanted states (#1184)

### DIFF
--- a/changelog.d/1184-manual-import-discoverability.md
+++ b/changelog.d/1184-manual-import-discoverability.md
@@ -1,0 +1,2 @@
+### Changed
+- **Manual Import is easier to find** (#1184) — the empty Queue and Wanted pages now point you straight to Manual Import (for files already on disk) and Scan Library (for files already in your library folder), so "I have ebooks downloaded but nothing imports" no longer leaves you stuck.

--- a/web/src/components/ImportHints.tsx
+++ b/web/src/components/ImportHints.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { btn, btnSize } from './buttons'
+
+// Discoverability CTA shown on empty Queue/Wanted states (#1184). New users who
+// already have files on disk often don't realise Manual Import / Scan Library
+// exist, so we point them straight at the existing flows rather than building a
+// new import UI. Both targets are Settings sub-tabs (deep-linked via ?tab=…):
+// Manual Import lives under Import / Migrate, Scan Library under General.
+export default function ImportHints() {
+  const { t } = useTranslation()
+  return (
+    <div className="mt-6 mx-auto max-w-md text-left rounded-lg border border-slate-200 dark:border-zinc-800 bg-slate-100 dark:bg-zinc-900 p-4">
+      <p className="text-sm font-medium text-slate-700 dark:text-zinc-300">
+        {t('importHints.heading')}
+      </p>
+      <p className="mt-1 text-xs text-slate-600 dark:text-zinc-500">
+        {t('importHints.body')}
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Link to="/settings?tab=import" className={`${btn.primary} ${btnSize.md}`}>
+          {t('importHints.manualImport')}
+        </Link>
+        <Link to="/settings?tab=general" className={`${btn.secondary} ${btnSize.md}`}>
+          {t('importHints.scanLibrary')}
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -281,6 +281,12 @@
     "removeConfirm": "Remove",
     "removeCancel": "Cancel"
   },
+  "importHints": {
+    "heading": "Already have files on disk?",
+    "body": "Bindery only auto-imports downloads it grabbed itself. Point it at files you already have, or rescan your library folder.",
+    "manualImport": "Import them",
+    "scanLibrary": "Scan Library"
+  },
   "blocklist": {
     "title": "Blocklist",
     "entries": "{{count}} entries",

--- a/web/src/pages/QueuePage.test.tsx
+++ b/web/src/pages/QueuePage.test.tsx
@@ -38,6 +38,10 @@ vi.mock('react-i18next', () => ({
         'queue.errorDetails': 'Show full error',
         'queue.clearAllFailed': 'Clear all failed',
         'queue.retryAllFailed': 'Retry all failed',
+        'importHints.heading': 'Already have files on disk?',
+        'importHints.body': 'Bindery only auto-imports downloads it grabbed itself.',
+        'importHints.manualImport': 'Import them',
+        'importHints.scanLibrary': 'Scan Library',
       }
       return labels[key] ?? key
     },
@@ -155,6 +159,16 @@ describe('QueuePage', () => {
     })
 
     expect(await screen.findByText('Queue is empty')).toBeInTheDocument()
+  })
+
+  it('surfaces the Manual Import and Scan Library hints in the empty state', async () => {
+    renderQueuePage()
+
+    expect(await screen.findByText('Queue is empty')).toBeInTheDocument()
+    const manualImport = screen.getByRole('link', { name: 'Import them' })
+    expect(manualImport).toHaveAttribute('href', '/settings?tab=import')
+    const scanLibrary = screen.getByRole('link', { name: 'Scan Library' })
+    expect(scanLibrary).toHaveAttribute('href', '/settings?tab=general')
   })
 
   it('renders queue statuses, progress, fallback errors, and error prefixes', async () => {

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, PendingRelease, QueueItem } from '../api/client'
 import BookAuthorLink from '../components/BookAuthorLink'
+import ImportHints from '../components/ImportHints'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
 import { summarizeError, ERROR_SUMMARY_LEN } from './queueError'
@@ -217,6 +218,7 @@ export default function QueuePage() {
       ) : queue.length === 0 && pending.length === 0 ? (
         <div className="text-center py-16 text-slate-600 dark:text-zinc-500">
           <p>{t('queue.empty')}</p>
+          <ImportHints />
         </div>
       ) : (
         <div className="space-y-6">

--- a/web/src/pages/WantedPage.test.tsx
+++ b/web/src/pages/WantedPage.test.tsx
@@ -32,6 +32,10 @@ vi.mock('react-i18next', () => ({
         'wanted.title': 'Wanted',
         'wanted.searchPlaceholder': 'Search by title or author...',
         'wanted.empty': 'No wanted books. Add an author to start tracking.',
+        'importHints.heading': 'Already have files on disk?',
+        'importHints.body': 'Bindery only auto-imports downloads it grabbed itself.',
+        'importHints.manualImport': 'Import them',
+        'importHints.scanLibrary': 'Scan Library',
         'wanted.noMatch': 'No books match your search.',
         'wanted.showExcluded': 'Show excluded',
         'wanted.searching': 'Searching...',
@@ -175,6 +179,16 @@ describe('WantedPage', () => {
     expect(await screen.findByText('No wanted books. Add an author to start tracking.')).toBeInTheDocument()
     expect(screen.getByText('0 of 0')).toBeInTheDocument()
     expect(api.listWanted).toHaveBeenCalledWith({ includeExcluded: false })
+  })
+
+  it('surfaces the Manual Import and Scan Library hints in the empty state', async () => {
+    renderWantedPage()
+
+    expect(await screen.findByText('No wanted books. Add an author to start tracking.')).toBeInTheDocument()
+    const manualImport = screen.getByRole('link', { name: 'Import them' })
+    expect(manualImport).toHaveAttribute('href', '/settings?tab=import')
+    const scanLibrary = screen.getByRole('link', { name: 'Scan Library' })
+    expect(scanLibrary).toHaveAttribute('href', '/settings?tab=general')
   })
 
   it('renders a row with the book title and its author', async () => {

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { api, Book, SearchResult } from '../api/client'
 import BulkActionBar from '../components/BulkActionBar'
+import ImportHints from '../components/ImportHints'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
 
@@ -202,6 +203,7 @@ export default function WantedPage() {
       ) : books.length === 0 ? (
         <div className="text-center py-16 text-slate-600 dark:text-zinc-500">
           <p>{t('wanted.empty')}</p>
+          <ImportHints />
         </div>
       ) : filtered.length === 0 ? (
         <div className="text-center py-16 text-slate-600 dark:text-zinc-500">


### PR DESCRIPTION
Closes #1184

## Summary

Manual Import (`/settings?tab=import` → Manual file import) and Scan Library (`/settings?tab=general`) already exist, but new users with files already on disk never find them, producing the recurring "I have ebooks downloaded but Bindery does nothing, how do I force an import?" support question. This adds a discoverability CTA so the existing flows are surfaced exactly where those users land.

Pure frontend discoverability, no backend change. Reuses the existing Manual Import + Scan Library flows — no new import UI.

## Changes

- New shared `ImportHints` component (empty-state card with two `Link`s): "Import them" → Settings ▸ Import / Migrate, "Scan Library" → Settings ▸ General.
- Rendered in the **Queue** empty state (no queue/pending items) and the **Wanted** empty state (no wanted books).
- All strings via `t()`, new `importHints.*` keys in `en.json`. Styling matches existing dark: pairs and the shared `btn`/`btnSize` button vocabulary.

## Tests

- `QueuePage.test.tsx` and `WantedPage.test.tsx`: empty state renders both CTAs with the correct `href` deep-links.

## Verification (frontend)

- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errors; only pre-existing warnings)
- `npm test` ✓ (336 passed)
- `npm run build` ✓
- `go build ./...` ✓ (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)