### PR TITLE
fix(indexer): require author corroboration for unanchored title matches (#1539)

### DIFF
--- a/changelog.d/1539-relevance-embedded-title.md
+++ b/changelog.d/1539-relevance-embedded-title.md
@@ -1,0 +1,16 @@
+### Fixed
+- **Wrong-author grabs from embedded title phrases** (#1539) — the release
+  relevance filter accepted any release whose name contained the book's title
+  words as a contiguous phrase, with no author check on that path, so a
+  different work embedding the requested title could be grabbed and imported
+  ("Reborn as an Assassin's Apprentice, Vol. 1 by okiuta" matched for Robin
+  Hobb's "Assassin's Apprentice"; reported by cleb on Discord with the root
+  cause pinned). Phrase and in-order title hits are now only trusted on their
+  own when *anchored* — preceded by nothing but the author, a series index
+  ("Book 1", "Vol. 2"), numbers, or filler words. When real foreign words sit
+  in front of the title (usually another work's longer title), the requested
+  author must appear somewhere in the release name. Releases titled with just
+  the book title still pass, so the fix costs no recall on the common
+  author-less naming shapes; the narrow tradeoff is that a release naming only
+  a series *name* (no author, no "Book N" marker) before the title is now
+  rejected rather than risk importing the wrong book.

--- a/internal/indexer/inorder.go
+++ b/internal/indexer/inorder.go
@@ -15,11 +15,18 @@ func containsInOrder(haystack string, seq []string) bool {
 	if len(seq) == 0 {
 		return true
 	}
+	return inOrderRegex(seq).MatchString(haystack)
+}
+
+// inOrderRegex returns the cached in-order-sequence regex for seq. Shared with
+// matchAnchored (searcher.go), which needs the leftmost match position to
+// inspect what precedes the sequence.
+func inOrderRegex(seq []string) *regexp.Regexp {
 	parts := make([]string, len(seq))
 	for i, w := range seq {
 		parts[i] = umlautFlexRegex(regexp.QuoteMeta(strings.ToLower(w)))
 	}
 	pattern := `(?i)\b` + strings.Join(parts, `\b.*\b`) + `\b`
 	re, _ := regexCache.LoadOrStore(pattern, regexp.MustCompile(pattern))
-	return re.(*regexp.Regexp).MatchString(haystack)
+	return re.(*regexp.Regexp)
 }

--- a/internal/indexer/release.go
+++ b/internal/indexer/release.go
@@ -106,6 +106,21 @@ func WordBoundaryRegex(kw string) *regexp.Regexp {
 	return re
 }
 
+// phraseRegex returns the cached contiguous-phrase regex for the given words:
+// each word at a boundary, separated only by non-word characters, with German
+// umlaut expansions matched flexibly (ae/oe/ue optionally contracts to a/o/u).
+// Callers needing the match position (see matchAnchored in searcher.go) share
+// this instead of rebuilding the pattern.
+func phraseRegex(phrase []string) *regexp.Regexp {
+	parts := make([]string, len(phrase))
+	for i, w := range phrase {
+		parts[i] = umlautFlexRegex(regexp.QuoteMeta(strings.ToLower(w)))
+	}
+	pattern := `(?i)\b` + strings.Join(parts, `\W+`) + `\b`
+	re, _ := regexCache.LoadOrStore(pattern, regexp.MustCompile(pattern))
+	return re.(*regexp.Regexp)
+}
+
 // ContainsPhrase returns true if all words in phrase appear in haystack in the
 // given order, separated only by non-word characters. haystack must already be
 // normalized (lowercased, separators→space). German umlaut expansions in phrase
@@ -114,13 +129,7 @@ func ContainsPhrase(haystack string, phrase []string) bool {
 	if len(phrase) == 0 {
 		return true
 	}
-	parts := make([]string, len(phrase))
-	for i, w := range phrase {
-		parts[i] = umlautFlexRegex(regexp.QuoteMeta(strings.ToLower(w)))
-	}
-	pattern := `(?i)\b` + strings.Join(parts, `\W+`) + `\b`
-	re, _ := regexCache.LoadOrStore(pattern, regexp.MustCompile(pattern))
-	return re.(*regexp.Regexp).MatchString(haystack)
+	return phraseRegex(phrase).MatchString(haystack)
 }
 
 // ParseRelease extracts structured metadata from an indexer result title.

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -345,12 +345,87 @@ func authorMatchesRelease(normResult string, tokens []string) bool {
 	}
 }
 
+// seriesMarkerTokens are words that legitimately sit before the title in a
+// release name as part of a series/sequence label ("Book 1 - Title",
+// "Vol. 2 Title", German "Band 3 Titel"). They carry no evidence that the
+// phrase belongs to a different work, so matchAnchored treats them as benign
+// prefix filler alongside numbers and stop words.
+var seriesMarkerTokens = map[string]bool{
+	"book": true, "vol": true, "volume": true, "part": true, "tome": true, "band": true,
+}
+
+// isAllDigits reports whether s is non-empty and consists only of ASCII digits.
+func isAllDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+// benignPrefixToken reports whether tok, appearing before the matched title in
+// a release name, is compatible with the release actually BEING that title:
+// the requested author's tokens, bare numbers (series indices, years), tokens
+// SigWords itself would discard (stop words, initials, "01"), and generic
+// series markers ("book", "vol", …). Anything else is a real foreign word —
+// most likely part of a different work's longer title.
+func benignPrefixToken(tok string, authorToks []string) bool {
+	if isAllDigits(tok) {
+		return true
+	}
+	if len(newznab.SigWords(tok)) == 0 {
+		return true
+	}
+	if seriesMarkerTokens[tok] {
+		return true
+	}
+	for _, a := range authorToks {
+		if WordBoundaryRegex(a).MatchString(tok) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchAnchored reports whether re's leftmost match in normResult is preceded
+// only by benign tokens (see benignPrefixToken). Legitimate release naming
+// puts the author, a series label, or nothing before the title; a title
+// embedded mid-way through a longer different title ("Reborn as an Assassin's
+// Apprentice" for "Assassin's Apprentice") has that other work's words in
+// front. Checking the leftmost match is sufficient: prefixes only grow, so a
+// foreign word before the first match precedes every later match too.
+func matchAnchored(normResult string, re *regexp.Regexp, authorToks []string) bool {
+	loc := re.FindStringIndex(normResult)
+	if loc == nil {
+		return false
+	}
+	for _, tok := range strings.Fields(normResult[:loc[0]]) {
+		if !benignPrefixToken(tok, authorToks) {
+			return false
+		}
+	}
+	return true
+}
+
 // titleMatchesResult returns true if the normalized result contains the
 // significant words of the title either as a contiguous phrase or (for
 // multi-word titles as a fallback) with every significant word appearing at
 // a word boundary. A single-significant-word title additionally requires the
 // author to be present (first+last for multi-token authors, surname-only for
 // single-token authors); see authorMatchesRelease.
+//
+// A phrase or in-order hit alone is only trusted when it is ANCHORED (see
+// matchAnchored): a release whose title merely embeds the requested title
+// inside a longer, different one ("Reborn as an Assassin's Apprentice, Vol. 1
+// by okiuta" for Robin Hobb's "Assassin's Apprentice", #1539) must name the
+// requested author somewhere to be accepted. Requiring the author on EVERY
+// phrase hit was considered and rejected — releases titled with just the book
+// title and no author are a large legitimate class — so the author demand
+// kicks in only when foreign words precede the phrase. Known tradeoff: a
+// "SeriesName 01 - Title" release that names neither the author nor a bare
+// series marker is now rejected; a wrong grab imports the wrong book, a missed
+// grab retries on another release.
 func titleMatchesResult(normResult string, titleKws []string, authorToks []string, allowKwFallback bool) bool {
 	switch len(titleKws) {
 	case 0:
@@ -366,7 +441,12 @@ func titleMatchesResult(normResult string, titleKws []string, authorToks []strin
 		return authorMatchesRelease(normResult, authorToks)
 	default:
 		if ContainsPhrase(normResult, titleKws) {
-			return true
+			if len(authorToks) == 0 {
+				// No author tokens to corroborate with — accept (can't do better).
+				return true
+			}
+			return matchAnchored(normResult, phraseRegex(titleKws), authorToks) ||
+				authorMatchesRelease(normResult, authorToks)
 		}
 		if !allowKwFallback {
 			return false
@@ -381,11 +461,16 @@ func titleMatchesResult(normResult string, titleKws []string, authorToks []strin
 		// Locked" vs "Locked Doors"; "Secrets of the Human Body" vs "Body of
 		// Secrets"). Accept only if the author anchors it, or the words appear in
 		// title order (legit stop-word-separated titles like "The Lord of the
-		// Rings").
+		// Rings") — and, mirroring the phrase branch, the in-order hit itself
+		// must be anchored so an embedded title can't sneak back in through
+		// this weaker path.
 		if len(authorToks) > 0 && authorMatchesRelease(normResult, authorToks) {
 			return true
 		}
-		return containsInOrder(normResult, titleKws)
+		if !containsInOrder(normResult, titleKws) {
+			return false
+		}
+		return len(authorToks) == 0 || matchAnchored(normResult, inOrderRegex(titleKws), authorToks)
 	}
 }
 

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -1366,3 +1366,80 @@ func TestSearchBook_TimeoutConstantExists(t *testing.T) {
 type nopWriter struct{}
 
 func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// TestFilterRelevantEmbeddedTitleDifferentAuthor covers #1539: a release
+// whose (longer, different) title EMBEDS the requested title as a contiguous
+// phrase must not pass on the phrase alone when the requested author is
+// nowhere in the release. The reported grab: searching Robin Hobb's
+// "Assassin's Apprentice" (audiobook) matched "Reborn as an Assassin's
+// Apprentice, Vol. 1 by okiuta" — an unrelated light novel. Anchored phrase
+// hits (nothing but author/series-index/filler before the title) must keep
+// passing without the author, since title-only release names are a large
+// legitimate class.
+func TestFilterRelevantEmbeddedTitleDifferentAuthor(t *testing.T) {
+	results := toResults(
+		// The reported wrong grab: embedded phrase, different author named.
+		"Reborn.as.an.Assassins.Apprentice.Vol.1.by.okiuta.ENG.M4B.VIP",
+		// Embedded phrase, no author at all — still a different work's title.
+		"Reborn.as.an.Assassins.Apprentice.Vol.2.M4B",
+		// Legit shapes that must keep passing:
+		"Robin.Hobb.-.Assassins.Apprentice.Farseer.1.Unabridged.M4B", // author-prefixed
+		"Assassins.Apprentice.1995.RETAIL.EPUB.eBook-NODE",           // bare title-only
+		"The.Assassins.Apprentice.epub",                              // article-prefixed
+		"Book.1.Assassins.Apprentice.m4b",                            // series-marker-prefixed
+		"Hobb.Assassins.Apprentice.epub",                             // surname-prefixed
+		// Unanchored phrase but the author appears later — corroborated, passes.
+		"Fantasy.Anthology.Assassins.Apprentice.Robin.Hobb.m4b",
+	)
+	got := filterRelevant(results, "Assassin's Apprentice", "Robin Hobb", nil)
+
+	for _, title := range []string{
+		"Reborn.as.an.Assassins.Apprentice.Vol.1.by.okiuta.ENG.M4B.VIP",
+		"Reborn.as.an.Assassins.Apprentice.Vol.2.M4B",
+	} {
+		if contains(got, title) {
+			t.Errorf("embedded-title release %q must be rejected; got %v", title, resultTitles(got))
+		}
+	}
+	for _, title := range []string{
+		"Robin.Hobb.-.Assassins.Apprentice.Farseer.1.Unabridged.M4B",
+		"Assassins.Apprentice.1995.RETAIL.EPUB.eBook-NODE",
+		"The.Assassins.Apprentice.epub",
+		"Book.1.Assassins.Apprentice.m4b",
+		"Hobb.Assassins.Apprentice.epub",
+		"Fantasy.Anthology.Assassins.Apprentice.Robin.Hobb.m4b",
+	} {
+		if !contains(got, title) {
+			t.Errorf("legitimate release %q must keep passing; got %v", title, resultTitles(got))
+		}
+	}
+}
+
+// The in-order fallback (stop-word-separated titles) has the same embedding
+// hole as the phrase path — a contiguous phrase is trivially in-order, and a
+// gapped sequence inside a longer foreign title is equally weak evidence. Both
+// must demand the author when the hit is unanchored (#1539).
+func TestFilterRelevantInOrderEmbeddedDifferentWork(t *testing.T) {
+	results := toResults(
+		// kws ["name","wind"] appear in order inside a different work's title,
+		// foreign words in front, requested author absent → reject.
+		"Jane.Doe.Chronicles.The.Name.That.Rides.The.Wind.epub",
+		// Anchored in-order hits without the author must keep passing.
+		"The.Name.of.the.Wind.Unabridged.m4b",
+		// Author-corroborated release passes as before.
+		"Patrick.Rothfuss.The.Name.of.the.Wind.Kingkiller.1.epub",
+	)
+	got := filterRelevant(results, "The Name of the Wind", "Patrick Rothfuss", nil)
+
+	if contains(got, "Jane.Doe.Chronicles.The.Name.That.Rides.The.Wind.epub") {
+		t.Errorf("unanchored in-order hit without author must be rejected; got %v", resultTitles(got))
+	}
+	for _, title := range []string{
+		"The.Name.of.the.Wind.Unabridged.m4b",
+		"Patrick.Rothfuss.The.Name.of.the.Wind.Kingkiller.1.epub",
+	} {
+		if !contains(got, title) {
+			t.Errorf("expected %q to pass; got %v", title, resultTitles(got))
+		}
+	}
+}


### PR DESCRIPTION
## What

Fixes #1539 (reported by cleb on Discord with an exact root cause — credit to him).

`titleMatchesResult`'s multi-keyword branch accepted a contiguous phrase hit with no author check, so a release whose longer, different title *embeds* the requested title passed the relevance filter even when it named another author. Real grab: "Reborn as an Assassin's Apprentice, Vol. 1 by okiuta [ENG/M4B]" matched and imported for Robin Hobb's "Assassin's Apprentice".

Two things beyond the report:

1. **The suggested fix (require author on every phrase hit) over-rejects.** That tradeoff was already made deliberately — releases titled with just the book title and no author are a large legitimate class (documented in `TestFilterRelevantMultiWordPhrase`). So the author demand had to be narrower.
2. **The in-order fallback has the same hole.** A contiguous phrase is trivially in-order, so gating only the phrase branch would let the exact repro back in through `containsInOrder` at the bottom of the fallback path. Both acceptance-without-author paths get the same gate.

## Fix — anchored matches

A phrase or in-order hit alone is trusted only when **anchored**: the leftmost match is preceded by nothing but the requested author's tokens, numbers (series index/year), tokens `SigWords` would discard (stop words, initials, "01"), or generic series markers (`book`, `vol`, `volume`, `part`, `tome`, `band`). That's how legitimate releases are actually named. Real foreign words in front of the title (usually another work's longer title) now require the author somewhere in the release name.

Leftmost-match anchoring is sufficient — prefixes only grow, so a foreign word before the first match precedes every later one.

| Release shape | Before | After |
|---|---|---|
| `Reborn.as.an.Assassins.Apprentice.Vol.1.by.okiuta` | ✅ grabbed | ❌ rejected |
| `Assassins.Apprentice.1995.RETAIL.EPUB` (title-only) | ✅ | ✅ |
| `Robin.Hobb.-.Assassins.Apprentice.Farseer.1` | ✅ | ✅ |
| `Book.1.Assassins.Apprentice.m4b` | ✅ | ✅ |
| `Fantasy.Anthology.Assassins.Apprentice.Robin.Hobb` | ✅ | ✅ (author corroborates) |
| `Lord.of.the.Rings.Unabridged.m4b` (in-order, no author) | ✅ | ✅ (anchored) |
| `SeriesName.01.Assassins.Apprentice` (no author) | ✅ | ❌ — documented tradeoff |

The last row is the deliberate cost: wrong grabs import the wrong book into the library; missed grabs retry on another release. Plumbing the *known* series name into the filter would recover it — that belongs with the #1470 matcher consolidation.

## Tests

- `TestFilterRelevantEmbeddedTitleDifferentAuthor` — the exact reported release rejected; six legitimate shapes (author-prefixed, title-only, article-prefixed, series-marker, surname, author-later) all keep passing.
- `TestFilterRelevantInOrderEmbeddedDifferentWork` — same hole closed on the in-order path, anchored in-order hits still pass.
- Full indexer suite, `FuzzParseRelease` (10s), api + scheduler suites, vet, golangci-lint: all clean. No pre-existing test changed behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)