### PR TITLE
fix(indexer): propagate IndexerPriority in manual/interactive search (#1246)

### DIFF
--- a/internal/indexer/debug.go
+++ b/internal/indexer/debug.go
@@ -140,6 +140,10 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 				hits[i].IndexerID = idx.ID
 				hits[i].IndexerName = idx.Name
 				hits[i].Protocol = protocol
+				// Mirror searcher.go: scoreResult adds IndexerPriority to the
+				// rank, so omitting it here made per-indexer priority a no-op
+				// for manual/interactive (debug) searches.
+				hits[i].IndexerPriority = idx.Priority
 			}
 			entry.ResultCount = len(hits)
 

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -1118,6 +1118,46 @@ func TestSearchBookWithDebug_PerResultLogging(t *testing.T) {
 	}
 }
 
+// TestSearchBookWithDebug_PropagatesIndexerPriority guards the fix for the
+// manual/interactive search path dropping per-indexer priority: scoreResult
+// ranks on IndexerPriority, so SearchBookWithDebug must stamp it on every hit
+// the way the auto-search path (searcher.go) does.
+func TestSearchBookWithDebug_PropagatesIndexerPriority(t *testing.T) {
+	const rssBody = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
+  <channel>
+    <newznab:response offset="0" total="1"/>
+    <item>
+      <title>Life Ascending Nick Lane</title>
+      <guid isPermaLink="false">guid-1</guid>
+      <enclosure url="https://fake/dl/1" length="1000" type="application/x-nzb"/>
+      <newznab:attr name="author" value="Nick Lane"/>
+    </item>
+  </channel>
+</rss>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		w.Write([]byte(rssBody))
+	}))
+	defer srv.Close()
+
+	idxs := []models.Indexer{{ID: 1, Name: "test", URL: srv.URL, Enabled: true, Categories: []int{7020}, Priority: 42}}
+	results, _ := newTestSearcher().SearchBookWithDebug(context.Background(), idxs, MatchCriteria{
+		Title:  "Life Ascending",
+		Author: "Nick Lane",
+	})
+
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	for _, r := range results {
+		if r.IndexerPriority != 42 {
+			t.Errorf("IndexerPriority = %d, want 42 (priority must propagate to debug-search results)", r.IndexerPriority)
+		}
+	}
+}
+
 // TestFilterRelevantDebugEditionQualifierParity verifies that
 // filterRelevantDebug and filterRelevant agree on which results to keep for a
 // title that carries a parenthesised edition qualifier — the bug reported in


### PR DESCRIPTION
Fixes #1246.

`SearchBookWithDebug` (the manual/interactive search path) stamped `IndexerID`/`IndexerName`/`Protocol` on each hit but not `IndexerPriority`. Since `scoreResult` ranks on `IndexerPriority`, interactive searches always scored that term as 0, so configured per-indexer priority had no effect on ordering — while the auto-search path (`searcher.go`) ranked correctly.

## Fix

One line: `hits[i].IndexerPriority = idx.Priority` in the debug tagging loop, mirroring `searcher.go`.

## Test

`TestSearchBookWithDebug_PropagatesIndexerPriority` drives the path against a fake newznab server with `Priority: 42` and asserts every returned result carries it. Fails before the fix (0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)