### PR TITLE
fix(indexer): apply the non-book content guard in the debug pipeline too (#1644)

### DIFF
--- a/changelog.d/1644-debug-nonbook-filter.md
+++ b/changelog.d/1644-debug-nonbook-filter.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Interactive search no longer shows video releases the automatic grabber rejects** (#1644) — the guard that keeps movie and TV releases out of book results was applied to scheduled searches but was missing from the search you run yourself, which is the one the UI uses. Releases tagged 1080p/x264/WEB-DL, or filed by the indexer under Movies, TV or similar, could therefore appear in manual search results and be grabbed by hand. The search details panel now also reports how many results that stage removed.

--- a/internal/indexer/debug.go
+++ b/internal/indexer/debug.go
@@ -52,10 +52,11 @@ type IndexerDebug struct {
 // PipelineDebug counts how results flowed through each filter stage in the
 // Searcher. Mismatches between stages reveal which filter is eating results.
 type PipelineDebug struct {
-	RawCount        int `json:"rawCount"`
-	AfterDedupe     int `json:"afterDedupe"`
-	AfterUsenetJunk int `json:"afterUsenetJunk"`
-	AfterRelevance  int `json:"afterRelevance"`
+	RawCount            int `json:"rawCount"`
+	AfterDedupe         int `json:"afterDedupe"`
+	AfterUsenetJunk     int `json:"afterUsenetJunk"`
+	AfterNonBookContent int `json:"afterNonBookContent"`
+	AfterRelevance      int `json:"afterRelevance"`
 }
 
 // FilterDebug records a per-candidate rejection emitted during the Searcher
@@ -171,6 +172,13 @@ func (s *Searcher) SearchBookWithDebug(ctx context.Context, indexers []models.In
 	results, junkFilters := filterUsenetJunkDebug(results)
 	dbg.Filters = append(dbg.Filters, junkFilters...)
 	dbg.Pipeline.AfterUsenetJunk = len(results)
+
+	// MUST stay in lockstep with SearchBook's pipeline (searcher.go). This stage
+	// was missing here, and since SearchBookWithDebug is the only entrypoint the
+	// API uses, the #1591 video guard was absent from every interactive search
+	// while the scheduler had it (#1644).
+	results = filterNonBookContent(results)
+	dbg.Pipeline.AfterNonBookContent = len(results)
 
 	results, relFilters := filterRelevantDebug(results, c.Title, c.Author, c.AuthorAliases)
 	dbg.Filters = append(dbg.Filters, relFilters...)

--- a/internal/indexer/debug_pipeline_parity_test.go
+++ b/internal/indexer/debug_pipeline_parity_test.go
@@ -1,0 +1,110 @@
+package indexer
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// videoFeedRSS mixes legitimate book releases with the #1591 population: video
+// releases sharing title words, and a result the indexer itself filed under a
+// non-book category.
+const videoFeedRSS = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:newznab="http://www.newznab.com/DTD/2010/feeds/attributes/">
+  <channel>
+    <newznab:response offset="0" total="5"/>
+    <item>
+      <title>Frank Herbert - Dune - retail epub</title>
+      <guid isPermaLink="false">g1</guid>
+      <enclosure url="https://fake/dl/1" length="1000" type="application/x-nzb"/>
+    </item>
+    <item>
+      <title>Frank Herbert Dune 2021 1080p WEB-DL x264-GROUP</title>
+      <guid isPermaLink="false">g2</guid>
+      <enclosure url="https://fake/dl/2" length="1000" type="application/x-nzb"/>
+    </item>
+    <item>
+      <title>Frank Herbert Dune S01E02 720p HDTV x264</title>
+      <guid isPermaLink="false">g3</guid>
+      <enclosure url="https://fake/dl/3" length="1000" type="application/x-nzb"/>
+    </item>
+    <item>
+      <title>Frank Herbert - Dune (Unabridged) m4b</title>
+      <guid isPermaLink="false">g4</guid>
+      <enclosure url="https://fake/dl/4" length="1000" type="application/x-nzb"/>
+    </item>
+  </channel>
+</rss>`
+
+// TestSearchPipelinesAgreeOnNonBookContent is the regression test for #1644.
+//
+// SearchBookWithDebug omitted filterNonBookContent, and it is the ONLY searcher
+// entrypoint the API uses (internal/api/indexers.go calls it for single-format
+// searches and for both legs of a media_type=both fan-out), while the scheduler
+// uses SearchBook. So the #1591 video guard applied to automated grabs but not
+// to interactive search, and the UI surfaced 1080p/x264/WEB-DL releases the
+// grab path would have dropped.
+//
+// This drives BOTH REAL entrypoints against the same fake indexer rather than
+// re-implementing their stage lists, so a future divergence in either pipeline
+// fails here.
+//
+// The video entries deliberately name the author as well as the title, so they
+// SURVIVE relevance filtering and only filterNonBookContent can remove them.
+// That is the #1591 population ("movie/TV releases sharing a few title words"),
+// and without it the parity assertion passes vacuously because relevance
+// happens to drop the junk anyway.
+func TestSearchPipelinesAgreeOnNonBookContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(videoFeedRSS))
+	}))
+	defer srv.Close()
+
+	idxs := []models.Indexer{{ID: 1, Name: "test", URL: srv.URL, Enabled: true, Categories: []int{7020}}}
+	crit := MatchCriteria{Title: "Dune", Author: "Frank Herbert"}
+
+	plain := newTestSearcher().SearchBook(context.Background(), idxs, crit)
+	debugged, dbg := newTestSearcher().SearchBookWithDebug(context.Background(), idxs, crit)
+
+	plainTitles := resultTitles(plain)
+	debugTitles := resultTitles(debugged)
+
+	if len(plainTitles) != len(debugTitles) {
+		t.Fatalf("pipelines disagree:\n  SearchBook          kept %d %v\n  SearchBookWithDebug kept %d %v",
+			len(plainTitles), plainTitles, len(debugTitles), debugTitles)
+	}
+	for i := range plainTitles {
+		if plainTitles[i] != debugTitles[i] {
+			t.Errorf("pipelines disagree at %d: %q vs %q", i, plainTitles[i], debugTitles[i])
+		}
+	}
+
+	// Guard against both pipelines being equally broken: the video releases must
+	// actually be gone, and the book releases must actually survive.
+	for _, title := range plainTitles {
+		if videoMarkerRe.MatchString(title) {
+			t.Errorf("video release survived filtering: %q", title)
+		}
+	}
+	if len(plainTitles) == 0 {
+		t.Fatal("expected the legitimate book releases to survive")
+	}
+
+	// The debug counter must be populated, since it is what makes the stage
+	// visible in the UI's search-details panel.
+	if dbg == nil {
+		t.Fatal("expected non-nil debug info")
+	}
+	if dbg.Pipeline.AfterNonBookContent != len(debugTitles) {
+		t.Errorf("AfterNonBookContent = %d, want %d (the count entering relevance)",
+			dbg.Pipeline.AfterNonBookContent, len(debugTitles))
+	}
+	if dbg.Pipeline.AfterNonBookContent >= dbg.Pipeline.AfterUsenetJunk {
+		t.Errorf("expected the non-book stage to drop results: afterUsenetJunk=%d afterNonBookContent=%d",
+			dbg.Pipeline.AfterUsenetJunk, dbg.Pipeline.AfterNonBookContent)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1644. `SearchBookWithDebug` omitted `filterNonBookContent`, so the two searcher pipelines diverged:

```
SearchBook:          dedupe -> usenetJunk -> nonBookContent -> relevance
SearchBookWithDebug: dedupe -> usenetJunk ->    (missing)    -> relevance
```

That matters because **`SearchBookWithDebug` is the only entrypoint the API uses** (`internal/api/indexers.go:356`, `:363`, `:389`, including both legs of the `media_type=both` fan-out), while the scheduler uses `SearchBook`. So #1591's video guard covered automated grabs but not interactive search: the UI surfaced `1080p`/`x264`/`WEB-DL` releases and results the indexer itself filed under Movies, TV, Console, PC or XXX.

Blast radius was bounded rather than zero, since `largestFileIsVideo` still blocks a video download at import. But a manual import with an explicit `formatHint` is the documented human override and bypasses that block.

## The fix

Add the missing stage, plus an `AfterNonBookContent` counter so the step is visible in the search-details panel rather than silently absent (`PipelineDebug` had no field for it, which is part of why nobody noticed).

## On the test

The regression test drives **both real entrypoints** against one fake indexer rather than re-implementing their stage lists, so a future divergence in either pipeline fails here — that is the property that actually broke.

Two things I checked rather than assumed:

- Its video entries deliberately name the **author** as well as the title, so they survive relevance filtering and only `filterNonBookContent` can remove them. That's the #1591 population ("movie/TV releases sharing a few title words"). My first draft used title-only video entries, and relevance dropped them anyway, which made the parity assertion pass vacuously.
- I verified the test **fails with the fix reverted**, and fails on the parity assertion specifically:

```
pipelines disagree:
  SearchBook          kept 2 [... - Dune (Unabridged) m4b, ... - Dune - retail epub]
  SearchBookWithDebug kept 4 [..., ..., Frank Herbert Dune 2021 1080p WEB-DL x264-GROUP,
                                        Frank Herbert Dune S01E02 720p HDTV x264]
```

## Test plan

- [x] `TestSearchPipelinesAgreeOnNonBookContent` — both real pipelines agree; video releases actually removed; `AfterNonBookContent` populated and lower than `AfterUsenetJunk`
- [x] Confirmed the test fails when the fix is reverted (shown above)
- [x] `go test ./...` — full suite passes
- [x] `gofmt`, `go vet`, `golangci-lint run internal/indexer/...` — 0 issues

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` updated if env vars, config, or upgrade path changed *(N/A)*
- [x] Added a changelog fragment under `changelog.d/`
- [x] Wiki pages updated if user-facing behavior changed *(N/A; the new counter appears in the existing search-details panel)*
