### PR TITLE
fix(scheduler): don't re-grab wanted books with a grab in flight

### DIFF
--- a/changelog.d/wanted-double-grab.md
+++ b/changelog.d/wanted-double-grab.md
@@ -1,0 +1,2 @@
+### Fixed
+- **The wanted-book sweep no longer double-grabs** — a Wanted book stays Wanted until its file is imported and reconciled, so a book whose grab was still downloading (or working through the import pipeline) was re-searched on the next scheduled sweep and, if the indexer now ranked a different release best, a second download was grabbed for the same book. The sweep now skips books with a grab already in flight, while still re-searching books whose previous download failed.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -762,28 +762,56 @@ func (s *Scheduler) searchWanted() {
 		}
 	}
 
+	searchQueue := s.wantedSearchQueue(ctx)
+	if len(searchQueue) == 0 {
+		return
+	}
+	concurrency.RunBounded(ctx, searchQueue, scheduledWantedSearchConcurrency, func(ctx context.Context, book models.Book) {
+		s.SearchAndGrabBook(ctx, book)
+	})
+}
+
+// inFlightDownloadStates are the states in which a download is actively working
+// toward a completed import. A Wanted book with a download in any of these must
+// not be re-searched: nothing flips the book off Wanted when it's grabbed (that
+// happens only once the file is imported and reconciled), so a re-search would
+// grab a *second* release for the same book, and even a same-GUID hit burns
+// indexer calls. Dead states (failed / import-failed / import-blocked) are
+// intentionally excluded from this list — those are the recovery path where
+// re-searching for a different release is correct.
+var inFlightDownloadStates = []models.DownloadState{
+	models.StateGrabbed,
+	models.StateDownloading,
+	models.StateCompleted,
+	models.StateImportPending,
+	models.StateImporting,
+	models.StateImportExternal, // external hand-off outstanding (issue #706 finding 3)
+}
+
+// wantedSearchQueue returns the Wanted books eligible for an auto-grab this
+// sweep, excluding user-excluded books and any book with a grab already in
+// flight (see inFlightDownloadStates).
+func (s *Scheduler) wantedSearchQueue(ctx context.Context) []models.Book {
 	wanted, err := s.books.ListByStatus(ctx, models.BookStatusWanted)
 	if err != nil {
 		slog.Error("failed to list wanted books", "error", err)
-		return
+		return nil
 	}
 	if len(wanted) == 0 {
-		return
+		return nil
 	}
 
-	// Books with a download parked in StateImportExternal have been handed off
-	// to an external import tool; the book is deliberately still Wanted so
-	// ScanLibrary can reconcile the file once it lands, but the release must
-	// NOT be re-grabbed in the meantime or the importer re-downloads the same
-	// book every sweep (issue #706 finding 3).
-	externalHandoffBooks := make(map[int64]bool)
+	inFlightBooks := make(map[int64]bool)
 	if s.downloads != nil {
-		if pending, derr := s.downloads.ListByStatus(ctx, models.StateImportExternal); derr != nil {
-			slog.Warn("failed to list external-handoff downloads", "error", derr)
-		} else {
-			for _, d := range pending {
+		for _, st := range inFlightDownloadStates {
+			active, derr := s.downloads.ListByStatus(ctx, st)
+			if derr != nil {
+				slog.Warn("failed to list in-flight downloads", "state", st, "error", derr)
+				continue
+			}
+			for _, d := range active {
 				if d.BookID != nil {
-					externalHandoffBooks[*d.BookID] = true
+					inFlightBooks[*d.BookID] = true
 				}
 			}
 		}
@@ -794,15 +822,13 @@ func (s *Scheduler) searchWanted() {
 		if book.Excluded {
 			continue
 		}
-		if externalHandoffBooks[book.ID] {
-			slog.Debug("skipping wanted search — external import hand-off outstanding", "book", book.Title)
+		if inFlightBooks[book.ID] {
+			slog.Debug("skipping wanted search — a grab is already in flight for this book", "book", book.Title)
 			continue
 		}
 		searchQueue = append(searchQueue, book)
 	}
-	concurrency.RunBounded(ctx, searchQueue, scheduledWantedSearchConcurrency, func(ctx context.Context, book models.Book) {
-		s.SearchAndGrabBook(ctx, book)
-	})
+	return searchQueue
 }
 
 func (s *Scheduler) refreshMetadata() {

--- a/internal/scheduler/scheduler_jobs_test.go
+++ b/internal/scheduler/scheduler_jobs_test.go
@@ -328,6 +328,69 @@ func TestSearchWanted_NoBooksInStatus(t *testing.T) {
 	s.searchWanted() // no panic; exits early because no "wanted" books
 }
 
+// TestWantedSearchQueue_SkipsInFlightGrabs is the regression guard for the
+// double-grab bug: a Wanted book with a grab already downloading must be left
+// out of the search queue (else the next sweep grabs a second release for it),
+// while a Wanted book whose only download died (import-failed) stays IN the
+// queue so a different release can be tried.
+func TestWantedSearchQueue_SkipsInFlightGrabs(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	dlRepo := db.NewDownloadRepo(database)
+
+	a := &models.Author{ForeignID: "OL9A", Name: "A", SortName: "A", MetadataProvider: "ol", Monitored: true}
+	if err := authRepo.Create(ctx, a); err != nil {
+		t.Fatalf("create author: %v", err)
+	}
+	mkBook := func(fid, title string) *models.Book {
+		b := &models.Book{
+			ForeignID: fid, AuthorID: a.ID, Title: title, SortTitle: title,
+			Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "ol", Monitored: true,
+		}
+		if err := bookRepo.Create(ctx, b); err != nil {
+			t.Fatalf("create book %s: %v", title, err)
+		}
+		return b
+	}
+	inFlight := mkBook("OL-INFLIGHT", "Being Downloaded")
+	dead := mkBook("OL-DEAD", "Import Failed")
+	fresh := mkBook("OL-FRESH", "Never Grabbed")
+
+	mkDownload := func(b *models.Book, st models.DownloadState) {
+		if err := dlRepo.Create(ctx, &models.Download{
+			GUID: "guid-" + b.ForeignID, BookID: &b.ID, Title: b.Title, Status: st, Protocol: "torrent",
+		}); err != nil {
+			t.Fatalf("create download for %s: %v", b.Title, err)
+		}
+	}
+	mkDownload(inFlight, models.StateDownloading)
+	mkDownload(dead, models.StateImportFailed)
+
+	s := &Scheduler{books: bookRepo, downloads: dlRepo}
+	queue := s.wantedSearchQueue(ctx)
+
+	got := make(map[int64]bool, len(queue))
+	for _, b := range queue {
+		got[b.ID] = true
+	}
+	if got[inFlight.ID] {
+		t.Errorf("book with a downloading grab was queued for re-search (double-grab bug)")
+	}
+	if !got[dead.ID] {
+		t.Errorf("book whose import failed must stay searchable (recovery path)")
+	}
+	if !got[fresh.ID] {
+		t.Errorf("never-grabbed wanted book must be searchable")
+	}
+}
+
 // TestRefreshMetadata_EmptyDB exercises the no-authors early-return path.
 func TestRefreshMetadata_EmptyDB(t *testing.T) {
 	database, err := db.OpenMemory()


### PR DESCRIPTION
## What

A book stays `BookStatusWanted` until its file is imported and reconciled — nothing flips it off Wanted at grab time. The scheduled wanted sweep therefore re-searched books that already had a download in progress, and the only exclusion was `StateImportExternal`. So a book still downloading (or mid-import) got a **second** release grabbed whenever the indexer's top-ranked result changed between sweeps; even a same-GUID hit re-ran an indexer search for it every cycle (default 12h — a slow torrent easily outlives that).

## Fix

`wantedSearchQueue` (extracted from `searchWanted` so it's directly testable) now skips any Wanted book with a download in an **actively-processing** state:

`grabbed, downloading, completed, importPending, importing, importExternal`

Dead states — `failed`, `importFailed`, `importBlocked` — are intentionally **not** excluded: those are the recovery path where searching for a *different* release is the correct behaviour.

## Testing

`TestWantedSearchQueue_SkipsInFlightGrabs`: a downloading grab is excluded from the queue; an import-failed book stays searchable; a never-grabbed book stays searchable.

Found during a codebase correctness sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)