### PR TITLE
fix(importer): skip symlinked files when discovering book files to import

### DIFF
--- a/internal/importer/scanner_handoff.go
+++ b/internal/importer/scanner_handoff.go
@@ -120,11 +120,20 @@ func (s *Scanner) pushToCWA(ctx context.Context, srcPath string) {
 // and the external-mode drop handoff.
 func discoverBookFiles(downloadPath string, explicitFiles []string) []string {
 	if len(explicitFiles) > 0 {
-		return explicitFiles
+		return filterSymlinks(explicitFiles)
 	}
 	var bookFiles []string
 	if err := filepath.Walk(downloadPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
+			return nil
+		}
+		// Skip symlinks. A malicious release can ship a book-extension symlink
+		// pointing at an arbitrary file (e.g. /config/bindery.db, /etc/passwd);
+		// importing it in copy mode would os.Open-follow the link and copy the
+		// target's bytes into the library where the user can download them.
+		// filepath.Walk Lstats, so a symlink shows ModeSymlink here.
+		if info.Mode()&os.ModeSymlink != 0 {
+			slog.Warn("skipping symlinked file in download path", "path", path)
 			return nil
 		}
 		if IsBookFile(path) {
@@ -135,6 +144,22 @@ func discoverBookFiles(downloadPath string, explicitFiles []string) []string {
 		slog.Warn("failed to walk download path", "path", downloadPath, "error", err)
 	}
 	return bookFiles
+}
+
+// filterSymlinks drops any path that is a symlink (Lstat, so the link itself is
+// inspected, not its target). The download client's authoritative file list
+// (#903) can include a symlink a malicious release planted to point at an
+// arbitrary file; importing it would copy the target's bytes into the library.
+func filterSymlinks(paths []string) []string {
+	out := paths[:0:0]
+	for _, p := range paths {
+		if fi, err := os.Lstat(p); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+			slog.Warn("skipping symlinked file in download path", "path", p)
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 // dropSettings reads the external-mode drop-folder configuration (#941).

--- a/internal/importer/scanner_symlink_test.go
+++ b/internal/importer/scanner_symlink_test.go
@@ -1,0 +1,55 @@
+package importer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDiscoverBookFiles_SkipsSymlinks is the security regression for the
+// arbitrary-file-read primitive: a malicious release that ships a
+// book-extension symlink pointing at an arbitrary file must not be collected
+// for import (which would copy the link target's bytes into the library).
+func TestDiscoverBookFiles_SkipsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+
+	real := filepath.Join(dir, "real.epub")
+	if err := os.WriteFile(real, []byte("book"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(dir, "secret.txt")
+	if err := os.WriteFile(secret, []byte("SECRET"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	evil := filepath.Join(dir, "evil.epub")
+	if err := os.Symlink(secret, evil); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	has := func(files []string, want string) bool {
+		for _, f := range files {
+			if f == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Walk path (no explicit file list).
+	walked := discoverBookFiles(dir, nil)
+	if !has(walked, real) {
+		t.Errorf("walk: expected the real ebook to be discovered, got %v", walked)
+	}
+	if has(walked, evil) {
+		t.Errorf("walk: symlinked file must be skipped, got %v", walked)
+	}
+
+	// Explicit-file path (download client's authoritative file list).
+	explicit := discoverBookFiles(dir, []string{real, evil})
+	if !has(explicit, real) {
+		t.Errorf("explicit: expected the real ebook, got %v", explicit)
+	}
+	if has(explicit, evil) {
+		t.Errorf("explicit: symlinked file must be skipped, got %v", explicit)
+	}
+}


### PR DESCRIPTION
## Weakness

`discoverBookFiles` collected book files by extension only — no symlink filter — on both the `filepath.Walk` path and the explicit download-client file list (#903). A malicious release can plant a book-extension symlink pointing at an arbitrary file (e.g. `/config/bindery.db`, `/etc/passwd`). On import in copy mode, `os.Open` follows the link and copies the **target's** bytes into the library, where the user can then download them — an arbitrary file read seeded by attacker-authored download content (the standard *arr threat model: you grab a release someone else built).

`bindery.db` holds every indexer key and download-client password, so this is a credential-disclosure primitive, not just a file read.

Reachable via the background import on a completed download; no auth needed.

## Fix

Skip entries whose `Lstat` shows `ModeSymlink`, on both the walk and the explicit-file paths (mirrors the existing symlink skip in `flatten.go`). The directory-recursive copy is already symlink-safe (`os.Root` + non-regular skip). The **library scan** is intentionally left as-is: it walks the user's own trusted library, where symlinks can be a legitimate layout.

## Test

`TestDiscoverBookFiles_SkipsSymlinks`: a real `.epub` plus an `evil.epub → secret.txt` symlink; the symlink is excluded from both the walk and the explicit-file list, the real file retained. Full `internal/importer` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)