### PR TITLE
fix(api): ownership-check bulk book delete (#1242)

### DIFF
--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -340,7 +340,7 @@ func (h *BulkHandler) BooksBulk(w http.ResponseWriter, r *http.Request) {
 		case "unmonitor":
 			opErr = h.setBookMonitored(r.Context(), id, false)
 		case "delete":
-			opErr = h.books.Delete(r.Context(), id)
+			opErr = h.deleteBook(r.Context(), id)
 		case "search":
 			book, err := h.books.GetByID(r.Context(), id)
 			if err != nil || book == nil || !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
@@ -443,6 +443,22 @@ func (h *BulkHandler) setAuthorMonitored(ctx context.Context, id int64, monitore
 	}
 	author.Monitored = monitored
 	return h.authors.Update(ctx, author)
+}
+
+// deleteBook removes a book after a Tier-1 ownership check, mirroring the
+// single-book BookHandler.Delete guard. Without this the bulk delete path
+// deleted purely by id (BookRepo.Delete is `DELETE FROM books WHERE id=?`),
+// letting a non-admin user cascade-delete another tenant's books under
+// BINDERY_ENFORCE_TENANCY.
+func (h *BulkHandler) deleteBook(ctx context.Context, id int64) error {
+	book, err := h.books.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if book == nil || !auth.CheckOwnership(ctx, book.OwnerUserID) {
+		return errBulkBookNotOwned
+	}
+	return h.books.Delete(ctx, id)
 }
 
 func (h *BulkHandler) setBookMonitored(ctx context.Context, id int64, monitored bool) error {

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -1211,6 +1211,55 @@ func TestBulk_Book_OwnershipMatrix(t *testing.T) {
 	}
 }
 
+// TestBulk_Book_Delete_OwnershipMatrix guards the bulk delete path against the
+// cross-tenant IDOR fixed alongside this test: with the gate on, a non-owner
+// must not be able to delete another user's book, and the row must survive.
+func TestBulk_Book_Delete_OwnershipMatrix(t *testing.T) {
+	cases := []struct {
+		name        string
+		gateOn      bool
+		callerIsBob bool
+		admin       bool
+		wantOK      bool
+		wantDeleted bool
+	}{
+		{"gate on, cross-user blocked", true, true, false, false, false},
+		{"gate on, owner allowed", true, false, false, true, true},
+		{"gate on, admin allowed", true, true, true, true, true},
+		{"gate off, cross-user allowed", false, true, false, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth.SetEnforceTenancyForTests(t, tc.gateOn)
+			f := seedTwoUserBulk(t)
+
+			caller := f.u1
+			role := "user"
+			if tc.callerIsBob {
+				caller = f.u2
+			}
+			if tc.admin {
+				caller = 99
+				role = "admin"
+			}
+
+			body := fmt.Sprintf(`{"ids":[%d],"action":"delete"}`, f.b1.ID)
+			rec := postBulkAs(t, f.h.BooksBulk, body, caller, role)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if got := resultOK(t, rec, f.b1.ID); got != tc.wantOK {
+				t.Errorf("per-id ok=%v, want %v", got, tc.wantOK)
+			}
+			got, _ := f.books.GetByID(context.Background(), f.b1.ID)
+			deleted := got == nil
+			if deleted != tc.wantDeleted {
+				t.Errorf("book deleted=%v, want %v (durable invariant)", deleted, tc.wantDeleted)
+			}
+		})
+	}
+}
+
 // TestBulk_Wanted_OwnershipMatrix exercises WantedBulk blocklist across the
 // same axes. The durable invariant is whether Alice's book got skipped.
 func TestBulk_Wanted_OwnershipMatrix(t *testing.T) {


### PR DESCRIPTION
Fixes #1242.

`POST /api/v1/book/bulk` with `action: "delete"` deleted each book via `BookRepo.Delete` (`DELETE FROM books WHERE id=?`, `book_files` cascade) with **no ownership check**, in the general authenticated route group. Under `BINDERY_ENFORCE_TENANCY` a non-admin could delete another tenant's books.

## Fix

New `deleteBook` helper loads the book and gates on `auth.CheckOwnership`, returning `errBulkBookNotOwned` on mismatch — identical to `setBookMonitored`/`setBookExcluded`/`setBookMediaType` and the single-book `BookHandler.Delete` "Tier-1 cross-user IDOR guard". The delete case now calls it.

## Test

`TestBulk_Book_Delete_OwnershipMatrix` across the tenancy/owner/admin axes asserts the **durable invariant**: a cross-user delete under the gate is rejected and the row survives; owner/admin succeed. The pre-existing `TestBulk_Book_OwnershipMatrix` only covered `unmonitor`, which is why this slipped through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)