### PR TITLE
fix(calibre): surface per-book push failure reasons and cap the error list (#1346)

### DIFF
--- a/internal/calibre/syncer.go
+++ b/internal/calibre/syncer.go
@@ -20,6 +20,14 @@ type SyncError struct {
 	Reason string `json:"reason"`
 }
 
+// maxSyncErrors caps the per-book error list kept in SyncProgress.Errors (and
+// thus returned on every status poll). A run that fails on every book — e.g. a
+// library path the Calibre container can't see (#1346) — would otherwise grow a
+// SyncError per book and re-serialize thousands of near-identical entries to the
+// UI on each poll. The full failure count is always in Stats.Failed; the list is
+// a sample for display.
+const maxSyncErrors = 50
+
 // SyncStats summarises one bulk-push run. Totals are cumulative across
 // every imported book with a file path; `Pushed` counts newly-added,
 // `AlreadyInCalibre` counts 409 Conflict responses (treated as success
@@ -199,6 +207,33 @@ func (s *Syncer) run(ctx context.Context, cfg Config) {
 	client := s.newClient(cfg)
 	sameLibrary := sameCalibreLibrary(ctx, cfg, client)
 
+	// Log the first book to hit each distinct failure reason at WARN. The
+	// summary line below only reports failed=N, and the per-book SyncErrors live
+	// in the polled progress (not the log), so a user staring at the log had no
+	// way to see *why* every push failed (#1346 — a path the Calibre container
+	// can't resolve). Dedupe by reason so a library-wide path mismatch logs once,
+	// not once per book.
+	loggedReasons := make(map[string]bool)
+	recordFailure := func(b *models.Book, path, reason string) {
+		s.setProgress(func(p *SyncProgress) {
+			p.Stats.Failed++
+			p.Stats.Processed++
+			if len(p.Errors) < maxSyncErrors {
+				p.Errors = append(p.Errors, SyncError{
+					BookID: b.ID,
+					Title:  b.Title,
+					Path:   path,
+					Reason: reason,
+				})
+			}
+		})
+		if !loggedReasons[reason] {
+			loggedReasons[reason] = true
+			slog.Warn("calibre sync: book push failed",
+				"bookId", b.ID, "title", b.Title, "path", path, "reason", reason)
+		}
+	}
+
 	for i := range eligible {
 		if err := ctx.Err(); err != nil {
 			s.fail("cancelled: " + err.Error())
@@ -208,16 +243,7 @@ func (s *Syncer) run(ctx context.Context, cfg Config) {
 		path := pushPath(b)
 		meta, err := s.metadataForBook(ctx, b, path, sameLibrary)
 		if err != nil {
-			s.setProgress(func(p *SyncProgress) {
-				p.Stats.Failed++
-				p.Stats.Processed++
-				p.Errors = append(p.Errors, SyncError{
-					BookID: b.ID,
-					Title:  b.Title,
-					Path:   path,
-					Reason: err.Error(),
-				})
-			})
+			recordFailure(b, path, err.Error())
 			continue
 		}
 		id, addErr := client.Add(ctx, path, meta)
@@ -239,16 +265,7 @@ func (s *Syncer) run(ctx context.Context, cfg Config) {
 				p.Stats.Processed++
 			})
 		default:
-			s.setProgress(func(p *SyncProgress) {
-				p.Stats.Failed++
-				p.Stats.Processed++
-				p.Errors = append(p.Errors, SyncError{
-					BookID: b.ID,
-					Title:  b.Title,
-					Path:   path,
-					Reason: addErr.Error(),
-				})
-			})
+			recordFailure(b, path, addErr.Error())
 		}
 	}
 
@@ -262,7 +279,8 @@ func (s *Syncer) run(ctx context.Context, cfg Config) {
 		"total", len(eligible),
 		"pushed", final.Stats.Pushed,
 		"alreadyInCalibre", final.Stats.AlreadyInCalibre,
-		"failed", final.Stats.Failed)
+		"failed", final.Stats.Failed,
+		"distinctFailureReasons", len(loggedReasons))
 }
 
 // pushPath returns the on-disk path to send to Calibre for the given

--- a/internal/calibre/syncer_test.go
+++ b/internal/calibre/syncer_test.go
@@ -3,6 +3,7 @@ package calibre
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -378,3 +379,40 @@ func TestSyncer_Start_RejectsConcurrentRuns(t *testing.T) {
 }
 
 func int64Ptr(v int64) *int64 { return &v }
+
+// TestSyncer_FailuresCappedButAllCounted covers the #1346 diagnostics: when
+// every book fails (e.g. a library path the Calibre container can't see),
+// Stats.Failed must count all of them, but the SyncErrors list returned to the
+// UI is capped at maxSyncErrors so the status payload stays bounded.
+func TestSyncer_FailuresCappedButAllCounted(t *testing.T) {
+	const n = maxSyncErrors + 25
+	bl := &fakeBookLister{}
+	calls := map[string]func() (int64, error){}
+	for i := 1; i <= n; i++ {
+		path := fmt.Sprintf("/l/book-%d.epub", i)
+		bl.books = append(bl.books, models.Book{ID: int64(i), Title: fmt.Sprintf("Book %d", i), FilePath: path})
+		calls[path] = func() (int64, error) {
+			return 0, errors.New("plugin client: server error 404: path not found in calibre library")
+		}
+	}
+	pusher := &fakePusher{calls: calls}
+
+	s := NewSyncer(bl)
+	s.newClient = func(_ Config) pluginPusher { return pusher }
+
+	if err := s.Start(context.Background(), Config{}, ModePlugin); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitUntil(t, 5*time.Second, func() bool { return !s.Running() })
+
+	p := s.Progress()
+	if p.Stats.Failed != n {
+		t.Errorf("Failed: got %d, want %d (all failures counted)", p.Stats.Failed, n)
+	}
+	if p.Stats.Processed != n {
+		t.Errorf("Processed: got %d, want %d", p.Stats.Processed, n)
+	}
+	if len(p.Errors) != maxSyncErrors {
+		t.Errorf("Errors len: got %d, want %d (capped sample)", len(p.Errors), maxSyncErrors)
+	}
+}


### PR DESCRIPTION
Addresses the diagnosability half of #1346.

## Problem

A user reported "Push to Calibre" failing on every book: `calibre sync complete failed=1819 pushed=0`, with **no per-book reason even in DEBUG**. The likely root cause is a cross-container path mismatch (Bindery library mounted at `/books`, Calibre at `/media/books`), so the plugin can't open the path Bindery sends — but the log gave the user nothing to diagnose with.

The per-book `SyncError{BookID,Title,Path,Reason}` entries were only ever written to the polled `SyncProgress.Errors`, never to the log. And that list was unbounded: 1819 failures = 1819 entries re-serialized to the UI on every status poll.

## Fix (observability only — no behaviour change to what gets pushed)

- **Log the cause.** The first book to hit each *distinct* failure reason is logged at WARN (`calibre sync: book push failed` with bookId/title/path/reason). Deduped by reason, so a library-wide path mismatch logs **once**, not 1819 times. The completion summary gains `distinctFailureReasons`.
- **Cap the UI error list** at `maxSyncErrors = 50`. `Stats.Failed` still counts every failure; `Errors` is a bounded sample so the status payload doesn't balloon.

## Tests

- New `TestSyncer_FailuresCappedButAllCounted`: 75 failing books → `Failed == 75`, `Errors` capped at 50.
- Existing syncer suite (mixed outcomes, single-failure error entry) still green; `go vet` clean.

## Not in scope

The actual path-mapping mismatch (the *cause* of #1346) is a config/UX problem — a separate change could validate/translate the library path to the Calibre container's view. This PR makes that failure legible instead of silent.
