### PR TITLE
feat(search): support Audible ASIN lookup in Add Book (#1189)

### DIFF
--- a/changelog.d/1189-add-book-asin-lookup.md
+++ b/changelog.d/1189-add-book-asin-lookup.md
@@ -1,0 +1,2 @@
+### Added
+- **Add Book searches by Audible ASIN** (#1189) — entering a 10-character ASIN such as `B0DBJBFHGT` in **Authors → Add Book** now resolves the Audible edition directly (via the existing ASIN resolver) and returns one addable audiobook result with the ASIN preserved, instead of falling through to an unreliable title search. ISBN and title searches are unchanged.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -751,7 +751,7 @@ func main() {
 		// Metadata search
 		r.Get("/search/author", searchHandler.SearchAuthors)
 		r.Get("/search/book", searchHandler.SearchBooks)
-		r.Get("/book/lookup", searchHandler.LookupByISBN)
+		r.Get("/book/lookup", searchHandler.Lookup)
 
 		// Authors
 		r.Get("/author", authorHandler.List)

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
 )
 
 type SearchHandler struct {
@@ -68,13 +70,25 @@ func (h *SearchHandler) SearchBooks(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, books)
 }
 
-func (h *SearchHandler) LookupByISBN(w http.ResponseWriter, r *http.Request) {
+// Lookup resolves a single book by a stable identifier passed as a query
+// param: either `isbn` (the original behavior) or `asin` (an Audible/audiobook
+// identifier). The route is shared (`/book/lookup`) so existing ISBN callers
+// keep working unchanged.
+func (h *SearchHandler) Lookup(w http.ResponseWriter, r *http.Request) {
+	asin := strings.TrimSpace(r.URL.Query().Get("asin"))
 	isbn := r.URL.Query().Get("isbn")
-	if isbn == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "isbn parameter required"})
-		return
-	}
 
+	switch {
+	case asin != "":
+		h.lookupByASIN(w, r, asin)
+	case isbn != "":
+		h.lookupByISBN(w, r, isbn)
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "isbn or asin parameter required"})
+	}
+}
+
+func (h *SearchHandler) lookupByISBN(w http.ResponseWriter, r *http.Request, isbn string) {
 	book, err := h.meta.GetBookByISBN(r.Context(), isbn)
 	if err != nil {
 		writeUpstreamError(w, err)
@@ -86,6 +100,31 @@ func (h *SearchHandler) LookupByISBN(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+
+	writeJSON(w, http.StatusOK, book)
+}
+
+func (h *SearchHandler) lookupByASIN(w http.ResponseWriter, r *http.Request, asin string) {
+	book, err := h.meta.GetCanonicalBookByASIN(r.Context(), asin)
+	if err != nil {
+		writeUpstreamError(w, err)
+		return
+	}
+	if book == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"error": fmt.Sprintf("No book found for ASIN %s. Check the identifier, or try searching by title instead.", asin),
+		})
+		return
+	}
+
+	// The resolver canonicalizes the ASIN against the primary provider, so the
+	// returned book carries the canonical foreignBookId (keep it) but loses the
+	// ASIN-origin shape. Re-stamp the ASIN and audiobook media type so the Add
+	// Book modal renders it as the audiobook edition the user searched for.
+	if book.ASIN == "" {
+		book.ASIN = asin
+	}
+	book.MediaType = models.MediaTypeAudiobook
 
 	writeJSON(w, http.StatusOK, book)
 }

--- a/internal/api/search_test.go
+++ b/internal/api/search_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/metadata/audnex"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -162,20 +163,25 @@ func TestSearchBooksEmptyIsArray(t *testing.T) {
 	}
 }
 
-func TestLookupByISBN(t *testing.T) {
+func TestLookup_ISBN(t *testing.T) {
 	p := &stubProvider{byISBN: &models.Book{Title: "Hyperion", Description: "A long-enough description to skip the enrichment branch in the aggregator."}}
 	h := NewSearchHandler(metadata.NewAggregator(p))
 
-	// Missing isbn
+	// Neither isbn nor asin → 400 naming both params.
 	rec := httptest.NewRecorder()
-	h.LookupByISBN(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/isbn", nil))
+	h.Lookup(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book/lookup", nil))
 	if rec.Code != http.StatusBadRequest {
-		t.Errorf("missing isbn: expected 400, got %d", rec.Code)
+		t.Errorf("missing params: expected 400, got %d", rec.Code)
+	}
+	var errBody map[string]string
+	json.NewDecoder(rec.Body).Decode(&errBody)
+	if msg := errBody["error"]; !strings.Contains(msg, "isbn") || !strings.Contains(msg, "asin") {
+		t.Errorf("400 message should name both params, got %q", msg)
 	}
 
-	// Success
+	// Success — ISBN path unchanged.
 	rec = httptest.NewRecorder()
-	h.LookupByISBN(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/isbn?isbn=9780553283686", nil))
+	h.Lookup(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book/lookup?isbn=9780553283686", nil))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rec.Code)
 	}
@@ -184,7 +190,7 @@ func TestLookupByISBN(t *testing.T) {
 	p2 := &stubProvider{byISBN: nil}
 	h2 := NewSearchHandler(metadata.NewAggregator(p2))
 	rec = httptest.NewRecorder()
-	h2.LookupByISBN(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/isbn?isbn=0000000000", nil))
+	h2.Lookup(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book/lookup?isbn=0000000000", nil))
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("not found: expected 404, got %d", rec.Code)
 	}
@@ -193,8 +199,74 @@ func TestLookupByISBN(t *testing.T) {
 	p3 := &stubProvider{byISBNErr: errors.New("net down")}
 	h3 := NewSearchHandler(metadata.NewAggregator(p3))
 	rec = httptest.NewRecorder()
-	h3.LookupByISBN(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search/isbn?isbn=fail", nil))
+	h3.Lookup(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book/lookup?isbn=fail", nil))
 	if rec.Code != http.StatusBadGateway {
 		t.Errorf("error: expected 502, got %d", rec.Code)
+	}
+}
+
+// stubAudnexClient drives the aggregator's ASIN canonicalization path without a
+// network call: GetBook returns the mapped audnex.Book for an ASIN, or nil.
+type stubAudnexClient struct {
+	books map[string]*audnex.Book
+}
+
+func (s *stubAudnexClient) GetBook(_ context.Context, asin string) (*audnex.Book, error) {
+	if s.books == nil {
+		return nil, nil
+	}
+	return s.books[asin], nil
+}
+
+// TestLookup_ASIN_Success proves the ?asin= path returns 200 with the canonical
+// book re-stamped into the ASIN-origin shape the Add Book modal expects: the
+// canonical foreignBookId is preserved, MediaType is audiobook, and the ASIN is
+// populated (the canonical OpenLibrary record carries neither on its own).
+func TestLookup_ASIN_Success(t *testing.T) {
+	primary := &stubProvider{
+		books:  []models.Book{{ForeignID: "OL-IRON", Title: "Iron Flame", EditionCount: 42, Author: &models.Author{Name: "Rebecca Yarros"}}},
+		byISBN: &models.Book{ForeignID: "OL-IRON", Title: "Iron Flame", Description: "Canonical OpenLibrary description for Iron Flame.", Author: &models.Author{Name: "Rebecca Yarros"}},
+	}
+	audnexClient := &stubAudnexClient{books: map[string]*audnex.Book{
+		"B0DBJBFHGT": {
+			ASIN:     "B0DBJBFHGT",
+			Title:    "Iron Flame",
+			Authors:  []audnex.Person{{Name: "Rebecca Yarros"}},
+			Language: "English",
+		},
+	}}
+	agg := metadata.NewAggregator(primary).WithAudnexClient(audnexClient)
+	h := NewSearchHandler(agg)
+
+	rec := httptest.NewRecorder()
+	h.Lookup(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book/lookup?asin=B0DBJBFHGT", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	var got models.Book
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.ForeignID != "OL-IRON" {
+		t.Errorf("expected canonical foreignBookId OL-IRON preserved, got %q", got.ForeignID)
+	}
+	if got.MediaType != models.MediaTypeAudiobook {
+		t.Errorf("expected mediaType %q, got %q", models.MediaTypeAudiobook, got.MediaType)
+	}
+	if got.ASIN != "B0DBJBFHGT" {
+		t.Errorf("expected ASIN populated, got %q", got.ASIN)
+	}
+}
+
+// TestLookup_ASIN_Miss proves a non-resolving ASIN returns 404 (the modal's
+// normal empty/error state), not a 500 or a crash.
+func TestLookup_ASIN_Miss(t *testing.T) {
+	agg := metadata.NewAggregator(&stubProvider{}).WithAudnexClient(&stubAudnexClient{})
+	h := NewSearchHandler(agg)
+
+	rec := httptest.NewRecorder()
+	h.Lookup(rec, httptest.NewRequest(http.MethodGet, "/api/v1/book/lookup?asin=B0NONEXIST", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("ASIN miss: expected 404, got %d (%s)", rec.Code, rec.Body.String())
 	}
 }

--- a/web/src/api/books.ts
+++ b/web/src/api/books.ts
@@ -110,6 +110,7 @@ export const booksApi = {
   searchAuthors: (term: string) => request<Author[]>(`/search/author?term=${encodeURIComponent(term)}`),
   searchBooks: (term: string) => request<Book[]>(`/search/book?term=${encodeURIComponent(term)}`),
   lookupISBN: (isbn: string) => request<Book>(`/book/lookup?isbn=${encodeURIComponent(isbn)}`),
+  lookupASIN: (asin: string) => request<Book>(`/book/lookup?asin=${encodeURIComponent(asin)}`),
 
   // Add a single book to wanted (adds author silently if new)
   addBook: (data: { foreignBookId: string; foreignAuthorId: string; authorName?: string; searchOnAdd?: boolean }) =>

--- a/web/src/components/AddBookModal.test.tsx
+++ b/web/src/components/AddBookModal.test.tsx
@@ -7,6 +7,7 @@ vi.mock('../api/client', () => ({
   api: {
     searchBooks: vi.fn(),
     lookupISBN: vi.fn(),
+    lookupASIN: vi.fn(),
     addBook: vi.fn(),
   },
 }))
@@ -28,7 +29,7 @@ describe('AddBookModal — null search results (#1188)', () => {
 
     render(<AddBookModal onClose={onClose} onAdded={onAdded} />)
 
-    fireEvent.change(screen.getByPlaceholderText(/Title or ISBN/i), {
+    fireEvent.change(screen.getByPlaceholderText(/Title, ISBN, or ASIN/i), {
       target: { value: 'qzznomatch' },
     })
     fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
@@ -36,5 +37,76 @@ describe('AddBookModal — null search results (#1188)', () => {
     await waitFor(() =>
       expect(screen.getByText(/no results found/i)).toBeInTheDocument()
     )
+  })
+})
+
+describe('AddBookModal — ASIN lookup (#1189)', () => {
+  const onClose = vi.fn()
+  const onAdded = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('routes an ASIN-shaped query to the ASIN lookup and renders the result', async () => {
+    vi.mocked(api.lookupASIN).mockResolvedValue({
+      foreignBookId: 'OL-IRON',
+      title: 'Iron Flame',
+      asin: 'B0DBJBFHGT',
+      mediaType: 'audiobook',
+      author: { authorName: 'Rebecca Yarros' },
+    } as never)
+
+    render(<AddBookModal onClose={onClose} onAdded={onAdded} />)
+
+    fireEvent.change(screen.getByPlaceholderText(/Title, ISBN, or ASIN/i), {
+      target: { value: 'b0dbjbfhgt' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText('Iron Flame')).toBeInTheDocument()
+    )
+    // ASIN lookup is called with the upper-cased token; not the title search.
+    expect(api.lookupASIN).toHaveBeenCalledWith('B0DBJBFHGT')
+    expect(api.searchBooks).not.toHaveBeenCalled()
+    // The result is addable.
+    expect(screen.getByRole('button', { name: /^add$/i })).toBeEnabled()
+  })
+
+  it('shows the normal empty state when the ASIN does not resolve', async () => {
+    vi.mocked(api.lookupASIN).mockRejectedValue(new Error('not found'))
+
+    render(<AddBookModal onClose={onClose} onAdded={onAdded} />)
+
+    fireEvent.change(screen.getByPlaceholderText(/Title, ISBN, or ASIN/i), {
+      target: { value: 'B0NONEXIST' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/not found/i)).toBeInTheDocument()
+    )
+    expect(api.searchBooks).not.toHaveBeenCalled()
+  })
+
+  it('still routes a plain title query to searchBooks', async () => {
+    vi.mocked(api.searchBooks).mockResolvedValue([
+      { foreignBookId: 'OL-DUNE', title: 'Dune', author: { authorName: 'Frank Herbert' } },
+    ] as never)
+
+    render(<AddBookModal onClose={onClose} onAdded={onAdded} />)
+
+    fireEvent.change(screen.getByPlaceholderText(/Title, ISBN, or ASIN/i), {
+      target: { value: 'Dune' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText('Dune')).toBeInTheDocument()
+    )
+    expect(api.searchBooks).toHaveBeenCalledWith('Dune')
+    expect(api.lookupASIN).not.toHaveBeenCalled()
+    expect(api.lookupISBN).not.toHaveBeenCalled()
   })
 })

--- a/web/src/components/AddBookModal.tsx
+++ b/web/src/components/AddBookModal.tsx
@@ -25,6 +25,11 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
       if (/^97[89]\d{10}$|^\d{9}[\dX]$/.test(q.replace(/[-\s]/g, ''))) {
         const book = await api.lookupISBN(q.replace(/[-\s]/g, ''))
         setResults([book])
+      } else if (/^B[0-9A-Z]{9}$/i.test(q)) {
+        // ASIN (Audible/Amazon) lookup — a 10-char token starting with B.
+        // Checked after ISBN; the two patterns don't overlap.
+        const book = await api.lookupASIN(q.toUpperCase())
+        setResults([book])
       } else {
         const books = await api.searchBooks(q)
         // Guard against a `null` body (e.g. an empty search the backend
@@ -65,7 +70,7 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
       <div className="bg-slate-100 dark:bg-zinc-900 border border-slate-300 dark:border-zinc-700 rounded-lg w-full max-w-lg shadow-2xl max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
         <div className="p-4 border-b border-slate-200 dark:border-zinc-800">
           <h3 className="text-lg font-semibold">Add Book</h3>
-          <p className="text-xs text-slate-500 dark:text-zinc-500 mt-0.5">Search by title or ISBN to add a specific book to your wanted list.</p>
+          <p className="text-xs text-slate-500 dark:text-zinc-500 mt-0.5">Search by title, ISBN, or ASIN to add a specific book to your wanted list.</p>
         </div>
 
         <div className="p-4 flex-1 overflow-y-auto">
@@ -88,7 +93,7 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
               value={query}
               onChange={e => setQuery(e.target.value)}
               onKeyDown={e => e.key === 'Enter' && search()}
-              placeholder="Title or ISBN (e.g. Dune, 9780441478125)"
+              placeholder="Title, ISBN, or ASIN (e.g. Dune, 9780441478125, B0DBJBFHGT)"
               className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
               autoFocus
             />


### PR DESCRIPTION
Closes #1189

## Summary
Adds Audible ASIN as a first-class **Authors → Add Book** lookup input. Entering an ASIN like `B0DBJBFHGT` now resolves the Audible edition directly instead of falling through to an unreliable title search.

## Backend
- Generalized the `/book/lookup` route: the handler `LookupByISBN` is renamed to `Lookup` and now reads **either** `?isbn=` (unchanged behavior) **or** `?asin=`. ISBN stays backward-compatible on the same path.
- The ASIN branch calls the existing `GetCanonicalBookByASIN` resolver (Audnex → primary-provider canonicalization). On a nil book it returns 404 with a helpful message; on upstream error it uses `writeUpstreamError` (502). On success it re-stamps the canonical result into the ASIN-origin shape: preserves the canonical `foreignBookId`, sets `mediaType=audiobook`, and populates `asin`.
- Neither param → 400 naming both params.

## Frontend
- `api.lookupASIN(asin)` added alongside `lookupISBN`.
- `AddBookModal` detects ASIN-shaped input (`/^B[0-9A-Z]{9}$/i`) after the ISBN check and calls `lookupASIN(q.toUpperCase())`. A non-resolving ASIN surfaces the normal empty/error state (the #1188 null-guard is preserved).
- Copy + placeholder updated from "Title or ISBN" to "Title, ISBN, or ASIN".

## Acceptance criteria
- [x] `B0DBJBFHGT` attempts an ASIN lookup instead of a generic title search.
- [x] A matching ASIN returns one addable result with audiobook media type and the ASIN preserved.
- [x] A non-matching ASIN shows the normal empty state, not an app error.
- [x] Existing ISBN and title searches continue to work.

## Tests
- Go: `internal/api` — ASIN success (200, mediaType=audiobook, asin populated, canonical foreignBookId kept), ASIN miss (404), ISBN still works, neither param (400). Existing `internal/metadata` ASIN resolver tests unchanged.
- Web: `AddBookModal.test.tsx` — ASIN-shaped query routes to `lookupASIN`, non-resolving ASIN shows empty state, title query still uses `searchBooks`.
- `go build ./... && go vet` clean; `go test ./internal/api/ ./internal/metadata/` pass; web `typecheck`, `build`, `lint` (0 errors), `npm test` (355 pass) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)