### PR TITLE
fix(qbittorrent): surface setCategory HTTP errors so missing-category warning fires (#1464)

### DIFF
--- a/changelog.d/1464-qbit-setcategory.md
+++ b/changelog.d/1464-qbit-setcategory.md
@@ -1,0 +1,3 @@
+### Fixed
+
+Bindery now notices when qBittorrent rejects a category assignment (for example a 409 because the category does not exist) instead of silently ignoring it, so the missing category warning fires and a mis categorized torrent no longer vanishes from the download poll (#1464).

--- a/internal/downloader/qbittorrent/client.go
+++ b/internal/downloader/qbittorrent/client.go
@@ -741,6 +741,9 @@ func (c *Client) setCategory(ctx context.Context, hash, category string) error {
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("setCategory HTTP %d", resp.StatusCode)
+	}
 	return nil
 }
 

--- a/internal/downloader/qbittorrent/client_test.go
+++ b/internal/downloader/qbittorrent/client_test.go
@@ -780,6 +780,39 @@ func TestSetAutoManagement(t *testing.T) {
 	}
 }
 
+// TestSetCategory_HTTPError verifies that a non-2xx status from setCategory
+// (qBittorrent returns 409 when the category does not exist) surfaces as an
+// error rather than being swallowed, so the caller's missing-category warning
+// (#969) can fire.
+func TestSetCategory_HTTPError(t *testing.T) {
+	var hit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/setCategory":
+			hit = true
+			w.WriteHeader(http.StatusConflict)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "admin", "pass")
+	c.loggedIn = true
+	err := c.setCategory(context.Background(), "abc123", "books")
+	if err == nil {
+		t.Fatal("expected setCategory to return an error on a 409, got nil")
+	}
+	if !hit {
+		t.Fatal("expected setCategory endpoint to be hit")
+	}
+	if !strings.Contains(err.Error(), "409") {
+		t.Errorf("error should surface the 409 status, got %q", err.Error())
+	}
+}
+
 // TestAddTorrent_DuplicateRecovery_EnablesAutoManagement verifies that the 409
 // duplicate-recovery path re-categorises the existing torrent AND enables
 // automatic torrent management so it relocates to the category's save path.


### PR DESCRIPTION
setCategory ignored the HTTP response status, so a 409 (category does not exist) got swallowed. That blinded the #969 missing-category warning and let a mis categorized torrent quietly drop out of the category filtered download poll.

Now it checks the status the same way setAutoManagement already does and returns an error on non 2xx, so the caller's existing best effort warning path fires. Success path unchanged.

Added a test that stands up a fake qBittorrent returning 409 for setCategory and asserts the error propagates.

Closes #1464

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>