### PR TITLE
fix(series): populate book membership in ListByAuthor so author-page grouping works (#1209)

### DIFF
--- a/changelog.d/1209-author-series-grouping.md
+++ b/changelog.d/1209-author-series-grouping.md
@@ -1,0 +1,2 @@
+### Fixed
+- **"Group by series" on the author page dumped every book into "Standalone"** (#1209) — the per-author series endpoint returned each series without its book membership (the `books` array was empty, and `omitempty` dropped it from the JSON entirely), so the frontend had nothing to group on and every book fell through to Standalone. `ListByAuthor` now joins through `series_books`/`books` and populates each series' book list (author-scoped, ordered by position-in-series), so books group under their series again.

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1896,7 +1897,7 @@ func TestListAuthorSeries(t *testing.T) {
 	if err := seriesRepo.CreateOrGet(ctx, s); err != nil {
 		t.Fatal(err)
 	}
-	if err := seriesRepo.LinkBook(ctx, s.ID, book.ID, "", true); err != nil {
+	if err := seriesRepo.LinkBook(ctx, s.ID, book.ID, "1", true); err != nil {
 		t.Fatal(err)
 	}
 	// A second unlinked series exists globally — must not appear in the
@@ -1923,6 +1924,16 @@ func TestListAuthorSeries(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].ID != s.ID {
 		t.Fatalf("got %d series, want only the linked one (id %d): %+v", len(got), s.ID, got)
+	}
+	// Regression guard for #1209: the series payload must carry its book
+	// membership. Books has `json:",omitempty"`, so an empty slice is dropped
+	// from JSON entirely; assert against the raw body that the "books" key is
+	// present and that the membership round-trips with the linked book.
+	if got[0].Books == nil || len(got[0].Books) != 1 || got[0].Books[0].BookID != book.ID {
+		t.Fatalf("series books not populated: %+v", got[0].Books)
+	}
+	if !strings.Contains(rec.Body.String(), `"books"`) {
+		t.Fatalf("response JSON missing books array (omitempty drop): %s", rec.Body.String())
 	}
 }
 

--- a/internal/db/author_monitored_series_test.go
+++ b/internal/db/author_monitored_series_test.go
@@ -228,13 +228,15 @@ func TestSeriesListByAuthor(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// a1 has two books in series A1 plus one standalone book that is not
+	// linked to any series (so it must not surface a phantom membership).
 	b1 := &models.Book{ForeignID: "OL-B1", AuthorID: a1.ID, Title: "X", SortTitle: "X", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"}
+	b1b := &models.Book{ForeignID: "OL-B1B", AuthorID: a1.ID, Title: "X2", SortTitle: "X2", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"}
 	b2 := &models.Book{ForeignID: "OL-B2", AuthorID: a2.ID, Title: "Y", SortTitle: "Y", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"}
-	if err := bookRepo.Create(ctx, b1); err != nil {
-		t.Fatal(err)
-	}
-	if err := bookRepo.Create(ctx, b2); err != nil {
-		t.Fatal(err)
+	for _, b := range []*models.Book{b1, b1b, b2} {
+		if err := bookRepo.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	sA := &models.Series{ForeignID: "ol-series:a1", Title: "A1"}
@@ -245,6 +247,9 @@ func TestSeriesListByAuthor(t *testing.T) {
 	if err := seriesRepo.CreateOrGet(ctx, sB); err != nil {
 		t.Fatal(err)
 	}
+	// Link b1b at position 2 and b1 at position 1 so we can prove the result is
+	// ordered by position-in-series, not by insertion order.
+	_ = seriesRepo.LinkBook(ctx, sA.ID, b1b.ID, "2", false)
 	_ = seriesRepo.LinkBook(ctx, sA.ID, b1.ID, "1", true)
 	_ = seriesRepo.LinkBook(ctx, sB.ID, b2.ID, "1", true)
 
@@ -255,6 +260,18 @@ func TestSeriesListByAuthor(t *testing.T) {
 	if len(got) != 1 || got[0].ID != sA.ID {
 		t.Fatalf("a1: want [sA], got %v", got)
 	}
+	// Regression guard for #1209: the series must carry its book membership so
+	// the author-page "Group by series" view can place books under the series.
+	if len(got[0].Books) != 2 {
+		t.Fatalf("a1 series A1: want 2 books populated, got %d (%+v)", len(got[0].Books), got[0].Books)
+	}
+	if got[0].Books[0].BookID != b1.ID || got[0].Books[1].BookID != b1b.ID {
+		t.Fatalf("a1 series A1: books not position-ordered: got [%d,%d] want [%d,%d]",
+			got[0].Books[0].BookID, got[0].Books[1].BookID, b1.ID, b1b.ID)
+	}
+	if got[0].Books[0].PositionInSeries != "1" || !got[0].Books[0].PrimarySeries {
+		t.Fatalf("a1 series A1: first book fields not populated: %+v", got[0].Books[0])
+	}
 
 	got2, err := seriesRepo.ListByAuthor(ctx, a2.ID)
 	if err != nil {
@@ -262,5 +279,9 @@ func TestSeriesListByAuthor(t *testing.T) {
 	}
 	if len(got2) != 1 || got2[0].ID != sB.ID {
 		t.Fatalf("a2: want [sB], got %v", got2)
+	}
+	// Author scope: only a2's book should be under sB, never a1's books.
+	if len(got2[0].Books) != 1 || got2[0].Books[0].BookID != b2.ID {
+		t.Fatalf("a2 series B: want only b2, got %+v", got2[0].Books)
 	}
 }

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -524,26 +524,84 @@ func (r *SeriesRepo) UnlinkBook(ctx context.Context, seriesID, bookID int64) err
 // API endpoint that backs it. Returns an empty slice (not nil) when the
 // author has no series-linked books.
 func (r *SeriesRepo) ListByAuthor(ctx context.Context, authorID int64) ([]models.Series, error) {
+	// One row per (series, author-book) membership so we can populate each
+	// series' .Books. The author scope stays in the WHERE clause, so only this
+	// author's books appear under each series — matching the frontend join,
+	// which only resolves bookIds against the author's filtered book set.
+	//
+	// Because we now select per-book columns we can no longer SELECT DISTINCT
+	// on series-only columns; we dedup series via a byID map (mirroring
+	// ListWithBooks) and append each book to its series.
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT DISTINCT s.id, s.foreign_id, s.title, s.description, s.monitored, s.created_at
+		SELECT s.id, s.foreign_id, s.title, s.description, s.monitored, s.created_at,
+		       sb.series_id, sb.book_id, sb.position_in_series, sb.primary_series,
+		       b.id, b.foreign_id, b.author_id, b.title, b.sort_title, b.status,
+		       b.monitored, b.image_url, b.release_date, b.created_at, b.updated_at
 		FROM series s
 		JOIN series_books sb ON sb.series_id = s.id
 		JOIN books b ON b.id = sb.book_id
 		WHERE b.author_id = ?
-		ORDER BY s.title`, authorID)
+		ORDER BY s.title, CAST(NULLIF(sb.position_in_series, '') AS REAL), sb.position_in_series, b.sort_title`, authorID)
 	if err != nil {
 		return nil, fmt.Errorf("list series by author %d: %w", authorID, err)
 	}
 	defer rows.Close()
 	series := make([]models.Series, 0)
+	byID := make(map[int64]int)
 	for rows.Next() {
 		var s models.Series
 		var monitored int
-		if err := rows.Scan(&s.ID, &s.ForeignID, &s.Title, &s.Description, &monitored, &s.CreatedAt); err != nil {
+		var sbSeriesID, sbBookID, bookID, bAuthorID sql.NullInt64
+		var position sql.NullString
+		var primarySeries, bookMonitored sql.NullInt64
+		var foreignID, title, sortTitle, status, imageURL sql.NullString
+		var releaseDate, bookCreatedAt, bookUpdatedAt sql.NullTime
+		if err := rows.Scan(
+			&s.ID, &s.ForeignID, &s.Title, &s.Description, &monitored, &s.CreatedAt,
+			&sbSeriesID, &sbBookID, &position, &primarySeries,
+			&bookID, &foreignID, &bAuthorID, &title, &sortTitle, &status,
+			&bookMonitored, &imageURL, &releaseDate, &bookCreatedAt, &bookUpdatedAt,
+		); err != nil {
 			return nil, fmt.Errorf("scan series by author: %w", err)
 		}
 		s.Monitored = monitored == 1
-		series = append(series, s)
+
+		idx, ok := byID[s.ID]
+		if !ok {
+			idx = len(series)
+			series = append(series, s)
+			byID[s.ID] = idx
+		}
+		if !sbBookID.Valid || !bookID.Valid {
+			continue
+		}
+
+		book := models.Book{
+			ID:        bookID.Int64,
+			ForeignID: foreignID.String,
+			AuthorID:  bAuthorID.Int64,
+			Title:     title.String,
+			SortTitle: sortTitle.String,
+			Status:    status.String,
+			Monitored: bookMonitored.Int64 == 1,
+			ImageURL:  imageURL.String,
+		}
+		if releaseDate.Valid {
+			book.ReleaseDate = &releaseDate.Time
+		}
+		if bookCreatedAt.Valid {
+			book.CreatedAt = bookCreatedAt.Time
+		}
+		if bookUpdatedAt.Valid {
+			book.UpdatedAt = bookUpdatedAt.Time
+		}
+		series[idx].Books = append(series[idx].Books, models.SeriesBook{
+			SeriesID:         sbSeriesID.Int64,
+			BookID:           sbBookID.Int64,
+			PositionInSeries: position.String,
+			PrimarySeries:    primarySeries.Int64 == 1,
+			Book:             &book,
+		})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
## Bug (#1209)
"Group by series" on the author page put every book into **Standalone**. Root cause: `SeriesRepo.ListByAuthor` (`internal/db/series.go`) selected only series-level columns and never populated `Series.Books`. With `Books []SeriesBook \`json:"books,omitempty"\``, the empty slice was dropped from JSON, so the frontend's `series.books ?? []` was empty for every series and all books fell to Standalone.

## Fix (backend only, no FE change)
Populate `Series.Books` in `ListByAuthor` by mirroring the sibling `ListWithBooks` join + ordering, author-scoped. The old `SELECT DISTINCT` over series-only columns is replaced with a per-membership join, deduping series via a `byID` map (DISTINCT would no longer dedup once book columns are added). Scan types match `ListWithBooks` exactly.

## Tests
- Repo test: `ListByAuthor` returns series with non-empty, position-ordered `Books` (positions "2" then "1" assert ordering, not insertion order), plus an author-scope assertion.
- API test: `GET /api/v1/author/{id}/series` JSON contains the `books` array (regression guard against the `omitempty` drop).

`go build/vet/test ./internal/db ./internal/api` + `golangci-lint`: green. Opus-reviewed: APPROVE.

Closes #1209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)