### PR TITLE
fix(web): stop AuthorDetailPage, HistoryPage, and CalendarPage truncating lists (#1467)

### DIFF
--- a/changelog.d/1467-frontend-truncation.md
+++ b/changelog.d/1467-frontend-truncation.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Lists no longer silently truncate at 100 rows** (#1467) — the History page now pages through your full history on the server (with a working event-type filter that offers all event types), an author's page loads the complete catalogue even for authors with more than 100 books (so counts, filters, and select-all cover everything), and the Calendar loads every release in the month instead of stopping at 500.

--- a/web/src/api/books.ts
+++ b/web/src/api/books.ts
@@ -140,10 +140,11 @@ export const booksApi = {
     return request<Page<Book>>(`/book${qs ? '?' + qs : ''}`)
   },
   // listAllBooks pages through the server until the full set is collected. For
-  // callers that need every book (calendar, series book picker) rather than one
-  // display page. Heavy on very large libraries by design — prefer paginated
-  // listBooks for browse views.
-  listAllBooks: async (params?: { search?: string; status?: string; mediaType?: string; sort?: string; includeExcluded?: boolean }): Promise<Book[]> => {
+  // callers that need every book (calendar month, author detail, series book
+  // picker) rather than one display page. Heavy on very large libraries by
+  // design — prefer paginated listBooks for browse views; use this only when
+  // the query itself is bounded (one author, one month, ...).
+  listAllBooks: async (params?: { authorId?: number; search?: string; status?: string; mediaType?: string; sort?: string; includeExcluded?: boolean; releaseFrom?: string; releaseBefore?: string }): Promise<Book[]> => {
     const pageSize = 500
     let offset = 0
     const all: Book[] = []

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -145,3 +145,65 @@ describe('ApiError message extraction', () => {
     await expect(api.grimmoryTest()).rejects.toThrow('primary')
   })
 })
+
+describe('listAllBooks', () => {
+  it('forwards authorId/includeExcluded and pages until the full catalogue is collected (#1467)', async () => {
+    const requests: Array<{ authorId: string | null; includeExcluded: string | null; limit: number; offset: number }> = []
+    const total = 230
+
+    server.use(
+      http.get(apiUrl('/book'), ({ request }) => {
+        const url = new URL(request.url)
+        const limit = Number(url.searchParams.get('limit'))
+        const offset = Number(url.searchParams.get('offset'))
+        requests.push({
+          authorId: url.searchParams.get('authorId'),
+          includeExcluded: url.searchParams.get('includeExcluded'),
+          limit,
+          offset,
+        })
+        const count = Math.max(0, Math.min(limit, total - offset))
+        const items = Array.from({ length: count }, (_, i) => ({ id: offset + i + 1, title: `Book ${offset + i + 1}` }))
+        return HttpResponse.json({ items, total, limit, offset })
+      }),
+    )
+
+    const { api } = await loadClient()
+
+    const books = await api.listAllBooks({ authorId: 42, includeExcluded: true })
+
+    // 230 books at a 500 page size: one request would suffice, but the loop
+    // must have asked for the author's rows with the filters intact.
+    expect(books).toHaveLength(total)
+    expect(books[0].id).toBe(1)
+    expect(books[total - 1].id).toBe(total)
+    expect(requests.every(r => r.authorId === '42' && r.includeExcluded === 'true')).toBe(true)
+    expect(requests[0].offset).toBe(0)
+  })
+
+  it('keeps fetching pages while the server returns partial pages', async () => {
+    // Server caps the page size below the client's 500 request — the loop must
+    // keep advancing by the *returned* count until total is reached.
+    const total = 250
+    const serverCap = 100
+    const offsets: number[] = []
+
+    server.use(
+      http.get(apiUrl('/book'), ({ request }) => {
+        const url = new URL(request.url)
+        const offset = Number(url.searchParams.get('offset'))
+        offsets.push(offset)
+        const count = Math.max(0, Math.min(serverCap, total - offset))
+        const items = Array.from({ length: count }, (_, i) => ({ id: offset + i + 1, title: `Book ${offset + i + 1}` }))
+        return HttpResponse.json({ items, total, limit: serverCap, offset })
+      }),
+    )
+
+    const { api } = await loadClient()
+
+    const books = await api.listAllBooks({ authorId: 7 })
+
+    expect(books).toHaveLength(total)
+    expect(offsets).toEqual([0, 100, 200])
+  })
+})

--- a/web/src/pages/AuthorDetailPage.test.tsx
+++ b/web/src/pages/AuthorDetailPage.test.tsx
@@ -14,7 +14,7 @@ vi.mock('../api/client', async importOriginal => {
     api: {
       ...actual.api,
       getAuthor: vi.fn(),
-      listBooks: vi.fn(),
+      listAllBooks: vi.fn(),
       listAuthors: vi.fn(),
       refreshAuthor: vi.fn(),
       searchAuthorLinkCandidates: vi.fn(),
@@ -96,7 +96,7 @@ function LocationProbe({ onLocation }: { onLocation?: (location: string) => void
 function renderAuthorDetailPage(books: Book[], view: 'grid' | 'table' = 'grid', authorOverride: Partial<Author> = {}, initialPath = '/author/42', onLocation?: (location: string) => void) {
   localStorage.setItem('bindery.view.author-detail', view)
   vi.mocked(api.getAuthor).mockResolvedValue({ ...author, ...authorOverride })
-  vi.mocked(api.listBooks).mockResolvedValue({ items: books, total: books.length, limit: 100, offset: 0 })
+  vi.mocked(api.listAllBooks).mockResolvedValue(books)
 
   return render(
     <MemoryRouter initialEntries={[initialPath]}>
@@ -124,6 +124,31 @@ function mockElementOverflow(overflows: boolean): () => void {
 }
 
 describe('AuthorDetailPage', () => {
+  it('loads the complete author catalogue via the paging fetch-all, and renders past 100 books (#1467)', async () => {
+    const books = Array.from({ length: 150 }, (_, i) =>
+      makeBook({ id: i + 1, title: `Book ${i + 1}`, status: 'imported' }))
+    renderAuthorDetailPage(books, 'table')
+
+    await screen.findByText('Book 1')
+
+    // The fetch must go through listAllBooks (which pages until `total` is
+    // reached) scoped to this author — a bare listBooks call silently stopped
+    // at the server's default page of 100.
+    expect(api.listAllBooks).toHaveBeenCalledWith({ authorId: 42, includeExcluded: false })
+    expect(screen.getByText('Book 150')).toBeInTheDocument()
+    expect(screen.getByText(/150 books/)).toBeInTheDocument()
+  })
+
+  it('passes includeExcluded through to the fetch-all when Show excluded is toggled', async () => {
+    renderAuthorDetailPage([makeBook({ id: 1, title: 'Visible Book', status: 'imported' })], 'table')
+
+    await screen.findByText('Visible Book')
+    fireEvent.click(screen.getByRole('checkbox', { name: /Show excluded/i }))
+
+    await waitFor(() =>
+      expect(api.listAllBooks).toHaveBeenCalledWith({ authorId: 42, includeExcluded: true }))
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     installLocalStorageMock()

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -148,11 +148,14 @@ export default function AuthorDetailPage() {
   useEffect(() => {
     let cancelled = false
     setLoading(true)
+    // listAllBooks pages through the server until the author's complete
+    // catalogue is loaded — a plain listBooks call silently capped the list at
+    // the server default of 100, corrupting counts/filters/select-all (#1467).
     Promise.all([
       api.getAuthor(authorId),
-      api.listBooks({ authorId, includeExcluded: showExcluded }),
+      api.listAllBooks({ authorId, includeExcluded: showExcluded }),
     ])
-      .then(([a, bs]) => { if (!cancelled) { setAuthor(a); setBooks(bs.items) } })
+      .then(([a, bs]) => { if (!cancelled) { setAuthor(a); setBooks(bs) } })
       .catch(err => setError(err instanceof Error ? err.message : 'Failed to load'))
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
@@ -181,9 +184,9 @@ export default function AuthorDetailPage() {
     setRefreshing(true)
     try {
       await api.refreshAuthor(author.id)
-      const [a, bs] = await Promise.all([api.getAuthor(authorId), api.listBooks({ authorId, includeExcluded: showExcluded })])
+      const [a, bs] = await Promise.all([api.getAuthor(authorId), api.listAllBooks({ authorId, includeExcluded: showExcluded })])
       setAuthor(a)
-      setBooks(bs.items)
+      setBooks(bs)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Refresh failed')
     } finally {
@@ -268,7 +271,7 @@ export default function AuthorDetailPage() {
   // unless showExcluded is on; delete removes them outright).
   const reloadBooks = async () => {
     try {
-      const { items } = await api.listBooks({ authorId, includeExcluded: showExcluded })
+      const items = await api.listAllBooks({ authorId, includeExcluded: showExcluded })
       setBooks(items)
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Reload failed')
@@ -755,8 +758,8 @@ export default function AuthorDetailPage() {
           onClose={() => setShowMetadataLink(false)}
           onLinked={updated => {
             setAuthor(updated)
-            Promise.all([api.getAuthor(authorId), api.listBooks({ authorId, includeExcluded: showExcluded })])
-              .then(([a, bs]) => { setAuthor(a); setBooks(bs.items) })
+            Promise.all([api.getAuthor(authorId), api.listAllBooks({ authorId, includeExcluded: showExcluded })])
+              .then(([a, bs]) => { setAuthor(a); setBooks(bs) })
               .catch(console.error)
           }}
         />
@@ -769,8 +772,8 @@ export default function AuthorDetailPage() {
           onClose={() => setShowMerge(false)}
           onMerged={() => {
             // Reload current author (aliases may have grown) + its books.
-            Promise.all([api.getAuthor(authorId), api.listBooks({ authorId })])
-              .then(([a, bs]) => { setAuthor(a); setBooks(bs.items) })
+            Promise.all([api.getAuthor(authorId), api.listAllBooks({ authorId })])
+              .then(([a, bs]) => { setAuthor(a); setBooks(bs) })
               .catch(console.error)
           }}
         />

--- a/web/src/pages/CalendarPage.tsx
+++ b/web/src/pages/CalendarPage.tsx
@@ -38,8 +38,11 @@ export default function CalendarPage() {
     const beforeMonth = viewMonth === 11 ? 0 : viewMonth + 1
     const before = `${beforeYear}-${pad(beforeMonth + 1)}-01`
     setLoading(true)
-    api.listBooks({ releaseFrom: from, releaseBefore: before, limit: 500 })
-      .then(({ items }) => setBooks(items))
+    // listAllBooks pages through the server so a month with more releases than
+    // the server's 500-row cap still renders completely (#1467). The query is
+    // bounded to one month, so the full fetch stays cheap.
+    api.listAllBooks({ releaseFrom: from, releaseBefore: before })
+      .then(setBooks)
       .catch(console.error)
       .finally(() => setLoading(false))
   }, [viewYear, viewMonth])

--- a/web/src/pages/HistoryPage.test.tsx
+++ b/web/src/pages/HistoryPage.test.tsx
@@ -36,28 +36,13 @@ vi.mock('react-i18next', () => ({
         'history.colDate': 'Date',
         'history.blocklist': 'Blocklist',
         'history.delete': 'Delete',
+        'pagination.previous': 'Previous',
+        'pagination.next': 'Next',
       }
       return labels[key] ?? opts?.defaultValue ?? key
     },
   }),
 }))
-
-vi.mock('../components/usePagination', () => ({
-  usePagination: <T,>(items: T[]) => ({
-    pageItems: items,
-    paginationProps: {
-      page: 1,
-      totalPages: 1,
-      pageSize: 100,
-      totalItems: items.length,
-      onPageChange: vi.fn(),
-      onPageSizeChange: vi.fn(),
-    },
-    reset: vi.fn(),
-  }),
-}))
-
-vi.mock('../components/Pagination', () => ({ default: () => null }))
 
 function makeHistory(overrides: Partial<HistoryEvent> = {}): HistoryEvent {
   return {
@@ -106,6 +91,7 @@ function rowFor(text: string) {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  localStorage.clear()
   document.title = 'Bindery'
   vi.mocked(api.listHistory).mockResolvedValue({ items: [], total: 0, limit: 100, offset: 0 })
   vi.mocked(api.deleteHistory).mockResolvedValue(undefined)
@@ -186,9 +172,11 @@ describe('HistoryPage', () => {
     const table = await findDesktopTable()
     expect(await within(table).findByText('Grabbed Release')).toBeInTheDocument()
 
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'downloadFailed' } })
+    // [0] is the event-type filter; the per-page selector inside Pagination is
+    // a second combobox.
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'downloadFailed' } })
 
-    await waitFor(() => expect(api.listHistory).toHaveBeenLastCalledWith({ eventType: 'downloadFailed' }))
+    await waitFor(() => expect(api.listHistory).toHaveBeenLastCalledWith({ eventType: 'downloadFailed', limit: 100, offset: 0 }))
     expect(await within(desktopTable()).findByText('Failed Release')).toBeInTheDocument()
     await waitFor(() => expect(within(desktopTable()).queryByText('Grabbed Release')).not.toBeInTheDocument())
   })
@@ -261,6 +249,49 @@ describe('HistoryPage', () => {
     renderHistoryPage()
 
     expect(await screen.findByText('No history events found')).toBeInTheDocument()
-    expect(api.listHistory).toHaveBeenCalledWith(undefined)
+    expect(api.listHistory).toHaveBeenCalledWith({ eventType: undefined, limit: 100, offset: 0 })
+  })
+
+  it('fetches later pages from the server so history beyond 100 events is reachable (#1467)', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, i) =>
+      makeHistory({ id: i + 1, sourceTitle: `Event ${i + 1}` }))
+    const secondPage = Array.from({ length: 50 }, (_, i) =>
+      makeHistory({ id: 101 + i, sourceTitle: `Event ${101 + i}` }))
+    vi.mocked(api.listHistory).mockImplementation(async params => {
+      const offset = params?.offset ?? 0
+      return { items: offset === 0 ? firstPage : secondPage, total: 150, limit: 100, offset }
+    })
+
+    renderHistoryPage()
+
+    const table = await findDesktopTable()
+    expect(await within(table).findByText('Event 1')).toBeInTheDocument()
+    expect(screen.getByText('1–100 of 150')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '2' }))
+
+    await waitFor(() => expect(api.listHistory).toHaveBeenLastCalledWith({ eventType: undefined, limit: 100, offset: 100 }))
+    expect(await within(desktopTable()).findByText('Event 101')).toBeInTheDocument()
+    expect(within(desktopTable()).queryByText('Event 1')).not.toBeInTheDocument()
+    expect(screen.getByText('101–150 of 150')).toBeInTheDocument()
+  })
+
+  it('offers known event types in the filter even when absent from the loaded page (#1467)', async () => {
+    vi.mocked(api.listHistory).mockResolvedValue({
+      items: [makeHistory({ id: 1, eventType: 'grabbed', sourceTitle: 'Only Grab' })],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    })
+
+    renderHistoryPage()
+    await findDesktopTable()
+
+    const filter = screen.getAllByRole('combobox')[0]
+    expect(within(filter).getByRole('option', { name: 'Grabbed' })).toBeInTheDocument()
+    // These types exist on the server but not in the visible rows — they must
+    // still be offered so filtering can surface older events.
+    expect(within(filter).getByRole('option', { name: 'Download Requeued' })).toBeInTheDocument()
+    expect(within(filter).getByRole('option', { name: 'Book Rebound' })).toBeInTheDocument()
   })
 })

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { api, HistoryEvent } from '../api/client'
 import BookAuthorLink from '../components/BookAuthorLink'
 import Pagination from '../components/Pagination'
-import { usePagination } from '../components/usePagination'
+import { useServerPagination } from '../components/usePagination'
 import { dangerLink } from '../components/buttons'
 
 const EVENT_TYPE_COLORS: Record<string, string> = {
@@ -58,11 +58,32 @@ function detectMediaType(title: string): '' | 'ebook' | 'audiobook' {
 
 const BLOCKLISTABLE = new Set(['grabbed', 'downloadFailed', 'importFailed'])
 
+// Every event type the backend can emit (internal/models/settings.go). The
+// filter dropdown is built from this list merged with whatever appears in the
+// loaded page, so the filter still offers types that happen not to occur in
+// the currently visible rows (#1467) while never dropping an unknown/legacy
+// type that does.
+const KNOWN_EVENT_TYPES = [
+  'grabbed',
+  'bookImported',
+  'downloadFailed',
+  'importFailed',
+  'bookRenamed',
+  'downloadFolderImported',
+  'bookFileDeleted',
+  'downloadStalled',
+  'downloadRequeued',
+  'bookRebound',
+]
+
 export default function HistoryPage() {
   const { t } = useTranslation()
   const [events, setEvents] = useState<HistoryEvent[]>([])
+  const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
   const [typeFilter, setTypeFilter] = useState('')
+
+  const { page, pageSize, paginationProps, reset } = useServerPagination(total, 100, 'history')
 
   // Friendly label for an event-type enum: curated i18n where available, else a
   // humanized camelCase fallback. Keeps the enum as the filter <option> value.
@@ -71,12 +92,21 @@ export default function HistoryPage() {
     [t],
   )
 
-  const load = useCallback((filter?: string) => {
-    api.listHistory(filter ? { eventType: filter } : undefined)
-      .then(({ items }) => setEvents(items))
+  // Server-side list (#1467): page, page size, and event-type filter are all
+  // applied by the API and `total` drives the pager, so history older than the
+  // server's default page of 100 stays reachable. Previously the response was
+  // never paged past offset 0 and the client pager sliced those same 100 rows.
+  const load = useCallback(() => {
+    setLoading(true)
+    api.listHistory({
+      eventType: typeFilter || undefined,
+      limit: pageSize,
+      offset: (page - 1) * pageSize,
+    })
+      .then(({ items, total }) => { setEvents(items); setTotal(total) })
       .catch(console.error)
       .finally(() => setLoading(false))
-  }, [])
+  }, [typeFilter, page, pageSize])
 
   useEffect(() => { load() }, [load])
 
@@ -87,25 +117,24 @@ export default function HistoryPage() {
 
   const handleFilterChange = (val: string) => {
     setTypeFilter(val)
-    setLoading(true)
-    load(val || undefined)
+    reset()
   }
 
+  // Row actions drop the row locally and decrement the pager total; the next
+  // page fetch resyncs with the server.
   const handleDelete = async (id: number) => {
     await api.deleteHistory(id).catch(console.error)
     setEvents(prev => prev.filter(e => e.id !== id))
+    setTotal(prev => Math.max(0, prev - 1))
   }
 
   const handleBlocklist = async (id: number) => {
     await api.blocklistFromHistory(id).catch(console.error)
     setEvents(prev => prev.filter(e => e.id !== id))
+    setTotal(prev => Math.max(0, prev - 1))
   }
 
-  const eventTypes = Array.from(new Set(events.map(e => e.eventType))).sort()
-
-  const { pageItems, paginationProps, reset } = usePagination(events, 100, 'history')
-
-  useEffect(() => { reset() }, [typeFilter, reset])
+  const eventTypes = Array.from(new Set([...KNOWN_EVENT_TYPES, ...events.map(e => e.eventType)])).sort()
 
   return (
     <div>
@@ -146,7 +175,7 @@ export default function HistoryPage() {
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-200 dark:divide-zinc-800">
-                  {pageItems.map(event => {
+                  {events.map(event => {
                     const parsed = parseEventData(event.data)
                     const detail = parsed.message || parsed.path || ''
                     const isError = event.eventType === 'downloadFailed' || event.eventType === 'importFailed'
@@ -212,7 +241,7 @@ export default function HistoryPage() {
 
           {/* Mobile card list */}
           <div className="sm:hidden space-y-2">
-            {pageItems.map(event => {
+            {events.map(event => {
               const parsed = parseEventData(event.data)
               const detail = parsed.message || parsed.path || ''
               const isError = event.eventType === 'downloadFailed' || event.eventType === 'importFailed'


### PR DESCRIPTION
Fixes #1467.

## Summary

- **AuthorDetailPage** loaded one default server page (100 rows) of an author's books and discarded `total`, so large catalogues were silently truncated and the status counts, filter chips, series grouping, and select-all all operated on the wrong set. It now fetches the complete catalogue via `api.listAllBooks` (pages until the server-reported total, bounded to a single author) at every call site: initial load, refresh, bulk-action reload, metadata relink, and merge.
- **HistoryPage** could never reach past the latest 100 events: no limit/offset was sent, `total` was discarded, and `usePagination(events, 100)` sliced those same 100 rows into one permanent page. It now uses `useServerPagination` (same pattern as BooksPage after #1010): page, page size, and the event-type filter are applied by the API and `total` drives the pager. The event-type dropdown is built from the full set of backend event types merged with the loaded rows, so it no longer offers only the types that happen to appear in the visible page.
- **CalendarPage** (the milder variant noted in the issue) fetched the month with `limit: 500`, which is exactly the server hard cap; it now uses the same bounded fetch-all scoped to the visible month.
- `api.listAllBooks` gains `authorId` / `releaseFrom` / `releaseBefore` passthrough to support the new callers.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new warnings (6 pre-existing, none in touched files)
- [x] `npx vitest run` — full suite, 45 files / 398 tests pass
- [x] New: HistoryPage fetches later pages from the server (`offset: 100`) and renders them; filter dropdown offers known event types absent from the visible page; filter/empty-state assertions updated for the paginated call shape
- [x] New: AuthorDetailPage loads >100 books via `listAllBooks({ authorId })` and renders all of them; `includeExcluded` is threaded through the fetch-all
- [x] New: `listAllBooks` unit tests (msw) — forwards `authorId`/`includeExcluded`, and keeps paging by the *returned* row count when the server caps the page size below the requested 500

No Go changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)