### PR TITLE
feat(api,web): ebook/audiobook/both selector on Add Book

### DIFF
--- a/changelog.d/1397-addbook-media-type.md
+++ b/changelog.d/1397-addbook-media-type.md
@@ -1,0 +1,7 @@
+### Added
+- **Format selector on Add Book** (#1397) — the Add Book modal (Authors/Home
+  page) now has an ebook / audiobook / both selector, matching the Series
+  page. Default keeps the previous behaviour (provider metadata, falling back
+  to the `default.media_type` setting). Picking a format applies it to the
+  added book even when it already existed in the library, re-evaluating
+  wanted status so the missing format gets searched.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -2147,6 +2147,10 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 		ForeignAuthorID string `json:"foreignAuthorId"`
 		AuthorName      string `json:"authorName"`
 		SearchOnAdd     bool   `json:"searchOnAdd"`
+		// MediaType optionally forces ebook/audiobook/both for the added book
+		// (#1397). Empty keeps the provider's media type, falling back to the
+		// default.media_type setting — the pre-selector behaviour.
+		MediaType string `json:"mediaType"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -2154,6 +2158,12 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.ForeignBookID == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "foreignBookId required"})
+		return
+	}
+	switch req.MediaType {
+	case "", models.MediaTypeEbook, models.MediaTypeAudiobook, models.MediaTypeBoth:
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "mediaType must be 'ebook', 'audiobook', or 'both'"})
 		return
 	}
 
@@ -2336,10 +2346,14 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 				if primary.Status == "" {
 					primary.Status = models.BookStatusWanted
 				}
-				// Some providers (notably Google Books) don't set a media type;
-				// fall back to the global default so the row isn't created with an
-				// empty format (which would mis-route its indexer search).
-				if primary.MediaType == "" {
+				// An explicit request choice wins over the provider's media type
+				// (#1397). Otherwise some providers (notably Google Books) don't
+				// set one; fall back to the global default so the row isn't
+				// created with an empty format (which would mis-route its
+				// indexer search).
+				if req.MediaType != "" {
+					primary.MediaType = req.MediaType
+				} else if primary.MediaType == "" {
 					primary.MediaType = h.resolveDefaultMediaType(ctx)
 				}
 				if err := h.books.Create(ctx, primary); err != nil {
@@ -2380,8 +2394,16 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 	}
 	bookCreated = true
 
-	// 3. Mark the book monitored (wanted).
+	// 3. Mark the book monitored (wanted). An explicit media-type choice is
+	// applied here too — the poll may have found a row created by the async
+	// catalogue sync (or one already in the library) carrying the default.
+	// Re-evaluate status on a change so e.g. adding an already-imported ebook
+	// as 'both' flips it back to wanted for the missing format (#1148).
 	book.Monitored = true
+	if req.MediaType != "" && book.MediaType != req.MediaType {
+		book.MediaType = req.MediaType
+		reevaluateBookStatus(book)
+	}
 	if err := h.books.Update(ctx, book); err != nil {
 		writeServerError(w, r, err)
 		return

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -3701,6 +3701,109 @@ func TestAddBook_DirectInsertCoversAlternateAuthorIdentifier(t *testing.T) {
 	}
 }
 
+// TestAddBook_InvalidMediaTypeRejected pins the request validation for the
+// optional mediaType field (#1397): anything outside ebook/audiobook/both
+// fails fast with a 400 before any author/book work happens.
+func TestAddBook_InvalidMediaTypeRejected(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(&stubMetaProvider{name: "openlibrary"}), nil, profileRepo, nil)
+
+	body, _ := json.Marshal(map[string]any{
+		"foreignBookId":   "OL-BOOK",
+		"foreignAuthorId": "OL-AUTHOR",
+		"mediaType":       "paperback",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/author/book", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.AddBook(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid mediaType, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestAddBook_MediaTypeOverridesProvider verifies the explicit request
+// choice (#1397) wins over the provider's media type on the direct-insert
+// path and is persisted on the final monitored book.
+func TestAddBook_MediaTypeOverridesProvider(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	ctx := context.Background()
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	existing := &models.Author{
+		ForeignID:        "OL-ALICE",
+		Name:             "Alice Author",
+		SortName:         "Author, Alice",
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+	}
+	if err := authorRepo.Create(ctx, existing); err != nil {
+		t.Fatalf("seed author: %v", err)
+	}
+	if err := authorRepo.UpsertAuthorIdentifier(ctx, existing.ID, "hc:alice-author"); err != nil {
+		t.Fatalf("seed author identifier: %v", err)
+	}
+	primary := &models.Book{
+		ForeignID:        "hc:book-one",
+		Title:            "Book One",
+		SortTitle:        "Book One",
+		Status:           models.BookStatusWanted,
+		Genres:           []string{},
+		MediaType:        models.MediaTypeEbook, // provider says ebook; request forces audiobook
+		MetadataProvider: "hardcover",
+	}
+	provider := &stubMetaProvider{
+		name:  "hardcover",
+		works: nil,
+		getBookByID: map[string]*models.Book{
+			"hc:book-one": primary,
+		},
+	}
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(provider), nil, profileRepo, nil)
+	body, _ := json.Marshal(map[string]any{
+		"foreignBookId":   "hc:book-one",
+		"foreignAuthorId": "hc:alice-author",
+		"authorName":      "Alice Author",
+		"mediaType":       models.MediaTypeAudiobook,
+	})
+	parent, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/author/book", bytes.NewReader(body)).WithContext(parent)
+	rec := httptest.NewRecorder()
+
+	h.AddBook(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, err := bookRepo.GetByForeignID(ctx, "hc:book-one")
+	if err != nil || got == nil {
+		t.Fatalf("book after AddBook = %+v err=%v, want persisted", got, err)
+	}
+	if got.MediaType != models.MediaTypeAudiobook {
+		t.Fatalf("book mediaType = %q, want %q (request override)", got.MediaType, models.MediaTypeAudiobook)
+	}
+	if !got.Monitored {
+		t.Fatalf("book should be monitored after AddBook success")
+	}
+}
+
 // TestAddBook_OrphanAuthorDeletedOnTimeout is the end-to-end guarantee
 // for issue #667. With a DNB-shaped synthetic author ID, the
 // (legacy-flow) async fetch returns zero books deterministically and the

--- a/web/src/api/books.ts
+++ b/web/src/api/books.ts
@@ -112,8 +112,10 @@ export const booksApi = {
   lookupISBN: (isbn: string) => request<Book>(`/book/lookup?isbn=${encodeURIComponent(isbn)}`),
   lookupASIN: (asin: string) => request<Book>(`/book/lookup?asin=${encodeURIComponent(asin)}`),
 
-  // Add a single book to wanted (adds author silently if new)
-  addBook: (data: { foreignBookId: string; foreignAuthorId: string; authorName?: string; searchOnAdd?: boolean }) =>
+  // Add a single book to wanted (adds author silently if new). mediaType
+  // optionally forces ebook/audiobook/both; empty keeps the provider value /
+  // default.media_type setting (#1397).
+  addBook: (data: { foreignBookId: string; foreignAuthorId: string; authorName?: string; searchOnAdd?: boolean; mediaType?: string }) =>
     request<Book>('/author/book', { method: 'POST', body: JSON.stringify(data) }),
 
   // Fix Match (#1238): move a mis-matched file to a different book. The file is

--- a/web/src/components/AddBookModal.test.tsx
+++ b/web/src/components/AddBookModal.test.tsx
@@ -110,3 +110,44 @@ describe('AddBookModal — ASIN lookup (#1189)', () => {
     expect(api.lookupISBN).not.toHaveBeenCalled()
   })
 })
+
+describe('AddBookModal — media-type selector (#1397)', () => {
+  const onClose = vi.fn()
+  const onAdded = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(api.searchBooks).mockResolvedValue([
+      { foreignBookId: 'OL-DUNE', title: 'Dune', author: { authorName: 'Frank Herbert', foreignAuthorId: 'OL-FH' } },
+    ] as never)
+    vi.mocked(api.addBook).mockResolvedValue({ id: 1, title: 'Dune' } as never)
+  })
+
+  const searchAndFind = async () => {
+    fireEvent.change(screen.getByPlaceholderText(/Title, ISBN, or ASIN/i), {
+      target: { value: 'Dune' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+    await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument())
+  }
+
+  it('omits mediaType when the selector is left on Default', async () => {
+    render(<AddBookModal onClose={onClose} onAdded={onAdded} />)
+    await searchAndFind()
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+    await waitFor(() => expect(api.addBook).toHaveBeenCalled())
+    expect(vi.mocked(api.addBook).mock.calls[0][0]).not.toHaveProperty('mediaType')
+  })
+
+  it('sends the chosen mediaType with the add request', async () => {
+    render(<AddBookModal onClose={onClose} onAdded={onAdded} />)
+    await searchAndFind()
+    fireEvent.change(screen.getByLabelText('Format to add'), { target: { value: 'audiobook' } })
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }))
+    await waitFor(() => expect(api.addBook).toHaveBeenCalled())
+    expect(vi.mocked(api.addBook).mock.calls[0][0]).toMatchObject({
+      foreignBookId: 'OL-DUNE',
+      mediaType: 'audiobook',
+    })
+  })
+})

--- a/web/src/components/AddBookModal.tsx
+++ b/web/src/components/AddBookModal.tsx
@@ -14,6 +14,8 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
   const [adding, setAdding] = useState<string | null>(null)
   const [added, setAdded] = useState<Set<string>>(new Set())
   const [searchOnAdd, setSearchOnAdd] = useState(true)
+  // '' = keep the provider's media type / the default.media_type setting.
+  const [mediaType, setMediaType] = useState('')
 
   const search = async () => {
     const q = query.trim()
@@ -55,6 +57,7 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
         foreignAuthorId: book.author.foreignAuthorId ?? '',
         authorName: book.author.authorName,
         searchOnAdd,
+        ...(mediaType ? { mediaType } : {}),
       })
       setAdded(prev => new Set(prev).add(book.foreignBookId))
       onAdded(created)
@@ -85,6 +88,22 @@ export default function AddBookModal({ onClose, onAdded }: Props) {
               <span className="font-medium">Search indexers after adding</span>
               <span className="block text-xs text-slate-600 dark:text-zinc-400 mt-0.5">Attempt to grab the book automatically once it's added to wanted.</span>
             </span>
+          </label>
+
+          <label className="flex items-center gap-2 text-sm mb-3 select-none">
+            <span className="font-medium">Format</span>
+            <select
+              aria-label="Format to add"
+              value={mediaType}
+              onChange={e => setMediaType(e.target.value)}
+              className="text-xs bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-2 py-1 focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+              title="Choose which format to add"
+            >
+              <option value="">Default</option>
+              <option value="ebook">📖 Ebook</option>
+              <option value="audiobook">🎧 Audiobook</option>
+              <option value="both">📖🎧 Both</option>
+            </select>
           </label>
 
           <div className="flex gap-2">


### PR DESCRIPTION
## Summary

Adds the ebook/audiobook/both selector to the Add Book modal on the Authors/Home page, matching the Series page. Closes #1397.

- `POST /author/book` accepts an optional `mediaType` (validated against `models.MediaType*`; 400 on anything else).
- Direct-insert path: explicit choice wins over provider metadata; otherwise unchanged (provider value, then `default.media_type`).
- Final monitored book gets the override too, with `reevaluateBookStatus` (#1148 semantics) so adding an already-imported ebook as *both* flips it back to wanted for the missing audiobook — the exact complaint in the issue ("search on add only grabs the ebook").
- Modal: Format select (Default / 📖 / 🎧 / 📖🎧), copied from the SeriesPage pattern. **Default preserves today's behaviour** so users relying on `default.media_type` see no change.

## Test plan

- [x] `go test ./internal/api/ -run TestAddBook` — pass (2 new: invalid mediaType 400, override persisted on direct insert)
- [x] `go vet ./internal/api/`, `go build ./...` — clean
- [x] `npx vitest run AddBookModal.test.tsx` — 6/6 (2 new: omits mediaType on Default, sends chosen value)
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)