### PR TITLE
fix(importer): strip control chars and cap component length in sanitizePath

### DIFF
--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -810,6 +810,11 @@ func CopyDirCtx(ctx context.Context, src, dst string) error {
 	return copyDirPublicCtx(ctx, src, dst)
 }
 
+// maxPathComponentLen caps each sanitized path segment. Most filesystems limit
+// a single name to 255 bytes (NAME_MAX); 200 leaves room for the extension and
+// any uniqueness suffix the importer appends.
+const maxPathComponentLen = 200
+
 func sanitizePath(s string) string {
 	// Remove characters that are problematic in file paths
 	replacer := strings.NewReplacer(
@@ -817,6 +822,15 @@ func sanitizePath(s string) string {
 		"\"", "", "<", "", ">", "", "|", "",
 	)
 	cleaned := strings.TrimSpace(replacer.Replace(s))
+	// Drop control characters, including the NUL byte: a NUL makes the os.*
+	// calls fail with EINVAL (a hard import failure driven by attacker-
+	// controlled metadata), and other control bytes are never valid in a name.
+	cleaned = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, cleaned)
 	// Strip traversal components (".", "..", empties) so a single field can't
 	// contribute a segment that walks out of the library root even after
 	// character replacement.
@@ -826,6 +840,11 @@ func sanitizePath(s string) string {
 		p = strings.TrimSpace(p)
 		if p == "" || p == "." || p == ".." {
 			continue
+		}
+		// Cap each component (rune-safe) so an overlong metadata field can't
+		// produce an ENAMETOOLONG that fails the whole import.
+		if r := []rune(p); len(r) > maxPathComponentLen {
+			p = strings.TrimSpace(string(r[:maxPathComponentLen]))
 		}
 		kept = append(kept, p)
 	}

--- a/internal/importer/renamer_sanitize_test.go
+++ b/internal/importer/renamer_sanitize_test.go
@@ -1,0 +1,39 @@
+package importer
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestSanitizePath_StripsControlChars(t *testing.T) {
+	cases := map[string]string{
+		"a\x00b": "ab", // NUL — would make os.* fail EINVAL
+		"a\tb":   "ab", // tab
+		"a\nb":   "ab", // newline
+		"a\x7fc": "ac", // DEL
+	}
+	for in, want := range cases {
+		if got := sanitizePath(in); got != want {
+			t.Errorf("sanitizePath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSanitizePath_CapsComponentLength(t *testing.T) {
+	got := sanitizePath(strings.Repeat("x", 500))
+	if n := utf8.RuneCountInString(got); n != maxPathComponentLen {
+		t.Errorf("component length = %d, want %d", n, maxPathComponentLen)
+	}
+}
+
+func TestSanitizePath_CapIsRuneSafe(t *testing.T) {
+	// Multi-byte runes must not be split mid-encoding by the length cap.
+	got := sanitizePath(strings.Repeat("é", 500))
+	if !utf8.ValidString(got) {
+		t.Errorf("truncation produced invalid UTF-8: %q", got)
+	}
+	if n := utf8.RuneCountInString(got); n != maxPathComponentLen {
+		t.Errorf("rune count = %d, want %d", n, maxPathComponentLen)
+	}
+}


### PR DESCRIPTION
## Weakness (hardening)

`sanitizePath` replaced shell/path metacharacters (`/ \ : * ? " < > |`) and stripped traversal segments (`.`, `..`), but left:
- **control characters / NUL bytes** — a NUL makes the `os.*` calls fail `EINVAL`, a hard import failure driven by attacker-controlled OpenLibrary/Hardcover metadata; and
- **overlong components** — a 300-char title segment can exceed `NAME_MAX` (`ENAMETOOLONG`).

Neither is a traversal escape (the `ensureContained` backstop already prevents that, and was confirmed sound in review), so this is robustness hardening, not a vuln fix.

## Fix

- Drop runes `< 0x20` and `0x7f` via `strings.Map`.
- Cap each component at 200 runes (rune-safe slice, so multi-byte names aren't split mid-encoding) — leaves room under the 255-byte `NAME_MAX` for the extension and uniqueness suffix.

## Test

`TestSanitizePath_StripsControlChars` (NUL/tab/newline/DEL removed), `_CapsComponentLength` (500→200), `_CapIsRuneSafe` (multi-byte `é`×500 stays valid UTF-8 at 200 runes). Existing `TestSanitizePathPreviewDriftGuard` still passes; full `internal/importer` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)