### PR TITLE
fix(author): exclude unmonitored from Wanted filter + add select-all (#1173, #1172)

### DIFF
--- a/changelog.d/1172-1173-author-page-filter-selectall.md
+++ b/changelog.d/1172-1173-author-page-filter-selectall.md
@@ -1,0 +1,5 @@
+### Fixed
+- **"Wanted" filter no longer shows unmonitored books** (#1173) — on the author page, the "Status: Wanted" filter now lists only genuinely wanted books (monitored and not yet imported). An unmonitored book carrying a stale `wanted` status is excluded, matching the status badge and the backend's wanted filter.
+
+### Added
+- **Select all / deselect all on the author page** (#1172) — the author page filter bar gains a single toggle that selects or deselects every currently displayed book for bulk actions. It respects the active filters, so it composes with the Wanted filter and only ever sweeps up visible books.

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -165,7 +165,9 @@
       "deleteConfirm": "Delete {{count}} book(s)? Files on disk are not removed.",
       "success": "{{action}} applied to {{count}} book(s).",
       "partial": "{{action}}: {{ok}} of {{total}} succeeded. First error: {{error}}",
-      "failed": "Bulk {{action}} failed: {{error}}"
+      "failed": "Bulk {{action}} failed: {{error}}",
+      "selectAll": "Select all",
+      "deselectAll": "Deselect all"
     }
   },
   "books": {

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -510,6 +510,60 @@ describe('AuthorDetailPage', () => {
     })
   })
 
+  it('excludes unmonitored books from the Wanted status filter (#1173)', async () => {
+    renderAuthorDetailPage(
+      [
+        makeBook({ id: 301, title: 'Genuinely Wanted', status: 'wanted', monitored: true }),
+        makeBook({ id: 302, title: 'Stale Wanted Unmonitored', status: 'wanted', monitored: false }),
+        makeBook({ id: 303, title: 'Already Imported', status: 'imported', monitored: true }),
+      ],
+      'table',
+    )
+
+    await screen.findByText('Genuinely Wanted')
+
+    // Apply the Wanted status filter.
+    fireEvent.click(screen.getByRole('button', { name: 'Wanted' }))
+
+    // Monitored wanted book stays; unmonitored "wanted" and imported drop out.
+    expect(screen.getByText('Genuinely Wanted')).toBeInTheDocument()
+    expect(screen.queryByText('Stale Wanted Unmonitored')).not.toBeInTheDocument()
+    expect(screen.queryByText('Already Imported')).not.toBeInTheDocument()
+  })
+
+  it('select-all toggles every displayed book and respects the active filter (#1172)', async () => {
+    vi.mocked(api.bulkActionBooks).mockResolvedValue({
+      results: { '401': { ok: true } },
+    })
+    renderAuthorDetailPage(
+      [
+        makeBook({ id: 401, title: 'Wanted Monitored', status: 'wanted', monitored: true }),
+        makeBook({ id: 402, title: 'Imported Book', status: 'imported', monitored: true }),
+      ],
+      'table',
+    )
+
+    await screen.findByText('Wanted Monitored')
+
+    // With no filter, Select all picks every book on the page.
+    fireEvent.click(screen.getByRole('button', { name: 'Select all' }))
+    expect(await screen.findByText('2 selected')).toBeInTheDocument()
+    // Toggle flips to Deselect all; clicking it clears the whole selection.
+    fireEvent.click(screen.getByRole('button', { name: 'Deselect all' }))
+    await waitFor(() => expect(screen.queryByText('2 selected')).not.toBeInTheDocument())
+
+    // Now narrow to just the wanted book and Select all again: selection must
+    // cover only the filtered (displayed) book, not the hidden imported one.
+    fireEvent.click(screen.getByRole('button', { name: 'Wanted' }))
+    expect(screen.queryByText('Imported Book')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select all' }))
+    expect(await screen.findByText('1 selected')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Monitor' }))
+    await waitFor(() => expect(api.bulkActionBooks).toHaveBeenCalledWith([401], 'monitor'))
+  })
+
   it('groups books by series with a Standalone group when the toggle is on', async () => {
     vi.mocked(api.listAuthorSeries).mockResolvedValue([
       {

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -328,7 +328,16 @@ export default function AuthorDetailPage() {
   const filteredBooks = useMemo(() => {
     let list = books
     if (typeFilter) list = list.filter(b => (b.mediaType || 'ebook') === typeFilter)
-    if (statusFilter) list = list.filter(b => b.status === statusFilter)
+    if (statusFilter) {
+      // "Wanted" means genuinely wanted: monitored AND status=wanted. An
+      // unmonitored book can carry a stale `wanted` status (#1173) but is not
+      // actually wanted, so it must be excluded — mirroring the backend's
+      // BookListFilter ("wanted" additionally requires monitored=1) and the
+      // monitored-aware status badge.
+      list = statusFilter === 'wanted'
+        ? list.filter(b => b.status === 'wanted' && b.monitored)
+        : list.filter(b => b.status === statusFilter)
+    }
     if (publishedFilter === 'released') {
       list = list.filter(b => !b.releaseDate || b.releaseDate.slice(0, 10) <= TODAY)
     } else if (publishedFilter === 'upcoming') {
@@ -798,6 +807,19 @@ export default function AuthorDetailPage() {
             <button onClick={() => setPublishedFilter('')} className={chipCls(publishedFilter === '')}>All</button>
             <button onClick={() => setPublishedFilter('released')} className={chipCls(publishedFilter === 'released')}>Released</button>
             <button onClick={() => setPublishedFilter('upcoming')} className={chipCls(publishedFilter === 'upcoming')}>Upcoming</button>
+
+            {/* Select/deselect every currently displayed book (#1172). Operates on
+                filteredBooks, so it respects the active filters above and composes
+                with the per-book checkboxes used by the bulk action bar. */}
+            {filteredBooks.length > 0 && (
+              <button
+                onClick={() => allVisibleSelected ? clearSelection() : selectAllVisible()}
+                className={`${chipCls(false)} ml-auto`}
+                aria-pressed={allVisibleSelected}
+              >
+                {allVisibleSelected ? t('authorDetail.bulk.deselectAll') : t('authorDetail.bulk.selectAll')}
+              </button>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Two fixes on the Author detail page, both in `web/src/pages/AuthorDetailPage.tsx`.

### Task A — Wanted filter excludes unmonitored (#1173)
The "Status: Wanted" filter matched any book with `status === 'wanted'` regardless of monitored state, so an unmonitored book carrying a stale `wanted` status still showed under "Wanted". The filter now requires `monitored` for the wanted case, matching:
- the monitored-aware status badge (`bookStatus.ts`, which renders unmonitored-wanted as "Not monitored"), and
- the backend `BookListFilter` (`internal/db/books.go`: "wanted" additionally requires `monitored = 1`).

### Task B — Select all / deselect all (#1172)
Adds a single Select all / Deselect all toggle to the filter bar. It operates on `filteredBooks` (the currently displayed set), so it respects the active filters and only ever selects visible books for the existing bulk-action bar. Composes correctly with the Wanted filter from Task A.

## Notes
- All user-facing strings go through `t()`; new keys `authorDetail.bulk.selectAll` / `deselectAll` added to `en.json`.
- New colour utilities reuse the existing `chipCls` helper (already dark-mode paired).

## Tests / verify
- Added 2 vitest cases: Wanted filter excludes an unmonitored book; select-all toggles all displayed books and respects the active filter.
- `npm run typecheck`, `npm run build`, `npm run lint` (0 errors), and full `npm test` (346 passing) all green.

Closes #1173
Closes #1172

🤖 Generated with [Claude Code](https://claude.com/claude-code)