### PR TITLE
fix(importlists): per-account Hardcover reading lists

### DIFF
--- a/changelog.d/1489-hardcover-list-accounts.md
+++ b/changelog.d/1489-hardcover-list-accounts.md
@@ -1,0 +1,9 @@
+### Fixed
+- **Per-account Hardcover reading lists** (#1489) — Hardcover's built-in
+  shelves ("Want to Read", …) share one slug per account, so loading a second
+  person's lists with their token showed their shelf as the already-added
+  first one and toggled the wrong list. List identity is now (slug, account):
+  the picker reports which Hardcover account it's browsing, saved lists
+  remember the account they came from (shown as an @username chip), and two
+  households' "Want to Read" lists sync side by side, each with its own
+  token.

--- a/internal/api/import_lists.go
+++ b/internal/api/import_lists.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -24,6 +25,7 @@ type HardcoverListSyncer interface {
 
 type hardcoverUserListClient interface {
 	GetUserLists(ctx context.Context) ([]hardcover.HCList, error)
+	GetUsername(ctx context.Context) (string, error)
 }
 
 type ImportListHandler struct {
@@ -165,7 +167,16 @@ func (h *ImportListHandler) HardcoverLists(w http.ResponseWriter, r *http.Reques
 		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
 		return
 	}
-	writeJSON(w, http.StatusOK, lists)
+	// account identifies whose lists these are (#1489): built-in shelves share
+	// one slug per account, so the frontend needs the username to keep two
+	// accounts' "Want to Read" apart. Best-effort — an empty account degrades
+	// to the legacy slug-only matching.
+	account, err := client.GetUsername(r.Context())
+	if err != nil {
+		slog.Debug("hardcover lists: username lookup failed", "error", err)
+		account = ""
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"account": account, "lists": lists})
 }
 
 // --- Exclusions ---

--- a/internal/api/import_lists_test.go
+++ b/internal/api/import_lists_test.go
@@ -501,10 +501,15 @@ func TestHardcoverListsHeaderOverrideDoesNotRequireAdmin(t *testing.T) {
 }
 
 type fakeHardcoverUserListClient struct {
-	lists []hardcover.HCList
-	err   error
+	lists   []hardcover.HCList
+	account string
+	err     error
 }
 
 func (f fakeHardcoverUserListClient) GetUserLists(context.Context) ([]hardcover.HCList, error) {
 	return f.lists, f.err
+}
+
+func (f fakeHardcoverUserListClient) GetUsername(context.Context) (string, error) {
+	return f.account, nil
 }

--- a/internal/db/import_lists.go
+++ b/internal/db/import_lists.go
@@ -19,7 +19,7 @@ func NewImportListRepo(db *sql.DB) *ImportListRepo {
 
 func (r *ImportListRepo) List(ctx context.Context) ([]models.ImportList, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, name, type, url, api_key, root_folder_id, quality_profile_id,
+		SELECT id, name, type, url, api_key, COALESCE(account, ''), root_folder_id, quality_profile_id,
 		       monitor_new, auto_add, enabled, media_type, last_sync_at, created_at, updated_at
 		FROM import_lists ORDER BY name`)
 	if err != nil {
@@ -40,7 +40,7 @@ func (r *ImportListRepo) List(ctx context.Context) ([]models.ImportList, error) 
 
 func (r *ImportListRepo) ListByType(ctx context.Context, listType string) ([]models.ImportList, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, name, type, url, api_key, root_folder_id, quality_profile_id,
+		SELECT id, name, type, url, api_key, COALESCE(account, ''), root_folder_id, quality_profile_id,
 		       monitor_new, auto_add, enabled, media_type, last_sync_at, created_at, updated_at
 		FROM import_lists WHERE type=? AND enabled=1 ORDER BY name`, listType)
 	if err != nil {
@@ -70,7 +70,7 @@ func (r *ImportListRepo) UpdateLastSyncAt(ctx context.Context, id int64) error {
 
 func (r *ImportListRepo) GetByID(ctx context.Context, id int64) (*models.ImportList, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, name, type, url, api_key, root_folder_id, quality_profile_id,
+		SELECT id, name, type, url, api_key, COALESCE(account, ''), root_folder_id, quality_profile_id,
 		       monitor_new, auto_add, enabled, media_type, last_sync_at, created_at, updated_at
 		FROM import_lists WHERE id=?`, id)
 	if err != nil {
@@ -94,10 +94,10 @@ func (r *ImportListRepo) GetByID(ctx context.Context, id int64) (*models.ImportL
 func (r *ImportListRepo) Create(ctx context.Context, il *models.ImportList) error {
 	now := time.Now().UTC()
 	result, err := r.db.ExecContext(ctx, `
-		INSERT INTO import_lists (name, type, url, api_key, root_folder_id, quality_profile_id,
+		INSERT INTO import_lists (name, type, url, api_key, account, root_folder_id, quality_profile_id,
 		                          monitor_new, auto_add, enabled, media_type, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		il.Name, il.Type, il.URL, il.APIKey, il.RootFolderID, il.QualityProfileID,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		il.Name, il.Type, il.URL, il.APIKey, il.Account, il.RootFolderID, il.QualityProfileID,
 		il.MonitorNew, il.AutoAdd, il.Enabled, il.MediaType, now, now)
 	if err != nil {
 		return fmt.Errorf("create import list: %w", err)
@@ -112,10 +112,10 @@ func (r *ImportListRepo) Create(ctx context.Context, il *models.ImportList) erro
 func (r *ImportListRepo) Update(ctx context.Context, il *models.ImportList) error {
 	now := time.Now().UTC()
 	_, err := r.db.ExecContext(ctx, `
-		UPDATE import_lists SET name=?, type=?, url=?, api_key=?, root_folder_id=?,
+		UPDATE import_lists SET name=?, type=?, url=?, api_key=?, account=?, root_folder_id=?,
 		                        quality_profile_id=?, monitor_new=?, auto_add=?, enabled=?, media_type=?, updated_at=?
 		WHERE id=?`,
-		il.Name, il.Type, il.URL, il.APIKey, il.RootFolderID, il.QualityProfileID,
+		il.Name, il.Type, il.URL, il.APIKey, il.Account, il.RootFolderID, il.QualityProfileID,
 		il.MonitorNew, il.AutoAdd, il.Enabled, il.MediaType, now, il.ID)
 	if err != nil {
 		return fmt.Errorf("update import list %d: %w", il.ID, err)
@@ -136,7 +136,7 @@ func scanImportList(rows *sql.Rows) (models.ImportList, error) {
 	var il models.ImportList
 	var monitorNew, autoAdd, enabled int
 	err := rows.Scan(
-		&il.ID, &il.Name, &il.Type, &il.URL, &il.APIKey,
+		&il.ID, &il.Name, &il.Type, &il.URL, &il.APIKey, &il.Account,
 		&il.RootFolderID, &il.QualityProfileID,
 		&monitorNew, &autoAdd, &enabled, &il.MediaType,
 		&il.LastSyncAt, &il.CreatedAt, &il.UpdatedAt,

--- a/internal/db/migrations/063_import_list_account.sql
+++ b/internal/db/migrations/063_import_list_account.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+-- Per-account Hardcover reading lists (#1489). Hardcover's built-in shelves
+-- share one slug per account ("want-to-read", ...), so two accounts' lists
+-- were indistinguishable once saved: the picker matched local rows by slug
+-- alone and treated the second account's shelf as the already-added first
+-- one. account stores the Hardcover username the list was loaded from, so
+-- list identity is (slug, account). Empty for legacy rows and non-Hardcover
+-- list types.
+ALTER TABLE import_lists ADD COLUMN account TEXT NOT NULL DEFAULT '';

--- a/internal/metadata/hardcover/lists.go
+++ b/internal/metadata/hardcover/lists.go
@@ -205,6 +205,32 @@ func (c *Client) GetUserLists(ctx context.Context) ([]HCList, error) {
 	return lists, nil
 }
 
+// GetUsername returns the Hardcover username of the account the client's
+// token belongs to (#1489). Built-in shelves share one slug per account
+// ("want-to-read", ...), so the username is what makes a saved list's
+// identity unique across accounts: (slug, account).
+func (c *Client) GetUsername(ctx context.Context) (string, error) {
+	gql := `query GetUsername {
+		me {
+			username
+		}
+	}`
+	var resp struct {
+		Data struct {
+			Me []struct {
+				Username string `json:"username"`
+			} `json:"me"`
+		} `json:"data"`
+	}
+	if err := c.query(ctx, gql, nil, &resp); err != nil {
+		return "", fmt.Errorf("hardcover get username: %w", err)
+	}
+	if len(resp.Data.Me) == 0 {
+		return "", nil
+	}
+	return resp.Data.Me[0].Username, nil
+}
+
 type hcCountAggregate struct {
 	Aggregate struct {
 		Count int `json:"count"`

--- a/internal/models/import_list.go
+++ b/internal/models/import_list.go
@@ -9,6 +9,11 @@ type ImportList struct {
 	URL              string `json:"url"`
 	APIKey           string `json:"apiKey"`
 	APIKeyConfigured bool   `json:"apiKeyConfigured"`
+	// Account is the provider-side account identity the list belongs to
+	// (#1489) — for Hardcover, the username reported by the token the list
+	// was loaded with. Two accounts' built-in shelves share slugs, so list
+	// identity is (URL slug, Account). Empty for legacy rows.
+	Account string `json:"account"`
 	RootFolderID     *int64 `json:"rootFolderId"`
 	QualityProfileID *int64 `json:"qualityProfileId"`
 	MonitorNew       bool   `json:"monitorNew"`

--- a/internal/models/import_list.go
+++ b/internal/models/import_list.go
@@ -13,7 +13,7 @@ type ImportList struct {
 	// (#1489) — for Hardcover, the username reported by the token the list
 	// was loaded with. Two accounts' built-in shelves share slugs, so list
 	// identity is (URL slug, Account). Empty for legacy rows.
-	Account string `json:"account"`
+	Account          string `json:"account"`
 	RootFolderID     *int64 `json:"rootFolderId"`
 	QualityProfileID *int64 `json:"qualityProfileId"`
 	MonitorNew       bool   `json:"monitorNew"`

--- a/web/src/api/importlists.ts
+++ b/web/src/api/importlists.ts
@@ -7,6 +7,9 @@ export interface ImportList {
   url: string
   apiKey: string
   apiKeyConfigured: boolean
+  // Provider-side account the list belongs to (#1489): the Hardcover username
+  // reported by the token the list was loaded with. Empty for legacy rows.
+  account: string
   rootFolderId?: number | null
   qualityProfileId?: number | null
   monitorNew: boolean
@@ -29,6 +32,14 @@ export interface HardcoverList {
   name: string
   slug: string
   booksCount: number
+}
+
+// Envelope for GET /importlist/hardcover/lists (#1489): the lists plus the
+// username of the account the supplied token belongs to, so the picker can
+// keep two accounts' identically-slugged shelves apart.
+export interface HardcoverListsResponse {
+  account: string
+  lists: HardcoverList[]
 }
 
 // GoodreadsRow mirrors a parsed Goodreads CSV row returned in a preview.
@@ -78,7 +89,7 @@ export const importListsApi = {
   deleteImportList: (id: number) => request<void>(`/importlist/${id}`, { method: 'DELETE' }),
   syncImportList: (id: number) => request<{ status: string }>(`/importlist/${id}/sync`, { method: 'POST' }),
   hardcoverLists: (token?: string) =>
-    request<HardcoverList[]>('/importlist/hardcover/lists', {
+    request<HardcoverListsResponse>('/importlist/hardcover/lists', {
       headers: token ? { Authorization: `Bearer ${token}` } : undefined,
     }),
   uploadMigrate: <T>(endpoint: 'csv' | 'readarr', body: FormData) =>

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -213,6 +213,7 @@ function makeImportList(overrides: Partial<ImportList> = {}): ImportList {
     url: 'want-to-read',
     apiKey: '',
     apiKeyConfigured: false,
+  account: '',
     rootFolderId: null,
     qualityProfileId: null,
     monitorNew: true,
@@ -246,6 +247,7 @@ function seedSettingsMocks(options: {
   oidcProviders?: OidcProvider[]
   importLists?: ImportList[]
   hardcoverLists?: HardcoverList[]
+  hardcoverAccount?: string
 } = {}) {
   vi.mocked(api.listIndexers).mockResolvedValue(options.indexers ?? [])
   vi.mocked(api.addIndexer).mockImplementation(async data => makeIndexer({ id: 100, ...data }))
@@ -285,7 +287,7 @@ function seedSettingsMocks(options: {
     vi.mocked(api.updateImportList).mockImplementation(async (id, data) => makeImportList({ id, ...data }))
     vi.mocked(api.deleteImportList).mockResolvedValue(undefined)
     vi.mocked(api.syncImportList).mockResolvedValue({ status: 'ok' })
-    vi.mocked(api.hardcoverLists).mockResolvedValue(options.hardcoverLists ?? [])
+    vi.mocked(api.hardcoverLists).mockResolvedValue({ account: options.hardcoverAccount ?? '', lists: options.hardcoverLists ?? [] })
     vi.mocked(api.triggerLibraryScan).mockResolvedValue({ message: 'started' })
     vi.mocked(api.createBackup).mockResolvedValue({ name: 'bindery-backup.zip', size: 0, modTime: '' })
     vi.mocked(api.deleteBackup).mockResolvedValue(undefined)
@@ -535,6 +537,37 @@ describe('SettingsPage', () => {
     await waitFor(() => {
       expect(api.updateImportList).toHaveBeenCalledWith(44, { enabled: true })
     })
+  })
+
+  it("keeps two accounts' identically-slugged shelves apart (#1489)", async () => {
+    // Alice's Want to Read is already saved. Browsing Bob's lists (account
+    // "bob") must NOT match Alice's row: the shelf shows as a fresh, addable
+    // list, and clicking it creates a NEW import list carrying account bob —
+    // not a toggle of Alice's row.
+    renderSettings({
+      importLists: [
+        makeImportList({ id: 61, name: "Alice Want to Read", url: 'want-to-read', account: 'alice', apiKeyConfigured: true, enabled: true }),
+      ],
+      hardcoverLists: [makeHardcoverList({ name: 'Want to Read', slug: 'want-to-read', booksCount: 4 })],
+      hardcoverAccount: 'bob',
+    })
+
+    await openImportTab()
+    const remoteName = await screen.findByText('Want to Read')
+    expect(screen.getByText('Alice Want to Read')).toBeInTheDocument()
+    // Alice's healthy row from another account must not be flagged stale.
+    expect(screen.queryByText('Saved only')).not.toBeInTheDocument()
+
+    const remoteRow = remoteName.closest('label')
+    expect(remoteRow).not.toBeNull()
+    fireEvent.click(within(remoteRow as HTMLElement).getByRole('checkbox'))
+
+    await waitFor(() => {
+      expect(api.addImportList).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'want-to-read', account: 'bob' }),
+      )
+    })
+    expect(api.updateImportList).not.toHaveBeenCalled()
   })
 
   it('can load Hardcover list picker results from a per-list override token', async () => {

--- a/web/src/pages/settings/ImportTab.tsx
+++ b/web/src/pages/settings/ImportTab.tsx
@@ -476,6 +476,7 @@ function HardcoverListsSection({ onNavigate }: { onNavigate?: (tab: string) => v
   const { t } = useTranslation()
   const [lists, setLists] = useState<ImportList[]>([])
   const [hcLists, setHcLists] = useState<HardcoverList[]>([])
+  const [hcAccount, setHcAccount] = useState('')
   const [loadingLists, setLoadingLists] = useState(true)
   const [pickerToken, setPickerToken] = useState('')
   const [activePickerToken, setActivePickerToken] = useState('')
@@ -495,9 +496,12 @@ function HardcoverListsSection({ onNavigate }: { onNavigate?: (tab: string) => v
       setError(err instanceof Error ? err.message : 'Failed to load saved Hardcover lists')
     }
     try {
-      setHcLists(await api.hardcoverLists(token || undefined))
+      const { account, lists: remote } = await api.hardcoverLists(token || undefined)
+      setHcLists(remote)
+      setHcAccount(account)
     } catch (err) {
       setHcLists([])
+      setHcAccount('')
       setError(err instanceof Error ? err.message : 'Failed to load Hardcover lists')
     } finally {
       setLoadingLists(false)
@@ -548,6 +552,7 @@ function HardcoverListsSection({ onNavigate }: { onNavigate?: (tab: string) => v
         type: 'hardcover',
         url: list.slug,
         apiKey: tokenOverride,
+        account: hcAccount,
         enabled: Boolean(tokenOverride),
         monitorNew: true,
         autoAdd: true,
@@ -616,16 +621,25 @@ function HardcoverListsSection({ onNavigate }: { onNavigate?: (tab: string) => v
     }
   }
 
-  const localsBySlug = new Map<string, ImportList[]>()
-  for (const il of lists) {
-    localsBySlug.set(il.url, [...(localsBySlug.get(il.url) ?? []), il])
+  // List identity is (slug, account) — two Hardcover accounts share built-in
+  // shelf slugs, so slug-only matching folded a second account's Want to Read
+  // into the first one's row (#1489). Legacy rows (empty account) match only
+  // in the saved-token view, where they were originally created.
+  const viewingSavedToken = activePickerToken.trim() === ''
+  const matchedLocalIds = new Set<number>()
+  const accountOf = (il: ImportList) => il.account ?? ''
+  const localsFor = (slug: string): ImportList[] => {
+    const exact = lists.filter(il => il.url === slug && accountOf(il) === hcAccount)
+    if (exact.length > 0) return exact
+    if (viewingSavedToken) return lists.filter(il => il.url === slug && accountOf(il) === '')
+    return []
   }
-  const remoteSlugs = new Set(hcLists.map(l => l.slug))
   const rows: HardcoverImportListRow[] = []
   for (const list of hcLists) {
-    const locals = localsBySlug.get(list.slug)
-    if (locals?.length) {
+    const locals = localsFor(list.slug)
+    if (locals.length) {
       for (const il of locals) {
+        matchedLocalIds.add(il.id)
         rows.push({ slug: il.url, name: il.name, booksCount: list.booksCount, remote: list, local: il, stale: false })
       }
       continue
@@ -633,8 +647,12 @@ function HardcoverListsSection({ onNavigate }: { onNavigate?: (tab: string) => v
     rows.push({ slug: list.slug, name: list.name, booksCount: list.booksCount, remote: list, stale: false })
   }
   for (const il of lists) {
-    if (!remoteSlugs.has(il.url)) {
-      rows.push({ slug: il.url, name: il.name, booksCount: 0, local: il, stale: true })
+    if (!matchedLocalIds.has(il.id)) {
+      // Stale = this row belongs to the CURRENT view's account context but its
+      // slug no longer exists remotely. Rows saved from a different account
+      // are healthy — they just aren't part of the lists being browsed.
+      const inCurrentView = accountOf(il) === hcAccount || (viewingSavedToken && accountOf(il) === '')
+      rows.push({ slug: il.url, name: il.name, booksCount: 0, local: il, stale: inCurrentView })
     }
   }
 
@@ -702,6 +720,7 @@ function HardcoverListsSection({ onNavigate }: { onNavigate?: (tab: string) => v
                     <span className="flex flex-wrap items-center gap-2">
                       <span className="text-sm font-medium">{row.name}</span>
                       <span className="text-[10px] px-1.5 py-0.5 bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400 rounded">{row.slug}</span>
+                      {(row.local?.account || (!row.local && hcAccount)) && <span className="text-[10px] px-1.5 py-0.5 bg-sky-100 dark:bg-sky-950 text-sky-700 dark:text-sky-400 rounded">@{row.local?.account || hcAccount}</span>}
                       {row.stale && <span className="text-[10px] px-1.5 py-0.5 bg-amber-100 dark:bg-amber-950 text-amber-700 dark:text-amber-400 rounded">{t('settings.import.hardcoverSavedOnly', 'Saved only')}</span>}
                       {il && <span className="text-[10px] px-1.5 py-0.5 bg-slate-200 dark:bg-zinc-800 text-slate-600 dark:text-zinc-400 rounded">{il.apiKeyConfigured ? t('settings.import.hardcoverOverrideConfigured', 'Override token') : t('settings.import.hardcoverGlobalToken', 'Global token')}</span>}
                     </span>


### PR DESCRIPTION
## Summary

Closes #1489 (ColinAgnew). Two people's Hardcover accounts can now each sync their own "Want to Read" into Bindery.

Root cause: built-in shelves share a fixed slug per account (`want-to-read`, …) and the picker matched saved rows by slug alone, so loading a second account's lists showed its shelf as the already-added first one — toggling the wrong row instead of creating a separate list.

- Migration 063: `import_lists.account` (Hardcover username; empty for legacy rows / other list types).
- New `hardcover.Client.GetUsername` (`me { username }`); `GET /importlist/hardcover/lists` now returns `{account, lists}` (breaking only for this internal endpoint; frontend updated in the same PR).
- Picker matches local rows by (slug, account); legacy empty-account rows only match in the saved-token view where they were created. Rows show an `@username` chip; another account's rows are no longer mislabeled "Saved only".
- Sync side needed no change — per-list token override (`tokenForList`) already fetches with the right account.

## Test plan

- [x] New vitest: two accounts' identically-slugged shelves stay separate — browsing bob's lists with alice's row saved creates a NEW list carrying `account: bob`, never toggles alice's (52/52 SettingsPage tests pass)
- [x] `go test ./internal/api -run 'Hardcover|ImportList'`, `./internal/db`, `./internal/hardcoverlistsyncer` — pass
- [x] `go vet`, `npm run typecheck`, `npm run lint` — clean; `go test ./cmd/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)