### PR TITLE
fix(import): honest hardlink probe + cross-device copy fallback

### DIFF
--- a/internal/api/samedevice_unix.go
+++ b/internal/api/samedevice_unix.go
@@ -54,3 +54,53 @@ func sameDevice(a, b string) bool {
 	}
 	return aStat.Dev == bStat.Dev
 }
+
+// nearestExistingDir returns p if it is an existing directory, otherwise the
+// nearest existing ancestor directory, or "" if none exists.
+func nearestExistingDir(p string) string {
+	for p != "" {
+		fi, err := os.Stat(p)
+		if err == nil && fi.IsDir() {
+			return p
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			return ""
+		}
+		p = parent
+	}
+	return ""
+}
+
+// hardlinkable reports whether downloads in a can actually be hard-linked into
+// b. Matching device IDs are necessary but NOT sufficient — two separate bind
+// mounts (or Unraid /mnt/user shares) report the same st_dev yet os.Link across
+// them fails with EXDEV. So after the cheap same-device gate this confirms with
+// a real link probe (created and cleaned up under the nearest existing
+// directories), which is what keeps the storage-health "share a filesystem"
+// message honest. If a probe file cannot be written it trusts the same-device
+// result rather than reporting a false negative. Mirrors importer.hardlinkable
+// (duplicated to keep api free of an importer dependency).
+func hardlinkable(a, b string) bool {
+	if !sameDevice(a, b) {
+		return false
+	}
+	aDir := nearestExistingDir(a)
+	bDir := nearestExistingDir(b)
+	if aDir == "" || bDir == "" {
+		return true
+	}
+	probe, err := os.CreateTemp(aDir, ".bindery-hlprobe-*")
+	if err != nil {
+		return true
+	}
+	name := probe.Name()
+	_ = probe.Close()
+	defer func() { _ = os.Remove(name) }()
+	link := filepath.Join(bDir, filepath.Base(name)+".lnk")
+	if err := os.Link(name, link); err != nil {
+		return false
+	}
+	_ = os.Remove(link)
+	return true
+}

--- a/internal/api/samedevice_windows.go
+++ b/internal/api/samedevice_windows.go
@@ -8,3 +8,10 @@ package api
 func sameDevice(_, _ string) bool {
 	return false
 }
+
+// hardlinkable mirrors sameDevice on Windows — device comparison is
+// unavailable, so the storage health endpoint reports downloads/library as not
+// hardlink-able.
+func hardlinkable(_, _ string) bool {
+	return false
+}

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -85,6 +85,6 @@ func (h *StorageHandler) Get(w http.ResponseWriter, _ *http.Request) {
 		LibraryDir:           cfg.LibraryDir,
 		AudiobookDir:         cfg.AudiobookDir,
 		Dirs:                 dirs,
-		Hardlinkable:         sameDevice(cfg.DownloadDir, cfg.LibraryDir),
+		Hardlinkable:         hardlinkable(cfg.DownloadDir, cfg.LibraryDir),
 	})
 }

--- a/internal/importer/hardlink_fallback_test.go
+++ b/internal/importer/hardlink_fallback_test.go
@@ -1,0 +1,114 @@
+//go:build !windows
+
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// forceEXDEV makes osLink behave as if every link crosses a device boundary,
+// the way os.Link does for separate bind mounts / Unraid user shares. Restored
+// on test cleanup.
+func forceEXDEV(t *testing.T) {
+	t.Helper()
+	orig := osLink
+	osLink = func(_, _ string) error {
+		return &os.LinkError{Op: "link", Err: syscall.EXDEV}
+	}
+	t.Cleanup(func() { osLink = orig })
+}
+
+// TestHardlinkFile_CrossDeviceFallsBackToCopy is the regression test for the
+// "stage hardlink: invalid cross-device link" import failure: when os.Link
+// returns EXDEV, the import must degrade to a copy (seeding-safe) instead of
+// failing, and the result must be an independent file, not a shared inode.
+func TestHardlinkFile_CrossDeviceFallsBackToCopy(t *testing.T) {
+	forceEXDEV(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.epub")
+	if err := os.WriteFile(src, []byte("seed-payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "library", "Author", "dst.epub")
+
+	if err := HardlinkFile(src, dst); err != nil {
+		t.Fatalf("HardlinkFile should fall back to copy on EXDEV, got: %v", err)
+	}
+
+	// Source must survive so the download client keeps seeding.
+	si, err := os.Stat(src)
+	if err != nil {
+		t.Fatalf("source removed by fallback: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(got) != "seed-payload" {
+		t.Fatalf("dst contents = %q, want seed-payload", got)
+	}
+	// It must be a real copy, not a hardlink (different inode).
+	di, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(si, di) {
+		t.Fatal("expected an independent copy, got a shared inode")
+	}
+}
+
+// TestStagedImport_HardlinkCrossDeviceFallsBackToCopy covers the same fallback
+// on the primary single-file book import path (StagedImport), and verifies the
+// staged file commits to dst with the source preserved.
+func TestStagedImport_HardlinkCrossDeviceFallsBackToCopy(t *testing.T) {
+	forceEXDEV(t)
+	dir := t.TempDir()
+	src := filepath.Join(dir, "download", "book.epub")
+	if err := os.MkdirAll(filepath.Dir(src), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("book-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "library", "book.epub")
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	staged, commit, rollback, err := StagedImport(context.Background(), "hardlink", src, dst)
+	if err != nil {
+		t.Fatalf("StagedImport hardlink EXDEV fallback: %v", err)
+	}
+	if staged == "" || commit == nil || rollback == nil {
+		t.Fatal("StagedImport returned nil commit/rollback")
+	}
+	if err := commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("source removed (hardlink/copy must preserve seeding): %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read committed dst: %v", err)
+	}
+	if string(got) != "book-bytes" {
+		t.Fatalf("committed dst = %q, want book-bytes", got)
+	}
+}
+
+// TestHardlinkable_RealProbe confirms the probe reports true for two paths that
+// genuinely support hardlinks (same temp dir) and false for empty input.
+func TestHardlinkable_RealProbe(t *testing.T) {
+	dir := t.TempDir()
+	if !hardlinkable(dir, dir) {
+		t.Fatal("same directory should be reported hardlinkable")
+	}
+	if hardlinkable("", dir) || hardlinkable(dir, "") {
+		t.Fatal("empty path must not be reported hardlinkable")
+	}
+}

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -294,14 +294,20 @@ func CopyFile(src, dst string) error {
 }
 
 // HardlinkFile creates a hard link at dst pointing to the same inode as src.
-// Both paths must be on the same filesystem — if they are not, os.Link returns
-// an error and no fallback is attempted (silently falling back to a move would
-// break seeding, which is the whole point of choosing hardlink mode).
+// When the two paths turn out to be on different mounts (EXDEV — common with
+// separate Docker bind mounts or Unraid /mnt/user shares that share a device id
+// but not a mount), it falls back to a COPY. A copy is seeding-safe: src is
+// left in place, so the download client keeps seeding — unlike a move fallback,
+// which would break seeding. The cost is extra disk for the imported copy.
+// Non-EXDEV errors (permissions, missing source) are returned as-is.
 func HardlinkFile(src, dst string) error {
 	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
 		return fmt.Errorf("create dir: %w", err)
 	}
-	if err := os.Link(src, dst); err != nil {
+	if err := osLink(src, dst); err != nil {
+		if crossDeviceErr(err) {
+			return copyFile(src, dst)
+		}
 		return fmt.Errorf("hardlink %q → %q: %w (download dir and library must be on the same filesystem)", src, dst, err)
 	}
 	return nil
@@ -403,7 +409,16 @@ func hardlinkDirRooted(srcRoot, dstRoot *os.Root, rel string) error {
 		}
 		srcPath := filepath.Join(srcRoot.Name(), child)
 		dstPath := filepath.Join(dstRoot.Name(), child)
-		if err := os.Link(srcPath, dstPath); err != nil {
+		if err := osLink(srcPath, dstPath); err != nil {
+			// Cross-mount (EXDEV): fall back to a seeding-safe rooted copy for
+			// this entry instead of failing the whole audiobook folder. See
+			// HardlinkFile for the copy-vs-move rationale.
+			if crossDeviceErr(err) {
+				if cerr := copyFileRooted(srcRoot, dstRoot, child); cerr != nil {
+					return fmt.Errorf("hardlink cross-device copy fallback %q → %q: %w", srcPath, dstPath, cerr)
+				}
+				continue
+			}
 			return fmt.Errorf("hardlink %q → %q: %w (download dir and library must be on the same filesystem)", srcPath, dstPath, err)
 		}
 	}
@@ -597,6 +612,11 @@ var (
 	moveFileCopy   = copyFileCtx
 )
 
+// osLink is an indirection seam over os.Link so tests can simulate a
+// cross-device (EXDEV) link failure and exercise the seeding-safe copy
+// fallback without a second real filesystem. Production always uses os.Link.
+var osLink = os.Link
+
 // MoveFileCtx is like MoveFile but returns ctx.Err() if the context is
 // cancelled during the cross-filesystem copy phase.
 func MoveFileCtx(ctx context.Context, src, dst string) error {
@@ -698,8 +718,19 @@ func StagedImport(ctx context.Context, mode, src, dst string) (stagedPath string
 
 	switch mode {
 	case "hardlink":
-		if err := os.Link(src, staged); err != nil {
-			return "", nil, nil, fmt.Errorf("stage hardlink: %w", err)
+		if err := osLink(src, staged); err != nil {
+			// Non-EXDEV errors (permissions, missing source) fail loudly.
+			if !crossDeviceErr(err) {
+				return "", nil, nil, fmt.Errorf("stage hardlink: %w", err)
+			}
+			// src and staged turned out to be on different mounts despite
+			// hardlink mode being selected (e.g. two bind mounts sharing a
+			// device id, or an operator forcing import.mode=hardlink). Fall
+			// back to COPY: unlike a move it preserves seeding (src is left in
+			// place), at the cost of extra disk.
+			if cerr := copyFileCtx(ctx, src, staged); cerr != nil {
+				return "", nil, nil, fmt.Errorf("stage hardlink cross-device copy fallback: %w", cerr)
+			}
 		}
 	case "copy":
 		if err := copyFileCtx(ctx, src, staged); err != nil {

--- a/internal/importer/samedevice_unix.go
+++ b/internal/importer/samedevice_unix.go
@@ -3,6 +3,7 @@
 package importer
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -51,4 +52,62 @@ func sameDevice(a, b string) bool {
 		return false
 	}
 	return aStat.Dev == bStat.Dev
+}
+
+// nearestExistingDir returns p if it is an existing directory, otherwise the
+// nearest ancestor directory that exists. Returns "" if none is found. A file
+// path resolves to its containing directory (the file itself is not a dir).
+func nearestExistingDir(p string) string {
+	for p != "" {
+		fi, err := os.Stat(p)
+		if err == nil && fi.IsDir() {
+			return p
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			return ""
+		}
+		p = parent
+	}
+	return ""
+}
+
+// hardlinkable reports whether a hardlink import from src into dst would
+// actually succeed. Matching device IDs (sameDevice) are necessary but NOT
+// sufficient: two separate bind mounts — or Unraid /mnt/user shares — report
+// the same st_dev yet os.Link across them fails with EXDEV ("invalid
+// cross-device link"). So after the cheap same-device gate it confirms with a
+// real link probe between the nearest existing directories of src and dst,
+// cleaning up the probe artifacts. If a probe file cannot be created (e.g. a
+// read-only download dir), it trusts the same-device result rather than
+// reporting a false negative.
+func hardlinkable(src, dst string) bool {
+	if !sameDevice(src, dst) {
+		return false
+	}
+	srcDir := nearestExistingDir(src)
+	dstDir := nearestExistingDir(dst)
+	if srcDir == "" || dstDir == "" {
+		return true
+	}
+	probe, err := os.CreateTemp(srcDir, ".bindery-hlprobe-*")
+	if err != nil {
+		return true
+	}
+	name := probe.Name()
+	_ = probe.Close()
+	defer func() { _ = os.Remove(name) }()
+	link := filepath.Join(dstDir, filepath.Base(name)+".lnk")
+	if err := os.Link(name, link); err != nil {
+		return false
+	}
+	_ = os.Remove(link)
+	return true
+}
+
+// crossDeviceErr reports whether err is an EXDEV ("invalid cross-device link")
+// failure — os.Link's signal that src and dst are on different mounts even when
+// they share a device id. Used to trigger the seeding-safe copy fallback.
+func crossDeviceErr(err error) bool {
+	return errors.Is(err, syscall.EXDEV)
 }

--- a/internal/importer/samedevice_windows.go
+++ b/internal/importer/samedevice_windows.go
@@ -7,3 +7,18 @@ package importer
 func sameDevice(_, _ string) bool {
 	return false
 }
+
+// hardlinkable mirrors sameDevice on Windows: device comparison is unavailable,
+// so the auto import mode falls back to "copy" rather than risk a failing
+// hardlink.
+func hardlinkable(_, _ string) bool {
+	return false
+}
+
+// crossDeviceErr is always false on Windows. Hardlink mode is never auto-
+// selected here (hardlinkable returns false), so the copy fallback path that
+// consults this is unreachable in practice; it exists so renamer.go compiles
+// without a build tag.
+func crossDeviceErr(_ error) bool {
+	return false
+}

--- a/internal/importer/scanner_handoff.go
+++ b/internal/importer/scanner_handoff.go
@@ -66,18 +66,23 @@ func (s *Scanner) configuredImportMode(ctx context.Context) string {
 
 // resolveImportMode picks the effective placement mode for a destination root.
 // An explicit operator setting (configuredMode) is honoured as-is. For the auto
-// default it returns "hardlink" when src and destRoot are on the same filesystem
-// (free, preserves seeding) or "copy" otherwise. destRoot MUST be the root the
-// files actually land under — per-author RootFolderID and audiobook roots can
-// live on a different mount than s.libraryDir, and choosing the mode against
-// s.libraryDir there picked an always-failing cross-device hardlink. Pass empty
-// strings for src/destRoot to get the cross-device default ("copy") without a
-// stat.
+// default it returns "hardlink" when a file can actually be hard-linked from
+// src into destRoot (free, preserves seeding) or "copy" otherwise. destRoot MUST be
+// the root the files actually land under — per-author RootFolderID and audiobook
+// roots can live on a different mount than s.libraryDir, and choosing the mode
+// against s.libraryDir there picked an always-failing cross-device hardlink.
+// Pass empty strings for src/destRoot to get the cross-device default ("copy")
+// without a probe.
+//
+// hardlinkable (not a bare same-device check) is used deliberately: separate
+// bind mounts and Unraid /mnt/user shares report the same st_dev yet reject
+// cross-mount hardlinks with EXDEV, so a device-ID match alone would auto-select
+// an always-failing hardlink mode.
 func (s *Scanner) resolveImportMode(configuredMode, src, destRoot string) string {
 	if configuredMode != "" {
 		return configuredMode
 	}
-	if sameDevice(src, destRoot) {
+	if hardlinkable(src, destRoot) {
 		return "hardlink"
 	}
 	slog.Warn("import.mode not set and src/dst are on different filesystems; defaulting to copy — seeding will be preserved but disk usage doubles")


### PR DESCRIPTION
## Report
> error: all 1 file(s) failed to import: stage hardlink: link /downloads/readarr/{BOOK} /books/{AUTHOR}/{BOOK}: invalid cross-device link — *Zig (Discord)*

His Docker mounts are two **separate** bind mounts (`/mnt/user/data/media/books:/books`, `/mnt/user/data/torrents:/downloads`), yet the Storage panel showed the green *"Downloads and library share a filesystem"* message.

## Root cause — two defects
**1. The "share a filesystem" claim was a false positive.** Both the storage-health check (`Hardlinkable`) and the auto import-mode selection (`resolveImportMode`) compared **only `st_dev`**. Two separate bind mounts — and Unraid `/mnt/user` shares — report the **same device id**, so the probe returned true: green message shown, auto-mode picked `hardlink`. But `os.Link` across them returns **EXDEV** because hardlinks can't cross a mount boundary. So the UI lied and the import always failed.

**2. No EXDEV fallback.** The hardlink staging paths returned the whole import as failed on any `os.Link` error. The existing `HardlinkFile` comment claimed a fallback "would break seeding" — that's true for a *move*, but a **copy** leaves the source in place and is seeding-safe. The maintainer conflated the two.

## Fix
- **Honest probe.** New `hardlinkable()` replaces the bare `sameDevice()` in `api` storage-health and `importer.resolveImportMode`: cheap same-device gate first (definite negative), then an **actual hardlink probe** between the nearest existing dirs (temp file created + linked + cleaned up). Now the green/amber message and the auto-mode are both truthful — Zig's setup correctly shows amber and auto-selects copy. *(No frontend change — `GeneralTab` already keys off `storage.hardlinkable`.)*
- **EXDEV → copy fallback** added to `StagedImport` (book files — Zig's exact path), `HardlinkFile`, and `hardlinkDirRooted` (audiobook folders). Seeding-safe (src preserved); non-EXDEV errors still fail loudly. Also covers operators who force `import.mode=hardlink` across devices.

## Implementation notes
- `os.Link` is indirected through an `osLink` seam so the EXDEV fallback is tested without a second real filesystem.
- EXDEV detection is isolated in build-tagged `crossDeviceErr` (returns false on Windows, where hardlink mode is never auto-selected), keeping `renamer.go` free of a build tag. Builds verified for `GOOS=linux` and `GOOS=windows`.

## Tests
`TestHardlinkFile_CrossDeviceFallsBackToCopy`, `TestStagedImport_HardlinkCrossDeviceFallsBackToCopy` (assert copy, src preserved, distinct inode), `TestHardlinkable_RealProbe`. Full `internal/importer` and `internal/api` suites green; targeted tests pass under `-race`; golangci-lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
