### PR TITLE
fix(telemetry-server): gate the funnel cohort on v1.30.1, not v1.31.0

### DIFF
--- a/changelog.d/funnel-min-version.md
+++ b/changelog.d/funnel-min-version.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Setup-funnel cohort gate corrected to v1.30.1** — it was pinned to 1.31.0 on the assumption the funnel fields would ship in a minor release. With the fields landing in 1.30.1, the old gate would have excluded every install that actually reports them, leaving the /stats setup-funnel section permanently empty.

--- a/cmd/telemetry-server/main.go
+++ b/cmd/telemetry-server/main.go
@@ -742,7 +742,7 @@ type featuresPayload struct {
 	OIDCEnabled     *bool `json:"oidc_enabled,omitempty"`
 	MultiUser       *bool `json:"multi_user,omitempty"`
 
-	// Setup-funnel day offsets (v1.31.0+): whole days from install creation
+	// Setup-funnel day offsets (v1.30.1+): whole days from install creation
 	// to each first milestone; absent = hasn't happened. Must be listed here
 	// or handlePing's normalising re-marshal would silently drop them.
 	SetupIndexerDay *int `json:"setup_indexer_day,omitempty"`
@@ -1183,7 +1183,7 @@ const telemetryFieldsHTML = `<!DOCTYPE html>
 
   <div class="field">
     <code>features.setup_indexer_day</code> / <code>features.setup_client_day</code> / <code>features.first_author_day</code> / <code>features.first_grab_day</code> / <code>features.first_import_day</code>
-    <div class="why">Integers (v1.31.0+): whole days between install creation and the first time each milestone happened — first indexer added, first download client added, first author added, first grab, first import. 0 means "the same day"; a field is absent until its milestone happens. Never timestamps, dates, or times of day — only a day count. These exist because most installs that never finish initial setup are abandoned within a day, and a day-count is the least data that shows where setup stalls.</div>
+    <div class="why">Integers (v1.30.1+): whole days between install creation and the first time each milestone happened — first indexer added, first download client added, first author added, first grab, first import. 0 means "the same day"; a field is absent until its milestone happens. Never timestamps, dates, or times of day — only a day count. These exist because most installs that never finish initial setup are abandoned within a day, and a day-count is the least data that shows where setup stalls.</div>
   </div>
 
   <h2>What we don't collect</h2>
@@ -1733,7 +1733,7 @@ var featureFields = []featureField{
 // day offsets. Installs on older versions can't be told apart from installs
 // that stalled before their first milestone (both send no funnel fields), so
 // the funnel cohort is gated on version, not on field presence.
-var funnelMinVersion = [3]int{1, 31, 0}
+var funnelMinVersion = [3]int{1, 30, 1}
 
 // funnelCapable reports whether a version string is >= funnelMinVersion.
 func funnelCapable(version string) bool {
@@ -2201,7 +2201,7 @@ func renderLongevity(buckets []statsBucket, youngDB bool) string {
 func renderFunnel(stages []funnelStage) string {
 	if len(stages) == 0 {
 		return `<div class="chart"><p class="empty">No funnel data yet. ` +
-			`Clients report setup-funnel day offsets starting with v1.31.0; ` +
+			`Clients report setup-funnel day offsets starting with v1.30.1; ` +
 			`this section populates as new installs arrive on it.</p></div>`
 	}
 	var b strings.Builder

--- a/cmd/telemetry-server/main_test.go
+++ b/cmd/telemetry-server/main_test.go
@@ -1457,8 +1457,13 @@ func TestLoadLedgerBackfill(t *testing.T) {
 
 func TestFunnelCapable(t *testing.T) {
 	for v, want := range map[string]bool{
-		"1.31.0": true, "1.31.1": true, "1.32.0": true, "2.0.0": true,
-		"1.30.0": false, "1.29.1": false, "sha-abc": false, "dev": false, "": false,
+		// The boundary is a PATCH bump (1.30.1), so the pair that matters
+		// most is 1.30.0/1.30.1 — a major/minor-only comparison would let
+		// the whole 1.30.x line in and pollute the cohort with installs
+		// that cannot report funnel fields at all.
+		"1.30.1": true, "1.30.2": true, "1.31.0": true, "1.32.0": true, "2.0.0": true,
+		"1.30.0": false, "1.29.9": false, "1.29.1": false, "0.99.9": false,
+		"sha-abc": false, "dev": false, "": false,
 	} {
 		if got := funnelCapable(v); got != want {
 			t.Errorf("funnelCapable(%q) = %v, want %v", v, got, want)
@@ -1470,7 +1475,7 @@ func TestFunnelCapable(t *testing.T) {
 // too young for a window stays out of that window's denominator, funnel-
 // incapable versions stay out entirely, and day offsets bucket correctly.
 func TestComputeSetupFunnel(t *testing.T) {
-	s := newTestServer(t, "v1.31.0")
+	s := newTestServer(t, "v1.30.1")
 	ctx := context.Background()
 	now := time.Now().UTC()
 
@@ -1489,11 +1494,11 @@ func TestComputeSetupFunnel(t *testing.T) {
 	}
 
 	// 10 days old, full same-day setup → counts in D1, D7, ever.
-	insert('1', "1.31.0", 10, `{"setup_indexer_day":0,"setup_client_day":0,"first_grab_day":2}`)
+	insert('1', "1.30.1", 10, `{"setup_indexer_day":0,"setup_client_day":0,"first_grab_day":2}`)
 	// 10 days old, never configured anything → in all denominators, no numerators.
-	insert('2', "1.31.0", 10, `{}`)
+	insert('2', "1.30.1", 10, `{}`)
 	// 3 days old, indexer on day 2 → in D1 denominator (missed), NOT in D7 denominator.
-	insert('3', "1.31.2", 3, `{"setup_indexer_day":2}`)
+	insert('3', "1.31.0", 3, `{"setup_indexer_day":2}`)
 	// funnel-incapable version → excluded from the cohort entirely.
 	insert('4', "1.30.0", 10, `{"indexers":3}`)
 
@@ -1527,10 +1532,10 @@ func TestComputeSetupFunnel(t *testing.T) {
 // handlePing: a features payload with funnel day offsets must round-trip
 // into the stored JSON, including a 0 ("same day") value.
 func TestHandlePing_PreservesFunnelFields(t *testing.T) {
-	s := newTestServer(t, "v1.31.0")
+	s := newTestServer(t, "v1.30.1")
 	s.limiter = newRateLimiter(time.Hour, time.Minute)
 
-	body := []byte(`{"install_id":"11111111-1111-1111-1111-111111111111","version":"1.31.0",` +
+	body := []byte(`{"install_id":"11111111-1111-1111-1111-111111111111","version":"1.30.1",` +
 		`"os":"linux","arch":"amd64","features":{"indexers":2,"setup_indexer_day":0,"first_grab_day":3}}`)
 	r := httptest.NewRequest(http.MethodPost, "/api/ping", bytes.NewReader(body))
 	r.RemoteAddr = "192.0.2.30:1234"


### PR DESCRIPTION
The setup-funnel fields (#1823) ship in **1.30.1**, a patch release — but `funnelMinVersion` was pinned to `1.31.0` on the assumption of a minor bump.

Left alone this fails closed and silently: `funnelCapable` would reject every install that actually reports funnel data, so the **Setup funnel** section on /stats would render its "no data yet" note forever while the data sat in the DB.

- `funnelMinVersion` → `{1, 30, 1}`. No logic change needed — `funnelCapable` already compares all three components — but the test now pins the `1.30.0`/`1.30.1` pair explicitly, because a major/minor-only comparison would admit the whole 1.30.x line, which is exactly the cohort pollution the gate exists to prevent.
- Both user-visible version mentions updated: the `/telemetry-fields` schema page and the empty-state note on `/stats`.
- The "funnel-incapable" fixture in `TestComputeSetupFunnel` is `1.30.0` — now the immediately-preceding release, so it tests the real boundary rather than a distant one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)