### PR TITLE
feat(backup): optional label on a created backup

### DIFF
--- a/changelog.d/1790-backup-labels.md
+++ b/changelog.d/1790-backup-labels.md
@@ -1,0 +1,2 @@
+### Added
+- **Label a backup when you create it** (#1790) — the Backup panel now has an optional label field, so a backup is saved as `bindery_<timestamp>_<label>.db` (e.g. `bindery_20260726_181731_pre-import.db`) instead of a bare timestamp you have to rename afterwards to recognise. Labeled and manually renamed (same-shape) backups now restore and delete correctly from the UI, which previously only accepted the bare-timestamp filename. Config-only backup, separate from the full database, is tracked as a follow-up.

--- a/docs/API.md
+++ b/docs/API.md
@@ -143,7 +143,7 @@ GET    /api/v1/notification                       list webhooks
 POST   /api/v1/notification                       create
 POST   /api/v1/notification/{id}/test             fire a test event
 
-POST   /api/v1/backup                             snapshot the SQLite database
+POST   /api/v1/backup                             snapshot the SQLite database (optional {"label": "..."})
 GET    /api/v1/system/status                      version, uptime, build info
 PUT    /api/v1/system/loglevel                    runtime log-level switch (debug/info/warn/error)
 GET    /api/v1/images?url=<encoded>               proxied + cached cover image (30-day TTL)
@@ -244,6 +244,20 @@ curl -H "X-Api-Key: $KEY" http://bindery:8787/api/v1/search/last-debug
 ```bash
 curl -X POST -H "X-Api-Key: $KEY" http://bindery:8787/api/v1/backup
 ```
+
+The body is optional. Pass a `label` to make the snapshot identifiable — it is
+appended to the filename as `bindery_<timestamp>_<label>.db`:
+
+```bash
+curl -X POST -H "X-Api-Key: $KEY" -H 'Content-Type: application/json' \
+  -d '{"label":"pre-upgrade"}' http://bindery:8787/api/v1/backup
+```
+
+The label is sanitised server-side before it reaches the filename: only
+`A-Za-z0-9_-` survive, every other character (including `/`, `\`, `.` and any
+non-ASCII) collapses to `-`, and the result is capped at 40 characters. A label
+that sanitises to nothing — an all-CJK label, for example — is dropped and the
+snapshot keeps the plain timestamp name.
 
 **Fire a test webhook:**
 

--- a/internal/api/backup.go
+++ b/internal/api/backup.go
@@ -5,6 +5,7 @@ package api
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -18,10 +19,19 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// backupFilenameRe matches files produced by Create, "bindery_YYYYMMDD_HHMMSS.db".
-// Restore/Delete reject anything else so path-traversal tricks like "..%2Fetc"
-// or unrelated files under the backup dir can't be referenced by untrusted input.
-var backupFilenameRe = regexp.MustCompile(`^bindery_\d{8}_\d{6}\.db$`)
+// backupFilenameRe matches files produced by Create: the timestamp name
+// "bindery_YYYYMMDD_HHMMSS.db" and the optional-label form
+// "bindery_YYYYMMDD_HHMMSS_<label>.db". The charset is restricted to
+// [A-Za-z0-9_-] with a fixed prefix and suffix, so Restore/Delete reject any
+// path-traversal trick ("..%2Fetc") or unrelated file — the name can contain no
+// slash, backslash, or dot other than the ".db" extension. Matching a manually
+// renamed backup that stays within this shape is intentional: List shows those
+// files, so Restore/Delete must be able to act on them too.
+var backupFilenameRe = regexp.MustCompile(`^bindery_[A-Za-z0-9_-]+\.db$`)
+
+// maxBackupLabelLen caps a sanitized backup label so the filename stays a sane
+// length.
+const maxBackupLabelLen = 40
 
 type BackupHandler struct {
 	db      *sql.DB
@@ -39,6 +49,41 @@ func NewBackupHandler(database *sql.DB, dbPath, dataDir string) *BackupHandler {
 
 func (h *BackupHandler) backupDir() string {
 	return filepath.Join(h.dataDir, "backups")
+}
+
+// sanitizeBackupLabel reduces a user-supplied backup label to the safe charset
+// allowed inside a backup filename ([A-Za-z0-9_-]): every other character (space,
+// slash, dot, unicode) becomes '-', runs of separators collapse, leading and
+// trailing separators are trimmed, and the result is capped at maxBackupLabelLen.
+// Returns "" when nothing usable remains, in which case the backup keeps its
+// plain timestamp name. This is what keeps a label from smuggling a path
+// separator or ".." into the filename.
+func sanitizeBackupLabel(raw string) string {
+	raw = strings.TrimSpace(raw)
+	var b strings.Builder
+	lastSep := false
+	for _, r := range raw {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastSep = false
+		case r == '_' || r == '-':
+			if !lastSep {
+				b.WriteRune(r)
+				lastSep = true
+			}
+		default:
+			if !lastSep {
+				b.WriteByte('-')
+				lastSep = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "_-")
+	if len(out) > maxBackupLabelLen {
+		out = strings.Trim(out[:maxBackupLabelLen], "_-")
+	}
+	return out
 }
 
 // List returns all backup files in the backup directory.
@@ -107,8 +152,25 @@ func (h *BackupHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	label := ""
+	if r.Body != nil {
+		// Optional {"label": "..."} body — a user-supplied tag folded into the
+		// filename so backups can be recognised at a glance (e.g. "pre-import").
+		// A missing/empty/malformed body is fine: the backup keeps its plain
+		// timestamp name. Cap the read so a huge body can't be forced through.
+		var body struct {
+			Label string `json:"label"`
+		}
+		if err := json.NewDecoder(io.LimitReader(r.Body, 4<<10)).Decode(&body); err == nil {
+			label = sanitizeBackupLabel(body.Label)
+		}
+	}
+
 	timestamp := start.UTC().Format("20060102_150405")
 	destName := fmt.Sprintf("bindery_%s.db", timestamp)
+	if label != "" {
+		destName = fmt.Sprintf("bindery_%s_%s.db", timestamp, label)
+	}
 	destPath := filepath.Join(dir, destName)
 	// Stage the snapshot under a .tmp name and rename on success. SQLite's
 	// VACUUM INTO refuses to overwrite an existing file, and an aborted

--- a/internal/api/backup_label_test.go
+++ b/internal/api/backup_label_test.go
@@ -30,7 +30,7 @@ func withFilenameParam(req *http.Request, filename string) *http.Request {
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
-// TestBackup_Create_WithLabel is the #1791 feature test: an optional label is
+// TestBackup_Create_WithLabel is the #1790 feature test: an optional label is
 // folded into the backup filename, and the labeled file round-trips through
 // List, Restore, and Delete (which previously rejected any name that was not a
 // bare timestamp).

--- a/internal/api/backup_label_test.go
+++ b/internal/api/backup_label_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// callCreateWithBody invokes Create with a JSON request body (the optional
+// {"label": "..."}).
+func callCreateWithBody(t *testing.T, h *BackupHandler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/backup", strings.NewReader(body))
+	h.Create(rec, req)
+	return rec
+}
+
+// withFilenameParam attaches a chi route context carrying the {filename} URL
+// parameter that Restore/Delete read.
+func withFilenameParam(req *http.Request, filename string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("filename", filename)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// TestBackup_Create_WithLabel is the #1791 feature test: an optional label is
+// folded into the backup filename, and the labeled file round-trips through
+// List, Restore, and Delete (which previously rejected any name that was not a
+// bare timestamp).
+func TestBackup_Create_WithLabel(t *testing.T) {
+	database, dbPath, dataDir := backupTestDB(t)
+	h := NewBackupHandler(database, dbPath, dataDir)
+
+	rec := callCreateWithBody(t, h, `{"label":"pre-import cleanup!"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	entries, err := os.ReadDir(filepath.Join(dataDir, "backups"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 backup file, got %d", len(entries))
+	}
+	name := entries[0].Name()
+	// "pre-import cleanup!" -> "pre-import-cleanup" (space and '!' become one '-',
+	// collapsed, trailing separator trimmed).
+	if !strings.HasSuffix(name, "_pre-import-cleanup.db") {
+		t.Fatalf("filename %q does not carry the sanitized label", name)
+	}
+	if !backupFilenameRe.MatchString(name) {
+		t.Fatalf("labeled filename %q rejected by backupFilenameRe", name)
+	}
+
+	// Restore accepts the labeled name (bug before the fix: strict regex 400'd it).
+	restoreRec := httptest.NewRecorder()
+	restoreReq := withFilenameParam(
+		httptest.NewRequest(http.MethodPost, "/backup/"+name+"/restore", nil), name)
+	restoreReq.Header.Set("X-Confirm-Restore", "true")
+	h.Restore(restoreRec, restoreReq)
+	if restoreRec.Code != http.StatusOK {
+		t.Fatalf("restore labeled backup: status=%d body=%s", restoreRec.Code, restoreRec.Body.String())
+	}
+
+	// Delete accepts it too.
+	delRec := httptest.NewRecorder()
+	delReq := withFilenameParam(httptest.NewRequest(http.MethodDelete, "/backup/"+name, nil), name)
+	h.Delete(delRec, delReq)
+	if delRec.Code != http.StatusNoContent {
+		t.Fatalf("delete labeled backup: status=%d body=%s", delRec.Code, delRec.Body.String())
+	}
+}
+
+// TestBackup_Create_NoLabel keeps the plain timestamp name when the body is
+// empty or omits a usable label.
+func TestBackup_Create_NoLabel(t *testing.T) {
+	database, dbPath, dataDir := backupTestDB(t)
+	h := NewBackupHandler(database, dbPath, dataDir)
+
+	for _, body := range []string{"", `{}`, `{"label":"   "}`, `{"label":"!!!"}`} {
+		rec := callCreateWithBody(t, h, body)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("create body=%q: status=%d", body, rec.Code)
+		}
+	}
+	entries, err := os.ReadDir(filepath.Join(dataDir, "backups"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		// bindery_YYYYMMDD_HHMMSS.db — 15 chars of timestamp between prefix and ext.
+		mid := strings.TrimSuffix(strings.TrimPrefix(e.Name(), "bindery_"), ".db")
+		if strings.ContainsAny(mid, "abcdefghijklmnopqrstuvwxyz") {
+			t.Errorf("expected a bare timestamp name, got %q", e.Name())
+		}
+	}
+}
+
+func TestSanitizeBackupLabel(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"pre-import", "pre-import"},
+		{"just_settings", "just_settings"},
+		{"pre-import cleanup!", "pre-import-cleanup"},
+		{"../../etc/passwd", "etc-passwd"},
+		{"a/b\\c", "a-b-c"},
+		{"..", ""},
+		{"   ", ""},
+		{"日本語", ""},
+		{"v1.2.3", "v1-2-3"},
+		{strings.Repeat("x", 100), strings.Repeat("x", 40)},
+	}
+	for _, tc := range cases {
+		got := sanitizeBackupLabel(tc.in)
+		if got != tc.want {
+			t.Errorf("sanitizeBackupLabel(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+		// The output must always be safe to splice into a filename.
+		if strings.ContainsAny(got, `/\.`) {
+			t.Errorf("sanitizeBackupLabel(%q) = %q contains a path/extension character", tc.in, got)
+		}
+	}
+}
+
+func TestBackupFilenameRe_RejectsTraversal(t *testing.T) {
+	ok := []string{
+		"bindery_20260726_181731.db",
+		"bindery_20260726_181731_just_settings.db",
+		"bindery_20260726_181731_pre-import-cleanup.db",
+	}
+	for _, name := range ok {
+		if !backupFilenameRe.MatchString(name) {
+			t.Errorf("expected %q to be accepted", name)
+		}
+	}
+	bad := []string{
+		"evil.db",
+		"bindery_../x.db",
+		"bindery_a/b.db",
+		"bindery_20260726_181731.db.bak",
+		"../bindery_20260726_181731.db",
+		"bindery_20260726_181731.sqlite",
+	}
+	for _, name := range bad {
+		if backupFilenameRe.MatchString(name) {
+			t.Errorf("expected %q to be rejected", name)
+		}
+	}
+}

--- a/internal/api/destructive_handlers_test.go
+++ b/internal/api/destructive_handlers_test.go
@@ -107,7 +107,7 @@ func TestBackupRestore_RejectsBadFilename(t *testing.T) {
 
 	// Bad-SHAPE names (path separators, wrong prefix, wrong extension, empty)
 	// are rejected before the filesystem is touched. Label-shaped names like
-	// "bindery_bad.db" are now valid shapes (#1791) — a missing one 404s, which
+	// "bindery_bad.db" are now valid shapes (#1790) — a missing one 404s, which
 	// is covered by TestBackup_Create_WithLabel's round-trip, not here.
 	for _, bad := range []string{"../../etc/passwd", "random.db", "bindery_a/b.db", "bindery_x.sqlite", ""} {
 		rec := httptest.NewRecorder()

--- a/internal/api/destructive_handlers_test.go
+++ b/internal/api/destructive_handlers_test.go
@@ -68,7 +68,7 @@ func TestBackupDelete_RejectsPathEscapeFilename(t *testing.T) {
 
 	for _, bad := range []string{
 		"../do_not_delete.db",
-		"bindery_2024.db",
+		"bindery_a/b.db",
 		"bindery_20240102_030405.db.tmp",
 		"evil.db",
 		"",
@@ -105,7 +105,11 @@ func TestBackupRestore_RejectsBadFilename(t *testing.T) {
 	database, dbPath, dataDir := backupTestDB(t)
 	h := NewBackupHandler(database, dbPath, dataDir)
 
-	for _, bad := range []string{"../../etc/passwd", "random.db", "bindery_bad.db", ""} {
+	// Bad-SHAPE names (path separators, wrong prefix, wrong extension, empty)
+	// are rejected before the filesystem is touched. Label-shaped names like
+	// "bindery_bad.db" are now valid shapes (#1791) — a missing one 404s, which
+	// is covered by TestBackup_Create_WithLabel's round-trip, not here.
+	for _, bad := range []string{"../../etc/passwd", "random.db", "bindery_a/b.db", "bindery_x.sqlite", ""} {
 		rec := httptest.NewRecorder()
 		req := backupURLRequest(http.MethodPost, bad)
 		req.Header.Set("X-Confirm-Restore", "true")

--- a/web/src/api/settings.ts
+++ b/web/src/api/settings.ts
@@ -21,6 +21,10 @@ export const settingsApi = {
 
   // Backup
   listBackups: () => request<Array<{ name: string; size: number; modTime: string }>>('/backup'),
-  createBackup: () => request<{ name: string; size: number; modTime: string }>('/backup', { method: 'POST' }),
+  createBackup: (label?: string) =>
+    request<{ name: string; size: number; modTime: string }>('/backup', {
+      method: 'POST',
+      body: label ? JSON.stringify({ label }) : undefined,
+    }),
   deleteBackup: (filename: string) => request<void>(`/backup/${encodeURIComponent(filename)}`, { method: 'DELETE' }),
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -741,6 +741,7 @@
       "backupHint": "Includes authors, books, indexers, and settings",
       "backupButton": "Create Backup",
       "backupCreating": "Creating...",
+      "backupLabelPlaceholder": "Label (optional)",
       "existingBackups": "Existing backups:",
       "security": "Security",
       "logRetention": "Log Retention",

--- a/web/src/pages/settings/LogsTab.tsx
+++ b/web/src/pages/settings/LogsTab.tsx
@@ -45,6 +45,7 @@ export default function LogsTab() {
   const [backups, setBackups] = useState<Array<{ name: string; size: number; modTime: string }>>([])
   const [creatingBackup, setCreatingBackup] = useState(false)
   const [deletingBackup, setDeletingBackup] = useState<string | null>(null)
+  const [backupLabel, setBackupLabel] = useState('')
 
   const fetchLogs = (page = 0) => {
     api.getLogs({
@@ -78,8 +79,9 @@ export default function LogsTab() {
   const handleBackup = async () => {
     setCreatingBackup(true)
     try {
-      const result = await api.createBackup()
+      const result = await api.createBackup(backupLabel.trim() || undefined)
       setBackups(prev => [result, ...prev])
+      setBackupLabel('')
       alert(`Backup created: ${result.name}`)
     } catch (err) {
       alert('Backup failed: ' + (err instanceof Error ? err.message : 'Unknown error'))
@@ -348,13 +350,24 @@ export default function LogsTab() {
               <p className="text-sm text-slate-700 dark:text-zinc-300">{t('settings.general.backupCreate')}</p>
               <p className="text-xs text-slate-600 dark:text-zinc-500 mt-0.5">{t('settings.general.backupHint')}</p>
             </div>
-            <button
-              onClick={handleBackup}
-              disabled={creatingBackup}
-              className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium disabled:opacity-50 flex-shrink-0"
-            >
-              {creatingBackup ? t('settings.general.backupCreating') : t('settings.general.backupButton')}
-            </button>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <input
+                type="text"
+                value={backupLabel}
+                onChange={e => setBackupLabel(e.target.value)}
+                disabled={creatingBackup}
+                placeholder={t('settings.general.backupLabelPlaceholder')}
+                maxLength={40}
+                className="px-2 py-2 w-40 text-sm rounded border border-slate-300 dark:border-zinc-700 bg-white dark:bg-zinc-950 text-slate-800 dark:text-zinc-200 disabled:opacity-50"
+              />
+              <button
+                onClick={handleBackup}
+                disabled={creatingBackup}
+                className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 rounded text-sm font-medium disabled:opacity-50"
+              >
+                {creatingBackup ? t('settings.general.backupCreating') : t('settings.general.backupButton')}
+              </button>
+            </div>
           </div>
           {backups.length > 0 && (
             <div className="mt-3 border-t border-slate-200 dark:border-zinc-800 pt-3">


### PR DESCRIPTION
Addresses part of a Discord request (EricSilberberg) — the "name the backup as part of the save" half. The larger "config-only backup" half is tracked in #1789.

## Problem

"Create Backup" always wrote `bindery_YYYYMMDD_HHMMSS.db` (`internal/api/backup.go`, `VACUUM INTO`). Users keeping several backups as rollback points renamed the files on disk to tell them apart. But `List` shows every `.db` in the backup dir, while `Restore`/`Delete` validated against the strict `^bindery_\d{8}_\d{6}\.db$` — so a renamed backup appeared in the UI with **Delete/Restore buttons that 400**. (The reporter hadn't hit it yet: "I have not yet tested restores.")

## Change

- **`Create`** accepts an optional `{"label": "..."}` body, sanitizes it (`sanitizeBackupLabel`: keep `[A-Za-z0-9_-]`, fold everything else to `-`, collapse runs, trim, cap 40 chars), and writes `bindery_<timestamp>_<label>.db`. A missing/empty/all-invalid label keeps the plain timestamp name.
- **Filename validator** widened to `^bindery_[A-Za-z0-9_-]+\.db$` so `Restore`/`Delete` accept labeled (and manually renamed, same-shape) backups. Still no path traversal: the name can contain no `/`, `\`, or dot except the `.db` extension, and the label sanitizer is what enforces that on the write side. This makes `List`/`Restore`/`Delete` agree.
- **Frontend**: a small optional label text field next to the Create Backup button (`LogsTab.tsx`), threaded through `api.createBackup(label?)`.

## Tests

- `TestBackup_Create_WithLabel` — labeled create, then the labeled file round-trips through List/Restore/Delete (all previously 400'd).
- `TestBackup_Create_NoLabel` — empty/blank/all-invalid labels keep the bare timestamp name.
- `TestSanitizeBackupLabel` — traversal (`../../etc/passwd` → `etc-passwd`), separators, unicode, length cap; asserts output never contains `/ \ .`.
- `TestBackupFilenameRe_RejectsTraversal` — accepts timestamp + labeled names, rejects wrong prefix/extension/separators.
- Updated two existing tests (`TestBackupRestore_RejectsBadFilename`, `TestBackupDelete_RejectsPathEscapeFilename`) whose fixtures used label-shaped names as "invalid" — those are now valid shapes (missing → 404); swapped in genuine bad-shape names.

Backend `go test ./internal/api/` green, lint 0, frontend `tsc` + build green.