### PR TITLE
fix(auth): enforce OIDC AllowedGroups against the configured group claim (#1244)

### DIFF
--- a/internal/api/auth_oidc.go
+++ b/internal/api/auth_oidc.go
@@ -288,18 +288,25 @@ func (h *OIDCHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Enforce the provider's AllowedGroups policy. When AllowedGroups is
-	// configured (non-empty), a login is only admitted if the IdP's `groups`
+	// configured (non-empty), a login is only admitted if the IdP's group
 	// claim intersects it; an empty AllowedGroups means "allow all" and the
 	// check is a no-op. This is fail-closed by design: if the IdP is not
-	// sending a `groups` claim, or sends a different group name than what is
+	// sending a group claim, or sends a different group name than what is
 	// configured, every login is rejected — the admin must fix the IdP scope
 	// mapping or the configured group name.
+	//
+	// Read the operator-configured claim (BINDERY_OIDC_GROUP_CLAIM), the same
+	// claim the admin-role sync below uses — not the literal "groups" claim
+	// baked into claims.Groups. Pointing the group claim at a non-default name
+	// otherwise made this policy compare against an always-empty slice, locking
+	// every user out (or, with AllowedGroups unset, silently no-op).
 	if cfg, ok := h.mgr.ProviderConfig(providerID); ok && len(cfg.AllowedGroups) > 0 {
-		if !oidc.GroupsAllowed(cfg.AllowedGroups, claims.Groups) {
+		userGroups := oidc.GroupClaimValues(claims.Raw, h.oidcGroupClaim)
+		if !oidc.GroupsAllowed(cfg.AllowedGroups, userGroups) {
 			slog.Warn("oidc: login rejected by AllowedGroups policy",
 				"provider", providerID, // #nosec -- providerID validated by oidcProviderIDRe at handler entry
 				"sub", sanitizeLog(claims.Sub),
-				"user_groups", len(claims.Groups),
+				"user_groups", len(userGroups),
 				"allowed_groups", strings.Join(cfg.AllowedGroups, ","),
 			)
 			writeErr(w, http.StatusForbidden,

--- a/internal/api/auth_oidc_callback_test.go
+++ b/internal/api/auth_oidc_callback_test.go
@@ -234,6 +234,56 @@ func TestCallback_AllowedGroups_OutOfGroup(t *testing.T) {
 	}
 }
 
+// TestCallback_AllowedGroups_CustomGroupClaim verifies the AllowedGroups policy
+// is evaluated against the operator-configured BINDERY_OIDC_GROUP_CLAIM, not the
+// literal "groups" claim. Here the IdP sends groups only under "bindery_groups";
+// before the fix this compared against an always-empty slice and locked the
+// in-group user out with a 403.
+func TestCallback_AllowedGroups_CustomGroupClaim(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub":            "user-custom-claim",
+		"nonce":          "test-nonce",
+		"email":          "custom@example.com",
+		"email_verified": true,
+		"bindery_groups": []string{"staff", "bindery-users"},
+		// deliberately no default "groups" claim
+	}
+	h, _, _ := newCallbackTestHandler(t, idp, []string{"bindery-users"}, false)
+	h.WithOIDCGroupClaim("bindery_groups")
+
+	rec := doCallback(t, h)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status=%d, want 302: AllowedGroups must honor BINDERY_OIDC_GROUP_CLAIM; body=%s", rec.Code, rec.Body.String())
+	}
+	if !hasSessionCookie(rec) {
+		t.Fatal("expected a session cookie for the in-group user under the configured claim")
+	}
+}
+
+// TestCallback_AllowedGroups_CustomGroupClaim_OutOfGroup verifies the negative
+// side of the configured-claim check still fails closed.
+func TestCallback_AllowedGroups_CustomGroupClaim_OutOfGroup(t *testing.T) {
+	idp := newFakeIDP(t)
+	idp.claims = map[string]any{
+		"sub":            "user-custom-claim-out",
+		"nonce":          "test-nonce",
+		"email":          "customout@example.com",
+		"email_verified": true,
+		"bindery_groups": []string{"staff", "contractors"},
+	}
+	h, _, _ := newCallbackTestHandler(t, idp, []string{"bindery-users"}, false)
+	h.WithOIDCGroupClaim("bindery_groups")
+
+	rec := doCallback(t, h)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status=%d, want 403 (out-of-group under configured claim must be rejected); body=%s", rec.Code, rec.Body.String())
+	}
+	if hasSessionCookie(rec) {
+		t.Fatal("a rejected login must not receive a session cookie")
+	}
+}
+
 // TestCallback_AllowedGroups_NoGroupsClaim verifies that when AllowedGroups is
 // configured but the IdP sends no `groups` claim at all, the login is rejected
 // (fail-closed) — the admin must fix the IdP scope mapping.


### PR DESCRIPTION
Fixes #1244.

The provider `AllowedGroups` policy was checked against `claims.Groups` (always the literal `groups` claim), ignoring `BINDERY_OIDC_GROUP_CLAIM`. The admin-role sync already reads the configured claim, so an operator who set a non-default group claim got a fail-closed lockout: `AllowedGroups` compared against an always-empty slice and rejected every login.

## Fix

`internal/api/auth_oidc.go` now evaluates `AllowedGroups` against `oidc.GroupClaimValues(claims.Raw, h.oidcGroupClaim)` — the same configured claim the admin-role sync uses. The log line counts the same resolved groups.

## Tests

- `TestCallback_AllowedGroups_CustomGroupClaim` — IdP sends groups only under `bindery_groups` (no default `groups`); the in-group user is now admitted (302 + session). Fails before the fix (403).
- `TestCallback_AllowedGroups_CustomGroupClaim_OutOfGroup` — out-of-group under the configured claim still fails closed (403, no session).
- Existing `groups`-claim AllowedGroups tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)