### PR TITLE
feat: first-run setup checklist backed by /system/setup-state

### DIFF
--- a/changelog.d/setup-checklist.md
+++ b/changelog.d/setup-checklist.md
@@ -1,0 +1,2 @@
+### Added
+- **Setup progress checklist** on the Authors page — indexer → download client → author → grab → import, ticking off as each happens and disappearing for good once a book has imported. This is the "your setup works" confirmation the app never had: until now the only evidence that first-run setup succeeded was a download showing up hours later, so a mis-wired install looked identical to a working one. Backed by a new `GET /api/v1/system/setup-state`; it replaces the getting-started card on that page (the checklist says everything the card did, plus what comes next).

--- a/cmd/bindery/main.go
+++ b/cmd/bindery/main.go
@@ -562,6 +562,7 @@ func main() {
 	} else {
 		slog.Warn("download client startup health check skipped", "error", err)
 	}
+	setupStateHandler := api.NewSetupStateHandler(indexerRepo, dlClientRepo, authorRepo, settingsRepo)
 	dlClientHandler := api.NewDownloadClientHandler(dlClientRepo).
 		WithHealth(downloadHealth).
 		WithStoragePaths(cfg.DownloadDir, cfg.AudiobookDownloadDir).
@@ -778,6 +779,9 @@ func main() {
 				EnhancedHardcoverDisabledReason: hardcoverState.EnhancedHardcoverDisabledReason,
 			})
 		})
+
+		// Onboarding checklist state (indexer/client/author/grab/import).
+		r.Get("/system/setup-state", setupStateHandler.Get)
 
 		// Auth — status/login/logout/setup are always allowed through the
 		// middleware (see auth.AllowUnauthPath). The config + mutation

--- a/internal/api/setup_state.go
+++ b/internal/api/setup_state.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/telemetry"
+)
+
+// SetupState reports how far an install has progressed through first-run
+// setup, backing the onboarding checklist. Every field is derived
+// server-side so the UI needs one round-trip instead of probing several
+// list endpoints.
+//
+// The two halves deliberately use different sources:
+//
+//   - HasIndexer/HasClient are CURRENT state (rows that exist right now).
+//     A user who deletes their only indexer has a broken pipeline again
+//     and must be told, so a "you did this once" marker would be wrong.
+//   - HasAuthor/HasGrab/HasImport are EVER-happened, read from the
+//     setup-funnel markers. History is prunable and books get deleted;
+//     "you have completed a download" stays true regardless.
+type SetupState struct {
+	HasIndexer bool `json:"hasIndexer"`
+	HasClient  bool `json:"hasClient"`
+	HasAuthor  bool `json:"hasAuthor"`
+	HasGrab    bool `json:"hasGrab"`
+	HasImport  bool `json:"hasImport"`
+	// Complete is true once the pipeline is configured AND has produced an
+	// import — the point at which the checklist has nothing left to say.
+	Complete bool `json:"complete"`
+}
+
+// SetupStateHandler serves GET /api/v1/system/setup-state.
+type SetupStateHandler struct {
+	indexers *db.IndexerRepo
+	clients  *db.DownloadClientRepo
+	authors  *db.AuthorRepo
+	settings *db.SettingsRepo
+}
+
+func NewSetupStateHandler(indexers *db.IndexerRepo, clients *db.DownloadClientRepo, authors *db.AuthorRepo, settings *db.SettingsRepo) *SetupStateHandler {
+	return &SetupStateHandler{indexers: indexers, clients: clients, authors: authors, settings: settings}
+}
+
+// settingPresent reports whether a settings key holds a non-empty value.
+// Read errors report false: the checklist showing an outstanding step it
+// has already completed is a far smaller harm than failing the request.
+func settingPresent(ctx context.Context, settings *db.SettingsRepo, key string) bool {
+	if settings == nil {
+		return false
+	}
+	v, err := settings.Get(ctx, key)
+	return err == nil && v != nil && v.Value != ""
+}
+
+func (h *SetupStateHandler) Get(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	state := SetupState{
+		HasAuthor: settingPresent(ctx, h.settings, telemetry.SettingFirstAuthorAt),
+		HasGrab:   settingPresent(ctx, h.settings, telemetry.SettingFirstGrabAt),
+		HasImport: settingPresent(ctx, h.settings, telemetry.SettingFirstImportAt),
+	}
+
+	// Enabled-only, matching what the pipeline actually uses: a disabled
+	// indexer is never searched and a disabled client never receives grabs,
+	// so neither counts as a completed setup step.
+	if list, err := h.indexers.List(ctx); err == nil {
+		for _, ix := range list {
+			if ix.Enabled {
+				state.HasIndexer = true
+				break
+			}
+		}
+	}
+	if list, err := h.clients.List(ctx); err == nil {
+		for _, c := range list {
+			if c.Enabled {
+				state.HasClient = true
+				break
+			}
+		}
+	}
+
+	// The funnel marker for "first author" only exists on installs that
+	// added one after the marker shipped. Fall back to current library
+	// contents so an older install doesn't see a permanently unchecked box.
+	if !state.HasAuthor && h.authors != nil {
+		// limit 1: only the total count matters, not the rows.
+		if _, total, err := h.authors.ListPage(ctx, 0, 1, 0); err == nil && total > 0 {
+			state.HasAuthor = true
+		}
+	}
+
+	state.Complete = state.HasIndexer && state.HasClient && state.HasAuthor && state.HasImport
+	writeJSON(w, http.StatusOK, state)
+}

--- a/internal/api/setup_state_test.go
+++ b/internal/api/setup_state_test.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/vavallee/bindery/internal/db"
+	"github.com/vavallee/bindery/internal/models"
+	"github.com/vavallee/bindery/internal/telemetry"
+)
+
+func newSetupStateFixture(t *testing.T) (*SetupStateHandler, *db.IndexerRepo, *db.DownloadClientRepo, *db.SettingsRepo) {
+	t.Helper()
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open memory db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	indexers := db.NewIndexerRepo(database)
+	clients := db.NewDownloadClientRepo(database)
+	authors := db.NewAuthorRepo(database)
+	settings := db.NewSettingsRepo(database)
+	return NewSetupStateHandler(indexers, clients, authors, settings), indexers, clients, settings
+}
+
+func getSetupState(t *testing.T, h *SetupStateHandler) SetupState {
+	t.Helper()
+	w := httptest.NewRecorder()
+	h.Get(w, httptest.NewRequest(http.MethodGet, "/api/v1/system/setup-state", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var s SetupState
+	if err := json.Unmarshal(w.Body.Bytes(), &s); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return s
+}
+
+func TestSetupState_EmptyInstall(t *testing.T) {
+	h, _, _, _ := newSetupStateFixture(t)
+	s := getSetupState(t, h)
+	if s.HasIndexer || s.HasClient || s.HasAuthor || s.HasGrab || s.HasImport || s.Complete {
+		t.Errorf("fresh install reports progress: %+v", s)
+	}
+}
+
+// Only ENABLED rows count — a disabled indexer is never searched and a
+// disabled client never receives grabs, so neither is a completed step.
+func TestSetupState_IgnoresDisabledRows(t *testing.T) {
+	h, indexers, clients, _ := newSetupStateFixture(t)
+	ctx := context.Background()
+
+	if err := indexers.Create(ctx, &models.Indexer{Name: "ix", URL: "http://x/api", Type: "newznab", Enabled: false}); err != nil {
+		t.Fatalf("create indexer: %v", err)
+	}
+	if err := clients.Create(ctx, &models.DownloadClient{Name: "sab", Type: "sabnzbd", Host: "h", Port: 8080, Enabled: false}); err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	if s := getSetupState(t, h); s.HasIndexer || s.HasClient {
+		t.Errorf("disabled rows counted as configured: %+v", s)
+	}
+
+	if err := indexers.Create(ctx, &models.Indexer{Name: "ix2", URL: "http://y/api", Type: "newznab", Enabled: true}); err != nil {
+		t.Fatalf("create enabled indexer: %v", err)
+	}
+	if s := getSetupState(t, h); !s.HasIndexer {
+		t.Error("enabled indexer not detected")
+	}
+}
+
+// Indexer/client are CURRENT state: deleting the last indexer must flip the
+// step back to outstanding, unlike the ever-happened funnel markers.
+func TestSetupState_IndexerStepIsCurrentState(t *testing.T) {
+	h, indexers, _, _ := newSetupStateFixture(t)
+	ctx := context.Background()
+
+	ix := &models.Indexer{Name: "ix", URL: "http://x/api", Type: "newznab", Enabled: true}
+	if err := indexers.Create(ctx, ix); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if s := getSetupState(t, h); !s.HasIndexer {
+		t.Fatal("expected HasIndexer after create")
+	}
+	if err := indexers.Delete(ctx, ix.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if s := getSetupState(t, h); s.HasIndexer {
+		t.Error("HasIndexer stayed true after the last indexer was deleted")
+	}
+}
+
+// Grab/import are ever-happened, read from the funnel markers, so they
+// survive history pruning and book deletion.
+func TestSetupState_GrabAndImportFromFunnelMarkers(t *testing.T) {
+	h, _, _, settings := newSetupStateFixture(t)
+	ctx := context.Background()
+
+	telemetry.MarkFirst(ctx, settings, telemetry.SettingFirstGrabAt)
+	s := getSetupState(t, h)
+	if !s.HasGrab {
+		t.Error("HasGrab not read from the funnel marker")
+	}
+	if s.HasImport {
+		t.Error("HasImport true without a marker")
+	}
+
+	telemetry.MarkFirst(ctx, settings, telemetry.SettingFirstImportAt)
+	if s := getSetupState(t, h); !s.HasImport {
+		t.Error("HasImport not read from the funnel marker")
+	}
+}
+
+// An install predating the funnel markers still has authors; the fallback
+// keeps its author step from being permanently unchecked.
+func TestSetupState_AuthorFallsBackToLibrary(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+	authors := db.NewAuthorRepo(database)
+	h := NewSetupStateHandler(db.NewIndexerRepo(database), db.NewDownloadClientRepo(database), authors, db.NewSettingsRepo(database))
+
+	if s := getSetupState(t, h); s.HasAuthor {
+		t.Fatal("empty library reports HasAuthor")
+	}
+	if err := authors.Create(ctx, &models.Author{Name: "Frank Herbert"}); err != nil {
+		t.Fatalf("create author: %v", err)
+	}
+	if s := getSetupState(t, h); !s.HasAuthor {
+		t.Error("HasAuthor not derived from library contents when no marker exists")
+	}
+}
+
+func TestSetupState_CompleteRequiresTheWholePipeline(t *testing.T) {
+	h, indexers, clients, settings := newSetupStateFixture(t)
+	ctx := context.Background()
+
+	if err := indexers.Create(ctx, &models.Indexer{Name: "ix", URL: "http://x/api", Type: "newznab", Enabled: true}); err != nil {
+		t.Fatalf("indexer: %v", err)
+	}
+	if err := clients.Create(ctx, &models.DownloadClient{Name: "sab", Type: "sabnzbd", Host: "h", Port: 8080, Enabled: true}); err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if err := settings.Set(ctx, telemetry.SettingFirstAuthorAt, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("author marker: %v", err)
+	}
+	// Everything but the import: still incomplete.
+	if s := getSetupState(t, h); s.Complete {
+		t.Error("Complete true before any import")
+	}
+	if err := settings.Set(ctx, telemetry.SettingFirstImportAt, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("import marker: %v", err)
+	}
+	if s := getSetupState(t, h); !s.Complete {
+		t.Error("Complete false with the full pipeline satisfied")
+	}
+}

--- a/web/src/api/system.ts
+++ b/web/src/api/system.ts
@@ -13,6 +13,18 @@ export interface SystemStatus {
   enhancedHardcoverDisabledReason?: 'env_disabled' | 'missing_token' | 'admin_disabled' | string
 }
 
+/** Onboarding-checklist progress; see internal/api/setup_state.go for why
+ *  the indexer/client fields are current state while the rest are
+ *  ever-happened. */
+export interface SetupState {
+  hasIndexer: boolean
+  hasClient: boolean
+  hasAuthor: boolean
+  hasGrab: boolean
+  hasImport: boolean
+  complete: boolean
+}
+
 export interface LogEntry {
   // Ring buffer shape
   time?: string
@@ -49,6 +61,7 @@ export const systemApi = {
   // System
   health: () => request<{ status: string; version: string }>('/health'),
   status: () => request<SystemStatus>('/system/status'),
+  setupState: () => request<SetupState>('/system/setup-state'),
   getLogs: (params?: { level?: string; component?: string; from?: string; to?: string; q?: string; limit?: number; offset?: number }) => {
     const p: Record<string, string> = {}
     if (params?.level) p.level = params.level

--- a/web/src/components/SetupChecklist.tsx
+++ b/web/src/components/SetupChecklist.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router'
+import { useTranslation } from 'react-i18next'
+import { api, type SetupState } from '../api/client'
+
+const STORAGE_KEY = 'bindery.setupChecklistDismissed'
+
+interface Step {
+  key: keyof Omit<SetupState, 'complete'>
+  labelKey: string
+  fallback: string
+  to?: string
+  actionKey?: string
+  actionFallback?: string
+}
+
+// Ordered as the pipeline runs. Account creation is deliberately absent:
+// the user cannot be looking at this without having done it, so listing it
+// would spend the first line of the checklist on a step that is always
+// already ticked.
+const STEPS: Step[] = [
+  {
+    key: 'hasIndexer',
+    labelKey: 'setupChecklist.indexer',
+    fallback: 'Add an indexer',
+    to: '/settings?tab=indexers',
+    actionKey: 'gettingStarted.indexers',
+    actionFallback: 'Set up Indexers',
+  },
+  {
+    key: 'hasClient',
+    labelKey: 'setupChecklist.client',
+    fallback: 'Add a download client',
+    to: '/settings?tab=clients',
+    actionKey: 'gettingStarted.downloadClients',
+    actionFallback: 'Set up Download Clients',
+  },
+  { key: 'hasAuthor', labelKey: 'setupChecklist.author', fallback: 'Add an author' },
+  { key: 'hasGrab', labelKey: 'setupChecklist.grab', fallback: 'Grab a book' },
+  { key: 'hasImport', labelKey: 'setupChecklist.import', fallback: 'First book imported' },
+]
+
+// First-run progress checklist, shown on the Authors page until the
+// pipeline has produced an import. This is the "your setup works"
+// confirmation the app never had: previously the only signal that setup
+// succeeded was a download appearing hours later, so a user who had
+// mis-wired something had no way to tell the difference between "working,
+// still searching" and "silently broken".
+//
+// Auto-hides for good once complete; also dismissible early for users who
+// deliberately run a partial setup (e.g. catalogue-only, no downloads).
+export default function SetupChecklist() {
+  const { t } = useTranslation()
+  const [state, setState] = useState<SetupState | null>(null)
+  const [dismissed, setDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === '1'
+    } catch {
+      return false
+    }
+  })
+
+  useEffect(() => {
+    let cancelled = false
+    api.setupState()
+      .then(s => { if (!cancelled) setState(s) })
+      .catch(() => { /* leave hidden — never block the page on this */ })
+    return () => { cancelled = true }
+  }, [])
+
+  if (!state || state.complete || dismissed) return null
+
+  const done = STEPS.filter(s => state[s.key]).length
+
+  return (
+    <div className="max-w-xl mx-auto mb-8 px-5 py-4 bg-slate-100 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 rounded-lg text-left">
+      <div className="flex items-center justify-between gap-3 mb-3">
+        <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+          {t('setupChecklist.title', 'Setup progress')}{' '}
+          <span className="font-normal text-fg-muted">{done}/{STEPS.length}</span>
+        </h3>
+        <button
+          onClick={() => {
+            try {
+              localStorage.setItem(STORAGE_KEY, '1')
+            } catch {
+              // localStorage unavailable — dismiss for this render only.
+            }
+            setDismissed(true)
+          }}
+          className="text-xs text-fg-muted hover:text-slate-900 dark:hover:text-white transition-colors"
+        >
+          {t('common.dismiss', 'Dismiss')}
+        </button>
+      </div>
+      <ul className="space-y-1.5">
+        {STEPS.map(step => {
+          const complete = state[step.key]
+          return (
+            <li key={step.key} className="flex items-center gap-2 text-sm">
+              <span
+                aria-hidden="true"
+                className={`inline-flex items-center justify-center w-4 h-4 rounded-full text-[10px] flex-shrink-0 ${
+                  complete
+                    ? 'bg-emerald-600 text-white'
+                    : 'border border-slate-300 dark:border-zinc-700 text-transparent'
+                }`}
+              >
+                ✓
+              </span>
+              <span className={complete ? 'text-fg-muted line-through' : 'text-slate-800 dark:text-zinc-200'}>
+                {t(step.labelKey, step.fallback)}
+              </span>
+              {!complete && step.to && (
+                <Link to={step.to} className="text-xs text-emerald-700 dark:text-emerald-400 hover:underline">
+                  {t(step.actionKey!, step.actionFallback!)}
+                </Link>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1015,6 +1015,14 @@
     "updated": "Updated to v{{version}}.",
     "link": "See what's new"
   },
+  "setupChecklist": {
+    "title": "Setup progress",
+    "indexer": "Add an indexer",
+    "client": "Add a download client",
+    "author": "Add an author",
+    "grab": "Grab a book",
+    "import": "First book imported"
+  },
   "protocolMismatch": {
     "torrent": "A Torznab indexer is enabled but no torrent download client (qBittorrent, Transmission, Deluge) is — its releases can be found but never downloaded.",
     "usenet": "A Newznab indexer is enabled but no usenet download client (SABnzbd, NZBGet) is — its releases can be found but never downloaded."

--- a/web/src/pages/AuthorsPage.onboarding.test.tsx
+++ b/web/src/pages/AuthorsPage.onboarding.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import AuthorsPage from './AuthorsPage'
 import { api } from '../api/client'
-import type { Indexer, DownloadClient } from '../api/client'
+import type { SetupState } from '../api/client'
 
 vi.mock('../api/client', async importOriginal => {
   const actual = await importOriginal<typeof import('../api/client')>()
@@ -12,8 +12,7 @@ vi.mock('../api/client', async importOriginal => {
     api: {
       ...actual.api,
       listAuthors: vi.fn(),
-      listIndexers: vi.fn(),
-      listDownloadClients: vi.fn(),
+      setupState: vi.fn(),
     },
   }
 })
@@ -24,10 +23,15 @@ vi.mock('react-i18next', () => ({
       const labels: Record<string, string> = {
         'authors.empty': 'No authors yet',
         'authors.emptyHint': 'Click Add Author to start',
-        'gettingStarted.title': 'Getting started',
-        'gettingStarted.reasonAuthors': 'Configure an indexer and a download client before adding authors.',
+        'setupChecklist.title': 'Setup progress',
+        'setupChecklist.indexer': 'Add an indexer',
+        'setupChecklist.client': 'Add a download client',
+        'setupChecklist.author': 'Add an author',
+        'setupChecklist.grab': 'Grab a book',
+        'setupChecklist.import': 'First book imported',
         'gettingStarted.indexers': 'Set up Indexers',
         'gettingStarted.downloadClients': 'Set up Download Clients',
+        'common.dismiss': 'Dismiss',
       }
       return labels[key] ?? fallback ?? key
     },
@@ -51,8 +55,17 @@ vi.mock('../components/usePagination', () => ({
 
 vi.mock('../components/Pagination', () => ({ default: () => null }))
 
-const fakeIndexer = { id: 1, name: 'NZBgeek' } as unknown as Indexer
-const fakeClient = { id: 1, name: 'qBittorrent' } as unknown as DownloadClient
+function state(overrides: Partial<SetupState> = {}): SetupState {
+  return {
+    hasIndexer: false,
+    hasClient: false,
+    hasAuthor: false,
+    hasGrab: false,
+    hasImport: false,
+    complete: false,
+    ...overrides,
+  }
+}
 
 function renderPage() {
   return render(
@@ -62,60 +75,67 @@ function renderPage() {
   )
 }
 
-describe('AuthorsPage first-run onboarding guidance', () => {
+describe('AuthorsPage setup checklist', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    localStorage.clear()
     vi.mocked(api.listAuthors).mockResolvedValue({ items: [], total: 0, limit: 100, offset: 0 })
   })
 
-  it('shows the getting-started guidance with links to settings when there are no authors and no indexers/clients', async () => {
-    vi.mocked(api.listIndexers).mockResolvedValue([])
-    vi.mocked(api.listDownloadClients).mockResolvedValue([])
+  it('lists every outstanding step with links to the settings tabs', async () => {
+    vi.mocked(api.setupState).mockResolvedValue(state())
 
     renderPage()
 
-    const heading = await screen.findByText('Getting started')
-    expect(heading).toBeInTheDocument()
-
-    const indexersLink = screen.getByRole('link', { name: 'Set up Indexers' })
-    expect(indexersLink).toHaveAttribute('href', '/settings?tab=indexers')
-    const clientsLink = screen.getByRole('link', { name: 'Set up Download Clients' })
-    expect(clientsLink).toHaveAttribute('href', '/settings?tab=clients')
-  })
-
-  // Half-configured states used to show NOTHING (the hook required both
-  // lists empty), which is exactly the state where grabs fail silently.
-  // Now the guidance names the one missing step and links only to it.
-  it('shows only the download-client step when an indexer exists but no client', async () => {
-    vi.mocked(api.listIndexers).mockResolvedValue([fakeIndexer])
-    vi.mocked(api.listDownloadClients).mockResolvedValue([])
-
-    renderPage()
-
-    expect(await screen.findByText('Getting started')).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Set up Download Clients' })).toHaveAttribute('href', '/settings?tab=clients')
-    expect(screen.queryByRole('link', { name: 'Set up Indexers' })).not.toBeInTheDocument()
-  })
-
-  it('shows only the indexer step when a client exists but no indexer', async () => {
-    vi.mocked(api.listIndexers).mockResolvedValue([])
-    vi.mocked(api.listDownloadClients).mockResolvedValue([fakeClient])
-
-    renderPage()
-
-    expect(await screen.findByText('Getting started')).toBeInTheDocument()
+    expect(await screen.findByText('Setup progress')).toBeInTheDocument()
+    expect(screen.getByText('0/5')).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'Set up Indexers' })).toHaveAttribute('href', '/settings?tab=indexers')
-    expect(screen.queryByRole('link', { name: 'Set up Download Clients' })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Set up Download Clients' })).toHaveAttribute('href', '/settings?tab=clients')
   })
 
-  it('does NOT show the guidance when both an indexer and a client exist', async () => {
-    vi.mocked(api.listIndexers).mockResolvedValue([fakeIndexer])
-    vi.mocked(api.listDownloadClients).mockResolvedValue([fakeClient])
+  it('counts completed steps and drops their action links', async () => {
+    vi.mocked(api.setupState).mockResolvedValue(state({ hasIndexer: true, hasClient: true, hasAuthor: true }))
+
+    renderPage()
+
+    expect(await screen.findByText('3/5')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Set up Indexers' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Set up Download Clients' })).not.toBeInTheDocument()
+    // Outstanding steps still listed.
+    expect(screen.getByText('Grab a book')).toBeInTheDocument()
+  })
+
+  // The checklist is a first-run aid, not a permanent fixture: once the
+  // pipeline has produced an import it must disappear for good.
+  it('hides itself once setup is complete', async () => {
+    vi.mocked(api.setupState).mockResolvedValue(
+      state({ hasIndexer: true, hasClient: true, hasAuthor: true, hasGrab: true, hasImport: true, complete: true }),
+    )
 
     renderPage()
 
     expect(await screen.findByText('No authors yet')).toBeInTheDocument()
-    await waitFor(() => expect(api.listIndexers).toHaveBeenCalled())
-    expect(screen.queryByText('Getting started')).not.toBeInTheDocument()
+    await waitFor(() => expect(api.setupState).toHaveBeenCalled())
+    expect(screen.queryByText('Setup progress')).not.toBeInTheDocument()
+  })
+
+  it('stays hidden when the setup-state request fails', async () => {
+    vi.mocked(api.setupState).mockRejectedValue(new Error('boom'))
+
+    renderPage()
+
+    expect(await screen.findByText('No authors yet')).toBeInTheDocument()
+    await waitFor(() => expect(api.setupState).toHaveBeenCalled())
+    expect(screen.queryByText('Setup progress')).not.toBeInTheDocument()
+  })
+
+  it('respects a stored dismissal', async () => {
+    localStorage.setItem('bindery.setupChecklistDismissed', '1')
+    vi.mocked(api.setupState).mockResolvedValue(state())
+
+    renderPage()
+
+    expect(await screen.findByText('No authors yet')).toBeInTheDocument()
+    expect(screen.queryByText('Setup progress')).not.toBeInTheDocument()
   })
 })

--- a/web/src/pages/AuthorsPage.tsx
+++ b/web/src/pages/AuthorsPage.tsx
@@ -11,8 +11,7 @@ import Pagination from '../components/Pagination'
 import { useServerPagination } from '../components/usePagination'
 import ViewToggle from '../components/ViewToggle'
 import { useView } from '../components/useView'
-import GettingStartedGuidance from '../components/GettingStartedGuidance'
-import { useNeedsSetup } from '../components/useNeedsSetup'
+import SetupChecklist from '../components/SetupChecklist'
 import { btn, btnSize } from '../components/buttons'
 import Switch from '../components/Switch'
 
@@ -48,7 +47,6 @@ export default function AuthorsPage() {
     return ''
   })
   const [view, setView] = useView('authors', 'grid')
-  const { needsIndexer, needsClient, needsAny } = useNeedsSetup()
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
   const [bulkBusy, setBulkBusy] = useState(false)
   const selectAllRef = useRef<HTMLInputElement>(null)
@@ -368,11 +366,12 @@ export default function AuthorsPage() {
         <button onClick={() => setMonitoredFilter('unmonitored')} className={sortBtnCls(monitoredFilter === 'unmonitored')}>{t('authors.filterUnmonitored')}</button>
       </div>
 
+      <SetupChecklist />
+
       {loading ? (
         <div className="text-slate-600 dark:text-zinc-500">{t('common.loading')}</div>
       ) : total === 0 && !debouncedSearch && !monitoredFilter ? (
         <div className="text-center py-16 text-slate-600 dark:text-zinc-500">
-          {needsAny && <GettingStartedGuidance reasonKey="gettingStarted.reasonAuthors" needsIndexer={needsIndexer} needsClient={needsClient} />}
           <p className="text-lg mb-2">{t('authors.empty')}</p>
           <p className="text-sm">{t('authors.emptyHint')}</p>
         </div>


### PR DESCRIPTION
WS5 of the growth roadmap — the missing completion signal.

## Why

Until now the only evidence that first-run setup worked was a download appearing hours later, so a silently mis-wired install looked identical to a working one. Telemetry: 22% of new installs never reach a working pipeline and churn at 72% within a day.

## What

**`GET /api/v1/system/setup-state`** (`internal/api/setup_state.go`) — five booleans plus `complete`, one round-trip. The two halves use different sources on purpose:

| fields | source | why |
|---|---|---|
| `hasIndexer`, `hasClient` | current enabled rows | deleting your last indexer breaks the pipeline again — a "you did this once" marker would be wrong |
| `hasAuthor`, `hasGrab`, `hasImport` | funnel markers (#1823) | history is prunable and books get deleted; "you completed a download" stays true |

`hasAuthor` falls back to library contents so installs predating the markers don't show a permanently unchecked box.

**`SetupChecklist`** renders above the Authors list *regardless of library contents* — a Readarr migrant with a full library but no download client still sees what's missing. Auto-hides for good once an import lands; dismissible early for deliberate partial setups (catalogue-only).

## One judgement call worth reviewing

It **replaces `GettingStartedGuidance` on the Authors page**. Keeping both would have stacked three overlapping nudges there (card + shell banner + checklist), and the checklist is a superset of what the card said. `BooksPage` keeps the card — no checklist there. The `AuthorsPage.onboarding` spec is rewritten accordingly (5 tests: outstanding steps, partial progress, auto-hide on complete, hidden on request failure, stored dismissal).

6 new Go tests cover empty install, disabled-rows-don't-count, current-state semantics for indexer, marker-based grab/import, the author fallback, and `complete` requiring the whole pipeline. 518 web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)