### PR TITLE
fix(web): make sortable headers look sortable, resolve /authors

### DIFF
--- a/changelog.d/1349-sort-affordance-authors-route.md
+++ b/changelog.d/1349-sort-affordance-authors-route.md
@@ -1,0 +1,15 @@
+### Fixed
+- **Sortable column headers on the Books page now look sortable** — the Books
+  table has supported sorting by author, type and status since v1.28.0
+  ([#1349](https://github.com/vavallee/bindery/issues/1349)), but nothing said
+  so: the Sort toolbar above the table offers only title and date, the headers
+  had no pointer cursor, and the ▲/▼ marker appeared only on the column already
+  in use. An unsorted Type or Status header was indistinguishable from plain
+  text, so the feature read as missing. Headers now show a pointer cursor, a
+  muted ↕ when inactive, and a "Sort by …" tooltip.
+- **`/authors` now resolves** — Authors is served from `/` because it was the
+  first page that existed, while every nav entry added later (`/books`,
+  `/import`, `/settings`, …) got a real path. `/authors` matched no route, and
+  with no catch-all it rendered the site chrome around an empty page rather
+  than a 404. It now redirects to `/`, the same way `/blocklist` redirects into
+  Settings.

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -103,6 +103,34 @@ describe('App auth routes', () => {
   })
 })
 
+describe('App — /authors alias', () => {
+  // Authors is served from "/" because it was the first page that existed.
+  // Every nav entry added later got a real path, so "/authors" matched no route
+  // — and with no catch-all it rendered the chrome around an empty <main>, a
+  // blank page rather than a 404. Reported by a user who guessed the URL from
+  // the pattern the other pages follow.
+  it('lands on the authors page instead of rendering nothing', async () => {
+    window.history.pushState(null, '', '/authors')
+
+    renderShell()
+
+    expect(await screen.findByTestId('page-authors')).toBeInTheDocument()
+    expect(window.location.pathname).toBe('/')
+  })
+
+  // Guards the failure the alias fixes: a path with no route and no catch-all
+  // renders the shell with nothing inside it. If someone later removes the
+  // alias, this is the shape the regression takes.
+  it('still renders the shell chrome around an unrouted path', () => {
+    window.history.pushState(null, '', '/definitely-not-a-route')
+
+    renderShell()
+
+    expect(screen.queryByTestId('page-authors')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('page-books')).not.toBeInTheDocument()
+  })
+})
+
 describe('Shell — desktop navigation', () => {
   it('renders all 9 nav links in the desktop nav bar', () => {
     renderShell()

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -251,6 +251,14 @@ function Shell() {
           <RoutedErrorBoundary>
           <Routes>
             <Route path="/" element={<AuthorsPage />} />
+            {/* Authors has always been served from "/" because it was the first
+                page that existed; every nav entry added since (/books, /import,
+                /settings, ...) got a real path. "/authors" therefore matched
+                nothing, and with no catch-all route it rendered the chrome
+                around an empty <main> — a blank page rather than a 404. Alias it
+                to the canonical "/" the same way /blocklist aliases into
+                settings, so a guessed or bookmarked URL lands somewhere. */}
+            <Route path="/authors" element={<Navigate to="/" replace />} />
             <Route path="/author/:id" element={<AuthorDetailPage />} />
             <Route path="/books" element={<BooksPage />} />
             <Route path="/book/:id" element={<BookDetailPage />} />

--- a/web/src/pages/BooksPage.test.tsx
+++ b/web/src/pages/BooksPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { MemoryRouter } from 'react-router'
@@ -177,5 +177,81 @@ describe('BooksPage', () => {
     expect(consoleError).toHaveBeenCalled()
 
     consoleError.mockRestore()
+  })
+})
+
+// Column-header sorting on the Books table. Reported by a user on v1.30.1 as
+// "book titles are sortable by published date but not type or status" — the
+// sort works and has since v1.28.0 (#1349), but nothing on screen said so:
+// the Sort toolbar above the table lists only title and date, Tailwind v4's
+// Preflight gives <button> no pointer cursor, and the ▲/▼ marker only appeared
+// on the column already being sorted. An unsorted Type header was therefore
+// indistinguishable from plain text.
+describe('BooksPage — sortable column headers', () => {
+  beforeEach(() => {
+    // The table view is where the headers live; the page defaults to grid.
+    localStorage.setItem('bindery.view.books', 'table')
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('sorts by type and status from the column headers, not just title and date', async () => {
+    const sorts: string[] = []
+    server.use(
+      http.get(apiUrl('/book'), ({ request }) => {
+        sorts.push(new URL(request.url).searchParams.get('sort') ?? '')
+        return HttpResponse.json({
+          items: [makeBook({ id: 1, title: 'Dune' })],
+          total: 1,
+          limit: 50,
+          offset: 0,
+        })
+      }),
+    )
+
+    renderBooksPage()
+    await screen.findByRole('button', { name: 'Type' })
+
+    // Re-query before every click. SortableHeader is declared inside the
+    // component body, so each render produces a new component identity and
+    // React remounts the header cells — a node captured before a click is
+    // detached by the time the next one lands.
+    const click = (name: string) =>
+      fireEvent.click(screen.getByRole('button', { name }))
+
+    click('Type')
+    await waitFor(() => expect(sorts).toContain('type-az'))
+    // A second click on the same column flips the direction.
+    click('Type')
+    await waitFor(() => expect(sorts).toContain('type-za'))
+
+    click('Status')
+    await waitFor(() => expect(sorts).toContain('status-az'))
+  })
+
+  it('marks every sortable header as clickable, not only the active one', async () => {
+    server.use(
+      http.get(apiUrl('/book'), () =>
+        HttpResponse.json({
+          items: [makeBook({ id: 1, title: 'Dune' })],
+          total: 1,
+          limit: 50,
+          offset: 0,
+        }),
+      ),
+    )
+
+    renderBooksPage()
+
+    // Title is the default sort, so it is the active column; Type and Status
+    // are inactive. All three must still look interactive — that inactive
+    // columns looked inert is the whole of the reported bug.
+    for (const name of ['Title', 'Type', 'Status']) {
+      const header = await screen.findByRole('button', { name })
+      expect(header.className).toContain('cursor-pointer')
+      expect(header).toHaveAttribute('title')
+    }
   })
 })

--- a/web/src/pages/BooksPage.tsx
+++ b/web/src/pages/BooksPage.tsx
@@ -144,6 +144,15 @@ export default function BooksPage() {
 
   // SortableHeader renders a clickable <th> with an ▲/▼ affordance when its
   // column is the active sort. asc/desc are the whitelisted keys for the column.
+  //
+  // The affordance matters more than it looks. Tailwind v4's Preflight does not
+  // give <button> a pointer cursor (v3 did), so without cursor-pointer these
+  // headers were clickable but indistinguishable from plain text: no cursor
+  // change, and the ▲/▼ only renders once a column is already the active sort.
+  // A user reading the Sort toolbar above the table — which offers only title
+  // and date — reasonably concluded type and status could not be sorted at all,
+  // when in fact both have worked since v1.28.0. AuthorDetailPage's sortable
+  // header already carried cursor-pointer select-none; this matches it.
   const SortableHeader = ({ label, asc, desc, className = '' }: { label: string; asc: SortMode; desc: SortMode; className?: string }) => {
     const active = sort === asc || sort === desc
     const arrow = sort === asc ? ' ▲' : sort === desc ? ' ▼' : ''
@@ -153,9 +162,13 @@ export default function BooksPage() {
           type="button"
           onClick={() => toggleSort(asc, desc)}
           aria-label={label}
-          className={`inline-flex items-center gap-0.5 uppercase transition-colors ${active ? 'text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white'}`}
+          title={t('books.sortByColumn', { column: label, defaultValue: 'Sort by {{column}}' })}
+          className={`inline-flex items-center gap-0.5 uppercase transition-colors cursor-pointer select-none ${active ? 'text-slate-900 dark:text-white' : 'text-slate-600 dark:text-zinc-400 hover:text-slate-900 dark:hover:text-white'}`}
         >
-          {label}<span aria-hidden="true">{arrow}</span>
+          {label}
+          {active
+            ? <span aria-hidden="true">{arrow}</span>
+            : <span aria-hidden="true" className="opacity-40">↕</span>}
         </button>
       </th>
     )


### PR DESCRIPTION
Two things a user reported on v1.30.1. Both are discoverability, not missing function.

## 1. The Books sort headers looked inert

The Books table has sorted by author, type and status since **v1.28.0** (#1349). The user reported it as "book titles are sortable by published date but not type or status." They were reading the UI correctly; three signals were missing at once:

- The **Sort toolbar** above the table lists only `A-Z / Z-A / Newest / Oldest` (`BooksPage.tsx:197-201`), so it reads as the complete set of sort options.
- The **headers had no pointer cursor**. Tailwind v4's Preflight does not give `<button>` `cursor: pointer` the way v3 did, and `SortableHeader` never set it. `AuthorDetailPage.tsx:583` — the equivalent sortable header elsewhere in this app — already carries `cursor-pointer select-none`, so the two pages disagreed.
- The **▲/▼ only rendered on the active column**, so an unsorted Type or Status header had no marker at all.

Nothing distinguished a sortable header from plain text. Fixed with `cursor-pointer select-none`, a muted `↕` on inactive columns, and a `Sort by …` tooltip.

## 2. `/authors` resolved to nothing

Authors is served from `/` (`App.tsx:253`) because it was the first page that existed. Every nav entry added since — `/books`, `/import`, `/settings`, `/queue`, … — got a real path, so guessing `/authors` from that pattern is the natural thing to do.

There is **no catch-all route**, so `/authors` matched nothing and rendered the header, nav and footer around an empty `<main>`: a blank page, not a 404. It now redirects to `/`, the same way `/blocklist` already redirects into Settings (`App.tsx:264`).

I aliased rather than moving Authors to `/authors`, since making `/authors` canonical would change the landing page and every existing bookmark. Say the word if you'd rather have it the other way round.

## What this does not do

**#1349 stays open.** Its title is "Sortable column headers + unmonitored/unwanted filter in Books **& Authors** views". The Books half shipped in v1.28.0; the **Authors** half never did — `AuthorsPage` headers (Name, Books, Rating, Monitored) are plain `<th>` (`AuthorsPage.tsx:398-402`) and the backend only accepts `az|za|recent` (`authorSortOrder`). That is the real outstanding work, and it is a separate PR.

## Tests

| Test | Status |
|---|---|
| type/status sort from column headers | **Pins existing behaviour** — would have passed before this change. Kept as a regression guard on the whitelisted keys. |
| every sortable header marked clickable | New. Fails when `cursor-pointer` is removed. |
| `/authors` lands on the authors page | New. Fails when the alias route is removed. |
| unrouted path still renders the shell | New. Documents the blank-page shape the alias fixes. |

Both new assertions verified by mutation. Full frontend suite green: **55 files, 528 tests**, `tsc --noEmit` clean.

## Noted, not fixed

`SortableHeader` is declared inside the `BooksPage` component body, so every render creates a new component identity and React remounts the header cells. Harmless in practice, but it detaches DOM nodes between clicks — the sort test has to re-query before each one. Left alone as unrelated to the report.

refs #1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)