### PR TITLE
feat(import): bulk folder import (scan + batch) for migration backlogs

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -811,7 +811,9 @@ func main() {
 		r.Group(func(r chi.Router) {
 			r.Use(auth.RequireAdmin)
 			r.Get("/queue/manual-import/lookup", manualImportHandler.Lookup)
+			r.Get("/queue/manual-import/scan", manualImportHandler.Scan)
 			r.Post("/queue/manual-import", manualImportHandler.Import)
+			r.Post("/queue/manual-import/batch", manualImportHandler.ImportBatch)
 		})
 		r.Get("/pending", pendingHandler.List)
 		r.Delete("/pending/{id}", pendingHandler.Delete)

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -81,73 +84,277 @@ type manualImportRequest struct {
 	Format string `json:"format"`
 }
 
+// prepareImport validates a single (path, bookId, format) request, resolves the
+// path inside a library root, confirms the book exists, and creates the
+// synthetic Download record. On success it returns the record and the
+// symlink-resolved path. On failure it returns an HTTP status and a message.
+// It is the shared core of Import (one item) and ImportBatch (many).
+func (h *ManualImportHandler) prepareImport(ctx context.Context, rawPath string, bookID int64, format string) (*models.Download, string, int, string) {
+	path := filepath.Clean(rawPath)
+	if path == "" || path == "." {
+		return nil, "", http.StatusBadRequest, "path is required"
+	}
+	if !filepath.IsAbs(path) {
+		return nil, "", http.StatusBadRequest, "path must be absolute"
+	}
+	// Resolve symlinks and confirm containment so a symlink inside a root that
+	// points outside it can't redirect the read/move to an arbitrary file.
+	resolved, ok := h.roots.ResolveContained(ctx, path)
+	if !ok {
+		return nil, "", http.StatusForbidden, "path is outside the configured library roots"
+	}
+	path = resolved
+	if bookID <= 0 {
+		return nil, "", http.StatusBadRequest, "bookId is required"
+	}
+	if format != "" && format != models.MediaTypeEbook && format != models.MediaTypeAudiobook {
+		return nil, "", http.StatusBadRequest, "format must be \"ebook\" or \"audiobook\""
+	}
+	info, err := os.Stat(path) //nolint:gosec // #nosec G304 -- path is symlink-resolved and confirmed inside a configured library root; RequireAdmin middleware enforced at route level
+	if err != nil {
+		return nil, "", http.StatusBadRequest, fmt.Sprintf("path not accessible: %v", err)
+	}
+	if !info.IsDir() && !importer.IsBookFile(path) {
+		return nil, "", http.StatusBadRequest, "path is not a recognised book file"
+	}
+	book, err := h.books.GetByID(ctx, bookID)
+	if err != nil || book == nil {
+		return nil, "", http.StatusBadRequest, "book not found"
+	}
+	now := time.Now().UTC()
+	dl := &models.Download{
+		GUID:   "manual-" + uuid.New().String(),
+		BookID: &bookID,
+		Title:  book.Title,
+		Status: models.StateCompleted,
+	}
+	dl.CompletedAt = &now
+	if err := h.downloads.Create(ctx, dl); err != nil {
+		return nil, "", http.StatusInternalServerError, "failed to create import record"
+	}
+	return dl, path, 0, ""
+}
+
 // Import handles POST /api/v1/queue/manual-import
 // It validates the path and book, creates a synthetic Download record, and
-// kicks off tryImportInternal asynchronously. Returns 202 with the new record.
+// kicks off the import asynchronously. Returns 202 with the new record.
 func (h *ManualImportHandler) Import(w http.ResponseWriter, r *http.Request) {
 	var req manualImportRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 		return
 	}
-	req.Path = filepath.Clean(req.Path)
-	if req.Path == "" || req.Path == "." {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path is required"})
+	dl, path, status, msg := h.prepareImport(r.Context(), req.Path, req.BookID, req.Format)
+	if dl == nil {
+		writeJSON(w, status, map[string]string{"error": msg})
 		return
 	}
-	if !filepath.IsAbs(req.Path) {
+	go h.scanner.ImportFromPath(context.WithoutCancel(r.Context()), dl, path, req.Format)
+	writeJSON(w, http.StatusAccepted, dl)
+}
+
+// ScanItem is one candidate book unit discovered under a folder during Scan.
+type ScanItem struct {
+	Path           string        `json:"path"`
+	Name           string        `json:"name"`
+	Match          string        `json:"match"` // "confident" | "ambiguous" | "none"
+	ParsedTitle    string        `json:"parsedTitle"`
+	ParsedAuthor   string        `json:"parsedAuthor"`
+	DetectedFormat string        `json:"detectedFormat"`
+	Book           *models.Book  `json:"book,omitempty"`
+	Candidates     []models.Book `json:"candidates,omitempty"`
+}
+
+// ScanResponse is the result of scanning a folder for importable book units.
+type ScanResponse struct {
+	Items     []ScanItem `json:"items"`
+	Truncated bool       `json:"truncated"`
+}
+
+// maxScanEntries caps how many child units a single Scan returns so pointing at
+// an enormous tree can't produce an unbounded response or stall the request.
+const maxScanEntries = 1000
+
+// Scan handles GET /api/v1/queue/manual-import/scan?path=...
+// It enumerates the immediate children of a folder (each book file, and each
+// subdirectory that contains at least one book file) and runs the same
+// catalogue Lookup on each, returning a per-unit match list to review and
+// bulk-import. No state is modified.
+func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
+	path := filepath.Clean(r.URL.Query().Get("path"))
+	if path == "" || path == "." {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path parameter required"})
+		return
+	}
+	if !filepath.IsAbs(path) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path must be absolute"})
 		return
 	}
-	resolved, ok := h.roots.ResolveContained(r.Context(), req.Path)
+	resolved, ok := h.roots.ResolveContained(r.Context(), path)
 	if !ok {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "path is outside the configured library roots"})
 		return
 	}
-	// Use the symlink-resolved path for every subsequent operation (stat,
-	// book-file detection, import) so a symlink inside a root that points
-	// outside it can't redirect the read/move to an arbitrary file.
-	req.Path = resolved
-	if req.BookID <= 0 {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "bookId is required"})
-		return
-	}
-	if req.Format != "" && req.Format != models.MediaTypeEbook && req.Format != models.MediaTypeAudiobook {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "format must be \"ebook\" or \"audiobook\""})
-		return
-	}
-
-	info, err := os.Stat(req.Path) //nolint:gosec // #nosec G304 -- path is symlink-resolved and confirmed inside a configured library root; RequireAdmin middleware enforced at route level
+	path = resolved
+	info, err := os.Stat(path) //nolint:gosec // #nosec G304 -- symlink-resolved and confirmed inside a configured library root; RequireAdmin enforced at route level
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("path not accessible: %v", err)})
 		return
 	}
-	if !info.IsDir() && !importer.IsBookFile(req.Path) {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path is not a recognised book file"})
+	if !info.IsDir() {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path must be a folder; use lookup for a single book"})
+		return
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("read folder: %v", err)})
+		return
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	resp := ScanResponse{Items: []ScanItem{}}
+	for _, e := range entries {
+		if len(resp.Items) >= maxScanEntries {
+			resp.Truncated = true
+			break
+		}
+		child := filepath.Join(path, e.Name())
+		isDir := e.IsDir()
+		if !isDir && !importer.IsBookFile(child) {
+			continue
+		}
+		if isDir && !dirHasBookFile(child) {
+			continue
+		}
+		res, err := h.scanner.Lookup(r.Context(), child)
+		if err != nil {
+			continue
+		}
+		resp.Items = append(resp.Items, ScanItem{
+			Path:           child,
+			Name:           e.Name(),
+			Match:          res.Match,
+			ParsedTitle:    res.ParsedTitle,
+			ParsedAuthor:   res.ParsedAuthor,
+			DetectedFormat: res.DetectedFormat,
+			Book:           res.Book,
+			Candidates:     res.Candidates,
+		})
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// dirHasBookFile reports whether dir contains at least one recognized book
+// file, walking up to a bounded number of entries so a deep or huge tree can't
+// stall the scan.
+func dirHasBookFile(dir string) bool {
+	const limit = 5000
+	count := 0
+	found := false
+	_ = filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries rather than abort the walk
+		}
+		count++
+		if count > limit {
+			return fs.SkipAll
+		}
+		if !d.IsDir() && importer.IsBookFile(p) {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+// BatchImportItem is one (path, bookId, format) pair in a batch import.
+type BatchImportItem struct {
+	Path   string `json:"path"`
+	BookID int64  `json:"bookId"`
+	Format string `json:"format"`
+}
+
+// BatchImportResult reports the per-item outcome of validation. The actual
+// import runs asynchronously after a successful validation (Accepted=true).
+type BatchImportResult struct {
+	Path       string `json:"path"`
+	Accepted   bool   `json:"accepted"`
+	Error      string `json:"error,omitempty"`
+	DownloadID int64  `json:"downloadId,omitempty"`
+}
+
+// BatchImportResponse summarizes a batch import submission.
+type BatchImportResponse struct {
+	Results  []BatchImportResult `json:"results"`
+	Accepted int                 `json:"accepted"`
+	Failed   int                 `json:"failed"`
+}
+
+const (
+	// maxBatchItems caps a single batch so one request can't enqueue an
+	// unbounded number of imports.
+	maxBatchItems = 1000
+	// batchImportConcurrency bounds how many imports run at once in the
+	// background, so a 500-item batch doesn't fan out 500 concurrent file moves.
+	batchImportConcurrency = 4
+)
+
+// ImportBatch handles POST /api/v1/queue/manual-import/batch
+// Body: a JSON array of {path, bookId, format}. Each item is validated and gets
+// a Download record synchronously; the file imports then run in the background
+// with bounded concurrency. Returns 202 with the per-item validation results.
+func (h *ManualImportHandler) ImportBatch(w http.ResponseWriter, r *http.Request) {
+	var items []BatchImportItem
+	if err := json.NewDecoder(r.Body).Decode(&items); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if len(items) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "no items to import"})
+		return
+	}
+	if len(items) > maxBatchItems {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("too many items (max %d)", maxBatchItems)})
 		return
 	}
 
-	book, err := h.books.GetByID(r.Context(), req.BookID)
-	if err != nil || book == nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "book not found"})
-		return
+	type job struct {
+		dl     *models.Download
+		path   string
+		format string
+	}
+	var jobs []job
+	resp := BatchImportResponse{Results: make([]BatchImportResult, 0, len(items))}
+	for _, it := range items {
+		dl, path, _, msg := h.prepareImport(r.Context(), it.Path, it.BookID, it.Format)
+		if dl == nil {
+			resp.Results = append(resp.Results, BatchImportResult{Path: it.Path, Accepted: false, Error: msg})
+			resp.Failed++
+			continue
+		}
+		jobs = append(jobs, job{dl: dl, path: path, format: it.Format})
+		resp.Results = append(resp.Results, BatchImportResult{Path: it.Path, Accepted: true, DownloadID: dl.ID})
+		resp.Accepted++
 	}
 
-	now := time.Now().UTC()
-	dl := &models.Download{
-		GUID:   "manual-" + uuid.New().String(),
-		BookID: &req.BookID,
-		Title:  book.Title,
-		Status: models.StateCompleted,
+	if len(jobs) > 0 {
+		ctx := context.WithoutCancel(r.Context())
+		go func() {
+			sem := make(chan struct{}, batchImportConcurrency)
+			var wg sync.WaitGroup
+			for _, j := range jobs {
+				sem <- struct{}{}
+				wg.Add(1)
+				go func(j job) {
+					defer wg.Done()
+					defer func() { <-sem }()
+					h.scanner.ImportFromPath(ctx, j.dl, j.path, j.format)
+				}(j)
+			}
+			wg.Wait()
+		}()
 	}
-	dl.CompletedAt = &now
 
-	if err := h.downloads.Create(r.Context(), dl); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create import record"})
-		return
-	}
-
-	go h.scanner.ImportFromPath(context.WithoutCancel(r.Context()), dl, req.Path, req.Format)
-
-	writeJSON(w, http.StatusAccepted, dl)
+	writeJSON(w, http.StatusAccepted, resp)
 }

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -624,3 +624,140 @@ func TestManualImportImport_PathOutsideAllowedRoots(t *testing.T) {
 		})
 	}
 }
+
+// ── Scan handler ────────────────────────────────────────────────────────────
+
+func scanRequest(path string) *http.Request {
+	u := "/api/v1/queue/manual-import/scan?" + url.Values{"path": {path}}.Encode()
+	return httptest.NewRequest(http.MethodGet, u, nil)
+}
+
+func writeTestFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestManualImportScan_EnumeratesBookUnits(t *testing.T) {
+	t.Parallel()
+	h, stub, _, _, _ := manualImportFixture(t)
+	stub.lookupResult = importer.LookupResult{Match: "none", ParsedTitle: "x"}
+
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "Book One.epub"))            // book file -> unit
+	writeTestFile(t, filepath.Join(root, "Book Two.mobi"))            // book file -> unit
+	writeTestFile(t, filepath.Join(root, "cover.jpg"))                // non-book -> skipped
+	writeTestFile(t, filepath.Join(root, "Author - Title", "ab.m4b")) // subdir w/ book -> unit
+	if err := os.MkdirAll(filepath.Join(root, "empty"), 0o755); err != nil {
+		t.Fatal(err) // subdir w/o book -> skipped
+	}
+
+	rec := httptest.NewRecorder()
+	h.Scan(rec, scanRequest(root))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp ScanResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 3 {
+		t.Fatalf("items = %d, want 3 (2 book files + 1 book subdir); got %+v", len(resp.Items), resp.Items)
+	}
+	if resp.Truncated {
+		t.Error("unexpected truncation for a small folder")
+	}
+}
+
+func TestManualImportScan_RejectsSingleFile(t *testing.T) {
+	t.Parallel()
+	h, _, _, _, _ := manualImportFixture(t)
+	root := t.TempDir()
+	f := filepath.Join(root, "book.epub")
+	writeTestFile(t, f)
+	rec := httptest.NewRecorder()
+	h.Scan(rec, scanRequest(f))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (scan needs a folder, not a file)", rec.Code)
+	}
+}
+
+func TestManualImportScan_EmptyPath(t *testing.T) {
+	t.Parallel()
+	h, _, _, _, _ := manualImportFixture(t)
+	rec := httptest.NewRecorder()
+	h.Scan(rec, httptest.NewRequest(http.MethodGet, "/api/v1/queue/manual-import/scan", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// ── Batch import ────────────────────────────────────────────────────────────
+
+func TestManualImportBatch_MixedValidity(t *testing.T) {
+	t.Parallel()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	ctx := context.Background()
+	book := seedBook(t, authors, books, ctx)
+
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books)
+
+	root := t.TempDir()
+	good := filepath.Join(root, "good.epub")
+	writeTestFile(t, good)
+	noBook := filepath.Join(root, "nobook.epub")
+	writeTestFile(t, noBook)
+
+	items := []map[string]any{
+		{"path": good, "bookId": book.ID, "format": models.MediaTypeEbook}, // valid
+		{"path": noBook, "bookId": 0},                                      // missing bookId
+		{"path": filepath.Join(root, "missing.epub"), "bookId": book.ID},   // path not accessible
+	}
+	body, _ := json.Marshal(items)
+	rec := httptest.NewRecorder()
+	h.ImportBatch(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/batch", bytes.NewReader(body)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp BatchImportResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Accepted != 1 || resp.Failed != 2 {
+		t.Fatalf("accepted=%d failed=%d, want 1/2; results=%+v", resp.Accepted, resp.Failed, resp.Results)
+	}
+	if !resp.Results[0].Accepted || resp.Results[0].DownloadID == 0 {
+		t.Errorf("first item should be accepted with a download id; got %+v", resp.Results[0])
+	}
+	if resp.Results[1].Accepted || resp.Results[2].Accepted {
+		t.Errorf("invalid items should not be accepted; got %+v", resp.Results[1:])
+	}
+	all, err := downloads.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 1 {
+		t.Errorf("download rows = %d, want 1 (only the valid item created one)", len(all))
+	}
+}
+
+func TestManualImportBatch_Empty(t *testing.T) {
+	t.Parallel()
+	h, _, _, _, _ := manualImportFixture(t)
+	rec := httptest.NewRecorder()
+	h.ImportBatch(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/batch", bytes.NewReader([]byte("[]"))))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for empty batch", rec.Code)
+	}
+}

--- a/web/src/api/queue.ts
+++ b/web/src/api/queue.ts
@@ -31,6 +31,42 @@ export interface ManualImportLookup {
   parsedAuthor: string
 }
 
+// ScanItem is one candidate book unit found under a folder by the bulk scan.
+export interface ScanItem {
+  path: string
+  name: string
+  match: 'confident' | 'ambiguous' | 'none'
+  parsedTitle: string
+  parsedAuthor: string
+  detectedFormat: string
+  book?: Book
+  candidates?: Book[]
+}
+
+export interface FolderScanResponse {
+  items: ScanItem[]
+  truncated: boolean
+}
+
+export interface BatchImportItem {
+  path: string
+  bookId: number
+  format?: string
+}
+
+export interface BatchImportResult {
+  path: string
+  accepted: boolean
+  error?: string
+  downloadId?: number
+}
+
+export interface BatchImportResponse {
+  results: BatchImportResult[]
+  accepted: number
+  failed: number
+}
+
 // QueueListResponse is the envelope returned by GET /queue. Items is the
 // flat array the UI has always rendered; partial/staleClients let a
 // future page iteration warn when a downloader client did not answer
@@ -89,6 +125,11 @@ export const queueApi = {
     request<ManualImportLookup>(`/queue/manual-import/lookup?path=${encodeURIComponent(path)}`),
   manualImport: (data: { path: string; bookId: number; format?: string }) =>
     request<Download>('/queue/manual-import', { method: 'POST', body: JSON.stringify(data) }),
+  // Bulk folder import: scan a folder for book units, then import the selected ones.
+  scanFolder: (path: string) =>
+    request<FolderScanResponse>(`/queue/manual-import/scan?path=${encodeURIComponent(path)}`),
+  batchImport: (items: BatchImportItem[]) =>
+    request<BatchImportResponse>('/queue/manual-import/batch', { method: 'POST', body: JSON.stringify(items) }),
 
   // Pending releases
   listPending: () => request<PendingRelease[]>('/pending'),

--- a/web/src/pages/settings/FolderScanSection.test.tsx
+++ b/web/src/pages/settings/FolderScanSection.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+// i18n: return the key (with crude interpolation) so assertions are stable.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: unknown) => {
+      // t(key) and t(key, 'default string') both render the bare key for
+      // stable assertions; t(key, {opts}) appends the interpolation values.
+      if (!options || typeof options !== 'object') return key
+      let out = key
+      for (const [k, v] of Object.entries(options as Record<string, unknown>)) {
+        if (k === 'defaultValue') continue
+        out += ` ${k}=${String(v)}`
+      }
+      return out
+    },
+  }),
+}))
+
+vi.mock('../../api/client', () => ({
+  api: {
+    scanFolder: vi.fn(),
+    batchImport: vi.fn(),
+  },
+}))
+
+import { api, FolderScanResponse } from '../../api/client'
+import { FolderScanSection } from './ImportTab'
+
+const mockScan = api.scanFolder as ReturnType<typeof vi.fn>
+const mockBatch = api.batchImport as ReturnType<typeof vi.fn>
+
+function scanResult(): FolderScanResponse {
+  return {
+    truncated: false,
+    items: [
+      {
+        path: '/dl/Confident Book', name: 'Confident Book', match: 'confident',
+        parsedTitle: 'Confident Book', parsedAuthor: 'A. Writer', detectedFormat: 'ebook',
+        book: { id: 11, title: 'Confident Book', author: { authorName: 'A. Writer' } } as never,
+      },
+      {
+        path: '/dl/Maybe Book', name: 'Maybe Book', match: 'ambiguous',
+        parsedTitle: 'Maybe Book', parsedAuthor: '', detectedFormat: 'ebook',
+        candidates: [
+          { id: 21, title: 'Maybe Book (1)', author: { authorName: 'X' } } as never,
+          { id: 22, title: 'Maybe Book (2)', author: { authorName: 'Y' } } as never,
+        ],
+      },
+      {
+        path: '/dl/Orphan', name: 'Orphan', match: 'none',
+        parsedTitle: 'Orphan', parsedAuthor: '', detectedFormat: 'audiobook',
+      },
+    ],
+  }
+}
+
+describe('FolderScanSection', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  async function scan() {
+    mockScan.mockResolvedValue(scanResult())
+    render(<FolderScanSection />)
+    fireEvent.change(screen.getByPlaceholderText('settings.import.bulkPathPlaceholder'), {
+      target: { value: '/dl' },
+    })
+    fireEvent.click(screen.getByText('settings.import.bulkScan'))
+    await waitFor(() => expect(screen.getByText('Confident Book')).toBeInTheDocument())
+  }
+
+  it('pre-selects only confident matches and imports them', async () => {
+    await scan()
+    expect(mockScan).toHaveBeenCalledWith('/dl')
+
+    const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
+    expect(checkboxes[0].checked).toBe(true)  // confident
+    expect(checkboxes[1].checked).toBe(false) // ambiguous, no pick yet
+    expect(checkboxes[2].disabled).toBe(true) // none, not selectable
+
+    // Import button reflects 1 selected (the confident one).
+    expect(screen.getByText(/settings\.import\.bulkImport count=1/)).toBeInTheDocument()
+
+    mockBatch.mockResolvedValue({ accepted: 1, failed: 0, results: [{ path: '/dl/Confident Book', accepted: true, downloadId: 5 }] })
+    fireEvent.click(screen.getByText(/settings\.import\.bulkImport count=1/))
+
+    await waitFor(() => expect(mockBatch).toHaveBeenCalledTimes(1))
+    expect(mockBatch).toHaveBeenCalledWith([{ path: '/dl/Confident Book', bookId: 11, format: 'ebook' }])
+    await waitFor(() => expect(screen.getByText(/bulkSummary accepted=1 failed=0/)).toBeInTheDocument())
+  })
+
+  it('lets an ambiguous match be resolved via the picker and included', async () => {
+    await scan()
+    // Pick candidate 22 for the ambiguous row.
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '22' } })
+    expect(screen.getByText(/settings\.import\.bulkImport count=2/)).toBeInTheDocument()
+
+    mockBatch.mockResolvedValue({ accepted: 2, failed: 0, results: [] })
+    fireEvent.click(screen.getByText(/settings\.import\.bulkImport count=2/))
+    await waitFor(() => expect(mockBatch).toHaveBeenCalledTimes(1))
+    expect(mockBatch).toHaveBeenCalledWith([
+      { path: '/dl/Confident Book', bookId: 11, format: 'ebook' },
+      { path: '/dl/Maybe Book', bookId: 22, format: 'ebook' },
+    ])
+  })
+})

--- a/web/src/pages/settings/ImportTab.tsx
+++ b/web/src/pages/settings/ImportTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, Book, HardcoverList, ImportList, ManualImportLookup } from '../../api/client'
+import { api, BatchImportItem, BatchImportResponse, Book, HardcoverList, ImportList, ManualImportLookup, ScanItem } from '../../api/client'
 import { inputCls } from './formStyles'
 import GoodreadsImportSection from './GoodreadsImportSection'
 
@@ -118,6 +118,7 @@ export default function ImportTab({ onNavigate }: ImportTabProps = {}) {
         )}
       </section>
       <ManualImportSection />
+      <FolderScanSection />
       <GoodreadsImportSection />
       <HardcoverListsSection onNavigate={onNavigate} />
 
@@ -258,6 +259,198 @@ function ManualImportSection() {
       {err && (
         <p className="text-sm text-red-600 dark:text-red-400">{err}</p>
       )}
+    </section>
+  )
+}
+
+interface ScanRowState {
+  include: boolean
+  bookId: number | null
+  format: string
+}
+
+// FolderScanSection scans a folder for book units and bulk-imports the selected
+// matches in one shot, so a migration backlog doesn't have to be imported one
+// path at a time. Matches against the existing catalogue (add the authors/books
+// first); unmatched units are listed but cannot be selected. Exported for tests.
+export function FolderScanSection() {
+  const { t } = useTranslation()
+  const [path, setPath] = useState('')
+  const [scanning, setScanning] = useState(false)
+  const [items, setItems] = useState<ScanItem[] | null>(null)
+  const [truncated, setTruncated] = useState(false)
+  const [rows, setRows] = useState<ScanRowState[]>([])
+  const [importing, setImporting] = useState(false)
+  const [summary, setSummary] = useState<BatchImportResponse | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  const handleScan = async () => {
+    if (!path.trim()) return
+    setScanning(true)
+    setErr(null)
+    setItems(null)
+    setSummary(null)
+    try {
+      const r = await api.scanFolder(path.trim())
+      setItems(r.items)
+      setTruncated(r.truncated)
+      setRows(r.items.map(it => ({
+        include: it.match === 'confident',
+        bookId: it.match === 'confident' && it.book ? it.book.id : null,
+        format: it.detectedFormat || '',
+      })))
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Scan failed')
+    } finally {
+      setScanning(false)
+    }
+  }
+
+  const patchRow = (i: number, patch: Partial<ScanRowState>) =>
+    setRows(prev => prev.map((r, idx) => (idx === i ? { ...r, ...patch } : r)))
+
+  const selectedCount = rows.filter(r => r.include && r.bookId).length
+
+  const handleImport = async () => {
+    if (!items) return
+    const batch: BatchImportItem[] = []
+    rows.forEach((r, i) => {
+      if (r.include && r.bookId) batch.push({ path: items[i].path, bookId: r.bookId, format: r.format || undefined })
+    })
+    if (batch.length === 0) return
+    setImporting(true)
+    setErr(null)
+    try {
+      const res = await api.batchImport(batch)
+      setSummary(res)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Import failed')
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  const matchBadge = (m: ScanItem['match']) => {
+    const map: Record<ScanItem['match'], string> = {
+      confident: 'bg-emerald-100 dark:bg-emerald-950 text-emerald-700 dark:text-emerald-400',
+      ambiguous: 'bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-400',
+      none: 'bg-slate-200 dark:bg-zinc-800 text-slate-500 dark:text-zinc-500',
+    }
+    return <span className={`text-[10px] px-1.5 py-0.5 rounded ${map[m]}`}>{t(`settings.import.bulkMatch_${m}`, m)}</span>
+  }
+
+  return (
+    <section>
+      <h3 className="text-base font-semibold mb-2 text-slate-800 dark:text-zinc-200">{t('settings.import.bulkHeading', 'Bulk folder import')}</h3>
+      <p className="text-xs text-slate-600 dark:text-zinc-500 mb-3">
+        {t('settings.import.bulkDescription', 'Scan a folder (e.g. your download directory) and import every book it can match to your library in one go. Matching is against books already in your library, so add the authors first. Unmatched items are listed but skipped.')}
+      </p>
+
+      <div className="flex gap-2 mb-3">
+        <input
+          className={inputCls + ' flex-1'}
+          placeholder={t('settings.import.bulkPathPlaceholder', '/downloads/books')}
+          value={path}
+          onChange={e => { setPath(e.target.value); setItems(null); setSummary(null) }}
+          onKeyDown={e => { if (e.key === 'Enter') handleScan() }}
+        />
+        <button
+          onClick={handleScan}
+          disabled={scanning || !path.trim()}
+          className="px-3 py-2 bg-slate-200 dark:bg-zinc-700 hover:bg-slate-300 dark:hover:bg-zinc-600 disabled:opacity-50 rounded text-sm font-medium"
+        >
+          {scanning ? t('settings.import.bulkScanning', 'Scanning…') : t('settings.import.bulkScan', 'Scan folder')}
+        </button>
+      </div>
+
+      {items && items.length === 0 && (
+        <p className="text-sm text-slate-500 dark:text-zinc-600">{t('settings.import.bulkEmpty', 'No book files or folders found here.')}</p>
+      )}
+
+      {items && items.length > 0 && !summary && (
+        <div className="space-y-2">
+          {truncated && (
+            <p className="text-xs text-amber-700 dark:text-amber-400">{t('settings.import.bulkTruncated', 'Showing the first 1000 items; narrow the folder to see the rest.')}</p>
+          )}
+          <div className="border border-slate-200 dark:border-zinc-800 rounded divide-y divide-slate-200 dark:divide-zinc-800 max-h-96 overflow-auto">
+            {items.map((it, i) => {
+              const row = rows[i]
+              const disabled = it.match === 'none'
+              return (
+                <div key={it.path} className="p-2 flex items-start gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    className="mt-1"
+                    checked={row.include && !disabled}
+                    disabled={disabled}
+                    onChange={e => patchRow(i, { include: e.target.checked })}
+                    aria-label={t('settings.import.bulkSelect', { name: it.name, defaultValue: `Import ${it.name}` })}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium truncate">{it.name}</span>
+                      {matchBadge(it.match)}
+                      <span className="text-[10px] px-1.5 py-0.5 bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400 rounded">{it.detectedFormat}</span>
+                    </div>
+                    <div className="text-xs text-slate-500 dark:text-zinc-600 truncate">
+                      {t('settings.import.bulkParsed', { title: it.parsedTitle || '?', author: it.parsedAuthor || '?', defaultValue: `parsed: ${it.parsedTitle || '?'} / ${it.parsedAuthor || '?'}` })}
+                    </div>
+                    {it.match === 'confident' && it.book && (
+                      <div className="text-xs text-emerald-700 dark:text-emerald-400 mt-0.5">→ {it.book.title}{it.book.author ? ` (${it.book.author.authorName})` : ''}</div>
+                    )}
+                    {it.match === 'ambiguous' && (
+                      <select
+                        className={inputCls + ' mt-1 text-xs'}
+                        value={row.bookId ?? ''}
+                        onChange={e => {
+                          const id = Number(e.target.value)
+                          patchRow(i, { bookId: id || null, include: Boolean(id) })
+                        }}
+                      >
+                        <option value="">{t('settings.import.bulkPick', '— pick a book —')}</option>
+                        {it.candidates?.map(b => (
+                          <option key={b.id} value={b.id}>{b.title}{b.author ? ` (${b.author.authorName})` : ''}</option>
+                        ))}
+                      </select>
+                    )}
+                    {it.match === 'none' && (
+                      <div className="text-xs text-slate-400 dark:text-zinc-600 mt-0.5">{t('settings.import.bulkNoMatch', 'No catalogue match; add the book first.')}</div>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+          <button
+            onClick={handleImport}
+            disabled={importing || selectedCount === 0}
+            className="px-3 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded text-sm font-medium"
+          >
+            {importing
+              ? t('settings.import.bulkImporting', 'Importing…')
+              : t('settings.import.bulkImport', { count: selectedCount, defaultValue: `Import ${selectedCount} selected` })}
+          </button>
+        </div>
+      )}
+
+      {summary && (
+        <div className="p-3 border border-slate-200 dark:border-zinc-800 rounded bg-slate-100 dark:bg-zinc-900 space-y-1">
+          <div className="text-sm font-medium">{t('settings.import.bulkSummary', { accepted: summary.accepted, failed: summary.failed, defaultValue: `${summary.accepted} queued, ${summary.failed} failed` })}</div>
+          {summary.failed > 0 && (
+            <details className="text-xs">
+              <summary className="cursor-pointer text-red-600 dark:text-red-400">{t('settings.import.bulkShowFailures', { count: summary.failed, defaultValue: `Show ${summary.failed} failures` })}</summary>
+              <ul className="mt-2 space-y-0.5 font-mono">
+                {summary.results.filter(r => !r.accepted).map(r => (
+                  <li key={r.path}><span className="text-slate-800 dark:text-zinc-200">{r.path}</span>: <span className="text-slate-500 dark:text-zinc-500">{r.error}</span></li>
+                ))}
+              </ul>
+            </details>
+          )}
+          <p className="text-xs text-slate-500 dark:text-zinc-600">{t('settings.import.bulkSummaryNote', 'Imports run in the background; watch the Queue for progress.')}</p>
+        </div>
+      )}
+
+      {err && <p className="text-sm text-red-600 dark:text-red-400 mt-2">{err}</p>}
     </section>
   )
 }


### PR DESCRIPTION
## Why

Manual import is **one path → one book**, so a Readarr migrant with a backlog of finished downloads has to repeat copy-path → lookup → pick → import for every single one. Two users hit this:
- **jiggs** (~591 files, filesystem) — Discord
- **Kedryn** (~500 torrents in qBittorrent's `book` category, #1225)

Both have populated catalogues (the migrate tools add the authors/books), so the missing piece is a way to **attach the existing files to the existing wanted books in bulk**. This is the MVP of #1292.

## What

**Backend** (`internal/api/manual_import.go`)
- `GET /queue/manual-import/scan?path=` — walks the immediate children of a folder (each book file, and each subdirectory containing a book file), runs the same catalogue `Lookup` on each, returns a per-unit list `{path, name, match, parsedTitle/Author, detectedFormat, book|candidates}`. Admin-only, root-contained, capped at 1000 units.
- `POST /queue/manual-import/batch` — takes the selected `{path, bookId, format}` pairs, validates + records each synchronously, then runs the imports in the background with **bounded concurrency (4)** so a 500-item batch doesn't fan out 500 concurrent file moves. Returns per-item validation results.
- The validate-and-create core is refactored into `prepareImport`, shared with the single `Import` handler.

**Frontend** (`ImportTab.tsx`)
- A "Bulk folder import" section: paste a folder, **Scan**, review the list (confident pre-checked, ambiguous gets a candidate picker, unmatched listed but not selectable), then **Import N selected** in one click with a summary + failure details.

## Scope
Matching is against the **existing catalogue** (unmatched units are surfaced, not auto-created) — that's the right MVP because the Readarr/Goodreads migrate tools already populate the catalogue. Lookup-and-create for cold migrations is the documented follow-up in #1292.

This also pairs with #1291 (em-dash parsing) — better parsing means more units land as `confident` here.

## Tests
`go test -race` + `golangci-lint` clean: scan enumeration (skips non-book files / empty dirs, rejects a single file), batch mixed-validity + empty. Frontend `FolderScanSection.test.tsx` covers pre-selection, the ambiguous picker, the batch payload, and the summary. Typecheck / lint / build / full vitest (367) green.

Closes the MVP of #1292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)