### PR TITLE
fix: Fix Match / delete data loss (#1368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.23.2] — 2026-07-01
+
+A data-loss patch for **Fix Match** (the file-reassign feature, #1238, shipped in
+v1.23.0). Anyone whose library is reached through a symlink should update.
+
+### Fixed
+- **Fix Match no longer strands (and later deletes) a file on symlinked
+  libraries** (#1368) — reassigning a file resolves the path through
+  `EvalSymlinks` for its containment check, but `book_files` stores the path as
+  it was recorded at import time. On a library mounted through a symlink (common
+  in Docker/NAS setups) the resolved and stored paths differ, so the exact-match
+  detach silently did nothing: the *old* record kept a live reference to the file
+  the reassign had moved to the target. Deleting that "empty-looking" record then
+  removed the file the target now needs. Bindery now detaches against the stored
+  path (falling back to the resolved form), so the source record is reliably
+  emptied. Closes #1368.
+- **Reassign cleanup no longer deletes the source when nothing was imported**
+  (#1368) — the post-reassign cleanup deleted the original file once it saw *any*
+  file on the target book, treating a pre-existing unrelated file (e.g. an ebook
+  the target already had) as proof the move succeeded. If the import placed
+  nothing, the source was deleted anyway. It now snapshots the target's files
+  before importing and only removes the source when a *newly added* file is
+  present on disk.
+- **Deleting a book can't remove a file another book owns** (#1368) — deleting a
+  book with "also delete files" falls back to the legacy single-path columns when
+  a book has no `book_files` rows, and did so without checking whether the path
+  was still in use. A stale legacy column could therefore delete a file a
+  different book actively tracks. The delete now skips any legacy path still
+  present in `book_files` (the `path` column is globally unique, so a match means
+  another book owns it).
+
 ## [v1.23.1] — 2026-06-29
 
 A patch release: responsive mobile Settings, correct alphabetical ordering for

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -526,10 +526,23 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		if len(files) == 0 {
 			if book, _ := h.books.GetByID(r.Context(), id); book != nil {
 				for _, p := range []string{book.EbookFilePath, book.AudiobookFilePath, book.FilePath} {
-					if p != "" {
-						if _, err := safeRemoveBookPath(r.Context(), h.roots, p, "", "id", id); err != nil {
-							slog.Warn("book delete: failed to remove legacy file", "id", id, "path", p, "error", err)
-						}
+					if p == "" {
+						continue
+					}
+					// This book has no book_files rows, so any book_files entry
+					// matching a legacy path here belongs to a DIFFERENT book (path
+					// is UNIQUE). Never delete a file another book still owns — a
+					// stale legacy column left by a mis-detached reassign must not
+					// take out the file the target now needs (#1368).
+					if tracked, err := h.books.PathTracked(r.Context(), p); err != nil {
+						slog.Warn("book delete: could not verify legacy path ownership; skipping disk delete", "id", id, "path", p, "error", err)
+						continue
+					} else if tracked {
+						slog.Warn("book delete: legacy path still tracked in book_files by another book; skipping disk delete", "id", id, "path", p)
+						continue
+					}
+					if _, err := safeRemoveBookPath(r.Context(), h.roots, p, "", "id", id); err != nil {
+						slog.Warn("book delete: failed to remove legacy file", "id", id, "path", p, "error", err)
 					}
 				}
 			}

--- a/internal/api/books_test.go
+++ b/internal/api/books_test.go
@@ -451,6 +451,63 @@ func TestBookDelete_WithDeleteFiles(t *testing.T) {
 	}
 }
 
+// TestBookDelete_LegacyFallbackSkipsFileOwnedByAnotherBook covers the #1368
+// amplifier: deleting a book that has NO book_files rows but a STALE legacy
+// path column must not os.Remove a file another book still tracks in
+// book_files. Roots are unset here so containment cannot be what saves the
+// file — the book_files ownership guard must.
+func TestBookDelete_LegacyFallbackSkipsFileOwnedByAnotherBook(t *testing.T) {
+	h, books, _, author, ctx := bookFixture(t)
+
+	shared := filepath.Join(t.TempDir(), "book.m4b")
+	if err := os.WriteFile(shared, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Owner legitimately tracks the file via book_files.
+	owner := &models.Book{
+		ForeignID: "OWNER", AuthorID: author.ID, Title: "Owner", SortTitle: "owner",
+		Status: "imported", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, owner.ID, models.MediaTypeAudiobook, shared); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ghost has no book_files rows but a stale legacy column pointing at the
+	// same on-disk file (the state a mis-detached reassign leaves behind).
+	ghost := &models.Book{
+		ForeignID: "GHOST", AuthorID: author.ID, Title: "Ghost", SortTitle: "ghost",
+		Status: "imported", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, ghost); err != nil {
+		t.Fatal(err)
+	}
+	ghost.AudiobookFilePath = shared
+	if err := books.Update(ctx, ghost); err != nil {
+		t.Fatal(err)
+	}
+	if gf, err := books.ListFiles(ctx, ghost.ID); err != nil || len(gf) != 0 {
+		t.Fatalf("ghost should have 0 book_files rows, got %d (err=%v)", len(gf), err)
+	}
+
+	req := withURLParam(httptest.NewRequest(http.MethodDelete, "/api/v1/book/"+strconv.FormatInt(ghost.ID, 10)+"?deleteFiles=true", nil), "id", strconv.FormatInt(ghost.ID, 10))
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d; body=%s", rec.Code, rec.Body.String())
+	}
+
+	if _, err := os.Stat(shared); err != nil {
+		t.Fatalf("shared file deleted by removing the ghost record — data loss (#1368): %v", err)
+	}
+	if of, err := books.ListFiles(ctx, owner.ID); err != nil || len(of) != 1 {
+		t.Errorf("owner should still track the file, got %d rows (err=%v)", len(of), err)
+	}
+}
+
 // TestBookDelete_WithoutDeleteFiles preserves the file even though the row
 // is gone — matches author-delete behaviour for non-opt-in sweeps.
 func TestBookDelete_WithoutDeleteFiles(t *testing.T) {

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -192,29 +192,84 @@ func (h *ManualImportHandler) Reassign(w http.ResponseWriter, r *http.Request) {
 	}
 	// Detach the stale association from the book that currently owns this path.
 	// RemoveBookFile is status-aware (flips a now-fileless source book back to
-	// "wanted") and is a no-op when the path isn't tracked. Best-effort: even if
-	// it fails, the re-import below still re-points the file to the target.
-	if _, err := h.books.RemoveBookFile(r.Context(), path); err != nil {
-		slog.Warn("reassign: detach source book file", "path", path, "error", err)
+	// "wanted"). book_files stores the path exactly as recorded at import time,
+	// which differs from prepareImport's EvalSymlinks-resolved `path` when the
+	// library is reached through a symlink (#1368). A silent no-op here leaves
+	// the source book still referencing a file the reassign is about to move
+	// away, so a later delete of the "empty-looking" source removes the target's
+	// file. Detach against the caller's raw path (what the frontend read from the
+	// DB) first, then fall back to the resolved form.
+	if !h.detachSourceFile(r.Context(), req.Path, path) {
+		slog.Warn("reassign: source file not tracked under raw or resolved path; source book may retain a stale reference",
+			"rawPath", req.Path, "resolvedPath", path)
 	}
 	ctx := context.WithoutCancel(r.Context())
 	targetID := req.TargetBookID
+	// Snapshot the target's existing files so removeStaleSource can tell whether
+	// THIS import actually placed a new file for the target, rather than treating
+	// a pre-existing unrelated file as proof of a successful move (#1368).
+	preexisting := h.targetFilePaths(ctx, targetID)
 	go func() {
 		h.scanner.ImportFromPath(ctx, dl, path, req.Format)
-		h.removeStaleSource(ctx, path, targetID)
+		h.removeStaleSource(ctx, path, targetID, preexisting)
 	}()
 	writeJSON(w, http.StatusAccepted, dl)
+}
+
+// detachSourceFile removes the book_files association for the file being
+// reassigned and reports whether a row was actually removed. book_files stores
+// the path exactly as recorded at import time, which for a symlinked library
+// differs from the EvalSymlinks-resolved path prepareImport produces (#1368).
+// Try the caller's raw (un-resolved) path — the string the frontend read back
+// from the DB — then the resolved path, so the source is reliably emptied
+// regardless of which form the row holds.
+func (h *ManualImportHandler) detachSourceFile(ctx context.Context, rawPath, resolvedPath string) bool {
+	raw := filepath.Clean(rawPath)
+	removed, err := h.books.RemoveBookFile(ctx, raw)
+	if err != nil {
+		slog.Warn("reassign: detach source book file", "path", raw, "error", err)
+	}
+	if removed != nil {
+		return true
+	}
+	if resolvedPath == raw {
+		return false
+	}
+	removed, err = h.books.RemoveBookFile(ctx, resolvedPath)
+	if err != nil {
+		slog.Warn("reassign: detach source book file", "path", resolvedPath, "error", err)
+	}
+	return removed != nil
+}
+
+// targetFilePaths returns the set of on-disk paths currently tracked for the
+// target book. Captured before the async import so removeStaleSource can
+// distinguish a file THIS reassign placed from one the target already had (#1368).
+func (h *ManualImportHandler) targetFilePaths(ctx context.Context, bookID int64) map[string]bool {
+	set := map[string]bool{}
+	files, err := h.books.ListBookFiles(ctx, bookID)
+	if err != nil {
+		slog.Warn("reassign: snapshot target files", "bookID", bookID, "error", err)
+		return set
+	}
+	for _, f := range files {
+		set[f.Path] = true
+	}
+	return set
 }
 
 // removeStaleSource deletes the original mis-filed copy after a successful
 // reassign. The import places the file under the target book (by hardlink or
 // copy), leaving the original where it was — which a later library scan would
 // re-attach to the wrong book. We remove it, but only once we can confirm the
-// import actually put the file somewhere else: the target must now have a
-// tracked file at a different path that exists on disk. If the import failed
-// (no new file) or resolved to the same path, the source is left untouched so a
-// file is never lost.
-func (h *ManualImportHandler) removeStaleSource(ctx context.Context, src string, targetID int64) {
+// import actually put the file somewhere else: the target must now have a file
+// that (a) is not the source path, (b) was not already present before this
+// reassign (preexisting), and (c) exists on disk. Counting a pre-existing
+// unrelated file (e.g. an ebook the target already had) as proof of a move
+// would delete the source even when this import placed nothing — data loss
+// (#1368). If the import failed (no new file) or resolved to the same path, the
+// source is left untouched so a file is never lost.
+func (h *ManualImportHandler) removeStaleSource(ctx context.Context, src string, targetID int64, preexisting map[string]bool) {
 	files, err := h.books.ListBookFiles(ctx, targetID)
 	if err != nil {
 		slog.Warn("reassign cleanup: list target files", "error", err)
@@ -224,6 +279,9 @@ func (h *ManualImportHandler) removeStaleSource(ctx context.Context, src string,
 	for _, f := range files {
 		if f.Path == src {
 			return // target ended up at the same path; nothing to clean up
+		}
+		if preexisting[f.Path] {
+			continue // already there before this reassign — not proof of a move
 		}
 		if _, statErr := os.Stat(f.Path); statErr == nil {
 			moved = true

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -815,6 +815,142 @@ func TestManualImportReassign_DetachesSourceAndImportsTarget(t *testing.T) {
 	}
 }
 
+// TestManualImportReassign_SymlinkedLibrary_DetachesSource reproduces #1368
+// Bug A: when the file being reassigned is stored in book_files under an
+// unresolved (symlinked) path, prepareImport resolves it via EvalSymlinks and
+// the detach must STILL empty the source book. Before the fix the detach ran
+// against the resolved path only, missed the exact-match book_files row, and
+// left the source book holding a live reference — so a later delete removed the
+// target's file.
+func TestManualImportReassign_SymlinkedLibrary_DetachesSource(t *testing.T) {
+	realDir := t.TempDir()
+	linkParent := t.TempDir()
+	link := filepath.Join(linkParent, "lib")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	// Physical file lives under the real directory.
+	authorDir := filepath.Join(realDir, "Author")
+	if err := os.MkdirAll(authorDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(authorDir, "book.m4b"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The path AS STORED in book_files goes through the symlink.
+	storedPath := filepath.Join(link, "Author", "book.m4b")
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	ctx := context.Background()
+
+	src := seedBook(t, authors, books, ctx)
+	if err := books.AddBookFile(ctx, src.ID, models.MediaTypeAudiobook, storedPath); err != nil {
+		t.Fatalf("attach audiobook to source: %v", err)
+	}
+	target := &models.Book{
+		ForeignID: "mi-target", AuthorID: src.AuthorID,
+		Title: "Correct Book", SortTitle: "correct book",
+		Status: "wanted", Genres: []string{},
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := books.Create(ctx, target); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books).
+		WithRoots(NewLibraryRoots(staticRootLister{paths: []string{link}}))
+	body, _ := json.Marshal(map[string]any{"path": storedPath, "targetBookId": target.ID, "format": models.MediaTypeAudiobook})
+	rec := httptest.NewRecorder()
+	h.Reassign(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/reassign", bytes.NewReader(body)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", rec.Code, rec.Body.String())
+	}
+
+	// The source must be fully detached despite the symlink path mismatch.
+	srcFiles, err := books.ListFiles(ctx, src.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(srcFiles) != 0 {
+		t.Errorf("source still has %d book_files row(s) after reassign; want 0 (detach must match the symlinked stored path)", len(srcFiles))
+	}
+	after, err := books.GetByID(ctx, src.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.AudiobookFilePath != "" || after.FilePath != "" {
+		t.Errorf("source legacy paths not cleared: audiobook=%q file=%q", after.AudiobookFilePath, after.FilePath)
+	}
+	if after.Status != models.BookStatusWanted {
+		t.Errorf("source status = %q, want wanted after losing its only file", after.Status)
+	}
+}
+
+// TestRemoveStaleSource_KeepsSourceWhenImportPlacedNothing reproduces #1368
+// Bug B: removeStaleSource must not delete the source file just because the
+// target already owns an unrelated file (e.g. an ebook). Only a file absent
+// from the pre-import snapshot proves this reassign actually moved something.
+func TestRemoveStaleSource_KeepsSourceWhenImportPlacedNothing(t *testing.T) {
+	t.Parallel()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	ctx := context.Background()
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books)
+
+	target := seedBook(t, authors, books, ctx)
+	tmp := t.TempDir()
+
+	// Target already owns an unrelated ebook that exists on disk.
+	existing := filepath.Join(tmp, "existing.epub")
+	if err := os.WriteFile(existing, []byte("e"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, target.ID, models.MediaTypeEbook, existing); err != nil {
+		t.Fatal(err)
+	}
+	// Snapshot taken before the (failed / no-op) import: it already contains the
+	// pre-existing ebook.
+	preexisting := h.targetFilePaths(ctx, target.ID)
+
+	src := filepath.Join(tmp, "source.m4b")
+	if err := os.WriteFile(src, []byte("s"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The import placed nothing new for the target, so the source must survive.
+	h.removeStaleSource(ctx, src, target.ID, preexisting)
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("source file deleted despite no new import (data loss): %v", err)
+	}
+
+	// Positive control: once the import DOES add a new file the source is cleaned.
+	moved := filepath.Join(tmp, "moved.m4b")
+	if err := os.WriteFile(moved, []byte("m"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, target.ID, models.MediaTypeAudiobook, moved); err != nil {
+		t.Fatal(err)
+	}
+	h.removeStaleSource(ctx, src, target.ID, preexisting)
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Errorf("source should be removed once a new file is placed at the target; stat err=%v", err)
+	}
+}
+
 func TestManualImportReassign_EmptyPath(t *testing.T) {
 	t.Parallel()
 	h, _, _, _, _ := manualImportFixture(t)

--- a/internal/db/book_files.go
+++ b/internal/db/book_files.go
@@ -80,6 +80,23 @@ func (r *BookFileRepo) DeleteByPath(ctx context.Context, path string) (int64, er
 	return bookID, nil
 }
 
+// PathTracked reports whether the given exact on-disk path is present in
+// book_files. The book-delete legacy-column fallback uses this to avoid
+// os.Remove-ing a file that another book still owns via book_files — the path
+// column is globally UNIQUE, so a hit means exactly one (other) book tracks it
+// (#1368).
+func (r *BookFileRepo) PathTracked(ctx context.Context, path string) (bool, error) {
+	var one int
+	err := r.db.QueryRowContext(ctx, `SELECT 1 FROM book_files WHERE path = ? LIMIT 1`, path).Scan(&one)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("book_files path tracked: %w", err)
+	}
+	return true, nil
+}
+
 // ListAllPaths returns every path currently registered in book_files.
 // Used by ScanLibrary to build the set of already-tracked files.
 func (r *BookFileRepo) ListAllPaths(ctx context.Context) ([]string, error) {

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -552,6 +552,12 @@ func (r *BookRepo) RemoveBookFile(ctx context.Context, path string) (*models.Boo
 	return r.GetByID(ctx, bookID)
 }
 
+// PathTracked reports whether an exact on-disk path is still registered in
+// book_files (owned by any book). See BookFileRepo.PathTracked (#1368).
+func (r *BookRepo) PathTracked(ctx context.Context, path string) (bool, error) {
+	return r.files.PathTracked(ctx, path)
+}
+
 // ListAllBookFilePaths returns every path in book_files.
 // Used by ScanLibrary to build the set of already-tracked files efficiently.
 func (r *BookRepo) ListAllBookFilePaths(ctx context.Context) ([]string, error) {


### PR DESCRIPTION
## What & why

Fixes #1368 — a data-loss bug in **Fix Match** (file reassign, #1238) confirmed by running the real code against a temp filesystem. Three parts:

### Fix A — reassign detach no-ops on symlinked libraries
`prepareImport` resolves the request path via `EvalSymlinks`, and `Reassign` detached with that resolved path. But `book_files.path` stores the path as recorded at import time, so on a symlinked media mount (common in Docker/NAS) the exact-match `DeleteByPath` missed → the detach silently did nothing → the source book kept a live reference to the file the reassign moved away. Now detach against the caller's raw path first, falling back to the resolved form.

### Fix B — `removeStaleSource` false-positive
It set `moved=true` if *any* file on the target existed on disk, then `os.Remove(src)`. If the target already owned an unrelated file (e.g. an ebook) and this reassign placed nothing, the source was deleted anyway. Now a pre-import snapshot of the target's files is taken, and only a *newly added* on-disk file counts as proof of a move.

### Amplifier — book-delete legacy fallback
`?deleteFiles=true` falls back to the legacy `ebook/audiobook/file_path` columns when a book has no `book_files` rows, with no cross-reference check — so a stale legacy column could delete a file another book still owns. Added a `PathTracked` lookup (path is globally UNIQUE) and skip the disk delete when the legacy path is still present in `book_files`.

## Tests

- `TestManualImportReassign_SymlinkedLibrary_DetachesSource` — reassign under a symlinked root fully empties the source (Fix A).
- `TestRemoveStaleSource_KeepsSourceWhenImportPlacedNothing` — source survives when the target only had a pre-existing file; positive control removes it once a new file appears (Fix B).
- `TestBookDelete_LegacyFallbackSkipsFileOwnedByAnotherBook` — deleting a ghost record with a stale legacy column leaves the owner's file intact (amplifier). Roots unset so the guard, not containment, is what saves the file.

All three fail against the pre-fix code. `go test ./internal/api ./internal/db ./internal/importer`, `gofmt`, `go vet`, and `golangci-lint` all green.

## Risk

Behaviour-narrowing: the delete guard only ever *skips* a disk delete it can prove is unsafe; the detach change adds a fallback rather than removing the existing lookup. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
