### PR TITLE
feat(importer): rename files to reorganize an existing library (#1181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to Bindery are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Rename files: reorganize an existing library to the naming template**
+  (#1181) — the naming template used to apply only at import time, so changing
+  it later, importing a pre-existing library, or ending up with a half-renamed
+  mix left no way to reconcile files short of deleting and re-importing. A new
+  **Rename files** action (on the book detail page and the author page) previews
+  every tracked file's `current → proposed` path under the current template and,
+  once confirmed, moves the ones that differ — updating the library index and
+  recording a rename in history. It is always a move within the library (never a
+  copy), refuses to overwrite an existing destination, skips files already in
+  the right place, and leaves anything not on disk untouched. Ebooks move as
+  single files; audiobooks move as whole folders. Backed by
+  `GET /api/v1/reorganize/preview` and `POST /api/v1/reorganize/apply` (both
+  admin-only). Whole-library scope is available through the API; the UI exposes
+  the per-book and per-author scopes.
 - **Manually match an unmatched download in the queue** (#1589) — a download the
   auto-matcher couldn't tie to a book ("could not match any book to this
   download") used to sit in the queue as a dead-end import failure. Import-failed

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -556,6 +556,7 @@ func main() {
 	manualImportHandler := api.NewManualImportHandler(importScanner, downloadRepo, bookRepo).
 		WithRoots(importRoots)
 	pendingHandler := api.NewPendingHandler(pendingReleaseRepo, queueHandler, downloadRepo, bookRepo)
+	reorganizeHandler := api.NewReorganizeHandler(importScanner)
 	importScanner.WithSettings(settingsRepo)
 	importScanner.WithRootFolders(rootFolderRepo)
 	importScanner.WithSeriesRepo(seriesRepo)
@@ -838,6 +839,11 @@ func main() {
 			r.Post("/queue/manual-import/batch", manualImportHandler.ImportBatch)
 			r.Post("/queue/manual-import/reassign", manualImportHandler.Reassign)
 			r.Post("/queue/manual-import/match", manualImportHandler.MatchDownload)
+
+			// Library reorganize (#1181) — admin-only: recomputes tracked files'
+			// paths from the current naming template and moves them in place.
+			r.Get("/reorganize/preview", reorganizeHandler.Preview)
+			r.Post("/reorganize/apply", reorganizeHandler.Apply)
 		})
 		r.Get("/pending", pendingHandler.List)
 		r.Delete("/pending/{id}", pendingHandler.Delete)

--- a/docs/API.md
+++ b/docs/API.md
@@ -124,6 +124,10 @@ POST   /api/v1/queue/manual-import/batch          import selected {path, bookId}
 POST   /api/v1/queue/manual-import/reassign       move a mis-matched file to another book (admin)
 POST   /api/v1/queue/manual-import/match          attach an importFailed download to a book and import its files (admin)
 
+GET    /api/v1/reorganize/preview                 preview renaming tracked files to the current template (admin)
+                                                    ?scope=book|author|library (&id=N for book/author)
+POST   /api/v1/reorganize/apply                   move the selected files {fileIds:[…]} to their templated paths (admin)
+
 GET    /api/v1/history                            grab / import / failure timeline
 POST   /api/v1/history/{id}/blocklist             add the release to the blocklist
 

--- a/internal/api/reorganize.go
+++ b/internal/api/reorganize.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/vavallee/bindery/internal/importer"
+)
+
+// reorganizeScanner is the slice of the import scanner the reorganize endpoints
+// use: compute where tracked files should live under the current naming
+// template, and move them there (#1181).
+type reorganizeScanner interface {
+	PreviewReorganizeBook(ctx context.Context, bookID int64) ([]importer.ReorganizeMove, error)
+	PreviewReorganizeAuthor(ctx context.Context, authorID int64) ([]importer.ReorganizeMove, error)
+	PreviewReorganizeLibrary(ctx context.Context) ([]importer.ReorganizeMove, error)
+	ApplyReorganize(ctx context.Context, fileIDs []int64) []importer.ReorganizeMove
+}
+
+// ReorganizeHandler serves the library-reorganize preview and apply endpoints.
+// All routes are admin-only (they move files on the server filesystem) and
+// mounted behind auth.RequireAdmin in main.go.
+type ReorganizeHandler struct {
+	scanner reorganizeScanner
+}
+
+// NewReorganizeHandler builds the handler over the import scanner.
+func NewReorganizeHandler(scanner reorganizeScanner) *ReorganizeHandler {
+	return &ReorganizeHandler{scanner: scanner}
+}
+
+type reorganizeSummary struct {
+	Total     int `json:"total"`
+	ToMove    int `json:"toMove"`
+	Noop      int `json:"noop"`
+	Collision int `json:"collision"`
+	Missing   int `json:"missing"`
+	Errored   int `json:"errored"`
+	Moved     int `json:"moved"`
+	Failed    int `json:"failed"`
+}
+
+type reorganizeResponse struct {
+	Moves   []importer.ReorganizeMove `json:"moves"`
+	Summary reorganizeSummary         `json:"summary"`
+}
+
+func summarize(moves []importer.ReorganizeMove) reorganizeSummary {
+	s := reorganizeSummary{Total: len(moves)}
+	for _, m := range moves {
+		switch m.Status {
+		case importer.ReorgStatusMove:
+			s.ToMove++
+		case importer.ReorgStatusNoop:
+			s.Noop++
+		case importer.ReorgStatusCollision:
+			s.Collision++
+		case importer.ReorgStatusMissing:
+			s.Missing++
+		case importer.ReorgStatusError:
+			s.Errored++
+		case importer.ReorgStatusMoved:
+			s.Moved++
+		case importer.ReorgStatusFailed:
+			s.Failed++
+		}
+	}
+	return s
+}
+
+// Preview handles GET /api/v1/reorganize/preview?scope=book|author|library&id=N
+// It computes the proposed moves for the requested scope without touching disk.
+func (h *ReorganizeHandler) Preview(w http.ResponseWriter, r *http.Request) {
+	scope := r.URL.Query().Get("scope")
+	ctx := r.Context()
+
+	var (
+		moves []importer.ReorganizeMove
+		err   error
+	)
+	switch scope {
+	case "book":
+		id, ok := parseReorgID(w, r)
+		if !ok {
+			return
+		}
+		moves, err = h.scanner.PreviewReorganizeBook(ctx, id)
+	case "author":
+		id, ok := parseReorgID(w, r)
+		if !ok {
+			return
+		}
+		moves, err = h.scanner.PreviewReorganizeAuthor(ctx, id)
+	case "library":
+		moves, err = h.scanner.PreviewReorganizeLibrary(ctx)
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "scope must be one of: book, author, library"})
+		return
+	}
+	if err != nil {
+		writeServerError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, reorganizeResponse{Moves: moves, Summary: summarize(moves)})
+}
+
+type applyReorganizeRequest struct {
+	FileIDs []int64 `json:"fileIds"`
+}
+
+// Apply handles POST /api/v1/reorganize/apply with a body of {fileIds:[...]}.
+// It recomputes each file's destination server-side (never trusting a
+// client-supplied target) and moves the ones still classified as a clean move,
+// returning a result per file.
+func (h *ReorganizeHandler) Apply(w http.ResponseWriter, r *http.Request) {
+	var req applyReorganizeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if len(req.FileIDs) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "fileIds is required"})
+		return
+	}
+	results := h.scanner.ApplyReorganize(r.Context(), req.FileIDs)
+	writeJSON(w, http.StatusOK, reorganizeResponse{Moves: results, Summary: summarize(results)})
+}
+
+// parseReorgID reads and validates the required ?id= query parameter for the
+// book/author scopes, writing a 400 and returning ok=false when it is absent or
+// malformed.
+func parseReorgID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	raw := r.URL.Query().Get("id")
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "a positive id is required for this scope"})
+		return 0, false
+	}
+	return id, true
+}

--- a/internal/api/reorganize_test.go
+++ b/internal/api/reorganize_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/importer"
+)
+
+// fakeReorganizeScanner is a stub implementing reorganizeScanner so the handler
+// can be exercised without a real filesystem/import scanner.
+type fakeReorganizeScanner struct {
+	previewBook    []importer.ReorganizeMove
+	previewAuthor  []importer.ReorganizeMove
+	previewLibrary []importer.ReorganizeMove
+	applied        []int64
+	applyResult    []importer.ReorganizeMove
+}
+
+func (f *fakeReorganizeScanner) PreviewReorganizeBook(_ context.Context, _ int64) ([]importer.ReorganizeMove, error) {
+	return f.previewBook, nil
+}
+func (f *fakeReorganizeScanner) PreviewReorganizeAuthor(_ context.Context, _ int64) ([]importer.ReorganizeMove, error) {
+	return f.previewAuthor, nil
+}
+func (f *fakeReorganizeScanner) PreviewReorganizeLibrary(_ context.Context) ([]importer.ReorganizeMove, error) {
+	return f.previewLibrary, nil
+}
+func (f *fakeReorganizeScanner) ApplyReorganize(_ context.Context, fileIDs []int64) []importer.ReorganizeMove {
+	f.applied = fileIDs
+	return f.applyResult
+}
+
+func TestReorganizePreview_ScopeValidation(t *testing.T) {
+	h := NewReorganizeHandler(&fakeReorganizeScanner{})
+
+	// Missing scope.
+	rec := httptest.NewRecorder()
+	h.Preview(rec, httptest.NewRequest(http.MethodGet, "/api/v1/reorganize/preview", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("missing scope: code = %d, want 400", rec.Code)
+	}
+
+	// book scope without id.
+	rec = httptest.NewRecorder()
+	h.Preview(rec, httptest.NewRequest(http.MethodGet, "/api/v1/reorganize/preview?scope=book", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("book scope no id: code = %d, want 400", rec.Code)
+	}
+}
+
+func TestReorganizePreview_SummaryCounts(t *testing.T) {
+	fake := &fakeReorganizeScanner{
+		previewBook: []importer.ReorganizeMove{
+			{FileID: 1, Status: importer.ReorgStatusMove},
+			{FileID: 2, Status: importer.ReorgStatusNoop},
+			{FileID: 3, Status: importer.ReorgStatusCollision},
+		},
+	}
+	h := NewReorganizeHandler(fake)
+	rec := httptest.NewRecorder()
+	h.Preview(rec, httptest.NewRequest(http.MethodGet, "/api/v1/reorganize/preview?scope=book&id=5", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200", rec.Code)
+	}
+	var resp reorganizeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Summary.Total != 3 || resp.Summary.ToMove != 1 || resp.Summary.Noop != 1 || resp.Summary.Collision != 1 {
+		t.Errorf("summary = %+v", resp.Summary)
+	}
+}
+
+func TestReorganizeApply(t *testing.T) {
+	fake := &fakeReorganizeScanner{
+		applyResult: []importer.ReorganizeMove{{FileID: 7, Status: importer.ReorgStatusMoved}},
+	}
+	h := NewReorganizeHandler(fake)
+
+	// Empty body.
+	rec := httptest.NewRecorder()
+	h.Apply(rec, httptest.NewRequest(http.MethodPost, "/api/v1/reorganize/apply", bytes.NewBufferString(`{"fileIds":[]}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("empty fileIds: code = %d, want 400", rec.Code)
+	}
+
+	// Valid apply.
+	rec = httptest.NewRecorder()
+	h.Apply(rec, httptest.NewRequest(http.MethodPost, "/api/v1/reorganize/apply", bytes.NewBufferString(`{"fileIds":[7]}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200", rec.Code)
+	}
+	if len(fake.applied) != 1 || fake.applied[0] != 7 {
+		t.Errorf("applied = %v, want [7]", fake.applied)
+	}
+	var resp reorganizeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Summary.Moved != 1 {
+		t.Errorf("summary.Moved = %d, want 1", resp.Summary.Moved)
+	}
+}

--- a/internal/db/book_files.go
+++ b/internal/db/book_files.go
@@ -31,6 +31,43 @@ func (r *BookFileRepo) Add(ctx context.Context, bookID int64, format, path strin
 	return nil
 }
 
+// UpdatePath changes the on-disk path of the book_files row with the given id.
+// Used by the library reorganize action (#1181) after a tracked file is moved
+// to the location the current naming template computes. The path column is
+// globally UNIQUE, so a move onto a path another row already owns fails here
+// rather than silently corrupting the index.
+func (r *BookFileRepo) UpdatePath(ctx context.Context, id int64, newPath string) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE book_files SET path = ? WHERE id = ?`, newPath, id)
+	if err != nil {
+		return fmt.Errorf("book_files update path: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("book_files update path rows: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("book_files update path: no row with id %d", id)
+	}
+	return nil
+}
+
+// BookIDForFile returns the owning book_id for a book_files row id, or 0 when
+// no such row exists. Used by the reorganize apply path (#1181) to resolve a
+// file the client picked back to its book.
+func (r *BookFileRepo) BookIDForFile(ctx context.Context, fileID int64) (int64, error) {
+	var bookID int64
+	err := r.db.QueryRowContext(ctx,
+		`SELECT book_id FROM book_files WHERE id = ?`, fileID).Scan(&bookID)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("book_files book_id lookup: %w", err)
+	}
+	return bookID, nil
+}
+
 // ListByBook returns all book_files rows for the given book, ordered by id.
 func (r *BookFileRepo) ListByBook(ctx context.Context, bookID int64) ([]models.BookFile, error) {
 	rows, err := r.db.QueryContext(ctx,

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -599,6 +599,22 @@ func (r *BookRepo) ListBookFiles(ctx context.Context, bookID int64) ([]models.Bo
 	return r.files.ListByBook(ctx, bookID)
 }
 
+// BookIDForFile returns the owning book id for a book_files row id (0 if none).
+func (r *BookRepo) BookIDForFile(ctx context.Context, fileID int64) (int64, error) {
+	return r.files.BookIDForFile(ctx, fileID)
+}
+
+// UpdateBookFilePath repoints a tracked book_files row at newPath (after the
+// library reorganize action moved the file on disk, #1181) and refreshes the
+// owning book's aggregate status so the computed ebook/audiobook path views
+// track the new location.
+func (r *BookRepo) UpdateBookFilePath(ctx context.Context, fileID, bookID int64, newPath string) error {
+	if err := r.files.UpdatePath(ctx, fileID, newPath); err != nil {
+		return err
+	}
+	return r.refreshBookStatus(ctx, bookID)
+}
+
 // refreshBookStatus recomputes the aggregate status for a book from its
 // current book_files rows and updates both the status and legacy columns.
 // It queries book_files directly so the result is always authoritative,

--- a/internal/importer/reorganize.go
+++ b/internal/importer/reorganize.go
@@ -1,0 +1,361 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// Reorganize move statuses (#1181). Every previewed file carries one so the UI
+// can show why a file will or will not move before anything touches disk.
+const (
+	ReorgStatusMove      = "move"      // proposed differs from current; ready to move
+	ReorgStatusNoop      = "noop"      // already at the templated location
+	ReorgStatusCollision = "collision" // a different file already occupies the proposed path
+	ReorgStatusMissing   = "missing"   // the tracked file is not on disk
+	ReorgStatusError     = "error"     // the target path could not be computed
+	ReorgStatusMoved     = "moved"     // apply: the move completed
+	ReorgStatusFailed    = "failed"    // apply: the move failed
+)
+
+// ReorganizeMove is a single tracked file's current location and where the
+// current naming template says it should live. It is the unit of both the
+// preview (proposed moves) and the apply result (with Status updated to
+// moved/failed).
+type ReorganizeMove struct {
+	BookID    int64  `json:"bookId"`
+	FileID    int64  `json:"fileId"`
+	Format    string `json:"format"`
+	BookTitle string `json:"bookTitle"`
+	Author    string `json:"author"`
+	Current   string `json:"current"`
+	Proposed  string `json:"proposed"`
+	Status    string `json:"status"`
+	Message   string `json:"message,omitempty"`
+}
+
+// PreviewReorganizeBook returns the proposed moves for one book's tracked
+// files. It never touches disk.
+func (s *Scanner) PreviewReorganizeBook(ctx context.Context, bookID int64) ([]ReorganizeMove, error) {
+	book, err := s.books.GetByID(ctx, bookID)
+	if err != nil {
+		return nil, err
+	}
+	if book == nil {
+		return nil, fmt.Errorf("book %d not found", bookID)
+	}
+	return s.previewBook(ctx, book)
+}
+
+// PreviewReorganizeAuthor returns the proposed moves for every book by an
+// author. It never touches disk.
+func (s *Scanner) PreviewReorganizeAuthor(ctx context.Context, authorID int64) ([]ReorganizeMove, error) {
+	books, err := s.books.ListByAuthor(ctx, authorID)
+	if err != nil {
+		return nil, err
+	}
+	return s.previewBooks(ctx, books)
+}
+
+// PreviewReorganizeLibrary returns the proposed moves for the whole library. It
+// never touches disk. On a large library this walks every book once; callers
+// should treat it as an admin-triggered, potentially slow read.
+func (s *Scanner) PreviewReorganizeLibrary(ctx context.Context) ([]ReorganizeMove, error) {
+	books, err := s.books.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.previewBooks(ctx, books)
+}
+
+func (s *Scanner) previewBooks(ctx context.Context, books []models.Book) ([]ReorganizeMove, error) {
+	var moves []ReorganizeMove
+	for i := range books {
+		if err := ctx.Err(); err != nil {
+			return moves, err
+		}
+		bm, err := s.previewBook(ctx, &books[i])
+		if err != nil {
+			slog.Warn("reorganize: failed to preview book", "bookID", books[i].ID, "error", err)
+			continue
+		}
+		moves = append(moves, bm...)
+	}
+	return moves, nil
+}
+
+// previewBook computes, for each of a book's tracked files, where the current
+// naming template would place it and whether that differs from where it sits.
+func (s *Scanner) previewBook(ctx context.Context, book *models.Book) ([]ReorganizeMove, error) {
+	files, err := s.books.ListBookFiles(ctx, book.ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	var author *models.Author
+	if a, err := s.authors.GetByID(ctx, book.AuthorID); err != nil {
+		slog.Warn("reorganize: failed to load author", "authorID", book.AuthorID, "error", err)
+	} else {
+		author = a
+	}
+	authorName := ""
+	if author != nil {
+		authorName = author.Name
+	}
+	seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
+
+	moves := make([]ReorganizeMove, 0, len(files))
+	for _, f := range files {
+		m := ReorganizeMove{
+			BookID:    book.ID,
+			FileID:    f.ID,
+			Format:    f.Format,
+			BookTitle: book.Title,
+			Author:    authorName,
+			Current:   f.Path,
+		}
+		proposed, status, msg := s.proposedPathFor(ctx, book, author, seriesTitle, seriesNum, f)
+		m.Proposed = proposed
+		m.Status = status
+		m.Message = msg
+		moves = append(moves, m)
+	}
+	return moves, nil
+}
+
+// proposedPathFor computes the templated destination for a single tracked file
+// and classifies the move. It reuses the exact renamer entrypoints the import
+// path uses (DestPath for ebooks, AudiobookDestDir for audiobook folders), so a
+// reorganized library matches a freshly-imported one byte-for-byte.
+func (s *Scanner) proposedPathFor(ctx context.Context, book *models.Book, author *models.Author, seriesTitle, seriesNum string, f models.BookFile) (proposed, status, msg string) {
+	var dest string
+	var err error
+	if f.Format == models.MediaTypeAudiobook {
+		root := s.effectiveAudiobookDir(ctx, author)
+		dest, err = s.renamer.AudiobookDestDir(root, author, book, seriesTitle, seriesNum)
+	} else {
+		root := s.effectiveLibraryDir(ctx, author)
+		dest, err = s.renamer.DestPath(root, author, book, seriesTitle, seriesNum, f.Path)
+	}
+	if err != nil {
+		return "", ReorgStatusError, err.Error()
+	}
+
+	if filepath.Clean(dest) == filepath.Clean(f.Path) {
+		return dest, ReorgStatusNoop, ""
+	}
+	// The source must still be on disk to move it.
+	if _, err := os.Stat(f.Path); err != nil {
+		if os.IsNotExist(err) {
+			return dest, ReorgStatusMissing, "tracked file is not on disk"
+		}
+		return dest, ReorgStatusError, err.Error()
+	}
+	// Never overwrite: if something already occupies the proposed path it is
+	// either an untracked file or another book's file. Surface it and skip.
+	if _, err := os.Stat(dest); err == nil {
+		return dest, ReorgStatusCollision, "destination already exists"
+	} else if !os.IsNotExist(err) {
+		return dest, ReorgStatusError, err.Error()
+	}
+	return dest, ReorgStatusMove, ""
+}
+
+// ApplyReorganize moves each of the given tracked files to its templated
+// location and updates the book_files index. It recomputes the destination
+// itself (it does not trust a client-supplied target), skips anything that is
+// no longer a clean move, and returns a result per file. Files not classified
+// as a move (noop/collision/missing/error) are reported unchanged, never moved.
+//
+// Reorganize is always a move within the library — never a copy — so a
+// hard-linked file keeps its link and a file is never duplicated.
+func (s *Scanner) ApplyReorganize(ctx context.Context, fileIDs []int64) []ReorganizeMove {
+	results := make([]ReorganizeMove, 0, len(fileIDs))
+	for _, fileID := range fileIDs {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+		results = append(results, s.applyOne(ctx, fileID))
+	}
+	return results
+}
+
+func (s *Scanner) applyOne(ctx context.Context, fileID int64) ReorganizeMove {
+	book, file, err := s.bookFileByID(ctx, fileID)
+	if err != nil {
+		return ReorganizeMove{FileID: fileID, Status: ReorgStatusFailed, Message: err.Error()}
+	}
+
+	var author *models.Author
+	if a, aerr := s.authors.GetByID(ctx, book.AuthorID); aerr == nil {
+		author = a
+	}
+	authorName := ""
+	if author != nil {
+		authorName = author.Name
+	}
+	seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
+
+	proposed, status, msg := s.proposedPathFor(ctx, book, author, seriesTitle, seriesNum, file)
+	m := ReorganizeMove{
+		BookID: book.ID, FileID: fileID, Format: file.Format,
+		BookTitle: book.Title, Author: authorName,
+		Current: file.Path, Proposed: proposed, Status: status, Message: msg,
+	}
+	// Only a clean, still-valid move is carried out. Anything the recompute now
+	// classifies otherwise (a racing collision, a vanished source, a template
+	// that no longer resolves) is reported as-is and left on disk.
+	if status != ReorgStatusMove {
+		return m
+	}
+
+	if err := s.moveTrackedFile(ctx, file, proposed); err != nil {
+		m.Status = ReorgStatusFailed
+		m.Message = err.Error()
+		return m
+	}
+
+	if err := s.books.UpdateBookFilePath(ctx, file.ID, book.ID, proposed); err != nil {
+		// The file is already at the new path on disk; failing to record it
+		// leaves the index pointing at a now-missing location. This is the one
+		// genuinely bad outcome, so it is surfaced as a failure with a specific
+		// message rather than swallowed.
+		slog.Error("reorganize: moved file but failed to update index", "fileID", file.ID, "from", file.Path, "to", proposed, "error", err)
+		m.Status = ReorgStatusFailed
+		m.Message = "file moved on disk but the library index could not be updated: " + err.Error()
+		return m
+	}
+
+	pruneEmptyParents(filepath.Dir(file.Path), s.rootsForFormat(ctx, author, file.Format))
+	bookID := book.ID
+	s.createHistoryEvent(ctx, models.HistoryEventBookRenamed, book.Title, &bookID, map[string]string{
+		"from":   file.Path,
+		"to":     proposed,
+		"format": file.Format,
+	})
+
+	m.Status = ReorgStatusMoved
+	return m
+}
+
+// moveTrackedFile moves an already-imported file (ebook) or folder (audiobook)
+// from its current path to dest, creating the parent directory. It reuses the
+// import machinery's move primitives: StagedImport for a single ebook file
+// (atomic commit + rollback across a same-fs rename or cross-fs copy), and
+// MoveDirCtx for an audiobook folder.
+func (s *Scanner) moveTrackedFile(ctx context.Context, file models.BookFile, dest string) error {
+	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+		return fmt.Errorf("create destination directory: %w", err)
+	}
+
+	info, err := os.Stat(file.Path)
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+	if info.IsDir() {
+		// Audiobook folder.
+		return MoveDirCtx(ctx, file.Path, dest)
+	}
+
+	// Single ebook file: stage → commit for an atomic, rollback-safe move.
+	_, commit, rollback, err := StagedImport(ctx, "move", file.Path, dest)
+	if err != nil {
+		return err
+	}
+	if err := commit(); err != nil {
+		rollback()
+		return err
+	}
+	return nil
+}
+
+// bookFileByID resolves a book_files row and its owning book. book_files has no
+// single-row getter, so this scans the owner's files for the id.
+func (s *Scanner) bookFileByID(ctx context.Context, fileID int64) (*models.Book, models.BookFile, error) {
+	bookID, err := s.books.BookIDForFile(ctx, fileID)
+	if err != nil {
+		return nil, models.BookFile{}, err
+	}
+	if bookID == 0 {
+		return nil, models.BookFile{}, fmt.Errorf("book file %d not found", fileID)
+	}
+	book, err := s.books.GetByID(ctx, bookID)
+	if err != nil {
+		return nil, models.BookFile{}, err
+	}
+	if book == nil {
+		return nil, models.BookFile{}, fmt.Errorf("book %d not found", bookID)
+	}
+	files, err := s.books.ListBookFiles(ctx, bookID)
+	if err != nil {
+		return nil, models.BookFile{}, err
+	}
+	for _, f := range files {
+		if f.ID == fileID {
+			return book, f, nil
+		}
+	}
+	return nil, models.BookFile{}, fmt.Errorf("book file %d not found", fileID)
+}
+
+// rootsForFormat returns the library root(s) a file of the given format may
+// live under, used to bound empty-directory pruning so it can never walk above
+// the library.
+func (s *Scanner) rootsForFormat(ctx context.Context, author *models.Author, format string) []string {
+	var roots []string
+	if format == models.MediaTypeAudiobook {
+		roots = append(roots, s.effectiveAudiobookDir(ctx, author), s.audiobookDir)
+	} else {
+		roots = append(roots, s.effectiveLibraryDir(ctx, author), s.libraryDir)
+	}
+	out := roots[:0]
+	for _, r := range roots {
+		if r != "" {
+			out = append(out, filepath.Clean(r))
+		}
+	}
+	return out
+}
+
+// pruneEmptyParents removes now-empty directories starting at dir and walking
+// upward, stopping at (and never removing) any of the given library roots.
+// Best-effort: a non-empty directory (ENOTEMPTY) ends the walk, and any other
+// error is ignored. Mirrors the import move-cleanup contract.
+func pruneEmptyParents(dir string, roots []string) {
+	isRoot := func(p string) bool {
+		for _, r := range roots {
+			if filepath.Clean(p) == r {
+				return true
+			}
+		}
+		return false
+	}
+	underAnyRoot := func(p string) bool {
+		for _, r := range roots {
+			if p == r || strings.HasPrefix(p, r+string(filepath.Separator)) {
+				return true
+			}
+		}
+		return false
+	}
+	cur := filepath.Clean(dir)
+	// Only prune inside the library; never touch a root or anything above it.
+	for underAnyRoot(cur) && !isRoot(cur) {
+		if err := os.Remove(cur); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				// ENOTEMPTY (siblings remain) or any other error: stop walking up.
+				return
+			}
+		}
+		cur = filepath.Dir(cur)
+	}
+}

--- a/internal/importer/reorganize_test.go
+++ b/internal/importer/reorganize_test.go
@@ -1,0 +1,275 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+type reorgEnv struct {
+	s       *Scanner
+	books   *db.BookRepo
+	authors *db.AuthorRepo
+}
+
+func reorgFixture(t *testing.T) (env reorgEnv, libraryDir, audiobookDir string, ctx context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx = context.Background()
+	libraryDir = t.TempDir()
+	audiobookDir = t.TempDir()
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	// Default templates: {Author}/{Title} ({Year})/{Title} - {Author}.{ext}
+	// and {Author}/{Title} ({Year}) for audiobooks.
+	s := NewScanner(db.NewDownloadRepo(database), db.NewDownloadClientRepo(database),
+		books, authors, db.NewHistoryRepo(database), libraryDir, audiobookDir, "", "", "")
+	s.WithSettings(db.NewSettingsRepo(database))
+	s.WithRootFolders(db.NewRootFolderRepo(database))
+	s.WithSeriesRepo(db.NewSeriesRepo(database))
+	return reorgEnv{s: s, books: books, authors: authors}, libraryDir, audiobookDir, ctx
+}
+
+func (env reorgEnv) seedAuthor(t *testing.T, ctx context.Context, authorName string) *models.Author {
+	t.Helper()
+	author := &models.Author{ForeignID: "A-" + authorName, Name: authorName, SortName: authorName, Monitored: true, MetadataProvider: "openlibrary"}
+	if err := env.authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	return author
+}
+
+func (env reorgEnv) seedBook(t *testing.T, ctx context.Context, author *models.Author, title string) *models.Book {
+	t.Helper()
+	rel := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	book := &models.Book{
+		ForeignID: "OL-" + title, AuthorID: author.ID, Title: title, SortTitle: title,
+		Status: models.BookStatusImported, Monitored: true, AnyEditionOK: true,
+		MediaType: models.MediaTypeEbook, MetadataProvider: "openlibrary", ReleaseDate: &rel,
+	}
+	if err := env.books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	return book
+}
+
+func (env reorgEnv) seed(t *testing.T, ctx context.Context, authorName, title string) *models.Book {
+	t.Helper()
+	return env.seedBook(t, ctx, env.seedAuthor(t, ctx, authorName), title)
+}
+
+func writeFileAt(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("book bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReorganize_EbookMove(t *testing.T) {
+	env, libraryDir, _, ctx := reorgFixture(t)
+	book := env.seed(t, ctx, "Jane Doe", "My Book")
+
+	// File sits at a non-templated location.
+	oldPath := filepath.Join(libraryDir, "misc", "downloaded", "randomname.epub")
+	writeFileAt(t, oldPath)
+	if err := env.books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, oldPath); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(libraryDir, "Jane Doe", "My Book (2020)", "My Book - Jane Doe.epub")
+
+	// Preview.
+	moves, err := env.s.PreviewReorganizeBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(moves) != 1 {
+		t.Fatalf("expected 1 move, got %d", len(moves))
+	}
+	if moves[0].Status != ReorgStatusMove {
+		t.Fatalf("status = %q, want move", moves[0].Status)
+	}
+	if moves[0].Proposed != want {
+		t.Fatalf("proposed = %q, want %q", moves[0].Proposed, want)
+	}
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatal("preview must not move the file")
+	}
+
+	// Apply.
+	results := env.s.ApplyReorganize(ctx, []int64{moves[0].FileID})
+	if len(results) != 1 || results[0].Status != ReorgStatusMoved {
+		t.Fatalf("apply result = %+v, want moved", results)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("file not at templated location: %v", err)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("old file should be gone, stat err = %v", err)
+	}
+	// Empty source parents pruned up to (not including) the library root.
+	if _, err := os.Stat(filepath.Join(libraryDir, "misc")); !os.IsNotExist(err) {
+		t.Errorf("empty source parent 'misc' should be pruned")
+	}
+	if _, err := os.Stat(libraryDir); err != nil {
+		t.Errorf("library root must not be pruned")
+	}
+	// Index updated.
+	files, err := env.books.ListBookFiles(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0].Path != want {
+		t.Errorf("book_files path = %v, want %q", files, want)
+	}
+}
+
+func TestReorganize_Noop(t *testing.T) {
+	env, libraryDir, _, ctx := reorgFixture(t)
+	book := env.seed(t, ctx, "Jane Doe", "My Book")
+	// Already at the templated path.
+	p := filepath.Join(libraryDir, "Jane Doe", "My Book (2020)", "My Book - Jane Doe.epub")
+	writeFileAt(t, p)
+	if err := env.books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, p); err != nil {
+		t.Fatal(err)
+	}
+	moves, err := env.s.PreviewReorganizeBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(moves) != 1 || moves[0].Status != ReorgStatusNoop {
+		t.Fatalf("want single noop, got %+v", moves)
+	}
+	// Apply on a noop is a no-op result, file untouched.
+	results := env.s.ApplyReorganize(ctx, []int64{moves[0].FileID})
+	if results[0].Status != ReorgStatusNoop {
+		t.Errorf("apply status = %q, want noop", results[0].Status)
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Errorf("noop must not move the file: %v", err)
+	}
+}
+
+func TestReorganize_Collision(t *testing.T) {
+	env, libraryDir, _, ctx := reorgFixture(t)
+	book := env.seed(t, ctx, "Jane Doe", "My Book")
+
+	oldPath := filepath.Join(libraryDir, "elsewhere", "book.epub")
+	writeFileAt(t, oldPath)
+	if err := env.books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, oldPath); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-occupy the templated destination with an unrelated file.
+	dest := filepath.Join(libraryDir, "Jane Doe", "My Book (2020)", "My Book - Jane Doe.epub")
+	writeFileAt(t, dest)
+
+	moves, err := env.s.PreviewReorganizeBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moves[0].Status != ReorgStatusCollision {
+		t.Fatalf("status = %q, want collision", moves[0].Status)
+	}
+	// Apply must refuse to overwrite.
+	results := env.s.ApplyReorganize(ctx, []int64{moves[0].FileID})
+	if results[0].Status != ReorgStatusCollision {
+		t.Errorf("apply status = %q, want collision (no overwrite)", results[0].Status)
+	}
+	if b, _ := os.ReadFile(oldPath); string(b) != "book bytes" {
+		t.Errorf("source must remain untouched on collision")
+	}
+}
+
+func TestReorganize_Missing(t *testing.T) {
+	env, libraryDir, _, ctx := reorgFixture(t)
+	book := env.seed(t, ctx, "Jane Doe", "My Book")
+	// Registered but not on disk.
+	ghost := filepath.Join(libraryDir, "ghost", "gone.epub")
+	if err := env.books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, ghost); err != nil {
+		t.Fatal(err)
+	}
+	moves, err := env.s.PreviewReorganizeBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moves[0].Status != ReorgStatusMissing {
+		t.Fatalf("status = %q, want missing", moves[0].Status)
+	}
+}
+
+func TestReorganize_AudiobookFolderMove(t *testing.T) {
+	env, _, audiobookDir, ctx := reorgFixture(t)
+	book := env.seed(t, ctx, "Jane Doe", "My Book")
+
+	// Audiobook is a folder holding multiple tracks.
+	oldDir := filepath.Join(audiobookDir, "unsorted", "My Book audio")
+	writeFileAt(t, filepath.Join(oldDir, "part1.mp3"))
+	writeFileAt(t, filepath.Join(oldDir, "part2.mp3"))
+	if err := env.books.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, oldDir); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(audiobookDir, "Jane Doe", "My Book (2020)")
+	moves, err := env.s.PreviewReorganizeBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if moves[0].Status != ReorgStatusMove || moves[0].Proposed != want {
+		t.Fatalf("audiobook preview = %+v, want move to %q", moves[0], want)
+	}
+	results := env.s.ApplyReorganize(ctx, []int64{moves[0].FileID})
+	if results[0].Status != ReorgStatusMoved {
+		t.Fatalf("apply = %+v, want moved", results[0])
+	}
+	for _, part := range []string{"part1.mp3", "part2.mp3"} {
+		if _, err := os.Stat(filepath.Join(want, part)); err != nil {
+			t.Errorf("track %s missing at destination: %v", part, err)
+		}
+	}
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Errorf("old audiobook dir should be gone")
+	}
+}
+
+func TestReorganize_AuthorAndLibraryScope(t *testing.T) {
+	env, libraryDir, _, ctx := reorgFixture(t)
+	author := env.seedAuthor(t, ctx, "Jane Doe")
+	b1 := env.seedBook(t, ctx, author, "Book One")
+	b2 := env.seedBook(t, ctx, author, "Book Two")
+
+	for _, b := range []*models.Book{b1, b2} {
+		p := filepath.Join(libraryDir, "flat", b.Title+".epub")
+		writeFileAt(t, p)
+		if err := env.books.AddBookFile(ctx, b.ID, models.MediaTypeEbook, p); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Author scope covers both env.books.
+	moves, err := env.s.PreviewReorganizeAuthor(ctx, b1.AuthorID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(moves) != 2 {
+		t.Fatalf("author scope: want 2 moves, got %d", len(moves))
+	}
+	// Library scope also covers both.
+	libMoves, err := env.s.PreviewReorganizeLibrary(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(libMoves) != 2 {
+		t.Fatalf("library scope: want 2 moves, got %d", len(libMoves))
+	}
+}

--- a/web/src/api/reorganize.ts
+++ b/web/src/api/reorganize.ts
@@ -1,0 +1,53 @@
+import { request } from './core'
+
+export type ReorganizeStatus =
+  | 'move'
+  | 'noop'
+  | 'collision'
+  | 'missing'
+  | 'error'
+  | 'moved'
+  | 'failed'
+
+export interface ReorganizeMove {
+  bookId: number
+  fileId: number
+  format: string
+  bookTitle: string
+  author: string
+  current: string
+  proposed: string
+  status: ReorganizeStatus
+  message?: string
+}
+
+export interface ReorganizeSummary {
+  total: number
+  toMove: number
+  noop: number
+  collision: number
+  missing: number
+  errored: number
+  moved: number
+  failed: number
+}
+
+export interface ReorganizeResponse {
+  moves: ReorganizeMove[]
+  summary: ReorganizeSummary
+}
+
+export type ReorganizeScope = 'book' | 'author' | 'library'
+
+export const reorganizeApi = {
+  preview: (scope: ReorganizeScope, id?: number) => {
+    const q = new URLSearchParams({ scope })
+    if (id != null) q.set('id', String(id))
+    return request<ReorganizeResponse>(`/reorganize/preview?${q.toString()}`)
+  },
+  apply: (fileIds: number[]) =>
+    request<ReorganizeResponse>('/reorganize/apply', {
+      method: 'POST',
+      body: JSON.stringify({ fileIds }),
+    }),
+}

--- a/web/src/components/RenameFilesModal.test.tsx
+++ b/web/src/components/RenameFilesModal.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import RenameFilesModal from './RenameFilesModal'
+import { reorganizeApi } from '../api/reorganize'
+
+vi.mock('../api/reorganize', () => ({
+  reorganizeApi: {
+    preview: vi.fn(),
+    apply: vi.fn(),
+  },
+}))
+
+const previewMock = vi.mocked(reorganizeApi.preview)
+const applyMock = vi.mocked(reorganizeApi.apply)
+
+const sampleMoves = [
+  {
+    bookId: 1, fileId: 10, format: 'ebook', bookTitle: 'My Book', author: 'Jane Doe',
+    current: '/lib/old/book.epub', proposed: '/lib/Jane Doe/My Book (2020)/My Book - Jane Doe.epub',
+    status: 'move' as const,
+  },
+  {
+    bookId: 1, fileId: 11, format: 'ebook', bookTitle: 'My Book', author: 'Jane Doe',
+    current: '/lib/Jane Doe/ok.epub', proposed: '/lib/Jane Doe/ok.epub', status: 'noop' as const,
+  },
+]
+
+describe('RenameFilesModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the preview and only counts movable files', async () => {
+    previewMock.mockResolvedValue({
+      moves: sampleMoves,
+      summary: { total: 2, toMove: 1, noop: 1, collision: 0, missing: 0, errored: 0, moved: 0, failed: 0 },
+    })
+    render(<RenameFilesModal scope="book" id={1} label="My Book" onClose={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText(/1 of 2 will move/)).toBeInTheDocument())
+    expect(previewMock).toHaveBeenCalledWith('book', 1)
+    // The apply button reflects the single movable file.
+    expect(screen.getByRole('button', { name: /Rename 1 file/ })).toBeInTheDocument()
+  })
+
+  it('applies only movable files and reports the result', async () => {
+    previewMock.mockResolvedValue({
+      moves: sampleMoves,
+      summary: { total: 2, toMove: 1, noop: 1, collision: 0, missing: 0, errored: 0, moved: 0, failed: 0 },
+    })
+    applyMock.mockResolvedValue({
+      moves: [{ ...sampleMoves[0], status: 'moved' }],
+      summary: { total: 1, toMove: 0, noop: 0, collision: 0, missing: 0, errored: 0, moved: 1, failed: 0 },
+    })
+    const onApplied = vi.fn()
+    render(<RenameFilesModal scope="book" id={1} label="My Book" onClose={() => {}} onApplied={onApplied} />)
+
+    await waitFor(() => screen.getByRole('button', { name: /Rename 1 file/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Rename 1 file/ }))
+
+    await waitFor(() => expect(applyMock).toHaveBeenCalledWith([10]))
+    await waitFor(() => expect(screen.getByText(/1 moved, 0 failed/)).toBeInTheDocument())
+    expect(onApplied).toHaveBeenCalled()
+  })
+
+  it('disables apply when there is nothing to move', async () => {
+    previewMock.mockResolvedValue({
+      moves: [sampleMoves[1]],
+      summary: { total: 1, toMove: 0, noop: 1, collision: 0, missing: 0, errored: 0, moved: 0, failed: 0 },
+    })
+    render(<RenameFilesModal scope="library" label="your library" onClose={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText(/0 of 1 will move/)).toBeInTheDocument())
+    expect(previewMock).toHaveBeenCalledWith('library', undefined)
+    expect(screen.queryByRole('button', { name: /Rename 0 files/ })).toBeDisabled()
+  })
+})

--- a/web/src/components/RenameFilesModal.tsx
+++ b/web/src/components/RenameFilesModal.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react'
+import {
+  reorganizeApi,
+  ReorganizeMove,
+  ReorganizeResponse,
+  ReorganizeScope,
+} from '../api/reorganize'
+
+interface Props {
+  scope: ReorganizeScope
+  id?: number
+  // A human label for what is being reorganized ("Dune", "Frank Herbert",
+  // "your library") shown in the modal header.
+  label: string
+  onClose: () => void
+  // Called after an apply that moved at least one file, so the caller can
+  // reload the affected book/author view.
+  onApplied?: () => void
+}
+
+const statusStyles: Record<string, string> = {
+  move: 'text-sky-600 dark:text-sky-400',
+  moved: 'text-emerald-600 dark:text-emerald-400',
+  noop: 'text-slate-400 dark:text-zinc-500',
+  collision: 'text-amber-600 dark:text-amber-400',
+  missing: 'text-amber-600 dark:text-amber-400',
+  error: 'text-red-600 dark:text-red-400',
+  failed: 'text-red-600 dark:text-red-400',
+}
+
+const statusLabel: Record<string, string> = {
+  move: 'Will move',
+  moved: 'Moved',
+  noop: 'Already correct',
+  collision: 'Destination exists',
+  missing: 'Not on disk',
+  error: 'Error',
+  failed: 'Failed',
+}
+
+export default function RenameFilesModal({ scope, id, label, onClose, onApplied }: Props) {
+  const [preview, setPreview] = useState<ReorganizeResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [applying, setApplying] = useState(false)
+  const [applied, setApplied] = useState<ReorganizeResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    reorganizeApi
+      .preview(scope, id)
+      .then(res => {
+        if (!cancelled) setPreview(res)
+      })
+      .catch(err => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Preview failed')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [scope, id])
+
+  const movable = (preview?.moves ?? []).filter(m => m.status === 'move')
+
+  const apply = async () => {
+    if (movable.length === 0) return
+    setApplying(true)
+    setError(null)
+    try {
+      const res = await reorganizeApi.apply(movable.map(m => m.fileId))
+      setApplied(res)
+      if (res.summary.moved > 0) onApplied?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Rename failed')
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  const shown = applied ?? preview
+  const moves = shown?.moves ?? []
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-700 rounded-lg shadow-xl p-6 w-full max-w-2xl mx-4 max-h-[85vh] flex flex-col"
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 className="text-base font-semibold mb-1 text-slate-900 dark:text-white">Rename files</h2>
+        <p className="text-xs text-slate-500 dark:text-zinc-400 mb-4">
+          Move the files for{' '}
+          <span className="font-medium text-slate-700 dark:text-zinc-200">{label}</span> to match the
+          current naming template. Files already in the right place are left alone.
+        </p>
+
+        {loading ? (
+          <p className="text-sm text-slate-500 dark:text-zinc-400">Computing changes…</p>
+        ) : error && !moves.length ? (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        ) : moves.length === 0 ? (
+          <p className="text-sm text-slate-500 dark:text-zinc-400">No tracked files to rename.</p>
+        ) : (
+          <div className="overflow-y-auto flex-1 -mx-2 px-2">
+            <ul className="space-y-3">
+              {moves.map(m => (
+                <MoveRow key={m.fileId} move={m} />
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {error && moves.length > 0 && (
+          <p className="mt-3 text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        <div className="mt-4 pt-4 border-t border-slate-200 dark:border-zinc-800 flex items-center gap-2">
+          <span className="text-xs text-slate-500 dark:text-zinc-400">
+            {applied
+              ? `${applied.summary.moved} moved, ${applied.summary.failed} failed`
+              : `${movable.length} of ${moves.length} will move`}
+          </span>
+          <div className="ml-auto flex gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-1.5 text-sm rounded bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700"
+            >
+              {applied ? 'Close' : 'Cancel'}
+            </button>
+            {!applied && (
+              <button
+                type="button"
+                onClick={apply}
+                disabled={applying || movable.length === 0}
+                className="px-4 py-1.5 text-sm rounded bg-sky-600 hover:bg-sky-500 disabled:opacity-40 font-medium text-white"
+              >
+                {applying ? 'Renaming…' : `Rename ${movable.length} file${movable.length === 1 ? '' : 's'}`}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function MoveRow({ move }: { move: ReorganizeMove }) {
+  return (
+    <li className="text-xs">
+      <div className="flex items-center gap-2 mb-0.5">
+        <span className={`font-medium ${statusStyles[move.status] ?? ''}`}>
+          {statusLabel[move.status] ?? move.status}
+        </span>
+        <span className="text-slate-400 dark:text-zinc-600">·</span>
+        <span className="text-slate-600 dark:text-zinc-300 truncate">{move.bookTitle}</span>
+        <span className="uppercase text-[10px] tracking-wide text-slate-400 dark:text-zinc-600">
+          {move.format}
+        </span>
+      </div>
+      <div className="font-mono text-slate-500 dark:text-zinc-500 break-all">
+        <div className="truncate" title={move.current}>
+          <span className="text-slate-400 dark:text-zinc-600">from </span>
+          {move.current}
+        </div>
+        {move.status !== 'noop' && (
+          <div className="truncate" title={move.proposed}>
+            <span className="text-slate-400 dark:text-zinc-600">to </span>
+            {move.proposed}
+          </div>
+        )}
+        {move.message && (
+          <div className="text-amber-600 dark:text-amber-400 not-italic">{move.message}</div>
+        )}
+      </div>
+    </li>
+  )
+}

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -7,6 +7,7 @@ import { bookStatusBadge } from '../components/bookStatus'
 import MergeAuthorsModal from '../components/MergeAuthorsModal'
 import EditAuthorModal from '../components/EditAuthorModal'
 import AuthorMetadataLinkModal from '../components/AuthorMetadataLinkModal'
+import RenameFilesModal from '../components/RenameFilesModal'
 import BulkActionBar from '../components/BulkActionBar'
 import { useView } from '../components/useView'
 import MarkdownDescription from '../components/MarkdownDescription'
@@ -49,6 +50,7 @@ export default function AuthorDetailPage() {
   const [searchingWanted, setSearchingWanted] = useState(false)
   const [showMerge, setShowMerge] = useState(false)
   const [showEdit, setShowEdit] = useState(false)
+  const [showRename, setShowRename] = useState(false)
   const [showMetadataLink, setShowMetadataLink] = useState(false)
   const [showExcluded, setShowExcluded] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -700,6 +702,13 @@ export default function AuthorDetailPage() {
               Edit
             </button>
             <button
+              onClick={() => setShowRename(true)}
+              className={`${btn.secondary} px-3 py-1.5 text-xs`}
+              title="Move this author’s files to match the current naming template"
+            >
+              Rename files
+            </button>
+            <button
               onClick={() => {
                 if (allAuthors.length === 0) api.listAllAuthors().then(setAllAuthors).catch(console.error)
                 setShowMerge(true)
@@ -749,6 +758,16 @@ export default function AuthorDetailPage() {
           author={author}
           onClose={() => setShowEdit(false)}
           onSaved={updated => setAuthor(updated)}
+        />
+      )}
+
+      {showRename && (
+        <RenameFilesModal
+          scope="author"
+          id={author.id}
+          label={author.authorName}
+          onClose={() => setShowRename(false)}
+          onApplied={() => api.listAllBooks({ authorId, includeExcluded: showExcluded }).then(setBooks).catch(() => {})}
         />
       )}
 

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -6,6 +6,7 @@ import SearchDebugPanel from '../components/SearchDebugPanel'
 import MediaBadge from '../components/MediaBadge'
 import { bookStatusBadge } from '../components/bookStatus'
 import RebindModal from '../components/RebindModal'
+import RenameFilesModal from '../components/RenameFilesModal'
 import ConfirmDialog from '../components/ConfirmDialog'
 import ClipboardManualFallback from '../components/ClipboardManualFallback'
 import { useClipboardCopy } from '../components/useClipboardCopy'
@@ -182,6 +183,7 @@ export default function BookDetailPage() {
   const [togglingExclude, setTogglingExclude] = useState(false)
   const [showRebind, setShowRebind] = useState(false)
   const [showFixMatch, setShowFixMatch] = useState(false)
+  const [showRename, setShowRename] = useState(false)
   const [showEdit, setShowEdit] = useState(false)
   const [showDeleteBook, setShowDeleteBook] = useState(false)
   const pathClipboard = useClipboardCopy()
@@ -661,6 +663,15 @@ export default function BookDetailPage() {
             </button>
             <button
               type="button"
+              onClick={() => setShowRename(true)}
+              disabled={!(book.ebookFilePath || book.audiobookFilePath) || deletingFile || deletingBook}
+              className={actionBtnCls}
+              title={t('bookDetail.renameFiles.hint', 'Move this book’s files to match the current naming template')}
+            >
+              {t('bookDetail.renameFiles.button', 'Rename files')}
+            </button>
+            <button
+              type="button"
               onClick={() => deleteFile(isDual ? fmt : undefined)}
               disabled={deletingFile || deletingBook || !hasActiveFile}
               className={`ml-auto ${dangerBtnCls}`}
@@ -818,6 +829,16 @@ export default function BookDetailPage() {
             setBook(updated)
             setShowRebind(false)
           }}
+        />
+      )}
+
+      {showRename && (
+        <RenameFilesModal
+          scope="book"
+          id={book.id}
+          label={book.title}
+          onClose={() => setShowRename(false)}
+          onApplied={() => api.getBook(bookId).then(setBook).catch(() => {})}
         />
       )}
 


### PR DESCRIPTION
Fixes #1181.

## Problem

The naming template is applied only at import time (`renamer.DestPath` / `AudiobookDestDir`). Once a file is in the library there's no way to re-apply the current template. Users who change their template, import a pre-existing library, or (per the two reports on the issue) end up with a half-renamed mix have no in-place reorganize short of deleting and re-importing every affected book.

## What this does

A **Rename files** action that recomputes each tracked `book_file`'s destination from the current template + the book's metadata and moves it if it differs from where it sits.

- **Preview first.** The preview returns every file's `current → proposed` path and a status, and touches nothing on disk. The user confirms before anything moves.
- **Scopes.** Book, author, and library. The UI wires up per-book (book detail page) and per-author (author page); library scope is available on the API.
- **Reuses the import machinery.** The exact renamer entrypoints the importer uses — `DestPath` for ebooks, `AudiobookDestDir` for audiobook folders — so a reorganized library is byte-for-byte what a fresh import would produce. Moves go through `StagedImport` (ebook files, atomic commit+rollback) and `MoveDirCtx` (audiobook folders).
- **Safety.**
  - Always a **move within the library, never a copy** — a hard-linked file keeps its link, a file is never duplicated.
  - **No overwrite:** if the proposed path already exists it's reported as a `collision` and skipped.
  - Files already at the templated path are `noop`; files not on disk are `missing`; neither is touched.
  - The renamer's existing containment check keeps proposed paths inside the configured root; empty source directories are pruned upward, bounded by the library root.
  - Apply **recomputes the destination server-side** from the file id — it never trusts a client-supplied target — and re-classifies each file at apply time, so a race that turned a move into a collision is caught.
- **Audit trail.** Each move emits the existing `bookRenamed` history event with `from`/`to`/`format`.

## Endpoints (both admin-only)

```
GET  /api/v1/reorganize/preview?scope=book|author|library[&id=N]
POST /api/v1/reorganize/apply   {fileIds:[…]}
```

Mounted behind `auth.RequireAdmin` alongside manual-import — they move files on the server filesystem.

## Out of scope (per the issue)

- Renaming audiobook *tracks* within a folder (that's #1126).
- Auto-rename on template change / metadata refresh. This is an explicit user-triggered action only.
- Full title/author re-verification of file contents.

## Testing

- Backend: `internal/importer/reorganize_test.go` covers ebook move (with index update + empty-parent prune), noop, collision (no overwrite), missing, audiobook folder move, and author/library scope; `internal/api/reorganize_test.go` covers scope validation, summary counts, and the apply wiring.
- Frontend: `RenameFilesModal.test.tsx` covers preview rendering, applying only movable files, and the disabled state when nothing moves.
- Full backend `go test`, `golangci-lint`, `go vet`, `gofmt`; frontend `tsc`, `lint`, `vitest`, `vite build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)