### PR TITLE
fix(settings): make Auto a first-class Import Mode

### DIFF
--- a/changelog.d/1444-import-mode-auto-default.md
+++ b/changelog.d/1444-import-mode-auto-default.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Import Mode UI now shows Auto as the default** (#1444) — the selector used to pre-select Move when no mode had ever been saved, while Bindery actually defaults to auto (hardlink same-filesystem, copy otherwise). Auto is now a real, selectable option, so the UI matches what's actually happening and you can switch back to it after picking something else.

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -69,6 +69,13 @@ const (
 	SettingImportDropLinkMode = "import.drop_link_mode"
 )
 
+// SettingImportMode is the KV key for the operator-chosen import placement
+// mode. Valid values are "", "auto" (equivalent — hardlink same-filesystem,
+// copy otherwise), "move", "copy", "hardlink", "external". The importer
+// package reads this key as a string literal to avoid an import cycle; keep
+// the literal in sync with this constant.
+const SettingImportMode = "import.mode"
+
 // SettingSearchInterval is the KV key for the wanted-book search cadence.
 // Value is a Go duration string (e.g. "12h", "24h"). Empty or unset falls
 // back to the scheduler's defaultSearchInterval (12h). Takes effect on restart.
@@ -368,6 +375,20 @@ func validateSettingValue(key, value string) error {
 		}
 		if value != "copy" && value != "hardlink" {
 			return fmt.Errorf("import.drop_link_mode %q is not one of: copy, hardlink", value)
+		}
+	case SettingImportMode:
+		// Empty falls back to auto at read time; validate non-empty writes
+		// so a typo can't silently strand the setting in an unrecognised
+		// state (configuredImportMode would then treat it as "" == auto,
+		// masking the typo instead of failing loudly).
+		if value == "" {
+			return nil
+		}
+		switch value {
+		case "auto", "move", "copy", "hardlink", "external":
+			return nil
+		default:
+			return fmt.Errorf("import.mode %q is not one of: auto, move, copy, hardlink, external", value)
 		}
 	case SettingCalibreMode:
 		// Canonical values only. An empty string falls through to the

--- a/internal/importer/scanner_handoff.go
+++ b/internal/importer/scanner_handoff.go
@@ -48,8 +48,8 @@ func uniqueNonEmptyStrings(values []string) []string {
 }
 
 // configuredImportMode returns the operator-set "import.mode" ("move", "copy",
-// "hardlink", or "external"), or "" when the setting is absent/unrecognised,
-// meaning "auto" (let resolveImportMode pick hardlink-vs-copy per destination).
+// "hardlink", or "external"), or "" when the setting is absent/unrecognised or
+// explicitly "auto" (let resolveImportMode pick hardlink-vs-copy per destination).
 // Read once per download so a mid-run UI toggle can't mix modes (#705).
 func (s *Scanner) configuredImportMode(ctx context.Context) string {
 	if s.settings != nil {
@@ -58,6 +58,8 @@ func (s *Scanner) configuredImportMode(ctx context.Context) string {
 			switch setting.Value {
 			case "move", "copy", "hardlink", "external":
 				return setting.Value
+			case "auto":
+				return ""
 			}
 		}
 	}

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -183,12 +183,13 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
             <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Import Mode</label>
             <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
               How Bindery places completed downloads into the library.
-              Use <strong>Hardlink</strong> or <strong>Copy</strong> to keep the source file intact for torrent seeding.
+              <strong>Auto</strong> (the default) hardlinks when the download folder and library share a filesystem, and copies otherwise — either way the source file is left intact for torrent seeding.
+              Use <strong>Hardlink</strong> or <strong>Copy</strong> to force one of those explicitly.
               Hardlink requires the download folder and library to be on the same filesystem/volume.
               Use <strong>External</strong> if another tool (Calibre, Grimmory, etc.) manages your library — Bindery grabs the download and stops; your tool processes it, then Bindery reconciles on the next library scan.
             </p>
             <div className="flex gap-2 flex-wrap">
-              {(['move', 'copy', 'hardlink', 'external'] as const).map(m => (
+              {(['auto', 'move', 'copy', 'hardlink', 'external'] as const).map(m => (
                 <button
                   key={m}
                   onClick={async () => {
@@ -196,7 +197,7 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
                     await api.setSetting('import.mode', m).catch(console.error)
                   }}
                   className={`px-3 py-1.5 rounded text-xs font-medium border transition-colors ${
-                    (settings['import.mode'] ?? 'move') === m
+                    (settings['import.mode'] ?? 'auto') === m
                       ? 'bg-emerald-600 border-emerald-600 text-white'
                       : 'border-slate-300 dark:border-zinc-700 text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white'
                   }`}
@@ -206,7 +207,7 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
               ))}
             </div>
           </div>
-          {['copy', 'hardlink'].includes(settings['import.mode'] ?? 'move') && (
+          {['copy', 'hardlink'].includes(settings['import.mode'] ?? 'auto') && (
             <div className="border-t border-slate-200 dark:border-zinc-800 pt-3">
               <label className="flex items-start gap-2 cursor-pointer">
                 <input
@@ -230,7 +231,7 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
               </label>
             </div>
           )}
-          {(settings['import.mode'] ?? 'move') === 'external' && (
+          {(settings['import.mode'] ?? 'auto') === 'external' && (
             <div className="border-t border-slate-200 dark:border-zinc-800 pt-3 space-y-3">
               <div>
                 <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">{t('settings.general.dropFolder', 'Drop folder')}</label>


### PR DESCRIPTION
## Summary
- The Import Mode selector pre-selected **Move** whenever `import.mode` had never been saved, but the backend (`resolveImportMode`) has defaulted an unset value to **auto** (hardlink same-filesystem, copy otherwise) since #577 — the display default never followed, so the UI showed Move as active while Bindery was actually hardlinking/copying.
- **Auto** is now a real, selectable button (first in the row), and it's the display default when `import.mode` is unset — so there's a way back to auto after picking something else, and the UI always matches actual backend behavior.
- Added backend validation for `import.mode` (previously unvalidated) accepting `"", auto, move, copy, hardlink, external` so a typo fails loudly instead of silently defaulting to auto.
- No change to actual import/placement behaviour.

Fixes #1444

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/api/... ./internal/importer/...`
- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/pages/SettingsPage.test.tsx` (51 passed, including the existing import-mode persistence test)