### PR TITLE
fix(hardcover): resolve numeric slugs by slug, not as a DB id (#1256)

### DIFF
--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -239,7 +239,7 @@ func (c *Client) GetAuthorWorksByName(ctx context.Context, authorName string) ([
 
 func (c *Client) GetAuthor(ctx context.Context, foreignID string) (*models.Author, error) {
 	id := strings.TrimPrefix(foreignID, idPrefix)
-	gql := `query GetAuthor($slug: String!) {
+	const slugGQL = `query GetAuthor($slug: String!) {
 		authors(where: {slug: {_eq: $slug}}, limit: 1) {
 			id
 			name
@@ -248,37 +248,49 @@ func (c *Client) GetAuthor(ctx context.Context, foreignID string) (*models.Autho
 			image { url }
 		}
 	}`
-	vars := map[string]any{"slug": id}
+	const idGQL = `query GetAuthor($id: Int!) {
+		authors(where: {id: {_eq: $id}}, limit: 1) {
+			id
+			name
+			slug
+			bio
+			image { url }
+		}
+	}`
+	fetch := func(gql string, vars map[string]any) (*models.Author, error) {
+		var resp struct {
+			Data struct {
+				Authors []hcAuthor `json:"authors"`
+			} `json:"data"`
+		}
+		if err := c.query(ctx, gql, vars, &resp); err != nil {
+			return nil, fmt.Errorf("hardcover get author: %w", err)
+		}
+		if len(resp.Data.Authors) == 0 {
+			return nil, nil
+		}
+		a := c.toAuthor(resp.Data.Authors[0])
+		return &a, nil
+	}
+
+	// Prefer the slug lookup. A purely numeric value is ambiguous — it may be a
+	// numeric slug or the DB-id fallback toAuthor emits when the slug is empty —
+	// so only fall back to a primary-key lookup when the slug matches nothing
+	// (#1256). The old code always took the id branch for numeric values,
+	// returning the wrong author for any numeric slug.
+	author, err := fetch(slugGQL, map[string]any{"slug": id})
+	if err != nil || author != nil {
+		return author, err
+	}
 	if numericID, ok := hardcoverNumericID(id); ok {
-		gql = `query GetAuthor($id: Int!) {
-			authors(where: {id: {_eq: $id}}, limit: 1) {
-				id
-				name
-				slug
-				bio
-				image { url }
-			}
-		}`
-		vars = map[string]any{"id": numericID}
+		return fetch(idGQL, map[string]any{"id": numericID})
 	}
-	var resp struct {
-		Data struct {
-			Authors []hcAuthor `json:"authors"`
-		} `json:"data"`
-	}
-	if err := c.query(ctx, gql, vars, &resp); err != nil {
-		return nil, fmt.Errorf("hardcover get author: %w", err)
-	}
-	if len(resp.Data.Authors) == 0 {
-		return nil, nil
-	}
-	a := c.toAuthor(resp.Data.Authors[0])
-	return &a, nil
+	return nil, nil
 }
 
 func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, error) {
 	id := strings.TrimPrefix(foreignID, idPrefix)
-	gql := `query GetBook($slug: String!) {
+	const slugGQL = `query GetBook($slug: String!) {
 		books(where: {slug: {_eq: $slug}}, limit: 1) {
 			id
 			title
@@ -295,40 +307,52 @@ func (c *Client) GetBook(ctx context.Context, foreignID string) (*models.Book, e
 			}
 		}
 	}`
-	vars := map[string]any{"slug": id}
-	if numericID, ok := hardcoverNumericID(id); ok {
-		gql = `query GetBook($id: Int!) {
-			books(where: {id: {_eq: $id}}, limit: 1) {
-				id
-				title
-				slug
-				description
-				image { url }
-				release_year
-				ratings_count
-				rating
-				default_audio_edition_id
-				default_ebook_edition_id
-				contributions {
-					author { id name slug }
-				}
+	const idGQL = `query GetBook($id: Int!) {
+		books(where: {id: {_eq: $id}}, limit: 1) {
+			id
+			title
+			slug
+			description
+			image { url }
+			release_year
+			ratings_count
+			rating
+			default_audio_edition_id
+			default_ebook_edition_id
+			contributions {
+				author { id name slug }
 			}
-		}`
-		vars = map[string]any{"id": numericID}
+		}
+	}`
+	fetch := func(gql string, vars map[string]any) (*models.Book, error) {
+		var resp struct {
+			Data struct {
+				Books []hcBook `json:"books"`
+			} `json:"data"`
+		}
+		if err := c.query(ctx, gql, vars, &resp); err != nil {
+			return nil, fmt.Errorf("hardcover get book: %w", err)
+		}
+		if len(resp.Data.Books) == 0 {
+			return nil, nil
+		}
+		b := c.toBook(resp.Data.Books[0])
+		return &b, nil
 	}
-	var resp struct {
-		Data struct {
-			Books []hcBook `json:"books"`
-		} `json:"data"`
+
+	// Prefer the slug lookup. A purely numeric value is ambiguous — it may be a
+	// numeric slug (e.g. "1984", "2001") or the DB-id fallback toBook emits when
+	// the slug is empty — so only fall back to a primary-key lookup when the slug
+	// matches nothing (#1256). The old code always took the id branch for numeric
+	// values, so GetBook("hc:1984") fetched whatever book had database id 1984.
+	book, err := fetch(slugGQL, map[string]any{"slug": id})
+	if err != nil || book != nil {
+		return book, err
 	}
-	if err := c.query(ctx, gql, vars, &resp); err != nil {
-		return nil, fmt.Errorf("hardcover get book: %w", err)
+	if numericID, ok := hardcoverNumericID(id); ok {
+		return fetch(idGQL, map[string]any{"id": numericID})
 	}
-	if len(resp.Data.Books) == 0 {
-		return nil, nil
-	}
-	b := c.toBook(resp.Data.Books[0])
-	return &b, nil
+	return nil, nil
 }
 
 func (c *Client) GetEditions(ctx context.Context, bookForeignID string) ([]models.Edition, error) {
@@ -337,7 +361,7 @@ func (c *Client) GetEditions(ctx context.Context, bookForeignID string) ([]model
 		return nil, nil
 	}
 
-	gql := `query GetEditions($slug: String!, $limit: Int!, $offset: Int!) {
+	const slugGQL = `query GetEditions($slug: String!, $limit: Int!, $offset: Int!) {
 		editions(
 			where: {book: {slug: {_eq: $slug}}},
 			limit: $limit,
@@ -363,9 +387,7 @@ func (c *Client) GetEditions(ctx context.Context, bookForeignID string) ([]model
 			book { title }
 		}
 	}`
-	vars := map[string]any{"slug": id}
-	if numericID, ok := hardcoverNumericID(id); ok {
-		gql = `query GetEditions($bookID: Int!, $limit: Int!, $offset: Int!) {
+	const idGQL = `query GetEditions($bookID: Int!, $limit: Int!, $offset: Int!) {
 		editions(
 			where: {book_id: {_eq: $bookID}},
 			limit: $limit,
@@ -391,27 +413,40 @@ func (c *Client) GetEditions(ctx context.Context, bookForeignID string) ([]model
 			book { title }
 		}
 	}`
-		vars = map[string]any{"bookID": numericID}
+
+	fetchAll := func(gql string, vars map[string]any) ([]models.Edition, error) {
+		editions := make([]models.Edition, 0, editionsPageSize)
+		for offset := 0; offset < editionsMaxCount; offset += editionsPageSize {
+			vars["limit"] = editionsPageSize
+			vars["offset"] = offset
+			var resp struct {
+				Data struct {
+					Editions []hcEdition `json:"editions"`
+				} `json:"data"`
+			}
+			if err := c.query(ctx, gql, vars, &resp); err != nil {
+				return nil, fmt.Errorf("hardcover get editions: %w", err)
+			}
+			for _, e := range resp.Data.Editions {
+				editions = append(editions, hardcoverEditionToModel(e))
+			}
+			if len(resp.Data.Editions) < editionsPageSize {
+				break
+			}
+		}
+		return editions, nil
 	}
 
-	editions := make([]models.Edition, 0, editionsPageSize)
-	for offset := 0; offset < editionsMaxCount; offset += editionsPageSize {
-		vars["limit"] = editionsPageSize
-		vars["offset"] = offset
-		var resp struct {
-			Data struct {
-				Editions []hcEdition `json:"editions"`
-			} `json:"data"`
-		}
-		if err := c.query(ctx, gql, vars, &resp); err != nil {
-			return nil, fmt.Errorf("hardcover get editions: %w", err)
-		}
-		for _, e := range resp.Data.Editions {
-			editions = append(editions, hardcoverEditionToModel(e))
-		}
-		if len(resp.Data.Editions) < editionsPageSize {
-			break
-		}
+	// Prefer the slug lookup; only fall back to a book_id lookup when the slug
+	// matches no editions, since a numeric value is ambiguous between a numeric
+	// slug and the DB-id fallback (#1256). The old code queried book_id directly
+	// for any numeric value, returning the editions of an unrelated book.
+	editions, err := fetchAll(slugGQL, map[string]any{"slug": id})
+	if err != nil || len(editions) > 0 {
+		return editions, err
+	}
+	if numericID, ok := hardcoverNumericID(id); ok {
+		return fetchAll(idGQL, map[string]any{"bookID": numericID})
 	}
 	return editions, nil
 }

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -783,15 +783,54 @@ func TestGetAuthor_Found(t *testing.T) {
 	}
 }
 
-func TestGetAuthor_NumericID(t *testing.T) {
-	var gotVars map[string]any
-	var gotQuery string
+// TestGetAuthor_NumericSlug is the #1256 regression: an author whose slug is
+// itself numeric must be resolved by slug, not misread as a database id.
+func TestGetAuthor_NumericSlug(t *testing.T) {
+	var queries []string
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
 		body, _ := io.ReadAll(r.Body)
 		var req gqlRequest
 		_ = json.Unmarshal(body, &req)
-		gotQuery = req.Query
-		gotVars = req.Variables
+		queries = append(queries, req.Query)
+		// The slug query matches the author whose slug is "100".
+		data := map[string]interface{}{
+			"authors": []map[string]interface{}{
+				{"id": 7, "name": "Numeric Slug Author", "slug": "100", "bio": "", "image": nil},
+			},
+		}
+		return gqlResponse(t, http.StatusOK, data), nil
+	})
+
+	author, err := c.GetAuthor(context.Background(), "hc:100")
+	if err != nil {
+		t.Fatalf("GetAuthor: %v", err)
+	}
+	if author == nil || author.Name != "Numeric Slug Author" {
+		t.Fatalf("author = %+v, want the slug-100 author", author)
+	}
+	if len(queries) != 1 {
+		t.Fatalf("expected exactly 1 query (slug match, no id fallback), got %d", len(queries))
+	}
+	if !strings.Contains(queries[0], "slug: {_eq: $slug}") {
+		t.Fatalf("first query must be a slug lookup, got: %s", queries[0])
+	}
+}
+
+// TestGetAuthor_NumericID_FallsBackWhenSlugMisses covers the DB-id fallback:
+// when the slug lookup returns nothing, a numeric value is retried as a
+// primary-key lookup.
+func TestGetAuthor_NumericID_FallsBackWhenSlugMisses(t *testing.T) {
+	var queries []string
+	var lastVars map[string]any
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		var req gqlRequest
+		_ = json.Unmarshal(body, &req)
+		queries = append(queries, req.Query)
+		lastVars = req.Variables
+		if strings.Contains(req.Query, "slug: {_eq: $slug}") {
+			return gqlResponse(t, http.StatusOK, map[string]interface{}{"authors": []interface{}{}}), nil
+		}
 		data := map[string]interface{}{
 			"authors": []map[string]interface{}{
 				{"id": 5, "name": "Neil Gaiman", "slug": "neil-gaiman", "bio": "Writer", "image": nil},
@@ -807,14 +846,14 @@ func TestGetAuthor_NumericID(t *testing.T) {
 	if author == nil || author.ForeignID != "hc:neil-gaiman" {
 		t.Fatalf("author = %+v, want slug-backed author", author)
 	}
-	if gotVars["id"] != float64(5) && gotVars["id"] != 5 {
-		t.Fatalf("id variable = %#v, want 5", gotVars["id"])
+	if len(queries) != 2 {
+		t.Fatalf("expected slug query then id fallback (2 queries), got %d", len(queries))
 	}
-	if _, ok := gotVars["slug"]; ok {
-		t.Fatalf("slug variable present for numeric lookup: %#v", gotVars["slug"])
+	if !strings.Contains(queries[1], "id: {_eq: $id}") {
+		t.Fatalf("fallback query must use id lookup, got: %s", queries[1])
 	}
-	if !strings.Contains(gotQuery, "id: {_eq: $id}") {
-		t.Fatalf("query did not use id lookup: %s", gotQuery)
+	if lastVars["id"] != float64(5) && lastVars["id"] != 5 {
+		t.Fatalf("id variable = %#v, want 5", lastVars["id"])
 	}
 }
 
@@ -880,25 +919,58 @@ func TestGetBook_Found(t *testing.T) {
 	}
 }
 
-func TestGetBook_NumericID(t *testing.T) {
-	var gotVars map[string]any
-	var gotQuery string
+// TestGetBook_NumericSlug is the #1256 regression: a book whose slug is itself
+// numeric (e.g. Orwell's "1984") must be resolved by slug, not misread as the
+// book with database id 1984.
+func TestGetBook_NumericSlug(t *testing.T) {
+	var queries []string
 	c := newMockClient(func(r *http.Request) (*http.Response, error) {
 		body, _ := io.ReadAll(r.Body)
 		var req gqlRequest
 		_ = json.Unmarshal(body, &req)
-		gotQuery = req.Query
-		gotVars = req.Variables
+		queries = append(queries, req.Query)
+		// The slug query matches the book whose slug is "1984".
 		data := map[string]interface{}{
 			"books": []map[string]interface{}{
-				{
-					"id":            99,
-					"title":         "American Gods",
-					"slug":          "american-gods",
-					"description":   "A novel about gods in America.",
-					"rating":        4.1,
-					"ratings_count": 12000,
-				},
+				{"id": 42, "title": "Nineteen Eighty-Four", "slug": "1984"},
+			},
+		}
+		return gqlResponse(t, http.StatusOK, data), nil
+	})
+
+	book, err := c.GetBook(context.Background(), "hc:1984")
+	if err != nil {
+		t.Fatalf("GetBook: %v", err)
+	}
+	if book == nil || book.Title != "Nineteen Eighty-Four" {
+		t.Fatalf("book = %+v, want the slug-1984 book", book)
+	}
+	if len(queries) != 1 {
+		t.Fatalf("expected exactly 1 query (slug match, no id fallback), got %d", len(queries))
+	}
+	if !strings.Contains(queries[0], "slug: {_eq: $slug}") {
+		t.Fatalf("first query must be a slug lookup, got: %s", queries[0])
+	}
+}
+
+// TestGetBook_NumericID_FallsBackWhenSlugMisses covers the DB-id fallback path:
+// a numeric value is retried as a primary-key lookup only after the slug lookup
+// returns nothing.
+func TestGetBook_NumericID_FallsBackWhenSlugMisses(t *testing.T) {
+	var queries []string
+	var lastVars map[string]any
+	c := newMockClient(func(r *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(r.Body)
+		var req gqlRequest
+		_ = json.Unmarshal(body, &req)
+		queries = append(queries, req.Query)
+		lastVars = req.Variables
+		if strings.Contains(req.Query, "slug: {_eq: $slug}") {
+			return gqlResponse(t, http.StatusOK, map[string]interface{}{"books": []interface{}{}}), nil
+		}
+		data := map[string]interface{}{
+			"books": []map[string]interface{}{
+				{"id": 99, "title": "American Gods", "slug": "american-gods", "rating": 4.1, "ratings_count": 12000},
 			},
 		}
 		return gqlResponse(t, http.StatusOK, data), nil
@@ -911,14 +983,14 @@ func TestGetBook_NumericID(t *testing.T) {
 	if book == nil || book.ForeignID != "hc:american-gods" {
 		t.Fatalf("book = %+v, want slug-backed book", book)
 	}
-	if gotVars["id"] != float64(99) && gotVars["id"] != 99 {
-		t.Fatalf("id variable = %#v, want 99", gotVars["id"])
+	if len(queries) != 2 {
+		t.Fatalf("expected slug query then id fallback (2 queries), got %d", len(queries))
 	}
-	if _, ok := gotVars["slug"]; ok {
-		t.Fatalf("slug variable present for numeric lookup: %#v", gotVars["slug"])
+	if !strings.Contains(queries[1], "id: {_eq: $id}") {
+		t.Fatalf("fallback query must use id lookup, got: %s", queries[1])
 	}
-	if !strings.Contains(gotQuery, "id: {_eq: $id}") {
-		t.Fatalf("query did not use id lookup: %s", gotQuery)
+	if lastVars["id"] != float64(99) && lastVars["id"] != 99 {
+		t.Fatalf("id variable = %#v, want 99", lastVars["id"])
 	}
 }
 


### PR DESCRIPTION
Fixes #1256.

ForeignIDs are `"hc:" + slug`, and some titles have a numeric slug (Orwell's *1984* → `1984`, *2001: A Space Odyssey* → `2001`). `GetBook`/`GetEditions`/`GetAuthor` called `hardcoverNumericID` on the value and switched from a slug query to a **primary-key** query for any numeric string — so `GetBook("hc:1984")` returned whatever book had database id 1984, along with its editions/cover/ratings. The aggregator routes `hc:` IDs here, so this fired on normal rebind/detail/edition flows for any numeric-slug title.

## Fix

Prefer the slug lookup; fall back to the numeric id query only when the slug matches nothing. **Backward compatible**: numeric slugs resolve by slug, while a genuine empty-slug DB-id fallback (stored `hc:<id>`) still resolves via the id retry when the slug query returns no rows. All three functions wrap their slug/id queries in a small `fetch` closure to keep the two query shapes intact.

## Tests

- `TestGetBook_NumericSlug` / `TestGetAuthor_NumericSlug` — a numeric-slug entity resolves via a single slug query, with no id fallback (the regression).
- `TestGetBook_NumericID_FallsBackWhenSlugMisses` / `TestGetAuthor_NumericID_FallsBackWhenSlugMisses` — slug-miss then id query, asserting both requests and the id var.
- `TestGetEditions_NumericIDUsesBookID` now exercises the slug-miss → `book_id` fallback. Full `internal/metadata/...` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)