### PR TITLE
fix(importer): fold case in the destination-inside-source check

### DIFF
--- a/changelog.d/1809-case-insensitive-containment.md
+++ b/changelog.d/1809-case-insensitive-containment.md
@@ -1,0 +1,6 @@
+- **Directory-move containment check now folds case**
+  ([#1809](https://github.com/vavallee/bindery/issues/1809)) — on a
+  case-insensitive filesystem (APFS, a Windows bind mount) a destination
+  differing from the source only in case is the same directory, so the move was
+  still able to recurse into its own output. Symlink resolution does not
+  normalise case, so the comparison now runs folded as well as exact.

--- a/internal/importer/movedir_test.go
+++ b/internal/importer/movedir_test.go
@@ -74,3 +74,39 @@ func mustWrite(t *testing.T, path, content string) {
 		t.Fatal(err)
 	}
 }
+
+// The filesystem decides what "same directory" means and checkDestNotInsideSource
+// cannot see which one it is standing on. On APFS or a Windows bind mount
+// /library/Author and /library/author are one directory, so a destination
+// differing from the source only in case is the nesting this guard exists to
+// refuse — and EvalSymlinks does not normalise case, so resolving misses it.
+func TestDestInsideSourceIsCaughtAcrossCase(t *testing.T) {
+	for _, tc := range []struct {
+		name, src, dst string
+		wantErr        bool
+	}{
+		{"exact nesting", "/library/Author", "/library/Author/Series/Title", true},
+		{"case-only difference", "/library/Author", "/library/author/Series/Title", true},
+		{"upper source, lower dest", "/Library/AUTHOR", "/library/author/Title", true},
+
+		// Must stay allowed: these are not containment, in any case-folding.
+		{"same path", "/library/Author", "/library/Author", false},
+		{"same path, case-only", "/library/Author", "/library/author", false},
+		{"sibling", "/library/Author", "/library/Authors", false},
+		{"sibling, case-only", "/library/Author", "/library/AUTHORS", false},
+		{"parent", "/library/Author/Book", "/library/Author", false},
+		{"unrelated", "/library/A", "/other/B", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkDestNotInsideSource("move", tc.src, tc.dst)
+			if tc.wantErr && !errors.Is(err, ErrDestInsideSource) {
+				t.Errorf("checkDestNotInsideSource(%q, %q) = %v, want ErrDestInsideSource",
+					tc.src, tc.dst, err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("checkDestNotInsideSource(%q, %q) refused a legal move: %v",
+					tc.src, tc.dst, err)
+			}
+		})
+	}
+}

--- a/internal/importer/renamer.go
+++ b/internal/importer/renamer.go
@@ -504,17 +504,40 @@ func dirContains(dir, p string) bool {
 // same-path move (ReorgStatusNoop) before it ever reaches these primitives.
 func checkDestNotInsideSource(op, src, dst string) error {
 	rsrc, rdst := resolveForContainment(src), resolveForContainment(dst)
-	if rsrc == rdst {
-		return nil
+	if nested(rsrc, rdst) || nested(strings.ToLower(rsrc), strings.ToLower(rdst)) {
+		return fmt.Errorf("cannot %s %q into %q: %w; choose a destination that is not nested under the source folder", op, src, dst, ErrDestInsideSource)
 	}
-	rel, err := filepath.Rel(rsrc, rdst)
+	return nil
+}
+
+// nested reports whether dst lies strictly inside src, comparing on path
+// component boundaries.
+//
+// Called twice by checkDestNotInsideSource: once on the resolved paths and once
+// lowercased. The filesystem decides what "same directory" means and this code
+// cannot see which one it is standing on — on APFS or a Windows bind mount
+// /library/Author and /library/author are one directory, so a template that
+// differs from the source only in case produces exactly the nesting the guard
+// exists to refuse, and the exact comparison walks straight past it.
+//
+// EvalSymlinks does not normalise case, so resolving does not cover this.
+//
+// On a case-sensitive filesystem the extra pass costs one thing: a move between
+// two genuinely distinct directories whose paths differ only in case is
+// refused. That is a pathological library layout, and refusing it is the safe
+// direction — the alternative is filling the disk.
+func nested(src, dst string) bool {
+	if src == dst {
+		// Not nesting. A same-path move is a distinct case with nothing to do,
+		// reported by the callers' existing "destination already exists" check
+		// and by the reorganize layer as a noop.
+		return false
+	}
+	rel, err := filepath.Rel(src, dst)
 	if err != nil {
-		return nil // different volumes: cannot be nested
+		return false // different volumes: cannot be nested
 	}
-	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return nil
-	}
-	return fmt.Errorf("cannot %s %q into %q: %w; choose a destination that is not nested under the source folder", op, src, dst, ErrDestInsideSource)
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // resolveForContainment returns p in absolute, symlink-resolved form for the


### PR DESCRIPTION
The one gap left after #1865, verified empirically against current `main`:

```go
checkDestNotInsideSource("move", "/library/Author", "/library/author/Series/Title")
→ nil        // not caught
```

`resolveForContainment` resolves symlinks, but `EvalSymlinks` does not normalise case — and the filesystem decides what "same directory" means. On APFS or a Windows bind mount those two paths are **one directory**, so a naming template differing from the source only in case produces exactly the nesting the guard exists to refuse.

`checkDestNotInsideSource` now compares folded as well as exact. The containment test moves into a `nested` helper called twice, which also folds the previous `src == dst` early-return into the single place that decides what counts as nesting.

**Tradeoff:** on a case-sensitive filesystem this refuses a move between two genuinely distinct directories whose paths differ only in case. Pathological layout; refusing is the safe direction, since the alternative is filling the disk.

Nine test cases pin both directions — including the ones that must stay allowed: same path, **same path differing only in case**, sibling, **sibling differing only in case** (`/library/Author` → `/library/AUTHORS`), parent, and different volumes.

---

Supersedes #1873, which I've closed: its `HardlinkDir` guard is redundant now that #1865 guards all three entry points, and its `dirContains` change targeted the wrong function.