### PR TITLE
fix(hardcover): reconcile list-sync authors/books against the library instead of duplicating (#1223)

### DIFF
--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/metadata/hardcover"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/textutil"
 )
 
 // ListSyncer syncs enabled Hardcover import lists into Bindery's book catalogue.
@@ -181,6 +182,11 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 
 	slog.Info("syncing hardcover list", "list", il.Name, "slug", il.URL, "books", len(books))
 
+	// Index existing authors by normalized name so a Hardcover author already in
+	// the library under a different provider's foreign id (e.g. an OpenLibrary
+	// author imported via ABS) is reused instead of duplicated (#1223).
+	nameIndex := s.buildAuthorNameIndex(ctx)
+
 	for _, book := range books {
 		if book.ForeignID == "" {
 			continue
@@ -194,9 +200,21 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 		}
 
 		// Look up or create the author
-		authorID, err := s.ensureAuthor(ctx, &book)
+		authorID, err := s.ensureAuthor(ctx, &book, nameIndex)
 		if err != nil {
 			slog.Warn("failed to ensure author for book", "title", book.Title, "error", err)
+			continue
+		}
+
+		// The book may already exist in the library under this author via a
+		// different source (ABS, Calibre, manual) with no Hardcover foreign id.
+		// Bind to that row instead of creating a duplicate "wanted" entry — the
+		// canonical dedup key collapses subtitle/case/foreign-id differences
+		// (#1223), the same cross-source bind the Calibre/ABS importers use.
+		if owned, derr := s.books.FindByAuthorAndDedupKey(ctx, authorID, book.Title); derr != nil {
+			slog.Warn("hardcover list sync: dedup-key lookup failed", "title", book.Title, "error", derr)
+		} else if owned != nil {
+			slog.Debug("book already owned under author, skipping", "title", book.Title, "author_id", authorID, "existing_id", owned.ID)
 			continue
 		}
 
@@ -267,9 +285,49 @@ func (s *ListSyncer) hydrateHardcoverEditions(ctx context.Context, book *models.
 	})
 }
 
-// ensureAuthor looks up the author by foreign ID, creating a minimal record if
-// missing. Returns the author's database ID.
-func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book) (int64, error) {
+// buildAuthorNameIndex maps each existing author's normalized name to the
+// matching rows. Used by ensureAuthor to reconcile a Hardcover author against
+// one already in the library under a different provider's foreign id (#1223).
+// A failed list is non-fatal: the index is empty and ensureAuthor falls back to
+// creating authors as before.
+func (s *ListSyncer) buildAuthorNameIndex(ctx context.Context) map[string][]models.Author {
+	index := make(map[string][]models.Author)
+	authors, err := s.authors.List(ctx)
+	if err != nil {
+		slog.Warn("hardcover list sync: failed to index authors by name; duplicate-author guard disabled", "error", err)
+		return index
+	}
+	for i := range authors {
+		key := textutil.NormalizeAuthorName(authors[i].Name)
+		if key == "" {
+			continue
+		}
+		index[key] = append(index[key], authors[i])
+	}
+	return index
+}
+
+// uniqueAuthorByName returns the single existing author whose normalized name
+// matches, or nil when there is no match or the match is ambiguous (more than
+// one author shares the normalized name — e.g. disambiguated namesakes). The
+// ambiguous case deliberately falls through to creating a new author rather
+// than guessing which namesake to merge into.
+func uniqueAuthorByName(index map[string][]models.Author, name string) *models.Author {
+	key := textutil.NormalizeAuthorName(name)
+	if key == "" {
+		return nil
+	}
+	matches := index[key]
+	if len(matches) != 1 {
+		return nil
+	}
+	return &matches[0]
+}
+
+// ensureAuthor looks up the author by foreign ID, then by normalized name,
+// creating a minimal record only if neither matches. Returns the author's
+// database ID.
+func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book, nameIndex map[string][]models.Author) (int64, error) {
 	if book.Author == nil {
 		return 0, fmt.Errorf("book %q has no author metadata", book.Title)
 	}
@@ -280,6 +338,18 @@ func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book) (int64
 	}
 	if existing != nil {
 		return existing.ID, nil
+	}
+
+	// Name fallback: reuse an existing author with the same normalized name
+	// instead of spawning a parallel row, and attach the Hardcover foreign id
+	// as an alias so future syncs match by id (#1223).
+	if matched := uniqueAuthorByName(nameIndex, book.Author.Name); matched != nil {
+		if fid := strings.TrimSpace(book.Author.ForeignID); fid != "" {
+			if err := s.authors.UpsertAuthorIdentifier(ctx, matched.ID, fid); err != nil && !errors.Is(err, db.ErrAuthorIdentifierConflict) {
+				slog.Warn("hardcover list sync: failed to attach author alias", "author", matched.Name, "foreignID", fid, "error", err)
+			}
+		}
+		return matched.ID, nil
 	}
 
 	// Create a minimal author record

--- a/internal/hardcoverlistsyncer/syncer_test.go
+++ b/internal/hardcoverlistsyncer/syncer_test.go
@@ -83,6 +83,115 @@ func TestSync_IgnoresDisabledHardcoverLists(t *testing.T) {
 	}
 }
 
+func TestUniqueAuthorByName(t *testing.T) {
+	index := map[string][]models.Author{
+		"john smith": {{ID: 1, Name: "John Smith"}, {ID: 2, Name: "John Smith"}}, // ambiguous namesakes
+		"jane doe":   {{ID: 3, Name: "Jane Doe"}},
+	}
+	// Ambiguous → nil (never guess which namesake to merge into).
+	if got := uniqueAuthorByName(index, "John  Smith"); got != nil {
+		t.Errorf("ambiguous match should return nil, got %+v", got)
+	}
+	// Unique → match (normalization collapses spacing/case).
+	if got := uniqueAuthorByName(index, "  jane   DOE "); got == nil || got.ID != 3 {
+		t.Errorf("expected unique match id 3, got %+v", got)
+	}
+	// No match → nil.
+	if got := uniqueAuthorByName(index, "Nobody Here"); got != nil {
+		t.Errorf("no match should return nil, got %+v", got)
+	}
+}
+
+// TestSyncOne_ReusesAuthorByNameAndDedupsOwnedBook is the #1223 regression:
+// a Hardcover list whose author/book already exist in the library under a
+// different provider's foreign id must not spawn a parallel author row or a
+// duplicate "wanted" book. The author is reconciled by normalized name (and
+// gets the Hardcover id attached as an alias), and the already-owned book is
+// bound by canonical dedup key instead of re-created.
+func TestSyncOne_ReusesAuthorByNameAndDedupsOwnedBook(t *testing.T) {
+	s, repo := newTestSyncer(t)
+	ctx := context.Background()
+
+	// Existing OpenLibrary-backed author + owned book, as an ABS import leaves them.
+	existingAuthor := &models.Author{
+		ForeignID:        "ol:OL123A",
+		Name:             "George R. R. Martin",
+		SortName:         "Martin, George R. R.",
+		MetadataProvider: "openlibrary",
+	}
+	if err := s.authors.Create(ctx, existingAuthor); err != nil {
+		t.Fatalf("seed author: %v", err)
+	}
+	ownedBook := &models.Book{
+		ForeignID:        "ol:OL999W",
+		Title:            "A Game of Thrones",
+		AuthorID:         existingAuthor.ID,
+		MetadataProvider: "openlibrary",
+		Status:           models.BookStatusImported,
+	}
+	if err := s.books.Create(ctx, ownedBook); err != nil {
+		t.Fatalf("seed book: %v", err)
+	}
+
+	il := testImportList("HC", "hardcover", true)
+	if err := repo.Create(ctx, &il); err != nil {
+		t.Fatalf("seed list: %v", err)
+	}
+
+	hcAuthor := func() *models.Author {
+		return &models.Author{ForeignID: "hc:grrm", Name: "George R.R. Martin", MetadataProvider: "hardcover"}
+	}
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
+			lists: []hardcover.HCList{{ID: 5, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{
+				// Same book, spacing-variant author name, no Hardcover book id match.
+				{ForeignID: "hc:got", Title: "A Game of Thrones", MetadataProvider: "hardcover", Author: hcAuthor()},
+				// Genuinely new book by the same author.
+				{ForeignID: "hc:clash", Title: "A Clash of Kings", MetadataProvider: "hardcover", Author: hcAuthor()},
+			},
+		}
+	})
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne: %v", err)
+	}
+
+	// No duplicate author row.
+	authors, err := s.authors.List(ctx)
+	if err != nil {
+		t.Fatalf("List authors: %v", err)
+	}
+	if len(authors) != 1 {
+		t.Fatalf("expected the existing author to be reused (1 author), got %d", len(authors))
+	}
+
+	// Hardcover foreign id attached as an alias on the existing author.
+	byHC, err := s.authors.GetByAnyForeignID(ctx, "hc:grrm")
+	if err != nil {
+		t.Fatalf("GetByAnyForeignID: %v", err)
+	}
+	if byHC == nil || byHC.ID != existingAuthor.ID {
+		t.Fatalf("expected hc:grrm alias to resolve to existing author %d, got %+v", existingAuthor.ID, byHC)
+	}
+
+	// Owned book not duplicated; exactly one new book created under the same author.
+	booksUnder, err := s.books.ListByAuthor(ctx, existingAuthor.ID)
+	if err != nil {
+		t.Fatalf("ListByAuthor: %v", err)
+	}
+	if len(booksUnder) != 2 {
+		t.Fatalf("expected 2 books (owned + 1 new), got %d: %+v", len(booksUnder), booksUnder)
+	}
+	titles := map[string]bool{}
+	for _, b := range booksUnder {
+		titles[b.Title] = true
+	}
+	if !titles["A Game of Thrones"] || !titles["A Clash of Kings"] {
+		t.Fatalf("unexpected book set under author: %v", titles)
+	}
+}
+
 func TestSortName(t *testing.T) {
 	tests := []struct {
 		in, want string


### PR DESCRIPTION
Fixes #1223.

## Problem

The Hardcover import-list syncer matched **both authors and books purely by Hardcover foreign id**:

- `ensureAuthor` → `GetByAnyForeignID(hc id)`. An author already in the library under another provider's id (an OpenLibrary author imported via ABS) never matched, so every Hardcover list spawned a **parallel author row**.
- `syncList` → `GetByForeignID(hc book id)`. An owned book has no Hardcover id, so every already-owned book came in as a fresh **"wanted" duplicate**.

Reported on Discord: a Hardcover list created ~140 duplicate books and split ~39 authors into two rows each.

## Fix (`internal/hardcoverlistsyncer/syncer.go`)

1. **Author name fallback.** When the foreign-id lookup misses, `ensureAuthor` now matches an existing author by normalized name (`textutil.NormalizeAuthorName`, so `George R. R. Martin` and `George R.R. Martin` collapse to the same key). On a *unique* match it reuses that author and attaches the Hardcover foreign id as an alias (`UpsertAuthorIdentifier`), so subsequent syncs match by id in O(1). Ambiguous namesakes (more than one author sharing a normalized name) deliberately fall through to creating a new row rather than guessing which to merge into.
2. **Book dedup-key bind.** Before creating, `syncList` binds each list book to an existing owned row by canonical dedup key (`FindByAuthorAndDedupKey` — the same cross-source bind the Calibre/ABS importers use, which collapses subtitle/case/foreign-id/umlaut differences). A matched book is skipped instead of duplicated.

The author index is built once per list sync from `AuthorRepo.List`; a failed list disables the name guard (logs and falls back to the old create-by-id behaviour) rather than failing the sync.

## Tests

- `TestUniqueAuthorByName` — unique match (normalization-insensitive), ambiguous → nil, no match → nil.
- `TestSyncOne_ReusesAuthorByNameAndDedupsOwnedBook` — end-to-end via the fake client: an OL-backed author + owned book, a Hardcover list whose first entry is the same book under a spacing-variant author name and whose second is a genuinely new book. Asserts exactly one author (reused), the `hc:` alias resolves to it, the owned book is not duplicated, and the new book is created under the same author.
- Full `internal/hardcoverlistsyncer` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)