### PR TITLE
fix(web): scheme-allowlist indexer infoUrl links (anti-XSS)

### DIFF
--- a/web/src/components/MarkdownDescription.tsx
+++ b/web/src/components/MarkdownDescription.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { CSSProperties, ReactNode } from 'react'
+import { safeHref } from '../util/safeHref'
 
 interface MarkdownDescriptionProps {
   text: string
@@ -15,12 +16,6 @@ const sourcesLineRE = /^\s*\(Sources?:\s*.*\)\s*$/i
 // reference link (rendered as plain text — the [ref]: defs are stripped),
 // **bold**, *italic*.
 const inlineTokenRE = /\[([^\]]+)\]\(([^)\s]+)\)|\[([^\]]+)\]\[[^\]]+\]|\*\*([^*\n]+?)\*\*|\*([^*\n]+?)\*/g
-
-// safeHref returns url only when it is an http(s) URL, so a description from an
-// upstream metadata provider can't inject javascript:/data: links.
-function safeHref(url: string): string {
-  return /^https?:\/\//i.test(url) ? url : ''
-}
 
 function cleanMarkdownDescription(text: string): string {
   return text

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -9,6 +9,7 @@ import RebindModal from '../components/RebindModal'
 import ConfirmDialog from '../components/ConfirmDialog'
 import ClipboardManualFallback from '../components/ClipboardManualFallback'
 import { useClipboardCopy } from '../components/useClipboardCopy'
+import { safeHref } from '../util/safeHref'
 
 function formatSize(n: number): string {
   if (!n || n <= 0) return ''
@@ -89,11 +90,11 @@ export function SearchResultsSection({
         </div>
         <span className="text-slate-500 dark:text-zinc-500 truncate block">
           {r.indexerName} · {formatSize(r.size)} · {r.grabs} grabs
-          {r.infoUrl && (
+          {safeHref(r.infoUrl) && (
             <>
               {' · '}
               <a
-                href={r.infoUrl}
+                href={safeHref(r.infoUrl)}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={e => e.stopPropagation()}

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -6,6 +6,7 @@ import BulkActionBar from '../components/BulkActionBar'
 import ImportHints from '../components/ImportHints'
 import Pagination from '../components/Pagination'
 import { usePagination } from '../components/usePagination'
+import { safeHref } from '../util/safeHref'
 
 // Shared grid template so the header row and every list row line up exactly.
 // columns: checkbox · cover · title+author · format · actions
@@ -363,11 +364,11 @@ export default function WantedPage() {
                           <span className="truncate block">{r.title}</span>
                           <span className="text-slate-600 dark:text-zinc-500 truncate block">
                             {r.indexerName} &middot; {formatSize(r.size)} &middot; {r.grabs} grabs
-                            {r.infoUrl && (
+                            {safeHref(r.infoUrl) && (
                               <>
                                 {' '}&middot;{' '}
                                 <a
-                                  href={r.infoUrl}
+                                  href={safeHref(r.infoUrl)}
                                   target="_blank"
                                   rel="noopener noreferrer"
                                   className="text-sky-600 dark:text-sky-400 hover:underline"

--- a/web/src/util/safeHref.test.ts
+++ b/web/src/util/safeHref.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { safeHref } from './safeHref'
+
+describe('safeHref', () => {
+  it('allows http(s) URLs', () => {
+    expect(safeHref('https://indexer.example/details/1')).toBe('https://indexer.example/details/1')
+    expect(safeHref('http://indexer.local/x')).toBe('http://indexer.local/x')
+    expect(safeHref('HTTPS://EXAMPLE/x')).toBe('HTTPS://EXAMPLE/x')
+  })
+
+  it('rejects dangerous and non-http schemes', () => {
+    for (const u of [
+      'javascript:alert(1)',
+      'JaVaScRiPt:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox',
+      'file:///etc/passwd',
+      '//evil.example/x',
+      'ftp://host/x',
+      'relative/path',
+    ]) {
+      expect(safeHref(u)).toBe('')
+    }
+  })
+
+  it('handles empty/nullish input', () => {
+    expect(safeHref('')).toBe('')
+    expect(safeHref(undefined)).toBe('')
+    expect(safeHref(null)).toBe('')
+  })
+})

--- a/web/src/util/safeHref.ts
+++ b/web/src/util/safeHref.ts
@@ -1,0 +1,8 @@
+// safeHref returns url only when it is an http(s) URL. Strings that reach an
+// <a href> from an upstream source we don't control — an indexer's release
+// infoUrl, a metadata provider's description link — could otherwise be a
+// `javascript:` / `data:` URI and execute on click. Anything that isn't a
+// plain http(s) URL collapses to '' so the caller renders no link.
+export function safeHref(url: string | undefined | null): string {
+  return url && /^https?:\/\//i.test(url) ? url : ''
+}


### PR DESCRIPTION
## Weakness

The interactive-search result `infoUrl` (supplied by the indexer) was placed directly into an `<a href>` on `WantedPage` and `BookDetailPage` with no scheme check. A malicious/compromised indexer could return a `javascript:` URI that executes on click. Low — it's outside the Google Books/Hardcover metadata scope and modern browsers neutralize `javascript:` in a new browsing context, but it's an easy, real hardening.

## Fix

`MarkdownDescription` already guarded its links with a local `safeHref` (`^https?://` only). Lift it into a shared `web/src/util/safeHref.ts`, route `infoUrl` through it on both pages, and de-duplicate the component's copy.

## Test

`safeHref.test.ts`: allows `http(s)` (incl. uppercase scheme); rejects `javascript:`/`data:`/`vbscript:`/`file:`/protocol-relative/`ftp:`/relative; handles empty/null. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)