### PR TITLE
fix(author): match aliases in author search (#1176)

### DIFF
--- a/changelog.d/1176-author-alias-search.md
+++ b/changelog.d/1176-author-alias-search.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Author search now matches aliases / pen names** (#1176) — searching an AKA (e.g. a pen name stored as an alias) surfaces the canonical author that owns it, instead of returning no results.

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -172,8 +172,12 @@ func (r *AuthorRepo) ListPageFiltered(ctx context.Context, f AuthorListFilter, l
 		args = append(args, f.UserID)
 	}
 	if s := strings.TrimSpace(f.Search); s != "" {
-		conds = append(conds, "name LIKE ? ESCAPE '\\' COLLATE NOCASE")
-		args = append(args, "%"+escapeLike(s)+"%")
+		// Match the canonical name OR any of the author's aliases (#1176), so
+		// searching a pen name / AKA (e.g. "Cassandra Clare" stored as an alias
+		// of Holly Black) still surfaces the author that owns it.
+		like := "%" + escapeLike(s) + "%"
+		conds = append(conds, "(name LIKE ? ESCAPE '\\' COLLATE NOCASE OR id IN (SELECT author_id FROM author_aliases WHERE name LIKE ? ESCAPE '\\' COLLATE NOCASE))")
+		args = append(args, like, like)
 	}
 	if f.Monitored != nil {
 		conds = append(conds, "monitored = ?")

--- a/internal/db/list_filtered_test.go
+++ b/internal/db/list_filtered_test.go
@@ -330,3 +330,50 @@ func TestBookRepo_ListPageFiltered(t *testing.T) {
 		t.Errorf("title-za first = %v, want [Warbreaker]", za)
 	}
 }
+
+// TestAuthorRepo_ListPageFiltered_SearchMatchesAlias covers #1176: searching a
+// pen name / AKA stored in author_aliases must surface the canonical author
+// that owns the alias, not just exact authors.name matches.
+func TestAuthorRepo_ListPageFiltered_SearchMatchesAlias(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewAuthorRepo(database)
+	aliasRepo := NewAuthorAliasRepo(database)
+
+	holly := &models.Author{ForeignID: "OL-HB", Name: "Holly Black", SortName: "Black, Holly", Monitored: true}
+	if err := repo.Create(ctx, holly); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Create(ctx, &models.Author{ForeignID: "OL-XX", Name: "Someone Else", SortName: "Else, Someone", Monitored: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := aliasRepo.Create(ctx, &models.AuthorAlias{AuthorID: holly.ID, Name: "Cassandra Clare"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Full alias match returns exactly the canonical author.
+	got, total, err := repo.ListPageFiltered(ctx, AuthorListFilter{Search: "cassandra clare"}, 50, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(got) != 1 {
+		t.Fatalf("alias search: want 1 author, got total=%d len=%d", total, len(got))
+	}
+	if got[0].ID != holly.ID {
+		t.Fatalf("alias search returned id=%d name=%q, want Holly Black (id=%d)", got[0].ID, got[0].Name, holly.ID)
+	}
+
+	// Partial alias match also resolves to the owner.
+	if _, total, err := repo.ListPageFiltered(ctx, AuthorListFilter{Search: "Cassandra"}, 50, 0); err != nil || total != 1 {
+		t.Fatalf("partial alias search: want 1 (err nil), got total=%d err=%v", total, err)
+	}
+
+	// Canonical-name search is unaffected.
+	if _, total, err := repo.ListPageFiltered(ctx, AuthorListFilter{Search: "Holly"}, 50, 0); err != nil || total != 1 {
+		t.Fatalf("canonical name search: want 1 (err nil), got total=%d err=%v", total, err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1176. Author search (`AuthorRepo.ListPageFiltered`) matched the term only against `authors.name`, so searching a pen name / AKA stored in `author_aliases` returned nothing — even though the author exists (the reporter's "Cassandra Clare" resolves to Holly Black via an alias). The search now also matches any alias name and returns the canonical author that owns it.

## Changes
- `internal/db/authors.go`: search condition now `name LIKE ? OR id IN (SELECT author_id FROM author_aliases WHERE name LIKE ?)`. The COUNT and page queries share the WHERE/args, so pagination totals stay correct.
- Test `TestAuthorRepo_ListPageFiltered_SearchMatchesAlias` covers full + partial alias match and confirms canonical-name search is unaffected.

## Test
`go test ./internal/db/ -run ListPageFiltered_Search` passes.