### PR TITLE
feat(telemetry): self-update advertised version from GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,36 +435,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Best-effort telemetry: advertise the new version to the in-app update
-  # check (bindery-ping). Split out of the goreleaser job: the telemetry
-  # cluster is regularly unreachable from the runner, and having this as a
-  # step inside goreleaser failed that whole job, which cascaded to skip
-  # deploy-prod and notify-discord (both gate on goreleaser success).
-  # It now runs as its own job that nothing depends on, with
-  # continue-on-error so a telemetry outage never reddens the release or
-  # blocks the prod deploy. Do NOT add this job to required status checks.
-  bump-latest-version:
-    name: Bump bindery-ping LATEST_VERSION
-    needs: goreleaser
-    if: startsWith(github.ref, 'refs/tags/v')
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-      - name: Bump bindery-ping LATEST_VERSION
-        continue-on-error: true
-        env:
-          KUBECONFIG_B64: ${{ secrets.HETZ1_KUBECONFIG }}
-          VERSION: ${{ github.ref_name }}
-        run: |
-          [ -z "$KUBECONFIG_B64" ] && exit 0
-          echo "$KUBECONFIG_B64" | base64 -d > /tmp/kc
-          KUBECONFIG=/tmp/kc kubectl -n bindery-ping set env deployment/bindery-ping \
-            LATEST_VERSION="$VERSION"
-          rm -f /tmp/kc
+  # NOTE: there is intentionally no "bump bindery-ping LATEST_VERSION" job here.
+  # That job pushed the new version into the telemetry cluster via
+  # `kubectl set env` from the runner, but the cluster API is not reachable from
+  # GitHub Actions, so it timed out and silently no-opped every release (masked
+  # by continue-on-error). bindery-ping now self-updates its advertised version
+  # by polling the GitHub Releases API from inside the cluster — see
+  # runLatestVersionLoop in cmd/telemetry-server/main.go.
 
   # Pinned ABS compatibility suite. Runs self-contained against the
   # repository's seeded Phase 6 fixture harness and can optionally target a

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -51,9 +52,99 @@ func isReleaseVersion(v string) bool {
 type server struct {
 	db            *sql.DB
 	dbDir         string // directory holding the DB, the writable data volume
-	latestVersion string
+	latestVersion atomic.Pointer[string]
 	statsToken    string
 	limiter       *rateLimiter
+}
+
+// latest returns the most recent published version the server advertises.
+// Backed by an atomic so the background poller (runLatestVersionLoop) can
+// update it while request handlers read it concurrently.
+func (s *server) latest() string {
+	if p := s.latestVersion.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// setLatest atomically replaces the advertised latest version.
+func (s *server) setLatest(v string) { s.latestVersion.Store(&v) }
+
+// latestVersionInterval is how often runLatestVersionLoop re-checks GitHub for
+// a newer release. A var so tests can shorten it. The unauthenticated GitHub
+// API allows 60 requests/hour per IP; 30 min (2/h) leaves ample headroom.
+var latestVersionInterval = 30 * time.Minute
+
+// githubAPIBase is the GitHub REST base URL; a var so tests can point it at a
+// local stub server.
+var githubAPIBase = "https://api.github.com"
+
+var latestVersionClient = &http.Client{Timeout: 15 * time.Second}
+
+// fetchLatestRelease returns the tag_name of the newest published (non-draft,
+// non-prerelease) release for repo ("owner/name"), e.g. "v1.22.1".
+func fetchLatestRelease(ctx context.Context, repo string) (string, error) {
+	url := githubAPIBase + "/repos/" + repo + "/releases/latest"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "bindery-telemetry-server (+https://github.com/vavallee/bindery)")
+	resp, err := latestVersionClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github releases/latest: status %d", resp.StatusCode)
+	}
+	var body struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+		return "", err
+	}
+	return body.TagName, nil
+}
+
+// runLatestVersionLoop keeps s.latest() in sync with the newest GitHub release
+// so a new release advertises itself without anyone pushing LATEST_VERSION into
+// this cluster. The previous mechanism (`kubectl set env` from the release CI
+// job) silently no-opped every release because the GitHub runner cannot reach
+// this cluster's API server. The LATEST_VERSION env now serves only as the
+// seed/fallback: used until the first successful poll and whenever GitHub is
+// unreachable. Best-effort — a failed poll keeps the last known value.
+func (s *server) runLatestVersionLoop(ctx context.Context, repo string) {
+	if repo == "" {
+		return
+	}
+	check := func() {
+		v, err := fetchLatestRelease(ctx, repo)
+		if err != nil {
+			slog.Warn("latest-version poll failed", "error", err)
+			return
+		}
+		if !isReleaseVersion(v) {
+			slog.Warn("latest-version poll: unexpected tag", "tag", v)
+			return
+		}
+		if v != s.latest() {
+			slog.Info("latest version updated", "from", s.latest(), "to", v)
+			s.setLatest(v)
+		}
+	}
+	check()
+	t := time.NewTicker(latestVersionInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			check()
+		}
+	}
 }
 
 // retentionWindow is the cutoff after which an install row that has stopped
@@ -371,6 +462,7 @@ func main() {
 	canonicalHost := env("CANONICAL_HOST", "")
 	latestVersion := env("LATEST_VERSION", "v1.4.3")
 	statsToken := env("STATS_TOKEN", "")
+	releaseRepo := env("GITHUB_REPO", "vavallee/bindery")
 
 	db, err := sql.Open("sqlite", dbPath+"?_journal=WAL&_timeout=5000")
 	if err != nil {
@@ -464,13 +556,15 @@ func main() {
 	}
 
 	s := &server{
-		db:            db,
-		dbDir:         filepath.Dir(dbPath),
-		latestVersion: latestVersion,
-		statsToken:    statsToken,
+		db:         db,
+		dbDir:      filepath.Dir(dbPath),
+		statsToken: statsToken,
 		// Each IP may ping at most once per hour.
 		limiter: newRateLimiter(1*time.Hour, 5*time.Minute),
 	}
+	// Seed the advertised version from the env; the poller below overrides it
+	// with the newest GitHub release once it can reach the API.
+	s.setLatest(latestVersion)
 
 	// Nightly retention job: drop rows whose last_seen is older than 60 days
 	// (dormant installs that won't return) and any dev/test rows that older
@@ -495,6 +589,11 @@ func main() {
 	// snapshots the current state into today's row (UPSERT), so a process
 	// restart can recover today's partial counts without manual intervention.
 	go s.runAggregateLoop(context.Background())
+
+	// Self-update the advertised "latest" version from the GitHub Releases API
+	// so a new release propagates without a runner→cluster push (which times
+	// out — the cluster API isn't reachable from GitHub Actions).
+	go s.runLatestVersionLoop(context.Background(), releaseRepo)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", s.handleHome)
@@ -805,7 +904,7 @@ func (s *server) handlePing(w http.ResponseWriter, r *http.Request) {
 	// Newer clients skip these client-side; older clients land here.
 	if !isReleaseVersion(req.Version) {
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(pingResponse{LatestVersion: s.latestVersion})
+		_ = json.NewEncoder(w).Encode(pingResponse{LatestVersion: s.latest()})
 		return
 	}
 	if !validDeploys[req.Deploy] {
@@ -847,7 +946,7 @@ func (s *server) handlePing(w http.ResponseWriter, r *http.Request) {
 	slog.Info("ping", "id", req.InstallID[:min(8, len(req.InstallID))], "version", req.Version, "os", req.OS, "arch", req.Arch, "features", featuresJSON.Valid)
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(pingResponse{LatestVersion: s.latestVersion})
+	_ = json.NewEncoder(w).Encode(pingResponse{LatestVersion: s.latest()})
 }
 
 // statsBucket pairs a label (version / OS / arch) with its install count.
@@ -1278,7 +1377,7 @@ func (s *server) handleStatsJSON(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	resp.Latest = s.latestVersion
+	resp.Latest = s.latest()
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=60")
@@ -1875,7 +1974,7 @@ func (s *server) handleStatsPage(w http.ResponseWriter, r *http.Request) {
 </body>
 </html>`,
 		d.Active7d, d.Active30d, d.Total,
-		renderVersionsTable(d.Versions, d.VersionsRecent, 8, normalizeVersion(s.latestVersion)),
+		renderVersionsTable(d.Versions, d.VersionsRecent, 8, normalizeVersion(s.latest())),
 		renderBarChart(d.OS, 0, ""),
 		renderBarChart(d.Arch, 0, ""),
 		renderBarChart(d.Deploy, 0, ""),

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -158,7 +158,84 @@ func newTestServer(t *testing.T, latest string) *server {
 			t.Fatalf("create table: %v", err)
 		}
 	}
-	return &server{db: db, latestVersion: latest}
+	s := &server{db: db}
+	s.setLatest(latest)
+	return s
+}
+
+// stubGitHubLatest points githubAPIBase at a test server that serves
+// releases/latest with the given tag (or a status code when tag is "").
+func stubGitHubLatest(t *testing.T, repo, tag string, status int) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/"+repo+"/releases/latest" {
+			http.Error(w, "unexpected path: "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": tag})
+	}))
+	t.Cleanup(srv.Close)
+	prev := githubAPIBase
+	githubAPIBase = srv.URL
+	t.Cleanup(func() { githubAPIBase = prev })
+}
+
+func TestFetchLatestRelease(t *testing.T) {
+	stubGitHubLatest(t, "vavallee/bindery", "v1.22.1", http.StatusOK)
+	got, err := fetchLatestRelease(context.Background(), "vavallee/bindery")
+	if err != nil {
+		t.Fatalf("fetchLatestRelease: %v", err)
+	}
+	if got != "v1.22.1" {
+		t.Errorf("tag = %q, want v1.22.1", got)
+	}
+}
+
+func TestFetchLatestRelease_Non200(t *testing.T) {
+	stubGitHubLatest(t, "vavallee/bindery", "", http.StatusForbidden)
+	if _, err := fetchLatestRelease(context.Background(), "vavallee/bindery"); err == nil {
+		t.Fatal("expected error on non-200 status, got nil")
+	}
+}
+
+func TestRunLatestVersionLoop_UpdatesFromGitHub(t *testing.T) {
+	stubGitHubLatest(t, "vavallee/bindery", "v1.22.1", http.StatusOK)
+	s := newTestServer(t, "v1.0.0") // seeded from "env"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.runLatestVersionLoop(ctx, "vavallee/bindery")
+	waitFor(t, 2*time.Second, func() bool { return s.latest() == "v1.22.1" })
+	if s.latest() != "v1.22.1" {
+		t.Fatalf("latest = %q, want v1.22.1 (poller should override the seed)", s.latest())
+	}
+}
+
+func TestRunLatestVersionLoop_KeepsSeedOnBadTag(t *testing.T) {
+	stubGitHubLatest(t, "vavallee/bindery", "nightly", http.StatusOK) // not a release tag
+	s := newTestServer(t, "v1.0.0")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.runLatestVersionLoop(ctx, "vavallee/bindery")
+	// Give the immediate check time to run and (correctly) reject the tag.
+	time.Sleep(200 * time.Millisecond)
+	if s.latest() != "v1.0.0" {
+		t.Fatalf("latest = %q, want the seed v1.0.0 to be kept for a non-release tag", s.latest())
+	}
+}
+
+func waitFor(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func TestHandleStatsJSON(t *testing.T) {


### PR DESCRIPTION
## Problem

`bindery-ping` advertised its "latest" version from a static `LATEST_VERSION` env, bumped each release by a CI job (`bump-latest-version`) that ran `kubectl set env` **from the GitHub runner**. The cluster API isn't reachable from GitHub Actions, so that job **timed out and silently no-opped every release** (masked by `continue-on-error`). Result: `stats.json` and the Discord "📦 Latest" voice channel stayed on the previous version until hand-fixed. v1.22.1 hit this — I had to `kubectl set env` it manually.

This is the counterpart to #1285 (the deploy promote couldn't reach branch protection); both stem from pushing *into* the cluster from CI.

## Fix — invert the flow

`bindery-ping` now discovers the latest version **itself**, from inside the cluster:
- `runLatestVersionLoop` polls `GET /repos/{repo}/releases/latest` every 30 min (2 req/h — well under the 60/h unauthenticated limit) and atomically updates the advertised version.
- `LATEST_VERSION` becomes the **seed/fallback**: used until the first successful poll and whenever GitHub is unreachable.
- The advertised value is now an `atomic.Pointer[string]` (`latest()`/`setLatest()`) so the poller can update it while `/stats.json`, `/api/ping`, and the dashboard read it concurrently (race-tested).
- `GITHUB_REPO` env (default `vavallee/bindery`) selects the repo.

Removes the dead `bump-latest-version` CI job (nothing `needs:` it) with a comment explaining why.

## Tests
`fetchLatestRelease` (parse + non-200 error), the loop overriding the seed from a stubbed GitHub server, and keeping the seed when GitHub returns a non-release tag. `go test -race` + `golangci-lint` clean.

## Deploy note
Takes effect once the `bindery-ping` image is rebuilt with this code and rolled. The current pod is already on `v1.22.1` (set manually); after this deploys, future releases self-propagate with no intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)