### PR TITLE
fix: collapse duplicated author names

### DIFF
--- a/changelog.d/filter-duplicated-author-names.md
+++ b/changelog.d/filter-duplicated-author-names.md
@@ -1,0 +1,2 @@
+### Fixed
+- Author search now collapses duplicated provider-noise names like `Black, Chuck, Black, Chuck` into the cleaner matching author record.

--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -197,7 +197,11 @@ func searchFanOut[T any](ctx context.Context, providers []Provider, fn func(cont
 // "Last, First" the same as "First Last" so a person's inverted and natural
 // forms collapse together.
 func canonicalAuthorKey(name string) string {
-	return normalizeForDedup(uninvertAuthorName(name))
+	key := normalizeForDedup(uninvertAuthorName(name))
+	if folded, ok := foldDuplicatedAuthorKey(key); ok {
+		return folded
+	}
+	return key
 }
 
 // CanonicalAuthorKey is the exported form of canonicalAuthorKey, so callers
@@ -261,6 +265,9 @@ func dedupeAuthorsByName(authors []models.Author) []models.Author {
 // one that doesn't (0 = unknown), so OpenLibrary's work/ratings-bearing records
 // win over enrichers that omit them; ties keep the earlier (provider-first) one.
 func betterAuthorRecord(a, b models.Author) bool {
+	if c := preferNonDuplicatedAuthorName(a.Name, b.Name); c != 0 {
+		return c > 0
+	}
 	if c := preferKnownGreater(authorBookCount(a), authorBookCount(b)); c != 0 {
 		return c > 0
 	}
@@ -268,6 +275,39 @@ func betterAuthorRecord(a, b models.Author) bool {
 		return c > 0
 	}
 	return false
+}
+
+// preferNonDuplicatedAuthorName prefers a clean author label over provider noise
+// that repeats the same token sequence, e.g. OpenLibrary's occasional
+// "Black, Chuck, Black, Chuck" duplicate for "Chuck Black".
+func preferNonDuplicatedAuthorName(a, b string) int {
+	ad, bd := duplicatedAuthorName(a), duplicatedAuthorName(b)
+	if ad == bd {
+		return 0
+	}
+	if ad {
+		return -1
+	}
+	return 1
+}
+
+func duplicatedAuthorName(name string) bool {
+	_, ok := foldDuplicatedAuthorKey(normalizeForDedup(name))
+	return ok
+}
+
+func foldDuplicatedAuthorKey(key string) (string, bool) {
+	tokens := strings.Fields(key)
+	if len(tokens) < 4 || len(tokens)%2 != 0 {
+		return "", false
+	}
+	half := len(tokens) / 2
+	for i := 0; i < half; i++ {
+		if tokens[i] != tokens[i+half] {
+			return "", false
+		}
+	}
+	return strings.Join(tokens[:half], " "), true
 }
 
 // preferKnownGreater compares two counts where 0 means "unknown": a known value

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -301,6 +301,29 @@ func TestCanonicalAuthorKey(t *testing.T) {
 	}
 }
 
+func TestCanonicalAuthorKey_FoldsDuplicatedProviderNoise(t *testing.T) {
+	if got, want := canonicalAuthorKey("Black, Chuck, Black, Chuck"), canonicalAuthorKey("Chuck Black"); got != want {
+		t.Fatalf("canonicalAuthorKey duplicated provider noise = %q, want %q", got, want)
+	}
+}
+
+func TestDuplicatedAuthorName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "Black, Chuck, Black, Chuck", want: true},
+		{name: "Chuck Black", want: false},
+		{name: "Black, Chuck, Jr.", want: false},
+		{name: "", want: false},
+	}
+	for _, tt := range tests {
+		if got := duplicatedAuthorName(tt.name); got != tt.want {
+			t.Errorf("duplicatedAuthorName(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
 func TestAuthorRelevance_InversionAware(t *testing.T) {
 	q := "arthur c brooks"
 	if natural := authorRelevance("Arthur C. Brooks", q); natural != 1.0 {
@@ -351,6 +374,26 @@ func TestAggregator_SearchAuthors_CollapsesFragments(t *testing.T) {
 	}
 	if len(got) != 2 {
 		t.Errorf("expected 2 results (collapsed Brooks + Some Other Author), got %d", len(got))
+	}
+}
+
+func TestAggregator_SearchAuthors_PrefersCleanNameOverDuplicatedProviderNoise(t *testing.T) {
+	stats := func(n int) *models.AuthorStats { return &models.AuthorStats{BookCount: n} }
+	primary := &mockProvider{name: "ol", searchAuthors: []models.Author{
+		{Name: "Chuck Black", ForeignID: "OL1480449A", Statistics: stats(47), RatingsCount: 14},
+		{Name: "Black, Chuck, Black, Chuck", ForeignID: "OL11441410A", Statistics: stats(1)},
+	}}
+	agg := newTestAggregator(primary)
+
+	got, err := agg.SearchAuthors(context.Background(), "Chuck Black")
+	if err != nil {
+		t.Fatalf("SearchAuthors: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("duplicated provider-noise row should collapse into the clean author, got %d: %+v", len(got), got)
+	}
+	if got[0].ForeignID != "OL1480449A" || got[0].Name != "Chuck Black" {
+		t.Fatalf("kept author = %+v, want clean Chuck Black record", got[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fold duplicated author keys like `Black, Chuck, Black, Chuck` to their clean identity during author search dedupe
- Prefer the non-duplicated author label when duplicate and clean provider records collapse together
- Add a regression test based on the Chuck Black/OpenLibrary duplicate shape

## Test plan
- `go test ./internal/metadata`
- `go test ./internal/api`
