### PR TITLE
fix(series): apply genre override before adding books

### DIFF
--- a/changelog.d/1709-series-genre-before-add.md
+++ b/changelog.d/1709-series-genre-before-add.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Series genre override** (#1709) — allow setting genres before adding books and apply the choice to newly created series books.

--- a/docs/Hardcover-Series-Wiki.md
+++ b/docs/Hardcover-Series-Wiki.md
@@ -36,7 +36,8 @@ If either requirement is missing, Bindery hides the enhanced controls and the en
 4. Use **Search** to find a matching Hardcover series.
 5. Pick the correct Hardcover result, or remove a bad existing link.
 6. Open the linked series to load the Hardcover catalog diff.
-7. Use **add** on a single missing row, or **add all** / **Fill gaps** to queue every missing catalog entry.
+7. Optionally use **Set genre** before adding books. The override is applied to current and newly added books in the series and locked against metadata refresh.
+8. Use **add** on a single missing row, or **add all** / **Fill gaps** to queue every missing catalog entry.
 
 Added Hardcover books are created as wanted and monitored rows. Bindery then queues indexer searches the same way it does for other wanted books.
 

--- a/internal/api/genre_apply.go
+++ b/internal/api/genre_apply.go
@@ -110,7 +110,12 @@ func (h *SeriesHandler) ApplyGenres(w http.ResponseWriter, r *http.Request) {
 		writeServerError(w, r, err)
 		return
 	}
-	updated, err := applyGenresToBooks(r.Context(), h.books, books, cleanGenreList(req.Genres))
+	genres := cleanGenreList(req.Genres)
+	if err := h.series.SetGenreOverride(r.Context(), series.ID, genres); err != nil {
+		writeServerError(w, r, err)
+		return
+	}
+	updated, err := applyGenresToBooks(r.Context(), h.books, books, genres)
 	if err != nil {
 		writeServerError(w, r, err)
 		return

--- a/internal/api/metadata_locks_test.go
+++ b/internal/api/metadata_locks_test.go
@@ -209,3 +209,35 @@ func TestSeriesApplyGenres(t *testing.T) {
 		t.Fatalf("series genre override not persisted: %+v", storedSeries)
 	}
 }
+
+func TestSeriesApplyGenresPersistenceFailure(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	seriesRepo := db.NewSeriesRepo(database)
+	ctx := context.Background()
+	series, err := seriesRepo.CreateManual(ctx, "Demo Series")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx, `
+		CREATE TRIGGER reject_series_genre_override
+		BEFORE UPDATE OF genre_override ON series
+		BEGIN
+			SELECT RAISE(FAIL, 'genre override rejected');
+		END`); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewSeriesHandler(seriesRepo, db.NewBookRepo(database), db.NewAuthorRepo(database), nil, nil)
+	raw, _ := json.Marshal(map[string]any{"genres": []string{"Fantasy"}})
+	req := withURLParam(httptest.NewRequest(http.MethodPut, "/api/v1/series/"+strconv.FormatInt(series.ID, 10)+"/genres", bytes.NewReader(raw)), "id", strconv.FormatInt(series.ID, 10))
+	rec := httptest.NewRecorder()
+	h.ApplyGenres(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/metadata_locks_test.go
+++ b/internal/api/metadata_locks_test.go
@@ -201,4 +201,11 @@ func TestSeriesApplyGenres(t *testing.T) {
 	if other.IsFieldLocked(models.BookFieldGenres) {
 		t.Fatalf("standalone book must be untouched; locked=%v", other.LockedFields)
 	}
+	storedSeries, err := seriesRepo.GetByID(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !storedSeries.GenreOverrideSet || len(storedSeries.GenreOverride) != 1 || storedSeries.GenreOverride[0] != "Fantasy" {
+		t.Fatalf("series genre override not persisted: %+v", storedSeries)
+	}
 }

--- a/internal/api/series.go
+++ b/internal/api/series.go
@@ -1423,6 +1423,10 @@ func (h *SeriesHandler) ensureHardcoverCatalogBook(ctx context.Context, series *
 	book.MediaType = firstNonEmpty(mediaType, models.MediaTypeEbook)
 	book.Language = firstNonEmpty(book.Language, "eng")
 	book.MetadataProvider = firstNonEmpty(book.MetadataProvider, "hardcover")
+	if series.GenreOverrideSet {
+		book.Genres = append([]string(nil), series.GenreOverride...)
+		book.LockField(models.BookFieldGenres)
+	}
 	if book.Genres == nil {
 		book.Genres = []string{}
 	}

--- a/internal/api/series_test.go
+++ b/internal/api/series_test.go
@@ -1440,6 +1440,9 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 	if err := seriesRepo.UpsertHardcoverLink(context.Background(), link); err != nil {
 		t.Fatal(err)
 	}
+	if err := seriesRepo.SetGenreOverride(context.Background(), series.ID, []string{"Fantasy", "Epic"}); err != nil {
+		t.Fatal(err)
+	}
 
 	rec := httptest.NewRecorder()
 	h.Fill(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/series/1/fill", nil), "id", "1"))
@@ -1470,6 +1473,12 @@ func TestSeriesFillCreatesMissingHardcoverBook(t *testing.T) {
 	}
 	if !created.AnyEditionOK {
 		t.Fatal("expected anyEditionOk to be preserved")
+	}
+	if len(created.Genres) != 2 || created.Genres[0] != "Fantasy" || created.Genres[1] != "Epic" {
+		t.Fatalf("expected series genres on created book, got %v", created.Genres)
+	}
+	if !created.IsFieldLocked(models.BookFieldGenres) {
+		t.Fatal("expected series genres to be locked on created book")
 	}
 	books, err := seriesRepo.ListBooksInSeries(context.Background(), series.ID)
 	if err != nil {

--- a/internal/db/migrations/067_series_genre_override.sql
+++ b/internal/db/migrations/067_series_genre_override.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE series ADD COLUMN genre_override TEXT;
+
+-- +migrate Down
+-- SQLite does not support DROP COLUMN in older versions; migration is non-reversible.

--- a/internal/db/series.go
+++ b/internal/db/series.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -196,6 +197,20 @@ func (r *SeriesRepo) SetMonitored(ctx context.Context, id int64, monitored bool)
 	return err
 }
 
+// SetGenreOverride stores the genres that should be applied to current and
+// subsequently created books in a series. A non-NULL empty array deliberately
+// means "keep genres empty and locked".
+func (r *SeriesRepo) SetGenreOverride(ctx context.Context, id int64, genres []string) error {
+	encoded, err := json.Marshal(genres)
+	if err != nil {
+		return fmt.Errorf("marshal series genre override: %w", err)
+	}
+	if _, err := r.db.ExecContext(ctx, "UPDATE series SET genre_override=? WHERE id=?", string(encoded), id); err != nil {
+		return fmt.Errorf("update series %d genre override: %w", id, err)
+	}
+	return nil
+}
+
 func (r *SeriesRepo) CreateManual(ctx context.Context, title string) (*models.Series, error) {
 	s := &models.Series{
 		ForeignID:   fmt.Sprintf("manual:series:%d", time.Now().UTC().UnixNano()),
@@ -257,17 +272,27 @@ func (r *SeriesRepo) GetByID(ctx context.Context, id int64) (*models.Series, err
 // ListWithBooksForUser for the semantics.
 func (r *SeriesRepo) GetByIDForUser(ctx context.Context, id, userID int64) (*models.Series, error) {
 	row := r.db.QueryRowContext(ctx,
-		"SELECT id, foreign_id, title, description, monitored, created_at FROM series WHERE id=?", id)
+		"SELECT id, foreign_id, title, description, monitored, genre_override, created_at FROM series WHERE id=?", id)
 
 	var s models.Series
 	var monitored int
-	err := row.Scan(&s.ID, &s.ForeignID, &s.Title, &s.Description, &monitored, &s.CreatedAt)
+	var genreOverride sql.NullString
+	err := row.Scan(&s.ID, &s.ForeignID, &s.Title, &s.Description, &monitored, &genreOverride, &s.CreatedAt)
 	s.Monitored = monitored == 1
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get series %d: %w", id, err)
+	}
+	if genreOverride.Valid {
+		s.GenreOverrideSet = true
+		if err := json.Unmarshal([]byte(genreOverride.String), &s.GenreOverride); err != nil {
+			return nil, fmt.Errorf("decode series %d genre override: %w", id, err)
+		}
+		if s.GenreOverride == nil {
+			s.GenreOverride = []string{}
+		}
 	}
 
 	// Fetch series books with minimal book data, scoped to the caller's

--- a/internal/db/series_test.go
+++ b/internal/db/series_test.go
@@ -607,3 +607,47 @@ func TestSeriesGetBookBySeriesPosition(t *testing.T) {
 		t.Fatalf("ambiguous position = %+v, want nil", got)
 	}
 }
+
+func TestSeriesGenreOverridePersistence(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	repo := NewSeriesRepo(database)
+	series, err := repo.CreateManual(ctx, "Demo Series")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.SetGenreOverride(ctx, series.ID, nil); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := repo.GetByID(ctx, series.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stored.GenreOverrideSet || stored.GenreOverride == nil || len(stored.GenreOverride) != 0 {
+		t.Fatalf("empty genre override not preserved: %+v", stored)
+	}
+
+	if _, err := database.ExecContext(ctx, "UPDATE series SET genre_override='not-json' WHERE id=?", series.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.GetByID(ctx, series.ID); err == nil || !strings.Contains(err.Error(), "decode series") {
+		t.Fatalf("expected malformed override error, got %v", err)
+	}
+
+	if _, err := database.ExecContext(ctx, `
+		CREATE TRIGGER reject_series_genre_override
+		BEFORE UPDATE OF genre_override ON series
+		BEGIN
+			SELECT RAISE(FAIL, 'genre override rejected');
+		END`); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SetGenreOverride(ctx, series.ID, []string{"Fantasy"}); err == nil || !strings.Contains(err.Error(), "update series") {
+		t.Fatalf("expected update error, got %v", err)
+	}
+}

--- a/internal/models/series.go
+++ b/internal/models/series.go
@@ -3,12 +3,14 @@ package models
 import "time"
 
 type Series struct {
-	ID          int64     `json:"id"`
-	ForeignID   string    `json:"foreignSeriesId"`
-	Title       string    `json:"title"`
-	Description string    `json:"description"`
-	Monitored   bool      `json:"monitored"`
-	CreatedAt   time.Time `json:"createdAt"`
+	ID               int64     `json:"id"`
+	ForeignID        string    `json:"foreignSeriesId"`
+	Title            string    `json:"title"`
+	Description      string    `json:"description"`
+	Monitored        bool      `json:"monitored"`
+	GenreOverride    []string  `json:"-"`
+	GenreOverrideSet bool      `json:"-"`
+	CreatedAt        time.Time `json:"createdAt"`
 
 	// Joined data
 	Books         []SeriesBook         `json:"books,omitempty"`

--- a/web/src/api/series.ts
+++ b/web/src/api/series.ts
@@ -108,8 +108,8 @@ export const seriesApi = {
       method: 'POST',
       ...(mediaType ? { body: JSON.stringify({ mediaType }) } : {}),
     }),
-  // Genre override (#1446): set + lock the genre list on every book in the
-  // series so metadata refresh keeps the user's taxonomy.
+  // Genre override (#1446, #1709): set + lock the genre list on every current
+  // and subsequently added book in the series.
   applySeriesGenres: (id: number, genres: string[]) =>
     request<{ updated: number }>(`/series/${id}/genres`, { method: 'PUT', body: JSON.stringify({ genres }) }),
   searchHardcoverSeries: (term: string, limit = 10) =>

--- a/web/src/pages/SeriesPage.test.tsx
+++ b/web/src/pages/SeriesPage.test.tsx
@@ -25,6 +25,7 @@ vi.mock('../api/client', async importOriginal => {
       linkBookToSeries: vi.fn(),
       fillSeries: vi.fn(),
       fillSeriesAll: vi.fn(),
+      applySeriesGenres: vi.fn(),
       autoLinkSeriesHardcover: vi.fn(),
       getSeriesHardcoverLink: vi.fn(),
       searchHardcoverSeries: vi.fn(),
@@ -89,6 +90,30 @@ describe('SeriesPage', () => {
     fireEvent.click(screen.getByRole('heading', { name: 'The Stormlight Archive' }))
     expect(screen.queryByText(/Hardcover:/)).not.toBeInTheDocument()
     expect(api.getSeriesHardcoverDiff).not.toHaveBeenCalled()
+  })
+
+  it('offers a genre override before a series has books', async () => {
+    vi.mocked(api.applySeriesGenres).mockResolvedValue({ updated: 0 })
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Fantasy, Epic')
+
+    try {
+      renderSeriesPage([{
+        id: 12,
+        foreignSeriesId: 'series-12',
+        title: 'Empty Series',
+        description: '',
+        monitored: true,
+        books: [],
+      }])
+
+      fireEvent.click(await screen.findByRole('heading', { name: 'Empty Series' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Set genre' }))
+
+      await waitFor(() => expect(api.applySeriesGenres).toHaveBeenCalledWith(12, ['Fantasy', 'Epic']))
+      expect(await screen.findByText('Genres set on 0 book(s)')).toBeInTheDocument()
+    } finally {
+      promptSpy.mockRestore()
+    }
   })
 
   it('links expanded series book rows to their book pages', async () => {

--- a/web/src/pages/SeriesPage.tsx
+++ b/web/src/pages/SeriesPage.tsx
@@ -327,7 +327,7 @@ export default function SeriesPage() {
                       Add Book
                     </button>
                   )}
-                  {isOpen && bookCount > 0 && (
+                  {isOpen && (
                     <button
                       onClick={() => applySeriesGenres(series)}
                       disabled={applyingGenres === series.id}


### PR DESCRIPTION
## Summary

I made the series genre override available before a series contains any books. The override is now persisted on the series and applied and locked on books subsequently created through the Hardcover fill flow.

Closes #1709.

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` not applicable (no environment, configuration, or upgrade-path changes)
- [x] Added a changelog fragment under `changelog.d/`
- [x] Updated the Hardcover series documentation

## Test plan

- [x] `go test -p 2 -count=1 ./internal/api ./internal/db`
- [x] `go vet ./internal/api ./internal/db ./internal/models`
- [x] `cd web && npm test` (446 tests)
- [x] `cd web && npm run typecheck`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run build`

I did not run the repository-wide `make check`; its full Go race/lint/build matrix is deferred to CI. The changed backend modules, complete frontend suite, frontend production build, typecheck, and lint completed locally.
