### PR TITLE
chore(release): changelog for v1.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.24.1] — 2026-07-06
+
+A patch cut of fixes surfaced by the community in the days after v1.24.0: two
+were Bindery giving actively wrong information (a dead-end fix for NZBFinder's
+error 203, and Grimmory test failures rendering as an opaque "Bad Gateway"),
+and two were the library scan and bulk import silently mishandling flat
+`Author/Title.epub` layouts.
+
+### Fixed
+- **Error 203 guidance no longer points at a setting that can't be changed**
+  (#1424) — the NZB grab error and the Troubleshooting wiki suggested
+  disabling Prowlarr's per-indexer Redirect setting, which Prowlarr requires
+  for Usenet indexers. Both now explain the real situation:
+  application-whitelisting indexers (like NZBFinder) have to approve
+  Bindery's identity, tracked in #1425.
+- **Grimmory "Test Connection" failures now show the real error** (#1431) — a
+  failed test displayed the bare HTTP status text ("Bad Gateway") instead of
+  the actual diagnostic (connection refused, login rejected, upstream proxy
+  error). The UI now surfaces the full message, upstream HTTP errors are
+  labeled with their status code, and failures are logged server-side.
+- **Bulk folder import shows the full source path on every row** (#1435) —
+  previously only the basename was shown, so an ambiguous match gave no way
+  to tell which file the "pick a book" dropdown referred to.
+- **Library scan no longer hides untracked ebooks that share a folder with a
+  tracked one** (#1436) — in a flat `Author/Title.epub` layout, one
+  registered file made the scan silently skip every sibling ebook in that
+  author folder, and the skipped files were missing from the result counts
+  entirely. Folder-level suppression now only applies to audiobook folders,
+  and the scan result shows an "Already tracked" count so files found always
+  adds up.
+
 ## [v1.24.0] — 2026-07-04
 
 The Grimmory integration goes from a settings tab nothing read to a working

--- a/changelog.d/1424-error-203-guidance.md
+++ b/changelog.d/1424-error-203-guidance.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Error 203 guidance no longer points at a setting that can't be changed** (#1424) — the NZB grab error and the Troubleshooting wiki suggested disabling Prowlarr's per-indexer Redirect setting, which Prowlarr requires for Usenet indexers. Both now explain the real situation: application-whitelisting indexers (like NZBFinder) have to approve Bindery's identity, tracked in #1425.

--- a/changelog.d/1431-grimmory-test-error.md
+++ b/changelog.d/1431-grimmory-test-error.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Grimmory "Test Connection" failures now show the real error** (#1431) — a failed test displayed the bare HTTP status text ("Bad Gateway") instead of the actual diagnostic (connection refused, login rejected, upstream proxy error). The UI now surfaces the full message, upstream HTTP errors are labeled with their status code, and failures are logged server-side.

--- a/changelog.d/1435-bulk-import-paths.md
+++ b/changelog.d/1435-bulk-import-paths.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Bulk folder import shows the full source path on every row** (#1435) — previously only the basename was shown, so with an ambiguous match there was no way to tell which file the "pick a book" dropdown referred to.

--- a/changelog.d/1436-scan-sibling-skip.md
+++ b/changelog.d/1436-scan-sibling-skip.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Library scan no longer hides untracked ebooks that share a folder with a tracked one** (#1436) — in a flat `Author/Title.epub` layout, one registered file made the scan silently skip every sibling ebook in that author folder, and the skipped files were missing from the result counts entirely. Folder-level suppression now only applies to audiobook folders, and the scan result shows an "Already tracked" count so files found always adds up.


### PR DESCRIPTION
Assembles changelog.d fragments for #1424, #1431, #1435, #1436 into the v1.24.1 CHANGELOG section and removes the consumed fragments.

Tag v1.24.1 follows once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)