### PR TITLE
test(importer): cover MoveFileCtx cross-fs copy+verify, mismatch-keeps-source, ctx-cancel

### DIFF
--- a/internal/importer/movefile_test.go
+++ b/internal/importer/movefile_test.go
@@ -1,0 +1,157 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// writeMoveFile is a small helper for the MoveFileCtx tests.
+func writeMoveFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func mustNotExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected %s to NOT exist, stat err=%v", path, err)
+	}
+}
+
+func mustHaveContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("content of %s = %q, want %q", path, string(got), want)
+	}
+}
+
+// TestMoveFileCtx_Rename covers the fast path: os.Rename succeeds (same
+// filesystem), dst lands with the right content and src disappears.
+func TestMoveFileCtx_Rename(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "book.epub")
+	dst := filepath.Join(dir, "library", "Author", "Title", "book.epub")
+	writeMoveFile(t, src, "hello world")
+
+	if err := MoveFileCtx(context.Background(), src, dst); err != nil {
+		t.Fatalf("MoveFileCtx: %v", err)
+	}
+
+	mustHaveContent(t, dst, "hello world")
+	mustNotExist(t, src)
+}
+
+// TestMoveFileCtx_CrossDeviceCopyFallback forces os.Rename to fail with EXDEV
+// (the cross-filesystem error that triggers the copy+verify+delete slow path)
+// and asserts the slow path copies the file, the verify passes, and the
+// source is removed.
+func TestMoveFileCtx_CrossDeviceCopyFallback(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "book.epub")
+	dst := filepath.Join(dir, "library", "book.epub")
+	writeMoveFile(t, src, "the quick brown fox")
+
+	// Force the cross-device branch: real os.Rename within one tempdir would
+	// succeed, so override the seam to return EXDEV exactly as a real
+	// cross-filesystem rename would.
+	defer restoreMoveSeams()
+	moveFileRename = func(_, _ string) error { return &os.LinkError{Op: "rename", Err: syscall.EXDEV} }
+
+	if err := MoveFileCtx(context.Background(), src, dst); err != nil {
+		t.Fatalf("MoveFileCtx (cross-device fallback): %v", err)
+	}
+
+	mustHaveContent(t, dst, "the quick brown fox")
+	mustNotExist(t, src)
+}
+
+// TestMoveFileCtx_VerifyMismatchKeepsSource is the data-safety invariant: if
+// the cross-filesystem copy produces a dst whose size does not match src
+// (truncated / partial write), MoveFileCtx must return an error, remove the
+// bad dst, and LEAVE THE SOURCE INTACT so the still-seeding/original file is
+// never destroyed by a corrupt copy.
+func TestMoveFileCtx_VerifyMismatchKeepsSource(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "book.epub")
+	dst := filepath.Join(dir, "library", "book.epub")
+	const srcContent = "complete original payload"
+	writeMoveFile(t, src, srcContent)
+
+	defer restoreMoveSeams()
+	// Trigger the slow path...
+	moveFileRename = func(_, _ string) error { return &os.LinkError{Op: "rename", Err: syscall.EXDEV} }
+	// ...and make the "copy" produce a short/wrong-size dst so verify fails.
+	moveFileCopy = func(_ context.Context, _, dst string) error {
+		return os.WriteFile(dst, []byte("short"), 0o644)
+	}
+
+	err := MoveFileCtx(context.Background(), src, dst)
+	if err == nil {
+		t.Fatal("expected size-mismatch error, got nil")
+	}
+
+	// Source MUST survive untouched: this is the data-loss guard.
+	mustHaveContent(t, src, srcContent)
+	// Bad dst must be cleaned up.
+	mustNotExist(t, dst)
+}
+
+// TestMoveFileCtx_ContextCancelKeepsSource cancels the context before the
+// copy fallback runs. copyFileCtx returns ctx.Err() and removes any partial
+// dst; MoveFileCtx must surface the error and the source must be preserved.
+func TestMoveFileCtx_ContextCancelKeepsSource(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src", "book.epub")
+	dst := filepath.Join(dir, "library", "book.epub")
+	const srcContent = "still seeding, do not lose me"
+	writeMoveFile(t, src, srcContent)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before the copy starts
+
+	defer restoreMoveSeams()
+	moveFileRename = func(_, _ string) error { return &os.LinkError{Op: "rename", Err: syscall.EXDEV} }
+	// The real copyFileCtx races io.Copy of the tiny file against ctx.Done(),
+	// so a pre-cancelled ctx is non-deterministic for a small file. To assert
+	// MoveFileCtx's contract deterministically we drive the copy through a
+	// hook that reports the cancellation the way the real copyFileCtx does on
+	// its ctx.Done() branch: remove any partial dst and return ctx.Err(). The
+	// point under test is that MoveFileCtx propagates that error and never
+	// removes the source.
+	moveFileCopy = func(c context.Context, _, dst string) error {
+		_ = os.Remove(dst)
+		return c.Err()
+	}
+
+	err := MoveFileCtx(ctx, src, dst)
+	if err == nil {
+		t.Fatal("expected ctx-cancel error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled in error chain, got %v", err)
+	}
+
+	// Source preserved; no half-written dst left behind.
+	mustHaveContent(t, src, srcContent)
+	mustNotExist(t, dst)
+}
+
+// restoreMoveSeams resets the test-only indirection hooks back to the real
+// production functions.
+func restoreMoveSeams() {
+	moveFileRename = os.Rename
+	moveFileCopy = copyFileCtx
+}

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -587,6 +587,16 @@ func copyFile(src, dst string) error {
 	return copyFileCtx(context.Background(), src, dst)
 }
 
+// moveFileRename and moveFileCopy are indirection seams over os.Rename and
+// copyFileCtx so tests can exercise MoveFileCtx's cross-filesystem fallback
+// without an actual second filesystem (and inject a short copy to verify the
+// size-mismatch data-safety branch). Production always uses the real
+// functions; tests override these in-process and restore them.
+var (
+	moveFileRename = os.Rename
+	moveFileCopy   = copyFileCtx
+)
+
 // MoveFileCtx is like MoveFile but returns ctx.Err() if the context is
 // cancelled during the cross-filesystem copy phase.
 func MoveFileCtx(ctx context.Context, src, dst string) error {
@@ -594,11 +604,11 @@ func MoveFileCtx(ctx context.Context, src, dst string) error {
 		return fmt.Errorf("create dir: %w", err)
 	}
 
-	if err := os.Rename(src, dst); err == nil {
+	if err := moveFileRename(src, dst); err == nil {
 		return nil
 	}
 
-	if err := copyFileCtx(ctx, src, dst); err != nil {
+	if err := moveFileCopy(ctx, src, dst); err != nil {
 		return fmt.Errorf("copy file: %w", err)
 	}
 


### PR DESCRIPTION
## What

Adds tests for `MoveFileCtx` in `internal/importer/renamer.go`, which had **0% coverage**. `MoveFileCtx` tries `os.Rename` first and, on a cross-filesystem error (`EXDEV`), falls back to copy → verify size → delete source. None of the fallback branches were exercised.

## Why this matters (data-loss risk)

The cross-filesystem fallback removes the source file **only after** the copy is verified by size. The single most dangerous failure mode is: the copy lands a truncated/partial `dst`, verification is skipped or wrong, and the code deletes the original source anyway — destroying a still-seeding/original file that can no longer be re-imported. The verify-mismatch branch (`src.Size() != dst.Size()` → remove `dst`, **keep `src`**) is the guard that prevents this, and it was completely untested.

## Tests added (`internal/importer/movefile_test.go`)

- `TestMoveFileCtx_Rename` — same-fs fast path: dst has the right content, src is gone.
- `TestMoveFileCtx_CrossDeviceCopyFallback` — forces `EXDEV`, asserts the copy+verify+delete slow path copies correctly and removes the source.
- `TestMoveFileCtx_VerifyMismatchKeepsSource` — injects a short/wrong-size copy; asserts `MoveFileCtx` errors, removes the bad `dst`, and **leaves the source intact**. This is the data-safety invariant.
- `TestMoveFileCtx_ContextCancelKeepsSource` — cancelled ctx during the fallback; asserts the error is surfaced and the source is preserved.

## Test-only seam

There is no way to force `os.Rename` to return `EXDEV` within a single `t.TempDir()` (no second filesystem in CI). I added a minimal seam: two unexported func vars in `renamer.go`,

```go
var (
    moveFileRename = os.Rename
    moveFileCopy   = copyFileCtx
)
```

`MoveFileCtx` now calls `moveFileRename`/`moveFileCopy` instead of `os.Rename`/`copyFileCtx` directly. The defaults are the real functions, so **production behavior is identical**; tests override them in-process and restore them via `defer`.

## Verification

`go test ./internal/importer/ -run 'Move' -v` and the full `go test ./internal/importer/` are green. `go vet` and `go build ./...` clean. MoveFileCtx coverage went from 0% to 81.2% (remaining gap is `MkdirAll`/`os.Stat` fault paths that need filesystem fault injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)