### PR TITLE
fix(series): link Missing diff rows to existing owned library books (#1210)

### DIFF
--- a/changelog.d/1210-series-missing-book-links.md
+++ b/changelog.d/1210-series-missing-book-links.md
@@ -1,0 +1,2 @@
+### Fixed
+- Un-added books on the series page that already exist in your library now render as links to the existing book instead of an "add" button (#1210). The match is ownership-scoped, so only books in your own library are linked.

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/bookhydrate"
 	"github.com/vavallee/bindery/internal/concurrency"
 	"github.com/vavallee/bindery/internal/db"
@@ -811,7 +812,7 @@ func (h *SeriesHandler) HardcoverDiff(w http.ResponseWriter, r *http.Request) {
 		writeUpstreamError(w, err)
 		return
 	}
-	diff := buildHardcoverDiff(series, link, catalog)
+	diff := buildHardcoverDiff(r.Context(), h.books, auth.UserIDFromContext(r.Context()), series, link, catalog)
 	writeJSON(w, http.StatusOK, diff)
 }
 
@@ -1053,7 +1054,18 @@ func (h *SeriesHandler) hardcoverCatalog(ctx context.Context, foreignID string) 
 	return catalog, nil
 }
 
-func buildHardcoverDiff(series *models.Series, link *models.SeriesHardcoverLink, catalog *metadata.SeriesCatalog) seriesHardcoverDiffResponse {
+// buildHardcoverDiff classifies the catalog against the local series. The
+// Missing set is then enriched: a catalog book the user has NOT linked to this
+// series may still already exist in their library (added standalone, or linked
+// to a different series). When books is non-nil we cross-reference each Missing
+// row against the requesting user's library so the frontend can render a link
+// to the existing /book/:id instead of an "add" button (#1210).
+//
+// The cross-reference is ownership-scoped via GetByForeignIDForUser: userID is
+// the requesting user's id, and a match owned by a different user is never
+// surfaced (cross-tenant guard). Callers without a DB/user context (e.g. the
+// create-missing write path) pass a nil books repo to skip enrichment.
+func buildHardcoverDiff(ctx context.Context, books *db.BookRepo, userID int64, series *models.Series, link *models.SeriesHardcoverLink, catalog *metadata.SeriesCatalog) seriesHardcoverDiffResponse {
 	diff := seriesHardcoverDiffResponse{
 		SeriesID:  series.ID,
 		Link:      link,
@@ -1092,7 +1104,9 @@ func buildHardcoverDiff(series *models.Series, link *models.SeriesHardcoverLink,
 		if _, ok := matchedCatalog[i]; ok {
 			continue
 		}
-		diff.Missing = append(diff.Missing, catalogDiffBook(book, catalog.AuthorName))
+		item := catalogDiffBook(book, catalog.AuthorName)
+		enrichMissingDiffBook(ctx, books, userID, book, &item)
+		diff.Missing = append(diff.Missing, item)
 	}
 	diff.PresentCount = len(diff.Present)
 	diff.MissingCount = len(diff.Missing)
@@ -1147,6 +1161,46 @@ func catalogDiffBook(book metadata.SeriesCatalogBook, fallbackAuthor string) ser
 	}
 }
 
+// enrichMissingDiffBook cross-references a Missing catalog row against the
+// requesting user's library and, on a match, sets LocalBookID (plus LocalTitle/
+// LocalStatus for parity with Present rows) so the frontend renders a link to
+// the existing book instead of an "add" button (#1210). The row stays in the
+// Missing set; only the link metadata is added.
+//
+// Matching is foreign-ID-first, mirroring ensureHardcoverCatalogBook's add-path
+// precedent: derive the catalog book's foreign id exactly as the write path
+// does (firstNonEmpty(Book.ForeignID, catalog.ForeignID), then the "hc:"+
+// providerID fallback) and look it up ownership-scoped via
+// GetByForeignIDForUser.
+//
+// We deliberately do NOT fall back to FindByAuthorAndDedupKey here: that lookup
+// needs a *local* author id, but a Missing (unlinked) catalog book carries only
+// a provider author *name*, not a resolved local author row, so there is no
+// reliable authorID to scope the dedup-key query. An unscoped or
+// name-guessed-author dedup match would also be ambiguous (FindAllByAuthorAndDedupKey
+// exists precisely because the key can collide across editions) and could link
+// the wrong edition, so we skip it rather than guess.
+func enrichMissingDiffBook(ctx context.Context, books *db.BookRepo, userID int64, catalogBook metadata.SeriesCatalogBook, item *seriesHardcoverDiffBook) {
+	if books == nil || ctx == nil {
+		return
+	}
+	foreignID := firstNonEmpty(catalogBook.Book.ForeignID, catalogBook.ForeignID)
+	if foreignID == "" && strings.TrimSpace(catalogBook.ProviderID) != "" {
+		foreignID = "hc:" + catalogBook.ProviderID
+	}
+	if foreignID == "" {
+		return
+	}
+	existing, err := books.GetByForeignIDForUser(ctx, foreignID, userID)
+	if err != nil || existing == nil {
+		return
+	}
+	id := existing.ID
+	item.LocalBookID = &id
+	item.LocalTitle = existing.Title
+	item.LocalStatus = existing.Status
+}
+
 func localDiffBook(local models.SeriesBook) seriesHardcoverDiffBook {
 	item := seriesHardcoverDiffBook{Position: local.PositionInSeries}
 	if local.Book == nil {
@@ -1183,7 +1237,9 @@ func (h *SeriesHandler) createMissingHardcoverBooks(ctx context.Context, seriesI
 	if catalog == nil {
 		return nil
 	}
-	diff := buildHardcoverDiff(series, series.HardcoverLink, catalog)
+	// Write path: only ForeignBookID/Position are consumed below, so skip the
+	// per-row library cross-reference by passing a nil books repo.
+	diff := buildHardcoverDiff(ctx, nil, 0, series, series.HardcoverLink, catalog)
 	for _, missing := range diff.Missing {
 		catalogBook, ok := findCatalogBook(catalog.Books, missing.ForeignBookID, missing.Position)
 		if !ok {
@@ -1220,7 +1276,8 @@ func (h *SeriesHandler) createMissingHardcoverBook(ctx context.Context, seriesID
 	if catalog == nil {
 		return nil, errSeriesCatalogBookNotFound
 	}
-	diff := buildHardcoverDiff(series, series.HardcoverLink, catalog)
+	// Write path: enrichment is unused here, so pass a nil books repo.
+	diff := buildHardcoverDiff(ctx, nil, 0, series, series.HardcoverLink, catalog)
 	for _, missing := range diff.Missing {
 		if !selector.matchesDiffBook(missing) {
 			continue

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -1060,6 +1060,132 @@ func TestSeriesHardcoverDiffEndpoint(t *testing.T) {
 	}
 }
 
+// TestBuildHardcoverDiffEnrichesMissingWithOwnedLibraryBook is the regression
+// guard for #1210. A catalog book that is NOT linked to this series (so it
+// lands in Missing) but already exists in the requesting user's library must
+// get LocalBookID populated so the frontend renders a link instead of an "add"
+// button. The companion assertion is the security guard: an identical book
+// owned by a DIFFERENT user must NOT be linked (LocalBookID stays nil), or one
+// tenant's series page would leak a link to another tenant's book.
+func TestBuildHardcoverDiffEnrichesMissingWithOwnedLibraryBook(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	seriesRepo := db.NewSeriesRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	userRepo := db.NewUserRepo(database)
+	ctx := context.Background()
+
+	owner, err := userRepo.Create(ctx, "owner", "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := userRepo.Create(ctx, "other", "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ownerUserID := owner.ID
+	otherUserID := other.ID
+
+	// Catalog: two books. "owned-missing" exists in user 7's library but is not
+	// linked to the series; "other-missing" exists only in user 8's library.
+	catalog := stormlightCatalog()
+	catalog.Books = append(catalog.Books,
+		metadata.SeriesCatalogBook{
+			ForeignID:  "hc:owned-missing",
+			ProviderID: "201",
+			Title:      "Owned But Unlinked",
+			Position:   "2",
+			Book: models.Book{
+				ForeignID: "hc:owned-missing",
+				Title:     "Owned But Unlinked",
+				Author:    catalog.Books[0].Book.Author,
+			},
+		},
+		metadata.SeriesCatalogBook{
+			ForeignID:  "hc:other-missing",
+			ProviderID: "202",
+			Title:      "Owned By Someone Else",
+			Position:   "3",
+			Book: models.Book{
+				ForeignID: "hc:other-missing",
+				Title:     "Owned By Someone Else",
+				Author:    catalog.Books[0].Book.Author,
+			},
+		},
+	)
+	catalog.BookCount = len(catalog.Books)
+
+	series := &models.Series{ForeignID: "manual:series:stormlight", Title: "Stormlight"}
+	if err := seriesRepo.Create(ctx, series); err != nil {
+		t.Fatal(err)
+	}
+	link := &models.SeriesHardcoverLink{
+		SeriesID:          series.ID,
+		HardcoverSeriesID: catalog.ForeignID,
+	}
+
+	author := &models.Author{ForeignID: "hc:brandon-sanderson", Name: "Brandon Sanderson", SortName: "Sanderson, Brandon"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the two library books and stamp their owners. BookRepo.Create does
+	// not set owner_user_id, so stamp it directly (mirrors history_test.go).
+	makeBook := func(foreignID, title string, owner int64) int64 {
+		book := &models.Book{
+			ForeignID: foreignID,
+			AuthorID:  author.ID,
+			Title:     title,
+			SortTitle: title,
+			Status:    models.BookStatusDownloaded,
+			Genres:    []string{},
+		}
+		if err := bookRepo.Create(ctx, book); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := database.Exec("UPDATE books SET owner_user_id=? WHERE id=?", owner, book.ID); err != nil {
+			t.Fatal(err)
+		}
+		return book.ID
+	}
+	ownedID := makeBook("hc:owned-missing", "Owned But Unlinked (local)", ownerUserID)
+	makeBook("hc:other-missing", "Owned By Someone Else (local)", otherUserID)
+
+	// Build the diff as user 7. Neither extra book is linked to the series, so
+	// both land in Missing.
+	diff := buildHardcoverDiff(ctx, bookRepo, ownerUserID, series, link, catalog)
+
+	var ownedRow, otherRow *seriesHardcoverDiffBook
+	for i := range diff.Missing {
+		switch diff.Missing[i].ForeignBookID {
+		case "hc:owned-missing":
+			ownedRow = &diff.Missing[i]
+		case "hc:other-missing":
+			otherRow = &diff.Missing[i]
+		}
+	}
+	if ownedRow == nil || otherRow == nil {
+		t.Fatalf("expected both unlinked catalog books in Missing, got %+v", diff.Missing)
+	}
+
+	// Positive: the user's own unlinked-but-existing book is linked.
+	if ownedRow.LocalBookID == nil || *ownedRow.LocalBookID != ownedID {
+		t.Fatalf("owned Missing row LocalBookID = %v, want %d", ownedRow.LocalBookID, ownedID)
+	}
+	if ownedRow.LocalTitle != "Owned But Unlinked (local)" {
+		t.Fatalf("owned Missing row LocalTitle = %q, want the local title", ownedRow.LocalTitle)
+	}
+
+	// Security guard: a book owned by a different user must NOT be linked.
+	if otherRow.LocalBookID != nil {
+		t.Fatalf("cross-tenant leak: other user's book linked on Missing row, LocalBookID = %v", *otherRow.LocalBookID)
+	}
+}
+
 func TestSeriesHardcoverDiffEndpointErrors(t *testing.T) {
 	catalog := stormlightCatalog()
 	h, seriesRepo, _, _ := seriesFixtureWithProvider(t, &stubSeriesProvider{

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -396,6 +396,31 @@ func (r *BookRepo) GetByForeignID(ctx context.Context, foreignID string) (*model
 	return &books[0], nil
 }
 
+// GetByForeignIDForUser is GetByForeignID constrained to books the given user
+// owns. Unlike GetByForeignID (global, used on the add/write path where the
+// caller already controls ownership), this is the lookup used to enrich a
+// series-diff view with a link to an *existing* library book, so it should not
+// surface another user's book into one tenant's series page (#1210).
+//
+// Scoping is conditional, matching every other ownership-scoped read in this
+// package: when userID > 0 (a per-user cookie identity under EnforceTenancy)
+// the owner_user_id predicate is applied; when userID is 0 — the admin-
+// equivalent modes (auth disabled, local-only, or API-key) — the predicate is
+// omitted via QueryScopeFor and behaviour matches the global GetByForeignID.
+// It is not an absolute cross-tenant guard; it is exactly as strong as the
+// rest of the library reads in those modes.
+func (r *BookRepo) GetByForeignIDForUser(ctx context.Context, foreignID string, userID int64) (*models.Book, error) {
+	where, args := QueryScopeFor("books.owner_user_id", "WHERE books.foreign_id = ?", userID, foreignID)
+	books, err := r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where, args)
+	if err != nil {
+		return nil, err
+	}
+	if len(books) == 0 {
+		return nil, nil
+	}
+	return &books[0], nil
+}
+
 func (r *BookRepo) Create(ctx context.Context, b *models.Book) error {
 	now := time.Now().UTC()
 	genresJSON, err := json.Marshal(b.Genres)


### PR DESCRIPTION
## Bug (#1210)
On the series page, "missing"/un-added books from the Hardcover diff that **also exist in the user's library** stayed as non-clickable "add" rows instead of linking to the existing `/book/:id`. Root cause: `catalogDiffBook` (`internal/api/series.go`) builds every `Missing` row and never sets `LocalBookID`; the handler writes the diff with no enrichment. So `missing[].localBookId` was always nil and the frontend `<Link>` branch (`SeriesPage.tsx:442`, shipped in #1156) was dead for real data. The FE half landed; the backend half never did. The existing FE test hand-mocked `localBookId: 555`, so CI stayed green over an inert feature.

## Fix
Enrich each `Missing` row by cross-referencing the catalog book against the requesting user's library, **foreign-ID-first**, mirroring `ensureHardcoverCatalogBook`'s add-path precedent. New `BookRepo.GetByForeignIDForUser` does an **ownership-scoped** lookup via `QueryScopeFor(owner_user_id, …)`.

Notes on the deliberate design (the reporter's literal proposal was unsound):
- **No `FindByAuthorAndDedupKey` fallback** — an unlinked Missing book carries only a provider author *name*, not a local author id, and the dedup key is ambiguous across editions (could mis-link). Foreign-ID match only.
- **Ownership scoping** is conditional and matches every other library read: scoped when a per-user identity is present (`userID > 0` under `EnforceTenancy`); unscoped in the admin-equivalent modes (auth disabled / local-only / API-key, `userID == 0`). Not an absolute cross-tenant guard, just parity with the rest of the system.
- Write-path callers pass `nil` repo + `userID 0`, which short-circuits enrichment (nil-guarded). No write-path behaviour change.

## Tests
`TestBuildHardcoverDiffEnrichesMissingWithOwnedLibraryBook`: two distinct real users own two unlinked catalog books; querying as user A links A's book (`LocalBookID` set) and, under a per-user identity, leaves B's row nil (cross-tenant guard). Opus reviewer bypassed the scope and confirmed the test fails (real guard, not tautological).

`go build/vet/test ./internal/api ./internal/db` + `golangci-lint` green; `web` typecheck/lint/`355 tests` green. Opus-reviewed: APPROVE (doc/commit prose corrected to not overstate the guard).

Closes #1210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)