### PR TITLE
chore(ci): harden AI workflows — egress block + digest allowed_mentions

### DIFF
--- a/.github/workflows/ai-sweep.yml
+++ b/.github/workflows/ai-sweep.yml
@@ -37,10 +37,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (block non-allowlisted egress)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          # block (#1401): this job hands ANTHROPIC_API_KEY and a write-scoped
+          # token to an LLM agent that reads untrusted issue/PR text. The
+          # allowedTools list is the first barrier; the egress allowlist is the
+          # network backstop so a future allowlist regression can't exfiltrate.
+          egress-policy: block
+          allowed-endpoints: >
+            api.anthropic.com:443
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            discord.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -129,5 +140,10 @@ jobs:
           if [ -n "${MAINTAINER_ID:-}" ]; then
             MSG="<@${MAINTAINER_ID}> ${MSG}"
           fi
+          # allowed_mentions (#1400): the digest embeds untrusted issue/PR
+          # titles, so an issue titled "@everyone" (or carrying a raw role
+          # mention) must not ping the channel. parse:["users"] keeps the
+          # explicit maintainer <@id> ping working while suppressing
+          # everyone/here/role parsing — same guard as notify-external-pr.yml.
           curl -fsS -H "Content-Type: application/json" \
-            -d "$(jq -Rn --arg c "$MSG" '{content:$c}')" "$DISCORD_WEBHOOK"
+            -d "$(jq -Rn --arg c "$MSG" '{content:$c, allowed_mentions:{parse:["users"]}}')" "$DISCORD_WEBHOOK"

--- a/.github/workflows/ai-triage.yml
+++ b/.github/workflows/ai-triage.yml
@@ -43,10 +43,20 @@ jobs:
        github.event.pull_request.draft == false &&
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (block non-allowlisted egress)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: audit
+          # block (#1401): this job hands ANTHROPIC_API_KEY and a write-scoped
+          # token to an LLM agent that reads untrusted issue/PR text. The
+          # allowedTools list is the first barrier; the egress allowlist is the
+          # network backstop so a future allowlist regression can't exfiltrate.
+          egress-policy: block
+          allowed-endpoints: >
+            api.anthropic.com:443
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

Closes #1400, closes #1401. Both were defense-in-depth findings from the prompt-injection review of the AI agent workflows.

- **#1401**: `ai-sweep.yml` and `ai-triage.yml` switch harden-runner from `egress-policy: audit` to `block` with explicit endpoint allowlists (`api.anthropic.com`, GitHub hosts; the sweep also gets `discord.com` for its isolated webhook post step). The agent's `allowedTools` list stops being the sole barrier against key/token exfiltration.
- **#1400**: the sweep's Discord digest payload now sets `allowed_mentions: {parse:["users"]}` — same guard as `notify-external-pr.yml` — so an issue titled `@everyone` or carrying a raw role mention can't ping the channel. The explicit maintainer `<@id>` ping keeps working.

## Test plan

- [ ] Next scheduled/dispatched ai-sweep run posts the digest successfully (webhook host allowed, mentions suppressed)
- [ ] ai-triage run on this PR completes with blocked egress (watch for harden-runner blocked-call annotations if I missed an endpoint)

Note: if a legit endpoint got missed, the job fails loudly with a harden-runner annotation naming it — cheap to amend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)