### PR TITLE
fix(recommender): suppress owned books across providers and count wanted as owned (#1726)

### DIFF
--- a/changelog.d/1726-discover-owned.md
+++ b/changelog.d/1726-discover-owned.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Discover no longer recommends books you already have** (#1726) — ownership was matched on provider-specific IDs, so a book owned via OpenLibrary or Audiobookshelf still came back as a Hardcover recommendation (one reported batch was 15 of 22 owned books). The recommender now also matches by work identity (canonical title key plus author), and books on your wanted list count as owned too instead of being recommended back.

--- a/internal/recommender/candidates.go
+++ b/internal/recommender/candidates.go
@@ -47,7 +47,7 @@ func GenerateSeries(
 			if !floatEqual(pos, nextPos) || sb.Book == nil {
 				continue
 			}
-			if profile.OwnedForeignIDs[sb.Book.ForeignID] {
+			if profile.IsOwned(sb.Book.ForeignID, sb.Book.Title, profile.AuthorNames[sb.Book.AuthorID]) {
 				continue
 			}
 
@@ -67,7 +67,7 @@ func GenerateSeries(
 				if !floatEqual(pos, missingPos) || sb.Book == nil {
 					continue
 				}
-				if profile.OwnedForeignIDs[sb.Book.ForeignID] {
+				if profile.IsOwned(sb.Book.ForeignID, sb.Book.Title, profile.AuthorNames[sb.Book.AuthorID]) {
 					continue
 				}
 
@@ -110,7 +110,7 @@ func GenerateAuthorNew(
 
 		for i := range authorBooks {
 			b := &authorBooks[i]
-			if profile.OwnedForeignIDs[b.ForeignID] {
+			if profile.IsOwned(b.ForeignID, b.Title, author.Name) {
 				continue
 			}
 			// Only recommend books with wanted or skipped status (they're in
@@ -157,7 +157,7 @@ func GenerateGenreSimilar(
 		}
 
 		for _, sb := range full.Books {
-			if sb.Book == nil || profile.OwnedForeignIDs[sb.Book.ForeignID] {
+			if sb.Book == nil || profile.IsOwned(sb.Book.ForeignID, sb.Book.Title, profile.AuthorNames[sb.Book.AuthorID]) {
 				continue
 			}
 			// Skip books already covered by series candidates.
@@ -204,7 +204,7 @@ func GenerateSerendipity(
 		}
 
 		for _, sb := range full.Books {
-			if sb.Book == nil || profile.OwnedForeignIDs[sb.Book.ForeignID] {
+			if sb.Book == nil || profile.IsOwned(sb.Book.ForeignID, sb.Book.Title, profile.AuthorNames[sb.Book.AuthorID]) {
 				continue
 			}
 
@@ -284,7 +284,7 @@ func GenerateListCross(
 
 	var candidates []models.RecommendationCandidate
 	for i := range books {
-		if profile.OwnedForeignIDs[books[i].ForeignID] {
+		if profile.IsOwned(books[i].ForeignID, books[i].Title, books[i].AuthorName) {
 			continue
 		}
 		books[i].RecType = models.RecTypeListCross

--- a/internal/recommender/engine_test.go
+++ b/internal/recommender/engine_test.go
@@ -451,8 +451,25 @@ func TestEngine_Run_WithMonitoredAuthorProducesCandidate(t *testing.T) {
 	}
 
 	a := seedAuthor(t, f, "Mon", "OLA_M", true)
-	// Wanted book from monitored author, not owned.
+	// Wanted book from monitored author: since #1726 wanted counts as owned,
+	// so it must NOT come back as a recommendation.
 	seedBook(t, f, a.ID, "OLW", "Wanted", []string{"fantasy"})
+	// Skipped book from the same author: still recommendable.
+	skipped := &models.Book{
+		ForeignID:        "OLS",
+		AuthorID:         a.ID,
+		Title:            "Skipped",
+		SortTitle:        "Skipped",
+		Genres:           []string{"fantasy"},
+		Status:           models.BookStatusSkipped,
+		MetadataProvider: "openlibrary",
+		Monitored:        true,
+		RatingsCount:     100,
+		AverageRating:    4.0,
+	}
+	if err := f.books.Create(ctx, skipped); err != nil {
+		t.Fatal(err)
+	}
 
 	e := New(f.books, f.authors, f.series, f.recs, f.settings)
 	if err := e.Run(ctx, f.userID); err != nil {
@@ -463,14 +480,20 @@ func TestEngine_Run_WithMonitoredAuthorProducesCandidate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	found := false
+	foundSkipped, foundWanted := false, false
 	for _, r := range recs {
+		if r.ForeignID == "OLS" {
+			foundSkipped = true
+		}
 		if r.ForeignID == "OLW" {
-			found = true
+			foundWanted = true
 		}
 	}
-	if !found {
-		t.Errorf("wanted book from monitored author should appear as a recommendation")
+	if !foundSkipped {
+		t.Errorf("skipped book from monitored author should appear as a recommendation")
+	}
+	if foundWanted {
+		t.Errorf("wanted book counts as owned (#1726) and must not be recommended back")
 	}
 }
 

--- a/internal/recommender/profile.go
+++ b/internal/recommender/profile.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 
 	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/indexer"
 	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/textutil"
 )
 
 // junkGenres are OpenLibrary subjects that add noise, not signal.
@@ -37,6 +39,8 @@ func BuildProfile(
 		AuthorBookCounts:    make(map[int64]int),
 		SeriesState:         make(map[int64]SeriesState),
 		OwnedForeignIDs:     make(map[string]bool),
+		OwnedWorkKeys:       make(map[string]bool),
+		AuthorNames:         make(map[int64]string),
 		DismissedForeignIDs: make(map[string]bool),
 		ExcludedAuthors:     make(map[string]bool),
 		PreferredLanguage:   "en",
@@ -46,6 +50,19 @@ func BuildProfile(
 	if settings != nil {
 		if s, _ := settings.Get(ctx, "search.preferredLanguage"); s != nil && s.Value != "" {
 			p.PreferredLanguage = s.Value
+		}
+	}
+
+	// Load authors before the book loop: the owned-work keys need each book's
+	// author name, and the monitored set comes from the same list.
+	allAuthors, err := authors.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range allAuthors {
+		p.AuthorNames[a.ID] = a.Name
+		if a.Monitored {
+			p.MonitoredAuthors[a.ID] = true
 		}
 	}
 
@@ -61,8 +78,13 @@ func BuildProfile(
 	genreDocCount := make(map[string]int)
 
 	for _, b := range allBooks {
-		if b.Status == models.BookStatusDownloaded || b.Status == models.BookStatusImported {
+		// Wanted counts as owned for suppression: recommending a book the
+		// user has already decided they want is never useful (#1726).
+		if b.Status == models.BookStatusDownloaded || b.Status == models.BookStatusImported || b.Status == models.BookStatusWanted {
 			p.OwnedForeignIDs[b.ForeignID] = true
+			for _, key := range ownedWorkKeys(b.Title, p.AuthorNames[b.AuthorID]) {
+				p.OwnedWorkKeys[key] = true
+			}
 		}
 		p.AuthorBookCounts[b.AuthorID]++
 
@@ -86,17 +108,6 @@ func BuildProfile(
 			tf := float64(docCount) / float64(p.TotalBooks)
 			idf := math.Log(float64(totalUniqueGenres) / float64(docCount))
 			p.GenreWeights[genre] = tf * idf
-		}
-	}
-
-	// Build monitored authors set.
-	allAuthors, err := authors.List(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for _, a := range allAuthors {
-		if a.Monitored {
-			p.MonitoredAuthors[a.ID] = true
 		}
 	}
 
@@ -163,6 +174,47 @@ func BuildProfile(
 	}
 
 	return p, nil
+}
+
+// ownedWorkKeys returns the work-identity keys a book is owned under: the
+// canonical title dedup key (#940) crossed with every normalized variant of
+// the author name. Variants — not a single fold — because candidate author
+// names are provider strings ("Card, Orson Scott", ASCII-ised umlauts) that
+// need not equal the local author row; NormalizeAuthorNameWithVariants is the
+// shared post-#1647 author comparison, and hand-rolling a different fold here
+// is the drift class #1648 exists to prevent. Returns nil when either the
+// title or the author name folds to nothing — the author dimension is
+// mandatory, so such books are only matchable by ForeignID.
+func ownedWorkKeys(title, authorName string) []string {
+	dedup := indexer.CanonicalDedupKey(title)
+	if dedup == "" {
+		return nil
+	}
+	variants := textutil.NormalizeAuthorNameWithVariants(authorName)
+	keys := make([]string, 0, len(variants))
+	for _, v := range variants {
+		keys = append(keys, dedup+"\x00"+v)
+	}
+	return keys
+}
+
+// IsOwned reports whether the user already has this work: first by exact
+// ForeignID, then by work identity (title dedup key + author name). The
+// second check is what catches the same work owned via a different provider
+// (candidate "hc:ender-in-exile" vs owned "OL49485W", #1726). The key
+// deliberately includes the author: a title-only match would silently
+// suppress same-titled books by different authors, and a missing
+// recommendation is harder to notice than a duplicate one.
+func (p *UserProfile) IsOwned(foreignID, title, authorName string) bool {
+	if p.OwnedForeignIDs[foreignID] {
+		return true
+	}
+	for _, key := range ownedWorkKeys(title, authorName) {
+		if p.OwnedWorkKeys[key] {
+			return true
+		}
+	}
+	return false
 }
 
 // medianReleaseYear returns the median publication year across all books that

--- a/internal/recommender/profile_test.go
+++ b/internal/recommender/profile_test.go
@@ -149,7 +149,8 @@ func TestBuildProfile_OwnedAndAuthorCounts(t *testing.T) {
 	f := newProfileFixtures(t)
 	a := seedAuthor(t, f, "Prolific", "OL_PROLIFIC", true)
 	b := seedAuthor(t, f, "One Hit", "OL_ONEHIT", false)
-	// Imported books should be "owned"; wanted books should not be.
+	// Imported AND wanted books both count as owned for suppression (#1726):
+	// re-recommending a book the user already decided they want is useless.
 	seedImportedBook(t, f, a.ID, "OL1I", "B1 imported", []string{"fantasy"})
 	seedImportedBook(t, f, a.ID, "OL2I", "B2 imported", []string{"fantasy"})
 	seedBook(t, f, a.ID, "OL3W", "B3 wanted", []string{"fantasy"})
@@ -162,8 +163,8 @@ func TestBuildProfile_OwnedAndAuthorCounts(t *testing.T) {
 	if !p.OwnedForeignIDs["OL1I"] || !p.OwnedForeignIDs["OL2I"] {
 		t.Errorf("imported books missing from OwnedForeignIDs: %v", p.OwnedForeignIDs)
 	}
-	if p.OwnedForeignIDs["OL3W"] || p.OwnedForeignIDs["OL4W"] {
-		t.Errorf("wanted books should not be in OwnedForeignIDs: %v", p.OwnedForeignIDs)
+	if !p.OwnedForeignIDs["OL3W"] || !p.OwnedForeignIDs["OL4W"] {
+		t.Errorf("wanted books should be in OwnedForeignIDs (#1726): %v", p.OwnedForeignIDs)
 	}
 	if p.AuthorBookCounts[a.ID] != 3 {
 		t.Errorf("Prolific book count: want 3, got %d", p.AuthorBookCounts[a.ID])
@@ -233,6 +234,105 @@ func TestBuildProfile_DismissedAndExclusions(t *testing.T) {
 	// Excluded authors are stored lowercased.
 	if !p.ExcludedAuthors["bad author"] {
 		t.Errorf("excluded authors should include 'bad author', got %v", p.ExcludedAuthors)
+	}
+}
+
+// TestIsOwned_CrossProvider is the #1726 regression: a work owned under one
+// provider's ForeignID must suppress the same work surfaced by another
+// provider, matched by title dedup key + author — and the author dimension
+// must keep same-titled books by different authors recommendable.
+func TestIsOwned_CrossProvider(t *testing.T) {
+	f := newProfileFixtures(t)
+	a := seedAuthor(t, f, "Orson Scott Card", "OL_CARD", false)
+	seedImportedBook(t, f, a.ID, "OL49485W", "Ender in Exile", []string{"science fiction"})
+
+	p, err := BuildProfile(context.Background(), f.userID, f.books, f.authors, f.series, f.recs, f.settings)
+	if err != nil {
+		t.Fatalf("BuildProfile: %v", err)
+	}
+
+	// Same work from Hardcover: different ForeignID, same title and author.
+	if !p.IsOwned("hc:ender-in-exile", "Ender in Exile", "Orson Scott Card") {
+		t.Error("same title+author from another provider should be owned")
+	}
+	// Provider spells the author last-first: still the same person.
+	if !p.IsOwned("hc:ender-in-exile", "Ender in Exile", "Card, Orson Scott") {
+		t.Error("last-first author spelling should still match")
+	}
+	// Same title, different author: a distinct work, must NOT be suppressed.
+	if p.IsOwned("hc:other", "Ender in Exile", "Jane Doe") {
+		t.Error("same title by a different author must not be owned")
+	}
+	// Exact ForeignID still matches regardless of title/author strings.
+	if !p.IsOwned("OL49485W", "", "") {
+		t.Error("exact ForeignID match should be owned")
+	}
+	// Missing author name must not fall back to title-only matching.
+	if p.IsOwned("hc:ender-in-exile", "Ender in Exile", "") {
+		t.Error("empty author name must not match on title alone")
+	}
+}
+
+// TestHardFilter_CrossProviderOwned drives the same scenario through the real
+// filter path candidates take.
+func TestHardFilter_CrossProviderOwned(t *testing.T) {
+	f := newProfileFixtures(t)
+	a := seedAuthor(t, f, "Orson Scott Card", "OL_CARD", false)
+	seedImportedBook(t, f, a.ID, "OL49485W", "Ender in Exile", []string{"science fiction"})
+
+	p, err := BuildProfile(context.Background(), f.userID, f.books, f.authors, f.series, f.recs, f.settings)
+	if err != nil {
+		t.Fatalf("BuildProfile: %v", err)
+	}
+
+	owned := models.RecommendationCandidate{
+		ForeignID:    "hc:ender-in-exile",
+		RecType:      models.RecTypeListCross,
+		Title:        "Ender in Exile",
+		AuthorName:   "Orson Scott Card",
+		Rating:       4.2,
+		RatingsCount: 500,
+	}
+	otherAuthor := models.RecommendationCandidate{
+		ForeignID:    "hc:other-exile",
+		RecType:      models.RecTypeListCross,
+		Title:        "Ender in Exile",
+		AuthorName:   "Jane Doe",
+		Rating:       4.2,
+		RatingsCount: 500,
+	}
+
+	got := hardFilter([]models.RecommendationCandidate{owned, otherAuthor}, p)
+	if len(got) != 1 {
+		t.Fatalf("hardFilter: want 1 survivor, got %d: %+v", len(got), got)
+	}
+	if got[0].ForeignID != "hc:other-exile" {
+		t.Errorf("wrong survivor: %q", got[0].ForeignID)
+	}
+}
+
+// TestHardFilter_WantedIsOwned pins the second #1726 fix: a wanted-status
+// library book must suppress the matching candidate.
+func TestHardFilter_WantedIsOwned(t *testing.T) {
+	f := newProfileFixtures(t)
+	a := seedAuthor(t, f, "Author A", "OL_A", false)
+	seedBook(t, f, a.ID, "OL_WANTED", "Red God", []string{"fantasy"}) // status=wanted via helper
+
+	p, err := BuildProfile(context.Background(), f.userID, f.books, f.authors, f.series, f.recs, f.settings)
+	if err != nil {
+		t.Fatalf("BuildProfile: %v", err)
+	}
+
+	cand := models.RecommendationCandidate{
+		ForeignID:    "OL_WANTED",
+		RecType:      models.RecTypeListCross,
+		Title:        "Red God",
+		AuthorName:   "Author A",
+		Rating:       4.0,
+		RatingsCount: 500,
+	}
+	if got := hardFilter([]models.RecommendationCandidate{cand}, p); len(got) != 0 {
+		t.Errorf("wanted book should be suppressed, got %+v", got)
 	}
 }
 

--- a/internal/recommender/recommender.go
+++ b/internal/recommender/recommender.go
@@ -155,7 +155,7 @@ func hardFilter(candidates []models.RecommendationCandidate, p *UserProfile) []m
 	var filtered []models.RecommendationCandidate
 	seen := make(map[string]bool)
 	for _, c := range candidates {
-		if p.OwnedForeignIDs[c.ForeignID] {
+		if p.IsOwned(c.ForeignID, c.Title, c.AuthorName) {
 			continue
 		}
 		if p.DismissedForeignIDs[c.ForeignID] {

--- a/internal/recommender/types.go
+++ b/internal/recommender/types.go
@@ -14,11 +14,21 @@ type SeriesState struct {
 
 // UserProfile captures the user's reading taste, built from their library.
 type UserProfile struct {
-	GenreWeights        map[string]float64
-	MonitoredAuthors    map[int64]bool
-	AuthorBookCounts    map[int64]int
-	SeriesState         map[int64]SeriesState
-	OwnedForeignIDs     map[string]bool
+	GenreWeights     map[string]float64
+	MonitoredAuthors map[int64]bool
+	AuthorBookCounts map[int64]int
+	SeriesState      map[int64]SeriesState
+	OwnedForeignIDs  map[string]bool
+	// OwnedWorkKeys keys ownership by work identity — indexer.CanonicalDedupKey
+	// of the title crossed with a normalized author-name variant (see
+	// ownedWorkKeys). ForeignIDs are provider-specific (hc:… vs OL… vs
+	// audible:…), so OwnedForeignIDs alone never matches the same work owned
+	// via a different metadata provider (#1726).
+	OwnedWorkKeys map[string]bool
+	// AuthorNames maps local author ID to display name so candidate
+	// generators can pass an author name to IsOwned for books that only carry
+	// an AuthorID. Populated by BuildProfile from the authors it already loads.
+	AuthorNames         map[int64]string
 	DismissedForeignIDs map[string]bool
 	ExcludedAuthors     map[string]bool
 	PreferredLanguage   string


### PR DESCRIPTION
## Summary
Discover was recommending books the user already owns (15 of 22 in one reported batch). Ownership is now matched by work identity across metadata providers, and wanted-list books count as owned for suppression.

## Root cause
Ownership checks in `hardFilter`, `BuildProfile`, and all six candidate generators keyed off exact `Book.ForeignID`. ForeignIDs are provider-specific (`hc:ender-in-exile` vs `OL49485W` vs `audible:...`), so the same work owned via another provider never matched. Separately, `BuildProfile` only treated Downloaded/Imported as owned, so wanted books came straight back as recommendations.

## Fix
- `UserProfile` gains `OwnedWorkKeys`, keyed by `indexer.CanonicalDedupKey(title)` + `"\x00"` + a normalized author-name variant. The author dimension is deliberate: a title-only key would silently suppress same-titled books by different authors. Author folding reuses `textutil.NormalizeAuthorNameWithVariants` (the shared post-#1647 author comparison) on both the owned and candidate side, so provider spellings like "Card, Orson Scott" still match — no new normalization hand-rolled.
- New `(*UserProfile).IsOwned(foreignID, title, authorName)` checks ForeignID first, then the work-identity map. It replaces the raw map lookups in `hardFilter` and the six sites in `candidates.go`. `BuildProfile` loads authors before the book loop (it already received the repo) and exposes an `AuthorNames` id-to-name map for generators that only have an `AuthorID`.
- `BuildProfile` now counts `BookStatusWanted` as owned. Side effect: author-new candidates now only surface skipped-status books, which is the intended behavior — wanted books should not be recommended back.
- Dismissals stay keyed by ForeignID, unchanged (out of scope per the issue).

## Test plan
- [x] `go test -count=1 ./internal/recommender/` — ok (new: `TestIsOwned_CrossProvider`, `TestHardFilter_CrossProviderOwned`, `TestHardFilter_WantedIsOwned`; updated: `TestBuildProfile_OwnedAndAuthorCounts`, `TestEngine_Run_WithMonitoredAuthorProducesCandidate`)
- [x] Non-vacuity: neutered both fixes (IsOwned reduced to the ForeignID lookup; Wanted removed from the owned condition) — all five tests above fail; restored, suite green
- [x] `go test -count=1 ./internal/indexer/ ./internal/textutil/` — ok
- [x] `gofmt -l internal/recommender` clean, `golangci-lint run ./internal/recommender/...` 0 issues, `go vet` clean

Closes #1726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
