### PR TITLE
fix(importer): render literal text after a zero-pad width (#1690)

### DIFF
--- a/changelog.d/1690-naming-width-then-literal.md
+++ b/changelog.d/1690-naming-width-then-literal.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Naming templates: literal text after a zero-pad width now renders** (#1690) — `{SeriesNumber:3 - }{Title}` dropped both the padding and the trailing text, giving `2Sample Book` instead of `002 - Sample Book`, and on a book with no series it leaked the modifier itself into the filename as `3 -`. The single-token spelling now behaves like the multi-token one (`{Series SeriesNumber:3 - }`), which was always correct. All-digit modifiers such as `{Year:2024}` keep their existing meaning as default text.

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -64,6 +64,25 @@ var templateGroupRe = regexp.MustCompile(`\{([^{}]*)\}`)
 // with an optional ":modifier" (default text or zero-pad width).
 var simpleGroupRe = regexp.MustCompile(`^(\w+)(?::([^{}]*))?$`)
 
+// widthThenLiteralRe recognises a modifier that is a zero-pad width followed
+// by literal text — "3 - " in "{SeriesNumber:3 - }" (#1690). simpleGroupRe's
+// modifier capture is greedy, so such a group used to parse as one token with
+// the whole "3 - " as its modifier: parseWidth rejected it for length, and
+// because the value was non-empty the default-text branch never ran either, so
+// BOTH the padding and the trailing literal were silently dropped. With an
+// empty value it was worse — the modifier text itself was substituted as the
+// default, putting a literal "3 -" in the filename of every non-series book.
+//
+// Groups matching this are handed to the conditional branch instead, where
+// groupWordRe's ":\d{1,2}" capture is already bounded correctly and the
+// trailing text is treated as conditional literal text. That also makes the
+// single-token form agree with the multi-token one, which always took the
+// conditional path and therefore always worked ("{Series SeriesNumber:3 - }").
+//
+// The trailing \D is what keeps "{Year:2024}" out: a modifier of all digits
+// stays default text, per parseWidth's 1-2 digit rule.
+var widthThenLiteralRe = regexp.MustCompile(`^\d{1,2}\D`)
+
 // groupWordRe finds keyword candidates inside a conditional group: a word
 // run with an optional ":N" width. Non-keyword word runs stay literal.
 var groupWordRe = regexp.MustCompile(`(\w+)(:\d{1,2})?`)
@@ -285,8 +304,12 @@ func renderSegment(seg string, values map[string]string) string {
 //     least one token in the group has a value; when every token is empty
 //     the whole group collapses to "". Widths are allowed after a token
 //     (":N"); text defaults are not supported in conditional groups.
+//
+// A single token carrying BOTH a width and a trailing literal
+// ("{SeriesNumber:3 - }") is conditional, not simple — see widthThenLiteralRe
+// for why the simple form cannot express it (#1690).
 func renderGroup(content string, values map[string]string) (rendered string, known bool) {
-	if m := simpleGroupRe.FindStringSubmatch(content); m != nil {
+	if m := simpleGroupRe.FindStringSubmatch(content); m != nil && !widthThenLiteralRe.MatchString(m[2]) {
 		v, ok := values[m[1]]
 		if !ok {
 			return "", false

--- a/internal/importer/renamer_preview_test.go
+++ b/internal/importer/renamer_preview_test.go
@@ -139,6 +139,67 @@ func TestRenamerConditionalGroupCollapse(t *testing.T) {
 	}
 }
 
+// TestRenamerWidthThenLiteral is the #1690 regression test: a single token
+// carrying BOTH a zero-pad width and trailing literal text.
+//
+// simpleGroupRe's modifier capture is greedy, so "{SeriesNumber:3 - }" used to
+// parse as one token with the modifier "3 - ". parseWidth rejected that for
+// length and, because the value was non-empty, the default-text branch never
+// ran either — so the padding AND the literal were both dropped ("2Sample
+// Book"). With an empty series it was worse: the modifier text itself was
+// substituted as the default, putting a literal "3 -" into the filename of
+// every standalone book.
+//
+// The multi-token spelling always worked because it took the conditional
+// branch, whose ":\d{1,2}" capture is bounded; these cases pin that the
+// single-token spelling now agrees with it. Mirrored in namingTemplate.test.ts.
+func TestRenamerWidthThenLiteral(t *testing.T) {
+	author := &models.Author{Name: "Jane Doe"}
+	book := &models.Book{Title: "Sample Book"}
+	r := NewRenamer("")
+
+	cases := []struct {
+		name                 string
+		template             string
+		series, seriesNumber string
+		want                 string
+	}{
+		{"width then literal renders both", "{SeriesNumber:3 - }{Title}", "Demo Series", "2", "002 - Sample Book"},
+		{"literal without width still works", "{SeriesNumber - }{Title}", "Demo Series", "2", "2 - Sample Book"},
+		{"agrees with the multi-token spelling", "{Series SeriesNumber:3 - }{Title}", "Demo Series", "2", "Demo Series 002 - Sample Book"},
+		{"leading literal form is unchanged", "{Title}{ - SeriesNumber:3}", "Demo Series", "2", "Sample Book - 002"},
+		{"bare width is unchanged", "{SeriesNumber:3}-{Title}", "Demo Series", "2", "002-Sample Book"},
+		// The empty-value case: the whole group collapses. It must NOT leak
+		// the modifier text ("3 -") as though it were default text.
+		{"collapses whole group when empty", "{SeriesNumber:3 - }{Title}", "", "", "Sample Book"},
+		{"no modifier text leaks when empty", "{SeriesNumber:12 vol }{Title}", "", "", "Sample Book"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.apply(tc.template, author, book, tc.series, tc.seriesNumber, "epub")
+			if got != tc.want {
+				t.Errorf("apply(%q) = %q, want %q (TS preview mirror must match)", tc.template, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenamerWidthThenLiteralKeepsDefaultText guards the boundary the fix must
+// not cross: an all-digit modifier keeps its historical default-text meaning,
+// so "{Year:2024}" is not re-read as width 20 plus the literal "24".
+func TestRenamerWidthThenLiteralKeepsDefaultText(t *testing.T) {
+	r := NewRenamer("")
+	author := &models.Author{Name: "Jane Doe"}
+	for _, tc := range []struct{ template, want string }{
+		{"{Year:2024}", "2024"},          // empty year → 4-digit modifier is default text
+		{"{Genre:Unsorted}", "Unsorted"}, // non-digit modifier is default text
+	} {
+		if got := r.apply(tc.template, author, &models.Book{Title: "T"}, "", "", "epub"); got != tc.want {
+			t.Errorf("apply(%q) = %q, want %q", tc.template, got, tc.want)
+		}
+	}
+}
+
 // TestSanitizePathPreviewDriftGuard pins sanitizePath for the characters the TS
 // mirror handles, so a change to the Go replacer set is caught here.
 func TestSanitizePathPreviewDriftGuard(t *testing.T) {

--- a/web/src/pages/settings/NamingTemplateField.test.tsx
+++ b/web/src/pages/settings/NamingTemplateField.test.tsx
@@ -110,10 +110,39 @@ describe('namingTemplate renderer (renamer.go mirror)', () => {
     expect(renderTemplate('{Year:20}', 'book', noYear)).toBe('')
   })
 
+  // #1690 — a single token carrying BOTH a width and trailing literal text.
+  // SIMPLE_GROUP_RE's modifier capture is greedy, so '{SeriesNumber:3 - }' used
+  // to parse as one token with the modifier '3 - ': parseWidth rejected it for
+  // length and, the value being non-empty, the default branch never ran, so the
+  // padding and the literal were both dropped. With an empty series it was
+  // worse — the modifier text itself rendered as the default, putting a literal
+  // '3 -' in every standalone book's name. Mirrors TestRenamerWidthThenLiteral.
+  it('renders both the width and the trailing literal in one group', () => {
+    expect(renderTemplate('{SeriesNumber:3 - }{Title}', 'book')).toBe('002 - Sample Book')
+    // The multi-token spelling always worked; the single-token one now agrees.
+    expect(renderTemplate('{Series SeriesNumber:3 - }{Title}', 'book')).toBe('Demo Series 002 - Sample Book')
+    expect(renderTemplate('{SeriesNumber - }{Title}', 'book')).toBe('2 - Sample Book')
+    expect(renderTemplate('{Title}{ - SeriesNumber:3}', 'book')).toBe('Sample Book - 002')
+    expect(renderTemplate('{SeriesNumber:3}-{Title}', 'book')).toBe('002-Sample Book')
+
+    // Empty value collapses the whole group — no modifier text leaks through.
+    const noSeries = { ...SAMPLE_BOOK, series: '', seriesNumber: '' }
+    expect(renderTemplate('{SeriesNumber:3 - }{Title}', 'book', noSeries)).toBe('Sample Book')
+    expect(renderTemplate('{SeriesNumber:12 vol }{Title}', 'book', noSeries)).toBe('Sample Book')
+
+    // The boundary the fix must not cross: an all-digit modifier stays default
+    // text, so '{Year:2024}' is not re-read as width 20 plus the literal '24'.
+    const noYear = { ...SAMPLE_BOOK, year: '' }
+    expect(renderTemplate('{Year:2024}', 'book', noYear)).toBe('2024')
+  })
+
   it('accepts conditional groups and widths in validation', () => {
     expect(validateTemplate('{Title}{ - Series}.{ext}').unknownTokens).toEqual([])
     expect(validateTemplate('{SeriesNumber:2} - {Title}').unknownTokens).toEqual([])
     expect(validateTemplate('{ - Titel}').unknownTokens).toEqual(['{ - Titel}'])
+    // #1690: a width-then-literal group is scanned for its token rather than
+    // judged on the leading word alone.
+    expect(validateTemplate('{SeriesNumber:3 - }{Title}').unknownTokens).toEqual([])
   })
 
   it('renders the {Genre} token and {Token:default} fallback', () => {

--- a/web/src/pages/settings/namingTemplate.ts
+++ b/web/src/pages/settings/namingTemplate.ts
@@ -139,6 +139,13 @@ const SEGMENT_GROUP_RE = /\{([^{}]*)\}/g
 const SIMPLE_GROUP_RE = /^(\w+)(?::([^{}]*))?$/
 const GROUP_WORD_RE = /(\w+)(:\d{1,2})?/g
 
+// WIDTH_THEN_LITERAL_RE mirrors widthThenLiteralRe in renamer.go: a modifier
+// that is a zero-pad width followed by literal text ("3 - " in
+// "{SeriesNumber:3 - }") belongs to the conditional branch, not the simple one
+// (#1690). The trailing \D keeps an all-digit modifier like "{Year:2024}" on
+// the simple path, where it stays default text.
+const WIDTH_THEN_LITERAL_RE = /^\d{1,2}\D/
+
 // sanitizeInline mirrors renamer.go sanitizeInline: neutralise path
 // separators in a conditional-group literal without trimming — its
 // whitespace is meaningful glue ("{ - Series}").
@@ -184,7 +191,7 @@ function zeroPad(v: string, width: number): string {
 // references no known token (caller keeps it verbatim).
 function renderGroup(content: string, values: Record<string, string>): string | null {
   const simple = SIMPLE_GROUP_RE.exec(content)
-  if (simple) {
+  if (simple && !WIDTH_THEN_LITERAL_RE.test(simple[2] ?? '')) {
     let v = values[simple[1]]
     if (v === undefined) return null
     const mod = simple[2]
@@ -277,7 +284,10 @@ const TRAVERSAL_RE = /(^|\/)\.\.?($|\/)/
 // keyword. Mirrors renderGroup's known/verbatim decision.
 function groupIsKnown(content: string): boolean {
   const simple = SIMPLE_GROUP_RE.exec(content)
-  if (simple) return SUPPORTED.has(`{${simple[1]}}`)
+  // Same width-then-literal exclusion as renderGroup (#1690), so a group like
+  // "{Foo:3 - Series}" is scanned for its known token instead of being judged
+  // solely on the leading word and flagged as unknown.
+  if (simple && !WIDTH_THEN_LITERAL_RE.test(simple[2] ?? '')) return SUPPORTED.has(`{${simple[1]}}`)
   GROUP_WORD_RE.lastIndex = 0
   let m: RegExpExecArray | null
   while ((m = GROUP_WORD_RE.exec(content)) !== null) {


### PR DESCRIPTION
## Summary

`{SeriesNumber:3 - }` dropped both the zero-pad and the trailing literal, and on a book with no series it leaked the modifier text itself into the filename. Closes #1690.

`simpleGroupRe` (`^(\w+)(?::([^{}]*))?$`) captures everything after the colon as one modifier, so the group parsed as a single token with the modifier `"3 - "`. `parseWidth` rejects that for length, and because the value was non-empty the default-text branch never ran either — so both the padding and the literal vanished.

The empty-value case was worse and was not in the report: `v == ""` falls into `v = sanitizePath(mod)`, putting a literal `3 -` into the name of **every** standalone book using such a template.

| template | series | before | after |
|---|---|---|---|
| `{SeriesNumber:3 - }{Title}` | Demo Series / 2 | `2Sample Book` | `002 - Sample Book` |
| `{SeriesNumber:3 - }{Title}` | none | `3 -Sample Book` | `Sample Book` |
| `{Series SeriesNumber:3 - }{Title}` | Demo Series / 2 | `Demo Series 002 - Sample Book` | unchanged |
| `{Year:2024}` | — | `2024` | unchanged |

## Implementation notes

The multi-token spelling always worked because it takes the conditional branch, where `groupWordRe`'s `(:\d{1,2})?` capture is bounded. The fix routes a width-followed-by-literal modifier to that same branch rather than teaching the simple branch a second syntax, so there is one parser for the case instead of two.

`widthThenLiteralRe` is `^\d{1,2}\D` — the trailing `\D` is what keeps `{Year:2024}` out. An all-digit modifier stays default text, per `parseWidth`'s existing 1–2 digit rule.

## Where it's mirrored

`web/src/pages/settings/namingTemplate.ts` re-implements the engine for the live preview and had the identical defect — the preview output quoted in the issue came from there. Both sides are fixed and both test suites pin the same cases. `groupIsKnown` gets the same guard so a group like `{Foo:3 - Series}` is scanned for its known token instead of being judged on the leading word alone.

## Checklist

- [x] Tests added or updated
- [x] Doc-update gate cleared — the `tokenSeriesNumber` i18n hint already documents both widths and conditional literals; this makes them composable as described, so no wording change
- [x] Added a changelog fragment under `changelog.d/`
- [ ] Wiki pages updated if user-facing behaviour changed — n/a

## Test plan

- [x] `go test ./cmd/... ./internal/...` — full suite green
- [x] `cd web && npm test` — 445 pass, `npx tsc --noEmit` clean, `npm run build` OK
- [x] Non-vacuity verified: reverting the guard fails 3 of the 7 new Go cases, reproducing both `2Sample Book` and `3 -Sample Book`
- New `TestRenamerWidthThenLiteral` / `TestRenamerWidthThenLiteralKeepsDefaultText`, mirrored in `NamingTemplateField.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
