### PR TITLE
fix(dnb): deduplicate author-catalogue editions into one book per work

### DIFF
--- a/internal/metadata/dnb/client.go
+++ b/internal/metadata/dnb/client.go
@@ -146,13 +146,41 @@ func (c *Client) GetAuthorWorks(ctx context.Context, authorForeignID string) ([]
 	if err != nil {
 		return nil, fmt.Errorf("dnb get author works %s: %w", authorForeignID, err)
 	}
+	// Series titles the author's records declare in MARC 490/800 — used to drop
+	// whole-series records (e.g. the complete-series audiobook titled "Die
+	// Königsmörder-Chronik") that would otherwise show up as a book (#1574).
+	seriesTitles := collectSeriesTitles(records)
 	books := make([]models.Book, 0, len(records))
+	vols := make([]int, 0, len(records))
 	for _, rec := range records {
-		if b := recordToBook(rec); b != nil {
-			books = append(books, *b)
+		b := recordToBook(rec)
+		if b == nil {
+			continue
 		}
+		// A record catalogued under a collective/series title names the actual book
+		// in 245 $p (e.g. $a="Die Königsmörder-Chronik" $p="Der Name des Windes").
+		// Prefer that individual title so the record collapses onto the standalone
+		// edition instead of surviving as a series-named dup — even though the two
+		// carry different ISBNs (#1574).
+		if title, vol, isPart := seriesPartTitle(rec); isPart {
+			b.Title = title
+			b.SortTitle = title
+			books = append(books, *b)
+			vols = append(vols, vol)
+			continue
+		}
+		// No $p: a record whose own title is a known series name is a whole-series
+		// / omnibus product, not one of the author's books — drop it.
+		if seriesTitles[workDedupKey(b.Title)] {
+			continue
+		}
+		books = append(books, *b)
+		vols = append(vols, dnbVolumeNumber(rec, b.Title))
 	}
-	return books, nil
+	// DNB returns one record per edition/printing/volume; collapse the printings
+	// of each volume to a single book so the author catalogue doesn't fill with
+	// near-duplicate rows, while keeping distinct volumes apart (#1574 follow-up).
+	return collapseAuthorWorks(books, vols), nil
 }
 
 // GetBook fetches a single record by its DNB control number (the foreignID

--- a/internal/metadata/dnb/works.go
+++ b/internal/metadata/dnb/works.go
@@ -1,0 +1,325 @@
+package dnb
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// collapseAuthorWorks merges the several catalogue records DNB returns for the
+// same physical book into one, while keeping genuinely distinct volumes apart.
+// Unlike OpenLibrary, DNB has no "work" abstraction: every edition, printing,
+// and volume is its own bibliographic record, each with a slightly different 245
+// title. A German multi-volume translation is the tricky case — "Die Furcht des
+// Weisen" ships as two Bände, and DNB holds several records for each:
+//
+//	Die Furcht des Weisen                                     (Teil 1 via 245 $n)
+//	Die Furcht des Weisen (1): … Band 1                       (Band 1)
+//	Die Furcht des Weisen/Band 1: …                           (Band 1)
+//	Die Furcht des Weisen (2): … Band 2                       (Band 2)
+//	Die Furcht des Weisen/Band 2: …                           (Band 2)
+//
+// Grouping by (work title, volume number) collapses the printings of each Band
+// to one row but preserves Band 1 and Band 2 as separate books — so the two-part
+// work surfaces as two entries, not five and not one (#1574). Each vols[i] is the
+// volume number for books[i] (0 = none), derived by the caller from the title
+// marker or MARC 245 $n.
+//
+// When a work has numbered volumes, its combined/undesignated edition (vol 0,
+// e.g. the one-volume "Die Furcht des Weisen : Roman" published alongside the two
+// Bände) is dropped: it is the same content as the volumes together and would
+// otherwise show up as a redundant third row. A work with no numbered volumes
+// keeps its single record untouched, so a standalone title carrying a real
+// subtitle is never rewritten. Order follows first appearance so the catalogue's
+// relevance ordering survives.
+func collapseAuthorWorks(books []models.Book, vols []int) []models.Book {
+	// A work title that has at least one numbered volume; its vol-0 combined
+	// edition is redundant and dropped below.
+	numbered := make(map[string]bool, len(books))
+	for i, b := range books {
+		if vols[i] > 0 {
+			numbered[workDedupKey(b.Title)] = true
+		}
+	}
+	order := make([]string, 0, len(books))
+	groups := make(map[string][]int, len(books))
+	for i, b := range books {
+		work := workDedupKey(b.Title)
+		if vols[i] == 0 && numbered[work] {
+			continue
+		}
+		key := work + "#" + strconv.Itoa(vols[i])
+		if _, ok := groups[key]; !ok {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], i)
+	}
+	result := make([]models.Book, 0, len(order))
+	for _, key := range order {
+		result = append(result, collapseGroup(books, vols, groups[key]))
+	}
+	return result
+}
+
+// collapseGroup reduces the records sharing one (work, volume) key to a single
+// book. When the group is a real collapse (more than one record) or the record
+// carries a volume number, the title is rebuilt as the clean work title plus the
+// volume ("Die Furcht des Weisen 1"), matching the form the issue asked for. A
+// lone record with no volume is returned untouched so its subtitle survives. The
+// representative prefers a record that was already a plain work title so a later
+// single-record GetBook refresh returns a matching title; the remaining records
+// fill gaps (date, description, cover, language, ISBNs).
+func collapseGroup(books []models.Book, vols []int, idxs []int) models.Book {
+	baseIdx := idxs[0]
+	for _, i := range idxs {
+		if isPlainWorkRecord(books[i].Title) {
+			baseIdx = i
+			break
+		}
+	}
+	rep := books[baseIdx]
+	vol := vols[baseIdx]
+	if len(idxs) == 1 && vol == 0 {
+		return rep
+	}
+	title := workBaseTitle(rep.Title)
+	if vol > 0 {
+		title += " " + strconv.Itoa(vol)
+	}
+	rep.Title = title
+	rep.SortTitle = title
+	for _, i := range idxs {
+		if i == baseIdx {
+			continue
+		}
+		rep = fillWorkFields(rep, books[i])
+	}
+	return rep
+}
+
+// fillWorkFields fills gaps in dst from src without overwriting existing values,
+// keeps the earlier release date, and unions the edition/ISBN lists.
+func fillWorkFields(dst, src models.Book) models.Book {
+	if dst.Description == "" {
+		dst.Description = src.Description
+	}
+	if dst.ImageURL == "" {
+		dst.ImageURL = src.ImageURL
+	}
+	if dst.Language == "" {
+		dst.Language = src.Language
+	}
+	if dst.Author == nil {
+		dst.Author = src.Author
+	}
+	if src.ReleaseDate != nil && (dst.ReleaseDate == nil || src.ReleaseDate.Before(*dst.ReleaseDate)) {
+		dst.ReleaseDate = src.ReleaseDate
+	}
+	dst.Editions = append(dst.Editions, src.Editions...)
+	return dst
+}
+
+// collectSeriesTitles returns the set of work keys for every series title the
+// records declare in MARC 490 $a (series statement) and 800 $t (series added
+// entry). A record whose own title matches one of these is a whole-series /
+// omnibus product (e.g. the complete-series audiobook "Die Königsmörder-Chronik
+// : vollständige Lesung"), not one of the author's individual books.
+func collectSeriesTitles(records []marcRecord) map[string]bool {
+	titles := make(map[string]bool)
+	for _, rec := range records {
+		for _, s := range rec.subfieldAll("490", "a") {
+			if k := workDedupKey(marcClean(s)); k != "" {
+				titles[k] = true
+			}
+		}
+		for _, s := range rec.subfieldAll("800", "t") {
+			if k := workDedupKey(marcClean(s)); k != "" {
+				titles[k] = true
+			}
+		}
+	}
+	return titles
+}
+
+// seriesPartTitle extracts the individual work title from MARC 245 $p and the
+// volume number from the $n that follows it. Returns ok=false when the record
+// has no $p (the common single-work case), so the caller keeps the assembled
+// title. The pre-$p $n (the record's position within the collective series, e.g.
+// "Tag 2") is deliberately ignored — it is not a volume of the individual work.
+func seriesPartTitle(rec marcRecord) (string, int, bool) {
+	for _, df := range rec.DataFields {
+		if df.Tag != "245" {
+			continue
+		}
+		title, vol, seenP := "", 0, false
+		for _, sf := range df.Subfields {
+			switch sf.Code {
+			case "p":
+				if !seenP {
+					if t := cleanPartTitle(sf.Value); t != "" {
+						title, seenP = t, true
+					}
+				}
+			case "n":
+				if seenP && vol == 0 {
+					vol = parseVolumeToken(sf.Value)
+				}
+			}
+		}
+		return title, vol, seenP
+	}
+	return "", 0, false
+}
+
+// cleanPartTitle normalizes a MARC 245 $p value to the bare work title, dropping
+// the statement-of-responsibility ("/ …"), a bracketed edition note (": [Mit
+// Bonuskapitel …]"), and promotional chains ("| …").
+func cleanPartTitle(s string) string {
+	s = marcClean(s)
+	for _, sep := range []string{" / ", " : ", " | "} {
+		if i := strings.Index(s, sep); i > 0 {
+			s = s[:i]
+		}
+	}
+	return strings.TrimSpace(strings.Trim(s, " /:.,;"))
+}
+
+// volumeMarkerRe matches a trailing volume designator on a DNB main title:
+// "(1)", "/Band 1", " Band 1", " Bd. 1", "/Teil 2", " Teil 2". The number may be
+// arabic or a short roman numeral; the whole marker sits at the end of the title.
+// The two capture groups hold the number from the parenthetical and worded forms.
+var volumeMarkerRe = regexp.MustCompile(`(?i)\s*[/,]?\s*(?:\((\d+|[ivxlcdm]+)\)|(?:band|bd\.?|teil|vol\.?|volume)\s*\.?\s*(\d+|[ivxlcdm]+))\s*$`)
+
+// dnbVolumeNumber returns the volume/part number for a DNB record, or 0 when the
+// record is not part of a numbered multi-volume set. The title marker wins (it
+// is the most specific), falling back to MARC 245 $n ("Teil 1.", "Band 2") — the
+// subfield DNB uses for the plain-titled first volume that carries no marker in
+// its 245 $a.
+func dnbVolumeNumber(rec marcRecord, title string) int {
+	if v := titleVolumeNumber(title); v > 0 {
+		return v
+	}
+	return parseVolumeToken(rec.subfield("245", "n"))
+}
+
+// titleVolumeNumber extracts the trailing volume number from a record title,
+// looking only at the main-title head (before the subtitle colon).
+func titleVolumeNumber(title string) int {
+	head := title
+	if i := strings.Index(head, ":"); i > 0 {
+		head = head[:i]
+	}
+	m := volumeMarkerRe.FindStringSubmatch(strings.TrimSpace(head))
+	if m == nil {
+		return 0
+	}
+	if m[1] != "" {
+		return parseVolumeToken(m[1])
+	}
+	return parseVolumeToken(m[2])
+}
+
+// parseVolumeToken parses a volume token that may be a bare arabic number, a
+// roman numeral, or a worded value like "Teil 1." Returns 0 when no number is
+// present.
+func parseVolumeToken(s string) int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	if n, ok := firstArabicNumber(s); ok {
+		return n
+	}
+	return romanToInt(s)
+}
+
+func firstArabicNumber(s string) (int, bool) {
+	start := strings.IndexFunc(s, func(r rune) bool { return r >= '0' && r <= '9' })
+	if start < 0 {
+		return 0, false
+	}
+	end := start
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	n, err := strconv.Atoi(s[start:end])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func romanToInt(s string) int {
+	vals := map[rune]int{'i': 1, 'v': 5, 'x': 10, 'l': 50, 'c': 100, 'd': 500, 'm': 1000}
+	total, prev := 0, 0
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		v, ok := vals[r]
+		if !ok {
+			return 0
+		}
+		if v > prev && prev != 0 {
+			total += v - 2*prev
+		} else {
+			total += v
+		}
+		prev = v
+	}
+	return total
+}
+
+// workBaseTitle reduces a DNB record title to the underlying work title: it drops
+// the subtitle (everything after the first colon, which cleanDNBTitle assembles
+// from MARC 245 $b) and strips a trailing volume marker. Applied repeatedly so
+// "Die Furcht des Weisen (1)" and "Die Furcht des Weisen/Band 1" both reduce to
+// "Die Furcht des Weisen".
+func workBaseTitle(title string) string {
+	head := title
+	if i := strings.Index(head, ":"); i > 0 {
+		head = head[:i]
+	}
+	head = strings.TrimSpace(head)
+	for {
+		stripped := strings.TrimRight(strings.TrimSpace(volumeMarkerRe.ReplaceAllString(head, "")), " /,-–—")
+		if stripped == head || stripped == "" {
+			break
+		}
+		head = stripped
+	}
+	if head == "" {
+		return strings.TrimSpace(title)
+	}
+	return head
+}
+
+// workDedupKey is the normalized grouping key for workBaseTitle: lowercased,
+// NFC-folded, punctuation removed, and whitespace collapsed, so titles that
+// differ only in case, spacing, or diacritic encoding group together.
+func workDedupKey(title string) string {
+	var b strings.Builder
+	space := false
+	for _, r := range norm.NFC.String(strings.ToLower(workBaseTitle(title))) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			if space && b.Len() > 0 {
+				b.WriteByte(' ')
+			}
+			space = false
+			b.WriteRune(r)
+		default:
+			space = true
+		}
+	}
+	return b.String()
+}
+
+// isPlainWorkRecord reports whether a title is already a bare work title — no
+// subtitle and no trailing volume marker — i.e. workBaseTitle leaves it
+// unchanged. Such records are preferred as the surviving representative.
+func isPlainWorkRecord(title string) bool {
+	return strings.EqualFold(strings.TrimSpace(title), workBaseTitle(title))
+}

--- a/internal/metadata/dnb/works_test.go
+++ b/internal/metadata/dnb/works_test.go
@@ -1,6 +1,9 @@
 package dnb
 
 import (
+	"context"
+	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -69,6 +72,72 @@ func TestCollapseAuthorWorks_MergesPrintingsKeepsVolumes(t *testing.T) {
 	}
 }
 
+// MARC fixtures for the end-to-end GetAuthorWorks collapse test. Each is a
+// distinct DNB record for the Kingkiller Chronicle catalogue.
+const (
+	// Standalone edition of book 1; declares its series in 490/800.
+	marcNameDesWindes = `<record xmlns="http://www.loc.gov/MARC21/slim">
+	  <controlfield tag="001">1207871044</controlfield>
+	  <datafield tag="245" ind1="1" ind2="0"><subfield code="a">Der Name des Windes</subfield></datafield>
+	  <datafield tag="490" ind1="1" ind2=" "><subfield code="a">Die Königsmörder-Chronik</subfield><subfield code="v">1. Tag</subfield></datafield>
+	  <datafield tag="800" ind1="1" ind2=" "><subfield code="a">Rothfuss, Patrick</subfield><subfield code="t">Die Königsmörder-Chronik</subfield><subfield code="v">1. Tag</subfield></datafield>
+	</record>`
+	// Same book catalogued under the series title, with the real title in 245 $p.
+	marcSeriesPartTag1 = `<record xmlns="http://www.loc.gov/MARC21/slim">
+	  <controlfield tag="001">1001929233</controlfield>
+	  <datafield tag="245" ind1="1" ind2="0"><subfield code="a">Die Königsmörder-Chronik</subfield><subfield code="n">Tag 1.</subfield><subfield code="p">Der Name des Windes</subfield></datafield>
+	</record>`
+	// Complete-series audiobook titled with the series name — must be dropped.
+	marcSeriesAudiobook = `<record xmlns="http://www.loc.gov/MARC21/slim">
+	  <controlfield tag="001">1264435096</controlfield>
+	  <datafield tag="245" ind1="1" ind2="0"><subfield code="a">Die Königsmörder-Chronik</subfield><subfield code="b">vollständige Lesung</subfield></datafield>
+	</record>`
+	// Book 2, volume 1 — volume comes from 245 $n.
+	marcFurchtTeil1 = `<record xmlns="http://www.loc.gov/MARC21/slim">
+	  <controlfield tag="001">1243544937</controlfield>
+	  <datafield tag="245" ind1="1" ind2="0"><subfield code="a">Die Furcht des Weisen</subfield><subfield code="n">Teil 1.</subfield></datafield>
+	</record>`
+	// Another printing of book 2, volume 1 — volume comes from the title marker.
+	marcFurchtBand1 = `<record xmlns="http://www.loc.gov/MARC21/slim">
+	  <controlfield tag="001">1073137554</controlfield>
+	  <datafield tag="245" ind1="1" ind2="0"><subfield code="a">Die Furcht des Weisen (1)</subfield><subfield code="b">Die Königsmörder-Chronik. Zweiter Tag. Band 1</subfield></datafield>
+	</record>`
+)
+
+// TestGetAuthorWorks_CollapsesEditions drives the whole GetAuthorWorks path over
+// a canned SRU response: the series-part edition merges onto the standalone book,
+// the two book-2 printings collapse to one volume, the series-name audiobook is
+// dropped, and a record with no 001 is skipped — leaving one clean book per work.
+func TestGetAuthorWorks_CollapsesEditions(t *testing.T) {
+	body := sruXMLN("6",
+		marcNameDesWindes,
+		marcSeriesPartTag1,
+		marcSeriesAudiobook,
+		marcFurchtTeil1,
+		marcFurchtBand1,
+		marcNoID, // no 001 controlfield → recordToBook returns nil, skipped
+	)
+	c := mockXMLClient(body, http.StatusOK)
+
+	books, err := c.GetAuthorWorks(context.Background(), "Rothfuss, Patrick")
+	if err != nil {
+		t.Fatalf("GetAuthorWorks: %v", err)
+	}
+	got := make([]string, len(books))
+	for i, b := range books {
+		got[i] = b.Title
+	}
+	want := []string{"Der Name des Windes", "Die Furcht des Weisen 1"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("GetAuthorWorks titles = %v, want %v", got, want)
+	}
+	// The series-part edition (dnb:1001929233) merged onto the standalone work's
+	// identity (dnb:1207871044), not the other way round.
+	if books[0].ForeignID != idPrefix+"1207871044" {
+		t.Errorf("Der Name des Windes foreign id = %q, want %s1207871044", books[0].ForeignID, idPrefix)
+	}
+}
+
 func marc245(subs ...string) marcRecord {
 	df := marcDataField{Tag: "245"}
 	for i := 0; i+1 < len(subs); i += 2 {
@@ -106,6 +175,11 @@ func TestSeriesPartTitle(t *testing.T) {
 			rec:  marc245("a", "Die Furcht des Weisen", "n", "Teil 1."),
 			ok:   false,
 		},
+		{
+			name: "blank $p is ignored",
+			rec:  marc245("a", "Die Königsmörder-Chronik", "p", "   "),
+			ok:   false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -114,6 +188,24 @@ func TestSeriesPartTitle(t *testing.T) {
 				t.Errorf("seriesPartTitle = (%q, %d, %v), want (%q, %d, %v)", title, vol, ok, tc.title, tc.vol, tc.ok)
 			}
 		})
+	}
+}
+
+// TestSeriesPartTitle_FieldOrder covers a 245 preceded by another datafield (the
+// tag-skip path) and a record with no 245 at all (the fallback return).
+func TestSeriesPartTitle_FieldOrder(t *testing.T) {
+	before := marcRecord{DataFields: []marcDataField{
+		{Tag: "100", Subfields: []marcSubfield{{Code: "a", Value: "Rothfuss, Patrick"}}},
+		{Tag: "245", Subfields: []marcSubfield{{Code: "a", Value: "Der Name des Windes"}}},
+	}}
+	if _, _, ok := seriesPartTitle(before); ok {
+		t.Errorf("a 245 without $p must report not-a-part")
+	}
+	no245 := marcRecord{DataFields: []marcDataField{
+		{Tag: "100", Subfields: []marcSubfield{{Code: "a", Value: "X"}}},
+	}}
+	if _, _, ok := seriesPartTitle(no245); ok {
+		t.Errorf("a record with no 245 must report not-a-part")
 	}
 }
 
@@ -152,7 +244,11 @@ func TestTitleVolumeNumber(t *testing.T) {
 }
 
 func TestParseVolumeToken(t *testing.T) {
-	cases := map[string]int{"Teil 1.": 1, "Band 2": 2, "3": 3, "iv": 4, "": 0, "Teil": 0}
+	cases := map[string]int{
+		"Teil 1.": 1, "Band 2": 2, "3": 3, "iv": 4, "": 0, "Teil": 0,
+		// A digit run that overflows int falls through to 0 (not a real volume).
+		"99999999999999999999": 0,
+	}
 	for in, want := range cases {
 		if got := parseVolumeToken(in); got != want {
 			t.Errorf("parseVolumeToken(%q) = %d, want %d", in, got, want)
@@ -166,6 +262,8 @@ func TestWorkBaseTitle(t *testing.T) {
 		"Die Furcht des Weisen (1): Die Königsmörder-Chronik. Zweiter Tag. Band 1": "Die Furcht des Weisen",
 		"Die Furcht des Weisen/Band 1: Die Königsmörder-Chronik. Zweiter Tag":      "Die Furcht des Weisen",
 		"Sturz der Titanen: Die Jahrhundert-Saga":                                  "Sturz der Titanen",
+		// Degenerate title whose main part is empty falls back to the trimmed original.
+		" : Untertitel": ": Untertitel",
 	}
 	for in, want := range cases {
 		if got := workBaseTitle(in); got != want {

--- a/internal/metadata/dnb/works_test.go
+++ b/internal/metadata/dnb/works_test.go
@@ -1,0 +1,186 @@
+package dnb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func book(title, id string, year int) models.Book {
+	b := models.Book{ForeignID: idPrefix + id, Title: title, SortTitle: title, MetadataProvider: "dnb"}
+	if year != 0 {
+		t := time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)
+		b.ReleaseDate = &t
+	}
+	return b
+}
+
+// TestCollapseAuthorWorks_MergesPrintingsKeepsVolumes reproduces the real DNB
+// catalogue for "Die Furcht des Weisen" (#1574): the two "Band 1" printings
+// collapse into one book, the two "Band 2" printings into another, the combined
+// single-volume edition (vol 0) is dropped as redundant, so the two-volume work
+// surfaces as exactly two entries — not six, not one — while genuinely distinct
+// titles pass through untouched.
+func TestCollapseAuthorWorks_MergesPrintingsKeepsVolumes(t *testing.T) {
+	books := []models.Book{
+		book("Der Name des Windes", "1207871044", 2008),
+		book("Die Furcht des Weisen (1): Die Königsmörder-Chronik. Zweiter Tag. Band 1", "1073137554", 2013),
+		book("Die Furcht des Weisen/Band 1: Die Königsmörder-Chronik. Zweiter Tag", "1038456037", 2012),
+		book("Die Furcht des Weisen", "1243544937", 2011),        // Teil 1 via 245 $n
+		book("Die Furcht des Weisen: Roman", "1244247731", 2021), // combined edition, no volume
+		book("Die Furcht des Weisen (2): Die Königsmörder-Chronik. Zweiter Tag. Band 2", "1073139808", 2013),
+		book("Die Furcht des Weisen/Band 2: Die Königsmörder-Chronik. Zweiter Tag", "1038456010", 2012),
+		book("Die Musik der Stille", "1264403445", 2015),
+	}
+	// Volume numbers as the caller derives them (title marker, or 245 $n for the
+	// plain first-volume record); the combined edition has none.
+	vols := []int{0, 1, 1, 1, 0, 2, 2, 0}
+
+	got := collapseAuthorWorks(books, vols)
+
+	titles := make([]string, len(got))
+	for i, b := range got {
+		titles[i] = b.Title
+	}
+	want := []string{
+		"Der Name des Windes",
+		"Die Furcht des Weisen 1",
+		"Die Furcht des Weisen 2",
+		"Die Musik der Stille",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("collapsed to %d books, want %d: %v", len(got), len(want), titles)
+	}
+	for i := range want {
+		if titles[i] != want[i] {
+			t.Errorf("book[%d] = %q, want %q (order must be preserved)", i, titles[i], want[i])
+		}
+	}
+
+	// Volume 1 must survive as the plain work record and carry the earliest date
+	// gathered from its merged printings.
+	v1 := got[1]
+	if v1.ForeignID != idPrefix+"1243544937" {
+		t.Errorf("volume 1 foreign id = %q, want the plain work record dnb:1243544937", v1.ForeignID)
+	}
+	if v1.ReleaseDate == nil || v1.ReleaseDate.Year() != 2011 {
+		t.Errorf("volume 1 release date = %v, want earliest (2011)", v1.ReleaseDate)
+	}
+}
+
+func marc245(subs ...string) marcRecord {
+	df := marcDataField{Tag: "245"}
+	for i := 0; i+1 < len(subs); i += 2 {
+		df.Subfields = append(df.Subfields, marcSubfield{Code: subs[i], Value: subs[i+1]})
+	}
+	return marcRecord{DataFields: []marcDataField{df}}
+}
+
+// TestSeriesPartTitle covers the series-catalogued editions the user flagged: a
+// record whose 245 $a is the collective series title but whose $p names the
+// individual book must resolve to that book's title (and its post-$p volume, if
+// any), so it collapses onto the standalone edition despite a different ISBN. A
+// record with no $p reports ok=false so the caller keeps the assembled title
+// (#1574).
+func TestSeriesPartTitle(t *testing.T) {
+	cases := []struct {
+		name  string
+		rec   marcRecord
+		title string
+		vol   int
+		ok    bool
+	}{
+		{
+			name:  "series part resolves to individual title, no sub-volume",
+			rec:   marc245("a", "Die Königsmörder-Chronik", "n", "Tag 1.", "p", "Der Name des Windes : [Mit Bonuskapitel aus Bd. 2]"),
+			title: "Der Name des Windes", vol: 0, ok: true,
+		},
+		{
+			name:  "series part with a splitting volume after $p",
+			rec:   marc245("a", "Die Königsmörder-Chronik", "n", "Tag 2.", "p", "Die Furcht des Weisen / [übertr. von …]", "n", "Teil 1"),
+			title: "Die Furcht des Weisen", vol: 1, ok: true,
+		},
+		{
+			name: "no $p reports not-a-part",
+			rec:  marc245("a", "Die Furcht des Weisen", "n", "Teil 1."),
+			ok:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			title, vol, ok := seriesPartTitle(tc.rec)
+			if ok != tc.ok || (ok && (title != tc.title || vol != tc.vol)) {
+				t.Errorf("seriesPartTitle = (%q, %d, %v), want (%q, %d, %v)", title, vol, ok, tc.title, tc.vol, tc.ok)
+			}
+		})
+	}
+}
+
+// TestCollectSeriesTitles verifies series names are gathered from MARC 490/800 so
+// a whole-series record titled with the series name can be dropped (#1574).
+func TestCollectSeriesTitles(t *testing.T) {
+	rec := marcRecord{DataFields: []marcDataField{
+		{Tag: "245", Subfields: []marcSubfield{{Code: "a", Value: "Der Name des Windes"}}},
+		{Tag: "490", Subfields: []marcSubfield{{Code: "a", Value: "Die Königsmörder-Chronik"}, {Code: "v", Value: "1. Tag"}}},
+		{Tag: "800", Subfields: []marcSubfield{{Code: "t", Value: "Die Königsmörder-Chronik"}, {Code: "v", Value: "1. Tag"}}},
+	}}
+	got := collectSeriesTitles([]marcRecord{rec})
+	if !got[workDedupKey("Die Königsmörder-Chronik")] {
+		t.Errorf("expected series title to be collected, got %v", got)
+	}
+	if got[workDedupKey("Der Name des Windes")] {
+		t.Errorf("the record's own book title must not be treated as a series title")
+	}
+}
+
+func TestTitleVolumeNumber(t *testing.T) {
+	cases := map[string]int{
+		"Die Furcht des Weisen": 0,
+		"Die Furcht des Weisen (1): Die Königsmörder-Chronik. Zweiter Tag. Band 1": 1,
+		"Die Furcht des Weisen/Band 1: Die Königsmörder-Chronik. Zweiter Tag":      1,
+		"Die Furcht des Weisen (2)": 2,
+		"Der Report der Magd (IV)":  4,
+		"Fahrenheit 451":            0, // bare trailing number is not a volume
+		"Blade Runner 2":            0,
+	}
+	for in, want := range cases {
+		if got := titleVolumeNumber(in); got != want {
+			t.Errorf("titleVolumeNumber(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestParseVolumeToken(t *testing.T) {
+	cases := map[string]int{"Teil 1.": 1, "Band 2": 2, "3": 3, "iv": 4, "": 0, "Teil": 0}
+	for in, want := range cases {
+		if got := parseVolumeToken(in); got != want {
+			t.Errorf("parseVolumeToken(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestWorkBaseTitle(t *testing.T) {
+	cases := map[string]string{
+		"Die Furcht des Weisen": "Die Furcht des Weisen",
+		"Die Furcht des Weisen (1): Die Königsmörder-Chronik. Zweiter Tag. Band 1": "Die Furcht des Weisen",
+		"Die Furcht des Weisen/Band 1: Die Königsmörder-Chronik. Zweiter Tag":      "Die Furcht des Weisen",
+		"Sturz der Titanen: Die Jahrhundert-Saga":                                  "Sturz der Titanen",
+	}
+	for in, want := range cases {
+		if got := workBaseTitle(in); got != want {
+			t.Errorf("workBaseTitle(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestCollapseAuthorWorks_SingletonKeepsSubtitle guards against over-collapsing:
+// a standalone title with a real subtitle and no volume (nothing to merge with)
+// must keep its full title rather than being stripped to the pre-colon head.
+func TestCollapseAuthorWorks_SingletonKeepsSubtitle(t *testing.T) {
+	books := []models.Book{book("Sturz der Titanen: Die Jahrhundert-Saga", "1", 2010)}
+	got := collapseAuthorWorks(books, []int{0})
+	if len(got) != 1 || got[0].Title != "Sturz der Titanen: Die Jahrhundert-Saga" {
+		t.Fatalf("standalone subtitle must be preserved, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary

DNB has no OpenLibrary-style "work" abstraction, so a DNB-primary author
catalogue imported many near-duplicate rows for the same book (e.g. *Die Furcht
des Weisen* as five rows). `GetAuthorWorks` now collapses editions, printings,
and volumes into one book per work, while keeping genuinely distinct volumes
separate. Closes #1585.

## Implementation notes

Contained entirely in the DNB provider (`internal/metadata/dnb/`) — no change to
the aggregator or other providers.

| Case | Rule |
|------|------|
| Duplicate printings/editions of a volume | Group by (work title, volume); volume read from the 245 title marker (`(1)`, `/Band 1`, `Teil 2`) or MARC `245 $n`, merged to one row. |
| Two-part book (*Die Furcht des Weisen*) | Distinct volumes stay separate → *…1* / *…2*. |
| Redundant combined single-volume edition | Dropped when the work already has numbered volumes. |
| Series-catalogued edition (*Die Königsmörder-Chronik / Tag 1 / Der Name des Windes*) | Prefer the individual title from `245 $p`, so it merges onto the standalone edition — a link no shared ISBN reveals (different printings). |
| Whole-series product (complete-series audiobook titled with the series name) | Dropped, recognised from the `490 $a` / `800 $t` series statements the individual books carry. |
| Standalone title with a real subtitle | Left untouched. |

Verified end-to-end (DNB primary, author *Patrick Rothfuss*): the catalogue
drops from ~11 rows to 6 clean books — the two-part work as two entries, the
series-catalogued editions merged into their standalone titles, and no
series-name phantom row.

Follow-up to the DNB-primary identity work in #1574 / #1577 (released in 1.26.2).

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared (provider-internal; no `docs/`, README, godoc, or Helm surface changed)
- [x] Wiki pages updated if user-facing behaviour changed — N/A: the wiki has no DNB / metadata-provider documentation to revise (see comment below).

## Test plan

- [x] `go test ./internal/metadata/...`
- [x] `go build ./...`
- [x] `golangci-lint run ./internal/metadata/dnb/...`
