### PR TITLE
fix(api): sweep all tracked files when deleting an author with files

### DIFF
--- a/changelog.d/author-delete-per-format-files.md
+++ b/changelog.d/author-delete-per-format-files.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Deleting an author with "delete files" now removes every tracked file** — the sweep enumerated only the legacy `file_path` column, so a book's ebook/audiobook files tracked in `book_files` (multi-format books, audiobook folders) and any excluded book's files were left orphaned on disk. It now walks `book_files` per book (falling back to the per-format/legacy columns) and includes excluded books, matching the single-book delete path.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1149,13 +1149,30 @@ func (h *AuthorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// rather than walking outside the library.
 	var pathsToRemove []string
 	if r.URL.Query().Get("deleteFiles") == "true" {
-		books, err := h.books.ListByAuthor(r.Context(), id)
+		// Include excluded books: the FK cascade below deletes them too, so
+		// their files must be swept as well or they are orphaned on disk.
+		books, err := h.books.ListByAuthorIncludingExcluded(r.Context(), id)
 		if err != nil {
 			slog.Warn("delete author: failed to list books for file cleanup", "author_id", id, "error", err)
 		}
 		for _, b := range books {
-			if b.FilePath != "" {
-				pathsToRemove = append(pathsToRemove, b.FilePath)
+			// Mirror the single-book delete (books.go Delete): prefer the
+			// book_files rows so every tracked ebook/audiobook file — including
+			// multi-format books and audiobook folders — is collected. Only fall
+			// back to the per-format / legacy columns for books that predate the
+			// book_files table (no rows). Collecting b.FilePath alone, as this
+			// did before, silently orphaned every file tracked in book_files.
+			files, _ := h.books.ListFiles(r.Context(), b.ID)
+			if len(files) > 0 {
+				for _, f := range files {
+					pathsToRemove = append(pathsToRemove, f.Path)
+				}
+				continue
+			}
+			for _, p := range []string{b.EbookFilePath, b.AudiobookFilePath, b.FilePath} {
+				if p != "" {
+					pathsToRemove = append(pathsToRemove, p)
+				}
 			}
 		}
 	}

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -333,6 +333,89 @@ func TestDeleteAuthor_SkipsFileOwnedByAnotherBook(t *testing.T) {
 	}
 }
 
+// TestDeleteAuthor_SweepsBookFilesAndPerFormatPaths guards the multi-format
+// sweep: deleting an author with ?deleteFiles=true must remove every file a
+// book tracks in book_files (ebook + audiobook), not just the legacy
+// file_path column. It also covers excluded books, which the FK cascade
+// deletes along with the author and whose files would otherwise be orphaned.
+// Before the fix the handler collected b.FilePath alone via ListByAuthor
+// (excluded=0), so all three files below survived on disk.
+func TestDeleteAuthor_SweepsBookFilesAndPerFormatPaths(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+	ctx := context.Background()
+
+	// Distinct basenames on purpose: safeRemoveBookPath also removes same-stem
+	// siblings, so a shared stem would let the old (file_path-only) sweep take
+	// the audiobook out as a side effect and hide the real gap. Different stems
+	// force the sweep to actually enumerate book_files.
+	dir := t.TempDir()
+	epub := filepath.Join(dir, "novel.epub")
+	m4b := filepath.Join(dir, "recording.m4b")
+	excludedFile := filepath.Join(dir, "hidden.epub")
+	for _, p := range []string{epub, m4b, excludedFile} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	author := &models.Author{ForeignID: "OLSWEEP", Name: "Sweep", SortName: "Sweep", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authorRepo.Create(ctx, author); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dual-format book: both files tracked in book_files, no legacy file_path.
+	dual := &models.Book{ForeignID: "OLDUAL", AuthorID: author.ID, Title: "Dual", SortTitle: "dual", Status: "imported", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true}
+	if err := bookRepo.Create(ctx, dual); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.AddBookFile(ctx, dual.ID, models.MediaTypeEbook, epub); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.AddBookFile(ctx, dual.ID, models.MediaTypeAudiobook, m4b); err != nil {
+		t.Fatal(err)
+	}
+
+	// Excluded book with a file. The cascade deletes it with the author, so its
+	// file must be swept too — which needs the include-excluded lister.
+	excluded := &models.Book{ForeignID: "OLEXCL", AuthorID: author.ID, Title: "Excl", SortTitle: "excl", Status: "imported", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true}
+	if err := bookRepo.Create(ctx, excluded); err != nil {
+		t.Fatal(err)
+	}
+	if err := bookRepo.AddBookFile(ctx, excluded.ID, models.MediaTypeEbook, excludedFile); err != nil {
+		t.Fatal(err)
+	}
+	excluded.Excluded = true
+	if err := bookRepo.Update(ctx, excluded); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, nil, nil, profileRepo, nil)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/author/"+strconv.FormatInt(author.ID, 10)+"?deleteFiles=true", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", strconv.FormatInt(author.ID, 10))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.Delete(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	for _, p := range []string{epub, m4b, excludedFile} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Errorf("file %s should have been swept on author delete, stat err=%v", p, err)
+		}
+	}
+}
+
 // TestDeleteAuthor_WithoutDeleteFiles confirms the default path leaves
 // files on disk. Preserves the pre-#15 behaviour for anyone who hits the
 // delete button reflexively without opting into a disk sweep.


### PR DESCRIPTION
Closes #1810.

## Problem

`AuthorHandler.Delete`'s `?deleteFiles=true` branch collected only each book's legacy `file_path` column via `ListByAuthor` (which filters `excluded = 0`). After the FK cascade removed the book and `book_files` rows:

- Files tracked in `book_files` but not mirrored into `file_path` (multi-format books, audiobook folders) were left orphaned on disk.
- Every excluded book's files were orphaned, since `ListByAuthor` never returned those books.

Single-book delete already handled this; author delete did not.

## Change

- `internal/api/authors.go` — enumerate `book_files` per book (fall back to the per-format/legacy columns only for pre-migration rows with no `book_files` entries), and switch to `ListByAuthorIncludingExcluded` so excluded books' files are swept. Paths are still collected before the cascade and run through the same library-root containment + cross-book ownership guards (#1368).
- New test `TestDeleteAuthor_SweepsBookFilesAndPerFormatPaths`.

## Verification

- Test is non-vacuous: reverting the handler leaves the audiobook file and the excluded book's file on disk (test fails); with the fix all files are swept (passes). Distinct filename stems, so it exercises real `book_files` enumeration rather than `safeRemoveBookPath`'s same-stem sibling removal.
- `go vet ./internal/api` clean, full `./internal/api` suite green.

Pre-existing bug, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)