### PR TITLE
fix(author): abort catalogue sync when the author row is deleted mid-fetch

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1494,6 +1494,19 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 		langSampled = h.meta.FillMissingAuthorWorkLanguages(ctx, books)
 	}
 
+	// Everything above can take minutes for a prolific author (works fetch,
+	// Audible supplement, language sampling), and this goroutine holds only a
+	// snapshot of the author row. By now the row may be gone: AddBook's
+	// orphan cleanup rolls back a speculative author insert when its poll
+	// times out and the direct insert didn't land (#804, #1559), and a user
+	// can delete the author mid-refresh. Bail out instead of running an
+	// insert loop where every row fails the author_id FK constraint.
+	if current, err := h.authors.GetByID(ctx, author.ID); err == nil && current == nil {
+		slog.Info("author deleted while catalogue fetch was running; aborting sync",
+			"author", author.Name, "authorId", author.ID)
+		return
+	}
+
 	// Track titles we've already added (case-insensitive) to avoid OL duplicates.
 	// The value is a pointer to the existing book so we can enrich calibre-imported
 	// stubs with the OL foreign ID and language when they title-match an OL record.
@@ -1710,6 +1723,18 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 					}
 				}
 				continue
+			}
+			// A FOREIGN KEY failure here almost always means the author row
+			// was deleted after the pre-loop existence check (orphan cleanup
+			// or a user delete racing this goroutine). Confirm and abort the
+			// whole sync — every remaining insert would fail the same way,
+			// emitting one WARN per work (#1559 saw 180 in a burst).
+			if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+				if current, gerr := h.authors.GetByID(ctx, author.ID); gerr == nil && current == nil {
+					slog.Info("author deleted mid-sync; aborting catalogue sync",
+						"author", author.Name, "authorId", author.ID, "added", added)
+					return
+				}
 			}
 			slog.Warn("failed to create book", "title", b.Title, "error", err)
 			continue

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -4625,5 +4626,74 @@ func TestFetchAuthorBooks_InitialSyncIgnoresMonitorNewItems(t *testing.T) {
 	got := monitorNewItemsFixture(t, models.AuthorMonitorNewItemsNone, true)
 	if !got.Monitored {
 		t.Error("initial sync must honour monitor-mode 'all' even with monitorNewItems=none")
+	}
+}
+
+// ── #1559: author deleted while the catalogue sync goroutine is running ─────
+
+// captureSlog redirects the default slog logger into a buffer for the test's
+// duration so assertions can pin which log lines a code path emits.
+func captureSlog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// When the author row disappears while fetchAuthorBooks is fetching the
+// catalogue (AddBook's orphan cleanup after a poll timeout, or a user
+// deleting the author mid-refresh), the sync must abort before the insert
+// loop instead of emitting one FK-constraint WARN per work (#804, #1559 —
+// 180 warns in one burst).
+func TestFetchAuthorBooks_AuthorDeletedDuringFetch_AbortsWithoutFKBurst(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OL-GONE", Name: "Michael Lewis", SortName: "Lewis, Michael",
+		MetadataProvider: "openlibrary",
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := *author // what fetchAuthorBooksAsync hands the goroutine
+
+	provider := &stubMetaProvider{works: []models.Book{
+		{ForeignID: "OL-W1", Title: "The Big Short", Status: models.BookStatusWanted, Genres: []string{}},
+		{ForeignID: "OL-W2", Title: "Moneyball", Status: models.BookStatusWanted, Genres: []string{}},
+		{ForeignID: "OL-W3", Title: "Liar's Poker", Status: models.BookStatusWanted, Genres: []string{}},
+	}}
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(provider), nil, profileRepo, nil)
+
+	// Simulate the race: the row is gone by the time the goroutine's slow
+	// catalogue fetch would have completed.
+	if err := authorRepo.Delete(ctx, author.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	logs := captureSlog(t)
+	h.fetchAuthorBooks(&snapshot, false, models.MediaTypeEbook, true)
+
+	if got := logs.String(); strings.Contains(got, "failed to create book") {
+		t.Errorf("sync against deleted author emitted per-book create failures:\n%s", got)
+	} else if !strings.Contains(got, "aborting sync") {
+		t.Errorf("expected sync to log an abort, got:\n%s", got)
+	}
+	books, err := bookRepo.ListByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(books) != 0 {
+		t.Errorf("expected no books for deleted author, got %d", len(books))
 	}
 }


### PR DESCRIPTION
## Summary

Verified #1559: the FK 787 burst is still reachable on v1.25.0+. `fetchAuthorBooks` runs in a goroutine against a snapshot of the author and can spend minutes fetching the catalogue; if the author row is deleted in that window, the insert loop fails the `author_id` FK once per work. This PR makes the sync notice the deletion and stop. Closes #1559.

## Root cause confirmed (refines the reporter's hypothesis)

#808's guarantee only holds when its direct insert **succeeds**. The still-open window: AddBook creates the author → the direct insert fails (`meta.GetBook` error or nil — plausible for disambiguation-heavy names like "Michael Lewis") → the 15s poll times out while the works fetch is still running → `cleanupOrphanIfNoBooks` deletes the zero-book author → the sync goroutine finishes fetching and inserts the whole catalogue against the dead id. A user deleting an author mid-refresh hits the identical burst. The reporter's DB evidence (author `created_at` ~41min after the burst, clean `foreign_key_check`) matches this sequence exactly.

## Implementation notes

- After the slow phase (works fetch, Audible supplement, language sampling), re-check the author row exists; if gone, log one INFO and return before the insert loop.
- Inside the loop, a `FOREIGN KEY constraint failed` create error re-checks author existence and aborts the whole sync when the row is gone, instead of warn-and-continue through the remaining catalogue. A FK failure with the author still present falls through to the existing WARN, so an unrelated FK issue stays visible.
- No change to orphan-cleanup semantics or to #808's direct insert.

## Test plan

- [x] New `TestFetchAuthorBooks_AuthorDeletedDuringFetch_AbortsWithoutFKBurst` — reproduces the reported burst pre-fix (`FOREIGN KEY constraint failed (787)` per work, `added=0`) and fails; passes with the fix (single abort log, no FK warns)
- [x] `go test ./internal/api/` full package green
- [x] `gofmt` / `go vet` clean

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (no user-facing config/behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)