### PR TITLE
fix(downloader): redact indexer apikey from fetch errors

### DIFF
--- a/changelog.d/download-key-redaction.md
+++ b/changelog.d/download-key-redaction.md
@@ -1,0 +1,2 @@
+### Security
+- **Indexer API keys no longer leak into errors** — when a torrent/NZB fetch failed at the transport layer (timeout, DNS, TLS), the underlying `url.Error` carried the full signed download URL, including the indexer's `apikey`, into the download row, history, and webhook/Discord notifications. All five download-client fetch paths now scrub the key before the error is wrapped.

--- a/internal/downloader/deluge/client.go
+++ b/internal/downloader/deluge/client.go
@@ -253,7 +253,9 @@ func (c *Client) fetchTorrentContent(ctx context.Context, rawURL string) (*fetch
 
 		resp, err := fetchClient.Do(req)
 		if err != nil {
-			return nil, err
+			// Scrub the indexer apikey the *url.Error would otherwise leak into
+			// the download row / history / webhook payloads.
+			return nil, httpsec.RedactURLError(err)
 		}
 
 		if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode < http.StatusBadRequest {

--- a/internal/downloader/nzbget/client.go
+++ b/internal/downloader/nzbget/client.go
@@ -317,7 +317,9 @@ func (c *Client) fetchNZBContent(ctx context.Context, nzbURL string) ([]byte, er
 	req.Header.Set("User-Agent", useragent.Get())
 	resp, err := c.fetchHTTP.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetch nzb from indexer: %w", err)
+		// Scrub the indexer apikey the *url.Error would otherwise leak into
+		// the download row / history / webhook payloads.
+		return nil, fmt.Errorf("fetch nzb from indexer: %w", httpsec.RedactURLError(err))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -533,7 +533,9 @@ func (c *Client) fetchTorrentContent(ctx context.Context, rawURL string) (*fetch
 
 		resp, err := fetchClient.Do(req)
 		if err != nil {
-			return nil, err
+			// Scrub the indexer apikey the *url.Error would otherwise leak into
+			// the download row / history / webhook payloads.
+			return nil, httpsec.RedactURLError(err)
 		}
 
 		if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode < http.StatusBadRequest {

--- a/internal/downloader/sabnzbd/client.go
+++ b/internal/downloader/sabnzbd/client.go
@@ -216,7 +216,9 @@ func (c *Client) fetchNZBContent(ctx context.Context, nzbURL string) ([]byte, er
 	req.Header.Set("User-Agent", useragent.Get())
 	resp, err := c.fetchHTTP.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetch nzb from indexer: %w", err)
+		// Scrub the indexer apikey the *url.Error would otherwise leak into
+		// the download row / history / webhook payloads.
+		return nil, fmt.Errorf("fetch nzb from indexer: %w", redactURLError(err))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -374,7 +374,9 @@ func (c *Client) fetchTorrentContent(ctx context.Context, torrentURL string) (*f
 
 		resp, err := fetchClient.Do(req)
 		if err != nil {
-			return nil, fmt.Errorf("fetch torrent from indexer: %w", err)
+			// Scrub the indexer apikey the *url.Error would otherwise leak into
+			// the download row / history / webhook payloads.
+			return nil, fmt.Errorf("fetch torrent from indexer: %w", httpsec.RedactURLError(err))
 		}
 
 		if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode < http.StatusBadRequest {

--- a/internal/httpsec/redact.go
+++ b/internal/httpsec/redact.go
@@ -1,6 +1,10 @@
 package httpsec
 
-import "regexp"
+import (
+	"errors"
+	"net/url"
+	"regexp"
+)
 
 // secretQueryParamRE matches sensitive query-string parameters whose values
 // must never reach a client-facing error. Google Books puts the API key in the
@@ -20,4 +24,22 @@ var secretQueryParamRE = regexp.MustCompile(`(?i)([?&](?:key|api_key|apikey|toke
 // any path that stringifies the error.
 func RedactSecrets(s string) string {
 	return secretQueryParamRE.ReplaceAllString(s, "${1}REDACTED")
+}
+
+// RedactURLError scrubs sensitive query-parameter values from the URL embedded
+// in a *url.Error, in place, and returns the same error. Transport failures
+// (timeout, DNS, TLS, an SSRF-guard dial rejection) surface as a *url.Error
+// whose Error() prints the full request URL — and download-fetch URLs carry the
+// indexer apikey (see newznab.signDownloadURL), so a raw %w-wrap leaks the key
+// into the download row, history, and webhook payloads.
+//
+// The error chain is left intact so errors.As/Is still reach the underlying net
+// error (nethint's timeout/DNS classification depends on it). Non-*url.Error
+// values pass through unchanged.
+func RedactURLError(err error) error {
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		ue.URL = RedactSecrets(ue.URL)
+	}
+	return err
 }

--- a/internal/httpsec/redact_test.go
+++ b/internal/httpsec/redact_test.go
@@ -92,7 +92,11 @@ func TestRedactURLError(t *testing.T) {
 
 	// Non-url.Error values pass through unchanged.
 	plain := errors.New("plain failure")
-	if RedactURLError(plain) != plain {
+	got := RedactURLError(plain)
+	if got.Error() != plain.Error() {
+		t.Fatalf("non-url.Error message changed: got %q, want %q", got.Error(), plain.Error())
+	}
+	if !errors.Is(got, plain) {
 		t.Fatal("non-url.Error should pass through unchanged")
 	}
 }

--- a/internal/httpsec/redact_test.go
+++ b/internal/httpsec/redact_test.go
@@ -1,6 +1,9 @@
 package httpsec
 
 import (
+	"errors"
+	"fmt"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -52,5 +55,44 @@ func TestRedactSecrets(t *testing.T) {
 				t.Fatalf("secret value leaked through redaction: %q", got)
 			}
 		})
+	}
+}
+
+// sentinelNetErr stands in for the underlying net error a *url.Error wraps, so
+// we can assert RedactURLError leaves the chain reachable by errors.Is/As.
+type sentinelNetErr struct{}
+
+func (sentinelNetErr) Error() string { return "dial tcp 10.0.0.53:443: i/o timeout" }
+
+func TestRedactURLError(t *testing.T) {
+	inner := sentinelNetErr{}
+	ue := &url.Error{
+		Op:  "Get",
+		URL: "https://indexer.example/download?id=42&apikey=SECRET123",
+		Err: inner,
+	}
+
+	// Wrap it the way the download clients do, to prove the apikey does not
+	// survive stringification even one %w-layer up.
+	wrapped := fmt.Errorf("fetch torrent from indexer: %w", RedactURLError(ue))
+
+	if strings.Contains(wrapped.Error(), "SECRET123") {
+		t.Fatalf("apikey leaked through redaction: %q", wrapped.Error())
+	}
+	if !strings.Contains(wrapped.Error(), "apikey=REDACTED") {
+		t.Fatalf("expected apikey=REDACTED, got %q", wrapped.Error())
+	}
+	// The chain must stay intact so nethint can still classify the net error.
+	if !errors.As(wrapped, new(*url.Error)) {
+		t.Fatal("*url.Error no longer reachable via errors.As")
+	}
+	if !errors.Is(wrapped, inner) {
+		t.Fatal("underlying net error no longer reachable via errors.Is")
+	}
+
+	// Non-url.Error values pass through unchanged.
+	plain := errors.New("plain failure")
+	if RedactURLError(plain) != plain {
+		t.Fatal("non-url.Error should pass through unchanged")
 	}
 }


### PR DESCRIPTION
## What

A transport-layer failure while fetching a torrent/NZB from the indexer (timeout, DNS, TLS, or an SSRF-guard dial rejection) surfaces as a `*url.Error` whose `Error()` prints the full request URL. Download-fetch URLs are signed with the indexer's `apikey` (`newznab.signDownloadURL`), so the raw `%w`-wrap leaked that key into:

- the download row's error field (visible to **non-admin** users in the queue UI),
- the history feed,
- webhook / Discord notification payloads.

## Fix

- Add `httpsec.RedactURLError`, which scrubs sensitive query-param values from the embedded `*url.Error` URL **in place** and returns the same error, leaving the chain intact so `errors.As`/`errors.Is` (and nethint's timeout/DNS classification) still reach the underlying net error.
- Apply it at all five client fetch sites: qbittorrent, deluge, transmission, nzbget. sabnzbd already had an equivalent local `redactURLError` used on its other fetch path; wired it into the one site that was missing it.

## Testing

- `TestRedactURLError` — asserts the apikey does not survive stringification one `%w`-layer up, that `apikey=REDACTED` is present, and that both `errors.As(*url.Error)` and `errors.Is(underlying)` still resolve.
- `go build ./...` clean; existing `httpsec` suite passes.

Found during a codebase security sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)