### PR TITLE
fix(web): show the source path on bulk import rows (#1435)

### DIFF
--- a/changelog.d/1435-bulk-import-paths.md
+++ b/changelog.d/1435-bulk-import-paths.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Bulk folder import shows the full source path on every row** (#1435) — previously only the basename was shown, so with an ambiguous match there was no way to tell which file the "pick a book" dropdown referred to.

--- a/web/src/pages/settings/ImportTab.tsx
+++ b/web/src/pages/settings/ImportTab.tsx
@@ -392,6 +392,10 @@ export function FolderScanSection() {
                       {matchBadge(it.match)}
                       <span className="text-[10px] px-1.5 py-0.5 bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400 rounded">{it.detectedFormat}</span>
                     </div>
+                    {/* Full source path so the user can tell which file a match
+                        (or the ambiguous picker below) refers to — the basename
+                        alone is ambiguous across folders (#1435). */}
+                    <div className="text-xs font-mono text-slate-500 dark:text-zinc-600 truncate" title={it.path}>{it.path}</div>
                     <div className="text-xs text-slate-500 dark:text-zinc-600 truncate">
                       {t('settings.import.bulkParsed', { title: it.parsedTitle || '?', author: it.parsedAuthor || '?', defaultValue: `parsed: ${it.parsedTitle || '?'} / ${it.parsedAuthor || '?'}` })}
                     </div>


### PR DESCRIPTION
Fixes #1435.

Bulk folder import rendered only the immediate child's basename per row; the full source path was in the scan payload but only ever shown in the post-import failure list. With an ambiguous match the user couldn't tell which file they were picking a book for (reported by Daize on Discord, July 6).

Each row now shows the full source path in a muted mono line under the name, truncated with the full value on hover. Web typecheck and settings tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)