### PR TITLE
feat(indexer): hold ratio-costing releases for approval instead of blocking at the indexer

### DIFF
--- a/internal/db/extra_repos_test.go
+++ b/internal/db/extra_repos_test.go
@@ -1002,3 +1002,66 @@ func TestSettingsRepo_SetMany_RollsBackOnFailure(t *testing.T) {
 		t.Errorf("abs.library_id = %+v, want nil (rollback failed)", got)
 	}
 }
+
+// TestIndexerRepo_FreeleechOnly covers the per-indexer freeleech policy column:
+// it defaults off for existing/new rows, survives a create+update round trip,
+// and can be turned back off.
+func TestIndexerRepo_FreeleechOnly(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	repo := NewIndexerRepo(database)
+
+	idx := &models.Indexer{
+		Name: "Private Tracker", Type: "torznab", URL: "https://example.com/api",
+		APIKey: "k", Categories: []int{7020}, Priority: 1, Enabled: true,
+	}
+	if err := repo.Create(ctx, idx); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := repo.GetByID(ctx, idx.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.FreeleechOnly {
+		t.Error("FreeleechOnly must default to off — the policy is strictly opt-in")
+	}
+
+	// Turn it on.
+	got.FreeleechOnly = true
+	if err := repo.Update(ctx, got); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, err = repo.GetByID(ctx, idx.ID)
+	if err != nil {
+		t.Fatalf("GetByID after enable: %v", err)
+	}
+	if !got.FreeleechOnly {
+		t.Error("FreeleechOnly did not persist through Update")
+	}
+	// And it must come back through List, which the scheduler uses to build
+	// the policy set.
+	all, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 1 || !all[0].FreeleechOnly {
+		t.Errorf("List must carry FreeleechOnly, got %+v", all)
+	}
+
+	// And off again.
+	got.FreeleechOnly = false
+	if err := repo.Update(ctx, got); err != nil {
+		t.Fatalf("Update (disable): %v", err)
+	}
+	got, err = repo.GetByID(ctx, idx.ID)
+	if err != nil {
+		t.Fatalf("GetByID after disable: %v", err)
+	}
+	if got.FreeleechOnly {
+		t.Error("FreeleechOnly did not clear through Update")
+	}
+}

--- a/internal/db/indexers.go
+++ b/internal/db/indexers.go
@@ -21,7 +21,7 @@ func NewIndexerRepo(db *sql.DB) *IndexerRepo {
 func (r *IndexerRepo) List(ctx context.Context) ([]models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
-		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at
+		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, freeleech_only, created_at, updated_at
 		FROM indexers ORDER BY priority`)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func (r *IndexerRepo) List(ctx context.Context) ([]models.Indexer, error) {
 func (r *IndexerRepo) GetByID(ctx context.Context, id int64) (*models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
-		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at
+		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, freeleech_only, created_at, updated_at
 		FROM indexers WHERE id=?`, id)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (r *IndexerRepo) GetByID(ctx context.Context, id int64) (*models.Indexer, e
 func (r *IndexerRepo) ListByProwlarrInstance(ctx context.Context, instanceID int64) ([]models.Indexer, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, name, type, url, api_key, categories, priority, enabled, supports_search,
-		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at
+		       prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, freeleech_only, created_at, updated_at
 		FROM indexers WHERE prowlarr_instance_id=?`, instanceID)
 	if err != nil {
 		return nil, err
@@ -87,11 +87,11 @@ func (r *IndexerRepo) Create(ctx context.Context, idx *models.Indexer) error {
 	}
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO indexers (name, type, url, api_key, categories, priority, enabled, supports_search,
-		                      prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		                      prowlarr_instance_id, prowlarr_indexer_id, seed_ratio, seed_ratio_source, freeleech_only, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		idx.Name, idx.Type, idx.URL, idx.APIKey, string(catsJSON),
 		idx.Priority, idx.Enabled, idx.SupportsSearch,
-		idx.ProwlarrInstanceID, idx.ProwlarrIndexerID, idx.SeedRatio, idx.SeedRatioSource, now, now)
+		idx.ProwlarrInstanceID, idx.ProwlarrIndexerID, idx.SeedRatio, idx.SeedRatioSource, idx.FreeleechOnly, now, now)
 	if err != nil {
 		return fmt.Errorf("create indexer: %w", err)
 	}
@@ -113,10 +113,10 @@ func (r *IndexerRepo) Update(ctx context.Context, idx *models.Indexer) error {
 	}
 	_, err = r.db.ExecContext(ctx, `
 		UPDATE indexers SET name=?, type=?, url=?, api_key=?, categories=?, priority=?,
-		                    enabled=?, supports_search=?, seed_ratio=?, seed_ratio_source=?, updated_at=?
+		                    enabled=?, supports_search=?, seed_ratio=?, seed_ratio_source=?, freeleech_only=?, updated_at=?
 		WHERE id=?`,
 		idx.Name, idx.Type, idx.URL, idx.APIKey, string(catsJSON),
-		idx.Priority, idx.Enabled, idx.SupportsSearch, idx.SeedRatio, idx.SeedRatioSource, now, idx.ID)
+		idx.Priority, idx.Enabled, idx.SupportsSearch, idx.SeedRatio, idx.SeedRatioSource, idx.FreeleechOnly, now, idx.ID)
 	return err
 }
 
@@ -152,18 +152,19 @@ type indexerScanner interface {
 
 func scanIndexer(s indexerScanner) (models.Indexer, error) {
 	var idx models.Indexer
-	var enabled, supportsSearch int
+	var enabled, supportsSearch, freeleechOnly int
 	var catsJSON string
 	if err := s.Scan(
 		&idx.ID, &idx.Name, &idx.Type, &idx.URL, &idx.APIKey,
 		&catsJSON, &idx.Priority, &enabled, &supportsSearch,
-		&idx.ProwlarrInstanceID, &idx.ProwlarrIndexerID, &idx.SeedRatio, &idx.SeedRatioSource,
+		&idx.ProwlarrInstanceID, &idx.ProwlarrIndexerID, &idx.SeedRatio, &idx.SeedRatioSource, &freeleechOnly,
 		&idx.CreatedAt, &idx.UpdatedAt,
 	); err != nil {
 		return idx, err
 	}
 	idx.Enabled = enabled == 1
 	idx.SupportsSearch = supportsSearch == 1
+	idx.FreeleechOnly = freeleechOnly == 1
 	if err := json.Unmarshal([]byte(catsJSON), &idx.Categories); err != nil {
 		return idx, fmt.Errorf("unmarshal indexer categories: %w", err)
 	}

--- a/internal/db/migrations/066_indexer_freeleech_only.sql
+++ b/internal/db/migrations/066_indexer_freeleech_only.sql
@@ -1,0 +1,23 @@
+-- +migrate Up
+-- Per-indexer "only auto-grab freeleech releases" policy (cleb's request).
+-- Private-tracker users close to a ratio floor could previously only stay safe
+-- by restricting the indexer itself to Freeleech/VIP in Jackett — which also
+-- hid normal releases from interactive single-book search, where the user is
+-- happy to pay the ratio cost on a book they actually care about.
+--
+-- Gating at the release level instead: when enabled, the scheduler's automatic
+-- grab path only auto-grabs releases this indexer reports as freeleech
+-- (torznab downloadvolumefactor == 0). Anything that would cost ratio is held
+-- in pending_releases for manual approval rather than hidden or grabbed blind,
+-- which also covers bulk/multi-book search (no picker, pure fire-and-forget).
+-- Interactive search builds its own specification set and is unaffected.
+--
+-- 0 = off (the prior behaviour, and what every existing row gets). Mirrors the
+-- per-indexer seed_ratio override (#883, migration 053) in shape and intent:
+-- tracker economics are per-tracker, so this must not be a global switch that
+-- also throttles public trackers and usenet where ratio is meaningless.
+ALTER TABLE indexers ADD COLUMN freeleech_only INTEGER NOT NULL DEFAULT 0;
+
+-- +migrate Down
+
+ALTER TABLE indexers DROP COLUMN freeleech_only;

--- a/internal/decision/decision.go
+++ b/internal/decision/decision.go
@@ -28,6 +28,10 @@ type Release struct {
 	Format      string // epub, pdf, m4b, … (parsed from title)
 	MediaType   string // "ebook" | "audiobook" | "" — set for dual-format book searches
 	CustomScore int    // cumulative custom-format score
+	// DownloadVolumeFactor is the torznab downloadvolumefactor: the fraction of
+	// the release size charged against the user's download ratio (0 =
+	// freeleech, 1 = normal). nil means the indexer did not report it.
+	DownloadVolumeFactor *float64
 }
 
 // Decision is the result of evaluating a single release.
@@ -101,6 +105,8 @@ func ReleaseFromSearchResult(sr newznab.SearchResult) Release {
 		Language:    sr.Language,
 		Format:      indexer.ParseRelease(sr.Title).Format,
 		MediaType:   sr.MediaType,
+
+		DownloadVolumeFactor: sr.DownloadVolumeFactor,
 	}
 }
 

--- a/internal/decision/freeleech_test.go
+++ b/internal/decision/freeleech_test.go
@@ -1,0 +1,106 @@
+package decision_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/decision"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// freeleechRelease builds a torrent release on indexer 7 with the given
+// downloadvolumefactor. Pass nil for "the indexer did not report it".
+func freeleechRelease(dvf *float64) decision.Release {
+	r := release(withProtocol("torrent"))
+	r.IndexerID = 7
+	r.DownloadVolumeFactor = dvf
+	return r
+}
+
+func dvf(v float64) *float64 { return &v }
+
+func flaggedSpec() decision.FreeleechOnlySpec {
+	return decision.FreeleechOnlySpec{IndexerIDs: map[int64]bool{7: true}}
+}
+
+// A freeleech release (downloadvolumefactor 0) costs no ratio and must pass.
+func TestFreeleechOnlySpec_FreeleechPasses(t *testing.T) {
+	ok, reason := flaggedSpec().IsSatisfiedBy(freeleechRelease(dvf(0)), emptyBook())
+	if !ok {
+		t.Fatalf("downloadvolumefactor 0 is freeleech and must pass, got rejection %q", reason)
+	}
+}
+
+// A normal release costs full ratio and must be held.
+func TestFreeleechOnlySpec_NonFreeleechHeld(t *testing.T) {
+	ok, reason := flaggedSpec().IsSatisfiedBy(freeleechRelease(dvf(1)), emptyBook())
+	if ok {
+		t.Fatal("downloadvolumefactor 1 costs ratio and must be held")
+	}
+	if !strings.Contains(reason, decision.RejectionFreeleechHold) {
+		t.Errorf("rejection %q must contain the %q sentinel — the scheduler matches on it to park the release in pending_releases",
+			reason, decision.RejectionFreeleechHold)
+	}
+}
+
+// Half-leech still costs ratio, so it is held too.
+func TestFreeleechOnlySpec_HalfLeechHeld(t *testing.T) {
+	ok, _ := flaggedSpec().IsSatisfiedBy(freeleechRelease(dvf(0.5)), emptyBook())
+	if ok {
+		t.Fatal("downloadvolumefactor 0.5 still costs ratio and must be held")
+	}
+}
+
+// Fail closed: an unreported factor must be held, not assumed free. Assuming
+// free would silently spend the ratio this policy exists to protect.
+func TestFreeleechOnlySpec_UnknownFactorHeld(t *testing.T) {
+	ok, reason := flaggedSpec().IsSatisfiedBy(freeleechRelease(nil), emptyBook())
+	if ok {
+		t.Fatal("an unreported downloadvolumefactor must fail closed, not be assumed freeleech")
+	}
+	if !strings.Contains(reason, decision.RejectionFreeleechHold) {
+		t.Errorf("rejection %q must carry the hold sentinel so the release is parked, not discarded", reason)
+	}
+}
+
+// Indexers without the policy are untouched, whatever their ratio cost.
+func TestFreeleechOnlySpec_OtherIndexerUnaffected(t *testing.T) {
+	r := freeleechRelease(dvf(1))
+	r.IndexerID = 99 // not in the flagged set
+	if ok, reason := flaggedSpec().IsSatisfiedBy(r, emptyBook()); !ok {
+		t.Fatalf("release from an unflagged indexer must pass, got %q", reason)
+	}
+}
+
+// An empty policy set is a no-op, so the common (no private tracker) case is
+// never affected.
+func TestFreeleechOnlySpec_EmptySetIsNoOp(t *testing.T) {
+	var s decision.FreeleechOnlySpec
+	if ok, reason := s.IsSatisfiedBy(freeleechRelease(dvf(1)), emptyBook()); !ok {
+		t.Fatalf("empty policy set must pass everything, got %q", reason)
+	}
+}
+
+// Usenet has no ratio economy and never reports the factor; holding those
+// would be pure noise if the policy were enabled on a newznab indexer.
+func TestFreeleechOnlySpec_UsenetPasses(t *testing.T) {
+	r := freeleechRelease(nil)
+	r.Protocol = "usenet"
+	if ok, reason := flaggedSpec().IsSatisfiedBy(r, emptyBook()); !ok {
+		t.Fatalf("usenet release must pass (no ratio economy), got %q", reason)
+	}
+}
+
+// The spec must reject through a full DecisionMaker too — that is the path the
+// scheduler uses, including when re-evaluating pending releases (a held
+// release has to keep failing until the user approves it by hand).
+func TestFreeleechOnlySpec_RejectsViaDecisionMaker(t *testing.T) {
+	dm := decision.New(flaggedSpec())
+	decisions := dm.Evaluate([]decision.Release{freeleechRelease(dvf(1))}, models.Book{})
+	if len(decisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(decisions))
+	}
+	if decisions[0].Approved {
+		t.Error("a ratio-costing release must stay rejected on re-evaluation, otherwise the scheduler auto-grabs it off the pending queue")
+	}
+}

--- a/internal/decision/specs.go
+++ b/internal/decision/specs.go
@@ -255,3 +255,57 @@ func (s *CustomFormatScoreSpec) matchCondition(r Release, c models.CustomConditi
 		return false
 	}
 }
+
+// --- FreeleechOnly ---
+
+// RejectionFreeleechHold prefixes every rejection produced by
+// FreeleechOnlySpec. The scheduler matches on this prefix to decide that a
+// release should be parked in pending_releases for manual approval rather than
+// discarded, so keep the two in step (the delay profile uses the same
+// substring-matching convention).
+const RejectionFreeleechHold = "freeleech hold"
+
+// FreeleechOnlySpec restricts AUTOMATIC grabs from selected indexers to
+// releases that cost no download ratio. It exists for private trackers where a
+// user near a ratio floor would otherwise have to restrict the whole indexer to
+// Freeleech/VIP upstream — which also hides normal releases from interactive
+// search, where they would happily pay the cost on a book they actually want.
+//
+// Gating here instead means the scheduler (and bulk multi-book search, which
+// has no picker and is pure fire-and-forget) stays ratio-safe, while rejected
+// releases are held for manual approval rather than hidden. Interactive search
+// builds its own specification set and must NOT include this spec.
+//
+// It must be part of the same DecisionMaker the scheduler uses to re-evaluate
+// pending releases: that path re-grabs anything that starts passing, so a
+// release held here has to keep failing until the user approves it by hand.
+type FreeleechOnlySpec struct {
+	// IndexerIDs is the set of indexer ids with the policy enabled. Releases
+	// from any other indexer pass untouched.
+	IndexerIDs map[int64]bool
+}
+
+func (s FreeleechOnlySpec) IsSatisfiedBy(r Release, _ models.Book) (bool, string) {
+	if len(s.IndexerIDs) == 0 || !s.IndexerIDs[r.IndexerID] {
+		return true, ""
+	}
+	// Usenet has no ratio economy — downloadvolumefactor is a torznab concept
+	// and is never reported. Holding usenet releases would be pure noise if the
+	// policy were switched on for a newznab indexer by mistake.
+	if r.Protocol != "torrent" {
+		return true, ""
+	}
+	if r.DownloadVolumeFactor == nil {
+		// Deliberately fail closed. This is a ratio-protection policy: assuming
+		// an unreported release is free would silently spend the ratio the user
+		// asked us to protect. Holding it is visible and recoverable — the item
+		// shows up in Pending with this reason and can be approved or the
+		// policy turned off.
+		return false, RejectionFreeleechHold + ": indexer did not report downloadvolumefactor"
+	}
+	if *r.DownloadVolumeFactor == 0 {
+		return true, ""
+	}
+	// Anything above zero costs ratio, including half-leech (0.5).
+	return false, fmt.Sprintf("%s: costs %g× ratio (not freeleech)", RejectionFreeleechHold, *r.DownloadVolumeFactor)
+}

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -521,9 +521,11 @@ func (c *Client) parseResults(items []rssItem) []SearchResult {
 			PubDate: item.PubDate,
 		}
 
-		// Parse newznab attributes
+		// Parse newznab attributes. Matched case-insensitively: the torznab
+		// spec is lowercase but trackers/proxies vary, and the sibling caps
+		// parser below already lowercases attribute names.
 		for _, attr := range item.Attrs {
-			switch attr.Name {
+			switch strings.ToLower(attr.Name) {
 			case "size":
 				if s, err := strconv.ParseInt(attr.Value, 10, 64); err == nil {
 					r.Size = s
@@ -540,6 +542,15 @@ func (c *Client) parseResults(items []rssItem) []SearchResult {
 				r.BookTitle = attr.Value
 			case "language":
 				r.Language = attr.Value
+			case "downloadvolumefactor":
+				// Ratio cost of this release (0 = freeleech). Parsed so the
+				// per-indexer freeleech-only policy can hold ratio-costing
+				// releases for manual approval instead of auto-grabbing them.
+				// A malformed value leaves the field nil ("unreported"), which
+				// the policy treats as unsafe rather than assuming freeleech.
+				if f, err := strconv.ParseFloat(strings.TrimSpace(attr.Value), 64); err == nil {
+					r.DownloadVolumeFactor = &f
+				}
 			}
 		}
 

--- a/internal/indexer/newznab/freeleech_test.go
+++ b/internal/indexer/newznab/freeleech_test.go
@@ -1,0 +1,88 @@
+package newznab
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// freeleechRSS is a torznab feed carrying the downloadvolumefactor attribute
+// Jackett emits for private trackers: one freeleech item (0), one normal (1),
+// one with the attribute absent, and one with mixed-case spelling.
+const freeleechRSS = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <item>
+      <title>Freeleech Book</title>
+      <guid>guid-free</guid>
+      <enclosure url="http://tracker/free.torrent" length="100" type="application/x-bittorrent"/>
+      <torznab:attr name="downloadvolumefactor" value="0"/>
+      <torznab:attr name="uploadvolumefactor" value="1"/>
+    </item>
+    <item>
+      <title>Normal Book</title>
+      <guid>guid-normal</guid>
+      <enclosure url="http://tracker/normal.torrent" length="200" type="application/x-bittorrent"/>
+      <torznab:attr name="downloadvolumefactor" value="1"/>
+    </item>
+    <item>
+      <title>Unreported Book</title>
+      <guid>guid-unreported</guid>
+      <enclosure url="http://tracker/unreported.torrent" length="300" type="application/x-bittorrent"/>
+    </item>
+    <item>
+      <title>Mixed Case Book</title>
+      <guid>guid-mixed</guid>
+      <enclosure url="http://tracker/mixed.torrent" length="400" type="application/x-bittorrent"/>
+      <torznab:attr name="downloadVolumeFactor" value="0.5"/>
+    </item>
+  </channel>
+</rss>`
+
+// TestParseResults_DownloadVolumeFactor covers the torznab ratio-cost
+// attribute the per-indexer freeleech-only policy keys off. Absent means nil
+// ("unreported") rather than 0, so the policy can fail closed instead of
+// assuming a release is free.
+func TestParseResults_DownloadVolumeFactor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(freeleechRSS))
+	}))
+	defer srv.Close()
+
+	results, err := testNew(srv.URL, "testkey").Search(context.Background(), "q", nil)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(results))
+	}
+
+	byTitle := map[string]*float64{}
+	for _, r := range results {
+		byTitle[r.Title] = r.DownloadVolumeFactor
+	}
+
+	if got := byTitle["Freeleech Book"]; got == nil || *got != 0 {
+		t.Errorf("freeleech item: downloadVolumeFactor = %v, want 0", derefOrNil(got))
+	}
+	if got := byTitle["Normal Book"]; got == nil || *got != 1 {
+		t.Errorf("normal item: downloadVolumeFactor = %v, want 1", derefOrNil(got))
+	}
+	if got := byTitle["Unreported Book"]; got != nil {
+		t.Errorf("absent attribute must stay nil (unreported), got %v", *got)
+	}
+	// Attribute names are matched case-insensitively: the torznab spec is
+	// lowercase but trackers and proxies vary.
+	if got := byTitle["Mixed Case Book"]; got == nil || *got != 0.5 {
+		t.Errorf("mixed-case attribute: downloadVolumeFactor = %v, want 0.5", derefOrNil(got))
+	}
+}
+
+func derefOrNil(f *float64) any {
+	if f == nil {
+		return nil
+	}
+	return *f
+}

--- a/internal/indexer/newznab/types.go
+++ b/internal/indexer/newznab/types.go
@@ -137,20 +137,26 @@ type capsCategory struct {
 
 // SearchResult is the domain type for an indexer search result.
 type SearchResult struct {
-	GUID            string `json:"guid"`
-	IndexerID       int64  `json:"indexerId"`
-	IndexerName     string `json:"indexerName"`
-	Title           string `json:"title"`
-	Size            int64  `json:"size"`
-	PubDate         string `json:"pubDate"`
-	NZBURL          string `json:"nzbUrl"`
-	InfoURL         string `json:"infoUrl,omitempty"` // human-readable indexer detail/release page (from comments, guid-permalink, or link); never the download URL
-	Category        string `json:"category"`
-	Grabs           int    `json:"grabs"`
-	Author          string `json:"author"`
-	BookTitle       string `json:"bookTitle"`
-	Protocol        string `json:"protocol"`            // "usenet" or "torrent"
-	Language        string `json:"language,omitempty"`  // ISO 639-1 from newznab:attr language (when present)
-	MediaType       string `json:"mediaType,omitempty"` // "ebook" or "audiobook"; set for dual-format book searches
-	IndexerPriority int    `json:"indexerPriority"`     // copied from models.Indexer.Priority; higher wins
+	GUID        string `json:"guid"`
+	IndexerID   int64  `json:"indexerId"`
+	IndexerName string `json:"indexerName"`
+	Title       string `json:"title"`
+	Size        int64  `json:"size"`
+	PubDate     string `json:"pubDate"`
+	NZBURL      string `json:"nzbUrl"`
+	InfoURL     string `json:"infoUrl,omitempty"` // human-readable indexer detail/release page (from comments, guid-permalink, or link); never the download URL
+	Category    string `json:"category"`
+	Grabs       int    `json:"grabs"`
+	Author      string `json:"author"`
+	BookTitle   string `json:"bookTitle"`
+	Protocol    string `json:"protocol"`           // "usenet" or "torrent"
+	Language    string `json:"language,omitempty"` // ISO 639-1 from newznab:attr language (when present)
+	// DownloadVolumeFactor is the torznab downloadvolumefactor attribute: the
+	// fraction of this release's size that counts against the user's download
+	// ratio. 0 means freeleech (costs nothing), 1 is a normal release, 0.5 is
+	// half-leech. nil means the indexer did not report it — usenet indexers
+	// never do, and it is absent from most public torznab feeds.
+	DownloadVolumeFactor *float64 `json:"downloadVolumeFactor,omitempty"`
+	MediaType            string   `json:"mediaType,omitempty"` // "ebook" or "audiobook"; set for dual-format book searches
+	IndexerPriority      int      `json:"indexerPriority"`     // copied from models.Indexer.Priority; higher wins
 }

--- a/internal/models/indexer.go
+++ b/internal/models/indexer.go
@@ -20,6 +20,15 @@ type Indexer struct {
 	// (Prowlarr/qBittorrent convention). The downloader adapters translate the
 	// value into each client's own API shape.
 	SeedRatio *float64 `json:"seedRatio,omitempty"`
+	// FreeleechOnly restricts this indexer's AUTOMATIC grabs to releases that
+	// cost no download ratio (torznab downloadvolumefactor == 0). Non-freeleech
+	// releases are not hidden: they are held in pending_releases for manual
+	// approval, so bulk and scheduled searches stay ratio-safe while the user
+	// can still deliberately pay the cost on a book they care about.
+	// Interactive search is unaffected — it builds its own specification set.
+	// Intended for private trackers; leave off for public trackers and usenet,
+	// where there is no ratio economy.
+	FreeleechOnly bool `json:"freeleechOnly"`
 	// SeedRatioSource records who last wrote SeedRatio, so the Prowlarr syncer
 	// (#1065) can auto-populate the ratio without clobbering an explicit user
 	// choice. See the SeedRatioSource* constants. The empty string means "unset"

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -495,6 +495,24 @@ func (s *Scheduler) resolveSeedRatio(ctx context.Context, indexerID int64) *floa
 	return idx.SeedRatio
 }
 
+// freeleechOnlyIndexerIDs returns the set of indexer ids whose freeleech-only
+// policy is enabled. Returns nil when none are, so the caller can skip adding
+// the specification entirely and leave the decision path untouched for the
+// (overwhelmingly common) case where nobody uses a private tracker.
+func freeleechOnlyIndexerIDs(idxs []models.Indexer) map[int64]bool {
+	var out map[int64]bool
+	for _, idx := range idxs {
+		if !idx.FreeleechOnly {
+			continue
+		}
+		if out == nil {
+			out = make(map[int64]bool)
+		}
+		out[idx.ID] = true
+	}
+	return out
+}
+
 // searchAndGrabFormat searches for and grabs a specific format of a book.
 // mediaType must be MediaTypeEbook or MediaTypeAudiobook.
 func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, mediaType string) {
@@ -570,6 +588,15 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 			specs = append(specs, decision.DelayProfileSpec{Profile: delayProfile})
 		}
 	}
+	// Per-indexer freeleech-only policy: releases that would cost download
+	// ratio on a flagged indexer are rejected here and parked in
+	// pending_releases below for manual approval. Applied only on this
+	// automatic path — interactive search (api/indexers.go) builds its own
+	// specification set deliberately without it, so a user can still see and
+	// hand-pick a ratio-costing release for a book they care about.
+	if freeleechOnly := freeleechOnlyIndexerIDs(idxs); len(freeleechOnly) > 0 {
+		specs = append(specs, decision.FreeleechOnlySpec{IndexerIDs: freeleechOnly})
+	}
 	dm := decision.New(specs...)
 	releases := make([]decision.Release, len(results))
 	for i, res := range results {
@@ -586,7 +613,14 @@ func (s *Scheduler) searchAndGrabFormat(ctx context.Context, book models.Book, m
 		// The sentinel "delay not met" matches both "usenet delay not met" and
 		// "torrent delay not met" produced by DelayProfileSpec. There is no typed
 		// flag on Decision today; left as-is per #707 (minor finding).
-		if s.pending != nil && strings.Contains(d.Rejection, "delay not met") {
+		// A freeleech hold is stored the same way, but for the opposite reason:
+		// a delayed release is expected to pass on a later sweep, whereas a
+		// ratio-costing one never will (the same spec runs in
+		// checkPendingReleases), so it waits in Pending until the user
+		// approves it by hand. Without this it would simply be discarded and
+		// the user would never learn the release existed.
+		if s.pending != nil && (strings.Contains(d.Rejection, "delay not met") ||
+			strings.Contains(d.Rejection, decision.RejectionFreeleechHold)) {
 			s.storePending(ctx, book.ID, mediaType, results[i], d.Rejection)
 		}
 	}

--- a/internal/scheduler/scheduler_freeleech_test.go
+++ b/internal/scheduler/scheduler_freeleech_test.go
@@ -1,0 +1,209 @@
+package scheduler
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/decision"
+	"github.com/vavallee/bindery/internal/indexer/newznab"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// freeleechFixture builds a DB-backed scheduler with one torrent indexer whose
+// freeleech-only policy is set by the caller, plus an enabled torrent client so
+// an approved release proceeds as far as a download record. The client points
+// at 127.0.0.1:1 so the send fails fast; the download row is created first,
+// which is the observable.
+func freeleechFixture(t *testing.T, freeleechOnly bool, results []newznab.SearchResult) (
+	*Scheduler, *db.DownloadRepo, *db.PendingReleaseRepo, models.Book,
+) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("OpenMemory: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+	downloads := db.NewDownloadRepo(database)
+	indexers := db.NewIndexerRepo(database)
+	pending := db.NewPendingReleaseRepo(database)
+
+	a := &models.Author{
+		ForeignID: "OL-FL-A", Name: "Ratio Author", SortName: "Author, Ratio",
+		MetadataProvider: "ol", Monitored: true,
+	}
+	if err := authors.Create(ctx, a); err != nil {
+		t.Fatalf("author create: %v", err)
+	}
+	book := models.Book{
+		ForeignID: "OL-FL-B", AuthorID: a.ID, Title: "Ratio Book",
+		SortTitle: "Ratio Book", Status: models.BookStatusWanted,
+		Genres: []string{}, MetadataProvider: "ol", Monitored: true,
+		MediaType: models.MediaTypeEbook,
+	}
+	if err := books.Create(ctx, &book); err != nil {
+		t.Fatalf("book create: %v", err)
+	}
+	if err := clients.Create(ctx, &models.DownloadClient{
+		Name: "qbit", Type: "qbittorrent", Host: "127.0.0.1", Port: 1, Enabled: true,
+	}); err != nil {
+		t.Fatalf("client create: %v", err)
+	}
+
+	idx := &models.Indexer{
+		Name: "private-tracker", Type: "torznab", URL: "http://127.0.0.1:1",
+		Enabled: true, FreeleechOnly: freeleechOnly,
+	}
+	if err := indexers.Create(ctx, idx); err != nil {
+		t.Fatalf("indexer create: %v", err)
+	}
+	for i := range results {
+		results[i].IndexerID = idx.ID
+	}
+
+	s := &Scheduler{
+		searcher:  &fixedResultsSearcher{results: results},
+		indexers:  indexers,
+		authors:   authors,
+		settings:  db.NewSettingsRepo(database),
+		blocklist: db.NewBlocklistRepo(database),
+		downloads: downloads,
+		clients:   clients,
+		profiles:  db.NewMetadataProfileRepo(database),
+		pending:   pending,
+	}
+	return s, downloads, pending, book
+}
+
+func ratio(v float64) *float64 { return &v }
+
+// TestSearchAndGrabFormat_HoldsNonFreeleechForApproval is the core of cleb's
+// request: on an indexer restricted to freeleech, a ratio-costing release must
+// NOT be auto-grabbed, and must NOT be silently dropped either — it lands in
+// pending_releases so the user can approve it by hand.
+func TestSearchAndGrabFormat_HoldsNonFreeleechForApproval(t *testing.T) {
+	ctx := context.Background()
+	s, downloads, pending, book := freeleechFixture(t, true, []newznab.SearchResult{{
+		GUID: "g-normal", Title: "Ratio Book.epub", NZBURL: "http://127.0.0.1:1/1",
+		Protocol: "torrent", DownloadVolumeFactor: ratio(1),
+	}})
+
+	s.searchAndGrabFormat(ctx, book, models.MediaTypeEbook)
+
+	rows, err := downloads.List(ctx)
+	if err != nil {
+		t.Fatalf("downloads list: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("a ratio-costing release must not be auto-grabbed, got %d download(s)", len(rows))
+	}
+
+	held, err := pending.ListByBookAndMediaType(ctx, book.ID, models.MediaTypeEbook)
+	if err != nil {
+		t.Fatalf("pending list: %v", err)
+	}
+	if len(held) != 1 {
+		t.Fatalf("expected the release to be held for manual approval, got %d pending entr(ies)", len(held))
+	}
+	if !strings.Contains(held[0].Reason, decision.RejectionFreeleechHold) {
+		t.Errorf("pending reason = %q, want it to carry the %q sentinel so the UI explains why",
+			held[0].Reason, decision.RejectionFreeleechHold)
+	}
+}
+
+// TestSearchAndGrabFormat_GrabsFreeleech is the control: a freeleech release
+// costs no ratio and is auto-grabbed as normal.
+func TestSearchAndGrabFormat_GrabsFreeleech(t *testing.T) {
+	ctx := context.Background()
+	s, downloads, pending, book := freeleechFixture(t, true, []newznab.SearchResult{{
+		GUID: "g-free", Title: "Ratio Book.epub", NZBURL: "http://127.0.0.1:1/2",
+		Protocol: "torrent", DownloadVolumeFactor: ratio(0),
+	}})
+
+	s.searchAndGrabFormat(ctx, book, models.MediaTypeEbook)
+
+	rows, err := downloads.List(ctx)
+	if err != nil {
+		t.Fatalf("downloads list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("a freeleech release must be grabbed normally, got %d download(s)", len(rows))
+	}
+	held, _ := pending.ListByBookAndMediaType(ctx, book.ID, models.MediaTypeEbook)
+	if len(held) != 0 {
+		t.Errorf("a grabbed freeleech release must not also be left pending, got %d", len(held))
+	}
+}
+
+// TestSearchAndGrabFormat_PolicyOffGrabsNonFreeleech confirms the feature is
+// strictly opt-in: with the policy off, the same ratio-costing release is
+// grabbed exactly as before.
+func TestSearchAndGrabFormat_PolicyOffGrabsNonFreeleech(t *testing.T) {
+	ctx := context.Background()
+	s, downloads, _, book := freeleechFixture(t, false, []newznab.SearchResult{{
+		GUID: "g-normal-off", Title: "Ratio Book.epub", NZBURL: "http://127.0.0.1:1/3",
+		Protocol: "torrent", DownloadVolumeFactor: ratio(1),
+	}})
+
+	s.searchAndGrabFormat(ctx, book, models.MediaTypeEbook)
+
+	rows, err := downloads.List(ctx)
+	if err != nil {
+		t.Fatalf("downloads list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("with the policy off nothing should change, got %d download(s)", len(rows))
+	}
+}
+
+// TestSearchAndGrabFormat_HeldReleaseStaysHeldOnResweep guards the trap in
+// checkPendingReleases: it re-evaluates pending entries every sweep and grabs
+// anything that starts passing. A ratio hold must keep failing, or the release
+// the user was asked to approve gets auto-grabbed on the next cycle anyway.
+func TestSearchAndGrabFormat_HeldReleaseStaysHeldOnResweep(t *testing.T) {
+	ctx := context.Background()
+	s, downloads, pending, book := freeleechFixture(t, true, []newznab.SearchResult{{
+		GUID: "g-normal", Title: "Ratio Book.epub", NZBURL: "http://127.0.0.1:1/4",
+		Protocol: "torrent", DownloadVolumeFactor: ratio(1),
+	}})
+
+	s.searchAndGrabFormat(ctx, book, models.MediaTypeEbook)
+	// Second sweep: the pending entry is re-evaluated with the same specs.
+	s.searchAndGrabFormat(ctx, book, models.MediaTypeEbook)
+
+	rows, err := downloads.List(ctx)
+	if err != nil {
+		t.Fatalf("downloads list: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("a held release must not be auto-grabbed off the pending queue on a later sweep, got %d download(s)", len(rows))
+	}
+	held, _ := pending.ListByBookAndMediaType(ctx, book.ID, models.MediaTypeEbook)
+	if len(held) != 1 {
+		t.Errorf("the release should still be waiting for manual approval, got %d pending entr(ies)", len(held))
+	}
+}
+
+// TestFreeleechOnlyIndexerIDs covers the set builder, including the nil return
+// that keeps the specification out of the decision path entirely when nobody
+// uses the policy.
+func TestFreeleechOnlyIndexerIDs(t *testing.T) {
+	if got := freeleechOnlyIndexerIDs(nil); got != nil {
+		t.Errorf("no indexers should yield a nil set, got %v", got)
+	}
+	if got := freeleechOnlyIndexerIDs([]models.Indexer{{ID: 1}, {ID: 2}}); got != nil {
+		t.Errorf("no flagged indexers should yield a nil set, got %v", got)
+	}
+	got := freeleechOnlyIndexerIDs([]models.Indexer{
+		{ID: 1}, {ID: 2, FreeleechOnly: true}, {ID: 3, FreeleechOnly: true},
+	})
+	if len(got) != 2 || !got[2] || !got[3] || got[1] {
+		t.Errorf("expected exactly indexers 2 and 3 flagged, got %v", got)
+	}
+}

--- a/web/src/api/indexers.ts
+++ b/web/src/api/indexers.ts
@@ -18,6 +18,10 @@ export interface Indexer {
   // seedCriteria.seedRatio (a later Prowlarr change may refresh it); 'user' = the
   // user set/cleared it (Prowlarr won't touch it); omitted/'' = unset.
   seedRatioSource?: string
+  // Only auto-grab freeleech releases from this indexer. Non-freeleech
+  // releases are held in the Pending queue for manual approval instead of
+  // being grabbed automatically. Interactive search is unaffected.
+  freeleechOnly?: boolean
 }
 
 export interface IndexerTestResult {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -427,7 +427,9 @@
         "seedRatioPlaceholder": "e.g. 1.0",
         "seedRatioUnlimited": "Unlimited",
         "seedRatioFromProwlarr": "Auto-filled from Prowlarr. Edit and save to override; Prowlarr won't change it again.",
-        "seedRatioHint": "Per-indexer seed-ratio limit applied to torrents grabbed from this indexer (qBittorrent, Transmission, Deluge). Leave blank to use the download client's global rule, or check Unlimited to seed forever. Ignored for Usenet."
+        "seedRatioHint": "Per-indexer seed-ratio limit applied to torrents grabbed from this indexer (qBittorrent, Transmission, Deluge). Leave blank to use the download client's global rule, or check Unlimited to seed forever. Ignored for Usenet.",
+        "freeleechOnly": "Only auto-grab freeleech releases",
+        "freeleechOnlyHint": "Automatic grabs from this indexer are limited to freeleech releases; anything else is held in the Pending queue for manual approval. Interactive search still shows everything. For private trackers where ratio matters — leave off for public trackers and Usenet."
       }
     },
     "prowlarr": {

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1247,6 +1247,7 @@ describe('SettingsPage', () => {
         priority: 0,
         enabled: true,
         seedRatio: null,
+        freeleechOnly: false,
       })
     })
     expect(await screen.findByText('SceneNZBs')).toBeInTheDocument()
@@ -1275,6 +1276,7 @@ describe('SettingsPage', () => {
         apiKey: 'slug-key',
         categories: [7020, 3030],
         seedRatio: null,
+        freeleechOnly: false,
       })
     })
     expect(await screen.findByText('DrunkenSlug')).toBeInTheDocument()
@@ -1315,6 +1317,29 @@ describe('SettingsPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
     expect(screen.getByLabelText('settings.indexers.form.seedRatioUnlimited')).toBeChecked()
+  })
+
+  it('saves the freeleech-only auto-grab toggle', async () => {
+    const indexer = makeIndexer({ id: 14, name: 'FreeleechIdx' })
+    renderSettings({ indexers: [indexer] })
+    await openIndexersTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+    fireEvent.click(screen.getByLabelText('settings.indexers.form.freeleechOnly'))
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => {
+      expect(api.updateIndexer).toHaveBeenCalledWith(14, expect.objectContaining({ freeleechOnly: true }))
+    })
+  })
+
+  it('initializes the freeleech-only toggle from the existing indexer', async () => {
+    const indexer = makeIndexer({ id: 15, name: 'PreFreeleech', freeleechOnly: true })
+    renderSettings({ indexers: [indexer] })
+    await openIndexersTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.edit' }))
+    expect(screen.getByLabelText('settings.indexers.form.freeleechOnly')).toBeChecked()
   })
 
   it('toggles and deletes an indexer', async () => {

--- a/web/src/pages/settings/IndexersTab.tsx
+++ b/web/src/pages/settings/IndexersTab.tsx
@@ -89,6 +89,21 @@ function SeedRatioField({ value, onChange, source }: { value: number | null | un
   )
 }
 
+// FreeleechOnlyField gates automatic grabbing to freeleech releases. It sits
+// next to the seed-ratio override because both are tracker-economics knobs.
+function FreeleechOnlyField({ value, onChange }: { value: boolean; onChange: (v: boolean) => void }) {
+  const { t } = useTranslation()
+  return (
+    <div>
+      <label className="flex items-center gap-1.5 text-xs text-slate-600 dark:text-zinc-400">
+        <input type="checkbox" checked={value} onChange={e => onChange(e.target.checked)} className="accent-emerald-600 dark:accent-emerald-500" />
+        {t('settings.indexers.form.freeleechOnly')}
+      </label>
+      <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.freeleechOnlyHint')}</p>
+    </div>
+  )
+}
+
 // indexers/prowlarrInstances are owned by SettingsPage so they can be fetched
 // eagerly on page mount (matching the pre-refactor monolith), not on tab open.
 interface Props {
@@ -333,12 +348,13 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
   const [categories, setCategories] = useState((indexer.categories ?? [7020]).join(', '))
   const [priority, setPriority] = useState(String(indexer.priority ?? 0))
   const [seedRatio, setSeedRatio] = useState<number | null>(indexer.seedRatio ?? null)
+  const [freeleechOnly, setFreeleechOnly] = useState(indexer.freeleechOnly ?? false)
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<IndexerTestResult | null>(null)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
-    const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey, categories: parseCats(categories), priority: parsePriority(priority), seedRatio })
+    const updated = await api.updateIndexer(indexer.id, { ...indexer, name, type, url, apiKey, categories: parseCats(categories), priority: parsePriority(priority), seedRatio, freeleechOnly })
     onSaved(updated)
   }
 
@@ -390,6 +406,7 @@ function EditIndexerForm({ indexer, onClose, onSaved }: { indexer: Indexer; onCl
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.priorityHint')}</p>
       </div>
       <SeedRatioField value={seedRatio} onChange={setSeedRatio} source={indexer.seedRatioSource} />
+      <FreeleechOnlyField value={freeleechOnly} onChange={setFreeleechOnly} />
       {testResult && <IndexerTestResultBanner r={testResult} />}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">{t('common.cancel')}</button>
@@ -409,12 +426,13 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
   const [categories, setCategories] = useState('7020')
   const [priority, setPriority] = useState('0')
   const [seedRatio, setSeedRatio] = useState<number | null>(null)
+  const [freeleechOnly, setFreeleechOnly] = useState(false)
   const [testing, setTesting] = useState(false)
   const [testResult, setTestResult] = useState<IndexerTestResult | null>(null)
   const labelCls = 'block text-xs text-slate-600 dark:text-zinc-400 mb-1'
 
   const submit = async () => {
-    const idx = await api.addIndexer({ name, url, apiKey, type, categories: parseCats(categories), priority: parsePriority(priority), enabled: true, seedRatio })
+    const idx = await api.addIndexer({ name, url, apiKey, type, categories: parseCats(categories), priority: parsePriority(priority), enabled: true, seedRatio, freeleechOnly })
     onAdded(idx)
   }
 
@@ -466,6 +484,7 @@ function AddIndexerForm({ onClose, onAdded }: { onClose: () => void; onAdded: (i
         <p className="text-xs text-slate-500 dark:text-zinc-500 mt-1">{t('settings.indexers.form.priorityHint')}</p>
       </div>
       <SeedRatioField value={seedRatio} onChange={setSeedRatio} />
+      <FreeleechOnlyField value={freeleechOnly} onChange={setFreeleechOnly} />
       {testResult && <IndexerTestResultBanner r={testResult} />}
       <div className="flex gap-2 justify-end">
         <button onClick={onClose} className="px-3 py-1.5 text-sm text-slate-600 dark:text-zinc-400">{t('common.cancel')}</button>


### PR DESCRIPTION
## Problem

Requested on Discord by **cleb**. Private-tracker users (MAM) close to a ratio floor can only stay safe today by restricting the MAM indexer in Jackett to Freeleech/VIP — but that also hides normal releases from **interactive single-book search**, where they'd happily pick one by hand and eat the ratio cost on a book they actually care about. It also does nothing for **bulk/multi-book search**, which has no picker and is pure fire-and-forget auto-grab.

## Verifying the report

cleb did the legwork; confirming what I found:

| Claim | Verdict |
|---|---|
| `downloadvolumefactor` never parsed | ✅ Confirmed — zero occurrences. Now parsed. |
| `indexerFlag` custom-format condition documented but unimplemented | ✅ Confirmed (`matchCondition` handles only `releaseTitle`/`releaseGroup`; `size` is unimplemented too). Not used by this PR — a purpose-built check was cleaner than reviving it. |
| "Most of `internal/decision` is dead code" | ⚠️ Overstated. `BlocklistedSpec` + `DelayProfileSpec` are live in the scheduler, `BlocklistedSpec` + `AlreadyImportedSpec` in interactive search. Only `CustomFormatScoreSpec`/`SizeLimitSpec` are unwired — so the specification framework was the natural, cheap extension point. |

The proposal also turned out to need **no new approval queue**: `pending_releases` already exists end to end (table, repo, `GET/DELETE/POST-grab` routes, Queue-page UI, and `PendingHandler.Grab` bypasses the decision engine — correct for a manual override). This PR reuses it.

## Approach

Gate at the **release** level, per cleb's proposal. Opt-in **per indexer** (migration 066), mirroring the per-indexer `seed_ratio` override (#883) — ratio economics are per-tracker, so a global switch would also throttle public trackers and usenet where ratio is meaningless.

When enabled on an indexer, the **scheduler's automatic path** only auto-grabs releases reported as freeleech (`downloadvolumefactor == 0`). Anything that would cost ratio is parked in `pending_releases` for manual approval instead of being hidden or grabbed blind. **Interactive search builds its own specification set and is deliberately left untouched** — so it keeps showing everything, which is exactly the outcome cleb wanted, with no per-indexer automatic-vs-interactive scope needed.

## Two traps worth calling out

1. **`checkPendingReleases` re-grabs anything that starts passing.** It re-evaluates pending entries every sweep, so if the freeleech check weren't part of that *same* `DecisionMaker`, a held release would be silently auto-grabbed on the next cycle — the exact ratio hit being avoided. Implementing it as a specification (not a pre-filter) makes the hold stable by construction. There's a regression test that sweeps twice.
2. **`storePending` was gated solely on `"delay not met"`**, so a new rejection reason would have been *discarded*, not queued. Extended, with a distinct exported `RejectionFreeleechHold` sentinel rather than another bare string literal.

## Decisions

- **Unreported factor fails closed** (held, not grabbed). This is a ratio-protection policy: assuming an unknown release is free would silently spend the ratio it exists to protect. A hold is visible in Pending with a clear reason and recoverable; an over-spend isn't.
- **Half-leech (0.5) is held** — it still costs ratio.
- **Usenet always passes** — no ratio economy, and the attribute is never reported, so enabling the policy on a newznab indexer by mistake is a no-op rather than a firehose of pending items.
- **No "I have VIP" toggle.** With VIP, downloads don't count against ratio at all, so the correct action is simply leaving the policy off — a second toggle meaning "ignore the first toggle" would be redundant. Easy to add later if MAM's VIP semantics turn out to be more nuanced.
- Attribute names now matched **case-insensitively** (the torznab spec is lowercase, but trackers/proxies vary; the sibling caps parser already lowercased).

## Tests

- **Spec**: freeleech passes; normal and half-leech held; unreported held (fail closed); unflagged indexer and empty policy set are no-ops; usenet passes; rejection carries the sentinel; rejects through a full `DecisionMaker`.
- **Scheduler (end-to-end)**: non-freeleech is not grabbed *and* lands in Pending with the right reason; freeleech is grabbed normally; policy-off changes nothing; **a held release stays held across a second sweep**.
- **Parsing**: `downloadvolumefactor` 0 / 1 / absent→nil / mixed-case.
- **DB**: defaults off, round-trips through Create/Update/List, clears again.
- Prowlarr sync verified not to clobber the flag (it mutates a DB-loaded row and writes it back).

Full backend suite, `gofmt`, `go vet`, `golangci-lint` (0 issues), frontend `tsc` + build + 425 vitest tests all green.

> **Note:** uses migration **066** because PR #1621 already claims 065.