### PR TITLE
feat(importer): Fix Match — reassign a file to a different book (#1238)

### DIFF
--- a/changelog.d/1238-fix-match.md
+++ b/changelog.d/1238-fix-match.md
@@ -1,0 +1,2 @@
+### Added
+- **Fix Match** (#1238) — a book's file can now be reassigned to a different book from the book detail page. The file is moved into the correct book's library folder and the mis-filed copy is removed, so a later library scan won't re-attach it to the wrong book.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -816,6 +816,7 @@ func main() {
 			r.Get("/queue/manual-import/scan", manualImportHandler.Scan)
 			r.Post("/queue/manual-import", manualImportHandler.Import)
 			r.Post("/queue/manual-import/batch", manualImportHandler.ImportBatch)
+			r.Post("/queue/manual-import/reassign", manualImportHandler.Reassign)
 		})
 		r.Get("/pending", pendingHandler.List)
 		r.Delete("/pending/{id}", pendingHandler.Delete)

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -151,6 +153,90 @@ func (h *ManualImportHandler) Import(w http.ResponseWriter, r *http.Request) {
 	}
 	go h.scanner.ImportFromPath(context.WithoutCancel(r.Context()), dl, path, req.Format)
 	writeJSON(w, http.StatusAccepted, dl)
+}
+
+// reassignRequest moves a single already-imported file to a different book
+// ("Fix Match", #1238) when the importer attached it to the wrong one.
+type reassignRequest struct {
+	// Path is the current on-disk path of the mis-matched file (book_files.path).
+	Path string `json:"path"`
+	// TargetBookID is the book the file should belong to.
+	TargetBookID int64 `json:"targetBookId"`
+	// Format is optional; auto-detected when empty. "ebook" or "audiobook".
+	Format string `json:"format"`
+}
+
+// Reassign handles POST /api/v1/queue/manual-import/reassign.
+//
+// It detaches the file from whatever book currently owns it and re-imports it
+// against TargetBookID, reusing the manual-import move/attach path so the file
+// is renamed into the correct book's library folder rather than just re-pointed
+// in the database. Returns 202 with the synthetic Download record that drives
+// the async import.
+func (h *ManualImportHandler) Reassign(w http.ResponseWriter, r *http.Request) {
+	var req reassignRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if strings.TrimSpace(req.Path) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "path is required"})
+		return
+	}
+	// Validate path containment, confirm the target book exists, and create the
+	// synthetic Download record. Nothing is mutated on failure.
+	dl, path, status, msg := h.prepareImport(r.Context(), req.Path, req.TargetBookID, req.Format)
+	if dl == nil {
+		writeJSON(w, status, map[string]string{"error": msg})
+		return
+	}
+	// Detach the stale association from the book that currently owns this path.
+	// RemoveBookFile is status-aware (flips a now-fileless source book back to
+	// "wanted") and is a no-op when the path isn't tracked. Best-effort: even if
+	// it fails, the re-import below still re-points the file to the target.
+	if _, err := h.books.RemoveBookFile(r.Context(), path); err != nil {
+		slog.Warn("reassign: detach source book file", "path", path, "error", err)
+	}
+	ctx := context.WithoutCancel(r.Context())
+	targetID := req.TargetBookID
+	go func() {
+		h.scanner.ImportFromPath(ctx, dl, path, req.Format)
+		h.removeStaleSource(ctx, path, targetID)
+	}()
+	writeJSON(w, http.StatusAccepted, dl)
+}
+
+// removeStaleSource deletes the original mis-filed copy after a successful
+// reassign. The import places the file under the target book (by hardlink or
+// copy), leaving the original where it was — which a later library scan would
+// re-attach to the wrong book. We remove it, but only once we can confirm the
+// import actually put the file somewhere else: the target must now have a
+// tracked file at a different path that exists on disk. If the import failed
+// (no new file) or resolved to the same path, the source is left untouched so a
+// file is never lost.
+func (h *ManualImportHandler) removeStaleSource(ctx context.Context, src string, targetID int64) {
+	files, err := h.books.ListBookFiles(ctx, targetID)
+	if err != nil {
+		slog.Warn("reassign cleanup: list target files", "error", err)
+		return
+	}
+	moved := false
+	for _, f := range files {
+		if f.Path == src {
+			return // target ended up at the same path; nothing to clean up
+		}
+		if _, statErr := os.Stat(f.Path); statErr == nil {
+			moved = true
+		}
+	}
+	if !moved {
+		return // import did not place a new file; leave the source in place
+	}
+	if err := os.Remove(src); err != nil {
+		slog.Warn("reassign cleanup: remove stale source file", "path", src, "error", err)
+		return
+	}
+	_ = os.Remove(filepath.Dir(src)) // best-effort: prune the now-empty folder
 }
 
 // ScanItem is one candidate book unit discovered under a folder during Scan.

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -761,3 +761,83 @@ func TestManualImportBatch_Empty(t *testing.T) {
 		t.Fatalf("status = %d, want 400 for empty batch", rec.Code)
 	}
 }
+
+func TestManualImportReassign_DetachesSourceAndImportsTarget(t *testing.T) {
+	t.Parallel()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	bookFiles := db.NewBookFileRepo(database)
+	ctx := context.Background()
+
+	src := seedBook(t, authors, books, ctx) // file is wrongly attached here
+	target := &models.Book{
+		ForeignID: "mi-book-2", AuthorID: src.AuthorID,
+		Title: "Correct Book", SortTitle: "correct book",
+		Status: "wanted", Genres: []string{},
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, target); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	tmp := t.TempDir()
+	epub := filepath.Join(tmp, "mismatched.epub")
+	if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, src.ID, models.MediaTypeEbook, epub); err != nil {
+		t.Fatalf("attach file to source: %v", err)
+	}
+
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books)
+	body, _ := json.Marshal(map[string]any{"path": epub, "targetBookId": target.ID, "format": models.MediaTypeEbook})
+	rec := httptest.NewRecorder()
+	h.Reassign(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/reassign", bytes.NewReader(body)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", rec.Code, rec.Body.String())
+	}
+
+	// The stale association is gone from the source book (the actual move to the
+	// target is performed by the stubbed ImportFromPath, exercised live, not here).
+	srcFiles, err := bookFiles.ListByBook(ctx, src.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(srcFiles) != 0 {
+		t.Errorf("source book still has %d file(s); want 0 after reassign", len(srcFiles))
+	}
+}
+
+func TestManualImportReassign_EmptyPath(t *testing.T) {
+	t.Parallel()
+	h, _, _, _, _ := manualImportFixture(t)
+	body, _ := json.Marshal(map[string]any{"path": "  ", "targetBookId": 1})
+	rec := httptest.NewRecorder()
+	h.Reassign(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/reassign", bytes.NewReader(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestManualImportReassign_TargetNotFound(t *testing.T) {
+	t.Parallel()
+	h, _, _, _, _ := manualImportFixture(t)
+	tmp := t.TempDir()
+	epub := filepath.Join(tmp, "book.epub")
+	if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(map[string]any{"path": epub, "targetBookId": 9999})
+	rec := httptest.NewRecorder()
+	h.Reassign(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/reassign", bytes.NewReader(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (book not found); body = %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -558,6 +558,11 @@ func (r *BookRepo) ListAllBookFilePaths(ctx context.Context) ([]string, error) {
 	return r.files.ListAllPaths(ctx)
 }
 
+// ListBookFiles returns the book_files rows for a single book.
+func (r *BookRepo) ListBookFiles(ctx context.Context, bookID int64) ([]models.BookFile, error) {
+	return r.files.ListByBook(ctx, bookID)
+}
+
 // refreshBookStatus recomputes the aggregate status for a book from its
 // current book_files rows and updates both the status and legacy columns.
 // It queries book_files directly so the result is always authoritative,

--- a/web/src/api/books.ts
+++ b/web/src/api/books.ts
@@ -116,6 +116,11 @@ export const booksApi = {
   addBook: (data: { foreignBookId: string; foreignAuthorId: string; authorName?: string; searchOnAdd?: boolean }) =>
     request<Book>('/author/book', { method: 'POST', body: JSON.stringify(data) }),
 
+  // Fix Match (#1238): move a mis-matched file to a different book. The file is
+  // detached from its current book and re-imported into the target's folder.
+  reassignFile: (data: { path: string; targetBookId: number; format?: string }) =>
+    request<{ id: number }>('/queue/manual-import/reassign', { method: 'POST', body: JSON.stringify(data) }),
+
   // Books
   listBooks: (params?: { authorId?: number; status?: string; includeExcluded?: boolean; limit?: number; offset?: number; search?: string; mediaType?: string; sort?: string; releaseFrom?: string; releaseBefore?: string }) => {
     const q = new URLSearchParams()

--- a/web/src/components/FixMatchModal.tsx
+++ b/web/src/components/FixMatchModal.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api, Book } from '../api/client'
+
+type Props = {
+  sourceBookId: number
+  path: string
+  format: string
+  onClose: () => void
+  onReassigned: (targetBookId: number) => void
+}
+
+// FixMatchModal lets the user move a mis-matched file to the correct existing
+// book (#1238). It searches the library and POSTs the chosen target to the
+// reassign endpoint; the backend moves the file into the target's folder.
+export default function FixMatchModal({ sourceBookId, path, format, onClose, onReassigned }: Props) {
+  const { t } = useTranslation()
+  const [term, setTerm] = useState('')
+  const [results, setResults] = useState<Book[]>([])
+  const [loading, setLoading] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const q = term.trim()
+    if (q.length < 2) {
+      setResults([])
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    const handle = setTimeout(async () => {
+      try {
+        const { items } = await api.listBooks({ search: q, limit: 20 })
+        if (!cancelled) setResults(items.filter(b => b.id !== sourceBookId))
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'search failed')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }, 300)
+    return () => {
+      cancelled = true
+      clearTimeout(handle)
+    }
+  }, [term, sourceBookId])
+
+  const reassign = async (target: Book) => {
+    setSubmitting(true)
+    setError('')
+    try {
+      await api.reassignFile({ path, targetBookId: target.id, format })
+      onReassigned(target.id)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'reassign failed')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 pt-20"
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className="w-full max-w-lg rounded-lg bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 shadow-xl"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        <div className="p-4 border-b border-slate-200 dark:border-zinc-800">
+          <h3 className="text-base font-semibold">
+            {t('bookDetail.fixMatch.title', 'Reassign file to another book')}
+          </h3>
+          <p className="mt-1 text-xs text-slate-500 dark:text-zinc-500 font-mono truncate" title={path}>
+            {path}
+          </p>
+        </div>
+        <div className="p-4">
+          <input
+            autoFocus
+            type="text"
+            value={term}
+            onChange={e => setTerm(e.target.value)}
+            placeholder={t('bookDetail.fixMatch.searchPlaceholder', 'Search your library for the correct book…')}
+            className="w-full px-3 py-2 rounded border border-slate-300 dark:border-zinc-700 bg-white dark:bg-zinc-950 text-sm"
+          />
+          {error && <p className="mt-2 text-xs text-red-600 dark:text-red-400">{error}</p>}
+          <div className="mt-3 max-h-72 overflow-y-auto divide-y divide-slate-100 dark:divide-zinc-800">
+            {loading && <p className="py-3 text-xs text-slate-500 dark:text-zinc-500">{t('common.loading')}</p>}
+            {!loading && term.trim().length >= 2 && results.length === 0 && (
+              <p className="py-3 text-xs text-slate-500 dark:text-zinc-500">
+                {t('bookDetail.fixMatch.noResults', 'No matching books in your library')}
+              </p>
+            )}
+            {results.map(b => (
+              <button
+                key={b.id}
+                type="button"
+                disabled={submitting}
+                onClick={() => reassign(b)}
+                className="block w-full text-left py-2 px-1 rounded hover:bg-slate-100 dark:hover:bg-zinc-800 disabled:opacity-50"
+              >
+                <span className="text-sm font-medium text-slate-900 dark:text-white">{b.title}</span>
+                {b.author?.authorName && (
+                  <span className="text-xs text-slate-500 dark:text-zinc-500"> · {b.author.authorName}</span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="p-4 border-t border-slate-200 dark:border-zinc-800 flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs rounded bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700"
+          >
+            {t('common.cancel')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -947,6 +947,13 @@
     "unexcludeHint": "Un-exclude this book from searches and the Wanted page",
     "deleteFile": "Delete file",
     "deletingFile": "Deleting…",
+    "fixMatch": {
+      "button": "Fix match",
+      "hint": "Move this file to a different book",
+      "title": "Reassign file to another book",
+      "searchPlaceholder": "Search your library for the correct book…",
+      "noResults": "No matching books in your library"
+    },
     "audiobookHeading": "Audiobook metadata",
     "asinLabel": "ASIN (Audible identifier)",
     "saveAsin": "Save ASIN",

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -11,6 +11,7 @@ import ClipboardManualFallback from '../components/ClipboardManualFallback'
 import { useClipboardCopy } from '../components/useClipboardCopy'
 import { safeHref } from '../util/safeHref'
 import { metadataSourceLink } from '../util/metadataSource'
+import FixMatchModal from '../components/FixMatchModal'
 
 function formatSize(n: number): string {
   if (!n || n <= 0) return ''
@@ -179,6 +180,7 @@ export default function BookDetailPage() {
   const [deletingBook, setDeletingBook] = useState(false)
   const [togglingExclude, setTogglingExclude] = useState(false)
   const [showRebind, setShowRebind] = useState(false)
+  const [showFixMatch, setShowFixMatch] = useState(false)
   const [showDeleteBook, setShowDeleteBook] = useState(false)
   const pathClipboard = useClipboardCopy()
   // For dual-format books, which format the file section is acting on.
@@ -639,6 +641,15 @@ export default function BookDetailPage() {
             </button>
             <button
               type="button"
+              onClick={() => setShowFixMatch(true)}
+              disabled={!hasActiveFile || deletingFile || deletingBook}
+              className={actionBtnCls}
+              title={t('bookDetail.fixMatch.hint', 'Move this file to a different book')}
+            >
+              {t('bookDetail.fixMatch.button', 'Fix match')}
+            </button>
+            <button
+              type="button"
               onClick={() => deleteFile(isDual ? fmt : undefined)}
               disabled={deletingFile || deletingBook || !hasActiveFile}
               className={`ml-auto ${dangerBtnCls}`}
@@ -788,6 +799,19 @@ export default function BookDetailPage() {
           onSuccess={updated => {
             setBook(updated)
             setShowRebind(false)
+          }}
+        />
+      )}
+
+      {showFixMatch && hasActiveFile && (
+        <FixMatchModal
+          sourceBookId={book.id}
+          path={activePath}
+          format={fmt}
+          onClose={() => setShowFixMatch(false)}
+          onReassigned={targetId => {
+            setShowFixMatch(false)
+            navigate(`/book/${targetId}`)
           }}
         />
       )}


### PR DESCRIPTION
## Summary

Closes #1238. When the importer attaches a file to the wrong book, you can now correct it: a **Fix match** button on the book detail page (next to Exclude) opens a picker to search your library and choose the correct book. The file is moved into that book's folder, detached from the wrong one, and the stale copy at the old location is removed.

## Implementation
- **Backend** (`POST /api/v1/queue/manual-import/reassign`, admin-only): reuses the manual-import move/attach path.
  - `prepareImport` validates path containment + target book.
  - `RemoveBookFile` detaches the source (status-aware: source flips back to `wanted`).
  - async `ImportFromPath` places the file under the target book.
  - `removeStaleSource` deletes the original **only after** confirming the target has a new file at a different existing path — so a failed import or same-path reassign never deletes data.
- **Frontend**: `FixMatchModal` (library search) + a "Fix match" button on the file action bar.

## Tests
- Unit: `TestManualImportReassign_*` (detach + validation), `go vet`, frontend `tsc`/`eslint`, `BookDetailPage` suite (136 tests).
- **Live (headless browser, isolated instance)**: drove the full UI flow; confirmed on disk + DB that the file moves to the correct book's folder, the source book flips to `wanted`, the target to `imported`, and **no orphaned copy** remains at the old location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)