### PR TITLE
fix(importer): don't treat filtered torrent listings as complete in stale-failure blocker (#1461)

### DIFF
--- a/changelog.d/1461-stale-failure-filtered-list.md
+++ b/changelog.d/1461-stale-failure-filtered-list.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Transmission/qBittorrent: healthy downloads no longer blocked as "source no longer available"** (#1461) — the stale-failure check treated a category-filtered torrent listing as a complete one. A failed-import download whose torrent was moved to another download directory, lost its label, or sat under a different qBittorrent category (while the unfiltered listing was unavailable) was terminally blocked even though the torrent was still seeding. Filtered or degraded listings now only block on retry exhaustion, never on "missing from the list".

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -549,11 +549,14 @@ func (s *Scanner) markDownloadFailed(ctx context.Context, dl *models.Download, m
 // predicate).
 //
 // sourceListIsComplete must be true only when seenSourceIDs was built from a
-// complete enumeration of the client's sources. Torrent clients return every
-// torrent, so a missing entry definitively means the source is gone. Usenet
-// history APIs are paginated (SABnzbd is capped at 50 slots here), so a missing
-// entry there could merely be an aged-out-but-healthy download — for those
-// callers this is false and only the retry-exhaustion case blocks, never the
+// complete enumeration of the client's sources. An UNFILTERED torrent listing
+// qualifies: a missing entry definitively means the source is gone. A
+// category/label-filtered or degraded listing does NOT (#1461): a torrent moved
+// to another directory/category or stripped of its label is absent from the
+// filtered view while still healthy in the client. Usenet history APIs are
+// paginated (SABnzbd is capped at 50 slots here), so a missing entry there
+// could merely be an aged-out-but-healthy download. For all such callers this
+// is false and only the retry-exhaustion case blocks, never the
 // vanished-source case.
 //
 // The download list is re-fetched here rather than reusing the caller's

--- a/internal/importer/scanner_poll.go
+++ b/internal/importer/scanner_poll.go
@@ -278,9 +278,13 @@ func (s *Scanner) checkTransmissionDownloads(ctx context.Context, client *models
 
 	// Terminally block StateImportFailed downloads whose torrent has been
 	// removed from Transmission, or whose retry budget is spent (issue #706
-	// finding 4). sourceListIsComplete is true: GetTorrents returns every
-	// torrent, so a missing entry definitively means the source is gone.
-	s.blockStaleImportFailures(ctx, seenSourceIDs, true, func(d models.Download) bool {
+	// finding 4). sourceListIsComplete only without a Category filter: with a
+	// Category, GetTorrents filters by downloadDir/label, so a torrent that was
+	// moved to another directory or lost its label is absent from the filtered
+	// list while still healthy in the daemon — treating that as "source gone"
+	// terminally blocked a seeding download (#1461). With a filter in play only
+	// the retry-exhaustion case may block.
+	s.blockStaleImportFailures(ctx, seenSourceIDs, client.Category == "", func(d models.Download) bool {
 		return d.DownloadClientID != nil && *d.DownloadClientID == client.ID
 	})
 }
@@ -548,9 +552,13 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 
 	// Terminally block StateImportFailed downloads whose torrent has been
 	// removed from qBittorrent, or whose retry budget is spent (issue #706
-	// finding 4). sourceListIsComplete is true: GetTorrents returns every
-	// torrent, so a missing entry definitively means the source is gone.
-	s.blockStaleImportFailures(ctx, seenSourceIDs, true, func(d models.Download) bool {
+	// finding 4). sourceListIsComplete only when the unfiltered listing
+	// succeeded: seenSourceIDs then covers every torrent regardless of category,
+	// so a missing entry definitively means the source is gone. When allErr is
+	// non-nil the view degraded to the category-filtered fetches, and a healthy
+	// torrent qBittorrent holds under another category would wrongly look
+	// vanished (#1461) — only the retry-exhaustion case may block then.
+	s.blockStaleImportFailures(ctx, seenSourceIDs, allErr == nil, func(d models.Download) bool {
 		return d.DownloadClientID != nil && *d.DownloadClientID == client.ID
 	})
 }

--- a/internal/importer/scanner_stale_filtered_test.go
+++ b/internal/importer/scanner_stale_filtered_test.go
@@ -1,0 +1,204 @@
+package importer
+
+// Regression tests for issue #1461: the stale-failure blocker must not treat a
+// category-filtered (or degraded) torrent listing as a complete enumeration.
+//
+// A StateImportFailed download whose torrent was moved to another download
+// directory (Transmission) or is only visible outside the polled categories
+// while the unfiltered listing is unavailable (qBittorrent) is absent from the
+// filtered view, but the torrent is still healthy in the client. Terminally
+// blocking it with "download source no longer available" was wrong — only the
+// retry-exhaustion case may block on a filtered view.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// staleFilteredFixture creates the shared DB scaffolding: a scanner, a
+// download client of the given type/category pointed at srvURL, and a
+// StateImportFailed download (retry budget NOT exhausted) tracking torrentID.
+func staleFilteredFixture(t *testing.T, srvURL, clientType, category, torrentID string) (*Scanner, *models.DownloadClient, *db.DownloadRepo, context.Context) {
+	t.Helper()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	s := NewScanner(dlRepo, clientRepo,
+		db.NewBookRepo(database), db.NewAuthorRepo(database), db.NewHistoryRepo(database),
+		t.TempDir(), "", "", "", "")
+
+	host, port := scannerTestHostPort(t, srvURL)
+	client := &models.DownloadClient{
+		Name: "stale-" + clientType, Type: clientType,
+		Host: host, Port: port, Category: category, Enabled: true,
+	}
+	if err := clientRepo.Create(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+
+	tid := torrentID
+	dl := &models.Download{
+		GUID:             "guid-1461-" + clientType + "-" + category,
+		Title:            "Still Seeding Elsewhere",
+		Status:           models.StateImportFailed,
+		Protocol:         "torrent",
+		TorrentID:        &tid,
+		DownloadClientID: &client.ID,
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	return s, client, dlRepo, ctx
+}
+
+// TestCheckTransmissionDownloads_FilteredListDoesNotBlock is the Transmission
+// half of issue #1461: with a Category configured, GetTorrents filters by
+// downloadDir/label, so a torrent moved to another directory disappears from
+// the filtered listing while still seeding. The poller must NOT terminally
+// block the StateImportFailed download on that filtered view.
+func TestCheckTransmissionDownloads_FilteredListDoesNotBlock(t *testing.T) {
+	// The daemon holds the torrent, but under a directory that does not match
+	// the client's Category filter — the filtered listing comes back empty.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		torrents := []map[string]any{{
+			"id":          42,
+			"hashString":  "h42",
+			"name":        "Still Seeding Elsewhere",
+			"percentDone": 1.0,
+			"status":      6, // seeding
+			"downloadDir": "/moved/elsewhere",
+		}}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"result":    "success",
+			"arguments": map[string]any{"torrents": torrents},
+		})
+	}))
+	defer srv.Close()
+
+	s, client, dlRepo, ctx := staleFilteredFixture(t, srv.URL, "transmission", "/data/books", "42")
+
+	s.checkTransmissionDownloads(ctx, client)
+
+	got, err := dlRepo.GetByGUID(ctx, "guid-1461-transmission-/data/books")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == models.StateImportBlocked {
+		t.Fatalf("issue #1461: download was terminally blocked from a category-filtered listing while its torrent is still seeding; status = %q", got.Status)
+	}
+	if got.Status != models.StateImportFailed {
+		t.Errorf("status = %q, want %q (unchanged, awaiting retry)", got.Status, models.StateImportFailed)
+	}
+}
+
+// TestCheckTransmissionDownloads_UnfilteredListStillBlocks guards the other
+// direction: with NO Category filter the listing is a complete enumeration,
+// so a StateImportFailed download whose torrent is genuinely gone must still
+// be terminally blocked (issue #706 finding 4 must keep working).
+func TestCheckTransmissionDownloads_UnfilteredListStillBlocks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"result":"success","arguments":{"torrents":[]}}`))
+	}))
+	defer srv.Close()
+
+	s, client, dlRepo, ctx := staleFilteredFixture(t, srv.URL, "transmission", "", "42")
+
+	s.checkTransmissionDownloads(ctx, client)
+
+	got, err := dlRepo.GetByGUID(ctx, "guid-1461-transmission-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StateImportBlocked {
+		t.Errorf("status = %q, want %q — with an unfiltered listing a vanished source must still be terminally blocked", got.Status, models.StateImportBlocked)
+	}
+}
+
+// TestCheckQbittorrentDownloads_DegradedListDoesNotBlock is the qBittorrent
+// half of issue #1461: when the unfiltered listing fails, seenSourceIDs
+// degrades to the category-filtered view. A torrent qBittorrent holds under a
+// different category is invisible in that view while still seeding, so the
+// poller must NOT terminally block its StateImportFailed download that cycle.
+func TestCheckQbittorrentDownloads_DegradedListDoesNotBlock(t *testing.T) {
+	const storedHash = "aaaa1111bbbb2222cccc3333dddd4444eeee5555"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			if r.URL.Query().Get("category") == "" {
+				// The unfiltered listing fails — recovery degraded this cycle.
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			// Category-filtered listing succeeds but does not contain the
+			// tracked torrent (it sits under a different category).
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	s, client, dlRepo, ctx := staleFilteredFixture(t, srv.URL, "qbittorrent", "books", storedHash)
+
+	s.checkQbittorrentDownloads(ctx, client)
+
+	got, err := dlRepo.GetByGUID(ctx, "guid-1461-qbittorrent-books")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == models.StateImportBlocked {
+		t.Fatalf("issue #1461: download was terminally blocked from a degraded (category-only) listing; status = %q", got.Status)
+	}
+	if got.Status != models.StateImportFailed {
+		t.Errorf("status = %q, want %q (unchanged, awaiting retry)", got.Status, models.StateImportFailed)
+	}
+}
+
+// TestCheckQbittorrentDownloads_CompleteListStillBlocks guards the other
+// direction for qBittorrent: when the unfiltered listing succeeds the
+// enumeration is complete, so a torrent absent from BOTH the category view and
+// the unfiltered view is definitively gone and the StateImportFailed download
+// must still be terminally blocked.
+func TestCheckQbittorrentDownloads_CompleteListStillBlocks(t *testing.T) {
+	const storedHash = "aaaa1111bbbb2222cccc3333dddd4444eeee5555"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte(`[]`)) // torrent gone everywhere
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	s, client, dlRepo, ctx := staleFilteredFixture(t, srv.URL, "qbittorrent", "books", storedHash)
+
+	s.checkQbittorrentDownloads(ctx, client)
+
+	got, err := dlRepo.GetByGUID(ctx, "guid-1461-qbittorrent-books")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StateImportBlocked {
+		t.Errorf("status = %q, want %q — with a complete enumeration a vanished source must still be terminally blocked", got.Status, models.StateImportBlocked)
+	}
+}


### PR DESCRIPTION
## Summary

The stale-failure blocker (`blockStaleImportFailures`) terminally blocks a `StateImportFailed` download whose torrent is absent from the observed source list, but only when told the enumeration was complete. Two pollers claimed completeness for views that can be partial:

- **Transmission**: `seenSourceIDs` is built from `GetTorrents(ctx, client.Category)`, which filters by downloadDir/label. A torrent moved to another directory or stripped of its label vanished from the filtered view, so the download was blocked with "download source no longer available" while the torrent was still seeding.
- **qBittorrent**: when the unfiltered listing fails, `seenSourceIDs` degrades to the category-filtered view but the poller still passed `sourceListIsComplete=true`, with the same effect for torrents held under a different category.

Fix: pass `client.Category == ""` (Transmission) / `allErr == nil` (qBittorrent) as the completeness flag, so filtered or degraded listings only block on retry exhaustion, never on absence from the list. Unfiltered/complete listings keep the #706 vanished-source blocking unchanged (covered by the new still-blocks tests). Closes #1461.

## Checklist

- [x] Tests added or updated (`internal/importer/scanner_stale_filtered_test.go`, 4 regression tests: filtered/degraded must not block, unfiltered/complete must still block)
- [x] Doc-update gate cleared (internal poller behaviour only; godoc contract on `blockStaleImportFailures` updated; changelog fragment `changelog.d/1461-stale-failure-filtered-list.md` added)
- [x] Wiki pages updated if user-facing behaviour changed (n/a)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/importer/`
- [x] `go test ./internal/importer/` (full package, no -race)
- [x] Verified the Transmission regression test fails against the pre-fix code (temporarily reverted the completeness flag: test fails; restored: passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)