### PR TITLE
fix(importer): re-read ebook/audiobook naming templates live

### DIFF
--- a/changelog.d/live-naming-templates.md
+++ b/changelog.d/live-naming-templates.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Ebook/audiobook naming templates now take effect without a restart** — the destination templates (`naming.bookTemplate`, `naming_template_audiobook`) were read once at boot and baked into the renamer, so saving a new template in Settings did nothing until Bindery restarted — and Reorganize actively applied the stale boot-time template. Both templates are now re-read from settings per import and per reorganize, matching how the per-track audiobook template already worked.

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -1254,13 +1254,8 @@ func googleBooksAPIKey(ctx context.Context, settings *db.SettingsRepo) string {
 // (#1356 — the two sides used different keys, so UI-configured templates were
 // silently ignored and every import fell back to the built-in default).
 func defaultNamingTemplate(settings *db.SettingsRepo) string {
-	if s, _ := settings.Get(context.Background(), "naming.bookTemplate"); s != nil && s.Value != "" {
-		return s.Value
-	}
-	if s, _ := settings.Get(context.Background(), "naming_template"); s != nil && s.Value != "" {
-		return s.Value
-	}
-	return ""
+	ebook, _ := importer.ResolveNamingTemplates(context.Background(), settings)
+	return ebook
 }
 
 // syncOnStartup reads the calibre.sync_on_startup setting and returns
@@ -1276,10 +1271,8 @@ func syncOnStartup(settings *db.SettingsRepo) bool {
 }
 
 func audiobookNamingTemplate(settings *db.SettingsRepo) string {
-	if s, _ := settings.Get(context.Background(), "naming_template_audiobook"); s != nil && s.Value != "" {
-		return s.Value
-	}
-	return ""
+	_, audiobook := importer.ResolveNamingTemplates(context.Background(), settings)
+	return audiobook
 }
 
 // bootstrapAuth seeds the three auth settings on first boot:

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/vavallee/bindery/internal/db"
 	"github.com/vavallee/bindery/internal/models"
 )
 
@@ -119,6 +120,31 @@ func NewRenamerWithAudiobook(ebookTemplate, audiobookTemplate string) *Renamer {
 		audiobookTemplate = defaultAudiobookTemplate
 	}
 	return &Renamer{template: ebookTemplate, audiobookTemplate: audiobookTemplate}
+}
+
+// ResolveNamingTemplates reads the operator's ebook and audiobook destination
+// templates from settings. The keys mirror what the Settings UI writes:
+// naming.bookTemplate (with the legacy naming_template fallback, #1356) and
+// naming_template_audiobook. An empty return means "use the built-in default"
+// (NewRenamerWithAudiobook fills it in). It is the single source of truth for
+// this resolution, used both to seed the boot-time renamer and to re-read the
+// templates live per import/reorganize so a saved template takes effect without
+// a restart.
+func ResolveNamingTemplates(ctx context.Context, settings *db.SettingsRepo) (ebook, audiobook string) {
+	if settings == nil {
+		return "", ""
+	}
+	get := func(key string) string {
+		if s, _ := settings.Get(ctx, key); s != nil {
+			return s.Value
+		}
+		return ""
+	}
+	ebook = get("naming.bookTemplate")
+	if ebook == "" {
+		ebook = get("naming_template")
+	}
+	return ebook, get("naming_template_audiobook")
 }
 
 // DestPath computes the destination path for an ebook file.

--- a/internal/importer/reorganize.go
+++ b/internal/importer/reorganize.go
@@ -142,10 +142,10 @@ func (s *Scanner) proposedPathFor(ctx context.Context, book *models.Book, author
 	audiobook := f.Format == models.MediaTypeAudiobook
 	if audiobook {
 		root := s.effectiveAudiobookDir(ctx, author)
-		dest, err = s.renamer.AudiobookDestDir(root, author, book, seriesTitle, seriesNum)
+		dest, err = s.destRenamer(ctx).AudiobookDestDir(root, author, book, seriesTitle, seriesNum)
 	} else {
 		root := s.effectiveLibraryDir(ctx, author)
-		dest, err = s.renamer.DestPath(root, author, book, seriesTitle, seriesNum, f.Path)
+		dest, err = s.destRenamer(ctx).DestPath(root, author, book, seriesTitle, seriesNum, f.Path)
 	}
 	if err != nil {
 		return "", ReorgStatusError, err.Error()

--- a/internal/importer/reorganize_test.go
+++ b/internal/importer/reorganize_test.go
@@ -136,6 +136,37 @@ func TestReorganize_EbookMove(t *testing.T) {
 	}
 }
 
+// Reorganize must render the destination with the CURRENT naming template, not
+// the one baked into the renamer at boot. Before the live-reread fix, a template
+// saved in the UI was ignored by Reorganize until a restart (#live-reload).
+func TestReorganize_UsesLiveNamingTemplate(t *testing.T) {
+	env, libraryDir, _, ctx := reorgFixture(t)
+	book := env.seed(t, ctx, "Jane Doe", "My Book")
+
+	oldPath := filepath.Join(libraryDir, "misc", "randomname.epub")
+	writeFileAt(t, oldPath)
+	if err := env.books.AddBookFile(ctx, book.ID, models.MediaTypeEbook, oldPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save a new template AFTER the scanner (and its boot renamer) were built.
+	if err := env.s.settings.Set(ctx, "naming.bookTemplate", "{Author} - {Title}.{ext}"); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(libraryDir, "Jane Doe - My Book.epub")
+	moves, err := env.s.PreviewReorganizeBook(ctx, book.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(moves) != 1 {
+		t.Fatalf("expected 1 move, got %d", len(moves))
+	}
+	if moves[0].Proposed != want {
+		t.Fatalf("proposed = %q, want %q (the live template, not the boot default)", moves[0].Proposed, want)
+	}
+}
+
 func TestReorganize_Noop(t *testing.T) {
 	env, libraryDir, _, ctx := reorgFixture(t)
 	book := env.seed(t, ctx, "Jane Doe", "My Book")

--- a/internal/importer/scanner.go
+++ b/internal/importer/scanner.go
@@ -135,6 +135,20 @@ func NewScanner(downloads *db.DownloadRepo, clients *db.DownloadClientRepo,
 	}
 }
 
+// destRenamer returns a Renamer built from the CURRENT ebook/audiobook naming
+// templates in settings, so a template saved in the Settings UI takes effect on
+// the next import or reorganize without a Bindery restart. The boot-time
+// s.renamer is only a fallback for wiring that has no settings repo (tests).
+// Mirrors how the per-track audiobook template is already re-read live per
+// import (#1126).
+func (s *Scanner) destRenamer(ctx context.Context) *Renamer {
+	if s.settings == nil {
+		return s.renamer
+	}
+	ebook, audiobook := ResolveNamingTemplates(ctx, s.settings)
+	return NewRenamerWithAudiobook(ebook, audiobook)
+}
+
 // WithAudiobookDownloadDir records the separate audiobook download watch
 // folder. When non-empty, this directory is the expected landing zone for
 // completed audiobook downloads (separate from the general download dir).
@@ -951,7 +965,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		// has any custom ebook root folder assigned (#421).
 		audiobookRoot := s.effectiveAudiobookDir(ctx, author)
 		seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
-		audiobookDest, destErr := s.renamer.AudiobookDestDir(audiobookRoot, author, book, seriesTitle, seriesNum)
+		audiobookDest, destErr := s.destRenamer(ctx).AudiobookDestDir(audiobookRoot, author, book, seriesTitle, seriesNum)
 		if destErr != nil {
 			slog.Error("failed to compute audiobook destination", "src", downloadPath, "error", destErr)
 			s.failImport(ctx, dl, models.StateImportBlocked, fmt.Sprintf("audiobook destination invalid: %v", destErr))
@@ -1196,7 +1210,7 @@ func (s *Scanner) tryImportInternal(ctx context.Context, dl *models.Download, do
 		}
 
 		seriesTitle, seriesNum := s.primarySeriesFor(ctx, book)
-		destPath, destErr := s.renamer.DestPath(ebookRoot, author, book, seriesTitle, seriesNum, srcFile)
+		destPath, destErr := s.destRenamer(ctx).DestPath(ebookRoot, author, book, seriesTitle, seriesNum, srcFile)
 		if destErr != nil {
 			slog.Error("failed to compute book destination", "src", srcFile, "error", destErr)
 			lastFileErr = destErr

--- a/internal/importer/scanner_handoff.go
+++ b/internal/importer/scanner_handoff.go
@@ -330,7 +330,7 @@ func (s *Scanner) placeDroppedFormat(ctx context.Context, book *models.Book, aut
 
 	if format == models.MediaTypeAudiobook {
 		if layout == "templated" {
-			d, derr := s.renamer.AudiobookDestDir(folder, author, book, seriesTitle, seriesNum)
+			d, derr := s.destRenamer(ctx).AudiobookDestDir(folder, author, book, seriesTitle, seriesNum)
 			if derr != nil {
 				return "", true, derr
 			}
@@ -350,7 +350,7 @@ func (s *Scanner) placeDroppedFormat(ctx context.Context, book *models.Book, aut
 	for _, srcFile := range bookFiles {
 		var fileDest string
 		if layout == "templated" {
-			d, derr := s.renamer.DestPath(folder, author, book, seriesTitle, seriesNum, srcFile)
+			d, derr := s.destRenamer(ctx).DestPath(folder, author, book, seriesTitle, seriesNum, srcFile)
 			if derr != nil {
 				lastErr = derr
 				continue


### PR DESCRIPTION
## Naming templates only took effect after a restart

The ebook (`naming.bookTemplate`) and audiobook (`naming_template_audiobook`) destination templates were read once at boot (`cmd/bindery/main.go`) and baked into the Scanner's `Renamer`. Saving a new template in Settings did nothing until Bindery restarted — and Reorganize (#1181) applied the **stale** boot-time template, made worse by the live client-side preview showing the new one.

By contrast, the per-track audiobook template (`naming.audiobook_file_template`, #1126) is already re-read from settings per import.

## Fix
- `internal/importer/renamer.go` — add `ResolveNamingTemplates(ctx, settings)`, the single resolver for both keys (with the legacy `naming_template` fallback, #1356).
- `internal/importer/scanner.go` — add `Scanner.destRenamer(ctx)`, which builds a `Renamer` from the current settings; the boot renamer remains a fallback for wiring with no settings repo (tests).
- Route the destination sites — `DestPath` / `AudiobookDestDir` in the import path (`scanner.go`, `scanner_handoff.go`) and reorganize (`reorganize.go`) — through it. Drop-folder names and the per-track template are unchanged.
- `cmd/bindery/main.go` — boot resolvers now delegate to `ResolveNamingTemplates`, so the key resolution lives in one place.

## Tests
`internal/importer/reorganize_test.go` — a template saved after the scanner is built is used by `PreviewReorganizeBook`. Verified non-vacuous: reverting the reorganize sites to the boot renamer produces the stale default path.

Found during the codebase audit for stale-until-restart settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)