### PR TITLE
fix(sync): pin list-sync-created authors to monitor mode none (#1290)

### DIFF
--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -691,6 +691,100 @@ func TestFetchAuthorBooks_AppliesAuthorMonitorModes(t *testing.T) {
 	}
 }
 
+// TestFetchAuthorBooks_NoneMode_PreservesListedBook_DropsBackCatalogue is the
+// #1290 reconcile guarantee from the API side. A Hardcover-list-created author
+// is monitored but pinned to MonitorMode "none", and the single listed book was
+// already inserted as monitored + wanted. When the scheduler's catalogue
+// discovery (FetchAuthorBooks) then surfaces the author's whole back-catalogue,
+// the listed book must stay monitored (already-tracked rows are left untouched)
+// while every newly-discovered work stays unmonitored — no back-catalogue
+// blowup.
+func TestFetchAuthorBooks_NoneMode_PreservesListedBook_DropsBackCatalogue(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+
+	author := &models.Author{
+		ForeignID:          "OL-LIST-AUTHOR",
+		Name:               "List Author",
+		SortName:           "Author, List",
+		MetadataProvider:   "openlibrary",
+		Monitored:          true,
+		MonitorMode:        models.AuthorMonitorModeNone,
+		MonitorLatestCount: 1,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	// The listed book, as the syncer inserts it: monitored + wanted, sharing the
+	// foreign id of one of the catalogue works the provider will surface.
+	listed := &models.Book{
+		ForeignID:        "OL-LISTED",
+		Title:            "The Listed Book",
+		AuthorID:         author.ID,
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+		Status:           models.BookStatusWanted,
+		Genres:           []string{},
+	}
+	if err := bookRepo.Create(ctx, listed); err != nil {
+		t.Fatal(err)
+	}
+
+	stub := &stubMetaProvider{
+		works: []models.Book{
+			// The listed book reappears as part of the discovered catalogue.
+			{ForeignID: "OL-LISTED", Title: "The Listed Book", SortTitle: "the listed book", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+			// Back-catalogue the user never asked for.
+			{ForeignID: "OL-BACK1", Title: "Back Catalogue One", SortTitle: "back catalogue one", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+			{ForeignID: "OL-BACK2", Title: "Back Catalogue Two", SortTitle: "back catalogue two", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+			{ForeignID: "OL-BACK3", Title: "Back Catalogue Three", SortTitle: "back catalogue three", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+		},
+	}
+	spy := &searcherSpy{}
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(stub), nil, profileRepo, spy)
+	h.FetchAuthorBooks(author, true, "")
+
+	books, err := bookRepo.ListByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantMonitored := map[string]bool{
+		"The Listed Book":      true,  // preserved
+		"Back Catalogue One":   false, // never auto-wanted
+		"Back Catalogue Two":   false,
+		"Back Catalogue Three": false,
+	}
+	if len(books) != len(wantMonitored) {
+		t.Fatalf("books = %d, want %d: %+v", len(books), len(wantMonitored), books)
+	}
+	for _, b := range books {
+		want, ok := wantMonitored[b.Title]
+		if !ok {
+			t.Fatalf("unexpected book %q", b.Title)
+		}
+		if b.Monitored != want {
+			t.Errorf("%s monitored = %v, want %v", b.Title, b.Monitored, want)
+		}
+	}
+
+	// The discovery pass searches only newly-discovered monitored books. Under
+	// "none" nothing new is monitored, and the already-tracked listed book is
+	// skipped (it was searched when the syncer created it). So this pass must
+	// queue zero searches — in particular none for the back-catalogue.
+	if got := spy.titles(); len(got) != 0 {
+		t.Errorf("unexpected searches queued by discovery pass: %v", got)
+	}
+}
+
 func TestFetchAuthorBooksHydratesOnlySupplementalHardcoverBooks(t *testing.T) {
 	database, err := db.OpenMemory()
 	if err != nil {

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -352,9 +352,18 @@ func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book, nameIn
 		return matched.ID, nil
 	}
 
-	// Create a minimal author record
+	// Create a minimal author record. List-sync authors are kept monitored so
+	// the scheduler refreshes their metadata, but their MonitorMode is pinned to
+	// "none": only the specific book(s) on the user's Hardcover list should end
+	// up wanted, never the author's entire back-catalogue (#1290). The listed
+	// book is monitored explicitly in syncList (book.Monitored = true), and the
+	// catalogue-discovery pass (FetchAuthorBooks) leaves already-tracked books
+	// untouched while gating newly-discovered works on shouldMonitorBookForAuthor
+	// — which returns false under "none". Leaving MonitorMode == "" would instead
+	// make that predicate treat the author as "all" and auto-want every work.
 	author := book.Author
 	author.Monitored = true
+	author.MonitorMode = models.AuthorMonitorModeNone
 	author.MetadataProvider = "hardcover"
 	if author.SortName == "" {
 		author.SortName = sortName(author.Name)

--- a/internal/hardcoverlistsyncer/syncer_test.go
+++ b/internal/hardcoverlistsyncer/syncer_test.go
@@ -192,6 +192,72 @@ func TestSyncOne_ReusesAuthorByNameAndDedupsOwnedBook(t *testing.T) {
 	}
 }
 
+// TestSyncOne_NewAuthorPinnedToMonitorModeNone is the #1290 regression: a list
+// whose book belongs to a brand-new author must create that author with
+// MonitorMode == "none", not the zero value "". An empty MonitorMode is treated
+// as "all" by shouldMonitorBookForAuthor, which makes the scheduler's later
+// catalogue-discovery pass auto-want the author's entire back-catalogue. Only
+// the single listed book may end up monitored + wanted.
+func TestSyncOne_NewAuthorPinnedToMonitorModeNone(t *testing.T) {
+	s, repo := newTestSyncer(t)
+	ctx := context.Background()
+
+	il := testImportList("HC", "hardcover", true)
+	if err := repo.Create(ctx, &il); err != nil {
+		t.Fatalf("seed list: %v", err)
+	}
+
+	newAuthor := func() *models.Author {
+		return &models.Author{ForeignID: "hc:newauthor", Name: "Brand New Author", MetadataProvider: "hardcover"}
+	}
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
+			lists: []hardcover.HCList{{ID: 7, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{
+				{ForeignID: "hc:listed", Title: "The Listed Book", MetadataProvider: "hardcover", Author: newAuthor()},
+			},
+		}
+	})
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne: %v", err)
+	}
+
+	created, err := s.authors.GetByAnyForeignID(ctx, "hc:newauthor")
+	if err != nil {
+		t.Fatalf("GetByAnyForeignID: %v", err)
+	}
+	if created == nil {
+		t.Fatal("expected the new author to be created")
+	}
+	// Author stays monitored (so metadata refresh keeps running)...
+	if !created.Monitored {
+		t.Errorf("new author Monitored = false, want true")
+	}
+	// ...but MonitorMode must be "none" so the back-catalogue is never auto-wanted.
+	if created.MonitorMode != models.AuthorMonitorModeNone {
+		t.Errorf("new author MonitorMode = %q, want %q (#1290)", created.MonitorMode, models.AuthorMonitorModeNone)
+	}
+
+	// The single listed book is monitored + wanted.
+	books, err := s.books.ListByAuthor(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("ListByAuthor: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("expected exactly the 1 listed book, got %d: %+v", len(books), books)
+	}
+	if books[0].Title != "The Listed Book" {
+		t.Errorf("listed book title = %q, want %q", books[0].Title, "The Listed Book")
+	}
+	if !books[0].Monitored {
+		t.Errorf("listed book Monitored = false, want true")
+	}
+	if books[0].Status != models.BookStatusWanted {
+		t.Errorf("listed book Status = %q, want %q", books[0].Status, models.BookStatusWanted)
+	}
+}
+
 func TestSortName(t *testing.T) {
 	tests := []struct {
 		in, want string


### PR DESCRIPTION
## Summary

Hardcover list sync was auto-wanting an author's entire back-catalogue. A 235-book "Want to Read" list created 321 authors and ballooned wanted from ~167 to ~2,018 (~6×). This pins newly list-sync-created authors to `MonitorMode = none` so only the books actually on the list end up wanted. Fixes #1290.

## Root cause

`internal/hardcoverlistsyncer/syncer.go` created new authors with `author.Monitored = true` but never set `author.MonitorMode`, leaving it the zero value `""`. In `internal/api/authors.go`, `shouldMonitorBookForAuthor` does `case models.AuthorMonitorModeAll, "": return true` — an empty mode is treated identically to `all`. So when the catalogue-discovery pass (`FetchAuthorBooks`) later runs for that author, **every** newly-discovered work is flipped to monitored + wanted, not just the listed book.

## Fix / design decision

Set `author.MonitorMode = models.AuthorMonitorModeNone` in `ensureAuthor`'s **create** branch only.

**Why `none` and not the configured default?** The install-wide default (`author.default_monitor_mode`, `resolveDefaultAuthorMonitorMode`) defaults to `all` and can be set to `all` by the user. Honoring it would reproduce the exact bug. The intent of list sync is "want precisely the books on this list", so `none` is the only author-level mode that is safe regardless of configuration. The syncer also has no settings dependency wired in, so hard-coding `none` is both correct and minimal.

**How the listed book stays wanted.** The per-book `book.Monitored = true` / `Status = wanted` is set explicitly in `syncList` before insert — independent of the author's mode. The author stays `Monitored = true` (so scheduled metadata refresh keeps running), but with mode `none`:

| Path | Listed book | Back-catalogue |
|------|-------------|----------------|
| `FetchAuthorBooks` discovery | already-tracked row, matched by foreign id, **Monitored left untouched** (only ratings/genres updated), stays wanted | new rows, `shouldMonitorBookForAuthor` returns `false` under `none`, not monitored |

`applyMonitorModeToExistingBooks` (which *would* unmonitor everything under `none`) is **not** on any automatic path — it only runs from the PATCH author handler when the user explicitly checks "apply to existing". So the listed book is never auto-unmonitored.

**Existing authors are unaffected** — the find-by-foreign-id and find-by-name branches of `ensureAuthor` return early and never touch `MonitorMode`.

## Tests

- `internal/hardcoverlistsyncer/syncer_test.go` — `TestSyncOne_NewAuthorPinnedToMonitorModeNone`: a list with one book by a brand-new author, author created `Monitored=true, MonitorMode=none`, the single listed book is monitored + wanted.
- `internal/api/authors_test.go` — `TestFetchAuthorBooks_NoneMode_PreservesListedBook_DropsBackCatalogue`: end-to-end reconcile. A `none`-mode author with a pre-existing monitored+wanted listed book; the discovery pass surfaces the listed book plus three back-catalogue works, listed book stays monitored, all three back-catalogue works land unmonitored, zero searches queued.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (no env/config/exported-symbol/user-facing-workflow change; godoc comment added at the fix site)
- [x] Wiki pages updated if user-facing behaviour changed (n/a)

## Test plan

- [x] `gofmt -l .` (clean)
- [x] `go vet ./...`
- [x] `golangci-lint run` (v2.11.4) on changed packages — 0 issues
- [x] `go test ./internal/hardcoverlistsyncer/... ./internal/api/...`
- [x] `go test ./...` (full suite green)
- [x] `govulncheck ./...` — no vulnerabilities
- [ ] frontend matrix — n/a (backend-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)