### PR TITLE
test(api): make path safety realpath assertion portable

### DIFF
--- a/changelog.d/path-safety-realpath-test.md
+++ b/changelog.d/path-safety-realpath-test.md
@@ -1,0 +1,2 @@
+### Fixed
+- Path-safety tests now compare resolved file paths so macOS `/var` temporary directories do not fail local runs.

--- a/internal/api/path_safety_test.go
+++ b/internal/api/path_safety_test.go
@@ -57,8 +57,12 @@ func TestLibraryRoots_ResolveContained(t *testing.T) {
 	if err := os.WriteFile(inside, []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got, ok := roots.ResolveContained(ctx, inside); !ok || got != inside {
-		t.Errorf("ResolveContained(inside) = %q, %v; want %q, true", got, ok, inside)
+	expectedInside, err := filepath.EvalSymlinks(inside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := roots.ResolveContained(ctx, inside); !ok || got != expectedInside {
+		t.Errorf("ResolveContained(inside) = %q, %v; want %q, true", got, ok, expectedInside)
 	}
 
 	// A secret outside the root, and a symlink to it placed INSIDE the root.


### PR DESCRIPTION
## Summary

Local macOS runs of `internal/api` failed because `t.TempDir()` can return a `/var/...` path while `filepath.EvalSymlinks` resolves the same file through `/private/var/...`. This keeps the path-safety test aligned with the strict `ResolveContained` contract by expecting the resolved path that the production helper returns.

- Compare the successful contained-path assertion against `filepath.EvalSymlinks(inside)`.
- Preserve the symlink escape, nonexistent path, and outside-root rejection coverage.
- Add a changelog fragment for the macOS local test portability fix.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (N/A - test-only change)
- [x] Added a changelog fragment under `changelog.d/` (not an edit to `CHANGELOG.md`) — see [changelog.d/README.md](../changelog.d/README.md)
- [x] Wiki pages updated if user-facing behaviour changed (N/A - test-only change)

## Test plan

- [x] `go test ./internal/api -run TestLibraryRoots_ResolveContained -count=1`
- [x] `go test ./internal/api -run TestLibraryRoots -count=1`
- [x] `go test ./internal/api -count=1`
