### PR TITLE
fix(httpsec): block the unspecified address (0.0.0.0, ::) in the SSRF guard

### DIFF
--- a/internal/httpsec/ssrf.go
+++ b/internal/httpsec/ssrf.go
@@ -149,6 +149,14 @@ func checkIP(ip net.IP, policy Policy) error {
 		ip = v4
 	}
 
+	// Always blocked: the unspecified address (0.0.0.0, ::). It is never a
+	// valid destination, and on Linux a connect to 0.0.0.0 targets loopback —
+	// so without this it bypasses the loopback block under every policy,
+	// including PolicyStrict (image proxy / notifier) and PolicyLANLoopback.
+	if ip.IsUnspecified() {
+		return errors.New("url not allowed: points to unspecified address")
+	}
+
 	// Loopback is blocked except under PolicyLANLoopback (admin-configured
 	// infrastructure URLs, where reaching a co-located service over 127.0.0.1 is
 	// the intended, normal case) or when explicitly allowed for tests via

--- a/internal/httpsec/ssrf_test.go
+++ b/internal/httpsec/ssrf_test.go
@@ -78,6 +78,25 @@ func TestValidateOutboundURL_Loopback(t *testing.T) {
 	}
 }
 
+// TestValidateOutboundURL_Unspecified pins that the unspecified address
+// (0.0.0.0 / ::) is blocked under every policy — on Linux it routes to loopback,
+// so allowing it would bypass the loopback block.
+func TestValidateOutboundURL_Unspecified(t *testing.T) {
+	r := fakeResolver{m: map[string][]net.IP{}}
+	cases := []string{
+		"http://0.0.0.0/",
+		"http://0.0.0.0:8080/",
+		"http://[::]/",
+	}
+	for _, u := range cases {
+		for _, p := range []Policy{PolicyStrict, PolicyLAN, PolicyLANLoopback} {
+			if err := validate(u, p, r); err == nil {
+				t.Errorf("expected block for unspecified %q under policy %v", u, p)
+			}
+		}
+	}
+}
+
 // TestValidateOutboundURL_LANLoopbackPolicy pins the admin-infra policy: it adds
 // loopback to PolicyLAN (loopback + RFC1918 allowed) but must still block
 // link-local and cloud metadata.


### PR DESCRIPTION
## Weakness

`checkIP` (`internal/httpsec/ssrf.go`) never rejected an unspecified IP. `0.0.0.0` / `::` is not loopback, link-local, RFC1918, or cloud-metadata, so it passed **every** policy including `PolicyStrict`. On Linux a connect to `0.0.0.0` targets loopback, so this bypassed the loopback block the guard exists to enforce.

Reachable by any authenticated user via the cover-image proxy: `GET /api/v1/images?url=http://0.0.0.0:PORT/` validates under `PolicyStrict`, passes, and dials a loopback-bound service (blind/oracle; body returned for `image/*` responses). The notifier and OIDC discovery probe share the gap.

## Fix

Reject `ip.IsUnspecified()` unconditionally, before the policy-specific checks (so it's blocked even under `PolicyLANLoopback`). One line; closes the bypass for every SSRF surface at once.

## Test

`TestValidateOutboundURL_Unspecified` asserts `0.0.0.0`, `0.0.0.0:8080`, and `[::]` are blocked under `PolicyStrict`, `PolicyLAN`, and `PolicyLANLoopback`. Full `internal/httpsec` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)