### PR TITLE
fix(authors): sort A-Z/Z-A case-insensitively

### DIFF
--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -67,11 +67,11 @@ func (r *AuthorRepo) List(ctx context.Context) ([]models.Author, error) {
 }
 
 const (
-	listAuthorsAll = "SELECT " + authorSelectCols + " FROM authors ORDER BY sort_name"
+	listAuthorsAll = "SELECT " + authorSelectCols + " FROM authors ORDER BY sort_name COLLATE NOCASE"
 	// Include rows with NULL owner_user_id — these are authors created before the
 	// multi-user migration ran its backfill (migration 025) or imported without a
 	// user context. Excluding them causes the list to silently drop visible authors.
-	listAuthorsByUser = "SELECT " + authorSelectCols + " FROM authors WHERE owner_user_id = ? OR owner_user_id IS NULL ORDER BY sort_name"
+	listAuthorsByUser = "SELECT " + authorSelectCols + " FROM authors WHERE owner_user_id = ? OR owner_user_id IS NULL ORDER BY sort_name COLLATE NOCASE"
 )
 
 func (r *AuthorRepo) ListByUser(ctx context.Context, userID int64) ([]models.Author, error) {
@@ -122,14 +122,21 @@ func escapeLike(s string) string {
 
 // authorSortOrder maps a whitelisted sort key to a fixed ORDER BY clause. The
 // value never contains user input, so it is safe to interpolate.
+//
+// sort_name is stored case-preserving ("Olsen, Mary-Kate", "de Balzac,
+// Honoré"), so a plain (BINARY-collation) ORDER BY sorts all uppercase letters
+// ahead of all lowercase ones (ASCII 'Z'=90 < 'a'=97) — names beginning with a
+// lowercase article ("de", "von") land after "Z", which users read as a jumble.
+// COLLATE NOCASE folds case so the A-Z / Z-A order matches expectations. The
+// "recent" sort keys on created_at (a timestamp) and is unaffected.
 func authorSortOrder(sort string) string {
 	switch sort {
 	case "za":
-		return "sort_name DESC"
+		return "sort_name COLLATE NOCASE DESC"
 	case "recent":
 		return "created_at DESC, id DESC"
 	default:
-		return "sort_name ASC"
+		return "sort_name COLLATE NOCASE ASC"
 	}
 }
 

--- a/internal/db/list_filtered_test.go
+++ b/internal/db/list_filtered_test.go
@@ -164,6 +164,61 @@ func TestAuthorRepo_ListPageFiltered_SearchSortMonitored(t *testing.T) {
 	}
 }
 
+// TestAuthorRepo_ListPageFiltered_SortNameCaseInsensitive is the regression
+// test for the Authors-tab "A-Z is a total jumble" report: sort_name is stored
+// case-preserving, so a BINARY-collation ORDER BY interleaves on case (all
+// uppercase before any lowercase) and pushes lowercase-article names ("de
+// Balzac") past "Z". The sort must be case-insensitive end to end.
+func TestAuthorRepo_ListPageFiltered_SortNameCaseInsensitive(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	// Deliberately mixed case, inserted out of order. Under BINARY collation
+	// these would sort as [Adams, Zola, adelson, de Balzac] (uppercase first,
+	// then lowercase) — the jumble users saw.
+	seed := []struct{ name, sortName string }{
+		{"Honoré de Balzac", "de Balzac, Honoré"},
+		{"Émile Zola", "Zola, Émile"},
+		{"Anita Adelson", "adelson, Anita"},
+		{"Douglas Adams", "Adams, Douglas"},
+	}
+	for _, s := range seed {
+		if err := repo.Create(ctx, &models.Author{
+			ForeignID: "OL-C" + s.sortName, Name: s.name, SortName: s.sortName,
+		}); err != nil {
+			t.Fatalf("seed %s: %v", s.sortName, err)
+		}
+	}
+
+	az, _, err := repo.ListPageFiltered(ctx, AuthorListFilter{Sort: "az"}, 50, 0)
+	if err != nil {
+		t.Fatalf("az: %v", err)
+	}
+	gotAZ := make([]string, len(az))
+	for i, a := range az {
+		gotAZ[i] = a.SortName
+	}
+	wantAZ := []string{"Adams, Douglas", "adelson, Anita", "de Balzac, Honoré", "Zola, Émile"}
+	for i := range wantAZ {
+		if gotAZ[i] != wantAZ[i] {
+			t.Fatalf("az order = %v, want %v", gotAZ, wantAZ)
+		}
+	}
+
+	za, _, err := repo.ListPageFiltered(ctx, AuthorListFilter{Sort: "za"}, 50, 0)
+	if err != nil {
+		t.Fatalf("za: %v", err)
+	}
+	if za[0].SortName != "Zola, Émile" || za[len(za)-1].SortName != "Adams, Douglas" {
+		t.Errorf("za ends = [%s ... %s], want [Zola, Émile ... Adams, Douglas]", za[0].SortName, za[len(za)-1].SortName)
+	}
+}
+
 func TestBookRepo_ListPageFiltered(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {

--- a/internal/db/migrations/055_authors_sort_name_nocase_index.sql
+++ b/internal/db/migrations/055_authors_sort_name_nocase_index.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+-- The Authors list sorts A-Z / Z-A by sort_name with COLLATE NOCASE (see
+-- db/authors.go authorSortOrder). The existing idx_authors_sort_name from
+-- migration 048 uses the column's default BINARY collation, so SQLite cannot
+-- use it to satisfy a NOCASE-ordered query and falls back to a full in-memory
+-- sort on every page. This adds a matching NOCASE index so the paginated
+-- ORDER BY stays index-backed.
+--
+-- IF NOT EXISTS so reruns are safe even after an operator hand-added it.
+CREATE INDEX IF NOT EXISTS idx_authors_sort_name_nocase ON authors(sort_name COLLATE NOCASE);
+
+-- +migrate Down
+DROP INDEX IF EXISTS idx_authors_sort_name_nocase;


### PR DESCRIPTION
## Report
> Anyone else having an issue with the Authors tab not properly alphabetizing the list? Sorting by recent works fine, but A-Z and Z-A are a total jumble — *cleb (Discord)*

## Root cause
`authors.sort_name` is stored case-preserving (`"Olsen, Mary-Kate"`, `"de Balzac, Honoré"`). `authorSortOrder` emitted a plain `ORDER BY sort_name ASC/DESC`, which under SQLite's default **BINARY** collation sorts every uppercase letter ahead of every lowercase one (`'Z'`=90 < `'a'`=97). So names beginning with a lowercase article (`de`, `von`) sort *after* `Z`, and any case inconsistency interleaves — the "jumble." The `recent` sort keys on `created_at` (a timestamp), which is why it looked fine.

## Fix
- `COLLATE NOCASE` on the `az`/`za` sort orders in `authorSortOrder`, and on the two non-paginated list consts (`listAuthorsAll`, `listAuthorsByUser`).
- Migration **055** adds `idx_authors_sort_name_nocase ON authors(sort_name COLLATE NOCASE)` so the paginated `ORDER BY … COLLATE NOCASE LIMIT/OFFSET` stays index-backed instead of falling back to a full in-memory sort (the BINARY index from 048 can't satisfy a NOCASE order).

## Test
`TestAuthorRepo_ListPageFiltered_SortNameCaseInsensitive` seeds mixed-case sort_names out of order (incl. a lowercase-article name) and asserts both A-Z and Z-A fold case correctly. Full `internal/db` suite green under `-race`.

## Note
`COLLATE NOCASE` folds ASCII case only — it does not normalize diacritics (`É` still sorts after `Z`). That's a separate, lower-impact concern; this PR fixes the reported case jumble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)