### PR TITLE
fix: read the ebook naming template from the key the Settings UI writes

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -1172,7 +1172,15 @@ func googleBooksAPIKey(ctx context.Context, settings *db.SettingsRepo) string {
 	return ""
 }
 
+// defaultNamingTemplate returns the operator's ebook naming template.
+// "naming.bookTemplate" is the key the Settings UI writes; "naming_template"
+// is the original backend-only key kept as a fallback for hand-seeded values
+// (#1356 — the two sides used different keys, so UI-configured templates were
+// silently ignored and every import fell back to the built-in default).
 func defaultNamingTemplate(settings *db.SettingsRepo) string {
+	if s, _ := settings.Get(context.Background(), "naming.bookTemplate"); s != nil && s.Value != "" {
+		return s.Value
+	}
 	if s, _ := settings.Get(context.Background(), "naming_template"); s != nil && s.Value != "" {
 		return s.Value
 	}

--- a/cmd/bindery/naming_template_test.go
+++ b/cmd/bindery/naming_template_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// The Settings UI writes the ebook naming template under "naming.bookTemplate";
+// "naming_template" is the legacy backend-only key. defaultNamingTemplate must
+// honour the UI key or every import silently falls back to the built-in
+// default layout (#1356).
+func TestDefaultNamingTemplate(t *testing.T) {
+	ctx := context.Background()
+	set := func(t *testing.T, repo *db.SettingsRepo, key, value string) {
+		t.Helper()
+		if err := repo.Set(ctx, key, value); err != nil {
+			t.Fatalf("set %s: %v", key, err)
+		}
+	}
+
+	tests := []struct {
+		name string
+		seed map[string]string
+		want string
+	}{
+		{name: "unset falls back to empty", want: ""},
+		{
+			name: "UI key is honoured",
+			seed: map[string]string{"naming.bookTemplate": "{Author}/{Series}/{Title}"},
+			want: "{Author}/{Series}/{Title}",
+		},
+		{
+			name: "legacy key still works",
+			seed: map[string]string{"naming_template": "{Author}/{Title}"},
+			want: "{Author}/{Title}",
+		},
+		{
+			name: "UI key wins over legacy",
+			seed: map[string]string{
+				"naming.bookTemplate": "{Author}/{Series}/{Title}",
+				"naming_template":     "{Author}/{Title}",
+			},
+			want: "{Author}/{Series}/{Title}",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database, err := db.OpenMemory()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { database.Close() })
+			repo := db.NewSettingsRepo(database)
+			for k, v := range tt.seed {
+				set(t, repo, k, v)
+			}
+			if got := defaultNamingTemplate(repo); got != tt.want {
+				t.Errorf("defaultNamingTemplate() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The Settings UI writes the ebook naming template to the `naming.bookTemplate` settings key (and has since v0.2.0). The backend seeds the importer's renamer from `naming_template` — a key nothing writes. So a UI-configured ebook template was silently ignored on every import, and the built-in default (`{Author}/{Title} ({Year})/{Title} - {Author}`) rendered instead. The field's live preview is computed client-side, so the UI showed the configured template applying while the server never saw it.

Fix Match made this visible (#1356): it re-imports through the same rename path, so it moved a correctly-placed file *out* of the user's configured series layout into the default layout. #1234 was the same mismatch seen from a library scan.

The audiobook template key (`naming_template_audiobook`) is consistent on both sides and unaffected.

## Fix

`defaultNamingTemplate` reads `naming.bookTemplate` first and keeps `naming_template` as a legacy fallback, following the existing `googleBooksAPIKey` legacy-key pattern in `cmd/bindery/main.go`.

## Tests

- New `TestDefaultNamingTemplate` (cmd/bindery): unset → empty, UI key honoured, legacy key still works, UI key wins when both are set.
- `go test ./cmd/bindery/`, `go vet` clean.

## Notes

The template is still read once at startup, matching existing behaviour — changing it in Settings applies after the next restart.

Closes #1356. Likely also the root cause behind the naming half of #1234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)