### PR TITLE
fix(web): support frontend validation on node 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           govulncheck ./...
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: npm ci --prefix web
@@ -77,7 +77,7 @@ jobs:
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: make smoke
@@ -151,7 +151,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: npm ci --prefix web
@@ -185,7 +185,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: npm ci --prefix web
@@ -393,7 +393,7 @@ jobs:
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: npm ci --prefix web

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: npm
           cache-dependency-path: web/package-lock.json
 
@@ -293,7 +293,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "26"
           cache: npm
           cache-dependency-path: web/package-lock.json
 

--- a/changelog.d/node26-frontend-validation.md
+++ b/changelog.d/node26-frontend-validation.md
@@ -1,0 +1,2 @@
+### Fixed
+- Frontend validation now runs under Node 26 with a stable Vitest/MSW test harness.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bindery-web",
-  "version": "1.19.0",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bindery-web",
-      "version": "1.19.0",
+      "version": "1.22.0",
       "license": "MIT",
       "dependencies": {
         "i18next": "^26.3.1",
@@ -4640,9 +4640,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/src/components/usePagination.ts
+++ b/web/src/components/usePagination.ts
@@ -2,21 +2,42 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 const SHARED_PAGE_SIZE_KEY = 'pageSize:shared'
 
+function pageSizeStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
 function readStoredPageSize(storageKey: string | undefined): number | null {
+  const storage = pageSizeStorage()
+  if (!storage) return null
   const keys = storageKey ? [`pageSize:${storageKey}`, SHARED_PAGE_SIZE_KEY] : [SHARED_PAGE_SIZE_KEY]
   for (const key of keys) {
-    const stored = localStorage.getItem(key)
-    if (stored) {
-      const n = parseInt(stored, 10)
-      if (!isNaN(n) && n > 0) return n
+    try {
+      const stored = storage.getItem(key)
+      if (stored) {
+        const n = parseInt(stored, 10)
+        if (!isNaN(n) && n > 0) return n
+      }
+    } catch {
+      return null
     }
   }
   return null
 }
 
 function persistPageSize(storageKey: string | undefined, size: number) {
-  if (storageKey) localStorage.setItem(`pageSize:${storageKey}`, String(size))
-  localStorage.setItem(SHARED_PAGE_SIZE_KEY, String(size))
+  const storage = pageSizeStorage()
+  if (!storage) return
+  try {
+    if (storageKey) storage.setItem(`pageSize:${storageKey}`, String(size))
+    storage.setItem(SHARED_PAGE_SIZE_KEY, String(size))
+  } catch {
+    // Storage is a user preference only; unavailable storage should not break lists.
+  }
 }
 
 /**
@@ -88,10 +109,7 @@ export function usePagination<T>(items: T[], defaultPageSize = 50, storageKey?: 
   const handlePageSizeChange = (size: number) => {
     setPageSize(size)
     setPage(1)
-    if (storageKey) {
-      localStorage.setItem(`pageSize:${storageKey}`, String(size))
-    }
-    localStorage.setItem(SHARED_PAGE_SIZE_KEY, String(size))
+    persistPageSize(storageKey, size)
   }
 
   return {

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import BookDetailPage, { SearchResultsSection } from './BookDetailPage'
 import { api } from '../api/client'
@@ -596,19 +596,24 @@ describe('BookDetailPage — live import polling (#1161)', () => {
       renderBookDetailPage()
 
       // Initial load: downloading, no file on disk yet.
-      await vi.advanceTimersByTimeAsync(0)
-      expect(screen.queryByText('/lib/leviathan.m4b')).not.toBeInTheDocument()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
       expect(vi.mocked(api.getBook).mock.calls.length).toBe(1)
+      expect(screen.queryByText('/lib/leviathan.m4b')).not.toBeInTheDocument()
 
       // The background import finishes; the 5s poll picks it up live.
-      await vi.advanceTimersByTimeAsync(5000)
-      await vi.advanceTimersByTimeAsync(0) // flush the setBook re-render
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
       expect(vi.mocked(api.getBook).mock.calls.length).toBeGreaterThan(1)
       expect(screen.getByText('/lib/leviathan.m4b')).toBeInTheDocument()
 
       // Once the book settles (imported), polling stops — no further fetches.
       const settledCalls = vi.mocked(api.getBook).mock.calls.length
-      await vi.advanceTimersByTimeAsync(15000)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15000)
+      })
       expect(vi.mocked(api.getBook).mock.calls.length).toBe(settledCalls)
     } finally {
       vi.useRealTimers()

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -4,10 +4,24 @@ import { server } from './test/msw'
 
 const originalFetch = globalThis.fetch
 let mswFetch = originalFetch
+const apiOrigin = 'http://localhost'
+
+function localApiURL(pathname: string, search = '', hash = '') {
+  return new URL(`${pathname}${search}${hash}`, apiOrigin)
+}
 
 function resolveRelativeApiURL(input: RequestInfo | URL): RequestInfo | URL {
   if (typeof input === 'string' && input.startsWith('/api/')) {
-    return new URL(input, 'http://localhost').toString()
+    return new URL(input, apiOrigin).toString()
+  }
+  if (input instanceof URL && input.pathname.startsWith('/api/')) {
+    return localApiURL(input.pathname, input.search, input.hash)
+  }
+  if (typeof Request !== 'undefined' && input instanceof Request) {
+    const url = new URL(input.url)
+    if (url.pathname.startsWith('/api/')) {
+      return new Request(localApiURL(url.pathname, url.search, url.hash), input)
+    }
   }
   return input
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
   base: './',
   test: {
     environment: 'jsdom',
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost/',
+      },
+    },
     globals: true,
     setupFiles: './src/test-setup.ts',
   },


### PR DESCRIPTION
## Summary

Node 26 exposed frontend validation drift in the Vitest/MSW harness: API requests needed a stable jsdom origin and Request/URL normalization, pagination needed to tolerate unavailable test storage, and one polling test depended on unwrapped fake-timer advancement. This makes the frontend suite pass under Node 26, aligns CI/security workflow Node pins with the Docker build image, and supersedes #1211 by carrying the `undici` lockfile update here. Closes #1201.

- Configure jsdom with `http://localhost/` and normalize `/api/...` fetches for string, `URL`, and `Request` inputs without relaxing MSW's strict unhandled-request behavior.
- Guard pagination page-size persistence when `localStorage` is unavailable or throws.
- Make the BookDetail live-import polling test deterministic with React `act` around fake timer advancement.
- Update `undici` to 7.28.0 in the web lockfile and set CI/security `actions/setup-node` pins to Node 26.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed (N/A - CI/test harness only)
- [x] Added a changelog fragment under `changelog.d/` (not an edit to `CHANGELOG.md`) — see [changelog.d/README.md](../changelog.d/README.md)
- [x] Wiki pages updated if user-facing behaviour changed (N/A - validation-only change)

## Test plan

- [x] `node --version` (`v26.0.0`)
- [x] `npm ci --prefix web`
- [x] `npm --prefix web test -- QueuePage.test.tsx SettingsPage.test.tsx BookDetailPage.test.tsx`
- [x] `npm --prefix web test`
- [x] `npm --prefix web run lint` (passes with existing warnings)
- [x] `npm --prefix web run typecheck`
- [x] `npm --prefix web run build`
