### PR TITLE
fix(api): honor ?format= on book file download for dual-format books

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -64,12 +64,12 @@ POST   /api/v1/book/bulk                          bulk monitor / status flip
 GET    /api/v1/book/{id}                          book detail (with editions, history, formats)
 PUT    /api/v1/book/{id}                          update monitor / status / metadata
 DELETE /api/v1/book/{id}                          remove from library
-DELETE /api/v1/book/{id}/file                     delete imported file(s) on disk
+DELETE /api/v1/book/{id}/file                     delete imported file(s) on disk (`?format=ebook|audiobook` scopes to one format)
 PUT    /api/v1/book/{id}/exclude                  exclude from future searches
 POST   /api/v1/book/{id}/rebind                   re-link to a different metadata record
 POST   /api/v1/book/{id}/enrich-audiobook         pull narrator/duration/cover from Audnex
 POST   /api/v1/book/{id}/search                   manual indexer search
-GET    /api/v1/book/{id}/file                     download the imported file (auth required)
+GET    /api/v1/book/{id}/file                     download the imported file (auth required; `?format=ebook|audiobook` picks the format on dual-format books)
 ```
 
 ### Search & discovery

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/auth"
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
 )
 
 type FileHandler struct {
@@ -55,6 +56,8 @@ func (h *FileHandler) WithRootFolders(rf *db.RootFolderRepo) *FileHandler {
 //   - Ebook (FilePath is a file): streams the file with its original name.
 //   - Audiobook (FilePath is a directory): streams a zip of the folder so
 //     multi-part m4b/mp3 + cover art come down as one bundle.
+//   - ?format=ebook|audiobook picks that format's file on dual-format books;
+//     without it the legacy FilePath wins, then ebook, then audiobook.
 func (h *FileHandler) Download(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 	if err != nil {
@@ -75,14 +78,33 @@ func (h *FileHandler) Download(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Prefer the legacy FilePath, fall back to per-format columns for books
-	// created after the dual-format schema landed (migration 026+).
-	filePath := book.FilePath
-	if filePath == "" {
+	// Optional ?format=ebook|audiobook scopes the download to one format on
+	// dual-format books (same query param contract as DeleteFile). Without it,
+	// keep the legacy FilePath-first chain so single-format books and rows
+	// predating the dual-format schema (migration 026) behave as before.
+	var filePath string
+	switch format := r.URL.Query().Get("format"); format {
+	case "":
+		filePath = book.FilePath
+		if filePath == "" {
+			filePath = book.EbookFilePath
+		}
+		if filePath == "" {
+			filePath = book.AudiobookFilePath
+		}
+	case models.MediaTypeEbook:
 		filePath = book.EbookFilePath
-	}
-	if filePath == "" {
+		if filePath == "" {
+			filePath = legacyPathForFormat(book.FilePath, false)
+		}
+	case models.MediaTypeAudiobook:
 		filePath = book.AudiobookFilePath
+		if filePath == "" {
+			filePath = legacyPathForFormat(book.FilePath, true)
+		}
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid format"})
+		return
 	}
 	if filePath == "" {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no file available for this book"})
@@ -112,6 +134,23 @@ func (h *FileHandler) Download(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", contentDisposition(filename))
 	w.Header().Set("Content-Length", strconv.FormatInt(info.Size(), 10))
 	http.ServeFile(w, r, filePath)
+}
+
+// legacyPathForFormat returns the legacy single FilePath when its on-disk
+// shape matches the requested format — a directory is an audiobook bundle, a
+// regular file is an ebook — and "" otherwise. Books imported before the
+// dual-format schema only populate FilePath, so a format-scoped download has
+// to infer which format that path actually holds rather than serve whatever
+// is there.
+func legacyPathForFormat(p string, wantDir bool) string {
+	if p == "" {
+		return ""
+	}
+	info, err := os.Stat(p)
+	if err != nil || info.IsDir() != wantDir {
+		return ""
+	}
+	return p
 }
 
 // contentDisposition builds an RFC 6266 / RFC 5987 attachment header that

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -480,3 +480,116 @@ func downloadReqCtx(ctx context.Context, id int64) *http.Request {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/file/download", nil).WithContext(ctx)
 	return withURLParam(req, "id", strconv.FormatInt(id, 10))
 }
+
+// ── ?format= scoping (#1561) ─────────────────────────────────────────────────
+
+// downloadReqFormat is downloadReq with a ?format= query param.
+func downloadReqFormat(id int64, format string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/file/download?format="+format, nil)
+	return withURLParam(req, "id", strconv.FormatInt(id, 10))
+}
+
+// A dual-format book must serve the format the client asked for, not whichever
+// path the legacy fallback chain reaches first (#1561).
+func TestFileDownload_FormatParamDualBook(t *testing.T) {
+	h, books, author, ctx, tmp := fileFixture(t)
+
+	epub := filepath.Join(tmp, "book.epub")
+	if err := os.WriteFile(epub, []byte("epub bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	audioDir := filepath.Join(tmp, "Title (Audio)")
+	if err := os.MkdirAll(audioDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(audioDir, "part1.m4b"), []byte("m4b bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	book := &models.Book{ForeignID: "OL3B", AuthorID: author.ID, Title: "T", MediaType: models.MediaTypeBoth}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.SetFormatFilePath(ctx, book.ID, models.MediaTypeEbook, epub); err != nil {
+		t.Fatal(err)
+	}
+	if err := books.SetFormatFilePath(ctx, book.ID, models.MediaTypeAudiobook, audioDir); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReqFormat(book.ID, "audiobook"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("format=audiobook: expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/zip" {
+		t.Errorf("format=audiobook: Content-Type got %q, want application/zip (epub served instead?)", ct)
+	}
+
+	rec = httptest.NewRecorder()
+	h.Download(rec, downloadReqFormat(book.ID, "ebook"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("format=ebook: expected 200, got %d", rec.Code)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), []byte("epub bytes")) {
+		t.Errorf("format=ebook: body mismatch, got %q", rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	h.Download(rec, downloadReqFormat(book.ID, "pdf"))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("format=pdf: expected 400, got %d", rec.Code)
+	}
+}
+
+// A format-scoped request against a pre-dual-format row (only the legacy
+// file_path column set) serves the legacy path only when its on-disk shape
+// matches the requested format: file = ebook, directory = audiobook.
+func TestFileDownload_FormatParamLegacyFilePath(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	ctx := context.Background()
+	author := &models.Author{ForeignID: "OL9A", Name: "A", SortName: "A"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	h := NewFileHandler(books, root)
+
+	epub := filepath.Join(root, "legacy.epub")
+	if err := os.WriteFile(epub, []byte("legacy epub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{ForeignID: "OL9B", AuthorID: author.ID, Title: "T", MediaType: models.MediaTypeEbook}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	// Write the legacy column directly — SetFilePath would register a
+	// book_files row and populate the per-format columns, which is exactly
+	// the modern state this test must avoid.
+	if _, err := database.ExecContext(ctx, `UPDATE books SET file_path=? WHERE id=?`, epub, book.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Download(rec, downloadReqFormat(book.ID, "ebook"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("format=ebook on legacy file: expected 200, got %d", rec.Code)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), []byte("legacy epub")) {
+		t.Errorf("format=ebook on legacy file: body mismatch, got %q", rec.Body.String())
+	}
+
+	// The legacy path is a regular file, so it cannot satisfy an audiobook
+	// request — 404, not the epub mislabeled as an audiobook.
+	rec = httptest.NewRecorder()
+	h.Download(rec, downloadReqFormat(book.ID, "audiobook"))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("format=audiobook on legacy ebook file: expected 404, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

`FileHandler.Download` ignored the `?format=` query param the frontend sends for dual-format books, so with Audiobook selected in the File section the download still served the epub whenever an ebook path existed. The handler now scopes file selection to the requested format, using the same query param contract `DeleteFile` already has. Closes #1561.

## Implementation notes

- `format=ebook` serves `EbookFilePath`, `format=audiobook` serves `AudiobookFilePath`; an unknown value is a 400.
- No param keeps the exact legacy chain (`FilePath` → ebook → audiobook), so single-format books and OPDS clients see no behaviour change.
- For rows predating the dual-format schema (only legacy `file_path` set), the requested format is satisfied from `file_path` only when its on-disk shape matches — directory = audiobook bundle, regular file = ebook — instead of serving whatever is there mislabeled.
- The frontend only appends `?format=` for dual-format books (`BookDetailPage.tsx`), so no web change needed.

## Checklist

- [x] Tests added or updated (`TestFileDownload_FormatParamDualBook`, `TestFileDownload_FormatParamLegacyFilePath`)
- [x] Doc-update gate cleared (`docs/API.md` — both `/book/{id}/file` entries note the param)
- [x] Wiki pages updated if user-facing behaviour changed (n/a — API reference covers it)

## Test plan

- [x] `go test ./internal/api/ -run TestFileDownload` (all pass, incl. new regression tests)
- [x] `gofmt` / `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)