### PR TITLE
fix(importer): skip terminal downloads before the qBittorrent not-found debug log (#1730)

### DIFF
--- a/changelog.d/1730-qbit-notfound-debug-spam.md
+++ b/changelog.d/1730-qbit-notfound-debug-spam.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Stopped the qBittorrent poll logging a Debug line for every already-imported download** (#1730) — the 15-second poll walked all download rows and logged "download not found in torrent list" for long-imported downloads whose torrent had been removed after import, one line per download per poll forever (96% of debug output on a 53-download library). Terminal downloads are now skipped before the log, matching the no-hash branch; failed-import rows still log and still feed stale-source detection unchanged.

--- a/internal/importer/scanner_poll.go
+++ b/internal/importer/scanner_poll.go
@@ -411,6 +411,18 @@ func (s *Scanner) checkQbittorrentDownloads(ctx context.Context, client *models.
 			// category). Common causes: the torrent was manually removed, or the
 			// hash stored in Bindery doesn't match what qBittorrent returned. This
 			// is blockStaleImportFailures territory; only log at Debug to avoid noise.
+			//
+			// Skip terminal downloads BEFORE logging, mirroring the no-hash branch
+			// above (#1730): List() has no status filter, so every long-imported
+			// download whose torrent was removed after import lands here on every
+			// 15s poll, and the Debug line below dominated debug output (96% on a
+			// 53-download library). StateImportFailed deliberately keeps flowing —
+			// blockStaleImportFailures relies on those rows NOT being marked in
+			// seenSourceIDs to detect a source that vanished from the client, and
+			// the Debug line is the operator's trace for that path.
+			if dl.Status == models.StateImported || dl.Status == models.StateFailed {
+				continue
+			}
 			hash := ""
 			if dl.TorrentID != nil {
 				hash = *dl.TorrentID

--- a/internal/importer/scanner_qbittorrent_notfound_log_test.go
+++ b/internal/importer/scanner_qbittorrent_notfound_log_test.go
@@ -1,0 +1,142 @@
+package importer
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestCheckQbittorrentDownloads_NotFoundLogSkipsTerminalStates is the
+// regression test for issue #1730.
+//
+// s.downloads.List has no status filter, so the qBittorrent poll also walks
+// long-imported downloads. When such a download's torrent has been removed
+// from qBittorrent after import, the not-found branch logged
+// "qbittorrent: download not found in torrent list" at Debug — once per
+// imported download, per 15s poll, forever (measured at 96% of all debug
+// output on a 53-download library). The terminal-status skip sat AFTER the
+// log; the no-hash branch above it checks BEFORE. This test pins the fixed
+// ordering:
+//
+//   - StateImported / StateFailed rows whose torrent is gone emit NO line.
+//   - StateImportFailed rows still emit the line AND still flow into
+//     blockStaleImportFailures unseen, so a vanished source is terminally
+//     blocked exactly as before (the #706 finding-4 behavior must not change).
+func TestCheckQbittorrentDownloads_NotFoundLogSkipsTerminalStates(t *testing.T) {
+	// qBittorrent holds no torrents at all: every tracked hash misses both the
+	// category-filtered map and the unfiltered fallback, driving each download
+	// into the not-found branch. The unfiltered listing succeeding is what
+	// makes sourceListIsComplete=true for blockStaleImportFailures.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/torrents/info":
+			_, _ = w.Write([]byte("[]"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	dlRepo := db.NewDownloadRepo(database)
+	clientRepo := db.NewDownloadClientRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	authorRepo := db.NewAuthorRepo(database)
+	histRepo := db.NewHistoryRepo(database)
+
+	s := NewScanner(dlRepo, clientRepo, bookRepo, authorRepo, histRepo, t.TempDir(), "", "", "", "")
+
+	host, port := scannerTestHostPort(t, srv.URL)
+	client := &models.DownloadClient{
+		Name:    "qbit-1730",
+		Type:    "qbittorrent",
+		Host:    host,
+		Port:    port,
+		Enabled: true,
+	}
+	if err := clientRepo.Create(ctx, client); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+
+	mkDownload := func(guid, title, hash string, status models.DownloadState) {
+		t.Helper()
+		h := hash
+		dl := &models.Download{
+			GUID:             guid,
+			Title:            title,
+			NZBURL:           "magnet:?xt=urn:btih:" + hash,
+			Status:           status,
+			Protocol:         "torrent",
+			TorrentID:        &h,
+			DownloadClientID: &client.ID,
+		}
+		if err := dlRepo.Create(ctx, dl); err != nil {
+			t.Fatalf("create download %s: %v", guid, err)
+		}
+	}
+	mkDownload("guid-1730-imported", "long-imported-book", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", models.StateImported)
+	mkDownload("guid-1730-failed", "failed-book", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", models.StateFailed)
+	mkDownload("guid-1730-importfailed", "vanished-importfailed-book", "cccccccccccccccccccccccccccccccccccccccc", models.StateImportFailed)
+
+	var logBuf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	s.checkQbittorrentDownloads(ctx, client)
+
+	// Collect only the not-found lines so unrelated Debug output (e.g. the
+	// per-poll summary line) can't mask a regression.
+	var notFoundLines []string
+	for _, line := range strings.Split(logBuf.String(), "\n") {
+		if strings.Contains(line, "download not found in torrent list") {
+			notFoundLines = append(notFoundLines, line)
+		}
+	}
+	joined := strings.Join(notFoundLines, "\n")
+
+	// Match on the full title attribute: "failed-book" alone is a substring of
+	// "vanished-importfailed-book" and would false-positive.
+	if strings.Contains(joined, "title=long-imported-book") {
+		t.Errorf("#1730 regression: StateImported download logged the not-found Debug line:\n%s", joined)
+	}
+	if strings.Contains(joined, "title=failed-book") {
+		t.Errorf("#1730 regression: StateFailed download logged the not-found Debug line:\n%s", joined)
+	}
+	if !strings.Contains(joined, "title=vanished-importfailed-book") {
+		t.Errorf("StateImportFailed must keep emitting the not-found Debug line (operator trace for blockStaleImportFailures), got:\n%s", logBuf.String())
+	}
+
+	// Behavioral invariant: the skip must not change what reaches
+	// blockStaleImportFailures. Terminal rows stay terminal, and the
+	// StateImportFailed row — absent from a complete source listing — is
+	// terminally blocked exactly as before the fix.
+	assertState := func(guid string, want models.DownloadState) {
+		t.Helper()
+		got, err := dlRepo.GetByGUID(ctx, guid)
+		if err != nil {
+			t.Fatalf("get %s: %v", guid, err)
+		}
+		if got.Status != want {
+			t.Errorf("%s: status = %s, want %s", guid, got.Status, want)
+		}
+	}
+	assertState("guid-1730-imported", models.StateImported)
+	assertState("guid-1730-failed", models.StateFailed)
+	assertState("guid-1730-importfailed", models.StateImportBlocked)
+}


### PR DESCRIPTION
## Summary

Fixes #1730: the 15 second qBittorrent poll logged one Debug line per already imported download, per poll, forever. On the reporter's 53 download library that was 212 lines/min, 96% of all debug output.

## Root cause

`s.downloads.List(ctx)` has no status filter, so the poll loop also walks long imported downloads. For a row whose torrent was removed from qBittorrent after import, the hash misses both the category filtered map and the unfiltered fallback, and the not-found branch logged "qbittorrent: download not found in torrent list" at `scanner_poll.go:418` with the terminal status skip sitting immediately AFTER it at :425. The no-hash branch above does the same check BEFORE its log (:388), so this was an ordering bug, not a missing check.

## Fix

Move the `StateImported || StateFailed` skip ahead of the Debug log inside the not-found branch, mirroring the no-hash branch. `StateImportFailed` deliberately keeps flowing: those rows were never marked in `seenSourceIDs` in this branch (the `continue` came before the mark), and `blockStaleImportFailures` relies on that to terminally block a source that vanished from the client. The Debug line stays as the operator trace for that path. `seenSourceIDs` semantics are unchanged for every state.

New regression test drives three hash bearing downloads (imported, failed, importFailed) against a qBittorrent stub holding zero torrents and asserts: no not-found line for imported/failed, the line still present for importFailed, terminal rows untouched, and the importFailed row still terminally blocked by the stale source sweep.

## Test plan

- [x] `go test -count=1 -run TestCheckQbittorrentDownloads_NotFoundLogSkipsTerminalStates ./internal/importer/`
- [x] Non-vacuity: reverted the scanner_poll.go change, test fails on both suppressed-log assertions; restored, passes
- [x] `go test -count=1 ./internal/importer/` (full suite, ok in 12s)
- [x] `gofmt -l internal/importer` clean
- [x] `golangci-lint run ./internal/importer/` 0 issues

Closes #1730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
