### PR TITLE
fix(api): hint at VPN killswitch when LAN test connections time out (#1474)

### DIFF
--- a/changelog.d/1474-vpn-timeout-hint.md
+++ b/changelog.d/1474-vpn-timeout-hint.md
@@ -1,0 +1,9 @@
+### Fixed
+- **VPN-killswitch timeouts are named, not just reported** (#1474) — when an
+  ABS or Calibre-plugin "Test connection" times out against a LAN-shaped host
+  (private IP, bare Docker hostname, `.local`/`.lan` suffix), the error now
+  points at the usual culprit: Bindery sharing a VPN container's network
+  (`network_mode: service:gluetun`) whose killswitch drops LAN traffic, with
+  the `FIREWALL_OUTBOUND_SUBNETS` fix named inline. Real upstream errors
+  (auth failures, refused connections) and public hosts keep their unmodified
+  message. Complements the "Running Bindery behind a VPN" deployment docs.

--- a/internal/api/abs.go
+++ b/internal/api/abs.go
@@ -410,7 +410,10 @@ func (h *ABSHandler) writeProbeError(w http.ResponseWriter, logMsg, baseURL stri
 		}
 	}
 	slog.Warn(logMsg, "host", redactABSHost(baseURL), "error", err)
-	writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+	// A bare Client.Timeout against a LAN host is the VPN-killswitch
+	// signature (#1474) — say so instead of leaving the operator with a
+	// timeout that contradicts what their browser sees.
+	writeJSON(w, http.StatusBadGateway, map[string]string{"error": lanTimeoutHint(baseURL, err)})
 }
 
 func redactABSHost(raw string) string {

--- a/internal/api/calibre.go
+++ b/internal/api/calibre.go
@@ -165,7 +165,9 @@ func (h *CalibreHandler) Test(w http.ResponseWriter, r *http.Request) {
 		version, err := pc.Health(r.Context())
 		if err != nil {
 			slog.Warn("calibre test failed: plugin health", "plugin_url", cfg.PluginURL, "error", err)
-			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+			// Timeout against a LAN host → likely a VPN-container
+			// killswitch dropping LAN traffic; name it (#1474).
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": lanTimeoutHint(cfg.PluginURL, err)})
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]string{

--- a/internal/api/lanhint.go
+++ b/internal/api/lanhint.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// lanTimeoutHint returns err's message, appending a VPN-killswitch pointer
+// when a connection test timed out against a LAN-looking host (#1474). The
+// recurring case: Bindery shares a VPN container's network namespace
+// (network_mode: service:gluetun) and the killswitch silently drops
+// LAN-bound packets, so "Test connection" to an on-LAN Audiobookshelf or
+// Calibre dies with a bare Client.Timeout while the same service loads fine
+// in a browser. The raw timeout gives the operator nothing to go on; naming
+// the likely cause and the fix turns a support thread into a one-liner.
+//
+// Only fires for a genuine timeout AND a private/LAN-shaped host, so real
+// upstream errors (auth failures, 404s, refused connections) and public
+// hosts keep their unmodified message. Host shape is judged without DNS
+// lookups — the error path must never block on resolution.
+func lanTimeoutHint(rawURL string, err error) string {
+	if err == nil {
+		return ""
+	}
+	if !isTimeoutErr(err) {
+		return err.Error()
+	}
+	u, perr := url.Parse(rawURL)
+	if perr != nil || !looksLANHost(u.Hostname()) {
+		return err.Error()
+	}
+	return err.Error() + " — the host looks LAN-local; if Bindery runs inside a VPN container's network (network_mode: service:gluetun), the VPN killswitch blocks LAN traffic by default — allow your LAN CIDR via FIREWALL_OUTBOUND_SUBNETS on the VPN container (see the deployment docs, \"Running Bindery behind a VPN\")"
+}
+
+// isTimeoutErr reports whether err is a deadline/timeout failure, from either
+// the context layer or the net stack (http.Client timeouts satisfy net.Error).
+func isTimeoutErr(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}
+
+// looksLANHost reports whether host is plausibly on the operator's LAN:
+// a private/loopback/link-local IP literal, a bare single-label hostname
+// (Docker service names, mDNS-less LAN hosts), or a conventional local
+// suffix. Deliberately lookup-free.
+func looksLANHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast()
+	}
+	if !strings.Contains(host, ".") {
+		return true
+	}
+	lower := strings.ToLower(host)
+	for _, suffix := range []string{".local", ".lan", ".internal", ".home", ".home.arpa"} {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/lanhint_test.go
+++ b/internal/api/lanhint_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// timeoutErr satisfies net.Error with Timeout()=true, mirroring what
+// http.Client produces when its overall Timeout fires.
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "Client.Timeout exceeded while awaiting headers" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return true }
+
+// TestLanTimeoutHint covers #1474: only a timeout against a LAN-shaped host
+// earns the VPN-killswitch hint; every other combination keeps the original
+// message untouched.
+func TestLanTimeoutHint(t *testing.T) {
+	timeout := error(timeoutErr{})
+	wrappedDeadline := fmt.Errorf("Get \"http://abs:13378/ping\": %w", context.DeadlineExceeded)
+	refused := errors.New("connection refused")
+
+	cases := []struct {
+		name     string
+		url      string
+		err      error
+		wantHint bool
+	}{
+		{"timeout + RFC1918 IP", "http://192.168.1.4:13378", timeout, true},
+		{"timeout + loopback", "http://127.0.0.1:8080", timeout, true},
+		{"timeout + bare docker hostname", "http://audiobookshelf:13378", timeout, true},
+		{"timeout + .local suffix", "http://abs.local:13378", timeout, true},
+		{"wrapped deadline + bare hostname", "http://abs:13378", wrappedDeadline, true},
+		{"timeout + public host", "https://api.audiobookshelf.org", timeout, false},
+		{"timeout + public IP", "http://8.8.8.8", timeout, false},
+		{"non-timeout + LAN IP", "http://192.168.1.4:13378", refused, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := lanTimeoutHint(c.url, c.err)
+			if !strings.HasPrefix(got, c.err.Error()) {
+				t.Errorf("message must start with the original error, got %q", got)
+			}
+			hinted := strings.Contains(got, "FIREWALL_OUTBOUND_SUBNETS")
+			if hinted != c.wantHint {
+				t.Errorf("hint=%v, want %v (got %q)", hinted, c.wantHint, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1474 (the docs half shipped in #1475; this is the remaining error-text half).

`lanTimeoutHint` appends the gluetun killswitch pointer (`FIREWALL_OUTBOUND_SUBNETS`, with a docs reference) to ABS and Calibre-plugin test-connection failures — but only when **both** conditions hold:

- genuine timeout (`net.Error.Timeout()` or wrapped `context.DeadlineExceeded`), and
- LAN-shaped host: private/loopback/link-local IP literal, bare single-label hostname (Docker service names), or `.local`/`.lan`/`.internal`/`.home`/`.home.arpa` suffix — judged **without DNS lookups** so the error path never blocks.

Auth failures, refused connections, 404s, and public hosts keep their unmodified messages. The calibredb binary mode is a local exec and is deliberately not hinted.

Tests: 8-case matrix (RFC1918/loopback/bare-hostname/.local/wrapped-deadline hint; public host/IP and non-timeout don't). Full api suite, vet, golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)