### PR TITLE
fix(importer): correct Transmission RPC status enum mapping

### DIFF
--- a/changelog.d/transmission-status-enum.md
+++ b/changelog.d/transmission-status-enum.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Transmission downloads queued behind others no longer fail to import** — the RPC status enum was mapped wrong (`3` was treated as "seeding", `6` as "stopped"; they are actually "queued to download" and "seeding"). A torrent sitting in Transmission's download queue at 0% was treated as complete, import fired against an empty directory, failed, and after exhausting its retries the download was terminally blocked even though it was perfectly healthy. Completion is now keyed off real seeding / 100%-downloaded state.

--- a/internal/downloader/transmission/types.go
+++ b/internal/downloader/transmission/types.go
@@ -2,20 +2,23 @@ package transmission
 
 // Torrent represents a single torrent as returned by the Transmission RPC API.
 type Torrent struct {
-	ID             int64    `json:"id"`
-	HashString     string   `json:"hashString"`
-	Name           string   `json:"name"`
-	TotalSize      int64    `json:"totalSize"`
-	DownloadedEver int64    `json:"downloadedEver"`
-	LeftUntilDone  int64    `json:"leftUntilDone"`
-	Status         int      `json:"status"` // 0=stopped, 1=checking, 2=downloading, 3=seeding, 4=allocating, 5=checking, 6=stopped
-	ErrorString    string   `json:"errorString"`
-	DownloadRate   int64    `json:"rateDownload"`
-	UploadRate     int64    `json:"rateUpload"`
-	ETA            int64    `json:"eta"`
-	PercentDone    float64  `json:"percentDone"`
-	DownloadDir    string   `json:"downloadDir"`
-	Labels         []string `json:"labels"`
+	ID             int64  `json:"id"`
+	HashString     string `json:"hashString"`
+	Name           string `json:"name"`
+	TotalSize      int64  `json:"totalSize"`
+	DownloadedEver int64  `json:"downloadedEver"`
+	LeftUntilDone  int64  `json:"leftUntilDone"`
+	// Status is the Transmission RPC status enum (stable since 2.40):
+	//   0=stopped 1=queued-to-check 2=checking
+	//   3=queued-to-download 4=downloading 5=queued-to-seed 6=seeding
+	Status       int      `json:"status"`
+	ErrorString  string   `json:"errorString"`
+	DownloadRate int64    `json:"rateDownload"`
+	UploadRate   int64    `json:"rateUpload"`
+	ETA          int64    `json:"eta"`
+	PercentDone  float64  `json:"percentDone"`
+	DownloadDir  string   `json:"downloadDir"`
+	Labels       []string `json:"labels"`
 }
 
 // TorrentAddResponse is returned when adding a torrent.

--- a/internal/importer/scanner_dispatch_matrix_test.go
+++ b/internal/importer/scanner_dispatch_matrix_test.go
@@ -355,7 +355,7 @@ func transmissionMatrixHandler(t *testing.T, conflicts *atomic.Int32, downloadDi
 					"hashString":  "feedfacefeedfacefeedfacefeedfacefeedface",
 					"name":        "the-book",
 					"percentDone": 1.0,
-					"status":      3, // seeding
+					"status":      6, // seeding
 					"downloadDir": downloadDir,
 				}},
 			},

--- a/internal/importer/scanner_extra_test.go
+++ b/internal/importer/scanner_extra_test.go
@@ -398,7 +398,7 @@ func TestCheckTransmissionDownloads_StoppedWithErrorMarksFailed(t *testing.T) {
 			"arguments": map[string]any{
 				"torrents": []map[string]any{{
 					"id":          9,
-					"status":      6,
+					"status":      0,
 					"percentDone": 0.2,
 					"downloadDir": "/downloads",
 					"errorString": "tracker connection failed",

--- a/internal/importer/scanner_poll.go
+++ b/internal/importer/scanner_poll.go
@@ -166,6 +166,25 @@ func (s *Scanner) tryImportNZBGet(ctx context.Context, ng *nzbget.Client, dl *mo
 	}, nil)
 }
 
+// transmissionCompletion classifies a torrent from its RPC status and progress.
+// The status enum is stable since Transmission 2.40:
+//
+//	0=stopped 1=queued-to-check 2=checking
+//	3=queued-to-download 4=downloading 5=queued-to-seed 6=seeding
+//
+// complete means the payload is fully downloaded (seeding, or PercentDone at
+// 1.0 for the brief window before it flips to seed/seed-wait). stopped means
+// Transmission has halted the torrent (paused by the user, or failed with an
+// errorString). The previous mapping treated status 3 as "seeding" and 6 as
+// "stopped" — inverted — so a torrent merely *queued to download* at 0% was
+// imported prematurely, failed with "no book files", burned its retry budget,
+// and got terminally blocked while perfectly healthy.
+func transmissionCompletion(status int, percentDone float64) (complete, stopped bool) {
+	complete = status == 6 || percentDone >= 1.0 // 6=seeding
+	stopped = status == 0                        // 0=stopped
+	return complete, stopped
+}
+
 // checkTransmissionDownloads polls Transmission for status changes.
 func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models.DownloadClient) {
 	trans := downloader.TransmissionFor(client)
@@ -222,9 +241,7 @@ func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models
 			continue
 		}
 
-		// Status codes: 0=stopped, 1=checking, 2=downloading, 3=seeding, 4=allocating, 5=checking, 6=stopped
-		isComplete := torrent.Status == 3 || (torrent.PercentDone >= 1.0)
-		isStopped := torrent.Status == 0 || torrent.Status == 6
+		isComplete, isStopped := transmissionCompletion(torrent.Status, torrent.PercentDone)
 		stopError := strings.TrimSpace(torrent.ErrorString)
 
 		if isComplete && (dl.Status == models.StateDownloading || dl.Status == models.StateGrabbed) {

--- a/internal/importer/scanner_poll_test.go
+++ b/internal/importer/scanner_poll_test.go
@@ -1,0 +1,38 @@
+package importer
+
+import "testing"
+
+// TestTransmissionCompletion pins the Transmission RPC status enum so the
+// status-3-is-queued / status-6-is-seeding mapping can't silently invert again
+// (the original bug: a torrent queued to download at 0% was classed complete,
+// imported, failed, and got terminally blocked).
+func TestTransmissionCompletion(t *testing.T) {
+	cases := []struct {
+		name         string
+		status       int
+		percentDone  float64
+		wantComplete bool
+		wantStopped  bool
+	}{
+		{"stopped, no data", 0, 0.0, false, true},
+		{"stopped but fully downloaded", 0, 1.0, true, true},
+		{"queued to check", 1, 0.0, false, false},
+		{"checking", 2, 0.5, false, false},
+		{"queued to download at 0% is NOT complete", 3, 0.0, false, false},
+		{"downloading mid-flight", 4, 0.5, false, false},
+		{"queued to seed is complete", 5, 1.0, true, false},
+		{"seeding is complete", 6, 1.0, true, false},
+		{"downloading at 100% is complete", 4, 1.0, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotComplete, gotStopped := transmissionCompletion(tc.status, tc.percentDone)
+			if gotComplete != tc.wantComplete {
+				t.Errorf("complete = %v, want %v (status=%d pct=%.2f)", gotComplete, tc.wantComplete, tc.status, tc.percentDone)
+			}
+			if gotStopped != tc.wantStopped {
+				t.Errorf("stopped = %v, want %v (status=%d pct=%.2f)", gotStopped, tc.wantStopped, tc.status, tc.percentDone)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

The Transmission completion check in the import poller had the RPC `status` enum wrong at both ends:

```go
isComplete := torrent.Status == 3 || (torrent.PercentDone >= 1.0)  // 3 is NOT seeding
isStopped  := torrent.Status == 0 || torrent.Status == 6           // 6 is NOT stopped
```

The actual enum (stable since Transmission 2.40):

| value | meaning |
|------|---------|
| 0 | stopped |
| 1 | queued to check |
| 2 | checking |
| **3** | **queued to download** |
| 4 | downloading |
| 5 | queued to seed |
| **6** | **seeding** |

## Impact

- A torrent sitting in Transmission's **download queue** (status 3, 0% done) was classed **complete** → import fired against a directory with no book files → `StateImportFailed` → each poll re-imported and burned the retry budget → `blockStaleImportFailures` terminally blocked a perfectly healthy queued download.
- A genuinely **seeding** torrent (status 6) was classed **stopped**; it survived only because the `PercentDone >= 1.0` short-circuit made `isComplete` win first.

## Fix

- Extract `transmissionCompletion(status, percentDone) (complete, stopped bool)`: complete = seeding or 100% downloaded, stopped = status 0 only.
- `TestTransmissionCompletion` pins all seven states, including the regression case (status 3 at 0% must **not** be complete).
- Fix the struct doc comment and the dispatch-matrix fixture that encoded the same wrong belief (`status: 3 // seeding` → `6`).

Found during a codebase correctness sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)