### PR TITLE
fix(grimmory): surface the real test-connection error instead of 'Bad Gateway' (#1431)

### DIFF
--- a/changelog.d/1431-grimmory-test-error.md
+++ b/changelog.d/1431-grimmory-test-error.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Grimmory "Test Connection" failures now show the real error** (#1431) — a failed test displayed the bare HTTP status text ("Bad Gateway") instead of the actual diagnostic (connection refused, login rejected, upstream proxy error). The UI now surfaces the full message, upstream HTTP errors are labeled with their status code, and failures are logged server-side.

--- a/internal/api/grimmory.go
+++ b/internal/api/grimmory.go
@@ -209,6 +209,7 @@ func (h *GrimmoryHandler) Test(w http.ResponseWriter, r *http.Request) {
 
 	status, err := client.Ping(r.Context())
 	if err != nil {
+		slog.Warn("grimmory: test connection failed", "baseURL", baseURL, "error", err)
 		writeJSON(w, http.StatusBadGateway, grimmoryTestResponse{OK: false, Message: err.Error()})
 		return
 	}
@@ -219,6 +220,7 @@ func (h *GrimmoryHandler) Test(w http.ResponseWriter, r *http.Request) {
 	}
 	if client.HasCredentials() {
 		if err := client.VerifyAuth(r.Context()); err != nil {
+			slog.Warn("grimmory: test login failed", "baseURL", baseURL, "error", err)
 			writeJSON(w, http.StatusBadGateway, grimmoryTestResponse{
 				OK: false, Message: msg + ", but login failed: " + err.Error(), Version: status.Version,
 			})

--- a/internal/grimmory/client.go
+++ b/internal/grimmory/client.go
@@ -39,7 +39,15 @@ func (e *APIError) Error() string {
 	if e.Message == "" {
 		return fmt.Sprintf("grimmory api error (%d)", e.StatusCode)
 	}
-	return e.Message
+	// Always carry the upstream status: a reverse proxy in front of Grimmory
+	// answering 502 with "Bad Gateway" must read as "Grimmory's URL replied
+	// 502", not as an opaque failure inside Bindery (#1431). Bodies can be
+	// whole proxy error pages — keep the rendered message short.
+	msg := e.Message
+	if len(msg) > 300 {
+		msg = strings.ToValidUTF8(msg[:300], "") + " […]"
+	}
+	return fmt.Sprintf("grimmory api error (%d): %s", e.StatusCode, msg)
 }
 
 // StatusResponse is the shape returned by GET /api/status.

--- a/internal/grimmory/client_test.go
+++ b/internal/grimmory/client_test.go
@@ -363,8 +363,15 @@ func TestDo_OmitsAuthHeaderWhenKeyEmpty(t *testing.T) {
 func TestAPIError_Error(t *testing.T) {
 	t.Run("with message", func(t *testing.T) {
 		e := &APIError{StatusCode: 403, Message: "forbidden"}
-		if got := e.Error(); got != "forbidden" {
-			t.Errorf("Error() = %q, want %q", got, "forbidden")
+		want := "grimmory api error (403): forbidden"
+		if got := e.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+	t.Run("long body truncated", func(t *testing.T) {
+		e := &APIError{StatusCode: 502, Message: strings.Repeat("x", 1000)}
+		if got := e.Error(); len(got) > 350 || !strings.HasSuffix(got, "[…]") {
+			t.Errorf("Error() not truncated: len=%d %q", len(got), got[:50])
 		}
 	})
 	t.Run("empty message fallback", func(t *testing.T) {

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -114,3 +114,34 @@ describe('api/client CSRF handling', () => {
     expect(logoutCSRF).toBe('cookie-token')
   })
 })
+
+describe('ApiError message extraction', () => {
+  it('surfaces a `message`-shaped failure body instead of the HTTP status text (#1431)', async () => {
+    server.use(
+      http.post(apiUrl('/grimmory/test'), () =>
+        HttpResponse.json(
+          { ok: false, message: 'grimmory login: dial tcp 192.168.1.5:6060: connection refused' },
+          { status: 502 },
+        ),
+      ),
+    )
+
+    const { api } = await loadClient()
+
+    await expect(api.grimmoryTest({ baseUrl: 'http://192.168.1.5:6060' })).rejects.toThrow(
+      /connection refused/,
+    )
+  })
+
+  it('prefers `error` over `message` when both are present', async () => {
+    server.use(
+      http.post(apiUrl('/grimmory/test'), () =>
+        HttpResponse.json({ error: 'primary', message: 'secondary' }, { status: 502 }),
+      ),
+    )
+
+    const { api } = await loadClient()
+
+    await expect(api.grimmoryTest()).rejects.toThrow('primary')
+  })
+})

--- a/web/src/api/core.ts
+++ b/web/src/api/core.ts
@@ -56,10 +56,13 @@ const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
 // unaffected.
 export class ApiError extends Error {
   status: number
-  body: { error?: string; [key: string]: unknown }
+  body: { error?: string; message?: string; [key: string]: unknown }
 
-  constructor(status: number, body: { error?: string; [key: string]: unknown }, fallback: string) {
-    super(body.error || fallback)
+  constructor(status: number, body: { error?: string; message?: string; [key: string]: unknown }, fallback: string) {
+    // Some endpoints report failures under `message` instead of `error`
+    // (e.g. POST /grimmory/test) — without this fallback the user sees the
+    // bare HTTP status text ("Bad Gateway") instead of the diagnostic (#1431).
+    super(body.error || body.message || fallback)
     this.name = 'ApiError'
     this.status = status
     this.body = body


### PR DESCRIPTION
Fixes #1431.

Every failed Grimmory Test Connection displayed as a bare "Bad Gateway" no matter what actually went wrong. The Test endpoint returns its diagnostic in a `message` JSON field, but the frontend's `ApiError` only reads `body.error`, so it always fell back to the HTTP status text, and a 502 status text is literally "Bad Gateway". The real reason (connection refused, TLS failure, login rejected) was thrown away. The reporter also correctly noted nothing showed in the logs: the handler never logged test failures.

Changes:
- `ApiError` falls back to `body.message` before the status text, fixing this for any endpoint that reports failures that way
- Grimmory `APIError` now always renders with its upstream status code and truncates long proxy error pages, so a reverse proxy in front of Grimmory answering 502 reads as `grimmory api error (502): ...` and is distinguishable from Bindery failing to connect at all
- Test-connection failures (ping and login) are logged with `slog.Warn` including the base URL

Tests: new vitest cases for the `message` fallback and `error` precedence, Go test updated for the new `APIError` rendering plus a truncation case. `go test ./internal/grimmory ./internal/api` and the web suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)