### PR TITLE
fix(calibre): show edition names in rollback preview (#1896)

### DIFF
--- a/changelog.d/1896-rollback-edition-display-name.md
+++ b/changelog.d/1896-rollback-edition-display-name.md
@@ -1,0 +1,5 @@
+### Fixed
+- **Calibre rollback previews show edition names**
+  ([#1896](https://github.com/vavallee/bindery/issues/1896)) — created-edition
+  rollback actions now look up the edition directly, so their display names are
+  no longer blank.

--- a/internal/calibre/import_rollback.go
+++ b/internal/calibre/import_rollback.go
@@ -642,16 +642,11 @@ func rollbackDisplayName(ctx context.Context, books *db.BookRepo, authors *db.Au
 		if editions == nil {
 			return ""
 		}
-		eds, err := editions.ListByBook(ctx, 0)
-		if err != nil {
+		e, err := editions.GetByID(ctx, entity.LocalID)
+		if err != nil || e == nil {
 			return ""
 		}
-		for _, e := range eds {
-			if e.ID == entity.LocalID {
-				return strings.TrimSpace(e.Title)
-			}
-		}
-		return ""
+		return strings.TrimSpace(e.Title)
 	default:
 		return ""
 	}

--- a/internal/calibre/import_rollback_test.go
+++ b/internal/calibre/import_rollback_test.go
@@ -139,6 +139,7 @@ func TestImporter_PreviewRollback_ReturnsExpectedActions(t *testing.T) {
 	}
 	// Preview must touch deletes for created authors/books/editions.
 	var sawAuthorDelete, sawBookDelete, sawEditionDelete bool
+	editionNames := make(map[string]bool)
 	for _, a := range preview.Actions {
 		switch {
 		case a.Action == "delete_author" && a.EntityType == entityTypeAuthor:
@@ -147,10 +148,16 @@ func TestImporter_PreviewRollback_ReturnsExpectedActions(t *testing.T) {
 			sawBookDelete = true
 		case a.Action == "delete_edition" && a.EntityType == entityTypeEdition:
 			sawEditionDelete = true
+			editionNames[a.DisplayName] = true
 		}
 	}
 	if !sawAuthorDelete || !sawBookDelete || !sawEditionDelete {
 		t.Errorf("missing planned actions: author=%v book=%v edition=%v", sawAuthorDelete, sawBookDelete, sawEditionDelete)
+	}
+	for _, want := range []string{"Book Ten", "Book Eleven"} {
+		if !editionNames[want] {
+			t.Errorf("missing edition display name %q; got %v", want, editionNames)
+		}
 	}
 }
 

--- a/internal/db/editions.go
+++ b/internal/db/editions.go
@@ -26,12 +26,31 @@ func NewEditionRepo(db *sql.DB) *EditionRepo {
 	return &EditionRepo{db: db, exec: db}
 }
 
-// WithTx returns a clone of this repo with its tx-aware methods (Delete)
-// routed through tx. See dbExecutor for the rationale.
+// WithTx returns a clone of this repo with its tx-aware methods routed through
+// tx. See dbExecutor for the rationale.
 func (r *EditionRepo) WithTx(tx *sql.Tx) *EditionRepo {
 	clone := *r
 	clone.exec = tx
 	return &clone
+}
+
+// GetByID returns the edition with the given local database ID. It uses the
+// repository executor so callers inside a transaction read through that same
+// transaction rather than waiting on the single database connection.
+func (r *EditionRepo) GetByID(ctx context.Context, id int64) (*models.Edition, error) {
+	row := r.exec.QueryRowContext(ctx, `
+		SELECT id, foreign_id, book_id, title, isbn_13, isbn_10, asin, publisher,
+		       publish_date, format, num_pages, language, image_url, is_ebook,
+		       edition_info, monitored, created_at, updated_at
+		FROM editions WHERE id = ?`, id)
+	e, err := scanEditionFrom(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get edition %d: %w", id, err)
+	}
+	return &e, nil
 }
 
 // GetByForeignID returns the edition keyed by its globally-unique foreign

--- a/internal/db/editions_test.go
+++ b/internal/db/editions_test.go
@@ -7,6 +7,57 @@ import (
 	"github.com/vavallee/bindery/internal/models"
 )
 
+func TestEditionRepo_GetByID(t *testing.T) {
+	database, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	ctx := context.Background()
+
+	authorRepo := NewAuthorRepo(database)
+	bookRepo := NewBookRepo(database)
+	a := &models.Author{ForeignID: "OL-GET-ED-A", Name: "A", SortName: "A", MetadataProvider: "openlibrary", Monitored: true}
+	if err := authorRepo.Create(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+	b := &models.Book{
+		ForeignID: "OL-GET-ED-B", AuthorID: a.ID, Title: "Book", SortTitle: "Book",
+		Status: "wanted", Genres: []string{}, MetadataProvider: "openlibrary", Monitored: true,
+	}
+	if err := bookRepo.Create(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewEditionRepo(database)
+	ed := &models.Edition{
+		ForeignID: "calibre:42:EPUB", BookID: b.ID, Title: "Named Edition",
+		Format: "EPUB", Language: "eng", IsEbook: true, Monitored: true,
+	}
+	if err := repo.Upsert(ctx, ed); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := repo.GetByID(ctx, ed.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected edition, got nil")
+	}
+	if got.ID != ed.ID || got.BookID != b.ID || got.Title != "Named Edition" || got.Format != "EPUB" {
+		t.Fatalf("unexpected edition: %+v", got)
+	}
+
+	missing, err := repo.GetByID(ctx, ed.ID+1000)
+	if err != nil {
+		t.Fatalf("GetByID missing: %v", err)
+	}
+	if missing != nil {
+		t.Fatalf("expected nil for missing edition, got %+v", missing)
+	}
+}
+
 func TestEditionRepo_UpsertInsertAndUpdate(t *testing.T) {
 	database, err := OpenMemory()
 	if err != nil {


### PR DESCRIPTION
## Summary

- add a transaction-aware edition lookup by local ID
- use that lookup when labelling Calibre rollback actions so created editions no longer have blank display names
- cover found, missing, and real rollback-preview behavior and add the required changelog fragment

Closes #1896

## Checklist

- [x] Tests added or updated
- [x] `docs/DEPLOYMENT.md` is unchanged because there are no environment, config, or upgrade-path changes
- [x] Added a changelog fragment under `changelog.d/`
- [x] Wiki updates are not required because no documented workflow or configuration changed

## Test plan

- [x] RED: new tests failed before the implementation because `EditionRepo.GetByID` did not exist
- [x] `go test -race ./internal/db ./internal/calibre`
- [x] `go test -coverprofile=coverage.out -covermode=atomic ./cmd/... ./internal/...`
- [x] `go vet ./...`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run --timeout=5m ./...` (`0 issues`)
- [x] `go run golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77 ./...` (no reachable vulnerabilities)
- [x] `make changelog`
- [x] `git diff --check`
- [ ] `make test` exercised the changed `internal/db` and `internal/calibre` packages successfully, but the untouched `internal/api` package exhausted the local 10-minute package timeout while applying SQLite migrations. The full non-race package set passed; CI shards API race tests with a 15-minute timeout.

Frontend and HTTP smoke suites were not run because this change touches only repository lookup and existing Calibre rollback-preview logic.

## AI assistance

Implementation and test preparation were assisted by OpenAI Codex. The final diff was independently reviewed against the transaction and rollback contracts.