### PR TITLE
fix(importer): stop narrator/chapter tags from breaking audiobook scan matching (#1239)

### DIFF
--- a/internal/importer/audiotag.go
+++ b/internal/importer/audiotag.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/dhowden/tag"
@@ -55,14 +56,31 @@ func readAudioTagsFrom(r io.ReadSeeker) (AudioTags, error) {
 	}, nil
 }
 
+// narratorCreditRe matches the leading "Read by" / "Narrated by" credit that
+// chapter-split audiobook releases frequently store in the Artist tag instead
+// of the author. Such a value is a narrator, not a book author, so treating it
+// as the author poisons library-scan matching (#1239).
+var narratorCreditRe = regexp.MustCompile(`(?i)^(read|narrated|performed|presented|told)\s+by\b`)
+
+// isNarratorCredit reports whether s looks like a narrator credit ("Read by
+// Nigel Planer") rather than an author name.
+func isNarratorCredit(s string) bool {
+	return narratorCreditRe.MatchString(strings.TrimSpace(s))
+}
+
 // pickAudioAuthor prefers the Artist tag (which audiobook tooling
 // conventionally uses for the book's author) and falls back to AlbumArtist
-// or Composer for files that leave Artist empty.
+// or Composer for files that leave Artist empty. Narrator-credit values
+// ("Read by …") are skipped rather than returned as the author (#1239); when
+// every candidate is empty or a narrator credit, the caller keeps whatever the
+// folder hierarchy resolved instead.
 func pickAudioAuthor(m tag.Metadata) string {
 	for _, candidate := range []string{m.Artist(), m.AlbumArtist(), m.Composer()} {
-		if s := strings.TrimSpace(candidate); s != "" {
-			return s
+		s := strings.TrimSpace(candidate)
+		if s == "" || isNarratorCredit(s) {
+			continue
 		}
+		return s
 	}
 	return ""
 }

--- a/internal/importer/audiotag_test.go
+++ b/internal/importer/audiotag_test.go
@@ -146,6 +146,37 @@ func TestPickAudioAuthor_Empty(t *testing.T) {
 	}
 }
 
+func TestPickAudioAuthor_SkipsNarratorCredit(t *testing.T) {
+	// Artist holds a narrator credit; the real author is in AlbumArtist.
+	got := pickAudioAuthor(fakeMetadata{artist: "Read by Nigel Planer", albumArtist: "Terry Pratchett"})
+	if got != "Terry Pratchett" {
+		t.Errorf("expected narrator credit to be skipped for AlbumArtist, got %q", got)
+	}
+}
+
+func TestPickAudioAuthor_NarratorOnlyReturnsEmpty(t *testing.T) {
+	// Only a narrator credit is present: return empty so the caller keeps the
+	// folder-resolved author instead of a narrator name.
+	if got := pickAudioAuthor(fakeMetadata{artist: "Narrated by Stephen Fry"}); got != "" {
+		t.Errorf("expected empty when only a narrator credit is present, got %q", got)
+	}
+}
+
+func TestIsNarratorCredit(t *testing.T) {
+	credits := []string{"Read by Nigel Planer", "read by X", "Narrated by Stephen Fry", "Performed by A. B.", "Told by Someone"}
+	for _, c := range credits {
+		if !isNarratorCredit(c) {
+			t.Errorf("expected %q to be a narrator credit", c)
+		}
+	}
+	authors := []string{"Terry Pratchett", "Reade Brothers", "Narrator", "Bradbury, Ray", "Reading Rainbow"}
+	for _, a := range authors {
+		if isNarratorCredit(a) {
+			t.Errorf("expected %q to NOT be a narrator credit", a)
+		}
+	}
+}
+
 // buildID3v23 returns an ID3v2.3 header block containing TIT2 (title), TPE1
 // (artist), and a TXXX ASIN frame. The returned bytes are a valid tag
 // followed by no audio — tag.ReadFrom only parses the tag, so this is

--- a/internal/importer/chaptertitle_test.go
+++ b/internal/importer/chaptertitle_test.go
@@ -1,0 +1,40 @@
+package importer
+
+import "testing"
+
+func TestLooksLikeChapterTitle(t *testing.T) {
+	chapters := []string{
+		"04 - Sinister Grey Mists Rolled Thru Docks Of Morpork",
+		"07 - The Temple Frescoes Of Al-Khali",
+		"04. Something",
+		"04_Something",
+		"1 - Intro",
+		"Chapter 3",
+		"chapter 12 - The End",
+		"Track 5",
+		"Part 2",
+		"Disc 1",
+		"CD 2",
+	}
+	for _, c := range chapters {
+		if !looksLikeChapterTitle(c) {
+			t.Errorf("expected %q to look like a chapter title", c)
+		}
+	}
+
+	titles := []string{
+		"Sourcery",
+		"1984",
+		"2001: A Space Odyssey",
+		"11/22/63",
+		"Slaughterhouse-Five",
+		"The Temporal Leader",
+		"Catch-22",
+		"Part of the Pattern", // "Part" not followed by a number
+	}
+	for _, ti := range titles {
+		if looksLikeChapterTitle(ti) {
+			t.Errorf("expected %q to NOT look like a chapter title", ti)
+		}
+	}
+}

--- a/internal/importer/chaptertitle_test.go
+++ b/internal/importer/chaptertitle_test.go
@@ -31,6 +31,15 @@ func TestLooksLikeChapterTitle(t *testing.T) {
 		"The Temporal Leader",
 		"Catch-22",
 		"Part of the Pattern", // "Part" not followed by a number
+		// Real numeric titles that must NOT be treated as chapters: the colon
+		// is a subtitle separator, not a chapter separator, and a digit after
+		// the separator means a number-dash/dot-number title, not "NN - Title".
+		"24: Live Another Day",
+		"42: The Answer",
+		"7: Seven",
+		"1-800 Where R You",
+		"3.14 Pi Day",
+		"Section 8", // "section" is not a chapter keyword (too title-like)
 	}
 	for _, ti := range titles {
 		if looksLikeChapterTitle(ti) {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -2047,11 +2047,17 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 // scanner has no reason to re-reconcile a file that's already where it
 // should be, and re-attaching would churn book_files rows for no benefit.
 // chapterTitleRe matches embedded-tag titles that name a track/chapter rather
-// than the book: a leading track number with a separator ("04 - Title", "04.
-// Title", "04_Title") or a Chapter/Track/Part/Disc/CD/Section keyword followed
-// by a number. The {1,3}-digit + required-separator shape deliberately does not
-// match year-like or numeric titles ("1984", "2001: A Space Odyssey").
-var chapterTitleRe = regexp.MustCompile(`(?i)^(\d{1,3}\s*[-._):]\s*\S|(chapter|track|part|disc|cd|section)\b\s*\.?\s*\d)`)
+// than the book: a leading track number followed by a dash/dot/underscore and a
+// NON-digit ("04 - Title", "04. Title", "04_Title"), or a Chapter/Track/Part/
+// Disc/CD keyword followed by a number.
+//
+// The shape is deliberately narrow to avoid discarding real numeric titles:
+//   - the {1,3}-digit cap skips years ("1984", "2001: A Space Odyssey");
+//   - the colon is NOT a separator, so subtitle titles survive ("24: Live
+//     Another Day", "7: Seven");
+//   - requiring a non-digit after the separator skips number-dash/dot-number
+//     titles ("1-800 Where R You", "3.14 …").
+var chapterTitleRe = regexp.MustCompile(`(?i)^(\d{1,3}\s*[-._]\s*\D|(chapter|track|part|disc|cd)\b\s*\.?\s*\d)`)
 
 // looksLikeChapterTitle reports whether an embedded-tag title looks like a
 // per-track chapter name rather than a book title (#1239).

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -2057,6 +2057,13 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 //     Another Day", "7: Seven");
 //   - requiring a non-digit after the separator skips number-dash/dot-number
 //     titles ("1-800 Where R You", "3.14 …").
+//
+// A residual ambiguity remains: a genuinely numbered title ("21 - Jump Street",
+// "8 - Mile") is indistinguishable from "04 - Chapter Name" without sibling or
+// semantic context, so it is treated as a chapter. The blast radius is small —
+// this only suppresses the tag title when the folder hierarchy already resolved
+// a title to fall back to (see the caller), so the worst case is using the
+// folder's title for such a book rather than the tag's.
 var chapterTitleRe = regexp.MustCompile(`(?i)^(\d{1,3}\s*[-._]\s*\D|(chapter|track|part|disc|cd)\b\s*\.?\s*\d)`)
 
 // looksLikeChapterTitle reports whether an embedded-tag title looks like a

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1910,7 +1910,7 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 				// already gave a real book title, don't let a per-chapter tag
 				// title clobber it — every track would otherwise parse to a
 				// different "book" and none would reconcile (#1239).
-				if tags.Title != "" && !(layoutTitle != "" && looksLikeChapterTitle(tags.Title)) {
+				if tags.Title != "" && (layoutTitle == "" || !looksLikeChapterTitle(tags.Title)) {
 					parsed.Title = tags.Title
 				}
 				if tags.Author != "" {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1884,12 +1884,14 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		// an "Author - Title" / "Title - Author" filename — the scan must not
 		// assume a single filename order (#754).
 		parsed := ParseFilename(path)
+		var layoutTitle string
 		if a, t, ok := authorTitleFromLayout(path, s.libraryDir, s.audiobookDir); ok {
 			if a != "" {
 				parsed.Author = a
 			}
 			if t != "" {
 				parsed.Title = t
+				layoutTitle = t
 			}
 		}
 
@@ -1903,7 +1905,12 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 					"path", path, "error", err)
 				tagReadFailed++
 			} else {
-				if tags.Title != "" {
+				// Multi-part audiobooks tag each track with its chapter name
+				// ("04 - Sinister Grey Mists..."). When the folder hierarchy
+				// already gave a real book title, don't let a per-chapter tag
+				// title clobber it — every track would otherwise parse to a
+				// different "book" and none would reconcile (#1239).
+				if tags.Title != "" && !(layoutTitle != "" && looksLikeChapterTitle(tags.Title)) {
 					parsed.Title = tags.Title
 				}
 				if tags.Author != "" {
@@ -2039,6 +2046,19 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 // Books with a valid on-disk file at any recorded path are skipped — the
 // scanner has no reason to re-reconcile a file that's already where it
 // should be, and re-attaching would churn book_files rows for no benefit.
+// chapterTitleRe matches embedded-tag titles that name a track/chapter rather
+// than the book: a leading track number with a separator ("04 - Title", "04.
+// Title", "04_Title") or a Chapter/Track/Part/Disc/CD/Section keyword followed
+// by a number. The {1,3}-digit + required-separator shape deliberately does not
+// match year-like or numeric titles ("1984", "2001: A Space Odyssey").
+var chapterTitleRe = regexp.MustCompile(`(?i)^(\d{1,3}\s*[-._):]\s*\S|(chapter|track|part|disc|cd|section)\b\s*\.?\s*\d)`)
+
+// looksLikeChapterTitle reports whether an embedded-tag title looks like a
+// per-track chapter name rather than a book title (#1239).
+func looksLikeChapterTitle(title string) bool {
+	return chapterTitleRe.MatchString(strings.TrimSpace(title))
+}
+
 func isReconcileCandidate(b *models.Book) bool {
 	if b == nil {
 		return false

--- a/internal/importer/scanner_chaptertag_test.go
+++ b/internal/importer/scanner_chaptertag_test.go
@@ -1,0 +1,62 @@
+package importer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestScanLibrary_ChapterTaggedAudiobookReconciles is the end-to-end #1239
+// regression: a multi-part audiobook whose tracks carry per-chapter title tags
+// and a "Read by …" narrator artist must still reconcile to the catalogue book
+// via the Author/Book folder hierarchy, instead of every track landing in
+// Unmatched. It drives the real ScanLibrary path (ReadAudioTags reads the file
+// on disk), so it would catch the layoutTitle/tag wiring being inverted.
+func TestScanLibrary_ChapterTaggedAudiobookReconciles(t *testing.T) {
+	s, _, books, authors, _, libraryDir, ctx := unmatchedFixture(t)
+
+	author := &models.Author{ForeignID: "ol:pratchett", Name: "Terry Pratchett", SortName: "Pratchett, Terry", Monitored: true, MetadataProvider: "openlibrary"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "ol:sourcery", AuthorID: author.ID, Title: "Sourcery", SortTitle: "sourcery",
+		Status: models.BookStatusWanted, Monitored: true, AnyEditionOK: true,
+		MediaType: models.MediaTypeAudiobook, MetadataProvider: "openlibrary",
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	// Lay the track out as <library>/Terry Pratchett/Sourcery/<track>.mp3, tagged
+	// with a chapter title and a narrator credit in the Artist field — exactly
+	// the shape that previously poisoned the match.
+	dir := filepath.Join(libraryDir, "Terry Pratchett", "Sourcery")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	trackPath := filepath.Join(dir, "dw05_04.mp3")
+	tagged := buildID3v23("04 - Sinister Grey Mists Rolled Thru Docks Of Morpork", "Read by Nigel Planer", "")
+	if err := os.WriteFile(trackPath, tagged, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	paths, err := books.ListAllBookFilePaths(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, p := range paths {
+		if filepath.Clean(p) == filepath.Clean(trackPath) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("chapter-tagged track was not reconciled to the catalogue book; book_file paths = %v", paths)
+	}
+}


### PR DESCRIPTION
Fixes #1239.

## Problem

Library scan resolves author/title correctly from the `Author/Book/file` folder hierarchy, then unconditionally overrides both with the file's embedded audio tags (the #303 behaviour). For chapter-split audiobooks that override is actively wrong: each track is tagged with its **chapter title** (`04 - Sinister Grey Mists Rolled Thru Docks Of Morpork`) and a **narrator credit** in the Artist field (`Read by Nigel Planer`). After the override, every track parses to a different "book" authored by the narrator, so none reconcile against the catalogue and the entire audiobook lands in **Unmatched** — reported on Discord as hundreds of unmatched tracks.

## Fix

Two surgical guards in `internal/importer`:

1. **`pickAudioAuthor` skips narrator credits.** `Read by` / `Narrated by` / `Performed by` / etc. values are no longer returned as the author; the picker falls through to AlbumArtist/Composer (usually the real author) and returns empty when only a credit is present, so the folder-resolved author survives.
2. **Chapter-style tag titles no longer clobber a folder-resolved title.** When the folder hierarchy already produced a title, a tag title that looks like a track/chapter (`04 - ...`, `Chapter 3`, `Track 5`, `Part 2`) is ignored. The `{1,3}`-digit + required-separator shape deliberately does not match numeric/year titles, so `1984`, `2001: A Space Odyssey`, and `11/22/63` still pass through.

Well-tagged single-file releases keep the #303 behaviour: a genuine tag title/author still overrides folder parsing.

## Tests

- `pickAudioAuthor` skips a narrator Artist for the AlbumArtist author, and returns empty when only a credit exists.
- `isNarratorCredit` positive/negative cases (guards against `Reade`, `Reading`, `Narrator` false positives).
- `looksLikeChapterTitle` positives (chapter/track/part forms) and negatives (`Sourcery`, `1984`, `2001: A Space Odyssey`, `Slaughterhouse-Five`, `Catch-22`).
- Full `internal/importer` suite passes.

Note: this is the minimal (1)+(2) fix from the issue. The larger structural item — grouping audiobook tracks by directory so a folder contributes one reconcile attempt instead of N — is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)