### PR TITLE
fix(scanner): single-flight guard for library scans (#1460)

### DIFF
--- a/changelog.d/1460-scan-single-flight.md
+++ b/changelog.d/1460-scan-single-flight.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Library scan single-flight** (#1460) — triggering a manual library scan while another scan is running (manual or the scheduled one) now returns 409 Conflict instead of starting a second concurrent walk that could race on book creation and clobber the last-scan status.

--- a/internal/api/library.go
+++ b/internal/api/library.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -11,7 +12,7 @@ import (
 
 // libraryScanner is the subset of importer.Scanner used by LibraryHandler.
 type libraryScanner interface {
-	ScanLibrary(ctx context.Context)
+	StartScan(ctx context.Context) error
 }
 
 type LibraryHandler struct {
@@ -31,11 +32,17 @@ func (h *LibraryHandler) WithSettings(sr *db.SettingsRepo) *LibraryHandler {
 
 // Scan triggers an immediate library reconciliation in the background and
 // returns 202 Accepted. The scan runs asynchronously; clients can monitor
-// progress via the book list.
+// progress via the book list. If a scan is already in flight (manual or the
+// scheduled 6-hourly job) it returns 409 Conflict instead of starting a
+// second concurrent full walk (#1460).
 func (h *LibraryHandler) Scan(w http.ResponseWriter, r *http.Request) {
-	// context.WithoutCancel so the goroutine isn't killed when the HTTP
+	// context.WithoutCancel so the scan goroutine isn't killed when the HTTP
 	// response is sent and the request context is cancelled.
-	go h.scanner.ScanLibrary(context.WithoutCancel(r.Context()))
+	err := h.scanner.StartScan(context.WithoutCancel(r.Context()))
+	if errors.Is(err, importer.ErrScanAlreadyRunning) {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	}
 	writeJSON(w, http.StatusAccepted, map[string]string{"message": "library scan started"})
 }
 

--- a/internal/api/library_test.go
+++ b/internal/api/library_test.go
@@ -11,12 +11,20 @@ import (
 	"github.com/vavallee/bindery/internal/importer"
 )
 
-// fakeScanner records the context it received so the test can inspect it.
+// fakeScanner records the context it received so the test can inspect it,
+// and can simulate an in-flight scan via err.
 type fakeScanner struct {
 	called chan context.Context
+	err    error
 }
 
-func (f *fakeScanner) ScanLibrary(ctx context.Context) { f.called <- ctx }
+func (f *fakeScanner) StartScan(ctx context.Context) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.called <- ctx
+	return nil
+}
 
 func newLibraryHandler(t *testing.T) *LibraryHandler {
 	t.Helper()
@@ -51,7 +59,7 @@ func TestLibraryScan_ContextOutlivesRequest(t *testing.T) {
 	// handler returns (the 202 has been flushed to the client).
 	cancel()
 
-	// Wait for the goroutine to call ScanLibrary and deliver its context.
+	// Receive the context the handler passed to StartScan.
 	scanCtx := <-fake.called
 
 	// The scan context must still be live even though the request context was
@@ -61,6 +69,27 @@ func TestLibraryScan_ContextOutlivesRequest(t *testing.T) {
 		t.Fatal("scan context was cancelled when the request context was cancelled (issue #55 regression)")
 	default:
 		// pass — context.WithoutCancel keeps the scan alive
+	}
+}
+
+// TestLibraryScan_AlreadyRunningReturns409 is the regression test for #1460:
+// a scan request while another scan is in flight must surface 409 Conflict
+// instead of spawning a second concurrent full walk.
+func TestLibraryScan_AlreadyRunningReturns409(t *testing.T) {
+	fake := &fakeScanner{err: importer.ErrScanAlreadyRunning}
+	h := &LibraryHandler{scanner: fake}
+
+	rec := httptest.NewRecorder()
+	h.Scan(rec, httptest.NewRequest(http.MethodPost, "/library/scan", nil))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict while a scan is running, got %d", rec.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if body["error"] == "" {
+		t.Error("expected non-empty error in response body")
 	}
 }
 

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -6,6 +6,7 @@ package importer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/vavallee/bindery/internal/calibre"
@@ -85,6 +87,12 @@ type Scanner struct {
 	absLib               absNotifier
 	absLibraryIDsFn      func() []string
 	notif                eventNotifier
+
+	// scanRunning is the single-flight guard for library scans (#1460).
+	// Concurrent full walks race on book creation (books has no unique
+	// constraint equivalent to book_files.path) and clobber library.lastScan,
+	// so only one scan — manual or scheduled — runs at a time.
+	scanRunning atomic.Bool
 
 	// testImportHook, when non-nil, intercepts tryImportInternal before any
 	// state transition or file operation and replaces the import entirely.
@@ -1664,10 +1672,47 @@ func authorTitleFromLayout(path string, roots ...string) (author, title string, 
 	return "", "", false
 }
 
-// ScanLibrary walks the library directory (and the separate audiobook directory
-// when configured) for book files not yet tracked in the database and reconciles
-// found files with existing "wanted" book records.
+// ErrScanAlreadyRunning is returned by StartScan when a library scan (manual
+// or scheduled) is already in flight. Matches the ABS importer's
+// ErrAlreadyRunning / Grimmory syncer's ErrSyncAlreadyRunning pattern.
+var ErrScanAlreadyRunning = errors.New("library scan already running")
+
+// StartScan launches a library scan in the background and returns
+// immediately. If a scan is already in flight it returns
+// ErrScanAlreadyRunning so callers (the manual-scan endpoint) can surface a
+// 409 instead of piling up concurrent full walks (#1460). Callers pass
+// context.WithoutCancel(r.Context()) so the HTTP response-send doesn't cancel
+// the scan.
+func (s *Scanner) StartScan(ctx context.Context) error {
+	if !s.scanRunning.CompareAndSwap(false, true) {
+		return ErrScanAlreadyRunning
+	}
+	go func() {
+		defer s.scanRunning.Store(false)
+		s.scanLibrary(ctx)
+	}()
+	return nil
+}
+
+// ScanLibrary runs a library scan synchronously, sharing the single-flight
+// guard with StartScan: if a scan is already in flight (e.g. a manual scan
+// racing the 6-hourly cron job) the call is skipped with a log line. The
+// cron scheduler's SkipIfStillRunning only guards cron-vs-cron, so this is
+// what prevents cron-vs-manual overlap (#1460).
 func (s *Scanner) ScanLibrary(ctx context.Context) {
+	if !s.scanRunning.CompareAndSwap(false, true) {
+		slog.Info("library scan already running; skipping")
+		return
+	}
+	defer s.scanRunning.Store(false)
+	s.scanLibrary(ctx)
+}
+
+// scanLibrary walks the library directory (and the separate audiobook directory
+// when configured) for book files not yet tracked in the database and reconciles
+// found files with existing "wanted" book records. Callers must hold the
+// scanRunning single-flight flag (via StartScan or ScanLibrary).
+func (s *Scanner) scanLibrary(ctx context.Context) {
 	if s.libraryDir == "" {
 		// #965: previously this returned without writing any result, so the UI
 		// kept showing a stale prior scan and the #962 "no files found" warning

--- a/internal/importer/scanner_singleflight_test.go
+++ b/internal/importer/scanner_singleflight_test.go
@@ -1,0 +1,86 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/db"
+)
+
+// singleFlightFixture wires a Scanner with a settings repo so tests can
+// observe whether a scan actually ran (a completed scan writes the
+// "library.lastScan" setting).
+func singleFlightFixture(t *testing.T) (*Scanner, *db.SettingsRepo, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	settings := db.NewSettingsRepo(database)
+	s := NewScanner(
+		db.NewDownloadRepo(database),
+		db.NewDownloadClientRepo(database),
+		db.NewBookRepo(database),
+		db.NewAuthorRepo(database),
+		db.NewHistoryRepo(database),
+		t.TempDir(), "", "", "", "",
+	).WithSettings(settings)
+	return s, settings, context.Background()
+}
+
+// TestScanLibrary_SingleFlight is the regression test for #1460: a scan
+// request while another scan is in flight must be rejected (StartScan) or
+// skipped (ScanLibrary, the cron path), never run concurrently.
+func TestScanLibrary_SingleFlight(t *testing.T) {
+	s, settings, ctx := singleFlightFixture(t)
+
+	// Simulate an in-flight scan holding the single-flight flag.
+	if !s.scanRunning.CompareAndSwap(false, true) {
+		t.Fatal("fresh scanner unexpectedly has scanRunning set")
+	}
+
+	// Manual path: a second StartScan must be rejected with the sentinel.
+	if err := s.StartScan(ctx); !errors.Is(err, ErrScanAlreadyRunning) {
+		t.Fatalf("StartScan during in-flight scan: got %v, want ErrScanAlreadyRunning", err)
+	}
+
+	// Cron path: ScanLibrary must skip — it returns without scanning, so no
+	// lastScan result may be written and the flag stays held by the "other"
+	// scan.
+	s.ScanLibrary(ctx)
+	if setting, err := settings.Get(ctx, "library.lastScan"); err != nil {
+		t.Fatal(err)
+	} else if setting != nil {
+		t.Fatalf("ScanLibrary ran concurrently with an in-flight scan: lastScan = %q", setting.Value)
+	}
+	if !s.scanRunning.Load() {
+		t.Fatal("skipped ScanLibrary released a flag it did not acquire")
+	}
+
+	// Release the simulated scan; the guard must now admit a scan again and
+	// release itself on completion.
+	s.scanRunning.Store(false)
+	if err := s.StartScan(ctx); err != nil {
+		t.Fatalf("StartScan after release: %v", err)
+	}
+	deadline := time.After(5 * time.Second)
+	for {
+		setting, err := settings.Get(ctx, "library.lastScan")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if setting != nil && !s.scanRunning.Load() {
+			break // scan ran to completion and released the guard
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("background scan did not complete and release the guard (lastScan set: %v, running: %v)",
+				setting != nil, s.scanRunning.Load())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`POST /library/scan` spawned an unguarded goroutine per request, and `importer.Scanner` had no running flag, so N clicks started N concurrent full filesystem walks. Concurrent reconcile passes race on creating book rows for the same untracked file (`books` has no unique constraint equivalent to `book_files.path`) and clobber `library.lastScan`. The cron scheduler's `SkipIfStillRunning` only guards cron-vs-cron, not manual-vs-manual or manual-vs-cron. Closes #1460.

## Implementation notes

- Single atomic flag (`scanRunning`) on `Scanner`, shared by both entrypoints:
  - `StartScan` (new, used by the handler): CAS the flag, spawn the scan goroutine, return `ErrScanAlreadyRunning` on conflict. Same shape as `abs.ErrAlreadyRunning` and `grimmory.ErrSyncAlreadyRunning`.
  - `ScanLibrary` (kept synchronous for the scheduler and existing tests): same CAS, skips with a log line if a scan is in flight, which also closes the cron-vs-manual gap.
- The handler now calls `StartScan(context.WithoutCancel(r.Context()))` and maps `ErrScanAlreadyRunning` to 409 Conflict with an error body; the happy path stays 202.
- The existing scan body moved unchanged to unexported `scanLibrary`.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (`POST /library/scan` is not documented in `docs/` or `README.md`; godoc on the new symbols added; changelog fragment in `changelog.d/`)
- [x] Wiki pages updated if user-facing behaviour changed (n/a — endpoint not covered by wiki pages)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/importer ./internal/api ./internal/scheduler`
- [x] `go test -count=1 ./internal/importer/ ./internal/api/ ./internal/scheduler/` (full suites for the touched packages; new tests: `TestScanLibrary_SingleFlight`, `TestLibraryScan_AlreadyRunningReturns409`)
- [ ] full `go test ./cmd/... ./internal/...` (not run here; CI covers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
