### PR TITLE
ci(scorecard): pin an action SHA that exists upstream

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: scorecard.sarif
           results_format: sarif


### PR DESCRIPTION
## What

`.github/workflows/scorecard.yml:41` pinned `ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621`, commented `# v2.4.0`.

That SHA does not exist in `ossf/scorecard-action`:

```
$ gh api repos/ossf/scorecard-action/commits/ff5dd8929f96a8a4dc67d13f32b8c75057829621
No commit found for SHA (HTTP 422)

$ real v2.4.0 => 62b2cac7ed8198b15735ed49ab1e5cf35480ba46
```

A commit that lives in a **fork** stays reachable through the upstream repo's shared object store, so `uses:` resolves it happily and the action runs. Scorecard's own publish step is the only thing that rejects it, and it has been failing on **every** push to main:

```
error sending scorecard results to webapp: http response 400
imposter commit: ff5dd8929f96a8a4dc67d13f32b8c75057829621
does not belong to ossf/scorecard-action
```

## Why it is worth fixing rather than muting

The visible symptom is cosmetic. The analysis runs and the SARIF uploads; only the dashboard publish fails.

The underlying problem is not cosmetic. Pinning to a SHA outside the upstream repo's history means the workflow executes code from a source that cannot be traced back to the project it claims to be, while *looking* like a properly pinned action. That is precisely the attack SHA pinning exists to prevent, and the "imposter commit" check exists to catch.

Most likely a copy-paste from a fork rather than anything hostile. The contents of `ff5dd892` cannot be inspected to confirm that, which is the argument for replacing it rather than assuming.

## Change

One line, pinned to **v2.4.4** (current release) at `2d1146689b8cda280b9bc96326124645441f03bc`, resolved through the git refs API rather than copied from anywhere:

```diff
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
```

Bumped past v2.4.0 rather than corrected to `62b2cac7`, since the pin had to change either way.

## Verification

The publish step failing is the check. If this is right, the OpenSSF Scorecard workflow goes green on the next push to main for the first time in at least six runs. That cannot be confirmed from a PR, since the workflow is `push`-triggered on main only.

Found while watching main CI after #1898; unrelated to that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)