### PR TITLE
fix(grimmory): surface content type when a 2xx response body isn't JSON

### DIFF
--- a/internal/grimmory/client.go
+++ b/internal/grimmory/client.go
@@ -259,7 +259,13 @@ func (c *Client) doWithToken(ctx context.Context, method, path, token string, bo
 		return &APIError{StatusCode: resp.StatusCode, Message: msg}
 	}
 	if out != nil && len(raw) > 0 {
-		return json.Unmarshal(raw, out)
+		if err := json.Unmarshal(raw, out); err != nil {
+			// A 2xx with a non-JSON body is almost always a SPA fallback page
+			// or a reverse proxy answering in Grimmory's place (#1485) — say
+			// so instead of surfacing json's "invalid character '<'".
+			return fmt.Errorf("grimmory: %s %s returned HTTP %d with a non-JSON body (Content-Type %q) — the base URL likely points at a web UI or proxy rather than the Grimmory API: %w",
+				method, path, resp.StatusCode, resp.Header.Get("Content-Type"), err)
+		}
 	}
 	return nil
 }

--- a/internal/grimmory/client_test.go
+++ b/internal/grimmory/client_test.go
@@ -298,6 +298,32 @@ func TestPing_ServerError(t *testing.T) {
 	}
 }
 
+// TestPing_HTMLBody covers #1485: a 2xx response carrying HTML (SPA fallback
+// or an interposing reverse proxy) must produce an actionable error naming the
+// content type, not json's bare "invalid character '<'".
+func TestPing_HTMLBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<!doctype html><html><body>Grimmory</body></html>"))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(srv.URL, "testkey")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	_, err = c.Ping(context.Background())
+	if err == nil {
+		t.Fatal("Ping: want error for HTML body, got nil")
+	}
+	for _, want := range []string{"non-JSON", "text/html", "/api/status"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q: want it to mention %q", err, want)
+		}
+	}
+}
+
 // TestPing_AuthedStatusWithCredentials covers #1448: Grimmory guards
 // /api/status behind a valid session, so an unauthenticated probe 401s. When a
 // username/password is configured, Ping must log in first and present the JWT


### PR DESCRIPTION
## Summary

Covers #1485: adding a Grimmory connection failed with `invalid character '<' looking for beginning of value` — `doWithToken` json.Unmarshals any 2xx body, so an HTML page (SPA fallback, or a reverse proxy answering on the API path) produced json's raw parse error. Now the error names the method, path, HTTP status, and Content-Type and says what that combination usually means, so the reporter can tell whether their base URL is landing on Grimmory's web UI or a proxy page.

This is the defensive half; the reporter's root cause is still open on the issue (their browser reaches `/api/status` fine, so it may be container-network specific). Refs #1485 rather than closing it — the improved error should let them self-diagnose.

## Checklist

- [x] Tests added or updated — `TestPing_HTMLBody` regression test
- [x] Doc-update gate cleared (see `commits` skill — `docs/`, `README.md`, godoc, Helm values)
- [x] Wiki pages updated if user-facing behaviour changed — n/a, error text only

## Test plan

- [x] `go test -race ./internal/grimmory/` — green
- [x] `go vet ./internal/grimmory/`, `gofmt -l` clean
- [ ] `lint` will stay red until #1492 (Go 1.26.5 bump) merges — the govulncheck stdlib failure is repo-wide, not from this diff