### PR TITLE
fix(metadata): page through all OpenLibrary author works (100-book cap)

### DIFF
--- a/changelog.d/openlibrary-author-works-pagination.md
+++ b/changelog.d/openlibrary-author-works-pagination.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Prolific authors capped at 100 books** — adding or refreshing an author from OpenLibrary fetched only the first page of the `/authors/{id}/works` endpoint, silently truncating any catalogue larger than 100 works. The works endpoint is now paged through to completion (bounded at 2000 works to keep pathological responses in check), so authors with hundreds of titles import their full catalogue. This is unrelated to the frontend list pagination fixed in #1011.

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -41,6 +41,15 @@ const (
 // the round-trip cheap (limit=N) rather than paging the full edition list.
 const editionLangSampleCap = 5
 
+// authorWorksPageSize is the per-request limit for the /authors/{id}/works
+// endpoint, and authorWorksMaxFetch bounds total pagination so an author with
+// an enormous (or maliciously inflated) catalogue can't trigger unbounded
+// requests. 2000 covers even the most prolific real authors at 20 requests.
+const (
+	authorWorksPageSize = 100
+	authorWorksMaxFetch = 2000
+)
+
 // Client implements the metadata.Provider interface for OpenLibrary.
 type Client struct {
 	http *http.Client
@@ -405,13 +414,44 @@ func (c *Client) searchAuthorWorks(ctx context.Context, authorForeignID string) 
 // authorWorksBackfill fetches the author's works list from OpenLibrary's
 // /authors/{id}/works endpoint. The raw entries are returned so the caller
 // can decide how to merge them with the primary search-index results.
+//
+// The endpoint is paginated: it returns at most authorWorksPageSize entries
+// per call and advertises the catalogue total in the response's Size field.
+// Previously only the first page was fetched, so authors with more than one
+// page of works had their catalogue silently truncated (issue: users seeing a
+// hard cap of 100 books on prolific authors). We now page through until the
+// catalogue is exhausted, bounded by authorWorksMaxFetch to keep pathological
+// or maliciously large responses from running away.
 func (c *Client) authorWorksBackfill(ctx context.Context, authorForeignID string) ([]authorWorkEntry, error) {
-	u := fmt.Sprintf("%s/authors/%s/works.json?limit=100", baseURL, authorForeignID)
-	var resp authorWorksResponse
-	if err := c.getJSON(ctx, u, &resp); err != nil {
-		return nil, err
+	var entries []authorWorkEntry
+	for offset := 0; offset < authorWorksMaxFetch; offset += authorWorksPageSize {
+		u := fmt.Sprintf("%s/authors/%s/works.json?limit=%d&offset=%d",
+			baseURL, authorForeignID, authorWorksPageSize, offset)
+		var resp authorWorksResponse
+		if err := c.getJSON(ctx, u, &resp); err != nil {
+			if offset == 0 {
+				return nil, err
+			}
+			// A later page failing shouldn't discard the works already
+			// collected — return what we have and let enrichment fill gaps.
+			slog.Warn("openlibrary: author works pagination stopped early",
+				"author", authorForeignID, "offset", offset, "error", err)
+			break
+		}
+		entries = append(entries, resp.Entries...)
+		// Stop on a short page (end of list) or once we've collected the
+		// advertised total. Size is omitted (0) by older/partial responses,
+		// in which case the short-page check is the authoritative terminator.
+		if len(resp.Entries) < authorWorksPageSize ||
+			(resp.Size > 0 && len(entries) >= resp.Size) {
+			break
+		}
 	}
-	return resp.Entries, nil
+	if len(entries) >= authorWorksMaxFetch {
+		slog.Warn("openlibrary: author works hit pagination cap; catalogue may be truncated",
+			"author", authorForeignID, "cap", authorWorksMaxFetch)
+	}
+	return entries, nil
 }
 
 // pickPreferredLanguage returns "eng" if present in the list, otherwise the

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -738,6 +739,37 @@ func TestGetAuthorWorks_HTTP_WorksEndpointFillsMissingSearchEntries(t *testing.T
 	}
 	if got[0] != "Older Book" || got[1] != "Recently Released" {
 		t.Errorf("expected [Older Book, Recently Released] in that order, got %v", got)
+	}
+}
+
+// Authors with more than one page of works must have their full catalogue
+// fetched, not just the first 100. Regression guard for the hard 100-book cap
+// reported on prolific authors (the works endpoint was fetched once, never
+// paged). The mock pages by ?offset= and advertises the total via Size.
+func TestGetAuthorWorks_HTTP_PaginatesPastFirstPage(t *testing.T) {
+	const total = 250
+	worksHandler := func(r *http.Request) string {
+		offset, _ := strconv.Atoi(r.URL.Query().Get("offset"))
+		var entries []authorWorkEntry
+		for i := offset; i < offset+authorWorksPageSize && i < total; i++ {
+			entries = append(entries, authorWorkEntry{
+				Key:   "/works/OL" + strconv.Itoa(i) + "W",
+				Title: "Book " + strconv.Itoa(i),
+			})
+		}
+		return jsonStr(authorWorksResponse{Size: total, Entries: entries})
+	}
+	c := newClientWithPaths(t, map[string]interface{}{
+		"/authors/OL123A/works.json": worksHandler,
+		"/search.json":               jsonStr(searchRespForAuthor{}),
+	})
+
+	books, err := c.GetAuthorWorks(context.Background(), "OL123A")
+	if err != nil {
+		t.Fatalf("GetAuthorWorks: %v", err)
+	}
+	if len(books) != total {
+		t.Fatalf("expected %d books across all pages, got %d (cap regression?)", total, len(books))
 	}
 }
 


### PR DESCRIPTION
## Problem

Reported in Discord (Solomon): authors with a large catalogue still show only **100 books**, even after #1011. That PR fixed frontend pagination of the library list pages — a different layer. The remaining cap is in the **OpenLibrary metadata client**.

`authorWorksBackfill` is the *primary* source for an author's catalogue. It fetched the `/authors/{id}/works.json` endpoint exactly once at `limit=100` and never paginated, even though the response carries the catalogue total in its `Size` field and the endpoint supports `offset`. Any author with >100 works was silently truncated to 100.

## Fix

Page through `/authors/{id}/works` using `offset` until a short page (or the advertised `Size` total) signals the end, bounded by `authorWorksMaxFetch = 2000` (20 requests) so a pathological or maliciously inflated response can't trigger unbounded fetching. A later-page failure logs and returns the works already collected rather than discarding them — existing best-effort semantics are preserved.

Single-page responses (the common case, and every existing test) take exactly one request as before: the short-page check terminates immediately when fewer than 100 entries come back.

## Test

`TestGetAuthorWorks_HTTP_PaginatesPastFirstPage` — a 250-work author served across 3 pages must come back with all 250, not 100.

```
go test ./internal/metadata/openlibrary/   ok
go vet ./internal/metadata/openlibrary/    clean
golangci-lint run ./internal/metadata/openlibrary/   0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)