### PR TITLE
fix(downloader): enable qBittorrent autoTMM and omit savepath when a category is set

### DIFF
--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -20,6 +20,14 @@ If Bindery and the download client see the storage at different paths (different
 
 **Fix:** set a download-client path remap in **Settings → Download clients**, then use **Queue → Retry import**. See [Path remapping](./DEPLOYMENT.md#path-remapping-multi-container--multi-pod-setups) in `DEPLOYMENT.md`.
 
+### qBittorrent files land in the download root instead of the category folder
+
+The torrent shows the right **category** label in qBittorrent, but the files are written to the download root (e.g. `/data/downloads`) instead of the category's configured save path (e.g. `/data/downloads/torrents/audiobooks`). The poller can't find them there and the import never starts.
+
+This happened on Bindery **1.22.1 and earlier**: Bindery sent the category **and** an explicit save path with automatic torrent management (auto_tmm) off. With auto_tmm off, an explicit save path overrides the category's save path, so qBittorrent dropped the files in the root.
+
+**Fix:** upgrade to the current release. Bindery now enables auto_tmm and omits the explicit save path whenever a category is set, so qBittorrent places files at the category's configured save path (the source of truth for Bindery's health checks). On an older version, work around it by enabling **Automatic Torrent Management** for the category in qBittorrent, or by setting the category's save path to match Bindery's download root.
+
 ## "Could not reach the metadata provider" / OpenLibrary timeout
 
 ```

--- a/internal/downloader/adapter_test.go
+++ b/internal/downloader/adapter_test.go
@@ -661,9 +661,12 @@ func TestSendDownload_QbittorrentAudiobookSavePath(t *testing.T) {
 // TestSendDownload_QbittorrentAudiobookCategory verifies that when a client has
 // CategoryAudiobook set and the send is for an audiobook, the qBittorrent
 // `category` form field reflects the audiobook category — not the ebook one
-// (#700). The savepath is also validated to round-trip the audiobook dir.
+// (#700). Because a category is set, the client must enable autoTMM and omit
+// the explicit savepath so qBittorrent honours the category's save path (cleb's
+// bug); the adapter still computes a savePath but the qBit client suppresses it.
 func TestSendDownload_QbittorrentAudiobookCategory(t *testing.T) {
-	var gotCategory, gotSavePath string
+	var gotCategory, gotAutoTMM string
+	var savePathPresent bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v2/auth/login":
@@ -671,7 +674,8 @@ func TestSendDownload_QbittorrentAudiobookCategory(t *testing.T) {
 		case "/api/v2/torrents/add":
 			_ = r.ParseForm()
 			gotCategory = r.FormValue("category")
-			gotSavePath = r.FormValue("savepath")
+			gotAutoTMM = r.FormValue("autoTMM")
+			_, savePathPresent = r.Form["savepath"]
 			_, _ = w.Write([]byte("Ok."))
 		case "/api/v2/torrents/info":
 			_, _ = w.Write([]byte("[]"))
@@ -700,8 +704,11 @@ func TestSendDownload_QbittorrentAudiobookCategory(t *testing.T) {
 	if gotCategory != "audiobooks" {
 		t.Errorf("category: want %q, got %q", "audiobooks", gotCategory)
 	}
-	if gotSavePath != "/media/audio-downloads" {
-		t.Errorf("savepath: want %q, got %q", "/media/audio-downloads", gotSavePath)
+	if gotAutoTMM != "true" {
+		t.Errorf("autoTMM: want 'true', got %q", gotAutoTMM)
+	}
+	if savePathPresent {
+		t.Error("savepath must NOT be sent when a category is set")
 	}
 }
 

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -202,6 +202,52 @@ func (c *Client) SetShareLimits(ctx context.Context, hash string, ratioLimit flo
 	return nil
 }
 
+// addTorrentFields resolves the category / autoTMM / savepath fields for a
+// POST /torrents/add request, gating on whether a category is set.
+//
+// When a category is set it is the source of truth for placement: Bindery's
+// health checks validate that the category's configured save path maps to
+// Bindery's download dir, so we enable qBittorrent's automatic torrent
+// management (autoTMM=true) and DO NOT send an explicit savepath. With
+// auto_tmm off and an explicit savepath, qBittorrent ignores the category's
+// save path and dumps files in the download root (cleb's report: files land
+// in /data/downloads instead of /data/downloads/torrents/audiobooks).
+//
+// When no category is set we keep the legacy behaviour: send the explicit
+// savepath (if any) and leave autoTMM off.
+func addTorrentFields(category, savePath string) map[string]string {
+	if category != "" {
+		return map[string]string{
+			"category": category,
+			"autoTMM":  "true",
+		}
+	}
+	if savePath != "" {
+		return map[string]string{"savepath": savePath}
+	}
+	return nil
+}
+
+// setAddTorrentFields writes the gated add fields onto a url.Values form
+// (magnet / url-encoded add branches).
+func setAddTorrentFields(form url.Values, category, savePath string) {
+	for k, v := range addTorrentFields(category, savePath) {
+		form.Set(k, v)
+	}
+}
+
+// writeAddTorrentFields writes the gated add fields onto a multipart writer
+// (torrent-file upload branch). Mirrors setAddTorrentFields so the three add
+// branches can't drift.
+func writeAddTorrentFields(mw *multipart.Writer, category, savePath string) error {
+	for k, v := range addTorrentFields(category, savePath) {
+		if err := mw.WriteField(k, v); err != nil {
+			return fmt.Errorf("write torrent %s: %w", k, err)
+		}
+	}
+	return nil
+}
+
 // AddTorrent submits a magnet link or torrent URL to qBittorrent for download
 // and returns the torrent hash when it can be determined.
 func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath string) (string, error) {
@@ -249,12 +295,7 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 		if fetched.magnetURL != "" {
 			submitted = fetched.magnetURL
 			form := url.Values{"urls": {fetched.magnetURL}}
-			if category != "" {
-				form.Set("category", category)
-			}
-			if savePath != "" {
-				form.Set("savepath", savePath)
-			}
+			setAddTorrentFields(form, category, savePath)
 			req, err = http.NewRequestWithContext(ctx, http.MethodPost,
 				c.baseURL+"/api/v2/torrents/add",
 				strings.NewReader(form.Encode()))
@@ -273,15 +314,8 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 			if _, err := fw.Write(fetched.data); err != nil {
 				return "", fmt.Errorf("write torrent content: %w", err)
 			}
-			if category != "" {
-				if err := mw.WriteField("category", category); err != nil {
-					return "", fmt.Errorf("write torrent category: %w", err)
-				}
-			}
-			if savePath != "" {
-				if err := mw.WriteField("savepath", savePath); err != nil {
-					return "", fmt.Errorf("write torrent savepath: %w", err)
-				}
+			if err := writeAddTorrentFields(mw, category, savePath); err != nil {
+				return "", err
 			}
 			if err := mw.Close(); err != nil {
 				return "", fmt.Errorf("close multipart: %w", err)
@@ -296,12 +330,7 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 		}
 	} else {
 		form := url.Values{"urls": {magnetOrURL}}
-		if category != "" {
-			form.Set("category", category)
-		}
-		if savePath != "" {
-			form.Set("savepath", savePath)
-		}
+		setAddTorrentFields(form, category, savePath)
 		var err error
 		req, err = http.NewRequestWithContext(ctx, http.MethodPost,
 			c.baseURL+"/api/v2/torrents/add",
@@ -338,6 +367,14 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 				// listing recovers category-missed torrents), but this is the root
 				// cause of the #969 cross-seed wedge, so surface it.
 				slog.Warn("add torrent: failed to set category on existing torrent",
+					"hash", hash, "category", category, "error", err)
+			}
+			// Enable automatic torrent management so the (possibly externally-added)
+			// torrent relocates to the category's configured save path rather than
+			// staying wherever it was manually placed. Best-effort: a failure here
+			// must not fail the grab.
+			if err := c.setAutoManagement(ctx, hash, true); err != nil {
+				slog.Warn("add torrent: failed to enable auto-management on existing torrent",
 					"hash", hash, "category", category, "error", err)
 			}
 		}
@@ -406,6 +443,13 @@ func (c *Client) AddTorrent(ctx context.Context, magnetOrURL, category, savePath
 					// Best-effort, but a torrent left outside Bindery's category
 					// is invisible to the category-filtered poll (#969/#939).
 					slog.Warn("add torrent: failed to set category on recovered torrent",
+						"hash", hash, "category", category, "error", err)
+				}
+				// Enable automatic torrent management so the torrent relocates to
+				// the category's configured save path. Best-effort: a failure here
+				// must not fail the grab.
+				if err := c.setAutoManagement(ctx, hash, true); err != nil {
+					slog.Warn("add torrent: failed to enable auto-management on recovered torrent",
 						"hash", hash, "category", category, "error", err)
 				}
 			}
@@ -697,6 +741,38 @@ func (c *Client) setCategory(ctx context.Context, hash, category string) error {
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+// setAutoManagement toggles qBittorrent's automatic torrent management for a
+// torrent by hash via POST /api/v2/torrents/setAutoManagement. With it enabled
+// the torrent is relocated to its category's configured save path, which is the
+// behaviour Bindery relies on when re-categorising an existing/duplicate
+// torrent that may have been added with a manual savepath and auto_tmm off.
+func (c *Client) setAutoManagement(ctx context.Context, hash string, enable bool) error {
+	if err := c.ensureLoggedIn(ctx); err != nil {
+		return err
+	}
+	form := url.Values{
+		"hashes": {hash},
+		"enable": {strconv.FormatBool(enable)},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/api/v2/torrents/setAutoManagement",
+		strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("build setAutoManagement request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("setAutoManagement: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("setAutoManagement HTTP %d", resp.StatusCode)
+	}
 	return nil
 }
 

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -484,8 +484,14 @@ func TestAddTorrent_Success(t *testing.T) {
 	}
 }
 
-func TestAddTorrent_WithCategoryAndSavePath(t *testing.T) {
-	var gotCategory, gotSavePath string
+// TestAddTorrent_WithCategory_EnablesAutoTMMAndOmitsSavePath is the regression
+// test for cleb's bug (qBittorrent 5.2.1): when a category is set, Bindery must
+// enable autoTMM and NOT send an explicit savepath, so qBittorrent places the
+// torrent at the category's configured save path rather than the download root.
+// Bindery passes a computed savePath here, but it must be suppressed.
+func TestAddTorrent_WithCategory_EnablesAutoTMMAndOmitsSavePath(t *testing.T) {
+	var gotCategory, gotAutoTMM string
+	var savePathPresent bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/v2/auth/login":
@@ -493,7 +499,8 @@ func TestAddTorrent_WithCategoryAndSavePath(t *testing.T) {
 		case "/api/v2/torrents/add":
 			_ = r.ParseForm()
 			gotCategory = r.FormValue("category")
-			gotSavePath = r.FormValue("savepath")
+			gotAutoTMM = r.FormValue("autoTMM")
+			_, savePathPresent = r.Form["savepath"]
 			_, _ = w.Write([]byte("Ok."))
 		}
 	}))
@@ -506,8 +513,41 @@ func TestAddTorrent_WithCategoryAndSavePath(t *testing.T) {
 	if gotCategory != "books" {
 		t.Errorf("category: want 'books', got %q", gotCategory)
 	}
+	if gotAutoTMM != "true" {
+		t.Errorf("autoTMM: want 'true', got %q", gotAutoTMM)
+	}
+	if savePathPresent {
+		t.Error("savepath must NOT be sent when a category is set (defeats the category save path)")
+	}
+}
+
+// TestAddTorrent_NoCategory_SendsSavePathNoAutoTMM verifies the legacy behaviour
+// is preserved when no category is set: the explicit savepath is sent and
+// autoTMM is not enabled.
+func TestAddTorrent_NoCategory_SendsSavePathNoAutoTMM(t *testing.T) {
+	var gotSavePath, gotAutoTMM string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/add":
+			_ = r.ParseForm()
+			gotSavePath = r.FormValue("savepath")
+			gotAutoTMM = r.FormValue("autoTMM")
+			_, _ = w.Write([]byte("Ok."))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	if _, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:abc", "", "/downloads"); err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
 	if gotSavePath != "/downloads" {
 		t.Errorf("savepath: want '/downloads', got %q", gotSavePath)
+	}
+	if gotAutoTMM == "true" {
+		t.Errorf("autoTMM must not be 'true' when no category is set, got %q", gotAutoTMM)
 	}
 }
 
@@ -646,10 +686,12 @@ func TestAddTorrent_TorrentURL_SubmitsMultipart(t *testing.T) {
 	}
 }
 
-// TestAddTorrent_TorrentURL_WithCategoryAndSavePath verifies that category and
-// savepath are included in the multipart body when submitting a torrent URL.
-func TestAddTorrent_TorrentURL_WithCategoryAndSavePath(t *testing.T) {
-	var gotCategory, gotSavePath string
+// TestAddTorrent_TorrentURL_WithCategory_EnablesAutoTMMAndOmitsSavePath is the
+// torrent-file (multipart) counterpart to cleb's bug: a category-set add via the
+// multipart upload branch must carry category + autoTMM=true and omit savepath.
+func TestAddTorrent_TorrentURL_WithCategory_EnablesAutoTMMAndOmitsSavePath(t *testing.T) {
+	var gotCategory, gotAutoTMM string
+	var savePathPresent bool
 	var mu sync.Mutex
 	added := false
 
@@ -663,7 +705,8 @@ func TestAddTorrent_TorrentURL_WithCategoryAndSavePath(t *testing.T) {
 		case "/api/v2/torrents/add":
 			if err := r.ParseMultipartForm(1 << 20); err == nil {
 				gotCategory = r.FormValue("category")
-				gotSavePath = r.FormValue("savepath")
+				gotAutoTMM = r.FormValue("autoTMM")
+				_, savePathPresent = r.Form["savepath"]
 			}
 			mu.Lock()
 			added = true
@@ -678,6 +721,8 @@ func TestAddTorrent_TorrentURL_WithCategoryAndSavePath(t *testing.T) {
 			} else {
 				_, _ = w.Write([]byte("[]"))
 			}
+		case "/api/v2/torrents/setCategory", "/api/v2/torrents/setAutoManagement":
+			w.WriteHeader(http.StatusOK)
 		}
 	}))
 	defer srv.Close()
@@ -690,8 +735,107 @@ func TestAddTorrent_TorrentURL_WithCategoryAndSavePath(t *testing.T) {
 	if gotCategory != "books" {
 		t.Errorf("category: want %q, got %q", "books", gotCategory)
 	}
-	if gotSavePath != "/downloads" {
-		t.Errorf("savepath: want %q, got %q", "/downloads", gotSavePath)
+	if gotAutoTMM != "true" {
+		t.Errorf("autoTMM: want 'true', got %q", gotAutoTMM)
+	}
+	if savePathPresent {
+		t.Error("savepath must NOT be sent in the multipart body when a category is set")
+	}
+}
+
+// TestSetAutoManagement verifies the new setAutoManagement helper hits the
+// correct endpoint with the hash and enable=true form fields.
+func TestSetAutoManagement(t *testing.T) {
+	var gotHash, gotEnable string
+	var hit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/setAutoManagement":
+			_ = r.ParseForm()
+			gotHash = r.FormValue("hashes")
+			gotEnable = r.FormValue("enable")
+			hit = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	c.loggedIn = true
+	if err := c.setAutoManagement(context.Background(), "abc123", true); err != nil {
+		t.Fatalf("setAutoManagement: %v", err)
+	}
+	if !hit {
+		t.Fatal("expected setAutoManagement endpoint to be hit")
+	}
+	if gotHash != "abc123" {
+		t.Errorf("hashes: want 'abc123', got %q", gotHash)
+	}
+	if gotEnable != "true" {
+		t.Errorf("enable: want 'true', got %q", gotEnable)
+	}
+}
+
+// TestAddTorrent_DuplicateRecovery_EnablesAutoManagement verifies that the 409
+// duplicate-recovery path re-categorises the existing torrent AND enables
+// automatic torrent management so it relocates to the category's save path.
+func TestAddTorrent_DuplicateRecovery_EnablesAutoManagement(t *testing.T) {
+	const hash = "abcdef123"
+	var setCategoryHash, setCategoryValue, autoMgmtHash, autoMgmtEnable string
+	var mu sync.Mutex
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte("[]"))
+		case "/api/v2/torrents/add":
+			// qBittorrent already holds the torrent.
+			w.WriteHeader(http.StatusConflict)
+		case "/api/v2/torrents/setCategory":
+			_ = r.ParseForm()
+			mu.Lock()
+			setCategoryHash = r.FormValue("hashes")
+			setCategoryValue = r.FormValue("category")
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case "/api/v2/torrents/setAutoManagement":
+			_ = r.ParseForm()
+			mu.Lock()
+			autoMgmtHash = r.FormValue("hashes")
+			autoMgmtEnable = r.FormValue("enable")
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	c.loggedIn = true
+	got, err := c.AddTorrent(context.Background(), "magnet:?xt=urn:btih:"+hash, "books", "/downloads")
+	if err != nil {
+		t.Fatalf("AddTorrent: %v", err)
+	}
+	if got != hash {
+		t.Errorf("hash: want %q, got %q", hash, got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if setCategoryHash != hash || setCategoryValue != "books" {
+		t.Errorf("setCategory: want hash=%q category=books, got hash=%q category=%q", hash, setCategoryHash, setCategoryValue)
+	}
+	if autoMgmtHash != hash {
+		t.Errorf("setAutoManagement hashes: want %q, got %q", hash, autoMgmtHash)
+	}
+	if autoMgmtEnable != "true" {
+		t.Errorf("setAutoManagement enable: want 'true', got %q", autoMgmtEnable)
 	}
 }
 


### PR DESCRIPTION
## Summary

On a qBittorrent grab Bindery applied the right **category** label but the files landed in the download root (e.g. `/data/downloads`) instead of the category's configured save path (e.g. `/data/downloads/torrents/audiobooks`), so the poller never found them and import never ran. Reported by **cleb** (qBittorrent 5.2.1, Bindery v1.22.1).

## Root cause

On every add Bindery sent **both** the `category` **and** an explicit `savepath` (its download root, computed by `qbitSavePath` in `adapter.go` via inverse path-remap) but **never set `autoTMM`**. qBit's debug showed `{ "category": "audiobooks", "auto_tmm": false, "savePath": "/data/downloads" }`. With `auto_tmm` off, an explicit `savepath` **overrides** the category's configured save path, so qBittorrent dropped files in the root. Bindery's health checks (`internal/downloader/health.go`) already validate the **category's** save path against Bindery's dir, so the category is the intended source of truth — the explicit savepath defeated it.

## The fix (gated on whether a category is set)

| `category` | `autoTMM` | `savepath` |
|-----------|-----------|------------|
| set       | `true`    | omitted (qBit uses the category's save path) |
| empty     | not sent  | sent if non-empty (legacy behaviour preserved) |

- Factored the field-setting into `addTorrentFields` + `setAddTorrentFields` (url.Values) / `writeAddTorrentFields` (multipart) so all **three** add branches — magnet via `url.Values`, torrent-file via multipart, and url-encoded — can't drift.
- Added `setAutoManagement(ctx, hash, enable)` hitting `POST /api/v2/torrents/setAutoManagement` (`hashes=<hash>&enable=true`), mirroring `setCategory`.
- Wired `setAutoManagement(..., true)` into **both** recovery paths after `setCategory` — the 409 duplicate-recovery and the hash-poll fallback — so externally-added / duplicate torrents also relocate to the category path. Best-effort: failures log a warning and never fail the grab.

The adapter's `qbitSavePath` computation is unchanged; the gating lives in the qBit client where category semantics belong (and `autoTMM` can only be set on the add request, which the adapter can't reach).

## Blast radius

qBittorrent **only**. Deluge, Transmission, NZBGet and SABnzbd were audited and are unaffected — none send a qBit-style category+savepath pair, and only the qBit client has this auto_tmm interaction.

## Tests

- `TestAddTorrent_WithCategory_EnablesAutoTMMAndOmitsSavePath` (magnet) and `TestAddTorrent_TorrentURL_WithCategory_EnablesAutoTMMAndOmitsSavePath` (torrent-file/multipart): assert `autoTMM=true` and no `savepath` when a category is set. Both verified to **fail against the pre-fix field logic**.
- `TestAddTorrent_NoCategory_SendsSavePathNoAutoTMM`: empty category, non-empty savePath → `savepath` sent, `autoTMM` not `true`.
- `TestSetAutoManagement`: correct endpoint, `hashes`, `enable=true`.
- `TestAddTorrent_DuplicateRecovery_EnablesAutoManagement`: 409 path calls `setCategory` then `setAutoManagement(enable=true)`.
- Updated `TestSendDownload_QbittorrentAudiobookCategory` (adapter) to the new gated behaviour.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — added a Troubleshooting-Wiki entry ("qBittorrent files land in the download root instead of the category folder")
- [x] Wiki pages updated (`docs/Troubleshooting-Wiki.md`)

## Test plan

- [x] `gofmt -l internal/downloader/` (clean)
- [x] `go vet ./...` (clean)
- [x] `golangci-lint run --timeout=5m` v2.11.4 (0 issues)
- [x] `govulncheck ./internal/downloader/...` (no vulnerabilities)
- [x] `go test -race ./internal/downloader/...` (clean — including the race detector)
- [x] `go test ./internal/... ./cmd/...` (all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)