### PR TITLE
fix(ci): stop the external-PR backstop re-pinging Discord forever

### DIFF
--- a/.github/workflows/notify-external-pr-backstop.yml
+++ b/.github/workflows/notify-external-pr-backstop.yml
@@ -24,13 +24,13 @@ on:
         default: '7'
 
 permissions:
-  pull-requests: write   # list + dedupe label; no checkout, so no contents access needed
+  pull-requests: write   # list PRs + apply the dedupe label
+  issues: write          # create the dedupe label if it has gone missing
 
 jobs:
   backstop:
     name: Catch missed external PRs
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
@@ -40,15 +40,23 @@ jobs:
       - name: Notify and label any missed external PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          # PR notifications go to #pr-feed, not the user-facing #releases
+          # channel. Falls back to the release webhook until DISCORD_PR_WEBHOOK
+          # is set, so this workflow keeps working across the split.
+          WEBHOOK: ${{ secrets.DISCORD_PR_WEBHOOK || secrets.DISCORD_RELEASE_WEBHOOK }}
           MAINTAINER_ID: ${{ vars.DISCORD_MAINTAINER_ID }}
           REPO: ${{ github.repository }}
           REPO_OWNER: ${{ github.repository_owner }}
           LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '7' }}
         run: |
           set -euo pipefail
+
+          # Self-heal the dedupe key before relying on it.
+          gh label create bindery-notified --repo "$REPO" \
+            --description "Discord notification already sent for this PR" \
+            --color ededed 2>/dev/null || true
           if [ -z "$WEBHOOK" ]; then
-            echo "::warning::DISCORD_RELEASE_WEBHOOK not set; nothing to do"
+            echo "::warning::no Discord PR webhook configured; nothing to do"
             exit 0
           fi
 
@@ -106,8 +114,9 @@ jobs:
               -X POST -H "Content-Type: application/json" \
               -d "$PAYLOAD" "$WEBHOOK") || HTTP=000
             if [ "$HTTP" = "204" ]; then
-              gh pr edit "$num" --repo "$REPO" --add-label bindery-notified || \
-                echo "::warning::failed to add label to #${num}; will retry on next tick"
+              # NOT best-effort. This is the only dedupe key; a post we cannot
+              # record is a post we will make again in 15 minutes, forever.
+              gh pr edit "$num" --repo "$REPO" --add-label bindery-notified
               POSTED=$((POSTED+1))
             else
               echo "::warning::Discord returned HTTP ${HTTP} for PR #${num}; will retry on next tick"
@@ -115,3 +124,12 @@ jobs:
           done
 
           echo "Posted ${POSTED} backstop notifications"
+
+          # A backstop is meant to catch the occasional miss. Catching several
+          # in one tick means the event-driven path or the dedupe is broken,
+          # and the next tick will do it again.
+          if [ "$POSTED" -gt 3 ]; then
+            echo "::error::backstop posted ${POSTED} notifications in a single run;" \
+                 "the event-driven workflow or the bindery-notified label is broken"
+            exit 1
+          fi

--- a/.github/workflows/notify-external-pr.yml
+++ b/.github/workflows/notify-external-pr.yml
@@ -26,7 +26,8 @@ on:
     types: [opened, ready_for_review]
 
 permissions:
-  pull-requests: write   # dedupe label; everything else (incl. contents) defaults to none
+  pull-requests: write   # apply the dedupe label
+  issues: write          # create the dedupe label if it has gone missing
 
 jobs:
   notify:
@@ -47,7 +48,9 @@ jobs:
       - name: Post to Discord
         id: post
         env:
-          WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          # PR notifications go to #pr-feed, not #releases. Falls back to the
+          # release webhook until DISCORD_PR_WEBHOOK is set.
+          WEBHOOK: ${{ secrets.DISCORD_PR_WEBHOOK || secrets.DISCORD_RELEASE_WEBHOOK }}
           # Optional: a Discord user ID to @mention so the maintainer gets a real
           # ping (a plain channel post is easy to miss). Stored as a repo variable
           # rather than hardcoded so the ID isn't baked into this public file and
@@ -60,7 +63,7 @@ jobs:
           PR_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
           if [ -z "$WEBHOOK" ]; then
-            echo "::warning::DISCORD_RELEASE_WEBHOOK not set; skipping"
+            echo "::warning::no Discord PR webhook configured; skipping"
             echo "posted=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -102,8 +105,15 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          # Best-effort: a missing label permission must not fail the job
-          # (the backstop will see no label and try again, which is fine
-          # because Discord requests at this volume are essentially free).
-          gh pr edit "$PR_NUMBER" --add-label bindery-notified --repo "$REPO" || \
-            echo "::warning::failed to add bindery-notified label (the cron backstop will retry)"
+          set -euo pipefail
+          # Self-heal: the label going missing (deleted, or never created in a
+          # fork) is the failure mode that turns the backstop into a ping loop.
+          gh label create bindery-notified --repo "$REPO" \
+            --description "Discord notification already sent for this PR" \
+            --color ededed 2>/dev/null || true
+
+          # NOT best-effort. This label is the backstop's only dedupe key: if we
+          # posted but failed to record it, the backstop re-posts every 15
+          # minutes forever. Fail loudly so it gets fixed rather than accruing
+          # silently in a channel nobody reads.
+          gh pr edit "$PR_NUMBER" --add-label bindery-notified --repo "$REPO"


### PR DESCRIPTION
## What was happening

`notify-external-pr-backstop.yml` dedupes by applying the `bindery-notified` label. **That label did not exist in this repo.** `gh pr edit --add-label` failed on every run, the failure was swallowed by `|| echo "::warning::…"`, and `continue-on-error: true` kept the job green — so every 15-minute tick re-posted every open external PR.

**2800 duplicate notifications** were sent to Discord between 2026-06-02 and 2026-08-09, each one an `@mention` of the maintainer:

| PR | pings |
|---|---|
| #1611 | 113 |
| #1554 / #1555 | 113 each |
| #1613 | 112 |
| #1571 | 107 |
| #1361 | 99 |
| #1784 | 97 |

92 PRs total. The release notes the channel exists for were buried in them.

The label has since been created and backfilled onto the three open external PRs, so the loop is already stopped. This PR is the structural fix.

## Changes

- Both workflows `gh label create` the label if missing — the dedupe key self-heals instead of failing open.
- **Applying the label is no longer best-effort.** A post we cannot record is a post we will make again in 15 minutes; that has to fail loudly.
- The backstop errors out if it posts more than 3 in a single run. Catching that many at once means the dedupe or the event-driven path is broken, and the next tick would repeat it.
- Dropped `continue-on-error` from the backstop. It is a scheduled job and fails to nobody's PR; suppressing its failures is exactly what hid this for two months.
- **Kept** `continue-on-error` on the event-driven job — that one runs on contributor PRs, where a red X for a Discord webhook problem would be misleading. The backstop's hard failure is the alarm.
- PR notifications move to `DISCORD_PR_WEBHOOK`, falling back to `DISCORD_RELEASE_WEBHOOK` until that secret is set, so `#releases` carries releases only.
- Added `issues: write` to both, required for `gh label create`.

## Follow-up needed

Create a webhook on the new `#pr-feed` Discord channel and store it as the `DISCORD_PR_WEBHOOK` repo secret. Until then the fallback keeps current behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)