### PR TITLE
fix(ui): surface the three silent first-run failure modes

### DIFF
--- a/changelog.d/silent-first-run.md
+++ b/changelog.d/silent-first-run.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Three silent first-run failure modes now warn in the UI** instead of living only in QUICKSTART.md: (1) an enabled Torznab/Newznab indexer with no matching-protocol download client shows an amber warning on the Indexers/Clients settings tabs (searches would find releases nothing could download); (2) turning on auto-search when the pipeline is incomplete warns right in the Add Author dialog (the background search's failure was invisible); (3) a failed download-client connection test against localhost explains the Docker loopback trap and what to use instead.

--- a/web/src/components/AddAuthorModal.test.tsx
+++ b/web/src/components/AddAuthorModal.test.tsx
@@ -37,6 +37,11 @@ vi.mock('../api/client', () => ({
     listRootFolders: vi.fn().mockResolvedValue([]),
     getSetting: vi.fn().mockResolvedValue({ key: 'default.media_type', value: 'ebook' }),
     searchAuthors: vi.fn(),
+    // useNeedsSetup (auto-grab misconfig warning) probes these on mount;
+    // report a configured pipeline so no warning interferes with layout
+    // assertions here.
+    listIndexers: vi.fn().mockResolvedValue([{ id: 1, enabled: true, type: 'newznab' }]),
+    listDownloadClients: vi.fn().mockResolvedValue([{ id: 1, enabled: true, type: 'sabnzbd' }]),
     searchBooks: vi.fn(),
     addAuthor: vi.fn(),
   },

--- a/web/src/components/AddAuthorModal.tsx
+++ b/web/src/components/AddAuthorModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, AddAuthorRequest, Author, AuthorConflictBody, AuthorMonitorMode, MediaType, MetadataProfile, RootFolder } from '../api/client'
 import { splitAuthorSearchResults } from './addAuthorTitleGuard'
+import { useNeedsSetup } from './useNeedsSetup'
 import { canLinkAuthorMetadata, hasSparseMetadata } from '../util/authorMetadata'
 
 interface Props {
@@ -57,6 +58,10 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
   const [rootFolders, setRootFolders] = useState<RootFolder[]>([])
   const [rootFolderId, setRootFolderId] = useState<number | null>(null)
   const [searchOnAdd, setSearchOnAdd] = useState(loadAutoGrabDefault)
+  // Preempt the silent auto-search failure: backend auto-search-on-add runs
+  // async, so a missing indexer/client fails with no visible error anywhere.
+  // Warn at the moment the user opts into it instead.
+  const { needsAny, needsClient } = useNeedsSetup()
   const [mediaType, setMediaType] = useState<MediaType>('ebook')
   const [monitorMode, setMonitorMode] = useState<AuthorMonitorMode>(DEFAULT_MONITOR_MODE)
   const [monitorLatestCount, setMonitorLatestCount] = useState(DEFAULT_MONITOR_LATEST_COUNT)
@@ -289,6 +294,13 @@ export default function AddAuthorModal({ onClose, onAdded }: Props) {
                     <span className="block text-xs text-fg-muted mt-0.5">{t('addAuthorModal.autoGrabHint')}</span>
                   </span>
                 </label>
+                {searchOnAdd && needsAny && (
+                  <p className="mt-2 px-3 py-2 rounded bg-amber-50 dark:bg-amber-950/40 border border-amber-300 dark:border-amber-700/60 text-xs text-amber-900 dark:text-amber-200">
+                    {needsClient
+                      ? t('addAuthorModal.autoGrabNoClient', 'Auto-search is on, but no download client is configured — searches will run and every grab will fail silently.')
+                      : t('addAuthorModal.autoGrabNoIndexer', 'Auto-search is on, but no indexer is configured — searches will run and find nothing.')}
+                  </p>
+                )}
               </div>
             </details>
 

--- a/web/src/components/ProtocolMismatchWarning.tsx
+++ b/web/src/components/ProtocolMismatchWarning.tsx
@@ -1,0 +1,46 @@
+import { useTranslation } from 'react-i18next'
+import type { Indexer } from '../api/indexers'
+import type { DownloadClient } from '../api/downloadclients'
+import { protocolGaps } from '../util/protocols'
+
+// Amber warning shown on the Indexers/Clients settings tabs when an enabled
+// indexer's protocol has no enabled download client to hand grabs to:
+// searches will list releases, every grab fails. The pairing rule (Newznab →
+// SABnzbd/NZBGet, Torznab → torrent client) previously lived only in
+// QUICKSTART.md, so users met it as an unexplained grab failure.
+//
+// Pure over the lists SettingsPage already holds, so it re-evaluates on
+// every save without extra fetches. Navigation goes through the same
+// onNavigate callback the tabs use (not a router Link) — SettingsPage is
+// deliberately renderable without a Router context.
+export default function ProtocolMismatchWarning({
+  indexers,
+  clients,
+  onNavigate,
+}: {
+  indexers: Indexer[]
+  clients: DownloadClient[]
+  onNavigate: (tab: string) => void
+}) {
+  const { t } = useTranslation()
+  const gaps = protocolGaps(indexers, clients)
+  if (gaps.length === 0) return null
+
+  return (
+    <div className="mb-4 px-4 py-3 rounded-lg border border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-950/40 text-sm text-amber-900 dark:text-amber-200">
+      {gaps.map(p => (
+        <p key={p} className="[&:not(:first-child)]:mt-1">
+          {p === 'torrent'
+            ? t('protocolMismatch.torrent', 'A Torznab indexer is enabled but no torrent download client (qBittorrent, Transmission, Deluge) is — its releases can be found but never downloaded.')
+            : t('protocolMismatch.usenet', 'A Newznab indexer is enabled but no usenet download client (SABnzbd, NZBGet) is — its releases can be found but never downloaded.')}
+        </p>
+      ))}
+      <button
+        onClick={() => onNavigate('clients')}
+        className="inline-block mt-2 font-medium underline hover:no-underline"
+      >
+        {t('gettingStarted.downloadClients', 'Set up Download Clients')}
+      </button>
+    </div>
+  )
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -558,7 +558,8 @@
       "audiobookCategoryLabel": "Audiobook Category / Label",
       "audiobookCategoryPlaceholder": "audiobooks",
       "audiobookCategoryHelp": "Optional. When set, audiobook grabs use this category instead of the one above. Leave blank to use the same category as ebooks.",
-      "pathNotVisible": "Connected, but Bindery can't read the client's completed-downloads folder. Configure a path remap or a shared mount so both point at the same storage, otherwise downloads won't import."
+      "pathNotVisible": "Connected, but Bindery can't read the client's completed-downloads folder. Configure a path remap or a shared mount so both point at the same storage, otherwise downloads won't import.",
+      "loopbackHint": "The host is localhost — if Bindery runs in Docker, localhost is the Bindery container itself, not the machine. Use the host's LAN IP or the client's container/service name instead."
     },
     "notifications": {
       "heading": "Webhook Notifications",
@@ -903,6 +904,8 @@
     "confirmAdd": "Add author",
     "autoGrabLabel": "Auto-grab books on add",
     "autoGrabHint": "Bindery will always fetch the book catalogue. Enable this to also queue downloads immediately.",
+    "autoGrabNoClient": "Auto-search is on, but no download client is configured — searches will run and every grab will fail silently.",
+    "autoGrabNoIndexer": "Auto-search is on, but no indexer is configured — searches will run and find nothing.",
     "searchPlaceholder": "Search by author name...",
     "search": "Search",
     "searching": "Searching...",
@@ -1007,6 +1010,10 @@
   },
   "setupBanner": {
     "both": "Finish setting up: add an indexer and a download client so searches and downloads work."
+  },
+  "protocolMismatch": {
+    "torrent": "A Torznab indexer is enabled but no torrent download client (qBittorrent, Transmission, Deluge) is — its releases can be found but never downloaded.",
+    "usenet": "A Newznab indexer is enabled but no usenet download client (SABnzbd, NZBGet) is — its releases can be found but never downloaded."
   },
   "users": {
     "title": "Users",

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, DownloadClient, Indexer, ProwlarrInstance } from '../api/client'
 import { useAuth } from '../auth/AuthContext'
+import ProtocolMismatchWarning from '../components/ProtocolMismatchWarning'
 
 // Decomposed from the former ~5100-line SettingsPage monolith (#547): each tab
 // now lives in its own file under ./settings/. Tabs are React.lazy code-split
@@ -132,8 +133,18 @@ export default function SettingsPage() {
   const renderTab = () => {
     switch (tab) {
       case 'general': return <GeneralTab onNavigate={navigateToTab} />
-      case 'indexers': return <IndexersTab indexers={indexers} setIndexers={setIndexers} prowlarrInstances={prowlarrInstances} setProwlarrInstances={setProwlarrInstances} />
-      case 'clients': return <ClientsTab clients={clients} setClients={setClients} />
+      case 'indexers': return (
+        <>
+          <ProtocolMismatchWarning indexers={indexers} clients={clients} onNavigate={navigateToTab} />
+          <IndexersTab indexers={indexers} setIndexers={setIndexers} prowlarrInstances={prowlarrInstances} setProwlarrInstances={setProwlarrInstances} />
+        </>
+      )
+      case 'clients': return (
+        <>
+          <ProtocolMismatchWarning indexers={indexers} clients={clients} onNavigate={navigateToTab} />
+          <ClientsTab clients={clients} setClients={setClients} />
+        </>
+      )
       case 'notifications': return <NotificationsTab />
       case 'quality': return <QualityTab />
       case 'metadata': return <MetadataTab />

--- a/web/src/pages/settings/ClientsTab.tsx
+++ b/web/src/pages/settings/ClientsTab.tsx
@@ -14,6 +14,17 @@ interface Props {
   setClients: React.Dispatch<React.SetStateAction<DownloadClient[]>>
 }
 
+// loopbackTestHint appends the single most common cause of a failed
+// connection test — Bindery running in Docker while the client address says
+// localhost, which inside the container is the container itself. Docs-only
+// knowledge until now (QUICKSTART.md); surfacing it here turns a dead-end
+// "connection refused" into a one-line fix. Only fires for connection-shaped
+// failures so an auth error on localhost doesn't get a misleading hint.
+function isLoopbackConnFailure(host: string, error: string): boolean {
+  const loopback = host === 'localhost' || host === '127.0.0.1' || host === '::1'
+  return loopback && /refused|timeout|timed out|unreachable|no route|EOF|connect/i.test(error)
+}
+
 export default function ClientsTab({ clients, setClients }: Props) {
   const { t } = useTranslation()
   const [showAddClient, setShowAddClient] = useState(false)
@@ -64,7 +75,9 @@ export default function ClientsTab({ clients, setClients }: Props) {
                           : undefined
                         setClientTestResult(prev => ({ ...prev, [c.id]: { ok: true, msg: t('common.connOk'), warn } }))
                       } catch (err: unknown) {
-                        setClientTestResult(prev => ({ ...prev, [c.id]: { ok: false, msg: t('common.connFail', { error: err instanceof Error ? err.message : 'Unknown error' }) } }))
+                        const error = err instanceof Error ? err.message : 'Unknown error'
+                        const warn = isLoopbackConnFailure(c.host, error) ? t('settings.clients.loopbackHint') : undefined
+                        setClientTestResult(prev => ({ ...prev, [c.id]: { ok: false, msg: t('common.connFail', { error }), warn } }))
                       }
                     }}
                     className="text-xs text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white"
@@ -186,7 +199,9 @@ function EditClientForm({ client, onClose, onSaved }: { client: DownloadClient; 
         : undefined
       setTestResult({ ok: true, msg: t('common.connOk'), warn })
     } catch (err: unknown) {
-      setTestResult({ ok: false, msg: t('common.connFail', { error: err instanceof Error ? err.message : 'Unknown error' }) })
+      const error = err instanceof Error ? err.message : 'Unknown error'
+      const warn = isLoopbackConnFailure(host, error) ? t('settings.clients.loopbackHint') : undefined
+      setTestResult({ ok: false, msg: t('common.connFail', { error }), warn })
     } finally {
       setTesting(false)
     }
@@ -364,7 +379,9 @@ function AddClientForm({ onClose, onAdded }: { onClose: () => void; onAdded: (c:
         : undefined
       setTestResult({ ok: true, msg: t('common.connOk'), warn })
     } catch (err: unknown) {
-      setTestResult({ ok: false, msg: t('common.connFail', { error: err instanceof Error ? err.message : 'Unknown error' }) })
+      const error = err instanceof Error ? err.message : 'Unknown error'
+      const warn = isLoopbackConnFailure(host, error) ? t('settings.clients.loopbackHint') : undefined
+      setTestResult({ ok: false, msg: t('common.connFail', { error }), warn })
     } finally {
       setTesting(false)
     }

--- a/web/src/util/protocols.test.ts
+++ b/web/src/util/protocols.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { clientProtocol, indexerProtocol, protocolGaps } from './protocols'
+import type { Indexer } from '../api/indexers'
+import type { DownloadClient } from '../api/downloadclients'
+
+const ix = (type: string, enabled = true) => ({ type, enabled }) as Indexer
+const cl = (type: string, enabled = true) => ({ type, enabled }) as DownloadClient
+
+describe('protocol mapping', () => {
+  it('classifies indexers and clients', () => {
+    expect(indexerProtocol('torznab')).toBe('torrent')
+    expect(indexerProtocol('newznab')).toBe('usenet')
+    expect(indexerProtocol('')).toBe('usenet') // backend default type
+    expect(clientProtocol('qbittorrent')).toBe('torrent')
+    expect(clientProtocol('sabnzbd')).toBe('usenet')
+    expect(clientProtocol('nzbget')).toBe('usenet')
+  })
+})
+
+describe('protocolGaps', () => {
+  it('flags a torznab indexer with only a usenet client', () => {
+    expect(protocolGaps([ix('torznab')], [cl('sabnzbd')])).toEqual(['torrent'])
+  })
+
+  it('flags a newznab indexer with only a torrent client', () => {
+    expect(protocolGaps([ix('newznab')], [cl('qbittorrent')])).toEqual(['usenet'])
+  })
+
+  it('is empty when protocols line up', () => {
+    expect(protocolGaps([ix('newznab'), ix('torznab')], [cl('sabnzbd'), cl('deluge')])).toEqual([])
+  })
+
+  it('ignores disabled rows on both sides', () => {
+    // Disabled torrent client doesn't cover the torznab indexer...
+    expect(protocolGaps([ix('torznab')], [cl('qbittorrent', false)])).toEqual(['torrent'])
+    // ...and a disabled indexer needs no coverage.
+    expect(protocolGaps([ix('torznab', false)], [cl('sabnzbd')])).toEqual([])
+  })
+
+  it('is empty with no indexers (that state is the setup banner, not this warning)', () => {
+    expect(protocolGaps([], [])).toEqual([])
+  })
+})

--- a/web/src/util/protocols.ts
+++ b/web/src/util/protocols.ts
@@ -1,0 +1,38 @@
+import type { Indexer } from '../api/indexers'
+import type { DownloadClient } from '../api/downloadclients'
+
+// Protocol matching between indexers and download clients. A Newznab
+// indexer yields NZBs that only a usenet client (SABnzbd, NZBGet) can
+// take; a Torznab indexer yields torrents that only a torrent client
+// (qBittorrent, Transmission, Deluge) can take. The rule was documented
+// only in QUICKSTART.md step 4 — users discovered it when their first
+// grab failed. Mirrors the backend: indexer/searcher.go protocolForType
+// and downloader/adapter.go IsTorrentClient/ProtocolForClient.
+
+export type Protocol = 'usenet' | 'torrent'
+
+export function indexerProtocol(type: string): Protocol {
+  return type === 'torznab' ? 'torrent' : 'usenet'
+}
+
+const TORRENT_CLIENTS = new Set(['transmission', 'qbittorrent', 'deluge'])
+
+export function clientProtocol(type: string): Protocol {
+  return TORRENT_CLIENTS.has(type) ? 'torrent' : 'usenet'
+}
+
+// protocolGaps returns the protocols for which enabled indexers exist but
+// no enabled download client does — i.e. searches will find releases that
+// nothing can download. Disabled rows don't count on either side.
+export function protocolGaps(indexers: Indexer[], clients: DownloadClient[]): Protocol[] {
+  const clientProtocols = new Set(
+    clients.filter(c => c.enabled).map(c => clientProtocol(c.type)),
+  )
+  const gaps = new Set<Protocol>()
+  for (const ix of indexers) {
+    if (!ix.enabled) continue
+    const p = indexerProtocol(ix.type)
+    if (!clientProtocols.has(p)) gaps.add(p)
+  }
+  return [...gaps]
+}


### PR DESCRIPTION
**Stacked on #1825** (uses its `useNeedsSetup` shape) — GitHub will retarget to `main` when that merges.

Three pieces of docs-only knowledge that killed first runs, now surfaced where they bite (fleet data: days-to-first-grab is the funnel stage these live in):

1. **Protocol mismatch** — an enabled Torznab indexer with only SABnzbd (or Newznab with only qBittorrent) meant every search listed releases and every grab failed. Amber warning on both settings tabs, computed from the lists `SettingsPage` already holds (`web/src/util/protocols.ts` mirrors `protocolForType`/`IsTorrentClient` from the backend, with tests incl. disabled-row semantics).
2. **Silent auto-search-on-add** — backend auto-search runs async; with no client configured it failed with zero UI feedback. The Add Author dialog now warns inline when auto-search is checked while the pipeline is incomplete.
3. **Docker loopback trap** — a failed client connection test against `localhost` now appends the explanation (inside a container, localhost is the container) at all three test sites; only for connection-shaped errors, so auth failures don't get a misleading hint.

511 web tests pass (6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)