### PR TITLE
fix(abs): import supplementary ebooks from combined audiobook+ebook libraries

### DIFF
--- a/docs/ABS-Import-Wiki.md
+++ b/docs/ABS-Import-Wiki.md
@@ -26,7 +26,7 @@ Bindery does not just create a shell entry with a title. It imports the ABS meta
 - authors
 - books
 - series and sequence numbers when ABS provides them
-- ebook and audiobook editions
+- ebook and audiobook editions (a combined item — epub stored alongside the audio files — imports both, even when the ABS library has "Audiobooks only" set and the epub is only listed as a supplementary file)
 - description
 - release date
 - genres

--- a/docs/abs_import.md
+++ b/docs/abs_import.md
@@ -147,7 +147,7 @@ The importer does not create an ABS-only ownership model. It reuses Bindery's ex
 
 Accepted paths:
 
-- ebook ownership comes from `NormalizedLibraryItem.EbookPath`
+- ebook ownership comes from `NormalizedLibraryItem.EbookPath`. That is `media.ebookFile` when ABS promoted a primary ebook; when the ABS library has **"Audiobooks only"** enabled ABS never promotes one, so the importer falls back to the item's supplementary ebook in `libraryFiles` (preferring `.epub`, matching ABS's own primary-ebook pick)
 - audiobook ownership comes from the ABS item `Path`
 - a path is only accepted when it resolves under a Bindery-visible library root
 

--- a/internal/abs/import_utils_test.go
+++ b/internal/abs/import_utils_test.go
@@ -86,3 +86,84 @@ func TestNormalizeTitle_DistinctBooksStayDistinct(t *testing.T) {
 		}
 	}
 }
+
+// ── Supplementary ebook fallback (#1565, Discussion #1556) ──────────────────
+
+func supplementaryTrue() *bool { b := true; return &b }
+
+// A combined audiobook+ebook item from a library with "Audiobooks only"
+// enabled carries no media.ebookFile — the epub is only a supplementary
+// libraryFiles entry. Normalization must still surface it as EbookPath so
+// the import derives an ebook edition.
+func TestNormalizeLibraryItem_SupplementaryEbookFallback(t *testing.T) {
+	item := LibraryItem{
+		ID:        "li_1",
+		MediaType: "book",
+		Media: BookMedia{
+			AudioFiles: []AudioFile{{INO: "ino_a1", Index: 1, Path: "/books/A/T/[Audio]/1.mp3"}},
+		},
+		LibraryFiles: []LibraryFile{
+			{INO: "ino_mp3", FileType: "audio", Metadata: LibraryFileMetadata{Ext: ".mp3", Path: "/books/A/T/[Audio]/1.mp3"}},
+			{INO: "ino_pdf", FileType: "ebook", IsSupplementary: supplementaryTrue(), Metadata: LibraryFileMetadata{Ext: ".pdf", Path: "/books/A/T/extras.pdf"}},
+			{INO: "ino_epub", FileType: "ebook", IsSupplementary: supplementaryTrue(), Metadata: LibraryFileMetadata{Ext: ".epub", Path: "/books/A/T/Title.epub"}},
+			{INO: "ino_jpg", FileType: "image", Metadata: LibraryFileMetadata{Ext: ".jpg", Path: "/books/A/T/cover.jpg"}},
+		},
+	}
+
+	out := NormalizeLibraryItem(item, true)
+	if out.EbookPath != "/books/A/T/Title.epub" {
+		t.Fatalf("EbookPath = %q, want the supplementary epub (preferred over pdf)", out.EbookPath)
+	}
+	if out.EbookINO != "ino_epub" {
+		t.Errorf("EbookINO = %q, want ino_epub", out.EbookINO)
+	}
+}
+
+// When ABS did promote a primary ebook, media.ebookFile wins and the
+// supplementary fallback must not override it.
+func TestNormalizeLibraryItem_PrimaryEbookFileWinsOverSupplementary(t *testing.T) {
+	item := LibraryItem{
+		ID: "li_2",
+		Media: BookMedia{
+			EbookFile: &EbookFile{Path: "/books/A/T/Primary.epub", INO: "ino_primary"},
+		},
+		LibraryFiles: []LibraryFile{
+			{INO: "ino_other", FileType: "ebook", Metadata: LibraryFileMetadata{Ext: ".epub", Path: "/books/A/T/Other.epub"}},
+		},
+	}
+	out := NormalizeLibraryItem(item, true)
+	if out.EbookPath != "/books/A/T/Primary.epub" || out.EbookINO != "ino_primary" {
+		t.Fatalf("EbookPath/INO = %q/%q, want the primary ebookFile", out.EbookPath, out.EbookINO)
+	}
+}
+
+// No ebook-typed library files at all: EbookPath stays empty (audiobook-only
+// item), no accidental promotion of images or audio files.
+func TestNormalizeLibraryItem_NoEbookFilesNoFallback(t *testing.T) {
+	item := LibraryItem{
+		ID: "li_3",
+		LibraryFiles: []LibraryFile{
+			{INO: "ino_mp3", FileType: "audio", Metadata: LibraryFileMetadata{Ext: ".mp3", Path: "/x/1.mp3"}},
+			{INO: "ino_jpg", FileType: "image", Metadata: LibraryFileMetadata{Ext: ".jpg", Path: "/x/c.jpg"}},
+		},
+	}
+	if out := NormalizeLibraryItem(item, true); out.EbookPath != "" || out.EbookINO != "" {
+		t.Fatalf("EbookPath/INO = %q/%q, want empty", out.EbookPath, out.EbookINO)
+	}
+}
+
+// The detail fetch is what carries libraryFiles; the merge must not drop the
+// list item's copy when the detail response omits it (defensive symmetry with
+// every other MergeLibraryItem field).
+func TestMergeLibraryItem_CarriesLibraryFiles(t *testing.T) {
+	listItem := LibraryItem{
+		ID: "li_4",
+		LibraryFiles: []LibraryFile{
+			{INO: "ino_epub", FileType: "ebook", Metadata: LibraryFileMetadata{Ext: ".epub", Path: "/x/T.epub"}},
+		},
+	}
+	merged := MergeLibraryItem(listItem, LibraryItem{ID: "li_4"})
+	if len(merged.LibraryFiles) != 1 || merged.LibraryFiles[0].INO != "ino_epub" {
+		t.Fatalf("merged.LibraryFiles = %+v, want the list item's entry carried over", merged.LibraryFiles)
+	}
+}

--- a/internal/abs/types.go
+++ b/internal/abs/types.go
@@ -82,6 +82,25 @@ type EbookFile struct {
 	INO  string `json:"ino"`
 }
 
+type LibraryFileMetadata struct {
+	Filename string `json:"filename"`
+	Ext      string `json:"ext"`
+	Path     string `json:"path"`
+	RelPath  string `json:"relPath"`
+}
+
+// LibraryFile is one entry of a library item's libraryFiles array (returned
+// by the expanded detail fetch). ABS lists every file it found for the item
+// here, including ebooks it did NOT promote to media.ebookFile — a library
+// with "Audiobooks only" enabled never promotes one, and marks the ebook
+// isSupplementary instead.
+type LibraryFile struct {
+	INO             string              `json:"ino"`
+	FileType        string              `json:"fileType"`
+	IsSupplementary *bool               `json:"isSupplementary"`
+	Metadata        LibraryFileMetadata `json:"metadata"`
+}
+
 type BookMetadata struct {
 	Title         string           `json:"title"`
 	Subtitle      string           `json:"subtitle"`
@@ -109,14 +128,15 @@ type BookMedia struct {
 }
 
 type LibraryItem struct {
-	ID        string    `json:"id"`
-	LibraryID string    `json:"libraryId"`
-	FolderID  string    `json:"folderId"`
-	Path      string    `json:"path"`
-	RelPath   string    `json:"relPath"`
-	IsFile    bool      `json:"isFile"`
-	MediaType string    `json:"mediaType"`
-	Media     BookMedia `json:"media"`
+	ID           string        `json:"id"`
+	LibraryID    string        `json:"libraryId"`
+	FolderID     string        `json:"folderId"`
+	Path         string        `json:"path"`
+	RelPath      string        `json:"relPath"`
+	IsFile       bool          `json:"isFile"`
+	MediaType    string        `json:"mediaType"`
+	Media        BookMedia     `json:"media"`
+	LibraryFiles []LibraryFile `json:"libraryFiles,omitempty"`
 }
 
 type LibraryItemsPage struct {
@@ -182,6 +202,30 @@ type NormalizedLibraryItem struct {
 	ResolvedBookForeignID   string                `json:"resolvedBookForeignId,omitempty"`
 	ResolvedBookTitle       string                `json:"resolvedBookTitle,omitempty"`
 	EditedTitle             string                `json:"editedTitle,omitempty"`
+}
+
+// SupplementaryEbookFile returns the libraryFiles entry to use as the item's
+// ebook when ABS didn't promote one to media.ebookFile — the case for every
+// item in a library with "Audiobooks only" enabled, where ebooks are only
+// listed as supplementary library files (#1565, Discussion #1556). Prefers
+// .epub over other formats, mirroring ABS's own primary-ebook selection
+// (BookScanner picks the first epub, else the first ebook file). Returns nil
+// when the item has no ebook-typed library files.
+func (i LibraryItem) SupplementaryEbookFile() *LibraryFile {
+	var first *LibraryFile
+	for idx := range i.LibraryFiles {
+		lf := &i.LibraryFiles[idx]
+		if lf.FileType != "ebook" || lf.Metadata.Path == "" {
+			continue
+		}
+		if strings.EqualFold(strings.TrimPrefix(lf.Metadata.Ext, "."), "epub") {
+			return lf
+		}
+		if first == nil {
+			first = lf
+		}
+	}
+	return first
 }
 
 func (i LibraryItem) DetailFetchReasons() []string {
@@ -284,6 +328,9 @@ func MergeLibraryItem(listItem, detailItem LibraryItem) LibraryItem {
 	if merged.Media.EbookFile == nil {
 		merged.Media.EbookFile = listItem.Media.EbookFile
 	}
+	if len(merged.LibraryFiles) == 0 {
+		merged.LibraryFiles = listItem.LibraryFiles
+	}
 	if !merged.IsFile && listItem.IsFile {
 		merged.IsFile = true
 	}
@@ -321,6 +368,16 @@ func NormalizeLibraryItem(item LibraryItem, detailFetched bool) NormalizedLibrar
 	if item.Media.EbookFile != nil {
 		out.EbookPath = item.Media.EbookFile.Path
 		out.EbookINO = item.Media.EbookFile.INO
+	}
+	// ABS only sets media.ebookFile when the library allows a primary ebook.
+	// With "Audiobooks only" enabled the epub is still on disk and listed in
+	// libraryFiles as a supplementary ebook — fall back to it so combined
+	// audiobook+ebook items import both formats (#1565, Discussion #1556).
+	if out.EbookPath == "" {
+		if lf := item.SupplementaryEbookFile(); lf != nil {
+			out.EbookPath = lf.Metadata.Path
+			out.EbookINO = lf.INO
+		}
 	}
 	out.Authors = make([]NormalizedAuthor, 0, len(item.Media.Metadata.Authors))
 	for _, author := range item.Media.Metadata.Authors {


### PR DESCRIPTION
## Summary

Combined ABS items (epub stored next to the audio files in one library item) imported only the audiobook when the ABS library has **"Audiobooks only"** enabled: ABS then never promotes an ebook to `media.ebookFile` — the epub is exposed only as a `libraryFiles[]` entry with `fileType: "ebook"`, `isSupplementary: true` — and Bindery only ever read `media.ebookFile`. Now the normalizer falls back to the supplementary ebook so `EbookPath` is populated and the ebook edition is created alongside the audiobook one. Closes #1565, refs Discussion #1556 (confirmed there on ABS v2.35.1: no `media.ebookFile` in the `expanded=1` response).

## Implementation notes

- `LibraryItem` gains `LibraryFiles` (decoded from the `expanded=1` detail fetch — folder-backed items always take that path already, so zero extra API calls).
- `SupplementaryEbookFile()` prefers `.epub` over other ebook formats, mirroring ABS's own primary-ebook selection in `BookScanner.js` (first epub, else first ebook file).
- A promoted primary `media.ebookFile` always wins; the fallback only fires when it's absent.
- `MergeLibraryItem` carries `libraryFiles` with the same nil-guard symmetry as every other field.

## Test plan

- [x] New tests: supplementary fallback (epub preferred over pdf), primary-wins, no-ebook-files stays empty, merge carries `libraryFiles`
- [x] `go test ./internal/abs/` full package green
- [x] `go test -count=1 ./tests/abscontract/...` green
- [x] `gofmt` / `go vet` clean

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (`docs/abs_import.md` file-reconciliation section, `docs/ABS-Import-Wiki.md` what-gets-imported list)
- [x] Wiki pages updated if user-facing behaviour changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)