### PR TITLE
fix(db): author sort-key transformer is not goroutine-safe (#1374)

### DIFF
--- a/internal/db/sortkey.go
+++ b/internal/db/sortkey.go
@@ -33,7 +33,7 @@ func authorSortKey(sortName string) string {
 	}
 	s = strings.ToLower(s)
 	s = nonDecomposableFolder.Replace(s)
-	folded, _, err := transform.String(accentStripper, s)
+	folded, _, err := transform.String(newAccentStripper(), s)
 	if err != nil {
 		// transform only errors on malformed input we can't normalize; fall
 		// back to the lowercased+replaced form rather than dropping the row to
@@ -43,13 +43,19 @@ func authorSortKey(sortName string) string {
 	return folded
 }
 
-// accentStripper decomposes runes (NFD) and removes combining marks (Mn), then
-// recomposes (NFC). This folds precomposed accented letters to their base.
-var accentStripper = transform.Chain(
-	norm.NFD,
-	runes.Remove(runes.In(unicode.Mn)),
-	norm.NFC,
-)
+// newAccentStripper builds a transformer that decomposes runes (NFD), removes
+// combining marks (Mn), then recomposes (NFC), folding precomposed accented
+// letters to their base. Constructed PER CALL: transform.Chain returns a
+// stateful transformer whose Transform mutates internal buffers, so a shared
+// package-level instance panics under concurrent author writes (#1374). The
+// three small allocations are noise next to the DB write that follows.
+func newAccentStripper() transform.Transformer {
+	return transform.Chain(
+		norm.NFD,
+		runes.Remove(runes.In(unicode.Mn)),
+		norm.NFC,
+	)
+}
 
 // nonDecomposableFolder handles the Latin letters NFD leaves intact because
 // they are atomic code points, not base+combining-mark compositions. Applied

--- a/internal/db/sortkey_test.go
+++ b/internal/db/sortkey_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/models"
@@ -123,4 +124,32 @@ func TestBackfillAuthorSortKeys_SurfacesWriteError(t *testing.T) {
 	if err := backfillAuthorSortKeys(database); err == nil {
 		t.Fatal("expected a write error backfilling under query_only, got nil")
 	}
+}
+
+// TestAuthorSortKey_ConcurrentUse guards the #1374 regression: authorSortKey is
+// called from parallel author-write paths (ABS import, author work discovery),
+// and a shared transform.Chain has mutable internal buffers — concurrent use
+// corrupted them into slice-bounds panics inside x/text/transform. Run with
+// -race this also fails on the data race itself, not just the panic.
+func TestAuthorSortKey_ConcurrentUse(t *testing.T) {
+	t.Parallel()
+	inputs := []string{
+		"Östergaard, Karl", "de Balzac, Honoré", "Nowak, Łukasz",
+		"Zola, Émile", "Çelik, Ayşe", "Straße, Anna", "Ángel, José",
+	}
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				in := inputs[(seed+i)%len(inputs)]
+				if got := authorSortKey(in); got == "" {
+					t.Errorf("authorSortKey(%q) = empty under concurrency", in)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## What & why

Fixes #1374 — `authorSortKey` (shipped in v1.23.1, #1347) panics under concurrent author writes:

```
panic: runtime error: slice bounds out of range [27:10]
  golang.org/x/text/transform.String → internal/db/sortkey.go:36
```

`accentStripper` was a package-level `transform.Chain`. `Chain` returns a stateful transformer whose `Transform` mutates internal link buffers — **not safe for concurrent use**. The ABS importer and author work discovery write authors from parallel goroutines, so two simultaneous writes corrupt the shared state. This crashed CI's `validate (Go)` on #1371 (`TestImporter_RollbackRemovesCreatedBatch`) and can crash a production import the same way.

## How

`newAccentStripper()` builds the NFD → remove-Mn → NFC chain **per call**. Author writes are low-frequency; three small allocations are noise next to the DB write. The `strings.NewReplacer` stays package-level (documented concurrency-safe).

## Tests

- `TestAuthorSortKey_ConcurrentUse` — 16 goroutines × 200 iterations. Against the old shared instance this fails immediately under `-race` (and panics without it); passes with the fix, `-race -count=5`.
- The CI-failing `TestImporter_RollbackRemovesCreatedBatch` now passes under `-race -count=3` locally.
- Full `./internal/db` suite + `golangci-lint` green.

## Note

This unblocks #1371, whose `validate (Go)` failure was this race, not its own diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
