### PR TITLE
fix(notifier): render ntfy notifications natively, not as raw JSON (#1323)

### DIFF
--- a/changelog.d/1323-ntfy-native.md
+++ b/changelog.d/1323-ntfy-native.md
@@ -1,0 +1,2 @@
+### Fixed
+- **ntfy notifications render natively instead of as raw JSON** (#1323). Set a notification's new **topic** field and point the URL at the ntfy server root; Bindery then posts a JSON body ntfy parses. Every event now also sends a meaningful `title` (what happened) and `message` (the subject) rather than repeating the item name twice, and carries `eventType` so one template can branch per event. The webhook payload schema is documented in `docs/API.md`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -138,6 +138,26 @@ PUT    /api/v1/system/loglevel                    runtime log-level switch (debu
 GET    /api/v1/images?url=<encoded>               proxied + cached cover image (30-day TTL)
 ```
 
+#### Webhook payload
+
+Every event POSTs a JSON body with a consistent shape so relays render it
+without a custom template:
+
+| Field | Meaning |
+|-------|---------|
+| `eventType` | `grabbed` \| `bookImported` \| `upgrade` \| `downloadFailed` \| `health` \| `test` — present on **every** event |
+| `title` | what happened, e.g. `Release Grabbed`, `Book Imported`, `Download Failed` |
+| `message` | the subject, e.g. `The Way of Kings · Brandon Sanderson` |
+| `body` | alias of `message` (Apprise requires a `body` field) |
+| `item` | the raw release/book name (the title before it was moved into `message`) |
+| event extras | `author`, `format`, `size`, `path`, `status`, `clientId` when relevant |
+
+**ntfy:** set the notification's **topic** field and point the URL at the ntfy
+server root (e.g. `https://ntfy.sh`). Bindery then POSTs the JSON body with a
+`topic` field to the root, which ntfy renders natively. Without a topic it POSTs
+to the URL as-is, so a topic URL would show the raw JSON — use the topic field
+or ntfy message-templating headers (`X-Title`, `X-Message`) instead.
+
 ### Auth and users (admin)
 
 ```

--- a/internal/db/migrations/057_notification_topic.sql
+++ b/internal/db/migrations/057_notification_topic.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+-- ntfy renders a JSON body natively only when the request is POSTed to the
+-- server root with a "topic" field. When this column is set, the notifier posts
+-- to the root URL instead of the topic URL so ntfy formats the message instead
+-- of printing the raw JSON (see issue 1323).
+ALTER TABLE notifications ADD COLUMN topic TEXT NOT NULL DEFAULT '';
+
+-- +migrate Down
+ALTER TABLE notifications DROP COLUMN topic;

--- a/internal/db/notifications.go
+++ b/internal/db/notifications.go
@@ -20,7 +20,7 @@ func NewNotificationRepo(db *sql.DB) *NotificationRepo {
 
 func (r *NotificationRepo) List(ctx context.Context) ([]models.Notification, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, name, type, url, method, headers,
+		SELECT id, name, type, url, method, headers, topic,
 		       on_grab, on_import, on_upgrade, on_failure, on_health,
 		       enabled, created_at, updated_at
 		FROM notifications ORDER BY id`)
@@ -42,7 +42,7 @@ func (r *NotificationRepo) List(ctx context.Context) ([]models.Notification, err
 
 func (r *NotificationRepo) GetByID(ctx context.Context, id int64) (*models.Notification, error) {
 	row := r.db.QueryRowContext(ctx, `
-		SELECT id, name, type, url, method, headers,
+		SELECT id, name, type, url, method, headers, topic,
 		       on_grab, on_import, on_upgrade, on_failure, on_health,
 		       enabled, created_at, updated_at
 		FROM notifications WHERE id=?`, id)
@@ -57,11 +57,11 @@ func (r *NotificationRepo) GetByID(ctx context.Context, id int64) (*models.Notif
 func (r *NotificationRepo) Create(ctx context.Context, n *models.Notification) error {
 	now := time.Now().UTC()
 	result, err := r.db.ExecContext(ctx, `
-		INSERT INTO notifications (name, type, url, method, headers,
+		INSERT INTO notifications (name, type, url, method, headers, topic,
 		                           on_grab, on_import, on_upgrade, on_failure, on_health,
 		                           enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		n.Name, n.Type, n.URL, n.Method, n.Headers,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		n.Name, n.Type, n.URL, n.Method, n.Headers, n.Topic,
 		n.OnGrab, n.OnImport, n.OnUpgrade, n.OnFailure, n.OnHealth,
 		n.Enabled, now, now)
 	if err != nil {
@@ -78,11 +78,11 @@ func (r *NotificationRepo) Update(ctx context.Context, n *models.Notification) e
 	now := time.Now().UTC()
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE notifications
-		SET name=?, type=?, url=?, method=?, headers=?,
+		SET name=?, type=?, url=?, method=?, headers=?, topic=?,
 		    on_grab=?, on_import=?, on_upgrade=?, on_failure=?, on_health=?,
 		    enabled=?, updated_at=?
 		WHERE id=?`,
-		n.Name, n.Type, n.URL, n.Method, n.Headers,
+		n.Name, n.Type, n.URL, n.Method, n.Headers, n.Topic,
 		n.OnGrab, n.OnImport, n.OnUpgrade, n.OnFailure, n.OnHealth,
 		n.Enabled, now, n.ID)
 	if err != nil {
@@ -106,7 +106,7 @@ func (r *NotificationRepo) scanRow(s scanner) (*models.Notification, error) {
 	var n models.Notification
 	var onGrab, onImport, onUpgrade, onFailure, onHealth, enabled int
 	if err := s.Scan(
-		&n.ID, &n.Name, &n.Type, &n.URL, &n.Method, &n.Headers,
+		&n.ID, &n.Name, &n.Type, &n.URL, &n.Method, &n.Headers, &n.Topic,
 		&onGrab, &onImport, &onUpgrade, &onFailure, &onHealth,
 		&enabled, &n.CreatedAt, &n.UpdatedAt,
 	); err != nil {

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -9,6 +9,10 @@ type Notification struct {
 	URL       string    `json:"url"`
 	Method    string    `json:"method"`
 	Headers   string    `json:"headers"`
+	// Topic, when set, makes the webhook POST to the server root with a "topic"
+	// field instead of POSTing to URL directly. This is what ntfy needs to render
+	// a JSON payload natively instead of printing it verbatim (#1323).
+	Topic     string    `json:"topic"`
 	OnGrab    bool      `json:"onGrab"`
 	OnImport  bool      `json:"onImport"`
 	OnUpgrade bool      `json:"onUpgrade"`

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -3,12 +3,12 @@ package models
 import "time"
 
 type Notification struct {
-	ID        int64     `json:"id"`
-	Name      string    `json:"name"`
-	Type      string    `json:"type"`
-	URL       string    `json:"url"`
-	Method    string    `json:"method"`
-	Headers   string    `json:"headers"`
+	ID      int64  `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	URL     string `json:"url"`
+	Method  string `json:"method"`
+	Headers string `json:"headers"`
 	// Topic, when set, makes the webhook POST to the server root with a "topic"
 	// field instead of POSTing to URL directly. This is what ntfy needs to render
 	// a JSON payload natively instead of printing it verbatim (#1323).

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -26,6 +27,90 @@ const (
 	EventHealth         = "health"
 	EventUpgrade        = "upgrade"
 )
+
+// normalizeEventPayload gives every event a consistent, human-readable shape so
+// relays that render without a template (ntfy, Apprise) read well, and so a
+// template can branch on the event (#1323). It sets `title` to *what happened*
+// (the event) and `message` to *the subject*, mirroring the Sonarr/Radarr shape
+// — previously `title` carried the item and `message` was often absent, so the
+// notification showed the same string twice and never said what occurred. The
+// original item name is preserved under `item`, and `eventType` is added to
+// every payload (not just `test`) so templates can key off it. All original
+// fields (size, format, path, status, clientId, …) are kept for templaters.
+func normalizeEventPayload(eventType string, payload map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(payload)+3)
+	for k, v := range payload {
+		out[k] = v
+	}
+	out["eventType"] = eventType
+
+	item, _ := out["title"].(string)
+	if item != "" {
+		out["item"] = item
+	}
+	msg, _ := out["message"].(string)
+	author, _ := out["author"].(string)
+	format, _ := out["format"].(string)
+	status, _ := out["status"].(string)
+
+	var title, body string
+	switch eventType {
+	case EventGrabbed:
+		title, body = "Release Grabbed", item
+		if author != "" {
+			body = item + " · " + author
+		}
+	case EventBookImported:
+		title, body = "Book Imported", item
+		if format != "" {
+			body = item + " (" + format + ")"
+		}
+	case EventUpgrade:
+		title, body = "Book Upgraded", item
+		if format != "" {
+			body = item + " (" + format + ")"
+		}
+	case EventDownloadFailed:
+		title = "Download Failed"
+		switch {
+		case item != "" && msg != "":
+			body = item + ": " + msg
+		case item != "":
+			body = item
+		default:
+			body = msg
+		}
+	case EventHealth:
+		title = "Download Client Unhealthy"
+		if body = msg; body == "" {
+			body = status
+		}
+	case "test":
+		title = "Bindery Test"
+		if body = msg; body == "" {
+			body = "Bindery notification test"
+		}
+	default:
+		title, body = item, msg
+	}
+	out["title"] = title
+	out["message"] = body
+	return out
+}
+
+// ntfyRootURL strips a topic URL (https://ntfy.sh/mytopic) down to the server
+// root (https://ntfy.sh/) so a JSON body with a "topic" field publishes
+// natively. Returns raw unchanged if it can't be parsed.
+func ntfyRootURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	u.Path = "/"
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
 
 // Notifier dispatches webhook notifications for Bindery events.
 type Notifier struct {
@@ -99,6 +184,7 @@ func (n *Notifier) Send(ctx context.Context, eventType string, payload map[strin
 		return
 	}
 
+	out := normalizeEventPayload(eventType, payload)
 	for _, notif := range notifications {
 		if !notif.Enabled {
 			continue
@@ -106,7 +192,7 @@ func (n *Notifier) Send(ctx context.Context, eventType string, payload map[strin
 		if !n.matchesEvent(&notif, eventType) {
 			continue
 		}
-		if err := n.send(ctx, &notif, payload); err != nil {
+		if err := n.send(ctx, &notif, out); err != nil {
 			slog.Error("notifier: failed to send notification",
 				"id", notif.ID,
 				"name", notif.Name,
@@ -118,10 +204,7 @@ func (n *Notifier) Send(ctx context.Context, eventType string, payload map[strin
 
 // Test sends a test payload to a single notification without persisting it.
 func (n *Notifier) Test(ctx context.Context, notification *models.Notification) error {
-	payload := map[string]interface{}{
-		"eventType": "test",
-		"message":   "Bindery notification test",
-	}
+	payload := normalizeEventPayload("test", map[string]interface{}{})
 	return n.send(ctx, notification, payload)
 }
 
@@ -180,6 +263,16 @@ func (n *Notifier) send(ctx context.Context, notif *models.Notification, payload
 		out["title"] = "Bindery"
 	}
 
+	// When a topic is configured, publish to the ntfy server root with the topic
+	// in the JSON body. ntfy only parses a JSON body at the root URL; POSTed to a
+	// topic URL it treats the body as plain text and prints the JSON verbatim
+	// (#1323). The host is unchanged, so the URL already passed validation above.
+	target := notif.URL
+	if topic := strings.TrimSpace(notif.Topic); topic != "" {
+		out["topic"] = topic
+		target = ntfyRootURL(notif.URL)
+	}
+
 	body, err := json.Marshal(out)
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
@@ -190,7 +283,7 @@ func (n *Notifier) send(ctx context.Context, notif *models.Notification, payload
 		method = http.MethodPost
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, notif.URL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, method, target, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -384,11 +384,11 @@ func TestUserAgentHeader(t *testing.T) {
 
 func TestNormalizeEventPayload(t *testing.T) {
 	cases := []struct {
-		name              string
-		event             string
-		in                map[string]interface{}
-		wantTitle         string
-		wantMessage       string
+		name        string
+		event       string
+		in          map[string]interface{}
+		wantTitle   string
+		wantMessage string
 	}{
 		{"grabbed", EventGrabbed, map[string]interface{}{"title": "Dune", "author": "Frank Herbert"}, "Release Grabbed", "Dune · Frank Herbert"},
 		{"grabbed-no-author", EventGrabbed, map[string]interface{}{"title": "Dune"}, "Release Grabbed", "Dune"},

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -381,3 +381,86 @@ func TestUserAgentHeader(t *testing.T) {
 		t.Errorf("User-Agent must be lowercase to clear nzbfinder.ws WAF; got %q", gotUA)
 	}
 }
+
+func TestNormalizeEventPayload(t *testing.T) {
+	cases := []struct {
+		name              string
+		event             string
+		in                map[string]interface{}
+		wantTitle         string
+		wantMessage       string
+	}{
+		{"grabbed", EventGrabbed, map[string]interface{}{"title": "Dune", "author": "Frank Herbert"}, "Release Grabbed", "Dune · Frank Herbert"},
+		{"grabbed-no-author", EventGrabbed, map[string]interface{}{"title": "Dune"}, "Release Grabbed", "Dune"},
+		{"imported", EventBookImported, map[string]interface{}{"title": "Dune", "format": "ebook"}, "Book Imported", "Dune (ebook)"},
+		{"failed", EventDownloadFailed, map[string]interface{}{"title": "Dune", "message": "no files"}, "Download Failed", "Dune: no files"},
+		{"health", EventHealth, map[string]interface{}{"status": "error", "message": "client offline"}, "Download Client Unhealthy", "client offline"},
+		{"test", "test", map[string]interface{}{}, "Bindery Test", "Bindery notification test"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out := normalizeEventPayload(c.event, c.in)
+			if out["eventType"] != c.event {
+				t.Errorf("eventType = %v, want %q", out["eventType"], c.event)
+			}
+			if got, _ := out["title"].(string); got != c.wantTitle {
+				t.Errorf("title = %q, want %q", got, c.wantTitle)
+			}
+			if got, _ := out["message"].(string); got != c.wantMessage {
+				t.Errorf("message = %q, want %q", got, c.wantMessage)
+			}
+			// The original item name is preserved when present.
+			if item, _ := c.in["title"].(string); item != "" && out["item"] != item {
+				t.Errorf("item = %v, want %q", out["item"], item)
+			}
+		})
+	}
+}
+
+func TestSend_TopicPostsToRoot(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := testNotifier(&http.Client{})
+	notif := &models.Notification{URL: srv.URL + "/mytopic", Method: "POST", Topic: "mytopic"}
+	if err := n.send(context.Background(), notif, normalizeEventPayload(EventGrabbed, map[string]interface{}{"title": "Dune"})); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if gotPath != "/" {
+		t.Errorf("topic publish must POST to root, got path %q", gotPath)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(gotBody, &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if body["topic"] != "mytopic" {
+		t.Errorf("body topic = %v, want \"mytopic\"", body["topic"])
+	}
+	if body["message"] != "Dune" || body["title"] != "Release Grabbed" {
+		t.Errorf("body title/message = %v/%v, want Release Grabbed/Dune", body["title"], body["message"])
+	}
+}
+
+func TestSend_NoTopicKeepsURLPath(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := testNotifier(&http.Client{})
+	notif := &models.Notification{URL: srv.URL + "/hooks/abc", Method: "POST"}
+	if err := n.send(context.Background(), notif, map[string]interface{}{}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if gotPath != "/hooks/abc" {
+		t.Errorf("without topic the configured path must be used, got %q", gotPath)
+	}
+}

--- a/web/src/api/notifications.ts
+++ b/web/src/api/notifications.ts
@@ -5,6 +5,9 @@ export interface NotificationConfig {
   name: string
   type: string
   url: string
+  // topic, when set, makes Bindery POST to the URL's server root with a "topic"
+  // field so ntfy renders the JSON natively instead of printing it (#1323).
+  topic: string
   method: string
   headers: string
   onGrab: boolean

--- a/web/src/pages/settings/NotificationsTab.tsx
+++ b/web/src/pages/settings/NotificationsTab.tsx
@@ -121,6 +121,7 @@ function EditNotificationForm({ notification, onClose, onSaved }: { notification
   const { t } = useTranslation()
   const [name, setName] = useState(notification.name)
   const [url, setUrl] = useState(notification.url)
+  const [topic, setTopic] = useState(notification.topic || '')
   const [method, setMethod] = useState(notification.method || 'POST')
   // Prefill the textarea pretty-printed when the stored value is non-empty;
   // empty string when the row is "{}" so the placeholder still shows.
@@ -146,7 +147,7 @@ function EditNotificationForm({ notification, onClose, onSaved }: { notification
     }
     setSaving(true)
     try {
-      const updated = await api.updateNotification(notification.id, { ...notification, name, url, method, headers: headersJSON, onGrab, onImport, onFailure, onUpgrade, onHealth })
+      const updated = await api.updateNotification(notification.id, { ...notification, name, url, topic, method, headers: headersJSON, onGrab, onImport, onFailure, onUpgrade, onHealth })
       onSaved(updated)
     } catch (err: unknown) {
       setSaveError(t('settings.notifications.saveFailed', { error: err instanceof Error ? err.message : 'Unknown error' }))
@@ -173,6 +174,11 @@ function EditNotificationForm({ notification, onClose, onSaved }: { notification
         </select>
       </div>
       <input value={url} onChange={e => setUrl(e.target.value)} placeholder="Webhook URL" className={inputCls} />
+      <div>
+        <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">ntfy topic (optional)</label>
+        <input value={topic} onChange={e => setTopic(e.target.value)} placeholder="my-topic" className={inputCls} />
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">For ntfy: set the topic here and point the URL at the ntfy server root (e.g. https://ntfy.sh). Bindery then posts a JSON body ntfy renders natively, instead of printing raw JSON.</p>
+      </div>
       <div>
         <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Custom headers (JSON, optional)</label>
         <textarea
@@ -211,6 +217,7 @@ function AddNotificationForm({ onClose, onAdded }: { onClose: () => void; onAdde
   const { t } = useTranslation()
   const [name, setName] = useState('')
   const [url, setUrl] = useState('')
+  const [topic, setTopic] = useState('')
   const [method, setMethod] = useState('POST')
   const [headers, setHeaders] = useState('')
   const [onGrab, setOnGrab] = useState(true)
@@ -231,7 +238,7 @@ function AddNotificationForm({ onClose, onAdded }: { onClose: () => void; onAdde
     setSaving(true)
     try {
       const n = await api.addNotification({
-        name, url, method, type: 'webhook',
+        name, url, topic, method, type: 'webhook',
         headers: headersJSON,
         onGrab, onImport, onFailure, onUpgrade, onHealth,
         enabled: true,
@@ -262,6 +269,11 @@ function AddNotificationForm({ onClose, onAdded }: { onClose: () => void; onAdde
         </select>
       </div>
       <input value={url} onChange={e => setUrl(e.target.value)} placeholder="Webhook URL" className={inputCls} />
+      <div>
+        <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">ntfy topic (optional)</label>
+        <input value={topic} onChange={e => setTopic(e.target.value)} placeholder="my-topic" className={inputCls} />
+        <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">For ntfy: set the topic here and point the URL at the ntfy server root (e.g. https://ntfy.sh). Bindery then posts a JSON body ntfy renders natively, instead of printing raw JSON.</p>
+      </div>
       <div>
         <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Custom headers (JSON, optional)</label>
         <textarea


### PR DESCRIPTION
## Summary

Closes #1323. ntfy notifications showed up as a raw JSON blob and every event's title duplicated its message. This makes ntfy render natively and gives every event a meaningful title/message.

## What changed
- **`topic` field on notifications** (migration 057). When set, the webhook POSTs to the URL's **server root** with `topic` in the JSON body — the only way ntfy parses JSON instead of printing it. Empty = current behavior (POST to URL as-is).
- **Centralized payload normalization** in the notifier:
  - `title` = *what happened* (`Release Grabbed`, `Book Imported`, `Download Failed`, …); `message` = the subject (`<book> · <author>`, `<book> (<format>)`, …). Previously `title` carried the item and `message` was often empty, so notifications showed the same string twice and never said what occurred.
  - `eventType` is now on **every** payload (was `test`-only) so one template can branch per event.
  - Original item name preserved under `item`; all event extras (`author`, `format`, `size`, `path`, `status`, `clientId`) kept.
- **UI**: an "ntfy topic (optional)" field on the add/edit notification form with inline guidance.
- **Docs**: webhook payload schema table added to `docs/API.md`.

## Verification
- Unit: `TestNormalizeEventPayload` (title/message/eventType/item per event), `TestSend_TopicPostsToRoot` (asserts POST to **root path** with `topic` + correct title/message in body), `TestSend_NoTopicKeepsURLPath`. Full `notifier`/`db`/`api` suites pass; `go vet`, `tsc`, `eslint` clean.
- Migration 057 applies cleanly on a fresh DB (`topic` column present).
- Headless screenshot confirms the topic field renders in the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)