### PR TITLE
fix(indexer): redact indexer apikey from newznab transport errors

### DIFF
--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -450,13 +451,13 @@ func (c *Client) Probe(ctx context.Context) ProbeResult {
 	start := time.Now()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		return ProbeResult{Error: err.Error()}
+		return ProbeResult{Error: httpsec.RedactSecrets(err.Error())}
 	}
 	req.Header.Set("User-Agent", useragent.Get())
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return ProbeResult{LatencyMs: time.Since(start).Milliseconds(), Error: err.Error()}
+		return ProbeResult{LatencyMs: time.Since(start).Milliseconds(), Error: httpsec.RedactSecrets(err.Error())}
 	}
 	defer resp.Body.Close()
 
@@ -553,16 +554,28 @@ func (c *Client) parseResults(items []rssItem) []SearchResult {
 	return results
 }
 
+// redactedErr flattens err to a string with secrets redacted (the apikey query
+// param in particular). Network errors are *url.Error values whose message
+// embeds the full request URL — including &apikey=<secret> — so returning them
+// raw leaked the indexer key into WARN logs and the (non-admin) search-debug
+// response. Flattening also prevents a downstream %w wrap from re-exposing it.
+func redactedErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	return errors.New(httpsec.RedactSecrets(err.Error()))
+}
+
 func (c *Client) getXML(ctx context.Context, rawURL string, target interface{}) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
-		return err
+		return redactedErr(err)
 	}
 	req.Header.Set("User-Agent", useragent.Get())
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return err
+		return redactedErr(err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/indexer/newznab/client_test.go
+++ b/internal/indexer/newznab/client_test.go
@@ -3,6 +3,7 @@ package newznab
 import (
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,37 @@ import (
 	"testing"
 	"time"
 )
+
+// errRoundTripper makes http.Client.Do fail with a transport error; net/http
+// wraps it in a *url.Error whose message embeds the request URL (incl. apikey).
+type errRoundTripper struct{ err error }
+
+func (e errRoundTripper) RoundTrip(*http.Request) (*http.Response, error) { return nil, e.err }
+
+// TestSearch_RedactsAPIKeyInTransportError guards the fix for the indexer apikey
+// leaking through an unredacted *url.Error into WARN logs and the non-admin
+// search-debug response: a transport failure must not expose the key.
+func TestSearch_RedactsAPIKeyInTransportError(t *testing.T) {
+	c := New("http://indexer.invalid", "supersecretkey")
+	c.http = &http.Client{Transport: errRoundTripper{err: errors.New("dial tcp 1.2.3.4:443: connect: connection refused")}}
+
+	_, err := c.Search(context.Background(), "book", []int{7020})
+	if err == nil {
+		t.Fatal("expected a transport error")
+	}
+	if strings.Contains(err.Error(), "supersecretkey") {
+		t.Fatalf("apikey leaked in error string: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "REDACTED") {
+		t.Fatalf("expected the apikey to be REDACTED, got: %s", err.Error())
+	}
+
+	// Probe surfaces the same error to the admin Test endpoint — redact there too.
+	res := c.Probe(context.Background())
+	if strings.Contains(res.Error, "supersecretkey") {
+		t.Fatalf("apikey leaked in ProbeResult.Error: %s", res.Error)
+	}
+}
 
 // testNew creates a newznab Client for use with httptest servers. It replaces
 // the hardened http.Client (whose DialContext blocks loopback) with a plain


### PR DESCRIPTION
## Weakness

newznab search/caps request URLs carry the indexer apikey as a query parameter (`buildURL` → `apikey=<secret>`). On a transport failure (DNS/connect/TLS/timeout — common for an unreachable or misconfigured indexer), `getXML` and `Probe` returned the raw `*url.Error`, whose `.Error()` embeds the full request URL **including `&apikey=<secret>`** with no redaction.

Two sinks, both reachable:
- **WARN logs** (`searcher.go`, `debug.go`) — not debug-gated, so the key lands in logs at any level.
- **search-debug response** — the per-indexer `Error` string flows into `GET /api/v1/search/last-debug`, which is registered **before** the `RequireAdmin` group, so a **non-admin** authenticated user can read another admin's indexer key out of a captured network error.

## Fix

Flatten the URL-bearing errors through `httpsec.RedactSecrets` at the client boundary (`getXML` and `Probe`). Flattening rather than wrapping also prevents a downstream `%w` from re-exposing the key via `errors.Unwrap`. Mirrors the existing Google Books redaction.

## Test

`TestSearch_RedactsAPIKeyInTransportError` injects a failing transport and asserts the apikey is `REDACTED` (and absent) in both the `Search` error and `ProbeResult.Error`. Full `internal/indexer/...` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)