### PR TITLE
chore(release): changelog for v1.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,85 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [v1.24.2] — 2026-07-07
+
+A fast follow-up patch. The headline fix is Bulk Folder Import, which stalled for
+minutes and then failed with no logs on any library with a few hundred entries,
+because it reloaded the whole book and author catalogue once for every item in
+the folder. The rest is a batch of correctness and security fixes surfaced by an
+internal audit: two data-safety races on the download pipeline, a nightly refresh
+that wiped enriched author metadata, a Transmission queue mapping that failed
+healthy downloads, and two hardening fixes covering system logs and indexer keys.
+
+### Security
+- **System logs are now admin-only** (#1451) — `/system/logs` and
+  `/system/loglevel` were reachable by any authenticated user, exposing the
+  app-wide log stream (other users' book and author names, OIDC usernames,
+  download titles) and letting a non-admin flip the global log level. They now
+  require admin, matching every other global-infra route.
+- **Indexer API keys no longer leak into errors** (#1450) — when a torrent/NZB
+  fetch failed at the transport layer (timeout, DNS, TLS), the underlying
+  `url.Error` carried the full signed download URL, including the indexer's
+  `apikey`, into the download row, history, and webhook/Discord notifications.
+  All five download-client fetch paths now scrub the key before the error is
+  wrapped.
+
+### Fixed
+- **Bulk Folder Import no longer times out on large libraries** (#1473) —
+  scanning a folder used to reload the entire book and author catalogue once for
+  every item, so a folder with a few hundred entries fired hundreds of
+  full-table queries in a single request and ran past the server's request
+  timeout, leaving the connection dead and no logs to explain it. The scan now
+  loads the catalogue once and reuses it for every item, and it logs when a scan
+  starts and finishes with how long it took and how many matches it found.
+- **Download status races** (#1462) — two things updating the same download at
+  once could slip an illegal state change through (re-completing an already
+  imported download or double stamping timestamps). The status update is now
+  applied atomically so only one writer wins and the row can't land in a bad
+  state.
+- **Transmission downloads queued behind others no longer fail to import**
+  (#1452) — the RPC status enum was mapped wrong (`3` was treated as "seeding",
+  `6` as "stopped"; they are actually "queued to download" and "seeding"). A
+  torrent sitting in Transmission's download queue at 0% was treated as
+  complete, import fired against an empty directory, failed, and after
+  exhausting its retries the download was terminally blocked even though it was
+  perfectly healthy. Completion is now keyed off real seeding / 100%-downloaded
+  state.
+- **The wanted-book sweep no longer double-grabs** (#1453) — a Wanted book stays
+  Wanted until its file is imported and reconciled, so a book whose grab was
+  still downloading (or working through the import pipeline) was re-searched on
+  the next scheduled sweep and, if the indexer now ranked a different release
+  best, a second download was grabbed for the same book. The sweep now skips
+  books with a grab already in flight, while still re-searching books whose
+  previous download failed.
+- **Author metadata refresh no longer wipes enriched fields** (#1463) — the
+  nightly refresh now keeps the existing description, ratings and rating count
+  when the upstream record comes back sparse, instead of overwriting them with
+  empty values.
+- **qBittorrent category rejections are no longer ignored** (#1464) — Bindery
+  now notices when qBittorrent rejects a category assignment (for example a 409
+  because the category does not exist) instead of silently ignoring it, so the
+  missing-category warning fires and a mis-categorized torrent no longer
+  vanishes from the download poll.
+- **Grimmory "Test connection" now authenticates before probing status** (#1448)
+  — recent Grimmory guards `/api/status` behind a valid session, so the test
+  button returned a 401 for anyone using username/password auth. Bindery now
+  logs in first and presents the token when checking connectivity (retrying once
+  if a cached token has expired), so the test succeeds instead of failing at the
+  door.
+- **Log search takes wildcards literally** (#1466) — searching the logs for a
+  term containing `%`, `_`, or `\` now matches those characters as text instead
+  of treating them as SQL wildcards, so you get the results you expect.
+- **Faster library, book, and search queries** (#1454) — the query that finds
+  each book's ebook/audiobook file ran twice per book listing and was doing a
+  full scan of the `book_files` table because no index covered its `format`
+  filter. A new composite index makes it an index seek, most noticeable on large
+  libraries and on the paginated Books page. Applied automatically on upgrade.
+- **Bulk "search" on the Wanted page is much faster** (#1455) — selecting a
+  large batch and hitting search issued one of the heaviest book queries per
+  book instead of a single batched fetch, so a 500-book bulk search ran hundreds
+  of full-table aggregations. It now loads all selected books in one query.
+
 ## [v1.24.1] — 2026-07-06
 
 A patch cut of fixes surfaced by the community in the days after v1.24.0: two

--- a/changelog.d/1448-grimmory-status-auth.md
+++ b/changelog.d/1448-grimmory-status-auth.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Grimmory "Test connection" now authenticates before probing status** (#1448) — recent Grimmory guards `/api/status` behind a valid session, so the test button returned a 401 for anyone using username/password auth. Bindery now logs in first and presents the token when checking connectivity (retrying once if a cached token has expired), so the test succeeds instead of failing at the door.

--- a/changelog.d/1462-updatestatus-toctou.md
+++ b/changelog.d/1462-updatestatus-toctou.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Download status races** (#1462): two things updating the same download at once could slip an illegal state change through (re-completing an already imported download or double stamping timestamps). The status update is now applied atomically so only one writer wins and the row can't land in a bad state.

--- a/changelog.d/1463-author-refresh-empty.md
+++ b/changelog.d/1463-author-refresh-empty.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Author metadata refresh no longer wipes enriched fields** (#1463) — the nightly refresh kept the existing description, ratings and rating count when the upstream record came back sparse, instead of overwriting them with empty values.

--- a/changelog.d/1464-qbit-setcategory.md
+++ b/changelog.d/1464-qbit-setcategory.md
@@ -1,3 +1,0 @@
-### Fixed
-
-Bindery now notices when qBittorrent rejects a category assignment (for example a 409 because the category does not exist) instead of silently ignoring it, so the missing category warning fires and a mis categorized torrent no longer vanishes from the download poll (#1464).

--- a/changelog.d/1466-log-search-escape.md
+++ b/changelog.d/1466-log-search-escape.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Log search takes wildcards literally** (#1466). Searching the logs for a term containing `%`, `_`, or `\` now matches those characters as text instead of treating them as SQL wildcards, so you get the results you expect.

--- a/changelog.d/1473-bulk-import-timeout.md
+++ b/changelog.d/1473-bulk-import-timeout.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Bulk Folder Import no longer times out on large libraries** (#1473). Scanning a folder used to reload the entire book and author catalogue once for every item in the folder, so a folder with a few hundred entries fired hundreds of full table queries in a single request and ran past the server's request timeout, leaving the connection dead and no logs to explain it. The scan now loads the catalogue once and reuses it for every item, and it logs when a scan starts and finishes with how long it took and how many matches it found.

--- a/changelog.d/book-files-format-index.md
+++ b/changelog.d/book-files-format-index.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Faster library, book, and search queries** — the query that finds each book's ebook/audiobook file ran twice per book listing and was doing a full scan of the `book_files` table because no index covered its `format` filter. A new composite index makes it an index seek, which is most noticeable on large libraries and on the paginated Books page. Applied automatically on upgrade.

--- a/changelog.d/bulk-search-n1.md
+++ b/changelog.d/bulk-search-n1.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Bulk "search" on the Wanted page is much faster** — selecting a large batch and hitting search issued one of the heaviest book queries per book instead of a single batched fetch, so a 500-book bulk search ran hundreds of full-table aggregations. It now loads all selected books in one query.

--- a/changelog.d/download-key-redaction.md
+++ b/changelog.d/download-key-redaction.md
@@ -1,2 +1,0 @@
-### Security
-- **Indexer API keys no longer leak into errors** — when a torrent/NZB fetch failed at the transport layer (timeout, DNS, TLS), the underlying `url.Error` carried the full signed download URL, including the indexer's `apikey`, into the download row, history, and webhook/Discord notifications. All five download-client fetch paths now scrub the key before the error is wrapped.

--- a/changelog.d/system-logs-admin.md
+++ b/changelog.d/system-logs-admin.md
@@ -1,2 +1,0 @@
-### Security
-- **System logs are now admin-only** — `/system/logs` and `/system/loglevel` were reachable by any authenticated user, exposing the app-wide log stream (other users' book and author names, OIDC usernames, download titles) and letting a non-admin flip the global log level. They now require admin, matching every other global-infra route.

--- a/changelog.d/transmission-status-enum.md
+++ b/changelog.d/transmission-status-enum.md
@@ -1,2 +1,0 @@
-### Fixed
-- **Transmission downloads queued behind others no longer fail to import** — the RPC status enum was mapped wrong (`3` was treated as "seeding", `6` as "stopped"; they are actually "queued to download" and "seeding"). A torrent sitting in Transmission's download queue at 0% was treated as complete, import fired against an empty directory, failed, and after exhausting its retries the download was terminally blocked even though it was perfectly healthy. Completion is now keyed off real seeding / 100%-downloaded state.

--- a/changelog.d/wanted-double-grab.md
+++ b/changelog.d/wanted-double-grab.md
@@ -1,2 +1,0 @@
-### Fixed
-- **The wanted-book sweep no longer double-grabs** — a Wanted book stays Wanted until its file is imported and reconciled, so a book whose grab was still downloading (or working through the import pipeline) was re-searched on the next scheduled sweep and, if the indexer now ranked a different release best, a second download was grabbed for the same book. The sweep now skips books with a grab already in flight, while still re-searching books whose previous download failed.


### PR DESCRIPTION
Assembles the v1.24.2 fragments into CHANGELOG.md and clears `changelog.d/`, so the release step can read the entry when the tag is pushed.

v1.24.2 bundles the headline Bulk Folder Import timeout fix (#1473) plus the internal-audit correctness and security batch: #1462, #1452, #1453, #1463, #1464, #1448, #1466, #1454, #1455, and the two Security items #1451 and #1450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)