### PR TITLE
fix(hardcover): stop edition hydration overriding a list-pinned media type (#1732)

### DIFF
--- a/changelog.d/1732-pinned-mediatype.md
+++ b/changelog.d/1732-pinned-mediatype.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Ebook-pinned Hardcover lists no longer create books as "both"** (#1732) — edition hydration ran right after a list-synced book was created and widened a pinned `ebook` media type to `both` whenever the work had any audio-shaped edition on Hardcover (true for most popular titles). Hydration now knows when the media type was deliberately pinned by the list and leaves it alone; books with no media type at all still promote to `audiobook` when an audio edition exists.

--- a/internal/bookhydrate/hardcover.go
+++ b/internal/bookhydrate/hardcover.go
@@ -38,6 +38,11 @@ type Options struct {
 	Books             BookUpdater
 	FetchEditions     EditionFetcher
 	Enricher          AudiobookEnricher
+	// MediaTypePinned marks the book's MediaType as a deliberate caller
+	// choice (e.g. an import list's per-list format override) rather than a
+	// provider-derived guess. Hydration must not widen a pinned single-format
+	// book to "both" just because an audio-shaped edition exists (#1732).
+	MediaTypePinned bool
 }
 
 // Result summarizes a best-effort hydration attempt.
@@ -125,7 +130,7 @@ func HydrateHardcoverEditions(ctx context.Context, opts Options) Result {
 	// maybePromoteASIN promotes the ASIN from, keeping the two derivations
 	// consistent.
 	if edition, ok := preferredAudioEdition(acceptedAudioEditions); ok {
-		if deriveAudiobookMetadataFromEdition(book, edition) {
+		if deriveAudiobookMetadataFromEdition(book, edition, opts.MediaTypePinned) {
 			result.MetadataDerived = true
 		}
 	}
@@ -189,13 +194,20 @@ func preferredAudioEdition(editions []models.Edition) (models.Edition, bool) {
 // never overwritten ("unknown ⇒ don't clobber known"). It also makes sure an
 // audio-bearing book carries an audiobook MediaType so the Audnex path is
 // eligible. Returns whether it changed anything.
-func deriveAudiobookMetadataFromEdition(book *models.Book, edition models.Edition) bool {
+//
+// mediaTypePinned means the caller set MediaType deliberately (a list's
+// per-list format override): the promotion below must not run, or an
+// ebook-pinned book would be widened to "both" whenever the work has any
+// audio edition on Hardcover — true for most popular titles (#1732). The
+// "" → audiobook arm is unaffected because a pinned MediaType is by
+// definition non-empty.
+func deriveAudiobookMetadataFromEdition(book *models.Book, edition models.Edition, mediaTypePinned bool) bool {
 	if book == nil {
 		return false
 	}
 	changed := false
 
-	if !bookAcceptsAudiobookASIN(book) {
+	if !bookAcceptsAudiobookASIN(book) && !mediaTypePinned {
 		// The chosen edition is audio-looking but the book wasn't flagged as
 		// audio yet; promote it so downstream audio enrichment is eligible.
 		switch book.MediaType {

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -256,7 +256,10 @@ func (s *ListSyncer) syncList(ctx context.Context, il models.ImportList) error {
 			slog.Warn("failed to create book", "title", book.Title, "error", err)
 			continue
 		}
-		s.hydrateHardcoverEditions(ctx, &book, client)
+		// Tell hydration whether the media type was pinned by the list above:
+		// a pinned ebook must not be widened to "both" just because the work
+		// has an audio edition on Hardcover (#1732).
+		s.hydrateHardcoverEditions(ctx, &book, client, il.MediaType != "")
 		slog.Info("imported book from hardcover list", "title", book.Title, "author_id", authorID)
 
 		s.linkSeriesRefs(ctx, &book)
@@ -294,17 +297,18 @@ func (s *ListSyncer) tokenForList(ctx context.Context, il models.ImportList) str
 	return hardcover.NormalizeAPIToken(s.tokenSource(ctx))
 }
 
-func (s *ListSyncer) hydrateHardcoverEditions(ctx context.Context, book *models.Book, client hardcoverClient) {
+func (s *ListSyncer) hydrateHardcoverEditions(ctx context.Context, book *models.Book, client hardcoverClient, mediaTypePinned bool) {
 	if book == nil || client == nil || s.editions == nil {
 		return
 	}
 	bookhydrate.HydrateHardcoverEditions(ctx, bookhydrate.Options{
-		Book:          book,
-		Provider:      "hardcover",
-		Editions:      s.editions,
-		Books:         s.books,
-		FetchEditions: client.GetEditions,
-		Enricher:      s.enricher,
+		Book:            book,
+		Provider:        "hardcover",
+		Editions:        s.editions,
+		Books:           s.books,
+		FetchEditions:   client.GetEditions,
+		Enricher:        s.enricher,
+		MediaTypePinned: mediaTypePinned,
 	})
 }
 

--- a/internal/hardcoverlistsyncer/syncer_test.go
+++ b/internal/hardcoverlistsyncer/syncer_test.go
@@ -889,3 +889,121 @@ func TestSync_HydratesHardcoverEditions(t *testing.T) {
 		t.Fatalf("expected hydrated edition, got %+v", got)
 	}
 }
+
+// newHydrationSyncer wires a syncer with edition hydration against a real
+// in-memory DB and a stub client whose list serves one book (with the given
+// Hardcover-derived media type) plus one audio-shaped edition for it — the
+// shape that used to trigger the ebook → both promotion (#1732).
+func newHydrationSyncer(t *testing.T, listMediaType, derivedMediaType string) (*ListSyncer, *db.BookRepo, context.Context) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	ctx := context.Background()
+	importLists := db.NewImportListRepo(database)
+	authors := db.NewAuthorRepo(database)
+	books := db.NewBookRepo(database)
+	editions := db.NewEditionRepo(database)
+
+	audioASIN := "B123PINNED"
+	client := &fakeHardcoverClient{
+		lists: []hardcover.HCList{{ID: 42, Slug: "pinned-list", Name: "Pinned"}},
+		books: []models.Book{{
+			ForeignID:        "hc:pinned-book",
+			Title:            "Pinned Book",
+			SortTitle:        "Pinned Book",
+			MetadataProvider: "hardcover",
+			MediaType:        derivedMediaType,
+			Genres:           []string{},
+			Author: &models.Author{
+				ForeignID:        "hc:pinned-author",
+				Name:             "Pinned Author",
+				SortName:         "Author, Pinned",
+				MetadataProvider: "hardcover",
+			},
+		}},
+		editions: []models.Edition{{
+			ForeignID: "hc:pinned-book-audio",
+			Title:     "Pinned Book",
+			ASIN:      &audioASIN,
+			Format:    "Audiobook",
+			Monitored: true,
+		}},
+	}
+	syncer := New(importLists, authors, books).
+		WithEditionHydration(editions, nil).
+		WithClientFactory(func(string) hardcoverClient { return client })
+	il := testImportList("Pinned", "hardcover", true)
+	il.URL = "pinned-list"
+	il.MediaType = listMediaType
+	if err := importLists.Create(ctx, &il); err != nil {
+		t.Fatal(err)
+	}
+	return syncer, books, ctx
+}
+
+// TestSync_EbookPinnedListSurvivesAudioEditionHydration is the #1732
+// regression: a list pinned to ebook creates the book as ebook, and the
+// edition hydration that runs immediately after must not widen it to "both"
+// just because the work has an audio edition on Hardcover (true for most
+// popular titles).
+func TestSync_EbookPinnedListSurvivesAudioEditionHydration(t *testing.T) {
+	syncer, books, ctx := newHydrationSyncer(t, models.MediaTypeEbook, models.MediaTypeBoth)
+	if err := syncer.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	book, err := books.GetByForeignID(ctx, "hc:pinned-book")
+	if err != nil || book == nil {
+		t.Fatalf("created book not found: %v", err)
+	}
+	if book.MediaType != models.MediaTypeEbook {
+		t.Fatalf("media type = %q, want ebook (list pin must survive edition hydration)", book.MediaType)
+	}
+	// An ebook must not carry the audio edition's ASIN either.
+	if book.ASIN != "" {
+		t.Fatalf("ASIN = %q, want empty on an ebook-pinned book", book.ASIN)
+	}
+}
+
+// TestSync_AudiobookPinnedListUnchangedByHydration confirms the working half
+// of the #1732 asymmetry stays working: an audiobook-pinned list stays
+// audiobook and still picks up the audio edition's ASIN.
+func TestSync_AudiobookPinnedListUnchangedByHydration(t *testing.T) {
+	syncer, books, ctx := newHydrationSyncer(t, models.MediaTypeAudiobook, models.MediaTypeBoth)
+	if err := syncer.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	book, err := books.GetByForeignID(ctx, "hc:pinned-book")
+	if err != nil || book == nil {
+		t.Fatalf("created book not found: %v", err)
+	}
+	if book.MediaType != models.MediaTypeAudiobook {
+		t.Fatalf("media type = %q, want audiobook", book.MediaType)
+	}
+	if book.ASIN != "B123PINNED" {
+		t.Fatalf("ASIN = %q, want the audio edition's ASIN promoted", book.ASIN)
+	}
+}
+
+// TestSync_UnpinnedEmptyMediaTypeStillPromotesToAudiobook confirms the fix
+// only suppresses the promotion for pinned lists: with no list pin and no
+// Hardcover-derived media type, an audio edition still promotes "" to
+// audiobook so downstream audio enrichment stays eligible.
+func TestSync_UnpinnedEmptyMediaTypeStillPromotesToAudiobook(t *testing.T) {
+	syncer, books, ctx := newHydrationSyncer(t, "", "")
+	if err := syncer.Sync(ctx); err != nil {
+		t.Fatal(err)
+	}
+	book, err := books.GetByForeignID(ctx, "hc:pinned-book")
+	if err != nil || book == nil {
+		t.Fatalf("created book not found: %v", err)
+	}
+	if book.MediaType != models.MediaTypeAudiobook {
+		t.Fatalf("media type = %q, want audiobook (unpinned \"\" still promotes)", book.MediaType)
+	}
+	if book.ASIN != "B123PINNED" {
+		t.Fatalf("ASIN = %q, want the audio edition's ASIN promoted", book.ASIN)
+	}
+}


### PR DESCRIPTION
## Summary

A Hardcover import list pinned to Media Type = Ebook created most of its books as `both`. Edition hydration now knows when the media type was deliberately pinned by the list and leaves it alone. Reported on Discord #bug-reports (2026-07-23).

## Root cause

`syncList` sets `book.MediaType = il.MediaType` on create, then immediately runs `hydrateHardcoverEditions`. Inside `deriveAudiobookMetadataFromEdition`, the `ebook -> both` promotion treated a deliberately pinned ebook the same as "no format decided yet" and widened it whenever any audio-shaped edition existed for the work on Hardcover, which is true for most popular titles. Audiobook-pinned lists were immune only by accident: a book created as `audiobook` already satisfies `bookAcceptsAudiobookASIN`, so the promotion never ran.

## Fix

- `bookhydrate.Options` gains `MediaTypePinned`; when set, `deriveAudiobookMetadataFromEdition` skips the media type promotion entirely. The `"" -> audiobook` arm is unaffected (a pinned type is by definition non-empty).
- The list syncer passes `il.MediaType != ""` as the pin. All other hydration callers (single-book add, series fill, author fill, recommendations) do not set the flag, so their behavior is byte-for-byte unchanged.
- Language/cover fill from the audio edition still runs for pinned books; only the media type widening is suppressed, and the ebook-pinned book correctly gets no audio ASIN.

Non-vacuity: with the `!mediaTypePinned` gate reverted, `TestSync_EbookPinnedListSurvivesAudioEditionHydration` fails with `media type = "both", want ebook`; restored, the full suites pass.

## Test plan

- [x] `go test -count=1 ./internal/hardcoverlistsyncer/ ./internal/bookhydrate/ ./internal/api/`
- [x] `golangci-lint run ./internal/hardcoverlistsyncer/ ./internal/bookhydrate/` (0 issues)
- [x] `gofmt -l` clean on changed dirs
- [x] New regression tests: ebook-pinned list stays `ebook` with an audio edition present; audiobook-pinned list unchanged (still promotes the ASIN); unpinned `""` still promotes to `audiobook`

Closes #1732.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
