### PR TITLE
fix(indexer): reject video releases from book search and import (#1591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ All notable changes to Bindery are documented here. Format loosely follows
   recorded files (or re-arms the scanner with a fresh retry budget) instead of
   leaving them permanently stuck.
 
+### Fixed
+- **Auto-grab no longer selects or imports unrelated video releases** (#1591) —
+  an automatic audiobook search could pick a movie, TV, or music release that
+  shared a few words with the book title, download it, and move the whole folder
+  (video file included) into the audiobook library marked as imported. Two new
+  guards close this: release names carrying video-only markers (`1080p`, `x265`,
+  `WEBRip`, `S01E02`, and similar) and results the indexer filed under a
+  movie/TV/console/PC category are now dropped from book search results; and at
+  import time, a download whose largest file is a video file is blocked for
+  manual review instead of being imported (an explicit format chosen through
+  manual import overrides the block).
+
+### Changed
+- The queue **Retry import** control now also revives downloads the scanner
+  terminally blocked (`importBlocked`) after exhausting their retry budget, not
+  only `importFailed` ones — previously it silently no-op'd on blocked items.
+  (Part of #1589.)
+
 ## [v1.26.2] — 2026-07-19
 
 A patch release fixing two reported metadata bugs: profile language filters

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -818,6 +818,20 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 
 	s.updateDownloadStatus(ctx, dl.ID, models.StateImporting)
 
+	// Video-content guard (#1591): a movie/TV release that slipped through
+	// release-name filtering can still reach import — e.g. a film whose folder
+	// carries one soundtrack .mp3, which both passes discoverBookFiles and tips
+	// detectDownloadFormat to audiobook, dragging the whole folder (video file
+	// included) into the audiobook library. If the download's dominant file is
+	// a video file, the release is not a book: block it for manual review
+	// instead of importing. An explicit formatHint is the override — a human
+	// declared the format, so their call wins.
+	if formatHint == "" && largestFileIsVideo(downloadPath, explicitFiles) {
+		s.failImport(ctx, dl, models.StateImportBlocked,
+			"download looks like video content (largest file is a video file) — not imported; use manual import with an explicit format to override")
+		return
+	}
+
 	// Per-import timeout so a stalled NFS copy does not hold the download in
 	// StateImporting indefinitely. 30 minutes is generous for any realistic
 	// book file; the context-aware file operations return promptly when it fires.
@@ -1355,6 +1369,50 @@ func detectDownloadFormat(files []string) string {
 		}
 	}
 	return models.MediaTypeEbook
+}
+
+// videoExtensions lists common video container extensions. None of these are
+// book files, so a download whose largest file carries one is a movie/TV
+// release regardless of what smaller files ride along (#1591).
+var videoExtensions = map[string]bool{
+	".mkv": true, ".mp4": true, ".avi": true, ".wmv": true, ".mov": true,
+	".mpg": true, ".mpeg": true, ".m2ts": true, ".ts": true, ".vob": true,
+	".webm": true, ".flv": true,
+}
+
+// largestFileIsVideo reports whether the download's single largest file by
+// size is a video file. When the caller supplied an explicit per-torrent file
+// list (#903) only those files are considered — downloadPath can be a shared
+// download root there, and walking it would judge this download by an
+// unrelated sibling's video file. Without an explicit list, downloadPath is a
+// per-job directory (SABnzbd/NZBGet) or a single file and is walked directly.
+// Unreadable entries are skipped: this is a rejection heuristic, and an
+// unstat-able file must not block an otherwise legitimate import.
+func largestFileIsVideo(downloadPath string, explicitFiles []string) bool {
+	var largestExt string
+	var largestSize int64
+	consider := func(path string, size int64) {
+		if size > largestSize {
+			largestSize = size
+			largestExt = strings.ToLower(filepath.Ext(path))
+		}
+	}
+	if len(explicitFiles) > 0 {
+		for _, f := range explicitFiles {
+			if fi, err := os.Lstat(f); err == nil && fi.Mode().IsRegular() {
+				consider(f, fi.Size())
+			}
+		}
+	} else if err := filepath.Walk(downloadPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !info.Mode().IsRegular() {
+			return nil //nolint:nilerr // best-effort walk: skip unreadable entries rather than abort the scan
+		}
+		consider(path, info.Size())
+		return nil
+	}); err != nil {
+		return false
+	}
+	return videoExtensions[largestExt]
 }
 
 // FindExisting searches the library directories for a book file that matches

--- a/internal/importer/scanner_videoguard_test.go
+++ b/internal/importer/scanner_videoguard_test.go
@@ -1,0 +1,147 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// writeSized writes a file of the given size (content is irrelevant — only the
+// extension and size drive the video guard).
+func writeSized(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.WriteFile(path, make([]byte, size), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLargestFileIsVideo(t *testing.T) {
+	t.Run("walk mode: video-dominated movie folder", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSized(t, filepath.Join(dir, "Unrelated.Release.WEBRip.1080p.x265.mkv"), 4096)
+		writeSized(t, filepath.Join(dir, "soundtrack.mp3"), 512)
+		if !largestFileIsVideo(dir, nil) {
+			t.Error("largest file is an .mkv — want true")
+		}
+	})
+	t.Run("walk mode: legitimate audiobook folder with cover art", func(t *testing.T) {
+		dir := t.TempDir()
+		writeSized(t, filepath.Join(dir, "Example Book.m4b"), 4096)
+		writeSized(t, filepath.Join(dir, "cover.jpg"), 512)
+		if largestFileIsVideo(dir, nil) {
+			t.Error("largest file is an .m4b — want false")
+		}
+	})
+	t.Run("explicit file list wins over shared download root", func(t *testing.T) {
+		// Torrent case (#903): downloadPath is a shared root holding an
+		// unrelated sibling's video; only the explicit list may be judged.
+		root := t.TempDir()
+		writeSized(t, filepath.Join(root, "Some.Other.Movie.mkv"), 8192)
+		bookFile := filepath.Join(root, "Example Book.epub")
+		writeSized(t, bookFile, 1024)
+		if largestFileIsVideo(root, []string{bookFile}) {
+			t.Error("explicit list holds only the .epub — the sibling .mkv must not be considered")
+		}
+	})
+	t.Run("empty dir is not video", func(t *testing.T) {
+		if largestFileIsVideo(t.TempDir(), nil) {
+			t.Error("empty dir should never report video")
+		}
+	})
+}
+
+func videoGuardFixture(t *testing.T) (s *Scanner, downloads *db.DownloadRepo, dl *models.Download, downloadDir string, ctx context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx = context.Background()
+	downloads = db.NewDownloadRepo(database)
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	settings := db.NewSettingsRepo(database)
+	s = NewScanner(downloads, db.NewDownloadClientRepo(database), books, authors,
+		db.NewHistoryRepo(database), t.TempDir(), t.TempDir(), "", "", "")
+	s.WithSettings(settings)
+	if err := settings.Set(ctx, "import.mode", "copy"); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{ForeignID: "OLA", Name: "Example Author", SortName: "Author, Example", Monitored: true, MetadataProvider: "openlibrary"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book := &models.Book{
+		ForeignID: "OLB", AuthorID: author.ID, Title: "Example Book", SortTitle: "example book",
+		Status: models.BookStatusWanted, Monitored: true, AnyEditionOK: true,
+		MediaType: models.MediaTypeAudiobook, MetadataProvider: "openlibrary",
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	// The #1591 shape: a movie folder whose lone soundtrack .mp3 passes book-file
+	// discovery and tips format detection to audiobook.
+	downloadDir = t.TempDir()
+	writeSized(t, filepath.Join(downloadDir, "Unrelated.Release.WEBRip.1080p.x265.mkv"), 8192)
+	writeSized(t, filepath.Join(downloadDir, "soundtrack.mp3"), 512)
+
+	dl = &models.Download{GUID: "guid-video", Title: "Unrelated.Release.WEBRip.1080p.x265", BookID: &book.ID, Status: models.StateCompleted, NZBURL: "fake://url"}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	return s, downloads, dl, downloadDir, ctx
+}
+
+// TestImport_BlocksVideoDominatedDownload is the import-side regression test
+// for #1591: a movie release whose only book-extension file is a soundtrack
+// .mp3 must be blocked for manual review, not moved into the audiobook library
+// and marked imported.
+func TestImport_BlocksVideoDominatedDownload(t *testing.T) {
+	s, downloads, dl, downloadDir, ctx := videoGuardFixture(t)
+
+	s.tryImportInternal(ctx, dl, downloadDir, "", "", "", nil, nil)
+
+	reloaded, err := downloads.GetByGUID(ctx, "guid-video")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Status != models.StateImportBlocked {
+		t.Fatalf("status = %q, want %q", reloaded.Status, models.StateImportBlocked)
+	}
+	if !strings.Contains(reloaded.ErrorMessage, "video") {
+		t.Errorf("error message %q should name the video guard", reloaded.ErrorMessage)
+	}
+	// Nothing may have been moved or copied into either library dir.
+	for _, root := range []string{s.libraryDir, s.audiobookDir} {
+		_ = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+			if err == nil && !info.IsDir() {
+				t.Errorf("file %s landed under %s despite the block", p, root)
+			}
+			return nil
+		})
+	}
+}
+
+// TestImport_FormatHintOverridesVideoGuard: an explicit format from manual
+// import is a human decision — the guard must step aside.
+func TestImport_FormatHintOverridesVideoGuard(t *testing.T) {
+	s, downloads, dl, downloadDir, ctx := videoGuardFixture(t)
+
+	s.tryImportInternal(ctx, dl, downloadDir, "", "", models.MediaTypeAudiobook, nil, nil)
+
+	reloaded, err := downloads.GetByGUID(ctx, "guid-video")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Status == models.StateImportBlocked {
+		t.Fatalf("explicit formatHint must bypass the video guard, got %q: %s", reloaded.Status, reloaded.ErrorMessage)
+	}
+}

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -194,6 +195,7 @@ func (s *Searcher) SearchBook(ctx context.Context, indexers []models.Indexer, c 
 
 	results = dedupe(results)
 	results = filterUsenetJunk(results)
+	results = filterNonBookContent(results)
 	results = filterRelevant(results, c.Title, c.Author, c.AuthorAliases)
 	rankResults(results, c)
 	return results
@@ -740,6 +742,56 @@ func filterUsenetJunk(results []newznab.SearchResult) []newznab.SearchResult {
 		if !usenetJunkRe.MatchString(r.Title) {
 			out = append(out, r)
 		}
+	}
+	return out
+}
+
+// videoMarkerRe matches release-name tokens that only appear on movie/TV
+// video content: resolutions, video codecs, rip/source tags, and television
+// season-episode numbering. No legitimate ebook or audiobook release carries
+// any of these, so a single match disqualifies the result outright (#1591:
+// a movie sharing a few title words with the requested book was auto-grabbed
+// and imported as its audiobook).
+var videoMarkerRe = regexp.MustCompile(
+	`(?i)\b(?:` +
+		`(?:480|576|720|1080|2160)[pi]` + `|` + // video resolutions
+		`[xh]\.?26[45]|hevc|xvid|divx` + `|` + // video codecs
+		`web-?rip|web-?dl|hdtv|bd-?rip|br-?rip|dvd-?rip|blu-?ray|bluray|remux` + `|` + // video rip sources
+		`s\d{1,2}e\d{1,3}` + // S01E02 television numbering
+		`)\b`,
+)
+
+// isNonBookCategory reports whether a result's self-reported Newznab category
+// sits under a top-level category that can never contain book content:
+// 1000 Console, 2000 Movies, 4000 PC, 5000 TV, 6000 XXX. Books are 7000s,
+// audio(books) 3000s, 0/8000s are misc/other — those are left alone, as is
+// anything empty or unparseable: only positive evidence drops a result.
+func isNonBookCategory(cat string) bool {
+	n, err := strconv.Atoi(strings.TrimSpace(cat))
+	if err != nil {
+		return false
+	}
+	return (n >= 1000 && n < 3000) || (n >= 4000 && n < 7000)
+}
+
+// filterNonBookContent drops results that are demonstrably not book content:
+// releases whose names carry video-only markers, and results the indexer
+// itself filed under a movie/TV/console/PC category. Book searches already
+// request book/audiobook categories, but some indexers ignore category
+// filters on q= searches and return anything matching the title words
+// (#1591) — this is the response-side backstop.
+func filterNonBookContent(results []newznab.SearchResult) []newznab.SearchResult {
+	out := make([]newznab.SearchResult, 0, len(results))
+	for _, r := range results {
+		if videoMarkerRe.MatchString(r.Title) {
+			slog.Debug("dropping video release from book search", "title", r.Title, "indexer", r.IndexerName)
+			continue
+		}
+		if isNonBookCategory(r.Category) {
+			slog.Debug("dropping non-book category result", "title", r.Title, "category", r.Category, "indexer", r.IndexerName)
+			continue
+		}
+		out = append(out, r)
 	}
 	return out
 }

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -1500,3 +1500,76 @@ func TestFilterRelevantInOrderEmbeddedDifferentWork(t *testing.T) {
 		}
 	}
 }
+
+func TestFilterNonBookContentVideoMarkers(t *testing.T) {
+	// The #1591 report: a movie release sharing a few title words with the
+	// requested book was selected as its audiobook. Every video-marked title
+	// must be dropped regardless of how well its words match.
+	dropped := []string{
+		"Unrelated.Release.WEBRip.1080p.x265",
+		"Example.Book.2019.720p.WEB-DL.h264-GRP",
+		"Example Book S01E03 HDTV x264",
+		"Example.Book.2160p.BluRay.REMUX.HEVC",
+		"Example.Book.DVDRip.XviD",
+	}
+	kept := []string{
+		"Example Author - Example Book (Unabridged) [M4B]",
+		"Example.Book.Example.Author.EPUB",
+		"Example Book by Example Author MP3 320",
+	}
+	results := filterNonBookContent(toResults(append(dropped, kept...)...))
+	for _, title := range dropped {
+		if contains(results, title) {
+			t.Errorf("video-marked release %q should be dropped", title)
+		}
+	}
+	for _, title := range kept {
+		if !contains(results, title) {
+			t.Errorf("book release %q should be kept", title)
+		}
+	}
+}
+
+func TestFilterNonBookContentCategories(t *testing.T) {
+	mk := func(title, cat string) newznab.SearchResult {
+		return newznab.SearchResult{Title: title, GUID: title, Category: cat}
+	}
+	results := filterNonBookContent([]newznab.SearchResult{
+		mk("movie-cat", "2040"),   // Movies/HD
+		mk("tv-cat", "5030"),      // TV/SD
+		mk("console-cat", "1010"), // Console
+		mk("pc-cat", "4050"),      // PC/Games
+		mk("audiobook-cat", "3030"),
+		mk("ebook-cat", "7020"),
+		mk("misc-cat", "8010"),
+		mk("no-cat", ""),
+		mk("garbage-cat", "Books > Audiobooks"),
+	})
+	for _, want := range []string{"audiobook-cat", "ebook-cat", "misc-cat", "no-cat", "garbage-cat"} {
+		if !contains(results, want) {
+			t.Errorf("result %q should be kept", want)
+		}
+	}
+	for _, drop := range []string{"movie-cat", "tv-cat", "console-cat", "pc-cat"} {
+		if contains(results, drop) {
+			t.Errorf("result %q should be dropped", drop)
+		}
+	}
+}
+
+func TestVideoMarkerReNoFalsePositives(t *testing.T) {
+	// Titles that skirt the marker vocabulary but are legitimate books.
+	for _, title := range []string{
+		"1080 Recipes - Simone Ortega EPUB",             // bare number, no p/i suffix
+		"Windows 10 for Dummies.epub",                   // OS version number
+		"Seveneves - Neal Stephenson (Unabridged)",      // contains 'eve', 'ns'
+		"The Subtle Art of Not Giving a F*ck MP3",       // profanity masking punctuation
+		"Sherlock Holmes - The Complete Series [M4B]",   // 'Series' without SxxExx
+		"Ready Player One - Ernest Cline - 2011 - AZW3", // year present
+		"Remus Lupin Chronicles - Book 2 (2020) [EPUB]", // 'Remu...' prefix of remux but bounded
+	} {
+		if videoMarkerRe.MatchString(title) {
+			t.Errorf("videoMarkerRe should not match book title %q", title)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1591.

## Problem

An automatic audiobook search could select a movie, TV, or music release that shared only a few words with the requested book title. Bindery downloaded it, then imported the unrelated files (a lone soundtrack `.mp3` is enough to tip format detection to audiobook) into the book's audiobook folder — moving the whole folder, video file included — and marked the audiobook successfully imported. From the report's INFO log:

```
auto-grabbing book ... result="Unrelated.Release.WEBRip.1080p.x265" format=audiobook
importing audiobook folder src=".../Unrelated.Release.WEBRip.1080p.x265" dst=".../audiobooks/Example Author/Example Book"
audiobook imported ...
```

Three gaps lined up: title-word filtering accepts a video release that embeds the book's words; the wrong-media-type score penalty is skipped for video releases because they parse to `unknown` quality; and import does zero content validation once a `BookID` is set, moving the entire download folder as a unit.

## What this does

**Search side** (`filterNonBookContent`, runs in the `SearchBook` pipeline after junk filtering, before relevance):
- Drops results whose names carry video-only markers: resolutions (`1080p`, `2160p`), video codecs (`x265`, `HEVC`, `XviD`), rip sources (`WEBRip`, `BluRay`, `HDTV`, `REMUX`), and `SxxExx` television numbering. No legitimate ebook/audiobook release carries these.
- Drops results the indexer itself filed under a non-book top-level category (1000 Console, 2000 Movies, 4000 PC, 5000 TV, 6000 XXX). This is the backstop for indexers that ignore category filters on `q=` searches. Empty/unparseable categories are left alone — only positive evidence drops a result.

**Import side** (`largestFileIsVideo`, checked after the `StateImporting` flip):
- If the download's single largest file is a video file, the release is not a book: block it to `importBlocked` for manual review instead of importing. Honors the explicit `--format` path list from torrent clients (#903) so a shared download root isn't judged by an unrelated sibling.
- An explicit `formatHint` (manual import) overrides the guard — a human declared the format, so their call wins.

## Testing

- `TestFilterNonBookContentVideoMarkers`, `TestFilterNonBookContentCategories`, `TestVideoMarkerReNoFalsePositives` (guards against matching book titles like "1080 Recipes", "Windows 10 for Dummies", "Seveneves").
- `TestLargestFileIsVideo` (walk mode, explicit-list mode, empty dir), `TestImport_BlocksVideoDominatedDownload`, `TestImport_FormatHintOverridesVideoGuard`.
- Full `go test -race`, `golangci-lint`, `go vet`, `gofmt` green on both touched packages.

## Notes

Content-level title/author verification of the downloaded files (the report's secondary ask — a mismatched *ebook* imported under the wrong book) is deliberately out of scope here; the embedded-metadata matcher only runs when no `BookID` is set, and extending it to re-verify grabbed downloads is a larger change worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)