### PR TITLE
fix(db): guard DownloadRepo.UpdateStatus against a status-race TOCTOU (#1462)

### DIFF
--- a/changelog.d/1462-updatestatus-toctou.md
+++ b/changelog.d/1462-updatestatus-toctou.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Download status races** (#1462): two things updating the same download at once could slip an illegal state change through (re-completing an already imported download or double stamping timestamps). The status update is now applied atomically so only one writer wins and the row can't land in a bad state.

--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -204,14 +204,24 @@ func (r *DownloadRepo) UpdateStatus(ctx context.Context, id int64, next models.D
 	}
 
 	now := time.Now().UTC()
+	// Every UPDATE below guards on `status=current` so the check-and-set is
+	// atomic in a single statement. The CanTransitionTo check above is only a
+	// fast-path/early-exit: between that read and the write, a concurrent
+	// writer could have moved the row on (re-completing an already-imported
+	// row, double-stamping a timestamp, or any other illegal hop). The SQL
+	// guard is the real safety — if the status has changed out from under us
+	// the UPDATE matches zero rows and we report the transition as invalid
+	// rather than clobbering the new state. See RetryFailed /
+	// RecoverInterruptedImports for the same pattern.
+	var result sql.Result
 	switch next {
 	case models.StateDownloading:
 		// Stamp grabbed_at on the Grabbed -> Downloading transition. The
 		// COALESCE preserves an earlier SetGrabbedAt value (e.g. a replayed
 		// historical timestamp) so an explicit override is never clobbered.
-		_, err = r.db.ExecContext(ctx,
-			"UPDATE downloads SET status=?, grabbed_at=COALESCE(grabbed_at, ?) WHERE id=?",
-			next, now, id)
+		result, err = r.db.ExecContext(ctx,
+			"UPDATE downloads SET status=?, grabbed_at=COALESCE(grabbed_at, ?) WHERE id=? AND status=?",
+			next, now, id, current)
 	case models.StateCompleted:
 		// Backfill grabbed_at on the duplicate-add fast-path (#769 and finding
 		// 22): a torrent that was already at 100 percent jumps straight from
@@ -219,20 +229,35 @@ func (r *DownloadRepo) UpdateStatus(ctx context.Context, id int64, next models.D
 		// StateDownloading. Without the backfill the row stays invisible to
 		// the stall detector (which filters on grabbed_at IS NOT NULL) and
 		// shows an empty Grabbed column in the queue UI.
-		_, err = r.db.ExecContext(ctx,
-			"UPDATE downloads SET status=?, completed_at=?, grabbed_at=COALESCE(grabbed_at, ?) WHERE id=?",
-			next, now, now, id)
+		result, err = r.db.ExecContext(ctx,
+			"UPDATE downloads SET status=?, completed_at=?, grabbed_at=COALESCE(grabbed_at, ?) WHERE id=? AND status=?",
+			next, now, now, id, current)
 	case models.StateImported:
-		_, err = r.db.ExecContext(ctx, "UPDATE downloads SET status=?, imported_at=? WHERE id=?", next, now, id)
+		result, err = r.db.ExecContext(ctx,
+			"UPDATE downloads SET status=?, imported_at=? WHERE id=? AND status=?", next, now, id, current)
 	default:
 		// StateGrabbed -> StateFailed (couldn't send to client) deliberately
 		// leaves grabbed_at NULL: nothing was ever grabbed. All other forward
 		// transitions stay in the import lifecycle, which is gated by the
 		// validTransitions table and only reachable after StateCompleted has
 		// already backfilled grabbed_at above.
-		_, err = r.db.ExecContext(ctx, "UPDATE downloads SET status=? WHERE id=?", next, id)
+		result, err = r.db.ExecContext(ctx,
+			"UPDATE downloads SET status=? WHERE id=? AND status=?", next, id, current)
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update status rows affected: %w", err)
+	}
+	if affected == 0 {
+		// The row's status changed between our read and write — the transition
+		// we validated no longer applies. Report it as invalid rather than
+		// silently no-op'ing.
+		return models.ErrInvalidTransition{From: current, To: next}
+	}
+	return nil
 }
 
 // SetGrabbedAt overrides the grabbed_at timestamp for a download. It exists
@@ -283,10 +308,24 @@ func (r *DownloadRepo) SetErrorWithStatus(ctx context.Context, id int64, status 
 	if current != status && !current.CanTransitionTo(status) {
 		return models.ErrInvalidTransition{From: current, To: status}
 	}
-	_, err := r.db.ExecContext(ctx,
-		"UPDATE downloads SET status=?, error_message=? WHERE id=?",
-		status, errMsg, id)
-	return err
+	// Guard on status=current so the validated transition is applied
+	// atomically: a concurrent writer that moved the row on between our read
+	// and write matches zero rows and we report the transition as invalid
+	// rather than stamping a failure onto whatever state it landed in.
+	result, err := r.db.ExecContext(ctx,
+		"UPDATE downloads SET status=?, error_message=? WHERE id=? AND status=?",
+		status, errMsg, id, current)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("set error with status rows affected: %w", err)
+	}
+	if affected == 0 {
+		return models.ErrInvalidTransition{From: current, To: status}
+	}
+	return nil
 }
 
 // IncrementImportRetryCount bumps the import_retry_count for the download by

--- a/internal/db/downloads_coverage_test.go
+++ b/internal/db/downloads_coverage_test.go
@@ -2,6 +2,9 @@ package db
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -143,6 +146,90 @@ func TestDownloadRepo_RecoverInterruptedImports(t *testing.T) {
 	}
 	if len(again) != 0 {
 		t.Errorf("second sweep recovered %d downloads, want 0", len(again))
+	}
+}
+
+// TestDownloadRepo_UpdateStatusRaceGuard is the regression test for #1462.
+// UpdateStatus used to validate the transition in Go and then issue an UPDATE
+// with no status guard, so two writers that both read the same starting state
+// could each "succeed" and double-apply an illegal transition (re-completing an
+// already-imported row, double-stamping timestamps, etc.). The UPDATE is now
+// conditional on the status the caller read (WHERE ... AND status=?), so the
+// check-and-set is atomic: exactly one racing writer wins and the losers get
+// ErrInvalidTransition without mutating the row.
+//
+// The invariant exploited here: StateGrabbed -> StateDownloading is a valid
+// transition, but StateDownloading -> StateDownloading is not (no self-loop in
+// validTransitions). So no matter how the two statements of each caller
+// interleave on the single shared connection, at most one writer can ever
+// legally land the row in StateDownloading. Before the fix, an interleave of
+// (A.select, B.select, A.update, B.update) let both writers commit.
+func TestDownloadRepo_UpdateStatusRaceGuard(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewDownloadRepo(database)
+
+	const iterations = 300
+	const writers = 6
+
+	for i := 0; i < iterations; i++ {
+		dl := &models.Download{
+			GUID: fmt.Sprintf("race-%d", i), Title: "race.release", NZBURL: "x",
+			Size: 1, Status: models.StateGrabbed, Protocol: "torrent",
+		}
+		if err := repo.Create(ctx, dl); err != nil {
+			t.Fatalf("iteration %d: create: %v", i, err)
+		}
+
+		// Fan several writers at the same Grabbed -> Downloading transition and
+		// release them together to maximise the chance of interleaving the
+		// select and update halves on the shared connection.
+		results := make([]error, writers)
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for w := 0; w < writers; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				<-start
+				// Each writer writes only its own results slot, so this stays
+				// data-race clean under `go test -race`.
+				results[w] = repo.UpdateStatus(ctx, dl.ID, models.StateDownloading)
+			}(w)
+		}
+		close(start)
+		wg.Wait()
+
+		successes := 0
+		for _, e := range results {
+			if e == nil {
+				successes++
+				continue
+			}
+			// Every loser must fail with the invalid-transition error, whether
+			// it lost at the fast-path CanTransitionTo check (its select already
+			// saw Downloading) or at the SQL guard (its update matched 0 rows).
+			var invalid models.ErrInvalidTransition
+			if !errors.As(e, &invalid) {
+				t.Fatalf("iteration %d: loser returned %v, want ErrInvalidTransition", i, e)
+			}
+		}
+		if successes != 1 {
+			t.Fatalf("iteration %d: %d writers succeeded, want exactly 1 (illegal transition double-applied)", i, successes)
+		}
+
+		// The row must sit in exactly the one applied state.
+		got, err := repo.GetByGUID(ctx, dl.GUID)
+		if err != nil || got == nil {
+			t.Fatalf("iteration %d: get after race: %v", i, err)
+		}
+		if got.Status != models.StateDownloading {
+			t.Fatalf("iteration %d: final status = %q, want %q", i, got.Status, models.StateDownloading)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

`DownloadRepo.UpdateStatus` (and `SetErrorWithStatus`) read the current status, validated the transition in Go, then ran an UPDATE with no status guard. A concurrent writer could slip in between the read and the write and push an illegal transition through: re-completing an already imported row, double stamping a timestamp, or any other hop the state machine forbids.

## Fix

The UPDATE is now conditional on the status we read (`WHERE ... AND status=?`) and `RowsAffected()==0` returns `ErrInvalidTransition`, so the check and set is atomic in one statement. This mirrors the guarded pattern the sibling `RetryFailed` / `RecoverInterruptedImports` methods already use. The `CanTransitionTo` pre check stays as a fast path.

Added a regression test that fans several writers at the same Grabbed to Downloading transition and asserts exactly one wins while the losers get `ErrInvalidTransition` and the row never lands in a bad state. Verified it fails on the old unguarded code and passes with the guard.

`go build ./...`, `go test ./internal/db/...` and `go test ./internal/importer/...` all green (db test also run under `-race`).

Closes #1462

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>