### PR TITLE
fix(auth): close login timing side-channel for username enumeration

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -212,7 +212,16 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, "lookup: "+err.Error())
 		return
 	}
-	if u == nil || !auth.VerifyPassword(req.Password, u.PasswordHash) {
+	// Always run a password verification, even when the username does not
+	// exist, so a missing user and a wrong password take the same time. If we
+	// skipped the KDF for u == nil, the argon2 cost (tens of ms) would only be
+	// paid for real usernames and its presence/absence would leak which
+	// usernames exist. See auth.DummyPasswordHash.
+	hash := auth.DummyPasswordHash()
+	if u != nil {
+		hash = u.PasswordHash
+	}
+	if ok := auth.VerifyPassword(req.Password, hash); u == nil || !ok {
 		h.limiter.Record(ip)
 		writeErr(w, http.StatusUnauthorized, "invalid credentials")
 		return

--- a/internal/api/opds_auth.go
+++ b/internal/api/opds_auth.go
@@ -72,7 +72,14 @@ func OPDSAuth(p auth.Provider, users *db.UserRepo, limiter *auth.LoginLimiter) f
 					return
 				}
 				u, err := users.GetByUsername(r.Context(), strings.TrimSpace(username))
-				if err == nil && u != nil && auth.VerifyPassword(password, u.PasswordHash) {
+				// Verify against a dummy hash when the user is missing so the
+				// basic-auth response time does not reveal which usernames exist
+				// (mirrors the main login handler). See auth.DummyPasswordHash.
+				hash := auth.DummyPasswordHash()
+				if err == nil && u != nil {
+					hash = u.PasswordHash
+				}
+				if ok := auth.VerifyPassword(password, hash); err == nil && u != nil && ok {
 					if limiter != nil {
 						limiter.Reset(ip)
 					}

--- a/internal/auth/password.go
+++ b/internal/auth/password.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"golang.org/x/crypto/argon2"
 )
@@ -69,6 +70,31 @@ func VerifyPassword(password, phc string) bool {
 	got := argon2.IDKey([]byte(password), salt, time, memory, threads, uint32(len(want))) //nolint:gosec // bounded by argonKeyLen
 	return subtle.ConstantTimeCompare(got, want) == 1
 }
+
+// dummyPasswordHash lazily builds a valid argon2id PHC hash (with the current
+// parameters) that no real password matches. It's computed once, on first use,
+// so importing this package costs nothing.
+var dummyPasswordHash = sync.OnceValue(func() string {
+	h, err := HashPassword("not-a-real-credential-only-for-timing")
+	if err != nil {
+		// rand.Read is the only failure path and effectively never fails; fall
+		// back to a structurally valid PHC with the same params so
+		// VerifyPassword still runs the full KDF (equal timing) and returns false.
+		return fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+			argon2.Version, argonMemory, argonTime, argonThreads,
+			base64.RawStdEncoding.EncodeToString(make([]byte, argonSaltLen)),
+			base64.RawStdEncoding.EncodeToString(make([]byte, argonKeyLen)),
+		)
+	}
+	return h
+})
+
+// DummyPasswordHash returns a valid argon2id hash that no password matches, for
+// equalizing login timing when the supplied username does not exist. Verifying
+// any password against it runs the full KDF and fails, so a missing-user login
+// costs the same as a wrong-password login and usernames cannot be enumerated
+// by measuring response time.
+func DummyPasswordHash() string { return dummyPasswordHash() }
 
 // RandomHex returns 2*n hex characters from crypto/rand.
 func RandomHex(n int) (string, error) {

--- a/internal/auth/password_test.go
+++ b/internal/auth/password_test.go
@@ -1,0 +1,44 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDummyPasswordHashEqualizesTiming asserts the dummy hash is a real
+// argon2id hash with the CURRENT parameters, so verifying against it costs the
+// same as verifying a genuine user's hash. If the argon parameters ever change
+// without the dummy following, the username-not-found path would run a
+// cheaper/absent KDF and reintroduce the login timing side-channel.
+func TestDummyPasswordHashEqualizesTiming(t *testing.T) {
+	dummy := DummyPasswordHash()
+
+	// Structurally valid and rejected for attacker-supplied passwords, so the
+	// missing-user branch always runs the KDF and fails. (The handler's u == nil
+	// guard means even a match here still returns 401, so this is belt-and-braces.)
+	for _, pw := range []string{"", "password", "admin", "hunter2"} {
+		if VerifyPassword(pw, dummy) {
+			t.Fatalf("dummy hash unexpectedly matched password %q", pw)
+		}
+	}
+
+	// Its parameters must match what HashPassword produces today, otherwise the
+	// KDF cost differs from a real verify and login timing diverges again.
+	real, err := HashPassword("whatever")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d, r := paramField(t, dummy), paramField(t, real); d != r {
+		t.Fatalf("dummy params %q != real params %q", d, r)
+	}
+}
+
+// paramField returns the "m=..,t=..,p=.." segment (4th field) of a PHC hash.
+func paramField(t *testing.T, phc string) string {
+	t.Helper()
+	parts := strings.Split(phc, "$")
+	if len(parts) != 6 {
+		t.Fatalf("malformed PHC hash: %q", phc)
+	}
+	return parts[3]
+}


### PR DESCRIPTION
## Problem

Both the main login handler and the OPDS basic-auth path short-circuited on a missing user (`u == nil || !VerifyPassword(...)`). When the username does not exist the argon2id KDF never runs, so the request returns in microseconds, while a real username pays the full hash (tens of ms). That timing gap is measurable over the network and lets an attacker enumerate valid usernames. The per-IP limiter slows it but does not close it (enumeration needs one probe per candidate).

## Fix

Always run a verification. Against the real hash when the user exists, against `auth.DummyPasswordHash()` when they don't. The dummy is a valid argon2id hash (current params) that no password matches, computed lazily with `sync.OnceValue` so importing the auth package costs nothing. Both paths now do equal work.

Applied to `internal/api/auth.go` (Login) and `internal/api/opds_auth.go` (basic auth).

## Test

`TestDummyPasswordHashEqualizesTiming` asserts the dummy rejects passwords and carries the same argon parameters as a real hash, so a future param change can't silently reopen the gap.

## Verified

`go build ./...`, `go test ./internal/auth ./internal/api` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)