### PR TITLE
feat(telemetry-server): ingest setup-funnel day offsets + funnel table on /stats

### DIFF
--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -2205,10 +2205,10 @@ func renderFunnel(stages []funnelStage) string {
 			`this section populates as new installs arrive on it.</p></div>`
 	}
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf(
+	fmt.Fprintf(&b,
 		`<p class="empty" style="margin:0 0 .5rem 0">Out of %d new install%s on funnel-capable versions. `+
 			`"By D+1/D+7" count only installs old enough for that window.</p>`,
-		stages[0].Cohort, pluralS(stages[0].Cohort)))
+		stages[0].Cohort, pluralS(stages[0].Cohort))
 	b.WriteString(`<div class="chart"><table class="bars"><tr>` +
 		`<td class="legend-cell"></td>` +
 		`<td class="count-cell">by D+1</td>` +

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -740,6 +741,15 @@ type featuresPayload struct {
 	HardcoverToken  *bool `json:"hardcover_token,omitempty"`
 	OIDCEnabled     *bool `json:"oidc_enabled,omitempty"`
 	MultiUser       *bool `json:"multi_user,omitempty"`
+
+	// Setup-funnel day offsets (v1.31.0+): whole days from install creation
+	// to each first milestone; absent = hasn't happened. Must be listed here
+	// or handlePing's normalising re-marshal would silently drop them.
+	SetupIndexerDay *int `json:"setup_indexer_day,omitempty"`
+	SetupClientDay  *int `json:"setup_client_day,omitempty"`
+	FirstAuthorDay  *int `json:"first_author_day,omitempty"`
+	FirstGrabDay    *int `json:"first_grab_day,omitempty"`
+	FirstImportDay  *int `json:"first_import_day,omitempty"`
 }
 
 // validDeploys constrains the set of deploy strings we accept on /api/ping.
@@ -1171,6 +1181,11 @@ const telemetryFieldsHTML = `<!DOCTYPE html>
     <div class="why">Booleans: whether OIDC sign-in is configured, and whether there is more than one user account in the local DB.</div>
   </div>
 
+  <div class="field">
+    <code>features.setup_indexer_day</code> / <code>features.setup_client_day</code> / <code>features.first_author_day</code> / <code>features.first_grab_day</code> / <code>features.first_import_day</code>
+    <div class="why">Integers (v1.31.0+): whole days between install creation and the first time each milestone happened — first indexer added, first download client added, first author added, first grab, first import. 0 means "the same day"; a field is absent until its milestone happens. Never timestamps, dates, or times of day — only a day count. These exist because most installs that never finish initial setup are abandoned within a day, and a day-count is the least data that shows where setup stalls.</div>
+  </div>
+
   <h2>What we don't collect</h2>
 
   <ul>
@@ -1359,6 +1374,12 @@ type statsData struct {
 	TopVersions  []string          // top-N versions for VersionTrend legend
 
 	// Features (last 7d): per-subsystem adoption counts among installs that
+	// Setup funnel: how fast new installs (first_seen in the last 30 days,
+	// on a funnel-capable client version) reach each first milestone.
+	// Filled by computeSetupFunnel; empty slice renders a "no data yet"
+	// note during the rollout window.
+	Funnel []funnelStage
+
 	// have reported a features payload in the last 7 days. FeaturesReporting
 	// is the denominator; each bucket count is the numerator. Older clients
 	// without the features field don't contribute to either, so the
@@ -1567,6 +1588,10 @@ func (s *server) computeStats(ctx context.Context) (*statsData, error) {
 	// Older clients send features = NULL and don't appear in either the
 	// numerator or the denominator, which gives an accurate "% of installs
 	// we have data for" rather than a misleading "% of all installs."
+	if err := s.computeSetupFunnel(ctx, time.Now().UTC().AddDate(0, 0, -30), d); err != nil {
+		return nil, err
+	}
+
 	if err := s.computeFeatureAdoption(ctx, cutoff7d, d); err != nil {
 		return nil, err
 	}
@@ -1702,6 +1727,116 @@ var featureFields = []featureField{
 	{"hardcover_token", "Hardcover enhanced"},
 	{"oidc_enabled", "OIDC auth"},
 	{"multi_user", "Multi-user"},
+}
+
+// funnelMinVersion is the first client release that reports the setup-funnel
+// day offsets. Installs on older versions can't be told apart from installs
+// that stalled before their first milestone (both send no funnel fields), so
+// the funnel cohort is gated on version, not on field presence.
+var funnelMinVersion = [3]int{1, 31, 0}
+
+// funnelCapable reports whether a version string is >= funnelMinVersion.
+func funnelCapable(version string) bool {
+	m := regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)$`).FindStringSubmatch(version)
+	if m == nil {
+		return false
+	}
+	for i := range 3 {
+		n, _ := strconv.Atoi(m[i+1])
+		if n != funnelMinVersion[i] {
+			return n > funnelMinVersion[i]
+		}
+	}
+	return true
+}
+
+// funnelStage is one milestone row in the setup-funnel table. Numerators
+// and denominators are kept per column because the windows differ: an
+// install two days old cannot yet have reached anything "by day 7", so it
+// belongs in the D+1 denominator but not the D+7 one.
+type funnelStage struct {
+	Label  string
+	D1Num  int // reached with day offset <= 1
+	D1Den  int // installs at least 1 day old
+	D7Num  int
+	D7Den  int // installs at least 7 days old
+	Ever   int
+	Cohort int // all funnel-capable installs in the window
+}
+
+func pct(num, den int) string {
+	if den == 0 {
+		return "–"
+	}
+	return fmt.Sprintf("%d%%", int(100*float64(num)/float64(den)+0.5))
+}
+
+// computeSetupFunnel fills d.Funnel from installs first seen inside the
+// window on funnel-capable versions. Row volume is small (new installs per
+// month is in the hundreds), so version filtering happens in Go where the
+// semver compare is honest, not approximated in SQL.
+func (s *server) computeSetupFunnel(ctx context.Context, since time.Time, d *statsData) error {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT version, substr(first_seen, 1, 10), COALESCE(features, '')
+		  FROM installs
+		 WHERE first_seen >= ?`, since)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	stages := []funnelStage{
+		{Label: "Indexer configured"},
+		{Label: "Download client configured"},
+		{Label: "Author added"},
+		{Label: "First grab"},
+		{Label: "First import"},
+	}
+	today := time.Now().UTC()
+	for rows.Next() {
+		var version, firstDay, featJSON string
+		if err := rows.Scan(&version, &firstDay, &featJSON); err != nil {
+			return err
+		}
+		if !funnelCapable(version) {
+			continue
+		}
+		var f featuresPayload
+		if featJSON != "" {
+			_ = json.Unmarshal([]byte(featJSON), &f)
+		}
+		fd, err := time.Parse("2006-01-02", firstDay)
+		if err != nil {
+			continue
+		}
+		age := int(today.Sub(fd).Hours() / 24)
+		for i, day := range []*int{f.SetupIndexerDay, f.SetupClientDay, f.FirstAuthorDay, f.FirstGrabDay, f.FirstImportDay} {
+			st := &stages[i]
+			st.Cohort++
+			if age >= 1 {
+				st.D1Den++
+				if day != nil && *day <= 1 {
+					st.D1Num++
+				}
+			}
+			if age >= 7 {
+				st.D7Den++
+				if day != nil && *day <= 7 {
+					st.D7Num++
+				}
+			}
+			if day != nil {
+				st.Ever++
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if stages[0].Cohort > 0 {
+		d.Funnel = stages
+	}
+	return nil
 }
 
 // computeFeatureAdoption fills d.FeaturesReporting and d.Features from
@@ -2059,6 +2194,36 @@ func renderLongevity(buckets []statsBucket, youngDB bool) string {
 // 7d-active install has reported a features payload yet (older clients
 // only), the section renders an explanatory message instead of an empty
 // chart with confusing zero counts.
+// renderFunnel renders the setup-funnel milestone table: for each first
+// milestone, the share of new funnel-capable installs that reached it
+// within 1 day, within 7 days, and at all. Denominators differ per column
+// (see funnelStage); each cell shows the honest cohort for its window.
+func renderFunnel(stages []funnelStage) string {
+	if len(stages) == 0 {
+		return `<div class="chart"><p class="empty">No funnel data yet. ` +
+			`Clients report setup-funnel day offsets starting with v1.31.0; ` +
+			`this section populates as new installs arrive on it.</p></div>`
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf(
+		`<p class="empty" style="margin:0 0 .5rem 0">Out of %d new install%s on funnel-capable versions. `+
+			`"By D+1/D+7" count only installs old enough for that window.</p>`,
+		stages[0].Cohort, pluralS(stages[0].Cohort)))
+	b.WriteString(`<div class="chart"><table class="bars"><tr>` +
+		`<td class="legend-cell"></td>` +
+		`<td class="count-cell">by D+1</td>` +
+		`<td class="count-cell">by D+7</td>` +
+		`<td class="count-cell">ever</td></tr>`)
+	for _, st := range stages {
+		b.WriteString(`<tr><td class="legend-cell">` + html.EscapeString(st.Label) + `</td>` +
+			`<td class="count-cell">` + pct(st.D1Num, st.D1Den) + `</td>` +
+			`<td class="count-cell">` + pct(st.D7Num, st.D7Den) + `</td>` +
+			`<td class="count-cell">` + pct(st.Ever, st.Cohort) + `</td></tr>`)
+	}
+	b.WriteString(`</table></div>`)
+	return b.String()
+}
+
 func renderFeatures(buckets []statsBucket, reporting int) string {
 	if reporting == 0 {
 		return `<div class="chart"><p class="empty">No features data yet. ` +
@@ -2373,6 +2538,11 @@ func (s *server) handleStatsPage(w http.ResponseWriter, r *http.Request) {
   </section>
 
   <section>
+    <h2>Setup funnel (installs from the last 30 days)</h2>
+    %s
+  </section>
+
+  <section>
     <h2>Feature adoption (last 7 days)</h2>
     %s
   </section>
@@ -2397,6 +2567,7 @@ func (s *server) handleStatsPage(w http.ResponseWriter, r *http.Request) {
 		renderSparkline(d.DailyNew),
 		renderMonthlyChart(d.Monthly),
 		renderLongevity(d.Longevity, d.LongevityYoungDB),
+		renderFunnel(d.Funnel),
 		renderFeatures(d.Features, d.FeaturesReporting),
 		renderVersionTrend(d.VersionTrend, d.TopVersions)+renderLedgerFootnote(d.LedgerEpoch),
 		time.Now().UTC().Format("2006-01-02 15:04 MST"),

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -1454,3 +1454,109 @@ func TestLoadLedgerBackfill(t *testing.T) {
 		t.Errorf("re-run inserted = %d, want 0 (done marker)", n2)
 	}
 }
+
+func TestFunnelCapable(t *testing.T) {
+	for v, want := range map[string]bool{
+		"1.31.0": true, "1.31.1": true, "1.32.0": true, "2.0.0": true,
+		"1.30.0": false, "1.29.1": false, "sha-abc": false, "dev": false, "": false,
+	} {
+		if got := funnelCapable(v); got != want {
+			t.Errorf("funnelCapable(%q) = %v, want %v", v, got, want)
+		}
+	}
+}
+
+// TestComputeSetupFunnel exercises the per-column denominators: an install
+// too young for a window stays out of that window's denominator, funnel-
+// incapable versions stay out entirely, and day offsets bucket correctly.
+func TestComputeSetupFunnel(t *testing.T) {
+	s := newTestServer(t, "v1.31.0")
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	insert := func(id byte, version string, ageDays int, features string) {
+		t.Helper()
+		var f any
+		if features != "" {
+			f = features
+		}
+		if _, err := s.db.ExecContext(ctx, `
+			INSERT INTO installs (install_id, version, os, arch, deploy, features, first_seen, last_seen)
+			VALUES (?, ?, 'linux', 'amd64', 'docker', ?, ?, ?)`,
+			uuid(id), version, f, now.AddDate(0, 0, -ageDays), now); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	// 10 days old, full same-day setup → counts in D1, D7, ever.
+	insert('1', "1.31.0", 10, `{"setup_indexer_day":0,"setup_client_day":0,"first_grab_day":2}`)
+	// 10 days old, never configured anything → in all denominators, no numerators.
+	insert('2', "1.31.0", 10, `{}`)
+	// 3 days old, indexer on day 2 → in D1 denominator (missed), NOT in D7 denominator.
+	insert('3', "1.31.2", 3, `{"setup_indexer_day":2}`)
+	// funnel-incapable version → excluded from the cohort entirely.
+	insert('4', "1.30.0", 10, `{"indexers":3}`)
+
+	d := &statsData{}
+	if err := s.computeSetupFunnel(ctx, now.AddDate(0, 0, -30), d); err != nil {
+		t.Fatalf("computeSetupFunnel: %v", err)
+	}
+	if len(d.Funnel) != 5 {
+		t.Fatalf("stages = %d, want 5", len(d.Funnel))
+	}
+	idx := d.Funnel[0] // Indexer configured
+	if idx.Cohort != 3 {
+		t.Errorf("cohort = %d, want 3 (1.30.0 install excluded)", idx.Cohort)
+	}
+	if idx.D1Den != 3 || idx.D1Num != 1 {
+		t.Errorf("D1 = %d/%d, want 1/3 (only install 1 by day 1)", idx.D1Num, idx.D1Den)
+	}
+	if idx.D7Den != 2 || idx.D7Num != 1 {
+		t.Errorf("D7 = %d/%d, want 1/2 (3-day-old install not in D7 window)", idx.D7Num, idx.D7Den)
+	}
+	if idx.Ever != 2 {
+		t.Errorf("ever = %d, want 2 (installs 1 and 3)", idx.Ever)
+	}
+	grab := d.Funnel[3] // First grab
+	if grab.D1Num != 0 || grab.D7Num != 1 {
+		t.Errorf("grab D1/D7 = %d/%d, want 0 and 1 (day-2 grab misses D1)", grab.D1Num, grab.D7Num)
+	}
+}
+
+// TestHandlePing_PreservesFunnelFields guards the normalising re-marshal in
+// handlePing: a features payload with funnel day offsets must round-trip
+// into the stored JSON, including a 0 ("same day") value.
+func TestHandlePing_PreservesFunnelFields(t *testing.T) {
+	s := newTestServer(t, "v1.31.0")
+	s.limiter = newRateLimiter(time.Hour, time.Minute)
+
+	body := []byte(`{"install_id":"11111111-1111-1111-1111-111111111111","version":"1.31.0",` +
+		`"os":"linux","arch":"amd64","features":{"indexers":2,"setup_indexer_day":0,"first_grab_day":3}}`)
+	r := httptest.NewRequest(http.MethodPost, "/api/ping", bytes.NewReader(body))
+	r.RemoteAddr = "192.0.2.30:1234"
+	w := httptest.NewRecorder()
+	s.handlePing(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("ping status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	var stored string
+	if err := s.db.QueryRowContext(context.Background(),
+		`SELECT features FROM installs WHERE install_id = '11111111-1111-1111-1111-111111111111'`,
+	).Scan(&stored); err != nil {
+		t.Fatalf("read features: %v", err)
+	}
+	var f featuresPayload
+	if err := json.Unmarshal([]byte(stored), &f); err != nil {
+		t.Fatalf("parse stored features: %v", err)
+	}
+	if f.SetupIndexerDay == nil || *f.SetupIndexerDay != 0 {
+		t.Errorf("setup_indexer_day = %v, want 0 (zero must survive the re-marshal)", f.SetupIndexerDay)
+	}
+	if f.FirstGrabDay == nil || *f.FirstGrabDay != 3 {
+		t.Errorf("first_grab_day = %v, want 3", f.FirstGrabDay)
+	}
+	if f.SetupClientDay != nil {
+		t.Errorf("setup_client_day = %d, want nil (not sent)", *f.SetupClientDay)
+	}
+}


### PR DESCRIPTION
Server half of #1823 (either merge order works — both sides are additive and tolerate the other's absence).

- `featuresPayload` gains `setup_indexer_day` / `setup_client_day` / `first_author_day` / `first_grab_day` / `first_import_day` (`*int`). Required for ingestion: `handlePing` re-marshals the payload for normalized storage, so unknown fields are silently dropped without them — guarded by a round-trip test including a 0 value.
- `/stats` gains **Setup funnel (installs from the last 30 days)**: per milestone, % reached by D+1, by D+7, and ever. Cohort is gated on client version ≥ 1.31.0 (`funnelCapable`) because a stalled install sends no funnel fields and is otherwise indistinguishable from an old client. Denominators are per column — installs too young for a window stay out of it. Renders a "no data yet" note until 1.31.0 installs arrive.
- `/telemetry-fields` documents the five fields (integers only, never timestamps).

Why: fleet data shows 7d retention is 66% for installs reaching indexer+client vs 16% for those that don't; this makes the stall points measurable so the onboarding changes (guidance-gap PRs, upcoming) can be evaluated against a baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)