### PR TITLE
docs(telemetry): refresh getbindery.dev landing page with the README pitch

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -700,21 +700,22 @@ func (s *server) handleHome(w http.ResponseWriter, _ *http.Request) {
     border: 1px solid #334155;
   }
   a.secondary:hover { background: #1e293b; color: #e2e8f0; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .85em; background: #1e293b; color: #cbd5e1; padding: .1em .35em; border-radius: 4px; }
 </style>
 </head>
 <body>
 <div class="card">
   <img src="https://raw.githubusercontent.com/vavallee/bindery/main/.github/assets/logo.png" alt="Bindery logo">
   <h1>Bindery</h1>
-  <p>Open-source automated book management for self-hosters. Monitor your
-     favourite authors, discover new books, and have them downloaded and
-     organized automatically — no scraping, no dead backends.</p>
+  <p><strong style="color:#e2e8f0">The Readarr replacement built to outlive its metadata sources.</strong><br>
+     Automated ebook &amp; audiobook management for Usenet &amp; torrents — monitor
+     authors, search indexers, download, and organize.</p>
   <div class="features">
-    <div class="feature"><div class="feature-dot"></div><span>Tracks monitored authors via OpenLibrary and surfaces new releases automatically</span></div>
-    <div class="feature"><div class="feature-dot"></div><span>Integrates with Prowlarr, qBittorrent, SABnzbd, and Transmission</span></div>
-    <div class="feature"><div class="feature-dot"></div><span>Discover page with personalized recommendations based on your library</span></div>
-    <div class="feature"><div class="feature-dot"></div><span>Calibre bridge plugin for automatic library import after download</span></div>
-    <div class="feature"><div class="feature-dot"></div><span>OPDS feed, OIDC auth, Prometheus metrics, and dark mode</span></div>
+    <div class="feature"><div class="feature-dot"></div><span>No single point of failure for metadata — OpenLibrary, Google Books, Hardcover, DNB, Audnex, and Audible. Documented public APIs, zero scraping.</span></div>
+    <div class="feature"><div class="feature-dot"></div><span>Bring your dead Readarr install with you — import <code>readarr.db</code> and your authors, indexers, download clients, and blocklist come across in one step.</span></div>
+    <div class="feature"><div class="feature-dot"></div><span>Ebooks and audiobooks in independent slots — separate roots, narrator metadata, and multi-part audiobook handling.</span></div>
+    <div class="feature"><div class="feature-dot"></div><span>Usenet and torrents — SABnzbd, NZBGet, qBittorrent, Transmission, and Deluge.</span></div>
+    <div class="feature"><div class="feature-dot"></div><span>Boring to run, by design — a single Go binary, SQLite, distroless image, Helm chart, ARM down to a Pi Zero.</span></div>
   </div>
   <div class="links">
     <a class="primary" href="https://github.com/vavallee/bindery">


### PR DESCRIPTION
Refreshes the getbindery.dev welcome page (`cmd/telemetry-server` `handleHome`) to match the README's positioning.

- **Tagline** → "The Readarr replacement built to outlive its metadata sources" + the README sub-line (ebooks & audiobooks, Usenet & torrents).
- **Features** → five tight bullets pulled from the README's *Why Bindery?* / comparison: metadata resilience (6 sources, no scraping), Readarr `.db` import, dual-format slots, Usenet+torrents clients, single-binary/distroless/ARM ops.
- Adds an inline `code` style for the `readarr.db` chip.
- **Logo:** already current — the `<img>` loads `.github/assets/logo.png` from `main`, which was replaced in #1324, so the live site already renders the new mark (verified in a local render).

Built + vetted; no test asserts on the landing copy. Screenshot verified locally.

### Go-live (manual — no auto-rollout)
Merging triggers `ping-server.yml` to build `ghcr.io/vavallee/bindery-ping:latest` + `:sha-<commit>`. The page updates only after `deploy/telemetry-server.yaml`'s pinned image sha is bumped to the new build and `kubectl apply`'d (namespace `bindery-ping`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)