### PR TITLE
fix(metadata): keep the primary provider's author identity through search dedup

### DIFF
--- a/internal/metadata/aggregator.go
+++ b/internal/metadata/aggregator.go
@@ -74,9 +74,18 @@ func (a *Aggregator) SearchAuthors(ctx context.Context, query string) ([]models.
 
 	var all []models.Author
 	for i := range providers {
+		// Stamp records that arrived without a provider identity with the
+		// provider that returned them, so the primary-preference below (and
+		// the add flow) can trust MetadataProvider.
+		pname := normalizedProviderName(providerName(providers[i]))
+		for j := range results[i] {
+			if results[i][j].MetadataProvider == "" {
+				results[i][j].MetadataProvider = pname
+			}
+		}
 		all = append(all, results[i]...)
 	}
-	merged := dedupeAuthorsByName(all)
+	merged := dedupeAuthorsByName(all, normalizedProviderName(providerName(a.primary)))
 	rerankAuthorsByRelevance(merged, query)
 	return merged, nil
 }
@@ -235,18 +244,20 @@ func authorBookCount(a models.Author) int {
 }
 
 // dedupeAuthorsByName collapses records that refer to the same person (canonical
-// name) to the single most-complete one — most works, then most ratings (each
-// compared only when both report it, since only some providers populate them),
-// then the earliest (provider-first) occurrence. Records with an empty name pass
-// through untouched. Output order follows the kept records' positions.
-func dedupeAuthorsByName(authors []models.Author) []models.Author {
+// name) to the single most-complete one — primary-provider identity first, then
+// most works, then most ratings (each compared only when both report it, since
+// only some providers populate them), then the earliest (provider-first)
+// occurrence. primaryProvider is the normalized name of the configured primary
+// metadata provider; pass "" to disable the preference. Records with an empty
+// name pass through untouched. Output order follows the kept records' positions.
+func dedupeAuthorsByName(authors []models.Author, primaryProvider string) []models.Author {
 	best := make(map[string]int)
 	for i := range authors {
 		key := canonicalAuthorKey(authors[i].Name)
 		if key == "" {
 			continue
 		}
-		if j, ok := best[key]; !ok || betterAuthorRecord(authors[i], authors[j]) {
+		if j, ok := best[key]; !ok || betterAuthorRecord(authors[i], authors[j], primaryProvider) {
 			best[key] = i
 		}
 	}
@@ -261,11 +272,19 @@ func dedupeAuthorsByName(authors []models.Author) []models.Author {
 }
 
 // betterAuthorRecord reports whether record a is a more complete representative
-// of an author than b. A provider that reports a count (>0) is preferred over
-// one that doesn't (0 = unknown), so OpenLibrary's work/ratings-bearing records
-// win over enrichers that omit them; ties keep the earlier (provider-first) one.
-func betterAuthorRecord(a, b models.Author) bool {
+// of an author than b. The primary provider's record wins outright (after the
+// noise-name check): the author's provider identity decides where the catalogue
+// is imported from, so a user who promoted DNB to primary must get the dnb:
+// record even though OpenLibrary's same-name record reports richer counts
+// (issue #1574 — DNB-primary setups silently imported English OL catalogues).
+// Beyond that, a provider that reports a count (>0) is preferred over one that
+// doesn't (0 = unknown), so OpenLibrary's work/ratings-bearing records win over
+// enrichers that omit them; ties keep the earlier (provider-first) one.
+func betterAuthorRecord(a, b models.Author, primaryProvider string) bool {
 	if c := preferNonDuplicatedAuthorName(a.Name, b.Name); c != 0 {
+		return c > 0
+	}
+	if c := preferPrimaryProvider(a, b, primaryProvider); c != 0 {
 		return c > 0
 	}
 	if c := preferKnownGreater(authorBookCount(a), authorBookCount(b)); c != 0 {
@@ -275,6 +294,24 @@ func betterAuthorRecord(a, b models.Author) bool {
 		return c > 0
 	}
 	return false
+}
+
+// preferPrimaryProvider prefers the record carrying the configured primary
+// provider's identity. Returns 0 when the preference is disabled (primary
+// unknown) or both records agree on being primary / non-primary.
+func preferPrimaryProvider(a, b models.Author, primaryProvider string) int {
+	if primaryProvider == "" {
+		return 0
+	}
+	ap := normalizedProviderName(a.MetadataProvider) == primaryProvider
+	bp := normalizedProviderName(b.MetadataProvider) == primaryProvider
+	if ap == bp {
+		return 0
+	}
+	if ap {
+		return 1
+	}
+	return -1
 }
 
 // preferNonDuplicatedAuthorName prefers a clean author label over provider noise

--- a/internal/metadata/aggregator_test.go
+++ b/internal/metadata/aggregator_test.go
@@ -377,6 +377,43 @@ func TestAggregator_SearchAuthors_CollapsesFragments(t *testing.T) {
 	}
 }
 
+// TestAggregator_SearchAuthors_PrimaryProviderIdentityWins is the regression
+// test for issue #1574: with DNB promoted to primary, the dnb: author record
+// must survive dedup even though OpenLibrary's same-name record reports work
+// and rating counts DNB never populates. The author's provider identity decides
+// where the catalogue imports from, so losing the dnb: record silently turned a
+// German-primary setup back into an English OpenLibrary catalogue.
+func TestAggregator_SearchAuthors_PrimaryProviderIdentityWins(t *testing.T) {
+	stats := func(n int) *models.AuthorStats { return &models.AuthorStats{BookCount: n} }
+	dnb := &mockProvider{name: "dnb", searchAuthors: []models.Author{
+		{Name: "Rothfuss, Patrick", ForeignID: "dnb:gnd:132949156", MetadataProvider: "dnb"},
+	}}
+	ol := &mockProvider{name: "ol", searchAuthors: []models.Author{
+		{Name: "Patrick Rothfuss", ForeignID: "OL1394865A", MetadataProvider: "openlibrary", Statistics: stats(23), RatingsCount: 900},
+	}}
+
+	// DNB primary: the count-less dnb: record wins the collapse.
+	got, err := newTestAggregator(dnb, ol).SearchAuthors(context.Background(), "Patrick Rothfuss")
+	if err != nil {
+		t.Fatalf("SearchAuthors: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("same-person records should collapse to 1, got %d: %+v", len(got), got)
+	}
+	if got[0].ForeignID != "dnb:gnd:132949156" {
+		t.Errorf("DNB primary must keep the dnb: identity, got %s", got[0].ForeignID)
+	}
+
+	// OL primary with DNB as enricher: unchanged behaviour, OL record wins.
+	got, err = newTestAggregator(ol, dnb).SearchAuthors(context.Background(), "Patrick Rothfuss")
+	if err != nil {
+		t.Fatalf("SearchAuthors: %v", err)
+	}
+	if len(got) != 1 || got[0].ForeignID != "OL1394865A" {
+		t.Errorf("OL primary must keep the OL identity, got %+v", got)
+	}
+}
+
 func TestAggregator_SearchAuthors_PrefersCleanNameOverDuplicatedProviderNoise(t *testing.T) {
 	stats := func(n int) *models.AuthorStats { return &models.AuthorStats{BookCount: n} }
 	primary := &mockProvider{name: "ol", searchAuthors: []models.Author{


### PR DESCRIPTION
## Summary

With DNB promoted to primary metadata provider, author search still handed back the OpenLibrary identity for any author both providers know, so the imported catalogue carried English OL work titles and book-driven searches could never find the German releases. The dedup that collapses same-name records judged "most complete" purely by work and rating counts, which only OpenLibrary reports; the dnb: record lost every time. Closes #1574.

## Implementation notes

- `dedupeAuthorsByName` / `betterAuthorRecord` now take the normalized primary provider name, and a record carrying the primary's identity wins the collapse ahead of the count comparisons (the noise-name guard still runs first). The author's provider identity decides where `GetAuthorWorks` imports from, so this one preference flips the whole downstream chain (catalogue titles, profile refresh, search queries) to the primary provider.
- `SearchAuthors` stamps records that arrive without a `MetadataProvider` with the provider that returned them, so the preference (and the add flow) can trust the field.
- OL-primary setups see no behaviour change: the preference is a no-op when both records agree on being primary or not, and OL wins the count comparison as before. Covered by the existing fragment-collapse test plus both directions in the new regression test.
- Existing authors already imported under the OL identity are not migrated; they can be relinked once via "Link metadata" on the author page (noted on the issue).

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (no env/config/API surface change; behaviour now matches what the README's "can be promoted to primary" already promises)
- [x] Wiki pages updated if user-facing behaviour changed (none apply)

## Test plan

- [x] `go test ./cmd/... ./internal/...`
- [x] `go test -race ./internal/metadata/`
- [x] `gofmt`, `go vet`, `golangci-lint v2.11.4`
