### PR TITLE
fix(search): return empty list (not null) for empty metadata search (#1188)

### DIFF
--- a/changelog.d/1188-add-book-null-results.md
+++ b/changelog.d/1188-add-book-null-results.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Add Book modal no longer crashes when a search returns no results** (#1188) — an empty metadata book search now serializes as `[]` instead of `null` from `/api/v1/search/book`, and the modal defensively coerces a null body to an empty list, so an empty search shows "No results found." instead of throwing `Cannot read properties of null (reading 'map')`.

--- a/internal/api/search_test.go
+++ b/internal/api/search_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/metadata"
@@ -98,6 +99,32 @@ func TestSearchBooks(t *testing.T) {
 	h.SearchBooks(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/book?term=x", nil))
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("error: expected 502, got %d", rec.Code)
+	}
+}
+
+// TestSearchBooksEmptyIsArray guards against the nil-slice bug from #1188: a
+// provider that succeeds but returns no rows must serialize as `[]`, not `null`,
+// or the Add Book modal crashes calling `.map()` on a null body.
+func TestSearchBooksEmptyIsArray(t *testing.T) {
+	p := &stubProvider{books: nil} // success, but no results
+	h := NewSearchHandler(metadata.NewAggregator(p))
+
+	rec := httptest.NewRecorder()
+	h.SearchBooks(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/book?term=zzznomatch", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if body := strings.TrimSpace(rec.Body.String()); body != "[]" {
+		t.Errorf("expected empty body to encode as [], got %q", body)
+	}
+
+	// And the aggregator itself returns a non-nil slice.
+	got, err := metadata.NewAggregator(p).SearchBooks(context.Background(), "zzznomatch")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Error("SearchBooks returned a nil slice for empty success; want non-nil empty slice")
 	}
 }
 

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -350,7 +350,7 @@ const searchProviderTimeout = 8 * time.Second
 func (a *Aggregator) SearchBooks(ctx context.Context, query string) ([]models.Book, error) {
 	providers := a.providers() // primary first, then enrichers
 	if len(providers) == 0 {
-		return nil, nil
+		return []models.Book{}, nil
 	}
 	results, anySuccess, firstErr := searchFanOut(ctx, providers, func(c context.Context, p Provider) ([]models.Book, error) {
 		return p.SearchBooks(c, query)
@@ -361,7 +361,9 @@ func (a *Aggregator) SearchBooks(ctx context.Context, query string) ([]models.Bo
 		return nil, firstErr
 	}
 
-	var merged []models.Book
+	// Non-nil so an empty result JSON-encodes as `[]`, not `null` — a nil slice
+	// reaches the frontend as `null` and crashes callers that `.map()` over it.
+	merged := []models.Book{}
 	seenISBN := map[string]bool{}
 	seenTA := map[string]bool{}
 	for i := range providers {

--- a/web/src/components/AddBookModal.test.tsx
+++ b/web/src/components/AddBookModal.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import AddBookModal from './AddBookModal'
+
+// Mock the api/client module so no real HTTP calls are made.
+vi.mock('../api/client', () => ({
+  api: {
+    searchBooks: vi.fn(),
+    lookupISBN: vi.fn(),
+    addBook: vi.fn(),
+  },
+}))
+
+import { api } from '../api/client'
+
+describe('AddBookModal — null search results (#1188)', () => {
+  const onClose = vi.fn()
+  const onAdded = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders "No results found." when the search returns null instead of crashing', async () => {
+    // The backend can encode an empty success as `null`; the modal must treat
+    // that as an empty list rather than calling `.map()` on null.
+    vi.mocked(api.searchBooks).mockResolvedValue(null as unknown as never)
+
+    render(<AddBookModal onClose={onClose} onAdded={onAdded} />)
+
+    fireEvent.change(screen.getByPlaceholderText(/Title or ISBN/i), {
+      target: { value: 'qzznomatch' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/no results found/i)).toBeInTheDocument()
+    )
+  })
+})

--- a/web/src/components/AddBookModal.tsx
+++ b/web/src/components/AddBookModal.tsx
@@ -27,7 +27,9 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
         setResults([book])
       } else {
         const books = await api.searchBooks(q)
-        setResults(books)
+        // Guard against a `null` body (e.g. an empty search the backend
+        // encoded as `null` instead of `[]`) so the render's `.map()` can't crash.
+        setResults(books ?? [])
       }
     } catch (err) {
       setSearchError(err instanceof Error ? err.message : 'Search failed')


### PR DESCRIPTION
## Problem

The Add Book modal crashed with `TypeError: Cannot read properties of null (reading 'map')` when an empty metadata book search returned no results.

Root cause is two layers:
1. **Backend** — `Aggregator.SearchBooks` built `merged` as a nil slice and returned it on empty success. A nil Go slice JSON-encodes as `null`, so `/api/v1/search/book` returned `null` instead of `[]`.
2. **Frontend** — `AddBookModal` did `setResults(books)` directly, so `results` became `null` and the render's `results.map(...)` threw.

## Fix (defense in depth)

- **Backend**: `SearchBooks` now returns a non-nil `[]models.Book{}` on empty success and on the no-providers early return, so the JSON body is `[]`.
- **Frontend**: the modal coerces a null/undefined result to an empty array (`books ?? []`), rendering the existing "No results found." empty state.

## Tests

- Go: `TestSearchBooksEmptyIsArray` asserts the handler body is `[]` (not `null`) and the aggregator returns a non-nil slice for empty success.
- Frontend: `AddBookModal.test.tsx` asserts the modal renders "No results found." when `searchBooks` resolves to `null` (verified it fails without the guard).

## Verification

`go build ./... && go vet ./...` clean, `go test ./internal/metadata/ ./internal/api/` passes. In `web/`: typecheck, build, lint (0 errors), and the new test all pass.

Closes #1188

🤖 Generated with [Claude Code](https://claude.com/claude-code)