### PR TITLE
fix(api): include configured root folders in download path allow-list

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -561,7 +561,8 @@ func main() {
 	}
 
 	libraryHandler := api.NewLibraryHandler(importScanner).WithSettings(settingsRepo)
-	fileHandler := api.NewFileHandler(bookRepo, cfg.LibraryDir, cfg.AudiobookDir)
+	fileHandler := api.NewFileHandler(bookRepo, cfg.LibraryDir, cfg.AudiobookDir).
+		WithRootFolders(rootFolderRepo)
 	historyHandler := api.NewHistoryHandler(historyRepo, blocklistRepo, bookRepo)
 	blocklistHandler := api.NewBlocklistHandler(blocklistRepo)
 	notificationHandler := api.NewNotificationHandler(notificationRepo, notif)

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"archive/zip"
+	"context"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -19,6 +21,14 @@ import (
 type FileHandler struct {
 	books        *db.BookRepo
 	allowedRoots []string
+	// rootFolders, when set, is consulted at REQUEST TIME so the download
+	// allow-list also covers user-configured root folders (rows in the
+	// root_folders table). The importer writes book files under these roots
+	// — which can live on a different mount than the static LibraryDir /
+	// AudiobookDir — so a startup-captured static list would wrongly deny
+	// downloads for the standard root-folder setup, and would miss folders
+	// created after boot. nil disables the dynamic check (static roots only).
+	rootFolders *db.RootFolderRepo
 }
 
 func NewFileHandler(books *db.BookRepo, allowedRoots ...string) *FileHandler {
@@ -29,6 +39,16 @@ func NewFileHandler(books *db.BookRepo, allowedRoots ...string) *FileHandler {
 		}
 	}
 	return &FileHandler{books: books, allowedRoots: roots}
+}
+
+// WithRootFolders attaches the root folder repo so the download allow-list can
+// include user-configured root folder paths resolved at request time. Mirrors
+// the scanner's WithRootFolders wiring (internal/importer/scanner.go) for
+// consistency. Returns the handler for chaining. Safe to omit: when unset only
+// the static roots (LibraryDir / AudiobookDir) are allowed.
+func (h *FileHandler) WithRootFolders(rf *db.RootFolderRepo) *FileHandler {
+	h.rootFolders = rf
+	return h
 }
 
 // Download serves the book's content for browser download.
@@ -72,7 +92,7 @@ func (h *FileHandler) Download(w http.ResponseWriter, r *http.Request) {
 	// Defence-in-depth: refuse to serve paths that aren't under a configured
 	// library root, even if a tampered DB row or importer bug set a path
 	// to something outside the library (e.g. /etc/passwd, /config/*).
-	if !h.isAllowedPath(filePath) {
+	if !h.isAllowedPath(r.Context(), filePath) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "access denied"})
 		return
 	}
@@ -128,20 +148,62 @@ func asciiFallback(name string) string {
 // configured — a production install missing BINDERY_LIBRARY_DIR should not
 // silently degrade to "serve any path on disk". Tests that need an unscoped
 // handler must seed allowedRoots explicitly (e.g. t.TempDir()).
-func (h *FileHandler) isAllowedPath(p string) bool {
-	if len(h.allowedRoots) == 0 {
-		return false
-	}
+//
+// Two sources of roots are consulted:
+//
+//   - The static roots (LibraryDir / AudiobookDir) captured at construction.
+//   - When a root folder repo is wired, the user-configured root folders
+//     (rows in the root_folders table), resolved at REQUEST TIME so folders
+//     added/removed after boot are honoured. The importer writes book files
+//     under these roots, so a book's file_path can legitimately live under any
+//     of them.
+//
+// FAIL CLOSED: if listing root folders errors, it is logged and treated as
+// "no additional roots" — a transient DB hiccup never widens the allow-list.
+func (h *FileHandler) isAllowedPath(ctx context.Context, p string) bool {
 	p = filepath.Clean(p)
-	for _, root := range h.allowedRoots {
-		if root == "" || root == "." {
-			continue
+
+	// Static roots first — the common case and the only path that works
+	// without the repo wired.
+	if containedUnder(p, h.allowedRoots) {
+		return true
+	}
+
+	// Dynamic root folders, resolved per request.
+	if h.rootFolders != nil {
+		folders, err := h.rootFolders.List(ctx)
+		if err != nil {
+			slog.Error("file download: failed to list root folders for allow-list, denying", "error", err)
+			return false
 		}
-		if p == root || strings.HasPrefix(p, root+string(filepath.Separator)) {
+		for _, f := range folders {
+			if pathContains(filepath.Clean(f.Path), p) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// containedUnder reports whether p (already cleaned) sits under any of roots.
+func containedUnder(p string, roots []string) bool {
+	for _, root := range roots {
+		if pathContains(filepath.Clean(root), p) {
 			return true
 		}
 	}
 	return false
+}
+
+// pathContains reports whether p is root itself or strictly nested under it.
+// root and p must already be filepath.Cleaned. The separator boundary check
+// ensures /lib/books does NOT match /lib/books-secret/x.
+func pathContains(root, p string) bool {
+	if root == "" || root == "." {
+		return false
+	}
+	return p == root || strings.HasPrefix(p, root+string(filepath.Separator))
 }
 
 // streamZip writes a zip archive of every regular file under srcDir to the

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -4,15 +4,18 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"database/sql"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
 )
@@ -219,4 +222,261 @@ func TestFileDownload_AudiobookDirStreamsZip(t *testing.T) {
 	if !names["part1.m4b"] || !names["nested/cover.jpg"] {
 		t.Errorf("missing entries in zip: %v", names)
 	}
+}
+
+// ── Root-folder allow-list (request-time resolution) ────────────────────────
+//
+// The download allow-list must include user-configured root folders, not just
+// the static LibraryDir / AudiobookDir. The importer writes book files under
+// root folders, which can live on a different mount than the static dirs, so a
+// book whose file_path is under a root folder must still be downloadable while
+// out-of-all-roots paths and traversal attempts stay denied.
+
+// rootFolderFileFixture builds a FileHandler with static roots (libraryDir,
+// audiobookDir) AND a real RootFolderRepo wired via WithRootFolders. It returns
+// the raw *sql.DB so tests can seed root_folders rows and owner_user_id columns
+// the same way the production code paths would at runtime.
+func rootFolderFileFixture(t *testing.T, libraryDir, audiobookDir string) (*FileHandler, *db.BookRepo, *db.RootFolderRepo, *models.Author, *sql.DB) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	rootFolders := db.NewRootFolderRepo(database)
+	ctx := context.Background()
+	author := &models.Author{ForeignID: "OL1A", Name: "A", SortName: "A"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	h := NewFileHandler(books, libraryDir, audiobookDir).WithRootFolders(rootFolders)
+	return h, books, rootFolders, author, database
+}
+
+// seedBookFile creates a real file at path and a book row pointing at it.
+func seedBookFile(t *testing.T, books *db.BookRepo, author *models.Author, foreignID, path string) *models.Book {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("epub bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{ForeignID: foreignID, AuthorID: author.ID, Title: "T"}
+	if err := books.Create(context.Background(), book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.SetFilePath(context.Background(), book.ID, path); err != nil {
+		t.Fatal(err)
+	}
+	return book
+}
+
+// TestFileDownload_RootFolderPathAllowed is the core regression test: a book
+// whose file lives under a configured root folder (NOT under LibraryDir /
+// AudiobookDir) must be downloadable. This case FAILS against the pre-fix code,
+// where the allow-list was the two static dirs captured at construction.
+func TestFileDownload_RootFolderPathAllowed(t *testing.T) {
+	libraryDir := t.TempDir()
+	audiobookDir := t.TempDir()
+	rootDir := t.TempDir() // a separate mount, not under library/audiobook
+
+	h, books, rootFolders, author, _ := rootFolderFileFixture(t, libraryDir, audiobookDir)
+	if _, err := rootFolders.Create(context.Background(), rootDir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(rootDir, "Author", "book.epub")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	book := seedBookFile(t, books, author, "OL-RF", path)
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReq(book.ID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("root-folder book: expected 200, got %d (body %s)", rec.Code, rec.Body.String())
+	}
+	if !bytes.Equal(rec.Body.Bytes(), []byte("epub bytes")) {
+		t.Errorf("body mismatch: got %q", rec.Body.String())
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, "book.epub") {
+		t.Errorf("Content-Disposition missing filename: %q", cd)
+	}
+}
+
+// TestFileDownload_StaticRootsStillWork guards against regression: with a root
+// folder repo wired, books under the static LibraryDir / AudiobookDir must
+// still download without consulting the dynamic list.
+func TestFileDownload_StaticRootsStillWork(t *testing.T) {
+	libraryDir := t.TempDir()
+	audiobookDir := t.TempDir()
+
+	h, books, _, author, _ := rootFolderFileFixture(t, libraryDir, audiobookDir)
+
+	libPath := filepath.Join(libraryDir, "lib.epub")
+	libBook := seedBookFile(t, books, author, "OL-LIB", libPath)
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReq(libBook.ID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("library-dir book: expected 200, got %d", rec.Code)
+	}
+
+	abPath := filepath.Join(audiobookDir, "ab.epub")
+	abBook := seedBookFile(t, books, author, "OL-AB", abPath)
+	rec = httptest.NewRecorder()
+	h.Download(rec, downloadReq(abBook.ID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("audiobook-dir book: expected 200, got %d", rec.Code)
+	}
+}
+
+// TestFileDownload_OutsideAllRootsDeniedWithRepo verifies that even with a root
+// folder repo wired, a path under none of (library, audiobook, any root folder)
+// is still denied with 403.
+func TestFileDownload_OutsideAllRootsDeniedWithRepo(t *testing.T) {
+	libraryDir := t.TempDir()
+	audiobookDir := t.TempDir()
+	rootDir := t.TempDir()
+
+	h, books, rootFolders, author, _ := rootFolderFileFixture(t, libraryDir, audiobookDir)
+	if _, err := rootFolders.Create(context.Background(), rootDir); err != nil {
+		t.Fatal(err)
+	}
+	// File exists but lives entirely outside every configured root.
+	outside := filepath.Join(t.TempDir(), "evil.epub")
+	book := seedBookFile(t, books, author, "OL-OUT", outside)
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReq(book.ID))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("out-of-all-roots: expected 403, got %d", rec.Code)
+	}
+}
+
+// TestFileDownload_RootFolderSeparatorBoundary verifies the separator-boundary
+// check holds for root folder paths: a root of /lib/books must NOT allow a
+// sibling /lib/books-secret/x that merely shares a string prefix.
+func TestFileDownload_RootFolderSeparatorBoundary(t *testing.T) {
+	base := t.TempDir()
+	rootDir := filepath.Join(base, "books")
+	siblingDir := filepath.Join(base, "books-secret")
+	if err := os.MkdirAll(rootDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(siblingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	h, books, rootFolders, author, _ := rootFolderFileFixture(t, t.TempDir(), t.TempDir())
+	if _, err := rootFolders.Create(context.Background(), rootDir); err != nil {
+		t.Fatal(err)
+	}
+	// File sits under the sibling dir that shares the "books" prefix but is
+	// NOT under the root folder. Must be denied.
+	path := filepath.Join(siblingDir, "leak.epub")
+	book := seedBookFile(t, books, author, "OL-SIB", path)
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReq(book.ID))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("sibling-prefix path: expected 403, got %d", rec.Code)
+	}
+}
+
+// TestFileDownload_RootFolderTraversalDenied verifies a path that escapes the
+// root folder via `..` is denied after filepath.Clean (the cleaned path is
+// outside the root, so no allow-list entry matches).
+func TestFileDownload_RootFolderTraversalDenied(t *testing.T) {
+	base := t.TempDir()
+	rootDir := filepath.Join(base, "books")
+	if err := os.MkdirAll(rootDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A real secret file outside the root that the traversal aims at.
+	secret := filepath.Join(base, "secret.epub")
+	if err := os.WriteFile(secret, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	h, books, rootFolders, author, database := rootFolderFileFixture(t, t.TempDir(), t.TempDir())
+	if _, err := rootFolders.Create(context.Background(), rootDir); err != nil {
+		t.Fatal(err)
+	}
+	// Store a traversal path: <root>/../secret.epub. filepath.Clean resolves
+	// this to base/secret.epub which is outside the root folder.
+	traversal := filepath.Join(rootDir, "..", "secret.epub")
+	book := &models.Book{ForeignID: "OL-TRAV", AuthorID: author.ID, Title: "T"}
+	if err := books.Create(context.Background(), book); err != nil {
+		t.Fatal(err)
+	}
+	// SetFilePath would normalise; write the raw traversal directly to be sure.
+	if _, err := database.Exec("UPDATE books SET file_path=? WHERE id=?", traversal, book.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReq(book.ID))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("traversal path: expected 403, got %d", rec.Code)
+	}
+}
+
+// TestFileDownload_OwnershipEnforcedUnderRootFolder verifies the per-book
+// ownership guard is untouched: a non-owner gets 404 even when the file lives
+// under a valid root folder (path allow-list widened, IDOR guard unchanged).
+func TestFileDownload_OwnershipEnforcedUnderRootFolder(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+
+	libraryDir := t.TempDir()
+	audiobookDir := t.TempDir()
+	rootDir := t.TempDir()
+
+	h, books, rootFolders, author, database := rootFolderFileFixture(t, libraryDir, audiobookDir)
+	if _, err := rootFolders.Create(context.Background(), rootDir); err != nil {
+		t.Fatal(err)
+	}
+	users := db.NewUserRepo(database)
+	owner, err := users.Create(context.Background(), "owner", "h1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := users.Create(context.Background(), "other", "h2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(rootDir, "book.epub")
+	book := seedBookFile(t, books, author, "OL-OWN", path)
+	if _, err := database.Exec("UPDATE books SET owner_user_id=? WHERE id=?", owner.ID, book.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Non-owner: path is under a valid root folder, but the IDOR guard must
+	// still 404 (not leak the file).
+	ctx := withAuthCtx(context.Background(), other.ID, "user")
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReqCtx(ctx, book.ID))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("non-owner under root folder: expected 404, got %d", rec.Code)
+	}
+
+	// Sanity: the owner can still download.
+	ownerCtx := withAuthCtx(context.Background(), owner.ID, "user")
+	rec = httptest.NewRecorder()
+	h.Download(rec, downloadReqCtx(ownerCtx, book.ID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("owner under root folder: expected 200, got %d", rec.Code)
+	}
+}
+
+// downloadReq builds a chi-aware GET request for the download handler with the
+// {id} URL param populated.
+func downloadReq(id int64) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/file/download", nil)
+	return withURLParam(req, "id", strconv.FormatInt(id, 10))
+}
+
+// downloadReqCtx is downloadReq with a caller-supplied base context (e.g.
+// carrying auth identity) layered under the chi route param.
+func downloadReqCtx(ctx context.Context, id int64) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/file/download", nil).WithContext(ctx)
+	return withURLParam(req, "id", strconv.FormatInt(id, 10))
 }


### PR DESCRIPTION
## Summary

The book file-download endpoint returned `{"error":"access denied"}` (HTTP 403) for any book whose file lives under a configured **root folder** rather than the two global dirs. This is the standard configuration (users set a root folder in the UI), so downloads were broken for most root-folder setups.

## Root cause

`FileHandler.Download` gates file paths through `isAllowedPath`, whose allow-list (`allowedRoots`) was set **once** at construction in `cmd/bindery/main.go` to just `cfg.LibraryDir` and `cfg.AudiobookDir`. But the importer writes book files under **root folders** (`root_folders` table rows), resolved per-author via `Scanner.effectiveLibraryDir` / `effectiveAudiobookDir`. Root folders can live on a different mount than the static dirs, so a book's `FilePath` / `EbookFilePath` / `AudiobookFilePath` can legitimately sit under any configured root folder — and `isAllowedPath` wrongly denied it.

## Fix

- `FileHandler` gains an optional `*db.RootFolderRepo`, wired via a new `WithRootFolders` setter (mirrors the scanner's existing `WithRootFolders` pattern). Wired in `main.go` where the repo is already constructed.
- `isAllowedPath` is now context-aware. After the existing static-root check misses, and when the repo is wired, it calls `rootFolders.List(ctx)` at **request time** (root folders are added/removed at runtime; a startup snapshot would miss folders created after boot) and tests the path against each configured root folder's `Path`.
- Same containment primitive for both sources: `p == root || strings.HasPrefix(p, root+sep)` after `filepath.Clean`.

## Security reasoning

- **Ownership unchanged.** The per-book IDOR guard (`auth.CheckOwnership`) is untouched — only the *path* allow-list is widened to legitimate write destinations.
- **Fails closed.** An empty total allow-list (no static roots AND no root folders) denies everything. If `List` errors, it is logged via slog and treated as deny — a transient DB hiccup never widens the allow-list.
- **Separator boundary preserved.** `/lib/books` does not match a sibling `/lib/books-secret/x`, and `..` traversal is rejected after `filepath.Clean`, for root folders too.

## Tests

Added to `internal/api/files_test.go` (mirrors existing FileHandler patterns; `db.OpenMemory` + `httptest`):

| Test | Asserts |
|------|---------|
| `RootFolderPathAllowed` | book under a configured root folder now downloads (200, bytes + Content-Disposition). **Verified this FAILS against pre-fix logic** (403). |
| `StaticRootsStillWork` | books under LibraryDir / AudiobookDir still download (no regression). |
| `OutsideAllRootsDeniedWithRepo` | path outside library, audiobook, and all root folders still 403. |
| `RootFolderSeparatorBoundary` | `/…/books` does NOT allow sibling `/…/books-secret/x`. |
| `RootFolderTraversalDenied` | `<root>/../secret.epub` is denied after Clean. |
| `OwnershipEnforcedUnderRootFolder` | non-owner gets 404 even under a valid root folder; owner still 200. |

### Pre-fix failure evidence

Temporarily disabling the new dynamic branch:
```
--- FAIL: TestFileDownload_RootFolderPathAllowed (403, want 200)
--- FAIL: TestFileDownload_OwnershipEnforcedUnderRootFolder
```
(`StaticRootsStillWork` still passed — the static path is unaffected.)

## Test plan

- [x] `gofmt -l` clean
- [x] `go vet ./internal/api/... ./cmd/...`
- [x] `golangci-lint run` (v2.11.4) — 0 issues
- [x] `govulncheck` — no vulnerabilities
- [x] `go test -race -run 'TestFileDownload|TestManualImport' ./internal/api/` — ok
- [x] `go test ./internal/api/ ./cmd/...` — ok

## Checklist

- [x] Tests added
- [x] Doc-update gate cleared — behavior fix, no env var / config / auth / ABS surface touched
- [x] No user-facing wiki change

🤖 Generated with [Claude Code](https://claude.com/claude-code)