### PR TITLE
fix(db): make the migration splitter comment- and literal-aware

### DIFF
--- a/changelog.d/1465-migration-semicolon.md
+++ b/changelog.d/1465-migration-semicolon.md
@@ -1,0 +1,6 @@
+### Fixed
+- **Migration runner semicolon gotcha** (#1465) — the SQL migration runner
+  split statements on `;` before stripping comments, so a semicolon inside a
+  `--` comment (or a string literal) corrupted the statement list and aborted
+  boot. The splitter is now aware of line comments, block comments, and
+  quoted literals, so migration authors can write natural SQL comments.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -637,7 +637,7 @@ func parseMigration(content string) (statements []string, togglesForeignKeys boo
 
 // splitSQLStatements splits SQL text on ';' boundaries while respecting `--`
 // line comments, `/* */` block comments, and single-quoted string literals
-// (including the '' escape). A ';' inside any of those no longer terminates a
+// (including the ” escape). A ';' inside any of those no longer terminates a
 // statement — the historical "semicolon gotcha" (#1465) where a semicolon in a
 // migration comment split the comment mid-line and glued its tail onto the
 // next statement, aborting boot. Comment text is dropped from the returned

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -623,21 +623,7 @@ func parseMigration(content string) (statements []string, togglesForeignKeys boo
 	}
 	sqlStr = strings.Replace(sqlStr, "-- +migrate Up", "", 1)
 
-	for _, stmt := range strings.Split(sqlStr, ";") {
-		// Strip comment-only lines
-		lines := strings.Split(stmt, "\n")
-		var cleaned []string
-		for _, line := range lines {
-			trimmed := strings.TrimSpace(line)
-			if trimmed == "" || strings.HasPrefix(trimmed, "--") {
-				continue
-			}
-			cleaned = append(cleaned, line)
-		}
-		stmt = strings.TrimSpace(strings.Join(cleaned, "\n"))
-		if stmt == "" {
-			continue
-		}
+	for _, stmt := range splitSQLStatements(sqlStr) {
 		// PRAGMA foreign_keys is a no-op inside a transaction; pull it out of
 		// the transactional body and signal the caller to handle it.
 		if isForeignKeysPragma(stmt) {
@@ -647,6 +633,77 @@ func parseMigration(content string) (statements []string, togglesForeignKeys boo
 		statements = append(statements, stmt)
 	}
 	return statements, togglesForeignKeys
+}
+
+// splitSQLStatements splits SQL text on ';' boundaries while respecting `--`
+// line comments, `/* */` block comments, and single-quoted string literals
+// (including the '' escape). A ';' inside any of those no longer terminates a
+// statement — the historical "semicolon gotcha" (#1465) where a semicolon in a
+// migration comment split the comment mid-line and glued its tail onto the
+// next statement, aborting boot. Comment text is dropped from the returned
+// statements; string literals are preserved verbatim.
+//
+// Known limitation: BEGIN...END trigger bodies still can't be expressed,
+// because the ';' terminators inside the body split it. No migration uses
+// triggers today; if one ever does, this splitter needs a BEGIN/END depth
+// counter.
+func splitSQLStatements(sqlStr string) []string {
+	var out []string
+	var b strings.Builder
+	i, n := 0, len(sqlStr)
+	for i < n {
+		c := sqlStr[i]
+		switch {
+		case c == '-' && i+1 < n && sqlStr[i+1] == '-':
+			// Line comment: skip to (not past) the newline so statements keep
+			// their line separation.
+			for i < n && sqlStr[i] != '\n' {
+				i++
+			}
+		case c == '/' && i+1 < n && sqlStr[i+1] == '*':
+			// Block comment: skip past the closing */ (or to EOF if unclosed).
+			i += 2
+			for i < n {
+				if sqlStr[i] == '*' && i+1 < n && sqlStr[i+1] == '/' {
+					i += 2
+					break
+				}
+				i++
+			}
+		case c == '\'':
+			// String literal: copy verbatim through the closing quote,
+			// honouring the '' escape.
+			b.WriteByte(c)
+			i++
+			for i < n {
+				b.WriteByte(sqlStr[i])
+				if sqlStr[i] == '\'' {
+					if i+1 < n && sqlStr[i+1] == '\'' {
+						i++
+						b.WriteByte(sqlStr[i])
+						i++
+						continue
+					}
+					i++
+					break
+				}
+				i++
+			}
+		case c == ';':
+			if s := strings.TrimSpace(b.String()); s != "" {
+				out = append(out, s)
+			}
+			b.Reset()
+			i++
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	if s := strings.TrimSpace(b.String()); s != "" {
+		out = append(out, s)
+	}
+	return out
 }
 
 // isForeignKeysPragma reports whether stmt is a bare `PRAGMA foreign_keys=...`

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1980,6 +1980,74 @@ func TestParseMigrationStripsForeignKeysPragma(t *testing.T) {
 	}
 }
 
+// TestParseMigrationSemicolonSafety pins the fix for the historical
+// "semicolon gotcha" (#1465): a ';' inside a `--` comment, a `/* */` block
+// comment, or a string literal must not split a statement. Before the fix the
+// runner split on ';' first and stripped comment lines second, so a comment
+// containing a semicolon left a non-comment tail glued to the next statement
+// and boot aborted with a syntax error.
+func TestParseMigrationSemicolonSafety(t *testing.T) {
+	t.Run("semicolon in line comment", func(t *testing.T) {
+		stmts, _ := parseMigration(
+			"-- +migrate Up\n" +
+				"-- careful; this comment has a semicolon\n" +
+				"CREATE TABLE a (id INTEGER); -- trailing; comment\n" +
+				"CREATE TABLE b (id INTEGER);\n")
+		if len(stmts) != 2 {
+			t.Fatalf("statements = %d (%q), want 2", len(stmts), stmts)
+		}
+		if stmts[0] != "CREATE TABLE a (id INTEGER)" || stmts[1] != "CREATE TABLE b (id INTEGER)" {
+			t.Fatalf("unexpected statements: %q", stmts)
+		}
+	})
+
+	t.Run("semicolon in block comment", func(t *testing.T) {
+		stmts, _ := parseMigration(
+			"-- +migrate Up\n" +
+				"/* block; comment; with; semicolons */\n" +
+				"CREATE TABLE a (id INTEGER);\n")
+		if len(stmts) != 1 || stmts[0] != "CREATE TABLE a (id INTEGER)" {
+			t.Fatalf("unexpected statements: %q", stmts)
+		}
+	})
+
+	t.Run("semicolon and escaped quote in string literal", func(t *testing.T) {
+		stmts, _ := parseMigration(
+			"-- +migrate Up\n" +
+				"INSERT INTO settings (key, value) VALUES ('greeting', 'hi; it''s -- not a comment');\n" +
+				"CREATE TABLE c (id INTEGER);\n")
+		if len(stmts) != 2 {
+			t.Fatalf("statements = %d (%q), want 2", len(stmts), stmts)
+		}
+		want := "INSERT INTO settings (key, value) VALUES ('greeting', 'hi; it''s -- not a comment')"
+		if stmts[0] != want {
+			t.Fatalf("literal statement = %q, want %q", stmts[0], want)
+		}
+	})
+
+	t.Run("every embedded migration still parses to nonempty statements", func(t *testing.T) {
+		entries, err := migrationsFS.ReadDir("migrations")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+				continue
+			}
+			content, err := migrationsFS.ReadFile("migrations/" + e.Name())
+			if err != nil {
+				t.Fatalf("read %s: %v", e.Name(), err)
+			}
+			stmts, _ := parseMigration(string(content))
+			for _, s := range stmts {
+				if strings.TrimSpace(s) == "" {
+					t.Fatalf("%s: empty statement leaked", e.Name())
+				}
+			}
+		}
+	})
+}
+
 // TestMigrationVersionIsFilenameNumber verifies the canonical version is the
 // filename prefix, not the slice index. With the 010 gap, migration 011 must
 // resolve to version 11 (finding 2).

--- a/internal/db/migrations/059_grimmory_pushes.sql
+++ b/internal/db/migrations/059_grimmory_pushes.sql
@@ -7,9 +7,9 @@
 -- file_path is the library path at push time (book_files.path or the legacy
 -- books.file_path column). grimmory_book_id is Grimmory's id when the upload
 -- response carried one, 0 when the file went to the review queue without an id.
--- NOTE for future migrations: the migration runner splits statements on
--- semicolons even inside comments — keep the semicolon character out of
--- comment text.
+-- NOTE: the runner's historical "semicolon in a comment" gotcha was fixed in
+-- #1465 — the splitter is now comment- and literal-aware. Trigger bodies
+-- (BEGIN ... END) are still unsupported.
 CREATE TABLE IF NOT EXISTS grimmory_pushes (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     book_id INTEGER NOT NULL,


### PR DESCRIPTION
## Summary

Fixes the migration runner's semicolon gotcha. Closes #1465.

`parseMigration` split the SQL on `;` first and stripped comment lines second, so a semicolon inside a `--` comment split the comment mid-line and glued its non-comment tail onto the next statement — a boot-aborting syntax error that has bitten twice and was only defended by a warning comment in migration 059.

- New `splitSQLStatements` scanner in `internal/db/db.go`: splits on `;` only outside `--` line comments, `/* */` block comments, and single-quoted string literals (`''` escape honoured). Comment text is dropped; literals preserved verbatim.
- Known limitation documented: `BEGIN ... END` trigger bodies are still unsupported (no migration uses triggers; needs a depth counter if one ever does).
- Migration 059's tribal-memory warning updated to point at the fix.
- No checksumming of applied migrations exists, so the 059 comment edit is safe for existing installs.

## Test plan

- [x] New `TestParseMigrationSemicolonSafety`: semicolon in line comment, in block comment, in string literal (with escaped quote), plus a sweep asserting every embedded migration still parses to non-empty statements
- [x] Full `go test ./internal/db/` — pass (all real migrations still apply via `OpenMemory`)
- [x] `go vet ./internal/db/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)