### PR TITLE
feat: ebook language detection + strict media-type policy (#1160, #1575)

### DIFF
--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1248,6 +1248,23 @@ func (h *AuthorHandler) resolveDefaultMediaType(ctx context.Context) string {
 	}
 }
 
+// resolveDefaultMediaTypeStrict reports whether the strict media-type policy
+// is enabled (#1575). When on, catalogue books whose media type falls entirely
+// outside default.media_type are skipped at add/refresh time instead of being
+// created as un-grabbable rows, and "both" works are narrowed to the default.
+// Defaults to off so existing installs keep their historical mixed catalogue;
+// a "both" default is unaffected because there is nothing to narrow to.
+func (h *AuthorHandler) resolveDefaultMediaTypeStrict(ctx context.Context) bool {
+	if h.settings == nil {
+		return false
+	}
+	s, _ := h.settings.Get(ctx, SettingDefaultMediaTypeStrict)
+	if s == nil {
+		return false
+	}
+	return s.Value == "true"
+}
+
 // isAutoGrabEnabled reads the autoGrab.enabled setting. Defaults to true when
 // the key is absent so existing installs keep working without any migration.
 func (h *AuthorHandler) isAutoGrabEnabled(ctx context.Context) bool {
@@ -1553,7 +1570,12 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 	searchQueue := make([]models.Book, 0)
 	autoSearchEnabled := autoSearch && h.searcher != nil && author.Monitored && h.isAutoGrabEnabled(ctx)
 
-	var added, skippedLang, skippedJunk int
+	// Strict media-type policy (#1575). When on and the default is a single
+	// format, catalogue population is narrowed to that format so an ebook-only
+	// (or audiobook-only) user never accumulates rows they can't grab.
+	strictMediaType := h.resolveDefaultMediaTypeStrict(ctx)
+
+	var added, skippedLang, skippedJunk, skippedMediaType int
 	for _, b := range books {
 		b.AuthorID = author.ID
 		// Apply the caller-provided default media type when the provider
@@ -1562,6 +1584,27 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 		// through with MediaType=audiobook already.
 		if mediaType != "" && b.MediaType == "" {
 			b.MediaType = mediaType
+		}
+
+		// Strict media-type policy (#1575): when enabled and the default is a
+		// single format, keep the catalogue to that format. A "both" work is
+		// narrowed to the default — its wanted format is still available. A
+		// work that is ONLY the other format has nothing the user asked for,
+		// so it is skipped rather than created as an un-grabbable row. A "both"
+		// default disables the clamp (the user wants everything). Existing rows
+		// are untouched; the Books bulk-edit action migrates those.
+		if strictMediaType && (mediaType == models.MediaTypeEbook || mediaType == models.MediaTypeAudiobook) {
+			switch b.MediaType {
+			case models.MediaTypeBoth:
+				b.MediaType = mediaType
+			case mediaType:
+				// already the wanted single format
+			default:
+				skippedMediaType++
+				slog.Debug("skipping media-type-mismatched book under strict default",
+					"title", b.Title, "bookMediaType", b.MediaType, "default", mediaType)
+				continue
+			}
 		}
 
 		// Filter out OpenLibrary "works" whose title is empty or is just the
@@ -1753,7 +1796,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 		}
 	}
 	runBookSearches(ctx, h.searcher, searchQueue, authorAutoSearchConcurrency)
-	slog.Info("author books synced", "author", author.Name, "added", added, "skipped_language", skippedLang, "skipped_junk", skippedJunk, "total", len(books))
+	slog.Info("author books synced", "author", author.Name, "added", added, "skipped_language", skippedLang, "skipped_junk", skippedJunk, "skipped_media_type", skippedMediaType, "total", len(books))
 }
 
 // reparentMisattachedBook re-links existing to the author being synced when

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -537,6 +537,70 @@ func TestFetchAuthorBooks_AutoSearchUsesBoundedConcurrency(t *testing.T) {
 	}
 }
 
+// TestFetchAuthorBooks_StrictMediaType verifies the #1575 strict policy: with
+// default.media_type=ebook and default.media_type_strict=true, an audiobook-only
+// work is skipped (never created), a "both" work is narrowed to ebook, and an
+// ebook work is created unchanged.
+func TestFetchAuthorBooks_StrictMediaType(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	settingsRepo := db.NewSettingsRepo(database)
+
+	ctx := context.Background()
+	if err := settingsRepo.Set(ctx, SettingDefaultMediaTypeStrict, "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	author := &models.Author{
+		ForeignID: "OL900A", Name: "Strict Author", SortName: "Author, Strict",
+		MetadataProvider: "openlibrary", Monitored: false,
+	}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	works := []models.Book{
+		{ForeignID: "OL901W", Title: "Ebook Only", SortTitle: "ebook only", Language: "eng",
+			MediaType: models.MediaTypeEbook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary"},
+		{ForeignID: "OL902W", Title: "Audio Only", SortTitle: "audio only", Language: "eng",
+			MediaType: models.MediaTypeAudiobook, Status: models.BookStatusWanted, MetadataProvider: "openlibrary"},
+		{ForeignID: "OL903W", Title: "Both Formats", SortTitle: "both formats", Language: "eng",
+			MediaType: models.MediaTypeBoth, Status: models.BookStatusWanted, MetadataProvider: "openlibrary"},
+	}
+	agg := metadata.NewAggregator(&stubMetaProvider{works: works})
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, agg, settingsRepo, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, models.MediaTypeEbook)
+
+	got, err := bookRepo.ListByAuthor(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byTitle := make(map[string]models.Book, len(got))
+	for _, b := range got {
+		byTitle[b.Title] = b
+	}
+	if _, ok := byTitle["Audio Only"]; ok {
+		t.Errorf("audiobook-only work should have been skipped under strict ebook default, but it was created")
+	}
+	if b, ok := byTitle["Ebook Only"]; !ok {
+		t.Errorf("ebook work should have been created")
+	} else if b.MediaType != models.MediaTypeEbook {
+		t.Errorf("ebook work MediaType = %q, want ebook", b.MediaType)
+	}
+	if b, ok := byTitle["Both Formats"]; !ok {
+		t.Errorf("both-format work should have been created (narrowed to ebook)")
+	} else if b.MediaType != models.MediaTypeEbook {
+		t.Errorf("both-format work MediaType = %q, want ebook (narrowed)", b.MediaType)
+	}
+}
+
 // stubLibraryFinder is a mock LibraryFinder that returns a fixed path for
 // a specific title and "" for everything else.
 type stubLibraryFinder struct {

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -27,6 +27,13 @@ import (
 // unset falls back to ebook for backwards compatibility.
 const SettingDefaultMediaType = "default.media_type"
 
+// SettingDefaultMediaTypeStrict is the KV key for the strict media-type policy
+// (#1575). "true" narrows/skips catalogue books that don't match
+// default.media_type at add/refresh time so single-format users stop
+// accumulating un-grabbable rows; any other value (or unset) leaves the
+// historical mixed-catalogue behaviour untouched.
+const SettingDefaultMediaTypeStrict = "default.media_type_strict"
+
 // SettingAuthorDefaultMonitorMode controls which newly discovered books are
 // monitored for authors created without an explicit monitorMode.
 const SettingAuthorDefaultMonitorMode = "author.default_monitor_mode"
@@ -414,6 +421,13 @@ func validateSettingValue(key, value string) error {
 		default:
 			return fmt.Errorf("default.media_type %q is not one of: ebook, audiobook, both", value)
 		}
+	case SettingDefaultMediaTypeStrict:
+		// Boolean flag; empty or "false" = off. Only accept the two canonical
+		// values so a typo can't be misread as truthy.
+		if value == "" || value == "true" || value == "false" {
+			return nil
+		}
+		return fmt.Errorf("default.media_type_strict %q is not one of: true, false", value)
 	case SettingAuthorDefaultMonitorMode:
 		if value == "" {
 			return nil

--- a/internal/db/books.go
+++ b/internal/db/books.go
@@ -703,6 +703,15 @@ func (r *BookRepo) SetFilePath(ctx context.Context, id int64, filePath string) e
 	return r.SetFormatFilePath(ctx, id, mediaType, filePath)
 }
 
+// SetLanguage persists a book's language code. Used by the importer to fill an
+// empty language from an embedded EPUB dc:language at import time (#1160); the
+// caller is responsible for gating on an empty existing value and an unlocked
+// language field, so this only writes the single column.
+func (r *BookRepo) SetLanguage(ctx context.Context, id int64, language string) error {
+	_, err := r.db.ExecContext(ctx, "UPDATE books SET language=? WHERE id=?", language, id)
+	return err
+}
+
 // SetCalibreID stores the Calibre-assigned book id for the given Bindery
 // book row. Called from the importer after a successful `calibredb add`.
 func (r *BookRepo) SetCalibreID(ctx context.Context, id, calibreID int64) error {

--- a/internal/importer/epubmeta.go
+++ b/internal/importer/epubmeta.go
@@ -9,6 +9,8 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/vavallee/bindery/internal/models"
 )
 
 // EpubMetadata is the subset of an EPUB's embedded Dublin Core metadata the
@@ -17,9 +19,10 @@ import (
 // metadata is far more reliable than the release filename, which routinely
 // encodes author/title/series in inconsistent orders (issue #1014).
 type EpubMetadata struct {
-	Title  string
-	Author string
-	ISBN   string // normalised (digits only); ISBN-13 preferred over ISBN-10
+	Title    string
+	Author   string
+	ISBN     string // normalised (digits only); ISBN-13 preferred over ISBN-10
+	Language string // ISO 639-2/B code from dc:language, normalised ("en" → "eng")
 }
 
 // IsEpubFile reports whether path is an EPUB we can read embedded metadata from.
@@ -132,6 +135,13 @@ func parseOPFMetadata(r io.Reader) (EpubMetadata, error) {
 					meta.ISBN = i13
 				} else if i10 != "" && isbn10 == "" {
 					isbn10 = i10
+				}
+			case "language":
+				// First dc:language wins. Normalise to the ISO 639-2/B code the
+				// language filter and metadata profiles use so a value like "en"
+				// or "en-US" matches an "eng" profile (#1160).
+				if meta.Language == "" {
+					meta.Language = models.NormalizeLanguageCode(val)
 				}
 			}
 		case xml.EndElement:

--- a/internal/importer/epubmeta_test.go
+++ b/internal/importer/epubmeta_test.go
@@ -67,6 +67,30 @@ func TestReadEpubMetadata(t *testing.T) {
 	if meta.ISBN != "9780345472199" {
 		t.Errorf("ISBN = %q, want %q", meta.ISBN, "9780345472199")
 	}
+	// dc:language "en" is normalised to the ISO 639-2/B code the filter uses.
+	if meta.Language != "eng" {
+		t.Errorf("Language = %q, want %q", meta.Language, "eng")
+	}
+}
+
+func TestReadEpubMetadata_LanguageRegionSubtag(t *testing.T) {
+	// A region-qualified dc:language ("de-DE") normalises to the bare 639-2/B code.
+	opf := `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Der Schwarm</dc:title>
+    <dc:creator>Frank Schätzing</dc:creator>
+    <dc:language>de-DE</dc:language>
+  </metadata>
+</package>`
+	p := writeTestEpub(t, "content.opf", opf)
+	meta, err := ReadEpubMetadata(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Language != "ger" {
+		t.Errorf("Language = %q, want %q", meta.Language, "ger")
+	}
 }
 
 func TestReadEpubMetadata_PrefersAutCreator(t *testing.T) {

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1085,6 +1085,12 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// library, so move-mode cleanup can delete exactly those files rather than
 	// RemoveAll-ing the whole download path (issue #705 finding 4).
 	var importedSrcFiles []string
+	// detectedLang holds a language read from an embedded EPUB dc:language, used
+	// to backfill an empty book language after the loop (#1160). Captured inside
+	// the loop because move mode consumes the source file on commit, so it must
+	// be read while srcFile still exists.
+	var detectedLang string
+	fillLanguage := book != nil && book.Language == "" && !book.IsFieldLocked(models.BookFieldLanguage)
 	// Resolve the ebook destination root and (auto) placement mode once: the
 	// root is stable for this author across the loop, and choosing hardlink-vs-
 	// copy against it rather than s.libraryDir avoids a cross-device hardlink
@@ -1097,6 +1103,15 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 			parsed := ParseFilename(srcFile)
 			slog.Info("unmatched import", "title", parsed.Title, "author", parsed.Author, "file", srcFile)
 			continue
+		}
+
+		// Read the embedded EPUB language while the source is still present
+		// (move mode deletes it on commit). Only when we actually intend to
+		// backfill, so we never open the zip needlessly.
+		if fillLanguage && detectedLang == "" && IsEpubFile(srcFile) {
+			if meta, err := ReadEpubMetadata(srcFile); err == nil && meta.Language != "" {
+				detectedLang = meta.Language
+			}
 		}
 
 		seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
@@ -1184,6 +1199,20 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		s.pushToGrimmory(ctx, book, destPath)
 
 		s.createHistoryEvent(ctx, models.HistoryEventBookImported, dl.Title, dl.BookID, map[string]string{"path": destPath, "format": models.MediaTypeEbook})
+	}
+
+	// Backfill the book's language from the embedded EPUB dc:language when the
+	// catalogue left it empty (#1160). Providers frequently have no work-level
+	// language (OpenLibrary especially), so an imported file is often the most
+	// reliable source. Best-effort: gated on an empty, unlocked field and at
+	// least one imported file; a persistence error just leaves it empty.
+	if fillLanguage && imported > 0 && detectedLang != "" {
+		if err := s.books.SetLanguage(ctx, book.ID, detectedLang); err != nil {
+			slog.Warn("failed to persist EPUB-detected language", "bookID", book.ID, "language", detectedLang, "error", err)
+		} else {
+			slog.Info("filled book language from embedded EPUB metadata", "bookID", book.ID, "language", detectedLang)
+			book.Language = detectedLang
+		}
 	}
 
 	// If every file failed to copy/move, the destination is likely not writable —

--- a/internal/importer/scanner_language_test.go
+++ b/internal/importer/scanner_language_test.go
@@ -1,0 +1,129 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// writeEpubWithLanguage builds a minimal EPUB with the given dc:language and writes it at
+// dst (so it can live inside a download folder rather than its own temp dir).
+func writeEpubWithLanguage(t *testing.T, dst, language string) {
+	t.Helper()
+	opf := `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Recursion</dc:title>
+    <dc:creator>Blake Crouch</dc:creator>
+    <dc:language>` + language + `</dc:language>
+  </metadata>
+</package>`
+	src := writeTestEpub(t, "content.opf", opf)
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// languageFixture wires an author + ebook book (empty language) + a completed
+// download pointing at it, and returns the scanner, download, book repo and ctx.
+func languageFixture(t *testing.T, libraryDir string, book *models.Book) (*Scanner, *models.Download, *db.BookRepo, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, libraryDir, "", "", "", "")
+
+	author := &models.Author{ForeignID: "OL-lang-test", Name: "Blake Crouch", SortName: "Crouch, Blake"}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book.AuthorID = author.ID
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+	dl := &models.Download{
+		GUID:   "guid-lang-test",
+		Title:  book.Title,
+		BookID: &book.ID,
+		Status: models.StateCompleted,
+		NZBURL: "fake://url",
+	}
+	if err := dlRepo.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	return s, dl, bookRepo, ctx
+}
+
+// TestTryImportInternal_FillsLanguageFromEpub verifies the #1160 import-time
+// backfill: an ebook with an empty catalogue language takes the normalised
+// dc:language ("en" -> "eng") from the imported EPUB.
+func TestTryImportInternal_FillsLanguageFromEpub(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	downloadPath := t.TempDir()
+	writeEpubWithLanguage(t, filepath.Join(downloadPath, "Recursion.epub"), "en")
+
+	book := &models.Book{
+		ForeignID: "OL-lang-book", Title: "Recursion", SortTitle: "recursion",
+		Status: models.BookStatusWanted, MediaType: models.MediaTypeEbook, Language: "",
+	}
+	s, dl, bookRepo, ctx := languageFixture(t, libraryDir, book)
+
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", "", nil, nil)
+
+	got, err := bookRepo.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Language != "eng" {
+		t.Fatalf("book language = %q, want %q (backfilled from EPUB dc:language)", got.Language, "eng")
+	}
+}
+
+// TestTryImportInternal_DoesNotOverwriteLockedLanguage verifies the backfill
+// respects a user-locked language field (#1446): a locked value survives an
+// import whose EPUB reports a different language.
+func TestTryImportInternal_DoesNotOverwriteLockedLanguage(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	downloadPath := t.TempDir()
+	writeEpubWithLanguage(t, filepath.Join(downloadPath, "Recursion.epub"), "de")
+
+	book := &models.Book{
+		ForeignID: "OL-lang-locked", Title: "Recursion", SortTitle: "recursion",
+		Status: models.BookStatusWanted, MediaType: models.MediaTypeEbook,
+		Language:     "eng",
+		LockedFields: []string{models.BookFieldLanguage},
+	}
+	s, dl, bookRepo, ctx := languageFixture(t, libraryDir, book)
+
+	s.tryImportInternal(ctx, dl, downloadPath, "qbittorrent", "abc123", "", nil, nil)
+
+	got, err := bookRepo.GetByID(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Language != "eng" {
+		t.Fatalf("locked language = %q, want %q (must not be overwritten by EPUB de)", got.Language, "eng")
+	}
+}

--- a/internal/models/language.go
+++ b/internal/models/language.go
@@ -33,6 +33,42 @@ func ParseAllowedLanguages(csv string) []string {
 	return out
 }
 
+// iso639TwoLetterToB maps common ISO 639-1 two-letter codes to the ISO 639-2/B
+// three-letter vocabulary Bindery stores in Book.Language and metadata-profile
+// allowed_languages. Deliberately scoped to the languages users actually filter
+// on; anything not listed passes through unchanged so a rarer language still
+// round-trips rather than being silently dropped. Mirrors the indexer's
+// release-tag alias table (internal/indexer/searcher.go).
+var iso639TwoLetterToB = map[string]string{
+	"en": "eng", "fr": "fre", "de": "ger", "nl": "dut", "es": "spa",
+	"it": "ita", "pt": "por", "ja": "jpn", "zh": "chi", "ru": "rus",
+	"sv": "swe", "no": "nor", "da": "dan", "pl": "pol", "cs": "cze",
+	"tr": "tur", "hi": "hin", "ko": "kor", "ar": "ara",
+}
+
+// NormalizeLanguageCode canonicalizes a language code from any source (an EPUB's
+// dc:language, provider metadata) into the lowercased ISO 639-2/B form the
+// language filter compares against. It drops a region/script subtag
+// ("en-US" → "en" → "eng", "zh-Hans" → "chi"), maps known two-letter codes to
+// their three-letter equivalent, and passes anything already three-letter (or
+// unrecognised) through lowercased so it still round-trips. Empty in, empty out.
+func NormalizeLanguageCode(code string) string {
+	code = strings.ToLower(strings.TrimSpace(code))
+	if code == "" {
+		return ""
+	}
+	// Drop a region/script subtag: "en-US", "pt_BR", "zh-Hans".
+	if i := strings.IndexAny(code, "-_"); i > 0 {
+		code = code[:i]
+	}
+	if len(code) == 2 {
+		if b, ok := iso639TwoLetterToB[code]; ok {
+			return b
+		}
+	}
+	return code
+}
+
 // IsLanguageAllowed reports whether code passes the allowed-language filter.
 // When allowed is empty the filter is disabled and everything passes. When
 // code is empty (source didn't report a language — common with OpenLibrary

--- a/internal/models/language_test.go
+++ b/internal/models/language_test.go
@@ -31,6 +31,32 @@ func TestParseAllowedLanguages(t *testing.T) {
 	}
 }
 
+func TestNormalizeLanguageCode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"  ", ""},
+		{"en", "eng"},
+		{"EN", "eng"},
+		{"en-US", "eng"},
+		{"pt_BR", "por"},
+		{"zh-Hans", "chi"},
+		{"de", "ger"},
+		// Already three-letter: passed through lowercased unchanged.
+		{"eng", "eng"},
+		{"GER", "ger"},
+		// Unknown two-letter code round-trips rather than being dropped.
+		{"xx", "xx"},
+	}
+	for _, tc := range cases {
+		if got := NormalizeLanguageCode(tc.in); got != tc.want {
+			t.Errorf("NormalizeLanguageCode(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestIsLanguageAllowed(t *testing.T) {
 	cases := []struct {
 		code        string

--- a/web/src/pages/settings/MetadataTab.tsx
+++ b/web/src/pages/settings/MetadataTab.tsx
@@ -104,6 +104,26 @@ export default function MetadataTab() {
               <option value="audiobook">{t('mediaType.audiobook', 'Audiobook')}</option>
               <option value="both">{t('mediaType.both', 'Both')}</option>
             </select>
+            {(settings['default.media_type'] ?? 'ebook') !== 'both' && (
+              <label className="mt-3 flex items-start gap-2 text-sm text-slate-800 dark:text-zinc-200">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 accent-emerald-500"
+                  checked={(settings['default.media_type_strict'] ?? 'false') === 'true'}
+                  onChange={async e => {
+                    const next = e.target.checked ? 'true' : 'false'
+                    setSettings(s => ({ ...s, 'default.media_type_strict': next }))
+                    await api.setSetting('default.media_type_strict', next).catch(console.error)
+                  }}
+                />
+                <span>
+                  {t('settings.general.strictMediaTypeLabel', 'Restrict new books to this media type')}
+                  <span className="block text-xs text-slate-600 dark:text-zinc-500">
+                    {t('settings.general.strictMediaTypeHint', 'Skip catalogue books available only in the other format, and narrow dual-format books to this one. Prevents monitoring books you can never grab.')}
+                  </span>
+                </span>
+              </label>
+            )}
           </div>
           <div>
             <label className="block text-sm font-medium text-slate-800 dark:text-zinc-200 mb-1">


### PR DESCRIPTION
Catalogue-hygiene features: stop mixed-language and off-format books from silently accumulating.

## What's here
- **#1160 — ebook language detection.** `dc:language` is read from the imported EPUB and a shared `models.NormalizeLanguageCode` canonicalises it (and provider codes) to the ISO 639-2/B vocabulary the metadata-profile language filter uses (`en`/`en-US` → `eng`, `zh-Hans` → `chi`). At import the ebook branch backfills `Book.Language` when the catalogue left it empty — via a narrow `BookRepo.SetLanguage`, gated on an empty and unlocked (#1446) field. The library and the language filter now reflect the real language of imported ebooks. (The optional content-detection sub-task was dropped: it needs a language-model dependency that fights the distroless-minimal image; reading `dc:language` fixes the actual leak.)
- **#1575 — strict media-type policy.** New `default.media_type_strict` setting (off by default). Under a single-format default, a `both` work is narrowed to that format and a work available only in the *other* format is skipped at add/refresh time rather than created as an un-grabbable row (Discussion #1572). Skips are counted into the author-sync summary log so the outcome is visible in the Logs tab without a per-book notification. Surfaced as a checkbox beside Default media type.

## Test
`go build`/`go vet`/`go test` green. Covers the normalizer, the EPUB read (incl. region subtag), the import backfill, the locked-field no-overwrite case, and the strict skip/clamp behaviour.
---

Closes #1575

Refs #1160 — only the first of three sub-tasks ships here (read `dc:language` at import). Content detection was dropped by design (needs a language-model dep, fights the distroless image), and the "editable + filterable on the Books page" sub-task is not built. The backfill also fires at **import** time, so adding an author today still pulls in foreign-language works at add/refresh. #1160 stays open for both.
