### PR TITLE
fix(api): stop leaking raw internal errors in 500 responses

### DIFF
--- a/internal/api/abs.go
+++ b/internal/api/abs.go
@@ -179,7 +179,7 @@ func (h *ABSHandler) SetConfig(w http.ResponseWriter, r *http.Request) {
 
 	libraryIDsJSON, err := json.Marshal(libraryIDs)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -197,7 +197,7 @@ func (h *ABSHandler) SetConfig(w http.ResponseWriter, r *http.Request) {
 		kvs = append(kvs, db.SettingKV{Key: SettingABSAPIKey, Value: apiKey})
 	}
 	if err := h.settings.SetMany(r.Context(), kvs); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 

--- a/internal/api/abs_conflicts.go
+++ b/internal/api/abs_conflicts.go
@@ -64,14 +64,14 @@ func (h *ABSConflictHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 	conflicts, total, err := h.conflicts.ListPaginated(r.Context(), limit, offset)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	out := make([]absConflictResponse, 0, len(conflicts))
 	for _, conflict := range conflicts {
 		item, err := h.decorateConflict(r, &conflict)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 		out = append(out, item)
@@ -96,7 +96,7 @@ func (h *ABSConflictHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 	}
 	conflict, err := h.conflicts.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if conflict == nil {
@@ -124,7 +124,7 @@ func (h *ABSConflictHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 	// disagreeing on which source won.
 	claimed, err := h.conflicts.Claim(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if !claimed {
@@ -132,7 +132,7 @@ func (h *ABSConflictHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 		// winning resolution without treating it as an error.
 		current, err := h.conflicts.GetByID(r.Context(), id)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 		if current == nil {
@@ -141,7 +141,7 @@ func (h *ABSConflictHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 		}
 		item, err := h.decorateConflict(r, current)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 		writeJSON(w, http.StatusOK, item)
@@ -149,19 +149,19 @@ func (h *ABSConflictHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := h.applyConflictChoice(r, conflict, source); err != nil {
 		_ = h.conflicts.Unclaim(r.Context(), id)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	conflict.AppliedSource = source
 	conflict.PreferredSource = source
 	conflict.ResolutionStatus = "resolved"
 	if err := h.conflicts.Upsert(r.Context(), conflict); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	item, err := h.decorateConflict(r, conflict)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, item)

--- a/internal/api/abs_import.go
+++ b/internal/api/abs_import.go
@@ -81,7 +81,7 @@ func (h *ABSImportHandler) Status(w http.ResponseWriter, _ *http.Request) {
 func (h *ABSImportHandler) Runs(w http.ResponseWriter, r *http.Request) {
 	runs, err := h.importer.RecentRuns(r.Context(), 10)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	resp := make([]abs.PersistedImportRun, 0, len(runs))

--- a/internal/api/abs_review.go
+++ b/internal/api/abs_review.go
@@ -41,7 +41,7 @@ func (h *ABSReviewHandler) List(w http.ResponseWriter, r *http.Request) {
 	limit, offset := parseLimitOffset(r, 50, 100)
 	items, total, err := h.reviews.ListByStatusPaginated(r.Context(), "pending", limit, offset)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	cfg := h.loadCfg(r.Context())
@@ -120,7 +120,7 @@ func (h *ABSReviewHandler) Approve(w http.ResponseWriter, r *http.Request) {
 	// status reset) rather than an imported item whose status stays "pending"
 	// and triggers a duplicate import on the next approval attempt.
 	if err := h.reviews.UpdateStatus(r.Context(), item.ID, "approved"); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if _, err := h.importer.ImportReview(r.Context(), runCfg, payload); err != nil {
@@ -130,7 +130,7 @@ func (h *ABSReviewHandler) Approve(w http.ResponseWriter, r *http.Request) {
 	}
 	updated, err := h.reviews.GetByID(r.Context(), item.ID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, updated)
@@ -192,7 +192,7 @@ func (h *ABSReviewHandler) ResolveBook(w http.ResponseWriter, r *http.Request) {
 	}
 	updated, err := h.reviews.GetByID(r.Context(), item.ID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, updated)
@@ -209,12 +209,12 @@ func (h *ABSReviewHandler) Dismiss(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.reviews.UpdateStatus(r.Context(), item.ID, "dismissed"); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	updated, err := h.reviews.GetByID(r.Context(), item.ID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, updated)
@@ -234,7 +234,7 @@ func (h *ABSReviewHandler) DismissRun(w http.ResponseWriter, r *http.Request) {
 	if h.runs != nil {
 		run, err := h.runs.GetByID(r.Context(), runID)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 		if run == nil {
@@ -244,7 +244,7 @@ func (h *ABSReviewHandler) DismissRun(w http.ResponseWriter, r *http.Request) {
 	}
 	dismissed, err := h.reviews.DismissByRunID(r.Context(), runID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]int64{"dismissed": dismissed})

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -115,7 +115,7 @@ func (h *AuthHandler) Status(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	count, err := h.users.Count(ctx)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "status: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	mode := h.mode(ctx)
@@ -147,7 +147,7 @@ func (h *AuthHandler) Setup(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	count, err := h.users.Count(ctx)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "setup: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	if count > 0 {
@@ -166,19 +166,19 @@ func (h *AuthHandler) Setup(w http.ResponseWriter, r *http.Request) {
 	}
 	hash, err := auth.HashPassword(req.Password)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "hash: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	u, err := h.users.Create(ctx, req.Username, hash)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "create user: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	// The first user is the admin. Create defaults role to "user"; without this
 	// promotion the freshly-set-up operator is locked out of every admin-gated
 	// page (Calibre plugin, user management, etc).
 	if err := h.users.PromoteFirstUser(ctx); err != nil {
-		writeErr(w, http.StatusInternalServerError, "promote admin: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	u.Role = "admin"
@@ -209,7 +209,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 	u, err := h.users.GetByUsername(ctx, strings.TrimSpace(req.Username))
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "lookup: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	// Always run a password verification, even when the username does not
@@ -287,7 +287,7 @@ func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 	}
 	hash, err := auth.HashPassword(req.NewPassword)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "hash: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	// UpdatePassword atomically bumps users.session_epoch, which invalidates
@@ -298,7 +298,7 @@ func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 	// browsers / devices / stolen cookies still hold the pre-bump epoch and
 	// are correctly evicted.
 	if err := h.users.UpdatePassword(ctx, u.ID, hash); err != nil {
-		writeErr(w, http.StatusInternalServerError, "update: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	// Re-mint only when the change is happening on behalf of a logged-in
@@ -338,11 +338,11 @@ func (h *AuthHandler) RegenerateAPIKey(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	key, err := auth.RandomHex(32)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "gen: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	if err := h.settings.Set(ctx, SettingAuthAPIKey, key); err != nil {
-		writeErr(w, http.StatusInternalServerError, "save: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	slog.Info("api key regenerated")
@@ -369,7 +369,7 @@ func (h *AuthHandler) RotateSessionSecret(w http.ResponseWriter, r *http.Request
 	// text, comfortably clearing the minSecretLen fail-closed guard.
 	newSecret, err := auth.RandomBase64(32)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "gen: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -382,7 +382,7 @@ func (h *AuthHandler) RotateSessionSecret(w http.ResponseWriter, r *http.Request
 		{Key: SettingAuthSessionSecretPrevious, Value: string(cur)},
 		{Key: SettingAuthSessionSecret, Value: newSecret},
 	}); err != nil {
-		writeErr(w, http.StatusInternalServerError, "save: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	slog.Info("session signing secret rotated")
@@ -436,7 +436,7 @@ func (h *AuthHandler) SetMode(w http.ResponseWriter, r *http.Request) {
 	}
 	mode := auth.ParseMode(req.Mode)
 	if err := h.settings.Set(ctx, SettingAuthMode, string(mode)); err != nil {
-		writeErr(w, http.StatusInternalServerError, "save: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	slog.Info("auth mode changed", "mode", mode)
@@ -521,7 +521,7 @@ func (h *AuthHandler) issueSession(w http.ResponseWriter, r *http.Request, ctx c
 	exp := time.Now().Add(dur)
 	epoch, err := h.users.GetSessionEpoch(ctx, userID)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "session epoch lookup: "+err.Error())
+		writeServerError(w, r, err)
 		return false
 	}
 	value, err := auth.SignSessionWithEpoch(h.sessionSecret(ctx), userID, epoch, exp)

--- a/internal/api/auth_oidc.go
+++ b/internal/api/auth_oidc.go
@@ -169,17 +169,17 @@ func (h *OIDCHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 	state, err := oidc.NewState()
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "gen state: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	nonce, err := oidc.NewNonce()
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "gen nonce: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	verifier, err := oidc.NewVerifier()
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "gen verifier: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -197,7 +197,7 @@ func (h *OIDCHandler) Login(w http.ResponseWriter, r *http.Request) {
 	// and we resolve it from the request rather than a static env var.
 	flowVal, err := oidc.EncodeFlowState(state, nonce, verifier, redirectBase)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "encode flow: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	http.SetCookie(w, &http.Cookie{
@@ -569,7 +569,7 @@ func (h *OIDCHandler) GetProviders(w http.ResponseWriter, r *http.Request) {
 	}
 	ps, err := oidc.ParseProviders(s.Value)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "parse providers: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	out := make([]providerWithStatus, 0, len(ps))
@@ -622,11 +622,11 @@ func (h *OIDCHandler) SetProviders(w http.ResponseWriter, r *http.Request) {
 
 	raw, err := json.Marshal(merged) // #nosec G117 -- persisted server-side only, never returned via API (see ProviderPublicConfig split)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "encode: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	if err := h.settings.Set(ctx, SettingOIDCProviders, string(raw)); err != nil {
-		writeErr(w, http.StatusInternalServerError, "save: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	// Reload async so the HTTP response isn't delayed by discovery. Anchor

--- a/internal/api/auth_users.go
+++ b/internal/api/auth_users.go
@@ -71,7 +71,7 @@ func toUserResponse(u db.User) userResponse {
 func (h *UserManagementHandler) List(w http.ResponseWriter, r *http.Request) {
 	users, err := h.users.List(r.Context())
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "list users: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	out := make([]userResponse, 0, len(users))
@@ -107,17 +107,17 @@ func (h *UserManagementHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	hash, err := auth.HashPassword(body.Password)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "hash password: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	u, err := h.users.Create(r.Context(), body.Username, hash)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "create user: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	if body.Role == "admin" {
 		if err := h.users.SetRole(r.Context(), u.ID, "admin"); err != nil {
-			writeErr(w, http.StatusInternalServerError, "set role: "+err.Error())
+			writeServerError(w, r, err)
 			return
 		}
 		u.Role = "admin"
@@ -184,11 +184,11 @@ func (h *UserManagementHandler) ResetPassword(w http.ResponseWriter, r *http.Req
 	}
 	hash, err := auth.HashPassword(body.Password)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "hash password: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	if err := h.users.UpdatePassword(r.Context(), id, hash); err != nil {
-		writeErr(w, http.StatusInternalServerError, "update password: "+err.Error())
+		writeServerError(w, r, err)
 		return
 	}
 	writeOK(w, map[string]any{"ok": true})

--- a/internal/api/author_refresh.go
+++ b/internal/api/author_refresh.go
@@ -190,7 +190,7 @@ func (h *AuthorRefreshHandler) RefreshAllStatus(w http.ResponseWriter, r *http.R
 	}
 	setting, err := h.settings.Get(r.Context(), SettingAuthorBulkRefresh)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if setting == nil {

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -208,7 +208,7 @@ func (h *AuthorHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 	authors, total, err := h.authors.ListPageFiltered(ctx, filter, limit, offset)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if authors == nil {
@@ -235,7 +235,7 @@ func (h *AuthorHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	author, err := h.authors.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if author == nil {
@@ -291,7 +291,7 @@ func (h *AuthorHandler) ListSeries(w http.ResponseWriter, r *http.Request) {
 	// check runs before we list series belonging to it.
 	author, err := h.authors.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if author == nil || !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
@@ -304,7 +304,7 @@ func (h *AuthorHandler) ListSeries(w http.ResponseWriter, r *http.Request) {
 	}
 	series, err := h.series.ListByAuthor(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, series)
@@ -360,7 +360,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if canonical, ambiguous, err := h.findCanonicalAuthorMatch(r.Context(), req.Name, author.Name); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	} else if ambiguous {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "author name resolves ambiguously — merge manually"})
@@ -372,7 +372,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 					writeJSON(w, http.StatusConflict, map[string]string{"error": "upstream author already exists locally"})
 					return
 				}
-				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				writeServerError(w, r, err)
 				return
 			}
 			mediaType := req.MediaType
@@ -408,7 +408,7 @@ func (h *AuthorHandler) Create(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusConflict, map[string]string{"error": "author already exists"})
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	h.recordAuthorCreateAlias(r.Context(), author, req.Name)
@@ -851,7 +851,7 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.authors.Update(r.Context(), author); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -863,7 +863,7 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 		if len(*req.MonitoredSeriesIDs) > 0 {
 			ownSeries, err := h.series.ListByAuthor(r.Context(), author.ID)
 			if err != nil {
-				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				writeServerError(w, r, err)
 				return
 			}
 			owned := make(map[int64]struct{}, len(ownSeries))
@@ -878,7 +878,7 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if err := h.authors.SetMonitoredSeriesIDs(r.Context(), author.ID, *req.MonitoredSeriesIDs); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 		author.MonitoredSeriesIDs = append([]int64(nil), (*req.MonitoredSeriesIDs)...)
@@ -892,7 +892,7 @@ func (h *AuthorHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	if req.ApplyMonitorModeToExisting {
 		if err := applyMonitorModeToExistingBooks(r.Context(), h.books, h.authors, h.series, author); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 	}
@@ -991,7 +991,7 @@ func (h *AuthorHandler) RelinkUpstream(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 	author, err := h.authors.GetByIDForUser(r.Context(), id, userID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if author == nil {
@@ -1030,7 +1030,7 @@ func (h *AuthorHandler) RelinkUpstream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if canonical, ambiguous, err := h.findCanonicalAuthorMatchExcluding(r.Context(), author.ID, author.Name, upstream.Name); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	} else if ambiguous {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "author name resolves ambiguously — merge manually"})
@@ -1040,7 +1040,7 @@ func (h *AuthorHandler) RelinkUpstream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if existing, err := h.authors.GetByAnyForeignIDForUser(r.Context(), upstream.ForeignID, userID); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	} else if existing != nil && existing.ID != author.ID {
 		h.writeCanonicalAuthorConflict(w, existing, "upstream author already exists locally")
@@ -1052,7 +1052,7 @@ func (h *AuthorHandler) RelinkUpstream(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusConflict, map[string]string{"error": "upstream author already exists locally"})
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -1069,7 +1069,7 @@ func (h *AuthorHandler) RelinkCandidates(w http.ResponseWriter, r *http.Request)
 	}
 	author, err := h.authors.GetByIDForUser(r.Context(), id, auth.UserIDFromContext(r.Context()))
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if author == nil {
@@ -1098,7 +1098,7 @@ func (h *AuthorHandler) RelinkCandidates(w http.ResponseWriter, r *http.Request)
 	}
 	identifiers, err := h.authors.ListAuthorIdentifiers(r.Context(), author.ID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	for _, identifier := range identifiers {
@@ -1133,7 +1133,7 @@ func (h *AuthorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// missing row so non-owners cannot probe for existence by status code.
 	author, err := h.authors.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if author == nil || !auth.CheckOwnership(r.Context(), author.OwnerUserID) {
@@ -1167,7 +1167,7 @@ func (h *AuthorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.authors.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -2179,7 +2179,7 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 		if author == nil {
 			if err := h.authors.CreateForUser(ctx, fetched, userID); err != nil {
 				if !strings.Contains(err.Error(), "UNIQUE constraint failed") && !errors.Is(err, db.ErrAuthorIdentifierConflict) {
-					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+					writeServerError(w, r, err)
 					return
 				}
 				// Race: another request created it between our check and insert.
@@ -2288,7 +2288,7 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	// 3. Mark the book monitored (wanted).
 	book.Monitored = true
 	if err := h.books.Update(ctx, book); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 

--- a/internal/api/authors_alias.go
+++ b/internal/api/authors_alias.go
@@ -35,7 +35,7 @@ func (h *AuthorAliasHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 	author, err := h.authors.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if author == nil {
@@ -49,7 +49,7 @@ func (h *AuthorAliasHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 	aliases, err := h.aliases.ListByAuthor(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if aliases == nil {
@@ -73,7 +73,7 @@ func (h *AuthorAliasHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 	author, err := h.authors.GetByID(r.Context(), authorID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if author == nil {
@@ -87,7 +87,7 @@ func (h *AuthorAliasHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 	deleted, err := h.aliases.DeleteForAuthor(r.Context(), authorID, aliasID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if !deleted {
@@ -139,7 +139,7 @@ func (h *AuthorAliasHandler) Merge(w http.ResponseWriter, r *http.Request) {
 	for _, id := range []int64{req.SourceID, targetID} {
 		a, err := h.authors.GetByID(r.Context(), id)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 		if a == nil || !auth.CheckOwnership(r.Context(), a.OwnerUserID) {
@@ -156,7 +156,7 @@ func (h *AuthorAliasHandler) Merge(w http.ResponseWriter, r *http.Request) {
 	result, err := h.aliases.Merge(r.Context(), req.SourceID, targetID, db.MergeOptions{OverwriteDefaults: overwrite})
 	if err != nil {
 		slog.Warn("merge authors failed", "sourceId", req.SourceID, "targetId", targetID, "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	slog.Info("merged authors", "sourceId", req.SourceID, "targetId", targetID,

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -50,7 +50,7 @@ func (h *BackupHandler) List(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusOK, []map[string]any{})
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -123,7 +123,7 @@ func (h *BackupHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if err := h.vacuumInto(r.Context(), tmpPath); err != nil {
 		_ = os.Remove(tmpPath)
 		slog.Error("backup failed", "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "backup failed: " + err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	// Match the live DB file's 0600 mode. VACUUM INTO honours umask, which on
@@ -132,13 +132,13 @@ func (h *BackupHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if err := os.Chmod(tmpPath, 0o600); err != nil {
 		_ = os.Remove(tmpPath)
 		slog.Error("backup chmod failed", "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "backup failed: " + err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if err := os.Rename(tmpPath, destPath); err != nil {
 		_ = os.Remove(tmpPath)
 		slog.Error("backup rename failed", "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "backup failed: " + err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -203,7 +203,7 @@ func (h *BackupHandler) Restore(w http.ResponseWriter, r *http.Request) {
 
 	if err := copyFile(srcPath, h.dbPath); err != nil {
 		slog.Error("restore failed", "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "restore failed: " + err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -225,7 +225,7 @@ func (h *BackupHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "backup file not found"})
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/blocklist.go
+++ b/internal/api/blocklist.go
@@ -21,7 +21,7 @@ func NewBlocklistHandler(blocklist *db.BlocklistRepo) *BlocklistHandler {
 func (h *BlocklistHandler) List(w http.ResponseWriter, r *http.Request) {
 	entries, err := h.blocklist.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if entries == nil {
@@ -37,7 +37,7 @@ func (h *BlocklistHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.blocklist.DeleteByID(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -53,7 +53,7 @@ func (h *BlocklistHandler) BulkDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, id := range req.IDs {
 		if err := h.blocklist.DeleteByID(r.Context(), id); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 	}

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -187,7 +187,7 @@ func (h *BookHandler) EnrichAudiobook(w http.ResponseWriter, r *http.Request) {
 	}
 	h.tryMapAudiobookMetadataByASIN(r.Context(), book)
 	if err := h.books.Update(r.Context(), book); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	cleanBookDescription(book)
@@ -313,7 +313,7 @@ func (h *BookHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if books == nil {
@@ -355,7 +355,7 @@ func (h *BookHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	book, err := h.books.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if book == nil {
@@ -462,7 +462,7 @@ func (h *BookHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.books.Update(r.Context(), book); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -502,7 +502,7 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// `?deleteFiles=true` branch re-fetches when it needs the legacy file
 	// columns; the extra lookup is cheap and keeps the diff localised.
 	if existing, err := h.books.GetByID(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	} else if existing == nil || !auth.CheckOwnership(r.Context(), existing.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
@@ -548,7 +548,7 @@ func (h *BookHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if err := h.books.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -570,7 +570,7 @@ func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 	// Tier-1 cross-user IDOR guard (D1). Fetch the book up-front so the
 	// ownership check runs before any file enumeration or destructive work.
 	if existing, err := h.books.GetByID(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	} else if existing == nil || !auth.CheckOwnership(r.Context(), existing.OwnerUserID) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
@@ -582,7 +582,7 @@ func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 	// Enumerate files from book_files for this book.
 	allFiles, err := h.books.ListFiles(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -635,7 +635,7 @@ func (h *BookHandler) DeleteFile(w http.ResponseWriter, r *http.Request) {
 		skipped, err := safeRemoveBookPath(r.Context(), h.roots, h.books, id, p, format, "id", id)
 		if err != nil {
 			slog.Error("failed to remove book file", "id", id, "path", p, "error", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 		if !skipped {
@@ -771,7 +771,7 @@ func (h *BookHandler) ListWanted(w http.ResponseWriter, r *http.Request) {
 		books, err = h.books.ListByStatus(r.Context(), models.BookStatusWanted)
 	}
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if books == nil {
@@ -913,7 +913,7 @@ func (h *BookHandler) Rebind(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusConflict, map[string]string{"error": "a different book already uses that foreign ID"})
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	h.hydrateHardcoverEditions(r.Context(), book, req.Provider)
@@ -986,7 +986,7 @@ func (h *BookHandler) ToggleExcluded(w http.ResponseWriter, r *http.Request) {
 
 	newVal := !book.Excluded
 	if err := h.books.SetExcluded(r.Context(), id, newVal); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	book.Excluded = newVal
@@ -1042,7 +1042,7 @@ func (h *BookHandler) MapMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 	currentAuthor, err := h.authors.GetByID(r.Context(), book.AuthorID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if !bookMapAuthorMatches(currentAuthor, target.Author) {
@@ -1052,13 +1052,13 @@ func (h *BookHandler) MapMetadata(w http.ResponseWriter, r *http.Request) {
 
 	preserveBookStateForMetadataMap(book, target)
 	if err := h.books.Update(r.Context(), book); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	h.hydrateHardcoverEditions(r.Context(), book, book.MetadataProvider)
 	updated, err := h.books.GetByID(r.Context(), book.ID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	h.attachBookFiles(r.Context(), updated)

--- a/internal/api/calibre_import.go
+++ b/internal/api/calibre_import.go
@@ -50,7 +50,7 @@ func (h *CalibreImportHandler) Start(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
 		return
 	case err != nil:
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusAccepted, h.importer.Progress())

--- a/internal/api/calibre_runs.go
+++ b/internal/api/calibre_runs.go
@@ -40,7 +40,7 @@ func (h *CalibreRunsHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 	runs, err := h.importer.RecentRuns(r.Context(), limit)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if runs == nil {

--- a/internal/api/calibre_sync.go
+++ b/internal/api/calibre_sync.go
@@ -57,7 +57,7 @@ func (h *CalibreSyncHandler) Start(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	case err != nil:
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusAccepted, h.syncer.Progress())

--- a/internal/api/custom_formats.go
+++ b/internal/api/custom_formats.go
@@ -22,7 +22,7 @@ func NewCustomFormatHandler(repo *db.CustomFormatRepo) *CustomFormatHandler {
 func (h *CustomFormatHandler) List(w http.ResponseWriter, r *http.Request) {
 	formats, err := h.repo.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if formats == nil {
@@ -39,7 +39,7 @@ func (h *CustomFormatHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 	cf, err := h.repo.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if cf == nil {
@@ -63,7 +63,7 @@ func (h *CustomFormatHandler) Create(w http.ResponseWriter, r *http.Request) {
 		cf.Conditions = []models.CustomCondition{}
 	}
 	if err := h.repo.Create(r.Context(), &cf); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, cf)
@@ -90,7 +90,7 @@ func (h *CustomFormatHandler) Update(w http.ResponseWriter, r *http.Request) {
 		cf.Conditions = []models.CustomCondition{}
 	}
 	if err := h.repo.Update(r.Context(), &cf); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, cf)
@@ -103,7 +103,7 @@ func (h *CustomFormatHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.repo.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/delay_profiles.go
+++ b/internal/api/delay_profiles.go
@@ -22,7 +22,7 @@ func NewDelayProfileHandler(repo *db.DelayProfileRepo) *DelayProfileHandler {
 func (h *DelayProfileHandler) List(w http.ResponseWriter, r *http.Request) {
 	profiles, err := h.repo.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if profiles == nil {
@@ -39,7 +39,7 @@ func (h *DelayProfileHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 	p, err := h.repo.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if p == nil {
@@ -59,7 +59,7 @@ func (h *DelayProfileHandler) Create(w http.ResponseWriter, r *http.Request) {
 		p.PreferredProtocol = "usenet"
 	}
 	if err := h.repo.Create(r.Context(), &p); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, p)
@@ -83,7 +83,7 @@ func (h *DelayProfileHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	p.ID = id
 	if err := h.repo.Update(r.Context(), &p); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, p)
@@ -96,7 +96,7 @@ func (h *DelayProfileHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.repo.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/download_clients.go
+++ b/internal/api/download_clients.go
@@ -104,7 +104,7 @@ func (h *DownloadClientHandler) WithDownloadPathRemap(remap string) *DownloadCli
 func (h *DownloadClientHandler) List(w http.ResponseWriter, r *http.Request) {
 	clients, err := h.clients.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if clients == nil {
@@ -151,7 +151,7 @@ func (h *DownloadClientHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.clients.Create(r.Context(), &c); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	h.refreshClientHealthAsync(c)
@@ -181,7 +181,7 @@ func (h *DownloadClientHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	c.ID = id
 	if err := h.clients.Update(r.Context(), &c); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	// Evict the pooled downloader client so the next poll picks up the new
@@ -198,7 +198,7 @@ func (h *DownloadClientHandler) Update(w http.ResponseWriter, r *http.Request) {
 func (h *DownloadClientHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 	if err := h.clients.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	// Drop the pooled client so its session/cookies and idle connections

--- a/internal/api/history.go
+++ b/internal/api/history.go
@@ -73,7 +73,7 @@ func (h *HistoryHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	events, total, err := h.history.ListPage(ctx, opts)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	items := make([]historyItem, len(events))
@@ -111,7 +111,7 @@ func (h *HistoryHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// Per-user scoping (D3): JOIN through books to find owner before delete.
 	owner, exists, err := h.history.GetOwnerByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if !exists {
@@ -123,7 +123,7 @@ func (h *HistoryHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.history.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -149,7 +149,7 @@ func (h *HistoryHandler) Blocklist(w http.ResponseWriter, r *http.Request) {
 	// search results.
 	owner, _, err := h.history.GetOwnerByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if !auth.CheckOwnership(r.Context(), owner) {
@@ -176,7 +176,7 @@ func (h *HistoryHandler) Blocklist(w http.ResponseWriter, r *http.Request) {
 	if guid != "" {
 		blocked, err := h.blocklist.IsBlocked(r.Context(), guid)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 		if blocked {
@@ -203,7 +203,7 @@ func (h *HistoryHandler) Blocklist(w http.ResponseWriter, r *http.Request) {
 		err = h.blocklist.Create(r.Context(), entry)
 	}
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, entry)

--- a/internal/api/import_lists.go
+++ b/internal/api/import_lists.go
@@ -47,7 +47,7 @@ func NewImportListHandler(repo *db.ImportListRepo, settings *db.SettingsRepo, hc
 func (h *ImportListHandler) List(w http.ResponseWriter, r *http.Request) {
 	lists, err := h.repo.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if lists == nil {
@@ -64,7 +64,7 @@ func (h *ImportListHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 	il, err := h.repo.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if il == nil {
@@ -93,7 +93,7 @@ func (h *ImportListHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	il.APIKey = hardcover.NormalizeAPIToken(il.APIKey)
 	if err := h.repo.Create(r.Context(), &il); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, importListResponse(il))
@@ -122,7 +122,7 @@ func (h *ImportListHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	il.ID = id
 	if err := h.repo.Update(r.Context(), &il); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, importListResponse(il))
@@ -135,7 +135,7 @@ func (h *ImportListHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.repo.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -173,7 +173,7 @@ func (h *ImportListHandler) HardcoverLists(w http.ResponseWriter, r *http.Reques
 func (h *ImportListHandler) ListExclusions(w http.ResponseWriter, r *http.Request) {
 	exclusions, err := h.repo.ListExclusions(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if exclusions == nil {
@@ -193,7 +193,7 @@ func (h *ImportListHandler) CreateExclusion(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := h.repo.CreateExclusion(r.Context(), &e); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, e)
@@ -206,7 +206,7 @@ func (h *ImportListHandler) DeleteExclusion(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := h.repo.DeleteExclusion(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -73,7 +73,7 @@ func (h *IndexerHandler) WithAliases(aliases *db.AuthorAliasRepo) *IndexerHandle
 func (h *IndexerHandler) List(w http.ResponseWriter, r *http.Request) {
 	idxs, err := h.indexers.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if idxs == nil {
@@ -135,7 +135,7 @@ func (h *IndexerHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.indexers.Create(r.Context(), &idx); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, idx)
@@ -170,7 +170,7 @@ func (h *IndexerHandler) Update(w http.ResponseWriter, r *http.Request) {
 	// the -1 unlimited sentinel — the explicit choice sticks.
 	idx.SeedRatioSource = models.SeedRatioSourceUser
 	if err := h.indexers.Update(r.Context(), &idx); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, idx)
@@ -182,7 +182,7 @@ func (h *IndexerHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.indexers.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -300,7 +300,7 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 
 	idxs, err := h.indexers.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -511,7 +511,7 @@ func (h *IndexerHandler) SearchQuery(w http.ResponseWriter, r *http.Request) {
 
 	idxs, err := h.indexers.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 

--- a/internal/api/library.go
+++ b/internal/api/library.go
@@ -49,7 +49,7 @@ func (h *LibraryHandler) ScanStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	setting, err := h.settings.Get(r.Context(), "library.lastScan")
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if setting == nil {

--- a/internal/api/logs.go
+++ b/internal/api/logs.go
@@ -116,7 +116,7 @@ func (h *LogHandler) List(w http.ResponseWriter, r *http.Request) {
 
 		entries, err := h.logs.Query(r.Context(), f)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 		if entries == nil {

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -72,7 +72,7 @@ func (h *ManualImportHandler) Lookup(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := h.scanner.Lookup(r.Context(), path)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, result)
@@ -360,7 +360,7 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	}
 	entries, err := os.ReadDir(path)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("read folder: %v", err)})
+		writeServerError(w, r, err)
 		return
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -141,8 +141,11 @@ func TestManualImportLookup_ScannerError(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500", rec.Code)
 	}
-	if !strings.Contains(rec.Body.String(), "catalogue unavailable") {
-		t.Errorf("body = %q, want scanner error message", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), "internal server error") {
+		t.Errorf("body = %q, want generic server error", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "catalogue unavailable") {
+		t.Errorf("body = %q, must not leak the internal error", rec.Body.String())
 	}
 }
 

--- a/internal/api/metadata_profiles.go
+++ b/internal/api/metadata_profiles.go
@@ -23,7 +23,7 @@ func NewMetadataProfileHandler(repo *db.MetadataProfileRepo) *MetadataProfileHan
 func (h *MetadataProfileHandler) List(w http.ResponseWriter, r *http.Request) {
 	profiles, err := h.repo.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if profiles == nil {
@@ -40,7 +40,7 @@ func (h *MetadataProfileHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 	p, err := h.repo.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if p == nil {
@@ -72,7 +72,7 @@ func (h *MetadataProfileHandler) Create(w http.ResponseWriter, r *http.Request) 
 		p.UnknownLanguageBehavior = models.UnknownLanguagePass
 	}
 	if err := h.repo.Create(r.Context(), &p); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, p)
@@ -104,7 +104,7 @@ func (h *MetadataProfileHandler) Update(w http.ResponseWriter, r *http.Request) 
 		p.UnknownLanguageBehavior = models.UnknownLanguagePass
 	}
 	if err := h.repo.Update(r.Context(), &p); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, p)
@@ -120,7 +120,7 @@ func (h *MetadataProfileHandler) Delete(w http.ResponseWriter, r *http.Request) 
 	// observe a 200 / 500 vs. 404 difference and probe for existence.
 	existing, err := h.repo.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if existing == nil || !auth.CheckOwnership(r.Context(), existing.OwnerUserID) {
@@ -128,7 +128,7 @@ func (h *MetadataProfileHandler) Delete(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if err := h.repo.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/migrate.go
+++ b/internal/api/migrate.go
@@ -134,7 +134,7 @@ func (h *MigrateHandler) ImportReadarr(w http.ResponseWriter, r *http.Request) {
 	tmp, err := os.CreateTemp(uploadTempDir(), "readarr-*.db")
 	if err != nil {
 		slog.Error("readarr import: create temp file failed", "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "create temp: " + err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	tmpPath := tmp.Name()
@@ -143,13 +143,13 @@ func (h *MigrateHandler) ImportReadarr(w http.ResponseWriter, r *http.Request) {
 		_ = tmp.Close()
 		_ = os.Remove(tmpPath)
 		slog.Error("readarr import: spool upload failed", "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "write temp: " + err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if err := tmp.Close(); err != nil {
 		slog.Error("readarr import: close temp file failed", "path", tmpPath, "error", err)
 		_ = os.Remove(tmpPath)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "close temp: " + err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -165,7 +165,7 @@ func (h *MigrateHandler) ImportReadarr(w http.ResponseWriter, r *http.Request) {
 	case err != nil:
 		_ = os.Remove(tmpPath)
 		slog.Error("readarr import: failed to start", "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -249,7 +249,7 @@ func (h *MigrateHandler) ImportGoodreadsPreview(w http.ResponseWriter, r *http.R
 			return
 		}
 		slog.Error("goodreads import: preview failed", "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, preview)
@@ -279,7 +279,7 @@ func (h *MigrateHandler) ImportGoodreadsCommit(w http.ResponseWriter, r *http.Re
 			return
 		}
 		slog.Error("goodreads import: commit failed", "error", err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, result)

--- a/internal/api/notifications.go
+++ b/internal/api/notifications.go
@@ -39,7 +39,7 @@ func NewNotificationHandler(notifications *db.NotificationRepo, notif *notifier.
 func (h *NotificationHandler) List(w http.ResponseWriter, r *http.Request) {
 	notifications, err := h.notifications.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if notifications == nil {
@@ -56,7 +56,7 @@ func (h *NotificationHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 	n, err := h.notifications.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if n == nil {
@@ -82,7 +82,7 @@ func (h *NotificationHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.notifications.Create(r.Context(), &n); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, n)
@@ -114,7 +114,7 @@ func (h *NotificationHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	n.ID = id
 	if err := h.notifications.Update(r.Context(), &n); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, n)
@@ -127,7 +127,7 @@ func (h *NotificationHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.notifications.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/opds.go
+++ b/internal/api/opds.go
@@ -39,7 +39,7 @@ func (h *OPDSHandler) Authors(w http.ResponseWriter, r *http.Request) {
 	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
 	feed, err := h.builder.BuildAuthors(r.Context(), baseURL(r), page, opdsCallerUserID(r.Context()))
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeOPDS(w, feed)
@@ -52,7 +52,7 @@ func (h *OPDSHandler) Author(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	feed, err := h.builder.BuildAuthor(r.Context(), baseURL(r), id, opdsCallerUserID(r.Context()))
-	if writeOPDSError(w, err) {
+	if writeOPDSError(w, r, err) {
 		return
 	}
 	writeOPDS(w, feed)
@@ -63,7 +63,7 @@ func (h *OPDSHandler) Series(w http.ResponseWriter, r *http.Request) {
 	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
 	feed, err := h.builder.BuildSeriesList(r.Context(), baseURL(r), page, opdsCallerUserID(r.Context()))
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeOPDS(w, feed)
@@ -76,7 +76,7 @@ func (h *OPDSHandler) OneSeries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	feed, err := h.builder.BuildSeries(r.Context(), baseURL(r), id, opdsCallerUserID(r.Context()))
-	if writeOPDSError(w, err) {
+	if writeOPDSError(w, r, err) {
 		return
 	}
 	writeOPDS(w, feed)
@@ -86,7 +86,7 @@ func (h *OPDSHandler) OneSeries(w http.ResponseWriter, r *http.Request) {
 func (h *OPDSHandler) Recent(w http.ResponseWriter, r *http.Request) {
 	feed, err := h.builder.BuildRecent(r.Context(), baseURL(r), opdsCallerUserID(r.Context()))
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeOPDS(w, feed)
@@ -100,7 +100,7 @@ func (h *OPDSHandler) Book(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	feed, err := h.builder.BuildBook(r.Context(), baseURL(r), id, opdsCallerUserID(r.Context()))
-	if writeOPDSError(w, err) {
+	if writeOPDSError(w, r, err) {
 		return
 	}
 	writeOPDS(w, feed)
@@ -135,7 +135,7 @@ func (h *OPDSHandler) DownloadFile(w http.ResponseWriter, r *http.Request) {
 		}
 		bk, err := h.books.GetByID(r.Context(), id)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 		if bk == nil || (bk.OwnerUserID != 0 && bk.OwnerUserID != uid) {
@@ -187,7 +187,7 @@ func writeOPDS(w http.ResponseWriter, feed opds.Feed) {
 
 // writeOPDSError handles known builder errors (currently just ErrNotFound).
 // Returns true when it wrote a response so the caller can bail out.
-func writeOPDSError(w http.ResponseWriter, err error) bool {
+func writeOPDSError(w http.ResponseWriter, r *http.Request, err error) bool {
 	if err == nil {
 		return false
 	}
@@ -195,6 +195,6 @@ func writeOPDSError(w http.ResponseWriter, err error) bool {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
 		return true
 	}
-	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	writeServerError(w, r, err)
 	return true
 }

--- a/internal/api/pending.go
+++ b/internal/api/pending.go
@@ -40,7 +40,7 @@ func NewPendingHandler(pending *db.PendingReleaseRepo, queue *QueueHandler, down
 func (h *PendingHandler) List(w http.ResponseWriter, r *http.Request) {
 	items, err := h.listForCaller(r)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -85,7 +85,7 @@ func (h *PendingHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// is the only ownership signal. Resolve and gate before deleting.
 	owner, exists, err := h.pending.GetOwnerByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if !exists {
@@ -97,7 +97,7 @@ func (h *PendingHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.pending.DeleteByID(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -121,7 +121,7 @@ func (h *PendingHandler) Grab(w http.ResponseWriter, r *http.Request) {
 	// GetOwnerByID handles the LEFT JOIN gracefully.
 	owner, _, err := h.pending.GetOwnerByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if !auth.CheckOwnership(r.Context(), owner) {
@@ -132,7 +132,7 @@ func (h *PendingHandler) Grab(w http.ResponseWriter, r *http.Request) {
 	// Deserialize the stored release JSON to get the full grab details.
 	var stored grabRequest
 	if err := json.Unmarshal([]byte(pr.ReleaseJSON), &stored); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "invalid stored release: " + err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -157,7 +157,7 @@ func (h *PendingHandler) Grab(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusConflict, map[string]string{"error": "already grabbed"})
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 

--- a/internal/api/prowlarr.go
+++ b/internal/api/prowlarr.go
@@ -69,7 +69,7 @@ func LoadProwlarrTimeout(ctx context.Context, s *db.SettingsRepo) time.Duration 
 func (h *ProwlarrHandler) List(w http.ResponseWriter, r *http.Request) {
 	items, err := h.instances.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if items == nil {
@@ -86,7 +86,7 @@ func (h *ProwlarrHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 	p, err := h.instances.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if p == nil {
@@ -114,7 +114,7 @@ func (h *ProwlarrHandler) Create(w http.ResponseWriter, r *http.Request) {
 		p.Name = "Prowlarr"
 	}
 	if err := h.instances.Create(r.Context(), &p); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, p)
@@ -128,7 +128,7 @@ func (h *ProwlarrHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	existing, err := h.instances.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if existing == nil {
@@ -146,12 +146,12 @@ func (h *ProwlarrHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.instances.Update(r.Context(), existing); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if existing.APIKey != previousKey && h.indexers != nil {
 		if _, err := h.indexers.UpdateAPIKeyByProwlarrInstance(r.Context(), id, existing.APIKey); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 	}
@@ -166,11 +166,11 @@ func (h *ProwlarrHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 	// Remove synced indexers before deleting the instance (FK constraint).
 	if err := h.indexers.DeleteByProwlarrInstance(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if err := h.instances.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/quality_profiles.go
+++ b/internal/api/quality_profiles.go
@@ -25,7 +25,7 @@ func NewQualityProfileHandler(profiles *db.QualityProfileRepo) *QualityProfileHa
 func (h *QualityProfileHandler) List(w http.ResponseWriter, r *http.Request) {
 	profiles, err := h.profiles.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if profiles == nil {
@@ -42,7 +42,7 @@ func (h *QualityProfileHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 	p, err := h.profiles.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if p == nil {
@@ -72,7 +72,7 @@ func (h *QualityProfileHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	taken, err := h.profiles.NameExists(r.Context(), p.Name, 0)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if taken {
@@ -80,7 +80,7 @@ func (h *QualityProfileHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.profiles.Create(r.Context(), &p); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, p)
@@ -94,7 +94,7 @@ func (h *QualityProfileHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	existing, err := h.profiles.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if existing == nil {
@@ -113,7 +113,7 @@ func (h *QualityProfileHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	taken, err := h.profiles.NameExists(r.Context(), p.Name, id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if taken {
@@ -121,7 +121,7 @@ func (h *QualityProfileHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.profiles.Update(r.Context(), &p); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, p)
@@ -148,7 +148,7 @@ func (h *QualityProfileHandler) Delete(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "quality profile not found"})
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -296,7 +296,7 @@ type queueListResponse struct {
 func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
 	enriched, diagnostics, err := h.enrichedQueueItems(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -362,7 +362,7 @@ type arrQueueRecord struct {
 func (h *QueueHandler) ListArrCompatible(w http.ResponseWriter, r *http.Request) {
 	enriched, _, err := h.enrichedQueueItems(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -633,7 +633,7 @@ func (h *QueueHandler) RetryImport(w http.ResponseWriter, r *http.Request) {
 	// attacker that the id space is enumerable.
 	owner, exists, err := h.downloads.GetOwnerByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if !exists {
@@ -647,7 +647,7 @@ func (h *QueueHandler) RetryImport(w http.ResponseWriter, r *http.Request) {
 
 	accepted, found, err := h.downloads.ResetImportRetry(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if !found {
@@ -887,7 +887,7 @@ func (h *QueueHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// happy path because it sources Download state Delete still needs.
 	owner, exists, err := h.downloads.GetOwnerByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if !exists {
@@ -901,7 +901,7 @@ func (h *QueueHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 	downloads, err := h.downloads.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	var target *models.Download
@@ -945,7 +945,7 @@ func (h *QueueHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.downloads.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/recommendations.go
+++ b/internal/api/recommendations.go
@@ -127,7 +127,7 @@ func (h *RecommendationHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	recs, err := h.recs.List(r.Context(), auth.UserIDFromContext(r.Context()), recType, limit, offset)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if recs == nil {
@@ -149,7 +149,7 @@ func (h *RecommendationHandler) Dismiss(w http.ResponseWriter, r *http.Request) 
 	// feed by ID. 404 (not 403) on mismatch to avoid leaking existence.
 	rec, err := h.recs.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if rec == nil || !auth.CheckOwnership(r.Context(), rec.UserID) {
@@ -158,7 +158,7 @@ func (h *RecommendationHandler) Dismiss(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := h.recs.Dismiss(r.Context(), auth.UserIDFromContext(r.Context()), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -174,7 +174,7 @@ func (h *RecommendationHandler) Add(w http.ResponseWriter, r *http.Request) {
 
 	rec, err := h.recs.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if rec == nil {
@@ -231,7 +231,7 @@ func (h *RecommendationHandler) Add(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.books.Create(r.Context(), book); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	h.hydrateHardcoverEditions(r.Context(), book)
@@ -269,7 +269,7 @@ func (h *RecommendationHandler) Refresh(w http.ResponseWriter, r *http.Request) 
 // ClearDismissals removes all dismissals for the current user.
 func (h *RecommendationHandler) ClearDismissals(w http.ResponseWriter, r *http.Request) {
 	if err := h.recs.ClearDismissals(r.Context(), auth.UserIDFromContext(r.Context())); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -279,7 +279,7 @@ func (h *RecommendationHandler) ClearDismissals(w http.ResponseWriter, r *http.R
 func (h *RecommendationHandler) ListAuthorExclusions(w http.ResponseWriter, r *http.Request) {
 	exclusions, err := h.recs.ListAuthorExclusions(r.Context(), auth.UserIDFromContext(r.Context()))
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if exclusions == nil {
@@ -299,7 +299,7 @@ func (h *RecommendationHandler) ExcludeAuthor(w http.ResponseWriter, r *http.Req
 	}
 
 	if err := h.recs.AddAuthorExclusion(r.Context(), auth.UserIDFromContext(r.Context()), req.AuthorName); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)
@@ -314,7 +314,7 @@ func (h *RecommendationHandler) RemoveAuthorExclusion(w http.ResponseWriter, r *
 	}
 
 	if err := h.recs.RemoveAuthorExclusion(r.Context(), auth.UserIDFromContext(r.Context()), name); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/root_folders.go
+++ b/internal/api/root_folders.go
@@ -24,7 +24,7 @@ func NewRootFolderHandler(folders *db.RootFolderRepo) *RootFolderHandler {
 func (h *RootFolderHandler) List(w http.ResponseWriter, r *http.Request) {
 	folders, err := h.folders.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if folders == nil {
@@ -61,7 +61,7 @@ func (h *RootFolderHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	folder, err := h.folders.Create(r.Context(), req.Path)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -80,7 +80,7 @@ func (h *RootFolderHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// distinguish "exists but not mine" from "does not exist".
 	existing, err := h.folders.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if existing == nil || !auth.CheckOwnership(r.Context(), existing.OwnerUserID) {
@@ -88,7 +88,7 @@ func (h *RootFolderHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.folders.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -129,6 +129,14 @@ func (h *SearchHandler) lookupByASIN(w http.ResponseWriter, r *http.Request, asi
 	writeJSON(w, http.StatusOK, book)
 }
 
+// writeServerError logs the underlying error server-side (with request
+// context) and returns a generic 500 body, so internal details like SQL
+// text or filesystem paths never reach the client.
+func writeServerError(w http.ResponseWriter, r *http.Request, err error) {
+	slog.Error("request failed", "method", r.Method, "path", r.URL.Path, "error", err)
+	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+}
+
 func writeJSON(w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -161,7 +161,7 @@ func validateSeriesTitle(title string) (string, string) {
 func (h *SeriesHandler) List(w http.ResponseWriter, r *http.Request) {
 	series, err := h.series.ListWithBooks(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if series == nil {
@@ -179,7 +179,7 @@ func (h *SeriesHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	s, err := h.series.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if s == nil {
@@ -207,7 +207,7 @@ func (h *SeriesHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	series, err := h.series.CreateManual(r.Context(), title)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, series)
@@ -232,7 +232,7 @@ func (h *SeriesHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	existing, err := h.series.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if existing == nil {
@@ -240,12 +240,12 @@ func (h *SeriesHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.series.UpdateTitle(r.Context(), id, title); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	updated, err := h.series.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, updated)
@@ -258,7 +258,7 @@ func (h *SeriesHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 	existing, err := h.series.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if existing == nil {
@@ -266,7 +266,7 @@ func (h *SeriesHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.series.Delete(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -292,7 +292,7 @@ func (h *SeriesHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	}
 	series, err := h.series.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if series == nil {
@@ -301,7 +301,7 @@ func (h *SeriesHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	}
 	book, err := h.books.GetByID(r.Context(), body.BookID)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if book == nil || book.Excluded {
@@ -313,12 +313,12 @@ func (h *SeriesHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 		primary = *body.PrimarySeries
 	}
 	if err := h.series.UpsertBookLink(r.Context(), id, body.BookID, body.PositionInSeries, primary); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	updated, err := h.series.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, updated)
@@ -341,7 +341,7 @@ func (h *SeriesHandler) Monitor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.series.SetMonitored(r.Context(), id, body.Monitored); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"monitored": body.Monitored})
@@ -448,7 +448,7 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 				writeUpstreamError(w, err)
 				return
 			}
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 
@@ -456,7 +456,7 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 		if book != nil {
 			didQueue, queuedBook, err := h.queueSeriesBook(r.Context(), *book)
 			if err != nil {
-				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				writeServerError(w, r, err)
 				return
 			}
 			if didQueue {
@@ -471,7 +471,7 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 	if h.enhancedHardcoverEnabled(r.Context()) {
 		if err := h.createMissingHardcoverBooks(r.Context(), id, body.mediaType()); err != nil {
 			if !errors.Is(err, errSeriesMetadataProvider) {
-				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				writeServerError(w, r, err)
 				return
 			}
 			slog.Warn("series fill: failed to expand Hardcover catalog; continuing with local books", "seriesID", id, "error", err)
@@ -480,7 +480,7 @@ func (h *SeriesHandler) Fill(w http.ResponseWriter, r *http.Request) {
 
 	books, err := h.series.ListBooksInSeries(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 
@@ -650,7 +650,7 @@ func (h *SeriesHandler) GetHardcoverLink(w http.ResponseWriter, r *http.Request)
 	}
 	link, err := h.series.GetHardcoverLink(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if link == nil {
@@ -670,7 +670,7 @@ func (h *SeriesHandler) AutoLinkHardcover(w http.ResponseWriter, r *http.Request
 	}
 	series, err := h.series.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if series == nil {
@@ -714,7 +714,7 @@ func (h *SeriesHandler) AutoLinkHardcover(w http.ResponseWriter, r *http.Request
 		LinkedBy:            "auto",
 	}
 	if err := h.series.UpsertHardcoverLink(r.Context(), link); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, seriesHardcoverAutoResponse{Linked: true, Link: link, Candidates: candidates})
@@ -729,7 +729,7 @@ func (h *SeriesHandler) PutHardcoverLink(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	if series, err := h.series.GetByID(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	} else if series == nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "series not found"})
@@ -753,11 +753,11 @@ func (h *SeriesHandler) PutHardcoverLink(w http.ResponseWriter, r *http.Request)
 			writeUpstreamError(w, err)
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if err := h.series.UpsertHardcoverLink(r.Context(), link); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, link)
@@ -772,7 +772,7 @@ func (h *SeriesHandler) DeleteHardcoverLink(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if err := h.series.DeleteHardcoverLink(r.Context(), id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
@@ -788,7 +788,7 @@ func (h *SeriesHandler) HardcoverDiff(w http.ResponseWriter, r *http.Request) {
 	}
 	series, err := h.series.GetByID(r.Context(), id)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if series == nil {
@@ -799,7 +799,7 @@ func (h *SeriesHandler) HardcoverDiff(w http.ResponseWriter, r *http.Request) {
 	if link == nil {
 		link, err = h.series.GetHardcoverLink(r.Context(), id)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			writeServerError(w, r, err)
 			return
 		}
 	}

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -151,7 +151,7 @@ func isWritableSecretSetting(key string) bool {
 func (h *SettingsHandler) List(w http.ResponseWriter, r *http.Request) {
 	settings, err := h.settings.List(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	filtered := make([]models.Setting, 0, len(settings))
@@ -171,7 +171,7 @@ func (h *SettingsHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 	s, err := h.settings.Get(r.Context(), key)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if s == nil {
@@ -200,7 +200,7 @@ func (h *SettingsHandler) Set(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.settings.Set(r.Context(), key, value); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	if isSecretSetting(key) {
@@ -491,7 +491,7 @@ func (h *SettingsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.settings.Delete(r.Context(), key); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeServerError(w, r, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
## Problem

About 234 handlers across `internal/api` returned the underlying error straight to the client on a 500:

```go
writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
```

That leaks internal detail over the wire. Raw SQLite messages carry table and column names and constraint text, and the library/backup/import paths surface absolute filesystem paths. It is an information disclosure bug and it trains clients to depend on server internals.

## Fix

New helper next to `writeJSON`:

```go
func writeServerError(w http.ResponseWriter, r *http.Request, err error) {
    slog.Error("request failed", "method", r.Method, "path", r.URL.Path, "error", err)
    writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
}
```

Operators keep the full error server-side with request context. The client gets a generic body.

## Scope

Converted 234 sites, all status 500 carrying a raw error:
- 198 exact `writeJSON(...err.Error())` 500s
- 9 wrapped `writeJSON` 500s (backup, migrate, pending, manual_import), prefixes like `"backup failed: "` dropped since the error still goes to the log
- 27 `writeErr(w, http.StatusInternalServerError, "...: "+err.Error())` in auth, auth_users, auth_oidc

Left untouched on purpose: static 500 bodies that carry no error (`"author repository unavailable"`, `"failed to create backup directory"`, the OIDC `"user lookup failed"` family, `"session signing unavailable"`), and every non-500 status (400/401/403/404/409 bodies stay user facing). `writeOPDSError` gained an `r` param so its 500 branch could use the helper (all three callers already had `r`).

## Verification

- `go build ./...` clean
- `go vet ./internal/api/...` clean
- `gofmt -l internal/api` empty
- package compiles under test, auth/backup/opds handler tests pass
- grep confirms zero `StatusInternalServerError` sites carrying `.Error()` or `Sprintf` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)