### PR TITLE
Feature/optional parent indexer categories

### DIFF
--- a/changelog.d/broad-parent-categories.md
+++ b/changelog.d/broad-parent-categories.md
@@ -1,0 +1,2 @@
+### Added
+- **Optional broad indexer categories** — Indexers can now opt in to searching the Newznab Books (`7000`) or Audio (`3000`) parent categories alongside their configured subcategories, helping recover releases from incomplete category mappings. The setting is available when adding or editing an indexer, persists across updates, and is preserved during Prowlarr syncs; it remains disabled by default because broad categories can return unrelated results.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -63,10 +63,11 @@ point Bindery at a Prowlarr instance.
   non-standard categories.
 - **Include broad parent categories** — disabled by default. Enable it for an
   indexer that advertises releases only under Books (`7000`) or Audio (`3000`).
-  Bindery then searches the supplied parent alongside specific children; it
-  never adds an unadvertised parent. Broader queries can recover releases
-  missed by incomplete mappings, but can also return comics, magazines, music,
-  or other unrelated results. Prowlarr re-syncs preserve this local choice.
+  Bindery then adds the appropriate parent to searches alongside the specific
+  children, including for existing indexers whose stored mappings no longer
+  contain the parent. Broader queries can recover releases missed by incomplete
+  mappings, but can also return comics, magazines, music, or other unrelated
+  results. Prowlarr re-syncs preserve this local choice.
 
 **Prowlarr** — under **Settings → Indexers → Add Prowlarr**, give the base URL
 (e.g. `http://prowlarr:9696`) and API key, then **Sync now** to pull its

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -61,6 +61,12 @@ point Bindery at a Prowlarr instance.
 - **Categories** — comma-separated Newznab category IDs. Default `7020`
   (eBooks); `3030` is Audiobooks. Add custom IDs for indexers with
   non-standard categories.
+- **Include broad parent categories** — disabled by default. Enable it for an
+  indexer that advertises releases only under Books (`7000`) or Audio (`3000`).
+  Bindery then searches the supplied parent alongside specific children; it
+  never adds an unadvertised parent. Broader queries can recover releases
+  missed by incomplete mappings, but can also return comics, magazines, music,
+  or other unrelated results. Prowlarr re-syncs preserve this local choice.
 
 **Prowlarr** — under **Settings → Indexers → Add Prowlarr**, give the base URL
 (e.g. `http://prowlarr:9696`) and API key, then **Sync now** to pull its

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"strconv"
 	"sync"
@@ -152,10 +153,27 @@ func (h *IndexerHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var idx models.Indexer
-	if err := json.NewDecoder(r.Body).Decode(&idx); err != nil {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 		return
+	}
+	var idx models.Indexer
+	if err := json.Unmarshal(body, &idx); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	// Preserve the opt-in for older API clients that do not know about the new
+	// field. A present false still explicitly disables it.
+	var optional struct {
+		IncludeParentCategories *bool `json:"includeParentCategories"`
+	}
+	if err := json.Unmarshal(body, &optional); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if optional.IncludeParentCategories == nil {
+		idx.IncludeParentCategories = existing.IncludeParentCategories
 	}
 	if idx.URL != "" {
 		if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLANLoopback); err != nil {

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -158,22 +158,24 @@ func (h *IndexerHandler) Update(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 		return
 	}
-	var idx models.Indexer
-	if err := json.Unmarshal(body, &idx); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
-		return
-	}
-	// Preserve the opt-in for older API clients that do not know about the new
-	// field. A present false still explicitly disables it.
-	var optional struct {
+	// Decode the model and presence-sensitive option together. The pointer
+	// distinguishes an omitted field from an explicit false without parsing the
+	// same JSON twice (whose second error path would be unreachable).
+	var update struct {
+		models.Indexer
 		IncludeParentCategories *bool `json:"includeParentCategories"`
 	}
-	if err := json.Unmarshal(body, &optional); err != nil {
+	if err := json.Unmarshal(body, &update); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
 		return
 	}
-	if optional.IncludeParentCategories == nil {
+	idx := update.Indexer
+	// Preserve the opt-in for older API clients that do not know about the new
+	// field. A present false still explicitly disables it.
+	if update.IncludeParentCategories == nil {
 		idx.IncludeParentCategories = existing.IncludeParentCategories
+	} else {
+		idx.IncludeParentCategories = *update.IncludeParentCategories
 	}
 	if idx.URL != "" {
 		if err := httpsec.ValidateOutboundURL(idx.URL, httpsec.PolicyLANLoopback); err != nil {

--- a/internal/api/indexers_test.go
+++ b/internal/api/indexers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -17,6 +18,12 @@ import (
 	"github.com/vavallee/bindery/internal/indexer/newznab"
 	"github.com/vavallee/bindery/internal/models"
 )
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}
 
 // mockIndexerSearcher implements indexerSearcher for unit tests.
 type mockIndexerSearcher struct {
@@ -145,6 +152,52 @@ func TestIndexerCRUD(t *testing.T) {
 	if rec.Code != http.StatusNoContent {
 		t.Errorf("delete: expected 204, got %d", rec.Code)
 	}
+}
+
+func TestIndexerUpdate_RequestBodyHandling(t *testing.T) {
+	h := indexerFixture(t)
+	idx := &models.Indexer{
+		Name: "Existing", URL: "https://example.com/api", Type: "newznab",
+		Categories: []int{7020}, IncludeParentCategories: true,
+	}
+	if err := h.indexers.Create(context.Background(), idx); err != nil {
+		t.Fatalf("create fixture indexer: %v", err)
+	}
+
+	t.Run("read error", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPut, "/indexer/1", failingReader{})
+		h.Update(rec, withURLParam(req, "id", strconv.FormatInt(idx.ID, 10)))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPut, "/indexer/1", bytes.NewBufferString(`{"name":`))
+		h.Update(rec, withURLParam(req, "id", strconv.FormatInt(idx.ID, 10)))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected 400, got %d", rec.Code)
+		}
+	})
+
+	t.Run("explicit false disables option", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		body := `{"name":"Existing","url":"https://example.com/api","type":"newznab","categories":[7020],"includeParentCategories":false}`
+		req := httptest.NewRequest(http.MethodPut, "/indexer/1", bytes.NewBufferString(body))
+		h.Update(rec, withURLParam(req, "id", strconv.FormatInt(idx.ID, 10)))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var updated models.Indexer
+		if err := json.NewDecoder(rec.Body).Decode(&updated); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if updated.IncludeParentCategories {
+			t.Error("explicit false did not disable IncludeParentCategories")
+		}
+	})
 }
 
 func TestIndexerCreate_Validation(t *testing.T) {

--- a/internal/api/indexers_test.go
+++ b/internal/api/indexers_test.go
@@ -75,7 +75,7 @@ func TestIndexerCRUD(t *testing.T) {
 	h := indexerFixture(t)
 
 	// Create
-	body := `{"name":"NZBGeek","url":"https://api.nzbgeek.info","apiKey":"testkey","type":"newznab"}`
+	body := `{"name":"NZBGeek","url":"https://api.nzbgeek.info","apiKey":"testkey","type":"newznab","includeParentCategories":true}`
 	rec := httptest.NewRecorder()
 	h.Create(rec, httptest.NewRequest(http.MethodPost, "/indexer", bytes.NewBufferString(body)))
 	if rec.Code != http.StatusCreated {
@@ -89,6 +89,9 @@ func TestIndexerCRUD(t *testing.T) {
 	// Default categories should be set
 	if len(created.Categories) == 0 {
 		t.Error("expected default categories to be populated")
+	}
+	if !created.IncludeParentCategories {
+		t.Error("expected includeParentCategories to round-trip on create")
 	}
 
 	// List
@@ -120,6 +123,13 @@ func TestIndexerCRUD(t *testing.T) {
 	h.Update(rec, withURLParam(httptest.NewRequest(http.MethodPut, "/indexer/1", bytes.NewBufferString(update)), "id", "1"))
 	if rec.Code != http.StatusOK {
 		t.Errorf("update: expected 200, got %d", rec.Code)
+	}
+	var updated models.Indexer
+	if err := json.NewDecoder(rec.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode update: %v", err)
+	}
+	if !updated.IncludeParentCategories {
+		t.Error("legacy update without includeParentCategories should preserve the stored value")
 	}
 
 	// Update — not found

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -790,6 +790,42 @@ func TestIndexerCRUD(t *testing.T) {
 	}
 }
 
+func TestIndexerListByProwlarrInstance_ParentCategoryOption(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	prowlarrRepo := NewProwlarrRepo(database)
+	instance := &models.ProwlarrInstance{Name: "Prowlarr", URL: "http://prowlarr:9696", APIKey: "key"}
+	if err := prowlarrRepo.Create(ctx, instance); err != nil {
+		t.Fatalf("create Prowlarr instance: %v", err)
+	}
+	prowlarrIndexerID := 42
+	idx := &models.Indexer{
+		Name: "Synced", Type: "torznab", URL: "http://prowlarr:9696/42/api",
+		Categories: []int{7010}, IncludeParentCategories: true,
+		ProwlarrInstanceID: &instance.ID, ProwlarrIndexerID: &prowlarrIndexerID,
+	}
+	repo := NewIndexerRepo(database)
+	if err := repo.Create(ctx, idx); err != nil {
+		t.Fatalf("create indexer: %v", err)
+	}
+
+	got, err := repo.ListByProwlarrInstance(ctx, instance.ID)
+	if err != nil {
+		t.Fatalf("list by Prowlarr instance: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d indexers, want 1", len(got))
+	}
+	if !got[0].IncludeParentCategories {
+		t.Error("IncludeParentCategories was not returned")
+	}
+}
+
 func TestCascadeDeleteAuthorBooks(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -744,14 +744,15 @@ func TestIndexerCRUD(t *testing.T) {
 	repo := NewIndexerRepo(database)
 
 	idx := &models.Indexer{
-		Name:           "Test Indexer",
-		Type:           "newznab",
-		URL:            "https://example.com/api",
-		APIKey:         "testkey123",
-		Categories:     []int{7000, 7020},
-		Priority:       25,
-		Enabled:        true,
-		SupportsSearch: true,
+		Name:                    "Test Indexer",
+		Type:                    "newznab",
+		URL:                     "https://example.com/api",
+		APIKey:                  "testkey123",
+		Categories:              []int{7000, 7020},
+		IncludeParentCategories: true,
+		Priority:                25,
+		Enabled:                 true,
+		SupportsSearch:          true,
 	}
 	err = repo.Create(ctx, idx)
 	if err != nil {
@@ -770,6 +771,9 @@ func TestIndexerCRUD(t *testing.T) {
 	}
 	if len(got.Categories) != 2 || got.Categories[0] != 7000 {
 		t.Errorf("unexpected categories: %v", got.Categories)
+	}
+	if !got.IncludeParentCategories {
+		t.Error("IncludeParentCategories was not persisted")
 	}
 
 	list, err := repo.List(ctx)

--- a/internal/db/indexers.go
+++ b/internal/db/indexers.go
@@ -20,7 +20,7 @@ func NewIndexerRepo(db *sql.DB) *IndexerRepo {
 
 func (r *IndexerRepo) List(ctx context.Context) ([]models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
+		SELECT id, name, type, url, api_key, categories, include_parent_categories, priority, enabled, supports_search,
 		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at
 		FROM indexers ORDER BY priority`)
 	if err != nil {
@@ -41,7 +41,7 @@ func (r *IndexerRepo) List(ctx context.Context) ([]models.Indexer, error) {
 
 func (r *IndexerRepo) GetByID(ctx context.Context, id int64) (*models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
+		SELECT id, name, type, url, api_key, categories, include_parent_categories, priority, enabled, supports_search,
 		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at
 		FROM indexers WHERE id=?`, id)
 	if err != nil {
@@ -61,7 +61,7 @@ func (r *IndexerRepo) GetByID(ctx context.Context, id int64) (*models.Indexer, e
 // ListByProwlarrInstance returns all indexers managed by a specific Prowlarr instance.
 func (r *IndexerRepo) ListByProwlarrInstance(ctx context.Context, instanceID int64) ([]models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
+		SELECT id, name, type, url, api_key, categories, include_parent_categories, priority, enabled, supports_search,
 		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at
 		FROM indexers WHERE prowlarr_instance_id=?`, instanceID)
 	if err != nil {
@@ -86,10 +86,10 @@ func (r *IndexerRepo) Create(ctx context.Context, idx *models.Indexer) error {
 		return fmt.Errorf("marshal indexer categories: %w", err)
 	}
 	result, err := r.db.ExecContext(ctx, `
-		INSERT INTO indexers (name, type, url, api_key, categories, priority, enabled, supports_search,
+		INSERT INTO indexers (name, type, url, api_key, categories, include_parent_categories, priority, enabled, supports_search,
 		                      prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		idx.Name, idx.Type, idx.URL, idx.APIKey, string(catsJSON),
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		idx.Name, idx.Type, idx.URL, idx.APIKey, string(catsJSON), idx.IncludeParentCategories,
 		idx.Priority, idx.Enabled, idx.SupportsSearch,
 		idx.ProwlarrInstanceID, idx.ProwlarrIndexerID, idx.SeedRatio, idx.SeedRatioSource, now, now)
 	if err != nil {
@@ -112,10 +112,10 @@ func (r *IndexerRepo) Update(ctx context.Context, idx *models.Indexer) error {
 		return fmt.Errorf("marshal indexer categories: %w", err)
 	}
 	_, err = r.db.ExecContext(ctx, `
-		UPDATE indexers SET name=?, type=?, url=?, api_key=?, categories=?, priority=?,
+		UPDATE indexers SET name=?, type=?, url=?, api_key=?, categories=?, include_parent_categories=?, priority=?,
 		                    enabled=?, supports_search=?, seed_ratio=?, seed_ratio_source=?, updated_at=?
 		WHERE id=?`,
-		idx.Name, idx.Type, idx.URL, idx.APIKey, string(catsJSON),
+		idx.Name, idx.Type, idx.URL, idx.APIKey, string(catsJSON), idx.IncludeParentCategories,
 		idx.Priority, idx.Enabled, idx.SupportsSearch, idx.SeedRatio, idx.SeedRatioSource, now, idx.ID)
 	return err
 }
@@ -152,11 +152,11 @@ type indexerScanner interface {
 
 func scanIndexer(s indexerScanner) (models.Indexer, error) {
 	var idx models.Indexer
-	var enabled, supportsSearch int
+	var includeParentCategories, enabled, supportsSearch int
 	var catsJSON string
 	if err := s.Scan(
 		&idx.ID, &idx.Name, &idx.Type, &idx.URL, &idx.APIKey,
-		&catsJSON, &idx.Priority, &enabled, &supportsSearch,
+		&catsJSON, &includeParentCategories, &idx.Priority, &enabled, &supportsSearch,
 		&idx.ProwlarrInstanceID, &idx.ProwlarrIndexerID, &idx.SeedRatio, &idx.SeedRatioSource,
 		&idx.CreatedAt, &idx.UpdatedAt,
 	); err != nil {
@@ -164,6 +164,7 @@ func scanIndexer(s indexerScanner) (models.Indexer, error) {
 	}
 	idx.Enabled = enabled == 1
 	idx.SupportsSearch = supportsSearch == 1
+	idx.IncludeParentCategories = includeParentCategories == 1
 	if err := json.Unmarshal([]byte(catsJSON), &idx.Categories); err != nil {
 		return idx, fmt.Errorf("unmarshal indexer categories: %w", err)
 	}

--- a/internal/db/migrations/064_indexer_parent_categories.sql
+++ b/internal/db/migrations/064_indexer_parent_categories.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+-- Opt in per indexer to searching broad Books (7000) and Audio (3000)
+-- categories. Existing and newly synced rows retain the safer child-only
+-- behavior through the false default.
+ALTER TABLE indexers ADD COLUMN include_parent_categories INTEGER NOT NULL DEFAULT 0;

--- a/internal/indexer/debug.go
+++ b/internal/indexer/debug.go
@@ -121,7 +121,7 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 			start := time.Now()
 
 			client := s.makeClient(idx.URL, idx.APIKey)
-			cats := filterCategoriesForMedia(idx.Categories, c.MediaType)
+			cats := filterCategoriesForMedia(idx.Categories, c.MediaType, idx.IncludeParentCategories)
 			entry.Categories = cats
 
 			hits, err := client.BookSearch(ctx, c.Title, c.Author, cats)

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -52,8 +52,8 @@ func NewSearcher() *Searcher {
 // rejected. MediaType filters the indexer category set; "audiobook" narrows
 // to the Newznab audiobook subcategory (303x, primarily 3030), anything else
 // narrows to the ebook subcategory (702x, primarily 7020). The broad parent
-// categories 7000 and 3000 are never sent — they cause indexers to return
-// noisier, less-targeted result sets.
+// categories 7000 and 3000 are only sent for indexers that explicitly opt in;
+// they can find releases missed by incomplete mappings but are often noisy.
 // AllowedLanguages is the author's metadata-profile language list; when it
 // contains exactly "eng" (or "en"), foreign-tagged releases are filtered out.
 type MatchCriteria struct {
@@ -93,12 +93,13 @@ func (s *Searcher) makeClient(baseURL, apiKey string) *newznab.Client {
 // match exists. Substituting a standard fallback ID (3030, 7020) on such
 // indexers returns unrelated results because the standard IDs do not cover
 // the indexer's extended subcategory tree.
-func filterCategoriesForMedia(cats []int, mediaType string) []int {
+func filterCategoriesForMedia(cats []int, mediaType string, includeParentCategories bool) []int {
 	// Newznab category convention: 7xxx is the Books parent (7020 ebook,
 	// 7030 magazines), 3xxx is Audio (3030 audiobook). The bare parents
-	// (7000 / 3000) are deliberately dropped: Prowlarr reports them for
-	// generic book trackers and sending them as-is returns the entire
-	// books or audio surface, which is noise.
+	// (7000 / 3000) are dropped by default: Prowlarr reports them for generic
+	// trackers and sending them as-is returns the entire books or audio surface.
+	// A per-indexer opt-in lets those parents pass when an indexer's mapping is
+	// incomplete; it never synthesizes a parent that was not configured.
 	//
 	// Beyond that, every non-parent subcategory in the matching bucket is
 	// trusted: the user explicitly added it to the indexer's category list
@@ -123,7 +124,7 @@ func filterCategoriesForMedia(cats []int, mediaType string) []int {
 	var out []int
 	hasNonStandard := false
 	for _, c := range cats {
-		if c/1000 == wantThousand && c != parent {
+		if c/1000 == wantThousand && (c != parent || includeParentCategories) {
 			out = append(out, c)
 		}
 		if c > 9999 {
@@ -165,7 +166,7 @@ func (s *Searcher) SearchBook(ctx context.Context, indexers []models.Indexer, c 
 			defer wg.Done()
 
 			client := s.makeClient(idx.URL, idx.APIKey)
-			cats := filterCategoriesForMedia(idx.Categories, c.MediaType)
+			cats := filterCategoriesForMedia(idx.Categories, c.MediaType, idx.IncludeParentCategories)
 			hits, err := client.BookSearch(ctx, c.Title, c.Author, cats)
 			if err != nil {
 				slog.Warn("indexer search failed", "indexer", idx.Name, "error", err)
@@ -197,7 +198,9 @@ func (s *Searcher) SearchBook(ctx context.Context, indexers []models.Indexer, c 
 	return results
 }
 
-// SearchQuery performs a generic text search across all enabled indexers.
+// SearchQuery performs a generic text search across all enabled indexers. It
+// intentionally retains its existing behavior and sends configured categories
+// directly because there is no media type with which to select a parent.
 func (s *Searcher) SearchQuery(ctx context.Context, indexers []models.Indexer, query string) []newznab.SearchResult {
 	var (
 		mu      sync.Mutex

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -93,13 +93,17 @@ func (s *Searcher) makeClient(baseURL, apiKey string) *newznab.Client {
 // match exists. Substituting a standard fallback ID (3030, 7020) on such
 // indexers returns unrelated results because the standard IDs do not cover
 // the indexer's extended subcategory tree.
+//
+// When includeParentCategories is true, the media-specific parent is prepended
+// even if it is absent from cats. Existing indexers may not have the parent
+// stored because Prowlarr sync historically removed it.
 func filterCategoriesForMedia(cats []int, mediaType string, includeParentCategories bool) []int {
 	// Newznab category convention: 7xxx is the Books parent (7020 ebook,
 	// 7030 magazines), 3xxx is Audio (3030 audiobook). The bare parents
 	// (7000 / 3000) are dropped by default: Prowlarr reports them for generic
 	// trackers and sending them as-is returns the entire books or audio surface.
-	// A per-indexer opt-in lets those parents pass when an indexer's mapping is
-	// incomplete; it never synthesizes a parent that was not configured.
+	// A per-indexer opt-in adds the relevant parent after filtering so it also
+	// works for existing rows from which Prowlarr sync previously removed it.
 	//
 	// Beyond that, every non-parent subcategory in the matching bucket is
 	// trusted: the user explicitly added it to the indexer's category list
@@ -118,13 +122,14 @@ func filterCategoriesForMedia(cats []int, mediaType string, includeParentCategor
 		parent = 3000
 		fallback = []int{3030}
 	}
-	if len(cats) == 0 {
-		return fallback
-	}
 	var out []int
 	hasNonStandard := false
+	hasParent := false
 	for _, c := range cats {
-		if c/1000 == wantThousand && (c != parent || includeParentCategories) {
+		if c == parent {
+			hasParent = true
+		}
+		if c/1000 == wantThousand && c != parent {
 			out = append(out, c)
 		}
 		if c > 9999 {
@@ -133,9 +138,19 @@ func filterCategoriesForMedia(cats []int, mediaType string, includeParentCategor
 	}
 	if len(out) == 0 {
 		if hasNonStandard {
-			return cats
+			for _, c := range cats {
+				if c != parent {
+					out = append(out, c)
+				}
+			}
+		} else if includeParentCategories && hasParent {
+			return []int{parent}
+		} else {
+			out = append([]int(nil), fallback...)
 		}
-		return fallback
+	}
+	if includeParentCategories {
+		out = append([]int{parent}, out...)
 	}
 	return out
 }

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -895,15 +895,17 @@ func TestFilterCategoriesParentOptIn(t *testing.T) {
 		mediaType string
 		want      []int
 	}{
+		{"existing ebook children", []int{7010, 7030, 7050}, "ebook", []int{7000, 7010, 7030, 7050}},
+		{"existing audiobook children", []int{3010, 3030, 3040}, "audiobook", []int{3000, 3010, 3030, 3040}},
 		{"ebook parent only", []int{7000}, "ebook", []int{7000}},
 		{"ebook parent and children", []int{7000, 7020, 7030}, "ebook", []int{7000, 7020, 7030}},
+		{"ebook parent after child is not duplicated", []int{7020, 7000}, "ebook", []int{7000, 7020}},
 		{"audiobook parent only", []int{3000}, "audiobook", []int{3000}},
 		{"audiobook parent and child", []int{3000, 3030}, "audiobook", []int{3000, 3030}},
 		{"ebook excludes audio parent", []int{3000, 7000, 7020}, "ebook", []int{7000, 7020}},
 		{"audiobook excludes books parent", []int{7000, 3000, 3030}, "audiobook", []int{3000, 3030}},
-		{"parent is not added", []int{7020}, "ebook", []int{7020}},
-		{"nonstandard fallback unchanged", []int{100060}, "ebook", []int{100060}},
-		{"empty still uses fallback", nil, "ebook", []int{7020}},
+		{"nonstandard categories retain parent opt-in", []int{100060}, "ebook", []int{7000, 100060}},
+		{"empty adds parent to fallback", nil, "ebook", []int{7000, 7020}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -913,6 +915,58 @@ func TestFilterCategoriesParentOptIn(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFilterCategoriesParentOptOutWithExistingChildren(t *testing.T) {
+	got := filterCategoriesForMedia([]int{7010, 7030, 7050}, "ebook", false)
+	want := []int{7010, 7030, 7050}
+	if !slices.Equal(got, want) {
+		t.Errorf("filterCategoriesForMedia() = %v, want %v", got, want)
+	}
+}
+
+func TestSearchBookUsesEachIndexersParentCategoryPreference(t *testing.T) {
+	newCaptureServer := func() (*httptest.Server, chan string) {
+		cats := make(chan string, 4)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case cats <- r.URL.Query().Get("cat"):
+			default:
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><rss xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/"><channel><newznab:response total="0"/></channel></rss>`))
+		}))
+		return srv, cats
+	}
+
+	enabledServer, enabledCats := newCaptureServer()
+	defer enabledServer.Close()
+	disabledServer, disabledCats := newCaptureServer()
+	defer disabledServer.Close()
+
+	searcher := newTestSearcher()
+	searcher.SearchBook(context.Background(), []models.Indexer{
+		{ID: 1, Name: "parent enabled", URL: enabledServer.URL, Categories: []int{7010, 7030, 7050}, IncludeParentCategories: true, Enabled: true},
+		{ID: 2, Name: "parent disabled", URL: disabledServer.URL, Categories: []int{7060}, IncludeParentCategories: false, Enabled: true},
+	}, MatchCriteria{Title: "Dune", Author: "Frank Herbert", MediaType: "ebook"})
+	close(enabledCats)
+	close(disabledCats)
+
+	assertAllCategories := func(name string, got <-chan string, want string) {
+		t.Helper()
+		count := 0
+		for cats := range got {
+			count++
+			if cats != want {
+				t.Errorf("%s request categories = %q, want %q", name, cats, want)
+			}
+		}
+		if count == 0 {
+			t.Errorf("%s made no search requests", name)
+		}
+	}
+	assertAllCategories("enabled indexer", enabledCats, "7000,7010,7030,7050")
+	assertAllCategories("disabled indexer", disabledCats, "7060")
 }
 
 func TestIsAudiobookFormat(t *testing.T) {

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -369,33 +370,33 @@ func TestFilterByLanguageAny(t *testing.T) {
 
 func TestFilterCategoriesForMedia(t *testing.T) {
 	all := []int{7000, 7020, 3030}
-	ebook := filterCategoriesForMedia(all, "ebook")
+	ebook := filterCategoriesForMedia(all, "ebook", false)
 	// 7000 (books parent) is dropped — sending the broad parent to indexers
 	// returns noise. 7020 is the canonical ebook subcategory. 3030 is audio
 	// so excluded from ebook search.
 	if !equalIntSlice(ebook, []int{7020}) {
 		t.Errorf("ebook filter = %v, want [7020]", ebook)
 	}
-	audio := filterCategoriesForMedia(all, "audiobook")
+	audio := filterCategoriesForMedia(all, "audiobook", false)
 	if len(audio) != 1 || audio[0] != 3030 {
 		t.Errorf("audiobook filter = %v, want [3030]", audio)
 	}
 	// Empty input falls back to the standard category for the media type.
-	if got := filterCategoriesForMedia(nil, "ebook"); len(got) != 1 || got[0] != 7020 {
+	if got := filterCategoriesForMedia(nil, "ebook", false); len(got) != 1 || got[0] != 7020 {
 		t.Errorf("nil + ebook should fall back to [7020], got %v", got)
 	}
-	if got := filterCategoriesForMedia(nil, "audiobook"); len(got) != 1 || got[0] != 3030 {
+	if got := filterCategoriesForMedia(nil, "audiobook", false); len(got) != 1 || got[0] != 3030 {
 		t.Errorf("nil + audiobook should fall back to [3030], got %v", got)
 	}
 	// Unknown type falls back to books.
-	if got := filterCategoriesForMedia(all, ""); len(got) != 1 {
+	if got := filterCategoriesForMedia(all, "", false); len(got) != 1 {
 		t.Errorf("empty type should default to books, got %v", got)
 	}
 	// Pre-v0.5.0 indexer config without 3030 still searches audiobooks
 	// via the fallback 3030 category rather than silently returning
 	// ebook results.
 	booksOnly := []int{7000, 7020}
-	if got := filterCategoriesForMedia(booksOnly, "audiobook"); len(got) != 1 || got[0] != 3030 {
+	if got := filterCategoriesForMedia(booksOnly, "audiobook", false); len(got) != 1 || got[0] != 3030 {
 		t.Errorf("no-match audiobook should fall back to [3030], got %v", got)
 	}
 }
@@ -773,12 +774,12 @@ func TestFilterRelevantStopWordsBetweenKeywords(t *testing.T) {
 func TestFilterCategoriesCustomIDs(t *testing.T) {
 	cats := []int{7020, 7120, 3030, 3130}
 
-	ebook := filterCategoriesForMedia(cats, "ebook")
+	ebook := filterCategoriesForMedia(cats, "ebook", false)
 	if !equalIntSlice(ebook, []int{7020, 7120}) {
 		t.Errorf("ebook cats = %v, want [7020, 7120]", ebook)
 	}
 
-	audio := filterCategoriesForMedia(cats, "audiobook")
+	audio := filterCategoriesForMedia(cats, "audiobook", false)
 	if !equalIntSlice(audio, []int{3030, 3130}) {
 		t.Errorf("audio cats = %v, want [3030, 3130]", audio)
 	}
@@ -791,11 +792,11 @@ func TestFilterCategoriesCustomIDs(t *testing.T) {
 func TestFilterCategoriesGermanEbooks(t *testing.T) {
 	cats := []int{7020, 7120, 7150, 7180, 3030}
 
-	ebook := filterCategoriesForMedia(cats, "ebook")
+	ebook := filterCategoriesForMedia(cats, "ebook", false)
 	if !equalIntSlice(ebook, []int{7020, 7120, 7150, 7180}) {
 		t.Errorf("ebook cats = %v, want all four 7xxx categories", ebook)
 	}
-	audio := filterCategoriesForMedia(cats, "audiobook")
+	audio := filterCategoriesForMedia(cats, "audiobook", false)
 	if !equalIntSlice(audio, []int{3030}) {
 		t.Errorf("audio cats = %v, want [3030]", audio)
 	}
@@ -825,7 +826,7 @@ func TestFilterCategoriesMaM(t *testing.T) {
 	// Typical MaM audiobook category list
 	mamAudioCats := []int{100013, 100039, 100041, 100042, 100044, 100045, 100046, 100047, 100111}
 
-	got := filterCategoriesForMedia(mamAudioCats, "audiobook")
+	got := filterCategoriesForMedia(mamAudioCats, "audiobook", false)
 	if len(got) != len(mamAudioCats) {
 		t.Fatalf("MaM audiobook cats: got %v, want all %v passed through", got, mamAudioCats)
 	}
@@ -838,7 +839,7 @@ func TestFilterCategoriesMaM(t *testing.T) {
 	// MaM ebook category list
 	mamEbookCats := []int{100014, 100060, 100062, 100063, 100064, 100112}
 
-	got = filterCategoriesForMedia(mamEbookCats, "ebook")
+	got = filterCategoriesForMedia(mamEbookCats, "ebook", false)
 	if len(got) != len(mamEbookCats) {
 		t.Fatalf("MaM ebook cats: got %v, want all %v passed through", got, mamEbookCats)
 	}
@@ -846,7 +847,7 @@ func TestFilterCategoriesMaM(t *testing.T) {
 	// Standard indexer with no audiobook cats still falls back correctly —
 	// the non-standard path must not fire when all configured IDs are standard.
 	booksOnly := []int{7000, 7020}
-	if fb := filterCategoriesForMedia(booksOnly, "audiobook"); len(fb) != 1 || fb[0] != 3030 {
+	if fb := filterCategoriesForMedia(booksOnly, "audiobook", false); len(fb) != 1 || fb[0] != 3030 {
 		t.Errorf("standard ebook-only indexer should fall back to [3030] for audiobook, got %v", fb)
 	}
 }
@@ -874,16 +875,43 @@ func TestFilterCategoriesParentDrop(t *testing.T) {
 		{[]int{7020, 7021, 7022}, "ebook", []int{7020, 7021, 7022}},
 	}
 	for _, tc := range cases {
-		got := filterCategoriesForMedia(tc.cats, tc.mediaType)
+		got := filterCategoriesForMedia(tc.cats, tc.mediaType, false)
 		if len(got) != len(tc.want) {
-			t.Errorf("filterCategoriesForMedia(%v, %q) = %v, want %v", tc.cats, tc.mediaType, got, tc.want)
+			t.Errorf("filterCategoriesForMedia(%v, %q, false) = %v, want %v", tc.cats, tc.mediaType, got, tc.want)
 			continue
 		}
 		for i := range tc.want {
 			if got[i] != tc.want[i] {
-				t.Errorf("filterCategoriesForMedia(%v, %q)[%d] = %d, want %d", tc.cats, tc.mediaType, i, got[i], tc.want[i])
+				t.Errorf("filterCategoriesForMedia(%v, %q, false)[%d] = %d, want %d", tc.cats, tc.mediaType, i, got[i], tc.want[i])
 			}
 		}
+	}
+}
+
+func TestFilterCategoriesParentOptIn(t *testing.T) {
+	tests := []struct {
+		name      string
+		cats      []int
+		mediaType string
+		want      []int
+	}{
+		{"ebook parent only", []int{7000}, "ebook", []int{7000}},
+		{"ebook parent and children", []int{7000, 7020, 7030}, "ebook", []int{7000, 7020, 7030}},
+		{"audiobook parent only", []int{3000}, "audiobook", []int{3000}},
+		{"audiobook parent and child", []int{3000, 3030}, "audiobook", []int{3000, 3030}},
+		{"ebook excludes audio parent", []int{3000, 7000, 7020}, "ebook", []int{7000, 7020}},
+		{"audiobook excludes books parent", []int{7000, 3000, 3030}, "audiobook", []int{3000, 3030}},
+		{"parent is not added", []int{7020}, "ebook", []int{7020}},
+		{"nonstandard fallback unchanged", []int{100060}, "ebook", []int{100060}},
+		{"empty still uses fallback", nil, "ebook", []int{7020}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterCategoriesForMedia(tt.cats, tt.mediaType, true)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("filterCategoriesForMedia(%v, %q, true) = %v, want %v", tt.cats, tt.mediaType, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/models/indexer.go
+++ b/internal/models/indexer.go
@@ -3,17 +3,18 @@ package models
 import "time"
 
 type Indexer struct {
-	ID                 int64  `json:"id"`
-	Name               string `json:"name"`
-	Type               string `json:"type"`
-	URL                string `json:"url"`
-	APIKey             string `json:"apiKey"`
-	Categories         []int  `json:"categories"`
-	Priority           int    `json:"priority"`
-	Enabled            bool   `json:"enabled"`
-	SupportsSearch     bool   `json:"supportsSearch"`
-	ProwlarrInstanceID *int64 `json:"prowlarrInstanceId,omitempty"`
-	ProwlarrIndexerID  *int   `json:"prowlarrIndexerId,omitempty"`
+	ID                      int64  `json:"id"`
+	Name                    string `json:"name"`
+	Type                    string `json:"type"`
+	URL                     string `json:"url"`
+	APIKey                  string `json:"apiKey"`
+	Categories              []int  `json:"categories"`
+	IncludeParentCategories bool   `json:"includeParentCategories"`
+	Priority                int    `json:"priority"`
+	Enabled                 bool   `json:"enabled"`
+	SupportsSearch          bool   `json:"supportsSearch"`
+	ProwlarrInstanceID      *int64 `json:"prowlarrInstanceId,omitempty"`
+	ProwlarrIndexerID       *int   `json:"prowlarrIndexerId,omitempty"`
 	// SeedRatio is the per-indexer seed-ratio override applied to torrents
 	// grabbed from this indexer. nil means "no override" (the download client
 	// keeps its global rule); an explicit -1 is the unlimited sentinel

--- a/internal/prowlarr/syncer.go
+++ b/internal/prowlarr/syncer.go
@@ -76,7 +76,9 @@ func (s *Syncer) Sync(ctx context.Context, instanceID int64) (SyncResult, error)
 		// ones disabled in Prowlarr, ones that don't support search, and
 		// ones with no ebook/audiobook categories. Users then deleted them
 		// manually and watched them reappear on the next sync.
-		cats := filterCategoriesForMedia(ri.Categories)
+		ex, exists := byProwlarrID[ri.ProwlarrID]
+		includeParentCategories := exists && ex.IncludeParentCategories
+		cats := filterCategoriesForMedia(ri.Categories, includeParentCategories)
 		switch {
 		case !ri.Enable:
 			slog.Debug("prowlarr sync: skipping disabled indexer",
@@ -98,7 +100,7 @@ func (s *Syncer) Sync(ctx context.Context, instanceID int64) (SyncResult, error)
 		instID := instanceID
 		idxType := indexerTypeForProtocol(ri.Protocol)
 
-		if ex, ok := byProwlarrID[ri.ProwlarrID]; ok {
+		if exists {
 			// Auto-populate the seed-ratio override from Prowlarr (#1065), but
 			// only on rows the user has not taken ownership of. An explicit
 			// user value/clear (source="user") always wins and is never touched;
@@ -191,10 +193,14 @@ func indexerTypeForProtocol(protocol string) string {
 
 // filterCategoriesForMedia normalises the Newznab category list at sync time.
 // Broad parent categories (7000 Other, 3000 Audio) are dropped when specific
-// children are already present. When only the parent is present (no children),
+// children are already present unless the indexer has opted in to retaining
+// parents. When only the parent is present (no children) and opt-in is off,
 // it is widened to its most useful specific child: 7000→7020 (Ebooks),
 // 3000→3030 (Audiobooks). All other categories pass through unchanged.
-func filterCategoriesForMedia(cats []int) []int {
+func filterCategoriesForMedia(cats []int, includeParentCategories bool) []int {
+	if includeParentCategories {
+		return append([]int(nil), cats...)
+	}
 	var has7000, has3000, hasChild7, hasChild3 bool
 	for _, c := range cats {
 		switch {

--- a/internal/prowlarr/syncer_test.go
+++ b/internal/prowlarr/syncer_test.go
@@ -105,7 +105,7 @@ func TestFilterCategoriesForMedia(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := filterCategoriesForMedia(tc.in)
+			got := filterCategoriesForMedia(tc.in, false)
 			if len(got) != len(tc.want) {
 				t.Errorf("filterCategoriesForMedia(%v) = %v, want %v", tc.in, got, tc.want)
 				return
@@ -116,6 +116,50 @@ func TestFilterCategoriesForMedia(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFilterCategoriesForMedia_ParentOptIn(t *testing.T) {
+	tests := []struct {
+		in, want []int
+	}{
+		{[]int{7000}, []int{7000}},
+		{[]int{7000, 7020, 7030}, []int{7000, 7020, 7030}},
+		{[]int{3000}, []int{3000}},
+		{[]int{3000, 3030}, []int{3000, 3030}},
+		{[]int{7020, 100060}, []int{7020, 100060}},
+	}
+	for _, tt := range tests {
+		got := filterCategoriesForMedia(tt.in, true)
+		if !intSliceEqual(got, tt.want) {
+			t.Errorf("filterCategoriesForMedia(%v, true) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSyncer_PreservesParentCategoryChoiceAndUpdatesCategories(t *testing.T) {
+	pID := 10
+	instID := int64(1)
+	existing := []models.Indexer{{
+		ID: 10, Name: "IndexerA", Type: "torznab", Categories: []int{7020},
+		IncludeParentCategories: true, ProwlarrInstanceID: &instID, ProwlarrIndexerID: &pID,
+	}}
+	srv := prowlarrStub(t, `[{"id":10,"name":"IndexerA","enable":true,"protocol":"torrent","supportsSearch":true,"categories":[{"id":7000},{"id":7020},{"id":7030}]}]`)
+	defer srv.Close()
+	existing[0].URL = srv.URL + "/10/api"
+	store := &fakeIndexerStore{existing: existing}
+
+	if _, err := NewSyncer(New(srv.URL, "k"), store, fakeInstanceStore{}).Sync(context.Background(), 1); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(store.updated) != 1 {
+		t.Fatalf("updated = %d, want 1", len(store.updated))
+	}
+	if !store.updated[0].IncludeParentCategories {
+		t.Fatal("IncludeParentCategories was overwritten during sync")
+	}
+	if want := []int{7000, 7020, 7030}; !intSliceEqual(store.updated[0].Categories, want) {
+		t.Errorf("Categories = %v, want %v", store.updated[0].Categories, want)
 	}
 }
 

--- a/web/src/api/indexers.ts
+++ b/web/src/api/indexers.ts
@@ -8,6 +8,7 @@ export interface Indexer {
   url: string
   apiKey: string
   categories: number[]
+  includeParentCategories?: boolean
   priority: number
   enabled: boolean
   prowlarrInstanceId?: number

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -421,6 +421,8 @@
         "categories": "Categories",
         "categoriesPlaceholder": "Categories (e.g. 7020, 7120, 3030)",
         "categoriesHint": "Comma-separated Newznab category IDs. 7020 = eBooks, 3030 = Audiobooks. Add custom IDs for indexers with non-standard categories (e.g. 7120 for German books).",
+        "includeParentCategories": "Include broad parent categories",
+        "includeParentCategoriesHint": "Search Books (7000) or Audio (3000) in addition to specific subcategories. This may find releases missed by incomplete mappings, but may also return comics, magazines, music, or other unrelated results.",
         "priority": "Priority",
         "priorityHint": "Higher wins ties when the same release is found on multiple indexers. Use it to prefer one indexer — e.g. set Usenet indexers above torrent ones. Default 0.",
         "seedRatio": "Seed ratio",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -390,6 +390,8 @@
         "categories": "카테고리",
         "categoriesPlaceholder": "카테고리 (예: 7020, 7120, 3030)",
         "categoriesHint": "쉼표로 구분된 Newznab 카테고리 ID입니다. 7020 = 전자책, 3030 = 오디오북. 비표준 카테고리를 사용하는 인덱서에는 사용자 지정 ID를 추가하세요(예: 독일어 도서의 경우 7120).",
+        "includeParentCategories": "Include broad parent categories",
+        "includeParentCategoriesHint": "Search Books (7000) or Audio (3000) in addition to specific subcategories. This may find releases missed by incomplete mappings, but may also return comics, magazines, music, or other unrelated results.",
         "priority": "우선순위",
         "priorityHint": "같은 릴리스가 여러 인덱서에서 발견될 때 값이 높을수록 우선합니다. 특정 인덱서를 선호하도록 설정하세요(예: Usenet 인덱서를 토렌트보다 높게). 기본값 0.",
         "seedRatio": "시드 비율",

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1244,6 +1244,7 @@ describe('SettingsPage', () => {
         apiKey: 'scene-key',
         type: 'torznab',
         categories: [7020, 7120, 3030],
+        includeParentCategories: false,
         priority: 0,
         enabled: true,
         seedRatio: null,
@@ -1274,10 +1275,28 @@ describe('SettingsPage', () => {
         url: 'https://slug.example.com/api',
         apiKey: 'slug-key',
         categories: [7020, 3030],
+        includeParentCategories: false,
         seedRatio: null,
       })
     })
     expect(await screen.findByText('DrunkenSlug')).toBeInTheDocument()
+  })
+
+  it('loads and changes the broad parent category option', async () => {
+    const indexer = makeIndexer({ id: 8, name: 'Parent Indexer', categories: [7000, 7020], includeParentCategories: true })
+    renderSettings({ indexers: [indexer] })
+    await openIndexersTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+    const checkbox = screen.getByRole('checkbox', { name: /settings\.indexers\.form\.includeParentCategories/ })
+    expect(checkbox).toBeChecked()
+    expect(screen.getByText('settings.indexers.form.includeParentCategoriesHint')).toBeInTheDocument()
+    fireEvent.click(checkbox)
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => {
+      expect(api.updateIndexer).toHaveBeenCalledWith(8, expect.objectContaining({ includeParentCategories: false }))
+    })
   })
 
   it('saves a numeric per-indexer seed ratio', async () => {

--- a/web/src/pages/settings/IndexersTab.tsx
+++ b/web/src/pages/settings/IndexersTab.tsx
@@ -89,6 +89,24 @@ function SeedRatioField({ value, onChange, source }: { value: number | null | un
   )
 }
 
+function ParentCategoriesField({ value, onChange }: { value: boolean; onChange: (v: boolean) => void }) {
+  const { t } = useTranslation()
+  return (
+    <label className="flex items-start gap-2 text-xs text-slate-600 dark:text-zinc-400">
+      <input
+        type="checkbox"
+        checked={value}
+        onChange={e => onChange(e.target.checked)}
+        className="mt-0.5 accent-emerald-600 dark:accent-emerald-500"
+      />
+      <span>
+        <span className="block font-medium text-slate-700 dark:text-zinc-300">{t('settings.indexers.form.includeParentCategories')}</span>
+        <span className="block mt-1 text-slate-500 dark:text-zinc-500">{t('settings.indexers.form.includeParentCategoriesHint')}</span>
+      </span>
+    </label>
+  )
+}
+
 // indexers/prowlarrInstances are owned by SettingsPage so they can be fetched
 // eagerly on page mount (matching the pre-refactor monolith), not on tab open.
 interface Props {
@@ -331,6 +349,7 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
   const [url, setUrl] = useState(indexer.url)
   const [apiKey, setApiKey] = useState(indexer.apiKey)
   const [categories, setCategories] = useState((indexer.categories ?? [7020]).join(', '))
+  const [includeParentCategories, setIncludeParentCategories] = useState(indexer.includeParentCategories ?? false)
   const [priority, setPriority] = useState(String(indexer.priority ?? 0))
   const [seedRatio, setSeedRatio] = useState<number | null>(indexer.seedRatio ?? null)
   const [testing, setTesting] = useState(false)
@@ -338,7 +357,7 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
-    const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey, categories: parseCats(categories), priority: parsePriority(priority), seedRatio })
+    const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey, categories: parseCats(categories), includeParentCategories, priority: parsePriority(priority), seedRatio })
     onSaved(updated)
   }
 
@@ -389,6 +408,7 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
         <input type="number" value={priority} onChange={e => setPriority(e.target.value)} placeholder="0" className={inputCls} />
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.priorityHint')}</p>
       </div>
+      <ParentCategoriesField value={includeParentCategories} onChange={setIncludeParentCategories} />
       <SeedRatioField value={seedRatio} onChange={setSeedRatio} source={indexer.seedRatioSource} />
       {testResult && <IndexerTestResultBanner r={testResult} />}
       <div className="flex gap-2 justify-end">
@@ -407,6 +427,7 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
   const [url, setUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [categories, setCategories] = useState('7020')
+  const [includeParentCategories, setIncludeParentCategories] = useState(false)
   const [priority, setPriority] = useState('0')
   const [seedRatio, setSeedRatio] = useState<number | null>(null)
   const [testing, setTesting] = useState(false)
@@ -414,7 +435,7 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
-    const idx = await api.addIndexer({ name, url, apiKey, type, categories: parseCats(categories), priority: parsePriority(priority), enabled: true, seedRatio })
+    const idx = await api.addIndexer({ name, url, apiKey, type, categories: parseCats(categories), includeParentCategories, priority: parsePriority(priority), enabled: true, seedRatio })
     onAdded(idx)
   }
 
@@ -465,6 +486,7 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
         <input type="number" value={priority} onChange={e => setPriority(e.target.value)} placeholder="0" className={inputCls} />
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.priorityHint')}</p>
       </div>
+      <ParentCategoriesField value={includeParentCategories} onChange={setIncludeParentCategories} />
       <SeedRatioField value={seedRatio} onChange={setSeedRatio} />
       {testResult && <IndexerTestResultBanner r={testResult} />}
       <div className="flex gap-2 justify-end">


### PR DESCRIPTION
## Summary

Adds a per-indexer option to include broad Newznab Books (`7000`) and Audio (`3000`) parent categories in searches. This helps recover releases from indexers with incomplete category mappings while remaining disabled by default to avoid unrelated results.

- Adds the option to indexer create/edit forms and API responses.
- Persists the setting through a forward-only database migration.
- Preserves the local choice during Prowlarr synchronization.
- Maintains compatibility with older API clients that omit the field.
- Updates backend and frontend tests, documentation, translations, and the changelog fragment.
- Ensures `SearchBook` adds the appropriate parent to the outbound category list even when earlier Prowlarr synchronization removed it from the stored categories.
- Applies each indexer's preference independently and avoids duplicate parent categories.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed *(N/A; no deployment configuration or upgrade steps changed)*
- [x] Added a changelog fragment under `changelog.d/` *(not an edit to `CHANGELOG.md`)*
- [x] Wiki pages updated if user-facing behavior changed *(N/A; the relevant guidance is in `docs/QUICKSTART.md`, which was updated)*

## Test Plan

- [x] Targeted indexer category and `SearchBook` tests.
- [x] Go build, vet, lint, and race tests for the changed indexer package.
- [x] `go test ./internal/api`
- [x] Frontend typecheck, lint, production build, and 410 tests.
- [x] GoReleaser snapshot validation.
- [x] `make check` — all stages passed except the race-enabled `internal/api` package exceeded the 10-minute timeout while repeatedly applying test migrations. No assertion or race failure was reported, and the package passed separately without race instrumentation.
- [x] Built and deployed the updated container alongside the existing Bindery installation using the same database, enabled broad parent categories on an existing indexer, and confirmed that ebook searches include `7000` and can successfully grab EPUB releases advertised only under that parent category.