### PR TITLE
fix(importer): strip Readarr "{Series} #{N} - " prefix from scanned book folders

### DIFF
--- a/internal/importer/parser.go
+++ b/internal/importer/parser.go
@@ -57,7 +57,26 @@ var (
 	// "Series Book N - Title" or "Series Book N: Title" inline pattern (after dot/underscore expansion).
 	// Captures: series name, book number, title (and optional author after another " - ").
 	seriesBookInlineRe = regexp.MustCompile(`(?i)^(.+?)\s+(?:book|vol(?:ume)?|part)\.?\s*(\d+(?:\.\d+)?)\s*[-–:]\s*(.+)$`)
+	// Readarr-style "{Series} #{N} - {Title}" book folder, e.g.
+	// "Discworld #8 - Guards! Guards!" (issue #1234). The hash + number + " - "
+	// separator distinguishes it from an ordinary "Title - Author" name, so the
+	// series prefix can be stripped to recover the real title (and surface the
+	// series + position). Groups: 1=series, 2=number, 3=title.
+	seriesHashTitleRe = regexp.MustCompile(`^(.+?)\s+#(\d+(?:\.\d+)?)\s+[-–]\s+(.+)$`)
 )
+
+// parseSeriesFolder splits a Readarr-style "{Series} #{N} - {Title}" folder or
+// file base name (e.g. "Discworld #8 - Guards! Guards!") into its series,
+// number, and title parts. ok is false when the name does not carry the
+// "#N - " series marker. Unicode dash variants are normalized first so an
+// em-dash separator parses the same as a hyphen (reuses dashNormalizer, #1291).
+func parseSeriesFolder(name string) (series, number, title string, ok bool) {
+	name = dashNormalizer.Replace(name)
+	if m := seriesHashTitleRe.FindStringSubmatch(name); len(m) == 4 {
+		return strings.TrimSpace(m[1]), strings.TrimSpace(m[2]), strings.TrimSpace(m[3]), true
+	}
+	return "", "", "", false
+}
 
 // dashNormalizer rewrites the Unicode dash variants a library or OS might use
 // (Unicode/non-breaking hyphen, figure dash, en dash, em dash, horizontal bar,
@@ -152,6 +171,13 @@ func ParseFilename(path string) ParsedFile {
 		} else if m := seriesParenRe.FindStringSubmatch(dir); len(m) == 3 {
 			p.Series = strings.TrimSpace(m[1])
 			p.SeriesNumber = strings.TrimSpace(m[2])
+		} else if s, n, _, ok := parseSeriesFolder(dir); ok {
+			// Readarr layout: the book folder is "{Series} #{N} - {Title}", e.g.
+			// "Discworld #8 - Guards! Guards!" (issue #1234). Surface the series
+			// and position so the series-position reconciliation fallback can
+			// match books whose title differs from the series opener.
+			p.Series = s
+			p.SeriesNumber = n
 		}
 	}
 	// If we have a series but no number yet, check if the base name leads with one:

--- a/internal/importer/parser_test.go
+++ b/internal/importer/parser_test.go
@@ -218,6 +218,22 @@ func TestParseFilenameSeriesExtraction(t *testing.T) {
 			wantSeriesNum: "1",
 			wantTitle:     "The Final Empire",
 		},
+		{
+			// issue #1234: Readarr "{Series} #{N} - {Title}" book folder.
+			// Series + position come from the parent dir; the title comes from
+			// the "Author - Title" filename so it transposes to the author here —
+			// the library scan corrects the title from the folder layout (#754).
+			name:          "readarr hash series folder surfaces series and position",
+			path:          "/books/Terry Pratchett/Discworld/Discworld #8 - Guards! Guards!/Terry Pratchett - Guards! Guards!.epub",
+			wantSeries:    "Discworld",
+			wantSeriesNum: "8",
+		},
+		{
+			name:          "readarr hash series folder with decimal position",
+			path:          "/books/Terry Pratchett/Discworld/Discworld #16.5 - The Last Hero/Terry Pratchett - The Last Hero.epub",
+			wantSeries:    "Discworld",
+			wantSeriesNum: "16.5",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1607,7 +1607,14 @@ func firstWordRun(tok string) string {
 
 // cleanLayoutTitle strips bracket/paren annotations from a book-folder name —
 // Calibre's " (id)", Readarr's " (year)" — so it matches the stored title.
+// It also strips a leading Readarr "{Series} #{N} - " prefix
+// ("Discworld #8 - Guards! Guards!" → "Guards! Guards!", issue #1234): without
+// this the whole folder name, series tag and all, leaks through as the title
+// and only series openers (where book title == series title) reconcile.
 func cleanLayoutTitle(dir string) string {
+	if _, _, title, ok := parseSeriesFolder(dir); ok {
+		dir = title
+	}
 	s := cleanRe.ReplaceAllString(dir, "")
 	s = multiSp.ReplaceAllString(s, " ")
 	return strings.TrimSpace(s)

--- a/internal/importer/scanner_layout_test.go
+++ b/internal/importer/scanner_layout_test.go
@@ -35,6 +35,21 @@ func TestAuthorTitleFromLayout(t *testing.T) {
 			wantA: "Brandon Sanderson", wantT: "The Final Empire", wantOK: true,
 		},
 		{
+			// issue #1234: Readarr "{Series} #{N} - {Title}" book folder. The
+			// title must be the real book title, not the whole folder string with
+			// the series tag glued on.
+			name:  "readarr series-number book folder strips the series prefix",
+			path:  filepath.Join(root, "Terry Pratchett", "Discworld", "Discworld #8 - Guards! Guards!", "Terry Pratchett - Guards! Guards!.epub"),
+			wantA: "Terry Pratchett", wantT: "Guards! Guards!", wantOK: true,
+		},
+		{
+			// issue #1234 regression guard: a flat non-series book folder that
+			// merely contains a hyphen must NOT be mistaken for a series prefix.
+			name:  "non-series book folder with hyphen is left intact",
+			path:  filepath.Join(root, "Ursula K. Le Guin", "The Dispossessed - An Ambiguous Utopia", "x.epub"),
+			wantA: "Ursula K. Le Guin", wantT: "The Dispossessed - An Ambiguous Utopia", wantOK: true,
+		},
+		{
 			name:  "author folder only",
 			path:  filepath.Join(root, "Isaac Asimov", "foundation.epub"),
 			wantA: "Isaac Asimov", wantT: "", wantOK: true,
@@ -91,5 +106,66 @@ func TestScanLibrary_ReadarrFolderLayoutFixesSwappedFilename(t *testing.T) {
 	}
 	if got.FilePath != epub {
 		t.Errorf("Readarr-layout file must reconcile via the folder names, want FilePath=%q, got %q", epub, got.FilePath)
+	}
+}
+
+// TestScanLibrary_ReadarrSeriesFolderReconcilesNonOpener is the #1234
+// regression test: a Readarr library laid out as
+// {Author}/{Series}/{Series} #{N} - {Title}/{Author} - {Title}.{ext}. Before
+// the fix the book-folder name ("Discworld #8 - Guards! Guards!") leaked through
+// as the parsed title, so only series openers (where book title == series
+// title) reconciled and other books collided on the same title. The scan must
+// strip the "{Series} #{N} - " prefix and reconcile each book to its real title.
+func TestScanLibrary_ReadarrSeriesFolderReconcilesNonOpener(t *testing.T) {
+	libDir := t.TempDir()
+
+	type fixtureBook struct {
+		seriesFolder string // e.g. "Discworld #8 - Guards! Guards!"
+		title        string // stored book title, e.g. "Guards! Guards!"
+	}
+	books := []fixtureBook{
+		{"Discworld #8 - Guards! Guards!", "Guards! Guards!"},
+		{"Discworld #1 - The Colour of Magic", "The Colour of Magic"},
+	}
+
+	paths := make([]string, len(books))
+	for i, b := range books {
+		bookDir := filepath.Join(libDir, "Terry Pratchett", "Discworld", b.seriesFolder)
+		if err := os.MkdirAll(bookDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Readarr's default "{Author} - {Title}.{ext}" filename.
+		epub := filepath.Join(bookDir, "Terry Pratchett - "+b.title+".epub")
+		if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		paths[i] = epub
+	}
+
+	s, bookRepo, authors, ctx := scannerFixture(t, libDir)
+	author := &models.Author{ForeignID: "OL-tp", Name: "Terry Pratchett", SortName: "Pratchett, Terry"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	ids := make([]int64, len(books))
+	for i, b := range books {
+		book := &models.Book{ForeignID: "OL-" + b.title, AuthorID: author.ID, Title: b.title, Status: models.BookStatusWanted}
+		if err := bookRepo.Create(ctx, book); err != nil {
+			t.Fatal(err)
+		}
+		ids[i] = book.ID
+	}
+
+	s.ScanLibrary(ctx)
+
+	for i, b := range books {
+		got, err := bookRepo.GetByID(ctx, ids[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.FilePath != paths[i] {
+			t.Errorf("book %q must reconcile to its own file via the stripped title, want FilePath=%q, got %q",
+				b.title, paths[i], got.FilePath)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

A Readarr library laid out as `{Author}/{Series}/{Series} #{N} - {Title}/{Author} - {Title}.{ext}` left most files unmatched on a library scan (reporter: 222 of 391 files). Only series openers reconciled; other books in a series collided onto one title. This strips the `{Series} #{N} - ` prefix so each book reconciles to its real title. Fixes #1234.

## Root cause

The library scan derives the title from the file's **immediate parent directory** via `authorTitleFromLayout` -> `cleanLayoutTitle`, and that layout-derived title overrides the filename parse (intended behaviour, #754). But `cleanLayoutTitle` only stripped `[bracket]`/`(paren)` annotations, so the Readarr book folder `Discworld #8 - Guards! Guards!` leaked through verbatim as `parsedTitle` — exactly the reporter's symptom. The folder, not the filename, was the leaking component. `ParseFilename`'s parent-dir series fallback only recognised bracket/paren notation, so `Series` + `SeriesNumber` were lost as well, defeating the series-position match tier too.

| Path component | Before | After |
|---|---|---|
| `parsedTitle` (from book folder) | `Discworld #8 - Guards! Guards!` | `Guards! Guards!` |
| `parsedAuthor` (from author folder) | `Terry Pratchett` | `Terry Pratchett` |
| `parsedSeries` / `parsedSeriesNumber` | empty / empty | `Discworld` / `8` |

## Implementation notes

- New unexported `parseSeriesFolder` in `parser.go` splits a `{Series} #{N} - {Title}` name, reusing the existing `dashNormalizer` (#1291) so an em-dash separator parses like a hyphen.
- `cleanLayoutTitle` (scanner) strips the series prefix -> correct title for the title+author tier.
- `ParseFilename`'s parent-dir series fallback gains a `#N` branch -> surfaces `Series`/`SeriesNumber` for the series-position fallback tier.

## Why minimal / scope decisions

The reporter asked for the scan to honour the configured **Book Naming Template** first. That full template-driven matching is a much larger change and is **explicitly NOT in this PR**. The MVP here is the root-cause fix for the specific `{Series} #{N} - {Title}` misparse: strip the prefix, recover the title, surface series + position. Flat layouts (`{Author}/{Title}/{Author} - {Title}.{ext}`) and single-file imports have no `#N - ` marker and are untouched — covered by a regression case.

## Follow-ups (not in this PR)

- Full naming-template-driven library matching.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (no env/config/API/exported-symbol surface changed — internal parsing only)
- [x] Wiki pages updated if user-facing behaviour changed (n/a)

## Test plan

- [x] `go test ./internal/importer/...`
- [x] `go test ./cmd/... ./internal/...`
- [x] `go vet ./...` + `golangci-lint run` (v2.11.4) — 0 issues
- Frontend matrix skipped (backend-only change).

New tests fail against pre-fix source (`reconciled=0, unmatched=2`) and pass after:
- `TestParseFilenameSeriesExtraction` — Readarr `#N` folder surfaces series + decimal position.
- `TestAuthorTitleFromLayout` — series-number folder strips prefix; non-series hyphen folder left intact.
- `TestScanLibrary_ReadarrSeriesFolderReconcilesNonOpener` — full scan, non-opener + opener both reconcile, no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)