### PR TITLE
fix(security): stamp owner_user_id on create paths and scope series views

### DIFF
--- a/changelog.d/1457-tenancy-stamping.md
+++ b/changelog.d/1457-tenancy-stamping.md
@@ -1,0 +1,12 @@
+### Security
+- **Multi-user tenancy: owners are now stamped and series views scoped**
+  (#1457, #1416) — new books inherit their author's owner on every create
+  path (add-book, author sync, series fill, ABS/Calibre imports), and new
+  downloads carry the grabbing user (background grabs inherit the book's
+  owner), so per-user scoping finally has data to scope on: a non-admin's
+  queue is no longer empty under tenancy, and the series list/detail no
+  longer let one user enumerate another user's titles, covers, and statuses.
+  The author page's embedded book list now applies the same owner predicate
+  as the book list, so the two views agree on co-authored books. Existing
+  unowned rows keep their legacy world-visible behaviour; only affects
+  deployments with `BINDERY_ENFORCE_TENANCY` enabled.

--- a/internal/abs/import_upserts.go
+++ b/internal/abs/import_upserts.go
@@ -698,8 +698,10 @@ func (i *Importer) upsertBook(ctx context.Context, cfg ImportConfig, runID int64
 	}
 
 	book := &models.Book{
-		ForeignID:        fid,
-		AuthorID:         author.ID,
+		ForeignID:   fid,
+		AuthorID:    author.ID,
+		OwnerUserID: author.OwnerUserID, // tenancy (#1457): inherit author's owner
+
 		Title:            title,
 		SortTitle:        title,
 		Description:      textutil.CleanDescription(item.Description),
@@ -755,6 +757,7 @@ func (i *Importer) upsertManualBook(ctx context.Context, cfg ImportConfig, runID
 	book := &models.Book{
 		ForeignID:        foreignID,
 		AuthorID:         author.ID,
+		OwnerUserID:      author.OwnerUserID, // tenancy (#1457): inherit author's owner
 		Title:            title,
 		SortTitle:        title,
 		Description:      textutil.CleanDescription(item.Description),
@@ -775,6 +778,7 @@ func (i *Importer) upsertManualBook(ctx context.Context, cfg ImportConfig, runID
 			book = full
 			book.ForeignID = foreignID
 			book.AuthorID = author.ID
+			book.OwnerUserID = author.OwnerUserID // tenancy (#1457)
 			if book.Title == "" {
 				book.Title = title
 			}

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -249,8 +249,10 @@ func (h *AuthorHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Attach books
-	books, err := h.books.ListByAuthor(r.Context(), id)
+	// Attach books, owner-scoped (#1416): the embedded list must apply the
+	// same tenancy predicate as GET /book?authorId=, or a co-author book
+	// owned by another user appears here but not there.
+	books, err := h.books.ListByAuthorAndUser(r.Context(), id, auth.ListScopeUserID(r.Context()))
 	if err == nil {
 		author.Books = books
 	}
@@ -1692,6 +1694,9 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 		}
 		seenTitles[dedupKey] = &b
 
+		// Tenancy (#1457): a new book inherits its author's owner so per-user
+		// scoping sees the sync's output. NULL-owned authors stay NULL-owned.
+		b.OwnerUserID = author.OwnerUserID
 		if err := h.books.Create(ctx, &b); err != nil {
 			// A UNIQUE constraint on foreign_id means the book was already
 			// created by a concurrent or earlier sync — treat as a benign
@@ -2342,6 +2347,9 @@ func (h *AuthorHandler) AddBook(w http.ResponseWriter, r *http.Request) {
 					"foreignBookId", req.ForeignBookID, "error", err)
 			} else if primary != nil {
 				primary.AuthorID = author.ID
+				// Tenancy (#1457): inherit the author's owner (stamped from the
+				// requesting user when this request created the author).
+				primary.OwnerUserID = author.OwnerUserID
 				primary.Monitored = author.Monitored
 				if primary.Status == "" {
 					primary.Status = models.BookStatusWanted

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/importer"
 	"github.com/vavallee/bindery/internal/models"
@@ -130,6 +131,11 @@ func (h *ManualImportHandler) prepareImport(ctx context.Context, rawPath string,
 		BookID: &bookID,
 		Title:  book.Title,
 		Status: models.StateCompleted,
+		// Tenancy (#1457): downloads use the strict owner scope, so an
+		// unstamped row is invisible to its own non-admin creator. Stamp
+		// from the request identity, falling back to the book's owner for
+		// API-key callers (uid 0).
+		OwnerUserID: downloadOwnerForRequest(ctx, book.OwnerUserID),
 	}
 	dl.CompletedAt = &now
 	if err := h.downloads.Create(ctx, dl); err != nil {
@@ -549,4 +555,15 @@ func (h *ManualImportHandler) ImportBatch(w http.ResponseWriter, r *http.Request
 	}
 
 	writeJSON(w, http.StatusAccepted, resp)
+}
+
+// downloadOwnerForRequest resolves the owner to stamp on a download created
+// by an HTTP request (#1457): the authenticated user when there is one,
+// otherwise (API-key / disabled-auth callers, uid 0) the owner of the book
+// the download belongs to, so the row stays visible to that library's user.
+func downloadOwnerForRequest(ctx context.Context, bookOwner int64) int64 {
+	if uid := auth.UserIDFromContext(ctx); uid != 0 {
+		return uid
+	}
+	return bookOwner
 }

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -780,12 +780,21 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 		editionID = existing.EditionID
 		indexerFlags = existing.IndexerFlags
 	}
+	// Tenancy (#1457): stamp from the request identity; API-key callers
+	// (uid 0) inherit the target book's owner when one is known.
+	grabOwner := auth.UserIDFromContext(ctx)
+	if grabOwner == 0 && bookID != nil {
+		if b, err := h.books.GetByID(ctx, *bookID); err == nil && b != nil {
+			grabOwner = b.OwnerUserID
+		}
+	}
 	dl := &models.Download{
 		GUID:             req.GUID,
 		BookID:           bookID,
 		EditionID:        editionID,
 		IndexerID:        indexerID,
 		DownloadClientID: &client.ID,
+		OwnerUserID:      grabOwner,
 		Title:            req.Title,
 		NZBURL:           req.NZBURL,
 		Size:             req.Size,

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -159,7 +159,9 @@ func validateSeriesTitle(title string) (string, string) {
 }
 
 func (h *SeriesHandler) List(w http.ResponseWriter, r *http.Request) {
-	series, err := h.series.ListWithBooks(r.Context())
+	// Owner-scoped books (#1457): a non-admin must not enumerate other
+	// users' titles through the series view. Series rows stay global.
+	series, err := h.series.ListWithBooksForUser(r.Context(), auth.ListScopeUserID(r.Context()))
 	if err != nil {
 		writeServerError(w, r, err)
 		return
@@ -177,7 +179,7 @@ func (h *SeriesHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s, err := h.series.GetByID(r.Context(), id)
+	s, err := h.series.GetByIDForUser(r.Context(), id, auth.ListScopeUserID(r.Context()))
 	if err != nil {
 		writeServerError(w, r, err)
 		return
@@ -1380,6 +1382,8 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *
 	}
 
 	book.AuthorID = storedAuthor.ID
+	// Tenancy (#1457): inherit the author's owner.
+	book.OwnerUserID = storedAuthor.OwnerUserID
 	book.Author = nil
 	book.Title = firstNonEmpty(book.Title, catalogBook.Title)
 	book.SortTitle = firstNonEmpty(book.SortTitle, book.Title)

--- a/internal/api/tenancy_stamping_test.go
+++ b/internal/api/tenancy_stamping_test.go
@@ -1,0 +1,304 @@
+package api
+
+// Cross-user regression tests for #1457 (owner stamping on create paths) and
+// #1416 (author-detail vs book-list scope divergence), following the v1.1.1
+// audit convention: two users, assert isolation.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/auth"
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/metadata"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestAddBook_StampsOwnerOnDirectInsert pins the #1457 fix on the AddBook
+// direct-insert path: the created book inherits the author's owner, so a
+// per-user library sees its own adds.
+func TestAddBook_StampsOwnerOnDirectInsert(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	ctx := context.Background()
+	users := db.NewUserRepo(database)
+	alice, err := users.Create(ctx, "alice", "h1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OL-ALICE", Name: "Alice Author", SortName: "Author, Alice",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.CreateForUser(ctx, author, alice.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := authorRepo.UpsertAuthorIdentifier(ctx, author.ID, "hc:alice-author"); err != nil {
+		t.Fatal(err)
+	}
+	primary := &models.Book{
+		ForeignID: "hc:book-one", Title: "Book One", SortTitle: "Book One",
+		Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "hardcover",
+	}
+	provider := &stubMetaProvider{
+		name:        "hardcover",
+		getBookByID: map[string]*models.Book{"hc:book-one": primary},
+	}
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(provider), nil, profileRepo, nil)
+
+	body, _ := json.Marshal(map[string]any{
+		"foreignBookId":   "hc:book-one",
+		"foreignAuthorId": "hc:alice-author",
+		"authorName":      "Alice Author",
+	})
+	parent, cancel := context.WithTimeout(auth.WithUserID(context.Background(), alice.ID), 200*time.Millisecond)
+	defer cancel()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/author/book", bytes.NewReader(body)).WithContext(parent)
+	rec := httptest.NewRecorder()
+
+	h.AddBook(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	got, err := bookRepo.GetByForeignID(ctx, "hc:book-one")
+	if err != nil || got == nil {
+		t.Fatalf("book after AddBook = %+v err=%v", got, err)
+	}
+	if got.OwnerUserID != alice.ID {
+		t.Fatalf("book owner = %d, want alice (%d)", got.OwnerUserID, alice.ID)
+	}
+}
+
+// TestSeriesList_ScopesBooksByOwner pins #1457's series fix: a non-admin
+// browsing the series view must not see another user's books, while legacy
+// NULL-owned books stay visible to everyone.
+func TestSeriesList_ScopesBooksByOwner(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	users := db.NewUserRepo(database)
+	alice, _ := users.Create(ctx, "alice", "h1")
+	bob, _ := users.Create(ctx, "bob", "h2")
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	seriesRepo := db.NewSeriesRepo(database)
+
+	author := &models.Author{ForeignID: "OL1A", Name: "A", SortName: "A", MetadataProvider: "openlibrary"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	mk := func(fid, title string, owner int64) *models.Book {
+		b := &models.Book{
+			ForeignID: fid, AuthorID: author.ID, Title: title, SortTitle: title,
+			Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary",
+			OwnerUserID: owner,
+		}
+		if err := bookRepo.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+		return b
+	}
+	aliceBook := mk("S-A", "Alice Secret Book", alice.ID)
+	legacyBook := mk("S-L", "Legacy Shared Book", 0)
+
+	series, err := seriesRepo.CreateManual(ctx, "Shared Series")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = seriesRepo.LinkBook(ctx, series.ID, aliceBook.ID, "1", true)
+	_ = seriesRepo.LinkBook(ctx, series.ID, legacyBook.ID, "2", false)
+
+	h := NewSeriesHandler(seriesRepo, bookRepo, authorRepo, nil, nil)
+
+	// Bob (role user) lists series: alice's book must be absent, the legacy
+	// NULL-owned book present.
+	bobCtx := auth.WithUserRole(auth.WithUserID(context.Background(), bob.ID), "user")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/series", nil).WithContext(bobCtx)
+	rec := httptest.NewRecorder()
+	h.List(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var listed []models.Series
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("series count = %d, want 1", len(listed))
+	}
+	titles := map[string]bool{}
+	for _, sb := range listed[0].Books {
+		if sb.Book != nil {
+			titles[sb.Book.Title] = true
+		}
+	}
+	if titles["Alice Secret Book"] {
+		t.Fatalf("bob can see alice's book through the series list: %v", titles)
+	}
+	if !titles["Legacy Shared Book"] {
+		t.Fatalf("legacy NULL-owned book missing from bob's series view: %v", titles)
+	}
+
+	// Single-series GET applies the same scope.
+	req = withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/series/"+strconv.FormatInt(series.ID, 10), nil).WithContext(bobCtx), "id", strconv.FormatInt(series.ID, 10))
+	rec = httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("series get: expected 200, got %d", rec.Code)
+	}
+	var one models.Series
+	_ = json.Unmarshal(rec.Body.Bytes(), &one)
+	for _, sb := range one.Books {
+		if sb.Book != nil && sb.Book.Title == "Alice Secret Book" {
+			t.Fatalf("bob can see alice's book through series get")
+		}
+	}
+
+	// Admin still sees everything.
+	adminCtx := auth.WithUserRole(auth.WithUserID(context.Background(), alice.ID), "admin")
+	rec = httptest.NewRecorder()
+	h.List(rec, httptest.NewRequest(http.MethodGet, "/api/v1/series", nil).WithContext(adminCtx))
+	var adminListed []models.Series
+	_ = json.Unmarshal(rec.Body.Bytes(), &adminListed)
+	if len(adminListed) != 1 || len(adminListed[0].Books) != 2 {
+		t.Fatalf("admin view lost books: %+v", adminListed)
+	}
+}
+
+// TestAuthorGet_ScopesEmbeddedBooks pins the #1416 divergence fix: the
+// author-detail payload's embedded books apply the same owner scope as the
+// book list, so the two views agree.
+func TestAuthorGet_ScopesEmbeddedBooks(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	users := db.NewUserRepo(database)
+	alice, _ := users.Create(ctx, "alice", "h1")
+	bob, _ := users.Create(ctx, "bob", "h2")
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	// Shared (NULL-owned) author with one book per user.
+	author := &models.Author{ForeignID: "OL1A", Name: "Shared Author", SortName: "Author, Shared", MetadataProvider: "openlibrary"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		fid, title string
+		owner      int64
+	}{
+		{"B-A", "Alice Book", alice.ID},
+		{"B-B", "Bob Book", bob.ID},
+	} {
+		b := &models.Book{
+			ForeignID: tc.fid, AuthorID: author.ID, Title: tc.title, SortTitle: tc.title,
+			Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary",
+			OwnerUserID: tc.owner,
+		}
+		if err := bookRepo.Create(ctx, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, nil, nil, profileRepo, nil)
+	bobCtx := auth.WithUserRole(auth.WithUserID(context.Background(), bob.ID), "user")
+	id := strconv.FormatInt(author.ID, 10)
+	req := withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/author/"+id, nil).WithContext(bobCtx), "id", id)
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got models.Author
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range got.Books {
+		if b.Title == "Alice Book" {
+			t.Fatalf("bob's author-detail payload leaks alice's book")
+		}
+	}
+	found := false
+	for _, b := range got.Books {
+		if b.Title == "Bob Book" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("bob's own book missing from author detail: %+v", got.Books)
+	}
+}
+
+// TestDownloadCreate_PersistsOwner pins the repo-level stamping (#1457):
+// downloads use the strict owner scope, so the row must round-trip its owner.
+func TestDownloadCreate_PersistsOwner(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	users := db.NewUserRepo(database)
+	alice, _ := users.Create(ctx, "alice", "h1")
+	dlRepo := db.NewDownloadRepo(database)
+
+	dl := &models.Download{GUID: "g-1", Title: "T", Status: models.StateGrabbed, Protocol: "usenet", OwnerUserID: alice.ID}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	mine, err := dlRepo.ListByUser(ctx, alice.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mine) != 1 || mine[0].OwnerUserID != alice.ID {
+		t.Fatalf("alice's downloads = %+v, want her stamped row", mine)
+	}
+
+	// Unowned rows keep NULL (legacy semantics): invisible under the strict
+	// user scope, visible unscoped.
+	unowned := &models.Download{GUID: "g-2", Title: "T2", Status: models.StateGrabbed, Protocol: "usenet"}
+	if err := dlRepo.Create(ctx, unowned); err != nil {
+		t.Fatal(err)
+	}
+	mine, _ = dlRepo.ListByUser(ctx, alice.ID)
+	if len(mine) != 1 {
+		t.Fatalf("strict scope must hide NULL-owned rows, got %d", len(mine))
+	}
+	all, _ := dlRepo.ListByUser(ctx, 0)
+	if len(all) != 2 {
+		t.Fatalf("unscoped list = %d rows, want 2", len(all))
+	}
+}

--- a/internal/calibre/importer.go
+++ b/internal/calibre/importer.go
@@ -678,6 +678,7 @@ func (i *Importer) upsertBook(ctx context.Context, runID int64, author *models.A
 	book := &models.Book{
 		ForeignID:        "calibre:book:" + strconv.FormatInt(cb.CalibreID, 10),
 		AuthorID:         author.ID,
+		OwnerUserID:      author.OwnerUserID, // tenancy (#1457): inherit author's owner
 		Title:            cb.Title,
 		SortTitle:        firstNonEmpty(cb.SortTitle, cb.Title),
 		ReleaseDate:      cb.PublishDate,

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -454,18 +454,27 @@ func (r *BookRepo) Create(ctx context.Context, b *models.Book) error {
 		return fmt.Errorf("marshal book locked_fields: %w", err)
 	}
 
+	// owner_user_id: NULL when unowned (#1457), matching CreateForUser's
+	// ownerArg idiom in authors.go. Callers stamp b.OwnerUserID before Create
+	// (HTTP paths from the request identity, background paths by inheriting
+	// the author row's owner).
+	var ownerArg any
+	if b.OwnerUserID != 0 {
+		ownerArg = b.OwnerUserID
+	}
+
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO books (foreign_id, author_id, title, sort_title, original_title, description,
 		                   image_url, release_date, genres, average_rating, ratings_count,
 		                   monitored, status, any_edition_ok, selected_edition_id,
 		                   language, media_type, narrator, duration_seconds, asin,
-		                   metadata_provider, dedup_key, locked_fields, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		                   metadata_provider, dedup_key, locked_fields, owner_user_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		b.ForeignID, b.AuthorID, b.Title, b.SortTitle, b.OriginalTitle, b.Description,
 		b.ImageURL, timeArg(b.ReleaseDate), string(genresJSON), b.AverageRating, b.RatingsCount,
 		b.Monitored, b.Status, b.AnyEditionOK, b.SelectedEditionID,
 		b.Language, mediaType, b.Narrator, b.DurationSeconds, b.ASIN,
-		b.MetadataProvider, b.DedupKey, string(lockedJSON), timeValueArg(now), timeValueArg(now))
+		b.MetadataProvider, b.DedupKey, string(lockedJSON), ownerArg, timeValueArg(now), timeValueArg(now))
 	if err != nil {
 		return fmt.Errorf("create book: %w", err)
 	}

--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -19,7 +19,7 @@ const downloadSelectColumns = `
 	id, guid, book_id, edition_id, indexer_id, download_client_id,
 	title, nzb_url, size, sabnzbd_nzo_id, torrent_id, status, protocol,
 	quality, indexer_flags, error_message, added_at, grabbed_at, completed_at, imported_at,
-	import_retry_count`
+	import_retry_count, COALESCE(owner_user_id, 0)`
 
 func NewDownloadRepo(db *sql.DB) *DownloadRepo {
 	return &DownloadRepo{db: db}
@@ -69,16 +69,25 @@ func (r *DownloadRepo) GetByTorrentID(ctx context.Context, torrentID string) (*m
 	return &dl[0], nil
 }
 
+// downloadOwnerArg maps 0 to NULL so unowned downloads keep the legacy
+// NULL-owner representation (matching CreateForUser's ownerArg idiom).
+func downloadOwnerArg(ownerUserID int64) any {
+	if ownerUserID == 0 {
+		return nil
+	}
+	return ownerUserID
+}
+
 func (r *DownloadRepo) Create(ctx context.Context, d *models.Download) error {
 	now := time.Now().UTC()
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO downloads (guid, book_id, edition_id, indexer_id, download_client_id,
 		                       title, nzb_url, size, sabnzbd_nzo_id, torrent_id, status, protocol,
-		                       quality, indexer_flags, error_message, added_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		                       quality, indexer_flags, error_message, owner_user_id, added_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		d.GUID, d.BookID, d.EditionID, d.IndexerID, d.DownloadClientID,
 		d.Title, d.NZBURL, d.Size, d.SABnzbdNzoID, d.TorrentID, d.Status, d.Protocol,
-		d.Quality, d.IndexerFlags, d.ErrorMessage, now)
+		d.Quality, d.IndexerFlags, d.ErrorMessage, downloadOwnerArg(d.OwnerUserID), now)
 	if err != nil {
 		return fmt.Errorf("create download: %w", err)
 	}
@@ -567,7 +576,7 @@ func (r *DownloadRepo) query(ctx context.Context, q string, args ...interface{})
 			&d.Title, &d.NZBURL, &d.Size, &d.SABnzbdNzoID, &d.TorrentID, &d.Status, &d.Protocol,
 			&d.Quality, &d.IndexerFlags, &d.ErrorMessage,
 			&d.AddedAt, &d.GrabbedAt, &d.CompletedAt, &d.ImportedAt,
-			&d.ImportRetryCount,
+			&d.ImportRetryCount, &d.OwnerUserID,
 		); err != nil {
 			return nil, fmt.Errorf("scan download: %w", err)
 		}

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -273,14 +273,16 @@ func (r *SeriesRepo) GetByIDForUser(ctx context.Context, id, userID int64) (*mod
 	// Fetch series books with minimal book data, scoped to the caller's
 	// visible books when userID != 0.
 	scope, args := QueryScopeForIncludingNull("b.owner_user_id", "WHERE sb.series_id = ?", userID, id)
-	bookRows, err := r.db.QueryContext(ctx, `
+	//nolint:gosec // scope is a fixed predicate from QueryScopeForIncludingNull; userID and id are bound via args, never concatenated into the SQL
+	q := `
 		SELECT sb.series_id, sb.book_id, sb.position_in_series, sb.primary_series,
 		       b.id, b.foreign_id, b.author_id, b.title, b.sort_title, b.status,
 		       b.monitored, b.image_url, b.created_at, b.updated_at
 		FROM series_books sb
 		JOIN books b ON b.id = sb.book_id
-		`+scope+`
-		ORDER BY sb.position_in_series`, args...)
+		` + scope + `
+		ORDER BY sb.position_in_series`
+	bookRows, err := r.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return &s, nil
 	}

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -48,6 +48,23 @@ func (r *SeriesRepo) List(ctx context.Context) ([]models.Series, error) {
 
 // ListWithBooks returns all series rows with their linked books populated.
 func (r *SeriesRepo) ListWithBooks(ctx context.Context) ([]models.Series, error) {
+	return r.ListWithBooksForUser(ctx, 0)
+}
+
+// ListWithBooksForUser is ListWithBooks with per-user book scoping (#1457):
+// books owned by another user scan as NULL (dropped like an unlinked join
+// row), so a non-admin can no longer enumerate other users' titles through
+// the series view. userID 0 = unscoped (admin / tenancy off). Legacy
+// NULL-owned books stay visible to everyone, matching the include-NULL tier
+// used by the book and history lists. Series rows themselves are global —
+// one series can span books owned by different users.
+func (r *SeriesRepo) ListWithBooksForUser(ctx context.Context, userID int64) ([]models.Series, error) {
+	bookJoin := "LEFT JOIN books b ON b.id = sb.book_id"
+	args := []any{}
+	if userID != 0 {
+		bookJoin += " AND (b.owner_user_id = ? OR b.owner_user_id IS NULL)"
+		args = append(args, userID)
+	}
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT s.id, s.foreign_id, s.title, s.description, s.monitored, s.created_at,
 		       sb.series_id, sb.book_id, sb.position_in_series, sb.primary_series,
@@ -55,8 +72,8 @@ func (r *SeriesRepo) ListWithBooks(ctx context.Context) ([]models.Series, error)
 		       b.monitored, b.image_url, b.release_date, b.created_at, b.updated_at
 		FROM series s
 		LEFT JOIN series_books sb ON sb.series_id = s.id
-		LEFT JOIN books b ON b.id = sb.book_id
-		ORDER BY s.title, CAST(NULLIF(sb.position_in_series, '') AS REAL), sb.position_in_series, b.sort_title`)
+		`+bookJoin+`
+		ORDER BY s.title, CAST(NULLIF(sb.position_in_series, '') AS REAL), sb.position_in_series, b.sort_title`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list series with books: %w", err)
 	}
@@ -233,6 +250,12 @@ func (r *SeriesRepo) ListBooksInSeries(ctx context.Context, seriesID int64) ([]m
 }
 
 func (r *SeriesRepo) GetByID(ctx context.Context, id int64) (*models.Series, error) {
+	return r.GetByIDForUser(ctx, id, 0)
+}
+
+// GetByIDForUser is GetByID with per-user book scoping (#1457) — see
+// ListWithBooksForUser for the semantics.
+func (r *SeriesRepo) GetByIDForUser(ctx context.Context, id, userID int64) (*models.Series, error) {
 	row := r.db.QueryRowContext(ctx,
 		"SELECT id, foreign_id, title, description, monitored, created_at FROM series WHERE id=?", id)
 
@@ -247,15 +270,17 @@ func (r *SeriesRepo) GetByID(ctx context.Context, id int64) (*models.Series, err
 		return nil, fmt.Errorf("get series %d: %w", id, err)
 	}
 
-	// Fetch series books with minimal book data
+	// Fetch series books with minimal book data, scoped to the caller's
+	// visible books when userID != 0.
+	scope, args := QueryScopeForIncludingNull("b.owner_user_id", "WHERE sb.series_id = ?", userID, id)
 	bookRows, err := r.db.QueryContext(ctx, `
 		SELECT sb.series_id, sb.book_id, sb.position_in_series, sb.primary_series,
 		       b.id, b.foreign_id, b.author_id, b.title, b.sort_title, b.status,
 		       b.monitored, b.image_url, b.created_at, b.updated_at
 		FROM series_books sb
 		JOIN books b ON b.id = sb.book_id
-		WHERE sb.series_id = ?
-		ORDER BY sb.position_in_series`, id)
+		`+scope+`
+		ORDER BY sb.position_in_series`, args...)
 	if err != nil {
 		return &s, nil
 	}

--- a/internal/models/download.go
+++ b/internal/models/download.go
@@ -37,8 +37,13 @@ type DownloadClientHealth struct {
 }
 
 type Download struct {
-	ID               int64         `json:"id"`
-	GUID             string        `json:"guid"`
+	ID   int64  `json:"id"`
+	GUID string `json:"guid"`
+	// OwnerUserID scopes the download to the user whose grab created it
+	// (#1457). 0 = unowned (persisted as NULL); the downloads list uses the
+	// STRICT owner scope, so stamping is what makes a non-admin's queue
+	// non-empty under tenancy. Background grabs inherit the book's owner.
+	OwnerUserID      int64         `json:"-"`
 	BookID           *int64        `json:"bookId"`
 	EditionID        *int64        `json:"editionId"`
 	IndexerID        *int64        `json:"indexerId"`

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -589,6 +589,7 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 	dl := &models.Download{
 		GUID:             best.GUID,
 		BookID:           &book.ID,
+		OwnerUserID:      book.OwnerUserID, // tenancy (#1457): background grab inherits the book's owner
 		IndexerID:        &best.IndexerID,
 		DownloadClientID: &client.ID,
 		Title:            best.Title,

--- a/web/src/test-localstorage.ts
+++ b/web/src/test-localstorage.ts
@@ -1,0 +1,28 @@
+// Deterministic in-memory localStorage, installed before any other setup file
+// (and before msw is imported). Node's experimental WebStorage — enabled on
+// some CI runners — exposes a native `globalThis.localStorage` getter that
+// returns undefined (or throws) unless --localstorage-file is passed, shadowing
+// jsdom's implementation. That made tests touching `localStorage` pass locally
+// but fail in CI. Installing our own polyfill first removes the dependency on
+// whichever storage backend the runtime happens to expose.
+const store = new Map<string, string>()
+
+const storage: Storage = {
+  get length() {
+    return store.size
+  },
+  clear: () => store.clear(),
+  getItem: key => (store.has(key) ? store.get(key)! : null),
+  key: index => Array.from(store.keys())[index] ?? null,
+  removeItem: key => {
+    store.delete(key)
+  },
+  setItem: (key, value) => {
+    store.set(String(key), String(value))
+  },
+}
+
+Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true })
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'localStorage', { value: storage, configurable: true })
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -26,6 +26,6 @@ export default defineConfig({
       },
     },
     globals: true,
-    setupFiles: './src/test-setup.ts',
+    setupFiles: ['./src/test-localstorage.ts', './src/test-setup.ts'],
   },
 })


### PR DESCRIPTION
## Summary

The #1457 tenancy implementation (closes #1457, closes #1416). Built from a full gap map of every unstamped create path and unscoped endpoint.

**Owner stamping (the root cause):** `BookRepo.Create` previously dropped `OwnerUserID` entirely — every book row was NULL-owned no matter what callers set. It now persists the owner (NULL when 0, same idiom as `AuthorRepo.CreateForUser`), and books inherit their **author's owner** at every create site: AddBook direct insert, the author-works sync, series fill, both ABS upsert paths, and the Calibre importer. Background jobs therefore stamp correctly without any HTTP identity.

**Downloads:** `models.Download` gains `OwnerUserID` (strict scope — an unstamped row is invisible to its own non-admin creator, which is why a non-admin's queue was always empty under tenancy). Manual import and queue grabs stamp the requesting user, API-key callers fall back to the book's owner, scheduler grabs inherit the book's owner.

**Series scoping:** `ListWithBooksForUser` / `GetByIDForUser` scope the books join include-NULL, wired via `auth.ListScopeUserID` — a non-admin can no longer enumerate other users' titles/covers/statuses through the series view. Series rows themselves stay global (one series legitimately spans owners).

**#1416:** the author-detail embedded book list now uses `ListByAuthorAndUser` with the same scope as `GET /book?authorId=`, so the two views agree.

**Deliberate deviations from the original plan, flagged for review:**
- No blanket re-parent-NULL-rows migration: books/authors use the include-NULL visibility tier, so re-parenting legacy rows to the admin would *hide* them from other users who can see them today — a visibility regression for shared-library households. Stamping stops the NULL population growing; a backfill can be a separate opt-in later.
- Hardcover list syncer and Goodreads migration books stay NULL-owned: neither has a user identity to inherit (import lists have no owner), and NULL preserves their current world-visible semantics.

All inert unless `BINDERY_ENFORCE_TENANCY` is on.

## Test plan

- [x] 4 new cross-user tests (v1.1.1 audit convention): AddBook stamps owner; series list+get hide another user's books while keeping legacy NULL rows; author-detail matches book-list scope; download owner round-trips under strict scope
- [x] Full suites: `internal/api` (50s), db, abs, calibre, scheduler, hardcoverlistsyncer, `cmd/...` — all pass
- [x] `make smoke` — pass; `go vet`, `gofmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)