### PR TITLE
ci: split bindery-ping LATEST_VERSION bump into its own non-blocking job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,7 +435,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Best-effort telemetry: advertise the new version to the in-app update
+  # check (bindery-ping). Split out of the goreleaser job: the telemetry
+  # cluster is regularly unreachable from the runner, and having this as a
+  # step inside goreleaser failed that whole job, which cascaded to skip
+  # deploy-prod and notify-discord (both gate on goreleaser success).
+  # It now runs as its own job that nothing depends on, with
+  # continue-on-error so a telemetry outage never reddens the release or
+  # blocks the prod deploy. Do NOT add this job to required status checks.
+  bump-latest-version:
+    name: Bump bindery-ping LATEST_VERSION
+    needs: goreleaser
+    if: startsWith(github.ref, 'refs/tags/v')
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - name: Bump bindery-ping LATEST_VERSION
+        continue-on-error: true
         env:
           KUBECONFIG_B64: ${{ secrets.HETZ1_KUBECONFIG }}
           VERSION: ${{ github.ref_name }}


### PR DESCRIPTION
## Problem
Every tagged release shows a red CI run and **skips `Deploy to prod`**. Root cause: the `Bump bindery-ping LATEST_VERSION` step is the last step of the `goreleaser` job, and the telemetry cluster (`bindery-ping`) is unreachable from GitHub's runners. That step times out → the whole `goreleaser` job fails → `deploy-prod` and `notify-discord` (both `if: needs.goreleaser.result == 'success'`) skip. The GitHub release, artifacts, and image all succeed; only telemetry fails, but it poisons the job. v1.21.0 and v1.22.0 both had to be deployed to prod by hand because of this.

## Fix
Move the telemetry bump into its own standalone `bump-latest-version` job:
- `needs: goreleaser`, tag-push only (`if: startsWith(github.ref, 'refs/tags/v')`).
- Nothing depends on it, so its outcome can't cascade.
- The `kubectl` step is `continue-on-error: true`, so a telemetry outage doesn't even redden the run.

`goreleaser` now succeeds on the release alone, so `deploy-prod` and `notify-discord` run automatically again — no more manual prod tag bump per release.

## Note for the maintainer
This job is **intentionally non-required**. Don't add `Bump bindery-ping LATEST_VERSION` to branch protection's required status checks, or the very failure mode this PR removes comes back.

Validated: `yaml.safe_load` parses clean; `goreleaser` job no longer contains the telemetry step; `deploy-prod` needs/if unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)