### PR TITLE
docs(skills): fix-issue step 7 points at changelog.d, not CHANGELOG.md

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -12,7 +12,7 @@ Fix GitHub issue $ARGUMENTS.
 4. Implement the fix on a branch `fix/<n>-<slug>`. Address the root cause, not the symptom.
 5. Security-sensitive area (auth, settings endpoints, user-scoped resources, proxy headers)? Check against the conventions in CLAUDE.md before proceeding.
 6. Run the affected package tests, then lint. Fix what breaks.
-7. Add a CHANGELOG.md entry under Unreleased.
+7. Add a fragment under `changelog.d/` (format in `changelog.d/README.md`; preview with `make changelog`). Do not edit CHANGELOG.md directly — a maintainer assembles it at release time.
 8. Push, open a PR targeting `main` with `Fixes #<n>`, summarize the root cause in the body.
 
 Never tag a release from this workflow — releases follow the flow in CLAUDE.md and are Vincent's call.


### PR DESCRIPTION
Step 7 said `Add a CHANGELOG.md entry under Unreleased` — stale since the changelog.d migration. CHANGELOG.md is assembled at release time; fragments go under `changelog.d/` (CONTRIBUTING.md:174, format in `changelog.d/README.md`, preview with `make changelog`).

Flagged in the original bindhelper design review and never fixed.

**This PR is also the first live test of `ai-triage.yml` since `ANTHROPIC_API_KEY` was added** — if a Sonnet review appears below, the whole chain (egress allowlist → bun → token override → CLI install → model call) works.