### PR TITLE
fix(web): repair two silently-broken Tailwind classes on the detail pages

### DIFF
--- a/changelog.d/detail-page-tailwind-bugs.md
+++ b/changelog.d/detail-page-tailwind-bugs.md
@@ -1,0 +1,3 @@
+### Fixed
+- **Book detail File card lost its two-column layout** — the label/value grid used a comma in its arbitrary track list, which compiles to invalid CSS that browsers drop, collapsing the card to a single column.
+- **Author detail page was rendering unconstrained** — its max-width class sat directly against a `${…}` interpolation, so Tailwind's scanner never extracted it and the rule was absent from the compiled CSS entirely.

--- a/web/eslint-rules/tailwind-safety.js
+++ b/web/eslint-rules/tailwind-safety.js
@@ -1,0 +1,160 @@
+/**
+ * Local ESLint rules for two Tailwind failure modes that are invisible at
+ * runtime: the class name looks correct in the DOM and the build succeeds, but
+ * the CSS rule is either never generated or generated invalid. Nothing else in
+ * the toolchain catches either one.
+ *
+ * No plugin dependency — these are flat-config inline rules.
+ */
+
+/** Does this node sit somewhere that ends up in a class attribute? */
+function inClassNameContext(node) {
+  let child = node
+  let parent = node.parent
+  // Walk up through expression wrappers (ternaries, &&, nested templates, and
+  // clsx()-style calls) to find what the string is ultimately assigned to.
+  while (parent) {
+    switch (parent.type) {
+      case 'JSXExpressionContainer':
+        if (
+          parent.parent?.type === 'JSXAttribute' &&
+          /^class(Name)?$/.test(parent.parent.name?.name ?? '')
+        ) {
+          return true
+        }
+        return false
+      case 'VariableDeclarator':
+        return /(^|[a-z])(cls|class|classes|className)$/i.test(parent.id?.name ?? '')
+      case 'Property':
+        return /(^|[a-z])(cls|class|classes|className)$/i.test(
+          parent.key?.name ?? parent.key?.value ?? '',
+        )
+      case 'ConditionalExpression':
+      case 'LogicalExpression':
+      case 'TemplateLiteral':
+      case 'CallExpression':
+      case 'ArrayExpression':
+      case 'ReturnStatement':
+      case 'ArrowFunctionExpression':
+        child = parent
+        parent = parent.parent
+        continue
+      default:
+        return false
+    }
+  }
+  return false
+}
+
+/**
+ * Flags `max-w-5xl${cond ? …}` — a class token glued directly to an
+ * interpolation. Tailwind v4's scanner reads source text, not runtime values,
+ * so it extracts the token `max-w-5xl${cond` and never emits `.max-w-5xl`.
+ * The page silently loses the class.
+ */
+const noGluedClassInterpolation = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow a Tailwind class immediately followed by ${…}; the scanner cannot extract it',
+    },
+    fixable: 'whitespace',
+    schema: [],
+    messages: {
+      glued:
+        "Tailwind cannot extract '{{token}}' because '${' follows it with no space. " +
+        'The class will be missing from the compiled CSS. Add a space before ${ ' +
+        'and move it inside the expression.',
+    },
+  },
+  create(context) {
+    return {
+      TemplateLiteral(node) {
+        if (node.expressions.length === 0) return
+        if (!inClassNameContext(node)) return
+
+        node.quasis.forEach((quasi, i) => {
+          // The last quasi has no interpolation after it.
+          if (i >= node.expressions.length) return
+          const raw = quasi.value.raw
+          if (raw === '' || /\s$/.test(raw)) return
+
+          const token = raw.split(/\s/).pop()
+          // A trailing separator means the interpolation supplies a value
+          // (`/book/${id}`, `bg-${color}`), not a class boundary.
+          if (/[-:/[(,._]$/.test(token)) return
+
+          context.report({
+            node: quasi,
+            messageId: 'glued',
+            data: { token },
+            fix: fixer => fixer.insertTextAfterRange([quasi.range[0], quasi.range[1] - 2], ' '),
+          })
+        })
+      },
+    }
+  },
+}
+
+/**
+ * Flags a comma at the top level of an arbitrary value — e.g. separating grid
+ * tracks with a comma rather than an underscore. Tailwind emits the comma
+ * literally, producing `grid-template-columns:92px<comma>1fr`, which is invalid
+ * CSS and gets dropped. Commas nested inside parens are legal (`bg-[rgb(…)]`).
+ *
+ * Examples here avoid spelling out a real broken class: Tailwind scans raw
+ * source text including comments, so a literal one would be emitted into the
+ * shipped CSS.
+ */
+const noCommaArbitraryValue = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow a top-level comma in a Tailwind arbitrary value; use _ as the separator',
+    },
+    schema: [],
+    messages: {
+      comma:
+        "Arbitrary value '[{{value}}]' has a top-level comma. Tailwind emits it " +
+        'literally, producing invalid CSS that the browser drops. Use _ instead.',
+    },
+  },
+  create(context) {
+    function check(node, text) {
+      if (!text || !text.includes('[')) return
+      // Scan each `-[...]` arbitrary value, tracking paren depth so commas
+      // inside rgb()/calc()/etc. are left alone.
+      const re = /-\[([^\]]*)\]/g
+      let m
+      while ((m = re.exec(text)) !== null) {
+        const value = m[1]
+        let depth = 0
+        for (const ch of value) {
+          if (ch === '(') depth++
+          else if (ch === ')') depth--
+          else if (ch === ',' && depth === 0) {
+            context.report({ node, messageId: 'comma', data: { value } })
+            break
+          }
+        }
+      }
+    }
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string') check(node, node.value)
+      },
+      TemplateElement(node) {
+        check(node, node.value.raw)
+      },
+    }
+  },
+}
+
+export const tailwindSafety = {
+  rules: {
+    'no-glued-class-interpolation': noGluedClassInterpolation,
+    'no-comma-arbitrary-value': noCommaArbitraryValue,
+  },
+}

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -3,6 +3,7 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
+import { tailwindSafety } from './eslint-rules/tailwind-safety.js'
 
 export default tseslint.config(
   { ignores: ['dist'] },
@@ -16,8 +17,14 @@ export default tseslint.config(
     plugins: {
       'react-hooks': reactHooks,
       'react-refresh': reactRefresh,
+      'tailwind-safety': tailwindSafety,
     },
     rules: {
+      // Two Tailwind bugs that produce no build error and no runtime error —
+      // the class is simply absent from the compiled CSS, or the declaration is
+      // invalid and dropped. Both shipped undetected; see eslint-rules/.
+      'tailwind-safety/no-glued-class-interpolation': 'error',
+      'tailwind-safety/no-comma-arbitrary-value': 'error',
       // Explicitly list the two classic hooks rules that were in recommended
       // before eslint-plugin-react-hooks 7.1 added React Compiler rules. The
       // new compiler rules (set-state-in-effect, immutability, purity, etc.)

--- a/web/src/pages/AuthorDetailPage.tsx
+++ b/web/src/pages/AuthorDetailPage.tsx
@@ -615,7 +615,7 @@ export default function AuthorDetailPage() {
     view === 'table' ? renderTable(list, withHeaderControls) : renderGrid(list)
 
   return (
-    <div className={`max-w-5xl${selected.size > 0 ? ' pb-20' : ''}`}>
+    <div className={`max-w-5xl ${selected.size > 0 ? 'pb-20' : ''}`}>
       <div className="mb-4 flex items-center gap-3 text-sm">
         <button onClick={() => navigate(-1)} className="text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white">← Back</button>
       </div>

--- a/web/src/pages/BookDetailPage.test.tsx
+++ b/web/src/pages/BookDetailPage.test.tsx
@@ -636,3 +636,50 @@ describe('BookDetailPage — live import polling (#1161)', () => {
     }
   })
 })
+
+// Regression guard for the File card's two-column grid.
+//
+// Separating the two tracks with a comma instead of an underscore compiles to
+// `grid-template-columns:92px<comma>1fr`, which is invalid CSS — every browser
+// drops the declaration and the card silently collapses to a single track. The
+// class name still *looks* right in the DOM and the build still succeeds, so
+// nothing catches it. jsdom's CSS parser rejects the same value a browser does,
+// so round-tripping the arbitrary value through a style declaration reproduces
+// the real failure without a build.
+//
+// NB: the broken class is deliberately not spelled out literally anywhere in
+// this repo. Tailwind scans raw source text, comments included, so writing it
+// out re-emits the invalid rule into the shipped CSS.
+describe('BookDetailPage — File card grid (regression: invalid arbitrary value)', () => {
+  // Pull the grid-cols-[…] arbitrary value off the File card and resolve it the
+  // way a browser would: assign it, then read back what survived parsing.
+  function computedTracks(el: Element): string {
+    const cls = Array.from(el.classList).find(c => c.startsWith('grid-cols-['))
+    if (!cls) throw new Error(`no grid-cols-[…] class on ${el.className}`)
+    const raw = cls.slice('grid-cols-['.length, -1).replace(/_/g, ' ')
+    const probe = document.createElement('div')
+    probe.style.gridTemplateColumns = raw
+    return probe.style.gridTemplateColumns
+  }
+
+  it('declares two grid tracks that survive CSS parsing', async () => {
+    const { container } = renderBookDetailPage()
+    await screen.findByText(resolveKey('bookDetail.fileHeading')!)
+
+    const grid = container.querySelector('[class*="grid-cols-["]')
+    expect(grid, 'File card grid element').not.toBeNull()
+
+    const tracks = computedTracks(grid!)
+    // A comma in the arbitrary value makes this empty — the browser drops it.
+    expect(tracks, 'grid-template-columns was rejected by the CSS parser').not.toBe('')
+    expect(tracks.split(/\s+/).filter(Boolean)).toHaveLength(2)
+  })
+
+  it('uses underscore, not comma, as the arbitrary-value separator', async () => {
+    const { container } = renderBookDetailPage()
+    await screen.findByText(resolveKey('bookDetail.fileHeading')!)
+
+    const grid = container.querySelector('[class*="grid-cols-["]')
+    expect(grid!.className).not.toMatch(/grid-cols-\[[^\]]*,/)
+  })
+})

--- a/web/src/pages/BookDetailPage.tsx
+++ b/web/src/pages/BookDetailPage.tsx
@@ -563,7 +563,7 @@ export default function BookDetailPage() {
           {t('bookDetail.fileHeading')}
         </h3>
         <div className="rounded-lg border border-slate-200 dark:border-zinc-800 bg-slate-100 dark:bg-zinc-900 p-4">
-          <div className="grid grid-cols-[92px,1fr] gap-x-4 gap-y-3 text-sm items-center">
+          <div className="grid grid-cols-[92px_1fr] gap-x-4 gap-y-3 text-sm items-center">
             <span className="text-xs text-slate-500 dark:text-zinc-500">{t('bookDetail.formatLabel')}</span>
             {isDual ? (
               <div className="inline-flex rounded overflow-hidden w-fit" role="group" aria-label={t('bookDetail.formatLabel')}>


### PR DESCRIPTION
Step 2 of the detail-page cleanup: the two confirmed CSS bugs, the interpolation audit, and regression guards. No layout/visual changes beyond what the two broken rules were already supposed to be doing.

## The bugs

Both are invisible to the toolchain — no build error, no runtime error, correct-looking class in the DOM — because the failure happens in the compiled CSS.

**1. `BookDetailPage.tsx:566` — File card collapsed to one column.**
`grid-cols-[92px,1fr]` passes the comma through verbatim, emitting `grid-template-columns:92px,1fr`. That is invalid CSS and browsers drop the declaration. The rule *is* generated, which is what makes it confusing to chase — it just does nothing. Fixed with the `_` separator.

**2. `AuthorDetailPage.tsx:618` — page rendering unconstrained.**
`` `max-w-5xl${…}` `` puts the class directly against an interpolation. Tailwind v4 scans source text, not runtime values, so it extracted `max-w-5xl${selected.size` and never emitted `.max-w-5xl` at all. `.max-w-4xl` and `.max-w-7xl` were present, which is why this looked like a Tailwind bug rather than a source bug. Fixed by adding the space.

## Verified against compiled CSS

Before:
```
.grid-cols-\[92px\,1fr\]  ->  grid-template-columns:92px,1fr   (invalid, dropped)
.max-w-5xl                ->  ABSENT
```
After:
```
.grid-cols-\[92px_1fr\]   ->  grid-template-columns:92px 1fr   (two tracks)
.max-w-5xl                ->  max-width:var(--container-5xl)
```

## Audit result

Swept every template literal in a `className` context across `web/src` for a token glued to `${`. **`AuthorDetailPage.tsx:618` was the only instance.** Caveat on scope: the sweep only covers statically identifiable template literals, so classes assembled inside helper functions or array joins would not appear. The lint rule below covers new occurrences regardless.

## Guards

- **`BookDetailPage.test.tsx`** — asserts the File card's arbitrary track list survives CSS parsing and resolves to two tracks. jsdom's CSS parser rejects the comma form exactly as a browser does, so this reproduces the real failure with no build step. Confirmed it fails when the comma is restored (not a test that can only pass).
- **`web/eslint-rules/tailwind-safety.js`** — two local flat-config rules, **no new dependency**, wired into the existing `lint` CI job so they also surface in-editor:
  - `no-comma-arbitrary-value` tracks paren depth, so `bg-[rgb(255,0,0)]` and `shadow-[…rgba(0,0,0,0.5)]` stay legal.
  - `no-glued-class-interpolation` only fires in className contexts and ignores value-supplying interpolations like `/book/${id}`, `bg-${color}`, and `` `${status}-${monitored}` ``. Autofix inserts the space.

Both rules confirmed to fire on the two original bugs and to report **0 errors** across the current tree.

## Checks

`npm run lint` 0 errors (6 pre-existing react-hooks warnings unchanged) · `npm run typecheck` clean · `npm test` 451/451 passing.

Labelled `dev-preview` for bindery-dev. Prod is untouched — no tag, no `values.yaml` write.