### PR TITLE
fix(api): scope recommendations to the authenticated user

### DIFF
--- a/internal/api/recommendations.go
+++ b/internal/api/recommendations.go
@@ -125,7 +125,7 @@ func (h *RecommendationHandler) List(w http.ResponseWriter, r *http.Request) {
 		offset = o
 	}
 
-	recs, err := h.recs.List(r.Context(), 1, recType, limit, offset)
+	recs, err := h.recs.List(r.Context(), auth.UserIDFromContext(r.Context()), recType, limit, offset)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -157,7 +157,7 @@ func (h *RecommendationHandler) Dismiss(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if err := h.recs.Dismiss(r.Context(), 1, id); err != nil {
+	if err := h.recs.Dismiss(r.Context(), auth.UserIDFromContext(r.Context()), id); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
@@ -239,7 +239,7 @@ func (h *RecommendationHandler) Add(w http.ResponseWriter, r *http.Request) {
 	fileFound := handleNewWantedBook(r.Context(), h.books, h.series, h.finder, *book, rec.AuthorName)
 
 	// Dismiss the recommendation now that the book is added.
-	_ = h.recs.Dismiss(r.Context(), 1, id)
+	_ = h.recs.Dismiss(r.Context(), auth.UserIDFromContext(r.Context()), id)
 
 	// Trigger search in background unless the file already exists on disk.
 	// Use the process-lifecycle context so the goroutine is cancelled on
@@ -255,8 +255,11 @@ func (h *RecommendationHandler) Add(w http.ResponseWriter, r *http.Request) {
 // The goroutine derives its context from the process-lifecycle context so it
 // is cancelled on shutdown instead of running on context.Background(). See #550.
 func (h *RecommendationHandler) Refresh(w http.ResponseWriter, r *http.Request) {
+	// Capture the caller's user id before the goroutine: r may be recycled
+	// once this handler returns, so the background run must not read from it.
+	uid := auth.UserIDFromContext(r.Context())
 	go func() {
-		if err := h.engine.Run(h.appCtx, 1); err != nil {
+		if err := h.engine.Run(h.appCtx, uid); err != nil {
 			slog.Error("recommendation refresh failed", "error", err)
 		}
 	}()
@@ -265,7 +268,7 @@ func (h *RecommendationHandler) Refresh(w http.ResponseWriter, r *http.Request) 
 
 // ClearDismissals removes all dismissals for the current user.
 func (h *RecommendationHandler) ClearDismissals(w http.ResponseWriter, r *http.Request) {
-	if err := h.recs.ClearDismissals(r.Context(), 1); err != nil {
+	if err := h.recs.ClearDismissals(r.Context(), auth.UserIDFromContext(r.Context())); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
@@ -274,7 +277,7 @@ func (h *RecommendationHandler) ClearDismissals(w http.ResponseWriter, r *http.R
 
 // ListAuthorExclusions returns all excluded authors for the current user.
 func (h *RecommendationHandler) ListAuthorExclusions(w http.ResponseWriter, r *http.Request) {
-	exclusions, err := h.recs.ListAuthorExclusions(r.Context(), 1)
+	exclusions, err := h.recs.ListAuthorExclusions(r.Context(), auth.UserIDFromContext(r.Context()))
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -295,7 +298,7 @@ func (h *RecommendationHandler) ExcludeAuthor(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if err := h.recs.AddAuthorExclusion(r.Context(), 1, req.AuthorName); err != nil {
+	if err := h.recs.AddAuthorExclusion(r.Context(), auth.UserIDFromContext(r.Context()), req.AuthorName); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
@@ -310,7 +313,7 @@ func (h *RecommendationHandler) RemoveAuthorExclusion(w http.ResponseWriter, r *
 		return
 	}
 
-	if err := h.recs.RemoveAuthorExclusion(r.Context(), 1, name); err != nil {
+	if err := h.recs.RemoveAuthorExclusion(r.Context(), auth.UserIDFromContext(r.Context()), name); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}

--- a/internal/api/recommendations_test.go
+++ b/internal/api/recommendations_test.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
@@ -15,6 +17,56 @@ import (
 type fakeRecommendationEngine struct{}
 
 func (fakeRecommendationEngine) Run(context.Context, int64) error { return nil }
+
+// TestRecommendationListScopedToCaller proves the feed is per-user: a request
+// authenticated as one user must never see another user's recommendations.
+// Before the fix the handler hardcoded user id 1, so every caller shared one
+// feed — this test fails against that code (alice's request returned user 1's
+// rows, not her own).
+func TestRecommendationListScopedToCaller(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	recRepo := db.NewRecommendationRepo(database)
+
+	const alice, bob int64 = 10, 20
+	if err := recRepo.ReplaceBatch(ctx, alice, []models.RecommendationCandidate{{
+		ForeignID: "hc:alice-book", RecType: models.RecTypeListCross,
+		Title: "Alice Book", Genres: []string{}, Score: 1,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := recRepo.ReplaceBatch(ctx, bob, []models.RecommendationCandidate{{
+		ForeignID: "hc:bob-book", RecType: models.RecTypeListCross,
+		Title: "Bob Book", Genres: []string{}, Score: 1,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewRecommendationHandler(recRepo, fakeRecommendationEngine{}, nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/recommendations", nil)
+	req = req.WithContext(auth.WithUserID(req.Context(), alice))
+	rec := httptest.NewRecorder()
+	handler.List(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got []models.Recommendation
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("alice should see exactly her 1 recommendation, got %d: %+v", len(got), got)
+	}
+	if got[0].ForeignID != "hc:alice-book" {
+		t.Fatalf("cross-user leak: alice saw %q, want hc:alice-book", got[0].ForeignID)
+	}
+}
 
 func TestRecommendationAddHydratesHardcoverEditions(t *testing.T) {
 	database, err := db.OpenMemory()


### PR DESCRIPTION
## Problem

The recommendation handlers hardcoded user id `1` at every call site (list, dismiss, refresh, clear dismissals, author exclusions). The recommender engine and repo are fully per-user, so on a multi-user install everyone shared user 1's feed, dismissals, and exclusions, and any user could mutate them. It was the only handler in the codebase that ignored the session identity.

## Fix

Thread `auth.UserIDFromContext` through all eight sites, matching how the authors and history handlers scope their data. `Refresh` captures the uid before its background goroutine so it never reads a recycled request.

`BuildProfile` reads the library globally, so the userID is purely the feed-ownership key. Single-user modes resolve to a consistent uid (0), so behavior there is unchanged. Existing single-user recs stored under 1 just regenerate on the next refresh.

## Test

Adds `TestRecommendationListScopedToCaller`: seeds two users, authenticates as one, asserts the feed contains only that user's rows. Fails against the old hardcoded-1 code.

## Verified

`go build ./...`, `go test ./internal/api/ -run Recommendation` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)