### PR TITLE
fix(importer): mirror import UniqueDir when reorganizing audiobook folders

### DIFF
--- a/internal/importer/reorganize.go
+++ b/internal/importer/reorganize.go
@@ -139,7 +139,8 @@ func (s *Scanner) previewBook(ctx context.Context, book *models.Book) ([]Reorgan
 func (s *Scanner) proposedPathFor(ctx context.Context, book *models.Book, author *models.Author, seriesTitle, seriesNum string, f models.BookFile) (proposed, status, msg string) {
 	var dest string
 	var err error
-	if f.Format == models.MediaTypeAudiobook {
+	audiobook := f.Format == models.MediaTypeAudiobook
+	if audiobook {
 		root := s.effectiveAudiobookDir(ctx, author)
 		dest, err = s.renamer.AudiobookDestDir(root, author, book, seriesTitle, seriesNum)
 	} else {
@@ -148,6 +149,18 @@ func (s *Scanner) proposedPathFor(ctx context.Context, book *models.Book, author
 	}
 	if err != nil {
 		return "", ReorgStatusError, err.Error()
+	}
+
+	// Mirror the import path's uniqueness handling for audiobook folders. Import
+	// runs the templated dir through UniqueDir (scanner.go), so a dual-format
+	// book whose audiobook template resolves to the same "Title (Year)" folder
+	// its ebook already occupies lands at "Title (Year) (2)". Reorganize must
+	// resolve to the same variant — treating this file's OWN current location as
+	// available, so an already-correctly-placed audiobook reads as a noop rather
+	// than a false collision (or an endless (N)→(N+1) churn). Ebooks are single
+	// files and are not uniquified at import, so they skip this.
+	if audiobook {
+		dest = uniqueDirExcluding(dest, f.Path)
 	}
 
 	if filepath.Clean(dest) == filepath.Clean(f.Path) {
@@ -167,7 +180,40 @@ func (s *Scanner) proposedPathFor(ctx context.Context, book *models.Book, author
 	} else if !os.IsNotExist(err) {
 		return dest, ReorgStatusError, err.Error()
 	}
+	// The destination can be free on disk yet already claimed in the index by a
+	// dangling book_files row (a file deleted off disk without clearing its
+	// row). book_files.path is UNIQUE, so moving here would land the file but
+	// then fail the index update, leaving the row pointing at a now-missing
+	// path. Treat an index-level owner as a collision too.
+	if owned, err := s.books.PathOwnedByOtherBook(ctx, dest, book.ID); err != nil {
+		return dest, ReorgStatusError, err.Error()
+	} else if owned {
+		return dest, ReorgStatusCollision, "another book already tracks the destination path"
+	}
 	return dest, ReorgStatusMove, ""
+}
+
+// uniqueDirExcluding mirrors UniqueDir but treats keep as if it were absent, so
+// resolving the destination for a file already parked at a uniquified location
+// returns that same location (a noop) instead of bumping to the next suffix.
+func uniqueDirExcluding(base, keep string) string {
+	keep = filepath.Clean(keep)
+	if filepath.Clean(base) == keep {
+		return base
+	}
+	if _, err := os.Stat(base); os.IsNotExist(err) {
+		return base
+	}
+	for i := 2; i < 1000; i++ {
+		candidate := fmt.Sprintf("%s (%d)", base, i)
+		if filepath.Clean(candidate) == keep {
+			return candidate
+		}
+		if _, err := os.Stat(candidate); os.IsNotExist(err) {
+			return candidate
+		}
+	}
+	return base
 }
 
 // ApplyReorganize moves each of the given tracked files to its templated

--- a/internal/importer/reorganize_test.go
+++ b/internal/importer/reorganize_test.go
@@ -243,6 +243,58 @@ func TestReorganize_AudiobookFolderMove(t *testing.T) {
 	}
 }
 
+// TestReorganize_DualFormatSharedRoot is the regression test for the audiobook
+// UniqueDir mismatch: with BINDERY_AUDIOBOOK_DIR unset (audiobookDir ==
+// libraryDir), a dual-format book's audiobook template resolves to the same
+// "Title (Year)" folder the ebook already sits in. Import parks it at
+// "Title (Year) (2)"; reorganize must read that as a noop, not a false
+// collision, and must not try to move an already-correctly-placed audiobook.
+func TestReorganize_DualFormatSharedRoot(t *testing.T) {
+	// Shared root: audiobookDir == libraryDir.
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	root := t.TempDir()
+	books := db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	s := NewScanner(db.NewDownloadRepo(database), db.NewDownloadClientRepo(database),
+		books, authors, db.NewHistoryRepo(database), root, root, "", "", "")
+	s.WithSettings(db.NewSettingsRepo(database))
+	s.WithRootFolders(db.NewRootFolderRepo(database))
+	s.WithSeriesRepo(db.NewSeriesRepo(database))
+	env := reorgEnv{s: s, books: books, authors: authors}
+
+	book := env.seed(t, ctx, "Jane Doe", "My Book")
+
+	// Ebook already at its templated path: <root>/Jane Doe/My Book (2020)/My Book - Jane Doe.epub
+	ebook := filepath.Join(root, "Jane Doe", "My Book (2020)", "My Book - Jane Doe.epub")
+	writeFileAt(t, ebook)
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, ebook); err != nil {
+		t.Fatal(err)
+	}
+	// Audiobook parked at the uniquified folder <root>/Jane Doe/My Book (2020) (2)
+	// (where import would have placed it, since (2020) is the ebook's folder).
+	audioDir := filepath.Join(root, "Jane Doe", "My Book (2020) (2)")
+	writeFileAt(t, filepath.Join(audioDir, "part1.mp3"))
+	if err := books.AddBookFile(ctx, book.ID, models.MediaTypeAudiobook, audioDir); err != nil {
+		t.Fatal(err)
+	}
+
+	moves, err := s.PreviewReorganizeBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Both files are already correctly placed — no collisions, no moves.
+	for _, m := range moves {
+		if m.Status != ReorgStatusNoop {
+			t.Errorf("%s file %q: status = %q (%s), want noop", m.Format, m.Current, m.Status, m.Message)
+		}
+	}
+}
+
 func TestReorganize_AuthorAndLibraryScope(t *testing.T) {
 	env, libraryDir, _, ctx := reorgFixture(t)
 	author := env.seedAuthor(t, ctx, "Jane Doe")


### PR DESCRIPTION
Follow-up correctness fix for the library reorganize feature (#1181, PR #1596), caught in review before v1.27.0 ships.

## Problem

`proposedPathFor` computed an audiobook's destination from `AudiobookDestDir` **without** the `UniqueDir` suffix the import path applies (`scanner.go` wraps it: `destDir := UniqueDir(audiobookDest)`). With `BINDERY_AUDIOBOOK_DIR` unset — so `audiobookDir == libraryDir`, the default single-root setup — a dual-format book's audiobook template resolves to the *same* `Author/Title (Year)` folder its ebook already occupies. Import handles that by parking the audiobook at `Title (Year) (2)`; reorganize computed the bare `Title (Year)`, saw the ebook's folder there, and reported a permanent **collision** — so the audiobook could never be reorganized, and the preview showed a confusing false positive. Order-dependent within an apply run, too (applying the ebook first created the folder that then tripped the audiobook's check).

No data loss — apply only proceeds on a clean `move` and never overwrites — but the classification was wrong.

## Fix

- Audiobook destinations now resolve through `uniqueDirExcluding`, which mirrors `UniqueDir` but treats the file's **own** current location as available. So an audiobook already correctly parked at `Title (Year) (2)` reads as a **noop**, not a collision, and there's no endless `(N) → (N+1)` churn. Ebooks are single files and aren't uniquified at import, so they're unaffected.
- Also treats an **index-level** owner as a collision: if `book_files` already has a (dangling) row for the destination path but the file is gone from disk, the old code classified it a `move`, moved the file, then failed the `UPDATE` (path column is UNIQUE), leaving the row pointing at a missing path. Now it's a collision up front.

## Testing

`TestReorganize_DualFormatSharedRoot` reproduces the shared-root dual-format case and asserts both files read as noop. Full importer `go test`, `golangci-lint`, `go vet`, `gofmt` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)