### PR TITLE
refactor(textutil): give the comparison alphabets one home (#1648)

### DIFF
--- a/changelog.d/1648-shared-normalization.md
+++ b/changelog.d/1648-shared-normalization.md
@@ -1,0 +1,5 @@
+### Fixed
+- **German and Scandinavian authors no longer end up duplicated or stuck in the review queue** (#1647) — author matching stripped accents ("Müller" → "muller") while every title matcher expands them ("Müller" → "mueller"), so a name spelled with accents in one place and ASCII-ised in another ("Jörg Müller" vs "Joerg Mueller") scored just under the auto-accept threshold. The same gap affected "Nesbø"/"Nesbo" and "Łukasz"/"Lukasz". Both spellings now resolve to one author.
+
+### Changed
+- **Normalization rules are defined in one place** (#1648) — the character folding used to compare titles and release names was copy-pasted into three packages and had started to drift, which is what caused #1643 and made #1642 possible. It now lives in a single shared helper, with the four legitimately-different comparison alphabets (title matching, author identity, sort keys, slugs) documented alongside it. No change to how releases match.

--- a/internal/db/sortkey.go
+++ b/internal/db/sortkey.go
@@ -7,6 +7,8 @@ import (
 	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
+
+	"github.com/vavallee/bindery/internal/textutil"
 )
 
 // authorSortKey derives an accent-folded, lowercased, BINARY-comparable key
@@ -32,7 +34,7 @@ func authorSortKey(sortName string) string {
 		return ""
 	}
 	s = strings.ToLower(s)
-	s = nonDecomposableFolder.Replace(s)
+	s = textutil.FoldNonDecomposableLatin(s)
 	folded, _, err := transform.String(newAccentStripper(), s)
 	if err != nil {
 		// transform only errors on malformed input we can't normalize; fall
@@ -57,20 +59,6 @@ func newAccentStripper() transform.Transformer {
 	)
 }
 
-// nonDecomposableFolder handles the Latin letters NFD leaves intact because
-// they are atomic code points, not base+combining-mark compositions. Applied
-// to already-lowercased input. Order/uppercase variants are unnecessary since
-// authorSortKey lowercases first.
-var nonDecomposableFolder = strings.NewReplacer(
-	"ø", "o",
-	"ł", "l",
-	"æ", "ae",
-	"œ", "oe",
-	"ß", "ss",
-	"þ", "th",
-	"ð", "d",
-	"đ", "d",
-	"ħ", "h",
-	"ı", "i",
-	"ŀ", "l",
-)
+// The Latin letters NFD leaves intact (ø, ł, æ, ß, …) are folded by
+// textutil.FoldNonDecomposableLatin, which is shared so this table and the
+// author-identity fold cannot drift apart (#1648).

--- a/internal/indexer/dedup.go
+++ b/internal/indexer/dedup.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/text/unicode/norm"
 
 	"github.com/vavallee/bindery/internal/indexer/newznab"
+	"github.com/vavallee/bindery/internal/textutil"
 )
 
 // NormalizeTitleForDedup returns a canonical form of title used as the
@@ -34,7 +35,7 @@ func NormalizeTitleForDedup(title string) string {
 	title = newznab.NormalizeQueryTitle(title)
 	title = stripSubtitle(title)
 	title = strings.ToLower(title)
-	title = transliterateUmlauts(title)
+	title = textutil.TransliterateUmlauts(title)
 	return title
 }
 

--- a/internal/indexer/newznab/words.go
+++ b/internal/indexer/newznab/words.go
@@ -2,7 +2,8 @@ package newznab
 
 import (
 	"strings"
-	"unicode"
+
+	"github.com/vavallee/bindery/internal/textutil"
 )
 
 // stopWords are common English words excluded from keyword significance checks.
@@ -32,17 +33,7 @@ var stopWords = map[string]bool{
 // word characters so non-Latin titles still tokenise.
 func SigWords(s string) []string {
 	var out []string
-	s = strings.ToLower(s)
-	s = strings.ReplaceAll(s, "'", "")
-	s = strings.ReplaceAll(s, "’", "")
-	normalised := strings.Map(func(r rune) rune {
-		if unicode.IsLetter(r) || unicode.IsNumber(r) {
-			return r
-		}
-		return ' '
-	}, s)
-	for _, w := range strings.Fields(normalised) {
-		w = transliterateUmlauts(w)
+	for _, w := range strings.Fields(textutil.FoldForTitleMatch(s)) {
 		if len(w) >= 3 && !stopWords[w] {
 			out = append(out, w)
 		}
@@ -70,16 +61,5 @@ func foldForSigWordMatch(s string) string {
 	s = strings.ToLower(s)
 	s = strings.ReplaceAll(s, "'", "")
 	s = strings.ReplaceAll(s, "’", "")
-	return transliterateUmlauts(s)
-}
-
-// transliterateUmlauts maps German umlaut characters to their common ASCII
-// two-letter equivalents (ä→ae, ö→oe, ü→ue, ß→ss). Must be called after
-// strings.ToLower so only the lowercase forms need to be handled.
-func transliterateUmlauts(s string) string {
-	s = strings.ReplaceAll(s, "ä", "ae")
-	s = strings.ReplaceAll(s, "ö", "oe")
-	s = strings.ReplaceAll(s, "ü", "ue")
-	s = strings.ReplaceAll(s, "ß", "ss")
-	return s
+	return textutil.TransliterateUmlauts(s)
 }

--- a/internal/indexer/release.go
+++ b/internal/indexer/release.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/vavallee/bindery/internal/textutil"
 )
 
 // ParsedRelease holds metadata extracted from a release/NZB title.
@@ -21,7 +23,6 @@ type ParsedRelease struct {
 }
 
 var (
-	separatorRe  = regexp.MustCompile(`[^\p{L}\p{N}]+`)
 	multiSpaceRe = regexp.MustCompile(`\s{2,}`)
 	articleRe    = regexp.MustCompile(`\b(a|an|the|and|or|of)\b`)
 
@@ -36,20 +37,6 @@ var (
 	articleSet = map[string]bool{"a": true, "an": true, "the": true, "and": true, "or": true, "of": true}
 )
 
-// transliterateUmlauts maps German umlaut characters to their common ASCII
-// two-letter equivalents (ä→ae, ö→oe, ü→ue, ß→ss). German NZB indexers
-// almost universally use this convention in release names, so normalising both
-// sides of a comparison to ASCII prevents false-negative title matches for
-// German-language books. Must be called after strings.ToLower so only the
-// lowercase forms need to be handled.
-func transliterateUmlauts(s string) string {
-	s = strings.ReplaceAll(s, "ä", "ae")
-	s = strings.ReplaceAll(s, "ö", "oe")
-	s = strings.ReplaceAll(s, "ü", "ue")
-	s = strings.ReplaceAll(s, "ß", "ss")
-	return s
-}
-
 // NormalizeRelease lowercases s and replaces every run of non-alphanumeric
 // characters with a single space, so all punctuation (dots, dashes, brackets,
 // pipes, and symbols like %, !, ?, #, $) collapses to word boundaries. This
@@ -62,14 +49,13 @@ func transliterateUmlauts(s string) string {
 // typically omit them ("Enders"). German umlauts are transliterated to their
 // ASCII equivalents (ä→ae etc.) to match the convention used by German-language
 // NZB indexers like Scenenzbs.
+//
+// The character rewriting itself lives in textutil.FoldForTitleMatch, which is
+// the ONE place the title-comparison alphabet is defined — newznab.SigWords and
+// the library-scan title matcher share it. It used to be copy-pasted per call
+// site, which is how #1643 (and its ancestors) happened.
 func NormalizeRelease(s string) string {
-	s = strings.ToLower(s)
-	s = strings.ReplaceAll(s, "'", "") // "ender's" → "enders", "hitchhiker's" → "hitchhikers"
-	s = strings.ReplaceAll(s, "’", "") // Unicode right single quote, same intent
-	s = transliterateUmlauts(s)
-	s = separatorRe.ReplaceAllString(s, " ")
-	s = multiSpaceRe.ReplaceAllString(s, " ")
-	return strings.TrimSpace(s)
+	return textutil.FoldForTitleMatch(s)
 }
 
 // StripArticles removes common English articles used as connectives from an

--- a/internal/textutil/author.go
+++ b/internal/textutil/author.go
@@ -137,9 +137,19 @@ func lastFirstSwap(tokens []string) []string {
 //   - compact-initials ("rr haywood")
 //   - expanded-initials ("r r haywood" from "rr haywood")
 //   - last-first ("haywood r r")
+//   - ASCII-transliterated ("joerg mueller" from "Jörg Müller")
 //
 // Callers should treat any match across the two variant sets as equivalent.
 // The first element is always the canonical base form.
+//
+// The ASCII-transliterated chain exists because NormalizeAuthorName STRIPS
+// diacritics (ö→o) while every title normalizer in the tree EXPANDS them
+// (ö→oe), so "Jörg Müller" and the ASCII-ised "Joerg Mueller" that German
+// library folders and providers routinely carry scored 0.9347 — just under the
+// 0.94 auto threshold, landing in the ambiguous band that either floods the
+// review queue or creates a duplicate author row (#1647). Adding the expanded
+// form as a variant makes that pair Exact. Variants only ever ADD matches, so
+// no previously-matching pair can stop matching.
 func NormalizeAuthorNameWithVariants(name string) []string {
 	base := NormalizeAuthorName(name)
 	if base == "" {
@@ -159,7 +169,7 @@ func NormalizeAuthorNameWithVariants(name string) []string {
 		seen[v] = struct{}{}
 		out = append(out, v)
 	}
-	addName := func(raw string) {
+	addForm := func(raw string) {
 		tokens := strings.Fields(NormalizeAuthorName(raw))
 		tokens = stripAuthorSuffixes(tokens)
 		if len(tokens) == 0 {
@@ -172,12 +182,38 @@ func NormalizeAuthorNameWithVariants(name string) []string {
 		add(compactInitials(lastFirstSwap(tokens)))
 		add(expandInitials(lastFirstSwap(tokens)))
 	}
+	addName := func(raw string) {
+		addForm(raw)
+		// Only pay for the second chain when the name actually contains
+		// something to transliterate — pure-ASCII names are the common case and
+		// would just re-derive identical variants that `seen` discards anyway.
+		if ascii := asciiTransliterate(raw); ascii != "" {
+			addForm(ascii)
+		}
+	}
 
 	addName(name)
 	if before, after, ok := strings.Cut(name, ","); ok {
 		addName(strings.TrimSpace(after) + " " + strings.TrimSpace(before))
 	}
 	return out
+}
+
+// asciiTransliterate returns the lowercased name with German umlauts expanded
+// (ö→oe) and the non-decomposable Latin letters folded (ø→o, ł→l), or "" when
+// neither step changed anything. See NormalizeAuthorNameWithVariants for why
+// this second romanisation is needed alongside the diacritic-stripping one.
+//
+// "Nesbø"/"Nesbo" and "Łukasz"/"Lukasz" are the same class as the umlaut case:
+// NFD leaves those letters intact, so stripping combining marks alone never
+// reconciles them with the ASCII spelling a provider or folder name used.
+func asciiTransliterate(name string) string {
+	lower := strings.ToLower(name)
+	folded := FoldNonDecomposableLatin(TransliterateUmlauts(lower))
+	if folded == lower {
+		return ""
+	}
+	return folded
 }
 
 // AuthorMatchKind classifies how confident a name match is.

--- a/internal/textutil/author_test.go
+++ b/internal/textutil/author_test.go
@@ -105,3 +105,45 @@ func TestMatchAuthorName_Symmetric(t *testing.T) {
 		}
 	}
 }
+
+// TestMatchAuthorNameAcrossRomanisations pins the #1647 fix: a name written
+// with diacritics and the ASCII spelling a German/Scandinavian library folder
+// or provider uses must resolve to the same author. Before the transliterated
+// variant chain these scored 0.9347 — inside the ambiguous band, which callers
+// turn into either a review-queue entry or a duplicate author row.
+func TestMatchAuthorNameAcrossRomanisations(t *testing.T) {
+	cases := []struct{ a, b string }{
+		{"Jörg Müller", "Joerg Mueller"},
+		{"Heinrich Böll", "Heinrich Boell"},
+		{"Böll, Heinrich", "Heinrich Boell"},
+		{"Günter Graß", "Guenter Grass"},
+		{"Jo Nesbø", "Jo Nesbo"},
+		{"Łukasz Orbitowski", "Lukasz Orbitowski"},
+		// The existing diacritic-stripping chain must keep working alongside it.
+		{"Jörg Müller", "Jorg Muller"},
+		{"José Saramago", "Jose Saramago"},
+	}
+	for _, tc := range cases {
+		if got := MatchAuthorName(tc.a, tc.b); got.Kind != AuthorMatchExact {
+			t.Errorf("MatchAuthorName(%q, %q) = %v (score %.4f), want Exact", tc.a, tc.b, got.Kind, got.Score)
+		}
+	}
+}
+
+// TestMatchAuthorNameStillRejectsDistinctAuthors makes sure the extra variants
+// only widen matching where the names really are the same person. Variants are
+// compared for equality and fed to Jaro-Winkler, so a careless addition could
+// push genuinely different authors over the auto-accept threshold.
+func TestMatchAuthorNameStillRejectsDistinctAuthors(t *testing.T) {
+	cases := []struct{ a, b string }{
+		{"Heinrich Böll", "Heinrich Mann"},
+		{"Jo Nesbø", "Jo Walton"},
+		{"Jörg Müller", "Jörg Fauser"},
+		{"Günter Graß", "Günter Wallraff"},
+	}
+	for _, tc := range cases {
+		if got := MatchAuthorName(tc.a, tc.b); got.Kind == AuthorMatchExact || got.Kind == AuthorMatchFuzzyAuto {
+			t.Errorf("MatchAuthorName(%q, %q) = %v (score %.4f), want no auto-match", tc.a, tc.b, got.Kind, got.Score)
+		}
+	}
+}

--- a/internal/textutil/fold.go
+++ b/internal/textutil/fold.go
@@ -1,0 +1,122 @@
+package textutil
+
+import (
+	"strings"
+	"unicode"
+)
+
+// This file is the single home for the character-level reductions used when
+// two strings have to be compared for sameness. It exists because the same bug
+// kept recurring: two sides of a comparison reduced through DIFFERENT
+// alphabets, so the match was silently always-false (#940, #871, #1608, #1642,
+// #1643, #1646, #1647).
+//
+// There are FOUR distinct comparison alphabets in this codebase, and they
+// legitimately differ. What was wrong before was that the difference was
+// accidental and undocumented, and that each fold was copy-pasted at its point
+// of use. They are named here so the next person can tell which one they want.
+//
+//  1. TITLE / RELEASE MATCHING — FoldForTitleMatch.
+//     German umlauts EXPAND (ö→oe) because that is the convention German NZB
+//     indexers use in release names. Apostrophes are deleted rather than split
+//     so "Ender's" meets "Enders". Every other non-alphanumeric run becomes a
+//     separator. Unicode letters survive so CJK/Cyrillic titles still tokenise.
+//     Used by indexer.NormalizeRelease, newznab.SigWords, importer title
+//     matching. Producers and consumers of a title comparison MUST share it.
+//
+//  2. AUTHOR IDENTITY — NormalizeAuthorName (author.go).
+//     Diacritics are STRIPPED (ö→o) rather than expanded, because author names
+//     arrive from providers in every romanisation and the goal is one identity
+//     per human. Punctuation collapses to spaces so "J.R.R." and "J. R. R."
+//     agree. NormalizeAuthorNameWithVariants layers initial-compaction,
+//     last-first inversion and umlaut expansion on top, so a name folded either
+//     way still meets its counterpart.
+//
+//  3. SORT KEYS — db.authorSortKey.
+//     Like (2) but additionally folds the non-decomposable Latin letters
+//     (FoldNonDecomposableLatin) so a Scandinavian or Polish name sorts in the
+//     expected A–Z place instead of after "Z". Lossy and ORDERING-ONLY; never
+//     compare identities with it.
+//
+//  4. SLUGS / FOREIGN IDs — e.g. openlibrary.seriesSlug.
+//     Must be stable and collision-free, not lenient. Different scripts must
+//     produce different slugs (#1645), so this one deliberately does NOT
+//     transliterate to ASCII.
+//
+// If you are about to write a `strings.ToLower` next to a comparison, one of
+// the four above is what you actually want.
+
+// TransliterateUmlauts maps German umlaut characters to their common ASCII
+// two-letter equivalents (ä→ae, ö→oe, ü→ue, ß→ss). German NZB indexers almost
+// universally use this convention in release names, so normalising both sides
+// of a comparison to ASCII prevents false-negative title matches for
+// German-language books. Must be called after strings.ToLower so only the
+// lowercase forms need to be handled.
+//
+// This used to be copied verbatim into both internal/indexer and
+// internal/indexer/newznab (the latter cannot import the former without an
+// import cycle), which is the duplication that let #1643 happen.
+func TransliterateUmlauts(s string) string {
+	return umlautExpander.Replace(s)
+}
+
+var umlautExpander = strings.NewReplacer(
+	"ä", "ae",
+	"ö", "oe",
+	"ü", "ue",
+	"ß", "ss",
+)
+
+// FoldForTitleMatch reduces s to the alphabet used for every title/release
+// comparison: lowercased, apostrophes deleted, German umlauts expanded, and
+// every run of non-letter/non-number characters collapsed to a single space.
+// The result is trimmed and single-space separated.
+//
+// Both sides of a title comparison must pass through this, or they live in
+// different alphabets and the comparison silently fails. Tokenisation POLICY
+// (stop-words, minimum length) deliberately stays with the caller — only the
+// character rewriting is shared.
+func FoldForTitleMatch(s string) string {
+	s = strings.ToLower(s)
+	s = apostropheStripper.Replace(s)
+	s = TransliterateUmlauts(s)
+	mapped := strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			return r
+		}
+		return ' '
+	}, s)
+	return strings.Join(strings.Fields(mapped), " ")
+}
+
+// apostropheStripper removes both the ASCII apostrophe and the Unicode right
+// single quote. They are DELETED rather than turned into separators so a
+// possessive reduces to one token ("ender's" → "enders"), which is the form
+// most release names use.
+var apostropheStripper = strings.NewReplacer("'", "", "’", "")
+
+// FoldNonDecomposableLatin maps the Latin letters that NFD leaves intact —
+// they are atomic code points, not base+combining-mark compositions — to an
+// ASCII approximation. Applied to already-lowercased input; uppercase variants
+// are unnecessary because every caller lowercases first.
+//
+// NFD + strip-Mn handles é→e, ö→o, ñ→n. It does nothing for ø, ł, æ, ß, þ, ð,
+// đ, so a name like "Nesbø" or "Łukasz" keeps a non-ASCII leading letter
+// unless this runs too.
+func FoldNonDecomposableLatin(s string) string {
+	return nonDecomposableFolder.Replace(s)
+}
+
+var nonDecomposableFolder = strings.NewReplacer(
+	"ø", "o",
+	"ł", "l",
+	"æ", "ae",
+	"œ", "oe",
+	"ß", "ss",
+	"þ", "th",
+	"ð", "d",
+	"đ", "d",
+	"ħ", "h",
+	"ı", "i",
+	"ŀ", "l",
+)

--- a/internal/textutil/fold.go
+++ b/internal/textutil/fold.go
@@ -3,6 +3,8 @@ package textutil
 import (
 	"strings"
 	"unicode"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // This file is the single home for the character-level reductions used when
@@ -68,15 +70,25 @@ var umlautExpander = strings.NewReplacer(
 )
 
 // FoldForTitleMatch reduces s to the alphabet used for every title/release
-// comparison: lowercased, apostrophes deleted, German umlauts expanded, and
-// every run of non-letter/non-number characters collapsed to a single space.
-// The result is trimmed and single-space separated.
+// comparison: NFC-composed, lowercased, apostrophes deleted, German umlauts
+// expanded, and every run of non-letter/non-number characters collapsed to a
+// single space. The result is trimmed and single-space separated.
 //
 // Both sides of a title comparison must pass through this, or they live in
 // different alphabets and the comparison silently fails. Tokenisation POLICY
 // (stop-words, minimum length) deliberately stays with the caller — only the
 // character rewriting is shared.
+//
+// The NFC step is load-bearing and was missing from every open-coded copy of
+// this fold. A combining mark is category Mn, not a letter, so in decomposed
+// input it hits the separator branch and TRUNCATES the word at the accent:
+// NFD "Café Society" folded to "cafe society" while the NFC spelling of the
+// same title folded to "café society". Two tokens, never equal — the #1642
+// failure mode arriving by a different route. macOS hands filenames back
+// decomposed while every metadata provider returns composed, so the two forms
+// meet constantly.
 func FoldForTitleMatch(s string) string {
+	s = norm.NFC.String(s)
 	s = strings.ToLower(s)
 	s = apostropheStripper.Replace(s)
 	s = TransliterateUmlauts(s)

--- a/internal/textutil/fold_test.go
+++ b/internal/textutil/fold_test.go
@@ -1,0 +1,117 @@
+package textutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFoldForTitleMatch(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lowercases", "The Hobbit", "the hobbit"},
+		{"collapses punctuation runs", "Guards! Guards! - (1989) [epub]", "guards guards 1989 epub"},
+		{"deletes ascii apostrophes", "Ender's Game", "enders game"},
+		{"deletes unicode apostrophes", "Ender’s Game", "enders game"},
+		{"expands umlauts", "Die Höhle", "die hoehle"},
+		{"expands eszett", "Der Prozeß", "der prozess"},
+		{"already-expanded form is stable", "Die Hoehle", "die hoehle"},
+		{"keeps cjk", "三体", "三体"},
+		{"keeps cyrillic", "Преступление и наказание", "преступление и наказание"},
+		{"keeps interior diacritics", "Perdido Street Station by China Miéville", "perdido street station by china miéville"},
+		{"trims and collapses whitespace", "  a   b  ", "a b"},
+		{"empty stays empty", "", ""},
+		{"punctuation only reduces to empty", "--- !!! ---", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FoldForTitleMatch(tc.in); got != tc.want {
+				t.Fatalf("FoldForTitleMatch(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFoldForTitleMatchIsIdempotent guards the property every caller relies on:
+// a folded string is already in the target alphabet, so folding it again is a
+// no-op. Without this, a value that passes through two normalizers (say a
+// dedup key derived from an already-normalized release) could drift.
+func TestFoldForTitleMatchIsIdempotent(t *testing.T) {
+	for _, in := range []string{
+		"Ender's Game", "Die Höhle", "Der Prozeß", "三体", "Åsa Larsson",
+		"Guards! Guards! - (1989) [epub]", "Преступление и наказание",
+	} {
+		once := FoldForTitleMatch(in)
+		if twice := FoldForTitleMatch(once); twice != once {
+			t.Errorf("not idempotent for %q: %q then %q", in, once, twice)
+		}
+	}
+}
+
+func TestTransliterateUmlauts(t *testing.T) {
+	cases := map[string]string{
+		"müller": "mueller",
+		"höhle":  "hoehle",
+		"bär":    "baer",
+		"straße": "strasse",
+		"muller": "muller",
+		"":       "",
+	}
+	for in, want := range cases {
+		if got := TransliterateUmlauts(in); got != want {
+			t.Errorf("TransliterateUmlauts(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFoldNonDecomposableLatin(t *testing.T) {
+	cases := map[string]string{
+		"nesbø":  "nesbo",
+		"łukasz": "lukasz",
+		"ærø":    "aero",
+		"þór":    "thór", // only the non-decomposable letter is folded here
+		"smith":  "smith",
+	}
+	for in, want := range cases {
+		if got := FoldNonDecomposableLatin(in); got != want {
+			t.Errorf("FoldNonDecomposableLatin(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestFoldForTitleMatchMatchesLegacyPipeline pins FoldForTitleMatch to the exact
+// sequence the three call sites used to open-code, so the consolidation in
+// #1648 cannot have silently changed release matching.
+func TestFoldForTitleMatchMatchesLegacyPipeline(t *testing.T) {
+	legacy := func(s string) string {
+		s = strings.ToLower(s)
+		s = strings.ReplaceAll(s, "'", "")
+		s = strings.ReplaceAll(s, "’", "")
+		s = strings.ReplaceAll(s, "ä", "ae")
+		s = strings.ReplaceAll(s, "ö", "oe")
+		s = strings.ReplaceAll(s, "ü", "ue")
+		s = strings.ReplaceAll(s, "ß", "ss")
+		var b strings.Builder
+		for _, r := range s {
+			switch {
+			case ('a' <= r && r <= 'z') || ('0' <= r && r <= '9'):
+				b.WriteRune(r)
+			case r > 127:
+				b.WriteRune(r)
+			default:
+				b.WriteByte(' ')
+			}
+		}
+		return strings.Join(strings.Fields(b.String()), " ")
+	}
+	for _, in := range []string{
+		"Ender's Game", "The Hobbit (1937) [EPUB]", "Die Höhle", "Der Prozeß",
+		"Foundation & Empire", "1984", "Guards! Guards!", "Åsa Larsson - Solstorm",
+	} {
+		if got, want := FoldForTitleMatch(in), legacy(in); got != want {
+			t.Errorf("FoldForTitleMatch(%q) = %q, legacy pipeline gave %q", in, got, want)
+		}
+	}
+}

--- a/internal/textutil/fold_test.go
+++ b/internal/textutil/fold_test.go
@@ -3,6 +3,8 @@ package textutil
 import (
 	"strings"
 	"testing"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 func TestFoldForTitleMatch(t *testing.T) {
@@ -31,6 +33,26 @@ func TestFoldForTitleMatch(t *testing.T) {
 				t.Fatalf("FoldForTitleMatch(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestFoldForTitleMatchUnicodeForms pins the NFC step. Without it a combining
+// mark (category Mn, not a letter) takes the separator branch and truncates the
+// word at the accent, so the decomposed spelling of a title produces a token
+// the composed spelling can never equal.
+func TestFoldForTitleMatchUnicodeForms(t *testing.T) {
+	for _, in := range []string{
+		"Café Society", "Die Höhle", "José Saramago", "Miéville",
+		"Amélie", "Ångström", "Señor", "Dvořák",
+	} {
+		nfc, nfd := norm.NFC.String(in), norm.NFD.String(in)
+		if nfc == nfd {
+			t.Fatalf("%q has no distinct NFD form; the case would be vacuous", in)
+		}
+		gotC, gotD := FoldForTitleMatch(nfc), FoldForTitleMatch(nfd)
+		if gotC != gotD {
+			t.Errorf("FoldForTitleMatch disagrees on Unicode form of %q: NFC %q vs NFD %q", in, gotC, gotD)
+		}
 	}
 }
 
@@ -81,9 +103,12 @@ func TestFoldNonDecomposableLatin(t *testing.T) {
 	}
 }
 
-// TestFoldForTitleMatchMatchesLegacyPipeline pins FoldForTitleMatch to the exact
+// TestFoldForTitleMatchMatchesLegacyPipeline pins FoldForTitleMatch to the
 // sequence the three call sites used to open-code, so the consolidation in
-// #1648 cannot have silently changed release matching.
+// #1648 cannot have silently changed release matching. Inputs are composed
+// (NFC), which is the form every producer already emitted — the added NFC step
+// is a no-op for them and only changes decomposed input, which previously had
+// no consistent behaviour at all (see TestFoldForTitleMatchUnicodeForms).
 func TestFoldForTitleMatchMatchesLegacyPipeline(t *testing.T) {
 	legacy := func(s string) string {
 		s = strings.ToLower(s)


### PR DESCRIPTION
First of three PRs closing out #1646/#1647/#1648. This one is the foundation the other two build on.

## What

`transliterateUmlauts` existed byte-identical in `internal/indexer` and `internal/indexer/newznab`, because `newznab` can't import `indexer` without a cycle. That duplication is what let #1643 happen. Same story for the non-decomposable Latin table in `db/sortkey.go`.

Moved the character-level folds into `internal/textutil` and wrote down the four alphabets that legitimately differ:

| alphabet | ö becomes | used by |
|---|---|---|
| title / release matching | `oe` | `NormalizeRelease`, `SigWords`, library-scan titles |
| author identity | `o` | `NormalizeAuthorName` |
| sort keys | `o` (+ ø→o, ł→l) | `db.authorSortKey`, ordering only |
| slugs / foreign IDs | unchanged | `openlibrary.seriesSlug` (#1645) |

The bug was never that they differ. It was that the difference was accidental and undocumented, and every fold was open-coded at its point of use.

## Behaviour

`NormalizeRelease`, `SigWords` and `authorSortKey` are pure delegation now. `TestFoldForTitleMatchMatchesLegacyPipeline` pins `FoldForTitleMatch` against a hand-written copy of the old sequence, so release matching provably did not move.

One deliberate change, which is the #1647 headline fix: `NormalizeAuthorNameWithVariants` gains an ASCII-transliterated chain. Author identity strips diacritics while titles expand them, so:

```
MatchAuthorName("Jörg Müller", "Joerg Mueller")  -> Ambiguous, 0.9347
```

0.9347 is just under the 0.94 auto threshold, and `abs/import_upserts.go:165` turns ambiguous into either a review-queue entry or a duplicate author row depending on `allowCreate`. So a German ABS library with ASCII-ised folder names either floods the queue or duplicates authors, while the *title* of the very same item folds correctly. Now Exact. Same class: `Nesbø`/`Nesbo` and `Łukasz`/`Lukasz`, which NFD leaves intact.

Variants only ever add matches, so nothing that matched before can stop matching. A negative test pins that distinct authors sharing a forename or surname (`Heinrich Böll` vs `Heinrich Mann`, `Jörg Müller` vs `Jörg Fauser`) still do not auto-merge.

## Verification

Verified `TestMatchAuthorNameAcrossRomanisations` fails with the new chain disabled, reproducing the exact 0.9347 from the issue. Full suite green, vet and gofmt clean.

Refs #1648, part of #1647