### PR TITLE
fix(net): route hardcover NewAuthenticated and prowlarr client through the outbound proxy

### DIFF
--- a/changelog.d/proxy-bypass.md
+++ b/changelog.d/proxy-bypass.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Hardcover list sync and Prowlarr sync now honor `BINDERY_OUTBOUND_PROXY`** — `hardcover.NewAuthenticated` (used by the import-list syncer and import-list browse) and the Prowlarr client were built without the proxy transport, so they dialed `hardcover.app` / the Prowlarr host directly while every sibling code path was proxied. On a locked-down egress they failed outright; on a VPN-only setup they leaked traffic outside the configured proxy. Both now use the shared proxy transport like the other clients.

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -97,7 +97,11 @@ func (c *Client) WithTokenSource(source func(context.Context) string) *Client {
 // for authenticated queries (e.g. reading user lists).
 func NewAuthenticated(token string) *Client {
 	return &Client{
-		http:  &http.Client{Timeout: 15 * time.Second},
+		// Honor BINDERY_OUTBOUND_PROXY like New(); without the proxy transport,
+		// the Hardcover list syncer and import-list browse (the callers of
+		// NewAuthenticated) dial hardcover.app directly while every other
+		// Hardcover call is proxied (#proxy-bypass).
+		http:  &http.Client{Timeout: 15 * time.Second, Transport: httpsec.DefaultProxyTransport()},
 		token: token,
 	}
 }

--- a/internal/metadata/hardcover/proxy_transport_test.go
+++ b/internal/metadata/hardcover/proxy_transport_test.go
@@ -1,0 +1,17 @@
+package hardcover
+
+import (
+	"testing"
+
+	"github.com/vavallee/bindery/internal/httpsec"
+)
+
+// NewAuthenticated must route through the shared outbound-proxy transport like
+// New() does, so the list syncer and import-list browse (its callers) honor
+// BINDERY_OUTBOUND_PROXY instead of dialing hardcover.app directly.
+func TestNewAuthenticated_UsesProxyTransport(t *testing.T) {
+	c := NewAuthenticated("tok")
+	if c.http.Transport != httpsec.DefaultProxyTransport() {
+		t.Errorf("NewAuthenticated must use the shared proxy transport; got %#v", c.http.Transport)
+	}
+}

--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vavallee/bindery/internal/httpsec"
 	"github.com/vavallee/bindery/internal/useragent"
 )
 
@@ -32,7 +33,11 @@ func NewWithTimeout(baseURL, apiKey string, timeout time.Duration) *Client {
 	return &Client{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		apiKey:  apiKey,
-		http:    &http.Client{Timeout: timeout},
+		// Honor BINDERY_OUTBOUND_PROXY like the newznab search client that talks
+		// to the same Prowlarr/Jackett hosts. Without the proxy transport, a
+		// Prowlarr reachable only through the configured egress proxy fails on
+		// the sync/test path while indexer searches succeed (#proxy-bypass).
+		http: &http.Client{Timeout: timeout, Transport: httpsec.DefaultProxyTransport()},
 	}
 }
 

--- a/internal/prowlarr/proxy_transport_test.go
+++ b/internal/prowlarr/proxy_transport_test.go
@@ -1,0 +1,21 @@
+package prowlarr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/httpsec"
+)
+
+// The Prowlarr client must route through the shared outbound-proxy transport
+// like the newznab search client that talks to the same hosts, so sync/test
+// calls honor BINDERY_OUTBOUND_PROXY instead of dialing Prowlarr directly.
+func TestNewWithTimeout_UsesProxyTransport(t *testing.T) {
+	c := NewWithTimeout("http://prowlarr:9696", "key", 30*time.Second)
+	if c.http.Transport != httpsec.DefaultProxyTransport() {
+		t.Errorf("NewWithTimeout must use the shared proxy transport; got %#v", c.http.Transport)
+	}
+	if New("http://prowlarr:9696", "key").http.Transport != httpsec.DefaultProxyTransport() {
+		t.Error("New must use the shared proxy transport")
+	}
+}


### PR DESCRIPTION
## Two clients ignored `BINDERY_OUTBOUND_PROXY`

`hardcover.NewAuthenticated` (`internal/metadata/hardcover/client.go`) and `prowlarr.NewWithTimeout` (`internal/prowlarr/client.go`) built their `http.Client` with no `Transport`, so they used `http.DefaultTransport`. `httpsec.ConfigureOutboundProxy` clones `DefaultTransport` rather than mutating it, so the proxy never applied to these two clients.

Meanwhile the siblings that talk to the same hosts do honor it: `hardcover.New` uses `httpsec.DefaultProxyTransport()`, and the newznab search client that hits the same Prowlarr/Jackett endpoints uses `httpsec.ProxyFunc()`.

Effect on an egress-restricted or VPN-only network with `BINDERY_OUTBOUND_PROXY` set:
- Hardcover import-list browse and scheduled list syncs (the callers of `NewAuthenticated`) dial `hardcover.app` directly — failing behind a locked-down egress, or leaking outside the proxy/VPN.
- Prowlarr sync/test calls dial the Prowlarr host directly, so `BINDERY_OUTBOUND_PROXY_NO_PROXY` entries for Prowlarr are meaningless for the sync client while indexer searches (newznab path) work.

## Fix
Set `Transport: httpsec.DefaultProxyTransport()` on both constructors, matching their siblings. Tests assert each client carries the shared proxy transport.

Found during a codebase audit for unwired/inconsistent settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)