### PR TITLE
feat(queue): manually match an unmatched download to an existing book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Bindery are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- **Manually match an unmatched download in the queue** (#1589) — a download the
+  auto-matcher couldn't tie to a book ("could not match any book to this
+  download") used to sit in the queue as a dead-end import failure. Import-failed
+  items now have a **Match to book** control: search your library, pick the book
+  the files belong to, and Bindery imports the already-downloaded files against
+  it — attaching the file and flipping the download to imported, with inline
+  feedback. The scanner now records where an unmatched download's files are (it
+  previously discarded that path), so the match can import them directly instead
+  of hoping the download client still remembers the release; downloads without a
+  recorded path fall back to a client re-poll.
+
 ## [v1.26.2] — 2026-07-19
 
 A patch release fixing two reported metadata bugs: profile language filters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ All notable changes to Bindery are documented here. Format loosely follows
   feedback. The scanner now records where an unmatched download's files are (it
   previously discarded that path), so the match can import them directly instead
   of hoping the download client still remembers the release; downloads without a
-  recorded path fall back to a client re-poll.
+  recorded path fall back to a client re-poll. Downloads the scanner terminally
+  blocked after exhausting their import-retry budget (the "stuck after three
+  attempts" case) are recoverable too — the Match to book and Retry import
+  controls now appear for `importBlocked` items, and a match re-imports the
+  recorded files (or re-arms the scanner with a fresh retry budget) instead of
+  leaving them permanently stuck.
 
 ## [v1.26.2] — 2026-07-19
 

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -837,6 +837,7 @@ func main() {
 			r.Post("/queue/manual-import", manualImportHandler.Import)
 			r.Post("/queue/manual-import/batch", manualImportHandler.ImportBatch)
 			r.Post("/queue/manual-import/reassign", manualImportHandler.Reassign)
+			r.Post("/queue/manual-import/match", manualImportHandler.MatchDownload)
 		})
 		r.Get("/pending", pendingHandler.List)
 		r.Delete("/pending/{id}", pendingHandler.Delete)

--- a/docs/API.md
+++ b/docs/API.md
@@ -122,6 +122,7 @@ GET    /api/v1/queue/manual-import/scan           enumerate + match book units u
 POST   /api/v1/queue/manual-import                import one path against a book (admin)
 POST   /api/v1/queue/manual-import/batch          import selected {path, bookId} pairs (admin)
 POST   /api/v1/queue/manual-import/reassign       move a mis-matched file to another book (admin)
+POST   /api/v1/queue/manual-import/match          attach an importFailed download to a book and import its files (admin)
 
 GET    /api/v1/history                            grab / import / failure timeline
 POST   /api/v1/history/{id}/blocklist             add the release to the blocklist

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -20,6 +20,12 @@ If Bindery and the download client see the storage at different paths (different
 
 **Fix:** set a download-client path remap in **Settings → Download clients**, then use **Queue → Retry import**. See [Path remapping](./DEPLOYMENT.md#path-remapping-multi-container--multi-pod-setups) in `DEPLOYMENT.md`.
 
+### "Could not match any book to this download"
+
+The files downloaded fine, but Bindery couldn't tie them to a book in your library, so the item sits in the Queue as `importFailed` with *could not match any book to this download*. This happens when a release was grabbed without a specific book (e.g. from the free-text Search page) or its title didn't parse to a catalogue book.
+
+**Fix:** on the failed Queue item, click **Match to book**, search your library for the correct book, and select it — Bindery imports the already-downloaded files against it and the item flips to **Imported**. If the book isn't in your library yet, add it first (Authors → the author → the book, or Add Book), then match. Once matched, an item shows **Matched to *&lt;book&gt;*** and its **Retry import** button re-runs the import against that book.
+
 ### qBittorrent files land in the download root instead of the category folder
 
 The torrent shows the right **category** label in qBittorrent, but the files are written to the download root (e.g. `/data/downloads`) instead of the category's configured save path (e.g. `/data/downloads/torrents/audiobooks`). The poller can't find them there and the import never starts.

--- a/docs/Troubleshooting-Wiki.md
+++ b/docs/Troubleshooting-Wiki.md
@@ -26,6 +26,8 @@ The files downloaded fine, but Bindery couldn't tie them to a book in your libra
 
 **Fix:** on the failed Queue item, click **Match to book**, search your library for the correct book, and select it — Bindery imports the already-downloaded files against it and the item flips to **Imported**. If the book isn't in your library yet, add it first (Authors → the author → the book, or Add Book), then match. Once matched, an item shows **Matched to *&lt;book&gt;*** and its **Retry import** button re-runs the import against that book.
 
+If the item was left unmatched long enough for the scanner to retry it a few times, it turns into `importBlocked` with *import retry limit reached*. That's the same situation — the files are still there — so **Match to book** and **Retry import** work exactly the same on a blocked item; matching it re-imports the recorded files, and Retry import re-arms the scanner with a fresh retry budget.
+
 ### qBittorrent files land in the download root instead of the category folder
 
 The torrent shows the right **category** label in qBittorrent, but the files are written to the download root (e.g. `/data/downloads`) instead of the category's configured save path (e.g. `/data/downloads/torrents/audiobooks`). The poller can't find them there and the import never starts.

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -606,8 +606,12 @@ func (h *ManualImportHandler) MatchDownload(w http.ResponseWriter, r *http.Reque
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "download not found"})
 		return
 	}
-	if dl.Status != models.StateImportFailed {
-		writeJSON(w, http.StatusConflict, map[string]string{"error": "download is not in importFailed state"})
+	// Recoverable failures only: an unmatched import that failed (importFailed)
+	// or one the scanner terminally blocked after exhausting its retry budget
+	// (importBlocked — the "stuck after three attempts" case, #1589). Any other
+	// state has no files waiting to be matched.
+	if dl.Status != models.StateImportFailed && dl.Status != models.StateImportBlocked {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "download is not in a recoverable import-failed state"})
 		return
 	}
 	book, err := h.books.GetByID(ctx, req.BookID)

--- a/internal/api/manual_import.go
+++ b/internal/api/manual_import.go
@@ -567,3 +567,91 @@ func downloadOwnerForRequest(ctx context.Context, bookOwner int64) int64 {
 	}
 	return bookOwner
 }
+
+type matchDownloadRequest struct {
+	DownloadID int64 `json:"downloadId"`
+	BookID     int64 `json:"bookId"`
+}
+
+// MatchDownload handles POST /api/v1/queue/manual-import/match.
+//
+// It resolves an unmatched, import-failed download (#1589): the auto-matcher
+// couldn't tie the completed files to a book, so they sat in the queue with no
+// way forward. The user picks an existing book here; we attach the download to
+// it and import the already-downloaded files against it.
+//
+// When the scanner recorded where the files are (import_path, set when the
+// unmatched-import failed with valid files present), we import them directly and
+// synchronously — the state flips to imported and the file is attached to the
+// book immediately. When there's no recorded path (a client-grabbed download
+// whose location is only known live), we reset the import retry so the scanner
+// re-imports against the now-assigned book on its next poll.
+func (h *ManualImportHandler) MatchDownload(w http.ResponseWriter, r *http.Request) {
+	var req matchDownloadRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if req.DownloadID <= 0 || req.BookID <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "downloadId and bookId are required"})
+		return
+	}
+	ctx := r.Context()
+	dl, err := h.downloads.GetByID(ctx, req.DownloadID)
+	if err != nil {
+		writeServerError(w, r, err)
+		return
+	}
+	if dl == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "download not found"})
+		return
+	}
+	if dl.Status != models.StateImportFailed {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "download is not in importFailed state"})
+		return
+	}
+	book, err := h.books.GetByID(ctx, req.BookID)
+	if err != nil || book == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "book not found"})
+		return
+	}
+	// Attach the chosen book so whichever import path runs targets it.
+	if err := h.downloads.SetBookID(ctx, req.DownloadID, req.BookID); err != nil {
+		writeServerError(w, r, err)
+		return
+	}
+	dl.BookID = &req.BookID
+
+	// Preferred path: the scanner recorded the files' location on the unmatched
+	// failure, so import them directly against the book. Runs in the background
+	// (a large audiobook copy can take a while) — the queue page polls and shows
+	// the state flip to imported.
+	if dl.ImportPath != "" {
+		if resolved, ok := h.roots.ResolveContained(ctx, dl.ImportPath); ok {
+			if _, statErr := os.Stat(resolved); statErr == nil { //nolint:gosec // #nosec G304 -- symlink-resolved and confirmed inside a configured library root; RequireAdmin enforced at route level
+				go h.scanner.ImportFromPath(context.WithoutCancel(ctx), dl, resolved, "")
+				writeJSON(w, http.StatusAccepted, map[string]any{"imported": true})
+				return
+			}
+		}
+		slog.Warn("manual match: recorded import path missing or outside roots; falling back to retry",
+			"downloadID", req.DownloadID, "path", dl.ImportPath)
+	}
+
+	// Fallback: no usable recorded path. If a download client still owns this
+	// download, reset the retry so the next poll re-derives the location and
+	// re-imports against the now-assigned book. With no client there is nothing
+	// to re-poll and no recorded files — the book is assigned, but we can't
+	// import automatically, so say so rather than promising a retry that will
+	// never fire (a source of "stuck on import failed" confusion, #1589).
+	if dl.DownloadClientID != nil {
+		accepted, _, err := h.downloads.ResetImportRetry(ctx, req.DownloadID)
+		if err != nil {
+			writeServerError(w, r, err)
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{"imported": false, "retryQueued": accepted})
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]any{"imported": false, "retryQueued": false, "located": false})
+}

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/importer"
@@ -33,6 +35,13 @@ type stubManualImportScanner struct {
 	lookupResult     importer.LookupResult
 	lookupErr        error
 	lookupBatchCalls int
+
+	// importMu guards the fields below: ImportFromPath is invoked in a goroutine
+	// by the handler, so tests read these under the lock after a short wait.
+	importMu    sync.Mutex
+	importCalls int
+	lastPath    string
+	lastBookID  int64
 }
 
 func (s *stubManualImportScanner) Lookup(_ context.Context, _ string) (importer.LookupResult, error) {
@@ -51,7 +60,14 @@ func (s *stubManualImportScanner) LookupBatch(_ context.Context, paths []string)
 	return out, nil
 }
 
-func (s *stubManualImportScanner) ImportFromPath(_ context.Context, _ *models.Download, _, _ string) {
+func (s *stubManualImportScanner) ImportFromPath(_ context.Context, dl *models.Download, path, _ string) {
+	s.importMu.Lock()
+	defer s.importMu.Unlock()
+	s.importCalls++
+	s.lastPath = path
+	if dl.BookID != nil {
+		s.lastBookID = *dl.BookID
+	}
 }
 
 // manualImportFixture spins up an in-memory DB and wires a ManualImportHandler.
@@ -372,6 +388,398 @@ func TestManualImportImport_DownloadCreateFails(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "failed to create import record") {
 		t.Errorf("body = %q, want 'failed to create import record'", rec.Body.String())
+	}
+}
+
+// TestMatchDownload_ImportsRecordedPath is the #1589 core: an unmatched
+// import-failed download that recorded where its files are is matched to a book
+// and imported directly against it — book assigned, ImportFromPath invoked with
+// the recorded path.
+func TestMatchDownload_ImportsRecordedPath(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	ctx := context.Background()
+	book := seedBook(t, authors, books, ctx)
+
+	stub := &stubManualImportScanner{}
+	h := NewManualImportHandler(stub, downloads, books) // nil roots ⇒ containment allows
+
+	tmp := t.TempDir()
+	epub := filepath.Join(tmp, "unmatched.epub")
+	if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dl := &models.Download{
+		GUID: "match-guid", Title: "Unmatched Release", NZBURL: "http://x/y.nzb",
+		Status: models.StateImportFailed, Protocol: "usenet",
+	}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	if err := downloads.SetImportPath(ctx, dl.ID, epub); err != nil {
+		t.Fatal(err)
+	}
+
+	body, _ := json.Marshal(map[string]any{"downloadId": dl.ID, "bookId": book.ID})
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewReader(body)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Imported bool `json:"imported"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Imported {
+		t.Errorf("imported = false, want true (recorded path present)")
+	}
+	// Book assigned to the download.
+	got, _ := downloads.GetByID(ctx, dl.ID)
+	if got.BookID == nil || *got.BookID != book.ID {
+		t.Errorf("download book = %v, want %d", got.BookID, book.ID)
+	}
+	// ImportFromPath invoked (async) with the recorded path and the assigned book.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		stub.importMu.Lock()
+		calls, path, bid := stub.importCalls, stub.lastPath, stub.lastBookID
+		stub.importMu.Unlock()
+		if calls > 0 {
+			if path != epub {
+				t.Errorf("import path = %q, want %q", path, epub)
+			}
+			if bid != book.ID {
+				t.Errorf("import bookID = %d, want %d", bid, book.ID)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("ImportFromPath was not called within 2s")
+}
+
+// TestMatchDownload_ClientFallbackResetsRetry: a download with no recorded path
+// but an owning download client is assigned the book and its retry is reset so
+// the next client poll re-derives the location and imports.
+func TestMatchDownload_ClientFallbackResetsRetry(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+	ctx := context.Background()
+	book := seedBook(t, authors, books, ctx)
+
+	client := &models.DownloadClient{Name: "sab", Type: "sabnzbd", Host: "h", Port: 1, Enabled: true}
+	if err := clients.Create(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+
+	stub := &stubManualImportScanner{}
+	h := NewManualImportHandler(stub, downloads, books)
+
+	dl := &models.Download{
+		GUID: "match-client", Title: "Client Release", NZBURL: "http://x/y.nzb",
+		Status: models.StateImportFailed, Protocol: "usenet", DownloadClientID: &client.ID,
+	}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx, "UPDATE downloads SET import_retry_count=3, download_client_id=? WHERE id=?", client.ID, dl.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	body, _ := json.Marshal(map[string]any{"downloadId": dl.ID, "bookId": book.ID})
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewReader(body)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", rec.Code, rec.Body.String())
+	}
+	got, _ := downloads.GetByID(ctx, dl.ID)
+	if got.BookID == nil || *got.BookID != book.ID {
+		t.Errorf("download book = %v, want %d", got.BookID, book.ID)
+	}
+	if got.ImportRetryCount != 0 {
+		t.Errorf("retry count = %d, want 0 (reset for re-poll)", got.ImportRetryCount)
+	}
+}
+
+// TestMatchDownload_NoPathNoClientReportsUnlocated: with neither a recorded path
+// nor an owning client there are no files to import and nothing to re-poll — the
+// book is still assigned, but the response reports located=false so the UI can
+// tell the user honestly instead of promising a retry that never fires (#1589).
+func TestMatchDownload_NoPathNoClientReportsUnlocated(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	ctx := context.Background()
+	book := seedBook(t, authors, books, ctx)
+
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books)
+	dl := &models.Download{
+		GUID: "match-orphan", Title: "No Files", NZBURL: "http://x/y.nzb",
+		Status: models.StateImportFailed, Protocol: "usenet",
+	}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	body, _ := json.Marshal(map[string]any{"downloadId": dl.ID, "bookId": book.ID})
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewReader(body)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Imported    bool `json:"imported"`
+		RetryQueued bool `json:"retryQueued"`
+		Located     bool `json:"located"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Imported || resp.RetryQueued || resp.Located {
+		t.Errorf("resp = %+v, want all false (nothing to import, nothing to re-poll)", resp)
+	}
+	// Book is still assigned so the queue shows it as matched.
+	got, _ := downloads.GetByID(ctx, dl.ID)
+	if got.BookID == nil || *got.BookID != book.ID {
+		t.Errorf("download book = %v, want %d", got.BookID, book.ID)
+	}
+}
+
+// TestMatchDownload_RejectsNonImportFailed guards against matching a book onto a
+// download that isn't in the importFailed state.
+func TestMatchDownload_RejectsNonImportFailed(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	ctx := context.Background()
+	book := seedBook(t, authors, books, ctx)
+
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books)
+	dl := &models.Download{
+		GUID: "match-completed", Title: "Done", NZBURL: "http://x/y.nzb",
+		Status: models.StateCompleted, Protocol: "usenet",
+	}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(map[string]any{"downloadId": dl.ID, "bookId": book.ID})
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewReader(body)))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+}
+
+func TestMatchDownload_BadJSON(t *testing.T) {
+	h, _, _, _, _ := manualImportFixture(t)
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewBufferString("not-json")))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestMatchDownload_MissingIDs(t *testing.T) {
+	h, _, _, _, _ := manualImportFixture(t)
+	for _, body := range []string{`{}`, `{"downloadId":1}`, `{"bookId":1}`} {
+		rec := httptest.NewRecorder()
+		h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewBufferString(body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("body %q: status = %d, want 400", body, rec.Code)
+		}
+	}
+}
+
+func TestMatchDownload_DownloadNotFound(t *testing.T) {
+	h, _, _, _, _ := manualImportFixture(t)
+	body, _ := json.Marshal(map[string]any{"downloadId": 999, "bookId": 1})
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewReader(body)))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestMatchDownload_BookNotFound(t *testing.T) {
+	h, _, downloads, _, ctx := manualImportFixture(t)
+	dl := &models.Download{GUID: "match-nobook", Title: "t", NZBURL: "x", Status: models.StateImportFailed, Protocol: "usenet"}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(map[string]any{"downloadId": dl.ID, "bookId": 9999})
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewReader(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (book not found)", rec.Code)
+	}
+}
+
+// TestMatchDownload_RecordedPathMissingFallsBack: import_path is set but the
+// file no longer exists on disk, so the direct-import branch is skipped and the
+// handler falls through — here with no client, so it reports located=false.
+func TestMatchDownload_RecordedPathMissingFallsBack(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	ctx := context.Background()
+	book := seedBook(t, authors, books, ctx)
+
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books)
+	dl := &models.Download{GUID: "match-gonepath", Title: "t", NZBURL: "x", Status: models.StateImportFailed, Protocol: "usenet"}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	if err := downloads.SetImportPath(ctx, dl.ID, filepath.Join(t.TempDir(), "vanished.epub")); err != nil {
+		t.Fatal(err)
+	}
+
+	body, _ := json.Marshal(map[string]any{"downloadId": dl.ID, "bookId": book.ID})
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewReader(body)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct{ Imported, Located bool }
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if resp.Imported || resp.Located {
+		t.Errorf("resp = %+v, want imported=false located=false (recorded file gone, no client)", resp)
+	}
+}
+
+// TestMatchDownload_LoadError forces the initial GetByID to fail by closing the
+// database, exercising the writeServerError branch.
+func TestMatchDownload_LoadError(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books)
+	database.Close() // subsequent queries error
+
+	body, _ := json.Marshal(map[string]any{"downloadId": 1, "bookId": 1})
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewReader(body)))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 on DB error", rec.Code)
+	}
+}
+
+// TestMatchDownload_SetBookError forces the SetBookID write to fail (read-only
+// DB) after the reads succeed, exercising that writeServerError branch.
+func TestMatchDownload_SetBookError(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	database.SetMaxOpenConns(1) // one conn so the query_only pragma sticks
+
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	ctx := context.Background()
+	book := seedBook(t, authors, books, ctx)
+	dl := &models.Download{GUID: "match-roerr", Title: "t", NZBURL: "x", Status: models.StateImportFailed, Protocol: "usenet"}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	// Reads still succeed; the next UPDATE (SetBookID) fails.
+	if _, err := database.ExecContext(ctx, "PRAGMA query_only=ON"); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books)
+	body, _ := json.Marshal(map[string]any{"downloadId": dl.ID, "bookId": book.ID})
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewReader(body)))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 when SetBookID fails; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestMatchDownload_RetryResetError reaches the client fallback (no recorded
+// path, has a client) and forces ResetImportRetry to fail via a trigger that
+// aborts only import_retry_count updates — so SetBookID still succeeds but the
+// retry reset errors, exercising that writeServerError branch.
+func TestMatchDownload_RetryResetError(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	database.SetMaxOpenConns(1)
+
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+	ctx := context.Background()
+	book := seedBook(t, authors, books, ctx)
+	client := &models.DownloadClient{Name: "sab", Type: "sabnzbd", Host: "h", Port: 1, Enabled: true}
+	if err := clients.Create(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+	dl := &models.Download{GUID: "match-reseterr", Title: "t", NZBURL: "x", Status: models.StateImportFailed, Protocol: "usenet", DownloadClientID: &client.ID}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx, "UPDATE downloads SET download_client_id=? WHERE id=?", client.ID, dl.ID); err != nil {
+		t.Fatal(err)
+	}
+	// Fires only when import_retry_count is updated: SetBookID (book_id) passes,
+	// ResetImportRetry (import_retry_count) aborts.
+	if _, err := database.ExecContext(ctx,
+		"CREATE TRIGGER fail_retry_reset BEFORE UPDATE OF import_retry_count ON downloads BEGIN SELECT RAISE(ABORT, 'boom'); END;"); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewManualImportHandler(&stubManualImportScanner{}, downloads, books)
+	body, _ := json.Marshal(map[string]any{"downloadId": dl.ID, "bookId": book.ID})
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewReader(body)))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 when ResetImportRetry fails; body = %s", rec.Code, rec.Body.String())
+	}
+	// SetBookID still applied before the failing reset.
+	got, _ := downloads.GetByID(ctx, dl.ID)
+	if got.BookID == nil || *got.BookID != book.ID {
+		t.Errorf("book = %v, want %d assigned before the reset error", got.BookID, book.ID)
 	}
 }
 

--- a/internal/api/manual_import_test.go
+++ b/internal/api/manual_import_test.go
@@ -467,6 +467,78 @@ func TestMatchDownload_ImportsRecordedPath(t *testing.T) {
 	t.Fatal("ImportFromPath was not called within 2s")
 }
 
+// TestMatchDownload_RecoversBlockedDownload: a download terminally blocked after
+// exhausting its retry budget ("stuck after three attempts") is still matchable —
+// the gate accepts importBlocked and the recorded path imports directly (#1589).
+func TestMatchDownload_RecoversBlockedDownload(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	authors := db.NewAuthorRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	ctx := context.Background()
+	book := seedBook(t, authors, books, ctx)
+
+	stub := &stubManualImportScanner{}
+	h := NewManualImportHandler(stub, downloads, books)
+
+	tmp := t.TempDir()
+	epub := filepath.Join(tmp, "blocked.epub")
+	if err := os.WriteFile(epub, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dl := &models.Download{
+		GUID: "match-blocked", Title: "Blocked Release", NZBURL: "http://x/y.nzb",
+		Status: models.StateImportFailed, Protocol: "usenet",
+	}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	if err := downloads.SetImportPath(ctx, dl.ID, epub); err != nil {
+		t.Fatal(err)
+	}
+	// Move it to the terminal blocked state, as the scanner would after 3 retries.
+	if _, err := database.ExecContext(ctx, "UPDATE downloads SET status=?, import_retry_count=3 WHERE id=?",
+		models.StateImportBlocked, dl.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	body, _ := json.Marshal(map[string]any{"downloadId": dl.ID, "bookId": book.ID})
+	rec := httptest.NewRecorder()
+	h.MatchDownload(rec, httptest.NewRequest(http.MethodPost, "/api/v1/queue/manual-import/match", bytes.NewReader(body)))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Imported bool `json:"imported"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Imported {
+		t.Errorf("imported = false, want true (recorded path present on a blocked download)")
+	}
+	got, _ := downloads.GetByID(ctx, dl.ID)
+	if got.BookID == nil || *got.BookID != book.ID {
+		t.Errorf("download book = %v, want %d", got.BookID, book.ID)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		stub.importMu.Lock()
+		calls := stub.importCalls
+		stub.importMu.Unlock()
+		if calls > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("ImportFromPath was not called within 2s")
+}
+
 // TestMatchDownload_ClientFallbackResetsRetry: a download with no recorded path
 // but an owning download client is assigned the book and its retry is reset so
 // the next client poll re-derives the location and imports.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1386,6 +1386,40 @@ func TestDownloadRepoResetImportRetry(t *testing.T) {
 		t.Fatalf("timestamps changed, got grabbed=%v completed=%v imported=%v", got.GrabbedAt, got.CompletedAt, got.ImportedAt)
 	}
 
+	// A terminally-blocked download (retry budget spent) is recoverable: the
+	// reset re-arms it back to importFailed with a fresh count so the scanner
+	// (and a manual match's fallback path) can retry it again (#1589).
+	blocked := &models.Download{
+		GUID:     "import-blocked-guid",
+		Title:    "Import Blocked",
+		NZBURL:   "https://example.com/blocked.nzb",
+		Status:   models.StateImportBlocked,
+		Protocol: "usenet",
+	}
+	if err := repo.Create(ctx, blocked); err != nil {
+		t.Fatalf("create blocked download: %v", err)
+	}
+	if _, err := database.ExecContext(ctx, "UPDATE downloads SET import_retry_count=3 WHERE id=?", blocked.ID); err != nil {
+		t.Fatalf("seed blocked retry count: %v", err)
+	}
+	accepted, found, err = repo.ResetImportRetry(ctx, blocked.ID)
+	if err != nil {
+		t.Fatalf("ResetImportRetry blocked: %v", err)
+	}
+	if !accepted || !found {
+		t.Fatalf("ResetImportRetry blocked accepted=%v found=%v, want true true", accepted, found)
+	}
+	gotBlocked, err := repo.GetByGUID(ctx, "import-blocked-guid")
+	if err != nil || gotBlocked == nil {
+		t.Fatalf("reload blocked download: %v", err)
+	}
+	if gotBlocked.Status != models.StateImportFailed {
+		t.Fatalf("blocked status = %q, want importFailed after reset", gotBlocked.Status)
+	}
+	if gotBlocked.ImportRetryCount != 0 {
+		t.Fatalf("blocked retry count = %d, want 0", gotBlocked.ImportRetryCount)
+	}
+
 	nonFailed := &models.Download{
 		GUID:     "not-import-failed",
 		Title:    "Not Import Failed",

--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -19,7 +19,7 @@ const downloadSelectColumns = `
 	id, guid, book_id, edition_id, indexer_id, download_client_id,
 	title, nzb_url, size, sabnzbd_nzo_id, torrent_id, status, protocol,
 	quality, indexer_flags, error_message, added_at, grabbed_at, completed_at, imported_at,
-	import_retry_count, COALESCE(owner_user_id, 0)`
+	import_retry_count, COALESCE(owner_user_id, 0), import_path`
 
 func NewDownloadRepo(db *sql.DB) *DownloadRepo {
 	return &DownloadRepo{db: db}
@@ -46,6 +46,14 @@ func (r *DownloadRepo) ListByStatusAndUser(ctx context.Context, status models.Do
 
 func (r *DownloadRepo) GetByGUID(ctx context.Context, guid string) (*models.Download, error) {
 	dl, err := r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads WHERE guid=?", guid)
+	if err != nil || len(dl) == 0 {
+		return nil, err
+	}
+	return &dl[0], nil
+}
+
+func (r *DownloadRepo) GetByID(ctx context.Context, id int64) (*models.Download, error) {
+	dl, err := r.query(ctx, "SELECT "+downloadSelectColumns+" FROM downloads WHERE id=?", id)
 	if err != nil || len(dl) == 0 {
 		return nil, err
 	}
@@ -242,8 +250,12 @@ func (r *DownloadRepo) UpdateStatus(ctx context.Context, id int64, next models.D
 			"UPDATE downloads SET status=?, completed_at=?, grabbed_at=COALESCE(grabbed_at, ?) WHERE id=? AND status=?",
 			next, now, now, id, current)
 	case models.StateImported:
+		// Clear any stale error_message: a download that failed (e.g. unmatched)
+		// and later imported — via manual match (#1589) or a client re-poll —
+		// is no longer in error, so the queue must not keep showing the old
+		// "could not match…" line next to an Imported status.
 		result, err = r.db.ExecContext(ctx,
-			"UPDATE downloads SET status=?, imported_at=? WHERE id=? AND status=?", next, now, id, current)
+			"UPDATE downloads SET status=?, imported_at=?, error_message='' WHERE id=? AND status=?", next, now, id, current)
 	default:
 		// StateGrabbed -> StateFailed (couldn't send to client) deliberately
 		// leaves grabbed_at NULL: nothing was ever grabbed. All other forward
@@ -296,6 +308,15 @@ func (r *DownloadRepo) SetTorrentID(ctx context.Context, id int64, torrentID str
 // without one (e.g. a free-text Search grab) — issue #1014.
 func (r *DownloadRepo) SetBookID(ctx context.Context, id, bookID int64) error {
 	_, err := r.db.ExecContext(ctx, "UPDATE downloads SET book_id=? WHERE id=?", bookID, id)
+	return err
+}
+
+// SetImportPath records the on-disk location of a completed download's files so
+// a later manual "Match to book" (#1589) can import them directly. Called when
+// an import fails only because no catalogue book matched — the files are valid
+// and present, they just have nowhere to go yet.
+func (r *DownloadRepo) SetImportPath(ctx context.Context, id int64, path string) error {
+	_, err := r.db.ExecContext(ctx, "UPDATE downloads SET import_path=? WHERE id=?", path, id)
 	return err
 }
 
@@ -576,7 +597,7 @@ func (r *DownloadRepo) query(ctx context.Context, q string, args ...interface{})
 			&d.Title, &d.NZBURL, &d.Size, &d.SABnzbdNzoID, &d.TorrentID, &d.Status, &d.Protocol,
 			&d.Quality, &d.IndexerFlags, &d.ErrorMessage,
 			&d.AddedAt, &d.GrabbedAt, &d.CompletedAt, &d.ImportedAt,
-			&d.ImportRetryCount, &d.OwnerUserID,
+			&d.ImportRetryCount, &d.OwnerUserID, &d.ImportPath,
 		); err != nil {
 			return nil, fmt.Errorf("scan download: %w", err)
 		}

--- a/internal/db/downloads.go
+++ b/internal/db/downloads.go
@@ -160,12 +160,15 @@ func (r *DownloadRepo) RetryFailed(ctx context.Context, d *models.Download) (boo
 }
 
 // ResetImportRetry atomically re-enables scanner retries for a download stuck
-// in StateImportFailed. It returns accepted=false when the row exists but is in
-// another state, and found=false when no row exists.
+// in StateImportFailed — or one already terminally blocked (StateImportBlocked)
+// after exhausting its retry budget, which it flips back to StateImportFailed so
+// the scanner picks it up again with a fresh count (#1589). It returns
+// accepted=false when the row exists but is in another (non-recoverable) state,
+// and found=false when no row exists.
 func (r *DownloadRepo) ResetImportRetry(ctx context.Context, id int64) (accepted bool, found bool, err error) {
 	result, err := r.db.ExecContext(ctx,
-		"UPDATE downloads SET import_retry_count=0 WHERE id=? AND status=?",
-		id, models.StateImportFailed)
+		"UPDATE downloads SET import_retry_count=0, status=? WHERE id=? AND status IN (?, ?)",
+		models.StateImportFailed, id, models.StateImportFailed, models.StateImportBlocked)
 	if err != nil {
 		return false, false, fmt.Errorf("reset import retry: %w", err)
 	}

--- a/internal/db/downloads_coverage_test.go
+++ b/internal/db/downloads_coverage_test.go
@@ -149,6 +149,86 @@ func TestDownloadRepo_RecoverInterruptedImports(t *testing.T) {
 	}
 }
 
+// TestDownloadRepo_GetByIDAndSetImportPath covers the two accessors added for
+// the manual-match flow (#1589): fetch a download by primary key, and record
+// where its unmatched files live.
+func TestDownloadRepo_GetByIDAndSetImportPath(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewDownloadRepo(database)
+
+	// Unknown id: nil, no error.
+	if got, err := repo.GetByID(ctx, 9999); err != nil || got != nil {
+		t.Fatalf("GetByID(unknown) = %v, %v; want nil, nil", got, err)
+	}
+
+	dl := &models.Download{GUID: "get-by-id", Title: "t", NZBURL: "x", Status: models.StateImportFailed}
+	if err := repo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.GetByID(ctx, dl.ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetByID(%d) = %v, %v; want the row", dl.ID, got, err)
+	}
+	if got.GUID != "get-by-id" || got.ImportPath != "" {
+		t.Fatalf("GetByID returned %+v; want GUID get-by-id, empty ImportPath", got)
+	}
+
+	const p = "/data/downloads/Some Book"
+	if err := repo.SetImportPath(ctx, dl.ID, p); err != nil {
+		t.Fatalf("SetImportPath: %v", err)
+	}
+	got, _ = repo.GetByID(ctx, dl.ID)
+	if got.ImportPath != p {
+		t.Errorf("ImportPath = %q, want %q", got.ImportPath, p)
+	}
+}
+
+// TestDownloadRepo_ImportClearsError verifies the StateImported transition
+// clears a stale error_message (#1589): a download that failed as unmatched and
+// then imported (via manual match or a client re-poll) must not keep showing the
+// old "could not match…" line next to an Imported status.
+func TestDownloadRepo_ImportClearsError(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewDownloadRepo(database)
+
+	dl := &models.Download{GUID: "unmatched-then-imported", Title: "x", NZBURL: "x", Status: models.StateCompleted}
+	if err := repo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	// Fail it as unmatched (records an error_message), then walk to imported.
+	if err := repo.SetErrorWithStatus(ctx, dl.ID, models.StateImportFailed, "could not match any book to this download"); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.UpdateStatus(ctx, dl.ID, models.StateImporting); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.UpdateStatus(ctx, dl.ID, models.StateImported); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.GetByGUID(ctx, "unmatched-then-imported")
+	if err != nil || got == nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Status != models.StateImported {
+		t.Fatalf("status = %q, want imported", got.Status)
+	}
+	if got.ErrorMessage != "" {
+		t.Errorf("error_message = %q, want cleared on import", got.ErrorMessage)
+	}
+}
+
 // TestDownloadRepo_UpdateStatusRaceGuard is the regression test for #1462.
 // UpdateStatus used to validate the transition in Go and then issue an UPDATE
 // with no status guard, so two writers that both read the same starting state

--- a/internal/db/migrations/064_downloads_import_path.sql
+++ b/internal/db/migrations/064_downloads_import_path.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+-- Persist the on-disk location of a completed download whose files could not be
+-- matched to a book (#1589). The scanner used to discard this path on an
+-- unmatched-import failure, so the only way to import the files later was an
+-- async re-poll of the download client — impossible once the client forgot the
+-- download, and invisible for downloads without a client. Storing it lets the
+-- queue "Match to book" action import the already-downloaded files directly
+-- against the book the user picks. Empty = no recorded path (the prior state).
+ALTER TABLE downloads ADD COLUMN import_path TEXT NOT NULL DEFAULT '';

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -506,6 +506,18 @@ func (s *Scanner) failImport(ctx context.Context, dl *models.Download, status mo
 	})
 }
 
+// recordUnmatchedImportPath persists where a completed download's files are so a
+// later manual "Match to book" (#1589) can import them directly. Best-effort: a
+// failure here only loses the manual-import shortcut, not any files.
+func (s *Scanner) recordUnmatchedImportPath(ctx context.Context, downloadID int64, path string) {
+	if path == "" {
+		return
+	}
+	if err := s.downloads.SetImportPath(ctx, downloadID, path); err != nil {
+		slog.Warn("failed to record unmatched import path", "download_id", downloadID, "path", path, "error", err)
+	}
+}
+
 func (s *Scanner) createHistoryEvent(ctx context.Context, eventType string, sourceTitle string, bookID *int64, data map[string]string) {
 	if s.history == nil {
 		return
@@ -873,6 +885,10 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		// BookID, the lookup errored, or the book row was deleted between
 		// grab and import.
 		if book == nil {
+			// Files are present and valid — only the book match is missing. Record
+			// the path so the queue "Match to book" action (#1589) can import these
+			// files directly against the book the user picks.
+			s.recordUnmatchedImportPath(ctx, dl.ID, downloadPath)
 			s.failImport(ctx, dl, models.StateImportFailed, "could not match any book to this download — check the release title")
 			return
 		}
@@ -1172,6 +1188,9 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// can see WHY it didn't match rather than getting a bare "check the release
 	// title" (issue #1014 point 5).
 	if imported == 0 && failed == 0 && book == nil {
+		// Valid files, no matching book — record where they are so the queue
+		// "Match to book" action (#1589) can import them against a chosen book.
+		s.recordUnmatchedImportPath(ctx, dl.ID, downloadPath)
 		s.failImport(ctx, dl, models.StateImportFailed, unmatchedReason(bookFiles))
 		return
 	}

--- a/internal/importer/scanner_unmatched_test.go
+++ b/internal/importer/scanner_unmatched_test.go
@@ -150,4 +150,53 @@ func TestImport_UnmatchedWithNoCatalogueMatchFails(t *testing.T) {
 	if reloaded.Status != models.StateImportFailed {
 		t.Errorf("status = %q, want %q", reloaded.Status, models.StateImportFailed)
 	}
+	// #1589: the files' location is recorded so a later manual "Match to book"
+	// can import them directly rather than hunting for the path.
+	if reloaded.ImportPath != downloadDir {
+		t.Errorf("ImportPath = %q, want %q (recorded for manual match)", reloaded.ImportPath, downloadDir)
+	}
+}
+
+// TestRecordUnmatchedImportPath_EmptyPathNoOp covers the guard: an empty path is
+// never persisted (nothing to import from), so the column stays clear.
+func TestRecordUnmatchedImportPath_EmptyPathNoOp(t *testing.T) {
+	s, downloads, _, _, _, _, ctx := unmatchedFixture(t)
+	dl := &models.Download{GUID: "empty-path", Title: "t", NZBURL: "x", Status: models.StateImportFailed}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	s.recordUnmatchedImportPath(ctx, dl.ID, "")
+	got, _ := downloads.GetByID(ctx, dl.ID)
+	if got.ImportPath != "" {
+		t.Errorf("ImportPath = %q, want empty (empty path is a no-op)", got.ImportPath)
+	}
+}
+
+// TestRecordUnmatchedImportPath_WriteErrorLogged covers the error branch: a
+// failing SetImportPath (here a read-only DB) is logged and swallowed — recording
+// the path is best-effort and must never abort the import failure handling.
+func TestRecordUnmatchedImportPath_WriteErrorLogged(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	database.SetMaxOpenConns(1)
+	downloads := db.NewDownloadRepo(database)
+	dl := &models.Download{GUID: "roerr", Title: "t", NZBURL: "x", Status: models.StateImportFailed}
+	if err := downloads.Create(context.Background(), dl); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(context.Background(), "PRAGMA query_only=ON"); err != nil {
+		t.Fatal(err)
+	}
+	s := NewScanner(downloads, db.NewDownloadClientRepo(database), db.NewBookRepo(database),
+		db.NewAuthorRepo(database), db.NewHistoryRepo(database), t.TempDir(), "", "", "", "")
+
+	s.recordUnmatchedImportPath(context.Background(), dl.ID, "/data/downloads/whatever") // UPDATE fails, logged
+
+	got, _ := downloads.GetByID(context.Background(), dl.ID)
+	if got.ImportPath != "" {
+		t.Errorf("ImportPath = %q, want empty (write failed, logged)", got.ImportPath)
+	}
 }

--- a/internal/models/download.go
+++ b/internal/models/download.go
@@ -63,6 +63,11 @@ type Download struct {
 	CompletedAt      *time.Time    `json:"completedAt"`
 	ImportedAt       *time.Time    `json:"importedAt"`
 	ImportRetryCount int           `json:"importRetryCount"`
+	// ImportPath is the on-disk location of the completed download's files,
+	// recorded when an import fails because no catalogue book matched (#1589).
+	// The queue "Match to book" action imports from here directly. Empty when
+	// no path was recorded (never completed, or matched successfully).
+	ImportPath string `json:"-"`
 }
 
 // Legacy status aliases — callers should prefer the typed State* constants in

--- a/internal/models/download_state.go
+++ b/internal/models/download_state.go
@@ -41,7 +41,10 @@ var validTransitions = map[DownloadState][]DownloadState{
 	StateImported:      {},
 	StateFailed:        {},
 	StateImportFailed:  {StateImportPending, StateImportBlocked, StateImporting},
-	StateImportBlocked: {},
+	// Terminal to the automatic pollers, but a manual match / retry can recover
+	// it: back into the import flow directly (StateImportPending), or back to
+	// StateImportFailed so the scanner re-polls with a fresh retry budget (#1589).
+	StateImportBlocked: {StateImportPending, StateImportFailed},
 	// External hand-off is non-terminal. It can only be retired by a manual
 	// retry (which routes through StateImportPending) — there is no automatic
 	// path out, by design: ScanLibrary reconciles the file independently.

--- a/internal/models/download_state_test.go
+++ b/internal/models/download_state_test.go
@@ -25,6 +25,12 @@ func TestCanTransitionTo(t *testing.T) {
 		// Terminal states have no outgoing transitions
 		{StateImported, StateImporting, false},
 		{StateFailed, StateGrabbed, false},
+
+		// StateImportBlocked is terminal to the pollers but manually recoverable
+		// (#1589): a match imports directly (→ importPending) or the reset re-arms
+		// the scanner (→ importFailed); it still cannot jump straight to importing.
+		{StateImportBlocked, StateImportPending, true},
+		{StateImportBlocked, StateImportFailed, true},
 		{StateImportBlocked, StateImporting, false},
 
 		// External hand-off is non-terminal (issue #706 finding 3)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -670,9 +670,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -862,9 +862,9 @@
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1085,9 +1085,9 @@
       "license": "MIT"
     },
     "node_modules/@microsoft/eslint-formatter-sarif/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2814,9 +2814,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3614,9 +3614,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -207,3 +207,29 @@ describe('listAllBooks', () => {
     expect(offsets).toEqual([0, 100, 200])
   })
 })
+
+describe('matchDownload (#1589)', () => {
+  beforeEach(() => {
+    document.cookie = 'bindery_csrf=; Max-Age=0; path=/'
+    window.history.pushState(null, '', '/')
+  })
+
+  it('POSTs the downloadId and bookId and returns the outcome', async () => {
+    let body: unknown = null
+    server.use(
+      http.get(apiUrl('/auth/csrf'), () => HttpResponse.json({ csrfToken: 't' })),
+      http.post(apiUrl('/queue/manual-import/match'), async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json({ imported: false, retryQueued: false, located: false })
+      }),
+    )
+
+    const { api, initCSRF } = await loadClient()
+    await initCSRF()
+
+    const res = await api.matchDownload(7, 42)
+
+    expect(body).toEqual({ downloadId: 7, bookId: 42 })
+    expect(res).toEqual({ imported: false, retryQueued: false, located: false })
+  })
+})

--- a/web/src/api/queue.ts
+++ b/web/src/api/queue.ts
@@ -117,6 +117,15 @@ export const queueApi = {
   listQueue: () => request<QueueListResponse>('/queue').then(r => r.items ?? []),
   grab: (data: GrabRequest) => request<Download>('/queue/grab', { method: 'POST', body: JSON.stringify(data) }),
   retryImport: (id: number) => request<{ ok: boolean }>(`/queue/${id}/retry-import`, { method: 'POST' }),
+  // matchDownload attaches an unmatched, import-failed download to an existing
+  // book and imports the already-downloaded files against it (#1589). Returns
+  // whether the files were imported directly (imported=true) or the import was
+  // re-queued for the download client to place on its next poll.
+  matchDownload: (downloadId: number, bookId: number) =>
+    request<{ imported: boolean; retryQueued?: boolean; located?: boolean }>('/queue/manual-import/match', {
+      method: 'POST',
+      body: JSON.stringify({ downloadId, bookId }),
+    }),
   deleteFromQueue: (id: number, deleteFiles = false) =>
     request<void>(`/queue/${id}${deleteFiles ? '?deleteFiles=true' : ''}`, { method: 'DELETE' }),
 

--- a/web/src/pages/QueuePage.test.tsx
+++ b/web/src/pages/QueuePage.test.tsx
@@ -221,11 +221,13 @@ describe('QueuePage', () => {
     expect(screen.getByText('Import Failed')).toBeInTheDocument()
     expect(screen.getByText('Import failed:')).toBeInTheDocument()
     expect(screen.getByText('Missing target folder')).toBeInTheDocument()
-    expect(screen.getByText(/After fixing the path remap/)).toBeInTheDocument()
+    // Both the blocked and the failed import (neither matched to a book) show the
+    // retry hint and controls — a blocked-after-3-attempts item is recoverable (#1589).
+    expect(screen.getAllByText(/After fixing the path remap/)).toHaveLength(2)
     expect(screen.getByText('Failed')).toBeInTheDocument()
     expect(screen.getByText('Error:')).toBeInTheDocument()
     expect(screen.getByText('Client rejected download')).toBeInTheDocument()
-    expect(screen.getAllByRole('button', { name: 'Retry import' })).toHaveLength(1)
+    expect(screen.getAllByRole('button', { name: 'Retry import' })).toHaveLength(2)
     expect(container.querySelector('[style="width: 45%;"]')).toBeInTheDocument()
   })
 
@@ -448,6 +450,32 @@ describe('QueuePage manual match (#1589)', () => {
     await waitFor(() => expect(api.matchDownload).toHaveBeenCalledWith(7, 55))
     // Feedback is surfaced instead of a silent no-op.
     expect(await screen.findByText('queue.matchImporting')).toBeInTheDocument()
+  })
+
+  it('matches a download blocked after exhausting its retry budget', async () => {
+    // "Stuck after three attempts": the scanner terminally blocked it, but the
+    // files are still there — the match controls must render and work (#1589).
+    vi.mocked(api.listQueue).mockResolvedValue([makeQueueItem({
+      id: 8,
+      title: 'Blocked Release',
+      status: 'importBlocked',
+      errorMessage: 'import retry limit reached (3 attempts)',
+    })])
+    vi.mocked(api.listAllBooks).mockResolvedValue([
+      { id: 55, title: 'The Right Book', author: { authorName: 'A. Writer' } },
+    ] as never)
+    vi.mocked(api.matchDownload).mockResolvedValue({ imported: true })
+
+    renderQueuePage()
+
+    expect(await screen.findByText('Blocked Release')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('queue.matchBook'))
+    fireEvent.change(screen.getByLabelText('queue.matchBookSearch'), { target: { value: 'Right' } })
+    fireEvent.click(screen.getByText('queue.matchBookSearchBtn'))
+
+    fireEvent.click(await screen.findByText(/The Right Book/))
+
+    await waitFor(() => expect(api.matchDownload).toHaveBeenCalledWith(8, 55))
   })
 
   it('shows a persistent matched indicator (survives reload) for an already-matched failed item', async () => {

--- a/web/src/pages/QueuePage.test.tsx
+++ b/web/src/pages/QueuePage.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
-import QueuePage from './QueuePage'
+import QueuePage, { MatchBookControl } from './QueuePage'
 import { summarizeError, ERROR_SUMMARY_LEN } from './queueError'
 import { api } from '../api/client'
 import type { Download, PendingRelease, QueueItem } from '../api/client'
@@ -18,6 +18,8 @@ vi.mock('../api/client', async importOriginal => {
       retryImport: vi.fn(),
       dismissPending: vi.fn(),
       grabPending: vi.fn(),
+      listAllBooks: vi.fn(),
+      matchDownload: vi.fn(),
     },
   }
 })
@@ -418,5 +420,149 @@ describe('QueuePage', () => {
     expect(api.listQueue).toHaveBeenCalledTimes(2)
     expect(api.listPending).toHaveBeenCalledTimes(2)
     clearIntervalSpy.mockRestore()
+  })
+})
+
+describe('QueuePage manual match (#1589)', () => {
+  it('matches an unmatched download to a book and shows feedback', async () => {
+    vi.mocked(api.listQueue).mockResolvedValue([makeQueueItem({
+      id: 7,
+      title: 'Unmatched Release',
+      status: 'importFailed',
+      errorMessage: 'could not match any book to this download',
+    })])
+    vi.mocked(api.listAllBooks).mockResolvedValue([
+      { id: 55, title: 'The Right Book', author: { authorName: 'A. Writer' } },
+    ] as never)
+    vi.mocked(api.matchDownload).mockResolvedValue({ imported: true })
+
+    renderQueuePage()
+
+    expect(await screen.findByText('Unmatched Release')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('queue.matchBook'))
+    fireEvent.change(screen.getByLabelText('queue.matchBookSearch'), { target: { value: 'Right' } })
+    fireEvent.click(screen.getByText('queue.matchBookSearchBtn'))
+
+    fireEvent.click(await screen.findByText(/The Right Book/))
+
+    await waitFor(() => expect(api.matchDownload).toHaveBeenCalledWith(7, 55))
+    // Feedback is surfaced instead of a silent no-op.
+    expect(await screen.findByText('queue.matchImporting')).toBeInTheDocument()
+  })
+
+  it('shows a persistent matched indicator (survives reload) for an already-matched failed item', async () => {
+    vi.mocked(api.listQueue).mockResolvedValue([makeQueueItem({
+      id: 9,
+      title: 'Already Matched Release',
+      status: 'importFailed',
+      errorMessage: 'could not match any book to this download',
+      book: { id: 3, title: 'Assigned Book', authorId: 1, authorName: 'A. Writer' },
+    })])
+
+    renderQueuePage()
+
+    // Persistent indicator is driven by item.book, not transient state.
+    expect(await screen.findByText('queue.matchedTo')).toBeInTheDocument()
+    // The action makes clear it's already matched.
+    expect(screen.getByText('queue.matchBookChange')).toBeInTheDocument()
+  })
+
+  it('routes Retry import on a matched item to a direct re-import of its book', async () => {
+    vi.mocked(api.listQueue).mockResolvedValue([makeQueueItem({
+      id: 9,
+      title: 'Already Matched Release',
+      status: 'importFailed',
+      book: { id: 3, title: 'Assigned Book', authorId: 1, authorName: 'A. Writer' },
+    })])
+    vi.mocked(api.matchDownload).mockResolvedValue({ imported: true })
+
+    renderQueuePage()
+
+    fireEvent.click(await screen.findByText('Retry import'))
+    // Matched → re-imports the recorded files against the assigned book,
+    // instead of the client-only retry-reset.
+    await waitFor(() => expect(api.matchDownload).toHaveBeenCalledWith(9, 3))
+    expect(api.retryImport).not.toHaveBeenCalled()
+  })
+
+  it('routes Retry import on an unmatched item to the client retry-reset', async () => {
+    vi.mocked(api.listQueue).mockResolvedValue([makeQueueItem({
+      id: 10,
+      title: 'Unmatched Release',
+      status: 'importFailed',
+    })])
+
+    renderQueuePage()
+
+    fireEvent.click(await screen.findByText('Retry import'))
+    await waitFor(() => expect(api.retryImport).toHaveBeenCalledWith(10))
+    expect(api.matchDownload).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an error when the match request fails', async () => {
+    vi.mocked(api.listQueue).mockResolvedValue([makeQueueItem({
+      id: 11,
+      title: 'Match Fails',
+      status: 'importFailed',
+      book: { id: 3, title: 'Assigned Book', authorId: 1, authorName: 'A. Writer' },
+    })])
+    vi.mocked(api.matchDownload).mockRejectedValue(new Error('nope'))
+
+    renderQueuePage()
+
+    fireEvent.click(await screen.findByText('Retry import'))
+    expect(await screen.findByText('Retry failed: nope')).toBeInTheDocument()
+  })
+})
+
+describe('MatchBookControl', () => {
+  const mockListAllBooks = api.listAllBooks as ReturnType<typeof vi.fn>
+  beforeEach(() => vi.clearAllMocks())
+
+  it('searches the library and matches the picked book (#1589)', async () => {
+    mockListAllBooks.mockResolvedValue([
+      { id: 42, title: 'Target Book', author: { authorName: 'A. Writer' } },
+    ])
+    const onMatch = vi.fn()
+    render(<MatchBookControl disabled={false} onMatch={onMatch} />)
+
+    // Opens the picker.
+    fireEvent.click(screen.getByText('queue.matchBook'))
+    fireEvent.change(screen.getByLabelText('queue.matchBookSearch'), { target: { value: 'Target' } })
+    fireEvent.click(screen.getByText('queue.matchBookSearchBtn'))
+
+    await waitFor(() => expect(screen.getByText(/Target Book/)).toBeInTheDocument())
+    // Searches the library by the entered term.
+    expect(mockListAllBooks).toHaveBeenCalledWith({ search: 'Target' })
+
+    fireEvent.click(screen.getByText(/Target Book/))
+    expect(onMatch).toHaveBeenCalledWith(42)
+  })
+
+  it('ignores an empty query submitted via Enter', () => {
+    render(<MatchBookControl disabled={false} onMatch={vi.fn()} />)
+    fireEvent.click(screen.getByText('queue.matchBook'))
+    fireEvent.keyDown(screen.getByLabelText('queue.matchBookSearch'), { key: 'Enter' })
+    expect(mockListAllBooks).not.toHaveBeenCalled()
+  })
+
+  it('searches on Enter and shows no results when the lookup errors', async () => {
+    mockListAllBooks.mockRejectedValue(new Error('boom'))
+    render(<MatchBookControl disabled={false} onMatch={vi.fn()} />)
+    fireEvent.click(screen.getByText('queue.matchBook'))
+    fireEvent.change(screen.getByLabelText('queue.matchBookSearch'), { target: { value: 'X' } })
+    fireEvent.keyDown(screen.getByLabelText('queue.matchBookSearch'), { key: 'Enter' })
+    await waitFor(() => expect(mockListAllBooks).toHaveBeenCalledWith({ search: 'X' }))
+    // Error path swallows results; the Search button returns from its loading state.
+    expect(await screen.findByText('queue.matchBookSearchBtn')).toBeInTheDocument()
+  })
+
+  it('closes the picker on Cancel', () => {
+    render(<MatchBookControl disabled={false} onMatch={vi.fn()} />)
+    fireEvent.click(screen.getByText('queue.matchBook'))
+    expect(screen.getByLabelText('queue.matchBookSearch')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('queue.matchBookCancel'))
+    expect(screen.getByText('queue.matchBook')).toBeInTheDocument()
+    expect(screen.queryByLabelText('queue.matchBookSearch')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -192,6 +192,11 @@ export default function QueuePage() {
   }
   const FAILED_STATUSES = new Set(['failed', 'importFailed', 'importBlocked'])
   const failedItems = queue.filter(q => FAILED_STATUSES.has(q.status))
+  // A download can be manually matched/retried when its files are waiting: an
+  // unmatched import failure, or one blocked after exhausting its retry budget
+  // ("stuck after three attempts", #1589). A plain 'failed' download never got
+  // files, so it isn't matchable.
+  const isMatchable = (status: string) => status === 'importFailed' || status === 'importBlocked'
 
   // Bulk actions over failed/blocked items, done client-side over the existing
   // per-item endpoints (no new API). Retry only applies to importFailed.
@@ -350,7 +355,7 @@ export default function QueuePage() {
                         )}
                       </div>
                     )}
-                    {item.status === 'importFailed' && !item.book && (
+                    {isMatchable(item.status) && !item.book && (
                       <div className="mt-1 text-xs text-slate-600 dark:text-zinc-400 bg-slate-200/70 dark:bg-zinc-800/70 rounded px-2 py-1 break-words">
                         {t('queue.retryImportHint')}
                       </div>
@@ -358,7 +363,7 @@ export default function QueuePage() {
                     {/* Persistent match indicator: an import-failed download that
                         already has a book was matched — survives reload so the
                         user isn't left wondering whether the match took (#1589). */}
-                    {item.status === 'importFailed' && item.book && (
+                    {isMatchable(item.status) && item.book && (
                       <div className="mt-1 text-xs text-emerald-700 dark:text-emerald-400 bg-emerald-400/10 rounded px-2 py-1 break-words">
                         {t('queue.matchedTo', { title: item.book.title, defaultValue: `Matched to ${item.book.title} — use Retry import to import it.` })}
                       </div>
@@ -383,14 +388,14 @@ export default function QueuePage() {
                     )}
                   </div>
                   <div className="ml-4 flex flex-col sm:flex-row items-end sm:items-center gap-2 flex-shrink-0">
-                    {item.status === 'importFailed' && (
+                    {isMatchable(item.status) && (
                       <MatchBookControl
                         disabled={retryingImportIds.has(item.id)}
                         alreadyMatched={!!item.book}
                         onMatch={bookId => handleMatch(item.id, bookId)}
                       />
                     )}
-                    {item.status === 'importFailed' && (
+                    {isMatchable(item.status) && (
                       <button
                         // A matched item re-imports its recorded files against the
                         // assigned book (works with no download client); an

--- a/web/src/pages/QueuePage.tsx
+++ b/web/src/pages/QueuePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, PendingRelease, QueueItem } from '../api/client'
+import { api, Book, PendingRelease, QueueItem } from '../api/client'
 import BookAuthorLink from '../components/BookAuthorLink'
 import ImportHints from '../components/ImportHints'
 import Pagination from '../components/Pagination'
@@ -16,6 +16,7 @@ export default function QueuePage() {
   const [grabbingPending, setGrabbingPending] = useState<number | null>(null)
   const [retryingImportIds, setRetryingImportIds] = useState<Set<number>>(() => new Set())
   const [retryImportErrors, setRetryImportErrors] = useState<Record<number, string>>({})
+  const [matchMessages, setMatchMessages] = useState<Record<number, string>>({})
   const [deleteTarget, setDeleteTarget] = useState<QueueItem | null>(null)
   const [deleteFiles, setDeleteFiles] = useState(false)
   const [deleting, setDeleting] = useState(false)
@@ -123,6 +124,36 @@ export default function QueuePage() {
       setRetryImportErrors(prev => ({
         ...prev,
         [id]: e instanceof Error ? e.message : 'Retry failed',
+      }))
+    } finally {
+      setRetryingImportIds(prev => {
+        const next = new Set(prev)
+        next.delete(id)
+        return next
+      })
+    }
+  }
+
+  // handleMatch attaches an unmatched download to the picked book and imports its
+  // files against it (#1589), then surfaces the outcome inline so the user gets
+  // feedback rather than a silent no-op.
+  const handleMatch = async (id: number, bookId: number) => {
+    setRetryingImportIds(prev => new Set(prev).add(id))
+    clearRetryImportError(id)
+    setMatchMessages(prev => { const n = { ...prev }; delete n[id]; return n })
+    try {
+      const res = await api.matchDownload(id, bookId)
+      const message = res.imported
+        ? t('queue.matchImporting', 'Matched — importing now; the status will update shortly.')
+        : res.retryQueued
+          ? t('queue.matchQueued', 'Matched — the import will run on the next download-client check.')
+          : t('queue.matchNoFiles', 'Matched to the book, but the downloaded files could not be located to import automatically. Re-import them with Manual file import, or re-download.')
+      setMatchMessages(prev => ({ ...prev, [id]: message }))
+      load()
+    } catch (e) {
+      setRetryImportErrors(prev => ({
+        ...prev,
+        [id]: e instanceof Error ? e.message : 'Match failed',
       }))
     } finally {
       setRetryingImportIds(prev => {
@@ -319,14 +350,27 @@ export default function QueuePage() {
                         )}
                       </div>
                     )}
-                    {item.status === 'importFailed' && (
+                    {item.status === 'importFailed' && !item.book && (
                       <div className="mt-1 text-xs text-slate-600 dark:text-zinc-400 bg-slate-200/70 dark:bg-zinc-800/70 rounded px-2 py-1 break-words">
                         {t('queue.retryImportHint')}
+                      </div>
+                    )}
+                    {/* Persistent match indicator: an import-failed download that
+                        already has a book was matched — survives reload so the
+                        user isn't left wondering whether the match took (#1589). */}
+                    {item.status === 'importFailed' && item.book && (
+                      <div className="mt-1 text-xs text-emerald-700 dark:text-emerald-400 bg-emerald-400/10 rounded px-2 py-1 break-words">
+                        {t('queue.matchedTo', { title: item.book.title, defaultValue: `Matched to ${item.book.title} — use Retry import to import it.` })}
                       </div>
                     )}
                     {retryImportErrors[item.id] && (
                       <div className="mt-1 text-xs text-red-600 dark:text-red-400 bg-red-400/10 rounded px-2 py-1 break-words">
                         {t('queue.retryImportError', { error: retryImportErrors[item.id] })}
+                      </div>
+                    )}
+                    {matchMessages[item.id] && (
+                      <div className="mt-1 text-xs text-emerald-700 dark:text-emerald-400 bg-emerald-400/10 rounded px-2 py-1 break-words">
+                        {matchMessages[item.id]}
                       </div>
                     )}
                     {item.percentage && (
@@ -340,8 +384,18 @@ export default function QueuePage() {
                   </div>
                   <div className="ml-4 flex flex-col sm:flex-row items-end sm:items-center gap-2 flex-shrink-0">
                     {item.status === 'importFailed' && (
+                      <MatchBookControl
+                        disabled={retryingImportIds.has(item.id)}
+                        alreadyMatched={!!item.book}
+                        onMatch={bookId => handleMatch(item.id, bookId)}
+                      />
+                    )}
+                    {item.status === 'importFailed' && (
                       <button
-                        onClick={() => handleRetryImport(item.id)}
+                        // A matched item re-imports its recorded files against the
+                        // assigned book (works with no download client); an
+                        // unmatched item resets the client retry counter (#1589).
+                        onClick={() => item.book ? handleMatch(item.id, item.book.id) : handleRetryImport(item.id)}
                         disabled={retryingImportIds.has(item.id)}
                         title={t('queue.retryImportHint')}
                         className="px-3 py-2 text-xs bg-sky-600 hover:bg-sky-500 disabled:opacity-50 rounded font-medium touch-manipulation"
@@ -454,6 +508,83 @@ export default function QueuePage() {
           </div>
         </div>
       )}
+    </div>
+  )
+}
+
+// MatchBookControl lets the user attach an unmatched (importFailed) download to
+// an existing library book, then retry the import against it (#1589). Search is
+// against books already in the library — the download's files exist on disk, we
+// only need to tell Bindery which book they belong to. Exported for tests.
+export function MatchBookControl({ disabled, onMatch, alreadyMatched = false }: { disabled: boolean; onMatch: (bookId: number) => void; alreadyMatched?: boolean }) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<Book[]>([])
+  const [searching, setSearching] = useState(false)
+
+  const search = async () => {
+    if (!query.trim()) return
+    setSearching(true)
+    try {
+      const books = await api.listAllBooks({ search: query.trim() })
+      setResults(books ?? [])
+    } catch {
+      setResults([])
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        title={t('queue.matchBookHint', 'Attach this download to an existing book and import it')}
+        className="px-3 py-2 text-xs bg-slate-200 dark:bg-zinc-700 hover:bg-slate-300 dark:hover:bg-zinc-600 disabled:opacity-50 rounded font-medium touch-manipulation"
+      >
+        {alreadyMatched ? t('queue.matchBookChange', 'Match to a different book') : t('queue.matchBook', 'Match to book')}
+      </button>
+    )
+  }
+
+  return (
+    <div className="w-64 p-2 bg-slate-50 dark:bg-zinc-950 border border-slate-200 dark:border-zinc-800 rounded space-y-1">
+      <div className="flex gap-1">
+        <input
+          autoFocus
+          className="flex-1 px-2 py-1 text-xs rounded border border-slate-300 dark:border-zinc-700 bg-white dark:bg-zinc-900"
+          placeholder={t('queue.matchBookPlaceholder', 'Search your library')}
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') search() }}
+          aria-label={t('queue.matchBookSearch', 'Search for a book')}
+        />
+        <button
+          onClick={search}
+          disabled={searching || !query.trim()}
+          className="px-2 py-1 text-xs bg-slate-200 dark:bg-zinc-700 hover:bg-slate-300 dark:hover:bg-zinc-600 disabled:opacity-50 rounded"
+        >
+          {searching ? t('queue.matchBookSearching', 'Searching…') : t('queue.matchBookSearchBtn', 'Search')}
+        </button>
+      </div>
+      {results.length > 0 && (
+        <div className="max-h-40 overflow-auto">
+          {results.map(b => (
+            <button
+              key={b.id}
+              onClick={() => { setOpen(false); onMatch(b.id) }}
+              className="block w-full text-left text-xs px-1 py-0.5 rounded text-emerald-700 dark:text-emerald-400 hover:bg-slate-200 dark:hover:bg-zinc-800"
+            >
+              {b.title}{b.author ? ` (${b.author.authorName})` : ''}
+            </button>
+          ))}
+        </div>
+      )}
+      <button onClick={() => setOpen(false)} className="text-[10px] text-slate-500 dark:text-zinc-500 hover:underline">
+        {t('queue.matchBookCancel', 'Cancel')}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
Fixes #1589.

## Problem

A completed download that couldn't be auto-matched to a book sits in the Queue as `importFailed` ("could not match any book to this download") with no way forward — the files are on disk, but the only actions are **Retry import** (which re-runs the same failing auto-match) or **Remove**.

## What this does

Import-failed queue items get a **Match to book** control: search the library, pick the book, and Bindery imports the already-downloaded files against it — attaching the file and flipping the download to **Imported**, with inline feedback.

- **Root cause fix:** the scanner discarded the on-disk location of files it couldn't match, so the only recovery was an async re-poll of the download client (impossible once the client forgot the release, and absent entirely for clientless downloads). It now records that path (`import_path`) on the unmatched failure, and the new `POST /queue/manual-import/match` endpoint imports directly from it via `ImportFromPath`. Downloads with no recorded path but an owning client fall back to resetting the retry; with neither, the response reports `located=false` so the UI says the files couldn't be found instead of promising a retry that never fires.
- The match **persists**: a matched item shows "Matched to _&lt;book&gt;_" (survives reload) and its **Retry import** re-runs the import against that book.
- Clears a download's stale `error_message` on the transition to imported.

Out of scope: #1236 (Scan Library wizard for files already on disk) and #1238 (Fix Match — re-pointing an already-imported file, already covered by `/reassign`).

## Testing

- **100% coverage on the changed code.** New Go tests for `MatchDownload` (every branch incl. both DB-write error paths), `GetByID` / `SetImportPath`, `recordUnmatchedImportPath`, and the imported-transition error clear; frontend tests for the match feedback + error, the Retry-import routing, the persistent indicator, and `MatchBookControl`; `matchDownload` wrapper via MSW.
- Verified end-to-end in a running instance: match → import → file attached in library → **Imported** → feedback.
- CHANGELOG entry under Unreleased; docs updated (`API.md` endpoint reference, Troubleshooting wiki entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)