### PR TITLE
fix(authors): stamp the author's real owner on synced books

### DIFF
--- a/changelog.d/1872-author-sync-owner.md
+++ b/changelog.d/1872-author-sync-owner.md
@@ -1,0 +1,17 @@
+### Fixed
+- **Books created by an author sync now belong to the user who added the author**
+  ([#1872](https://github.com/vavallee/bindery/issues/1872)) — `CreateForUser`
+  wrote `owner_user_id` to the `authors` row but never set it on the struct it
+  returned, so the catalogue sync stamped owner `0` onto every book it created.
+  A `0` owner is stored as NULL, which per-user scoping reads as "shared", so on
+  a multi-user install one user's whole catalogue was visible to every other
+  account. The repo now reflects the persisted owner back onto the author, and
+  the sync re-reads the author row before its insert loop so a stale snapshot
+  can no longer carry the wrong owner into new books. Migration
+  `074_backfill_book_owner_from_author.sql` repairs the rows already written: a
+  NULL-owned book under an owned author inherits that author's owner. Books
+  under a NULL-owned author are left alone, so deliberately shared content and
+  pre-multi-user libraries are untouched. On a multi-user install this will
+  remove books from other users' views — that is the fix working. The issue was
+  reported as the allowed-languages filter dropping books; the language filter
+  was not involved.

--- a/internal/api/authors.go
+++ b/internal/api/authors.go
@@ -1520,10 +1520,24 @@ func (h *AuthorHandler) fetchAuthorBooks(author *models.Author, autoSearch bool,
 	// times out and the direct insert didn't land (#804, #1559), and a user
 	// can delete the author mid-refresh. Bail out instead of running an
 	// insert loop where every row fails the author_id FK constraint.
-	if current, err := h.authors.GetByID(ctx, author.ID); err == nil && current == nil {
-		slog.Info("author deleted while catalogue fetch was running; aborting sync",
-			"author", author.Name, "authorId", author.ID)
-		return
+	if current, err := h.authors.GetByID(ctx, author.ID); err == nil {
+		if current == nil {
+			slog.Info("author deleted while catalogue fetch was running; aborting sync",
+				"author", author.Name, "authorId", author.ID)
+			return
+		}
+		// This re-read is also the last chance to correct a stale owner before
+		// the insert loop stamps it onto every new book. `author` is a
+		// caller-supplied snapshot whose OwnerUserID may never have matched the
+		// row, and the row itself can be re-owned between the snapshot and here.
+		// The persisted value is the only one that satisfies the books.owner_user_id
+		// foreign key and the only one per-user scoping will agree with (#1872).
+		if author.OwnerUserID != current.OwnerUserID {
+			slog.Debug("catalogue sync adopting the author row's persisted owner",
+				"author", author.Name, "authorId", author.ID,
+				"snapshotOwner", author.OwnerUserID, "persistedOwner", current.OwnerUserID)
+			author.OwnerUserID = current.OwnerUserID
+		}
 	}
 
 	// Track titles we've already added (case-insensitive) to avoid OL duplicates.

--- a/internal/api/authors_test.go
+++ b/internal/api/authors_test.go
@@ -4375,13 +4375,29 @@ func TestAddBook_ExistingAuthorDirectInsertWhenSyncSkipsWork(t *testing.T) {
 	profileRepo := db.NewMetadataProfileRepo(database)
 
 	ctx := context.Background()
-	// The author is already in the library, added long before this request.
+	// The author is already in the library, added long before this request, and
+	// belongs to a real user — which is what every author on a multi-user
+	// install looks like.
+	//
+	// The owner is not incidental to this test. Seeding it through
+	// CreateForUser (with a users row to satisfy the books.owner_user_id
+	// foreign key) is what makes the tenancy assertion at the bottom mean
+	// something: against a zero-owned author it compared 0 to 0 and would have
+	// passed with tenancy inheritance deleted outright (#1760, #1843). Setting
+	// the struct field alone does not work — Create writes NULL regardless.
+	owner, err := db.NewUserRepo(database).Create(ctx, "reader", "hash")
+	if err != nil {
+		t.Fatal(err)
+	}
 	author := &models.Author{
 		ForeignID: "OL23919A", Name: "J. K. Rowling", SortName: "Rowling, J. K.",
 		MetadataProvider: "openlibrary", Monitored: true,
 	}
-	if err := authorRepo.Create(ctx, author); err != nil {
+	if err := authorRepo.CreateForUser(ctx, author, owner.ID); err != nil {
 		t.Fatal(err)
+	}
+	if author.OwnerUserID == 0 {
+		t.Fatal("fixture: the author must be owned, or the tenancy assertion below is vacuous")
 	}
 
 	// The catalogue sync sees the requested work tagged with a language the
@@ -4453,8 +4469,13 @@ func TestAddBook_ExistingAuthorDirectInsertWhenSyncSkipsWork(t *testing.T) {
 		t.Errorf("explicit media type should win, got %q", got.MediaType)
 	}
 	// Tenancy (#1457): the direct-inserted row inherits the author's owner.
+	// Asserted against the literal seeded owner, not just author.OwnerUserID,
+	// so this cannot go vacuous again if the fixture's owner regresses to 0.
+	if got.OwnerUserID != owner.ID {
+		t.Errorf("book owner = %d, want the author's owner %d", got.OwnerUserID, owner.ID)
+	}
 	if got.OwnerUserID != author.OwnerUserID {
-		t.Errorf("book owner = %d, want the author's owner %d", got.OwnerUserID, author.OwnerUserID)
+		t.Errorf("book owner = %d, author owner = %d", got.OwnerUserID, author.OwnerUserID)
 	}
 
 	// The explicit add must not resurrect anything the user did NOT pick:
@@ -5352,5 +5373,137 @@ func TestAddBook_DirectInsertRejectsUnusableTitle(t *testing.T) {
 				t.Fatalf("unusable title %q must not be inserted, got %d row(s): %q", tc.title, len(rows), rows[0].Title)
 			}
 		})
+	}
+}
+
+// TestFetchAuthorBooks_NewBooksInheritThePersistedOwner is the production-facing
+// half of #1872.
+//
+// The reported symptom was books vanishing from an owned author's catalogue,
+// blamed on the allowed-languages filter. The filter is innocent. The author
+// snapshot handed to the sync carried the wrong owner, because
+// AuthorRepo.CreateForUser wrote owner_user_id to the row but never reflected
+// it back onto the struct — so `b.OwnerUserID = author.OwnerUserID` in the
+// insert loop stamped 0 onto every new book.
+//
+// Zero means NULL means "shared" to every per-user query in the codebase, so a
+// multi-user install silently published one user's whole catalogue to all the
+// others.
+//
+// This pins the end-to-end invariant, not one layer's mechanism: the fix has a
+// write-back in CreateForUser AND an owner re-read in FetchAuthorBooks, and
+// either alone satisfies this test. TestAuthorCreateForUser_ReflectsPersistedOwner
+// pins the write-back on its own; the stale-snapshot test below pins the re-read.
+func TestFetchAuthorBooks_NewBooksInheritThePersistedOwner(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	ctx := context.Background()
+	owner, err := db.NewUserRepo(database).Create(ctx, "owner", "hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OL23919A", Name: "J. K. Rowling", SortName: "Rowling, J. K.",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.CreateForUser(ctx, author, owner.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	stub := &stubMetaProvider{
+		name: "openlibrary",
+		works: []models.Book{
+			{ForeignID: "OL82563W", Title: "Harry Potter and the Prisoner of Azkaban", SortTitle: "harry potter and the prisoner of azkaban", Language: "eng", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+		},
+	}
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(stub), nil, profileRepo, nil)
+	h.FetchAuthorBooks(author, false, "")
+
+	got, err := bookRepo.GetByForeignID(ctx, "OL82563W")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("the catalogue sync created no book at all")
+	}
+	if got.OwnerUserID != owner.ID {
+		t.Fatalf("book owner = %d, want the author's owner %d — a 0 here is a NULL-owned row every user on the install can see",
+			got.OwnerUserID, owner.ID)
+	}
+}
+
+// TestFetchAuthorBooks_AdoptsPersistedOwnerOverStaleSnapshot covers the second
+// half of the #1872 fix, independently of who wrote the snapshot.
+//
+// FetchAuthorBooks already re-reads the author row before its insert loop (to
+// abort when the row was deleted mid-fetch) but used only the nil check and
+// discarded the row. Any snapshot whose owner disagrees with the row — a stale
+// copy, a re-owned author, or the CreateForUser gap above — therefore stamped
+// the wrong owner on every book.
+//
+// The wrong owner is not merely mislabelled. books.owner_user_id is
+// `REFERENCES users(id)`, so a snapshot naming a user that does not exist makes
+// every insert fail the foreign key: the sync logs one WARN per work, adds
+// nothing, and the catalogue looks empty for reasons the log line about the
+// language filter does not explain. That is exactly the failure #1843 hit.
+func TestFetchAuthorBooks_AdoptsPersistedOwnerOverStaleSnapshot(t *testing.T) {
+	database, err := db.OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	database.SetMaxOpenConns(1)
+
+	ctx := context.Background()
+	owner, err := db.NewUserRepo(database).Create(ctx, "owner", "hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authorRepo := db.NewAuthorRepo(database)
+	bookRepo := db.NewBookRepo(database)
+	profileRepo := db.NewMetadataProfileRepo(database)
+
+	author := &models.Author{
+		ForeignID: "OL23919A", Name: "J. K. Rowling", SortName: "Rowling, J. K.",
+		MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := authorRepo.CreateForUser(ctx, author, owner.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// The snapshot names a user id that was never created. Before the fix this
+	// reached books.Create verbatim and every insert died on the FK.
+	stale := *author
+	stale.OwnerUserID = owner.ID + 999
+
+	stub := &stubMetaProvider{
+		name: "openlibrary",
+		works: []models.Book{
+			{ForeignID: "OL82563W", Title: "Harry Potter and the Prisoner of Azkaban", SortTitle: "harry potter and the prisoner of azkaban", Language: "eng", Status: models.BookStatusWanted, Genres: []string{}, MetadataProvider: "openlibrary"},
+		},
+	}
+	h := NewAuthorHandler(authorRepo, nil, bookRepo, nil, metadata.NewAggregator(stub), nil, profileRepo, nil)
+	h.FetchAuthorBooks(&stale, false, "")
+
+	got, err := bookRepo.GetByForeignID(ctx, "OL82563W")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("no book created — the stale owner failed the books.owner_user_id foreign key")
+	}
+	if got.OwnerUserID != owner.ID {
+		t.Fatalf("book owner = %d, want the author row's persisted owner %d", got.OwnerUserID, owner.ID)
 	}
 }

--- a/internal/db/authors.go
+++ b/internal/db/authors.go
@@ -382,6 +382,15 @@ func (r *AuthorRepo) CreateForUser(ctx context.Context, a *models.Author, ownerU
 	a.ID = id
 	a.CreatedAt = now
 	a.UpdatedAt = now
+	// Reflect the persisted owner back onto the struct, exactly as
+	// QualityProfileRepo.CreateForUser and MetadataProfileRepo.CreateForUser
+	// already do. Without this the caller holds an author it believes is
+	// NULL-owned while the row is owned by ownerUserID, and every downstream
+	// use of that snapshot inherits the wrong tenancy: FetchAuthorBooks copies
+	// author.OwnerUserID onto each book it creates, so an author added by user
+	// 7 produced a whole catalogue of NULL-owned (globally visible) book rows
+	// (#1872).
+	a.OwnerUserID = ownerUserID
 	if err := r.upsertIdentifierTx(ctx, tx, a.ID, a.ForeignID, now); err != nil {
 		return err
 	}

--- a/internal/db/authors_test.go
+++ b/internal/db/authors_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 	"testing"
@@ -666,5 +667,167 @@ func TestAuthorDeleteCleansIdentifiersWithoutCascade(t *testing.T) {
 	}
 	if err := repo.UpsertAuthorIdentifier(ctx, b.ID, "hc:delete-me"); err != nil {
 		t.Fatalf("re-attach identifier after delete: %v", err)
+	}
+}
+
+// TestAuthorCreateForUser_ReflectsPersistedOwner pins the write-back that
+// #1872 was missing.
+//
+// CreateForUser already reflects the row's generated id and timestamps back
+// onto the caller's struct — UserRepo.Create does the same with SessionEpoch,
+// for the stated reason that the in-memory value must match the row that was
+// just written. owner_user_id was the one column left out, so a caller held an
+// author it believed was NULL-owned while the row belonged to ownerUserID.
+//
+// That gap is not cosmetic: AuthorHandler.FetchAuthorBooks stamps
+// author.OwnerUserID onto every book it creates, so an author added by a real
+// user produced an entire catalogue of NULL-owned rows, which per-user scoping
+// treats as shared and shows to every account on the install.
+func TestAuthorCreateForUser_ReflectsPersistedOwner(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	owner, err := NewUserRepo(database).Create(ctx, "owner", "hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewAuthorRepo(database)
+	a := &models.Author{ForeignID: "OL_OWNED_A", Name: "Owned Author", SortName: "Author, Owned"}
+	if err := repo.CreateForUser(ctx, a, owner.ID); err != nil {
+		t.Fatal(err)
+	}
+	if a.OwnerUserID != owner.ID {
+		t.Fatalf("in-memory owner = %d, want %d — the struct disagrees with the row it just wrote", a.OwnerUserID, owner.ID)
+	}
+
+	persisted, err := repo.GetByID(ctx, a.ID)
+	if err != nil || persisted == nil {
+		t.Fatalf("read back author: err=%v got=%v", err, persisted)
+	}
+	if persisted.OwnerUserID != a.OwnerUserID {
+		t.Fatalf("persisted owner = %d, in-memory owner = %d", persisted.OwnerUserID, a.OwnerUserID)
+	}
+}
+
+// TestAuthorCreate_ReportsTheNullOwnerItWrote is the other half of the same
+// invariant, and the reason the #1843 fixture could not be made non-vacuous by
+// setting the struct field alone.
+//
+// Create is the system-owned constructor: it hard-codes ownerUserID 0 and
+// writes NULL, ignoring whatever the caller put in a.OwnerUserID. Silently
+// discarding that value is what made the drift invisible, so Create now
+// reports the owner it actually persisted. A caller that wants an owned author
+// must use CreateForUser.
+func TestAuthorCreate_ReportsTheNullOwnerItWrote(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	repo := NewAuthorRepo(database)
+	a := &models.Author{ForeignID: "OL_UNOWNED_A", Name: "Unowned", SortName: "Unowned", OwnerUserID: 7}
+	if err := repo.Create(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	if a.OwnerUserID != 0 {
+		t.Fatalf("in-memory owner = %d after Create, want 0 — Create writes NULL and must say so", a.OwnerUserID)
+	}
+
+	persisted, err := repo.GetByID(ctx, a.ID)
+	if err != nil || persisted == nil {
+		t.Fatalf("read back author: err=%v got=%v", err, persisted)
+	}
+	if persisted.OwnerUserID != 0 {
+		t.Fatalf("persisted owner = %d, want 0", persisted.OwnerUserID)
+	}
+}
+
+// TestMigration074_BackfillsBookOwnerFromAuthor pins the repair migration for
+// the rows #1872 already wrote.
+//
+// Three shapes have to come out differently:
+//   - an owned author's NULL-owned book is adopted (the bug's signature)
+//   - a NULL-owned author's NULL-owned book is left NULL (deliberately shared
+//     content, and legacy pre-multi-user data; there is no owner to inherit)
+//   - a book that already has an owner is never re-pointed, including to a
+//     different user than its author's
+func TestMigration074_BackfillsBookOwnerFromAuthor(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	ctx := context.Background()
+	users := NewUserRepo(database)
+	alice, err := users.Create(ctx, "alice", "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bob, err := users.Create(ctx, "bob", "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authors := NewAuthorRepo(database)
+	owned := &models.Author{ForeignID: "OL_OWNED", Name: "Owned", SortName: "Owned"}
+	if err := authors.CreateForUser(ctx, owned, alice.ID); err != nil {
+		t.Fatal(err)
+	}
+	shared := &models.Author{ForeignID: "OL_SHARED", Name: "Shared", SortName: "Shared"}
+	if err := authors.Create(ctx, shared); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write the three rows straight to SQL: the point is the state on disk
+	// after the buggy code ran, which the repaired repo can no longer produce.
+	insert := func(foreignID string, authorID int64, owner any) {
+		t.Helper()
+		if _, err := database.ExecContext(ctx,
+			`INSERT INTO books (foreign_id, author_id, title, sort_title, status, owner_user_id, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, 'wanted', ?, datetime('now'), datetime('now'))`,
+			foreignID, authorID, foreignID, foreignID, owner); err != nil {
+			t.Fatal(err)
+		}
+	}
+	insert("B_ORPHANED", owned.ID, nil)   // the bug: owned author, NULL book
+	insert("B_SHARED", shared.ID, nil)    // no owner to inherit
+	insert("B_ALREADY", owned.ID, bob.ID) // already attributed, to someone else
+
+	// OpenMemory already ran 074 at open, before these rows existed. Re-apply
+	// the real file (not a hand-copied query) against the state above.
+	migration, err := migrationsFS.ReadFile("migrations/074_backfill_book_owner_from_author.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.ExecContext(ctx, string(migration)); err != nil {
+		t.Fatalf("apply migration 074: %v", err)
+	}
+
+	ownerOf := func(foreignID string) (int64, bool) {
+		t.Helper()
+		var owner sql.NullInt64
+		if err := database.QueryRowContext(ctx,
+			"SELECT owner_user_id FROM books WHERE foreign_id=?", foreignID).Scan(&owner); err != nil {
+			t.Fatal(err)
+		}
+		return owner.Int64, owner.Valid
+	}
+
+	if got, ok := ownerOf("B_ORPHANED"); !ok || got != alice.ID {
+		t.Errorf("orphaned book owner = %d (set=%v), want alice %d", got, ok, alice.ID)
+	}
+	if _, ok := ownerOf("B_SHARED"); ok {
+		t.Error("a NULL-owned author's book must stay NULL-owned — nothing to inherit")
+	}
+	if got, ok := ownerOf("B_ALREADY"); !ok || got != bob.ID {
+		t.Errorf("already-owned book owner = %d (set=%v), want bob %d untouched", got, ok, bob.ID)
 	}
 }

--- a/internal/db/migrations/074_backfill_book_owner_from_author.sql
+++ b/internal/db/migrations/074_backfill_book_owner_from_author.sql
@@ -1,0 +1,23 @@
+-- +migrate Up
+-- Repair the books an author sync mis-attributed under #1872.
+--
+-- AuthorRepo.CreateForUser wrote owner_user_id to the authors row but never set
+-- it on the struct it handed back, so AuthorHandler.FetchAuthorBooks copied a
+-- zero owner onto every book it created. Zero is persisted as NULL, and NULL is
+-- what every per-user query in this codebase treats as "shared", so on a
+-- multi-user install the books belonging to one user's authors were listed for
+-- all of them. The code fix stops new rows from landing this way; it cannot
+-- restore the owner on the rows already written.
+--
+-- A NULL-owned book hanging off an owned author is that bug's signature. It is
+-- not the shape of legacy data: migration 025 backfilled authors and books
+-- together, so a pre-multi-user install has them agreeing (both user 1, or both
+-- NULL). Deliberately shared content is NULL-owned on BOTH rows and is left
+-- alone by the author-side predicate.
+--
+-- Books under a NULL-owned author are untouched — there is no owner to inherit
+-- and guessing one would take content away from whoever can currently see it.
+UPDATE books
+SET owner_user_id = (SELECT a.owner_user_id FROM authors a WHERE a.id = books.author_id)
+WHERE owner_user_id IS NULL
+  AND author_id IN (SELECT id FROM authors WHERE owner_user_id IS NOT NULL);


### PR DESCRIPTION
## What this is

`#1872` was reported as the allowed-languages filter dropping books from an owned author's catalogue. The language filter is innocent. The real defect is a tenancy one, and it is worse than the reported symptom.

`AuthorRepo.CreateForUser` writes `owner_user_id` to the `authors` row but never sets it on the struct it hands back. `QualityProfileRepo.CreateForUser` and `MetadataProfileRepo.CreateForUser` both already do this (`quality_profiles.go:117`, `metadata_profiles.go:106`), and `UserRepo.Create` does the same for `SessionEpoch` with a comment giving the exact reason. `AuthorRepo` was the one that skipped it.

`AuthorHandler.FetchAuthorBooks` stamps `author.OwnerUserID` onto every book it creates (`authors.go:1788`). So an author added by user 7 got a whole catalogue of owner-0 books. Zero is persisted as NULL, and NULL is what every per-user query in this codebase treats as shared, so **on a multi-user install one user's books were listed for every other account**.

Both entry points are affected: `AddAuthor` (`authors.go:399`) and `AddBook`'s author side effect (`authors.go:2286`), plus the direct insert at `authors.go:2374`.

## The #1843 connection

`#1843` gave the fixture author `OwnerUserID: 7` and its `validate (Go)` went red. That red run was the PR working. `AuthorRepo.Create` writes NULL regardless of the struct field, so the fixture held an author claiming owner 7 against a row owning nothing, no `users` row 7 existed, and every book insert died on the `books.owner_user_id` foreign key:

```
WARN failed to create book title="Harry Potter and the Prisoner of Azkaban" error="create book: constraint failed: FOREIGN KEY constraint failed (787)"
INFO author books synced added=0 skipped_language=1 skipped_junk=1 skipped_media_type=0 total=3
```

`skipped_language=1` is the correct skip of the Spanish work the fixture wants skipped. The missing book is the FK failure, which produces one WARN and no error anywhere the user can see.

## Changes

- **`internal/db/authors.go`** — `CreateForUser` sets `a.OwnerUserID = ownerUserID` after the insert. `Create` still writes NULL and now reports that, rather than silently discarding a caller-set value.
- **`internal/api/authors.go`** — `FetchAuthorBooks` already re-read the author row before its insert loop (to abort on a mid-fetch delete) but used only the nil check and threw the row away. It now adopts the persisted owner, so any stale snapshot is corrected before it reaches a book.
- **`internal/db/migrations/074_backfill_book_owner_from_author.sql`** — repairs rows already written. A NULL-owned book under an owned author inherits that owner. Books under a NULL-owned author are left alone, so deliberately shared content and pre-multi-user libraries (migration 025 backfilled authors and books together, so they agree) are untouched.

Either code change alone fixes the common case. The `FetchAuthorBooks` one additionally covers any stale snapshot, including the FK failure above; the `CreateForUser` one is load-bearing for `AddBook`'s direct insert, which does not go through that re-read.

## Tradeoff, stated

Migration 074 will **remove books from other users' views** on an affected multi-user install. That is the fix, but it is a visible change for anyone who had been browsing another user's catalogue without realising it. Single-user installs see nothing: everything is owner 1 or NULL, and `ListByUser` includes NULL.

## #1843's assertion, delivered

`TestAddBook_ExistingAuthorDirectInsertWhenSyncSkipsWork` now seeds a real `users` row and creates the author through `CreateForUser`, which is what the fixture needed to work. The assertion compares against that literal owner. Deleting `primary.OwnerUserID = author.OwnerUserID` from `authors.go` now fails it:

```
authors_test.go:4475: book owner = 0, want the author's owner 1
```

That is exactly what AshSgDe set out to pin in #1843, on a green run.

## Verification

Every test here was mutation-tested — the fix reverted, the test confirmed failing, the fix restored:

| Test | Mutation | Result |
|---|---|---|
| `TestAuthorCreateForUser_ReflectsPersistedOwner` | drop the write-back | fails |
| `TestAuthorCreate_ReportsTheNullOwnerItWrote` | drop the write-back | fails |
| `TestFetchAuthorBooks_AdoptsPersistedOwnerOverStaleSnapshot` | drop the sync adoption | fails, no book created |
| `TestMigration074_BackfillsBookOwnerFromAuthor` | neuter the UPDATE | fails |
| `TestMigration074_BackfillsBookOwnerFromAuthor` | drop the author-owned guard | fails, re-points an already-owned book |
| `TestAddBook_ExistingAuthorDirectInsertWhenSyncSkipsWork` | delete tenancy inheritance | fails |

`TestFetchAuthorBooks_NewBooksInheritThePersistedOwner` pins the end-to-end invariant and passes with either layer's fix alone; the comment says so rather than over-claiming.

`go build ./...`, `go test ./... -count=1` and `golangci-lint run` on `internal/db` + `internal/api` are all clean.

closes #1872
refs #1760, #1843

🤖 Generated with [Claude Code](https://claude.com/claude-code)