### PR TITLE
fix(notifier): re-validate webhook redirects + guard the dial against rebind

### DIFF
--- a/internal/api/notifications_test.go
+++ b/internal/api/notifications_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/notifier"
 )
@@ -26,6 +27,10 @@ func notificationFixture(t *testing.T) (*NotificationHandler, *db.NotificationRe
 	n := notifier.New(repo)
 	// Disable SSRF validation so httptest.NewServer (loopback) works in tests.
 	n.SetValidator(nil)
+	// notifier.New also installs a dial-time SSRF guard (NewDialContext) that
+	// blocks loopback regardless of the validator; opt loopback into the dialer
+	// so the webhook test can reach its httptest server.
+	t.Cleanup(httpsec.AllowLoopbackForTests())
 	return NewNotificationHandler(repo, n), repo
 }
 

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -39,14 +39,49 @@ type Notifier struct {
 
 // New creates a Notifier backed by the given repo.
 func New(repo *db.NotificationRepo) *Notifier {
+	policy := httpsec.PolicyFromEnv(httpsec.PolicyStrict, "BINDERY_NOTIFICATIONS_ALLOW_PRIVATE")
 	return &Notifier{
 		repo: repo,
-		http: &http.Client{Timeout: 10 * time.Second, Transport: httpsec.DefaultProxyTransport()},
+		http: &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: guardedTransport(policy),
+			// Re-validate every redirect hop. The up-front validate only checks
+			// the configured URL; a webhook host that passes it could otherwise
+			// 302 into loopback / RFC1918 / cloud-metadata and have Bindery
+			// follow it blindly.
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if len(via) >= 5 {
+					return fmt.Errorf("too many redirects")
+				}
+				if err := httpsec.ValidateOutboundURL(req.URL.String(), policy); err != nil {
+					return fmt.Errorf("redirect blocked: %w", err)
+				}
+				return nil
+			},
+		},
 		validate: func(u string) error {
-			policy := httpsec.PolicyFromEnv(httpsec.PolicyStrict, "BINDERY_NOTIFICATIONS_ALLOW_PRIVATE")
 			return httpsec.ValidateOutboundURL(u, policy)
 		},
 	}
+}
+
+// guardedTransport mirrors the image-proxy transport. On the direct path it
+// installs a per-dial SSRF-revalidating DialContext, closing the DNS-rebind
+// TOCTOU between the up-front validate and the actual connect. When an outbound
+// proxy is configured the dial targets the operator-trusted proxy (not the
+// webhook host), so the strict per-dial recheck is skipped and the up-front
+// validate + CheckRedirect carry the guard.
+func guardedTransport(policy httpsec.Policy) http.RoundTripper {
+	base := httpsec.DefaultProxyTransport()
+	if httpsec.ProxyFunc() != nil {
+		return base
+	}
+	if t, ok := base.(*http.Transport); ok {
+		c := t.Clone()
+		c.DialContext = httpsec.NewDialContext(policy)
+		return c
+	}
+	return &http.Transport{DialContext: httpsec.NewDialContext(policy)}
 }
 
 // SetValidator overrides the SSRF validator. Intended for tests that need to

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -302,6 +303,9 @@ func TestNew_DefaultValidator(t *testing.T) {
 }
 
 func TestSetValidator_Override(t *testing.T) {
+	// The production New() now also installs a dial-time SSRF guard, so reaching
+	// an httptest server on loopback requires opting loopback in for the dialer.
+	defer httpsec.AllowLoopbackForTests()()
 	n := New(nil)
 	called := 0
 	n.SetValidator(func(string) error {
@@ -319,6 +323,30 @@ func TestSetValidator_Override(t *testing.T) {
 	}
 	if called != 1 {
 		t.Errorf("overridden validator calls: want 1, got %d", called)
+	}
+}
+
+// TestSend_RedirectToPrivateBlocked verifies the CheckRedirect guard: a webhook
+// that passes the up-front check but 302s to an RFC1918 address must not be
+// followed. Loopback is opted in only so the test server is reachable; the
+// redirect target (10.x) stays blocked under the strict policy.
+func TestSend_RedirectToPrivateBlocked(t *testing.T) {
+	defer httpsec.AllowLoopbackForTests()()
+	n := New(nil)
+	n.SetValidator(func(string) error { return nil }) // allow the loopback test server URL
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://10.0.0.1/internal", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	notif := &models.Notification{URL: srv.URL}
+	err := n.send(context.Background(), notif, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected the redirect to a private address to be blocked")
+	}
+	if !strings.Contains(err.Error(), "redirect blocked") && !strings.Contains(err.Error(), "private network") {
+		t.Fatalf("expected a redirect-blocked error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Weakness

The webhook notifier ran `ValidateOutboundURL` once at send time but used a non-dial-guarded transport with **no `CheckRedirect`**. Two bypasses of the SSRF guard:
- **Redirect**: a webhook host that passes the up-front check 302s to `169.254.169.254` / loopback / RFC1918, and the client follows it blindly.
- **DNS rebind**: a hostname that resolves public at validate time rebinds to a private IP before the dial (TOCTOU).

Blind (response discarded), and the URL is admin-configured, hence Medium — but it defeats a defense-in-depth control the codebase already enforces elsewhere.

## Fix

Mirror the image-proxy hardening (`internal/api/imageproxy.go`):
- A per-dial `NewDialContext(policy)` guard, skipped only when `BINDERY_OUTBOUND_PROXY` is set (the dial then targets the operator-trusted proxy, not the webhook host — same carve-out the image proxy uses).
- A `CheckRedirect` that re-runs `ValidateOutboundURL` on every hop with the configured policy, capped at 5.

## Tests

- `TestSend_RedirectToPrivateBlocked` — a loopback test server that 302s to `10.0.0.1` is blocked (loopback opted in only so the server is reachable; the redirect target stays blocked).
- `TestSetValidator_Override` updated to opt loopback into the new dialer. Full `internal/notifier` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)