### PR TITLE
fix(hardcover): drop the _ilike arm the API rejects with 403

### DIFF
--- a/changelog.d/1733-hardcover-ilike-403.md
+++ b/changelog.d/1733-hardcover-ilike-403.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Author metadata refresh works again against Hardcover** — the author-role filter added for the narrator-as-author fix used an `_ilike` pattern arm, and Hardcover's API rejects pattern operators outright with `403 ilike and related operations are not permitted on this server`. That is a hard request failure rather than a missed match, so every per-author "Refresh Metadata" and every "Refresh All" against a Hardcover-linked author would have failed. The filter now uses `_in` with the literal spellings, which is the widest operator the server allows on that field.

--- a/internal/metadata/hardcover/client.go
+++ b/internal/metadata/hardcover/client.go
@@ -637,10 +637,21 @@ type hcContribution struct {
 // keeps only author-role rows. It must accept a null/empty role: on Hardcover
 // the primary author's contribution row almost never sets `contribution`, so a
 // bare `{contribution: {_eq: "Author"}}` matches nearly nothing and would
-// silently return an empty result set (#1733). The `_ilike` arm has no
-// wildcard prefix, so it matches "Author", "author" and compounds such as
-// "Author/Narrator" without matching "Narrator" or "Translator".
-const authorContributionFilter = `_or: [{contribution: {_is_null: true}}, {contribution: {_eq: ""}}, {contribution: {_ilike: "author%"}}]`
+// silently return an empty result set (#1733). Verified live: on "Blackflame"
+// the narrator's row reads `contribution: "Narrator"` while Will Wight's own
+// row is null.
+//
+// The explicit spellings are NOT decoration and NOT reachable by a pattern
+// match. Hardcover's server rejects pattern operators outright —
+//
+//	{"error":"ilike and related operations are not permitted on this server."}  (HTTP 403)
+//
+// — so an `_ilike: "author%"` arm does not merely fail to match, it fails the
+// whole request, which would take down every per-author "Refresh Metadata" and
+// "Refresh All" run. `_in` is the widest operator the server actually allows
+// here. A literal "Author" is rare but real (verified live), so the arm earns
+// its place: without it those authors' catalogues come back empty.
+const authorContributionFilter = `_or: [{contribution: {_is_null: true}}, {contribution: {_eq: ""}}, {contribution: {_in: ["Author", "author", "AUTHOR"]}}]`
 
 // isAuthorContributionRole mirrors authorContributionFilter client-side. An
 // empty role means "author" both because Hardcover leaves the primary author's

--- a/internal/metadata/hardcover/client_test.go
+++ b/internal/metadata/hardcover/client_test.go
@@ -2544,10 +2544,20 @@ func TestGetAuthorWorksByName_FiltersToAuthorContributionRole(t *testing.T) {
 	for _, want := range []string{
 		`{contribution: {_is_null: true}}`,
 		`{contribution: {_eq: ""}}`,
-		`{contribution: {_ilike: "author%"}}`,
+		`{contribution: {_in: ["Author", "author", "AUTHOR"]}}`,
 	} {
 		if !strings.Contains(gotQuery, want) {
 			t.Fatalf("author-works role filter missing %s: %s", want, gotQuery)
+		}
+	}
+	// Hardcover's server refuses pattern operators outright, with HTTP 403
+	// "ilike and related operations are not permitted on this server." An
+	// _ilike arm therefore does not degrade to a missed match, it fails the
+	// entire request — taking every per-author refresh with it. Verified live
+	// against api.hardcover.app.
+	for _, banned := range []string{"_ilike", "_like", "_similar", "_iregex", "_regex"} {
+		if strings.Contains(gotQuery, banned) {
+			t.Fatalf("author-works query uses %s, which Hardcover rejects with 403: %s", banned, gotQuery)
 		}
 	}
 	requireSelectsContributionRole(t, gotQuery)


### PR DESCRIPTION
## The problem

#1869 (merged) added an author-role filter whose third arm is `{contribution: {_ilike: "author%"}}`. Hardcover's API refuses pattern operators:

```
POST https://api.hardcover.app/v1/graphql
→ HTTP 403
{"error":"ilike and related operations are not permitted on this server."}
```

That is a **hard request failure**, not a missed match. `GetAuthorWorksByName` backs per-author **Refresh Metadata** and **Refresh All**, so on current `main` both would fail for every Hardcover-linked author.

Reproduced by running the merged `authorContributionFilter` constant verbatim against the live API with a real token.

## Why it got through

#1869 could not be verified live (no token in that environment). The operator set was taken from Hardcover's generated `schema.graphql`, where `String_comparison_exp` does expose `_ilike` — the schema advertises it and the **server** blocks it at runtime.

## The fix

`_in` with the literal spellings, the widest operator the server allows on this field.

## Verified live

The premise behind #1869 holds — confirmed on the exact book from the report, `Blackflame` (id 446665):

| contribution | author |
|---|---|
| `"Narrator"` | Travis Baldree ← **listed first** |
| `null` | Will Wight ← the real author |

So `Contributions[0]` really was the narrator, and the primary author's role really is null. A bare `_eq: "Author"` would have matched nothing here and dropped the author entirely.

With the `_in` filter, all HTTP 200:

| author | result |
|---|---|
| Will Wight | his own Cradle books |
| Travis Baldree | the books he **wrote** (Legends & Lattes + translations), not the ones he narrated |
| Stephen Hackett | 2 books — one of the rare rows where `contribution` literally reads `"Author"`, so the `_in` arm is load-bearing, not decoration |

## Test

The query-text assertion now pins the `_in` arm, plus a new guard rejecting `_ilike`/`_like`/`_similar`/`_regex`/`_iregex` in that query so this cannot come back.

Refs #1733.