### PR TITLE
fix(grimmory): probe /api/v1/healthcheck for Test connection (#1485)

### DIFF
--- a/changelog.d/1485-grimmory-healthcheck-probe.md
+++ b/changelog.d/1485-grimmory-healthcheck-probe.md
@@ -1,0 +1,10 @@
+### Fixed
+- **Grimmory "Test connection" against Grimmory v3.x** (#1485) — the connection
+  test probed `GET /api/status`, a route current Grimmory (v3.x) no longer has.
+  Its Spring security layer answers any unmapped `/api/**` path with a 401
+  Whitelabel page, which looked like an auth wall (and was mistaken for one in
+  #1448) but was really a missing route, so the test could never pass and failed
+  with `invalid character '<'`. The probe now hits Grimmory's public
+  `GET /api/v1/healthcheck` endpoint for reachability and version; credential
+  verification stays with the separate login round-trip, so "Test connection"
+  still reports whether your username/password actually work.

--- a/changelog.d/1524-transmission-response-cap.md
+++ b/changelog.d/1524-transmission-response-cap.md
@@ -1,0 +1,8 @@
+### Fixed
+- **Transmission polling on large torrent histories** (#1524) — the download
+  poller read at most 1 MiB of Transmission's `torrent-get` reply, so an
+  instance with a few thousand torrents (one report: ~12 MiB for 5000+) had its
+  response silently truncated and every poll failed with "unexpected end of
+  JSON input", blocking imports. The RPC read cap is now 64 MiB, and a reply
+  that somehow still exceeds it returns a clear "too many torrents to poll in
+  one request" error instead of invalid JSON.

--- a/internal/api/grimmory_test.go
+++ b/internal/api/grimmory_test.go
@@ -131,13 +131,13 @@ func TestGrimmorySetConfig_InvalidBaseURL(t *testing.T) {
 	}
 }
 
-// TestGrimmoryTest_Success points the handler at a fake Grimmory /api/status
-// endpoint and asserts the version is reported.
+// TestGrimmoryTest_Success points the handler at a fake Grimmory
+// /api/v1/healthcheck endpoint and asserts the version is reported.
 func TestGrimmoryTest_Success(t *testing.T) {
 	h, _ := grimmoryFixture(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/status" {
-			_, _ = w.Write([]byte(`{"status":"ok","version":"3.4.1"}`))
+		if r.URL.Path == "/api/v1/healthcheck" {
+			_, _ = w.Write([]byte(`{"data":{"status":"UP","version":"3.4.1"}}`))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -208,8 +208,8 @@ func TestGrimmoryTest_InvalidBaseURL(t *testing.T) {
 func TestGrimmoryTest_UsesStoredConfig(t *testing.T) {
 	h, settings := grimmoryFixture(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/status" {
-			_, _ = w.Write([]byte(`{"status":"ok","version":"9.9.9"}`))
+		if r.URL.Path == "/api/v1/healthcheck" {
+			_, _ = w.Write([]byte(`{"data":{"status":"UP","version":"9.9.9"}}`))
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/downloader/transmission/client.go
+++ b/internal/downloader/transmission/client.go
@@ -481,6 +481,28 @@ func validateHost(host string) error {
 }
 
 // doRequest sends a request and handles the 409 conflict response (session ID update).
+// maxRPCResponseBytes caps how much of a Transmission RPC reply doRequest will
+// read. torrent-get returns every torrent in one response, so an instance with
+// a large history is easily multiple MiB (one report: ~12 MiB for 5000+
+// torrents, #1524). The old 1 MiB cap silently truncated the body and the
+// caller saw "unexpected end of JSON input"; 64 MiB gives generous headroom
+// and readRPCBody turns an over-limit reply into a clear error instead.
+const maxRPCResponseBytes = 64 << 20
+
+// readRPCBody reads an RPC response under maxRPCResponseBytes. Unlike a bare
+// io.LimitReader it reports truncation as an explicit error rather than
+// handing back a half-JSON document that fails to parse (#1524).
+func readRPCBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxRPCResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxRPCResponseBytes {
+		return nil, fmt.Errorf("transmission RPC response exceeded %d bytes — too many torrents to poll in one request", maxRPCResponseBytes)
+	}
+	return body, nil
+}
+
 func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 	if err := c.validateRequestTarget(req.URL); err != nil {
 		return nil, err
@@ -492,7 +514,10 @@ func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	body, err := readRPCBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("transmission: read body: %w", err)
+	}
 
 	// Handle 409 Conflict - need to set session ID and retry
 	if resp.StatusCode == http.StatusConflict {
@@ -516,7 +541,7 @@ func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 			}
 			defer resp2.Body.Close()
 
-			body, err = io.ReadAll(io.LimitReader(resp2.Body, 1024*1024))
+			body, err = readRPCBody(resp2.Body)
 			if err != nil {
 				return nil, fmt.Errorf("transmission: read retry body: %w", err)
 			}

--- a/internal/downloader/transmission/client_test.go
+++ b/internal/downloader/transmission/client_test.go
@@ -945,3 +945,39 @@ func TestAddTorrent_SeedRatio_Unset(t *testing.T) {
 		t.Error("seedRatioMode must be omitted when no override is set")
 	}
 }
+
+// TestGetTorrents_LargeResponseExceedsOldCap is the regression test for #1524:
+// a Transmission instance with a large torrent history returns a torrent-get
+// body well over the old 1 MiB read cap. The cap silently truncated the JSON
+// and the caller saw "unexpected end of JSON input". The body must now be read
+// in full and decoded.
+func TestGetTorrents_LargeResponseExceedsOldCap(t *testing.T) {
+	const n = 20000 // ~1.8 MiB of JSON, comfortably past the old 1 MiB cap
+	var b strings.Builder
+	b.WriteString(`{"result":"success","arguments":{"torrents":[`)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"id":%d,"name":"Book %d","percentDone":1.0,"status":6,"downloadDir":"/downloads"}`, i, i)
+	}
+	b.WriteString(`]}}`)
+	payload := b.String()
+	if len(payload) <= 1024*1024 {
+		t.Fatalf("test payload is %d bytes, expected > 1 MiB to exercise the old cap", len(payload))
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL, "user", "pass")
+	torrents, err := c.GetTorrents(context.Background(), "")
+	if err != nil {
+		t.Fatalf("GetTorrents on large response: %v", err)
+	}
+	if len(torrents) != n {
+		t.Fatalf("expected %d torrents, got %d", n, len(torrents))
+	}
+}

--- a/internal/grimmory/client.go
+++ b/internal/grimmory/client.go
@@ -50,10 +50,21 @@ func (e *APIError) Error() string {
 	return fmt.Sprintf("grimmory api error (%d): %s", e.StatusCode, msg)
 }
 
-// StatusResponse is the shape returned by GET /api/status.
+// StatusResponse is the connectivity/version summary Ping distills from
+// Grimmory's health endpoint (see healthcheckEnvelope).
 type StatusResponse struct {
 	Status  string `json:"status"`
 	Version string `json:"version,omitempty"`
+}
+
+// healthcheckEnvelope is the shape returned by GET /api/v1/healthcheck. Grimmory
+// wraps the interesting fields in a "data" object alongside a top-level
+// message/status/timestamp; only the nested status and version matter here.
+type healthcheckEnvelope struct {
+	Data struct {
+		Status  string `json:"status"`
+		Version string `json:"version"`
+	} `json:"data"`
 }
 
 // NormalizeBaseURL validates and canonicalises the user-supplied server URL.
@@ -182,39 +193,24 @@ func (c *Client) WithCredentials(username, password string) *Client {
 	return c
 }
 
-// Ping calls GET /api/status to verify connectivity and authentication.
+// Ping calls GET /api/v1/healthcheck to confirm the base URL points at a real
+// Grimmory API and to read its version. That endpoint is public and returns a
+// JSON envelope with the status and version nested under "data"; it needs no
+// authentication. Verifying that the configured credentials actually work is a
+// separate concern owned by VerifyAuth, which the "Test connection" handler
+// calls right after a successful Ping.
 //
-// Current Grimmory guards /api/status behind a valid session, so an
-// unauthenticated probe now returns 401 (#1448). When username/password (or a
-// static key) is configured, Ping authenticates first — acquiring a JWT via
-// login when needed — and retries once on 401 after forcing a fresh login, so
-// an expired cached token heals transparently. Without any credentials it
-// falls back to an unauthenticated probe (still useful against a Grimmory that
-// leaves /api/status public).
+// Earlier versions probed GET /api/status and treated its 401 as "guarded by a
+// session" (#1448). But current Grimmory (v3.x) has no /api/status route at
+// all: its Spring security layer answers any unmapped /api/** path with a 401
+// Whitelabel page, which read like an auth wall but was really a 404 in
+// disguise — so the probe could never succeed (#1485).
 func (c *Client) Ping(ctx context.Context) (*StatusResponse, error) {
-	var resp StatusResponse
-	if !c.HasCredentials() {
-		if err := c.do(ctx, http.MethodGet, "/api/status", nil, &resp); err != nil {
-			return nil, err
-		}
-		return &resp, nil
-	}
-	token, err := c.bearer(ctx, false)
-	if err != nil {
+	var env healthcheckEnvelope
+	if err := c.do(ctx, http.MethodGet, "/api/v1/healthcheck", nil, &env); err != nil {
 		return nil, err
 	}
-	err = c.doWithToken(ctx, http.MethodGet, "/api/status", token, nil, &resp)
-	var apiErr *APIError
-	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusUnauthorized && c.apiKey == "" {
-		if token, err = c.bearer(ctx, true); err != nil {
-			return nil, err
-		}
-		err = c.doWithToken(ctx, http.MethodGet, "/api/status", token, nil, &resp)
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &resp, nil
+	return &StatusResponse{Status: env.Data.Status, Version: env.Data.Version}, nil
 }
 
 // do issues a request carrying only a statically-configured API key as auth

--- a/internal/grimmory/client_test.go
+++ b/internal/grimmory/client_test.go
@@ -228,7 +228,7 @@ func TestPing_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(StatusResponse{Status: "ok", Version: "1.0"})
+		_, _ = w.Write([]byte(`{"data":{"status":"UP","version":"1.0"},"message":"Pong","status":200}`))
 	}))
 	defer srv.Close()
 
@@ -240,8 +240,8 @@ func TestPing_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ping: unexpected error: %v", err)
 	}
-	if resp.Status != "ok" {
-		t.Errorf("Status: got %q, want %q", resp.Status, "ok")
+	if resp.Status != "UP" {
+		t.Errorf("Status: got %q, want %q", resp.Status, "UP")
 	}
 	if resp.Version != "1.0" {
 		t.Errorf("Version: got %q, want %q", resp.Version, "1.0")
@@ -317,37 +317,34 @@ func TestPing_HTMLBody(t *testing.T) {
 	if err == nil {
 		t.Fatal("Ping: want error for HTML body, got nil")
 	}
-	for _, want := range []string{"non-JSON", "text/html", "/api/status"} {
+	for _, want := range []string{"non-JSON", "text/html", "/api/v1/healthcheck"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q: want it to mention %q", err, want)
 		}
 	}
 }
 
-// TestPing_AuthedStatusWithCredentials covers #1448: Grimmory guards
-// /api/status behind a valid session, so an unauthenticated probe 401s. When a
-// username/password is configured, Ping must log in first and present the JWT
-// on /api/status rather than failing the "Test connection" button outright.
-func TestPing_AuthedStatusWithCredentials(t *testing.T) {
-	var logins, statusHits int
+// TestPing_HealthcheckEnvelope covers #1485: Ping probes the public
+// GET /api/v1/healthcheck route and pulls the status/version out of the nested
+// "data" envelope. It must not require authentication — no JWT login, no
+// Authorization header — because verifying credentials is VerifyAuth's job.
+func TestPing_HealthcheckEnvelope(t *testing.T) {
+	var loginHits int
+	var probePath, probeAuth string
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/v1/auth/login", func(w http.ResponseWriter, r *http.Request) {
-		var creds map[string]string
-		_ = json.NewDecoder(r.Body).Decode(&creds)
-		if creds["username"] != "bindery" || creds["password"] != "s3cret" {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		logins++
+		loginHits++
 		_ = json.NewEncoder(w).Encode(map[string]string{"accessToken": "jwt-1", "refreshToken": "refresh-1"})
 	})
+	mux.HandleFunc("GET /api/v1/healthcheck", func(w http.ResponseWriter, r *http.Request) {
+		probePath = r.URL.Path
+		probeAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"data":{"status":"UP","version":"v3.2.4"},"message":"Pong","status":200}`))
+	})
+	// The old route is gone in current Grimmory; 401 it like Spring security does
+	// so a regression back to /api/status fails loudly instead of silently.
 	mux.HandleFunc("GET /api/status", func(w http.ResponseWriter, r *http.Request) {
-		statusHits++
-		if r.Header.Get("Authorization") != "Bearer jwt-1" {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(StatusResponse{Status: "ok", Version: "3.1"})
+		w.WriteHeader(http.StatusUnauthorized)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -362,58 +359,20 @@ func TestPing_AuthedStatusWithCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ping: unexpected error: %v", err)
 	}
-	if resp.Version != "3.1" {
-		t.Errorf("Version: got %q, want %q", resp.Version, "3.1")
+	if resp.Version != "v3.2.4" {
+		t.Errorf("Version: got %q, want %q", resp.Version, "v3.2.4")
 	}
-	if logins != 1 {
-		t.Errorf("logins: got %d, want 1", logins)
+	if resp.Status != "UP" {
+		t.Errorf("Status: got %q, want %q", resp.Status, "UP")
 	}
-}
-
-// TestPing_AuthedStatusRetriesOn401 covers the stale-token path: a cached JWT
-// that Grimmory has since expired should trigger one forced re-login and a
-// retry rather than surfacing the 401 to the "Test connection" button.
-func TestPing_AuthedStatusRetriesOn401(t *testing.T) {
-	var logins int
-	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/auth/login", func(w http.ResponseWriter, r *http.Request) {
-		logins++
-		// First login hands out the stale token, second the fresh one.
-		tok := "jwt-fresh"
-		if logins == 1 {
-			tok = "jwt-stale"
-		}
-		_ = json.NewEncoder(w).Encode(map[string]string{"accessToken": tok, "refreshToken": "refresh-1"})
-	})
-	mux.HandleFunc("GET /api/status", func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer jwt-fresh" {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(StatusResponse{Status: "ok", Version: "3.1"})
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
-
-	c, err := NewClient(srv.URL, "")
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
+	if probePath != "/api/v1/healthcheck" {
+		t.Errorf("probe path: got %q, want /api/v1/healthcheck", probePath)
 	}
-	c.WithCredentials("bindery", "s3cret")
-	// Seed a stale token so the first /api/status attempt 401s.
-	if _, err := c.login(context.Background()); err != nil {
-		t.Fatalf("seed login: %v", err)
+	if loginHits != 0 {
+		t.Errorf("Ping must not authenticate: got %d logins, want 0", loginHits)
 	}
-
-	resp, err := c.Ping(context.Background())
-	if err != nil {
-		t.Fatalf("Ping: unexpected error: %v", err)
-	}
-	if resp.Version != "3.1" {
-		t.Errorf("Version: got %q, want %q", resp.Version, "3.1")
-	}
-	if logins != 2 {
-		t.Errorf("logins: got %d, want 2 (seed + forced re-login)", logins)
+	if probeAuth != "" {
+		t.Errorf("Ping must not send an Authorization header, got %q", probeAuth)
 	}
 }
 


### PR DESCRIPTION
## What

Grimmory "Test connection" probed `GET /api/status`, which current Grimmory (v3.x) doesn't have. Its Spring security layer answers any unmapped `/api/**` path with a 401 Whitelabel page — #1448 mistook that for an auth-guarded endpoint, but it's really a missing route, so the test could never pass and surfaced as `invalid character '<'`.

Reporter (@Moohan, #1485) proved it from Bindery's own network namespace: `/api/status` → 401, `/api/v1/healthcheck` → 200 JSON with the version.

## Fix

`Ping` now hits the public `GET /api/v1/healthcheck` for reachability + version (parsed from its nested `data` envelope) and no longer authenticates. Credential verification already lives in `VerifyAuth`, which the Test handler calls right after a successful `Ping`, so "Test connection" still reports whether the configured username/password actually work — reachability and auth are just cleanly separated now.

## Tests

- `TestPing_HealthcheckEnvelope` — asserts the probe hits `/api/v1/healthcheck`, parses the `data` envelope, and sends no auth (no login, no `Authorization` header).
- Updated `TestPing_Success`, `TestPing_HTMLBody`, and the handler tests to the new route/shape.
- `go test ./internal/grimmory/... ./internal/api/`, `go vet`, `golangci-lint` all clean.

Fixes #1485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)