### PR TITLE
fix(settings): stop naming-template empty-error firing on load (supersedes #1141)

### DIFF
--- a/changelog.d/naming-template-touched-validation.md
+++ b/changelog.d/naming-template-touched-validation.md
@@ -1,0 +1,2 @@
+### Fixed
+- **File Naming settings** — "Template cannot be empty" validation error no longer appears on page load when no template has been saved yet (the server uses a built-in default for empty templates, so the error was a false alarm until the field is actually edited).

--- a/web/src/pages/settings/NamingTemplateField.test.tsx
+++ b/web/src/pages/settings/NamingTemplateField.test.tsx
@@ -150,6 +150,16 @@ describe('NamingTemplateField component', () => {
     expect(save.disabled).toBe(true)
   })
 
+  it('shows content errors for a non-empty saved template on initial load (no interaction)', () => {
+    // A persisted but invalid template is a real misconfiguration: unlike the
+    // empty-default case, its error must be visible immediately, not gated
+    // behind touch.
+    render(<Harness initial="{Bogus}/{Title}" />)
+    expect(screen.getByText(/errorUnknownTokens.*\{Bogus\}/)).toBeTruthy()
+    const save = screen.getByRole('button', { name: 'common.save' }) as HTMLButtonElement
+    expect(save.disabled).toBe(true)
+  })
+
   it('blocks save on an empty template', () => {
     render(<Harness initial="" />)
     const input = screen.getByPlaceholderText('placeholder')

--- a/web/src/pages/settings/NamingTemplateField.test.tsx
+++ b/web/src/pages/settings/NamingTemplateField.test.tsx
@@ -143,6 +143,8 @@ describe('NamingTemplateField component', () => {
 
   it('warns on an unknown token and disables save', () => {
     render(<Harness initial="{Bogus}/{Title}" />)
+    const input = screen.getByPlaceholderText('placeholder')
+    fireEvent.blur(input)
     expect(screen.getByText(/errorUnknownTokens.*\{Bogus\}/)).toBeTruthy()
     const save = screen.getByRole('button', { name: 'common.save' }) as HTMLButtonElement
     expect(save.disabled).toBe(true)
@@ -150,7 +152,17 @@ describe('NamingTemplateField component', () => {
 
   it('blocks save on an empty template', () => {
     render(<Harness initial="" />)
+    const input = screen.getByPlaceholderText('placeholder')
+    fireEvent.blur(input)
     expect(screen.getByText('settings.general.naming.errorEmpty')).toBeTruthy()
+    const save = screen.getByRole('button', { name: 'common.save' }) as HTMLButtonElement
+    expect(save.disabled).toBe(true)
+  })
+
+  it('does not show validation errors on initial load with an empty (default) value', () => {
+    render(<Harness initial="" />)
+    expect(screen.queryByText('settings.general.naming.errorEmpty')).toBeNull()
+    // Save is still disabled even without the error message visible.
     const save = screen.getByRole('button', { name: 'common.save' }) as HTMLButtonElement
     expect(save.disabled).toBe(true)
   })

--- a/web/src/pages/settings/NamingTemplateField.tsx
+++ b/web/src/pages/settings/NamingTemplateField.tsx
@@ -6,7 +6,7 @@
 // which mirrors the Go renamer (internal/importer/renamer.go) so the preview
 // matches what the importer actually writes.
 
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { inputCls, labelCls } from './formStyles'
 import {
@@ -39,6 +39,7 @@ export default function NamingTemplateField({
 }: NamingTemplateFieldProps) {
   const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement>(null)
+  const [touched, setTouched] = useState(false)
 
   const validation = validateTemplate(value)
   const preview = renderTemplate(value, kind)
@@ -78,7 +79,7 @@ export default function NamingTemplateField({
             <button
               key={tok.token}
               type="button"
-              onClick={() => !greyed && insertToken(tok.token)}
+              onClick={() => { if (!greyed) { setTouched(true); insertToken(tok.token) } }}
               disabled={greyed}
               title={
                 greyed
@@ -101,9 +102,10 @@ export default function NamingTemplateField({
         <input
           ref={inputRef}
           value={value}
-          onChange={e => onChange(e.target.value)}
+          onChange={e => { setTouched(true); onChange(e.target.value) }}
+          onBlur={() => setTouched(true)}
           placeholder={placeholder}
-          aria-invalid={hasErrors}
+          aria-invalid={touched && hasErrors}
           className={inputCls + ' flex-1 font-mono'}
         />
         <button
@@ -131,18 +133,18 @@ export default function NamingTemplateField({
         </p>
       )}
 
-      {/* Validation feedback */}
-      {validation.empty && (
+      {/* Validation feedback — only after user interaction */}
+      {touched && validation.empty && (
         <p className="text-xs text-red-600 dark:text-red-400 mt-1.5" role="alert">
           {t('settings.general.naming.errorEmpty')}
         </p>
       )}
-      {validation.traversal && (
+      {touched && validation.traversal && (
         <p className="text-xs text-red-600 dark:text-red-400 mt-1.5" role="alert">
           {t('settings.general.naming.errorTraversal')}
         </p>
       )}
-      {validation.unknownTokens.length > 0 && (
+      {touched && validation.unknownTokens.length > 0 && (
         <p className="text-xs text-amber-600 dark:text-amber-400 mt-1.5" role="alert">
           {t('settings.general.naming.errorUnknownTokens', {
             tokens: validation.unknownTokens.join(', '),

--- a/web/src/pages/settings/NamingTemplateField.tsx
+++ b/web/src/pages/settings/NamingTemplateField.tsx
@@ -45,6 +45,14 @@ export default function NamingTemplateField({
   const preview = renderTemplate(value, kind)
   const hasErrors =
     validation.empty || validation.traversal || validation.unknownTokens.length > 0
+  // The "empty" error is a false alarm on initial load: an unset template means
+  // the server falls back to a compiled-in default, so only surface it once the
+  // user has actually interacted. A NON-empty saved template that fails
+  // validation (traversal / unknown tokens) is a real, pre-existing
+  // misconfiguration and must be shown immediately on load, not hidden behind
+  // `touched` — hence those errors gate on a non-empty value instead.
+  const showInteractionErrors = touched
+  const showContentErrors = touched || value.trim() !== ''
 
   // Insert a token at the caret (or replace the current selection). Falls back
   // to appending when the input is not focused.
@@ -105,7 +113,7 @@ export default function NamingTemplateField({
           onChange={e => { setTouched(true); onChange(e.target.value) }}
           onBlur={() => setTouched(true)}
           placeholder={placeholder}
-          aria-invalid={touched && hasErrors}
+          aria-invalid={showContentErrors && hasErrors}
           className={inputCls + ' flex-1 font-mono'}
         />
         <button
@@ -133,18 +141,21 @@ export default function NamingTemplateField({
         </p>
       )}
 
-      {/* Validation feedback — only after user interaction */}
-      {touched && validation.empty && (
+      {/* Validation feedback. The empty-template error is suppressed until the
+          field is touched (an unset template legitimately means "use the server
+          default"); content errors on a non-empty saved template surface
+          immediately so a real misconfiguration isn't hidden on load. */}
+      {showInteractionErrors && validation.empty && (
         <p className="text-xs text-red-600 dark:text-red-400 mt-1.5" role="alert">
           {t('settings.general.naming.errorEmpty')}
         </p>
       )}
-      {touched && validation.traversal && (
+      {showContentErrors && validation.traversal && (
         <p className="text-xs text-red-600 dark:text-red-400 mt-1.5" role="alert">
           {t('settings.general.naming.errorTraversal')}
         </p>
       )}
-      {touched && validation.unknownTokens.length > 0 && (
+      {showContentErrors && validation.unknownTokens.length > 0 && (
         <p className="text-xs text-amber-600 dark:text-amber-400 mt-1.5" role="alert">
           {t('settings.general.naming.errorUnknownTokens', {
             tokens: validation.unknownTokens.join(', '),


### PR DESCRIPTION
Lands @hazeledmands's fix from #1141 with a narrower validation gate.

**Original fix (#1141):** the File Naming settings page showed "Template cannot be empty" immediately on load, because the server returns an empty string for a never-set template (the renamer falls back to a compiled-in default at import time). #1141 gated *all* validation feedback behind a `touched` state.

**Why narrower:** gating `traversal` and `unknownTokens` behind `touched` too would hide a *real* problem — an already-saved template that contains a path-traversal segment or an unknown token would show no warning on load until the user happened to interact with the field. Only the empty-template error is a genuine false alarm at load (empty == "use default").

**This PR:**
- Empty-template error: suppressed until the field is touched (the #1141 behaviour).
- Traversal / unknown-token errors: shown immediately whenever the value is non-empty, touched or not — so a saved misconfiguration surfaces on load.
- Save stays disabled for any invalid template regardless, as before.
- Adds a test asserting a non-empty invalid template warns on initial load with no interaction.

Co-authored-by: Hazel <hazeledmands@gmail.com>

Closes #1141