### PR TITLE
fix(search): pace bulk indexer searches to stop bursting Prowlarr (#1515)

### DIFF
--- a/changelog.d/1515-search-pacing.md
+++ b/changelog.d/1515-search-pacing.md
@@ -1,0 +1,8 @@
+### Fixed
+- **Bulk searches no longer burst your indexers** (#1515) — "search all wanted"
+  for a prolific author, filling a series, per-author auto-search, and the
+  scheduled wanted loop now pace their indexer searches (a short gap between
+  each) instead of firing as fast as slots free up. A 30-book author could
+  previously flood a rate-limit-free Prowlarr into dropping requests, so
+  nothing got grabbed; the fan-outs still run with the same concurrency caps
+  but no longer sustain a tight query loop.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 	"unicode"
 
@@ -20,6 +19,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/bookhydrate"
+	"github.com/vavallee/bindery/internal/concurrency"
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/metadata"
@@ -1808,32 +1808,16 @@ func handleNewWantedBook(ctx context.Context, books *db.BookRepo, series *db.Ser
 	return false
 }
 
-func runBookSearches(ctx context.Context, searcher BookSearcher, books []models.Book, concurrency int) {
+func runBookSearches(ctx context.Context, searcher BookSearcher, books []models.Book, maxConcurrent int) {
 	if searcher == nil || len(books) == 0 {
 		return
 	}
-	if concurrency <= 0 {
-		concurrency = 1
-	}
-
-	sem := make(chan struct{}, concurrency)
-	var wg sync.WaitGroup
-	for _, book := range books {
-		select {
-		case sem <- struct{}{}:
-		case <-ctx.Done():
-			wg.Wait()
-			return
-		}
-		book := book
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			defer func() { <-sem }()
-			searcher.SearchAndGrabBook(ctx, book)
-		}()
-	}
-	wg.Wait()
+	// Paced so a large author's auto-search doesn't burst every indexer at
+	// once as slots free up (#1515); shares the package pace with the bulk
+	// "search all" and series-fill fan-outs.
+	concurrency.RunBoundedPaced(ctx, books, maxConcurrent, searchPaceInterval, func(ctx context.Context, book models.Book) {
+		searcher.SearchAndGrabBook(ctx, book)
+	})
 }
 
 func shouldMonitorBookForAuthor(author *models.Author, book models.Book, latestKeys map[string]struct{}, today time.Time) bool {

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -481,6 +481,11 @@ func TestFetchAuthorBooks_RefreshesAuthorProfile(t *testing.T) {
 }
 
 func TestFetchAuthorBooks_AutoSearchUsesBoundedConcurrency(t *testing.T) {
+	// This test asserts the concurrency cap; disable search pacing so launches
+	// aren't spaced out (pacing is covered in the concurrency package).
+	searchPaceInterval = 0
+	t.Cleanup(func() { searchPaceInterval = 3 * time.Second })
+
 	database, err := db.OpenMemory()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/api/bulk.go
+++ b/internal/api/bulk.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/concurrency"
@@ -33,6 +34,19 @@ var (
 // uses the same bound. Tune in code if real-world indexer pools change
 // shape — a setting for one number would be more noise than signal.
 const bulkSearchConcurrency = 8
+
+// searchPaceInterval is the minimum gap between successive indexer-search
+// launches in every user- or catalogue-triggered fan-out in this package
+// (bulk "search all", per-author auto-search, series fill). The concurrency
+// caps bound parallelism; this bounds rate, so a large author or series can't
+// burst a rate-limit-free Prowlarr into dropping requests (#1515). Fixed in
+// code, like the concurrency caps — one tunable number is more noise than
+// signal. The scheduled wanted loop paces itself with the same value
+// (scheduler.searchPaceInterval, kept in sync).
+//
+// A var, not a const, only so tests that assert concurrency behaviour can set
+// it to 0 and observe an unpaced fan-out; production never mutates it.
+var searchPaceInterval = 3 * time.Second
 
 // BulkHandler handles multi-ID mutation endpoints for authors, books, and
 // wanted books. All three endpoints use a per-ID result map with 200 status
@@ -329,7 +343,7 @@ func (h *BulkHandler) fanOutSearches(books []models.Book) {
 		return
 	}
 	bgCtx := h.bgCtx()
-	go concurrency.RunBounded(bgCtx, books, bulkSearchConcurrency, func(ctx context.Context, b models.Book) {
+	go concurrency.RunBoundedPaced(bgCtx, books, bulkSearchConcurrency, searchPaceInterval, func(ctx context.Context, b models.Book) {
 		h.searcher.SearchAndGrabBook(ctx, b)
 	})
 }

--- a/internal/api/bulk_test.go
+++ b/internal/api/bulk_test.go
@@ -1046,6 +1046,11 @@ func (m *boundedMockSearcher) SearchAndGrabBook(_ context.Context, _ models.Book
 // (8); we use 32 books and assert the observed in-flight count never
 // exceeds it.
 func TestAuthorsBulk_Search_BoundsConcurrency(t *testing.T) {
+	// Asserts the concurrency cap; disable pacing so launches aren't spaced
+	// out (pacing is covered in the concurrency package).
+	searchPaceInterval = 0
+	t.Cleanup(func() { searchPaceInterval = 3 * time.Second })
+
 	const total = 32
 	searcher := newBoundedMockSearcher(total)
 	h, _, books, author, ctx := bulkFixtureWithSearcher(t, searcher)

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -521,7 +521,7 @@ func (h *SeriesHandler) fanOutSeriesSearches(_ context.Context, books []models.B
 	// per-call indexer credentials are already baked into searcher state, so
 	// there is nothing on the request ctx that the search needs.
 	bgCtx := h.bgCtx()
-	go concurrency.RunBounded(bgCtx, books, seriesFillSearchConcurrency, func(ctx context.Context, b models.Book) {
+	go concurrency.RunBoundedPaced(bgCtx, books, seriesFillSearchConcurrency, searchPaceInterval, func(ctx context.Context, b models.Book) {
 		h.searcher.SearchAndGrabBook(ctx, b)
 	})
 }

--- a/internal/concurrency/pool.go
+++ b/internal/concurrency/pool.go
@@ -53,6 +53,65 @@ func RunBounded[T any](ctx context.Context, items []T, maxConcurrent int, fn fun
 	wg.Wait()
 }
 
+// RunBoundedPaced is RunBounded plus a minimum gap between successive task
+// starts. maxConcurrent still caps how many fns run at once; minInterval
+// additionally throttles the launch rate so a large batch can't burst its
+// downstream even as slots free up. The first item starts immediately; each
+// subsequent launch waits until at least minInterval has elapsed since the
+// previous one.
+//
+// This exists for the indexer-search fan-outs (bulk "search all", per-author
+// auto-search, series fill, the scheduled wanted loop): a bare concurrency cap
+// bounds parallelism but not rate, so as each search returns the next fires
+// instantly and a 30-book author sustains a tight loop of indexer queries that
+// can overwhelm a Prowlarr with no per-indexer limits of its own (#1515).
+//
+// minInterval <= 0 makes this behave exactly like RunBounded.
+func RunBoundedPaced[T any](ctx context.Context, items []T, maxConcurrent int, minInterval time.Duration, fn func(context.Context, T)) {
+	if fn == nil || len(items) == 0 {
+		return
+	}
+	if maxConcurrent <= 0 {
+		maxConcurrent = 1
+	}
+
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+	var lastStart time.Time
+	for _, item := range items {
+		// Pace gate: hold the launch until minInterval has passed since the
+		// previous actual start. Measured from the real launch (below), not
+		// the loop iteration, so a stall on the concurrency gate doesn't let
+		// the next two starts bunch up.
+		if minInterval > 0 && !lastStart.IsZero() {
+			if wait := minInterval - time.Since(lastStart); wait > 0 {
+				select {
+				case <-time.After(wait):
+				case <-ctx.Done():
+					wg.Wait()
+					return
+				}
+			}
+		}
+		// Concurrency gate.
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		}
+		lastStart = time.Now()
+		item := item
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			fn(ctx, item)
+		}()
+	}
+	wg.Wait()
+}
+
 // BoundedResult pairs a per-item outcome with whether it actually
 // completed within the per-call deadline. Items whose fn returned an
 // error, whose timeout fired, or whose parent ctx was canceled before

--- a/internal/concurrency/pool_test.go
+++ b/internal/concurrency/pool_test.go
@@ -259,3 +259,117 @@ func TestRunBoundedWithTimeout_EmptyInput(t *testing.T) {
 		t.Fatalf("expected empty results, got %d", len(results))
 	}
 }
+
+func TestRunBoundedPaced_ThrottlesLaunchRate(t *testing.T) {
+	const items = 6
+	const interval = 20 * time.Millisecond
+
+	work := make([]int, items)
+	for i := range work {
+		work[i] = i
+	}
+
+	var processed int32
+	start := time.Now()
+	// High concurrency so the semaphore never blocks; pacing is the only
+	// thing gating the launch rate.
+	RunBoundedPaced(context.Background(), work, 100, interval, func(_ context.Context, _ int) {
+		atomic.AddInt32(&processed, 1)
+	})
+	elapsed := time.Since(start)
+
+	if got := atomic.LoadInt32(&processed); got != items {
+		t.Fatalf("processed = %d, want %d", got, items)
+	}
+	// n items paced at `interval` cannot complete faster than (n-1)*interval,
+	// since the first starts immediately and each subsequent launch waits.
+	min := time.Duration(items-1) * interval
+	if elapsed < min*9/10 {
+		t.Fatalf("completed in %v, want >= ~%v (pacing not applied)", elapsed, min)
+	}
+}
+
+func TestRunBoundedPaced_RespectsConcurrencyCap(t *testing.T) {
+	const items = 30
+	const cap = 3
+
+	work := make([]int, items)
+	for i := range work {
+		work[i] = i
+	}
+
+	var active, maxActive int32
+	// Tiny interval so pacing doesn't dominate; the point is the cap holds.
+	RunBoundedPaced(context.Background(), work, cap, time.Millisecond, func(_ context.Context, _ int) {
+		now := atomic.AddInt32(&active, 1)
+		for {
+			prev := atomic.LoadInt32(&maxActive)
+			if now <= prev || atomic.CompareAndSwapInt32(&maxActive, prev, now) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		atomic.AddInt32(&active, -1)
+	})
+
+	if got := atomic.LoadInt32(&maxActive); got > cap {
+		t.Fatalf("max concurrent = %d, want <= %d", got, cap)
+	}
+}
+
+func TestRunBoundedPaced_ZeroIntervalIsUnpaced(t *testing.T) {
+	const items = 50
+	work := make([]int, items)
+	for i := range work {
+		work[i] = i
+	}
+
+	var processed int32
+	start := time.Now()
+	RunBoundedPaced(context.Background(), work, 8, 0, func(_ context.Context, _ int) {
+		atomic.AddInt32(&processed, 1)
+	})
+	elapsed := time.Since(start)
+
+	if got := atomic.LoadInt32(&processed); got != items {
+		t.Fatalf("processed = %d, want %d", got, items)
+	}
+	// With no pacing this should finish near-instantly, not accumulate any
+	// per-item delay.
+	if elapsed > 100*time.Millisecond {
+		t.Fatalf("unpaced run took %v, expected near-instant", elapsed)
+	}
+}
+
+func TestRunBoundedPaced_CtxCancelStopsLaunching(t *testing.T) {
+	const items = 100
+	const interval = 30 * time.Millisecond
+
+	work := make([]int, items)
+	for i := range work {
+		work[i] = i
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var processed int32
+	go func() {
+		// Let a couple launch, then cancel mid-pace.
+		time.Sleep(75 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	RunBoundedPaced(ctx, work, 4, interval, func(_ context.Context, _ int) {
+		atomic.AddInt32(&processed, 1)
+	})
+	elapsed := time.Since(start)
+
+	if got := atomic.LoadInt32(&processed); got >= items {
+		t.Fatalf("processed = %d, expected to stop early on ctx cancel", got)
+	}
+	// Should return shortly after cancel, not run the full paced batch
+	// (which would take ~3s).
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("returned in %v, expected prompt exit after cancel", elapsed)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -154,6 +154,14 @@ type Scheduler struct {
 
 const scheduledWantedSearchConcurrency = 2
 
+// searchPaceInterval is the minimum gap between successive indexer-search
+// launches in the scheduled wanted loop. Kept in sync with the api package's
+// searchPaceInterval so every search fan-out (manual bulk, per-author, series
+// fill, and this loop) throttles Prowlarr at the same rate (#1515).
+//
+// A var, not a const, only so tests can set it to 0; production never mutates it.
+var searchPaceInterval = 3 * time.Second
+
 // New creates a new scheduler.
 //
 // appCtx is the process-lifecycle context — a context that is not tied to any
@@ -767,7 +775,7 @@ func (s *Scheduler) searchWanted() {
 	if len(searchQueue) == 0 {
 		return
 	}
-	concurrency.RunBounded(ctx, searchQueue, scheduledWantedSearchConcurrency, func(ctx context.Context, book models.Book) {
+	concurrency.RunBoundedPaced(ctx, searchQueue, scheduledWantedSearchConcurrency, searchPaceInterval, func(ctx context.Context, book models.Book) {
 		s.SearchAndGrabBook(ctx, book)
 	})
 }


### PR DESCRIPTION
Closes #1515.

## Why

"Search all wanted" for a prolific author (and series fill, per-author auto-search, the scheduled wanted loop) bounded *concurrency* but not *rate*. Each fan-out ran N book-searches with a small in-flight cap, but as each search returned the next fired instantly — and every book-search fans out to every configured indexer. A 30+ book author sustained a tight query loop that could overwhelm a Prowlarr with no per-indexer limits of its own, so searches timed out and nothing got grabbed. Reported by @DigNits.

## What

- New `concurrency.RunBoundedPaced` — `RunBounded` plus a minimum gap between task *starts*. Concurrency caps still bound parallelism; pacing bounds the launch rate. `minInterval <= 0` behaves exactly like `RunBounded`.
- Every search fan-out routed through it at a **3s** pace: bulk `fanOutSearches`, `series.Fill`, per-author `runBookSearches` (which also drops its bespoke duplicate semaphore), and the scheduled `searchWanted` loop.
- Non-search bulk ops (delete, monitor-toggle) keep the unpaced `RunBounded` — no reason to slow those.
- Fixed constant, not a user setting, matching the existing "one tunable number is more noise than signal" note on the concurrency caps. It's a package `var` only so concurrency tests can zero it; production never mutates it.

A 30-book author now finishes its searches in ~90s in the background instead of a single burst.

## Tests

`RunBoundedPaced` throttle-rate / concurrency-cap / zero-interval / ctx-cancel in the concurrency package; the two existing api concurrency tests pin pacing off (they assert the cap, which pacing is orthogonal to). Full `gofmt` / `vet` / `golangci-lint` (0 issues) and api + scheduler + concurrency suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)