### PR TITLE
fix(security): bump js-yaml to 4.3.1 for GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/changelog.d/js-yaml-advisory.md
+++ b/changelog.d/js-yaml-advisory.md
@@ -1,0 +1,2 @@
+### Security
+- **Bumped js-yaml to 4.3.1** (GHSA-5p4m-2wfm-xmqj) — resolves a high-severity quadratic-CPU advisory in `!!omap` resolution. Build tooling only: js-yaml is a transitive devDependency of ESLint and never reaches the browser bundle, so no deployed instance was exposed.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3968,9 +3968,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Unblocks the `SAST – Frontend` job, which is currently failing at `npm audit` on **every** PR and on `main`.

## The advisory

[GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — high severity, quadratic CPU consumption in js-yaml's `!!omap` resolution. The CVE-2026-59870 fix was never backported to the affected `4.0.0 – 4.3.0` range. `4.3.1` (published on the `v4-legacy` dist-tag) sits outside it and satisfies the `^4.1.0` both dependents ask for, so this is a patch bump with no other resolution changes.

## Scope: build tooling, not the shipped app

js-yaml is a **transitive devDependency**, reached via `@eslint/eslintrc` and the `eslint` bundled inside `@microsoft/eslint-formatter-sarif`. It is not in the runtime dependency tree and never reaches the browser bundle. **No deployed instance was exposed** — this unblocks CI rather than patching a live vulnerability.

Confirmed pre-existing: the advisory reproduces on a clean worktree of `main` at `359df14c`, so it was not introduced by any in-flight branch.

## Why the lockfile was edited by hand

`npm audit fix` produced a **+3 / −33** diff. Beyond the js-yaml bump it stripped the `libc` fields from ten optional rollup/oxide native packages, because this machine runs **npm 10** while the lockfile was written by the **npm 11** that CI uses (node 26). Those fields gate musl-vs-glibc binary selection, so dropping them risked changing which native binary the Docker build resolves — unrelated risk for a security patch.

So the committed diff is exactly three lines — `version`, `resolved`, `integrity` — and the integrity hash was read from the registry via `npm view js-yaml@4.3.1 dist.integrity` rather than copied out of the audit-fix diff.

```
-      "version": "4.3.0",
+      "version": "4.3.1",
```

## Verification

`npm audit` → **0 vulnerabilities** · `npm ci` resolves the lockfile and installs 4.3.1 · `npm run lint` 0 errors (6 pre-existing react-hooks warnings unchanged) · `npm run typecheck` clean · `npm test` 449/449.

Not labelled `dev-preview` — it is a dev-dependency change with no runtime effect, so there is nothing to eyeball on bindery-dev.