### PR TITLE
fix(httpsec): opt into iframe embedding via BINDERY_FRAME_ANCESTORS (#1367)

### DIFF
--- a/charts/bindery/values.yaml
+++ b/charts/bindery/values.yaml
@@ -81,6 +81,10 @@ env:
   # IP or CIDR of the reverse proxy in front of Bindery. When set, X-Forwarded-For
   # is trusted only from that address. Required for local-only auth mode to be safe.
   # BINDERY_TRUSTED_PROXY: "192.168.1.1"
+  # Allow the UI to be embedded in an <iframe> by a trusted dashboard (Organizr,
+  # etc.). Empty (default) blocks all framing. Set to a CSP frame-ancestors
+  # source list: 'self' for same-origin, or a specific origin. See #1367.
+  # BINDERY_FRAME_ANCESTORS: "https://organizr.example.com"
 
 resources:
   requests:

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -664,7 +664,7 @@ func main() {
 	r.Use(trustedProxyMiddleware())
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Compress(5))
-	r.Use(api.SecurityHeaders)
+	r.Use(api.SecurityHeaders(cfg.FrameAncestors))
 	// Cap JSON / form request bodies at 1 MiB by default so an authenticated
 	// client cannot pin the process by streaming a multi-gigabyte body into
 	// json.Decode. Routes that legitimately accept larger payloads opt in via

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -335,6 +335,7 @@ Bindery parks the download as *handed off* and reconciles the managed copy the e
 | `BINDERY_LOG_RETENTION_DAYS` | `14` | Days to retain persisted log entries in the SQLite log store before they are pruned. |
 | `BINDERY_TRUSTED_PROXY` | _(empty)_ | Comma-separated IP/CIDR list of reverse proxies trusted to set `X-Forwarded-*`. Bindery resolves the real client IP (for local-only auth and the per-IP login rate-limiter) by walking the `X-Forwarded-For` chain and only trusting hops in this list; it never trusts a client-supplied leftmost entry. An entry like `0.0.0.0/0` trusts every peer and effectively disables per-IP decisions. **Required** when proxy auth mode is active — Bindery refuses to start without it. |
 | `BINDERY_TELEMETRY_DISABLED` | _(unset)_ | Set to `true` to opt out of the daily anonymous telemetry ping before any DB setting exists (e.g. on first boot). Equivalent to `telemetry.enabled: false` in **Settings → General**, but takes effect before the first ping fires. |
+| `BINDERY_FRAME_ANCESTORS` | _(empty)_ | Allow the UI to be embedded in an `<iframe>` by a dashboard such as Organizr ([#1367](https://github.com/vavallee/bindery/issues/1367)). Empty (the default) blocks all framing (`Content-Security-Policy: frame-ancestors 'none'` + `X-Frame-Options: DENY`). Set it to a CSP `frame-ancestors` source list to opt in — `'self'` for same-origin framing, or a specific origin like `https://organizr.example.com` (space-separate multiple origins). When set, `X-Frame-Options` is dropped so it can't override the allowlist. Only allow origins you trust: framing widens clickjacking exposure. |
 
 ## Service URLs and the SSRF policy
 
@@ -407,7 +408,7 @@ auth:
   existingSecret: my-bindery-secret  # kubectl create secret generic my-bindery-secret --from-literal=apiKey=...
 ```
 
-**Response headers.** Every response now sets CSP, `X-Frame-Options: DENY`, `Referrer-Policy`, and — when TLS is in play — HSTS. If you previously embedded the Bindery UI in an `<iframe>`, `X-Frame-Options: DENY` will block it. No such usage is supported, but it's the most likely breakage vector.
+**Response headers.** Every response now sets CSP, `X-Frame-Options: DENY`, `Referrer-Policy`, and — when TLS is in play — HSTS. If you previously embedded the Bindery UI in an `<iframe>`, `X-Frame-Options: DENY` will block it; opt back in for a trusted dashboard origin with [`BINDERY_FRAME_ANCESTORS`](#environment-variables).
 
 ### From v0.10.x to v0.11.0
 

--- a/internal/api/securityheaders.go
+++ b/internal/api/securityheaders.go
@@ -1,26 +1,54 @@
 package api
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
 
-const cspValue = "default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+// cspTemplate is the Content-Security-Policy with a single %s placeholder for
+// the frame-ancestors source list, which is the only part configurable at
+// runtime (issue #1367).
+const cspTemplate = "default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; frame-ancestors %s; base-uri 'self'; form-action 'self'"
 
-// SecurityHeaders sets defensive HTTP response headers on every response.
-// It is mounted outside the auth middleware so 401 responses are also
-// protected.
-func SecurityHeaders(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		h := w.Header()
-		h.Set("X-Content-Type-Options", "nosniff")
-		h.Set("X-Frame-Options", "DENY")
-		h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
-		h.Set("Content-Security-Policy", cspValue)
+// SecurityHeaders returns middleware that sets defensive HTTP response headers
+// on every response. It is mounted outside the auth middleware so 401 responses
+// are also protected.
+//
+// frameAncestors controls whether the UI may be embedded in an <iframe>
+// (issue #1367 — dashboards such as Organizr). Empty (the default) locks
+// embedding down entirely: CSP `frame-ancestors 'none'` plus a belt-and-braces
+// `X-Frame-Options: DENY`. A non-empty value is used verbatim as the CSP
+// `frame-ancestors` source list — e.g. "'self'" for same-origin framing, or
+// "https://organizr.example.com" for a specific dashboard. X-Frame-Options is
+// then omitted, because it cannot express an origin allowlist and its
+// DENY/SAMEORIGIN values would override the more expressive CSP directive.
+func SecurityHeaders(frameAncestors string) func(http.Handler) http.Handler {
+	frameAncestors = strings.TrimSpace(frameAncestors)
+	locked := frameAncestors == ""
+	src := frameAncestors
+	if locked {
+		src = "'none'"
+	}
+	csp := fmt.Sprintf(cspTemplate, src)
 
-		// HSTS is meaningful only over a TLS connection. Setting it over plain
-		// HTTP would cause browsers to break future HTTP access with no benefit.
-		if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
-			h.Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
-		}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := w.Header()
+			h.Set("X-Content-Type-Options", "nosniff")
+			if locked {
+				h.Set("X-Frame-Options", "DENY")
+			}
+			h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			h.Set("Content-Security-Policy", csp)
 
-		next.ServeHTTP(w, r)
-	})
+			// HSTS is meaningful only over a TLS connection. Setting it over plain
+			// HTTP would cause browsers to break future HTTP access with no benefit.
+			if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
+				h.Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/internal/api/securityheaders_test.go
+++ b/internal/api/securityheaders_test.go
@@ -2,15 +2,26 @@ package api
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
-func TestSecurityHeaders_AlwaysPresent(t *testing.T) {
-	h := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+// lockedCSP is the Content-Security-Policy emitted with the default (empty)
+// frame-ancestors config — embedding fully blocked.
+var lockedCSP = fmt.Sprintf(cspTemplate, "'none'")
+
+// okHandler is a trivial 200 handler used to exercise the middleware.
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-	}))
+	})
+}
+
+func TestSecurityHeaders_AlwaysPresent(t *testing.T) {
+	h := SecurityHeaders("")(okHandler())
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()
@@ -27,27 +38,53 @@ func TestSecurityHeaders_AlwaysPresent(t *testing.T) {
 	check("X-Content-Type-Options", "nosniff")
 	check("X-Frame-Options", "DENY")
 	check("Referrer-Policy", "strict-origin-when-cross-origin")
-	check("Content-Security-Policy", cspValue)
+	check("Content-Security-Policy", lockedCSP)
 }
 
 func TestSecurityHeaders_CSP_ExactMatch(t *testing.T) {
-	h := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	h := SecurityHeaders("")(okHandler())
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
 	got := rr.Header().Get("Content-Security-Policy")
-	if got != cspValue {
-		t.Errorf("CSP mismatch:\n got  %q\n want %q", got, cspValue)
+	if got != lockedCSP {
+		t.Errorf("CSP mismatch:\n got  %q\n want %q", got, lockedCSP)
+	}
+}
+
+// When BINDERY_FRAME_ANCESTORS is set, the CSP frame-ancestors directive uses
+// the supplied source list and X-Frame-Options is dropped so it cannot override
+// the origin allowlist (issue #1367).
+func TestSecurityHeaders_FrameAncestors_AllowsEmbedding(t *testing.T) {
+	cases := []struct{ name, ancestors, wantSrc string }{
+		{"same-origin", "'self'", "'self'"},
+		{"specific-host", "https://organizr.example.com", "https://organizr.example.com"},
+		{"trims-whitespace", "  'self'  ", "'self'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := SecurityHeaders(tc.ancestors)(okHandler())
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+
+			if got := rr.Header().Get("X-Frame-Options"); got != "" {
+				t.Errorf("X-Frame-Options should be absent when framing is allowed, got %q", got)
+			}
+			wantCSP := fmt.Sprintf(cspTemplate, tc.wantSrc)
+			if got := rr.Header().Get("Content-Security-Policy"); got != wantCSP {
+				t.Errorf("CSP:\n got  %q\n want %q", got, wantCSP)
+			}
+			if got := rr.Header().Get("Content-Security-Policy"); !strings.Contains(got, "frame-ancestors "+tc.wantSrc) {
+				t.Errorf("CSP missing expected frame-ancestors %q: %q", tc.wantSrc, got)
+			}
+		})
 	}
 }
 
 func TestSecurityHeaders_HSTS_AbsentOverHTTP(t *testing.T) {
-	h := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	h := SecurityHeaders("")(okHandler())
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	// No TLS, no X-Forwarded-Proto header.
@@ -60,9 +97,7 @@ func TestSecurityHeaders_HSTS_AbsentOverHTTP(t *testing.T) {
 }
 
 func TestSecurityHeaders_HSTS_PresentWhenTLS(t *testing.T) {
-	h := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	h := SecurityHeaders("")(okHandler())
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.TLS = &tls.ConnectionState{} // signal TLS
@@ -76,9 +111,7 @@ func TestSecurityHeaders_HSTS_PresentWhenTLS(t *testing.T) {
 }
 
 func TestSecurityHeaders_HSTS_PresentWhenForwardedProto(t *testing.T) {
-	h := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	h := SecurityHeaders("")(okHandler())
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("X-Forwarded-Proto", "https")
@@ -92,9 +125,7 @@ func TestSecurityHeaders_HSTS_PresentWhenForwardedProto(t *testing.T) {
 }
 
 func TestSecurityHeaders_HSTS_AbsentWhenForwardedProtoHTTP(t *testing.T) {
-	h := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	h := SecurityHeaders("")(okHandler())
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("X-Forwarded-Proto", "http")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,14 @@ type Config struct {
 	// BINDERY_URL_BASE. Automatically normalised: leading slash added, trailing
 	// slash removed, full URLs truncated to their path component.
 	URLBase string
+	// FrameAncestors opts the UI out of the default clickjacking lockdown so it
+	// can be embedded in an <iframe> by a dashboard such as Organizr (issue
+	// #1367). Empty (the default) keeps embedding fully blocked
+	// (`frame-ancestors 'none'` + `X-Frame-Options: DENY`). A non-empty value is
+	// used verbatim as the CSP `frame-ancestors` source list, e.g. "'self'" for
+	// same-origin framing or "https://organizr.example.com" for a specific host.
+	// Set via BINDERY_FRAME_ANCESTORS.
+	FrameAncestors string
 	// OutboundProxy routes Bindery's remote-facing outbound HTTP (indexers,
 	// metadata providers, cover images, webhook notifications, telemetry)
 	// through a proxy. Set via BINDERY_OUTBOUND_PROXY as a single URL, e.g.
@@ -112,6 +120,7 @@ func Load() *Config {
 		RateLimitMaxFailures:     envInt("BINDERY_RATE_LIMIT_MAX_FAILURES", 5),
 		RateLimitWindowMinutes:   envInt("BINDERY_RATE_LIMIT_WINDOW_MINUTES", 15),
 		URLBase:                  normalizeURLBase(envOr("BINDERY_URL_BASE", "")),
+		FrameAncestors:           strings.TrimSpace(envOr("BINDERY_FRAME_ANCESTORS", "")),
 		OutboundProxy:            envOr("BINDERY_OUTBOUND_PROXY", ""),
 		OutboundProxyBypassLocal: envBool("BINDERY_OUTBOUND_PROXY_BYPASS_LOCAL", true),
 		OutboundProxyNoProxy:     envOr("BINDERY_OUTBOUND_PROXY_NO_PROXY", ""),

--- a/tests/security/headers_test.go
+++ b/tests/security/headers_test.go
@@ -13,7 +13,7 @@ import (
 // header is a regression against the v0.12.0 hardening.
 func TestSecurityHeaders_AlwaysPresent(t *testing.T) {
 	t.Parallel()
-	h := api.SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	h := api.SecurityHeaders("")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -40,7 +40,7 @@ func TestSecurityHeaders_AlwaysPresent(t *testing.T) {
 // without documenting the reason should fail this test.
 func TestSecurityHeaders_CSPLocksDownExternalOrigins(t *testing.T) {
 	t.Parallel()
-	h := api.SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	h := api.SecurityHeaders("")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -73,7 +73,7 @@ func TestSecurityHeaders_CSPLocksDownExternalOrigins(t *testing.T) {
 // it on plaintext would lock the browser into a host that doesn't speak TLS.
 func TestSecurityHeaders_HSTSOnlyUnderTLS(t *testing.T) {
 	t.Parallel()
-	h := api.SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	h := api.SecurityHeaders("")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 


### PR DESCRIPTION
Closes #1367.

## What
The UI could not be embedded in an `<iframe>` — `SecurityHeaders` hard-coded `X-Frame-Options: DENY` and CSP `frame-ancestors 'none'`, blocking use inside dashboards like Organizr. The lockdown stays the default; an admin can now opt in per trusted origin.

## How
- `SecurityHeaders` becomes a constructor taking a frame-ancestors source list from `BINDERY_FRAME_ANCESTORS`.
- Empty (default) → full clickjacking lockdown unchanged (`frame-ancestors 'none'` + `X-Frame-Options: DENY`).
- Non-empty (e.g. `'self'` or `https://organizr.example.com`) → used verbatim as the CSP `frame-ancestors` list; `X-Frame-Options` is omitted since it can't express an origin allowlist and `DENY`/`SAMEORIGIN` would override the more expressive CSP directive.

## Docs / config
- `docs/DEPLOYMENT.md` — env table row + upgrade note
- `charts/bindery/values.yaml` — commented example

## Tests
- New `TestSecurityHeaders_FrameAncestors_AllowsEmbedding` (table: `'self'`, specific host, whitespace-trim) asserts X-Frame-Options absent and CSP carries the source.
- Existing default-lockdown + HSTS tests updated to the constructor form.
- `go build` / `go vet` / `go test ./internal/api ./internal/config` / `helm lint --strict` all green.