### PR TITLE
fix(metadata): dont overwrite author description/ratings with empty values on refresh (#1463)

### DIFF
--- a/changelog.d/1463-author-refresh-empty.md
+++ b/changelog.d/1463-author-refresh-empty.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Author metadata refresh no longer wipes enriched fields** (#1463) — the nightly refresh kept the existing description, ratings and rating count when the upstream record came back sparse, instead of overwriting them with empty values.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -841,13 +841,22 @@ func (s *Scheduler) refreshMetadata() {
 			continue
 		}
 
-		// Update changed fields
-		author.Description = updated.Description
+		// Update changed fields. Only overwrite when the upstream record
+		// actually carries a value: a sparse OpenLibrary refresh must not
+		// clobber a previously enriched description/ratings with empties
+		// (#1463). Same guard the ImageURL update has always had.
+		if updated.Description != "" {
+			author.Description = updated.Description
+		}
 		if updated.ImageURL != "" {
 			author.ImageURL = updated.ImageURL
 		}
-		author.AverageRating = updated.AverageRating
-		author.RatingsCount = updated.RatingsCount
+		if updated.AverageRating != 0 {
+			author.AverageRating = updated.AverageRating
+		}
+		if updated.RatingsCount != 0 {
+			author.RatingsCount = updated.RatingsCount
+		}
 		if err := s.authors.Update(ctx, &author); err != nil {
 			slog.Warn("failed to persist refreshed author", "author", author.Name, "error", err)
 			continue

--- a/internal/scheduler/scheduler_jobs_test.go
+++ b/internal/scheduler/scheduler_jobs_test.go
@@ -566,3 +566,89 @@ func TestRefreshMetadata_NilAuthor_DoesNotPanic(t *testing.T) {
 	}()
 	s.refreshMetadata()
 }
+
+// TestRefreshMetadata_SparseRefresh_DoesNotClobber pins down #1463: a sparse
+// upstream record (empty description/ratings, e.g. OpenLibrary) must not
+// overwrite previously enriched values with empties. A populated refresh must
+// still update them.
+func TestRefreshMetadata_SparseRefresh_DoesNotClobber(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	authRepo := db.NewAuthorRepo(database)
+	if err := authRepo.Create(ctx, &models.Author{
+		ForeignID:        "OL_SPARSE_A",
+		Name:             "Enriched Author",
+		SortName:         "Author, Enriched",
+		Description:      "A rich, previously enriched biography.",
+		ImageURL:         "https://example.com/keep.jpg",
+		AverageRating:    4.5,
+		RatingsCount:     1200,
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}); err != nil {
+		t.Fatalf("create author: %v", err)
+	}
+
+	// Sparse upstream: name only, everything enriched is empty/zero.
+	sparse := &mockMetaProvider{
+		author: &models.Author{
+			ForeignID: "OL_SPARSE_A",
+			Name:      "Enriched Author",
+		},
+	}
+	s := &Scheduler{authors: authRepo, meta: metadata.NewAggregator(sparse)}
+	s.refreshMetadata()
+
+	got, err := authRepo.GetByForeignID(ctx, "OL_SPARSE_A")
+	if err != nil {
+		t.Fatalf("GetByForeignID: %v", err)
+	}
+	if got.Description != "A rich, previously enriched biography." {
+		t.Errorf("Description clobbered by sparse refresh: %q", got.Description)
+	}
+	if got.ImageURL != "https://example.com/keep.jpg" {
+		t.Errorf("ImageURL clobbered by sparse refresh: %q", got.ImageURL)
+	}
+	if got.AverageRating != 4.5 {
+		t.Errorf("AverageRating clobbered by sparse refresh: %v", got.AverageRating)
+	}
+	if got.RatingsCount != 1200 {
+		t.Errorf("RatingsCount clobbered by sparse refresh: %d", got.RatingsCount)
+	}
+
+	// Populated upstream: values present, so they must overwrite.
+	populated := &mockMetaProvider{
+		author: &models.Author{
+			ForeignID:     "OL_SPARSE_A",
+			Name:          "Enriched Author",
+			Description:   "A fresher biography from upstream.",
+			ImageURL:      "https://example.com/new.jpg",
+			AverageRating: 4.8,
+			RatingsCount:  1500,
+		},
+	}
+	s = &Scheduler{authors: authRepo, meta: metadata.NewAggregator(populated)}
+	s.refreshMetadata()
+
+	got, err = authRepo.GetByForeignID(ctx, "OL_SPARSE_A")
+	if err != nil {
+		t.Fatalf("GetByForeignID: %v", err)
+	}
+	if got.Description != "A fresher biography from upstream." {
+		t.Errorf("Description not updated by populated refresh: %q", got.Description)
+	}
+	if got.ImageURL != "https://example.com/new.jpg" {
+		t.Errorf("ImageURL not updated by populated refresh: %q", got.ImageURL)
+	}
+	if got.AverageRating != 4.8 {
+		t.Errorf("AverageRating not updated by populated refresh: %v", got.AverageRating)
+	}
+	if got.RatingsCount != 1500 {
+		t.Errorf("RatingsCount not updated by populated refresh: %d", got.RatingsCount)
+	}
+}


### PR DESCRIPTION
The nightly author metadata refresh was overwriting description, average rating and ratings count with empty values whenever the upstream record came back sparse (thin OpenLibrary entries are the common case). ImageURL already had the non-empty guard, its siblings did not, so an author who had been enriched once would get wiped on the next refresh cycle.

Extended the same `!= ""` / `!= 0` guard to description, average rating and ratings count. Present upstream values still overwrite as before.

Added a scheduler test that runs a sparse refresh (keeps existing values) then a populated refresh (updates them).

Closes #1463

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>