### PR TITLE
fix: bulk import 403s on the library root and download dir (#1373)

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -536,8 +536,14 @@ func main() {
 		WithNotifier(notif).
 		WithStoragePaths(cfg.DownloadDir, cfg.AudiobookDownloadDir).
 		WithIndexers(indexerRepo)
+	// Manual/bulk import may read from the download dirs as well as the library
+	// roots — a Readarr/qBittorrent migrant's backlog sits in the download dir,
+	// not the library (#1373). These are trusted, configured source dirs the
+	// automated importer already reads from; the stricter `libraryRoots` (no
+	// download dirs) still gates the delete handlers.
+	importRoots := api.NewLibraryRoots(rootFolderRepo, cfg.LibraryDir, cfg.AudiobookDir, cfg.DownloadDir, cfg.AudiobookDownloadDir)
 	manualImportHandler := api.NewManualImportHandler(importScanner, downloadRepo, bookRepo).
-		WithRoots(libraryRoots)
+		WithRoots(importRoots)
 	pendingHandler := api.NewPendingHandler(pendingReleaseRepo, queueHandler, downloadRepo, bookRepo)
 	importScanner.WithSettings(settingsRepo)
 	importScanner.WithRootFolders(rootFolderRepo)

--- a/docs/API.md
+++ b/docs/API.md
@@ -117,6 +117,12 @@ DELETE /api/v1/queue/{id}                         remove (also from downloader)
 GET    /api/v1/pending                            grabs awaiting delay-profile clearance
 POST   /api/v1/pending/{id}/grab                  promote pending to queue immediately
 
+GET    /api/v1/queue/manual-import/lookup         parse + catalogue-match one path (admin)
+GET    /api/v1/queue/manual-import/scan           enumerate + match book units under a folder (admin)
+POST   /api/v1/queue/manual-import                import one path against a book (admin)
+POST   /api/v1/queue/manual-import/batch          import selected {path, bookId} pairs (admin)
+POST   /api/v1/queue/manual-import/reassign       move a mis-matched file to another book (admin)
+
 GET    /api/v1/history                            grab / import / failure timeline
 POST   /api/v1/history/{id}/blocklist             add the release to the blocklist
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -312,7 +312,7 @@ Bindery parks the download as *handed off* and reconciles the managed copy the e
 | `BINDERY_DATA_DIR` | `/config` on Linux; `%APPDATA%\Bindery` on Windows; `~/Library/Application Support/Bindery` on macOS | Config directory (backups live here) |
 | `BINDERY_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
 | `BINDERY_API_KEY` | _(empty)_ | **Seed only.** Bootstraps the initial API key on first launch if set; after that the key lives in the database and can be regenerated from the UI. |
-| `BINDERY_DOWNLOAD_DIR` | `/downloads` | Where the download client places completed downloads |
+| `BINDERY_DOWNLOAD_DIR` | `/downloads` | Where the download client places completed downloads. Manual/bulk import may also read from here (and from `BINDERY_AUDIOBOOK_DOWNLOAD_DIR`), so a migration backlog sitting in the download folder can be scanned and attached in bulk. |
 | `BINDERY_AUDIOBOOK_DOWNLOAD_DIR` | falls back to `BINDERY_DOWNLOAD_DIR` | Separate watch folder for audiobook downloads; set this when your download client routes audiobook grabs to a dedicated category/path |
 | `BINDERY_LIBRARY_DIR` | `/books` | Destination for imported ebook files |
 | `BINDERY_AUDIOBOOK_DIR` | falls back to `BINDERY_LIBRARY_DIR` | Destination for imported audiobook folders |

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -673,6 +673,51 @@ func TestManualImportScan_EnumeratesBookUnits(t *testing.T) {
 	}
 }
 
+// TestManualImportScan_AllowsConfiguredRootItself reproduces #1373: pasting a
+// configured root ("/books") or an allow-listed download dir ("/downloads")
+// into bulk import must scan it, not 403. Before the fix, ResolveContained
+// reused the delete path's strict containment (root != contained), so the two
+// most obvious targets for the feature both failed with "path is outside the
+// configured library roots".
+func TestManualImportScan_AllowsConfiguredRootItself(t *testing.T) {
+	t.Parallel()
+	h, stub, _, _, _ := manualImportFixture(t)
+	stub.lookupResult = importer.LookupResult{Match: "none", ParsedTitle: "x"}
+
+	libraryDir := t.TempDir()
+	downloadDir := t.TempDir()
+	outside := t.TempDir()
+	writeTestFile(t, filepath.Join(libraryDir, "Book One.epub"))
+	writeTestFile(t, filepath.Join(downloadDir, "Backlog Book.epub"))
+	writeTestFile(t, filepath.Join(outside, "secret.epub"))
+	// Mirror the production wiring (#1373): the manual-import allow-list holds
+	// the library root AND the download dir.
+	h.WithRoots(NewLibraryRoots(nil, libraryDir, downloadDir))
+
+	for _, dir := range []string{libraryDir, downloadDir} {
+		rec := httptest.NewRecorder()
+		h.Scan(rec, scanRequest(dir))
+		if rec.Code != http.StatusOK {
+			t.Errorf("Scan(%s) status = %d, want 200; body = %s", dir, rec.Code, rec.Body.String())
+			continue
+		}
+		var resp ScanResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(resp.Items) != 1 {
+			t.Errorf("Scan(%s) items = %d, want 1", dir, len(resp.Items))
+		}
+	}
+
+	// The gate itself still stands: an unconfigured dir is rejected.
+	rec := httptest.NewRecorder()
+	h.Scan(rec, scanRequest(outside))
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("Scan(outside) status = %d, want 403", rec.Code)
+	}
+}
+
 func TestManualImportScan_RejectsSingleFile(t *testing.T) {
 	t.Parallel()
 	h, _, _, _, _ := manualImportFixture(t)

--- a/internal/api/path_safety.go
+++ b/internal/api/path_safety.go
@@ -191,11 +191,31 @@ func (r *LibraryRoots) ResolveContained(ctx context.Context, p string) (string, 
 		if rr, err := filepath.EvalSymlinks(root); err == nil {
 			realRoot = rr
 		}
-		if containsUnderRoot(resolved, realRoot) {
+		// Import/scan may legitimately target a configured root itself (e.g.
+		// "scan everything under /books"), unlike the delete path where a root
+		// is never a deletable book. Allow root-equality here (#1373).
+		if containsUnderOrEqualRoot(resolved, realRoot) {
 			return resolved, true
 		}
 	}
 	return "", false
+}
+
+// containsUnderOrEqualRoot is containsUnderRoot but also accepts p == root. Used
+// by the manual-import read/scan path (ResolveContained), where pointing at a
+// configured directory as a whole is a valid operation (#1373).
+func containsUnderOrEqualRoot(p, root string) bool {
+	if root == "" || root == "." {
+		return false
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true // rel == "." (p == root) is allowed here
 }
 
 // containsUnderRoot is the lexical containment primitive shared by Contains.

--- a/internal/api/path_safety_test.go
+++ b/internal/api/path_safety_test.go
@@ -89,6 +89,28 @@ func TestLibraryRoots_ResolveContained(t *testing.T) {
 	}
 }
 
+// TestLibraryRoots_ResolveContained_AllowsRootItself covers #1373: the
+// import/scan path may target a configured root as a whole ("scan everything
+// under /books"), unlike the delete path where a root is never a deletable
+// book. Contains must keep rejecting root-equality; ResolveContained must not.
+func TestLibraryRoots_ResolveContained_AllowsRootItself(t *testing.T) {
+	root := t.TempDir()
+	roots := NewLibraryRoots(staticRootLister{paths: []string{root}})
+	ctx := context.Background()
+
+	expected, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := roots.ResolveContained(ctx, root); !ok || got != expected {
+		t.Errorf("ResolveContained(root itself) = %q, %v; want %q, true", got, ok, expected)
+	}
+	// The delete-path primitive stays strict: a root is not a deletable book.
+	if roots.Contains(ctx, root) {
+		t.Error("Contains(root itself) must remain false for the delete path")
+	}
+}
+
 // TestLibraryRoots_ResolveContained_NilReceiverAllows mirrors the Contains
 // nil-receiver opt-out: a handler not wired with WithRoots keeps legacy
 // behaviour (used by fixtures that don't configure roots).


### PR DESCRIPTION
## What & why

Fixes #1373 — the bulk folder import MVP (#1292 / #1293, shipped v1.23.0) rejects both of its obvious targets with `path is outside the configured library roots`, reported by Kedryn ([#1292 comment](https://github.com/vavallee/bindery/issues/1292#issuecomment-4826690695)) and independently by Garrett on Discord. Both run the stock `/books` + `/downloads` layout, so as shipped the feature can't do its headline job.

### Fix 1 — allow scanning a configured root itself
`ResolveContained` reused the delete path's `containsUnderRoot`, which rejects `p == root` ("a root is never a deletable book"). Correct for deletes, wrong for read/scan: pasting `/books` 403'd, forcing per-author pasting — the exact grind #1292 was meant to kill. New `containsUnderOrEqualRoot` accepts root-equality **only** on the `ResolveContained` (read/scan) path; `Contains` — the delete gate — is untouched and a test now pins that asymmetry.

### Fix 2 — include the download dirs in the manual-import allow-list
The allow-list was `root_folders` + `BINDERY_LIBRARY_DIR`/`AUDIOBOOK_DIR`; `BINDERY_DOWNLOAD_DIR` / `BINDERY_AUDIOBOOK_DOWNLOAD_DIR` were never in it, so scanning a migration backlog in `/downloads` — PR #1293's stated use case — was forbidden. `main.go` now wires the manual-import handler with a widened `importRoots` list including the configured download dirs. This is consistency, not a new trust grant: the automated importer already reads and moves files from those dirs on every completed grab. The delete handlers keep the stricter library-only `libraryRoots`.

## Tests

- `TestLibraryRoots_ResolveContained_AllowsRootItself` — root itself passes ResolveContained; `Contains(root)` stays false for the delete path.
- `TestManualImportScan_AllowsConfiguredRootItself` — Scan of the library root and of an allow-listed download dir returns 200 with the right units; an unconfigured dir still 403s.
- Existing containment tests (symlink escape, fail-closed, nil receiver) unchanged and green.

## Docs

- `docs/API.md`: added the five `queue/manual-import/*` endpoints (previously undocumented).
- `docs/DEPLOYMENT.md`: `BINDERY_DOWNLOAD_DIR` row notes manual/bulk import may read from it.

`go test ./internal/api`, `make smoke`, `gofmt`, `golangci-lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
