### PR TITLE
fix(api): gate /migrate/* import routes behind RequireAdmin

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -1001,24 +1001,10 @@ func main() {
 			r.Post("/calibre/runs/{runID}/rollback", calibreRunsHandler.Rollback)
 		})
 
-		// Migration imports (CSV of author names, or Readarr SQLite DB).
-		// The Readarr import is async — POST returns 202 immediately and the
-		// UI polls GET /migrate/readarr/status to track completion.
-		//
-		// Per-route body caps override the 1 MiB default for routes that
-		// accept multipart file uploads. The handler-side acceptUpload still
-		// applies the authoritative per-route cap via http.MaxBytesReader;
-		// these overrides just raise the outer router-level ceiling so the
-		// inner wrap is the one that decides.
-		r.With(api.WithMaxBody(6<<20)).Post("/migrate/csv", migrateHandler.ImportCSV)         // CSV under 5 MiB
-		r.With(api.WithMaxBody(2<<30)).Post("/migrate/readarr", migrateHandler.ImportReadarr) // readarr.db can be hundreds of MiB
-		r.Get("/migrate/readarr/status", migrateHandler.ImportReadarrStatus)
-
-		// Goodreads library CSV import — a two-step migration aid: POST the
-		// export to /goodreads/preview for a dry-run, then POST the returned
-		// token to /goodreads/commit to add the resolved books.
-		r.With(api.WithMaxBody(24<<20)).Post("/migrate/goodreads/preview", migrateHandler.ImportGoodreadsPreview) // Goodreads export under 20 MiB
-		r.Post("/migrate/goodreads/commit", migrateHandler.ImportGoodreadsCommit)
+		// Migration imports (CSV of author names, or Readarr SQLite DB). The
+		// Readarr import is async — POST returns 202 immediately and the UI
+		// polls GET /migrate/readarr/status. Admin-only (see registerMigrateRoutes).
+		registerMigrateRoutes(r, migrateHandler)
 
 		// Image proxy — caches external cover images locally so the browser
 		// never leaks the user's IP to Goodreads / OpenLibrary / etc.

--- a/cmd/bindery/sensitive_routes.go
+++ b/cmd/bindery/sensitive_routes.go
@@ -5,8 +5,38 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/vavallee/bindery/internal/api"
 	"github.com/vavallee/bindery/internal/auth"
 )
+
+// migrateRouteHandler is the surface registerMigrateRoutes needs.
+type migrateRouteHandler interface {
+	ImportCSV(http.ResponseWriter, *http.Request)
+	ImportReadarr(http.ResponseWriter, *http.Request)
+	ImportReadarrStatus(http.ResponseWriter, *http.Request)
+	ImportGoodreadsPreview(http.ResponseWriter, *http.Request)
+	ImportGoodreadsCommit(http.ResponseWriter, *http.Request)
+}
+
+// registerMigrateRoutes mounts the /migrate/* import routes. The whole subtree
+// is admin-only: these import authors, indexers, and download-client
+// credentials and parse uploaded files server-side, the same config-mutating
+// privilege level as the other admin routes. A non-admin must not be able to
+// import a Readarr DB full of indexer keys / client passwords. The per-route
+// WithMaxBody overrides raise the outer router ceiling; the handler-side
+// acceptUpload still applies the authoritative cap.
+func registerMigrateRoutes(r chi.Router, h migrateRouteHandler) {
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAdmin)
+		r.With(api.WithMaxBody(6 << 20)).Post("/migrate/csv", h.ImportCSV)         // CSV under 5 MiB
+		r.With(api.WithMaxBody(2 << 30)).Post("/migrate/readarr", h.ImportReadarr) // readarr.db can be hundreds of MiB
+		r.Get("/migrate/readarr/status", h.ImportReadarrStatus)
+		// Goodreads library CSV import — POST the export to /goodreads/preview
+		// for a dry-run, then POST the returned token to /goodreads/commit.
+		r.With(api.WithMaxBody(24 << 20)).Post("/migrate/goodreads/preview", h.ImportGoodreadsPreview) // export under 20 MiB
+		r.Post("/migrate/goodreads/commit", h.ImportGoodreadsCommit)
+	})
+}
 
 // indexerRouteHandler is the surface registerIndexerRoutes needs. The full
 // IndexerHandler exposes more methods (SearchBook, LastSearchDebug,

--- a/cmd/bindery/sensitive_routes.go
+++ b/cmd/bindery/sensitive_routes.go
@@ -28,12 +28,12 @@ type migrateRouteHandler interface {
 func registerMigrateRoutes(r chi.Router, h migrateRouteHandler) {
 	r.Group(func(r chi.Router) {
 		r.Use(auth.RequireAdmin)
-		r.With(api.WithMaxBody(6 << 20)).Post("/migrate/csv", h.ImportCSV)         // CSV under 5 MiB
-		r.With(api.WithMaxBody(2 << 30)).Post("/migrate/readarr", h.ImportReadarr) // readarr.db can be hundreds of MiB
+		r.With(api.WithMaxBody(6<<20)).Post("/migrate/csv", h.ImportCSV)         // CSV under 5 MiB
+		r.With(api.WithMaxBody(2<<30)).Post("/migrate/readarr", h.ImportReadarr) // readarr.db can be hundreds of MiB
 		r.Get("/migrate/readarr/status", h.ImportReadarrStatus)
 		// Goodreads library CSV import — POST the export to /goodreads/preview
 		// for a dry-run, then POST the returned token to /goodreads/commit.
-		r.With(api.WithMaxBody(24 << 20)).Post("/migrate/goodreads/preview", h.ImportGoodreadsPreview) // export under 20 MiB
+		r.With(api.WithMaxBody(24<<20)).Post("/migrate/goodreads/preview", h.ImportGoodreadsPreview) // export under 20 MiB
 		r.Post("/migrate/goodreads/commit", h.ImportGoodreadsCommit)
 	})
 }

--- a/cmd/bindery/sensitive_routes_test.go
+++ b/cmd/bindery/sensitive_routes_test.go
@@ -53,6 +53,21 @@ func (h *stubSensitiveHandler) SearchQuery(w http.ResponseWriter, _ *http.Reques
 func (h *stubSensitiveHandler) LastSearchDebug(w http.ResponseWriter, _ *http.Request) {
 	h.record("last-search-debug", w)
 }
+func (h *stubSensitiveHandler) ImportCSV(w http.ResponseWriter, _ *http.Request) {
+	h.record("import-csv", w)
+}
+func (h *stubSensitiveHandler) ImportReadarr(w http.ResponseWriter, _ *http.Request) {
+	h.record("import-readarr", w)
+}
+func (h *stubSensitiveHandler) ImportReadarrStatus(w http.ResponseWriter, _ *http.Request) {
+	h.record("import-readarr-status", w)
+}
+func (h *stubSensitiveHandler) ImportGoodreadsPreview(w http.ResponseWriter, _ *http.Request) {
+	h.record("import-goodreads-preview", w)
+}
+func (h *stubSensitiveHandler) ImportGoodreadsCommit(w http.ResponseWriter, _ *http.Request) {
+	h.record("import-goodreads-commit", w)
+}
 
 // TestSensitiveRoutesRequireAdmin nails down the security finding from the
 // v1.15.0 review: List/Get/Create/Update/Delete on the indexer, prowlarr, and
@@ -92,6 +107,12 @@ func TestSensitiveRoutesRequireAdmin(t *testing.T) {
 		{name: "delete download client", method: http.MethodDelete, path: "/downloadclient/1"},
 		{name: "test download client", method: http.MethodPost, path: "/downloadclient/1/test"},
 		{name: "test download client config", method: http.MethodPost, path: "/downloadclient/test"},
+		// Migrate imports — pull in indexer/client credentials, so admin-only.
+		{name: "import csv", method: http.MethodPost, path: "/migrate/csv"},
+		{name: "import readarr", method: http.MethodPost, path: "/migrate/readarr"},
+		{name: "import readarr status", method: http.MethodGet, path: "/migrate/readarr/status"},
+		{name: "import goodreads preview", method: http.MethodPost, path: "/migrate/goodreads/preview"},
+		{name: "import goodreads commit", method: http.MethodPost, path: "/migrate/goodreads/commit"},
 	}
 
 	for _, tt := range tests {
@@ -101,6 +122,7 @@ func TestSensitiveRoutesRequireAdmin(t *testing.T) {
 			registerIndexerRoutes(router, h)
 			registerProwlarrRoutes(router, h)
 			registerDownloadClientRoutes(router, h)
+			registerMigrateRoutes(router, h)
 
 			req := httptest.NewRequest(tt.method, tt.path, nil)
 			req = req.WithContext(auth.WithUserRole(req.Context(), "user"))

--- a/cmd/bindery/sensitive_routes_test.go
+++ b/cmd/bindery/sensitive_routes_test.go
@@ -171,6 +171,13 @@ func TestSensitiveRoutesAllowAdmin(t *testing.T) {
 		{name: "delete download client", method: http.MethodDelete, path: "/downloadclient/1", called: "delete"},
 		{name: "test download client", method: http.MethodPost, path: "/downloadclient/1/test", called: "test"},
 		{name: "test download client config", method: http.MethodPost, path: "/downloadclient/test", called: "test-config"},
+		// Migrate imports — admin must still reach each handler (guards against
+		// accidentally mounting them outside the group so they 404 instead).
+		{name: "import csv", method: http.MethodPost, path: "/migrate/csv", called: "import-csv"},
+		{name: "import readarr", method: http.MethodPost, path: "/migrate/readarr", called: "import-readarr"},
+		{name: "import readarr status", method: http.MethodGet, path: "/migrate/readarr/status", called: "import-readarr-status"},
+		{name: "import goodreads preview", method: http.MethodPost, path: "/migrate/goodreads/preview", called: "import-goodreads-preview"},
+		{name: "import goodreads commit", method: http.MethodPost, path: "/migrate/goodreads/commit", called: "import-goodreads-commit"},
 	}
 
 	for _, tt := range tests {
@@ -180,6 +187,7 @@ func TestSensitiveRoutesAllowAdmin(t *testing.T) {
 			registerIndexerRoutes(router, h)
 			registerProwlarrRoutes(router, h)
 			registerDownloadClientRoutes(router, h)
+			registerMigrateRoutes(router, h)
 
 			req := httptest.NewRequest(tt.method, tt.path, nil)
 			req = req.WithContext(auth.WithUserRole(req.Context(), "admin"))


### PR DESCRIPTION
## Weakness

The `/migrate/{csv,readarr,goodreads/*}` import routes were registered in the general authenticated group, **not** under `RequireAdmin`. They import authors, indexers, and download-client credentials and parse uploaded files server-side — the same config-mutating privilege level as every other admin route (auth, backup, calibre rollback). Any authenticated non-admin could import a Readarr DB full of indexer API keys and download-client passwords.

Authenticated + CSRF-protected, so Low — the gap is privilege level, not an open door.

## Fix

Extract `registerMigrateRoutes` (mirroring the existing `registerIndexerRoutes`/`registerProwlarrRoutes`/`registerDownloadClientRoutes` helpers) with a `RequireAdmin` group, and replace the inline registration in `main.go` with a call to it. The per-route `WithMaxBody` caps are preserved.

## Test

The migrate routes are added to `TestSensitiveRoutesRequireAdmin`, which asserts a `role=user` request gets 403 and the handler never runs — so a future route added outside the admin group trips the test. Full `cmd/bindery` suite + vet pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)