### PR TITLE
fix(indexer): normalize author names like release titles so dotted initials match (#1608)

### DIFF
--- a/changelog.d/1608-author-dotted-initials.md
+++ b/changelog.d/1608-author-dotted-initials.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Authors with dotted initials match releases again** (#1608) — a name like "J.R.R. Tolkien" produced an author token ("j.r.r") that can never appear in a normalized release name, so searches for single-keyword titles ("The Hobbit") returned zero results even when indexers found dozens. Author names are now normalized the same way release titles are before tokenizing; hyphenated first names ("Mary-Kate") are fixed by the same change.

--- a/internal/indexer/searcher.go
+++ b/internal/indexer/searcher.go
@@ -295,20 +295,28 @@ func stripPossessivePrefix(title, author string) string {
 }
 
 // authorTokens splits an author name into a (significant, all-lowercased)
-// token list suitable for word-boundary matching. Significant means >=3 chars
-// of letters/digits; shorter tokens (typically initials like "R." or "R")
-// are treated as optional and dropped. German umlauts are transliterated to
-// match NormalizeRelease. Returns nil for empty / all-initials input — the
-// caller should fall back to surname-only behaviour.
+// token list suitable for word-boundary matching. The name is passed through
+// NormalizeRelease first so the tokens live in the same alphabet as the
+// normalized release strings they are matched against: interior punctuation
+// becomes a token boundary exactly as it does on the release side. Previously
+// only edge punctuation was trimmed, so "J.R.R. Tolkien" produced the token
+// "j.r.r" — which can never occur in a NormalizeRelease haystack (dots
+// collapse to spaces there), making every all-tokens author match fail and
+// zeroing out single-keyword-title searches for such authors (#1608).
+// Hyphenated first names ("Mary-Kate") had the same defect.
+//
+// Significant means >=3 chars of letters/digits; shorter tokens (typically
+// initials like "R." or "R") are treated as optional and dropped, so the
+// compact dotted form decomposes exactly like the spaced "J. R. R. Tolkien".
+// German umlauts are transliterated by the normalization. Returns nil for
+// empty / all-initials input — the caller should fall back to surname-only
+// behaviour.
 func authorTokens(author string) []string {
 	if author == "" {
 		return nil
 	}
 	var out []string
-	for _, w := range strings.Fields(strings.ToLower(author)) {
-		w = strings.ReplaceAll(w, "'", "")
-		w = strings.Trim(w, ".,;:()[]")
-		w = transliterateUmlauts(w)
+	for _, w := range strings.Fields(NormalizeRelease(author)) {
 		if len(w) >= 3 {
 			out = append(out, w)
 		}

--- a/internal/indexer/searcher_test.go
+++ b/internal/indexer/searcher_test.go
@@ -1224,17 +1224,77 @@ func TestAuthorMatchesReleaseSingleName(t *testing.T) {
 }
 
 // TestAuthorMatchesReleaseHyphenated covers hyphenated names like
-// "Mary-Kate Olsen" (#563). The hyphen is non-word so the regex \bmary-kate\b
-// matches "mary-kate" in the release, and "olsen" matches separately.
+// "Mary-Kate Olsen" (#563, #1608). The hyphen is a token boundary — the name
+// tokenizes to ["mary", "kate", "olsen"], matching both the hyphenated raw
+// form (the \W+ phrase separator covers "-") and the NormalizeRelease form
+// where the hyphen has collapsed to a space.
 func TestAuthorMatchesReleaseHyphenated(t *testing.T) {
 	toks := authorTokens("Mary-Kate Olsen")
 	if !authorMatchesRelease("mary-kate olsen biography epub", toks) {
 		t.Errorf("hyphenated name should match: tokens=%v", toks)
 	}
-	// Bare "kate" alone is not enough — the monitored author has the hyphenated
-	// first name as one token; partial first-name match doesn't count.
+	// Production haystacks always come out of NormalizeRelease, which turns
+	// the hyphen into a space (#1608): the tokens must match that form too.
+	if !authorMatchesRelease("mary kate olsen biography epub", toks) {
+		t.Errorf("normalized (hyphen→space) release should match: tokens=%v", toks)
+	}
+	// Bare "kate" alone is not enough — every significant token of the name
+	// must appear; partial first-name match doesn't count.
 	if authorMatchesRelease("kate olsen biography epub", toks) {
 		t.Errorf("partial first-name match should be rejected: tokens=%v", toks)
+	}
+}
+
+// TestAuthorTokensDottedInitials covers #1608: compact dotted initials
+// ("J.R.R. Tolkien") must decompose exactly like the spaced form
+// ("J. R. R. Tolkien") — interior punctuation is a token boundary, the
+// initials drop as insignificant, and only ["tolkien"] remains. Previously
+// the first token survived as "j.r.r", which can never occur in a
+// NormalizeRelease haystack (dots collapse to spaces there), so every
+// all-tokens author match failed.
+func TestAuthorTokensDottedInitials(t *testing.T) {
+	cases := []struct {
+		author string
+		want   []string
+	}{
+		{"J.R.R. Tolkien", []string{"tolkien"}},
+		{"J. R. R. Tolkien", []string{"tolkien"}},
+		{"George R.R. Martin", []string{"george", "martin"}},
+		{"Mary-Kate Olsen", []string{"mary", "kate", "olsen"}},
+	}
+	for _, c := range cases {
+		if got := authorTokens(c.author); !equalSlices(got, c.want) {
+			t.Errorf("authorTokens(%q) = %v, want %v", c.author, got, c.want)
+		}
+	}
+}
+
+// TestFilterRelevantDottedInitialsAuthor is the end-to-end regression for
+// #1608: with author "J.R.R. Tolkien" (OpenLibrary's canonical compact form)
+// and the single-significant-word title "The Hobbit", releases naming the
+// author in any punctuation variant must pass the relevance filter. Before
+// the fix the unmatchable "j.r.r" token zeroed out every one of these while
+// multi-word titles escaped via the anchored phrase path — the same author
+// worked for "The Lord of the Rings" but returned nothing for "The Hobbit".
+func TestFilterRelevantDottedInitialsAuthor(t *testing.T) {
+	cases := []struct {
+		release string
+		want    bool // true = kept (relevant), false = dropped
+	}{
+		{"J R R Tolkien - The Hobbit (retail) (azw3)", true},
+		{"The Hobbit - J. R. R. Tolkien", true},
+		{"J.R.R. Tolkien - The Hobbit EPUB", true},
+		// Single-keyword titles still demand the author: a foreign-author
+		// release must not ride in on the loosened tokenization.
+		{"The Hobbit by Jane Doe EPUB", false},
+	}
+	for _, c := range cases {
+		got := filterRelevant([]newznab.SearchResult{{Title: c.release}}, "The Hobbit", "J.R.R. Tolkien", nil)
+		kept := len(got) == 1
+		if kept != c.want {
+			t.Errorf("filterRelevant(%q | title=%q author=%q): kept=%v, want %v",
+				c.release, "The Hobbit", "J.R.R. Tolkien", kept, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #1608.

**Problem** — for any author whose canonical metadata name uses compact dotted initials (OpenLibrary's "J.R.R. Tolkien" being the flagship case), every search for a book whose title reduces to a single significant keyword ("The Hobbit", "The Silmarillion") returns zero results, even when indexers return dozens of correct releases — including one literally titled `The Hobbit - J. R. R. Tolkien`. Multi-word titles escape via the anchored phrase path, which makes the failure look title-specific and maddening to diagnose.

**Root cause** — `authorTokens` only trimmed punctuation from token *edges* (`strings.Trim(w, ".,;:()[]")`), so `"J.R.R. Tolkien"` tokenized to `["j.r.r", "tolkien"]`. `NormalizeRelease` collapses all punctuation to spaces on the release side, so the token `j.r.r` can never occur in any haystack it is matched against; the all-tokens fallback in `authorMatchesRelease` therefore failed for every release, and single-sig-word titles (which hard-require the author) dropped everything. Hyphenated first names ("Mary-Kate" → token `mary-kate`) had the same defect against production (normalized) haystacks.

**Fix** — tokenize the author through `NormalizeRelease` so both sides of the comparison share one alphabet by construction. The #563 initials-dropping behaviour is preserved: `"J.R.R."` now decomposes exactly like the spaced `"J. R. R."` (sub-3-char initials drop, `["tolkien"]` remains). No change to matching semantics beyond the tokenization; umlaut transliteration and apostrophe stripping are inherited from `NormalizeRelease` (which also covers the Unicode `’` the old code missed).

Found while debugging a live deployment (v1.26.2) where every Tolkien single-keyword title auto-search returned empty; the code path is unchanged on current `main`.

## Checklist

- [x] Tests added or updated
- [ ] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed — n/a
- [x] Added a changelog fragment under `changelog.d/` (not an edit to `CHANGELOG.md`)
- [ ] Wiki pages updated if user-facing behaviour changed — n/a (bug fix, no behaviour contract change)

## Test plan

- [x] `go test ./cmd/... ./internal/...` — full suite green
- New `TestAuthorTokensDottedInitials` — compact dotted, spaced, and hyphenated forms produce the expected token sets
- New `TestFilterRelevantDottedInitialsAuthor` — end-to-end regression: author "J.R.R. Tolkien", title "The Hobbit", release `J R R Tolkien - The Hobbit (retail) (azw3)` (and punctuation variants) pass the filter; a wrong-author release (`The Hobbit by Jane Doe EPUB`) is still rejected
- Extended `TestAuthorMatchesReleaseHyphenated` — now also asserts the *normalized* (hyphen→space) haystack matches, which is what production actually feeds the matcher
- Existing behaviour guards stay green: `TestAuthorMatchesReleaseInitials` (#563 initials-dropping), `TestFilterRelevantReorderedKeywordCollisions`, possessive-prefix (#409), umlaut, and iso639 alias tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
