### PR TITLE
fix(api): scope wanted/missing list to the caller under tenancy

### DIFF
--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -839,12 +839,18 @@ func sweepMatchesFormat(name, format string) bool {
 }
 
 func (h *BookHandler) ListWanted(w http.ResponseWriter, r *http.Request) {
+	// Scope to the caller's own + unowned books under tenancy (0 = unscoped for
+	// admins / API-key / single-tenant), matching the main book list. Without
+	// this a non-admin's wanted/missing page leaked every user's books (#1220
+	// tenancy: the scoped ListByStatusAndUser existed and was used by OPDS, but
+	// this handler still called the unscoped variant).
+	scope := auth.ListScopeUserID(r.Context())
 	var books []models.Book
 	var err error
 	if r.URL.Query().Get("includeExcluded") == "true" {
-		books, err = h.books.ListByStatusIncludingExcluded(r.Context(), models.BookStatusWanted)
+		books, err = h.books.ListByStatusIncludingExcludedAndUser(r.Context(), models.BookStatusWanted, scope)
 	} else {
-		books, err = h.books.ListByStatus(r.Context(), models.BookStatusWanted)
+		books, err = h.books.ListByStatusAndUser(r.Context(), models.BookStatusWanted, scope)
 	}
 	if err != nil {
 		writeServerError(w, r, err)

--- a/internal/api/list_scope_test.go
+++ b/internal/api/list_scope_test.go
@@ -202,3 +202,48 @@ func TestListScope_TenancyDisabled_Unscoped(t *testing.T) {
 	assertSameSet(t, f.listAuthorNames(t, ctx), []string{"Alice Author", "Bob Author", "Global Author"})
 	assertSameSet(t, f.listBookTitles(t, ctx), []string{"Alice Book", "Bob Book", "Global Book"})
 }
+
+func (f *listScopeFixture) listWantedTitles(t *testing.T, ctx context.Context) []string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/wanted/missing", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+	f.booksH.ListWanted(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("wanted list status %d: %s", rec.Code, rec.Body.String())
+	}
+	var books []models.Book
+	if err := json.Unmarshal(rec.Body.Bytes(), &books); err != nil {
+		t.Fatalf("decode wanted: %v", err)
+	}
+	titles := make([]string, 0, len(books))
+	for _, b := range books {
+		titles = append(titles, b.Title)
+	}
+	return titles
+}
+
+// TestListScope_Wanted_NonAdminIsolated is the security regression: the
+// /wanted/missing endpoint used the unscoped ListByStatus, so a non-admin saw
+// every user's wanted books. It must now scope like the main book list —
+// own + unowned only, never the other user's.
+func TestListScope_Wanted_NonAdminIsolated(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := newListScopeFixture(t)
+	ctx := auth.WithUserRole(auth.WithUserID(context.Background(), f.bob), "user")
+
+	got := f.listWantedTitles(t, ctx)
+	assertSameSet(t, got, []string{"Bob Book", "Global Book"})
+	if slices.Contains(got, "Alice Book") {
+		t.Errorf("ISOLATION LEAK: non-admin bob saw alice's wanted book: %v", got)
+	}
+}
+
+// TestListScope_Wanted_AdminSeesEverything confirms the scoping does not hide
+// other users' wanted books from an admin (scope userID 0 = unscoped).
+func TestListScope_Wanted_AdminSeesEverything(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	f := newListScopeFixture(t)
+	ctx := auth.WithUserRole(auth.WithUserID(context.Background(), f.bob), "admin")
+
+	assertSameSet(t, f.listWantedTitles(t, ctx), []string{"Alice Book", "Bob Book", "Global Book"})
+}

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -347,6 +347,15 @@ func (r *BookRepo) ListByStatusIncludingExcluded(ctx context.Context, status str
 	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE status = ? AND books.monitored = 1 ORDER BY sort_title", []any{status})
 }
 
+// ListByStatusIncludingExcludedAndUser is ListByStatusIncludingExcluded scoped
+// to a user's own + unowned books (userID 0 leaves it unscoped, for admins and
+// single-tenant deployments). The excluded-aware counterpart to
+// ListByStatusAndUser.
+func (r *BookRepo) ListByStatusIncludingExcludedAndUser(ctx context.Context, status string, userID int64) ([]models.Book, error) {
+	where, args := QueryScopeForIncludingNull("books.owner_user_id", "WHERE status = ? AND books.monitored = 1", userID, status)
+	return r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" "+where+" ORDER BY sort_title", args)
+}
+
 func (r *BookRepo) GetByID(ctx context.Context, id int64) (*models.Book, error) {
 	books, err := r.query(ctx, bookCTE+" SELECT "+bookColumns+" FROM books "+bookJoins+" WHERE books.id = ?", []any{id})
 	if err != nil {


### PR DESCRIPTION
## Problem

`ListWanted` (`GET /api/v1/wanted/missing`, in the non-admin `/api/v1` route group) called the **unscoped** `ListByStatus` / `ListByStatusIncludingExcluded`, neither of which filters by `owner_user_id`. Every other book/author browse path scopes through `auth.ListScopeUserID`; this one was missed.

**Impact:** with `BINDERY_ENFORCE_TENANCY` on (multi-user mode), any non-admin user calling `/wanted/missing` received **every** user's wanted/missing books — titles, authors, metadata — not just their own. Read-only, no mutation, but a direct violation of the "user-scoped resources must filter by `owner_user_id`" convention. A scoped `ListByStatusAndUser` already existed (used by OPDS) but the handler didn't call it.

Found in a security sweep of the handler/auth surface.

## Fix

`ListWanted` now resolves `auth.ListScopeUserID(r.Context())` and calls the scoped `ListByStatusAndUser` / new `ListByStatusIncludingExcludedAndUser`. Scope `0` (admins, API-key, single-tenant) stays unscoped, matching the main book list exactly, so nothing changes for non-tenancy deployments.

## Testing

- `TestListScope_Wanted_NonAdminIsolated`: non-admin sees only own + unowned, never the other user's wanted book (the leak reproduction).
- `TestListScope_Wanted_AdminSeesEverything`: admin still sees all (scope 0 unscoped).
- `go test`, `golangci-lint`, `go vet`, `gofmt` green.

## Note

The security sweep also flagged the blocklist (`GET /api/v1/blocklist`, `DELETE /blocklist/{id}`) as not owner-scoped — a non-admin can see and delete other users' entries. But the blocklist's runtime effect is genuinely global (GUID-based, shared across users), so whether `created_by_user_id` should scope reads/deletes is a design call, not a clear bug. Left out of this PR — flagging for a maintainer decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)