### PR TITLE
docs: point the log-level instructions at Settings → Logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,7 +45,8 @@ body:
     attributes:
       label: Trace logs
       description: |
-        Set log level to DEBUG in Settings → General, reproduce the bug, then paste the relevant log section.
+        Set the **Runtime level** to DEBUG in Settings → Logs, reproduce the bug, then paste the relevant log section.
+        Settings → Logs is admin-only; on an instance where you are not an admin, start Bindery with `BINDERY_LOG_LEVEL=debug` instead.
         **Issues without logs may be closed without investigation.**
       render: text
     validations:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -444,7 +444,7 @@ On first launch Bindery bootstraps itself — **no environment variables are req
 
 **Graceful shutdown** — `BINDERY_SHUTDOWN_GRACE` (default `10s`) controls how long the server drains in-flight requests after SIGTERM. `kubectl rollout restart` no longer drops in-flight requests. After request draining, detached background jobs (ABS import, Grimmory sync, manual library scan, startup syncs) are drained for up to `BINDERY_JOBS_DRAIN_GRACE` (default `15s`) before the database is closed, so a deploy mid-import no longer produces "database is closed" errors or (for Grimmory) re-uploads on the next run. The two graces run serially, so the defaults total 25s — under the default Kubernetes 30s `terminationGracePeriodSeconds`; raise both together if you extend either.
 
-**Log level UI toggle** — The log level toggle in Settings → System now immediately affects the log viewer (previously only `BINDERY_LOG_LEVEL` at startup worked).
+**Log level UI toggle** — The **Runtime level** selector in Settings → Logs now immediately affects the log viewer (previously only `BINDERY_LOG_LEVEL` at startup worked).
 
 ### From v0.11.x to v0.12.0 (security posture)
 


### PR DESCRIPTION
Both places that tell a user how to turn on DEBUG logging name a tab that does not have the control.

| File | Says | Reality |
|---|---|---|
| `.github/ISSUE_TEMPLATE/bug_report.yml:48` | Settings → **General** | `GeneralTab.tsx` has no log-level control — its only "log" matches are `logins` and `logging` |
| `docs/DEPLOYMENT.md:447` | Settings → **System** | there is no System tab; `ALL_TABS` is `general`, `about`, and `ADMIN_TABS` |

The runtime selector is the **Runtime level** dropdown in `web/src/pages/settings/LogsTab.tsx:150`, under **Settings → Logs**.

## Why the template also needs the env-var fallback

`logs` is in `ADMIN_TABS` (`SettingsPage.tsx:39`), so on a multi-user instance a non-admin reporter cannot reach that tab under any name. `BINDERY_LOG_LEVEL=debug` is the only route available to them.

That matters because the template warns in bold that **"Issues without logs may be closed without investigation."** An instruction the reporter cannot follow costs them the report.

## Found how

Writing automated triage copy that asks under-specified bug reports for logs. Grounding that copy in the template's own words would have reproduced the wrong path on every such issue — so the template gets fixed first.

CHANGELOG entries keep the old wording; they record what was written at the time.