### PR TITLE
fix(importer): stop hiding untracked sibling ebooks from the library scan (#1436)

### DIFF
--- a/changelog.d/1436-scan-sibling-skip.md
+++ b/changelog.d/1436-scan-sibling-skip.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Library scan no longer hides untracked ebooks that share a folder with a tracked one** (#1436) — in a flat `Author/Title.epub` layout, one registered file made the scan silently skip every sibling ebook in that author folder, and the skipped files were missing from the result counts entirely. Folder-level suppression now only applies to audiobook folders, and the scan result shows an "Already tracked" count so files found always adds up.

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1707,7 +1707,7 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 	slog.Info("library scan found files", "paths", []string{s.libraryDir, s.audiobookDir}, "count", len(foundFiles))
 
 	if len(foundFiles) == 0 {
-		s.writeScanResult(ctx, len(foundFiles), 0, 0, 0, nil)
+		s.writeScanResult(ctx, len(foundFiles), 0, 0, 0, 0, nil)
 		return
 	}
 
@@ -1722,16 +1722,20 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		return
 	}
 
-	// Build a set of tracked file paths AND their parent directories.
-	// Populated from book_files (all registered paths, not just the first per
-	// format) so that multi-file books don't show their non-first files as
-	// untracked on subsequent scans.
+	// Build a set of tracked file paths, plus the parent directories of
+	// tracked AUDIO files: a multi-track audiobook registers one path but its
+	// folder holds sibling tracks belonging to the same book. Ebook parents
+	// must not be tracked — in a flat Author/Title.epub layout the parent is
+	// the author folder, and tracking it hid every untracked sibling ebook in
+	// that folder from the scan (#1436).
 	trackedPaths := make(map[string]bool)
 	if allPaths, err := s.books.ListAllBookFilePaths(ctx); err == nil {
 		for _, p := range allPaths {
 			cleanP := filepath.Clean(p)
 			trackedPaths[cleanP] = true
-			trackedPaths[filepath.Clean(filepath.Dir(cleanP))] = true
+			if detectDownloadFormat([]string{cleanP}) == models.MediaTypeAudiobook {
+				trackedPaths[filepath.Clean(filepath.Dir(cleanP))] = true
+			}
 		}
 	}
 
@@ -1858,7 +1862,7 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 	}
 
 	var unmatchedFiles []unmatchedFile
-	var reconciled, unmatched, tagReadFailed int
+	var reconciled, unmatched, alreadyTracked, tagReadFailed int
 
 	// tryReconcileTitle attempts to reconcile path to the given wanted book via
 	// the fuzzy title tier, returning true once a book is claimed. The
@@ -1900,16 +1904,24 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 		}
 		slog.Info("library scan: reconciled book", "title", b.Title, "path", path, "jw", jwScore)
 		trackedPaths[cleanPath] = true
+		if detectedFmt == models.MediaTypeAudiobook {
+			// Sibling tracks of a just-reconciled audiobook folder belong to
+			// this book — count them as tracked, not unmatched.
+			trackedPaths[filepath.Clean(filepath.Dir(cleanPath))] = true
+		}
 		reconciledBooks[b.ID] = true
 		reconciled++
 		return true
 	}
 
 	for _, path := range foundFiles {
-		// Skip files already tracked, or files inside a tracked directory
-		// (individual tracks inside an already-imported audiobook folder).
+		// Files already registered, and sibling tracks inside a tracked
+		// audiobook folder, are counted instead of silently skipped so
+		// files_found always equals reconciled + unmatched + already_tracked
+		// (#1436).
 		cleanPath := filepath.Clean(path)
 		if trackedPaths[cleanPath] || trackedPaths[filepath.Clean(filepath.Dir(cleanPath))] {
+			alreadyTracked++
 			continue
 		}
 
@@ -1979,6 +1991,9 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 				}
 				slog.Info("library scan: reconciled book via ASIN", "asin", parsed.ASIN, "title", b.Title, "path", path)
 				trackedPaths[cleanPath] = true
+				if detectedFmt == models.MediaTypeAudiobook {
+					trackedPaths[filepath.Clean(filepath.Dir(cleanPath))] = true
+				}
 				reconciledBooks[b.ID] = true
 				reconciled++
 				matched = true
@@ -2031,6 +2046,9 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 						slog.Info("library scan: reconciled book via series position",
 							"series", parsed.Series, "position", parsed.SeriesNumber, "title", book.Title, "path", path)
 						trackedPaths[cleanPath] = true
+						if detectedFmt == models.MediaTypeAudiobook {
+							trackedPaths[filepath.Clean(filepath.Dir(cleanPath))] = true
+						}
 						reconciledBooks[book.ID] = true
 						reconciled++
 						matched = true
@@ -2065,7 +2083,7 @@ func (s *Scanner) ScanLibrary(ctx context.Context) {
 	slog.Info("library scan complete", "paths", scanRoots, "bookFiles", len(foundFiles),
 		"reconciled", reconciled, "unmatched", unmatched, "tagReadFailed", tagReadFailed)
 
-	s.writeScanResult(ctx, len(foundFiles), reconciled, unmatched, tagReadFailed, unmatchedFiles)
+	s.writeScanResult(ctx, len(foundFiles), reconciled, unmatched, alreadyTracked, tagReadFailed, unmatchedFiles)
 }
 
 // isReconcileCandidate reports whether a book should be considered for
@@ -2153,19 +2171,19 @@ type unmatchedFile struct {
 // shape as a normal scan — zero counts plus a non-empty scan_error message the
 // frontend renders the same way as the other scan-outcome warnings.
 func (s *Scanner) writeScanError(ctx context.Context, message string) {
-	s.writeScanResultWithError(ctx, 0, 0, 0, 0, nil, message)
+	s.writeScanResultWithError(ctx, 0, 0, 0, 0, 0, nil, message)
 }
 
 // writeScanResult persists the scan summary to the settings table under
 // "library.lastScan" so the UI can surface the result without polling logs.
-func (s *Scanner) writeScanResult(ctx context.Context, filesFound, reconciled, unmatched, tagReadFailed int, unmatchedFiles []unmatchedFile) {
-	s.writeScanResultWithError(ctx, filesFound, reconciled, unmatched, tagReadFailed, unmatchedFiles, "")
+func (s *Scanner) writeScanResult(ctx context.Context, filesFound, reconciled, unmatched, alreadyTracked, tagReadFailed int, unmatchedFiles []unmatchedFile) {
+	s.writeScanResultWithError(ctx, filesFound, reconciled, unmatched, alreadyTracked, tagReadFailed, unmatchedFiles, "")
 }
 
 // writeScanResultWithError is the shared writer for both successful scans and
 // early-return failures. scanError is empty for a normal scan and a
 // user-facing message when the scan could not complete (#965).
-func (s *Scanner) writeScanResultWithError(ctx context.Context, filesFound, reconciled, unmatched, tagReadFailed int, unmatchedFiles []unmatchedFile, scanError string) {
+func (s *Scanner) writeScanResultWithError(ctx context.Context, filesFound, reconciled, unmatched, alreadyTracked, tagReadFailed int, unmatchedFiles []unmatchedFile, scanError string) {
 	if s.settings == nil {
 		return
 	}
@@ -2214,9 +2232,9 @@ func (s *Scanner) writeScanResultWithError(ctx context.Context, filesFound, reco
 	}
 
 	payload := fmt.Sprintf(
-		`{"ran_at":%q,"files_found":%d,"reconciled":%d,"unmatched":%d,"tag_read_failed":%d,"unmatched_files":%s,"library_dir":%q,"audiobook_dir":%q,"scanned_paths":%s,"no_files_found":%t,"scan_error":%s}`,
+		`{"ran_at":%q,"files_found":%d,"reconciled":%d,"unmatched":%d,"already_tracked":%d,"tag_read_failed":%d,"unmatched_files":%s,"library_dir":%q,"audiobook_dir":%q,"scanned_paths":%s,"no_files_found":%t,"scan_error":%s}`,
 		time.Now().UTC().Format(time.RFC3339),
-		filesFound, reconciled, unmatched, tagReadFailed,
+		filesFound, reconciled, unmatched, alreadyTracked, tagReadFailed,
 		unmatchedJSON,
 		s.libraryDir, s.audiobookDir, pathsJSON, noFilesFound, scanErrorJSON,
 	)

--- a/internal/importer/scanner_trackedpaths_test.go
+++ b/internal/importer/scanner_trackedpaths_test.go
@@ -1,0 +1,133 @@
+package importer
+
+// Regression tests for #1436: ScanLibrary tracked one registered file's parent
+// directory for every format, so in a flat Author/Title.epub layout one
+// tracked book hid every untracked sibling ebook in the same author folder —
+// silently, with the skips counted nowhere ("6 found, 0 reconciled, 2
+// unmatched"). Parent-dir suppression is now scoped to audiobook folders and
+// every walked file lands in exactly one counter.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func trackedPathsFixture(t *testing.T) (s *Scanner, books *db.BookRepo, authors *db.AuthorRepo, settings *db.SettingsRepo, libDir string, ctx context.Context) {
+	t.Helper()
+	libDir = t.TempDir()
+	s, books, authors, settings, ctx = visibilityFixture(t, libDir, "")
+	return
+}
+
+func createScanAuthor(t *testing.T, ctx context.Context, authors *db.AuthorRepo) *models.Author {
+	t.Helper()
+	author := &models.Author{ForeignID: "ol:doe", Name: "Jane Doe", SortName: "Doe, Jane", Monitored: true, MetadataProvider: "openlibrary"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	return author
+}
+
+func createScanBook(t *testing.T, ctx context.Context, books *db.BookRepo, authorID int64, foreignID, title, status, mediaType string) *models.Book {
+	t.Helper()
+	book := &models.Book{
+		ForeignID: foreignID, AuthorID: authorID, Title: title, SortTitle: title,
+		Status: status, Monitored: true, AnyEditionOK: true,
+		MediaType: mediaType, MetadataProvider: "openlibrary",
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	return book
+}
+
+// TestScanLibrary_TrackedSiblingEbooksStillScanned is the flat-layout repro:
+// three epubs in one author folder, one of them already registered. The two
+// untracked siblings must be reconciled, not silently skipped because their
+// parent directory carries a tracked file, and the counters must add up.
+func TestScanLibrary_TrackedSiblingEbooksStillScanned(t *testing.T) {
+	s, books, authors, settings, libDir, ctx := trackedPathsFixture(t)
+	author := createScanAuthor(t, ctx, authors)
+
+	dir := filepath.Join(libDir, "Jane Doe")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	trackedPath := write("Alpha Adventure.epub")
+	write("Beta Business.epub")
+	write("Gamma Games.epub")
+
+	tracked := createScanBook(t, ctx, books, author.ID, "ol:alpha", "Alpha Adventure", models.BookStatusImported, models.MediaTypeEbook)
+	if err := books.AddBookFile(ctx, tracked.ID, models.MediaTypeEbook, trackedPath); err != nil {
+		t.Fatal(err)
+	}
+	createScanBook(t, ctx, books, author.ID, "ol:beta", "Beta Business", models.BookStatusWanted, models.MediaTypeEbook)
+	createScanBook(t, ctx, books, author.ID, "ol:gamma", "Gamma Games", models.BookStatusWanted, models.MediaTypeEbook)
+
+	s.ScanLibrary(ctx)
+
+	p := readScanResult(t, ctx, settings)
+	if p.FilesFound != 3 {
+		t.Fatalf("FilesFound = %d, want 3", p.FilesFound)
+	}
+	if p.Reconciled != 2 {
+		t.Errorf("Reconciled = %d, want 2 (siblings of a tracked ebook must still be scanned)", p.Reconciled)
+	}
+	if p.AlreadyTrack != 1 {
+		t.Errorf("AlreadyTrack = %d, want 1 (the registered file itself)", p.AlreadyTrack)
+	}
+	if got := p.Reconciled + p.Unmatched + p.AlreadyTrack; got != p.FilesFound {
+		t.Errorf("counters don't add up: reconciled+unmatched+already_tracked = %d, files_found = %d", got, p.FilesFound)
+	}
+}
+
+// TestScanLibrary_AudiobookFolderSiblingsCountAsTracked pins the behaviour the
+// directory tracking was built for: sibling tracks inside an already-imported
+// audiobook folder are still suppressed, but now show up in already_tracked
+// instead of vanishing from the totals.
+func TestScanLibrary_AudiobookFolderSiblingsCountAsTracked(t *testing.T) {
+	s, books, authors, settings, libDir, ctx := trackedPathsFixture(t)
+	author := createScanAuthor(t, ctx, authors)
+
+	dir := filepath.Join(libDir, "Jane Doe", "Delta Drama")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	track1 := filepath.Join(dir, "01 - track.mp3")
+	track2 := filepath.Join(dir, "02 - track.mp3")
+	for _, p := range []string{track1, track2} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	book := createScanBook(t, ctx, books, author.ID, "ol:delta", "Delta Drama", models.BookStatusImported, models.MediaTypeAudiobook)
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, track1); err != nil {
+		t.Fatal(err)
+	}
+
+	s.ScanLibrary(ctx)
+
+	p := readScanResult(t, ctx, settings)
+	if p.FilesFound != 2 {
+		t.Fatalf("FilesFound = %d, want 2", p.FilesFound)
+	}
+	if p.Unmatched != 0 {
+		t.Errorf("Unmatched = %d, want 0 (sibling track belongs to the tracked audiobook)", p.Unmatched)
+	}
+	if p.AlreadyTrack != 2 {
+		t.Errorf("AlreadyTrack = %d, want 2 (registered track + sibling in its folder)", p.AlreadyTrack)
+	}
+}

--- a/internal/importer/scanner_visibility_test.go
+++ b/internal/importer/scanner_visibility_test.go
@@ -23,6 +23,7 @@ type scanResultPayload struct {
 	FilesFound   int      `json:"files_found"`
 	Reconciled   int      `json:"reconciled"`
 	Unmatched    int      `json:"unmatched"`
+	AlreadyTrack int      `json:"already_tracked"`
 	TagReadFail  int      `json:"tag_read_failed"`
 	LibraryDir   string   `json:"library_dir"`
 	AudiobookDir string   `json:"audiobook_dir"`

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -636,6 +636,7 @@
       "filesFound": "Files found:",
       "reconciled": "Reconciled:",
       "unmatched": "Unmatched:",
+      "alreadyTracked": "Already tracked:",
       "scannedPaths": "Scanned:",
       "scanNoFilesWarning": "No book files found under {{path}} — check BINDERY_LIBRARY_DIR points at your library.",
       "scanAllUnmatchedHint": "Files were found but none matched a book. Unmatched files need their author's book catalogue populated first — refresh the author (or re-run the import so it fetches books) and scan again.",

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -34,6 +34,7 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
     files_found: number
     reconciled: number
     unmatched: number
+    already_tracked?: number
     tag_read_failed?: number
     unmatched_files?: Array<{ path: string; parsed_title: string; parsed_author: string }>
     library_dir?: string
@@ -436,6 +437,9 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
                 <span>{t('settings.general.filesFound')} <span className="font-mono text-slate-800 dark:text-zinc-200">{lastScan.files_found}</span></span>
                 <span>{t('settings.general.reconciled')} <span className="font-mono text-emerald-700 dark:text-emerald-400">{lastScan.reconciled}</span></span>
                 <span>{t('settings.general.unmatched')} <span className="font-mono text-slate-800 dark:text-zinc-200">{lastScan.unmatched}</span></span>
+                {(lastScan.already_tracked ?? 0) > 0 && (
+                  <span>{t('settings.general.alreadyTracked')} <span className="font-mono text-slate-800 dark:text-zinc-200">{lastScan.already_tracked}</span></span>
+                )}
               </div>
               <p className="mt-1 text-slate-500 dark:text-zinc-500">
                 {new Date(lastScan.ran_at).toLocaleString()}


### PR DESCRIPTION
Fixes #1436.

ScanLibrary seeds `trackedPaths` with each registered file's parent directory so sibling tracks of an imported audiobook folder don't show up as untracked. In a flat `Author/Title.epub` layout that misfires: the parent is the author folder, so one tracked book silently hides every untracked sibling ebook in it. The skips were also counted nowhere, which is how Daize's scan reported "6 found, 0 reconciled, 2 unmatched" with 4 files unaccounted for.

Changes:
- Parent-directory suppression is scoped to audio files, both when seeding from `book_files` and when a reconcile lands during the scan (sibling tracks of a just-reconciled audiobook count as tracked instead of unmatched)
- Files skipped as already registered (exact path or tracked audiobook folder) are counted in a new `already_tracked` result field, so `files_found = reconciled + unmatched + already_tracked` always holds
- The Last scan result panel shows "Already tracked: N" when non-zero

Tests: two regressions — the flat-layout repro (siblings must reconcile, counters must add up) and the audiobook-folder parity case (siblings still suppressed, now counted). Full importer suite and web settings tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)