### PR TITLE
feat(ui): what's-new toast after an upgrade

### DIFF
--- a/changelog.d/whats-new-toast.md
+++ b/changelog.d/whats-new-toast.md
@@ -1,0 +1,2 @@
+### Added
+- **"Updated to vX — see what's new" toast** after an upgrade, closing the loop the update badge opens: the badge tells you an update exists, this confirms it landed and links to the release notes. Shows once per version, never on a first-ever load (a fresh install has nothing to catch up on), and never for dev/sha builds.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import ErrorBoundary from './components/ErrorBoundary'
 import Logo from './components/Logo'
 import SetupBanner from './components/SetupBanner'
 import VersionBadge from './components/VersionBadge'
+import WhatsNewToast from './components/WhatsNewToast'
 import { useTheme } from './theme'
 
 // Route-scoped error boundary: a render crash in one page shows an inline error
@@ -243,6 +244,7 @@ function Shell() {
       </header>
 
       {isAdmin && <SetupBanner />}
+      <WhatsNewToast version={version} />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         <Suspense fallback={<PageLoadingFallback />}>

--- a/web/src/components/WhatsNewToast.test.tsx
+++ b/web/src/components/WhatsNewToast.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import WhatsNewToast from './WhatsNewToast'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>, opts?: Record<string, unknown>) => {
+      const vars = (typeof fallback === 'object' ? fallback : opts) ?? {}
+      const labels: Record<string, string> = {
+        'whatsNew.updated': `Updated to v${vars.version}.`,
+        'whatsNew.link': "See what's new",
+        'common.dismiss': 'Dismiss',
+      }
+      return labels[key] ?? (typeof fallback === 'string' ? fallback : key)
+    },
+  }),
+}))
+
+const KEY = 'bindery.lastSeenVersion'
+
+describe('WhatsNewToast', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('stays silent on a first-ever load and records the version', () => {
+    render(<WhatsNewToast version="1.30.0" />)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(localStorage.getItem(KEY)).toBe('1.30.0')
+  })
+
+  it('announces an upgrade and links to the new release', () => {
+    localStorage.setItem(KEY, '1.29.1')
+    render(<WhatsNewToast version="1.30.0" />)
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByText('Updated to v1.30.0.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: "See what's new" }))
+      .toHaveAttribute('href', 'https://github.com/vavallee/bindery/releases/tag/v1.30.0')
+    expect(localStorage.getItem(KEY)).toBe('1.30.0')
+  })
+
+  it('does not repeat on the next load of the same version', () => {
+    localStorage.setItem(KEY, '1.29.1')
+    const { unmount } = render(<WhatsNewToast version="1.30.0" />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    unmount()
+
+    render(<WhatsNewToast version="1.30.0" />)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('ignores dev/sha builds and empty versions', () => {
+    localStorage.setItem(KEY, '1.29.1')
+    render(<WhatsNewToast version="sha-9ecd99e" />)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    // The stored version must not be clobbered by a non-release build,
+    // or the next real upgrade would compare against a sha.
+    expect(localStorage.getItem(KEY)).toBe('1.29.1')
+
+    render(<WhatsNewToast version="" />)
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('can be dismissed', () => {
+    localStorage.setItem(KEY, '1.29.1')
+    render(<WhatsNewToast version="1.30.0" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }))
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/WhatsNewToast.tsx
+++ b/web/src/components/WhatsNewToast.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { isReleaseVersion, releaseHref } from '../util/version'
+
+const STORAGE_KEY = 'bindery.lastSeenVersion'
+
+// Closes the loop the update badge opens: badge → user upgrades → this
+// confirms the upgrade landed and points at what changed. Without it the
+// only feedback for upgrading is the badge disappearing.
+//
+// Fires once per version, on the first load after the running version
+// changes. Deliberately silent on a first-ever load (no stored version):
+// a fresh install has nothing to catch up on, and greeting it with
+// "updated to X" would be a lie. Release builds only — a sha/dev build
+// switching hashes is not an upgrade worth announcing.
+export default function WhatsNewToast({ version }: { version: string }) {
+  const { t } = useTranslation()
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    if (!version || !isReleaseVersion(version)) return
+    let previous: string | null
+    try {
+      previous = localStorage.getItem(STORAGE_KEY)
+      localStorage.setItem(STORAGE_KEY, version)
+    } catch {
+      // localStorage unavailable (private mode): skip rather than showing
+      // the toast on every load, which we could not suppress.
+      return
+    }
+    if (previous && previous !== version) setShow(true)
+  }, [version])
+
+  if (!show) return null
+
+  return (
+    <div
+      role="status"
+      className="fixed bottom-4 right-4 z-50 max-w-sm flex items-start gap-3 px-4 py-3 rounded-lg shadow-lg border border-emerald-300 dark:border-emerald-700/60 bg-emerald-50 dark:bg-emerald-950/70 text-sm text-emerald-900 dark:text-emerald-200"
+    >
+      <span className="flex-1">
+        {t('whatsNew.updated', 'Updated to v{{version}}.', { version })}{' '}
+        <a
+          href={releaseHref(version)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium underline hover:no-underline"
+        >
+          {t('whatsNew.link', "See what's new")}
+        </a>
+      </span>
+      <button
+        onClick={() => setShow(false)}
+        aria-label={t('common.dismiss', 'Dismiss')}
+        className="px-1 rounded hover:bg-emerald-100 dark:hover:bg-emerald-900/50 transition-colors"
+      >
+        ✕
+      </button>
+    </div>
+  )
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1011,6 +1011,10 @@
   "setupBanner": {
     "both": "Finish setting up: add an indexer and a download client so searches and downloads work."
   },
+  "whatsNew": {
+    "updated": "Updated to v{{version}}.",
+    "link": "See what's new"
+  },
   "protocolMismatch": {
     "torrent": "A Torznab indexer is enabled but no torrent download client (qBittorrent, Transmission, Deluge) is — its releases can be found but never downloaded.",
     "usenet": "A Newznab indexer is enabled but no usenet download client (SABnzbd, NZBGet) is — its releases can be found but never downloaded."


### PR DESCRIPTION
WS6 of the growth roadmap. Closes the loop #1822 opened: the badge says an update exists, the user upgrades — and nothing acknowledged it. Now a one-time toast per version links to that release's notes.

- Reuses `isReleaseVersion`/`releaseHref` from `web/src/util/version.ts` (added in #1822).
- **Silent on a first-ever load** — a fresh install has nothing to catch up on, and "updated to X" would be a lie.
- A non-release build never overwrites the stored version, or the next real upgrade would compare against a sha.
- localStorage unavailable (private mode) → skip entirely rather than re-firing on every load with no way to suppress it.

5 new tests covering first-load silence, the upgrade announcement, no-repeat, dev-build/empty-version rejection, and dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)