### PR TITLE
fix(logs): escape LIKE wildcards in log search (#1466)

### DIFF
--- a/changelog.d/1466-log-search-escape.md
+++ b/changelog.d/1466-log-search-escape.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Log search takes wildcards literally** (#1466). Searching the logs for a term containing `%`, `_`, or `\` now matches those characters as text instead of treating them as SQL wildcards, so you get the results you expect.

--- a/internal/db/logs.go
+++ b/internal/db/logs.go
@@ -80,8 +80,8 @@ func (r *LogRepo) Query(ctx context.Context, f LogFilter) ([]LogEntry, error) {
 		args = append(args, f.ToTS.UTC())
 	}
 	if f.Q != "" {
-		conds = append(conds, "(message LIKE ? OR fields LIKE ?)")
-		pattern := "%" + strings.ReplaceAll(f.Q, "%", "\\%") + "%"
+		conds = append(conds, "(message LIKE ? ESCAPE '\\' OR fields LIKE ? ESCAPE '\\')")
+		pattern := "%" + escapeLike(f.Q) + "%"
 		args = append(args, pattern, pattern)
 	}
 

--- a/internal/db/logs_test.go
+++ b/internal/db/logs_test.go
@@ -146,6 +146,42 @@ func TestLogRepo_QueryFullText(t *testing.T) {
 	}
 }
 
+// A search term containing LIKE metacharacters (%, _) must match literally,
+// not act as a wildcard (#1466).
+func TestLogRepo_QueryEscapesLikeWildcards(t *testing.T) {
+	repo, cleanup := openLogDB(t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	insertEntry(t, repo, now.Add(-2*time.Second), "INFO", "", "job 100% complete")
+	insertEntry(t, repo, now.Add(-1*time.Second), "INFO", "", "job aborted at start")
+	insertEntry(t, repo, now, "INFO", "", "user_id resolved")
+	// Decoy: an unescaped "_" wildcard would also match this "userXid" row.
+	insertEntry(t, repo, now, "INFO", "", "userXid resolved")
+
+	// "%" must be literal: it should match only the "100% complete" row, not
+	// every row (which is what an unescaped "%...%" wildcard would do).
+	entries, err := repo.Query(context.Background(), LogFilter{Q: "100%", Limit: 100})
+	if err != nil {
+		t.Fatalf("query %%: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry matching literal '100%%', got %d", len(entries))
+	}
+	if entries[0].Message != "job 100% complete" {
+		t.Errorf("matched wrong row: %q", entries[0].Message)
+	}
+
+	// "_" must be literal: it should match "user_id", not "userXid".
+	entries, err = repo.Query(context.Background(), LogFilter{Q: "user_id", Limit: 100})
+	if err != nil {
+		t.Fatalf("query _: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry matching literal 'user_id', got %d", len(entries))
+	}
+}
+
 func TestLogRepo_Trim(t *testing.T) {
 	repo, cleanup := openLogDB(t)
 	defer cleanup()


### PR DESCRIPTION
Log search built its LIKE pattern by escaping only `%` and never added `ESCAPE '\'`, so searching for a term with `%`, `_`, or `\` treated those as SQL wildcards. This was the one search path that didn't already do the escaping that authors.go and books.go do.

Now it routes the term through the shared `escapeLike` helper and adds `ESCAPE '\'` to both LIKE clauses, so terms match literally.

Added a test with `100%`, `user_id`, and a `userXid` decoy row to prove the wildcards no longer leak.

Closes #1466

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>