### PR TITLE
fix(auth): resolve an operator identity for install-authenticated requests (#1725)

### DIFF
--- a/changelog.d/1725-operator-identity.md
+++ b/changelog.d/1725-operator-identity.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Dismissed recommendations no longer come back** (#1725) — requests that authenticate as the install itself, from a trusted local network or with an API key, were treated as an admin but carried no user identity, so a refresh triggered that way saved its recommendations against a user that does not exist while the nightly job saved them against a real one. Dismissals recorded on one batch never applied to the other. Both now resolve to the same operator account, and an upgrade hands any stranded recommendations and dismissals back to it.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -721,6 +721,13 @@ func main() {
 		proxyCIDRs:     trustedCIDRs,
 	}
 
+	// Keep the nightly recommendation batch and manual refreshes on one
+	// identity: the auth layer stamps this same operator on trusted-local and
+	// API-key requests, and a mismatch is why dismissals stopped applying
+	// (#1725). Registered here rather than at WithRecommender because the
+	// provider does not exist yet at that point.
+	sched.WithOperatorUserID(authProvider.OperatorUserID)
+
 	r.Route("/api", func(r chi.Router) {
 		r.Use(auth.Middleware(authProvider))
 		r.Use(auth.RequireXRequestedWith)
@@ -1382,6 +1389,20 @@ func (p *dbAuthProvider) SetupRequired() bool {
 func (p *dbAuthProvider) ProxyAuthHeader() string         { return p.proxyHeader }
 func (p *dbAuthProvider) ProxyAutoProvision() bool        { return p.proxyProvision }
 func (p *dbAuthProvider) TrustedProxyCIDRs() []*net.IPNet { return p.proxyCIDRs }
+
+// OperatorUserID resolves the install's operator to the lowest-id admin, the
+// identity trusted-local and API-key requests act as (#1725). Cheap indexed
+// lookup on a tiny table, and it must stay live rather than cached at startup
+// because the first admin is created during first-run setup.
+func (p *dbAuthProvider) OperatorUserID(ctx context.Context) int64 {
+	id, err := p.users.FirstAdminID(ctx)
+	if err != nil {
+		slog.Warn("auth: failed to resolve operator user id", "error", err)
+		return 0
+	}
+	return id
+}
+
 func (p *dbAuthProvider) UserRole(ctx context.Context, userID int64) string {
 	u, err := p.users.GetByID(ctx, userID)
 	if err != nil || u == nil {

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -636,6 +636,14 @@ func (p *epochProvider) ProxyAuthHeader() string               { return "" }
 func (p *epochProvider) ProxyAutoProvision() bool              { return false }
 func (p *epochProvider) TrustedProxyCIDRs() []*net.IPNet       { return nil }
 func (p *epochProvider) UserProvisioner() auth.UserProvisioner { return nil }
+
+// operatorUserID lets a test pin the identity install-authenticated
+// requests resolve to; zero means "no admin exists" (#1725).
+func (p *epochProvider) OperatorUserID(ctx context.Context) int64 {
+	id, _ := p.users.FirstAdminID(ctx)
+	return id
+}
+
 func (p *epochProvider) UserRole(ctx context.Context, id int64) string {
 	u, _ := p.users.GetByID(ctx, id)
 	if u == nil {

--- a/internal/api/opds_test.go
+++ b/internal/api/opds_test.go
@@ -137,6 +137,10 @@ func (p *testProvider) ProxyAutoProvision() bool                   { return fals
 func (p *testProvider) TrustedProxyCIDRs() []*net.IPNet            { return nil }
 func (p *testProvider) UserRole(_ context.Context, _ int64) string { return "admin" }
 
+// OperatorUserID: these OPDS tests assert unauthenticated/api-key behaviour and
+// have no users table, so there is no admin to resolve (#1725).
+func (p *testProvider) OperatorUserID(context.Context) int64 { return 0 }
+
 // UserSessionEpoch returns 0 here; the OPDS tests in this file mint session
 // cookies via SignSession (legacy v2/v1 wrapper) which decode as epoch=0, so
 // returning 0 keeps every existing cookie test passing. The dedicated

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -243,6 +243,9 @@ type fakeProvider struct {
 	proxyProvision bool
 	proxyCIDRs     []*net.IPNet
 	provisioner    UserProvisioner
+	// operatorUserID is what OperatorUserID returns: the identity
+	// install-authenticated requests resolve to (#1725). 0 = no admin exists.
+	operatorUserID int64
 	// wantEpoch is what UserSessionEpoch returns. Defaults to 0, which lets
 	// legacy v1/v2 test cookies (which decode as epoch=0) authenticate
 	// without every test having to mint v3 cookies.
@@ -268,7 +271,11 @@ func (f *fakeProvider) ProxyAuthHeader() string                    { return f.pr
 func (f *fakeProvider) ProxyAutoProvision() bool                   { return f.proxyProvision }
 func (f *fakeProvider) TrustedProxyCIDRs() []*net.IPNet            { return f.proxyCIDRs }
 func (f *fakeProvider) UserRole(_ context.Context, _ int64) string { return "admin" }
-func (f *fakeProvider) UserProvisioner() UserProvisioner           { return f.provisioner }
+
+// OperatorUserID returns the identity install-authenticated requests resolve
+// to; 0 (the zero value) means "no admin exists" (#1725).
+func (f *fakeProvider) OperatorUserID(context.Context) int64 { return f.operatorUserID }
+func (f *fakeProvider) UserProvisioner() UserProvisioner     { return f.provisioner }
 
 // UserSessionEpoch defaults to 0 so legacy v1/v2 test cookies (which decode
 // as epoch=0) continue to authenticate. Tests that exercise the password-
@@ -1584,5 +1591,71 @@ func TestSession_VerifyMultiRejectsWhenNoSecretUsable(t *testing.T) {
 	cookie, _ := SignSession(testSecret32, 1, time.Now().Add(time.Hour))
 	if _, err := VerifySessionMulti([][]byte{[]byte("short"), nil}, cookie); !errors.Is(err, ErrSessionInvalid) {
 		t.Fatal("VerifySessionMulti must fail closed when no secret meets minSecretLen")
+	}
+}
+
+// TestInstallAuthenticatedRequestsCarryOperatorIdentity is the #1725
+// regression. Local-only and API-key requests are already treated as admin;
+// without a user id they were also anonymous, so every handler persisting
+// per-user rows wrote them under a user that does not exist.
+func TestInstallAuthenticatedRequestsCarryOperatorIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		provider *fakeProvider
+		request  func() *http.Request
+		wantID   int64
+	}{
+		{
+			name:     "local-only trusted request",
+			provider: &fakeProvider{mode: ModeLocalOnly, secret: testSecret32, operatorUserID: 7},
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/recommendations", nil)
+				req.RemoteAddr = "127.0.0.1:5555"
+				return req
+			},
+			wantID: 7,
+		},
+		{
+			name:     "api-key request",
+			provider: &fakeProvider{mode: ModeEnabled, apiKey: "secret-key", secret: testSecret32, operatorUserID: 7},
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/recommendations", nil)
+				req.Header.Set("X-Api-Key", "secret-key")
+				return req
+			},
+			wantID: 7,
+		},
+		{
+			name:     "no admin exists leaves the request unattributed",
+			provider: &fakeProvider{mode: ModeLocalOnly, secret: testSecret32, operatorUserID: 0},
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/recommendations", nil)
+				req.RemoteAddr = "127.0.0.1:5555"
+				return req
+			},
+			wantID: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotID int64
+			var gotRole string
+			h := Middleware(tc.provider)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				gotID = UserIDFromContext(r.Context())
+				gotRole = UserRoleFromContext(r.Context())
+			}))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, tc.request())
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			if gotID != tc.wantID {
+				t.Errorf("UserIDFromContext = %d, want %d — per-user writes land under this id (#1725)", gotID, tc.wantID)
+			}
+			// The admin role these branches already granted must be untouched.
+			if gotRole != "admin" {
+				t.Errorf("role = %q, want admin", gotRole)
+			}
+		})
 	}
 }

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -162,6 +163,34 @@ func WithAPIKeyAuth(ctx context.Context) context.Context {
 	return context.WithValue(ctx, viaAPIKeyCtxKey, true)
 }
 
+// operatorWarnOnce keeps a missing-operator install from logging on every
+// request; the condition is process-lifetime, not per-request.
+var operatorWarnOnce sync.Once
+
+// withOperatorUserID stamps the install's operator identity on a request that
+// authenticated as the install rather than as a person.
+//
+// Without it UserIDFromContext returns 0 for these requests, so every handler
+// that persists per-user rows wrote them under a user that does not exist —
+// invisible to the same operator reading through a session, and never matched
+// by dismissals or scoping queries (#1725). An existing identity is never
+// overwritten: the proxy-auth branch above may already have resolved a real
+// user, and that is the more specific answer.
+func withOperatorUserID(ctx context.Context, p Provider) context.Context {
+	if UserIDFromContext(ctx) != 0 {
+		return ctx
+	}
+	id := p.OperatorUserID(ctx)
+	if id == 0 {
+		operatorWarnOnce.Do(func() {
+			slog.Warn("auth: no admin user to attribute install-authenticated requests to; " +
+				"per-user data from local-only and API-key requests stays unattributed")
+		})
+		return ctx
+	}
+	return context.WithValue(ctx, userIDCtxKey, id)
+}
+
 // UserIDFromContext returns the authenticated user ID (0 if unauthenticated).
 func UserIDFromContext(ctx context.Context) int64 {
 	v, _ := ctx.Value(userIDCtxKey).(int64)
@@ -239,6 +268,14 @@ type Provider interface {
 	// UserRole returns the role string ("admin" or "user") for the given user
 	// id. Returns "" if the user is not found or an error occurs.
 	UserRole(ctx context.Context, userID int64) string
+	// OperatorUserID returns the user id that requests authenticating as the
+	// install itself — trusted local-only requests and API-key requests — act
+	// as. Both are already treated as admin; without an id they were also
+	// anonymous, so anything persisting per-user data wrote it under user 0
+	// while the scheduler wrote under a different id (#1725). Returns 0 when
+	// no admin exists, which callers treat as "unknown" and leave the context
+	// unstamped rather than inventing an identity.
+	OperatorUserID(ctx context.Context) int64
 	// UserSessionEpoch returns the user's current session epoch, the value
 	// the cookie's epoch field must match for the cookie to authenticate.
 	// Bumped on password change so old cookies stop verifying.
@@ -374,6 +411,7 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 				// even though the whole point of local-only mode is to grant
 				// frictionless access from a trusted private network (#799).
 				ctx := context.WithValue(r.Context(), userRoleCtxKey, "admin")
+				ctx = withOperatorUserID(ctx, p)
 				r = r.WithContext(ctx)
 				next.ServeHTTP(w, r)
 				return
@@ -389,6 +427,7 @@ func Middleware(p Provider) func(http.Handler) http.Handler {
 				// (#708 finding 3). A request reaches this branch only after
 				// subtle.ConstantTimeCompare confirmed the key.
 				ctx = context.WithValue(ctx, viaAPIKeyCtxKey, true)
+				ctx = withOperatorUserID(ctx, p)
 				r = r.WithContext(ctx)
 				next.ServeHTTP(w, r)
 				return

--- a/internal/db/auth.go
+++ b/internal/db/auth.go
@@ -165,6 +165,22 @@ func (r *UserRepo) GetOrCreateByOIDC(ctx context.Context, issuer, sub, preferred
 	return r.GetByID(ctx, id)
 }
 
+// FirstAdminID returns the lowest-id admin user — "the operator" for requests
+// that authenticate as the install rather than as a person (local-only trust,
+// API key). Returns 0 when no admin exists, which callers must treat as
+// "identity unknown" rather than as a valid user id (#1725).
+func (r *UserRepo) FirstAdminID(ctx context.Context) (int64, error) {
+	var id sql.NullInt64
+	if err := r.db.QueryRowContext(ctx,
+		"SELECT MIN(id) FROM users WHERE role='admin'").Scan(&id); err != nil {
+		return 0, fmt.Errorf("first admin id: %w", err)
+	}
+	if !id.Valid {
+		return 0, nil
+	}
+	return id.Int64, nil
+}
+
 // CountAdmins returns the number of users with role "admin". Used by the OIDC
 // callback to detect the lockout trap (zero admins) at provision time.
 func (r *UserRepo) CountAdmins(ctx context.Context) (int, error) {

--- a/internal/db/migrations/069_recommendations_user_zero.sql
+++ b/internal/db/migrations/069_recommendations_user_zero.sql
@@ -1,0 +1,35 @@
+-- +migrate Up
+-- Re-parent recommendation rows stranded under user 0 (#1725).
+--
+-- The local-only and API-key auth branches set the caller's role but never the
+-- caller's user id, so UserIDFromContext returned 0 and a refresh triggered
+-- from a trusted-local browser or a script wrote its batch under user 0, while
+-- the nightly scheduler job wrote under a hardcoded id. Recommendations and
+-- dismissals are both user-scoped, so the two never saw each other: dismissed
+-- books reappeared, and a batch generated one way was invisible the other.
+--
+-- Rows under user 0 are unreachable — no session can read or dismiss them —
+-- so hand them to the operator (the lowest-id admin, the same identity the
+-- auth layer now resolves). Guarded on an admin existing; on an install with
+-- none, the rows stay put and the next refresh replaces them anyway.
+UPDATE recommendations
+SET user_id = (SELECT MIN(id) FROM users WHERE role = 'admin')
+WHERE user_id = 0
+  AND EXISTS (SELECT 1 FROM users WHERE role = 'admin');
+
+-- Dismissals carry (user_id, foreign_id) with a uniqueness constraint, so a
+-- straight UPDATE can collide with a dismissal the admin already recorded for
+-- the same book. Move only the rows that do not collide, then drop the rest:
+-- a duplicate dismissal carries no information the surviving row lacks.
+UPDATE OR IGNORE recommendation_dismissals
+SET user_id = (SELECT MIN(id) FROM users WHERE role = 'admin')
+WHERE user_id = 0
+  AND EXISTS (SELECT 1 FROM users WHERE role = 'admin');
+
+DELETE FROM recommendation_dismissals
+WHERE user_id = 0
+  AND EXISTS (SELECT 1 FROM users WHERE role = 'admin');
+
+-- +migrate Down
+-- Irreversible: user 0 is not a real account, and which rows originated there
+-- is not recorded once they are re-parented.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -130,26 +130,29 @@ type Scheduler struct {
 	searcher bookSearcher
 	meta     *metadata.Aggregator
 
-	authors              *db.AuthorRepo
-	books                *db.BookRepo
-	indexers             *db.IndexerRepo
-	downloads            *db.DownloadRepo
-	clients              *db.DownloadClientRepo
-	history              *db.HistoryRepo
-	settings             *db.SettingsRepo
-	blocklist            *db.BlocklistRepo
-	delayProfiles        *db.DelayProfileRepo
-	pending              *db.PendingReleaseRepo
-	aliases              *db.AuthorAliasRepo     // optional; used for non-latin author matching
-	profiles             *db.MetadataProfileRepo // optional; applies profile language filters to auto-grab
-	qualityProfiles      *db.QualityProfileRepo  // optional; enforces the profile's allowed formats on auto-grab (#1693)
-	calibreSyncer        CalibreSyncer           // optional; nil if Calibre is not configured
-	recommender          RecommendationEngine    // optional; generates recommendations
-	hcSyncer             HCListSyncer            // optional; syncs Hardcover import lists
-	telemetry            TelemetryPinger         // optional; sends daily anonymous install ping
-	logs                 *db.LogRepo             // optional; enables periodic log retention trim
-	notif                eventNotifier           // optional; fires EventGrabbed on auto-grab success (#849)
-	logRetainDays        int                     // 0 = use default (14)
+	authors         *db.AuthorRepo
+	books           *db.BookRepo
+	indexers        *db.IndexerRepo
+	downloads       *db.DownloadRepo
+	clients         *db.DownloadClientRepo
+	history         *db.HistoryRepo
+	settings        *db.SettingsRepo
+	blocklist       *db.BlocklistRepo
+	delayProfiles   *db.DelayProfileRepo
+	pending         *db.PendingReleaseRepo
+	aliases         *db.AuthorAliasRepo     // optional; used for non-latin author matching
+	profiles        *db.MetadataProfileRepo // optional; applies profile language filters to auto-grab
+	qualityProfiles *db.QualityProfileRepo  // optional; enforces the profile's allowed formats on auto-grab (#1693)
+	calibreSyncer   CalibreSyncer           // optional; nil if Calibre is not configured
+	recommender     RecommendationEngine    // optional; generates recommendations
+	// operatorUserID resolves the user the recommendation job writes under.
+	// Optional; nil falls back to the historical hardcoded admin id (#1725).
+	operatorUserID       func(context.Context) int64
+	hcSyncer             HCListSyncer    // optional; syncs Hardcover import lists
+	telemetry            TelemetryPinger // optional; sends daily anonymous install ping
+	logs                 *db.LogRepo     // optional; enables periodic log retention trim
+	notif                eventNotifier   // optional; fires EventGrabbed on auto-grab success (#849)
+	logRetainDays        int             // 0 = use default (14)
 	downloadDir          string
 	audiobookDownloadDir string
 }
@@ -260,6 +263,14 @@ func (s *Scheduler) WithCalibreSyncer(syncer CalibreSyncer) {
 // Must be called before Start.
 func (s *Scheduler) WithRecommender(engine RecommendationEngine) {
 	s.recommender = engine
+}
+
+// WithOperatorUserID supplies the identity the recommendation job attributes
+// its batch to. It must agree with the id the auth layer stamps on
+// install-authenticated requests, or a manual refresh and the nightly job
+// write to different users and dismissals never suppress anything (#1725).
+func (s *Scheduler) WithOperatorUserID(fn func(context.Context) int64) {
+	s.operatorUserID = fn
 }
 
 // WithHardcoverSyncer registers a Hardcover list syncer that runs every 24
@@ -385,7 +396,18 @@ func (s *Scheduler) Start() {
 					return
 				}
 			}
-			if err := s.recommender.Run(s.ctx(), 1); err != nil {
+			// Attribute the batch to the same operator the auth layer
+			// resolves for install-authenticated requests. Hardcoding 1 here
+			// meant the nightly job and a manual refresh could write under
+			// different users, so dismissals never applied (#1725).
+			ctx := s.ctx()
+			uid := int64(1)
+			if s.operatorUserID != nil {
+				if resolved := s.operatorUserID(ctx); resolved != 0 {
+					uid = resolved
+				}
+			}
+			if err := s.recommender.Run(ctx, uid); err != nil {
 				slog.Error("recommendation engine failed", "error", err)
 			}
 		}))


### PR DESCRIPTION
## Summary

Fixes #1725. Reported against the recommender, but the defect is in auth: any handler deriving identity from `UserIDFromContext` behind two of the middleware's branches got `0`.

## Root cause

`internal/auth/middleware.go` — the local-only bypass and the API-key branch both set `userRoleCtxKey` to `admin` but never set `userIDCtxKey`. `UserIDFromContext` returns the zero value, so those requests are admin-privileged and simultaneously anonymous.

Where that lands, with storage that is fully user-scoped (`ReplaceBatch`, `List` and `Dismiss` all filter `user_id`):

| Writer | user id |
| --- | --- |
| `RecommendationHandler.Refresh` from a trusted-local browser or a script | **0** |
| the 24-hour scheduler job | **1**, hardcoded |
| a dismissal from a normal session | the real user |

Three writers that can disagree. Dismissals recorded against one batch never suppressed the other — the reporter's symptom.

The report covered the local-only path only. The **API-key branch has the identical hole**, and that is the path automation and scripts use, so the blast radius is larger than filed.

## Fix

* `UserRepo.FirstAdminID` resolves the lowest-id admin; `Provider` gains `OperatorUserID` so the middleware asks for the identity rather than reaching into the users table itself.
* Both branches stamp it, guarded by `UserIDFromContext(ctx) != 0` so an identity already resolved by proxy auth is never overwritten — that is the more specific answer. Warn-once, not per-request, when no admin exists; the request proceeds unattributed rather than being blocked.
* The scheduler takes the same resolver instead of hardcoding `1`, wired from the auth provider in `main.go` so the two cannot drift apart.
* Migration `069` re-parents rows stranded under user 0. Dismissals move with `UPDATE OR IGNORE` followed by a delete, because `(user_id, foreign_id)` is unique and a duplicate dismissal carries nothing the surviving row lacks.

## Test plan

`TestInstallAuthenticatedRequestsCarryOperatorIdentity` covers local-only, API-key, and the no-admin case, and asserts the `admin` role those branches already granted is untouched.

Non-vacuity: removing the two `withOperatorUserID` calls fails it with `UserIDFromContext = 0, want 7` on both authenticated cases; restored, green.

- [x] `go test ./... -count=1` — full suite, no failures
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofmt -l internal/ cmd/` — clean
- [x] Changelog fragment under `changelog.d/`

Migration numbering: `067` is #1711 (merged), `068` is #1743, this is `069`.

`docs/DEPLOYMENT.md` not applicable — no configuration or upgrade-path change beyond the automatic migration.

Closes #1725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
