### PR TITLE
fix(transmission): raise RPC read cap so large torrent lists poll (#1524)

### DIFF
--- a/changelog.d/1524-transmission-response-cap.md
+++ b/changelog.d/1524-transmission-response-cap.md
@@ -1,0 +1,8 @@
+### Fixed
+- **Transmission polling on large torrent histories** (#1524) — the download
+  poller read at most 1 MiB of Transmission's `torrent-get` reply, so an
+  instance with a few thousand torrents (one report: ~12 MiB for 5000+) had its
+  response silently truncated and every poll failed with "unexpected end of
+  JSON input", blocking imports. The RPC read cap is now 64 MiB, and a reply
+  that somehow still exceeds it returns a clear "too many torrents to poll in
+  one request" error instead of invalid JSON.

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -481,6 +481,28 @@ func validateHost(host string) error {
 }
 
 // doRequest sends a request and handles the 409 conflict response (session ID update).
+// maxRPCResponseBytes caps how much of a Transmission RPC reply doRequest will
+// read. torrent-get returns every torrent in one response, so an instance with
+// a large history is easily multiple MiB (one report: ~12 MiB for 5000+
+// torrents, #1524). The old 1 MiB cap silently truncated the body and the
+// caller saw "unexpected end of JSON input"; 64 MiB gives generous headroom
+// and readRPCBody turns an over-limit reply into a clear error instead.
+const maxRPCResponseBytes = 64 << 20
+
+// readRPCBody reads an RPC response under maxRPCResponseBytes. Unlike a bare
+// io.LimitReader it reports truncation as an explicit error rather than
+// handing back a half-JSON document that fails to parse (#1524).
+func readRPCBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxRPCResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxRPCResponseBytes {
+		return nil, fmt.Errorf("transmission RPC response exceeded %d bytes — too many torrents to poll in one request", maxRPCResponseBytes)
+	}
+	return body, nil
+}
+
 func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 	if err := c.validateRequestTarget(req.URL); err != nil {
 		return nil, err
@@ -492,7 +514,10 @@ func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	body, err := readRPCBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("transmission: read body: %w", err)
+	}
 
 	// Handle 409 Conflict - need to set session ID and retry
 	if resp.StatusCode == http.StatusConflict {
@@ -516,7 +541,7 @@ func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 			}
 			defer resp2.Body.Close()
 
-			body, err = io.ReadAll(io.LimitReader(resp2.Body, 1024*1024))
+			body, err = readRPCBody(resp2.Body)
 			if err != nil {
 				return nil, fmt.Errorf("transmission: read retry body: %w", err)
 			}

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -945,3 +945,39 @@ func TestAddTorrent_SeedRatio_Unset(t *testing.T) {
 		t.Error("seedRatioMode must be omitted when no override is set")
 	}
 }
+
+// TestGetTorrents_LargeResponseExceedsOldCap is the regression test for #1524:
+// a Transmission instance with a large torrent history returns a torrent-get
+// body well over the old 1 MiB read cap. The cap silently truncated the JSON
+// and the caller saw "unexpected end of JSON input". The body must now be read
+// in full and decoded.
+func TestGetTorrents_LargeResponseExceedsOldCap(t *testing.T) {
+	const n = 20000 // ~1.8 MiB of JSON, comfortably past the old 1 MiB cap
+	var b strings.Builder
+	b.WriteString(`{"result":"success","arguments":{"torrents":[`)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"id":%d,"name":"Book %d","percentDone":1.0,"status":6,"downloadDir":"/downloads"}`, i, i)
+	}
+	b.WriteString(`]}}`)
+	payload := b.String()
+	if len(payload) <= 1024*1024 {
+		t.Fatalf("test payload is %d bytes, expected > 1 MiB to exercise the old cap", len(payload))
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	torrents, err := c.GetTorrents(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetTorrents on large response: %v", err)
+	}
+	if len(torrents) != n {
+		t.Fatalf("expected %d torrents, got %d", n, len(torrents))
+	}
+}


### PR DESCRIPTION
Closes #1524.

## Why

`doRequest` read at most **1 MiB** of Transmission's `torrent-get` reply. `GetTorrents` asks for every torrent, so an instance with a few thousand returns several MiB (@ancathri measured ~12 MiB for 5000+ torrents). The `io.LimitReader` silently truncated the body and the caller failed with `unexpected end of JSON input`, so download polling never imported anything — even though the connection test passed (it returns a tiny body).

Great report: @ancathri pinpointed the exact line and captured the response size.

## What

- Raise the RPC read cap to **64 MiB** (`maxRPCResponseBytes`) — generous headroom over the observed ~12 MiB; a minimal-field `torrent-get` is compact.
- Route both read sites in `doRequest` (initial + post-409 retry) through `readRPCBody`, which reads `cap+1` and returns a clear "too many torrents to poll in one request" error if the reply somehow still exceeds the cap, instead of a half-JSON document. This is exactly the "clear error rather than invalid JSON" the reporter asked for.

## Tests

`TestGetTorrents_LargeResponseExceedsOldCap` serves a >1 MiB `torrent-get` response (20k torrents) and asserts `GetTorrents` decodes it in full — it would have failed under the old cap. gofmt / vet / golangci-lint (0 issues) and the transmission suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)