### PR TITLE
docs: clarify Hardcover requires a token for search (not just user queries)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@
 |--------|------|----------|
 | [OpenLibrary](https://openlibrary.org) | None | Primary: authors, books, editions, covers, ISBN |
 | [Google Books](https://developers.google.com/books) | API key (free) | Enrichment: descriptions, ratings |
-| [Hardcover.app](https://hardcover.app) | None (public GraphQL) | Enrichment: community ratings, series, wishlist |
+| [Hardcover.app](https://hardcover.app) | API token (free) | Search enrichment + community ratings, series, wishlist. Token required for **all** queries — without it Hardcover is silently skipped ([troubleshooting](docs/Troubleshooting-Wiki.md#a-book-is-on-hardcoverapp-but-doesnt-show-up-in-add-book--add-author-search)) |
 | [DNB](https://www.dnb.de/) | None (public SRU) | German-language descriptions, language, year, publisher; can be promoted to **primary** |
 | [Audnex](https://api.audnex.us) | None | Audiobook narrator, duration, cover by ASIN |
 | [Audible](https://audible.com) | None | Supplemental audiobook author lookup — pulls ASINs OL/Hardcover miss |

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -38,3 +38,13 @@ Bindery's primary metadata provider is OpenLibrary or DNB (the German national l
 
 - Behind a VPN: split-tunnel `openlibrary.org` out of the VPN. Metadata lookups do not need VPN protection — only torrent traffic does — so a paid dedicated IP is not required. Switching to a different VPN exit location also often helps, since some exit IPs are blocked and others are not.
 - Not on a VPN: retry later, and check the status of `openlibrary.org` / `archive.org`.
+
+## A book is on hardcover.app but doesn't show up in Add Book / Add Author search
+
+The provider dropdown in `Settings → General` only offers **OpenLibrary** or **DNB** for the *primary* provider. Hardcover cannot be set as the primary, and it does not need to be: it always runs as a **search enricher**. Add Book and Add Author fan the query out to the primary provider **plus** Hardcover (and Google Books, if an API key is set), then merge in any titles the primary didn't return. Books that only exist on hardcover.app are exactly what that path is meant to surface.
+
+The catch is that **Hardcover's GraphQL API requires an API token for every query, including search** — an unauthenticated request returns `{"error":"Unable to verify token"}`. Bindery skips a provider that errors rather than failing the whole search, so without a token Hardcover contributes nothing silently and you only see OpenLibrary / DNB results.
+
+**Fix:** add a Hardcover API token in `Settings → General` (the same token used for [Enhanced Hardcover Series](./Hardcover-Series-Wiki.md) and wishlist features), then re-run the search. Hardcover-only titles should appear in the merged results.
+
+If results still don't appear with a token saved, confirm the instance has outbound HTTPS access to `api.hardcover.app` and that the token is valid (a bad token produces the same "Unable to verify token" error, which is logged and skipped).

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -34,11 +34,14 @@ const (
 	hardcoverSuccessResponseBodyLimit = 8 << 20
 )
 
-// Client implements metadata.Provider for Hardcover.app using its public GraphQL API.
-// Set an API token via WithToken or NewAuthenticated to enable authenticated queries.
+// Client implements metadata.Provider for Hardcover.app using its GraphQL API.
+// As of 2026 the endpoint rejects unauthenticated requests with
+// {"error":"Unable to verify token"} for every query — including plain
+// search — so a token must be set via WithToken, WithTokenSource, or
+// NewAuthenticated for any call to succeed.
 type Client struct {
 	http        *http.Client
-	token       string // optional API token; required for user-specific queries
+	token       string // API token; required for all queries (search included)
 	tokenSource func(context.Context) string
 }
 


### PR DESCRIPTION
## Why

A Discord user couldn't find newer titles in Add Book search even though they exist on hardcover.app. The root cause is that Hardcover runs as a search **enricher**, but its GraphQL endpoint now rejects unauthenticated requests for **every** query — including plain book/author search:

```
$ curl -X POST https://api.hardcover.app/v1/graphql ...
{"error":"Unable to verify token"}
```

The aggregator silently skips a provider that errors, so without a Hardcover API token Hardcover contributes nothing and Add Book/Add Author show only OpenLibrary/DNB results. The docs and code comments said the opposite (`None (public GraphQL)`, "required for user-specific queries"), which is exactly why this stayed hidden.

## Changes

- **`docs/Troubleshooting-Wiki.md`** — new entry "A book is on hardcover.app but doesn't show up in Add Book / Add Author search": explains the enricher fan-out, the token requirement, the exact error string, and the fix.
- **`README.md`** — corrected the metadata-provider table: Hardcover auth `None (public GraphQL)` → `API token (free)`, noting it's required for all queries, with a link to the troubleshooting entry.
- **`internal/metadata/hardcover/client.go`** — corrected the now-false struct/field doc comments ("public GraphQL API" / "required for user-specific queries").

Verified against the live endpoint (the `curl` above). No behavior change — docs/comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)