### PR TITLE
ci: fork-gate dev-preview, align go toolchain, add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Keep the Docker build context small and reproducible. The image builds the
+# frontend (web/) and the Go binary itself, so host-side build outputs and
+# scratch files are never needed and only bloat/poison the context.
+#
+# Do NOT exclude web/ source, go.mod/go.sum, or any *.go — the build copies them.
+
+# VCS
+.git
+.gitignore
+
+# Frontend build outputs (the frontend stage runs `npm ci` + `npm run build`)
+web/node_modules
+web/dist
+web/coverage
+web/.vite
+
+# Stray local build binaries (Dockerfile compiles fresh inside the image)
+/bindery
+/telemetry-server
+/cmd/discord-stats/discord-stats
+/discord-stats
+/cmd/telemetry-server/telemetry-server
+
+# Logs and scratch files (never part of the build)
+*.log
+bindery.txt
+reply.txt
+e.log
+
+# Docs / CI / root markdown — not consumed by the build (go:embed only pulls
+# internal/webui/dist and internal/db/migrations)
+.github
+docs
+*.md

--- a/.github/workflows/dev-preview.yml
+++ b/.github/workflows/dev-preview.yml
@@ -54,8 +54,14 @@ jobs:
           git fetch origin main
           git checkout -B development origin/main
 
+          # SECURITY: only merge PRs whose head lives in this same repo. A fork
+          # PR gets merged into `development`, which then dispatches ci.yml with
+          # full repo secrets (kubeconfig, deploy tokens). Labelling a fork PR
+          # `dev-preview` must NOT hand it those secrets, so filter out
+          # cross-repository (fork) PRs here regardless of who labelled them.
           mapfile -t PRS < <(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
-            --label dev-preview --json number --jq '.[].number' | sort -n)
+            --label dev-preview --json number,isCrossRepository \
+            --jq '.[] | select(.isCrossRepository == false) | .number' | sort -n)
 
           MERGED=(); SKIPPED=()
           for n in "${PRS[@]:-}"; do

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # Binaries
 /bindery
 *.exe
+# Scratch / working files (must never be committed)
+/bindery.txt
+/reply.txt
+/e.log
+# Personal, gitignored ops notes
+CLAUDE.local.md
 *.dll
 *.so
 *.dylib

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/vavallee/bindery
 
 go 1.25.11
 
+toolchain go1.26.4
+
 require (
 	github.com/coreos/go-oidc/v3 v3.19.0
 	github.com/creditx/go-fuzzywuzzy v0.0.0-20190710081230-e795b6c0d97a


### PR DESCRIPTION
A few small CI/build/hygiene fixes found in an audit. Conservative, no working CI touched.

## Fixes

- **dev-preview fork PR secret exposure (security).** `dev-preview.yml` merged every open PR labelled `dev-preview` into `development`, including fork PRs via `pull/N/head`, then dispatched `ci.yml` which runs with full repo secrets (kubeconfig, deploy tokens). A fork PR getting that label could reach those secrets. Now only same-repo PRs are merged (`isCrossRepository == false`). Existing label/state filters kept.
- **go toolchain skew.** `go.mod` said `go 1.25.11` while the Dockerfile and every CI job build with `golang:1.26.4`. Added `toolchain go1.26.4` (language-version line left as is). `go mod verify` and `go build ./...` pass.
- **.dockerignore added.** It was absent and the Dockerfile does `COPY . .`. Excludes `.git`, web build outputs, stray root binaries, logs, scratch txt, and root docs/CI markdown. The image builds `web/` and the Go binary itself, and `go:embed` only pulls from `internal/`, so none of the excluded paths are needed in the build context.
- **.gitignore hygiene.** Ignore the scratch files (`/bindery.txt`, `/reply.txt`, `/e.log`) and the personal `CLAUDE.local.md` so they cannot be committed by accident.

## Note

The `race` job's `go test -race` already carries `-timeout=25m`, comfortably above the failing 10m default, so it was left as is.

## Verification

- `go mod verify` -> all modules verified
- `go build ./...` -> clean
- both workflow files parse (`yaml.safe_load`)
- fork filter tested against sample JSON, drops the cross-repo PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)