### PR TITLE
feat(calibre): push path remap for mismatched container mounts (#1346)

### DIFF
--- a/changelog.d/1346-calibre-push-path-remap.md
+++ b/changelog.d/1346-calibre-push-path-remap.md
@@ -1,0 +1,12 @@
+### Added
+- **Calibre push path remap** (#1346) — Bindery hands the Bindery Bridge
+  plugin the exact path it stores each book at, and the plugin opens that
+  path on *its* side of the container boundary; when the two containers mount
+  the library at different points (the recurring Unraid case), every push
+  failed with "No such file or directory". A new **Settings → Calibre → Push
+  path remap** field (plugin mode) translates Bindery's library prefix to the
+  Calibre container's before the push, using the same `from:to[,from:to]`
+  grammar as `BINDERY_DOWNLOAD_PATH_REMAP` — e.g.
+  `/books:/mnt/user/media/books`. Malformed pairs are rejected at save time;
+  empty means no translation, and aligning the mounts remains the preferred
+  zero-config setup.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -347,7 +347,7 @@ func main() {
 	calibreCfg := api.LoadCalibreConfig(ctxBoot, settingsRepo)
 	currentMode := api.LoadCalibreMode(ctxBoot, settingsRepo)
 	if currentMode == calibre.ModePlugin {
-		pluginClient := calibre.NewPluginClient(calibreCfg.PluginURL, calibreCfg.PluginAPIKey)
+		pluginClient := calibre.NewPluginClient(calibreCfg.PluginURL, calibreCfg.PluginAPIKey).WithPushPathRemap(calibreCfg.PushPathRemap)
 		importScanner.WithCalibre(modeResolver, pluginClient)
 		slog.Info("calibre integration enabled", "mode", "plugin", "url", calibreCfg.PluginURL)
 	} else {

--- a/internal/api/calibre.go
+++ b/internal/api/calibre.go
@@ -22,6 +22,14 @@ const (
 	SettingCalibreSyncOnStartup = "calibre.sync_on_startup"
 	SettingCalibrePluginURL     = "calibre.plugin_url"
 	SettingCalibrePluginAPIKey  = "calibre.plugin_api_key"
+	// SettingCalibrePushPathRemap translates Bindery library paths to the
+	// prefix the Calibre (Bridge plugin) container sees before a push, in
+	// pathmap "from:to[,from:to]" form — e.g. "/books:/mnt/user/media/books".
+	// Bindery hands the Bridge the path it stores a book at and the plugin
+	// opens it on ITS side; when the two containers mount the library at
+	// different points every push fails with "No such file or directory"
+	// (#1346, Unraid setups mostly). Empty = no translation.
+	SettingCalibrePushPathRemap = "calibre.push_path_remap"
 )
 
 // SettingCWAIngestPath is the directory bindery copies finished ebook
@@ -96,6 +104,7 @@ func LoadCalibreConfig(ctx context.Context, settings *db.SettingsRepo) calibre.C
 		SyncOnStartup: strings.EqualFold(get(SettingCalibreSyncOnStartup), "true"),
 		PluginURL:     get(SettingCalibrePluginURL),
 		PluginAPIKey:  get(SettingCalibrePluginAPIKey),
+		PushPathRemap: get(SettingCalibrePushPathRemap),
 	}
 }
 

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/metadata/hardcover"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/pathmap"
 )
 
 // SettingDefaultMediaType is the KV key for the global media-type default
@@ -451,6 +452,16 @@ func validateSettingValue(key, value string) error {
 			return nil
 		default:
 			return fmt.Errorf("metadata.primary_provider %q is not one of: openlibrary, dnb", value)
+		}
+	case SettingCalibrePushPathRemap:
+		if value == "" {
+			return nil
+		}
+		// Same "from:to[,from:to]" grammar as BINDERY_DOWNLOAD_PATH_REMAP;
+		// reject malformed pairs at save time instead of silently skipping
+		// them at push time (#1346).
+		if err := pathmap.Validate(value); err != nil {
+			return fmt.Errorf("push_path_remap: %w", err)
 		}
 	case SettingCalibrePluginURL:
 		if value == "" {

--- a/internal/api/settings_handler_test.go
+++ b/internal/api/settings_handler_test.go
@@ -585,3 +585,19 @@ func mustJSON(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
+
+// TestValidateSettingValue_CalibrePushPathRemap covers the #1346 save-time
+// grammar check: valid from:to pairs (and empty) pass, malformed pairs are
+// rejected instead of being silently skipped at push time.
+func TestValidateSettingValue_CalibrePushPathRemap(t *testing.T) {
+	for _, v := range []string{"", "/books:/mnt/user/media/books", "/a:/b,/c:/d"} {
+		if err := validateSettingValue(SettingCalibrePushPathRemap, v); err != nil {
+			t.Errorf("value %q should validate, got %v", v, err)
+		}
+	}
+	for _, v := range []string{"/books", "/books:", ":/books", "/a:/b,broken"} {
+		if err := validateSettingValue(SettingCalibrePushPathRemap, v); err == nil {
+			t.Errorf("value %q should be rejected", v)
+		}
+	}
+}

--- a/internal/calibre/client.go
+++ b/internal/calibre/client.go
@@ -32,6 +32,7 @@ type Config struct {
 	SyncOnStartup bool   // run a library import when Bindery starts
 	PluginURL     string // base URL of the Bindery Bridge Calibre plugin (mode=plugin)
 	PluginAPIKey  string // bearer token for the plugin's HTTP API (mode=plugin)
+	PushPathRemap string // pathmap "from:to" pairs translating Bindery paths to the plugin container's mounts (#1346)
 }
 
 // runner is the shape of exec.CommandContext, abstracted for tests.

--- a/internal/calibre/plugin_client.go
+++ b/internal/calibre/plugin_client.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/vavallee/bindery/internal/pathmap"
 )
 
 // ErrAlreadyInCalibre is returned by PluginClient.Add when the plugin
@@ -30,6 +32,9 @@ type PluginClient struct {
 	baseURL string
 	apiKey  string
 	http    *http.Client
+	// remap translates Bindery-side library paths to the prefix the plugin's
+	// container sees before they go over the wire (#1346). nil = passthrough.
+	remap *pathmap.Remapper
 
 	capMu                 sync.Mutex
 	capabilitiesLoaded    bool
@@ -48,6 +53,29 @@ func NewPluginClient(baseURL, apiKey string) *PluginClient {
 	}
 }
 
+// WithPushPathRemap installs a pathmap "from:to[,from:to]" translation applied
+// to every file path sent to the plugin (#1346). Bindery hands the Bridge the
+// path it stores a book at and the plugin opens that path on ITS side of the
+// container boundary; when the two containers mount the library at different
+// points (the recurring Unraid case) every push fails with "No such file or
+// directory". The spec is parsed once here; empty or all-malformed input
+// leaves the client in passthrough mode. Returns the client for chaining.
+func (c *PluginClient) WithPushPathRemap(spec string) *PluginClient {
+	if r := pathmap.Parse(spec); !r.Empty() {
+		c.remap = r
+	}
+	return c
+}
+
+// pushPathFor returns the path to put on the wire for filePath: remapped when
+// a translation is configured, verbatim otherwise.
+func (c *PluginClient) pushPathFor(filePath string) string {
+	if c.remap == nil {
+		return filePath
+	}
+	return c.remap.Apply(filePath)
+}
+
 // Add POSTs the file path and Bindery metadata to the plugin and returns the
 // Calibre book id.
 // Retries once on 503 (library swap in progress); all other non-2xx
@@ -63,7 +91,9 @@ func (c *PluginClient) Add(ctx context.Context, filePath string, meta Metadata) 
 			legacyPayload = true
 		}
 	}
-	return c.addWithRetry(ctx, filePath, meta, 1, legacyPayload)
+	// Translate once, up front: addWithRetry recurses for the 503 and
+	// legacy-payload retries and must carry the already-translated path.
+	return c.addWithRetry(ctx, c.pushPathFor(filePath), meta, 1, legacyPayload)
 }
 
 func (c *PluginClient) addWithRetry(ctx context.Context, filePath string, meta Metadata, retries int, legacyPayload bool) (int64, error) {

--- a/internal/calibre/plugin_client_test.go
+++ b/internal/calibre/plugin_client_test.go
@@ -238,3 +238,55 @@ func TestPluginClient_TrimsTrailingSlash(t *testing.T) {
 		t.Errorf("baseURL should be trimmed: %q", c.baseURL)
 	}
 }
+
+// TestPluginClient_AddAppliesPushPathRemap covers #1346: with a remap
+// configured, the path that goes over the wire is the Calibre container's
+// view of the file, while paths outside every mapped prefix pass through
+// verbatim. An empty spec leaves the client in passthrough mode.
+func TestPluginClient_AddAppliesPushPathRemap(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v1/health" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"plugin_version":"0.5.0","calibre_version":"9.8","library":"/books","capabilities":["book_metadata"]}`))
+			return
+		}
+		var body struct {
+			Path string `json:"path"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotPath = body.Path
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":7,"duplicate":false}`))
+	}))
+	defer srv.Close()
+
+	t.Run("remapped prefix", func(t *testing.T) {
+		c := NewPluginClient(srv.URL, "k").WithPushPathRemap("/books:/mnt/user/media/books")
+		if _, err := c.Add(context.Background(), "/books/Robin Hobb/Assassins Apprentice (1995)/book.epub", Metadata{Title: "x"}); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		want := "/mnt/user/media/books/Robin Hobb/Assassins Apprentice (1995)/book.epub"
+		if gotPath != want {
+			t.Errorf("wire path = %q, want %q", gotPath, want)
+		}
+	})
+	t.Run("path outside mapped prefix passes through", func(t *testing.T) {
+		c := NewPluginClient(srv.URL, "k").WithPushPathRemap("/books:/mnt/user/media/books")
+		if _, err := c.Add(context.Background(), "/audiobooks/x.epub", Metadata{Title: "x"}); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		if gotPath != "/audiobooks/x.epub" {
+			t.Errorf("wire path = %q, want passthrough", gotPath)
+		}
+	})
+	t.Run("empty spec is passthrough", func(t *testing.T) {
+		c := NewPluginClient(srv.URL, "k").WithPushPathRemap("")
+		if _, err := c.Add(context.Background(), "/books/y.epub", Metadata{Title: "x"}); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		if gotPath != "/books/y.epub" {
+			t.Errorf("wire path = %q, want verbatim", gotPath)
+		}
+	})
+}

--- a/internal/calibre/syncer.go
+++ b/internal/calibre/syncer.go
@@ -100,7 +100,7 @@ func NewSyncer(books BookLister) *Syncer {
 	return &Syncer{
 		books: books,
 		newClient: func(cfg Config) pluginPusher {
-			return NewPluginClient(cfg.PluginURL, cfg.PluginAPIKey)
+			return NewPluginClient(cfg.PluginURL, cfg.PluginAPIKey).WithPushPathRemap(cfg.PushPathRemap)
 		},
 	}
 }

--- a/web/src/pages/settings/CalibreTab.tsx
+++ b/web/src/pages/settings/CalibreTab.tsx
@@ -66,6 +66,7 @@ function CalibreSection({
   const [libraryPathSaveResult, libraryPathSave] = useSaveResult()
   const [binaryPathSaveResult, binaryPathSave] = useSaveResult()
   const [pluginUrlSaveResult, pluginUrlSave] = useSaveResult()
+  const [pushRemapSaveResult, pushRemapSave] = useSaveResult()
   const [pluginKeySaveResult, pluginKeySave] = useSaveResult()
   const [cwaPathSaveResult, cwaPathSave] = useSaveResult()
   const [importProgress, setImportProgress] = useState<CalibreImportProgress | null>(null)
@@ -346,6 +347,36 @@ function CalibreSection({
               </button>
             </div>
             {saveError?.key === 'calibre.plugin_api_key' && (
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1">{saveError.msg}</p>
+            )}
+          </div>
+        )}
+
+        {mode === 'plugin' && (
+          <div>
+            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">Push path remap</label>
+            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
+              Optional. If the Calibre container mounts your library at a different path than Bindery,
+              map Bindery&rsquo;s prefix to Calibre&rsquo;s as <code className="font-mono">from:to</code> pairs
+              (comma separated), e.g. <code className="font-mono">/books:/mnt/user/media/books</code>.
+              Leave empty when both containers see the library at the same path.
+            </p>
+            <div className="flex gap-2">
+              <input
+                value={settings['calibre.push_path_remap'] ?? ''}
+                onChange={e => setSettings(s => ({ ...s, 'calibre.push_path_remap': e.target.value }))}
+                placeholder="/books:/mnt/user/media/books"
+                className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+              />
+              <button
+                onClick={() => pushRemapSave(() => saveSettingWithErrorThrowing('calibre.push_path_remap'))}
+                disabled={saving === 'calibre.push_path_remap'}
+                className={`px-3 py-2 rounded text-xs font-medium disabled:opacity-50 ${pushRemapSaveResult === 'saved' ? 'bg-emerald-500' : pushRemapSaveResult === 'error' ? 'bg-red-600' : 'bg-emerald-600 hover:bg-emerald-500'}`}
+              >
+                {pushRemapSaveResult === 'saved' ? 'Saved ✓' : pushRemapSaveResult === 'error' ? 'Error' : saving === 'calibre.push_path_remap' ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+            {saveError?.key === 'calibre.push_path_remap' && (
               <p className="text-xs text-red-600 dark:text-red-400 mt-1">{saveError.msg}</p>
             )}
           </div>


### PR DESCRIPTION
Closes #1346 (Kedryn's "Push to Calibre" — all 1891 pushes failing with `No such file or directory` because Bindery's `/books` isn't where the Calibre container mounts the library on his Unraid box).

**What**: `calibre.push_path_remap` setting + **Settings → Calibre → Push path remap** field (plugin mode only). Translates Bindery's library prefix to the Calibre container's view before the path goes to the Bridge, using the same `pathmap` `from:to[,from:to]` grammar as `BINDERY_DOWNLOAD_PATH_REMAP` — e.g. `/books:/mnt/user/media/books`.

**Where the translation lives**: top of `PluginClient.Add`, so
- both call sites (bulk sync + per-import mirror) get it for free,
- the 503/legacy-payload retries carry the already-translated path (no double-apply),
- local metadata/edition reads keep the Bindery-side path,
- calibredb binary mode (local exec) is untouched.

Spec parsed once per client (`WithPushPathRemap`); empty/malformed → passthrough. Save-time `pathmap.Validate` rejects bad pairs with a visible error instead of silently skipping at push time. Bulk sync rebuilds its client per run so setting changes apply live; the per-import client reads it at boot, consistent with how plugin URL/key already behave.

**Tests**: wire-path assertions (remapped prefix, outside-prefix passthrough, empty spec), settings validation matrix. calibre + importer suites, vet, golangci-lint, tsc, eslint, SettingsPage vitest — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)