### PR TITLE
test(clients): context-cancel + malformed-body error paths for metadata/download clients

### DIFF
--- a/internal/downloader/nzbget/client_test.go
+++ b/internal/downloader/nzbget/client_test.go
@@ -419,6 +419,52 @@ func TestGetQueue(t *testing.T) {
 	}
 }
 
+// TestGetQueue_MalformedBody verifies that a 200 carrying invalid JSON on the
+// listgroups RPC surfaces a decode error rather than panicking or silently
+// returning an empty queue. NZBGet's response is untrusted upstream input.
+func TestGetQueue_MalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Truncated JSON object — the decoder must reject this.
+		_, _ = io.WriteString(w, `{"result": `)
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", "", false)
+
+	groups, err := c.GetQueue(context.Background())
+	if err == nil {
+		t.Fatal("expected decode error on malformed JSON body, got nil")
+	}
+	if groups != nil {
+		t.Errorf("expected nil groups on decode error, got %v", groups)
+	}
+}
+
+// TestListCategories_MalformedBody verifies the config RPC path also surfaces a
+// decode error on a malformed 200 body rather than returning an empty category
+// set as if the call succeeded — that would let a category-mismatch preflight
+// pass on garbage.
+func TestListCategories_MalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{not json`)
+	}))
+	defer srv.Close()
+
+	host, port := serverHostPort(t, srv.URL)
+	c := New(host, port, "", "", "", false)
+
+	cats, err := c.ListCategories(context.Background())
+	if err == nil {
+		t.Fatal("expected decode error on malformed JSON body, got nil")
+	}
+	if cats != nil {
+		t.Errorf("expected nil categories on decode error, got %v", cats)
+	}
+}
+
 // TestGetHistory verifies that GetHistory returns success and failure items.
 func TestGetHistory(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/downloader/sabnzbd/client_test.go
+++ b/internal/downloader/sabnzbd/client_test.go
@@ -374,6 +374,47 @@ func TestGetCategories(t *testing.T) {
 	}
 }
 
+// TestGetCategories_MalformedBody verifies that a 200 carrying invalid JSON on
+// the get_cats call surfaces a decode error rather than panicking or silently
+// returning an empty category list. SAB's response is untrusted upstream input.
+func TestGetCategories_MalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Truncated JSON object — the decoder must reject this.
+		_, _ = io.WriteString(w, `{`)
+	}))
+	defer srv.Close()
+
+	c := New("127.0.0.1", 0, "testkey", "", false)
+	c.baseURL = srv.URL
+
+	cats, err := c.GetCategories(context.Background())
+	if err == nil {
+		t.Fatal("expected decode error on malformed JSON body, got nil")
+	}
+	if cats != nil {
+		t.Errorf("expected nil categories on decode error, got %v", cats)
+	}
+}
+
+// TestGetQueue_MalformedBody verifies the queue poll path also surfaces a
+// decode error on a malformed 200 body rather than returning a zero-value
+// QueueData as if the poll succeeded.
+func TestGetQueue_MalformedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"queue": `) // truncated mid-object
+	}))
+	defer srv.Close()
+
+	c := New("127.0.0.1", 0, "testkey", "", false)
+	c.baseURL = srv.URL
+
+	if _, err := c.GetQueue(context.Background()); err == nil {
+		t.Fatal("expected decode error on malformed queue body, got nil")
+	}
+}
+
 func TestDeleteHistory(t *testing.T) {
 	var gotMode, gotName, gotValue, gotDelFiles string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/metadata/audible/client_test.go
+++ b/internal/metadata/audible/client_test.go
@@ -2,6 +2,7 @@ package audible
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -136,6 +137,63 @@ func TestSearchBooksByAuthor_HTTPError(t *testing.T) {
 	_, err := c.SearchBooksByAuthor(context.Background(), "Somebody")
 	if err == nil {
 		t.Fatal("expected error on HTTP 503")
+	}
+}
+
+// TestSearchBooksByAuthor_MalformedBody verifies that a 200 carrying invalid
+// JSON surfaces a decode error rather than panicking or silently returning an
+// empty result set. The catalogue response is untrusted upstream input, so a
+// truncated/garbage body must fail loudly.
+func TestSearchBooksByAuthor_MalformedBody(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1.0/catalog/products", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Truncated JSON object — a decoder must reject this.
+		_, _ = w.Write([]byte(`{`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New()
+	c.baseURL = srv.URL
+
+	books, err := c.SearchBooksByAuthor(context.Background(), "Somebody")
+	if err == nil {
+		t.Fatal("expected decode error on malformed JSON body, got nil")
+	}
+	if books != nil {
+		t.Errorf("expected nil books on decode error, got %v", books)
+	}
+}
+
+// TestSearchBooksByAuthor_ContextCanceled verifies that an already-cancelled
+// context makes the call return promptly with a context error instead of
+// hanging or returning a nil error. No metadata client had a context-cancel
+// test before this.
+func TestSearchBooksByAuthor_ContextCanceled(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/1.0/catalog/products", func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("server must not be reached when the context is already cancelled")
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New()
+	c.baseURL = srv.URL
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the call
+
+	books, err := c.SearchBooksByAuthor(ctx, "Somebody")
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if books != nil {
+		t.Errorf("expected nil books on cancellation, got %v", books)
 	}
 }
 

--- a/internal/metadata/audnex/client_test.go
+++ b/internal/metadata/audnex/client_test.go
@@ -2,6 +2,7 @@ package audnex
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -63,5 +64,60 @@ func TestGetBook404(t *testing.T) {
 	}
 	if b != nil {
 		t.Errorf("expected nil on 404, got %+v", b)
+	}
+}
+
+// TestGetBook_MalformedBody verifies that a 200 carrying invalid JSON surfaces
+// a decode error rather than panicking or silently returning an empty Book.
+// audnex parses an untrusted upstream response, so a truncated/garbage body
+// must fail loudly.
+func TestGetBook_MalformedBody(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/books/B0BAD", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Truncated JSON object — a decoder must reject this.
+		w.Write([]byte(`{`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New("us")
+	c.baseURL = srv.URL
+
+	b, err := c.GetBook(context.Background(), "B0BAD")
+	if err == nil {
+		t.Fatal("expected decode error on malformed JSON body, got nil")
+	}
+	if b != nil {
+		t.Errorf("expected nil book on decode error, got %+v", b)
+	}
+}
+
+// TestGetBook_ContextCanceled verifies that an already-cancelled context makes
+// GetBook return promptly with a context error instead of hanging or returning
+// a nil error. No metadata client had a context-cancel test before this.
+func TestGetBook_ContextCanceled(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/books/B0036S4B2G", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server must not be reached when the context is already cancelled")
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New("us")
+	c.baseURL = srv.URL
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the call
+
+	b, err := c.GetBook(ctx, "B0036S4B2G")
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if b != nil {
+		t.Errorf("expected nil book on cancellation, got %+v", b)
 	}
 }

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -551,6 +551,59 @@ func TestGetBook_HTTP_Error(t *testing.T) {
 	}
 }
 
+// ctxAwareTransport is a RoundTripper that honors request-context cancellation
+// the way a real network transport does: if the context is already done it
+// returns its error without "dialing", otherwise it serves a fixed body. Used
+// to exercise the context-cancel path deterministically (the path-routing test
+// transport ignores the context).
+type ctxAwareTransport struct {
+	t       *testing.T
+	dialled *bool
+}
+
+func (tr *ctxAwareTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if err := r.Context().Err(); err != nil {
+		return nil, err
+	}
+	if tr.dialled != nil {
+		*tr.dialled = true
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// TestGetBook_HTTP_ContextCanceled verifies that an already-cancelled context
+// makes GetBook return promptly with an error instead of hanging or returning
+// a nil error, and that the transport is never reached.
+//
+// Note: getJSON rebuilds transport errors via errors.New(RedactSecrets(...)),
+// which flattens the error chain — so errors.Is(err, context.Canceled) does
+// NOT hold here and we assert on the message instead.
+func TestGetBook_HTTP_ContextCanceled(t *testing.T) {
+	var dialled bool
+	c := &Client{http: &http.Client{Transport: &ctxAwareTransport{t: t, dialled: &dialled}}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the call
+
+	book, err := c.GetBook(ctx, "OL456W")
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("expected error to mention context cancellation, got %v", err)
+	}
+	if book != nil {
+		t.Errorf("expected nil book on cancellation, got %+v", book)
+	}
+	if dialled {
+		t.Error("transport must not be reached when the context is already cancelled")
+	}
+}
+
 func TestGetBook_HTTP_CoverImage(t *testing.T) {
 	workResp := workResponse{
 		Key:    "/works/OL777W",


### PR DESCRIPTION
## What

Adds missing error-path tests for external clients that parse untrusted upstream responses. Tests only — no production changes.

A coverage review surfaced two gaps:

- **No metadata client had a context-cancel/timeout test.** A cancelled/expired context must abort the call promptly with a context error rather than hang or report a nil error.
- **audnex, audible, sabnzbd, nzbget lacked malformed-response-body tests.** A 200 carrying invalid JSON must surface a decode error, not panic and not silently return an empty success.

These clients all decode responses from external services (api.audnex.us, api.audible.com, SABnzbd, NZBGet) — i.e. untrusted input — so these failure modes matter.

## Tests added

Context-cancel (already-cancelled context, tripwire server/transport asserts it is never reached):
- `internal/metadata/audnex`: `TestGetBook_ContextCanceled`
- `internal/metadata/audible`: `TestSearchBooksByAuthor_ContextCanceled`
- `internal/metadata/openlibrary`: `TestGetBook_HTTP_ContextCanceled`

Malformed body (200 + invalid JSON → decode error, nil result):
- `internal/metadata/audnex`: `TestGetBook_MalformedBody`
- `internal/metadata/audible`: `TestSearchBooksByAuthor_MalformedBody`
- `internal/downloader/sabnzbd`: `TestGetCategories_MalformedBody`, `TestGetQueue_MalformedBody`
- `internal/downloader/nzbget`: `TestGetQueue_MalformedBody`, `TestListCategories_MalformedBody`

Each test matches its package's existing harness (httptest + context; openlibrary uses a context-aware `http.RoundTripper` since its `baseURL` is a package const that can't be redirected to httptest).

## Note

`openlibrary.getJSON` rebuilds transport errors via `errors.New(httpsec.RedactSecrets(err.Error()))`, which flattens the error chain — so `errors.Is(err, context.Canceled)` does not hold there. The openlibrary test asserts on the error message accordingly; audnex/audible preserve the chain and assert with `errors.Is`.

## Verification

```
ok  github.com/vavallee/bindery/internal/metadata/audnex
ok  github.com/vavallee/bindery/internal/metadata/audible
ok  github.com/vavallee/bindery/internal/metadata/openlibrary
ok  github.com/vavallee/bindery/internal/downloader/sabnzbd
ok  github.com/vavallee/bindery/internal/downloader/nzbget
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
