### PR TITLE
fix(security): stamp owner_user_id on metadata and quality profile create

### DIFF
--- a/changelog.d/profile-owner-idor.md
+++ b/changelog.d/profile-owner-idor.md
@@ -1,0 +1,2 @@
+### Security
+- **Metadata and quality profiles created via the API are now scoped to their creator** — `Create` never wrote `owner_user_id`, so with `BINDERY_ENFORCE_TENANCY` on, every API-created profile was owner-less and the per-user access check (`CheckOwnership`) treated it as shared, letting any authenticated user read, edit, or delete another user's profile. Both profile Create paths now stamp the caller's user id (`CreateForUser`), matching authors/books. Existing owner-less rows stay shared, as before.

--- a/internal/api/authorization_test.go
+++ b/internal/api/authorization_test.go
@@ -3,9 +3,11 @@ package api
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -422,6 +424,95 @@ func TestQualityProfile_Get_GateOffAllowsCrossUser(t *testing.T) {
 	h.Get(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("gate off must preserve cross-user access; got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestMetadataProfile_Create_StampsOwnerClosesIDOR drives the real Create
+// handler (not setOwner) to prove the owner-stamp fix: before it, Create never
+// wrote owner_user_id, so every API-created profile was owner-0 and
+// CheckOwnership let any authenticated user read/modify/delete it. After the
+// fix a second user's Get on the creator's profile is blocked.
+func TestMetadataProfile_Create_StampsOwnerClosesIDOR(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	users := db.NewUserRepo(database)
+	repo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+	alice, _ := users.Create(ctx, "alice", "h1")
+	bob, _ := users.Create(ctx, "bob", "h2")
+
+	h := NewMetadataProfileHandler(repo)
+
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/metadataprofile",
+		strings.NewReader(`{"name":"Alice Profile","allowedLanguages":"eng"}`)).
+		WithContext(withAuthCtx(context.Background(), alice.ID, "user"))
+	createRec := httptest.NewRecorder()
+	h.Create(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create: got %d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var created models.MetadataProfile
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil || created.ID == 0 {
+		t.Fatalf("decode created: err=%v id=%d", err, created.ID)
+	}
+
+	bobRec := httptest.NewRecorder()
+	h.Get(bobRec, newRequestForID(http.MethodGet, "/x", created.ID, withAuthCtx(context.Background(), bob.ID, "user")))
+	if bobRec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user Get must 404 after owner stamp; got %d", bobRec.Code)
+	}
+
+	aliceRec := httptest.NewRecorder()
+	h.Get(aliceRec, newRequestForID(http.MethodGet, "/x", created.ID, withAuthCtx(context.Background(), alice.ID, "user")))
+	if aliceRec.Code != http.StatusOK {
+		t.Fatalf("owner Get must 200; got %d body=%s", aliceRec.Code, aliceRec.Body.String())
+	}
+}
+
+// TestQualityProfile_Create_StampsOwnerClosesIDOR is the quality-profile
+// counterpart — same owner-stamp gap, same fix.
+func TestQualityProfile_Create_StampsOwnerClosesIDOR(t *testing.T) {
+	auth.SetEnforceTenancyForTests(t, true)
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	users := db.NewUserRepo(database)
+	repo := db.NewQualityProfileRepo(database)
+	ctx := context.Background()
+	alice, _ := users.Create(ctx, "alice", "h1")
+	bob, _ := users.Create(ctx, "bob", "h2")
+
+	h := NewQualityProfileHandler(repo)
+
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/qualityprofile",
+		strings.NewReader(`{"name":"Alice QP","cutoff":"epub","items":[{"quality":"epub","allowed":true}]}`)).
+		WithContext(withAuthCtx(context.Background(), alice.ID, "user"))
+	createRec := httptest.NewRecorder()
+	h.Create(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create: got %d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var created models.QualityProfile
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil || created.ID == 0 {
+		t.Fatalf("decode created: err=%v id=%d", err, created.ID)
+	}
+
+	bobRec := httptest.NewRecorder()
+	h.Get(bobRec, newRequestForID(http.MethodGet, "/x", created.ID, withAuthCtx(context.Background(), bob.ID, "user")))
+	if bobRec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user Get must 404 after owner stamp; got %d", bobRec.Code)
+	}
+
+	aliceRec := httptest.NewRecorder()
+	h.Get(aliceRec, newRequestForID(http.MethodGet, "/x", created.ID, withAuthCtx(context.Background(), alice.ID, "user")))
+	if aliceRec.Code != http.StatusOK {
+		t.Fatalf("owner Get must 200; got %d body=%s", aliceRec.Code, aliceRec.Body.String())
 	}
 }
 

--- a/internal/api/metadata_profiles.go
+++ b/internal/api/metadata_profiles.go
@@ -71,7 +71,7 @@ func (h *MetadataProfileHandler) Create(w http.ResponseWriter, r *http.Request) 
 	if p.UnknownLanguageBehavior != models.UnknownLanguageFail {
 		p.UnknownLanguageBehavior = models.UnknownLanguagePass
 	}
-	if err := h.repo.Create(r.Context(), &p); err != nil {
+	if err := h.repo.CreateForUser(r.Context(), &p, auth.UserIDFromContext(r.Context())); err != nil {
 		writeServerError(w, r, err)
 		return
 	}

--- a/internal/api/quality_profiles.go
+++ b/internal/api/quality_profiles.go
@@ -79,7 +79,7 @@ func (h *QualityProfileHandler) Create(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusConflict, map[string]string{"error": "a quality profile with that name already exists"})
 		return
 	}
-	if err := h.profiles.Create(r.Context(), &p); err != nil {
+	if err := h.profiles.CreateForUser(r.Context(), &p, auth.UserIDFromContext(r.Context())); err != nil {
 		writeServerError(w, r, err)
 		return
 	}

--- a/internal/db/metadata_profiles.go
+++ b/internal/db/metadata_profiles.go
@@ -62,18 +62,39 @@ func (r *MetadataProfileRepo) GetByID(ctx context.Context, id int64) (*models.Me
 	return &p, rows.Err()
 }
 
+// Create inserts a system-owned metadata profile (owner_user_id NULL). Use it
+// for non-user-driven writers (seeding, migrations). User-driven creates from
+// the API MUST use CreateForUser so the row is scoped to its creator —
+// otherwise it lands owner-less and CheckOwnership treats it as shared, letting
+// any authenticated user read/modify/delete it.
 func (r *MetadataProfileRepo) Create(ctx context.Context, p *models.MetadataProfile) error {
+	return r.create(ctx, p, 0)
+}
+
+// CreateForUser inserts a metadata profile owned by ownerUserID. A zero id
+// (API-key / local-only / disabled-auth requests that carry no user identity)
+// is written as NULL, matching AuthorRepo.CreateForUser and the "0 ⇒ shared /
+// admin-equivalent" convention CheckOwnership relies on.
+func (r *MetadataProfileRepo) CreateForUser(ctx context.Context, p *models.MetadataProfile, ownerUserID int64) error {
+	return r.create(ctx, p, ownerUserID)
+}
+
+func (r *MetadataProfileRepo) create(ctx context.Context, p *models.MetadataProfile, ownerUserID int64) error {
 	if p.UnknownLanguageBehavior == "" {
 		p.UnknownLanguageBehavior = models.UnknownLanguagePass
+	}
+	var ownerArg any
+	if ownerUserID != 0 {
+		ownerArg = ownerUserID
 	}
 	result, err := r.db.ExecContext(ctx, `
 		INSERT INTO metadata_profiles (name, min_popularity, min_pages, skip_missing_date,
 		                               skip_missing_isbn, skip_part_books, allowed_languages,
-		                               unknown_language_behavior)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		                               unknown_language_behavior, owner_user_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		p.Name, p.MinPopularity, p.MinPages,
 		p.SkipMissingDate, p.SkipMissingISBN, p.SkipPartBooks, p.AllowedLanguages,
-		p.UnknownLanguageBehavior)
+		p.UnknownLanguageBehavior, ownerArg)
 	if err != nil {
 		return fmt.Errorf("create metadata profile: %w", err)
 	}
@@ -82,6 +103,7 @@ func (r *MetadataProfileRepo) Create(ctx context.Context, p *models.MetadataProf
 		return fmt.Errorf("get metadata profile id: %w", err)
 	}
 	p.ID = id
+	p.OwnerUserID = ownerUserID
 	return nil
 }
 

--- a/internal/db/quality_profiles.go
+++ b/internal/db/quality_profiles.go
@@ -72,7 +72,24 @@ func (r *QualityProfileRepo) GetByID(ctx context.Context, id int64) (*models.Qua
 // Create inserts a new quality profile. The items slice is serialised to JSON
 // in a single column — items are inherently ordered (preference) and small
 // enough that a separate join table buys nothing.
+// Create inserts a system-owned quality profile (owner_user_id NULL). Use it
+// for non-user-driven writers (seeding, migrations). User-driven creates from
+// the API MUST use CreateForUser so the row is scoped to its creator —
+// otherwise it lands owner-less and CheckOwnership treats it as shared, letting
+// any authenticated user read/modify/delete it.
 func (r *QualityProfileRepo) Create(ctx context.Context, p *models.QualityProfile) error {
+	return r.create(ctx, p, 0)
+}
+
+// CreateForUser inserts a quality profile owned by ownerUserID. A zero id
+// (API-key / local-only / disabled-auth requests that carry no user identity)
+// is written as NULL, matching AuthorRepo.CreateForUser and the "0 ⇒ shared /
+// admin-equivalent" convention CheckOwnership relies on.
+func (r *QualityProfileRepo) CreateForUser(ctx context.Context, p *models.QualityProfile, ownerUserID int64) error {
+	return r.create(ctx, p, ownerUserID)
+}
+
+func (r *QualityProfileRepo) create(ctx context.Context, p *models.QualityProfile, ownerUserID int64) error {
 	itemsJSON, err := marshalItems(p.Items)
 	if err != nil {
 		return err
@@ -81,10 +98,14 @@ func (r *QualityProfileRepo) Create(ctx context.Context, p *models.QualityProfil
 	if p.UpgradeAllowed {
 		upgrade = 1
 	}
+	var ownerArg any
+	if ownerUserID != 0 {
+		ownerArg = ownerUserID
+	}
 	result, err := r.db.ExecContext(ctx, `
-		INSERT INTO quality_profiles (name, upgrade_allowed, cutoff, items)
-		VALUES (?, ?, ?, ?)`,
-		p.Name, upgrade, p.Cutoff, itemsJSON)
+		INSERT INTO quality_profiles (name, upgrade_allowed, cutoff, items, owner_user_id)
+		VALUES (?, ?, ?, ?, ?)`,
+		p.Name, upgrade, p.Cutoff, itemsJSON, ownerArg)
 	if err != nil {
 		return fmt.Errorf("create quality profile: %w", err)
 	}
@@ -93,6 +114,7 @@ func (r *QualityProfileRepo) Create(ctx context.Context, p *models.QualityProfil
 		return fmt.Errorf("get quality profile id: %w", err)
 	}
 	p.ID = id
+	p.OwnerUserID = ownerUserID
 	return nil
 }
 


### PR DESCRIPTION
## Cross-user IDOR on metadata and quality profiles

`MetadataProfileRepo.Create` (`internal/db/metadata_profiles.go`) and `QualityProfileRepo.Create` (`internal/db/quality_profiles.go`) omitted `owner_user_id` from their INSERT. Migration 025 added that column as nullable with no default, so an API-created profile stored `NULL`, which the SQLite driver scans back as `int64(0)`.

`auth.CheckOwnership` returns `true` when `ownerUserID == 0` (the legacy-row / API-key bypass). So with `BINDERY_ENFORCE_TENANCY` on, the ownership guards on `Get`/`Update`/`Delete` passed for **every** authenticated user — any non-admin could read, modify, or delete another user's metadata or quality profile. This is the "user-scoped resources must filter by `owner_user_id`" rule from the v1.1.1 multi-user audit.

Verified with an in-memory-DB probe: a profile created through the handler came back with `owner_user_id = 0`.

## Fix
Add `CreateForUser(ctx, p, ownerUserID)` to both repos (writing `NULL` when the id is 0, matching `AuthorRepo.CreateForUser` and the "0 ⇒ shared / admin-equivalent" convention), and switch both Create handlers to stamp `auth.UserIDFromContext`. Existing owner-less rows stay shared, so no library is orphaned when tenancy is first enabled.

## Tests
`internal/api/authorization_test.go` — two regression tests drive the real Create handler (not the `setOwner` helper, whose own comment noted profiles "do not yet write that column") and assert a second user's Get on the creator's profile 404s while the owner's succeeds. Confirmed non-vacuous: reverting the handler to `Create` makes the cross-user Get return 200.

Same class as the metadata-profile finding; the quality-profile Create had the identical gap and is fixed here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)