### PR TITLE
fix: centralize book-file delete ownership guard (#1368 hardening)

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1171,8 +1171,12 @@ func (h *AuthorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The author's books (and their book_files rows) were cascade-deleted above,
+	// so excludeBookID=0 makes the ownership guard skip any path still tracked by
+	// a surviving book of another author — deleting an author must not delete a
+	// file some other book still owns (#1368).
 	for _, p := range pathsToRemove {
-		if _, err := safeRemoveBookPath(r.Context(), h.roots, p, "", "author_id", id); err != nil {
+		if _, err := safeRemoveBookPath(r.Context(), h.roots, h.books, 0, p, "", "author_id", id); err != nil {
 			slog.Warn("delete author: failed to remove file", "author_id", id, "path", p, "error", err)
 		}
 	}

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -239,6 +239,75 @@ func TestDeleteAuthor_WithDeleteFiles(t *testing.T) {
 	}
 }
 
+// TestDeleteAuthor_SkipsFileOwnedByAnotherBook covers the #1368 ownership guard
+// on the author-delete sweep: a book under the deleted author whose STALE legacy
+// file_path points at a file another (surviving) book still tracks in book_files
+// must not be removed from disk.
+func TestDeleteAuthor_SkipsFileOwnedByAnotherBook(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+
+	shared := filepath.Join(t.TempDir(), "shared.m4b")
+	if err := os.WriteFile(shared, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Surviving owner under a different author, tracking the file in book_files.
+	keepAuthor := &models.Author{ForeignID: "OLKEEP", Name: "Keep", SortName: "Keep", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authorRepo.Create(ctx, keepAuthor); err != nil {
+		t.Fatal(err)
+	}
+	owner := &models.Book{ForeignID: "OLOWNER", AuthorID: keepAuthor.ID, Title: "Owner", SortTitle: "owner", Status: "imported", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true}
+	if err := bookRepo.Create(ctx, owner); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.AddBookFile(ctx, owner.ID, models.MediaTypeAudiobook, shared); err != nil {
+		t.Fatal(err)
+	}
+
+	// Doomed author with a book whose legacy file_path aliases the same file but
+	// has no book_files row of its own.
+	author := &models.Author{ForeignID: "OLDOOM", Name: "Doom", SortName: "Doom", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	ghost := &models.Book{ForeignID: "OLGHOST", AuthorID: author.ID, Title: "Ghost", SortTitle: "ghost", Status: "imported", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true}
+	if err := bookRepo.Create(ctx, ghost); err != nil {
+		t.Fatal(err)
+	}
+	ghost.FilePath = shared
+	if err := bookRepo.Update(ctx, ghost); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, nil, nil, profileRepo, nil)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/author/"+strconv.FormatInt(author.ID, 10)+"?deleteFiles=true", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(author.ID, 10))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if _, err := os.Stat(shared); err != nil {
+		t.Fatalf("shared file deleted by author delete despite another book owning it (#1368): %v", err)
+	}
+	if of, err := bookRepo.ListFiles(ctx, owner.ID); err != nil || len(of) != 1 {
+		t.Errorf("owner should still track the file, got %d rows (err=%v)", len(of), err)
+	}
+}
+
 // TestDeleteAuthor_WithoutDeleteFiles confirms the default path leaves
 // files on disk. Preserves the pre-#15 behaviour for anyone who hits the
 // delete button reflexively without opting into a disk sweep.

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -518,30 +518,22 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Get("deleteFiles") == "true" {
 		files, _ := h.books.ListFiles(r.Context(), id)
 		for _, f := range files {
-			if _, err := safeRemoveBookPath(r.Context(), h.roots, f.Path, "", "id", id); err != nil {
+			if _, err := safeRemoveBookPath(r.Context(), h.roots, h.books, id, f.Path, "", "id", id); err != nil {
 				slog.Warn("book delete: failed to remove file", "id", id, "path", f.Path, "error", err)
 			}
 		}
-		// Fallback for books imported before the book_files migration.
+		// Fallback for books imported before the book_files migration. This book
+		// has no book_files rows, so safeRemoveBookPath's ownership guard (exclude
+		// this id) skips any legacy path another book still tracks — a stale
+		// legacy column left by a mis-detached reassign must not take out the file
+		// the target now needs (#1368).
 		if len(files) == 0 {
 			if book, _ := h.books.GetByID(r.Context(), id); book != nil {
 				for _, p := range []string{book.EbookFilePath, book.AudiobookFilePath, book.FilePath} {
 					if p == "" {
 						continue
 					}
-					// This book has no book_files rows, so any book_files entry
-					// matching a legacy path here belongs to a DIFFERENT book (path
-					// is UNIQUE). Never delete a file another book still owns — a
-					// stale legacy column left by a mis-detached reassign must not
-					// take out the file the target now needs (#1368).
-					if tracked, err := h.books.PathTracked(r.Context(), p); err != nil {
-						slog.Warn("book delete: could not verify legacy path ownership; skipping disk delete", "id", id, "path", p, "error", err)
-						continue
-					} else if tracked {
-						slog.Warn("book delete: legacy path still tracked in book_files by another book; skipping disk delete", "id", id, "path", p)
-						continue
-					}
-					if _, err := safeRemoveBookPath(r.Context(), h.roots, p, "", "id", id); err != nil {
+					if _, err := safeRemoveBookPath(r.Context(), h.roots, h.books, id, p, "", "id", id); err != nil {
 						slog.Warn("book delete: failed to remove legacy file", "id", id, "path", p, "error", err)
 					}
 				}
@@ -640,7 +632,7 @@ func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 	// strand the row permanently behind a path the user cannot delete.
 	var deletedPaths []string
 	for _, p := range toDelete {
-		skipped, err := safeRemoveBookPath(r.Context(), h.roots, p, format, "id", id)
+		skipped, err := safeRemoveBookPath(r.Context(), h.roots, h.books, id, p, format, "id", id)
 		if err != nil {
 			slog.Error("failed to remove book file", "id", id, "path", p, "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -290,6 +290,15 @@ func (h *ManualImportHandler) removeStaleSource(ctx context.Context, src string,
 	if !moved {
 		return // import did not place a new file; leave the source in place
 	}
+	// Never delete src while a book still tracks it in book_files — another
+	// record may legitimately own this exact path. Fail safe on error (#1368).
+	if owned, err := h.books.PathOwnedByOtherBook(ctx, src, 0); err != nil {
+		slog.Warn("reassign cleanup: could not verify source ownership; leaving file in place", "path", src, "error", err)
+		return
+	} else if owned {
+		slog.Warn("reassign cleanup: source path still tracked by a book; leaving file in place", "path", src)
+		return
+	}
 	if err := os.Remove(src); err != nil {
 		slog.Warn("reassign cleanup: remove stale source file", "path", src, "error", err)
 		return

--- a/internal/api/path_safety.go
+++ b/internal/api/path_safety.go
@@ -230,11 +230,39 @@ func containsUnderRoot(p, root string) bool {
 // metadata.opf with `<path>/etc/passwd</path>`) could redirect a delete
 // outside any library. The Calibre integration writes into a configured
 // library dir anyway, so legitimate Calibre books still pass the check.
-func safeRemoveBookPath(ctx context.Context, roots *LibraryRoots, p, format string, logFields ...any) (skipped bool, err error) {
+func safeRemoveBookPath(ctx context.Context, roots *LibraryRoots, owner bookFileOwner, excludeBookID int64, p, format string, logFields ...any) (skipped bool, err error) {
 	if !roots.Contains(ctx, p) {
 		fields := append([]any{"path", p, "operation", "book_file_delete"}, logFields...)
 		slog.Warn("path containment: refusing to delete file outside configured library roots", fields...)
 		return true, nil
 	}
+	// Ownership guard (#1368): never unlink a file that another book still tracks
+	// in book_files. A stale legacy path column, a mis-detached Fix Match, or a
+	// duplicate record must not let deleting one book destroy another book's
+	// file. Fail safe — if ownership can't be determined, skip the disk delete
+	// (the DB row is going away regardless; a stranded path is recoverable, a
+	// deleted file is not).
+	if owner != nil {
+		otherOwns, ownErr := owner.PathOwnedByOtherBook(ctx, p, excludeBookID)
+		if ownErr != nil {
+			fields := append([]any{"path", p, "operation", "book_file_delete", "error", ownErr}, logFields...)
+			slog.Warn("path ownership: could not verify book_files ownership; skipping disk delete", fields...)
+			return true, nil
+		}
+		if otherOwns {
+			fields := append([]any{"path", p, "operation", "book_file_delete"}, logFields...)
+			slog.Warn("path ownership: file still tracked by another book; skipping disk delete", fields...)
+			return true, nil
+		}
+	}
 	return false, removeBookPathScoped(p, format)
+}
+
+// bookFileOwner reports whether an on-disk path is still registered in
+// book_files to a book other than excludeBookID. safeRemoveBookPath consults it
+// so no delete path — book delete, per-file delete, author delete, reassign
+// cleanup — can unlink a file another book still owns (#1368). The book_files
+// path column is globally UNIQUE, so any hit is a single unambiguous owner.
+type bookFileOwner interface {
+	PathOwnedByOtherBook(ctx context.Context, path string, excludeBookID int64) (bool, error)
 }

--- a/internal/db/book_files.go
+++ b/internal/db/book_files.go
@@ -80,21 +80,22 @@ func (r *BookFileRepo) DeleteByPath(ctx context.Context, path string) (int64, er
 	return bookID, nil
 }
 
-// PathTracked reports whether the given exact on-disk path is present in
-// book_files. The book-delete legacy-column fallback uses this to avoid
-// os.Remove-ing a file that another book still owns via book_files — the path
-// column is globally UNIQUE, so a hit means exactly one (other) book tracks it
-// (#1368).
-func (r *BookFileRepo) PathTracked(ctx context.Context, path string) (bool, error) {
-	var one int
-	err := r.db.QueryRowContext(ctx, `SELECT 1 FROM book_files WHERE path = ? LIMIT 1`, path).Scan(&one)
+// PathOwnedByOtherBook reports whether the given on-disk path is present in
+// book_files under a book other than excludeBookID. The path column is globally
+// UNIQUE, so there is at most one owner. Pass excludeBookID=0 to treat ANY
+// registered owner as "another book" (e.g. when the current book's rows have
+// already been cascade-deleted). The delete and reassign-cleanup paths use this
+// to avoid os.Remove-ing a file another book still owns (#1368).
+func (r *BookFileRepo) PathOwnedByOtherBook(ctx context.Context, path string, excludeBookID int64) (bool, error) {
+	var owner int64
+	err := r.db.QueryRowContext(ctx, `SELECT book_id FROM book_files WHERE path = ? LIMIT 1`, path).Scan(&owner)
 	if err == sql.ErrNoRows {
 		return false, nil
 	}
 	if err != nil {
-		return false, fmt.Errorf("book_files path tracked: %w", err)
+		return false, fmt.Errorf("book_files owner lookup: %w", err)
 	}
-	return true, nil
+	return owner != excludeBookID, nil
 }
 
 // ListAllPaths returns every path currently registered in book_files.

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -552,10 +552,11 @@ func (r *BookRepo) RemoveBookFile(ctx context.Context, path string) (*models.Boo
 	return r.GetByID(ctx, bookID)
 }
 
-// PathTracked reports whether an exact on-disk path is still registered in
-// book_files (owned by any book). See BookFileRepo.PathTracked (#1368).
-func (r *BookRepo) PathTracked(ctx context.Context, path string) (bool, error) {
-	return r.files.PathTracked(ctx, path)
+// PathOwnedByOtherBook reports whether an on-disk path is still registered in
+// book_files under a book other than excludeBookID. See
+// BookFileRepo.PathOwnedByOtherBook (#1368).
+func (r *BookRepo) PathOwnedByOtherBook(ctx context.Context, path string, excludeBookID int64) (bool, error) {
+	return r.files.PathOwnedByOtherBook(ctx, path, excludeBookID)
 }
 
 // ListAllBookFilePaths returns every path in book_files.


### PR DESCRIPTION
## What & why

Hardening follow-up to #1368 (data loss via Fix Match / delete). The acute fix (#1369, shipped in v1.23.2) added the "don't delete a file another book owns" check in exactly **one** place — the book-delete legacy-column fallback. The same class of bug can bite the other delete paths, which had **no** ownership check at all:

- `DeleteFile` (per-file scrub)
- author delete (`AuthorHandler.Delete` sweep)
- reassign cleanup (`removeStaleSource`, raw `os.Remove(src)`)

This moves the invariant into `safeRemoveBookPath` — the single chokepoint every book-file deletion routes through — so no current or future handler can unlink a library file another book still tracks.

## How

- `safeRemoveBookPath(ctx, roots, owner, excludeBookID, p, format, …)` now consults `PathOwnedByOtherBook` after the containment check and **skips** the on-disk unlink when the path is registered in `book_files` to a book other than `excludeBookID`. `book_files.path` is globally UNIQUE, so a hit is a single unambiguous owner.
- **Fails safe**: if ownership can't be determined, the file is left in place (the DB row is going away regardless; a stranded path is recoverable, a deleted file is not).
- `excludeBookID` = the current book for book-delete / DeleteFile (its own files are allowed); `= 0` for author-delete and reassign-cleanup, where the current book's rows are already gone so *any* surviving reference means another book owns it.
- Replaces the narrower `PathTracked` helper from #1369 with `PathOwnedByOtherBook`.

## Tests

- `TestDeleteAuthor_SkipsFileOwnedByAnotherBook` — deleting an author whose book has a stale legacy `file_path` aliasing a file a *different* author's book tracks leaves the file intact.
- All existing delete tests still pass unchanged (book delete, per-file delete, author delete with real files), confirming the guard only ever *adds* a skip for provably-unsafe unlinks.

`go test ./internal/api ./internal/db ./internal/importer`, `gofmt`, `go vet`, `golangci-lint` all green.

## Follow-ups (not in this PR)

The CI grep-guard for raw `os.Remove` in `internal/importer`/`internal/api`, and a symlinked-library test-topology helper, are still open from the #1368 retro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
