### PR TITLE
fix(telemetry): true cumulative install count + stop new_installs erosion

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -282,7 +282,7 @@ func (s *server) snapshotDay(ctx context.Context, day time.Time) error {
 		VALUES (?, ?, ?, ?)
 		ON CONFLICT(day) DO UPDATE SET
 			active_day   = excluded.active_day,
-			new_installs = excluded.new_installs,
+			new_installs = MAX(daily_global.new_installs, excluded.new_installs),
 			total        = excluded.total
 	`, dayStr, activeDay, newInstalls, total); err != nil {
 		return fmt.Errorf("snapshot %s: upsert global: %w", dayStr, err)
@@ -356,8 +356,15 @@ func (s *server) snapshotDay(ctx context.Context, day time.Time) error {
 // backfillNewInstalls populates daily_global.new_installs for every day in
 // the installs table's first_seen range. Only this column is historically
 // recoverable; the others depend on last_seen which has rolled forward.
-// Idempotent: existing rows have new_installs replaced; active_day, total
-// are preserved (only set non-zero when we have current data for the day).
+//
+// Idempotent AND monotonic: the conflict clause raises new_installs but never
+// lowers it (MAX). This matters because the source is COUNT(*) over installs,
+// which the 60-day retention sweep erodes for old days — once the churned
+// rows first-seen on day D are GC'd, recomputing D from survivors yields a
+// smaller count. Without the MAX guard, every restart would clobber a
+// correctly-recorded historical value downward. new_installs is genuinely
+// monotonic (a day's true count only ever grew, on the day itself), so MAX is
+// the correct reconciliation: whichever snapshot saw the day freshest wins.
 //
 // Runs once at startup. Cheap: one INSERT ... SELECT against an indexed
 // substring; the installs table holds at most ~5k rows at our scale.
@@ -369,9 +376,67 @@ func (s *server) backfillNewInstalls(ctx context.Context) error {
 		 WHERE first_seen IS NOT NULL
 		 GROUP BY day
 		ON CONFLICT(day) DO UPDATE SET
-			new_installs = excluded.new_installs
+			new_installs = MAX(daily_global.new_installs, excluded.new_installs)
 	`)
 	return err
+}
+
+// dayKeyRE matches a YYYY-MM-DD seed key. Keys that don't match are skipped
+// so a malformed seed file can't inject junk rows into daily_global.
+var dayKeyRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+// reconcileNewInstallsSeed raises daily_global.new_installs for each day in a
+// {day: count} JSON file to at least the seeded value, never lowering it. It
+// restores historical counts that a pre-monotonic backfill eroded once the
+// underlying installs aged past the 60-day retention window (those raw rows
+// are gone, so the only source of the true count is an external snapshot).
+//
+// The seed is aggregate-only (day -> integer count); it carries no install
+// IDs or any per-install data. Idempotent: re-running with the same seed is a
+// no-op. Returns the number of days whose stored value was actually raised.
+func (s *server) reconcileNewInstallsSeed(ctx context.Context, path string) (int, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- path is an operator-supplied env var, not user input
+	if err != nil {
+		return 0, fmt.Errorf("read seed: %w", err)
+	}
+	var seed map[string]int
+	if err := json.Unmarshal(raw, &seed); err != nil {
+		return 0, fmt.Errorf("parse seed: %w", err)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	raised := 0
+	for day, count := range seed {
+		if !dayKeyRE.MatchString(day) {
+			slog.Warn("seed reconcile: skipping malformed day key", "key", day)
+			continue
+		}
+		if count < 0 {
+			continue
+		}
+		res, err := tx.ExecContext(ctx, `
+			INSERT INTO daily_global (day, active_day, new_installs, total)
+			VALUES (?, 0, ?, 0)
+			ON CONFLICT(day) DO UPDATE SET
+				new_installs = excluded.new_installs
+			WHERE excluded.new_installs > daily_global.new_installs
+		`, day, count)
+		if err != nil {
+			return 0, fmt.Errorf("upsert %s: %w", day, err)
+		}
+		if n, _ := res.RowsAffected(); n > 0 {
+			raised++
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
+	}
+	return raised, nil
 }
 
 // runAggregateLoop drives snapshotDay on the same daily cadence as
@@ -442,18 +507,20 @@ type pingResponse struct {
 }
 
 type statsResponse struct {
-	Active30d int            `json:"active_30d"`
-	Total     int            `json:"total"`
-	Versions  map[string]int `json:"versions"`
+	Active30d  int            `json:"active_30d"`
+	Total      int            `json:"total"`
+	Cumulative int            `json:"cumulative"`
+	Versions   map[string]int `json:"versions"`
 }
 
 // statsJSON is the response shape for the public /stats.json endpoint. It
-// surfaces the three numbers the Discord stats bot (and any future scraper)
-// needs without requiring the full /api/stats token-gated payload.
+// surfaces the numbers the Discord stats bot (and any future scraper) needs
+// without requiring the full /api/stats token-gated payload.
 type statsJSON struct {
-	Active int    `json:"active"` // 30-day active install count
-	Total  int    `json:"total"`  // all-time install count
-	Latest string `json:"latest"` // latest released version, e.g. "v1.9.5"
+	Active     int    `json:"active"`     // 30-day active install count
+	Total      int    `json:"total"`      // rolling 60-day distinct count (bounded by retention)
+	Cumulative int    `json:"cumulative"` // all-time installs ever (sum of daily new_installs)
+	Latest     string `json:"latest"`     // latest released version, e.g. "v1.9.5"
 }
 
 func main() {
@@ -582,6 +649,20 @@ func main() {
 	// a failure here does not block startup.
 	if err := s.backfillNewInstalls(context.Background()); err != nil {
 		slog.Warn("aggregate backfill failed", "error", err)
+	}
+
+	// Optional one-time repair: when NEW_INSTALLS_SEED_PATH points at a
+	// {day: count} JSON file, raise each day's new_installs to the seeded
+	// value (never lowers). Used to restore historical new_installs that an
+	// earlier, non-monotonic backfill eroded once installs aged past the
+	// 60-day retention window. Aggregate-only data, idempotent, no-op when
+	// the env var is unset; safe to leave mounted across restarts.
+	if seedPath := env("NEW_INSTALLS_SEED_PATH", ""); seedPath != "" {
+		if n, err := s.reconcileNewInstallsSeed(context.Background(), seedPath); err != nil {
+			slog.Warn("new-installs seed reconcile failed", "path", seedPath, "error", err)
+		} else {
+			slog.Info("new-installs seed reconciled", "path", seedPath, "days_raised", n)
+		}
 	}
 
 	// Daily snapshot job for the aggregate tables. Mirrors the retention
@@ -977,7 +1058,13 @@ type statsData struct {
 	Active7d  int
 	Active30d int
 	Total     int
-	Versions  []statsBucket
+	// Cumulative is the true all-time install count: the sum of new_installs
+	// across every day in daily_global. Unlike Total (a rolling 60-day count
+	// bounded by the retention sweep), this is monotonic — it counts every
+	// distinct install_id ever seen, including those long since evicted from
+	// the installs table. Backed by the perpetual daily_global aggregate.
+	Cumulative int
+	Versions   []statsBucket
 	// VersionsRecent is the same set of buckets restricted to installs that
 	// pinged in the last 7 days. Dashboard renders both alongside each other
 	// so dormant installs (e.g. v1.8.1 pinged once and never again) stop
@@ -1025,6 +1112,14 @@ func (s *server) computeStats(ctx context.Context) (*statsData, error) {
 	if err := s.db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM installs`,
 	).Scan(&d.Total); err != nil {
+		return nil, err
+	}
+	// Cumulative all-time installs from the perpetual daily aggregate. Survives
+	// the 60-day retention sweep on raw rows and, thanks to the MAX-guarded
+	// backfill, only ever grows.
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(new_installs), 0) FROM daily_global`,
+	).Scan(&d.Cumulative); err != nil {
 		return nil, err
 	}
 
@@ -1287,9 +1382,10 @@ func (s *server) handleStats(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(statsResponse{
-		Active30d: d.Active30d,
-		Total:     d.Total,
-		Versions:  versions,
+		Active30d:  d.Active30d,
+		Total:      d.Total,
+		Cumulative: d.Cumulative,
+		Versions:   versions,
 	})
 }
 
@@ -1375,6 +1471,13 @@ func (s *server) handleStatsJSON(w http.ResponseWriter, r *http.Request) {
 		`SELECT COUNT(*) FROM installs`,
 	).Scan(&resp.Total); err != nil {
 		slog.Error("stats.json: total count", "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if err := s.db.QueryRowContext(r.Context(),
+		`SELECT COALESCE(SUM(new_installs), 0) FROM daily_global`,
+	).Scan(&resp.Cumulative); err != nil {
+		slog.Error("stats.json: cumulative count", "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
@@ -1909,13 +2012,13 @@ func (s *server) handleStatsPage(w http.ResponseWriter, r *http.Request) {
   <header>
     <a class="back" href="/">← Bindery</a>
     <h1>Telemetry</h1>
-    <p>Anonymous install counts from instances that opted in to update checks. No identifying information is collected, only an opaque install UUID, the version, the OS/arch reported by Go's runtime, and (on v1.15.3+) per-subsystem adoption counts. "Active 7d" is the count of installs that pinged in the last seven days (the closest proxy we have for "running right now"); "Active 30d" is the wider 30-day window and includes dormant installs that have not pinged in a while. Full schema and opt-out instructions: <a href="/telemetry-fields" style="color:#10b981">/telemetry-fields</a>.</p>
+    <p>Anonymous install counts from instances that opted in to update checks. No identifying information is collected, only an opaque install UUID, the version, the OS/arch reported by Go's runtime, and (on v1.15.3+) per-subsystem adoption counts. "Active 7d" is the count of installs that pinged in the last seven days (the closest proxy we have for "running right now"); "Active 30d" is the wider 30-day window and includes dormant installs that have not pinged in a while. "Cumulative installs" is every distinct install ever seen — it only ever grows and counts each install UUID once, so an install that recreates its database (a fresh volume, a wiped config) is counted again. Full schema and opt-out instructions: <a href="/telemetry-fields" style="color:#10b981">/telemetry-fields</a>.</p>
   </header>
 
   <div class="summary">
     <div class="stat"><div class="num">%d</div><div class="label">Active installs (7d)</div></div>
     <div class="stat"><div class="num">%d</div><div class="label">Active installs (30d)</div></div>
-    <div class="stat"><div class="num">%d</div><div class="label">Total installs (all-time)</div></div>
+    <div class="stat"><div class="num">%d</div><div class="label">Cumulative installs</div></div>
   </div>
 
   <section>
@@ -1974,7 +2077,7 @@ func (s *server) handleStatsPage(w http.ResponseWriter, r *http.Request) {
 </div>
 </body>
 </html>`,
-		d.Active7d, d.Active30d, d.Total,
+		d.Active7d, d.Active30d, d.Cumulative,
 		renderVersionsTable(d.Versions, d.VersionsRecent, 8, normalizeVersion(s.latest())),
 		renderBarChart(d.OS, 0, ""),
 		renderBarChart(d.Arch, 0, ""),

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1002,5 +1004,148 @@ func TestComputeStats_MonthlyReadsFromAggregates(t *testing.T) {
 	}
 	if got != 42 {
 		t.Errorf("Monthly[%s] = %d, want 42 (from daily_global with no raw rows)", monthLabel, got)
+	}
+}
+
+// TestBackfillNewInstalls_Monotonic is the regression test for the erosion
+// bug: once installs first-seen on a day age past the 60-day retention window
+// and are swept, recomputing that day's new_installs from surviving rows
+// yields a smaller count. The MAX-guarded conflict clause must refuse to
+// lower a day's already-recorded value.
+func TestBackfillNewInstalls_Monotonic(t *testing.T) {
+	s := newTestServer(t, "v1.20.0")
+	day := time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+
+	// The true count for 2026-05-05 was 5, recorded back when the day was
+	// fresh. Simulate that historical record.
+	if _, err := s.db.ExecContext(context.Background(),
+		`INSERT INTO daily_global (day, active_day, new_installs, total)
+		 VALUES ('2026-05-05', 0, 5, 0)`); err != nil {
+		t.Fatalf("seed history: %v", err)
+	}
+	// Only one install first-seen that day has survived the retention sweep;
+	// the other four rows are long gone.
+	insertInstall(t, s, uuid('1'), "1.20.0", day, now)
+
+	if err := s.backfillNewInstalls(context.Background()); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	var got int
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT new_installs FROM daily_global WHERE day = '2026-05-05'`,
+	).Scan(&got); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got != 5 {
+		t.Errorf("new_installs eroded to %d; MAX guard must keep the recorded 5", got)
+	}
+}
+
+// TestComputeStats_Cumulative verifies the cumulative headline sums
+// daily_global.new_installs across all days, independent of the raw installs
+// table (which the retention sweep bounds to 60 days).
+func TestComputeStats_Cumulative(t *testing.T) {
+	s := newTestServer(t, "v1.25.0")
+	for _, r := range []struct {
+		day string
+		n   int
+	}{
+		{"2026-05-05", 5},
+		{"2026-05-06", 3},
+		{"2026-06-01", 10},
+		{"2026-07-01", 2},
+	} {
+		if _, err := s.db.ExecContext(context.Background(),
+			`INSERT INTO daily_global (day, active_day, new_installs, total) VALUES (?, 0, ?, 0)`,
+			r.day, r.n); err != nil {
+			t.Fatalf("seed %s: %v", r.day, err)
+		}
+	}
+
+	d, err := s.computeStats(context.Background())
+	if err != nil {
+		t.Fatalf("computeStats: %v", err)
+	}
+	if d.Cumulative != 20 {
+		t.Errorf("Cumulative = %d, want 20 (5+3+10+2)", d.Cumulative)
+	}
+	if d.Total != 0 {
+		t.Errorf("Total = %d, want 0 (no live installs rows); cumulative must not read the installs table", d.Total)
+	}
+}
+
+// TestReconcileNewInstallsSeed verifies the one-time repair hook: it raises
+// eroded/missing days to the seeded value, never lowers a healthy day, skips
+// malformed keys, and is idempotent.
+func TestReconcileNewInstallsSeed(t *testing.T) {
+	s := newTestServer(t, "v1.25.0")
+
+	// Existing state: one eroded day (below seed) and one healthy day (above seed).
+	for _, r := range []struct {
+		day string
+		n   int
+	}{
+		{"2026-05-05", 1},  // eroded — seed says 5, should be raised
+		{"2026-06-01", 20}, // healthy — seed says 10, must NOT be lowered
+	} {
+		if _, err := s.db.ExecContext(context.Background(),
+			`INSERT INTO daily_global (day, active_day, new_installs, total) VALUES (?, 0, ?, 0)`,
+			r.day, r.n); err != nil {
+			t.Fatalf("seed %s: %v", r.day, err)
+		}
+	}
+
+	seed := map[string]int{
+		"2026-05-05": 5,  // raise 1 -> 5
+		"2026-05-20": 7,  // insert brand-new day
+		"2026-06-01": 10, // must not lower 20
+		"garbage":    99, // must be skipped
+	}
+	buf, _ := json.Marshal(seed)
+	path := filepath.Join(t.TempDir(), "seed.json")
+	if err := os.WriteFile(path, buf, 0o600); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	raised, err := s.reconcileNewInstallsSeed(context.Background(), path)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if raised != 2 {
+		t.Errorf("raised = %d, want 2 (2026-05-05 up, 2026-05-20 inserted)", raised)
+	}
+
+	want := map[string]int{"2026-05-05": 5, "2026-05-20": 7, "2026-06-01": 20}
+	for day, exp := range want {
+		var got int
+		if err := s.db.QueryRowContext(context.Background(),
+			`SELECT new_installs FROM daily_global WHERE day = ?`, day,
+		).Scan(&got); err != nil {
+			t.Fatalf("read %s: %v", day, err)
+		}
+		if got != exp {
+			t.Errorf("new_installs[%s] = %d, want %d", day, got, exp)
+		}
+	}
+	// The malformed key must not have created a row.
+	var junk int
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM daily_global WHERE day = 'garbage'`,
+	).Scan(&junk); err != nil {
+		t.Fatalf("count junk: %v", err)
+	}
+	if junk != 0 {
+		t.Errorf("malformed seed key created %d rows, want 0", junk)
+	}
+
+	// Idempotent: re-running raises nothing.
+	raised2, err := s.reconcileNewInstallsSeed(context.Background(), path)
+	if err != nil {
+		t.Fatalf("reconcile twice: %v", err)
+	}
+	if raised2 != 0 {
+		t.Errorf("second reconcile raised = %d, want 0 (idempotent)", raised2)
 	}
 }


### PR DESCRIPTION
## Why

The `/stats` **"Total installs (all-time)"** card and `stats.json`'s `total` were both `SELECT COUNT(*) FROM installs` — but the retention sweep deletes rows dormant >60 days, so that number is a **rolling ~60-day count**, not all-time. It rises and falls as installs churn through the window (which is what surfaced this).

Compounding it: `backfillNewInstalls` ran on every startup with `ON CONFLICT DO UPDATE SET new_installs = excluded.new_installs`, recomputing each day from the *surviving* `installs` rows. For days past the 60-day line the churned rows are already GC'd, so the recompute was smaller and **clobbered the correct historical value downward** — eroding the one perpetual source of an all-time number a little more on each deploy. Telemetry launched 2026-05-05, so erosion began ~2026-07-04; measured impact so far is 31 installs across 2 days (May 6, May 7), recoverable from the daily backups.

Peer note: nobody (Home Assistant, Syncthing, Homebrew, Servarr) publishes "installs ever"; HA's headline is a rolling 60-day count that also drops by design. We keep the honest rolling number *and* add a real monotonic cumulative.

## What

- **Stop the erosion:** `backfillNewInstalls` and `snapshotDay` now `MAX`-guard `new_installs` so a restart can only ever raise a day's count. `new_installs` is genuinely monotonic (a day's true count only grew on the day itself).
- **Real cumulative metric:** `SUM(daily_global.new_installs)` (perpetual aggregate, survives the sweep) on the `/stats` card ("Cumulative installs" + an honest note that it counts each install UUID, so recreating a DB counts again), a new `cumulative` field in `stats.json` (kept `total`, corrected its comment to "rolling 60-day"), and `/api/stats`.
- **Dormant repair hook:** `reconcileNewInstallsSeed` (`NEW_INSTALLS_SEED_PATH`) raises eroded days to values recovered from the off-site backups. Aggregate-only (day→count), idempotent, never lowers a healthy day, no-op when the env var is unset.

## Tests

`TestBackfillNewInstalls_Monotonic` (erosion regression), `TestComputeStats_Cumulative`, `TestReconcileNewInstallsSeed` (raise / insert / skip-malformed / idempotent). Full `./cmd/...` suite + gofmt/vet/golangci-lint green. Verified end-to-end against a seeded DB: `stats.json` returns `cumulative`, and the seed reconcile repairs eroded days without lowering healthy ones.

The one-time production repair (create the seed ConfigMap on the `bindery-ping` cluster, set the env, verify, remove) is an ops step handled out-of-band — this PR is just the code and is inert until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)