### PR TITLE
fix(ui): setup guidance for half-configured installs + shell banner

### DIFF
--- a/changelog.d/guidance-gap.md
+++ b/changelog.d/guidance-gap.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Half-configured installs now get setup guidance.** The getting-started card required indexers AND download clients to BOTH be missing, so a user who had configured one of the two — the state where searches or grabs fail silently — saw no guidance at all. It now names the one missing step ("…every grab will fail") and links only to it. Guidance also no longer hides inside the Authors/Books empty states: a dismissible banner in the app shell shows while the pipeline is incomplete, so library-importers (whose pages are never empty) finally see it too.

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -47,6 +47,9 @@ vi.mock('./auth/AuthContext', () => ({
 vi.mock('./api/client', () => ({
   api: {
     status: vi.fn().mockResolvedValue({ version: '0.15.0', commit: 'abc', buildDate: '' }),
+    // SetupBanner (mounted in the admin shell) probes these on mount.
+    listIndexers: vi.fn().mockResolvedValue([]),
+    listDownloadClients: vi.fn().mockResolvedValue([]),
   },
 }))
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import AuthGuard from './auth/AuthGuard'
 import PublicOnlyRoute from './auth/PublicOnlyRoute'
 import ErrorBoundary from './components/ErrorBoundary'
 import Logo from './components/Logo'
+import SetupBanner from './components/SetupBanner'
 import VersionBadge from './components/VersionBadge'
 import { useTheme } from './theme'
 
@@ -240,6 +241,8 @@ function Shell() {
           </div>
         )}
       </header>
+
+      {isAdmin && <SetupBanner />}
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         <Suspense fallback={<PageLoadingFallback />}>

--- a/web/src/components/GettingStartedGuidance.tsx
+++ b/web/src/components/GettingStartedGuidance.tsx
@@ -3,38 +3,58 @@ import { useTranslation } from 'react-i18next'
 
 interface Props {
   // A short, context-specific line explaining why setup is needed here, e.g.
-  // "configure these before adding authors" vs "...before searching".
+  // "configure these before adding authors" vs "...before searching". Used
+  // when BOTH pieces are missing; a half-configured state overrides it with
+  // the sharper "downloads will fail" / "searches find nothing" line.
   reasonKey: string
+  needsIndexer: boolean
+  needsClient: boolean
 }
 
-// First-run onboarding nudge shown on the Authors/Books empty states when the
-// instance has no indexers AND no download clients configured. Adding an author
-// or searching silently does nothing without them, so we point the user at the
-// two settings tabs they need first. Modelled on DiscoverPage's empty-state
-// link-to-settings pattern (card surface, emerald primary action).
-export default function GettingStartedGuidance({ reasonKey }: Props) {
+// First-run onboarding nudge shown when part of the search→download pipeline
+// is unconfigured. Adding an author or searching silently does nothing
+// without an indexer AND a download client, so this points the user at
+// exactly the missing settings tab(s). Modelled on DiscoverPage's
+// empty-state link-to-settings pattern (card surface, emerald primary
+// action).
+export default function GettingStartedGuidance({ reasonKey, needsIndexer, needsClient }: Props) {
   const { t } = useTranslation()
+  if (!needsIndexer && !needsClient) return null
+
+  // Both missing → the context reason. One missing → name the consequence.
+  const reason = needsIndexer && needsClient
+    ? t(reasonKey)
+    : needsClient
+      ? t('gettingStarted.clientMissing', 'An indexer is configured but there is no download client — searches will find releases, but every grab will fail.')
+      : t('gettingStarted.indexerMissing', 'A download client is configured but there is no indexer — searches have nowhere to look and will find nothing.')
+
   return (
     <div className="max-w-xl mx-auto mb-8 px-5 py-4 bg-slate-100 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded-lg text-left">
       <h3 className="text-sm font-semibold text-slate-900 dark:text-white mb-1">
         {t('gettingStarted.title')}
       </h3>
       <p className="text-sm text-slate-600 dark:text-zinc-400 mb-3">
-        {t(reasonKey)}
+        {reason}
       </p>
       <div className="flex flex-wrap gap-2">
-        <Link
-          to="/settings?tab=indexers"
-          className="inline-block px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 text-white rounded-md text-sm font-medium transition-colors"
-        >
-          {t('gettingStarted.indexers')}
-        </Link>
-        <Link
-          to="/settings?tab=clients"
-          className="inline-block px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 text-slate-900 dark:text-white rounded-md text-sm font-medium transition-colors"
-        >
-          {t('gettingStarted.downloadClients')}
-        </Link>
+        {needsIndexer && (
+          <Link
+            to="/settings?tab=indexers"
+            className="inline-block px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 text-white rounded-md text-sm font-medium transition-colors"
+          >
+            {t('gettingStarted.indexers')}
+          </Link>
+        )}
+        {needsClient && (
+          <Link
+            to="/settings?tab=clients"
+            className={needsIndexer
+              ? 'inline-block px-3 py-1.5 bg-slate-200 dark:bg-zinc-800 hover:bg-slate-300 dark:hover:bg-zinc-700 text-slate-900 dark:text-white rounded-md text-sm font-medium transition-colors'
+              : 'inline-block px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 text-white rounded-md text-sm font-medium transition-colors'}
+          >
+            {t('gettingStarted.downloadClients')}
+          </Link>
+        )}
       </div>
     </div>
   )

--- a/web/src/components/SetupBanner.tsx
+++ b/web/src/components/SetupBanner.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { Link } from 'react-router'
+import { useTranslation } from 'react-i18next'
+import { useNeedsSetup } from './useNeedsSetup'
+
+// dismissKey encodes WHICH incomplete state was dismissed, so dismissing
+// "no indexer and no client" doesn't also swallow a later, different
+// warning (e.g. the user adds an indexer, and the sharper "downloads will
+// fail" state should get one fresh chance to show).
+const STORAGE_KEY = 'bindery.setupBannerDismissed'
+
+function signature(needsIndexer: boolean, needsClient: boolean): string {
+  return `${needsIndexer ? 'indexer' : ''}+${needsClient ? 'client' : ''}`
+}
+
+// App-shell banner shown while the search→download pipeline is incomplete.
+// Exists because the GettingStartedGuidance card only renders inside the
+// Authors/Books EMPTY states — a user who imports an existing library first
+// (the common Readarr-migrant path) has non-empty pages and previously got
+// no setup guidance anywhere. Dismissible; the dismissal is remembered per
+// missing-state signature in localStorage.
+export default function SetupBanner() {
+  const { t } = useTranslation()
+  const { needsIndexer, needsClient, needsAny } = useNeedsSetup()
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY)
+    } catch {
+      return null
+    }
+  })
+
+  if (!needsAny || dismissed === signature(needsIndexer, needsClient)) return null
+
+  const message = needsIndexer && needsClient
+    ? t('setupBanner.both', 'Finish setting up: add an indexer and a download client so searches and downloads work.')
+    : needsClient
+      ? t('gettingStarted.clientMissing', 'An indexer is configured but there is no download client — searches will find releases, but every grab will fail.')
+      : t('gettingStarted.indexerMissing', 'A download client is configured but there is no indexer — searches have nowhere to look and will find nothing.')
+
+  const target = needsIndexer ? '/settings?tab=indexers' : '/settings?tab=clients'
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-4">
+      <div className="flex flex-wrap items-center gap-3 px-4 py-3 rounded-lg border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-950/40 text-sm text-amber-900 dark:text-amber-200">
+        <span className="flex-1 min-w-[16rem]">{message}</span>
+        <Link
+          to={target}
+          className="px-3 py-1.5 rounded-md bg-amber-600 hover:bg-amber-500 text-white font-medium transition-colors"
+        >
+          {needsIndexer ? t('gettingStarted.indexers') : t('gettingStarted.downloadClients')}
+        </Link>
+        <button
+          onClick={() => {
+            const sig = signature(needsIndexer, needsClient)
+            try {
+              localStorage.setItem(STORAGE_KEY, sig)
+            } catch {
+              // localStorage unavailable (private mode) — dismiss for this render only.
+            }
+            setDismissed(sig)
+          }}
+          aria-label={t('common.dismiss', 'Dismiss')}
+          className="px-2 py-1 rounded-md hover:bg-amber-100 dark:hover:bg-amber-900/50 transition-colors"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/useNeedsSetup.ts
+++ b/web/src/components/useNeedsSetup.ts
@@ -1,27 +1,42 @@
 import { useEffect, useState } from 'react'
 import { api } from '../api/client'
 
-// Returns true once we've confirmed the instance has NO indexers AND NO
-// download clients configured. Used to decide whether to show the first-run
-// onboarding guidance on the Authors/Books empty states. Defaults to false
-// (and stays false on any error) so the guidance never blocks or replaces the
-// normal empty state if the checks fail.
-export function useNeedsSetup(): boolean {
-  const [needsSetup, setNeedsSetup] = useState(false)
+export interface NeedsSetup {
+  /** No indexers configured — searches will find nothing. */
+  needsIndexer: boolean
+  /** No download clients configured — grabs will fail. */
+  needsClient: boolean
+  /** Either piece missing. */
+  needsAny: boolean
+}
+
+const NONE: NeedsSetup = { needsIndexer: false, needsClient: false, needsAny: false }
+
+// Reports which half of the search→download pipeline is unconfigured, so
+// guidance can name the missing step. Per-item on purpose: the previous
+// all-or-nothing boolean (indexers AND clients both empty) meant a user who
+// configured only one of the two — the most common half-finished state, and
+// one where grabs fail silently — got no guidance at all. Defaults to "all
+// configured" (and stays there on any error) so the guidance never blocks
+// or replaces the normal empty state if the checks fail.
+export function useNeedsSetup(): NeedsSetup {
+  const [needs, setNeeds] = useState<NeedsSetup>(NONE)
 
   useEffect(() => {
     let cancelled = false
     Promise.all([api.listIndexers(), api.listDownloadClients()])
       .then(([indexers, clients]) => {
         if (cancelled) return
-        setNeedsSetup(indexers.length === 0 && clients.length === 0)
+        const needsIndexer = indexers.length === 0
+        const needsClient = clients.length === 0
+        setNeeds({ needsIndexer, needsClient, needsAny: needsIndexer || needsClient })
       })
       .catch(() => {
         // Fall back to the normal empty state on failure.
-        if (!cancelled) setNeedsSetup(false)
+        if (!cancelled) setNeeds(NONE)
       })
     return () => { cancelled = true }
   }, [])
 
-  return needsSetup
+  return needs
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1000,8 +1000,13 @@
     "title": "Getting started",
     "reasonAuthors": "Configure an indexer and a download client before adding authors — without them, added authors won't fetch anything.",
     "reasonBooks": "Configure an indexer and a download client before searching — without them, searches can't find or grab anything.",
+    "clientMissing": "An indexer is configured but there is no download client — searches will find releases, but every grab will fail.",
+    "indexerMissing": "A download client is configured but there is no indexer — searches have nowhere to look and will find nothing.",
     "indexers": "Set up Indexers",
     "downloadClients": "Set up Download Clients"
+  },
+  "setupBanner": {
+    "both": "Finish setting up: add an indexer and a download client so searches and downloads work."
   },
   "users": {
     "title": "Users",

--- a/web/src/pages/AuthorsPage.onboarding.test.tsx
+++ b/web/src/pages/AuthorsPage.onboarding.test.tsx
@@ -83,27 +83,39 @@ describe('AuthorsPage first-run onboarding guidance', () => {
     expect(clientsLink).toHaveAttribute('href', '/settings?tab=clients')
   })
 
-  it('does NOT show the guidance when at least one indexer exists', async () => {
+  // Half-configured states used to show NOTHING (the hook required both
+  // lists empty), which is exactly the state where grabs fail silently.
+  // Now the guidance names the one missing step and links only to it.
+  it('shows only the download-client step when an indexer exists but no client', async () => {
     vi.mocked(api.listIndexers).mockResolvedValue([fakeIndexer])
     vi.mocked(api.listDownloadClients).mockResolvedValue([])
 
     renderPage()
 
-    // Normal empty state still renders...
-    expect(await screen.findByText('No authors yet')).toBeInTheDocument()
-    // ...but the guidance does not.
-    await waitFor(() => expect(api.listIndexers).toHaveBeenCalled())
-    expect(screen.queryByText('Getting started')).not.toBeInTheDocument()
+    expect(await screen.findByText('Getting started')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Set up Download Clients' })).toHaveAttribute('href', '/settings?tab=clients')
+    expect(screen.queryByRole('link', { name: 'Set up Indexers' })).not.toBeInTheDocument()
   })
 
-  it('does NOT show the guidance when at least one download client exists', async () => {
+  it('shows only the indexer step when a client exists but no indexer', async () => {
     vi.mocked(api.listIndexers).mockResolvedValue([])
     vi.mocked(api.listDownloadClients).mockResolvedValue([fakeClient])
 
     renderPage()
 
+    expect(await screen.findByText('Getting started')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Set up Indexers' })).toHaveAttribute('href', '/settings?tab=indexers')
+    expect(screen.queryByRole('link', { name: 'Set up Download Clients' })).not.toBeInTheDocument()
+  })
+
+  it('does NOT show the guidance when both an indexer and a client exist', async () => {
+    vi.mocked(api.listIndexers).mockResolvedValue([fakeIndexer])
+    vi.mocked(api.listDownloadClients).mockResolvedValue([fakeClient])
+
+    renderPage()
+
     expect(await screen.findByText('No authors yet')).toBeInTheDocument()
-    await waitFor(() => expect(api.listDownloadClients).toHaveBeenCalled())
+    await waitFor(() => expect(api.listIndexers).toHaveBeenCalled())
     expect(screen.queryByText('Getting started')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -48,7 +48,7 @@ export default function AuthorsPage() {
     return ''
   })
   const [view, setView] = useView('authors', 'grid')
-  const needsSetup = useNeedsSetup()
+  const { needsIndexer, needsClient, needsAny } = useNeedsSetup()
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
   const [bulkBusy, setBulkBusy] = useState(false)
   const selectAllRef = useRef<HTMLInputElement>(null)
@@ -372,7 +372,7 @@ export default function AuthorsPage() {
         <div className="text-slate-600 dark:text-zinc-500">{t('common.loading')}</div>
       ) : total === 0 && !debouncedSearch && !monitoredFilter ? (
         <div className="text-center py-16 text-slate-600 dark:text-zinc-500">
-          {needsSetup && <GettingStartedGuidance reasonKey="gettingStarted.reasonAuthors" />}
+          {needsAny && <GettingStartedGuidance reasonKey="gettingStarted.reasonAuthors" needsIndexer={needsIndexer} needsClient={needsClient} />}
           <p className="text-lg mb-2">{t('authors.empty')}</p>
           <p className="text-sm">{t('authors.emptyHint')}</p>
         </div>

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -48,7 +48,7 @@ export default function BooksPage() {
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const [sort, setSort] = useState<SortMode>('title-az')
   const [view, setView] = useView('books', 'grid')
-  const needsSetup = useNeedsSetup()
+  const { needsIndexer, needsClient, needsAny } = useNeedsSetup()
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
   const [bulkBusy, setBulkBusy] = useState(false)
   const selectAllRef = useRef<HTMLInputElement>(null)
@@ -219,7 +219,7 @@ export default function BooksPage() {
         <div className="text-center py-16 text-slate-600 dark:text-zinc-500">
           {!debouncedSearch && !statusFilter && !mediaFilter && !monitoredFilter ? (
             <>
-              {needsSetup && <GettingStartedGuidance reasonKey="gettingStarted.reasonBooks" />}
+              {needsAny && <GettingStartedGuidance reasonKey="gettingStarted.reasonBooks" needsIndexer={needsIndexer} needsClient={needsClient} />}
               <p className="font-medium">{t('books.empty')}</p>
               <p className="text-sm mt-1">{t('books.emptyHint')}</p>
             </>


### PR DESCRIPTION
## Why

Fleet telemetry: installs that never reach indexer+download-client retain 16% at 7 days (vs 66% configured) and 72% churn within one day — and the in-app guidance that should catch them has two visibility bugs:

1. `useNeedsSetup` used AND — guidance appeared only when indexers and clients were BOTH missing. The half-configured state (one of the two, grabs/searches failing silently) showed nothing.
2. `GettingStartedGuidance` rendered only inside the Authors/Books empty states — import a library first and it never appears.

## What

- `useNeedsSetup` returns `{needsIndexer, needsClient, needsAny}`; the card shows only the missing step with a consequence-first message ("…every grab will fail").
- New `SetupBanner` mounted in the admin shell: amber, dismissible, visible on every page while the pipeline is incomplete. Dismissal is stored per missing-state signature, so dismissing "both missing" doesn't swallow a later "client missing" warning.
- After first-run `/setup`, the user lands on `/` where the banner is guaranteed visible — closing the hand-off cliff (setup → empty Authors page with no next step).
- Onboarding tests updated: the two "does NOT show when half-configured" tests now assert the inverse (that behavior was the bug), plus a both-configured negative case.

## Measurement

Setup-funnel charts (#1823/#1824): D+1 both-configured rate (baseline ~78%) and the one-day churn share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)