### PR TITLE
fix(author): refresh author bio and photo, not just the catalogue

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -374,8 +374,13 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 			if mediaType == "" {
 				mediaType = h.resolveDefaultMediaType(r.Context())
 			}
-			h.fetchAuthorBooksAsync(canonical, req.SearchOnAdd, mediaType)
+			// Finish mutating `canonical` (description clean-up) BEFORE spawning
+			// the async catalogue+profile refresh. fetchAuthorBooksAsync snapshots
+			// the author at spawn time and the goroutine now reads/writes profile
+			// fields (Description, ImageURL, ...); cleaning afterwards would race
+			// the snapshot read against this write (see fetchAuthorBooksAsync).
 			cleanAuthorDescription(canonical)
+			h.fetchAuthorBooksAsync(canonical, req.SearchOnAdd, mediaType)
 			writeJSON(w, http.StatusOK, canonical)
 			return
 		}
@@ -416,11 +421,16 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		mediaType = h.resolveDefaultMediaType(r.Context())
 	}
 
+	// Clean the description BEFORE spawning the async refresh: the goroutine
+	// snapshots `author` and now reads/writes its profile fields (Description,
+	// ImageURL, ...). Cleaning after the spawn would race the snapshot read
+	// against this write (see fetchAuthorBooksAsync).
+	cleanAuthorDescription(author)
+
 	// Fetch and store books for this author. Always populate the catalogue;
 	// pass searchOnAdd so FetchAuthorBooks knows whether to also queue grabs.
 	h.fetchAuthorBooksAsync(author, req.SearchOnAdd, mediaType)
 
-	cleanAuthorDescription(author)
 	writeJSON(w, http.StatusCreated, author)
 }
 

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1300,6 +1300,77 @@ func (h *AuthorHandler) relinkCalibreAuthor(ctx context.Context, author *models.
 	return nil
 }
 
+// refreshAuthorProfile re-fetches the author's profile fields (bio, photo,
+// disambiguation, ratings) from the linked metadata provider and persists any
+// the provider now supplies. The manual "Refresh Metadata" action previously
+// only repopulated the catalogue, leaving the author's own Description and
+// ImageURL empty even after the user added them upstream (Discussion #1226).
+//
+// Best-effort: a missing aggregator, a provider miss, or a save error is logged
+// and swallowed — the catalogue sync that follows must still run. Identity
+// (ForeignID/Name/MetadataProvider) and user-controlled monitoring fields are
+// never touched here; only the read-only profile fields are merged.
+func (h *AuthorHandler) refreshAuthorProfile(ctx context.Context, author *models.Author) {
+	if h.meta == nil || author == nil {
+		return
+	}
+	upstream, err := h.meta.GetAuthor(ctx, author.ForeignID)
+	if err != nil {
+		slog.Warn("author profile refresh: metadata lookup failed",
+			"author", author.Name, "foreignId", author.ForeignID, "error", err)
+		return
+	}
+	if upstream == nil {
+		return
+	}
+	if !mergeAuthorProfileFields(author, upstream) {
+		return // provider returned nothing new — skip a no-op write
+	}
+	now := time.Now().UTC()
+	author.LastMetadataRefreshAt = &now
+	if err := h.authors.Update(ctx, author); err != nil {
+		slog.Warn("author profile refresh: save failed", "author", author.Name, "error", err)
+		return
+	}
+	slog.Info("refreshed author profile from metadata provider",
+		"author", author.Name, "foreignId", author.ForeignID)
+}
+
+// mergeAuthorProfileFields copies provider-supplied profile fields onto the
+// local author, following the project's established "only overwrite when the
+// provider has a non-empty value" merge policy (mirrors
+// relinkExistingAuthorToUpstream). It reports whether any field actually
+// changed so the caller can skip a redundant DB write. SortName is only filled
+// when missing, since the local sort order may have been curated.
+func mergeAuthorProfileFields(author, upstream *models.Author) bool {
+	changed := false
+	if desc := textutil.CleanDescription(upstream.Description); desc != "" && desc != author.Description {
+		author.Description = desc
+		changed = true
+	}
+	if imageURL := strings.TrimSpace(upstream.ImageURL); imageURL != "" && imageURL != author.ImageURL {
+		author.ImageURL = imageURL
+		changed = true
+	}
+	if disambiguation := strings.TrimSpace(upstream.Disambiguation); disambiguation != "" && disambiguation != author.Disambiguation {
+		author.Disambiguation = disambiguation
+		changed = true
+	}
+	if upstream.RatingsCount > 0 && upstream.RatingsCount != author.RatingsCount {
+		author.RatingsCount = upstream.RatingsCount
+		changed = true
+	}
+	if upstream.AverageRating > 0 && upstream.AverageRating != author.AverageRating {
+		author.AverageRating = upstream.AverageRating
+		changed = true
+	}
+	if sn := strings.TrimSpace(upstream.SortName); sn != "" && strings.TrimSpace(author.SortName) == "" {
+		author.SortName = sn
+		changed = true
+	}
+	return changed
+}
+
 // FetchAuthorBooks populates the author's catalogue from the metadata provider.
 // mediaType is applied to each newly-created book when the provider didn't
 // return one; pass an empty string to accept whatever the provider set.
@@ -1313,11 +1384,23 @@ func (h *AuthorHandler) FetchAuthorBooks(author *models.Author, autoSearch bool,
 	// provider by name so the first Refresh Metadata click pulls real data.
 	// If the re-link fails (name not found, network error) we fall through and
 	// keep the synthetic ID, matching the prior skip-silently behaviour.
-	if strings.HasPrefix(author.ForeignID, "calibre:") {
+	wasCalibre := strings.HasPrefix(author.ForeignID, "calibre:")
+	if wasCalibre {
 		if err := h.relinkCalibreAuthor(ctx, author); err != nil {
 			slog.Info("calibre author not re-linked to metadata provider", "author", author.Name, "reason", err)
 			return
 		}
+	}
+
+	// Refresh the author's OWN profile (bio, photo, disambiguation, ratings)
+	// from the metadata provider. Everything below only repopulates the
+	// author's BOOKS; without this step an already-linked author's Description
+	// and ImageURL stay stale on a manual "Refresh Metadata" even after they
+	// appear upstream (Discussion #1226). Calibre authors are skipped here
+	// because relinkCalibreAuthor already pulled and persisted their profile
+	// just above, so re-fetching would only spend a redundant round-trip.
+	if !wasCalibre {
+		h.refreshAuthorProfile(ctx, author)
 	}
 
 	// Use the dedicated author works endpoint for accurate results, with

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -93,6 +93,9 @@ type stubMetaProvider struct {
 	// authorWorksByName lets tests act as an author-scoped supplemental
 	// provider such as Hardcover.
 	authorWorksByName []models.Book
+	// author, when non-nil, is returned by GetAuthor so tests can exercise
+	// the author-profile refresh path (Discussion #1226).
+	author *models.Author
 }
 
 func (p *stubMetaProvider) Name() string {
@@ -108,7 +111,7 @@ func (p *stubMetaProvider) SearchBooks(_ context.Context, _ string) ([]models.Bo
 	return nil, nil
 }
 func (p *stubMetaProvider) GetAuthor(_ context.Context, _ string) (*models.Author, error) {
-	return nil, nil
+	return p.author, nil
 }
 func (p *stubMetaProvider) GetBook(_ context.Context, fid string) (*models.Book, error) {
 	if p.getBookByID != nil {
@@ -332,6 +335,79 @@ func TestFetchAuthorBooks_FiresSearchForMonitoredAuthor(t *testing.T) {
 	titles := spy.titles()
 	if len(titles) != 2 {
 		t.Fatalf("expected 2 searcher calls, got %d: %v", len(titles), titles)
+	}
+}
+
+// TestFetchAuthorBooks_RefreshesAuthorProfile verifies that a metadata refresh
+// repopulates the author's OWN profile fields (description + image) from the
+// linked provider, not just the catalogue. Before the fix the refresh fetched
+// books but left Description/ImageURL empty even when the provider supplied them
+// (Discussion #1226).
+func TestFetchAuthorBooks_RefreshesAuthorProfile(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	ctx := context.Background()
+	// An already-linked OpenLibrary author whose local profile is empty,
+	// mirroring the reporter's "linked but bio/photo blank" state.
+	author := &models.Author{
+		ForeignID: "OL6094856A", Name: "Paul Cornell", SortName: "Cornell, Paul",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	stub := &stubMetaProvider{
+		works: []models.Book{
+			{ForeignID: "OL700W", Title: "London Falling", SortTitle: "london falling", Language: "eng", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+		},
+		author: &models.Author{
+			ForeignID:        "OL6094856A",
+			Name:             "Paul Cornell",
+			Description:      "British writer of novels, comics and TV.",
+			ImageURL:         "https://covers.openlibrary.org/a/id/14431281-L.jpg",
+			Disambiguation:   "British author",
+			RatingsCount:     42,
+			AverageRating:    4.1,
+			MetadataProvider: "openlibrary",
+		},
+	}
+	agg := metadata.NewAggregator(stub)
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, nil, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, "")
+
+	got, err := authorRepo.GetByID(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Description != "British writer of novels, comics and TV." {
+		t.Errorf("Description not refreshed: got %q", got.Description)
+	}
+	if got.ImageURL != "https://covers.openlibrary.org/a/id/14431281-L.jpg" {
+		t.Errorf("ImageURL not refreshed: got %q", got.ImageURL)
+	}
+	if got.Disambiguation != "British author" {
+		t.Errorf("Disambiguation not refreshed: got %q", got.Disambiguation)
+	}
+	if got.RatingsCount != 42 || got.AverageRating != 4.1 {
+		t.Errorf("ratings not refreshed: count=%d avg=%v", got.RatingsCount, got.AverageRating)
+	}
+	if got.LastMetadataRefreshAt == nil {
+		t.Error("LastMetadataRefreshAt not stamped on profile refresh")
+	}
+	// The catalogue must still be populated by the same refresh.
+	books, _ := bookRepo.ListByAuthor(ctx, author.ID)
+	if len(books) != 1 {
+		t.Errorf("expected 1 book synced, got %d", len(books))
 	}
 }
 

--- a/internal/metadata/openlibrary/client_http_test.go
+++ b/internal/metadata/openlibrary/client_http_test.go
@@ -312,6 +312,48 @@ func TestGetAuthor_HTTP_NegativePhoto(t *testing.T) {
 	}
 }
 
+// TestGetAuthor_HTTP_BioShapesAndPhoto pins the author-profile parsing the
+// refresh path depends on (Discussion #1226): the OpenLibrary bio field arrives
+// as either a bare string or a {type,value} object, and the photo arrives as a
+// numeric cover id that must become a covers.openlibrary.org image URL. Both bio
+// shapes must populate Description so a Refresh Metadata can persist them.
+func TestGetAuthor_HTTP_BioShapesAndPhoto(t *testing.T) {
+	cases := []struct {
+		name string
+		bio  interface{}
+	}{
+		{name: "string bio", bio: "British writer of novels, comics and TV."},
+		{name: "object bio", bio: map[string]interface{}{
+			"type":  "/type/text",
+			"value": "British writer of novels, comics and TV.",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := authorResponse{
+				Key:    "/authors/OL6094856A",
+				Name:   "Paul Cornell",
+				Bio:    tc.bio,
+				Photos: []int{14431281},
+			}
+			c := newClientWithPaths(t, map[string]interface{}{
+				"/authors/OL6094856A.json": jsonStr(resp),
+			})
+
+			author, err := c.GetAuthor(context.Background(), "OL6094856A")
+			if err != nil {
+				t.Fatalf("GetAuthor: %v", err)
+			}
+			if author.Description != "British writer of novels, comics and TV." {
+				t.Errorf("Description: want bio text, got %q", author.Description)
+			}
+			if author.ImageURL != "https://covers.openlibrary.org/a/id/14431281-L.jpg" {
+				t.Errorf("ImageURL: want photo cover URL, got %q", author.ImageURL)
+			}
+		})
+	}
+}
+
 // --- GetEditions ---
 
 func TestGetEditions_HTTP(t *testing.T) {


### PR DESCRIPTION
## Summary

Manual **Refresh Metadata** on an author updated the author's book count and book list but left the author's own **bio (Description)** and **photo (ImageURL)** empty, even after the user added them upstream on OpenLibrary. This fixes the refresh to also re-fetch and persist the author's profile from the linked provider. Surfaced in Discussion #1226.

## Root cause

The per-author refresh handler (`AuthorHandler.Refresh` → `fetchAuthorBooksAsync` → `FetchAuthorBooks`) only ever touched the author's **books**. For an already-linked (non-calibre) author it never called `GetAuthor` to re-pull the profile, so `Description`/`ImageURL`/`Disambiguation`/ratings were never written. The only code path that pulled author profile fields was `relinkCalibreAuthor`, gated on a synthetic `calibre:` foreign ID — so a properly-linked OpenLibrary author (e.g. `OL6094856A`) got its catalogue refreshed but its profile skipped entirely.

The OpenLibrary provider was **not** at fault: `openlibrary.Client.GetAuthor` already parses both bio shapes (bare string and `{"type":"/type/text","value":"…"}` via `extractText`) and builds the photo cover URL (`https://covers.openlibrary.org/a/id/{photoId}-L.jpg`). The aggregator's `GetAuthor` returns it intact. The gap was purely the missing fetch-and-save step in the API layer.

## Fix

| Change | Detail |
|--------|--------|
| `FetchAuthorBooks` | After the calibre re-link branch, for non-calibre authors call the new `refreshAuthorProfile` before syncing the catalogue. Calibre authors are skipped here because `relinkCalibreAuthor` already pulled and persisted their profile. |
| `refreshAuthorProfile` (new) | Best-effort: `meta.GetAuthor(foreignID)`, merge profile fields, stamp `LastMetadataRefreshAt`, persist via `authors.Update`. A provider miss or save error is logged, never fatal to the catalogue sync. |
| `mergeAuthorProfileFields` (new) | Applies the project's existing "overwrite only when the provider has a non-empty value" merge policy (mirrors `relinkExistingAuthorToUpstream`). Returns whether anything changed so a no-op write is skipped. Touches only read-only profile fields — never identity or monitoring state. |

## Tests

- `internal/api`: `TestFetchAuthorBooks_RefreshesAuthorProfile` — a linked OL author with an empty local profile; asserts refresh populates Description, ImageURL, Disambiguation, ratings, stamps `LastMetadataRefreshAt`, and still syncs the catalogue.
- `internal/metadata/openlibrary`: `TestGetAuthor_HTTP_BioShapesAndPhoto` — table test over **both** bio shapes (string and `{type,value}` object), asserting Description is populated and the photo id becomes the cover URL. (The existing `TestGetAuthor_HTTP` asserted neither Description nor the object bio shape.)

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (no config/env/exported-symbol/feature-surface changes; new symbols are unexported)
- [x] Wiki pages updated if user-facing behaviour changed (n/a)

## Test plan

- [x] `go test ./internal/metadata/... ./internal/api/... ./internal/db/...` — all pass
- [x] `go vet ./internal/...`
- [x] `gofmt -l` clean on touched files
- [x] `golangci-lint run` (v2.11.4) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)