### PR TITLE
fix(web): note restart requirement on Google Books key and primary provider

### DIFF
--- a/changelog.d/restart-hints.md
+++ b/changelog.d/restart-hints.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Google Books API key and primary metadata provider now show a "restart required" hint** — both are read once at boot, so a change only takes effect after a Bindery restart. The settings fields now say so (matching the existing wanted-search-interval note), instead of silently appearing to save with no effect.

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -722,7 +722,8 @@
       "search": "Search",
       "searchIntervalLabel": "Wanted search interval",
       "searchIntervalHint": "How often Bindery searches all wanted books against your indexers. Reduce if you have a large library and are hitting indexer API rate limits.",
-      "searchIntervalRestart": "Takes effect after the next Bindery restart."
+      "searchIntervalRestart": "Takes effect after the next Bindery restart.",
+      "restartRequired": "Takes effect after the next Bindery restart."
     },
     "import": {
       "csvHeading": "CSV of author names",

--- a/web/src/pages/settings/ApiKeysTab.tsx
+++ b/web/src/pages/settings/ApiKeysTab.tsx
@@ -155,6 +155,9 @@ export default function ApiKeysTab() {
                 testId="save-googlebooks-key"
               />
             </div>
+            <p className="text-xs text-slate-500 dark:text-zinc-600 mt-1">
+              {t('settings.general.restartRequired')}
+            </p>
           </div>
 
           <div className="border-t border-slate-200 dark:border-zinc-800 pt-4 space-y-3">

--- a/web/src/pages/settings/MetadataTab.tsx
+++ b/web/src/pages/settings/MetadataTab.tsx
@@ -80,6 +80,9 @@ export default function MetadataTab() {
             <option value="openlibrary">{t('settings.general.metadataProviderOpenlibrary', 'OpenLibrary (default)')}</option>
             <option value="dnb">{t('settings.general.metadataProviderDnb', 'DNB — Deutsche Nationalbibliothek (German/DACH)')}</option>
           </select>
+          <p className="text-xs text-slate-500 dark:text-zinc-600 mt-1">
+            {t('settings.general.restartRequired')}
+          </p>
         </div>
 
         {/* Author defaults */}


### PR DESCRIPTION
## Interim for the two boot-only settings

`googlebooks.apiKey` (builds the Google Books enricher) and `metadata.primary_provider` (picks the aggregator's primary) are both read once at boot, so saving a new value in Settings has no effect until a restart — with no indication why (audit finding).

The proper fix is a live-reconfigurable aggregator, which is a larger, high-blast-radius change. This is the safe interim: surface the restart requirement so the fields don't read as if the change applied immediately.

## Change
Add the existing `"Takes effect after the next Bindery restart."` hint (generalised to `settings.general.restartRequired`, same copy as the wanted-search-interval note) under both fields. Pure UI copy — no behavior change.

- `web/src/pages/settings/ApiKeysTab.tsx` — hint under the Google Books API key.
- `web/src/pages/settings/MetadataTab.tsx` — hint under the primary provider selector.
- `web/src/i18n/locales/en.json` — new `restartRequired` key.

`tsc` clean; the SettingsPage suite (55 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)