### PR TITLE
fix(importer): normalize Unicode dashes so em-dash folders parse

### DIFF
--- a/internal/importer/parser.go
+++ b/internal/importer/parser.go
@@ -59,6 +59,22 @@ var (
 	seriesBookInlineRe = regexp.MustCompile(`(?i)^(.+?)\s+(?:book|vol(?:ume)?|part)\.?\s*(\d+(?:\.\d+)?)\s*[-–:]\s*(.+)$`)
 )
 
+// dashNormalizer rewrites the Unicode dash variants a library or OS might use
+// (Unicode/non-breaking hyphen, figure dash, en dash, em dash, horizontal bar,
+// minus sign) to a plain ASCII hyphen, so the "Title - Author" and series
+// separators above match regardless of which dash the path uses. Without it an
+// em-dash folder ("Title — Author", common from macOS/auto-formatting) never
+// splits and the whole name falls through as the title, matching nothing.
+var dashNormalizer = strings.NewReplacer(
+	"‐", "-", // ‐ hyphen
+	"‑", "-", // ‑ non-breaking hyphen
+	"‒", "-", // ‒ figure dash
+	"–", "-", // – en dash
+	"—", "-", // — em dash
+	"―", "-", // ― horizontal bar
+	"−", "-", // − minus sign
+)
+
 // bookExtensions lists common ebook file extensions.
 var bookExtensions = map[string]bool{
 	".epub": true, ".mobi": true, ".azw3": true, ".azw": true,
@@ -79,6 +95,11 @@ func ParseFilename(path string) ParsedFile {
 	// Work with the base name without extension
 	name := filepath.Base(path)
 	name = strings.TrimSuffix(name, filepath.Ext(name))
+
+	// Normalize Unicode dash variants to a plain hyphen up front so every
+	// dash-based separator below (Title - Author, Author - [Series] - Title,
+	// leading position number, ...) matches an em dash the same as a hyphen.
+	name = dashNormalizer.Replace(name)
 
 	// Extract ASIN if present and strip it so it doesn't pollute the title
 	if asin := asinRe.FindString(name); asin != "" {

--- a/internal/importer/parser_test.go
+++ b/internal/importer/parser_test.go
@@ -70,6 +70,37 @@ func TestParseFilename(t *testing.T) {
 			wantAuthor: "Peter F Hamilton",
 			wantFormat: "epub",
 		},
+		{
+			// em dash (U+2014) separator must split like a hyphen does. Before the
+			// dash normalization this fell through to title="Dark Matter — Author
+			// Name" and matched nothing.
+			input:      "Dark Matter — Author Name.epub",
+			wantTitle:  "Dark Matter",
+			wantAuthor: "Author Name",
+			wantFormat: "epub",
+		},
+		{
+			// en dash (U+2013) separator.
+			input:      "Recursion – Blake Crouch.mobi",
+			wantTitle:  "Recursion",
+			wantAuthor: "Blake Crouch",
+			wantFormat: "mobi",
+		},
+		{
+			// em dash in the Author-leading series convention (issue #1014 shape).
+			input:      "Peter F Hamilton — [Commonwealth Saga 01] — Pandora's Star.epub",
+			wantTitle:  "Pandora's Star",
+			wantAuthor: "Peter F Hamilton",
+			wantFormat: "epub",
+		},
+		{
+			// A hyphenated compound in the title (no surrounding spaces) must NOT
+			// be treated as a Title-Author separator.
+			input:      "Spider-Man.epub",
+			wantTitle:  "Spider-Man",
+			wantAuthor: "",
+			wantFormat: "epub",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

The filename/folder parser splits `Title - Author` (and the Author-leading `Author - [Series] - Title` convention) on a dash, but the separator character classes (`parser.go` `titleAuthorRe`, `authorSeriesTitleRe`, `dashCollapseRe`, `leadingNumRe`, `seriesBookInlineRe`) only listed **ASCII hyphen + en dash** `[-–]`. A folder using an **em dash** (`Title — Author`) — common from macOS and auto-formatting tools — never split: the whole name fell through as the title and matched nothing, both in manual **Look Up** and the **library-scan reconciler** (so whole folders pile into "Unmatched").

Reported on Discord — a user importing a Terry Pratchett library found "another book did work, so it might be the dash." They're right.

## Fix

Normalize the Unicode dash variants (Unicode/NB hyphen, figure dash, en dash, em dash, horizontal bar, minus sign) to a plain ASCII hyphen at the top of `ParseFilename`, so every dash-based separator matches regardless of which dash the path uses. One central `strings.Replacer` rather than editing five regex char classes.

- Spaces are still required around the separator, so a hyphenated compound like **`Spider-Man`** stays intact (test added).
- The parsed title is only used for matching/candidate display (manual import selects a catalogue book; scan reconciles to existing books), so normalizing dashes in it is safe.

## Tests
Added em-dash, en-dash, em-dash-in-series-convention, and hyphenated-compound cases to `TestParseFilename`. Full `internal/importer` suite + `golangci-lint` pass.

## Not in scope
- **Title-vs-Author order** (`Author - Title` parsed backwards) — genuinely ambiguous from a bare `X - Y`; left alone.
- **Author-folder → all books / bulk import** — filed separately as a feature; it needs a new lookup response shape + UI + batch endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)