### PR TITLE
chore(telemetry): bump telemetry-server image to the #1521 build

### DIFF
--- a/deploy/telemetry-server.yaml
+++ b/deploy/telemetry-server.yaml
@@ -45,7 +45,7 @@ spec:
           # GitHub release every 30m. Deploys here are manual (the cluster is
           # unreachable from CI runners), so bump this sha when rolling a new
           # telemetry-server build.
-          image: ghcr.io/vavallee/bindery-ping:sha-793ee55580f2e5cf3e2bda525fc8ec71b076ade4
+          image: ghcr.io/vavallee/bindery-ping:sha-23586cd355e40700e2b60e8d9344ba4e2afd3cb3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
Bumps `deploy/telemetry-server.yaml` to `sha-23586cd3…`, the image built from #1521 (true cumulative install metric + `new_installs` erosion fix).

**Already deployed.** I rolled this to the bindery-ping cluster manually on 2026-07-14 (the cluster is unreachable from CI, so telemetry-server deploys are hand-applied). The one-time repair seed (`NEW_INSTALLS_SEED_PATH` + ConfigMap) ran once — reconciled 7 eroded days — and has been torn down. `https://api.getbindery.dev/stats.json` now reports `"cumulative": 766`, and it persists after the seed was removed.

This PR just makes the committed manifest match what's running, so a future `kubectl apply -f` of this file doesn't roll prod back to the old sha (which would drop the `cumulative` field). No seed wiring is committed — the erosion bug is fixed in the image, so the seed is a spent one-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)