### PR TITLE
chore(deploy): bump bindery-ping image to the landing-page refresh

### DIFF
--- a/deploy/telemetry-server.yaml
+++ b/deploy/telemetry-server.yaml
@@ -45,7 +45,7 @@ spec:
           # GitHub release every 30m. Deploys here are manual (the cluster is
           # unreachable from CI runners), so bump this sha when rolling a new
           # telemetry-server build.
-          image: ghcr.io/vavallee/bindery-ping:sha-c2c0e1a36e0eca286a792630deb8e41fe7978df3
+          image: ghcr.io/vavallee/bindery-ping:sha-793ee55580f2e5cf3e2bda525fc8ec71b076ade4
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Bumps the pinned `bindery-ping` image to `sha-793ee55` (#1340, the getbindery.dev pitch refresh). Already rolled out on the cluster via `kubectl set image`; this keeps `deploy/telemetry-server.yaml` in sync so it's not drifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)