### PR TITLE
feat(importer): conditional token groups and zero-pad widths in naming templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Clean-room Go rewrite, modern React UI, MIT-licensed, actively developed.
 
 **Import & organize**
 - Completed downloads matched by NZO ID and placed in the library with configurable naming. Modes: **Move** (default), **Copy** (keep source for seeding), **Hardlink** (zero extra disk; same filesystem required).
-- Naming tokens — `{Author}`, `{SortAuthor}`, `{Title}`, `{Year}`, `{Series}`, `{SeriesNumber}`, `{Genre}`, `{Lang}`, `{ext}` — collapse cleanly for non-series books.
+- Naming tokens — `{Author}`, `{SortAuthor}`, `{Title}`, `{Year}`, `{Series}`, `{SeriesNumber}`, `{Genre}`, `{Lang}`, `{ext}` — collapse cleanly for non-series books, with conditional literals (`{Title}{ - Series}` emits the dash only when a series exists) and zero-pad widths (`{SeriesNumber:2}` → `02`).
 - Cross-filesystem-safe moves: atomic rename when possible, copy + verify + delete for NFS / separate volumes. Full grab / import / failure history per book.
 - Calibre integration in three modes: `calibredb` CLI hook on import, [Bindery Bridge plugin](https://github.com/vavallee/bindery-plugins) (cross-container), or direct read of an existing Calibre library's `metadata.db` as Bindery's catalogue.
 

--- a/changelog.d/1127-naming-conditional-width.md
+++ b/changelog.d/1127-naming-conditional-width.md
@@ -1,0 +1,11 @@
+### Added
+- **Conditional text and zero-pad widths in naming templates** (#1127) —
+  literal text placed inside a brace group renders only when its token has a
+  value (`{Title}{ - Series}` emits the dash only for series books, no more
+  trailing separators), and numeric tokens accept a width modifier
+  (`{SeriesNumber:2}` → `02`) so alphabetic filename sorts keep parts in
+  order. Both are backward compatible: bare tokens, `{Genre:Unsorted}`-style
+  defaults, and unknown-token passthrough behave exactly as before. One edge:
+  a 1–2 digit modifier is now a width, so a numeric *default* that short is
+  no longer supported (3+ digits, e.g. `{Year:2024}`, still works as a
+  default).

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -13,13 +13,21 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
-// templateTokenRe matches a "{Token}" placeholder, optionally with a default
-// value after a colon ("{Genre:Unsorted}"). The default is substituted when the
-// token renders empty, mirroring Calibre's ifempty(...) so a top-level taxonomy
-// folder (e.g. genre) can route un-tagged books to a fixed folder instead of
-// collapsing the path segment. Group 1 is the token name; group 2 (optional) is
-// the default text.
-var templateTokenRe = regexp.MustCompile(`\{(\w+)(?::([^}]*))?\}`)
+// templateGroupRe matches one "{...}" group. The content is parsed by
+// renderGroup: either the classic simple form — a bare "{Token}", optionally
+// with a default after a colon ("{Genre:Unsorted}") or a zero-pad width
+// ("{SeriesNumber:2}") — or a conditional group (#1127) where literal text
+// sits alongside the token(s) inside the braces ("{Title}{ - Series}") and
+// the whole group collapses to "" when every token in it is empty.
+var templateGroupRe = regexp.MustCompile(`\{([^{}]*)\}`)
+
+// simpleGroupRe matches the classic single-token group content: a keyword
+// with an optional ":modifier" (default text or zero-pad width).
+var simpleGroupRe = regexp.MustCompile(`^(\w+)(?::([^{}]*))?$`)
+
+// groupWordRe finds keyword candidates inside a conditional group: a word
+// run with an optional ":N" width. Non-keyword word runs stay literal.
+var groupWordRe = regexp.MustCompile(`(\w+)(:\d{1,2})?`)
 
 const defaultNamingTemplate = "{Author}/{Title} ({Year})/{Title} - {Author}.{ext}"
 const defaultAudiobookTemplate = "{Author}/{Title} ({Year})"
@@ -131,8 +139,8 @@ func (r *Renamer) apply(template string, author *models.Author, book *models.Boo
 	return strings.Join(kept, "/")
 }
 
-// renderSegment substitutes "{Token}" placeholders in a single path segment.
-// When the leading token(s) of a segment resolve to empty, the separator glue
+// renderSegment substitutes "{...}" groups in a single path segment.
+// When the leading group(s) of a segment resolve to empty, the separator glue
 // that would dangle in front of the first real value is dropped, so a template
 // like "{SeriesNumber} - {Title}" with no series number yields "Title" rather
 // than " - Title" (issue: Discord report, Jonathan Stroud "The Hollow Boy").
@@ -142,29 +150,26 @@ func (r *Renamer) apply(template string, author *models.Author, book *models.Boo
 // "{Title}.{ext}" → "Title." (audiobook folders) is preserved — those are
 // pinned by the preview drift guard and mirrored client-side.
 //
-// Unknown tokens are left verbatim (e.g. a "{Titel}" typo stays "{Titel}"),
-// matching the previous literal-passthrough behaviour.
+// Groups that reference no known token are left verbatim (e.g. a "{Titel}"
+// typo stays "{Titel}"), matching the previous literal-passthrough behaviour.
 func renderSegment(seg string, values map[string]string) string {
-	locs := templateTokenRe.FindAllStringSubmatchIndex(seg, -1)
+	locs := templateGroupRe.FindAllStringSubmatchIndex(seg, -1)
 	if len(locs) == 0 {
 		return strings.TrimSpace(seg)
 	}
 
-	// Split the segment into literals (len n+1) interleaved with token values
+	// Split the segment into literals (len n+1) interleaved with group values
 	// (len n): lits[0] vals[0] lits[1] vals[1] ... vals[n-1] lits[n].
 	lits := make([]string, 0, len(locs)+1)
 	vals := make([]string, 0, len(locs))
 	prev := 0
 	for _, m := range locs {
 		start, end := m[0], m[1]
-		name := seg[m[2]:m[3]]
+		content := seg[m[2]:m[3]]
 		lits = append(lits, seg[prev:start])
-		v, ok := values[name]
-		switch {
-		case !ok:
-			v = seg[start:end] // unknown token: keep "{Token}" (or "{Token:def}") verbatim
-		case v == "" && m[4] >= 0:
-			v = sanitizePath(seg[m[4]:m[5]]) // empty known token with a default
+		v, known := renderGroup(content, values)
+		if !known {
+			v = seg[start:end] // no known token in the group: keep it verbatim
 		}
 		vals = append(vals, v)
 		prev = end
@@ -191,6 +196,100 @@ func renderSegment(seg string, values map[string]string) string {
 	}
 	b.WriteString(lits[len(lits)-1])
 	return strings.TrimSpace(b.String())
+}
+
+// renderGroup renders the content of one "{...}" group. known=false means
+// the group references no known token and the caller keeps it verbatim.
+//
+// Two forms (#1127):
+//
+//   - Simple: "Token", "Token:default", "Token:N". A ":modifier" of 1–2
+//     digits is a zero-pad width applied to an all-digit value
+//     ("{SeriesNumber:2}" → "02"); anything else is the classic default text
+//     substituted when the token is empty ("{Genre:Unsorted}").
+//   - Conditional: literal text alongside the token(s) inside the braces
+//     ("{ - Series}", "{Vol SeriesNumber}"). Literals render only when at
+//     least one token in the group has a value; when every token is empty
+//     the whole group collapses to "". Widths are allowed after a token
+//     (":N"); text defaults are not supported in conditional groups.
+func renderGroup(content string, values map[string]string) (rendered string, known bool) {
+	if m := simpleGroupRe.FindStringSubmatch(content); m != nil {
+		v, ok := values[m[1]]
+		if !ok {
+			return "", false
+		}
+		if mod := m[2]; mod != "" {
+			if w, isWidth := parseWidth(mod); isWidth {
+				v = zeroPad(v, w)
+			} else if v == "" {
+				v = sanitizePath(mod)
+			}
+		}
+		return v, true
+	}
+
+	anyKnown, anyValue := false, false
+	var b strings.Builder
+	prev := 0
+	for _, m := range groupWordRe.FindAllStringSubmatchIndex(content, -1) {
+		word := content[m[2]:m[3]]
+		v, ok := values[word]
+		if !ok {
+			continue // non-keyword word run: stays part of the literal text
+		}
+		anyKnown = true
+		b.WriteString(sanitizeInline(content[prev:m[0]]))
+		if m[4] >= 0 { // ":N" width attached to this token
+			if w, isWidth := parseWidth(content[m[4]+1 : m[5]]); isWidth {
+				v = zeroPad(v, w)
+			}
+		}
+		if v != "" {
+			anyValue = true
+		}
+		b.WriteString(v)
+		prev = m[1]
+	}
+	if !anyKnown {
+		return "", false
+	}
+	if !anyValue {
+		return "", true
+	}
+	b.WriteString(sanitizeInline(content[prev:]))
+	return b.String(), true
+}
+
+// parseWidth reports whether a ":modifier" is a zero-pad width: 1–2 digits
+// (1–99). Longer all-digit strings (e.g. "{Year:2024}") keep their historical
+// meaning as default text.
+func parseWidth(mod string) (int, bool) {
+	if len(mod) == 0 || len(mod) > 2 {
+		return 0, false
+	}
+	w := 0
+	for i := 0; i < len(mod); i++ {
+		if mod[i] < '0' || mod[i] > '9' {
+			return 0, false
+		}
+		w = w*10 + int(mod[i]-'0')
+	}
+	return w, w > 0
+}
+
+// zeroPad left-pads an all-digit value with zeros to the given width so
+// alphabetic filename sorts order "02" before "10". Non-numeric and empty
+// values are returned unchanged — padding "Demo Series" would be nonsense.
+func zeroPad(v string, width int) string {
+	if v == "" || len(v) >= width {
+		return v
+	}
+	for i := 0; i < len(v); i++ {
+		if v[i] < '0' || v[i] > '9' {
+			return v
+		}
+	}
+	return strings.Repeat("0", width-len(v)) + v
 }
 
 // firstGenre returns the primary genre for the {Genre} token: the first entry
@@ -857,12 +956,33 @@ func CopyDirCtx(ctx context.Context, src, dst string) error {
 // any uniqueness suffix the importer appends.
 const maxPathComponentLen = 200
 
+// pathCharReplacer neutralises characters that are problematic in file
+// paths. Shared by sanitizePath (full field sanitisation) and sanitizeInline
+// (conditional-group literals, #1127).
+var pathCharReplacer = strings.NewReplacer(
+	"/", "-", "\\", "-", ":", "-", "*", "", "?", "",
+	"\"", "", "<", "", ">", "", "|", "",
+)
+
+// sanitizeInline neutralises path separators and control characters in a
+// conditional-group literal without trimming or segment-splitting — the
+// literal's surrounding whitespace is meaningful glue ("{ - Series}").
+// Replacing the separators is what keeps a group literal from injecting an
+// extra path level or a traversal segment after the template has been split
+// on "/".
+func sanitizeInline(s string) string {
+	cleaned := pathCharReplacer.Replace(s)
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, cleaned)
+}
+
 func sanitizePath(s string) string {
 	// Remove characters that are problematic in file paths
-	replacer := strings.NewReplacer(
-		"/", "-", "\\", "-", ":", "-", "*", "", "?", "",
-		"\"", "", "<", "", ">", "", "|", "",
-	)
+	replacer := pathCharReplacer
 	cleaned := strings.TrimSpace(replacer.Replace(s))
 	// Drop control characters, including the NUL byte: a NUL makes the os.*
 	// calls fail with EINVAL (a hard import failure driven by attacker-

--- a/internal/importer/renamer_preview_test.go
+++ b/internal/importer/renamer_preview_test.go
@@ -58,11 +58,80 @@ func TestRenamerPreviewSampleDriftGuard(t *testing.T) {
 			ext:      "", // AudiobookDestDir passes ext=""
 			want:     "Sample Book.",
 		},
+		// #1127 conditional groups + width modifiers. Every case here is
+		// mirrored in NamingTemplateField.test.tsx — keep them in lockstep.
+		{
+			name:     "conditional group renders literal with value",
+			template: "{Title}{ - Series}.{ext}",
+			ext:      "epub",
+			want:     "Sample Book - Demo Series.epub",
+		},
+		{
+			name:     "width modifier zero-pads a numeric value",
+			template: "{SeriesNumber:2} - {Title}",
+			ext:      "epub",
+			want:     "02 - Sample Book",
+		},
+		{
+			name:     "width modifier inside a conditional group",
+			template: "{Title}{ #SeriesNumber:3}",
+			ext:      "epub",
+			want:     "Sample Book #002",
+		},
+		{
+			name:     "width on a non-numeric value is a no-op",
+			template: "{Series:2}",
+			ext:      "epub",
+			want:     "Demo Series",
+		},
+		{
+			name:     "non-keyword words in a conditional group stay literal",
+			template: "{Vol SeriesNumber}",
+			ext:      "epub",
+			want:     "Vol 2",
+		},
+		{
+			name:     "group with no known token stays verbatim",
+			template: "{ - Titel}",
+			ext:      "epub",
+			want:     "{ - Titel}",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := r.apply(tc.template, author, book, series, seriesNumber, tc.ext)
+			if got != tc.want {
+				t.Errorf("apply(%q) = %q, want %q (TS preview mirror must match)", tc.template, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenamerConditionalGroupCollapse pins the empty-token side of #1127:
+// a conditional group's literal text collapses with its token(s), and 3+
+// digit modifiers keep their historical default-text meaning. Mirrored in
+// NamingTemplateField.test.tsx.
+func TestRenamerConditionalGroupCollapse(t *testing.T) {
+	author := &models.Author{Name: "Jane Doe"}
+	book := &models.Book{Title: "Sample Book"} // no series, no year, no genre
+
+	r := NewRenamer("")
+
+	cases := []struct {
+		name     string
+		template string
+		want     string
+	}{
+		{"conditional group collapses when empty", "{Title}{ - Series}.{ext}", "Sample Book.epub"},
+		{"conditional-only segment is dropped", "{Vol SeriesNumber}/{Title}.{ext}", "Sample Book.epub"},
+		{"width does not invent a value", "{SeriesNumber:2} - {Title}", "Sample Book"},
+		{"3+ digit modifier stays a default", "{Year:2024}", "2024"},
+		{"1-2 digit modifier is a width, not a default", "{Year:20}", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.apply(tc.template, author, book, "", "", "epub")
 			if got != tc.want {
 				t.Errorf("apply(%q) = %q, want %q (TS preview mirror must match)", tc.template, got, tc.want)
 			}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -603,7 +603,7 @@
         "tokenYear": "{Year} — release year (blank if unknown)",
         "tokenAsin": "{ASIN} — Audible ASIN (blank if none)",
         "tokenSeries": "{Series} — series title (blank for standalone)",
-        "tokenSeriesNumber": "{SeriesNumber} — position in series",
+        "tokenSeriesNumber": "{SeriesNumber} — position in series. {SeriesNumber:2} zero-pads to 2 digits; literal text inside braces ({Title}{ - Series}) renders only when the token has a value.",
         "tokenGenre": "{Genre} — primary genre, best with Hardcover enabled. Use {Genre:Unsorted} to set a fallback folder.",
         "tokenLang": "{Lang} — book language code, e.g. en (blank if unknown)",
         "tokenExt": "{ext} — file extension, no leading dot (ebook only)",

--- a/web/src/pages/settings/NamingTemplateField.test.tsx
+++ b/web/src/pages/settings/NamingTemplateField.test.tsx
@@ -82,6 +82,40 @@ describe('namingTemplate renderer (renamer.go mirror)', () => {
     ).toBe('Sample Book ()')
   })
 
+  // #1127 conditional groups + width modifiers — every case here is pinned
+  // identically in renamer_preview_test.go. Keep the two in lockstep.
+  it('renders conditional groups with literal text alongside the token', () => {
+    expect(renderTemplate('{Title}{ - Series}.{ext}', 'book')).toBe('Sample Book - Demo Series.epub')
+    const noSeries = { ...SAMPLE_BOOK, series: '', seriesNumber: '' }
+    expect(renderTemplate('{Title}{ - Series}.{ext}', 'book', noSeries)).toBe('Sample Book.epub')
+    // Conditional-only segment is dropped entirely when its tokens are empty.
+    expect(renderTemplate('{Vol SeriesNumber}/{Title}.{ext}', 'book', noSeries)).toBe('Sample Book.epub')
+    // Non-keyword words inside the group stay literal.
+    expect(renderTemplate('{Vol SeriesNumber}', 'book')).toBe('Vol 2')
+    // A group with no known token stays verbatim.
+    expect(renderTemplate('{ - Titel}', 'book')).toBe('{ - Titel}')
+  })
+
+  it('zero-pads numeric values via the :N width modifier', () => {
+    expect(renderTemplate('{SeriesNumber:2} - {Title}', 'book')).toBe('02 - Sample Book')
+    expect(renderTemplate('{Title}{ #SeriesNumber:3}', 'book')).toBe('Sample Book #002')
+    // Width on a non-numeric value is a no-op.
+    expect(renderTemplate('{Series:2}', 'book')).toBe('Demo Series')
+    // Width does not invent a value for an empty token.
+    const noSeries = { ...SAMPLE_BOOK, series: '', seriesNumber: '' }
+    expect(renderTemplate('{SeriesNumber:2} - {Title}', 'book', noSeries)).toBe('Sample Book')
+    // 3+ digit modifiers keep the historical default-text meaning.
+    const noYear = { ...SAMPLE_BOOK, year: '' }
+    expect(renderTemplate('{Year:2024}', 'book', noYear)).toBe('2024')
+    expect(renderTemplate('{Year:20}', 'book', noYear)).toBe('')
+  })
+
+  it('accepts conditional groups and widths in validation', () => {
+    expect(validateTemplate('{Title}{ - Series}.{ext}').unknownTokens).toEqual([])
+    expect(validateTemplate('{SeriesNumber:2} - {Title}').unknownTokens).toEqual([])
+    expect(validateTemplate('{ - Titel}').unknownTokens).toEqual(['{ - Titel}'])
+  })
+
   it('renders the {Genre} token and {Token:default} fallback', () => {
     expect(renderTemplate('{Genre}/{Title}.{ext}', 'book')).toBe('Fantasy/Sample Book.epub')
     const noGenre = { ...SAMPLE_BOOK, genre: '' }

--- a/web/src/pages/settings/namingTemplate.ts
+++ b/web/src/pages/settings/namingTemplate.ts
@@ -132,34 +132,114 @@ export function renderTemplate(
     .join(SEP)
 }
 
-// Group 1: token name. Group 2 (optional): default after a colon, used when the
-// token renders empty ("{Genre:Unsorted}"). Mirrors templateTokenRe in renamer.go.
-const SEGMENT_TOKEN_RE = /\{(\w+)(?::([^}]*))?\}/g
+// Mirrors templateGroupRe in renamer.go: one {...} group; renderGroup parses
+// the content (simple token, token:default, token:width, or a conditional
+// group with literal text alongside the token(s), #1127).
+const SEGMENT_GROUP_RE = /\{([^{}]*)\}/g
+const SIMPLE_GROUP_RE = /^(\w+)(?::([^{}]*))?$/
+const GROUP_WORD_RE = /(\w+)(:\d{1,2})?/g
 
-// renderSegment mirrors renamer.go renderSegment: substitute "{Token}"
-// placeholders in a single path segment and, when the leading token(s) render
-// empty, drop the separator glue that would otherwise dangle before the first
-// real value ("{SeriesNumber} - {Title}" with no series number → "Title", not
+// sanitizeInline mirrors renamer.go sanitizeInline: neutralise path
+// separators in a conditional-group literal without trimming — its
+// whitespace is meaningful glue ("{ - Series}").
+function sanitizeInline(s: string): string {
+  let cleaned = ''
+  for (const ch of s) {
+    switch (ch) {
+      case '/':
+      case '\\':
+      case ':':
+        cleaned += '-'
+        break
+      case '*':
+      case '?':
+      case '"':
+      case '<':
+      case '>':
+      case '|':
+        break
+      default:
+        cleaned += ch
+    }
+  }
+  return cleaned
+}
+
+// parseWidth mirrors renamer.go parseWidth: a ":modifier" of 1–2 digits
+// (1–99) is a zero-pad width; longer digit strings keep the historical
+// default-text meaning.
+function parseWidth(mod: string): number | null {
+  if (!/^\d{1,2}$/.test(mod)) return null
+  const w = parseInt(mod, 10)
+  return w > 0 ? w : null
+}
+
+// zeroPad mirrors renamer.go zeroPad: left-pad an all-digit value.
+function zeroPad(v: string, width: number): string {
+  if (v === '' || v.length >= width || !/^\d+$/.test(v)) return v
+  return v.padStart(width, '0')
+}
+
+// renderGroup mirrors renamer.go renderGroup. Returns null when the group
+// references no known token (caller keeps it verbatim).
+function renderGroup(content: string, values: Record<string, string>): string | null {
+  const simple = SIMPLE_GROUP_RE.exec(content)
+  if (simple) {
+    let v = values[simple[1]]
+    if (v === undefined) return null
+    const mod = simple[2]
+    if (mod !== undefined && mod !== '') {
+      const w = parseWidth(mod)
+      if (w !== null) {
+        v = zeroPad(v, w)
+      } else if (v === '') {
+        v = sanitizePath(mod)
+      }
+    }
+    return v
+  }
+
+  let anyKnown = false
+  let anyValue = false
+  let out = ''
+  let prev = 0
+  GROUP_WORD_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = GROUP_WORD_RE.exec(content)) !== null) {
+    let v = values[m[1]]
+    if (v === undefined) continue // non-keyword word run: stays literal
+    anyKnown = true
+    out += sanitizeInline(content.slice(prev, m.index))
+    if (m[2]) {
+      const w = parseWidth(m[2].slice(1))
+      if (w !== null) v = zeroPad(v, w)
+    }
+    if (v !== '') anyValue = true
+    out += v
+    prev = m.index + m[0].length
+  }
+  if (!anyKnown) return null
+  if (!anyValue) return ''
+  return out + sanitizeInline(content.slice(prev))
+}
+
+// renderSegment mirrors renamer.go renderSegment: substitute "{...}" groups
+// in a single path segment and, when the leading group(s) render empty, drop
+// the separator glue that would otherwise dangle before the first real value
+// ("{SeriesNumber} - {Title}" with no series number → "Title", not
 // " - Title"). Only leading glue is collapsed; interior/trailing glue stays so
 // "{Title} ({Year})" → "Title ()" and "{Title}.{ext}" → "Title." are preserved.
-// A "{Token:default}" empty token renders its default instead. Unknown tokens
-// are kept verbatim.
+// Groups with no known token are kept verbatim.
 function renderSegment(seg: string, values: Record<string, string>): string {
   const lits: string[] = []
   const vals: string[] = []
   let prev = 0
-  SEGMENT_TOKEN_RE.lastIndex = 0
+  SEGMENT_GROUP_RE.lastIndex = 0
   let m: RegExpExecArray | null
-  while ((m = SEGMENT_TOKEN_RE.exec(seg)) !== null) {
+  while ((m = SEGMENT_GROUP_RE.exec(seg)) !== null) {
     lits.push(seg.slice(prev, m.index))
-    const v = values[m[1]]
-    if (v === undefined) {
-      vals.push(m[0]) // unknown token: keep "{Token}" (or "{Token:def}") verbatim
-    } else if (v === '' && m[2] !== undefined) {
-      vals.push(sanitizePath(m[2])) // empty known token with a default
-    } else {
-      vals.push(v)
-    }
+    const rendered = renderGroup(m[1], values)
+    vals.push(rendered === null ? m[0] : rendered)
     prev = m.index + m[0].length
   }
   if (vals.length === 0) return seg.trim()
@@ -191,17 +271,30 @@ export interface ValidationResult {
 const TOKEN_RE = /\{[^{}]*\}/g
 const TRAVERSAL_RE = /(^|\/)\.\.?($|\/)/
 
-// validateTemplate flags any {Foo} not in the supported set, an empty template,
-// and explicit path-traversal segments. These mirror the failure modes the
-// backend would reject (ensureContained) or that produce surprising output.
+// groupIsKnown reports whether one {...} group references at least one
+// supported token — a simple "{Token}"/"{Token:mod}" with a known keyword, or
+// a conditional group (#1127) whose literal text sits alongside a known
+// keyword. Mirrors renderGroup's known/verbatim decision.
+function groupIsKnown(content: string): boolean {
+  const simple = SIMPLE_GROUP_RE.exec(content)
+  if (simple) return SUPPORTED.has(`{${simple[1]}}`)
+  GROUP_WORD_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = GROUP_WORD_RE.exec(content)) !== null) {
+    if (SUPPORTED.has(`{${m[1]}}`)) return true
+  }
+  return false
+}
+
+// validateTemplate flags any {...} group that references no supported token,
+// an empty template, and explicit path-traversal segments. These mirror the
+// failure modes the backend would reject (ensureContained) or that produce
+// surprising output (a verbatim "{Titel}" in the folder name).
 export function validateTemplate(template: string): ValidationResult {
   const matches = template.match(TOKEN_RE) ?? []
   const unknown: string[] = []
   for (const m of matches) {
-    // Strip an optional ":default" ("{Genre:Unsorted}" → "{Genre}") before the
-    // supported-token check; report the original token text if still unknown.
-    const norm = m.replace(/^(\{\w+):[^}]*\}$/, '$1}')
-    if (!SUPPORTED.has(norm) && !unknown.includes(m)) unknown.push(m)
+    if (!groupIsKnown(m.slice(1, -1)) && !unknown.includes(m)) unknown.push(m)
   }
   return {
     unknownTokens: unknown,


### PR DESCRIPTION
## Summary

Implements the two template-engine extensions from #1127 (closes #1127). Unblocks the audiobook file-renaming design in #1126.

**Conditional groups** — literal text inside a brace group renders only when a token in the group has a value; otherwise the whole group collapses:
- `{Title}{ - Series}` → `My Book - Demo Series` with a series, `My Book` without. No more trailing separators.
- Non-keyword words inside a group stay literal (`{Vol SeriesNumber}` → `Vol 2`), and group literals are separator-sanitized so they can't inject a path level.

**Width modifier** — `{SeriesNumber:2}` → `02`. A `:N` of 1–2 digits zero-pads all-digit values; non-numeric values and empty tokens are untouched.

**Backward compatibility** (all pinned by drift guards): bare tokens, `{Genre:Unsorted}` defaults (3+ char / non-digit modifiers stay defaults), unknown groups kept verbatim (`{Titel}`), leading-glue collapse, case-sensitive keywords (deliberate deviation from the issue's case-insensitive proposal — `{author}` renders literally today and silently changing that could rename existing libraries). One documented edge: a 1–2 digit numeric *default* now parses as a width.

Engine changes mirrored in the TS preview (`namingTemplate.ts`), with identical test cases pinned on both sides; `validateTemplate` accepts the new grammar and still flags no-known-token groups.

## Test plan

- [x] `go test ./internal/importer/` — pass (6 new drift-guard cases + 5 collapse/width cases)
- [x] `npx vitest run src/pages/settings/` — 46/46 (mirror cases identical to Go)
- [x] `go vet`, `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)