### PR TITLE
fix(import): stop usenet job-folder leak and keep receipts out of the library (#1542)

### DIFF
--- a/changelog.d/1542-usenet-import-leak.md
+++ b/changelog.d/1542-usenet-import-leak.md
@@ -1,0 +1,18 @@
+### Fixed
+- **Usenet imports no longer leak completed job folders or library receipts**
+  (#1542) — `import.mode` was applied with no protocol distinction, so usenet
+  downloads inherited hardlink/copy behaviour whose only purpose is preserving
+  torrent seeding. The completed job folder was left behind forever — and
+  invisibly, since post-import cleanup removes the client's history entry but
+  not its files (one report: 2.4 GB orphaned from three audiobook grabs).
+  SABnzbd/NZBGet downloads now resolve `auto` and `hardlink` to `move`
+  (explicit `copy` stays honoured for operators who want the client's
+  retention to see finished files). Separately, directory placements copied
+  the whole job tree verbatim, so `.nzb` receipts and `.par2` repair files
+  landed in the library next to the media: hardlink, copy, move, and
+  multi-disc-flatten placements now all skip download artifacts
+  (`.nzb`/`.par2`/`.sfv`/`.srr`/`.srs`/`.diz` — `.nfo`, covers, and cue
+  sheets are deliberately kept). Multi-disc flattening also works under move
+  mode now (flatten via copy, then remove the source), so usenet downloads
+  resolving to move don't lose it. Reported by cleb on Discord with both root
+  causes correctly identified.

--- a/internal/importer/flatten.go
+++ b/internal/importer/flatten.go
@@ -239,6 +239,9 @@ func carryRootSidecars(ctx context.Context, mode, srcRoot, destDir string, reser
 		if audioFlattenExtensions[strings.ToLower(filepath.Ext(name))] {
 			continue
 		}
+		if isDownloadArtifact(name) {
+			continue // receipts/repair files never enter the library (#1542)
+		}
 		if _, taken := reserved[name]; taken {
 			continue
 		}

--- a/internal/importer/import_mode_test.go
+++ b/internal/importer/import_mode_test.go
@@ -305,3 +305,121 @@ func TestImportMode_Settings(t *testing.T) {
 		}
 	}
 }
+
+// TestEffectiveConfiguredMode covers the #1542 usenet remap: hardlink (and
+// the auto default) exists to preserve torrent seeding, which a finished
+// usenet job doesn't do, so both resolve to move for sabnzbd/nzbget
+// downloads. Explicit copy/move/external are honoured, and torrent or
+// client-less imports pass through untouched.
+func TestEffectiveConfiguredMode(t *testing.T) {
+	cases := []struct {
+		mode, clientType, want string
+	}{
+		// Usenet clients: auto and hardlink collapse to move.
+		{"", "sabnzbd", "move"},
+		{"hardlink", "sabnzbd", "move"},
+		{"", "nzbget", "move"},
+		{"hardlink", "nzbget", "move"},
+		// Usenet clients: explicit copy/move/external honoured.
+		{"copy", "sabnzbd", "copy"},
+		{"move", "nzbget", "move"},
+		{"external", "sabnzbd", "external"},
+		// Torrent clients: untouched, including auto.
+		{"", "qbittorrent", ""},
+		{"hardlink", "transmission", "hardlink"},
+		{"copy", "deluge", "copy"},
+		// Client-less imports (drop folder, ABS, manual): untouched.
+		{"", "", ""},
+		{"hardlink", "", "hardlink"},
+	}
+	for _, c := range cases {
+		if got := effectiveConfiguredMode(c.mode, c.clientType); got != c.want {
+			t.Errorf("effectiveConfiguredMode(%q, %q) = %q, want %q", c.mode, c.clientType, got, c.want)
+		}
+	}
+}
+
+// TestDirectoryPlacementSkipsDownloadArtifacts covers the #1542 receipt
+// filtering: .nzb/.par2/.sfv style artifacts in a job folder must not reach
+// the library under any directory placement mode, while media and wanted
+// sidecars (cover art, .nfo, .cue) ride along untouched.
+func TestDirectoryPlacementSkipsDownloadArtifacts(t *testing.T) {
+	mkSrc := func(t *testing.T) string {
+		t.Helper()
+		src := filepath.Join(t.TempDir(), "job")
+		if err := os.MkdirAll(filepath.Join(src, "CD1"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for _, f := range []string{
+			"book.m4b", "cover.jpg", "book.nfo", "book.cue",
+			"receipt.nzb", "book.vol01+02.par2", "book.sfv", "book.srr", "file_id.diz",
+			filepath.Join("CD1", "track.mp3"), filepath.Join("CD1", "cd1.par2"),
+		} {
+			if err := os.WriteFile(filepath.Join(src, f), []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return src
+	}
+	wantKept := []string{"book.m4b", "cover.jpg", "book.nfo", "book.cue", filepath.Join("CD1", "track.mp3")}
+	wantGone := []string{"receipt.nzb", "book.vol01+02.par2", "book.sfv", "book.srr", "file_id.diz", filepath.Join("CD1", "cd1.par2")}
+
+	check := func(t *testing.T, dst string) {
+		t.Helper()
+		for _, f := range wantKept {
+			if _, err := os.Stat(filepath.Join(dst, f)); err != nil {
+				t.Errorf("%s missing from destination: %v", f, err)
+			}
+		}
+		for _, f := range wantGone {
+			if _, err := os.Stat(filepath.Join(dst, f)); err == nil {
+				t.Errorf("download artifact %s reached the library", f)
+			}
+		}
+	}
+
+	t.Run("hardlink", func(t *testing.T) {
+		src, dst := mkSrc(t), filepath.Join(t.TempDir(), "lib")
+		if err := HardlinkDir(src, dst); err != nil {
+			t.Fatalf("HardlinkDir: %v", err)
+		}
+		check(t, dst)
+	})
+	t.Run("copy", func(t *testing.T) {
+		src, dst := mkSrc(t), filepath.Join(t.TempDir(), "lib")
+		if err := CopyDir(src, dst); err != nil {
+			t.Fatalf("CopyDir: %v", err)
+		}
+		check(t, dst)
+		// Copy mode must leave the source intact, artifacts included.
+		if _, err := os.Stat(filepath.Join(src, "receipt.nzb")); err != nil {
+			t.Error("copy mode must not touch the source's artifacts")
+		}
+	})
+	t.Run("move-rename-fastpath", func(t *testing.T) {
+		// src and dst share t.TempDir's filesystem, so MoveDir takes the
+		// os.Rename fast path; artifacts ride along and must be swept after.
+		base := t.TempDir()
+		src := filepath.Join(base, "job")
+		if err := os.MkdirAll(filepath.Join(src, "CD1"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for _, f := range []string{
+			"book.m4b", "cover.jpg", "book.nfo", "book.cue",
+			"receipt.nzb", "book.vol01+02.par2", "book.sfv", "book.srr", "file_id.diz",
+			filepath.Join("CD1", "track.mp3"), filepath.Join("CD1", "cd1.par2"),
+		} {
+			if err := os.WriteFile(filepath.Join(src, f), []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		dst := filepath.Join(base, "lib", "job")
+		if err := MoveDir(src, dst); err != nil {
+			t.Fatalf("MoveDir: %v", err)
+		}
+		check(t, dst)
+		if _, err := os.Stat(src); err == nil {
+			t.Error("move mode must consume the source")
+		}
+	})
+}

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -12,6 +14,42 @@ import (
 
 	"github.com/vavallee/bindery/internal/models"
 )
+
+// downloadArtifactExts are download-client receipt and repair files that ride
+// along in a completed job folder but have no business in the library: the
+// queued .nzb itself, PAR2 repair volumes, and scene checksum/description
+// sidecars (#1542). Directory placements (hardlink, copy, move) skip them so
+// a usenet job's receipts never land next to the imported media. Deliberately
+// NOT included: .nfo, cover art, .cue, booklets — files some users want kept.
+var downloadArtifactExts = map[string]bool{
+	".nzb": true, ".par2": true, ".sfv": true, ".srr": true, ".srs": true, ".diz": true,
+}
+
+// isDownloadArtifact reports whether name has a download-artifact extension
+// (case-insensitive). PAR2 volumes like "x.vol01+02.par2" resolve to ".par2"
+// via filepath.Ext, so they are covered without special-casing.
+func isDownloadArtifact(name string) bool {
+	return downloadArtifactExts[strings.ToLower(filepath.Ext(name))]
+}
+
+// removeDownloadArtifacts deletes download-artifact files anywhere under dir.
+// Used after MoveDir's same-filesystem rename fast path, which moves the job
+// folder wholesale (a rename cannot filter); the copy-based paths skip the
+// artifacts at placement time instead. Best-effort: a receipt that cannot be
+// removed is not worth failing an otherwise-successful import over.
+func removeDownloadArtifacts(dir string) {
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.Type().IsRegular() && isDownloadArtifact(d.Name()) {
+			if rmErr := os.Remove(path); rmErr != nil {
+				slog.Warn("could not remove download artifact from imported folder", "path", path, "error", rmErr)
+			}
+		}
+		return nil
+	})
+}
 
 // templateGroupRe matches one "{...}" group. The content is parsed by
 // renderGroup: either the classic simple form — a bare "{Token}", optionally
@@ -368,8 +406,12 @@ func moveDirCtx(ctx context.Context, src, dst string) error {
 		return fmt.Errorf("create parent dir: %w", err)
 	}
 
-	// Fast path: same filesystem.
+	// Fast path: same filesystem. Rename moves the folder wholesale, so any
+	// download artifacts (.nzb receipts, .par2 volumes) ride along — sweep
+	// them out of the destination afterwards to match the filtering the
+	// copy-based paths do at placement time.
 	if err := os.Rename(src, dst); err == nil {
+		removeDownloadArtifacts(dst)
 		return nil
 	}
 
@@ -498,6 +540,9 @@ func hardlinkDirRooted(srcRoot, dstRoot *os.Root, rel string) error {
 		if !e.Type().IsRegular() && !e.IsDir() {
 			continue // skip symlinks
 		}
+		if e.Type().IsRegular() && isDownloadArtifact(e.Name()) {
+			continue // receipts/repair files never enter the library (#1542)
+		}
 		if e.IsDir() {
 			if err := dstRoot.Mkdir(child, 0o750); err != nil && !os.IsExist(err) {
 				return err
@@ -577,6 +622,9 @@ func copyDirRooted(ctx context.Context, srcRoot, dstRoot *os.Root, rel string) e
 		child := filepath.Join(rel, e.Name())
 		if !e.Type().IsRegular() && !e.IsDir() {
 			continue // skip symlinks and other non-regular entries
+		}
+		if e.Type().IsRegular() && isDownloadArtifact(e.Name()) {
+			continue // receipts/repair files never enter the library (#1542)
 		}
 		if e.IsDir() {
 			if err := dstRoot.Mkdir(child, 0o750); err != nil && !os.IsExist(err) {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -730,8 +730,10 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// that was deliberately copied. The auto (unset) hardlink-vs-copy choice is
 	// made per placement below against the file's real destination root, not
 	// s.libraryDir, because per-author / audiobook roots can be on a separate
-	// mount (#1254).
-	configuredMode := s.configuredImportMode(ctx)
+	// mount (#1254). Usenet downloads remap auto/hardlink to move first —
+	// nothing seeds from a finished usenet job, so leaving the source behind
+	// is a pure disk leak (#1542); see effectiveConfiguredMode.
+	configuredMode := effectiveConfiguredMode(s.configuredImportMode(ctx), cleanupClientType)
 
 	// External mode: skip all file operations and leave the book Wanted so the
 	// library scan can reconcile it after the user's external tool (Calibre,
@@ -964,20 +966,32 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 				return
 			}
 			if srcInfo.IsDir() {
-				// Multi-disc flattening (#886): when enabled AND the resolved
-				// mode is copy/hardlink (NEVER move — the source must keep
-				// seeding and flattening renames files) AND the source is a
-				// multi-disc audiobook, place every track flat into destDir as
-				// "Part 001.ext", … instead of mirroring the disc-folder tree.
-				// The mode restriction is enforced here in the backend even if a
-				// stale UI setting is enabled, because import mode is resolved at
-				// import time. Falls through to the normal dir placement when the
-				// source is single-disc.
-				if (mode == "copy" || mode == "hardlink") &&
+				// Multi-disc flattening (#886): when enabled AND the source is
+				// a multi-disc audiobook, place every track flat into destDir
+				// as "Part 001.ext", … instead of mirroring the disc-folder
+				// tree. flattenAudiobookDir itself only places via copy or
+				// hardlink (it renames files, so it never touches the source);
+				// "move" — which since #1542 is what usenet downloads resolve
+				// to — flattens via copy and then removes the source, the same
+				// copy-then-delete contract as MoveDirCtx's slow path. The
+				// source removal is skipped when the import context was
+				// cancelled: sidecar carry is best-effort and swallows
+				// per-file errors, so only an uncancelled nil return proves
+				// the folder was fully placed.
+				if (mode == "copy" || mode == "hardlink" || mode == "move") &&
 					s.flattenMultiDiscEnabled(ctx) &&
 					isMultiDiscAudiobook(audiobookSource) {
-					slog.Info("flattening multi-disc audiobook", "src", audiobookSource, "dst", destDir, "mode", mode)
-					dirErr = flattenAudiobookDir(importCtx, mode, audiobookSource, destDir)
+					flattenMode := mode
+					if mode == "move" {
+						flattenMode = "copy"
+					}
+					slog.Info("flattening multi-disc audiobook", "src", audiobookSource, "dst", destDir, "mode", flattenMode)
+					dirErr = flattenAudiobookDir(importCtx, flattenMode, audiobookSource, destDir)
+					if dirErr == nil && mode == "move" && importCtx.Err() == nil {
+						if rmErr := os.RemoveAll(audiobookSource); rmErr != nil {
+							slog.Warn("flatten: could not remove source after move-mode flatten", "src", audiobookSource, "error", rmErr)
+						}
+					}
 				} else {
 					switch mode {
 					case "hardlink":

--- a/internal/importer/scanner_flatten_test.go
+++ b/internal/importer/scanner_flatten_test.go
@@ -110,23 +110,25 @@ func TestScannerFlatten_HardlinkMode(t *testing.T) {
 	}
 }
 
-// TestScannerFlatten_MoveModeNeverFlattens asserts the backend enforces the
-// copy/hardlink restriction: with import mode "move" the multi-disc folder is
-// moved whole (disc subfolders preserved), never flattened, even if the setting
-// is on.
-func TestScannerFlatten_MoveModeNeverFlattens(t *testing.T) {
+// TestScannerFlatten_MoveModeFlattensAndConsumesSource asserts the #1542
+// contract: move mode flattens like copy/hardlink and then removes the
+// source. The old "never move" restriction guarded seeding, which a
+// move-mode source doesn't do anyway — and since #1542 usenet downloads
+// resolve to move, keeping the restriction would have silently cost usenet
+// users flattening. Placement is copy-then-delete, matching MoveDirCtx's
+// slow-path semantics.
+func TestScannerFlatten_MoveModeFlattensAndConsumesSource(t *testing.T) {
 	s, dl, downloadPath := flattenScannerFixture(t, "move", true)
 	ctx := context.Background()
 
 	s.tryImportInternal(ctx, dl, downloadPath, "", "", "", nil, nil)
 
 	dest := importedAudiobookDir(t, s)
-	// Disc subfolders must be preserved (no flattening in move mode).
-	if _, err := os.Stat(filepath.Join(dest, "Disc 1", "Track 01.mp3")); err != nil {
-		t.Errorf("move mode must preserve disc-folder layout, missing Disc 1/Track 01.mp3: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(dest, "Part 001.mp3")); !os.IsNotExist(err) {
-		t.Error("move mode must NOT produce flattened Part 001.mp3")
+	assertFlatResult(t, dest)
+
+	// Move mode must consume the source after a successful flatten.
+	if _, err := os.Stat(downloadPath); !os.IsNotExist(err) {
+		t.Errorf("move mode must remove the source after flattening, stat err=%v", err)
 	}
 }
 

--- a/internal/importer/scanner_handoff.go
+++ b/internal/importer/scanner_handoff.go
@@ -66,6 +66,35 @@ func (s *Scanner) configuredImportMode(ctx context.Context) string {
 	return ""
 }
 
+// isUsenetClient reports whether clientType names a usenet download client.
+// Completed usenet job folders have no post-import purpose — nothing seeds
+// from them — which is what justifies effectiveConfiguredMode's remapping.
+func isUsenetClient(clientType string) bool {
+	return clientType == "sabnzbd" || clientType == "nzbget"
+}
+
+// effectiveConfiguredMode maps the operator-set import mode through the
+// protocol of the client that produced the download (#1542). Hardlink — and
+// the auto default that probes for it — exists solely to preserve torrent
+// seeding; for a usenet download it has zero benefit and a real cost: the
+// completed job folder is left behind forever, and invisibly so, because the
+// post-import cleanup removes the client's history entry but not its files.
+// Both therefore resolve to "move" for usenet downloads. Explicit "copy" is
+// honoured (an operator may want the client's own retention or external
+// tooling to see the finished files), as are "move" and "external". Non-usenet
+// clients and client-less imports (drop folder, ABS, manual) pass through
+// untouched.
+func effectiveConfiguredMode(configuredMode, clientType string) string {
+	if !isUsenetClient(clientType) {
+		return configuredMode
+	}
+	switch configuredMode {
+	case "", "hardlink":
+		return "move"
+	}
+	return configuredMode
+}
+
 // resolveImportMode picks the effective placement mode for a destination root.
 // An explicit operator setting (configuredMode) is honoured as-is. For the auto
 // default it returns "hardlink" when a file can actually be hard-linked from


### PR DESCRIPTION
## What

Fixes #1542 (reported by cleb on Discord — both root causes correctly identified, credit to him).

1. **Usenet downloads leaked their completed job folders under hardlink/copy.** `import.mode` is global with no protocol branch; hardlink's only rationale is torrent seeding. Worse than a stale folder: post-import cleanup calls `DeleteHistory(nzoID, deleteFiles=false)`, so the orphaned files aren't even visible in the client's UI anymore. Invisible, unbounded disk leak (2.4 GB from three grabs in the report).
2. **Directory placements carried `.nzb`/`.par2` receipts into the library** — no filtering in `hardlinkDirRooted`, and (broader than reported) none in the copy path, the move path, or the multi-disc flatten sidecar carry either.

## Fix

**Protocol-aware mode** — `effectiveConfiguredMode` remaps sabnzbd/nzbget downloads: `auto → move`, `hardlink → move` (for usenet, hardlink-then-abandon-source is just move with a leak; the placed result is identical). Explicit `copy` stays honoured (client retention / external tooling), `move`/`external` unchanged, torrent and client-less imports (drop folder, ABS, manual) untouched. Applied once at the same place the mode is read once-per-download (#705).

**Artifact filtering** — shared `isDownloadArtifact` deny-list (`.nzb .par2 .sfv .srr .srs .diz`) enforced in hardlink and copy directory placement and the flatten sidecar carry; MoveDir's rename fast path (which moves the folder wholesale) sweeps the destination afterwards. Deliberately kept: `.nfo`, cover art, `.cue`, booklets.

**Flatten under move** — the old copy/hardlink-only gate protected seeding, which move-mode sources never did; with usenet now resolving to move, the gate would have silently cost usenet users multi-disc flattening. Move mode flattens via copy then removes the source (skipped when the import ctx was cancelled — the best-effort sidecar carry swallows per-file errors, so only an uncancelled nil return proves full placement), matching `MoveDirCtx`'s own copy-then-delete contract.

## Tests

- `TestEffectiveConfiguredMode` — full remap matrix (usenet auto/hardlink→move; copy/move/external honoured; torrent + client-less untouched).
- `TestDirectoryPlacementSkipsDownloadArtifacts` — hardlink/copy/move(rename-fastpath) all drop nested artifacts while keeping media, covers, `.nfo`, `.cue`; copy leaves the source untouched, move consumes it.
- `TestScannerFlatten_MoveModeNeverFlattens` → `TestScannerFlatten_MoveModeFlattensAndConsumesSource`, asserting the new contract end-to-end through the scanner.
- Full importer + api suites, vet, golangci-lint: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)