### PR TITLE
fix(api): honor selected download format (#1561)

### DIFF
--- a/changelog.d/1561-audiobook-download-format.md
+++ b/changelog.d/1561-audiobook-download-format.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Dual-format audiobook downloads** (#1561) — honor the selected format so audiobook downloads no longer return an ebook or fail through a stale legacy path.

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
 )
 
 type FileHandler struct {
@@ -75,14 +76,35 @@ func (h *FileHandler) Download(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Prefer the legacy FilePath, fall back to per-format columns for books
-	// created after the dual-format schema landed (migration 026+).
-	filePath := book.FilePath
-	if filePath == "" {
+	// Dual-format book pages tell us which slot the user selected. Honour that
+	// before consulting the legacy FilePath column, which can point at the other
+	// format (or at a file that no longer exists). Legacy single-format rows may
+	// not have their per-format view populated yet, so retain a type-safe fallback
+	// for those records. Callers that omit format (including OPDS) keep the
+	// historical preference order.
+	var filePath string
+	switch r.URL.Query().Get("format") {
+	case models.MediaTypeEbook:
 		filePath = book.EbookFilePath
-	}
-	if filePath == "" {
+		if filePath == "" && book.MediaType != models.MediaTypeAudiobook {
+			filePath = book.FilePath
+		}
+	case models.MediaTypeAudiobook:
 		filePath = book.AudiobookFilePath
+		if filePath == "" && book.MediaType == models.MediaTypeAudiobook {
+			filePath = book.FilePath
+		}
+	case "":
+		filePath = book.FilePath
+		if filePath == "" {
+			filePath = book.EbookFilePath
+		}
+		if filePath == "" {
+			filePath = book.AudiobookFilePath
+		}
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid format"})
+		return
 	}
 	if filePath == "" {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no file available for this book"})

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -304,6 +304,129 @@ func TestFileDownload_DualFormatHonoursEbookQuery(t *testing.T) {
 	}
 }
 
+func TestFileDownload_LegacyEbookPathWithFormatQuery(t *testing.T) {
+	h, books, author, ctx, tmp := fileFixture(t)
+	path := filepath.Join(tmp, "legacy.epub")
+	if err := os.WriteFile(path, []byte("legacy ebook bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rows created before per-format paths were introduced only have FilePath.
+	book := &models.Book{
+		ForeignID: "OL-LEGACY-EBOOK", AuthorID: author.ID, Title: "Legacy ebook",
+		MediaType: models.MediaTypeEbook, FilePath: path,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.Update(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReqFormat(book.ID, models.MediaTypeEbook))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Equal(rec.Body.Bytes(), []byte("legacy ebook bytes")) {
+		t.Errorf("body mismatch: got %q", rec.Body.String())
+	}
+}
+
+func TestFileDownload_LegacyAudiobookPathWithFormatQuery(t *testing.T) {
+	h, books, author, ctx, tmp := fileFixture(t)
+	path := filepath.Join(tmp, "legacy.m4b")
+	if err := os.WriteFile(path, []byte("legacy audiobook bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Legacy audiobook rows likewise keep their only path in FilePath.
+	book := &models.Book{
+		ForeignID: "OL-LEGACY-AUDIOBOOK", AuthorID: author.ID, Title: "Legacy audiobook",
+		MediaType: models.MediaTypeAudiobook, FilePath: path,
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.Update(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReqFormat(book.ID, models.MediaTypeAudiobook))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Equal(rec.Body.Bytes(), []byte("legacy audiobook bytes")) {
+		t.Errorf("body mismatch: got %q", rec.Body.String())
+	}
+}
+
+func TestFileDownload_NoFormatPreservesLegacyPreferenceOrder(t *testing.T) {
+	tests := []struct {
+		name          string
+		legacyPath    bool
+		ebookPath     bool
+		audiobookPath bool
+		want          string
+	}{
+		{name: "legacy path before per-format paths", legacyPath: true, ebookPath: true, audiobookPath: true, want: "legacy bytes"},
+		{name: "ebook path before audiobook path", ebookPath: true, audiobookPath: true, want: "ebook bytes"},
+		{name: "audiobook path when it is the only path", audiobookPath: true, want: "audiobook bytes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, books, author, ctx, tmp := fileFixture(t)
+			paths := map[string]string{
+				"legacy":    filepath.Join(tmp, "legacy.epub"),
+				"ebook":     filepath.Join(tmp, "ebook.epub"),
+				"audiobook": filepath.Join(tmp, "audiobook.m4b"),
+			}
+			for name, path := range paths {
+				if err := os.WriteFile(path, []byte(name+" bytes"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			book := &models.Book{
+				ForeignID: "OL-NO-FORMAT", AuthorID: author.ID, Title: "No format",
+				MediaType: models.MediaTypeBoth,
+			}
+			if err := books.Create(ctx, book); err != nil {
+				t.Fatal(err)
+			}
+			if tt.ebookPath {
+				if err := books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, paths["ebook"]); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.audiobookPath {
+				if err := books.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, paths["audiobook"]); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.legacyPath {
+				// AddBookFile maintains FilePath for compatibility, so restore the
+				// distinct legacy value after populating the per-format slots.
+				book.FilePath = paths["legacy"]
+				if err := books.Update(ctx, book); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			rec := httptest.NewRecorder()
+			h.Download(rec, withURLParam(httptest.NewRequest(http.MethodGet, "/api/v1/file/1/download", nil), "id", "1"))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if rec.Body.String() != tt.want {
+				t.Errorf("body mismatch: got %q, want %q", rec.Body.String(), tt.want)
+			}
+		})
+	}
+}
+
 func TestFileDownload_InvalidFormat(t *testing.T) {
 	h, books, author, ctx, _ := fileFixture(t)
 	book := &models.Book{ForeignID: "OL-BAD-FORMAT", AuthorID: author.ID, Title: "T"}

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -224,6 +224,100 @@ func TestFileDownload_AudiobookDirStreamsZip(t *testing.T) {
 	}
 }
 
+func TestFileDownload_DualFormatHonoursAudiobookQuery(t *testing.T) {
+	h, books, author, ctx, tmp := fileFixture(t)
+	ebookPath := filepath.Join(tmp, "book.epub")
+	if err := os.WriteFile(ebookPath, []byte("ebook bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	audiobookDir := filepath.Join(tmp, "audiobook")
+	if err := os.MkdirAll(audiobookDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(audiobookDir, "book.m4b"), []byte("audio bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	book := &models.Book{
+		ForeignID: "OL-DUAL-AUDIO", AuthorID: author.ID, Title: "Dual",
+		MediaType: models.MediaTypeBoth, FilePath: filepath.Join(tmp, "stale.epub"),
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.Update(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, ebookPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, audiobookDir); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReqFormat(book.ID, models.MediaTypeAudiobook))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/zip" {
+		t.Fatalf("Content-Type: got %q, want application/zip", ct)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(rec.Body.Bytes()), int64(rec.Body.Len()))
+	if err != nil {
+		t.Fatalf("zip reader: %v", err)
+	}
+	if len(zr.File) != 1 || zr.File[0].Name != "book.m4b" {
+		t.Fatalf("unexpected audiobook zip entries: %+v", zr.File)
+	}
+}
+
+func TestFileDownload_DualFormatHonoursEbookQuery(t *testing.T) {
+	h, books, author, ctx, tmp := fileFixture(t)
+	ebookPath := filepath.Join(tmp, "book.epub")
+	if err := os.WriteFile(ebookPath, []byte("ebook bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	audiobookDir := filepath.Join(tmp, "audiobook")
+	if err := os.MkdirAll(audiobookDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	book := &models.Book{ForeignID: "OL-DUAL-EBOOK", AuthorID: author.ID, Title: "Dual", MediaType: models.MediaTypeBoth}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, ebookPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, audiobookDir); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReqFormat(book.ID, models.MediaTypeEbook))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !bytes.Equal(rec.Body.Bytes(), []byte("ebook bytes")) {
+		t.Errorf("body mismatch: got %q", rec.Body.String())
+	}
+}
+
+func TestFileDownload_InvalidFormat(t *testing.T) {
+	h, books, author, ctx, _ := fileFixture(t)
+	book := &models.Book{ForeignID: "OL-BAD-FORMAT", AuthorID: author.ID, Title: "T"}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReqFormat(book.ID, "magazine"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid format: expected 400, got %d", rec.Code)
+	}
+}
+
 // ── Root-folder allow-list (request-time resolution) ────────────────────────
 //
 // The download allow-list must include user-configured root folders, not just
@@ -471,6 +565,11 @@ func TestFileDownload_OwnershipEnforcedUnderRootFolder(t *testing.T) {
 // {id} URL param populated.
 func downloadReq(id int64) *http.Request {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/file/download", nil)
+	return withURLParam(req, "id", strconv.FormatInt(id, 10))
+}
+
+func downloadReqFormat(id int64, format string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/file/download?format="+url.QueryEscape(format), nil)
 	return withURLParam(req, "id", strconv.FormatInt(id, 10))
 }
 


### PR DESCRIPTION
## Summary
Honor the format selected when downloading files from dual-format books. Audiobook requests now use the audiobook path instead of falling through the legacy or ebook path, while callers that omit the format retain the existing fallback behavior.

Invalid format values now return HTTP 400, and regression tests cover both ebook and audiobook selection.

**Important side note**: I’m a C# developer, and until today I had never written a single line of Go. My expertise mostly began and ended with knowing the mascot is adorable. This is my first Go contribution, developed with AI assistance. I’ve reviewed and tested the change, but please keep me honest if anything doesn’t match the project’s conventions. 🙂

Closes #1561.


## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed
- [x] Added a changelog fragment under `changelog.d/` (not an edit to `CHANGELOG.md`) — see [changelog.d/README.md](../changelog.d/README.md)
- [ ] Wiki pages updated if user-facing behaviour changed;

## Test plan
- [x] `go vet ./...`
- [x] `go test ./cmd/... ./internal/...`
- [x] Frontend production build
- [x] `docker buildx build --platform linux/amd64,linux/arm64 -t bindery:local .`
make check had issues on unrelated files (internal/decision/decision.go, internal/decision/specs.go, internal/downloader/nethint/nethint.go)
