### PR TITLE
feat(importer): add {Lang} naming-template token

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Clean-room Go rewrite, modern React UI, MIT-licensed, actively developed.
 
 **Import & organize**
 - Completed downloads matched by NZO ID and placed in the library with configurable naming. Modes: **Move** (default), **Copy** (keep source for seeding), **Hardlink** (zero extra disk; same filesystem required).
-- Naming tokens — `{Author}`, `{SortAuthor}`, `{Title}`, `{Year}`, `{Series}`, `{SeriesNumber}`, `{ext}` — collapse cleanly for non-series books.
+- Naming tokens — `{Author}`, `{SortAuthor}`, `{Title}`, `{Year}`, `{Series}`, `{SeriesNumber}`, `{Genre}`, `{Lang}`, `{ext}` — collapse cleanly for non-series books.
 - Cross-filesystem-safe moves: atomic rename when possible, copy + verify + delete for NFS / separate volumes. Full grab / import / failure history per book.
 - Calibre integration in three modes: `calibredb` CLI hook on import, [Bindery Bridge plugin](https://github.com/vavallee/bindery-plugins) (cross-container), or direct read of an existing Calibre library's `metadata.db` as Bindery's catalogue.
 

--- a/changelog.d/1175-lang-naming-token.md
+++ b/changelog.d/1175-lang-naming-token.md
@@ -1,0 +1,5 @@
+### Added
+- **`{Lang}` naming token** (#1175) — naming templates can now include the
+  book's language code (e.g. `en`), so foreign-language books can carry the
+  language in their folder or file name. Blank when the language is unknown,
+  collapsing cleanly like the other optional tokens.

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -113,6 +113,7 @@ func (r *Renamer) apply(template string, author *models.Author, book *models.Boo
 		"Series":       sanitizePath(series),
 		"SeriesNumber": sanitizePath(seriesNumber),
 		"Genre":        sanitizePath(firstGenre(book.Genres)),
+		"Lang":         sanitizePath(book.Language),
 		"ext":          ext,
 	}
 

--- a/internal/importer/renamer_preview_test.go
+++ b/internal/importer/renamer_preview_test.go
@@ -18,7 +18,8 @@ import (
 func TestRenamerPreviewSampleDriftGuard(t *testing.T) {
 	// Mirrors SAMPLE_BOOK: author "Jane Doe" (sort "Doe, Jane"),
 	// title "Sample Book", year 2024, ASIN "B01ABCDEFG",
-	// series "Demo Series", series number "2", genre "Fantasy", ext "epub".
+	// series "Demo Series", series number "2", genre "Fantasy", lang "en",
+	// ext "epub".
 	releaseDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	author := &models.Author{Name: "Jane Doe"}
 	book := &models.Book{
@@ -26,6 +27,7 @@ func TestRenamerPreviewSampleDriftGuard(t *testing.T) {
 		ASIN:        "B01ABCDEFG",
 		ReleaseDate: &releaseDate,
 		Genres:      []string{"Fantasy"},
+		Language:    "en",
 	}
 	const series = "Demo Series"
 	const seriesNumber = "2"
@@ -40,9 +42,9 @@ func TestRenamerPreviewSampleDriftGuard(t *testing.T) {
 	}{
 		{
 			name:     "all tokens (ebook)",
-			template: "{Author}|{SortAuthor}|{Title}|{Year}|{ASIN}|{Series}|{SeriesNumber}|{Genre}|{ext}",
+			template: "{Author}|{SortAuthor}|{Title}|{Year}|{ASIN}|{Series}|{SeriesNumber}|{Genre}|{Lang}|{ext}",
 			ext:      "epub",
-			want:     "Jane Doe|Doe, Jane|Sample Book|2024|B01ABCDEFG|Demo Series|2|Fantasy|epub",
+			want:     "Jane Doe|Doe, Jane|Sample Book|2024|B01ABCDEFG|Demo Series|2|Fantasy|en|epub",
 		},
 		{
 			name:     "default ebook template",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -605,6 +605,7 @@
         "tokenSeries": "{Series} — series title (blank for standalone)",
         "tokenSeriesNumber": "{SeriesNumber} — position in series",
         "tokenGenre": "{Genre} — primary genre, best with Hardcover enabled. Use {Genre:Unsorted} to set a fallback folder.",
+        "tokenLang": "{Lang} — book language code, e.g. en (blank if unknown)",
         "tokenExt": "{ext} — file extension, no leading dot (ebook only)",
         "tokenIgnoredAudiobook": "{{token}} is ignored for the audiobook folder template",
         "errorTraversal": "Template must not contain \".\" or \"..\" path segments.",

--- a/web/src/pages/settings/NamingTemplateField.test.tsx
+++ b/web/src/pages/settings/NamingTemplateField.test.tsx
@@ -43,10 +43,16 @@ describe('namingTemplate renderer (renamer.go mirror)', () => {
   })
 
   it('renders all tokens', () => {
-    const out = renderTemplate('{Author}|{SortAuthor}|{Title}|{Year}|{ASIN}|{Series}|{SeriesNumber}|{Genre}|{ext}', 'book')
+    const out = renderTemplate('{Author}|{SortAuthor}|{Title}|{Year}|{ASIN}|{Series}|{SeriesNumber}|{Genre}|{Lang}|{ext}', 'book')
     // "|" is stripped by sanitize only inside a substituted field, not in the
     // literal template, so the separators survive between tokens.
-    expect(out).toBe('Jane Doe|Doe, Jane|Sample Book|2024|B01ABCDEFG|Demo Series|2|Fantasy|epub')
+    expect(out).toBe('Jane Doe|Doe, Jane|Sample Book|2024|B01ABCDEFG|Demo Series|2|Fantasy|en|epub')
+  })
+
+  it('renders the {Lang} token and collapses its glue when empty', () => {
+    expect(renderTemplate('{Title} [{Lang}]', 'book')).toBe('Sample Book [en]')
+    const noLang = { ...SAMPLE_BOOK, lang: '' }
+    expect(renderTemplate('{Lang}/{Title}.{ext}', 'book', noLang)).toBe('Sample Book.epub')
   })
 
   it('renders {ext} as empty for the audiobook (folder) kind', () => {

--- a/web/src/pages/settings/namingTemplate.ts
+++ b/web/src/pages/settings/namingTemplate.ts
@@ -16,7 +16,7 @@ export interface NamingToken {
   ebookOnly?: boolean
 }
 
-// The 8 tokens supported by Renamer.apply, in display order. {ext} is
+// The tokens supported by Renamer.apply, in display order. {ext} is
 // ebook-only: the audiobook template names a directory, so the renderer
 // substitutes it with the empty string there.
 export const NAMING_TOKENS: readonly NamingToken[] = [
@@ -28,6 +28,7 @@ export const NAMING_TOKENS: readonly NamingToken[] = [
   { token: '{Series}', descKey: 'tokenSeries' },
   { token: '{SeriesNumber}', descKey: 'tokenSeriesNumber' },
   { token: '{Genre}', descKey: 'tokenGenre' },
+  { token: '{Lang}', descKey: 'tokenLang' },
   { token: '{ext}', descKey: 'tokenExt', ebookOnly: true },
 ] as const
 
@@ -46,6 +47,7 @@ export interface SampleBook {
   series: string
   seriesNumber: string
   genre: string
+  lang: string
   ext: string
 }
 
@@ -59,6 +61,7 @@ export const SAMPLE_BOOK: SampleBook = {
   series: 'Demo Series',
   seriesNumber: '2',
   genre: 'Fantasy',
+  lang: 'en',
   ext: 'epub',
 }
 
@@ -119,6 +122,7 @@ export function renderTemplate(
     Series: sanitizePath(sample.series),
     SeriesNumber: sanitizePath(sample.seriesNumber),
     Genre: sanitizePath(sample.genre),
+    Lang: sanitizePath(sample.lang),
     ext,
   }
   return template


### PR DESCRIPTION
## Summary

Adds a `{Lang}` token to the naming-template engine so foreign-language books can carry the language code in their folder/file names. Closes #1175.

- `internal/importer/renamer.go` — `Lang` entry in the values map, sourced from `models.Book.Language` (already loaded at rename time), sanitized like other fields.
- `web/src/pages/settings/namingTemplate.ts` — TS preview mirror: token list entry, `SampleBook.lang`, values map. Locale entry `tokenLang` (en; others fall back).
- Drift guards updated on both sides: `renamer_preview_test.go` all-tokens case now includes `{Lang}`, and `NamingTemplateField.test.tsx` gains a `{Lang}` render + empty-collapse test.
- README token list updated; changelog.d fragment included.

Blank when the language is unknown, and collapses with its glue like the other optional tokens (`{Lang}/{Title}` with no language doesn't leave an empty folder level).

## Test plan

- [x] `go test ./internal/importer/` — pass (incl. drift guard)
- [x] `go vet`, `go build ./...` — clean
- [x] `cd web && npx vitest run NamingTemplateField.test.tsx` — 17/17
- [x] `npm run typecheck` / `npm run lint` — clean (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)