### PR TITLE
chore(deploy): point telemetry-server manifest at the poller image

### DIFF
--- a/deploy/telemetry-server.yaml
+++ b/deploy/telemetry-server.yaml
@@ -40,7 +40,12 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ping
-          image: ghcr.io/vavallee/bindery-ping:sha-a91386de6543efb3c90235436a72bd29d6b5fd04
+          # Carries the latest-release poller (#1289): on boot it seeds
+          # LATEST_VERSION below, then keeps `latest` in sync with the newest
+          # GitHub release every 30m. Deploys here are manual (the cluster is
+          # unreachable from CI runners), so bump this sha when rolling a new
+          # telemetry-server build.
+          image: ghcr.io/vavallee/bindery-ping:sha-c2c0e1a36e0eca286a792630deb8e41fe7978df3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -51,8 +56,14 @@ spec:
           env:
             - name: DB_PATH
               value: /data/telemetry.db
+            # Boot-time fallback only; the poller (#1289) overrides this from the
+            # GitHub Releases API within a second of startup. Kept current so the
+            # advertised version is sane even if GitHub is unreachable at boot.
             - name: LATEST_VERSION
-              value: v1.11.0
+              value: v1.22.2
+            # Repo the poller queries for the newest release (defaults to this).
+            - name: GITHUB_REPO
+              value: vavallee/bindery
             - name: STATS_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## What

`deploy/telemetry-server.yaml` had drifted from the live `bindery-ping` deployment. It pinned `bindery-ping:sha-a91386de` with `LATEST_VERSION=v1.11.0`, while prod now runs the #1289 latest-release poller build. A stray `kubectl apply` of the old manifest would have reverted the poller and downgraded the advertised version.

## Changes
- Image → deployed poller sha `c2c0e1a` (#1289 build); comment notes deploys here are manual (cluster unreachable from CI runners).
- `LATEST_VERSION` seed `v1.11.0` → `v1.22.2` (boot fallback only; poller overrides from GitHub Releases ~1s after start).
- Record `GITHUB_REPO=vavallee/bindery` explicitly (was the in-code default).

## Why now
While fixing the stale Discord 'Latest' channel after v1.22.2, I deployed the poller image to prod. This makes the repo match that reality. No behavior change to the running deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)