### PR TITLE
feat(storage): explain hardlink and writability failures instead of generic warnings (#1427)

### DIFF
--- a/changelog.d/1427-storage-health-reasons.md
+++ b/changelog.d/1427-storage-health-reasons.md
@@ -1,0 +1,13 @@
+### Fixed
+- **Storage health now says *why*, not just *that*** (#1427) — the
+  "downloads and library can't hardlink" banner and the "not writable"
+  warnings were generic, sending operators hunting through mount tables and
+  permission bits blind. The hardlink probe now names the actual cause
+  (different filesystems; same device ID but cross-mount EXDEV, typical of
+  mergerfs pools, separate bind mounts, and Unraid `/mnt/user` shares; or a
+  filesystem that refuses hardlinks, common on exFAT/NTFS/network shares) in
+  Settings → General. And a failed writability check now reports the uid/gid
+  the process actually runs as versus who owns the directory, with the
+  `user: "UID:GID"` hint when they differ — the classic case being folders
+  prepared for the stack's usual user while the container runs as the
+  distroless default `65532` because `user:` was never set in Compose.

--- a/internal/api/samedevice_unix.go
+++ b/internal/api/samedevice_unix.go
@@ -3,6 +3,8 @@
 package api
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -27,34 +29,6 @@ func statExistingDevice(p string) (os.FileInfo, error) {
 	}
 }
 
-// sameDevice reports whether a and b reside on the same filesystem by
-// comparing OS device IDs — i.e. whether a hardlink import from a to b is
-// possible. Returns false on any stat error or empty input. This duplicates
-// importer.sameDevice intentionally to keep config/api free of an importer
-// dependency.
-func sameDevice(a, b string) bool {
-	if a == "" || b == "" {
-		return false
-	}
-	ai, err := os.Stat(a)
-	if err != nil {
-		return false
-	}
-	bi, err := statExistingDevice(b)
-	if err != nil {
-		return false
-	}
-	aStat, ok := ai.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false
-	}
-	bStat, ok := bi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return false
-	}
-	return aStat.Dev == bStat.Dev
-}
-
 // nearestExistingDir returns p if it is an existing directory, otherwise the
 // nearest existing ancestor directory, or "" if none exists.
 func nearestExistingDir(p string) string {
@@ -72,35 +46,60 @@ func nearestExistingDir(p string) string {
 	return ""
 }
 
-// hardlinkable reports whether downloads in a can actually be hard-linked into
-// b. Matching device IDs are necessary but NOT sufficient — two separate bind
-// mounts (or Unraid /mnt/user shares) report the same st_dev yet os.Link across
-// them fails with EXDEV. So after the cheap same-device gate this confirms with
-// a real link probe (created and cleaned up under the nearest existing
-// directories), which is what keeps the storage-health "share a filesystem"
-// message honest. If a probe file cannot be written it trusts the same-device
-// result rather than reporting a false negative. Mirrors importer.hardlinkable
-// (duplicated to keep api free of an importer dependency).
-func hardlinkable(a, b string) bool {
-	if !sameDevice(a, b) {
-		return false
+// hardlinkableReason reports whether downloads in a can actually be
+// hard-linked into b and, when they can't, WHY — the generic "will copy
+// instead" banner sent users hunting through mount tables blind (#1427).
+// Matching device IDs are necessary but NOT sufficient — two separate bind
+// mounts (or Unraid /mnt/user shares) report the same st_dev yet os.Link
+// across them fails with EXDEV. So after the cheap same-device gate this
+// confirms with a real link probe (created and cleaned up under the nearest
+// existing directories), which is what keeps the storage-health "share a
+// filesystem" message honest. If a probe file cannot be written it trusts the
+// same-device result rather than reporting a false negative. Mirrors
+// importer.hardlinkable (duplicated to keep api free of an importer
+// dependency).
+func hardlinkableReason(a, b string) (bool, string) {
+	if a == "" || b == "" {
+		return false, "the download or library directory is not configured"
+	}
+	ai, err := os.Stat(a)
+	if err != nil {
+		return false, fmt.Sprintf("cannot inspect the download directory: %v", err)
+	}
+	bi, err := statExistingDevice(b)
+	if err != nil {
+		return false, fmt.Sprintf("cannot inspect the library directory: %v", err)
+	}
+	aStat, aOK := ai.Sys().(*syscall.Stat_t)
+	bStat, bOK := bi.Sys().(*syscall.Stat_t)
+	if !aOK || !bOK {
+		return false, "device comparison is not supported on this platform"
+	}
+	if aStat.Dev != bStat.Dev {
+		return false, "the download directory and the library are on different filesystems, so imports copy instead of hardlinking (mount both from the same filesystem to fix)"
 	}
 	aDir := nearestExistingDir(a)
 	bDir := nearestExistingDir(b)
 	if aDir == "" || bDir == "" {
-		return true
+		return true, ""
 	}
 	probe, err := os.CreateTemp(aDir, ".bindery-hlprobe-*")
 	if err != nil {
-		return true
+		return true, ""
 	}
 	name := probe.Name()
 	_ = probe.Close()
 	defer func() { _ = os.Remove(name) }()
 	link := filepath.Join(bDir, filepath.Base(name)+".lnk")
 	if err := os.Link(name, link); err != nil {
-		return false
+		if errors.Is(err, syscall.EXDEV) {
+			return false, "the paths report the same device ID but hardlinks between them fail (EXDEV) — typical of mergerfs pools, separate Docker bind mounts, and Unraid /mnt/user shares; imports will copy instead"
+		}
+		if errors.Is(err, syscall.EPERM) {
+			return false, "the filesystem refused the hardlink (operation not permitted) — common on exFAT, NTFS, and some network shares; imports will copy instead"
+		}
+		return false, fmt.Sprintf("a test hardlink between the two directories failed: %v — imports will copy instead", err)
 	}
 	_ = os.Remove(link)
-	return true
+	return true, ""
 }

--- a/internal/api/samedevice_windows.go
+++ b/internal/api/samedevice_windows.go
@@ -2,16 +2,10 @@
 
 package api
 
-// sameDevice always returns false on Windows because device-ID comparison via
-// syscall.Stat_t is not available — mirrors importer.sameDevice so the storage
-// health endpoint reports downloads/library as not hardlink-able there.
-func sameDevice(_, _ string) bool {
-	return false
-}
-
-// hardlinkable mirrors sameDevice on Windows — device comparison is
-// unavailable, so the storage health endpoint reports downloads/library as not
-// hardlink-able.
-func hardlinkable(_, _ string) bool {
-	return false
+// hardlinkableReason always reports not-hardlinkable on Windows because
+// device-ID comparison via syscall.Stat_t is not available there — mirrors
+// importer.sameDevice's platform split, with the explanation the #1427
+// storage-health surface expects.
+func hardlinkableReason(_, _ string) (bool, string) {
+	return false, "hardlink detection is not supported on Windows; imports will copy instead"
 }

--- a/internal/api/storage.go
+++ b/internal/api/storage.go
@@ -48,6 +48,10 @@ type storageResponse struct {
 	// filesystem, so completed downloads can be hard-linked into the library
 	// instead of copied. False means imports will copy (slower, double disk).
 	Hardlinkable bool `json:"hardlinkable"`
+	// HardlinkReason explains WHY hardlinking is unavailable when
+	// Hardlinkable is false (different filesystems, cross-mount EXDEV,
+	// filesystem refusing links, …); empty when hardlinking works (#1427).
+	HardlinkReason string `json:"hardlinkReason,omitempty"`
 }
 
 // statusFor builds a dirStatus from config.CheckDir.
@@ -79,12 +83,14 @@ func (h *StorageHandler) Get(w http.ResponseWriter, _ *http.Request) {
 		dirs = append(dirs, statusFor("audiobook-download", cfg.AudiobookDownloadDir))
 	}
 
+	linkable, linkReason := hardlinkableReason(cfg.DownloadDir, cfg.LibraryDir)
 	writeJSON(w, http.StatusOK, storageResponse{
 		DownloadDir:          cfg.DownloadDir,
 		AudiobookDownloadDir: cfg.AudiobookDownloadDir,
 		LibraryDir:           cfg.LibraryDir,
 		AudiobookDir:         cfg.AudiobookDir,
 		Dirs:                 dirs,
-		Hardlinkable:         hardlinkable(cfg.DownloadDir, cfg.LibraryDir),
+		Hardlinkable:         linkable,
+		HardlinkReason:       linkReason,
 	})
 }

--- a/internal/api/storage_test.go
+++ b/internal/api/storage_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/vavallee/bindery/internal/config"
@@ -80,7 +82,7 @@ func TestStorageHandler_HardlinkableSameRoot(t *testing.T) {
 }
 
 func TestStorageHandler_HardlinkableFieldPresentForMissingPaths(t *testing.T) {
-	// When a path can't be stat'd, sameDevice returns false; assert the field
+	// When a path can't be stat'd, the probe reports not-hardlinkable; assert the field
 	// is a definite boolean (best-effort cross-filesystem coverage).
 	cfg := &config.Config{DownloadDir: "/nonexistent-aaa", LibraryDir: "/nonexistent-bbb"}
 	got := getStorage(t, cfg)
@@ -159,4 +161,41 @@ func TestStorageHandler_EmptyAudiobookDownloadDirPassesThrough(t *testing.T) {
 	if got.AudiobookDownloadDir != "" {
 		t.Errorf("AudiobookDownloadDir = %q, want empty so the UI can fall back to DownloadDir", got.AudiobookDownloadDir)
 	}
+}
+
+// TestStorageHandler_HardlinkReason covers #1427: when hardlinking is
+// unavailable the response must say WHY, and when it works the reason must be
+// empty so the UI shows the green state alone.
+func TestStorageHandler_HardlinkReason(t *testing.T) {
+	t.Run("healthy has no reason", func(t *testing.T) {
+		tmp := t.TempDir()
+		cfg := &config.Config{DownloadDir: tmp, LibraryDir: filepath.Join(tmp, "lib")}
+		got := getStorage(t, cfg)
+		if !got.Hardlinkable || got.HardlinkReason != "" {
+			t.Errorf("same-root paths: hardlinkable=%v reason=%q, want true and empty", got.Hardlinkable, got.HardlinkReason)
+		}
+	})
+	t.Run("unstattable paths carry a reason", func(t *testing.T) {
+		cfg := &config.Config{DownloadDir: "/nonexistent-aaa", LibraryDir: "/nonexistent-bbb"}
+		got := getStorage(t, cfg)
+		if got.Hardlinkable {
+			t.Fatal("unstattable paths must not be hardlinkable")
+		}
+		if got.HardlinkReason == "" {
+			t.Error("non-hardlinkable state must carry a reason")
+		}
+	})
+	t.Run("different filesystems named as the cause", func(t *testing.T) {
+		if runtime.GOOS != "linux" {
+			t.Skip("uses /proc to guarantee a distinct filesystem; linux only")
+		}
+		cfg := &config.Config{DownloadDir: "/proc", LibraryDir: t.TempDir()}
+		got := getStorage(t, cfg)
+		if got.Hardlinkable {
+			t.Fatal("/proc and tmp must not be hardlinkable")
+		}
+		if !strings.Contains(got.HardlinkReason, "different filesystems") {
+			t.Errorf("reason should name different filesystems, got %q", got.HardlinkReason)
+		}
+	})
 }

--- a/internal/config/owner_unix.go
+++ b/internal/config/owner_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// writabilityIdentity describes who the process is versus who owns the
+// directory, so a "not writable" warning is self-diagnosing (#1427). The
+// recurring support case: an operator prepares folders for their stack's
+// user (typically 1000:1000, linuxserver-style) but never sets `user:` on
+// the container, so Bindery runs as the distroless default UID 65532 and the
+// folder genuinely isn't writable — while "the permissions are right" from
+// the operator's point of view. Naming both identities in the message turns
+// that thread-length back-and-forth into a one-line fix.
+func writabilityIdentity(info os.FileInfo) string {
+	msg := fmt.Sprintf("process runs as uid=%d gid=%d", os.Getuid(), os.Getgid())
+	if st, ok := info.Sys().(*syscall.Stat_t); ok {
+		msg += fmt.Sprintf("; directory is owned by uid=%d gid=%d mode=%s", st.Uid, st.Gid, info.Mode().Perm())
+		if int(st.Uid) != os.Getuid() {
+			msg += fmt.Sprintf(" — if that owner is intentional, run the container with user: \"%d:%d\"", st.Uid, st.Gid)
+		}
+	}
+	return msg
+}

--- a/internal/config/owner_windows.go
+++ b/internal/config/owner_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package config
+
+import "os"
+
+// writabilityIdentity has no useful uid/gid story on Windows — os.Getuid
+// returns -1 and FileInfo.Sys carries no POSIX ownership — so the enriched
+// "who am I vs who owns it" diagnostics (#1427) are a no-op there.
+func writabilityIdentity(_ os.FileInfo) string {
+	return ""
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -166,6 +166,14 @@ func checkDir(logger *slog.Logger, envVar, path string) error {
 	// Probe writability by creating and immediately removing a temporary file.
 	f, err := os.CreateTemp(path, ".bindery-write-check-*")
 	if err != nil {
+		// Name who the process is and who owns the directory (#1427): the
+		// classic failure is folders prepared for the stack's usual user
+		// while the container runs as the distroless default 65532 because
+		// `user:` was never set — invisible from the bare "permission
+		// denied".
+		if identity := writabilityIdentity(info); identity != "" {
+			return fmt.Errorf("not writable: %w (%s)", err, identity)
+		}
 		return fmt.Errorf("not writable: %w", err)
 	}
 	_ = f.Close()

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -254,5 +255,32 @@ func TestValidate_NilLogger(t *testing.T) {
 	}
 	if err := cfg.Validate(nil); err != nil {
 		t.Errorf("nil logger should not cause error; got: %v", err)
+	}
+}
+
+// TestCheckDir_NotWritableNamesProcessIdentity covers the #1427 diagnostics:
+// a permission failure must name the uid/gid the process runs as and the
+// directory's owner, so the recurring "the folders have the right
+// permissions" confusion (folders prepared for the stack's user while the
+// container runs as the distroless default 65532) is self-diagnosing.
+func TestCheckDir_NotWritableNamesProcessIdentity(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uid/gid identity diagnostics are unix-only")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root can write anywhere; the probe cannot fail")
+	}
+	dir := filepath.Join(t.TempDir(), "readonly")
+	if err := os.Mkdir(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	h := CheckDir(dir)
+	if h.Writable {
+		t.Fatal("0o555 dir must not be writable")
+	}
+	for _, want := range []string{"process runs as uid=", "owned by uid="} {
+		if !strings.Contains(h.Reason, want) {
+			t.Errorf("reason %q should contain %q", h.Reason, want)
+		}
 	}
 }

--- a/web/src/api/system.ts
+++ b/web/src/api/system.ts
@@ -39,6 +39,7 @@ export interface StorageHealth {
   audiobookDir: string
   dirs: StorageDirStatus[]
   hardlinkable: boolean
+  hardlinkReason?: string
 }
 
 export const systemApi = {

--- a/web/src/pages/settings/GeneralTab.storageHealth.test.tsx
+++ b/web/src/pages/settings/GeneralTab.storageHealth.test.tsx
@@ -69,6 +69,7 @@ describe('GeneralTab storage health', () => {
   it('renders a failing reason for a missing dir and the cross-filesystem warning', async () => {
     vi.mocked(api.getStorage).mockResolvedValue(storage({
       hardlinkable: false,
+      hardlinkReason: 'the download directory and the library are on different filesystems, so imports copy instead of hardlinking',
       dirs: [
         { name: 'download', path: '/downloads', exists: true, writable: true },
         { name: 'library', path: '/books', exists: false, writable: false, reason: 'directory does not exist' },
@@ -81,5 +82,7 @@ describe('GeneralTab storage health', () => {
     expect(screen.getByText(/directory does not exist/)).toBeTruthy()
     // Different-filesystem notice ("imports will copy, not hardlink").
     expect(screen.getByText('settings.general.storageHardlinkWarning')).toBeTruthy()
+    // The specific WHY from the backend is rendered under it (#1427).
+    expect(screen.getByText(/different filesystems/)).toBeTruthy()
   })
 })

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -405,6 +405,9 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
             ) : (
               <p className="text-xs text-amber-600 dark:text-amber-400 border-t border-slate-200 dark:border-zinc-800 pt-3">
                 {t('settings.general.storageHardlinkWarning')}
+                {storage.hardlinkReason && (
+                  <span className="block mt-1 text-slate-600 dark:text-zinc-400">{storage.hardlinkReason}</span>
+                )}
               </p>
             )
           )}


### PR DESCRIPTION
Closes #1427.

Two diagnostics upgrades to storage health, both driven by recurring support threads (the mergerfs hardlink thread on Discord, the "folders have write permission but it complains" report on Reddit):

**1. Hardlink probe says why.** `hardlinkableReason` replaces the bare bool on `/api/v1/system/storage` and distinguishes: different filesystems (device IDs differ) · same device ID but cross-mount EXDEV (mergerfs pools, separate bind mounts, Unraid `/mnt/user`) · filesystem refusing links (exFAT/NTFS/network shares) · probe error passthrough. Settings → General renders the reason under the existing warning banner.

**2. Writability failures name both identities.** `checkDir` now appends `process runs as uid=… gid=…; directory is owned by uid=… gid=… mode=…` with a `user: "UID:GID"` hint when owner ≠ process. This makes the distroless-65532-vs-folder-owner footgun self-diagnosing — the startup PUID assertion only fires when PUID is explicitly set, so people who never set it used to get a bare "permission denied".

Platform-split unix/windows (windows keeps an honest "not supported" reason; identity diagnostics are a no-op there — `GOOS=windows` build verified). Dead `sameDevice`/`hardlinkable` wrappers in the api copy removed post-refactor.

Tests: reason-empty-when-healthy, reason-on-unstattable, different-filesystem reason via `/proc` (linux-only subtest); config identity test on a 0o555 dir (skips as root); frontend storage-health test asserts the reason renders. Full api + config suites, vet, golangci-lint, tsc, eslint, vitest clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)