### PR TITLE
fix(web): show auto as the import-mode default instead of move

### DIFF
--- a/docs/Storage-And-Hardlinks-Wiki.md
+++ b/docs/Storage-And-Hardlinks-Wiki.md
@@ -14,13 +14,15 @@ This is the standard *arr layout. It matters because **hardlinks only work withi
 
 ## Import modes
 
-Set the import mode in **Settings → File Naming**.
+Set the import mode in **Settings → General → File Naming**.
 
 | Mode | Extra disk | Seeding | Notes |
 |---|---|---|---|
-| **hardlink** | none | kept | Recommended for torrents. The completed file is linked into the library instantly; the download client keeps seeding the same data on disk. Requires downloads and library on one filesystem. |
-| **copy** | doubled | kept | Use when downloads and library are on different filesystems. Copies into the library and leaves the download in place so it can keep seeding. |
+| **auto** *(default)* | none / doubled | kept | Recommended. Hardlinks when the download folder and library share a filesystem (no extra disk), otherwise copies (doubled). The source stays in place either way, so torrents keep seeding. Picks hardlink or copy automatically per download. |
+| **hardlink** | none | kept | Forces hardlinking for torrents. The completed file is linked into the library instantly; the download client keeps seeding the same data on disk. Requires downloads and library on one filesystem. |
+| **copy** | doubled | kept | Forces copying. Use when downloads and library are on different filesystems. Copies into the library and leaves the download in place so it can keep seeding. |
 | **move** | none | **broken** | Moves the file out of the download location, so a torrent can no longer seed it. Only suitable for Usenet, or when you do not seed. |
+| **external** | none | kept | Hands off to a sibling tool (Calibre, CWA, Grimmory, Storyteller). Bindery stops after grabbing; the external tool processes and places the file, then Bindery reconciles it on the next library scan. Can drop the file into a configured watch folder. |
 
 ## Multi-disc audiobook flattening
 

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -84,6 +84,14 @@ const SettingSearchInterval = "search.interval"
 // the literal in sync with this constant.
 const SettingImportAudiobookFlattenMultiDisc = "import.audiobook.flatten_multi_disc"
 
+// SettingImportMode is the placement mode for completed downloads. Recognised
+// values are "auto" (empty/unset behaves identically — hardlink when the source
+// and destination share a filesystem, else copy; preserves seeding), "move"
+// (relocate the source, breaking seeding), "copy", "hardlink", and "external"
+// (hand off to a sibling tool). The importer reads this key as a string literal
+// (configuredImportMode) to avoid an import cycle; keep the literal in sync.
+const SettingImportMode = "import.mode"
+
 type SettingsHandler struct {
 	settings *db.SettingsRepo
 }
@@ -368,6 +376,19 @@ func validateSettingValue(key, value string) error {
 		}
 		if value != "copy" && value != "hardlink" {
 			return fmt.Errorf("import.drop_link_mode %q is not one of: copy, hardlink", value)
+		}
+	case SettingImportMode:
+		// Empty = auto (same as "auto"); a typo must fail loudly here rather
+		// than silently fall through to auto at import time, where the operator
+		// would think Move/External was in effect.
+		if value == "" {
+			return nil
+		}
+		switch value {
+		case "auto", "move", "copy", "hardlink", "external":
+			return nil
+		default:
+			return fmt.Errorf("import.mode %q is not one of: auto, move, copy, hardlink, external", value)
 		}
 	case SettingCalibreMode:
 		// Canonical values only. An empty string falls through to the

--- a/internal/api/settings_handler_test.go
+++ b/internal/api/settings_handler_test.go
@@ -562,6 +562,25 @@ func TestValidateSettingValue_SearchInterval(t *testing.T) {
 	}
 }
 
+func TestValidateSettingValue_ImportMode(t *testing.T) {
+	// Empty = auto (same as the explicit "auto"), accepted.
+	if err := validateSettingValue(SettingImportMode, ""); err != nil {
+		t.Errorf("empty should be accepted (auto): %v", err)
+	}
+	// All recognised modes, including the explicit "auto" the UI now writes for
+	// the default (#1444).
+	for _, v := range []string{"auto", "move", "copy", "hardlink", "external"} {
+		if err := validateSettingValue(SettingImportMode, v); err != nil {
+			t.Errorf("%q should be accepted: %v", v, err)
+		}
+	}
+	// A typo must fail loudly rather than silently fall through to auto at
+	// import time, where the operator would think Move/External was in effect.
+	if err := validateSettingValue(SettingImportMode, "moove"); err == nil {
+		t.Error("'moove' should be rejected (not a valid import mode)")
+	}
+}
+
 func mustJSON(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)

--- a/internal/importer/scanner_handoff.go
+++ b/internal/importer/scanner_handoff.go
@@ -48,8 +48,10 @@ func uniqueNonEmptyStrings(values []string) []string {
 }
 
 // configuredImportMode returns the operator-set "import.mode" ("move", "copy",
-// "hardlink", or "external"), or "" when the setting is absent/unrecognised,
-// meaning "auto" (let resolveImportMode pick hardlink-vs-copy per destination).
+// "hardlink", or "external"), or "" when the setting is absent, "auto", or
+// unrecognised — all of which mean "auto" (let resolveImportMode pick
+// hardlink-vs-copy per destination). "auto" is the explicit UI value for this
+// default (api.SettingImportMode); it maps to "" here just like an unset key.
 // Read once per download so a mid-run UI toggle can't mix modes (#705).
 func (s *Scanner) configuredImportMode(ctx context.Context) string {
 	if s.settings != nil {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -593,6 +593,27 @@ describe('SettingsPage', () => {
     })
   })
 
+  it('defaults the import mode selector to Auto when unset and persists an explicit Auto choice', async () => {
+    // No import.mode row (seedSettingsMocks default) — the backend treats an
+    // absent value as auto (hardlink/copy), so the UI must show Auto selected,
+    // not Move (#1444: the display default used to be 'move' and contradicted
+    // the backend, misleading operators into thinking sources were being moved).
+    renderSettings()
+
+    expect(await screen.findByText('Import Mode')).toBeInTheDocument()
+    const fileNaming = sectionForHeading('settings.general.fileNaming')
+
+    const autoBtn = fileNaming.getByRole('button', { name: 'Auto' })
+    const moveBtn = fileNaming.getByRole('button', { name: 'Move' })
+    expect(autoBtn.className).toContain('bg-emerald-600')
+    expect(moveBtn.className).not.toContain('bg-emerald-600')
+
+    // Clicking Auto writes the explicit value so the choice round-trips through
+    // the settings table rather than relying on an absent key.
+    fireEvent.click(autoBtn)
+    await waitFor(() => expect(api.setSetting).toHaveBeenCalledWith('import.mode', 'auto'))
+  })
+
   it('refreshes library scan status', async () => {
     vi.mocked(api.libraryScanStatus)
       .mockResolvedValueOnce({ ran_at: new Date(Date.now() - 10_000).toISOString(), files_found: 2, reconciled: 1, unmatched: 1 })

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -183,12 +183,13 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
             <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Import Mode</label>
             <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
               How Bindery places completed downloads into the library.
-              Use <strong>Hardlink</strong> or <strong>Copy</strong> to keep the source file intact for torrent seeding.
-              Hardlink requires the download folder and library to be on the same filesystem/volume.
+              <strong>Auto</strong> (the default) hardlinks when the download folder and library share a volume, otherwise copies — either way the source stays in place so torrent seeding keeps working.
+              <strong>Move</strong> relocates the source out of the download folder, which breaks seeding.
+              Use <strong>Hardlink</strong> or <strong>Copy</strong> to force keeping the source file intact; Hardlink requires the download folder and library to be on the same filesystem/volume.
               Use <strong>External</strong> if another tool (Calibre, Grimmory, etc.) manages your library — Bindery grabs the download and stops; your tool processes it, then Bindery reconciles on the next library scan.
             </p>
             <div className="flex gap-2 flex-wrap">
-              {(['move', 'copy', 'hardlink', 'external'] as const).map(m => (
+              {(['auto', 'move', 'copy', 'hardlink', 'external'] as const).map(m => (
                 <button
                   key={m}
                   onClick={async () => {
@@ -196,7 +197,7 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
                     await api.setSetting('import.mode', m).catch(console.error)
                   }}
                   className={`px-3 py-1.5 rounded text-xs font-medium border transition-colors ${
-                    (settings['import.mode'] ?? 'move') === m
+                    (settings['import.mode'] ?? 'auto') === m
                       ? 'bg-emerald-600 border-emerald-600 text-white'
                       : 'border-slate-300 dark:border-zinc-700 text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white'
                   }`}
@@ -206,7 +207,7 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
               ))}
             </div>
           </div>
-          {['copy', 'hardlink'].includes(settings['import.mode'] ?? 'move') && (
+          {['copy', 'hardlink'].includes(settings['import.mode'] ?? 'auto') && (
             <div className="border-t border-slate-200 dark:border-zinc-800 pt-3">
               <label className="flex items-start gap-2 cursor-pointer">
                 <input
@@ -230,7 +231,7 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
               </label>
             </div>
           )}
-          {(settings['import.mode'] ?? 'move') === 'external' && (
+          {(settings['import.mode'] ?? 'auto') === 'external' && (
             <div className="border-t border-slate-200 dark:border-zinc-800 pt-3 space-y-3">
               <div>
                 <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('settings.general.dropFolder', 'Drop folder')}</label>


### PR DESCRIPTION
## Summary

The **Import Mode** selector pre-selected **Move** whenever `import.mode` was unset, but the backend has treated an unset value as **auto** (hardlink on the same filesystem, else copy) since #577. The UI therefore showed Move as active while Bindery was actually hardlinking/copying — leaving sources in the download folder and misleading operators into thinking seeding was being broken. This makes **Auto** a first-class, selectable mode so the displayed mode always matches backend behaviour. Closes #1444.

## Implementation notes

- `web/src/pages/settings/GeneralTab.tsx` — add an **Auto** button (first in the row); default the displayed mode to `auto` when unset; rewrite the help text so it names Auto as the default and warns that Move breaks seeding.
- `internal/api/settings_handler.go` — new `SettingImportMode` constant and **validation** for `import.mode` (previously unvalidated), accepting `auto/move/copy/hardlink/external` so a typo fails loudly and `auto` is an explicit, documented value.
- `internal/importer/scanner_handoff.go` — doc comment only: `configuredImportMode` now records that `auto`/unset/unrecognised all map to `""` (no behaviour change).
- `docs/Storage-And-Hardlinks-Wiki.md` — add the **auto** (default) and **external** rows to the Import modes table.

No change to actual import/placement behaviour — this only makes the UI honest and restores a UI path back to the safe default (previously, once any mode was chosen there was no way to re-select auto without editing the DB).

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (`docs/Storage-And-Hardlinks-Wiki.md`)
- [x] Wiki pages updated (user-facing behaviour changed)

## Test plan

- [x] `cd web && npm run typecheck` — clean
- [x] `cd web && npm test` — 390/390 pass (incl. new "defaults to Auto when unset" test)
- [x] `cd web && npm run lint` — 0 errors
- [ ] `go test ./cmd/... ./internal/...` — not run locally (no Go toolchain on this machine); relying on CI for the backend build and `TestValidateSettingValue_ImportMode`
