### PR TITLE
feat: per-file audiobook renaming + ebook/audiobook drop pair-gating (#1126, #942)

### DIFF
--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -543,7 +543,7 @@ func queueItemSizeLeft(item enrichedQueueItem) int64 {
 	switch item.Download.Status {
 	case models.StateCompleted, models.StateImportPending, models.StateImporting,
 		models.StateImported, models.StateFailed, models.StateImportFailed,
-		models.StateImportBlocked, models.StateImportExternal:
+		models.StateImportBlocked, models.StateImportExternal, models.StateImportHeld:
 		return 0
 	default:
 		return item.Download.Size

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -85,6 +85,14 @@ const SettingSearchInterval = "search.interval"
 // the literal in sync with this constant.
 const SettingImportAudiobookFlattenMultiDisc = "import.audiobook.flatten_multi_disc"
 
+// SettingNamingAudiobookFileTemplate is the per-file audiobook naming template
+// (#1126). Empty (the default) preserves the download's internal layout; a
+// non-empty value flattens every audiobook folder and renames each track from
+// the template, whose {Part} token carries the playback order. The importer
+// reads this key as a string literal to avoid an import cycle; keep the literal
+// in sync with this constant.
+const SettingNamingAudiobookFileTemplate = "naming.audiobook_file_template"
+
 // SettingImportMode is the placement mode for completed downloads. Recognised
 // values are "auto" (empty/unset behaves identically — hardlink when the source
 // and destination share a filesystem, else copy; preserves seeding), "move"
@@ -370,6 +378,16 @@ func validateSettingValue(key, value string) error {
 		}
 		if value != "flat" && value != "templated" {
 			return fmt.Errorf("import.drop_layout %q is not one of: flat, templated", value)
+		}
+	case SettingNamingAudiobookFileTemplate:
+		// Empty disables per-file audiobook renaming (#1126). A non-empty
+		// template MUST carry a {Part} token, otherwise every track flattens to
+		// the same filename and all but the last are dropped.
+		if value == "" {
+			return nil
+		}
+		if !strings.Contains(value, "{Part") {
+			return fmt.Errorf("naming.audiobook_file_template must include a {Part} token so each track gets a unique name")
 		}
 	case SettingImportDropLinkMode:
 		if value == "" {

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -68,6 +68,23 @@ const (
 	// typically deletes what it ingests) or "hardlink" (disk-free same-fs). The
 	// source is never moved, so the download keeps seeding.
 	SettingImportDropLinkMode = "import.drop_link_mode"
+	// SettingImportDropPairGating (#942) opts media_type=both books into
+	// hold-until-paired handoff on the drop path: "true" holds the first-arriving
+	// format (ebook or audiobook) and drops it only once the sibling format is
+	// present too, so a paired-reader tool (Storyteller) ingests both together
+	// instead of wasting a watch-folder cycle on a half-pair. Unset/"false"
+	// (default) keeps the original behaviour — each format drops the moment it
+	// completes. Only affects media_type=both books; single-format books are
+	// never held. The importer reads this key as a string literal to avoid an
+	// import cycle; keep the literal in sync with this constant.
+	SettingImportDropPairGating = "import.drop_pair_gating"
+	// SettingImportDropPairGatingTimeoutHours (#942) is the escape hatch: it
+	// bounds how long a held format waits for its sibling before being dropped
+	// alone and finished. Value is a positive integer number of hours; unset,
+	// empty, non-numeric, or non-positive falls back to 72h. Without it a
+	// never-arriving second format would wedge the first forever. The importer
+	// reads this key as a string literal; keep the literal in sync.
+	SettingImportDropPairGatingTimeoutHours = "import.drop_pair_gating_timeout_hours"
 )
 
 // SettingSearchInterval is the KV key for the wanted-book search cadence.
@@ -395,6 +412,24 @@ func validateSettingValue(key, value string) error {
 		}
 		if value != "copy" && value != "hardlink" {
 			return fmt.Errorf("import.drop_link_mode %q is not one of: copy, hardlink", value)
+		}
+	case SettingImportDropPairGating:
+		// Boolean flag; empty or "false" = off. Only accept the two canonical
+		// values so a typo can't be silently misread as truthy.
+		if value == "" || value == "true" || value == "false" {
+			return nil
+		}
+		return fmt.Errorf("import.drop_pair_gating %q is not one of: true, false", value)
+	case SettingImportDropPairGatingTimeoutHours:
+		// Empty falls back to the 72h default; a non-empty value must be a
+		// positive integer number of hours so a typo fails loudly here rather
+		// than silently reverting to the default at hold time.
+		if value == "" {
+			return nil
+		}
+		n, err := strconv.Atoi(value)
+		if err != nil || n <= 0 {
+			return fmt.Errorf("import.drop_pair_gating_timeout_hours %q must be a positive integer number of hours", value)
 		}
 	case SettingImportMode:
 		// Empty = auto (same as "auto"); a typo must fail loudly here rather

--- a/internal/api/settings_handler_test.go
+++ b/internal/api/settings_handler_test.go
@@ -581,6 +581,59 @@ func TestValidateSettingValue_ImportMode(t *testing.T) {
 	}
 }
 
+// TestValidateSettingValue_AudiobookFileTemplate covers the #1126 per-file
+// audiobook naming template. Empty disables the feature; a non-empty template
+// MUST carry a {Part} token, otherwise every track would flatten to the same
+// filename and all but the last would be dropped.
+func TestValidateSettingValue_AudiobookFileTemplate(t *testing.T) {
+	// Empty = feature off, accepted.
+	if err := validateSettingValue(SettingNamingAudiobookFileTemplate, ""); err != nil {
+		t.Errorf("empty should be accepted (feature off): %v", err)
+	}
+	// Templates carrying a {Part} token, with and without a zero-pad width.
+	for _, v := range []string{
+		"{Title} - Part {Part:3}.{ext}",
+		"{Part}.{ext}",
+		"{Author} - {Title} - {Part:2}.{ext}",
+	} {
+		if err := validateSettingValue(SettingNamingAudiobookFileTemplate, v); err != nil {
+			t.Errorf("%q should be accepted: %v", v, err)
+		}
+	}
+	// No {Part} token: must be rejected at save time rather than collapsing
+	// every track onto one name at import time.
+	for _, v := range []string{"{Title}.{ext}", "track.{ext}", "{Author}/{Title}"} {
+		if err := validateSettingValue(SettingNamingAudiobookFileTemplate, v); err == nil {
+			t.Errorf("%q should be rejected (no {Part} token)", v)
+		}
+	}
+}
+
+// TestValidateSettingValue_DropPairGating covers the #942 pair-gating keys:
+// the boolean opt-in and the positive-integer-hours escape-hatch timeout.
+func TestValidateSettingValue_DropPairGating(t *testing.T) {
+	for _, v := range []string{"", "true", "false"} {
+		if err := validateSettingValue(SettingImportDropPairGating, v); err != nil {
+			t.Errorf("gating %q should be accepted: %v", v, err)
+		}
+	}
+	if err := validateSettingValue(SettingImportDropPairGating, "yes"); err == nil {
+		t.Error("'yes' should be rejected (not a canonical boolean)")
+	}
+
+	for _, v := range []string{"", "1", "72", "168"} {
+		if err := validateSettingValue(SettingImportDropPairGatingTimeoutHours, v); err != nil {
+			t.Errorf("timeout %q should be accepted: %v", v, err)
+		}
+	}
+	// Non-positive / non-numeric must not silently wedge a held format forever.
+	for _, v := range []string{"0", "-5", "soon"} {
+		if err := validateSettingValue(SettingImportDropPairGatingTimeoutHours, v); err == nil {
+			t.Errorf("timeout %q should be rejected", v)
+		}
+	}
+}
+
 func mustJSON(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)

--- a/internal/importer/audiobook_naming_test.go
+++ b/internal/importer/audiobook_naming_test.go
@@ -1,0 +1,103 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+func TestAudiobookFileName(t *testing.T) {
+	r := NewRenamer("")
+	author := &models.Author{Name: "Brandon Sanderson"}
+	book := &models.Book{Title: "The Way of Kings"}
+
+	cases := []struct {
+		name     string
+		template string
+		part     int
+		ext      string
+		want     string
+	}{
+		{"default template pads part", "", 1, "mp3", "The Way of Kings - Part 001.mp3"},
+		{"default template pads part 12", "", 12, "m4b", "The Way of Kings - Part 012.m4b"},
+		{"custom template with author", "{Author} - {Title} - {Part:2}.{ext}", 3, "mp3", "Brandon Sanderson - The Way of Kings - 03.mp3"},
+		{"no pad", "{Title}.{Part}.{ext}", 5, "flac", "The Way of Kings.5.flac"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.AudiobookFileName(tc.template, author, book, "", "", tc.ext, tc.part)
+			if got != tc.want {
+				t.Errorf("AudiobookFileName = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAudiobookFileName_NoSeparatorEscape ensures a template that would inject a
+// path separator collapses to a bare filename (defence against directory escape).
+func TestAudiobookFileName_NoSeparatorEscape(t *testing.T) {
+	r := NewRenamer("")
+	book := &models.Book{Title: "Book"}
+	// {Author} of "../evil" sanitises, and any separator is stripped by Base.
+	got := r.AudiobookFileName("{Author}/{Title} - {Part:3}.{ext}", &models.Author{Name: "../evil"}, book, "", "", "mp3", 1)
+	if filepath.Base(got) != got {
+		t.Errorf("AudiobookFileName produced a path separator: %q", got)
+	}
+}
+
+func TestFlattenAudiobookDirNamed_Ordering(t *testing.T) {
+	src := buildMultiDiscTree(t)
+	dst := filepath.Join(t.TempDir(), "Author", "Book")
+
+	r := NewRenamer("")
+	book := &models.Book{Title: "Recursion"}
+	author := &models.Author{Name: "Blake Crouch"}
+	namer := func(index int, ext string) string {
+		return r.AudiobookFileName("{Title} - Part {Part:3}.{ext}", author, book, "", "", trimDot(ext), index+1)
+	}
+
+	if err := flattenAudiobookDirNamed(context.Background(), "copy", src, dst, namer); err != nil {
+		t.Fatalf("flattenAudiobookDirNamed: %v", err)
+	}
+
+	// Disc 1 tracks come before Disc 2 tracks, numbered contiguously.
+	for i, want := range []string{
+		"Recursion - Part 001.mp3",
+		"Recursion - Part 002.mp3",
+		"Recursion - Part 003.mp3",
+		"Recursion - Part 004.mp3",
+	} {
+		if _, err := os.Stat(filepath.Join(dst, want)); err != nil {
+			t.Errorf("track %d: expected %q to exist: %v", i+1, want, err)
+		}
+	}
+	// The cover sidecar is carried across unrenamed.
+	if _, err := os.Stat(filepath.Join(dst, "cover.jpg")); err != nil {
+		t.Errorf("cover.jpg sidecar not carried across: %v", err)
+	}
+}
+
+// TestFlattenAudiobookDirNamed_DuplicateNameFails guards the {Part}-less template
+// case: a namer that returns the same name for every track must fail loudly
+// rather than silently drop all but the last file.
+func TestFlattenAudiobookDirNamed_DuplicateNameFails(t *testing.T) {
+	src := buildMultiDiscTree(t)
+	dst := filepath.Join(t.TempDir(), "out")
+	namer := func(index int, ext string) string { return "same" + ext } // no {Part}
+	if err := flattenAudiobookDirNamed(context.Background(), "copy", src, dst, namer); err == nil {
+		t.Error("expected a duplicate-name error when the namer omits Part")
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Errorf("failed flatten must not leave a partial destination: %v", err)
+	}
+}
+
+func trimDot(ext string) string {
+	if len(ext) > 0 && ext[0] == '.' {
+		return ext[1:]
+	}
+	return ext
+}

--- a/internal/importer/flatten.go
+++ b/internal/importer/flatten.go
@@ -167,6 +167,18 @@ func isMultiDiscAudiobook(srcRoot string) bool {
 // importer: every destination path is a direct child of destDir (Part NNN has
 // no separators), so book-derived strings cannot escape the library.
 func flattenAudiobookDir(ctx context.Context, mode, srcRoot, destDir string) error {
+	// Default "Part NNN.ext" naming: mirrors the historical multi-disc flatten.
+	return flattenAudiobookDirNamed(ctx, mode, srcRoot, destDir, func(index int, ext string) string {
+		return fmt.Sprintf("Part %03d%s", index+1, ext)
+	})
+}
+
+// flattenAudiobookDirNamed is flattenAudiobookDir with a caller-supplied namer,
+// so both the built-in "Part NNN" multi-disc flatten and the opt-in per-file
+// audiobook naming template (#1126) share one deterministic placement path.
+// nameFor receives the 0-based playback index and the lowercased source
+// extension (with leading dot) and returns the destination basename.
+func flattenAudiobookDirNamed(ctx context.Context, mode, srcRoot, destDir string, nameFor func(index int, ext string) string) error {
 	if mode != "copy" && mode != "hardlink" {
 		return fmt.Errorf("flatten supports copy/hardlink only, got %q", mode)
 	}
@@ -184,7 +196,7 @@ func flattenAudiobookDir(ctx context.Context, mode, srcRoot, destDir string) err
 		return fmt.Errorf("create dest dir: %w", err)
 	}
 
-	// reserved tracks every generated Part filename so a sidecar copy can never
+	// reserved tracks every generated filename so a sidecar copy can never
 	// clobber one, and so a re-run never silently overwrites.
 	reserved := make(map[string]struct{}, len(tracks))
 	for i, tr := range tracks {
@@ -193,7 +205,13 @@ func flattenAudiobookDir(ctx context.Context, mode, srcRoot, destDir string) err
 			return err
 		}
 		ext := strings.ToLower(filepath.Ext(tr.src))
-		name := fmt.Sprintf("Part %03d%s", i+1, ext)
+		name := filepath.Base(nameFor(i, ext))
+		if _, clash := reserved[name]; clash {
+			// A template that omits {Part} would collapse every track to one
+			// name and silently drop all but the last. Fail loudly instead.
+			_ = os.RemoveAll(destDir)
+			return fmt.Errorf("audiobook file template produced a duplicate name %q for %q — include {Part}", name, tr.rel)
+		}
 		reserved[name] = struct{}{}
 		dst := filepath.Join(destDir, name)
 		if err := placeFlattened(ctx, mode, tr.src, dst); err != nil {

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -70,6 +71,12 @@ var groupWordRe = regexp.MustCompile(`(\w+)(:\d{1,2})?`)
 const defaultNamingTemplate = "{Author}/{Title} ({Year})/{Title} - {Author}.{ext}"
 const defaultAudiobookTemplate = "{Author}/{Title} ({Year})"
 
+// defaultAudiobookFileTemplate is the per-file audiobook name used when
+// audiobook file renaming is enabled but no explicit template is set (#1126).
+// {Part} is the 1-based playback-order index; ":3" zero-pads it so an
+// alphabetic sort keeps "Part 002" before "Part 010".
+const defaultAudiobookFileTemplate = "{Title} - Part {Part:3}.{ext}"
+
 // Renamer moves and renames imported book files according to a naming template.
 // Separate templates for ebook (per-file) and audiobook (per-folder) outputs.
 type Renamer struct {
@@ -102,6 +109,24 @@ func (r *Renamer) DestPath(rootFolder string, author *models.Author, book *model
 	ext := strings.TrimPrefix(filepath.Ext(srcPath), ".")
 	dest := filepath.Join(rootFolder, r.apply(r.template, author, book, series, seriesNumber, ext))
 	return ensureContained(dest, rootFolder)
+}
+
+// AudiobookFileName renders the per-file audiobook naming template for one
+// track at 1-based playback position `part`. The result is a single sanitized
+// filename (no path separators) to place directly inside the audiobook
+// destination directory (#1126). An empty template falls back to the default.
+// ext is the source extension WITHOUT a leading dot (the template supplies the
+// dot before {ext}, matching the ebook template convention).
+func (r *Renamer) AudiobookFileName(template string, author *models.Author, book *models.Book, series, seriesNumber, ext string, part int) string {
+	if template == "" {
+		template = defaultAudiobookFileTemplate
+	}
+	name := r.applyWithExtra(template, author, book, series, seriesNumber, ext, map[string]string{
+		"Part": strconv.Itoa(part),
+	})
+	// Defensive: collapse any separator a hand-edited template might introduce
+	// so a track can never escape the destination directory.
+	return filepath.Base(name)
 }
 
 // AudiobookDestDir computes the destination directory into which an audiobook
@@ -142,6 +167,13 @@ func ensureContained(dest, baseDir string) (string, error) {
 }
 
 func (r *Renamer) apply(template string, author *models.Author, book *models.Book, series, seriesNumber, ext string) string {
+	return r.applyWithExtra(template, author, book, series, seriesNumber, ext, nil)
+}
+
+// applyWithExtra is apply with an extra token map merged over the standard
+// book/author tokens. Used by the per-file audiobook namer to inject {Part}
+// (the playback-order index), which has no meaning at the book level.
+func (r *Renamer) applyWithExtra(template string, author *models.Author, book *models.Book, series, seriesNumber, ext string, extra map[string]string) string {
 	year := ""
 	if book.ReleaseDate != nil {
 		year = fmt.Sprintf("%d", book.ReleaseDate.Year())
@@ -161,6 +193,9 @@ func (r *Renamer) apply(template string, author *models.Author, book *models.Boo
 		"Genre":        sanitizePath(firstGenre(book.Genres)),
 		"Lang":         sanitizePath(book.Language),
 		"ext":          ext,
+	}
+	for k, v := range extra {
+		values[k] = v
 	}
 
 	// Render per path segment. A segment that renders empty (e.g. an empty

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -996,19 +996,42 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 				return
 			}
 			if srcInfo.IsDir() {
-				// Multi-disc flattening (#886): when enabled AND the source is
-				// a multi-disc audiobook, place every track flat into destDir
-				// as "Part 001.ext", … instead of mirroring the disc-folder
-				// tree. flattenAudiobookDir itself only places via copy or
-				// hardlink (it renames files, so it never touches the source);
-				// "move" — which since #1542 is what usenet downloads resolve
-				// to — flattens via copy and then removes the source, the same
-				// copy-then-delete contract as MoveDirCtx's slow path. The
-				// source removal is skipped when the import context was
-				// cancelled: sidecar carry is best-effort and swallows
-				// per-file errors, so only an uncancelled nil return proves
-				// the folder was fully placed.
-				if (mode == "copy" || mode == "hardlink" || mode == "move") &&
+				// Per-file audiobook renaming (#1126): when a naming template is
+				// configured, flatten EVERY audiobook folder (single- or
+				// multi-disc) into destDir with each track named from the
+				// template's {Part} order. This supersedes both the verbatim
+				// folder copy and the "Part NNN" multi-disc flatten. Move mode
+				// flattens via copy then removes the source, matching the
+				// multi-disc contract below.
+				if tmpl := s.audiobookFileTemplate(ctx); tmpl != "" &&
+					(mode == "copy" || mode == "hardlink" || mode == "move") {
+					flattenMode := mode
+					if mode == "move" {
+						flattenMode = "copy"
+					}
+					namer := func(index int, ext string) string {
+						return s.renamer.AudiobookFileName(tmpl, author, book, seriesTitle, seriesNum, strings.TrimPrefix(ext, "."), index+1)
+					}
+					slog.Info("renaming audiobook files per template", "src", audiobookSource, "dst", destDir, "mode", flattenMode, "template", tmpl)
+					dirErr = flattenAudiobookDirNamed(importCtx, flattenMode, audiobookSource, destDir, namer)
+					if dirErr == nil && mode == "move" && importCtx.Err() == nil {
+						if rmErr := os.RemoveAll(audiobookSource); rmErr != nil {
+							slog.Warn("could not remove source after move-mode audiobook rename", "src", audiobookSource, "error", rmErr)
+						}
+					}
+				} else if (mode == "copy" || mode == "hardlink" || mode == "move") &&
+					// Multi-disc flattening (#886): when enabled AND the source is
+					// a multi-disc audiobook, place every track flat into destDir
+					// as "Part 001.ext", … instead of mirroring the disc-folder
+					// tree. flattenAudiobookDir itself only places via copy or
+					// hardlink (it renames files, so it never touches the source);
+					// "move" — which since #1542 is what usenet downloads resolve
+					// to — flattens via copy and then removes the source, the same
+					// copy-then-delete contract as MoveDirCtx's slow path. The
+					// source removal is skipped when the import context was
+					// cancelled: sidecar carry is best-effort and swallows
+					// per-file errors, so only an uncancelled nil return proves
+					// the folder was fully placed.
 					s.flattenMultiDiscEnabled(ctx) &&
 					isMultiDiscAudiobook(audiobookSource) {
 					flattenMode := mode

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -760,6 +760,13 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 	// searchWanted skip the book while the hand-off is outstanding, and
 	// ScanLibrary still reconciles the file the moment it lands.
 	if configuredMode == "external" {
+		// Escape hatch for pair gating (#942): before handing off, release any
+		// formats that have been held past the timeout waiting for a sibling
+		// that never arrived. Evaluated here — on every external-mode tick —
+		// rather than on a dedicated scheduled sweep, so held formats drain on
+		// the next drop-folder activity after their deadline. No-op when nothing
+		// is held.
+		s.sweepHeldPairGating(ctx)
 		// When a drop folder is configured (#941), external mode renames the
 		// finished file into that folder (copy/hardlink, never move) for a
 		// sibling tool (CWA, Calibre, Storyteller) to ingest, then still parks

--- a/internal/importer/scanner_handoff.go
+++ b/internal/importer/scanner_handoff.go
@@ -146,6 +146,24 @@ func (s *Scanner) flattenMultiDiscEnabled(ctx context.Context) bool {
 	return setting.Value == "true"
 }
 
+// audiobookFileTemplate reads the "naming.audiobook_file_template" setting
+// (#1126). A non-empty value opts the install into per-file audiobook renaming:
+// every audiobook folder import is flattened into destDir with each track named
+// from this template (its {Part} token carries the playback order). Empty (the
+// default) preserves the download's internal layout. Kept as a string literal
+// to avoid an import cycle with the api package; keep in sync with
+// api.SettingNamingAudiobookFileTemplate.
+func (s *Scanner) audiobookFileTemplate(ctx context.Context) string {
+	if s.settings == nil {
+		return ""
+	}
+	setting, err := s.settings.Get(ctx, "naming.audiobook_file_template")
+	if err != nil || setting == nil {
+		return ""
+	}
+	return strings.TrimSpace(setting.Value)
+}
+
 // pushToCWA copies the just-imported file into the directory watched by a
 // sibling Calibre-Web-Automated container, when the cwa.ingest_path setting
 // is configured. CWA's auto-ingest deletes whatever lands in that folder

--- a/internal/importer/scanner_handoff.go
+++ b/internal/importer/scanner_handoff.go
@@ -285,18 +285,9 @@ func (s *Scanner) dropToFolder(ctx context.Context, dl *models.Download, downloa
 		return true
 	}
 
-	// Resolve book + author for naming (best-effort; nil book is fatal for the
-	// drop path because we can't compute a destination name).
-	var book *models.Book
-	var author *models.Author
-	if dl.BookID != nil {
-		if b, err := s.books.GetByID(ctx, *dl.BookID); err == nil && b != nil {
-			book = b
-			if a, err := s.authors.GetByID(ctx, b.AuthorID); err == nil {
-				author = a
-			}
-		}
-	}
+	// Resolve book + author for naming. A nil book is fatal for the drop path
+	// because we can't compute a destination name.
+	book, author := s.resolveBookAuthor(ctx, dl.BookID)
 	if book == nil {
 		s.failImport(ctx, dl, models.StateImportFailed, "could not match any book to this download — check the release title")
 		return true
@@ -307,59 +298,110 @@ func (s *Scanner) dropToFolder(ctx context.Context, dl *models.Download, downloa
 		detectedFormat = formatHint
 	}
 
+	// Pair gating (#942): a media_type=both book only hands off once BOTH
+	// formats are present, so the drop of this format may be held back until its
+	// sibling arrives. Single-format books, and everything when gating is off,
+	// fall through to the immediate placement below unchanged.
+	if s.dropPairGatingEnabled(ctx) && book.MediaType == models.MediaTypeBoth {
+		return s.dropPairGated(ctx, dl, book, author, downloadPath, bookFiles, explicitFiles, detectedFormat, folder, layout, linkMode)
+	}
+
+	dest, blocked, err := s.placeDroppedFormat(ctx, book, author, downloadPath, bookFiles, explicitFiles, detectedFormat, folder, layout, linkMode)
+	if err != nil {
+		s.failDrop(ctx, dl, blocked, err)
+		return true
+	}
+	s.finishDrop(ctx, dl, layout, linkMode, detectedFormat, dest)
+	return true
+}
+
+// placeDroppedFormat copies/hardlinks one completed format (ebook or audiobook)
+// into the configured drop folder using the flat or templated layout, never
+// moving the source (the download keeps seeding). It returns the destination
+// path recorded in history, a "blocked" flag distinguishing an invalid
+// destination (a template/config error — StateImportBlocked, retryable by the
+// user after fixing settings) from a placement failure (StateImportFailed), and
+// the error. Shared by the immediate drop, the paired release, and the timeout
+// escape hatch so all three place files identically.
+func (s *Scanner) placeDroppedFormat(ctx context.Context, book *models.Book, author *models.Author, downloadPath string, bookFiles, explicitFiles []string, format, folder, layout, linkMode string) (dest string, blocked bool, err error) {
 	importCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
 	defer cancel()
 	seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
 
-	if detectedFormat == models.MediaTypeAudiobook {
-		var dest string
+	if format == models.MediaTypeAudiobook {
 		if layout == "templated" {
-			d, err := s.renamer.AudiobookDestDir(folder, author, book, seriesTitle, seriesNum)
-			if err != nil {
-				s.failImport(ctx, dl, models.StateImportBlocked, fmt.Sprintf("drop folder destination invalid: %v", err))
-				return true
+			d, derr := s.renamer.AudiobookDestDir(folder, author, book, seriesTitle, seriesNum)
+			if derr != nil {
+				return "", true, derr
 			}
 			dest = d
 		} else {
 			dest = filepath.Join(folder, s.renamer.DropAudiobookName(author, book))
 		}
 		dest = UniqueDir(dest)
-		if err := s.dropPlaceAudiobook(importCtx, downloadPath, bookFiles, explicitFiles, dest, linkMode); err != nil {
-			slog.Warn("drop: audiobook handoff failed", "title", dl.Title, "dst", dest, "mode", linkMode, "error", err)
-			s.failImport(ctx, dl, models.StateImportFailed, fmt.Sprintf("drop folder handoff failed: %v", err))
-			return true
+		if perr := s.dropPlaceAudiobook(importCtx, downloadPath, bookFiles, explicitFiles, dest, linkMode); perr != nil {
+			return "", false, perr
 		}
-		s.finishDrop(ctx, dl, layout, linkMode, models.MediaTypeAudiobook, dest)
-		return true
+		return dest, false, nil
 	}
 
 	var placed int
 	var lastErr error
 	for _, srcFile := range bookFiles {
-		var dest string
+		var fileDest string
 		if layout == "templated" {
-			d, err := s.renamer.DestPath(folder, author, book, seriesTitle, seriesNum, srcFile)
-			if err != nil {
-				lastErr = err
+			d, derr := s.renamer.DestPath(folder, author, book, seriesTitle, seriesNum, srcFile)
+			if derr != nil {
+				lastErr = derr
 				continue
 			}
-			dest = d
+			fileDest = d
 		} else {
-			dest = filepath.Join(folder, s.renamer.DropEbookName(author, book, srcFile))
+			fileDest = filepath.Join(folder, s.renamer.DropEbookName(author, book, srcFile))
 		}
-		if err := dropPlaceFile(importCtx, srcFile, dest, linkMode); err != nil {
-			lastErr = err
+		if perr := dropPlaceFile(importCtx, srcFile, fileDest, linkMode); perr != nil {
+			lastErr = perr
 			continue
 		}
 		placed++
 	}
 	if placed == 0 {
-		slog.Warn("drop: ebook handoff placed no files", "title", dl.Title, "error", lastErr)
-		s.failImport(ctx, dl, models.StateImportFailed, fmt.Sprintf("drop folder handoff failed: %v", lastErr))
-		return true
+		if lastErr == nil {
+			lastErr = fmt.Errorf("no book files could be placed")
+		}
+		return "", false, lastErr
 	}
-	s.finishDrop(ctx, dl, layout, linkMode, models.MediaTypeEbook, folder)
-	return true
+	return folder, false, nil
+}
+
+// failDrop marks a drop-path import as failed, distinguishing an invalid
+// destination (StateImportBlocked — the operator must fix the naming template /
+// folder before a retry can succeed) from a transient placement failure
+// (StateImportFailed — retryable as-is).
+func (s *Scanner) failDrop(ctx context.Context, dl *models.Download, blocked bool, err error) {
+	if blocked {
+		s.failImport(ctx, dl, models.StateImportBlocked, fmt.Sprintf("drop folder destination invalid: %v", err))
+		return
+	}
+	slog.Warn("drop: handoff failed", "title", dl.Title, "error", err)
+	s.failImport(ctx, dl, models.StateImportFailed, fmt.Sprintf("drop folder handoff failed: %v", err))
+}
+
+// resolveBookAuthor loads the book (and, best-effort, its author) for a
+// download's BookID. Returns nil book when the download has no BookID or the
+// lookup fails — callers treat that as "unmatched".
+func (s *Scanner) resolveBookAuthor(ctx context.Context, bookID *int64) (*models.Book, *models.Author) {
+	if bookID == nil {
+		return nil, nil
+	}
+	b, err := s.books.GetByID(ctx, *bookID)
+	if err != nil || b == nil {
+		return nil, nil
+	}
+	if a, err := s.authors.GetByID(ctx, b.AuthorID); err == nil {
+		return b, a
+	}
+	return b, nil
 }
 
 // finishDrop parks a successful drop handoff in StateImportExternal and records

--- a/internal/importer/scanner_pair_gating.go
+++ b/internal/importer/scanner_pair_gating.go
@@ -1,0 +1,237 @@
+package importer
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// dropPairGatingDefaultTimeout is the escape-hatch fallback: how long a held
+// format waits for its sibling before being dropped alone. Overridable via the
+// import.drop_pair_gating_timeout_hours setting (#942).
+const dropPairGatingDefaultTimeout = 72 * time.Hour
+
+// dropPairGatingEnabled reports whether the opt-in "hold until both formats
+// present" gate is on for drop-folder handoff (#942). It returns true only when
+// the value is explicitly "true"; the feature is OFF by default so existing
+// drops hand off the moment a format completes. Read as a string literal to
+// avoid an import cycle with the api package; keep in sync with
+// api.SettingImportDropPairGating.
+func (s *Scanner) dropPairGatingEnabled(ctx context.Context) bool {
+	if s.settings == nil {
+		return false
+	}
+	setting, err := s.settings.Get(ctx, "import.drop_pair_gating")
+	if err != nil || setting == nil {
+		return false
+	}
+	return setting.Value == "true"
+}
+
+// dropPairGatingTimeout returns how long a held format waits for its sibling
+// before the escape hatch releases it alone. It reads
+// import.drop_pair_gating_timeout_hours (a positive integer number of hours),
+// falling back to dropPairGatingDefaultTimeout when unset, empty, non-numeric,
+// or non-positive. Read as a string literal; keep in sync with
+// api.SettingImportDropPairGatingTimeoutHours.
+func (s *Scanner) dropPairGatingTimeout(ctx context.Context) time.Duration {
+	if s.settings == nil {
+		return dropPairGatingDefaultTimeout
+	}
+	setting, err := s.settings.Get(ctx, "import.drop_pair_gating_timeout_hours")
+	if err != nil || setting == nil {
+		return dropPairGatingDefaultTimeout
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(setting.Value))
+	if err != nil || n <= 0 {
+		return dropPairGatingDefaultTimeout
+	}
+	return time.Duration(n) * time.Hour
+}
+
+// siblingFormatOnDisk reports whether the given format's file path is already
+// recorded on the book — i.e. that format is present in the library (a mixed
+// config where one format imports normally and the other drops). In the common
+// pure-drop-both case neither path is ever set (the external tool owns the
+// library), so pairing is resolved through the held-download record instead;
+// this covers the mixed case the issue frames as "both present locally".
+func siblingFormatOnDisk(book *models.Book, format string) bool {
+	if book == nil {
+		return false
+	}
+	if format == models.MediaTypeAudiobook {
+		return strings.TrimSpace(book.AudiobookFilePath) != ""
+	}
+	return strings.TrimSpace(book.EbookFilePath) != ""
+}
+
+// dropPairGated implements the hold/release gate for a media_type=both book on
+// the drop path (#942). When the sibling format is not yet present (neither on
+// disk nor already held), this format is parked in StateImportHeld with its
+// files left in place. When the sibling IS present, this format drops now and,
+// if the sibling was held, it is released into the drop folder too so the pair
+// lands together. Returns true — it always takes ownership of the download.
+func (s *Scanner) dropPairGated(ctx context.Context, dl *models.Download, book *models.Book, author *models.Author, downloadPath string, bookFiles, explicitFiles []string, format, folder, layout, linkMode string) bool {
+	siblingFormat := models.MediaTypeAudiobook
+	if format == models.MediaTypeAudiobook {
+		siblingFormat = models.MediaTypeEbook
+	}
+
+	heldSibling := s.findHeldSibling(ctx, book.ID, dl.ID, siblingFormat)
+	if !siblingFormatOnDisk(book, siblingFormat) && heldSibling == nil {
+		// The other format isn't here yet — hold this one until it arrives (or
+		// the timeout escape hatch fires).
+		s.parkHeldFormat(ctx, dl, format, downloadPath)
+		return true
+	}
+
+	// Sibling is present: drop this format now.
+	dest, blocked, err := s.placeDroppedFormat(ctx, book, author, downloadPath, bookFiles, explicitFiles, format, folder, layout, linkMode)
+	if err != nil {
+		s.failDrop(ctx, dl, blocked, err)
+		return true
+	}
+
+	// Release the held sibling alongside it so the pair lands together.
+	if heldSibling != nil {
+		s.releaseHeldSibling(ctx, heldSibling, book, author, siblingFormat, folder, layout, linkMode)
+	}
+
+	s.finishDrop(ctx, dl, layout, linkMode, format, dest)
+	return true
+}
+
+// parkHeldFormat holds a completed format under pair gating: it records the
+// download's on-disk location (so the files can be released later without
+// re-deriving the path) and parks it in StateImportHeld. The source files are
+// left untouched in the download dir — still seeding — until the sibling
+// completes or the timeout drops this format alone.
+func (s *Scanner) parkHeldFormat(ctx context.Context, dl *models.Download, format, downloadPath string) {
+	if err := s.downloads.SetImportPath(ctx, dl.ID, downloadPath); err != nil {
+		slog.Warn("drop: pair gating — failed to record held download path", "title", dl.Title, "path", downloadPath, "error", err)
+	}
+	s.updateDownloadStatus(ctx, dl.ID, models.StateImportHeld)
+	slog.Info("drop: pair gating — holding format until its sibling arrives",
+		"title", dl.Title, "format", format, "path", downloadPath)
+	s.createHistoryEvent(ctx, models.HistoryEventDownloadFolderImport, dl.Title, dl.BookID, map[string]string{
+		"mode":   "drop-hold",
+		"status": string(models.StateImportHeld),
+		"format": format,
+		"path":   downloadPath,
+	})
+}
+
+// findHeldSibling returns a held download for the same book whose format is
+// wantFormat (excluding excludeID). It re-detects each held download's format
+// from the files still at its recorded path, so a held download whose files
+// have since vanished can't be classified and is skipped.
+func (s *Scanner) findHeldSibling(ctx context.Context, bookID, excludeID int64, wantFormat string) *models.Download {
+	if s.downloads == nil {
+		return nil
+	}
+	held, err := s.downloads.ListByStatus(ctx, models.StateImportHeld)
+	if err != nil {
+		slog.Warn("drop: pair gating — failed to list held downloads", "error", err)
+		return nil
+	}
+	for i := range held {
+		h := &held[i]
+		if h.ID == excludeID || h.BookID == nil || *h.BookID != bookID {
+			continue
+		}
+		files := discoverBookFiles(h.ImportPath, nil)
+		if len(files) == 0 {
+			continue
+		}
+		if detectDownloadFormat(files) == wantFormat {
+			return h
+		}
+	}
+	return nil
+}
+
+// releaseHeldSibling drops a previously held format into the drop folder and
+// finishes it, re-discovering its files from the recorded path. Used when the
+// second format of a pair completes.
+func (s *Scanner) releaseHeldSibling(ctx context.Context, held *models.Download, book *models.Book, author *models.Author, format, folder, layout, linkMode string) {
+	files := discoverBookFiles(held.ImportPath, nil)
+	if len(files) == 0 {
+		s.failImport(ctx, held, models.StateImportFailed,
+			"pair gating release: held download files are no longer present — retry the import")
+		return
+	}
+	dest, blocked, err := s.placeDroppedFormat(ctx, book, author, held.ImportPath, files, nil, format, folder, layout, linkMode)
+	if err != nil {
+		s.failDrop(ctx, held, blocked, err)
+		return
+	}
+	slog.Info("drop: pair gating — releasing held format now that its sibling arrived",
+		"title", held.Title, "format", format, "dst", dest)
+	s.finishDrop(ctx, held, layout, linkMode, format, dest)
+}
+
+// sweepHeldPairGating is the escape hatch (#942): it drops any held format whose
+// sibling never arrived within the configured timeout, alone, and finishes the
+// download so it can't wait forever. It is evaluated lazily — invoked on every
+// external-mode import tick from tryImportInternal — rather than on a dedicated
+// scheduled sweep, so a held format is released on the next drop-folder activity
+// after its deadline. The hold-start time is taken from completed_at (stamped
+// when the download completed, moments before it was held), falling back to
+// added_at. The sweep runs regardless of the gating setting so that turning the
+// feature off still drains anything already held.
+func (s *Scanner) sweepHeldPairGating(ctx context.Context) {
+	if s.downloads == nil {
+		return
+	}
+	held, err := s.downloads.ListByStatus(ctx, models.StateImportHeld)
+	if err != nil {
+		slog.Warn("drop: pair gating — failed to list held downloads for timeout sweep", "error", err)
+		return
+	}
+	if len(held) == 0 {
+		return
+	}
+	folder, layout, linkMode := s.dropSettings(ctx)
+	if folder == "" {
+		// No drop folder configured any more — nowhere to release to. Leave the
+		// held rows as-is; a manual retry can recover them.
+		return
+	}
+	timeout := s.dropPairGatingTimeout(ctx)
+	now := time.Now()
+	for i := range held {
+		h := &held[i]
+		start := h.AddedAt
+		if h.CompletedAt != nil {
+			start = *h.CompletedAt
+		}
+		age := now.Sub(start)
+		if age < timeout {
+			continue
+		}
+		book, author := s.resolveBookAuthor(ctx, h.BookID)
+		if book == nil {
+			slog.Warn("drop: pair gating timeout — held download has no matching book, skipping", "title", h.Title)
+			continue
+		}
+		files := discoverBookFiles(h.ImportPath, nil)
+		format := detectDownloadFormat(files)
+		slog.Warn("drop: pair gating timeout — releasing held format alone; its sibling never arrived",
+			"title", h.Title, "format", format, "held_for", age.Truncate(time.Minute).String(), "timeout", timeout.String())
+		if len(files) == 0 {
+			s.failImport(ctx, h, models.StateImportFailed,
+				"pair gating timeout: held download files are no longer present — retry the import")
+			continue
+		}
+		dest, blocked, err := s.placeDroppedFormat(ctx, book, author, h.ImportPath, files, nil, format, folder, layout, linkMode)
+		if err != nil {
+			s.failDrop(ctx, h, blocked, err)
+			continue
+		}
+		s.finishDrop(ctx, h, layout, linkMode, format, dest)
+	}
+}

--- a/internal/importer/scanner_pair_gating_test.go
+++ b/internal/importer/scanner_pair_gating_test.go
@@ -1,0 +1,247 @@
+package importer
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// pairFixture wires a scanner with a media_type=both book for the drop-folder
+// pair-gating tests (#942). It returns the raw *sql.DB too so tests can backdate
+// completed_at to exercise the timeout escape hatch.
+func pairFixture(t *testing.T, mediaType string) (s *Scanner, settings *db.SettingsRepo, downloads *db.DownloadRepo, books *db.BookRepo, database *sql.DB, dropDir string, book *models.Book, ctx context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx = context.Background()
+	settings = db.NewSettingsRepo(database)
+	downloads = db.NewDownloadRepo(database)
+	books = db.NewBookRepo(database)
+	authors := db.NewAuthorRepo(database)
+	libraryDir := t.TempDir()
+	dropDir = t.TempDir()
+
+	author := &models.Author{ForeignID: "OLA1", Name: "Author A", SortName: "A, Author", Monitored: true, MetadataProvider: "openlibrary"}
+	if err := authors.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	book = &models.Book{
+		ForeignID: "OLB1", AuthorID: author.ID, Title: "Title T", SortTitle: "t, title",
+		Status: models.BookStatusWanted, Monitored: true, AnyEditionOK: true,
+		MediaType: mediaType, MetadataProvider: "openlibrary",
+	}
+	if err := books.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	s = NewScanner(
+		downloads, db.NewDownloadClientRepo(database),
+		books, authors, db.NewHistoryRepo(database),
+		libraryDir, "", "", "", "",
+	)
+	s.WithSettings(settings)
+	return s, settings, downloads, books, database, dropDir, book, ctx
+}
+
+// newPairDownload creates a completed download for a book with a format-specific
+// GUID so both formats of a "both" book can coexist.
+func newPairDownload(t *testing.T, downloads *db.DownloadRepo, book *models.Book, format string, ctx context.Context) *models.Download {
+	t.Helper()
+	dl := &models.Download{GUID: "guid-pair-" + format + "-" + book.ForeignID, Title: book.Title, BookID: &book.ID, Status: models.StateCompleted, NZBURL: "fake://url"}
+	if err := downloads.Create(ctx, dl); err != nil {
+		t.Fatal(err)
+	}
+	return dl
+}
+
+// writeEbookDownload creates a download dir with a single epub and returns it.
+func writeEbookDownload(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "book.epub"), []byte("epub bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// writeAudiobookDownload creates a download dir with a single m4b and returns it.
+func writeAudiobookDownload(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "audiobook.m4b"), []byte("m4b bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func setPairSettings(t *testing.T, settings *db.SettingsRepo, ctx context.Context, kv map[string]string) {
+	t.Helper()
+	kv["import.mode"] = "external"
+	for k, v := range kv {
+		if err := settings.Set(ctx, k, v); err != nil {
+			t.Fatalf("set %s: %v", k, err)
+		}
+	}
+}
+
+// (a) Gating OFF: a media_type=both book drops each format immediately, exactly
+// as before — the first format lands in the drop folder and parks external.
+func TestPairGating_Off_DropsImmediately(t *testing.T) {
+	s, settings, downloads, _, _, dropDir, book, ctx := pairFixture(t, models.MediaTypeBoth)
+	setPairSettings(t, settings, ctx, map[string]string{"import.drop_folder": dropDir}) // no pair gating
+
+	ebookDir := writeEbookDownload(t)
+	dl := newPairDownload(t, downloads, book, "ebook", ctx)
+
+	s.tryImportInternal(ctx, dl, ebookDir, "", "", "", nil, nil)
+
+	dst := filepath.Join(dropDir, "Title T - Author A.epub")
+	if _, err := os.Stat(dst); err != nil {
+		t.Fatalf("gating off: ebook should drop immediately, missing at %s: %v", dst, err)
+	}
+	assertStatus(t, downloads, ctx, dl.GUID, models.StateImportExternal)
+}
+
+// (b) Gating ON, first format completes: it is HELD, not dropped, and the
+// download is parked in the non-terminal StateImportHeld with its source intact.
+func TestPairGating_On_FirstFormatHeld(t *testing.T) {
+	s, settings, downloads, _, _, dropDir, book, ctx := pairFixture(t, models.MediaTypeBoth)
+	setPairSettings(t, settings, ctx, map[string]string{
+		"import.drop_folder":      dropDir,
+		"import.drop_pair_gating": "true",
+	})
+
+	ebookDir := writeEbookDownload(t)
+	dl := newPairDownload(t, downloads, book, "ebook", ctx)
+
+	s.tryImportInternal(ctx, dl, ebookDir, "", "", "", nil, nil)
+
+	assertEmptyDir(t, dropDir, "drop dir")
+	if _, err := os.Stat(filepath.Join(ebookDir, "book.epub")); err != nil {
+		t.Errorf("held format source must be left intact: %v", err)
+	}
+	assertStatus(t, downloads, ctx, dl.GUID, models.StateImportHeld)
+
+	// The recorded import path lets a later release find the files.
+	reloaded, err := downloads.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.ImportPath != ebookDir {
+		t.Errorf("held download import_path = %q, want %q", reloaded.ImportPath, ebookDir)
+	}
+}
+
+// (c) Gating ON, second format completes: both formats are released together
+// into the drop folder and both downloads finish.
+func TestPairGating_On_SecondFormatReleasesBoth(t *testing.T) {
+	s, settings, downloads, _, _, dropDir, book, ctx := pairFixture(t, models.MediaTypeBoth)
+	setPairSettings(t, settings, ctx, map[string]string{
+		"import.drop_folder":      dropDir,
+		"import.drop_pair_gating": "true",
+	})
+
+	// First: ebook completes and is held.
+	ebookDir := writeEbookDownload(t)
+	ebookDL := newPairDownload(t, downloads, book, "ebook", ctx)
+	s.tryImportInternal(ctx, ebookDL, ebookDir, "", "", "", nil, nil)
+	assertStatus(t, downloads, ctx, ebookDL.GUID, models.StateImportHeld)
+	assertEmptyDir(t, dropDir, "drop dir before second format")
+
+	// Second: audiobook completes and releases both.
+	audioDir := writeAudiobookDownload(t)
+	audioDL := newPairDownload(t, downloads, book, "audiobook", ctx)
+	s.tryImportInternal(ctx, audioDL, audioDir, "", "", "", nil, nil)
+
+	ebookDst := filepath.Join(dropDir, "Title T - Author A.epub")
+	if _, err := os.Stat(ebookDst); err != nil {
+		t.Errorf("held ebook not released to drop folder at %s: %v", ebookDst, err)
+	}
+	audioDst := filepath.Join(dropDir, "Title T - Author A", "audiobook.m4b")
+	if _, err := os.Stat(audioDst); err != nil {
+		t.Errorf("audiobook not dropped at %s: %v", audioDst, err)
+	}
+	assertStatus(t, downloads, ctx, ebookDL.GUID, models.StateImportExternal)
+	assertStatus(t, downloads, ctx, audioDL.GUID, models.StateImportExternal)
+}
+
+// (d) Single-format book: unaffected by gating — drops immediately even with
+// the gate on (there is nothing to pair).
+func TestPairGating_On_SingleFormatUnaffected(t *testing.T) {
+	s, settings, downloads, _, _, dropDir, book, ctx := pairFixture(t, models.MediaTypeEbook)
+	setPairSettings(t, settings, ctx, map[string]string{
+		"import.drop_folder":      dropDir,
+		"import.drop_pair_gating": "true",
+	})
+
+	ebookDir := writeEbookDownload(t)
+	dl := newPairDownload(t, downloads, book, "ebook", ctx)
+
+	s.tryImportInternal(ctx, dl, ebookDir, "", "", "", nil, nil)
+
+	dst := filepath.Join(dropDir, "Title T - Author A.epub")
+	if _, err := os.Stat(dst); err != nil {
+		t.Fatalf("single-format book must drop immediately, missing at %s: %v", dst, err)
+	}
+	assertStatus(t, downloads, ctx, dl.GUID, models.StateImportExternal)
+}
+
+// (e) Timeout escape hatch: a held format whose sibling never arrives is dropped
+// alone once it ages past the timeout, and the download finishes.
+func TestPairGating_TimeoutReleasesHeldAlone(t *testing.T) {
+	s, settings, downloads, _, database, dropDir, book, ctx := pairFixture(t, models.MediaTypeBoth)
+	setPairSettings(t, settings, ctx, map[string]string{
+		"import.drop_folder":      dropDir,
+		"import.drop_pair_gating": "true",
+	})
+
+	// Hold the ebook.
+	ebookDir := writeEbookDownload(t)
+	dl := newPairDownload(t, downloads, book, "ebook", ctx)
+	s.tryImportInternal(ctx, dl, ebookDir, "", "", "", nil, nil)
+	assertStatus(t, downloads, ctx, dl.GUID, models.StateImportHeld)
+
+	// Backdate the hold-start (completed_at) well past the default 72h timeout.
+	old := time.Now().Add(-100 * time.Hour).UTC()
+	if _, err := database.ExecContext(ctx, "UPDATE downloads SET completed_at=? WHERE id=?", old, dl.ID); err != nil {
+		t.Fatalf("backdate completed_at: %v", err)
+	}
+
+	s.sweepHeldPairGating(ctx)
+
+	dst := filepath.Join(dropDir, "Title T - Author A.epub")
+	if _, err := os.Stat(dst); err != nil {
+		t.Fatalf("timeout: held ebook should be dropped alone, missing at %s: %v", dst, err)
+	}
+	assertStatus(t, downloads, ctx, dl.GUID, models.StateImportExternal)
+}
+
+// A held format that has NOT yet aged out is left held by the sweep.
+func TestPairGating_TimeoutNotReachedKeepsHeld(t *testing.T) {
+	s, settings, downloads, _, _, dropDir, book, ctx := pairFixture(t, models.MediaTypeBoth)
+	setPairSettings(t, settings, ctx, map[string]string{
+		"import.drop_folder":      dropDir,
+		"import.drop_pair_gating": "true",
+	})
+
+	ebookDir := writeEbookDownload(t)
+	dl := newPairDownload(t, downloads, book, "ebook", ctx)
+	s.tryImportInternal(ctx, dl, ebookDir, "", "", "", nil, nil)
+	assertStatus(t, downloads, ctx, dl.GUID, models.StateImportHeld)
+
+	// completed_at is unset and added_at is ~now, so the fallback age is tiny.
+	s.sweepHeldPairGating(ctx)
+
+	assertEmptyDir(t, dropDir, "drop dir")
+	assertStatus(t, downloads, ctx, dl.GUID, models.StateImportHeld)
+}

--- a/internal/models/download_state.go
+++ b/internal/models/download_state.go
@@ -26,6 +26,17 @@ const (
 	// download in this state so the release is not re-grabbed forever while the
 	// hand-off is outstanding (issue #706 finding 3).
 	StateImportExternal DownloadState = "importExternal"
+	// StateImportHeld marks a completed drop-folder download whose format is
+	// being held back under pair gating (#942): a media_type=both book only
+	// hands off to the paired-reader tool (Storyteller) once BOTH the ebook and
+	// audiobook are present, so the first-arriving format parks here — files
+	// untouched in the download dir, its on-disk location recorded in
+	// import_path — until the sibling completes and releases both together, or
+	// the pair-gating timeout drops it alone. Like StateImportExternal it is
+	// deliberately NON-terminal and is NOT swept by RecoverInterruptedImports;
+	// searchWanted skips books with a download in this state so the release is
+	// not re-grabbed while the hold is outstanding.
+	StateImportHeld DownloadState = "importHeld"
 )
 
 // validTransitions defines which state transitions are allowed.
@@ -36,7 +47,7 @@ var validTransitions = map[DownloadState][]DownloadState{
 	StateGrabbed:       {StateDownloading, StateCompleted, StateFailed},
 	StateDownloading:   {StateCompleted, StateFailed},
 	StateCompleted:     {StateImportPending, StateImportFailed},
-	StateImportPending: {StateImporting, StateImportFailed, StateImportExternal},
+	StateImportPending: {StateImporting, StateImportFailed, StateImportExternal, StateImportHeld},
 	StateImporting:     {StateImported, StateImportFailed, StateImportBlocked},
 	StateImported:      {},
 	StateFailed:        {},
@@ -49,6 +60,12 @@ var validTransitions = map[DownloadState][]DownloadState{
 	// retry (which routes through StateImportPending) — there is no automatic
 	// path out, by design: ScanLibrary reconciles the file independently.
 	StateImportExternal: {StateImportPending},
+	// A held format (#942) releases into the external hand-off once its sibling
+	// arrives or the pair-gating timeout fires (StateImportExternal), fails there
+	// if the placement can't complete (StateImportFailed) or the destination is
+	// invalid (StateImportBlocked), or is recovered by a manual retry
+	// (StateImportPending), mirroring StateImportExternal.
+	StateImportHeld: {StateImportExternal, StateImportFailed, StateImportBlocked, StateImportPending},
 }
 
 // CanTransitionTo reports whether a transition from s to next is valid.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -834,6 +834,7 @@ var inFlightDownloadStates = []models.DownloadState{
 	models.StateImportPending,
 	models.StateImporting,
 	models.StateImportExternal, // external hand-off outstanding (issue #706 finding 3)
+	models.StateImportHeld,     // drop-folder format held awaiting its pair (#942)
 }
 
 // wantedSearchQueue returns the Wanted books eligible for an auto-grab this

--- a/web/src/pages/settings/GeneralTab.tsx
+++ b/web/src/pages/settings/GeneralTab.tsx
@@ -308,6 +308,30 @@ export default function GeneralTab({ onNavigate }: GeneralTabProps = {}) {
             onSave={() => saveSetting('naming_template_audiobook')}
             saving={saving === 'naming_template_audiobook'}
           />
+          <div>
+            <label className="block text-xs text-slate-600 dark:text-zinc-400 mb-1">
+              {t('settings.general.audiobookFileTemplate', 'Audiobook file naming (per track)')}
+            </label>
+            <p className="text-xs text-slate-600 dark:text-zinc-500 mb-2">
+              {t('settings.general.audiobookFileTemplateHint', 'Leave empty to keep the download’s original file layout. Set a template to rename every audiobook track in playback order — it must include {Part}.')}
+            </p>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={settings['naming.audiobook_file_template'] ?? ''}
+                onChange={e => setSettings(s => ({ ...s, 'naming.audiobook_file_template': e.target.value }))}
+                placeholder="{Title} - Part {Part:3}.{ext}"
+                className="flex-1 bg-slate-200 dark:bg-zinc-800 border border-slate-300 dark:border-zinc-700 rounded px-3 py-2 text-sm font-mono focus:outline-none focus:border-slate-400 dark:focus:border-zinc-600"
+              />
+              <button
+                onClick={() => saveSetting('naming.audiobook_file_template')}
+                disabled={saving === 'naming.audiobook_file_template'}
+                className="px-3 py-2 rounded text-xs font-medium disabled:opacity-50 bg-emerald-600 hover:bg-emerald-500"
+              >
+                {saving === 'naming.audiobook_file_template' ? t('common.saving') : t('common.save')}
+              </button>
+            </div>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
Two opt-in audiobook import features.

## What's here
- **#1126 — per-file audiobook renaming.** Ebook imports rename per file, but audiobook folders were copied verbatim. New `naming.audiobook_file_template` (empty = off, unchanged) flattens every audiobook folder on import and renames each track in resolved playback order, its `{Part}` token carrying the index. Built on the existing multi-disc flatten: `flattenAudiobookDir` is generalised to `flattenAudiobookDirNamed(namer)`, so the `Part NNN` default and the template share one deterministic collect-tracks ordering and sidecar carry. Works across copy/hardlink/move. A template without `{Part}` is rejected at save and defensively fails the flatten rather than collapsing every track to one name. Field in Settings → General → naming.
- **#942 — ebook+audiobook drop-folder pair-gating** (completes #942; single-format Storyteller drop shipped in #941). New `import.drop_pair_gating` opts `media_type=both` books into hold-until-paired handoff via a non-terminal `StateImportHeld`: the first-arriving format is parked (files left in place, kept out of the re-grab loop) until its sibling completes, then both are dropped together so a paired-reader tool ingests them at once. Escape hatch: `import.drop_pair_gating_timeout_hours` (default 72h), evaluated lazily on drop-folder activity, drops a held format alone if the sibling never arrives.

## Test
`go build`/`go vet`/`go test ./internal/importer/... ./internal/api/... ./internal/scheduler/... ./internal/models/...` green; frontend `tsc` green. New tests cover the naming/ordering/duplicate-name-fail path and the hold/release/timeout/single-format cases.
---

Closes #942

Refs #1126 — only the audiobook **directory** placement path is renamed. The per-file-list path, the single-file path, sidecar renaming, and TS naming-preview parity are not done. #1126 stays open for those.
