### PR TITLE
fix(models): rank plain .azw releases instead of scoring them 0 (#1250)

### DIFF
--- a/internal/models/quality_test.go
+++ b/internal/models/quality_test.go
@@ -1,0 +1,31 @@
+package models
+
+import "testing"
+
+// TestQualityRank_AZW guards the fix for plain .azw releases scoring 0 in
+// ranking: ParseRelease emits "azw" as a distinct format token from "azw3", but
+// QualityRank lacked an "azw" key, so scoreResult's QualityRank[quality]*100
+// term collapsed a legitimate Kindle release to base score 0.
+func TestQualityRank_AZW(t *testing.T) {
+	rank, ok := QualityRank["azw"]
+	if !ok {
+		t.Fatal("QualityRank is missing an \"azw\" entry; plain .azw releases rank 0")
+	}
+	if rank <= QualityRank["unknown"] {
+		t.Errorf("azw rank %d should outrank unknown (%d)", rank, QualityRank["unknown"])
+	}
+	// azw is the DRM-wrapped mobi predecessor to azw3; rank it with mobi and
+	// below azw3.
+	if rank != QualityRank["mobi"] {
+		t.Errorf("azw rank %d should equal mobi (%d)", rank, QualityRank["mobi"])
+	}
+	if rank >= QualityRank["azw3"] {
+		t.Errorf("azw rank %d should be below azw3 (%d)", rank, QualityRank["azw3"])
+	}
+}
+
+func TestQualityFromFilename_AZW(t *testing.T) {
+	if got := QualityFromFilename("Some Book.azw"); got != "azw" {
+		t.Errorf("QualityFromFilename(.azw) = %q, want \"azw\"", got)
+	}
+}

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -13,6 +13,7 @@ var QualityRank = map[string]int{
 	"rtf":     2,
 	"pdf":     3,
 	"mobi":    4,
+	"azw":     4, // older Kindle format (KF7), mobi-equivalent; ParseRelease emits it as a distinct token from azw3
 	"epub":    5,
 	"azw3":    6,
 	"mp3":     7, // audiobook


### PR DESCRIPTION
Fixes #1250.

`ParseRelease` emits `azw` as a distinct format token from `azw3`, but `models.QualityRank` only had `azw3`. `scoreResult` computes `QualityRank[quality]*100`, so a `.azw` release got base quality 0 and ranked below `txt`/`unknown`.

## Fix

Add `"azw": 4` — azw (KF7) is the DRM-wrapped mobi predecessor to azw3, so it ranks with `mobi` and below `azw3`.

## Test

`TestQualityRank_AZW` (azw present, outranks unknown, equals mobi, below azw3) and `TestQualityFromFilename_AZW`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)