### PR TITLE
fix(api): require admin for /system/logs and /system/loglevel

### DIFF
--- a/changelog.d/system-logs-admin.md
+++ b/changelog.d/system-logs-admin.md
@@ -1,0 +1,2 @@
+### Security
+- **System logs are now admin-only** — `/system/logs` and `/system/loglevel` were reachable by any authenticated user, exposing the app-wide log stream (other users' book and author names, OIDC usernames, download titles) and letting a non-admin flip the global log level. They now require admin, matching every other global-infra route.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -969,10 +969,8 @@ func main() {
 			r.Delete("/backup/{filename}", backupHandler.Delete)
 		})
 
-		// System logs
-		r.Get("/system/logs", logHandler.List)
-		r.Get("/system/loglevel", logHandler.GetLevel)
-		r.Put("/system/loglevel", logHandler.SetLevel)
+		// System logs — admin-only (see registerSystemLogRoutes).
+		registerSystemLogRoutes(r, logHandler)
 
 		// Storage paths (read-only view of the env/config-driven dirs plus
 		// exists/writable/hardlink-able health, #1183). Admin-only: it reveals

--- a/cmd/bindery/sensitive_routes.go
+++ b/cmd/bindery/sensitive_routes.go
@@ -9,6 +9,28 @@ import (
 	"github.com/vavallee/bindery/internal/auth"
 )
 
+// systemLogRouteHandler is the surface registerSystemLogRoutes needs.
+type systemLogRouteHandler interface {
+	List(http.ResponseWriter, *http.Request)
+	GetLevel(http.ResponseWriter, *http.Request)
+	SetLevel(http.ResponseWriter, *http.Request)
+}
+
+// registerSystemLogRoutes mounts the /system/logs and /system/loglevel routes.
+// The whole subtree is admin-only: List streams app-wide log output — other
+// users' book/author names, OIDC usernames, download titles — which is exactly
+// the cross-tenant disclosure the multi-user model forbids, and SetLevel is a
+// global mutation that can be flipped to debug to amplify it. Same privilege
+// level as /system/storage.
+func registerSystemLogRoutes(r chi.Router, h systemLogRouteHandler) {
+	r.Group(func(r chi.Router) {
+		r.Use(auth.RequireAdmin)
+		r.Get("/system/logs", h.List)
+		r.Get("/system/loglevel", h.GetLevel)
+		r.Put("/system/loglevel", h.SetLevel)
+	})
+}
+
 // migrateRouteHandler is the surface registerMigrateRoutes needs.
 type migrateRouteHandler interface {
 	ImportCSV(http.ResponseWriter, *http.Request)

--- a/cmd/bindery/sensitive_routes_test.go
+++ b/cmd/bindery/sensitive_routes_test.go
@@ -68,6 +68,82 @@ func (h *stubSensitiveHandler) ImportGoodreadsPreview(w http.ResponseWriter, _ *
 func (h *stubSensitiveHandler) ImportGoodreadsCommit(w http.ResponseWriter, _ *http.Request) {
 	h.record("import-goodreads-commit", w)
 }
+func (h *stubSensitiveHandler) GetLevel(w http.ResponseWriter, _ *http.Request) {
+	h.record("get-level", w)
+}
+func (h *stubSensitiveHandler) SetLevel(w http.ResponseWriter, _ *http.Request) {
+	h.record("set-level", w)
+}
+
+// TestSystemLogRoutesRequireAdmin locks in the sweep finding that
+// /system/logs and /system/loglevel were mounted outside any admin Group, so
+// role=user could read the app-wide log stream (other users' titles, OIDC
+// usernames) and flip the global log level. A non-admin must be rejected
+// before the handler runs.
+func TestSystemLogRoutesRequireAdmin(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "read logs", method: http.MethodGet, path: "/system/logs"},
+		{name: "get loglevel", method: http.MethodGet, path: "/system/loglevel"},
+		{name: "set loglevel", method: http.MethodPut, path: "/system/loglevel"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &stubSensitiveHandler{}
+			router := chi.NewRouter()
+			registerSystemLogRoutes(router, h)
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req = req.WithContext(auth.WithUserRole(req.Context(), "user"))
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d; want %d (RequireAdmin should reject role=user)", rec.Code, http.StatusForbidden)
+			}
+			if len(h.called) != 0 {
+				t.Fatalf("handler invoked for non-admin request: %v", h.called)
+			}
+		})
+	}
+}
+
+// TestSystemLogRoutesAllowAdmin is the symmetry case: an admin must reach each
+// handler (guards against mounting them outside the group so they 404).
+func TestSystemLogRoutesAllowAdmin(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		called string
+	}{
+		{name: "read logs", method: http.MethodGet, path: "/system/logs", called: "list"},
+		{name: "get loglevel", method: http.MethodGet, path: "/system/loglevel", called: "get-level"},
+		{name: "set loglevel", method: http.MethodPut, path: "/system/loglevel", called: "set-level"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &stubSensitiveHandler{}
+			router := chi.NewRouter()
+			registerSystemLogRoutes(router, h)
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req = req.WithContext(auth.WithUserRole(req.Context(), "admin"))
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d; want %d", rec.Code, http.StatusNoContent)
+			}
+			if len(h.called) != 1 || h.called[0] != tt.called {
+				t.Fatalf("called = %v; want [%s]", h.called, tt.called)
+			}
+		})
+	}
+}
 
 // TestSensitiveRoutesRequireAdmin nails down the security finding from the
 // v1.15.0 review: List/Get/Create/Update/Delete on the indexer, prowlarr, and


### PR DESCRIPTION
## What

`/system/logs`, `GET /system/loglevel`, and `PUT /system/loglevel` were mounted directly in the `/api/v1` group with **no** `RequireAdmin`. Any authenticated non-admin user could:

- `GET /system/logs` — the app-wide slog stream, which carries other users' book/author names, OIDC usernames, and download titles (the exact cross-tenant disclosure the multi-user model forbids), and
- `PUT /system/loglevel` — a global mutation, flipping the level to `debug` to amplify what everyone's logs disclose.

Every other global-infra operation (backups, `/system/storage`, migrate imports) is already admin-gated. `/system/storage` was gated with the note "reveals server filesystem layout"; logs reveal at least as much.

## Fix

- Extract `registerSystemLogRoutes` (mirroring `registerMigrateRoutes` and the other `register*Routes` helpers) wrapping all three in a `RequireAdmin` group.
- Add `TestSystemLogRoutesRequireAdmin` / `TestSystemLogRoutesAllowAdmin` to the sensitive-routes suite — a future route added outside the group trips the test.

## Notes

The Logs settings tab is already admin-only in the nav, so no legitimate non-admin UI flow depended on these being public.

Found during a codebase security sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)