### PR TITLE
fix(api): admin-gate root-folder, Grimmory, and Calibre integration routes

### DIFF
--- a/cmd/bindery/integration_routes.go
+++ b/cmd/bindery/integration_routes.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+)
+
+// These helpers mount the root-folder, Grimmory, and Calibre-integration routes
+// behind the same admin-gate boundary the credential-bearing routes use (see
+// sensitive_routes.go). Keeping them as small, standalone registration
+// functions makes the boundary a single testable shape — integration_routes_test
+// asserts a non-admin caller is rejected and an admin still reaches each handler.
+
+// rootFolderRouteHandler is the surface registerRootFolderRoutes needs.
+type rootFolderRouteHandler interface {
+	List(http.ResponseWriter, *http.Request)
+	Create(http.ResponseWriter, *http.Request)
+	Delete(http.ResponseWriter, *http.Request)
+}
+
+// registerRootFolderRoutes mounts /rootfolder. List (reads) stays open, but
+// Create and Delete register/remove server filesystem storage roots — global
+// infrastructure config — so they are admin-only.
+func registerRootFolderRoutes(r chi.Router, h rootFolderRouteHandler) {
+	r.Get("/rootfolder", h.List)
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAdmin)
+		r.Post("/rootfolder", h.Create)
+		r.Delete("/rootfolder/{id}", h.Delete)
+	})
+}
+
+// grimmoryRouteHandler is the surface registerGrimmoryRoutes needs.
+type grimmoryRouteHandler interface {
+	GetConfig(http.ResponseWriter, *http.Request)
+	SetConfig(http.ResponseWriter, *http.Request)
+	Test(http.ResponseWriter, *http.Request)
+}
+
+// registerGrimmoryRoutes mounts /grimmory/*. GetConfig redacts the API key so
+// it stays open; SetConfig writes the integration URL + credential and Test
+// probes it, so those are admin-only (matching the abs/* config pattern).
+func registerGrimmoryRoutes(r chi.Router, h grimmoryRouteHandler) {
+	r.Get("/grimmory/config", h.GetConfig)
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAdmin)
+		r.Put("/grimmory/config", h.SetConfig)
+		r.Post("/grimmory/test", h.Test)
+	})
+}
+
+// calibreProbeHandler is the /calibre/test surface.
+type calibreProbeHandler interface {
+	Test(http.ResponseWriter, *http.Request)
+}
+
+// calibreJobHandler is the Start/Status surface shared by the import and sync
+// handlers.
+type calibreJobHandler interface {
+	Start(http.ResponseWriter, *http.Request)
+	Status(http.ResponseWriter, *http.Request)
+}
+
+// registerCalibreIntegrationRoutes mounts the Calibre probe/import/sync routes.
+// The whole subtree is admin-only: probing runs a credentialed connection test,
+// import creates authors/books wholesale (like /migrate), and sync POSTs every
+// imported book out to the external plugin. The status polls are grouped in for
+// consistency since only an admin can start the jobs, and to match the
+// abs/import and calibre-rollback boundaries.
+func registerCalibreIntegrationRoutes(r chi.Router, probe calibreProbeHandler, imp, sync calibreJobHandler) {
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAdmin)
+		r.Post("/calibre/test", probe.Test)
+		r.Post("/calibre/import", imp.Start)
+		r.Get("/calibre/import/status", imp.Status)
+		r.Post("/calibre/sync", sync.Start)
+		r.Get("/calibre/sync/status", sync.Status)
+	})
+}

--- a/cmd/bindery/integration_routes_test.go
+++ b/cmd/bindery/integration_routes_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/vavallee/bindery/internal/auth"
+)
+
+// stubIntegrationHandler stands in for the root-folder, Grimmory, and Calibre
+// handlers. Every method records its name and writes 204, so when RequireAdmin
+// rejects a request the handler never runs and `called` stays empty.
+type stubIntegrationHandler struct {
+	called []string
+}
+
+func (h *stubIntegrationHandler) record(name string, w http.ResponseWriter) {
+	h.called = append(h.called, name)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *stubIntegrationHandler) List(w http.ResponseWriter, _ *http.Request) { h.record("list", w) }
+func (h *stubIntegrationHandler) Create(w http.ResponseWriter, _ *http.Request) {
+	h.record("create", w)
+}
+func (h *stubIntegrationHandler) Delete(w http.ResponseWriter, _ *http.Request) {
+	h.record("delete", w)
+}
+func (h *stubIntegrationHandler) GetConfig(w http.ResponseWriter, _ *http.Request) {
+	h.record("get-config", w)
+}
+func (h *stubIntegrationHandler) SetConfig(w http.ResponseWriter, _ *http.Request) {
+	h.record("set-config", w)
+}
+func (h *stubIntegrationHandler) Test(w http.ResponseWriter, _ *http.Request)  { h.record("test", w) }
+func (h *stubIntegrationHandler) Start(w http.ResponseWriter, _ *http.Request) { h.record("start", w) }
+func (h *stubIntegrationHandler) Status(w http.ResponseWriter, _ *http.Request) {
+	h.record("status", w)
+}
+
+// newIntegrationRouter wires the three integration route helpers onto a fresh
+// router with one shared stub, mirroring how main.go mounts them.
+func newIntegrationRouter(h *stubIntegrationHandler) chi.Router {
+	router := chi.NewRouter()
+	registerRootFolderRoutes(router, h)
+	registerGrimmoryRoutes(router, h)
+	registerCalibreIntegrationRoutes(router, h, h, h)
+	return router
+}
+
+// TestIntegrationRoutesRequireAdmin nails down the audit finding that a
+// non-admin session could register/delete storage roots, rewrite the Grimmory
+// integration credential, and drive the Calibre import/sync (bulk DB writes +
+// pushing the whole library to an external plugin). Each gated route must 403
+// for role=user.
+func TestIntegrationRoutesRequireAdmin(t *testing.T) {
+	gated := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"create root folder", http.MethodPost, "/rootfolder"},
+		{"delete root folder", http.MethodDelete, "/rootfolder/1"},
+		{"set grimmory config", http.MethodPut, "/grimmory/config"},
+		{"test grimmory", http.MethodPost, "/grimmory/test"},
+		{"test calibre", http.MethodPost, "/calibre/test"},
+		{"start calibre import", http.MethodPost, "/calibre/import"},
+		{"calibre import status", http.MethodGet, "/calibre/import/status"},
+		{"start calibre sync", http.MethodPost, "/calibre/sync"},
+		{"calibre sync status", http.MethodGet, "/calibre/sync/status"},
+	}
+	for _, tt := range gated {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &stubIntegrationHandler{}
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req = req.WithContext(auth.WithUserRole(req.Context(), "user"))
+			rec := httptest.NewRecorder()
+			newIntegrationRouter(h).ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d; want %d (RequireAdmin should reject role=user)", rec.Code, http.StatusForbidden)
+			}
+			if len(h.called) != 0 {
+				t.Fatalf("handler invoked for non-admin request: %v", h.called)
+			}
+		})
+	}
+}
+
+// TestIntegrationRoutesAllowAdmin is the symmetry case: an admin must still
+// reach every gated handler (guards against mounting a route outside the group
+// so it 404s instead of dispatching).
+func TestIntegrationRoutesAllowAdmin(t *testing.T) {
+	tests := []struct {
+		method string
+		path   string
+		called string
+	}{
+		{http.MethodPost, "/rootfolder", "create"},
+		{http.MethodDelete, "/rootfolder/1", "delete"},
+		{http.MethodPut, "/grimmory/config", "set-config"},
+		{http.MethodPost, "/grimmory/test", "test"},
+		{http.MethodPost, "/calibre/test", "test"},
+		{http.MethodPost, "/calibre/import", "start"},
+		{http.MethodGet, "/calibre/import/status", "status"},
+		{http.MethodPost, "/calibre/sync", "start"},
+		{http.MethodGet, "/calibre/sync/status", "status"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			h := &stubIntegrationHandler{}
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req = req.WithContext(auth.WithUserRole(req.Context(), "admin"))
+			rec := httptest.NewRecorder()
+			newIntegrationRouter(h).ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d; want %d", rec.Code, http.StatusNoContent)
+			}
+			if len(h.called) != 1 || h.called[0] != tt.called {
+				t.Fatalf("called = %v; want [%s]", h.called, tt.called)
+			}
+		})
+	}
+}
+
+// TestIntegrationOpenReadsAllowNonAdmin guards the reads we deliberately kept
+// open: GET /rootfolder and GET /grimmory/config (which redacts its key). If a
+// refactor drops them inside the admin group, non-admin UI loses them.
+func TestIntegrationOpenReadsAllowNonAdmin(t *testing.T) {
+	tests := []struct {
+		path   string
+		called string
+	}{
+		{"/rootfolder", "list"},
+		{"/grimmory/config", "get-config"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			h := &stubIntegrationHandler{}
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req = req.WithContext(auth.WithUserRole(req.Context(), "user"))
+			rec := httptest.NewRecorder()
+			newIntegrationRouter(h).ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d; want %d (non-admin must reach open reads)", rec.Code, http.StatusNoContent)
+			}
+			if len(h.called) != 1 || h.called[0] != tt.called {
+				t.Fatalf("called = %v; want [%s]", h.called, tt.called)
+			}
+		})
+	}
+}

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -802,10 +802,9 @@ func main() {
 		registerIndexerRoutes(r, indexerHandler)
 		registerProwlarrRoutes(r, prowlarrHandler)
 
-		// Root folders
-		r.Get("/rootfolder", rootFolderHandler.List)
-		r.Post("/rootfolder", rootFolderHandler.Create)
-		r.Delete("/rootfolder/{id}", rootFolderHandler.Delete)
+		// Root folders — List open, mutations admin-only (they point library
+		// storage at server filesystem paths). See registerRootFolderRoutes.
+		registerRootFolderRoutes(r, rootFolderHandler)
 
 		registerDownloadClientRoutes(r, dlClientHandler)
 
@@ -981,25 +980,13 @@ func main() {
 		r.Post("/authors/refresh-all", authorRefreshHandler.RefreshAll)
 		r.Get("/authors/refresh-all/status", authorRefreshHandler.RefreshAllStatus)
 
-		// Grimmory integration.
-		r.Get("/grimmory/config", grimmoryHandler.GetConfig)
-		r.Put("/grimmory/config", grimmoryHandler.SetConfig)
-		r.Post("/grimmory/test", grimmoryHandler.Test)
+		// Grimmory integration — GetConfig open (redacts the key), writes admin.
+		// See registerGrimmoryRoutes.
+		registerGrimmoryRoutes(r, grimmoryHandler)
 
-		// Calibre integration — settings live under /setting/calibre.*,
-		// this endpoint just validates + probes the configured install.
-		r.Post("/calibre/test", calibreHandler.Test)
-
-		// Calibre library import (read side). Start is fire-and-forget;
-		// the UI polls Status while it runs.
-		r.Post("/calibre/import", calibreImportHandler.Start)
-		r.Get("/calibre/import/status", calibreImportHandler.Status)
-
-		// Calibre bulk push (write side). Iterates every imported book and
-		// POSTs its file to the plugin; 409 Conflict is treated as
-		// idempotent. Single-job policy — second call returns 409.
-		r.Post("/calibre/sync", calibreSyncHandler.Start)
-		r.Get("/calibre/sync/status", calibreSyncHandler.Status)
+		// Calibre integration (probe + library import + bulk push) — all
+		// admin-only. See registerCalibreIntegrationRoutes.
+		registerCalibreIntegrationRoutes(r, calibreHandler, calibreImportHandler, calibreSyncHandler)
 
 		// Calibre import run history + rollback (#643). Admin-only — a bad
 		// rollback can delete authors/books wholesale, so the destructive


### PR DESCRIPTION
## Problem

Three infra/credential surfaces sat outside `RequireAdmin`, reachable by any authenticated non-admin session:

- `/rootfolder` POST/DELETE — register or delete server filesystem storage roots
- `/grimmory/config` PUT + `/grimmory/test` — rewrite the Grimmory integration URL and API key
- `/calibre/test|import|sync` — credentialed probe, bulk author/book creation, and pushing the whole library out to an external plugin

That contradicts the boundary the rest of the router already enforces (indexers, download clients, prowlarr, notifications, backups, ABS, migrate are all admin-only).

## Fix

Extract these into `registerRootFolderRoutes` / `registerGrimmoryRoutes` / `registerCalibreIntegrationRoutes`, mirroring `sensitive_routes.go`, so the gate is a single testable shape. Wrap the mutations and credential-writes in `RequireAdmin`. Reads that expose no secrets stay open: `GET /rootfolder`, and `GET /grimmory/config` (which redacts the key).

## Tests

`integration_routes_test.go` asserts role=user is rejected on every gated route, admins still reach each handler, and the open reads stay reachable.

## Deliberately left open

`/library/scan` and `/authors/refresh-all` were flagged by the audit too, but they are content operations, not credential/infra surfaces. Gating them is a product call, so I left them and am flagging it here for your decision.

## Note on the original finding

`/migrate/*` was in the finding but is already admin-gated via `registerMigrateRoutes` — no change needed there.

## Verified

`go build ./...`, `go vet`, `go test ./cmd/bindery` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)