### PR TITLE
fix(deps): bump Go toolchain to 1.26.5 for GO-2026-4970 and GO-2026-5856

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
 
       - name: Run live-provider canaries
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
@@ -73,7 +73,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -102,7 +102,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -131,7 +131,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - run: go test -race -timeout=25m ./cmd/... ./internal/...
 
@@ -174,7 +174,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - run: go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -209,7 +209,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - run: go test -race -timeout=25m ./cmd/... ./internal/...
 
@@ -389,7 +389,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -461,7 +461,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - name: Run ABS contract suite
         env:
@@ -490,7 +490,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
       - name: Wait for ArgoCD dev to sync
         env:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - name: Locate Go fuzz corpus cache

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -300,7 +300,7 @@ jobs:
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           cache: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY web/ .
 RUN npm run build
 
 # Stage 2: Build Go binary (native on BUILDPLATFORM, cross-compile to TARGETOS/TARGETARCH)
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/vavallee/bindery
 
 go 1.25.11
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/coreos/go-oidc/v3 v3.19.0


### PR DESCRIPTION
## Summary

go1.26.4 shipped two stdlib vulns that govulncheck reports as reachable in Bindery: GO-2026-4970 (crypto/tls, hit via the downloader HTTP clients) and GO-2026-5856 (os.Root, hit via `importer.hardlinkDirRooted`/`copyFileRooted`). This has been failing the required `lint` check on every PR since 2026-07-08, and grype's Container Scan since 2026-07-09 when its DB picked the vulns up. The v1.24.2 binaries and image were built with the affected stdlib, so this wants a patch release once merged.

Bumps go1.26.4 → go1.26.5 in:

| Where | What |
|-------|------|
| `go.mod` | `toolchain go1.26.5` |
| `ci.yml`, `canary.yml`, `fuzz.yml`, `security.yml` | all `go-version` pins |
| `Dockerfile` | `golang:1.26.5-alpine` builder digest |

Sidecar Dockerfiles (`cmd/telemetry-server`, `cmd/discord-stats`) float on `golang:1.26-alpine` digests and have open dependabot bumps (#1486/#1487), so they're not touched here.

## Checklist

- [x] Tests added or updated — n/a, no code change
- [x] Doc-update gate cleared (see `commits` skill — `docs/`, `README.md`, godoc, Helm values)
- [x] Wiki pages updated if user-facing behaviour changed — n/a

## Test plan

- [x] `govulncheck ./...` under 1.26.5 — 0 vulnerabilities
- [x] `go test ./cmd/... ./internal/...` — green
- [x] `gofmt -l .` clean
- [ ] `cd web && npm run build` — untouched