### PR TITLE
fix: prune author work subject outliers

### DIFF
--- a/changelog.d/filter-author-work-collisions.md
+++ b/changelog.d/filter-author-work-collisions.md
@@ -1,0 +1,2 @@
+### Fixed
+- Author refresh now prunes obvious technical same-name collisions from fiction-heavy catalogs, avoiding unrelated works like computer-networking textbooks on fiction author pages.

--- a/internal/metadata/aggregator_author_works.go
+++ b/internal/metadata/aggregator_author_works.go
@@ -111,6 +111,7 @@ func (a *Aggregator) GetAuthorWorksForAuthor(ctx context.Context, author models.
 		}
 	}
 	books = pruneAuthorWorkCompilations(books, compilationTitles)
+	books = pruneAuthorWorkSubjectOutliers(books)
 
 	a.enrichMissingAuthorWorkCovers(ctx, books)
 	if supplementsComplete {
@@ -178,6 +179,71 @@ func pruneAuthorWorkCompilations(books []models.Book, compilationTitles map[stri
 		filtered = append(filtered, b)
 	}
 	return filtered
+}
+
+// pruneAuthorWorkSubjectOutliers drops obvious same-name-author collisions from
+// primary-provider author work lists. OpenLibrary occasionally groups unrelated
+// people who share a name; when a catalog is overwhelmingly fiction/juvenile
+// fiction, a computer-networking textbook is almost certainly from another
+// author and should not be auto-wanted under the fiction author.
+func pruneAuthorWorkSubjectOutliers(books []models.Book) []models.Book {
+	if len(books) < 4 || fictionCatalogSignalCount(books) < 3 {
+		return books
+	}
+	filtered := books[:0]
+	for _, b := range books {
+		if isTechnicalSubjectOutlier(b) {
+			continue
+		}
+		filtered = append(filtered, b)
+	}
+	return filtered
+}
+
+func fictionCatalogSignalCount(books []models.Book) int {
+	count := 0
+	for _, b := range books {
+		if hasFictionSubjectSignal(b) {
+			count++
+		}
+	}
+	return count
+}
+
+func isTechnicalSubjectOutlier(book models.Book) bool {
+	if hasFictionSubjectSignal(book) {
+		return false
+	}
+	signals := 0
+	for _, genre := range book.Genres {
+		g := strings.ToLower(strings.TrimSpace(genre))
+		switch {
+		case strings.Contains(g, "computer network"),
+			strings.Contains(g, "software-defined network"),
+			strings.Contains(g, "networking"),
+			strings.Contains(g, "telecommunication"),
+			strings.Contains(g, "programming language"),
+			strings.Contains(g, "software engineering"):
+			signals++
+		}
+	}
+	return signals >= 2
+}
+
+func hasFictionSubjectSignal(book models.Book) bool {
+	for _, genre := range book.Genres {
+		g := strings.ToLower(strings.TrimSpace(genre))
+		switch {
+		case strings.Contains(g, "fiction"),
+			strings.Contains(g, "fantasy"),
+			strings.Contains(g, "science fiction"),
+			strings.Contains(g, "juvenile"),
+			strings.Contains(g, "christian life"),
+			strings.Contains(g, "religious"):
+			return true
+		}
+	}
+	return false
 }
 
 func cloneBooks(books []models.Book) []models.Book {

--- a/internal/metadata/aggregator_author_works_test.go
+++ b/internal/metadata/aggregator_author_works_test.go
@@ -229,6 +229,43 @@ func TestAggregator_GetAuthorWorksForAuthor_PrunesCompilations(t *testing.T) {
 	}
 }
 
+func TestAggregator_GetAuthorWorksForAuthor_PrunesTechnicalSameNameCollision(t *testing.T) {
+	primary := &mockWorksProvider{
+		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{
+			{ForeignID: "OL1W", Title: "Kingdom's Dawn", MetadataProvider: "openlibrary", Genres: []string{"Juvenile Fiction", "Christian life, fiction"}},
+			{ForeignID: "OL2W", Title: "Kingdom's Hope", MetadataProvider: "openlibrary", Genres: []string{"Fiction, fantasy, general"}},
+			{ForeignID: "OL3W", Title: "Rise of the Fallen", MetadataProvider: "openlibrary", Genres: []string{"Adventure and adventurers, fiction", "Christian life, fiction"}},
+			{ForeignID: "OL4W", Title: "Software Defined Networks", MetadataProvider: "openlibrary", Genres: []string{
+				"Computer networks",
+				"Software-defined networking (Computer network technology)",
+				"Professional, career & trade -> computer science -> networking",
+				"Telecommunications",
+			}},
+		}},
+	}
+	agg := &Aggregator{
+		primary: primary,
+		cache:   newTTLCache(time.Minute),
+	}
+
+	got, err := agg.GetAuthorWorksForAuthor(context.Background(), models.Author{ForeignID: "OL1480449A", Name: "Chuck Black"})
+	if err != nil {
+		t.Fatalf("GetAuthorWorksForAuthor: %v", err)
+	}
+	titles := map[string]bool{}
+	for _, b := range got {
+		titles[b.Title] = true
+	}
+	if titles["Software Defined Networks"] {
+		t.Fatalf("technical same-name collision should be pruned, got %+v", got)
+	}
+	for _, want := range []string{"Kingdom's Dawn", "Kingdom's Hope", "Rise of the Fallen"} {
+		if !titles[want] {
+			t.Fatalf("expected %q to remain, got %+v", want, got)
+		}
+	}
+}
+
 func TestAggregator_GetAuthorWorksForAuthor_MergesSupplementalIntoFirstDuplicateTitle(t *testing.T) {
 	primary := &mockWorksProvider{
 		mockProvider: mockProvider{name: "ol", authorWorks: []models.Book{


### PR DESCRIPTION
## Summary
- Prune obvious same-name author collisions from author refresh results when a fiction-heavy catalog includes a technical/computer-networking outlier
- Add a regression test based on the Chuck Black / `Software Defined Networks` OpenLibrary collision
- Add a changelog fragment

## Test plan
- `go test ./internal/metadata`
- `go test ./internal/api`
