### PR TITLE
docs: README import-mode default + changelog fragment for #1444

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Clean-room Go rewrite, modern React UI, MIT-licensed, actively developed.
 - Quality profiles (EPUB / MOBI / AZW3 / PDF), language filter, regex-based custom formats, delay profiles, blocklist (consulted on every search; one-click add from History), and failure visibility in Queue and History.
 
 **Import & organize**
-- Completed downloads matched by NZO ID and placed in the library with configurable naming. Modes: **Move** (default), **Copy** (keep source for seeding), **Hardlink** (zero extra disk; same filesystem required).
+- Completed downloads matched by NZO ID and placed in the library with configurable naming. Modes: **Auto** (default — hardlink when possible, else copy; seeding-safe), **Move**, **Copy** (keep source for seeding), **Hardlink** (zero extra disk; same filesystem required), **External** (hand off to a sibling tool).
 - Naming tokens — `{Author}`, `{SortAuthor}`, `{Title}`, `{Year}`, `{Series}`, `{SeriesNumber}`, `{Genre}`, `{Lang}`, `{ext}` — collapse cleanly for non-series books, with conditional literals (`{Title}{ - Series}` emits the dash only when a series exists) and zero-pad widths (`{SeriesNumber:2}` → `02`).
 - Cross-filesystem-safe moves: atomic rename when possible, copy + verify + delete for NFS / separate volumes. Full grab / import / failure history per book.
 - Calibre integration in three modes: `calibredb` CLI hook on import, [Bindery Bridge plugin](https://github.com/vavallee/bindery-plugins) (cross-container), or direct read of an existing Calibre library's `metadata.db` as Bindery's catalogue.

--- a/changelog.d/1444-import-mode-auto-default.md
+++ b/changelog.d/1444-import-mode-auto-default.md
@@ -1,0 +1,8 @@
+### Fixed
+- **Import Mode UI no longer claims Move is the default** (#1444) — the
+  selector pre-selected Move while the backend has defaulted to auto
+  (hardlink on the same filesystem, else copy) since the seeding fix. Auto is
+  now a first-class, selectable mode shown as the default, restoring a UI
+  path back to the safe behaviour, and `import.mode` is validated so a typo
+  fails loudly instead of silently behaving as auto. Contributed by
+  @johnistheman.


### PR DESCRIPTION
## Summary

Follow-up to #1445 (promised there): README's feature list was the last place claiming **Move** is the default import mode; it now names **Auto** and the full mode set. Adds the changelog.d fragment for #1444, crediting @johnistheman.

🤖 Generated with [Claude Code](https://claude.com/claude-code)