### PR TITLE
fix(api): admins see all libraries in list/browse views

### DIFF
--- a/docs/multi-user.md
+++ b/docs/multi-user.md
@@ -10,6 +10,8 @@ Bindery v1.0 introduces per-user library scoping: authors, books, downloads, qua
 > - **Tier-2 join-scoped resources** — download queue, history, pending grabs, and the OPDS catalogue — to the requesting user.
 > - **Per-user resources** — each user's own authors, books, profiles, API key, password, and notification preferences. (Root folders are **not** per-user; see the note above.)
 >
+> **Admins see everything in list views.** With enforcement on, an `admin` is never filtered by ownership: the authors and books list endpoints (and the OPDS feed) return *all* users' libraries plus unowned/global rows, the same way an admin can already open any single item by ID. This is a **shared library across admins**, by design — it does not widen access, it makes lists consistent with per-item access. Non-admin (`user`) accounts stay isolated to their own rows plus unowned/global rows. Requests authenticated by API key (or in `disabled` / `local-only` auth modes) carry no user identity and are likewise unscoped.
+>
 > Role-based gating of admin-only configuration (indexers, download clients, user management, system settings) applies in **both** modes — that does not depend on `BINDERY_ENFORCE_TENANCY`. The flag only controls whether *library data* is partitioned per user.
 
 For upgrade instructions and migration steps, see [docs/upgrade-v1.md](upgrade-v1.md).

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -186,7 +186,12 @@ const (
 
 func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	userID := auth.UserIDFromContext(ctx)
+	// Scope the browse list with ListScopeUserID (not UserIDFromContext): admins
+	// and API-key/no-tenancy callers get 0 = unscoped so they see the shared
+	// library, matching CheckOwnership's per-item bypass; non-admins stay scoped
+	// to their own + unowned rows. Fixes admins not seeing another admin's
+	// authors in the list even though they can open them by ID.
+	userID := auth.ListScopeUserID(ctx)
 	limit, offset := parseLimitOffset(r, authorListDefaultLimit, authorListMaxLimit)
 	filter := db.AuthorListFilter{
 		UserID: userID,

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -273,7 +273,10 @@ func (h *BookHandler) List(w http.ResponseWriter, r *http.Request) {
 		if includeExcluded {
 			books, err = h.books.ListByAuthorIncludingExcluded(r.Context(), id)
 		} else {
-			books, err = h.books.ListByAuthor(r.Context(), id)
+			// Scope to the caller's library: admins / API-key / no-tenancy get
+			// 0 = unscoped (identical to ListByAuthor), non-admins are isolated
+			// to their own + unowned books even when navigating by authorId.
+			books, err = h.books.ListByAuthorAndUser(r.Context(), id, auth.ListScopeUserID(r.Context()))
 		}
 		books, total = pageBooks(books, limit, offset)
 	case includeExcluded:
@@ -295,6 +298,11 @@ func (h *BookHandler) List(w http.ResponseWriter, r *http.Request) {
 		// monitored=1 for "wanted" — matching what the Books page showed when
 		// it filtered client-side over the full set.
 		books, total, err = h.books.ListPageFiltered(r.Context(), db.BookListFilter{
+			// Scope with ListScopeUserID so admins / API-key / no-tenancy callers
+			// see the shared library (0 = unscoped) while non-admins stay isolated
+			// to their own + unowned books, consistent with the authors list and
+			// CheckOwnership's per-item bypass.
+			UserID:        auth.ListScopeUserID(r.Context()),
 			Search:        strings.TrimSpace(r.URL.Query().Get("search")),
 			Status:        status,
 			MediaType:     r.URL.Query().Get("mediaType"),

--- a/internal/api/list_scope_test.go
+++ b/internal/api/list_scope_test.go
@@ -1,0 +1,204 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// listScopeFixture seeds two users — alice (the "other" user, id 1) and bob
+// (the caller under test, id 2) — each owning one author + book, plus an
+// unowned (owner_user_id NULL) "global" author + book. It returns the List
+// handlers wired to the same DB so the admin-bypass / isolation matrix can be
+// driven through the real HTTP handlers.
+type listScopeFixture struct {
+	database *sql.DB
+	authorsH *AuthorHandler
+	booksH   *BookHandler
+	alice    int64
+	bob      int64
+}
+
+func newListScopeFixture(t *testing.T) *listScopeFixture {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	ctx := context.Background()
+	users := db.NewUserRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+
+	alice, err := users.Create(ctx, "alice", "h1")
+	if err != nil {
+		t.Fatalf("create alice: %v", err)
+	}
+	bob, err := users.Create(ctx, "bob", "h2")
+	if err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+
+	aAlice := &models.Author{ForeignID: "ol-alice", Name: "Alice Author", SortName: "Author, Alice", Monitored: true}
+	if err := authorRepo.CreateForUser(ctx, aAlice, alice.ID); err != nil {
+		t.Fatalf("seed alice author: %v", err)
+	}
+	aBob := &models.Author{ForeignID: "ol-bob", Name: "Bob Author", SortName: "Author, Bob", Monitored: true}
+	if err := authorRepo.CreateForUser(ctx, aBob, bob.ID); err != nil {
+		t.Fatalf("seed bob author: %v", err)
+	}
+	aGlobal := &models.Author{ForeignID: "ol-global", Name: "Global Author", SortName: "Author, Global", Monitored: true}
+	if err := authorRepo.Create(ctx, aGlobal); err != nil { // Create => NULL owner_user_id
+		t.Fatalf("seed global author: %v", err)
+	}
+
+	seedBook := func(fid, title string, authorID, owner int64) {
+		b := &models.Book{
+			ForeignID: fid, AuthorID: authorID, Title: title, SortTitle: title,
+			Status: models.BookStatusWanted, Monitored: true, MediaType: models.MediaTypeEbook,
+		}
+		if err := bookRepo.Create(ctx, b); err != nil {
+			t.Fatalf("seed book %s: %v", title, err)
+		}
+		// books.Create does not set owner_user_id; set it explicitly (owner 0
+		// leaves it NULL, modelling a pre-multiuser / imported book).
+		if owner != 0 {
+			if _, err := database.Exec("UPDATE books SET owner_user_id=? WHERE id=?", owner, b.ID); err != nil {
+				t.Fatalf("set owner for %s: %v", title, err)
+			}
+		}
+	}
+	seedBook("b-alice", "Alice Book", aAlice.ID, alice.ID)
+	seedBook("b-bob", "Bob Book", aBob.ID, bob.ID)
+	seedBook("b-global", "Global Book", aGlobal.ID, 0)
+
+	return &listScopeFixture{
+		database: database,
+		authorsH: NewAuthorHandler(authorRepo, nil, bookRepo, nil, nil, nil, nil, nil),
+		booksH:   NewBookHandler(bookRepo, nil, nil, nil),
+		alice:    alice.ID,
+		bob:      bob.ID,
+	}
+}
+
+func (f *listScopeFixture) listAuthorNames(t *testing.T, ctx context.Context) []string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/authors?limit=500", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	f.authorsH.List(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authors list status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp authorListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode authors: %v", err)
+	}
+	names := make([]string, 0, len(resp.Items))
+	for _, a := range resp.Items {
+		names = append(names, a.Name)
+	}
+	return names
+}
+
+func (f *listScopeFixture) listBookTitles(t *testing.T, ctx context.Context) []string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/books?limit=500", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	f.booksH.List(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("books list status %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp bookListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode books: %v", err)
+	}
+	titles := make([]string, 0, len(resp.Items))
+	for _, b := range resp.Items {
+		titles = append(titles, b.Title)
+	}
+	return titles
+}
+
+func assertSameSet(t *testing.T, got, want []string) {
+	t.Helper()
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	slices.Sort(g)
+	slices.Sort(w)
+	if !slices.Equal(g, w) {
+		t.Errorf("set mismatch:\n got  = %v\n want = %v", got, want)
+	}
+}
+
+// TestListScope_Admin_SeesEverything is the bug reproduction: with tenancy on,
+// an ADMIN (role "admin", id=2 = bob) listing authors/books must see the OTHER
+// user's (alice, id=1) owned rows, the unowned/global rows, and their own.
+// Pre-fix the handlers scoped strictly to UserIDFromContext with no admin
+// bypass, so alice's author/book were invisible to the admin even though
+// CheckOwnership lets the admin open them by ID — this test failed pre-fix.
+func TestListScope_Admin_SeesEverything(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := newListScopeFixture(t)
+	ctx := auth.WithUserRole(auth.WithUserID(context.Background(), f.bob), "admin")
+
+	assertSameSet(t, f.listAuthorNames(t, ctx), []string{"Alice Author", "Bob Author", "Global Author"})
+	assertSameSet(t, f.listBookTitles(t, ctx), []string{"Alice Book", "Bob Book", "Global Book"})
+}
+
+// TestListScope_NonAdmin_IsolatedPlusGlobal asserts a non-admin (role "user",
+// id=2 = bob) sees ONLY their own rows plus the unowned/global rows, and NOT
+// the other user's (alice) rows. The global-book visibility specifically
+// exercises the books "OR owner_user_id IS NULL" fix.
+func TestListScope_NonAdmin_IsolatedPlusGlobal(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := newListScopeFixture(t)
+	ctx := auth.WithUserRole(auth.WithUserID(context.Background(), f.bob), "user")
+
+	gotAuthors := f.listAuthorNames(t, ctx)
+	assertSameSet(t, gotAuthors, []string{"Bob Author", "Global Author"})
+	if slices.Contains(gotAuthors, "Alice Author") {
+		t.Errorf("ISOLATION LEAK: non-admin bob saw alice's author: %v", gotAuthors)
+	}
+
+	gotBooks := f.listBookTitles(t, ctx)
+	// "Global Book" present proves the OR-IS-NULL fix; "Alice Book" absent
+	// proves isolation is preserved.
+	assertSameSet(t, gotBooks, []string{"Bob Book", "Global Book"})
+	if slices.Contains(gotBooks, "Alice Book") {
+		t.Errorf("ISOLATION LEAK: non-admin bob saw alice's book: %v", gotBooks)
+	}
+}
+
+// TestListScope_APIKey_Unscoped asserts that a request with no user identity
+// (API-key / disabled / local-only — UserIDFromContext == 0) sees everything
+// even with tenancy on, matching CheckOwnership's admin-equivalent handling.
+func TestListScope_APIKey_Unscoped(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := newListScopeFixture(t)
+	ctx := context.Background() // no user id, no role
+
+	assertSameSet(t, f.listAuthorNames(t, ctx), []string{"Alice Author", "Bob Author", "Global Author"})
+	assertSameSet(t, f.listBookTitles(t, ctx), []string{"Alice Book", "Bob Book", "Global Book"})
+}
+
+// TestListScope_TenancyDisabled_Unscoped asserts that with the tenancy gate off
+// (single-user default) even a non-admin context is unscoped — the per-user
+// filter must not engage, preserving pre-multiuser behaviour.
+func TestListScope_TenancyDisabled_Unscoped(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, false)
+	f := newListScopeFixture(t)
+	ctx := auth.WithUserRole(auth.WithUserID(context.Background(), f.bob), "user")
+
+	assertSameSet(t, f.listAuthorNames(t, ctx), []string{"Alice Author", "Bob Author", "Global Author"})
+	assertSameSet(t, f.listBookTitles(t, ctx), []string{"Alice Book", "Bob Book", "Global Book"})
+}

--- a/internal/api/opds.go
+++ b/internal/api/opds.go
@@ -111,14 +111,12 @@ func (h *OPDSHandler) Book(w http.ResponseWriter, r *http.Request) {
 // when there is no authenticated user (API-key / disabled / local-only auth
 // paths). The Build* methods on opds.Builder treat 0 as "no per-user
 // filter", which preserves pre-D3 behaviour for those paths.
+//
+// This is exactly auth.ListScopeUserID — the shared helper that scopes every
+// owner-filtered list view — so OPDS feeds stay consistent with the JSON
+// authors/books lists.
 func opdsCallerUserID(ctx context.Context) int64 {
-	if !auth.EnforceTenancy() {
-		return 0
-	}
-	if auth.UserRoleFromContext(ctx) == "admin" {
-		return 0
-	}
-	return auth.UserIDFromContext(ctx)
+	return auth.ListScopeUserID(ctx)
 }
 
 // DownloadFile serves the book bytes. Delegates to the same FileHandler

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -86,6 +86,32 @@ func CheckOwnership(ctx context.Context, ownerUserID int64) bool {
 	return uid == ownerUserID
 }
 
+// ListScopeUserID returns the owner_user_id a LIST/browse query should scope
+// to, or 0 for "unscoped / see everything". It mirrors CheckOwnership's
+// bypasses so list views stay consistent with per-item access:
+//
+//   - tenancy disabled  => 0 (no scoping; single-user default);
+//   - admin role        => 0 (admins manage every user's library, matching
+//     CheckOwnership, which already lets an admin open any item by ID);
+//   - otherwise         => the caller's user id, which the DB layer treats as
+//     "owner_user_id = id OR owner_user_id IS NULL". A 0 here (API-key /
+//     disabled / local-only requests, which carry no user identity) already
+//     means unscoped downstream, matching CheckOwnership's admin-equivalent
+//     handling of those auth modes.
+//
+// Use this — not UserIDFromContext — to scope owner-filtered list handlers so
+// admins see the shared library and non-admins stay isolated to their own
+// rows (plus unowned/global rows).
+func ListScopeUserID(ctx context.Context) int64 {
+	if !EnforceTenancy() {
+		return 0
+	}
+	if UserRoleFromContext(ctx) == "admin" {
+		return 0
+	}
+	return UserIDFromContext(ctx)
+}
+
 // Mode represents the auth posture. Matches Sonarr's "Authentication Required"
 // dropdown semantics.
 type Mode string

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -169,7 +169,7 @@ func (r *BookRepo) List(ctx context.Context) ([]models.Book, error) {
 }
 
 func (r *BookRepo) ListByUser(ctx context.Context, userID int64) ([]models.Book, error) {
-	where, args := QueryScopeFor("books.owner_user_id", "WHERE excluded = 0", userID)
+	where, args := QueryScopeForIncludingNull("books.owner_user_id", "WHERE excluded = 0", userID)
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where+" ORDER BY sort_title", args)
 }
 
@@ -187,7 +187,7 @@ func (r *BookRepo) ListPage(ctx context.Context, userID int64, limit, offset int
 	if offset < 0 {
 		offset = 0
 	}
-	where, args := QueryScopeFor("books.owner_user_id", "WHERE excluded = 0", userID)
+	where, args := QueryScopeForIncludingNull("books.owner_user_id", "WHERE excluded = 0", userID)
 	total, err := r.count(ctx, "SELECT COUNT(*) FROM books "+where, args)
 	if err != nil {
 		return nil, 0, err
@@ -206,7 +206,7 @@ func (r *BookRepo) ListPage(ctx context.Context, userID int64, limit, offset int
 // BookListFilter narrows ListPageFiltered. The zero value (with UserID 0)
 // selects every non-excluded book in sort_title order — identical to ListPage.
 type BookListFilter struct {
-	UserID int64 // 0 = unscoped; otherwise owner_user_id = UserID
+	UserID int64 // 0 = unscoped; otherwise owner_user_id = UserID OR owner_user_id IS NULL
 	// Search is a case-insensitive substring match on the book title OR its
 	// author's name. Empty disables the filter.
 	Search string
@@ -257,7 +257,7 @@ func (r *BookRepo) ListPageFiltered(ctx context.Context, f BookListFilter, limit
 		offset = 0
 	}
 
-	where, args := QueryScopeFor("books.owner_user_id", "WHERE excluded = 0", f.UserID)
+	where, args := QueryScopeForIncludingNull("books.owner_user_id", "WHERE excluded = 0", f.UserID)
 	if s := strings.TrimSpace(f.Search); s != "" {
 		where += " AND (books.title LIKE ? ESCAPE '\\' COLLATE NOCASE OR au.name LIKE ? ESCAPE '\\' COLLATE NOCASE)"
 		like := "%" + escapeLike(s) + "%"
@@ -323,7 +323,7 @@ func (r *BookRepo) ListByAuthor(ctx context.Context, authorID int64) ([]models.B
 }
 
 func (r *BookRepo) ListByAuthorAndUser(ctx context.Context, authorID, userID int64) ([]models.Book, error) {
-	where, args := QueryScopeFor("books.owner_user_id", "WHERE author_id = ? AND excluded = 0", userID, authorID)
+	where, args := QueryScopeForIncludingNull("books.owner_user_id", "WHERE author_id = ? AND excluded = 0", userID, authorID)
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where+" ORDER BY release_date", args)
 }
 
@@ -337,7 +337,7 @@ func (r *BookRepo) ListByStatus(ctx context.Context, status string) ([]models.Bo
 }
 
 func (r *BookRepo) ListByStatusAndUser(ctx context.Context, status string, userID int64) ([]models.Book, error) {
-	where, args := QueryScopeFor("books.owner_user_id", "WHERE status = ? AND books.monitored = 1 AND excluded = 0", userID, status)
+	where, args := QueryScopeForIncludingNull("books.owner_user_id", "WHERE status = ? AND books.monitored = 1 AND excluded = 0", userID, status)
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where+" ORDER BY sort_title", args)
 }
 

--- a/internal/db/list_scope_test.go
+++ b/internal/db/list_scope_test.go
@@ -1,0 +1,56 @@
+package db_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestBookRepo_ListPageFiltered_IncludesNullOwner pins the books-list predicate
+// fix: a scoped list (UserID = a real user) must include the user's own books
+// AND unowned (owner_user_id NULL) books — mirroring the authors list and
+// CheckOwnership, which treat a NULL owner as visible to everyone — while still
+// excluding another user's owned books. A UserID of 0 must be fully unscoped.
+func TestBookRepo_ListPageFiltered_IncludesNullOwner(t *testing.T) {
+	f := newTenancyFixture(t)
+	ctx := context.Background()
+
+	// Add a third, unowned (NULL owner) book alongside the fixture's owned ones.
+	globalBook := &models.Book{
+		ForeignID: "book-global", AuthorID: f.authorA, Title: "Global Book", SortTitle: "Global Book",
+		Status: models.BookStatusWanted, Monitored: true, MediaType: models.MediaTypeEbook,
+	}
+	if err := f.books.Create(ctx, globalBook); err != nil { // Create leaves owner_user_id NULL
+		t.Fatalf("create global book: %v", err)
+	}
+
+	titlesFor := func(userID int64) []string {
+		books, _, err := f.books.ListPageFiltered(ctx, db.BookListFilter{UserID: userID}, 500, 0)
+		if err != nil {
+			t.Fatalf("ListPageFiltered(userID=%d): %v", userID, err)
+		}
+		return titles(books)
+	}
+
+	// Scoped to user A: own book + the NULL-owner book, but NOT user B's book.
+	gotA := titlesFor(f.userA)
+	slices.Sort(gotA)
+	wantA := []string{"Alice Book", "Global Book"}
+	if !slices.Equal(gotA, wantA) {
+		t.Errorf("userA scoped list = %v, want %v (own + NULL-owner, no cross-tenant)", gotA, wantA)
+	}
+	if slices.Contains(gotA, "Bob Book") {
+		t.Errorf("CROSS-TENANT LEAK: userA saw Bob Book: %v", gotA)
+	}
+
+	// userID 0 = unscoped: every book regardless of owner.
+	gotAll := titlesFor(0)
+	slices.Sort(gotAll)
+	wantAll := []string{"Alice Book", "Bob Book", "Global Book"}
+	if !slices.Equal(gotAll, wantAll) {
+		t.Errorf("unscoped (userID=0) list = %v, want %v", gotAll, wantAll)
+	}
+}

--- a/internal/db/scope.go
+++ b/internal/db/scope.go
@@ -26,3 +26,24 @@ func QueryScopeFor(column, where string, userID int64, args ...any) (string, []a
 	}
 	return where + " AND " + column + " = ?", append(args, userID)
 }
+
+// QueryScopeForIncludingNull is QueryScopeFor but the owner predicate also
+// matches rows whose owner column is NULL: "(column = ? OR column IS NULL)".
+// This mirrors the authors list predicate and auth.CheckOwnership, which treat
+// an unowned (NULL) row as visible to every user — so a logged-in user is not
+// shown an empty library just because some rows pre-date the multi-user
+// migration (or were imported without an owner). userID 0 still means unscoped
+// (no predicate added), so admins / API-key / no-tenancy callers see all rows.
+//
+// Use this for owner-scoped library LIST/browse queries. Per-item ownership
+// reads that must enforce strict equality should keep using QueryScopeFor.
+func QueryScopeForIncludingNull(column, where string, userID int64, args ...any) (string, []any) {
+	if userID == 0 {
+		return where, args
+	}
+	pred := "(" + column + " = ? OR " + column + " IS NULL)"
+	if where == "" {
+		return "WHERE " + pred, append([]any{userID}, args...)
+	}
+	return where + " AND " + pred, append(args, userID)
+}


### PR DESCRIPTION
## Root cause (verified against prod)

A multi-admin instance had authors/books split by `owner_user_id` (user 1 `admin`, user 2 `akadmin` — the latter auto-provisioned when SSO was enabled). The list endpoints scoped strictly to the caller's id (`AuthorHandler.List` → `filter.UserID = auth.UserIDFromContext(ctx)`) with **no admin bypass**, while `auth.CheckOwnership` already treats admins (and API-key / no-tenancy callers) as able to access any item by id. So admin user 2 could not **see** user 1's authors/books in lists, and "Add Author" hit the global `foreign_id` UNIQUE constraint → dead-end "author already exists".

Confirmed on the live DB: author `Cory Doctorow` (id 41) is `owner_user_id = 1`; browsing as admin user 2 hid it; owner spread was NULL=25 / u1=13 / u2=14.

## Fix
- **`auth.ListScopeUserID(ctx)`** — returns 0 (unscoped) for admin role, disabled tenancy, or API-key callers; the caller's id otherwise. Mirrors `CheckOwnership`'s bypasses.
- Routed the owner-scoped **list/browse** handlers through it: authors list, books list, `ListByAuthorAndUser`, OPDS.
- **`db.QueryScopeForIncludingNull`** — books list now uses `(owner = ? OR owner IS NULL)` like the authors list, so owner-NULL rows (pre-multi-user / imported without an owner) are visible to a logged-in user instead of hidden. `userID == 0` still means unscoped.

## Security
No real access widening: admins can already open any item by id via `CheckOwnership`; this only makes **lists** consistent with that. Non-admin isolation is preserved and tested — a non-admin sees only their own rows plus unowned, never another non-admin's.

## Tests
`internal/api/list_scope_test.go`, `internal/db/list_scope_test.go`: admin-sees-everything, non-admin-isolated-plus-global, API-key unscoped, tenancy-disabled unscoped, books-includes-null-owner. Admin-sees-everything fails pre-fix. Full api/db/auth suites pass; targeted scope tests clean under `-race` (0 data races; the full-package `-race` only timed out on a constrained box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)