### PR TITLE
fix(web): bucket calendar releases by UTC date, not local time (#1252)

### DIFF
--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, Book } from '../api/client'
+import { bucketBooksByDay } from './calendarBuckets'
 
 function getDaysInMonth(year: number, month: number) {
   return new Date(year, month + 1, 0).getDate()
@@ -63,17 +64,9 @@ export default function CalendarPage() {
     setViewMonth(today.getMonth())
   }
 
-  // Index books by day-of-month for the current view
-  const booksByDay: Record<number, Book[]> = {}
-  for (const book of books) {
-    if (!book.releaseDate || !book.monitored) continue
-    const d = new Date(book.releaseDate)
-    if (d.getFullYear() === viewYear && d.getMonth() === viewMonth) {
-      const day = d.getDate()
-      if (!booksByDay[day]) booksByDay[day] = []
-      booksByDay[day].push(book)
-    }
-  }
+  // Index books by day-of-month for the current view (timezone-safe; see
+  // bucketBooksByDay).
+  const booksByDay = bucketBooksByDay(books, viewYear, viewMonth)
 
   const daysInMonth = getDaysInMonth(viewYear, viewMonth)
   const firstDay = getFirstDayOfMonth(viewYear, viewMonth)

--- a/web/src/pages/calendarBuckets.test.ts
+++ b/web/src/pages/calendarBuckets.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { bucketBooksByDay } from './calendarBuckets'
+import { Book } from '../api/client'
+
+function book(partial: Partial<Book>): Book {
+  return { id: 1, title: 't', monitored: true, ...partial } as Book
+}
+
+describe('bucketBooksByDay', () => {
+  it('buckets a midnight-UTC release on its calendar day regardless of local timezone', () => {
+    // A book releasing 2026-06-01T00:00:00Z must land on June 1, not May 31,
+    // even for a browser west of UTC where new Date(...).getDate() would be 31.
+    const books = [book({ releaseDate: '2026-06-01T00:00:00Z' })]
+    const byDay = bucketBooksByDay(books, 2026, 5) // month is 0-based: 5 = June
+    expect(byDay[1]?.length).toBe(1)
+    expect(byDay[31]).toBeUndefined()
+  })
+
+  it('keeps the first-of-month release inside the viewed month', () => {
+    const books = [book({ releaseDate: '2026-06-01T00:00:00Z' })]
+    // Viewing May must NOT show a June 1 release.
+    expect(Object.keys(bucketBooksByDay(books, 2026, 4))).toHaveLength(0)
+  })
+
+  it('accepts a date-only string', () => {
+    const byDay = bucketBooksByDay([book({ releaseDate: '2026-06-15' })], 2026, 5)
+    expect(byDay[15]?.length).toBe(1)
+  })
+
+  it('skips unmonitored books and books without a release date', () => {
+    const books = [
+      book({ releaseDate: '2026-06-10T00:00:00Z', monitored: false }),
+      book({ releaseDate: undefined }),
+    ]
+    expect(Object.keys(bucketBooksByDay(books, 2026, 5))).toHaveLength(0)
+  })
+})

--- a/web/src/pages/calendarBuckets.ts
+++ b/web/src/pages/calendarBuckets.ts
@@ -1,0 +1,23 @@
+import { Book } from '../api/client'
+
+// bucketBooksByDay groups monitored books with a release date into the given
+// month view, keyed by day-of-month.
+//
+// The date portion of releaseDate is parsed directly from the ISO string rather
+// than via `new Date()`. releaseDate is a UTC timestamp, and reading it back
+// with getFullYear/getMonth/getDate applies the browser's local-timezone
+// offset, which shifts a midnight-UTC release into the previous day — and out
+// of the viewed month — for users west of UTC. Mirrors the TZ-safe
+// `releaseDate.slice(0, 10)` comparison used elsewhere (AuthorDetailPage).
+export function bucketBooksByDay(books: Book[], viewYear: number, viewMonth: number): Record<number, Book[]> {
+  const booksByDay: Record<number, Book[]> = {}
+  for (const book of books) {
+    if (!book.releaseDate || !book.monitored) continue
+    const [y, m, dd] = book.releaseDate.slice(0, 10).split('-').map(Number)
+    if (y === viewYear && m - 1 === viewMonth) {
+      if (!booksByDay[dd]) booksByDay[dd] = []
+      booksByDay[dd].push(book)
+    }
+  }
+  return booksByDay
+}


### PR DESCRIPTION
Fixes #1252.

`CalendarPage` re-bucketed books with `new Date(book.releaseDate)` and read `getMonth()`/`getDate()` in **local** time. `releaseDate` is a UTC timestamp, so for users west of UTC a midnight-UTC release shifted to the previous day — wrong day, or out of the viewed month entirely (a 1st-of-month release silently disappeared). The fetch boundary is string-based and returns the book; the local-time re-filter then discards it.

## Fix

Extract `bucketBooksByDay`, which parses the date portion directly (`releaseDate.slice(0, 10).split('-')`), mirroring the TZ-safe form already used in `AuthorDetailPage`.

## Test

`calendarBuckets.test.ts` (run under `TZ=America/Los_Angeles`): a `2026-06-01T00:00:00Z` release buckets to June 1 (not May 31), stays out of the May view, date-only strings work, unmonitored/no-date are skipped. Fails before the fix. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)