### PR TITLE
feat(web): link to upstream metadata source on detail pages (#1296)

### DIFF
--- a/changelog.d/1296-metadata-source-links.md
+++ b/changelog.d/1296-metadata-source-links.md
@@ -1,0 +1,2 @@
+### Added
+- **Links to the upstream metadata source** (#1296) — author and book detail pages now show a "View on OpenLibrary / Google Books" link (à la the *arr stacks' TMDB/IMDB links) when the source has a stable public page.

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "loading": "Loading...",
+    "viewOnSource": "View on {{source}} ↗",
     "gridView": "Grid view",
     "tableView": "Table view",
     "cancel": "Cancel",

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -11,6 +11,7 @@ import BulkActionBar from '../components/BulkActionBar'
 import { useView } from '../components/useView'
 import MarkdownDescription from '../components/MarkdownDescription'
 import { canLinkAuthorMetadata, hasSparseMetadata } from '../util/authorMetadata'
+import { metadataSourceLink } from '../util/metadataSource'
 import { btn } from '../components/buttons'
 import Switch from '../components/Switch'
 
@@ -614,6 +615,19 @@ export default function AuthorDetailPage() {
             {author.averageRating > 0 && (
               <span>★ {author.averageRating.toFixed(2)} ({author.ratingsCount.toLocaleString()} ratings)</span>
             )}
+            {(() => {
+              const src = metadataSourceLink(author.foreignAuthorId, 'author')
+              return src ? (
+                <a
+                  href={src.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-emerald-600 dark:text-emerald-400 hover:underline"
+                >
+                  {t('common.viewOnSource', { source: src.label, defaultValue: 'View on {{source}} ↗' })}
+                </a>
+              ) : null
+            })()}
           </div>
           {author.description && (
             <MarkdownDescription

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -10,6 +10,7 @@ import ConfirmDialog from '../components/ConfirmDialog'
 import ClipboardManualFallback from '../components/ClipboardManualFallback'
 import { useClipboardCopy } from '../components/useClipboardCopy'
 import { safeHref } from '../util/safeHref'
+import { metadataSourceLink } from '../util/metadataSource'
 
 function formatSize(n: number): string {
   if (!n || n <= 0) return ''
@@ -491,6 +492,22 @@ export default function BookDetailPage() {
                 <span className="text-slate-600 dark:text-zinc-400">{formatDuration(book.durationSeconds)}</span>
               </>
             ) : null}
+            {(() => {
+              const src = metadataSourceLink(book.foreignBookId, 'book')
+              return src ? (
+                <>
+                  <span aria-hidden className="text-slate-400 dark:text-zinc-600">·</span>
+                  <a
+                    href={src.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-emerald-600 dark:text-emerald-400 hover:underline"
+                  >
+                    {t('common.viewOnSource', { source: src.label, defaultValue: 'View on {{source}} ↗' })}
+                  </a>
+                </>
+              ) : null
+            })()}
           </div>
 
           {book.description && (

--- a/web/src/util/metadataSource.test.ts
+++ b/web/src/util/metadataSource.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { metadataSourceLink } from './metadataSource'
+
+describe('metadataSourceLink', () => {
+  it('links OpenLibrary authors', () => {
+    expect(metadataSourceLink('OL23919A', 'author')).toEqual({
+      url: 'https://openlibrary.org/authors/OL23919A',
+      label: 'OpenLibrary',
+    })
+  })
+
+  it('links OpenLibrary works and editions for books', () => {
+    expect(metadataSourceLink('OL27448W', 'book')?.url).toBe('https://openlibrary.org/works/OL27448W')
+    expect(metadataSourceLink('OL7353617M', 'book')?.url).toBe('https://openlibrary.org/books/OL7353617M')
+  })
+
+  it('links Google Books only for books', () => {
+    expect(metadataSourceLink('gb:zyTCAlFPjgYC', 'book')).toEqual({
+      url: 'https://books.google.com/books?id=zyTCAlFPjgYC',
+      label: 'Google Books',
+    })
+    expect(metadataSourceLink('gb:zyTCAlFPjgYC', 'author')).toBeNull()
+  })
+
+  it('returns null for providers without a reliable public URL', () => {
+    expect(metadataSourceLink('hc:12345', 'book')).toBeNull()
+    expect(metadataSourceLink('dnb:123456789', 'book')).toBeNull()
+    expect(metadataSourceLink('abs:abc', 'book')).toBeNull()
+    expect(metadataSourceLink('calibre:7', 'book')).toBeNull()
+  })
+
+  it('returns null for empty / malformed ids', () => {
+    expect(metadataSourceLink('', 'author')).toBeNull()
+    expect(metadataSourceLink(undefined, 'book')).toBeNull()
+    expect(metadataSourceLink('gb:', 'book')).toBeNull()
+    expect(metadataSourceLink('OL123', 'author')).toBeNull() // no trailing A
+  })
+})

--- a/web/src/util/metadataSource.ts
+++ b/web/src/util/metadataSource.ts
@@ -1,0 +1,42 @@
+// Build a link to the upstream metadata source for an author or book, à la
+// the *arr stacks' TMDB/IMDB links (#1296). The provider is implied by the
+// foreign-ID prefix, matching the backend convention in
+// internal/metadata/aggregator_providers.go and models.AuthorProviderFromForeignID.
+//
+// We only emit a link when the public URL can be constructed reliably from the
+// stored ID. OpenLibrary (bare OL keys) and Google Books (gb:) qualify;
+// Hardcover (hc:), DNB (dnb:), Calibre and Audiobookshelf do not — their stored
+// IDs don't map to a stable public page — so those return null rather than risk
+// a dead link.
+
+export type MetadataSourceLink = { url: string; label: string }
+
+export function metadataSourceLink(
+  foreignId: string | undefined | null,
+  kind: 'author' | 'book',
+): MetadataSourceLink | null {
+  const id = (foreignId ?? '').trim()
+  if (!id) return null
+
+  if (id.startsWith('gb:')) {
+    const vol = id.slice(3).trim()
+    // Google Books has no canonical author page; only books map cleanly.
+    if (kind !== 'book' || !vol) return null
+    return { url: `https://books.google.com/books?id=${encodeURIComponent(vol)}`, label: 'Google Books' }
+  }
+
+  // No reliable public URL for these providers.
+  if (id.startsWith('hc:') || id.startsWith('dnb:') || id.startsWith('abs:') || id.startsWith('calibre:')) {
+    return null
+  }
+
+  // Default: OpenLibrary, whose foreign IDs are bare OL keys. Author keys end
+  // in A, work keys in W, edition keys in M.
+  if (kind === 'author') {
+    if (!/^OL\w+A$/i.test(id)) return null
+    return { url: `https://openlibrary.org/authors/${id}`, label: 'OpenLibrary' }
+  }
+  if (/^OL\w+W$/i.test(id)) return { url: `https://openlibrary.org/works/${id}`, label: 'OpenLibrary' }
+  if (/^OL\w+M$/i.test(id)) return { url: `https://openlibrary.org/books/${id}`, label: 'OpenLibrary' }
+  return null
+}


### PR DESCRIPTION
## Summary

Closes #1296. Adds *arr-style links to the upstream metadata source on the author and book detail pages.

- Author header meta line gets a **View on OpenLibrary ↗** link.
- Book detail meta line gets **View on OpenLibrary / Google Books ↗**.

The provider is inferred from the foreign-ID prefix (same convention as `internal/metadata/aggregator_providers.go`). Links are only emitted where the public URL is reliably constructible:

| Source | Author | Book |
|--------|--------|------|
| OpenLibrary (bare `OL…` key) | `/authors/OL…A` | `/works/OL…W`, `/books/OL…M` |
| Google Books (`gb:`) | — (no canonical page) | `books?id=…` |
| Hardcover / DNB / Calibre / ABS | — | — (no stable public URL from stored ID) |

Frontend-only: the needed data (`foreignAuthorId`/`foreignBookId`) is already in the API, so no backend/DB change.

## Test
- New unit test `web/src/util/metadataSource.test.ts` (5 cases): OL author/work/edition, Google Books books-only, null for hc/dnb/abs/calibre, null for empty/malformed.
- `tsc --noEmit` and `eslint` clean on changed files.