### PR TITLE
fix(openlibrary): preserve error chain instead of flattening transport errors

### DIFF
--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -759,9 +759,14 @@ func (c *Client) getJSON(ctx context.Context, rawURL string, target interface{})
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		// Redact any secret query-param values a transport error's embedded
-		// request URL might carry before the error propagates (#1144).
-		return errors.New(httpsec.RedactSecrets(err.Error()))
+		// Wrap with %w so the error chain survives: callers (and tests) rely on
+		// errors.Is(err, context.Canceled)/context.DeadlineExceeded to classify
+		// cancellations and timeouts. OpenLibrary is a keyless API — every
+		// request URL is built from public path/query params (no key/token/auth),
+		// so the transport error's embedded URL carries no secret to redact.
+		// (#1144 added RedactSecrets here, but it matched nothing in OL URLs and
+		// only flattened the chain, breaking errors.Is classification.)
+		return fmt.Errorf("openlibrary request: %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/metadata/openlibrary/client_errchain_test.go
+++ b/internal/metadata/openlibrary/client_errchain_test.go
@@ -1,0 +1,64 @@
+package openlibrary
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// errRoundTripper returns a fixed error for every request, mimicking the way
+// http.Client.Do surfaces transport failures: wrapped in a *url.Error.
+type errRoundTripper struct{ err error }
+
+func (rt errRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return nil, &url.Error{Op: "Get", URL: r.URL.String(), Err: rt.err}
+}
+
+// TestGetJSONPreservesContextCanceled asserts that getJSON wraps transport
+// errors with %w so the chain survives. Previously getJSON flattened the error
+// via errors.New(RedactSecrets(err.Error())), which broke errors.Is and forced
+// callers to classify failures by matching on the message string.
+func TestGetJSONPreservesContextCanceled(t *testing.T) {
+	c := &Client{http: &http.Client{Transport: errRoundTripper{err: context.Canceled}}}
+
+	err := c.getJSON(context.Background(), "https://openlibrary.org/works/OL1W.json", new(struct{}))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("errors.Is(err, context.Canceled) = false; chain was flattened. err = %v", err)
+	}
+}
+
+// TestGetJSONPreservesDeadlineExceeded covers the timeout case the same way.
+func TestGetJSONPreservesDeadlineExceeded(t *testing.T) {
+	c := &Client{http: &http.Client{Transport: errRoundTripper{err: context.DeadlineExceeded}}}
+
+	err := c.getJSON(context.Background(), "https://openlibrary.org/works/OL1W.json", new(struct{}))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("errors.Is(err, context.DeadlineExceeded) = false; chain was flattened. err = %v", err)
+	}
+}
+
+// TestGetJSONRealCancelledContext exercises the end-to-end path with a context
+// that is already cancelled before the request is issued, so the cancellation
+// originates from the real transport rather than an injected error.
+func TestGetJSONRealCancelledContext(t *testing.T) {
+	c := New() // real proxy transport; the cancelled context short-circuits the dial
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := c.getJSON(ctx, "https://openlibrary.org/works/OL1W.json", new(struct{}))
+	if err == nil {
+		t.Fatal("expected an error for a pre-cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("errors.Is(err, context.Canceled) = false. err = %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`internal/metadata/openlibrary/client.go` `getJSON` wrapped transport errors as:

```go
return errors.New(httpsec.RedactSecrets(err.Error()))
```

`errors.New` over a stringified error **flattens the error chain**. After this, `errors.Is(err, context.Canceled)` and `errors.Is(err, context.DeadlineExceeded)` no longer held, so callers (and tests) could not classify cancellations/timeouts and were forced to assert on the message string instead of the typed sentinel.

## Why RedactSecrets was doing nothing here

OpenLibrary is a **keyless** API. Every request URL in this client is built from the `baseURL` constant plus public path/query params (`q`, `author_key`, `isbn`, subject slug, `limit`, `offset`). There is no `key`/`token`/`auth`/`api_key` parameter — the only contact info OL wants is in the `User-Agent` header, not the URL. `httpsec.RedactSecrets` matches exactly those secret query params, so it matched **nothing** on OpenLibrary URLs. Its sole effect at this site was flattening the chain.

(Contrast with sabnzbd, which does carry an `apikey` query param and uses `redactAPIURL` before wrapping — there redaction is real.)

## Fix

Since the URL carries no secret, replace the flatten with a normal `%w` wrap:

```go
return fmt.Errorf("openlibrary request: %w", err)
```

This keeps `errors.Is`/`errors.As` working. No redaction is needed because there is no secret to redact. (The HTTP-status path still uses `RedactSecrets` on the response body — unchanged.)

## Tests

Added `client_errchain_test.go`:
- `TestGetJSONPreservesContextCanceled` — injected `*url.Error{Err: context.Canceled}` → `errors.Is(err, context.Canceled)` holds.
- `TestGetJSONPreservesDeadlineExceeded` — same for `context.DeadlineExceeded`.
- `TestGetJSONRealCancelledContext` — pre-cancelled real context through the real transport.

All three FAIL against the old flattening code (chain broken, message doubled) and PASS with the fix. `go test ./internal/metadata/openlibrary/` and `go vet` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)