### PR TITLE
fix(downloader): correct error-203 guidance — Prowlarr can't disable Redirect for Usenet (#1424)

### DIFF
--- a/changelog.d/1424-error-203-guidance.md
+++ b/changelog.d/1424-error-203-guidance.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Error 203 guidance no longer points at a setting that can't be changed** (#1424) — the NZB grab error and the Troubleshooting wiki suggested disabling Prowlarr's per-indexer Redirect setting, which Prowlarr requires for Usenet indexers. Both now explain the real situation: application-whitelisting indexers (like NZBFinder) have to approve Bindery's identity, tracked in #1425.

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -37,9 +37,15 @@ fetch nzb: indexer refused the download (HTTP 400, newznab error 203:
 This application is not allowed to download NZBs from NZBFinder.)
 ```
 
-Some indexers (NZBFinder is the known case) restrict NZB downloads to a whitelist of approved applications. Prowlarr is on that list; Bindery is not. When Prowlarr performs the download itself and hands Bindery the file, the indexer sees Prowlarr and allows it. But if the indexer's **Redirect** setting is enabled in Prowlarr, Prowlarr answers Bindery's grab with a redirect straight to the indexer instead of proxying it — the indexer then sees Bindery, and rejects the download with error 203. The error message names both hosts when this hand-off happened.
+Some indexers (NZBFinder is the known case) restrict API access to a whitelist of approved applications, keyed on the client's identity rather than your API key. Prowlarr is on that list; Bindery is not yet. Prowlarr answers Bindery's grab with a redirect straight to the indexer (its per-indexer **Redirect** setting), so the indexer sees Bindery's own identity and rejects the download with error 203. The error message names both hosts when this hand-off happened.
 
-**Fix:** in Prowlarr, open **Settings → Indexers → (the indexer)**, show advanced settings, and disable **Redirect**. Prowlarr then downloads the NZB itself with its whitelisted identity and streams it to Bindery. This only matters for whitelisting indexers — Redirect is safe to leave on for indexers that don't restrict by application.
+There is **no user-side workaround**:
+
+- Disabling Redirect in Prowlarr is not possible for Usenet indexers — Prowlarr requires it and no longer proxies NZB downloads itself (earlier versions of this page and of Bindery's error text suggested that setting; that advice was wrong, see #1424).
+- Adding the indexer to Bindery directly doesn't help either: the whitelist covers the whole newznab API, so searches fail with the same error 203 even with a valid API key (#1404).
+- Bindery always identifies itself honestly as `bindery/<version>` and will not impersonate Prowlarr or an arr to get around a whitelist.
+
+**Fix:** the indexer has to add Bindery to its approved applications. For NZBFinder that request is underway (#1425 tracks it) — if you're a member there, asking them too genuinely helps. For other whitelisting indexers, point them at Bindery's stable User-Agent (`bindery/<version>`) and the request pattern (standard newznab caps/search/download on the user's own API key, same as Readarr).
 
 ## "Could not reach the metadata provider" / OpenLibrary timeout
 

--- a/internal/downloader/nzbfetch/nzbfetch.go
+++ b/internal/downloader/nzbfetch/nzbfetch.go
@@ -40,7 +40,10 @@ type newznabError struct {
 // instead of the proxy's (Prowlarr etc.), which is exactly how app-whitelisting
 // indexers like NZBFinder come to reject the grab with error 203 even though
 // the same release downloads fine from inside Prowlarr (#1404). That hop is
-// therefore called out, with the Prowlarr setting that removes it.
+// called out so the failure is explainable, but there is no user-side setting
+// that removes it: Prowlarr refuses to disable Redirect for Usenet indexers
+// and no longer proxies NZB downloads (#1424), so the only real fix is the
+// indexer whitelisting Bindery's identity (#1425).
 func Error(requestedURL string, resp *http.Response, body []byte) error {
 	msg := describeBody(resp.StatusCode, body)
 	if hop := crossHostHop(requestedURL, resp); hop != "" {
@@ -76,5 +79,5 @@ func crossHostHop(requestedURL string, resp *http.Response) string {
 	if from == "" || to == "" || from == to {
 		return ""
 	}
-	return fmt.Sprintf(" — the download request was redirected from %q to %q, so the indexer saw Bindery directly instead of the app that performed the search. If %q is Prowlarr, disable this indexer's Redirect setting there (Settings → Indexers → indexer → Redirect, advanced) so Prowlarr downloads the NZB itself with its own whitelisted identity", from, to, from)
+	return fmt.Sprintf(" — the download request was redirected from %q to %q, so the indexer saw Bindery directly instead of the app that performed the search. Indexers that whitelist applications (NZBFinder is the known case) reject that with error 203. No Prowlarr setting avoids this hop: Prowlarr requires Redirect for Usenet indexers and no longer proxies NZB downloads. The fix is the indexer adding Bindery to its approved applications — see the error 203 entry in the Troubleshooting wiki", from, to)
 }

--- a/internal/downloader/nzbfetch/nzbfetch_test.go
+++ b/internal/downloader/nzbfetch/nzbfetch_test.go
@@ -40,12 +40,13 @@ func TestError_ParsesNewznabErrorDocument(t *testing.T) {
 
 // The #1404 shape: the release's nzbUrl points at Prowlarr, Prowlarr 302s to
 // the indexer (its per-indexer Redirect setting), the indexer rejects
-// Bindery's identity. The error must name both hosts and the Prowlarr setting.
+// Bindery's identity. The error must name both hosts and explain that the fix
+// is indexer-side whitelisting — Prowlarr can't proxy Usenet grabs (#1424).
 func TestError_CrossHostRedirectAddsProwlarrGuidance(t *testing.T) {
 	err := Error("http://prowlarr:9696/3/download?apikey=k&link=abc", &http.Response{StatusCode: 400, Request: endedAt(t, "https://nzbfinder.ws/getnzb/abc")}, []byte(nzbfinder203))
 
 	msg := err.Error()
-	for _, want := range []string{"newznab error 203", `redirected from "prowlarr" to "nzbfinder.ws"`, "Redirect setting", "whitelisted identity"} {
+	for _, want := range []string{"newznab error 203", `redirected from "prowlarr" to "nzbfinder.ws"`, "approved applications", "No Prowlarr setting avoids this hop"} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error missing %q: %s", want, msg)
 		}

--- a/internal/downloader/sabnzbd/fetch_diagnostics_test.go
+++ b/internal/downloader/sabnzbd/fetch_diagnostics_test.go
@@ -16,8 +16,8 @@ const nzbfinder203Body = `<?xml version="1.0" encoding="UTF-8"?>
 // URL points at a Prowlarr-style proxy which 302-redirects to the indexer
 // (Prowlarr's per-indexer Redirect setting), and the indexer rejects Bindery's
 // identity with newznab error 203. The resulting error must surface the
-// structured newznab error plus the redirect hop and the Prowlarr fix, instead
-// of the raw XML soup the log used to carry.
+// structured newznab error plus the redirect hop and the whitelist guidance
+// (#1424), instead of the raw XML soup the log used to carry.
 //
 // The proxy is addressed as "localhost" and redirects to "127.0.0.1" so the
 // two ends of the hop have different hostnames, like prowlarr → nzbfinder.ws.
@@ -52,7 +52,7 @@ func TestAddURL_ProwlarrRedirectRejection(t *testing.T) {
 		"newznab error 203",
 		"not allowed to download NZBs",
 		`redirected from "localhost" to "127.0.0.1"`,
-		"Redirect setting",
+		"approved applications",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error missing %q:\n%s", want, msg)


### PR DESCRIPTION
Fixes #1424.

The v1.24.0 cross-host-hop diagnostic and the Troubleshooting wiki both told users to disable the indexer's Redirect setting in Prowlarr. That setting can't be disabled for Usenet indexers (Prowlarr hard-requires it and no longer proxies NZB downloads), so the guidance sent people to a dead end — confirmed by the reporter on #1404, who also proved the whitelist gates the entire newznab API by application identity, not just downloads.

Text-only change:
- `crossHostHop` suffix now explains that whitelisting indexers reject the hop, no Prowlarr setting avoids it, and the fix is indexer-side approval of Bindery (with a pointer to the wiki entry)
- Troubleshooting wiki entry rewritten: whole-API whitelist keyed on client identity, no user-side workaround, honest identity policy, NZBFinder request tracked in #1425, guidance for other whitelisting indexers
- Tests updated to pin the new wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)