### PR TITLE
feat(web): add Settings → About section showing version and commit (#1235)

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -327,7 +327,16 @@
       "abs": "Audiobookshelf",
       "grimmory": "Grimmory",
       "blocklist": "Blocklist",
-      "apiKeys": "API Keys"
+      "apiKeys": "API Keys",
+      "about": "About"
+    },
+    "about": {
+      "title": "About",
+      "hint": "Build details for this Bindery instance. Include the version and commit when filing a bug report.",
+      "version": "Version",
+      "commit": "Commit",
+      "buildDate": "Build date",
+      "loadError": "Could not load build details."
     },
     "abs": {
       "review": {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -32,12 +32,16 @@ const ApiKeysTab = lazy(() => import('./settings/ApiKeysTab'))
 const ImportTab = lazy(() => import('./settings/ImportTab'))
 const BlocklistTab = lazy(() => import('./settings/BlocklistTab'))
 const LogsTab = lazy(() => import('./settings/LogsTab'))
+const AboutTab = lazy(() => import('./settings/AboutTab'))
 
-type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import' | 'rootfolders' | 'logs' | 'blocklist' | 'calibre' | 'abs' | 'grimmory' | 'api-keys'
+type Tab = 'indexers' | 'clients' | 'notifications' | 'quality' | 'metadata' | 'general' | 'import' | 'rootfolders' | 'logs' | 'blocklist' | 'calibre' | 'abs' | 'grimmory' | 'api-keys' | 'about'
 
 const ADMIN_TABS: Tab[] = ['indexers', 'clients', 'notifications', 'quality', 'metadata', 'import', 'rootfolders', 'logs', 'blocklist', 'calibre', 'abs', 'grimmory', 'api-keys']
 
-const ALL_TABS: Tab[] = ['general', ...ADMIN_TABS]
+// 'general' and 'about' are visible to every authenticated user — About is where
+// the in-app update message and bug_report.yml ("check Settings → About") point
+// users to read their exact version/commit.
+const ALL_TABS: Tab[] = ['general', 'about', ...ADMIN_TABS]
 
 // Allow deep-linking to a specific tab via ?tab=indexers (used by first-run
 // onboarding guidance on the Authors/Books empty states). Read from the URL
@@ -141,6 +145,7 @@ export default function SettingsPage() {
       case 'blocklist': return <BlocklistTab />
       case 'logs': return <LogsTab />
       case 'api-keys': return <ApiKeysTab />
+      case 'about': return <AboutTab />
     }
   }
 
@@ -160,6 +165,7 @@ export default function SettingsPage() {
         {/* Sidebar navigation */}
         <nav className="w-44 flex-shrink-0 space-y-0.5">
           <SettingsNavLink tab="general" active={tab} onSelect={setTab} label={t('settings.tabs.general')} />
+          <SettingsNavLink tab="about" active={tab} onSelect={setTab} label={t('settings.tabs.about', 'About')} />
 
           {isAdmin && (
             <>

--- a/web/src/pages/settings/AboutTab.test.tsx
+++ b/web/src/pages/settings/AboutTab.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+// i18n: t(key) and t(key, 'default string') both render the bare key so
+// assertions stay stable; t(key, {opts}) is unused here.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: unknown) => {
+      if (!options || typeof options !== 'object') return key
+      return key
+    },
+  }),
+}))
+
+vi.mock('../../api/client', () => ({
+  api: {
+    status: vi.fn(),
+  },
+}))
+
+import { api, SystemStatus } from '../../api/client'
+import AboutTab from './AboutTab'
+
+const mockStatus = api.status as ReturnType<typeof vi.fn>
+
+function status(overrides: Partial<SystemStatus> = {}): SystemStatus {
+  return {
+    version: '1.22.1',
+    commit: '9ecd99e',
+    buildDate: '2026-06-01T00:00:00Z',
+    enhancedHardcoverApi: false,
+    hardcoverTokenConfigured: false,
+    ...overrides,
+  }
+}
+
+describe('AboutTab', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders the release version, commit, and build date from /system/status', async () => {
+    mockStatus.mockResolvedValue(status())
+    render(<AboutTab />)
+
+    // Tagged build → "vX.Y.Z" label linking to the tag-specific release.
+    const link = await screen.findByText('v1.22.1')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', 'https://github.com/vavallee/bindery/releases/tag/v1.22.1')
+
+    expect(screen.getByText('9ecd99e')).toBeInTheDocument()
+    expect(screen.getByText('2026-06-01T00:00:00Z')).toBeInTheDocument()
+  })
+
+  it('shows the raw sha and the releases index for an untagged build', async () => {
+    mockStatus.mockResolvedValue(status({ version: 'sha-9ecd99e' }))
+    render(<AboutTab />)
+
+    const link = await screen.findByText('sha-9ecd99e')
+    expect(link).toHaveAttribute('href', 'https://github.com/vavallee/bindery/releases')
+  })
+
+  it('renders a load error when /system/status fails', async () => {
+    mockStatus.mockRejectedValue(new Error('boom'))
+    render(<AboutTab />)
+
+    await waitFor(() =>
+      expect(screen.getByText('settings.about.loadError')).toBeInTheDocument(),
+    )
+  })
+})

--- a/web/src/pages/settings/AboutTab.tsx
+++ b/web/src/pages/settings/AboutTab.tsx
@@ -1,0 +1,90 @@
+import { ReactNode, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api, SystemStatus } from '../../api/client'
+
+// Where the in-app "check Settings → About" guidance (update message,
+// bug_report.yml pre-flight) lands. Surfaces the build identity already exposed
+// by /system/status — the same source the top-right version link reads — so a
+// user filing a bug can copy an exact version/commit instead of guessing from
+// the header sha.
+
+// isRelease mirrors App.tsx's header heuristic: a tagged build reports a
+// semver-ish version (e.g. "1.22.1"); an untagged build reports a sha
+// ("sha-9ecd99e"). Tagged builds get a "vX.Y.Z" label and a tag-specific
+// release link; everything else falls back to the releases index.
+function isRelease(version: string): boolean {
+  return /^\d+\.\d+/.test(version)
+}
+
+function ReleaseLink({ version }: { version: string }) {
+  const href = isRelease(version)
+    ? `https://github.com/vavallee/bindery/releases/tag/v${version}`
+    : 'https://github.com/vavallee/bindery/releases'
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+    >
+      {isRelease(version) ? `v${version}` : version}
+    </a>
+  )
+}
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-2 border-t border-slate-200 dark:border-zinc-800 first:border-t-0 first:pt-0">
+      <span className="text-sm font-medium text-slate-800 dark:text-zinc-200">{label}</span>
+      <span className="text-sm text-slate-600 dark:text-zinc-400 text-right break-all">{children}</span>
+    </div>
+  )
+}
+
+export default function AboutTab() {
+  const { t } = useTranslation()
+  const [status, setStatus] = useState<SystemStatus | null>(null)
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    api.status().then(setStatus).catch(() => setFailed(true))
+  }, [])
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">
+          {t('settings.about.title', 'About')}
+        </h3>
+        <p className="text-xs text-slate-600 dark:text-zinc-500 mb-3">
+          {t('settings.about.hint', 'Build details for this Bindery instance. Include the version and commit when filing a bug report.')}
+        </p>
+        <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+          {failed ? (
+            <p className="text-sm text-slate-600 dark:text-zinc-400">
+              {t('settings.about.loadError', 'Could not load build details.')}
+            </p>
+          ) : !status ? (
+            <p className="text-sm text-slate-600 dark:text-zinc-400">
+              {t('common.loading', 'Loading…')}
+            </p>
+          ) : (
+            <>
+              <Row label={t('settings.about.version', 'Version')}>
+                <ReleaseLink version={status.version} />
+              </Row>
+              <Row label={t('settings.about.commit', 'Commit')}>
+                <code className="font-mono text-xs">{status.commit}</code>
+              </Row>
+              {status.buildDate && (
+                <Row label={t('settings.about.buildDate', 'Build date')}>
+                  <span className="font-mono text-xs">{status.buildDate}</span>
+                </Row>
+              )}
+            </>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

The in-app update message and the bug-report template (`bug_report.yml` pre-flight: *"I'm running the latest version (check Settings → About)"*) both point users to **Settings → About** to read their release, but no such section existed. The only version hint was the `sha-…` string in the header, which users couldn't reliably map to a release. This adds a real **About** section so that guidance lands somewhere useful. Fixes #1235.

## Where the version comes from

No new backend endpoint. The data is the same one the header version link already reads: `GET /system/status` → `SystemStatus { version, commit, buildDate, … }` (served from `cmd/bindery/main.go`, consumed via `api.status()`). The new tab just renders it.

## Implementation notes

- New `web/src/pages/settings/AboutTab.tsx`, lazy-loaded and registered in `SettingsPage.tsx` like every other tab.
- Placed in the **always-visible** nav area next to *General* (not admin-gated) — any user filing a bug needs to read the version.
- Version rendering mirrors the existing header heuristic in `App.tsx`: a tagged build (`/^\d+\.\d+/`) shows `vX.Y.Z` linking to the tag release; an untagged build shows the raw sha linking to the releases index.
- "Update available / on the latest" state is **not** shown: the telemetry `LatestVersion` is not exposed client-side today, and wiring a new backend field was out of scope for this MVP. The `bug_report.yml` text needs no change — it now points at a real location.
- i18n: keys added to `en.json` (`settings.tabs.about`, `settings.about.*`); component uses the `t('key', 'inline default')` form so other locales fall back cleanly.

## Checklist

- [x] Tests added (`AboutTab.test.tsx`)
- [x] Doc-update gate cleared — frontend-only, no env/config/auth/Helm surface touched
- [ ] Wiki — n/a

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test -- AboutTab.test.tsx` — 3 passed (tagged version + link, untagged sha + link, load error)
- [x] `npm test -- SettingsPage.test.tsx` — 51 passed (no regression)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — built

🤖 Generated with [Claude Code](https://claude.com/claude-code)