### PR TITLE
test(normdrift): assert the normalization alphabets against each other (#1648)

### DIFF
--- a/changelog.d/1648-drift-test-and-consolidation.md
+++ b/changelog.d/1648-drift-test-and-consolidation.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Accented titles no longer produce two different indexer searches** (#1648) — the same title could be sent to indexers in two different encodings depending on where it came from, which also gave it two different deduplication keys. Found by the new consistency test, not by a bug report.
+- **Books stored with a format tag in the title stop getting a duplicate row** (#1648) — a book saved as "Title [Unabridged]" was not recognised as the same work as OpenLibrary's "Title", so an author sync created a second row for it.
+- **Series named "... Series" or tagged "[Audiobook]" can be upgraded to full Hardcover data** (#1648) — the lookup and the upgrade check disagreed about what counts as the same series name, so some series matched one and failed the other.
+
+### Changed
+- **Author name handling is defined in one place** (#1648) — several helpers that build author search queries and sort names existed as identical copies in four packages. They now live in one, and a new test suite compares every normalization rule in the codebase against a corpus of awkward names and titles (dotted initials, possessives, umlauts, Nordic and Polish letters, CJK, Cyrillic, Greek, Hebrew) so that two of them disagreeing is a build failure rather than a bug report months later.

--- a/internal/abs/import_author_matcher.go
+++ b/internal/abs/import_author_matcher.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"strings"
-	"unicode"
 
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
@@ -595,67 +594,9 @@ func authorSearchWorkCount(author models.Author) int {
 	return author.Statistics.BookCount
 }
 
+// authorSearchQueries delegates to textutil, which owns this expansion. It and
+// the three helpers it used were byte-identical to the copies in internal/api
+// (#1648).
 func authorSearchQueries(name string) []string {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return nil
-	}
-	queries := []string{name}
-	if compact := compactInitialsAuthorQuery(name); compact != "" {
-		queries = append(queries, compact)
-	}
-	if norm := normalizeAuthorName(name); norm != "" {
-		queries = append(queries, norm)
-		if surname := initialedSurnameFallback(norm); surname != "" {
-			queries = append(queries, surname)
-		}
-	}
-	return dedupeStrings(queries)
-}
-
-func compactInitialsAuthorQuery(name string) string {
-	fields := strings.Fields(name)
-	if len(fields) < 3 {
-		return ""
-	}
-	initials := make([]string, 0, len(fields)-1)
-	idx := 0
-	for idx < len(fields)-1 {
-		initial, ok := authorInitial(fields[idx])
-		if !ok {
-			break
-		}
-		initials = append(initials, strings.ToUpper(initial)+".")
-		idx++
-	}
-	if len(initials) < 2 || idx >= len(fields) {
-		return ""
-	}
-	return strings.Join(initials, "") + " " + strings.Join(fields[idx:], " ")
-}
-
-func authorInitial(token string) (string, bool) {
-	var letters []rune
-	for _, r := range token {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			letters = append(letters, unicode.ToLower(r))
-		}
-	}
-	if len(letters) != 1 {
-		return "", false
-	}
-	return string(letters[0]), true
-}
-
-func initialedSurnameFallback(normalized string) string {
-	fields := strings.Fields(normalized)
-	if len(fields) < 2 {
-		return ""
-	}
-	for _, field := range fields[:len(fields)-1] {
-		if len([]rune(field)) != 1 {
-			return ""
-		}
-	}
-	return fields[len(fields)-1]
+	return textutil.AuthorSearchQueries(name)
 }

--- a/internal/abs/import_utils.go
+++ b/internal/abs/import_utils.go
@@ -205,13 +205,7 @@ func itemFileIDs(item NormalizedLibraryItem) []string {
 }
 
 func sortNameFromFull(name string) string {
-	fields := strings.Fields(name)
-	if len(fields) < 2 {
-		return name
-	}
-	last := fields[len(fields)-1]
-	rest := strings.Join(fields[:len(fields)-1], " ")
-	return last + ", " + rest
+	return textutil.SortName(name)
 }
 
 func firstNonEmpty(values ...string) string {

--- a/internal/abs/import_utils.go
+++ b/internal/abs/import_utils.go
@@ -116,24 +116,6 @@ func cleanStrings(values []string) []string {
 	return out
 }
 
-func dedupeStrings(values []string) []string {
-	out := make([]string, 0, len(values))
-	seen := make(map[string]struct{}, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		key := strings.ToLower(value)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		out = append(out, value)
-	}
-	return out
-}
-
 func normalizeLibraryIDs(primary string, values []string) []string {
 	primary = strings.TrimSpace(primary)
 	out := make([]string, 0, len(values)+1)

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/go-chi/chi/v5"
 
@@ -1528,9 +1527,16 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 	// The value is a pointer to the existing book so we can enrich calibre-imported
 	// stubs with the OL foreign ID and language when they title-match an OL record.
 	existingBooks, _ := h.books.ListByAuthor(ctx, author.ID)
+	// CanonicalDedupKey, not NormalizeTitleForDedup: this map decides whether a
+	// provider work becomes a NEW book row, which is exactly the #940 invariant
+	// that CanonicalDedupKey exists to be the single authority for. The two
+	// differ by StripBracketSuffixes, so an ABS-sourced row stored as
+	// "X [Unabridged]" did not match OpenLibrary's "X" here — a second row was
+	// created, and both then carried the same books.dedup_key, violating the
+	// invariant from the inside (#1648).
 	seenTitles := make(map[string]*models.Book)
 	for i := range existingBooks {
-		seenTitles[indexer.NormalizeTitleForDedup(existingBooks[i].Title)] = &existingBooks[i]
+		seenTitles[indexer.CanonicalDedupKey(existingBooks[i].Title)] = &existingBooks[i]
 	}
 
 	normalizedAuthor := strings.ToLower(strings.TrimSpace(author.Name))
@@ -1699,7 +1705,7 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 		//     behaviour — preserves the pre-#442 upgrade path).
 		//   • A duplicate that carries the same media_type as the existing row is
 		//     truly redundant and is silently skipped (no format gain).
-		dedupKey := indexer.NormalizeTitleForDedup(b.Title)
+		dedupKey := indexer.CanonicalDedupKey(b.Title) // must match how seenTitles was keyed
 		if existing := seenTitles[dedupKey]; existing != nil {
 			hydrateExistingFromMatchedHardcover := false
 			switch {
@@ -2080,69 +2086,11 @@ func (h *AuthorHandler) lookupUpstreamAuthorByName(ctx context.Context, name str
 	return full, nil
 }
 
+// authorSearchQueries delegates to textutil, which owns this expansion. It and
+// the three helpers it used were byte-identical to the copies in internal/abs
+// (#1648).
 func authorSearchQueries(name string) []string {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return nil
-	}
-	queries := []string{name}
-	if compact := compactInitialsAuthorQuery(name); compact != "" {
-		queries = append(queries, compact)
-	}
-	if norm := textutil.NormalizeAuthorName(name); norm != "" {
-		queries = append(queries, norm)
-		if surname := initialedSurnameFallback(norm); surname != "" {
-			queries = append(queries, surname)
-		}
-	}
-	return dedupeAuthorQueries(queries)
-}
-
-func compactInitialsAuthorQuery(name string) string {
-	fields := strings.Fields(name)
-	if len(fields) < 3 {
-		return ""
-	}
-	initials := make([]string, 0, len(fields)-1)
-	idx := 0
-	for idx < len(fields)-1 {
-		initial, ok := authorInitial(fields[idx])
-		if !ok {
-			break
-		}
-		initials = append(initials, strings.ToUpper(initial)+".")
-		idx++
-	}
-	if len(initials) < 2 || idx >= len(fields) {
-		return ""
-	}
-	return strings.Join(initials, "") + " " + strings.Join(fields[idx:], " ")
-}
-
-func authorInitial(token string) (string, bool) {
-	var letters []rune
-	for _, r := range token {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			letters = append(letters, unicode.ToLower(r))
-		}
-	}
-	if len(letters) != 1 {
-		return "", false
-	}
-	return string(letters[0]), true
-}
-
-func initialedSurnameFallback(normalized string) string {
-	fields := strings.Fields(normalized)
-	if len(fields) < 2 {
-		return ""
-	}
-	for _, field := range fields[:len(fields)-1] {
-		if len([]rune(field)) != 1 {
-			return ""
-		}
-	}
-	return fields[len(fields)-1]
+	return textutil.AuthorSearchQueries(name)
 }
 
 func dedupeAuthorQueries(values []string) []string {

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -2093,24 +2093,6 @@ func authorSearchQueries(name string) []string {
 	return textutil.AuthorSearchQueries(name)
 }
 
-func dedupeAuthorQueries(values []string) []string {
-	out := make([]string, 0, len(values))
-	seen := make(map[string]struct{}, len(values))
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		key := strings.ToLower(value)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		out = append(out, value)
-	}
-	return out
-}
-
 // AddBook adds a single book to the wanted list by its metadata foreign ID.
 // If the author is not yet in Bindery it is added as unmonitored and its
 // books are fetched in the background; the endpoint then polls until the

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/textutil"
 )
 
 // BookSearcher triggers an immediate indexer search and auto-grab for a
@@ -70,11 +71,5 @@ func parseLimitOffset(r *http.Request, defaultLimit, maxLimit int) (int, int) {
 }
 
 func sortName(name string) string {
-	parts := strings.Fields(name)
-	if len(parts) < 2 {
-		return name
-	}
-	last := parts[len(parts)-1]
-	rest := strings.Join(parts[:len(parts)-1], " ")
-	return last + ", " + rest
+	return textutil.SortName(name)
 }

--- a/internal/db/sortkey_test.go
+++ b/internal/db/sortkey_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -152,4 +154,23 @@ func TestAuthorSortKey_ConcurrentUse(t *testing.T) {
 		}(g)
 	}
 	wg.Wait()
+}
+
+// TestAuthorSortKeyUnicodeFormInvariant is the unexported-normalizer half of
+// the drift suite in internal/normdrift, which can only reach exported folds.
+// A sort key that depends on Unicode form would order the two spellings of one
+// name into different places in the A–Z list.
+func TestAuthorSortKeyUnicodeFormInvariant(t *testing.T) {
+	for _, in := range []string{
+		"Östergaard, Anne", "Miéville, China", "Böll, Heinrich",
+		"Larsson, Åsa", "Saramago, José", "Dvořák, Antonín",
+	} {
+		nfc, nfd := norm.NFC.String(in), norm.NFD.String(in)
+		if nfc == nfd {
+			t.Fatalf("%q has no distinct NFD form; the case would be vacuous", in)
+		}
+		if got, want := authorSortKey(nfd), authorSortKey(nfc); got != want {
+			t.Errorf("authorSortKey is not Unicode-form invariant for %q: NFD %q vs NFC %q", in, got, want)
+		}
+	}
 }

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -20,6 +20,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/useragent"
 )
@@ -354,7 +356,14 @@ var parenSuffixRe = regexp.MustCompile(`\s*\([^)]*\)\s*$`)
 // and collapsed, and a single trailing parenthesised qualifier is removed.
 // Called by primaryTitleForQuery and exported so ingestion paths can use
 // the same normalization for title-based deduplication.
+//
+// Unicode form is composed first, which is the same class of "incidental
+// difference" this function already exists to strip: macOS-sourced titles
+// arrive decomposed while providers return composed, so the two spellings of
+// one accented title produced two different indexer queries and two different
+// dedup keys. Found by the drift test in internal/normdrift (#1648).
 func NormalizeQueryTitle(title string) string {
+	title = norm.NFC.String(title)
 	title = strings.NewReplacer(
 		"\u2018", "'", "\u2019", "'",
 		"\u201C", `"`, "\u201D", `"`,

--- a/internal/indexer/release.go
+++ b/internal/indexer/release.go
@@ -197,6 +197,19 @@ func ParseRelease(title string) ParsedRelease {
 
 // AuthorSurname returns the last whitespace-separated token of author,
 // lowercased. Returns "" for empty input.
+//
+// It deliberately does NOT go through NormalizeRelease, unlike its neighbour
+// authorTokens (#1609). Its only consumer is the latin-alias gate in
+// filterRelevant, which asks "is this surname non-ASCII, so should I also try
+// romanised aliases?". Transliteration would answer that question wrongly in
+// the direction that LOSES matches: "Böll" folds to the ASCII "boell", which
+// would close the gate and stop trying a German author's latin aliases
+// altogether. Answering with the raw form only ever opens the gate wider, and
+// the gate only ever ADDS candidate token sets.
+//
+// So the inconsistency with authorTokens is real and intended. Do not "fix" it
+// without moving the gate's ASCII test somewhere it can widen instead of
+// narrow.
 func AuthorSurname(author string) string {
 	fields := strings.Fields(author)
 	if len(fields) == 0 {

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vavallee/bindery/internal/isbnutil"
 	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/textutil"
 	"github.com/vavallee/bindery/internal/useragent"
 )
 
@@ -1388,13 +1389,7 @@ func positiveIntPtr(value *int) *int {
 }
 
 func sortName(name string) string {
-	parts := strings.Fields(name)
-	if len(parts) < 2 {
-		return name
-	}
-	last := parts[len(parts)-1]
-	rest := strings.Join(parts[:len(parts)-1], " ")
-	return last + ", " + rest
+	return textutil.SortName(name)
 }
 
 func hardcoverNumericID(value string) (int, bool) {

--- a/internal/metadata/openlibrary/client.go
+++ b/internal/metadata/openlibrary/client.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/textutil"
 	"github.com/vavallee/bindery/internal/useragent"
 )
 
@@ -825,13 +826,7 @@ func extractText(v interface{}) string {
 }
 
 func sortName(name string) string {
-	parts := strings.Fields(name)
-	if len(parts) < 2 {
-		return name
-	}
-	last := parts[len(parts)-1]
-	rest := strings.Join(parts[:len(parts)-1], " ")
-	return last + ", " + rest
+	return textutil.SortName(name)
 }
 
 func first(s []string) string {

--- a/internal/metadata/openlibrary/series_slug_drift_test.go
+++ b/internal/metadata/openlibrary/series_slug_drift_test.go
@@ -1,0 +1,41 @@
+package openlibrary
+
+import (
+	"testing"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+// TestSeriesSlugUnicodeFormInvariant is the unexported-normalizer half of the
+// drift suite in internal/normdrift, which can only reach exported folds. The
+// slug is a FOREIGN ID: a slug that depends on Unicode form would create two
+// series rows for one series, the inverse of #1645's collapse.
+func TestSeriesSlugUnicodeFormInvariant(t *testing.T) {
+	for _, in := range []string{
+		"Die Höhle", "Les Misérables", "Ångström Chronicles", "Dvořák Cycle",
+	} {
+		nfc, nfd := norm.NFC.String(in), norm.NFD.String(in)
+		if nfc == nfd {
+			t.Fatalf("%q has no distinct NFD form; the case would be vacuous", in)
+		}
+		if got, want := seriesSlug(nfd), seriesSlug(nfc); got != want {
+			t.Errorf("seriesSlug is not Unicode-form invariant for %q: NFD %q vs NFC %q", in, got, want)
+		}
+	}
+}
+
+// TestSeriesSlugKeepsScriptsDistinct re-pins #1645 alongside it.
+func TestSeriesSlugKeepsScriptsDistinct(t *testing.T) {
+	seen := map[string]string{}
+	for _, in := range []string{"三体", "黑暗森林", "Преступление", "Наказание", "The Expanse"} {
+		slug := seriesSlug(in)
+		if slug == "" {
+			t.Errorf("seriesSlug(%q) = \"\" — every series in that script would share one row", in)
+			continue
+		}
+		if prev, dup := seen[slug]; dup {
+			t.Errorf("seriesSlug collapsed %q and %q onto %q", prev, in, slug)
+		}
+		seen[slug] = in
+	}
+}

--- a/internal/normdrift/doc.go
+++ b/internal/normdrift/doc.go
@@ -1,0 +1,12 @@
+// Package normdrift holds no production code. It exists so one test file can
+// import every package that owns a normalization alphabet at once, and assert
+// the relationships BETWEEN them.
+//
+// Every bug in the #940 / #871 / #1608 / #1642-#1647 family is the same shape:
+// two sides of a string comparison reduced through different alphabets, so the
+// match is silently always-false. Each one was found by hand, months apart,
+// after users reported the symptom. The properties asserted next door are the
+// cheapest thing that would have caught most of them automatically.
+//
+// The normalizers themselves are documented in internal/textutil/fold.go.
+package normdrift

--- a/internal/normdrift/normdrift_test.go
+++ b/internal/normdrift/normdrift_test.go
@@ -1,0 +1,300 @@
+package normdrift
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/vavallee/bindery/internal/indexer"
+	"github.com/vavallee/bindery/internal/indexer/newznab"
+	"github.com/vavallee/bindery/internal/seriesmatch"
+	"github.com/vavallee/bindery/internal/textutil"
+)
+
+// adversarialTitles is the input corpus. Every entry is here because some
+// normalizer in this codebase has, at some point, silently destroyed it.
+var adversarialTitles = []string{
+	// Possessives — #1643, #871.
+	"Ender's Game",
+	"Ender’s Game",
+	"The Hitchhiker's Guide to the Galaxy",
+	// Punctuation that a release name drops.
+	"Guards! Guards!",
+	"Eat That Frog!",
+	"Foundation & Empire",
+	"Who Goes There?",
+	"Star Wars: A New Hope",
+	"Nineteen Eighty-Four",
+	// German — the one script that accidentally worked before #1642.
+	"Die Höhle",
+	"Die Hoehle",
+	"Der Prozeß",
+	"Der Prozess",
+	"Fräulein Smillas Gespür für Schnee",
+	"Geräusch",
+	// Edge-position diacritics: the exact shape #1642 could never match.
+	"Åsa Larsson",
+	"José Saramago",
+	"Jo Nesbø",
+	"Łukasz Orbitowski",
+	"Ångström",
+	// Interior diacritics, which always worked — kept so a fix that breaks
+	// them is loud.
+	"Perdido Street Station",
+	"China Miéville",
+	"Stanisław Lem",
+	"Dvořák",
+	// Non-Latin scripts — #1642, #1645.
+	"三体",
+	"刘慈欣",
+	"村上春樹",
+	"Преступление и наказание",
+	"Ο Άρχοντας των Δαχτυλιδιών",
+	"עם הרוח",
+	// Numerals and single tokens.
+	"1984",
+	"2001",
+	"Circle",
+	// Bracketed and parenthesised qualifiers.
+	"The Eye of the World [Unabridged]",
+	"The Hobbit (German Edition)",
+}
+
+// adversarialAuthors is the same idea for the author-identity alphabet.
+var adversarialAuthors = []string{
+	"J. R. R. Tolkien",
+	"J.R.R. Tolkien",
+	"Tolkien, J.R.R.",
+	"George R. R. Martin",
+	"George R.R. Martin",
+	"Mary-Kate Olsen",
+	"Ursula K. Le Guin",
+	"John Smith Jr.",
+	"Heinrich Böll",
+	"Heinrich Boell",
+	"Jörg Müller",
+	"Joerg Mueller",
+	"Björn Andersen",
+	"Jo Nesbø",
+	"Østergaard, Anne",
+	"刘慈欣",
+	"村上春樹",
+	"Фёдор Достоевский",
+	"Plato",
+}
+
+// stringFolds is every exported normalizer that maps a string to a comparison
+// key. Adding one here is how you opt it into the properties below.
+var stringFolds = []struct {
+	name string
+	fn   func(string) string
+}{
+	{"textutil.FoldForTitleMatch", textutil.FoldForTitleMatch},
+	{"textutil.NormalizeAuthorName", textutil.NormalizeAuthorName},
+	{"indexer.NormalizeRelease", indexer.NormalizeRelease},
+	{"indexer.NormalizeTitleForDedup", indexer.NormalizeTitleForDedup},
+	{"indexer.CanonicalDedupKey", indexer.CanonicalDedupKey},
+	{"seriesmatch.NormalizeSeriesName", seriesmatch.NormalizeSeriesName},
+	{"newznab.NormalizeQueryTitle", newznab.NormalizeQueryTitle},
+}
+
+// TestNormalizersAgreeAcrossUnicodeForm is the single most valuable property
+// here. macOS hands filenames back DECOMPOSED while every metadata provider
+// returns COMPOSED, so the two spellings of an accented name meet constantly.
+// A normalizer that treats them differently produces two keys for one thing,
+// and the comparison that uses it silently never matches.
+//
+// This is what broke the importer (#1646), Calibre author resolution and
+// metadata enrichment (#1647), and — via a combining mark hitting the
+// separator branch and truncating the word at the accent — the shared title
+// fold itself.
+func TestNormalizersAgreeAcrossUnicodeForm(t *testing.T) {
+	inputs := append(append([]string{}, adversarialTitles...), adversarialAuthors...)
+	for _, fold := range stringFolds {
+		for _, in := range inputs {
+			nfc, nfd := norm.NFC.String(in), norm.NFD.String(in)
+			if nfc == nfd {
+				continue // no decomposed form; nothing to disagree about
+			}
+			gotC, gotD := fold.fn(nfc), fold.fn(nfd)
+			if gotC != gotD {
+				t.Errorf("%s is not Unicode-form invariant for %q:\n  NFC -> %q\n  NFD -> %q",
+					fold.name, in, gotC, gotD)
+			}
+		}
+	}
+}
+
+// TestNormalizersAreIdempotent catches folds that are not fixed points. Keys
+// routinely pass through a second normalizer (a dedup key built from an
+// already-normalized release, a series name built from a dedup key), and a
+// fold that keeps changing its own output makes those chains order-dependent.
+func TestNormalizersAreIdempotent(t *testing.T) {
+	inputs := append(append([]string{}, adversarialTitles...), adversarialAuthors...)
+	for _, fold := range stringFolds {
+		for _, in := range inputs {
+			once := fold.fn(in)
+			if twice := fold.fn(once); twice != once {
+				t.Errorf("%s is not idempotent for %q:\n  once  -> %q\n  twice -> %q",
+					fold.name, in, once, twice)
+			}
+		}
+	}
+}
+
+// TestEveryKeywordIsFindableInItsOwnHaystack is the property that would have
+// caught #1642 AND #1643 on the day each was written, without anyone knowing
+// to look for them.
+//
+// SigWords produces the keywords; NormalizeRelease produces the haystack they
+// are matched against; WordBoundaryRegex does the matching. Feeding one title
+// through BOTH sides must therefore always match — a keyword that cannot be
+// found in the normalization of the very string it came from is, by
+// definition, a keyword no release can ever satisfy.
+//
+// #1642: keywords with a non-ASCII edge rune compiled to a regex matching
+// nothing, because RE2's `\b` is ASCII-only while NormalizeRelease preserves
+// \p{L}. #1643: the haystack was merely lowercased, so the apostrophe-stripped
+// keyword "enders" was absent from "ender's game".
+func TestEveryKeywordIsFindableInItsOwnHaystack(t *testing.T) {
+	for _, title := range adversarialTitles {
+		haystack := indexer.NormalizeRelease(title)
+		for _, kw := range newznab.SigWords(title) {
+			if !indexer.WordBoundaryRegex(kw).MatchString(haystack) {
+				t.Errorf("keyword %q from %q is unfindable in its own haystack %q",
+					kw, title, haystack)
+			}
+		}
+	}
+}
+
+// TestAuthorTokensAreFindableInTheirOwnRelease is the author-side twin, and is
+// the property #1608/#1609 violated: "J.R.R. Tolkien" produced the token
+// "j.r.r", which cannot occur in a NormalizeRelease haystack because dots
+// collapse to spaces there.
+func TestAuthorTokensAreFindableInTheirOwnRelease(t *testing.T) {
+	for _, author := range adversarialAuthors {
+		haystack := indexer.NormalizeRelease(author)
+		for _, tok := range strings.Fields(haystack) {
+			if len(tok) < 3 {
+				continue // initials are dropped as optional
+			}
+			if !indexer.WordBoundaryRegex(tok).MatchString(haystack) {
+				t.Errorf("author token %q from %q is unfindable in its own release form %q",
+					tok, author, haystack)
+			}
+		}
+	}
+}
+
+// TestSeriesNameFoldSubsumesDedupKey pins the subset relation ABS depends on:
+// series are LOOKED UP by CanonicalDedupKey and PROMOTED by
+// NormalizeSeriesName. If promotion is not at least as lenient as lookup, a
+// series can match on lookup and then be refused the promotion check that
+// exists for it — which is what "The Expanse [Audiobook]" did (#1648).
+func TestSeriesNameFoldSubsumesDedupKey(t *testing.T) {
+	names := []string{
+		"The Expanse", "The Expanse Series", "The Expanse [Audiobook]",
+		"The Expanse [Unabridged]", "Discworld", "Discworld Series",
+		"Die Höhle", "Die Hoehle", "三体", "Преступление",
+	}
+	for i, a := range names {
+		for _, b := range names[i+1:] {
+			if indexer.CanonicalDedupKey(a) != indexer.CanonicalDedupKey(b) {
+				continue
+			}
+			if seriesmatch.NormalizeSeriesName(a) != seriesmatch.NormalizeSeriesName(b) {
+				t.Errorf("%q and %q share a dedup key (%q) but not a series key (%q vs %q) — "+
+					"they would match on lookup and then be refused promotion",
+					a, b, indexer.CanonicalDedupKey(a),
+					seriesmatch.NormalizeSeriesName(a), seriesmatch.NormalizeSeriesName(b))
+			}
+		}
+	}
+}
+
+// TestAuthorMatchIsReflexiveAndSymmetric guards the tiered matcher's basic
+// algebra. A name that does not match itself would make every caller create
+// duplicates; asymmetry would make the result depend on argument order, which
+// differs between call sites.
+func TestAuthorMatchIsReflexiveAndSymmetric(t *testing.T) {
+	for _, a := range adversarialAuthors {
+		if got := textutil.MatchAuthorName(a, a); got.Kind != textutil.AuthorMatchExact {
+			t.Errorf("MatchAuthorName(%q, %q) = %v, want Exact", a, a, got.Kind)
+		}
+		if got := textutil.MatchAuthorName(a, norm.NFD.String(a)); got.Kind != textutil.AuthorMatchExact {
+			t.Errorf("MatchAuthorName(%q, NFD of itself) = %v, want Exact", a, got.Kind)
+		}
+		for _, b := range adversarialAuthors {
+			ab := textutil.MatchAuthorName(a, b)
+			ba := textutil.MatchAuthorName(b, a)
+			if ab.Kind != ba.Kind {
+				t.Errorf("MatchAuthorName is asymmetric for %q / %q: %v vs %v", a, b, ab.Kind, ba.Kind)
+			}
+		}
+	}
+}
+
+// TestDiacriticSchemesAreTheDocumentedOnes makes the deliberate divergence
+// LOUD. The four alphabets differ on purpose (see internal/textutil/fold.go) —
+// the bug was always that the difference was undocumented and unnoticed. If
+// you are changing one of these, you are changing what "the same book" or "the
+// same person" means, and you should have to say so here.
+func TestDiacriticSchemesAreTheDocumentedOnes(t *testing.T) {
+	cases := []struct {
+		fold string
+		fn   func(string) string
+		in   string
+		want string
+	}{
+		// Title/release matching EXPANDS German umlauts (the NZB convention).
+		{"FoldForTitleMatch", textutil.FoldForTitleMatch, "Höhle", "hoehle"},
+		{"NormalizeRelease", indexer.NormalizeRelease, "Höhle", "hoehle"},
+		{"CanonicalDedupKey", indexer.CanonicalDedupKey, "Höhle", "hoehle"},
+		// ...but leaves other diacritics alone, so scripts stay distinct.
+		{"FoldForTitleMatch", textutil.FoldForTitleMatch, "Miéville", "miéville"},
+		{"NormalizeRelease", indexer.NormalizeRelease, "Nesbø", "nesbø"},
+		// Author identity STRIPS diacritics instead.
+		{"NormalizeAuthorName", textutil.NormalizeAuthorName, "Höhle", "hohle"},
+		{"NormalizeAuthorName", textutil.NormalizeAuthorName, "Miéville", "mieville"},
+		// Author identity also collapses punctuation to token boundaries,
+		// which is what makes dotted initials work.
+		{"NormalizeAuthorName", textutil.NormalizeAuthorName, "J.R.R. Tolkien", "j r r tolkien"},
+	}
+	for _, tc := range cases {
+		if got := tc.fn(tc.in); got != tc.want {
+			t.Errorf("%s(%q) = %q, want %q — if this change is intended, update "+
+				"internal/textutil/fold.go and say which comparisons it moves",
+				tc.fold, tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestNonLatinScriptsKeepDistinctKeys pins #1645 from the other side: a fold
+// used for identity must not collapse different works or people into one key
+// just because it cannot romanise them.
+func TestNonLatinScriptsKeepDistinctKeys(t *testing.T) {
+	groups := [][]string{
+		{"三体", "黑暗森林", "死神永生"},
+		{"刘慈欣", "村上春樹", "遠藤周作"},
+		{"Преступление", "Наказание", "Идиот"},
+	}
+	for _, fold := range stringFolds {
+		for _, group := range groups {
+			seen := make(map[string]string, len(group))
+			for _, in := range group {
+				key := fold.fn(in)
+				if key == "" {
+					t.Errorf("%s(%q) = \"\" — a non-Latin string reduced to nothing, "+
+						"so every string in its script now shares one key", fold.name, in)
+					continue
+				}
+				if prev, dup := seen[key]; dup {
+					t.Errorf("%s collapsed %q and %q onto the same key %q", fold.name, prev, in, key)
+				}
+				seen[key] = in
+			}
+		}
+	}
+}

--- a/internal/seriesmatch/match.go
+++ b/internal/seriesmatch/match.go
@@ -27,8 +27,20 @@ func SamePosition(a, b string) bool {
 	return aerr == nil && berr == nil && math.Abs(af-bf) < 0.001
 }
 
+// NormalizeSeriesName reduces a series name for comparison: the canonical
+// dedup key, minus a redundant trailing collective noun ("… Series", "…
+// Trilogy").
+//
+// It builds on CanonicalDedupKey rather than NormalizeTitleForDedup so that it
+// is a strict WIDENING of the key ABS uses to LOOK UP an existing series
+// (findSeriesByTitle → normalizeTitle → CanonicalDedupKey). The two differ by
+// StripBracketSuffixes, and before #1648 neither was a subset of the other, so
+// both directions leaked: "The Expanse Series" never reached the promotion
+// check it exists for, while "The Expanse [Audiobook]" matched on lookup and
+// was then refused promotion. Widening keeps the implication that matters —
+// if a series matched on lookup, it can still be promoted.
 func NormalizeSeriesName(name string) string {
-	normalized := indexer.NormalizeTitleForDedup(strings.TrimSpace(name))
+	normalized := indexer.CanonicalDedupKey(strings.TrimSpace(name))
 	if normalized == "" {
 		return ""
 	}

--- a/internal/textutil/authorquery.go
+++ b/internal/textutil/authorquery.go
@@ -1,0 +1,131 @@
+package textutil
+
+import (
+	"strings"
+	"unicode"
+)
+
+// The helpers below were byte-identical copies in internal/abs
+// (import_author_matcher.go) and internal/api (authors.go), differing only in
+// which dedupe wrapper they called. Two copies of a matching rule is how the
+// rules drift, which is the whole subject of #1648 — so they live here now and
+// both packages delegate.
+
+// SortName converts a display name to "Last, First Middle" sort form, leaving
+// single-token names untouched. It was copied into internal/api,
+// internal/abs, openlibrary and hardcover; all four were identical.
+//
+// Deliberately naive: it flips on the last whitespace-separated token and does
+// no particle handling ("van", "de", "von") or script awareness. That is fine
+// for a DISPLAY and ordering value — do not compare identities with it. Author
+// identity comparison is MatchAuthorName; ordering is db.authorSortKey.
+func SortName(name string) string {
+	parts := strings.Fields(name)
+	if len(parts) < 2 {
+		return name
+	}
+	last := parts[len(parts)-1]
+	rest := strings.Join(parts[:len(parts)-1], " ")
+	return last + ", " + rest
+}
+
+// AuthorSearchQueries expands an author name into the provider query strings
+// worth trying, most specific first: the name verbatim, a compact-initials form
+// ("J.R.R. Tolkien" from "J. R. R. Tolkien"), the normalized form, and — when
+// everything but the last token is a single letter — the bare surname.
+// Duplicates are removed case-insensitively, preserving order.
+func AuthorSearchQueries(name string) []string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	queries := []string{name}
+	if compact := CompactInitialsAuthorQuery(name); compact != "" {
+		queries = append(queries, compact)
+	}
+	if norm := NormalizeAuthorName(name); norm != "" {
+		queries = append(queries, norm)
+		if surname := InitialedSurnameFallback(norm); surname != "" {
+			queries = append(queries, surname)
+		}
+	}
+	return dedupeFold(queries)
+}
+
+// CompactInitialsAuthorQuery collapses a leading run of two or more single-
+// letter tokens into the compact form providers often index under:
+// "George R. R. Martin" → "G.R.R. Martin" is NOT produced (the run must start
+// at the first token), but "J. R. R. Tolkien" → "J.R.R. Tolkien" is. Returns
+// "" when the name has no such run.
+func CompactInitialsAuthorQuery(name string) string {
+	fields := strings.Fields(name)
+	if len(fields) < 3 {
+		return ""
+	}
+	initials := make([]string, 0, len(fields)-1)
+	idx := 0
+	for idx < len(fields)-1 {
+		initial, ok := AuthorInitial(fields[idx])
+		if !ok {
+			break
+		}
+		initials = append(initials, strings.ToUpper(initial)+".")
+		idx++
+	}
+	if len(initials) < 2 || idx >= len(fields) {
+		return ""
+	}
+	return strings.Join(initials, "") + " " + strings.Join(fields[idx:], " ")
+}
+
+// AuthorInitial reports whether token carries exactly one letter or digit, and
+// returns it lowercased. "R." and "R" are initials; "Le" and "" are not.
+func AuthorInitial(token string) (string, bool) {
+	var letters []rune
+	for _, r := range token {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			letters = append(letters, unicode.ToLower(r))
+		}
+	}
+	if len(letters) != 1 {
+		return "", false
+	}
+	return string(letters[0]), true
+}
+
+// InitialedSurnameFallback returns the last token of an already-normalized name
+// when every preceding token is a single rune, so "j r r tolkien" yields
+// "tolkien" and "george r r martin" yields "". Providers that index only the
+// surname need this; anything with a real forename does not.
+func InitialedSurnameFallback(normalized string) string {
+	fields := strings.Fields(normalized)
+	if len(fields) < 2 {
+		return ""
+	}
+	for _, field := range fields[:len(fields)-1] {
+		if len([]rune(field)) != 1 {
+			return ""
+		}
+	}
+	return fields[len(fields)-1]
+}
+
+// dedupeFold removes blanks and case-insensitive duplicates while preserving
+// first-seen order and the original casing.
+func dedupeFold(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}


### PR DESCRIPTION
Last of the set. **Stacked on #1658 → #1657 → #1656.**

#1642-#1647 are symptoms. Each was found by hand, months apart, after a user reported it. This is the part that stops the next one.

## The drift test

`internal/normdrift` holds no production code — it exists so one test file can import every package that owns a comparison alphabet and assert the relationships *between* them, over a corpus where every entry is there because some normalizer here has actually destroyed it.

| property | what it would have caught |
|---|---|
| Unicode-form invariance for every exported fold | #1646, #1647 |
| every `SigWords` keyword findable via `WordBoundaryRegex` in the `NormalizeRelease` of its own source | **#1642 and #1643** |
| same for author tokens | #1608 |
| idempotence | chains where a key passes through a second fold |
| `CanonicalDedupKey`-equal ⟹ `NormalizeSeriesName`-equal | the ABS series lookup/promotion split |
| `MatchAuthorName` reflexive + symmetric | order-dependent results across call sites |
| non-Latin strings keep **distinct** keys | #1645, the inverse failure |
| the deliberate per-domain diacritic divergence, asserted explicitly | makes changing one a build failure you have to argue for |

The keyword property is the strong one. A keyword that cannot be found in the normalization of the very string it came from is, by construction, a keyword no release can ever satisfy — you don't need to know *why* to know it's broken.

### It is not vacuous

Reintroduced three historical bugs and counted the failures:

```
drop NFC from FoldForTitleMatch          -> 26 unicode-form failures
restore ASCII \b in WordBoundaryRegex    -> 21 unfindable-keyword failures  (#1642)
restore NormalizeTitleForDedup in NormalizeSeriesName -> 3 series-subset failures
```

Unexported folds (`db.authorSortKey`, `openlibrary.seriesSlug`) get the same invariance check inside their own packages, since a cross-package test can't reach them.

### It found one immediately

`NormalizeQueryTitle` did not compose to NFC, so one accented title produced two different indexer queries and two different dedup keys — exactly the class of "incidental difference" its own docstring says it exists to strip.

## Consolidation

`authorSearchQueries`, `compactInitialsAuthorQuery`, `authorInitial`, `initialedSurnameFallback` were **byte-identical** in `internal/abs` and `internal/api`; `sortName` was copied four times (api, abs, openlibrary, hardcover). All delegate to `textutil` now.

## Cheap fixes from the issue

- `api/authors.go` keyed its create-or-reuse map with `NormalizeTitleForDedup` where every other producer and consumer uses `CanonicalDedupKey`. The difference is `StripBracketSuffixes`, so an ABS row stored as `"X [Unabridged]"` didn't match OpenLibrary's `"X"` — a second row was created, and both then carried the same `dedup_key`, violating the #940 invariant from the inside.
- `NormalizeSeriesName` now builds on `CanonicalDedupKey`, making it a strict **widening** of the lookup key rather than merely a different one. Before, neither was a subset of the other and both directions leaked.
- `AuthorSurname` is left raw **on purpose** and now says why. Transliterating it would fold `Böll` to the ASCII `boell`, closing the latin-alias gate for exactly the German authors it should stay open for. The inconsistency is intended; the missing thing was the comment.

## Deliberately not done

Two items from the issue turned out not to be cheap, and I'd rather say so than half-do them right after three PRs of German matching changes:

- **`umlautFlexRegex` false accept** (`michael` → `michae?l` matches `Michal`). Fixing it properly means the regex builder has to know which `ae` came from an `ä`, and that information is destroyed by the fold before the keyword reaches it. Real but narrow — it needs *every* author token to match, so it can't fire alone.
- **SQLite `LOWER()` / `COLLATE NOCASE` folding ASCII only in search.** Typing `Östergaard` still won't find a stored `östergaard`. That's a search-behaviour change across several queries, not an identity-invariant fix, and belongs on its own.

**Typed keys** (`DedupKey` vs `ReleaseNormalized` as distinct types) is the one measure that would prevent this class structurally rather than by discipline. It's also a signature change through most of the tree. Worth doing, worth doing on its own.

I'll file a follow-up for those three so #1648 can close on the four recommendations it actually made.

Closes #1648