### PR TITLE
fix(indexer): apply metadata profile languages to release filtering and auto-grab

### DIFF
--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -428,6 +428,7 @@ func main() {
 		authorRepo, bookRepo, indexerRepo, downloadRepo, dlClientRepo, settingsRepo, blocklistRepo)
 	sched.WithHistory(historyRepo)
 	sched.WithAliases(authorAliasRepo)
+	sched.WithMetadataProfiles(metadataProfileRepo)
 	sched.WithDelayProfiles(delayProfileRepo)
 	sched.WithPendingReleases(pendingReleaseRepo)
 	sched.WithStoragePaths(cfg.DownloadDir, cfg.AudiobookDownloadDir)

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/vavallee/bindery/internal/auth"
@@ -392,18 +393,19 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 	var specs []decision.Specification
 
 	// Language filter: author profile takes precedence, fall back to global setting.
-	lang := langFilterFromAllowed(allowedLangs)
-	if lang == "" {
-		if s, _ := h.settings.Get(r.Context(), "search.preferredLanguage"); s != nil {
-			lang = s.Value
-		}
-	}
 	beforeLang := len(results)
-	results = indexer.FilterByLanguage(results, lang)
+	filterDesc := ""
+	if len(allowedLangs) > 0 {
+		results = indexer.FilterByAllowedLanguages(results, allowedLangs)
+		filterDesc = "allowed=" + strings.Join(allowedLangs, ",")
+	} else if s, _ := h.settings.Get(r.Context(), "search.preferredLanguage"); s != nil {
+		results = indexer.FilterByLanguage(results, s.Value)
+		filterDesc = "filter=" + s.Value
+	}
 	if dbg != nil && beforeLang != len(results) {
 		dbg.Filters = append(dbg.Filters, indexer.FilterDebug{
 			Stage:  "language",
-			Reason: "release name matched a foreign-language tag (filter=" + lang + ")",
+			Reason: "release name tagged with a language outside the profile (" + filterDesc + ")",
 			Title:  "(" + strconv.Itoa(beforeLang-len(results)) + " result(s) dropped)",
 		})
 	}
@@ -488,17 +490,6 @@ func (h *IndexerHandler) resolveAllowedLanguages(ctx context.Context, author *mo
 		return []string{}
 	}
 	return models.ParseAllowedLanguages(p.AllowedLanguages)
-}
-
-// langFilterFromAllowed converts an AllowedLanguages slice to the single-lang
-// token expected by indexer.FilterByLanguage. Returns "en" only when the
-// profile is English-exclusive (so the foreign-tag filter is active).
-// Returns "" for multi-language or empty profiles (filter is skipped).
-func langFilterFromAllowed(langs []string) string {
-	if len(langs) == 1 && (langs[0] == "en" || langs[0] == "eng") {
-		return "en"
-	}
-	return ""
 }
 
 // SearchQuery performs a freeform search across all indexers.

--- a/internal/api/indexers_test.go
+++ b/internal/api/indexers_test.go
@@ -253,26 +253,6 @@ func TestIndexerSearchQuery_MissingQ(t *testing.T) {
 	}
 }
 
-func TestLangFilterFromAllowed(t *testing.T) {
-	for _, tc := range []struct {
-		langs []string
-		want  string
-		desc  string
-	}{
-		{[]string{"en"}, "en", "English-only (en)"},
-		{[]string{"eng"}, "en", "English-only (eng)"},
-		{[]string{"en", "fr"}, "", "multi-language — no filter"},
-		{[]string{"fr"}, "", "French-only — no English filter"},
-		{nil, "", "nil — no filter"},
-		{[]string{}, "", "empty — no filter"},
-	} {
-		got := langFilterFromAllowed(tc.langs)
-		if got != tc.want {
-			t.Errorf("%s: langFilterFromAllowed(%v) = %q, want %q", tc.desc, tc.langs, got, tc.want)
-		}
-	}
-}
-
 func TestSearchBook_DualFormat_MediaTypeTagging(t *testing.T) {
 	database, err := db.OpenMemory()
 	if err != nil {

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -54,8 +54,10 @@ func NewSearcher() *Searcher {
 // narrows to the ebook subcategory (702x, primarily 7020). The broad parent
 // categories 7000 and 3000 are never sent — they cause indexers to return
 // noisier, less-targeted result sets.
-// AllowedLanguages is the author's metadata-profile language list; when it
-// contains exactly "eng" (or "en"), foreign-tagged releases are filtered out.
+// AllowedLanguages is the author's metadata-profile language list; callers
+// apply it to results via FilterByAllowedLanguages (releases tagged with a
+// language outside the set are dropped). Recorded here so search debug
+// output shows which set was in force.
 type MatchCriteria struct {
 	Title            string
 	Author           string
@@ -772,54 +774,107 @@ func protocolForType(t string) string {
 	return "usenet"
 }
 
-// knownForeignTags lists release-name markers indicating a non-English
-// release. Matched at word boundaries against the normalized title — so
-// "RUSSE" (French for "Russian") no longer falsely matches "RUSSELL".
-var knownForeignTags = []string{
-	"french", "francais",
-	"vf", "vostfr", "vff",
-	"german", "deutsch",
-	"spanish", "espanol", "español",
-	"dutch", "netherlands",
-	"italian", "italiano",
-	"portuguese", "portugues",
-	"russian", "russe",
-	"japanese", "japonais",
-	"chinese", "mandarin",
-	"korean",
-	"arabic", "arabe",
-	"swedish", "svenska", "norwegian", "danish",
-	"polish", "polski",
-	"czech",
-	"turkish",
-	"hindi",
+// releaseLanguageTags maps release-name language markers to the ISO 639-2/B
+// code of the language they indicate. Matched at word boundaries against the
+// normalized title — so "RUSSE" (French for "Russian") no longer falsely
+// matches "RUSSELL". The codes use the same vocabulary the metadata-profile
+// editor writes into allowed_languages, so a profile's language set can be
+// checked against a release directly.
+var releaseLanguageTags = map[string]string{
+	"english": "eng",
+	"french":  "fre", "francais": "fre",
+	"vf": "fre", "vostfr": "fre", "vff": "fre",
+	"german": "ger", "deutsch": "ger",
+	"spanish": "spa", "espanol": "spa", "español": "spa",
+	"dutch": "dut", "netherlands": "dut",
+	"italian": "ita", "italiano": "ita",
+	"portuguese": "por", "portugues": "por",
+	"russian": "rus", "russe": "rus",
+	"japanese": "jpn", "japonais": "jpn",
+	"chinese": "chi", "mandarin": "chi",
+	"korean": "kor",
+	"arabic": "ara", "arabe": "ara",
+	"swedish": "swe", "svenska": "swe",
+	"norwegian": "nor",
+	"danish":    "dan",
+	"polish":    "pol", "polski": "pol",
+	"czech":   "cze",
+	"turkish": "tur",
+	"hindi":   "hin",
 }
 
-// FilterByLanguage removes results whose titles contain known foreign-language
-// markers when lang is "en". When lang is "any" (or empty), all results pass.
-// Tag matching is word-boundary anchored to avoid false positives (e.g. the
-// former "RUSSE" ⊂ "RUSSELL" bug).
-func FilterByLanguage(results []newznab.SearchResult, lang string) []newznab.SearchResult {
-	if lang == "" || lang == "any" {
+// iso639TwoLetterAliases maps common two-letter (ISO 639-1) codes to the
+// 639-2/B codes used by releaseLanguageTags and the profile editor, so a
+// hand-edited profile like "it,en" still filters correctly.
+var iso639TwoLetterAliases = map[string]string{
+	"en": "eng", "fr": "fre", "de": "ger", "nl": "dut", "es": "spa",
+	"it": "ita", "pt": "por", "ja": "jpn", "zh": "chi", "ru": "rus",
+}
+
+// releaseLanguageCodes returns the distinct language codes indicated by
+// markers in the normalized release title. Empty means the release carries no
+// recognisable language tag.
+func releaseLanguageCodes(norm string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for tag, code := range releaseLanguageTags {
+		if seen[code] {
+			continue
+		}
+		if WordBoundaryRegex(tag).MatchString(norm) {
+			seen[code] = true
+			out = append(out, code)
+		}
+	}
+	return out
+}
+
+// FilterByAllowedLanguages drops results whose release name is tagged with a
+// language outside the metadata profile's allowed set. Untagged releases
+// always pass — most releases carry no language marker, and dropping them
+// would empty nearly every search; the tag check can only ever be a negative
+// signal. An empty allowed list disables the filter, and codes are normalized
+// to the ISO 639-2/B vocabulary the profile editor writes ("en" → "eng").
+func FilterByAllowedLanguages(results []newznab.SearchResult, allowed []string) []newznab.SearchResult {
+	if len(allowed) == 0 {
 		return results
 	}
-	if lang != "en" {
-		return results
+	set := make(map[string]bool, len(allowed))
+	for _, code := range allowed {
+		code = strings.ToLower(strings.TrimSpace(code))
+		if alias, ok := iso639TwoLetterAliases[code]; ok {
+			code = alias
+		}
+		if code == "any" {
+			return results
+		}
+		set[code] = true
 	}
 
 	filtered := make([]newznab.SearchResult, 0, len(results))
 	for _, r := range results {
 		norm := NormalizeRelease(r.Title)
-		foreign := false
-		for _, tag := range knownForeignTags {
-			if WordBoundaryRegex(tag).MatchString(norm) {
-				foreign = true
+		ok := true
+		for _, code := range releaseLanguageCodes(norm) {
+			if !set[code] {
+				ok = false
 				break
 			}
 		}
-		if !foreign {
+		if ok {
 			filtered = append(filtered, r)
 		}
 	}
 	return filtered
+}
+
+// FilterByLanguage removes results whose titles contain known foreign-language
+// markers when lang is "en". When lang is "any" (or empty), all results pass.
+// This is the global search.preferredLanguage setting's filter; profile-aware
+// callers use FilterByAllowedLanguages directly.
+func FilterByLanguage(results []newznab.SearchResult, lang string) []newznab.SearchResult {
+	if lang != "en" {
+		return results
+	}
+	return FilterByAllowedLanguages(results, []string{"eng"})
 }

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -678,6 +678,63 @@ func TestFilterByLanguagePassesAllWhenNoForeignTags(t *testing.T) {
 	}
 }
 
+func TestFilterByAllowedLanguages(t *testing.T) {
+	results := toResults(
+		"Il.Libro.ITALIAN.epub", // ita — allowed
+		"The.Book.epub",         // untagged — passes
+		"The.Book.ENGLISH.epub", // eng — allowed
+		"Das.Buch.GERMAN.epub",  // ger — dropped
+		"Le.Livre.FRENCH.epub",  // fre — dropped
+		"El.Libro.SPANISH.epub", // spa — dropped
+	)
+	got := FilterByAllowedLanguages(results, []string{"ita", "eng"})
+	want := []string{"Il.Libro.ITALIAN.epub", "The.Book.epub", "The.Book.ENGLISH.epub"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d results, got %v", len(want), resultTitles(got))
+	}
+	for _, w := range want {
+		if !contains(got, w) {
+			t.Errorf("expected %q to pass the ita/eng filter, got %v", w, resultTitles(got))
+		}
+	}
+}
+
+func TestFilterByAllowedLanguagesTwoLetterAliases(t *testing.T) {
+	results := toResults(
+		"Il.Libro.ITALIANO.epub",
+		"Das.Buch.GERMAN.epub",
+	)
+	// Hand-edited profiles may hold 639-1 codes; "it" must behave like "ita".
+	got := FilterByAllowedLanguages(results, []string{"it"})
+	if !contains(got, "Il.Libro.ITALIANO.epub") || contains(got, "Das.Buch.GERMAN.epub") {
+		t.Errorf("alias 'it' should keep the Italian release and drop the German one, got %v", resultTitles(got))
+	}
+}
+
+func TestFilterByAllowedLanguagesDisabled(t *testing.T) {
+	results := toResults("Das.Buch.GERMAN.epub", "The.Book.epub")
+	if got := FilterByAllowedLanguages(results, nil); len(got) != 2 {
+		t.Errorf("empty allowed set must pass everything, got %v", resultTitles(got))
+	}
+	if got := FilterByAllowedLanguages(results, []string{"ita", "any"}); len(got) != 2 {
+		t.Errorf("an 'any' entry must disable the filter, got %v", resultTitles(got))
+	}
+}
+
+func TestFilterByLanguageEnglishKeepsEnglishTagged(t *testing.T) {
+	results := toResults(
+		"The.Book.ENGLISH.epub",
+		"Das.Buch.GERMAN.epub",
+	)
+	got := FilterByLanguage(results, "en")
+	if !contains(got, "The.Book.ENGLISH.epub") {
+		t.Error("explicitly ENGLISH-tagged release must pass lang=en")
+	}
+	if contains(got, "Das.Buch.GERMAN.epub") {
+		t.Error("GERMAN-tagged release must be dropped for lang=en")
+	}
+}
+
 func TestIsArticle(t *testing.T) {
 	for _, w := range []string{"the", "The", "THE", "a", "A", "an", "AN"} {
 		if !IsArticle(w) {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -140,14 +140,15 @@ type Scheduler struct {
 	blocklist            *db.BlocklistRepo
 	delayProfiles        *db.DelayProfileRepo
 	pending              *db.PendingReleaseRepo
-	aliases              *db.AuthorAliasRepo  // optional; used for non-latin author matching
-	calibreSyncer        CalibreSyncer        // optional; nil if Calibre is not configured
-	recommender          RecommendationEngine // optional; generates recommendations
-	hcSyncer             HCListSyncer         // optional; syncs Hardcover import lists
-	telemetry            TelemetryPinger      // optional; sends daily anonymous install ping
-	logs                 *db.LogRepo          // optional; enables periodic log retention trim
-	notif                eventNotifier        // optional; fires EventGrabbed on auto-grab success (#849)
-	logRetainDays        int                  // 0 = use default (14)
+	aliases              *db.AuthorAliasRepo     // optional; used for non-latin author matching
+	profiles             *db.MetadataProfileRepo // optional; applies profile language filters to auto-grab
+	calibreSyncer        CalibreSyncer           // optional; nil if Calibre is not configured
+	recommender          RecommendationEngine    // optional; generates recommendations
+	hcSyncer             HCListSyncer            // optional; syncs Hardcover import lists
+	telemetry            TelemetryPinger         // optional; sends daily anonymous install ping
+	logs                 *db.LogRepo             // optional; enables periodic log retention trim
+	notif                eventNotifier           // optional; fires EventGrabbed on auto-grab success (#849)
+	logRetainDays        int                     // 0 = use default (14)
 	downloadDir          string
 	audiobookDownloadDir string
 }
@@ -223,6 +224,14 @@ func (s *Scheduler) WithHistory(h *db.HistoryRepo) {
 // in MatchCriteria for non-latin author name matching. Must be called before Start.
 func (s *Scheduler) WithAliases(aliases *db.AuthorAliasRepo) {
 	s.aliases = aliases
+}
+
+// WithMetadataProfiles attaches the metadata profile repo so auto-grab can
+// apply the author's allowed-languages set to search results — previously
+// only the interactive search honoured it (Discussion #1572). Must be called
+// before Start.
+func (s *Scheduler) WithMetadataProfiles(profiles *db.MetadataProfileRepo) {
+	s.profiles = profiles
 }
 
 // WithStoragePaths attaches the process-level download roots used when sending
@@ -451,6 +460,26 @@ func (s *Scheduler) SearchAndGrabBook(ctx context.Context, book models.Book) {
 	}
 }
 
+// resolveAllowedLanguages returns the parsed allowed-language list for an
+// author's metadata profile, mirroring the api package's resolver. Returns
+// empty (no filter) when the repo is unattached or the profile cannot be
+// loaded — falling back to English-only would silently break users whose
+// indexers return language-tagged releases.
+func (s *Scheduler) resolveAllowedLanguages(ctx context.Context, author *models.Author) []string {
+	if s.profiles == nil {
+		return nil
+	}
+	id := models.DefaultMetadataProfileID
+	if author.MetadataProfileID != nil {
+		id = *author.MetadataProfileID
+	}
+	p, err := s.profiles.GetByID(ctx, id)
+	if err != nil || p == nil {
+		return nil
+	}
+	return models.ParseAllowedLanguages(p.AllowedLanguages)
+}
+
 // resolveSeedRatio looks up the per-indexer seed-ratio override (#883) for the
 // indexer a release was grabbed from. Returns nil (no override) when the
 // indexer repo is unset, the id is zero, the lookup fails, or the indexer has
@@ -490,11 +519,13 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 
 	authorName := ""
 	var authorAliases []string
+	var allowedLangs []string
 	if s.authors != nil {
 		if a, err := s.authors.GetByID(ctx, book.AuthorID); err != nil {
 			slog.Warn("failed to load author for search", "author_id", book.AuthorID, "error", err)
 		} else if a != nil {
 			authorName = a.Name
+			allowedLangs = s.resolveAllowedLanguages(ctx, a)
 			if s.aliases != nil {
 				if aliases, err := s.aliases.ListByAuthor(ctx, a.ID); err == nil {
 					for _, al := range aliases {
@@ -505,18 +536,26 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		}
 	}
 	crit := indexer.MatchCriteria{
-		Title:         book.Title,
-		Author:        authorName,
-		MediaType:     mediaType,
-		ASIN:          book.ASIN,
-		AuthorAliases: authorAliases,
+		Title:            book.Title,
+		Author:           authorName,
+		MediaType:        mediaType,
+		ASIN:             book.ASIN,
+		AuthorAliases:    authorAliases,
+		AllowedLanguages: allowedLangs,
 	}
 	if book.ReleaseDate != nil {
 		crit.Year = book.ReleaseDate.Year()
 	}
 
 	results := s.searcher.SearchBook(ctx, idxs, crit)
-	results = indexer.FilterByLanguage(results, lang)
+	// Author profile takes precedence over the global preferred-language
+	// setting, mirroring the interactive SearchBook endpoint (Discussion
+	// #1572: auto-grab previously ignored the profile entirely).
+	if len(allowedLangs) > 0 {
+		results = indexer.FilterByAllowedLanguages(results, allowedLangs)
+	} else {
+		results = indexer.FilterByLanguage(results, lang)
+	}
 
 	var specs []decision.Specification
 	if s.blocklist != nil {

--- a/internal/scheduler/scheduler_language_test.go
+++ b/internal/scheduler/scheduler_language_test.go
@@ -1,0 +1,138 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/indexer"
+	"github.com/vavallee/bindery/internal/indexer/newznab"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// fixedResultsSearcher returns a canned result set and records the criteria
+// it was called with, so tests can assert what searchAndGrabFormat resolved.
+type fixedResultsSearcher struct {
+	results  []newznab.SearchResult
+	lastCrit indexer.MatchCriteria
+}
+
+func (s *fixedResultsSearcher) SearchBook(_ context.Context, _ []models.Indexer, c indexer.MatchCriteria) []newznab.SearchResult {
+	s.lastCrit = c
+	return s.results
+}
+
+// languageFixture builds a DB-backed scheduler whose author is bound to a
+// metadata profile restricted to allowedLanguages, plus one enabled usenet
+// client so an approved release proceeds all the way to a download record.
+// The client points at 127.0.0.1:1, so the send itself fails fast — the
+// download row is still created first, which is the observable we assert on.
+func languageFixture(t *testing.T, allowedLanguages string, results []newznab.SearchResult) (*Scheduler, *fixedResultsSearcher, *db.DownloadRepo, models.Book) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	profiles := db.NewMetadataProfileRepo(database)
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+	downloads := db.NewDownloadRepo(database)
+
+	p := &models.MetadataProfile{Name: "Restricted", AllowedLanguages: allowedLanguages}
+	if err := profiles.Create(ctx, p); err != nil {
+		t.Fatalf("profile create: %v", err)
+	}
+	a := &models.Author{
+		ForeignID: "OL-LANG-A", Name: "Autore Prova", SortName: "Prova, Autore",
+		MetadataProvider: "ol", Monitored: true, MetadataProfileID: &p.ID,
+	}
+	if err := authors.Create(ctx, a); err != nil {
+		t.Fatalf("author create: %v", err)
+	}
+	book := models.Book{
+		ForeignID: "OL-LANG-B", AuthorID: a.ID, Title: "Il Libro",
+		SortTitle: "Il Libro", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "ol", Monitored: true,
+		MediaType: models.MediaTypeEbook,
+	}
+	if err := books.Create(ctx, &book); err != nil {
+		t.Fatalf("book create: %v", err)
+	}
+	if err := clients.Create(ctx, &models.DownloadClient{
+		Name: "sab", Type: "sabnzbd", Host: "127.0.0.1", Port: 1, Enabled: true,
+	}); err != nil {
+		t.Fatalf("client create: %v", err)
+	}
+
+	// downloads.indexer_id carries an FK, so results need a real indexer row.
+	indexers := db.NewIndexerRepo(database)
+	idx := &models.Indexer{Name: "stub", Type: "newznab", URL: "http://127.0.0.1:1", Enabled: true}
+	if err := indexers.Create(ctx, idx); err != nil {
+		t.Fatalf("indexer create: %v", err)
+	}
+	for i := range results {
+		results[i].IndexerID = idx.ID
+	}
+
+	ss := &fixedResultsSearcher{results: results}
+	s := &Scheduler{
+		searcher:  ss,
+		indexers:  indexers,
+		authors:   authors,
+		settings:  db.NewSettingsRepo(database),
+		blocklist: db.NewBlocklistRepo(database),
+		downloads: downloads,
+		clients:   clients,
+		profiles:  profiles,
+	}
+	return s, ss, downloads, book
+}
+
+// TestSearchAndGrabFormat_DropsDisallowedLanguage is the regression test for
+// Discussion #1572: auto-grab used to ignore the author's metadata-profile
+// languages entirely, so an ITA-only profile happily grabbed German releases.
+func TestSearchAndGrabFormat_DropsDisallowedLanguage(t *testing.T) {
+	ctx := context.Background()
+	s, ss, downloads, book := languageFixture(t, "ita", []newznab.SearchResult{
+		{GUID: "g-ger", Title: "Das.Buch.GERMAN.epub", NZBURL: "http://127.0.0.1:1/1", Protocol: "usenet"},
+	})
+
+	s.searchAndGrabFormat(ctx, book, models.MediaTypeEbook)
+
+	if got := ss.lastCrit.AllowedLanguages; len(got) != 1 || got[0] != "ita" {
+		t.Errorf("expected profile languages [ita] on the search criteria, got %v", got)
+	}
+	rows, err := downloads.List(ctx)
+	if err != nil {
+		t.Fatalf("downloads list: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("GERMAN-tagged release must not be grabbed under an ITA-only profile, got %d download(s)", len(rows))
+	}
+}
+
+// TestSearchAndGrabFormat_GrabsAllowedLanguage is the control: an allowed
+// (or untagged) release still proceeds to a download record.
+func TestSearchAndGrabFormat_GrabsAllowedLanguage(t *testing.T) {
+	ctx := context.Background()
+	s, _, downloads, book := languageFixture(t, "ita,eng", []newznab.SearchResult{
+		{GUID: "g-ita", Title: "Il.Libro.ITALIANO.epub", NZBURL: "http://127.0.0.1:1/2", Protocol: "usenet"},
+	})
+
+	s.searchAndGrabFormat(ctx, book, models.MediaTypeEbook)
+
+	rows, err := downloads.List(ctx)
+	if err != nil {
+		t.Fatalf("downloads list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ITALIANO-tagged release should be grabbed under an ita,eng profile, got %d download(s)", len(rows))
+	}
+	if rows[0].GUID != "g-ita" {
+		t.Errorf("grabbed GUID = %q, want g-ita", rows[0].GUID)
+	}
+}


### PR DESCRIPTION
## Summary

Metadata profile allowed languages now actually constrain what gets downloaded. Previously the release filter only activated for English exclusive profiles, and the auto grab path never loaded the profile at all, so an ITA/ENG profile still grabbed German or French releases whenever one ranked first (Discussion #1572). Closes #1573.

## Implementation notes

| Piece | Change |
|-------|--------|
| `indexer.releaseLanguageTags` | The former `knownForeignTags` list becomes a map from release marker to ISO 639-2/B code (`german` → `ger`), plus an `english` → `eng` entry, so any profile set can be checked against a release |
| `indexer.FilterByAllowedLanguages` | New: drops results tagged with a language outside the allowed set. Untagged releases always pass, since the tag can only ever be a negative signal. Tolerates 639-1 codes (`it` → `ita`) |
| `indexer.FilterByLanguage` | Now a thin wrapper: `en` delegates to `FilterByAllowedLanguages(["eng"])`, anything else passes. Kept for the global `search.preferredLanguage` fallback |
| `api.SearchBook` | Uses the profile aware filter when the author's profile restricts languages; falls back to the global setting otherwise. `langFilterFromAllowed` deleted |
| `scheduler.searchAndGrabFormat` | Resolves the author's profile (new `WithMetadataProfiles` wiring) and applies the same filter before grabbing, mirroring the interactive path |

Behaviour notes: an English only profile now also keeps explicitly ENGLISH tagged releases (previously indistinguishable from untagged). Ranking still has no language component; this only drops releases with a recognisable tag outside the set.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (see `commits` skill — `docs/`, `README.md`, godoc, Helm values)
- [x] Wiki pages updated if user-facing behaviour changed (none apply; README's "language filter" line still accurate)

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [x] `go test -race ./internal/indexer/ ./internal/scheduler/` and targeted `-race` on the api search tests
- [x] `gofmt`, `go vet`, `golangci-lint v2.11.4`, `govulncheck`
- [x] `go test -count=1 ./tests/smoke/...` (scheduler wiring changed)
