### PR TITLE
fix(importer): guard the hardlink path too, and compare case-insensitively

### DIFF
--- a/changelog.d/1809-hardlink-and-case-guard.md
+++ b/changelog.d/1809-hardlink-and-case-guard.md
@@ -1,0 +1,6 @@
+- **Directory moves and hardlinks refuse a destination inside the source**
+  ([#1809](https://github.com/vavallee/bindery/issues/1809)) — the copy-based
+  move and `HardlinkDir` both walked into the directory they were creating and
+  recursed until the disk filled. Containment is now checked case-insensitively
+  as well, so a case-only difference cannot slip past on APFS or a Windows
+  mount.

--- a/internal/importer/movedir_test.go
+++ b/internal/importer/movedir_test.go
@@ -74,3 +74,53 @@ func mustWrite(t *testing.T, path, content string) {
 		t.Fatal(err)
 	}
 }
+
+// hardlinkDirRooted MkdirAlls the destination and then walks the source, so a
+// nested destination recurses into the tree it is creating — the same hazard as
+// the copy path (#1809). Unreachable from reorganize, which never hardlinks,
+// but HardlinkDir is exported.
+func TestHardlinkDirRefusesDstInsideSrc(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "book.m4b"), []byte("data"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	dst := filepath.Join(src, "Series", "Title")
+
+	err := HardlinkDir(src, dst)
+	if !errors.Is(err, ErrDestInsideSource) {
+		t.Fatalf("HardlinkDir err = %v, want ErrDestInsideSource", err)
+	}
+	// Nothing created: the guard runs before MkdirAll.
+	if _, statErr := os.Stat(filepath.Join(src, "Series")); !os.IsNotExist(statErr) {
+		t.Error("the refused hardlink still created a directory inside the source")
+	}
+	if _, statErr := os.Stat(filepath.Join(src, "book.m4b")); statErr != nil {
+		t.Errorf("source content disturbed: %v", statErr)
+	}
+}
+
+// The filesystem decides what "same directory" means and dirContains cannot see
+// it. On a case-insensitive volume /library/Author and /library/author are one
+// directory, so a case-only difference must still be refused — otherwise the
+// guard is bypassed by nothing more than a template that lowercases.
+func TestDirContainsIsCaseInsensitiveToo(t *testing.T) {
+	for _, tc := range []struct {
+		name, dir, p string
+		want         bool
+	}{
+		{"exact nesting", "/library/Author", "/library/Author/Series/Title", true},
+		{"case-only difference", "/library/Author", "/library/author/Series/Title", true},
+		{"upper vs lower root", "/Library/AUTHOR", "/library/author/Title", true},
+		{"same dir is not containment", "/library/Author", "/library/Author", false},
+		{"sibling", "/library/Author", "/library/Authors", false},
+		{"sibling differing in case only", "/library/Author", "/library/AUTHORS", false},
+		{"parent", "/library/Author/Book", "/library/Author", false},
+		{"unrelated", "/library/A", "/other/B", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dirContains(tc.dir, tc.p); got != tc.want {
+				t.Errorf("dirContains(%q, %q) = %v, want %v", tc.dir, tc.p, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -473,7 +473,23 @@ var ErrDestInsideSource = errors.New("destination is inside the source directory
 // dirContains reports whether p is lexically nested strictly inside dir. Purely
 // path-based (the destination normally does not exist yet), matching how the
 // rest of the importer reasons about containment.
+//
+// Compared case-insensitively as well as exactly, because the filesystem
+// underneath decides what "same directory" means and we cannot see it from
+// here: on APFS or a Windows bind mount, /library/Author and /library/author
+// are one directory, and a case-only difference between source and destination
+// would otherwise slip past into the runaway this guard exists to stop. The
+// cost of the extra check on a case-sensitive filesystem is refusing a move
+// between two genuinely distinct directories whose paths differ only in case —
+// a pathological library layout, and refusing it is the safe direction.
 func dirContains(dir, p string) bool {
+	if containsExact(dir, p) {
+		return true
+	}
+	return containsExact(strings.ToLower(dir), strings.ToLower(p))
+}
+
+func containsExact(dir, p string) bool {
 	rel, err := filepath.Rel(filepath.Clean(dir), filepath.Clean(p))
 	if err != nil || rel == "." {
 		return false
@@ -603,6 +619,15 @@ func HardlinkDir(src, dst string) error {
 	}
 	if _, err := os.Stat(dst); err == nil {
 		return fmt.Errorf("destination already exists: %s", dst)
+	}
+	// Same hazard as the copy path (#1809): hardlinkDirRooted MkdirAlls the
+	// destination and then walks the source, so a destination nested inside the
+	// source would descend into the tree it is creating and recurse until the
+	// inode table or the path length gives out. Not reachable from reorganize —
+	// that path never hardlinks — but the primitive is exported and the guard
+	// costs one comparison.
+	if dirContains(src, dst) {
+		return fmt.Errorf("%w: %s is inside %s", ErrDestInsideSource, dst, src)
 	}
 	if err := os.MkdirAll(dst, 0o750); err != nil {
 		return fmt.Errorf("create dest dir: %w", err)


### PR DESCRIPTION
Both follow-ups #1863's review deliberately left open. **Stacked on `fix/1809-reorganize-dest-inside-source`** — merge that one first.

## 1. `HardlinkDir` had the identical hazard

`hardlinkDirRooted` MkdirAlls the destination and then walks the source, so a nested destination recurses into the tree it is creating. Not reachable from reorganize (which never hardlinks), which is why it was out of scope for the fix — but the primitive is exported, and the guard is one comparison against a disk-filling failure.

## 2. `dirContains` now compares case-insensitively

The filesystem decides what "same directory" means and this code cannot see it. On APFS or a Windows bind mount, `/library/Author` and `/library/author` are **one directory** — so a case-only difference between source and destination walked straight past the guard into the runaway it exists to stop.

The cost on a case-sensitive filesystem is refusing a move between two genuinely distinct directories whose paths differ only in case. That's a pathological layout, and refusing it is the safe direction; the alternative is filling the disk.

## Tests

`TestHardlinkDirRefusesDstInsideSrc` — sentinel returned, **nothing created** (the guard runs before `MkdirAll`), source intact.

`TestDirContainsIsCaseInsensitiveToo` — eight cases including the ones that must stay `false`: same dir, sibling, **sibling differing only in case** (`/library/Author` vs `/library/AUTHORS`), parent, unrelated.

Full `internal/importer` package green (12.3s), `go vet` clean.