### PR TITLE
docs(multi-user): root folders are global, not per-user

### DIFF
--- a/docs/multi-user.md
+++ b/docs/multi-user.md
@@ -1,12 +1,14 @@
 # Multi-User
 
-Bindery v1.0 introduces per-user library scoping: authors, books, downloads, quality profiles, metadata profiles, and root folders can be owned by a specific user, and users log in with their own credentials.
+Bindery v1.0 introduces per-user library scoping: authors, books, downloads, quality profiles, and metadata profiles can be owned by a specific user, and users log in with their own credentials.
+
+> **Root folders are not per-user.** They are a single shared, admin-managed pool (Settings → Root Folders), and import destinations resolve per-author plus a global default — there is no per-user library directory today. Regular users don't get their own root folders. Per-user root folders are a tracked future enhancement, not current behaviour.
 
 > **Important — data isolation is opt-in.** Per-user data isolation is gated behind the `BINDERY_ENFORCE_TENANCY` environment variable, which **defaults OFF**. With it unset (the default), any authenticated user can see and manage *all* data — Bindery behaves like a single-user instance regardless of how many accounts exist. To make users see only their own library, set `BINDERY_ENFORCE_TENANCY=true`.
 >
 > When enforcement is on, Bindery scopes:
 > - **Tier-2 join-scoped resources** — download queue, history, pending grabs, and the OPDS catalogue — to the requesting user.
-> - **Per-user resources** — each user's own authors, books, profiles, root folders, API key, password, and notification preferences.
+> - **Per-user resources** — each user's own authors, books, profiles, API key, password, and notification preferences. (Root folders are **not** per-user; see the note above.)
 >
 > Role-based gating of admin-only configuration (indexers, download clients, user management, system settings) applies in **both** modes — that does not depend on `BINDERY_ENFORCE_TENANCY`. The flag only controls whether *library data* is partitioned per user.
 
@@ -27,7 +29,7 @@ Two roles exist: `admin` and `user`.
 |--------|:-------:|:------:|
 | View and manage own authors/books/downloads | Yes | Yes |
 | View and manage own quality/metadata profiles | Yes | Yes |
-| View and manage own root folders | Yes | Yes |
+| Manage root folders (single shared/global pool) | Yes | No |
 | Change own password and API key | Yes | Yes |
 | Configure own notification preferences | Yes | Yes |
 | View other users' library data | Yes | No |


### PR DESCRIPTION
## Problem
A user enabled `BINDERY_ENFORCE_TENANCY` expecting per-user root folders (the docs promise them) and couldn't find the controls as admin or as a user. They're right: root folders are **not** per-user.

`docs/multi-user.md` claims otherwise in three places:
- L3: "...metadata profiles, and **root folders** can be owned by a specific user"
- L9: per-user resources "...profiles, **root folders**, API key..."
- Capability matrix: "View and manage own root folders | Yes | Yes"

But in code: `root_folders` got `owner_user_id` in migration 025, yet `RootFolderRepo.Create` (`internal/db/root_folders.go`) never sets it and `List` never filters on it — so every user sees one shared pool. The management UI is admin-only (`RootFoldersTab` in `ADMIN_TABS`). And `effectiveLibraryDir` (`internal/importer/scanner.go`) resolves the destination per-author + global default, with no user dimension, so files aren't isolated per user either.

## Fix
Docs-only. Drop the per-user claim, add a note that root folders are a single shared admin-managed pool, and correct the capability-matrix row to `Manage root folders (single shared/global pool) | Yes | No`. Real per-user root folders are tracked separately as a feature (needs CRUD scoping **and** a user-aware import-path resolver).

Docs-only change, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)