### PR TITLE
fix(grimmory): authenticate before probing /api/status on test connection (#1448)

### DIFF
--- a/changelog.d/1448-grimmory-status-auth.md
+++ b/changelog.d/1448-grimmory-status-auth.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Grimmory "Test connection" now authenticates before probing status** (#1448) — recent Grimmory guards `/api/status` behind a valid session, so the test button returned a 401 for anyone using username/password auth. Bindery now logs in first and presents the token when checking connectivity (retrying once if a cached token has expired), so the test succeeds instead of failing at the door.

--- a/internal/grimmory/client.go
+++ b/internal/grimmory/client.go
@@ -183,25 +183,61 @@ func (c *Client) WithCredentials(username, password string) *Client {
 }
 
 // Ping calls GET /api/status to verify connectivity and authentication.
+//
+// Current Grimmory guards /api/status behind a valid session, so an
+// unauthenticated probe now returns 401 (#1448). When username/password (or a
+// static key) is configured, Ping authenticates first — acquiring a JWT via
+// login when needed — and retries once on 401 after forcing a fresh login, so
+// an expired cached token heals transparently. Without any credentials it
+// falls back to an unauthenticated probe (still useful against a Grimmory that
+// leaves /api/status public).
 func (c *Client) Ping(ctx context.Context) (*StatusResponse, error) {
 	var resp StatusResponse
-	if err := c.do(ctx, http.MethodGet, "/api/status", nil, &resp); err != nil {
+	if !c.HasCredentials() {
+		if err := c.do(ctx, http.MethodGet, "/api/status", nil, &resp); err != nil {
+			return nil, err
+		}
+		return &resp, nil
+	}
+	token, err := c.bearer(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	err = c.doWithToken(ctx, http.MethodGet, "/api/status", token, nil, &resp)
+	var apiErr *APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnauthorized && c.apiKey == "" {
+		if token, err = c.bearer(ctx, true); err != nil {
+			return nil, err
+		}
+		err = c.doWithToken(ctx, http.MethodGet, "/api/status", token, nil, &resp)
+	}
+	if err != nil {
 		return nil, err
 	}
 	return &resp, nil
 }
 
+// do issues a request carrying only a statically-configured API key as auth
+// (or none). Used by the login/refresh calls, which must not present a JWT —
+// they are how the JWT is obtained.
+//
+// Grimmory v3.x does not have API keys; the maintainer confirmed this on
+// grimmory-tools/grimmory#1487 (#818). Send the Authorization header only when
+// the user actually configured one — sending "Bearer " with an empty token is
+// a no-op against current Grimmory and just noise on the wire.
 func (c *Client) do(ctx context.Context, method, path string, body io.Reader, out any) error {
+	return c.doWithToken(ctx, method, path, c.apiKey, body, out)
+}
+
+// doWithToken issues a request carrying the given bearer token (empty token =
+// no Authorization header).
+func (c *Client) doWithToken(ctx context.Context, method, path, token string, body io.Reader, out any) error {
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
 	if err != nil {
 		return err
 	}
-	// Grimmory v3.x does not have API keys; the maintainer confirmed this on
-	// grimmory-tools/grimmory#1487 (#818). Send the Authorization header only
-	// when the user actually configured one — sending "Bearer " with an empty
-	// token is a no-op against current Grimmory and just noise on the wire.
-	if c.apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 	req.Header.Set("User-Agent", c.userAgent)
 	if body != nil {

--- a/internal/grimmory/client_test.go
+++ b/internal/grimmory/client_test.go
@@ -298,6 +298,99 @@ func TestPing_ServerError(t *testing.T) {
 	}
 }
 
+// TestPing_AuthedStatusWithCredentials covers #1448: Grimmory guards
+// /api/status behind a valid session, so an unauthenticated probe 401s. When a
+// username/password is configured, Ping must log in first and present the JWT
+// on /api/status rather than failing the "Test connection" button outright.
+func TestPing_AuthedStatusWithCredentials(t *testing.T) {
+	var logins, statusHits int
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		var creds map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&creds)
+		if creds["username"] != "bindery" || creds["password"] != "s3cret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		logins++
+		_ = json.NewEncoder(w).Encode(map[string]string{"accessToken": "jwt-1", "refreshToken": "refresh-1"})
+	})
+	mux.HandleFunc("GET /api/status", func(w http.ResponseWriter, r *http.Request) {
+		statusHits++
+		if r.Header.Get("Authorization") != "Bearer jwt-1" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(StatusResponse{Status: "ok", Version: "3.1"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c, err := NewClient(srv.URL, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.WithCredentials("bindery", "s3cret")
+
+	resp, err := c.Ping(context.Background())
+	if err != nil {
+		t.Fatalf("Ping: unexpected error: %v", err)
+	}
+	if resp.Version != "3.1" {
+		t.Errorf("Version: got %q, want %q", resp.Version, "3.1")
+	}
+	if logins != 1 {
+		t.Errorf("logins: got %d, want 1", logins)
+	}
+}
+
+// TestPing_AuthedStatusRetriesOn401 covers the stale-token path: a cached JWT
+// that Grimmory has since expired should trigger one forced re-login and a
+// retry rather than surfacing the 401 to the "Test connection" button.
+func TestPing_AuthedStatusRetriesOn401(t *testing.T) {
+	var logins int
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		logins++
+		// First login hands out the stale token, second the fresh one.
+		tok := "jwt-fresh"
+		if logins == 1 {
+			tok = "jwt-stale"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"accessToken": tok, "refreshToken": "refresh-1"})
+	})
+	mux.HandleFunc("GET /api/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer jwt-fresh" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(StatusResponse{Status: "ok", Version: "3.1"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c, err := NewClient(srv.URL, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.WithCredentials("bindery", "s3cret")
+	// Seed a stale token so the first /api/status attempt 401s.
+	if _, err := c.login(context.Background()); err != nil {
+		t.Fatalf("seed login: %v", err)
+	}
+
+	resp, err := c.Ping(context.Background())
+	if err != nil {
+		t.Fatalf("Ping: unexpected error: %v", err)
+	}
+	if resp.Version != "3.1" {
+		t.Errorf("Version: got %q, want %q", resp.Version, "3.1")
+	}
+	if logins != 2 {
+		t.Errorf("logins: got %d, want 2 (seed + forced re-login)", logins)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // do — header verification
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The Grimmory "Test connection" button was returning `401 Unauthorized` on `/api/status` for users authenticating with username/password (#1448).

## Why

`Ping` (behind the Test button) issued its `/api/status` probe through `do()`, which only ever attaches a **static API key** to the request — never the JWT from the login flow. Grimmory v3 has no static API keys (#818), so the probe went out with no `Authorization` header at all. Older Grimmory left `/api/status` public so this happened to work; recent Grimmory guards it behind a valid session, so the probe now 401s and the test fails *before* the login step (`VerifyAuth`) ever runs.

## Fix

- `Ping` now acquires a bearer token via the login flow when credentials are configured, presents it on `/api/status`, and retries once on 401 after a forced re-login (mirroring `UploadBookDrop`) so an expired cached token heals transparently.
- With no credentials configured it still falls back to an unauthenticated probe (useful against a Grimmory that leaves `/api/status` public).
- Split `do()` into `do()` / `doWithToken()` so `login`/`refresh` keep going out without a JWT.

## Testing

- `TestPing_AuthedStatusWithCredentials` — status is auth-gated; Ping logs in and presents the JWT.
- `TestPing_AuthedStatusRetriesOn401` — a stale cached token triggers one forced re-login and a retry.
- Existing Ping / `do` header tests unchanged and passing.

Closes #1448

🤖 Generated with [Claude Code](https://claude.com/claude-code)