### PR TITLE
fix(hardcover): default list-sync authors' metadata profile (#1736)

### DIFF
--- a/changelog.d/1736-listsync-null-metadata-profile.md
+++ b/changelog.d/1736-listsync-null-metadata-profile.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Authors created via Hardcover list-sync now get the same default metadata profile as every other author-create path** (#1736) — previously they landed with no profile assigned at all instead of falling back to the default "Standard" profile. Existing affected authors are backfilled by migration.

--- a/internal/db/migration_071_test.go
+++ b/internal/db/migration_071_test.go
@@ -1,0 +1,60 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vavallee/bindery/internal/models"
+)
+
+// TestMigrate071BackfillsNullMetadataProfile is the #1736 regression: authors
+// created via the pre-fix ensureAuthor (internal/hardcoverlistsyncer) landed
+// with metadata_profile_id NULL, unlike every author-create path that goes
+// through applyAuthorCreateOptions. Migration 071 backfills existing NULL
+// rows to the same default those paths would have stamped at create time.
+func TestMigrate071BackfillsNullMetadataProfile(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	repo := NewAuthorRepo(database)
+	author := &models.Author{
+		ForeignID:        "hc:pre-fix-author",
+		Name:             "Pre Fix Author",
+		SortName:         "Author, Pre Fix",
+		MetadataProvider: "hardcover",
+	}
+	if err := repo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate the pre-#1736 state: metadata_profile_id left NULL, as
+	// ensureAuthor produced before it stamped a default.
+	if _, err := database.ExecContext(ctx, `UPDATE authors SET metadata_profile_id = NULL WHERE id = ?`, author.ID); err != nil {
+		t.Fatalf("clear metadata_profile_id: %v", err)
+	}
+
+	v071 := migrationVersionForTest(t, "071_backfill_null_metadata_profile.sql")
+	if _, err := database.ExecContext(ctx, `DELETE FROM schema_migrations WHERE version = ?`, v071); err != nil {
+		t.Fatalf("clear migration 071 marker: %v", err)
+	}
+	if err := migrate(database); err != nil {
+		t.Fatalf("rerun migration 071: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, author.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("author not found after migration")
+	}
+	if got.MetadataProfileID == nil {
+		t.Fatal("MetadataProfileID is nil after migration 071, want DefaultMetadataProfileID")
+	}
+	if *got.MetadataProfileID != models.DefaultMetadataProfileID {
+		t.Errorf("MetadataProfileID = %d, want %d", *got.MetadataProfileID, models.DefaultMetadataProfileID)
+	}
+}

--- a/internal/db/migrations/071_backfill_null_metadata_profile.sql
+++ b/internal/db/migrations/071_backfill_null_metadata_profile.sql
@@ -1,0 +1,17 @@
+-- +migrate Up
+-- ensureAuthor (internal/hardcoverlistsyncer/syncer.go) built list-sync
+-- authors by hand and never stamped a metadata profile, unlike every other
+-- author-create path (applyAuthorCreateOptions), which has always defaulted
+-- to the seeded "Standard" profile (id=1) when the caller sent none (#1736).
+--
+-- The code path is now fixed for new authors; this backfills existing rows
+-- so already-affected libraries converge without hand-editing, matching the
+-- exact default applyAuthorCreateOptions would have stamped at create time.
+UPDATE authors
+SET metadata_profile_id = 1
+WHERE metadata_profile_id IS NULL
+  AND EXISTS (SELECT 1 FROM metadata_profiles WHERE id = 1);
+
+-- +migrate Down
+-- Irreversible: the rows this backfilled were already NULL before the fix,
+-- and there is no record of which rows were touched versus already 1.

--- a/internal/hardcoverlistsyncer/syncer.go
+++ b/internal/hardcoverlistsyncer/syncer.go
@@ -397,6 +397,13 @@ func (s *ListSyncer) ensureAuthor(ctx context.Context, book *models.Book, nameIn
 	if author.SortName == "" {
 		author.SortName = sortName(author.Name)
 	}
+	// Mirror applyAuthorCreateOptions' fallback (internal/api/authors.go) so a
+	// list-sync-created author gets the same default metadata profile every
+	// other creation path stamps, instead of staying unset (#1736).
+	if author.MetadataProfileID == nil {
+		def := models.DefaultMetadataProfileID
+		author.MetadataProfileID = &def
+	}
 
 	if err := s.authors.CreateForUser(ctx, author, ownerID); err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint failed") || errors.Is(err, db.ErrAuthorIdentifierConflict) {

--- a/internal/hardcoverlistsyncer/syncer_test.go
+++ b/internal/hardcoverlistsyncer/syncer_test.go
@@ -332,6 +332,53 @@ func TestSyncOne_NewAuthorPinnedToMonitorModeNone(t *testing.T) {
 	}
 }
 
+// TestSyncOne_NewAuthorDefaultsMetadataProfile is the #1736 regression:
+// ensureAuthor built the author struct by hand and called CreateForUser
+// directly, bypassing applyAuthorCreateOptions (internal/api/authors.go) —
+// the only place a metadata profile was ever defaulted. Every other
+// author-create path falls back to DefaultMetadataProfileID when the caller
+// sends none; list-sync-created authors must do the same instead of landing
+// with a permanently unset profile.
+func TestSyncOne_NewAuthorDefaultsMetadataProfile(t *testing.T) {
+	s, repo := newTestSyncer(t)
+	ctx := context.Background()
+
+	il := testImportList("HC", "hardcover", true)
+	if err := repo.Create(ctx, &il); err != nil {
+		t.Fatalf("seed list: %v", err)
+	}
+
+	newAuthor := func() *models.Author {
+		return &models.Author{ForeignID: "hc:newauthor", Name: "Brand New Author", MetadataProvider: "hardcover"}
+	}
+	s.WithClientFactory(func(string) hardcoverClient {
+		return &fakeHardcoverClient{
+			lists: []hardcover.HCList{{ID: 7, Slug: il.URL, Name: il.Name}},
+			books: []models.Book{
+				{ForeignID: "hc:listed", Title: "The Listed Book", MetadataProvider: "hardcover", Author: newAuthor()},
+			},
+		}
+	})
+
+	if err := s.SyncOne(ctx, il.ID); err != nil {
+		t.Fatalf("SyncOne: %v", err)
+	}
+
+	created, err := s.authors.GetByAnyForeignID(ctx, "hc:newauthor")
+	if err != nil {
+		t.Fatalf("GetByAnyForeignID: %v", err)
+	}
+	if created == nil {
+		t.Fatal("expected the new author to be created")
+	}
+	if created.MetadataProfileID == nil {
+		t.Fatal("new author MetadataProfileID is nil, want DefaultMetadataProfileID (#1736)")
+	}
+	if *created.MetadataProfileID != models.DefaultMetadataProfileID {
+		t.Errorf("new author MetadataProfileID = %d, want %d", *created.MetadataProfileID, models.DefaultMetadataProfileID)
+	}
+}
+
 // TestSyncOne_StampsListOwner is the hoxtonia-report regression: under
 // multi-user tenancy a list with an owner_user_id must stamp that owner onto
 // every book AND author it creates, so scheduler-synced content is scoped to


### PR DESCRIPTION
## Summary
- `ensureAuthor` (`internal/hardcoverlistsyncer/syncer.go`) built the author struct by hand and called `CreateForUser` directly, bypassing `applyAuthorCreateOptions` — the only place a metadata profile was ever defaulted.
- Every other author-create path falls back to `DefaultMetadataProfileID` (the seeded "Standard" profile) when the caller sends none. List-sync-created authors now get the same fallback.
- Migration `071` backfills already-affected rows (`metadata_profile_id IS NULL`) to the same default, so existing libraries converge without hand-editing.

Closes #1736.

## Test plan
- [x] New test `TestSyncOne_NewAuthorDefaultsMetadataProfile` (`internal/hardcoverlistsyncer/syncer_test.go`) — asserts a fresh list-sync-created author gets `MetadataProfileID == DefaultMetadataProfileID`.
- [x] New test `TestMigrate071BackfillsNullMetadataProfile` (`internal/db/migration_071_test.go`) — creates an author, nulls `metadata_profile_id` to simulate the pre-fix state, reruns migration 071, asserts the backfill applied.
- [x] `gofmt -l` clean on changed files
- [x] `go vet ./...` clean
- [x] `golangci-lint run --timeout=5m` — 0 issues, full repo
- [x] `govulncheck ./...` — 0 vulnerabilities in code/imports
- [x] `go test ./cmd/... ./internal/...` — full suite passes, no regressions
