### PR TITLE
test(api): cover prowlarr and grimmory handlers

### DIFF
--- a/internal/api/grimmory_test.go
+++ b/internal/api/grimmory_test.go
@@ -1,0 +1,233 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+)
+
+func grimmoryFixture(t *testing.T) (*GrimmoryHandler, *db.SettingsRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	settings := db.NewSettingsRepo(database)
+	return NewGrimmoryHandler(settings), settings
+}
+
+// TestGrimmoryConfigRoundTrip exercises SetConfig -> GetConfig and asserts the
+// values actually persist to the settings repo (api key is stored but only the
+// "configured" boolean is returned).
+func TestGrimmoryConfigRoundTrip(t *testing.T) {
+	h, settings := grimmoryFixture(t)
+	ctx := context.Background()
+
+	// Initially empty.
+	rec := httptest.NewRecorder()
+	h.GetConfig(rec, httptest.NewRequest(http.MethodGet, "/grimmory/config", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d", rec.Code)
+	}
+	var cfg GrimmoryConfigResponse
+	json.NewDecoder(rec.Body).Decode(&cfg)
+	if cfg.Enabled || cfg.BaseURL != "" || cfg.APIKeyConfigured {
+		t.Fatalf("expected empty config, got %+v", cfg)
+	}
+
+	// Save a full config. Use an RFC1918 literal so the SSRF LAN policy passes.
+	body := `{"enabled":true,"baseUrl":"http://10.20.30.40:8080/","apiKey":"  topsecret  "}`
+	rec = httptest.NewRecorder()
+	h.SetConfig(rec, httptest.NewRequest(http.MethodPost, "/grimmory/config", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("set: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	json.NewDecoder(rec.Body).Decode(&cfg)
+	if !cfg.Enabled {
+		t.Errorf("enabled not echoed back")
+	}
+	// NormalizeBaseURL strips the trailing slash.
+	if cfg.BaseURL != "http://10.20.30.40:8080" {
+		t.Errorf("baseUrl = %q, want normalized http://10.20.30.40:8080", cfg.BaseURL)
+	}
+	if !cfg.APIKeyConfigured {
+		t.Errorf("apiKeyConfigured should be true after saving a key")
+	}
+
+	// Verify persistence directly in the settings table.
+	stored := LoadGrimmoryConfig(settings)
+	if !stored.Enabled {
+		t.Errorf("enabled not persisted")
+	}
+	if stored.BaseURL != "http://10.20.30.40:8080" {
+		t.Errorf("baseUrl not persisted: %q", stored.BaseURL)
+	}
+	// NormalizeAPIKey trims surrounding whitespace.
+	if stored.APIKey != "topsecret" {
+		t.Errorf("apiKey not persisted/trimmed: %q", stored.APIKey)
+	}
+
+	// GetConfig must redact the key (only the boolean is exposed).
+	rec = httptest.NewRecorder()
+	h.GetConfig(rec, httptest.NewRequest(http.MethodGet, "/grimmory/config", nil))
+	rawBody := rec.Body.String()
+	if contains := bytes.Contains([]byte(rawBody), []byte("topsecret")); contains {
+		t.Errorf("GetConfig leaked the api key: %s", rawBody)
+	}
+
+	_ = ctx
+}
+
+// TestGrimmorySetConfig_Partial confirms a partial update only touches the
+// supplied fields and leaves the rest intact.
+func TestGrimmorySetConfig_Partial(t *testing.T) {
+	h, settings := grimmoryFixture(t)
+	ctx := context.Background()
+	if err := settings.Set(ctx, SettingGrimmoryBaseURL, "http://10.0.0.1:8080"); err != nil {
+		t.Fatal(err)
+	}
+	if err := settings.Set(ctx, SettingGrimmoryEnabled, "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only toggle enabled off; baseUrl must survive.
+	body := `{"enabled":false}`
+	rec := httptest.NewRecorder()
+	h.SetConfig(rec, httptest.NewRequest(http.MethodPost, "/grimmory/config", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	stored := LoadGrimmoryConfig(settings)
+	if stored.Enabled {
+		t.Errorf("enabled should be false")
+	}
+	if stored.BaseURL != "http://10.0.0.1:8080" {
+		t.Errorf("baseUrl should be untouched, got %q", stored.BaseURL)
+	}
+}
+
+func TestGrimmorySetConfig_BadJSON(t *testing.T) {
+	h, _ := grimmoryFixture(t)
+	rec := httptest.NewRecorder()
+	h.SetConfig(rec, httptest.NewRequest(http.MethodPost, "/grimmory/config", bytes.NewBufferString(`not-json`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestGrimmorySetConfig_InvalidBaseURL(t *testing.T) {
+	h, _ := grimmoryFixture(t)
+	// ftp scheme is rejected by ValidateBaseURLSecure.
+	rec := httptest.NewRecorder()
+	h.SetConfig(rec, httptest.NewRequest(http.MethodPost, "/grimmory/config", bytes.NewBufferString(`{"baseUrl":"ftp://example.com"}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid base url, got %d", rec.Code)
+	}
+}
+
+// TestGrimmoryTest_Success points the handler at a fake Grimmory /api/status
+// endpoint and asserts the version is reported.
+func TestGrimmoryTest_Success(t *testing.T) {
+	h, _ := grimmoryFixture(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/status" {
+			_, _ = w.Write([]byte(`{"status":"ok","version":"3.4.1"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	// Override credentials in the request body (loopback URL via NormalizeBaseURL).
+	body := `{"baseUrl":"` + srv.URL + `","apiKey":"k"}`
+	rec := httptest.NewRecorder()
+	h.Test(rec, httptest.NewRequest(http.MethodPost, "/grimmory/test", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out grimmoryTestResponse
+	json.NewDecoder(rec.Body).Decode(&out)
+	if !out.OK {
+		t.Errorf("expected ok=true, got %+v", out)
+	}
+	if out.Version != "3.4.1" {
+		t.Errorf("version not surfaced: %+v", out)
+	}
+}
+
+// TestGrimmoryTest_UpstreamFailure asserts a 5xx from Grimmory yields a 502 with
+// ok=false.
+func TestGrimmoryTest_UpstreamFailure(t *testing.T) {
+	h, _ := grimmoryFixture(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	body := `{"baseUrl":"` + srv.URL + `"}`
+	rec := httptest.NewRecorder()
+	h.Test(rec, httptest.NewRequest(http.MethodPost, "/grimmory/test", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out grimmoryTestResponse
+	json.NewDecoder(rec.Body).Decode(&out)
+	if out.OK {
+		t.Errorf("expected ok=false on upstream failure, got %+v", out)
+	}
+	if out.Message == "" {
+		t.Errorf("expected a non-empty failure message")
+	}
+}
+
+// TestGrimmoryTest_InvalidBaseURL: a base url that fails client construction
+// (empty / bad scheme) yields a 400 before any network call.
+func TestGrimmoryTest_InvalidBaseURL(t *testing.T) {
+	h, _ := grimmoryFixture(t)
+	// No stored config and no override -> empty base url -> NewClient errors.
+	rec := httptest.NewRecorder()
+	h.Test(rec, httptest.NewRequest(http.MethodPost, "/grimmory/test", bytes.NewBufferString(`{}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty base url, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out grimmoryTestResponse
+	json.NewDecoder(rec.Body).Decode(&out)
+	if out.OK {
+		t.Errorf("expected ok=false, got %+v", out)
+	}
+}
+
+// TestGrimmoryTest_UsesStoredConfig confirms Test falls back to the persisted
+// base url when the request body omits it.
+func TestGrimmoryTest_UsesStoredConfig(t *testing.T) {
+	h, settings := grimmoryFixture(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/status" {
+			_, _ = w.Write([]byte(`{"status":"ok","version":"9.9.9"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := settings.Set(context.Background(), SettingGrimmoryBaseURL, srv.URL); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Test(rec, httptest.NewRequest(http.MethodPost, "/grimmory/test", bytes.NewBufferString(`{}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 using stored config, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out grimmoryTestResponse
+	json.NewDecoder(rec.Body).Decode(&out)
+	if !out.OK || out.Version != "9.9.9" {
+		t.Errorf("stored-config probe wrong: %+v", out)
+	}
+}

--- a/internal/api/prowlarr_test.go
+++ b/internal/api/prowlarr_test.go
@@ -1,0 +1,446 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func prowlarrFixture(t *testing.T) (*ProwlarrHandler, *db.ProwlarrRepo, *db.IndexerRepo, *db.SettingsRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	instances := db.NewProwlarrRepo(database)
+	indexers := db.NewIndexerRepo(database)
+	settings := db.NewSettingsRepo(database)
+	h := NewProwlarrHandler(instances, indexers).WithSettings(settings)
+	return h, instances, indexers, settings
+}
+
+func TestProwlarrList_Empty(t *testing.T) {
+	h, _, _, _ := prowlarrFixture(t)
+	rec := httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/prowlarr", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	// Must be a JSON array, never null.
+	if got := rec.Body.String(); got != "[]\n" && got != "[]" {
+		t.Errorf("empty list body = %q, want []", got)
+	}
+}
+
+// TestProwlarrCRUD exercises the full Create -> Get/List -> Update -> Delete
+// round-trip against an in-memory DB, asserting that fields actually persist
+// and that the row is gone after Delete (not just that status codes are right).
+func TestProwlarrCRUD(t *testing.T) {
+	h, instances, _, _ := prowlarrFixture(t)
+	ctx := context.Background()
+
+	// Create. Use an RFC1918 literal so the SSRF LAN policy accepts it.
+	body := `{"name":"Main","url":"http://10.10.10.10:9696","apiKey":"secret","syncOnStartup":true,"enabled":true}`
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/prowlarr", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created models.ProwlarrInstance
+	if err := json.NewDecoder(rec.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+	if created.ID == 0 {
+		t.Fatal("expected non-zero ID after create")
+	}
+
+	// Persistence check via the repo.
+	stored, err := instances.GetByID(ctx, created.ID)
+	if err != nil || stored == nil {
+		t.Fatalf("stored row missing: %v", err)
+	}
+	if stored.Name != "Main" || stored.URL != "http://10.10.10.10:9696" || stored.APIKey != "secret" {
+		t.Fatalf("persisted fields wrong: %+v", stored)
+	}
+	if !stored.SyncOnStartup || !stored.Enabled {
+		t.Errorf("flags not persisted: syncOnStartup=%v enabled=%v", stored.SyncOnStartup, stored.Enabled)
+	}
+
+	// Get returns the row including the APIKey (handler logic; admin-gated at router).
+	idStr := strconv.FormatInt(created.ID, 10)
+	rec = httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/prowlarr/"+idStr, nil), "id", idStr))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get: expected 200, got %d", rec.Code)
+	}
+	var got models.ProwlarrInstance
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.APIKey != "secret" {
+		t.Errorf("Get should surface APIKey at the handler level, got %q", got.APIKey)
+	}
+
+	// List has exactly the one entry.
+	rec = httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/prowlarr", nil))
+	var list []models.ProwlarrInstance
+	if err := json.NewDecoder(rec.Body).Decode(&list); err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(list))
+	}
+
+	// Update — change name + apiKey + url.
+	update := `{"name":"Renamed","url":"http://10.10.10.11:9696","apiKey":"newsecret","syncOnStartup":false,"enabled":false}`
+	rec = httptest.NewRecorder()
+	h.Update(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/prowlarr/"+idStr, bytes.NewBufferString(update)), "id", idStr))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	stored, _ = instances.GetByID(ctx, created.ID)
+	if stored == nil {
+		t.Fatal("row vanished after update")
+	}
+	if stored.Name != "Renamed" || stored.URL != "http://10.10.10.11:9696" || stored.APIKey != "newsecret" {
+		t.Fatalf("update did not persist: %+v", stored)
+	}
+	if stored.SyncOnStartup || stored.Enabled {
+		t.Errorf("update should have cleared flags: %+v", stored)
+	}
+
+	// Delete — row gone afterward.
+	rec = httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/prowlarr/"+idStr, nil), "id", idStr))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete: expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	stored, _ = instances.GetByID(ctx, created.ID)
+	if stored != nil {
+		t.Errorf("expected row gone after delete, still present: %+v", stored)
+	}
+}
+
+// TestProwlarrUpdate_PropagatesAPIKeyToIndexers verifies the side effect in
+// Update: when the instance APIKey changes, synced indexer rows have their
+// api_key column rewritten.
+func TestProwlarrUpdate_PropagatesAPIKeyToIndexers(t *testing.T) {
+	h, instances, indexers, _ := prowlarrFixture(t)
+	ctx := context.Background()
+
+	inst := &models.ProwlarrInstance{Name: "P", URL: "http://10.0.0.5:9696", APIKey: "old", Enabled: true}
+	if err := instances.Create(ctx, inst); err != nil {
+		t.Fatal(err)
+	}
+	idx := &models.Indexer{
+		Name:               "From Prowlarr",
+		Type:               "torznab",
+		URL:                "http://10.0.0.5:9696/1/api",
+		APIKey:             "old",
+		Enabled:            true,
+		ProwlarrInstanceID: &inst.ID,
+	}
+	if err := indexers.Create(ctx, idx); err != nil {
+		t.Fatal(err)
+	}
+
+	idStr := strconv.FormatInt(inst.ID, 10)
+	update := `{"name":"P","url":"http://10.0.0.5:9696","apiKey":"rotated","enabled":true}`
+	rec := httptest.NewRecorder()
+	h.Update(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/prowlarr/"+idStr, bytes.NewBufferString(update)), "id", idStr))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("update: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rows, err := indexers.ListByProwlarrInstance(ctx, inst.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 synced indexer, got %d", len(rows))
+	}
+	if rows[0].APIKey != "rotated" {
+		t.Errorf("indexer api_key not propagated: got %q, want rotated", rows[0].APIKey)
+	}
+}
+
+// TestProwlarrDelete_RemovesSyncedIndexers verifies Delete first removes the
+// synced indexers (FK constraint) and then the instance.
+func TestProwlarrDelete_RemovesSyncedIndexers(t *testing.T) {
+	h, instances, indexers, _ := prowlarrFixture(t)
+	ctx := context.Background()
+
+	inst := &models.ProwlarrInstance{Name: "P", URL: "http://10.0.0.5:9696", APIKey: "k", Enabled: true}
+	if err := instances.Create(ctx, inst); err != nil {
+		t.Fatal(err)
+	}
+	idx := &models.Indexer{
+		Name: "From Prowlarr", Type: "torznab", URL: "http://10.0.0.5:9696/1/api",
+		APIKey: "k", Enabled: true, ProwlarrInstanceID: &inst.ID,
+	}
+	if err := indexers.Create(ctx, idx); err != nil {
+		t.Fatal(err)
+	}
+
+	idStr := strconv.FormatInt(inst.ID, 10)
+	rec := httptest.NewRecorder()
+	h.Delete(rec, withURLParam(httptest.NewRequest(http.MethodDelete, "/prowlarr/"+idStr, nil), "id", idStr))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete: expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rows, _ := indexers.ListByProwlarrInstance(ctx, inst.ID)
+	if len(rows) != 0 {
+		t.Errorf("expected synced indexers removed, got %d", len(rows))
+	}
+	if stored, _ := instances.GetByID(ctx, inst.ID); stored != nil {
+		t.Errorf("instance not deleted")
+	}
+}
+
+func TestProwlarrCreate_Validation(t *testing.T) {
+	h, _, _, _ := prowlarrFixture(t)
+	for name, body := range map[string]string{
+		"missing url": `{"name":"x"}`,
+		"bad json":    `not-json`,
+	} {
+		rec := httptest.NewRecorder()
+		h.Create(rec, httptest.NewRequest(http.MethodPost, "/prowlarr", bytes.NewBufferString(body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d", name, rec.Code)
+		}
+	}
+}
+
+func TestProwlarrCreate_DefaultName(t *testing.T) {
+	h, instances, _, _ := prowlarrFixture(t)
+	body := `{"url":"http://10.10.10.10:9696","apiKey":"k"}`
+	rec := httptest.NewRecorder()
+	h.Create(rec, httptest.NewRequest(http.MethodPost, "/prowlarr", bytes.NewBufferString(body)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created models.ProwlarrInstance
+	json.NewDecoder(rec.Body).Decode(&created)
+	stored, _ := instances.GetByID(context.Background(), created.ID)
+	if stored == nil || stored.Name != "Prowlarr" {
+		t.Errorf("default name not applied: %+v", stored)
+	}
+}
+
+func TestProwlarrGet_NotFound(t *testing.T) {
+	h, _, _, _ := prowlarrFixture(t)
+	rec := httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/prowlarr/999", nil), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestProwlarrGet_InvalidID(t *testing.T) {
+	h, _, _, _ := prowlarrFixture(t)
+	rec := httptest.NewRecorder()
+	h.Get(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/prowlarr/abc", nil), "id", "abc"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestProwlarrUpdate_NotFound(t *testing.T) {
+	h, _, _, _ := prowlarrFixture(t)
+	rec := httptest.NewRecorder()
+	body := bytes.NewBufferString(`{"url":"http://10.0.0.1:9696"}`)
+	h.Update(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/prowlarr/999", body), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// newProwlarrStub returns an httptest server impersonating a Prowlarr instance.
+// /api/v1/system/status returns the system status (used by Test); /api/v1/indexer
+// returns the indexer list (used by Sync).
+func newProwlarrStub(t *testing.T, version string, indexers string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/system/status":
+			_, _ = w.Write([]byte(`{"version":"` + version + `"}`))
+		case "/api/v1/indexer":
+			_, _ = w.Write([]byte(indexers))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestProwlarrTest_Success points the handler's upstream client at a fake
+// Prowlarr and asserts the version is surfaced.
+func TestProwlarrTest_Success(t *testing.T) {
+	h, instances, _, _ := prowlarrFixture(t)
+	srv := newProwlarrStub(t, "1.21.2.4649", "[]")
+
+	inst := &models.ProwlarrInstance{Name: "P", URL: srv.URL, APIKey: "k", Enabled: true}
+	if err := instances.Create(context.Background(), inst); err != nil {
+		t.Fatal(err)
+	}
+
+	idStr := strconv.FormatInt(inst.ID, 10)
+	rec := httptest.NewRecorder()
+	h.Test(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/prowlarr/"+idStr+"/test", nil), "id", idStr))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out map[string]string
+	json.NewDecoder(rec.Body).Decode(&out)
+	if out["ok"] != "true" {
+		t.Errorf("expected ok=true, got %v", out)
+	}
+	if out["version"] != "1.21.2.4649" {
+		t.Errorf("version not surfaced: %v", out)
+	}
+}
+
+// TestProwlarrTest_UpstreamError points the client at a server returning 500 and
+// asserts the handler surfaces ok=false with an error (still HTTP 200 body).
+func TestProwlarrTest_UpstreamError(t *testing.T) {
+	h, instances, _, _ := prowlarrFixture(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	inst := &models.ProwlarrInstance{Name: "P", URL: srv.URL, APIKey: "k", Enabled: true}
+	if err := instances.Create(context.Background(), inst); err != nil {
+		t.Fatal(err)
+	}
+
+	idStr := strconv.FormatInt(inst.ID, 10)
+	rec := httptest.NewRecorder()
+	h.Test(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/prowlarr/"+idStr+"/test", nil), "id", idStr))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 envelope, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out map[string]string
+	json.NewDecoder(rec.Body).Decode(&out)
+	if out["ok"] != "false" {
+		t.Errorf("expected ok=false on upstream error, got %v", out)
+	}
+	if out["error"] == "" {
+		t.Errorf("expected a non-empty error message, got %v", out)
+	}
+}
+
+func TestProwlarrTest_NotFound(t *testing.T) {
+	h, _, _, _ := prowlarrFixture(t)
+	rec := httptest.NewRecorder()
+	h.Test(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/prowlarr/999/test", nil), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// TestProwlarrSync_Success drives Sync against a fake Prowlarr that advertises
+// one searchable, book-categorised torrent indexer and asserts it is created
+// in Bindery's indexer table (added=1).
+func TestProwlarrSync_Success(t *testing.T) {
+	h, instances, indexers, _ := prowlarrFixture(t)
+	ctx := context.Background()
+
+	const indexerJSON = `[{
+		"id": 5,
+		"name": "MyTorrentSite",
+		"enable": true,
+		"protocol": "torrent",
+		"supportsSearch": true,
+		"categories": [{"id": 7020, "name": "Ebooks"}]
+	}]`
+	srv := newProwlarrStub(t, "1.21.2", indexerJSON)
+
+	inst := &models.ProwlarrInstance{Name: "P", URL: srv.URL, APIKey: "k", Enabled: true}
+	if err := instances.Create(ctx, inst); err != nil {
+		t.Fatal(err)
+	}
+
+	idStr := strconv.FormatInt(inst.ID, 10)
+	rec := httptest.NewRecorder()
+	h.Sync(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/prowlarr/"+idStr+"/sync", nil), "id", idStr))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Added, Updated, Removed int
+	}
+	json.NewDecoder(rec.Body).Decode(&out)
+	if out.Added != 1 {
+		t.Errorf("expected added=1, got %+v", out)
+	}
+
+	rows, _ := indexers.ListByProwlarrInstance(ctx, inst.ID)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 indexer synced into DB, got %d", len(rows))
+	}
+	if rows[0].Name != "MyTorrentSite" || rows[0].Type != "torznab" {
+		t.Errorf("synced indexer wrong: %+v", rows[0])
+	}
+}
+
+// TestProwlarrSync_UpstreamError asserts Sync surfaces a 502 when the upstream
+// Prowlarr fails.
+func TestProwlarrSync_UpstreamError(t *testing.T) {
+	h, instances, _, _ := prowlarrFixture(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	inst := &models.ProwlarrInstance{Name: "P", URL: srv.URL, APIKey: "k", Enabled: true}
+	if err := instances.Create(context.Background(), inst); err != nil {
+		t.Fatal(err)
+	}
+
+	idStr := strconv.FormatInt(inst.ID, 10)
+	rec := httptest.NewRecorder()
+	h.Sync(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/prowlarr/"+idStr+"/sync", nil), "id", idStr))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 on upstream error, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProwlarrSync_NotFound(t *testing.T) {
+	h, _, _, _ := prowlarrFixture(t)
+	rec := httptest.NewRecorder()
+	h.Sync(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/prowlarr/999/sync", nil), "id", "999"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+// TestProwlarrClientTimeout_FromSettings confirms the configurable
+// prowlarr.search_timeout_seconds setting overrides the 60s default.
+func TestProwlarrClientTimeout_FromSettings(t *testing.T) {
+	h, _, _, settings := prowlarrFixture(t)
+	ctx := context.Background()
+	if got := h.prowlarrClientTimeout(ctx); got.Seconds() != 60 {
+		t.Errorf("default timeout = %v, want 60s", got)
+	}
+	if err := settings.Set(ctx, SettingProwlarrSearchTimeoutSeconds, "5"); err != nil {
+		t.Fatal(err)
+	}
+	if got := h.prowlarrClientTimeout(ctx); got.Seconds() != 5 {
+		t.Errorf("configured timeout = %v, want 5s", got)
+	}
+	if got := LoadProwlarrTimeout(ctx, settings); got.Seconds() != 5 {
+		t.Errorf("LoadProwlarrTimeout = %v, want 5s", got)
+	}
+}


### PR DESCRIPTION
## What

Adds Go tests (no production changes) for the two `internal/api` handlers that had **no test file** (0% coverage): `prowlarr.go` and `grimmory.go`.

## Tests added

**prowlarr_test.go**
- Full **Create → Get/List → Update → Delete** round-trip on an in-memory DB, asserting fields actually persist (name/url/apiKey/flags) and that the row is *gone* after delete — effect assertions, not just status codes.
- `Update` side effect: rotating the instance APIKey rewrites the `api_key` column of synced indexer rows.
- `Delete` cascade: synced indexers are removed before the instance (FK constraint).
- Validation / not-found / invalid-id / default-name paths.
- `Test` and `Sync` pointed at an `httptest` Prowlarr stub: success surfaces the version / `added=1` (verified in the indexer table), and an upstream 500 surfaces `ok=false` (Test) / HTTP 502 (Sync).
- Configurable `prowlarr.search_timeout_seconds` setting override.

**grimmory_test.go**
- `GetConfig`/`SetConfig` round-trip with persistence verified via the settings repo, plus api-key redaction in `GetConfig`.
- Partial update (only supplied fields change), bad-JSON and invalid-base-URL rejection.
- `Test` against an `httptest` Grimmory `/api/status` stub: success (version reported), upstream 5xx → 502, invalid base URL → 400, and stored-config fallback when the request omits the URL.

## Test output

`go test ./internal/api/ -run 'Prowlarr|Grimmory' -v` → 24 tests, all PASS. Full `go test ./internal/api/` is green; `go vet ./internal/api/` clean.

## Skipped / notes

- `List`/`Get` return the `APIKey` field; this is admin-gated at the router, so the handler-level test simply confirms the handler returns it (documented in a test comment).
- The Prowlarr API client and grimmory `Test`'s client factory don't apply the SSRF guard (only the `Create`/`SetConfig` admin-input boundary does), so the `httptest` loopback stubs work without `AllowLoopbackForTests`. RFC1918 literals are used where the Create/SetConfig SSRF validator runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)