### PR TITLE
docs+refactor: explain the author metadata button; dedup its predicates

### DIFF
--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -48,3 +48,12 @@ The catch is that **Hardcover's GraphQL API requires an API token for every quer
 **Fix:** add a Hardcover API token in `Settings → General` (the same token used for [Enhanced Hardcover Series](./Hardcover-Series-Wiki.md) and wishlist features), then re-run the search. Hardcover-only titles should appear in the merged results.
 
 If results still don't appear with a token saved, confirm the instance has outbound HTTPS access to `api.hardcover.app` and that the token is valid (a bad token produces the same "Unable to verify token" error, which is logged and skipped).
+
+## Why is the metadata button on some authors but not others?
+
+The metadata button on an author's page only appears when Bindery thinks the author's record could be improved, so you'll see it on some authors and not others. Two cases show it:
+
+- **"Link metadata"** — the author isn't linked to a metadata provider yet, or was created from an **Audiobookshelf / Calibre import** (those use `abs:` / `calibre:` foreign IDs). The button lets you attach a real provider record.
+- **"Find better metadata"** — the author *is* linked, but the stored record is **sparse**: no description, no image, no disambiguation, and no ratings. The button searches the providers for a richer match to relink to.
+
+An author that already has a filled-in record (a description, an image, ratings) hides the button, because there's nothing obviously better to fetch. So a missing button means that author already has good metadata. If an author looks well populated but still shows the button, the stored description/image/ratings are likely empty even though the page renders other fields — relink and pick the best match to fill them in.

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, AddAuthorRequest, Author, AuthorConflictBody, AuthorMonitorMode, MediaType, MetadataProfile, RootFolder } from '../api/client'
 import { splitAuthorSearchResults } from './addAuthorTitleGuard'
+import { canLinkAuthorMetadata, hasSparseMetadata } from '../util/authorMetadata'
 
 interface Props {
   onClose: () => void
@@ -38,17 +39,6 @@ function conflictBody(err: unknown): AuthorConflictBody | null {
   return null
 }
 
-function canLinkAuthorMetadata(author?: Author): boolean {
-  if (!author) return true
-  const foreignId = (author.foreignAuthorId || '').trim()
-  const provider = (author.metadataProvider || '').trim().toLowerCase()
-  return foreignId === '' || foreignId.startsWith('abs:') || foreignId.startsWith('calibre:') || provider === 'audiobookshelf' || provider === 'calibre'
-}
-
-function hasSparseMetadata(author?: Author): boolean {
-  if (!author) return true
-  return !author.description && !author.imageUrl && !author.disambiguation && (author.ratingsCount ?? 0) === 0 && (author.averageRating ?? 0) === 0
-}
 
 export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const { t } = useTranslation()

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -10,6 +10,7 @@ import AuthorMetadataLinkModal from '../components/AuthorMetadataLinkModal'
 import BulkActionBar from '../components/BulkActionBar'
 import { useView } from '../components/useView'
 import MarkdownDescription from '../components/MarkdownDescription'
+import { canLinkAuthorMetadata, hasSparseMetadata } from '../util/authorMetadata'
 import { btn } from '../components/buttons'
 import Switch from '../components/Switch'
 
@@ -30,16 +31,6 @@ function mediaLabel(mediaType?: Book['mediaType']): string {
   if (mediaType === 'audiobook') return '🎧 Audiobook'
   if (mediaType === 'both') return '📖🎧 Both'
   return '📖 Ebook'
-}
-
-function canLinkAuthorMetadata(author: Author): boolean {
-  const foreignId = (author.foreignAuthorId || '').trim()
-  const provider = (author.metadataProvider || '').trim().toLowerCase()
-  return foreignId === '' || foreignId.startsWith('abs:') || foreignId.startsWith('calibre:') || provider === 'audiobookshelf' || provider === 'calibre'
-}
-
-function hasSparseMetadata(author: Author): boolean {
-  return !author.description && !author.imageUrl && !author.disambiguation && (author.ratingsCount ?? 0) === 0 && (author.averageRating ?? 0) === 0
 }
 
 export default function AuthorDetailPage() {

--- a/web/src/util/authorMetadata.test.ts
+++ b/web/src/util/authorMetadata.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import type { Author } from '../api/client'
+import { canLinkAuthorMetadata, hasSparseMetadata } from './authorMetadata'
+
+const author = (over: Partial<Author>): Author => ({ id: 1, name: 'X', ...over }) as Author
+
+describe('canLinkAuthorMetadata', () => {
+  it('is true when unlinked or import-derived', () => {
+    expect(canLinkAuthorMetadata(author({ foreignAuthorId: '' }))).toBe(true)
+    expect(canLinkAuthorMetadata(author({ foreignAuthorId: 'abs:123' }))).toBe(true)
+    expect(canLinkAuthorMetadata(author({ foreignAuthorId: 'calibre:7' }))).toBe(true)
+    expect(canLinkAuthorMetadata(author({ foreignAuthorId: 'OL1A', metadataProvider: 'audiobookshelf' }))).toBe(true)
+    expect(canLinkAuthorMetadata(author({ foreignAuthorId: 'OL1A', metadataProvider: 'calibre' }))).toBe(true)
+  })
+  it('is false for a real provider link', () => {
+    expect(canLinkAuthorMetadata(author({ foreignAuthorId: 'OL1A', metadataProvider: 'openlibrary' }))).toBe(false)
+  })
+  it('defaults to true for a nil author', () => {
+    expect(canLinkAuthorMetadata(undefined)).toBe(true)
+  })
+})
+
+describe('hasSparseMetadata', () => {
+  it('is true only when description, image, disambiguation, and ratings are all empty', () => {
+    expect(hasSparseMetadata(author({}))).toBe(true)
+    expect(hasSparseMetadata(author({ description: 'A bio' }))).toBe(false)
+    expect(hasSparseMetadata(author({ imageUrl: 'http://x/y.jpg' }))).toBe(false)
+    expect(hasSparseMetadata(author({ disambiguation: 'the elder' }))).toBe(false)
+    expect(hasSparseMetadata(author({ ratingsCount: 5 }))).toBe(false)
+    expect(hasSparseMetadata(author({ averageRating: 4.2 }))).toBe(false)
+  })
+  it('defaults to true for a nil author', () => {
+    expect(hasSparseMetadata(undefined)).toBe(true)
+  })
+})

--- a/web/src/util/authorMetadata.ts
+++ b/web/src/util/authorMetadata.ts
@@ -1,0 +1,22 @@
+import type { Author } from '../api/client'
+
+// canLinkAuthorMetadata reports whether an author has no real upstream metadata
+// link yet — unlinked, or created from an Audiobookshelf / Calibre import (those
+// use `abs:` / `calibre:` foreign IDs). The UI offers a "Link metadata" action
+// in that case so a provider record can be attached. A nil author defaults to
+// true (the add-author conflict path may not have a canonical author yet).
+export function canLinkAuthorMetadata(author?: Author): boolean {
+  if (!author) return true
+  const foreignId = (author.foreignAuthorId || '').trim()
+  const provider = (author.metadataProvider || '').trim().toLowerCase()
+  return foreignId === '' || foreignId.startsWith('abs:') || foreignId.startsWith('calibre:') || provider === 'audiobookshelf' || provider === 'calibre'
+}
+
+// hasSparseMetadata reports whether a linked author's record is thin enough to be
+// worth relinking to a richer source: no description, image, disambiguation, or
+// ratings. Drives the "Find better metadata" action. A nil author defaults to
+// true for the same reason as canLinkAuthorMetadata.
+export function hasSparseMetadata(author?: Author): boolean {
+  if (!author) return true
+  return !author.description && !author.imageUrl && !author.disambiguation && (author.ratingsCount ?? 0) === 0 && (author.averageRating ?? 0) === 0
+}


### PR DESCRIPTION
Answers Q&A #1226 ("Why is *Find better metadata* on some authors but not others?") and removes the duplication behind it.

## Docs
New Troubleshooting entry explaining the rule:
- **"Link metadata"** — author unlinked or import-derived (`abs:` / `calibre:` foreign IDs).
- **"Find better metadata"** — author linked but the record is sparse (no description, image, disambiguation, or ratings).
- A populated author hides the button (nothing better to fetch).

## Refactor
`canLinkAuthorMetadata` and `hasSparseMetadata` were **copy-pasted verbatim** in `AuthorDetailPage.tsx` and `AddAuthorModal.tsx`, so the documented behavior had two definitions that could drift. Extracted to `web/src/util/authorMetadata.ts`, imported in both. The shared version keeps the `nil author -> true` guard the add-author conflict path relied on, so **no behavior change**. Added `authorMetadata.test.ts` pinning both predicates (link cases, sparse cases, nil default).

Typecheck / lint / build / full vitest (370) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)