### PR TITLE
fix(importer): prune empty job folder after single-file usenet ebook import

### DIFF
--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -1266,12 +1266,26 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 func (s *Scanner) cleanupMovedSources(downloadPath string, importedSrcFiles []string) {
 	cleanDownloadPath := filepath.Clean(downloadPath)
 
-	// Refuse to prune if downloadPath is empty, relative, the filesystem root, or
+	// pruneRoot is the boundary directory the cleanup is allowed to remove up to
+	// (inclusive). It is normally the download path itself. But a single-file
+	// usenet job resolves downloadPath to the *file*, not its containing folder
+	// (SABnzbd/NZBGet report the storage path of the single file) — and every
+	// guard below is "at or under downloadPath", which a file's parent is not.
+	// The result was the now-empty job folder being left behind after an
+	// otherwise-clean ebook import (cleb's report; audiobooks escaped it because
+	// they move the whole directory via MoveDirCtx). When downloadPath is a
+	// file, prune from its parent folder instead.
+	pruneRoot := cleanDownloadPath
+	if downloadPathIsFile(cleanDownloadPath, importedSrcFiles) {
+		pruneRoot = filepath.Dir(cleanDownloadPath)
+	}
+
+	// Refuse to prune if pruneRoot is empty, relative, the filesystem root, or
 	// equal to / an ancestor of a configured library root. This is a
 	// belt-and-braces guard on top of the os.Remove non-empty-dir protection.
-	if cleanDownloadPath == "" || cleanDownloadPath == "." ||
-		cleanDownloadPath == string(filepath.Separator) ||
-		!filepath.IsAbs(cleanDownloadPath) {
+	if pruneRoot == "" || pruneRoot == "." ||
+		pruneRoot == string(filepath.Separator) ||
+		!filepath.IsAbs(pruneRoot) {
 		slog.Warn("move cleanup: refusing to prune unsafe download path", "path", downloadPath)
 		return
 	}
@@ -1280,33 +1294,33 @@ func (s *Scanner) cleanupMovedSources(downloadPath string, importedSrcFiles []st
 			continue
 		}
 		cleanRoot := filepath.Clean(root)
-		if cleanDownloadPath == cleanRoot || pathUnderDir(cleanRoot, cleanDownloadPath) {
+		if pruneRoot == cleanRoot || pathUnderDir(cleanRoot, pruneRoot) {
 			slog.Warn("move cleanup: download path equals or contains a library root — skipping cleanup",
-				"downloadPath", cleanDownloadPath, "libraryRoot", cleanRoot)
+				"downloadPath", cleanDownloadPath, "pruneRoot", pruneRoot, "libraryRoot", cleanRoot)
 			return
 		}
 	}
 
-	// dirsToPrune collects every directory at or below downloadPath that may now
+	// dirsToPrune collects every directory at or below pruneRoot that may now
 	// be empty, deepest-first so children are removed before parents.
 	prune := make(map[string]bool)
 	for _, src := range importedSrcFiles {
 		cleanSrc := filepath.Clean(src)
-		// Only touch files that actually live under downloadPath — never delete
+		// Only touch files that actually live under pruneRoot — never delete
 		// something outside the download we were asked to import.
-		if cleanSrc != cleanDownloadPath && !pathUnderDir(cleanSrc, cleanDownloadPath) {
+		if cleanSrc != pruneRoot && !pathUnderDir(cleanSrc, pruneRoot) {
 			slog.Warn("move cleanup: imported source outside download path, skipping",
-				"src", cleanSrc, "downloadPath", cleanDownloadPath)
+				"src", cleanSrc, "pruneRoot", pruneRoot)
 			continue
 		}
 		if err := os.Remove(cleanSrc); err != nil && !os.IsNotExist(err) {
 			slog.Warn("move cleanup: failed to remove imported source file", "src", cleanSrc, "error", err)
 		}
 		// Mark every ancestor directory from the file up to (and including)
-		// downloadPath as a pruning candidate.
+		// pruneRoot as a pruning candidate.
 		for dir := filepath.Dir(cleanSrc); ; dir = filepath.Dir(dir) {
 			prune[dir] = true
-			if dir == cleanDownloadPath || !pathUnderDir(dir, cleanDownloadPath) {
+			if dir == pruneRoot || !pathUnderDir(dir, pruneRoot) {
 				break
 			}
 		}
@@ -1322,8 +1336,8 @@ func (s *Scanner) cleanupMovedSources(downloadPath string, importedSrcFiles []st
 	// Deepest paths first: longer cleaned paths sort after shorter ancestors.
 	sort.Slice(dirs, func(i, j int) bool { return len(dirs[i]) > len(dirs[j]) })
 	for _, dir := range dirs {
-		// Never prune above downloadPath.
-		if dir != cleanDownloadPath && !pathUnderDir(dir, cleanDownloadPath) {
+		// Never prune above pruneRoot.
+		if dir != pruneRoot && !pathUnderDir(dir, pruneRoot) {
 			continue
 		}
 		if err := os.Remove(dir); err != nil {
@@ -1337,6 +1351,23 @@ func (s *Scanner) cleanupMovedSources(downloadPath string, importedSrcFiles []st
 		}
 		slog.Debug("move cleanup: pruned empty directory", "dir", dir)
 	}
+}
+
+// downloadPathIsFile reports whether cleanDownloadPath refers to a single file
+// rather than a download folder. It stats the path first; in move mode the file
+// has usually already been renamed away by the time cleanup runs, so it falls
+// back to checking whether the path is exactly one of the imported source files
+// (a folder never appears in importedSrcFiles, only the files inside it do).
+func downloadPathIsFile(cleanDownloadPath string, importedSrcFiles []string) bool {
+	if info, err := os.Stat(cleanDownloadPath); err == nil {
+		return !info.IsDir()
+	}
+	for _, src := range importedSrcFiles {
+		if filepath.Clean(src) == cleanDownloadPath {
+			return true
+		}
+	}
+	return false
 }
 
 func safeRemoteID(id *string) string {

--- a/internal/importer/scanner_usenet_leak_test.go
+++ b/internal/importer/scanner_usenet_leak_test.go
@@ -1,0 +1,135 @@
+package importer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestTryImportInternal_UsenetEbookPrunesJobFolder reproduces cleb's report:
+// a single-file ebook grabbed via SABnzbd (import.mode=hardlink, which #1542
+// remaps to move for usenet) imports cleanly, but the now-empty job folder is
+// left behind under complete/ebooks/. It must be pruned like the audiobook
+// path already does.
+func TestTryImportInternal_UsenetEbookPrunesJobFolder(t *testing.T) {
+	libraryDir := t.TempDir()
+	completeDir := t.TempDir()
+	jobDir := filepath.Join(completeDir, "Natalie Haynes - Stone Blind (epub)")
+	if err := os.MkdirAll(jobDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	epubSrc := filepath.Join(jobDir, "Stone Blind.epub")
+	if err := os.WriteFile(epubSrc, []byte("epub-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// import.mode=hardlink; the SABnzbd client type must remap it to move.
+	s, dl, dlRepo, _, ctx := dataLossFixture(t, libraryDir, "hardlink")
+
+	// cleanupClientType "sabnzbd" is what triggers effectiveConfiguredMode's
+	// usenet remap.
+	s.tryImportInternal(ctx, dl, jobDir, "sabnzbd", "nzo-1", "", nil, nil)
+
+	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StateImported {
+		t.Fatalf("download status = %q, want imported", got.Status)
+	}
+
+	// The empty job folder must be gone.
+	if _, err := os.Stat(jobDir); !os.IsNotExist(err) {
+		t.Errorf("usenet ebook job folder left behind (empty-dir leak): stat err = %v", err)
+	}
+	// The parent complete/ dir must survive (shared category root).
+	if _, err := os.Stat(completeDir); err != nil {
+		t.Errorf("complete dir must not be pruned: %v", err)
+	}
+}
+
+// TestTryImportInternal_UsenetEbookFilePath_PrunesJobFolder covers the case
+// where the completed-job path resolves to the single ebook FILE rather than
+// its containing folder. cleanupMovedSources must still prune the now-empty
+// parent job folder.
+func TestTryImportInternal_UsenetEbookFilePath_PrunesJobFolder(t *testing.T) {
+	libraryDir := t.TempDir()
+	completeDir := t.TempDir()
+	jobDir := filepath.Join(completeDir, "Natalie Haynes - Stone Blind (epub)")
+	if err := os.MkdirAll(jobDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	epubSrc := filepath.Join(jobDir, "Stone Blind.epub")
+	if err := os.WriteFile(epubSrc, []byte("epub-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, dl, dlRepo, _, ctx := dataLossFixture(t, libraryDir, "hardlink")
+
+	// downloadPath is the FILE itself (single-file job), not the job folder.
+	s.tryImportInternal(ctx, dl, epubSrc, "sabnzbd", "nzo-1", "", nil, nil)
+
+	got, err := dlRepo.GetByGUID(ctx, dl.GUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.StateImported {
+		t.Fatalf("download status = %q, want imported", got.Status)
+	}
+	if _, err := os.Stat(jobDir); !os.IsNotExist(err) {
+		t.Errorf("empty job folder left behind when downloadPath is the file: stat err = %v", err)
+	}
+	if _, err := os.Stat(completeDir); err != nil {
+		t.Errorf("complete dir must survive: %v", err)
+	}
+}
+
+// TestCleanupMovedSources_FilePathPrunesParentButKeepsSiblings verifies the
+// single-file-job fix at the unit level: when downloadPath is the file itself,
+// its parent job folder is pruned when empty — but a sibling in that folder
+// (or in the folder above) keeps the relevant directory intact.
+func TestCleanupMovedSources_FilePathPrunesParent(t *testing.T) {
+	s := &Scanner{libraryDir: t.TempDir()}
+	category := t.TempDir() // e.g. complete/ebooks
+	jobDir := filepath.Join(category, "Some Book (epub)")
+	if err := os.MkdirAll(jobDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(jobDir, "book.epub")
+	// Model post-move state: file already moved away.
+
+	// downloadPath is the FILE.
+	s.cleanupMovedSources(file, []string{file})
+
+	if _, err := os.Stat(jobDir); !os.IsNotExist(err) {
+		t.Errorf("empty job folder should be pruned when downloadPath is a file, stat err = %v", err)
+	}
+	// The category dir above the job folder must never be pruned.
+	if _, err := os.Stat(category); err != nil {
+		t.Errorf("category dir above the job folder must survive: %v", err)
+	}
+}
+
+// TestCleanupMovedSources_FilePathKeepsNonEmptyParent ensures the file-path
+// branch still respects the non-empty-directory guard: a job folder holding a
+// leftover sibling (e.g. a .nfo) is kept, never force-removed.
+func TestCleanupMovedSources_FilePathKeepsNonEmptyParent(t *testing.T) {
+	s := &Scanner{libraryDir: t.TempDir()}
+	jobDir := t.TempDir()
+	file := filepath.Join(jobDir, "book.epub")
+	sibling := filepath.Join(jobDir, "extra.nfo")
+	if err := os.WriteFile(sibling, []byte("nfo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s.cleanupMovedSources(file, []string{file})
+
+	if _, err := os.Stat(jobDir); err != nil {
+		t.Errorf("job folder with a leftover sibling must be kept: %v", err)
+	}
+	if _, err := os.Stat(sibling); err != nil {
+		t.Errorf("sibling file must survive: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

Reported on Discord by **cleb** (confirmed on v1.27.0, `import.mode=hardlink`, SABnzbd): a single-file ebook imports cleanly — the `.epub` is moved correctly (mode resolves to `move` per the #1542 usenet remap) — but the now-empty job folder is left behind:

```
complete/ebooks/Natalie Haynes - Stone Blind (epub)/   <- empty dir, survives import
```

A same-shape audiobook grab leaves `complete/audiobooks/` completely clean. cleb's analysis was on the money: the audiobook path `os.Rename`s the whole folder (`MoveDirCtx`), so the source ceases to exist; the ebook loop moves per file and relies on `cleanupMovedSources` to prune the parent — and it wasn't firing for this case.

## Root cause

Usenet clients report the storage path of a **single-file** job as the **file itself**, not a containing folder, so `tryImportInternal`'s `downloadPath` was the `.epub`. `cleanupMovedSources` only prunes directories **at or under `downloadPath`**, and a file's parent folder is not *under* the file — so the job folder was never a valid prune target and its removal guard (`dir != downloadPath && !pathUnderDir(dir, downloadPath)`) skipped it.

This is exactly why the leak was ebook-and-usenet-only:
- **Torrents** pass a folder as `downloadPath` (+ explicit file list) → pruned fine.
- **Audiobooks** move the whole directory via `MoveDirCtx` → source dir gone.
- **Single-file usenet ebooks** → `downloadPath` is the file → parent never pruned.

## Fix

`cleanupMovedSources` now derives a `pruneRoot`: the download path when it's a directory, or its **parent** when `downloadPath` is the imported file itself. File-ness is detected by `stat`, falling back to matching the imported-source set (move mode has already renamed the file away by cleanup time, so `stat` can miss). Every prune guard and the library-root / shared-root safety checks operate on `pruneRoot`, so the empty job folder is removed while the category dir above it — and any folder still holding a leftover sibling — stays protected.

## Tests

- End-to-end: single-file usenet ebook with `downloadPath` = the file → job folder pruned; `complete/` dir survives. (A companion test with `downloadPath` = the folder already passed, confirming the folder case was never broken.)
- Unit: file-path prunes the empty parent but keeps the category dir; file-path with a leftover sibling keeps the non-empty parent (non-empty-dir guard intact).
- Existing `cleanupMovedSources` regression tests (shared-root, library-root, folder prune) still pass; full importer package green.

`gofmt`, `go vet`, `golangci-lint` clean.

Closes cleb's report.