### PR TITLE
fix(importer): choose auto import mode against the real destination root (#1254)

### DIFF
--- a/internal/importer/import_mode_test.go
+++ b/internal/importer/import_mode_test.go
@@ -229,6 +229,41 @@ func TestImportMode_DefaultHardlinkSameDevice_DstNotExist(t *testing.T) {
 	}
 }
 
+// TestResolveImportMode covers the helper the import pipeline uses to choose a
+// placement mode against the real destination root (#1254). An explicit mode is
+// returned verbatim; the auto default keys hardlink-vs-copy off the destRoot
+// argument it is given (which the call sites now set to the per-author /
+// audiobook root rather than s.libraryDir).
+func TestResolveImportMode(t *testing.T) {
+	s := &Scanner{}
+
+	// Explicit configured modes are returned as-is regardless of src/dst.
+	for _, m := range []string{"move", "copy", "hardlink", "external"} {
+		if got := s.resolveImportMode(m, "/any/src", "/any/dst"); got != m {
+			t.Errorf("explicit configuredMode %q: got %q", m, got)
+		}
+	}
+
+	// Auto (empty configuredMode), same-device src/destRoot → hardlink.
+	dir := t.TempDir()
+	src := filepath.Join(dir, "downloads")
+	destRoot := filepath.Join(dir, "library")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(destRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.resolveImportMode("", src, destRoot); got != "hardlink" {
+		t.Errorf("auto same-device: got %q, want hardlink", got)
+	}
+
+	// Auto with empty paths → safe cross-device default copy.
+	if got := s.resolveImportMode("", "", ""); got != "copy" {
+		t.Errorf("auto empty paths: got %q, want copy", got)
+	}
+}
+
 // TestImportMode_Settings exercises all branches of importMode when a real
 // SettingsRepo is attached: "copy", "hardlink", unknown value, and absent key.
 func TestImportMode_Settings(t *testing.T) {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -696,13 +696,15 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 
 	s.updateDownloadStatus(ctx, dl.ID, models.StateImportPending)
 
-	// Resolve the import mode ONCE for the whole download (issue #705 finding 2).
-	// Re-reading "import.mode" per file means an operator toggling copy↔move in
-	// the UI mid-run mixes copy and move within a single download; the final
-	// cleanup could then RemoveAll the still-seeding source of a file that was
-	// deliberately copied. The decided mode is threaded through every call site
-	// below — no further DB reads of "import.mode" occur for this import.
-	importMode := s.importMode(ctx, downloadPath, s.libraryDir)
+	// Read the configured import mode ONCE for the whole download (issue #705
+	// finding 2). Re-reading "import.mode" per file means an operator toggling
+	// copy↔move in the UI mid-run mixes copy and move within a single download;
+	// the final cleanup could then RemoveAll the still-seeding source of a file
+	// that was deliberately copied. The auto (unset) hardlink-vs-copy choice is
+	// made per placement below against the file's real destination root, not
+	// s.libraryDir, because per-author / audiobook roots can be on a separate
+	// mount (#1254).
+	configuredMode := s.configuredImportMode(ctx)
 
 	// External mode: skip all file operations and leave the book Wanted so the
 	// library scan can reconcile it after the user's external tool (Calibre,
@@ -716,7 +718,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// sweep, each prior download reading as a success. StateImportExternal lets
 	// searchWanted skip the book while the hand-off is outstanding, and
 	// ScanLibrary still reconciles the file the moment it lands.
-	if importMode == "external" {
+	if configuredMode == "external" {
 		// When a drop folder is configured (#941), external mode renames the
 		// finished file into that folder (copy/hardlink, never move) for a
 		// sibling tool (CWA, Calibre, Storyteller) to ingest, then still parks
@@ -875,7 +877,10 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			return
 		}
 		destDir := UniqueDir(audiobookDest)
-		mode := importMode
+		// Choose hardlink-vs-copy (when auto) against the audiobook root the
+		// files actually land under, not s.libraryDir — they can be on
+		// different mounts and a cross-device hardlink would hard-fail (#1254).
+		mode := s.resolveImportMode(configuredMode, downloadPath, audiobookRoot)
 		// audiobookSource is the path the move/copy/hardlink will operate on.
 		// When the caller supplied an explicit per-torrent file list (issue
 		// #903), prefer that to downloadPath: downloadPath can be a shared
@@ -1009,6 +1014,12 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// library, so move-mode cleanup can delete exactly those files rather than
 	// RemoveAll-ing the whole download path (issue #705 finding 4).
 	var importedSrcFiles []string
+	// Resolve the ebook destination root and (auto) placement mode once: the
+	// root is stable for this author across the loop, and choosing hardlink-vs-
+	// copy against it rather than s.libraryDir avoids a cross-device hardlink
+	// failure when the author's RootFolderID is on a separate mount (#1254).
+	ebookRoot := s.effectiveLibraryDir(ctx, author)
+	ebookMode := s.resolveImportMode(configuredMode, downloadPath, ebookRoot)
 	for _, srcFile := range bookFiles {
 		if book == nil {
 			// Try to match from filename
@@ -1018,7 +1029,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		}
 
 		seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
-		destPath, destErr := s.renamer.DestPath(s.effectiveLibraryDir(ctx, author), author, book, seriesTitle, seriesNum, srcFile)
+		destPath, destErr := s.renamer.DestPath(ebookRoot, author, book, seriesTitle, seriesNum, srcFile)
 		if destErr != nil {
 			slog.Error("failed to compute book destination", "src", srcFile, "error", destErr)
 			lastFileErr = destErr
@@ -1041,7 +1052,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			continue
 		}
 
-		mode := importMode
+		mode := ebookMode
 		slog.Info("importing book", "src", srcFile, "dst", destPath, "mode", mode)
 
 		// Wave 4 / finding 23: stage the file under a sibling temp name,
@@ -1157,7 +1168,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		// files and then prune now-empty parent directories with os.Remove —
 		// which fails on non-empty directories and therefore can never destroy
 		// a shared root or sibling data.
-		if importMode == "move" {
+		if configuredMode == "move" {
 			s.cleanupMovedSources(downloadPath, importedSrcFiles)
 		}
 		if cleanupFunc != nil {

--- a/internal/importer/scanner_handoff.go
+++ b/internal/importer/scanner_handoff.go
@@ -47,13 +47,11 @@ func uniqueNonEmptyStrings(values []string) []string {
 	return out
 }
 
-// importMode reads the "import.mode" setting and returns one of "move",
-// "copy", "hardlink", or "external". When the setting is absent or
-// unrecognised, it defaults to "hardlink" if src and dst are on the same
-// filesystem (free, preserves seeding) or "copy" when they are on different
-// filesystems. Pass empty strings for src/dst to get the cross-device default
-// ("copy") without performing a stat.
-func (s *Scanner) importMode(ctx context.Context, src, dst string) string {
+// configuredImportMode returns the operator-set "import.mode" ("move", "copy",
+// "hardlink", or "external"), or "" when the setting is absent/unrecognised,
+// meaning "auto" (let resolveImportMode pick hardlink-vs-copy per destination).
+// Read once per download so a mid-run UI toggle can't mix modes (#705).
+func (s *Scanner) configuredImportMode(ctx context.Context) string {
 	if s.settings != nil {
 		setting, err := s.settings.Get(ctx, "import.mode")
 		if err == nil && setting != nil {
@@ -63,12 +61,36 @@ func (s *Scanner) importMode(ctx context.Context, src, dst string) string {
 			}
 		}
 	}
-	// No explicit setting — choose the safest mode that also preserves seeding.
-	if sameDevice(src, dst) {
+	return ""
+}
+
+// resolveImportMode picks the effective placement mode for a destination root.
+// An explicit operator setting (configuredMode) is honoured as-is. For the auto
+// default it returns "hardlink" when src and destRoot are on the same filesystem
+// (free, preserves seeding) or "copy" otherwise. destRoot MUST be the root the
+// files actually land under — per-author RootFolderID and audiobook roots can
+// live on a different mount than s.libraryDir, and choosing the mode against
+// s.libraryDir there picked an always-failing cross-device hardlink. Pass empty
+// strings for src/destRoot to get the cross-device default ("copy") without a
+// stat.
+func (s *Scanner) resolveImportMode(configuredMode, src, destRoot string) string {
+	if configuredMode != "" {
+		return configuredMode
+	}
+	if sameDevice(src, destRoot) {
 		return "hardlink"
 	}
 	slog.Warn("import.mode not set and src/dst are on different filesystems; defaulting to copy — seeding will be preserved but disk usage doubles")
 	return "copy"
+}
+
+// importMode reads the "import.mode" setting and returns one of "move", "copy",
+// "hardlink", or "external", falling back to the same-filesystem auto default
+// for src/dst. Retained for the standalone callers/tests; the import pipeline
+// uses configuredImportMode + resolveImportMode so the auto check runs against
+// the real destination root.
+func (s *Scanner) importMode(ctx context.Context, src, dst string) string {
+	return s.resolveImportMode(s.configuredImportMode(ctx), src, dst)
 }
 
 // flattenMultiDiscEnabled reads the "import.audiobook.flatten_multi_disc"


### PR DESCRIPTION
Fixes #1254.

With `import.mode` unset, the importer auto-selected hardlink-vs-copy via `sameDevice(downloadPath, s.libraryDir)`, but ebooks land under `effectiveLibraryDir(author)` and audiobooks under `effectiveAudiobookDir(author)` — which can be on a different mount. When `downloadPath` and `s.libraryDir` shared a device, auto chose `hardlink` while the real destination was cross-device, so `HardlinkFile`/`HardlinkDir` failed with **no fallback** and the import errored.

## Fix

Split mode resolution:
- `configuredImportMode(ctx)` reads the `import.mode` setting **once** per download (preserving the #705 invariant against mid-run copy↔move mixing).
- `resolveImportMode(configuredMode, src, destRoot)` returns an explicit mode verbatim, and for the auto default makes the hardlink-vs-copy choice against the **actual destination root** — `effectiveAudiobookDir(author)` for audiobooks, `effectiveLibraryDir(author)` (hoisted once before the ebook loop) for ebooks.

External handling and the move-cleanup decision now key off `configuredMode`; auto never yields move/external, so behaviour is unchanged there. `importMode` is retained as a thin wrapper over the two helpers for the standalone callers/tests.

## Tests

`TestResolveImportMode` (explicit modes returned verbatim; auto same-device → hardlink; auto empty → copy). All existing `TestImportMode_*` and the full `internal/importer` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)