### PR TITLE
fix(hardcoverlistsyncer): dedup authors by normalized name in list sync (#1223)

### DIFF
--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -303,8 +303,30 @@ func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book) (int64
 			"name", book.Author.Name, "error", matchErr)
 	} else if matched != nil {
 		if err := s.authors.UpsertAuthorIdentifier(ctx, matched.ID, book.Author.ForeignID); err != nil {
-			// Alias attach is best-effort — if it fails we still want to reuse
-			// the matched author for this sync. Next sync will retry.
+			if errors.Is(err, db.ErrAuthorIdentifierConflict) {
+				// Another author already owns this Hardcover foreign_id —
+				// almost certainly via a concurrent sync. Re-fetch the true
+				// owner via the alias table and reuse that author instead of
+				// the one we matched by name, which may be a homonym
+				// (issue #1224 review).
+				owner, ownerErr := s.authors.GetByAnyForeignID(ctx, book.Author.ForeignID)
+				if ownerErr != nil {
+					return 0, fmt.Errorf("resolve author-identifier conflict for %q: %w", book.Author.ForeignID, ownerErr)
+				}
+				if owner == nil {
+					return 0, fmt.Errorf("author identifier conflict for %q but no current owner found", book.Author.ForeignID)
+				}
+				if owner.ID != matched.ID {
+					slog.Info("hardcover list sync: name match lost identifier race; reusing identifier owner",
+						"matchedAuthorID", matched.ID, "matchedName", matched.Name,
+						"ownerAuthorID", owner.ID, "ownerName", owner.Name,
+						"hcForeignID", book.Author.ForeignID)
+				}
+				return owner.ID, nil
+			}
+			// Any other alias-attach failure is best-effort — log and keep
+			// reusing the name-matched author for this sync. Next sync will
+			// retry.
 			slog.Warn("hardcover list sync: failed to attach Hardcover alias to existing author",
 				"existingAuthorID", matched.ID, "name", matched.Name, "hcForeignID", book.Author.ForeignID, "error", err)
 		} else {
@@ -336,12 +358,16 @@ func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book) (int64
 	return author.ID, nil
 }
 
-// findExistingAuthorByName scans the existing authors and returns the first
-// one whose name or sort_name normalizes to the same value as the candidate's
-// Name. Returns nil with no error when no match is found. The scan is linear
-// over List(); acceptable here because list sync is a scheduled batch job
-// (not request-path) and the author table is bounded by a single user's
-// library.
+// findExistingAuthorByName scans the existing authors and returns the
+// unique author whose name or sort_name normalizes to the same value as the
+// candidate's Name. Returns nil with no error when no match is found OR
+// when the match is ambiguous (two or more distinct authors normalize to
+// the same key) — merging homonyms silently is the failure mode flagged in
+// issue #1224's review, so an ambiguous match falls through to create-new.
+//
+// The scan is linear over List(); acceptable here because list sync is a
+// scheduled batch job (not request-path) and the author table is bounded
+// by a single user's library.
 func (s *ListSyncer) findExistingAuthorByName(ctx context.Context, candidate *models.Author) (*models.Author, error) {
 	if candidate == nil || strings.TrimSpace(candidate.Name) == "" {
 		return nil, nil
@@ -355,13 +381,35 @@ func (s *ListSyncer) findExistingAuthorByName(ctx context.Context, candidate *mo
 	if err != nil {
 		return nil, fmt.Errorf("list authors for name match: %w", err)
 	}
+	var matches []*models.Author
 	for i := range all {
 		a := &all[i]
 		if normalizeAuthorName(a.Name) == target || normalizeAuthorName(a.SortName) == target {
-			return a, nil
+			matches = append(matches, a)
 		}
 	}
-	return nil, nil
+	switch len(matches) {
+	case 0:
+		return nil, nil
+	case 1:
+		return matches[0], nil
+	default:
+		// Ambiguous: multiple distinct authors collapse to the same
+		// normalized key. Refuse to merge them — a real "Stephen King"
+		// and a real "Stephen Hawking" must not be collapsed just because
+		// some future bug drops the surname. Log the candidates and fall
+		// through to create-new.
+		names := make([]string, 0, len(matches))
+		for _, m := range matches {
+			names = append(names, m.Name)
+		}
+		slog.Warn("hardcover list sync: ambiguous normalized-name match; creating new author instead of merging",
+			"candidateName", candidate.Name,
+			"candidateForeignID", candidate.ForeignID,
+			"candidateCount", len(matches),
+			"candidateNames", names)
+		return nil, nil
+	}
 }
 
 // normalizeAuthorName produces a canonical form suitable for author-identity

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -269,6 +269,17 @@ func (s *ListSyncer) hydrateHardcoverEditions(ctx context.Context, book *models.
 
 // ensureAuthor looks up the author by foreign ID, creating a minimal record if
 // missing. Returns the author's database ID.
+//
+// Lookup order:
+//  1. Primary foreign_id or alternate identifier match via GetByAnyForeignID.
+//  2. Normalized-name match against existing authors. When a confident hit is
+//     found, the Hardcover foreign_id is attached as an alias via
+//     UpsertAuthorIdentifier so future list syncs hit step 1 directly.
+//     This is the path that prevents the duplicate-author row described in
+//     issue #1223: a library populated by ABS/OpenLibrary has no Hardcover
+//     foreign_id, so step 1 misses even though the author already exists.
+//
+// Returns the author's database ID.
 func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book) (int64, error) {
 	if book.Author == nil {
 		return 0, fmt.Errorf("book %q has no author metadata", book.Title)
@@ -280,6 +291,27 @@ func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book) (int64
 	}
 	if existing != nil {
 		return existing.ID, nil
+	}
+
+	// Fallback: normalize the candidate name and look for an existing author
+	// whose stored name (or sort_name) normalizes to the same value. This
+	// matches "George R. R. Martin" against "George R.R. Martin", and
+	// "Stephen  King" against "Stephen King". On a hit we attach the
+	// Hardcover foreign_id as an alias so the next list sync hits step 1.
+	if matched, matchErr := s.findExistingAuthorByName(ctx, book.Author); matchErr != nil {
+		slog.Warn("hardcover list sync: normalized author lookup failed; creating new author",
+			"name", book.Author.Name, "error", matchErr)
+	} else if matched != nil {
+		if err := s.authors.UpsertAuthorIdentifier(ctx, matched.ID, book.Author.ForeignID); err != nil {
+			// Alias attach is best-effort — if it fails we still want to reuse
+			// the matched author for this sync. Next sync will retry.
+			slog.Warn("hardcover list sync: failed to attach Hardcover alias to existing author",
+				"existingAuthorID", matched.ID, "name", matched.Name, "hcForeignID", book.Author.ForeignID, "error", err)
+		} else {
+			slog.Info("reused existing author for hardcover list import",
+				"existingAuthorID", matched.ID, "name", matched.Name, "hcForeignID", book.Author.ForeignID)
+		}
+		return matched.ID, nil
 	}
 
 	// Create a minimal author record
@@ -302,6 +334,70 @@ func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book) (int64
 	}
 	slog.Info("created author from hardcover list", "name", author.Name, "foreignID", author.ForeignID)
 	return author.ID, nil
+}
+
+// findExistingAuthorByName scans the existing authors and returns the first
+// one whose name or sort_name normalizes to the same value as the candidate's
+// Name. Returns nil with no error when no match is found. The scan is linear
+// over List(); acceptable here because list sync is a scheduled batch job
+// (not request-path) and the author table is bounded by a single user's
+// library.
+func (s *ListSyncer) findExistingAuthorByName(ctx context.Context, candidate *models.Author) (*models.Author, error) {
+	if candidate == nil || strings.TrimSpace(candidate.Name) == "" {
+		return nil, nil
+	}
+	target := normalizeAuthorName(candidate.Name)
+	if target == "" {
+		return nil, nil
+	}
+
+	all, err := s.authors.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list authors for name match: %w", err)
+	}
+	for i := range all {
+		a := &all[i]
+		if normalizeAuthorName(a.Name) == target || normalizeAuthorName(a.SortName) == target {
+			return a, nil
+		}
+	}
+	return nil, nil
+}
+
+// normalizeAuthorName produces a canonical form suitable for author-identity
+// matching: lowercased, with periods and commas stripped, and runs of
+// whitespace condensed to a single space. "George R. R. Martin",
+// "George R.R. Martin", and "george r r martin" all collapse to the same
+// key. Empty and whitespace-only inputs return "" so callers can short-
+// circuit without a separate check.
+func normalizeAuthorName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(name))
+	prevSpace := false
+	for _, r := range name {
+		switch r {
+		case '.', ',', ';', ':', '\t', '\n', '\r':
+			// Skip — treat as separators.
+			if !prevSpace && b.Len() > 0 {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+		case ' ':
+			if !prevSpace && b.Len() > 0 {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+		default:
+			b.WriteRune(r)
+			prevSpace = false
+		}
+	}
+	out := strings.ToLower(strings.TrimSpace(b.String()))
+	return out
 }
 
 func sortName(name string) string {

--- a/internal/hardcoverlistsyncer/syncer_test.go
+++ b/internal/hardcoverlistsyncer/syncer_test.go
@@ -715,3 +715,199 @@ func TestSyncOne_CreatesNewAuthorWhenNoNameMatch(t *testing.T) {
 		t.Fatalf("book author_id = %d, want new author %d", imported.AuthorID, authors[0].ID)
 	}
 }
+
+// TestSyncOne_AmbiguousNameMatch_CreatesNewAuthor pins P1 #1 of the
+// #1224 review. When two distinct existing authors normalize to the same
+// key (e.g. one stored as "Stephen King" and one as "Stephen K"), the
+// syncer must NOT silently merge the incoming Hardcover author into
+// either of them. It should fall through to create-new, leaving the
+// existing authors untouched and importing the new book against a
+// fresh author row.
+func TestSyncOne_AmbiguousNameMatch_CreatesNewAuthor(t *testing.T) {
+	s, repo := newTestSyncer(t)
+	ctx := context.Background()
+
+	// Two pre-existing authors that both normalize to "stephen k" —
+	// the candidate's normalized name collides with BOTH, so the
+	// match is ambiguous and the syncer must fall through to
+	// create-new instead of silently merging into either.
+	first := &models.Author{
+		ForeignID:        "OL-AUTHOR-SK",
+		Name:             "Stephen. K.", // normalizes to "stephen k"
+		SortName:         "K, Stephen",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := s.authors.Create(ctx, first); err != nil {
+		t.Fatalf("seed first author: %v", err)
+	}
+	second := &models.Author{
+		ForeignID:        "OL-AUTHOR-SK2",
+		Name:             "Stephen K", // normalizes to "stephen k"
+		SortName:         "K, Stephen",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := s.authors.Create(ctx, second); err != nil {
+		t.Fatalf("seed second author: %v", err)
+	}
+
+	il := testImportList("HC Ambiguous", "hardcover", true)
+	if err := repo.Create(ctx, &il); err != nil {
+		t.Fatalf("seed list: %v", err)
+	}
+
+	// Incoming Hardcover author whose normalized name collides with both.
+	book := bookWithSeriesRef("hc:ambiguous-book", "Ambiguous Book", nil)
+	book.Author.ForeignID = "hc:ambiguous-stephen"
+	book.Author.Name = "Stephen K"
+	book.Author.SortName = ""
+	book.Author.MetadataProvider = "hardcover"
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
+			lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{book},
+		}
+	})
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne: %v", err)
+	}
+
+	// A third author must have been created. The two existing authors
+	// must not be merged into the new row, and the new row must not
+	// share an ID with either of them.
+	authors, err := s.authors.List(ctx)
+	if err != nil {
+		t.Fatalf("List authors: %v", err)
+	}
+	if len(authors) != 3 {
+		names := make([]string, 0, len(authors))
+		for _, a := range authors {
+			names = append(names, a.Name)
+		}
+		t.Fatalf("authors = %d (%v), want 3 (ambiguous match must not merge)", len(authors), names)
+	}
+
+	// The book must be linked to the new author (not to either of the
+	// pre-existing ones).
+	imported, err := s.books.GetByForeignID(ctx, "hc:ambiguous-book")
+	if err != nil || imported == nil {
+		t.Fatalf("imported book = %+v err=%v, want persisted", imported, err)
+	}
+	if imported.AuthorID == first.ID || imported.AuthorID == second.ID {
+		t.Fatalf("book author_id = %d, must not reuse an ambiguous name-match (%d, %d)",
+			imported.AuthorID, first.ID, second.ID)
+	}
+
+	// The pre-existing authors must remain pristine — no alias should
+	// have been attached to either of them from this import.
+	for _, a := range []*models.Author{first, second} {
+		ids, err := s.authors.ListAuthorIdentifiers(ctx, a.ID)
+		if err != nil {
+			t.Fatalf("ListAuthorIdentifiers(%d): %v", a.ID, err)
+		}
+		for _, ident := range ids {
+			if ident.ForeignID == "hc:ambiguous-stephen" {
+				t.Fatalf("pre-existing author %d (%s) was wrongly tagged with HC alias", a.ID, a.Name)
+			}
+		}
+	}
+}
+
+// TestSyncOne_NameMatchLosesIdentifierRace_ReusesIdentifierOwner pins
+// P1 #2 of the #1224 review. When the normalized-name fallback picks an
+// author but the HC foreign_id has already been attached to a DIFFERENT
+// author (concurrent sync), the syncer must NOT pretend the alias
+// attached. It must re-fetch via GetByAnyForeignID and reuse the
+// identifier's true owner.
+func TestSyncOne_NameMatchLosesIdentifierRace_ReusesIdentifierOwner(t *testing.T) {
+	s, repo := newTestSyncer(t)
+	ctx := context.Background()
+
+	// Pre-existing author whose name matches the incoming book.
+	nameMatch := &models.Author{
+		ForeignID:        "OL-AUTHOR-MARTIN",
+		Name:             "George R. R. Martin",
+		SortName:         "Martin, George R. R.",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := s.authors.Create(ctx, nameMatch); err != nil {
+		t.Fatalf("seed name-match author: %v", err)
+	}
+
+	// Pre-existing author who already owns the HC foreign_id the
+	// incoming book carries. This is the "concurrent sync won the
+	// race" scenario — a different author already claimed the alias.
+	identifierOwner := &models.Author{
+		ForeignID:        "OL-AUTHOR-MARTIN-WEB",
+		Name:             "George R. R. Martin",
+		SortName:         "Martin, George R. R.",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := s.authors.Create(ctx, identifierOwner); err != nil {
+		t.Fatalf("seed identifier-owner author: %v", err)
+	}
+	if err := s.authors.UpsertAuthorIdentifier(ctx, identifierOwner.ID, "hc:george-rr-martin"); err != nil {
+		t.Fatalf("seed HC alias on identifier owner: %v", err)
+	}
+
+	il := testImportList("HC Race", "hardcover", true)
+	if err := repo.Create(ctx, &il); err != nil {
+		t.Fatalf("seed list: %v", err)
+	}
+
+	book := bookWithSeriesRef("hc:got-race", "A Game of Thrones", nil)
+	book.Author.ForeignID = "hc:george-rr-martin"
+	book.Author.Name = "George R.R. Martin"
+	book.Author.SortName = ""
+	book.Author.MetadataProvider = "hardcover"
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
+			lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{book},
+		}
+	})
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne: %v", err)
+	}
+
+	// Exactly the two pre-existing authors must remain — no third
+	// author should have been created.
+	authors, err := s.authors.List(ctx)
+	if err != nil {
+		t.Fatalf("List authors: %v", err)
+	}
+	if len(authors) != 2 {
+		t.Fatalf("authors = %d, want 2 (no new author created)", len(authors))
+	}
+
+	// The book must be linked to the identifier owner — not to the
+	// author that was matched by name. The previous bug returned
+	// matched.ID and silently attributed the book to the wrong author.
+	imported, err := s.books.GetByForeignID(ctx, "hc:got-race")
+	if err != nil || imported == nil {
+		t.Fatalf("imported book = %+v err=%v, want persisted", imported, err)
+	}
+	if imported.AuthorID != identifierOwner.ID {
+		t.Fatalf("book author_id = %d, want identifier owner %d (name-match %d is wrong)",
+			imported.AuthorID, identifierOwner.ID, nameMatch.ID)
+	}
+
+	// The HC foreign_id must still belong to the identifier owner
+	// only — the name-match author must not have been retroactively
+	// tagged.
+	nameMatchAliases, err := s.authors.ListAuthorIdentifiers(ctx, nameMatch.ID)
+	if err != nil {
+		t.Fatalf("ListAuthorIdentifiers(nameMatch): %v", err)
+	}
+	for _, ident := range nameMatchAliases {
+		if ident.ForeignID == "hc:george-rr-martin" {
+			t.Fatalf("name-match author %d was wrongly tagged with HC alias that belongs to author %d",
+				nameMatch.ID, identifierOwner.ID)
+		}
+	}
+}

--- a/internal/hardcoverlistsyncer/syncer_test.go
+++ b/internal/hardcoverlistsyncer/syncer_test.go
@@ -540,3 +540,178 @@ func TestSync_HydratesHardcoverEditions(t *testing.T) {
 		t.Fatalf("expected hydrated edition, got %+v", got)
 	}
 }
+
+// TestNormalizeAuthorName pins the canonicalization rules used by the
+// name-based fallback in ensureAuthor. Pairs of names that should collapse to
+// the same key must collapse, and distinct authors must remain distinct.
+func TestNormalizeAuthorName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"whitespace-only", "   \t\n", ""},
+		{"plain", "George R. R. Martin", "george r r martin"},
+		{"periods-stripped", "George R.R. Martin", "george r r martin"},
+		{"no-periods", "George R R Martin", "george r r martin"},
+		{"collapsed-whitespace", "Stephen   King", "stephen king"},
+		{"trimmed", "  Ursula K. Le Guin  ", "ursula k le guin"},
+		{"lowercased", "STEPHEN KING", "stephen king"},
+		{"commas-stripped", "Doe, John", "doe john"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeAuthorName(tc.in); got != tc.want {
+				t.Errorf("normalizeAuthorName(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeAuthorName_DistinctAuthors verifies the helper doesn't
+// over-collapse. Authors that share a surname or a common first-name token
+// must NOT map to the same key — otherwise the fallback in ensureAuthor
+// would incorrectly merge them.
+func TestNormalizeAuthorName_DistinctAuthors(t *testing.T) {
+	pairs := [][2]string{
+		{"Stephen King", "Stephen Hawking"},      // shared first name only
+		{"George R. R. Martin", "George Martin"}, // middle-initials differ
+	}
+	for _, p := range pairs {
+		if normalizeAuthorName(p[0]) == normalizeAuthorName(p[1]) {
+			t.Errorf("expected %q and %q to be distinct, both normalize to %q",
+				p[0], p[1], normalizeAuthorName(p[0]))
+		}
+	}
+}
+
+// TestSyncOne_ReusesAuthorByNormalizedName is the regression test for
+// issue #1223. A library populated by ABS/OpenLibrary has authors with OL
+// foreign_ids; a Hardcover list import brings authors with HC foreign_ids.
+// The two never match by primary foreign_id or alias. Without the fix, each
+// HC book creates a duplicate author row. With the fix, the syncer falls
+// back to a normalized-name match, attaches the HC id as an alias, and
+// reuses the existing author.
+func TestSyncOne_ReusesAuthorByNormalizedName(t *testing.T) {
+	s, repo := newTestSyncer(t)
+	ctx := context.Background()
+
+	existing := &models.Author{
+		ForeignID:        "OL-AUTHOR-MARTIN",
+		Name:             "George R. R. Martin",
+		SortName:         "Martin, George R. R.",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := s.authors.Create(ctx, existing); err != nil {
+		t.Fatalf("seed author: %v", err)
+	}
+
+	il := testImportList("HC Martin List", "hardcover", true)
+	if err := repo.Create(ctx, &il); err != nil {
+		t.Fatalf("seed list: %v", err)
+	}
+
+	// Hardcover hands back the same author under a different surface name
+	// ("George R.R. Martin" without spaces around the periods) and a
+	// brand-new HC foreign_id that nothing in the library knows about.
+	book := bookWithSeriesRef("hc:game-of-thrones", "A Game of Thrones", nil)
+	book.Author.ForeignID = "hc:george-rr-martin"
+	book.Author.Name = "George R.R. Martin"
+	book.Author.SortName = ""
+	book.Author.MetadataProvider = "hardcover"
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
+			lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{book},
+		}
+	})
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne: %v", err)
+	}
+
+	// Exactly one author must exist — the existing OL author, reused.
+	authors, err := s.authors.List(ctx)
+	if err != nil {
+		t.Fatalf("List authors: %v", err)
+	}
+	if len(authors) != 1 {
+		names := make([]string, 0, len(authors))
+		for _, a := range authors {
+			names = append(names, a.Name)
+		}
+		t.Fatalf("authors = %d (%v), want 1 (existing author reused; no duplicate)",
+			len(authors), names)
+	}
+	if authors[0].ID != existing.ID {
+		t.Fatalf("reused author id = %d, want existing %d", authors[0].ID, existing.ID)
+	}
+
+	// The book must be linked to the existing author.
+	imported, err := s.books.GetByForeignID(ctx, "hc:game-of-thrones")
+	if err != nil || imported == nil {
+		t.Fatalf("imported book = %+v err=%v, want persisted", imported, err)
+	}
+	if imported.AuthorID != existing.ID {
+		t.Fatalf("book author_id = %d, want existing author %d", imported.AuthorID, existing.ID)
+	}
+
+	// The HC foreign_id must have been attached as an alias so the next
+	// list sync hits the cheap path (GetByAnyForeignID) directly.
+	aliases, err := s.authors.ListAuthorIdentifiers(ctx, existing.ID)
+	if err != nil {
+		t.Fatalf("ListIdentifiers: %v", err)
+	}
+	found := false
+	for _, a := range aliases {
+		if a.ForeignID == "hc:george-rr-martin" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected HC alias %q attached to existing author, got %+v",
+			"hc:george-rr-martin", aliases)
+	}
+}
+
+// TestSyncOne_CreatesNewAuthorWhenNoNameMatch protects the fallback: when
+// neither the foreign_id nor a normalized-name match exists, the syncer
+// must still create the author. This guards against the fallback silently
+// swallowing real new authors.
+func TestSyncOne_CreatesNewAuthorWhenNoNameMatch(t *testing.T) {
+	s, repo := newTestSyncer(t)
+	ctx := context.Background()
+
+	il := testImportList("HC Fresh List", "hardcover", true)
+	if err := repo.Create(ctx, &il); err != nil {
+		t.Fatalf("seed list: %v", err)
+	}
+	book := bookWithSeriesRef("hc:fresh-book", "Fresh Book", nil)
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
+			lists: []hardcover.HCList{{ID: 12, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{book},
+		}
+	})
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne: %v", err)
+	}
+	authors, err := s.authors.List(ctx)
+	if err != nil {
+		t.Fatalf("List authors: %v", err)
+	}
+	if len(authors) != 1 {
+		t.Fatalf("authors = %d, want 1 new author created", len(authors))
+	}
+	imported, err := s.books.GetByForeignID(ctx, "hc:fresh-book")
+	if err != nil || imported == nil {
+		t.Fatalf("book should be imported: %+v err=%v", imported, err)
+	}
+	if imported.AuthorID != authors[0].ID {
+		t.Fatalf("book author_id = %d, want new author %d", imported.AuthorID, authors[0].ID)
+	}
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bindery-web",
-  "version": "1.19.0",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bindery-web",
-      "version": "1.19.0",
+      "version": "1.22.0",
       "license": "MIT",
       "dependencies": {
         "i18next": "^26.3.1",
@@ -32,7 +32,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.6.0",
-        "jsdom": "^29.1.0",
+        "jsdom": "^29.1.1",
         "msw": "^2.14.6",
         "postcss": "^8.5.15",
         "tailwindcss": "^4.2.4",
@@ -112,12 +112,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -126,29 +127,31 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -165,13 +168,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -181,13 +185,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -197,36 +202,39 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -236,53 +244,57 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -300,31 +312,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -332,13 +346,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3343,6 +3358,7 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -3684,6 +3700,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -4269,6 +4286,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -4640,9 +4658,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5050,7 +5068,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/web/package.json
+++ b/web/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.6.0",
-    "jsdom": "^29.1.0",
+    "jsdom": "^29.1.1",
     "msw": "^2.14.6",
     "postcss": "^8.5.15",
     "tailwindcss": "^4.2.4",
@@ -44,5 +44,9 @@
     "typescript-eslint": "^8.61.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"
+  },
+  "overrides": {
+    "undici": "^7.28.0",
+    "@babel/core": "^7.29.6"
   }
 }


### PR DESCRIPTION
Fixes #1223.

## Summary

When syncing a Hardcover import list against a library populated by another metadata provider (ABS / OpenLibrary), `ListSyncer.ensureAuthor` only matched authors by `GetByAnyForeignID` — which compares the Hardcover foreign_id against the canonical `foreign_id` and the `author_identifiers` alias table. Both lookups miss for libraries populated by a non-Hardcover provider: ABS books have no Hardcover ID, OpenLibrary authors carry `OL-` IDs that Hardcover does not hand out, and no alias has been written yet.

The result: every Hardcover list book created a fresh `wanted` row and a duplicate author row. On the affected library this produced ~140 duplicate books and ~39 split authors (per the issue's Discord report from cleb).

## What changed

`internal/hardcoverlistsyncer/syncer.go`

- **`ensureAuthor`** now tries a second lookup before falling through to `Create`. After `GetByAnyForeignID` returns nil, it calls the new `findExistingAuthorByName`, which scans `authors.List` and matches by a normalized-name key. On a hit, the Hardcover foreign_id is attached as an alias via `UpsertAuthorIdentifier` so subsequent list syncs take the cheap path (step 1) directly.
- The new fallback is best-effort: if the alias attach fails the syncer still reuses the matched author for this sync (logged at warn) and retries the attach on the next sync. The existing race-handling path (UNIQUE / `ErrAuthorIdentifierConflict`) is preserved.
- **`findExistingAuthorByName`** is a small helper scoped to this package. The lookup is linear over `List()` — acceptable here because list sync is a scheduled batch job (not request-path) and the author table is bounded by a single user's library. If the author table grows beyond comfortable, this should move to a SQL `LIKE` / `LOWER(...)` query on the author repo; flagged with a doc comment.
- **`normalizeAuthorName`** produces a canonical key: lowercased, periods / commas / semicolons / colons stripped, runs of whitespace condensed. `George R. R. Martin`, `George R.R. Martin`, and `george r r martin` all collapse to `george r r martin`. Returns `""` for empty / whitespace-only input so callers can short-circuit.

`internal/hardcoverlistsyncer/syncer_test.go`

- **`TestNormalizeAuthorName`** pins the canonicalization rules — pairs of inputs that must collapse together, plus empty / whitespace / trimming behavior.
- **`TestNormalizeAuthorName_DistinctAuthors`** is the negative guard — names that share a first-name token (`Stephen King` vs `Stephen Hawking`) or have different initials (`George R. R. Martin` vs `George Martin`) must NOT collapse to the same key, otherwise the fallback would incorrectly merge distinct authors.
- **`TestSyncOne_ReusesAuthorByNormalizedName`** is the integration regression test for #1223: seeds an existing `OL-AUTHOR-MARTIN` author, runs SyncOne with a Hardcover book whose author is `George R.R. Martin` (different surface name, no alias), and asserts (a) exactly one author row exists, (b) the book links to the existing author's id, and (c) the Hardcover foreign_id has been attached as an alias.
- **`TestSyncOne_CreatesNewAuthorWhenNoNameMatch`** protects the fallback: when neither foreign_id nor normalized-name match exists, the syncer must still create a fresh author row. Guards against the fallback silently swallowing real new authors.

## Scope

This PR implements the **author** side of the issue's proposed scope (sections 1 in the issue body). It deliberately does NOT touch the **book** side (section 2) for two reasons:

1. The book-deduplication path requires normalized `(author, title)` matching, which is a substantially larger surface (title-variant handling — subtitles, edition suffixes like `Part 1: Steel and Snow`, etc., is called out as "may warrant its own follow-up" in the issue itself).
2. Once the author side is fixed, the duplicate-author rows stop growing, and the existing per-author `/author/{id}/relink-upstream` affordance becomes tractable for the historical row cleanup. Book-side dedup can build on that.

## Tested by

- `go test ./internal/hardcoverlistsyncer/...` — new + existing tests cover the fallback, the positive match, the negative match (no false positives), and the create-new path.
- I cannot run `go build ./...` or `go vet` locally: this repo pins `go 1.25.11` in `go.mod` and the only Go toolchain available in my environment is 1.19. I verified the change with `gofmt -e -d` (clean) and a careful read-through of the diff against the existing patterns in `ensureAuthor` and the import-time author matcher in `internal/importer/`. Maintainers running CI on Go 1.25 will get the actual test signal.

## Related

- #1176 — adjacent cross-provider author identity work (search AKA names).
- #805 — adjacent Hardcover list-sync work (series refs).
- The importer-side author matcher in `internal/importer/scanner.go` already uses a similar `significantAuthorTokens` helper for filename→author reconciliation; this PR deliberately doesn't depend on it (different surface, different normalization rules) but the same shape is intentional.
