### PR TITLE
fix(web): make Settings layout responsive on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.23.1] — 2026-06-29
+
+A patch release: responsive mobile Settings, correct alphabetical ordering for
+accented author names, and legible Calibre push failures.
+
+### Fixed
+- **Settings is usable on a phone** (#1344) — the Settings page rendered its
+  fixed `w-44` sidebar beside the content at every viewport, crushing the content
+  column to ~180px on a narrow screen, so indexer rows overlapped and the theme
+  toggle and Regenerate button overflowed their cards. The sidebar now stacks
+  above the content below the `md` breakpoint, giving forms the full width. A
+  headless mobile audit caught and fixed horizontal overflow on eight settings
+  tabs, not just the two originally reported; desktop and tablet layout is
+  unchanged.
+- **Authors list sorts accented names in their place** (#1347) — #1312 made the
+  A–Z / Z–A sort case-insensitive with SQLite `COLLATE NOCASE`, but that folds
+  ASCII only, so any author whose `sort_name` began with a diacritic (Ö, Á, Ł,
+  Ø, Æ…) still sorted after "Z". Bindery now stores an accent-folded `sort_key`
+  (migration 058, computed on every author write and backfilled once at startup)
+  and orders by it, so Scandinavian / Polish / Spanish / Turkish names sort by
+  their base letter. Follow-up to #1312.
+- **"Push all to Calibre" reports why each book failed** (#1346) — a bulk push
+  that failed on every book logged only `calibre sync complete failed=N` with no
+  per-book reason, even in DEBUG, so a library path the Calibre container can't
+  resolve (e.g. `/books` vs `/media/books`) was invisible. The sync now logs the
+  first book to hit each distinct failure reason at WARN (deduped, so one
+  library-wide mismatch logs once instead of once per book) and adds
+  `distinctFailureReasons` to the completion summary. The per-book error list
+  returned to the UI is capped at 50 so a fail-on-every-book run no longer bloats
+  the status payload; `failed` still counts every book.
+
+### Dependencies
+- Routine `minor`/`patch` dependency bumps across the Go and npm modules and the
+  Docker base images (Dependabot).
+
 ## [v1.23.0] — 2026-06-27
 
 A feature release: correct a mis-matched file in place, links out to the

--- a/web/src/components/LanguageSwitcher.tsx
+++ b/web/src/components/LanguageSwitcher.tsx
@@ -33,7 +33,7 @@ export default function LanguageSwitcher() {
     <select
       value={current}
       onChange={e => handleChange(e.target.value)}
-      className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+      className="shrink-0 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
     >
       {LANGUAGES.map(l => (
         <option key={l.code} value={l.code}>{l.labelKey ? t(l.labelKey) : l.label}</option>

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -10,7 +10,7 @@ export default function ThemeToggle() {
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
       aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
       aria-pressed={isDark}
-      className={`relative inline-flex h-7 w-12 items-center rounded-full border transition-colors ${
+      className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full border transition-colors ${
         isDark
           ? 'bg-zinc-700 border-zinc-600'
           : 'bg-slate-200 border-slate-300'

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -161,9 +161,10 @@ export default function SettingsPage() {
     <div>
       <h2 className="text-2xl font-bold mb-6">{t('settings.title')}</h2>
 
-      <div className="flex gap-8 items-start">
-        {/* Sidebar navigation */}
-        <nav className="w-44 flex-shrink-0 space-y-0.5">
+      <div className="flex flex-col md:flex-row gap-4 md:gap-8 items-stretch md:items-start">
+        {/* Sidebar navigation — stacks above content on mobile so the tab
+            content gets the full viewport width instead of ~180px. */}
+        <nav className="w-full md:w-44 flex-shrink-0 space-y-0.5">
           <SettingsNavLink tab="general" active={tab} onSelect={setTab} label={t('settings.tabs.general')} />
           <SettingsNavLink tab="about" active={tab} onSelect={setTab} label={t('settings.tabs.about', 'About')} />
 

--- a/web/src/pages/settings/ABSTab.tsx
+++ b/web/src/pages/settings/ABSTab.tsx
@@ -679,14 +679,14 @@ function AudiobookshelfSection() {
         </div>
 
         <div className="pt-3 border-t border-slate-200 dark:border-zinc-800 space-y-3">
-          <div className="flex items-center justify-between gap-4">
-            <div>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="min-w-0">
               <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">Catalog import</label>
               <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">
                 Import authors, books, series, and editions from the selected ABS libraries. Shared filesystem paths are reconciled into Bindery ownership automatically; when ABS and Bindery use different mount prefixes, add a path translation above. Non-visible paths stay metadata-only and are counted for manual follow-up.
               </p>
             </div>
-            <div className="flex flex-col items-end gap-2 flex-shrink-0">
+            <div className="flex flex-col items-start sm:items-end gap-2 flex-shrink-0 flex-wrap">
               <label className="flex items-center gap-2 text-xs text-slate-600 dark:text-zinc-400">
                 <input
                   type="checkbox"

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -152,15 +152,15 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
       <section>
         <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.appearance')}</h3>
         <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
-          <div className="flex items-center justify-between">
-            <div>
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
               <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">{t('settings.general.theme')}</label>
               <p className="text-xs text-slate-600 dark:text-zinc-500 mt-1">{t('settings.general.themeHint')}</p>
             </div>
             <ThemeToggle />
           </div>
-          <div className="flex items-center justify-between border-t border-slate-200 dark:border-zinc-800 pt-3 mt-3">
-            <div>
+          <div className="flex items-center justify-between gap-3 border-t border-slate-200 dark:border-zinc-800 pt-3 mt-3">
+            <div className="min-w-0">
               <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">{t('settings.general.language')}</label>
               <p className="text-xs text-slate-600 dark:text-zinc-500 mt-1">{t('settings.general.languageHint')}</p>
             </div>
@@ -686,8 +686,8 @@ function SecuritySection() {
           <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
             Pass as <code className="font-mono">X-Api-Key</code> header or <code className="font-mono">?apikey=</code> query parameter. Used by external integrations (Tautulli, custom scripts, etc.).
           </p>
-          <div className="flex gap-2">
-            <code className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm font-mono text-slate-700 dark:text-zinc-300 truncate">
+          <div className="flex flex-wrap gap-2">
+            <code className="flex-1 min-w-[12rem] bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm font-mono text-slate-700 dark:text-zinc-300 truncate">
               {showKey ? cfg.apiKey : '••••••••••••••••••••••••••••••••'}
             </code>
             <button onClick={() => setShowKey(s => !s)} className="px-3 py-2 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 rounded text-xs font-medium">

--- a/web/src/pages/settings/IndexersTab.tsx
+++ b/web/src/pages/settings/IndexersTab.tsx
@@ -123,7 +123,7 @@ export default function IndexersTab({ indexers, setIndexers, prowlarrInstances, 
         <div className="space-y-2">
           {indexers.map(idx => (
             <div key={idx.id}>
-              <div className="flex items-center justify-between p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
                 <div className="flex items-center gap-3 min-w-0">
                   <Toggle
                     checked={idx.enabled}
@@ -134,11 +134,11 @@ export default function IndexersTab({ indexers, setIndexers, prowlarrInstances, 
                     title={idx.enabled ? t('common.disable') : t('common.enable')}
                   />
                   <div className="min-w-0">
-                    <h4 className={`font-medium text-sm ${!idx.enabled ? 'text-slate-600 dark:text-zinc-500' : ''}`}>{idx.name}</h4>
+                    <h4 className={`font-medium text-sm truncate ${!idx.enabled ? 'text-slate-600 dark:text-zinc-500' : ''}`}>{idx.name}</h4>
                     <p className="text-xs text-slate-600 dark:text-zinc-500 truncate">{idx.url}</p>
                   </div>
                 </div>
-                <div className="flex items-center gap-3 flex-shrink-0">
+                <div className="flex items-center gap-3 flex-shrink-0 flex-wrap">
                   <button onClick={() => setEditingIndexer(editingIndexer === idx.id ? null : idx.id)} className="text-xs text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white">{t('common.edit')}</button>
                   <button
                     disabled={indexerTestResults[idx.id]?.testing}
@@ -231,10 +231,10 @@ export default function IndexersTab({ indexers, setIndexers, prowlarrInstances, 
         <div className="space-y-2">
           {prowlarrInstances.map(p => (
             <div key={p.id} className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
-              <div className="flex items-center justify-between">
-                <div>
-                  <h5 className="font-medium text-sm">{p.name}</h5>
-                  <p className="text-xs text-slate-500 dark:text-zinc-500">{p.url}</p>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
+                  <h5 className="font-medium text-sm truncate">{p.name}</h5>
+                  <p className="text-xs text-slate-500 dark:text-zinc-500 truncate">{p.url}</p>
                   {p.lastSyncAt && (
                     <p className="text-xs text-slate-400 dark:text-zinc-600 mt-0.5">
                       {t('settings.prowlarr.lastSynced', {
@@ -250,7 +250,7 @@ export default function IndexersTab({ indexers, setIndexers, prowlarrInstances, 
                     <p className={`text-xs mt-0.5 ${prowlarrTestResult[p.id].ok ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}`}>{prowlarrTestResult[p.id].msg}</p>
                   )}
                 </div>
-                <div className="flex items-center gap-3 flex-shrink-0">
+                <div className="flex items-center gap-3 flex-shrink-0 flex-wrap">
                   <button onClick={() => setEditingProwlarr(editingProwlarr === p.id ? null : p.id)} className="text-xs text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white">
                     {t('settings.prowlarr.edit')}
                   </button>

--- a/web/src/pages/settings/LogsTab.tsx
+++ b/web/src/pages/settings/LogsTab.tsx
@@ -306,8 +306,8 @@ export default function LogsTab() {
       <section className="mt-8">
         <h3 className="text-base font-semibold mb-3 text-slate-800 dark:text-zinc-200">{t('settings.general.logRetention')}</h3>
         <div className="p-4 border border-slate-200 dark:border-zinc-800 rounded-lg bg-slate-100 dark:bg-zinc-900">
-          <div className="flex items-center justify-between gap-4">
-            <div>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div className="min-w-0">
               <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200">{t('settings.general.logRetentionLabel')}</label>
               <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">{t('settings.general.logRetentionHint')}</p>
             </div>

--- a/web/src/pages/settings/MetadataTab.tsx
+++ b/web/src/pages/settings/MetadataTab.tsx
@@ -75,7 +75,7 @@ export default function MetadataTab() {
               setSettings(s => ({ ...s, 'metadata.primary_provider': next }))
               await api.setSetting('metadata.primary_provider', next).catch(console.error)
             }}
-            className="bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
+            className="w-full max-w-md bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-emerald-500"
           >
             <option value="openlibrary">{t('settings.general.metadataProviderOpenlibrary', 'OpenLibrary (default)')}</option>
             <option value="dnb">{t('settings.general.metadataProviderDnb', 'DNB — Deutsche Nationalbibliothek (German/DACH)')}</option>

--- a/web/src/pages/settings/NotificationsTab.tsx
+++ b/web/src/pages/settings/NotificationsTab.tsx
@@ -19,7 +19,7 @@ export default function NotificationsTab() {
 
   return (
     <div>
-      <div className="flex justify-between items-center mb-4">
+      <div className="flex flex-wrap gap-2 justify-between items-center mb-4">
         <h3 className="text-lg font-semibold">{t('settings.notifications.heading')}</h3>
         <button onClick={() => setShowAddNotification(true)} className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 rounded text-xs font-medium">
           {t('settings.notifications.addButton')}


### PR DESCRIPTION
## What

Settings rendered its fixed `w-44` sidebar side-by-side with the tab content at **every** viewport, so on a ~390px phone the content column was crushed to ~180px. That produced the three issues seen on mobile, and several more found by auditing the rest of the app:

- **Indexers** rows overlapped — toggle, name, and Edit/Test/Delete actions collided.
- **Appearance** theme toggle's knob spilled past the card's right edge.
- **API Key** Regenerate button overflowed the card.
- Plus horizontal overflow on most other admin tabs: the Metadata provider `<select>` sized itself to its longest option (DNB…), the Notifications header, Calibre / API-key / ABS button rows, and the Logs retention row.

## How

All changes are responsive-gated (`md:` / `sm:`) so desktop and tablet are untouched:

- **SettingsPage** — nav stacks above content on mobile (`flex-col` → `md:flex-row`, `w-full` → `md:w-44`); content gets the full width. This is the root fix.
- **IndexersTab** — indexer and Prowlarr rows stack name-over-actions on mobile; long names truncate.
- **ThemeToggle / LanguageSwitcher** — `shrink-0` so the control can't be squeezed (knob no longer overflows).
- **GeneralTab** — API-key controls `flex-wrap` with a 12rem min on the key field; Appearance rows get `min-w-0` + `gap`.
- **MetadataTab** — provider select is `w-full max-w-md` instead of growing to its longest option.
- **NotificationsTab / LogsTab / ABSTab** — header and label+action rows wrap / stack on mobile.

## Testing

- Headless mobile harness (Chromium, iPhone emulation) over **every route + all 15 settings tabs**:
  - **390px and 360px** → zero horizontal overflow anywhere (was overflowing on 8 tabs by up to +269px).
  - **1280px and 768/767px** → re-checked: desktop/tablet layout **unchanged**, zero overflow.
- `tsc --noEmit` clean; `eslint` no new findings; `vitest` settings suite **98/98 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)