### PR TITLE
fix(author): accent-fold author sort key so diacritic names sort A–Z in place (#1347)

### DIFF
--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -67,11 +67,13 @@ func (r *AuthorRepo) List(ctx context.Context) ([]models.Author, error) {
 }
 
 const (
-	listAuthorsAll = "SELECT " + authorSelectCols + " FROM authors ORDER BY sort_name COLLATE NOCASE"
+	// sort_key is the accent-folded ordering key (migration 058, #1347); the
+	// sort_name tiebreaker keeps order deterministic when two folded keys collide.
+	listAuthorsAll = "SELECT " + authorSelectCols + " FROM authors ORDER BY sort_key, sort_name COLLATE NOCASE"
 	// Include rows with NULL owner_user_id — these are authors created before the
 	// multi-user migration ran its backfill (migration 025) or imported without a
 	// user context. Excluding them causes the list to silently drop visible authors.
-	listAuthorsByUser = "SELECT " + authorSelectCols + " FROM authors WHERE owner_user_id = ? OR owner_user_id IS NULL ORDER BY sort_name COLLATE NOCASE"
+	listAuthorsByUser = "SELECT " + authorSelectCols + " FROM authors WHERE owner_user_id = ? OR owner_user_id IS NULL ORDER BY sort_key, sort_name COLLATE NOCASE"
 )
 
 func (r *AuthorRepo) ListByUser(ctx context.Context, userID int64) ([]models.Author, error) {
@@ -123,20 +125,20 @@ func escapeLike(s string) string {
 // authorSortOrder maps a whitelisted sort key to a fixed ORDER BY clause. The
 // value never contains user input, so it is safe to interpolate.
 //
-// sort_name is stored case-preserving ("Olsen, Mary-Kate", "de Balzac,
-// Honoré"), so a plain (BINARY-collation) ORDER BY sorts all uppercase letters
-// ahead of all lowercase ones (ASCII 'Z'=90 < 'a'=97) — names beginning with a
-// lowercase article ("de", "von") land after "Z", which users read as a jumble.
-// COLLATE NOCASE folds case so the A-Z / Z-A order matches expectations. The
-// "recent" sort keys on created_at (a timestamp) and is unaffected.
+// Ordering is on sort_key — the accent-folded, lowercased key (migration 058,
+// authorSortKey) — so case AND diacritics fold uniformly. #1312 used COLLATE
+// NOCASE, which only folds ASCII A-Z, leaving accented leading letters (Ö, Ł,
+// Ø…) sorting after "Z" (#1347). sort_name is the tiebreaker for a stable order
+// when two folded keys collide. The "recent" sort keys on created_at (a
+// timestamp) and is unaffected.
 func authorSortOrder(sort string) string {
 	switch sort {
 	case "za":
-		return "sort_name COLLATE NOCASE DESC"
+		return "sort_key DESC, sort_name COLLATE NOCASE DESC"
 	case "recent":
 		return "created_at DESC, id DESC"
 	default:
-		return "sort_name COLLATE NOCASE ASC"
+		return "sort_key ASC, sort_name COLLATE NOCASE ASC"
 	}
 }
 
@@ -152,7 +154,7 @@ func (r *AuthorRepo) ListPage(ctx context.Context, userID int64, limit, offset i
 // limit/offset so the UI can paginate). limit must be positive; offset is
 // clamped at 0.
 //
-// The sort_name order is backed by idx_authors_sort_name (migration 048).
+// The sort_key order is backed by idx_authors_sort_key (migration 058).
 func (r *AuthorRepo) ListPageFiltered(ctx context.Context, f AuthorListFilter, limit, offset int) ([]models.Author, int, error) {
 	if limit <= 0 {
 		limit = 50
@@ -360,12 +362,12 @@ func (r *AuthorRepo) CreateForUser(ctx context.Context, a *models.Author, ownerU
 	defer func() { _ = tx.Rollback() }()
 
 	result, err := tx.ExecContext(ctx, `
-		INSERT INTO authors (foreign_id, name, sort_name, description, image_url, disambiguation,
+		INSERT INTO authors (foreign_id, name, sort_name, sort_key, description, image_url, disambiguation,
 		                     ratings_count, average_rating, monitored, quality_profile_id, metadata_profile_id, root_folder_id,
 		                     audiobook_root_folder_id, monitor_mode, monitor_latest_count, metadata_provider, owner_user_id,
 		                     created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		a.ForeignID, a.Name, a.SortName, a.Description, a.ImageURL, a.Disambiguation,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		a.ForeignID, a.Name, a.SortName, authorSortKey(a.SortName), a.Description, a.ImageURL, a.Disambiguation,
 		a.RatingsCount, a.AverageRating, a.Monitored, a.QualityProfileID, a.MetadataProfileID, a.RootFolderID,
 		a.AudiobookRootFolderID, a.MonitorMode, a.MonitorLatestCount, a.MetadataProvider, ownerArg, timeValueArg(now), timeValueArg(now))
 	if err != nil {
@@ -539,15 +541,17 @@ func (r *AuthorRepo) UpgradeSyntheticDNB(ctx context.Context, currentForeignID s
 			SET foreign_id        = ?,
 			    name              = COALESCE(NULLIF(?, ''), name),
 		    sort_name         = COALESCE(NULLIF(?, ''), sort_name),
+		    sort_key          = CASE WHEN ? != '' THEN ? ELSE sort_key END,
 		    description       = CASE WHEN ? != '' THEN ? ELSE description END,
 		    image_url         = CASE WHEN ? != '' THEN ? ELSE image_url END,
 		    disambiguation    = CASE WHEN ? != '' THEN ? ELSE disambiguation END,
 		    metadata_provider = COALESCE(NULLIF(?, ''), metadata_provider),
 		    updated_at        = ?
 		WHERE foreign_id = ?`,
-		target.ForeignID,                       // foreign_id =
-		target.Name,                            // name = COALESCE(NULLIF(?,''), name)
-		target.SortName,                        // sort_name = COALESCE(NULLIF(?,''), sort_name)
+		target.ForeignID,                                // foreign_id =
+		target.Name,                                     // name = COALESCE(NULLIF(?,''), name)
+		target.SortName,                                 // sort_name = COALESCE(NULLIF(?,''), sort_name)
+		target.SortName, authorSortKey(target.SortName), // sort_key CASE WHEN ?!='' THEN ? ELSE sort_key
 		target.Description, target.Description, // description CASE WHEN ? != '' THEN ?
 		target.ImageURL, target.ImageURL, // image_url
 		target.Disambiguation, target.Disambiguation, // disambiguation
@@ -610,12 +614,12 @@ func (r *AuthorRepo) Update(ctx context.Context, a *models.Author) error {
 
 func (r *AuthorRepo) update(ctx context.Context, exec dbExecutor, a *models.Author, now time.Time) error {
 	_, err := exec.ExecContext(ctx, `
-		UPDATE authors SET foreign_id=?, name=?, sort_name=?, description=?, image_url=?, disambiguation=?,
+		UPDATE authors SET foreign_id=?, name=?, sort_name=?, sort_key=?, description=?, image_url=?, disambiguation=?,
 		                   ratings_count=?, average_rating=?, monitored=?, quality_profile_id=?,
 		                   metadata_profile_id=?, root_folder_id=?, audiobook_root_folder_id=?, monitor_mode=?,
 		                   monitor_latest_count=?, metadata_provider=?, last_metadata_refresh_at=?, updated_at=?
 		WHERE id=?`,
-		a.ForeignID, a.Name, a.SortName, a.Description, a.ImageURL, a.Disambiguation,
+		a.ForeignID, a.Name, a.SortName, authorSortKey(a.SortName), a.Description, a.ImageURL, a.Disambiguation,
 		a.RatingsCount, a.AverageRating, a.Monitored, a.QualityProfileID,
 		a.MetadataProfileID, a.RootFolderID, a.AudiobookRootFolderID, a.MonitorMode,
 		a.MonitorLatestCount, a.MetadataProvider, timeArg(a.LastMetadataRefreshAt), timeValueArg(now), a.ID)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -258,6 +258,79 @@ func migrate(database *sql.DB) error {
 		return fmt.Errorf("backfill book dedup keys: %w", err)
 	}
 
+	// Migration 058 adds authors.sort_key but SQLite cannot accent-fold, so the
+	// column ships empty for existing rows. Populate it from sort_name with the
+	// Go folder (#1347). Idempotent: a no-op once every row holds its key, and it
+	// re-folds any row whose stored key drifts from authorSortKey (e.g. after a
+	// future change to the folding rules).
+	if err := backfillAuthorSortKeys(database); err != nil {
+		return fmt.Errorf("backfill author sort keys: %w", err)
+	}
+
+	return nil
+}
+
+// backfillAuthorSortKeys recomputes authors.sort_key for every row whose stored
+// value differs from authorSortKey(sort_name). It runs on every startup after
+// migrations so legacy rows created before migration 058 (which leaves sort_key
+// empty) get a correct accent-folded key, and a future change to the folder
+// re-canonicalizes existing rows on the next boot.
+func backfillAuthorSortKeys(database *sql.DB) error {
+	type pending struct {
+		id  int64
+		key string
+	}
+	// Read phase in its own scope so the cursor closes before the write tx opens
+	// — holding a read cursor across Begin() risks "database is locked" on SQLite.
+	updates, err := func() ([]pending, error) {
+		rows, err := database.Query("SELECT id, sort_name, COALESCE(sort_key, '') FROM authors")
+		if err != nil {
+			return nil, fmt.Errorf("read authors for sort_key backfill: %w", err)
+		}
+		defer rows.Close()
+		var out []pending
+		for rows.Next() {
+			var id int64
+			var sortName, stored string
+			if err := rows.Scan(&id, &sortName, &stored); err != nil {
+				return nil, fmt.Errorf("scan author for sort_key backfill: %w", err)
+			}
+			if want := authorSortKey(sortName); want != stored {
+				out = append(out, pending{id: id, key: want})
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("iterate authors for sort_key backfill: %w", err)
+		}
+		return out, nil
+	}()
+	if err != nil {
+		return err
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+
+	tx, err := database.Begin()
+	if err != nil {
+		return fmt.Errorf("begin sort_key backfill tx: %w", err)
+	}
+	stmt, err := tx.Prepare("UPDATE authors SET sort_key = ? WHERE id = ?")
+	if err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("prepare sort_key backfill: %w", err)
+	}
+	defer stmt.Close()
+	for _, u := range updates {
+		if _, err := stmt.Exec(u.key, u.id); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("update sort_key for author %d: %w", u.id, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit sort_key backfill: %w", err)
+	}
+	slog.Info("backfilled author sort keys", "rows", len(updates))
 	return nil
 }
 

--- a/internal/db/list_filtered_test.go
+++ b/internal/db/list_filtered_test.go
@@ -181,11 +181,18 @@ func TestAuthorRepo_ListPageFiltered_SortNameCaseInsensitive(t *testing.T) {
 	// Deliberately mixed case, inserted out of order. Under BINARY collation
 	// these would sort as [Adams, Zola, adelson, de Balzac] (uppercase first,
 	// then lowercase) — the jumble users saw.
+	// "Östergaard" / "Łukasz" begin with a non-ASCII letter (code point > 'z'):
+	// under COLLATE NOCASE they sorted after "Zola", which #1347 reports as the
+	// remaining jumble. The accent-folded sort_key (migration 058) must place
+	// them by their base letter: Östergaard→o (after "de Balzac", before "Zola"),
+	// Łukasz→l (between "de Balzac" and "Östergaard").
 	seed := []struct{ name, sortName string }{
 		{"Honoré de Balzac", "de Balzac, Honoré"},
 		{"Émile Zola", "Zola, Émile"},
 		{"Anita Adelson", "adelson, Anita"},
 		{"Douglas Adams", "Adams, Douglas"},
+		{"Karl Östergaard", "Östergaard, Karl"},
+		{"Łukasz Nowak", "Nowak, Łukasz"},
 	}
 	for _, s := range seed {
 		if err := repo.Create(ctx, &models.Author{
@@ -203,7 +210,7 @@ func TestAuthorRepo_ListPageFiltered_SortNameCaseInsensitive(t *testing.T) {
 	for i, a := range az {
 		gotAZ[i] = a.SortName
 	}
-	wantAZ := []string{"Adams, Douglas", "adelson, Anita", "de Balzac, Honoré", "Zola, Émile"}
+	wantAZ := []string{"Adams, Douglas", "adelson, Anita", "de Balzac, Honoré", "Nowak, Łukasz", "Östergaard, Karl", "Zola, Émile"}
 	for i := range wantAZ {
 		if gotAZ[i] != wantAZ[i] {
 			t.Fatalf("az order = %v, want %v", gotAZ, wantAZ)

--- a/internal/db/migrations/058_authors_sort_key.sql
+++ b/internal/db/migrations/058_authors_sort_key.sql
@@ -1,0 +1,10 @@
+-- Accent-folded sort key for the Authors A–Z/Z–A list (#1347, follow-up to #1312).
+--
+-- #1312 added `COLLATE NOCASE`, which folds ASCII case only. SQLite has no
+-- Unicode-aware collation here, so any sort_name beginning with a diacritic
+-- (Ö, Á, Ł, Ø, Æ…) still sorted after "Z". We store an accent-folded, lowercased
+-- key computed in Go (see authorSortKey) and ORDER BY it with a plain BINARY
+-- index. SQLite cannot fold accents, so existing rows are left at '' here and
+-- populated by the Go-side backfillAuthorSortKeys pass on the next startup.
+ALTER TABLE authors ADD COLUMN sort_key TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_authors_sort_key ON authors(sort_key);

--- a/internal/db/sortkey.go
+++ b/internal/db/sortkey.go
@@ -1,0 +1,70 @@
+package db
+
+import (
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+// authorSortKey derives an accent-folded, lowercased, BINARY-comparable key
+// from an author's sort_name.
+//
+// SQLite's built-in NOCASE collation folds only ASCII A–Z, so #1312 (which
+// added COLLATE NOCASE) still left any sort_name beginning with a non-ASCII
+// letter — "Östergaard", "Łukasz", "Ángel", "Ørsted" — sorting after "Z",
+// which users read as the A–Z list being out of order (#1347). We fold once on
+// write into authors.sort_key and ORDER BY that column with a plain BINARY
+// index (migration 058), so the ordering needs no Unicode-aware collation at
+// query time.
+//
+// Folding strips combining marks via NFD decomposition (é→e, ö→o, ñ→n) and
+// then maps the common Latin letters that do NOT decompose under NFD (ø, ł, æ,
+// ß, þ, ð, đ, …) to an ASCII approximation, so a Scandinavian/Polish/German
+// catalogue sorts in the expected place. The result is lowercased so case no
+// longer interleaves. It is intentionally lossy and for ordering only — the
+// human-facing value remains sort_name.
+func authorSortKey(sortName string) string {
+	s := strings.TrimSpace(sortName)
+	if s == "" {
+		return ""
+	}
+	s = strings.ToLower(s)
+	s = nonDecomposableFolder.Replace(s)
+	folded, _, err := transform.String(accentStripper, s)
+	if err != nil {
+		// transform only errors on malformed input we can't normalize; fall
+		// back to the lowercased+replaced form rather than dropping the row to
+		// an empty key (which would sort it to the very top).
+		return s
+	}
+	return folded
+}
+
+// accentStripper decomposes runes (NFD) and removes combining marks (Mn), then
+// recomposes (NFC). This folds precomposed accented letters to their base.
+var accentStripper = transform.Chain(
+	norm.NFD,
+	runes.Remove(runes.In(unicode.Mn)),
+	norm.NFC,
+)
+
+// nonDecomposableFolder handles the Latin letters NFD leaves intact because
+// they are atomic code points, not base+combining-mark compositions. Applied
+// to already-lowercased input. Order/uppercase variants are unnecessary since
+// authorSortKey lowercases first.
+var nonDecomposableFolder = strings.NewReplacer(
+	"ø", "o",
+	"ł", "l",
+	"æ", "ae",
+	"œ", "oe",
+	"ß", "ss",
+	"þ", "th",
+	"ð", "d",
+	"đ", "d",
+	"ħ", "h",
+	"ı", "i",
+	"ŀ", "l",
+)

--- a/internal/db/sortkey_test.go
+++ b/internal/db/sortkey_test.go
@@ -1,6 +1,11 @@
 package db
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
 
 func TestAuthorSortKey(t *testing.T) {
 	cases := []struct{ in, want string }{
@@ -36,5 +41,44 @@ func TestAuthorSortKey_Ordering(t *testing.T) {
 	}
 	if o >= zola {
 		t.Errorf("Östergaard key %q should sort before Zola key %q", o, zola)
+	}
+}
+
+// TestBackfillAuthorSortKeys covers the migration-058 startup backfill: a row
+// whose sort_key is empty (as legacy rows are immediately after the ALTER TABLE,
+// since SQLite can't accent-fold) must be populated from sort_name, and a second
+// run must be a no-op.
+func TestBackfillAuthorSortKeys(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	a := &models.Author{ForeignID: "OL-BF", Name: "Karl Östergaard", SortName: "Östergaard, Karl"}
+	if err := repo.Create(ctx, a); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Simulate a pre-058 row: blank the key the Create path just computed.
+	if _, err := database.Exec("UPDATE authors SET sort_key = '' WHERE id = ?", a.ID); err != nil {
+		t.Fatalf("blank sort_key: %v", err)
+	}
+
+	if err := backfillAuthorSortKeys(database); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	var got string
+	if err := database.QueryRow("SELECT sort_key FROM authors WHERE id = ?", a.ID).Scan(&got); err != nil {
+		t.Fatalf("read sort_key: %v", err)
+	}
+	if want := "ostergaard, karl"; got != want {
+		t.Errorf("sort_key after backfill = %q, want %q", got, want)
+	}
+
+	// Idempotent: a second pass finds nothing to update and errors on nothing.
+	if err := backfillAuthorSortKeys(database); err != nil {
+		t.Fatalf("backfill (second pass): %v", err)
 	}
 }

--- a/internal/db/sortkey_test.go
+++ b/internal/db/sortkey_test.go
@@ -82,3 +82,45 @@ func TestBackfillAuthorSortKeys(t *testing.T) {
 		t.Fatalf("backfill (second pass): %v", err)
 	}
 }
+
+// TestBackfillAuthorSortKeys_SurfacesReadError ensures a failure reading the
+// authors table propagates rather than being swallowed — a silent backfill
+// failure at startup would leave sort_key empty and the list mis-ordered.
+func TestBackfillAuthorSortKeys_SurfacesReadError(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	database.Close() // query against a closed handle errors on the read phase
+	if err := backfillAuthorSortKeys(database); err == nil {
+		t.Fatal("expected an error backfilling against a closed database, got nil")
+	}
+}
+
+// TestBackfillAuthorSortKeys_SurfacesWriteError ensures a write failure during
+// the update phase propagates (and rolls back) rather than being ignored.
+func TestBackfillAuthorSortKeys_SurfacesWriteError(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	repo := NewAuthorRepo(database)
+	ctx := context.Background()
+
+	a := &models.Author{ForeignID: "OL-WE", Name: "Anna Straße", SortName: "Straße, Anna"}
+	if err := repo.Create(ctx, a); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := database.Exec("UPDATE authors SET sort_key = '' WHERE id = ?", a.ID); err != nil {
+		t.Fatalf("blank sort_key: %v", err)
+	}
+	// Make the connection reject writes: the read phase still succeeds, so the
+	// failure lands in the UPDATE, exercising the rollback/return path.
+	if _, err := database.Exec("PRAGMA query_only = ON"); err != nil {
+		t.Fatalf("set query_only: %v", err)
+	}
+	if err := backfillAuthorSortKeys(database); err == nil {
+		t.Fatal("expected a write error backfilling under query_only, got nil")
+	}
+}

--- a/internal/db/sortkey_test.go
+++ b/internal/db/sortkey_test.go
@@ -28,8 +28,13 @@ func TestAuthorSortKey(t *testing.T) {
 // Leading-diacritic keys must order by their folded base letter, not after "z".
 func TestAuthorSortKey_Ordering(t *testing.T) {
 	// Östergaard folds to 'o', so it must sort between "nowak" and "zola".
+	nowak := authorSortKey("Nowak, Łukasz")
 	o := authorSortKey("Östergaard, Karl")
-	if !(authorSortKey("Nowak, Łukasz") < o && o < authorSortKey("Zola, Émile")) {
-		t.Errorf("Östergaard key %q not ordered between Nowak and Zola", o)
+	zola := authorSortKey("Zola, Émile")
+	if o <= nowak {
+		t.Errorf("Östergaard key %q should sort after Nowak key %q", o, nowak)
+	}
+	if o >= zola {
+		t.Errorf("Östergaard key %q should sort before Zola key %q", o, zola)
 	}
 }

--- a/internal/db/sortkey_test.go
+++ b/internal/db/sortkey_test.go
@@ -1,0 +1,35 @@
+package db
+
+import "testing"
+
+func TestAuthorSortKey(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"  ", ""},
+		{"Adams, Douglas", "adams, douglas"},
+		{"adelson, Anita", "adelson, anita"},       // case folds
+		{"de Balzac, Honoré", "de balzac, honore"}, // accent in tail folds
+		{"Zola, Émile", "zola, emile"},
+		{"Östergaard, Karl", "ostergaard, karl"}, // leading diacritic → base letter
+		{"Ángel, José", "angel, jose"},
+		{"Çelik, Ayşe", "celik, ayse"},
+		{"Nowak, Łukasz", "nowak, lukasz"}, // ł is non-decomposable
+		{"Ørsted, Hans", "orsted, hans"},   // ø is non-decomposable
+		{"Æsop", "aesop"},                  // ligature expands
+		{"Straße, Anna", "strasse, anna"},  // ß → ss
+	}
+	for _, c := range cases {
+		if got := authorSortKey(c.in); got != c.want {
+			t.Errorf("authorSortKey(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// Leading-diacritic keys must order by their folded base letter, not after "z".
+func TestAuthorSortKey_Ordering(t *testing.T) {
+	// Östergaard folds to 'o', so it must sort between "nowak" and "zola".
+	o := authorSortKey("Östergaard, Karl")
+	if !(authorSortKey("Nowak, Łukasz") < o && o < authorSortKey("Zola, Émile")) {
+		t.Errorf("Östergaard key %q not ordered between Nowak and Zola", o)
+	}
+}


### PR DESCRIPTION
Closes #1347. Follow-up to #1312.

## Problem

#1312 added `COLLATE NOCASE` to the Authors A–Z/Z–A ordering, but SQLite's built-in `NOCASE` collation folds **ASCII A–Z only** — no Unicode/accent folding. Any `sort_name` whose first character is a non-ASCII letter (Ö, Á, Ç, Ł, Ø, Æ…) has a code point past `'z'`, so it sorted after every ASCII name. A user on v1.23.0 reported the Authors list still reading as "out of order."

## Fix

Store an accent-folded, lowercased `sort_key` derived from `sort_name` and `ORDER BY sort_key` (sort_name as a stable tiebreaker), backed by a plain BINARY index — no Unicode-aware collation needed at query time.

- **`authorSortKey`** (`internal/db/sortkey.go`): NFD decompose + strip combining marks (é→e, ö→o), plus an explicit map for the Latin letters NFD leaves intact (ø→o, ł→l, æ→ae, ß→ss, þ→th, ð/đ→d…), then lowercase. Lossy and ordering-only; the human-facing value stays `sort_name`.
- **Migration 058** adds `authors.sort_key` + `idx_authors_sort_key`. SQLite can't fold accents, so existing rows ship empty and are populated by…
- **`backfillAuthorSortKeys`** (`internal/db/db.go`): one-time startup pass mirroring `backfillBookDedupKeys` — idempotent, and re-folds any row whose key drifts from `authorSortKey` after a future rules change.
- Key is written on every author path: insert, update, and the DNB-synthetic relink merge.

## Tests

- Extended the #1312 regression test with leading-diacritic cases (`Östergaard`, `Łukasz`) — they now sort by base letter (o, l), not after `Zola`.
- Added `authorSortKey` unit coverage (accents, ligatures, non-decomposables, ß).
- Full `internal/db` suite green; `go build ./...` + `go vet` clean.

## Scope / risk

Read-path ordering + one additive nullable-defaulted column. No API shape change, no model change (`sort_key` is DB-internal, not selected into `models.Author`). Backfill is O(authors) once per boot and a no-op thereafter.
