### PR TITLE
chore(deploy): pull base images through mirror.gcr.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # in sync on a weekly cadence (see .github/dependabot.yml).
 
 # Stage 1: Build frontend (runs on the builder's native arch — output is arch-agnostic JS)
-FROM --platform=$BUILDPLATFORM node:26-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66 AS frontend
+FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/node:26-alpine@sha256:e88a35be04478413b7c71c455cd9865de9b9360e1f43456be5951032d7ac1a66 AS frontend
 WORKDIR /app/web
 COPY web/package*.json ./
 RUN npm ci
@@ -10,7 +10,7 @@ COPY web/ .
 RUN npm run build
 
 # Stage 2: Build Go binary (native on BUILDPLATFORM, cross-compile to TARGETOS/TARGETARCH)
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM --platform=$BUILDPLATFORM mirror.gcr.io/library/golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/cmd/discord-stats/Dockerfile
+++ b/cmd/discord-stats/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM mirror.gcr.io/library/golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/cmd/telemetry-server/Dockerfile
+++ b/cmd/telemetry-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+FROM mirror.gcr.io/library/golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
## Summary

Docker Hub anonymous pulls are rate-limited (429 Too Many Requests from registry-1.docker.io), which has been hitting CI. This repoints the `node` and `golang` base images in `Dockerfile`, `cmd/telemetry-server/Dockerfile`, and `cmd/discord-stats/Dockerfile` from implicit `docker.io` to `mirror.gcr.io`, Google's free, unauthenticated read-through cache of Docker Hub.

Same image content/digests are pinned — this is a drop-in registry swap, not a version change. `gcr.io/distroless/static-debian12` stages are untouched since they were never pulled from Docker Hub.

## Checklist

- [x] Tests added or updated — n/a, no behaviour change
- [x] Doc-update gate cleared — n/a, no docs reference the base image registry
- [ ] Wiki pages updated if user-facing behaviour changed — n/a

## Test plan

- [x] `pre-commit run` on the three changed Dockerfiles (gitleaks, end-of-file-fixer, trailing-whitespace — all passed; golangci-lint/eslint skipped, no matching files)