### PR TITLE
fix(security): stop leaking indexer apikey in search and queue responses

### DIFF
--- a/changelog.d/indexer-apikey-leak.md
+++ b/changelog.d/indexer-apikey-leak.md
@@ -1,0 +1,2 @@
+### Security
+- **Indexer API keys no longer leak to non-admin users in search and queue responses** — interactive indexer search signs the instance's indexer/Prowlarr apikey into each result's `nzbUrl`, and that download URL was returned verbatim to any authenticated user (search results and the queue list). The apikey is now stripped from every client-facing response and re-attached server-side at grab time from the release's indexer id, so grabbing still works while the shared credential stays off the wire.

--- a/internal/api/indexers.go
+++ b/internal/api/indexers.go
@@ -457,8 +457,14 @@ func (h *IndexerHandler) SearchBook(w http.ResponseWriter, r *http.Request) {
 	}
 	out := make([]searchDecision, len(decisions))
 	for i, d := range decisions {
+		res := results[i]
+		// Strip the indexer apikey the search path signs into the download URL
+		// before it reaches the client. Interactive search is available to
+		// non-admin users, so returning the signed URL leaks the shared indexer
+		// credential; the grab handler re-signs from the indexer id server-side.
+		res.NZBURL = newznab.RedactDownloadURL(res.NZBURL)
 		out[i] = searchDecision{
-			SearchResult: results[i],
+			SearchResult: res,
 			Approved:     d.Approved,
 			Rejection:    d.Rejection,
 		}
@@ -530,5 +536,10 @@ func (h *IndexerHandler) SearchQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	results := h.searcher.SearchQuery(r.Context(), idxs, query)
+	// Strip the indexer apikey from each download URL before returning to the
+	// client; the grab handler re-signs server-side (see SearchBook).
+	for i := range results {
+		results[i].NZBURL = newznab.RedactDownloadURL(results[i].NZBURL)
+	}
 	writeJSON(w, http.StatusOK, results)
 }

--- a/internal/api/indexers_test.go
+++ b/internal/api/indexers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -328,6 +329,64 @@ func TestSearchBook_DualFormat_MediaTypeTagging(t *testing.T) {
 	}
 	if byGUID["au1"] != "audiobook" {
 		t.Errorf("audiobook result: got mediaType=%q, want %q", byGUID["au1"], "audiobook")
+	}
+}
+
+// SearchBook must not return the indexer apikey the search path signs into the
+// download URL: interactive search is available to non-admin users, so leaking
+// the shared indexer credential in nzbUrl is a cross-user secret disclosure. The
+// grab handler re-signs from the indexer id server-side.
+func TestSearchBook_RedactsIndexerAPIKey(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	ctx := context.Background()
+	authorRepo := db.NewAuthorRepo(database)
+	author := &models.Author{ForeignID: "OL1A", Name: "Jane Doe", SortName: "Doe, Jane", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	bookRepo := db.NewBookRepo(database)
+	book := &models.Book{Title: "Test Book", ForeignID: "OL1M", AuthorID: author.ID, MediaType: models.MediaTypeEbook, Monitored: true}
+	if err := bookRepo.Create(ctx, book); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockIndexerSearcher{
+		ebookResults: []newznab.SearchResult{{
+			GUID:   "eb1",
+			Title:  "Test Book epub",
+			NZBURL: "https://idx.example.com/dl?apikey=SUPERSECRET&id=eb1",
+		}},
+	}
+	h := NewIndexerHandler(
+		db.NewIndexerRepo(database), bookRepo, authorRepo,
+		db.NewMetadataProfileRepo(database), mock,
+		db.NewSettingsRepo(database), db.NewBlocklistRepo(database),
+	)
+
+	rec := httptest.NewRecorder()
+	req := withURLParam(httptest.NewRequest(http.MethodGet, "/indexer/book/1/search", nil), "id", strconv.FormatInt(book.ID, 10))
+	h.SearchBook(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "SUPERSECRET") {
+		t.Fatalf("search response leaked the indexer apikey: %s", rec.Body.String())
+	}
+	var resp struct {
+		Results []struct {
+			NZBURL string `json:"nzbUrl"`
+		} `json:"results"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 1 || resp.Results[0].NZBURL != "https://idx.example.com/dl?id=eb1" {
+		t.Fatalf("nzbUrl not redacted as expected: %+v", resp.Results)
 	}
 }
 

--- a/internal/api/queue.go
+++ b/internal/api/queue.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/downloader"
 	"github.com/vavallee/bindery/internal/indexer"
+	"github.com/vavallee/bindery/internal/indexer/newznab"
 	"github.com/vavallee/bindery/internal/models"
 	"github.com/vavallee/bindery/internal/notifier"
 )
@@ -305,6 +306,11 @@ func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
 	bookIDs := make([]int64, 0, len(enriched))
 	for i, item := range enriched {
 		items[i] = QueueItem{Download: item.Download}
+		// Strip the indexer apikey from the stored download URL before it
+		// reaches the client. The queue is per-user but the apikey is the shared
+		// indexer credential, so exposing it in any user's queue leaks it (same
+		// reason SearchBook redacts). Retries re-sign server-side in grab().
+		items[i].NZBURL = newznab.RedactDownloadURL(items[i].NZBURL)
 		if item.HasLive {
 			items[i].Percentage = item.Live.Percentage
 			items[i].TimeLeft = item.Live.TimeLeft
@@ -789,6 +795,17 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 			grabOwner = b.OwnerUserID
 		}
 	}
+	// Re-attach the indexer apikey the search/queue responses strip out
+	// (SEC: the shared credential must not reach non-admin clients). The client
+	// hands back an apikey-less download URL plus the indexer id; sign it
+	// server-side here. No-op when the URL already carries a key (scheduler /
+	// retry paths) or its host does not match the indexer.
+	nzbURL := req.NZBURL
+	if indexerID != nil && h.indexers != nil {
+		if idx, err := h.indexers.GetByID(ctx, *indexerID); err == nil && idx != nil {
+			nzbURL = newznab.SignDownloadURLFor(req.NZBURL, idx.URL, idx.APIKey)
+		}
+	}
 	dl := &models.Download{
 		GUID:             req.GUID,
 		BookID:           bookID,
@@ -797,7 +814,7 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 		DownloadClientID: &client.ID,
 		OwnerUserID:      grabOwner,
 		Title:            req.Title,
-		NZBURL:           req.NZBURL,
+		NZBURL:           nzbURL,
 		Size:             req.Size,
 		Status:           models.StateGrabbed,
 		Protocol:         protocol,
@@ -817,7 +834,7 @@ func (h *QueueHandler) grab(ctx context.Context, req grabRequest) (*models.Downl
 		return nil, err
 	}
 
-	sendRes, err := downloader.SendDownload(ctx, client, req.NZBURL, req.Title, downloader.SendOptions{
+	sendRes, err := downloader.SendDownload(ctx, client, nzbURL, req.Title, downloader.SendOptions{
 		MediaType:            req.MediaType,
 		DownloadDir:          h.downloadDir,
 		AudiobookDownloadDir: h.audiobookDownloadDir,

--- a/internal/indexer/newznab/client.go
+++ b/internal/indexer/newznab/client.go
@@ -135,21 +135,67 @@ func newHTTPClient() *http.Client {
 // by NZBGet as empty content) without leaking the apikey to third-party
 // direct-from-uploader links an indexer might return.
 func (c *Client) signDownloadURL(raw string) string {
-	if raw == "" || c.apiKey == "" {
+	return signDownloadURL(raw, c.baseHost, c.apiKey)
+}
+
+// signDownloadURL appends apiKey to raw when, and only when, raw targets
+// baseHost and carries no apikey yet. Shared by the search path (via *Client)
+// and the grab re-sign helper (SignDownloadURLFor).
+func signDownloadURL(raw, baseHost, apiKey string) string {
+	apiKey = strings.TrimSpace(apiKey)
+	if raw == "" || apiKey == "" || baseHost == "" {
 		return raw
 	}
 	u, err := url.Parse(raw)
 	if err != nil {
 		return raw
 	}
-	if !strings.EqualFold(u.Host, c.baseHost) {
+	if !strings.EqualFold(u.Host, baseHost) {
 		return raw
 	}
 	q := u.Query()
 	if q.Get("apikey") != "" {
 		return raw
 	}
-	q.Set("apikey", c.apiKey)
+	q.Set("apikey", apiKey)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// SignDownloadURLFor re-appends an indexer's apikey to a download URL
+// server-side, using the same host-match rule as the search path. It exists so
+// search and queue responses can be returned to clients with the apikey
+// stripped (RedactDownloadURL) — keeping the shared indexer credential off
+// multi-user clients — while the grab handler restores it just before dialing
+// the indexer. indexerURL is the configured indexer base URL; its host is
+// derived exactly as New() derives baseHost, so a URL whose host does not match
+// the indexer is returned untouched (never signed with a foreign host). Passing
+// an already-signed URL is a no-op.
+func SignDownloadURLFor(rawURL, indexerURL, apiKey string) string {
+	baseHost := ""
+	if u, err := url.Parse(normalizeEndpointURL(indexerURL)); err == nil {
+		baseHost = strings.ToLower(u.Host)
+	}
+	return signDownloadURL(rawURL, baseHost, apiKey)
+}
+
+// RedactDownloadURL removes the apikey query parameter from a download URL so it
+// can be returned to API clients without leaking the indexer credential. The
+// grab handler restores it server-side via SignDownloadURLFor before dialing the
+// indexer. A URL with no apikey is returned unchanged.
+func RedactDownloadURL(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	q := u.Query()
+	if q.Get("apikey") == "" {
+		return raw
+	}
+	q.Del("apikey")
 	u.RawQuery = q.Encode()
 	return u.String()
 }

--- a/internal/indexer/newznab/download_url_test.go
+++ b/internal/indexer/newznab/download_url_test.go
@@ -1,0 +1,67 @@
+package newznab
+
+import "testing"
+
+func TestRedactDownloadURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"strips apikey", "https://idx.example.com/dl?id=abc&apikey=SECRET", "https://idx.example.com/dl?id=abc"},
+		{"no apikey untouched", "https://idx.example.com/dl?id=abc", "https://idx.example.com/dl?id=abc"},
+		{"only apikey", "https://idx.example.com/dl?apikey=SECRET", "https://idx.example.com/dl"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		if got := RedactDownloadURL(tt.in); got != tt.want {
+			t.Errorf("%s: RedactDownloadURL(%q) = %q, want %q", tt.name, tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSignDownloadURLFor(t *testing.T) {
+	const indexerURL = "https://idx.example.com/api"
+
+	// Same-host URL with no key gets the indexer apikey.
+	got := SignDownloadURLFor("https://idx.example.com/dl?id=abc", indexerURL, "SECRET")
+	if got != "https://idx.example.com/dl?apikey=SECRET&id=abc" {
+		t.Errorf("same-host sign: got %q", got)
+	}
+
+	// A URL that already carries an apikey is left alone (idempotent — covers the
+	// scheduler/retry paths that hand back an already-signed URL).
+	already := "https://idx.example.com/dl?apikey=OTHER&id=abc"
+	if got := SignDownloadURLFor(already, indexerURL, "SECRET"); got != already {
+		t.Errorf("already-signed should be unchanged: got %q", got)
+	}
+
+	// A URL pointing at a different host (a direct-from-uploader link) never gets
+	// the indexer key appended.
+	foreign := "https://cdn.other.net/file.nzb?id=abc"
+	if got := SignDownloadURLFor(foreign, indexerURL, "SECRET"); got != foreign {
+		t.Errorf("foreign host must not be signed: got %q", got)
+	}
+
+	// Empty apikey is a no-op.
+	if got := SignDownloadURLFor("https://idx.example.com/dl?id=abc", indexerURL, ""); got != "https://idx.example.com/dl?id=abc" {
+		t.Errorf("empty apikey should be a no-op: got %q", got)
+	}
+}
+
+// The client redacts a signed URL for the response, and the grab handler
+// restores exactly the original signed URL — the round trip a real grab makes.
+func TestRedactThenReSign_RoundTrips(t *testing.T) {
+	const indexerURL = "https://idx.example.com/api"
+	signed := signDownloadURL("https://idx.example.com/dl?id=abc", "idx.example.com", "SECRET")
+	if signed == "" {
+		t.Fatal("precondition: signed URL empty")
+	}
+	redacted := RedactDownloadURL(signed)
+	if redacted == signed {
+		t.Fatal("redaction did not remove the apikey")
+	}
+	if resigned := SignDownloadURLFor(redacted, indexerURL, "SECRET"); resigned != signed {
+		t.Errorf("round trip mismatch: signed=%q resigned=%q", signed, resigned)
+	}
+}

--- a/web/src/api/books.ts
+++ b/web/src/api/books.ts
@@ -43,6 +43,7 @@ export interface Book {
 
 export interface SearchResult {
   guid: string
+  indexerId: number
   indexerName: string
   title: string
   size: number

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -66,6 +66,7 @@ vi.mock('../components/MediaBadge', () => ({
 function makeResult({ guid, title, ...rest }: Partial<SearchResult> & { guid: string }): SearchResult {
   return {
     guid,
+    indexerId: 3,
     indexerName: 'TestIndexer',
     title: title ?? guid,
     size: 1048576,
@@ -434,6 +435,7 @@ describe('BookDetailPage — search', () => {
       nzbUrl: 'https://indexer.example.com/grab-guid.nzb',
       size: 2147483648,
       bookId: 42,
+      indexerId: 3,
       protocol: 'torrent',
       mediaType: 'ebook',
     })

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -278,6 +278,7 @@ export default function BookDetailPage() {
         nzbUrl: r.nzbUrl,
         size: r.size,
         bookId: book.id,
+        indexerId: r.indexerId,
         protocol: r.protocol,
         mediaType: book.mediaType,
       })

--- a/web/src/pages/SearchPage.test.tsx
+++ b/web/src/pages/SearchPage.test.tsx
@@ -50,6 +50,7 @@ vi.mock('../api/client', async importOriginal => {
 
 function makeResult(overrides: Partial<SearchResult> & { guid: string; title: string }): SearchResult {
   return {
+    indexerId: 7,
     indexerName: 'Test Indexer',
     size: 1572864,
     nzbUrl: 'https://indexer.example.com/release.nzb',

--- a/web/src/pages/SearchPage.tsx
+++ b/web/src/pages/SearchPage.tsx
@@ -57,6 +57,7 @@ export default function SearchPage() {
         title: r.title,
         nzbUrl: r.nzbUrl,
         size: r.size,
+        indexerId: r.indexerId,
         protocol: r.protocol,
       })
       setGrabbed(prev => new Set(prev).add(r.guid))

--- a/web/src/pages/WantedPage.test.tsx
+++ b/web/src/pages/WantedPage.test.tsx
@@ -126,6 +126,7 @@ function makeResult({ guid, title, ...rest }: Partial<SearchResult> & { guid: st
   return {
     guid,
     title,
+    indexerId: 9,
     indexerName: 'Wanted Indexer',
     size: 1572864,
     nzbUrl: 'https://indexer.example.com/release.nzb',
@@ -353,6 +354,7 @@ describe('WantedPage', () => {
       nzbUrl: 'https://indexer.example.com/dune.nzb',
       size: 1572864,
       bookId: 1,
+      indexerId: 9,
       protocol: 'usenet',
       mediaType: 'ebook',
     })

--- a/web/src/pages/WantedPage.tsx
+++ b/web/src/pages/WantedPage.tsx
@@ -122,6 +122,7 @@ export default function WantedPage() {
         nzbUrl: result.nzbUrl,
         size: result.size,
         bookId: book.id,
+        indexerId: result.indexerId,
         protocol: result.protocol,
         mediaType: book.mediaType,
       })


### PR DESCRIPTION
## Indexer/Prowlarr API key exposed to non-admin users

The newznab search path signs the indexer's apikey into each result's download URL (`SearchResult.NZBURL`) so Prowlarr-proxy enclosure URLs work (`signDownloadURL`). That signed URL was returned to clients in two places:
- `POST /book/{id}/search` (interactive search) — **not** admin-gated, so any authenticated non-admin user could run a search and read the shared indexer/Prowlarr apikey.
- The queue list (`QueueItem` embeds `models.Download`, whose `nzbUrl` carried the signed URL).

With that key a non-admin can query the indexer directly, bypassing Bindery. This is the "responses must not leak sensitive settings to non-admins" rule from the multi-user audit.

## Fix
Keep the apikey off every client-facing response and re-attach it server-side only when actually dialing the indexer:

- **`internal/indexer/newznab`** — factor the signing into a shared `signDownloadURL(raw, baseHost, apiKey)`; add exported `RedactDownloadURL` (strips the `apikey` param) and `SignDownloadURLFor(rawURL, indexerURL, apiKey)` (host-match guarded, idempotent when the URL already has a key).
- **`internal/api/indexers.go`** — redact `nzbUrl` in `SearchBook` and `SearchQuery` responses.
- **`internal/api/queue.go`** — redact `nzbUrl` in the queue `List`; at grab time re-sign `req.NZBURL` from the release's `indexerId` (via `h.indexers`) before `SendDownload`. Idempotent, so scheduler auto-grab and retry paths (which store an already-signed URL) are unaffected.
- **frontend** — `SearchResult` gains `indexerId`; the three grab call sites (Search, Wanted, BookDetail) now send it so the server can re-sign. Grabbing is unchanged for the user.

## Tests
- `internal/indexer/newznab/download_url_test.go` — redact strips the key; re-sign only signs same-host URLs, is idempotent, and refuses foreign hosts; redact→re-sign round-trips to the original signed URL.
- `internal/api/indexers_test.go` — `SearchBook` response contains no apikey and returns the redacted URL. Verified non-vacuous (removing the redaction fails the test, leaking `SUPERSECRET`).
- Frontend grab tests updated to assert `indexerId` is sent; `tsc` + vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)