### PR TITLE
fix(sabnzbd): stop apikey re-leaking through %w-wrapped url.Error

### DIFF
--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -317,6 +318,19 @@ func (c *Client) DeleteHistory(ctx context.Context, nzoID string, deleteFiles bo
 	return c.apiCall(ctx, params, &resp)
 }
 
+// redactURLError scrubs the apikey from a *url.Error's URL field in place, so
+// the error string no longer leaks the secret when it is %w-wrapped, while
+// leaving the wrapped error chain intact for type-based inspection (nethint's
+// DNS/timeout classification relies on errors.As reaching the underlying net
+// error). Non-url.Error values pass through unchanged.
+func redactURLError(err error) error {
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		ue.URL = redactAPIURL(ue.URL)
+	}
+	return err
+}
+
 // redactAPIURL returns a copy of rawURL with the "apikey" query parameter
 // replaced by "REDACTED", safe for use in error messages and logs.
 func redactAPIURL(rawURL string) string {
@@ -339,12 +353,16 @@ func (c *Client) apiCall(ctx context.Context, params url.Values, target interfac
 	u := fmt.Sprintf("%s/api?%s", c.baseURL, params.Encode())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		return fmt.Errorf("build request for %s: %w", redactAPIURL(u), err)
+		return fmt.Errorf("build request for %s: %w", redactAPIURL(u), redactURLError(err))
 	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return fmt.Errorf("request to %s: %w", redactAPIURL(u), err)
+		// redactURLError scrubs the apikey from the *url.Error's URL field
+		// (which %w would otherwise re-expose despite the redacted prefix)
+		// while keeping the wrapped chain intact so nethint can still classify
+		// the network failure.
+		return fmt.Errorf("request to %s: %w", redactAPIURL(u), redactURLError(err))
 	}
 	defer resp.Body.Close()
 
@@ -367,13 +385,14 @@ func (c *Client) apiUpload(ctx context.Context, params url.Values, body *bytes.B
 	u := fmt.Sprintf("%s/api?%s", c.baseURL, params.Encode())
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, body)
 	if err != nil {
-		return fmt.Errorf("build upload for %s: %w", redactAPIURL(u), err)
+		return fmt.Errorf("build upload for %s: %w", redactAPIURL(u), redactURLError(err))
 	}
 	req.Header.Set("Content-Type", contentType)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return fmt.Errorf("upload to %s: %w", redactAPIURL(u), err)
+		// See apiCall: redact the url.Error's URL in place, keep the chain for nethint.
+		return fmt.Errorf("upload to %s: %w", redactAPIURL(u), redactURLError(err))
 	}
 	defer resp.Body.Close()
 

--- a/internal/downloader/sabnzbd/client_test.go
+++ b/internal/downloader/sabnzbd/client_test.go
@@ -590,3 +590,26 @@ type netTimeoutErr struct{}
 func (e *netTimeoutErr) Error() string   { return "i/o timeout" }
 func (e *netTimeoutErr) Timeout() bool   { return true }
 func (e *netTimeoutErr) Temporary() bool { return true }
+
+// sabErrRoundTripper makes http.Client.Do fail so net/http wraps the request
+// URL (incl. apikey) into a *url.Error — exercising the redaction path.
+type sabErrRoundTripper struct{}
+
+func (sabErrRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, io.ErrUnexpectedEOF
+}
+
+// TestAPICall_RedactsAPIKeyOnTransportError guards against the SAB apikey
+// leaking through a %w-wrapped *url.Error into Test/health errors and logs.
+func TestAPICall_RedactsAPIKeyOnTransportError(t *testing.T) {
+	c := New("127.0.0.1", 8080, "supersecretkey", "", false)
+	c.http = &http.Client{Transport: sabErrRoundTripper{}}
+
+	err := c.Test(context.Background())
+	if err == nil {
+		t.Fatal("expected a transport error")
+	}
+	if strings.Contains(err.Error(), "supersecretkey") {
+		t.Fatalf("apikey leaked in error string: %s", err.Error())
+	}
+}


### PR DESCRIPTION
## Weakness

`apiCall`/`apiUpload` prefixed their errors with a redacted URL (`redactAPIURL(u)`) but then `%w`-wrapped the original `*url.Error`, whose message still embeds the full request URL including `&apikey=<secret>`. The redacted prefix is cosmetic — `errors.Unwrap` / `.Error()` on the result yields the cleartext key (the #1053 fix partially undone by the `%w`). These errors surface to the admin Test/health paths and admin-readable logs (Low — admin-only sinks).

## Fix

Add `redactURLError`, which scrubs the apikey from the `*url.Error`'s `URL` field **in place**, then keep the `%w` wrap. This removes the secret from the error string while leaving the wrapped chain intact — important because `nethint.ForErr` uses `errors.As` to reach the underlying net error and add Docker/firewall network hints. (Flattening the error to a plain string would have regressed those hints; `redactURLError` avoids that.)

## Test

`TestAPICall_RedactsAPIKeyOnTransportError` injects a failing transport and asserts the apikey does not appear in the resulting `Test()` error. The existing `TestTest_DNSNotFound` / `TestTest_Timeout` network-hint tests still pass (chain preserved). Full `internal/downloader/sabnzbd` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)