### PR TITLE
fix(downloader): SSRF-guard the dial on indexer NZB/torrent fetches

### DIFF
--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -39,6 +39,7 @@ type Client struct {
 	baseURL            string
 	password           string
 	http               *http.Client
+	fetchTransport     http.RoundTripper // SSRF-guarded transport for indexer torrent fetches
 	validateTorrentURL func(string) error
 	mu                 sync.Mutex // guards loggedIn
 	loggedIn           bool
@@ -71,9 +72,10 @@ func New(host string, port int, password, urlBase string, useSSL bool) *Client {
 	}
 	jar, _ := cookiejar.New(nil)
 	return &Client{
-		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
-		password: password,
-		http:     &http.Client{Timeout: 15 * time.Second, Jar: jar},
+		baseURL:        fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
+		password:       password,
+		http:           &http.Client{Timeout: 15 * time.Second, Jar: jar},
+		fetchTransport: httpsec.GuardedTransport(httpsec.DownloadFetchPolicy()),
 	}
 }
 
@@ -226,7 +228,12 @@ type fetchedTorrentContent struct {
 func (c *Client) fetchTorrentContent(ctx context.Context, rawURL string) (*fetchedTorrentContent, error) {
 	current := rawURL
 	fetchClient := &http.Client{
-		Transport: c.http.Transport,
+		// Guard the dial against the indexer-controlled torrent URL: the loop
+		// re-validates each redirect hop, and this adds a per-dial recheck so a
+		// DNS rebind between validate and connect can't reach a forbidden host.
+		// Uses the download-fetch-policy transport, not the RPC client's (which
+		// targets the admin-configured download client over loopback).
+		Transport: c.fetchTransport,
 		Timeout:   c.http.Timeout,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse

--- a/internal/downloader/deluge/export_test.go
+++ b/internal/downloader/deluge/export_test.go
@@ -11,6 +11,9 @@ func (c *Client) SetHTTPTransport(rt http.RoundTripper) {
 
 // SetValidateTorrentURL injects a custom URL validator for tests, bypassing
 // the default SSRF check so httptest.Server loopback addresses are accepted.
+// It also drops the dial-time SSRF guard on the fetch transport, which would
+// otherwise reject the loopback test server at connect time.
 func (c *Client) SetValidateTorrentURL(fn func(string) error) {
 	c.validateTorrentURL = fn
+	c.fetchTransport = nil
 }

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -53,8 +53,11 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 		baseURL:   fmt.Sprintf("%s://%s:%d%s/jsonrpc", scheme, host, port, urlbase.Normalize(urlBase)),
 		username:  username,
 		password:  password,
-		http:      &http.Client{Timeout: 15 * time.Second},
-		fetchHTTP: &http.Client{Timeout: 60 * time.Second},
+		http: &http.Client{Timeout: 15 * time.Second},
+		// fetchHTTP pulls indexer-controlled NZB URLs, so guard the dial: it
+		// re-validates the resolved IP on every connect (DNS-rebind) and
+		// rejects a redirect to a forbidden host at dial time.
+		fetchHTTP: &http.Client{Timeout: 60 * time.Second, Transport: httpsec.GuardedTransport(httpsec.DownloadFetchPolicy())},
 		validateNZBURL: func(raw string) error {
 			return httpsec.ValidateOutboundURL(raw, httpsec.DownloadFetchPolicy())
 		},

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -50,10 +50,10 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 		scheme = "https"
 	}
 	return &Client{
-		baseURL:   fmt.Sprintf("%s://%s:%d%s/jsonrpc", scheme, host, port, urlbase.Normalize(urlBase)),
-		username:  username,
-		password:  password,
-		http: &http.Client{Timeout: 15 * time.Second},
+		baseURL:  fmt.Sprintf("%s://%s:%d%s/jsonrpc", scheme, host, port, urlbase.Normalize(urlBase)),
+		username: username,
+		password: password,
+		http:     &http.Client{Timeout: 15 * time.Second},
 		// fetchHTTP pulls indexer-controlled NZB URLs, so guard the dial: it
 		// re-validates the resolved IP on every connect (DNS-rebind) and
 		// rejects a redirect to a forbidden host at dial time.

--- a/internal/downloader/nzbget/client_test.go
+++ b/internal/downloader/nzbget/client_test.go
@@ -95,9 +95,12 @@ func TestTest_EmptyVersion(t *testing.T) {
 
 const testNZBContent = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE nzb PUBLIC "-//newzBin//DTD NZB 1.1//EN" "http://www.newzbin.com/DTD/nzb/nzb-1.1.dtd"><nzb></nzb>`
 
-// allowNZBFetch bypasses the SSRF guard for loopback test servers.
+// allowNZBFetch bypasses the SSRF guard for loopback test servers: it disables
+// both the up-front URL validator and the dial-time transport guard (the latter
+// by reverting fetchHTTP to the default transport).
 func allowNZBFetch(c *Client) {
 	c.validateNZBURL = func(string) error { return nil }
+	c.fetchHTTP.Transport = nil
 }
 
 // configWithCategories returns a configResponse JSON payload exposing the
@@ -981,5 +984,27 @@ func TestCompletedDir(t *testing.T) {
 				t.Fatalf("CompletedDir = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestFetchNZB_DialGuardBlocksLoopback proves the dial-time SSRF guard on the
+// fetch transport: even with the up-front URL validator bypassed, a fetch to a
+// loopback address is rejected at connect time. This closes the DNS-rebind /
+// redirect-to-internal window a malicious indexer could otherwise use.
+func TestFetchNZB_DialGuardBlocksLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<nzb/>"))
+	}))
+	defer srv.Close()
+
+	c := New("127.0.0.1", 6789, "", "", "", false)
+	c.validateNZBURL = func(string) error { return nil } // bypass up-front check; keep the transport dial guard
+
+	_, err := c.fetchNZBContent(context.Background(), srv.URL+"/file.nzb")
+	if err == nil {
+		t.Fatal("expected the dial-time SSRF guard to reject the loopback fetch")
+	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("expected a 'not allowed' SSRF rejection, got: %v", err)
 	}
 }

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -71,6 +71,7 @@ type Client struct {
 	username           string
 	password           string
 	http               *http.Client
+	fetchTransport     http.RoundTripper // SSRF-guarded transport for indexer torrent fetches
 	validateTorrentURL func(string) error
 	mu                 sync.Mutex // guards loggedIn
 	addMu              sync.Mutex // serialises AddTorrent: keeps before/after hash diff atomic
@@ -91,7 +92,8 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
 		username: username,
 		password: password,
-		http:     &http.Client{Timeout: 15 * time.Second, Jar: jar},
+		http:           &http.Client{Timeout: 15 * time.Second, Jar: jar},
+		fetchTransport: httpsec.GuardedTransport(httpsec.DownloadFetchPolicy()),
 		validateTorrentURL: func(raw string) error {
 			return httpsec.ValidateOutboundURL(raw, httpsec.DownloadFetchPolicy())
 		},
@@ -460,7 +462,12 @@ type fetchedTorrentContent struct {
 func (c *Client) fetchTorrentContent(ctx context.Context, rawURL string) (*fetchedTorrentContent, error) {
 	current := rawURL
 	fetchClient := &http.Client{
-		Transport: c.http.Transport,
+		// Guard the dial against the indexer-controlled torrent URL: the loop
+		// re-validates each redirect hop, and this adds a per-dial recheck so a
+		// DNS rebind between validate and connect can't reach a forbidden host.
+		// Uses the download-fetch-policy transport, not the RPC client's (which
+		// targets the admin-configured download client over loopback).
+		Transport: c.fetchTransport,
 		Timeout:   c.http.Timeout,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -89,9 +89,9 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 
 	jar, _ := cookiejar.New(nil)
 	return &Client{
-		baseURL:  fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
-		username: username,
-		password: password,
+		baseURL:        fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
+		username:       username,
+		password:       password,
 		http:           &http.Client{Timeout: 15 * time.Second, Jar: jar},
 		fetchTransport: httpsec.GuardedTransport(httpsec.DownloadFetchPolicy()),
 		validateTorrentURL: func(raw string) error {

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -216,6 +216,7 @@ func newTestClient(serverURL, username, password string) *Client {
 
 func allowTorrentFetch(c *Client) {
 	c.validateTorrentURL = func(string) error { return nil }
+	c.fetchTransport = nil // also drop the dial-time SSRF guard for loopback test servers
 }
 
 func TestNew(t *testing.T) {

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -40,8 +40,11 @@ func New(host string, port int, apiKey, urlBase string, useSSL bool) *Client {
 	return &Client{
 		baseURL:   fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
 		apiKey:    apiKey,
-		http:      &http.Client{Timeout: 15 * time.Second},
-		fetchHTTP: &http.Client{Timeout: 60 * time.Second},
+		http: &http.Client{Timeout: 15 * time.Second},
+		// fetchHTTP pulls indexer-controlled NZB URLs, so guard the dial: it
+		// re-validates the resolved IP on every connect (DNS-rebind) and
+		// rejects a redirect to a forbidden host at dial time.
+		fetchHTTP: &http.Client{Timeout: 60 * time.Second, Transport: httpsec.GuardedTransport(httpsec.DownloadFetchPolicy())},
 		validateNZBURL: func(raw string) error {
 			return httpsec.ValidateOutboundURL(raw, httpsec.DownloadFetchPolicy())
 		},

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -38,9 +38,9 @@ func New(host string, port int, apiKey, urlBase string, useSSL bool) *Client {
 		scheme = "https"
 	}
 	return &Client{
-		baseURL:   fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
-		apiKey:    apiKey,
-		http: &http.Client{Timeout: 15 * time.Second},
+		baseURL: fmt.Sprintf("%s://%s:%d%s", scheme, host, port, urlbase.Normalize(urlBase)),
+		apiKey:  apiKey,
+		http:    &http.Client{Timeout: 15 * time.Second},
 		// fetchHTTP pulls indexer-controlled NZB URLs, so guard the dial: it
 		// re-validates the resolved IP on every connect (DNS-rebind) and
 		// rejects a redirect to a forbidden host at dial time.

--- a/internal/downloader/sabnzbd/client_test.go
+++ b/internal/downloader/sabnzbd/client_test.go
@@ -19,9 +19,12 @@ import (
 
 const testNZBContent = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE nzb PUBLIC "-//newzBin//DTD NZB 1.1//EN" "http://www.newzbin.com/DTD/nzb/nzb-1.1.dtd"><nzb></nzb>`
 
-// allowNZBFetch bypasses the SSRF guard for loopback test servers.
+// allowNZBFetch bypasses the SSRF guard for loopback test servers: it disables
+// both the up-front URL validator and the dial-time transport guard (the latter
+// by reverting fetchHTTP to the default transport).
 func allowNZBFetch(c *Client) {
 	c.validateNZBURL = func(string) error { return nil }
+	c.fetchHTTP.Transport = nil
 }
 
 // readMultipartFile decodes a multipart request body and returns the first

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -51,10 +51,14 @@ func New(host string, port int, username, password, urlBase string, useSSL bool)
 	}
 
 	client := &Client{
-		username:  username,
-		password:  password,
-		http:      &http.Client{Timeout: 15 * time.Second},
-		fetchHTTP: &http.Client{Timeout: 60 * time.Second},
+		username: username,
+		password: password,
+		http:     &http.Client{Timeout: 15 * time.Second},
+		// fetchHTTP pulls indexer-controlled .torrent URLs. The fetch loop
+		// already re-validates each redirect hop; the guarded transport adds a
+		// per-dial recheck so a DNS rebind between validate and connect can't
+		// reach a forbidden host. The per-fetch client inherits this transport.
+		fetchHTTP: &http.Client{Timeout: 60 * time.Second, Transport: httpsec.GuardedTransport(httpsec.DownloadFetchPolicy())},
 		validateTorrentURL: func(raw string) error {
 			return httpsec.ValidateOutboundURL(raw, httpsec.DownloadFetchPolicy())
 		},

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -134,6 +134,7 @@ func TestAddTorrent_HTTPRedirectToMagnet(t *testing.T) {
 
 	c := newTestClient(rpc.URL, "user", "pass")
 	c.validateTorrentURL = func(string) error { return nil } // allow the loopback test server
+	c.fetchHTTP.Transport = nil                              // and drop the dial-time SSRF guard
 
 	id, err := c.AddTorrent(context.Background(), indexer.URL+"/download/123", "", nil)
 	if err != nil {
@@ -702,6 +703,7 @@ const testTorrentContent = "d8:announce32:http://tracker.example.com/announce4:i
 // loopback httptest server. Mirrors allowNZBFetch in the sabnzbd tests.
 func allowTorrentFetch(c *Client) {
 	c.validateTorrentURL = func(string) error { return nil }
+	c.fetchHTTP.Transport = nil // also drop the dial-time SSRF guard for loopback test servers
 }
 
 // readRPCArgs decodes the JSON-RPC request body and returns the arguments

--- a/internal/httpsec/proxy.go
+++ b/internal/httpsec/proxy.go
@@ -121,6 +121,30 @@ func DefaultProxyTransport() http.RoundTripper {
 	return outboundProxyTransport
 }
 
+// GuardedTransport returns a RoundTripper that re-validates the resolved IP on
+// every dial against policy, closing the DNS-rebind TOCTOU window between an
+// up-front ValidateOutboundURL check and the actual connect. For clients that
+// follow redirects it also catches a redirect to a forbidden host at dial time.
+//
+// When an outbound proxy is configured the dial targets the operator-trusted
+// proxy (not the destination host), so a per-dial recheck would re-validate the
+// proxy's own address and break a LAN/loopback proxy; in that case the shared
+// proxy transport is returned unchanged and callers rely on the up-front
+// validation (the rebind recheck cannot see past the proxy anyway). It clones
+// DefaultProxyTransport so installing DialContext never mutates the shared pool.
+func GuardedTransport(policy Policy) http.RoundTripper {
+	base := DefaultProxyTransport()
+	if ProxyFunc() != nil {
+		return base
+	}
+	if t, ok := base.(*http.Transport); ok {
+		c := t.Clone()
+		c.DialContext = NewDialContext(policy)
+		return c
+	}
+	return &http.Transport{DialContext: NewDialContext(policy)}
+}
+
 // bypassProxyForHost reports whether requests to host should skip the proxy and
 // be dialled directly. The no-proxy list is always honoured; the LAN/loopback
 // heuristics apply only when bypassLocal is enabled.


### PR DESCRIPTION
## Weakness

The NZB/.torrent fetch clients pull an **indexer-controlled** download URL server-side with a non-dial-guarded transport. They validate the URL up front, but:
- **nzbget/sabnzbd** followed redirects with the default client and no per-hop revalidation; and
- **all five** (nzbget, sabnzbd, transmission, qbittorrent, deluge) lacked a dial-time IP recheck, so a hostname that resolved public at validate time could rebind to loopback/RFC1918 before the actual connect (TOCTOU).

A malicious or compromised indexer could use either to reach internal services. The newznab *search* client already installs a `NewDialContext` guard — the fetch clients were the inconsistent gap.

## Fix

- New shared `httpsec.GuardedTransport(policy)`: a proxy-aware transport whose `DialContext` re-validates the resolved IP on every connect (closing the rebind window, and catching a redirect-to-internal at dial time). Skipped when an outbound proxy is configured (the dial then targets the trusted proxy), matching the image-proxy carve-out.
- Wired into every fetch client under `DownloadFetchPolicy()`. transmission keeps its existing per-hop redirect revalidation and now also gets the dial guard. qbittorrent/deluge gain a `fetchTransport` field so the per-fetch client no longer borrows the RPC client's transport (which targets the admin download client over loopback under a different policy).

## Tests

- `TestFetchNZB_DialGuardBlocksLoopback` (nzbget): with the up-front validator bypassed, a loopback fetch is rejected at **dial time** — isolating the new protection.
- Existing fetch tests' bypass helpers now also drop the dial guard (so loopback test servers remain reachable); the SSRF-rejection tests are untouched and still assert blocking. Full `internal/downloader/...` + `internal/httpsec` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)