### PR TITLE
fix(auth): surface transient DB error in session-epoch check instead of silent logout

### DIFF
--- a/changelog.d/session-epoch-transient-error.md
+++ b/changelog.d/session-epoch-transient-error.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Spurious logout on a database blip** — a transient database error while checking a session's epoch no longer silently invalidates a valid session cookie. The auth middleware now distinguishes a real "session revoked" epoch mismatch from a failed lookup and returns a server error (500) on the latter, instead of dropping the request to unauthenticated and logging the user out.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -1333,14 +1333,14 @@ func (p *dbAuthProvider) UserRole(ctx context.Context, userID int64) string {
 // the cookie payload must match for the auth middleware to accept it. Bumped
 // inside UpdatePassword so a password change immediately evicts every
 // outstanding cookie for that user (Wave 1 / Bundle C audit finding).
-// Returns 0 on lookup failure or missing user — that fails closed against
-// any cookie minted after the 047 migration (which defaults the column to 1).
-func (p *dbAuthProvider) UserSessionEpoch(ctx context.Context, userID int64) int64 {
-	epoch, err := p.users.GetSessionEpoch(ctx, userID)
-	if err != nil {
-		return 0
-	}
-	return epoch
+//
+// The error is propagated rather than swallowed: a transient DB failure here
+// previously returned epoch 0, which the middleware read as a mismatch and
+// silently logged out users holding a valid cookie (cookies minted after the
+// 047 migration carry epoch >= 1). The middleware now treats a non-nil error
+// as a server-side failure (5xx) instead of a forced logout.
+func (p *dbAuthProvider) UserSessionEpoch(ctx context.Context, userID int64) (int64, error) {
+	return p.users.GetSessionEpoch(ctx, userID)
 }
 func (p *dbAuthProvider) UserProvisioner() auth.UserProvisioner {
 	return &dbUserProvisioner{users: p.users}

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -643,9 +643,8 @@ func (p *epochProvider) UserRole(ctx context.Context, id int64) string {
 	}
 	return u.Role
 }
-func (p *epochProvider) UserSessionEpoch(ctx context.Context, id int64) int64 {
-	e, _ := p.users.GetSessionEpoch(ctx, id)
-	return e
+func (p *epochProvider) UserSessionEpoch(ctx context.Context, id int64) (int64, error) {
+	return p.users.GetSessionEpoch(ctx, id)
 }
 
 // extractSessionCookie returns the session cookie set on the response, or nil

--- a/internal/api/opds_test.go
+++ b/internal/api/opds_test.go
@@ -141,7 +141,7 @@ func (p *testProvider) UserRole(_ context.Context, _ int64) string { return "adm
 // cookies via SignSession (legacy v2/v1 wrapper) which decode as epoch=0, so
 // returning 0 keeps every existing cookie test passing. The dedicated
 // password-change/epoch-bump integration tests live elsewhere.
-func (p *testProvider) UserSessionEpoch(_ context.Context, _ int64) int64 { return 0 }
+func (p *testProvider) UserSessionEpoch(_ context.Context, _ int64) (int64, error) { return 0, nil }
 func (p *testProvider) UserProvisioner() auth.UserProvisioner {
 	return nil // proxy auth not exercised in these tests
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -246,6 +247,10 @@ type fakeProvider struct {
 	// legacy v1/v2 test cookies (which decode as epoch=0) authenticate
 	// without every test having to mint v3 cookies.
 	wantEpoch int64
+	// epochErr, when non-nil, simulates a transient DB failure on the session
+	// epoch lookup. UserSessionEpoch returns it so the middleware exercises the
+	// "surface server error instead of silent logout" path.
+	epochErr error
 }
 
 func (f *fakeProvider) Mode() Mode            { return f.mode }
@@ -268,7 +273,9 @@ func (f *fakeProvider) UserProvisioner() UserProvisioner           { return f.pr
 // UserSessionEpoch defaults to 0 so legacy v1/v2 test cookies (which decode
 // as epoch=0) continue to authenticate. Tests that exercise the password-
 // change epoch-bump path override this via the wantEpoch field below.
-func (f *fakeProvider) UserSessionEpoch(_ context.Context, _ int64) int64 { return f.wantEpoch }
+func (f *fakeProvider) UserSessionEpoch(_ context.Context, _ int64) (int64, error) {
+	return f.wantEpoch, f.epochErr
+}
 
 // staticProvisioner always returns the same user ID for any username.
 type staticProvisioner struct{ uid int64 }
@@ -367,6 +374,108 @@ func TestMiddlewareAcceptsValidSessionCookie(t *testing.T) {
 	}
 	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: cookie})
 	h.ServeHTTP(nopWriter{}, req)
+	if gotUID != 7 {
+		t.Errorf("uid = %d; want 7", gotUID)
+	}
+}
+
+// TestMiddlewareSessionEpochTransientErrorFailsServerSide proves a transient DB
+// error on the session-epoch lookup is surfaced as a 500 rather than silently
+// dropping a valid cookie to unauthenticated. Without the fix the lookup
+// returned epoch 0, the (0 == 1) comparison failed, and the user was logged out
+// (401) by a mere DB blip.
+func TestMiddlewareSessionEpochTransientErrorFailsServerSide(t *testing.T) {
+	secret := testSecret32
+	p := &fakeProvider{
+		mode:      ModeEnabled,
+		secret:    secret,
+		wantEpoch: 1,
+		epochErr:  errors.New("database is locked"),
+	}
+	mw := Middleware(p)
+	nextCalled := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+	}))
+
+	// A genuinely valid cookie carrying the live epoch (1).
+	cookie, err := SignSessionWithEpoch(secret, 7, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: cookie})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if nextCalled {
+		t.Error("handler should not run when epoch lookup errors")
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d; want %d (transient DB error must surface as 5xx, not a silent logout)",
+			rec.Code, http.StatusInternalServerError)
+	}
+	if rec.Code == http.StatusUnauthorized || rec.Code == http.StatusOK {
+		t.Errorf("status = %d; a DB blip must not log a valid cookie out", rec.Code)
+	}
+}
+
+// TestMiddlewareSessionEpochMismatchLogsOut confirms the genuine-revocation path
+// is unchanged: a cookie whose epoch differs from the user's current epoch (with
+// no lookup error) is rejected with 401, exactly as before.
+func TestMiddlewareSessionEpochMismatchLogsOut(t *testing.T) {
+	secret := testSecret32
+	p := &fakeProvider{
+		mode:      ModeEnabled,
+		secret:    secret,
+		wantEpoch: 2, // current epoch advanced past the cookie's epoch
+	}
+	mw := Middleware(p)
+	nextCalled := false
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		nextCalled = true
+	}))
+
+	cookie, err := SignSessionWithEpoch(secret, 7, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: cookie})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if nextCalled {
+		t.Error("handler should not run for a revoked (epoch-mismatched) cookie")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d; want %d (genuine epoch mismatch is a logout)", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+// TestMiddlewareSessionEpochMatchAuthenticates confirms the happy path: a cookie
+// whose epoch matches the user's current epoch (no error) authenticates.
+func TestMiddlewareSessionEpochMatchAuthenticates(t *testing.T) {
+	secret := testSecret32
+	p := &fakeProvider{mode: ModeEnabled, secret: secret, wantEpoch: 1}
+	mw := Middleware(p)
+	var gotUID int64
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotUID = UserIDFromContext(r.Context())
+	}))
+
+	cookie, err := SignSessionWithEpoch(secret, 7, 1, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	req, _ := http.NewRequest("GET", "/api/v1/author", nil)
+	req.AddCookie(&http.Cookie{Name: SessionCookieName, Value: cookie})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d; want 200 for a matching-epoch cookie", rec.Code)
+	}
 	if gotUID != 7 {
 		t.Errorf("uid = %d; want 7", gotUID)
 	}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -215,11 +215,18 @@ type Provider interface {
 	UserRole(ctx context.Context, userID int64) string
 	// UserSessionEpoch returns the user's current session epoch, the value
 	// the cookie's epoch field must match for the cookie to authenticate.
-	// Bumped on password change so old cookies stop verifying. Returns 0 if
-	// the user does not exist or the lookup fails — the comparison below then
-	// fails closed for any cookie minted after the 047 migration (which sets
-	// session_epoch to >= 1 by default).
-	UserSessionEpoch(ctx context.Context, userID int64) int64
+	// Bumped on password change so old cookies stop verifying.
+	//
+	// The returned error distinguishes a transient lookup failure (DB blip)
+	// from a genuine "user gone / epoch advanced" rejection. On a non-nil
+	// error the caller MUST NOT treat the cookie as merely invalid and drop to
+	// unauthenticated — that would silently log out a user holding a valid
+	// cookie whenever the DB hiccups. Instead the request is failed with a
+	// server error so the blip surfaces as a 5xx rather than a spurious logout.
+	// When err is nil the int64 is authoritative: a value that differs from the
+	// cookie's epoch is a real mismatch (revoked cookie) and the user is logged
+	// out exactly as before.
+	UserSessionEpoch(ctx context.Context, userID int64) (int64, error)
 }
 
 // AllowUnauthPath reports whether the given method+path combination must always
@@ -271,6 +278,13 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 			// handlers (like /auth/status) can report "authenticated: true".
 			ctx := r.Context()
 			cookieValid := false
+			// epochLookupFailed records a transient DB failure while looking up
+			// the user's current session epoch. We cannot prove the cookie's
+			// epoch matches, but we also must not treat that as a genuine
+			// mismatch and silently log the user out (a DB blip is not a
+			// credential revocation). When set, an otherwise-unauthenticated
+			// request is answered with 500 instead of 401 below.
+			epochLookupFailed := false
 			if c, err := r.Cookie(SessionCookieName); err == nil {
 				if uid, epoch, err := VerifySessionMultiWithEpoch(p.SessionSecrets(), c.Value); err == nil {
 					// Compare the cookie's epoch field against the user's
@@ -283,7 +297,16 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 					// cookies decode as epoch=0; the migration default of 1
 					// makes them all fail here on upgrade, which is the
 					// deliberate forced-logout-on-upgrade behaviour.
-					if p.UserSessionEpoch(ctx, uid) == epoch {
+					curEpoch, epochErr := p.UserSessionEpoch(ctx, uid)
+					switch {
+					case epochErr != nil:
+						// Transient lookup failure — do not authenticate, but do
+						// not treat as a revoked cookie either. Flag it so an
+						// otherwise-unauthenticated request fails with 500 rather
+						// than silently logging the user out on a DB blip.
+						slog.Error("session epoch lookup failed", "user_id", uid, "error", epochErr)
+						epochLookupFailed = true
+					case curEpoch == epoch:
 						ctx = context.WithValue(ctx, userIDCtxKey, uid)
 						ctx = context.WithValue(ctx, userRoleCtxKey, p.UserRole(ctx, uid))
 						cookieValid = true
@@ -346,6 +369,21 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 			}
 			if cookieValid {
 				next.ServeHTTP(w, r)
+				return
+			}
+
+			// A transient DB error prevented us from confirming the cookie's
+			// session epoch. The cookie may well be valid — we just couldn't
+			// check — so the request would otherwise be rejected as
+			// unauthenticated, silently logging the user out on a DB blip. None
+			// of the path-based bypasses above applied (those already returned),
+			// so surface this as a server error instead of a spurious 401.
+			if epochLookupFailed {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				if _, err := w.Write([]byte(`{"error":"internal error"}`)); err != nil {
+					slog.Warn("failed to write internal error response", "error", err)
+				}
 				return
 			}
 


### PR DESCRIPTION
## Bug

The auth middleware (`internal/auth/middleware.go`) compares a session cookie's epoch field against the user's current `session_epoch` to enforce the "log everyone out on password change" check. The provider implementation (`dbAuthProvider.UserSessionEpoch` in `cmd/bindery/main.go`) **swallowed any DB error** from `GetSessionEpoch` and returned `0`.

Cookies minted after migration 047 carry `epoch >= 1`. So on a transient DB failure the comparison became `0 == epoch` → `false`, which is indistinguishable from a genuine epoch mismatch. The result: a perfectly valid session cookie was **silently rejected and the user logged out (401/redirect)** because of a momentary DB blip, instead of the request failing with a 5xx.

## Fix

- `Provider.UserSessionEpoch` now returns `(int64, error)`.
- `dbAuthProvider.UserSessionEpoch` propagates the DB error instead of coercing it to `0`.
- The middleware distinguishes the two cases:
  - **non-nil error** → log it and surface a `500` (the request can't be authenticated *or* safely rejected, so it fails server-side) rather than dropping to unauthenticated.
  - **epoch mismatch, no error** → unchanged: genuine revocation, user logged out exactly as before.
  - **matching epoch** → unchanged: authenticated.
- Path-based bypasses (health/auth endpoints, disabled mode, local-only, API key, valid cookie) still short-circuit *before* the new 500, so a DB blip never blocks unauth-allowed paths or already-authenticated requests.

## Tests

Added `internal/auth/auth_test.go` cases:
- `TestMiddlewareSessionEpochTransientErrorFailsServerSide` — transient error yields 500, not a silent logout / not 200.
- `TestMiddlewareSessionEpochMismatchLogsOut` — genuine mismatch still 401.
- `TestMiddlewareSessionEpochMatchAuthenticates` — happy path still authenticates.

`go build ./...`, `go vet ./...` clean; `go test ./internal/auth/... ./internal/api/... ./cmd/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)