### PR TITLE
fix(importer): remove per-item catalogue reload that stalled bulk folder scan (#1473)

### DIFF
--- a/changelog.d/1473-bulk-import-timeout.md
+++ b/changelog.d/1473-bulk-import-timeout.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Bulk Folder Import no longer times out on large libraries** (#1473). Scanning a folder used to reload the entire book and author catalogue once for every item in the folder, so a folder with a few hundred entries fired hundreds of full table queries in a single request and ran past the server's request timeout, leaving the connection dead and no logs to explain it. The scan now loads the catalogue once and reuses it for every item, and it logs when a scan starts and finishes with how long it took and how many matches it found.

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -22,6 +22,7 @@ import (
 
 type manualImportScanner interface {
 	Lookup(ctx context.Context, path string) (importer.LookupResult, error)
+	LookupBatch(ctx context.Context, paths []string) ([]importer.LookupResult, error)
 	ImportFromPath(ctx context.Context, dl *models.Download, path, formatHint string)
 }
 
@@ -365,10 +366,23 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
 
-	resp := ScanResponse{Items: []ScanItem{}}
+	start := time.Now()
+
+	// Collect the importable children first, then run a single catalogue-backed
+	// batch lookup. Previously each child called Lookup, which re-queried the
+	// full books AND authors tables per item; a folder of several hundred
+	// entries produced hundreds of full-table scans in one synchronous request
+	// and blew past the server WriteTimeout, killing the connection mid-write
+	// with no logs (issue #1473).
+	type candidate struct {
+		path string
+		name string
+	}
+	var cands []candidate
+	truncated := false
 	for _, e := range entries {
-		if len(resp.Items) >= maxScanEntries {
-			resp.Truncated = true
+		if len(cands) >= maxScanEntries {
+			truncated = true
 			break
 		}
 		child := filepath.Join(path, e.Name())
@@ -379,13 +393,32 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 		if isDir && !dirHasBookFile(child) {
 			continue
 		}
-		res, err := h.scanner.Lookup(r.Context(), child)
-		if err != nil {
-			continue
+		cands = append(cands, candidate{path: child, name: e.Name()})
+	}
+
+	slog.Info("bulk folder import scan started", "path", path, "entries", len(cands), "truncated", truncated)
+
+	paths := make([]string, len(cands))
+	for i, c := range cands {
+		paths[i] = c.path
+	}
+	results, err := h.scanner.LookupBatch(r.Context(), paths)
+	if err != nil {
+		slog.Error("bulk folder import scan failed to load catalogue", "path", path, "error", err)
+		writeServerError(w, r, err)
+		return
+	}
+
+	resp := ScanResponse{Items: make([]ScanItem, 0, len(cands)), Truncated: truncated}
+	matched := 0
+	for i, c := range cands {
+		res := results[i]
+		if res.Match == "confident" {
+			matched++
 		}
 		resp.Items = append(resp.Items, ScanItem{
-			Path:           child,
-			Name:           e.Name(),
+			Path:           c.path,
+			Name:           c.name,
 			Match:          res.Match,
 			ParsedTitle:    res.ParsedTitle,
 			ParsedAuthor:   res.ParsedAuthor,
@@ -394,6 +427,12 @@ func (h *ManualImportHandler) Scan(w http.ResponseWriter, r *http.Request) {
 			Candidates:     res.Candidates,
 		})
 	}
+	slog.Info("bulk folder import scan complete",
+		"path", path,
+		"duration", time.Since(start),
+		"items", len(resp.Items),
+		"matched", matched,
+		"truncated", truncated)
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -30,12 +30,25 @@ func lookupRequest(path string) *http.Request {
 // ImportFromPath is a no-op because the handler calls it in a goroutine and
 // the tests only verify the synchronous HTTP response.
 type stubManualImportScanner struct {
-	lookupResult importer.LookupResult
-	lookupErr    error
+	lookupResult     importer.LookupResult
+	lookupErr        error
+	lookupBatchCalls int
 }
 
 func (s *stubManualImportScanner) Lookup(_ context.Context, _ string) (importer.LookupResult, error) {
 	return s.lookupResult, s.lookupErr
+}
+
+func (s *stubManualImportScanner) LookupBatch(_ context.Context, paths []string) ([]importer.LookupResult, error) {
+	s.lookupBatchCalls++
+	if s.lookupErr != nil {
+		return nil, s.lookupErr
+	}
+	out := make([]importer.LookupResult, len(paths))
+	for i := range paths {
+		out[i] = s.lookupResult
+	}
+	return out, nil
 }
 
 func (s *stubManualImportScanner) ImportFromPath(_ context.Context, _ *models.Download, _, _ string) {
@@ -673,6 +686,12 @@ func TestManualImportScan_EnumeratesBookUnits(t *testing.T) {
 	}
 	if resp.Truncated {
 		t.Error("unexpected truncation for a small folder")
+	}
+	// Regression guard for #1473: however many units a scan enumerates, it must
+	// load the catalogue exactly once (a single batch lookup) rather than once
+	// per item, which is the N+1 that stalled large scans past WriteTimeout.
+	if stub.lookupBatchCalls != 1 {
+		t.Errorf("LookupBatch called %d times, want exactly 1 for the whole scan", stub.lookupBatchCalls)
 	}
 }
 

--- a/internal/importer/lookup.go
+++ b/internal/importer/lookup.go
@@ -34,6 +34,55 @@ type LookupResult struct {
 // "audiobook" regardless of content.
 func (s *Scanner) Lookup(ctx context.Context, path string) (LookupResult, error) {
 	parsed := ParseFilename(path)
+	base := LookupResult{
+		DetectedFormat: lookupDetectFormat(path),
+		ParsedTitle:    parsed.Title,
+		ParsedAuthor:   parsed.Author,
+	}
+	books, err := s.books.List(ctx)
+	if err != nil {
+		return base, fmt.Errorf("lookup: list books: %w", err)
+	}
+	authors, err := s.authors.List(ctx)
+	if err != nil {
+		return base, fmt.Errorf("lookup: list authors: %w", err)
+	}
+	return lookupWith(path, books, authors), nil
+}
+
+// LookupBatch runs the same catalogue match as Lookup over many paths while
+// loading the books and authors catalogue exactly ONCE for the whole batch,
+// instead of re-querying both full tables per path. Bulk Folder Import points
+// this at a folder with hundreds of entries; the old per-item Lookup issued
+// hundreds of full-table scans in a single synchronous request and blew past
+// the server WriteTimeout (issue #1473). Results are returned aligned with the
+// input paths. It returns an error only if the one-time catalogue load fails,
+// in which case the caller should fail the whole scan loudly rather than
+// swallow it per item.
+func (s *Scanner) LookupBatch(ctx context.Context, paths []string) ([]LookupResult, error) {
+	books, err := s.books.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("lookup batch: list books: %w", err)
+	}
+	authors, err := s.authors.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("lookup batch: list authors: %w", err)
+	}
+	results := make([]LookupResult, len(paths))
+	for i, p := range paths {
+		results[i] = lookupWith(p, books, authors)
+	}
+	return results, nil
+}
+
+// lookupWith performs the catalogue match against PRE-LOADED books and authors
+// slices instead of querying the repositories itself. Bulk scans (Scan) load
+// the catalogue once and call this per item so a folder of several hundred
+// entries no longer triggers a full-table books+authors query per item — the
+// N+1 that stalled large scans past the server WriteTimeout (issue #1473). The
+// match logic is identical to Lookup's.
+func lookupWith(path string, books []models.Book, authors []models.Author) LookupResult {
+	parsed := ParseFilename(path)
 	detectedFormat := lookupDetectFormat(path)
 
 	result := LookupResult{
@@ -44,12 +93,7 @@ func (s *Scanner) Lookup(ctx context.Context, path string) (LookupResult, error)
 
 	if parsed.Title == "" && parsed.ASIN == "" {
 		result.Match = "none"
-		return result, nil
-	}
-
-	books, err := s.books.List(ctx)
-	if err != nil {
-		return result, fmt.Errorf("lookup: list books: %w", err)
+		return result
 	}
 
 	// Tier 1: ASIN exact match.
@@ -58,16 +102,12 @@ func (s *Scanner) Lookup(ctx context.Context, path string) (LookupResult, error)
 			if books[i].ASIN == parsed.ASIN {
 				result.Match = "confident"
 				result.Book = &books[i]
-				return result, nil
+				return result
 			}
 		}
 	}
 
 	// Tiers 2+: title match with optional author filter.
-	authors, err := s.authors.List(ctx)
-	if err != nil {
-		return result, fmt.Errorf("lookup: list authors: %w", err)
-	}
 	authorNames := make(map[int64]string, len(authors))
 	for _, a := range authors {
 		authorNames[a.ID] = a.Name
@@ -94,7 +134,7 @@ func (s *Scanner) Lookup(ctx context.Context, path string) (LookupResult, error)
 		result.Match = "ambiguous"
 		result.Candidates = matches
 	}
-	return result, nil
+	return result
 }
 
 // matchBookForDownload tries to associate an unmatched download (one grabbed

--- a/internal/importer/lookup_test.go
+++ b/internal/importer/lookup_test.go
@@ -149,6 +149,59 @@ func TestScanner_Lookup_TitleAuthor(t *testing.T) {
 	}
 }
 
+// TestScanner_LookupBatch_MatchesEqualLookup verifies LookupBatch returns the
+// same per-path match as calling Lookup individually, so the N+1 fix for #1473
+// (loading the catalogue once for the whole batch) does not alter matching.
+func TestScanner_LookupBatch_MatchesEqualLookup(t *testing.T) {
+	t.Parallel()
+	s, books, authors, ctx := scannerFixture(t, t.TempDir())
+
+	author := &models.Author{Name: "Andy Weir", ForeignID: "a1", SortName: "Weir, Andy"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{AuthorID: author.ID, Title: "Project Hail Mary", ForeignID: "b1", Status: "wanted"}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	tmp := t.TempDir()
+	match := filepath.Join(tmp, "Project.Hail.Mary.Andy.Weir.epub")
+	miss := filepath.Join(tmp, "Unknown.Book.Nobody.epub")
+	for _, f := range []string{match, miss} {
+		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	paths := []string{match, miss}
+	batch, err := s.LookupBatch(ctx, paths)
+	if err != nil {
+		t.Fatalf("LookupBatch: %v", err)
+	}
+	if len(batch) != len(paths) {
+		t.Fatalf("batch len = %d, want %d", len(batch), len(paths))
+	}
+	for i, p := range paths {
+		want, err := s.Lookup(ctx, p)
+		if err != nil {
+			t.Fatalf("Lookup(%s): %v", p, err)
+		}
+		if batch[i].Match != want.Match {
+			t.Errorf("path %s: batch match = %q, want %q", p, batch[i].Match, want.Match)
+		}
+		if (batch[i].Book == nil) != (want.Book == nil) {
+			t.Errorf("path %s: batch book presence mismatch", p)
+		}
+		if batch[i].Book != nil && want.Book != nil && batch[i].Book.ID != want.Book.ID {
+			t.Errorf("path %s: batch book id = %d, want %d", p, batch[i].Book.ID, want.Book.ID)
+		}
+	}
+	if batch[0].Match != "confident" || batch[1].Match != "none" {
+		t.Errorf("matches = %q,%q; want confident,none", batch[0].Match, batch[1].Match)
+	}
+}
+
 // TestScanner_Lookup_None verifies no-match returns "none".
 func TestScanner_Lookup_None(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What

Bulk Folder Import (the v1.24 headline feature) timed out on large libraries and errored with no logs.

The scan looped over every child of a folder and called Lookup on each one, and every single Lookup re-ran `books.List` and `authors.List`, two full table catalogue queries. Point it at a folder with a few hundred entries and you get hundreds of full table scans crammed into one synchronous request. That runs straight past the server's 120s WriteTimeout, so the connection dies mid write, the frontend shows a generic toast, and to top it off the per item errors were dropped with a bare `continue` so there was nothing in the logs even at debug.

## Fix

Hoist the catalogue load out of the loop. New `Scanner.LookupBatch` loads books and authors once and reuses the preloaded slices for every path, running the exact same match logic (pulled out into `lookupWith`, which the existing `Lookup` now delegates to as well). One pair of queries for the whole scan instead of one pair per item.

`Scan` also logs now: an info line when it starts (path, entry count) and one when it finishes (duration, matched count), so a slow or failing scan is actually visible.

No API, schema, or frontend change. Matching behavior is identical.

## Tests

`go test ./internal/api/... ./internal/importer/...` green. Added a regression test asserting the scan runs a single batch lookup for the whole folder (not one per item), plus an importer test asserting `LookupBatch` returns the same matches as calling `Lookup` per path.

Closes #1473

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>