### PR TITLE
chore(api): remove dead POST /book/{id}/map endpoint

### DIFF
--- a/changelog.d/remove-map-endpoint.md
+++ b/changelog.d/remove-map-endpoint.md
@@ -1,0 +1,2 @@
+### Removed
+- **Dead `POST /book/{id}/map` endpoint** — an undocumented metadata-map handler with no caller (the Fix Match UI uses `rebind`, and ABS review uses its own resolve endpoint). Removing it drops maintained authenticated surface that duplicated rebind's logic; the shared helpers it used remain in place for the audiobook ASIN-map path.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -830,7 +830,6 @@ func main() {
 		r.Delete("/book/{id}/file", bookHandler.DeleteFile)
 		r.Put("/book/{id}/exclude", bookHandler.ToggleExcluded)
 		r.Post("/book/{id}/rebind", bookHandler.Rebind)
-		r.Post("/book/{id}/map", bookHandler.MapMetadata)
 		r.Post("/book/{id}/enrich-audiobook", bookHandler.EnrichAudiobook)
 		r.Post("/book/{id}/search", indexerHandler.SearchBook)
 		r.Get("/book/{id}/file", fileHandler.Download)

--- a/internal/api/books.go
+++ b/internal/api/books.go
@@ -1183,79 +1183,10 @@ func (h *BookHandler) ToggleExcluded(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, book)
 }
 
-func (h *BookHandler) MapMetadata(w http.ResponseWriter, r *http.Request) {
-	id, ok := parseID(w, r)
-	if !ok {
-		return
-	}
-	if h.meta == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "metadata provider unavailable"})
-		return
-	}
-	if h.authors == nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "author repository unavailable"})
-		return
-	}
-	var req struct {
-		ForeignBookID string `json:"foreignBookId"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
-		return
-	}
-	if strings.TrimSpace(req.ForeignBookID) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "foreignBookId is required"})
-		return
-	}
-	book, err := h.books.GetByID(r.Context(), id)
-	if err != nil || book == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
-		return
-	}
-	// Tier-1 cross-user IDOR guard (D1).
-	if !auth.CheckOwnership(r.Context(), book.OwnerUserID) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "book not found"})
-		return
-	}
-	target, err := h.meta.GetBook(r.Context(), req.ForeignBookID)
-	if err != nil {
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
-		return
-	}
-	if target == nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "upstream book not found"})
-		return
-	}
-	if target.ForeignID == "" {
-		target.ForeignID = req.ForeignBookID
-	}
-	currentAuthor, err := h.authors.GetByID(r.Context(), book.AuthorID)
-	if err != nil {
-		writeServerError(w, r, err)
-		return
-	}
-	if !bookMapAuthorMatches(currentAuthor, target.Author) {
-		writeJSON(w, http.StatusConflict, map[string]string{"error": "target book author does not match current author"})
-		return
-	}
-
-	preserveBookStateForMetadataMap(book, target)
-	if err := h.books.Update(r.Context(), book); err != nil {
-		writeServerError(w, r, err)
-		return
-	}
-	h.hydrateHardcoverEditions(r.Context(), book, book.MetadataProvider)
-	updated, err := h.books.GetByID(r.Context(), book.ID)
-	if err != nil {
-		writeServerError(w, r, err)
-		return
-	}
-	h.attachBookFiles(r.Context(), updated)
-	cleanBookDescription(updated)
-	proxyBookImages(updated)
-	writeJSON(w, http.StatusOK, updated)
-}
-
+// preserveBookStateForMetadataMap and bookMapAuthorMatches below are retained:
+// they are shared with tryMapAudiobookMetadataByASIN. The standalone
+// POST /book/{id}/map handler that also used them was removed as dead surface —
+// it had no caller (the UI uses rebind), and was undocumented.
 func preserveBookStateForMetadataMap(book *models.Book, target *models.Book) {
 	id := book.ID
 	authorID := book.AuthorID

--- a/internal/api/rebind_test.go
+++ b/internal/api/rebind_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/vavallee/bindery/internal/db"
-	"github.com/vavallee/bindery/internal/metadata"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -134,58 +133,6 @@ func TestRebind_HydratesHardcoverEditions(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(editions) != 1 || editions[0].ForeignID != "hc:correct-audio" {
-		t.Fatalf("expected hydrated edition, got %+v", editions)
-	}
-}
-
-func TestMapMetadata_HydratesHardcoverEditions(t *testing.T) {
-	h, books, _, _, author, book, ctx := rebindFixture(t)
-	book.MediaType = models.MediaTypeAudiobook
-	if err := books.Update(ctx, book); err != nil {
-		t.Fatal(err)
-	}
-	audioASIN := "B987654321"
-	provider := &stubMetaProvider{
-		name: "hardcover",
-		getBookByID: map[string]*models.Book{
-			"hc:mapped": {
-				ForeignID:        "hc:mapped",
-				Title:            "Mapped Book",
-				SortTitle:        "Mapped Book",
-				MetadataProvider: "hardcover",
-				Author:           &models.Author{ForeignID: author.ForeignID, Name: author.Name},
-			},
-		},
-		editionsByBook: map[string][]models.Edition{
-			"hc:mapped": {{
-				ForeignID: "hc:mapped-audio",
-				Title:     "Mapped Book",
-				ASIN:      &audioASIN,
-				Format:    "Audiobook",
-				Monitored: true,
-			}},
-		},
-	}
-	h.meta = metadata.NewAggregator(provider).WithAudnexClient(nil)
-
-	body := bytes.NewBufferString(`{"foreignBookId":"hc:mapped"}`)
-	rec := httptest.NewRecorder()
-	h.MapMetadata(rec, withURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/book/1/map-metadata", body), "id", strconv.FormatInt(book.ID, 10)))
-	if rec.Code != http.StatusOK {
-		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
-	}
-	updated, err := books.GetByID(ctx, book.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if updated.ASIN != audioASIN {
-		t.Fatalf("ASIN = %q, want %q", updated.ASIN, audioASIN)
-	}
-	editions, err := h.editions.ListByBook(ctx, book.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(editions) != 1 || editions[0].ForeignID != "hc:mapped-audio" {
 		t.Fatalf("expected hydrated edition, got %+v", editions)
 	}
 }


### PR DESCRIPTION
## Dead surface

`POST /book/{id}/map` (`BookHandler.MapMetadata`) has no caller:
- the frontend's Fix Match modal uses `rebind` (`web/src/api/books.ts`),
- the ABS import review flow uses `/abs/review/{id}/resolve-book`,
- it is absent from `docs/API.md`, and nothing in `web/src` requests any `/map` path.

It was introduced in #590 (ABS import hardening) and superseded; since then it has been maintained-but-unused authenticated surface that duplicates rebind's author-match + preserve-state + hydrate-editions logic.

## Change
Remove the handler, its route registration, and its unit test. The two helpers it used — `preserveBookStateForMetadataMap` and `bookMapAuthorMatches` — are **kept**, because they are also used by `tryMapAudiobookMetadataByASIN` (the live audiobook ASIN-map path).

I did **not** touch `POST /backup/{filename}/restore`, the other unwired endpoint from the audit: it is unreachable from the UI but is the only database-restore path, so it should be documented/surfaced, not deleted.

Found during the codebase audit for dead surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)