### PR TITLE
perf(api): batch book fetch in WantedBulk search instead of N+1 GetByID

### DIFF
--- a/changelog.d/bulk-search-n1.md
+++ b/changelog.d/bulk-search-n1.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Bulk "search" on the Wanted page is much faster** — selecting a large batch and hitting search issued one of the heaviest book queries per book instead of a single batched fetch, so a 500-book bulk search ran hundreds of full-table aggregations. It now loads all selected books in one query.

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -441,13 +441,23 @@ func (h *BulkHandler) WantedBulk(w http.ResponseWriter, r *http.Request) {
 
 	var searchTargets []models.Book
 
+	// The search action needs the full book for each id. Fetch them in one
+	// query instead of a GetByID per id — GetByID runs the book CTE (which
+	// aggregates the whole book_files table twice) for a single row, so a
+	// 500-id bulk search was ~500 of those. A nil map (query error) makes every
+	// lookup miss, which yields the same not-owned result the per-id path did.
+	var booksByID map[int64]*models.Book
+	if req.Action == "search" {
+		booksByID, _ = h.books.GetByIDs(r.Context(), req.IDs)
+	}
+
 	for _, id := range req.IDs {
 		key := fmt.Sprintf("%d", id)
 		var opErr error
 		switch req.Action {
 		case "search":
-			book, err := h.books.GetByID(r.Context(), id)
-			if err != nil || book == nil || !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
+			book := booksByID[id]
+			if book == nil || !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
 				resp.Results[key] = bulkItemResult{Error: errBulkBookNotOwned.Error()}
 				continue
 			}


### PR DESCRIPTION
## What

The bulk **search** action (`WantedBulk`) fetched each selected book with `h.books.GetByID` inside the id loop. `GetByID` runs the `bookCTE`, which aggregates the whole `book_files` table **twice**, to return a single row — so a 500-id bulk search issued ~500 of those aggregations, serialized on the single SQLite connection.

## Fix

Fetch all ids in one `h.books.GetByIDs(ctx, req.IDs)` (built for exactly this, previously unused here) and look each book up from the returned map. The per-book `auth.CheckOwnership` check is unchanged. On a query error the map is nil, so every lookup misses and yields the same not-owned result the per-id path produced on `GetByID` error — no behavior change on the error path.

## Testing

`TestWantedBulk_Search_FiresSearcher` and `TestBulk_Wanted_OwnershipMatrix` pass unchanged.

Pairs well with #1454 (the index that makes each of those CTE runs cheaper), but stands alone.

Found during a codebase performance sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)