### PR TITLE
fix(helm): keep Chart.yaml appVersion in step with the deployed tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -618,6 +618,20 @@ jobs:
           FILE_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${FILE_PATH}?ref=${DEPLOY_BRANCH}" --jq .sha)
           CONTENT=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${FILE_PATH}?ref=${DEPLOY_BRANCH}" \
             --jq '.content' | base64 -d | sed "s|tag:.*|tag: \"${IMAGE_TAG}\"|" | base64 -w0)
+
+          # Keep Chart.yaml's appVersion in step with the deployed tag. It sat
+          # frozen (1.22.3 vs tag 1.30.0) because only values.yaml was bumped
+          # here — anyone reading `helm show chart` got a stale answer.
+          CHART_PATH="charts/bindery/Chart.yaml"
+          CHART_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${CHART_PATH}?ref=${DEPLOY_BRANCH}" --jq .sha)
+          CHART_CONTENT=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${CHART_PATH}?ref=${DEPLOY_BRANCH}" \
+            --jq '.content' | base64 -d | sed "s|^appVersion:.*|appVersion: \"${IMAGE_TAG}\"|" | base64 -w0)
+          gh api "repos/${GITHUB_REPOSITORY}/contents/${CHART_PATH}" \
+            -X PUT \
+            -f message="chore(deploy): appVersion ${IMAGE_TAG}" \
+            -f content="${CHART_CONTENT}" \
+            -f sha="${CHART_SHA}" \
+            -f branch="${DEPLOY_BRANCH}"
           # NOTE: the branch commit deliberately does NOT carry [skip ci]. The
           # required checks (lint, validate, Security Summary) must actually run
           # on the PR head, otherwise they stay "expected" forever and the merge

--- a/changelog.d/helm-appversion.md
+++ b/changelog.d/helm-appversion.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Helm chart `appVersion` no longer drifts from the deployed tag** — it had been frozen at 1.22.3 while `values.yaml` advanced to 1.30.0, because the release pipeline only bumped the latter. The prod-deploy step now updates both, and `appVersion` is corrected to 1.30.0.

--- a/charts/bindery/Chart.yaml
+++ b/charts/bindery/Chart.yaml
@@ -3,7 +3,7 @@ name: bindery
 description: Automated book download manager for Usenet and Torrents
 type: application
 version: 0.9.12
-appVersion: "1.22.3"
+appVersion: "1.30.0"
 home: https://github.com/vavallee/bindery
 sources:
   - https://github.com/vavallee/bindery


### PR DESCRIPTION
WS7 of the growth roadmap — smallest item, pure hygiene.

- `charts/bindery/Chart.yaml` `appVersion`: 1.22.3 → 1.30.0 (it was frozen since May; `values.yaml` `tag` moved on without it, so `helm show chart` reported a stale version).
- `deploy-prod` in `ci.yml` now bumps `appVersion` alongside the `values.yaml` tag on the same auto-deploy branch, so it can't drift again.

Helm installs are the least-current deploy segment in fleet telemetry (40% on a recent release); a chart that misreports its own app version doesn't help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)